### PR TITLE
remove timeout from goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,8 +26,6 @@ notarize:
         issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
         key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
         key: "{{.Env.MACOS_NOTARY_KEY}}"
-        wait: true
-        timeout: 45m
 
 archives:
   - formats:


### PR DESCRIPTION
Remove waiting for notarisation. The [Goreleaser documentation](https://goreleaser.com/customization/notarize/#cross-platform) does not recommend waiting with a timeout, "as it could take a really long time."