### PR TITLE
Show both project and local settings in entire status

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -427,7 +428,13 @@ func runStatus(w io.Writer) error {
 
 	// Check if either settings file exists
 	_, projectErr := os.Stat(settingsPath)
+	if projectErr != nil && !errors.Is(projectErr, fs.ErrNotExist) {
+		return fmt.Errorf("cannot access project settings file: %w", projectErr)
+	}
 	_, localErr := os.Stat(localSettingsPath)
+	if localErr != nil && !errors.Is(localErr, fs.ErrNotExist) {
+		return fmt.Errorf("cannot access local settings file: %w", localErr)
+	}
 	projectExists := projectErr == nil
 	localExists := localErr == nil
 

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -485,3 +485,70 @@ func TestRunEnableWithStrategy_PreservesLocalSettings(t *testing.T) {
 		t.Errorf("strategy_options.push should be true, got %v", settings.StrategyOptions["push"])
 	}
 }
+
+func TestRunStatus_LocalSettingsOnly(t *testing.T) {
+	setupTestRepo(t)
+	writeLocalSettings(t, `{"strategy": "auto-commit", "enabled": true}`)
+
+	var stdout bytes.Buffer
+	if err := runStatus(&stdout); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Local, enabled") {
+		t.Errorf("Expected output to show 'Local, enabled', got: %s", output)
+	}
+	if strings.Contains(output, "Project,") {
+		t.Errorf("Should not show Project settings when only local exists, got: %s", output)
+	}
+}
+
+func TestRunStatus_BothProjectAndLocal(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, `{"strategy": "manual-commit", "enabled": true}`)
+	writeLocalSettings(t, `{"strategy": "auto-commit", "enabled": false}`)
+
+	var stdout bytes.Buffer
+	if err := runStatus(&stdout); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Project, enabled (manual-commit)") {
+		t.Errorf("Expected output to show 'Project, enabled (manual-commit)', got: %s", output)
+	}
+	if !strings.Contains(output, "Local, disabled (auto-commit)") {
+		t.Errorf("Expected output to show 'Local, disabled (auto-commit)', got: %s", output)
+	}
+}
+
+func TestRunStatus_ShowsStrategy(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, `{"strategy": "auto-commit", "enabled": true}`)
+
+	var stdout bytes.Buffer
+	if err := runStatus(&stdout); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "(auto-commit)") {
+		t.Errorf("Expected output to show strategy '(auto-commit)', got: %s", output)
+	}
+}
+
+func TestRunStatus_ShowsManualCommitStrategy(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, `{"strategy": "manual-commit", "enabled": false}`)
+
+	var stdout bytes.Buffer
+	if err := runStatus(&stdout); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Project, disabled (manual-commit)") {
+		t.Errorf("Expected output to show 'Project, disabled (manual-commit)', got: %s", output)
+	}
+}


### PR DESCRIPTION
1. Read `settings.json` → display its `enabled` and `strategy` values
2. Read `settings.local.json` → display its `enabled` and `strategy` values

Scenario 1: 
1. User runs entire enable → selects auto-commit → selects "Use local settings" 
2. entire status shows:
	Project, enabled (auto-commit)
	Local, enabled (auto-commit)

Scenario 2: 
1. User runs entire enable → selects auto-commit → selects "Update project settings" 
2. entire status shows:
	Project, enabled (auto-commit)
	Local, disabled (auto-commit)

Scenario 3: 
1. User runs entire enable → selects manual-commit → selects "Update project settings" 
2. entire status shows:
	Project, enabled (manual-commit)
	Local, disabled (auto-commit)

Scenario 4: 
1. User runs entire enable → selects manual-commit → selects "Use local settings"
2. entire status shows:
	Project, enabled (manual-commit)
	Local, enabled (manual-commit)