### PR TITLE
hide completion command

### DIFF
--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -42,6 +42,7 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
+	cmd.CompletionOptions.HiddenDefaultCmd = true
 	// Add subcommands here
 	cmd.AddCommand(newRewindCmd())
 	cmd.AddCommand(newResumeCmd())


### PR DESCRIPTION
cobra docs: https://github.com/spf13/cobra/blob/main/site/content/completions/_index.md#adapting-the-default-completion-command