### PR TITLE
Enable automatic entire/sessions pushing

### DIFF
--- a/cmd/entire/cli/integration_test/setup_claude_hooks_test.go
+++ b/cmd/entire/cli/integration_test/setup_claude_hooks_test.go
@@ -33,7 +33,7 @@ type Hook struct {
 }
 
 // TestSetupClaudeHooks_AddsAllRequiredHooks is a smoke test verifying that
-// `entire enable claude-hooks` adds all required hooks to the correct file.
+// `entire enable --agent claude-code` adds all required hooks to the correct file.
 // Detailed hook manipulation logic is tested in unit tests (setup_test.go).
 func TestSetupClaudeHooks_AddsAllRequiredHooks(t *testing.T) {
 	t.Parallel()
@@ -46,8 +46,8 @@ func TestSetupClaudeHooks_AddsAllRequiredHooks(t *testing.T) {
 	env.GitAdd("README.md")
 	env.GitCommit("Initial commit")
 
-	// Run entire enable claude-hooks (non-interactive)
-	output, err := env.RunCLIWithError("enable", "claude-hooks")
+	// Run entire enable --agent claude-code (non-interactive)
+	output, err := env.RunCLIWithError("enable", "--agent", "claude-code")
 	if err != nil {
 		t.Fatalf("enable claude-hooks command failed: %v\nOutput: %s", err, output)
 	}
@@ -116,7 +116,7 @@ func TestSetupClaudeHooks_PreservesExistingSettings(t *testing.T) {
 	}
 
 	// Run enable claude-hooks
-	output, err := env.RunCLIWithError("enable", "claude-hooks")
+	output, err := env.RunCLIWithError("enable", "--agent", "claude-code")
 	if err != nil {
 		t.Fatalf("enable claude-hooks failed: %v\nOutput: %s", err, output)
 	}

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -405,7 +405,7 @@ func TestRunEnableWithStrategy_PreservesExistingSettings(t *testing.T) {
 
 	// Run enable with a different strategy
 	var stdout bytes.Buffer
-	err := runEnableWithStrategy(&stdout, "auto-commit", false, false, false, true, false, false)
+	err := runEnableWithStrategy(&stdout, "auto-commit", false, false, false, true, false, false, false)
 	if err != nil {
 		t.Fatalf("runEnableWithStrategy() error = %v", err)
 	}
@@ -461,7 +461,7 @@ func TestRunEnableWithStrategy_PreservesLocalSettings(t *testing.T) {
 
 	// Run enable with --local flag
 	var stdout bytes.Buffer
-	err := runEnableWithStrategy(&stdout, "auto-commit", false, false, true, false, false, false)
+	err := runEnableWithStrategy(&stdout, "auto-commit", false, false, true, false, false, false, false)
 	if err != nil {
 		t.Fatalf("runEnableWithStrategy() error = %v", err)
 	}

--- a/cmd/entire/cli/strategy/manual_commit_types.go
+++ b/cmd/entire/cli/strategy/manual_commit_types.go
@@ -6,9 +6,6 @@ const (
 	// sessionStateDirName is the directory name for session state files within git common dir.
 	sessionStateDirName = "entire-sessions"
 
-	// pushSessionsPrompt is the default push_sessions config value.
-	pushSessionsPrompt = "prompt"
-
 	// logsOnlyScanLimit is the maximum number of commits to scan for logs-only points.
 	logsOnlyScanLimit = 50
 )

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -20,11 +20,16 @@ import (
 
 // pushSessionsBranchCommon is the shared implementation for pushing session branches.
 // Used by both manual-commit and auto-commit strategies.
-// Configuration options (stored in .entire/settings.json under strategy_options.push_sessions):
-//   - "auto": always push automatically
-//   - "prompt" (default): ask user with option to enable auto
-//   - "false"/"off"/"no": never push
+// By default, session logs are pushed automatically alongside user pushes.
+// Configuration (stored in .entire/settings.json under strategy_options.push_sessions):
+//   - false: disable automatic pushing
+//   - true or not set: push automatically (default)
 func pushSessionsBranchCommon(remote, branchName string) error {
+	// Check if pushing is disabled
+	if isPushSessionsDisabled() {
+		return nil
+	}
+
 	repo, err := OpenRepository()
 	if err != nil {
 		return nil //nolint:nilerr // Hook must be silent on failure
@@ -44,18 +49,7 @@ func pushSessionsBranchCommon(remote, branchName string) error {
 		return nil
 	}
 
-	// Get configuration
-	pushMode := getPushSessionsConfig()
-
-	switch pushMode {
-	case "false", "off", "no":
-		return nil
-	case "auto":
-		return doPushSessionsBranch(remote, branchName)
-	default:
-		// "prompt" or any other value - ask user
-		return promptAndPushSessionsCommon(remote, branchName)
-	}
+	return doPushSessionsBranch(remote, branchName)
 }
 
 // hasUnpushedSessionsCommon checks if the local branch differs from the remote.
@@ -74,9 +68,10 @@ func hasUnpushedSessionsCommon(repo *git.Repository, remote string, localHash pl
 	return localHash != remoteRef.Hash()
 }
 
-// getPushSessionsConfig reads the push_sessions setting from strategy options.
+// isPushSessionsDisabled checks if push_sessions is disabled in settings.
+// Returns true if push_sessions is explicitly set to false.
 // Checks settings.local.json first (user preference), then settings.json (shared).
-func getPushSessionsConfig() string {
+func isPushSessionsDisabled() bool {
 	// Use repo root to find settings files when run from a subdirectory
 	localSettingsPath, err := paths.AbsPath(".entire/settings.local.json")
 	if err != nil {
@@ -88,151 +83,50 @@ func getPushSessionsConfig() string {
 	}
 
 	// Try local settings first (user preference, not committed)
-	if val := readPushSessionsFromFile(localSettingsPath); val != "" {
-		return val
+	if disabled, found := readPushSessionsFromFile(localSettingsPath); found {
+		return disabled
 	}
 
 	// Fall back to shared settings
-	if val := readPushSessionsFromFile(sharedSettingsPath); val != "" {
-		return val
+	if disabled, found := readPushSessionsFromFile(sharedSettingsPath); found {
+		return disabled
 	}
 
-	return pushSessionsPrompt
+	// Default: push is enabled
+	return false
 }
 
 // readPushSessionsFromFile reads push_sessions from a specific settings file.
-func readPushSessionsFromFile(settingsPath string) string {
+// Returns (isDisabled, found). If not found, returns (false, false).
+func readPushSessionsFromFile(settingsPath string) (bool, bool) {
 	//nolint:gosec // G304: settingsPath is always a hardcoded constant from this package
 	data, err := os.ReadFile(settingsPath)
 	if err != nil {
-		return ""
+		return false, false
 	}
 
 	var settings struct {
 		StrategyOptions map[string]interface{} `json:"strategy_options"`
 	}
 	if err := json.Unmarshal(data, &settings); err != nil {
-		return ""
+		return false, false
 	}
 
 	if settings.StrategyOptions == nil {
-		return ""
+		return false, false
 	}
 
-	if val, ok := settings.StrategyOptions["push_sessions"].(string); ok {
-		return val
-	}
-	return ""
-}
-
-// setPushSessionsConfig saves the push_sessions setting to settings.local.json.
-// This is a user preference that should not be committed to the repository.
-func setPushSessionsConfig(value string) error {
-	// Use repo root to find settings file when run from a subdirectory
-	localSettingsFile, err := paths.AbsPath(".entire/settings.local.json")
-	if err != nil {
-		localSettingsFile = ".entire/settings.local.json" // Fallback
+	val, exists := settings.StrategyOptions["push_sessions"]
+	if !exists {
+		return false, false
 	}
 
-	// Read existing local settings or start fresh
-	var settings map[string]interface{}
-	data, err := os.ReadFile(localSettingsFile) //nolint:gosec // Path is controlled
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to read local settings: %w", err)
-		}
-		// File doesn't exist, start with empty settings
-		settings = make(map[string]interface{})
-	} else {
-		if err := json.Unmarshal(data, &settings); err != nil {
-			return fmt.Errorf("failed to parse local settings: %w", err)
-		}
+	// Handle boolean value
+	if boolVal, ok := val.(bool); ok {
+		return !boolVal, true // disabled = !push_sessions
 	}
 
-	// Update strategy_options
-	strategyOptions, ok := settings["strategy_options"].(map[string]interface{})
-	if !ok || strategyOptions == nil {
-		strategyOptions = make(map[string]interface{})
-	}
-	strategyOptions["push_sessions"] = value
-	settings["strategy_options"] = strategyOptions
-
-	newData, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to serialize local settings: %w", err)
-	}
-
-	//nolint:gosec // G306: Settings file needs to be readable by user
-	if err := os.WriteFile(localSettingsFile, newData, 0o644); err != nil {
-		return fmt.Errorf("failed to write local settings: %w", err)
-	}
-	return nil
-}
-
-// promptAndPushSessionsCommon prompts the user and optionally pushes the sessions branch.
-func promptAndPushSessionsCommon(remote, branchName string) error {
-	// Open /dev/tty for interactive input in hook context
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
-	if err != nil {
-		// Can't prompt (non-interactive), skip silently
-		return nil
-	}
-	defer tty.Close()
-
-	fmt.Fprintf(tty, "\n[entire] Push session logs to %s?\n", remote)
-	fmt.Fprintf(tty, "  1) Yes, and always do this automatically\n")
-	fmt.Fprintf(tty, "  2) Yes\n")
-	fmt.Fprintf(tty, "  3) No\n")
-	fmt.Fprintf(tty, "Choice [1]: ")
-
-	// Read response with timeout to avoid hanging indefinitely
-	type readResult struct {
-		data []byte
-		err  error
-	}
-	resultCh := make(chan readResult, 1)
-
-	go func() {
-		buf := make([]byte, 10)
-		n, err := tty.Read(buf)
-		resultCh <- readResult{data: buf[:n], err: err}
-	}()
-
-	const ttyReadTimeout = 60 * time.Second
-	var choice string
-	select {
-	case result := <-resultCh:
-		if result.err != nil {
-			return nil
-		}
-		choice = strings.TrimSpace(string(result.data))
-	case <-time.After(ttyReadTimeout):
-		fmt.Fprintf(tty, "\n[entire] Timed out waiting for input, skipping.\n")
-		return nil
-	}
-
-	if choice == "" {
-		choice = "1" // Default
-	}
-
-	switch choice {
-	case "1":
-		// Save preference and push
-		if err := setPushSessionsConfig("auto"); err != nil {
-			fmt.Fprintf(tty, "[entire] Warning: couldn't save preference: %v\n", err)
-		} else {
-			fmt.Fprintf(tty, "[entire] Preference saved. Future pushes will be automatic.\n")
-		}
-		return doPushSessionsBranch(remote, branchName)
-	case "2":
-		return doPushSessionsBranch(remote, branchName)
-	case "3":
-		fmt.Fprintf(tty, "[entire] Skipping session logs push.\n")
-		return nil
-	default:
-		fmt.Fprintf(tty, "[entire] Invalid choice, skipping.\n")
-		return nil
-	}
+	return false, false
 }
 
 // doPushSessionsBranch pushes the sessions branch to the remote.


### PR DESCRIPTION
Pushing `entire/sessions` is now enabled by default. It can be disabled during initial enabling (or later by running `enable` again`) by adding `--skip-push-sessions`. 