### PR TITLE
Show session runtime in checkpoint list

### DIFF
--- a/cmd/entire/cli/list.go
+++ b/cmd/entire/cli/list.go
@@ -3,12 +3,64 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sync"
+	"time"
 
 	"entire.io/cli/cmd/entire/cli/list"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
+
+// spinner frames for loading indicator
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// loadingSpinner displays a loading spinner until stopped.
+type loadingSpinner struct {
+	message string
+	stop    chan struct{}
+	done    sync.WaitGroup
+}
+
+// newLoadingSpinner creates and starts a loading spinner with the given message.
+func newLoadingSpinner(message string) *loadingSpinner {
+	s := &loadingSpinner{
+		message: message,
+		stop:    make(chan struct{}),
+	}
+	s.done.Add(1)
+	go s.run()
+	return s
+}
+
+// run displays the spinner animation.
+func (s *loadingSpinner) run() {
+	defer s.done.Done()
+	frame := 0
+	ticker := time.NewTicker(80 * time.Millisecond)
+	defer ticker.Stop()
+
+	// Print initial frame
+	fmt.Printf("\r%s %s", spinnerFrames[frame], s.message)
+
+	for {
+		select {
+		case <-s.stop:
+			// Clear the line
+			fmt.Print("\r\033[K")
+			return
+		case <-ticker.C:
+			frame = (frame + 1) % len(spinnerFrames)
+			fmt.Printf("\r%s %s", spinnerFrames[frame], s.message)
+		}
+	}
+}
+
+// Stop stops the spinner and clears the line.
+func (s *loadingSpinner) Stop() {
+	close(s.stop)
+	s.done.Wait()
+}
 
 func newListCmd() *cobra.Command {
 	var jsonOutput bool
@@ -54,6 +106,9 @@ are currently running in an agent.`,
 }
 
 func runListInteractive() error {
+	// Show loading spinner while fetching data
+	spinner := newLoadingSpinner("Loading checkpoints...")
+
 	// Fetch latest entire/sessions from origin
 	FetchSessionsBranch()
 
@@ -62,6 +117,8 @@ func runListInteractive() error {
 
 	// Fetch data
 	data, err := list.FetchTreeData()
+	spinner.Stop()
+
 	if err != nil {
 		return fmt.Errorf("failed to fetch data: %w", err)
 	}

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -425,6 +425,12 @@ func (s *ManualCommitStrategy) PostCommit() error {
 			fmt.Fprintf(os.Stderr, "[entire] Warning: failed to update session state: %v\n", err)
 		}
 
+		// Update current_session to reflect this session's activity
+		// This ensures the session that just created a checkpoint is marked as active
+		if err := paths.WriteCurrentSession(state.SessionID); err != nil {
+			fmt.Fprintf(os.Stderr, "[entire] Warning: failed to update current session: %v\n", err)
+		}
+
 		shortID := state.SessionID
 		if len(shortID) > 8 {
 			shortID = shortID[:8]


### PR DESCRIPTION
Experiment on top of experiment. Basically this tries to show sessions in the UI too. The lines on the left go from start of a session until last checkpoint/commit with that session. 

<img width="510" height="487" alt="image" src="https://github.com/user-attachments/assets/2d894c48-8984-4c4f-abcf-9686fe88212b" />

The image has overlapping sessions but usually that is not the case. 

Talked to @dipree and mentioned it's not obvious what it means.