### PR TITLE
Move help.go from commands subpackage to main cli package

### DIFF
--- a/cmd/entire/cli/help.go
+++ b/cmd/entire/cli/help.go
@@ -1,4 +1,4 @@
-package commands
+package cli
 
 import (
 	"fmt"

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"runtime"
 
-	"entire.io/cli/cmd/entire/cli/commands"
 	"entire.io/cli/cmd/entire/cli/telemetry"
 	"github.com/spf13/cobra"
 )
@@ -62,7 +61,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newExplainCmd())
 
 	// Replace default help command with custom one that supports -t flag
-	cmd.SetHelpCommand(commands.NewHelpCmd(cmd))
+	cmd.SetHelpCommand(NewHelpCmd(cmd))
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

- Move `help.go` from `cmd/entire/cli/commands/` to `cmd/entire/cli/` for consistency
- Remove the now-empty `commands/` subpackage
- Update `root.go` to call `NewHelpCmd()` directly instead of via `commands.NewHelpCmd()`

Closes ENT-98

## Test plan

- [x] `mise run test` - all tests pass
- [x] `mise run lint` - no lint errors
- [x] Run `entire help` - verify help command still works
- [x] Run `entire help -t` - verify hidden tree flag still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)