### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @entireio/cli-maintainers


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` file
- Sets `@entireio/cli-maintainers` as default code owners for all files

## Test plan
- [x] Verify file is created with correct syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)