### PR TITLE
Do not pin Golang with Mise.

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,4 @@
 [tools]
-go = { version = '1.25.5', postinstall = "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest && go install github.com/go-delve/delve/cmd/dlv@latest" }
 golangci-lint = 'latest'
 
 [tasks.lint]


### PR DESCRIPTION
# Description

We already pin the Golang version in go.mod.

Context: https://entireio.slack.com/archives/C095MMM9YHG/p1768793640975889