### PR TITLE
Add README files to Entire-created locations

### DIFF
--- a/.entire/README.md
+++ b/.entire/README.md
@@ -1,0 +1,6 @@
+# .entire
+
+This directory is created by [Entire](https://entire.io) to store local session state.
+
+- In `.gitignore` - not committed to the repository
+- Safe to delete - will be recreated as needed

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"entire.io/cli/cmd/entire/cli/paths"
 	"entire.io/cli/cmd/entire/cli/strategy"
@@ -291,6 +292,29 @@ func (env *TestEnv) ClearSessionState(sessionID string) error {
 		return fmt.Errorf("failed to clear session state: %w", err)
 	}
 	return nil
+}
+
+// CountSessionStateFiles returns the number of session state files in .git/entire-sessions/.
+// Only counts .json files, excluding README.md and other non-session files.
+func (env *TestEnv) CountSessionStateFiles() (int, error) {
+	env.T.Helper()
+
+	sessionStateDir := filepath.Join(env.RepoDir, ".git", "entire-sessions")
+	entries, err := os.ReadDir(sessionStateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // HookOutput contains the result of running a hook.

--- a/cmd/entire/cli/integration_test/manual_commit_workflow_test.go
+++ b/cmd/entire/cli/integration_test/manual_commit_workflow_test.go
@@ -429,13 +429,12 @@ func TestShadow_MultipleConcurrentSessions(t *testing.T) {
 	}
 
 	// Verify session state file exists
-	sessionStateDir := filepath.Join(env.RepoDir, ".git", "entire-sessions")
-	entries, err := os.ReadDir(sessionStateDir)
+	stateFileCount, err := env.CountSessionStateFiles()
 	if err != nil {
-		t.Fatalf("Failed to read session state dir: %v", err)
+		t.Fatalf("Failed to count session state files: %v", err)
 	}
-	if len(entries) != 1 {
-		t.Errorf("Expected 1 session state file, got %d", len(entries))
+	if stateFileCount != 1 {
+		t.Errorf("Expected 1 session state file, got %d", stateFileCount)
 	}
 
 	// Starting a second session while session1 has uncommitted checkpoints triggers warning
@@ -450,12 +449,12 @@ func TestShadow_MultipleConcurrentSessions(t *testing.T) {
 
 	// Verify session2 state file was created with ConcurrentWarningShown flag
 	// This is set by the hook when it outputs continue:false
-	entries, err = os.ReadDir(sessionStateDir)
+	stateFileCount, err = env.CountSessionStateFiles()
 	if err != nil {
-		t.Fatalf("Failed to read session state dir: %v", err)
+		t.Fatalf("Failed to count session state files: %v", err)
 	}
-	if len(entries) != 2 {
-		t.Errorf("Expected 2 session state files after second session attempt, got %d", len(entries))
+	if stateFileCount != 2 {
+		t.Errorf("Expected 2 session state files after second session attempt, got %d", stateFileCount)
 	}
 
 	// Clear session1 state file - this makes the shadow branch "orphaned"

--- a/cmd/entire/cli/integration_test/rewind_reset_test.go
+++ b/cmd/entire/cli/integration_test/rewind_reset_test.go
@@ -3,8 +3,6 @@
 package integration
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -88,27 +86,25 @@ func TestRewindReset_ClearsSessionState(t *testing.T) {
 	}
 
 	// Verify session state files exist
-	sessionStateDir := filepath.Join(env.RepoDir, ".git", "entire-sessions")
-	entries, err := os.ReadDir(sessionStateDir)
+	numStateFilesBefore, err := env.CountSessionStateFiles()
 	if err != nil {
-		t.Fatalf("Failed to read session state dir: %v", err)
+		t.Fatalf("Failed to count session state files: %v", err)
 	}
-	if len(entries) == 0 {
+	if numStateFilesBefore == 0 {
 		t.Fatal("Expected session state files before reset")
 	}
-	numStateFilesBefore := len(entries)
 
 	// Run rewind reset
 	output := env.RunCLI("rewind", "reset", "--force")
 	t.Logf("Rewind reset output:\n%s", output)
 
 	// Verify session state files are cleared
-	entries, err = os.ReadDir(sessionStateDir)
+	numStateFilesAfter, err := env.CountSessionStateFiles()
 	if err != nil {
-		t.Fatalf("Failed to read session state dir after reset: %v", err)
+		t.Fatalf("Failed to count session state files after reset: %v", err)
 	}
-	if len(entries) > 0 {
-		t.Errorf("Expected no session state files after reset, got %d", len(entries))
+	if numStateFilesAfter > 0 {
+		t.Errorf("Expected no session state files after reset, got %d", numStateFilesAfter)
 	}
 
 	// Verify output indicates clearing
@@ -187,13 +183,12 @@ func TestRewindReset_WithMultipleSessions(t *testing.T) {
 	}
 
 	// Verify session state file exists
-	sessionStateDir := filepath.Join(env.RepoDir, ".git", "entire-sessions")
-	entries, err := os.ReadDir(sessionStateDir)
+	stateFileCount, err := env.CountSessionStateFiles()
 	if err != nil {
-		t.Fatalf("Failed to read session state dir: %v", err)
+		t.Fatalf("Failed to count session state files: %v", err)
 	}
-	if len(entries) < 1 {
-		t.Fatalf("Expected at least 1 session state file, got %d", len(entries))
+	if stateFileCount < 1 {
+		t.Fatalf("Expected at least 1 session state file, got %d", stateFileCount)
 	}
 
 	// Run rewind reset
@@ -201,12 +196,12 @@ func TestRewindReset_WithMultipleSessions(t *testing.T) {
 	t.Logf("Rewind reset output:\n%s", output)
 
 	// Verify all session state files are cleared
-	entries, err = os.ReadDir(sessionStateDir)
+	stateFileCount, err = env.CountSessionStateFiles()
 	if err != nil {
-		t.Fatalf("Failed to read session state dir after reset: %v", err)
+		t.Fatalf("Failed to count session state files after reset: %v", err)
 	}
-	if len(entries) > 0 {
-		t.Errorf("Expected no session state files after reset, got %d", len(entries))
+	if stateFileCount > 0 {
+		t.Errorf("Expected no session state files after reset, got %d", stateFileCount)
 	}
 
 	// Verify shadow branch is deleted

--- a/cmd/entire/cli/paths/paths.go
+++ b/cmd/entire/cli/paths/paths.go
@@ -44,7 +44,7 @@ const (
 
 This directory is created by [Entire](https://entire.io) to store local session state.
 
-- In ` + "`.gitignore`" + ` - not committed to the repository
+- Added to ` + "`.gitignore`" + ` so it is not committed to the repository
 - Safe to delete - will be recreated as needed
 `
 

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -127,6 +127,13 @@ func (s *StateStore) Save(ctx context.Context, state *State) error {
 		return fmt.Errorf("failed to create session state directory: %w", err)
 	}
 
+	// Write README if it doesn't exist (explains what this directory is for)
+	readmePath := filepath.Join(s.stateDir, paths.ReadmeFileName)
+	if _, err := os.Stat(readmePath); os.IsNotExist(err) {
+		// Best-effort: don't fail if README can't be written
+		_ = os.WriteFile(readmePath, []byte(paths.SessionStateDirReadme), 0o644) //nolint:errcheck,gosec // best-effort, README should be world-readable
+	}
+
 	data, err := jsonutil.MarshalIndentWithNewline(state, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal session state: %w", err)

--- a/cmd/entire/cli/session/state_test.go
+++ b/cmd/entire/cli/session/state_test.go
@@ -1,0 +1,133 @@
+package session
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"entire.io/cli/cmd/entire/cli/paths"
+)
+
+func TestStateStore_Save_CreatesReadme(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, "entire-sessions")
+
+	store := NewStateStoreWithDir(stateDir)
+
+	state := &State{
+		SessionID:  "test-session-123",
+		BaseCommit: "abc123def456",
+		StartedAt:  time.Now(),
+	}
+
+	err := store.Save(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Verify README was created
+	readmePath := filepath.Join(stateDir, paths.ReadmeFileName)
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("README should exist at %s: %v", readmePath, err)
+	}
+
+	// Verify content matches expected
+	if string(content) != paths.SessionStateDirReadme {
+		t.Errorf("README content mismatch\ngot:\n%s\nwant:\n%s", string(content), paths.SessionStateDirReadme)
+	}
+}
+
+func TestStateStore_Save_DoesNotOverwriteExistingReadme(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, "entire-sessions")
+
+	// Create directory with custom README
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("failed to create state dir: %v", err)
+	}
+	customContent := "# Custom README\n\nUser-modified content\n"
+	readmePath := filepath.Join(stateDir, paths.ReadmeFileName)
+	if err := os.WriteFile(readmePath, []byte(customContent), 0o644); err != nil {
+		t.Fatalf("failed to write custom README: %v", err)
+	}
+
+	store := NewStateStoreWithDir(stateDir)
+
+	state := &State{
+		SessionID:  "test-session-456",
+		BaseCommit: "def789abc012",
+		StartedAt:  time.Now(),
+	}
+
+	err := store.Save(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Verify README still has custom content
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("failed to read README: %v", err)
+	}
+
+	if string(content) != customContent {
+		t.Errorf("README was overwritten\ngot:\n%s\nwant:\n%s", string(content), customContent)
+	}
+}
+
+func TestStateStore_SaveLoadClear(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, "entire-sessions")
+
+	store := NewStateStoreWithDir(stateDir)
+
+	// Test Save
+	state := &State{
+		SessionID:       "test-session-789",
+		BaseCommit:      "abc123",
+		StartedAt:       time.Now().Truncate(time.Second),
+		CheckpointCount: 5,
+		FilesTouched:    []string{"file1.go", "file2.go"},
+	}
+
+	err := store.Save(context.Background(), state)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Test Load
+	loaded, err := store.Load(context.Background(), state.SessionID)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load() returned nil")
+	}
+	if loaded.SessionID != state.SessionID {
+		t.Errorf("SessionID = %q, want %q", loaded.SessionID, state.SessionID)
+	}
+	if loaded.BaseCommit != state.BaseCommit {
+		t.Errorf("BaseCommit = %q, want %q", loaded.BaseCommit, state.BaseCommit)
+	}
+	if loaded.CheckpointCount != state.CheckpointCount {
+		t.Errorf("CheckpointCount = %d, want %d", loaded.CheckpointCount, state.CheckpointCount)
+	}
+
+	// Test Clear
+	err = store.Clear(context.Background(), state.SessionID)
+	if err != nil {
+		t.Fatalf("Clear() error = %v", err)
+	}
+
+	// Verify cleared
+	loaded, err = store.Load(context.Background(), state.SessionID)
+	if err != nil {
+		t.Fatalf("Load() after clear error = %v", err)
+	}
+	if loaded != nil {
+		t.Error("Load() after clear should return nil")
+	}
+}


### PR DESCRIPTION
## Summary

Closes ENT-95

- Add explanatory README.md files to help developers understand what Entire-created directories and branches are for
- READMEs are created on first use and won't overwrite existing files

**Locations:**
- `.entire/README.md` - explains local session state directory
- `.git/entire-sessions/README.md` - explains active session tracking  
- `entire/sessions` branch root - explains the orphan metadata branch

## Test plan

- [x] Unit tests added for README creation in all three locations
- [x] Tests verify READMEs are not overwritten if they already exist
- [x] `mise run test` passes
- [x] `mise run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)