### PR TITLE
Add GitHub Copilot instructions for coding agent onboarding

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,15 @@ if isAccessibleMode() {
 }
 ```
 
+### Logging vs User Output
+
+- **Internal/debug logging**: Use `logging.Debug/Info/Warn/Error(ctx, msg, attrs...)` from `cli/logging/`. Writes to `.entire/logs/`.
+- **User-facing output**: Use `fmt.Fprint*(cmd.OutOrStdout(), ...)` or `cmd.ErrOrStderr()`.
+
+Don't use `fmt.Print*` for operational messages (checkpoint saves, hook invocations) - use the `logging` package.
+
+**Privacy**: Don't log user content (prompts, file contents, commit messages). Log only operational metadata (IDs, counts, paths, durations).
+
 ## Project Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,15 @@ return fmt.Errorf("unknown strategy: %s", name)
 - `root.go` - Sets `SilenceErrors: true` on root command
 - `main.go` - Checks for `SilentError` before printing
 
+### Logging vs User Output
+
+- **Internal/debug logging**: Use `logging.Debug/Info/Warn/Error(ctx, msg, attrs...)` from `cmd/entire/cli/logging/`. Writes to `.entire/logs/`.
+- **User-facing output**: Use `fmt.Fprint*(cmd.OutOrStdout(), ...)` or `cmd.ErrOrStderr()`.
+
+Don't use `fmt.Print*` for operational messages (checkpoint saves, hook invocations, strategy decisions) - those should use the `logging` package.
+
+**Privacy**: Don't log user content (prompts, file contents, commit messages). Log only operational metadata (IDs, counts, paths, durations).
+
 ### Git Operations
 
 We use github.com/go-git/go-git for most git operations, but with important exceptions:


### PR DESCRIPTION
## Summary
- Adds `.github/copilot-instructions.md` to help GitHub Copilot coding agent work efficiently with this repository
- Documents build/test/lint commands and their proper ordering
- Highlights critical code patterns (SilentError, forbidden go-git operations, path handling, accessibility)
- Provides high-level project structure and testing guidelines

## Test plan
- [x] Verified all commands in the document work (`mise run fmt/lint/test/test:ci/lint:gomod`)
- [x] File follows the 2-page limit guideline
- [x] Instructions are general (not task-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)