### PR TITLE
mise-tasks(dev:publish): Install binaries "globally".

### DIFF
--- a/mise-tasks/dev/publish
+++ b/mise-tasks/dev/publish
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#MISE description="Install binaries into ~/go/bin"
+
+set -eu
+
+export GOBIN=${GOPATH:-$HOME/go}/bin
+echo "NOTE: we're overriding \$GOBIN: $GOBIN" 1>&2
+
+go install ./cmd/entire


### PR DESCRIPTION
# Description

I think providing a simple helper to install the binary into a place that's probably in your `$PATH` is a better solution to the problem discussed in https://github.com/entireio/cli/pull/49.
