### PR TITLE
fix: use consistent Checkpoint: xxx subject for all entire/sessions commits

### DIFF
--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -500,14 +500,18 @@ func (s *GitStore) readArchivedSessions(checkpointTree *object.Tree, sessionCoun
 }
 
 // buildCommitMessage constructs the commit message with proper trailers.
+// The commit subject is always "Checkpoint: <id>" for consistency.
+// If CommitSubject is provided (e.g., for task checkpoints), it's included in the body.
 func (s *GitStore) buildCommitMessage(opts WriteCommittedOptions, taskMetadataPath string) string {
 	var commitMsg strings.Builder
 
-	// Use custom subject if provided
+	// Subject line is always the checkpoint ID for consistent formatting
+	commitMsg.WriteString(fmt.Sprintf("Checkpoint: %s\n\n", opts.CheckpointID))
+
+	// Include custom description in body if provided (e.g., task checkpoint details)
 	if opts.CommitSubject != "" {
 		commitMsg.WriteString(opts.CommitSubject + "\n\n")
 	}
-	commitMsg.WriteString(fmt.Sprintf("Checkpoint: %s\n\n", opts.CheckpointID))
 	commitMsg.WriteString(fmt.Sprintf("%s: %s\n", paths.SessionTrailerKey, opts.SessionID))
 	commitMsg.WriteString(fmt.Sprintf("%s: %s\n", paths.StrategyTrailerKey, opts.Strategy))
 	if opts.Agent != "" {


### PR DESCRIPTION
## Summary
- Fixed inconsistent commit message subjects on the `entire/sessions` branch
- Task checkpoints were using custom subjects (e.g., "Subagent: dev completed...") while regular checkpoints used "Checkpoint: xxx"
- Now all commits consistently use "Checkpoint: <id>" as the subject line
- Task checkpoint descriptions are preserved in the commit body

## Test plan
- [x] All existing tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [ ] Verify new checkpoints on `entire/sessions` all have `Checkpoint: xxx` subjects

🤖 Generated with [Claude Code](https://claude.com/claude-code)