### PR TITLE
Add Agents array to CommittedMetadata for multi-agent checkpoints

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -325,7 +325,9 @@ type CommittedMetadata struct {
 	FilesTouched     []string        `json:"files_touched"`
 
 	// Agent identifies the agent that created this checkpoint (e.g., "Claude Code", "Cursor")
-	Agent agent.AgentType `json:"agent,omitempty"`
+	// For multi-session checkpoints, this is the first agent (see Agents for all)
+	Agent  agent.AgentType   `json:"agent,omitempty"`
+	Agents []agent.AgentType `json:"agents,omitempty"` // All agents that contributed (multi-session, deduplicated)
 
 	// Multi-session support: when multiple sessions contribute to the same checkpoint
 	SessionCount int      `json:"session_count,omitempty"` // Number of sessions (1 if omitted for backwards compat)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces multi-agent tracking for committed checkpoints while preserving backwards compatibility.
> 
> - Add `Agents` array to `CommittedMetadata`; keep `Agent` as the first agent for compat (single-session omits `agents`)
> - Update `writeMetadataJSON` to merge multi-session data: deduplicate/merge `agents`, `session_ids`, `files_touched`, and increment `session_count`
> - New `mergeAgents` helper for order-preserving deduplication
> - Add tests: single-session (no `agents`), multi-session (ordered agents array), and deduplication; plus helper to read metadata from branch
> 
> Risk: Low — additive metadata field and merge logic covered by tests; existing reads continue using `agent` field
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b543b3ae79e713c65e8338787768e994dd833a17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->