### PR TITLE
setup the remote tracking for `entire/sessions` when doing the first push

### DIFF
--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -106,7 +106,7 @@ func readPushSessionsFromFile(settingsPath string) (bool, bool) {
 	}
 
 	var settings struct {
-		StrategyOptions map[string]interface{} `json:"strategy_options"`
+		StrategyOptions map[string]any `json:"strategy_options"`
 	}
 	if err := json.Unmarshal(data, &settings); err != nil {
 		return false, false
@@ -160,7 +160,8 @@ func tryPushSessionsCommon(remote, branchName string) error {
 	defer cancel()
 
 	// Use --no-verify to prevent recursive hook calls
-	cmd := exec.CommandContext(ctx, "git", "push", "--no-verify", remote, branchName)
+	// Use -u to set up tracking relationship on first push
+	cmd := exec.CommandContext(ctx, "git", "push", "-u", "--no-verify", remote, branchName)
 	cmd.Stdin = nil // Disconnect stdin to prevent hanging in hook context
 
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
When debugging sessions from other contributors I sometime would pull in `entire/sessions` locally. I just noticed that I had to setup the remote branch and this just makes sure this happens automatically.