### PR TITLE
make manual-commit default option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Entire offers two strategies for capturing your work:
 
 | Command | Description |
 |---------|-------------|
-| `entire enable` | Enable Entire in your repository, install hooks |
+| `entire enable` | Enable Entire in your repository (uses `manual-commit` by default) |
 | `entire disable` | Remove Entire hooks from repository |
 | `entire status` | Show current session and strategy info |
 | `entire rewind` | Rewind to a previous checkpoint |
@@ -105,6 +105,29 @@ Entire offers two strategies for capturing your work:
 | `entire explain` | Explain a session or commit |
 | `entire session` | View and manage sessions (list, show details, view logs) |
 | `entire version` | Show Entire CLI version |
+
+### `entire enable` Flags
+
+| Flag | Description |
+|------|-------------|
+| `--strategy <name>` | Strategy to use: `manual-commit` (default) or `auto-commit` |
+| `--force`, `-f` | Force reinstall hooks (removes existing Entire hooks first) |
+| `--local` | Write settings to `settings.local.json` instead of `settings.json` |
+| `--project` | Write settings to `settings.json` even if it already exists |
+| `--telemetry=false` | Disable anonymous usage analytics |
+
+**Examples:**
+
+```bash
+# Use auto-commit strategy
+entire enable --strategy auto-commit
+
+# Force reinstall hooks
+entire enable --force
+
+# Save settings locally (not committed to git)
+entire enable --local
+```
 
 ## Configuration
 


### PR DESCRIPTION
Entire-Checkpoint: d9d99712b16b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `manual-commit` as the default strategy for `entire enable` and removes the interactive strategy selection.
> 
> - `enable` now auto-selects `manual-commit` and shows a hint to use `--strategy` to change it; telemetry and shell completion prompts remain
> - Updated command help text and success output to reflect the default strategy
> - README: documents default behavior, adds `entire enable` flag table and examples
> - Integration tests: add `RunEnableWithAccessibleMode` and `TestEnableDefaultStrategy` to verify default; adjust outputs accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74be582280ff75195a2e4cceb6d9db205849d8c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->