### PR TITLE
.github/workflows: Remove unnecessary GITHUB_TOKEN.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,9 @@ on:
       - main
 jobs:
   test:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Tests
         run: mise run test:ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,6 @@ jobs:
           fetch-depth: "0"
 
       - uses: jdx/mise-action@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check gofmt formatting
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
           fetch-depth: 0
 
       - uses: jdx/mise-action@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate Homebrew Tap token
         id: app-token


### PR DESCRIPTION
# Description

I don't believe we need GITHUB_TOKEN to install tools.  The `mise install` action grabs publicly-downloadable tools, let's apply the principle of least privilege here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unnecessary `with.github_token` configuration from `jdx/mise-action@v3` across workflows.
> 
> - Updates `ci.yml`, `lint.yml`, and `release.yml` to run `mise-action` without `GITHUB_TOKEN`
> - No changes to the functional steps for tests, linting, or release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f39fc0787db250a4d57ef9828ae65a239f4de9c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->