### PR TITLE
deletes all references about legacy strategies names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,8 +192,6 @@ All strategies implement:
 | **manual-commit** (default) | Unchanged (no commits) | `entire/<HEAD-hash>` branches + `entire/sessions` | Recommended for most workflows |
 | **auto-commit** | Creates clean commits | Orphan `entire/sessions` branch | Teams that want code commits from sessions |
 
-Legacy names `shadow` and `dual` are only recognized when reading settings or checkpoint metadata.
-
 #### Strategy Details
 
 **Manual-Commit Strategy** (`manual_commit*.go`) - Default

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -638,7 +638,6 @@ func (s *GitStore) ReadCommitted(ctx context.Context, checkpointID id.Checkpoint
 		if content, contentErr := metadataFile.Contents(); contentErr == nil {
 			//nolint:errcheck,gosec // Best-effort parsing, defaults are fine
 			json.Unmarshal([]byte(content), &result.Metadata)
-			result.Metadata.Strategy = trailers.NormalizeStrategyName(result.Metadata.Strategy)
 		}
 	}
 

--- a/cmd/entire/cli/config.go
+++ b/cmd/entire/cli/config.go
@@ -252,7 +252,6 @@ func applyDefaultStrategy(settings *EntireSettings) {
 	if settings.Strategy == "" {
 		settings.Strategy = strategy.DefaultStrategyName
 	}
-	settings.Strategy = strategy.NormalizeStrategyName(settings.Strategy)
 }
 
 func saveSettingsToFile(settings *EntireSettings, filePath string) error {

--- a/cmd/entire/cli/config_test.go
+++ b/cmd/entire/cli/config_test.go
@@ -76,40 +76,6 @@ func TestLoadEntireSettings_EnabledDefaultsToTrue(t *testing.T) {
 	}
 }
 
-func TestLoadEntireSettings_LegacyStrategyNames(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Chdir(tmpDir)
-
-	settingsDir := filepath.Dir(EntireSettingsFile)
-	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
-		t.Fatalf("Failed to create settings dir: %v", err)
-	}
-
-	if err := os.WriteFile(EntireSettingsFile, []byte(`{"strategy": "shadow"}`), 0o644); err != nil {
-		t.Fatalf("Failed to write settings file: %v", err)
-	}
-
-	settings, err := LoadEntireSettings()
-	if err != nil {
-		t.Fatalf("LoadEntireSettings() error = %v", err)
-	}
-	if settings.Strategy != strategy.StrategyNameManualCommit {
-		t.Errorf("Strategy = %q, want %q", settings.Strategy, strategy.StrategyNameManualCommit)
-	}
-
-	if err := os.WriteFile(EntireSettingsLocalFile, []byte(`{"strategy": "dual"}`), 0o644); err != nil {
-		t.Fatalf("Failed to write local settings file: %v", err)
-	}
-
-	settings, err = LoadEntireSettings()
-	if err != nil {
-		t.Fatalf("LoadEntireSettings() error = %v", err)
-	}
-	if settings.Strategy != strategy.StrategyNameAutoCommit {
-		t.Errorf("Strategy = %q, want %q", settings.Strategy, strategy.StrategyNameAutoCommit)
-	}
-}
-
 func TestSaveEntireSettings_PreservesEnabled(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -191,7 +191,7 @@ func TestResumeFromCurrentBranch_WithEntireCheckpointTrailer(t *testing.T) {
 	_, _, _ = setupResumeTestRepo(t, tmpDir, false)
 
 	// Set up the auto-commit strategy and create checkpoint metadata on entire/sessions branch
-	strat := strategy.NewDualStrategy()
+	strat := strategy.NewAutoCommitStrategy()
 	if err := strat.EnsureSetup(); err != nil {
 		t.Fatalf("Failed to ensure setup: %v", err)
 	}

--- a/cmd/entire/cli/strategy/auto_commit.go
+++ b/cmd/entire/cli/strategy/auto_commit.go
@@ -87,14 +87,6 @@ func NewAutoCommitStrategy() Strategy {
 	return &AutoCommitStrategy{}
 }
 
-// NewDualStrategy creates a new auto-commit strategy instance.
-// This legacy constructor delegates to NewAutoCommitStrategy.
-//
-
-func NewDualStrategy() Strategy {
-	return NewAutoCommitStrategy()
-}
-
 func (s *AutoCommitStrategy) Name() string {
 	return StrategyNameAutoCommit
 }
@@ -995,7 +987,7 @@ func (s *AutoCommitStrategy) ListOrphanedItems() ([]CleanupItem, error) {
 			continue
 		}
 		// Only consider checkpoints created by this strategy
-		if result.Metadata.Strategy == StrategyNameAutoCommit || result.Metadata.Strategy == StrategyNameDual {
+		if result.Metadata.Strategy == StrategyNameAutoCommit {
 			autoCommitCheckpoints[cp.CheckpointID.String()] = true
 		}
 	}

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -361,11 +361,6 @@ func ListAllCleanupItems() ([]CleanupItem, error) {
 
 	// Iterate over all registered strategies
 	for _, name := range List() {
-		// Skip legacy names to avoid duplicates
-		if IsLegacyStrategyName(name) {
-			continue
-		}
-
 		strat, err := Get(name)
 		if err != nil {
 			if firstErr == nil {

--- a/cmd/entire/cli/strategy/registry.go
+++ b/cmd/entire/cli/strategy/registry.go
@@ -51,8 +51,6 @@ func List() []string {
 
 // Strategy name constants
 const (
-	StrategyNameDual         = "dual"   // Legacy name (auto-commit)
-	StrategyNameShadow       = "shadow" // Legacy name (manual-commit)
 	StrategyNameManualCommit = "manual-commit"
 	StrategyNameAutoCommit   = "auto-commit"
 )
@@ -73,23 +71,4 @@ func Default() Strategy {
 		}
 	}
 	return s
-}
-
-// NormalizeStrategyName maps legacy strategy names to current names.
-// These are the strategy names used during initial development and are kept for backwards
-// compatibility
-func NormalizeStrategyName(name string) string {
-	switch name {
-	case StrategyNameDual:
-		return StrategyNameAutoCommit
-	case StrategyNameShadow:
-		return StrategyNameManualCommit
-	default:
-		return name
-	}
-}
-
-// IsLegacyStrategyName returns true for names that should be mapped.
-func IsLegacyStrategyName(name string) bool {
-	return name == StrategyNameDual || name == StrategyNameShadow
 }

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -67,7 +67,7 @@ var (
 func ParseStrategy(commitMessage string) (string, bool) {
 	matches := strategyTrailerRegex.FindStringSubmatch(commitMessage)
 	if len(matches) > 1 {
-		return NormalizeStrategyName(strings.TrimSpace(matches[1])), true
+		return strings.TrimSpace(matches[1]), true
 	}
 	return "", false
 }
@@ -160,20 +160,6 @@ func ParseAllSessions(commitMessage string) []string {
 		}
 	}
 	return sessionIDs
-}
-
-// NormalizeStrategyName maps legacy strategy names to current names.
-// These are the strategy names used during initial development and are kept for backwards
-// compatibility.
-func NormalizeStrategyName(name string) string {
-	switch name {
-	case "dual":
-		return "auto-commit"
-	case "shadow":
-		return "manual-commit"
-	default:
-		return name
-	}
 }
 
 // FormatStrategy creates a commit message with just the strategy trailer.


### PR DESCRIPTION
No more dual/shadow in our code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it intentionally drops backward compatibility: existing repos with settings, commit trailers, or checkpoint metadata using `dual`/`shadow` may no longer be interpreted correctly (e.g., filtering/cleanup and strategy parsing).
> 
> **Overview**
> Eliminates all code paths that *normalize or accept* legacy strategy names (`dual`, `shadow`), including config loading defaults, commit trailer parsing, checkpoint metadata reads, and the strategy registry/constants.
> 
> Updates cleanup and auto-commit orphan detection to only treat `auto-commit` metadata as auto-commit (no legacy alias), removes the legacy `NewDualStrategy` constructor, and deletes the associated tests/docs that referenced legacy names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d36bcc0e3ca8b11752e9ad97ccd8e19d21dd4682. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->