### PR TITLE
update to go 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module entire.io/cli
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/charmbracelet/huh v0.8.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Please also keep the version aligned in the go.mod file
-go = { version = '1.25.5', postinstall = "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest && go install github.com/go-delve/delve/cmd/dlv@latest" }
+go = { version = '1.25.6', postinstall = "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest && go install github.com/go-delve/delve/cmd/dlv@latest" }
 golangci-lint = 'latest'
 
 [tasks.lint]


### PR DESCRIPTION
Entire-Checkpoint: 5c1039ad85f4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump that only updates the Go toolchain version references; main impact is potential CI/build environment compatibility with Go 1.25.6.
> 
> **Overview**
> Updates the project’s Go toolchain version from `1.25.5` to `1.25.6` in both `go.mod` and `mise.toml` to keep local dev and build tooling aligned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c3007ffd952aaaff3cf0abe60ea377ac817e3c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->