### PR TITLE
change goreleaser once repo is public

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,44 +75,6 @@ homebrew_casks:
     directory: Casks
     homepage: "https://github.com/entireio/cli"
     description: "CLI for Entire"
-    custom_block: |
-      module GitHubHelper
-        def self.token
-          require "utils/github"
-
-          # Prefer environment variable if available
-          github_token = ENV["HOMEBREW_GITHUB_API_TOKEN"]
-          github_token ||= GitHub::API.credentials
-          raise "Failed to retrieve github api token" if github_token.nil? || github_token.empty?
-
-          github_token
-        end
-
-        def self.release_asset_url(tag, name)
-          require "json"
-          require "net/http"
-          require "uri"
-
-          resp = Net::HTTP.get(
-            URI.parse("https://api.github.com/repos/entireio/cli/releases/tags/#{tag}"),
-            {
-              "Accept" => "application/vnd.github+json",
-              "Authorization" => "Bearer #{token}",
-              "X-GitHub-Api-Version" => "2022-11-28"
-            }
-          )
-
-          release = JSON.parse(resp)
-          release["assets"].find { |asset| asset["name"] == name }["url"]
-        end
-      end
-
-    url:
-      template: '#{GitHubHelper.release_asset_url("{{.Tag}}", "{{.ArtifactName}}")}'
-      headers:
-        - "Accept: application/octet-stream"
-        - "Authorization: Bearer #{GitHubHelper.token}"
-        - "X-GitHub-Api-Version: 2022-11-28"
     binaries:
       - entire
     completions:


### PR DESCRIPTION
Do not merge until repo is public.

Related to this: https://github.com/entireio/homebrew-tap/pull/2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config change limited to release packaging/publishing; main risk is Homebrew cask installs failing if the default asset URL/template behavior differs from the removed custom GitHub API download flow.
> 
> **Overview**
> Removes the `homebrew_casks` `custom_block` Ruby helper and custom `url`/`headers` that fetched release assets via the GitHub API with an auth token.
> 
> Homebrew cask generation now relies on GoReleaser’s default URL behavior while keeping the same tap repo, cask metadata, binaries, and shell completions configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 267b755f42caaf9369873fdcf0ca3fc524dd489a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->