### PR TITLE
add npm release into goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,6 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 version: 2
+pro: true
 
 before:
   hooks:
@@ -119,3 +121,18 @@ homebrew_casks:
       bash: "completions/entire.bash"
       zsh: "completions/entire.zsh"
       fish: "completions/entire.fish"
+
+npms:
+  - name: "@entire/entire"
+    repository: "git+https://github.com/entireio/cli.git"
+    bugs: https://github.com/entireio/cli/issues
+    description: CLI for Entire
+    homepage: https://github.com/entireio/cli
+    license: MIT
+    access: public
+    keywords:
+      - entire
+      - cli
+      - claude
+      - gemini
+      - opencode


### PR DESCRIPTION
Based on their [docs](https://goreleaser.com/customization/npm/#options) it should work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes release automation by enabling GoReleaser Pro features and adding an npm publish target; misconfiguration could break CI releases or publish incorrect artifacts.
> 
> **Overview**
> Updates `.goreleaser.yaml` to enable GoReleaser Pro (`pro: true`) and adds an `npms` configuration to publish the CLI as the public npm package `@entire/entire` with repository/metadata links.
> 
> Also adds the yaml-language-server schema header for improved config validation/editing support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90058d79fbceead6fa01a6c531a142308e3088de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->