### PR TITLE
do not display suggestions if command fails

### DIFF
--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -68,11 +68,6 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
-	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		fmt.Fprint(cmd.OutOrStderr(), cmd.UsageString())
-		fmt.Fprintf(cmd.OutOrStderr(), "\nError: Invalid usage: %v\n", err)
-		return NewSilentError(err)
-	})
 	// Add subcommands here
 	cmd.AddCommand(newRewindCmd())
 	cmd.AddCommand(newResumeCmd())

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -35,8 +35,8 @@ func main() {
 		switch {
 		case errors.As(err, &silent):
 			// Command already printed the error
-		case strings.Contains(err.Error(), "unknown command"):
-			showSuggestion(rootCmd)
+		case strings.Contains(err.Error(), "unknown command") || strings.Contains(err.Error(), "unknown flag"):
+			showSuggestion(rootCmd, err)
 		default:
 			fmt.Fprintln(rootCmd.OutOrStderr(), err)
 		}
@@ -47,17 +47,8 @@ func main() {
 	cancel() // Cleanup on successful exit
 }
 
-func showSuggestion(cmd *cobra.Command) {
+func showSuggestion(cmd *cobra.Command, err error) {
 	// Print usage first (brew style)
 	fmt.Fprint(cmd.OutOrStderr(), cmd.UsageString())
-
-	// Build error message with optional suggestion
-	errMsg := fmt.Sprintf("Unknown command: %s %s", cmd.CommandPath(), os.Args[1])
-	suggestions := cmd.SuggestionsFor(os.Args[1])
-	if len(suggestions) > 0 {
-		errMsg += fmt.Sprintf(". Did you mean \"%s\"?", suggestions[0])
-	}
-
-	// Print error at the end
-	fmt.Fprintf(cmd.OutOrStderr(), "\nError: Invalid usage: %s\n", errMsg)
+	fmt.Fprintf(cmd.OutOrStderr(), "\nError: Invalid usage: %v\n", err)
 }


### PR DESCRIPTION
Only display suggestions when the command fails due to bad CLI usage (wrong command, wrong flags, etc.). That's where they're useful. For other failures, it's just noise.

Current:
```
$entire rewind --to xxx
Usage:
  entire rewind [flags]

Flags:
  -h, --help        help for rewind
      --list        List available rewind points (JSON output)
      --logs-only   Only restore logs, don't modify working directory (for logs-only points)
      --reset       Reset branch to commit (destructive, for logs-only points)
      --to string   Rewind to specific commit ID (non-interactive)

rewind point not found: xxx
```

How it looks now:
```
$entire rewindd --tooo
Usage:
  entire
  entire [command]

Available Commands:
  clean            Clean up orphaned entire's data
  disable          Disable Entire
  enable           Enable Entire
  explain          Explain a session or commit
  help             Help about any command
  resume           Switch to a branch and resume its session
  rewind           Rewind commands for session management
  status           Show Entire status
  version          Show version information

Use "entire [command] --help" for more information about a command.

Error: Invalid usage: unknown command "rewindd" for "entire"

Did you mean this?
        rewind
-----------------------------
$entire rewind --tooo
Usage:
  entire
  entire [command]

Available Commands:
  clean            Clean up orphaned entire's data
  disable          Disable Entire
  enable           Enable Entire
  explain          Explain a session or commit
  help             Help about any command
  resume           Switch to a branch and resume its session
  rewind           Rewind commands for session management
  status           Show Entire status
  version          Show version information

Use "entire [command] --help" for more information about a command.

Error: Invalid usage: unknown flag: --tooo
-----------------------------
$entire rewind --to xxx
rewind point not found: xxx
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI UX change that adjusts when usage output is printed; main concern is the string-based detection of "unknown" errors potentially missing/overmatching in future Cobra error messages.
> 
> **Overview**
> Reduces noisy CLI output by silencing Cobra usage by default (`SilenceUsage: true`) and moving usage/error printing into `main.go`.
> 
> `main.go` now only prints the full usage + "Invalid usage" error message for *bad CLI usage* cases (unknown command/unknown flag); other runtime errors are printed plainly, and `SilentError` continues to suppress duplicate output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41aa312be9dcca10d130311d01b34e7ddac63e24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->