### PR TITLE
fix(explain): show help when positional arg passed without qualifier flag

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -84,12 +84,13 @@ Output verbosity levels (for --checkpoint):
   --full:    + complete transcript
 
 Only one of --session, --commit, or --checkpoint can be specified at a time.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// If positional args provided without qualifier flags, show help
-			if len(args) > 0 && sessionFlag == "" && commitFlag == "" && checkpointFlag == "" {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Hint: use --checkpoint, --session, or --commit to specify what to explain\n\n")
-				return cmd.Help()
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unexpected argument %q\nHint: use --checkpoint, --session, or --commit to specify what to explain", args[0])
 			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if Entire is disabled
 			if checkDisabledGuard(cmd.OutOrStdout()) {
 				return nil


### PR DESCRIPTION
## Summary
- Shows help text when user passes a positional argument without `--checkpoint`, `--session`, or `--commit` flag
- Adds a hint message guiding users to the correct flag usage
- Previously `entire explain abc123` would silently do nothing

## Test plan
- [x] Unit test added for the new behavior
- [x] All existing explain tests pass
- [x] Manual testing: `entire explain abc123` now shows hint + help

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI UX change: `explain` now errors on unexpected positional args and adds a guidance hint; core explain logic and data handling are unchanged.
> 
> **Overview**
> `entire explain` now **rejects positional arguments** and returns a clearer error that includes a hint to use `--checkpoint`, `--session`, or `--commit` instead of silently doing nothing.
> 
> Adds a unit test (`TestExplainCmd_RejectsPositionalArgs`) covering multiple arg orderings to ensure the new validation and hint remain in place.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cc044cd1c5ec6cce471a35dfce838f8397f1987. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->