### PR TITLE
chore: add session-end hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-end"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "matcher": "",


### PR DESCRIPTION
what it says on the tin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.claude/settings.json` to run an additional hook command on session end, with no product code or data/auth logic changes.
> 
> **Overview**
> Adds a new **Claude Code lifecycle hook**: `SessionEnd` in `.claude/settings.json`, invoking `go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-end` when sessions close.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bce4d083cabcf72385f909db5db86cff8defda8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->