### PR TITLE
Persist CLAUDE_PROJECT_DIR for entire hooks in remote environment

### DIFF
--- a/.claude/scripts/remote-setup.sh
+++ b/.claude/scripts/remote-setup.sh
@@ -36,8 +36,9 @@ if [ -n "$CLAUDE_ENV_FILE" ]; then
   echo "Persisting mise environment..."
 
   # Export CLAUDE_PROJECT_DIR for entire hooks that need it
+  # Use printf %q to safely escape the value for shell sourcing
   if [ -n "$CLAUDE_PROJECT_DIR" ]; then
-    echo "export CLAUDE_PROJECT_DIR=\"$CLAUDE_PROJECT_DIR\"" >> "$CLAUDE_ENV_FILE"
+    printf 'export CLAUDE_PROJECT_DIR=%q\n' "$CLAUDE_PROJECT_DIR" >> "$CLAUDE_ENV_FILE"
   fi
 
   # Capture exports before and after mise activation, then write only the diff


### PR DESCRIPTION
The entire CLI hooks use ${CLAUDE_PROJECT_DIR} to locate the Go source,
but this variable wasn't being persisted to CLAUDE_ENV_FILE. This caused
hooks to fail silently in Claude Code web sessions because the path
resolved to /cmd/entire/main.go instead of the correct project path.

https://claude.ai/code/session_014D4MsBUAjz2JhRvT72kbzK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to a remote setup shell script that only affects Claude Code web sessions; main risk is minor environment file formatting/duplication issues.
> 
> **Overview**
> Fixes Claude Code web-session hook failures by persisting `CLAUDE_PROJECT_DIR` into `CLAUDE_ENV_FILE` during remote setup so subsequent hooks resolve paths correctly.
> 
> `remote-setup.sh` now writes a safely shell-escaped `export CLAUDE_PROJECT_DIR=...` line before appending the `mise activate` environment diff.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31fa2da171f9e177034002b81fe1e555db498001. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->