### PR TITLE
switch ldflags in goreleaser to new package name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,10 +17,10 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X entire.io/cli/cmd/entire/cli.Version={{.Version}}
-      - -X entire.io/cli/cmd/entire/cli.Commit={{.ShortCommit}}
-      - -X entire.io/cli/cmd/entire/cli/telemetry.PostHogAPIKey={{.Env.POSTHOG_API_KEY}}
-      - -X entire.io/cli/cmd/entire/cli/telemetry.PostHogEndpoint={{.Env.POSTHOG_ENDPOINT}}
+      - -X github.com/entireio/cli/cmd/entire/cli.Version={{.Version}}
+      - -X github.com/entireio/cli/cmd/entire/cli.Commit={{.ShortCommit}}
+      - -X github.com/entireio/cli/cmd/entire/cli/telemetry.PostHogAPIKey={{.Env.POSTHOG_API_KEY}}
+      - -X github.com/entireio/cli/cmd/entire/cli/telemetry.PostHogEndpoint={{.Env.POSTHOG_ENDPOINT}}
 
 notarize:
   macos:


### PR DESCRIPTION
will fix `entire version` command showing `Entire CLI dev (unknown)` for binaries published via goreleaser