### PR TITLE
Update Homebrew tap and install commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Entire hooks into your git workflow to capture AI agent sessions on every push. 
 ## Quick Start
 
 ```
-# Install via Homebrew (requires SSH access)
+# Install via Homebrew
 brew tap entireio/tap
 brew install entireio/tap/entire
 


### PR DESCRIPTION
this needs to be merged when we make this repo and the homebrew repo publc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that affects install guidance but not runtime code or behavior.
> 
> **Overview**
> Updates the README Quick Start Homebrew instructions to use the public `entireio/tap` tap (removing the prior SSH-based `entirehq` tap URL) and adjusts the install command accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c25b2c639dead50b02522ea452e55121a328d75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->