### PR TITLE
Use entire binary for claude hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
           },
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-start"
+            "command": "entire hooks claude-code session-start"
           }
         ]
       }
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-end"
+            "command": "entire hooks claude-code session-end"
           }
         ]
       }
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code user-prompt-submit"
+            "command": "entire hooks claude-code user-prompt-submit"
           }
         ]
       }
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code stop"
+            "command": "entire hooks claude-code stop"
           }
         ]
       }
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code pre-task"
+            "command": "entire hooks claude-code pre-task"
           }
         ]
       }
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code post-task"
+            "command": "entire hooks claude-code post-task"
           }
         ]
       },
@@ -74,7 +74,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code post-todo"
+            "command": "entire hooks claude-code post-todo"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ mise run lint
 
 # Format the code
 mise run fmt
+
+# Install current code as the entire binary
+mise run dev:publish
 ```
 
 ### Project Structure


### PR DESCRIPTION
Also mention how to install the binary from current code in the Readme.  The task already exists in `mise-tasks/dev/publish`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/config-only change; main risk is local environments where `entire` is not installed or not on `PATH`, which would break hook execution.
> 
> **Overview**
> Claude hook configuration now runs `entire hooks claude-code ...` directly instead of invoking `go run .../cmd/entire/main.go` for each hook event.
> 
> The development README adds `mise run dev:publish` as the documented way to install the current working tree as the `entire` binary so these hooks can run against an installed CLI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4b7c836715b542f449e433e62b3e93501dadde7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->