### PR TITLE
mise run dev:publish - set version flags.

### DIFF
--- a/mise-tasks/dev/publish
+++ b/mise-tasks/dev/publish
@@ -6,4 +6,7 @@ set -eu
 export GOBIN=${GOPATH:-$HOME/go}/bin
 echo "NOTE: we're overriding \$GOBIN: $GOBIN" 1>&2
 
-go install ./cmd/entire
+VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+go install -ldflags "-X github.com/entireio/cli/cmd/entire/cli.Version=${VERSION} -X github.com/entireio/cli/cmd/entire/cli.Commit=${COMMIT}" ./cmd/entire


### PR DESCRIPTION
```shellsession
$ mise run dev:publish
NOTE: we're overriding $GOBIN: /Users/paul/go/bin
$ which entire
/Users/paul/go/bin/entire
$ entire version
Entire CLI v0.3.12-1-g7293bb8 (7293bb8)
Go version: go1.25.6
OS/Arch: darwin/arm64
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the local dev publish script to pass build-time version metadata; risk is limited to incorrect/empty version strings if git commands fail or paths change.
> 
> **Overview**
> Updates `mise run dev:publish` to embed build metadata into the `entire` binary. The script now derives `VERSION` from `git describe` and `COMMIT` from `git rev-parse`, and passes them via `go install -ldflags -X ...` so `entire version` reports the current tag/commit instead of a default value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7293bb8b7c1b95b4636486dafbdc82bb0c375e18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->