### PR TITLE
Show helpful error when --agent flag is missing a value

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -69,8 +69,6 @@ Strategies: manual-commit (default), auto-commit`,
 			// not a usage error, so we silence Cobra's output and use SilentError
 			// to prevent duplicate error output in main.go
 			if _, err := paths.RepoRoot(); err != nil {
-				cmd.SilenceUsage = true
-				cmd.SilenceErrors = true
 				fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Please run 'entire enable' from within a git repository.")
 				return NewSilentError(errors.New("not a git repository"))
 			}
@@ -80,12 +78,17 @@ Strategies: manual-commit (default), auto-commit`,
 			}
 			// Non-interactive mode if --agent flag is provided
 			if cmd.Flags().Changed("agent") && agentName == "" {
-				cmd.SilenceUsage = true
 				printMissingAgentError(cmd.ErrOrStderr())
 				return NewSilentError(errors.New("missing agent name"))
 			}
+
 			if agentName != "" {
-				return setupAgentHooksNonInteractive(cmd.OutOrStdout(), agent.AgentName(agentName), strategyFlag, localDev, forceHooks, skipPushSessions, telemetry)
+				ag, err := agent.Get(agent.AgentName(agentName))
+				if err != nil {
+					printWrongAgentError(cmd.ErrOrStderr(), agentName)
+					return NewSilentError(errors.New("wrong agent name"))
+				}
+				return setupAgentHooksNonInteractive(cmd.OutOrStdout(), ag, strategyFlag, localDev, forceHooks, skipPushSessions, telemetry)
 			}
 			// If strategy is specified via flag, skip interactive selection
 			if strategyFlag != "" {
@@ -503,10 +506,10 @@ func setupClaudeCodeHook(localDev, forceHooks bool) (int, error) {
 	return count, nil
 }
 
-// printMissingAgentError writes a helpful error listing available agents.
-func printMissingAgentError(w io.Writer) {
+// printAgentError writes an error message followed by available agents and usage.
+func printAgentError(w io.Writer, message string) {
 	agents := agent.List()
-	fmt.Fprintln(w, "Missing agent name. Available agents:")
+	fmt.Fprintf(w, "%s Available agents:\n", message)
 	fmt.Fprintln(w)
 	for _, a := range agents {
 		suffix := ""
@@ -519,14 +522,20 @@ func printMissingAgentError(w io.Writer) {
 	fmt.Fprintln(w, "Usage: entire enable --agent <agent-name>")
 }
 
+// printMissingAgentError writes a helpful error listing available agents.
+func printMissingAgentError(w io.Writer) {
+	printAgentError(w, "Missing agent name.")
+}
+
+// printWrongAgentError writes a helpful error when an unknown agent name is provided.
+func printWrongAgentError(w io.Writer, name string) {
+	printAgentError(w, fmt.Sprintf("Unknown agent %q.", name))
+}
+
 // setupAgentHooksNonInteractive sets up hooks for a specific agent non-interactively.
 // If strategyName is provided, it sets the strategy; otherwise uses default.
-func setupAgentHooksNonInteractive(w io.Writer, agentName agent.AgentName, strategyName string, localDev, forceHooks, skipPushSessions, telemetry bool) error {
-	ag, err := agent.Get(agentName)
-	if err != nil {
-		return fmt.Errorf("unknown agent: %s", agentName)
-	}
-
+func setupAgentHooksNonInteractive(w io.Writer, ag agent.Agent, strategyName string, localDev, forceHooks, skipPushSessions, telemetry bool) error {
+	agentName := ag.Name()
 	// Check if agent supports hooks
 	hookAgent, ok := ag.(agent.HookSupport)
 	if !ok {

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -786,12 +786,37 @@ func TestRemoveEntireDirectory_NotExists(t *testing.T) {
 }
 
 func TestPrintMissingAgentError(t *testing.T) {
+	t.Parallel()
+
 	var buf bytes.Buffer
 	printMissingAgentError(&buf)
 	output := buf.String()
 
 	if !strings.Contains(output, "Missing agent name") {
 		t.Error("expected 'Missing agent name' in output")
+	}
+	for _, a := range agent.List() {
+		if !strings.Contains(output, string(a)) {
+			t.Errorf("expected agent %q listed in output", a)
+		}
+	}
+	if !strings.Contains(output, "(default)") {
+		t.Error("expected default annotation in output")
+	}
+	if !strings.Contains(output, "Usage: entire enable --agent") {
+		t.Error("expected usage line in output")
+	}
+}
+
+func TestPrintWrongAgentError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	printWrongAgentError(&buf, "not-an-agent")
+	output := buf.String()
+
+	if !strings.Contains(output, `Unknown agent "not-an-agent"`) {
+		t.Error("expected unknown agent name in output")
 	}
 	for _, a := range agent.List() {
 		if !strings.Contains(output, string(a)) {


### PR DESCRIPTION
## Summary

- `entire enable --agent` (no value) and `entire enable --agent=` (empty value) now show a helpful error listing available agents with default annotation and usage example, instead of cobra's generic "flag needs an argument"
- Uses `pflag.ValueRequiredError` type assertion instead of fragile string matching for robustness across pflag version updates
- Extracts `printMissingAgentError()` helper shared by both the flag-parse error path and the empty-value path

**Before:**
```
Error: flag needs an argument: --agent
```

**After:**
```
Missing agent name. Available agents:

  claude-code    (default)
  gemini

Usage: entire enable --agent <agent-name>
```

## Test plan

- [x] `TestPrintMissingAgentError` — verifies output content (agents listed, default annotation, usage line)
- [x] `TestEnableCmd_AgentFlagNoValue` — verifies `--agent` without value shows helpful error
- [x] `TestEnableCmd_AgentFlagEmptyValue` — verifies `--agent=` shows helpful error
- [x] `mise run fmt && mise run lint && mise run test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only error handling and messaging changes with added tests; minimal functional impact outside flag parsing/validation.
> 
> **Overview**
> Improves `entire enable --agent` UX by intercepting pflag “value required” parse errors and the empty-value case to print a custom message listing available agents, marking the default, and showing correct usage.
> 
> Also validates the provided agent name up front and returns a silent error with the same helpful output for unknown agents, with new tests covering the helper output and both `--agent` without a value and `--agent=` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 441b31fbcea3d7497d29a05c7fa6021a3042c8ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->