### PR TITLE
remove bash from code blocks to have no strange coloring

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Entire hooks into your git workflow to capture AI agent sessions on every push. 
 
 ## Quick Start
 
-```bash
+```
 # Install via Homebrew (requires SSH access)
 brew tap entirehq/tap git@github.com:entirehq/homebrew-entire.git
 brew install entirehq/tap/entire
@@ -20,7 +20,7 @@ entire status
 
 ### 1. Enable Entire in Your Repository
 
-```bash
+```
 entire enable
 ```
 
@@ -30,7 +30,7 @@ This installs Claude Code and git hooks that automatically capture checkpoints w
 
 Just use Claude Code normally. Entire runs in the background, creating checkpoints automatically:
 
-```bash
+```
 entire status  # Check current session status anytime
 ```
 
@@ -38,7 +38,7 @@ entire status  # Check current session status anytime
 
 If you want to undo some changes and go back to an earlier checkpoint:
 
-```bash
+```
 entire rewind
 ```
 
@@ -48,7 +48,7 @@ This shows all available checkpoints in the current session. Select one to resto
 
 To see and restore sessions from earlier work:
 
-```bash
+```
 entire resume
 ```
 
@@ -56,7 +56,7 @@ Lists all past sessions with timestamps. You can view the conversation history o
 
 ### 5. Disable Entire (Optional)
 
-```bash
+```
 entire disable
 ```
 
@@ -121,7 +121,7 @@ Entire offers two strategies for capturing your work:
 
 **Examples:**
 
-```bash
+```
 # Use auto-commit strategy
 entire enable --strategy auto-commit
 
@@ -216,14 +216,14 @@ Failed to fetch metadata: failed to fetch entire/sessions from origin: ssh: hand
 
 This is a [known issue with go-git's SSH handling](https://github.com/go-git/go-git/issues/411). Fix it by adding GitHub's host keys to your known_hosts file:
 
-```bash
+```
 ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts
 ssh-keyscan -t ecdsa github.com >> ~/.ssh/known_hosts
 ```
 
 ### Debug Mode
 
-```bash
+```
 # Via environment variable
 ENTIRE_LOG_LEVEL=debug entire status
 
@@ -235,7 +235,7 @@ ENTIRE_LOG_LEVEL=debug entire status
 
 ### Resetting State
 
-```bash
+```
 # Reset shadow branch for current commit
 entire reset --force
 
@@ -247,7 +247,7 @@ entire disable && entire enable --force
 
 For screen reader users, enable accessible mode:
 
-```bash
+```
 export ACCESSIBLE=1
 entire enable
 ```
@@ -264,7 +264,7 @@ This project uses [mise](https://mise.jdx.dev/) for task automation and dependen
 
 ### Getting Started
 
-```bash
+```
 # Clone the repository
 git clone <repo-url>
 cd cli
@@ -278,7 +278,7 @@ mise run build
 
 ### Common Tasks
 
-```bash
+```
 # Run tests
 mise run test
 
@@ -310,7 +310,7 @@ mise run dev:publish
 
 ## Getting Help
 
-```bash
+```
 entire --help              # General help
 entire <command> --help    # Command-specific help
 ```


### PR DESCRIPTION
Updated README.md to include code block formatting for commands.

With these changes `enable` is not blue anymore.

<img width="285" height="557" alt="image" src="https://github.com/user-attachments/assets/98dd7c39-6fa3-4c65-9149-fd90babe1875" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only formatting change with no impact on runtime behavior.
> 
> **Overview**
> Updates `README.md` to remove the `bash` language specifier from multiple fenced command examples, leaving plain triple-backtick code blocks to avoid odd syntax highlighting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 684f1d1e2c3c495ecf3b98e908cb0d7db4a655a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->