### PR TITLE
rename entire/sessions -> entire/checkpoints/v1 consistently

### DIFF
--- a/.claude/skills/test-repo/SKILL.md
+++ b/.claude/skills/test-repo/SKILL.md
@@ -94,7 +94,7 @@ Expected results by strategy:
 | Active branch | No Entire-* trailers | Entire-Checkpoint: trailer only |
 | Session state | ✓ Exists | ✗ Not used |
 | Shadow branch | ✓ entire/{hash} | ✗ None |
-| Metadata branch | ✓ entire/sessions | ✓ entire/sessions |
+| Metadata branch | ✓ entire/checkpoints/v1 | ✓ entire/checkpoints/v1 |
 | Rewind points | ✓ At least 1 | ✓ At least 1 |
 
 #### 4. Test Rewind
@@ -147,7 +147,7 @@ go build -o /tmp/entire-bin ./cmd/entire && \
 ### Manual-Commit Strategy (default, alias: shadow)
 - Active branch commits: **NO modifications** (no commits created by Entire)
 - Shadow branches: `entire/<commit-hash[:7]>` created for checkpoints
-- Metadata: stored on both shadow branches and `entire/sessions` branch (condensed on user commits)
+- Metadata: stored on both shadow branches and `entire/checkpoints/v1` branch (condensed on user commits)
 - Rewind: restores files from shadow branch commit tree (no git reset)
   - **Shows preview warning** listing untracked files that will be deleted
   - Preserves untracked files that existed at session start
@@ -156,7 +156,7 @@ go build -o /tmp/entire-bin ./cmd/entire && \
 ### Auto-Commit Strategy (alias: dual)
 - Active branch commits: **clean commits** with only `Entire-Checkpoint: <12-hex-char>` trailer
 - Shadow branches: none
-- Metadata: stored on orphan `entire/sessions` branch at sharded paths
+- Metadata: stored on orphan `entire/checkpoints/v1` branch at sharded paths
 - Rewind: full reset allowed if commit is only on current branch
   - Uses `git reset --hard` which doesn't delete untracked files
   - **No preview warnings** (untracked files are safe)
@@ -199,8 +199,8 @@ For manual-commit, test log condensation:
 git add app.js
 git commit -m "Add greeting function"
 
-# Verify logs condensed to entire/sessions
-git show entire/sessions --stat | grep -E "^[0-9a-f]{2}/[0-9a-f]"
+# Verify logs condensed to entire/checkpoints/v1
+git show entire/checkpoints/v1 --stat | grep -E "^[0-9a-f]{2}/[0-9a-f]"
 
 # Verify shadow branch still exists
 git branch -a | grep "entire/[0-9a-f]"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A **session** represents a complete interaction with your AI agent, from start t
 
 **Session ID format:** `YYYY-MM-DD-<UUID>` (e.g., `2026-01-08-abc123de-f456-7890-abcd-ef1234567890`)
 
-Sessions are stored separately from your code commits on the `entire/sessions` branch.
+Sessions are stored separately from your code commits on the `entire/checkpoints/v1` branch.
 
 ### Checkpoints
 
@@ -167,7 +167,7 @@ Personal overrides, gitignored by default:
 | `enabled`                              | `true`, `false`                  | Enable/disable Entire                          |
 | `agent`                                | `claude-code`, `gemini`, etc.    | AI agent to integrate with                     |
 | `log_level`                            | `debug`, `info`, `warn`, `error` | Logging verbosity                              |
-| `strategy_options.push_sessions`       | `true`, `false`                  | Auto-push `entire/sessions` branch on git push |
+| `strategy_options.push_sessions`       | `true`, `false`                  | Auto-push `entire/checkpoints/v1` branch on git push |
 | `strategy_options.summarize.enabled`   | `true`, `false`                  | Auto-generate AI summaries at commit time      |
 
 ### Auto-Summarization
@@ -211,7 +211,7 @@ Local settings override project settings field-by-field. When you run `entire st
 If you see an error like this when running `entire resume`:
 
 ```
-Failed to fetch metadata: failed to fetch entire/sessions from origin: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
+Failed to fetch metadata: failed to fetch entire/checkpoints/v1 from origin: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
 ```
 
 This is a [known issue with go-git's SSH handling](https://github.com/go-git/go-git/issues/411). Fix it by adding GitHub's host keys to your known_hosts file:

--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -53,7 +53,7 @@ const (
 	Temporary Type = iota
 
 	// Committed checkpoints contain metadata + commit reference and are stored
-	// on the entire/sessions branch. They are the permanent record.
+	// on the entire/checkpoints/v1 branch. They are the permanent record.
 	Committed
 )
 
@@ -80,7 +80,7 @@ type Store interface {
 	// ListTemporary lists all shadow branches with their checkpoint info.
 	ListTemporary(ctx context.Context) ([]TemporaryInfo, error)
 
-	// WriteCommitted writes a committed checkpoint to the entire/sessions branch.
+	// WriteCommitted writes a committed checkpoint to the entire/checkpoints/v1 branch.
 	// Checkpoints are stored at sharded paths: <id[:2]>/<id[2:]>/
 	WriteCommitted(ctx context.Context, opts WriteCommittedOptions) error
 
@@ -386,7 +386,7 @@ type SessionFilePaths struct {
 // to their file paths. Session-specific data (including initial_attribution)
 // is stored in the session's subdirectory metadata.json.
 //
-// Structure on entire/sessions branch:
+// Structure on entire/checkpoints/v1 branch:
 //
 //	<checkpoint-id[:2]>/<checkpoint-id[2:]>/
 //	├── metadata.json         # This CheckpointSummary

--- a/cmd/entire/cli/checkpoint/checkpoint_test.go
+++ b/cmd/entire/cli/checkpoint/checkpoint_test.go
@@ -676,7 +676,7 @@ func TestUpdateSummary_NotFound(t *testing.T) {
 }
 
 // TestListCommitted_FallsBackToRemote verifies that ListCommitted can find
-// checkpoints when only origin/entire/sessions exists (simulating post-clone state).
+// checkpoints when only origin/entire/checkpoints/v1 exists (simulating post-clone state).
 func TestListCommitted_FallsBackToRemote(t *testing.T) {
 	// Create "remote" repo (non-bare, so we can make commits)
 	remoteDir := t.TempDir()
@@ -703,7 +703,7 @@ func TestListCommitted_FallsBackToRemote(t *testing.T) {
 		t.Fatalf("failed to create initial commit: %v", err)
 	}
 
-	// Create entire/sessions branch on the remote with a checkpoint
+	// Create entire/checkpoints/v1 branch on the remote with a checkpoint
 	remoteStore := NewGitStore(remoteRepo)
 	cpID := id.MustCheckpointID("abcdef123456")
 	err = remoteStore.WriteCommitted(context.Background(), WriteCommittedOptions{
@@ -718,7 +718,7 @@ func TestListCommitted_FallsBackToRemote(t *testing.T) {
 		t.Fatalf("failed to write checkpoint to remote: %v", err)
 	}
 
-	// Clone the repo (this clones main, but not entire/sessions by default)
+	// Clone the repo (this clones main, but not entire/checkpoints/v1 by default)
 	localDir := t.TempDir()
 	localRepo, err := git.PlainClone(localDir, false, &git.CloneOptions{
 		URL: remoteDir,
@@ -727,7 +727,7 @@ func TestListCommitted_FallsBackToRemote(t *testing.T) {
 		t.Fatalf("failed to clone repo: %v", err)
 	}
 
-	// Fetch the entire/sessions branch to origin/entire/sessions
+	// Fetch the entire/checkpoints/v1 branch to origin/entire/checkpoints/v1
 	// (but don't create local branch - simulating post-clone state)
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", paths.MetadataBranchName, paths.MetadataBranchName)
 	err = localRepo.Fetch(&git.FetchOptions{
@@ -735,19 +735,19 @@ func TestListCommitted_FallsBackToRemote(t *testing.T) {
 		RefSpecs:   []config.RefSpec{config.RefSpec(refSpec)},
 	})
 	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
-		t.Fatalf("failed to fetch entire/sessions: %v", err)
+		t.Fatalf("failed to fetch entire/checkpoints/v1: %v", err)
 	}
 
 	// Verify local branch doesn't exist
 	_, err = localRepo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err == nil {
-		t.Fatal("local entire/sessions branch should not exist")
+		t.Fatal("local entire/checkpoints/v1 branch should not exist")
 	}
 
 	// Verify remote-tracking branch exists
 	_, err = localRepo.Reference(plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("origin/entire/sessions should exist: %v", err)
+		t.Fatalf("origin/entire/checkpoints/v1 should exist: %v", err)
 	}
 
 	// ListCommitted should find the checkpoint by falling back to remote
@@ -765,7 +765,7 @@ func TestListCommitted_FallsBackToRemote(t *testing.T) {
 }
 
 // TestGetCheckpointAuthor verifies that GetCheckpointAuthor retrieves the
-// author of the commit that created the checkpoint on the entire/sessions branch.
+// author of the commit that created the checkpoint on the entire/checkpoints/v1 branch.
 func TestGetCheckpointAuthor(t *testing.T) {
 	repo, _ := setupBranchTestRepo(t)
 	store := NewGitStore(repo)
@@ -823,7 +823,7 @@ func TestGetCheckpointAuthor_NotFound(t *testing.T) {
 }
 
 // TestGetCheckpointAuthor_NoSessionsBranch verifies that GetCheckpointAuthor
-// returns empty author when the entire/sessions branch doesn't exist.
+// returns empty author when the entire/checkpoints/v1 branch doesn't exist.
 func TestGetCheckpointAuthor_NoSessionsBranch(t *testing.T) {
 	// Create a fresh repo without sessions branch
 	tempDir := t.TempDir()

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -34,7 +34,7 @@ import (
 // errStopIteration is used to stop commit iteration early in GetCheckpointAuthor.
 var errStopIteration = errors.New("stop iteration")
 
-// WriteCommitted writes a committed checkpoint to the entire/sessions branch.
+// WriteCommitted writes a committed checkpoint to the entire/checkpoints/v1 branch.
 // Checkpoints are stored at sharded paths: <id[:2]>/<id[2:]>/
 //
 // For task checkpoints (IsTask=true), additional files are written under tasks/<tool-use-id>/:
@@ -570,7 +570,7 @@ type taskCheckpointData struct {
 	AgentID        string `json:"agent_id,omitempty"`
 }
 
-// ReadCommitted reads a committed checkpoint's summary by ID from the entire/sessions branch.
+// ReadCommitted reads a committed checkpoint's summary by ID from the entire/checkpoints/v1 branch.
 // Returns only the CheckpointSummary (paths + aggregated stats), not actual content.
 // Use ReadSessionContent to read actual transcript/prompts/context.
 // Returns nil, nil if the checkpoint doesn't exist.
@@ -721,7 +721,7 @@ func (s *GitStore) ReadSessionContentByID(ctx context.Context, checkpointID id.C
 	return nil, fmt.Errorf("session %q not found in checkpoint %s", sessionID, checkpointID)
 }
 
-// ListCommitted lists all committed checkpoints from the entire/sessions branch.
+// ListCommitted lists all committed checkpoints from the entire/checkpoints/v1 branch.
 // Scans sharded paths: <id[:2]>/<id[2:]>/ directories containing metadata.json.
 //
 
@@ -943,7 +943,7 @@ func (s *GitStore) UpdateSummary(ctx context.Context, checkpointID id.Checkpoint
 	return nil
 }
 
-// ensureSessionsBranch ensures the entire/sessions branch exists.
+// ensureSessionsBranch ensures the entire/checkpoints/v1 branch exists.
 func (s *GitStore) ensureSessionsBranch() error {
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 	_, err := s.repo.Reference(refName, true)
@@ -970,8 +970,8 @@ func (s *GitStore) ensureSessionsBranch() error {
 	return nil
 }
 
-// getSessionsBranchTree returns the tree object for the entire/sessions branch.
-// Falls back to origin/entire/sessions if the local branch doesn't exist.
+// getSessionsBranchTree returns the tree object for the entire/checkpoints/v1 branch.
+// Falls back to origin/entire/checkpoints/v1 if the local branch doesn't exist.
 func (s *GitStore) getSessionsBranchTree() (*object.Tree, error) {
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 	ref, err := s.repo.Reference(refName, true)
@@ -1227,7 +1227,7 @@ type Author struct {
 	Email string
 }
 
-// GetCheckpointAuthor retrieves the author of a checkpoint from the entire/sessions commit history.
+// GetCheckpointAuthor retrieves the author of a checkpoint from the entire/checkpoints/v1 commit history.
 // Returns the author of the commit that introduced this checkpoint's metadata.json file.
 // Returns empty Author if the checkpoint is not found or the sessions branch doesn't exist.
 func (s *GitStore) GetCheckpointAuthor(ctx context.Context, checkpointID id.CheckpointID) (Author, error) {

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CheckpointID is a 12-character hex identifier for checkpoints.
-// It's used to link code commits to metadata on the entire/sessions branch.
+// It's used to link code commits to metadata on the entire/checkpoints/v1 branch.
 //
 //nolint:recvcheck // UnmarshalJSON requires pointer receiver, others use value receiver - standard pattern
 type CheckpointID string
@@ -73,7 +73,7 @@ func (id CheckpointID) IsEmpty() bool {
 	return id == EmptyCheckpointID
 }
 
-// Path returns the sharded path for this checkpoint ID on entire/sessions.
+// Path returns the sharded path for this checkpoint ID on entire/checkpoints/v1.
 // Uses first 2 characters as shard (256 buckets), remaining as folder name.
 // Example: "a3b2c4d5e6f7" -> "a3/b2c4d5e6f7"
 func (id CheckpointID) Path() string {

--- a/cmd/entire/cli/checkpoint/temporary.go
+++ b/cmd/entire/cli/checkpoint/temporary.go
@@ -556,7 +556,7 @@ var errStop = errors.New("stop iteration")
 
 // GetTranscriptFromCommit retrieves the transcript from a specific commit's tree.
 // This is used for shadow branch checkpoints where the transcript is stored in the commit tree
-// rather than on the entire/sessions branch.
+// rather than on the entire/checkpoints/v1 branch.
 // commitHash is the commit to read from, metadataDir is the path within the tree.
 // agentType is used for reassembling chunked transcripts in the correct format.
 // Handles both chunked and non-chunked transcripts.

--- a/cmd/entire/cli/clean.go
+++ b/cmd/entire/cli/clean.go
@@ -26,7 +26,7 @@ This command finds and removes orphaned data from any strategy:
     Track active sessions. Orphaned when no checkpoints or shadow branches
     reference them.
 
-  Checkpoint metadata (entire/sessions branch)
+  Checkpoint metadata (entire/checkpoints/v1 branch)
     For auto-commit checkpoints: orphaned when commits are rebased/squashed
     and no commit references the checkpoint ID anymore.
     Manual-commit checkpoints are permanent (condensed history) and are
@@ -35,7 +35,7 @@ This command finds and removes orphaned data from any strategy:
 Without --force, shows a preview of items that would be deleted.
 With --force, actually deletes the orphaned items.
 
-The entire/sessions branch itself is never deleted.`,
+The entire/checkpoints/v1 branch itself is never deleted.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runClean(cmd.OutOrStdout(), forceFlag)
 		},

--- a/cmd/entire/cli/clean_test.go
+++ b/cmd/entire/cli/clean_test.go
@@ -92,7 +92,7 @@ func TestRunClean_PreviewMode(t *testing.T) {
 		}
 	}
 
-	// Also create entire/sessions (should NOT be listed)
+	// Also create entire/checkpoints/v1 (should NOT be listed)
 	sessionsRef := plumbing.NewHashReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), commitHash)
 	if err := repo.Storer.SetReference(sessionsRef); err != nil {
 		t.Fatalf("failed to create %s: %v", paths.MetadataBranchName, err)
@@ -183,7 +183,7 @@ func TestRunClean_SessionsBranchPreserved(t *testing.T) {
 
 	sessionsRef := plumbing.NewHashReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), commitHash)
 	if err := repo.Storer.SetReference(sessionsRef); err != nil {
-		t.Fatalf("failed to create entire/sessions: %v", err)
+		t.Fatalf("failed to create entire/checkpoints/v1: %v", err)
 	}
 
 	var stdout bytes.Buffer
@@ -201,7 +201,7 @@ func TestRunClean_SessionsBranchPreserved(t *testing.T) {
 	// Sessions branch should still exist
 	sessionsRefName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 	if _, err := repo.Reference(sessionsRefName, true); err != nil {
-		t.Error("entire/sessions branch should be preserved")
+		t.Error("entire/checkpoints/v1 branch should be preserved")
 	}
 }
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -799,7 +799,7 @@ var errStopIteration = errors.New("stop iteration")
 // Behavior:
 //   - On feature branches: only show checkpoints unique to this branch (not in main)
 //   - On default branch (main/master): show all checkpoints in history (up to limit)
-//   - Includes both committed checkpoints (entire/sessions) and temporary checkpoints (shadow branches)
+//   - Includes both committed checkpoints (entire/checkpoints/v1) and temporary checkpoints (shadow branches)
 func getBranchCheckpoints(repo *git.Repository, limit int) ([]strategy.RewindPoint, error) {
 	store := checkpoint.NewGitStore(repo)
 
@@ -1039,8 +1039,8 @@ func convertTemporaryCheckpoint(repo *git.Repository, tc checkpoint.TemporaryChe
 		return nil
 	}
 
-	// Read session prompt from the shadow branch commit's tree (not from entire/sessions)
-	// Temporary checkpoints store their metadata in the shadow branch, not in entire/sessions
+	// Read session prompt from the shadow branch commit's tree (not from entire/checkpoints/v1)
+	// Temporary checkpoints store their metadata in the shadow branch, not in entire/checkpoints/v1
 	var sessionPrompt string
 	shadowTree, treeErr := shadowCommit.Tree()
 	if treeErr == nil {

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1995,14 +1995,14 @@ func TestGetBranchCheckpoints_FiltersMainCommits(t *testing.T) {
 	}
 
 	// Get checkpoints - should only include feature branch commits, not main
-	// Note: Without actual checkpoint data in entire/sessions, this returns empty
+	// Note: Without actual checkpoint data in entire/checkpoints/v1, this returns empty
 	// but the important thing is it doesn't error and the filtering logic runs
 	points, err := getBranchCheckpoints(repo, 20)
 	if err != nil {
 		t.Fatalf("getBranchCheckpoints() error = %v", err)
 	}
 
-	// Without checkpoint data (no entire/sessions branch), should return 0 checkpoints
+	// Without checkpoint data (no entire/checkpoints/v1 branch), should return 0 checkpoints
 	// This validates the filtering code path runs without error
 	if len(points) != 0 {
 		t.Errorf("expected 0 checkpoints without checkpoint data, got %d", len(points))

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -379,7 +379,7 @@ func FetchAndCheckoutRemoteBranch(branchName string) error {
 	return CheckoutBranch(branchName)
 }
 
-// FetchMetadataBranch fetches the entire/sessions branch from origin and creates/updates the local branch.
+// FetchMetadataBranch fetches the entire/checkpoints/v1 branch from origin and creates/updates the local branch.
 // This is used when the metadata branch exists on remote but not locally.
 // Uses git CLI instead of go-git for fetch because go-git doesn't use credential helpers,
 // which breaks HTTPS URLs that require authentication.

--- a/cmd/entire/cli/integration_test/attribution_test.go
+++ b/cmd/entire/cli/integration_test/attribution_test.go
@@ -136,10 +136,10 @@ func TestManualCommit_Attribution(t *testing.T) {
 	// ========================================
 	t.Log("Verifying attribution in metadata")
 
-	// Read metadata from entire/sessions branch
+	// Read metadata from entire/checkpoints/v1 branch
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("Failed to get entire/sessions branch: %v", err)
+		t.Fatalf("Failed to get entire/checkpoints/v1 branch: %v", err)
 	}
 
 	sessionsCommit, err := repo.CommitObject(sessionsRef.Hash())
@@ -282,7 +282,7 @@ func TestManualCommit_AttributionDeletionOnly(t *testing.T) {
 
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("Failed to get entire/sessions branch: %v", err)
+		t.Fatalf("Failed to get entire/checkpoints/v1 branch: %v", err)
 	}
 
 	sessionsCommit, err := repo.CommitObject(sessionsRef.Hash())
@@ -517,14 +517,14 @@ func TestManualCommit_AttributionNoDoubleCount(t *testing.T) {
 	}
 }
 
-// getAttributionFromMetadata reads attribution from a checkpoint on entire/sessions branch.
+// getAttributionFromMetadata reads attribution from a checkpoint on entire/checkpoints/v1 branch.
 // InitialAttribution is stored in session-level metadata (0/metadata.json).
 func getAttributionFromMetadata(t *testing.T, repo *git.Repository, checkpointID id.CheckpointID) *checkpoint.InitialAttribution {
 	t.Helper()
 
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("Failed to get entire/sessions branch: %v", err)
+		t.Fatalf("Failed to get entire/checkpoints/v1 branch: %v", err)
 	}
 
 	sessionsCommit, err := repo.CommitObject(sessionsRef.Hash())

--- a/cmd/entire/cli/integration_test/auto_commit_checkpoint_fix_test.go
+++ b/cmd/entire/cli/integration_test/auto_commit_checkpoint_fix_test.go
@@ -163,7 +163,7 @@ func TestDualStrategy_IncrementalPromptContent(t *testing.T) {
 	// Verify first checkpoint has prompt A (session files in numbered subdirectory)
 	prompt1Content, found := env.ReadFileFromBranch(paths.MetadataBranchName, SessionFilePath(checkpoint1ID, "prompt.txt"))
 	if !found {
-		t.Fatal("First checkpoint should have prompt.txt on entire/sessions branch")
+		t.Fatal("First checkpoint should have prompt.txt on entire/checkpoints/v1 branch")
 	}
 	t.Logf("First checkpoint prompt.txt:\n%s", prompt1Content)
 
@@ -211,7 +211,7 @@ func TestDualStrategy_IncrementalPromptContent(t *testing.T) {
 	// Session files are now in numbered subdirectory (e.g., 0/prompt.txt)
 	prompt2Content, found := env.ReadFileFromBranch(paths.MetadataBranchName, SessionFilePath(checkpoint2ID, "prompt.txt"))
 	if !found {
-		t.Fatal("Second checkpoint should have prompt.txt on entire/sessions branch")
+		t.Fatal("Second checkpoint should have prompt.txt on entire/checkpoints/v1 branch")
 	}
 	t.Logf("Second checkpoint prompt.txt:\n%s", prompt2Content)
 

--- a/cmd/entire/cli/integration_test/last_checkpoint_id_test.go
+++ b/cmd/entire/cli/integration_test/last_checkpoint_id_test.go
@@ -99,7 +99,7 @@ func TestShadowStrategy_LastCheckpointID_ReusedAcrossCommits(t *testing.T) {
 			firstCheckpointID, secondCheckpointID)
 	}
 
-	// Verify the checkpoint exists on entire/sessions branch
+	// Verify the checkpoint exists on entire/checkpoints/v1 branch
 	checkpointPath := paths.CheckpointPath(id.MustCheckpointID(firstCheckpointID))
 	if !env.FileExistsInBranch(paths.MetadataBranchName, checkpointPath+"/"+paths.MetadataFileName) {
 		t.Errorf("Checkpoint metadata should exist at %s on %s branch",
@@ -355,11 +355,11 @@ func TestShadowStrategy_ShadowBranchCleanedUpAfterCondensation(t *testing.T) {
 		t.Errorf("Shadow branch %s should be deleted after condensation", shadowBranchName)
 	}
 
-	// Verify data exists on entire/sessions
+	// Verify data exists on entire/checkpoints/v1
 	checkpointID := env.GetLatestCheckpointID()
 	checkpointPath := paths.CheckpointPath(id.MustCheckpointID(checkpointID))
 	if !env.FileExistsInBranch(paths.MetadataBranchName, checkpointPath+"/"+paths.MetadataFileName) {
-		t.Error("Checkpoint metadata should exist on entire/sessions branch")
+		t.Error("Checkpoint metadata should exist on entire/checkpoints/v1 branch")
 	}
 }
 

--- a/cmd/entire/cli/integration_test/logs_only_rewind_test.go
+++ b/cmd/entire/cli/integration_test/logs_only_rewind_test.go
@@ -64,7 +64,7 @@ func TestLogsOnlyRewind_AppearsInRewindList(t *testing.T) {
 
 	env.GitCommitWithShadowHooks("Add main.go", "main.go")
 
-	// Get commit hash and condensation ID (now from entire/sessions branch, not commit trailer)
+	// Get commit hash and condensation ID (now from entire/checkpoints/v1 branch, not commit trailer)
 	commitHash := env.GetHeadHash()
 	condensationID := env.GetLatestCondensationID()
 	t.Logf("Condensation ID: %s", condensationID)

--- a/cmd/entire/cli/integration_test/manual_commit_workflow_test.go
+++ b/cmd/entire/cli/integration_test/manual_commit_workflow_test.go
@@ -244,9 +244,9 @@ func TestShadow_FullWorkflow(t *testing.T) {
 	checkpoint1ID = env.GetLatestCheckpointIDFromHistory()
 	t.Logf("Checkpoint 1 ID: %s", checkpoint1ID)
 
-	// Verify entire/sessions branch exists with checkpoint folder
+	// Verify entire/checkpoints/v1 branch exists with checkpoint folder
 	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Error("entire/sessions branch should exist after condensation")
+		t.Error("entire/checkpoints/v1 branch should exist after condensation")
 	}
 
 	// Verify checkpoint folder contents (check via git show)
@@ -344,7 +344,7 @@ func TestShadow_FullWorkflow(t *testing.T) {
 		t.Error("Commits should NOT have Entire-Session trailer (clean history)")
 	}
 
-	// 2 checkpoint folders in entire/sessions (Already verified above)
+	// 2 checkpoint folders in entire/checkpoints/v1 (Already verified above)
 
 	// Verify all expected files exist in working directory
 	expectedFiles := []string{"README.md", "src/auth.go", "src/bcrypt.go", "src/session.go"}
@@ -626,7 +626,7 @@ func TestShadow_ShadowBranchNaming(t *testing.T) {
 }
 
 // TestShadow_TranscriptCondensation verifies that session transcripts are
-// included in the entire/sessions branch during condensation.
+// included in the entire/checkpoints/v1 branch during condensation.
 func TestShadow_TranscriptCondensation(t *testing.T) {
 	t.Parallel()
 	env := NewTestEnv(t)
@@ -664,13 +664,13 @@ func TestShadow_TranscriptCondensation(t *testing.T) {
 	// Commit with hooks (triggers condensation)
 	env.GitCommitWithShadowHooks("Add main.go", "main.go")
 
-	// Get checkpoint ID from entire/sessions branch (not from commit message)
+	// Get checkpoint ID from entire/checkpoints/v1 branch (not from commit message)
 	checkpointID := env.GetLatestCheckpointID()
 	t.Logf("Checkpoint ID: %s", checkpointID)
 
-	// Verify entire/sessions branch exists
+	// Verify entire/checkpoints/v1 branch exists
 	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Fatal("entire/sessions branch should exist after condensation")
+		t.Fatal("entire/checkpoints/v1 branch should exist after condensation")
 	}
 
 	// Verify root metadata.json (CheckpointSummary) exists
@@ -1293,7 +1293,7 @@ func TestShadow_IntermediateCommitsWithoutPrompts(t *testing.T) {
 			checkpoint1ID, checkpoint3ID)
 	}
 
-	t.Log("Phase 5: Verify checkpoints exist in entire/sessions")
+	t.Log("Phase 5: Verify checkpoints exist in entire/checkpoints/v1")
 
 	for _, cpID := range []string{checkpoint1ID, checkpoint3ID} {
 		shardedPath := ShardedCheckpointPath(cpID)
@@ -1629,11 +1629,11 @@ func TestShadow_TrailerRemovalSkipsCondensation(t *testing.T) {
 
 	t.Log("Phase 3: Verify no condensation happened")
 
-	// entire/sessions branch exists (created at setup), but should not have any checkpoint commits yet
+	// entire/checkpoints/v1 branch exists (created at setup), but should not have any checkpoint commits yet
 	// since the user removed the trailer
 	latestCheckpointID := env.TryGetLatestCheckpointID()
 	if latestCheckpointID == "" {
-		t.Log("✓ No checkpoint found on entire/sessions branch (no condensation)")
+		t.Log("✓ No checkpoint found on entire/checkpoints/v1 branch (no condensation)")
 	} else {
 		// If there is a checkpoint, this is unexpected for this test
 		t.Logf("Found checkpoint ID: %s (should be from previous activity, not this commit)", latestCheckpointID)
@@ -1677,7 +1677,7 @@ func TestShadow_TrailerRemovalSkipsCondensation(t *testing.T) {
 
 	// Verify condensation happened for second commit
 	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Fatal("entire/sessions branch should exist after second commit with trailer")
+		t.Fatal("entire/checkpoints/v1 branch should exist after second commit with trailer")
 	}
 
 	// Verify checkpoint exists
@@ -1692,7 +1692,7 @@ func TestShadow_TrailerRemovalSkipsCondensation(t *testing.T) {
 	t.Log("Trailer removal opt-out test completed successfully!")
 }
 
-// TestShadow_SessionsBranchCommitTrailers verifies that commits on the entire/sessions
+// TestShadow_SessionsBranchCommitTrailers verifies that commits on the entire/checkpoints/v1
 // branch contain the expected trailers: Entire-Session, Entire-Strategy, and Entire-Agent.
 func TestShadow_SessionsBranchCommitTrailers(t *testing.T) {
 	t.Parallel()
@@ -1724,9 +1724,9 @@ func TestShadow_SessionsBranchCommitTrailers(t *testing.T) {
 	// Commit to trigger condensation
 	env.GitCommitWithShadowHooks("Add main.go", "main.go")
 
-	// Get the commit message on entire/sessions branch
+	// Get the commit message on entire/checkpoints/v1 branch
 	sessionsCommitMsg := env.GetLatestCommitMessageOnBranch(paths.MetadataBranchName)
-	t.Logf("entire/sessions commit message:\n%s", sessionsCommitMsg)
+	t.Logf("entire/checkpoints/v1 commit message:\n%s", sessionsCommitMsg)
 
 	// Verify required trailers are present
 	requiredTrailers := map[string]string{
@@ -1737,7 +1737,7 @@ func TestShadow_SessionsBranchCommitTrailers(t *testing.T) {
 
 	for trailerKey, expectedValue := range requiredTrailers {
 		if !strings.Contains(sessionsCommitMsg, trailerKey+":") {
-			t.Errorf("entire/sessions commit should have %s trailer", trailerKey)
+			t.Errorf("entire/checkpoints/v1 commit should have %s trailer", trailerKey)
 			continue
 		}
 
@@ -1745,7 +1745,7 @@ func TestShadow_SessionsBranchCommitTrailers(t *testing.T) {
 		if expectedValue != "" {
 			expectedTrailer := trailerKey + ": " + expectedValue
 			if !strings.Contains(sessionsCommitMsg, expectedTrailer) {
-				t.Errorf("entire/sessions commit should have %q, got message:\n%s", expectedTrailer, sessionsCommitMsg)
+				t.Errorf("entire/checkpoints/v1 commit should have %q, got message:\n%s", expectedTrailer, sessionsCommitMsg)
 			} else {
 				t.Logf("✓ Found trailer: %s", expectedTrailer)
 			}

--- a/cmd/entire/cli/integration_test/phase_transitions_test.go
+++ b/cmd/entire/cli/integration_test/phase_transitions_test.go
@@ -20,7 +20,7 @@ import (
 // SimulateUserPromptSubmit and SimulateStop), the session should transition to
 // ACTIVE_COMMITTED. This defers condensation because the agent is still working.
 // When the agent finishes its turn (SimulateStop), the deferred condensation fires
-// and the session transitions to IDLE with metadata persisted to entire/sessions.
+// and the session transitions to IDLE with metadata persisted to entire/checkpoints/v1.
 //
 // State machine transitions tested:
 //   - ACTIVE + GitCommit -> ACTIVE_COMMITTED (defer condensation, migrate shadow branch)
@@ -192,13 +192,13 @@ func TestShadow_CommitBeforeStop(t *testing.T) {
 	t.Logf("Session phase after stop: %s (StepCount: %d)", state.Phase, state.StepCount)
 
 	// Deferred condensation should have fired during TurnEnd (ACTIVE_COMMITTED → IDLE).
-	// Verify StepCount was reset and metadata was persisted to entire/sessions.
+	// Verify StepCount was reset and metadata was persisted to entire/checkpoints/v1.
 	if state.StepCount != 0 {
 		t.Errorf("StepCount should be 0 after TurnEnd condensation, got %d", state.StepCount)
 	}
 
 	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Fatal("entire/sessions branch should exist after TurnEnd condensation")
+		t.Fatal("entire/checkpoints/v1 branch should exist after TurnEnd condensation")
 	}
 	latestCheckpointID := env.TryGetLatestCheckpointID()
 	if latestCheckpointID != "" {
@@ -259,7 +259,7 @@ func TestShadow_AmendPreservesTrailer(t *testing.T) {
 
 	// Verify condensation happened
 	if !env.BranchExists(paths.MetadataBranchName) {
-		t.Fatal("entire/sessions branch should exist after condensation")
+		t.Fatal("entire/checkpoints/v1 branch should exist after condensation")
 	}
 
 	// Record the sessions branch state for later comparison

--- a/cmd/entire/cli/integration_test/resume_test.go
+++ b/cmd/entire/cli/integration_test/resume_test.go
@@ -21,7 +21,7 @@ import (
 const masterBranch = "master"
 
 // Note: Resume tests only run with auto-commit strategy because:
-// - Auto-commit strategy creates commits with Entire-Checkpoint trailers and metadata on entire/sessions
+// - Auto-commit strategy creates commits with Entire-Checkpoint trailers and metadata on entire/checkpoints/v1
 //   immediately during SimulateStop
 // - Manual-commit strategy only creates this structure after user commits (via prepare-commit-msg
 //   and post-commit hooks), which requires the full workflow tested in manual_commit_workflow_test.go
@@ -344,13 +344,13 @@ func TestResume_MultipleSessionsOnBranch(t *testing.T) {
 }
 
 // TestResume_CheckpointWithoutMetadata tests resume when a commit has an Entire-Checkpoint
-// trailer but the corresponding metadata is missing from entire/sessions branch.
+// trailer but the corresponding metadata is missing from entire/checkpoints/v1 branch.
 // This can happen if the metadata branch was corrupted or reset.
 func TestResume_CheckpointWithoutMetadata(t *testing.T) {
 	t.Parallel()
 	env := NewFeatureBranchEnv(t, strategy.StrategyNameAutoCommit)
 
-	// First create a real session so the entire/sessions branch exists
+	// First create a real session so the entire/checkpoints/v1 branch exists
 	session := env.NewSession()
 	if err := env.SimulateUserPromptSubmit(session.ID); err != nil {
 		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)

--- a/cmd/entire/cli/integration_test/subagent_checkpoints_test.go
+++ b/cmd/entire/cli/integration_test/subagent_checkpoints_test.go
@@ -300,9 +300,9 @@ func verifyCheckpointStorage(t *testing.T, env *TestEnv, strategyName, sessionID
 		verifyShadowCheckpointStorage(t, env, entireSessionID, taskToolUseID)
 
 	case strategy.StrategyNameAutoCommit:
-		// Dual strategy stores metadata on orphan entire/sessions branch
+		// Dual strategy stores metadata on orphan entire/checkpoints/v1 branch
 		// Verify that commits were created (incremental + final)
-		t.Logf("Note: auto-commit strategy stores checkpoints in entire/sessions branch")
+		t.Logf("Note: auto-commit strategy stores checkpoints in entire/checkpoints/v1 branch")
 	}
 }
 

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -1131,7 +1131,7 @@ func (env *TestEnv) ListBranchesWithPrefix(prefix string) []string {
 	return branches
 }
 
-// GetLatestCheckpointID returns the most recent checkpoint ID from the entire/sessions branch.
+// GetLatestCheckpointID returns the most recent checkpoint ID from the entire/checkpoints/v1 branch.
 // This is used by tests that previously extracted the checkpoint ID from commit message trailers.
 // Now that active branch commits are clean (no trailers), we get the ID from the sessions branch.
 // Fatals if the checkpoint ID cannot be found, with detailed context about what was found.
@@ -1143,7 +1143,7 @@ func (env *TestEnv) GetLatestCheckpointID() string {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
 
-	// Get the entire/sessions branch
+	// Get the entire/checkpoints/v1 branch
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 	ref, err := repo.Reference(refName, true)
 	if err != nil {
@@ -1169,7 +1169,7 @@ func (env *TestEnv) GetLatestCheckpointID() string {
 	return ""
 }
 
-// TryGetLatestCheckpointID returns the most recent checkpoint ID from the entire/sessions branch.
+// TryGetLatestCheckpointID returns the most recent checkpoint ID from the entire/checkpoints/v1 branch.
 // Returns empty string if the branch doesn't exist or has no checkpoint commits yet.
 // Use this when you need to check if a checkpoint exists without failing the test.
 func (env *TestEnv) TryGetLatestCheckpointID() string {
@@ -1180,7 +1180,7 @@ func (env *TestEnv) TryGetLatestCheckpointID() string {
 		return ""
 	}
 
-	// Get the entire/sessions branch
+	// Get the entire/checkpoints/v1 branch
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 	ref, err := repo.Reference(refName, true)
 	if err != nil {

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -321,14 +321,14 @@ func promptResumeFromOlderCheckpoint() (bool, error) {
 	return confirmed, nil
 }
 
-// checkRemoteMetadata checks if checkpoint metadata exists on origin/entire/sessions
+// checkRemoteMetadata checks if checkpoint metadata exists on origin/entire/checkpoints/v1
 // and automatically fetches it if available.
 func checkRemoteMetadata(repo *git.Repository, checkpointID id.CheckpointID) error {
 	// Try to get remote metadata branch tree
 	remoteTree, err := strategy.GetRemoteMetadataBranchTree(repo)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Checkpoint '%s' found in commit but session metadata not available\n", checkpointID)
-		fmt.Fprintf(os.Stderr, "The entire/sessions branch may not exist locally or on the remote.\n")
+		fmt.Fprintf(os.Stderr, "The entire/checkpoints/v1 branch may not exist locally or on the remote.\n")
 		return nil //nolint:nilerr // Informational message, not a fatal error
 	}
 
@@ -343,7 +343,7 @@ func checkRemoteMetadata(repo *git.Repository, checkpointID id.CheckpointID) err
 	fmt.Fprintf(os.Stderr, "Fetching session metadata from origin...\n")
 	if err := FetchMetadataBranch(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fetch metadata: %v\n", err)
-		fmt.Fprintf(os.Stderr, "You can try manually: git fetch origin entire/sessions:entire/sessions\n")
+		fmt.Fprintf(os.Stderr, "You can try manually: git fetch origin entire/checkpoints/v1:entire/checkpoints/v1\n")
 		return NewSilentError(errors.New("failed to fetch metadata"))
 	}
 

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -101,7 +101,7 @@ func setupResumeTestRepo(t *testing.T, tmpDir string, createFeatureBranch bool) 
 		}
 	}
 
-	// Ensure entire/sessions branch exists
+	// Ensure entire/checkpoints/v1 branch exists
 	if err := strategy.EnsureMetadataBranch(repo); err != nil {
 		t.Fatalf("Failed to create metadata branch: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestResumeFromCurrentBranch_WithEntireCheckpointTrailer(t *testing.T) {
 
 	_, _, _ = setupResumeTestRepo(t, tmpDir, false)
 
-	// Set up the auto-commit strategy and create checkpoint metadata on entire/sessions branch
+	// Set up the auto-commit strategy and create checkpoint metadata on entire/checkpoints/v1 branch
 	strat := strategy.NewAutoCommitStrategy()
 	if err := strat.EnsureSetup(); err != nil {
 		t.Fatalf("Failed to ensure setup: %v", err)
@@ -214,7 +214,7 @@ func TestResumeFromCurrentBranch_WithEntireCheckpointTrailer(t *testing.T) {
 		t.Fatalf("Failed to write test file: %v", err)
 	}
 
-	// Use SaveChanges to create a commit with checkpoint metadata on entire/sessions branch
+	// Use SaveChanges to create a commit with checkpoint metadata on entire/checkpoints/v1 branch
 	ctx := strategy.SaveContext{
 		CommitMessage:  "test commit with checkpoint",
 		MetadataDir:    filepath.Join(paths.EntireMetadataDir, sessionID),
@@ -306,7 +306,7 @@ func TestRunResume_UncommittedChanges(t *testing.T) {
 	}
 }
 
-// createCheckpointOnMetadataBranch creates a checkpoint on the entire/sessions branch.
+// createCheckpointOnMetadataBranch creates a checkpoint on the entire/checkpoints/v1 branch.
 // Returns the checkpoint ID.
 func createCheckpointOnMetadataBranch(t *testing.T, repo *git.Repository, sessionID string) id.CheckpointID {
 	t.Helper()
@@ -478,11 +478,11 @@ func TestCheckRemoteMetadata_MetadataExistsOnRemote(t *testing.T) {
 
 	repo, _, _ := setupResumeTestRepo(t, tmpDir, false)
 
-	// Create checkpoint metadata on local entire/sessions branch
+	// Create checkpoint metadata on local entire/checkpoints/v1 branch
 	sessionID := "2025-01-01-test-session"
 	checkpointID := createCheckpointOnMetadataBranch(t, repo, sessionID)
 
-	// Copy the local entire/sessions to origin/entire/sessions (simulate remote)
+	// Copy the local entire/checkpoints/v1 to origin/entire/checkpoints/v1 (simulate remote)
 	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
 		t.Fatalf("Failed to get local metadata branch: %v", err)
@@ -495,7 +495,7 @@ func TestCheckRemoteMetadata_MetadataExistsOnRemote(t *testing.T) {
 		t.Fatalf("Failed to create remote ref: %v", err)
 	}
 
-	// Delete local entire/sessions branch to simulate "not fetched yet"
+	// Delete local entire/checkpoints/v1 branch to simulate "not fetched yet"
 	if err := repo.Storer.RemoveReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName)); err != nil {
 		t.Fatalf("Failed to remove local metadata branch: %v", err)
 	}
@@ -520,12 +520,12 @@ func TestCheckRemoteMetadata_NoRemoteMetadataBranch(t *testing.T) {
 
 	repo, _, _ := setupResumeTestRepo(t, tmpDir, false)
 
-	// Delete local entire/sessions branch
+	// Delete local entire/checkpoints/v1 branch
 	if err := repo.Storer.RemoveReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName)); err != nil {
 		t.Fatalf("Failed to remove local metadata branch: %v", err)
 	}
 
-	// Don't create any remote ref - simulating no remote entire/sessions
+	// Don't create any remote ref - simulating no remote entire/checkpoints/v1
 
 	// Call checkRemoteMetadata - should handle gracefully (no remote branch)
 	err := checkRemoteMetadata(repo, "nonexistent123")
@@ -540,11 +540,11 @@ func TestCheckRemoteMetadata_CheckpointNotOnRemote(t *testing.T) {
 
 	repo, _, _ := setupResumeTestRepo(t, tmpDir, false)
 
-	// Create checkpoint metadata on local entire/sessions branch
+	// Create checkpoint metadata on local entire/checkpoints/v1 branch
 	sessionID := "2025-01-01-test-session"
 	_ = createCheckpointOnMetadataBranch(t, repo, sessionID)
 
-	// Copy the local entire/sessions to origin/entire/sessions (simulate remote)
+	// Copy the local entire/checkpoints/v1 to origin/entire/checkpoints/v1 (simulate remote)
 	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
 		t.Fatalf("Failed to get local metadata branch: %v", err)
@@ -557,7 +557,7 @@ func TestCheckRemoteMetadata_CheckpointNotOnRemote(t *testing.T) {
 		t.Fatalf("Failed to create remote ref: %v", err)
 	}
 
-	// Delete local entire/sessions branch
+	// Delete local entire/checkpoints/v1 branch
 	if err := repo.Storer.RemoveReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName)); err != nil {
 		t.Fatalf("Failed to remove local metadata branch: %v", err)
 	}
@@ -579,11 +579,11 @@ func TestResumeFromCurrentBranch_FallsBackToRemote(t *testing.T) {
 
 	repo, w, _ := setupResumeTestRepo(t, tmpDir, false)
 
-	// Create checkpoint metadata on local entire/sessions branch
+	// Create checkpoint metadata on local entire/checkpoints/v1 branch
 	sessionID := "2025-01-01-test-session-uuid"
 	checkpointID := createCheckpointOnMetadataBranch(t, repo, sessionID)
 
-	// Copy the local entire/sessions to origin/entire/sessions (simulate remote)
+	// Copy the local entire/checkpoints/v1 to origin/entire/checkpoints/v1 (simulate remote)
 	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
 		t.Fatalf("Failed to get local metadata branch: %v", err)
@@ -596,7 +596,7 @@ func TestResumeFromCurrentBranch_FallsBackToRemote(t *testing.T) {
 		t.Fatalf("Failed to create remote ref: %v", err)
 	}
 
-	// Delete local entire/sessions branch to simulate "not fetched yet"
+	// Delete local entire/checkpoints/v1 branch to simulate "not fetched yet"
 	if err := repo.Storer.RemoveReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName)); err != nil {
 		t.Fatalf("Failed to remove local metadata branch: %v", err)
 	}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -568,7 +568,7 @@ func setupAgentHooksNonInteractive(w io.Writer, agentName agent.AgentName, strat
 	}
 	fmt.Fprintf(w, "✓ Project configured (%s)\n", configDisplayProject)
 
-	// Let the strategy handle its own setup requirements (creates entire/sessions branch, etc.)
+	// Let the strategy handle its own setup requirements (creates entire/checkpoints/v1 branch, etc.)
 	strat, err := strategy.Get(settings.Strategy)
 	if err != nil {
 		return fmt.Errorf("failed to get strategy: %w", err)

--- a/cmd/entire/cli/strategy/auto_commit_test.go
+++ b/cmd/entire/cli/strategy/auto_commit_test.go
@@ -56,7 +56,7 @@ func TestAutoCommitStrategy_SaveChanges_CommitHasMetadataRef(t *testing.T) {
 
 	t.Chdir(dir)
 
-	// Setup strategy and ensure entire/sessions branch exists
+	// Setup strategy and ensure entire/checkpoints/v1 branch exists
 	s := NewAutoCommitStrategy()
 	if err := s.EnsureSetup(); err != nil {
 		t.Fatalf("EnsureSetup() error = %v", err)
@@ -122,10 +122,10 @@ func TestAutoCommitStrategy_SaveChanges_CommitHasMetadataRef(t *testing.T) {
 		t.Errorf("code commit should NOT have session trailer, got message:\n%s", commit.Message)
 	}
 
-	// Verify metadata was stored on entire/sessions branch
+	// Verify metadata was stored on entire/checkpoints/v1 branch
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("entire/sessions branch not found: %v", err)
+		t.Fatalf("entire/checkpoints/v1 branch not found: %v", err)
 	}
 	sessionsCommit, err := repo.CommitObject(sessionsRef.Hash())
 	if err != nil {
@@ -229,10 +229,10 @@ func TestAutoCommitStrategy_SaveChanges_MetadataRefPointsToValidCommit(t *testin
 		t.Errorf("code commit should NOT have source-ref trailer, got:\n%s", commit.Message)
 	}
 
-	// Get the entire/sessions branch
+	// Get the entire/checkpoints/v1 branch
 	metadataBranchRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("failed to get entire/sessions branch: %v", err)
+		t.Fatalf("failed to get entire/checkpoints/v1 branch: %v", err)
 	}
 
 	metadataCommit, err := repo.CommitObject(metadataBranchRef.Hash())
@@ -341,10 +341,10 @@ func TestAutoCommitStrategy_SaveTaskCheckpoint_CommitHasMetadataRef(t *testing.T
 		t.Errorf("task checkpoint commit should NOT have strategy trailer, got message:\n%s", commit.Message)
 	}
 
-	// Verify metadata was stored on entire/sessions branch
+	// Verify metadata was stored on entire/checkpoints/v1 branch
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("entire/sessions branch not found: %v", err)
+		t.Fatalf("entire/checkpoints/v1 branch not found: %v", err)
 	}
 	sessionsCommit, err := repo.CommitObject(sessionsRef.Hash())
 	if err != nil {
@@ -436,10 +436,10 @@ func TestAutoCommitStrategy_SaveTaskCheckpoint_NoChangesSkipsCommit(t *testing.T
 		t.Error("checkpoint without file changes should have the same tree hash")
 	}
 
-	// Metadata should still be stored on entire/sessions branch
+	// Metadata should still be stored on entire/checkpoints/v1 branch
 	metadataBranch, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("failed to get entire/sessions branch: %v", err)
+		t.Fatalf("failed to get entire/checkpoints/v1 branch: %v", err)
 	}
 
 	metadataCommit, err := repo.CommitObject(metadataBranch.Hash())
@@ -449,7 +449,7 @@ func TestAutoCommitStrategy_SaveTaskCheckpoint_NoChangesSkipsCommit(t *testing.T
 
 	// Verify metadata was committed to the branch
 	if !strings.Contains(metadataCommit.Message, trailers.MetadataTaskTrailerKey) {
-		t.Error("metadata should still be committed to entire/sessions branch")
+		t.Error("metadata should still be committed to entire/checkpoints/v1 branch")
 	}
 }
 
@@ -515,7 +515,7 @@ func TestAutoCommitStrategy_GetSessionContext(t *testing.T) {
 		metadataDirAbs = metadataDir
 	}
 
-	// Save changes - this creates a checkpoint on entire/sessions
+	// Save changes - this creates a checkpoint on entire/checkpoints/v1
 	ctx := SaveContext{
 		CommitMessage:  "Test checkpoint",
 		MetadataDir:    metadataDir,
@@ -604,7 +604,7 @@ func TestAutoCommitStrategy_ListSessions_HasDescription(t *testing.T) {
 		metadataDirAbs = metadataDir
 	}
 
-	// Save changes - this creates a checkpoint on entire/sessions
+	// Save changes - this creates a checkpoint on entire/checkpoints/v1
 	ctx := SaveContext{
 		CommitMessage:  "Test checkpoint",
 		MetadataDir:    metadataDir,
@@ -877,10 +877,10 @@ func TestAutoCommitStrategy_SaveChanges_FilesAlreadyCommitted(t *testing.T) {
 		t.Fatalf("failed to commit test file: %v", err)
 	}
 
-	// Get count of commits on entire/sessions before the call
+	// Get count of commits on entire/checkpoints/v1 before the call
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("entire/sessions branch not found: %v", err)
+		t.Fatalf("entire/checkpoints/v1 branch not found: %v", err)
 	}
 	sessionsCommitBefore := sessionsRef.Hash()
 
@@ -927,13 +927,13 @@ func TestAutoCommitStrategy_SaveChanges_FilesAlreadyCommitted(t *testing.T) {
 		t.Errorf("HEAD should still be user's commit %s, got %s", userCommit, head.Hash())
 	}
 
-	// Verify entire/sessions branch has no new commits (metadata not created)
+	// Verify entire/checkpoints/v1 branch has no new commits (metadata not created)
 	sessionsRefAfter, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("entire/sessions branch not found after SaveChanges: %v", err)
+		t.Fatalf("entire/checkpoints/v1 branch not found after SaveChanges: %v", err)
 	}
 	if sessionsRefAfter.Hash() != sessionsCommitBefore {
-		t.Errorf("entire/sessions should not have new commits when files already committed, before=%s after=%s",
+		t.Errorf("entire/checkpoints/v1 should not have new commits when files already committed, before=%s after=%s",
 			sessionsCommitBefore, sessionsRefAfter.Hash())
 	}
 }
@@ -976,10 +976,10 @@ func TestAutoCommitStrategy_SaveChanges_NoChangesSkipped(t *testing.T) {
 		t.Fatalf("EnsureSetup() error = %v", err)
 	}
 
-	// Get count of commits on entire/sessions before the call
+	// Get count of commits on entire/checkpoints/v1 before the call
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("entire/sessions branch not found: %v", err)
+		t.Fatalf("entire/checkpoints/v1 branch not found: %v", err)
 	}
 	sessionsCommitBefore := sessionsRef.Hash()
 
@@ -1025,13 +1025,13 @@ func TestAutoCommitStrategy_SaveChanges_NoChangesSkipped(t *testing.T) {
 		t.Errorf("HEAD should still be initial commit %s, got %s", initialCommit, head.Hash())
 	}
 
-	// Verify entire/sessions branch has no new commits (metadata not created)
+	// Verify entire/checkpoints/v1 branch has no new commits (metadata not created)
 	sessionsRefAfter, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
-		t.Fatalf("entire/sessions branch not found after SaveChanges: %v", err)
+		t.Fatalf("entire/checkpoints/v1 branch not found after SaveChanges: %v", err)
 	}
 	if sessionsRefAfter.Hash() != sessionsCommitBefore {
-		t.Errorf("entire/sessions should not have new commits when no code changes, before=%s after=%s",
+		t.Errorf("entire/checkpoints/v1 should not have new commits when no code changes, before=%s after=%s",
 			sessionsCommitBefore, sessionsRefAfter.Hash())
 	}
 }

--- a/cmd/entire/cli/strategy/clean_test.go
+++ b/cmd/entire/cli/strategy/clean_test.go
@@ -304,7 +304,7 @@ func TestDeleteShadowBranches_Empty(t *testing.T) {
 // P1 Bug: A session that just started (via InitializeSession) but hasn't created
 // its first checkpoint yet would be incorrectly marked as orphaned because it has:
 // - A session state file
-// - No checkpoints on entire/sessions
+// - No checkpoints on entire/checkpoints/v1
 // - No shadow branch (if using auto-commit strategy, or before first checkpoint)
 //
 // This test should FAIL with the current implementation, demonstrating the bug.

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -64,7 +64,7 @@ var shadowBranchPattern = regexp.MustCompile(`^entire/[0-9a-fA-F]{7,}(-[0-9a-fA-
 // commit hash is at least 7 hex characters and worktree hash is 6 hex characters.
 // The "entire/checkpoints/v1" branch is NOT a shadow branch.
 func IsShadowBranch(branchName string) bool {
-	// Explicitly exclude entire/sessions
+	// Explicitly exclude entire/checkpoints/v1
 	if branchName == paths.MetadataBranchName {
 		return false
 	}
@@ -152,7 +152,7 @@ func DeleteShadowBranches(branches []string) (deleted []string, failed []string,
 
 // ListOrphanedSessionStates returns session state files that are orphaned.
 // A session state is orphaned if:
-//   - No checkpoints on entire/sessions reference this session ID
+//   - No checkpoints on entire/checkpoints/v1 reference this session ID
 //   - No shadow branch exists for the session's base commit
 //
 // This is strategy-agnostic as session states are shared by all strategies.
@@ -205,7 +205,7 @@ func ListOrphanedSessionStates() ([]CleanupItem, error) {
 			continue
 		}
 
-		// Check if session has checkpoints on entire/sessions
+		// Check if session has checkpoints on entire/checkpoints/v1
 		hasCheckpoints := sessionsWithCheckpoints[state.SessionID]
 
 		// Check if shadow branch exists for this session's base commit and worktree
@@ -249,7 +249,7 @@ func DeleteOrphanedSessionStates(sessionIDs []string) (deleted []string, failed 
 	return deleted, failed, nil
 }
 
-// DeleteOrphanedCheckpoints removes checkpoint directories from the entire/sessions branch.
+// DeleteOrphanedCheckpoints removes checkpoint directories from the entire/checkpoints/v1 branch.
 func DeleteOrphanedCheckpoints(checkpointIDs []string) (deleted []string, failed []string, err error) {
 	if len(checkpointIDs) == 0 {
 		return []string{}, []string{}, nil

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -68,7 +68,7 @@ func IsAncestorOf(repo *git.Repository, commit, target plumbing.Hash) bool {
 	return found
 }
 
-// ListCheckpoints returns all checkpoints from the entire/sessions branch.
+// ListCheckpoints returns all checkpoints from the entire/checkpoints/v1 branch.
 // Scans sharded paths: <id[:2]>/<id[2:]>/ directories containing metadata.json.
 // Used by both manual-commit and auto-commit strategies.
 func ListCheckpoints() ([]CheckpointInfo, error) {
@@ -213,7 +213,7 @@ func resolveAgentType(ctxAgentType agent.AgentType, state *SessionState) agent.A
 	return DefaultAgentType
 }
 
-// ensureMetadataBranch creates the orphan entire/sessions branch if it doesn't exist.
+// ensureMetadataBranch creates the orphan entire/checkpoints/v1 branch if it doesn't exist.
 // This branch has no parent and starts with an empty tree.
 func EnsureMetadataBranch(repo *git.Repository) error {
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
@@ -271,7 +271,7 @@ func EnsureMetadataBranch(repo *git.Repository) error {
 	return nil
 }
 
-// readCheckpointMetadata reads metadata.json from a checkpoint path on entire/sessions.
+// readCheckpointMetadata reads metadata.json from a checkpoint path on entire/checkpoints/v1.
 // With the new format, root metadata.json is a CheckpointSummary with Agents array.
 // This function reads the summary and extracts relevant fields into CheckpointInfo,
 // also reading session-level metadata for IsTask/ToolUseID fields.
@@ -339,7 +339,7 @@ func ReadCheckpointMetadata(tree *object.Tree, checkpointPath string) (*Checkpoi
 	return &metadata, nil
 }
 
-// GetMetadataBranchTree returns the tree object for the entire/sessions branch.
+// GetMetadataBranchTree returns the tree object for the entire/checkpoints/v1 branch.
 func GetMetadataBranchTree(repo *git.Repository) (*object.Tree, error) {
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 	ref, err := repo.Reference(refName, true)
@@ -468,7 +468,7 @@ func ReadSessionPromptFromShadow(repo *git.Repository, baseCommit, worktreeID, s
 	return ReadSessionPromptFromTree(tree, checkpointPath)
 }
 
-// GetRemoteMetadataBranchTree returns the tree object for origin/entire/sessions.
+// GetRemoteMetadataBranchTree returns the tree object for origin/entire/checkpoints/v1.
 func GetRemoteMetadataBranchTree(repo *git.Repository) (*object.Tree, error) {
 	refName := plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName)
 	ref, err := repo.Reference(refName, true)
@@ -1317,7 +1317,7 @@ func getSessionDescriptionFromTree(tree *object.Tree, metadataDir string) string
 // It checks local config first, then falls back to global config.
 // Returns ("Unknown", "unknown@local") if no user is configured - this allows
 // operations to proceed even without git user config, which is especially useful
-// for internal metadata commits on branches like entire/sessions.
+// for internal metadata commits on branches like entire/checkpoints/v1.
 func GetGitAuthorFromRepo(repo *git.Repository) (name, email string) {
 	// Get repository config (includes local settings)
 	cfg, err := repo.Config()

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -77,11 +77,11 @@ func (s *ManualCommitStrategy) Name() string {
 
 // Description returns the strategy description.
 func (s *ManualCommitStrategy) Description() string {
-	return "Manual commit checkpoints with session logs on entire/sessions"
+	return "Manual commit checkpoints with session logs on entire/checkpoints/v1"
 }
 
 // AllowsMainBranch returns true because manual-commit strategy only writes to shadow
-// branches (entire/<hash>) and entire/sessions, never modifying the working branch's
+// branches (entire/<hash>) and entire/checkpoints/v1, never modifying the working branch's
 // commit history.
 func (s *ManualCommitStrategy) AllowsMainBranch() bool {
 	return true
@@ -108,7 +108,7 @@ func (s *ManualCommitStrategy) EnsureSetup() error {
 		return err
 	}
 
-	// Ensure the entire/sessions orphan branch exists for permanent session storage
+	// Ensure the entire/checkpoints/v1 orphan branch exists for permanent session storage
 	repo, err := OpenRepository()
 	if err != nil {
 		return fmt.Errorf("failed to open git repository: %w", err)

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -26,7 +26,7 @@ import (
 )
 
 // listCheckpoints returns all checkpoints from the sessions branch.
-// Uses checkpoint.GitStore.ListCommitted() for reading from entire/sessions.
+// Uses checkpoint.GitStore.ListCommitted() for reading from entire/checkpoints/v1.
 func (s *ManualCommitStrategy) listCheckpoints() ([]CheckpointInfo, error) {
 	store, err := s.getCheckpointStore()
 	if err != nil {
@@ -80,7 +80,7 @@ func (s *ManualCommitStrategy) getCheckpointsForSession(sessionID string) ([]Che
 }
 
 // getCheckpointLog returns the transcript for a specific checkpoint ID.
-// Uses checkpoint.GitStore.ReadCommitted() for reading from entire/sessions.
+// Uses checkpoint.GitStore.ReadCommitted() for reading from entire/checkpoints/v1.
 func (s *ManualCommitStrategy) getCheckpointLog(checkpointID id.CheckpointID) ([]byte, error) {
 	store, err := s.getCheckpointStore()
 	if err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_logs.go
+++ b/cmd/entire/cli/strategy/manual_commit_logs.go
@@ -67,7 +67,7 @@ func (s *ManualCommitStrategy) GetSessionInfo() (*SessionInfo, error) {
 }
 
 // GetMetadataRef returns a reference to the metadata for the given checkpoint.
-// For manual-commit strategy, returns the sharded path on entire/sessions branch.
+// For manual-commit strategy, returns the sharded path on entire/checkpoints/v1 branch.
 func (s *ManualCommitStrategy) GetMetadataRef(checkpoint Checkpoint) string {
 	if checkpoint.CheckpointID.IsEmpty() {
 		return ""
@@ -76,7 +76,7 @@ func (s *ManualCommitStrategy) GetMetadataRef(checkpoint Checkpoint) string {
 }
 
 // GetSessionMetadataRef returns a reference to the most recent metadata commit for a session.
-// For manual-commit strategy, metadata lives on the entire/sessions branch.
+// For manual-commit strategy, metadata lives on the entire/checkpoints/v1 branch.
 func (s *ManualCommitStrategy) GetSessionMetadataRef(_ string) string {
 	repo, err := OpenRepository()
 	if err != nil {
@@ -90,13 +90,13 @@ func (s *ManualCommitStrategy) GetSessionMetadataRef(_ string) string {
 		return ""
 	}
 
-	// The tip of entire/sessions contains all condensed sessions
+	// The tip of entire/checkpoints/v1 contains all condensed sessions
 	// Return a reference to it (sessionID is not used as all sessions are on the same branch)
 	return trailers.FormatSourceRef(paths.MetadataBranchName, ref.Hash().String())
 }
 
 // GetSessionContext returns the context.md content for a session.
-// For manual-commit strategy, reads from the entire/sessions branch using the sessions map.
+// For manual-commit strategy, reads from the entire/checkpoints/v1 branch using the sessions map.
 func (s *ManualCommitStrategy) GetSessionContext(sessionID string) string {
 	// Find a checkpoint for this session
 	checkpoints, err := s.getCheckpointsForSession(sessionID)
@@ -184,7 +184,7 @@ func (s *ManualCommitStrategy) GetSessionContext(sessionID string) string {
 }
 
 // GetCheckpointLog returns the session transcript for a specific checkpoint.
-// For manual-commit strategy, metadata is stored at sharded paths on entire/sessions branch.
+// For manual-commit strategy, metadata is stored at sharded paths on entire/checkpoints/v1 branch.
 func (s *ManualCommitStrategy) GetCheckpointLog(checkpoint Checkpoint) ([]byte, error) {
 	if checkpoint.CheckpointID.IsEmpty() {
 		return nil, ErrNoMetadata

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -3,7 +3,7 @@ package strategy
 import "github.com/entireio/cli/cmd/entire/cli/paths"
 
 // PrePush is called by the git pre-push hook before pushing to a remote.
-// It pushes the entire/sessions branch alongside the user's push.
+// It pushes the entire/checkpoints/v1 branch alongside the user's push.
 // Configuration options (stored in .entire/settings.json under strategy_options.push_sessions):
 //   - "auto": always push automatically
 //   - "prompt" (default): ask user with option to enable auto

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -124,11 +124,11 @@ func (s *ManualCommitStrategy) GetRewindPoints(limit int) ([]RewindPoint, error)
 }
 
 // GetLogsOnlyRewindPoints finds commits in the current branch's history that have
-// condensed session logs on the entire/sessions branch. These are commits that
+// condensed session logs on the entire/checkpoints/v1 branch. These are commits that
 // were created with session data but the shadow branch has been condensed.
 //
 // The function works by:
-// 1. Getting all checkpoints from the entire/sessions branch
+// 1. Getting all checkpoints from the entire/checkpoints/v1 branch
 // 2. Building a map of checkpoint ID -> checkpoint info
 // 3. Scanning the current branch history for commits with Entire-Checkpoint trailers
 // 4. Matching by checkpoint ID (stable across amend/rebase)
@@ -138,7 +138,7 @@ func (s *ManualCommitStrategy) GetLogsOnlyRewindPoints(limit int) ([]RewindPoint
 		return nil, err
 	}
 
-	// Get all checkpoints from entire/sessions branch
+	// Get all checkpoints from entire/checkpoints/v1 branch
 	checkpoints, err := s.listCheckpoints()
 	if err != nil {
 		// No checkpoints yet is fine
@@ -189,7 +189,7 @@ func (s *ManualCommitStrategy) GetLogsOnlyRewindPoints(limit int) ([]RewindPoint
 		if !found {
 			return nil
 		}
-		// Check if this checkpoint ID has metadata on entire/sessions
+		// Check if this checkpoint ID has metadata on entire/checkpoints/v1
 		cpInfo, found := checkpointInfoMap[cpID]
 		if !found {
 			return nil
@@ -617,7 +617,7 @@ func (s *ManualCommitStrategy) PreviewRewind(point RewindPoint) (*RewindPreview,
 }
 
 // RestoreLogsOnly restores session logs from a logs-only rewind point.
-// This fetches the transcript from entire/sessions and writes it to Claude's project directory.
+// This fetches the transcript from entire/checkpoints/v1 and writes it to Claude's project directory.
 // Does not modify the working directory.
 // When multiple sessions were condensed to the same checkpoint, ALL sessions are restored.
 // If force is false, prompts for confirmation when local logs have newer timestamps.

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -991,7 +991,7 @@ func TestSessionState_JSONRoundTrip(t *testing.T) {
 func TestShadowStrategy_GetCheckpointLog_WithCheckpointID(t *testing.T) {
 	// This test verifies that GetCheckpointLog correctly uses the checkpoint ID
 	// to look up the log. Since getCheckpointLog requires a full git setup
-	// with entire/sessions branch, we test the lookup logic by checking error behavior.
+	// with entire/checkpoints/v1 branch, we test the lookup logic by checking error behavior.
 
 	dir := t.TempDir()
 	_, err := git.PlainInit(dir, false)
@@ -1011,7 +1011,7 @@ func TestShadowStrategy_GetCheckpointLog_WithCheckpointID(t *testing.T) {
 	}
 
 	// This should attempt to call getCheckpointLog (which will fail because
-	// there's no entire/sessions branch), but the important thing is it uses
+	// there's no entire/checkpoints/v1 branch), but the important thing is it uses
 	// the checkpoint ID to look up metadata
 	_, err = s.GetCheckpointLog(checkpoint)
 	if err == nil {
@@ -1437,7 +1437,7 @@ func TestShadowStrategy_PrepareCommitMsg_ReusesLastCheckpointID(t *testing.T) {
 }
 
 // TestShadowStrategy_CondenseSession_EphemeralBranchTrailer verifies that checkpoint commits
-// on the entire/sessions branch include the Ephemeral-branch trailer indicating which shadow
+// on the entire/checkpoints/v1 branch include the Ephemeral-branch trailer indicating which shadow
 // branch the checkpoint originated from.
 func TestShadowStrategy_CondenseSession_EphemeralBranchTrailer(t *testing.T) {
 	dir := t.TempDir()
@@ -2055,7 +2055,7 @@ func TestCondenseSession_IncludesInitialAttribution(t *testing.T) {
 		t.Errorf("CheckpointID = %q, want %q", result.CheckpointID, checkpointID)
 	}
 
-	// Read metadata from entire/sessions branch and verify InitialAttribution
+	// Read metadata from entire/checkpoints/v1 branch and verify InitialAttribution
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
 		t.Fatalf("failed to get sessions branch: %v", err)

--- a/cmd/entire/cli/strategy/phase_postcommit_test.go
+++ b/cmd/entire/cli/strategy/phase_postcommit_test.go
@@ -95,9 +95,9 @@ func TestPostCommit_IdleSession_Condenses(t *testing.T) {
 	err = s.PostCommit()
 	require.NoError(t, err)
 
-	// Verify condensation happened: the entire/sessions branch should exist
+	// Verify condensation happened: the entire/checkpoints/v1 branch should exist
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
-	require.NoError(t, err, "entire/sessions branch should exist after condensation")
+	require.NoError(t, err, "entire/checkpoints/v1 branch should exist after condensation")
 	assert.NotNil(t, sessionsRef)
 
 	// Verify shadow branch IS deleted after condensation
@@ -156,10 +156,10 @@ func TestPostCommit_RebaseDuringActive_SkipsTransition(t *testing.T) {
 	assert.Equal(t, originalStepCount, state.StepCount,
 		"StepCount should be unchanged - no condensation during rebase")
 
-	// Verify NO condensation happened (entire/sessions branch should not exist)
+	// Verify NO condensation happened (entire/checkpoints/v1 branch should not exist)
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.Error(t, err,
-		"entire/sessions branch should NOT exist - no condensation during rebase")
+		"entire/checkpoints/v1 branch should NOT exist - no condensation during rebase")
 
 	// Verify shadow branch still exists (not cleaned up during rebase)
 	refName := plumbing.NewBranchReferenceName(shadowBranch)
@@ -225,11 +225,11 @@ func TestPostCommit_ShadowBranch_PreservedWhenActiveSessionExists(t *testing.T) 
 	assert.Equal(t, session.PhaseActiveCommitted, activeState.Phase,
 		"ACTIVE session should transition to ACTIVE_COMMITTED on GitCommit")
 
-	// Verify the IDLE session actually condensed (entire/sessions branch should exist)
+	// Verify the IDLE session actually condensed (entire/checkpoints/v1 branch should exist)
 	idleState, err = s.loadSessionState(idleSessionID)
 	require.NoError(t, err)
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
-	require.NoError(t, err, "entire/sessions branch should exist after IDLE session condensation")
+	require.NoError(t, err, "entire/checkpoints/v1 branch should exist after IDLE session condensation")
 	require.NotNil(t, sessionsRef)
 
 	// Verify IDLE session's StepCount was reset by condensation
@@ -291,10 +291,10 @@ func TestPostCommit_CondensationFailure_PreservesShadowBranch(t *testing.T) {
 	assert.Equal(t, originalStepCount, state.StepCount,
 		"StepCount should NOT be reset when condensation fails")
 
-	// Verify entire/sessions branch does NOT exist (condensation failed)
+	// Verify entire/checkpoints/v1 branch does NOT exist (condensation failed)
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.Error(t, err,
-		"entire/sessions branch should NOT exist when condensation fails")
+		"entire/checkpoints/v1 branch should NOT exist when condensation fails")
 
 	// Phase transition still applies even when condensation fails
 	assert.Equal(t, session.PhaseIdle, state.Phase,
@@ -353,10 +353,10 @@ func TestPostCommit_IdleSession_NoNewContent_UpdatesBaseCommit(t *testing.T) {
 	require.NoError(t, err,
 		"shadow branch should still exist when no condensation happened")
 
-	// entire/sessions branch should NOT exist (no condensation)
+	// entire/checkpoints/v1 branch should NOT exist (no condensation)
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.Error(t, err,
-		"entire/sessions branch should NOT exist when no condensation happened")
+		"entire/checkpoints/v1 branch should NOT exist when no condensation happened")
 
 	// StepCount should be unchanged
 	assert.Equal(t, originalStepCount, state.StepCount,
@@ -397,9 +397,9 @@ func TestPostCommit_EndedSession_FilesTouched_Condenses(t *testing.T) {
 	err = s.PostCommit()
 	require.NoError(t, err)
 
-	// Verify entire/sessions branch exists (condensation happened)
+	// Verify entire/checkpoints/v1 branch exists (condensation happened)
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
-	require.NoError(t, err, "entire/sessions branch should exist after condensation")
+	require.NoError(t, err, "entire/checkpoints/v1 branch should exist after condensation")
 	assert.NotNil(t, sessionsRef)
 
 	// Verify old shadow branch is deleted after condensation
@@ -461,10 +461,10 @@ func TestPostCommit_EndedSession_FilesTouched_NoNewContent(t *testing.T) {
 	err = s.PostCommit()
 	require.NoError(t, err)
 
-	// Verify entire/sessions branch does NOT exist (no condensation)
+	// Verify entire/checkpoints/v1 branch does NOT exist (no condensation)
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.Error(t, err,
-		"entire/sessions branch should NOT exist when no new content")
+		"entire/checkpoints/v1 branch should NOT exist when no new content")
 
 	// Shadow branch should still exist
 	refName := plumbing.NewBranchReferenceName(shadowBranch)
@@ -522,10 +522,10 @@ func TestPostCommit_EndedSession_NoFilesTouched_Discards(t *testing.T) {
 	err = s.PostCommit()
 	require.NoError(t, err)
 
-	// Verify entire/sessions branch does NOT exist (no condensation for discard path)
+	// Verify entire/checkpoints/v1 branch does NOT exist (no condensation for discard path)
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.Error(t, err,
-		"entire/sessions branch should NOT exist for discard path")
+		"entire/checkpoints/v1 branch should NOT exist for discard path")
 
 	// BaseCommit should be updated to new HEAD
 	state, err = s.loadSessionState(sessionID)
@@ -604,10 +604,10 @@ func TestPostCommit_ActiveCommitted_MigratesShadowBranch(t *testing.T) {
 	assert.Equal(t, originalStepCount, state.StepCount,
 		"StepCount should be unchanged - no condensation for ACTIVE_COMMITTED")
 
-	// entire/sessions branch should NOT exist (no condensation)
+	// entire/checkpoints/v1 branch should NOT exist (no condensation)
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.Error(t, err,
-		"entire/sessions branch should NOT exist - no condensation for ACTIVE_COMMITTED")
+		"entire/checkpoints/v1 branch should NOT exist - no condensation for ACTIVE_COMMITTED")
 }
 
 // TestPostCommit_CondensationFailure_EndedSession_PreservesShadowBranch verifies
@@ -659,10 +659,10 @@ func TestPostCommit_CondensationFailure_EndedSession_PreservesShadowBranch(t *te
 	assert.Equal(t, originalStepCount, state.StepCount,
 		"StepCount should NOT be reset when condensation fails for ENDED session")
 
-	// Verify entire/sessions branch does NOT exist (condensation failed)
+	// Verify entire/checkpoints/v1 branch does NOT exist (condensation failed)
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.Error(t, err,
-		"entire/sessions branch should NOT exist when condensation fails")
+		"entire/checkpoints/v1 branch should NOT exist when condensation fails")
 
 	// Phase stays ENDED
 	assert.Equal(t, session.PhaseEnded, state.Phase,
@@ -836,7 +836,7 @@ func TestTurnEnd_ConcurrentSession_PreservesShadowBranch(t *testing.T) {
 
 // TestTurnEnd_ActiveCommitted_CondensesSession verifies that HandleTurnEnd
 // with ActionCondense (from ACTIVE_COMMITTED → IDLE) condenses the session
-// to entire/sessions and cleans up the shadow branch.
+// to entire/checkpoints/v1 and cleans up the shadow branch.
 func TestTurnEnd_ActiveCommitted_CondensesSession(t *testing.T) {
 	dir := setupGitRepo(t)
 	t.Chdir(dir)
@@ -881,9 +881,9 @@ func TestTurnEnd_ActiveCommitted_CondensesSession(t *testing.T) {
 	err = s.HandleTurnEnd(state, remaining)
 	require.NoError(t, err)
 
-	// Verify condensation happened: entire/sessions branch should exist
+	// Verify condensation happened: entire/checkpoints/v1 branch should exist
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
-	require.NoError(t, err, "entire/sessions branch should exist after turn-end condensation")
+	require.NoError(t, err, "entire/checkpoints/v1 branch should exist after turn-end condensation")
 	assert.NotNil(t, sessionsRef)
 
 	// Verify shadow branch IS deleted after condensation
@@ -955,10 +955,10 @@ func TestTurnEnd_ActiveCommitted_CondensationFailure_PreservesShadowBranch(t *te
 	assert.Equal(t, originalStepCount, state.StepCount,
 		"StepCount should NOT be reset when condensation fails")
 
-	// entire/sessions branch should NOT exist (condensation failed)
+	// entire/checkpoints/v1 branch should NOT exist (condensation failed)
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	assert.Error(t, err,
-		"entire/sessions branch should NOT exist when condensation fails")
+		"entire/checkpoints/v1 branch should NOT exist when condensation fails")
 }
 
 // TestTurnEnd_Active_NoActions verifies that HandleTurnEnd with no actions

--- a/cmd/entire/cli/strategy/session.go
+++ b/cmd/entire/cli/strategy/session.go
@@ -43,7 +43,7 @@ type Session struct {
 // Checkpoints can be either session-level (on Stop) or task-level (on subagent completion).
 type Checkpoint struct {
 	// CheckpointID is the stable 12-hex-char identifier for this checkpoint.
-	// Used to look up metadata at <id[:2]>/<id[2:]>/ on entire/sessions branch.
+	// Used to look up metadata at <id[:2]>/<id[2:]>/ on entire/checkpoints/v1 branch.
 	CheckpointID id.CheckpointID
 
 	// Message is the commit message or checkpoint description
@@ -84,7 +84,7 @@ type CheckpointDetails struct {
 	Files []string
 }
 
-// ListSessions returns all sessions from the entire/sessions branch,
+// ListSessions returns all sessions from the entire/checkpoints/v1 branch,
 // plus any additional sessions from strategies implementing SessionSource.
 // It automatically discovers all registered strategies and merges their sessions.
 func ListSessions() ([]Session, error) {
@@ -93,7 +93,7 @@ func ListSessions() ([]Session, error) {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
 
-	// Get checkpoints from the entire/sessions branch
+	// Get checkpoints from the entire/checkpoints/v1 branch
 	checkpoints, err := ListCheckpoints()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list checkpoints: %w", err)
@@ -216,7 +216,7 @@ func GetSession(sessionID string) (*Session, error) {
 	return findSessionByID(sessions, sessionID)
 }
 
-// getDescriptionForCheckpoint reads the description for a checkpoint from the entire/sessions branch.
+// getDescriptionForCheckpoint reads the description for a checkpoint from the entire/checkpoints/v1 branch.
 // It reads from the latest session subdirectory in the new storage format.
 func getDescriptionForCheckpoint(repo *git.Repository, checkpointID id.CheckpointID) string {
 	tree, err := GetMetadataBranchTree(repo)

--- a/cmd/entire/cli/strategy/session_test.go
+++ b/cmd/entire/cli/strategy/session_test.go
@@ -195,7 +195,7 @@ func TestListSessionsEmptyRepo(t *testing.T) {
 	initTestRepo(t, tmpDir)
 	t.Chdir(tmpDir)
 
-	// No entire/sessions branch exists yet
+	// No entire/checkpoints/v1 branch exists yet
 	sessions, err := ListSessions()
 	if err != nil {
 		t.Fatalf("ListSessions() error = %v, want nil", err)
@@ -222,7 +222,7 @@ func TestListSessionsWithCheckpoints(t *testing.T) {
 		t.Fatalf("OpenRepository() failed: %v", err)
 	}
 
-	// Create entire/sessions branch with test checkpoints
+	// Create entire/checkpoints/v1 branch with test checkpoints
 	createTestMetadataBranch(t, repo, testSessionID)
 
 	sessions, err := ListSessions()
@@ -262,7 +262,7 @@ func TestListSessionsWithDescription(t *testing.T) {
 		t.Fatalf("OpenRepository() failed: %v", err)
 	}
 
-	// Create entire/sessions branch with test checkpoint including prompt.txt
+	// Create entire/checkpoints/v1 branch with test checkpoint including prompt.txt
 	expectedDesc := "Fix the bug in the login form"
 	createTestMetadataBranchWithPrompt(t, repo, testSessionID, testCheckpointID, expectedDesc)
 

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -35,13 +35,13 @@ const (
 	// Format: "<branch>@<commit-hash>" e.g. "entire/metadata@abc123def456"
 	SourceRefTrailerKey = "Entire-Source-Ref"
 
-	// CheckpointTrailerKey links commits to their checkpoint metadata on entire/sessions.
+	// CheckpointTrailerKey links commits to their checkpoint metadata on entire/checkpoints/v1.
 	// Format: 12 hex characters e.g. "a3b2c4d5e6f7"
 	// This trailer survives git amend and rebase operations.
 	CheckpointTrailerKey = "Entire-Checkpoint"
 
 	// EphemeralBranchTrailerKey identifies the shadow branch that a checkpoint originated from.
-	// Used in manual-commit strategy checkpoint commits on entire/sessions branch.
+	// Used in manual-commit strategy checkpoint commits on entire/checkpoints/v1 branch.
 	// Format: full branch name e.g. "entire/2b4c177"
 	EphemeralBranchTrailerKey = "Ephemeral-branch"
 
@@ -222,7 +222,7 @@ func FormatShadowTaskCommit(message, taskMetadataDir, sessionID string) string {
 }
 
 // FormatCheckpoint creates a commit message with a checkpoint trailer.
-// This links user commits to their checkpoint metadata on entire/sessions branch.
+// This links user commits to their checkpoint metadata on entire/checkpoints/v1 branch.
 func FormatCheckpoint(message string, cpID checkpointID.CheckpointID) string {
 	return fmt.Sprintf("%s\n\n%s: %s\n", message, CheckpointTrailerKey, cpID.String())
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad, cross-cutting rename touching checkpoint persistence and resume/fetch flows; low algorithmic change but risks regressions for existing repos/remotes still using the old branch name.
> 
> **Overview**
> Renames the git metadata branch used to store committed checkpoint/session logs from `entire/sessions` to `entire/checkpoints/v1` across the CLI.
> 
> This updates checkpoint storage/read paths, fetch/push behavior, cleanup logic, user-facing messages, and a broad set of unit/integration tests plus documentation to reference the new branch name consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 359de3dfed92edf414dae68989a67e8e198e18f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->