### PR TITLE
Update community links to Discord and GitHub Discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,11 +267,11 @@ type -a entire
 
 Join the Entire community:
 
-- **Slack** - [Join our workspace][slack] for discussions and support
-- **Events & Meetups** - [See upcoming events][events]
+- **Discord** - [Join our server][discord] for discussions and support
+- **GitHub Discussions** - [Join the conversation][discussions]
 
-[slack]: https://entire-community.slack.com
-[events]: https://entire.io/events
+[discord]: https://discord.gg/4WXDu2Ph
+[discussions]: https://github.com/entireio/cli/discussions
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only link updates with no impact on runtime behavior or security.
> 
> **Overview**
> Updates `CONTRIBUTING.md` community section to point contributors to **Discord** and **GitHub Discussions**, replacing the previous Slack/events links and adding the corresponding reference URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1041cfa771f51295b0fe98a07732f42dba13d27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->