### PR TITLE
.goreleaser.yaml: Await notarization.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,7 @@ notarize:
         issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
         key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
         key: "{{.Env.MACOS_NOTARY_KEY}}"
+        wait: true # do not let an unusable binary slip into the wild
 
 archives:
   - formats:


### PR DESCRIPTION
If we don't, we risk committing an unusable build into our Homebrew tap repo, causing ugly failures for our users.

Let's rather get a red build and investigate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release pipeline change only; it may slow or fail builds if notarization is delayed or errors, but doesn’t affect runtime code or user data.
> 
> **Overview**
> Updates `.goreleaser.yaml` to **block the release until macOS notarization completes** by setting `notarize.macos[].notarize.wait: true`, preventing unsigned/unusable binaries from being published (e.g., into the Homebrew tap).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d3e839200b7916ddcd3333a33d6ebe727a3e369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->