### PR TITLE
Adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,104 @@
+name: Bug Report
+description: Report an error or unexpected behavior in the Entire CLI
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the form below.
+
+        Before submitting:
+        - Search [existing issues](https://github.com/entireio/cli/issues) to avoid duplicates
+        - Try upgrading to the latest version (`entire version` to check)
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: |
+        A clear description of the bug. Include the full error message or
+        unexpected output. Please paste text rather than screenshots.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior. Include exact commands.
+      placeholder: |
+        1. `entire enable`
+        2. Make some changes, then `entire checkpoint list`
+        3. See error: "..."
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Entire CLI version
+      description: "Run `entire version` and paste the output."
+      placeholder: "e.g., entire v0.1.0 (abc1234)"
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: OS and architecture
+      description: "Your operating system and architecture (see `uname -orsm`)."
+      placeholder: "e.g., macOS 15.2 arm64, Ubuntu 24.04 x86_64"
+    validations:
+      required: false
+
+  - type: input
+    id: agent
+    attributes:
+      label: Agent
+      description: Which AI coding agent were you using?
+      placeholder: "e.g., Claude Code, Gemini CLI"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: strategy
+    attributes:
+      label: Strategy
+      description: "Which strategy is configured? (check `.entire/settings.json` or `entire status`)"
+      options:
+        - manual-commit (default)
+        - auto-commit
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal
+      description: Which terminal emulator are you using?
+      placeholder: "e.g., iTerm2, Terminal.app, Ghostty, Alacritty, Windows Terminal, Warp"
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / debug output
+      description: |
+        Relevant log output from `.entire/logs/`. If logs are long, use a
+        [GitHub Gist](https://gist.github.com/). Review output for sensitive
+        information before posting.
+      render: bash
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: |
+        Anything else that might help: Git version, shell (bash/zsh/fish),
+        whether running in a git worktree, tmux/SSH, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and Support
+    url: https://github.com/entireio/cli/discussions
+    about: For general questions, use GitHub Discussions instead of filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please search
+        [existing issues](https://github.com/entireio/cli/issues?q=label%3Aenhancement)
+        before filing to avoid duplicates.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: |
+        What problem are you trying to solve? Focus on the end goal,
+        not the solution.
+      placeholder: |
+        Example: When working with multiple sessions, I need to ...
+        but currently there is no way to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Desired behavior
+      description: |
+        Show what the ideal experience would look like. Include example
+        commands, flags, or output if applicable.
+      placeholder: |
+        $ entire <command> --new-flag
+        Expected output...
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        If you have ideas on implementation, describe them here.
+        This is optional — we're equally interested in the problem.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: Any workarounds you've tried or alternative approaches you've considered?
+    validations:
+      required: false


### PR DESCRIPTION
This adds two issue templates for bugs and feature requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds GitHub metadata only and does not affect runtime code paths.
> 
> **Overview**
> Adds GitHub issue forms for `Bug Report` and `Feature Request`, guiding reporters to include repro steps, CLI version, environment details, and (for bugs) logs.
> 
> Disables blank issues via `.github/ISSUE_TEMPLATE/config.yml` and directs support/questions to GitHub Discussions through a contact link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d59e877a3c09547117ea06ae7b7d5268d058fb28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->