### PR TITLE
Fix getting started URL

### DIFF
--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -15,7 +15,7 @@ const gettingStarted = `
 Getting Started:
   To get started with Entire CLI, run 'entire enable' to configure
   your project's environment. For more information, visit:
-  https://docs.entire.io/getting-started
+  https://docs.entire.io/introduction
 
 `
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk text-only change to CLI help output, with no behavioral or runtime impact.
> 
> **Overview**
> Updates the `gettingStarted` help text shown in the CLI root command to point to `https://docs.entire.io/introduction` instead of the previous getting-started URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b733e9940597532ca014a6f454bda27090563863. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->