### PR TITLE
update sessions-and-checkpoints doc to be in line with the code base

### DIFF
--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -224,11 +224,11 @@ Metadata only, sharded by checkpoint ID. Supports **multiple sessions per checkp
   "files_touched": ["file1.txt", "file2.txt"],
   "sessions": [
     {
-      "metadata": "ab/c123def456/0/metadata.json",
-      "transcript": "ab/c123def456/0/full.jsonl",
-      "context": "ab/c123def456/0/context.md",
-      "content_hash": "ab/c123def456/0/content_hash.txt",
-      "prompt": "ab/c123def456/0/prompt.txt"
+      "metadata": "/ab/c123def456/0/metadata.json",
+      "transcript": "/ab/c123def456/0/full.jsonl",
+      "context": "/ab/c123def456/0/context.md",
+      "content_hash": "/ab/c123def456/0/content_hash.txt",
+      "prompt": "/ab/c123def456/0/prompt.txt"
     }
   ],
   "token_usage": {


### PR DESCRIPTION
This got a bit lost in the last few days of last minute changes. Let's make sure the doc aligns with the code base.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime behavior impact; risk is limited to potential confusion if details are still inaccurate.
> 
> **Overview**
> Updates `docs/architecture/sessions-and-checkpoints.md` to match the current sessions/checkpoints implementation, including the revised `Session`/`Checkpoint` structs, `strategy/session.go` access patterns (`ListSessions`, `GetSession`), and the `checkpoint.Store` API and option types.
> 
> Refreshes the documented storage layout and workflows: temporary shadow branch naming now includes worktree hash, committed checkpoint layout now uses per-session numbered subdirectories with a root `CheckpointSummary`, and strategy APIs/terminology are updated (task checkpoints, `CondenseSession`, `SaveChanges`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e115f16d2c2ff88c8684a523ea3de1a8b50b3d82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->