### PR TITLE
[WIP] feat(resume): add --run/-r to auto-start restored session

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Multiple AI sessions can run on the same commit. If you start a second session w
 | `--force`, `-f`  | Resume from older checkpoint without prompt |
 | `--run`, `-r`    | Start the restored session immediately      |
 
+Set `"autoRunResume": true` in `.entire/settings.json` (or `.entire/settings.local.json`) to make `--run` the default.
+
 ### `entire enable` Flags
 
 | Flag                   | Description                                                        |
@@ -238,6 +240,7 @@ Personal overrides, gitignored by default:
 |--------------------------------------|----------------------------------|------------------------------------------------------|
 | `enabled`                            | `true`, `false`                  | Enable/disable Entire                                |
 | `log_level`                          | `debug`, `info`, `warn`, `error` | Logging verbosity                                    |
+| `autoRunResume`                      | `true`, `false`                  | Auto-run restored session for `entire resume`        |
 | `strategy`                           | `manual-commit`, `auto-commit`   | Session capture strategy                             |
 | `strategy_options.push_sessions`     | `true`, `false`                  | Auto-push `entire/checkpoints/v1` branch on git push |
 | `strategy_options.summarize.enabled` | `true`, `false`                  | Auto-generate AI summaries at commit time            |

--- a/cmd/entire/cli/config_test.go
+++ b/cmd/entire/cli/config_test.go
@@ -229,6 +229,28 @@ func TestLoadEntireSettings_LocalOverridesLocalDev(t *testing.T) {
 	}
 }
 
+func TestLoadEntireSettings_LocalOverridesAutoRunResume(t *testing.T) {
+	setupLocalOverrideTestDir(t)
+
+	baseSettings := `{"strategy": "manual-commit", "autoRunResume": false}`
+	if err := os.WriteFile(EntireSettingsFile, []byte(baseSettings), 0o644); err != nil {
+		t.Fatalf("Failed to write settings file: %v", err)
+	}
+
+	localSettings := `{"autoRunResume": true}`
+	if err := os.WriteFile(EntireSettingsLocalFile, []byte(localSettings), 0o644); err != nil {
+		t.Fatalf("Failed to write local settings file: %v", err)
+	}
+
+	settings, err := LoadEntireSettings()
+	if err != nil {
+		t.Fatalf("LoadEntireSettings() error = %v", err)
+	}
+	if !settings.AutoRunResume {
+		t.Error("AutoRunResume should be true from local override")
+	}
+}
+
 func TestLoadEntireSettings_LocalMergesStrategyOptions(t *testing.T) {
 	setupLocalOverrideTestDir(t)
 

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -51,7 +51,7 @@ most recent commit with a checkpoint.  You'll be prompted to confirm resuming in
 			if checkDisabledGuard(cmd.OutOrStdout()) {
 				return nil
 			}
-			return runResume(args[0], force, autoRun)
+			return runResume(args[0], force, resolveAutoRun(cmd, autoRun))
 		},
 	}
 
@@ -59,6 +59,18 @@ most recent commit with a checkpoint.  You'll be prompted to confirm resuming in
 	cmd.Flags().BoolVarP(&autoRun, "run", "r", false, "Start the restored session immediately")
 
 	return cmd
+}
+
+func resolveAutoRun(cmd *cobra.Command, autoRun bool) bool {
+	if cmd.Flags().Changed("run") {
+		return autoRun
+	}
+
+	s, err := LoadEntireSettings()
+	if err != nil {
+		return autoRun
+	}
+	return s.AutoRunResume
 }
 
 func runResume(branchName string, force, autoRun bool) error {

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -43,6 +43,10 @@ type EntireSettings struct {
 	// Defaults to "info".
 	LogLevel string `json:"log_level,omitempty"`
 
+	// AutoRunResume controls whether `entire resume` automatically runs the
+	// agent resume command when `--run` is not explicitly provided.
+	AutoRunResume bool `json:"autoRunResume,omitempty"`
+
 	// StrategyOptions contains strategy-specific configuration
 	StrategyOptions map[string]any `json:"strategy_options,omitempty"`
 
@@ -178,6 +182,15 @@ func mergeJSON(settings *EntireSettings, data []byte) error {
 		if ll != "" {
 			settings.LogLevel = ll
 		}
+	}
+
+	// Override autoRunResume if present
+	if autoRunResumeRaw, ok := raw["autoRunResume"]; ok {
+		var ar bool
+		if err := json.Unmarshal(autoRunResumeRaw, &ar); err != nil {
+			return fmt.Errorf("parsing autoRunResume field: %w", err)
+		}
+		settings.AutoRunResume = ar
 	}
 
 	// Merge strategy_options if present

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -58,6 +58,7 @@ func TestLoad_AcceptsValidKeys(t *testing.T) {
 		"enabled": true,
 		"local_dev": false,
 		"log_level": "debug",
+		"autoRunResume": true,
 		"strategy_options": {"key": "value"},
 		"telemetry": true
 	}`
@@ -88,6 +89,9 @@ func TestLoad_AcceptsValidKeys(t *testing.T) {
 	}
 	if settings.LogLevel != "debug" {
 		t.Errorf("expected log_level 'debug', got %q", settings.LogLevel)
+	}
+	if !settings.AutoRunResume {
+		t.Error("expected autoRunResume to be true")
 	}
 	if settings.Telemetry == nil || !*settings.Telemetry {
 		t.Error("expected telemetry to be true")


### PR DESCRIPTION
Adds a `--run`/`-r` flag and `resumeAutoRun` config option so calling resume will automatically start the session for the given coding agent. 

WIP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alter CLI behavior by executing a subprocess based on the agent-provided resume command, which could impact user environments and requires careful handling of command parsing/execution.
> 
> **Overview**
> `entire resume` now supports **auto-starting the restored agent session** via a new `--run`/`-r` flag, and can default to this behavior using the new `autoRunResume` setting (with explicit CLI flags overriding config).
> 
> Implementation updates thread an `autoRun` parameter through the resume flow, add helpers to print-or-exec the formatted resume command (`exec.Command`), and extend settings loading/merging plus tests to cover the new setting and flag behavior. README is updated with the new usage and configuration option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6248e461f2a6af9df67d6b6b6a679f30e1268a66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->