### PR TITLE
Update README and CONTRIBUTING with `mise trust` first-time setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,9 @@ Please answer these questions in your bug report:
 git clone https://github.com/entireio/cli.git
 cd cli
 
+# Trust the mise configuration (required on first setup)
+mise trust
+
 # Install dependencies (mise will install the correct Go version)
 mise install
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ cd cli
 # Install dependencies (including Go)
 mise install
 
+# Trust the mise configuration (required on first setup)
+mise trust
+
 # Build the CLI
 mise run build
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts onboarding steps; no code or runtime behavior is modified.
> 
> **Overview**
> Updates `README.md` and `CONTRIBUTING.md` setup instructions to include an explicit `mise trust` step for first-time repository setup, so `mise` config is trusted before running `mise install`/build commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f95cb57ee8149b917973f718786e65080de27bf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->