### PR TITLE
docs: fix incorrect resume documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Multiple AI sessions can run on the same commit. If you start a second session w
 | `entire enable`  | Enable Entire in your repository (uses `manual-commit` by default)            |
 | `entire explain` | Explain a session or commit                                                   |
 | `entire reset`   | Delete the shadow branch and session state for the current HEAD commit        |
-| `entire resume <branch>` | Switch to a branch, restore latest checkpointed session metadata, and show command(s) to continue |
+| `entire resume`  | Switch to a branch, restore latest checkpointed session metadata, and show command(s) to continue |
 | `entire rewind`  | Rewind to a previous checkpoint                                               |
 | `entire status`  | Show current session and strategy info                                        |
 | `entire version` | Show Entire CLI version                                                       |
@@ -281,7 +281,7 @@ If you run into any issues with Gemini CLI integration, please [open an issue](h
 
 ### SSH Authentication Errors
 
-If you see an error like this when running `entire resume <branch>`:
+If you see an error like this when running `entire resume`:
 
 ```
 Failed to fetch metadata: failed to fetch entire/checkpoints/v1 from origin: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain


### PR DESCRIPTION
The docs incorrectly (perhaps aspirationally) suggests you can run `entire resume` with no args and lists all past sesssions, when in reality it only extracts the sessions that exist in the current/most recent checkpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no code paths or runtime behavior are modified.
> 
> **Overview**
> Updates `README.md` to correct `entire resume` documentation: it now requires a `<branch>` argument and is described as switching to that branch, restoring the latest checkpointed session metadata, and printing follow-up command(s).
> 
> Also updates the Commands Reference entry to match this behavior, replacing the prior implication that `entire resume` lists/recovers arbitrary past sessions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19d3adc759a9278f3c403c5620942f33bf3e4254. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->