### PR TITLE
Pin golangci-lint version 2.8.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: 'v2.8.0'

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 # Please also keep the version aligned in the go.mod file
 go = { version = '1.25.6', postinstall = "go install github.com/go-delve/delve/cmd/dlv@latest" }
-golangci-lint = 'latest'
+golangci-lint = '2.8.0'
 shellcheck = 'latest'
 
 [tasks.fmt]


### PR DESCRIPTION
We were getting inconsistent CI and local dev experience.  Fix for now.  2.9.0 introduced new lint issues we should get around to fixing.

This was blocking @gtrrz-victor's work: https://github.com/entireio/cli/actions/runs/21888821964/job/63190027616?pr=214