### PR TITLE
Unify DetectChangedFiles and ComputeFileChanges into DetectFileChanges.

### DIFF
--- a/cmd/entire/cli/debug.go
+++ b/cmd/entire/cli/debug.go
@@ -187,10 +187,14 @@ func printTranscriptChanges(w io.Writer, transcriptPath, currentSession, repoRoo
 			fmt.Fprintf(w, "  Error loading pre-prompt state: %v\n", loadErr)
 		}
 	}
-	// Always call ComputeFileChanges - deleted files don't depend on preState
-	newFiles, deletedFiles, err = ComputeFileChanges(preState.PreUntrackedFiles())
+	// Always call DetectFileChanges - deleted files don't depend on preState
+	fileChanges, err := DetectFileChanges(preState.PreUntrackedFiles())
 	if err != nil {
 		fmt.Fprintf(w, "  Error computing file changes: %v\n", err)
+	}
+	if fileChanges != nil {
+		newFiles = fileChanges.New
+		deletedFiles = fileChanges.Deleted
 	}
 
 	// Filter and normalize paths

--- a/cmd/entire/cli/hooks_geminicli_handlers.go
+++ b/cmd/entire/cli/hooks_geminicli_handlers.go
@@ -202,14 +202,17 @@ func commitGeminiSession(ctx *geminiSessionContext) error {
 	}
 
 	// Compute new and deleted files (single git status call)
-	newFiles, deletedFiles, err := ComputeFileChanges(preState.PreUntrackedFiles())
+	changes, err := DetectFileChanges(preState.PreUntrackedFiles())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to compute file changes: %v\n", err)
 	}
 
 	relModifiedFiles := FilterAndNormalizePaths(ctx.modifiedFiles, repoRoot)
-	relNewFiles := FilterAndNormalizePaths(newFiles, repoRoot)
-	relDeletedFiles := FilterAndNormalizePaths(deletedFiles, repoRoot)
+	var relNewFiles, relDeletedFiles []string
+	if changes != nil {
+		relNewFiles = FilterAndNormalizePaths(changes.New, repoRoot)
+		relDeletedFiles = FilterAndNormalizePaths(changes.Deleted, repoRoot)
+	}
 
 	totalChanges := len(relModifiedFiles) + len(relNewFiles) + len(relDeletedFiles)
 	if totalChanges == 0 {

--- a/cmd/entire/cli/state_test.go
+++ b/cmd/entire/cli/state_test.go
@@ -386,10 +386,10 @@ func TestPrePromptState_WithSummaryOnlyTranscript(t *testing.T) {
 	}
 }
 
-func TestComputeFileChanges_DeletedFilesWithNilPreState(t *testing.T) {
-	// This test verifies that ComputeFileChanges detects deleted files
-	// even when preState is nil. This is critical because deleted file
-	// detection doesn't depend on pre-prompt state.
+func TestDetectFileChanges_DeletedFilesWithNilPreState(t *testing.T) {
+	// This test verifies that DetectFileChanges detects deleted files
+	// even when previouslyUntracked is nil. Deleted file detection
+	// doesn't depend on pre-prompt state.
 
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
@@ -429,28 +429,28 @@ func TestComputeFileChanges_DeletedFilesWithNilPreState(t *testing.T) {
 		t.Fatalf("failed to delete tracked file: %v", err)
 	}
 
-	// Call ComputeFileChanges with nil preState
-	newFiles, deletedFiles, err := ComputeFileChanges(nil)
+	// Call DetectFileChanges with nil previouslyUntracked
+	changes, err := DetectFileChanges(nil)
 	if err != nil {
-		t.Fatalf("ComputeFileChanges(nil) error = %v", err)
+		t.Fatalf("DetectFileChanges(nil) error = %v", err)
 	}
 
-	// newFiles should be nil when preState is nil
-	if newFiles != nil {
-		t.Errorf("ComputeFileChanges(nil) newFiles = %v, want nil", newFiles)
+	// New should be nil when there are no untracked files
+	if len(changes.New) != 0 {
+		t.Errorf("DetectFileChanges(nil) New = %v, want empty", changes.New)
 	}
 
-	// deletedFiles should contain the deleted tracked file
-	if len(deletedFiles) != 1 {
-		t.Errorf("ComputeFileChanges(nil) deletedFiles = %v, want [tracked.txt]", deletedFiles)
-	} else if deletedFiles[0] != "tracked.txt" {
-		t.Errorf("ComputeFileChanges(nil) deletedFiles[0] = %v, want tracked.txt", deletedFiles[0])
+	// Deleted should contain the deleted tracked file
+	if len(changes.Deleted) != 1 {
+		t.Errorf("DetectFileChanges(nil) Deleted = %v, want [tracked.txt]", changes.Deleted)
+	} else if changes.Deleted[0] != "tracked.txt" {
+		t.Errorf("DetectFileChanges(nil) Deleted[0] = %v, want tracked.txt", changes.Deleted[0])
 	}
 }
 
-func TestComputeFileChanges_NewAndDeletedFiles(t *testing.T) {
-	// This test verifies that ComputeFileChanges correctly identifies both
-	// new files (untracked files not in preState) and deleted files
+func TestDetectFileChanges_NewAndDeletedFiles(t *testing.T) {
+	// This test verifies that DetectFileChanges correctly identifies both
+	// new files (untracked files not in previouslyUntracked) and deleted files
 	// (tracked files that were deleted).
 
 	tmpDir := t.TempDir()
@@ -509,36 +509,30 @@ func TestComputeFileChanges_NewAndDeletedFiles(t *testing.T) {
 		t.Fatalf("failed to write new file: %v", err)
 	}
 
-	// Create preState that includes the pre-existing untracked file
-	preState := &PrePromptState{
-		SessionID:      "test-session",
-		UntrackedFiles: []string{"pre-existing-untracked.txt"},
-	}
-
-	// Call ComputeFileChanges with preState
-	newFiles, deletedFiles, err := ComputeFileChanges(preState.PreUntrackedFiles())
+	// Call DetectFileChanges with pre-existing untracked files
+	changes, err := DetectFileChanges([]string{"pre-existing-untracked.txt"})
 	if err != nil {
-		t.Fatalf("ComputeFileChanges(preState) error = %v", err)
+		t.Fatalf("DetectFileChanges() error = %v", err)
 	}
 
-	// newFiles should contain only new-file.txt (not pre-existing-untracked.txt)
-	if len(newFiles) != 1 {
-		t.Errorf("ComputeFileChanges(preState) newFiles = %v, want [new-file.txt]", newFiles)
-	} else if newFiles[0] != "new-file.txt" {
-		t.Errorf("ComputeFileChanges(preState) newFiles[0] = %v, want new-file.txt", newFiles[0])
+	// New should contain only new-file.txt (not pre-existing-untracked.txt)
+	if len(changes.New) != 1 {
+		t.Errorf("DetectFileChanges() New = %v, want [new-file.txt]", changes.New)
+	} else if changes.New[0] != "new-file.txt" {
+		t.Errorf("DetectFileChanges() New[0] = %v, want new-file.txt", changes.New[0])
 	}
 
-	// deletedFiles should contain tracked1.txt
-	if len(deletedFiles) != 1 {
-		t.Errorf("ComputeFileChanges(preState) deletedFiles = %v, want [tracked1.txt]", deletedFiles)
-	} else if deletedFiles[0] != "tracked1.txt" {
-		t.Errorf("ComputeFileChanges(preState) deletedFiles[0] = %v, want tracked1.txt", deletedFiles[0])
+	// Deleted should contain tracked1.txt
+	if len(changes.Deleted) != 1 {
+		t.Errorf("DetectFileChanges() Deleted = %v, want [tracked1.txt]", changes.Deleted)
+	} else if changes.Deleted[0] != "tracked1.txt" {
+		t.Errorf("DetectFileChanges() Deleted[0] = %v, want tracked1.txt", changes.Deleted[0])
 	}
 }
 
-func TestComputeFileChanges_NoChanges(t *testing.T) {
-	// This test verifies ComputeFileChanges returns empty slices
-	// when there are no new or deleted files.
+func TestDetectFileChanges_NoChanges(t *testing.T) {
+	// This test verifies DetectFileChanges returns empty slices
+	// when there are no new, modified, or deleted files.
 
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
@@ -573,23 +567,93 @@ func TestComputeFileChanges_NoChanges(t *testing.T) {
 		t.Fatalf("failed to commit: %v", err)
 	}
 
-	// Create preState with no untracked files
-	preState := &PrePromptState{
-		SessionID:      "test-session",
-		UntrackedFiles: []string{},
-	}
-
-	// Call ComputeFileChanges - no changes should be detected
-	newFiles, deletedFiles, err := ComputeFileChanges(preState.PreUntrackedFiles())
+	// Call DetectFileChanges with empty previouslyUntracked - no changes should be detected
+	changes, err := DetectFileChanges([]string{})
 	if err != nil {
-		t.Fatalf("ComputeFileChanges(preState) error = %v", err)
+		t.Fatalf("DetectFileChanges() error = %v", err)
 	}
 
-	if len(newFiles) != 0 {
-		t.Errorf("ComputeFileChanges(preState) newFiles = %v, want empty", newFiles)
+	if len(changes.Modified) != 0 {
+		t.Errorf("DetectFileChanges() Modified = %v, want empty", changes.Modified)
 	}
 
-	if len(deletedFiles) != 0 {
-		t.Errorf("ComputeFileChanges(preState) deletedFiles = %v, want empty", deletedFiles)
+	if len(changes.New) != 0 {
+		t.Errorf("DetectFileChanges() New = %v, want empty", changes.New)
+	}
+
+	if len(changes.Deleted) != 0 {
+		t.Errorf("DetectFileChanges() Deleted = %v, want empty", changes.Deleted)
+	}
+}
+
+func TestDetectFileChanges_NilPreviouslyUntracked_ReturnsModified(t *testing.T) {
+	// This test verifies that DetectFileChanges with nil previouslyUntracked
+	// returns all untracked files as New and also returns Modified files.
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	// Initialize git repo with go-git
+	repo, err := git.PlainInit(tmpDir, false)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	// Create and commit a tracked file
+	trackedFile := filepath.Join(tmpDir, "tracked.txt")
+	if err := os.WriteFile(trackedFile, []byte("content"), 0o644); err != nil {
+		t.Fatalf("failed to write tracked file: %v", err)
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %v", err)
+	}
+
+	if _, err := worktree.Add("tracked.txt"); err != nil {
+		t.Fatalf("failed to add file: %v", err)
+	}
+
+	if _, err := worktree.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+		},
+	}); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	// Modify the tracked file and create an untracked file
+	if err := os.WriteFile(trackedFile, []byte("modified content"), 0o644); err != nil {
+		t.Fatalf("failed to modify tracked file: %v", err)
+	}
+	untrackedFile := filepath.Join(tmpDir, "untracked.txt")
+	if err := os.WriteFile(untrackedFile, []byte("untracked"), 0o644); err != nil {
+		t.Fatalf("failed to write untracked file: %v", err)
+	}
+
+	// Call DetectFileChanges with nil (all untracked files should be returned)
+	changes, err := DetectFileChanges(nil)
+	if err != nil {
+		t.Fatalf("DetectFileChanges(nil) error = %v", err)
+	}
+
+	// Modified should contain tracked.txt
+	if len(changes.Modified) != 1 {
+		t.Errorf("DetectFileChanges(nil) Modified = %v, want [tracked.txt]", changes.Modified)
+	} else if changes.Modified[0] != "tracked.txt" {
+		t.Errorf("DetectFileChanges(nil) Modified[0] = %v, want tracked.txt", changes.Modified[0])
+	}
+
+	// New should contain untracked.txt
+	if len(changes.New) != 1 {
+		t.Errorf("DetectFileChanges(nil) New = %v, want [untracked.txt]", changes.New)
+	} else if changes.New[0] != "untracked.txt" {
+		t.Errorf("DetectFileChanges(nil) New[0] = %v, want untracked.txt", changes.New[0])
+	}
+
+	// Deleted should be empty
+	if len(changes.Deleted) != 0 {
+		t.Errorf("DetectFileChanges(nil) Deleted = %v, want empty", changes.Deleted)
 	}
 }

--- a/docs/architecture/claude-hooks-integration.md
+++ b/docs/architecture/claude-hooks-integration.md
@@ -198,7 +198,7 @@ Fires whenever a subagent updates its todo list. Enables fine-grained, increment
 
 2.  **Detect File Changes**:
 
-    - Calls `DetectChangedFiles()` to check for modifications since the last checkpoint.
+    - Calls `DetectFileChanges()` to check for modifications since the last checkpoint.
     - Compares against git worktree status for modified, new, and deleted files.
 
 3.  **Skip if No Changes**: If no files have changed, logs a message and returns without creating a checkpoint.


### PR DESCRIPTION
# Description

Both functions opened a git repo, got worktree status, filtered infrastructure paths, and iterated the status map. The only difference was how they categorized untracked vs modified files. Merge them into a single DetectFileChanges(previouslyUntracked) returning a FileChanges struct with Modified, New, and Deleted slices.

This is a followup cleanup after working on #218.