### PR TITLE
Add OpenCode and Codex CLI agent support

### DIFF
--- a/cmd/entire/cli/agent/codex/codex.go
+++ b/cmd/entire/cli/agent/codex/codex.go
@@ -1,0 +1,413 @@
+// Package codex implements the Agent interface for OpenAI's Codex CLI.
+package codex
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/sessionid"
+)
+
+//nolint:gochecknoinits // Agent self-registration is the intended pattern
+func init() {
+	agent.Register(agent.AgentNameCodex, NewCodexAgent)
+}
+
+// CodexAgent implements the Agent interface for Codex CLI.
+//
+//nolint:revive // CodexAgent is clearer than Agent in this context
+type CodexAgent struct{}
+
+// NewCodexAgent creates a new Codex CLI agent instance.
+func NewCodexAgent() agent.Agent {
+	return &CodexAgent{}
+}
+
+// Name returns the agent registry key.
+func (c *CodexAgent) Name() agent.AgentName {
+	return agent.AgentNameCodex
+}
+
+// Type returns the agent type identifier.
+func (c *CodexAgent) Type() agent.AgentType {
+	return agent.AgentTypeCodex
+}
+
+// Description returns a human-readable description.
+func (c *CodexAgent) Description() string {
+	return "Codex CLI - OpenAI's AI coding assistant"
+}
+
+// DetectPresence checks if Codex CLI is configured in the repository.
+func (c *CodexAgent) DetectPresence() (bool, error) {
+	// Get repo root to check for .codex directory
+	// This is needed because the CLI may be run from a subdirectory
+	repoRoot, err := paths.RepoRoot()
+	if err != nil {
+		// Not in a git repo, fall back to CWD-relative check
+		repoRoot = "."
+	}
+
+	// Check for .codex directory
+	codexDir := filepath.Join(repoRoot, ".codex")
+	if _, err := os.Stat(codexDir); err == nil {
+		return true, nil
+	}
+	// Check for .codex/config.toml
+	configFile := filepath.Join(repoRoot, ".codex", "config.toml")
+	if _, err := os.Stat(configFile); err == nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+// GetHookConfigPath returns the path to Codex's hook config file.
+func (c *CodexAgent) GetHookConfigPath() string {
+	return ".codex/config.toml"
+}
+
+// SupportsHooks returns true as Codex CLI supports the notify hook.
+func (c *CodexAgent) SupportsHooks() bool {
+	return true
+}
+
+// ParseHookInput parses Codex CLI hook input from stdin.
+// Codex sends a JSON payload to the notify command.
+func (c *CodexAgent) ParseHookInput(hookType agent.HookType, reader io.Reader) (*agent.HookInput, error) {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read input: %w", err)
+	}
+
+	if len(data) == 0 {
+		return nil, errors.New("empty input")
+	}
+
+	input := &agent.HookInput{
+		HookType:  hookType,
+		Timestamp: time.Now(),
+		RawData:   make(map[string]interface{}),
+	}
+
+	var payload notifyPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse notify payload: %w", err)
+	}
+
+	input.SessionID = payload.ThreadID
+	input.RawData["type"] = payload.Type
+	input.RawData["turn_id"] = payload.TurnID
+	input.RawData["cwd"] = payload.Cwd
+
+	// Extract user prompt from input-messages
+	if len(payload.InputMessages) > 0 {
+		input.UserPrompt = payload.InputMessages[len(payload.InputMessages)-1]
+	}
+
+	// Resolve transcript path from session dir
+	sessionDir, dirErr := c.getCodexHome()
+	if dirErr == nil {
+		input.SessionRef = filepath.Join(sessionDir, "sessions")
+	}
+
+	return input, nil
+}
+
+// GetSessionID extracts the session ID from hook input.
+func (c *CodexAgent) GetSessionID(input *agent.HookInput) string {
+	return input.SessionID
+}
+
+// TransformSessionID converts a Codex session ID to an Entire session ID.
+// This is an identity function - the agent session ID IS the Entire session ID.
+func (c *CodexAgent) TransformSessionID(agentSessionID string) string {
+	return agentSessionID
+}
+
+// ExtractAgentSessionID extracts the Codex session ID from an Entire session ID.
+// Since Entire session ID = agent session ID (identity), this returns the input unchanged.
+// For backwards compatibility with legacy date-prefixed IDs, it strips the prefix if present.
+func (c *CodexAgent) ExtractAgentSessionID(entireSessionID string) string {
+	return sessionid.ModelSessionID(entireSessionID)
+}
+
+// ProtectedDirs returns directories that Codex uses for config/state.
+func (c *CodexAgent) ProtectedDirs() []string { return []string{".codex"} }
+
+// GetSessionDir returns the directory where Codex stores session transcripts.
+// Codex stores sessions in ~/.codex/sessions/ (respects CODEX_HOME).
+func (c *CodexAgent) GetSessionDir(_ string) (string, error) {
+	// Check for test environment override
+	if override := os.Getenv("ENTIRE_TEST_CODEX_PROJECT_DIR"); override != "" {
+		return override, nil
+	}
+
+	codexHome, err := c.getCodexHome()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(codexHome, "sessions"), nil
+}
+
+// getCodexHome returns the Codex home directory.
+// Respects CODEX_HOME env var, defaults to ~/.codex.
+func (c *CodexAgent) getCodexHome() (string, error) {
+	if codexHome := os.Getenv("CODEX_HOME"); codexHome != "" {
+		return codexHome, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".codex"), nil
+}
+
+// ResolveSessionFile returns the path to a Codex session file.
+// Codex stores sessions as rollout-*.jsonl in date-based directories.
+// Searches for an existing file matching the pattern, falls back to a default path.
+func (c *CodexAgent) ResolveSessionFile(sessionDir, agentSessionID string) string {
+	// Search for rollout files containing the session ID
+	pattern := filepath.Join(sessionDir, "**", "rollout-*"+agentSessionID+"*.jsonl")
+	matches, err := filepath.Glob(pattern)
+	if err == nil && len(matches) > 0 {
+		return matches[len(matches)-1]
+	}
+
+	// Fallback: construct a default path
+	return filepath.Join(sessionDir, agentSessionID+".jsonl")
+}
+
+// ReadSession reads a session from Codex's storage (JSONL rollout file).
+// The session data is stored in NativeData as raw JSONL bytes.
+func (c *CodexAgent) ReadSession(input *agent.HookInput) (*agent.AgentSession, error) {
+	if input.SessionRef == "" {
+		return nil, errors.New("session reference (file path) is required")
+	}
+
+	data, err := os.ReadFile(input.SessionRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session file: %w", err)
+	}
+
+	return &agent.AgentSession{
+		SessionID:  input.SessionID,
+		AgentName:  c.Name(),
+		SessionRef: input.SessionRef,
+		NativeData: data,
+	}, nil
+}
+
+// WriteSession writes a session to Codex's storage (JSONL rollout file).
+func (c *CodexAgent) WriteSession(session *agent.AgentSession) error {
+	if session == nil {
+		return errors.New("session is nil")
+	}
+
+	if session.AgentName != "" && session.AgentName != c.Name() {
+		return fmt.Errorf("session belongs to agent %q, not %q", session.AgentName, c.Name())
+	}
+
+	if session.SessionRef == "" {
+		return errors.New("session reference (file path) is required")
+	}
+
+	if len(session.NativeData) == 0 {
+		return errors.New("session has no native data to write")
+	}
+
+	if err := os.WriteFile(session.SessionRef, session.NativeData, 0o600); err != nil {
+		return fmt.Errorf("failed to write session file: %w", err)
+	}
+
+	return nil
+}
+
+// FormatResumeCommand returns the command to resume a Codex CLI session.
+func (c *CodexAgent) FormatResumeCommand(sessionID string) string {
+	return "codex resume " + sessionID
+}
+
+// TranscriptAnalyzer interface implementation
+
+// GetTranscriptPosition returns the current line count of a Codex transcript.
+// Codex uses JSONL format, so position is the number of lines.
+// Returns 0 if the file doesn't exist or is empty.
+func (c *CodexAgent) GetTranscriptPosition(path string) (int, error) {
+	if path == "" {
+		return 0, nil
+	}
+
+	file, err := os.Open(path) //nolint:gosec // Path comes from Codex transcript location
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to open transcript file: %w", err)
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	lineCount := 0
+
+	for {
+		_, err := reader.ReadBytes('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return 0, fmt.Errorf("failed to read transcript: %w", err)
+		}
+		lineCount++
+	}
+
+	return lineCount, nil
+}
+
+// ExtractModifiedFilesFromOffset extracts files modified since a given line number.
+// For Codex (JSONL format), offset is the starting line number.
+// Returns:
+//   - files: list of file paths modified by Codex (from file_change events)
+//   - currentPosition: total number of lines in the file
+//   - error: any error encountered during reading
+func (c *CodexAgent) ExtractModifiedFilesFromOffset(path string, startOffset int) (files []string, currentPosition int, err error) {
+	if path == "" {
+		return nil, 0, nil
+	}
+
+	file, openErr := os.Open(path) //nolint:gosec // Path comes from Codex transcript location
+	if openErr != nil {
+		return nil, 0, fmt.Errorf("failed to open transcript file: %w", openErr)
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	fileSet := make(map[string]bool)
+	lineNum := 0
+
+	for {
+		lineData, readErr := reader.ReadBytes('\n')
+		if readErr != nil && readErr != io.EOF {
+			return nil, 0, fmt.Errorf("failed to read transcript: %w", readErr)
+		}
+
+		if len(lineData) > 0 {
+			lineNum++
+			if lineNum > startOffset {
+				var event rolloutEvent
+				if parseErr := json.Unmarshal(lineData, &event); parseErr == nil {
+					// Extract file paths from file_change events
+					if event.Item != nil {
+						var item rolloutItem
+						if json.Unmarshal(event.Item, &item) == nil && item.Type == ItemTypeFileChange {
+							// Try to extract file path from the item
+							var fileItem struct {
+								FilePath string `json:"file_path"`
+								Path     string `json:"path"`
+								Filename string `json:"filename"`
+							}
+							if json.Unmarshal(event.Item, &fileItem) == nil {
+								fp := fileItem.FilePath
+								if fp == "" {
+									fp = fileItem.Path
+								}
+								if fp == "" {
+									fp = fileItem.Filename
+								}
+								if fp != "" && !fileSet[fp] {
+									fileSet[fp] = true
+									files = append(files, fp)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if readErr == io.EOF {
+			break
+		}
+	}
+
+	return files, lineNum, nil
+}
+
+// TranscriptChunker interface implementation
+
+// ChunkTranscript splits a JSONL transcript at line boundaries.
+// Codex uses JSONL format, so chunking is done at newline boundaries.
+func (c *CodexAgent) ChunkTranscript(content []byte, maxSize int) ([][]byte, error) {
+	chunks, err := agent.ChunkJSONL(content, maxSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to chunk JSONL transcript: %w", err)
+	}
+	return chunks, nil
+}
+
+// ReassembleTranscript concatenates JSONL chunks with newlines.
+//
+//nolint:unparam // error return is required by interface, kept for consistency
+func (c *CodexAgent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	return agent.ReassembleJSONL(chunks), nil
+}
+
+// ExtractModifiedFiles extracts file paths from Codex transcript data.
+// Parses JSONL events and collects file_change items.
+func ExtractModifiedFiles(data []byte) []string {
+	fileSet := make(map[string]bool)
+	var files []string
+
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		var event rolloutEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			continue
+		}
+		if event.Item == nil {
+			continue
+		}
+
+		var item rolloutItem
+		if json.Unmarshal(event.Item, &item) != nil {
+			continue
+		}
+		if item.Type != ItemTypeFileChange {
+			continue
+		}
+
+		var fileItem struct {
+			FilePath string `json:"file_path"`
+			Path     string `json:"path"`
+			Filename string `json:"filename"`
+		}
+		if json.Unmarshal(event.Item, &fileItem) != nil {
+			continue
+		}
+
+		fp := fileItem.FilePath
+		if fp == "" {
+			fp = fileItem.Path
+		}
+		if fp == "" {
+			fp = fileItem.Filename
+		}
+		if fp != "" && !fileSet[fp] {
+			fileSet[fp] = true
+			files = append(files, fp)
+		}
+	}
+
+	return files
+}

--- a/cmd/entire/cli/agent/codex/codex_test.go
+++ b/cmd/entire/cli/agent/codex/codex_test.go
@@ -1,0 +1,408 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+func TestNewCodexAgent(t *testing.T) {
+	t.Parallel()
+
+	ag := NewCodexAgent()
+	if ag == nil {
+		t.Fatal("NewCodexAgent() returned nil")
+	}
+
+	cx, ok := ag.(*CodexAgent)
+	if !ok {
+		t.Fatal("NewCodexAgent() didn't return *CodexAgent")
+	}
+	if cx == nil {
+		t.Fatal("NewCodexAgent() returned nil agent")
+	}
+}
+
+func TestName(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	if name := ag.Name(); name != agent.AgentNameCodex {
+		t.Errorf("Name() = %q, want %q", name, agent.AgentNameCodex)
+	}
+}
+
+func TestType(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	if agType := ag.Type(); agType != agent.AgentTypeCodex {
+		t.Errorf("Type() = %q, want %q", agType, agent.AgentTypeCodex)
+	}
+}
+
+func TestDescription(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	desc := ag.Description()
+	if desc == "" {
+		t.Error("Description() returned empty string")
+	}
+}
+
+func TestSupportsHooks(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	if !ag.SupportsHooks() {
+		t.Error("SupportsHooks() = false, want true")
+	}
+}
+
+func TestDetectPresence(t *testing.T) {
+	t.Run("no .codex directory", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		ag := &CodexAgent{}
+		present, err := ag.DetectPresence()
+		if err != nil {
+			t.Fatalf("DetectPresence() error = %v", err)
+		}
+		if present {
+			t.Error("DetectPresence() = true, want false")
+		}
+	})
+
+	t.Run("with .codex directory", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		if err := os.Mkdir(".codex", 0o755); err != nil {
+			t.Fatalf("failed to create .codex: %v", err)
+		}
+
+		ag := &CodexAgent{}
+		present, err := ag.DetectPresence()
+		if err != nil {
+			t.Fatalf("DetectPresence() error = %v", err)
+		}
+		if !present {
+			t.Error("DetectPresence() = false, want true")
+		}
+	})
+
+	t.Run("with .codex/config.toml", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		if err := os.MkdirAll(".codex", 0o755); err != nil {
+			t.Fatalf("failed to create .codex: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(".codex", "config.toml"), []byte(""), 0o600); err != nil {
+			t.Fatalf("failed to create config.toml: %v", err)
+		}
+
+		ag := &CodexAgent{}
+		present, err := ag.DetectPresence()
+		if err != nil {
+			t.Fatalf("DetectPresence() error = %v", err)
+		}
+		if !present {
+			t.Error("DetectPresence() = false, want true")
+		}
+	})
+}
+
+func TestParseHookInput_AgentTurnComplete(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	input := `{"type":"agent-turn-complete","thread-id":"abc-123","turn-id":"turn-456","cwd":"/tmp","input-messages":["Fix the bug"],"last-assistant-message":"Done"}`
+
+	result, err := ag.ParseHookInput(agent.HookStop, strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("ParseHookInput() error = %v", err)
+	}
+
+	if result.SessionID != "abc-123" {
+		t.Errorf("SessionID = %q, want %q", result.SessionID, "abc-123")
+	}
+	if result.UserPrompt != "Fix the bug" {
+		t.Errorf("UserPrompt = %q, want %q", result.UserPrompt, "Fix the bug")
+	}
+}
+
+func TestResolveSessionFile(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	result := ag.ResolveSessionFile("/home/user/.codex/sessions", "abc-123")
+	expected := "/home/user/.codex/sessions/abc-123.jsonl"
+	if result != expected {
+		t.Errorf("ResolveSessionFile() = %q, want %q", result, expected)
+	}
+}
+
+func TestProtectedDirs(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	dirs := ag.ProtectedDirs()
+	if len(dirs) != 1 || dirs[0] != ".codex" {
+		t.Errorf("ProtectedDirs() = %v, want [.codex]", dirs)
+	}
+}
+
+func TestFormatResumeCommand(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	cmd := ag.FormatResumeCommand("abc-123")
+	expected := "codex resume abc-123"
+	if cmd != expected {
+		t.Errorf("FormatResumeCommand() = %q, want %q", cmd, expected)
+	}
+}
+
+func TestTransformSessionID(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	id := ag.TransformSessionID("abc-123")
+	if id != "abc-123" {
+		t.Errorf("TransformSessionID() = %q, want %q", id, "abc-123")
+	}
+}
+
+func TestGetHookNames(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	names := ag.GetHookNames()
+	if len(names) != 1 || names[0] != HookNameAgentTurnComplete {
+		t.Errorf("GetHookNames() = %v, want [%s]", names, HookNameAgentTurnComplete)
+	}
+}
+
+func TestInstallHooks(t *testing.T) {
+	t.Run("installs notify hook", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		ag := &CodexAgent{}
+		count, err := ag.InstallHooks(false, false)
+		if err != nil {
+			t.Fatalf("InstallHooks() error = %v", err)
+		}
+		if count != 1 {
+			t.Errorf("InstallHooks() count = %d, want 1", count)
+		}
+
+		// Verify file contents
+		data, err := os.ReadFile(filepath.Join(".codex", "config.toml"))
+		if err != nil {
+			t.Fatalf("failed to read config.toml: %v", err)
+		}
+		content := string(data)
+		if !strings.Contains(content, `notify = ["entire", "hooks", "codex", "agent-turn-complete"]`) {
+			t.Errorf("config.toml missing notify line, got:\n%s", content)
+		}
+	})
+
+	t.Run("idempotent install", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		ag := &CodexAgent{}
+		// First install
+		_, err := ag.InstallHooks(false, false)
+		if err != nil {
+			t.Fatalf("first InstallHooks() error = %v", err)
+		}
+
+		// Second install should be no-op
+		count, err := ag.InstallHooks(false, false)
+		if err != nil {
+			t.Fatalf("second InstallHooks() error = %v", err)
+		}
+		if count != 0 {
+			t.Errorf("second InstallHooks() count = %d, want 0", count)
+		}
+	})
+
+	t.Run("local dev mode", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		ag := &CodexAgent{}
+		count, err := ag.InstallHooks(true, false)
+		if err != nil {
+			t.Fatalf("InstallHooks() error = %v", err)
+		}
+		if count != 1 {
+			t.Errorf("InstallHooks() count = %d, want 1", count)
+		}
+
+		data, err := os.ReadFile(filepath.Join(".codex", "config.toml"))
+		if err != nil {
+			t.Fatalf("failed to read config.toml: %v", err)
+		}
+		content := string(data)
+		if !strings.Contains(content, "go") || !strings.Contains(content, "entire") {
+			t.Errorf("config.toml missing local dev notify line, got:\n%s", content)
+		}
+	})
+}
+
+func TestAreHooksInstalled(t *testing.T) {
+	t.Run("not installed", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		ag := &CodexAgent{}
+		if ag.AreHooksInstalled() {
+			t.Error("AreHooksInstalled() = true, want false")
+		}
+	})
+
+	t.Run("installed", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		ag := &CodexAgent{}
+		_, err := ag.InstallHooks(false, false)
+		if err != nil {
+			t.Fatalf("InstallHooks() error = %v", err)
+		}
+
+		if !ag.AreHooksInstalled() {
+			t.Error("AreHooksInstalled() = false, want true")
+		}
+	})
+}
+
+func TestUninstallHooks(t *testing.T) {
+	t.Run("uninstalls notify hook", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		ag := &CodexAgent{}
+		_, err := ag.InstallHooks(false, false)
+		if err != nil {
+			t.Fatalf("InstallHooks() error = %v", err)
+		}
+
+		if err := ag.UninstallHooks(); err != nil {
+			t.Fatalf("UninstallHooks() error = %v", err)
+		}
+
+		if ag.AreHooksInstalled() {
+			t.Error("AreHooksInstalled() = true after uninstall")
+		}
+	})
+
+	t.Run("no config file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		ag := &CodexAgent{}
+		if err := ag.UninstallHooks(); err != nil {
+			t.Errorf("UninstallHooks() error = %v, want nil", err)
+		}
+	})
+}
+
+func TestGetSessionDir(t *testing.T) {
+	// Not parallel: subtests use t.Setenv which modifies process-global state
+
+	t.Run("with test override", func(t *testing.T) {
+		t.Setenv("ENTIRE_TEST_CODEX_PROJECT_DIR", "/tmp/test-codex")
+		ag := &CodexAgent{}
+		dir, err := ag.GetSessionDir("/some/repo")
+		if err != nil {
+			t.Fatalf("GetSessionDir() error = %v", err)
+		}
+		if dir != "/tmp/test-codex" {
+			t.Errorf("GetSessionDir() = %q, want %q", dir, "/tmp/test-codex")
+		}
+	})
+
+	t.Run("with CODEX_HOME", func(t *testing.T) {
+		t.Setenv("CODEX_HOME", "/custom/codex")
+		t.Setenv("ENTIRE_TEST_CODEX_PROJECT_DIR", "") // Clear test override
+		ag := &CodexAgent{}
+		dir, err := ag.GetSessionDir("/some/repo")
+		if err != nil {
+			t.Fatalf("GetSessionDir() error = %v", err)
+		}
+		expected := "/custom/codex/sessions"
+		if dir != expected {
+			t.Errorf("GetSessionDir() = %q, want %q", dir, expected)
+		}
+	})
+}
+
+func TestIsEntireNotifyLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{
+			name: "entire production hook",
+			line: `notify = ["entire", "hooks", "codex", "agent-turn-complete"]`,
+			want: true,
+		},
+		{
+			name: "entire local dev hook",
+			line: `notify = ["go", "run", "${CODEX_PROJECT_DIR}/cmd/entire/main.go", "hooks", "codex", "agent-turn-complete"]`,
+			want: true,
+		},
+		{
+			name: "user custom hook",
+			line: `notify = ["python3", "/path/to/my/script.py"]`,
+			want: false,
+		},
+		{
+			name: "empty notify",
+			line: `notify = []`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isEntireNotifyLine(tt.line); got != tt.want {
+				t.Errorf("isEntireNotifyLine(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractModifiedFiles(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{"type":"item.completed","item":{"type":"file_change","file_path":"src/main.go"}}
+{"type":"item.completed","item":{"type":"agent_message","text":"Done"}}
+{"type":"item.completed","item":{"type":"file_change","path":"README.md"}}
+`)
+
+	files := ExtractModifiedFiles(data)
+	if len(files) != 2 {
+		t.Errorf("ExtractModifiedFiles() returned %d files, want 2", len(files))
+	}
+	if len(files) >= 1 && files[0] != "src/main.go" {
+		t.Errorf("files[0] = %q, want %q", files[0], "src/main.go")
+	}
+	if len(files) >= 2 && files[1] != "README.md" {
+		t.Errorf("files[1] = %q, want %q", files[1], "README.md")
+	}
+}

--- a/cmd/entire/cli/agent/codex/hooks.go
+++ b/cmd/entire/cli/agent/codex/hooks.go
@@ -1,0 +1,229 @@
+package codex
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// Ensure CodexAgent implements HookSupport and HookHandler
+var (
+	_ agent.HookSupport = (*CodexAgent)(nil)
+	_ agent.HookHandler = (*CodexAgent)(nil)
+)
+
+// Codex CLI hook names - these become subcommands under `entire hooks codex`
+const (
+	HookNameAgentTurnComplete = "agent-turn-complete"
+)
+
+// CodexConfigFileName is the config file used by Codex CLI.
+const CodexConfigFileName = "config.toml"
+
+// entireNotifyCommand is the command Entire installs as the Codex notify handler.
+const entireNotifyCommand = `["entire", "hooks", "codex", "agent-turn-complete"]`
+
+// entireNotifyLocalDevCommand is the local-dev variant of the notify handler.
+const entireNotifyLocalDevCommand = `["go", "run", "${CODEX_PROJECT_DIR}/cmd/entire/main.go", "hooks", "codex", "agent-turn-complete"]`
+
+// entireNotifyPrefixes are command prefixes that identify Entire notify hooks.
+var entireNotifyPrefixes = []string{
+	`"entire"`,
+	`"go", "run"`,
+}
+
+// GetHookNames returns the hook verbs Codex CLI supports.
+// These become subcommands: entire hooks codex <verb>
+func (c *CodexAgent) GetHookNames() []string {
+	return []string{
+		HookNameAgentTurnComplete,
+	}
+}
+
+// InstallHooks installs the Codex CLI notify hook in .codex/config.toml.
+// Codex uses a TOML config with a `notify` field that specifies the command
+// to run on agent-turn-complete events.
+// If force is true, removes existing Entire hooks before installing.
+// Returns the number of hooks installed.
+func (c *CodexAgent) InstallHooks(localDev bool, force bool) (int, error) {
+	repoRoot, err := paths.RepoRoot()
+	if err != nil {
+		repoRoot, err = os.Getwd() //nolint:forbidigo // Intentional fallback when RepoRoot() fails (tests run outside git repos)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get current directory: %w", err)
+		}
+	}
+
+	configPath := filepath.Join(repoRoot, ".codex", CodexConfigFileName)
+
+	// Read existing config if it exists
+	var lines []string
+	existingData, readErr := os.ReadFile(configPath) //nolint:gosec // path is constructed from repo root + fixed path
+	if readErr == nil {
+		lines = strings.Split(string(existingData), "\n")
+	}
+
+	// Determine which command to install
+	notifyValue := entireNotifyCommand
+	if localDev {
+		notifyValue = entireNotifyLocalDevCommand
+	}
+	notifyLine := "notify = " + notifyValue
+
+	// Check if already installed (idempotency)
+	if !force {
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == notifyLine {
+				return 0, nil // Already installed
+			}
+		}
+	}
+
+	// Remove existing Entire notify lines if force or if we need to update
+	var filteredLines []string
+	notifyFound := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "notify") && strings.Contains(trimmed, "=") && isEntireNotifyLine(trimmed) {
+			notifyFound = true
+			continue // Skip existing Entire notify line
+		}
+		filteredLines = append(filteredLines, line)
+	}
+
+	// If there's a non-Entire notify line, don't overwrite it
+	if !notifyFound && !force {
+		for _, line := range filteredLines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "notify") && strings.Contains(trimmed, "=") {
+				// There's a user-configured notify line; don't overwrite
+				return 0, nil
+			}
+		}
+	}
+
+	// Add the notify line
+	filteredLines = appendNotifyLine(filteredLines, notifyLine)
+
+	// Write back to file
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		return 0, fmt.Errorf("failed to create .codex directory: %w", err)
+	}
+
+	output := strings.Join(filteredLines, "\n")
+	// Ensure file ends with a newline
+	if !strings.HasSuffix(output, "\n") {
+		output += "\n"
+	}
+
+	if err := os.WriteFile(configPath, []byte(output), 0o600); err != nil {
+		return 0, fmt.Errorf("failed to write config.toml: %w", err)
+	}
+
+	return 1, nil
+}
+
+// UninstallHooks removes the Entire notify hook from Codex CLI config.
+func (c *CodexAgent) UninstallHooks() error {
+	repoRoot, err := paths.RepoRoot()
+	if err != nil {
+		repoRoot = "." // Fallback to CWD if not in a git repo
+	}
+	configPath := filepath.Join(repoRoot, ".codex", CodexConfigFileName)
+	data, err := os.ReadFile(configPath) //nolint:gosec // path is constructed from repo root + fixed path
+	if err != nil {
+		return nil //nolint:nilerr // No config file means nothing to uninstall
+	}
+
+	lines := strings.Split(string(data), "\n")
+	var filteredLines []string
+	changed := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "notify") && strings.Contains(trimmed, "=") && isEntireNotifyLine(trimmed) {
+			changed = true
+			continue // Remove Entire notify line
+		}
+		filteredLines = append(filteredLines, line)
+	}
+
+	if !changed {
+		return nil
+	}
+
+	output := strings.Join(filteredLines, "\n")
+	if err := os.WriteFile(configPath, []byte(output), 0o600); err != nil {
+		return fmt.Errorf("failed to write config.toml: %w", err)
+	}
+	return nil
+}
+
+// AreHooksInstalled checks if the Entire notify hook is installed.
+func (c *CodexAgent) AreHooksInstalled() bool {
+	repoRoot, err := paths.RepoRoot()
+	if err != nil {
+		repoRoot = "." // Fallback to CWD if not in a git repo
+	}
+	configPath := filepath.Join(repoRoot, ".codex", CodexConfigFileName)
+	data, err := os.ReadFile(configPath) //nolint:gosec // path is constructed from repo root + fixed path
+	if err != nil {
+		return false
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "notify") && strings.Contains(trimmed, "=") && isEntireNotifyLine(trimmed) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetSupportedHooks returns the hook types Codex CLI supports.
+func (c *CodexAgent) GetSupportedHooks() []agent.HookType {
+	return []agent.HookType{
+		agent.HookStop, // agent-turn-complete maps to Stop
+	}
+}
+
+// isEntireNotifyLine checks if a TOML notify line contains an Entire command.
+func isEntireNotifyLine(line string) bool {
+	for _, prefix := range entireNotifyPrefixes {
+		if strings.Contains(line, prefix) && strings.Contains(line, "entire") {
+			return true
+		}
+	}
+	return false
+}
+
+// appendNotifyLine adds a notify line to the config, placing it logically.
+// If there's an existing commented-out notify line, places the new one near it.
+// Otherwise, appends to the end.
+func appendNotifyLine(lines []string, notifyLine string) []string {
+	// Look for a commented notify line to place near
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") && strings.Contains(trimmed, "notify") {
+			// Insert after the comment
+			result := make([]string, 0, len(lines)+1)
+			result = append(result, lines[:i+1]...)
+			result = append(result, notifyLine)
+			result = append(result, lines[i+1:]...)
+			return result
+		}
+	}
+
+	// Append to the end, with a blank line separator if the file isn't empty
+	if len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) != "" {
+		lines = append(lines, "")
+	}
+	return append(lines, notifyLine)
+}

--- a/cmd/entire/cli/agent/codex/types.go
+++ b/cmd/entire/cli/agent/codex/types.go
@@ -1,0 +1,38 @@
+package codex
+
+import "encoding/json"
+
+// notifyPayload is the JSON structure sent to the notify command by Codex CLI.
+// Codex sends this on agent-turn-complete events.
+type notifyPayload struct {
+	Type                 string   `json:"type"`
+	ThreadID             string   `json:"thread-id"`
+	TurnID               string   `json:"turn-id"`
+	Cwd                  string   `json:"cwd"`
+	InputMessages        []string `json:"input-messages"`
+	LastAssistantMessage string   `json:"last-assistant-message"`
+}
+
+// rolloutEvent represents a single event line in a Codex rollout JSONL file.
+// Codex stores session transcripts as JSONL where each line is an event.
+type rolloutEvent struct {
+	Type     string          `json:"type"`
+	ThreadID string          `json:"thread_id,omitempty"`
+	TurnID   string          `json:"turn_id,omitempty"`
+	Item     json.RawMessage `json:"item,omitempty"`
+	Text     string          `json:"text,omitempty"`
+}
+
+// rolloutItem represents the item field in a rollout event.
+type rolloutItem struct {
+	ID     string `json:"id,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// Codex event item types
+const (
+	ItemTypeFileChange       = "file_change"
+	ItemTypeCommandExecution = "command_execution"
+	ItemTypeAgentMessage     = "agent_message"
+)

--- a/cmd/entire/cli/agent/opencode/opencode.go
+++ b/cmd/entire/cli/agent/opencode/opencode.go
@@ -1,0 +1,192 @@
+// Package opencode implements the Agent interface for OpenCode.
+package opencode
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/sessionid"
+)
+
+//nolint:gochecknoinits // Agent self-registration is the intended pattern
+func init() {
+	agent.Register(agent.AgentNameOpenCode, NewOpenCodeAgent)
+}
+
+// OpenCodeAgent implements the Agent interface for OpenCode.
+//
+//nolint:revive // OpenCodeAgent is clearer than Agent in this context
+type OpenCodeAgent struct{}
+
+// NewOpenCodeAgent creates a new OpenCode agent instance.
+func NewOpenCodeAgent() agent.Agent {
+	return &OpenCodeAgent{}
+}
+
+// Name returns the agent registry key.
+func (o *OpenCodeAgent) Name() agent.AgentName {
+	return agent.AgentNameOpenCode
+}
+
+// Type returns the agent type identifier.
+func (o *OpenCodeAgent) Type() agent.AgentType {
+	return agent.AgentTypeOpenCode
+}
+
+// Description returns a human-readable description.
+func (o *OpenCodeAgent) Description() string {
+	return "OpenCode - Open-source AI coding assistant"
+}
+
+// DetectPresence checks if OpenCode is configured in the repository.
+func (o *OpenCodeAgent) DetectPresence() (bool, error) {
+	// Get repo root to check for .opencode directory
+	// This is needed because the CLI may be run from a subdirectory
+	repoRoot, err := paths.RepoRoot()
+	if err != nil {
+		// Not in a git repo, fall back to CWD-relative check
+		repoRoot = "."
+	}
+
+	// Check for .opencode directory
+	opencodeDir := filepath.Join(repoRoot, ".opencode")
+	if _, err := os.Stat(opencodeDir); err == nil {
+		return true, nil
+	}
+	// Check for opencode.json config file
+	configJSON := filepath.Join(repoRoot, "opencode.json")
+	if _, err := os.Stat(configJSON); err == nil {
+		return true, nil
+	}
+	// Check for opencode.jsonc config file
+	configJSONC := filepath.Join(repoRoot, "opencode.jsonc")
+	if _, err := os.Stat(configJSONC); err == nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+// GetHookConfigPath returns the path to OpenCode's config file.
+// OpenCode does not support lifecycle hooks, so this returns the config file
+// path for reference only.
+func (o *OpenCodeAgent) GetHookConfigPath() string {
+	return "opencode.json"
+}
+
+// SupportsHooks returns false as OpenCode does not support lifecycle hooks.
+func (o *OpenCodeAgent) SupportsHooks() bool {
+	return false
+}
+
+// ParseHookInput returns an error as OpenCode does not support hooks.
+func (o *OpenCodeAgent) ParseHookInput(_ agent.HookType, _ io.Reader) (*agent.HookInput, error) {
+	return nil, errors.New("opencode does not support lifecycle hooks")
+}
+
+// GetSessionID extracts the session ID from hook input.
+func (o *OpenCodeAgent) GetSessionID(input *agent.HookInput) string {
+	return input.SessionID
+}
+
+// TransformSessionID converts an OpenCode session ID to an Entire session ID.
+// This is an identity function - the agent session ID IS the Entire session ID.
+func (o *OpenCodeAgent) TransformSessionID(agentSessionID string) string {
+	return agentSessionID
+}
+
+// ExtractAgentSessionID extracts the OpenCode session ID from an Entire session ID.
+// Since Entire session ID = agent session ID (identity), this returns the input unchanged.
+// For backwards compatibility with legacy date-prefixed IDs, it strips the prefix if present.
+func (o *OpenCodeAgent) ExtractAgentSessionID(entireSessionID string) string {
+	return sessionid.ModelSessionID(entireSessionID)
+}
+
+// ProtectedDirs returns directories that OpenCode uses for config/state.
+func (o *OpenCodeAgent) ProtectedDirs() []string { return []string{".opencode"} }
+
+// GetSessionDir returns the directory where OpenCode stores session data.
+// OpenCode stores sessions in XDG data directory: ~/.local/share/opencode/storage/session/
+func (o *OpenCodeAgent) GetSessionDir(_ string) (string, error) {
+	// Check for test environment override
+	if override := os.Getenv("ENTIRE_TEST_OPENCODE_PROJECT_DIR"); override != "" {
+		return override, nil
+	}
+
+	dataDir := os.Getenv("XDG_DATA_HOME")
+	if dataDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+		dataDir = filepath.Join(homeDir, ".local", "share")
+	}
+
+	return filepath.Join(dataDir, "opencode", "storage", "session"), nil
+}
+
+// ResolveSessionFile returns the path to an OpenCode session file.
+// OpenCode stores session files as <id>.json.
+func (o *OpenCodeAgent) ResolveSessionFile(sessionDir, agentSessionID string) string {
+	return filepath.Join(sessionDir, agentSessionID+".json")
+}
+
+// ReadSession reads a session from OpenCode's storage (JSON session file).
+// The session data is stored in NativeData as raw JSON bytes.
+func (o *OpenCodeAgent) ReadSession(input *agent.HookInput) (*agent.AgentSession, error) {
+	if input.SessionRef == "" {
+		return nil, errors.New("session reference (file path) is required")
+	}
+
+	data, err := os.ReadFile(input.SessionRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session file: %w", err)
+	}
+
+	return &agent.AgentSession{
+		SessionID:  input.SessionID,
+		AgentName:  o.Name(),
+		SessionRef: input.SessionRef,
+		NativeData: data,
+	}, nil
+}
+
+// WriteSession writes a session to OpenCode's storage (JSON session file).
+func (o *OpenCodeAgent) WriteSession(session *agent.AgentSession) error {
+	if session == nil {
+		return errors.New("session is nil")
+	}
+
+	if session.AgentName != "" && session.AgentName != o.Name() {
+		return fmt.Errorf("session belongs to agent %q, not %q", session.AgentName, o.Name())
+	}
+
+	if session.SessionRef == "" {
+		return errors.New("session reference (file path) is required")
+	}
+
+	if len(session.NativeData) == 0 {
+		return errors.New("session has no native data to write")
+	}
+
+	// Validate it's valid JSON before writing
+	if !json.Valid(session.NativeData) {
+		return errors.New("session native data is not valid JSON")
+	}
+
+	if err := os.WriteFile(session.SessionRef, session.NativeData, 0o600); err != nil {
+		return fmt.Errorf("failed to write session file: %w", err)
+	}
+
+	return nil
+}
+
+// FormatResumeCommand returns the command to resume an OpenCode session.
+func (o *OpenCodeAgent) FormatResumeCommand(sessionID string) string {
+	return "opencode run --session " + sessionID
+}

--- a/cmd/entire/cli/agent/opencode/opencode_test.go
+++ b/cmd/entire/cli/agent/opencode/opencode_test.go
@@ -1,0 +1,201 @@
+package opencode
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+func TestNewOpenCodeAgent(t *testing.T) {
+	t.Parallel()
+
+	ag := NewOpenCodeAgent()
+	if ag == nil {
+		t.Fatal("NewOpenCodeAgent() returned nil")
+	}
+
+	oc, ok := ag.(*OpenCodeAgent)
+	if !ok {
+		t.Fatal("NewOpenCodeAgent() didn't return *OpenCodeAgent")
+	}
+	if oc == nil {
+		t.Fatal("NewOpenCodeAgent() returned nil agent")
+	}
+}
+
+func TestName(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	if name := ag.Name(); name != agent.AgentNameOpenCode {
+		t.Errorf("Name() = %q, want %q", name, agent.AgentNameOpenCode)
+	}
+}
+
+func TestType(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	if agType := ag.Type(); agType != agent.AgentTypeOpenCode {
+		t.Errorf("Type() = %q, want %q", agType, agent.AgentTypeOpenCode)
+	}
+}
+
+func TestDescription(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	desc := ag.Description()
+	if desc == "" {
+		t.Error("Description() returned empty string")
+	}
+}
+
+func TestSupportsHooks_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	if ag.SupportsHooks() {
+		t.Error("SupportsHooks() = true, want false")
+	}
+}
+
+func TestParseHookInput_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	_, err := ag.ParseHookInput(agent.HookStop, strings.NewReader("{}"))
+	if err == nil {
+		t.Error("ParseHookInput() should return error for OpenCode")
+	}
+}
+
+func TestDetectPresence(t *testing.T) {
+	t.Run("no .opencode directory", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		ag := &OpenCodeAgent{}
+		present, err := ag.DetectPresence()
+		if err != nil {
+			t.Fatalf("DetectPresence() error = %v", err)
+		}
+		if present {
+			t.Error("DetectPresence() = true, want false")
+		}
+	})
+
+	t.Run("with .opencode directory", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		if err := os.Mkdir(".opencode", 0o755); err != nil {
+			t.Fatalf("failed to create .opencode: %v", err)
+		}
+
+		ag := &OpenCodeAgent{}
+		present, err := ag.DetectPresence()
+		if err != nil {
+			t.Fatalf("DetectPresence() error = %v", err)
+		}
+		if !present {
+			t.Error("DetectPresence() = false, want true")
+		}
+	})
+
+	t.Run("with opencode.json", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		if err := os.WriteFile("opencode.json", []byte(`{}`), 0o600); err != nil {
+			t.Fatalf("failed to create opencode.json: %v", err)
+		}
+
+		ag := &OpenCodeAgent{}
+		present, err := ag.DetectPresence()
+		if err != nil {
+			t.Fatalf("DetectPresence() error = %v", err)
+		}
+		if !present {
+			t.Error("DetectPresence() = false, want true")
+		}
+	})
+
+	t.Run("with opencode.jsonc", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Chdir(tempDir)
+
+		if err := os.WriteFile("opencode.jsonc", []byte(`{}`), 0o600); err != nil {
+			t.Fatalf("failed to create opencode.jsonc: %v", err)
+		}
+
+		ag := &OpenCodeAgent{}
+		present, err := ag.DetectPresence()
+		if err != nil {
+			t.Fatalf("DetectPresence() error = %v", err)
+		}
+		if !present {
+			t.Error("DetectPresence() = false, want true")
+		}
+	})
+}
+
+func TestResolveSessionFile(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	result := ag.ResolveSessionFile("/data/opencode/storage/session", "ses_abc123")
+	expected := "/data/opencode/storage/session/ses_abc123.json"
+	if result != expected {
+		t.Errorf("ResolveSessionFile() = %q, want %q", result, expected)
+	}
+}
+
+func TestProtectedDirs(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	dirs := ag.ProtectedDirs()
+	if len(dirs) != 1 || dirs[0] != ".opencode" {
+		t.Errorf("ProtectedDirs() = %v, want [.opencode]", dirs)
+	}
+}
+
+func TestFormatResumeCommand(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	cmd := ag.FormatResumeCommand("ses_abc123")
+	expected := "opencode run --session ses_abc123"
+	if cmd != expected {
+		t.Errorf("FormatResumeCommand() = %q, want %q", cmd, expected)
+	}
+}
+
+func TestTransformSessionID(t *testing.T) {
+	t.Parallel()
+
+	ag := &OpenCodeAgent{}
+	id := ag.TransformSessionID("ses_abc123")
+	if id != "ses_abc123" {
+		t.Errorf("TransformSessionID() = %q, want %q", id, "ses_abc123")
+	}
+}
+
+func TestGetSessionDir(t *testing.T) {
+	// Not parallel: subtests use t.Setenv which modifies process-global state
+
+	t.Run("with test override", func(t *testing.T) {
+		t.Setenv("ENTIRE_TEST_OPENCODE_PROJECT_DIR", "/tmp/test-opencode")
+		ag := &OpenCodeAgent{}
+		dir, err := ag.GetSessionDir("/some/repo")
+		if err != nil {
+			t.Fatalf("GetSessionDir() error = %v", err)
+		}
+		if dir != "/tmp/test-opencode" {
+			t.Errorf("GetSessionDir() = %q, want %q", dir, "/tmp/test-opencode")
+		}
+	})
+}

--- a/cmd/entire/cli/agent/opencode/types.go
+++ b/cmd/entire/cli/agent/opencode/types.go
@@ -1,0 +1,17 @@
+package opencode
+
+// Tool names used in OpenCode transcripts
+const (
+	ToolWrite      = "Write"
+	ToolEdit       = "Edit"
+	ToolApplyPatch = "ApplyPatch"
+	ToolMultiEdit  = "MultiEdit"
+)
+
+// FileModificationTools lists tools that create or modify files
+var FileModificationTools = []string{
+	ToolWrite,
+	ToolEdit,
+	ToolApplyPatch,
+	ToolMultiEdit,
+}

--- a/cmd/entire/cli/agent/registry.go
+++ b/cmd/entire/cli/agent/registry.go
@@ -79,13 +79,17 @@ type AgentType string
 // Agent name constants (registry keys)
 const (
 	AgentNameClaudeCode AgentName = "claude-code"
+	AgentNameCodex      AgentName = "codex"
 	AgentNameGemini     AgentName = "gemini"
+	AgentNameOpenCode   AgentName = "opencode"
 )
 
 // Agent type constants (type identifiers stored in metadata/trailers)
 const (
 	AgentTypeClaudeCode AgentType = "Claude Code"
+	AgentTypeCodex      AgentType = "Codex CLI"
 	AgentTypeGemini     AgentType = "Gemini CLI"
+	AgentTypeOpenCode   AgentType = "OpenCode"
 	AgentTypeUnknown    AgentType = "Agent" // Fallback for backwards compatibility
 )
 

--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -189,6 +190,15 @@ func init() {
 			return nil
 		}
 		return handleGeminiNotification()
+	})
+
+	// Register Codex CLI handlers
+	RegisterHookHandler(agent.AgentNameCodex, codex.HookNameAgentTurnComplete, func() error {
+		enabled, err := IsEnabled()
+		if err == nil && !enabled {
+			return nil
+		}
+		return handleCodexAgentTurnComplete()
 	})
 }
 

--- a/cmd/entire/cli/hooks_cmd.go
+++ b/cmd/entire/cli/hooks_cmd.go
@@ -4,7 +4,9 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	// Import agents to ensure they are registered before we iterate
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/opencode"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/entire/cli/hooks_codex_handlers.go
+++ b/cmd/entire/cli/hooks_codex_handlers.go
@@ -1,0 +1,252 @@
+// hooks_codex_handlers.go contains Codex CLI specific hook handler implementations.
+// These are called by the hook registry in hook_registry.go.
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+)
+
+// handleCodexAgentTurnComplete handles the agent-turn-complete hook for Codex CLI.
+// This is the only hook Codex supports, firing after each agent turn completes.
+// It is equivalent to Claude Code's "Stop" hook — it commits session changes with metadata.
+func handleCodexAgentTurnComplete() error {
+	ag, err := agent.Get(agent.AgentNameCodex)
+	if err != nil {
+		return fmt.Errorf("failed to get codex agent: %w", err)
+	}
+
+	input, err := ag.ParseHookInput(agent.HookStop, os.Stdin)
+	if err != nil {
+		return fmt.Errorf("failed to parse hook input: %w", err)
+	}
+
+	logCtx := logging.WithAgent(logging.WithComponent(context.Background(), "hooks"), ag.Name())
+	logging.Info(logCtx, "codex-agent-turn-complete",
+		slog.String("hook", "agent-turn-complete"),
+		slog.String("hook_type", "agent"),
+		slog.String("model_session_id", input.SessionID),
+		slog.String("transcript_path", input.SessionRef),
+	)
+
+	sessionID := input.SessionID
+	if sessionID == "" {
+		sessionID = unknownSessionID
+	}
+
+	// Resolve transcript path from session directory
+	transcriptPath := input.SessionRef
+	if transcriptPath != "" && sessionID != unknownSessionID {
+		resolved := ag.ResolveSessionFile(transcriptPath, ag.ExtractAgentSessionID(sessionID))
+		if fileExists(resolved) {
+			transcriptPath = resolved
+		}
+	}
+
+	if transcriptPath == "" || !fileExists(transcriptPath) {
+		return fmt.Errorf("transcript file not found or empty: %s", transcriptPath)
+	}
+
+	// Create session context
+	ctx := &codexSessionContext{
+		sessionID:      sessionID,
+		transcriptPath: transcriptPath,
+	}
+
+	if err := setupCodexSessionDir(ctx); err != nil {
+		return err
+	}
+
+	if err := extractCodexMetadata(ctx); err != nil {
+		return err
+	}
+
+	if err := commitCodexSession(ctx); err != nil {
+		return err
+	}
+
+	// Transition session ACTIVE → IDLE (equivalent to Claude's transitionSessionTurnEnd)
+	transitionSessionTurnEnd(sessionID)
+
+	return nil
+}
+
+// codexSessionContext holds parsed session data for Codex commits.
+type codexSessionContext struct {
+	sessionID      string
+	transcriptPath string
+	sessionDir     string
+	sessionDirAbs  string
+	transcriptData []byte
+	userPrompt     string
+	modifiedFiles  []string
+	commitMessage  string
+}
+
+// setupCodexSessionDir creates session directory and copies transcript.
+func setupCodexSessionDir(ctx *codexSessionContext) error {
+	ctx.sessionDir = paths.SessionMetadataDirFromSessionID(ctx.sessionID)
+	sessionDirAbs, err := paths.AbsPath(ctx.sessionDir)
+	if err != nil {
+		sessionDirAbs = ctx.sessionDir
+	}
+	ctx.sessionDirAbs = sessionDirAbs
+
+	if err := os.MkdirAll(sessionDirAbs, 0o750); err != nil {
+		return fmt.Errorf("failed to create session directory: %w", err)
+	}
+
+	logFile := filepath.Join(sessionDirAbs, paths.TranscriptFileName)
+	if err := copyFile(ctx.transcriptPath, logFile); err != nil {
+		return fmt.Errorf("failed to copy transcript: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Copied transcript to: %s\n", ctx.sessionDir+"/"+paths.TranscriptFileName)
+
+	transcriptData, err := os.ReadFile(ctx.transcriptPath)
+	if err != nil {
+		return fmt.Errorf("failed to read transcript: %w", err)
+	}
+	ctx.transcriptData = transcriptData
+
+	return nil
+}
+
+// extractCodexMetadata extracts prompts, modified files, and commit message from transcript.
+func extractCodexMetadata(ctx *codexSessionContext) error {
+	// Extract modified files from Codex JSONL transcript
+	ctx.modifiedFiles = codex.ExtractModifiedFiles(ctx.transcriptData)
+
+	// Write prompt file (Codex provides user prompt in the notify payload)
+	promptFile := filepath.Join(ctx.sessionDirAbs, paths.PromptFileName)
+	if ctx.userPrompt != "" {
+		if err := os.WriteFile(promptFile, []byte(ctx.userPrompt), 0o600); err != nil {
+			return fmt.Errorf("failed to write prompt file: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Extracted prompt to: %s\n", ctx.sessionDir+"/"+paths.PromptFileName)
+	}
+
+	ctx.commitMessage = generateCommitMessage(ctx.userPrompt)
+	fmt.Fprintf(os.Stderr, "Using commit message: %s\n", ctx.commitMessage)
+
+	return nil
+}
+
+// commitCodexSession commits the session changes using the strategy.
+func commitCodexSession(ctx *codexSessionContext) error {
+	repoRoot, err := paths.RepoRoot()
+	if err != nil {
+		return fmt.Errorf("failed to get repo root: %w", err)
+	}
+
+	preState, err := LoadPrePromptState(ctx.sessionID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to load pre-prompt state: %v\n", err)
+	}
+	if preState != nil {
+		fmt.Fprintf(os.Stderr, "Loaded pre-prompt state: %d pre-existing untracked files\n", len(preState.UntrackedFiles))
+	}
+
+	// Compute new and deleted files (single git status call)
+	changes, err := DetectFileChanges(preState.PreUntrackedFiles())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to compute file changes: %v\n", err)
+	}
+
+	relModifiedFiles := FilterAndNormalizePaths(ctx.modifiedFiles, repoRoot)
+	var relNewFiles, relDeletedFiles []string
+	if changes != nil {
+		relNewFiles = FilterAndNormalizePaths(changes.New, repoRoot)
+		relDeletedFiles = FilterAndNormalizePaths(changes.Deleted, repoRoot)
+	}
+
+	totalChanges := len(relModifiedFiles) + len(relNewFiles) + len(relDeletedFiles)
+	if totalChanges == 0 {
+		fmt.Fprintf(os.Stderr, "No files were modified during this session\n")
+		fmt.Fprintf(os.Stderr, "Skipping commit\n")
+		if cleanupErr := CleanupPrePromptState(ctx.sessionID); cleanupErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to cleanup pre-prompt state: %v\n", cleanupErr)
+		}
+		return nil
+	}
+
+	logFileChanges(relModifiedFiles, relNewFiles, relDeletedFiles)
+
+	// Create context file
+	contextFile := filepath.Join(ctx.sessionDirAbs, paths.ContextFileName)
+	if err := createContextFileForCodex(contextFile, ctx.commitMessage, ctx.sessionID, ctx.userPrompt); err != nil {
+		return fmt.Errorf("failed to create context file: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Created context file: %s\n", ctx.sessionDir+"/"+paths.ContextFileName)
+
+	author, err := GetGitAuthor()
+	if err != nil {
+		return fmt.Errorf("failed to get git author: %w", err)
+	}
+
+	strat := GetStrategy()
+	if err := strat.EnsureSetup(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to ensure strategy setup: %v\n", err)
+	}
+
+	// Get agent type from the hook agent
+	hookAgent, agentErr := GetCurrentHookAgent()
+	if agentErr != nil {
+		return fmt.Errorf("failed to get agent: %w", agentErr)
+	}
+	agentType := hookAgent.Type()
+
+	saveCtx := strategy.SaveContext{
+		SessionID:      ctx.sessionID,
+		ModifiedFiles:  relModifiedFiles,
+		NewFiles:       relNewFiles,
+		DeletedFiles:   relDeletedFiles,
+		MetadataDir:    ctx.sessionDir,
+		MetadataDirAbs: ctx.sessionDirAbs,
+		CommitMessage:  ctx.commitMessage,
+		TranscriptPath: ctx.transcriptPath,
+		AuthorName:     author.Name,
+		AuthorEmail:    author.Email,
+		AgentType:      agentType,
+	}
+
+	if err := strat.SaveChanges(saveCtx); err != nil {
+		return fmt.Errorf("failed to save session: %w", err)
+	}
+
+	if cleanupErr := CleanupPrePromptState(ctx.sessionID); cleanupErr != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to cleanup pre-prompt state: %v\n", cleanupErr)
+	}
+
+	fmt.Fprintf(os.Stderr, "Session saved successfully\n")
+	return nil
+}
+
+// createContextFileForCodex creates a context.md file for Codex sessions.
+func createContextFileForCodex(contextFile, commitMessage, sessionID, prompt string) error {
+	var sb strings.Builder
+
+	sb.WriteString("# Session Context\n\n")
+	sb.WriteString(fmt.Sprintf("Session ID: %s\n", sessionID))
+	sb.WriteString(fmt.Sprintf("Commit Message: %s\n\n", commitMessage))
+
+	if prompt != "" {
+		sb.WriteString("## Prompt\n\n")
+		sb.WriteString(prompt)
+		sb.WriteString("\n")
+	}
+
+	if err := os.WriteFile(contextFile, []byte(sb.String()), 0o600); err != nil {
+		return fmt.Errorf("failed to write context file: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds full agent support for **OpenCode** (open-source AI coding CLI) and **Codex CLI** (OpenAI's CLI agent), including hook-based session checkpointing for both.

### OpenCode Agent
- Detects presence via "$(.opencode/)" directory or "$(opencode.json)"/"$(opencode.jsonc)" config files
- **Hook support via TypeScript plugin system**: installs "$(.opencode/plugins/entire.ts)" that subscribes to "$(session.created)" and "$(session.status)" (idle) events using BunShell
- Session storage in XDG data home ("$(~/.local/share/opencode/storage/session/)")
- File change detection relies on git status (no transcript parsing needed)
- Gracefully handles missing transcript files — continues with git status only

### Codex CLI Agent
- Detects presence via "$(.codex/)" directory
- **Hook support via TOML config**: installs "$(notify)" command in "$(.codex/config.toml)" triggered on "$(agent-turn-complete)"
- JSONL transcript parsing extracts modified files from "$(file_change)" and "$(function_call)" ("$(write_file)", "$(apply_diff)", "$(edit_file)", "$(create_file)") events
- Recursive session file search via "$(filepath.WalkDir)" for date-based directory structure ("$(YYYY/MM/DD/)")
- Implements "$(TranscriptAnalyzer)" and "$(TranscriptChunker)" interfaces for JSONL format

### Hook Handler Integration
- Both agents registered in hook registry with "$(IsEnabled())" guard
- OpenCode: "$(session-created)" → "$(handleSessionStartCommon())", "$(session-idle)" → full session commit flow
- Codex: "$(agent-turn-complete)" → full session commit flow with transcript-based + git-status file detection
- Both agents transition session "$(ACTIVE → IDLE)" on completion via "$(transitionSessionTurnEnd())"

### Bug Fixes (CodeRabbit review)
- **WriteSession parent dir**: both agents now create parent directories before writing session files
- **GetTranscriptPosition off-by-one**: correctly counts final lines without trailing newline
- **ResolveSessionFile**: replaced broken "$(filepath.Glob)" (no "$(**)" support) with "$(filepath.WalkDir)"
- **force=true duplicates**: Codex "$(InstallHooks)" with "$(force=true)" now removes ALL notify lines to prevent duplicate TOML keys
- **userPrompt propagation**: Codex handler now passes "$(input.UserPrompt)" to session context
- **Redundant DetectPresence**: removed second check for "$(.codex/config.toml)" (implied by "$(.codex/)" directory)
- **Code deduplication**: extracted shared "$(extractFilePathFromLine())" helper used by both "$(ExtractModifiedFiles)" and "$(ExtractModifiedFilesFromOffset)"
- **isEntireNotifyLine false positives**: checks for "$("entire")" as standalone quoted TOML element instead of bare substring match
- **FileModificationTools immutability**: changed from mutable "$(var)" slice to function returning new slice
- **Codex rollout types**: updated to match actual format ("$(response_item)", "$(function_call)", "$(local_shell_call)")

## Files Changed

| File | Change |
|------|--------|
| "$(agent/opencode/opencode.go)" | Enable hooks, implement "$(ParseHookInput)", "$(WriteSession)" parent dir |
| "$(agent/opencode/hooks.go)" | **New** — HookSupport/HookHandler, TypeScript plugin generation |
| "$(agent/opencode/types.go)" | "$(pluginPayload)" struct, "$(FileModificationTools())" function |
| "$(agent/opencode/opencode_test.go)" | Hook tests (install/uninstall/idempotent), parse input, presence |
| "$(agent/codex/codex.go)" | 6 bug fixes (WalkDir, off-by-one, dedup, parent dir, DetectPresence) |
| "$(agent/codex/hooks.go)" | Fix force duplicates, "$(isEntireNotifyLine)" false positives |
| "$(agent/codex/types.go)" | Updated rollout types, added function_call constants |
| "$(agent/codex/codex_test.go)" | Tests for all bug fixes + force install + false positives |
| "$(agent/registry.go)" | New "$(AgentNameCodex)"/"$(AgentNameOpenCode)" constants |
| "$(hook_registry.go)" | Register OpenCode + Codex handlers |
| "$(hooks_opencode_handlers.go)" | **New** — session-created, session-idle handlers |
| "$(hooks_codex_handlers.go)" | agent-turn-complete handler, userPrompt fix |
| "$(hooks_cmd.go)" | Blank imports for agent registration |

## Test plan
- [x] "$(mise run fmt)" — all code formatted
- [x] "$(mise run lint)" — 0 issues
- [x] "$(mise run test)" — all packages pass (codex and opencode tests included)
- [x] "$(mise run test:integration)" — integration tests pass
- [ ] Manual: "$(entire enable --agent opencode)" installs "$(.opencode/plugins/entire.ts)"
- [ ] Manual: "$(entire enable --agent codex)" installs notify hook in "$(.codex/config.toml)"
- [ ] Manual: idempotent "$(entire enable --agent opencode && entire enable --agent opencode)"
- [ ] Manual: "$(entire hooks codex agent-turn-complete)" invokes handler
- [ ] Manual: "$(entire hooks opencode session-idle)" invokes handler