### PR TITLE
Add usage examples to command help text

### DIFF
--- a/cmd/entire/cli/clean.go
+++ b/cmd/entire/cli/clean.go
@@ -37,6 +37,11 @@ Default: shows a preview of items that would be deleted.
 With --force, actually deletes the orphaned items.
 
 The entire/checkpoints/v1 branch itself is never deleted.`,
+		Example: `  # Preview orphaned items (dry run)
+  entire clean
+
+  # Delete orphaned items
+  entire clean --force`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runClean(cmd.OutOrStdout(), forceFlag)
 		},

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -38,6 +38,11 @@ For each stuck session, you can choose to:
 
 Use --force to condense all fixable sessions without prompting.  Sessions that can't
 be condensed will be discarded.`,
+		Example: `  # Scan for stuck sessions and fix interactively
+  entire doctor
+
+  # Fix all stuck sessions without prompting
+  entire doctor --force`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runSessionsFix(cmd, forceFlag)
 		},

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -108,6 +108,26 @@ Checkpoint detail view shows:
   - Prompts and responses from the session
 
 Note: --session filters the list view; --commit and --checkpoint are mutually exclusive.`,
+		Example: `  # Show all checkpoints on the current branch
+  entire explain
+
+  # Explain a specific checkpoint in detail
+  entire explain --checkpoint a3b2c4d5e6f7
+
+  # Show summary only (short mode)
+  entire explain --checkpoint a3b2c4d5e6f7 --short
+
+  # Show full session transcript
+  entire explain --checkpoint a3b2c4d5e6f7 --full
+
+  # Explain the checkpoint associated with a commit
+  entire explain --commit HEAD
+
+  # Filter checkpoints by session ID
+  entire explain --session 2026-01-13
+
+  # Generate an AI summary for a checkpoint
+  entire explain --checkpoint a3b2c4d5e6f7 --generate`,
 		Args: func(_ *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return fmt.Errorf("unexpected argument %q\nHint: use --checkpoint, --session, or --commit to specify what to explain", args[0])

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -43,6 +43,11 @@ to fetch it.
 If newer commits without checkpoints exist on the branch (e.g., after merging main
 or cherry-picking from elsewhere), this operation will reset your Git status to the
 most recent commit with a checkpoint.  You'll be prompted to confirm resuming in this case.`,
+		Example: `  # Switch to a branch and resume its session
+  entire resume feature/login
+
+  # Resume from an older checkpoint without confirmation
+  entire resume feature/login --force`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if checkDisabledGuard(cmd.OutOrStdout()) {

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -52,6 +52,20 @@ func newRewindCmd() *cobra.Command {
 This command will show you an interactive list of recent checkpoints.  You'll be
 able to select one for Entire to rewind your branch state, including your code and
 your agent's context.`,
+		Example: `  # Browse checkpoints interactively
+  entire rewind
+
+  # List available rewind points as JSON
+  entire rewind --list
+
+  # Rewind to a specific checkpoint (non-interactive)
+  entire rewind --to abc1234
+
+  # Restore only session logs without changing files
+  entire rewind --to abc1234 --logs-only
+
+  # Reset branch to a committed checkpoint (destructive)
+  entire rewind --to abc1234 --reset`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if Entire is disabled
 			if checkDisabledGuard(cmd.OutOrStdout()) {

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -64,6 +64,20 @@ Uses the manual-commit strategy by default. To use a different strategy:
   entire enable --strategy auto-commit
 
 Strategies: manual-commit (default), auto-commit`,
+		Example: `  # Enable Entire with default settings (interactive)
+  entire enable
+
+  # Enable with a specific strategy
+  entire enable --strategy auto-commit
+
+  # Enable for a specific agent (non-interactive)
+  entire enable --agent claude-code
+
+  # Enable with auto-commit strategy for a specific agent
+  entire enable --strategy auto-commit --agent gemini
+
+  # Force reinstall hooks
+  entire enable --force`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if we're in a git repository first - this is a prerequisite error,
 			// not a usage error, so we silence Cobra's output and use SilentError
@@ -150,6 +164,14 @@ To completely remove Entire integrations from this repository, use --uninstall:
   - Session state files (.git/entire-sessions/)
   - Shadow branches (entire/<hash>)
   - Agent hooks (Claude Code, Gemini CLI)`,
+		Example: `  # Disable Entire (hooks become no-ops)
+  entire disable
+
+  # Completely remove Entire from the repository
+  entire disable --uninstall
+
+  # Uninstall without confirmation prompt
+  entire disable --uninstall --force`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if uninstall {
 				return runUninstall(cmd.OutOrStdout(), cmd.ErrOrStderr(), force)

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -27,6 +27,11 @@ func newStatusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "Show Entire status",
 		Long:  "Show whether Entire is currently enabled or disabled",
+		Example: `  # Show current status
+  entire status
+
+  # Show detailed status for each settings file
+  entire status --detailed`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runStatus(cmd.OutOrStdout(), detailed)
 		},


### PR DESCRIPTION
## Summary
- Adds `Example:` sections to commands missing them: enable, disable, status, rewind, resume, explain, clean, doctor
- Uses consistent style matching existing patterns in the codebase
- Makes `entire <command> --help` more useful for new users

## Test plan
- [x] `gofmt` formatting passes
- [x] `go build ./cmd/entire/...` succeeds
- [x] `go test ./cmd/entire/cli/...` passes (all 22 packages)
- [x] Verified examples render correctly with `entire <command> --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)