### PR TITLE
Clarify --local/--project flags reference .entire/ settings

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -110,8 +110,8 @@ Strategies: manual-commit (default), auto-commit`,
 	cmd.Flags().MarkHidden("local-dev") //nolint:errcheck,gosec // flag is defined above
 	cmd.Flags().BoolVar(&ignoreUntracked, "ignore-untracked", false, "Commit all new files without tracking pre-existing untracked files")
 	cmd.Flags().MarkHidden("ignore-untracked") //nolint:errcheck,gosec // flag is defined above
-	cmd.Flags().BoolVar(&useLocalSettings, "local", false, "Write settings to settings.local.json instead of settings.json")
-	cmd.Flags().BoolVar(&useProjectSettings, "project", false, "Write settings to settings.json even if it already exists")
+	cmd.Flags().BoolVar(&useLocalSettings, "local", false, "Write settings to .entire/settings.local.json instead of .entire/settings.json")
+	cmd.Flags().BoolVar(&useProjectSettings, "project", false, "Write settings to .entire/settings.json even if it already exists")
 	cmd.Flags().StringVar(&agentName, "agent", "", "Agent to setup hooks for (e.g., claude-code). Enables non-interactive mode.")
 	cmd.Flags().StringVar(&strategyFlag, "strategy", "", "Strategy to use (manual-commit or auto-commit)")
 	cmd.Flags().BoolVarP(&forceHooks, "force", "f", false, "Force reinstall hooks (removes existing Entire hooks first)")
@@ -166,7 +166,7 @@ To completely remove Entire integrations from this repository, use --uninstall:
 		},
 	}
 
-	cmd.Flags().BoolVar(&useProjectSettings, "project", false, "Update settings.json instead of settings.local.json")
+	cmd.Flags().BoolVar(&useProjectSettings, "project", false, "Update .entire/settings.json instead of .entire/settings.local.json")
 	cmd.Flags().BoolVar(&uninstall, "uninstall", false, "Completely remove Entire from this repository")
 	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt (use with --uninstall)")
 


### PR DESCRIPTION
## Summary
- Updated `--local` and `--project` flag descriptions on `enable` and `disable` commands to include the `.entire/` prefix, making it clear these flags affect Entire's own settings files, not the agent's settings (e.g., `.claude/settings.json`)

Fixes #279
Fixes #293

## Test plan
- [ ] Run `entire enable --help` and verify `--local` and `--project` descriptions mention `.entire/` paths
- [ ] Run `entire disable --help` and verify `--project` description mentions `.entire/` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)