### PR TITLE
fix: condense checkpoints when agent commits mid-turn

### DIFF
--- a/cmd/entire/cli/integration_test/mid_session_commit_test.go
+++ b/cmd/entire/cli/integration_test/mid_session_commit_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 )
 
@@ -208,5 +209,184 @@ func TestShadowStrategy_AgentCommit_AlwaysGetsTrailer(t *testing.T) {
 		t.Error("Agent commit during ACTIVE session should always get a checkpoint trailer")
 	} else {
 		t.Logf("Agent commit correctly got checkpoint trailer: %s", checkpointID)
+	}
+}
+
+// TestAgentCommitMidTurn_CondensingWithoutSaveChanges tests that when an agent
+// commits mid-turn (before Stop/SaveChanges runs), the PostCommit hook still
+// condenses the session data to entire/checkpoints/v1.
+//
+// This is the fix for #274: previously, StepCount=0 and FilesTouched=[] caused
+// hasNew=false, so no condensation occurred. Now we check TranscriptPath != ""
+// as a signal that the session is properly initialized and has work to condense.
+//
+// Flow:
+//  1. Start session (ACTIVE phase, TranscriptPath set)
+//  2. Agent creates files, writes transcript (NO SaveChanges/Stop)
+//  3. Agent commits mid-turn (no shadow branch exists)
+//  4. Verify: checkpoint trailer added to commit
+//  5. Verify: condensation happened — checkpoint on entire/checkpoints/v1
+//  6. Verify: session stays ACTIVE
+//  7. Agent stops → session transitions to IDLE cleanly
+func TestAgentCommitMidTurn_CondensingWithoutSaveChanges(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t, strategy.StrategyNameManualCommit)
+
+	sess := env.NewSession()
+
+	// Start session with transcript path (needed for mid-turn commit detection)
+	if err := env.SimulateUserPromptSubmitWithTranscriptPath(sess.ID, sess.TranscriptPath); err != nil {
+		t.Fatalf("user-prompt-submit failed: %v", err)
+	}
+
+	// Verify session is ACTIVE with TranscriptPath
+	state, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Session state is nil")
+	}
+	if state.Phase != session.PhaseActive {
+		t.Errorf("Phase should be %q, got %q", session.PhaseActive, state.Phase)
+	}
+	if state.TranscriptPath == "" {
+		t.Fatal("Session state should have TranscriptPath")
+	}
+
+	// Verify NO shadow branch exists (Stop/SaveChanges never called)
+	shadowBranches := env.ListBranchesWithPrefix("entire/")
+	for _, b := range shadowBranches {
+		if b != paths.MetadataBranchName {
+			t.Fatalf("Shadow branch %s should not exist before Stop", b)
+		}
+	}
+
+	// Agent creates a file and writes transcript (simulating Claude working)
+	env.WriteFile("agent_feature.go", "package main\n\nfunc AgentFeature() {}\n")
+	sess.CreateTranscript("Implement the agent feature", []FileChange{
+		{Path: "agent_feature.go", Content: "package main\n\nfunc AgentFeature() {}\n"},
+	})
+
+	// Agent commits mid-turn (as agent, no TTY) — NO Stop/SaveChanges has run
+	headBefore := env.GetHeadHash()
+	env.GitCommitWithShadowHooksAsAgent("Implement agent feature", "agent_feature.go")
+
+	commitHash := env.GetHeadHash()
+	if commitHash == headBefore {
+		t.Fatal("Commit was not created")
+	}
+
+	// Step 4: Verify checkpoint trailer was added
+	checkpointID := env.GetCheckpointIDFromCommitMessage(commitHash)
+	if checkpointID == "" {
+		t.Fatal("Agent mid-turn commit should have Entire-Checkpoint trailer")
+	}
+	t.Logf("Agent mid-turn commit has checkpoint ID: %s", checkpointID)
+
+	// Step 5: CRITICAL — Verify condensation actually happened
+	// This is the core assertion for #274: the checkpoint must exist on entire/checkpoints/v1
+	if !env.BranchExists(paths.MetadataBranchName) {
+		t.Fatal("entire/checkpoints/v1 branch should exist after mid-turn commit condensation")
+	}
+	summaryPath := CheckpointSummaryPath(checkpointID)
+	if !env.FileExistsInBranch(paths.MetadataBranchName, summaryPath) {
+		t.Fatalf("Checkpoint metadata should exist at %s on entire/checkpoints/v1", summaryPath)
+	}
+	t.Logf("Condensation verified: checkpoint %s exists on entire/checkpoints/v1", checkpointID)
+
+	// Verify transcript was condensed
+	transcriptPath := SessionFilePath(checkpointID, "full.jsonl")
+	if !env.FileExistsInBranch(paths.MetadataBranchName, transcriptPath) {
+		t.Error("Transcript should be condensed to entire/checkpoints/v1")
+	}
+
+	// Step 6: Verify session stays ACTIVE after mid-turn commit
+	state, err = env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Session state should exist after commit")
+	}
+	if state.Phase != session.PhaseActive {
+		t.Errorf("Phase after mid-turn commit should stay %q, got %q",
+			session.PhaseActive, state.Phase)
+	}
+
+	// Step 7: Agent stops — session should transition to IDLE cleanly
+	if err := env.SimulateStop(sess.ID, sess.TranscriptPath); err != nil {
+		t.Fatalf("SimulateStop failed: %v", err)
+	}
+
+	state, err = env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Session state should exist after stop")
+	}
+	if state.Phase != session.PhaseIdle {
+		t.Errorf("Phase after stop should be %q, got %q",
+			session.PhaseIdle, state.Phase)
+	}
+	t.Logf("Session transitioned to IDLE cleanly (StepCount: %d)", state.StepCount)
+}
+
+// TestAgentCommitMidTurn_NoCondensationWithoutTranscript tests the safety guard:
+// when TranscriptPath is empty (legacy/edge case), mid-turn commits should NOT
+// trigger condensation even if the session is ACTIVE.
+//
+// This ensures we don't blindly condense sessions that have no transcript data.
+func TestAgentCommitMidTurn_NoCondensationWithoutTranscript(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t, strategy.StrategyNameManualCommit)
+
+	sess := env.NewSession()
+
+	// Start session WITHOUT transcript path (legacy behavior)
+	if err := env.SimulateUserPromptSubmit(sess.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+
+	// Verify session is ACTIVE but has no TranscriptPath
+	state, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if state == nil {
+		t.Fatal("Session state is nil")
+	}
+	if state.Phase != session.PhaseActive {
+		t.Errorf("Phase should be %q, got %q", session.PhaseActive, state.Phase)
+	}
+	if state.TranscriptPath != "" {
+		t.Fatalf("TranscriptPath should be empty for this test, got %q", state.TranscriptPath)
+	}
+
+	// Agent creates a file and commits (no transcript, no shadow branch)
+	env.WriteFile("no_transcript_file.txt", "content without transcript")
+	env.GitCommitWithShadowHooksAsAgent("Commit without transcript", "no_transcript_file.txt")
+
+	commitHash := env.GetHeadHash()
+
+	// The agent commit fast path adds a trailer regardless, but PostCommit
+	// should not condense because there's no transcript data to condense.
+	// Check if condensation happened by looking for checkpoint data.
+	checkpointID := env.GetCheckpointIDFromCommitMessage(commitHash)
+
+	if checkpointID != "" {
+		// Trailer may exist (agent fast path), but condensation should not have
+		// succeeded — no checkpoint data on entire/checkpoints/v1.
+		summaryPath := CheckpointSummaryPath(checkpointID)
+		if env.BranchExists(paths.MetadataBranchName) && env.FileExistsInBranch(paths.MetadataBranchName, summaryPath) {
+			t.Error("Condensation should not produce checkpoint data when TranscriptPath is empty")
+		} else {
+			t.Log("Correctly: trailer exists but no condensed checkpoint data (no transcript)")
+		}
+	} else {
+		t.Log("Correctly: no checkpoint trailer added without transcript")
 	}
 }

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -547,6 +547,13 @@ func (s *ManualCommitStrategy) PostCommit() error {
 			// We only condense if this session actually has work.
 			if state.StepCount > 0 || len(state.FilesTouched) > 0 {
 				hasNew = true
+			} else if state.TranscriptPath != "" {
+				// Agent committed mid-turn before SaveChanges ran.
+				// PrepareCommitMsg already validated this commit is session-related
+				// (added trailer via addTrailerForAgentCommit fast path).
+				// Trust it — the condensation code handles "no shadow branch"
+				// by reading the live transcript directly.
+				hasNew = true
 			} else {
 				// No checkpoints and no tracked files - check the live transcript.
 				// Use sessionHasNewContentInCommittedFiles because staged files are empty


### PR DESCRIPTION
## Summary

- When an agent commits mid-turn (before Stop/SaveChanges fires), StepCount and FilesTouched are both 0, causing PostCommit to skip condensation entirely — no checkpoint is ever created
- Fix: in the PostCommit hook, check TranscriptPath != "" as a signal that the session is properly initialized and has work to condense, falling through to the existing extractSessionDataFromLiveTranscript codepath
- Add integration tests verifying condensation happens (and doesn't happen without a transcript)

Closes #274

## Test plan

- [x] TestAgentCommitMidTurn_CondensingWithoutSaveChanges — full flow: session starts, agent commits mid-turn without SaveChanges, condensation produces checkpoint on entire/checkpoints/v1
- [x] TestAgentCommitMidTurn_NoCondensationWithoutTranscript — safety guard: no condensation when TranscriptPath is empty
- [x] Existing mid-session commit and phase transition tests still pass
- [x] Full test suite passes with race detection

Generated with [Claude Code](https://claude.com/claude-code)