### PR TITLE
feat: Husky v9 hook compatibility

### DIFF
--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -18,6 +18,10 @@ const entireHookMarker = "Entire CLI hooks"
 const backupSuffix = ".pre-entire"
 const chainComment = "# Chain: run pre-existing hook"
 
+// Husky injection markers
+const huskyBeginMarker = "# BEGIN entire"
+const huskyEndMarker = "# END entire"
+
 // gitHookNames are the git hooks managed by Entire CLI
 var gitHookNames = []string{"prepare-commit-msg", "commit-msg", "post-commit", "pre-push"}
 
@@ -110,7 +114,27 @@ func IsGitHookInstalledInDir(repoDir string) bool {
 }
 
 // isGitHookInstalledInHooksDir checks if all hooks are installed in the given hooks directory.
+// When Husky is detected and hooks are installed as injected blocks, it checks the
+// user-editable .husky/<hookname> files. Otherwise falls through to standard check.
 func isGitHookInstalledInHooksDir(hooksDir string) bool {
+	// When Husky is detected, check user-facing hook files for injected blocks
+	if huskyUserDir := getHuskyUserHooksDir(hooksDir); huskyUserDir != "" {
+		if hasHuskyInjectedHooks(huskyUserDir) {
+			for _, hook := range gitHookNames {
+				hookPath := filepath.Join(huskyUserDir, hook)
+				data, err := os.ReadFile(hookPath) //nolint:gosec // Path is constructed from constants
+				if err != nil {
+					return false
+				}
+				if extractEntireBlock(string(data)) == "" {
+					return false
+				}
+			}
+			return true
+		}
+	}
+
+	// Standard check: look for standalone hook files with our marker
 	for _, hook := range gitHookNames {
 		hookPath := filepath.Join(hooksDir, hook)
 		data, err := os.ReadFile(hookPath) //nolint:gosec // Path is constructed from constants
@@ -166,14 +190,14 @@ func buildHookSpecs(cmdPrefix string) []hookSpec {
 // These hooks work with any strategy - the strategy is determined at runtime.
 // If silent is true, no output is printed (except backup notifications, which always print).
 // Returns the number of hooks that were installed (0 if all already up to date).
+//
+// When Husky v9 is detected (core.hooksPath points to .husky/_), hooks are injected
+// into the user-editable .husky/<hookname> files instead of writing standalone hooks
+// into .husky/_/. This ensures hooks survive `npm install` which regenerates .husky/_/.
 func InstallGitHook(silent bool) (int, error) {
 	hooksDir, err := GetHooksDir()
 	if err != nil {
 		return 0, err
-	}
-
-	if err := os.MkdirAll(hooksDir, 0o755); err != nil { //nolint:gosec // Git hooks require executable permissions
-		return 0, fmt.Errorf("failed to create hooks directory: %w", err)
 	}
 
 	// Determine command prefix based on local_dev setting
@@ -182,6 +206,20 @@ func InstallGitHook(silent bool) (int, error) {
 		cmdPrefix = "go run ./cmd/entire/main.go"
 	} else {
 		cmdPrefix = "entire"
+	}
+
+	// Check for Husky v9: core.hooksPath resolves to .husky/_
+	if huskyUserDir := getHuskyUserHooksDir(hooksDir); huskyUserDir != "" {
+		return installHuskyHooks(hooksDir, huskyUserDir, cmdPrefix, silent)
+	}
+
+	return installStandardHooks(hooksDir, cmdPrefix, silent)
+}
+
+// installStandardHooks installs standalone git hooks into the hooks directory.
+func installStandardHooks(hooksDir, cmdPrefix string, silent bool) (int, error) {
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil { //nolint:gosec // Git hooks require executable permissions
+		return 0, fmt.Errorf("failed to create hooks directory: %w", err)
 	}
 
 	specs := buildHookSpecs(cmdPrefix)
@@ -246,7 +284,8 @@ func writeHookFile(path, content string) (bool, error) {
 }
 
 // RemoveGitHook removes all Entire CLI git hooks from the repository.
-// If a .pre-entire backup exists, it is restored.
+// For standard hooks: removes hook files and restores .pre-entire backups.
+// For Husky hooks: strips BEGIN/END entire blocks from .husky/<hookname> files.
 // Returns the number of hooks removed.
 func RemoveGitHook() (int, error) {
 	hooksDir, err := GetHooksDir()
@@ -254,6 +293,19 @@ func RemoveGitHook() (int, error) {
 		return 0, err
 	}
 
+	// When Husky is detected and hooks are actually installed as Husky injections,
+	// strip blocks from user-facing hook files.
+	if huskyUserDir := getHuskyUserHooksDir(hooksDir); huskyUserDir != "" {
+		if hasHuskyInjectedHooks(huskyUserDir) {
+			return removeHuskyHooks(huskyUserDir)
+		}
+	}
+
+	return removeStandardHooks(hooksDir)
+}
+
+// removeStandardHooks removes standalone Entire hook files and restores backups.
+func removeStandardHooks(hooksDir string) (int, error) {
 	removed := 0
 	var removeErrors []string
 
@@ -302,6 +354,237 @@ if [ -x "$_entire_hook_dir/%s%s" ]; then
     "$_entire_hook_dir/%s%s" "$@"
 fi
 `, chainComment, hookName, backupSuffix, hookName, backupSuffix)
+}
+
+// isHuskyHooksPath returns true if the given hooks directory is managed by Husky v9.
+// Husky v9 sets core.hooksPath to .husky/_, so we detect it by path suffix.
+func isHuskyHooksPath(hooksDir string) bool {
+	cleaned := filepath.Clean(hooksDir)
+	return filepath.Base(filepath.Dir(cleaned)) == ".husky" && filepath.Base(cleaned) == "_"
+}
+
+// getHuskyUserHooksDir returns the Husky user-editable hooks directory (.husky/)
+// from the Husky generated hooks directory (.husky/_), or empty string if not a Husky path
+// or if the .husky/ directory doesn't exist on disk.
+func getHuskyUserHooksDir(hooksDir string) string {
+	if !isHuskyHooksPath(hooksDir) {
+		return ""
+	}
+	// .husky/_  →  .husky/
+	userDir := filepath.Dir(filepath.Clean(hooksDir))
+	if !fileExists(userDir) {
+		return ""
+	}
+	return userDir
+}
+
+// hasHuskyInjectedHooks returns true if any Husky user hook files contain an Entire block.
+func hasHuskyInjectedHooks(huskyUserDir string) bool {
+	for _, hook := range gitHookNames {
+		hookPath := filepath.Join(huskyUserDir, hook)
+		data, err := os.ReadFile(hookPath) //nolint:gosec // path is controlled
+		if err != nil {
+			continue
+		}
+		if extractEntireBlock(string(data)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// huskyInjectionSpec defines hook content to inject into Husky user-facing hook files.
+type huskyInjectionSpec struct {
+	name    string
+	content string // content between BEGIN/END markers (without markers themselves)
+}
+
+// buildHuskyInjectionSpecs returns injection specifications for all managed hooks.
+// The content does not include a shebang — Husky v9 user scripts run in the wrapper's shell context.
+func buildHuskyInjectionSpecs(cmdPrefix string) []huskyInjectionSpec {
+	return []huskyInjectionSpec{
+		{
+			name:    "prepare-commit-msg",
+			content: fmt.Sprintf("# %s\n%s hooks git prepare-commit-msg \"$1\" \"$2\" 2>/dev/null || true", entireHookMarker, cmdPrefix),
+		},
+		{
+			name:    "commit-msg",
+			content: fmt.Sprintf("# %s\n# Commit-msg hook: strip trailer if no user content (allows aborting empty commits)\n%s hooks git commit-msg \"$1\" || exit 1", entireHookMarker, cmdPrefix),
+		},
+		{
+			name:    "post-commit",
+			content: fmt.Sprintf("# %s\n# Post-commit hook: condense session data if commit has Entire-Checkpoint trailer\n%s hooks git post-commit 2>/dev/null || true", entireHookMarker, cmdPrefix),
+		},
+		{
+			name:    "pre-push",
+			content: fmt.Sprintf("# %s\n# Pre-push hook: push session logs alongside user's push\n# $1 is the remote name (e.g., \"origin\")\n%s hooks git pre-push \"$1\" || true", entireHookMarker, cmdPrefix),
+		},
+	}
+}
+
+// extractEntireBlock returns the BEGIN/END entire block from content (inclusive of markers),
+// or empty string if not found.
+func extractEntireBlock(content string) string {
+	beginIdx := strings.Index(content, huskyBeginMarker)
+	if beginIdx == -1 {
+		return ""
+	}
+	endIdx := strings.Index(content, huskyEndMarker)
+	if endIdx == -1 {
+		return ""
+	}
+	return content[beginIdx : endIdx+len(huskyEndMarker)]
+}
+
+// replaceEntireBlock replaces an existing BEGIN/END entire block with newBlock.
+// If no existing block is found, returns the original content unchanged.
+func replaceEntireBlock(content, newBlock string) string {
+	existing := extractEntireBlock(content)
+	if existing == "" {
+		return content
+	}
+	return strings.Replace(content, existing, newBlock, 1)
+}
+
+// buildEntireBlock wraps injection content in BEGIN/END markers.
+func buildEntireBlock(injectionContent string) string {
+	return huskyBeginMarker + "\n" + injectionContent + "\n" + huskyEndMarker
+}
+
+// injectHuskyHookContent injects or updates an Entire block in a hook file's content.
+// If the file has no existing block, the block is appended.
+// If the file already has a block, it is replaced.
+// Returns the new file content.
+func injectHuskyHookContent(existingContent, injectionContent string) string {
+	block := buildEntireBlock(injectionContent)
+
+	if extractEntireBlock(existingContent) != "" {
+		return replaceEntireBlock(existingContent, block)
+	}
+
+	// Append to existing content
+	if existingContent == "" {
+		return block + "\n"
+	}
+	// Ensure a newline before the block
+	if !strings.HasSuffix(existingContent, "\n") {
+		existingContent += "\n"
+	}
+	return existingContent + block + "\n"
+}
+
+// removeEntireBlock strips the BEGIN/END entire block from content.
+// Returns the cleaned content with the block removed.
+func removeEntireBlock(content string) string {
+	existing := extractEntireBlock(content)
+	if existing == "" {
+		return content
+	}
+	result := strings.Replace(content, existing, "", 1)
+	// Clean up extra blank lines that may result from removal
+	result = strings.TrimRight(result, "\n")
+	if result != "" {
+		result += "\n"
+	}
+	return result
+}
+
+// installHuskyHooks injects Entire hook commands into Husky user-facing hook files (.husky/<hookname>).
+// It also cleans up any stale standalone hooks in .husky/_/ from previous installations.
+func installHuskyHooks(hooksDir, huskyUserDir, cmdPrefix string, silent bool) (int, error) {
+	specs := buildHuskyInjectionSpecs(cmdPrefix)
+	installedCount := 0
+
+	for _, spec := range specs {
+		userHookPath := filepath.Join(huskyUserDir, spec.name)
+		block := buildEntireBlock(spec.content)
+
+		var existingContent string
+		data, err := os.ReadFile(userHookPath) //nolint:gosec // path is controlled
+		if err == nil {
+			existingContent = string(data)
+		}
+
+		// Check if already has our block with same content
+		if existingBlock := extractEntireBlock(existingContent); existingBlock == block {
+			// Already up to date — still clean up stale hooks
+			cleanUpStaleHuskyHook(hooksDir, spec.name)
+			continue
+		}
+
+		newContent := injectHuskyHookContent(existingContent, spec.content)
+
+		if err := os.WriteFile(userHookPath, []byte(newContent), 0o755); err != nil { //nolint:gosec // Hook files need executable permissions
+			return installedCount, fmt.Errorf("failed to inject %s into Husky hook: %w", spec.name, err)
+		}
+		installedCount++
+
+		// Clean up stale standalone hook in .husky/_/ to prevent double execution
+		cleanUpStaleHuskyHook(hooksDir, spec.name)
+	}
+
+	if !silent {
+		fmt.Println("✓ Installed git hooks into Husky user hooks (prepare-commit-msg, commit-msg, post-commit, pre-push)")
+		fmt.Println("  Hooks injected into .husky/ hook files (survives npm install)")
+	}
+
+	return installedCount, nil
+}
+
+// cleanUpStaleHuskyHook removes a stale standalone Entire hook from .husky/_/ if it exists.
+func cleanUpStaleHuskyHook(generatedHooksDir, hookName string) {
+	hookPath := filepath.Join(generatedHooksDir, hookName)
+	data, err := os.ReadFile(hookPath) //nolint:gosec // path is controlled
+	if err != nil {
+		return
+	}
+	if strings.Contains(string(data), entireHookMarker) {
+		_ = os.Remove(hookPath)
+	}
+}
+
+// removeHuskyHooks strips Entire blocks from Husky user-facing hook files (.husky/<hookname>).
+// If a file becomes empty after removal, it is deleted.
+// Returns the number of hooks removed.
+func removeHuskyHooks(huskyUserDir string) (int, error) {
+	removed := 0
+	var removeErrors []string
+
+	for _, hook := range gitHookNames {
+		userHookPath := filepath.Join(huskyUserDir, hook)
+		data, err := os.ReadFile(userHookPath) //nolint:gosec // path is controlled
+		if err != nil {
+			continue // File doesn't exist, nothing to remove
+		}
+
+		content := string(data)
+		if extractEntireBlock(content) == "" {
+			continue // No Entire block in this file
+		}
+
+		cleaned := removeEntireBlock(content)
+		cleaned = strings.TrimSpace(cleaned)
+
+		if cleaned == "" {
+			// File is empty after removing our block — delete it
+			if err := os.Remove(userHookPath); err != nil {
+				removeErrors = append(removeErrors, fmt.Sprintf("%s: %v", hook, err))
+				continue
+			}
+		} else {
+			// Write back the file without our block
+			if err := os.WriteFile(userHookPath, []byte(cleaned+"\n"), 0o755); err != nil { //nolint:gosec // Hook files need executable permissions
+				removeErrors = append(removeErrors, fmt.Sprintf("%s: %v", hook, err))
+				continue
+			}
+		}
+		removed++
+	}
+
+	if len(removeErrors) > 0 {
+		return removed, fmt.Errorf("failed to remove Husky hooks: %s", strings.Join(removeErrors, "; "))
+	}
+	return removed, nil
 }
 
 // isLocalDev reads the local_dev setting from .entire/settings.json

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -1175,6 +1175,435 @@ func TestRemoveGitHook_DoesNotOverwriteReplacedHook(t *testing.T) {
 	}
 }
 
+// --- Husky v9 tests ---
+
+// initHuskyTestRepo creates a temporary git repository with Husky-style core.hooksPath
+// pointing to .husky/_. Both .husky/ and .husky/_/ directories are created on disk.
+// Returns the repo dir, the generated hooks dir (.husky/_), and the user hooks dir (.husky/).
+func initHuskyTestRepo(t *testing.T) (string, string, string) {
+	t.Helper()
+	tmpDir, _ := initHooksTestRepo(t)
+
+	huskyDir := filepath.Join(tmpDir, ".husky")
+	generatedDir := filepath.Join(huskyDir, "_")
+	if err := os.MkdirAll(generatedDir, 0o755); err != nil {
+		t.Fatalf("failed to create .husky/_: %v", err)
+	}
+
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, "git", "config", "core.hooksPath", ".husky/_")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set core.hooksPath: %v", err)
+	}
+
+	return tmpDir, generatedDir, huskyDir
+}
+
+func TestIsHuskyHooksPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/repo/.husky/_", true},
+		{"/repo/.husky/_/", true},
+		{".husky/_", true},
+		{"/repo/.git/hooks", false},
+		{"/repo/.husky", false},
+		{"/repo/husky/_", false},
+		{"/repo/.husky/_/nested", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if got := isHuskyHooksPath(tt.path); got != tt.want {
+			t.Errorf("isHuskyHooksPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestGetHuskyUserHooksDir(t *testing.T) {
+	t.Parallel()
+
+	// Non-Husky path should return empty
+	if got := getHuskyUserHooksDir("/some/path/.git/hooks"); got != "" {
+		t.Errorf("getHuskyUserHooksDir(non-husky) = %q, want empty", got)
+	}
+
+	// Create a real .husky/ directory
+	tmpDir := t.TempDir()
+	huskyDir := filepath.Join(tmpDir, ".husky")
+	generatedDir := filepath.Join(huskyDir, "_")
+	if err := os.MkdirAll(generatedDir, 0o755); err != nil {
+		t.Fatalf("failed to create dirs: %v", err)
+	}
+
+	got := getHuskyUserHooksDir(generatedDir)
+	if got != huskyDir {
+		t.Errorf("getHuskyUserHooksDir(%q) = %q, want %q", generatedDir, got, huskyDir)
+	}
+}
+
+func TestGetHuskyUserHooksDir_DirNotExists(t *testing.T) {
+	t.Parallel()
+
+	// .husky/_ path but .husky/ doesn't exist on disk
+	if got := getHuskyUserHooksDir("/nonexistent/.husky/_"); got != "" {
+		t.Errorf("getHuskyUserHooksDir(missing dir) = %q, want empty", got)
+	}
+}
+
+func TestInstallGitHook_HuskyDetected(t *testing.T) {
+	tmpDir, generatedDir, huskyDir := initHuskyTestRepo(t)
+
+	count, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+	if count == 0 {
+		t.Fatal("InstallGitHook() should install hooks")
+	}
+
+	// Hooks should be injected into .husky/<hookname>, not .husky/_/<hookname>
+	for _, hook := range gitHookNames {
+		userHookPath := filepath.Join(huskyDir, hook)
+		data, err := os.ReadFile(userHookPath)
+		if err != nil {
+			t.Fatalf("expected user hook %s to exist: %v", hook, err)
+		}
+		content := string(data)
+		if !strings.Contains(content, huskyBeginMarker) {
+			t.Errorf("user hook %s should contain BEGIN marker", hook)
+		}
+		if !strings.Contains(content, huskyEndMarker) {
+			t.Errorf("user hook %s should contain END marker", hook)
+		}
+		if !strings.Contains(content, entireHookMarker) {
+			t.Errorf("user hook %s should contain Entire CLI marker", hook)
+		}
+		// Should NOT have a shebang (Husky user scripts don't need one)
+		if strings.Contains(content, "#!/bin/sh") {
+			t.Errorf("user hook %s should not have a shebang", hook)
+		}
+
+		// Should NOT have standalone hooks in .husky/_/
+		generatedHookPath := filepath.Join(generatedDir, hook)
+		if _, statErr := os.Stat(generatedHookPath); !os.IsNotExist(statErr) {
+			t.Errorf("generated hook %s should not exist in .husky/_/", hook)
+		}
+	}
+
+	if !IsGitHookInstalledInDir(tmpDir) {
+		t.Error("IsGitHookInstalledInDir() should detect Husky-injected hooks")
+	}
+}
+
+func TestInstallGitHook_HuskyIdempotent(t *testing.T) {
+	initHuskyTestRepo(t)
+
+	// First install
+	firstCount, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("first InstallGitHook() error = %v", err)
+	}
+	if firstCount == 0 {
+		t.Fatal("first install should install hooks")
+	}
+
+	// Second install should return 0 (all already up to date)
+	secondCount, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("second InstallGitHook() error = %v", err)
+	}
+	if secondCount != 0 {
+		t.Errorf("second InstallGitHook() = %d, want 0 (idempotent)", secondCount)
+	}
+}
+
+func TestInstallGitHook_HuskyExistingContent(t *testing.T) {
+	_, _, huskyDir := initHuskyTestRepo(t)
+
+	// Create existing user hook content
+	userContent := "npm test\nlint-staged\n"
+	hookPath := filepath.Join(huskyDir, "pre-push")
+	if err := os.WriteFile(hookPath, []byte(userContent), 0o755); err != nil {
+		t.Fatalf("failed to create user hook: %v", err)
+	}
+
+	_, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+
+	data, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("hook should exist: %v", err)
+	}
+	content := string(data)
+
+	// User content should be preserved
+	if !strings.Contains(content, "npm test") {
+		t.Error("user content 'npm test' should be preserved")
+	}
+	if !strings.Contains(content, "lint-staged") {
+		t.Error("user content 'lint-staged' should be preserved")
+	}
+
+	// Entire block should be appended
+	if !strings.Contains(content, huskyBeginMarker) {
+		t.Error("should contain BEGIN marker")
+	}
+	if !strings.Contains(content, huskyEndMarker) {
+		t.Error("should contain END marker")
+	}
+
+	// User content should come before Entire block
+	userIdx := strings.Index(content, "npm test")
+	entireIdx := strings.Index(content, huskyBeginMarker)
+	if userIdx > entireIdx {
+		t.Error("user content should come before Entire block")
+	}
+}
+
+func TestInstallGitHook_HuskyUpdateBlock(t *testing.T) {
+	_, _, huskyDir := initHuskyTestRepo(t)
+
+	// Pre-populate with an old version of the block
+	hookPath := filepath.Join(huskyDir, "prepare-commit-msg")
+	oldContent := "npm test\n# BEGIN entire\n# old stuff\n# END entire\n"
+	if err := os.WriteFile(hookPath, []byte(oldContent), 0o755); err != nil {
+		t.Fatalf("failed to create hook: %v", err)
+	}
+
+	count, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+	if count == 0 {
+		t.Error("should update the outdated block")
+	}
+
+	data, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("hook should exist: %v", err)
+	}
+	content := string(data)
+
+	// Old content should be replaced
+	if strings.Contains(content, "# old stuff") {
+		t.Error("old block content should be replaced")
+	}
+
+	// New block should be present
+	if !strings.Contains(content, entireHookMarker) {
+		t.Error("new block should contain Entire CLI marker")
+	}
+
+	// User content should be preserved
+	if !strings.Contains(content, "npm test") {
+		t.Error("user content should be preserved")
+	}
+
+	// Should have exactly one BEGIN/END pair
+	if strings.Count(content, huskyBeginMarker) != 1 {
+		t.Errorf("should have exactly one BEGIN marker, got %d", strings.Count(content, huskyBeginMarker))
+	}
+}
+
+func TestRemoveGitHook_Husky(t *testing.T) {
+	tmpDir, _, huskyDir := initHuskyTestRepo(t)
+
+	// Install hooks
+	_, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+
+	// Remove hooks
+	removed, err := RemoveGitHook()
+	if err != nil {
+		t.Fatalf("RemoveGitHook() error = %v", err)
+	}
+	if removed != len(gitHookNames) {
+		t.Errorf("RemoveGitHook() = %d, want %d", removed, len(gitHookNames))
+	}
+
+	// Hook files should be deleted (they only had Entire content)
+	for _, hook := range gitHookNames {
+		hookPath := filepath.Join(huskyDir, hook)
+		if _, statErr := os.Stat(hookPath); !os.IsNotExist(statErr) {
+			t.Errorf("hook %s should be deleted after removal", hook)
+		}
+	}
+
+	if IsGitHookInstalledInDir(tmpDir) {
+		t.Error("IsGitHookInstalledInDir() should be false after removal")
+	}
+}
+
+func TestRemoveGitHook_HuskyPreservesUserContent(t *testing.T) {
+	_, _, huskyDir := initHuskyTestRepo(t)
+
+	// Create existing user hook content, then install
+	hookPath := filepath.Join(huskyDir, "pre-push")
+	userContent := "npm test\nlint-staged\n"
+	if err := os.WriteFile(hookPath, []byte(userContent), 0o755); err != nil {
+		t.Fatalf("failed to create user hook: %v", err)
+	}
+
+	_, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+
+	// Verify block was injected
+	data, readErr := os.ReadFile(hookPath)
+	if readErr != nil {
+		t.Fatalf("failed to read hook: %v", readErr)
+	}
+	if !strings.Contains(string(data), huskyBeginMarker) {
+		t.Fatal("setup: block should be injected before removal test")
+	}
+
+	// Remove hooks
+	_, err = RemoveGitHook()
+	if err != nil {
+		t.Fatalf("RemoveGitHook() error = %v", err)
+	}
+
+	// User content should survive
+	data, err = os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatal("hook file should still exist (user content present)")
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "npm test") {
+		t.Error("user content 'npm test' should be preserved after removal")
+	}
+	if !strings.Contains(content, "lint-staged") {
+		t.Error("user content 'lint-staged' should be preserved after removal")
+	}
+
+	// Entire block should be gone
+	if strings.Contains(content, huskyBeginMarker) {
+		t.Error("BEGIN marker should be removed")
+	}
+	if strings.Contains(content, huskyEndMarker) {
+		t.Error("END marker should be removed")
+	}
+}
+
+func TestIsGitHookInstalled_Husky(t *testing.T) {
+	tmpDir, _, huskyDir := initHuskyTestRepo(t)
+
+	// Before install: should not be detected
+	if IsGitHookInstalledInDir(tmpDir) {
+		t.Error("should not be installed before install")
+	}
+
+	// Install
+	_, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+
+	// After install: should be detected
+	if !IsGitHookInstalledInDir(tmpDir) {
+		t.Error("should be installed after install")
+	}
+
+	// Remove one hook's block to simulate partial installation
+	hookPath := filepath.Join(huskyDir, "post-commit")
+	if err := os.Remove(hookPath); err != nil {
+		t.Fatalf("failed to remove hook: %v", err)
+	}
+
+	// Partial installation: should not be detected
+	if IsGitHookInstalledInDir(tmpDir) {
+		t.Error("should not be detected with partial installation")
+	}
+}
+
+func TestInstallGitHook_HuskyDirNotExists(t *testing.T) {
+	tmpDir, _ := initHooksTestRepo(t)
+
+	// Set core.hooksPath to .husky/_ but don't create .husky/ on disk
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, "git", "config", "core.hooksPath", ".husky/_")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set core.hooksPath: %v", err)
+	}
+
+	// Should fall back to standard install (creates .husky/_/ directory)
+	count, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+	if count == 0 {
+		t.Fatal("should install hooks via standard path")
+	}
+
+	// Hooks should be standalone files in .husky/_/
+	generatedDir := filepath.Join(tmpDir, ".husky", "_")
+	for _, hook := range gitHookNames {
+		hookPath := filepath.Join(generatedDir, hook)
+		data, readErr := os.ReadFile(hookPath)
+		if readErr != nil {
+			t.Fatalf("expected standalone hook %s in .husky/_/: %v", hook, readErr)
+		}
+		// Should be a standalone hook with shebang
+		if !strings.Contains(string(data), "#!/bin/sh") {
+			t.Errorf("standalone hook %s should have shebang", hook)
+		}
+		if !strings.Contains(string(data), entireHookMarker) {
+			t.Errorf("standalone hook %s should contain Entire marker", hook)
+		}
+	}
+}
+
+func TestInstallGitHook_HuskyCleansUpGenerated(t *testing.T) {
+	_, generatedDir, huskyDir := initHuskyTestRepo(t)
+
+	// Simulate stale standalone hooks in .husky/_/ (from PR #355 behavior)
+	for _, hook := range gitHookNames {
+		staleContent := "#!/bin/sh\n# " + entireHookMarker + "\nentire hooks git " + hook + "\n"
+		stalePath := filepath.Join(generatedDir, hook)
+		if err := os.WriteFile(stalePath, []byte(staleContent), 0o755); err != nil {
+			t.Fatalf("failed to create stale hook %s: %v", hook, err)
+		}
+	}
+
+	// Install with Husky detection
+	_, err := InstallGitHook(true)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+
+	// Stale hooks in .husky/_/ should be cleaned up
+	for _, hook := range gitHookNames {
+		stalePath := filepath.Join(generatedDir, hook)
+		if _, statErr := os.Stat(stalePath); !os.IsNotExist(statErr) {
+			t.Errorf("stale hook %s should be cleaned up from .husky/_/", hook)
+		}
+	}
+
+	// User hooks should be installed in .husky/
+	for _, hook := range gitHookNames {
+		userHookPath := filepath.Join(huskyDir, hook)
+		data, readErr := os.ReadFile(userHookPath)
+		if readErr != nil {
+			t.Fatalf("expected user hook %s: %v", hook, readErr)
+		}
+		if !strings.Contains(string(data), huskyBeginMarker) {
+			t.Errorf("user hook %s should contain BEGIN marker", hook)
+		}
+	}
+}
+
 func TestRemoveGitHook_PermissionDenied(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("Test cannot run as root (permission checks are bypassed)")


### PR DESCRIPTION
## Summary

- When Husky v9 is detected (`core.hooksPath` → `.husky/_`), inject Entire's hook commands into `.husky/<hookname>` user-editable files instead of `.husky/_/`
- User-facing Husky files are committed to the repo and survive `npm install` (which regenerates `.husky/_/`)
- Falls back to standard standalone hook installation when `.husky/` directory doesn't exist on disk
- Cleans up stale standalone hooks in `.husky/_/` left by prior installations (PR #355)

Closes #228

## Test plan

- [x] `TestIsHuskyHooksPath` — detection with various path patterns
- [x] `TestGetHuskyUserHooksDir` — derives `.husky/` from `.husky/_`
- [x] `TestInstallGitHook_HuskyDetected` — injects into `.husky/<hookname>`, not `.husky/_/`
- [x] `TestInstallGitHook_HuskyIdempotent` — second install returns 0
- [x] `TestInstallGitHook_HuskyExistingContent` — preserves user content, appends block
- [x] `TestInstallGitHook_HuskyUpdateBlock` — replaces existing block on re-install
- [x] `TestRemoveGitHook_Husky` — strips blocks, removes empty files
- [x] `TestRemoveGitHook_HuskyPreservesUserContent` — user content survives removal
- [x] `TestIsGitHookInstalled_Husky` — detection works with injected blocks
- [x] `TestInstallGitHook_HuskyDirNotExists` — falls back to standard install
- [x] `TestInstallGitHook_HuskyCleansUpGenerated` — removes stale `.husky/_/` hooks
- [x] All existing hooks tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)