### PR TITLE
Add IsPreview() to Agent interface

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -30,6 +30,9 @@ type Agent interface {
 	// Description returns a human-readable description for UI
 	Description() string
 
+	// IsPreview returns whether the agent integration is in preview or stable
+	IsPreview() bool
+
 	// DetectPresence checks if this agent is configured in the repository
 	DetectPresence() (bool, error)
 

--- a/cmd/entire/cli/agent/agent_test.go
+++ b/cmd/entire/cli/agent/agent_test.go
@@ -16,6 +16,7 @@ var _ Agent = (*mockAgent)(nil) // Compile-time interface check
 func (m *mockAgent) Name() AgentName               { return mockAgentName }
 func (m *mockAgent) Type() AgentType               { return mockAgentType }
 func (m *mockAgent) Description() string           { return "Mock agent for testing" }
+func (m *mockAgent) IsPreview() bool               { return false }
 func (m *mockAgent) DetectPresence() (bool, error) { return false, nil }
 func (m *mockAgent) GetHookConfigPath() string     { return "" }
 func (m *mockAgent) SupportsHooks() bool           { return false }

--- a/cmd/entire/cli/agent/claudecode/claude.go
+++ b/cmd/entire/cli/agent/claudecode/claude.go
@@ -47,6 +47,8 @@ func (c *ClaudeCodeAgent) Description() string {
 	return "Claude Code - Anthropic's CLI coding assistant"
 }
 
+func (c *ClaudeCodeAgent) IsPreview() bool { return false }
+
 // DetectPresence checks if Claude Code is configured in the repository.
 func (c *ClaudeCodeAgent) DetectPresence() (bool, error) {
 	// Get repo root to check for .claude directory

--- a/cmd/entire/cli/agent/geminicli/gemini.go
+++ b/cmd/entire/cli/agent/geminicli/gemini.go
@@ -47,6 +47,8 @@ func (g *GeminiCLIAgent) Description() string {
 	return "Gemini CLI - Google's AI coding assistant"
 }
 
+func (g *GeminiCLIAgent) IsPreview() bool { return true }
+
 // DetectPresence checks if Gemini CLI is configured in the repository.
 func (g *GeminiCLIAgent) DetectPresence() (bool, error) {
 	// Get repo root to check for .gemini directory

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -29,6 +29,7 @@ var _ agent.Agent = (*mockLifecycleAgent)(nil)
 func (m *mockLifecycleAgent) Name() agent.AgentName                  { return m.name }
 func (m *mockLifecycleAgent) Type() agent.AgentType                  { return m.agentType }
 func (m *mockLifecycleAgent) Description() string                    { return "Mock agent for lifecycle tests" }
+func (m *mockLifecycleAgent) IsPreview() bool                        { return false }
 func (m *mockLifecycleAgent) DetectPresence() (bool, error)          { return false, nil }
 func (m *mockLifecycleAgent) GetHookConfigPath() string              { return "" }
 func (m *mockLifecycleAgent) SupportsHooks() bool                    { return true }

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -763,13 +763,13 @@ func setupAgentHooksNonInteractive(w io.Writer, ag agent.Agent, strategyName str
 
 	if installedHooks == 0 {
 		msg := fmt.Sprintf("Hooks for %s already installed", ag.Description())
-		if agentName == agent.AgentNameGemini {
+		if ag.IsPreview() {
 			msg += " (Preview)"
 		}
 		fmt.Fprintf(w, "%s\n", msg)
 	} else {
 		msg := fmt.Sprintf("Installed %d hooks for %s", installedHooks, ag.Description())
-		if agentName == agent.AgentNameGemini {
+		if ag.IsPreview() {
 			msg += " (Preview)"
 		}
 		fmt.Fprintf(w, "%s\n", msg)


### PR DESCRIPTION
## Summary
- Adds `IsPreview() bool` method to the `Agent` interface
- Implements it on all agents: Claude Code (`false`), Gemini CLI (`true`)
- Replaces hardcoded `agentName == agent.AgentNameGemini` checks in `setup.go` with `ag.IsPreview()`
- New agents can now declare preview status via the interface instead of requiring changes to setup logic

## Test plan
- [x] All existing tests pass (`mise run test:ci`)
- [x] Lint passes (`mise run lint`)
- [x] Mock agents in tests updated with `IsPreview()` implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)