### PR TITLE
Fix integration tests hanging on machines with a TTY

### DIFF
--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -108,6 +108,7 @@ func (env *TestEnv) cliEnv() []string {
 	return append(os.Environ(),
 		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir,
 		"ENTIRE_TEST_GEMINI_PROJECT_DIR="+env.GeminiProjectDir,
+		"ENTIRE_TEST_TTY=0", // Prevent interactive prompts from blocking in tests
 	)
 }
 


### PR DESCRIPTION
## Summary

- After #404 moved `detectOrSelectAgent` to the command handler, integration tests calling `entire enable --strategy` now hit the interactive agent selection form when a real TTY is available, causing hangs
- Sets `ENTIRE_TEST_TTY=0` in `cliEnv()` so all CLI subprocesses skip the TTY check by default
- Tests that need TTY simulation (hook tests) already override this per-subprocess with `ENTIRE_TEST_TTY=1`

## Test plan

- [x] `mise run fmt && mise run lint` passes
- [x] `mise run test:ci` passes (unit + integration)
- [x] Verified all `ENTIRE_TEST_TTY=1` usages are on per-subprocess env, not via `cliEnv()`

🤖 Generated with [Claude Code](https://claude.ai/code)