### PR TITLE
Remove unused GetHookConfigPath from Agent interface

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -69,9 +69,6 @@ type Agent interface {
 
 	// --- Legacy methods (will move to optional interfaces in Phase 4) ---
 
-	// GetHookConfigPath returns path to hook config file (empty if none).
-	GetHookConfigPath() string
-
 	// SupportsHooks returns true if agent supports lifecycle hooks.
 	SupportsHooks() bool
 

--- a/cmd/entire/cli/agent/agent_test.go
+++ b/cmd/entire/cli/agent/agent_test.go
@@ -18,7 +18,6 @@ func (m *mockAgent) Type() AgentType               { return mockAgentType }
 func (m *mockAgent) Description() string           { return "Mock agent for testing" }
 func (m *mockAgent) IsPreview() bool               { return false }
 func (m *mockAgent) DetectPresence() (bool, error) { return false, nil }
-func (m *mockAgent) GetHookConfigPath() string     { return "" }
 func (m *mockAgent) SupportsHooks() bool           { return false }
 
 //nolint:nilnil // Mock implementation

--- a/cmd/entire/cli/agent/claudecode/claude.go
+++ b/cmd/entire/cli/agent/claudecode/claude.go
@@ -72,11 +72,6 @@ func (c *ClaudeCodeAgent) DetectPresence() (bool, error) {
 	return false, nil
 }
 
-// GetHookConfigPath returns the path to Claude's hook config file.
-func (c *ClaudeCodeAgent) GetHookConfigPath() string {
-	return ".claude/settings.json"
-}
-
 // SupportsHooks returns true as Claude Code supports lifecycle hooks.
 func (c *ClaudeCodeAgent) SupportsHooks() bool {
 	return true

--- a/cmd/entire/cli/agent/geminicli/gemini.go
+++ b/cmd/entire/cli/agent/geminicli/gemini.go
@@ -73,11 +73,6 @@ func (g *GeminiCLIAgent) DetectPresence() (bool, error) {
 	return false, nil
 }
 
-// GetHookConfigPath returns the path to Gemini's hook config file.
-func (g *GeminiCLIAgent) GetHookConfigPath() string {
-	return ".gemini/settings.json"
-}
-
 // SupportsHooks returns true as Gemini CLI supports lifecycle hooks.
 func (g *GeminiCLIAgent) SupportsHooks() bool {
 	return true

--- a/cmd/entire/cli/agent/geminicli/gemini_test.go
+++ b/cmd/entire/cli/agent/geminicli/gemini_test.go
@@ -80,14 +80,6 @@ func TestDetectPresence(t *testing.T) {
 	})
 }
 
-func TestGetHookConfigPath(t *testing.T) {
-	ag := &GeminiCLIAgent{}
-	path := ag.GetHookConfigPath()
-	if path != ".gemini/settings.json" {
-		t.Errorf("GetHookConfigPath() = %q, want .gemini/settings.json", path)
-	}
-}
-
 func TestSupportsHooks(t *testing.T) {
 	ag := &GeminiCLIAgent{}
 	if !ag.SupportsHooks() {

--- a/cmd/entire/cli/integration_test/agent_test.go
+++ b/cmd/entire/cli/integration_test/agent_test.go
@@ -817,14 +817,4 @@ func TestGeminiCLIHelperMethods(t *testing.T) {
 		}
 	})
 
-	t.Run("GetHookConfigPath returns .gemini/settings.json", func(t *testing.T) {
-		t.Parallel()
-
-		ag, _ := agent.Get("gemini")
-		path := ag.GetHookConfigPath()
-
-		if path != ".gemini/settings.json" {
-			t.Errorf("GetHookConfigPath() = %q, want %q", path, ".gemini/settings.json")
-		}
-	})
 }

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -31,7 +31,6 @@ func (m *mockLifecycleAgent) Type() agent.AgentType                  { return m.
 func (m *mockLifecycleAgent) Description() string                    { return "Mock agent for lifecycle tests" }
 func (m *mockLifecycleAgent) IsPreview() bool                        { return false }
 func (m *mockLifecycleAgent) DetectPresence() (bool, error)          { return false, nil }
-func (m *mockLifecycleAgent) GetHookConfigPath() string              { return "" }
 func (m *mockLifecycleAgent) SupportsHooks() bool                    { return true }
 func (m *mockLifecycleAgent) ProtectedDirs() []string                { return nil }
 func (m *mockLifecycleAgent) HookNames() []string                    { return nil }


### PR DESCRIPTION
## Summary
- Removes `GetHookConfigPath()` from the `Agent` interface — it was never called in production code
- Removes implementations from Claude Code and Gemini CLI agents
- Removes associated tests and mock implementations

related to  #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)