### PR TITLE
fix: handle camelCase filePath keys and session-state agent type for OpenCode

### DIFF
--- a/cmd/entire/cli/agent/opencode/transcript.go
+++ b/cmd/entire/cli/agent/opencode/transcript.go
@@ -139,8 +139,10 @@ func ExtractModifiedFiles(data []byte) ([]string, error) {
 }
 
 // extractFilePathFromInput extracts the file path from a tool's input map.
+// OpenCode tools use camelCase keys (filePath) while the Go convention is snake_case (file_path).
+// Check both to handle current and future key naming.
 func extractFilePathFromInput(input map[string]interface{}) string {
-	for _, key := range []string{"file_path", "path", "file", "filename"} {
+	for _, key := range []string{"filePath", "file_path", "path", "file", "filename"} {
 		if v, ok := input[key]; ok {
 			if s, ok := v.(string); ok && s != "" {
 				return s

--- a/cmd/entire/cli/agent/opencode/transcript_test.go
+++ b/cmd/entire/cli/agent/opencode/transcript_test.go
@@ -400,6 +400,50 @@ func TestExtractModifiedFiles(t *testing.T) {
 	}
 }
 
+// testTranscriptCamelCaseJSONL uses camelCase "filePath" keys (as produced by OpenCode SDK)
+// instead of snake_case "file_path". Both should be handled by extractFilePathFromInput.
+const testTranscriptCamelCaseJSONL = `{"id":"msg-1","role":"user","content":"Fix the bug","time":{"created":1708300000}}
+{"id":"msg-2","role":"assistant","content":"Fixing.","time":{"created":1708300001,"completed":1708300005},"tokens":{"input":100,"output":50,"reasoning":0,"cache":{"read":0,"write":0}},"cost":0.001,"parts":[{"type":"tool","tool":"edit","callID":"call-1","state":{"status":"completed","input":{"filePath":"src/app.ts"},"output":"Applied edit"}},{"type":"tool","tool":"write","callID":"call-2","state":{"status":"completed","input":{"filePath":"src/new.ts"},"output":"File written"}}]}
+`
+
+func TestExtractModifiedFiles_CamelCaseFilePath(t *testing.T) {
+	t.Parallel()
+
+	files, err := ExtractModifiedFiles([]byte(testTranscriptCamelCaseJSONL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files from camelCase filePath, got %d: %v", len(files), files)
+	}
+	if files[0] != "src/app.ts" {
+		t.Errorf("expected first file 'src/app.ts', got %q", files[0])
+	}
+	if files[1] != "src/new.ts" {
+		t.Errorf("expected second file 'src/new.ts', got %q", files[1])
+	}
+}
+
+func TestExtractModifiedFilesFromOffset_CamelCaseFilePath(t *testing.T) {
+	t.Parallel()
+	ag := &OpenCodeAgent{}
+	path := writeTestTranscript(t, testTranscriptCamelCaseJSONL)
+
+	files, pos, err := ag.ExtractModifiedFilesFromOffset(path, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pos != 2 {
+		t.Errorf("expected position 2, got %d", pos)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files from camelCase filePath, got %d: %v", len(files), files)
+	}
+	if files[0] != "src/app.ts" {
+		t.Errorf("expected first file 'src/app.ts', got %q", files[0])
+	}
+}
+
 // Compile-time interface checks are in transcript.go.
 // Verify the unused import guard by referencing the agent package.
 var _ = agent.AgentNameOpenCode

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -387,8 +387,16 @@ func explainTemporaryCheckpoint(w io.Writer, repo *git.Repository, store *checkp
 		return "", false
 	}
 
-	// Read agent type from shadow branch metadata (stored during checkpoint creation)
-	agentType := strategy.ReadAgentTypeFromTree(shadowTree, tc.MetadataDir)
+	// Read agent type: prefer session state (authoritative) over tree heuristic.
+	// Tree-based detection is ambiguous when a repo has multiple agent config dirs
+	// (e.g., both .claude/ and .opencode/).
+	agentType := agent.AgentTypeUnknown
+	if sessionState, stateErr := strategy.LoadSessionState(tc.SessionID); stateErr == nil && sessionState != nil && sessionState.AgentType != "" {
+		agentType = sessionState.AgentType
+	}
+	if agentType == agent.AgentTypeUnknown || agentType == "" {
+		agentType = strategy.ReadAgentTypeFromTree(shadowTree, tc.MetadataDir)
+	}
 
 	// Handle raw transcript output
 	if rawTranscript {


### PR DESCRIPTION
## Summary

Two bugs remain in the OpenCode integration after the recent agent architecture refactor (PR #415):

1. **`extractFilePathFromInput` misses camelCase `filePath` key** — OpenCode SDK serializes tool input with camelCase keys (`filePath`), but the extractor only checked snake_case (`file_path`). This caused modified files to be invisible during transcript synthesis, leading to empty file lists in checkpoints.

2. **`explainTemporaryCheckpoint` misidentifies agent type via tree heuristic** — When a repo contains both `.claude/` and `.opencode/` directories, `ReadAgentTypeFromTree` can pick the wrong agent. The session state's `AgentType` (set authoritatively at session creation) should be preferred, falling back to tree detection only when unavailable.

## Changes

- **`transcript.go`**: Add `"filePath"` (camelCase) to the key list in `extractFilePathFromInput`, checked before `"file_path"` since it's the primary key used by the OpenCode SDK.
- **`transcript_test.go`**: Add two tests (`TestExtractModifiedFiles_CamelCaseFilePath`, `TestExtractModifiedFilesFromOffset_CamelCaseFilePath`) that verify camelCase `filePath` keys are correctly extracted.
- **`explain.go`**: In `explainTemporaryCheckpoint`, load session state first and use its `AgentType` if available. Only fall back to `ReadAgentTypeFromTree` when session state is missing or has an unknown agent type.

## Testing

- All 30 OpenCode unit tests pass (including 2 new tests)
- `go build ./...` clean
- Verified end-to-end with a live OpenCode session: agent type correctly identified as `OpenCode`, full transcript synthesized with correct file list