### PR TITLE
Make git hooks a noop if entire is not enabled in the repo

### DIFF
--- a/cmd/entire/cli/hook_registry_test.go
+++ b/cmd/entire/cli/hook_registry_test.go
@@ -60,6 +60,12 @@ func TestNewAgentHookVerbCmd_LogsInvocation(t *testing.T) {
 		t.Fatalf("failed to create .entire directory: %v", err)
 	}
 
+	// Create settings.json to indicate Entire is set up in this repo
+	settingsFile := filepath.Join(entireDir, "settings.json")
+	if err := os.WriteFile(settingsFile, []byte(`{"enabled":true,"strategy":"manual-commit"}`), 0o644); err != nil {
+		t.Fatalf("failed to create settings file: %v", err)
+	}
+
 	// Create logs directory
 	logsDir := filepath.Join(entireDir, "logs")
 	if err := os.MkdirAll(logsDir, 0o755); err != nil {

--- a/cmd/entire/cli/hooks_git_cmd_test.go
+++ b/cmd/entire/cli/hooks_git_cmd_test.go
@@ -28,6 +28,16 @@ func TestInitHookLogging(t *testing.T) {
 	}
 
 	t.Run("returns cleanup func when no session state exists", func(t *testing.T) {
+		// Create settings.json to indicate Entire is set up
+		entireDir := filepath.Join(tmpDir, paths.EntireDir)
+		if err := os.MkdirAll(entireDir, 0o755); err != nil {
+			t.Fatalf("failed to create .entire directory: %v", err)
+		}
+		settingsFile := filepath.Join(entireDir, "settings.json")
+		if err := os.WriteFile(settingsFile, []byte(`{"enabled":true}`), 0o644); err != nil {
+			t.Fatalf("failed to create settings file: %v", err)
+		}
+
 		cleanup := initHookLogging()
 		if cleanup == nil {
 			t.Fatal("expected cleanup function, got nil")
@@ -40,6 +50,12 @@ func TestInitHookLogging(t *testing.T) {
 		entireDir := filepath.Join(tmpDir, paths.EntireDir)
 		if err := os.MkdirAll(entireDir, 0o755); err != nil {
 			t.Fatalf("failed to create .entire directory: %v", err)
+		}
+
+		// Create settings.json to indicate Entire is set up in this repo
+		settingsFile := filepath.Join(entireDir, "settings.json")
+		if err := os.WriteFile(settingsFile, []byte(`{"enabled":true,"strategy":"manual-commit"}`), 0o644); err != nil {
+			t.Fatalf("failed to create settings file: %v", err)
 		}
 
 		// Create session state file in .git/entire-sessions/
@@ -84,4 +100,70 @@ func TestInitHookLogging(t *testing.T) {
 			t.Errorf("expected log file to be created at %s", logFile)
 		}
 	})
+}
+
+// TestInitHookLogging_SkipsWhenNotSetUp tests that initHookLogging() does not
+// create .entire/logs/ in repos where Entire has not been set up.
+// This is a separate test because it needs its own t.Chdir() to a different directory.
+func TestInitHookLogging_SkipsWhenNotSetUp(t *testing.T) {
+	// Create a temp directory without .entire/settings.json
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	// Initialize git repo
+	gitInit := exec.CommandContext(context.Background(), "git", "init")
+	gitInit.Dir = tmpDir
+	if err := gitInit.Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+
+	// Do NOT create .entire/settings.json - simulating a repo where Entire is not set up
+
+	cleanup := initHookLogging()
+	if cleanup == nil {
+		t.Fatal("expected cleanup function, got nil")
+	}
+	cleanup() // Should not panic
+
+	// Verify .entire/logs was NOT created
+	logsDir := filepath.Join(tmpDir, ".entire", "logs")
+	if _, err := os.Stat(logsDir); !os.IsNotExist(err) {
+		t.Errorf("expected .entire/logs to NOT be created when Entire is not set up, but it exists")
+	}
+}
+
+// TestInitHookLogging_SkipsWhenDisabled tests that initHookLogging() does not
+// create .entire/logs/ when Entire is set up but disabled.
+func TestInitHookLogging_SkipsWhenDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	// Initialize git repo
+	gitInit := exec.CommandContext(context.Background(), "git", "init")
+	gitInit.Dir = tmpDir
+	if err := gitInit.Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+
+	// Create .entire/settings.json with enabled: false
+	entireDir := filepath.Join(tmpDir, paths.EntireDir)
+	if err := os.MkdirAll(entireDir, 0o755); err != nil {
+		t.Fatalf("failed to create .entire directory: %v", err)
+	}
+	settingsFile := filepath.Join(entireDir, "settings.json")
+	if err := os.WriteFile(settingsFile, []byte(`{"enabled":false,"strategy":"manual-commit"}`), 0o644); err != nil {
+		t.Fatalf("failed to create settings file: %v", err)
+	}
+
+	cleanup := initHookLogging()
+	if cleanup == nil {
+		t.Fatal("expected cleanup function, got nil")
+	}
+	cleanup() // Should not panic
+
+	// Verify .entire/logs was NOT created
+	logsDir := filepath.Join(tmpDir, ".entire", "logs")
+	if _, err := os.Stat(logsDir); !os.IsNotExist(err) {
+		t.Errorf("expected .entire/logs to NOT be created when Entire is disabled, but it exists")
+	}
 }

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -213,6 +213,32 @@ func applyDefaults(settings *EntireSettings) {
 	}
 }
 
+// IsSetUp returns true if Entire has been set up in the current repository.
+// This checks if .entire/settings.json exists.
+// Use this to avoid creating files/directories in repos where Entire was never enabled.
+func IsSetUp() bool {
+	settingsFileAbs, err := paths.AbsPath(EntireSettingsFile)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(settingsFileAbs)
+	return err == nil
+}
+
+// IsSetUpAndEnabled returns true if Entire is both set up and enabled.
+// This checks if .entire/settings.json exists AND has enabled: true.
+// Use this for hooks that should be no-ops when Entire is not active.
+func IsSetUpAndEnabled() bool {
+	if !IsSetUp() {
+		return false
+	}
+	s, err := Load()
+	if err != nil {
+		return false
+	}
+	return s.Enabled
+}
+
 // IsSummarizeEnabled checks if auto-summarize is enabled in settings.
 // Returns false by default if settings cannot be loaded or the key is missing.
 func IsSummarizeEnabled() bool {


### PR DESCRIPTION
In the case of git hooks being installed but entire not enabled in the repository this will make any git hook call a noop. 

https://github.com/entireio/cli/issues/460