### PR TITLE
refactor: CalculateTokenUsage accepts bytes instead of file path

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -165,8 +165,8 @@ type TranscriptPreparer interface {
 type TokenCalculator interface {
 	Agent
 
-	// CalculateTokenUsage computes token usage from the transcript starting at the given offset.
-	CalculateTokenUsage(sessionRef string, fromOffset int) (*TokenUsage, error)
+	// CalculateTokenUsage computes token usage from the transcript bytes starting at the given offset.
+	CalculateTokenUsage(data []byte, fromOffset int) (*TokenUsage, error)
 }
 
 // SubagentAwareExtractor provides methods for extracting files and tokens including subagents.

--- a/cmd/entire/cli/agent/claudecode/lifecycle.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle.go
@@ -128,13 +128,16 @@ func (c *ClaudeCodeAgent) PrepareTranscript(sessionRef string) error {
 	return nil
 }
 
-// CalculateTokenUsage computes token usage from the transcript starting at the given line offset.
-func (c *ClaudeCodeAgent) CalculateTokenUsage(sessionRef string, fromOffset int) (*agent.TokenUsage, error) {
-	// Subagent transcripts live in <transcriptDir>/<sessionID>/subagents/
-	// but we don't have the sessionID here. The caller should pass the transcript path
-	// which may contain the session ID in its directory structure.
-	// For now, compute subagentsDir from the transcript path structure.
-	return CalculateTotalTokenUsage(sessionRef, fromOffset, "")
+// CalculateTokenUsage computes token usage from the transcript bytes starting at the given line offset.
+func (c *ClaudeCodeAgent) CalculateTokenUsage(data []byte, fromOffset int) (*agent.TokenUsage, error) {
+	lines, err := transcript.ParseFromBytes(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse transcript: %w", err)
+	}
+	if fromOffset > 0 && fromOffset < len(lines) {
+		lines = lines[fromOffset:]
+	}
+	return CalculateTokenUsage(lines), nil
 }
 
 // --- Internal hook parsing functions ---

--- a/cmd/entire/cli/agent/geminicli/lifecycle.go
+++ b/cmd/entire/cli/agent/geminicli/lifecycle.go
@@ -96,11 +96,6 @@ func (g *GeminiCLIAgent) ExtractSummary(sessionRef string) (string, error) {
 	return ExtractLastAssistantMessage(data)
 }
 
-// CalculateTokenUsage computes token usage from the transcript starting at the given message offset.
-func (g *GeminiCLIAgent) CalculateTokenUsage(sessionRef string, fromOffset int) (*agent.TokenUsage, error) {
-	return CalculateTokenUsageFromFile(sessionRef, fromOffset)
-}
-
 // --- Internal hook parsing functions ---
 
 func (g *GeminiCLIAgent) parseSessionStart(stdin io.Reader) (*agent.Event, error) {

--- a/cmd/entire/cli/agent/geminicli/transcript.go
+++ b/cmd/entire/cli/agent/geminicli/transcript.go
@@ -296,13 +296,14 @@ func SliceFromMessage(data []byte, startMessageIndex int) ([]byte, error) {
 // This is specific to Gemini's API format where each message may have a tokens object
 // with input, output, cached, thoughts, tool, and total counts.
 // Only processes messages from startMessageIndex onwards (0-indexed).
-func CalculateTokenUsage(data []byte, startMessageIndex int) *agent.TokenUsage {
+// CalculateTokenUsage computes token usage from the transcript bytes starting at the given message offset.
+func (g *GeminiCLIAgent) CalculateTokenUsage(data []byte, startMessageIndex int) (*agent.TokenUsage, error) {
 	var transcript struct {
 		Messages []geminiMessageWithTokens `json:"messages"`
 	}
 
 	if err := json.Unmarshal(data, &transcript); err != nil {
-		return &agent.TokenUsage{}
+		return &agent.TokenUsage{}, err
 	}
 
 	usage := &agent.TokenUsage{}
@@ -328,23 +329,5 @@ func CalculateTokenUsage(data []byte, startMessageIndex int) *agent.TokenUsage {
 		usage.CacheReadTokens += msg.Tokens.Cached
 	}
 
-	return usage
-}
-
-// CalculateTokenUsageFromFile calculates token usage from a Gemini transcript file.
-// If startMessageIndex > 0, only considers messages from that index onwards.
-func CalculateTokenUsageFromFile(path string, startMessageIndex int) (*agent.TokenUsage, error) {
-	if path == "" {
-		return &agent.TokenUsage{}, nil
-	}
-
-	data, err := os.ReadFile(path) //nolint:gosec // Reading from controlled transcript path
-	if err != nil {
-		if os.IsNotExist(err) {
-			return &agent.TokenUsage{}, nil
-		}
-		return nil, fmt.Errorf("failed to read transcript: %w", err)
-	}
-
-	return CalculateTokenUsage(data, startMessageIndex), nil
+	return usage, nil
 }

--- a/cmd/entire/cli/agent/geminicli/transcript_test.go
+++ b/cmd/entire/cli/agent/geminicli/transcript_test.go
@@ -616,7 +616,11 @@ func TestCalculateTokenUsage_BasicMessages(t *testing.T) {
   ]
 }`)
 
-	usage := CalculateTokenUsage(data, 0)
+	ag := &GeminiCLIAgent{}
+	usage, err := ag.CalculateTokenUsage(data, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Should have 2 API calls (2 gemini messages)
 	if usage.APICallCount != 2 {
@@ -653,7 +657,11 @@ func TestCalculateTokenUsage_StartIndex(t *testing.T) {
 }`)
 
 	// Start from index 2 - should only count the last gemini message
-	usage := CalculateTokenUsage(data, 2)
+	ag := &GeminiCLIAgent{}
+	usage, err := ag.CalculateTokenUsage(data, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Should have 1 API call (only the gemini message at index 3)
 	if usage.APICallCount != 1 {
@@ -685,7 +693,11 @@ func TestCalculateTokenUsage_IgnoresUserMessages(t *testing.T) {
   ]
 }`)
 
-	usage := CalculateTokenUsage(data, 0)
+	ag := &GeminiCLIAgent{}
+	usage, err := ag.CalculateTokenUsage(data, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Should only count gemini message tokens
 	if usage.APICallCount != 1 {
@@ -705,7 +717,11 @@ func TestCalculateTokenUsage_EmptyTranscript(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`{"messages": []}`)
-	usage := CalculateTokenUsage(data, 0)
+	ag := &GeminiCLIAgent{}
+	usage, err := ag.CalculateTokenUsage(data, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if usage.APICallCount != 0 {
 		t.Errorf("APICallCount = %d, want 0", usage.APICallCount)
@@ -725,7 +741,11 @@ func TestCalculateTokenUsage_InvalidJSON(t *testing.T) {
 	t.Parallel()
 
 	data := []byte(`not valid json`)
-	usage := CalculateTokenUsage(data, 0)
+	ag := &GeminiCLIAgent{}
+	usage, err := ag.CalculateTokenUsage(data, 0)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
 
 	// Should return empty usage on parse error
 	if usage.APICallCount != 0 {
@@ -744,7 +764,11 @@ func TestCalculateTokenUsage_MissingTokensField(t *testing.T) {
   ]
 }`)
 
-	usage := CalculateTokenUsage(data, 0)
+	ag := &GeminiCLIAgent{}
+	usage, err := ag.CalculateTokenUsage(data, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// No tokens to count
 	if usage.APICallCount != 0 {

--- a/cmd/entire/cli/agent/opencode/transcript.go
+++ b/cmd/entire/cli/agent/opencode/transcript.go
@@ -292,31 +292,7 @@ func CalculateTokenUsageFromBytes(data []byte, startMessageIndex int) *agent.Tok
 	return usage
 }
 
-// CalculateTokenUsage computes token usage from assistant messages starting at the given offset.
-func (a *OpenCodeAgent) CalculateTokenUsage(sessionRef string, fromOffset int) (*agent.TokenUsage, error) {
-	session, err := parseExportSessionFromFile(sessionRef)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil //nolint:nilnil // nil usage for nonexistent file is expected
-		}
-		return nil, fmt.Errorf("failed to parse transcript for token usage: %w", err)
-	}
-	if session == nil {
-		return nil, nil //nolint:nilnil // nil usage for empty file is expected
-	}
-
-	usage := &agent.TokenUsage{}
-	for i := fromOffset; i < len(session.Messages); i++ {
-		msg := session.Messages[i]
-		if msg.Info.Role != roleAssistant || msg.Info.Tokens == nil {
-			continue
-		}
-		usage.InputTokens += msg.Info.Tokens.Input
-		usage.OutputTokens += msg.Info.Tokens.Output
-		usage.CacheReadTokens += msg.Info.Tokens.Cache.Read
-		usage.CacheCreationTokens += msg.Info.Tokens.Cache.Write
-		usage.APICallCount++
-	}
-
-	return usage, nil
+// CalculateTokenUsage computes token usage from the transcript bytes starting at the given message offset.
+func (a *OpenCodeAgent) CalculateTokenUsage(data []byte, fromOffset int) (*agent.TokenUsage, error) {
+	return CalculateTokenUsageFromBytes(data, fromOffset), nil
 }

--- a/cmd/entire/cli/agent/opencode/transcript_test.go
+++ b/cmd/entire/cli/agent/opencode/transcript_test.go
@@ -341,10 +341,9 @@ func TestExtractSummary_EmptyTranscript(t *testing.T) {
 func TestCalculateTokenUsage(t *testing.T) {
 	t.Parallel()
 	ag := &OpenCodeAgent{}
-	path := writeTestTranscript(t, testExportJSON)
 
 	// From offset 0 — both assistant messages
-	usage, err := ag.CalculateTokenUsage(path, 0)
+	usage, err := ag.CalculateTokenUsage([]byte(testExportJSON), 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -371,9 +370,8 @@ func TestCalculateTokenUsage(t *testing.T) {
 func TestCalculateTokenUsage_FromOffset(t *testing.T) {
 	t.Parallel()
 	ag := &OpenCodeAgent{}
-	path := writeTestTranscript(t, testExportJSON)
 
-	usage, err := ag.CalculateTokenUsage(path, 2)
+	usage, err := ag.CalculateTokenUsage([]byte(testExportJSON), 2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -388,16 +386,24 @@ func TestCalculateTokenUsage_FromOffset(t *testing.T) {
 	}
 }
 
-func TestCalculateTokenUsage_NonexistentFile(t *testing.T) {
+func TestCalculateTokenUsage_EmptyData(t *testing.T) {
 	t.Parallel()
 	ag := &OpenCodeAgent{}
 
-	usage, err := ag.CalculateTokenUsage("/nonexistent/path.json", 0)
+	usage, err := ag.CalculateTokenUsage(nil, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if usage != nil {
-		t.Errorf("expected nil usage for nonexistent file, got %+v", usage)
+	if usage.InputTokens != 0 || usage.OutputTokens != 0 || usage.APICallCount != 0 {
+		t.Errorf("expected zero usage for nil data, got %+v", usage)
+	}
+
+	usage, err = ag.CalculateTokenUsage([]byte{}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.InputTokens != 0 || usage.OutputTokens != 0 || usage.APICallCount != 0 {
+		t.Errorf("expected zero usage for empty data, got %+v", usage)
 	}
 }
 

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -356,7 +356,7 @@ func handleLifecycleTurnEnd(ag agent.Agent, event *agent.Event) error {
 		}
 	} else if calculator, ok := ag.(agent.TokenCalculator); ok {
 		// Fall back to basic token calculation (main transcript only)
-		usage, tokenErr := calculator.CalculateTokenUsage(transcriptRef, transcriptLinesAtStart)
+		usage, tokenErr := calculator.CalculateTokenUsage(transcriptData, transcriptLinesAtStart)
 		if tokenErr != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to calculate token usage: %v\n", tokenErr)
 		} else {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
-	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
 	"github.com/entireio/cli/cmd/entire/cli/agent/opencode"
 	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -599,36 +598,19 @@ func calculateTokenUsage(agentType agent.AgentType, data []byte, startOffset int
 	if len(data) == 0 {
 		return &agent.TokenUsage{}
 	}
-
-	// OpenCode uses JSONL with token info on assistant messages (different schema from Claude Code)
-	if agentType == agent.AgentTypeOpenCode {
-		return opencode.CalculateTokenUsageFromBytes(data, startOffset)
-	}
-
-	// Try Gemini format first if agentType is Gemini, or as fallback if Unknown
-	if agentType == agent.AgentTypeGemini || agentType == agent.AgentTypeUnknown {
-		// Attempt to parse as Gemini JSON
-		transcript, err := geminicli.ParseTranscript(data)
-		if err == nil && transcript != nil && len(transcript.Messages) > 0 {
-			return geminicli.CalculateTokenUsage(data, startOffset)
-		}
-		// If agentType is explicitly Gemini but parsing failed, return empty usage
-		if agentType == agent.AgentTypeGemini {
-			return &agent.TokenUsage{}
-		}
-		// Otherwise fall through to JSONL parsing for Unknown type
-	}
-
-	// Claude Code and other JSONL-based agents
-	lines, err := transcript.ParseFromBytes(data)
-	if err != nil || len(lines) == 0 {
+	ag, err := agent.GetByAgentType(agentType)
+	if err != nil {
 		return &agent.TokenUsage{}
 	}
-	// Slice transcript lines to only include checkpoint portion
-	if startOffset > 0 && startOffset < len(lines) {
-		lines = lines[startOffset:]
+	calculator, ok := ag.(agent.TokenCalculator)
+	if !ok {
+		return nil
 	}
-	return claudecode.CalculateTokenUsage(lines)
+	usage, err := calculator.CalculateTokenUsage(data, startOffset)
+	if err != nil {
+		return &agent.TokenUsage{}
+	}
+	return usage
 }
 
 // extractUserPromptsFromLines extracts user prompts from JSONL transcript lines.


### PR DESCRIPTION
## Summary
- Changes the `TokenCalculator` interface to accept `[]byte` data instead of a `sessionRef string` (file path), so callers own file I/O and agents only parse
- Each agent's `CalculateTokenUsage` now operates on in-memory bytes rather than reading files internally
- Replaces hardcoded agent-type switch in `manual_commit_condensation.go` with the `TokenCalculator` interface via the agent registry

## Test plan
- [x] Existing unit tests updated to pass bytes directly
- [ ] `mise run test:ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)