### PR TITLE
fix: update empty local metadata branch from remote on enable

### DIFF
--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -285,15 +285,35 @@ func resolveAgentType(ctxAgentType agent.AgentType, state *SessionState) agent.A
 	return DefaultAgentType
 }
 
-// EnsureMetadataBranch creates the local entire/checkpoints/v1 branch if it doesn't exist.
-// If the remote-tracking branch (origin/entire/checkpoints/v1) exists, creates the local
-// branch from it to preserve existing checkpoint data. Otherwise creates an empty orphan.
+// EnsureMetadataBranch creates or updates the local entire/checkpoints/v1 branch.
+// If the remote-tracking branch (origin/entire/checkpoints/v1) exists and the local
+// branch is missing or empty, creates/updates the local branch from it.
+// Otherwise creates an empty orphan.
 func EnsureMetadataBranch(repo *git.Repository) error {
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 
+	// Check if remote-tracking branch exists (e.g., after clone/fetch)
+	remoteRefName := plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName)
+	remoteRef, remoteErr := repo.Reference(remoteRefName, true)
+	if remoteErr != nil && !errors.Is(remoteErr, plumbing.ErrReferenceNotFound) {
+		return fmt.Errorf("failed to check remote metadata branch: %w", remoteErr)
+	}
+
 	// Check if local branch already exists
-	_, err := repo.Reference(refName, true)
+	localRef, err := repo.Reference(refName, true)
 	if err == nil {
+		// If local is an empty orphan and remote has data, update from remote.
+		// This fixes repos where enable ran before the remote had checkpoint data.
+		if remoteErr == nil && localRef.Hash() != remoteRef.Hash() {
+			isEmpty, checkErr := isEmptyMetadataBranch(repo, localRef)
+			if checkErr == nil && isEmpty {
+				ref := plumbing.NewHashReference(refName, remoteRef.Hash())
+				if setErr := repo.Storer.SetReference(ref); setErr != nil {
+					return fmt.Errorf("failed to update metadata branch from remote: %w", setErr)
+				}
+				fmt.Fprintf(os.Stderr, "✓ Updated local branch '%s' from origin\n", paths.MetadataBranchName)
+			}
+		}
 		return nil
 	}
 	if !errors.Is(err, plumbing.ErrReferenceNotFound) {
@@ -301,11 +321,6 @@ func EnsureMetadataBranch(repo *git.Repository) error {
 	}
 
 	// Local branch doesn't exist — create from remote if available
-	remoteRefName := plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName)
-	remoteRef, remoteErr := repo.Reference(remoteRefName, true)
-	if remoteErr != nil && !errors.Is(remoteErr, plumbing.ErrReferenceNotFound) {
-		return fmt.Errorf("failed to check remote metadata branch: %w", remoteErr)
-	}
 	if remoteErr == nil {
 		ref := plumbing.NewHashReference(refName, remoteRef.Hash())
 		if err := repo.Storer.SetReference(ref); err != nil {
@@ -360,6 +375,19 @@ func EnsureMetadataBranch(repo *git.Repository) error {
 
 	fmt.Fprintf(os.Stderr, "✓ Created orphan branch '%s' for session metadata\n", paths.MetadataBranchName)
 	return nil
+}
+
+// isEmptyMetadataBranch returns true if the branch ref points to a commit with an empty tree.
+func isEmptyMetadataBranch(repo *git.Repository, ref *plumbing.Reference) (bool, error) {
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		return false, fmt.Errorf("failed to get commit: %w", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return false, fmt.Errorf("failed to get tree: %w", err)
+	}
+	return len(tree.Entries) == 0, nil
 }
 
 // readCheckpointMetadata reads metadata.json from a checkpoint path on entire/checkpoints/v1.

--- a/cmd/entire/cli/strategy/common_test.go
+++ b/cmd/entire/cli/strategy/common_test.go
@@ -1069,6 +1069,61 @@ func TestEnsureMetadataBranch(t *testing.T) {
 		}
 	})
 
+	t.Run("updates empty orphan from remote", func(t *testing.T) {
+		bareDir := initBareWithMetadataBranch(t)
+		cloneDir := filepath.Join(t.TempDir(), "clone")
+		cmd := exec.CommandContext(context.Background(), "git", "clone", bareDir, cloneDir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("clone failed: %v\n%s", err, out)
+		}
+
+		repo, err := git.PlainOpenWithOptions(cloneDir, &git.PlainOpenOptions{EnableDotGitCommonDir: true})
+		if err != nil {
+			t.Fatalf("failed to open repo: %v", err)
+		}
+
+		// Create an empty orphan locally (simulates old enable behavior)
+		emptyTree := &object.Tree{Entries: []object.TreeEntry{}}
+		treeObj := repo.Storer.NewEncodedObject()
+		if err := emptyTree.Encode(treeObj); err != nil {
+			t.Fatalf("failed to encode tree: %v", err)
+		}
+		treeHash, err := repo.Storer.SetEncodedObject(treeObj)
+		if err != nil {
+			t.Fatalf("failed to store tree: %v", err)
+		}
+		orphan := &object.Commit{
+			TreeHash: treeHash,
+			Author:   object.Signature{Name: "Test", Email: "test@test.com"},
+			Message:  "Initialize metadata branch\n",
+		}
+		orphanObj := repo.Storer.NewEncodedObject()
+		if err := orphan.Encode(orphanObj); err != nil {
+			t.Fatalf("failed to encode commit: %v", err)
+		}
+		orphanHash, err := repo.Storer.SetEncodedObject(orphanObj)
+		if err != nil {
+			t.Fatalf("failed to store commit: %v", err)
+		}
+		refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+		if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, orphanHash)); err != nil {
+			t.Fatalf("failed to set ref: %v", err)
+		}
+
+		if err := EnsureMetadataBranch(repo); err != nil {
+			t.Fatalf("EnsureMetadataBranch() failed: %v", err)
+		}
+
+		// Should have been updated from remote — no longer empty
+		ref, err := repo.Reference(refName, true)
+		if err != nil {
+			t.Fatalf("local branch not found: %v", err)
+		}
+		if ref.Hash() == orphanHash {
+			t.Error("local branch still points to empty orphan — was not updated from remote")
+		}
+	})
+
 	t.Run("creates empty orphan when no remote", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()


### PR DESCRIPTION
## Problem

Users who already ran `entire enable` on old code have an empty orphan `entire/checkpoints/v1` branch. When they update to the new code (from #511) and run `enable` again, it sees the local branch exists and does nothing — leaving `entire explain` broken.

This is the recovery path for existing installs. PR #511 prevents the problem for fresh clones; this PR fixes repos already in the broken state.

**Discussion:** https://entireio.slack.com/archives/C0A095SNK32/p1772083910982219?thread_ts=1772052543.300359&cid=C0A095SNK32

## Fix

When the local `entire/checkpoints/v1` exists, check if it's an empty orphan (single commit with empty tree). If so, and the remote has real data, update the local branch to match the remote.

Non-empty local branches are never overwritten.

## Test plan

- [x] `TestEnsureMetadataBranch/updates_empty_orphan_from_remote` — detects empty orphan, updates from remote
- [x] Existing tests still pass (fresh clone, no remote)
- [x] `mise run fmt && mise run lint && mise run test:ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)