### PR TITLE
WIP feat: add Kiro agent integration

### DIFF
--- a/cmd/entire/cli/agent/kiro/hooks.go
+++ b/cmd/entire/cli/agent/kiro/hooks.go
@@ -1,0 +1,330 @@
+package kiro
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// Ensure KiroAgent implements HookSupport
+var _ agent.HookSupport = (*KiroAgent)(nil)
+
+// Kiro hook names - these become subcommands under `entire hooks kiro`
+const (
+	HookNameAgentSpawn       = "agent-spawn"
+	HookNameUserPromptSubmit = "user-prompt-submit"
+	HookNameStop             = "stop"
+	HookNamePreToolUse       = "pre-tool-use"
+	HookNamePostToolUse      = "post-tool-use"
+)
+
+// HooksFileName is the hooks file used by Kiro.
+const HooksFileName = "hooks.json"
+
+// entireHookPrefixes are command prefixes that identify Entire hooks
+var entireHookPrefixes = []string{
+	"entire ",
+	"go run ${KIRO_PROJECT_DIR}/cmd/entire/main.go ",
+}
+
+// HookNames returns the hook verbs Kiro supports.
+// These become subcommands: entire hooks kiro <verb>
+func (k *KiroAgent) HookNames() []string {
+	return []string{
+		HookNameAgentSpawn,
+		HookNameUserPromptSubmit,
+		HookNameStop,
+		HookNamePreToolUse,
+		HookNamePostToolUse,
+	}
+}
+
+// InstallHooks installs Kiro hooks in .kiro/hooks.json.
+// If force is true, removes existing Entire hooks before installing.
+// Returns the number of hooks installed.
+// Unknown top-level fields and hook types are preserved on round-trip.
+func (k *KiroAgent) InstallHooks(ctx context.Context, localDev bool, force bool) (int, error) {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		worktreeRoot = "."
+	}
+
+	hooksPath := filepath.Join(worktreeRoot, ".kiro", HooksFileName)
+
+	// Use raw maps to preserve unknown fields on round-trip
+	var rawFile map[string]json.RawMessage
+	var rawHooks map[string]json.RawMessage
+
+	existingData, readErr := os.ReadFile(hooksPath) //nolint:gosec // path is constructed from repo root + fixed path
+	if readErr == nil {
+		if err := json.Unmarshal(existingData, &rawFile); err != nil {
+			return 0, fmt.Errorf("failed to parse existing %s: %w", HooksFileName, err)
+		}
+		if hooksRaw, ok := rawFile["hooks"]; ok {
+			if err := json.Unmarshal(hooksRaw, &rawHooks); err != nil {
+				return 0, fmt.Errorf("failed to parse hooks in %s: %w", HooksFileName, err)
+			}
+		}
+	} else {
+		rawFile = make(map[string]json.RawMessage)
+	}
+
+	if rawHooks == nil {
+		rawHooks = make(map[string]json.RawMessage)
+	}
+
+	// Parse only the hook types we manage
+	var agentSpawn, userPromptSubmit, stop, preToolUse, postToolUse []KiroHookEntry
+	parseKiroHookType(rawHooks, "agentSpawn", &agentSpawn)
+	parseKiroHookType(rawHooks, "userPromptSubmit", &userPromptSubmit)
+	parseKiroHookType(rawHooks, "stop", &stop)
+	parseKiroHookType(rawHooks, "preToolUse", &preToolUse)
+	parseKiroHookType(rawHooks, "postToolUse", &postToolUse)
+
+	// If force is true, remove all existing Entire hooks first
+	if force {
+		agentSpawn = removeEntireHooks(agentSpawn)
+		userPromptSubmit = removeEntireHooks(userPromptSubmit)
+		stop = removeEntireHooks(stop)
+		preToolUse = removeEntireHooks(preToolUse)
+		postToolUse = removeEntireHooks(postToolUse)
+	}
+
+	// Define hook commands
+	var cmdPrefix string
+	if localDev {
+		cmdPrefix = "go run ${KIRO_PROJECT_DIR}/cmd/entire/main.go hooks kiro "
+	} else {
+		cmdPrefix = "entire hooks kiro "
+	}
+
+	agentSpawnCmd := cmdPrefix + HookNameAgentSpawn
+	userPromptSubmitCmd := cmdPrefix + HookNameUserPromptSubmit
+	stopCmd := cmdPrefix + HookNameStop
+	preToolUseCmd := cmdPrefix + HookNamePreToolUse
+	postToolUseCmd := cmdPrefix + HookNamePostToolUse
+
+	count := 0
+
+	// Add hooks if they don't exist
+	if !hookCommandExists(agentSpawn, agentSpawnCmd) {
+		agentSpawn = append(agentSpawn, KiroHookEntry{Command: agentSpawnCmd})
+		count++
+	}
+	if !hookCommandExists(userPromptSubmit, userPromptSubmitCmd) {
+		userPromptSubmit = append(userPromptSubmit, KiroHookEntry{Command: userPromptSubmitCmd})
+		count++
+	}
+	if !hookCommandExists(stop, stopCmd) {
+		stop = append(stop, KiroHookEntry{Command: stopCmd})
+		count++
+	}
+	if !hookCommandExists(preToolUse, preToolUseCmd) {
+		preToolUse = append(preToolUse, KiroHookEntry{Command: preToolUseCmd})
+		count++
+	}
+	if !hookCommandExists(postToolUse, postToolUseCmd) {
+		postToolUse = append(postToolUse, KiroHookEntry{Command: postToolUseCmd})
+		count++
+	}
+
+	if count == 0 {
+		return 0, nil
+	}
+
+	// Marshal modified hook types back into rawHooks
+	marshalKiroHookType(rawHooks, "agentSpawn", agentSpawn)
+	marshalKiroHookType(rawHooks, "userPromptSubmit", userPromptSubmit)
+	marshalKiroHookType(rawHooks, "stop", stop)
+	marshalKiroHookType(rawHooks, "preToolUse", preToolUse)
+	marshalKiroHookType(rawHooks, "postToolUse", postToolUse)
+
+	// Marshal hooks and update raw file
+	hooksJSON, err := json.Marshal(rawHooks)
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal hooks: %w", err)
+	}
+	rawFile["hooks"] = hooksJSON
+
+	// Write to file
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o750); err != nil {
+		return 0, fmt.Errorf("failed to create .kiro directory: %w", err)
+	}
+
+	output, err := jsonutil.MarshalIndentWithNewline(rawFile, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal %s: %w", HooksFileName, err)
+	}
+
+	if err := os.WriteFile(hooksPath, output, 0o600); err != nil {
+		return 0, fmt.Errorf("failed to write %s: %w", HooksFileName, err)
+	}
+
+	return count, nil
+}
+
+// UninstallHooks removes Entire hooks from Kiro hooks.json.
+// Unknown top-level fields and hook types are preserved on round-trip.
+func (k *KiroAgent) UninstallHooks(ctx context.Context) error {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		worktreeRoot = "."
+	}
+	hooksPath := filepath.Join(worktreeRoot, ".kiro", HooksFileName)
+	data, err := os.ReadFile(hooksPath) //nolint:gosec // path is constructed from repo root + fixed path
+	if err != nil {
+		return nil //nolint:nilerr // No hooks file means nothing to uninstall
+	}
+
+	var rawFile map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawFile); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", HooksFileName, err)
+	}
+
+	var rawHooks map[string]json.RawMessage
+	if hooksRaw, ok := rawFile["hooks"]; ok {
+		if err := json.Unmarshal(hooksRaw, &rawHooks); err != nil {
+			return fmt.Errorf("failed to parse hooks in %s: %w", HooksFileName, err)
+		}
+	}
+	if rawHooks == nil {
+		rawHooks = make(map[string]json.RawMessage)
+	}
+
+	// Parse only the hook types we manage
+	var agentSpawn, userPromptSubmit, stop, preToolUse, postToolUse []KiroHookEntry
+	parseKiroHookType(rawHooks, "agentSpawn", &agentSpawn)
+	parseKiroHookType(rawHooks, "userPromptSubmit", &userPromptSubmit)
+	parseKiroHookType(rawHooks, "stop", &stop)
+	parseKiroHookType(rawHooks, "preToolUse", &preToolUse)
+	parseKiroHookType(rawHooks, "postToolUse", &postToolUse)
+
+	// Remove Entire hooks from all hook types
+	agentSpawn = removeEntireHooks(agentSpawn)
+	userPromptSubmit = removeEntireHooks(userPromptSubmit)
+	stop = removeEntireHooks(stop)
+	preToolUse = removeEntireHooks(preToolUse)
+	postToolUse = removeEntireHooks(postToolUse)
+
+	// Marshal modified hook types back into rawHooks
+	marshalKiroHookType(rawHooks, "agentSpawn", agentSpawn)
+	marshalKiroHookType(rawHooks, "userPromptSubmit", userPromptSubmit)
+	marshalKiroHookType(rawHooks, "stop", stop)
+	marshalKiroHookType(rawHooks, "preToolUse", preToolUse)
+	marshalKiroHookType(rawHooks, "postToolUse", postToolUse)
+
+	// Marshal hooks back (preserving unknown hook types)
+	if len(rawHooks) > 0 {
+		hooksJSON, err := json.Marshal(rawHooks)
+		if err != nil {
+			return fmt.Errorf("failed to marshal hooks: %w", err)
+		}
+		rawFile["hooks"] = hooksJSON
+	} else {
+		delete(rawFile, "hooks")
+	}
+
+	// Write back
+	output, err := jsonutil.MarshalIndentWithNewline(rawFile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s: %w", HooksFileName, err)
+	}
+
+	if err := os.WriteFile(hooksPath, output, 0o600); err != nil {
+		return fmt.Errorf("failed to write %s: %w", HooksFileName, err)
+	}
+	return nil
+}
+
+// AreHooksInstalled checks if Entire hooks are installed.
+func (k *KiroAgent) AreHooksInstalled(ctx context.Context) bool {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		worktreeRoot = "."
+	}
+	hooksPath := filepath.Join(worktreeRoot, ".kiro", HooksFileName)
+	data, err := os.ReadFile(hooksPath) //nolint:gosec // path is constructed from repo root + fixed path
+	if err != nil {
+		return false
+	}
+
+	var hooksFile KiroHooksFile
+	if err := json.Unmarshal(data, &hooksFile); err != nil {
+		return false
+	}
+
+	return hasEntireHook(hooksFile.Hooks.AgentSpawn) ||
+		hasEntireHook(hooksFile.Hooks.UserPromptSubmit) ||
+		hasEntireHook(hooksFile.Hooks.Stop) ||
+		hasEntireHook(hooksFile.Hooks.PreToolUse) ||
+		hasEntireHook(hooksFile.Hooks.PostToolUse)
+}
+
+// parseKiroHookType parses a specific hook type from rawHooks into the target slice.
+// Silently ignores parse errors (leaves target unchanged).
+func parseKiroHookType(rawHooks map[string]json.RawMessage, hookType string, target *[]KiroHookEntry) {
+	if data, ok := rawHooks[hookType]; ok {
+		//nolint:errcheck,gosec // Intentionally ignoring parse errors - leave target as nil/empty
+		json.Unmarshal(data, target)
+	}
+}
+
+// marshalKiroHookType marshals a hook type back into rawHooks.
+// If the slice is empty, removes the key from rawHooks.
+func marshalKiroHookType(rawHooks map[string]json.RawMessage, hookType string, entries []KiroHookEntry) {
+	if len(entries) == 0 {
+		delete(rawHooks, hookType)
+		return
+	}
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return // Silently ignore marshal errors (shouldn't happen)
+	}
+	rawHooks[hookType] = data
+}
+
+// Helper functions for hook management
+
+func hookCommandExists(entries []KiroHookEntry, command string) bool {
+	for _, entry := range entries {
+		if entry.Command == command {
+			return true
+		}
+	}
+	return false
+}
+
+func isEntireHook(command string) bool {
+	for _, prefix := range entireHookPrefixes {
+		if strings.HasPrefix(command, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEntireHook(entries []KiroHookEntry) bool {
+	for _, entry := range entries {
+		if isEntireHook(entry.Command) {
+			return true
+		}
+	}
+	return false
+}
+
+func removeEntireHooks(entries []KiroHookEntry) []KiroHookEntry {
+	result := make([]KiroHookEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !isEntireHook(entry.Command) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}

--- a/cmd/entire/cli/agent/kiro/hooks_test.go
+++ b/cmd/entire/cli/agent/kiro/hooks_test.go
@@ -1,0 +1,427 @@
+package kiro
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallHooks_FreshInstall(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &KiroAgent{}
+	count, err := ag.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+
+	if count != 5 {
+		t.Errorf("InstallHooks() count = %d, want 5", count)
+	}
+
+	hooksFile := readHooksFile(t, tempDir)
+
+	// Verify all hooks are present
+	if len(hooksFile.Hooks.AgentSpawn) != 1 {
+		t.Errorf("AgentSpawn hooks = %d, want 1", len(hooksFile.Hooks.AgentSpawn))
+	}
+	if len(hooksFile.Hooks.UserPromptSubmit) != 1 {
+		t.Errorf("UserPromptSubmit hooks = %d, want 1", len(hooksFile.Hooks.UserPromptSubmit))
+	}
+	if len(hooksFile.Hooks.Stop) != 1 {
+		t.Errorf("Stop hooks = %d, want 1", len(hooksFile.Hooks.Stop))
+	}
+	if len(hooksFile.Hooks.PreToolUse) != 1 {
+		t.Errorf("PreToolUse hooks = %d, want 1", len(hooksFile.Hooks.PreToolUse))
+	}
+	if len(hooksFile.Hooks.PostToolUse) != 1 {
+		t.Errorf("PostToolUse hooks = %d, want 1", len(hooksFile.Hooks.PostToolUse))
+	}
+
+	// Verify commands
+	assertEntryCommand(t, hooksFile.Hooks.AgentSpawn, "entire hooks kiro agent-spawn")
+	assertEntryCommand(t, hooksFile.Hooks.UserPromptSubmit, "entire hooks kiro user-prompt-submit")
+	assertEntryCommand(t, hooksFile.Hooks.Stop, "entire hooks kiro stop")
+	assertEntryCommand(t, hooksFile.Hooks.PreToolUse, "entire hooks kiro pre-tool-use")
+	assertEntryCommand(t, hooksFile.Hooks.PostToolUse, "entire hooks kiro post-tool-use")
+}
+
+func TestInstallHooks_Idempotent(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &KiroAgent{}
+
+	// First install
+	count1, err := ag.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("first InstallHooks() error = %v", err)
+	}
+	if count1 != 5 {
+		t.Errorf("first InstallHooks() count = %d, want 5", count1)
+	}
+
+	// Second install
+	count2, err := ag.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("second InstallHooks() error = %v", err)
+	}
+	if count2 != 0 {
+		t.Errorf("second InstallHooks() count = %d, want 0 (already installed)", count2)
+	}
+
+	// Verify no duplicates
+	hooksFile := readHooksFile(t, tempDir)
+	if len(hooksFile.Hooks.Stop) != 1 {
+		t.Errorf("Stop hooks = %d after double install, want 1", len(hooksFile.Hooks.Stop))
+	}
+}
+
+func TestAreHooksInstalled_NotInstalled(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &KiroAgent{}
+	if ag.AreHooksInstalled(context.Background()) {
+		t.Error("AreHooksInstalled() = true, want false (no hooks.json)")
+	}
+}
+
+func TestAreHooksInstalled_AfterInstall(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &KiroAgent{}
+
+	_, err := ag.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+
+	if !ag.AreHooksInstalled(context.Background()) {
+		t.Error("AreHooksInstalled() = false, want true")
+	}
+}
+
+func TestUninstallHooks(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &KiroAgent{}
+
+	// Install
+	_, err := ag.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+	if !ag.AreHooksInstalled(context.Background()) {
+		t.Fatal("hooks should be installed before uninstall")
+	}
+
+	// Uninstall
+	err = ag.UninstallHooks(context.Background())
+	if err != nil {
+		t.Fatalf("UninstallHooks() error = %v", err)
+	}
+
+	if ag.AreHooksInstalled(context.Background()) {
+		t.Error("AreHooksInstalled() = true after uninstall, want false")
+	}
+}
+
+func TestUninstallHooks_NoHooksFile(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &KiroAgent{}
+
+	// Should not error when no hooks file exists
+	err := ag.UninstallHooks(context.Background())
+	if err != nil {
+		t.Fatalf("UninstallHooks() should not error when no hooks file: %v", err)
+	}
+}
+
+func TestInstallHooks_ForceReinstall(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &KiroAgent{}
+
+	// Install normally
+	_, err := ag.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("first InstallHooks() error = %v", err)
+	}
+
+	// Force reinstall
+	count, err := ag.InstallHooks(context.Background(), false, true)
+	if err != nil {
+		t.Fatalf("force InstallHooks() error = %v", err)
+	}
+	if count != 5 {
+		t.Errorf("force InstallHooks() count = %d, want 5", count)
+	}
+
+	// Verify no duplicates
+	hooksFile := readHooksFile(t, tempDir)
+	if len(hooksFile.Hooks.Stop) != 1 {
+		t.Errorf("Stop hooks = %d after force reinstall, want 1", len(hooksFile.Hooks.Stop))
+	}
+}
+
+func TestInstallHooks_PreservesExistingHooks(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	// Create hooks file with existing user hooks
+	writeHooksFile(t, tempDir, KiroHooksFile{
+		Hooks: KiroHooks{
+			Stop: []KiroHookEntry{
+				{Command: "echo user hook"},
+			},
+			PostToolUse: []KiroHookEntry{
+				{Command: "echo file written", Matcher: "write_file"},
+			},
+		},
+	})
+
+	ag := &KiroAgent{}
+	_, err := ag.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+
+	hooksFile := readHooksFile(t, tempDir)
+
+	// Stop should have user hook + entire hook
+	if len(hooksFile.Hooks.Stop) != 2 {
+		t.Errorf("Stop hooks = %d, want 2 (user + entire)", len(hooksFile.Hooks.Stop))
+	}
+	assertEntryCommand(t, hooksFile.Hooks.Stop, "echo user hook")
+	assertEntryCommand(t, hooksFile.Hooks.Stop, "entire hooks kiro stop")
+
+	// PostToolUse should have user hook + Entire hook
+	if len(hooksFile.Hooks.PostToolUse) != 2 {
+		t.Errorf("PostToolUse hooks = %d, want 2 (user + Entire)", len(hooksFile.Hooks.PostToolUse))
+	}
+	assertEntryWithMatcher(t, hooksFile.Hooks.PostToolUse, "write_file", "echo file written")
+	assertEntryCommand(t, hooksFile.Hooks.PostToolUse, "entire hooks kiro post-tool-use")
+}
+
+func TestInstallHooks_LocalDev(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &KiroAgent{}
+	_, err := ag.InstallHooks(context.Background(), true, false)
+	if err != nil {
+		t.Fatalf("InstallHooks(localDev=true) error = %v", err)
+	}
+
+	hooksFile := readHooksFile(t, tempDir)
+	assertEntryCommand(t, hooksFile.Hooks.Stop, "go run ${KIRO_PROJECT_DIR}/cmd/entire/main.go hooks kiro stop")
+}
+
+func TestInstallHooks_PreservesUnknownFields(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	// Create a hooks file with unknown top-level fields and unknown hook types
+	existingJSON := `{
+  "kiroSettings": {"theme": "dark"},
+  "hooks": {
+    "stop": [{"command": "echo user stop"}],
+    "onNotification": [{"command": "echo notify", "filter": "error"}],
+    "customHook": [{"command": "echo custom"}]
+  }
+}`
+	kiroDir := filepath.Join(tempDir, ".kiro")
+	if err := os.MkdirAll(kiroDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kiroDir, HooksFileName), []byte(existingJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ag := &KiroAgent{}
+	count, err := ag.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatalf("InstallHooks() error = %v", err)
+	}
+	if count != 5 {
+		t.Errorf("InstallHooks() count = %d, want 5", count)
+	}
+
+	// Read the raw JSON to verify unknown fields are preserved
+	data, err := os.ReadFile(filepath.Join(kiroDir, HooksFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var rawFile map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawFile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify unknown top-level field "kiroSettings" is preserved
+	if _, ok := rawFile["kiroSettings"]; !ok {
+		t.Error("unknown top-level field 'kiroSettings' was dropped")
+	}
+
+	// Verify hooks object contains unknown hook types
+	var rawHooks map[string]json.RawMessage
+	if err := json.Unmarshal(rawFile["hooks"], &rawHooks); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := rawHooks["onNotification"]; !ok {
+		t.Error("unknown hook type 'onNotification' was dropped")
+	}
+	if _, ok := rawHooks["customHook"]; !ok {
+		t.Error("unknown hook type 'customHook' was dropped")
+	}
+
+	// Verify user's existing stop hook is preserved alongside ours
+	var stopHooks []KiroHookEntry
+	if err := json.Unmarshal(rawHooks["stop"], &stopHooks); err != nil {
+		t.Fatal(err)
+	}
+	if len(stopHooks) != 2 {
+		t.Errorf("stop hooks = %d, want 2 (user + entire)", len(stopHooks))
+	}
+	assertEntryCommand(t, stopHooks, "echo user stop")
+	assertEntryCommand(t, stopHooks, "entire hooks kiro stop")
+}
+
+func TestUninstallHooks_PreservesUnknownFields(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	// Install hooks first
+	ag := &KiroAgent{}
+	_, err := ag.InstallHooks(context.Background(), false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add unknown fields to the file
+	hooksPath := filepath.Join(tempDir, ".kiro", HooksFileName)
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var rawFile map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawFile); err != nil {
+		t.Fatal(err)
+	}
+	rawFile["kiroSettings"] = json.RawMessage(`{"theme":"dark"}`)
+
+	var rawHooks map[string]json.RawMessage
+	if err := json.Unmarshal(rawFile["hooks"], &rawHooks); err != nil {
+		t.Fatal(err)
+	}
+	rawHooks["onNotification"] = json.RawMessage(`[{"command":"echo notify"}]`)
+	hooksJSON, err := json.Marshal(rawHooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawFile["hooks"] = hooksJSON
+
+	updatedData, err := json.MarshalIndent(rawFile, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hooksPath, updatedData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Uninstall hooks
+	if err := ag.UninstallHooks(context.Background()); err != nil {
+		t.Fatalf("UninstallHooks() error = %v", err)
+	}
+
+	// Read and verify unknown fields are preserved
+	data, err = os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := json.Unmarshal(data, &rawFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := rawFile["kiroSettings"]; !ok {
+		t.Error("unknown top-level field 'kiroSettings' was dropped after uninstall")
+	}
+
+	if err := json.Unmarshal(rawFile["hooks"], &rawHooks); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := rawHooks["onNotification"]; !ok {
+		t.Error("unknown hook type 'onNotification' was dropped after uninstall")
+	}
+
+	// Verify Entire hooks were actually removed
+	if ag.AreHooksInstalled(context.Background()) {
+		t.Error("Entire hooks should be removed after uninstall")
+	}
+}
+
+// --- Test helpers ---
+
+func readHooksFile(t *testing.T, tempDir string) KiroHooksFile {
+	t.Helper()
+	hooksPath := filepath.Join(tempDir, ".kiro", HooksFileName)
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", HooksFileName, err)
+	}
+
+	var hooksFile KiroHooksFile
+	if err := json.Unmarshal(data, &hooksFile); err != nil {
+		t.Fatalf("failed to parse %s: %v", HooksFileName, err)
+	}
+	return hooksFile
+}
+
+func writeHooksFile(t *testing.T, tempDir string, hooksFile KiroHooksFile) {
+	t.Helper()
+	kiroDir := filepath.Join(tempDir, ".kiro")
+	if err := os.MkdirAll(kiroDir, 0o755); err != nil {
+		t.Fatalf("failed to create .kiro dir: %v", err)
+	}
+	data, err := json.MarshalIndent(hooksFile, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal %s: %v", HooksFileName, err)
+	}
+	hooksPath := filepath.Join(kiroDir, HooksFileName)
+	if err := os.WriteFile(hooksPath, data, 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", HooksFileName, err)
+	}
+}
+
+func assertEntryCommand(t *testing.T, entries []KiroHookEntry, command string) {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Command == command {
+			return
+		}
+	}
+	t.Errorf("hook with command %q not found", command)
+}
+
+func assertEntryWithMatcher(t *testing.T, entries []KiroHookEntry, matcher, command string) {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Matcher == matcher && entry.Command == command {
+			return
+		}
+	}
+	t.Errorf("hook with matcher=%q command=%q not found", matcher, command)
+}

--- a/cmd/entire/cli/agent/kiro/kiro.go
+++ b/cmd/entire/cli/agent/kiro/kiro.go
@@ -1,0 +1,162 @@
+// Package kiro implements the Agent interface for Kiro.
+package kiro
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+//nolint:gochecknoinits // Agent self-registration is the intended pattern
+func init() {
+	agent.Register(agent.AgentNameKiro, NewKiroAgent)
+}
+
+// KiroAgent implements the Agent interface for Kiro.
+//
+//nolint:revive // KiroAgent is clearer than Agent in this context
+type KiroAgent struct{}
+
+// NewKiroAgent creates a new Kiro agent instance.
+func NewKiroAgent() agent.Agent {
+	return &KiroAgent{}
+}
+
+// Name returns the agent registry key.
+func (k *KiroAgent) Name() agent.AgentName {
+	return agent.AgentNameKiro
+}
+
+// Type returns the agent type identifier.
+func (k *KiroAgent) Type() agent.AgentType {
+	return agent.AgentTypeKiro
+}
+
+// Description returns a human-readable description.
+func (k *KiroAgent) Description() string {
+	return "Kiro - AI-powered coding agent by Amazon"
+}
+
+// IsPreview returns true because Kiro integration is in preview.
+func (k *KiroAgent) IsPreview() bool { return true }
+
+// DetectPresence checks if Kiro is configured in the repository.
+func (k *KiroAgent) DetectPresence(ctx context.Context) (bool, error) {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		worktreeRoot = "."
+	}
+
+	kiroDir := filepath.Join(worktreeRoot, ".kiro")
+	if _, err := os.Stat(kiroDir); err == nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+// GetSessionID extracts the session ID from hook input.
+func (k *KiroAgent) GetSessionID(input *agent.HookInput) string {
+	return input.SessionID
+}
+
+// ResolveSessionFile returns the path to a Kiro session file.
+func (k *KiroAgent) ResolveSessionFile(sessionDir, agentSessionID string) string {
+	return filepath.Join(sessionDir, agentSessionID+".json")
+}
+
+// ProtectedDirs returns directories that Kiro uses for config/state.
+func (k *KiroAgent) ProtectedDirs() []string { return []string{".kiro"} }
+
+// GetSessionDir returns the directory where Kiro stores session data for this repo.
+func (k *KiroAgent) GetSessionDir(repoPath string) (string, error) {
+	if override := os.Getenv("ENTIRE_TEST_KIRO_PROJECT_DIR"); override != "" {
+		return override, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	projectDir := sanitizePathForKiro(repoPath)
+	return filepath.Join(homeDir, ".kiro", "projects", projectDir), nil
+}
+
+// ReadSession reads a session from Kiro's storage.
+// ModifiedFiles is left empty because Kiro uses SQLite for sessions.
+// File detection relies on git status instead.
+func (k *KiroAgent) ReadSession(input *agent.HookInput) (*agent.AgentSession, error) {
+	if input.SessionRef == "" {
+		return nil, errors.New("session reference is required")
+	}
+
+	data, err := os.ReadFile(input.SessionRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session file: %w", err)
+	}
+
+	return &agent.AgentSession{
+		SessionID:  input.SessionID,
+		AgentName:  k.Name(),
+		SessionRef: input.SessionRef,
+		StartTime:  time.Now(),
+		NativeData: data,
+	}, nil
+}
+
+// WriteSession writes a session to Kiro's storage.
+func (k *KiroAgent) WriteSession(_ context.Context, session *agent.AgentSession) error {
+	if session == nil {
+		return errors.New("session is nil")
+	}
+
+	if session.AgentName != "" && session.AgentName != k.Name() {
+		return fmt.Errorf("session belongs to agent %q, not %q", session.AgentName, k.Name())
+	}
+
+	if session.SessionRef == "" {
+		return errors.New("session reference is required")
+	}
+
+	if len(session.NativeData) == 0 {
+		return errors.New("session has no native data to write")
+	}
+
+	if err := os.WriteFile(session.SessionRef, session.NativeData, 0o600); err != nil {
+		return fmt.Errorf("failed to write session file: %w", err)
+	}
+
+	return nil
+}
+
+// FormatResumeCommand returns an instruction to resume a Kiro session.
+func (k *KiroAgent) FormatResumeCommand(_ string) string {
+	return "kiro-cli chat --resume"
+}
+
+var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9]`)
+
+func sanitizePathForKiro(path string) string {
+	return nonAlphanumericRegex.ReplaceAllString(path, "-")
+}
+
+// ChunkTranscript splits a JSON transcript into chunks.
+func (k *KiroAgent) ChunkTranscript(_ context.Context, content []byte, maxSize int) ([][]byte, error) {
+	chunks, err := agent.ChunkJSONL(content, maxSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to chunk transcript: %w", err)
+	}
+	return chunks, nil
+}
+
+// ReassembleTranscript concatenates transcript chunks.
+func (k *KiroAgent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	return agent.ReassembleJSONL(chunks), nil
+}

--- a/cmd/entire/cli/agent/kiro/kiro_test.go
+++ b/cmd/entire/cli/agent/kiro/kiro_test.go
@@ -1,0 +1,543 @@
+package kiro
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// sampleSessionContent returns sample session data for testing.
+func sampleSessionContent() string {
+	return `{"role":"user","content":"hello"}
+{"role":"assistant","content":"Hi there! How can I help?"}
+{"role":"user","content":"create a file"}
+{"role":"assistant","content":"Done! Created the file."}
+`
+}
+
+func writeSampleSession(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "session.json")
+	if err := os.WriteFile(path, []byte(sampleSessionContent()), 0o644); err != nil {
+		t.Fatalf("failed to write sample session: %v", err)
+	}
+	return path
+}
+
+// --- Identity ---
+
+func TestKiroAgent_Name(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	if ag.Name() != agent.AgentNameKiro {
+		t.Errorf("Name() = %q, want %q", ag.Name(), agent.AgentNameKiro)
+	}
+}
+
+func TestKiroAgent_Type(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	if ag.Type() != agent.AgentTypeKiro {
+		t.Errorf("Type() = %q, want %q", ag.Type(), agent.AgentTypeKiro)
+	}
+}
+
+func TestKiroAgent_Description(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	if ag.Description() == "" {
+		t.Error("Description() returned empty string")
+	}
+}
+
+func TestKiroAgent_IsPreview(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	if !ag.IsPreview() {
+		t.Error("IsPreview() = false, want true")
+	}
+}
+
+func TestKiroAgent_ProtectedDirs(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	dirs := ag.ProtectedDirs()
+	if len(dirs) != 1 || dirs[0] != ".kiro" {
+		t.Errorf("ProtectedDirs() = %v, want [.kiro]", dirs)
+	}
+}
+
+func TestKiroAgent_FormatResumeCommand(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	cmd := ag.FormatResumeCommand("some-session-id")
+	if !strings.Contains(cmd, "kiro-cli") {
+		t.Errorf("FormatResumeCommand() = %q, expected mention of kiro-cli", cmd)
+	}
+}
+
+// --- GetSessionID ---
+
+func TestKiroAgent_GetSessionID(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	input := &agent.HookInput{SessionID: "kiro-sess-42"}
+	if id := ag.GetSessionID(input); id != "kiro-sess-42" {
+		t.Errorf("GetSessionID() = %q, want kiro-sess-42", id)
+	}
+}
+
+// --- ResolveSessionFile ---
+
+func TestKiroAgent_ResolveSessionFile(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	result := ag.ResolveSessionFile("/tmp/sessions", "abc123")
+	expected := "/tmp/sessions/abc123.json"
+	if result != expected {
+		t.Errorf("ResolveSessionFile() = %q, want %q", result, expected)
+	}
+}
+
+// --- GetSessionDir ---
+
+func TestKiroAgent_GetSessionDir_EnvOverride(t *testing.T) {
+	ag := &KiroAgent{}
+	t.Setenv("ENTIRE_TEST_KIRO_PROJECT_DIR", "/test/override")
+
+	dir, err := ag.GetSessionDir("/some/repo")
+	if err != nil {
+		t.Fatalf("GetSessionDir() error = %v", err)
+	}
+	if dir != "/test/override" {
+		t.Errorf("GetSessionDir() = %q, want /test/override", dir)
+	}
+}
+
+func TestKiroAgent_GetSessionDir_DefaultPath(t *testing.T) {
+	ag := &KiroAgent{}
+	t.Setenv("ENTIRE_TEST_KIRO_PROJECT_DIR", "")
+
+	dir, err := ag.GetSessionDir("/some/repo")
+	if err != nil {
+		t.Fatalf("GetSessionDir() error = %v", err)
+	}
+	if !filepath.IsAbs(dir) {
+		t.Errorf("GetSessionDir() should return absolute path, got %q", dir)
+	}
+	if !strings.Contains(dir, ".kiro") {
+		t.Errorf("GetSessionDir() = %q, expected path containing .kiro", dir)
+	}
+}
+
+// --- ReadSession ---
+
+func TestReadSession_Success(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	sessionPath := writeSampleSession(t, tmpDir)
+
+	ag := &KiroAgent{}
+	input := &agent.HookInput{
+		SessionID:  "kiro-session-1",
+		SessionRef: sessionPath,
+	}
+
+	session, err := ag.ReadSession(input)
+	if err != nil {
+		t.Fatalf("ReadSession() error = %v", err)
+	}
+
+	if session.SessionID != "kiro-session-1" {
+		t.Errorf("SessionID = %q, want kiro-session-1", session.SessionID)
+	}
+	if session.AgentName != agent.AgentNameKiro {
+		t.Errorf("AgentName = %q, want %q", session.AgentName, agent.AgentNameKiro)
+	}
+	if session.SessionRef != sessionPath {
+		t.Errorf("SessionRef = %q, want %q", session.SessionRef, sessionPath)
+	}
+	if len(session.NativeData) == 0 {
+		t.Error("NativeData is empty")
+	}
+	if session.StartTime.IsZero() {
+		t.Error("StartTime is zero")
+	}
+}
+
+func TestReadSession_NativeDataMatchesFile(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	sessionPath := writeSampleSession(t, tmpDir)
+
+	ag := &KiroAgent{}
+	input := &agent.HookInput{
+		SessionID:  "sess-read",
+		SessionRef: sessionPath,
+	}
+
+	session, err := ag.ReadSession(input)
+	if err != nil {
+		t.Fatalf("ReadSession() error = %v", err)
+	}
+
+	fileData, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("failed to read session file: %v", err)
+	}
+
+	if !bytes.Equal(session.NativeData, fileData) {
+		t.Error("NativeData does not match file contents")
+	}
+}
+
+func TestReadSession_EmptySessionRef(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	input := &agent.HookInput{SessionID: "sess-no-ref"}
+
+	_, err := ag.ReadSession(input)
+	if err == nil {
+		t.Fatal("ReadSession() should error when SessionRef is empty")
+	}
+}
+
+func TestReadSession_MissingFile(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	input := &agent.HookInput{
+		SessionID:  "sess-missing",
+		SessionRef: "/nonexistent/path/session.json",
+	}
+
+	_, err := ag.ReadSession(input)
+	if err == nil {
+		t.Fatal("ReadSession() should error when session file doesn't exist")
+	}
+}
+
+// --- WriteSession ---
+
+func TestWriteSession_Success(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	sessionPath := filepath.Join(tmpDir, "output.json")
+
+	content := sampleSessionContent()
+
+	ag := &KiroAgent{}
+	session := &agent.AgentSession{
+		SessionID:  "write-session-1",
+		AgentName:  agent.AgentNameKiro,
+		SessionRef: sessionPath,
+		NativeData: []byte(content),
+	}
+
+	if err := ag.WriteSession(context.Background(), session); err != nil {
+		t.Fatalf("WriteSession() error = %v", err)
+	}
+
+	data, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("failed to read written file: %v", err)
+	}
+	if string(data) != content {
+		t.Errorf("written content does not match original")
+	}
+}
+
+func TestWriteSession_RoundTrip(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	sessionPath := writeSampleSession(t, tmpDir)
+
+	ag := &KiroAgent{}
+
+	// Read
+	input := &agent.HookInput{
+		SessionID:  "roundtrip-session",
+		SessionRef: sessionPath,
+	}
+	session, err := ag.ReadSession(input)
+	if err != nil {
+		t.Fatalf("ReadSession() error = %v", err)
+	}
+
+	// Write to new path
+	newPath := filepath.Join(tmpDir, "roundtrip.json")
+	session.SessionRef = newPath
+	if err := ag.WriteSession(context.Background(), session); err != nil {
+		t.Fatalf("WriteSession() error = %v", err)
+	}
+
+	// Read back and compare
+	original, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("failed to read original: %v", err)
+	}
+	written, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("failed to read written: %v", err)
+	}
+	if !bytes.Equal(original, written) {
+		t.Error("round-trip data mismatch: written file differs from original")
+	}
+}
+
+func TestWriteSession_Nil(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	if err := ag.WriteSession(context.Background(), nil); err == nil {
+		t.Error("WriteSession(nil) should error")
+	}
+}
+
+func TestWriteSession_WrongAgent(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	session := &agent.AgentSession{
+		AgentName:  "claude-code",
+		SessionRef: "/path/to/file",
+		NativeData: []byte("data"),
+	}
+	if err := ag.WriteSession(context.Background(), session); err == nil {
+		t.Error("WriteSession() should error for wrong agent")
+	}
+}
+
+func TestWriteSession_EmptyAgentName(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	sessionPath := filepath.Join(tmpDir, "empty-agent.json")
+
+	ag := &KiroAgent{}
+	session := &agent.AgentSession{
+		AgentName:  "", // Empty agent name should be accepted
+		SessionRef: sessionPath,
+		NativeData: []byte("data"),
+	}
+	if err := ag.WriteSession(context.Background(), session); err != nil {
+		t.Errorf("WriteSession() with empty AgentName should succeed, got: %v", err)
+	}
+}
+
+func TestWriteSession_NoSessionRef(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	session := &agent.AgentSession{
+		AgentName:  agent.AgentNameKiro,
+		NativeData: []byte("data"),
+	}
+	if err := ag.WriteSession(context.Background(), session); err == nil {
+		t.Error("WriteSession() should error when SessionRef is empty")
+	}
+}
+
+func TestWriteSession_NoNativeData(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	session := &agent.AgentSession{
+		AgentName:  agent.AgentNameKiro,
+		SessionRef: "/path/to/file",
+	}
+	if err := ag.WriteSession(context.Background(), session); err == nil {
+		t.Error("WriteSession() should error when NativeData is empty")
+	}
+}
+
+// --- ChunkTranscript / ReassembleTranscript ---
+
+func TestChunkTranscript_SmallContent(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+
+	content := []byte(sampleSessionContent())
+
+	chunks, err := ag.ChunkTranscript(context.Background(), content, agent.MaxChunkSize)
+	if err != nil {
+		t.Fatalf("ChunkTranscript() error = %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Errorf("expected 1 chunk for small content, got %d", len(chunks))
+	}
+}
+
+func TestChunkTranscript_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+
+	original := []byte(sampleSessionContent())
+
+	// Use a max size large enough for individual lines but small enough to force splits
+	chunks, err := ag.ChunkTranscript(context.Background(), original, 100)
+	if err != nil {
+		t.Fatalf("ChunkTranscript() error = %v", err)
+	}
+
+	reassembled, err := ag.ReassembleTranscript(chunks)
+	if err != nil {
+		t.Fatalf("ReassembleTranscript() error = %v", err)
+	}
+
+	if !bytes.Equal(original, reassembled) {
+		t.Errorf("round-trip mismatch:\n  original len=%d\n  reassembled len=%d", len(original), len(reassembled))
+	}
+}
+
+func TestChunkTranscript_EmptyContent(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+
+	chunks, err := ag.ChunkTranscript(context.Background(), []byte{}, agent.MaxChunkSize)
+	if err != nil {
+		t.Fatalf("ChunkTranscript() error = %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Errorf("expected 0 chunks for empty content, got %d", len(chunks))
+	}
+}
+
+func TestReassembleTranscript_EmptyChunks(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+
+	result, err := ag.ReassembleTranscript([][]byte{})
+	if err != nil {
+		t.Fatalf("ReassembleTranscript() error = %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result for empty chunks, got %d bytes", len(result))
+	}
+}
+
+// --- ReadTranscript ---
+
+func TestReadTranscript_Success(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	sessionPath := writeSampleSession(t, tmpDir)
+
+	ag := &KiroAgent{}
+	data, err := ag.ReadTranscript(sessionPath)
+	if err != nil {
+		t.Fatalf("ReadTranscript() error = %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("ReadTranscript() returned empty data")
+	}
+}
+
+func TestReadTranscript_MissingFile(t *testing.T) {
+	t.Parallel()
+	ag := &KiroAgent{}
+	_, err := ag.ReadTranscript("/nonexistent/path/session.json")
+	if err == nil {
+		t.Fatal("ReadTranscript() should error for missing file")
+	}
+}
+
+func TestReadTranscript_MatchesReadSession(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	sessionPath := writeSampleSession(t, tmpDir)
+
+	ag := &KiroAgent{}
+
+	transcriptData, err := ag.ReadTranscript(sessionPath)
+	if err != nil {
+		t.Fatalf("ReadTranscript() error = %v", err)
+	}
+
+	session, err := ag.ReadSession(&agent.HookInput{
+		SessionID:  "compare-session",
+		SessionRef: sessionPath,
+	})
+	if err != nil {
+		t.Fatalf("ReadSession() error = %v", err)
+	}
+
+	if !bytes.Equal(transcriptData, session.NativeData) {
+		t.Error("ReadTranscript() and ReadSession().NativeData should return identical bytes")
+	}
+}
+
+// --- DetectPresence ---
+
+func TestDetectPresence_NoKiroDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	ag := &KiroAgent{}
+	present, err := ag.DetectPresence(context.Background())
+	if err != nil {
+		t.Fatalf("DetectPresence() error = %v", err)
+	}
+	if present {
+		t.Error("DetectPresence() = true, want false")
+	}
+}
+
+func TestDetectPresence_WithKiroDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".kiro"), 0o755); err != nil {
+		t.Fatalf("failed to create .kiro: %v", err)
+	}
+
+	initGitRepo(t, tmpDir)
+
+	ag := &KiroAgent{}
+	present, err := ag.DetectPresence(context.Background())
+	if err != nil {
+		t.Fatalf("DetectPresence() error = %v", err)
+	}
+	if !present {
+		t.Error("DetectPresence() = false, want true")
+	}
+}
+
+// --- sanitizePathForKiro ---
+
+func TestSanitizePathForKiro(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"/Users/robin/project", "-Users-robin-project"},
+		{"/tmp/test", "-tmp-test"},
+		{"simple", "simple"},
+		{"/path/with spaces/dir", "-path-with-spaces-dir"},
+		{"/path.with.dots/dir", "-path-with-dots-dir"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			result := sanitizePathForKiro(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizePathForKiro(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// --- helpers ---
+
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("failed to create .git: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("failed to write HEAD: %v", err)
+	}
+}

--- a/cmd/entire/cli/agent/kiro/lifecycle.go
+++ b/cmd/entire/cli/agent/kiro/lifecycle.go
@@ -1,0 +1,115 @@
+package kiro
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// ParseHookEvent translates a Kiro hook into a normalized lifecycle Event.
+// Returns nil if the hook has no lifecycle significance.
+func (k *KiroAgent) ParseHookEvent(_ context.Context, hookName string, stdin io.Reader) (*agent.Event, error) {
+	switch hookName {
+	case HookNameAgentSpawn:
+		return k.parseSessionStart(stdin)
+	case HookNameUserPromptSubmit:
+		return k.parseTurnStart(stdin)
+	case HookNameStop:
+		return k.parseTurnEnd(stdin)
+	case HookNamePreToolUse:
+		return k.parsePreToolUse(stdin)
+	case HookNamePostToolUse:
+		return k.parsePostToolUse(stdin)
+	default:
+		return nil, nil //nolint:nilnil // Unknown hooks have no lifecycle action
+	}
+}
+
+// ReadTranscript reads the raw transcript bytes for a session.
+func (k *KiroAgent) ReadTranscript(sessionRef string) ([]byte, error) {
+	data, err := os.ReadFile(sessionRef) //nolint:gosec // Path comes from agent hook input
+	if err != nil {
+		return nil, fmt.Errorf("failed to read transcript: %w", err)
+	}
+	return data, nil
+}
+
+// Note: KiroAgent does NOT implement TranscriptAnalyzer. Kiro uses SQLite
+// for sessions, so transcript-based file extraction is not available.
+// File detection relies on git status instead.
+
+// --- Internal hook parsing functions ---
+
+func (k *KiroAgent) parseSessionStart(stdin io.Reader) (*agent.Event, error) {
+	raw, err := agent.ReadAndParseHookInput[agentSpawnRaw](stdin)
+	if err != nil {
+		return nil, err
+	}
+	return &agent.Event{
+		Type:      agent.SessionStart,
+		SessionID: raw.SessionID,
+		Timestamp: time.Now(),
+	}, nil
+}
+
+func (k *KiroAgent) parseTurnStart(stdin io.Reader) (*agent.Event, error) {
+	raw, err := agent.ReadAndParseHookInput[userPromptSubmitRaw](stdin)
+	if err != nil {
+		return nil, err
+	}
+	return &agent.Event{
+		Type:      agent.TurnStart,
+		SessionID: raw.SessionID,
+		Prompt:    raw.Prompt,
+		Timestamp: time.Now(),
+	}, nil
+}
+
+func (k *KiroAgent) parseTurnEnd(stdin io.Reader) (*agent.Event, error) {
+	raw, err := agent.ReadAndParseHookInput[stopRaw](stdin)
+	if err != nil {
+		return nil, err
+	}
+	return &agent.Event{
+		Type:      agent.TurnEnd,
+		SessionID: raw.SessionID,
+		Timestamp: time.Now(),
+	}, nil
+}
+
+func (k *KiroAgent) parsePreToolUse(stdin io.Reader) (*agent.Event, error) {
+	raw, err := agent.ReadAndParseHookInput[preToolUseRaw](stdin)
+	if err != nil {
+		return nil, err
+	}
+	// Only map to SubagentStart for delegation-like tools
+	if raw.ToolName == "" {
+		return nil, nil //nolint:nilnil // No tool name means no lifecycle action
+	}
+	return &agent.Event{
+		Type:      agent.SubagentStart,
+		SessionID: raw.SessionID,
+		ToolUseID: raw.ToolUseID,
+		Timestamp: time.Now(),
+	}, nil
+}
+
+func (k *KiroAgent) parsePostToolUse(stdin io.Reader) (*agent.Event, error) {
+	raw, err := agent.ReadAndParseHookInput[postToolUseRaw](stdin)
+	if err != nil {
+		return nil, err
+	}
+	if raw.ToolName == "" {
+		return nil, nil //nolint:nilnil // No tool name means no lifecycle action
+	}
+	return &agent.Event{
+		Type:      agent.SubagentEnd,
+		SessionID: raw.SessionID,
+		ToolUseID: raw.ToolUseID,
+		Timestamp: time.Now(),
+	}, nil
+}

--- a/cmd/entire/cli/agent/kiro/lifecycle_test.go
+++ b/cmd/entire/cli/agent/kiro/lifecycle_test.go
@@ -1,0 +1,271 @@
+package kiro
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+func TestParseHookEvent_SessionStart(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+	input := `{"session_id": "test-session-123", "hook_event_name": "agentSpawn", "cwd": "/tmp/repo"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameAgentSpawn, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if event.Type != agent.SessionStart {
+		t.Errorf("expected event type %v, got %v", agent.SessionStart, event.Type)
+	}
+	if event.SessionID != "test-session-123" {
+		t.Errorf("expected session_id 'test-session-123', got %q", event.SessionID)
+	}
+	if event.Timestamp.IsZero() {
+		t.Error("expected non-zero timestamp")
+	}
+}
+
+func TestParseHookEvent_TurnStart(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+	input := `{"session_id": "sess-456", "hook_event_name": "userPromptSubmit", "cwd": "/tmp/repo", "prompt": "Hello world"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameUserPromptSubmit, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if event.Type != agent.TurnStart {
+		t.Errorf("expected event type %v, got %v", agent.TurnStart, event.Type)
+	}
+	if event.SessionID != "sess-456" {
+		t.Errorf("expected session_id 'sess-456', got %q", event.SessionID)
+	}
+	if event.Prompt != "Hello world" {
+		t.Errorf("expected prompt 'Hello world', got %q", event.Prompt)
+	}
+}
+
+func TestParseHookEvent_TurnEnd(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+	input := `{"session_id": "sess-789", "hook_event_name": "stop", "cwd": "/tmp/repo"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameStop, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if event.Type != agent.TurnEnd {
+		t.Errorf("expected event type %v, got %v", agent.TurnEnd, event.Type)
+	}
+	if event.SessionID != "sess-789" {
+		t.Errorf("expected session_id 'sess-789', got %q", event.SessionID)
+	}
+}
+
+func TestParseHookEvent_PreToolUse(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+	input := `{"session_id": "sess-tool", "hook_event_name": "preToolUse", "cwd": "/tmp/repo", "tool_name": "write_file", "tool_use_id": "tu_123"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePreToolUse, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if event.Type != agent.SubagentStart {
+		t.Errorf("expected event type %v, got %v", agent.SubagentStart, event.Type)
+	}
+	if event.SessionID != "sess-tool" {
+		t.Errorf("expected session_id 'sess-tool', got %q", event.SessionID)
+	}
+	if event.ToolUseID != "tu_123" {
+		t.Errorf("expected tool_use_id 'tu_123', got %q", event.ToolUseID)
+	}
+}
+
+func TestParseHookEvent_PreToolUse_NoToolName_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+	input := `{"session_id": "sess-empty", "hook_event_name": "preToolUse", "cwd": "/tmp/repo"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePreToolUse, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Errorf("expected nil event for preToolUse with no tool_name, got %+v", event)
+	}
+}
+
+func TestParseHookEvent_PostToolUse(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+	input := `{"session_id": "sess-post", "hook_event_name": "postToolUse", "cwd": "/tmp/repo", "tool_name": "write_file", "tool_use_id": "tu_456"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if event.Type != agent.SubagentEnd {
+		t.Errorf("expected event type %v, got %v", agent.SubagentEnd, event.Type)
+	}
+	if event.ToolUseID != "tu_456" {
+		t.Errorf("expected tool_use_id 'tu_456', got %q", event.ToolUseID)
+	}
+}
+
+func TestParseHookEvent_PostToolUse_NoToolName_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+	input := `{"session_id": "sess-empty", "hook_event_name": "postToolUse", "cwd": "/tmp/repo"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Errorf("expected nil event for postToolUse with no tool_name, got %+v", event)
+	}
+}
+
+func TestParseHookEvent_UnknownHook_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+	input := `{"session_id": "unknown"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), "unknown-hook-name", strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Errorf("expected nil event for unknown hook, got %+v", event)
+	}
+}
+
+func TestParseHookEvent_EmptyInput_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+
+	_, err := ag.ParseHookEvent(context.Background(), HookNameAgentSpawn, strings.NewReader(""))
+
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty hook input") {
+		t.Errorf("expected 'empty hook input' error, got: %v", err)
+	}
+}
+
+func TestParseHookEvent_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	ag := &KiroAgent{}
+	input := `{"session_id": "test", "cwd": INVALID}`
+
+	_, err := ag.ParseHookEvent(context.Background(), HookNameAgentSpawn, strings.NewReader(input))
+
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse hook input") {
+		t.Errorf("expected 'failed to parse hook input' error, got: %v", err)
+	}
+}
+
+func TestParseHookEvent_AllHookTypes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		hookName      string
+		expectedType  agent.EventType
+		expectNil     bool
+		inputTemplate string
+	}{
+		{
+			hookName:      HookNameAgentSpawn,
+			expectedType:  agent.SessionStart,
+			inputTemplate: `{"session_id": "s1", "cwd": "/tmp"}`,
+		},
+		{
+			hookName:      HookNameUserPromptSubmit,
+			expectedType:  agent.TurnStart,
+			inputTemplate: `{"session_id": "s2", "cwd": "/tmp", "prompt": "hi"}`,
+		},
+		{
+			hookName:      HookNameStop,
+			expectedType:  agent.TurnEnd,
+			inputTemplate: `{"session_id": "s3", "cwd": "/tmp"}`,
+		},
+		{
+			hookName:      HookNamePreToolUse,
+			expectedType:  agent.SubagentStart,
+			inputTemplate: `{"session_id": "s4", "cwd": "/tmp", "tool_name": "write", "tool_use_id": "t1"}`,
+		},
+		{
+			hookName:      HookNamePostToolUse,
+			expectedType:  agent.SubagentEnd,
+			inputTemplate: `{"session_id": "s5", "cwd": "/tmp", "tool_name": "write", "tool_use_id": "t2"}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.hookName, func(t *testing.T) {
+			t.Parallel()
+
+			ag := &KiroAgent{}
+			event, err := ag.ParseHookEvent(context.Background(), tc.hookName, strings.NewReader(tc.inputTemplate))
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.expectNil {
+				if event != nil {
+					t.Errorf("expected nil event, got %+v", event)
+				}
+				return
+			}
+
+			if event == nil {
+				t.Fatal("expected event, got nil")
+			}
+			if event.Type != tc.expectedType {
+				t.Errorf("expected event type %v, got %v", tc.expectedType, event.Type)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/agent/kiro/types.go
+++ b/cmd/entire/cli/agent/kiro/types.go
@@ -1,0 +1,70 @@
+package kiro
+
+// KiroHooksFile represents the .kiro/hooks.json structure.
+// Kiro uses a flat JSON file with hooks sections, similar to Cursor.
+//
+//nolint:revive // KiroHooksFile is clearer than HooksFile when used outside this package
+type KiroHooksFile struct {
+	Hooks KiroHooks `json:"hooks"`
+}
+
+// KiroHooks contains all hook configurations.
+//
+//nolint:revive // KiroHooks is clearer than Hooks when used outside this package
+type KiroHooks struct {
+	AgentSpawn       []KiroHookEntry `json:"agentSpawn,omitempty"`
+	UserPromptSubmit []KiroHookEntry `json:"userPromptSubmit,omitempty"`
+	Stop             []KiroHookEntry `json:"stop,omitempty"`
+	PreToolUse       []KiroHookEntry `json:"preToolUse,omitempty"`
+	PostToolUse      []KiroHookEntry `json:"postToolUse,omitempty"`
+}
+
+// KiroHookEntry represents a single hook command.
+//
+//nolint:revive // KiroHookEntry is clearer than HookEntry when used outside this package
+type KiroHookEntry struct {
+	Command string `json:"command"`
+	Matcher string `json:"matcher,omitempty"`
+}
+
+// agentSpawnRaw is the JSON structure from Kiro's agentSpawn hook.
+type agentSpawnRaw struct {
+	SessionID     string `json:"session_id"`
+	HookEventName string `json:"hook_event_name"`
+	CWD           string `json:"cwd"`
+}
+
+// userPromptSubmitRaw is the JSON structure from Kiro's userPromptSubmit hook.
+type userPromptSubmitRaw struct {
+	SessionID     string `json:"session_id"`
+	HookEventName string `json:"hook_event_name"`
+	CWD           string `json:"cwd"`
+	Prompt        string `json:"prompt"`
+}
+
+// stopRaw is the JSON structure from Kiro's stop hook.
+type stopRaw struct {
+	SessionID     string `json:"session_id"`
+	HookEventName string `json:"hook_event_name"`
+	CWD           string `json:"cwd"`
+}
+
+// preToolUseRaw is the JSON structure from Kiro's preToolUse hook.
+type preToolUseRaw struct {
+	SessionID     string `json:"session_id"`
+	HookEventName string `json:"hook_event_name"`
+	CWD           string `json:"cwd"`
+	ToolName      string `json:"tool_name"`
+	ToolUseID     string `json:"tool_use_id"`
+	Input         string `json:"input"`
+}
+
+// postToolUseRaw is the JSON structure from Kiro's postToolUse hook.
+type postToolUseRaw struct {
+	SessionID     string `json:"session_id"`
+	HookEventName string `json:"hook_event_name"`
+	CWD           string `json:"cwd"`
+	ToolName      string `json:"tool_name"`
+	ToolUseID     string `json:"tool_use_id"`
+	Output        string `json:"output"`
+}

--- a/cmd/entire/cli/agent/registry.go
+++ b/cmd/entire/cli/agent/registry.go
@@ -107,6 +107,7 @@ const (
 	AgentNameClaudeCode AgentName = "claude-code"
 	AgentNameCursor     AgentName = "cursor"
 	AgentNameGemini     AgentName = "gemini"
+	AgentNameKiro       AgentName = "kiro"
 	AgentNameOpenCode   AgentName = "opencode"
 )
 
@@ -115,6 +116,7 @@ const (
 	AgentTypeClaudeCode AgentType = "Claude Code"
 	AgentTypeCursor     AgentType = "Cursor"
 	AgentTypeGemini     AgentType = "Gemini CLI"
+	AgentTypeKiro       AgentType = "Kiro"
 	AgentTypeOpenCode   AgentType = "OpenCode"
 	AgentTypeUnknown    AgentType = "Agent" // Fallback for backwards compatibility
 )

--- a/cmd/entire/cli/checkpoint/temporary.go
+++ b/cmd/entire/cli/checkpoint/temporary.go
@@ -538,7 +538,7 @@ func (s *GitStore) ListAllTemporaryCheckpoints(ctx context.Context, sessionID st
 		branchCheckpoints, branchErr := s.listCheckpointsForBranch(ctx, branch.BranchName, sessionID, limit)
 		if branchErr != nil {
 			if errors.Is(branchErr, context.Canceled) || errors.Is(branchErr, context.DeadlineExceeded) {
-				return nil, branchErr //nolint:wrapcheck // Propagating context cancellation
+				return nil, branchErr
 			}
 			continue // Skip branches we can't read
 		}

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -549,7 +549,7 @@ func scopeTranscriptForCheckpoint(fullTranscript []byte, startOffset int, agentT
 			return nil
 		}
 		return scoped
-	case agent.AgentTypeClaudeCode, agent.AgentTypeCursor, agent.AgentTypeUnknown:
+	case agent.AgentTypeClaudeCode, agent.AgentTypeCursor, agent.AgentTypeKiro, agent.AgentTypeUnknown:
 		return transcript.SliceFromLine(fullTranscript, startOffset)
 	}
 	return transcript.SliceFromLine(fullTranscript, startOffset)
@@ -1565,7 +1565,7 @@ func transcriptOffset(transcriptBytes []byte, agentType agent.AgentType) int {
 			return 0
 		}
 		return len(t.Messages)
-	case agent.AgentTypeClaudeCode, agent.AgentTypeOpenCode, agent.AgentTypeCursor, agent.AgentTypeUnknown:
+	case agent.AgentTypeClaudeCode, agent.AgentTypeOpenCode, agent.AgentTypeCursor, agent.AgentTypeKiro, agent.AgentTypeUnknown:
 		return countLines(transcriptBytes)
 	}
 	return countLines(transcriptBytes)

--- a/cmd/entire/cli/hooks_cmd.go
+++ b/cmd/entire/cli/hooks_cmd.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/cursor"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/kiro"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/opencode"
 
 	"github.com/spf13/cobra"

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -246,7 +246,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 					slog.String("error", sliceErr.Error()))
 			}
 			scopedTranscript = scoped
-		case agent.AgentTypeClaudeCode, agent.AgentTypeCursor, agent.AgentTypeUnknown:
+		case agent.AgentTypeClaudeCode, agent.AgentTypeCursor, agent.AgentTypeKiro, agent.AgentTypeUnknown:
 			scopedTranscript = transcript.SliceFromLine(sessionData.Transcript, state.CheckpointTranscriptStart)
 		}
 		if len(scopedTranscript) > 0 {

--- a/cmd/entire/cli/summarize/summarize.go
+++ b/cmd/entire/cli/summarize/summarize.go
@@ -119,8 +119,8 @@ func BuildCondensedTranscriptFromBytes(content []byte, agentType agent.AgentType
 		return buildCondensedTranscriptFromGemini(content)
 	case agent.AgentTypeOpenCode:
 		return buildCondensedTranscriptFromOpenCode(content)
-	case agent.AgentTypeClaudeCode, agent.AgentTypeCursor, agent.AgentTypeUnknown:
-		// Claude/cursor format - fall through to shared logic below
+	case agent.AgentTypeClaudeCode, agent.AgentTypeCursor, agent.AgentTypeKiro, agent.AgentTypeUnknown:
+		// Claude/Cursor/Kiro format - fall through to shared logic below
 	}
 	// Claude format (JSONL) - handles Claude Code, Unknown, and any future agent types
 	lines, err := transcript.ParseFromBytes(content)

--- a/e2e/agents/kiro.go
+++ b/e2e/agents/kiro.go
@@ -1,0 +1,117 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func init() {
+	if env := os.Getenv("E2E_AGENT"); env != "" && env != "kiro" {
+		return
+	}
+	if _, err := exec.LookPath("kiro-cli"); err != nil {
+		return
+	}
+	Register(&kiroAgent{timeout: 2 * time.Minute})
+}
+
+type kiroAgent struct {
+	timeout time.Duration
+}
+
+func (a *kiroAgent) Name() string               { return "kiro" }
+func (a *kiroAgent) Binary() string             { return "kiro-cli" }
+func (a *kiroAgent) EntireAgent() string        { return "kiro" }
+func (a *kiroAgent) PromptPattern() string      { return `❯` }
+func (a *kiroAgent) TimeoutMultiplier() float64 { return 1.5 }
+
+func (a *kiroAgent) IsTransientError(out Output, err error) bool {
+	if err == nil {
+		return false
+	}
+	combined := out.Stdout + out.Stderr
+	transientPatterns := []string{
+		"overloaded",
+		"rate limit",
+		"429",
+		"503",
+		"ECONNRESET",
+		"ETIMEDOUT",
+	}
+	for _, p := range transientPatterns {
+		if strings.Contains(combined, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *kiroAgent) Bootstrap() error {
+	return nil
+}
+
+func (a *kiroAgent) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
+	cfg := &runConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	args := []string{"chat", "--no-interactive", "--agent", "entire", prompt}
+
+	timeout := a.timeout
+	if envTimeout := os.Getenv("E2E_TIMEOUT"); envTimeout != "" {
+		if parsed, err := time.ParseDuration(envTimeout); err == nil {
+			timeout = parsed
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, a.Binary(), args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0")
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	out := Output{
+		Command: a.Binary() + " " + strings.Join(args, " "),
+		Stdout:  stdout.String(),
+		Stderr:  stderr.String(),
+	}
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			out.ExitCode = exitErr.ExitCode()
+		} else {
+			out.ExitCode = -1
+		}
+		return out, err
+	}
+
+	return out, nil
+}
+
+func (a *kiroAgent) StartSession(ctx context.Context, dir string) (Session, error) {
+	name := fmt.Sprintf("kiro-test-%d", time.Now().UnixNano())
+	s, err := NewTmuxSession(name, dir, nil, "env", "ENTIRE_TEST_TTY=0", a.Binary(), "chat", "--agent", "entire")
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := s.WaitFor(`❯`, 15*time.Second); err != nil {
+		_ = s.Close()
+		return nil, fmt.Errorf("waiting for startup: %w", err)
+	}
+	s.stableAtSend = ""
+	return s, nil
+}

--- a/e2e/tests/main_test.go
+++ b/e2e/tests/main_test.go
@@ -28,6 +28,8 @@ func TestMain(m *testing.M) {
 	// Resolve the entire binary (builds from source if E2E_ENTIRE_BIN is unset).
 	entireBin := entire.BinPath()
 
+	os.Setenv("PATH", filepath.Dir(entireBin)+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	// Preflight: verify required dependencies before running any tests.
 	var missing []string
 	for _, bin := range []string{"git", "tmux"} {

--- a/mise.toml
+++ b/mise.toml
@@ -162,6 +162,20 @@ go run ./e2e/cmd/testreport -color -o "$E2E_ARTIFACT_DIR/report.txt" "$E2E_ARTIF
 exit ${rc:-0}
 """
 
+[tasks."test:e2e:kiro"]
+description = "Run E2E tests with Kiro"
+usage = 'arg "[filter]" help="Test name filter (regex)" default=""'
+quiet = true
+run = """
+E2E_ARTIFACT_DIR="$PWD/e2e/artifacts/$(date +%Y-%m-%dT%H-%M-%S)"
+export E2E_ARTIFACT_DIR
+mkdir -p "$E2E_ARTIFACT_DIR"
+echo "artifacts: $E2E_ARTIFACT_DIR"
+E2E_AGENT=kiro gotestsum --format dots --jsonfile "$E2E_ARTIFACT_DIR/test-events.json" -- -tags=e2e -count=1 -timeout=30m ${usage_filter:+-run "$usage_filter"} ./e2e/tests/... || rc=$?
+go run ./e2e/cmd/testreport -color -o "$E2E_ARTIFACT_DIR/report.txt" "$E2E_ARTIFACT_DIR/test-events.json"
+exit ${rc:-0}
+"""
+
 [tasks."test:e2e:opencode"]
 description = "Run E2E tests with OpenCode"
 usage = 'arg "[filter]" help="Test name filter (regex)" default=""'

--- a/scripts/test-kiro-agent-integration.sh
+++ b/scripts/test-kiro-agent-integration.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# Test script for Kiro agent integration with Entire CLI.
+# Captures hook payloads from kiro-cli to validate lifecycle mapping.
+#
+# Usage:
+#   ./scripts/test-kiro-agent-integration.sh              # Static checks only
+#   ./scripts/test-kiro-agent-integration.sh --manual-live # Interactive capture mode
+#
+# In --manual-live mode, the script:
+#   1. Creates a temporary .kiro/agents/entire-probe.json agent config
+#   2. Waits for you to run: kiro-cli chat --agent entire-probe
+#   3. Captures all hook payloads to .entire/tmp/probe-kiro-*/captures/
+#   4. Pretty-prints captured payloads and generates a compatibility report
+#
+# Prerequisites: kiro-cli must be installed and in PATH.
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+MANUAL_LIVE=false
+if [[ "$1" == "--manual-live" ]]; then
+    MANUAL_LIVE=true
+fi
+
+pass() { echo -e "${GREEN}PASS${NC}: $1"; }
+warn() { echo -e "${YELLOW}WARN${NC}: $1"; }
+fail() { echo -e "${RED}FAIL${NC}: $1"; }
+info() { echo -e "${BLUE}INFO${NC}: $1"; }
+
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+
+check_pass() { ((PASS_COUNT++)); pass "$1"; }
+check_warn() { ((WARN_COUNT++)); warn "$1"; }
+check_fail() { ((FAIL_COUNT++)); fail "$1"; }
+
+echo "=============================================="
+echo "  Kiro Agent Integration - Compatibility Test"
+echo "=============================================="
+echo ""
+
+# --- Static Checks ---
+info "Phase 1: Static checks"
+
+# Check kiro-cli binary
+if command -v kiro-cli &>/dev/null; then
+    KIRO_BIN=$(command -v kiro-cli)
+    check_pass "kiro-cli found: $KIRO_BIN"
+else
+    check_fail "kiro-cli not found in PATH"
+    echo "Install kiro-cli and try again."
+    exit 1
+fi
+
+# Check version
+KIRO_VERSION=$(kiro-cli --version 2>&1 || true)
+if [[ -n "$KIRO_VERSION" ]]; then
+    check_pass "kiro-cli version: $KIRO_VERSION"
+else
+    check_warn "Could not determine kiro-cli version"
+fi
+
+# Check help output for hook-related flags
+KIRO_HELP=$(kiro-cli --help 2>&1 || true)
+if echo "$KIRO_HELP" | grep -qi "agent"; then
+    check_pass "kiro-cli help mentions 'agent'"
+else
+    check_warn "kiro-cli help does not mention 'agent'"
+fi
+
+if echo "$KIRO_HELP" | grep -qi "hook"; then
+    check_pass "kiro-cli help mentions 'hook'"
+else
+    check_warn "kiro-cli help does not mention 'hook' (hooks may be agent-config-only)"
+fi
+
+# Check config directories
+KIRO_CONFIG_DIR="$HOME/.kiro"
+if [[ -d "$KIRO_CONFIG_DIR" ]]; then
+    check_pass "Kiro config dir exists: $KIRO_CONFIG_DIR"
+else
+    check_warn "Kiro config dir not found: $KIRO_CONFIG_DIR"
+fi
+
+if [[ -d "$KIRO_CONFIG_DIR/agents" ]]; then
+    check_pass "Kiro agents dir exists: $KIRO_CONFIG_DIR/agents"
+else
+    check_warn "Kiro agents dir not found: $KIRO_CONFIG_DIR/agents (will be created)"
+fi
+
+echo ""
+
+# --- Manual Live Capture ---
+if [[ "$MANUAL_LIVE" != "true" ]]; then
+    info "Skipping live capture (use --manual-live to enable)"
+    echo ""
+    echo "=== Summary ==="
+    echo -e "  ${GREEN}PASS${NC}: $PASS_COUNT"
+    echo -e "  ${YELLOW}WARN${NC}: $WARN_COUNT"
+    echo -e "  ${RED}FAIL${NC}: $FAIL_COUNT"
+    exit 0
+fi
+
+info "Phase 2: Manual live capture mode"
+echo ""
+
+# Create capture directory
+CAPTURE_DIR=".entire/tmp/probe-kiro-$(date +%s)"
+mkdir -p "$CAPTURE_DIR/captures"
+info "Capture directory: $CAPTURE_DIR"
+
+# Create the hook capture script
+CAPTURE_SCRIPT="$CAPTURE_DIR/capture-hook.sh"
+cat > "$CAPTURE_SCRIPT" << 'HOOK_SCRIPT'
+#!/bin/bash
+# Capture hook payload from stdin
+EVENT_NAME="${1:-unknown}"
+CAPTURE_DIR="${2:-.}"
+TIMESTAMP=$(date +%s%N)
+OUTFILE="$CAPTURE_DIR/captures/${EVENT_NAME}-${TIMESTAMP}.json"
+cat > "$OUTFILE"
+echo "Captured: $OUTFILE" >&2
+HOOK_SCRIPT
+chmod +x "$CAPTURE_SCRIPT"
+
+CAPTURE_SCRIPT_ABS="$(cd "$(dirname "$CAPTURE_SCRIPT")" && pwd)/$(basename "$CAPTURE_SCRIPT")"
+CAPTURE_DIR_ABS="$(cd "$CAPTURE_DIR" && pwd)"
+
+# Create probe agent config
+AGENT_CONFIG_DIR="$KIRO_CONFIG_DIR/agents"
+mkdir -p "$AGENT_CONFIG_DIR"
+PROBE_CONFIG="$AGENT_CONFIG_DIR/entire-probe.json"
+
+cat > "$PROBE_CONFIG" << EOF
+{
+  "name": "entire-probe",
+  "description": "Entire CLI integration probe - captures hook payloads for analysis",
+  "hooks": {
+    "agentSpawn": [{"command": "$CAPTURE_SCRIPT_ABS agent-spawn $CAPTURE_DIR_ABS"}],
+    "userPromptSubmit": [{"command": "$CAPTURE_SCRIPT_ABS user-prompt-submit $CAPTURE_DIR_ABS"}],
+    "stop": [{"command": "$CAPTURE_SCRIPT_ABS stop $CAPTURE_DIR_ABS"}],
+    "preToolUse": [{"command": "$CAPTURE_SCRIPT_ABS pre-tool-use $CAPTURE_DIR_ABS"}],
+    "postToolUse": [{"command": "$CAPTURE_SCRIPT_ABS post-tool-use $CAPTURE_DIR_ABS"}]
+  }
+}
+EOF
+
+info "Created probe agent config: $PROBE_CONFIG"
+echo ""
+echo "=============================================="
+echo "  Now run the following in another terminal:"
+echo ""
+echo "    kiro-cli chat --agent entire-probe"
+echo ""
+echo "  Then interact with Kiro (send a prompt,"
+echo "  let it use tools, then stop the session)."
+echo "  Press Enter here when done."
+echo "=============================================="
+echo ""
+
+read -r -p "Press Enter to collect captures..."
+
+echo ""
+info "Phase 3: Capture collection"
+
+# Collect and display captures
+CAPTURE_COUNT=$(find "$CAPTURE_DIR/captures" -name "*.json" 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$CAPTURE_COUNT" -eq 0 ]]; then
+    check_fail "No hook payloads captured"
+    echo "Make sure you ran kiro-cli chat --agent entire-probe and interacted with it."
+else
+    check_pass "Captured $CAPTURE_COUNT hook payloads"
+    echo ""
+
+    for f in "$CAPTURE_DIR/captures"/*.json; do
+        EVENT=$(basename "$f" | sed 's/-[0-9]*\.json$//')
+        echo -e "${BLUE}--- $EVENT ---${NC}"
+        if command -v jq &>/dev/null; then
+            jq . "$f" 2>/dev/null || cat "$f"
+        else
+            cat "$f"
+        fi
+        echo ""
+
+        # Check for key fields
+        if command -v jq &>/dev/null; then
+            HAS_SESSION_ID=$(jq -r 'has("session_id")' "$f" 2>/dev/null || echo "false")
+            HAS_CONVERSATION_ID=$(jq -r 'has("conversation_id")' "$f" 2>/dev/null || echo "false")
+            HAS_TRANSCRIPT_PATH=$(jq -r 'has("transcript_path")' "$f" 2>/dev/null || echo "false")
+            HAS_HOOK_EVENT_NAME=$(jq -r 'has("hook_event_name")' "$f" 2>/dev/null || echo "false")
+            HAS_CWD=$(jq -r 'has("cwd")' "$f" 2>/dev/null || echo "false")
+
+            [[ "$HAS_SESSION_ID" == "true" ]] && info "  session_id: present"
+            [[ "$HAS_CONVERSATION_ID" == "true" ]] && info "  conversation_id: present"
+            [[ "$HAS_TRANSCRIPT_PATH" == "true" ]] && info "  transcript_path: present"
+            [[ "$HAS_HOOK_EVENT_NAME" == "true" ]] && info "  hook_event_name: present"
+            [[ "$HAS_CWD" == "true" ]] && info "  cwd: present"
+        fi
+        echo ""
+    done
+fi
+
+# Cleanup probe config
+rm -f "$PROBE_CONFIG"
+info "Removed probe agent config: $PROBE_CONFIG"
+
+echo ""
+echo "=== Compatibility Report ==="
+echo ""
+echo "| Kiro Hook          | Entire EventType | Status   |"
+echo "|-------------------|-----------------|----------|"
+
+for EVENT in agent-spawn user-prompt-submit stop pre-tool-use post-tool-use; do
+    COUNT=$(find "$CAPTURE_DIR/captures" -name "${EVENT}-*.json" 2>/dev/null | wc -l | tr -d ' ')
+    case "$EVENT" in
+        agent-spawn)        ENTIRE_EVENT="SessionStart";;
+        user-prompt-submit) ENTIRE_EVENT="TurnStart";;
+        stop)               ENTIRE_EVENT="TurnEnd";;
+        pre-tool-use)       ENTIRE_EVENT="SubagentStart";;
+        post-tool-use)      ENTIRE_EVENT="SubagentEnd";;
+    esac
+    if [[ "$COUNT" -gt 0 ]]; then
+        echo "| $EVENT | $ENTIRE_EVENT | CAPTURED |"
+    else
+        echo "| $EVENT | $ENTIRE_EVENT | MISSING  |"
+    fi
+done
+
+echo ""
+echo "=== Summary ==="
+echo -e "  ${GREEN}PASS${NC}: $PASS_COUNT"
+echo -e "  ${YELLOW}WARN${NC}: $WARN_COUNT"
+echo -e "  ${RED}FAIL${NC}: $FAIL_COUNT"
+echo ""
+info "Captures saved to: $CAPTURE_DIR/captures/"
+echo "Review the JSON payloads to determine exact field names for the Kiro agent types."


### PR DESCRIPTION
Implement the Agent and HookSupport interfaces for Amazon's Kiro CLI, following the Cursor agent as the closest template. Kiro hooks are installed in .kiro/hooks.json and map to Entire lifecycle events: agentSpawn→SessionStart, userPromptSubmit→TurnStart, stop→TurnEnd, preToolUse→SubagentStart, postToolUse→SubagentEnd.

New files:
- cmd/entire/cli/agent/kiro/ (types, core, lifecycle, hooks + tests)
- e2e/agents/kiro.go (E2E test runner)
- scripts/test-kiro-agent-integration.sh (payload capture script)

Also adds AgentTypeKiro to all exhaustive switch statements, registers the agent in hooks_cmd.go, and adds the test:e2e:kiro mise task.


Entire-Checkpoint: 0816e5acc0d2