### PR TITLE
Add opencode database lock to transient errors

### DIFF
--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -44,6 +44,7 @@ func (a *openCodeAgent) IsTransientError(out Output, _ error) bool {
 		"ECONNRESET",
 		"ETIMEDOUT",
 		"Token refresh failed",
+		"database is locked",
 	}
 	for _, p := range transientPatterns {
 		if strings.Contains(out.Stderr, p) {


### PR DESCRIPTION
## Summary
- Adds `"database is locked"` to opencode's transient error patterns so the E2E retry logic handles SQLite lock contention from parallel tests

## Context
Flaky failure on CI: `TestMultiSessionSequential/opencode` (1/37) — opencode's shared SQLite DB hit a lock when two tests raced to open it. The bootstrap warmup mitigates most cases, but this catches the rare remainder.

## Test plan
- [x] `mise run lint` clean
- [x] `mise run test:ci` passing