### PR TITLE
Handle factory ai welcome message, new HookResponseWriter interface

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -172,6 +172,18 @@ type TokenCalculator interface {
 	CalculateTokenUsage(transcriptData []byte, fromOffset int) (*TokenUsage, error)
 }
 
+// HookResponseWriter is implemented by agents that support structured hook responses.
+// Agents that implement this can output messages (e.g., banners) to the user via
+// the agent's response protocol. For example, Claude Code outputs JSON with a
+// systemMessage field to stdout. Agents that don't implement this will silently
+// skip hook response output.
+type HookResponseWriter interface {
+	Agent
+
+	// WriteHookResponse outputs a message to the user via the agent's hook response protocol.
+	WriteHookResponse(message string) error
+}
+
 // SubagentAwareExtractor provides methods for extracting files and tokens including subagents.
 // Agents that support spawning subagents (like Claude Code's Task tool) should implement this
 // to ensure subagent contributions are included in checkpoints.

--- a/cmd/entire/cli/agent/claudecode/lifecycle.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle.go
@@ -22,7 +22,20 @@ var (
 	_ agent.TranscriptPreparer     = (*ClaudeCodeAgent)(nil)
 	_ agent.TokenCalculator        = (*ClaudeCodeAgent)(nil)
 	_ agent.SubagentAwareExtractor = (*ClaudeCodeAgent)(nil)
+	_ agent.HookResponseWriter     = (*ClaudeCodeAgent)(nil)
 )
+
+// WriteHookResponse outputs a JSON hook response to stdout.
+// Claude Code reads this JSON and displays the systemMessage to the user.
+func (c *ClaudeCodeAgent) WriteHookResponse(message string) error {
+	resp := struct {
+		SystemMessage string `json:"systemMessage,omitempty"`
+	}{SystemMessage: message}
+	if err := json.NewEncoder(os.Stdout).Encode(resp); err != nil {
+		return fmt.Errorf("failed to encode hook response: %w", err)
+	}
+	return nil
+}
 
 // HookNames returns the hook verbs Claude Code supports.
 // These become subcommands: entire hooks claude-code <verb>

--- a/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
+++ b/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
@@ -18,7 +18,18 @@ var (
 	_ agent.TranscriptAnalyzer     = (*FactoryAIDroidAgent)(nil)
 	_ agent.TokenCalculator        = (*FactoryAIDroidAgent)(nil)
 	_ agent.SubagentAwareExtractor = (*FactoryAIDroidAgent)(nil)
+	_ agent.HookResponseWriter     = (*FactoryAIDroidAgent)(nil)
 )
+
+// WriteHookResponse outputs the hook response as plain text to stdout.
+// Factory AI Droid does not parse the JSON systemMessage protocol,
+// so we write plain text that it displays directly in the terminal.
+func (f *FactoryAIDroidAgent) WriteHookResponse(message string) error {
+	if _, err := fmt.Fprintln(os.Stdout, message); err != nil {
+		return fmt.Errorf("failed to write hook response: %w", err)
+	}
+	return nil
+}
 
 // HookNames returns the hook verbs Factory AI Droid supports.
 // These become subcommands: entire hooks factoryai-droid <verb>

--- a/cmd/entire/cli/hooks.go
+++ b/cmd/entire/cli/hooks.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 )
@@ -230,21 +229,4 @@ func logPostTaskHookContext(w io.Writer, input *PostTaskHookInput, subagentTrans
 	} else {
 		_, _ = fmt.Fprintln(w, "  Subagent Transcript: (none)")
 	}
-}
-
-// hookResponse represents a JSON response.
-// Used to control whether Agent continues processing the prompt.
-type hookResponse struct {
-	SystemMessage string `json:"systemMessage,omitempty"`
-}
-
-// outputHookResponse outputs a JSON response to stdout
-func outputHookResponse(reason string) error {
-	resp := hookResponse{
-		SystemMessage: reason,
-	}
-	if err := json.NewEncoder(os.Stdout).Encode(resp); err != nil {
-		return fmt.Errorf("failed to encode hook response: %w", err)
-	}
-	return nil
 }

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -82,12 +82,16 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 		message += fmt.Sprintf("\n  %d other active conversation(s) in this workspace will also be included.\n  Use 'entire status' for more information.", count)
 	}
 
-	// Output informational message
+	// Output informational message if the agent supports hook responses.
+	// Claude Code reads JSON from stdout; agents that don't implement
+	// HookResponseWriter silently skip (avoids raw JSON in their terminal).
 	if event.ResponseMessage != "" {
 		message = event.ResponseMessage
 	}
-	if err := outputHookResponse(message); err != nil {
-		return err
+	if writer, ok := ag.(agent.HookResponseWriter); ok {
+		if err := writer.WriteHookResponse(message); err != nil {
+			return fmt.Errorf("failed to write hook response: %w", err)
+		}
 	}
 
 	// Fire EventSessionStart for the current session (if state exists).

--- a/docs/architecture/agent-guide.md
+++ b/docs/architecture/agent-guide.md
@@ -50,6 +50,7 @@ Every agent must implement all 19 methods on the `Agent` interface:
 | `TranscriptPreparer` | `PrepareTranscript` | Agent writes transcripts asynchronously and needs a flush/sync step |
 | `TokenCalculator` | `CalculateTokenUsage` | Agent's transcript contains token usage data |
 | `SubagentAwareExtractor` | `ExtractAllModifiedFiles`, `CalculateTotalTokenUsage` | Agent spawns subagents (like Claude Code's Task tool) |
+| `HookResponseWriter` | `WriteHookResponse` | Agent can display messages from hook responses (e.g., session start banner). Claude Code uses JSON `systemMessage` on stdout; Factory AI Droid uses plain text on stdout. |
 | `FileWatcher` | `GetWatchPaths`, `OnFileChange` | Agent doesn't support hooks; uses file-based detection instead |
 
 ## Step-by-Step Implementation Guide
@@ -502,6 +503,19 @@ The framework dispatcher (`DispatchLifecycleEvent` in `lifecycle.go`) handles ea
 **Without it:** Users must manually configure hooks to call `entire hooks <agent> <verb>`.
 
 **Implement when:** Your agent supports a config file with hook definitions (e.g., `.claude/settings.json`, `.gemini/settings.json`).
+
+### `HookResponseWriter`
+
+**What it enables:** Displaying messages to the user during hook execution (e.g., the "Powered by Entire" banner on session start).
+
+**Without it:** No message is shown to the user on session start. The framework silently skips the output.
+
+**Implement when:** Your agent displays hook stdout to the user. The output format is agent-specific:
+- Claude Code: JSON `{"systemMessage":"..."}` to stdout (parsed by Claude Code's UI)
+- Factory AI Droid: Plain text to stdout (displayed directly in terminal)
+
+**Methods:**
+- `WriteHookResponse(message string) error` - Output a message via the agent's hook response protocol.
 
 ### `FileWatcher`
 


### PR DESCRIPTION
When testing Factory AI Droid the welcome message was printed as json: 

```
>  {"systemMessage":"\n\nPowered by Entire:\n  This conversation will be linked to your next commit."}
```

This adds a new Interface to allow agent specific messaging. Factory AI Droid just needs a message, Claude a JSON and for Gemini, OpenCode and Cursor nothing is shown.