### PR TITLE
fix: optimize prepare-commit-msg hook performance for large repos

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1107,8 +1107,17 @@ func truncateHash(h string) string {
 func (s *ManualCommitStrategy) filterSessionsWithNewContent(ctx context.Context, repo *git.Repository, sessions []*SessionState) []*SessionState {
 	var result []*SessionState
 
-	// Compute staged files once for all sessions
-	stagedFiles := getStagedFiles(ctx)
+	// Compute staged files once for all sessions.
+	// On error, pass nil — sessionHasNewContent treats nil stagedFiles as
+	// "unavailable" and skips overlap checks, falling through to other heuristics.
+	stagedFiles, err := getStagedFiles(ctx)
+	if err != nil {
+		logging.Debug(logging.WithComponent(ctx, "manual-commit"),
+			"filterSessionsWithNewContent: getStagedFiles failed, skipping overlap checks",
+			slog.String("error", err.Error()),
+		)
+		stagedFiles = nil
+	}
 
 	for _, state := range sessions {
 		// Skip fully-condensed ended sessions — no new content possible.
@@ -1133,9 +1142,10 @@ func (s *ManualCommitStrategy) filterSessionsWithNewContent(ctx context.Context,
 // redundant work across multiple sessions in a single hook invocation.
 type contentCheckOpts struct {
 	// stagedFiles is the pre-computed list of staged files (from getStagedFiles).
-	// When nil, getStagedFiles is not called (PostCommit context where files are
-	// already committed). When non-nil (even if empty), the caller has already
-	// resolved staged files and no additional calls are needed.
+	// nil means staged files are unavailable (error or PostCommit context where
+	// files are already committed) — callers skip overlap checks and fall through
+	// to other heuristics (e.g., transcript growth).
+	// Non-nil empty means successfully resolved but no files are staged.
 	stagedFiles []string
 
 	// shadowTree, when non-nil, is used directly to avoid redundant shadow branch
@@ -1849,26 +1859,29 @@ func (s *ManualCommitStrategy) calculatePromptAttributionAtStart(
 // This is much faster than go-git's worktree.Status() which scans the entire
 // working tree. `git diff --cached --name-only` uses native git's optimized index
 // and filesystem monitors.
-func getStagedFiles(ctx context.Context) []string {
+//
+// Returns (non-nil empty slice, nil) when no files are staged — callers can
+// distinguish "no staged files" from "error resolving staged files" (nil, err).
+func getStagedFiles(ctx context.Context) ([]string, error) {
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("resolve worktree root: %w", err)
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--name-only")
 	cmd.Dir = repoRoot
 	output, err := cmd.Output()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("git diff --cached: %w", err)
 	}
 
-	var staged []string
+	staged := []string{}
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		if line != "" {
 			staged = append(staged, line)
 		}
 	}
-	return staged
+	return staged, nil
 }
 
 // getLastPrompt retrieves the most recent user prompt from a session's shadow branch.

--- a/cmd/entire/cli/strategy/mid_turn_commit_test.go
+++ b/cmd/entire/cli/strategy/mid_turn_commit_test.go
@@ -85,7 +85,8 @@ func TestSessionHasNewContentFromLiveTranscript_NormalizesAbsolutePaths(t *testi
 
 	// Call sessionHasNewContent — should fall through to live transcript check
 	// since there's no shadow branch. Pass staged files via contentCheckOpts.
-	stagedFiles := getStagedFiles(context.Background())
+	stagedFiles, err := getStagedFiles(context.Background())
+	require.NoError(t, err)
 	hasNew, err := s.sessionHasNewContent(context.Background(), repo, state, contentCheckOpts{stagedFiles: stagedFiles})
 	require.NoError(t, err)
 	assert.True(t, hasNew,
@@ -177,7 +178,8 @@ func TestSessionHasNewContentFromLiveTranscript_IncludesSubagentFiles(t *testing
 	// Call sessionHasNewContent — should fall through to live transcript check
 	// since there's no shadow branch, and should detect subagent file modifications.
 	// Pass staged files via contentCheckOpts.
-	stagedFiles := getStagedFiles(context.Background())
+	stagedFiles, err := getStagedFiles(context.Background())
+	require.NoError(t, err)
 	hasNew, err := s.sessionHasNewContent(context.Background(), repo, state, contentCheckOpts{stagedFiles: stagedFiles})
 	require.NoError(t, err)
 	assert.True(t, hasNew,

--- a/cmd/entire/cli/strategy/preparecommitmsg_bench_test.go
+++ b/cmd/entire/cli/strategy/preparecommitmsg_bench_test.go
@@ -31,12 +31,18 @@ func BenchmarkPrepareCommitMsg(b *testing.B) {
 
 func benchPrepareCommitMsg(fileCount, sessionCount int) func(*testing.B) {
 	return func(b *testing.B) {
+		// Setup once before the loop — repo creation is expensive and
+		// PrepareCommitMsg only mutates COMMIT_EDITMSG on the idle-session + no-TTY path.
+		dir, commitMsgFile := benchSetupPrepareCommitMsgRepo(b, fileCount, sessionCount)
+		b.Chdir(dir)
+
+		b.ResetTimer()
 		for range b.N {
-			b.StopTimer()
-			dir, commitMsgFile := benchSetupPrepareCommitMsgRepo(b, fileCount, sessionCount)
-			b.Chdir(dir)
+			// Reset only what PrepareCommitMsg mutates
+			if err := os.WriteFile(commitMsgFile, []byte("implement feature\n"), 0o644); err != nil {
+				b.Fatalf("rewrite commit msg: %v", err)
+			}
 			paths.ClearWorktreeRootCache()
-			b.StartTimer()
 
 			s := &ManualCommitStrategy{}
 			if err := s.PrepareCommitMsg(context.Background(), commitMsgFile, ""); err != nil {
@@ -52,28 +58,31 @@ func benchPrepareCommitMsg(fileCount, sessionCount int) func(*testing.B) {
 func BenchmarkGetStagedFiles(b *testing.B) {
 	for _, fileCount := range []int{10, 100, 500} {
 		b.Run(fmt.Sprintf("Files_%d", fileCount), func(b *testing.B) {
+			// Setup once before the loop — repo creation + staging is expensive.
+			br := benchutil.NewBenchRepo(b, benchutil.RepoOpts{FileCount: fileCount})
+			b.Chdir(br.Dir)
+
+			// Stage some modifications
+			for i := range min(5, fileCount) {
+				name := fmt.Sprintf("src/file_%03d.go", i)
+				content := benchutil.GenerateGoFile(9000+i, 100)
+				br.WriteFile(b, name, content)
+				wt, err := br.Repo.Worktree()
+				if err != nil {
+					b.Fatalf("worktree: %v", err)
+				}
+				if _, err := wt.Add(name); err != nil {
+					b.Fatalf("add: %v", err)
+				}
+			}
+
+			b.ResetTimer()
 			for range b.N {
-				b.StopTimer()
-				br := benchutil.NewBenchRepo(b, benchutil.RepoOpts{FileCount: fileCount})
-				b.Chdir(br.Dir)
 				paths.ClearWorktreeRootCache()
 
-				// Stage some modifications
-				for i := range min(5, fileCount) {
-					name := fmt.Sprintf("src/file_%03d.go", i)
-					content := benchutil.GenerateGoFile(9000+i, 100)
-					br.WriteFile(b, name, content)
-					wt, err := br.Repo.Worktree()
-					if err != nil {
-						b.Fatalf("worktree: %v", err)
-					}
-					if _, err := wt.Add(name); err != nil {
-						b.Fatalf("add: %v", err)
-					}
+				if _, err := getStagedFiles(context.Background()); err != nil {
+					b.Fatalf("getStagedFiles: %v", err)
 				}
-				b.StartTimer()
-
-				_ = getStagedFiles(context.Background())
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- **Replace `getStagedFiles` with native git CLI**: Swap go-git's `worktree.Status()` (O(all files), scans entire working tree) with `git diff --cached --name-only` (constant time, uses git's optimized index and fsmonitor)
- **Cache staged files across sessions**: Compute staged files once in `filterSessionsWithNewContent` and pass via `contentCheckOpts` struct, eliminating up to 3×N redundant calls for N sessions
- **Optimize `getLastPrompt`**: Read `prompt.txt` directly from the shadow branch tree instead of calling `extractSessionData()` which parses the full transcript (token counting, context generation, prompt extraction)
- **Add benchmark harness**: `BenchmarkPrepareCommitMsg` with 6 sub-benchmarks (Small/Medium/Large repo × 1/3 sessions) and `BenchmarkGetStagedFiles` for isolated measurement

Also includes the prior fix for `entire explain` hanging on repos with many checkpoints (commit `eff1e18d`).

## Test plan

- [x] `mise run fmt` — clean
- [x] `mise run lint` — 0 issues
- [x] `mise run test:ci` — all tests pass (unit + integration)
- [x] Benchmarks run successfully at all repo sizes
- [x] Manual test: `git commit` with Entire enabled on a large repo no longer hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)