### PR TITLE
Fix entire cli hanging on `prepare-commit-msg` git hook

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -1165,7 +1166,7 @@ func (s *ManualCommitStrategy) sessionHasNewContent(ctx context.Context, repo *g
 		if len(state.FilesTouched) > 0 {
 			// Shadow branch has files from carry-forward - check if staged files overlap
 			// AND have matching content (content-aware check).
-			stagedFiles := getStagedFiles(repo)
+			stagedFiles := getStagedFiles(ctx)
 			if len(stagedFiles) > 0 {
 				// PrepareCommitMsg context: check staged files overlap with content
 				result := stagedFilesOverlapWithContent(ctx, repo, tree, stagedFiles, state.FilesTouched)
@@ -1218,7 +1219,7 @@ func (s *ManualCommitStrategy) sessionHasNewContent(ctx context.Context, repo *g
 
 	// Check if staged files overlap with session's files with content-aware matching.
 	// This is primarily for PrepareCommitMsg; in PostCommit, stagedFiles is empty.
-	stagedFiles := getStagedFiles(repo)
+	stagedFiles := getStagedFiles(ctx)
 	if len(stagedFiles) > 0 {
 		result := stagedFilesOverlapWithContent(ctx, repo, tree, stagedFiles, state.FilesTouched)
 		logging.Debug(logCtx, "sessionHasNewContent: staged files overlap check",
@@ -1270,7 +1271,7 @@ func (s *ManualCommitStrategy) sessionHasNewContentFromLiveTranscript(ctx contex
 	// Check if any modified files overlap with currently staged files
 	// This ensures we only add checkpoint trailers to commits that include
 	// files the agent actually modified
-	stagedFiles := getStagedFiles(repo)
+	stagedFiles := getStagedFiles(ctx)
 
 	logging.Debug(logCtx, "live transcript check: comparing staged vs modified",
 		slog.String("session_id", state.SessionID),
@@ -1815,23 +1816,21 @@ func (s *ManualCommitStrategy) calculatePromptAttributionAtStart(
 	return result
 }
 
-// getStagedFiles returns a list of files staged for commit.
-func getStagedFiles(repo *git.Repository) []string {
-	worktree, err := repo.Worktree()
+// getStagedFiles returns a list of files staged for commit using native git CLI.
+// Uses git diff --cached which is much faster than go-git's worktree.Status()
+// on large repositories (O(staged files) vs O(all files in working tree)).
+func getStagedFiles(ctx context.Context) []string {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--name-only")
+	output, err := cmd.Output()
 	if err != nil {
 		return nil
 	}
 
-	status, err := worktree.Status()
-	if err != nil {
-		return nil
-	}
-
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
 	var staged []string
-	for path, fileStatus := range status {
-		// Check if file is staged (in index)
-		if fileStatus.Staging != git.Unmodified && fileStatus.Staging != git.Untracked {
-			staged = append(staged, path)
+	for _, line := range lines {
+		if line != "" {
+			staged = append(staged, line)
 		}
 	}
 	return staged


### PR DESCRIPTION
## Problem

[Reported this in Discord earlier](https://discord.com/channels/1468014954689855716/1476959081594880052).  After setting up the entire cli in my project, I wasnt able to commit anymore. `git commit` would just hang.

After some quick research, I found that the root cause for the hang was the entire cli hook: `entire hooks git prepare-commit-msg`, it just hangs.

## Proposed solution

**Disclaimer: This solution was written by claude code. I think it makes sense, that's why I'm sending this PR but my knowledge around how the entire cli works is limited**

- Fix prepare-commit-msg hook hanging on large repos by replacing go-git's worktree.Status() with native git diff --cached --name-only in getStagedFiles()
   - worktree.Status() scans the entire working tree (O(all files)) — computing hashes, reading .gitignore, comparing with the index — all in pure Go. On repos with deep node_modules or many packages (like stilla-server), this takes 20+ seconds or hangs indefinitely
   - git diff --cached --name-only only lists staged files (O(staged files)), completing in under a second

The codebase already uses exec.CommandContext(ctx, "git", ...) extensively, so this fix reuses and existing pattern, it is not creating a new one:
  - paths.WorktreeRoot() — git rev-parse --show-toplevel
  - HardResetWithProtection() in common.go — git reset --hard
  - CheckoutBranch() in git_operations.go — git checkout
  - getUntrackedFiles() in common.go — git ls-files --others
  - HasUncommittedChanges() in git_operations.go — git status --porcelain

## Test plan

- All existing TestPrepareCommitMsg tests pass
- Full test suite passes (go test ./...)
- Manual test: I built the CLI locally and tested it in my project. It no longer hangs and completes in less than a second