### PR TITLE
chore: Update Go version requirement to 1.26.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Please answer these questions in your bug report:
 
 ### Prerequisites
 
-- **Go 1.25.x** - Check with `go version`
+- **Go 1.26.x** - Check with `go version`
 - **mise** - Task runner and version manager. Install with `curl https://mise.run | sh`
 
 ### Clone and Install


### PR DESCRIPTION
I was going over the contributing docs and noticed the Go version is out of date with `go.mod`.
This PR fixes it https://github.com/entireio/cli/blob/6e8cfd5c6cfdeb9173f9e6ac298c7fc6dc951c2c/go.mod#L3