### PR TITLE
Simplify PATH setup message in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -234,24 +234,23 @@ main() {
         esac
 
         echo ""
-        echo -e "  ${YELLOW}Almost there!${NC} Add it to your PATH so you can run ${BOLD}entire${NC} from anywhere."
+        echo -e "  Add ${BOLD}entire${NC} to your PATH:"
         echo ""
         if [[ "$shell_name" == "fish" ]]; then
-            echo -e "  Run this, then restart your terminal:"
-            echo ""
             echo -e "    ${BOLD}mkdir -p ~/.config/fish${NC}"
             echo -e "    ${BOLD}echo 'fish_add_path ${install_dir}' >> \$HOME/.config/fish/config.fish${NC}"
         elif [[ -n "$shell_config" ]]; then
-            echo -e "  Run this, then restart your terminal:"
-            echo ""
             echo -e "    ${BOLD}echo 'export PATH=\"${install_dir}:\$PATH\"' >> ${shell_config}${NC}"
         else
-            echo -e "  Add this to your shell config, then restart your terminal:"
+            echo -e "  Add this to your shell config:"
             echo ""
             echo -e "    ${BOLD}export PATH=\"${install_dir}:\$PATH\"${NC}"
+            echo ""
+            echo -e "  Restart your terminal, then run ${BOLD}entire${NC} to get started."
+            exit 0
         fi
         echo ""
-        echo -e "  Then run ${BOLD}entire${NC} to get started."
+        echo -e "  Restart your terminal, then run ${BOLD}entire${NC} to get started."
         exit 0
     fi
 


### PR DESCRIPTION
## Summary
- Streamlines the post-install PATH instructions to be more concise
- Removes redundant "Almost there!" and "Run this, then restart" text
- Consolidates the restart and run instructions into a single line

## Test plan
- [ ] Run install script on a system where the install directory is not in PATH
- [ ] Verify the new message format displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)