### PR TITLE
do not set ENTIRE_TEST_TTY=0 for actual agent execution in E2E tests

### DIFF
--- a/e2e/agents/agent.go
+++ b/e2e/agents/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -103,4 +104,24 @@ func ReleaseSlot(a Agent) {
 
 func All() []Agent {
 	return registry
+}
+
+// filterEnv returns env with entries matching any of the given variable names
+// removed. Used to strip test-only overrides (e.g. ENTIRE_TEST_TTY) from agent
+// processes so they exercise real detection paths.
+func filterEnv(env []string, names ...string) []string {
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		skip := false
+		for _, name := range names {
+			if strings.HasPrefix(e, name+"=") {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			out = append(out, e)
+		}
+	}
+	return out
 }

--- a/e2e/agents/claude.go
+++ b/e2e/agents/claude.go
@@ -40,14 +40,17 @@ func cleanConfigDir() (string, error) {
 	return dst, nil
 }
 
-// cleanEnv returns os.Environ() with CLAUDECODE removed so that
-// Claude Code doesn't refuse to start inside this test runner.
+// cleanEnv returns os.Environ() with agent-incompatible variables removed.
+// It strips CLAUDECODE (so Claude Code doesn't refuse to start inside this
+// test runner) and ENTIRE_TEST_TTY (so agents exercise the real TTY detection
+// paths instead of the test override).
 func cleanEnv() []string {
 	var env []string
 	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "CLAUDECODE=") {
-			env = append(env, e)
+		if strings.HasPrefix(e, "CLAUDECODE=") || strings.HasPrefix(e, "ENTIRE_TEST_TTY=") {
+			continue
 		}
+		env = append(env, e)
 	}
 	return env
 }
@@ -188,7 +191,7 @@ func (c *Claude) StartSession(ctx context.Context, dir string) (Session, error) 
 
 	args := append([]string{"env"}, envArgs...)
 	args = append(args, c.Binary(), "--dangerously-skip-permissions")
-	s, err := NewTmuxSession(name, dir, []string{"CLAUDECODE"}, args[0], args[1:]...)
+	s, err := NewTmuxSession(name, dir, []string{"CLAUDECODE", "ENTIRE_TEST_TTY"}, args[0], args[1:]...)
 	if err != nil {
 		_ = os.RemoveAll(configDir)
 		return nil, err

--- a/e2e/agents/droid.go
+++ b/e2e/agents/droid.go
@@ -148,7 +148,7 @@ func (d *Droid) RunPrompt(ctx context.Context, dir string, prompt string, opts .
 	cmd := exec.CommandContext(ctx, d.Binary(), args...)
 	cmd.Dir = dir
 	cmd.Stdin = nil
-	cmd.Env = os.Environ()
+	cmd.Env = filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
@@ -180,7 +180,7 @@ func (d *Droid) RunPrompt(ctx context.Context, dir string, prompt string, opts .
 
 func (d *Droid) StartSession(ctx context.Context, dir string) (Session, error) {
 	name := fmt.Sprintf("droid-test-%d", time.Now().UnixNano())
-	s, err := NewTmuxSession(name, dir, nil, d.Binary(), "--model", defaultDroidModel, "--skip-permissions-unsafe")
+	s, err := NewTmuxSession(name, dir, []string{"ENTIRE_TEST_TTY"}, d.Binary(), "--model", defaultDroidModel, "--skip-permissions-unsafe")
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -86,7 +86,7 @@ func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 	cmd := exec.CommandContext(promptCtx, g.Binary(), args...)
 	cmd.Dir = dir
 	cmd.Stdin = nil
-	cmd.Env = append(os.Environ(), "ACCESSIBLE=1")
+	cmd.Env = append(filterEnv(os.Environ(), "ENTIRE_TEST_TTY"), "ACCESSIBLE=1")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
@@ -125,7 +125,7 @@ func (g *Gemini) StartSession(ctx context.Context, dir string) (Session, error) 
 	name := fmt.Sprintf("gemini-test-%d", time.Now().UnixNano())
 	// Unset CI and GITHUB_ACTIONS so gemini doesn't force headless mode —
 	// it checks both in isHeadlessMode() and skips interactive TUI entirely.
-	s, err := NewTmuxSession(name, dir, []string{"CI", "GITHUB_ACTIONS"}, "env", "ACCESSIBLE=1", g.Binary(), "--model", geminiDefaultModel, "-y")
+	s, err := NewTmuxSession(name, dir, []string{"CI", "GITHUB_ACTIONS", "ENTIRE_TEST_TTY"}, "env", "ACCESSIBLE=1", g.Binary(), "--model", geminiDefaultModel, "-y")
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -106,7 +106,7 @@ func (a *openCodeAgent) RunPrompt(ctx context.Context, dir string, prompt string
 
 	cmd := exec.CommandContext(ctx, a.Binary(), args...)
 	cmd.Dir = dir
-	cmd.Env = os.Environ()
+	cmd.Env = filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
 
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
@@ -140,7 +140,7 @@ func (a *openCodeAgent) StartSession(ctx context.Context, dir string) (Session, 
 	for attempt := range 2 {
 		name := fmt.Sprintf("opencode-test-%d", time.Now().UnixNano())
 		var err error
-		s, err = NewTmuxSession(name, dir, nil, a.Binary(), "--model", a.model)
+		s, err = NewTmuxSession(name, dir, []string{"ENTIRE_TEST_TTY"}, a.Binary(), "--model", a.model)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This hides any issues with the agent doing inline commits and TTY or used env variables (like 'GEMINI_CLI=1` or `GIT_TERMINAL_PROMPT=0` changes or hides problems with new agent integrations.

So only set that when it's needed, for example when doing `git commit -m ""` for manual commits since then we want to hide the prompt.