### PR TITLE
Add end2end tests for `entire resume` for squash merged commits

### DIFF
--- a/e2e/tests/resume_test.go
+++ b/e2e/tests/resume_test.go
@@ -70,6 +70,11 @@ func TestResumeSquashMergeMultipleCheckpoints(t *testing.T) {
 	testutil.ForEachAgent(t, 5*time.Minute, func(t *testing.T, s *testutil.RepoState, ctx context.Context) {
 		mainBranch := testutil.GitOutput(t, s.Dir, "branch", "--show-current")
 
+		// Commit files from `entire enable` so main has a clean working tree
+		// for branch switching and squash merging.
+		s.Git(t, "add", ".")
+		s.Git(t, "commit", "-m", "Enable entire")
+
 		// Create feature branch with two agent-assisted commits.
 		s.Git(t, "checkout", "-b", "feature")
 


### PR DESCRIPTION
## Summary

Add E2E tests for `entire resume` and support restoring multiple checkpoints from squash-merged commits.

### E2E tests (`e2e/tests/resume_test.go`)

- **TestResumeFromFeatureBranch** — agent work on feature branch, switch to main, `entire resume feature`
- **TestResumeSquashMergeMultipleCheckpoints** — two agent commits squash-merged to main; tests both GitHub format (top-level trailers) and git CLI format (4-space indented trailers in SQUASH_MSG)
- **TestResumeNoCheckpointOnBranch** — human-only feature branch, resume exits cleanly with informational message
- **TestResumeOlderCheckpointWithNewerCommits** — checkpoint commit followed by human commit, resume still finds the older checkpoint

## Test plan

- [x] `mise run test:e2e --agent claude-code TestResume` — all 4 resume E2E tests pass