### PR TITLE
Replace O(n) go-git tree walks with git diff-tree in post-commit hook

### DIFF
--- a/cmd/entire/cli/gitops/diff.go
+++ b/cmd/entire/cli/gitops/diff.go
@@ -10,9 +10,10 @@ import (
 
 // DiffTreeFiles returns the set of files changed between two commits using git diff-tree.
 // For initial commits (commit1 is empty), use --root mode.
+// repoDir is the path to the git repository working tree; the command runs in that directory.
 // Returns a map of file paths for O(1) lookup.
-func DiffTreeFiles(ctx context.Context, commit1, commit2 string) (map[string]struct{}, error) {
-	files, err := diffTreeRaw(ctx, commit1, commit2)
+func DiffTreeFiles(ctx context.Context, repoDir, commit1, commit2 string) (map[string]struct{}, error) {
+	files, err := diffTreeRaw(ctx, repoDir, commit1, commit2)
 	if err != nil {
 		return nil, err
 	}
@@ -26,12 +27,13 @@ func DiffTreeFiles(ctx context.Context, commit1, commit2 string) (map[string]str
 
 // DiffTreeFileList returns the list of files changed between two commits using git diff-tree.
 // For initial commits (commit1 is empty), use --root mode.
-func DiffTreeFileList(ctx context.Context, commit1, commit2 string) ([]string, error) {
-	return diffTreeRaw(ctx, commit1, commit2)
+// repoDir is the path to the git repository working tree; the command runs in that directory.
+func DiffTreeFileList(ctx context.Context, repoDir, commit1, commit2 string) ([]string, error) {
+	return diffTreeRaw(ctx, repoDir, commit1, commit2)
 }
 
-// diffTreeRaw runs git diff-tree and returns the list of changed file paths.
-func diffTreeRaw(ctx context.Context, commit1, commit2 string) ([]string, error) {
+// diffTreeRaw runs git diff-tree in the given directory and returns the list of changed file paths.
+func diffTreeRaw(ctx context.Context, dir, commit1, commit2 string) ([]string, error) {
 	var cmd *exec.Cmd
 	if commit1 == "" {
 		// Initial commit (no parent): list all files in the tree
@@ -39,6 +41,7 @@ func diffTreeRaw(ctx context.Context, commit1, commit2 string) ([]string, error)
 	} else {
 		cmd = exec.CommandContext(ctx, "git", "diff-tree", "--no-commit-id", "-r", "-z", commit1, commit2)
 	}
+	cmd.Dir = dir
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/cmd/entire/cli/gitops/diff_test.go
+++ b/cmd/entire/cli/gitops/diff_test.go
@@ -84,9 +84,8 @@ func gitCommit(t *testing.T, dir, msg string) {
 	}
 }
 
-// Tests that use os.Chdir cannot be parallelized (Go test framework restriction).
-
 func TestDiffTreeFiles_NormalCommit(t *testing.T) {
+	t.Parallel()
 	dir := initTestRepo(t)
 
 	writeFile(t, dir, "file1.go", "package main\n")
@@ -100,9 +99,7 @@ func TestDiffTreeFiles_NormalCommit(t *testing.T) {
 	gitCommit(t, dir, "second")
 	commit2 := commitHash(t, dir)
 
-	t.Chdir(dir)
-
-	result, err := DiffTreeFiles(context.Background(), commit1, commit2)
+	result, err := DiffTreeFiles(context.Background(), dir, commit1, commit2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,6 +116,7 @@ func TestDiffTreeFiles_NormalCommit(t *testing.T) {
 }
 
 func TestDiffTreeFiles_InitialCommit(t *testing.T) {
+	t.Parallel()
 	dir := initTestRepo(t)
 
 	writeFile(t, dir, "a.go", "package a\n")
@@ -127,9 +125,7 @@ func TestDiffTreeFiles_InitialCommit(t *testing.T) {
 	gitCommit(t, dir, "initial")
 	commit := commitHash(t, dir)
 
-	t.Chdir(dir)
-
-	result, err := DiffTreeFiles(context.Background(), "", commit)
+	result, err := DiffTreeFiles(context.Background(), dir, "", commit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -146,6 +142,7 @@ func TestDiffTreeFiles_InitialCommit(t *testing.T) {
 }
 
 func TestDiffTreeFileList_MultiCommitRange(t *testing.T) {
+	t.Parallel()
 	dir := initTestRepo(t)
 
 	writeFile(t, dir, "base.go", "package base\n")
@@ -163,9 +160,7 @@ func TestDiffTreeFileList_MultiCommitRange(t *testing.T) {
 	gitCommit(t, dir, "third")
 	commit3 := commitHash(t, dir)
 
-	t.Chdir(dir)
-
-	files, err := DiffTreeFileList(context.Background(), commit1, commit3)
+	files, err := DiffTreeFileList(context.Background(), dir, commit1, commit3)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -184,6 +179,7 @@ func TestDiffTreeFileList_MultiCommitRange(t *testing.T) {
 }
 
 func TestDiffTreeFiles_DeletedFile(t *testing.T) {
+	t.Parallel()
 	dir := initTestRepo(t)
 
 	writeFile(t, dir, "keep.go", "package keep\n")
@@ -200,9 +196,7 @@ func TestDiffTreeFiles_DeletedFile(t *testing.T) {
 	gitCommit(t, dir, "remove file")
 	commit2 := commitHash(t, dir)
 
-	t.Chdir(dir)
-
-	result, err := DiffTreeFiles(context.Background(), commit1, commit2)
+	result, err := DiffTreeFiles(context.Background(), dir, commit1, commit2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -216,6 +210,7 @@ func TestDiffTreeFiles_DeletedFile(t *testing.T) {
 }
 
 func TestDiffTreeFiles_NoChanges(t *testing.T) {
+	t.Parallel()
 	dir := initTestRepo(t)
 
 	writeFile(t, dir, "file.go", "package main\n")
@@ -223,9 +218,7 @@ func TestDiffTreeFiles_NoChanges(t *testing.T) {
 	gitCommit(t, dir, "initial")
 	commit := commitHash(t, dir)
 
-	t.Chdir(dir)
-
-	result, err := DiffTreeFiles(context.Background(), commit, commit)
+	result, err := DiffTreeFiles(context.Background(), dir, commit, commit)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -236,6 +229,7 @@ func TestDiffTreeFiles_NoChanges(t *testing.T) {
 }
 
 func TestDiffTreeFiles_SubdirectoryFiles(t *testing.T) {
+	t.Parallel()
 	dir := initTestRepo(t)
 
 	writeFile(t, dir, "root.go", "package root\n")
@@ -248,9 +242,7 @@ func TestDiffTreeFiles_SubdirectoryFiles(t *testing.T) {
 	gitCommit(t, dir, "add deep file")
 	commit2 := commitHash(t, dir)
 
-	t.Chdir(dir)
-
-	result, err := DiffTreeFiles(context.Background(), commit1, commit2)
+	result, err := DiffTreeFiles(context.Background(), dir, commit1, commit2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -264,6 +256,7 @@ func TestDiffTreeFiles_SubdirectoryFiles(t *testing.T) {
 }
 
 func TestDiffTreeFiles_Rename(t *testing.T) {
+	t.Parallel()
 	dir := initTestRepo(t)
 
 	writeFile(t, dir, "original.go", "package original\n")
@@ -280,19 +273,26 @@ func TestDiffTreeFiles_Rename(t *testing.T) {
 	gitCommit(t, dir, "rename file")
 	commit2 := commitHash(t, dir)
 
-	t.Chdir(dir)
-
-	result, err := DiffTreeFiles(context.Background(), commit1, commit2)
+	result, err := DiffTreeFiles(context.Background(), dir, commit1, commit2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Both old and new names should appear
+	// Without -M flag, rename shows as D+A — both old and new names should appear
 	if _, ok := result["original.go"]; !ok {
 		t.Error("expected original.go in result")
 	}
 	if _, ok := result["renamed.go"]; !ok {
 		t.Error("expected renamed.go in result")
+	}
+}
+
+func TestDiffTreeFiles_InvalidDir(t *testing.T) {
+	t.Parallel()
+
+	_, err := DiffTreeFiles(context.Background(), t.TempDir(), "abc123", "def456")
+	if err == nil {
+		t.Error("expected error for non-git directory")
 	}
 }
 
@@ -334,6 +334,7 @@ func TestParseDiffTreeOutput(t *testing.T) {
 
 	t.Run("rename", func(t *testing.T) {
 		t.Parallel()
+		// R/C status only appears with -M/-C flags (defensive handling)
 		data := []byte(":100644 100644 abc1234 def5678 R100\x00old.go\x00new.go\x00")
 		result := parseDiffTreeOutput(data)
 		if len(result) != 2 {
@@ -373,4 +374,34 @@ func TestParseDiffTreeOutput(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestExtractStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected byte
+	}{
+		{"modify", ":100644 100644 abc1234 def5678 M", 'M'},
+		{"add", ":000000 100644 0000000 abc1234 A", 'A'},
+		{"delete", ":100644 000000 abc1234 0000000 D", 'D'},
+		{"rename with score", ":100644 100644 abc1234 def5678 R100", 'R'},
+		{"copy with score", ":100644 100644 abc1234 abc1234 C075", 'C'},
+		{"type change", ":100644 120000 abc1234 def5678 T", 'T'},
+		{"empty string", "", 0},
+		{"too few fields", ":100644 100644 abc1234", 0},
+		{"whitespace only", "   ", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractStatus(tt.input)
+			if got != tt.expected {
+				t.Errorf("extractStatus(%q) = %c (%d), want %c (%d)", tt.input, got, got, tt.expected, tt.expected)
+			}
+		})
+	}
 }

--- a/cmd/entire/cli/strategy/manual_commit_attribution.go
+++ b/cmd/entire/cli/strategy/manual_commit_attribution.go
@@ -15,12 +15,12 @@ import (
 )
 
 // getAllChangedFiles returns all files that changed between the attribution base
-// and HEAD. When commit hashes are provided, uses fast git diff-tree CLI; otherwise
-// falls back to go-git tree walk (used by CondenseSessionByID / doctor command).
-func getAllChangedFiles(ctx context.Context, baseTree, headTree *object.Tree, baseCommitHash, headCommitHash string) ([]string, error) {
+// and HEAD. When commit hashes and repoDir are provided, uses fast git diff-tree CLI;
+// otherwise falls back to go-git tree walk (used by CondenseSessionByID / doctor command).
+func getAllChangedFiles(ctx context.Context, baseTree, headTree *object.Tree, repoDir, baseCommitHash, headCommitHash string) ([]string, error) {
 	// Fast path: use git diff-tree when commit hashes are available
 	if baseCommitHash != "" && headCommitHash != "" {
-		return gitops.DiffTreeFileList(ctx, baseCommitHash, headCommitHash) //nolint:wrapcheck // Propagating gitops error
+		return gitops.DiffTreeFileList(ctx, repoDir, baseCommitHash, headCommitHash) //nolint:wrapcheck // Propagating gitops error
 	}
 
 	// Slow path: go-git tree walk (CondenseSessionByID fallback)
@@ -193,6 +193,7 @@ func CalculateAttributionWithAccumulated(
 	headTree *object.Tree,
 	filesTouched []string,
 	promptAttributions []PromptAttribution,
+	repoDir string,
 	attributionBaseCommit string,
 	headCommitHash string,
 ) *checkpoint.InitialAttribution {
@@ -243,7 +244,7 @@ func CalculateAttributionWithAccumulated(
 
 	// Calculate total user edits to non-agent files (files not in filesTouched)
 	// These files are not in the shadow tree, so base→head captures ALL their user edits
-	allChangedFiles, err := getAllChangedFiles(ctx, baseTree, headTree, attributionBaseCommit, headCommitHash)
+	allChangedFiles, err := getAllChangedFiles(ctx, baseTree, headTree, repoDir, attributionBaseCommit, headCommitHash)
 	if err != nil {
 		logging.Warn(logging.WithComponent(ctx, "attribution"),
 			"attribution: failed to enumerate changed files",

--- a/cmd/entire/cli/strategy/manual_commit_attribution_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_attribution_test.go
@@ -280,7 +280,7 @@ func TestCalculateAttributionWithAccumulated_BasicCase(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -339,7 +339,7 @@ func TestCalculateAttributionWithAccumulated_BugScenario(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -398,7 +398,7 @@ func TestCalculateAttributionWithAccumulated_DeletionOnly(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -449,7 +449,7 @@ func TestCalculateAttributionWithAccumulated_NoUserEdits(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -503,7 +503,7 @@ func TestCalculateAttributionWithAccumulated_NoAgentWork(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -559,7 +559,7 @@ func TestCalculateAttributionWithAccumulated_UserRemovesAllAgentLines(t *testing
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -630,7 +630,7 @@ func TestCalculateAttributionWithAccumulated_WithPromptAttributions(t *testing.T
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -675,7 +675,7 @@ func TestCalculateAttributionWithAccumulated_EmptyFilesTouched(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, []string{}, []PromptAttribution{}, "", "",
+		baseTree, shadowTree, headTree, []string{}, []PromptAttribution{}, "", "", "",
 	)
 
 	if result != nil {
@@ -729,7 +729,7 @@ func TestCalculateAttributionWithAccumulated_UserEditsNonAgentFile(t *testing.T)
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -1036,7 +1036,7 @@ func TestCalculateAttributionWithAccumulated_UserSelfModification(t *testing.T) 
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -1109,7 +1109,7 @@ func TestCalculateAttributionWithAccumulated_MixedModifications(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -1192,7 +1192,7 @@ func TestCalculateAttributionWithAccumulated_UncommittedWorktreeFiles(t *testing
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "",
+		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -110,6 +110,7 @@ func (s *ManualCommitStrategy) getCheckpointLog(ctx context.Context, checkpointI
 type condenseOpts struct {
 	shadowRef      *plumbing.Reference // Pre-resolved shadow branch ref (nil = resolve from repo)
 	headTree       *object.Tree        // Pre-resolved HEAD tree (passed through to calculateSessionAttributions)
+	repoDir        string              // Repository worktree path for git CLI commands
 	headCommitHash string              // HEAD commit hash (passed through for attribution)
 }
 
@@ -202,6 +203,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 
 	attribution := calculateSessionAttributions(ctx, repo, ref, sessionData, state, attributionOpts{
 		headTree:              o.headTree,
+		repoDir:               o.repoDir,
 		attributionBaseCommit: attrBase,
 		headCommitHash:        o.headCommitHash,
 	})
@@ -289,6 +291,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 type attributionOpts struct {
 	headTree              *object.Tree // HEAD commit tree (already resolved by PostCommit)
 	shadowTree            *object.Tree // Shadow branch tree (already resolved by PostCommit)
+	repoDir               string       // Repository worktree path for git CLI commands
 	attributionBaseCommit string       // Base commit hash for non-agent file detection (empty = fall back to go-git tree walk)
 	headCommitHash        string       // HEAD commit hash for non-agent file detection (empty = fall back to go-git tree walk)
 }
@@ -399,6 +402,7 @@ func calculateSessionAttributions(ctx context.Context, repo *git.Repository, sha
 		headTree,
 		sessionData.FilesTouched,
 		state.PromptAttributions,
+		o.repoDir,
 		o.attributionBaseCommit,
 		o.headCommitHash,
 	)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -581,6 +581,7 @@ type postCommitActionHandler struct {
 	head                   *plumbing.Reference
 	commit                 *object.Commit
 	newHead                string
+	repoDir                string
 	shadowBranchName       string
 	shadowBranchesToDelete map[string]struct{}
 	committedFileSet       map[string]struct{}
@@ -615,6 +616,7 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 		h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
 			shadowRef:      h.shadowRef,
 			headTree:       h.headTree,
+			repoDir:        h.repoDir,
 			headCommitHash: h.newHead,
 		})
 	} else {
@@ -640,6 +642,7 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 		h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
 			shadowRef:      h.shadowRef,
 			headTree:       h.headTree,
+			repoDir:        h.repoDir,
 			headCommitHash: h.newHead,
 		})
 	} else {
@@ -800,7 +803,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:
 		}
 	}
 
-	committedFileSet := filesChangedInCommit(ctx, commit)
+	committedFileSet := filesChangedInCommit(ctx, worktreePath, commit)
 
 	for _, state := range sessions {
 		// Skip fully-condensed ended sessions — no work remains.
@@ -809,7 +812,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:
 			continue
 		}
 		s.postCommitProcessSession(ctx, repo, state, &transitionCtx, checkpointID,
-			head, commit, newHead, headTree, parentTree, committedFileSet,
+			head, commit, newHead, worktreePath, headTree, parentTree, committedFileSet,
 			shadowBranchesToDelete, uncondensedActiveOnBranch)
 	}
 
@@ -849,6 +852,7 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 	head *plumbing.Reference,
 	commit *object.Commit,
 	newHead string,
+	repoDir string,
 	headTree, parentTree *object.Tree,
 	committedFileSet map[string]struct{},
 	shadowBranchesToDelete map[string]struct{},
@@ -926,6 +930,7 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 		head:                   head,
 		commit:                 commit,
 		newHead:                newHead,
+		repoDir:                repoDir,
 		shadowBranchName:       shadowBranchName,
 		shadowBranchesToDelete: shadowBranchesToDelete,
 		committedFileSet:       committedFileSet,
@@ -2128,15 +2133,15 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 }
 
 // filesChangedInCommit returns the set of files changed in a commit using git diff-tree.
-// Uses the git CLI for O(n log n) performance instead of go-git's O(n) tree walks.
-func filesChangedInCommit(ctx context.Context, commit *object.Commit) map[string]struct{} {
+// Uses the git CLI for faster performance vs go-git tree walks (lower constant factors).
+func filesChangedInCommit(ctx context.Context, repoDir string, commit *object.Commit) map[string]struct{} {
 	var parentHash string
 	if commit.NumParents() > 0 {
 		parentHash = commit.ParentHashes[0].String()
 	}
-	result, err := gitops.DiffTreeFiles(ctx, parentHash, commit.Hash.String())
+	result, err := gitops.DiffTreeFiles(ctx, repoDir, parentHash, commit.Hash.String())
 	if err != nil {
-		logging.Warn(ctx, "post-commit: failed to detect files changed in commit, attribution may be inaccurate",
+		logging.Warn(ctx, "post-commit: git diff-tree failed; condensation and carry-forward may be affected",
 			slog.String("commit", commit.Hash.String()),
 			slog.String("error", err.Error()),
 		)

--- a/cmd/entire/cli/strategy/phase_postcommit_test.go
+++ b/cmd/entire/cli/strategy/phase_postcommit_test.go
@@ -878,7 +878,7 @@ func TestFilesChangedInCommit(t *testing.T) {
 	commit, err := repo.CommitObject(commitHash)
 	require.NoError(t, err)
 
-	changed := filesChangedInCommit(context.Background(), commit)
+	changed := filesChangedInCommit(context.Background(), dir, commit)
 	assert.Contains(t, changed, "file1.txt")
 	assert.Contains(t, changed, "file2.txt")
 	// test.txt was in the initial commit, not this one
@@ -915,7 +915,7 @@ func TestFilesChangedInCommit_InitialCommit(t *testing.T) {
 	commit, err := repo.CommitObject(commitHash)
 	require.NoError(t, err)
 
-	changed := filesChangedInCommit(context.Background(), commit)
+	changed := filesChangedInCommit(context.Background(), dir, commit)
 	assert.Contains(t, changed, "init.txt")
 	assert.Len(t, changed, 1)
 }


### PR DESCRIPTION
## Summary
- Add `cmd/entire/cli/gitops/` package with `DiffTreeFiles`/`DiffTreeFileList` wrappers around `git diff-tree --no-commit-id -r -z`
- Replace `filesChangedInCommit` go-git tree walk with `git diff-tree` (703ms → ~25ms on 58k-file repos)
- Replace `getAllChangedFilesBetweenTrees` in attribution with `git diff-tree` (4685ms → ~36ms), keeping go-git fallback for `CondenseSessionByID` (doctor command)
- Remove timing instrumentation added during investigation

### Before/after (58k-file repo)
```
origin/main:  5.95s
this branch:  0.30s  (20x faster)
```

## Test plan
- [x] New `cmd/entire/cli/gitops/diff_test.go` — tests DiffTreeFiles with real git repos (normal commit, initial commit, multi-commit range, deleted files, no changes, subdirectory files)
- [x] `TestGetAllChangedFilesBetweenTreesSlow` — preserved coverage for go-git fallback path (nil trees, identical trees, add/delete scenarios)
- [x] All existing `CalculateAttributionWithAccumulated` tests updated and passing (exercise slow fallback via empty commit hashes)
- [x] `TestFilesChangedInCommit` / `TestFilesChangedInCommit_InitialCommit` updated for new signature
- [x] `mise run fmt && mise run lint && mise run test:ci` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)