### PR TITLE
add E2E test failure alerting

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: [e2e-tests]
-    if: ${{ always() && needs.e2e-tests.result == 'failure' }}
+    if: ${{ always() && needs.e2e-tests.result == 'failure' && github.event_name == 'push' }}
     steps:
       - name: Get failed agents
         id: failed


### PR DESCRIPTION
This will alert us in Slack when an E2E test failure is detected.