### PR TITLE
fix: stabilize Droid interactive E2E tests for CI

### DIFF
--- a/e2e/agents/droid.go
+++ b/e2e/agents/droid.go
@@ -199,7 +199,12 @@ func (d *Droid) StartSession(ctx context.Context, dir string) (Session, error) {
 
 	// Droid auto-generates a greeting on startup which fires a Stop hook.
 	// Wait for the greeting turn to fully complete before accepting prompts.
-	time.Sleep(2 * time.Second)
+	select {
+	case <-ctx.Done():
+		_ = s.Close()
+		return nil, fmt.Errorf("context cancelled during startup wait: %w", ctx.Err())
+	case <-time.After(2 * time.Second):
+	}
 	s.stableAtSend = ""
 
 	return s, nil

--- a/e2e/agents/tmux.go
+++ b/e2e/agents/tmux.go
@@ -163,7 +163,9 @@ func (s *TmuxSession) IsPaneDead() bool {
 	cmd := exec.Command("tmux", "display-message", "-t", s.name, "-p", "#{pane_dead}")
 	out, err := cmd.Output()
 	if err != nil {
-		return false
+		// If tmux itself fails (e.g. session/pane no longer exists),
+		// treat it as dead so WaitFor doesn't poll until timeout.
+		return true
 	}
 	return strings.TrimSpace(string(out)) == "1"
 }

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -164,7 +164,11 @@ func mergeDroidCustomModels(globalSettingsPath, repoSettingsPath string) error {
 	// Set the active custom model so interactive mode uses the BYOK model
 	// instead of prompting for selection. The value must match the Model
 	// field from the customModels entry (not the displayName).
-	repoSettings["model"] = json.RawMessage(`"` + agents.DefaultDroidModel() + `"`)
+	modelJSON, err := json.Marshal(agents.DefaultDroidModel())
+	if err != nil {
+		return fmt.Errorf("marshal model setting: %w", err)
+	}
+	repoSettings["model"] = json.RawMessage(modelJSON)
 
 	// High autonomy prevents Droid from asking for confirmation during
 	// interactive E2E tests, which would cause hangs waiting for input.


### PR DESCRIPTION
## Summary
- Add `customModel` and `autonomyMode: "auto-high"` to Droid's repo-local `.factory/settings.json` so interactive mode uses the BYOK model without prompting for selection or confirmation
- Remove redundant `--model`/`--skip-permissions-unsafe` CLI flags from `StartSession` (now configured via settings.json)
- Unset `CI`/`GITHUB_ACTIONS` env vars in both `RunPrompt` and `StartSession` so Droid doesn't enter headless/single-turn mode
- Increase Droid timeout multiplier from 1.5x to 2.0x
- Add `IsPaneDead()` check to `WaitFor` to fail fast when the Droid process exits unexpectedly
- Add 2s sleep after startup greeting to let the Stop hook complete before sending prompts

## Test plan
- [x] Run Droid interactive E2E test (`mise run test:e2e --agent factoryai-droid interactive`)
- [x] Verify settings.json in test repo contains `customModel` and `autonomyMode` fields
- [x] Confirm no interactive prompts or confirmation dialogs appear during test

🤖 Generated with [Claude Code](https://claude.com/claude-code)