### PR TITLE
Include agent name in E2E preflight error

### DIFF
--- a/e2e/tests/main_test.go
+++ b/e2e/tests/main_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 	}
 	for _, a := range agents.All() {
 		if _, err := exec.LookPath(a.Binary()); err != nil {
-			missing = append(missing, a.Binary())
+			missing = append(missing, fmt.Sprintf("%s (%s)", a.Binary(), a.Name()))
 		}
 	}
 	if len(missing) > 0 {


### PR DESCRIPTION
## Summary
- E2E preflight check now shows the agent name alongside the binary name when a required binary is missing
- Before: `preflight: missing required binaries: [agent]`
- After: `preflight: missing required binaries: [agent (cursor-cli)]`

## Test plan
- [x] Run `mise run test:e2e` without `cursor` agent binary installed, verify improved error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)