### PR TITLE
fix: hide merged/closed trails from `trail list` by default

### DIFF
--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -127,6 +127,8 @@ func runTrailListAll(w io.Writer, statusFilter string, jsonOutput, showAll bool)
 		trails = []*trail.Metadata{}
 	}
 
+	totalCount := len(trails)
+
 	// Apply status filter
 	if statusFilter != "" {
 		status := trail.Status(statusFilter)
@@ -166,12 +168,17 @@ func runTrailListAll(w io.Writer, statusFilter string, jsonOutput, showAll bool)
 	}
 
 	if len(trails) == 0 {
-		fmt.Fprintln(w, "No trails found.")
-		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Commands:")
-		fmt.Fprintln(w, "  entire trail create   Create a trail for the current branch")
-		fmt.Fprintln(w, "  entire trail list     List all trails")
-		fmt.Fprintln(w, "  entire trail update   Update trail metadata")
+		hiddenCount := totalCount - len(trails)
+		if hiddenCount > 0 {
+			fmt.Fprintf(w, "No active trails found. %d merged/closed trail(s) hidden — use --all to show.\n", hiddenCount)
+		} else {
+			fmt.Fprintln(w, "No trails found.")
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "Commands:")
+			fmt.Fprintln(w, "  entire trail create   Create a trail for the current branch")
+			fmt.Fprintln(w, "  entire trail list     List all trails")
+			fmt.Fprintln(w, "  entire trail update   Update trail metadata")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- `entire trail list` now hides merged and closed trails by default, reducing noise
- Added `--all` / `-a` flag to include merged and closed trails when needed
- Explicit `--status` filter is unaffected and works as before

## Test plan

- [x] `go build` passes
- [x] Unit tests pass (`mise run test`)
- [x] Lint passes (`mise run lint`)
- [x] Manual: `entire trail list` only shows active trails
- [ ] Manual: `entire trail list --all` shows all trails including merged/closed
- [x] Manual: `entire trail list --status merged` still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)