### PR TITLE
fix: use associated commit author for explain, fix GetCheckpointAuthor fallback

### DIFF
--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -1614,7 +1614,7 @@ type Author struct {
 }
 
 // GetCheckpointAuthor retrieves the author of a checkpoint from the entire/checkpoints/v1 commit history.
-// Returns the author of the commit that introduced this checkpoint's metadata.json file.
+// Finds the commit whose subject matches "Checkpoint: <id>" and returns its author.
 // Returns empty Author if the checkpoint is not found or the sessions branch doesn't exist.
 func (s *GitStore) GetCheckpointAuthor(ctx context.Context, checkpointID id.CheckpointID) (Author, error) {
 	if err := ctx.Err(); err != nil {
@@ -1627,10 +1627,9 @@ func (s *GitStore) GetCheckpointAuthor(ctx context.Context, checkpointID id.Chec
 		return Author{}, nil
 	}
 
-	// Path to the checkpoint's metadata file
-	metadataPath := checkpointID.Path() + "/" + paths.MetadataFileName
+	// Search for the commit whose subject matches "Checkpoint: <id>"
+	targetSubject := "Checkpoint: " + checkpointID.String()
 
-	// Walk commit history looking for the commit that introduced this file
 	iter, err := s.repo.Log(&git.LogOptions{
 		From:  ref.Hash(),
 		Order: git.LogOrderCommitterTime,
@@ -1641,36 +1640,21 @@ func (s *GitStore) GetCheckpointAuthor(ctx context.Context, checkpointID id.Chec
 	defer iter.Close()
 
 	var author Author
-	var foundCommit *object.Commit
-
 	err = iter.ForEach(func(c *object.Commit) error {
 		if err := ctx.Err(); err != nil {
 			return err //nolint:wrapcheck // Propagating context cancellation
 		}
-		tree, treeErr := c.Tree()
-		if treeErr != nil {
-			return nil //nolint:nilerr // Skip commits we can't read, continue searching
-		}
-
-		_, fileErr := tree.File(metadataPath)
-		if fileErr != nil {
-			// File doesn't exist in this commit - we've gone past the creation point
-			if foundCommit != nil {
-				return errStopIteration
+		subject := strings.SplitN(c.Message, "\n", 2)[0] //nolint:mnd // Split into subject + rest
+		if subject == targetSubject {
+			author = Author{
+				Name:  c.Author.Name,
+				Email: c.Author.Email,
 			}
-			return nil
-		}
-
-		// File exists - track it (oldest one with file is the creator)
-		foundCommit = c
-		author = Author{
-			Name:  c.Author.Name,
-			Email: c.Author.Email,
+			return errStopIteration
 		}
 		return nil
 	})
 
-	// Ignore errStopIteration - it's just for early exit
 	if err != nil && !errors.Is(err, errStopIteration) {
 		return Author{}, nil
 	}

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -45,6 +45,7 @@ type associatedCommit struct {
 	ShortSHA string
 	Message  string
 	Author   string
+	Email    string
 	Date     time.Time
 }
 
@@ -286,11 +287,21 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 		return nil
 	}
 
-	// Look up the author for this checkpoint (best-effort, ignore errors)
-	author, _ := store.GetCheckpointAuthor(ctx, fullCheckpointID) //nolint:errcheck // Author is optional
-
 	// Find associated commits (git commits with matching Entire-Checkpoint trailer)
 	associatedCommits, _ := getAssociatedCommits(ctx, repo, fullCheckpointID, searchAll) //nolint:errcheck // Best-effort
+
+	// Derive author from the first associated commit (the user who made the commit).
+	// Fall back to GetCheckpointAuthor (walks entire/checkpoints/v1) for checkpoints
+	// not reachable from the current branch.
+	var author checkpoint.Author
+	if len(associatedCommits) > 0 {
+		author = checkpoint.Author{
+			Name:  associatedCommits[0].Author,
+			Email: associatedCommits[0].Email,
+		}
+	} else {
+		author, _ = store.GetCheckpointAuthor(ctx, fullCheckpointID) //nolint:errcheck // Author is optional
+	}
 
 	// Format and output
 	output := formatCheckpointOutput(summary, content, fullCheckpointID, associatedCommits, author, verbose, full)
@@ -479,6 +490,7 @@ func getAssociatedCommits(ctx context.Context, repo *git.Repository, checkpointI
 			ShortSHA: shortSHA,
 			Message:  strings.Split(c.Message, "\n")[0],
 			Author:   c.Author.Name,
+			Email:    c.Author.Email,
 			Date:     c.Author.When,
 		})
 	}


### PR DESCRIPTION
Stacked on #625.

## Summary

The "Author:" field in `entire explain` detail view was showing the wrong person. `GetCheckpointAuthor` walked the full `entire/checkpoints/v1` commit history with a fragile heuristic that broke with cumulative trees and multi-timezone commit ordering.

## Changes

- **Prefer associated commit author**: derive author from the first associated commit (the actual user commit on the working branch with `Entire-Checkpoint` trailer)
- **Fall back gracefully**: only use `GetCheckpointAuthor` for checkpoints not reachable from the current branch (e.g., unmerged feature branches)
- **Fix `GetCheckpointAuthor`**: rewrite to match commit subjects (`Checkpoint: <id>`) instead of walking trees — simpler, correct, stops early
- **Add `Email` to `associatedCommit`** struct so it's available for author display

## Why

The old `GetCheckpointAuthor`:
1. Walked potentially thousands of commits (cumulative tree means file exists in every commit after creation)
2. Used `LogOrderCommitterTime` which gives unpredictable ordering with multi-timezone authors
3. Could return the wrong person when the walk stopped at the wrong boundary

The associated commit author is the person who made the actual `git commit` — which is the same person who triggered the PostCommit condense hook.

## Test plan

- [x] `TestGetCheckpointAuthor` passes (commit subject matching works)
- [x] `TestGetCheckpointAuthor_NotFound` passes
- [x] `TestGetCheckpointAuthor_NoSessionsBranch` passes
- [x] Full unit test suite passes
- [x] Lint passes