### PR TITLE
use changelog.md for release notes, if not updated yet, fail release

### DIFF
--- a/.ferrata/setup
+++ b/.ferrata/setup
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Install mise (tool version manager)
+if ! command -v mise &> /dev/null; then
+    curl https://mise.run | sh
+
+    # Add mise to .bashrc for future sessions
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+    echo 'eval "$(mise activate bash)"' >> ~/.bashrc
+fi
+
+# Add mise to PATH for this session
+export PATH="$HOME/.local/bin:$PATH"
+
+# Trust this directory and install tools (both real and symlinked paths)
+HOST_REPO_PATH="${1:-$(pwd)}"
+mise trust /mnt/shared/repo
+mise trust "$HOST_REPO_PATH"
+if [ -f mise.toml ]; then
+    mise install -y
+fi
+
+# Install Entire CLI (yes to skip prompts in non-interactive sessions)
+yes | curl -fsSL https://entire.io/install.sh | bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Extract release notes from CHANGELOG.md
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md > release_notes.md
+          awk -v ver="$VERSION" 'BEGIN{header="^## \\[" ver "\\]"} $0 ~ header{found=1; next} /^## \[/{if(found) exit} found{print}' CHANGELOG.md > release_notes.md
           if [ ! -s release_notes.md ]; then
             echo "::error::No changelog entry found for version ${VERSION} in CHANGELOG.md"
             exit 1
@@ -58,7 +58,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: [release]
-    if: ${{ failure() }}
+    if: ${{ always() && needs.release.result == 'failure' }}
     steps:
       - name: Notify Slack of release failure
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,8 +61,6 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-changelog:
-  disable: true
 
 homebrew_casks:
   - name: entire


### PR DESCRIPTION
We are generating the CHANGELOG.md before every release, let's use that instead of generating it a second time on release.