### PR TITLE
feat: real-time file tracking via post-file-edit hook

### DIFF
--- a/cmd/entire/cli/agent/claudecode/hooks.go
+++ b/cmd/entire/cli/agent/claudecode/hooks.go
@@ -26,6 +26,7 @@ const (
 	HookNamePreTask          = "pre-task"
 	HookNamePostTask         = "post-task"
 	HookNamePostTodo         = "post-todo"
+	HookNamePostFileEdit     = "post-file-edit"
 )
 
 // ClaudeSettingsFileName is the settings file used by Claude Code.
@@ -113,7 +114,7 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 	}
 
 	// Define hook commands
-	var sessionStartCmd, sessionEndCmd, stopCmd, userPromptSubmitCmd, preTaskCmd, postTaskCmd, postTodoCmd string
+	var sessionStartCmd, sessionEndCmd, stopCmd, userPromptSubmitCmd, preTaskCmd, postTaskCmd, postTodoCmd, postFileEditCmd string
 	if localDev {
 		sessionStartCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-start"
 		sessionEndCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-end"
@@ -122,6 +123,7 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 		preTaskCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code pre-task"
 		postTaskCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code post-task"
 		postTodoCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code post-todo"
+		postFileEditCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code post-file-edit"
 	} else {
 		sessionStartCmd = "entire hooks claude-code session-start"
 		sessionEndCmd = "entire hooks claude-code session-end"
@@ -130,6 +132,7 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 		preTaskCmd = "entire hooks claude-code pre-task"
 		postTaskCmd = "entire hooks claude-code post-task"
 		postTodoCmd = "entire hooks claude-code post-todo"
+		postFileEditCmd = "entire hooks claude-code post-file-edit"
 	}
 
 	count := 0
@@ -161,6 +164,14 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 	}
 	if !hookCommandExistsWithMatcher(postToolUse, "TodoWrite", postTodoCmd) {
 		postToolUse = addHookToMatcher(postToolUse, "TodoWrite", postTodoCmd)
+		count++
+	}
+	if !hookCommandExistsWithMatcher(postToolUse, "Write", postFileEditCmd) {
+		postToolUse = addHookToMatcher(postToolUse, "Write", postFileEditCmd)
+		count++
+	}
+	if !hookCommandExistsWithMatcher(postToolUse, "Edit", postFileEditCmd) {
+		postToolUse = addHookToMatcher(postToolUse, "Edit", postFileEditCmd)
 		count++
 	}
 

--- a/cmd/entire/cli/agent/claudecode/hooks_test.go
+++ b/cmd/entire/cli/agent/claudecode/hooks_test.go
@@ -500,6 +500,8 @@ func TestInstallHooks_PreservesUserHooksOnSameType(t *testing.T) {
 		assertHookExists(t, matchers, "Write", "echo user wrote file", "user Write hook")
 		assertHookExists(t, matchers, "Task", "entire hooks claude-code post-task", "Entire Task hook")
 		assertHookExists(t, matchers, "TodoWrite", "entire hooks claude-code post-todo", "Entire TodoWrite hook")
+		assertHookExists(t, matchers, "Write", "entire hooks claude-code post-file-edit", "Entire Write post-file-edit hook")
+		assertHookExists(t, matchers, "Edit", "entire hooks claude-code post-file-edit", "Entire Edit post-file-edit hook")
 	})
 }
 

--- a/cmd/entire/cli/agent/claudecode/lifecycle.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle.go
@@ -46,6 +46,7 @@ func (c *ClaudeCodeAgent) HookNames() []string {
 		HookNamePreTask,
 		HookNamePostTask,
 		HookNamePostTodo,
+		HookNamePostFileEdit,
 	}
 }
 
@@ -65,6 +66,8 @@ func (c *ClaudeCodeAgent) ParseHookEvent(_ context.Context, hookName string, std
 		return c.parseSubagentStart(stdin)
 	case HookNamePostTask:
 		return c.parseSubagentEnd(stdin)
+	case HookNamePostFileEdit:
+		return c.parseFileEdit(stdin)
 	case HookNamePostTodo:
 		// PostTodo is Claude-specific; handled outside the generic dispatcher.
 		return nil, nil //nolint:nilnil // nil event = no lifecycle action
@@ -182,6 +185,35 @@ func (c *ClaudeCodeAgent) parseSubagentEnd(stdin io.Reader) (*agent.Event, error
 		event.SubagentID = raw.ToolResponse.AgentID
 	}
 	return event, nil
+}
+
+// fileEditToolInput extracts file_path from Write/Edit tool input.
+type fileEditToolInput struct {
+	FilePath string `json:"file_path"`
+}
+
+func (c *ClaudeCodeAgent) parseFileEdit(stdin io.Reader) (*agent.Event, error) {
+	raw, err := agent.ReadAndParseHookInput[postToolHookInputRaw](stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	var toolInput fileEditToolInput
+	if err := json.Unmarshal(raw.ToolInput, &toolInput); err != nil {
+		// tool_input doesn't match expected schema — skip silently
+		return nil, nil //nolint:nilnil,nilerr // not our tool format
+	}
+	if toolInput.FilePath == "" {
+		return nil, nil //nolint:nilnil // no file_path = skip
+	}
+
+	return &agent.Event{
+		Type:       agent.FileEdit,
+		SessionID:  raw.SessionID,
+		SessionRef: raw.TranscriptPath,
+		FilePath:   toolInput.FilePath,
+		Timestamp:  time.Now(),
+	}, nil
 }
 
 // --- Transcript flush sentinel ---

--- a/cmd/entire/cli/agent/claudecode/lifecycle.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle.go
@@ -52,7 +52,7 @@ func (c *ClaudeCodeAgent) HookNames() []string {
 
 // ParseHookEvent translates a Claude Code hook into a normalized lifecycle Event.
 // Returns nil if the hook has no lifecycle significance.
-func (c *ClaudeCodeAgent) ParseHookEvent(_ context.Context, hookName string, stdin io.Reader) (*agent.Event, error) {
+func (c *ClaudeCodeAgent) ParseHookEvent(ctx context.Context, hookName string, stdin io.Reader) (*agent.Event, error) {
 	switch hookName {
 	case HookNameSessionStart:
 		return c.parseSessionStart(stdin)
@@ -67,7 +67,7 @@ func (c *ClaudeCodeAgent) ParseHookEvent(_ context.Context, hookName string, std
 	case HookNamePostTask:
 		return c.parseSubagentEnd(stdin)
 	case HookNamePostFileEdit:
-		return c.parseFileEdit(stdin)
+		return c.parseFileEdit(ctx, stdin)
 	case HookNamePostTodo:
 		// PostTodo is Claude-specific; handled outside the generic dispatcher.
 		return nil, nil //nolint:nilnil // nil event = no lifecycle action
@@ -192,7 +192,7 @@ type fileEditToolInput struct {
 	FilePath string `json:"file_path"`
 }
 
-func (c *ClaudeCodeAgent) parseFileEdit(stdin io.Reader) (*agent.Event, error) {
+func (c *ClaudeCodeAgent) parseFileEdit(ctx context.Context, stdin io.Reader) (*agent.Event, error) {
 	raw, err := agent.ReadAndParseHookInput[postToolHookInputRaw](stdin)
 	if err != nil {
 		return nil, err
@@ -200,8 +200,12 @@ func (c *ClaudeCodeAgent) parseFileEdit(stdin io.Reader) (*agent.Event, error) {
 
 	var toolInput fileEditToolInput
 	if err := json.Unmarshal(raw.ToolInput, &toolInput); err != nil {
-		// tool_input doesn't match expected schema — skip silently
-		return nil, nil //nolint:nilnil,nilerr // not our tool format
+		// Write/Edit hooks should always have file_path — log unexpected format
+		logCtx := logging.WithComponent(ctx, "agent.claudecode")
+		logging.Debug(logCtx, "parseFileEdit: unexpected tool_input format",
+			slog.String("error", err.Error()),
+		)
+		return nil, nil //nolint:nilnil // skip event but don't block agent
 	}
 	if toolInput.FilePath == "" {
 		return nil, nil //nolint:nilnil // no file_path = skip

--- a/cmd/entire/cli/agent/claudecode/lifecycle_test.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle_test.go
@@ -270,6 +270,47 @@ func TestParseHookEvent_PostTodo_ReturnsNil(t *testing.T) {
 	}
 }
 
+func TestParseFileEdit(t *testing.T) {
+	t.Parallel()
+
+	ag := &ClaudeCodeAgent{}
+	input := `{"session_id":"sess-123","transcript_path":"/tmp/t.jsonl","tool_use_id":"tu_abc","tool_input":{"file_path":"/repo/src/main.go"},"tool_response":{}}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostFileEdit, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if event.Type != agent.FileEdit {
+		t.Errorf("expected event type %v, got %v", agent.FileEdit, event.Type)
+	}
+	if event.SessionID != "sess-123" {
+		t.Errorf("expected session_id 'sess-123', got %q", event.SessionID)
+	}
+	if event.FilePath != "/repo/src/main.go" {
+		t.Errorf("expected file_path '/repo/src/main.go', got %q", event.FilePath)
+	}
+}
+
+func TestParseFileEdit_NoFilePath(t *testing.T) {
+	t.Parallel()
+
+	ag := &ClaudeCodeAgent{}
+	input := `{"session_id":"sess-123","transcript_path":"/tmp/t.jsonl","tool_use_id":"tu_abc","tool_input":{"content":"hello"},"tool_response":{}}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostFileEdit, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Errorf("expected nil event when file_path is missing, got %+v", event)
+	}
+}
+
 func TestParseHookEvent_UnknownHook_ReturnsNil(t *testing.T) {
 	t.Parallel()
 
@@ -360,6 +401,11 @@ func TestParseHookEvent_AllHookTypes(t *testing.T) {
 			hookName:      HookNamePostTodo,
 			expectNil:     true,
 			inputTemplate: `{"session_id": "s7", "transcript_path": "/t"}`,
+		},
+		{
+			hookName:      HookNamePostFileEdit,
+			expectedType:  agent.FileEdit,
+			inputTemplate: `{"session_id": "s8", "transcript_path": "/t", "tool_use_id": "t3", "tool_input": {"file_path": "/repo/f.go"}, "tool_response": {}}`,
 		},
 	}
 

--- a/cmd/entire/cli/agent/claudecode/lifecycle_test.go
+++ b/cmd/entire/cli/agent/claudecode/lifecycle_test.go
@@ -311,6 +311,23 @@ func TestParseFileEdit_NoFilePath(t *testing.T) {
 	}
 }
 
+func TestParseFileEdit_MalformedToolInput(t *testing.T) {
+	t.Parallel()
+
+	ag := &ClaudeCodeAgent{}
+	// tool_input is a string instead of an object — json.Unmarshal into struct should fail gracefully
+	input := `{"session_id":"sess-123","transcript_path":"/tmp/t.jsonl","tool_use_id":"tu_abc","tool_input":"not-an-object","tool_response":{}}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostFileEdit, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Errorf("expected nil event for malformed tool_input, got %+v", event)
+	}
+}
+
 func TestParseHookEvent_UnknownHook_ReturnsNil(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/event.go
+++ b/cmd/entire/cli/agent/event.go
@@ -40,6 +40,10 @@ const (
 	// (e.g., Gemini CLI's BeforeModel). The framework stores the model as a hint
 	// for subsequent TurnStart/TurnEnd events in the same session.
 	ModelUpdate
+
+	// FileEdit indicates the agent modified a file via a Write/Edit tool.
+	// The framework appends the file path to the session's tracking file.
+	FileEdit
 )
 
 // String returns a human-readable name for the event type.
@@ -61,6 +65,8 @@ func (e EventType) String() string {
 		return "SubagentEnd"
 	case ModelUpdate:
 		return "ModelUpdate"
+	case FileEdit:
+		return "FileEdit"
 	default:
 		return "Unknown"
 	}
@@ -113,6 +119,11 @@ type Event struct {
 	// Populated on SubagentEnd events when the agent provides this data
 	// directly via hook payload (e.g., Cursor's subagentStop).
 	ModifiedFiles []string
+
+	// FilePath is the path to a file that was edited (for FileEdit events).
+	// Populated by agents from tool_input.file_path. May be absolute — the
+	// framework normalizes to repo-relative before persisting.
+	FilePath string
 
 	// ResponseMessage is an optional message to display to the user via the agent.
 	ResponseMessage string

--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -79,7 +79,8 @@ func getHookType(hookName string) string {
 	switch hookName {
 	case claudecode.HookNamePreTask, claudecode.HookNamePostTask, claudecode.HookNamePostTodo:
 		return "subagent"
-	case geminicli.HookNameBeforeTool, geminicli.HookNameAfterTool:
+	case geminicli.HookNameBeforeTool, geminicli.HookNameAfterTool,
+		claudecode.HookNamePostFileEdit:
 		return "tool"
 	default:
 		return "agent"

--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -73,7 +73,7 @@ func newAgentHooksCmd(agentName types.AgentName, handler agent.HookSupport) *cob
 
 // getHookType returns the hook type based on the hook name.
 // Returns "subagent" for task-related hooks (pre-task, post-task, post-todo),
-// "tool" for tool-related hooks (before-tool, after-tool),
+// "tool" for tool-related hooks (before-tool, after-tool, post-file-edit),
 // "agent" for all other agent hooks.
 func getHookType(hookName string) string {
 	switch hookName {

--- a/cmd/entire/cli/integration_test/agent_test.go
+++ b/cmd/entire/cli/integration_test/agent_test.go
@@ -121,9 +121,10 @@ func TestAgentHookInstallation(t *testing.T) {
 			t.Fatalf("InstallHooks() error = %v", err)
 		}
 
-		// Should install 7 hooks: SessionStart, SessionEnd, Stop, UserPromptSubmit, PreToolUse[Task], PostToolUse[Task], PostToolUse[TodoWrite]
-		if count != 7 {
-			t.Errorf("InstallHooks() count = %d, want 7", count)
+		// Should install 9 hooks: SessionStart, SessionEnd, Stop, UserPromptSubmit,
+		// PreToolUse[Task], PostToolUse[Task], PostToolUse[TodoWrite], PostToolUse[Write], PostToolUse[Edit]
+		if count != 9 {
+			t.Errorf("InstallHooks() count = %d, want 9", count)
 		}
 
 		// Verify hooks are installed

--- a/cmd/entire/cli/integration_test/file_tracking_test.go
+++ b/cmd/entire/cli/integration_test/file_tracking_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestPostFileEdit_TracksEditedFiles tests the end-to-end flow of file tracking
+// via the post-file-edit hook. When the agent edits files (Write/Edit tools),
+// the hook handler normalizes absolute paths to repo-relative and appends them
+// to .git/entire-sessions/<session-id>.files.
+func TestPostFileEdit_TracksEditedFiles(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	sess := env.NewSession()
+
+	// Start session (user-prompt-submit creates session state and starts a turn)
+	if err := env.SimulateUserPromptSubmit(sess.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+
+	// Simulate two file edits with absolute paths (the handler normalizes them)
+	if err := env.SimulatePostFileEdit(PostFileEditInput{
+		SessionID:      sess.ID,
+		TranscriptPath: sess.TranscriptPath,
+		ToolUseID:      "tu_write_1",
+		FilePath:       filepath.Join(env.RepoDir, "src", "main.go"),
+	}); err != nil {
+		t.Fatalf("SimulatePostFileEdit (src/main.go) failed: %v", err)
+	}
+
+	if err := env.SimulatePostFileEdit(PostFileEditInput{
+		SessionID:      sess.ID,
+		TranscriptPath: sess.TranscriptPath,
+		ToolUseID:      "tu_edit_1",
+		FilePath:       filepath.Join(env.RepoDir, "README.md"),
+	}); err != nil {
+		t.Fatalf("SimulatePostFileEdit (README.md) failed: %v", err)
+	}
+
+	// Verify the tracking file has both files (repo-relative, sorted)
+	trackingFile := filepath.Join(env.RepoDir, ".git", "entire-sessions", sess.ID+".files")
+	data, err := os.ReadFile(trackingFile)
+	if err != nil {
+		t.Fatalf("Failed to read tracking file %s: %v", trackingFile, err)
+	}
+
+	// Parse lines, deduplicate and sort (matching ReadFilesTouched behavior)
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	seen := make(map[string]bool)
+	var unique []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" && !seen[line] {
+			seen[line] = true
+			unique = append(unique, line)
+		}
+	}
+	sort.Strings(unique)
+
+	expected := []string{"README.md", "src/main.go"}
+	if len(unique) != len(expected) {
+		t.Fatalf("Expected %d tracked files, got %d: %v", len(expected), len(unique), unique)
+	}
+	for i, want := range expected {
+		if unique[i] != want {
+			t.Errorf("Tracked file [%d]: want %q, got %q", i, want, unique[i])
+		}
+	}
+}

--- a/cmd/entire/cli/integration_test/file_tracking_test.go
+++ b/cmd/entire/cli/integration_test/file_tracking_test.go
@@ -3,11 +3,11 @@
 package integration
 
 import (
-	"os"
+	"context"
 	"path/filepath"
-	"sort"
-	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/session"
 )
 
 // TestPostFileEdit_TracksEditedFiles tests the end-to-end flow of file tracking
@@ -44,33 +44,21 @@ func TestPostFileEdit_TracksEditedFiles(t *testing.T) {
 		t.Fatalf("SimulatePostFileEdit (README.md) failed: %v", err)
 	}
 
-	// Verify the tracking file has both files (repo-relative, sorted)
-	trackingFile := filepath.Join(env.RepoDir, ".git", "entire-sessions", sess.ID+".files")
-	data, err := os.ReadFile(trackingFile)
+	// Verify via ReadFilesTouched (deduplicates and sorts)
+	stateDir := filepath.Join(env.RepoDir, ".git", "entire-sessions")
+	store := session.NewStateStoreWithDir(stateDir)
+	files, err := store.ReadFilesTouched(context.Background(), sess.ID)
 	if err != nil {
-		t.Fatalf("Failed to read tracking file %s: %v", trackingFile, err)
+		t.Fatalf("ReadFilesTouched failed: %v", err)
 	}
-
-	// Parse lines, deduplicate and sort (matching ReadFilesTouched behavior)
-	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	seen := make(map[string]bool)
-	var unique []string
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line != "" && !seen[line] {
-			seen[line] = true
-			unique = append(unique, line)
-		}
-	}
-	sort.Strings(unique)
 
 	expected := []string{"README.md", "src/main.go"}
-	if len(unique) != len(expected) {
-		t.Fatalf("Expected %d tracked files, got %d: %v", len(expected), len(unique), unique)
+	if len(files) != len(expected) {
+		t.Fatalf("Expected %d tracked files, got %d: %v", len(expected), len(files), files)
 	}
 	for i, want := range expected {
-		if unique[i] != want {
-			t.Errorf("Tracked file [%d]: want %q, got %q", i, want, unique[i])
+		if files[i] != want {
+			t.Errorf("Tracked file [%d]: want %q, got %q", i, want, files[i])
 		}
 	}
 }

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -408,6 +408,38 @@ func (env *TestEnv) SimulatePostTodo(input PostTodoInput) error {
 	return runner.SimulatePostTodo(input)
 }
 
+// PostFileEditInput contains the input for PostToolUse[Write/Edit] hook.
+type PostFileEditInput struct {
+	SessionID      string
+	TranscriptPath string
+	ToolUseID      string
+	FilePath       string
+}
+
+// SimulatePostFileEdit simulates the PostToolUse[Write/Edit] hook.
+func (r *HookRunner) SimulatePostFileEdit(input PostFileEditInput) error {
+	r.T.Helper()
+
+	hookInput := map[string]interface{}{
+		"session_id":      input.SessionID,
+		"transcript_path": input.TranscriptPath,
+		"tool_use_id":     input.ToolUseID,
+		"tool_input": map[string]string{
+			"file_path": input.FilePath,
+		},
+		"tool_response": map[string]interface{}{},
+	}
+
+	return r.runHookWithInput("post-file-edit", hookInput)
+}
+
+// SimulatePostFileEdit is a convenience method on TestEnv.
+func (env *TestEnv) SimulatePostFileEdit(input PostFileEditInput) error {
+	env.T.Helper()
+	runner := NewHookRunner(env.RepoDir, env.ClaudeProjectDir, env.T)
+	return runner.SimulatePostFileEdit(input)
+}
+
 // ClearSessionState removes the session state file for the given session ID.
 // This simulates what happens when a user commits their changes (session is "completed").
 // Used in tests to allow sequential sessions to run without triggering concurrent session warnings.

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -175,15 +175,22 @@ func handleLifecycleModelUpdate(ctx context.Context, ag agent.Agent, event *agen
 
 // handleLifecycleFileEdit appends a file path to the session's tracking file.
 // This is intentionally lightweight — no JSON state loading, just a file append.
+// Returns nil unconditionally; errors are logged but not propagated to avoid blocking the agent.
 func handleLifecycleFileEdit(ctx context.Context, _ agent.Agent, event *agent.Event) error {
 	if event.SessionID == "" || event.FilePath == "" {
 		return nil
 	}
 
+	logCtx := logging.WithComponent(ctx, "lifecycle")
+
 	// Normalize to repo-relative path
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
-		return nil //nolint:nilerr // can't normalize path outside git repo, skip silently
+		logging.Warn(logCtx, "failed to get worktree root for file edit tracking",
+			slog.String("session_id", event.SessionID),
+			slog.String("error", err.Error()),
+		)
+		return nil
 	}
 
 	relPath := paths.ToRelativePath(event.FilePath, repoRoot)
@@ -193,11 +200,14 @@ func handleLifecycleFileEdit(ctx context.Context, _ agent.Agent, event *agent.Ev
 
 	store, err := session.NewStateStore(ctx)
 	if err != nil {
-		return nil //nolint:nilerr // can't access state store, skip silently
+		logging.Warn(logCtx, "failed to create state store for file edit tracking",
+			slog.String("session_id", event.SessionID),
+			slog.String("error", err.Error()),
+		)
+		return nil
 	}
 
 	if appendErr := store.AppendFileTouched(ctx, event.SessionID, relPath); appendErr != nil {
-		logCtx := logging.WithComponent(ctx, "lifecycle")
 		logging.Warn(logCtx, "failed to track file edit",
 			slog.String("session_id", event.SessionID),
 			slog.String("file_path", relPath),

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -53,6 +53,8 @@ func DispatchLifecycleEvent(ctx context.Context, ag agent.Agent, event *agent.Ev
 		return handleLifecycleSubagentEnd(ctx, ag, event)
 	case agent.ModelUpdate:
 		return handleLifecycleModelUpdate(ctx, ag, event)
+	case agent.FileEdit:
+		return handleLifecycleFileEdit(ctx, ag, event)
 	default:
 		return fmt.Errorf("unknown lifecycle event type: %d", event.Type)
 	}
@@ -166,6 +168,41 @@ func handleLifecycleModelUpdate(ctx context.Context, ag agent.Agent, event *agen
 	if err := strategy.StoreModelHint(ctx, event.SessionID, event.Model); err != nil {
 		logging.Warn(logCtx, "failed to store model hint",
 			slog.String("error", err.Error()))
+	}
+
+	return nil
+}
+
+// handleLifecycleFileEdit appends a file path to the session's tracking file.
+// This is intentionally lightweight — no JSON state loading, just a file append.
+func handleLifecycleFileEdit(ctx context.Context, _ agent.Agent, event *agent.Event) error {
+	if event.SessionID == "" || event.FilePath == "" {
+		return nil
+	}
+
+	// Normalize to repo-relative path
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return nil //nolint:nilerr // can't normalize path outside git repo, skip silently
+	}
+
+	relPath := paths.ToRelativePath(event.FilePath, repoRoot)
+	if relPath == "" {
+		return nil // path outside repo, skip
+	}
+
+	store, err := session.NewStateStore(ctx)
+	if err != nil {
+		return nil //nolint:nilerr // can't access state store, skip silently
+	}
+
+	if appendErr := store.AppendFileTouched(ctx, event.SessionID, relPath); appendErr != nil {
+		logCtx := logging.WithComponent(ctx, "lifecycle")
+		logging.Warn(logCtx, "failed to track file edit",
+			slog.String("session_id", event.SessionID),
+			slog.String("file_path", relPath),
+			slog.String("error", appendErr.Error()),
+		)
 	}
 
 	return nil

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -406,6 +407,94 @@ func (s *StateStore) List(ctx context.Context) ([]*State, error) {
 // stateFilePath returns the path to a session state file.
 func (s *StateStore) stateFilePath(sessionID string) string {
 	return filepath.Join(s.stateDir, sessionID+".json")
+}
+
+// filesTouchedPath returns the path to the append-only file tracking file for a session.
+func (s *StateStore) filesTouchedPath(sessionID string) string {
+	return filepath.Join(s.stateDir, sessionID+".files")
+}
+
+// AppendFileTouched appends a single file path to the session's tracking file.
+// The file is created if it doesn't exist. Paths are stored one per line.
+func (s *StateStore) AppendFileTouched(ctx context.Context, sessionID, filePath string) error {
+	_ = ctx // Reserved for future use
+
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return fmt.Errorf("invalid session ID: %w", err)
+	}
+
+	if err := os.MkdirAll(s.stateDir, 0o750); err != nil {
+		return fmt.Errorf("failed to create session state directory: %w", err)
+	}
+
+	f, err := os.OpenFile(s.filesTouchedPath(sessionID), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to open files touched tracking file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := fmt.Fprintln(f, filePath); err != nil {
+		return fmt.Errorf("failed to write to files touched tracking file: %w", err)
+	}
+	return nil
+}
+
+// ReadFilesTouched reads the session's file tracking file and returns a deduplicated,
+// sorted list of file paths. Returns (nil, nil) if the file doesn't exist or is empty.
+func (s *StateStore) ReadFilesTouched(ctx context.Context, sessionID string) ([]string, error) {
+	_ = ctx // Reserved for future use
+
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return nil, fmt.Errorf("invalid session ID: %w", err)
+	}
+
+	data, err := os.ReadFile(s.filesTouchedPath(sessionID))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read files touched tracking file: %w", err)
+	}
+
+	// Deduplicate using a map
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			seen[line] = struct{}{}
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil, nil
+	}
+
+	// Collect and sort
+	result := make([]string, 0, len(seen))
+	for path := range seen {
+		result = append(result, path)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+// ClearFilesTouched removes the session's file tracking file.
+// Returns nil if the file doesn't exist (idempotent).
+func (s *StateStore) ClearFilesTouched(ctx context.Context, sessionID string) error {
+	_ = ctx // Reserved for future use
+
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return fmt.Errorf("invalid session ID: %w", err)
+	}
+
+	err := os.Remove(s.filesTouchedPath(sessionID))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to remove files touched tracking file: %w", err)
+	}
+	return nil
 }
 
 // gitCommonDirCache caches the git common dir to avoid repeated subprocess calls.

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -423,6 +423,10 @@ func (s *StateStore) AppendFileTouched(ctx context.Context, sessionID, filePath 
 		return fmt.Errorf("invalid session ID: %w", err)
 	}
 
+	if strings.ContainsAny(filePath, "\n\r") {
+		return fmt.Errorf("file path contains newline characters: %q", filePath)
+	}
+
 	if err := os.MkdirAll(s.stateDir, 0o750); err != nil {
 		return fmt.Errorf("failed to create session state directory: %w", err)
 	}
@@ -458,7 +462,7 @@ func (s *StateStore) ReadFilesTouched(ctx context.Context, sessionID string) ([]
 
 	// Deduplicate using a map
 	seen := make(map[string]struct{})
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
 			seen[line] = struct{}{}

--- a/cmd/entire/cli/session/state_test.go
+++ b/cmd/entire/cli/session/state_test.go
@@ -455,3 +455,103 @@ func TestGetGitCommonDir_ErrorOutsideRepo(t *testing.T) {
 	_, err := getGitCommonDir(context.Background())
 	assert.Error(t, err)
 }
+
+func TestAppendFileTouched(t *testing.T) {
+	t.Parallel()
+
+	store := NewStateStoreWithDir(t.TempDir())
+	ctx := context.Background()
+	sessionID := "2026-01-13-test-session"
+
+	// Append multiple files including a duplicate
+	require.NoError(t, store.AppendFileTouched(ctx, sessionID, "src/main.go"))
+	require.NoError(t, store.AppendFileTouched(ctx, sessionID, "README.md"))
+	require.NoError(t, store.AppendFileTouched(ctx, sessionID, "src/main.go")) // duplicate
+	require.NoError(t, store.AppendFileTouched(ctx, sessionID, "api/handler.go"))
+
+	// Read back — should be deduped and sorted
+	files, err := store.ReadFilesTouched(ctx, sessionID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"README.md", "api/handler.go", "src/main.go"}, files)
+}
+
+func TestReadFilesTouched_NoFile(t *testing.T) {
+	t.Parallel()
+
+	store := NewStateStoreWithDir(t.TempDir())
+	ctx := context.Background()
+
+	files, err := store.ReadFilesTouched(ctx, "nonexistent-session")
+	require.NoError(t, err)
+	require.Nil(t, files)
+}
+
+func TestClearFilesTouched(t *testing.T) {
+	t.Parallel()
+
+	store := NewStateStoreWithDir(t.TempDir())
+	ctx := context.Background()
+	sessionID := "2026-01-13-clear-test"
+
+	// Create tracking file
+	require.NoError(t, store.AppendFileTouched(ctx, sessionID, "file.txt"))
+
+	// Verify it exists
+	files, err := store.ReadFilesTouched(ctx, sessionID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"file.txt"}, files)
+
+	// Clear it
+	require.NoError(t, store.ClearFilesTouched(ctx, sessionID))
+
+	// Verify it's gone
+	files, err = store.ReadFilesTouched(ctx, sessionID)
+	require.NoError(t, err)
+	require.Nil(t, files)
+
+	// Clearing again should not error (idempotent)
+	require.NoError(t, store.ClearFilesTouched(ctx, sessionID))
+}
+
+func TestClear_RemovesFilesTracking(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	store := NewStateStoreWithDir(stateDir)
+	ctx := context.Background()
+	sessionID := "2026-01-13-clear-all"
+
+	// Create both .json state and .files tracking
+	state := &State{
+		SessionID:  sessionID,
+		BaseCommit: "abc123",
+		StartedAt:  time.Now(),
+	}
+	require.NoError(t, store.Save(ctx, state))
+	require.NoError(t, store.AppendFileTouched(ctx, sessionID, "tracked.go"))
+
+	// Verify both files exist
+	_, err := os.Stat(filepath.Join(stateDir, sessionID+".json"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(stateDir, sessionID+".files"))
+	require.NoError(t, err)
+
+	// Clear should remove all session files including .files
+	require.NoError(t, store.Clear(ctx, sessionID))
+
+	matches, err := filepath.Glob(filepath.Join(stateDir, sessionID+".*"))
+	require.NoError(t, err)
+	assert.Empty(t, matches, "all session files including .files should be removed")
+}
+
+func TestAppendFileTouched_InvalidSessionID(t *testing.T) {
+	t.Parallel()
+
+	store := NewStateStoreWithDir(t.TempDir())
+	ctx := context.Background()
+
+	// Path traversal attempt
+	err := store.AppendFileTouched(ctx, "../evil", "file.txt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid session ID")
+}

--- a/cmd/entire/cli/session/state_test.go
+++ b/cmd/entire/cli/session/state_test.go
@@ -555,3 +555,18 @@ func TestAppendFileTouched_InvalidSessionID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid session ID")
 }
+
+func TestAppendFileTouched_RejectsNewlines(t *testing.T) {
+	t.Parallel()
+
+	store := NewStateStoreWithDir(t.TempDir())
+	ctx := context.Background()
+
+	err := store.AppendFileTouched(ctx, "session-1", "file\ninjected")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "newline")
+
+	err = store.AppendFileTouched(ctx, "session-1", "file\rinjected")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "newline")
+}

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -1030,6 +1031,10 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 			shadowTree: shadowTree,
 		})
 		state.FilesTouched = remainingFiles
+		// Clear tracking file — state.FilesTouched now has the authoritative carry-forward list
+		if store, storeErr := s.getStateStore(ctx); storeErr == nil {
+			_ = store.ClearFilesTouched(ctx, state.SessionID) //nolint:errcheck // Best-effort cleanup, non-critical
+		}
 		logging.Debug(logCtx, "post-commit: carry-forward decision (content-aware)",
 			slog.String("session_id", state.SessionID),
 			slog.Int("files_touched_before", len(filesTouchedBefore)),
@@ -1121,6 +1126,10 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 	state.PromptAttributions = nil
 	state.PendingPromptAttribution = nil
 	state.FilesTouched = nil
+	// Clear the file tracking file alongside state.FilesTouched
+	if store, storeErr := s.getStateStore(ctx); storeErr == nil {
+		_ = store.ClearFilesTouched(ctx, state.SessionID) //nolint:errcheck // Best-effort cleanup, non-critical
+	}
 
 	// NOTE: filesystem prompt.txt is NOT cleared here. The caller (PostCommit handler)
 	// decides whether to clear it based on carry-forward: if remaining files exist,
@@ -1459,9 +1468,27 @@ func (s *ManualCommitStrategy) sessionHasNewContentFromLiveTranscript(ctx contex
 // Handles PrepareTranscript internally before falling back to extraction,
 // so callers don't need to prepare the transcript first.
 func (s *ManualCommitStrategy) resolveFilesTouched(ctx context.Context, state *SessionState) []string {
-	if len(state.FilesTouched) > 0 {
-		result := make([]string, len(state.FilesTouched))
-		copy(result, state.FilesTouched)
+	var tracked []string
+	if store, err := s.getStateStore(ctx); err == nil {
+		tracked, _ = store.ReadFilesTouched(ctx, state.SessionID) //nolint:errcheck // Best-effort read, falls back to transcript
+	}
+
+	if len(state.FilesTouched) > 0 || len(tracked) > 0 {
+		seen := make(map[string]struct{})
+		var result []string
+		for _, f := range state.FilesTouched {
+			if _, ok := seen[f]; !ok {
+				seen[f] = struct{}{}
+				result = append(result, f)
+			}
+		}
+		for _, f := range tracked {
+			if _, ok := seen[f]; !ok {
+				seen[f] = struct{}{}
+				result = append(result, f)
+			}
+		}
+		sort.Strings(result)
 		return result
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1032,9 +1032,7 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 		})
 		state.FilesTouched = remainingFiles
 		// Clear tracking file — state.FilesTouched now has the authoritative carry-forward list
-		if store, storeErr := s.getStateStore(ctx); storeErr == nil {
-			_ = store.ClearFilesTouched(ctx, state.SessionID) //nolint:errcheck // Best-effort cleanup, non-critical
-		}
+		s.clearFilesTracking(ctx, state.SessionID)
 		logging.Debug(logCtx, "post-commit: carry-forward decision (content-aware)",
 			slog.String("session_id", state.SessionID),
 			slog.Int("files_touched_before", len(filesTouchedBefore)),
@@ -1127,9 +1125,7 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 	state.PendingPromptAttribution = nil
 	state.FilesTouched = nil
 	// Clear the file tracking file alongside state.FilesTouched
-	if store, storeErr := s.getStateStore(ctx); storeErr == nil {
-		_ = store.ClearFilesTouched(ctx, state.SessionID) //nolint:errcheck // Best-effort cleanup, non-critical
-	}
+	s.clearFilesTracking(ctx, state.SessionID)
 
 	// NOTE: filesystem prompt.txt is NOT cleared here. The caller (PostCommit handler)
 	// decides whether to clear it based on carry-forward: if remaining files exist,
@@ -1468,21 +1464,26 @@ func (s *ManualCommitStrategy) sessionHasNewContentFromLiveTranscript(ctx contex
 // Handles PrepareTranscript internally before falling back to extraction,
 // so callers don't need to prepare the transcript first.
 func (s *ManualCommitStrategy) resolveFilesTouched(ctx context.Context, state *SessionState) []string {
+	logCtx := logging.WithComponent(ctx, "checkpoint")
 	var tracked []string
-	if store, err := s.getStateStore(ctx); err == nil {
-		tracked, _ = store.ReadFilesTouched(ctx, state.SessionID) //nolint:errcheck // Best-effort read, falls back to transcript
+	if store, err := s.getStateStore(ctx); err != nil {
+		logging.Debug(logCtx, "resolveFilesTouched: could not get state store, falling back to transcript",
+			slog.String("session_id", state.SessionID),
+			slog.String("error", err.Error()),
+		)
+	} else if files, readErr := store.ReadFilesTouched(ctx, state.SessionID); readErr != nil {
+		logging.Debug(logCtx, "resolveFilesTouched: could not read tracking file, falling back to transcript",
+			slog.String("session_id", state.SessionID),
+			slog.String("error", readErr.Error()),
+		)
+	} else {
+		tracked = files
 	}
 
 	if len(state.FilesTouched) > 0 || len(tracked) > 0 {
 		seen := make(map[string]struct{})
 		var result []string
-		for _, f := range state.FilesTouched {
-			if _, ok := seen[f]; !ok {
-				seen[f] = struct{}{}
-				result = append(result, f)
-			}
-		}
-		for _, f := range tracked {
+		for _, f := range append(state.FilesTouched, tracked...) {
 			if _, ok := seen[f]; !ok {
 				seen[f] = struct{}{}
 				result = append(result, f)
@@ -1496,6 +1497,22 @@ func (s *ManualCommitStrategy) resolveFilesTouched(ctx context.Context, state *S
 	prepareTranscriptForState(ctx, state)
 
 	return s.extractModifiedFilesFromLiveTranscript(ctx, state, state.CheckpointTranscriptStart)
+}
+
+// clearFilesTracking removes the session's file tracking file (best-effort).
+// Logs at Debug level on failure to aid debugging stale data accumulation.
+func (s *ManualCommitStrategy) clearFilesTracking(ctx context.Context, sessionID string) {
+	store, storeErr := s.getStateStore(ctx)
+	if storeErr != nil {
+		return
+	}
+	if clearErr := store.ClearFilesTouched(ctx, sessionID); clearErr != nil {
+		logCtx := logging.WithComponent(ctx, "checkpoint")
+		logging.Debug(logCtx, "failed to clear tracking file (non-critical)",
+			slog.String("session_id", sessionID),
+			slog.String("error", clearErr.Error()),
+		)
+	}
 }
 
 // hasNewTranscriptWork checks if the agent has done work since the last condensation.

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -3677,4 +3678,81 @@ func TestResolveFilesTouched_PrefersStateFallsBackToTranscript(t *testing.T) {
 			t.Errorf("resolveFilesTouched with no sources = %v, want nil", files)
 		}
 	})
+}
+
+// TestResolveFilesTouched_FromTrackingFile verifies that resolveFilesTouched reads from
+// the file tracking file when state.FilesTouched is empty.
+func TestResolveFilesTouched_FromTrackingFile(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	// Set up tracking file via StateStore
+	stateDir := filepath.Join(dir, ".git", session.SessionStateDirName)
+	store := session.NewStateStoreWithDir(stateDir)
+	ctx := context.Background()
+	sessionID := "2026-01-15-tracking-test"
+
+	// Append files to the tracking file
+	if err := store.AppendFileTouched(ctx, sessionID, "tracked-b.txt"); err != nil {
+		t.Fatalf("failed to append file: %v", err)
+	}
+	if err := store.AppendFileTouched(ctx, sessionID, "tracked-a.txt"); err != nil {
+		t.Fatalf("failed to append file: %v", err)
+	}
+
+	s := &ManualCommitStrategy{}
+	state := &SessionState{
+		SessionID:    sessionID,
+		FilesTouched: nil, // empty — should fall through to tracking file
+	}
+
+	files := s.resolveFilesTouched(ctx, state)
+
+	// Should return tracking file data, sorted
+	if len(files) != 2 {
+		t.Fatalf("resolveFilesTouched = %v, want 2 files", files)
+	}
+	if files[0] != "tracked-a.txt" || files[1] != "tracked-b.txt" {
+		t.Errorf("resolveFilesTouched = %v, want [tracked-a.txt tracked-b.txt]", files)
+	}
+}
+
+// TestResolveFilesTouched_MergesBothSources verifies that resolveFilesTouched merges
+// state.FilesTouched AND tracking file data, deduplicating and sorting the result.
+func TestResolveFilesTouched_MergesBothSources(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	// Set up tracking file via StateStore
+	stateDir := filepath.Join(dir, ".git", session.SessionStateDirName)
+	store := session.NewStateStoreWithDir(stateDir)
+	ctx := context.Background()
+	sessionID := "2026-01-15-merge-test"
+
+	// Append files to the tracking file (including one that overlaps with state)
+	if err := store.AppendFileTouched(ctx, sessionID, "shared.txt"); err != nil {
+		t.Fatalf("failed to append file: %v", err)
+	}
+	if err := store.AppendFileTouched(ctx, sessionID, "only-tracked.txt"); err != nil {
+		t.Fatalf("failed to append file: %v", err)
+	}
+
+	s := &ManualCommitStrategy{}
+	state := &SessionState{
+		SessionID:    sessionID,
+		FilesTouched: []string{"shared.txt", "only-state.txt"},
+	}
+
+	files := s.resolveFilesTouched(ctx, state)
+
+	// Should merge both sources: shared.txt (deduplicated), only-state.txt, only-tracked.txt
+	expected := []string{"only-state.txt", "only-tracked.txt", "shared.txt"}
+	if len(files) != len(expected) {
+		t.Fatalf("resolveFilesTouched = %v, want %v", files, expected)
+	}
+	for i, f := range files {
+		if f != expected[i] {
+			t.Errorf("resolveFilesTouched[%d] = %q, want %q", i, f, expected[i])
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Adds real-time file tracking via a `post-file-edit` hook, eliminating the need for transcript parsing to determine which files an agent touched
- Introduces an append-only tracking file (`.git/entire-sessions/<session-id>.files`) that records file paths as agents edit them
- Wires Claude Code's `PostToolUse[Write]` and `PostToolUse[Edit]` hooks to fire the new event
- `resolveFilesTouched` now merges the tracking file with `state.FilesTouched`, falling back to transcript extraction only when both are empty

This is Phase 1 of the transcript parsing replacement plan. Other agents (Gemini CLI, Factory AI Droid, OpenCode, Copilot CLI) will be wired in follow-up PRs.

## Architecture

```
Agent fires Write/Edit tool
  → PostToolUse hook fires `entire hooks <agent> post-file-edit`
    → parseFileEdit extracts file_path from tool_input
      → DispatchLifecycleEvent routes FileEdit event
        → handleLifecycleFileEdit normalizes path, appends to .files
```

At checkpoint time, `resolveFilesTouched` merges:
1. `state.FilesTouched` (from previous turns' SaveStep)
2. Tracking file (from current turn's real-time hook)
3. Falls back to transcript extraction only when both are empty

## Changes

**New event type & handler:**
- `FileEdit` event type in `agent/event.go`
- `handleLifecycleFileEdit` in `lifecycle.go` — normalizes to repo-relative paths, fail-open

**Session package:**
- `AppendFileTouched` — O_APPEND write, one path per line
- `ReadFilesTouched` — deduplicated, sorted read
- `ClearFilesTouched` — cleanup after condensation
- Newline validation to prevent line injection

**Strategy integration:**
- `resolveFilesTouched` merges tracking file + state, falls back to transcript
- Cleanup at condensation and carry-forward points

**Claude Code wiring:**
- `PostToolUse[Write]` and `PostToolUse[Edit]` matchers in hooks
- `parseFileEdit` extracts `file_path` from `tool_input` JSON

## Test plan

- [x] Unit tests: 8 new tests (session state, event type, Claude Code parsing, strategy merge)
- [x] Integration test: end-to-end file tracking through hook binary
- [x] All 43 E2E canary tests pass
- [x] `mise run fmt && mise run lint && mise run test:ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)