### PR TITLE
feat: wire Gemini CLI post-file-edit hook

### DIFF
--- a/cmd/entire/cli/agent/event.go
+++ b/cmd/entire/cli/agent/event.go
@@ -121,8 +121,8 @@ type Event struct {
 	ModifiedFiles []string
 
 	// FilePath is the path to a file that was edited (for FileEdit events).
-	// Populated by agents from tool_input.file_path. May be absolute — the
-	// framework normalizes to repo-relative before persisting.
+	// Populated by agents from tool input (field name varies by agent).
+	// May be absolute — the framework normalizes to repo-relative before persisting.
 	FilePath string
 
 	// ResponseMessage is an optional message to display to the user via the agent.

--- a/cmd/entire/cli/agent/geminicli/hooks.go
+++ b/cmd/entire/cli/agent/geminicli/hooks.go
@@ -28,6 +28,7 @@ const (
 	HookNameAfterTool           = "after-tool"
 	HookNamePreCompress         = "pre-compress"
 	HookNameNotification        = "notification"
+	HookNamePostFileEdit        = "post-file-edit"
 )
 
 // GeminiSettingsFileName is the settings file used by Gemini CLI.
@@ -160,22 +161,29 @@ func (g *GeminiCLIAgent) InstallHooks(ctx context.Context, localDev bool, force 
 	beforeTool = addGeminiHook(beforeTool, "*", "entire-before-tool", cmdPrefix+"before-tool")
 	afterTool = addGeminiHook(afterTool, "*", "entire-after-tool", cmdPrefix+"after-tool")
 
+	// File-edit hooks (AfterTool with specific matchers for file-modifying tools)
+	postFileEditCmd := cmdPrefix + "post-file-edit"
+	for _, toolName := range FileModificationTools {
+		afterTool = addGeminiHook(afterTool, toolName, "entire-post-file-edit-"+toolName, postFileEditCmd)
+	}
+
 	// Compression hook (before chat history compression)
 	preCompress = addGeminiHook(preCompress, "", "entire-pre-compress", cmdPrefix+"pre-compress")
 
 	// Notification hook (errors, warnings, info)
 	notification = addGeminiHook(notification, "", "entire-notification", cmdPrefix+"notification")
 
-	// 12 hooks total:
+	// 16 hooks total:
 	// - session-start (1)
 	// - session-end exit + logout (2)
 	// - before-agent, after-agent (2)
 	// - before-model, after-model (2)
 	// - before-tool-selection (1)
 	// - before-tool, after-tool (2)
+	// - post-file-edit: write_file, edit_file, save_file, replace (4)
 	// - pre-compress (1)
 	// - notification (1)
-	count := 12
+	count := 16
 
 	// Marshal modified hook types back to rawHooks
 	marshalGeminiHookType(rawHooks, "SessionStart", sessionStart)

--- a/cmd/entire/cli/agent/geminicli/hooks_test.go
+++ b/cmd/entire/cli/agent/geminicli/hooks_test.go
@@ -20,10 +20,11 @@ func TestInstallHooks_FreshInstall(t *testing.T) {
 		t.Fatalf("InstallHooks() error = %v", err)
 	}
 
-	// 12 hooks: SessionStart, SessionEnd (exit+logout), BeforeAgent, AfterAgent,
-	// BeforeModel, AfterModel, BeforeToolSelection, BeforeTool, AfterTool, PreCompress, Notification
-	if count != 12 {
-		t.Errorf("InstallHooks() count = %d, want 12", count)
+	// 16 hooks: SessionStart, SessionEnd (exit+logout), BeforeAgent, AfterAgent,
+	// BeforeModel, AfterModel, BeforeToolSelection, BeforeTool, AfterTool,
+	// PostFileEdit (write_file, edit_file, save_file, replace), PreCompress, Notification
+	if count != 16 {
+		t.Errorf("InstallHooks() count = %d, want 16", count)
 	}
 
 	// Verify settings.json was created with hooks
@@ -51,8 +52,9 @@ func TestInstallHooks_FreshInstall(t *testing.T) {
 	if len(settings.Hooks.BeforeTool) != 1 {
 		t.Errorf("BeforeTool hooks = %d, want 1", len(settings.Hooks.BeforeTool))
 	}
-	if len(settings.Hooks.AfterTool) != 1 {
-		t.Errorf("AfterTool hooks = %d, want 1", len(settings.Hooks.AfterTool))
+	// AfterTool has 5 matchers: * (all tools) + 4 file-edit tools
+	if len(settings.Hooks.AfterTool) != 5 {
+		t.Errorf("AfterTool hooks = %d, want 5 (* + 4 file-edit tools)", len(settings.Hooks.AfterTool))
 	}
 	if len(settings.Hooks.BeforeModel) != 1 {
 		t.Errorf("BeforeModel hooks = %d, want 1", len(settings.Hooks.BeforeModel))
@@ -81,6 +83,10 @@ func TestInstallHooks_FreshInstall(t *testing.T) {
 	verifyHookCommand(t, settings.Hooks.BeforeToolSelection, "", "entire hooks gemini before-tool-selection")
 	verifyHookCommand(t, settings.Hooks.BeforeTool, "*", "entire hooks gemini before-tool")
 	verifyHookCommand(t, settings.Hooks.AfterTool, "*", "entire hooks gemini after-tool")
+	verifyHookCommand(t, settings.Hooks.AfterTool, "write_file", "entire hooks gemini post-file-edit")
+	verifyHookCommand(t, settings.Hooks.AfterTool, "edit_file", "entire hooks gemini post-file-edit")
+	verifyHookCommand(t, settings.Hooks.AfterTool, "save_file", "entire hooks gemini post-file-edit")
+	verifyHookCommand(t, settings.Hooks.AfterTool, "replace", "entire hooks gemini post-file-edit")
 	verifyHookCommand(t, settings.Hooks.PreCompress, "", "entire hooks gemini pre-compress")
 	verifyHookCommand(t, settings.Hooks.Notification, "", "entire hooks gemini notification")
 }
@@ -121,8 +127,8 @@ func TestInstallHooks_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first InstallHooks() error = %v", err)
 	}
-	if count1 != 12 {
-		t.Errorf("first InstallHooks() count = %d, want 12", count1)
+	if count1 != 16 {
+		t.Errorf("first InstallHooks() count = %d, want 16", count1)
 	}
 
 	// Second install should add 0 hooks
@@ -161,8 +167,8 @@ func TestInstallHooks_Force(t *testing.T) {
 	if err != nil {
 		t.Fatalf("force InstallHooks() error = %v", err)
 	}
-	if count != 12 {
-		t.Errorf("force InstallHooks() count = %d, want 12", count)
+	if count != 16 {
+		t.Errorf("force InstallHooks() count = %d, want 16", count)
 	}
 }
 
@@ -483,6 +489,7 @@ func TestHookNames(t *testing.T) {
 		HookNameAfterTool,
 		HookNamePreCompress,
 		HookNameNotification,
+		HookNamePostFileEdit,
 	}
 
 	if len(names) != len(expected) {

--- a/cmd/entire/cli/agent/geminicli/lifecycle.go
+++ b/cmd/entire/cli/agent/geminicli/lifecycle.go
@@ -32,6 +32,7 @@ func (g *GeminiCLIAgent) HookNames() []string {
 		HookNameAfterTool,
 		HookNamePreCompress,
 		HookNameNotification,
+		HookNamePostFileEdit,
 	}
 }
 
@@ -51,6 +52,8 @@ func (g *GeminiCLIAgent) ParseHookEvent(_ context.Context, hookName string, stdi
 		return g.parseCompaction(stdin)
 	case HookNameBeforeModel:
 		return g.parseBeforeModel(stdin)
+	case HookNamePostFileEdit:
+		return g.parseFileEdit(stdin)
 	case HookNameBeforeTool, HookNameAfterTool,
 		HookNameAfterModel, HookNameBeforeToolSelection, HookNameNotification:
 		// Acknowledged hooks with no lifecycle action
@@ -174,6 +177,49 @@ func (g *GeminiCLIAgent) parseBeforeModel(stdin io.Reader) (*agent.Event, error)
 		SessionID: raw.SessionID,
 		Model:     model,
 		Timestamp: time.Now(),
+	}, nil
+}
+
+// fileEditToolInput extracts file_path from Gemini CLI tool input.
+// Gemini tools use file_path, path, or filename depending on the tool.
+type fileEditToolInput struct {
+	FilePath string `json:"file_path"`
+	Path     string `json:"path"`
+	Filename string `json:"filename"`
+}
+
+// filePath returns the first non-empty path field.
+func (f fileEditToolInput) filePath() string {
+	if f.FilePath != "" {
+		return f.FilePath
+	}
+	if f.Path != "" {
+		return f.Path
+	}
+	return f.Filename
+}
+
+func (g *GeminiCLIAgent) parseFileEdit(stdin io.Reader) (*agent.Event, error) {
+	raw, err := agent.ReadAndParseHookInput[afterToolHookInputRaw](stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	var toolInput fileEditToolInput
+	if err := json.Unmarshal(raw.ToolInput, &toolInput); err != nil {
+		return nil, nil //nolint:nilnil,nilerr // tool_input doesn't match expected schema
+	}
+	path := toolInput.filePath()
+	if path == "" {
+		return nil, nil //nolint:nilnil // no file path = skip
+	}
+
+	return &agent.Event{
+		Type:       agent.FileEdit,
+		SessionID:  raw.SessionID,
+		SessionRef: raw.TranscriptPath,
+		FilePath:   path,
+		Timestamp:  time.Now(),
 	}, nil
 }
 

--- a/cmd/entire/cli/agent/geminicli/lifecycle.go
+++ b/cmd/entire/cli/agent/geminicli/lifecycle.go
@@ -211,6 +211,7 @@ func (g *GeminiCLIAgent) parseFileEdit(ctx context.Context, stdin io.Reader) (*a
 	if err := json.Unmarshal(raw.ToolInput, &toolInput); err != nil {
 		logCtx := logging.WithComponent(ctx, "agent.geminicli")
 		logging.Debug(logCtx, "parseFileEdit: unexpected tool_input format",
+			slog.String("tool_name", raw.ToolName),
 			slog.String("error", err.Error()),
 		)
 		return nil, nil //nolint:nilnil // skip event but don't block agent

--- a/cmd/entire/cli/agent/geminicli/lifecycle.go
+++ b/cmd/entire/cli/agent/geminicli/lifecycle.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
 
 // Compile-time interface assertions for new interfaces.
@@ -38,7 +40,7 @@ func (g *GeminiCLIAgent) HookNames() []string {
 
 // ParseHookEvent translates a Gemini CLI hook into a normalized lifecycle Event.
 // Returns nil if the hook has no lifecycle significance (e.g., pass-through hooks).
-func (g *GeminiCLIAgent) ParseHookEvent(_ context.Context, hookName string, stdin io.Reader) (*agent.Event, error) {
+func (g *GeminiCLIAgent) ParseHookEvent(ctx context.Context, hookName string, stdin io.Reader) (*agent.Event, error) {
 	switch hookName {
 	case HookNameSessionStart:
 		return g.parseSessionStart(stdin)
@@ -53,7 +55,7 @@ func (g *GeminiCLIAgent) ParseHookEvent(_ context.Context, hookName string, stdi
 	case HookNameBeforeModel:
 		return g.parseBeforeModel(stdin)
 	case HookNamePostFileEdit:
-		return g.parseFileEdit(stdin)
+		return g.parseFileEdit(ctx, stdin)
 	case HookNameBeforeTool, HookNameAfterTool,
 		HookNameAfterModel, HookNameBeforeToolSelection, HookNameNotification:
 		// Acknowledged hooks with no lifecycle action
@@ -180,8 +182,8 @@ func (g *GeminiCLIAgent) parseBeforeModel(stdin io.Reader) (*agent.Event, error)
 	}, nil
 }
 
-// fileEditToolInput extracts file_path from Gemini CLI tool input.
-// Gemini tools use file_path, path, or filename depending on the tool.
+// fileEditToolInput extracts the edited file's path from Gemini CLI tool input.
+// Different tools use different field names: file_path, path, or filename.
 type fileEditToolInput struct {
 	FilePath string `json:"file_path"`
 	Path     string `json:"path"`
@@ -199,7 +201,7 @@ func (f fileEditToolInput) filePath() string {
 	return f.Filename
 }
 
-func (g *GeminiCLIAgent) parseFileEdit(stdin io.Reader) (*agent.Event, error) {
+func (g *GeminiCLIAgent) parseFileEdit(ctx context.Context, stdin io.Reader) (*agent.Event, error) {
 	raw, err := agent.ReadAndParseHookInput[afterToolHookInputRaw](stdin)
 	if err != nil {
 		return nil, err
@@ -207,7 +209,11 @@ func (g *GeminiCLIAgent) parseFileEdit(stdin io.Reader) (*agent.Event, error) {
 
 	var toolInput fileEditToolInput
 	if err := json.Unmarshal(raw.ToolInput, &toolInput); err != nil {
-		return nil, nil //nolint:nilnil,nilerr // tool_input doesn't match expected schema
+		logCtx := logging.WithComponent(ctx, "agent.geminicli")
+		logging.Debug(logCtx, "parseFileEdit: unexpected tool_input format",
+			slog.String("error", err.Error()),
+		)
+		return nil, nil //nolint:nilnil // skip event but don't block agent
 	}
 	path := toolInput.filePath()
 	if path == "" {

--- a/cmd/entire/cli/agent/geminicli/lifecycle_test.go
+++ b/cmd/entire/cli/agent/geminicli/lifecycle_test.go
@@ -252,6 +252,31 @@ func TestParseHookEvent_FileEdit_FallbackPath(t *testing.T) {
 	}
 }
 
+func TestParseHookEvent_FileEdit_FallbackFilename(t *testing.T) {
+	t.Parallel()
+
+	ag := &GeminiCLIAgent{}
+	// Some Gemini tools use "filename" instead of "file_path" or "path"
+	input := `{
+		"session_id": "gem-sess-4",
+		"transcript_path": "/tmp/gem.json",
+		"tool_name": "save_file",
+		"tool_input": {"filename": "config.yaml", "content": "key: value"}
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostFileEdit, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if event.FilePath != "config.yaml" {
+		t.Errorf("expected file_path 'config.yaml', got %q", event.FilePath)
+	}
+}
+
 func TestParseHookEvent_FileEdit_NoFilePath(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/geminicli/lifecycle_test.go
+++ b/cmd/entire/cli/agent/geminicli/lifecycle_test.go
@@ -197,6 +197,82 @@ func TestParseHookEvent_BeforeModel_EmptyModel_ReturnsNil(t *testing.T) {
 	}
 }
 
+func TestParseHookEvent_FileEdit(t *testing.T) {
+	t.Parallel()
+
+	ag := &GeminiCLIAgent{}
+	input := `{
+		"session_id": "gem-sess-1",
+		"transcript_path": "/tmp/gem.json",
+		"tool_name": "write_file",
+		"tool_input": {"file_path": "docs/hello.md", "content": "hello"}
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostFileEdit, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if event.Type != agent.FileEdit {
+		t.Errorf("expected event type %v, got %v", agent.FileEdit, event.Type)
+	}
+	if event.SessionID != "gem-sess-1" {
+		t.Errorf("expected session_id 'gem-sess-1', got %q", event.SessionID)
+	}
+	if event.FilePath != "docs/hello.md" {
+		t.Errorf("expected file_path 'docs/hello.md', got %q", event.FilePath)
+	}
+}
+
+func TestParseHookEvent_FileEdit_FallbackPath(t *testing.T) {
+	t.Parallel()
+
+	ag := &GeminiCLIAgent{}
+	// Some Gemini tools use "path" instead of "file_path"
+	input := `{
+		"session_id": "gem-sess-2",
+		"transcript_path": "/tmp/gem.json",
+		"tool_name": "replace",
+		"tool_input": {"path": "src/main.go", "old_string": "a", "new_string": "b"}
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostFileEdit, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if event.FilePath != "src/main.go" {
+		t.Errorf("expected file_path 'src/main.go', got %q", event.FilePath)
+	}
+}
+
+func TestParseHookEvent_FileEdit_NoFilePath(t *testing.T) {
+	t.Parallel()
+
+	ag := &GeminiCLIAgent{}
+	input := `{
+		"session_id": "gem-sess-3",
+		"transcript_path": "/tmp/gem.json",
+		"tool_name": "write_file",
+		"tool_input": {"content": "no path here"}
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostFileEdit, strings.NewReader(input))
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event != nil {
+		t.Errorf("expected nil event for missing file_path, got %+v", event)
+	}
+}
+
 func TestParseHookEvent_PassThroughHooks_ReturnNil(t *testing.T) {
 	t.Parallel()
 
@@ -317,6 +393,11 @@ func TestParseHookEvent_AllLifecycleHooks(t *testing.T) {
 			hookName:      HookNameAfterTool,
 			expectNil:     true,
 			inputTemplate: `{"session_id": "s7", "transcript_path": "/t"}`,
+		},
+		{
+			hookName:      HookNamePostFileEdit,
+			expectedType:  agent.FileEdit,
+			inputTemplate: `{"session_id": "s7b", "transcript_path": "/t", "tool_name": "write_file", "tool_input": {"file_path": "f.txt"}}`,
 		},
 		{
 			hookName:      HookNameBeforeModel,

--- a/cmd/entire/cli/agent/geminicli/types.go
+++ b/cmd/entire/cli/agent/geminicli/types.go
@@ -1,5 +1,7 @@
 package geminicli
 
+import "encoding/json"
+
 // GeminiSettings represents the .gemini/settings.json structure
 type GeminiSettings struct {
 	HooksConfig GeminiHooksConfig `json:"hooksConfig,omitempty"`
@@ -71,6 +73,15 @@ type beforeModelRaw struct {
 	LLMRequest     struct {
 		Model string `json:"model"`
 	} `json:"llm_request"`
+}
+
+// afterToolHookInputRaw is the JSON structure from AfterTool hooks.
+// Gemini CLI sends tool_name and tool_input for the tool that just executed.
+type afterToolHookInputRaw struct {
+	SessionID      string          `json:"session_id"`
+	TranscriptPath string          `json:"transcript_path"`
+	ToolName       string          `json:"tool_name"`
+	ToolInput      json.RawMessage `json:"tool_input"`
 }
 
 // Tool names used in Gemini CLI that modify files

--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -80,7 +80,7 @@ func getHookType(hookName string) string {
 	case claudecode.HookNamePreTask, claudecode.HookNamePostTask, claudecode.HookNamePostTodo:
 		return "subagent"
 	case geminicli.HookNameBeforeTool, geminicli.HookNameAfterTool,
-		claudecode.HookNamePostFileEdit: // same value for all agents: "post-file-edit"
+		claudecode.HookNamePostFileEdit: // all agents use "post-file-edit"; only one constant needed (Go disallows duplicate case values)
 		return "tool"
 	default:
 		return "agent"

--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -80,7 +80,7 @@ func getHookType(hookName string) string {
 	case claudecode.HookNamePreTask, claudecode.HookNamePostTask, claudecode.HookNamePostTodo:
 		return "subagent"
 	case geminicli.HookNameBeforeTool, geminicli.HookNameAfterTool,
-		claudecode.HookNamePostFileEdit:
+		claudecode.HookNamePostFileEdit: // same value for all agents: "post-file-edit"
 		return "tool"
 	default:
 		return "agent"

--- a/cmd/entire/cli/integration_test/agent_test.go
+++ b/cmd/entire/cli/integration_test/agent_test.go
@@ -478,10 +478,11 @@ func TestGeminiCLIHookInstallation(t *testing.T) {
 			t.Fatalf("InstallHooks() error = %v", err)
 		}
 
-		// Should install 12 hooks: SessionStart, SessionEnd (exit+logout), BeforeAgent, AfterAgent,
-		// BeforeModel, AfterModel, BeforeToolSelection, BeforeTool, AfterTool, PreCompress, Notification
-		if count != 12 {
-			t.Errorf("InstallHooks() count = %d, want 12", count)
+		// Should install 16 hooks: SessionStart, SessionEnd (exit+logout), BeforeAgent, AfterAgent,
+		// BeforeModel, AfterModel, BeforeToolSelection, BeforeTool, AfterTool,
+		// PostFileEdit (write_file, edit_file, save_file, replace), PreCompress, Notification
+		if count != 16 {
+			t.Errorf("InstallHooks() count = %d, want 16", count)
 		}
 
 		// Verify hooks are installed
@@ -665,8 +666,8 @@ func TestGeminiCLIHookInstallation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("force InstallHooks() error = %v", err)
 		}
-		if count != 12 {
-			t.Errorf("force InstallHooks() count = %d, want 12", count)
+		if count != 16 {
+			t.Errorf("force InstallHooks() count = %d, want 16", count)
 		}
 	})
 }

--- a/cmd/entire/cli/integration_test/file_tracking_test.go
+++ b/cmd/entire/cli/integration_test/file_tracking_test.go
@@ -62,3 +62,55 @@ func TestPostFileEdit_TracksEditedFiles(t *testing.T) {
 		}
 	}
 }
+
+// TestGeminiPostFileEdit_TracksEditedFiles tests the end-to-end flow of file
+// tracking via the Gemini CLI post-file-edit hook. Gemini hooks use the AfterTool
+// schema (tool_name + tool_input) rather than Claude Code's PostToolUse schema.
+func TestGeminiPostFileEdit_TracksEditedFiles(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	sess := env.NewSession()
+
+	// Start session via Gemini's BeforeAgent hook (equivalent to user-prompt-submit)
+	if err := env.SimulateGeminiBeforeAgent(sess.ID); err != nil {
+		t.Fatalf("SimulateGeminiBeforeAgent failed: %v", err)
+	}
+
+	// Simulate file edits via Gemini's post-file-edit hook (AfterTool schema)
+	if err := env.SimulateGeminiPostFileEdit(GeminiPostFileEditInput{
+		SessionID:      sess.ID,
+		TranscriptPath: sess.TranscriptPath,
+		ToolName:       "write_file",
+		FilePath:       filepath.Join(env.RepoDir, "src", "app.go"),
+	}); err != nil {
+		t.Fatalf("SimulateGeminiPostFileEdit (src/app.go) failed: %v", err)
+	}
+
+	if err := env.SimulateGeminiPostFileEdit(GeminiPostFileEditInput{
+		SessionID:      sess.ID,
+		TranscriptPath: sess.TranscriptPath,
+		ToolName:       "replace",
+		FilePath:       filepath.Join(env.RepoDir, "docs", "guide.md"),
+	}); err != nil {
+		t.Fatalf("SimulateGeminiPostFileEdit (docs/guide.md) failed: %v", err)
+	}
+
+	// Verify via ReadFilesTouched (deduplicates and sorts)
+	stateDir := filepath.Join(env.RepoDir, ".git", "entire-sessions")
+	store := session.NewStateStoreWithDir(stateDir)
+	files, err := store.ReadFilesTouched(context.Background(), sess.ID)
+	if err != nil {
+		t.Fatalf("ReadFilesTouched failed: %v", err)
+	}
+
+	expected := []string{"docs/guide.md", "src/app.go"}
+	if len(files) != len(expected) {
+		t.Fatalf("Expected %d tracked files, got %d: %v", len(expected), len(files), files)
+	}
+	for i, want := range expected {
+		if files[i] != want {
+			t.Errorf("Tracked file [%d]: want %q, got %q", i, want, files[i])
+		}
+	}
+}

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -408,7 +408,7 @@ func (env *TestEnv) SimulatePostTodo(input PostTodoInput) error {
 	return runner.SimulatePostTodo(input)
 }
 
-// PostFileEditInput contains the input for PostToolUse[Write/Edit] hook.
+// PostFileEditInput contains the input for the post-file-edit hook.
 type PostFileEditInput struct {
 	SessionID      string
 	TranscriptPath string
@@ -416,7 +416,7 @@ type PostFileEditInput struct {
 	FilePath       string
 }
 
-// SimulatePostFileEdit simulates the PostToolUse[Write/Edit] hook.
+// SimulatePostFileEdit simulates the post-file-edit hook (file-modifying tool completion).
 func (r *HookRunner) SimulatePostFileEdit(input PostFileEditInput) error {
 	r.T.Helper()
 
@@ -820,6 +820,37 @@ func (env *TestEnv) SimulateGeminiAfterAgent(sessionID, transcriptPath string) e
 	env.T.Helper()
 	runner := NewGeminiHookRunner(env.RepoDir, env.GeminiProjectDir, env.T)
 	return runner.SimulateGeminiAfterAgent(sessionID, transcriptPath)
+}
+
+// GeminiPostFileEditInput contains the input for the Gemini post-file-edit hook.
+type GeminiPostFileEditInput struct {
+	SessionID      string
+	TranscriptPath string
+	ToolName       string
+	FilePath       string
+}
+
+// SimulateGeminiPostFileEdit simulates the post-file-edit hook for Gemini CLI.
+func (r *GeminiHookRunner) SimulateGeminiPostFileEdit(input GeminiPostFileEditInput) error {
+	r.T.Helper()
+
+	hookInput := map[string]interface{}{
+		"session_id":      input.SessionID,
+		"transcript_path": input.TranscriptPath,
+		"tool_name":       input.ToolName,
+		"tool_input": map[string]string{
+			"file_path": input.FilePath,
+		},
+	}
+
+	return r.runGeminiHookWithInput("post-file-edit", hookInput)
+}
+
+// SimulateGeminiPostFileEdit is a convenience method on TestEnv.
+func (env *TestEnv) SimulateGeminiPostFileEdit(input GeminiPostFileEditInput) error {
+	env.T.Helper()
+	runner := NewGeminiHookRunner(env.RepoDir, env.GeminiProjectDir, env.T)
+	return runner.SimulateGeminiPostFileEdit(input)
 }
 
 // SimulateGeminiSessionEnd is a convenience method on TestEnv.

--- a/cmd/entire/cli/strategy/common_test.go
+++ b/cmd/entire/cli/strategy/common_test.go
@@ -1432,8 +1432,8 @@ func TestReadLatestSessionPromptFromCommittedTree(t *testing.T) {
 		// Session 1 (latest) has no prompt.txt, session 0 does.
 		// This happens when a test session gets condensed alongside a real one.
 		tree := buildCommittedTree(t, map[string]string{
-			"a3/b2c4d5e6f7/0/prompt.txt":      "Real session prompt",
-			"a3/b2c4d5e6f7/1/metadata.json":    `{"session_id":"test"}`,
+			"a3/b2c4d5e6f7/0/prompt.txt":    "Real session prompt",
+			"a3/b2c4d5e6f7/1/metadata.json": `{"session_id":"test"}`,
 		})
 
 		got := ReadLatestSessionPromptFromCommittedTree(tree, cpID, 2)
@@ -1446,9 +1446,9 @@ func TestReadLatestSessionPromptFromCommittedTree(t *testing.T) {
 		t.Parallel()
 		// Sessions 2 and 1 have no prompt, session 0 does.
 		tree := buildCommittedTree(t, map[string]string{
-			"a3/b2c4d5e6f7/0/prompt.txt":      "Original prompt",
-			"a3/b2c4d5e6f7/1/metadata.json":    `{"session_id":"s1"}`,
-			"a3/b2c4d5e6f7/2/metadata.json":    `{"session_id":"s2"}`,
+			"a3/b2c4d5e6f7/0/prompt.txt":    "Original prompt",
+			"a3/b2c4d5e6f7/1/metadata.json": `{"session_id":"s1"}`,
+			"a3/b2c4d5e6f7/2/metadata.json": `{"session_id":"s2"}`,
 		})
 
 		got := ReadLatestSessionPromptFromCommittedTree(tree, cpID, 3)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1490,8 +1490,18 @@ func (s *ManualCommitStrategy) resolveFilesTouched(ctx context.Context, state *S
 			}
 		}
 		sort.Strings(result)
+		logging.Debug(logCtx, "resolveFilesTouched: using hook-tracked files",
+			slog.String("session_id", state.SessionID),
+			slog.Int("from_state", len(state.FilesTouched)),
+			slog.Int("from_tracking_file", len(tracked)),
+			slog.Int("merged", len(result)),
+		)
 		return result
 	}
+
+	logging.Debug(logCtx, "resolveFilesTouched: no hook-tracked files, falling back to transcript extraction",
+		slog.String("session_id", state.SessionID),
+	)
 
 	// Prepare transcript before extraction (e.g., OpenCode `opencode export`).
 	prepareTranscriptForState(ctx, state)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1458,7 +1458,8 @@ func (s *ManualCommitStrategy) sessionHasNewContentFromLiveTranscript(ctx contex
 }
 
 // resolveFilesTouched returns the file list for a session.
-// Prefers hook-populated state.FilesTouched, falls back to transcript extraction.
+// Merges hook-populated state.FilesTouched with the session's .files tracking file,
+// falling back to transcript extraction when neither has data.
 // All call sites that need "what files did the agent touch?" should use this.
 //
 // Handles PrepareTranscript internally before falling back to extraction,
@@ -1514,6 +1515,11 @@ func (s *ManualCommitStrategy) resolveFilesTouched(ctx context.Context, state *S
 func (s *ManualCommitStrategy) clearFilesTracking(ctx context.Context, sessionID string) {
 	store, storeErr := s.getStateStore(ctx)
 	if storeErr != nil {
+		logCtx := logging.WithComponent(ctx, "checkpoint")
+		logging.Debug(logCtx, "clearFilesTracking: could not get state store (non-critical)",
+			slog.String("session_id", sessionID),
+			slog.String("error", storeErr.Error()),
+		)
 		return
 	}
 	if clearErr := store.ClearFilesTouched(ctx, sessionID); clearErr != nil {


### PR DESCRIPTION
## Summary
- Wire `post-file-edit` hook for Gemini CLI agent's file-modifying tools (write_file, edit_file, save_file, replace)
- Parse AfterTool hook input with fallback path resolution (`file_path` → `path` → `filename`)
- Add observability logging to `resolveFilesTouched` to distinguish hook-tracked files from transcript fallback
- Update hook counts in integration tests (12 → 16 with 4 new AfterTool matchers)

## Details
Part of the post-file-edit hook rollout (one PR per agent). Framework + Claude Code wiring in #637.

Gemini CLI's AfterTool hooks use matcher-based config in `.gemini/settings.json`. Each file-modifying tool gets its own matcher entry that routes to `entire hooks gemini-cli post-file-edit`. The hook parses the tool input JSON to extract the file path, handling different field names across tools.

## Test plan
- [x] Unit tests: `parseFileEdit` with valid input, fallback path fields, and missing path
- [x] Hook installation tests: verify 4 new AfterTool matchers + idempotency
- [x] Integration tests: updated hook count expectations
- [x] E2E: `TestSingleSessionManualCommit --agent gemini-cli` — confirmed hook fires and file tracked
- [x] CI: `mise run fmt && mise run lint && mise run test:ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)