### PR TITLE
fix(agent): scan full transcript for spawned agent IDs

### DIFF
--- a/cmd/entire/cli/agent/claudecode/transcript.go
+++ b/cmd/entire/cli/agent/claudecode/transcript.go
@@ -264,6 +264,17 @@ func ExtractSpawnedAgentIDs(transcript []TranscriptLine) map[string]string {
 	return agentIDs
 }
 
+// extractAllSpawnedAgentIDs parses the full transcript from the beginning to find
+// all spawned agent IDs, regardless of startLine offset. This ensures subagents
+// spawned before a checkpoint boundary are still discovered.
+func extractAllSpawnedAgentIDs(transcriptData []byte) map[string]string {
+	fullParsed, err := transcript.ParseFromBytes(transcriptData)
+	if err != nil {
+		return nil
+	}
+	return ExtractSpawnedAgentIDs(fullParsed)
+}
+
 // extractAgentIDFromText extracts an agent ID from text containing "agentId: <id>".
 func extractAgentIDFromText(text string) string {
 	const prefix = "agentId: "
@@ -305,8 +316,10 @@ func (c *ClaudeCodeAgent) CalculateTotalTokenUsage(transcriptData []byte, startL
 	// Calculate token usage from parsed transcript
 	mainUsage := CalculateTokenUsage(parsed)
 
-	// Extract spawned agent IDs from the same parsed transcript
-	agentIDs := ExtractSpawnedAgentIDs(parsed)
+	// Extract spawned agent IDs from the FULL transcript (not just startLine).
+	// Subagents spawned before startLine may still be active and writing to their
+	// transcript files, so we need to discover them from the beginning.
+	agentIDs := extractAllSpawnedAgentIDs(transcriptData)
 
 	// Calculate subagent token usage (skip when subagentsDir is empty to avoid reading from cwd)
 	if len(agentIDs) > 0 && subagentsDir != "" {
@@ -359,8 +372,10 @@ func (c *ClaudeCodeAgent) ExtractAllModifiedFiles(transcriptData []byte, startLi
 		}
 	}
 
-	// Find spawned subagents and collect their modified files (skip when subagentsDir is empty to avoid reading from cwd)
-	agentIDs := ExtractSpawnedAgentIDs(parsed)
+	// Find spawned subagents from the FULL transcript (not just startLine).
+	// Subagents spawned before startLine may still be active and writing files,
+	// so we need to discover them from the beginning.
+	agentIDs := extractAllSpawnedAgentIDs(transcriptData)
 	if subagentsDir == "" {
 		return files, nil
 	}

--- a/cmd/entire/cli/agent/factoryaidroid/transcript.go
+++ b/cmd/entire/cli/agent/factoryaidroid/transcript.go
@@ -347,6 +347,16 @@ func extractAgentIDFromText(text string) string {
 	return ""
 }
 
+// extractAllSpawnedAgentIDsFromBytes parses the full transcript from the beginning to find
+// all spawned agent IDs, regardless of startLine offset.
+func extractAllSpawnedAgentIDsFromBytes(data []byte) map[string]string {
+	fullParsed, _, err := ParseDroidTranscriptFromBytes(data, 0)
+	if err != nil {
+		return nil
+	}
+	return ExtractSpawnedAgentIDs(fullParsed)
+}
+
 // CalculateTotalTokenUsageFromBytes calculates token usage from pre-loaded transcript bytes,
 // including subagents. It parses the main transcript bytes from startLine, extracts spawned
 // agent IDs, and calculates their token usage from transcript files in subagentsDir.
@@ -362,7 +372,10 @@ func CalculateTotalTokenUsageFromBytes(data []byte, startLine int, subagentsDir 
 
 	mainUsage := CalculateTokenUsage(parsed)
 
-	agentIDs := ExtractSpawnedAgentIDs(parsed)
+	// Extract spawned agent IDs from the FULL transcript (not just startLine).
+	// Subagents spawned before startLine may still be active and writing to their
+	// transcript files, so we need to discover them from the beginning.
+	agentIDs := extractAllSpawnedAgentIDsFromBytes(data)
 	if len(agentIDs) > 0 && subagentsDir != "" {
 		subagentUsage := &agent.TokenUsage{}
 		for agentID := range agentIDs {
@@ -405,7 +418,8 @@ func ExtractAllModifiedFilesFromBytes(data []byte, startLine int, subagentsDir s
 		fileSet[f] = true
 	}
 
-	agentIDs := ExtractSpawnedAgentIDs(parsed)
+	// Extract spawned agent IDs from the FULL transcript (not just startLine).
+	agentIDs := extractAllSpawnedAgentIDsFromBytes(data)
 	if subagentsDir == "" {
 		return files, nil
 	}
@@ -443,8 +457,13 @@ func CalculateTotalTokenUsageFromTranscript(transcriptPath string, startLine int
 	// Calculate token usage from parsed transcript
 	mainUsage := CalculateTokenUsage(parsed)
 
-	// Extract spawned agent IDs from the same parsed transcript
-	agentIDs := ExtractSpawnedAgentIDs(parsed)
+	// Extract spawned agent IDs from the FULL transcript (not just startLine).
+	// Subagents spawned before startLine may still be active.
+	allParsed, _, parseAllErr := ParseDroidTranscript(transcriptPath, 0)
+	var agentIDs map[string]string
+	if parseAllErr == nil {
+		agentIDs = ExtractSpawnedAgentIDs(allParsed)
+	}
 
 	// Calculate subagent token usage
 	if len(agentIDs) > 0 {
@@ -493,8 +512,13 @@ func ExtractAllModifiedFilesFromTranscript(transcriptPath string, startLine int,
 		fileSet[f] = true
 	}
 
-	// Find spawned subagents and collect their modified files
-	agentIDs := ExtractSpawnedAgentIDs(parsed)
+	// Find spawned subagents from the FULL transcript (not just startLine).
+	// Subagents spawned before startLine may still be active and writing files.
+	allParsed, _, parseAllErr := ParseDroidTranscript(transcriptPath, 0)
+	var agentIDs map[string]string
+	if parseAllErr == nil {
+		agentIDs = ExtractSpawnedAgentIDs(allParsed)
+	}
 	for agentID := range agentIDs {
 		agentPath := filepath.Join(subagentsDir, fmt.Sprintf("agent-%s.jsonl", agentID))
 		agentLines, _, agentErr := ParseDroidTranscript(agentPath, 0)


### PR DESCRIPTION
## Summary

Closes #329

Fixes a bug where subagent token usage and modified files were undercounted when a checkpoint boundary (`startLine`) was set.

### The Problem

`CalculateTotalTokenUsage` and `ExtractAllModifiedFiles` both:
1. Slice the transcript from `startLine` to get the current turn's data
2. Extract spawned agent IDs from that sliced data
3. Read subagent transcript files and sum their usage/files

The issue: subagents spawned **before** `startLine` (in a previous turn) may still be actively writing to their transcript files during the current turn. By only scanning from `startLine`, those agent IDs were never discovered, so their token usage and file modifications were silently dropped.

### The Fix

Agent ID extraction now scans the **full transcript** from the beginning (line 0), while file/token extraction still respects the `startLine` boundary. This ensures all subagents are discovered regardless of when they were spawned.

Added `extractAllSpawnedAgentIDs()` helper that parses the full transcript bytes independently of the startLine-sliced data.

## Changes

**Claude Code agent (`claudecode/transcript.go`):**
- `CalculateTotalTokenUsage` - Uses `extractAllSpawnedAgentIDs(transcriptData)` instead of `ExtractSpawnedAgentIDs(parsed)` 
- `ExtractAllModifiedFiles` - Same fix
- Added `extractAllSpawnedAgentIDs()` helper

**Factory AI Droid agent (`factoryaidroid/transcript.go`):**
- `CalculateTotalTokenUsageFromBytes` / `ExtractAllModifiedFilesFromBytes` - Added `extractAllSpawnedAgentIDsFromBytes()` helper with same full-scan approach
- `CalculateTotalTokenUsageFromTranscript` / `ExtractAllModifiedFilesFromTranscript` - Re-parses full transcript file at line 0 for agent ID discovery

## Testing

- All existing transcript tests continue to pass
- The fix is conservative - it only broadens agent ID discovery, not file/token extraction boundaries

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>