### PR TITLE
figure out remote branch properly with v6

### DIFF
--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -136,7 +136,8 @@ func fetchAndMergeSessionsCommon(ctx context.Context, remote, branchName string)
 	defer cancel()
 
 	// Use git CLI for fetch (go-git's fetch can be tricky with auth)
-	fetchCmd := exec.CommandContext(ctx, "git", "fetch", remote, branchName)
+	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branchName, remote, branchName)
+	fetchCmd := exec.CommandContext(ctx, "git", "fetch", remote, refSpec)
 	fetchCmd.Stdin = nil
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)


### PR DESCRIPTION
Turns out the old code worked with v5 but was not really correct `FETCH_HEAD` is not a direct ref, this should make it work with go-git v6 again