### PR TITLE
fix: resolve repo root for initialization when started from subdirectory

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -388,15 +388,11 @@ If Entire is already configured but disabled, this re-enables it.`,
 				return NewSilentError(errors.New("not a git repository"))
 			}
 
-			// Change to repo root so all paths resolve correctly.
-			// This ensures agent hooks (e.g., .gemini/settings.json, .claude/settings.json)
-			// are created at the repo root even when running from a subdirectory.
+			// Notify the user when running from a subdirectory.
+			// All path resolution uses paths.WorktreeRoot(ctx) which returns the
+			// correct repo root regardless of CWD, so no directory change is needed.
 			cwd, err := os.Getwd() //nolint:forbidigo // Need CWD to detect subdirectory
 			if err == nil && cwd != repoRoot {
-				if err := os.Chdir(repoRoot); err != nil {
-					return fmt.Errorf("failed to change to repository root %s: %w", repoRoot, err)
-				}
-				paths.ClearWorktreeRootCache()
 				fmt.Fprintf(cmd.ErrOrStderr(), "Note: Running from repository root (%s)\n\n", repoRoot)
 			}
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -391,9 +391,9 @@ If Entire is already configured but disabled, this re-enables it.`,
 			// Change to repo root so all paths resolve correctly.
 			// This ensures agent hooks (e.g., .gemini/settings.json, .claude/settings.json)
 			// are created at the repo root even when running from a subdirectory.
-			cwd, _ := os.Getwd() //nolint:forbidigo // Need CWD to detect subdirectory
-			if cwd != repoRoot {
-				if err := os.Chdir(repoRoot); err != nil { //nolint:forbidigo // Intentional chdir to repo root for correct path resolution
+			cwd, err := os.Getwd() //nolint:forbidigo // Need CWD to detect subdirectory
+			if err == nil && cwd != repoRoot {
+				if err := os.Chdir(repoRoot); err != nil {
 					return fmt.Errorf("failed to change to repository root %s: %w", repoRoot, err)
 				}
 				paths.ClearWorktreeRootCache()

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -382,9 +382,22 @@ If Entire is already configured but disabled, this re-enables it.`,
 			// Check if we're in a git repository first - this is a prerequisite error,
 			// not a usage error, so we silence Cobra's output and use SilentError
 			// to prevent duplicate error output in main.go
-			if _, err := paths.WorktreeRoot(ctx); err != nil {
+			repoRoot, err := paths.WorktreeRoot(ctx)
+			if err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Please run 'entire enable' from within a git repository.")
 				return NewSilentError(errors.New("not a git repository"))
+			}
+
+			// Change to repo root so all paths resolve correctly.
+			// This ensures agent hooks (e.g., .gemini/settings.json, .claude/settings.json)
+			// are created at the repo root even when running from a subdirectory.
+			cwd, _ := os.Getwd() //nolint:forbidigo // Need CWD to detect subdirectory
+			if cwd != repoRoot {
+				if err := os.Chdir(repoRoot); err != nil { //nolint:forbidigo // Intentional chdir to repo root for correct path resolution
+					return fmt.Errorf("failed to change to repository root %s: %w", repoRoot, err)
+				}
+				paths.ClearWorktreeRootCache()
+				fmt.Fprintf(cmd.ErrOrStderr(), "Note: Running from repository root (%s)\n\n", repoRoot)
 			}
 
 			if err := validateSetupFlags(opts.UseLocalSettings, opts.UseProjectSettings); err != nil {


### PR DESCRIPTION
## Summary
Fixes #559

When `entire enable` is run from a subdirectory (e.g., `cd repo/frontend && entire enable`), the agent hook config files (`.gemini/settings.json`, `.claude/settings.json`) must be created at the repo root for agents to find them. While internal path resolution via `paths.AbsPath()` already uses `git rev-parse --show-toplevel`, some agent config lookups are CWD-relative. This fix explicitly changes to the repo root before the enable flow begins.

## Changes
- Detect when `entire enable` is run from a subdirectory (CWD != repo root)
- Change to the repo root before proceeding with setup
- Clear the worktree root cache after changing directory
- Print a note so the user knows the repo root is being used

## Testing
- Run `entire enable` from a subdirectory within a git repo and verify it succeeds
- Verify `.entire/settings.json` and agent config files are created at the repo root, not the subdirectory
- Run `entire enable` from the repo root and verify no extra note is printed

This contribution was developed with AI assistance (Claude Code).