### PR TITLE
fix: handle .bare/worktrees/ layout in GetWorktreeID

### DIFF
--- a/cmd/entire/cli/paths/worktree.go
+++ b/cmd/entire/cli/paths/worktree.go
@@ -38,9 +38,16 @@ func GetWorktreeID(worktreePath string) (string, error) {
 	gitdir := strings.TrimPrefix(line, "gitdir: ")
 
 	// Extract worktree name from path like /repo/.git/worktrees/<name>
-	// The path after ".git/worktrees/" is the worktree identifier
-	const marker = ".git/worktrees/"
-	_, worktreeID, found := strings.Cut(gitdir, marker)
+	// or /repo/.bare/worktrees/<name> (bare repo + worktree layout).
+	// The path after the marker is the worktree identifier.
+	var worktreeID string
+	var found bool
+	for _, marker := range []string{".git/worktrees/", ".bare/worktrees/"} {
+		_, worktreeID, found = strings.Cut(gitdir, marker)
+		if found {
+			break
+		}
+	}
 	if !found {
 		return "", fmt.Errorf("unexpected gitdir format (no worktrees): %s", gitdir)
 	}

--- a/cmd/entire/cli/paths/worktree_test.go
+++ b/cmd/entire/cli/paths/worktree_test.go
@@ -55,6 +55,22 @@ func TestGetWorktreeID(t *testing.T) {
 			errContain: "invalid .git file format",
 		},
 		{
+			name: "bare repo worktree simple name",
+			setupFunc: func(dir string) error {
+				content := "gitdir: /some/repo/.bare/worktrees/main\n"
+				return os.WriteFile(filepath.Join(dir, ".git"), []byte(content), 0o644)
+			},
+			wantID: "main",
+		},
+		{
+			name: "bare repo worktree with subdirectory name",
+			setupFunc: func(dir string) error {
+				content := "gitdir: /repo/.bare/worktrees/feature/login\n"
+				return os.WriteFile(filepath.Join(dir, ".git"), []byte(content), 0o644)
+			},
+			wantID: "feature/login",
+		},
+		{
 			name: "gitdir without worktrees path",
 			setupFunc: func(dir string) error {
 				content := "gitdir: /some/repo/.git\n"


### PR DESCRIPTION
## Summary

Fixes #431

- `GetWorktreeID` now checks both `.git/worktrees/` and `.bare/worktrees/` markers when extracting the worktree ID from a gitdir path
- Supports the widely-used bare repo + worktree layout pattern where repos use `.bare/` instead of `.git/`

## Changes

- `cmd/entire/cli/paths/worktree.go` - Added `.bare/worktrees/` as a fallback marker in `GetWorktreeID`
- `cmd/entire/cli/paths/worktree_test.go` - Added test cases for bare repo worktree layout

## Test plan

- [x] Existing tests pass
- [x] New test cases cover `.bare/worktrees/` paths
- [x] `gofmt` and `go vet` clean

This contribution was developed with AI assistance (Claude Code).