### PR TITLE
fix: filter system-reminder messages in OpenCode transcript parser

### DIFF
--- a/cmd/entire/cli/agent/opencode/transcript.go
+++ b/cmd/entire/cli/agent/opencode/transcript.go
@@ -209,20 +209,22 @@ func ExtractTextFromParts(parts []Part) string {
 	return strings.Join(texts, "\n")
 }
 
-// systemReminderOpen is the opening tag for system-reminder messages injected by
-// oh-my-opencode and similar orchestration tools. These arrive with role "user"
-// but are not actual user prompts.
-const systemReminderOpen = "<system-reminder>"
+// Tags used by oh-my-opencode and similar orchestration tools to inject
+// context into the conversation with role "user" — not actual user prompts.
+const (
+	systemReminderOpen  = "<system-reminder>"
+	systemReminderClose = "</system-reminder>"
+)
 
-// systemReminderClose is the corresponding closing tag.
-const systemReminderClose = "</system-reminder>"
-
-// isSystemReminderOnly reports whether content consists entirely of a
-// <system-reminder>...</system-reminder> block (after trimming whitespace).
+// isSystemReminderOnly reports whether content consists entirely of
+// <system-reminder>...</system-reminder> blocks (after trimming whitespace).
+// Delegates to stripSystemReminders to correctly handle multiple blocks
+// (HasPrefix+HasSuffix would false-positive on "<sr>a</sr>real<sr>b</sr>").
 func isSystemReminderOnly(content string) bool {
-	trimmed := strings.TrimSpace(content)
-	return strings.HasPrefix(trimmed, systemReminderOpen) &&
-		strings.HasSuffix(trimmed, systemReminderClose)
+	if strings.TrimSpace(content) == "" {
+		return false
+	}
+	return stripSystemReminders(content) == ""
 }
 
 // stripSystemReminders removes all <system-reminder>...</system-reminder>

--- a/cmd/entire/cli/agent/opencode/transcript_test.go
+++ b/cmd/entire/cli/agent/opencode/transcript_test.go
@@ -824,6 +824,13 @@ func TestIsSystemReminderOnly(t *testing.T) {
 			content: "",
 			want:    false,
 		},
+		{
+			// Multiple blocks with real content between them — starts with open tag
+			// and ends with close tag, but is NOT system-reminder-only.
+			name:    "real content between multiple blocks",
+			content: "<system-reminder>a</system-reminder>Fix this<system-reminder>b</system-reminder>",
+			want:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes #564

Filters out `<system-reminder>` messages that are injected by tools like oh-my-opencode with `user` role. These messages were incorrectly counted as user prompts in attribution and checkpoint data.

## Changes

- `cmd/entire/cli/agent/opencode/transcript.go` - Added `isSystemReminderOnly()` and `stripSystemReminders()` functions; updated `ExtractAllUserPrompts()` to skip or strip system-reminder content
- `cmd/entire/cli/agent/opencode/transcript_test.go` - Added 6 test functions covering pure system-reminder messages, mixed content, and whitespace handling

## Approach

Content-based heuristic: messages entirely wrapped in `<system-reminder>...</system-reminder>` tags are skipped. Mixed messages have the reminder tags stripped. This is the best approach given that OpenCode doesn't expose `x-initiator` metadata.

## Test plan

- [x] System-reminder-only messages excluded from prompts
- [x] Mixed messages have reminder sections stripped
- [x] Normal user messages unaffected
- [x] `gofmt` and `go vet` clean

This contribution was developed with AI assistance (Claude Code).