### PR TITLE
fix: push trail data to remote after trail update

### DIFF
--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -366,7 +366,7 @@ func newTrailUpdateCmd() *cobra.Command {
 		Use:   "update",
 		Short: "Update trail metadata",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runTrailUpdate(cmd.OutOrStdout(), statusStr, title, body, branch, labelAdd, labelRemove)
+			return runTrailUpdate(cmd.OutOrStdout(), cmd.ErrOrStderr(), statusStr, title, body, branch, labelAdd, labelRemove)
 		},
 	}
 
@@ -380,7 +380,7 @@ func newTrailUpdateCmd() *cobra.Command {
 	return cmd
 }
 
-func runTrailUpdate(w io.Writer, statusStr, title, body, branch string, labelAdd, labelRemove []string) error {
+func runTrailUpdate(w, errW io.Writer, statusStr, title, body, branch string, labelAdd, labelRemove []string) error {
 	repo, err := strategy.OpenRepository(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
@@ -475,6 +475,11 @@ func runTrailUpdate(w io.Writer, statusStr, title, body, branch string, labelAdd
 	}
 
 	fmt.Fprintf(w, "Updated trail for branch %s\n", branch)
+
+	if err := strategy.PushTrailsBranch(context.Background(), "origin"); err != nil {
+		fmt.Fprintf(errW, "Warning: failed to push trail data: %v\n", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- `trail update` was only writing changes locally without pushing the `entire/trails/v1` branch to remote, unlike `trail create` which pushes immediately
- This caused status updates (and other metadata changes) to appear lost when checked from other machines or after `trail list` fetches from remote
- Added `strategy.PushTrailsBranch` call after the local write, matching the existing pattern in `trail create`

## Test plan

- [x] `go build` compiles successfully
- [x] `mise run fmt && mise run lint` passes
- [x] `mise run test` passes
- [ ] Manually verify: `entire trail create`, then `entire trail update --status open`, confirm remote `entire/trails/v1` branch reflects the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)