### PR TITLE
fix: handle submodule gitdir format in GetWorktreeID

### DIFF
--- a/cmd/entire/cli/paths/worktree.go
+++ b/cmd/entire/cli/paths/worktree.go
@@ -11,6 +11,8 @@ import (
 // For the main worktree (where .git is a directory), returns empty string.
 // For linked worktrees (where .git is a file), extracts the name from
 // .git/worktrees/<name>/ path. This name is stable across `git worktree move`.
+// For submodules (where .git is a file pointing to .git/modules/<name>),
+// returns empty string since submodules behave like main worktrees.
 func GetWorktreeID(worktreePath string) (string, error) {
 	gitPath := filepath.Join(worktreePath, ".git")
 
@@ -25,6 +27,7 @@ func GetWorktreeID(worktreePath string) (string, error) {
 	}
 
 	// Linked worktree has .git as a file with content: "gitdir: /path/to/.git/worktrees/<name>"
+	// Submodules also have .git as a file with content: "gitdir: ../.git/modules/<name>"
 	content, err := os.ReadFile(gitPath) //nolint:gosec // gitPath is constructed from worktreePath + ".git"
 	if err != nil {
 		return "", fmt.Errorf("failed to read .git file: %w", err)
@@ -37,15 +40,35 @@ func GetWorktreeID(worktreePath string) (string, error) {
 
 	gitdir := strings.TrimPrefix(line, "gitdir: ")
 
-	// Extract worktree name from path like /repo/.git/worktrees/<name>
-	// The path after ".git/worktrees/" is the worktree identifier
-	const marker = ".git/worktrees/"
-	_, worktreeID, found := strings.Cut(gitdir, marker)
-	if !found {
+	// Submodules point to .git/modules/<name> — treat them like main worktrees
+	// since they have their own independent git state.
+	if isSubmoduleGitdir(gitdir) {
+		return "", nil
+	}
+
+	// Extract worktree name from path ending in /worktrees/<name>.
+	// This handles both standard worktrees (.git/worktrees/<name>) and
+	// worktrees inside submodules (.git/modules/<submod>/worktrees/<name>).
+	const marker = "/worktrees/"
+	idx := strings.LastIndex(gitdir, marker)
+	if idx < 0 {
 		return "", fmt.Errorf("unexpected gitdir format (no worktrees): %s", gitdir)
 	}
+	worktreeID := gitdir[idx+len(marker):]
 	// Remove trailing slashes if any
 	worktreeID = strings.TrimSuffix(worktreeID, "/")
 
 	return worktreeID, nil
+}
+
+// isSubmoduleGitdir checks if a gitdir path points to a submodule's git directory.
+// Submodule gitdir paths contain "/modules/" and do NOT contain "/worktrees/".
+// Examples:
+//   - "../.git/modules/submod" → true
+//   - "/repo/.git/modules/libs/crypto" → true (nested submodule)
+//   - "/repo/.git/worktrees/feature" → false (linked worktree)
+func isSubmoduleGitdir(gitdir string) bool {
+	// Normalize to forward slashes for consistent matching
+	normalized := filepath.ToSlash(gitdir)
+	return strings.Contains(normalized, "/modules/") && !strings.Contains(normalized, "/worktrees/")
 }

--- a/cmd/entire/cli/paths/worktree_test.go
+++ b/cmd/entire/cli/paths/worktree_test.go
@@ -63,6 +63,40 @@ func TestGetWorktreeID(t *testing.T) {
 			wantErr:    true,
 			errContain: "unexpected gitdir format",
 		},
+		{
+			name: "submodule with relative gitdir",
+			setupFunc: func(dir string) error {
+				content := "gitdir: ../.git/modules/mysubmodule\n"
+				return os.WriteFile(filepath.Join(dir, ".git"), []byte(content), 0o644)
+			},
+			wantID: "",
+		},
+		{
+			name: "submodule with absolute gitdir",
+			setupFunc: func(dir string) error {
+				content := "gitdir: /repo/.git/modules/libs/crypto\n"
+				return os.WriteFile(filepath.Join(dir, ".git"), []byte(content), 0o644)
+			},
+			wantID: "",
+		},
+		{
+			name: "nested submodule",
+			setupFunc: func(dir string) error {
+				content := "gitdir: /repo/.git/modules/vendor/deps/openssl\n"
+				return os.WriteFile(filepath.Join(dir, ".git"), []byte(content), 0o644)
+			},
+			wantID: "",
+		},
+		{
+			name: "worktree inside a submodule",
+			setupFunc: func(dir string) error {
+				// A linked worktree created inside a submodule points to
+				// .git/modules/<submod>/worktrees/<name>
+				content := "gitdir: /repo/.git/modules/mylib/worktrees/feature-branch\n"
+				return os.WriteFile(filepath.Join(dir, ".git"), []byte(content), 0o644)
+			},
+			wantID: "feature-branch",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes #640

`GetWorktreeID` failed with `unexpected gitdir format (no worktrees)` when run inside a git submodule. Submodule `.git` files point to `../.git/modules/<name>` instead of `.git/worktrees/<name>`, which the existing parser didn't handle.

### Changes

**`cmd/entire/cli/paths/worktree.go`**:
- Added `isSubmoduleGitdir()` helper that detects submodule gitdir paths (contain `/modules/` without `/worktrees/`)
- Submodules return empty string (treated like main worktrees since they have independent git state)
- Changed worktree marker from `strings.Cut` with `.git/worktrees/` to `strings.LastIndex` with `/worktrees/` — this also handles:
  - Worktrees inside submodules (`.git/modules/<submod>/worktrees/<name>`)
  - Bare repo layouts (`.bare/worktrees/<name>`, overlaps with #431)

**`cmd/entire/cli/paths/worktree_test.go`**:
- Added 4 test cases: relative submodule gitdir, absolute submodule gitdir, nested submodule, worktree inside a submodule

### Root cause

Git submodules use `.git` files (not directories) that point to the parent repo's `.git/modules/<name>` directory. The existing code only checked for `/worktrees/` in the gitdir path and returned an error for anything else, causing session initialization to fail completely inside submodules.

## Test plan

- [x] All existing `TestGetWorktreeID` cases pass
- [x] New submodule test cases pass (4 cases)
- [x] `mise run lint` — 0 issues
- [x] `mise run test` — all unit tests pass
- [x] `mise run fmt` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)