### PR TITLE
fix: resolve symlinks in worktree path comparison (fixes #686)

### DIFF
--- a/cmd/entire/cli/paths/paths.go
+++ b/cmd/entire/cli/paths/paths.go
@@ -85,6 +85,14 @@ func WorktreeRoot(ctx context.Context) (string, error) {
 
 	root := strings.TrimSpace(string(output))
 
+	// Resolve symlinks so the canonical path is always used.
+	// This prevents mismatches when the same directory is accessed via
+	// different paths (e.g., /tmp vs /private/tmp on macOS).
+	// On failure, fall back to the unresolved path.
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+
 	worktreeRootMu.Lock()
 	worktreeRootCache = root
 	worktreeRootCacheDir = cwd

--- a/cmd/entire/cli/paths/paths_test.go
+++ b/cmd/entire/cli/paths/paths_test.go
@@ -2,6 +2,7 @@ package paths
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -60,6 +61,51 @@ func TestGetClaudeProjectDir_Override(t *testing.T) {
 
 	if result != "/tmp/test-claude-project" {
 		t.Errorf("GetClaudeProjectDir() = %q, want %q", result, "/tmp/test-claude-project")
+	}
+}
+
+func TestWorktreeRoot_ResolvesSymlinks(t *testing.T) {
+	// Cannot use t.Parallel() because t.Chdir modifies process-global state.
+
+	// Create a real directory and a symlink to it
+	realDir := t.TempDir()
+	symlinkDir := filepath.Join(t.TempDir(), "symlink-repo")
+	if err := os.Symlink(realDir, symlinkDir); err != nil {
+		t.Skipf("cannot create symlinks: %v", err)
+	}
+
+	// Initialize a git repo in the real directory
+	ctx := t.Context()
+	cmd := exec.CommandContext(ctx, "git", "init", realDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+	cmd = exec.CommandContext(ctx, "git", "-C", realDir, "config", "user.email", "test@test.com")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git config failed: %v", err)
+	}
+	cmd = exec.CommandContext(ctx, "git", "-C", realDir, "config", "user.name", "Test")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git config failed: %v", err)
+	}
+
+	// cd into the symlink path and call WorktreeRoot
+	t.Chdir(symlinkDir)
+
+	ClearWorktreeRootCache()
+	root, err := WorktreeRoot(ctx)
+	if err != nil {
+		t.Fatalf("WorktreeRoot() error = %v", err)
+	}
+
+	// Resolve the real dir for comparison (handles /tmp -> /private/tmp on macOS)
+	resolvedReal, evalErr := filepath.EvalSymlinks(realDir)
+	if evalErr != nil {
+		t.Fatalf("EvalSymlinks(%q) error = %v", realDir, evalErr)
+	}
+
+	if root != resolvedReal {
+		t.Errorf("WorktreeRoot() via symlink = %q, want resolved real path %q", root, resolvedReal)
 	}
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
@@ -14,6 +15,15 @@ import (
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 )
+
+// resolvePathForComparison resolves symlinks and cleans a path for comparison.
+// Returns the cleaned original path if symlink resolution fails.
+func resolvePathForComparison(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(p)
+}
 
 // Shadow strategy session state methods.
 // Uses session.StateStore for persistence.
@@ -102,15 +112,19 @@ func (s *ManualCommitStrategy) listAllSessionStates(ctx context.Context) ([]*Ses
 }
 
 // findSessionsForWorktree finds all sessions for the given worktree path.
+// Paths are compared after symlink resolution to handle cases where the same
+// directory is accessed via different paths (e.g., /tmp vs /private/tmp on macOS).
 func (s *ManualCommitStrategy) findSessionsForWorktree(ctx context.Context, worktreePath string) ([]*SessionState, error) {
 	allStates, err := s.listAllSessionStates(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	resolvedTarget := resolvePathForComparison(worktreePath)
+
 	var matching []*SessionState
 	for _, state := range allStates {
-		if state.WorktreePath == worktreePath {
+		if state.WorktreePath == worktreePath || resolvePathForComparison(state.WorktreePath) == resolvedTarget {
 			matching = append(matching, state)
 		}
 	}
@@ -172,13 +186,16 @@ func (s *ManualCommitStrategy) CountOtherActiveSessionsWithCheckpoints(ctx conte
 		return 0, err
 	}
 
+	resolvedCurrentWorktree := resolvePathForComparison(currentWorktree)
+
 	count := 0
 	for _, state := range allStates {
 		// Only consider sessions from the same worktree with checkpoints
 		// AND based on the same commit (current HEAD)
 		// Sessions from different base commits are independent and shouldn't be counted
+		sameWorktree := state.WorktreePath == currentWorktree || resolvePathForComparison(state.WorktreePath) == resolvedCurrentWorktree
 		if state.SessionID != currentSessionID &&
-			state.WorktreePath == currentWorktree &&
+			sameWorktree &&
 			state.StepCount > 0 &&
 			state.BaseCommit == currentHead {
 			count++

--- a/cmd/entire/cli/strategy/manual_commit_session_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_session_test.go
@@ -1,0 +1,54 @@
+package strategy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolvePathForComparison(t *testing.T) {
+	t.Parallel()
+
+	t.Run("identical paths", func(t *testing.T) {
+		t.Parallel()
+		a := resolvePathForComparison("/some/path/to/repo")
+		b := resolvePathForComparison("/some/path/to/repo")
+		if a != b {
+			t.Errorf("identical paths should resolve equally: %q != %q", a, b)
+		}
+	})
+
+	t.Run("trailing slash normalization", func(t *testing.T) {
+		t.Parallel()
+		a := resolvePathForComparison("/some/path/to/repo/")
+		b := resolvePathForComparison("/some/path/to/repo")
+		if a != b {
+			t.Errorf("trailing slash mismatch: %q != %q", a, b)
+		}
+	})
+
+	t.Run("symlink resolution", func(t *testing.T) {
+		t.Parallel()
+		realDir := t.TempDir()
+		symlinkDir := filepath.Join(t.TempDir(), "link")
+		if err := os.Symlink(realDir, symlinkDir); err != nil {
+			t.Skipf("cannot create symlinks: %v", err)
+		}
+
+		resolved1 := resolvePathForComparison(realDir)
+		resolved2 := resolvePathForComparison(symlinkDir)
+		if resolved1 != resolved2 {
+			t.Errorf("symlinked paths should resolve equally: %q != %q", resolved1, resolved2)
+		}
+	})
+
+	t.Run("nonexistent path returns cleaned", func(t *testing.T) {
+		t.Parallel()
+		p := "/nonexistent/path/to/repo/"
+		got := resolvePathForComparison(p)
+		want := filepath.Clean(p)
+		if got != want {
+			t.Errorf("nonexistent path: got %q, want %q", got, want)
+		}
+	})
+}

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -116,11 +116,14 @@ func FindMostRecentSession(ctx context.Context) string {
 	}
 
 	// Scope to current worktree to prevent cross-worktree pollution.
+	// Compare with symlink resolution to handle cases where the same
+	// directory is accessed via different paths.
 	worktreePath, wpErr := paths.WorktreeRoot(ctx)
 	if wpErr == nil && worktreePath != "" {
+		resolvedTarget := resolvePathForComparison(worktreePath)
 		var filtered []*SessionState
 		for _, s := range states {
-			if s.WorktreePath == worktreePath {
+			if s.WorktreePath == worktreePath || resolvePathForComparison(s.WorktreePath) == resolvedTarget {
 				filtered = append(filtered, s)
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #686 — `prepare-commit-msg` hook silently fails to add `Entire-Checkpoint` trailer when the repository is accessed via a symlinked path.

### Root Cause

`findSessionsForWorktree()` uses exact string equality (`state.WorktreePath == worktreePath`) to match sessions. When a repo is accessed via a symlink (e.g., `/tmp/myrepo` → `/private/tmp/myrepo` on macOS), the stored `WorktreePath` and the runtime-resolved path can differ, causing the hook to find zero matching sessions and silently return without modifying the commit message.

### Fix

**Two-layer defense:**

1. **`WorktreeRoot()` now resolves symlinks** via `filepath.EvalSymlinks` before caching, so new sessions always store the canonical path.

2. **All worktree path comparisons use symlink-aware fallback** — if the fast exact-string match fails, paths are resolved and compared. This handles existing session state files that were created before the fix.

### Files Changed

| File | Change |
|---|---|
| `cmd/entire/cli/paths/paths.go` | `WorktreeRoot()` resolves symlinks before caching |
| `cmd/entire/cli/paths/paths_test.go` | Test: symlinked git repo returns resolved path |
| `cmd/entire/cli/strategy/manual_commit_session.go` | `findSessionsForWorktree()` + `CountOtherActiveSessionsWithCheckpoints()` use symlink-aware comparison; add `resolvePathForComparison()` helper |
| `cmd/entire/cli/strategy/manual_commit_session_test.go` | Tests for `resolvePathForComparison` (symlinks, trailing slashes, nonexistent paths) |
| `cmd/entire/cli/strategy/session_state.go` | `FindMostRecentSession()` uses symlink-aware comparison |

## Test plan

- [x] `mise run fmt` — clean
- [x] `mise run lint` — 0 issues
- [x] `mise run test:ci` — all 43 tests pass (unit + integration + Vogon E2E canary)
- [x] New test `TestWorktreeRoot_ResolvesSymlinks` verifies symlink resolution
- [x] New test `TestResolvePathForComparison` covers symlinks, trailing slashes, nonexistent paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)