### PR TITLE
Fix: Prevent zero attribution by fixing baseline diff and double cond…

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_attribution.go
+++ b/cmd/entire/cli/strategy/manual_commit_attribution.go
@@ -191,10 +191,11 @@ func CalculateAttributionWithAccumulated(
 	baseTree *object.Tree,
 	shadowTree *object.Tree,
 	headTree *object.Tree,
+	parentTree *object.Tree,
 	filesTouched []string,
 	promptAttributions []PromptAttribution,
 	repoDir string,
-	attributionBaseCommit string,
+	parentCommitHash string,
 	headCommitHash string,
 ) *checkpoint.InitialAttribution {
 	if len(filesTouched) == 0 {
@@ -243,8 +244,9 @@ func CalculateAttributionWithAccumulated(
 	}
 
 	// Calculate total user edits to non-agent files (files not in filesTouched)
-	// These files are not in the shadow tree, so base→head captures ALL their user edits
-	allChangedFiles, err := getAllChangedFiles(ctx, baseTree, headTree, repoDir, attributionBaseCommit, headCommitHash)
+	// These files are not in the shadow tree, so parent→head captures ALL their user edits
+	// This avoids inflating user edits when intermediate commits exist (Bug #421).
+	allChangedFiles, err := getAllChangedFiles(ctx, parentTree, headTree, repoDir, parentCommitHash, headCommitHash)
 	if err != nil {
 		logging.Warn(logging.WithComponent(ctx, "attribution"),
 			"attribution: failed to enumerate changed files",
@@ -258,9 +260,9 @@ func CalculateAttributionWithAccumulated(
 			continue // Skip agent-touched files
 		}
 
-		baseContent := getFileContent(baseTree, filePath)
+		parentContent := getFileContent(parentTree, filePath)
 		headContent := getFileContent(headTree, filePath)
-		_, userAdded, _ := diffLines(baseContent, headContent)
+		_, userAdded, _ := diffLines(parentContent, headContent)
 		allUserEditsToNonAgentFiles += userAdded
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_attribution_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_attribution_test.go
@@ -280,7 +280,7 @@ func TestCalculateAttributionWithAccumulated_BasicCase(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -339,7 +339,7 @@ func TestCalculateAttributionWithAccumulated_BugScenario(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -398,7 +398,7 @@ func TestCalculateAttributionWithAccumulated_DeletionOnly(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -449,7 +449,7 @@ func TestCalculateAttributionWithAccumulated_NoUserEdits(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -503,7 +503,7 @@ func TestCalculateAttributionWithAccumulated_NoAgentWork(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -559,7 +559,7 @@ func TestCalculateAttributionWithAccumulated_UserRemovesAllAgentLines(t *testing
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -630,7 +630,7 @@ func TestCalculateAttributionWithAccumulated_WithPromptAttributions(t *testing.T
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -729,7 +729,7 @@ func TestCalculateAttributionWithAccumulated_UserEditsNonAgentFile(t *testing.T)
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -1036,7 +1036,7 @@ func TestCalculateAttributionWithAccumulated_UserSelfModification(t *testing.T) 
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -1109,7 +1109,7 @@ func TestCalculateAttributionWithAccumulated_MixedModifications(t *testing.T) {
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {
@@ -1192,7 +1192,7 @@ func TestCalculateAttributionWithAccumulated_UncommittedWorktreeFiles(t *testing
 
 	result := CalculateAttributionWithAccumulated(
 		context.Background(),
-		baseTree, shadowTree, headTree, filesTouched, promptAttributions, "", "", "",
+		baseTree, shadowTree, headTree, baseTree, filesTouched, promptAttributions, "", "", "",
 	)
 
 	if result == nil {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -89,8 +89,10 @@ func (s *ManualCommitStrategy) getCheckpointLog(ctx context.Context, checkpointI
 type condenseOpts struct {
 	shadowRef      *plumbing.Reference // Pre-resolved shadow branch ref (nil = resolve from repo)
 	headTree       *object.Tree        // Pre-resolved HEAD tree (passed through to calculateSessionAttributions)
+	parentTree     *object.Tree        // Pre-resolved parent tree
 	repoDir        string              // Repository worktree path for git CLI commands
 	headCommitHash string              // HEAD commit hash (passed through for attribution)
+	parentCommitHash string            // parent commit hash
 }
 
 // CondenseSession condenses a session's shadow branch to permanent storage.
@@ -193,9 +195,11 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 
 	attribution := calculateSessionAttributions(ctx, repo, ref, sessionData, state, attributionOpts{
 		headTree:              o.headTree,
+		parentTree:            o.parentTree,
 		repoDir:               o.repoDir,
 		attributionBaseCommit: attrBase,
 		headCommitHash:        o.headCommitHash,
+		parentCommitHash:      o.parentCommitHash,
 	})
 
 	// Get current branch name
@@ -296,9 +300,11 @@ func buildSessionMetrics(state *SessionState) *cpkg.SessionMetrics {
 type attributionOpts struct {
 	headTree              *object.Tree // HEAD commit tree (already resolved by PostCommit)
 	shadowTree            *object.Tree // Shadow branch tree (already resolved by PostCommit)
+	parentTree            *object.Tree // Pre-resolved parent tree
 	repoDir               string       // Repository worktree path for git CLI commands
 	attributionBaseCommit string       // Base commit hash for non-agent file detection (empty = fall back to go-git tree walk)
 	headCommitHash        string       // HEAD commit hash for non-agent file detection (empty = fall back to go-git tree walk)
+	parentCommitHash      string       // Parent commit hash
 }
 
 func calculateSessionAttributions(ctx context.Context, repo *git.Repository, shadowRef *plumbing.Reference, sessionData *ExtractedSessionData, state *SessionState, opts ...attributionOpts) *cpkg.InitialAttribution {
@@ -405,10 +411,11 @@ func calculateSessionAttributions(ctx context.Context, repo *git.Repository, sha
 		baseTree,
 		shadowTree,
 		headTree,
+		o.parentTree,
 		sessionData.FilesTouched,
 		state.PromptAttributions,
 		o.repoDir,
-		o.attributionBaseCommit,
+		o.parentCommitHash,
 		o.headCommitHash,
 	)
 

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -630,9 +630,11 @@ type postCommitActionHandler struct {
 	parentTree *object.Tree        // HEAD's first parent tree (shared, nil for initial commits)
 	shadowRef  *plumbing.Reference // Per-session shadow branch ref (nil if branch doesn't exist)
 	shadowTree *object.Tree        // Per-session shadow commit tree (nil if branch doesn't exist)
+	parentCommitHash string        // HEAD's first parent commit hash
 
 	// Output: set by handler methods, read by caller after TransitionAndLog.
 	condensed bool
+	commitAlreadyCondensed *bool
 }
 
 func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
@@ -648,12 +650,23 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 	)
 
 	if shouldCondense {
-		h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
-			shadowRef:      h.shadowRef,
-			headTree:       h.headTree,
-			repoDir:        h.repoDir,
-			headCommitHash: h.newHead,
-		})
+		if *h.commitAlreadyCondensed {
+			logging.Debug(logCtx, "post-commit: skipping condensation, another session already condensed this commit",
+				slog.String("session_id", state.SessionID))
+			h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
+		} else {
+			h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
+				shadowRef:      h.shadowRef,
+				headTree:       h.headTree,
+				parentTree:     h.parentTree,
+				repoDir:        h.repoDir,
+				headCommitHash: h.newHead,
+				parentCommitHash: h.parentCommitHash,
+			})
+			if h.condensed {
+				*h.commitAlreadyCondensed = true
+			}
+		}
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
 	}
@@ -674,12 +687,23 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 	)
 
 	if shouldCondense {
-		h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
-			shadowRef:      h.shadowRef,
-			headTree:       h.headTree,
-			repoDir:        h.repoDir,
-			headCommitHash: h.newHead,
-		})
+		if *h.commitAlreadyCondensed {
+			logging.Debug(logCtx, "post-commit: skipping condensation, another session already condensed this commit",
+				slog.String("session_id", state.SessionID))
+			h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
+		} else {
+			h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
+				shadowRef:      h.shadowRef,
+				headTree:       h.headTree,
+				parentTree:     h.parentTree,
+				repoDir:        h.repoDir,
+				headCommitHash: h.newHead,
+				parentCommitHash: h.parentCommitHash,
+			})
+			if h.condensed {
+				*h.commitAlreadyCondensed = true
+			}
+		}
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
 	}
@@ -846,7 +870,9 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:
 		headTree = t
 	}
 	var parentTree *object.Tree
+	var parentCommitHash string
 	if commit.NumParents() > 0 {
+		parentCommitHash = commit.ParentHashes[0].String()
 		if parent, err := commit.Parent(0); err == nil {
 			if t, err := parent.Tree(); err == nil {
 				parentTree = t
@@ -857,6 +883,22 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:
 	committedFileSet := filesChangedInCommit(ctx, worktreePath, commit, headTree, parentTree)
 	resolveTreesSpan.End()
 
+	// Track if any active session condensed this commit
+	commitAlreadyCondensed := false
+
+	// Sort sessions so ACTIVE sessions are processed first. This prevents Bug 3 (double condensation)
+	// where an ENDED session claims a commit, gets 0-attribution, and is then overwritten by the ACTIVE session,
+	// or vice versa. By processing ACTIVE first, it claims the commit and we can skip others.
+	slices.SortFunc(sessions, func(a, b *SessionState) int {
+		if a.Phase.IsActive() && !b.Phase.IsActive() {
+			return -1
+		}
+		if !a.Phase.IsActive() && b.Phase.IsActive() {
+			return 1
+		}
+		return 0
+	})
+
 	for _, state := range sessions {
 		// Skip fully-condensed ended sessions — no work remains.
 		// These sessions only persist for LastCheckpointID (amend trailer reuse).
@@ -864,8 +906,8 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:
 			continue
 		}
 		s.postCommitProcessSession(ctx, repo, state, &transitionCtx, checkpointID,
-			head, commit, newHead, worktreePath, headTree, parentTree, committedFileSet,
-			shadowBranchesToDelete, uncondensedActiveOnBranch)
+			head, commit, newHead, worktreePath, headTree, parentTree, parentCommitHash, committedFileSet,
+			shadowBranchesToDelete, uncondensedActiveOnBranch, &commitAlreadyCondensed)
 	}
 
 	// Clean up shadow branches — only delete when ALL sessions on the branch are non-active
@@ -908,9 +950,11 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 	newHead string,
 	repoDir string,
 	headTree, parentTree *object.Tree,
+	parentCommitHash string,
 	committedFileSet map[string]struct{},
 	shadowBranchesToDelete map[string]struct{},
 	uncondensedActiveOnBranch map[string]bool,
+	commitAlreadyCondensed *bool,
 ) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
@@ -1001,6 +1045,8 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 		parentTree:             parentTree,
 		shadowRef:              shadowRef,
 		shadowTree:             shadowTree,
+		parentCommitHash:       parentCommitHash,
+		commitAlreadyCondensed: commitAlreadyCondensed,
 	}
 
 	if err := TransitionAndLog(ctx, state, session.EventGitCommit, *transitionCtx, handler); err != nil {


### PR DESCRIPTION
FIX:#421

Issue
initial_attribution in checkpoint metadata (entire/checkpoints/v1) always shows agent_lines: 0 and agent_percentage: 0, regardless of the actual agent contribution.

This was caused by three bugs in the PostCommit condensation pipeline:

Wrong baseline: Non-agent human edits were calculated by diffing the current commit against the session's start commit (baseTree). Any intermediate commits by the user inflated the non-agent human edit count.
Stale sessions claiming commits: The overlap check wasn't stringent enough to prevent ENDED sessions from trying to condense a commit just because it touched the same files that the ENDED session had previously modified.
Double Condensation: A race condition in the 
PostCommit
 hook caused both the ACTIVE session and the ENDED session to condense. The ENDED session would calculate 0 attribution and overwrite the correct metadata written by the ACTIVE session because both used the exact same checkpointID from the commit trailer.
Solution
Fix Baseline: Modified 
CalculateAttributionWithAccumulated
 in 
manual_commit_attribution.go
 to diff using parentTree (the immediate parent of the current commit) instead of baseTree. The parentCommitHash and parentTree are now passed down through 
manual_commit_condensation.go
.
Prevent Double Condensation: Updated 
manual_commit_hooks.go
 to sort the session list in the 
PostCommit
 hook so that ACTIVE sessions are processed first.
Claim Tracker: Added a commitAlreadyCondensed reference to the 
PostCommit
 loop. Once an ACTIVE session condenses the commit, subsequent sessions (like the ENDED ones) are skipped, preventing them from overwriting the valid metadata with zeros.
