### PR TITLE
cursor 2026.03.11 transitions from flat to nested path during a session

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -120,6 +120,11 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		hasShadowBranch = err == nil
 	}
 
+	// Re-resolve transcript path before any reads — handles agents that relocate
+	// transcripts mid-session (e.g., Cursor CLI flat → nested layout change).
+	// Errors are ignored; downstream readers handle missing transcripts gracefully.
+	resolveTranscriptPath(state) //nolint:errcheck,gosec // best-effort; downstream readers handle missing files
+
 	var sessionData *ExtractedSessionData
 	if hasShadowBranch {
 		var extractErr error
@@ -513,12 +518,13 @@ func (s *ManualCommitStrategy) extractSessionDataFromLiveTranscript(ctx context.
 
 	ag, _ := agent.GetByAgentType(state.AgentType) //nolint:errcheck // ag may be nil for unknown agent types; callers use type assertions so nil is safe
 
-	// Read the live transcript
-	if state.TranscriptPath == "" {
-		return nil, errors.New("no transcript path in session state")
+	// Resolve the transcript path (handles agents that relocate mid-session).
+	transcriptPath, resolveErr := resolveTranscriptPath(state)
+	if resolveErr != nil {
+		return nil, resolveErr
 	}
 
-	liveData, err := os.ReadFile(state.TranscriptPath)
+	liveData, err := os.ReadFile(transcriptPath) //nolint:gosec // path validated by resolveTranscriptPath
 	if err != nil {
 		return nil, fmt.Errorf("failed to read live transcript: %w", err)
 	}

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1486,6 +1486,15 @@ func (s *ManualCommitStrategy) hasNewTranscriptWork(ctx context.Context, state *
 		return false
 	}
 
+	// Re-resolve transcript path — handles agents that relocate transcripts mid-session.
+	if _, resolveErr := resolveTranscriptPath(state); resolveErr != nil {
+		logging.Debug(logCtx, "hasNewTranscriptWork: transcript path resolution failed",
+			slog.String("session_id", state.SessionID),
+			slog.Any("error", resolveErr),
+		)
+		return false
+	}
+
 	ag, err := agent.GetByAgentType(state.AgentType)
 	if err != nil {
 		return false
@@ -1543,6 +1552,15 @@ func (s *ManualCommitStrategy) extractModifiedFilesFromLiveTranscript(ctx contex
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 
 	if state.TranscriptPath == "" || state.AgentType == "" {
+		return nil
+	}
+
+	// Re-resolve transcript path — handles agents that relocate transcripts mid-session.
+	if _, resolveErr := resolveTranscriptPath(state); resolveErr != nil {
+		logging.Debug(logCtx, "extractModifiedFilesFromLiveTranscript: transcript path resolution failed",
+			slog.String("session_id", state.SessionID),
+			slog.Any("error", resolveErr),
+		)
 		return nil
 	}
 
@@ -2160,7 +2178,8 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 
 	errCount := 0
 
-	// Read full transcript from live transcript file
+	// Read full transcript from live transcript file, re-resolving the path if the
+	// agent relocated it mid-session (e.g., Cursor CLI flat → nested layout change).
 	if state.TranscriptPath == "" {
 		logging.Warn(logCtx, "finalize: no transcript path, skipping",
 			slog.String("session_id", state.SessionID),
@@ -2169,7 +2188,17 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 		return 1 // Count as error - all checkpoints will be skipped
 	}
 
-	fullTranscript, err := os.ReadFile(state.TranscriptPath)
+	transcriptPath, resolveErr := resolveTranscriptPath(state)
+	if resolveErr != nil {
+		logging.Warn(logCtx, "finalize: transcript path resolution failed, skipping",
+			slog.String("session_id", state.SessionID),
+			slog.Any("error", resolveErr),
+		)
+		state.TurnCheckpointIDs = nil
+		return 1 // Count as error - all checkpoints will be skipped
+	}
+
+	fullTranscript, err := os.ReadFile(transcriptPath) //nolint:gosec // path validated by resolveTranscriptPath
 	if err != nil || len(fullTranscript) == 0 {
 		msg := "finalize: empty transcript, skipping"
 		if err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -2909,6 +2909,93 @@ func TestCondenseSession_PrefersLiveTranscript(t *testing.T) {
 	}
 }
 
+// TestCondenseSession_TranscriptRelocatedMidSession verifies that CondenseSession
+// succeeds when the agent relocates its transcript mid-session (e.g., Cursor CLI
+// switching from flat <dir>/<id>.jsonl to nested <dir>/<id>/<id>.jsonl layout).
+// This is a regression test for a Cursor CLI 2026.03.11 change that broke mid-turn
+// commits because the stored TranscriptPath became stale.
+func TestCondenseSession_TranscriptRelocatedMidSession(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content"), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if _, err := wt.Add("file.txt"); err != nil {
+		t.Fatalf("failed to stage: %v", err)
+	}
+	_, err = wt.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	t.Chdir(dir)
+
+	s := &ManualCommitStrategy{}
+	sessionID := "87874108-eff2-47a0-b260-183961dd6cb0"
+
+	// Create the session state with a flat TranscriptPath (what before-submit-prompt reports)
+	agentTranscriptsDir := filepath.Join(dir, "agent-transcripts")
+	if err := os.MkdirAll(agentTranscriptsDir, 0o755); err != nil {
+		t.Fatalf("failed to create agent-transcripts dir: %v", err)
+	}
+	flatPath := filepath.Join(agentTranscriptsDir, sessionID+".jsonl")
+
+	// But the file actually lives at the nested path (Cursor relocated it)
+	nestedDir := filepath.Join(agentTranscriptsDir, sessionID)
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("failed to create nested dir: %v", err)
+	}
+	nestedPath := filepath.Join(nestedDir, sessionID+".jsonl")
+	transcript := `{"type":"human","message":{"content":"create a file"}}
+{"type":"assistant","message":{"content":"done"}}
+`
+	if err := os.WriteFile(nestedPath, []byte(transcript), 0o644); err != nil {
+		t.Fatalf("failed to write transcript: %v", err)
+	}
+
+	// Create session state pointing to the FLAT (stale) path
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("failed to get HEAD: %v", err)
+	}
+	state := &SessionState{
+		SessionID:      sessionID,
+		BaseCommit:     head.Hash().String(),
+		WorktreePath:   dir,
+		AgentType:      agent.AgentTypeCursor,
+		TranscriptPath: flatPath, // stale: file was relocated to nested path
+	}
+	if err := s.saveSessionState(context.Background(), state); err != nil {
+		t.Fatalf("saveSessionState() error = %v", err)
+	}
+
+	// CondenseSession should succeed by re-resolving the transcript path
+	checkpointID := id.MustCheckpointID("c1d2e3f4a5b6")
+	result, err := s.CondenseSession(context.Background(), repo, checkpointID, state, nil)
+	if err != nil {
+		t.Fatalf("CondenseSession() error = %v, want nil (should re-resolve stale transcript path)", err)
+	}
+
+	if result.TotalTranscriptLines != 2 {
+		t.Errorf("TotalTranscriptLines = %d, want 2", result.TotalTranscriptLines)
+	}
+
+	// State should have been updated to the resolved path
+	if state.TranscriptPath != nestedPath {
+		t.Errorf("state.TranscriptPath = %q, want %q (should be updated after re-resolution)", state.TranscriptPath, nestedPath)
+	}
+}
+
 // TestCondenseSession_GeminiTranscript verifies that CondenseSession works correctly
 // with Gemini JSON format transcripts, including prompt extraction and format detection.
 func TestCondenseSession_GeminiTranscript(t *testing.T) {

--- a/cmd/entire/cli/strategy/resolve_transcript.go
+++ b/cmd/entire/cli/strategy/resolve_transcript.go
@@ -1,0 +1,62 @@
+package strategy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// resolveTranscriptPath returns the current path to the session's transcript file.
+// If the file exists at state.TranscriptPath, that path is returned immediately.
+//
+// If the file is missing (os.ErrNotExist), the function re-resolves the path
+// using the agent's ResolveSessionFile method. This handles agents that relocate
+// transcripts mid-session (e.g., Cursor CLI switching from a flat layout
+// <dir>/<id>.jsonl to a nested layout <dir>/<id>/<id>.jsonl).
+//
+// On successful re-resolution, state.TranscriptPath is updated so that
+// subsequent reads use the correct path without repeating the resolution.
+func resolveTranscriptPath(state *SessionState) (string, error) {
+	if state.TranscriptPath == "" {
+		return "", errors.New("no transcript path in session state")
+	}
+
+	// Fast path: file exists at the stored location.
+	if _, err := os.Stat(state.TranscriptPath); err == nil {
+		return state.TranscriptPath, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		// Non-ENOENT error (permission denied, etc.) — return as-is.
+		return "", fmt.Errorf("failed to access transcript: %w", err)
+	}
+
+	// File not found — attempt re-resolution via the agent.
+	ag, agErr := agent.GetByAgentType(state.AgentType)
+	if agErr != nil {
+		return "", fmt.Errorf("transcript not found at %s: %w", state.TranscriptPath, os.ErrNotExist)
+	}
+
+	// Extract the session dir and agent session ID from the stored path.
+	// Stored path format: <sessionDir>/<agentSessionID>.jsonl
+	sessionDir := filepath.Dir(state.TranscriptPath)
+	base := filepath.Base(state.TranscriptPath)
+	agentSessionID := strings.TrimSuffix(base, filepath.Ext(base))
+
+	resolved := ag.ResolveSessionFile(sessionDir, agentSessionID)
+	if resolved == state.TranscriptPath {
+		// Agent resolved to the same path — file genuinely doesn't exist.
+		return "", fmt.Errorf("transcript not found at %s: %w", state.TranscriptPath, os.ErrNotExist)
+	}
+
+	// Check if the re-resolved path exists.
+	if _, err := os.Stat(resolved); err != nil {
+		return "", fmt.Errorf("transcript not found at %s (also tried %s): %w", state.TranscriptPath, resolved, os.ErrNotExist)
+	}
+
+	// Update state so subsequent reads use the correct path.
+	state.TranscriptPath = resolved
+	return resolved, nil
+}

--- a/cmd/entire/cli/strategy/resolve_transcript_test.go
+++ b/cmd/entire/cli/strategy/resolve_transcript_test.go
@@ -1,0 +1,202 @@
+package strategy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+
+	// Register agents so GetByAgentType works in tests.
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/cursor"
+)
+
+func TestResolveTranscriptPath_FileExists(t *testing.T) {
+	t.Parallel()
+
+	// When the transcript file exists at the stored path, resolveTranscriptPath
+	// should return that path unchanged.
+	tmpDir := t.TempDir()
+	transcriptFile := filepath.Join(tmpDir, "session-123.jsonl")
+	if err := os.WriteFile(transcriptFile, []byte(`{"test":true}`), 0o600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	state := &session.State{
+		TranscriptPath: transcriptFile,
+		AgentType:      agent.AgentTypeCursor,
+	}
+
+	resolved, err := resolveTranscriptPath(state)
+	if err != nil {
+		t.Fatalf("resolveTranscriptPath() error = %v", err)
+	}
+	if resolved != transcriptFile {
+		t.Errorf("resolveTranscriptPath() = %q, want %q", resolved, transcriptFile)
+	}
+	if state.TranscriptPath != transcriptFile {
+		t.Errorf("state.TranscriptPath changed to %q, should remain %q", state.TranscriptPath, transcriptFile)
+	}
+}
+
+func TestResolveTranscriptPath_ReResolvesToNestedLayout(t *testing.T) {
+	t.Parallel()
+
+	// Simulates Cursor CLI relocating a transcript mid-session:
+	// Stored path (flat):  <dir>/<uuid>.jsonl  (does not exist)
+	// Actual path (nested): <dir>/<uuid>/<uuid>.jsonl  (exists)
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "agent-transcripts")
+	if err := os.MkdirAll(sessionDir, 0o750); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+
+	agentSessionID := "87874108-eff2-47a0-b260-183961dd6cb0"
+	flatPath := filepath.Join(sessionDir, agentSessionID+".jsonl")
+
+	// Create the file at the nested path only
+	nestedDir := filepath.Join(sessionDir, agentSessionID)
+	if err := os.MkdirAll(nestedDir, 0o750); err != nil {
+		t.Fatalf("failed to create nested dir: %v", err)
+	}
+	nestedPath := filepath.Join(nestedDir, agentSessionID+".jsonl")
+	if err := os.WriteFile(nestedPath, []byte(`{"role":"user"}`), 0o600); err != nil {
+		t.Fatalf("failed to write nested transcript: %v", err)
+	}
+
+	state := &session.State{
+		TranscriptPath: flatPath,
+		AgentType:      agent.AgentTypeCursor,
+	}
+
+	resolved, err := resolveTranscriptPath(state)
+	if err != nil {
+		t.Fatalf("resolveTranscriptPath() error = %v", err)
+	}
+	if resolved != nestedPath {
+		t.Errorf("resolveTranscriptPath() = %q, want %q", resolved, nestedPath)
+	}
+	// State should be updated to the resolved path
+	if state.TranscriptPath != nestedPath {
+		t.Errorf("state.TranscriptPath = %q, want %q", state.TranscriptPath, nestedPath)
+	}
+}
+
+func TestResolveTranscriptPath_FileNotFoundAndCannotResolve(t *testing.T) {
+	t.Parallel()
+
+	// When the file doesn't exist and re-resolution also fails, the original
+	// not-found error should be returned.
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "agent-transcripts")
+	if err := os.MkdirAll(sessionDir, 0o750); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+
+	agentSessionID := "nonexistent-uuid"
+	flatPath := filepath.Join(sessionDir, agentSessionID+".jsonl")
+
+	state := &session.State{
+		TranscriptPath: flatPath,
+		AgentType:      agent.AgentTypeCursor,
+	}
+
+	_, err := resolveTranscriptPath(state)
+	if err == nil {
+		t.Fatal("resolveTranscriptPath() expected error, got nil")
+	}
+	// State should not change
+	if state.TranscriptPath != flatPath {
+		t.Errorf("state.TranscriptPath changed to %q, should remain %q", state.TranscriptPath, flatPath)
+	}
+}
+
+func TestResolveTranscriptPath_UnknownAgentFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	// When the agent type is unknown, re-resolution should not be attempted,
+	// and the original not-found error should be returned.
+	tmpDir := t.TempDir()
+	missingPath := filepath.Join(tmpDir, "nonexistent.jsonl")
+
+	state := &session.State{
+		TranscriptPath: missingPath,
+		AgentType:      "Unknown Agent",
+	}
+
+	_, err := resolveTranscriptPath(state)
+	if err == nil {
+		t.Fatal("resolveTranscriptPath() expected error, got nil")
+	}
+}
+
+func TestResolveTranscriptPath_EmptyPath(t *testing.T) {
+	t.Parallel()
+
+	state := &session.State{
+		TranscriptPath: "",
+		AgentType:      agent.AgentTypeCursor,
+	}
+
+	_, err := resolveTranscriptPath(state)
+	if err == nil {
+		t.Fatal("resolveTranscriptPath() expected error for empty path, got nil")
+	}
+}
+
+func TestResolveTranscriptPath_DirectoryPathReturnsAsIs(t *testing.T) {
+	t.Parallel()
+
+	// When the path is a directory (not a file), os.Stat succeeds so
+	// resolveTranscriptPath returns the path as-is. The caller will get
+	// an error when it tries os.ReadFile.
+	tmpDir := t.TempDir()
+	dirPath := filepath.Join(tmpDir, "adir")
+	if err := os.MkdirAll(dirPath, 0o750); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	state := &session.State{
+		TranscriptPath: dirPath,
+		AgentType:      agent.AgentTypeCursor,
+	}
+
+	resolved, err := resolveTranscriptPath(state)
+	if err != nil {
+		t.Fatalf("resolveTranscriptPath() error = %v", err)
+	}
+	if resolved != dirPath {
+		t.Errorf("resolveTranscriptPath() = %q, want %q", resolved, dirPath)
+	}
+}
+
+func TestResolveTranscriptPath_ClaudeCodeNoReResolution(t *testing.T) {
+	t.Parallel()
+
+	// Claude Code transcripts don't relocate mid-session. resolveTranscriptPath
+	// should still attempt re-resolution (the agent's ResolveSessionFile handles it).
+	// This test verifies the function works generically for any agent.
+	tmpDir := t.TempDir()
+	sessionDir := filepath.Join(tmpDir, "projects", "sessions")
+	if err := os.MkdirAll(sessionDir, 0o750); err != nil {
+		t.Fatalf("failed to create session dir: %v", err)
+	}
+
+	missingPath := filepath.Join(sessionDir, "session-abc.jsonl")
+
+	state := &session.State{
+		TranscriptPath: missingPath,
+		AgentType:      agent.AgentTypeClaudeCode,
+	}
+
+	_, err := resolveTranscriptPath(state)
+	if err == nil {
+		t.Fatal("resolveTranscriptPath() expected error, got nil")
+	}
+	// Path should remain unchanged since re-resolution also fails
+	if state.TranscriptPath != missingPath {
+		t.Errorf("state.TranscriptPath = %q, want %q", state.TranscriptPath, missingPath)
+	}
+}


### PR DESCRIPTION
E2E test for cursor where failing, turns out that the CLI agent is initially reporting a flat file path (`<dir>/<id>.jsonl`) but then during the session the log is actually stored in a nested directory (`<dir>/<id>/<id>.jsonl`). 

We already had logic for both path formats and did check both if one wasn't there but it was skipped since a path was initially reported. This is now always goes through `resolveTranscriptPath()` and always handling the fallback.