### PR TITLE
Prevent any issues if more then expected files are modified

### DIFF
--- a/e2e/tests/split_commits_test.go
+++ b/e2e/tests/split_commits_test.go
@@ -85,7 +85,7 @@ func TestPartialStaging(t *testing.T) {
 			t.Fatalf("agent prompt 2 failed: %v", err)
 		}
 
-		s.Git(t, "add", "src/main.go")
+		s.Git(t, "add", "-A")
 		s.Git(t, "commit", "-m", "Add goodbye world")
 
 		testutil.WaitForCheckpointAdvanceFrom(t, s.Dir, cpBranch1, 15*time.Second)


### PR DESCRIPTION
This seems to cause flakes with gemini. In theory the prompt should only update an existing file but the artifacts showed that gemini logs had "I have also compiled and run the program to confirm the change" so it probably made a binary that was left and not added/committed so the shadow branch was kept -> test failed. 

Let's just commit everything. In this test it's fine since we did not expect any other files.