### PR TITLE
Add external agent selection to enable

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -162,7 +162,7 @@ func runAddAgents(ctx context.Context, w io.Writer, opts EnableOptions) error {
 		return nil
 	}
 
-	options, allInstalled := buildAgentOptions(installedSet)
+	options, allInstalled := buildAgentOptions(ctx, installedSet)
 	externalCurrentlyEnabled := settings.IsExternalAgentsEnabled(ctx)
 	if allInstalled && externalCurrentlyEnabled {
 		fmt.Fprintln(w, "All available agents are already enabled.")
@@ -219,7 +219,7 @@ func runAddAgents(ctx context.Context, w io.Writer, opts EnableOptions) error {
 
 // buildAgentOptions builds agent multi-select options with the external agents toggle.
 // Returns options and whether all real agents are already installed.
-func buildAgentOptions(installedSet map[types.AgentName]struct{}) ([]huh.Option[string], bool) {
+func buildAgentOptions(ctx context.Context, installedSet map[types.AgentName]struct{}) ([]huh.Option[string], bool) {
 	agentNames := agent.List()
 	options := make([]huh.Option[string], 0, len(agentNames)+1)
 	allInstalled := true
@@ -245,7 +245,7 @@ func buildAgentOptions(installedSet map[types.AgentName]struct{}) ([]huh.Option[
 
 	// Add "External Agents" toggle option at the end.
 	externalOpt := huh.NewOption("External Agents", externalAgentsSentinel)
-	if settings.IsExternalAgentsEnabled(context.Background()) {
+	if settings.IsExternalAgentsEnabled(ctx) {
 		externalOpt = externalOpt.Selected(true)
 	}
 	options = append(options, externalOpt)
@@ -965,15 +965,7 @@ func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(availab
 	}
 
 	// Separate the external agents sentinel from real agent selections.
-	externalSelected := false
-	realAgentNames := make([]string, 0, len(selectedAgentNames))
-	for _, name := range selectedAgentNames {
-		if name == externalAgentsSentinel {
-			externalSelected = true
-			continue
-		}
-		realAgentNames = append(realAgentNames, name)
-	}
+	realAgentNames, externalSelected := splitExternalAgentSelection(selectedAgentNames)
 
 	selectedAgents := make([]agent.Agent, 0, len(realAgentNames))
 	for _, name := range realAgentNames {

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -1404,3 +1404,136 @@ func TestDetectOrSelectAgent_ReRun_EmptySelection_ReturnsError(t *testing.T) {
 		t.Errorf("Expected 'no agents selected' error, got: %v", err)
 	}
 }
+
+func TestSplitExternalAgentSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		input           []string
+		wantNames       []string
+		wantExtSelected bool
+	}{
+		{
+			name:            "empty input",
+			input:           []string{},
+			wantNames:       []string{},
+			wantExtSelected: false,
+		},
+		{
+			name:            "agents only",
+			input:           []string{"claude-code", "gemini"},
+			wantNames:       []string{"claude-code", "gemini"},
+			wantExtSelected: false,
+		},
+		{
+			name:            "sentinel only",
+			input:           []string{externalAgentsSentinel},
+			wantNames:       []string{},
+			wantExtSelected: true,
+		},
+		{
+			name:            "mixed agents and sentinel",
+			input:           []string{"claude-code", externalAgentsSentinel, "gemini"},
+			wantNames:       []string{"claude-code", "gemini"},
+			wantExtSelected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotNames, gotExt := splitExternalAgentSelection(tt.input)
+			if len(gotNames) != len(tt.wantNames) {
+				t.Fatalf("got %d names, want %d", len(gotNames), len(tt.wantNames))
+			}
+			for i, name := range gotNames {
+				if name != tt.wantNames[i] {
+					t.Errorf("name[%d] = %q, want %q", i, name, tt.wantNames[i])
+				}
+			}
+			if gotExt != tt.wantExtSelected {
+				t.Errorf("externalSelected = %v, want %v", gotExt, tt.wantExtSelected)
+			}
+		})
+	}
+}
+
+func TestDetectOrSelectAgent_ExternalAgentsSelected(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+
+	// selectFn returns a real agent + the external agents sentinel
+	selectFn := func(available []string) ([]string, error) {
+		// Verify sentinel is in available options
+		hasSentinel := false
+		for _, name := range available {
+			if name == externalAgentsSentinel {
+				hasSentinel = true
+				break
+			}
+		}
+		if !hasSentinel {
+			t.Error("external agents sentinel not in available options")
+		}
+		return []string{string(agent.AgentNameClaudeCode), externalAgentsSentinel}, nil
+	}
+
+	var buf bytes.Buffer
+	agents, externalSelected, err := detectOrSelectAgent(context.Background(), &buf, selectFn, false)
+	if err != nil {
+		t.Fatalf("detectOrSelectAgent() error = %v", err)
+	}
+
+	// Should return only the real agent (sentinel filtered out)
+	if len(agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(agents))
+	}
+	if agents[0].Name() != agent.AgentNameClaudeCode {
+		t.Errorf("agent = %v, want %v", agents[0].Name(), agent.AgentNameClaudeCode)
+	}
+
+	// externalSelected should be true since sentinel was in selection
+	if !externalSelected {
+		t.Error("externalSelected = false, want true")
+	}
+}
+
+func TestDetectOrSelectAgent_ExternalAgentsPreSelected(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+
+	// selectFn returns only a real agent (deselects external agents)
+	selectFn := func(available []string) ([]string, error) {
+		// Verify sentinel is in available options even when pre-selected
+		hasSentinel := false
+		for _, name := range available {
+			if name == externalAgentsSentinel {
+				hasSentinel = true
+				break
+			}
+		}
+		if !hasSentinel {
+			t.Error("external agents sentinel not in available options")
+		}
+		// User deselects external agents, keeps only real agent
+		return []string{string(agent.AgentNameClaudeCode)}, nil
+	}
+
+	var buf bytes.Buffer
+	agents, externalSelected, err := detectOrSelectAgent(context.Background(), &buf, selectFn, true)
+	if err != nil {
+		t.Fatalf("detectOrSelectAgent() error = %v", err)
+	}
+
+	if len(agents) != 1 {
+		t.Fatalf("got %d agents, want 1", len(agents))
+	}
+
+	// externalSelected should be false since user deselected it
+	if externalSelected {
+		t.Error("externalSelected = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds "External Agents" toggle to the agent multi-select during `entire enable`
- Selecting only "External Agents" (without a built-in agent) is now a valid choice
- Persists the choice as `external_agents: true/false` in `.entire/settings.json`

## Test plan
- [x] `mise run fmt && mise run lint` — 0 issues
- [x] `mise run test:ci` — all tests pass (unit + integration + canary E2E)
- [ ] Manual: run `entire enable` in a test repo, verify "External Agents" appears in multi-select
- [ ] Manual: select only "External Agents" and confirm it proceeds without validation error
- [ ] Manual: verify `external_agents: true` in `.entire/settings.json` when accepted
- [ ] Manual: `entire enable --external-agents` works non-interactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes interactive/non-interactive setup flows and persists a new `external_agents` setting, which could affect agent discovery and hook installation behavior across repos.
> 
> **Overview**
> Adds an **"External Agents"** toggle to the agent multi-select during initial setup and `entire configure`, and wires a new `--external-agents` flag into both `configure` and `enable` so external plugin discovery can be explicitly controlled.
> 
> Agent selection now returns both selected built-in agents and whether external discovery was chosen (via an `__external_agents__` sentinel), and this preference is persisted to settings (`external_agents`) during interactive and non-interactive enable paths; `configure`’s add-agents flow can also toggle the setting without requiring new built-in agents to be added. Tests are updated and expanded to cover sentinel splitting and external-selection/pre-selection behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 038346c6215484b7ae062b5e23f75210e1bd7799. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->