### PR TITLE
fix: remove stderr output for ErrEmptyRepository in stop hook

### DIFF
--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -156,9 +156,9 @@ func executeAgentHook(cmd *cobra.Command, agentName types.AgentName, hookName st
 		hookErr = DispatchLifecycleEvent(ctx, ag, event)
 	}
 
-	// ErrEmptyRepository is a graceful no-op: print the message but exit 0
+	// ErrEmptyRepository is a graceful no-op: silently exit 0
 	// so agents don't treat it as a hook failure.
-	if hookErr != nil && errors.Is(hookErr, strategy.ErrEmptyRepository) {
+	if hookErr != nil && event != nil && event.Type == agent.TurnEnd && errors.Is(hookErr, strategy.ErrEmptyRepository) {
 		hookErr = nil
 	}
 


### PR DESCRIPTION
## Summary
- Added ErrEmptyRepository handling — after dispatching a lifecycle event, if the error is
  ErrEmptyRepository, silently set it to nil so the hook exits 0. This prevents agents from
  treating empty repos as hook failures.
<img width="783" height="338" alt="Screenshot 2026-03-18 at 3 32 00 PM" src="https://github.com/user-attachments/assets/bd913225-e417-4293-81e0-5ea1cdc524b5" />

## Test plan
- [x] `mise run lint` passes (0 issues)
- [x] `mise run test:ci` passes (all unit, integration, and canary E2E tests green)
- [x] Verify agents no longer report stop hook errors in empty repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small control-flow change limited to hook execution, only suppressing a known benign error for empty repositories.
> 
> **Overview**
> Ensures hook execution does not surface `strategy.ErrEmptyRepository` as a failure: after `DispatchLifecycleEvent`, the error is detected and cleared so the hook exits successfully without propagating an error.
> 
> This prevents agents that treat any hook failure output as fatal from erroring when running hooks in repositories with no commits yet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2d14636af93924ad253536f2bbf41f6b676bd17. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->