### PR TITLE
Use cleaner base URL in login output

### DIFF
--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -67,9 +67,9 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	}
 
 	fmt.Fprintf(outW, "Device code: %s\n", start.UserCode)
-	approvalURL := start.VerificationURIComplete
+	approvalURL := start.VerificationURI
 	if approvalURL == "" {
-		approvalURL = start.VerificationURI
+		approvalURL = start.VerificationURIComplete
 	}
 
 	if canPromptInteractively() {


### PR DESCRIPTION
## Summary

- Prefer `verification_uri` (base URL) over `verification_uri_complete` (URL with code query param) in `entire login` output
- The device code is already printed on its own line, so repeating it in the URL is redundant noise

### Before

```
Device code: RB3X-56HU
Press Enter to open https://entire.io/cli/auth?code=RB3X-56HU in your browser...
```

### After

```
Device code: RB3X-56HU
Press Enter to open https://entire.io/cli/auth in your browser...
```

## Test plan

- [x] `mise run fmt && mise run lint` passes
- [x] `mise run test:ci` passes (unit + integration + canary)
- [ ] Manual test: run `entire login` and verify the URL no longer includes the code query param

> **Note:** Depends on #723 — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes which verification URL is printed/opened during device login, with a simple fallback if the preferred field is empty.
> 
> **Overview**
> Updates `entire login` to prefer `verification_uri` (base URL) over `verification_uri_complete` when displaying/opening the approval link, falling back to the complete URL only when the base URL is missing. This reduces redundant noise since the device code is already printed separately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e016d62cae9543bf051717b16b8283715114683. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->