### PR TITLE
fix: warn at session start when repo has no commits

### DIFF
--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -308,7 +308,6 @@ func handleLifecycleTurnEnd(ctx context.Context, ag agent.Agent, event *agent.Ev
 	// Return nil (not an error) so the hook exits 0 — agents treat non-zero
 	// exit codes as hook failures. The user was already warned at session start.
 	if repo, err := strategy.OpenRepository(ctx); err == nil && strategy.IsEmptyRepository(repo) {
-		prepareSpan.RecordError(strategy.ErrEmptyRepository)
 		prepareSpan.End()
 		logging.Info(logCtx, "skipping checkpoint - will activate after first commit")
 		return nil

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -155,6 +155,79 @@ func TestHandleLifecycleSessionStart_EmptySessionID(t *testing.T) {
 	}
 }
 
+// mockHookResponseAgent extends mockLifecycleAgent with HookResponseWriter.
+type mockHookResponseAgent struct {
+	mockLifecycleAgent
+
+	lastMessage string
+}
+
+var _ agent.HookResponseWriter = (*mockHookResponseAgent)(nil)
+
+func (m *mockHookResponseAgent) WriteHookResponse(message string) error {
+	m.lastMessage = message
+	return nil
+}
+
+func newMockHookResponseAgent() *mockHookResponseAgent {
+	return &mockHookResponseAgent{
+		mockLifecycleAgent: mockLifecycleAgent{
+			name:      "mock-hrw",
+			agentType: "Mock HRW Agent",
+		},
+	}
+}
+
+func TestHandleLifecycleSessionStart_EmptyRepoWarning(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir) // no commits — empty repo
+	t.Chdir(tmpDir)
+	paths.ClearWorktreeRootCache()
+
+	ag := newMockHookResponseAgent()
+	event := &agent.Event{
+		Type:      agent.SessionStart,
+		SessionID: "test-empty-repo-warning",
+		Timestamp: time.Now(),
+	}
+
+	err := handleLifecycleSessionStart(context.Background(), ag, event)
+	require.NoError(t, err)
+
+	if !strings.Contains(ag.lastMessage, "No commits yet") {
+		t.Errorf("expected message containing 'No commits yet', got: %q", ag.lastMessage)
+	}
+}
+
+func TestHandleLifecycleSessionStart_DefaultMessageWithCommits(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "init.txt", "init")
+	testutil.GitAdd(t, tmpDir, "init.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+	paths.ClearWorktreeRootCache()
+
+	ag := newMockHookResponseAgent()
+	event := &agent.Event{
+		Type:      agent.SessionStart,
+		SessionID: "test-default-message",
+		Timestamp: time.Now(),
+	}
+
+	err := handleLifecycleSessionStart(context.Background(), ag, event)
+	require.NoError(t, err)
+
+	if !strings.Contains(ag.lastMessage, "linked to your next commit") {
+		t.Errorf("expected message containing 'linked to your next commit', got: %q", ag.lastMessage)
+	}
+	if strings.Contains(ag.lastMessage, "No commits yet") {
+		t.Errorf("did not expect empty-repo warning, got: %q", ag.lastMessage)
+	}
+}
+
 // --- handleLifecycleTurnStart tests ---
 
 func TestHandleLifecycleTurnStart_EmptySessionID(t *testing.T) {


### PR DESCRIPTION
## Summary

Alternative to #727. Instead of silently suppressing `ErrEmptyRepository` at the hook level, this:

- **Changes the welcome message** at session start to warn the user: "No commits yet — checkpoints will activate after your first commit" (instead of "This conversation will be linked to your next commit")
- **Returns nil instead of SilentError** from TurnEnd for empty repos, so the hook exits 0 and agents don't treat it as a failure

This way users know *upfront* that nothing will be captured, rather than discovering it after a full session.

## Test plan
- [x] `mise run fmt` passes
- [x] `mise run lint` passes (0 issues)
- [x] `mise run test:ci` passes (all unit, integration, and canary E2E tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral change limited to lifecycle hooks, mainly adjusting user-facing messaging and returning success in the empty-repo case to avoid agent hook failures.
> 
> **Overview**
> Adds an early warning on `SessionStart` when the git repository has no commits yet, updating the hook response message to indicate checkpoints won’t activate until after the first commit.
> 
> Changes `TurnEnd` handling for empty repositories to *gracefully no-op* by returning `nil` (exit 0) instead of propagating a `SilentError`, and updates the corresponding unit test to expect success.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4ee8542e015e81d3b9446c505b5964b5fdb1ad4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->