### PR TITLE
move entire/checkpoints/v1 to dedicated repo

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,5 +1,11 @@
 {
   "enabled": true,
   "local_dev": true,
-  "strategy": "manual-commit"
+  "strategy": "manual-commit",
+  "strategy_options": {
+    "checkpoint_remote": {
+      "provider": "github",
+      "repo": "entireio/cli-checkpoints"
+    }
+  }
 }


### PR DESCRIPTION
let's move checkpoints into a dedicated repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that just adds a `checkpoint_remote` target for checkpoint storage; no runtime logic changes are included.
> 
> **Overview**
> Updates `.entire/settings.json` to add `strategy_options.checkpoint_remote`, pointing checkpoint storage to the GitHub repo `entireio/cli-checkpoints` while keeping the `manual-commit` strategy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c159ae2ff9730afe51a65ddb38a3e367862baf73. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->