### PR TITLE
Add cosign keyless signing for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # cosign keyless signing via Sigstore OIDC
 
 jobs:
   release:
@@ -16,6 +17,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - uses: sigstore/cosign-installer@v4
 
       - uses: jdx/mise-action@v4
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,6 +61,17 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes" # keyless signing (Sigstore/Fulcio OIDC)
+    artifacts: checksum
+
 
 homebrew_casks:
   - name: entire

--- a/README.md
+++ b/README.md
@@ -57,6 +57,40 @@ cd your-project && entire enable
 entire status
 ```
 
+### Download & Verify (manual install)
+
+Pre-built binaries are available from the [GitHub Releases](https://github.com/entireio/cli/releases) page. All release checksums are signed with [cosign](https://docs.sigstore.dev/cosign/overview/) using keyless (ephemeral) signing via Sigstore, so you can verify that artifacts haven't been tampered with.
+
+```bash
+# 1. Set the version and platform
+VERSION="0.5.0"              # replace with desired version
+OS="linux"                   # linux or darwin
+ARCH="amd64"                 # amd64 or arm64
+
+# 2. Download the archive, checksums, signature and certificate
+BASE_URL="https://github.com/entireio/cli/releases/download/v${VERSION}"
+curl -fsSLO "${BASE_URL}/entire_${OS}_${ARCH}.tar.gz"
+curl -fsSLO "${BASE_URL}/checksums.txt"
+curl -fsSLO "${BASE_URL}/checksums.txt.sig"
+curl -fsSLO "${BASE_URL}/checksums.txt.pem"
+
+# 3. Verify the signature on the checksums file
+cosign verify-blob checksums.txt \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'github\.com/entireio/cli'
+
+# 4. Verify the archive against the signed checksums
+sha256sum --check --ignore-missing checksums.txt
+
+# 5. Extract and install
+tar xzf "entire_${OS}_${ARCH}.tar.gz"
+sudo install -m 755 entire /usr/local/bin/entire
+```
+
+> **Note:** On macOS, use `shasum -a 256 --check --ignore-missing checksums.txt` instead of `sha256sum`.
+
 ## Typical Workflow
 
 ### 1. Enable Entire in Your Repository


### PR DESCRIPTION
Configure goreleaser to sign `checksums.txt` using cosign with Sigstore OIDC-based ephemeral keys. Install cosign in the release workflow and grant id-token permission for the OIDC token. Add download and verification instructions to the README Quick Start.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline to use GitHub OIDC and `cosign` for keyless signing, which could break or block publishing if CI permissions or signing steps are misconfigured.
> 
> **Overview**
> Adds **keyless Sigstore/cosign signing** to the release process by granting `id-token: write` and installing `cosign` in the GitHub Actions release workflow.
> 
> Configures GoReleaser to run `cosign sign-blob` on the generated `checksums.txt`, publishing the `.sig` and `.pem` alongside the release.
> 
> Updates the README with **manual download + verification** steps for release artifacts using `cosign verify-blob` and checksum validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 176abe392dedf85e09c22831f301874cb6e8b431. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->