### PR TITLE
make sure we are not trying to open urls automatically if none-interactive

### DIFF
--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -79,13 +79,13 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		waitForEnter()
 
 		fmt.Fprintln(outW)
+
+		if err := openURL(ctx, approvalURL); err != nil {
+			fmt.Fprintf(errW, "Warning: failed to open browser: %v\n", err)
+			fmt.Fprintln(outW, "Open the approval URL in your browser to continue.")
+		}
 	} else {
 		fmt.Fprintf(outW, "Approval URL: %s\n", approvalURL)
-	}
-
-	if err := openURL(ctx, approvalURL); err != nil {
-		fmt.Fprintf(errW, "Warning: failed to open browser: %v\n", err)
-		fmt.Fprintln(outW, "Open the approval URL in your browser to continue.")
 	}
 
 	fmt.Fprintln(outW, "Waiting for approval...")


### PR DESCRIPTION
I just did run `mise run test:ci` locally and my browser got three new tabs for `/approve`. 

Only open URLs if we know we can prompt interactively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes CLI login UX to avoid launching a browser when running non-interactively (e.g., CI), with no auth/token logic changes.
> 
> **Overview**
> Prevents `entire login` from automatically opening the device-approval URL when running in non-interactive contexts. The browser launch is now gated behind `canPromptInteractively()`, so CI/piped runs only print the approval URL instead of spawning browser tabs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceaf0775b7c164ad0dd343e4c29c62b0878568ad. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->