### PR TITLE
fix: increase commit assertion timeout for multi-turn E2E test

### DIFF
--- a/e2e/tests/attribution_test.go
+++ b/e2e/tests/attribution_test.go
@@ -99,7 +99,7 @@ func TestInteractiveAttributionMultiCommitSameSession(t *testing.T) {
 		// Second prompt: modify same file and commit again.
 		s.Send(t, session, "add another stanza to poem.txt about debugging, then create a NEW commit (do not amend). Do not ask for confirmation.")
 		s.WaitFor(t, session, prompt, 90*time.Second)
-		testutil.AssertNewCommits(t, s, 2)
+		testutil.AssertNewCommitsWithTimeout(t, s, 2, 60*time.Second)
 
 		testutil.WaitForCheckpointAdvanceFrom(t, s.Dir, cpBranch1, 15*time.Second)
 		cpID2 := testutil.AssertHasCheckpointTrailer(t, s.Dir, "HEAD")

--- a/e2e/testutil/assertions.go
+++ b/e2e/testutil/assertions.go
@@ -61,7 +61,16 @@ func WaitForFileExists(t *testing.T, dir string, glob string, timeout time.Durat
 // agent's prompt pattern appears before its git commit lands on disk.
 func AssertNewCommits(t *testing.T, s *RepoState, atLeast int) {
 	t.Helper()
-	deadline := time.Now().Add(20 * time.Second)
+	AssertNewCommitsWithTimeout(t, s, atLeast, 20*time.Second)
+}
+
+// AssertNewCommitsWithTimeout is like AssertNewCommits but with a configurable
+// timeout. Use this when WaitFor may settle on stale pane content (e.g.
+// multi-turn interactive tests where the previous turn's prompt is still
+// visible), giving the agent more time to complete its commit.
+func AssertNewCommitsWithTimeout(t *testing.T, s *RepoState, atLeast int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
 	for {
 		out := GitOutput(t, s.Dir, "log", "--oneline", s.HeadBefore+"..HEAD")
 		var lines []string
@@ -72,7 +81,7 @@ func AssertNewCommits(t *testing.T, s *RepoState, atLeast int) {
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("expected at least %d new commit(s), got %d after 20s", atLeast, len(lines))
+			t.Fatalf("expected at least %d new commit(s), got %d after %s", atLeast, len(lines), timeout)
 		}
 		time.Sleep(500 * time.Millisecond)
 	}


### PR DESCRIPTION
## Summary
- Added `AssertNewCommitsWithTimeout` helper with configurable timeout to `e2e/testutil/assertions.go`
- Refactored existing `AssertNewCommits` to delegate to the new helper (preserves all existing call sites)
- Used 60s timeout in `TestInteractiveAttributionMultiCommitSameSession` for the second-turn commit assertion, fixing flaky failures where `WaitFor` matches stale pane content from the previous turn

## Test plan
- [x] `mise run fmt && mise run lint` — passed
- [x] `mise run test:e2e:canary` — vogon passed
- [x] `mise run test:e2e --agent opencode TestInteractiveAttributionMultiCommitSameSession` — passed (46.4s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)