### PR TITLE
chore: Fix Go version in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This repo contains the CLI for Entire.
 
 ## Tech Stack
 
-- Language: Go 1.25.x
+- Language: Go 1.26.x
 - Build tool: mise, go modules
 - Linting: golangci-lint
 


### PR DESCRIPTION
## Summary
- Updated Go version in CLAUDE.md from 1.25.x to 1.26.x to match go.mod (1.26.1) and CONTRIBUTING.md

## Test plan
- No code changes; documentation-only fix