### PR TITLE
fix: redirect questions/support links to Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions and Support
-    url: https://github.com/entireio/cli/discussions
-    about: For general questions, use GitHub Discussions instead of filing an issue.
+    url: https://discord.gg/jZJs3Tue4S
+    about: For general questions, join our Discord instead of filing an issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,7 @@ If you discover a security vulnerability, **do not report it through GitHub Issu
 Contributions and communications are expected to occur through:
 
 - [GitHub Issues](https://github.com/entireio/cli/issues) - Bug reports and feature requests
-- [GitHub Discussions](https://github.com/entireio/cli/discussions) - Questions and general conversation
-- [Discord](https://discord.gg/jZJs3Tue4S) - Real-time chat and support
+- [Discord](https://discord.gg/jZJs3Tue4S) - Questions, general conversation, and real-time support
 
 Please represent the project and community respectfully in all public and private interactions.
 
@@ -327,10 +326,8 @@ type -a entire
 Join the Entire community:
 
 - **Discord** - [Join our server][discord] for discussions and support
-- **GitHub Discussions** - [Join the conversation][discussions]
 
 [discord]: https://discord.gg/jZJs3Tue4S
-[discussions]: https://github.com/entireio/cli/discussions
 
 ---
 


### PR DESCRIPTION
## Summary
- Redirects "Questions and Support" link in issue template from GitHub Discussions to Discord
- Consolidates CONTRIBUTING.md to use Discord as the single community channel for questions and support
- Removes GitHub Discussions references

Closes #752


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates community/support links; no runtime or behavior impact.
> 
> **Overview**
> Updates the **"Questions and Support"** contact link in `.github/ISSUE_TEMPLATE/config.yml` to point to Discord.
> 
> Cleans up `CONTRIBUTING.md` to **standardize on Discord** for questions/support and removes GitHub Discussions references/links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc220b902355c1673abf01204329d849ad53970d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->