### PR TITLE
docs: add Linux PATH instruction for go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ brew install entireio/tap/entire
 # Or install via Go
 go install github.com/entireio/cli/cmd/entire@latest
 
+# Linux: Add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc if not already configured)
+export PATH="$HOME/go/bin:$PATH"
+
 # Enable in your project
 cd your-project && entire enable
 


### PR DESCRIPTION
Fixes #762 

The `go install` method in the README doesn't mention that Linux users need to add `$HOME/go/bin` to their PATH. This adds a note for Arch/Ubuntu/Debian users who encounter "command not found" after installation.