### PR TITLE
fix: strip betterleaks env vars so git subprocesses can authenticate

### DIFF
--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -18,6 +18,28 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
+// gitSubprocessEnv returns a copy of the current process environment suitable for
+// spawning git subprocesses that need credential-helper access.
+//
+// The betterleaks library (used for secret redaction) sets GIT_CONFIG_GLOBAL=/dev/null
+// and GIT_CONFIG_NOSYSTEM=1 in its init(), which prevents git from reading ~/.gitconfig
+// where credential helpers (e.g. gh auth git-credential) are configured. This function
+// strips those vars so that git can authenticate normally, while keeping
+// GIT_TERMINAL_PROMPT=0 to prevent interactive prompts in hook/non-TTY contexts.
+func gitSubprocessEnv() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, e := range env {
+		if strings.HasPrefix(e, "GIT_CONFIG_GLOBAL=") ||
+			strings.HasPrefix(e, "GIT_CONFIG_NOSYSTEM=") ||
+			strings.HasPrefix(e, "GIT_NO_REPLACE_OBJECTS=") {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return append(filtered, "GIT_TERMINAL_PROMPT=0")
+}
+
 // pushBranchIfNeeded pushes a branch to the given target if it has unpushed changes.
 // The target can be a remote name (e.g., "origin") or a URL for direct push.
 // When pushing to a URL, the "has unpushed" optimization is skipped since there are
@@ -125,6 +147,7 @@ func tryPushSessionsCommon(ctx context.Context, remote, branchName string) error
 	// Use --no-verify to prevent recursive hook calls
 	cmd := exec.CommandContext(ctx, "git", "push", "--no-verify", remote, branchName)
 	cmd.Stdin = nil // Disconnect stdin to prevent hanging in hook context
+	cmd.Env = gitSubprocessEnv()
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -161,6 +184,7 @@ func fetchAndMergeSessionsCommon(ctx context.Context, target, branchName string)
 	// Use git CLI for fetch (go-git's fetch can be tricky with auth)
 	fetchCmd := exec.CommandContext(ctx, "git", "fetch", target, refSpec)
 	fetchCmd.Stdin = nil
+	fetchCmd.Env = gitSubprocessEnv()
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
 	}


### PR DESCRIPTION
## Summary

The `betterleaks` library (used for secret redaction) has an `init()` in `config/config.go` that unconditionally sets process-wide environment variables:

```go
func init() {
    env := map[string]string{
        "GIT_CONFIG_GLOBAL":      "/dev/null",
        "GIT_TERMINAL_PROMPT":    "0",
        "GIT_NO_REPLACE_OBJECTS": "1",
        "GIT_CONFIG_NOSYSTEM":    "1",
    }
    for key, value := range env {
        os.Setenv(key, value)
    }
}
```

Since Go's `init()` runs at import time, this poisons the entire process environment. When the pre-push hook spawns `git push`/`git fetch` subprocesses (in `push_common.go`), they inherit `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_NOSYSTEM=1`, which prevents git from reading `~/.gitconfig` — where credential helpers like `gh auth git-credential` are configured. The result is every pre-push hook sync failing with:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

### Fix

Added `gitSubprocessEnv()` helper that strips the betterleaks-injected vars (`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_NOSYSTEM`, `GIT_NO_REPLACE_OBJECTS`) from the environment before spawning git subprocesses, while keeping `GIT_TERMINAL_PROMPT=0` to prevent interactive prompts in hook contexts.

Applied to both `tryPushSessionsCommon` (push) and `fetchAndMergeSessionsCommon` (fetch).

### Note

`checkpoint_remote.go` and `trail_cmd.go` have the same latent bug — they use `os.Environ()` directly which includes the poisoned vars. They may work today because their operations either don't require auth or fail silently, but should be updated to use `gitSubprocessEnv()` too.

Longer term, the `betterleaks` library should scope these env vars to its own subprocesses rather than setting them process-wide.

## Test plan

- [x] Built the fixed binary and ran `entire hooks git pre-push origin` — all syncs succeed
- [ ] Run existing tests: `go test ./cmd/entire/cli/strategy/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to pre-push git subprocess environment setup and primarily affects authentication behavior; main failure mode would be altered credential/config resolution for these commands.
> 
> **Overview**
> Fixes hook-driven session sync failures by introducing `gitSubprocessEnv()` to remove betterleaks-injected vars (`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_NOSYSTEM`, `GIT_NO_REPLACE_OBJECTS`) from the environment passed to git subprocesses, while explicitly enforcing `GIT_TERMINAL_PROMPT=0`.
> 
> Applies this sanitized environment to the `git push` in `tryPushSessionsCommon` and the `git fetch` in `fetchAndMergeSessionsCommon`, restoring access to user credential helpers/config during non-interactive hook runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e86ac476e2216045287b74ef8fd6fa4392ebefd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->