### PR TITLE
Fix: Normalize FilesTouched paths to prevent missing checkpoint trail…

### DIFF
--- a/cmd/entire/cli/strategy/content_overlap.go
+++ b/cmd/entire/cli/strategy/content_overlap.go
@@ -186,10 +186,14 @@ func filesOverlapWithContent(ctx context.Context, repo *git.Repository, shadowBr
 func stagedFilesOverlapWithContent(ctx context.Context, repo *git.Repository, shadowTree *object.Tree, stagedFiles, filesTouched []string) bool {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 
-	// Build set of filesTouched for quick lookup
+	// Build set of filesTouched for quick lookup.
+	// Normalize to base filenames as a fallback to handle path format mismatches
+	// (absolute vs repo-relative) from stale sessions or older CLI versions (#768).
 	touchedSet := make(map[string]bool)
+	touchedByBase := make(map[string]bool) // fallback: basename-only lookup
 	for _, f := range filesTouched {
 		touchedSet[f] = true
+		touchedByBase[filepath.Base(f)] = true
 	}
 
 	// Get HEAD tree to determine if files are being modified or newly created
@@ -232,8 +236,17 @@ func stagedFilesOverlapWithContent(ctx context.Context, repo *git.Repository, sh
 
 	// Check each staged file
 	for _, stagedPath := range stagedFiles {
+		// Try exact path match first, then fall back to basename match.
+		// This handles stale sessions or older CLI versions that stored
+		// absolute paths in FilesTouched (#768).
 		if !touchedSet[stagedPath] {
-			continue // Not in filesTouched, skip
+			if !touchedByBase[filepath.Base(stagedPath)] {
+				continue // Not in filesTouched by exact or basename, skip
+			}
+			logging.Debug(logCtx, "stagedFilesOverlapWithContent: path format mismatch, matched by basename",
+				slog.String("staged_path", stagedPath),
+				slog.Any("files_touched", filesTouched),
+			)
 		}
 
 		// Check if this is a modified file (exists in HEAD) or new file

--- a/cmd/entire/cli/strategy/manual_commit_git.go
+++ b/cmd/entire/cli/strategy/manual_commit_git.go
@@ -141,7 +141,8 @@ func (s *ManualCommitStrategy) SaveStep(ctx context.Context, step StepContext) e
 	state.PromptAttributions = append(state.PromptAttributions, promptAttr)
 
 	// Track touched files (modified, new, and deleted)
-	state.FilesTouched = mergeFilesTouched(state.FilesTouched, step.ModifiedFiles, step.NewFiles, step.DeletedFiles)
+	// Normalize paths to repo-relative form to prevent path format mismatches (#768)
+	state.FilesTouched = mergeFilesTouched(state.WorktreePath, state.FilesTouched, step.ModifiedFiles, step.NewFiles, step.DeletedFiles)
 
 	// On first checkpoint, record the transcript identifier for this session
 	if state.StepCount == 1 {
@@ -273,7 +274,8 @@ func (s *ManualCommitStrategy) SaveTaskStep(ctx context.Context, step TaskStepCo
 	}
 
 	// Track touched files (modified, new, and deleted)
-	state.FilesTouched = mergeFilesTouched(state.FilesTouched, step.ModifiedFiles, step.NewFiles, step.DeletedFiles)
+	// Normalize paths to repo-relative form to prevent path format mismatches (#768)
+	state.FilesTouched = mergeFilesTouched(state.WorktreePath, state.FilesTouched, step.ModifiedFiles, step.NewFiles, step.DeletedFiles)
 
 	// Save updated state
 	if err := s.saveSessionState(ctx, state); err != nil {
@@ -315,15 +317,17 @@ func (s *ManualCommitStrategy) SaveTaskStep(ctx context.Context, step TaskStepCo
 }
 
 // mergeFilesTouched merges multiple file lists into existing touched files, deduplicating.
-func mergeFilesTouched(existing []string, fileLists ...[]string) []string {
+// All paths are normalized to repo-relative form using worktreePath to prevent
+// path format mismatches between absolute agent paths and repo-relative git paths (#768).
+func mergeFilesTouched(worktreePath string, existing []string, fileLists ...[]string) []string {
 	seen := make(map[string]bool)
 	for _, f := range existing {
-		seen[f] = true
+		seen[normalizeToRepoRelative(f, worktreePath)] = true
 	}
 
 	for _, list := range fileLists {
 		for _, f := range list {
-			seen[f] = true
+			seen[normalizeToRepoRelative(f, worktreePath)] = true
 		}
 	}
 
@@ -335,6 +339,18 @@ func mergeFilesTouched(existing []string, fileLists ...[]string) []string {
 	// Sort for deterministic output
 	sort.Strings(result)
 	return result
+}
+
+// normalizeToRepoRelative converts a file path to repo-relative form.
+// If the path is already relative or worktreePath is empty, the path is returned as-is.
+func normalizeToRepoRelative(filePath, worktreePath string) string {
+	if worktreePath == "" || !filepath.IsAbs(filePath) {
+		return filePath
+	}
+	if rel := paths.ToRelativePath(filePath, worktreePath); rel != "" {
+		return rel
+	}
+	return filePath
 }
 
 // accumulateTokenUsage adds new token usage to existing accumulated usage.


### PR DESCRIPTION
Issue
Commits never receive Entire-Checkpoint trailers despite hooks running correctly. The prepare-commit-msg hook finds sessions but logs "no content to link" for all of them.

The root cause is a path format mismatch in 
stagedFilesOverlapWithContent
. 
getStagedFiles()
 returns repo-relative paths (e.g., src/screens/SessionDetail.tsx) from git diff --cached --name-only, but state.FilesTouched stores the exact paths the agent provides — often absolute (e.g., /Users/alex/project/src/screens/SessionDetail.tsx). The touchedSet[stagedPath] lookup silently fails, so no file ever reaches the content comparison logic.

A contributing factor is that opencode export returns invalid JSON, which prevents the active session's live transcript fallback from detecting content.

Solution
Normalize at write time: 
mergeFilesTouched
 now accepts a worktreePath parameter and normalizes all incoming paths to repo-relative form via a new 
normalizeToRepoRelative
 helper before storing them in state.FilesTouched.
Basename fallback at read time: 
stagedFilesOverlapWithContent
 now builds a secondary touchedByBase map keyed by filepath.Base(). When the exact path lookup fails, it falls back to basename matching to handle stale sessions from older CLI versions.
Debug logging: A new log line ("path format mismatch, matched by basename") makes this class of silent failure visible in future.
