### PR TITLE
fix: handle copilot-cli Edit mode in E2E interactive sessions

### DIFF
--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -130,9 +130,52 @@ type CopilotSession struct {
 
 func (cs *CopilotSession) Send(input string) error {
 	preSend := stableContent(cs.Capture())
-	// Send text and Enter separately, same as TmuxSession.Send.
-	if err := cs.SendKeys(input); err != nil {
+
+	if err := cs.sendOnce(input, preSend); err != nil {
 		return err
+	}
+
+	// Copilot CLI's autocomplete can non-deterministically trigger during
+	// text input (e.g. a "/" in "docs/red.md" opens the slash-command menu).
+	// If detected, dismiss with Escape, clear the input, and retry once.
+	time.Sleep(300 * time.Millisecond)
+	if isAutocompleteMenu(cs.Capture()) {
+		if err := cs.SendKeys("Escape"); err != nil {
+			return err
+		}
+		time.Sleep(200 * time.Millisecond)
+		// Ctrl+U clears the current input line.
+		if err := cs.SendKeys("C-u"); err != nil {
+			return err
+		}
+		time.Sleep(200 * time.Millisecond)
+		if err := cs.sendOnce(input, stableContent(cs.Capture())); err != nil {
+			return err
+		}
+	}
+
+	// Wait for the terminal to reflect the echoed input, then snapshot.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(200 * time.Millisecond)
+		current := stableContent(cs.Capture())
+		if current != preSend {
+			cs.stableAtSend = current
+			return nil
+		}
+	}
+	cs.stableAtSend = stableContent(cs.Capture())
+	return nil
+}
+
+// sendOnce types the input text, sends Enter, and handles Edit mode fallback.
+func (cs *CopilotSession) sendOnce(input string, preSend string) error {
+	// Use -l (literal) flag to prevent tmux from interpreting characters
+	// in the prompt text as special key names.
+	args := []string{"send-keys", "-l", "-t", cs.name, input}
+	cmd := exec.Command("tmux", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tmux send-keys -l: %w\n%s", err, out)
 	}
 	time.Sleep(200 * time.Millisecond)
 	if err := cs.SendKeys("Enter"); err != nil {
@@ -157,18 +200,6 @@ func (cs *CopilotSession) Send(input string) error {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-
-	// Wait for the terminal to reflect the echoed input, then snapshot.
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		time.Sleep(200 * time.Millisecond)
-		current := stableContent(cs.Capture())
-		if current != preSend {
-			cs.stableAtSend = current
-			return nil
-		}
-	}
-	cs.stableAtSend = stableContent(cs.Capture())
 	return nil
 }
 
@@ -182,6 +213,24 @@ func isEditMode(content string) bool {
 	for i := len(lines) - 1; i >= 0 && i >= len(lines)-3; i-- {
 		if strings.Contains(lines[i], statusPhrase) {
 			return true
+		}
+	}
+	return false
+}
+
+// isAutocompleteMenu detects copilot's slash-command autocomplete dropdown.
+// When triggered, copilot shows a list of commands starting with "▋  /"
+// below the input line, preventing prompt submission.
+func isAutocompleteMenu(content string) bool {
+	lines := strings.Split(content, "\n")
+	matches := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "▋") && strings.Contains(trimmed, "/") {
+			matches++
+			if matches >= 2 {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
## What broke

`TestInteractiveAttributionMultiCommitSameSession` flaky timeout for copilot-cli on commit b752a118. The second prompt was typed into copilot-cli's "Edit" mode where Enter inserts a newline instead of submitting. The agent never started processing, causing a 90s timeout.

## What was fixed

Added `CopilotSession` wrapper around `TmuxSession` that detects Edit mode (via "ctrl+s" in the status bar) and falls back to sending Ctrl+S when Enter doesn't submit. This handles copilot-cli's non-deterministic mode switching between Chat and Edit modes after completing a prompt.

## Notes

Auto-generated fix from e2e failure on b752a11895669ca3c534b21bde95eec627c44b96 (main)
Failed agent: copilot-cli

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to E2E `copilot-cli` interactive harness and only alters how prompts are submitted, with minimal impact outside test execution.
> 
> **Overview**
> Fixes flakiness in `copilot-cli` interactive E2E sessions by introducing a `CopilotSession` wrapper that handles Copilot CLI’s non-deterministic *Chat vs Edit* input modes.
> 
> After sending a prompt and `Enter`, the session now detects Edit mode via the `ctrl+s` status hint and sends `Ctrl+S` to submit when needed; `StartSession` returns this wrapper instead of the raw `TmuxSession`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b18b3b8f710cb227bab6091d5fd054865232d971. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->