### PR TITLE
capture scenario where git hooks are overwritten during a running agent prompt

### DIFF
--- a/cmd/entire/cli/integration_test/hook_overwrite_test.go
+++ b/cmd/entire/cli/integration_test/hook_overwrite_test.go
@@ -66,8 +66,10 @@ func TestHookOverwrite_MidTurnWipe_NextPromptRecovers(t *testing.T) {
 		"hooks should be detected as overwritten")
 
 	// Second commit — hooks are gone, use plain go-git commit (no binary invoked).
-	// This simulates what happens in the real world: git runs the husky hook script,
-	// which doesn't call `entire`, so no trailer is added.
+	// This simulates the real-world situation after husky/lefthook has overwritten
+	// our hooks: a commit is made where git would run a third-party hook that does
+	// not call `entire`, so from Entire's perspective no hooks run and no trailer
+	// is added.
 	env.GitAdd("fileB.go")
 	env.GitCommit("Add file B")
 	cpID2 := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
@@ -78,17 +80,16 @@ func TestHookOverwrite_MidTurnWipe_NextPromptRecovers(t *testing.T) {
 	err = env.SimulateStop(sess.ID, sess.TranscriptPath)
 	require.NoError(t, err)
 
-	// === Prompt 2: EnsureSetup should reinstall hooks ===
-	sess2 := env.NewSession()
+	// === Prompt 2: same session, next turn — EnsureSetup should reinstall hooks ===
 
 	env.WriteFile("fileC.go", "package main\n\nfunc C() {}\n")
 
-	sess2.CreateTranscript("Create file C", []FileChange{
+	sess.CreateTranscript("Create file C", []FileChange{
 		{Path: "fileC.go", Content: "package main\n\nfunc C() {}\n"},
 	})
 
 	err = env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(
-		sess2.ID, "Create file C", sess2.TranscriptPath)
+		sess.ID, "Create file C", sess.TranscriptPath)
 	require.NoError(t, err)
 
 	// Verify hooks were reinstalled by EnsureSetup
@@ -102,8 +103,8 @@ func TestHookOverwrite_MidTurnWipe_NextPromptRecovers(t *testing.T) {
 		assert.NoError(t, err, "backup %s.pre-entire should exist after reinstall", hookName)
 	}
 
-	// Third commit — hooks restored, binary invoked again → trailer added
-	env.GitCommitWithShadowHooks("Add file C", "fileC.go")
+	// Third commit — hooks restored, agent commits (no TTY) → trailer added via fast path
+	env.GitCommitWithShadowHooksAsAgent("Add file C", "fileC.go")
 	cpID3 := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
 	assert.NotEmpty(t, cpID3,
 		"third commit should have trailer (hooks reinstalled by prompt 2)")


### PR DESCRIPTION
This is in context of: https://github.com/entireio/cli/issues/784

It validates the assumption around hooks being overwritten but not the exact scenario described there. In the issue the next prompt fails too but this test shows our restore git hook logic works and recovers for the next prompt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an integration test only, but it touches git hook state on disk and could be flaky if the test harness or hook detection changes.
> 
> **Overview**
> Adds a new integration test (`hook_overwrite_test.go`) that reproduces the issue-784 scenario where third-party tools overwrite managed git hooks *mid prompt*, causing an intermediate commit to miss the checkpoint trailer.
> 
> The test then starts a second prompt to assert `EnsureSetup` reinstalls hooks (including creating `.pre-entire` backups for chaining) and that subsequent commits again include a checkpoint trailer with a new checkpoint ID.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b4aa6dcb455eb0631498ba68883389fc32be9bc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->