### PR TITLE
Fix git hook chaining for frameworks using basename resolution

### DIFF
--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -237,6 +237,12 @@ func InstallGitHook(ctx context.Context, silent, localDev, absolutePath bool) (i
 				if err := os.Rename(hookPath, backupPath); err != nil {
 					return installedCount, fmt.Errorf("failed to back up %s: %w", spec.name, err)
 				}
+				// Ensure backup is executable — os.Rename preserves permissions,
+				// but on some platforms (Windows/Git Bash) the execute bit can be lost.
+				// The chain script checks [ -x ] and silently skips non-executable backups.
+				if err := os.Chmod(backupPath, 0o755); err != nil { //nolint:gosec // Git hooks require executable permissions
+					return installedCount, fmt.Errorf("failed to set permissions on %s: %w", backupPath, err)
+				}
 				fmt.Fprintf(os.Stderr, "[entire] Backed up existing %s to %s%s\n", spec.name, spec.name, backupSuffix)
 			} else {
 				fmt.Fprintf(os.Stderr, "[entire] Warning: replacing %s (backup %s%s already exists from a previous install)\n", spec.name, spec.name, backupSuffix)
@@ -333,13 +339,26 @@ func RemoveGitHook(ctx context.Context) (int, error) {
 
 // generateChainedContent appends a chain call to the base hook content,
 // so the pre-existing hook (backed up to .pre-entire) is called after our hook.
+//
+// The chain uses a temporary symlink with the original hook name so that
+// hook frameworks like Husky (which use basename "$0" to resolve the hook
+// type) see the correct name instead of "pre-push.pre-entire".
 func generateChainedContent(baseContent, hookName string) string {
 	return baseContent + fmt.Sprintf(`%s
 _entire_hook_dir="$(dirname "$0")"
-if [ -x "$_entire_hook_dir/%s%s" ]; then
-    "$_entire_hook_dir/%s%s" "$@"
+_entire_backup="$_entire_hook_dir/%s%s"
+if [ -x "$_entire_backup" ]; then
+    # Invoke via a temp symlink so basename "$0" returns the original
+    # hook name — required by frameworks like Husky that resolve hooks
+    # via basename.
+    _entire_chain_dir="$(mktemp -d)" && \
+        ln -sf "$_entire_backup" "$_entire_chain_dir/%s" && \
+        "$_entire_chain_dir/%s" "$@"; _entire_rc=$?
+    rm -f "$_entire_chain_dir/%s" 2>/dev/null
+    rmdir "$_entire_chain_dir" 2>/dev/null
+    exit "$_entire_rc"
 fi
-`, chainComment, hookName, backupSuffix, hookName, backupSuffix)
+`, chainComment, hookName, backupSuffix, hookName, hookName, hookName)
 }
 
 // hookCmdPrefix returns the command prefix for hook scripts and warning messages.

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -1335,3 +1335,62 @@ func TestRemoveGitHook_PermissionDenied(t *testing.T) {
 		t.Errorf("error should mention 'failed to remove hooks', got: %v", err)
 	}
 }
+
+func TestInstallGitHook_BackupPreservesExecutePermission(t *testing.T) {
+	_, hooksDir := initHooksTestRepo(t)
+
+	// Create a custom hook with restricted permissions (simulate Windows/Git Bash
+	// where execute bits may be lost during rename)
+	hookPath := filepath.Join(hooksDir, "pre-push")
+	customContent := "#!/bin/sh\necho 'custom pre-push'\n"
+	if err := os.WriteFile(hookPath, []byte(customContent), 0o644); err != nil {
+		t.Fatalf("failed to create hook: %v", err)
+	}
+
+	_, err := InstallGitHook(context.Background(), true, false, false)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+
+	// Verify backup exists and is executable (chmod 0o755 applied after rename)
+	backupPath := filepath.Join(hooksDir, "pre-push"+backupSuffix)
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		t.Fatalf("backup should exist: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("backup permissions = %o, want executable (at least 0o755)", info.Mode().Perm())
+	}
+}
+
+func TestGenerateChainedContent_UsesSymlinkForBasenameCompat(t *testing.T) {
+	t.Parallel()
+
+	base := "#!/bin/sh\n# Entire CLI hooks\nentire hooks git pre-push 2>/dev/null || true\n"
+	result := generateChainedContent(base, "pre-push")
+
+	// Should contain symlink-based chain (mktemp + ln -sf) for basename compatibility
+	if !strings.Contains(result, "mktemp -d") {
+		t.Error("chain should use mktemp for temp directory")
+	}
+	if !strings.Contains(result, "ln -sf") {
+		t.Error("chain should create a symlink to backup")
+	}
+	// The symlink target should use the original hook name (not .pre-entire suffix)
+	// so that basename "$0" resolves correctly for frameworks like Husky
+	if !strings.Contains(result, `"$_entire_chain_dir/pre-push"`) {
+		t.Error("chain symlink should use original hook name (pre-push), not the .pre-entire name")
+	}
+	// Should still reference the backup file
+	if !strings.Contains(result, "pre-push"+backupSuffix) {
+		t.Error("chain should reference the .pre-entire backup file")
+	}
+	// Should clean up temp dir
+	if !strings.Contains(result, "rmdir") {
+		t.Error("chain should clean up temp directory")
+	}
+	// Should propagate exit code
+	if !strings.Contains(result, "_entire_rc") {
+		t.Error("chain should capture and propagate exit code")
+	}
+}


### PR DESCRIPTION
## Summary
This PR fixes git hook chaining to work correctly with hook frameworks like Husky that use `basename "$0"` to determine the hook type. Previously, when chaining to backed-up hooks, the script would be invoked with the `.pre-entire` suffix, causing basename-based resolution to fail.

## Key Changes

- **Symlink-based hook invocation**: Modified `generateChainedContent()` to create a temporary symlink with the original hook name (e.g., `pre-push`) pointing to the backup file (e.g., `pre-push.pre-entire`). This ensures frameworks using `basename "$0"` see the correct hook name.

- **Backup permission preservation**: Added explicit `os.Chmod(backupPath, 0o755)` after renaming the original hook to ensure the backup is executable. This addresses issues on Windows/Git Bash where execute bits can be lost during file operations.

- **Improved chain script robustness**: The new chain implementation:
  - Uses `mktemp -d` to create a temporary directory for the symlink
  - Properly captures and propagates the exit code from the chained hook
  - Cleans up temporary files and directories after execution
  - Silently skips non-executable backups (via `[ -x ]` check)

## Implementation Details

The chain script now follows this flow:
1. Create a temporary directory
2. Create a symlink with the original hook name pointing to the backup
3. Execute the backup via the symlink (so `basename "$0"` resolves correctly)
4. Capture the exit code
5. Clean up the symlink and temporary directory
6. Exit with the captured code

This approach maintains backward compatibility while fixing integration with hook frameworks that rely on hook name resolution.

https://claude.ai/code/session_0175aPSzQdbjriiAyZn6k3Qi