### PR TITLE
Fix checkpoint_remote silently falling back to origin on owner mismatch

### DIFF
--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -76,9 +76,11 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 		return ps
 	}
 
-	// Get the push remote URL for protocol detection and fork detection
+	// Get the push remote URL for protocol detection
 	pushRemoteURL, err := getRemoteURL(ctx, pushRemoteName)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "[entire] Warning: checkpoint_remote is configured (%s) but could not get push remote URL: %v\n", config.Repo, err)
+		fmt.Fprintln(os.Stderr, "[entire] Checkpoints will be pushed to origin instead. Check your git remote configuration.")
 		logging.Debug(ctx, "checkpoint-remote: could not get push remote URL, skipping",
 			slog.String("remote", pushRemoteName),
 			slog.String("error", err.Error()),
@@ -86,9 +88,11 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 		return ps
 	}
 
-	// Parse the push remote URL once for both fork detection and URL derivation
+	// Parse the push remote URL for protocol detection and URL derivation
 	pushInfo, err := parseGitRemoteURL(pushRemoteURL)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "[entire] Warning: checkpoint_remote is configured (%s) but could not parse push remote URL: %v\n", config.Repo, err)
+		fmt.Fprintln(os.Stderr, "[entire] Checkpoints will be pushed to origin instead. Check your git remote configuration.")
 		logging.Warn(ctx, "checkpoint-remote: could not parse push remote URL",
 			slog.String("remote", pushRemoteName),
 			slog.String("error", err.Error()),
@@ -96,19 +100,22 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 		return ps
 	}
 
-	// Fork detection: compare owners
+	// Log when push remote owner differs from checkpoint remote owner.
+	// Previously this skipped checkpoint_remote entirely (fork detection),
+	// but the user explicitly configured a checkpoint remote — respect that choice.
 	checkpointOwner := config.Owner()
 	if pushInfo.owner != "" && checkpointOwner != "" && !strings.EqualFold(pushInfo.owner, checkpointOwner) {
-		logging.Debug(ctx, "checkpoint-remote: push remote owner differs from checkpoint remote owner, skipping (fork detected)",
+		logging.Debug(ctx, "checkpoint-remote: push remote owner differs from checkpoint remote owner, proceeding with configured checkpoint remote",
 			slog.String("push_owner", pushInfo.owner),
 			slog.String("checkpoint_owner", checkpointOwner),
 		)
-		return ps
 	}
 
 	// Derive checkpoint URL using same protocol as push remote
 	checkpointURL, err := deriveCheckpointURLFromInfo(pushInfo, config)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "[entire] Warning: checkpoint_remote is configured (%s) but could not derive URL from push remote: %v\n", config.Repo, err)
+		fmt.Fprintln(os.Stderr, "[entire] Checkpoints will be pushed to origin instead. Check your checkpoint_remote settings.")
 		logging.Warn(ctx, "checkpoint-remote: could not derive URL from push remote",
 			slog.String("remote", pushRemoteName),
 			slog.String("repo", config.Repo),

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -490,9 +490,10 @@ func TestResolvePushSettings_ForkDetection(t *testing.T) {
 	t.Chdir(localDir)
 
 	ps := resolvePushSettings(ctx, "origin")
-	// Should fall back to origin since fork detected (alice != org)
-	assert.False(t, ps.hasCheckpointURL())
-	assert.Equal(t, "origin", ps.pushTarget())
+	// Should proceed with checkpoint remote even when owners differ —
+	// the user explicitly configured it, respect that choice.
+	assert.True(t, ps.hasCheckpointURL())
+	assert.Equal(t, "git@github.com:org/checkpoints.git", ps.pushTarget())
 	assert.False(t, ps.pushDisabled)
 }
 


### PR DESCRIPTION
## Summary

- **Removed fork detection skip** in `resolvePushSettings()` — when a user explicitly configures `checkpoint_remote`, that choice is now respected regardless of owner mismatch between push remote and checkpoint remote
- **Added user-visible stderr warnings** for all fallback paths (remote URL lookup failure, URL parse failure, URL derivation failure) so users know when checkpoint_remote is being skipped

## Context

When `checkpoint_remote` was configured (e.g., `{"provider": "github", "repo": "alice/checkpoints"}`) but the origin remote had a different owner (e.g., `org/work-repo`), fork detection silently skipped the checkpoint remote and pushed to origin instead. All failure messages went to debug/warn logs in `.entire/logs/` — the user had no idea their config was being ignored.

Reproduced with: origin = `hydeparksda/invite-automation`, checkpoint_remote = `blackgirlbytes/genuary2026`.

Fixes #800

## Test plan

- [x] Unit tests pass (`mise run test`)
- [x] Integration tests pass (`mise run test:integration`)
- [x] Lint passes (`mise run lint`)
- [x] Updated `TestResolvePushSettings_ForkDetection` to expect checkpoint URL is set even with owner mismatch
- [ ] Manual verification: configure checkpoint_remote with different owner than origin, push, confirm checkpoints land on checkpoint remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)