### PR TITLE
Remove gnome-keyring setup from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup Keyring
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gnome-keyring
-          echo 'somecredstorepass' | gnome-keyring-daemon --unlock
       - uses: jdx/mise-action@v4
       - name: Tests
         run: mise run test:ci


### PR DESCRIPTION
## Summary
- Remove the "Setup Keyring" step from CI that installed and unlocked gnome-keyring on Ubuntu
- The `auth` package already uses `keyring.MockInit()` in its `TestMain`, which replaces the system keyring with an in-memory mock — no OS keyring needed
- Speeds up CI by eliminating `apt-get update` + `apt-get install`

## Test plan
- [x] `mise run test:ci` passes locally without system keyring (all 53 tests pass, including auth tests)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that reduces CI dependencies; potential risk is uncovering hidden reliance on OS keyring during tests in GitHub Actions.
> 
> **Overview**
> Simplifies the GitHub Actions test workflow by removing the `gnome-keyring` installation/unlock step, leaving CI to just checkout, setup `mise`, and run `mise run test:ci`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6d878fc71cc2a538be4204ff3e0330d4c19c982. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->