### PR TITLE
fix: handle Claude Code 2.x JSON array response in summarization

### DIFF
--- a/cmd/entire/cli/summarize/claude.go
+++ b/cmd/entire/cli/summarize/claude.go
@@ -68,7 +68,7 @@ type ClaudeGenerator struct {
 
 // claudeCLIResponse represents the JSON response from the Claude CLI.
 // Claude Code 1.x returns a single object: {"result": "..."}
-// Claude Code 2.x returns an array: [{type:"system",...}, {type:"result", result:"..."}]
+// Claude Code 2.x returns an array: [{"type":"system",...}, {"type":"result", "result":"..."}]
 type claudeCLIResponse struct {
 	Type   string `json:"type"`
 	Result string `json:"result"`
@@ -141,7 +141,7 @@ func (g *ClaudeGenerator) Generate(ctx context.Context, input Input) (*checkpoin
 	// Claude Code 1.x returns a single JSON object; try that as a fallback.
 	resultJSON, err := parseClaudeCLIResult(stdout.Bytes())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse claude CLI response: %w", err)
 	}
 
 	// Try to extract JSON if it's wrapped in markdown code blocks
@@ -164,10 +164,18 @@ func parseClaudeCLIResult(data []byte) (string, error) {
 	// Try array format first (Claude Code 2.x)
 	var responses []claudeCLIResponse
 	if err := json.Unmarshal(data, &responses); err == nil {
+		hasEmptyResultElement := false
 		for _, r := range responses {
-			if r.Type == "result" && r.Result != "" {
+			if r.Type == "result" {
+				if r.Result == "" {
+					hasEmptyResultElement = true
+					continue
+				}
 				return r.Result, nil
 			}
+		}
+		if hasEmptyResultElement {
+			return "", errors.New("claude CLI response contained empty result")
 		}
 		return "", errors.New("claude CLI response array contained no result element")
 	}

--- a/cmd/entire/cli/summarize/claude.go
+++ b/cmd/entire/cli/summarize/claude.go
@@ -67,7 +67,10 @@ type ClaudeGenerator struct {
 }
 
 // claudeCLIResponse represents the JSON response from the Claude CLI.
+// Claude Code 1.x returns a single object: {"result": "..."}
+// Claude Code 2.x returns an array: [{type:"system",...}, {type:"result", result:"..."}]
 type claudeCLIResponse struct {
+	Type   string `json:"type"`
 	Result string `json:"result"`
 }
 
@@ -133,14 +136,13 @@ func (g *ClaudeGenerator) Generate(ctx context.Context, input Input) (*checkpoin
 		return nil, fmt.Errorf("failed to run claude CLI: %w", err)
 	}
 
-	// Parse the CLI response
-	var cliResponse claudeCLIResponse
-	if err := json.Unmarshal(stdout.Bytes(), &cliResponse); err != nil {
-		return nil, fmt.Errorf("failed to parse claude CLI response: %w", err)
+	// Parse the CLI response.
+	// Claude Code 2.x returns a JSON array of messages; extract the "result" element.
+	// Claude Code 1.x returns a single JSON object; try that as a fallback.
+	resultJSON, err := parseClaudeCLIResult(stdout.Bytes())
+	if err != nil {
+		return nil, err
 	}
-
-	// The result field contains the actual JSON summary
-	resultJSON := cliResponse.Result
 
 	// Try to extract JSON if it's wrapped in markdown code blocks
 	resultJSON = extractJSONFromMarkdown(resultJSON)
@@ -152,6 +154,33 @@ func (g *ClaudeGenerator) Generate(ctx context.Context, input Input) (*checkpoin
 	}
 
 	return &summary, nil
+}
+
+// parseClaudeCLIResult extracts the result string from the Claude CLI JSON output.
+// It handles both formats:
+//   - Claude Code 2.x: JSON array with a "type":"result" element
+//   - Claude Code 1.x: single JSON object with a "result" field
+func parseClaudeCLIResult(data []byte) (string, error) {
+	// Try array format first (Claude Code 2.x)
+	var responses []claudeCLIResponse
+	if err := json.Unmarshal(data, &responses); err == nil {
+		for _, r := range responses {
+			if r.Type == "result" && r.Result != "" {
+				return r.Result, nil
+			}
+		}
+		return "", errors.New("claude CLI response array contained no result element")
+	}
+
+	// Fall back to single object (Claude Code 1.x)
+	var single claudeCLIResponse
+	if err := json.Unmarshal(data, &single); err != nil {
+		return "", fmt.Errorf("failed to parse claude CLI response: %w", err)
+	}
+	if single.Result == "" {
+		return "", errors.New("claude CLI response contained empty result")
+	}
+	return single.Result, nil
 }
 
 // buildSummarizationPrompt creates the prompt for the Claude CLI.

--- a/cmd/entire/cli/summarize/claude_test.go
+++ b/cmd/entire/cli/summarize/claude_test.go
@@ -347,6 +347,11 @@ func TestParseClaudeCLIResult(t *testing.T) {
 			input:       `{"result": ""}`,
 			expectError: "empty result",
 		},
+		{
+			name:        "array with empty result element",
+			input:       `[{"type":"system"},{"type":"result","result":""}]`,
+			expectError: "empty result",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/entire/cli/summarize/claude_test.go
+++ b/cmd/entire/cli/summarize/claude_test.go
@@ -133,6 +133,67 @@ func TestClaudeGenerator_NonZeroExit(t *testing.T) {
 	}
 }
 
+func TestClaudeGenerator_ArrayResponse(t *testing.T) {
+	t.Parallel()
+
+	summaryJSON := `{\"intent\":\"Fix a bug\",\"outcome\":\"Bug fixed\",\"learnings\":{\"repo\":[],\"code\":[],\"workflow\":[]},\"friction\":[],\"open_items\":[]}`
+	// Claude Code 2.x array format with system, assistant, and result elements
+	response := `[{"type":"system","system":"..."},{"type":"assistant","message":"..."},{"type":"result","result":"` + summaryJSON + `"}]`
+
+	gen := &ClaudeGenerator{
+		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
+		},
+	}
+
+	input := Input{
+		Transcript: []Entry{
+			{Type: EntryTypeUser, Content: "Fix the bug"},
+		},
+	}
+
+	summary, err := gen.Generate(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if summary.Intent != "Fix a bug" {
+		t.Errorf("unexpected intent: %s", summary.Intent)
+	}
+
+	if summary.Outcome != "Bug fixed" {
+		t.Errorf("unexpected outcome: %s", summary.Outcome)
+	}
+}
+
+func TestClaudeGenerator_ArrayResponseNoResult(t *testing.T) {
+	t.Parallel()
+
+	// Array with no "result" type element
+	response := `[{"type":"system","system":"..."},{"type":"assistant","message":"..."}]`
+
+	gen := &ClaudeGenerator{
+		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
+		},
+	}
+
+	input := Input{
+		Transcript: []Entry{
+			{Type: EntryTypeUser, Content: "Hello"},
+		},
+	}
+
+	_, err := gen.Generate(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected error when array has no result element")
+	}
+
+	if !strings.Contains(err.Error(), "no result element") {
+		t.Errorf("expected 'no result element' error, got: %v", err)
+	}
+}
+
 func TestClaudeGenerator_ErrorCases(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -244,6 +305,70 @@ func TestClaudeGenerator_MarkdownCodeBlock(t *testing.T) {
 
 	if summary.Intent != "Test markdown extraction" {
 		t.Errorf("unexpected intent: %s", summary.Intent)
+	}
+}
+
+func TestParseClaudeCLIResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError string
+	}{
+		{
+			name:     "single object (1.x format)",
+			input:    `{"result": "the summary"}`,
+			expected: "the summary",
+		},
+		{
+			name:     "array with result (2.x format)",
+			input:    `[{"type":"system","system":"..."},{"type":"result","result":"the summary"}]`,
+			expected: "the summary",
+		},
+		{
+			name:     "array picks result type over others",
+			input:    `[{"type":"assistant","result":"wrong"},{"type":"result","result":"correct"}]`,
+			expected: "correct",
+		},
+		{
+			name:        "array with no result element",
+			input:       `[{"type":"system"},{"type":"assistant"}]`,
+			expectError: "no result element",
+		},
+		{
+			name:        "invalid JSON",
+			input:       `not json at all`,
+			expectError: "parse claude CLI response",
+		},
+		{
+			name:        "single object with empty result",
+			input:       `{"result": ""}`,
+			expectError: "empty result",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := parseClaudeCLIResult([]byte(tt.input))
+			if tt.expectError != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectError)
+				}
+				if !strings.Contains(err.Error(), tt.expectError) {
+					t.Errorf("expected error containing %q, got: %v", tt.expectError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Claude Code 2.x changed `--print --output-format json` to return a JSON array of messages (`[{type:"system",...}, {type:"result", result:"..."}]`) instead of a single object. This breaks `entire explain --generate` and auto-summarization on commit, since the Go code tries to unmarshal the array into a single `claudeCLIResponse` struct.

This PR updates `parseClaudeCLIResult()` to try the array format first (extracting the element with `type: "result"`), falling back to the single-object format for Claude Code 1.x backward compatibility.

Fixes #750

## What changed

- Added `Type` field to `claudeCLIResponse` struct
- Extracted parsing logic into `parseClaudeCLIResult()` that handles both formats
- Array format (2.x): iterates elements, returns the one with `type: "result"`
- Single-object format (1.x): fallback path, unchanged behavior

## Test plan

- [x] `mise run fmt` — no formatting issues
- [x] `mise run lint` — 0 issues
- [x] `mise run test` — all tests pass
- [x] New unit test: `TestParseClaudeCLIResult` — covers both formats, edge cases (no result element, invalid JSON, empty result)
- [x] New integration test: `TestClaudeGenerator_ArrayResponse` — full Generate() flow with 2.x array format
- [x] New error test: `TestClaudeGenerator_ArrayResponseNoResult` — array without result element
- [x] Existing tests pass unchanged (1.x format backward compat)