### PR TITLE
feat: entire session sub commands

### DIFF
--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -35,6 +35,12 @@ Examples:
   entire sessions info <session-id>        Show session details
   entire sessions info <session-id> --json Output as JSON
   entire sessions stop                     Interactive stop`,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := paths.WorktreeRoot(cmd.Context()); err != nil {
+				return errors.New("not a git repository")
+			}
+			return nil
+		},
 	}
 
 	cmd.AddCommand(newListCmd())
@@ -72,11 +78,6 @@ Examples:
 
 			if allFlag && sessionID != "" {
 				return errors.New("--all and session ID argument are mutually exclusive")
-			}
-
-			// Check if in git repository
-			if _, err := paths.WorktreeRoot(ctx); err != nil {
-				return errors.New("not a git repository")
 			}
 
 			return runStop(ctx, cmd, sessionID, allFlag, forceFlag)
@@ -180,13 +181,7 @@ For active sessions only, use 'entire status'.
 Examples:
   entire sessions list    List all sessions across all worktrees`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			ctx := cmd.Context()
-
-			if _, err := paths.WorktreeRoot(ctx); err != nil {
-				return errors.New("not a git repository")
-			}
-
-			return runSessionList(ctx, cmd)
+			return runSessionList(cmd.Context(), cmd)
 		},
 	}
 
@@ -298,13 +293,7 @@ Examples:
   entire sessions info <session-id> --json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-
-			if _, err := paths.WorktreeRoot(ctx); err != nil {
-				return errors.New("not a git repository")
-			}
-
-			return runSessionInfo(ctx, cmd, args[0], jsonFlag)
+			return runSessionInfo(cmd.Context(), cmd, args[0], jsonFlag)
 		},
 	}
 

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -421,11 +421,11 @@ func TestStopCmd_NotGitRepo(t *testing.T) {
 	paths.ClearWorktreeRootCache()
 	session.ClearGitCommonDirCache()
 
-	cmd := newStopCmd()
+	cmd := newSessionsCmd()
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{})
+	cmd.SetArgs([]string{"stop"})
 
 	err := cmd.ExecuteContext(context.Background())
 	if err == nil {
@@ -703,10 +703,10 @@ func TestListCmd_NotGitRepo(t *testing.T) {
 	paths.ClearWorktreeRootCache()
 	session.ClearGitCommonDirCache()
 
-	cmd := newListCmd()
+	cmd := newSessionsCmd()
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
-	cmd.SetArgs([]string{})
+	cmd.SetArgs([]string{"list"})
 
 	err := cmd.ExecuteContext(context.Background())
 	if err == nil {
@@ -911,11 +911,11 @@ func TestInfoCmd_NotGitRepo(t *testing.T) {
 	paths.ClearWorktreeRootCache()
 	session.ClearGitCommonDirCache()
 
-	cmd := newInfoCmd()
+	cmd := newSessionsCmd()
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{"some-id"})
+	cmd.SetArgs([]string{"info", "some-id"})
 
 	err := cmd.ExecuteContext(context.Background())
 	if err == nil {


### PR DESCRIPTION
 Fixes `sessions stop` worktree scoping bug and adds `sessions list` and `sessions info` subcommands.                                              
                                                                          
sessions stop fix: The no-args and --all paths silently filtered to the current worktree, hiding sessions that entire status showed. 

- Now all active sessions are visible across all worktrees, with worktree labels in the multi-select picker for context.

sessions list: Shows all sessions (active and ended) in status-style card format with labeled session and checkpoint IDs for easy copy-paste into explain, rewind, and info.                                         
                  
sessions info <session-id>: Detailed session inspection — agent, model, status, worktree, timing, token breakdown, checkpoint linkage, and files touched. Supports --json for scripting.  


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `sessions stop` semantics to operate across *all* worktrees (including `--all`), which could unexpectedly stop more sessions than before, though logic is well-covered by new tests. New `list`/`info` subcommands add output/formatting and JSON serialization but don’t touch auth or external side effects beyond reading session state.
> 
> **Overview**
> Adds `entire sessions list` and `entire sessions info <id>` (with optional `--json`) to browse all tracked sessions and inspect a single session’s full state, including token breakdown, checkpoint linkage, worktree metadata, and files touched.
> 
> Fixes `sessions stop` worktree-scoping so the no-args flow and `--all` operate **globally across worktrees**, and updates the multi-select UI to include worktree labels and truncated prompts; active-session filtering is aligned with `status` so sessions with `PhaseEnded` or `EndedAt` set are excluded. Test coverage is expanded to validate cross-worktree behavior plus the new `list`/`info` outputs (text + JSON) and helper label functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 832c509e7e68d82f4cf5128a8817909168d4550f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->