### PR TITLE
fix: use `Basic` auth instead of `Bearer` for checkpoint token

### DIFF
--- a/cmd/entire/cli/strategy/checkpoint_token.go
+++ b/cmd/entire/cli/strategy/checkpoint_token.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,9 +10,11 @@ import (
 	"sync"
 )
 
-// CheckpointTokenEnvVar is the environment variable for providing a bearer token
+// CheckpointTokenEnvVar is the environment variable for providing an access token
 // used to authenticate git push/fetch operations for checkpoint branches.
-// The token is injected as an HTTP Authorization header for HTTPS remotes.
+// The token is injected as an HTTP Basic Authorization header per RFC 7617:
+// the credentials string "x-access-token:<token>" is base64-encoded and sent as
+// "Authorization: Basic <base64>". This matches GitHub's token auth for Git HTTPS.
 // SSH remotes ignore the token (with a warning).
 const CheckpointTokenEnvVar = "ENTIRE_CHECKPOINT_TOKEN"
 
@@ -19,7 +22,7 @@ var sshTokenWarningOnce sync.Once
 
 // CheckpointGitCommand creates an exec.Cmd for a git operation that may need
 // checkpoint token authentication. If ENTIRE_CHECKPOINT_TOKEN is set and the
-// target resolves to an HTTPS remote, the bearer token is injected via
+// target resolves to an HTTPS remote, a Basic auth token is injected via
 // GIT_CONFIG_COUNT/GIT_CONFIG_KEY_*/GIT_CONFIG_VALUE_* environment variables.
 //
 // For SSH remotes, a warning is printed once to stderr and the token is not injected.
@@ -64,7 +67,9 @@ func CheckpointGitCommand(ctx context.Context, target string, args ...string) *e
 }
 
 // appendCheckpointTokenEnv appends GIT_CONFIG_COUNT-based env vars to inject
-// an Authorization bearer token header into git HTTP requests.
+// an Authorization header into git HTTP requests. The token is sent as a Basic
+// credential with the format "x-access-token:<token>" (base64-encoded), which
+// is compatible with GitHub's token authentication.
 // It filters out any pre-existing GIT_CONFIG_COUNT/KEY/VALUE entries to avoid
 // conflicts, then appends the new ones.
 //
@@ -82,10 +87,11 @@ func appendCheckpointTokenEnv(baseEnv []string, token string) []string {
 		}
 		filtered = append(filtered, e)
 	}
+	encoded := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
 	return append(filtered,
 		"GIT_CONFIG_COUNT=1",
 		"GIT_CONFIG_KEY_0=http.extraHeader",
-		"GIT_CONFIG_VALUE_0=Authorization: Bearer "+token,
+		"GIT_CONFIG_VALUE_0=Authorization: Basic "+encoded,
 	)
 }
 

--- a/cmd/entire/cli/strategy/checkpoint_token_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_token_test.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -96,7 +97,8 @@ func TestAppendCheckpointTokenEnv(t *testing.T) {
 		assert.Contains(t, env, "HOME=/home/user")
 		assert.Contains(t, env, "GIT_CONFIG_COUNT=1")
 		assert.Contains(t, env, "GIT_CONFIG_KEY_0=http.extraHeader")
-		assert.Contains(t, env, "GIT_CONFIG_VALUE_0=Authorization: Bearer my-secret-token")
+		wantAuth := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:my-secret-token"))
+		assert.Contains(t, env, "GIT_CONFIG_VALUE_0="+wantAuth)
 	})
 
 	t.Run("filters existing GIT_CONFIG entries", func(t *testing.T) {
@@ -123,7 +125,8 @@ func TestAppendCheckpointTokenEnv(t *testing.T) {
 		// New entries should be present
 		assert.Contains(t, env, "GIT_CONFIG_COUNT=1")
 		assert.Contains(t, env, "GIT_CONFIG_KEY_0=http.extraHeader")
-		assert.Contains(t, env, "GIT_CONFIG_VALUE_0=Authorization: Bearer new-token")
+		wantAuth := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:new-token"))
+		assert.Contains(t, env, "GIT_CONFIG_VALUE_0="+wantAuth)
 	})
 }
 
@@ -190,7 +193,8 @@ func TestCheckpointGitCommand_HTTPS_InjectsToken(t *testing.T) {
 	envMap := envToMap(cmd.Env)
 	assert.Equal(t, "1", envMap["GIT_CONFIG_COUNT"])
 	assert.Equal(t, "http.extraHeader", envMap["GIT_CONFIG_KEY_0"])
-	assert.Equal(t, "Authorization: Bearer ghp_test123", envMap["GIT_CONFIG_VALUE_0"])
+	wantAuth := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:ghp_test123"))
+	assert.Equal(t, wantAuth, envMap["GIT_CONFIG_VALUE_0"])
 }
 
 // Not parallel: uses t.Setenv() and os.Stderr
@@ -274,10 +278,10 @@ func setupTokenTestRepo(t *testing.T) string {
 }
 
 // TestCheckpointToken_HTTPSServer_SendsAuthHeader uses a real TLS server to verify
-// that the bearer token is actually sent as an HTTP header in git fetch requests.
+// that the Basic auth token is actually sent as an HTTP header in git fetch requests.
 // Not parallel: uses t.Chdir()
 func TestCheckpointToken_HTTPSServer_SendsAuthHeader(t *testing.T) {
-	t.Setenv(CheckpointTokenEnvVar, "test-bearer-token-abc123")
+	t.Setenv(CheckpointTokenEnvVar, "test-token-abc123")
 
 	srv, getCapture := newTLSTestServer(t)
 	tmpDir := setupTokenTestRepo(t)
@@ -294,8 +298,9 @@ func TestCheckpointToken_HTTPSServer_SendsAuthHeader(t *testing.T) {
 
 	auth, count := getCapture()
 	require.Positive(t, count, "server should have received at least one request")
-	assert.Equal(t, "Bearer test-bearer-token-abc123", auth,
-		"git should send the bearer token as an Authorization header")
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:test-token-abc123"))
+	assert.Equal(t, wantAuth, auth,
+		"git should send the token as a Basic Authorization header")
 }
 
 // TestCheckpointToken_HTTPSServer_NoTokenNoHeader verifies that without
@@ -342,8 +347,9 @@ func TestCheckpointToken_HTTPSServer_LsRemoteSendsAuthHeader(t *testing.T) {
 
 	auth, count := getCapture()
 	require.Positive(t, count, "server should have received at least one request")
-	assert.Equal(t, "Bearer push-token-xyz789", auth,
-		"git ls-remote should send the bearer token as an Authorization header")
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:push-token-xyz789"))
+	assert.Equal(t, wantAuth, auth,
+		"git ls-remote should send the token as a Basic Authorization header")
 }
 
 // TestCheckpointToken_GIT_TERMINAL_PROMPT_Coexistence verifies that the token env
@@ -361,7 +367,8 @@ func TestCheckpointToken_GIT_TERMINAL_PROMPT_Coexistence(t *testing.T) {
 
 	envMap := envToMap(cmd.Env)
 	assert.Equal(t, "1", envMap["GIT_CONFIG_COUNT"])
-	assert.Equal(t, "Authorization: Bearer coexist-token", envMap["GIT_CONFIG_VALUE_0"])
+	wantAuth := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:coexist-token"))
+	assert.Equal(t, wantAuth, envMap["GIT_CONFIG_VALUE_0"])
 	assert.Equal(t, "0", envMap["GIT_TERMINAL_PROMPT"])
 }
 


### PR DESCRIPTION
GitHub supports Bearer tokens for its REST/GraphQL API, but not for Git HTTP protocol operations. Git HTTPS auth requires Basic auth with the format `"x-access-token:<token>"` (base64-encoded).

Follow-up from #818.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `ENTIRE_CHECKPOINT_TOKEN` is translated into the `http.extraHeader` for Git HTTPS operations; if the encoding/format is wrong it could break checkpoint fetch/push authentication. Scoped to checkpoint-token injection and covered by updated unit/integration tests.
> 
> **Overview**
> Updates checkpoint-branch Git HTTPS authentication to send `ENTIRE_CHECKPOINT_TOKEN` via `Authorization: Basic <base64(x-access-token:<token>)>` instead of a Bearer header, aligning with GitHub’s Git HTTP requirements.
> 
> Adjusts `appendCheckpointTokenEnv` to base64-encode the Basic credential and updates all related tests (including TLS server assertions) to validate the new header format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86547931be23c83cff2ff57c236b0fa185e99ddd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->