### PR TITLE
Lower timeout for external deadline-respecting test

### DIFF
--- a/cmd/entire/cli/agent/external/external_test.go
+++ b/cmd/entire/cli/agent/external/external_test.go
@@ -202,7 +202,7 @@ esac
 
 	// Provide a context with a short deadline. run() should respect it
 	// and NOT override with its own (longer) timeout.
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
 	start := time.Now()
@@ -212,7 +212,7 @@ esac
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
 	}
-	if elapsed >= 5*time.Second {
+	if elapsed >= 2*time.Second {
 		t.Errorf("run() took %v; caller's deadline was not respected", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary
- Reduce the deadline in `TestRun_RespectsExistingDeadline` from `1s` to `200ms` to cut unit test wall time.
- Tighten the elapsed-time guard from `5s` to `2s` to keep the assertion aligned with the shorter timeout.
- Keep test intent unchanged: `run()` must respect caller-provided context deadlines.

## Verification
- `go test ./cmd/entire/cli/agent/external -count=1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts unit-test timing thresholds without changing production code paths.
> 
> **Overview**
> Reduces the timeout used by `TestRun_RespectsExistingDeadline` in `external_test.go` from `1s` to `200ms` to cut overall test wall time.
> 
> Tightens the test’s elapsed-time guard from `5s` to `2s` while keeping the same behavioral expectation that `run()` respects an existing caller-provided context deadline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cf796815a0acabdbfc59589589b0b8e669b0fa5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->