### PR TITLE
docs: add changelog entries for #826 and #840

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Resume failing when checkpoints aren't fetched locally yet ([#796](https://github.com/entireio/cli/pull/796))
 - OpenCode transcript export resilient to stdout truncation ([#832](https://github.com/entireio/cli/pull/832))
+- Checkpoint linkage preserved after git history rewrites (rebase, filter-branch, amend) via tree hash fallback ([#840](https://github.com/entireio/cli/pull/840), [#834](https://github.com/entireio/cli/issues/834))
+- Fail-closed content detection in prepare-commit-msg to prevent dangling checkpoint trailers from stale sessions ([#826](https://github.com/entireio/cli/pull/826))
+
+### Thanks
+
+Thanks to @sanogueralorenzo for the fail-closed content detection fix and OpenCode plugin session-start ordering! Thanks to @SvenMeyer for reporting the checkpoint linkage issue after git history rewrites.
 
 ### Housekeeping
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating release notes with no runtime or behavioral impact.
> 
> **Overview**
> Updates `CHANGELOG.md` for `0.5.3` to document two additional fixes: preserving checkpoint linkage across git history rewrites (tree-hash fallback) and fail-closed content detection in `prepare-commit-msg` to avoid stale/dangling checkpoint trailers. Adds a **Thanks** section acknowledging contributors/reporters for these fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8ffa5221e3013d3451250506082cdef87618f29. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->