### PR TITLE
docs: update v0.5.3 changelog with additional bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.5.3] - 2026-04-02
+## [0.5.3] - 2026-04-03
 
 ### Added
 
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Resume failing when checkpoints aren't fetched locally yet ([#796](https://github.com/entireio/cli/pull/796))
 - OpenCode transcript export resilient to stdout truncation ([#832](https://github.com/entireio/cli/pull/832))
+- Fail-closed content detection in `prepare-commit-msg` to prevent dangling checkpoint trailers from stale sessions ([#826](https://github.com/entireio/cli/pull/826))
 
 ### Housekeeping
 


### PR DESCRIPTION
Add checkpoint linkage preservation after history rewrites (#840) and fail-closed content detection in prepare-commit-msg (#826). Update release date to 2026-04-03.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates; no runtime behavior changes or code paths affected.
> 
> **Overview**
> Updates the `0.5.3` changelog entry by bumping the release date to `2026-04-03` and adding two additional *Fixed* bullets: checkpoint linkage preservation after git history rewrites and fail-closed content detection in `prepare-commit-msg`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b2353383eedc6975c778cbdc9126ee317f453de. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->