### PR TITLE
feat: make search command visible in CLI help

### DIFF
--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -27,9 +27,8 @@ func newSearchCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:    "search [query]",
-		Short:  "Search checkpoints using semantic and keyword matching",
-		Hidden: true,
+		Use:   "search [query]",
+		Short: "Search checkpoints using semantic and keyword matching",
 		Long: `Search checkpoints using hybrid search (semantic + keyword),
 powered by the Entire search service.
 


### PR DESCRIPTION
## Summary
- Unhide the `entire search` command by setting `Hidden: false` — it was gated during development and is now GA

## Test plan
- [ ] Run `entire --help` and verify `search` appears in the command list
- [ ] Run `entire search --help` and verify it shows usage info
- [ ] Test `entire search` interactive and `--json` modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes Cobra command metadata to make `entire search` show up in CLI help; no behavioral or data/auth logic changes.
> 
> **Overview**
> Makes the `entire search` command visible in `--help` output by flipping `Hidden` from `true` to `false` in `search_cmd.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6505e32130daf113e6b8ab79c0de0afeda6f6dfe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->