### PR TITLE
Fix flaky e2e startup and mid-turn condensation races

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -151,11 +151,13 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 			if state.Phase.IsActive() && errors.Is(extractErr, os.ErrNotExist) {
 				// Mid-turn race: the live transcript may be temporarily unavailable
 				// when PostCommit runs (e.g., opencode export path not materialized yet).
-				// Keep condensation non-fatal and fall back to state/filesystem data.
+				// Keep condensation non-fatal and fall back to state/filesystem data
+				// without re-preparing or rereading the transcript. If FilesTouched
+				// is empty, downstream logic can still rely on committed-files fallback.
 				sessionData = &ExtractedSessionData{
 					FullTranscriptLines: state.CheckpointTranscriptStart,
 					Prompts:             readPromptsFromFilesystem(ctx, state.SessionID),
-					FilesTouched:        s.resolveFilesTouched(ctx, state),
+					FilesTouched:        append([]string(nil), state.FilesTouched...),
 				}
 			} else {
 				return nil, fmt.Errorf("failed to extract session data from live transcript: %w", extractErr)

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -148,7 +148,18 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		var extractErr error
 		sessionData, extractErr = s.extractSessionDataFromLiveTranscript(ctx, state)
 		if extractErr != nil {
-			return nil, fmt.Errorf("failed to extract session data from live transcript: %w", extractErr)
+			if state.Phase.IsActive() && errors.Is(extractErr, os.ErrNotExist) {
+				// Mid-turn race: the live transcript may be temporarily unavailable
+				// when PostCommit runs (e.g., opencode export path not materialized yet).
+				// Keep condensation non-fatal and fall back to state/filesystem data.
+				sessionData = &ExtractedSessionData{
+					FullTranscriptLines: state.CheckpointTranscriptStart,
+					Prompts:             readPromptsFromFilesystem(ctx, state.SessionID),
+					FilesTouched:        s.resolveFilesTouched(ctx, state),
+				}
+			} else {
+				return nil, fmt.Errorf("failed to extract session data from live transcript: %w", extractErr)
+			}
 		}
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -109,6 +109,8 @@ type condenseOpts struct {
 //
 // For mid-session commits (no Stop/SaveStep called yet), the shadow branch may not exist.
 // In this case, data is extracted from the live transcript instead.
+//
+//nolint:maintidx // condensation orchestrates transcript extraction, attribution, checkpoint writes, and active-session fallback paths; splitting further would obscure the flow
 func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Repository, checkpointID id.CheckpointID, state *SessionState, committedFiles map[string]struct{}, opts ...condenseOpts) (*CondenseResult, error) {
 	ag, _ := agent.GetByAgentType(state.AgentType) //nolint:errcheck // ag may be nil for unknown agent types; callers use type assertions so nil is safe
 	var o condenseOpts

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -3039,26 +3040,17 @@ func TestCondenseSession_TranscriptRelocatedMidSession(t *testing.T) {
 // and the live transcript file is temporarily unavailable.
 func TestCondenseSession_MidTurnMissingTranscriptDoesNotFail(t *testing.T) {
 	dir := t.TempDir()
-	repo, err := git.PlainInit(dir, false)
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
 	if err != nil {
-		t.Fatalf("failed to init repo: %v", err)
+		t.Fatalf("failed to open repo: %v", err)
 	}
 
-	wt, err := repo.Worktree()
-	if err != nil {
-		t.Fatalf("failed to get worktree: %v", err)
-	}
 	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content\n"), 0o644); err != nil {
 		t.Fatalf("failed to write file: %v", err)
 	}
-	if _, err := wt.Add("file.txt"); err != nil {
-		t.Fatalf("failed to stage: %v", err)
-	}
-	if _, err := wt.Commit("Initial commit", &git.CommitOptions{
-		Author: &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()},
-	}); err != nil {
-		t.Fatalf("failed to commit: %v", err)
-	}
+	testutil.GitAdd(t, dir, "file.txt")
+	testutil.GitCommit(t, dir, "Initial commit")
 
 	t.Chdir(dir)
 

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -3030,6 +3031,65 @@ func TestCondenseSession_TranscriptRelocatedMidSession(t *testing.T) {
 	// State should have been updated to the resolved path
 	if state.TranscriptPath != nestedPath {
 		t.Errorf("state.TranscriptPath = %q, want %q (should be updated after re-resolution)", state.TranscriptPath, nestedPath)
+	}
+}
+
+// TestCondenseSession_MidTurnMissingTranscriptDoesNotFail verifies that
+// condensation does not fail when an ACTIVE mid-turn session has no shadow branch
+// and the live transcript file is temporarily unavailable.
+func TestCondenseSession_MidTurnMissingTranscriptDoesNotFail(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content\n"), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if _, err := wt.Add("file.txt"); err != nil {
+		t.Fatalf("failed to stage: %v", err)
+	}
+	if _, err := wt.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()},
+	}); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	t.Chdir(dir)
+
+	s := &ManualCommitStrategy{}
+
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("failed to get HEAD: %v", err)
+	}
+
+	state := &SessionState{
+		SessionID:                 "mid-turn-missing-transcript",
+		BaseCommit:                head.Hash().String(),
+		WorktreePath:              dir,
+		Phase:                     session.PhaseActive,
+		AgentType:                 agent.AgentTypeOpenCode,
+		TranscriptPath:            filepath.Join(dir, ".entire", "tmp", "missing.json"),
+		CheckpointTranscriptStart: 0,
+	}
+
+	checkpointID := id.MustCheckpointID("d4e5f6a1b2c3")
+	result, err := s.CondenseSession(context.Background(), repo, checkpointID, state, map[string]struct{}{"file.txt": {}})
+	if err != nil {
+		t.Fatalf("CondenseSession() error = %v, want nil (missing live transcript should not fail condensation)", err)
+	}
+
+	if result == nil {
+		t.Fatal("CondenseSession() result = nil, want non-nil")
+	}
+	if len(result.FilesTouched) == 0 || result.FilesTouched[0] != "file.txt" {
+		t.Fatalf("FilesTouched = %v, want [file.txt]", result.FilesTouched)
 	}
 }
 

--- a/e2e/agents/cursor_cli.go
+++ b/e2e/agents/cursor_cli.go
@@ -33,8 +33,8 @@ func (a *CursorCLI) EntireAgent() string        { return "cursor" }
 func (a *CursorCLI) TimeoutMultiplier() float64 { return 1.5 }
 
 // PromptPattern returns a regex matching the Cursor CLI's TUI input prompt.
-// The CLI shows a styled input box with placeholder text when ready for input.
-func (a *CursorCLI) PromptPattern() string { return `/ commands` }
+// Cursor has used both legacy and newer placeholder copy across releases.
+func (a *CursorCLI) PromptPattern() string { return `(/ commands|Plan, search, build anything)` }
 
 func (a *CursorCLI) IsTransientError(out Output, err error) bool {
 	if err == nil {

--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -128,7 +128,7 @@ func (g *Gemini) StartSession(ctx context.Context, dir string) (Session, error) 
 
 	// Dismiss startup dialogs (auth, workspace trust, etc.)
 	for range 10 {
-		content, err := s.WaitFor(`(Type your message|trust|Enter to select|Enter to confirm)`, 30*time.Second)
+		content, err := s.WaitFor(`(Type your message|trust|Enter to select|Enter to confirm|New Agents Discovered|Acknowledge and Enable)`, 30*time.Second)
 		if err != nil {
 			_ = s.Close()
 			return nil, fmt.Errorf("waiting for startup prompt: %w", err)

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -2,6 +2,8 @@ package testutil
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +20,8 @@ import (
 )
 
 const droidRepoSettingsPath = ".factory/settings.json"
+
+var geminiAckMu sync.Mutex
 
 // RepoState holds the working state for a single test's cloned repository.
 type RepoState struct {
@@ -82,6 +87,9 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 	}
 
 	entire.Enable(t, dir, agent.EntireAgent())
+	if agent.Name() == "gemini-cli" {
+		acknowledgeGeminiSearchAgent(t, dir)
+	}
 	if agent.Name() == "factoryai-droid" {
 		if err := configureDroidRepoSettings(dir); err != nil {
 			t.Fatalf("configure droid repo settings: %v", err)
@@ -146,6 +154,58 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 	})
 
 	return state
+}
+
+func acknowledgeGeminiSearchAgent(t *testing.T, repoDir string) {
+	t.Helper()
+
+	agentFile := filepath.Join(repoDir, ".gemini", "agents", "entire-search.md")
+	content, err := os.ReadFile(agentFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		t.Fatalf("read gemini agent file: %v", err)
+	}
+
+	sum := sha256.Sum256(content)
+	hash := hex.EncodeToString(sum[:])
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("get home dir: %v", err)
+	}
+	ackPath := filepath.Join(home, ".gemini", "acknowledgments", "agents.json")
+
+	geminiAckMu.Lock()
+	defer geminiAckMu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(ackPath), 0o755); err != nil {
+		t.Fatalf("create gemini acknowledgments dir: %v", err)
+	}
+
+	acks := map[string]map[string]string{}
+	if data, readErr := os.ReadFile(ackPath); readErr == nil {
+		if err := json.Unmarshal(data, &acks); err != nil {
+			t.Fatalf("parse gemini acknowledgments: %v", err)
+		}
+	} else if !errors.Is(readErr, os.ErrNotExist) {
+		t.Fatalf("read gemini acknowledgments: %v", readErr)
+	}
+
+	if acks[repoDir] == nil {
+		acks[repoDir] = map[string]string{}
+	}
+	acks[repoDir]["entire-search"] = hash
+
+	out, err := json.MarshalIndent(acks, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal gemini acknowledgments: %v", err)
+	}
+	out = append(out, '\n')
+
+	if err := os.WriteFile(ackPath, out, 0o644); err != nil {
+		t.Fatalf("write gemini acknowledgments: %v", err)
+	}
 }
 
 func configureDroidRepoSettings(repoDir string) error {

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -186,7 +186,7 @@ func acknowledgeGeminiSearchAgent(t *testing.T, repoDir string) {
 	acks := map[string]map[string]string{}
 	if data, readErr := os.ReadFile(ackPath); readErr == nil {
 		if err := json.Unmarshal(data, &acks); err != nil {
-			t.Fatalf("parse gemini acknowledgments: %v", err)
+			acks = map[string]map[string]string{}
 		}
 	} else if !errors.Is(readErr, os.ErrNotExist) {
 		t.Fatalf("read gemini acknowledgments: %v", readErr)


### PR DESCRIPTION
## Summary
- Update Cursor e2e startup prompt detection to accept both legacy (`/ commands`) and current (`Plan, search, build anything`) placeholder text so interactive startup waits stop timing out across Cursor versions.
- Stabilize Gemini e2e startup by pre-acknowledging the repo-managed `entire-search` agent in `~/.gemini/acknowledgments/agents.json` during test repo setup, and recognize the new discovery dialog strings during startup waits.
- Fix a mid-turn post-commit condensation race by treating missing live transcript files (`ENOENT`) as a non-fatal ACTIVE-session condition and falling back to state/filesystem data; add a regression test for this path.

## Why
Recent CI failures were caused by startup/readiness drift in agent CLIs and a timing race where PostCommit can run before a live transcript path is materialized. These changes make startup and condensation behavior resilient without changing normal success paths.

## Validation
- `mise run fmt`
- `mise run lint`
- `mise run test:ci`
- `go test ./e2e/...`
- `go build ./...`
- `go vet ./...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts checkpoint condensation to fail-open on `ENOENT` for active mid-turn sessions, which could change what metadata gets persisted during rare races. E2E agent readiness detection and Gemini acknowledgment writes also affect test harness behavior and filesystem state in CI/home dirs.
> 
> **Overview**
> **Improves reliability of mid-turn checkpoint condensation and E2E agent startup.**
> 
> Manual-commit condensation now treats a missing live transcript (`os.ErrNotExist`) as *non-fatal* for **active** sessions without a shadow branch, falling back to state/filesystem-derived prompts and `files_touched`, and adds a regression test for this race.
> 
> E2E harness updates Cursor CLI prompt readiness regex to handle newer placeholder text, expands Gemini startup dialog detection, and pre-acknowledges the repo-provided Gemini `entire-search` agent by writing its content hash to `~/.gemini/acknowledgments/agents.json` (guarded by a mutex for parallel tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32af9ba6d9648c1fb757366124da07d7df7ad92. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->