### PR TITLE
give opencode in E2E more time to boot

### DIFF
--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -148,7 +148,7 @@ func (a *openCodeAgent) StartSession(ctx context.Context, dir string) (Session, 
 		// Wait for TUI to be ready (input area with placeholder text).
 		// OpenCode's TUI has a large ASCII banner and multiple panels that
 		// can take a while to render on CI, plus WaitFor needs 2s settle.
-		if _, err := s.WaitFor(`Ask anything`, 30*time.Second); err != nil {
+		if _, err := s.WaitFor(`Ask anything`, 60*time.Second); err != nil {
 			content := s.Capture()
 			_ = s.Close()
 			if strings.TrimSpace(content) == "" && attempt == 0 {


### PR DESCRIPTION
Assumption is that opencodes TUI isn't able to boot in 30s sometimes on a GitHub runner, let's see if this helps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only relaxes an E2E startup readiness timeout to reduce CI flakiness, with no production code or data/auth logic changes.
> 
> **Overview**
> Extends the opencode E2E agent session startup wait from 30s to 60s when waiting for the TUI to reach the `Ask anything` prompt, reducing CI flakes from slow renders/boot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c998856a54a716acd8e1be4d74dffbc91b30627b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->