### PR TITLE
more hermetic separation for gemini auth config files in E2E

### DIFF
--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -52,17 +52,7 @@ func (g *Gemini) IsTransientError(out Output, err error) bool {
 }
 
 func (g *Gemini) Bootstrap() error {
-	// Pre-configure auth so gemini doesn't show the onboarding dialog.
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("get home dir: %w", err)
-	}
-	dir := filepath.Join(home, ".gemini")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("mkdir %s: %w", dir, err)
-	}
-	config := `{"security":{"auth":{"selectedType":"gemini-api-key"}}}`
-	return os.WriteFile(filepath.Join(dir, "settings.json"), []byte(config), 0o644)
+	return nil
 }
 
 func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
@@ -85,7 +75,11 @@ func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 	cmd := exec.CommandContext(promptCtx, g.Binary(), args...)
 	cmd.Dir = dir
 	cmd.Stdin = nil
-	cmd.Env = append(filterEnv(os.Environ(), "ENTIRE_TEST_TTY"), "ACCESSIBLE=1")
+	cmd.Env = append(
+		filterEnv(os.Environ(), "ENTIRE_TEST_TTY"),
+		"ACCESSIBLE=1",
+		"HOME="+geminiTestHomeDir(dir),
+	)
 	setupProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
 
@@ -118,10 +112,21 @@ func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 }
 
 func (g *Gemini) StartSession(ctx context.Context, dir string) (Session, error) {
+	_ = ctx
 	name := fmt.Sprintf("gemini-test-%d", time.Now().UnixNano())
+
+	envArgs := []string{"ACCESSIBLE=1", "HOME=" + geminiTestHomeDir(dir)}
+	for _, key := range []string{"TERM"} {
+		if v := os.Getenv(key); v != "" {
+			envArgs = append(envArgs, key+"="+v)
+		}
+	}
+
 	// Unset CI and GITHUB_ACTIONS so gemini doesn't force headless mode —
 	// it checks both in isHeadlessMode() and skips interactive TUI entirely.
-	s, err := NewTmuxSession(name, dir, []string{"CI", "GITHUB_ACTIONS", "ENTIRE_TEST_TTY"}, "env", "ACCESSIBLE=1", g.Binary(), "--model", geminiDefaultModel, "-y")
+	args := append([]string{"env"}, envArgs...)
+	args = append(args, g.Binary(), "--model", geminiDefaultModel, "-y")
+	s, err := NewTmuxSession(name, dir, []string{"CI", "GITHUB_ACTIONS", "ENTIRE_TEST_TTY", "HOME"}, args[0], args[1:]...)
 	if err != nil {
 		return nil, err
 	}
@@ -142,4 +147,8 @@ func (g *Gemini) StartSession(ctx context.Context, dir string) (Session, error) 
 	s.stableAtSend = ""
 
 	return s, nil
+}
+
+func geminiTestHomeDir(repoDir string) string {
+	return filepath.Join(filepath.Dir(repoDir), filepath.Base(repoDir)+"-gemini-home")
 }

--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -111,8 +111,7 @@ func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 	}, err
 }
 
-func (g *Gemini) StartSession(ctx context.Context, dir string) (Session, error) {
-	_ = ctx
+func (g *Gemini) StartSession(_ context.Context, dir string) (Session, error) {
 	name := fmt.Sprintf("gemini-test-%d", time.Now().UnixNano())
 
 	envArgs := []string{"ACCESSIBLE=1", "HOME=" + geminiTestHomeDir(dir)}

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -20,8 +19,6 @@ import (
 )
 
 const droidRepoSettingsPath = ".factory/settings.json"
-
-var geminiAckMu sync.Mutex
 
 // RepoState holds the working state for a single test's cloned repository.
 type RepoState struct {
@@ -88,7 +85,7 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 
 	entire.Enable(t, dir, agent.EntireAgent())
 	if agent.Name() == "gemini-cli" {
-		acknowledgeGeminiSearchAgent(t, dir)
+		setupGeminiTestHome(t, dir)
 	}
 	if agent.Name() == "factoryai-droid" {
 		if err := configureDroidRepoSettings(dir); err != nil {
@@ -156,8 +153,25 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 	return state
 }
 
-func acknowledgeGeminiSearchAgent(t *testing.T, repoDir string) {
+func setupGeminiTestHome(t *testing.T, repoDir string) {
 	t.Helper()
+
+	homeDir := geminiTestHomeDir(repoDir)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(homeDir); err != nil {
+			t.Fatalf("remove gemini test home: %v", err)
+		}
+	})
+
+	geminiDir := filepath.Join(homeDir, ".gemini")
+	if err := os.MkdirAll(filepath.Join(geminiDir, "acknowledgments"), 0o755); err != nil {
+		t.Fatalf("create gemini test home: %v", err)
+	}
+
+	config := `{"security":{"auth":{"selectedType":"gemini-api-key"}}}`
+	if err := os.WriteFile(filepath.Join(geminiDir, "settings.json"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write gemini settings: %v", err)
+	}
 
 	agentFile := filepath.Join(repoDir, ".gemini", "agents", "entire-search.md")
 	content, err := os.ReadFile(agentFile)
@@ -171,18 +185,7 @@ func acknowledgeGeminiSearchAgent(t *testing.T, repoDir string) {
 	sum := sha256.Sum256(content)
 	hash := hex.EncodeToString(sum[:])
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("get home dir: %v", err)
-	}
-	ackPath := filepath.Join(home, ".gemini", "acknowledgments", "agents.json")
-
-	geminiAckMu.Lock()
-	defer geminiAckMu.Unlock()
-	if err := os.MkdirAll(filepath.Dir(ackPath), 0o755); err != nil {
-		t.Fatalf("create gemini acknowledgments dir: %v", err)
-	}
-
+	ackPath := filepath.Join(geminiDir, "acknowledgments", "agents.json")
 	acks := map[string]map[string]string{}
 	if data, readErr := os.ReadFile(ackPath); readErr == nil {
 		if err := json.Unmarshal(data, &acks); err != nil {
@@ -206,6 +209,10 @@ func acknowledgeGeminiSearchAgent(t *testing.T, repoDir string) {
 	if err := os.WriteFile(ackPath, out, 0o644); err != nil {
 		t.Fatalf("write gemini acknowledgments: %v", err)
 	}
+}
+
+func geminiTestHomeDir(repoDir string) string {
+	return filepath.Join(filepath.Dir(repoDir), filepath.Base(repoDir)+"-gemini-home")
 }
 
 func configureDroidRepoSettings(repoDir string) error {

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -159,7 +159,7 @@ func setupGeminiTestHome(t *testing.T, repoDir string) {
 	homeDir := geminiTestHomeDir(repoDir)
 	t.Cleanup(func() {
 		if err := os.RemoveAll(homeDir); err != nil {
-			t.Fatalf("remove gemini test home: %v", err)
+			t.Errorf("remove gemini test home: %v", err)
 		}
 	})
 


### PR DESCRIPTION
Entire-Checkpoint: 58a364f11b5f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk and test-only, but it changes how `gemini` is bootstrapped and which `HOME`/acknowledgment files it reads, so Gemini E2E runs could fail if the CLI expects additional state in the real home directory.
> 
> **Overview**
> **Makes Gemini E2E runs hermetic by isolating Gemini CLI state into a per-repo test HOME directory.** The Gemini agent no longer writes global auth config in `Bootstrap`; instead, `SetupRepo` creates a dedicated `...-gemini-home` directory, seeds `.gemini/settings.json`, and writes acknowledgment state there.
> 
> Gemini prompt and interactive session execution now explicitly set `HOME` to this test directory (and preserve `TERM` for tmux runs), removing previous reliance on the developer’s real home directory and eliminating the prior global mutex/serialization around acknowledgments. Adds a standalone `docs/gmeta-poc-plan.md` planning document (no production code changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f3d0d738f24bd8aad2bc56acb27538207d7ea1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->