### PR TITLE
Fix GoReleaser using wrong tag for concurrent releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
           version: latest
           args: release --clean --release-notes=${{ runner.temp }}/release_notes.md
         env:
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag (semver with v prefix, e.g. v1.2.3)"
+        required: true
+        type: string
   push:
     tags:
       - "v*"
@@ -12,10 +17,13 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref }}
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
@@ -39,7 +47,7 @@ jobs:
       - name: Detect release type
         id: release-type
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           if [[ "$VERSION" == *-* ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -49,7 +57,7 @@ jobs:
       - name: Extract release notes from CHANGELOG.md
         if: steps.release-type.outputs.prerelease == 'false'
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${RELEASE_TAG#v}"
           awk -v ver="$VERSION" 'BEGIN{header="^## \\[" ver "\\]"} $0 ~ header{found=1; next} /^## \[/{if(found) exit} found{print}' CHANGELOG.md > "$RUNNER_TEMP/release_notes.md"
           if [ ! -s "$RUNNER_TEMP/release_notes.md" ]; then
             echo "::error::No changelog entry found for version ${VERSION} in CHANGELOG.md"
@@ -59,13 +67,13 @@ jobs:
       - name: Generate nightly release notes
         if: steps.release-type.outputs.prerelease == 'true'
         run: |
-          LAST_NIGHTLY=$(git tag -l 'v*-nightly.*' --sort=-creatordate | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+          LAST_NIGHTLY=$(git tag -l 'v*-nightly.*' --sort=-creatordate | grep -v "^${RELEASE_TAG}$" | head -1)
           if [ -n "$LAST_NIGHTLY" ]; then
             BASE_TAG="$LAST_NIGHTLY"
           else
             BASE_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' HEAD 2>/dev/null || echo "")
           fi
-          echo "## Nightly Build (${GITHUB_REF_NAME})" > "$RUNNER_TEMP/release_notes.md"
+          echo "## Nightly Build (${RELEASE_TAG})" > "$RUNNER_TEMP/release_notes.md"
           echo "" >> "$RUNNER_TEMP/release_notes.md"
           if [ -n "$BASE_TAG" ]; then
             echo "Changes since ${BASE_TAG}:" >> "$RUNNER_TEMP/release_notes.md"
@@ -80,7 +88,7 @@ jobs:
           version: latest
           args: release --clean --release-notes=${{ runner.temp }}/release_notes.md
         env:
-          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+          GORELEASER_CURRENT_TAG: ${{ env.RELEASE_TAG }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
@@ -111,7 +119,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":red_circle: *Release Failed* for `${{ github.ref_name }}`\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run details>"
+                    "text": ":red_circle: *Release Failed* for `${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}`\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run details>"
                   }
                 },
                 {
@@ -119,7 +127,7 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "Tag: `${{ github.ref_name }}` by ${{ github.actor }}"
+                      "text": "Tag: `${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}` by ${{ github.actor }}"
                     }
                   ]
                 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,17 @@ on:
 permissions:
   contents: write
 
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref }}
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
@@ -119,7 +120,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":red_circle: *Release Failed* for `${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}`\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run details>"
+                    "text": ":red_circle: *Release Failed* for `${{ env.RELEASE_TAG }}`\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run details>"
                   }
                 },
                 {
@@ -127,7 +128,7 @@ jobs:
                   "elements": [
                     {
                       "type": "mrkdwn",
-                      "text": "Tag: `${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}` by ${{ github.actor }}"
+                      "text": "Tag: `${{ env.RELEASE_TAG }}` by ${{ github.actor }}"
                     }
                   ]
                 }


### PR DESCRIPTION
## Summary
- Resolve the release tag once as workflow `env.RELEASE_TAG` (manual `workflow_dispatch` `version` input or `github.ref_name` on tag push) so checkout, GoReleaser, and failure notifications all use the same value
- Set `GORELEASER_CURRENT_TAG` to `${{ env.RELEASE_TAG }}` so GoReleaser does not auto-detect the wrong tag when nightly and stable releases are created from the same commit
- Support `workflow_dispatch` with a required `version` input for manual releases

## Test plan
- [ ] Push a nightly and stable tag on the same commit and verify each release uses the correct version
- [ ] Run the workflow manually with `version` set to an existing tag and confirm checkout and artifacts match that tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release pipeline by overriding GoReleaser tag detection, which could impact versioning/published artifacts if misconfigured, but the change is small and isolated to CI.
> 
> **Overview**
> Ensures concurrent tag-based releases (e.g., nightly and stable from the same commit) use the intended version by explicitly setting `GORELEASER_CURRENT_TAG` to `github.ref_name` in the GitHub Actions `release.yml` GoReleaser step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63945011c288a3c359ab8a02157c12766f24952a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
