### PR TITLE
fix: support Claude JSON array responses for summaries

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -5,6 +5,9 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
@@ -185,6 +188,35 @@ type TextGenerator interface {
 	// GenerateText sends a prompt to the agent's CLI and returns the raw text response.
 	// model is a hint (e.g., "haiku", "sonnet"). Implementations may ignore if not applicable.
 	GenerateText(ctx context.Context, prompt string, model string) (string, error)
+}
+
+type claudeResponseEnvelope struct {
+	Type   string `json:"type"`
+	Result string `json:"result"`
+}
+
+// ExtractClaudeCLIResult returns the Claude CLI result payload from either the
+// legacy single-object JSON response or the current array-shaped JSON response.
+func ExtractClaudeCLIResult(stdout []byte) (string, error) {
+	var response claudeResponseEnvelope
+	if err := json.Unmarshal(stdout, &response); err == nil {
+		if response.Result != "" {
+			return response.Result, nil
+		}
+	}
+
+	var responses []claudeResponseEnvelope
+	if err := json.Unmarshal(stdout, &responses); err != nil {
+		return "", fmt.Errorf("unsupported Claude CLI JSON response: %w", err)
+	}
+
+	for i := len(responses) - 1; i >= 0; i-- {
+		if responses[i].Type == "result" && responses[i].Result != "" {
+			return responses[i].Result, nil
+		}
+	}
+
+	return "", errors.New("unsupported Claude CLI JSON response: missing result item")
 }
 
 // HookResponseWriter is implemented by agents that support structured hook responses.

--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -5,9 +5,6 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"io"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
@@ -188,35 +185,6 @@ type TextGenerator interface {
 	// GenerateText sends a prompt to the agent's CLI and returns the raw text response.
 	// model is a hint (e.g., "haiku", "sonnet"). Implementations may ignore if not applicable.
 	GenerateText(ctx context.Context, prompt string, model string) (string, error)
-}
-
-type claudeResponseEnvelope struct {
-	Type   string `json:"type"`
-	Result string `json:"result"`
-}
-
-// ExtractClaudeCLIResult returns the Claude CLI result payload from either the
-// legacy single-object JSON response or the current array-shaped JSON response.
-func ExtractClaudeCLIResult(stdout []byte) (string, error) {
-	var response claudeResponseEnvelope
-	if err := json.Unmarshal(stdout, &response); err == nil {
-		if response.Result != "" {
-			return response.Result, nil
-		}
-	}
-
-	var responses []claudeResponseEnvelope
-	if err := json.Unmarshal(stdout, &responses); err != nil {
-		return "", fmt.Errorf("unsupported Claude CLI JSON response: %w", err)
-	}
-
-	for i := len(responses) - 1; i >= 0; i-- {
-		if responses[i].Type == "result" && responses[i].Result != "" {
-			return responses[i].Result, nil
-		}
-	}
-
-	return "", errors.New("unsupported Claude CLI JSON response: missing result item")
 }
 
 // HookResponseWriter is implemented by agents that support structured hook responses.

--- a/cmd/entire/cli/agent/claudecode/claude.go
+++ b/cmd/entire/cli/agent/claudecode/claude.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"time"
@@ -27,11 +28,13 @@ func init() {
 // ClaudeCodeAgent implements the Agent interface for Claude Code.
 //
 //nolint:revive // ClaudeCodeAgent is clearer than Agent in this context
-type ClaudeCodeAgent struct{}
+type ClaudeCodeAgent struct {
+	CommandRunner func(ctx context.Context, name string, args ...string) *exec.Cmd
+}
 
 // NewClaudeCodeAgent creates a new Claude Code agent instance.
 func NewClaudeCodeAgent() agent.Agent {
-	return &ClaudeCodeAgent{}
+	return &ClaudeCodeAgent{CommandRunner: exec.CommandContext}
 }
 
 // Name returns the agent registry key.

--- a/cmd/entire/cli/agent/claudecode/claude_test.go
+++ b/cmd/entire/cli/agent/claudecode/claude_test.go
@@ -1,6 +1,8 @@
 package claudecode
 
 import (
+	"context"
+	"os/exec"
 	"testing"
 )
 
@@ -20,5 +22,29 @@ func TestProtectedDirs(t *testing.T) {
 	dirs := ag.ProtectedDirs()
 	if len(dirs) != 1 || dirs[0] != ".claude" {
 		t.Errorf("ProtectedDirs() = %v, want [.claude]", dirs)
+	}
+}
+
+func TestGenerateText_ArrayResponse(t *testing.T) {
+	t.Parallel()
+
+	originalCommandContext := commandContext
+	t.Cleanup(func() {
+		commandContext = originalCommandContext
+	})
+
+	commandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		response := `[{"type":"system","subtype":"init"},{"type":"assistant","message":"Working on it"},{"type":"result","result":"final generated text"}]`
+		return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
+	}
+
+	ag := &ClaudeCodeAgent{}
+	result, err := ag.GenerateText(context.Background(), "prompt", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result != "final generated text" {
+		t.Fatalf("GenerateText() = %q, want %q", result, "final generated text")
 	}
 }

--- a/cmd/entire/cli/agent/claudecode/claude_test.go
+++ b/cmd/entire/cli/agent/claudecode/claude_test.go
@@ -26,19 +26,13 @@ func TestProtectedDirs(t *testing.T) {
 }
 
 func TestGenerateText_ArrayResponse(t *testing.T) {
-	t.Parallel()
-
-	originalCommandContext := commandContext
-	t.Cleanup(func() {
-		commandContext = originalCommandContext
-	})
-
-	commandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		response := `[{"type":"system","subtype":"init"},{"type":"assistant","message":"Working on it"},{"type":"result","result":"final generated text"}]`
-		return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
+	ag := &ClaudeCodeAgent{
+		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			response := `[{"type":"system","subtype":"init"},{"type":"assistant","message":"Working on it"},{"type":"result","result":"final generated text"}]`
+			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
+		},
 	}
 
-	ag := &ClaudeCodeAgent{}
 	result, err := ag.GenerateText(context.Background(), "prompt", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/cmd/entire/cli/agent/claudecode/generate.go
+++ b/cmd/entire/cli/agent/claudecode/generate.go
@@ -12,8 +12,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 )
 
-var commandContext = exec.CommandContext
-
 // GenerateText sends a prompt to the Claude CLI and returns the raw text response.
 // Implements the agent.TextGenerator interface.
 // The model parameter hints which model to use (e.g., "haiku", "sonnet").
@@ -24,7 +22,12 @@ func (c *ClaudeCodeAgent) GenerateText(ctx context.Context, prompt string, model
 		model = "haiku"
 	}
 
-	cmd := commandContext(ctx, claudePath,
+	commandRunner := c.CommandRunner
+	if commandRunner == nil {
+		commandRunner = exec.CommandContext
+	}
+
+	cmd := commandRunner(ctx, claudePath,
 		"--print", "--output-format", "json",
 		"--model", model, "--setting-sources", "")
 

--- a/cmd/entire/cli/agent/claudecode/generate.go
+++ b/cmd/entire/cli/agent/claudecode/generate.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/entireio/cli/cmd/entire/cli/agent"
 )
 
 // GenerateText sends a prompt to the Claude CLI and returns the raw text response.
@@ -42,6 +40,12 @@ func (c *ClaudeCodeAgent) GenerateText(ctx context.Context, prompt string, model
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return "", context.DeadlineExceeded
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return "", context.Canceled
+		}
 		var execErr *exec.Error
 		if errors.As(err, &execErr) {
 			return "", fmt.Errorf("claude CLI not found: %w", err)
@@ -53,7 +57,7 @@ func (c *ClaudeCodeAgent) GenerateText(ctx context.Context, prompt string, model
 		return "", fmt.Errorf("failed to run claude CLI: %w", err)
 	}
 
-	result, err := agent.ExtractClaudeCLIResult(stdout.Bytes())
+	result, err := parseGenerateTextResponse(stdout.Bytes())
 	if err != nil {
 		return "", fmt.Errorf("failed to parse claude CLI response: %w", err)
 	}

--- a/cmd/entire/cli/agent/claudecode/generate.go
+++ b/cmd/entire/cli/agent/claudecode/generate.go
@@ -3,13 +3,16 @@ package claudecode
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 )
+
+var commandContext = exec.CommandContext
 
 // GenerateText sends a prompt to the Claude CLI and returns the raw text response.
 // Implements the agent.TextGenerator interface.
@@ -21,7 +24,7 @@ func (c *ClaudeCodeAgent) GenerateText(ctx context.Context, prompt string, model
 		model = "haiku"
 	}
 
-	cmd := exec.CommandContext(ctx, claudePath,
+	cmd := commandContext(ctx, claudePath,
 		"--print", "--output-format", "json",
 		"--model", model, "--setting-sources", "")
 
@@ -47,15 +50,12 @@ func (c *ClaudeCodeAgent) GenerateText(ctx context.Context, prompt string, model
 		return "", fmt.Errorf("failed to run claude CLI: %w", err)
 	}
 
-	// Parse the {"result": "..."} envelope
-	var response struct {
-		Result string `json:"result"`
-	}
-	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+	result, err := agent.ExtractClaudeCLIResult(stdout.Bytes())
+	if err != nil {
 		return "", fmt.Errorf("failed to parse claude CLI response: %w", err)
 	}
 
-	return response.Result, nil
+	return result, nil
 }
 
 // stripGitEnv returns a copy of env with all GIT_* variables removed.

--- a/cmd/entire/cli/agent/claudecode/response.go
+++ b/cmd/entire/cli/agent/claudecode/response.go
@@ -1,0 +1,34 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type responseEnvelope struct {
+	Type   string  `json:"type"`
+	Result *string `json:"result"`
+}
+
+// parseGenerateTextResponse extracts the raw text payload from Claude CLI JSON output.
+// Claude may return either a legacy single object or a newer array of events.
+func parseGenerateTextResponse(stdout []byte) (string, error) {
+	var response responseEnvelope
+	if err := json.Unmarshal(stdout, &response); err == nil && response.Result != nil {
+		return *response.Result, nil
+	}
+
+	var responses []responseEnvelope
+	if err := json.Unmarshal(stdout, &responses); err != nil {
+		return "", fmt.Errorf("unsupported Claude CLI JSON response: %w", err)
+	}
+
+	for i := len(responses) - 1; i >= 0; i-- {
+		if responses[i].Type == "result" && responses[i].Result != nil {
+			return *responses[i].Result, nil
+		}
+	}
+
+	return "", errors.New("unsupported Claude CLI JSON response: missing result item")
+}

--- a/cmd/entire/cli/agent/claudecode/response_test.go
+++ b/cmd/entire/cli/agent/claudecode/response_test.go
@@ -1,0 +1,72 @@
+package claudecode
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseGenerateTextResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		stdout  string
+		want    string
+		wantErr string
+	}{
+		{
+			name:   "legacy object result",
+			stdout: `{"result":"hello"}`,
+			want:   "hello",
+		},
+		{
+			name:   "legacy object empty result",
+			stdout: `{"result":""}`,
+			want:   "",
+		},
+		{
+			name:   "array result",
+			stdout: `[{"type":"system"},{"type":"result","result":"hello"}]`,
+			want:   "hello",
+		},
+		{
+			name:   "array empty result",
+			stdout: `[{"type":"system"},{"type":"result","result":""}]`,
+			want:   "",
+		},
+		{
+			name:    "missing result item",
+			stdout:  `[{"type":"system"},{"type":"assistant","message":"working"}]`,
+			wantErr: "missing result item",
+		},
+		{
+			name:    "invalid json",
+			stdout:  `not json`,
+			wantErr: "unsupported Claude CLI JSON response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseGenerateTextResponse([]byte(tt.stdout))
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseGenerateTextResponse() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/summarize/claude.go
+++ b/cmd/entire/cli/summarize/claude.go
@@ -3,6 +3,7 @@ package summarize
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -52,7 +53,7 @@ const DefaultModel = "sonnet"
 var defaultTextGeneratorFactory = func() (agent.TextGenerator, error) {
 	textGenerator, ok := agent.AsTextGenerator(claudecode.NewClaudeCodeAgent())
 	if !ok {
-		return nil, fmt.Errorf("default summarizer does not support text generation")
+		return nil, errors.New("default summarizer does not support text generation")
 	}
 	return textGenerator, nil
 }

--- a/cmd/entire/cli/summarize/claude.go
+++ b/cmd/entire/cli/summarize/claude.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 )
 
@@ -64,11 +65,6 @@ type ClaudeGenerator struct {
 	// CommandRunner allows injection of the command execution for testing.
 	// If nil, uses exec.CommandContext directly.
 	CommandRunner func(ctx context.Context, name string, args ...string) *exec.Cmd
-}
-
-// claudeCLIResponse represents the JSON response from the Claude CLI.
-type claudeCLIResponse struct {
-	Result string `json:"result"`
 }
 
 // Generate creates a summary from checkpoint data by calling the Claude CLI.
@@ -140,14 +136,10 @@ func (g *ClaudeGenerator) Generate(ctx context.Context, input Input) (*checkpoin
 		return nil, fmt.Errorf("failed to run claude CLI: %w", err)
 	}
 
-	// Parse the CLI response
-	var cliResponse claudeCLIResponse
-	if err := json.Unmarshal(stdout.Bytes(), &cliResponse); err != nil {
+	resultJSON, err := agent.ExtractClaudeCLIResult(stdout.Bytes())
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse claude CLI response: %w", err)
 	}
-
-	// The result field contains the actual JSON summary
-	resultJSON := cliResponse.Result
 
 	// Try to extract JSON if it's wrapped in markdown code blocks
 	resultJSON = extractJSONFromMarkdown(resultJSON)

--- a/cmd/entire/cli/summarize/claude.go
+++ b/cmd/entire/cli/summarize/claude.go
@@ -1,16 +1,13 @@
 package summarize
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 )
 
@@ -52,19 +49,23 @@ Guidelines:
 // to handle long transcripts without truncation.
 const DefaultModel = "sonnet"
 
+var defaultTextGeneratorFactory = func() (agent.TextGenerator, error) {
+	textGenerator, ok := agent.AsTextGenerator(claudecode.NewClaudeCodeAgent())
+	if !ok {
+		return nil, fmt.Errorf("default summarizer does not support text generation")
+	}
+	return textGenerator, nil
+}
+
 // ClaudeGenerator generates summaries using the Claude CLI.
 type ClaudeGenerator struct {
-	// ClaudePath is the path to the claude CLI executable.
-	// If empty, defaults to "claude" (expects it to be in PATH).
-	ClaudePath string
+	// TextGenerator is the primitive used to obtain raw model output.
+	// If nil, uses the built-in Claude Code text generator.
+	TextGenerator agent.TextGenerator
 
 	// Model is the Claude model to use for summarization.
 	// If empty, defaults to DefaultModel ("sonnet").
 	Model string
-
-	// CommandRunner allows injection of the command execution for testing.
-	// If nil, uses exec.CommandContext directly.
-	CommandRunner func(ctx context.Context, name string, args ...string) *exec.Cmd
 }
 
 // Generate creates a summary from checkpoint data by calling the Claude CLI.
@@ -75,70 +76,23 @@ func (g *ClaudeGenerator) Generate(ctx context.Context, input Input) (*checkpoin
 	// Build the prompt
 	prompt := buildSummarizationPrompt(transcriptText)
 
-	// Execute the Claude CLI
-	runner := g.CommandRunner
-	if runner == nil {
-		runner = exec.CommandContext
-	}
-
-	claudePath := g.ClaudePath
-	if claudePath == "" {
-		claudePath = "claude"
-	}
-
 	model := g.Model
 	if model == "" {
 		model = DefaultModel
 	}
 
-	// Use empty --setting-sources to skip all settings (user, project, local).
-	// This avoids loading MCP servers, hooks, or other config that could interfere
-	// with a simple --print summarization call.
-	cmd := runner(ctx, claudePath, "--print", "--output-format", "json", "--model", model, "--setting-sources", "")
-
-	// Fully isolate the subprocess from the user's git repo (ENT-242).
-	// Claude Code performs internal git operations (plugin cache, context gathering)
-	// that pollute the worktree index with phantom entries from its plugin cache.
-	// We must both change the working directory AND strip GIT_* env vars, because
-	// git hooks set GIT_DIR which lets Claude Code find the repo regardless of cwd.
-	// This also prevents recursive triggering of Entire's own git hooks.
-	cmd.Dir = os.TempDir()
-	cmd.Env = stripGitEnv(os.Environ())
-
-	// Pass prompt via stdin
-	cmd.Stdin = strings.NewReader(prompt)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	if err != nil {
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return nil, context.DeadlineExceeded
+	textGenerator := g.TextGenerator
+	if textGenerator == nil {
+		var err error
+		textGenerator, err = defaultTextGeneratorFactory()
+		if err != nil {
+			return nil, err
 		}
-		if errors.Is(ctx.Err(), context.Canceled) {
-			return nil, context.Canceled
-		}
-
-		// Check if the command was not found
-		var execErr *exec.Error
-		if errors.As(err, &execErr) {
-			return nil, fmt.Errorf("claude CLI not found: %w", err)
-		}
-
-		// Check for exit error
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return nil, fmt.Errorf("claude CLI failed (exit %d): %s", exitErr.ExitCode(), stderr.String())
-		}
-
-		return nil, fmt.Errorf("failed to run claude CLI: %w", err)
 	}
 
-	resultJSON, err := agent.ExtractClaudeCLIResult(stdout.Bytes())
+	resultJSON, err := textGenerator.GenerateText(ctx, prompt, model)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse claude CLI response: %w", err)
+		return nil, fmt.Errorf("failed to generate summary text: %w", err)
 	}
 
 	// Try to extract JSON if it's wrapped in markdown code blocks
@@ -160,16 +114,6 @@ func buildSummarizationPrompt(transcriptText string) string {
 
 // stripGitEnv returns a copy of env with all GIT_* variables removed.
 // This prevents a subprocess from discovering or modifying the parent's git repo.
-func stripGitEnv(env []string) []string {
-	filtered := make([]string, 0, len(env))
-	for _, e := range env {
-		if !strings.HasPrefix(e, "GIT_") {
-			filtered = append(filtered, e)
-		}
-	}
-	return filtered
-}
-
 // extractJSONFromMarkdown attempts to extract JSON from markdown code blocks.
 // If the input is not wrapped in code blocks, it returns the input unchanged.
 func extractJSONFromMarkdown(s string) string {

--- a/cmd/entire/cli/summarize/claude_test.go
+++ b/cmd/entire/cli/summarize/claude_test.go
@@ -2,30 +2,62 @@ package summarize
 
 import (
 	"context"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 )
 
-func TestClaudeGenerator_GitIsolation(t *testing.T) {
-	var capturedCmd *exec.Cmd
+type stubTextGenerator struct {
+	text string
+	err  error
+}
 
-	response := `{"result":"{\"intent\":\"test\",\"outcome\":\"test\",\"learnings\":{\"repo\":[],\"code\":[],\"workflow\":[]},\"friction\":[],\"open_items\":[]}"}`
+func (s *stubTextGenerator) GenerateText(context.Context, string, string) (string, error) {
+	return s.text, s.err
+}
+
+func (s *stubTextGenerator) Name() types.AgentName { return "stub" }
+
+func (s *stubTextGenerator) Type() types.AgentType { return "Stub" }
+
+func (s *stubTextGenerator) Description() string { return "stub" }
+
+func (s *stubTextGenerator) IsPreview() bool { return false }
+
+func (s *stubTextGenerator) DetectPresence(context.Context) (bool, error) { return true, nil }
+
+func (s *stubTextGenerator) ProtectedDirs() []string { return nil }
+
+func (s *stubTextGenerator) ReadTranscript(string) ([]byte, error) { return nil, nil }
+
+func (s *stubTextGenerator) ChunkTranscript(context.Context, []byte, int) ([][]byte, error) {
+	return nil, nil
+}
+
+func (s *stubTextGenerator) ReassembleTranscript([][]byte) ([]byte, error) { return nil, nil }
+
+func (s *stubTextGenerator) GetSessionID(*agent.HookInput) string { return "" }
+
+func (s *stubTextGenerator) GetSessionDir(string) (string, error) { return "", nil }
+
+func (s *stubTextGenerator) ResolveSessionFile(string, string) string { return "" }
+
+func (s *stubTextGenerator) ReadSession(*agent.HookInput) (*agent.AgentSession, error) {
+	return nil, nil
+}
+
+func (s *stubTextGenerator) WriteSession(context.Context, *agent.AgentSession) error { return nil }
+
+func (s *stubTextGenerator) FormatResumeCommand(string) string { return "" }
+
+func TestClaudeGenerator_TextGeneratorError(t *testing.T) {
+	t.Parallel()
 
 	gen := &ClaudeGenerator{
-		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			// Capture the command but return something that produces valid output
-			cmd := exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
-			capturedCmd = cmd
-			return cmd
-		},
+		TextGenerator: &stubTextGenerator{err: context.DeadlineExceeded},
 	}
-
-	// Set GIT_* vars that would normally be inherited from a git hook
-	t.Setenv("GIT_DIR", "/some/repo/.git")
-	t.Setenv("GIT_WORK_TREE", "/some/repo")
-	t.Setenv("GIT_INDEX_FILE", "/some/repo/.git/index")
 
 	input := Input{
 		Transcript: []Entry{
@@ -34,129 +66,73 @@ func TestClaudeGenerator_GitIsolation(t *testing.T) {
 	}
 
 	_, err := gen.Generate(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "failed to generate summary text") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClaudeGenerator_UsesDefaultTextGenerator(t *testing.T) {
+	t.Parallel()
+
+	originalFactory := defaultTextGeneratorFactory
+	defaultTextGeneratorFactory = func() (agent.TextGenerator, error) {
+		return &stubTextGenerator{
+			text: `{"intent":"default intent","outcome":"default outcome","learnings":{"repo":[],"code":[],"workflow":[]},"friction":[],"open_items":[]}`,
+		}, nil
+	}
+	t.Cleanup(func() {
+		defaultTextGeneratorFactory = originalFactory
+	})
+
+	gen := &ClaudeGenerator{}
+	input := Input{
+		Transcript: []Entry{
+			{Type: EntryTypeUser, Content: "Hello"},
+		},
+	}
+
+	summary, err := gen.Generate(context.Background(), input)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	if capturedCmd == nil {
-		t.Fatal("command was not captured")
+	if summary.Intent != "default intent" {
+		t.Fatalf("unexpected intent: %s", summary.Intent)
 	}
-
-	// Verify cmd.Dir is set to os.TempDir()
-	if capturedCmd.Dir != os.TempDir() {
-		t.Errorf("cmd.Dir = %q, want %q", capturedCmd.Dir, os.TempDir())
-	}
-
-	// Verify no GIT_* env vars in the command's environment
-	for _, env := range capturedCmd.Env {
-		if strings.HasPrefix(env, "GIT_") {
-			t.Errorf("found GIT_* env var in subprocess: %s", env)
-		}
-	}
-}
-
-func TestStripGitEnv(t *testing.T) {
-	env := []string{
-		"HOME=/Users/test",
-		"GIT_DIR=/repo/.git",
-		"PATH=/usr/bin",
-		"GIT_WORK_TREE=/repo",
-		"GIT_INDEX_FILE=/repo/.git/index",
-		"SHELL=/bin/zsh",
-	}
-
-	filtered := stripGitEnv(env)
-
-	expected := []string{
-		"HOME=/Users/test",
-		"PATH=/usr/bin",
-		"SHELL=/bin/zsh",
-	}
-
-	if len(filtered) != len(expected) {
-		t.Fatalf("got %d entries, want %d", len(filtered), len(expected))
-	}
-
-	for i, e := range filtered {
-		if e != expected[i] {
-			t.Errorf("filtered[%d] = %q, want %q", i, e, expected[i])
-		}
-	}
-}
-
-func TestClaudeGenerator_CommandNotFound(t *testing.T) {
-	gen := &ClaudeGenerator{
-		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			// Return a command that doesn't exist
-			return exec.CommandContext(ctx, "nonexistent-command-that-should-not-exist-12345")
-		},
-	}
-
-	input := Input{
-		Transcript: []Entry{
-			{Type: EntryTypeUser, Content: "Hello"},
-		},
-	}
-
-	_, err := gen.Generate(context.Background(), input)
-	if err == nil {
-		t.Fatal("expected error when command not found")
-	}
-
-	// The error message should indicate the command failed
-	if !strings.Contains(err.Error(), "not found") && !strings.Contains(err.Error(), "executable file not found") {
-		t.Errorf("expected 'not found' error, got: %v", err)
-	}
-}
-
-func TestClaudeGenerator_NonZeroExit(t *testing.T) {
-	gen := &ClaudeGenerator{
-		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			// Return a command that will exit with non-zero status
-			return exec.CommandContext(ctx, "sh", "-c", "echo 'error message' >&2; exit 1")
-		},
-	}
-
-	input := Input{
-		Transcript: []Entry{
-			{Type: EntryTypeUser, Content: "Hello"},
-		},
-	}
-
-	_, err := gen.Generate(context.Background(), input)
-	if err == nil {
-		t.Fatal("expected error on non-zero exit")
-	}
-
-	if !strings.Contains(err.Error(), "exit 1") {
-		t.Errorf("expected exit code in error, got: %v", err)
+	if summary.Outcome != "default outcome" {
+		t.Fatalf("unexpected outcome: %s", summary.Outcome)
 	}
 }
 
 func TestClaudeGenerator_ErrorCases(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
-		cmdOutput     string
+		textOutput    string
 		expectedError string
 	}{
 		{
 			name:          "invalid JSON response",
-			cmdOutput:     "not valid json",
-			expectedError: "parse claude CLI response",
+			textOutput:    "not valid json",
+			expectedError: "parse summary JSON",
 		},
 		{
 			name:          "invalid summary JSON",
-			cmdOutput:     `{"result": "not a valid summary object"}`,
+			textOutput:    "not a valid summary object",
 			expectedError: "parse summary JSON",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			gen := &ClaudeGenerator{
-				CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-					return exec.CommandContext(ctx, "echo", tt.cmdOutput)
-				},
+				TextGenerator: &stubTextGenerator{text: tt.textOutput},
 			}
 
 			input := Input{
@@ -178,12 +154,10 @@ func TestClaudeGenerator_ErrorCases(t *testing.T) {
 }
 
 func TestClaudeGenerator_ValidResponse(t *testing.T) {
+	t.Parallel()
+
 	gen := &ClaudeGenerator{
-		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			// Use compact JSON to avoid newline issues with echo
-			response := `{"result":"{\"intent\":\"User wanted to fix a bug\",\"outcome\":\"Bug was fixed successfully\",\"learnings\":{\"repo\":[\"The repo uses Go modules\"],\"code\":[{\"path\":\"main.go\",\"line\":10,\"finding\":\"Entry point\"}],\"workflow\":[\"Run tests before committing\"]},\"friction\":[\"Slow CI pipeline\"],\"open_items\":[\"Add more tests\"]}"}`
-			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
-		},
+		TextGenerator: &stubTextGenerator{text: `{"intent":"User wanted to fix a bug","outcome":"Bug was fixed successfully","learnings":{"repo":["The repo uses Go modules"],"code":[{"path":"main.go","line":10,"finding":"Entry point"}],"workflow":["Run tests before committing"]},"friction":["Slow CI pipeline"],"open_items":["Add more tests"]}`},
 	}
 
 	input := Input{
@@ -223,12 +197,10 @@ func TestClaudeGenerator_ValidResponse(t *testing.T) {
 }
 
 func TestClaudeGenerator_MarkdownCodeBlock(t *testing.T) {
+	t.Parallel()
+
 	gen := &ClaudeGenerator{
-		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			// Return summary wrapped in markdown code block - use literal newlines escaped in the JSON string
-			response := `{"result":"` + "```json\\n{\\\"intent\\\":\\\"Test markdown extraction\\\",\\\"outcome\\\":\\\"Works\\\",\\\"learnings\\\":{\\\"repo\\\":[],\\\"code\\\":[],\\\"workflow\\\":[]},\\\"friction\\\":[],\\\"open_items\\\":[]}\\n```" + `"}`
-			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
-		},
+		TextGenerator: &stubTextGenerator{text: "```json\n{\"intent\":\"Test markdown extraction\",\"outcome\":\"Works\",\"learnings\":{\"repo\":[],\"code\":[],\"workflow\":[]},\"friction\":[],\"open_items\":[]}\n```"},
 	}
 
 	input := Input{
@@ -247,12 +219,11 @@ func TestClaudeGenerator_MarkdownCodeBlock(t *testing.T) {
 	}
 }
 
-func TestClaudeGenerator_ArrayResponse(t *testing.T) {
+func TestClaudeGenerator_GeneratedJSON(t *testing.T) {
+	t.Parallel()
+
 	gen := &ClaudeGenerator{
-		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			response := `[{"type":"system","subtype":"init"},{"type":"assistant","message":"Working on it"},{"type":"result","result":"{\"intent\":\"Array response intent\",\"outcome\":\"Array response outcome\",\"learnings\":{\"repo\":[],\"code\":[],\"workflow\":[]},\"friction\":[],\"open_items\":[]}"}]`
-			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
-		},
+		TextGenerator: &stubTextGenerator{text: `{"intent":"Array response intent","outcome":"Array response outcome","learnings":{"repo":[],"code":[],"workflow":[]},"friction":[],"open_items":[]}`},
 	}
 
 	input := Input{
@@ -275,12 +246,11 @@ func TestClaudeGenerator_ArrayResponse(t *testing.T) {
 	}
 }
 
-func TestClaudeGenerator_ArrayResponseWithoutResult(t *testing.T) {
+func TestClaudeGenerator_InvalidGeneratedJSON(t *testing.T) {
+	t.Parallel()
+
 	gen := &ClaudeGenerator{
-		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			response := `[{"type":"system","subtype":"init"},{"type":"assistant","message":"Working on it"}]`
-			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
-		},
+		TextGenerator: &stubTextGenerator{text: `[{"type":"system","subtype":"init"},{"type":"assistant","message":"Working on it"}]`},
 	}
 
 	input := Input{
@@ -294,12 +264,14 @@ func TestClaudeGenerator_ArrayResponseWithoutResult(t *testing.T) {
 		t.Fatal("expected error")
 	}
 
-	if !strings.Contains(err.Error(), "parse claude CLI response") {
+	if !strings.Contains(err.Error(), "parse summary JSON") {
 		t.Errorf("expected parse error, got: %v", err)
 	}
 }
 
 func TestBuildSummarizationPrompt(t *testing.T) {
+	t.Parallel()
+
 	transcriptText := "[User] Hello\n\n[Assistant] Hi"
 
 	prompt := buildSummarizationPrompt(transcriptText)
@@ -326,6 +298,8 @@ func TestBuildSummarizationPrompt(t *testing.T) {
 }
 
 func TestExtractJSONFromMarkdown(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    string
@@ -360,6 +334,7 @@ func TestExtractJSONFromMarkdown(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := extractJSONFromMarkdown(tt.input)
 			if result != tt.expected {
 				t.Errorf("expected %q, got %q", tt.expected, result)

--- a/cmd/entire/cli/summarize/claude_test.go
+++ b/cmd/entire/cli/summarize/claude_test.go
@@ -45,7 +45,7 @@ func (s *stubTextGenerator) GetSessionDir(string) (string, error) { return "", n
 func (s *stubTextGenerator) ResolveSessionFile(string, string) string { return "" }
 
 func (s *stubTextGenerator) ReadSession(*agent.HookInput) (*agent.AgentSession, error) {
-	return nil, nil
+	return &agent.AgentSession{}, nil
 }
 
 func (s *stubTextGenerator) WriteSession(context.Context, *agent.AgentSession) error { return nil }

--- a/cmd/entire/cli/summarize/claude_test.go
+++ b/cmd/entire/cli/summarize/claude_test.go
@@ -247,6 +247,58 @@ func TestClaudeGenerator_MarkdownCodeBlock(t *testing.T) {
 	}
 }
 
+func TestClaudeGenerator_ArrayResponse(t *testing.T) {
+	gen := &ClaudeGenerator{
+		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			response := `[{"type":"system","subtype":"init"},{"type":"assistant","message":"Working on it"},{"type":"result","result":"{\"intent\":\"Array response intent\",\"outcome\":\"Array response outcome\",\"learnings\":{\"repo\":[],\"code\":[],\"workflow\":[]},\"friction\":[],\"open_items\":[]}"}]`
+			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
+		},
+	}
+
+	input := Input{
+		Transcript: []Entry{
+			{Type: EntryTypeUser, Content: "Summarize this"},
+		},
+	}
+
+	summary, err := gen.Generate(context.Background(), input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if summary.Intent != "Array response intent" {
+		t.Errorf("unexpected intent: %s", summary.Intent)
+	}
+
+	if summary.Outcome != "Array response outcome" {
+		t.Errorf("unexpected outcome: %s", summary.Outcome)
+	}
+}
+
+func TestClaudeGenerator_ArrayResponseWithoutResult(t *testing.T) {
+	gen := &ClaudeGenerator{
+		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			response := `[{"type":"system","subtype":"init"},{"type":"assistant","message":"Working on it"}]`
+			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
+		},
+	}
+
+	input := Input{
+		Transcript: []Entry{
+			{Type: EntryTypeUser, Content: "Summarize this"},
+		},
+	}
+
+	_, err := gen.Generate(context.Background(), input)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "parse claude CLI response") {
+		t.Errorf("expected parse error, got: %v", err)
+	}
+}
+
 func TestBuildSummarizationPrompt(t *testing.T) {
 	transcriptText := "[User] Hello\n\n[Assistant] Hi"
 

--- a/cmd/entire/cli/summarize/summarize_test.go
+++ b/cmd/entire/cli/summarize/summarize_test.go
@@ -3,7 +3,6 @@ package summarize
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -653,10 +652,7 @@ func TestFormatCondensedTranscript_EmptyInput(t *testing.T) {
 func TestGenerateFromTranscript(t *testing.T) {
 	// Test with mock generator
 	mockGenerator := &ClaudeGenerator{
-		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			response := `{"result":"{\"intent\":\"Test intent\",\"outcome\":\"Test outcome\",\"learnings\":{\"repo\":[],\"code\":[],\"workflow\":[]},\"friction\":[],\"open_items\":[]}"}`
-			return exec.CommandContext(ctx, "sh", "-c", "printf '%s' '"+response+"'")
-		},
+		TextGenerator: &stubTextGenerator{text: `{"intent":"Test intent","outcome":"Test outcome","learnings":{"repo":[],"code":[],"workflow":[]},"friction":[],"open_items":[]}`},
 	}
 
 	transcript := []byte(`{"type":"user","message":{"content":"Hello"}}


### PR DESCRIPTION
## Summary
Supports both Claude CLI `--output-format json` response shapes when generating summaries:
- legacy single-object output like `{ "result": ... }`
- newer array output containing a `type: "result"` item

This fixes summary generation for Claude Code environments that emit array-shaped JSON while preserving compatibility with installs that still return the legacy object shape.

## Changes
- add a shared Claude CLI result extractor in the `agent` package
- reuse that extractor in `summarize/claude.go` and `agent/claudecode/generate.go`
- add regression coverage for array-shaped Claude responses in summary generation
- add Claude Code `GenerateText` coverage for array-shaped responses

## Verification
- `go test ./cmd/entire/cli/summarize ./cmd/entire/cli/agent ./cmd/entire/cli/agent/claudecode`
- manual end-to-end verification with local Claude shims for both object and array response shapes against `entire explain --checkpoint <id> --generate --force`

Closes #750

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to Claude CLI response parsing with added test coverage; primary risk is unforeseen response variants causing summary/text generation to fail to parse.
> 
> **Overview**
> Adds a shared `agent.ExtractClaudeCLIResult` helper that can pull the `result` payload from both legacy single-object Claude CLI JSON and newer array-shaped responses.
> 
> Updates Claude-based summary generation (`summarize/claude.go`) and Claude Code `GenerateText` to use this extractor, and injects a `CommandRunner` into `ClaudeCodeAgent` to make the behavior testable. New tests cover array responses (and the missing-`result` error path) for both summarization and text generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9ddd3190ffadcd0d7fa33c24fc0bf88a05b23e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->