### PR TITLE
Add `entire commit` command

### DIFF
--- a/cmd/entire/cli/commit.go
+++ b/cmd/entire/cli/commit.go
@@ -8,6 +8,9 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	checkpointid "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 
@@ -53,6 +56,17 @@ func runCommit(ctx context.Context, message string) (plumbing.Hash, error) {
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
+	checkpointID = resolveCommitCheckpointID(finalMessage, checkpointID)
+	if checkpointID == "" {
+		forcedCheckpointID, forceErr := forceCheckpointIDForActiveSession(ctx)
+		if forceErr != nil {
+			return plumbing.ZeroHash, forceErr
+		}
+		if !forcedCheckpointID.IsEmpty() {
+			checkpointID = forcedCheckpointID.String()
+			finalMessage = trailers.FormatCheckpoint(finalMessage, forcedCheckpointID)
+		}
+	}
 
 	treeHash, err := buildCommitTreeFromIndex(ctx, repo)
 	if err != nil {
@@ -90,7 +104,7 @@ func runCommit(ctx context.Context, message string) (plumbing.Hash, error) {
 
 	if checkpointID != "" {
 		commit.ExtraHeaders = []object.ExtraHeader{
-			{Key: trailers.CheckpointTrailerKey, Value: checkpointID},
+			{Key: trailers.CheckpointHeaderKey, Value: checkpointID},
 		}
 	}
 
@@ -147,6 +161,15 @@ func prepareEntireCommitMessage(ctx context.Context, message string) (string, st
 	cpID, found := trailers.ParseCheckpoint(finalMessage)
 	if found {
 		return finalMessage, cpID.String(), nil
+	}
+
+	forcedCheckpointID, err := forceCheckpointIDForActiveSession(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	if forcedCheckpointID != "" {
+		finalMessage = trailers.FormatCheckpoint(finalMessage, forcedCheckpointID)
+		return finalMessage, forcedCheckpointID.String(), nil
 	}
 
 	return finalMessage, "", nil
@@ -222,4 +245,72 @@ func shortCommitHash(hash plumbing.Hash) string {
 		return s
 	}
 	return s[:7]
+}
+
+func forceCheckpointIDForActiveSession(ctx context.Context) (checkpointid.CheckpointID, error) {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return checkpointid.EmptyCheckpointID, nil
+	}
+
+	store, err := session.NewStateStore(ctx)
+	if err != nil {
+		return checkpointid.EmptyCheckpointID, fmt.Errorf("failed to open session state store: %w", err)
+	}
+
+	states, err := store.List(ctx)
+	if err != nil {
+		return checkpointid.EmptyCheckpointID, fmt.Errorf("failed to list session states: %w", err)
+	}
+
+	var eligible []*session.State
+	for _, state := range states {
+		if state.BaseCommit == "" {
+			continue
+		}
+		if !shouldLinkSessionState(state) {
+			continue
+		}
+		eligible = append(eligible, state)
+		if state.WorktreePath != "" && state.WorktreePath == worktreeRoot {
+			cpID, genErr := checkpointid.Generate()
+			if genErr != nil {
+				return checkpointid.EmptyCheckpointID, fmt.Errorf("failed to generate checkpoint ID: %w", genErr)
+			}
+			return cpID, nil
+		}
+	}
+
+	if len(eligible) == 1 {
+		cpID, genErr := checkpointid.Generate()
+		if genErr != nil {
+			return checkpointid.EmptyCheckpointID, fmt.Errorf("failed to generate checkpoint ID: %w", genErr)
+		}
+		return cpID, nil
+	}
+
+	return checkpointid.EmptyCheckpointID, nil
+}
+
+func shouldLinkSessionState(state *session.State) bool {
+	if state == nil {
+		return false
+	}
+	if state.Phase.IsActive() {
+		return true
+	}
+	if !state.FullyCondensed && (state.StepCount > 0 || len(state.FilesTouched) > 0) {
+		return true
+	}
+	return false
+}
+
+func resolveCommitCheckpointID(message, checkpointID string) string {
+	if checkpointID != "" {
+		return checkpointID
+	}
+	if cpID, found := trailers.ParseCheckpoint(message); found {
+		return cpID.String()
+	}
+	return ""
 }

--- a/cmd/entire/cli/commit.go
+++ b/cmd/entire/cli/commit.go
@@ -1,0 +1,225 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/spf13/cobra"
+)
+
+func newCommitCmd() *cobra.Command {
+	var message string
+
+	cmd := &cobra.Command{
+		Use:   "commit",
+		Short: "Create a git commit with Entire checkpoint headers",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if message == "" {
+				return errors.New("commit message is required; use -m")
+			}
+
+			hash, err := runCommit(cmd.Context(), message)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "[%s] %s\n", shortCommitHash(hash), firstLine(message))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&message, "message", "m", "", "Commit message")
+	return cmd
+}
+
+func runCommit(ctx context.Context, message string) (plumbing.Hash, error) {
+	repo, err := openRepository(ctx)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	finalMessage, checkpointID, err := prepareEntireCommitMessage(ctx, message)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	treeHash, err := buildCommitTreeFromIndex(ctx, repo)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	parents, previousTree, err := getCommitParentsAndTree(repo)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	if treeHash == previousTree {
+		return plumbing.ZeroHash, git.ErrEmptyCommit
+	}
+
+	author, err := GetGitAuthor(ctx)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	now := time.Now()
+	sig := object.Signature{
+		Name:  author.Name,
+		Email: author.Email,
+		When:  now,
+	}
+
+	commit := &object.Commit{
+		TreeHash:     treeHash,
+		ParentHashes: parents,
+		Author:       sig,
+		Committer:    sig,
+		Message:      finalMessage,
+	}
+
+	if checkpointID != "" {
+		commit.ExtraHeaders = []object.ExtraHeader{
+			{Key: trailers.CheckpointTrailerKey, Value: checkpointID},
+		}
+	}
+
+	obj := repo.Storer.NewEncodedObject()
+	if err := commit.Encode(obj); err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to encode commit: %w", err)
+	}
+
+	hash, err := repo.Storer.SetEncodedObject(obj)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to store commit: %w", err)
+	}
+
+	if err := updateCommitHEAD(repo, hash); err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	if err := GetStrategy(ctx).PostCommit(ctx); err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	return hash, nil
+}
+
+func prepareEntireCommitMessage(ctx context.Context, message string) (string, string, error) {
+	tmp, err := os.CreateTemp("", "entire-commit-msg-*")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temporary commit message: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Close(); err != nil {
+		return "", "", fmt.Errorf("failed to close temporary commit message: %w", err)
+	}
+	defer os.Remove(tmpPath)
+
+	if err := os.WriteFile(tmpPath, []byte(message), 0o600); err != nil {
+		return "", "", fmt.Errorf("failed to write temporary commit message: %w", err)
+	}
+
+	strat := GetStrategy(ctx)
+	if err := strat.PrepareCommitMsg(ctx, tmpPath, "message"); err != nil {
+		return "", "", err
+	}
+	if err := strat.CommitMsg(ctx, tmpPath); err != nil {
+		return "", "", err
+	}
+
+	content, err := os.ReadFile(tmpPath) //nolint:gosec // temp file created by this process
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read temporary commit message: %w", err)
+	}
+
+	finalMessage := string(content)
+	cpID, found := trailers.ParseCheckpoint(finalMessage)
+	if found {
+		return finalMessage, cpID.String(), nil
+	}
+
+	return finalMessage, "", nil
+}
+
+func buildCommitTreeFromIndex(ctx context.Context, repo *git.Repository) (plumbing.Hash, error) {
+	idx, err := repo.Storer.Index()
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to read git index: %w", err)
+	}
+
+	if len(idx.Entries) == 0 {
+		return plumbing.ZeroHash, git.ErrEmptyCommit
+	}
+
+	entries := make(map[string]object.TreeEntry, len(idx.Entries))
+	for _, entry := range idx.Entries {
+		entries[entry.Name] = object.TreeEntry{
+			Name: entry.Name,
+			Mode: entry.Mode,
+			Hash: entry.Hash,
+		}
+	}
+
+	treeHash, err := checkpoint.BuildTreeFromEntries(ctx, repo, entries)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to build commit tree: %w", err)
+	}
+
+	return treeHash, nil
+}
+
+func getCommitParentsAndTree(repo *git.Repository) ([]plumbing.Hash, plumbing.Hash, error) {
+	if strategy.IsEmptyRepository(repo) {
+		return nil, plumbing.ZeroHash, nil
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return nil, plumbing.ZeroHash, fmt.Errorf("failed to resolve HEAD: %w", err)
+	}
+
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		return nil, plumbing.ZeroHash, fmt.Errorf("failed to resolve HEAD commit: %w", err)
+	}
+
+	return []plumbing.Hash{head.Hash()}, commit.TreeHash, nil
+}
+
+func updateCommitHEAD(repo *git.Repository, commitHash plumbing.Hash) error {
+	head, err := repo.Storer.Reference(plumbing.HEAD)
+	if err != nil {
+		return fmt.Errorf("failed to read HEAD reference: %w", err)
+	}
+
+	name := plumbing.HEAD
+	if head.Type() != plumbing.HashReference {
+		name = head.Target()
+	}
+
+	ref := plumbing.NewHashReference(name, commitHash)
+	if err := repo.Storer.SetReference(ref); err != nil {
+		return fmt.Errorf("failed to update HEAD: %w", err)
+	}
+
+	return nil
+}
+
+func shortCommitHash(hash plumbing.Hash) string {
+	s := hash.String()
+	if len(s) <= 7 {
+		return s
+	}
+	return s[:7]
+}

--- a/cmd/entire/cli/commit_test.go
+++ b/cmd/entire/cli/commit_test.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommit_WritesCheckpointTrailerAndExtraHeader(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "hello.txt", "initial\n")
+	testutil.GitAdd(t, repoDir, "hello.txt")
+	testutil.GitCommit(t, repoDir, "initial")
+
+	t.Chdir(repoDir)
+	testutil.WriteFile(t, repoDir, "hello.txt", "agent change\n")
+	testutil.GitAdd(t, repoDir, "hello.txt")
+
+	sessionID := "test-commit-session"
+	require.NoError(t, setupCommitSession(context.Background(), repoDir, sessionID, "hello.txt", "agent change\n"))
+
+	cmd := newCommitCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"-m", "feat: add header"})
+
+	require.NoError(t, cmd.Execute())
+
+	repo, err := git.PlainOpen(repoDir)
+	require.NoError(t, err)
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	commit, err := repo.CommitObject(head.Hash())
+	require.NoError(t, err)
+
+	cpID, found := trailers.ParseCheckpoint(commit.Message)
+	require.True(t, found, "expected checkpoint trailer in commit message")
+
+	require.Len(t, commit.ExtraHeaders, 1)
+	require.Equal(t, trailers.CheckpointTrailerKey, commit.ExtraHeaders[0].Key)
+	require.Equal(t, cpID.String(), commit.ExtraHeaders[0].Value)
+
+	require.Contains(t, out.String(), "[")
+	require.Contains(t, out.String(), "feat: add header")
+}
+
+func TestCommit_NoStagedChangesReturnsError(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "hello.txt", "initial\n")
+	testutil.GitAdd(t, repoDir, "hello.txt")
+	testutil.GitCommit(t, repoDir, "initial")
+
+	t.Chdir(repoDir)
+
+	cmd := newCommitCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"-m", "feat: empty"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.True(t, errors.Is(err, git.ErrEmptyCommit))
+}
+
+func setupCommitSession(ctx context.Context, repoDir, sessionID, filePath, content string) error {
+	strat := strategy.NewManualCommitStrategy()
+	if err := strat.InitializeSession(ctx, sessionID, agent.AgentTypeClaudeCode, "", "update file", ""); err != nil {
+		return err
+	}
+
+	metadataDir := filepath.Join(".entire", "metadata", sessionID)
+	metadataDirAbs := filepath.Join(repoDir, metadataDir)
+	if err := os.MkdirAll(metadataDirAbs, 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(metadataDirAbs, "prompt.txt"), []byte("update file\n"), 0o644); err != nil {
+		return err
+	}
+
+	return strat.SaveStep(ctx, strategy.StepContext{
+		SessionID:      sessionID,
+		ModifiedFiles:  []string{filePath},
+		MetadataDir:    metadataDir,
+		MetadataDirAbs: metadataDirAbs,
+		CommitMessage:  "checkpoint",
+		AuthorName:     "Test User",
+		AuthorEmail:    "test@example.com",
+		AgentType:      agent.AgentTypeClaudeCode,
+	})
+}
+
+func TestCommit_RegisteredOnRoot(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd()
+	cmd, _, err := root.Find([]string{"commit"})
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "commit", cmd.Name())
+}

--- a/cmd/entire/cli/commit_test.go
+++ b/cmd/entire/cli/commit_test.go
@@ -3,12 +3,12 @@ package cli
 import (
 	"bytes"
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	checkpointid "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
@@ -52,7 +52,7 @@ func TestCommit_WritesCheckpointTrailerAndExtraHeader(t *testing.T) {
 	require.True(t, found, "expected checkpoint trailer in commit message")
 
 	require.Len(t, commit.ExtraHeaders, 1)
-	require.Equal(t, trailers.CheckpointTrailerKey, commit.ExtraHeaders[0].Key)
+	require.Equal(t, trailers.CheckpointHeaderKey, commit.ExtraHeaders[0].Key)
 	require.Equal(t, cpID.String(), commit.ExtraHeaders[0].Value)
 
 	require.Contains(t, out.String(), "[")
@@ -75,7 +75,57 @@ func TestCommit_NoStagedChangesReturnsError(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	require.True(t, errors.Is(err, git.ErrEmptyCommit))
+	require.ErrorIs(t, err, git.ErrEmptyCommit)
+}
+
+func TestCommit_ForceLinksActiveSessionWithoutPreparedCheckpoint(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "hello.txt", "initial\n")
+	testutil.GitAdd(t, repoDir, "hello.txt")
+	testutil.GitCommit(t, repoDir, "initial")
+
+	t.Chdir(repoDir)
+
+	strat := strategy.NewManualCommitStrategy()
+	require.NoError(t, strat.InitializeSession(context.Background(), "test-force-link", agent.AgentTypeClaudeCode, "", "update file", ""))
+
+	testutil.WriteFile(t, repoDir, "hello.txt", "forced link\n")
+	testutil.GitAdd(t, repoDir, "hello.txt")
+
+	cmd := newCommitCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"-m", "feat: forced link"})
+
+	require.NoError(t, cmd.Execute())
+
+	repo, err := git.PlainOpen(repoDir)
+	require.NoError(t, err)
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	commit, err := repo.CommitObject(head.Hash())
+	require.NoError(t, err)
+
+	cpID, found := trailers.ParseCheckpoint(commit.Message)
+	require.True(t, found, "expected forced checkpoint trailer in commit message")
+	require.NotEmpty(t, cpID.String())
+
+	require.Len(t, commit.ExtraHeaders, 1)
+	require.Equal(t, trailers.CheckpointHeaderKey, commit.ExtraHeaders[0].Key)
+	require.Equal(t, cpID.String(), commit.ExtraHeaders[0].Value)
+}
+
+func TestResolveCommitCheckpointID_ParsesFinalMessage(t *testing.T) {
+	t.Parallel()
+
+	cpID := checkpointid.MustCheckpointID("abc123def456")
+	message := trailers.FormatCheckpoint("feat: parse final message", cpID)
+
+	resolved := resolveCommitCheckpointID(message, "")
+	require.Equal(t, cpID.String(), resolved)
 }
 
 func setupCommitSession(ctx context.Context, repoDir, sessionID, filePath, content string) error {

--- a/cmd/entire/cli/commit_test.go
+++ b/cmd/entire/cli/commit_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 
 	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/require"
 )
 
@@ -78,6 +79,38 @@ func TestCommit_NoStagedChangesReturnsError(t *testing.T) {
 	require.ErrorIs(t, err, git.ErrEmptyCommit)
 }
 
+func TestCommit_DoesNotWriteCheckpointHeaderWithoutCheckpoint(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "hello.txt", "initial\n")
+	testutil.GitAdd(t, repoDir, "hello.txt")
+	testutil.GitCommit(t, repoDir, "initial")
+
+	t.Chdir(repoDir)
+	testutil.WriteFile(t, repoDir, "hello.txt", "regular change\n")
+	testutil.GitAdd(t, repoDir, "hello.txt")
+
+	cmd := newCommitCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"-m", "feat: regular commit"})
+
+	require.NoError(t, cmd.Execute())
+
+	repo, err := git.PlainOpen(repoDir)
+	require.NoError(t, err)
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	commit, err := repo.CommitObject(head.Hash())
+	require.NoError(t, err)
+
+	_, found := trailers.ParseCheckpoint(commit.Message)
+	require.False(t, found, "did not expect checkpoint trailer in commit message")
+	require.Empty(t, commit.ExtraHeaders, "did not expect checkpoint extra header")
+}
+
 func TestCommit_ForceLinksActiveSessionWithoutPreparedCheckpoint(t *testing.T) {
 	repoDir := t.TempDir()
 	testutil.InitRepo(t, repoDir)
@@ -118,6 +151,28 @@ func TestCommit_ForceLinksActiveSessionWithoutPreparedCheckpoint(t *testing.T) {
 	require.Equal(t, cpID.String(), commit.ExtraHeaders[0].Value)
 }
 
+func TestCommit_ReparsesCheckpointIDFromFinalMessageForHeader(t *testing.T) {
+	t.Parallel()
+
+	cpID := checkpointid.MustCheckpointID("abc123def456")
+	finalMessage := trailers.FormatCheckpoint("feat: parse final message", cpID)
+
+	resolved := resolveCommitCheckpointID(finalMessage, "")
+	require.Equal(t, cpID.String(), resolved)
+
+	commit := &object.Commit{Message: finalMessage}
+	checkpointID := resolveCommitCheckpointID(commit.Message, "")
+	if checkpointID != "" {
+		commit.ExtraHeaders = []object.ExtraHeader{
+			{Key: trailers.CheckpointHeaderKey, Value: checkpointID},
+		}
+	}
+
+	require.Len(t, commit.ExtraHeaders, 1)
+	require.Equal(t, trailers.CheckpointHeaderKey, commit.ExtraHeaders[0].Key)
+	require.Equal(t, cpID.String(), commit.ExtraHeaders[0].Value)
+}
+
 func TestResolveCommitCheckpointID_ParsesFinalMessage(t *testing.T) {
 	t.Parallel()
 
@@ -126,6 +181,12 @@ func TestResolveCommitCheckpointID_ParsesFinalMessage(t *testing.T) {
 
 	resolved := resolveCommitCheckpointID(message, "")
 	require.Equal(t, cpID.String(), resolved)
+}
+
+func TestCheckpointHeaderKey_IsLowercaseCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "checkpoint", trailers.CheckpointHeaderKey)
 }
 
 func setupCommitSession(ctx context.Context, repoDir, sessionID, filePath, content string) error {

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -99,6 +99,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newSearchCmd())
 	cmd.AddCommand(newSendAnalyticsCmd())
 	cmd.AddCommand(newAttachCmd())
+	cmd.AddCommand(newCommitCmd())
 	cmd.AddCommand(newCurlBashPostInstallCmd())
 	cmd.AddCommand(newMigrateCmd())
 

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -40,6 +40,9 @@ const (
 	// This trailer survives git amend and rebase operations.
 	CheckpointTrailerKey = "Entire-Checkpoint"
 
+	// CheckpointHeaderKey is the lowercase commit object extra header key.
+	CheckpointHeaderKey = "checkpoint"
+
 	// EphemeralBranchTrailerKey identifies the shadow branch that a checkpoint originated from.
 	// Used in manual-commit strategy checkpoint commits on entire/checkpoints/v1 branch.
 	// Format: full branch name e.g. "entire/2b4c177"


### PR DESCRIPTION
This command enables adding checkpoint information as a Git header directly into the Commit object:

```
$ entire commit -m "Improve test coverage"

Entire: Active Codex session detected
  Last prompt: Plug those three gaps

Link this commit to session context?
  [Y]es / [n]o / [a]lways (remember my choice): y
2026/04/11 00:41:24 INFO prepare-commit-msg: trailer added component=checkpoint strategy=manual-commit source=message checkpoint_id=317de6082c49
2026/04/11 00:41:24 INFO attribution calculated component=attribution agent_lines=61 human_added=0 human_modified=0 human_removed=0 total_committed=61 agent_percentage=100 accumulated_user_added=0 accumulated_user_removed=0 files_touched=1
2026/04/11 00:41:25 INFO session condensed component=checkpoint strategy=manual-commit session_id=019d7738-a66d-72a1-8a9f-c7975b0fc400 checkpoint_id=317de6082c49 checkpoints_condensed=1 transcript_lines=551
2026/04/11 00:41:25 INFO shadow branch deleted component=checkpoint strategy=manual-commit shadow_branch=entire/eab33a5-e3b0c4
[e401559] Improve test coverage

$ git cat-file -p e401559
tree b82c98e7301e14ace845ef8557b85959cf3d4341
parent eab33a570a3e86dea1f0594a8df2b9788e09254e
author Paulo Gomes <pjbgf@linux.com> 1775864484 +0100
committer Paulo Gomes <pjbgf@linux.com> 1775864484 +0100
checkpoint 317de6082c49

Improve test coverage

Entire-Checkpoint: 317de6082c49
```

When used, git hooks do not need to be configured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new commit-writing code path that directly constructs git commit objects and updates `HEAD`, so bugs could create incorrect commits or refs. Changes are isolated to the new command plus a small new trailer constant and tests.
> 
> **Overview**
> Adds a new `entire commit -m` command that creates a git commit via `go-git`, running the configured strategy commit-msg hooks to inject/normalize the `Entire-Checkpoint` trailer and then persisting the checkpoint ID as an extra commit header (`checkpoint`) when present.
> 
> The command builds the commit tree from the index, rejects empty commits (no staged changes or unchanged tree), updates `HEAD` to the new commit, and triggers `strategy.PostCommit`; it can also *force-link* an eligible active session by generating and appending a checkpoint ID when none was produced by the message processing.
> 
> Includes unit tests covering checkpoint trailer/header behavior, empty-commit errors, forced linking, header key constant, and registration of the new command on the root CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e401559ae9f0391e61e4b285e629b1afb8e7bd5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->