### PR TITLE
ci: remove nightly Windows E2E schedule

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -8,8 +8,6 @@ on:
         description: "Test name filter (regex)"
         required: false
         default: ""
-  schedule:
-    - cron: "0 6 * * *" # Nightly at 6am UTC
 
 concurrency:
   group: e2e-windows-tests


### PR DESCRIPTION
## Summary

Removes the `schedule` cron trigger (6am UTC nightly) from `.github/workflows/e2e-windows.yml`.

Windows E2E is already exercised on merge via `workflow_call`, so the nightly run was redundant and added noise/cost.

## Test plan

- [ ] CI / workflow YAML is valid (no syntax issues)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that removes the cron trigger; it only affects when the workflow runs, not the test execution itself.
> 
> **Overview**
> Removes the nightly `schedule` cron trigger from `.github/workflows/e2e-windows.yml`, so Windows E2E runs only when invoked via `workflow_call` or manually via `workflow_dispatch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ce22dfa3b1ecc33418532089d02922ae8cc7898. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->