### PR TITLE
handle PI_CODING_AGENT in env to not try to do anything interactive

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -62,6 +62,13 @@ func hasTTY() bool {
 		return false
 	}
 
+	// Pi Coding Agent sets PI_CODING_AGENT=true when running shell commands.
+	// Like other agents, the subprocess may inherit the TTY but can't respond
+	// to interactive prompts.
+	if os.Getenv("PI_CODING_AGENT") != "" {
+		return false
+	}
+
 	// GIT_TERMINAL_PROMPT=0 disables git's own terminal prompts.
 	// Factory AI Droid (and other non-interactive environments like CI) set this.
 	// Since we run as a git hook, respect it — if the environment doesn't want


### PR DESCRIPTION
don't show prompts / interactive when running triggering entire via git operations when executed by the pi agent. This is a temporary fix and we should add this to the external agent interface. 

See also: https://github.com/badlogic/pi-mono/blob/3b7448d156aab5af1e21fd9ab45d19e4f10865a8/packages/coding-agent/src/cli.ts#L9


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small environment-variable gate that only affects whether hooks consider a TTY available, preventing hangs in PI agent subprocesses.
> 
> **Overview**
> Prevents interactive git-hook prompting when commands are run under the Pi Coding Agent by extending `hasTTY()` to return false when `PI_CODING_AGENT` is set.
> 
> This ensures `prepare-commit-msg`/related hook flows take the non-interactive path in that environment (similar to existing `GEMINI_CLI`/`COPILOT_CLI` handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4591a1e1d1c384a74e7ca62fd774eb98b410f17f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->