### PR TITLE
show more descriptive info if a checkpoints push, did push something

### DIFF
--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -74,9 +74,8 @@ func doPushBranch(ctx context.Context, target, branchName string) error {
 	stop := startProgressDots(os.Stderr)
 
 	// Try pushing first
-	if err := tryPushSessionsCommon(ctx, target, branchName); err == nil {
-		stop(" done")
-		printSettingsCommitHint(ctx, target)
+	if result, err := tryPushSessionsCommon(ctx, target, branchName); err == nil {
+		finishPush(ctx, stop, result, target)
 		return nil
 	}
 	stop("")
@@ -97,13 +96,12 @@ func doPushBranch(ctx context.Context, target, branchName string) error {
 	fmt.Fprintf(os.Stderr, "[entire] Pushing %s to %s...", branchName, displayTarget)
 	stop = startProgressDots(os.Stderr)
 
-	if err := tryPushSessionsCommon(ctx, target, branchName); err != nil {
+	if result, err := tryPushSessionsCommon(ctx, target, branchName); err != nil {
 		stop("")
 		fmt.Fprintf(os.Stderr, "[entire] Warning: failed to push %s after sync: %v\n", branchName, err)
 		printCheckpointRemoteHint(target)
 	} else {
-		stop(" done")
-		printSettingsCommitHint(ctx, target)
+		finishPush(ctx, stop, result, target)
 	}
 
 	return nil
@@ -159,8 +157,35 @@ func isCheckpointRemoteCommitted(ctx context.Context) bool {
 	return committed.GetCheckpointRemote() != nil
 }
 
+// pushResult describes what happened during a push attempt.
+type pushResult struct {
+	// upToDate is true when the remote already had all commits (nothing transferred).
+	upToDate bool
+}
+
+// parsePushResult checks git push output for known status strings and returns
+// a pushResult. git prints "Everything up-to-date" to stderr when nothing was pushed.
+func parsePushResult(output string) pushResult {
+	return pushResult{
+		upToDate: strings.Contains(output, "Everything up-to-date") ||
+			strings.Contains(output, "everything up-to-date"),
+	}
+}
+
+// finishPush stops the progress dots and prints "already up-to-date" or "done"
+// depending on the push result. Only prints the settings commit hint when new
+// content was actually pushed.
+func finishPush(ctx context.Context, stop func(string), result pushResult, target string) {
+	if result.upToDate {
+		stop(" already up-to-date")
+	} else {
+		stop(" done")
+		printSettingsCommitHint(ctx, target)
+	}
+}
+
 // tryPushSessionsCommon attempts to push the sessions branch.
-func tryPushSessionsCommon(ctx context.Context, remote, branchName string) error {
+func tryPushSessionsCommon(ctx context.Context, remote, branchName string) (pushResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
@@ -168,15 +193,17 @@ func tryPushSessionsCommon(ctx context.Context, remote, branchName string) error
 	cmd := CheckpointGitCommand(ctx, remote, "push", "--no-verify", remote, branchName)
 
 	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
 	if err != nil {
 		// Check if it's a non-fast-forward error (we can try to recover)
-		if strings.Contains(string(output), "non-fast-forward") ||
-			strings.Contains(string(output), "rejected") {
-			return errors.New("non-fast-forward")
+		if strings.Contains(outputStr, "non-fast-forward") ||
+			strings.Contains(outputStr, "rejected") {
+			return pushResult{}, errors.New("non-fast-forward")
 		}
-		return fmt.Errorf("push failed: %s", output)
+		return pushResult{}, fmt.Errorf("push failed: %s", outputStr)
 	}
-	return nil
+
+	return parsePushResult(outputStr), nil
 }
 
 // fetchAndRebaseSessionsCommon fetches remote sessions and rebases local commits

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -163,13 +163,20 @@ type pushResult struct {
 	upToDate bool
 }
 
-// parsePushResult checks git push output for known status strings and returns
-// a pushResult. git prints "Everything up-to-date" to stderr when nothing was pushed.
+// parsePushResult checks git push --porcelain output for ref status flags.
+// In porcelain mode, each ref gets a tab-delimited status line:
+//
+//	<flag>\t<from>:<to>\t<summary>
+//
+// where flag '=' means the ref was already up-to-date. This is locale-independent,
+// unlike the human-readable "Everything up-to-date" message.
 func parsePushResult(output string) pushResult {
-	return pushResult{
-		upToDate: strings.Contains(output, "Everything up-to-date") ||
-			strings.Contains(output, "everything up-to-date"),
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, "=\t") {
+			return pushResult{upToDate: true}
+		}
 	}
+	return pushResult{upToDate: false}
 }
 
 // finishPush stops the progress dots and prints "already up-to-date" or "done"
@@ -189,8 +196,9 @@ func tryPushSessionsCommon(ctx context.Context, remote, branchName string) (push
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	// Use --no-verify to prevent recursive hook calls
-	cmd := CheckpointGitCommand(ctx, remote, "push", "--no-verify", remote, branchName)
+	// Use --no-verify to prevent recursive hook calls.
+	// Use --porcelain for machine-readable, locale-independent output.
+	cmd := CheckpointGitCommand(ctx, remote, "push", "--no-verify", "--porcelain", remote, branchName)
 
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -1099,3 +1099,91 @@ func TestPrintSettingsCommitHint(t *testing.T) {
 		assert.Equal(t, 1, count, "hint should print exactly once, got %d", count)
 	})
 }
+
+// captureStderr redirects os.Stderr to a pipe and returns a function that restores
+// stderr and returns the captured output. Must be called on the main goroutine
+// (not parallel-safe).
+func captureStderr(t *testing.T) func() string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	return func() string {
+		w.Close()
+		var buf bytes.Buffer
+		_, readErr := buf.ReadFrom(r)
+		require.NoError(t, readErr)
+		os.Stderr = old
+		return buf.String()
+	}
+}
+
+// setupBareRemoteWithCheckpointBranch creates a work repo with a checkpoint branch
+// and a bare remote that already has the branch pushed. Returns (workDir, bareDir).
+// Caller must t.Chdir(workDir) before calling push functions.
+func setupBareRemoteWithCheckpointBranch(t *testing.T) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	workDir := setupRepoWithCheckpointBranch(t)
+
+	bareDir := t.TempDir()
+	initCmd := exec.CommandContext(ctx, "git", "init", "--bare")
+	initCmd.Dir = bareDir
+	initCmd.Env = testutil.GitIsolatedEnv()
+	out, err := initCmd.CombinedOutput()
+	require.NoError(t, err, "git init --bare failed: %s", out)
+
+	// Push the checkpoint branch to the bare remote
+	pushCmd := exec.CommandContext(ctx, "git", "push", bareDir, paths.MetadataBranchName)
+	pushCmd.Dir = workDir
+	pushCmd.Env = testutil.GitIsolatedEnv()
+	out, err = pushCmd.CombinedOutput()
+	require.NoError(t, err, "initial push failed: %s", out)
+
+	return workDir, bareDir
+}
+
+// TestDoPushBranch_AlreadyUpToDate verifies that when the remote already has all
+// commits, the output says "already up-to-date" instead of "done".
+//
+// Not parallel: uses t.Chdir() and os.Stderr redirection.
+func TestDoPushBranch_AlreadyUpToDate(t *testing.T) {
+	workDir, bareDir := setupBareRemoteWithCheckpointBranch(t)
+	t.Chdir(workDir)
+
+	restore := captureStderr(t)
+	err := doPushBranch(context.Background(), bareDir, paths.MetadataBranchName)
+	output := restore()
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "already up-to-date", "should indicate nothing was pushed")
+	assert.NotContains(t, output, " done", "should not say 'done' when nothing was pushed")
+}
+
+// TestDoPushBranch_NewContent_SaysDone verifies that when there are new commits
+// to push, the output says "done".
+//
+// Not parallel: uses t.Chdir() and os.Stderr redirection.
+func TestDoPushBranch_NewContent_SaysDone(t *testing.T) {
+	workDir := setupRepoWithCheckpointBranch(t)
+
+	// Create a bare remote with no checkpoint branch yet
+	bareDir := t.TempDir()
+	initCmd := exec.CommandContext(context.Background(), "git", "init", "--bare")
+	initCmd.Dir = bareDir
+	initCmd.Env = testutil.GitIsolatedEnv()
+	out, err := initCmd.CombinedOutput()
+	require.NoError(t, err, "git init --bare failed: %s", out)
+
+	t.Chdir(workDir)
+
+	restore := captureStderr(t)
+	err = doPushBranch(context.Background(), bareDir, paths.MetadataBranchName)
+	output := restore()
+
+	require.NoError(t, err)
+	assert.Contains(t, output, " done", "should say 'done' when new content was pushed")
+	assert.NotContains(t, output, "already up-to-date", "should not say 'already up-to-date' when content was pushed")
+}

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -1102,18 +1102,31 @@ func TestPrintSettingsCommitHint(t *testing.T) {
 
 // captureStderr redirects os.Stderr to a pipe and returns a function that restores
 // stderr and returns the captured output. Must be called on the main goroutine
-// (not parallel-safe).
+// (not parallel-safe). Uses t.Cleanup as a safety net to restore stderr and close
+// pipe file descriptors if the test fails or panics before the returned function
+// is called.
 func captureStderr(t *testing.T) func() string {
 	t.Helper()
 	old := os.Stderr
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 	os.Stderr = w
+
+	// Safety net: restore stderr and close pipe ends on test failure/panic.
+	// In the normal path the returned function handles cleanup first;
+	// duplicate Close calls return an error that we intentionally ignore.
+	t.Cleanup(func() {
+		os.Stderr = old
+		_ = w.Close()
+		_ = r.Close()
+	})
+
 	return func() string {
-		w.Close()
+		_ = w.Close()
 		var buf bytes.Buffer
 		_, readErr := buf.ReadFrom(r)
 		require.NoError(t, readErr)
+		_ = r.Close()
 		os.Stderr = old
 		return buf.String()
 	}

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -41,7 +41,7 @@ func pushRefIfNeeded(ctx context.Context, target string, refName plumbing.Refere
 }
 
 // tryPushRef attempts to push a custom ref using an explicit refspec.
-func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceName) error {
+func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceName) (pushResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
@@ -50,14 +50,16 @@ func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceNa
 	cmd := CheckpointGitCommand(ctx, target, "push", "--no-verify", target, refSpec)
 
 	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
 	if err != nil {
-		if strings.Contains(string(output), "non-fast-forward") ||
-			strings.Contains(string(output), "rejected") {
-			return errors.New("non-fast-forward")
+		if strings.Contains(outputStr, "non-fast-forward") ||
+			strings.Contains(outputStr, "rejected") {
+			return pushResult{}, errors.New("non-fast-forward")
 		}
-		return fmt.Errorf("push failed: %s", output)
+		return pushResult{}, fmt.Errorf("push failed: %s", outputStr)
 	}
-	return nil
+
+	return parsePushResult(outputStr), nil
 }
 
 // doPushRef pushes a custom ref with fetch+merge recovery on conflict.
@@ -71,9 +73,8 @@ func doPushRef(ctx context.Context, target string, refName plumbing.ReferenceNam
 	fmt.Fprintf(os.Stderr, "[entire] Pushing %s to %s...", shortRef, displayTarget)
 	stop := startProgressDots(os.Stderr)
 
-	if err := tryPushRef(ctx, target, refName); err == nil {
-		stop(" done")
-		printSettingsCommitHint(ctx, target)
+	if result, err := tryPushRef(ctx, target, refName); err == nil {
+		finishPush(ctx, stop, result, target)
 		return nil
 	}
 	stop("")
@@ -92,13 +93,12 @@ func doPushRef(ctx context.Context, target string, refName plumbing.ReferenceNam
 	fmt.Fprintf(os.Stderr, "[entire] Pushing %s to %s...", shortRef, displayTarget)
 	stop = startProgressDots(os.Stderr)
 
-	if err := tryPushRef(ctx, target, refName); err != nil {
+	if result, err := tryPushRef(ctx, target, refName); err != nil {
 		stop("")
 		fmt.Fprintf(os.Stderr, "[entire] Warning: failed to push %s after sync: %v\n", shortRef, err)
 		printCheckpointRemoteHint(target)
 	} else {
-		stop(" done")
-		printSettingsCommitHint(ctx, target)
+		finishPush(ctx, stop, result, target)
 	}
 
 	return nil
@@ -328,7 +328,7 @@ func handleRotationConflict(ctx context.Context, target string, repo *git.Reposi
 		return fmt.Errorf("failed to update archive ref: %w", err)
 	}
 
-	if pushErr := tryPushRef(ctx, target, archiveRefName); pushErr != nil {
+	if _, pushErr := tryPushRef(ctx, target, archiveRefName); pushErr != nil {
 		return fmt.Errorf("failed to push updated archive: %w", pushErr)
 	}
 

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -45,9 +45,10 @@ func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceNa
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	// Use --no-verify to prevent recursive hook calls (this runs inside pre-push)
+	// Use --no-verify to prevent recursive hook calls (this runs inside pre-push).
+	// Use --porcelain for machine-readable, locale-independent output.
 	refSpec := fmt.Sprintf("%s:%s", refName, refName)
-	cmd := CheckpointGitCommand(ctx, target, "push", "--no-verify", target, refSpec)
+	cmd := CheckpointGitCommand(ctx, target, "push", "--no-verify", "--porcelain", target, refSpec)
 
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)


### PR DESCRIPTION
before: 

```
cli on  soph/opencode-grant-more-bootime [$] via 🐹 v1.26.2 took 5s
❯ git push
[entire] Pushing entire/checkpoints/v1 to checkpoint remote.... done
Everything up-to-date

cli on  soph/opencode-grant-more-bootime [$] via 🐹 v1.26.2 took 2s
❯ git push
[entire] Pushing entire/checkpoints/v1 to checkpoint remote.... done
Everything up-to-date
```

after:

```
cli on  soph/show-better-push-state [$] via 🐹 v1.26.2 took 2s
❯ git push
[entire] Pushing entire/checkpoints/v1 to checkpoint remote.... already up-to-date
Everything up-to-date
cli on  soph/show-better-push-state [$] via 🐹 v1.26.2 took 2s
❯ git push
[entire] Pushing entire/checkpoints/v1 to checkpoint remote.... already up-to-date
Everything up-to-date
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core checkpoint push control flow and function signatures to parse `git push` output, which could mis-detect status across git versions/locales and alter user-facing hook messaging.
> 
> **Overview**
> Improves checkpoint push UX by detecting when a `git push` is a no-op and printing **"already up-to-date"** instead of **"done"**, and only showing the post-push `checkpoint_remote` settings hint when new content was actually transferred.
> 
> This introduces a `pushResult` parsed from `git push` output and threads it through both branch pushes (`tryPushSessionsCommon`/`doPushBranch`) and v2 ref pushes (`tryPushRef`/`doPushRef`), with new tests asserting the updated stderr messaging for up-to-date vs new-content pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed79f72aa79b2ebd850a34ace2e690beb311aba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->