### PR TITLE
hide search command from menu

### DIFF
--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -39,7 +39,8 @@ displayed in an interactive table. Use --json for machine-readable output.
 
 CLI queries also support inline filters like author:<name>, date:<week|month>,
 branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
-		Args: cobra.ArbitraryArgs,
+		Args:   cobra.ArbitraryArgs,
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			query := strings.Join(args, " ")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only marks the `entire search` Cobra command as hidden, affecting CLI discoverability/help output but not execution logic.
> 
> **Overview**
> Hides the `entire search` command from the CLI help/menu by setting `Hidden: true` on the Cobra command, while keeping the command and its flags/behavior otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342e0515b270c863c3caa440cd08f7b99be5c703. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->