### PR TITLE
Fetch checkpoint refs by URL to avoid polluting origin config

### DIFF
--- a/cmd/entire/cli/fetch_no_config_pollution_test.go
+++ b/cmd/entire/cli/fetch_no_config_pollution_test.go
@@ -41,11 +41,12 @@ func TestFetchDoesNotPolluteOriginConfig(t *testing.T) {
 	runGit(t, localDir, "branch", paths.MetadataBranchName)
 	runGit(t, localDir, "update-ref", paths.V2MainRefName, "HEAD")
 	runGit(t, localDir, "push", "origin", "HEAD:refs/heads/main", paths.MetadataBranchName, paths.V2MainRefName)
+	runGit(t, bareDir, "symbolic-ref", "HEAD", "refs/heads/main")
 
 	// Clone fresh so local has no metadata branch yet — this is the scenario
 	// the fetch helpers in git_operations.go are designed for.
 	clonedDir := filepath.Join(tmpDir, "cloned")
-	runGit(t, tmpDir, "clone", bareDir, clonedDir)
+	runGit(t, tmpDir, "clone", "--branch", "main", bareDir, clonedDir)
 	// git clone writes a global git config in some environments; configure
 	// user identity so any subsequent ops here don't fail.
 	runGit(t, clonedDir, "config", "user.email", "test@example.com")

--- a/cmd/entire/cli/fetch_no_config_pollution_test.go
+++ b/cmd/entire/cli/fetch_no_config_pollution_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,13 @@ func TestFetchDoesNotPolluteOriginConfig(t *testing.T) {
 	// user identity so any subsequent ops here don't fail.
 	runGit(t, clonedDir, "config", "user.email", "test@example.com")
 	runGit(t, clonedDir, "config", "user.name", "Test")
+	if err := os.MkdirAll(filepath.Join(clonedDir, ".entire"), 0o755); err != nil {
+		t.Fatalf("failed to create .entire directory: %v", err)
+	}
+	settingsJSON := `{"enabled": true, "strategy_options": {"filtered_fetches_use_url": true}}`
+	if err := os.WriteFile(filepath.Join(clonedDir, ".entire", "settings.json"), []byte(settingsJSON), 0o644); err != nil {
+		t.Fatalf("failed to write settings.json: %v", err)
+	}
 
 	t.Chdir(clonedDir)
 

--- a/cmd/entire/cli/fetch_no_config_pollution_test.go
+++ b/cmd/entire/cli/fetch_no_config_pollution_test.go
@@ -39,7 +39,8 @@ func TestFetchDoesNotPolluteOriginConfig(t *testing.T) {
 	testutil.GitCommit(t, localDir, "init")
 	runGit(t, localDir, "remote", "add", "origin", bareDir)
 	runGit(t, localDir, "branch", paths.MetadataBranchName)
-	runGit(t, localDir, "push", "origin", "HEAD:refs/heads/main", paths.MetadataBranchName)
+	runGit(t, localDir, "update-ref", paths.V2MainRefName, "HEAD")
+	runGit(t, localDir, "push", "origin", "HEAD:refs/heads/main", paths.MetadataBranchName, paths.V2MainRefName)
 
 	// Clone fresh so local has no metadata branch yet — this is the scenario
 	// the fetch helpers in git_operations.go are designed for.
@@ -52,7 +53,7 @@ func TestFetchDoesNotPolluteOriginConfig(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(clonedDir, ".entire"), 0o755); err != nil {
 		t.Fatalf("failed to create .entire directory: %v", err)
 	}
-	settingsJSON := `{"enabled": true, "strategy_options": {"filtered_fetches_use_url": true}}`
+	settingsJSON := `{"enabled": true, "strategy_options": {"filtered_fetches": true}}`
 	if err := os.WriteFile(filepath.Join(clonedDir, ".entire", "settings.json"), []byte(settingsJSON), 0o644); err != nil {
 		t.Fatalf("failed to write settings.json: %v", err)
 	}
@@ -65,6 +66,8 @@ func TestFetchDoesNotPolluteOriginConfig(t *testing.T) {
 	}{
 		{"FetchMetadataBranch", FetchMetadataBranch},
 		{"FetchMetadataTreeOnly", FetchMetadataTreeOnly},
+		{"FetchV2MainTreeOnly", FetchV2MainTreeOnly},
+		{"FetchV2MainRef", FetchV2MainRef},
 	}
 
 	for _, tc := range cases {

--- a/cmd/entire/cli/fetch_no_config_pollution_test.go
+++ b/cmd/entire/cli/fetch_no_config_pollution_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// TestFetchDoesNotPolluteOriginConfig is a regression test for #712.
+//
+// Using `git fetch --filter=blob:none <remote-name>` causes git to persist
+// remote.<name>.promisor=true and remote.<name>.partialclonefilter=blob:none
+// into .git/config. That is sticky across future fetches on the same remote
+// (including the user's regular `git fetch origin` / `git pull`), turning
+// origin into a promisor remote and changing fetch behavior repo-wide.
+//
+// The fix fetches by URL instead of by remote name so git does not touch
+// remote.origin.* in local config.
+func TestFetchDoesNotPolluteOriginConfig(t *testing.T) {
+	// Uses t.Chdir() — cannot run in parallel.
+
+	tmpDir := t.TempDir()
+	bareDir := filepath.Join(tmpDir, "bare.git")
+	localDir := filepath.Join(tmpDir, "local")
+
+	runGit(t, tmpDir, "init", "--bare", bareDir)
+
+	// Set up local repo with an initial commit and the metadata branch pushed
+	// to the bare remote.
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "README.md", "hello")
+	testutil.GitAdd(t, localDir, "README.md")
+	testutil.GitCommit(t, localDir, "init")
+	runGit(t, localDir, "remote", "add", "origin", bareDir)
+	runGit(t, localDir, "branch", paths.MetadataBranchName)
+	runGit(t, localDir, "push", "origin", "HEAD:refs/heads/main", paths.MetadataBranchName)
+
+	// Clone fresh so local has no metadata branch yet — this is the scenario
+	// the fetch helpers in git_operations.go are designed for.
+	clonedDir := filepath.Join(tmpDir, "cloned")
+	runGit(t, tmpDir, "clone", bareDir, clonedDir)
+	// git clone writes a global git config in some environments; configure
+	// user identity so any subsequent ops here don't fail.
+	runGit(t, clonedDir, "config", "user.email", "test@example.com")
+	runGit(t, clonedDir, "config", "user.name", "Test")
+
+	t.Chdir(clonedDir)
+
+	cases := []struct {
+		name string
+		fn   func(context.Context) error
+	}{
+		{"FetchMetadataBranch", FetchMetadataBranch},
+		{"FetchMetadataTreeOnly", FetchMetadataTreeOnly},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear any previous pollution from earlier subtest runs. These
+			// return exit 5 if the key is absent; ignore either outcome.
+			//nolint:errcheck // cleanup is best-effort
+			runGitAllow(t, clonedDir, "config", "--unset", "remote.origin.promisor")
+			//nolint:errcheck // cleanup is best-effort
+			runGitAllow(t, clonedDir, "config", "--unset", "remote.origin.partialclonefilter")
+
+			if err := tc.fn(t.Context()); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+
+			if got := gitConfigValue(t, clonedDir, "remote.origin.promisor"); got != "" {
+				t.Errorf("%s: remote.origin.promisor was set to %q — fetch leaked partial-clone config onto origin", tc.name, got)
+			}
+			if got := gitConfigValue(t, clonedDir, "remote.origin.partialclonefilter"); got != "" {
+				t.Errorf("%s: remote.origin.partialclonefilter was set to %q — fetch leaked partial-clone config onto origin", tc.name, got)
+			}
+		})
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\nOutput: %s", strings.Join(args, " "), err, output)
+	}
+}
+
+func runGitAllow(t *testing.T, dir string, args ...string) error {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	return cmd.Run()
+}
+
+func gitConfigValue(t *testing.T, dir, key string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "config", "--local", "--get", key)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	output, err := cmd.Output()
+	if err != nil {
+		// git config returns exit 1 when key is absent — treat as empty.
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -376,8 +376,6 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 // support on-demand blob retrieval.
 // Uses git CLI instead of go-git for fetch because go-git doesn't use credential helpers,
 // which breaks HTTPS URLs that require authentication.
-// Fetches by URL (not by remote name) so git does not persist
-// remote.origin.promisor / remote.origin.partialclonefilter in .git/config.
 func FetchMetadataBranch(ctx context.Context) error {
 	branchName := paths.MetadataBranchName
 
@@ -385,14 +383,14 @@ func FetchMetadataBranch(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	originURL, err := strategy.OriginURL(ctx)
+	fetchTarget, err := strategy.ResolveFilteredFetchTarget(ctx, "origin")
 	if err != nil {
-		return fmt.Errorf("failed to resolve origin URL: %w", err)
+		return fmt.Errorf("failed to resolve filtered fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, originURL, "fetch", "--no-tags", "--filter=blob:none", originURL, refSpec)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, refSpec)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("fetch timed out after 2 minutes")
@@ -432,14 +430,14 @@ func FetchMetadataTreeOnly(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	originURL, err := strategy.OriginURL(ctx)
+	fetchTarget, err := strategy.ResolveFilteredFetchTarget(ctx, "origin")
 	if err != nil {
-		return fmt.Errorf("failed to resolve origin URL: %w", err)
+		return fmt.Errorf("failed to resolve filtered fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, originURL, "fetch", "--no-tags", "--depth=1", "--filter=blob:none", originURL, refSpec)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--depth=1", "--filter=blob:none", fetchTarget, refSpec)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("treeless fetch timed out after 2 minutes")
@@ -475,14 +473,14 @@ func FetchV2MainTreeOnly(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	originURL, err := strategy.OriginURL(ctx)
+	fetchTarget, err := strategy.ResolveFilteredFetchTarget(ctx, "origin")
 	if err != nil {
-		return fmt.Errorf("failed to resolve origin URL: %w", err)
+		return fmt.Errorf("failed to resolve filtered fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, originURL, "fetch", "--no-tags", "--depth=1", "--filter=blob:none", originURL, refSpec)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--depth=1", "--filter=blob:none", fetchTarget, refSpec)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 treeless fetch timed out after 2 minutes")
@@ -501,14 +499,14 @@ func FetchV2MainRef(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	originURL, err := strategy.OriginURL(ctx)
+	fetchTarget, err := strategy.ResolveFilteredFetchTarget(ctx, "origin")
 	if err != nil {
-		return fmt.Errorf("failed to resolve origin URL: %w", err)
+		return fmt.Errorf("failed to resolve filtered fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, originURL, "fetch", "--no-tags", "--filter=blob:none", originURL, refSpec)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, refSpec)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 fetch timed out after 2 minutes")

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -376,6 +376,8 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 // support on-demand blob retrieval.
 // Uses git CLI instead of go-git for fetch because go-git doesn't use credential helpers,
 // which breaks HTTPS URLs that require authentication.
+// Fetches by URL (not by remote name) so git does not persist
+// remote.origin.promisor / remote.origin.partialclonefilter in .git/config.
 func FetchMetadataBranch(ctx context.Context) error {
 	branchName := paths.MetadataBranchName
 
@@ -383,14 +385,19 @@ func FetchMetadataBranch(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
+	originURL, err := strategy.OriginURL(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve origin URL: %w", err)
+	}
+
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", "fetch", "--no-tags", "--filter=blob:none", "origin", refSpec)
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	fetchCmd := strategy.CheckpointGitCommand(ctx, originURL, "fetch", "--no-tags", "--filter=blob:none", originURL, refSpec)
+	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("fetch timed out after 2 minutes")
 		}
-		return fmt.Errorf("failed to fetch %s from origin: %s: %w", branchName, strings.TrimSpace(string(output)), err)
+		return fmt.Errorf("failed to fetch %s from origin: %s: %w", branchName, strings.TrimSpace(string(output)), fetchErr)
 	}
 
 	repo, err := openRepository(ctx)
@@ -425,14 +432,19 @@ func FetchMetadataTreeOnly(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
+	originURL, err := strategy.OriginURL(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve origin URL: %w", err)
+	}
+
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", "fetch", "--no-tags", "--depth=1", "--filter=blob:none", "origin", refSpec)
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	fetchCmd := strategy.CheckpointGitCommand(ctx, originURL, "fetch", "--no-tags", "--depth=1", "--filter=blob:none", originURL, refSpec)
+	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("treeless fetch timed out after 2 minutes")
 		}
-		return fmt.Errorf("failed to treeless-fetch %s from origin: %s: %w", branchName, strings.TrimSpace(string(output)), err)
+		return fmt.Errorf("failed to treeless-fetch %s from origin: %s: %w", branchName, strings.TrimSpace(string(output)), fetchErr)
 	}
 
 	repo, err := openRepository(ctx)
@@ -463,14 +475,19 @@ func FetchV2MainTreeOnly(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
+	originURL, err := strategy.OriginURL(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve origin URL: %w", err)
+	}
+
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", "fetch", "--no-tags", "--depth=1", "--filter=blob:none", "origin", refSpec)
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	fetchCmd := strategy.CheckpointGitCommand(ctx, originURL, "fetch", "--no-tags", "--depth=1", "--filter=blob:none", originURL, refSpec)
+	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 treeless fetch timed out after 2 minutes")
 		}
-		return fmt.Errorf("failed to treeless-fetch v2 /main from origin: %s: %w", strings.TrimSpace(string(output)), err)
+		return fmt.Errorf("failed to treeless-fetch v2 /main from origin: %s: %w", strings.TrimSpace(string(output)), fetchErr)
 	}
 
 	return nil
@@ -484,14 +501,19 @@ func FetchV2MainRef(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
+	originURL, err := strategy.OriginURL(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve origin URL: %w", err)
+	}
+
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", "fetch", "--no-tags", "--filter=blob:none", "origin", refSpec)
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	fetchCmd := strategy.CheckpointGitCommand(ctx, originURL, "fetch", "--no-tags", "--filter=blob:none", originURL, refSpec)
+	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 fetch timed out after 2 minutes")
 		}
-		return fmt.Errorf("failed to fetch v2 /main from origin: %s: %w", strings.TrimSpace(string(output)), err)
+		return fmt.Errorf("failed to fetch v2 /main from origin: %s: %w", strings.TrimSpace(string(output)), fetchErr)
 	}
 
 	return nil

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -18,6 +18,26 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
+func formatFilteredFetchError(prefix, fetchTarget string, output []byte, fetchErr error) error {
+	redactedTarget := fetchTarget
+	if isFetchTargetURL(fetchTarget) {
+		redactedTarget = strategy.RedactURL(fetchTarget)
+	}
+
+	msg := strings.TrimSpace(string(output))
+	if isFetchTargetURL(fetchTarget) {
+		msg = strings.TrimSpace(strings.ReplaceAll(msg, fetchTarget, redactedTarget))
+	}
+	if msg != "" {
+		return fmt.Errorf("%s from %s: %s: %w", prefix, redactedTarget, msg, fetchErr)
+	}
+	return fmt.Errorf("%s from %s: %w", prefix, redactedTarget, fetchErr)
+}
+
+func isFetchTargetURL(target string) bool {
+	return strings.Contains(target, "://") || strings.Contains(target, "@")
+}
+
 // openRepository opens the git repository with linked worktree support enabled.
 // This is a convenience wrapper around strategy.OpenRepository() for use in the CLI package.
 func openRepository(ctx context.Context) (*git.Repository, error) {
@@ -383,19 +403,20 @@ func FetchMetadataBranch(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := strategy.ResolveFilteredFetchTarget(ctx, "origin")
+	fetchTarget, err := strategy.ResolveFetchTarget(ctx, "origin")
 	if err != nil {
-		return fmt.Errorf("failed to resolve filtered fetch target: %w", err)
+		return fmt.Errorf("failed to resolve fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, refSpec)
+	fetchArgs := strategy.AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refSpec})
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("fetch timed out after 2 minutes")
 		}
-		return fmt.Errorf("failed to fetch %s from origin: %s: %w", branchName, strings.TrimSpace(string(output)), fetchErr)
+		return formatFilteredFetchError("failed to fetch "+branchName, fetchTarget, output, fetchErr)
 	}
 
 	repo, err := openRepository(ctx)
@@ -430,19 +451,20 @@ func FetchMetadataTreeOnly(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := strategy.ResolveFilteredFetchTarget(ctx, "origin")
+	fetchTarget, err := strategy.ResolveFetchTarget(ctx, "origin")
 	if err != nil {
-		return fmt.Errorf("failed to resolve filtered fetch target: %w", err)
+		return fmt.Errorf("failed to resolve fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--depth=1", "--filter=blob:none", fetchTarget, refSpec)
+	fetchArgs := strategy.AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", "--depth=1", fetchTarget, refSpec})
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("treeless fetch timed out after 2 minutes")
 		}
-		return fmt.Errorf("failed to treeless-fetch %s from origin: %s: %w", branchName, strings.TrimSpace(string(output)), fetchErr)
+		return formatFilteredFetchError("failed to treeless-fetch "+branchName, fetchTarget, output, fetchErr)
 	}
 
 	repo, err := openRepository(ctx)
@@ -473,19 +495,20 @@ func FetchV2MainTreeOnly(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := strategy.ResolveFilteredFetchTarget(ctx, "origin")
+	fetchTarget, err := strategy.ResolveFetchTarget(ctx, "origin")
 	if err != nil {
-		return fmt.Errorf("failed to resolve filtered fetch target: %w", err)
+		return fmt.Errorf("failed to resolve fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--depth=1", "--filter=blob:none", fetchTarget, refSpec)
+	fetchArgs := strategy.AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", "--depth=1", fetchTarget, refSpec})
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 treeless fetch timed out after 2 minutes")
 		}
-		return fmt.Errorf("failed to treeless-fetch v2 /main from origin: %s: %w", strings.TrimSpace(string(output)), fetchErr)
+		return formatFilteredFetchError("failed to treeless-fetch v2 /main", fetchTarget, output, fetchErr)
 	}
 
 	return nil
@@ -499,19 +522,20 @@ func FetchV2MainRef(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := strategy.ResolveFilteredFetchTarget(ctx, "origin")
+	fetchTarget, err := strategy.ResolveFetchTarget(ctx, "origin")
 	if err != nil {
-		return fmt.Errorf("failed to resolve filtered fetch target: %w", err)
+		return fmt.Errorf("failed to resolve fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, refSpec)
+	fetchArgs := strategy.AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refSpec})
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 fetch timed out after 2 minutes")
 		}
-		return fmt.Errorf("failed to fetch v2 /main from origin: %s: %w", strings.TrimSpace(string(output)), fetchErr)
+		return formatFilteredFetchError("failed to fetch v2 /main", fetchTarget, output, fetchErr)
 	}
 
 	return nil

--- a/cmd/entire/cli/integration_test/git_author_test.go
+++ b/cmd/entire/cli/integration_test/git_author_test.go
@@ -241,6 +241,7 @@ func TestGetGitAuthorRemovingLocalConfig(t *testing.T) {
 	if err := os.WriteFile(configPath, []byte(configWithoutUser), 0o644); err != nil {
 		t.Fatalf("failed to write .git/config: %v", err)
 	}
+	env.AcceptGitConfigChanges(configWithoutUser)
 
 	env.InitEntire()
 

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -51,6 +52,8 @@ type TestEnv struct {
 	GeminiProjectDir   string
 	OpenCodeProjectDir string
 	SessionCounter     int
+	gitConfigSnapshot  string
+	gitConfigGuardSet  bool
 }
 
 // NewTestEnv creates a new isolated test environment.
@@ -241,6 +244,84 @@ func (env *TestEnv) InitRepo() {
 	if err := repo.SetConfig(cfg); err != nil {
 		env.T.Fatalf("failed to set repo config: %v", err)
 	}
+
+	env.setGitConfigBaseline()
+}
+
+func (env *TestEnv) setGitConfigBaseline() {
+	env.T.Helper()
+
+	configPath := env.gitConfigPath()
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		env.T.Fatalf("failed to read %s: %v", configPath, err)
+	}
+
+	env.gitConfigSnapshot = string(data)
+	if env.gitConfigGuardSet {
+		return
+	}
+
+	env.gitConfigGuardSet = true
+	env.T.Cleanup(func() {
+		configPath := env.gitConfigPath()
+		currentData, err := os.ReadFile(configPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				if _, statErr := os.Stat(env.RepoDir); errors.Is(statErr, os.ErrNotExist) {
+					return
+				}
+			}
+			env.T.Fatalf(".git/config guard failed: could not read %s during cleanup: %v", configPath, err)
+		}
+
+		current := string(currentData)
+		if normalizeGitConfigForGuard(current) == normalizeGitConfigForGuard(env.gitConfigSnapshot) {
+			return
+		}
+
+		env.T.Fatalf(
+			".git/config changed unexpectedly during integration test\nBaseline:\n%s\nCurrent:\n%s",
+			env.gitConfigSnapshot,
+			current,
+		)
+	})
+}
+
+// AcceptGitConfigChanges updates the .git/config guard baseline after verifying
+// the config matches the exact content the test intended to write.
+func (env *TestEnv) AcceptGitConfigChanges(expected string) {
+	env.T.Helper()
+
+	actual, err := os.ReadFile(env.gitConfigPath())
+	if err != nil {
+		env.T.Fatalf("failed to read %s: %v", env.gitConfigPath(), err)
+	}
+	if string(actual) != expected {
+		env.T.Fatalf(
+			".git/config did not match expected test mutation\nExpected:\n%s\nActual:\n%s",
+			expected,
+			string(actual),
+		)
+	}
+
+	env.gitConfigSnapshot = expected
+}
+
+func (env *TestEnv) gitConfigPath() string {
+	return filepath.Join(env.RepoDir, ".git", "config")
+}
+
+var gitConfigGuardRepositoryFormatVersionRE = regexp.MustCompile(`(?m)^([ \t]*)repositoryformatversion = [01]$`)
+
+var gitConfigGuardTransportPromisorRemoteRE = regexp.MustCompile(
+	`(?m)^\[remote "(?:(?:https?|ssh|file)://|/|[A-Za-z]:[\\/]|[^"\n]+@[^"\n]+:[^"\n]+).+"\]\n(?:[ \t]+promisor = true\n[ \t]+partialclonefilter = blob:none\n?|[ \t]+partialclonefilter = blob:none\n[ \t]+promisor = true\n?)`,
+)
+
+func normalizeGitConfigForGuard(content string) string {
+	content = gitConfigGuardRepositoryFormatVersionRE.ReplaceAllString(content, `${1}repositoryformatversion = <normalized>`)
+	content = gitConfigGuardTransportPromisorRemoteRE.ReplaceAllString(content, "")
+	return content
 }
 
 // InitEntire initializes the .entire directory with the specified strategy.
@@ -1783,6 +1864,8 @@ func (env *TestEnv) SetupNamedBareRemote(remoteName string) string {
 		env.T.Fatalf("failed to push to %s: %v\n%s", remoteName, err, output)
 	}
 
+	env.setGitConfigBaseline()
+
 	return bareDir
 }
 
@@ -1853,6 +1936,7 @@ func (env *TestEnv) CloneFrom(bareDir string) *TestEnv {
 
 	// Initialize Entire in the clone
 	cloneEnv.InitEntire()
+	cloneEnv.setGitConfigBaseline()
 
 	return cloneEnv
 }
@@ -1942,7 +2026,7 @@ func (env *TestEnv) FetchMetadataBranch(remoteURL string) {
 
 	branchName := paths.MetadataBranchName
 	refSpec := "+refs/heads/" + branchName + ":refs/heads/" + branchName
-	cmd := exec.CommandContext(env.T.Context(), "git", "fetch", "--no-tags", "--filter=blob:none", remoteURL, refSpec)
+	cmd := exec.CommandContext(env.T.Context(), "git", "fetch", "--no-tags", remoteURL, refSpec)
 	cmd.Dir = env.RepoDir
 	cmd.Env = testutil.GitIsolatedEnv()
 

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -320,6 +320,9 @@ var gitConfigGuardTransportPromisorRemoteRE = regexp.MustCompile(
 
 func normalizeGitConfigForGuard(content string) string {
 	content = gitConfigGuardRepositoryFormatVersionRE.ReplaceAllString(content, `${1}repositoryformatversion = <normalized>`)
+	// Deliberately ignore only the full promisor+partialclonefilter pair that
+	// git writes for transport-keyed remotes during filtered fetches. If git ever
+	// writes a partial section, the guard should still fail loudly.
 	content = gitConfigGuardTransportPromisorRemoteRE.ReplaceAllString(content, "")
 	return content
 }
@@ -373,7 +376,13 @@ func (env *TestEnv) initEntireInternal(strategyOptions map[string]any) {
 		"enabled":   true,
 		"local_dev": true, // Note: git-triggered hooks won't work (path is relative); tests call hooks via getTestBinary() instead
 	}
-	if strategyOptions != nil {
+	if strategyOptions == nil {
+		strategyOptions = make(map[string]any)
+	}
+	if _, exists := strategyOptions["filtered_fetches"]; !exists {
+		strategyOptions["filtered_fetches"] = true
+	}
+	if len(strategyOptions) > 0 {
 		settings["strategy_options"] = strategyOptions
 	}
 	data, err := jsonutil.MarshalIndentWithNewline(settings, "", "  ")

--- a/cmd/entire/cli/integration_test/testenv_test.go
+++ b/cmd/entire/cli/integration_test/testenv_test.go
@@ -204,3 +204,39 @@ func TestNewFeatureBranchEnv(t *testing.T) {
 		t.Error("README.md should exist")
 	}
 }
+
+func TestNormalizeGitConfigForGuard_IgnoresTransportPromisorRemote(t *testing.T) {
+	t.Parallel()
+
+	baseline := `[core]
+	repositoryformatversion = 0
+`
+	withURLPromisor := `[core]
+	repositoryformatversion = 1
+[remote "https://github.com/entireio/cli.git"]
+	promisor = true
+	partialclonefilter = blob:none
+`
+
+	if got, want := normalizeGitConfigForGuard(withURLPromisor), normalizeGitConfigForGuard(baseline); got != want {
+		t.Fatalf("normalizeGitConfigForGuard should ignore transport-keyed promisor remotes\nGot:\n%s\nWant:\n%s", got, want)
+	}
+}
+
+func TestNormalizeGitConfigForGuard_PreservesNamedRemotePromisor(t *testing.T) {
+	t.Parallel()
+
+	baseline := `[core]
+	repositoryformatversion = 0
+`
+	withOriginPromisor := `[core]
+	repositoryformatversion = 1
+[remote "origin"]
+	promisor = true
+	partialclonefilter = blob:none
+`
+
+	if normalizeGitConfigForGuard(withOriginPromisor) == normalizeGitConfigForGuard(baseline) {
+		t.Fatal("normalizeGitConfigForGuard should preserve named remote promisor changes")
+	}
+}

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -432,6 +432,16 @@ func IsPushV2RefsEnabled(ctx context.Context) bool {
 	return s.IsPushV2RefsEnabled()
 }
 
+// IsFilteredFetchesUseURLEnabled checks if filtered fetches should resolve
+// remote names to URLs before invoking git fetch. Returns false by default.
+func IsFilteredFetchesUseURLEnabled(ctx context.Context) bool {
+	s, err := Load(ctx)
+	if err != nil {
+		return false
+	}
+	return s.IsFilteredFetchesUseURLEnabled()
+}
+
 // IsSummarizeEnabled checks if auto-summarize is enabled in settings.
 // Returns false by default if settings cannot be loaded or the key is missing.
 func IsSummarizeEnabled(ctx context.Context) bool {
@@ -521,6 +531,17 @@ func (s *EntireSettings) IsPushV2RefsEnabled() bool {
 		return false
 	}
 	val, ok := s.StrategyOptions["push_v2_refs"].(bool)
+	return ok && val
+}
+
+// IsFilteredFetchesUseURLEnabled checks if filtered fetches should use a
+// resolved remote URL instead of a remote name. This is a temporary rollout
+// guard for the URL-based filtered fetch behavior.
+func (s *EntireSettings) IsFilteredFetchesUseURLEnabled() bool {
+	if s.StrategyOptions == nil {
+		return false
+	}
+	val, ok := s.StrategyOptions["filtered_fetches_use_url"].(bool)
 	return ok && val
 }
 

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -432,14 +432,16 @@ func IsPushV2RefsEnabled(ctx context.Context) bool {
 	return s.IsPushV2RefsEnabled()
 }
 
-// IsFilteredFetchesUseURLEnabled checks if filtered fetches should resolve
-// remote names to URLs before invoking git fetch. Returns false by default.
-func IsFilteredFetchesUseURLEnabled(ctx context.Context) bool {
+// IsFilteredFetchesEnabled checks if filtered fetches should be used.
+// When enabled, filtered fetches always resolve remote names to URLs first so
+// git does not persist promisor settings onto named remotes in local config.
+// Returns false by default.
+func IsFilteredFetchesEnabled(ctx context.Context) bool {
 	s, err := Load(ctx)
 	if err != nil {
 		return false
 	}
-	return s.IsFilteredFetchesUseURLEnabled()
+	return s.IsFilteredFetchesEnabled()
 }
 
 // IsSummarizeEnabled checks if auto-summarize is enabled in settings.
@@ -534,14 +536,14 @@ func (s *EntireSettings) IsPushV2RefsEnabled() bool {
 	return ok && val
 }
 
-// IsFilteredFetchesUseURLEnabled checks if filtered fetches should use a
-// resolved remote URL instead of a remote name. This is a temporary rollout
-// guard for the URL-based filtered fetch behavior.
-func (s *EntireSettings) IsFilteredFetchesUseURLEnabled() bool {
+// IsFilteredFetchesEnabled checks if fetches should use --filter=blob:none.
+// When enabled, filtered fetches always use resolved URLs rather than remote
+// names to avoid persisting promisor settings onto named remotes.
+func (s *EntireSettings) IsFilteredFetchesEnabled() bool {
 	if s.StrategyOptions == nil {
 		return false
 	}
-	val, ok := s.StrategyOptions["filtered_fetches_use_url"].(bool)
+	val, ok := s.StrategyOptions["filtered_fetches"].(bool)
 	return ok && val
 }
 

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -597,6 +597,36 @@ func TestIsPushV2RefsEnabled_RequiresBothFlags(t *testing.T) {
 	}
 }
 
+func TestIsFilteredFetchesUseURLEnabled_DefaultsFalse(t *testing.T) {
+	t.Parallel()
+	s := &EntireSettings{Enabled: true}
+	if s.IsFilteredFetchesUseURLEnabled() {
+		t.Error("expected IsFilteredFetchesUseURLEnabled to default to false")
+	}
+}
+
+func TestIsFilteredFetchesUseURLEnabled_True(t *testing.T) {
+	t.Parallel()
+	s := &EntireSettings{
+		Enabled:         true,
+		StrategyOptions: map[string]any{"filtered_fetches_use_url": true},
+	}
+	if !s.IsFilteredFetchesUseURLEnabled() {
+		t.Error("expected IsFilteredFetchesUseURLEnabled to be true")
+	}
+}
+
+func TestIsFilteredFetchesUseURLEnabled_WrongType(t *testing.T) {
+	t.Parallel()
+	s := &EntireSettings{
+		Enabled:         true,
+		StrategyOptions: map[string]any{"filtered_fetches_use_url": "yes"},
+	}
+	if s.IsFilteredFetchesUseURLEnabled() {
+		t.Error("expected IsFilteredFetchesUseURLEnabled to be false for non-bool value")
+	}
+}
+
 // containsUnknownField checks if the error message indicates an unknown field
 func containsUnknownField(msg string) bool {
 	// Go's json package reports unknown fields with this message format

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -597,33 +597,33 @@ func TestIsPushV2RefsEnabled_RequiresBothFlags(t *testing.T) {
 	}
 }
 
-func TestIsFilteredFetchesUseURLEnabled_DefaultsFalse(t *testing.T) {
+func TestIsFilteredFetchesEnabled_DefaultsFalse(t *testing.T) {
 	t.Parallel()
 	s := &EntireSettings{Enabled: true}
-	if s.IsFilteredFetchesUseURLEnabled() {
-		t.Error("expected IsFilteredFetchesUseURLEnabled to default to false")
+	if s.IsFilteredFetchesEnabled() {
+		t.Error("expected IsFilteredFetchesEnabled to default to false")
 	}
 }
 
-func TestIsFilteredFetchesUseURLEnabled_True(t *testing.T) {
+func TestIsFilteredFetchesEnabled_True(t *testing.T) {
 	t.Parallel()
 	s := &EntireSettings{
 		Enabled:         true,
-		StrategyOptions: map[string]any{"filtered_fetches_use_url": true},
+		StrategyOptions: map[string]any{"filtered_fetches": true},
 	}
-	if !s.IsFilteredFetchesUseURLEnabled() {
-		t.Error("expected IsFilteredFetchesUseURLEnabled to be true")
+	if !s.IsFilteredFetchesEnabled() {
+		t.Error("expected IsFilteredFetchesEnabled to be true")
 	}
 }
 
-func TestIsFilteredFetchesUseURLEnabled_WrongType(t *testing.T) {
+func TestIsFilteredFetchesEnabled_WrongType(t *testing.T) {
 	t.Parallel()
 	s := &EntireSettings{
 		Enabled:         true,
-		StrategyOptions: map[string]any{"filtered_fetches_use_url": "yes"},
+		StrategyOptions: map[string]any{"filtered_fetches": "yes"},
 	}
-	if s.IsFilteredFetchesUseURLEnabled() {
-		t.Error("expected IsFilteredFetchesUseURLEnabled to be false for non-bool value")
+	if s.IsFilteredFetchesEnabled() {
+		t.Error("expected IsFilteredFetchesEnabled to be false for non-bool value")
 	}
 }
 

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -186,6 +186,11 @@ func ResolveRemoteRepo(ctx context.Context, remoteName string) (host, owner, rep
 	return info.host, info.owner, info.repo, nil
 }
 
+// OriginURL returns the configured URL for the origin remote.
+func OriginURL(ctx context.Context) (string, error) {
+	return getRemoteURL(ctx, "origin")
+}
+
 // gitRemoteInfo holds parsed components of a git remote URL.
 type gitRemoteInfo struct {
 	protocol string // "ssh" or "https"
@@ -301,15 +306,6 @@ func getRemoteURL(ctx context.Context, remoteName string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// OriginURL returns the URL configured for the "origin" remote.
-// Exported so callers outside this package can fetch by URL instead of by
-// remote name, which avoids git persisting partial-clone config
-// (remote.origin.promisor, remote.origin.partialclonefilter) when --filter
-// is used.
-func OriginURL(ctx context.Context) (string, error) {
-	return getRemoteURL(ctx, "origin")
-}
-
 // redactURL removes credentials from a URL for safe logging.
 // Handles both HTTPS URLs with embedded credentials and general URLs.
 func redactURL(rawURL string) string {
@@ -384,15 +380,16 @@ func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 		fetchCmd.Env = os.Environ()
 	}
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	output, fetchErr := fetchCmd.CombinedOutput()
+	if fetchErr != nil {
 		// Include redacted output for diagnostics without leaking credentials.
 		// Git stderr may echo the URL with embedded credentials, so replace it.
 		redactedURL := redactURL(remoteURL)
 		msg := strings.TrimSpace(strings.ReplaceAll(string(output), remoteURL, redactedURL))
 		if msg != "" {
-			return fmt.Errorf("fetch from %s failed: %s: %w", redactedURL, msg, err)
+			return fmt.Errorf("fetch from %s failed: %s: %w", redactedURL, msg, fetchErr)
 		}
-		return fmt.Errorf("fetch from %s failed: %w", redactedURL, err)
+		return fmt.Errorf("fetch from %s failed: %w", redactedURL, fetchErr)
 	}
 
 	repo, err := OpenRepository(ctx)
@@ -428,13 +425,14 @@ func FetchV2MainFromURL(ctx context.Context, remoteURL string) error {
 		fetchCmd.Env = os.Environ()
 	}
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	output, fetchErr := fetchCmd.CombinedOutput()
+	if fetchErr != nil {
 		redactedURL := redactURL(remoteURL)
 		msg := strings.TrimSpace(strings.ReplaceAll(string(output), remoteURL, redactedURL))
 		if msg != "" {
-			return fmt.Errorf("fetch v2 /main from %s failed: %s: %w", redactedURL, msg, err)
+			return fmt.Errorf("fetch v2 /main from %s failed: %s: %w", redactedURL, msg, fetchErr)
 		}
-		return fmt.Errorf("fetch v2 /main from %s failed: %w", redactedURL, err)
+		return fmt.Errorf("fetch v2 /main from %s failed: %w", redactedURL, fetchErr)
 	}
 
 	return nil

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -212,7 +212,7 @@ func parseGitRemoteURL(rawURL string) (*gitRemoteInfo, error) {
 		// Split on the first ":"
 		parts := strings.SplitN(rawURL, ":", 2)
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid SSH URL: %s", redactURL(rawURL))
+			return nil, fmt.Errorf("invalid SSH URL: %s", RedactURL(rawURL))
 		}
 		hostPart := parts[0] // e.g., "git@github.com"
 		pathPart := parts[1] // e.g., "org/repo.git"
@@ -233,12 +233,12 @@ func parseGitRemoteURL(rawURL string) (*gitRemoteInfo, error) {
 	// URL format: https://github.com/org/repo.git or ssh://git@github.com/org/repo.git
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid URL: %s", redactURL(rawURL))
+		return nil, fmt.Errorf("invalid URL: %s", RedactURL(rawURL))
 	}
 
 	protocol := u.Scheme
 	if protocol == "" {
-		return nil, fmt.Errorf("no protocol in URL: %s", redactURL(rawURL))
+		return nil, fmt.Errorf("no protocol in URL: %s", RedactURL(rawURL))
 	}
 	host := u.Hostname()
 
@@ -306,9 +306,9 @@ func getRemoteURL(ctx context.Context, remoteName string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// redactURL removes credentials from a URL for safe logging.
+// RedactURL removes credentials from a URL for safe logging.
 // Handles both HTTPS URLs with embedded credentials and general URLs.
-func redactURL(rawURL string) string {
+func RedactURL(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		// For non-URL formats (SSH SCP), just return the host portion
@@ -373,7 +373,8 @@ func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 
 	tmpRef := "refs/entire-fetch-tmp/" + branchName
 	refSpec := fmt.Sprintf("+refs/heads/%s:%s", branchName, tmpRef)
-	fetchCmd := CheckpointGitCommand(fetchCtx, remoteURL, "fetch", "--no-tags", "--filter=blob:none", remoteURL, refSpec)
+	fetchArgs := AppendFetchFilterArgs(fetchCtx, []string{"fetch", "--no-tags", remoteURL, refSpec})
+	fetchCmd := CheckpointGitCommand(fetchCtx, remoteURL, fetchArgs...)
 	// Merge GIT_TERMINAL_PROMPT=0 into whatever env CheckpointGitCommand set.
 	// If the token was injected, cmd.Env is already populated; otherwise use os.Environ().
 	if fetchCmd.Env == nil {
@@ -384,7 +385,7 @@ func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 	if fetchErr != nil {
 		// Include redacted output for diagnostics without leaking credentials.
 		// Git stderr may echo the URL with embedded credentials, so replace it.
-		redactedURL := redactURL(remoteURL)
+		redactedURL := RedactURL(remoteURL)
 		msg := strings.TrimSpace(strings.ReplaceAll(string(output), remoteURL, redactedURL))
 		if msg != "" {
 			return fmt.Errorf("fetch from %s failed: %s: %w", redactedURL, msg, fetchErr)
@@ -420,14 +421,15 @@ func FetchV2MainFromURL(ctx context.Context, remoteURL string) error {
 	defer cancel()
 
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
-	fetchCmd := CheckpointGitCommand(fetchCtx, remoteURL, "fetch", "--no-tags", "--filter=blob:none", remoteURL, refSpec)
+	fetchArgs := AppendFetchFilterArgs(fetchCtx, []string{"fetch", "--no-tags", remoteURL, refSpec})
+	fetchCmd := CheckpointGitCommand(fetchCtx, remoteURL, fetchArgs...)
 	if fetchCmd.Env == nil {
 		fetchCmd.Env = os.Environ()
 	}
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
 	output, fetchErr := fetchCmd.CombinedOutput()
 	if fetchErr != nil {
-		redactedURL := redactURL(remoteURL)
+		redactedURL := RedactURL(remoteURL)
 		msg := strings.TrimSpace(strings.ReplaceAll(string(output), remoteURL, redactedURL))
 		if msg != "" {
 			return fmt.Errorf("fetch v2 /main from %s failed: %s: %w", redactedURL, msg, fetchErr)

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -301,6 +301,15 @@ func getRemoteURL(ctx context.Context, remoteName string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+// OriginURL returns the URL configured for the "origin" remote.
+// Exported so callers outside this package can fetch by URL instead of by
+// remote name, which avoids git persisting partial-clone config
+// (remote.origin.promisor, remote.origin.partialclonefilter) when --filter
+// is used.
+func OriginURL(ctx context.Context) (string, error) {
+	return getRemoteURL(ctx, "origin")
+}
+
 // redactURL removes credentials from a URL for safe logging.
 // Handles both HTTPS URLs with embedded credentials and general URLs.
 func redactURL(rawURL string) string {

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -186,7 +186,7 @@ func TestRedactURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, redactURL(tt.url))
+			assert.Equal(t, tt.want, RedactURL(tt.url))
 		})
 	}
 }

--- a/cmd/entire/cli/strategy/checkpoint_token.go
+++ b/cmd/entire/cli/strategy/checkpoint_token.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
 // CheckpointTokenEnvVar is the environment variable for providing an access token
@@ -127,4 +129,14 @@ func resolveTargetProtocol(ctx context.Context, target string) string {
 		return ""
 	}
 	return info.protocol
+}
+
+// ResolveFilteredFetchTarget returns the git fetch target to use for filtered
+// fetches. When the rollout flag is enabled, configured remotes are resolved to
+// their URL so git does not persist promisor settings onto the remote name.
+func ResolveFilteredFetchTarget(ctx context.Context, target string) (string, error) {
+	if isURL(target) || !settings.IsFilteredFetchesUseURLEnabled(ctx) {
+		return target, nil
+	}
+	return getRemoteURL(ctx, target)
 }

--- a/cmd/entire/cli/strategy/checkpoint_token.go
+++ b/cmd/entire/cli/strategy/checkpoint_token.go
@@ -131,12 +131,21 @@ func resolveTargetProtocol(ctx context.Context, target string) string {
 	return info.protocol
 }
 
-// ResolveFilteredFetchTarget returns the git fetch target to use for filtered
-// fetches. When the rollout flag is enabled, configured remotes are resolved to
-// their URL so git does not persist promisor settings onto the remote name.
-func ResolveFilteredFetchTarget(ctx context.Context, target string) (string, error) {
-	if isURL(target) || !settings.IsFilteredFetchesUseURLEnabled(ctx) {
+// ResolveFetchTarget returns the git fetch target to use. When filtered
+// fetches are enabled, configured remotes are resolved to their URL so git does
+// not persist promisor settings onto the remote name.
+func ResolveFetchTarget(ctx context.Context, target string) (string, error) {
+	if isURL(target) || !settings.IsFilteredFetchesEnabled(ctx) {
 		return target, nil
 	}
 	return getRemoteURL(ctx, target)
+}
+
+// AppendFetchFilterArgs appends the partial-clone filter arguments when the
+// filtered fetch rollout is enabled.
+func AppendFetchFilterArgs(ctx context.Context, args []string) []string {
+	if !settings.IsFilteredFetchesEnabled(ctx) {
+		return args
+	}
+	return append(args, "--filter=blob:none")
 }

--- a/cmd/entire/cli/strategy/checkpoint_token_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_token_test.go
@@ -87,6 +87,49 @@ func TestResolveTargetProtocol_SSHRemoteName(t *testing.T) {
 	assert.Equal(t, protocolSSH, resolveTargetProtocol(ctx, "origin"))
 }
 
+// Not parallel: uses t.Chdir()
+func TestResolveFilteredFetchTarget(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+
+	cmd := exec.CommandContext(ctx, "git", "remote", "add", "origin", "https://github.com/org/repo.git")
+	cmd.Dir = tmpDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	require.NoError(t, cmd.Run())
+
+	t.Chdir(tmpDir)
+
+	t.Run("disabled returns remote name", func(t *testing.T) {
+		target, err := ResolveFilteredFetchTarget(ctx, "origin")
+		require.NoError(t, err)
+		assert.Equal(t, "origin", target)
+	})
+
+	t.Run("enabled resolves remote to URL", func(t *testing.T) {
+		testutil.WriteFile(
+			t,
+			tmpDir,
+			".entire/settings.json",
+			`{"enabled": true, "strategy_options": {"filtered_fetches_use_url": true}}`,
+		)
+
+		target, err := ResolveFilteredFetchTarget(ctx, "origin")
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/org/repo.git", target)
+	})
+
+	t.Run("URL target stays unchanged", func(t *testing.T) {
+		target, err := ResolveFilteredFetchTarget(ctx, "https://github.com/org/repo.git")
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/org/repo.git", target)
+	})
+}
+
 func TestAppendCheckpointTokenEnv(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/strategy/checkpoint_token_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_token_test.go
@@ -88,7 +88,7 @@ func TestResolveTargetProtocol_SSHRemoteName(t *testing.T) {
 }
 
 // Not parallel: uses t.Chdir()
-func TestResolveFilteredFetchTarget(t *testing.T) {
+func TestResolveFetchTarget(t *testing.T) {
 	ctx := context.Background()
 
 	tmpDir := t.TempDir()
@@ -105,7 +105,7 @@ func TestResolveFilteredFetchTarget(t *testing.T) {
 	t.Chdir(tmpDir)
 
 	t.Run("disabled returns remote name", func(t *testing.T) {
-		target, err := ResolveFilteredFetchTarget(ctx, "origin")
+		target, err := ResolveFetchTarget(ctx, "origin")
 		require.NoError(t, err)
 		assert.Equal(t, "origin", target)
 	})
@@ -115,16 +115,16 @@ func TestResolveFilteredFetchTarget(t *testing.T) {
 			t,
 			tmpDir,
 			".entire/settings.json",
-			`{"enabled": true, "strategy_options": {"filtered_fetches_use_url": true}}`,
+			`{"enabled": true, "strategy_options": {"filtered_fetches": true}}`,
 		)
 
-		target, err := ResolveFilteredFetchTarget(ctx, "origin")
+		target, err := ResolveFetchTarget(ctx, "origin")
 		require.NoError(t, err)
 		assert.Equal(t, "https://github.com/org/repo.git", target)
 	})
 
 	t.Run("URL target stays unchanged", func(t *testing.T) {
-		target, err := ResolveFilteredFetchTarget(ctx, "https://github.com/org/repo.git")
+		target, err := ResolveFetchTarget(ctx, "https://github.com/org/repo.git")
 		require.NoError(t, err)
 		assert.Equal(t, "https://github.com/org/repo.git", target)
 	})

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -187,11 +187,17 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	// Determine fetch refspec. When target is a URL, use a temp ref;
-	// when it's a remote name, use the standard remote-tracking ref.
+	fetchTarget, err := ResolveFilteredFetchTarget(ctx, target)
+	if err != nil {
+		return fmt.Errorf("resolve filtered fetch target: %w", err)
+	}
+
+	// Determine fetch refspec. When the resolved fetch target is a URL, use a
+	// temp ref; when it's still a remote name, use the standard remote-tracking
+	// ref.
 	var fetchedRefName plumbing.ReferenceName
 	var refSpec string
-	if isURL(target) {
+	if isURL(fetchTarget) {
 		tmpRef := "refs/entire-fetch-tmp/" + branchName
 		refSpec = fmt.Sprintf("+refs/heads/%s:%s", branchName, tmpRef)
 		fetchedRefName = plumbing.ReferenceName(tmpRef)
@@ -204,7 +210,7 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	// Use --filter=blob:none for a partial fetch that downloads only commits
 	// and trees, skipping blobs. The merge only needs the tree structure to
 	// combine entries; blobs are already local or fetched on demand.
-	fetchCmd := CheckpointGitCommand(ctx, target, "fetch", "--no-tags", "--filter=blob:none", target, refSpec)
+	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, refSpec)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
 	}

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -187,9 +187,9 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := ResolveFilteredFetchTarget(ctx, target)
+	fetchTarget, err := ResolveFetchTarget(ctx, target)
 	if err != nil {
-		return fmt.Errorf("resolve filtered fetch target: %w", err)
+		return fmt.Errorf("resolve fetch target: %w", err)
 	}
 
 	// Determine fetch refspec. When the resolved fetch target is a URL, use a
@@ -197,7 +197,8 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	// ref.
 	var fetchedRefName plumbing.ReferenceName
 	var refSpec string
-	if isURL(fetchTarget) {
+	usedTempRef := isURL(fetchTarget)
+	if usedTempRef {
 		tmpRef := "refs/entire-fetch-tmp/" + branchName
 		refSpec = fmt.Sprintf("+refs/heads/%s:%s", branchName, tmpRef)
 		fetchedRefName = plumbing.ReferenceName(tmpRef)
@@ -210,7 +211,8 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	// Use --filter=blob:none for a partial fetch that downloads only commits
 	// and trees, skipping blobs. The merge only needs the tree structure to
 	// combine entries; blobs are already local or fetched on demand.
-	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, refSpec)
+	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refSpec})
+	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
 	}
@@ -263,7 +265,7 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 		if err := repo.Storer.SetReference(ref); err != nil {
 			return fmt.Errorf("failed to fast-forward branch ref: %w", err)
 		}
-		if isURL(target) {
+		if usedTempRef {
 			_ = repo.Storer.RemoveReference(fetchedRefName) //nolint:errcheck // cleanup is best-effort
 		}
 		return nil
@@ -284,7 +286,7 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 		if err := repo.Storer.SetReference(ref); err != nil {
 			return fmt.Errorf("failed to update branch ref: %w", err)
 		}
-		if isURL(target) {
+		if usedTempRef {
 			_ = repo.Storer.RemoveReference(fetchedRefName) //nolint:errcheck // cleanup is best-effort
 		}
 		return nil
@@ -302,7 +304,7 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	}
 
 	// Clean up temp ref if we used one (best-effort, not critical if it fails)
-	if isURL(target) {
+	if usedTempRef {
 		_ = repo.Storer.RemoveReference(fetchedRefName) //nolint:errcheck // cleanup is best-effort
 	}
 

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -826,6 +826,109 @@ func TestFetchAndRebase_URLTarget_ReconcilesFetchedTempRef(t *testing.T) {
 	assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound, "temporary fetched ref should be cleaned up")
 }
 
+// TestFetchAndRebase_FlaggedOriginTarget_UsesTempRef verifies that enabling
+// filtered_fetches for a normal remote-name target follows the temp-ref
+// path and still cleans up after rebasing.
+//
+// Not parallel: uses t.Chdir() (required for OpenRepository).
+func TestFetchAndRebase_FlaggedOriginTarget_UsesTempRef(t *testing.T) {
+	ctx := context.Background()
+	branchName := paths.MetadataBranchName
+
+	bareDir := t.TempDir()
+	setupDir := t.TempDir()
+	gitRun := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = dir
+		cmd.Env = testutil.GitIsolatedEnv()
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v in %s failed: %s", args, dir, out)
+	}
+
+	gitRun(bareDir, "init", "--bare", "-b", "main")
+	gitRun(setupDir, "clone", bareDir, ".")
+	gitRun(setupDir, "config", "user.email", "test@test.com")
+	gitRun(setupDir, "config", "user.name", "Test User")
+	gitRun(setupDir, "config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(setupDir, "README.md"), []byte("# Test"), 0o644))
+	gitRun(setupDir, "add", ".")
+	gitRun(setupDir, "commit", "-m", "init")
+	gitRun(setupDir, "push", "origin", "main")
+
+	gitRun(setupDir, "checkout", "--orphan", branchName)
+	gitRun(setupDir, "rm", "-rf", ".")
+	baseDir := filepath.Join(setupDir, "aa", "aaaaaaaaaa")
+	require.NoError(t, os.MkdirAll(baseDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "metadata.json"),
+		[]byte(`{"checkpoint_id":"aaaaaaaaaaaa"}`), 0o644))
+	gitRun(setupDir, "add", ".")
+	gitRun(setupDir, "commit", "-m", "Checkpoint: aaaaaaaaaaaa")
+	gitRun(setupDir, "push", "origin", branchName)
+	gitRun(setupDir, "checkout", "main")
+
+	cloneDir := filepath.Join(t.TempDir(), "clone")
+	require.NoError(t, os.MkdirAll(cloneDir, 0o755))
+	gitRun(cloneDir, "clone", bareDir, ".")
+	gitRun(cloneDir, "config", "user.email", "test@test.com")
+	gitRun(cloneDir, "config", "user.name", "Test User")
+	gitRun(cloneDir, "config", "commit.gpgsign", "false")
+	gitRun(cloneDir, "branch", branchName, "origin/"+branchName)
+	require.NoError(t, os.MkdirAll(filepath.Join(cloneDir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(cloneDir, ".entire", "settings.json"),
+		[]byte(`{"enabled": true, "strategy_options": {"filtered_fetches": true}}`),
+		0o644,
+	))
+
+	gitRun(cloneDir, "checkout", "--orphan", "temp-orphan")
+	gitRun(cloneDir, "rm", "-rf", ".")
+	localDir := filepath.Join(cloneDir, "cc", "cccccccccc")
+	require.NoError(t, os.MkdirAll(localDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "metadata.json"),
+		[]byte(`{"checkpoint_id":"cccccccccccc"}`), 0o644))
+	gitRun(cloneDir, "add", ".")
+	gitRun(cloneDir, "commit", "-m", "Checkpoint: cccccccccccc")
+	gitRun(cloneDir, "branch", "-f", branchName, "temp-orphan")
+	gitRun(cloneDir, "checkout", "main")
+
+	repo, err := git.PlainOpen(cloneDir)
+	require.NoError(t, err)
+	localRefBeforeFetch, err := repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
+	require.NoError(t, err)
+	staleOriginRef := plumbing.NewHashReference(
+		plumbing.NewRemoteReferenceName("origin", branchName),
+		localRefBeforeFetch.Hash(),
+	)
+	require.NoError(t, repo.Storer.SetReference(staleOriginRef))
+
+	t.Chdir(cloneDir)
+
+	err = fetchAndRebaseSessionsCommon(ctx, "origin", branchName)
+	require.NoError(t, err)
+
+	repo, err = git.PlainOpen(cloneDir)
+	require.NoError(t, err)
+
+	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
+	require.NoError(t, err)
+
+	tipCommit, err := repo.CommitObject(localRef.Hash())
+	require.NoError(t, err)
+	require.Len(t, tipCommit.ParentHashes, 1)
+
+	tree, err := tipCommit.Tree()
+	require.NoError(t, err)
+
+	entries := make(map[string]object.TreeEntry)
+	require.NoError(t, checkpoint.FlattenTree(repo, tree, "", entries))
+	assert.Contains(t, entries, "aa/aaaaaaaaaa/metadata.json", "remote checkpoint should be preserved")
+	assert.Contains(t, entries, "cc/cccccccccc/metadata.json", "local checkpoint should be preserved")
+
+	_, err = repo.Reference(plumbing.ReferenceName("refs/entire-fetch-tmp/"+branchName), true)
+	assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound, "temporary fetched ref should be cleaned up")
+}
+
 // TestIsCheckpointRemoteCommitted verifies that the discoverability check reads
 // the committed content of .entire/settings.json at HEAD, not just tracking status.
 // Not parallel: uses t.Chdir().

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -114,6 +114,11 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
+	fetchTarget, err := ResolveFilteredFetchTarget(ctx, target)
+	if err != nil {
+		return fmt.Errorf("resolve filtered fetch target: %w", err)
+	}
+
 	// Fetch to a temp ref
 	tmpRefSuffix := strings.ReplaceAll(string(refName), "/", "-")
 	tmpRefName := plumbing.ReferenceName("refs/entire-fetch-tmp/" + tmpRefSuffix)
@@ -122,7 +127,7 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	// Use --filter=blob:none for a partial fetch that downloads only commits
 	// and trees, skipping blobs. The merge only needs the tree structure to
 	// combine entries; blobs are already local or fetched on demand.
-	fetchCmd := CheckpointGitCommand(ctx, target, "fetch", "--no-tags", "--filter=blob:none", target, refSpec)
+	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, refSpec)
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
@@ -140,7 +145,7 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	if refName == plumbing.ReferenceName(paths.V2FullCurrentRefName) {
 		remoteOnlyArchives, detectErr := detectRemoteOnlyArchives(ctx, target, repo)
 		if detectErr == nil && len(remoteOnlyArchives) > 0 {
-			return handleRotationConflict(ctx, target, repo, refName, tmpRefName, remoteOnlyArchives)
+			return handleRotationConflict(ctx, target, fetchTarget, repo, refName, tmpRefName, remoteOnlyArchives)
 		}
 	}
 
@@ -241,7 +246,7 @@ func detectRemoteOnlyArchives(ctx context.Context, target string, repo *git.Repo
 // handleRotationConflict handles the case where remote /full/current was rotated.
 // Merges local /full/current into the latest remote archived generation to avoid
 // duplicating checkpoint data, then adopts remote's /full/current as local.
-func handleRotationConflict(ctx context.Context, target string, repo *git.Repository, refName, tmpRefName plumbing.ReferenceName, remoteOnlyArchives []string) error {
+func handleRotationConflict(ctx context.Context, target, fetchTarget string, repo *git.Repository, refName, tmpRefName plumbing.ReferenceName, remoteOnlyArchives []string) error {
 	// Use the latest remote-only archive
 	latestArchive := remoteOnlyArchives[len(remoteOnlyArchives)-1]
 	archiveRefName := plumbing.ReferenceName(paths.V2FullRefPrefix + latestArchive)
@@ -249,7 +254,7 @@ func handleRotationConflict(ctx context.Context, target string, repo *git.Reposi
 	// Fetch the latest archived generation
 	archiveTmpRef := plumbing.ReferenceName("refs/entire-fetch-tmp/archive-" + latestArchive)
 	archiveRefSpec := fmt.Sprintf("+%s:%s", archiveRefName, archiveTmpRef)
-	fetchCmd := CheckpointGitCommand(ctx, target, "fetch", "--no-tags", "--filter=blob:none", target, archiveRefSpec)
+	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, archiveRefSpec)
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		return fmt.Errorf("fetch archived generation failed: %s", output)

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -114,9 +114,9 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := ResolveFilteredFetchTarget(ctx, target)
+	fetchTarget, err := ResolveFetchTarget(ctx, target)
 	if err != nil {
-		return fmt.Errorf("resolve filtered fetch target: %w", err)
+		return fmt.Errorf("resolve fetch target: %w", err)
 	}
 
 	// Fetch to a temp ref
@@ -127,7 +127,8 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	// Use --filter=blob:none for a partial fetch that downloads only commits
 	// and trees, skipping blobs. The merge only needs the tree structure to
 	// combine entries; blobs are already local or fetched on demand.
-	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, refSpec)
+	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refSpec})
+	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
@@ -254,7 +255,8 @@ func handleRotationConflict(ctx context.Context, target, fetchTarget string, rep
 	// Fetch the latest archived generation
 	archiveTmpRef := plumbing.ReferenceName("refs/entire-fetch-tmp/archive-" + latestArchive)
 	archiveRefSpec := fmt.Sprintf("+%s:%s", archiveRefName, archiveTmpRef)
-	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, "fetch", "--no-tags", "--filter=blob:none", fetchTarget, archiveRefSpec)
+	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, archiveRefSpec})
+	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		return fmt.Errorf("fetch archived generation failed: %s", output)


### PR DESCRIPTION
This does three things: 

- adding a setting to enable fetch filtering for `entire/checkpoints/v1` branches
- use the direct remote url instead of the remote name so a `.git/config` setting is only created for the url not the remote in general impacting all branches
- add an integration test guard that checks if operations touch `.git/config` and only allow expected changes.

Note: 

Running 0.5.4 introduced fetches which will cause a change in the `.git/config` like:

```
[remote "origin"]
    promisor = true
    partialclonefilter = blob:none
```

This was an unintentional result of the changes when fetching