### PR TITLE
Use --filter=blob:none only in promisor repos, shallow fetch otherwise

### DIFF
--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -385,7 +385,9 @@ func FetchMetadataBranch(ctx context.Context) error {
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", "fetch", "--no-tags", "--filter=blob:none", "origin", refSpec)
+	args := append([]string{"fetch", "--no-tags"}, strategy.PartialCloneFilterArgs(ctx)...)
+	args = append(args, "origin", refSpec)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", args...)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("fetch timed out after 2 minutes")
@@ -427,7 +429,9 @@ func FetchMetadataTreeOnly(ctx context.Context) error {
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", "fetch", "--no-tags", "--depth=1", "--filter=blob:none", "origin", refSpec)
+	args := append([]string{"fetch", "--no-tags"}, strategy.PartialCloneFilterArgsWithDepth(ctx)...)
+	args = append(args, "origin", refSpec)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", args...)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("treeless fetch timed out after 2 minutes")
@@ -465,7 +469,9 @@ func FetchV2MainTreeOnly(ctx context.Context) error {
 
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", "fetch", "--no-tags", "--depth=1", "--filter=blob:none", "origin", refSpec)
+	args := append([]string{"fetch", "--no-tags"}, strategy.PartialCloneFilterArgsWithDepth(ctx)...)
+	args = append(args, "origin", refSpec)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", args...)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 treeless fetch timed out after 2 minutes")
@@ -486,7 +492,9 @@ func FetchV2MainRef(ctx context.Context) error {
 
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", "fetch", "--no-tags", "--filter=blob:none", "origin", refSpec)
+	args := append([]string{"fetch", "--no-tags"}, strategy.PartialCloneFilterArgs(ctx)...)
+	args = append(args, "origin", refSpec)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", args...)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 fetch timed out after 2 minutes")

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -372,8 +372,8 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 
 // FetchMetadataBranch fetches the entire/checkpoints/v1 branch from origin and creates/updates the local branch.
 // This is used when the metadata branch exists on remote but not locally.
-// The fetch is treeless (--filter=blob:none) because checkpoint metadata reads
-// support on-demand blob retrieval.
+// In promisor repos the fetch is treeless (--filter=blob:none); in non-promisor repos
+// it is shallow (--depth=1) to avoid creating promisor packs.
 // Uses git CLI instead of go-git for fetch because go-git doesn't use credential helpers,
 // which breaks HTTPS URLs that require authentication.
 func FetchMetadataBranch(ctx context.Context) error {
@@ -415,11 +415,11 @@ func FetchMetadataBranch(ctx context.Context) error {
 	return nil
 }
 
-// FetchMetadataTreeOnly fetches the tip of the entire/checkpoints/v1 branch
-// from origin with --depth=1 --filter=blob:none, downloading only the latest
-// commit and its tree objects (no blobs, no history).
-// After this call, tree navigation via go-git works but blob reads will fail
-// for objects that weren't previously fetched.
+// FetchMetadataTreeOnly fetches the tip of the entire/checkpoints/v1 branch from origin.
+// In promisor repos: --depth=1 --filter=blob:none (tree objects only, no blobs).
+// In non-promisor repos: --depth=1 (shallow fetch including blobs for the tip commit).
+// After this call, tree navigation via go-git works. In promisor repos, blob reads
+// will fail for objects that weren't previously fetched.
 // Uses git CLI for credential helper support.
 func FetchMetadataTreeOnly(ctx context.Context) error {
 	branchName := paths.MetadataBranchName
@@ -459,9 +459,9 @@ func FetchMetadataTreeOnly(ctx context.Context) error {
 	return nil
 }
 
-// FetchV2MainTreeOnly fetches the tip of the v2 /main ref from origin with
-// --depth=1 --filter=blob:none, downloading only the latest commit and its
-// tree objects (no blobs, no history).
+// FetchV2MainTreeOnly fetches the tip of the v2 /main ref from origin.
+// In promisor repos: --depth=1 --filter=blob:none (tree objects only, no blobs).
+// In non-promisor repos: --depth=1 (shallow fetch including blobs for the tip commit).
 // Uses explicit refspec since v2 refs are under refs/entire/, not refs/heads/.
 func FetchV2MainTreeOnly(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
@@ -483,8 +483,8 @@ func FetchV2MainTreeOnly(ctx context.Context) error {
 }
 
 // FetchV2MainRef fetches the v2 /main ref from origin.
-// The fetch is treeless (--filter=blob:none) because /main is metadata-only and
-// v2 checkpoint reads handle transcript retrieval separately.
+// In promisor repos: --filter=blob:none (treeless, consistent with partial clone).
+// In non-promisor repos: --depth=1 (shallow fetch to avoid creating promisor packs).
 // Uses explicit refspec since v2 refs are under refs/entire/, not refs/heads/.
 func FetchV2MainRef(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -368,7 +368,9 @@ func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 
 	tmpRef := "refs/entire-fetch-tmp/" + branchName
 	refSpec := fmt.Sprintf("+refs/heads/%s:%s", branchName, tmpRef)
-	fetchCmd := CheckpointGitCommand(fetchCtx, remoteURL, "fetch", "--no-tags", "--filter=blob:none", remoteURL, refSpec)
+	args := append([]string{"fetch", "--no-tags"}, PartialCloneFilterArgs(ctx)...)
+	args = append(args, remoteURL, refSpec)
+	fetchCmd := CheckpointGitCommand(fetchCtx, remoteURL, args...)
 	// Merge GIT_TERMINAL_PROMPT=0 into whatever env CheckpointGitCommand set.
 	// If the token was injected, cmd.Env is already populated; otherwise use os.Environ().
 	if fetchCmd.Env == nil {
@@ -414,7 +416,9 @@ func FetchV2MainFromURL(ctx context.Context, remoteURL string) error {
 	defer cancel()
 
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, paths.V2MainRefName)
-	fetchCmd := CheckpointGitCommand(fetchCtx, remoteURL, "fetch", "--no-tags", "--filter=blob:none", remoteURL, refSpec)
+	args := append([]string{"fetch", "--no-tags"}, PartialCloneFilterArgs(ctx)...)
+	args = append(args, remoteURL, refSpec)
+	fetchCmd := CheckpointGitCommand(fetchCtx, remoteURL, args...)
 	if fetchCmd.Env == nil {
 		fetchCmd.Env = os.Environ()
 	}

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -49,6 +49,52 @@ const MaxCommitTraversalDepth = 1000
 // Each package needs its own package-scoped sentinel for git log iteration patterns.
 var errStop = errors.New("stop iteration")
 
+var (
+	promisorOnce sync.Once
+	isPromisor   bool
+)
+
+// IsPromisorRepo returns true if the repository is already configured as a
+// partial clone (promisor-enabled). Detection checks git config for
+// extensions.partialClone, which git sets when a repo is cloned with
+// --filter or receives a filtered fetch.
+// The result is cached for the lifetime of the process.
+func IsPromisorRepo(ctx context.Context) bool {
+	promisorOnce.Do(func() {
+		cmd := exec.CommandContext(ctx, "git", "config", "--get", "extensions.partialClone")
+		out, err := cmd.Output()
+		isPromisor = err == nil && strings.TrimSpace(string(out)) != ""
+	})
+	return isPromisor
+}
+
+// resetPromisorCacheForTest resets the cached promisor detection result.
+// Only for use in tests.
+func resetPromisorCacheForTest() {
+	promisorOnce = sync.Once{}
+	isPromisor = false
+}
+
+// PartialCloneFilterArgs returns fetch arguments appropriate for the repo type.
+// Promisor repos: ["--filter=blob:none"] (treeless fetch, consistent with partial clone).
+// Non-promisor repos: ["--depth=1"] (shallow fetch, avoids creating promisor packs).
+func PartialCloneFilterArgs(ctx context.Context) []string {
+	if IsPromisorRepo(ctx) {
+		return []string{"--filter=blob:none"}
+	}
+	return []string{"--depth=1"}
+}
+
+// PartialCloneFilterArgsWithDepth returns fetch arguments for tree-only fetches.
+// Promisor repos: ["--depth=1", "--filter=blob:none"].
+// Non-promisor repos: ["--depth=1"] (filter omitted to avoid creating promisor packs).
+func PartialCloneFilterArgsWithDepth(ctx context.Context) []string {
+	if IsPromisorRepo(ctx) {
+		return []string{"--depth=1", "--filter=blob:none"}
+	}
+	return []string{"--depth=1"}
+}
+
 // IsEmptyRepository returns true if the repository has no commits yet.
 // After git-init, HEAD points to an unborn branch (e.g., refs/heads/main)
 // whose target does not yet exist. repo.Head() returns ErrReferenceNotFound

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -61,7 +61,10 @@ var (
 // The result is cached for the lifetime of the process.
 func IsPromisorRepo(ctx context.Context) bool {
 	promisorOnce.Do(func() {
-		cmd := exec.CommandContext(ctx, "git", "config", "--get", "extensions.partialClone")
+		// Use a non-cancelable context so that a canceled/timed-out caller
+		// doesn't permanently cache false via sync.Once. The git-config
+		// call is local and fast, so it doesn't need cancellation support.
+		cmd := exec.CommandContext(context.WithoutCancel(ctx), "git", "config", "--local", "--get", "extensions.partialClone")
 		out, err := cmd.Output()
 		isPromisor = err == nil && strings.TrimSpace(string(out)) != ""
 	})
@@ -85,9 +88,9 @@ func PartialCloneFilterArgs(ctx context.Context) []string {
 	return []string{"--depth=1"}
 }
 
-// PartialCloneFilterArgsWithDepth returns fetch arguments for tree-only fetches.
-// Promisor repos: ["--depth=1", "--filter=blob:none"].
-// Non-promisor repos: ["--depth=1"] (filter omitted to avoid creating promisor packs).
+// PartialCloneFilterArgsWithDepth returns fetch arguments for shallow fetches.
+// Promisor repos: ["--depth=1", "--filter=blob:none"] (treeless: tree objects only, no blobs).
+// Non-promisor repos: ["--depth=1"] (shallow: tip commit with blobs, no filter to avoid creating promisor packs).
 func PartialCloneFilterArgsWithDepth(ctx context.Context) []string {
 	if IsPromisorRepo(ctx) {
 		return []string{"--depth=1", "--filter=blob:none"}

--- a/cmd/entire/cli/strategy/common_test.go
+++ b/cmd/entire/cli/strategy/common_test.go
@@ -1694,3 +1694,111 @@ func TestReadAgentTypeFromTree_MetadataJSON_OverridesDir(t *testing.T) {
 	result := ReadAgentTypeFromTree(tree, "cp")
 	assert.Equal(t, agent.AgentTypeCursor, result)
 }
+
+func TestIsPromisorRepo(t *testing.T) {
+	// Uses t.Chdir and resets package-level sync.Once — cannot be parallel.
+
+	t.Run("NonPromisor", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testutil.InitRepo(t, tmpDir)
+		testutil.WriteFile(t, tmpDir, "f.txt", "init")
+		testutil.GitAdd(t, tmpDir, "f.txt")
+		testutil.GitCommit(t, tmpDir, "init")
+
+		t.Chdir(tmpDir)
+		resetPromisorCacheForTest()
+
+		ctx := context.Background()
+		assert.False(t, IsPromisorRepo(ctx))
+	})
+
+	t.Run("Promisor", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testutil.InitRepo(t, tmpDir)
+		testutil.WriteFile(t, tmpDir, "f.txt", "init")
+		testutil.GitAdd(t, tmpDir, "f.txt")
+		testutil.GitCommit(t, tmpDir, "init")
+
+		cmd := exec.CommandContext(context.Background(), "git", "config", "extensions.partialClone", "origin")
+		cmd.Dir = tmpDir
+		require.NoError(t, cmd.Run())
+
+		t.Chdir(tmpDir)
+		resetPromisorCacheForTest()
+
+		ctx := context.Background()
+		assert.True(t, IsPromisorRepo(ctx))
+	})
+}
+
+func TestPartialCloneFilterArgs(t *testing.T) {
+	// Uses t.Chdir and resets package-level sync.Once — cannot be parallel.
+
+	t.Run("NonPromisor", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testutil.InitRepo(t, tmpDir)
+		testutil.WriteFile(t, tmpDir, "f.txt", "init")
+		testutil.GitAdd(t, tmpDir, "f.txt")
+		testutil.GitCommit(t, tmpDir, "init")
+
+		t.Chdir(tmpDir)
+		resetPromisorCacheForTest()
+
+		ctx := context.Background()
+		assert.Equal(t, []string{"--depth=1"}, PartialCloneFilterArgs(ctx))
+	})
+
+	t.Run("Promisor", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testutil.InitRepo(t, tmpDir)
+		testutil.WriteFile(t, tmpDir, "f.txt", "init")
+		testutil.GitAdd(t, tmpDir, "f.txt")
+		testutil.GitCommit(t, tmpDir, "init")
+
+		cmd := exec.CommandContext(context.Background(), "git", "config", "extensions.partialClone", "origin")
+		cmd.Dir = tmpDir
+		require.NoError(t, cmd.Run())
+
+		t.Chdir(tmpDir)
+		resetPromisorCacheForTest()
+
+		ctx := context.Background()
+		assert.Equal(t, []string{"--filter=blob:none"}, PartialCloneFilterArgs(ctx))
+	})
+}
+
+func TestPartialCloneFilterArgsWithDepth(t *testing.T) {
+	// Uses t.Chdir and resets package-level sync.Once — cannot be parallel.
+
+	t.Run("NonPromisor", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testutil.InitRepo(t, tmpDir)
+		testutil.WriteFile(t, tmpDir, "f.txt", "init")
+		testutil.GitAdd(t, tmpDir, "f.txt")
+		testutil.GitCommit(t, tmpDir, "init")
+
+		t.Chdir(tmpDir)
+		resetPromisorCacheForTest()
+
+		ctx := context.Background()
+		assert.Equal(t, []string{"--depth=1"}, PartialCloneFilterArgsWithDepth(ctx))
+	})
+
+	t.Run("Promisor", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testutil.InitRepo(t, tmpDir)
+		testutil.WriteFile(t, tmpDir, "f.txt", "init")
+		testutil.GitAdd(t, tmpDir, "f.txt")
+		testutil.GitCommit(t, tmpDir, "init")
+
+		cmd := exec.CommandContext(context.Background(), "git", "config", "extensions.partialClone", "origin")
+		cmd.Dir = tmpDir
+		require.NoError(t, cmd.Run())
+
+		t.Chdir(tmpDir)
+		resetPromisorCacheForTest()
+
+		ctx := context.Background()
+		assert.Equal(t, []string{"--depth=1", "--filter=blob:none"}, PartialCloneFilterArgsWithDepth(ctx))
+	})
+}

--- a/cmd/entire/cli/strategy/common_test.go
+++ b/cmd/entire/cli/strategy/common_test.go
@@ -1729,6 +1729,45 @@ func TestIsPromisorRepo(t *testing.T) {
 		ctx := context.Background()
 		assert.True(t, IsPromisorRepo(ctx))
 	})
+
+	t.Run("CanceledContextDoesNotCacheFalse", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testutil.InitRepo(t, tmpDir)
+		testutil.WriteFile(t, tmpDir, "f.txt", "init")
+		testutil.GitAdd(t, tmpDir, "f.txt")
+		testutil.GitCommit(t, tmpDir, "init")
+
+		cmd := exec.CommandContext(context.Background(), "git", "config", "extensions.partialClone", "origin")
+		cmd.Dir = tmpDir
+		require.NoError(t, cmd.Run())
+
+		t.Chdir(tmpDir)
+		resetPromisorCacheForTest()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		assert.True(t, IsPromisorRepo(ctx), "canceled context must not prevent detection")
+	})
+
+	t.Run("IgnoresGlobalConfig", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		testutil.InitRepo(t, tmpDir)
+		testutil.WriteFile(t, tmpDir, "f.txt", "init")
+		testutil.GitAdd(t, tmpDir, "f.txt")
+		testutil.GitCommit(t, tmpDir, "init")
+
+		// Set extensions.partialClone at --global level only (not --local).
+		globalCfg := filepath.Join(tmpDir, "fake-global-gitconfig")
+		cmd := exec.CommandContext(context.Background(), "git", "config", "--file", globalCfg, "extensions.partialClone", "origin")
+		cmd.Dir = tmpDir
+		require.NoError(t, cmd.Run())
+
+		t.Setenv("GIT_CONFIG_GLOBAL", globalCfg)
+		t.Chdir(tmpDir)
+		resetPromisorCacheForTest()
+
+		assert.False(t, IsPromisorRepo(context.Background()), "global-only partialClone must not mark repo as promisor")
+	})
 }
 
 func TestPartialCloneFilterArgs(t *testing.T) {

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -201,10 +201,14 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	}
 
 	// Use git CLI for fetch (go-git's fetch can be tricky with auth).
-	// Use --filter=blob:none for a partial fetch that downloads only commits
-	// and trees, skipping blobs. The merge only needs the tree structure to
-	// combine entries; blobs are already local or fetched on demand.
-	fetchCmd := CheckpointGitCommand(ctx, target, "fetch", "--no-tags", "--filter=blob:none", target, refSpec)
+	// In promisor repos, use --filter=blob:none to stay consistent with partial clone.
+	// In non-promisor repos, do a plain fetch (needs full history for rebase).
+	args := []string{"fetch", "--no-tags"}
+	if IsPromisorRepo(ctx) {
+		args = append(args, "--filter=blob:none")
+	}
+	args = append(args, target, refSpec)
+	fetchCmd := CheckpointGitCommand(ctx, target, args...)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
 	}

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -119,10 +119,14 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	tmpRefName := plumbing.ReferenceName("refs/entire-fetch-tmp/" + tmpRefSuffix)
 	refSpec := fmt.Sprintf("+%s:%s", refName, tmpRefName)
 
-	// Use --filter=blob:none for a partial fetch that downloads only commits
-	// and trees, skipping blobs. The merge only needs the tree structure to
-	// combine entries; blobs are already local or fetched on demand.
-	fetchCmd := CheckpointGitCommand(ctx, target, "fetch", "--no-tags", "--filter=blob:none", target, refSpec)
+	// In promisor repos, use --filter=blob:none to stay consistent with partial clone.
+	// In non-promisor repos, do a plain fetch (needs full history for tree merge).
+	args := []string{"fetch", "--no-tags"}
+	if IsPromisorRepo(ctx) {
+		args = append(args, "--filter=blob:none")
+	}
+	args = append(args, target, refSpec)
+	fetchCmd := CheckpointGitCommand(ctx, target, args...)
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)


### PR DESCRIPTION
  Checkpoint fetches previously always used `--filter=blob:none`, which  turns non-promisor repositories into promisor-enabled ones as a side  effect. Now we detect whether the repo is already a partial clone (via `extensions.partialClone` config) and only use treeless fetches in that case. Non-promisor repos use --depth=1 (shallow) instead,  or plain fetches where full history is needed for rebase/merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `git fetch` flags across checkpoint metadata read/push paths based on detected repo type, which can affect how much history/blobs are available and could impact resume/sync behavior in edge cases.
> 
> **Overview**
> Stops unconditionally using `--filter=blob:none` for checkpoint-related fetches so **non-partial-clone repos don’t get converted into promisor repos** as a side effect.
> 
> Adds promisor detection via `git config --local extensions.partialClone` (cached per process) and centralizes flag selection in `PartialCloneFilterArgs*`; metadata/v2 fetches now use *treeless* fetches only for promisor repos and otherwise prefer shallow (`--depth=1`) or unfiltered fetches where full history is required for rebase/merge.
> 
> Updates both origin fetches and checkpoint-remote URL fetches, and adds unit tests covering promisor detection, context-cancellation behavior, and the chosen fetch arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42c0fe298ca70ed81da4b5aa07c36e8af1a78ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->