### PR TITLE
Fix external agent `explain` commmand

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
 	"github.com/entireio/cli/cmd/entire/cli/agent/opencode"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
@@ -154,6 +155,9 @@ Note: --session filters the list view; --commit and --checkpoint are mutually ex
 			if rawTranscriptFlag && checkpointFlag == "" {
 				return errors.New("--raw-transcript requires --checkpoint/-c flag")
 			}
+
+			// Discover external agents so checkpoints from external agents can be resolved.
+			external.DiscoverAndRegister(cmd.Context())
 
 			// Convert short flag to verbose (verbose = !short)
 			verbose := !shortFlag

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/summarize"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -4781,4 +4782,68 @@ func createCommitWithTree(t *testing.T, repo *git.Repository, treeHash plumbing.
 		t.Fatalf("failed to store commit: %v", err)
 	}
 	return hash
+}
+
+// TestExplainCmd_DiscoversExternalAgents verifies that the explain command
+// discovers external agent plugins so that checkpoints from external agents
+// (e.g. pi) can be resolved. This was missing, causing transcript parsing
+// to fail for external agents.
+func TestExplainCmd_DiscoversExternalAgents(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+
+	t.Chdir(tmpDir)
+	paths.ClearWorktreeRootCache()
+	session.ClearGitCommonDirCache()
+
+	// Create .entire/settings.json with external_agents enabled
+	entireDir := filepath.Join(tmpDir, paths.EntireDir)
+	if err := os.MkdirAll(entireDir, 0o755); err != nil {
+		t.Fatalf("failed to create .entire directory: %v", err)
+	}
+	settingsFile := filepath.Join(entireDir, "settings.json")
+	if err := os.WriteFile(settingsFile, []byte(`{"enabled":true,"external_agents":true}`), 0o644); err != nil {
+		t.Fatalf("failed to write settings file: %v", err)
+	}
+
+	// Create a mock external agent binary
+	agentName := types.AgentName("explain-test-agent")
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "entire-agent-"+string(agentName))
+	infoJSON := `{
+  "protocol_version": 1,
+  "name": "` + string(agentName) + `",
+  "type": "Explain Test Agent",
+  "description": "Agent for explain discovery test",
+  "is_preview": false,
+  "protected_dirs": [],
+  "hook_names": [],
+  "capabilities": {"transcript_analyzer": true}
+}`
+	script := "#!/bin/sh\nif [ \"$1\" = \"info\" ]; then\n  echo '" + infoJSON + "'\nfi\n"
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write mock agent binary: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Execute the explain command — it should discover the external agent
+	cmd := newExplainCmd()
+	cmd.SetArgs([]string{"--no-pager"})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(context.Background())
+	_ = cmd.Execute() //nolint:errcheck // May error (no checkpoints); we only check agent discovery
+
+	// The external agent should have been discovered and registered
+	if _, err := agent.Get(agentName); err != nil {
+		t.Errorf("expected external agent %q to be registered after explain, got: %v", agentName, err)
+	}
 }

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -400,6 +400,9 @@ func generateSummary(ctx context.Context, redactedTranscript redact.RedactedByte
 		scopedTranscript = scoped
 	case agent.AgentTypeCodex, agent.AgentTypeClaudeCode, agent.AgentTypeCursor, agent.AgentTypeFactoryAIDroid, agent.AgentTypeUnknown:
 		scopedTranscript = transcript.SliceFromLine(transcriptBytes, state.CheckpointTranscriptStart)
+	default:
+		// External agents: use line-based slicing (works for any JSONL format)
+		scopedTranscript = transcript.SliceFromLine(transcriptBytes, state.CheckpointTranscriptStart)
 	}
 
 	if len(scopedTranscript) == 0 {

--- a/cmd/entire/cli/summarize/summarize.go
+++ b/cmd/entire/cli/summarize/summarize.go
@@ -129,13 +129,53 @@ func BuildCondensedTranscriptFromBytes(content redact.RedactedBytes, agentType t
 		return buildCondensedTranscriptFromCodex(content)
 	case agent.AgentTypeClaudeCode, agent.AgentTypeCursor, agent.AgentTypeUnknown:
 		// Claude/cursor format - fall through to shared logic below
+	default:
+		// External/unknown agent types: use compact auto-detection which handles
+		// any JSONL variant (including type:"message" with nested message.role).
+		return buildCondensedTranscriptViaCompact(content)
 	}
-	// Claude format (JSONL) - handles Claude Code, Unknown, and any future agent types
+	// Claude format (JSONL) - handles Claude Code, Unknown, and Cursor
 	lines, err := transcript.ParseFromBytes(content.Bytes())
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse transcript: %w", err)
 	}
 	return BuildCondensedTranscript(lines), nil
+}
+
+// buildCondensedTranscriptViaCompact normalizes a transcript using the format
+// auto-detection in compact.Compact, then parses the compact output into entries.
+// This is the fallback for external agent types whose transcript format isn't
+// known at compile time.
+func buildCondensedTranscriptViaCompact(content redact.RedactedBytes) ([]Entry, error) {
+	compacted, err := compact.Compact(content, compact.MetadataFields{
+		Agent:      "unknown",
+		CLIVersion: "0.0.0",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to compact transcript: %w", err)
+	}
+	return buildCondensedFromCompactBytes(compacted)
+}
+
+// buildCondensedFromCompactBytes parses compact transcript.jsonl bytes into entries.
+func buildCondensedFromCompactBytes(compactBytes []byte) ([]Entry, error) {
+	compactEntries, err := compact.BuildCondensedEntries(compactBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing compact transcript: %w", err)
+	}
+
+	entries := make([]Entry, 0, len(compactEntries))
+	for _, entry := range compactEntries {
+		switch entry.Type {
+		case "user":
+			entries = append(entries, Entry{Type: EntryTypeUser, Content: entry.Content})
+		case "assistant":
+			entries = append(entries, Entry{Type: EntryTypeAssistant, Content: entry.Content})
+		case "tool":
+			entries = append(entries, Entry{Type: EntryTypeTool, ToolName: entry.ToolName, ToolDetail: entry.ToolDetail})
+		}
+	}
+	return entries, nil
 }
 
 // buildCondensedTranscriptFromGemini parses Gemini JSON transcript and extracts a condensed view.

--- a/cmd/entire/cli/transcript/compact/codex.go
+++ b/cmd/entire/cli/transcript/compact/codex.go
@@ -107,7 +107,7 @@ func compactCodex(content []byte, opts MetadataFields) ([]byte, error) {
 		}
 
 		switch {
-		case p.Type == transcriptTypeMessage && p.Role == "user":
+		case p.Type == transcriptTypeMessage && p.Role == transcript.TypeUser:
 			text := codexUserText(p.Content)
 			if text == "" {
 				continue
@@ -122,7 +122,7 @@ func compactCodex(content []byte, opts MetadataFields) ([]byte, error) {
 			line.Content = contentJSON
 			appendLine(&result, line)
 
-		case p.Type == transcriptTypeMessage && p.Role == "assistant":
+		case p.Type == transcriptTypeMessage && p.Role == transcript.TypeAssistant:
 			text := codexAssistantText(p.Content)
 			if text == "" {
 				continue

--- a/cmd/entire/cli/transcript/compact/compact.go
+++ b/cmd/entire/cli/transcript/compact/compact.go
@@ -131,11 +131,21 @@ var userAliases = map[string]bool{
 
 // normalizeKind returns the canonical entry kind ("user" or "assistant") for a
 // JSONL transcript line. It checks the "type" field, then falls back to "role".
+// For type:"message" lines (used by external agents like pi), the role is
+// extracted from the nested "message" object.
 // Returns "" for unrecognised or dropped entries.
 func normalizeKind(raw map[string]json.RawMessage) string {
 	kind := unquote(raw["type"])
 	if kind == "" {
 		kind = unquote(raw["role"])
+	}
+
+	// External agents may wrap messages as type:"message" with the actual role
+	// inside a nested "message" object: {"type":"message","message":{"role":"user",...}}.
+	if kind == transcriptTypeMessage {
+		if role := nestedMessageRole(raw); role != "" {
+			kind = role
+		}
 	}
 
 	if droppedTypes[kind] {
@@ -146,6 +156,21 @@ func normalizeKind(raw map[string]json.RawMessage) string {
 	}
 	if kind == transcript.TypeAssistant {
 		return transcript.TypeAssistant
+	}
+	return ""
+}
+
+// nestedMessageRole extracts the "role" field from a nested "message" object.
+func nestedMessageRole(raw map[string]json.RawMessage) string {
+	msgRaw, ok := raw["message"]
+	if !ok {
+		return ""
+	}
+	var msg struct {
+		Role string `json:"role"`
+	}
+	if json.Unmarshal(msgRaw, &msg) == nil {
+		return msg.Role
 	}
 	return ""
 }
@@ -639,12 +664,21 @@ func stripAssistantContent(contentRaw json.RawMessage) json.RawMessage {
 			continue
 		}
 
-		if blockType == transcript.ContentTypeToolUse {
+		if blockType == transcript.ContentTypeToolUse || blockType == "toolCall" {
 			stripped := make(map[string]json.RawMessage)
-			copyField(stripped, block, "type")
+			stripped["type"] = json.RawMessage(`"` + transcript.ContentTypeToolUse + `"`)
 			copyField(stripped, block, "id")
 			copyField(stripped, block, "name")
-			copyField(stripped, block, "input")
+			// Normalize "arguments" (used by external agents like pi) to "input".
+			if _, ok := block["input"]; ok {
+				copyField(stripped, block, "input")
+			} else {
+				copyField(stripped, block, "arguments")
+				if v, ok := stripped["arguments"]; ok {
+					stripped["input"] = v
+					delete(stripped, "arguments")
+				}
+			}
 			result = append(result, stripped)
 			continue
 		}

--- a/cmd/entire/cli/transcript/compact/compact_test.go
+++ b/cmd/entire/cli/transcript/compact/compact_test.go
@@ -633,3 +633,139 @@ func assertJSONLines(t *testing.T, actual []byte, expected []string) {
 		}
 	}
 }
+
+// --- External agent (pi format) tests ---
+
+// TestCompact_PiMessageFormat verifies that the compact layer handles transcripts
+// using type:"message" with a nested message.role field (pi agent format).
+func TestCompact_PiMessageFormat(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{"type":"session","version":3,"id":"sess-1","timestamp":"2026-01-01T00:00:00Z","cwd":"/repo"}
+{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-01-01T00:00:00Z","provider":"anthropic","modelId":"claude-opus-4-6"}
+{"type":"message","id":"m1","parentId":"mc1","timestamp":"2026-01-01T00:00:01Z","message":{"role":"user","content":[{"type":"text","text":"add a README"}],"timestamp":1700000000000}}
+{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-01-01T00:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"I'll create a README for you."},{"type":"toolCall","id":"tc1","name":"write","arguments":{"path":"README.md","content":"# Hello"}}],"usage":{"input":500,"output":100},"stopReason":"toolUse"}}
+`)
+
+	opts := agentOpts("pi")
+	result, err := Compact(redact.AlreadyRedacted(input), opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(result)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 output lines, got %d: %s", len(lines), string(result))
+	}
+
+	// Verify we got user and assistant entries, and toolCall was normalized to tool_use
+	var hasUser, hasAssistant, hasToolUse bool
+	for _, line := range lines {
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &parsed); err != nil {
+			t.Fatalf("failed to parse output line: %v", err)
+		}
+		if parsed["type"] == "user" {
+			hasUser = true
+		}
+		if parsed["type"] == "assistant" {
+			hasAssistant = true
+			// Check that the assistant content has a normalized tool_use block
+			if content, ok := parsed["content"].([]interface{}); ok {
+				for _, block := range content {
+					if blockMap, ok := block.(map[string]interface{}); ok {
+						if blockMap["type"] == "tool_use" {
+							hasToolUse = true
+							// Verify "arguments" was renamed to "input"
+							if _, hasInput := blockMap["input"]; !hasInput {
+								t.Error("tool_use block should have 'input' field (normalized from 'arguments')")
+							}
+							if _, hasArgs := blockMap["arguments"]; hasArgs {
+								t.Error("tool_use block should not have 'arguments' field after normalization")
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if !hasUser {
+		t.Error("expected a user entry in compact output")
+	}
+	if !hasAssistant {
+		t.Error("expected an assistant entry in compact output")
+	}
+	if !hasToolUse {
+		t.Error("expected a tool_use entry in compact output (normalized from toolCall)")
+	}
+
+	// Verify that BuildCondensedEntries can parse the compact output into tool entries
+	condensed, err := BuildCondensedEntries(result)
+	if err != nil {
+		t.Fatalf("BuildCondensedEntries failed: %v", err)
+	}
+	var hasTool bool
+	for _, entry := range condensed {
+		if entry.Type == "tool" && entry.ToolName == "write" {
+			hasTool = true
+		}
+	}
+	if !hasTool {
+		t.Errorf("expected condensed entry with tool name 'write', got: %+v", condensed)
+	}
+}
+
+func TestNormalizeKind_NestedMessageRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "type:message with role:user",
+			raw:  `{"type":"message","message":{"role":"user","content":[]}}`,
+			want: "user",
+		},
+		{
+			name: "type:message with role:assistant",
+			raw:  `{"type":"message","message":{"role":"assistant","content":[]}}`,
+			want: "assistant",
+		},
+		{
+			name: "type:message without message field",
+			raw:  `{"type":"message"}`,
+			want: "",
+		},
+		{
+			name: "type:message with non-object message",
+			raw:  `{"type":"message","message":"hello"}`,
+			want: "",
+		},
+		{
+			name: "regular user type unchanged",
+			raw:  `{"type":"user","message":{"content":"hello"}}`,
+			want: "user",
+		},
+		{
+			name: "regular assistant type unchanged",
+			raw:  `{"type":"assistant","message":{"content":[]}}`,
+			want: "assistant",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(tt.raw), &raw); err != nil {
+				t.Fatalf("failed to parse test input: %v", err)
+			}
+			got := normalizeKind(raw)
+			if got != tt.want {
+				t.Errorf("normalizeKind() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/transcript/compact/parse.go
+++ b/cmd/entire/cli/transcript/compact/parse.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/transcript"
 )
 
 type CondensedEntry struct {
@@ -59,7 +61,7 @@ func BuildCondensedEntries(content []byte) ([]CondensedEntry, error) {
 		}
 
 		switch line.Type {
-		case "user":
+		case transcript.TypeUser:
 			var parts []string
 			for _, block := range blocks {
 				var text string
@@ -68,10 +70,10 @@ func BuildCondensedEntries(content []byte) ([]CondensedEntry, error) {
 				}
 			}
 			if len(parts) > 0 {
-				entries = append(entries, CondensedEntry{Type: "user", Content: strings.Join(parts, "\n")})
+				entries = append(entries, CondensedEntry{Type: transcript.TypeUser, Content: strings.Join(parts, "\n")})
 			}
 
-		case "assistant":
+		case transcript.TypeAssistant:
 			for _, block := range blocks {
 				var blockType string
 				if err := json.Unmarshal(block["type"], &blockType); err != nil {
@@ -82,7 +84,7 @@ func BuildCondensedEntries(content []byte) ([]CondensedEntry, error) {
 				case "text":
 					var text string
 					if err := json.Unmarshal(block["text"], &text); err == nil && text != "" {
-						entries = append(entries, CondensedEntry{Type: "assistant", Content: text})
+						entries = append(entries, CondensedEntry{Type: transcript.TypeAssistant, Content: text})
 					}
 				case "tool_use":
 					var toolName string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes transcript parsing/compaction and summary generation fallbacks for previously supported agent types, which could affect `explain` output and summarization if the auto-detection misclassifies lines.
> 
> **Overview**
> `explain` now **discovers and registers external agent plugins** at command startup so checkpoints created by external agents can be resolved.
> 
> Transcript handling was updated to better support external JSONL formats (e.g. *pi*): summary scoping falls back to line-based slicing for unknown agent types, summarization adds a compact-based auto-detection fallback, and the compact normalizer now understands `type:"message"` with nested `message.role` plus normalizes `toolCall`/`arguments` into canonical `tool_use`/`input`.
> 
> Adds targeted tests covering external agent discovery from `PATH` and compact parsing/normalization for the pi-style transcript format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6210124f6c58f218368ee7eeaf7885f66630d8c0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->