### PR TITLE
Add devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    build-essential \
+    ca-certificates \
+    curl \
+    dbus-x11 \
+    git \
+    gnome-keyring \
+    jq \
+    less \
+    openssh-client \
+    pkg-config \
+    shellcheck \
+    sudo \
+    tmux \
+    unzip \
+    xz-utils \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
+
+ENV MISE_DATA_DIR=/home/vscode/.local/share/mise
+ENV PATH=/home/vscode/.local/share/mise/shims:/home/vscode/.local/bin:/home/vscode/go/bin:${PATH}
+
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Entire CLI",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "vscode",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "gopls": {
+          "build.buildFlags": [
+            "-tags=e2e,integration"
+          ]
+        },
+        "go.testTags": "e2e,integration"
+      },
+      "extensions": [
+        "golang.Go",
+        "timonwong.shellcheck"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,5 +8,3 @@ cd "${REPO_ROOT}"
 
 mise trust --yes
 mise install
-mise exec -- go install github.com/entireio/roger-roger/cmd/roger-roger@latest
-mise exec -- go install github.com/entireio/roger-roger/cmd/entire-agent-roger-roger@latest

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+mise trust --yes
+mise install
+mise exec -- go install github.com/entireio/roger-roger/cmd/roger-roger@latest
+mise exec -- go install github.com/entireio/roger-roger/cmd/entire-agent-roger-roger@latest

--- a/.devcontainer/run-with-keyring.sh
+++ b/.devcontainer/run-with-keyring.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  set -- mise run test:ci
+fi
+
+export ENTIRE_DEVCONTAINER_KEYRING_PASSWORD="${ENTIRE_DEVCONTAINER_KEYRING_PASSWORD:-entire-devcontainer}"
+
+exec dbus-run-session -- bash -lc '
+  set -euo pipefail
+  printf "%s" "$ENTIRE_DEVCONTAINER_KEYRING_PASSWORD" | gnome-keyring-daemon --unlock >/dev/null
+  exec "$@"
+' bash "$@"

--- a/.devcontainer/run-with-keyring.sh
+++ b/.devcontainer/run-with-keyring.sh
@@ -5,7 +5,10 @@ if [ "$#" -eq 0 ]; then
   set -- mise run test:ci
 fi
 
-export ENTIRE_DEVCONTAINER_KEYRING_PASSWORD="${ENTIRE_DEVCONTAINER_KEYRING_PASSWORD:-entire-devcontainer}"
+if [ -z "${ENTIRE_DEVCONTAINER_KEYRING_PASSWORD:-}" ]; then
+  ENTIRE_DEVCONTAINER_KEYRING_PASSWORD="$(openssl rand -hex 16)"
+fi
+export ENTIRE_DEVCONTAINER_KEYRING_PASSWORD
 
 exec dbus-run-session -- bash -lc '
   set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -462,6 +462,19 @@ mise trust
 mise run build
 ```
 
+### Dev Container
+
+The repo includes a `.devcontainer/` configuration that installs the system packages used by local development and CI (`git`, `tmux`, `gnome-keyring`, etc) and then bootstraps the repo's `mise` toolchain.
+
+Open the folder in a Dev Container, or start it from the `devcontainer` CLI as follows:
+
+```bash
+devcontainer up --workspace-folder .
+devcontainer exec --workspace-folder . bash -lc '.devcontainer/run-with-keyring.sh'
+```
+
+The container's `postCreateCommand` runs `mise trust --yes && mise install`, so Go, `golangci-lint`, `gotestsum`, `shellcheck`, and the canary E2E helper binaries are ready after creation. Use `.devcontainer/run-with-keyring.sh <command>` for commands that touch the Linux keyring, including `mise run test:ci`.
+
 ### Common Tasks
 
 ```

--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ devcontainer exec --workspace-folder . bash -lc '.devcontainer/run-with-keyring.
 
 The container's `postCreateCommand` runs `mise trust --yes && mise install`, so Go, `golangci-lint`, `gotestsum`, `shellcheck`, and the canary E2E helper binaries are ready after creation. Use `.devcontainer/run-with-keyring.sh <command>` for commands that touch the Linux keyring, including `mise run test:ci`.
 
+If you need keyring-dependent commands to work reliably in the devcontainer, set `ENTIRE_DEVCONTAINER_KEYRING_PASSWORD` in the environment before invoking `.devcontainer/run-with-keyring.sh`. The helper uses that value to unlock/configure the keyring non-interactively. If `ENTIRE_DEVCONTAINER_KEYRING_PASSWORD` is unset, the helper will not have a password to provide, so commands that need the keyring may prompt, fail to unlock it, or otherwise be unreliable in non-interactive runs.
 ### Common Tasks
 
 ```

--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ devcontainer exec --workspace-folder . bash -lc '.devcontainer/run-with-keyring.
 The container's `postCreateCommand` runs `mise trust --yes && mise install`, so Go, `golangci-lint`, `gotestsum`, `shellcheck`, and the canary E2E helper binaries are ready after creation. Use `.devcontainer/run-with-keyring.sh <command>` for commands that touch the Linux keyring, including `mise run test:ci`.
 
 If `ENTIRE_DEVCONTAINER_KEYRING_PASSWORD` is set in the environment, `.devcontainer/run-with-keyring.sh` uses that value to unlock the keyring non-interactively. If it is unset, the script generates a random password for the session automatically.
+
 ### Common Tasks
 
 ```

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ devcontainer exec --workspace-folder . bash -lc '.devcontainer/run-with-keyring.
 
 The container's `postCreateCommand` runs `mise trust --yes && mise install`, so Go, `golangci-lint`, `gotestsum`, `shellcheck`, and the canary E2E helper binaries are ready after creation. Use `.devcontainer/run-with-keyring.sh <command>` for commands that touch the Linux keyring, including `mise run test:ci`.
 
-If you need keyring-dependent commands to work reliably in the devcontainer, set `ENTIRE_DEVCONTAINER_KEYRING_PASSWORD` in the environment before invoking `.devcontainer/run-with-keyring.sh`. The helper uses that value to unlock/configure the keyring non-interactively. If `ENTIRE_DEVCONTAINER_KEYRING_PASSWORD` is unset, the helper will not have a password to provide, so commands that need the keyring may prompt, fail to unlock it, or otherwise be unreliable in non-interactive runs.
+If `ENTIRE_DEVCONTAINER_KEYRING_PASSWORD` is set in the environment, `.devcontainer/run-with-keyring.sh` uses that value to unlock the keyring non-interactively. If it is unset, the script generates a random password for the session automatically.
 ### Common Tasks
 
 ```


### PR DESCRIPTION
This pull request introduces a devcontainer setup. It adds a `.devcontainer` directory with configuration files, a custom Dockerfile, and helper scripts to automate environment provisioning, dependency installation, and keyring management. Documentation is updated to guide users on leveraging the new dev container.

**Dev Container Setup:**

* Added `.devcontainer/Dockerfile` to define a development environment based on Ubuntu 24.04, installing essential tools and configuring the `mise` version manager for language and toolchain management.
* Introduced `.devcontainer/devcontainer.json` to configure VS Code Dev Containers, specifying build context, user, post-create commands, editor settings, and recommended extensions for Go and shell scripting.

**Automation Scripts:**

* Added `.devcontainer/post-create.sh` to bootstrap the repository by trusting and installing the `mise` toolchain and installing required Go binaries after container creation.
* Added `.devcontainer/run-with-keyring.sh` to run commands within a session that unlocks the Linux keyring, supporting workflows that require secure credential storage (e.g., running tests).

**Documentation:**

* Updated `README.md` with instructions on using the dev container, including startup commands, available tooling, and guidance for running commands that require the Linux keyring.

**Entire**

* [Checkpoint: 03ecbfaa1b6e](https://entire.io/gh/entireio/cli/commit/9b01555b25c8810e8e7e2daadc9a7f949e0335dc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new devcontainer config/scripts and README docs without changing application/runtime code. Main risk is developer environment drift or tooling install failures inside the container.
> 
> **Overview**
> Adds a new `.devcontainer/` setup to standardize development in a container: an Ubuntu 24.04 Dockerfile with common dev/CI packages plus `mise`, a `devcontainer.json` that runs a post-create bootstrap, and scripts to install toolchains/binaries and to run commands with an unlocked `gnome-keyring` via `dbus-run-session`.
> 
> Updates `README.md` with Dev Container usage instructions and notes that keyring-dependent commands (e.g., `mise run test:ci`) should be run through `.devcontainer/run-with-keyring.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b01555b25c8810e8e7e2daadc9a7f949e0335dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->