### PR TITLE
Fix Factory fallback tool use IDs

### DIFF
--- a/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
+++ b/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -231,11 +232,15 @@ func (f *FactoryAIDroidAgent) parseSubagentStart(stdin io.Reader) (*agent.Event,
 	if err != nil {
 		return nil, err
 	}
+	toolUseID := raw.ToolUseID
+	if toolUseID == "" {
+		toolUseID = fallbackToolUseID(raw.SessionID, raw.ToolName, raw.ToolInput)
+	}
 	return &agent.Event{
 		Type:       agent.SubagentStart,
 		SessionID:  raw.SessionID,
 		SessionRef: raw.TranscriptPath,
-		ToolUseID:  raw.ToolUseID,
+		ToolUseID:  toolUseID,
 		ToolInput:  raw.ToolInput,
 		Timestamp:  time.Now(),
 	}, nil
@@ -246,16 +251,20 @@ func (f *FactoryAIDroidAgent) parseSubagentEnd(stdin io.Reader) (*agent.Event, e
 	if err != nil {
 		return nil, err
 	}
+	toolUseID := raw.ToolUseID
+	if toolUseID == "" {
+		toolUseID = fallbackToolUseID(raw.SessionID, raw.ToolName, raw.ToolInput)
+	}
 	event := &agent.Event{
 		Type:       agent.SubagentEnd,
 		SessionID:  raw.SessionID,
 		SessionRef: raw.TranscriptPath,
-		ToolUseID:  raw.ToolUseID,
+		ToolUseID:  toolUseID,
 		ToolInput:  raw.ToolInput,
 		Timestamp:  time.Now(),
 	}
-	if raw.ToolResponse.AgentID != "" {
-		event.SubagentID = raw.ToolResponse.AgentID
+	if agentID := parseHookToolResponseAgentID(raw.ToolResponse); agentID != "" {
+		event.SubagentID = agentID
 	}
 	return event, nil
 }
@@ -271,4 +280,45 @@ func (f *FactoryAIDroidAgent) parseCompaction(stdin io.Reader) (*agent.Event, er
 		SessionRef: raw.TranscriptPath,
 		Timestamp:  time.Now(),
 	}, nil
+}
+
+func parseHookToolResponseAgentID(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+
+	var obj struct {
+		AgentID string `json:"agentId"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil && obj.AgentID != "" {
+		return obj.AgentID
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return extractHookToolResponseAgentID(text)
+	}
+
+	return ""
+}
+
+func extractHookToolResponseAgentID(text string) string {
+	const prefix = "agentId: "
+	_, after, found := strings.Cut(text, prefix)
+	if !found {
+		return ""
+	}
+
+	after = strings.TrimSpace(after)
+	end := 0
+	for end < len(after) {
+		ch := after[end]
+		if ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9' || ch == '-' || ch == '_' {
+			end++
+			continue
+		}
+		break
+	}
+
+	return after[:end]
 }

--- a/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
+++ b/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
@@ -1,6 +1,7 @@
 package factoryaidroid
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -289,7 +290,7 @@ func (f *FactoryAIDroidAgent) parseCompaction(stdin io.Reader) (*agent.Event, er
 }
 
 func parseHookToolResponseAgentID(raw json.RawMessage) string {
-	if len(raw) == 0 || string(raw) == "null" {
+	if trimmed := bytes.TrimSpace(raw); len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
 		return ""
 	}
 

--- a/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
+++ b/cmd/entire/cli/agent/factoryaidroid/lifecycle.go
@@ -51,7 +51,7 @@ func (f *FactoryAIDroidAgent) HookNames() []string {
 
 // ParseHookEvent translates a Factory AI Droid hook into a normalized lifecycle Event.
 // Returns nil if the hook has no lifecycle significance.
-func (f *FactoryAIDroidAgent) ParseHookEvent(_ context.Context, hookName string, stdin io.Reader) (*agent.Event, error) {
+func (f *FactoryAIDroidAgent) ParseHookEvent(ctx context.Context, hookName string, stdin io.Reader) (*agent.Event, error) {
 	switch hookName {
 	case HookNameSessionStart:
 		return f.parseSessionStart(stdin)
@@ -62,9 +62,9 @@ func (f *FactoryAIDroidAgent) ParseHookEvent(_ context.Context, hookName string,
 	case HookNameSessionEnd:
 		return f.parseSessionEnd(stdin)
 	case HookNamePreToolUse:
-		return f.parseSubagentStart(stdin)
+		return f.parseSubagentStart(ctx, stdin)
 	case HookNamePostToolUse:
-		return f.parseSubagentEnd(stdin)
+		return f.parseSubagentEnd(ctx, stdin)
 	case HookNamePreCompact:
 		return f.parseCompaction(stdin)
 	case HookNameSubagentStop, HookNameNotification:
@@ -227,14 +227,17 @@ func (f *FactoryAIDroidAgent) parseSessionEnd(stdin io.Reader) (*agent.Event, er
 	}, nil
 }
 
-func (f *FactoryAIDroidAgent) parseSubagentStart(stdin io.Reader) (*agent.Event, error) {
+func (f *FactoryAIDroidAgent) parseSubagentStart(ctx context.Context, stdin io.Reader) (*agent.Event, error) {
 	raw, err := agent.ReadAndParseHookInput[taskHookInputRaw](stdin)
 	if err != nil {
 		return nil, err
 	}
 	toolUseID := raw.ToolUseID
 	if toolUseID == "" {
-		toolUseID = fallbackToolUseID(raw.SessionID, raw.ToolName, raw.ToolInput)
+		toolUseID, err = registerFallbackToolUseID(ctx, raw.SessionID, raw.ToolName, raw.ToolInput)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &agent.Event{
 		Type:       agent.SubagentStart,
@@ -246,14 +249,17 @@ func (f *FactoryAIDroidAgent) parseSubagentStart(stdin io.Reader) (*agent.Event,
 	}, nil
 }
 
-func (f *FactoryAIDroidAgent) parseSubagentEnd(stdin io.Reader) (*agent.Event, error) {
+func (f *FactoryAIDroidAgent) parseSubagentEnd(ctx context.Context, stdin io.Reader) (*agent.Event, error) {
 	raw, err := agent.ReadAndParseHookInput[postToolHookInputRaw](stdin)
 	if err != nil {
 		return nil, err
 	}
 	toolUseID := raw.ToolUseID
 	if toolUseID == "" {
-		toolUseID = fallbackToolUseID(raw.SessionID, raw.ToolName, raw.ToolInput)
+		toolUseID, err = resolveFallbackToolUseID(ctx, raw.SessionID, raw.ToolName, raw.ToolInput)
+		if err != nil {
+			return nil, err
+		}
 	}
 	event := &agent.Event{
 		Type:       agent.SubagentEnd,

--- a/cmd/entire/cli/agent/factoryaidroid/lifecycle_test.go
+++ b/cmd/entire/cli/agent/factoryaidroid/lifecycle_test.go
@@ -176,6 +176,42 @@ func TestParseHookEvent_SubagentEnd(t *testing.T) {
 	}
 }
 
+func TestParseHookEvent_SubagentStart_MissingToolUseID(t *testing.T) {
+	t.Parallel()
+
+	ag := &FactoryAIDroidAgent{}
+	input := `{"session_id": "sess-4", "transcript_path": "/tmp/t.jsonl", "tool_name": "Task", "tool_input": {"prompt": "do something"}}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePreToolUse, strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.ToolUseID == "" {
+		t.Fatal("expected fallback tool_use_id, got empty string")
+	}
+}
+
+func TestParseHookEvent_SubagentEnd_StringToolResponse(t *testing.T) {
+	t.Parallel()
+
+	ag := &FactoryAIDroidAgent{}
+	input := `{"session_id": "sess-5", "transcript_path": "/tmp/t.jsonl", "tool_name": "Task", "tool_input": {}, "tool_response": "agentId: agent-789"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if event.Type != agent.SubagentEnd {
+		t.Errorf("expected SubagentEnd, got %v", event.Type)
+	}
+	if event.SubagentID != "agent-789" {
+		t.Errorf("expected SubagentID 'agent-789', got %q", event.SubagentID)
+	}
+	if event.ToolUseID == "" {
+		t.Fatal("expected fallback tool_use_id, got empty string")
+	}
+}
+
 func TestParseHookEvent_Compaction(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/factoryaidroid/lifecycle_test.go
+++ b/cmd/entire/cli/agent/factoryaidroid/lifecycle_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
-	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	git "github.com/go-git/go-git/v6"
 	"github.com/stretchr/testify/require"
 )
 
@@ -217,7 +217,9 @@ func TestParseHookEvent_SubagentEnd_StringToolResponse(t *testing.T) {
 
 func TestParseHookEvent_MissingToolUseID_RepeatedInputsStayUniqueAndCorrelate(t *testing.T) {
 	repoDir := t.TempDir()
-	testutil.InitRepo(t, repoDir)
+	if _, err := git.PlainInit(repoDir, false); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
 	t.Chdir(repoDir)
 	paths.ClearWorktreeRootCache()
 	t.Cleanup(paths.ClearWorktreeRootCache)

--- a/cmd/entire/cli/agent/factoryaidroid/lifecycle_test.go
+++ b/cmd/entire/cli/agent/factoryaidroid/lifecycle_test.go
@@ -2,10 +2,13 @@ package factoryaidroid
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -209,6 +212,53 @@ func TestParseHookEvent_SubagentEnd_StringToolResponse(t *testing.T) {
 	}
 	if event.ToolUseID == "" {
 		t.Fatal("expected fallback tool_use_id, got empty string")
+	}
+}
+
+func TestParseHookEvent_MissingToolUseID_RepeatedInputsStayUniqueAndCorrelate(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	ag := &FactoryAIDroidAgent{}
+	input := `{"session_id": "sess-repeat", "transcript_path": "/tmp/t.jsonl", "tool_name": "Task", "tool_input": {"prompt": "do something"}}`
+
+	startOne, err := ag.ParseHookEvent(context.Background(), HookNamePreToolUse, strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error on first start: %v", err)
+	}
+	startTwo, err := ag.ParseHookEvent(context.Background(), HookNamePreToolUse, strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error on second start: %v", err)
+	}
+	if startOne.ToolUseID == startTwo.ToolUseID {
+		t.Fatalf("expected unique fallback tool_use_id values, got %q", startOne.ToolUseID)
+	}
+
+	endTwo, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error on second end: %v", err)
+	}
+	if endTwo.ToolUseID != startTwo.ToolUseID {
+		t.Fatalf("expected most recent fallback tool_use_id %q, got %q", startTwo.ToolUseID, endTwo.ToolUseID)
+	}
+
+	endOne, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error on first end: %v", err)
+	}
+	if endOne.ToolUseID != startOne.ToolUseID {
+		t.Fatalf("expected earlier fallback tool_use_id %q, got %q", startOne.ToolUseID, endOne.ToolUseID)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(repoDir, paths.EntireTmpDir, fallbackToolUseStatePrefix+"*.json"))
+	if err != nil {
+		t.Fatalf("glob fallback state files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected fallback state cleanup, found %v", matches)
 	}
 }
 

--- a/cmd/entire/cli/agent/factoryaidroid/tool_use_fallback.go
+++ b/cmd/entire/cli/agent/factoryaidroid/tool_use_fallback.go
@@ -1,0 +1,147 @@
+package factoryaidroid
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+const fallbackToolUseStatePrefix = "factory-task-tool-use-"
+
+type fallbackToolUseState struct {
+	Entries []fallbackToolUseEntry `json:"entries"`
+}
+
+type fallbackToolUseEntry struct {
+	Fingerprint string `json:"fingerprint"`
+	ToolUseID   string `json:"tool_use_id"`
+}
+
+func registerFallbackToolUseID(
+	ctx context.Context,
+	sessionID, toolName string,
+	toolInput json.RawMessage,
+) (string, error) {
+	statePath, err := fallbackToolUseStatePath(ctx, sessionID)
+	if err != nil {
+		return "", err
+	}
+
+	state, err := loadFallbackToolUseState(statePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			state = &fallbackToolUseState{}
+		} else {
+			return "", err
+		}
+	}
+
+	toolUseID, err := newFallbackToolUseID()
+	if err != nil {
+		return "", err
+	}
+
+	state.Entries = append(state.Entries, fallbackToolUseEntry{
+		Fingerprint: fallbackToolFingerprint(toolName, toolInput),
+		ToolUseID:   toolUseID,
+	})
+	if err := saveFallbackToolUseState(statePath, state); err != nil {
+		return "", err
+	}
+
+	return toolUseID, nil
+}
+
+func resolveFallbackToolUseID(
+	ctx context.Context,
+	sessionID, toolName string,
+	toolInput json.RawMessage,
+) (string, error) {
+	statePath, err := fallbackToolUseStatePath(ctx, sessionID)
+	if err != nil {
+		return "", err
+	}
+
+	state, err := loadFallbackToolUseState(statePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fallbackToolUseID(sessionID, toolName, toolInput), nil
+		}
+		return "", err
+	}
+
+	fingerprint := fallbackToolFingerprint(toolName, toolInput)
+	for i := len(state.Entries) - 1; i >= 0; i-- {
+		if state.Entries[i].Fingerprint != fingerprint {
+			continue
+		}
+
+		toolUseID := state.Entries[i].ToolUseID
+		state.Entries = append(state.Entries[:i], state.Entries[i+1:]...)
+		if err := saveFallbackToolUseState(statePath, state); err != nil {
+			return "", err
+		}
+		return toolUseID, nil
+	}
+
+	return fallbackToolUseID(sessionID, toolName, toolInput), nil
+}
+
+func newFallbackToolUseID() (string, error) {
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", fmt.Errorf("generate fallback tool_use_id: %w", err)
+	}
+	return "factorytask_" + hex.EncodeToString(suffix[:]), nil
+}
+
+func fallbackToolUseStatePath(ctx context.Context, sessionID string) (string, error) {
+	tmpDir, err := paths.AbsPath(ctx, paths.EntireTmpDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve fallback tool_use_id tmp dir: %w", err)
+	}
+	if err := os.MkdirAll(tmpDir, 0o750); err != nil {
+		return "", fmt.Errorf("create fallback tool_use_id tmp dir: %w", err)
+	}
+
+	sessionHash := fallbackToolUseID(sessionID, "", nil)
+	return filepath.Join(tmpDir, fallbackToolUseStatePrefix+sessionHash+".json"), nil
+}
+
+func loadFallbackToolUseState(path string) (*fallbackToolUseState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var state fallbackToolUseState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("unmarshal fallback tool_use_id state: %w", err)
+	}
+	return &state, nil
+}
+
+func saveFallbackToolUseState(path string, state *fallbackToolUseState) error {
+	if len(state.Entries) == 0 {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove empty fallback tool_use_id state: %w", err)
+		}
+		return nil
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal fallback tool_use_id state: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write fallback tool_use_id state: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/agent/factoryaidroid/tool_use_fallback.go
+++ b/cmd/entire/cli/agent/factoryaidroid/tool_use_fallback.go
@@ -116,9 +116,9 @@ func fallbackToolUseStatePath(ctx context.Context, sessionID string) (string, er
 }
 
 func loadFallbackToolUseState(path string) (*fallbackToolUseState, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read fallback tool_use_id state: %w", err)
 	}
 
 	var state fallbackToolUseState

--- a/cmd/entire/cli/agent/factoryaidroid/types.go
+++ b/cmd/entire/cli/agent/factoryaidroid/types.go
@@ -1,6 +1,10 @@
 package factoryaidroid
 
-import "encoding/json"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
 
 // FactorySettings represents the .factory/settings.json structure.
 type FactorySettings struct {
@@ -57,6 +61,7 @@ type taskHookInputRaw struct {
 	SessionID      string          `json:"session_id"`
 	TranscriptPath string          `json:"transcript_path"`
 	ToolUseID      string          `json:"tool_use_id"`
+	ToolName       string          `json:"tool_name"`
 	ToolInput      json.RawMessage `json:"tool_input"`
 }
 
@@ -65,10 +70,14 @@ type postToolHookInputRaw struct {
 	SessionID      string          `json:"session_id"`
 	TranscriptPath string          `json:"transcript_path"`
 	ToolUseID      string          `json:"tool_use_id"`
+	ToolName       string          `json:"tool_name"`
 	ToolInput      json.RawMessage `json:"tool_input"`
-	ToolResponse   struct {
-		AgentID string `json:"agentId"`
-	} `json:"tool_response"`
+	ToolResponse   json.RawMessage `json:"tool_response"`
+}
+
+func fallbackToolUseID(sessionID, toolName string, toolInput json.RawMessage) string {
+	sum := sha256.Sum256([]byte(sessionID + "\n" + toolName + "\n" + string(toolInput)))
+	return "factorytask_" + hex.EncodeToString(sum[:8])
 }
 
 // Tool names used in Factory Droid transcripts.

--- a/cmd/entire/cli/agent/factoryaidroid/types.go
+++ b/cmd/entire/cli/agent/factoryaidroid/types.go
@@ -80,6 +80,11 @@ func fallbackToolUseID(sessionID, toolName string, toolInput json.RawMessage) st
 	return "factorytask_" + hex.EncodeToString(sum[:8])
 }
 
+func fallbackToolFingerprint(toolName string, toolInput json.RawMessage) string {
+	sum := sha256.Sum256([]byte(toolName + "\n" + string(toolInput)))
+	return hex.EncodeToString(sum[:16])
+}
+
 // Tool names used in Factory Droid transcripts.
 const (
 	ToolCreate       = "Create"

--- a/e2e/tests/factory_hooks_test.go
+++ b/e2e/tests/factory_hooks_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/e2e/testutil"
+)
+
+func TestFactoryTaskHooksDoNotFail(t *testing.T) {
+	testutil.ForEachAgent(t, 3*time.Minute, func(t *testing.T, s *testutil.RepoState, ctx context.Context) {
+		if s.Agent.Name() != "factoryai-droid" {
+			t.Skip("factory-only regression test")
+		}
+
+		session := s.StartSession(t, ctx)
+		if session == nil {
+			t.Skip("factoryai-droid does not support interactive mode")
+		}
+
+		s.WaitFor(t, session, s.Agent.PromptPattern(), 30*time.Second)
+		s.Send(t, session,
+			"Can you run a Worker that inspects this code and comes up with a short summary about what it is about? Have the Worker write that summary to docs/factory-hook-check.md as one short paragraph followed by exactly 3 bullet points. Do not create or edit the file in the main agent process. Only the Worker should write the file. Do not commit. Do not ask for confirmation.")
+		s.WaitFor(t, session, s.Agent.PromptPattern(), 90*time.Second)
+
+		testutil.WaitForFileExists(t, s.Dir, "docs/factory-hook-check.md", 10*time.Second)
+		testutil.AssertConsoleLogDoesNotContain(t, s,
+			"tool_use_id is required",
+			"failed to parse hook event",
+			"postToolHookInputRaw.tool_response",
+		)
+	})
+}

--- a/e2e/testutil/assertions.go
+++ b/e2e/testutil/assertions.go
@@ -36,6 +36,22 @@ func AssertFileExists(t *testing.T, dir string, glob string) {
 	assert.NotEmpty(t, matches, "expected files matching %s in %s", glob, dir)
 }
 
+// AssertConsoleLogDoesNotContain asserts that the current test's console.log
+// does not contain any of the forbidden substrings.
+func AssertConsoleLogDoesNotContain(t *testing.T, s *RepoState, forbidden ...string) {
+	t.Helper()
+
+	require.NoError(t, s.ConsoleLog.Sync())
+
+	data, err := os.ReadFile(filepath.Join(s.ArtifactDir, "console.log"))
+	require.NoError(t, err)
+
+	log := string(data)
+	for _, needle := range forbidden {
+		assert.NotContains(t, log, needle, "console.log should not contain %q", needle)
+	}
+}
+
 // WaitForFileExists polls until at least one file matches the glob pattern
 // relative to dir, or fails the test after timeout. Handles the race where an
 // interactive agent's prompt pattern appears before file writes land on disk.


### PR DESCRIPTION
## Summary
Fix Factory AI Droid fallback `tool_use_id` handling so repeated Worker runs with identical inputs do not collide while pre/post task hooks still correlate correctly.

## What Changed
- replaced the deterministic fallback-only path with a per-invocation fallback `tool_use_id` generated during `PreToolUse`
- added a small Factory-only pending fallback state file under `.entire/tmp` so `PostToolUse` can recover and consume the exact ID for the matching Worker invocation when Factory omits `tool_use_id`
- threaded hook parsing context through the Factory lifecycle parser so the fallback state can be resolved relative to the repo tmp dir
- added focused lifecycle coverage proving repeated identical missing-`tool_use_id` invocations stay unique, correlate in LIFO order, and clean up temporary state

## Verification
- `go test ./cmd/entire/cli/agent/factoryaidroid`
- `mise run test:e2e --agent factoryai-droid TestFactoryTaskHooksDoNotFail`

fixes: https://github.com/entireio/cli/issues/917, https://github.com/entireio/cli/issues/930, https://github.com/entireio/cli/issues/938