### PR TITLE
Rename full.jsonl to raw_transcript in v2 checkpoint paths

### DIFF
--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -416,8 +416,8 @@ func (s *V2GitStore) writeContentHash(redactedTranscript []byte, sessionPath str
 	if err != nil {
 		return err
 	}
-	entries[sessionPath+paths.ContentHashFileName] = object.TreeEntry{
-		Name: sessionPath + paths.ContentHashFileName,
+	entries[sessionPath+paths.V2RawTranscriptHashFileName] = object.TreeEntry{
+		Name: sessionPath + paths.V2RawTranscriptHashFileName,
 		Mode: filemode.Regular,
 		Hash: hashBlob,
 	}
@@ -549,7 +549,7 @@ func (s *V2GitStore) writeTranscriptBlobs(ctx context.Context, transcript redact
 	}
 
 	for i, chunk := range chunks {
-		chunkPath := sessionPath + agent.ChunkFileName(paths.TranscriptFileName, i)
+		chunkPath := sessionPath + agent.ChunkFileName(paths.V2RawTranscriptFileName, i)
 		blobHash, err := CreateBlobFromContent(s.repo, chunk)
 		if err != nil {
 			return nil, err

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -237,7 +237,7 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 
 // writeCommittedMain writes metadata entries to the /main ref.
 // This includes session metadata and prompts — but NOT the raw transcript
-// (full.jsonl) or content hash (content_hash.txt), which go to /full/current.
+// (raw_transcript) or content hash (raw_transcript_hash.txt), which go to /full/current.
 // Returns the session index used, so the caller can pass it to writeCommittedFullTranscript.
 func (s *V2GitStore) writeCommittedMain(ctx context.Context, opts WriteCommittedOptions) (int, error) {
 	refName := plumbing.ReferenceName(paths.V2MainRefName)
@@ -321,8 +321,8 @@ func (s *V2GitStore) writeMainCheckpointEntries(ctx context.Context, opts WriteC
 
 // writeMainSessionToSubdirectory writes a single session's metadata, prompts,
 // and compact transcript to a session subdirectory (0/, 1/, 2/, … indexed by
-// session order within the checkpoint). The raw transcript (full.jsonl) and its
-// content hash (content_hash.txt) go to /full/current, not here.
+// session order within the checkpoint). The raw transcript (raw_transcript) and its
+// content hash (raw_transcript_hash.txt) go to /full/current, not here.
 func (s *V2GitStore) writeMainSessionToSubdirectory(opts WriteCommittedOptions, sessionPath string, entries map[string]object.TreeEntry) (SessionFilePaths, error) {
 	filePaths := SessionFilePaths{}
 

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -127,8 +127,8 @@ func TestAddGenerationJSONToTree(t *testing.T) {
 
 	// Start with a root tree that has a shard directory entry (simulating checkpoint data)
 	shardEntries := map[string]object.TreeEntry{}
-	shardEntries["aa/bbccddeeff/0/full.jsonl"] = object.TreeEntry{
-		Name: "full.jsonl",
+	shardEntries["aa/bbccddeeff/0/"+paths.V2RawTranscriptFileName] = object.TreeEntry{
+		Name: paths.V2RawTranscriptFileName,
 		Mode: 0o100644,
 		Hash: plumbing.ZeroHash, // dummy
 	}

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -233,7 +233,7 @@ func TestWriteCommittedFull_NoGenerationJSON(t *testing.T) {
 	}
 
 	// Checkpoint data should still be present
-	content := v2ReadFile(t, fullTree, cpID.Path()+"/0/"+paths.TranscriptFileName)
+	content := v2ReadFile(t, fullTree, cpID.Path()+"/0/"+paths.V2RawTranscriptFileName)
 	assert.Contains(t, content, "hello")
 }
 
@@ -276,7 +276,7 @@ func TestUpdateCommitted_DoesNotAddGenerationJSON(t *testing.T) {
 	}
 
 	// Verify the transcript was actually updated (sanity check)
-	content := v2ReadFile(t, fullTree, cpID.Path()+"/0/"+paths.TranscriptFileName)
+	content := v2ReadFile(t, fullTree, cpID.Path()+"/0/"+paths.V2RawTranscriptFileName)
 	assert.Contains(t, content, "finalized")
 }
 
@@ -414,7 +414,7 @@ func TestRotateGeneration_ArchivesCurrentAndCreatesNewOrphan(t *testing.T) {
 	archiveTree, err := archiveCommit.Tree()
 	require.NoError(t, err)
 	for _, cpID := range cpIDs {
-		_, treeErr := archiveTree.File(cpID.Path() + "/0/" + paths.TranscriptFileName)
+		_, treeErr := archiveTree.File(cpID.Path() + "/0/" + paths.V2RawTranscriptFileName)
 		require.NoError(t, treeErr, "archived tree should contain transcript for %s", cpID)
 	}
 

--- a/cmd/entire/cli/checkpoint/v2_read.go
+++ b/cmd/entire/cli/checkpoint/v2_read.go
@@ -240,7 +240,7 @@ func (s *V2GitStore) ReadSessionMetadataAndPrompts(ctx context.Context, checkpoi
 }
 
 // ReadSessionContent reads a session's metadata and prompts from the v2 /main ref,
-// and the raw transcript (full.jsonl) from /full/* refs (current + archived generations).
+// and the raw transcript (raw_transcript) from /full/* refs (current + archived generations).
 // This is the v2 equivalent of GitStore.ReadSessionContent — it reads the raw agent
 // transcript, not the compact transcript.jsonl. Used by resume and RestoreLogsOnly.
 // Returns ErrNoTranscript if the session exists but no raw transcript is available.

--- a/cmd/entire/cli/checkpoint/v2_read.go
+++ b/cmd/entire/cli/checkpoint/v2_read.go
@@ -441,11 +441,11 @@ func readTranscriptFromObjectTree(tree *object.Tree, agentType types.AgentType) 
 	var hasBaseFile bool
 
 	for _, entry := range tree.Entries {
-		if entry.Name == paths.TranscriptFileName {
+		if entry.Name == paths.V2RawTranscriptFileName {
 			hasBaseFile = true
 		}
-		if strings.HasPrefix(entry.Name, paths.TranscriptFileName+".") {
-			idx := agent.ParseChunkIndex(entry.Name, paths.TranscriptFileName)
+		if strings.HasPrefix(entry.Name, paths.V2RawTranscriptFileName+".") {
+			idx := agent.ParseChunkIndex(entry.Name, paths.V2RawTranscriptFileName)
 			if idx > 0 {
 				chunkFiles = append(chunkFiles, entry.Name)
 			}
@@ -454,9 +454,9 @@ func readTranscriptFromObjectTree(tree *object.Tree, agentType types.AgentType) 
 
 	// If chunk files exist, reassemble all chunks (base file is chunk 0)
 	if len(chunkFiles) > 0 {
-		chunkFiles = agent.SortChunkFiles(chunkFiles, paths.TranscriptFileName)
+		chunkFiles = agent.SortChunkFiles(chunkFiles, paths.V2RawTranscriptFileName)
 		if hasBaseFile {
-			chunkFiles = append([]string{paths.TranscriptFileName}, chunkFiles...)
+			chunkFiles = append([]string{paths.V2RawTranscriptFileName}, chunkFiles...)
 		}
 
 		var chunks [][]byte
@@ -483,7 +483,7 @@ func readTranscriptFromObjectTree(tree *object.Tree, agentType types.AgentType) 
 
 	// No chunk files — read base file directly (non-chunked transcript)
 	if hasBaseFile {
-		file, err := tree.File(paths.TranscriptFileName)
+		file, err := tree.File(paths.V2RawTranscriptFileName)
 		if err == nil {
 			content, contentErr := file.Contents()
 			if contentErr == nil {

--- a/cmd/entire/cli/checkpoint/v2_read.go
+++ b/cmd/entire/cli/checkpoint/v2_read.go
@@ -411,7 +411,7 @@ func (s *V2GitStore) fetchRemoteFullRefs(ctx context.Context) error {
 
 // readTranscriptFromRef reads the raw transcript from a specific /full/* ref.
 // Follows the same chunking convention as readTranscriptFromTree in committed.go:
-// chunk 0 is the base file (full.jsonl), chunks 1+ are full.jsonl.001, .002, etc.
+// chunk 0 is the base file (raw_transcript), chunks 1+ are raw_transcript.001, .002, etc.
 // When chunk files exist, all chunks (including chunk 0) are reassembled using
 // agent-aware reassembly via agent.ReassembleTranscript.
 func (s *V2GitStore) readTranscriptFromRef(refName plumbing.ReferenceName, sessionPath string, agentType types.AgentType) ([]byte, error) {

--- a/cmd/entire/cli/checkpoint/v2_read_test.go
+++ b/cmd/entire/cli/checkpoint/v2_read_test.go
@@ -195,7 +195,7 @@ func TestV2ReadSessionContent_ChunkedTranscript(t *testing.T) {
 	require.NoError(t, err)
 
 	// Manually write chunked transcript to /full/current:
-	// chunk 0 = full.jsonl (base file), chunk 1 = full.jsonl.001
+	// chunk 0 = raw_transcript (base file), chunk 1 = raw_transcript.001
 	chunk0 := []byte(`{"line":"one"}` + "\n" + `{"line":"two"}`)
 	chunk1 := []byte(`{"line":"three"}` + "\n" + `{"line":"four"}`)
 

--- a/cmd/entire/cli/checkpoint/v2_read_test.go
+++ b/cmd/entire/cli/checkpoint/v2_read_test.go
@@ -215,13 +215,13 @@ func TestV2ReadSessionContent_ChunkedTranscript(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := map[string]object.TreeEntry{
-		sessionPath + paths.TranscriptFileName: {
-			Name: sessionPath + paths.TranscriptFileName,
+		sessionPath + paths.V2RawTranscriptFileName: {
+			Name: sessionPath + paths.V2RawTranscriptFileName,
 			Mode: filemode.Regular,
 			Hash: blob0,
 		},
-		sessionPath + paths.TranscriptFileName + ".001": {
-			Name: sessionPath + paths.TranscriptFileName + ".001",
+		sessionPath + paths.V2RawTranscriptFileName + ".001": {
+			Name: sessionPath + paths.V2RawTranscriptFileName + ".001",
 			Mode: filemode.Regular,
 			Hash: blob1,
 		},

--- a/cmd/entire/cli/checkpoint/v2_store_test.go
+++ b/cmd/entire/cli/checkpoint/v2_store_test.go
@@ -577,7 +577,7 @@ func TestV2GitStore_WriteCommittedFull_ExcludesMetadata(t *testing.T) {
 			"prompt.txt must not be on /full/current ref")
 	}
 
-	// content_hash.txt SHOULD be on /full/current (co-located with the transcript it hashes)
+	// raw_transcript_hash.txt SHOULD be on /full/current (co-located with the transcript it hashes)
 	hashContent := v2ReadFile(t, tree, cpPath+"/0/"+paths.V2RawTranscriptHashFileName)
 	assert.True(t, strings.HasPrefix(hashContent, "sha256:"), "content hash should be sha256 prefixed")
 }

--- a/cmd/entire/cli/checkpoint/v2_store_test.go
+++ b/cmd/entire/cli/checkpoint/v2_store_test.go
@@ -283,7 +283,7 @@ func TestV2GitStore_WriteCommittedMain_ExcludesTranscript(t *testing.T) {
 	tree := v2MainTree(t, repo)
 	cpPath := cpID.Path()
 
-	// full.jsonl should NOT be in the /main tree
+	// raw_transcript should NOT be in the /main tree
 	cpTree, err := tree.Tree(cpPath)
 	require.NoError(t, err)
 
@@ -391,7 +391,7 @@ func TestV2GitStore_WriteCommittedMain_UsesCompactTranscriptStart(t *testing.T) 
 		Prompts:                   []string{"hello"},
 		AuthorName:                "Test",
 		AuthorEmail:               "test@test.com",
-		CheckpointTranscriptStart: 42, // full.jsonl offset (must not be used in v2 metadata)
+		CheckpointTranscriptStart: 42, // raw_transcript offset (must not be used in v2 metadata)
 		CompactTranscriptStart:    15, // transcript.jsonl offset (must be used in v2 metadata)
 	})
 	require.NoError(t, err)

--- a/cmd/entire/cli/checkpoint/v2_store_test.go
+++ b/cmd/entire/cli/checkpoint/v2_store_test.go
@@ -258,8 +258,8 @@ func TestV2GitStore_WriteCommittedMain_WritesPrompts(t *testing.T) {
 	// content_hash.txt should NOT be on /main — it lives on /full/current
 	mainSessionTree, err := tree.Tree(cpPath + "/0")
 	require.NoError(t, err)
-	_, err = mainSessionTree.File(paths.ContentHashFileName)
-	assert.Error(t, err, "content_hash.txt should not be on /main ref")
+	_, err = mainSessionTree.File(paths.V2RawTranscriptHashFileName)
+	assert.Error(t, err, "raw_transcript_hash.txt should not be on /main ref")
 }
 
 func TestV2GitStore_WriteCommittedMain_ExcludesTranscript(t *testing.T) {
@@ -291,9 +291,9 @@ func TestV2GitStore_WriteCommittedMain_ExcludesTranscript(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, entry := range sessionTree.Entries {
-		assert.NotEqual(t, paths.TranscriptFileName, entry.Name,
-			"raw transcript (full.jsonl) must not be on /main ref")
-		assert.False(t, strings.HasPrefix(entry.Name, paths.TranscriptFileName+"."),
+		assert.NotEqual(t, paths.V2RawTranscriptFileName, entry.Name,
+			"raw transcript (raw_transcript) must not be on /main ref")
+		assert.False(t, strings.HasPrefix(entry.Name, paths.V2RawTranscriptFileName+"."),
 			"transcript chunks must not be on /main ref")
 	}
 }
@@ -538,7 +538,7 @@ func TestV2GitStore_WriteCommittedFull_WritesTranscript(t *testing.T) {
 	cpPath := cpID.Path()
 
 	// Transcript should exist at session subdirectory 0/
-	content := v2ReadFile(t, tree, cpPath+"/0/"+paths.TranscriptFileName)
+	content := v2ReadFile(t, tree, cpPath+"/0/"+paths.V2RawTranscriptFileName)
 	assert.Contains(t, content, `"type":"human"`)
 	assert.Contains(t, content, `"type":"assistant"`)
 }
@@ -578,7 +578,7 @@ func TestV2GitStore_WriteCommittedFull_ExcludesMetadata(t *testing.T) {
 	}
 
 	// content_hash.txt SHOULD be on /full/current (co-located with the transcript it hashes)
-	hashContent := v2ReadFile(t, tree, cpPath+"/0/"+paths.ContentHashFileName)
+	hashContent := v2ReadFile(t, tree, cpPath+"/0/"+paths.V2RawTranscriptHashFileName)
 	assert.True(t, strings.HasPrefix(hashContent, "sha256:"), "content hash should be sha256 prefixed")
 }
 
@@ -644,10 +644,10 @@ func TestV2GitStore_WriteCommittedFullTranscript_AccumulatesCheckpoints(t *testi
 	tree := v2FullTree(t, repo)
 
 	// Both checkpoints should be present
-	contentA := v2ReadFile(t, tree, cpA.Path()+"/0/"+paths.TranscriptFileName)
+	contentA := v2ReadFile(t, tree, cpA.Path()+"/0/"+paths.V2RawTranscriptFileName)
 	assert.Contains(t, contentA, `"from":"A"`)
 
-	contentB := v2ReadFile(t, tree, cpB.Path()+"/0/"+paths.TranscriptFileName)
+	contentB := v2ReadFile(t, tree, cpB.Path()+"/0/"+paths.V2RawTranscriptFileName)
 	assert.Contains(t, contentB, `"from":"B"`)
 }
 
@@ -681,15 +681,15 @@ func TestV2GitStore_WriteCommitted_WritesBothRefs(t *testing.T) {
 	mainSessionTree, err := mainTree.Tree(cpPath + "/0")
 	require.NoError(t, err)
 	for _, entry := range mainSessionTree.Entries {
-		assert.NotEqual(t, paths.TranscriptFileName, entry.Name)
-		assert.NotEqual(t, paths.ContentHashFileName, entry.Name)
+		assert.NotEqual(t, paths.V2RawTranscriptFileName, entry.Name)
+		assert.NotEqual(t, paths.V2RawTranscriptHashFileName, entry.Name)
 	}
 
 	// /full/current ref should have transcript + content hash
 	fullTree := v2FullTree(t, repo)
-	content := v2ReadFile(t, fullTree, cpPath+"/0/"+paths.TranscriptFileName)
+	content := v2ReadFile(t, fullTree, cpPath+"/0/"+paths.V2RawTranscriptFileName)
 	assert.Contains(t, content, `"type":"assistant"`)
-	hashContent := v2ReadFile(t, fullTree, cpPath+"/0/"+paths.ContentHashFileName)
+	hashContent := v2ReadFile(t, fullTree, cpPath+"/0/"+paths.V2RawTranscriptHashFileName)
 	assert.True(t, strings.HasPrefix(hashContent, "sha256:"))
 }
 
@@ -761,7 +761,7 @@ func TestV2GitStore_WriteCommitted_MultiSession_ConsistentIndex(t *testing.T) {
 
 	// /full/current should have session Y (latest write replaces)
 	fullTree := v2FullTree(t, repo)
-	contentY := v2ReadFile(t, fullTree, cpPath+"/1/"+paths.TranscriptFileName)
+	contentY := v2ReadFile(t, fullTree, cpPath+"/1/"+paths.V2RawTranscriptFileName)
 	assert.Contains(t, contentY, `"from":"Y"`)
 }
 
@@ -805,7 +805,7 @@ func TestV2GitStore_UpdateCommitted_UpdatesBothRefs(t *testing.T) {
 
 	// /full/current should have finalized transcript
 	fullTree := v2FullTree(t, repo)
-	content := v2ReadFile(t, fullTree, cpPath+"/0/"+paths.TranscriptFileName)
+	content := v2ReadFile(t, fullTree, cpPath+"/0/"+paths.V2RawTranscriptFileName)
 	assert.Contains(t, content, "finalized")
 	assert.NotContains(t, content, "initial")
 }
@@ -846,7 +846,7 @@ func TestV2GitStore_UpdateCommitted_NoTranscript_OnlyUpdatesMain(t *testing.T) {
 
 	// /full/current should still have original transcript (not replaced)
 	fullTree := v2FullTree(t, repo)
-	content := v2ReadFile(t, fullTree, cpID.Path()+"/0/"+paths.TranscriptFileName)
+	content := v2ReadFile(t, fullTree, cpID.Path()+"/0/"+paths.V2RawTranscriptFileName)
 	assert.Contains(t, content, "original")
 }
 

--- a/cmd/entire/cli/checkpoint/v2_store_test.go
+++ b/cmd/entire/cli/checkpoint/v2_store_test.go
@@ -255,7 +255,7 @@ func TestV2GitStore_WriteCommittedMain_WritesPrompts(t *testing.T) {
 	assert.Contains(t, promptContent, "do the thing")
 	assert.Contains(t, promptContent, "also this")
 
-	// content_hash.txt should NOT be on /main — it lives on /full/current
+	// raw_transcript_hash.txt should NOT be on /main — it lives on /full/current
 	mainSessionTree, err := tree.Tree(cpPath + "/0")
 	require.NoError(t, err)
 	_, err = mainSessionTree.File(paths.V2RawTranscriptHashFileName)

--- a/cmd/entire/cli/integration_test/v2_dual_write_test.go
+++ b/cmd/entire/cli/integration_test/v2_dual_write_test.go
@@ -96,8 +96,8 @@ func TestV2DualWrite_FullWorkflow(t *testing.T) {
 	assert.Contains(t, mainPrompts, "Add greeting function")
 
 	// Transcript should NOT be on /main
-	_, found = env.ReadFileFromRef(paths.V2MainRefName, cpPath+"/0/"+paths.TranscriptFileName)
-	assert.False(t, found, "full.jsonl should NOT be on v2 /main")
+	_, found = env.ReadFileFromRef(paths.V2MainRefName, cpPath+"/0/"+paths.V2RawTranscriptFileName)
+	assert.False(t, found, "raw_transcript should NOT be on v2 /main")
 
 	// transcript.jsonl (compact format) SHOULD be on /main
 	compactTranscript, found := env.ReadFileFromRef(paths.V2MainRefName, cpPath+"/0/"+paths.CompactTranscriptFileName)
@@ -117,13 +117,13 @@ func TestV2DualWrite_FullWorkflow(t *testing.T) {
 		"v2 /full/current ref should exist")
 
 	// Transcript should be on /full/current
-	fullTranscript, found := env.ReadFileFromRef(paths.V2FullCurrentRefName, cpPath+"/0/"+paths.TranscriptFileName)
-	require.True(t, found, "full.jsonl should exist on v2 /full/current")
+	fullTranscript, found := env.ReadFileFromRef(paths.V2FullCurrentRefName, cpPath+"/0/"+paths.V2RawTranscriptFileName)
+	require.True(t, found, "raw_transcript should exist on v2 /full/current")
 	assert.Contains(t, fullTranscript, "Greet")
 
 	// Content hash should be co-located with transcript
-	fullHash, found := env.ReadFileFromRef(paths.V2FullCurrentRefName, cpPath+"/0/"+paths.ContentHashFileName)
-	require.True(t, found, "content_hash.txt should exist on v2 /full/current")
+	fullHash, found := env.ReadFileFromRef(paths.V2FullCurrentRefName, cpPath+"/0/"+paths.V2RawTranscriptHashFileName)
+	require.True(t, found, "raw_transcript_hash.txt should exist on v2 /full/current")
 	assert.True(t, strings.HasPrefix(fullHash, "sha256:"))
 
 	// Metadata should NOT be on /full/current
@@ -235,8 +235,8 @@ func TestV2DualWrite_StopTimeFinalization(t *testing.T) {
 	require.NoError(t, err)
 
 	// After stop-time finalization, /full/current should have the finalized transcript
-	fullTranscript, found := env.ReadFileFromRef(paths.V2FullCurrentRefName, cpPath+"/0/"+paths.TranscriptFileName)
-	require.True(t, found, "full.jsonl should exist on /full/current after finalization")
+	fullTranscript, found := env.ReadFileFromRef(paths.V2FullCurrentRefName, cpPath+"/0/"+paths.V2RawTranscriptFileName)
+	require.True(t, found, "raw_transcript should exist on /full/current after finalization")
 	assert.Contains(t, fullTranscript, "main")
 
 	// transcript.jsonl should exist on /main after stop-time finalization

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -300,7 +300,7 @@ func hasCurrentFullSessionArtifacts(repo *git.Repository, v2Store *checkpoint.V2
 
 	hasTranscript := false
 	for _, entry := range sessionTree.Entries {
-		if entry.Name == paths.TranscriptFileName || strings.HasPrefix(entry.Name, paths.TranscriptFileName+".") {
+		if entry.Name == paths.V2RawTranscriptFileName || strings.HasPrefix(entry.Name, paths.V2RawTranscriptFileName+".") {
 			hasTranscript = true
 			break
 		}
@@ -309,7 +309,7 @@ func hasCurrentFullSessionArtifacts(repo *git.Repository, v2Store *checkpoint.V2
 		return false, nil
 	}
 
-	if _, err := sessionTree.File(paths.ContentHashFileName); err != nil {
+	if _, err := sessionTree.File(paths.V2RawTranscriptHashFileName); err != nil {
 		return false, nil //nolint:nilerr // Missing content hash indicates incomplete /full/current artifacts.
 	}
 

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -569,10 +569,10 @@ func removeV2SessionTranscriptFiles(t *testing.T, repo *git.Repository, v2Store 
 		checkpoint.UpdateSubtreeOptions{
 			MergeMode: checkpoint.MergeKeepExisting,
 			DeleteNames: []string{
-				paths.TranscriptFileName,
-				paths.TranscriptFileName + ".001",
-				paths.TranscriptFileName + ".002",
-				paths.ContentHashFileName,
+				paths.V2RawTranscriptFileName,
+				paths.V2RawTranscriptFileName + ".001",
+				paths.V2RawTranscriptFileName + ".002",
+				paths.V2RawTranscriptHashFileName,
 			},
 		},
 	)

--- a/cmd/entire/cli/paths/paths.go
+++ b/cmd/entire/cli/paths/paths.go
@@ -31,6 +31,8 @@ const (
 	TranscriptFileNameLegacy      = "full.log"
 	CompactTranscriptFileName     = "transcript.jsonl"
 	CompactTranscriptHashFileName = "transcript_hash.txt"
+	V2RawTranscriptFileName       = "raw_transcript"
+	V2RawTranscriptHashFileName   = "raw_transcript_hash.txt"
 	MetadataFileName              = "metadata.json"
 	CheckpointFileName            = "checkpoint.json"
 	ContentHashFileName           = "content_hash.txt"

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -4027,8 +4027,8 @@ func TestCondenseSession_V2DualWrite(t *testing.T) {
 	require.NoError(t, err)
 	fullSessionTree, err := fullCpTree.Tree("0")
 	require.NoError(t, err)
-	_, err = fullSessionTree.File(paths.TranscriptFileName)
-	require.NoError(t, err, "full.jsonl should exist on /full/current")
+	_, err = fullSessionTree.File(paths.V2RawTranscriptFileName)
+	require.NoError(t, err, "raw_transcript should exist on /full/current")
 }
 
 // TestCondenseSession_V2CompactTranscriptStart verifies v2 /main writes


### PR DESCRIPTION
## Summary

- Renames `full.jsonl` to `raw_transcript` and `content_hash.txt` to `raw_transcript_hash.txt` in all v2 checkpoint code paths
- Adds new v2-specific constants `V2RawTranscriptFileName` and `V2RawTranscriptHashFileName` in `paths/paths.go`
- v1 code paths are completely unchanged — existing `TranscriptFileName` and `ContentHashFileName` constants remain as-is

## Motivation

The v2 checkpoint code stored raw agent transcripts as `full.jsonl` on `/full/*` refs. This is misleading: 2 of 8 supported agents (Gemini CLI, OpenCode) produce JSON, not JSONL. Using the extension-neutral `raw_transcript` avoids making a format promise the storage layer can't guarantee. Renaming `content_hash.txt` to `raw_transcript_hash.txt` pairs it with its companion file, matching the existing `transcript.jsonl` / `transcript_hash.txt` convention on `/main`.

## Backward compatibility

No backward compatibility concerns. The v2 code paths are behind the `checkpoints_v2` strategy option and have no production data — v2 checkpoints have only been created during local development validation. This is a safe rename with no migration needed.

## Test plan

- [x] All v2 unit tests pass (`checkpoint/v2_store_test.go`, `v2_read_test.go`, `v2_generation_test.go`)
- [x] All v2 integration tests pass (`v2_dual_write_test.go`)
- [x] Migration tests pass (`migrate_test.go`)
- [x] Full test suite passes (`mise run test:ci` — unit + integration + canary)
- [x] Lint clean (`mise run fmt && mise run lint`)
- [x] v1 tests unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename confined to v2 checkpoint storage paths and related tests/migration checks; primary risk is mismatched filenames when reading/writing existing v2 data.
> 
> **Overview**
> Renames the v2 checkpoint **raw transcript** artifact from `full.jsonl` to `raw_transcript`, and its paired hash from `content_hash.txt` to `raw_transcript_hash.txt` across v2 write, read/reassembly, integration/unit tests, and v2 migration/repair checks.
> 
> Adds new path constants `paths.V2RawTranscriptFileName` and `paths.V2RawTranscriptHashFileName` and switches v2 chunking/reassembly logic to use the new base filename, while leaving v1 constants and behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9225ecf51a8cd256243081ebc6293fe7b57b0be2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->