### PR TITLE
Add v2 checkpoint health checks to entire doctor

### DIFF
--- a/cmd/entire/cli/checkpoint/v2_generation.go
+++ b/cmd/entire/cli/checkpoint/v2_generation.go
@@ -41,9 +41,9 @@ type GenerationMetadata struct {
 	NewestCheckpointAt time.Time `json:"newest_checkpoint_at"`
 }
 
-// readGeneration reads generation.json from the given tree hash.
+// ReadGeneration reads generation.json from the given tree hash.
 // Returns a zero-value GenerationMetadata if the file doesn't exist (new/empty generation).
-func (s *V2GitStore) readGeneration(treeHash plumbing.Hash) (GenerationMetadata, error) {
+func (s *V2GitStore) ReadGeneration(treeHash plumbing.Hash) (GenerationMetadata, error) {
 	if treeHash == plumbing.ZeroHash {
 		return GenerationMetadata{}, nil
 	}
@@ -80,7 +80,7 @@ func (s *V2GitStore) ReadGenerationFromRef(refName plumbing.ReferenceName) (Gene
 	if err != nil {
 		return GenerationMetadata{}, fmt.Errorf("failed to get ref state: %w", err)
 	}
-	return s.readGeneration(treeHash)
+	return s.ReadGeneration(treeHash)
 }
 
 // marshalGenerationBlob marshals gen as generation.json and stores it as a git blob.

--- a/cmd/entire/cli/checkpoint/v2_generation.go
+++ b/cmd/entire/cli/checkpoint/v2_generation.go
@@ -74,8 +74,8 @@ func (s *V2GitStore) readGeneration(treeHash plumbing.Hash) (GenerationMetadata,
 	return gen, nil
 }
 
-// readGenerationFromRef reads generation.json from the tree pointed to by the given ref.
-func (s *V2GitStore) readGenerationFromRef(refName plumbing.ReferenceName) (GenerationMetadata, error) {
+// ReadGenerationFromRef reads generation.json from the tree pointed to by the given ref.
+func (s *V2GitStore) ReadGenerationFromRef(refName plumbing.ReferenceName) (GenerationMetadata, error) {
 	_, treeHash, err := s.GetRefState(refName)
 	if err != nil {
 		return GenerationMetadata{}, fmt.Errorf("failed to get ref state: %w", err)

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -113,7 +113,7 @@ func TestReadGenerationFromRef(t *testing.T) {
 	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)))
 
 	// Read back via ref
-	result, err := store.readGenerationFromRef(refName)
+	result, err := store.ReadGenerationFromRef(refName)
 	require.NoError(t, err)
 
 	assert.True(t, result.OldestCheckpointAt.Equal(now))
@@ -460,7 +460,7 @@ func TestRotateGeneration_SequentialNumbering(t *testing.T) {
 	// Verify each archived ref has generation.json with timestamps
 	for _, name := range archived {
 		refName := plumbing.ReferenceName(paths.V2FullRefPrefix + name)
-		gen, readErr := store.readGenerationFromRef(refName)
+		gen, readErr := store.ReadGenerationFromRef(refName)
 		require.NoError(t, readErr)
 		assert.False(t, gen.OldestCheckpointAt.IsZero(), "archive %s should have oldest timestamp", name)
 		assert.False(t, gen.NewestCheckpointAt.IsZero(), "archive %s should have newest timestamp", name)

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -27,7 +27,7 @@ func TestReadGeneration_EmptyTree_ReturnsDefault(t *testing.T) {
 	emptyTree, err := BuildTreeFromEntries(context.Background(), repo, map[string]object.TreeEntry{})
 	require.NoError(t, err)
 
-	gen, err := store.readGeneration(emptyTree)
+	gen, err := store.ReadGeneration(emptyTree)
 	require.NoError(t, err)
 
 	assert.True(t, gen.OldestCheckpointAt.IsZero())
@@ -53,7 +53,7 @@ func TestReadGeneration_ParsesJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	// Read it back
-	gen, err := store.readGeneration(treeHash)
+	gen, err := store.ReadGeneration(treeHash)
 	require.NoError(t, err)
 
 	assert.True(t, gen.OldestCheckpointAt.Equal(now.Add(-1*time.Hour)))
@@ -82,7 +82,7 @@ func TestWriteGeneration_RoundTrips(t *testing.T) {
 	treeHash, err := BuildTreeFromEntries(context.Background(), repo, entries)
 	require.NoError(t, err)
 
-	gen, err := store.readGeneration(treeHash)
+	gen, err := store.ReadGeneration(treeHash)
 	require.NoError(t, err)
 
 	assert.True(t, gen.OldestCheckpointAt.Equal(now))
@@ -146,7 +146,7 @@ func TestAddGenerationJSONToTree(t *testing.T) {
 	assert.NotEqual(t, rootTreeHash, newRootHash)
 
 	// Verify generation.json is present and shard dir is preserved
-	readGen, err := store.readGeneration(newRootHash)
+	readGen, err := store.ReadGeneration(newRootHash)
 	require.NoError(t, err)
 	assert.False(t, readGen.OldestCheckpointAt.IsZero())
 
@@ -405,7 +405,7 @@ func TestRotateGeneration_ArchivesCurrentAndCreatesNewOrphan(t *testing.T) {
 	// Archived ref should contain generation.json with timestamps
 	archiveCommit, err := repo.CommitObject(archiveRef.Hash())
 	require.NoError(t, err)
-	archiveGen, err := store.readGeneration(archiveCommit.TreeHash)
+	archiveGen, err := store.ReadGeneration(archiveCommit.TreeHash)
 	require.NoError(t, err)
 	assert.False(t, archiveGen.OldestCheckpointAt.IsZero(), "archived generation should have oldest timestamp")
 	assert.False(t, archiveGen.NewestCheckpointAt.IsZero(), "archived generation should have newest timestamp")
@@ -502,7 +502,7 @@ func TestReadGeneration_BackwardCompatible(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should parse without error, ignoring the unknown checkpoints field
-	gen, err := store.readGeneration(treeHash)
+	gen, err := store.ReadGeneration(treeHash)
 	require.NoError(t, err)
 
 	expected := time.Date(2026, 3, 25, 12, 0, 0, 0, time.UTC)

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -499,7 +499,7 @@ func checkV2GenerationHealth(cmd *cobra.Command, repo *git.Repository) error {
 			continue
 		}
 
-		gen, genErr := v2Store.ReadGenerationFromRef(refName)
+		gen, genErr := v2Store.ReadGeneration(treeHash)
 		if genErr != nil {
 			warnings = append(warnings, fmt.Sprintf("generation %s: failed to read generation.json: %v", genName, genErr))
 			continue
@@ -587,7 +587,7 @@ func checkV2CheckpointCounts(cmd *cobra.Command, repo *git.Repository) error {
 
 // checkV2RefExistence verifies that v2 refs exist (or both are absent for a fresh repo).
 // One ref without the other suggests a partial initialization.
-func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error { //nolint:unparam // error return kept for consistency with other check functions
+func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error {
 	w := cmd.OutOrStdout()
 
 	mainRefName := plumbing.ReferenceName(paths.V2MainRefName)
@@ -606,8 +606,10 @@ func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error { //nol
 		fmt.Fprintln(w, "✓ v2 refs: OK (no checkpoints written yet)")
 	case hasMain && !hasFull:
 		fmt.Fprintln(w, "v2 refs: INCONSISTENT — /main exists but /full/current is missing")
+		return errors.New("v2 refs inconsistent: /main exists but /full/current is missing")
 	case !hasMain && hasFull:
 		fmt.Fprintln(w, "v2 refs: INCONSISTENT — /full/current exists but /main is missing")
+		return errors.New("v2 refs inconsistent: /full/current exists but /main is missing")
 	}
 
 	return nil

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -505,7 +505,7 @@ func checkV2GenerationHealth(cmd *cobra.Command, repo *git.Repository) error {
 			continue
 		}
 
-		if gen.OldestCheckpointAt.IsZero() && gen.NewestCheckpointAt.IsZero() {
+		if gen.OldestCheckpointAt.IsZero() || gen.NewestCheckpointAt.IsZero() {
 			warnings = append(warnings, fmt.Sprintf("generation %s: WARNING — missing generation.json", genName))
 		} else if gen.OldestCheckpointAt.After(gen.NewestCheckpointAt) {
 			warnings = append(warnings, fmt.Sprintf("generation %s: WARNING — invalid timestamps (oldest > newest)", genName))

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -549,10 +549,10 @@ func checkV2GenerationHealth(cmd *cobra.Command, repo *git.Repository) error {
 		for _, warning := range warnings {
 			fmt.Fprintf(w, "  %s\n", warning)
 		}
-	} else {
-		fmt.Fprintf(w, "✓ v2 generations: OK (%d archived)\n", len(archived))
+		return fmt.Errorf("v2 generation health: %d issue(s) found", len(warnings))
 	}
 
+	fmt.Fprintf(w, "✓ v2 generations: OK (%d archived)\n", len(archived))
 	return nil
 }
 
@@ -597,10 +597,10 @@ func checkV2CheckpointCounts(cmd *cobra.Command, repo *git.Repository) error {
 
 	if fullCount > mainCount {
 		fmt.Fprintf(w, "v2 checkpoint counts: INCONSISTENT — /full/current has %d checkpoints but /main has only %d\n", fullCount, mainCount)
-	} else {
-		fmt.Fprintf(w, "✓ v2 checkpoint counts: OK (main: %d, full/current: %d)\n", mainCount, fullCount)
+		return fmt.Errorf("v2 checkpoint counts inconsistent: /full/current (%d) exceeds /main (%d)", fullCount, mainCount)
 	}
 
+	fmt.Fprintf(w, "✓ v2 checkpoint counts: OK (main: %d, full/current: %d)\n", mainCount, fullCount)
 	return nil
 }
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 
 	"github.com/go-git/go-git/v6"
@@ -31,14 +32,21 @@ Checks performed:
   1. Disconnected metadata branches: detects when local and remote
      entire/checkpoints/v1 branches share no common ancestor (caused by a
      previous bug). Fixes by cherry-picking local checkpoints onto remote tip.
-  2. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
+
+  When checkpoints_v2 is enabled:
+  2. Disconnected v2 /main ref: same detection for v2 refs under refs/entire/.
+  3. v2 ref existence: verifies /main and /full/current refs exist consistently.
+  4. v2 checkpoint counts: verifies /main and /full/current checkpoint counts are consistent.
+  5. v2 generation health: checks archived generations for valid metadata.
+
+  6. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
 
 A session is considered stuck if:
   - It is in ACTIVE phase with no interaction for over 1 hour
   - It is in ENDED phase with uncondensed checkpoint data on a shadow branch
 
 For each stuck session, you can choose to:
-  - Condense: Save session data to permanent storage (entire/checkpoints/v1 branch)
+  - Condense: Save session data to permanent storage
   - Discard: Remove the session state and shadow branch data
   - Skip: Leave the session as-is
 
@@ -78,8 +86,48 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 	}
 	fmt.Fprintln(cmd.OutOrStdout())
 
-	// Check 2: Stuck sessions
+	// v2 checks (only when checkpoints_v2 is enabled)
 	ctx := cmd.Context()
+	if settings.IsCheckpointsV2Enabled(ctx) {
+		// Check 2: Disconnected v2 /main ref
+		v2DisconnectedErr := checkDisconnectedV2Main(cmd, force)
+		if v2DisconnectedErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: v2 /main check failed: %v\n", v2DisconnectedErr)
+			if finalErr == nil {
+				finalErr = NewSilentError(fmt.Errorf("v2 /main check failed: %w", v2DisconnectedErr))
+			}
+		}
+
+		if repo, repoErr := openRepository(ctx); repoErr == nil {
+			// Check 3: v2 ref existence
+			if refErr := checkV2RefExistence(cmd, repo); refErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Error: v2 ref existence check failed: %v\n", refErr)
+				if finalErr == nil {
+					finalErr = NewSilentError(fmt.Errorf("v2 ref check failed: %w", refErr))
+				}
+			}
+
+			// Check 4: v2 checkpoint count consistency
+			if countErr := checkV2CheckpointCounts(cmd, repo); countErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Error: v2 checkpoint count check failed: %v\n", countErr)
+				if finalErr == nil {
+					finalErr = NewSilentError(fmt.Errorf("v2 count check failed: %w", countErr))
+				}
+			}
+
+			// Check 5: v2 generation health
+			if genErr := checkV2GenerationHealth(cmd, repo); genErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Error: v2 generation health check failed: %v\n", genErr)
+				if finalErr == nil {
+					finalErr = NewSilentError(fmt.Errorf("v2 generation check failed: %w", genErr))
+				}
+			}
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout())
+	}
+
+	// Stuck sessions
 	// Load all session states
 	states, err := strategy.ListSessionStates(ctx)
 	if err != nil {

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -620,6 +620,12 @@ func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error {
 
 	_, mainErr := repo.Reference(mainRefName, true)
 	_, fullErr := repo.Reference(fullRefName, true)
+	if mainErr != nil && !errors.Is(mainErr, plumbing.ErrReferenceNotFound) {
+		return fmt.Errorf("failed to read /main ref: %w", mainErr)
+	}
+	if fullErr != nil && !errors.Is(fullErr, plumbing.ErrReferenceNotFound) {
+		return fmt.Errorf("failed to read /full/current ref: %w", fullErr)
+	}
 
 	hasMain := mainErr == nil
 	hasFull := fullErr == nil

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/charmbracelet/huh"
@@ -359,6 +360,79 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 	}
 
 	fmt.Fprintln(w, "  ✓ Fixed: metadata branches reconciled")
+	return nil
+}
+
+// checkV2GenerationHealth verifies that archived /full/* generations are well-formed.
+// Checks: generation.json exists and is valid, timestamps are sane, generation has checkpoints,
+// and generation sequence numbers are contiguous.
+func checkV2GenerationHealth(cmd *cobra.Command, repo *git.Repository) error {
+	w := cmd.OutOrStdout()
+
+	v2Store := checkpoint.NewV2GitStore(repo, "origin")
+
+	archived, err := v2Store.ListArchivedGenerations()
+	if err != nil {
+		return fmt.Errorf("failed to list archived generations: %w", err)
+	}
+
+	if len(archived) == 0 {
+		fmt.Fprintln(w, "✓ v2 generations: OK (no archived generations)")
+		return nil
+	}
+
+	var warnings []string
+
+	for _, genName := range archived {
+		refName := plumbing.ReferenceName(paths.V2FullRefPrefix + genName)
+
+		_, treeHash, refErr := v2Store.GetRefState(refName)
+		if refErr != nil {
+			warnings = append(warnings, fmt.Sprintf("generation %s: cannot read ref", genName))
+			continue
+		}
+
+		gen, genErr := v2Store.ReadGenerationFromRef(refName)
+		if genErr != nil {
+			warnings = append(warnings, fmt.Sprintf("generation %s: failed to read generation.json: %v", genName, genErr))
+			continue
+		}
+
+		if gen.OldestCheckpointAt.IsZero() && gen.NewestCheckpointAt.IsZero() {
+			warnings = append(warnings, fmt.Sprintf("generation %s: WARNING — missing generation.json", genName))
+		} else if gen.OldestCheckpointAt.After(gen.NewestCheckpointAt) {
+			warnings = append(warnings, fmt.Sprintf("generation %s: WARNING — invalid timestamps (oldest > newest)", genName))
+		}
+
+		cpCount, countErr := v2Store.CountCheckpointsInTree(treeHash)
+		if countErr != nil {
+			warnings = append(warnings, fmt.Sprintf("generation %s: failed to count checkpoints: %v", genName, countErr))
+			continue
+		}
+		if cpCount == 0 {
+			warnings = append(warnings, fmt.Sprintf("generation %s: WARNING — empty (no checkpoint shards)", genName))
+		}
+	}
+
+	if len(archived) > 1 {
+		for i := 1; i < len(archived); i++ {
+			prev, _ := strconv.ParseInt(archived[i-1], 10, 64)
+			curr, _ := strconv.ParseInt(archived[i], 10, 64)
+			if curr-prev > 1 {
+				warnings = append(warnings, fmt.Sprintf("INFO — gap in generation sequence (%013d missing)", prev+1))
+			}
+		}
+	}
+
+	if len(warnings) > 0 {
+		fmt.Fprintf(w, "v2 generations: %d issue(s) found in %d archived generation(s):\n", len(warnings), len(archived))
+		for _, warning := range warnings {
+			fmt.Fprintf(w, "  %s\n", warning)
+		}
+	} else {
+		fmt.Fprintf(w, "✓ v2 generations: OK (%d archived)\n", len(archived))
+	}
+
 	return nil
 }
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -511,7 +511,7 @@ func checkV2GenerationHealth(cmd *cobra.Command, repo *git.Repository) error {
 
 		_, treeHash, refErr := v2Store.GetRefState(refName)
 		if refErr != nil {
-			warnings = append(warnings, fmt.Sprintf("generation %s: cannot read ref", genName))
+			warnings = append(warnings, fmt.Sprintf("generation %s: cannot read ref: %v", genName, refErr))
 			continue
 		}
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -436,6 +436,13 @@ func checkDisconnectedV2Main(cmd *cobra.Command, force bool) error {
 
 	disconnected, err := strategy.IsV2MainDisconnected(ctx, repo, remote)
 	if err != nil {
+		// If no checkpoint_remote is configured and origin doesn't exist or is
+		// unreachable, treat as "can't check" rather than a hard failure — mirrors
+		// the v1 behavior which no-ops when the remote-tracking ref is absent.
+		if !configured {
+			fmt.Fprintln(cmd.OutOrStdout(), "✓ v2 /main ref: OK (no remote to compare)")
+			return nil
+		}
 		return fmt.Errorf("could not check v2 /main ref state: %w", err)
 	}
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -523,8 +523,11 @@ func checkV2GenerationHealth(cmd *cobra.Command, repo *git.Repository) error {
 
 	if len(archived) > 1 {
 		for i := 1; i < len(archived); i++ {
-			prev, _ := strconv.ParseInt(archived[i-1], 10, 64)
-			curr, _ := strconv.ParseInt(archived[i], 10, 64)
+			prev, prevErr := strconv.ParseInt(archived[i-1], 10, 64)
+			curr, currErr := strconv.ParseInt(archived[i], 10, 64)
+			if prevErr != nil || currErr != nil {
+				continue
+			}
 			if curr-prev > 1 {
 				warnings = append(warnings, fmt.Sprintf("INFO — gap in generation sequence (%013d missing)", prev+1))
 			}
@@ -558,8 +561,9 @@ func checkV2CheckpointCounts(cmd *cobra.Command, repo *git.Repository) error {
 	_, mainTreeHash, mainErr := v2Store.GetRefState(mainRefName)
 	_, fullTreeHash, fullErr := v2Store.GetRefState(fullRefName)
 
+	// Skip if either ref doesn't exist (already covered by checkV2RefExistence)
 	if mainErr != nil || fullErr != nil {
-		return nil
+		return nil //nolint:nilerr // Intentional: missing ref is not an error here, just means nothing to compare
 	}
 
 	mainCount, err := v2Store.CountCheckpointsInTree(mainTreeHash)
@@ -583,7 +587,7 @@ func checkV2CheckpointCounts(cmd *cobra.Command, repo *git.Repository) error {
 
 // checkV2RefExistence verifies that v2 refs exist (or both are absent for a fresh repo).
 // One ref without the other suggests a partial initialization.
-func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error {
+func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error { //nolint:unparam // error return kept for consistency with other check functions
 	w := cmd.OutOrStdout()
 
 	mainRefName := plumbing.ReferenceName(paths.V2MainRefName)

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -362,6 +362,34 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 	return nil
 }
 
+// checkV2RefExistence verifies that v2 refs exist (or both are absent for a fresh repo).
+// One ref without the other suggests a partial initialization.
+func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error {
+	w := cmd.OutOrStdout()
+
+	mainRefName := plumbing.ReferenceName(paths.V2MainRefName)
+	fullRefName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+
+	_, mainErr := repo.Reference(mainRefName, true)
+	_, fullErr := repo.Reference(fullRefName, true)
+
+	hasMain := mainErr == nil
+	hasFull := fullErr == nil
+
+	switch {
+	case hasMain && hasFull:
+		fmt.Fprintln(w, "✓ v2 refs: OK")
+	case !hasMain && !hasFull:
+		fmt.Fprintln(w, "✓ v2 refs: OK (no checkpoints written yet)")
+	case hasMain && !hasFull:
+		fmt.Fprintln(w, "v2 refs: INCONSISTENT — /main exists but /full/current is missing")
+	case !hasMain && hasFull:
+		fmt.Fprintln(w, "v2 refs: INCONSISTENT — /full/current exists but /main is missing")
+	}
+
+	return nil
+}
+
 // canDeleteShadowBranch checks if a shadow branch can be safely deleted.
 // Returns true if no other sessions (besides excludeSessionID) need this branch.
 func canDeleteShadowBranch(ctx context.Context, shadowBranch, excludeSessionID string) (bool, error) {

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -420,7 +420,10 @@ func checkDisconnectedV2Main(cmd *cobra.Command, force bool) error {
 	}
 
 	ctx := cmd.Context()
-	remote := strategy.ResolveCheckpointURL(ctx, "origin")
+	remote, configured, resolveErr := strategy.ResolveCheckpointRemoteURL(ctx)
+	if configured && resolveErr != nil {
+		return fmt.Errorf("checkpoint_remote is configured but could not be resolved: %w", resolveErr)
+	}
 	if remote == "" {
 		remote = "origin"
 	}

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -362,6 +362,44 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 	return nil
 }
 
+// checkV2CheckpointCounts verifies checkpoint count consistency between /main and /full/current.
+// /main is permanent (accumulates all checkpoints), /full/current holds only the current generation.
+// So main count >= full/current count. If full/current exceeds main, a dual-write partially failed.
+// Skips silently if either ref doesn't exist (already covered by checkV2RefExistence).
+func checkV2CheckpointCounts(cmd *cobra.Command, repo *git.Repository) error {
+	w := cmd.OutOrStdout()
+
+	v2Store := checkpoint.NewV2GitStore(repo, "origin")
+
+	mainRefName := plumbing.ReferenceName(paths.V2MainRefName)
+	fullRefName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+
+	_, mainTreeHash, mainErr := v2Store.GetRefState(mainRefName)
+	_, fullTreeHash, fullErr := v2Store.GetRefState(fullRefName)
+
+	if mainErr != nil || fullErr != nil {
+		return nil
+	}
+
+	mainCount, err := v2Store.CountCheckpointsInTree(mainTreeHash)
+	if err != nil {
+		return fmt.Errorf("failed to count /main checkpoints: %w", err)
+	}
+
+	fullCount, err := v2Store.CountCheckpointsInTree(fullTreeHash)
+	if err != nil {
+		return fmt.Errorf("failed to count /full/current checkpoints: %w", err)
+	}
+
+	if fullCount > mainCount {
+		fmt.Fprintf(w, "v2 checkpoint counts: INCONSISTENT — /full/current has %d checkpoints but /main has only %d\n", fullCount, mainCount)
+	} else {
+		fmt.Fprintf(w, "✓ v2 checkpoint counts: OK (main: %d, full/current: %d)\n", mainCount, fullCount)
+	}
+
+	return nil
+}
+
 // checkV2RefExistence verifies that v2 refs exist (or both are absent for a fresh repo).
 // One ref without the other suggests a partial initialization.
 func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error {

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -98,7 +98,13 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 			}
 		}
 
-		if repo, repoErr := openRepository(ctx); repoErr == nil {
+		repo, repoErr := openRepository(ctx)
+		if repoErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: could not open repository for v2 checks: %v\n", repoErr)
+			if finalErr == nil {
+				finalErr = NewSilentError(fmt.Errorf("v2 checks failed: %w", repoErr))
+			}
+		} else {
 			// Check 3: v2 ref existence
 			if refErr := checkV2RefExistence(cmd, repo); refErr != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Error: v2 ref existence check failed: %v\n", refErr)

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -363,6 +363,65 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 	return nil
 }
 
+// checkDisconnectedV2Main detects and optionally repairs disconnected
+// local/remote v2 /main refs.
+func checkDisconnectedV2Main(cmd *cobra.Command, force bool) error {
+	repo, err := openRepository(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("failed to open repository: %w", err)
+	}
+
+	ctx := cmd.Context()
+	remote := strategy.ResolveCheckpointURL(ctx, "origin")
+	if remote == "" {
+		remote = "origin"
+	}
+
+	disconnected, err := strategy.IsV2MainDisconnected(ctx, repo, remote)
+	if err != nil {
+		return fmt.Errorf("could not check v2 /main ref state: %w", err)
+	}
+
+	w := cmd.OutOrStdout()
+
+	if !disconnected {
+		fmt.Fprintln(w, "✓ v2 /main ref: OK")
+		return nil
+	}
+
+	fmt.Fprintln(w, "v2 /main ref: DISCONNECTED")
+	fmt.Fprintln(w, "  Local and remote v2 /main refs share no common ancestor.")
+	fmt.Fprintln(w, "  Fix: cherry-pick local checkpoints onto remote tip (preserves all data).")
+
+	if !force {
+		var confirmed bool
+		form := NewAccessibleForm(
+			huh.NewGroup(
+				huh.NewConfirm().
+					Title("Fix disconnected v2 /main ref?").
+					Value(&confirmed),
+			),
+		)
+		if formErr := form.Run(); formErr != nil {
+			if errors.Is(formErr, huh.ErrUserAborted) {
+				return nil
+			}
+			return fmt.Errorf("prompt failed: %w", formErr)
+		}
+		if !confirmed {
+			fmt.Fprintln(w, "  -> Skipped")
+			return nil
+		}
+	}
+
+	if fixErr := strategy.ReconcileDisconnectedV2Ref(ctx, repo, remote, cmd.ErrOrStderr()); fixErr != nil {
+		return fmt.Errorf("failed to reconcile v2 /main ref: %w", fixErr)
+	}
+
+	fmt.Fprintln(w, "  ✓ Fixed: v2 /main ref reconciled")
+	return nil
+}
+
 // checkV2GenerationHealth verifies that archived /full/* generations are well-formed.
 // Checks: generation.json exists and is valid, timestamps are sane, generation has checkpoints,
 // and generation sequence numbers are contiguous.

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -561,9 +561,18 @@ func checkV2CheckpointCounts(cmd *cobra.Command, repo *git.Repository) error {
 	_, mainTreeHash, mainErr := v2Store.GetRefState(mainRefName)
 	_, fullTreeHash, fullErr := v2Store.GetRefState(fullRefName)
 
-	// Skip if either ref doesn't exist (already covered by checkV2RefExistence)
-	if mainErr != nil || fullErr != nil {
-		return nil //nolint:nilerr // Intentional: missing ref is not an error here, just means nothing to compare
+	// Skip only when ref is missing (already covered by checkV2RefExistence).
+	if mainErr != nil {
+		if errors.Is(mainErr, plumbing.ErrReferenceNotFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to read /main ref: %w", mainErr)
+	}
+	if fullErr != nil {
+		if errors.Is(fullErr, plumbing.ErrReferenceNotFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to read /full/current ref: %w", fullErr)
 	}
 
 	mainCount, err := v2Store.CountCheckpointsInTree(mainTreeHash)

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -545,7 +545,13 @@ func checkV2GenerationHealth(cmd *cobra.Command, repo *git.Repository) error {
 				continue
 			}
 			if curr-prev > 1 {
-				warnings = append(warnings, fmt.Sprintf("INFO — gap in generation sequence (%013d missing)", prev+1))
+				first := prev + 1
+				last := curr - 1
+				if first == last {
+					warnings = append(warnings, fmt.Sprintf("INFO — gap in generation sequence (%013d missing)", first))
+				} else {
+					warnings = append(warnings, fmt.Sprintf("INFO — gap in generation sequence (%013d–%013d missing)", first, last))
+				}
 			}
 		}
 	}

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -505,9 +505,16 @@ func checkV2GenerationHealth(cmd *cobra.Command, repo *git.Repository) error {
 			continue
 		}
 
-		if gen.OldestCheckpointAt.IsZero() || gen.NewestCheckpointAt.IsZero() {
+		hasOldest := !gen.OldestCheckpointAt.IsZero()
+		hasNewest := !gen.NewestCheckpointAt.IsZero()
+
+		switch {
+		case !hasOldest && !hasNewest:
+			// ReadGeneration returns zero-value when the file is absent
 			warnings = append(warnings, fmt.Sprintf("generation %s: WARNING — missing generation.json", genName))
-		} else if gen.OldestCheckpointAt.After(gen.NewestCheckpointAt) {
+		case hasOldest != hasNewest:
+			warnings = append(warnings, fmt.Sprintf("generation %s: WARNING — incomplete generation.json (partial timestamps)", genName))
+		case gen.OldestCheckpointAt.After(gen.NewestCheckpointAt):
 			warnings = append(warnings, fmt.Sprintf("generation %s: WARNING — invalid timestamps (oldest > newest)", genName))
 		}
 

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +37,56 @@ func createV2Ref(t *testing.T, repo *git.Repository, refName string) {
 		Author:    object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
 		Committer: object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
 		Message:   "init v2 ref",
+		TreeHash:  treeHash,
+	}
+	enc := repo.Storer.NewEncodedObject()
+	require.NoError(t, commitObj.Encode(enc))
+	commitHash, err := repo.Storer.SetEncodedObject(enc)
+	require.NoError(t, err)
+
+	ref := plumbing.NewHashReference(plumbing.ReferenceName(refName), commitHash)
+	require.NoError(t, repo.Storer.SetReference(ref))
+}
+
+// createBlob stores a string as a git blob and returns its hash.
+func createBlob(t *testing.T, repo *git.Repository, content string) plumbing.Hash {
+	t.Helper()
+	obj := repo.Storer.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	hash, err := repo.Storer.SetEncodedObject(obj)
+	require.NoError(t, err)
+	return hash
+}
+
+// createV2RefWithCheckpoints creates a v2 custom ref with N checkpoint shard directories.
+// Each shard has a minimal metadata.json file.
+func createV2RefWithCheckpoints(t *testing.T, repo *git.Repository, refName string, count int) {
+	t.Helper()
+
+	entries := make(map[string]object.TreeEntry)
+	for i := range count {
+		cpID := fmt.Sprintf("%02x%010x", i%256, i)
+		path := cpID[:2] + "/" + cpID[2:] + "/" + paths.MetadataFileName
+		blobHash := createBlob(t, repo, fmt.Sprintf(`{"checkpoint_id":"%s"}`, cpID))
+		entries[path] = object.TreeEntry{
+			Name: paths.MetadataFileName,
+			Mode: filemode.Regular,
+			Hash: blobHash,
+		}
+	}
+
+	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, entries)
+	require.NoError(t, err)
+
+	commitObj := &object.Commit{
+		Author:    object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+		Committer: object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+		Message:   "v2 ref with checkpoints",
 		TreeHash:  treeHash,
 	}
 	enc := repo.Storer.NewEncodedObject()
@@ -394,6 +446,65 @@ func TestCheckV2RefExistence_OnlyFullCurrentExists(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "INCONSISTENT")
 	assert.Contains(t, stdout.String(), "/main is missing")
+}
+
+func TestCheckV2CheckpointCounts_Consistent(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	createV2RefWithCheckpoints(t, repo, paths.V2MainRefName, 10)
+	createV2RefWithCheckpoints(t, repo, paths.V2FullCurrentRefName, 5)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = checkV2CheckpointCounts(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "v2 checkpoint counts: OK")
+	assert.Contains(t, stdout.String(), "main: 10")
+	assert.Contains(t, stdout.String(), "full/current: 5")
+}
+
+func TestCheckV2CheckpointCounts_FullExceedsMain(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	createV2RefWithCheckpoints(t, repo, paths.V2MainRefName, 3)
+	createV2RefWithCheckpoints(t, repo, paths.V2FullCurrentRefName, 5)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = checkV2CheckpointCounts(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "INCONSISTENT")
+}
+
+func TestCheckV2CheckpointCounts_SkipsWhenRefsMissing(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = checkV2CheckpointCounts(cmd, repo)
+	require.NoError(t, err)
+	assert.Empty(t, stdout.String())
 }
 
 // TestRunSessionsFix_MetadataCheckFailure_PropagatesError verifies that when

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -505,6 +506,196 @@ func TestCheckV2CheckpointCounts_SkipsWhenRefsMissing(t *testing.T) {
 	err = checkV2CheckpointCounts(cmd, repo)
 	require.NoError(t, err)
 	assert.Empty(t, stdout.String())
+}
+
+// createArchivedGeneration creates an archived generation ref with the given generation.json
+// and checkpoint count. generationNum is the sequence number (e.g., 1 -> "0000000000001").
+func createArchivedGeneration(t *testing.T, repo *git.Repository, generationNum int, gen *checkpoint.GenerationMetadata, checkpointCount int) {
+	t.Helper()
+
+	entries := make(map[string]object.TreeEntry)
+
+	for i := range checkpointCount {
+		cpID := fmt.Sprintf("%02x%010x", i%256, i)
+		path := cpID[:2] + "/" + cpID[2:] + "/0/" + paths.TranscriptFileName
+		blobHash := createBlob(t, repo, `{"transcript":"data"}`)
+		entries[path] = object.TreeEntry{
+			Name: paths.TranscriptFileName,
+			Mode: filemode.Regular,
+			Hash: blobHash,
+		}
+	}
+
+	if gen != nil {
+		genJSON, err := json.Marshal(gen)
+		require.NoError(t, err)
+		blobHash := createBlob(t, repo, string(genJSON))
+		entries[paths.GenerationFileName] = object.TreeEntry{
+			Name: paths.GenerationFileName,
+			Mode: filemode.Regular,
+			Hash: blobHash,
+		}
+	}
+
+	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, entries)
+	require.NoError(t, err)
+
+	commitObj := &object.Commit{
+		Author:    object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+		Committer: object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+		Message:   "archived generation",
+		TreeHash:  treeHash,
+	}
+	enc := repo.Storer.NewEncodedObject()
+	require.NoError(t, commitObj.Encode(enc))
+	commitHash, err := repo.Storer.SetEncodedObject(enc)
+	require.NoError(t, err)
+
+	refName := fmt.Sprintf("%s%013d", paths.V2FullRefPrefix, generationNum)
+	ref := plumbing.NewHashReference(plumbing.ReferenceName(refName), commitHash)
+	require.NoError(t, repo.Storer.SetReference(ref))
+}
+
+func TestCheckV2GenerationHealth_NoArchives(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	err = checkV2GenerationHealth(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "no archived generations")
+}
+
+func TestCheckV2GenerationHealth_HealthyGeneration(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	gen := &checkpoint.GenerationMetadata{
+		OldestCheckpointAt: now.Add(-24 * time.Hour),
+		NewestCheckpointAt: now,
+	}
+	createArchivedGeneration(t, repo, 1, gen, 5)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	err = checkV2GenerationHealth(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "v2 generations: OK (1 archived)")
+}
+
+func TestCheckV2GenerationHealth_MissingGenerationJSON(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	createArchivedGeneration(t, repo, 1, nil, 5)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	err = checkV2GenerationHealth(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "WARNING")
+	assert.Contains(t, stdout.String(), "missing generation.json")
+}
+
+func TestCheckV2GenerationHealth_InvalidTimestamps(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	gen := &checkpoint.GenerationMetadata{
+		OldestCheckpointAt: now,
+		NewestCheckpointAt: now.Add(-24 * time.Hour),
+	}
+	createArchivedGeneration(t, repo, 1, gen, 5)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	err = checkV2GenerationHealth(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "WARNING")
+	assert.Contains(t, stdout.String(), "invalid timestamps")
+}
+
+func TestCheckV2GenerationHealth_EmptyGeneration(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	gen := &checkpoint.GenerationMetadata{
+		OldestCheckpointAt: now.Add(-24 * time.Hour),
+		NewestCheckpointAt: now,
+	}
+	createArchivedGeneration(t, repo, 1, gen, 0)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	err = checkV2GenerationHealth(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "WARNING")
+	assert.Contains(t, stdout.String(), "empty")
+}
+
+func TestCheckV2GenerationHealth_SequenceGap(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	gen1 := &checkpoint.GenerationMetadata{
+		OldestCheckpointAt: now.Add(-48 * time.Hour),
+		NewestCheckpointAt: now.Add(-24 * time.Hour),
+	}
+	createArchivedGeneration(t, repo, 1, gen1, 3)
+
+	gen3 := &checkpoint.GenerationMetadata{
+		OldestCheckpointAt: now.Add(-12 * time.Hour),
+		NewestCheckpointAt: now,
+	}
+	createArchivedGeneration(t, repo, 3, gen3, 3)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	err = checkV2GenerationHealth(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "INFO")
+	assert.Contains(t, stdout.String(), "gap")
 }
 
 // TestRunSessionsFix_MetadataCheckFailure_PropagatesError verifies that when

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -857,10 +857,11 @@ func TestRunSessionsFix_V2ChecksRunWhenEnabled(t *testing.T) {
 
 	cmd, stdout, _ := newTestCmd(t)
 
-	// May get an error from the disconnected check (no remote), that's OK
-	_ = runSessionsFix(cmd, true) //nolint:errcheck // error from missing remote is expected
+	err = runSessionsFix(cmd, true)
+	require.NoError(t, err)
 
 	output := stdout.String()
 	// v2 checks should appear in output
+	assert.Contains(t, output, "v2 /main ref: OK (no remote to compare)")
 	assert.Contains(t, output, "v2 refs: OK")
 }

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -605,6 +605,27 @@ func TestCheckV2GenerationHealth_InvalidTimestamps(t *testing.T) {
 	assert.Contains(t, stdout.String(), "invalid timestamps")
 }
 
+func TestCheckV2GenerationHealth_PartialMissingTimestamp(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	gen := &checkpoint.GenerationMetadata{
+		OldestCheckpointAt: time.Time{},
+		NewestCheckpointAt: now,
+	}
+	createArchivedGeneration(t, repo, 1, gen, 5)
+
+	cmd, stdout, _ := newTestCmd(t)
+
+	err = checkV2GenerationHealth(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "WARNING")
+	assert.Contains(t, stdout.String(), "missing generation.json")
+}
+
 func TestCheckV2GenerationHealth_EmptyGeneration(t *testing.T) {
 	t.Parallel()
 	dir := setupGitRepoForPhaseTest(t)

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -30,21 +30,10 @@ import (
 func createV2Ref(t *testing.T, repo *git.Repository, refName string) {
 	t.Helper()
 
-	emptyTree := &object.Tree{Entries: []object.TreeEntry{}}
-	treeObj := repo.Storer.NewEncodedObject()
-	require.NoError(t, emptyTree.Encode(treeObj))
-	treeHash, err := repo.Storer.SetEncodedObject(treeObj)
+	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, make(map[string]object.TreeEntry))
 	require.NoError(t, err)
 
-	commitObj := &object.Commit{
-		Author:    object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
-		Committer: object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
-		Message:   "init v2 ref",
-		TreeHash:  treeHash,
-	}
-	enc := repo.Storer.NewEncodedObject()
-	require.NoError(t, commitObj.Encode(enc))
-	commitHash, err := repo.Storer.SetEncodedObject(enc)
+	commitHash, err := checkpoint.CreateCommit(repo, treeHash, plumbing.ZeroHash, "init v2 ref", "test", "test@test.com")
 	require.NoError(t, err)
 
 	ref := plumbing.NewHashReference(plumbing.ReferenceName(refName), commitHash)
@@ -86,19 +75,22 @@ func createV2RefWithCheckpoints(t *testing.T, repo *git.Repository, refName stri
 	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, entries)
 	require.NoError(t, err)
 
-	commitObj := &object.Commit{
-		Author:    object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
-		Committer: object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
-		Message:   "v2 ref with checkpoints",
-		TreeHash:  treeHash,
-	}
-	enc := repo.Storer.NewEncodedObject()
-	require.NoError(t, commitObj.Encode(enc))
-	commitHash, err := repo.Storer.SetEncodedObject(enc)
+	commitHash, err := checkpoint.CreateCommit(repo, treeHash, plumbing.ZeroHash, "v2 ref with checkpoints", "test", "test@test.com")
 	require.NoError(t, err)
 
 	ref := plumbing.NewHashReference(plumbing.ReferenceName(refName), commitHash)
 	require.NoError(t, repo.Storer.SetReference(ref))
+}
+
+// newTestCmd creates a minimal cobra.Command with captured stdout/stderr for testing.
+func newTestCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	return cmd, &stdout, &stderr
 }
 
 // testBaseCommit is a fake commit hash used across classifySession tests.
@@ -382,11 +374,7 @@ func TestCheckV2RefExistence_BothExist(t *testing.T) {
 	createV2Ref(t, repo, paths.V2MainRefName)
 	createV2Ref(t, repo, paths.V2FullCurrentRefName)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
+	cmd, stdout, stderr := newTestCmd(t)
 
 	err = checkV2RefExistence(cmd, repo)
 	require.NoError(t, err)
@@ -400,11 +388,7 @@ func TestCheckV2RefExistence_NeitherExist(t *testing.T) {
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2RefExistence(cmd, repo)
 	require.NoError(t, err)
@@ -419,14 +403,10 @@ func TestCheckV2RefExistence_OnlyMainExists(t *testing.T) {
 
 	createV2Ref(t, repo, paths.V2MainRefName)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2RefExistence(cmd, repo)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "INCONSISTENT")
 	assert.Contains(t, stdout.String(), "/full/current is missing")
 }
@@ -439,14 +419,10 @@ func TestCheckV2RefExistence_OnlyFullCurrentExists(t *testing.T) {
 
 	createV2Ref(t, repo, paths.V2FullCurrentRefName)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2RefExistence(cmd, repo)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "INCONSISTENT")
 	assert.Contains(t, stdout.String(), "/main is missing")
 }
@@ -460,11 +436,7 @@ func TestCheckV2CheckpointCounts_Consistent(t *testing.T) {
 	createV2RefWithCheckpoints(t, repo, paths.V2MainRefName, 10)
 	createV2RefWithCheckpoints(t, repo, paths.V2FullCurrentRefName, 5)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2CheckpointCounts(cmd, repo)
 	require.NoError(t, err)
@@ -482,11 +454,7 @@ func TestCheckV2CheckpointCounts_FullExceedsMain(t *testing.T) {
 	createV2RefWithCheckpoints(t, repo, paths.V2MainRefName, 3)
 	createV2RefWithCheckpoints(t, repo, paths.V2FullCurrentRefName, 5)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2CheckpointCounts(cmd, repo)
 	require.NoError(t, err)
@@ -499,11 +467,7 @@ func TestCheckV2CheckpointCounts_SkipsWhenRefsMissing(t *testing.T) {
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2CheckpointCounts(cmd, repo)
 	require.NoError(t, err)
@@ -542,15 +506,7 @@ func createArchivedGeneration(t *testing.T, repo *git.Repository, generationNum 
 	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, entries)
 	require.NoError(t, err)
 
-	commitObj := &object.Commit{
-		Author:    object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
-		Committer: object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
-		Message:   "archived generation",
-		TreeHash:  treeHash,
-	}
-	enc := repo.Storer.NewEncodedObject()
-	require.NoError(t, commitObj.Encode(enc))
-	commitHash, err := repo.Storer.SetEncodedObject(enc)
+	commitHash, err := checkpoint.CreateCommit(repo, treeHash, plumbing.ZeroHash, "archived generation", "test", "test@test.com")
 	require.NoError(t, err)
 
 	refName := fmt.Sprintf("%s%013d", paths.V2FullRefPrefix, generationNum)
@@ -564,11 +520,7 @@ func TestCheckV2GenerationHealth_NoArchives(t *testing.T) {
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&bytes.Buffer{})
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
 	require.NoError(t, err)
@@ -588,11 +540,7 @@ func TestCheckV2GenerationHealth_HealthyGeneration(t *testing.T) {
 	}
 	createArchivedGeneration(t, repo, 1, gen, 5)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&bytes.Buffer{})
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
 	require.NoError(t, err)
@@ -607,11 +555,7 @@ func TestCheckV2GenerationHealth_MissingGenerationJSON(t *testing.T) {
 
 	createArchivedGeneration(t, repo, 1, nil, 5)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&bytes.Buffer{})
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
 	require.NoError(t, err)
@@ -632,11 +576,7 @@ func TestCheckV2GenerationHealth_InvalidTimestamps(t *testing.T) {
 	}
 	createArchivedGeneration(t, repo, 1, gen, 5)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&bytes.Buffer{})
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
 	require.NoError(t, err)
@@ -657,11 +597,7 @@ func TestCheckV2GenerationHealth_EmptyGeneration(t *testing.T) {
 	}
 	createArchivedGeneration(t, repo, 1, gen, 0)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&bytes.Buffer{})
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
 	require.NoError(t, err)
@@ -688,11 +624,7 @@ func TestCheckV2GenerationHealth_SequenceGap(t *testing.T) {
 	}
 	createArchivedGeneration(t, repo, 3, gen3, 3)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&bytes.Buffer{})
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
 	require.NoError(t, err)
@@ -806,11 +738,7 @@ func TestRunSessionsFix_V2ChecksSkippedWhenDisabled(t *testing.T) {
 	require.NoError(t, err)
 	createV2Ref(t, repo, paths.V2MainRefName)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
+	cmd, stdout, _ := newTestCmd(t)
 
 	err = runSessionsFix(cmd, true)
 	require.NoError(t, err)
@@ -840,11 +768,7 @@ func TestRunSessionsFix_V2ChecksRunWhenEnabled(t *testing.T) {
 	createV2Ref(t, repo, paths.V2MainRefName)
 	createV2Ref(t, repo, paths.V2FullCurrentRefName)
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
+	cmd, stdout, _ := newTestCmd(t)
 
 	// May get an error from the disconnected check (no remote), that's OK
 	_ = runSessionsFix(cmd, true) //nolint:errcheck // error from missing remote is expected

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -457,7 +457,7 @@ func TestCheckV2CheckpointCounts_FullExceedsMain(t *testing.T) {
 	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2CheckpointCounts(cmd, repo)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "INCONSISTENT")
 }
 
@@ -579,7 +579,7 @@ func TestCheckV2GenerationHealth_MissingGenerationJSON(t *testing.T) {
 	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "WARNING")
 	assert.Contains(t, stdout.String(), "missing generation.json")
 }
@@ -600,7 +600,7 @@ func TestCheckV2GenerationHealth_InvalidTimestamps(t *testing.T) {
 	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "WARNING")
 	assert.Contains(t, stdout.String(), "invalid timestamps")
 }
@@ -620,7 +620,7 @@ func TestCheckV2GenerationHealth_PartialTimestamp_MissingNewest(t *testing.T) {
 	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "WARNING")
 	assert.Contains(t, stdout.String(), "incomplete generation.json")
 }
@@ -640,7 +640,7 @@ func TestCheckV2GenerationHealth_PartialTimestamp_MissingOldest(t *testing.T) {
 	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "WARNING")
 	assert.Contains(t, stdout.String(), "incomplete generation.json")
 }
@@ -661,7 +661,7 @@ func TestCheckV2GenerationHealth_EmptyGeneration(t *testing.T) {
 	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "WARNING")
 	assert.Contains(t, stdout.String(), "empty")
 }
@@ -688,7 +688,7 @@ func TestCheckV2GenerationHealth_SequenceGap(t *testing.T) {
 	cmd, stdout, _ := newTestCmd(t)
 
 	err = checkV2GenerationHealth(cmd, repo)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "INFO")
 	assert.Contains(t, stdout.String(), "gap")
 }

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -790,4 +792,64 @@ func TestRunSessionsFix_ForceDiscardOutput_Indented(t *testing.T) {
 			assert.True(t, strings.HasPrefix(line, "  ✓ "), "expected nested success line to stay indented: %q", line)
 		}
 	}
+}
+
+func TestRunSessionsFix_V2ChecksSkippedWhenDisabled(t *testing.T) {
+	// Cannot use t.Parallel() because t.Chdir modifies process-global state.
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	// Create v2 refs but do NOT enable checkpoints_v2 in settings.
+	// Intentionally only create /main (not /full/current) to trigger INCONSISTENT
+	// if the check were to run.
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	createV2Ref(t, repo, paths.V2MainRefName)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = runSessionsFix(cmd, true)
+	require.NoError(t, err)
+
+	output := stdout.String()
+	// v2 checks should not appear in output
+	assert.NotContains(t, output, "v2 refs")
+	assert.NotContains(t, output, "v2 checkpoint counts")
+	assert.NotContains(t, output, "v2 generations")
+	assert.NotContains(t, output, "v2 /main ref")
+}
+
+func TestRunSessionsFix_V2ChecksRunWhenEnabled(t *testing.T) {
+	// Cannot use t.Parallel() because t.Chdir modifies process-global state.
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	// Create settings.json with checkpoints_v2 enabled
+	entireDir := filepath.Join(dir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	settingsJSON := `{"enabled": true, "strategy_options": {"checkpoints_v2": true}}`
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644))
+
+	// Create both v2 refs so ref existence check passes
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	createV2Ref(t, repo, paths.V2MainRefName)
+	createV2Ref(t, repo, paths.V2FullCurrentRefName)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	_ = runSessionsFix(cmd, true)
+	// May get an error from the disconnected check (no remote), that's OK
+
+	output := stdout.String()
+	// v2 checks should appear in output
+	assert.Contains(t, output, "v2 refs: OK")
 }

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -846,8 +846,8 @@ func TestRunSessionsFix_V2ChecksRunWhenEnabled(t *testing.T) {
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
 
-	_ = runSessionsFix(cmd, true)
 	// May get an error from the disconnected check (no remote), that's OK
+	_ = runSessionsFix(cmd, true) //nolint:errcheck // error from missing remote is expected
 
 	output := stdout.String()
 	// v2 checks should appear in output

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -20,6 +20,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// createV2Ref creates a v2 custom ref with an empty tree commit.
+// Works for refs/entire/checkpoints/v2/main, refs/entire/checkpoints/v2/full/current, etc.
+func createV2Ref(t *testing.T, repo *git.Repository, refName string) {
+	t.Helper()
+
+	emptyTree := &object.Tree{Entries: []object.TreeEntry{}}
+	treeObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, emptyTree.Encode(treeObj))
+	treeHash, err := repo.Storer.SetEncodedObject(treeObj)
+	require.NoError(t, err)
+
+	commitObj := &object.Commit{
+		Author:    object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+		Committer: object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+		Message:   "init v2 ref",
+		TreeHash:  treeHash,
+	}
+	enc := repo.Storer.NewEncodedObject()
+	require.NoError(t, commitObj.Encode(enc))
+	commitHash, err := repo.Storer.SetEncodedObject(enc)
+	require.NoError(t, err)
+
+	ref := plumbing.NewHashReference(plumbing.ReferenceName(refName), commitHash)
+	require.NoError(t, repo.Storer.SetReference(ref))
+}
+
 // testBaseCommit is a fake commit hash used across classifySession tests.
 const testBaseCommit = "abcdef1234567890abcdef1234567890abcdef12"
 
@@ -290,6 +316,84 @@ func TestClassifySession_WorktreeIDInShadowBranch(t *testing.T) {
 	assert.True(t, result.HasShadowBranch)
 	expectedBranch := checkpoint.ShadowBranchNameForCommit(baseCommit, worktreeID)
 	assert.Equal(t, expectedBranch, result.ShadowBranch)
+}
+
+func TestCheckV2RefExistence_BothExist(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	createV2Ref(t, repo, paths.V2MainRefName)
+	createV2Ref(t, repo, paths.V2FullCurrentRefName)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = checkV2RefExistence(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "v2 refs: OK")
+	assert.Empty(t, stderr.String())
+}
+
+func TestCheckV2RefExistence_NeitherExist(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = checkV2RefExistence(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "no checkpoints written yet")
+}
+
+func TestCheckV2RefExistence_OnlyMainExists(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	createV2Ref(t, repo, paths.V2MainRefName)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = checkV2RefExistence(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "INCONSISTENT")
+	assert.Contains(t, stdout.String(), "/full/current is missing")
+}
+
+func TestCheckV2RefExistence_OnlyFullCurrentExists(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	createV2Ref(t, repo, paths.V2FullCurrentRefName)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = checkV2RefExistence(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "INCONSISTENT")
+	assert.Contains(t, stdout.String(), "/main is missing")
 }
 
 // TestRunSessionsFix_MetadataCheckFailure_PropagatesError verifies that when

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -605,16 +605,15 @@ func TestCheckV2GenerationHealth_InvalidTimestamps(t *testing.T) {
 	assert.Contains(t, stdout.String(), "invalid timestamps")
 }
 
-func TestCheckV2GenerationHealth_PartialMissingTimestamp(t *testing.T) {
+func TestCheckV2GenerationHealth_PartialTimestamp_MissingNewest(t *testing.T) {
 	t.Parallel()
 	dir := setupGitRepoForPhaseTest(t)
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
 
-	now := time.Now().UTC()
 	gen := &checkpoint.GenerationMetadata{
-		OldestCheckpointAt: time.Time{},
-		NewestCheckpointAt: now,
+		OldestCheckpointAt: time.Now().UTC(),
+		// NewestCheckpointAt is zero — partial/corrupt
 	}
 	createArchivedGeneration(t, repo, 1, gen, 5)
 
@@ -623,7 +622,27 @@ func TestCheckV2GenerationHealth_PartialMissingTimestamp(t *testing.T) {
 	err = checkV2GenerationHealth(cmd, repo)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "WARNING")
-	assert.Contains(t, stdout.String(), "missing generation.json")
+	assert.Contains(t, stdout.String(), "incomplete generation.json")
+}
+
+func TestCheckV2GenerationHealth_PartialTimestamp_MissingOldest(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	gen := &checkpoint.GenerationMetadata{
+		// OldestCheckpointAt is zero — partial/corrupt
+		NewestCheckpointAt: time.Now().UTC(),
+	}
+	createArchivedGeneration(t, repo, 1, gen, 5)
+
+	cmd, stdout, _ := newTestCmd(t)
+
+	err = checkV2GenerationHealth(cmd, repo)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "WARNING")
+	assert.Contains(t, stdout.String(), "incomplete generation.json")
 }
 
 func TestCheckV2GenerationHealth_EmptyGeneration(t *testing.T) {

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -690,7 +690,33 @@ func TestCheckV2GenerationHealth_SequenceGap(t *testing.T) {
 	err = checkV2GenerationHealth(cmd, repo)
 	require.Error(t, err)
 	assert.Contains(t, stdout.String(), "INFO")
-	assert.Contains(t, stdout.String(), "gap")
+	assert.Contains(t, stdout.String(), "0000000000002 missing")
+}
+
+func TestCheckV2GenerationHealth_SequenceGapRange(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	gen1 := &checkpoint.GenerationMetadata{
+		OldestCheckpointAt: now.Add(-72 * time.Hour),
+		NewestCheckpointAt: now.Add(-48 * time.Hour),
+	}
+	createArchivedGeneration(t, repo, 1, gen1, 3)
+
+	gen5 := &checkpoint.GenerationMetadata{
+		OldestCheckpointAt: now.Add(-24 * time.Hour),
+		NewestCheckpointAt: now,
+	}
+	createArchivedGeneration(t, repo, 5, gen5, 3)
+
+	cmd, stdout, _ := newTestCmd(t)
+
+	err = checkV2GenerationHealth(cmd, repo)
+	require.Error(t, err)
+	assert.Contains(t, stdout.String(), "0000000000002–0000000000004 missing")
 }
 
 // TestRunSessionsFix_MetadataCheckFailure_PropagatesError verifies that when

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -474,6 +474,27 @@ func TestCheckV2CheckpointCounts_SkipsWhenRefsMissing(t *testing.T) {
 	assert.Empty(t, stdout.String())
 }
 
+func TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef(t *testing.T) {
+	t.Parallel()
+	dir := setupGitRepoForPhaseTest(t)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	// /full/current exists and is valid.
+	createV2RefWithCheckpoints(t, repo, paths.V2FullCurrentRefName, 1)
+
+	// /main exists but points to a missing commit object.
+	missingHash := plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	err = repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(paths.V2MainRefName), missingHash))
+	require.NoError(t, err)
+
+	cmd, _, _ := newTestCmd(t)
+
+	err = checkV2CheckpointCounts(cmd, repo)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read /main")
+}
+
 // createArchivedGeneration creates an archived generation ref with the given generation.json
 // and checkpoint count. generationNum is the sequence number (e.g., 1 -> "0000000000001").
 func createArchivedGeneration(t *testing.T, repo *git.Repository, generationNum int, gen *checkpoint.GenerationMetadata, checkpointCount int) {

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -342,8 +342,17 @@ func lsRemoteRef(ctx context.Context, repoPath, remote, refName string) (plumbin
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "ls-remote", remote, refName)
+	fetchTarget, err := ResolveFetchTarget(ctx, remote)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("resolve fetch target for ls-remote: %w", err)
+	}
+
+	cmd := CheckpointGitCommand(ctx, remote, "ls-remote", fetchTarget, refName)
 	cmd.Dir = repoPath
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.Output()
 	if err != nil {
 		return plumbing.ZeroHash, fmt.Errorf("git ls-remote %s failed: %w", RedactURL(remote), err)
@@ -367,11 +376,27 @@ func fetchRefToTemp(ctx context.Context, repoPath, remote, srcRef, dstRef string
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	fetchTarget, err := ResolveFetchTarget(ctx, remote)
+	if err != nil {
+		return fmt.Errorf("resolve fetch target for doctor v2 fetch: %w", err)
+	}
+
 	refspec := fmt.Sprintf("+%s:%s", srcRef, dstRef)
-	cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", remote, refspec)
+	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refspec})
+	cmd := CheckpointGitCommand(ctx, remote, fetchArgs...)
 	cmd.Dir = repoPath
-	if _, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git fetch %s failed: %w", RedactURL(remote), err)
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		redactedURL := RedactURL(remote)
+		msg := strings.TrimSpace(strings.ReplaceAll(string(output), remote, redactedURL))
+		if msg != "" {
+			return fmt.Errorf("git fetch %s failed: %s: %w", redactedURL, msg, err)
+		}
+		return fmt.Errorf("git fetch %s failed: %w", redactedURL, err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -346,7 +346,7 @@ func lsRemoteRef(ctx context.Context, repoPath, remote, refName string) (plumbin
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("git ls-remote failed: %w", err)
+		return plumbing.ZeroHash, fmt.Errorf("git ls-remote %s failed: %w", RedactURL(remote), err)
 	}
 
 	line := strings.TrimSpace(string(output))
@@ -370,8 +370,8 @@ func fetchRefToTemp(ctx context.Context, repoPath, remote, srcRef, dstRef string
 	refspec := fmt.Sprintf("+%s:%s", srcRef, dstRef)
 	cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", remote, refspec)
 	cmd.Dir = repoPath
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git fetch failed: %s: %w", output, err)
+	if _, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git fetch %s failed: %w", RedactURL(remote), err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -378,7 +378,7 @@ func fetchRefToTemp(ctx context.Context, repoPath, remote, srcRef, dstRef string
 
 // cleanupTmpRef deletes the temporary ref used by doctor checks.
 func cleanupTmpRef(repo *git.Repository) {
-	_ = repo.Storer.RemoveReference(plumbing.ReferenceName(v2DoctorTmpRef))
+	_ = repo.Storer.RemoveReference(plumbing.ReferenceName(v2DoctorTmpRef)) //nolint:errcheck // best-effort cleanup
 }
 
 // isDisconnected checks if two commits have no common ancestor using git merge-base.

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -234,13 +234,23 @@ func IsV2MainDisconnected(ctx context.Context, repo *git.Repository, remote stri
 		return false, nil
 	}
 
-	// Fetch remote ref to temporary local ref for merge-base check
+	// Fetch remote ref to temporary local ref for merge-base check.
+	// Use the fetched hash (not ls-remote hash) since the remote may have advanced.
 	if fetchErr := fetchRefToTemp(ctx, repoPath, remote, paths.V2MainRefName, v2DoctorTmpRef); fetchErr != nil {
 		return false, fmt.Errorf("failed to fetch remote v2 /main: %w", fetchErr)
 	}
 	defer cleanupTmpRef(repo)
 
-	return isDisconnected(ctx, repoPath, localRef.Hash().String(), remoteHash.String())
+	fetchedHash, err := resolveRefHash(repo, v2DoctorTmpRef)
+	if err != nil {
+		return false, fmt.Errorf("failed to read fetched v2 /main ref: %w", err)
+	}
+
+	if localRef.Hash() == fetchedHash {
+		return false, nil
+	}
+
+	return isDisconnected(ctx, repoPath, localRef.Hash().String(), fetchedHash.String())
 }
 
 // ReconcileDisconnectedV2Ref detects and repairs disconnected local/remote
@@ -286,7 +296,17 @@ func ReconcileDisconnectedV2Ref(
 	}
 	defer cleanupTmpRef(repo)
 
-	disconnected, err := isDisconnected(ctx, repoPath, localRef.Hash().String(), remoteHash.String())
+	// Use the fetched hash (not ls-remote hash) since the remote may have advanced.
+	fetchedHash, err := resolveRefHash(repo, v2DoctorTmpRef)
+	if err != nil {
+		return fmt.Errorf("failed to read fetched v2 /main ref: %w", err)
+	}
+
+	if localRef.Hash() == fetchedHash {
+		return nil
+	}
+
+	disconnected, err := isDisconnected(ctx, repoPath, localRef.Hash().String(), fetchedHash.String())
 	if err != nil {
 		return fmt.Errorf("failed to check v2 /main ancestry: %w", err)
 	}
@@ -313,7 +333,7 @@ func ReconcileDisconnectedV2Ref(
 	}
 
 	if len(dataCommits) == 0 {
-		ref := plumbing.NewHashReference(refName, remoteHash)
+		ref := plumbing.NewHashReference(refName, fetchedHash)
 		if setErr := repo.Storer.SetReference(ref); setErr != nil {
 			return fmt.Errorf("failed to reset v2 /main to remote: %w", setErr)
 		}
@@ -323,7 +343,7 @@ func ReconcileDisconnectedV2Ref(
 
 	fmt.Fprintf(w, "[entire] Cherry-picking %d local checkpoint(s) onto remote...\n", len(dataCommits))
 
-	newTip, err := cherryPickOnto(ctx, repo, remoteHash, dataCommits)
+	newTip, err := cherryPickOnto(ctx, repo, fetchedHash, dataCommits)
 	if err != nil {
 		return fmt.Errorf("failed to cherry-pick local commits onto remote: %w", err)
 	}
@@ -400,6 +420,15 @@ func fetchRefToTemp(ctx context.Context, repoPath, remote, srcRef, dstRef string
 		return fmt.Errorf("git fetch %s failed: %w", redactedURL, err)
 	}
 	return nil
+}
+
+// resolveRefHash reads the commit hash that a ref points to.
+func resolveRefHash(repo *git.Repository, refName string) (plumbing.Hash, error) {
+	ref, err := repo.Reference(plumbing.ReferenceName(refName), true)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("ref %s not found: %w", refName, err)
+	}
+	return ref.Hash(), nil
 }
 
 // cleanupTmpRef deletes the temporary ref used by doctor checks.

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -242,6 +242,100 @@ func IsV2MainDisconnected(ctx context.Context, repo *git.Repository, remote stri
 	return isDisconnected(ctx, repoPath, localRef.Hash().String(), remoteHash.String())
 }
 
+// ReconcileDisconnectedV2Ref detects and repairs disconnected local/remote
+// v2 /main refs. Same strategy as v1: cherry-pick local commits onto remote tip.
+// The remote is discovered via git ls-remote and fetched to a temp ref.
+//
+// remote is the git remote URL or path.
+func ReconcileDisconnectedV2Ref(
+	ctx context.Context,
+	repo *git.Repository,
+	remote string,
+	w io.Writer,
+) error {
+	refName := plumbing.ReferenceName(paths.V2MainRefName)
+
+	localRef, err := repo.Reference(refName, true)
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check local v2 /main ref: %w", err)
+	}
+
+	repoPath, err := getRepoPath(repo)
+	if err != nil {
+		return err
+	}
+
+	remoteHash, err := lsRemoteRef(ctx, repoPath, remote, paths.V2MainRefName)
+	if err != nil {
+		return fmt.Errorf("failed to ls-remote v2 /main: %w", err)
+	}
+	if remoteHash == plumbing.ZeroHash {
+		return nil
+	}
+
+	if localRef.Hash() == remoteHash {
+		return nil
+	}
+
+	if fetchErr := fetchRefToTemp(ctx, repoPath, remote, paths.V2MainRefName, v2DoctorTmpRef); fetchErr != nil {
+		return fmt.Errorf("failed to fetch remote v2 /main: %w", fetchErr)
+	}
+	defer cleanupTmpRef(repo)
+
+	disconnected, err := isDisconnected(ctx, repoPath, localRef.Hash().String(), remoteHash.String())
+	if err != nil {
+		return fmt.Errorf("failed to check v2 /main ancestry: %w", err)
+	}
+	if !disconnected {
+		return nil
+	}
+
+	fmt.Fprintln(w, "[entire] Detected disconnected v2 /main refs (local and remote share no common ancestor)")
+
+	localCommits, err := collectCommitChain(repo, localRef.Hash())
+	if err != nil {
+		return fmt.Errorf("failed to collect local commits: %w", err)
+	}
+
+	var dataCommits []*object.Commit
+	for _, c := range localCommits {
+		tree, treeErr := c.Tree()
+		if treeErr != nil {
+			return fmt.Errorf("failed to read tree for commit %s: %w", c.Hash.String()[:7], treeErr)
+		}
+		if len(tree.Entries) > 0 {
+			dataCommits = append(dataCommits, c)
+		}
+	}
+
+	if len(dataCommits) == 0 {
+		ref := plumbing.NewHashReference(refName, remoteHash)
+		if setErr := repo.Storer.SetReference(ref); setErr != nil {
+			return fmt.Errorf("failed to reset v2 /main to remote: %w", setErr)
+		}
+		fmt.Fprintln(w, "[entire] Done — local had no checkpoint data, reset to remote")
+		return nil
+	}
+
+	fmt.Fprintf(w, "[entire] Cherry-picking %d local checkpoint(s) onto remote...\n", len(dataCommits))
+
+	newTip, err := cherryPickOnto(ctx, repo, remoteHash, dataCommits)
+	if err != nil {
+		return fmt.Errorf("failed to cherry-pick local commits onto remote: %w", err)
+	}
+
+	ref := plumbing.NewHashReference(refName, newTip)
+	if setErr := repo.Storer.SetReference(ref); setErr != nil {
+		return fmt.Errorf("failed to update v2 /main ref: %w", setErr)
+	}
+
+	fmt.Fprintln(w, "[entire] Done — all local and remote checkpoints preserved")
+	return nil
+}
+
 // lsRemoteRef runs git ls-remote and returns the hash for a specific ref.
 // Returns plumbing.ZeroHash if the ref doesn't exist on the remote.
 func lsRemoteRef(ctx context.Context, repoPath, remote, refName string) (plumbing.Hash, error) {

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -193,6 +194,97 @@ func ReconcileDisconnectedMetadataBranch(
 
 	fmt.Fprintln(w, "[entire] Done — all local and remote checkpoints preserved")
 	return nil
+}
+
+// v2DoctorTmpRef is the temporary ref used by doctor to fetch and compare the remote v2 /main.
+const v2DoctorTmpRef = "refs/entire/tmp/doctor-v2-main"
+
+// IsV2MainDisconnected checks whether the local v2 /main ref and the remote
+// v2 /main ref exist but share no common ancestor. Uses git ls-remote to
+// discover the remote ref (custom refs don't have remote-tracking refs).
+//
+// remote is the git remote URL or path to check against.
+// Returns (false, nil) if either ref doesn't exist or they share ancestry.
+func IsV2MainDisconnected(ctx context.Context, repo *git.Repository, remote string) (bool, error) {
+	refName := plumbing.ReferenceName(paths.V2MainRefName)
+
+	localRef, err := repo.Reference(refName, true)
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to check local v2 /main ref: %w", err)
+	}
+
+	repoPath, err := getRepoPath(repo)
+	if err != nil {
+		return false, err
+	}
+
+	remoteHash, err := lsRemoteRef(ctx, repoPath, remote, paths.V2MainRefName)
+	if err != nil {
+		return false, fmt.Errorf("failed to ls-remote v2 /main: %w", err)
+	}
+	if remoteHash == plumbing.ZeroHash {
+		return false, nil // Remote doesn't have the ref
+	}
+
+	if localRef.Hash() == remoteHash {
+		return false, nil
+	}
+
+	// Fetch remote ref to temporary local ref for merge-base check
+	if fetchErr := fetchRefToTemp(ctx, repoPath, remote, paths.V2MainRefName, v2DoctorTmpRef); fetchErr != nil {
+		return false, fmt.Errorf("failed to fetch remote v2 /main: %w", fetchErr)
+	}
+	defer cleanupTmpRef(repo)
+
+	return isDisconnected(ctx, repoPath, localRef.Hash().String(), remoteHash.String())
+}
+
+// lsRemoteRef runs git ls-remote and returns the hash for a specific ref.
+// Returns plumbing.ZeroHash if the ref doesn't exist on the remote.
+func lsRemoteRef(ctx context.Context, repoPath, remote, refName string) (plumbing.Hash, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", remote, refName)
+	cmd.Dir = repoPath
+	output, err := cmd.Output()
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("git ls-remote failed: %w", err)
+	}
+
+	line := strings.TrimSpace(string(output))
+	if line == "" {
+		return plumbing.ZeroHash, nil
+	}
+
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return plumbing.ZeroHash, nil
+	}
+
+	return plumbing.NewHash(parts[0]), nil
+}
+
+// fetchRefToTemp fetches a remote ref to a temporary local ref for comparison.
+func fetchRefToTemp(ctx context.Context, repoPath, remote, srcRef, dstRef string) error {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	refspec := fmt.Sprintf("+%s:%s", srcRef, dstRef)
+	cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", remote, refspec)
+	cmd.Dir = repoPath
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git fetch failed: %s: %w", output, err)
+	}
+	return nil
+}
+
+// cleanupTmpRef deletes the temporary ref used by doctor checks.
+func cleanupTmpRef(repo *git.Repository) {
+	_ = repo.Storer.RemoveReference(plumbing.ReferenceName(v2DoctorTmpRef))
 }
 
 // isDisconnected checks if two commits have no common ancestor using git merge-base.

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -197,7 +197,8 @@ func ReconcileDisconnectedMetadataBranch(
 }
 
 // v2DoctorTmpRef is the temporary ref used by doctor to fetch and compare the remote v2 /main.
-const v2DoctorTmpRef = "refs/entire/tmp/doctor-v2-main"
+// Uses the refs/entire-fetch-tmp/ namespace consistent with checkpoint_remote.go.
+const v2DoctorTmpRef = "refs/entire-fetch-tmp/doctor-v2-main"
 
 // IsV2MainDisconnected checks whether the local v2 /main ref and the remote
 // v2 /main ref exist but share no common ancestor. Uses git ls-remote to

--- a/cmd/entire/cli/strategy/metadata_reconcile_test.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile_test.go
@@ -955,3 +955,71 @@ func TestIsV2MainDisconnected_SharedAncestry(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, disconnected, "diverged with shared ancestor should not be disconnected")
 }
+
+func TestReconcileDisconnectedV2Ref_CherryPicksOntoRemote(t *testing.T) {
+	t.Parallel()
+
+	bareDir := initBareWithV2MainRef(t)
+	cloneDir, _ := cloneWithConfig(t, bareDir)
+
+	// Create disconnected local v2 /main with different checkpoint data
+	repo, err := git.PlainOpen(cloneDir)
+	require.NoError(t, err)
+
+	localEntries := map[string]object.TreeEntry{
+		"cd/ef01234567/" + paths.MetadataFileName: {
+			Name: paths.MetadataFileName,
+			Mode: 0o100644,
+			Hash: createTestBlob(t, repo, `{"checkpoint_id":"cdef01234567"}`),
+		},
+	}
+	localTreeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, localEntries)
+	require.NoError(t, err)
+	localCommitHash, err := checkpoint.CreateCommit(repo, localTreeHash, plumbing.ZeroHash, "local checkpoint", "test", "test@test.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(paths.V2MainRefName), localCommitHash)))
+
+	// Verify disconnected
+	disconnected, err := IsV2MainDisconnected(context.Background(), repo, bareDir)
+	require.NoError(t, err)
+	require.True(t, disconnected, "setup: should be disconnected")
+
+	// Reconcile
+	var buf strings.Builder
+	err = ReconcileDisconnectedV2Ref(context.Background(), repo, bareDir, &buf)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Cherry-picking")
+	assert.Contains(t, buf.String(), "Done")
+
+	// After reconciliation, should no longer be disconnected
+	disconnected, err = IsV2MainDisconnected(context.Background(), repo, bareDir)
+	require.NoError(t, err)
+	assert.False(t, disconnected, "should be connected after reconciliation")
+
+	// Verify both remote and local checkpoint data exist in the tree
+	ref, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	require.NoError(t, err)
+	tipCommit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	tree, err := tipCommit.Tree()
+	require.NoError(t, err)
+	entries := make(map[string]object.TreeEntry)
+	require.NoError(t, checkpoint.FlattenTree(repo, tree, "", entries))
+
+	assert.Contains(t, entries, "ab/cdef012345/"+paths.MetadataFileName, "remote checkpoint should be preserved")
+	assert.Contains(t, entries, "cd/ef01234567/"+paths.MetadataFileName, "local checkpoint should be preserved")
+}
+
+func TestReconcileDisconnectedV2Ref_NoLocalRef(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	var buf strings.Builder
+	err = ReconcileDisconnectedV2Ref(context.Background(), repo, dir, &buf)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}

--- a/cmd/entire/cli/strategy/metadata_reconcile_test.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -769,4 +770,188 @@ func TestReconcileDisconnected_CherryPickDeletion(t *testing.T) {
 	assert.Contains(t, entries, "ab/cdef012345/metadata.json", "kept checkpoint should be present")
 	// Second local checkpoint should be deleted
 	assert.NotContains(t, entries, "cd/ef01234567/metadata.json", "deleted checkpoint should not be present")
+}
+
+// initBareWithV2MainRef creates a bare repo with a v2 /main custom ref containing
+// checkpoint data, plus a "main" branch so clones work. Returns the bare dir path.
+func initBareWithV2MainRef(t *testing.T) string {
+	t.Helper()
+	bareDir := t.TempDir()
+	workDir := t.TempDir()
+	run := func(dir string, args ...string) {
+		cmd := exec.CommandContext(context.Background(), "git", args...)
+		cmd.Dir = dir
+		cmd.Env = testutil.GitIsolatedEnv()
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run(bareDir, "init", "--bare", "-b", "main")
+	run(workDir, "clone", bareDir, ".")
+	run(workDir, "config", "user.email", "test@test.com")
+	run(workDir, "config", "user.name", "Test User")
+	run(workDir, "config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "README.md"), []byte("# Test"), 0o644))
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "init")
+	run(workDir, "push", "origin", "main")
+
+	// Create v2 /main ref with checkpoint data using go-git
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+
+	cpDir := "ab/cdef012345"
+	entries := map[string]object.TreeEntry{
+		cpDir + "/" + paths.MetadataFileName: {
+			Name: paths.MetadataFileName,
+			Mode: 0o100644,
+			Hash: createTestBlob(t, repo, `{"checkpoint_id":"abcdef012345"}`),
+		},
+	}
+	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, entries)
+	require.NoError(t, err)
+	commitHash, err := checkpoint.CreateCommit(repo, treeHash, plumbing.ZeroHash, "Checkpoint: abcdef012345", "test", "test@test.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(paths.V2MainRefName), commitHash)))
+
+	// Push the custom ref to bare
+	run(workDir, "push", "origin", paths.V2MainRefName+":"+paths.V2MainRefName)
+
+	return bareDir
+}
+
+// createTestBlob stores a string as a blob and returns its hash.
+func createTestBlob(t *testing.T, repo *git.Repository, content string) plumbing.Hash {
+	t.Helper()
+	obj := repo.Storer.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	hash, err := repo.Storer.SetEncodedObject(obj)
+	require.NoError(t, err)
+	return hash
+}
+
+func TestIsV2MainDisconnected_NoLocalRef(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	disconnected, err := IsV2MainDisconnected(context.Background(), repo, dir)
+	require.NoError(t, err)
+	assert.False(t, disconnected)
+}
+
+func TestIsV2MainDisconnected_NoRemoteRef(t *testing.T) {
+	t.Parallel()
+
+	bareDir := t.TempDir()
+	workDir := t.TempDir()
+	run := func(dir string, args ...string) {
+		cmd := exec.CommandContext(context.Background(), "git", args...)
+		cmd.Dir = dir
+		cmd.Env = testutil.GitIsolatedEnv()
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run(bareDir, "init", "--bare", "-b", "main")
+	run(workDir, "clone", bareDir, ".")
+	run(workDir, "config", "user.email", "test@test.com")
+	run(workDir, "config", "user.name", "Test User")
+	run(workDir, "config", "commit.gpgsign", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "README.md"), []byte("# Test"), 0o644))
+	run(workDir, "add", ".")
+	run(workDir, "commit", "-m", "init")
+	run(workDir, "push", "origin", "main")
+
+	// Create local v2 /main ref but don't push it
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+	emptyTree := &object.Tree{Entries: []object.TreeEntry{}}
+	treeObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, emptyTree.Encode(treeObj))
+	treeHash, err := repo.Storer.SetEncodedObject(treeObj)
+	require.NoError(t, err)
+	commitHash, err := checkpoint.CreateCommit(repo, treeHash, plumbing.ZeroHash, "init v2", "test", "test@test.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(paths.V2MainRefName), commitHash)))
+
+	disconnected, err := IsV2MainDisconnected(context.Background(), repo, bareDir)
+	require.NoError(t, err)
+	assert.False(t, disconnected, "should not be disconnected when remote doesn't have the ref")
+}
+
+func TestIsV2MainDisconnected_Disconnected(t *testing.T) {
+	t.Parallel()
+
+	bareDir := initBareWithV2MainRef(t)
+	cloneDir, _ := cloneWithConfig(t, bareDir)
+
+	// Create a disconnected local v2 /main ref (independent orphan)
+	repo, err := git.PlainOpen(cloneDir)
+	require.NoError(t, err)
+
+	localEntries := map[string]object.TreeEntry{
+		"cd/ef01234567/" + paths.MetadataFileName: {
+			Name: paths.MetadataFileName,
+			Mode: 0o100644,
+			Hash: createTestBlob(t, repo, `{"checkpoint_id":"cdef01234567"}`),
+		},
+	}
+	localTreeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, localEntries)
+	require.NoError(t, err)
+	localCommitHash, err := checkpoint.CreateCommit(repo, localTreeHash, plumbing.ZeroHash, "local checkpoint", "test", "test@test.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(paths.V2MainRefName), localCommitHash)))
+
+	disconnected, err := IsV2MainDisconnected(context.Background(), repo, bareDir)
+	require.NoError(t, err)
+	assert.True(t, disconnected, "independent orphan commits should be disconnected")
+}
+
+func TestIsV2MainDisconnected_SharedAncestry(t *testing.T) {
+	t.Parallel()
+
+	bareDir := initBareWithV2MainRef(t)
+	cloneDir, run := cloneWithConfig(t, bareDir)
+
+	// Fetch the v2 /main ref from remote
+	run("fetch", "origin", paths.V2MainRefName+":"+paths.V2MainRefName)
+
+	// Add a local commit on top (diverged but shared ancestry)
+	repo, err := git.PlainOpen(cloneDir)
+	require.NoError(t, err)
+
+	ref, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	require.NoError(t, err)
+	parentCommit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	parentTree, err := parentCommit.Tree()
+	require.NoError(t, err)
+
+	existing := make(map[string]object.TreeEntry)
+	require.NoError(t, checkpoint.FlattenTree(repo, parentTree, "", existing))
+	existing["ef/0123456789/"+paths.MetadataFileName] = object.TreeEntry{
+		Name: paths.MetadataFileName,
+		Mode: 0o100644,
+		Hash: createTestBlob(t, repo, `{"checkpoint_id":"ef0123456789"}`),
+	}
+	newTreeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, existing)
+	require.NoError(t, err)
+	newCommitHash, err := checkpoint.CreateCommit(repo, newTreeHash, ref.Hash(), "local checkpoint 2", "test", "test@test.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(paths.V2MainRefName), newCommitHash)))
+
+	disconnected, err := IsV2MainDisconnected(context.Background(), repo, bareDir)
+	require.NoError(t, err)
+	assert.False(t, disconnected, "diverged with shared ancestor should not be disconnected")
 }


### PR DESCRIPTION
## Summary

Implements task A13 from the [checkpoints v2 spec](docs/superpowers/specs/2026-03-19-checkpoints-v2-design.md): add v2 ref health checks to `entire doctor`.

The v2 checkpoint storage layout uses custom refs under `refs/entire/` instead of branches under `refs/heads/`. This means the existing v1 doctor checks (which operate on the `entire/checkpoints/v1` branch) don't cover v2 refs. This PR adds equivalent diagnostic and repair capabilities for v2, ensuring `entire doctor` can detect and fix the same classes of issues in both storage formats.

All v2 checks are gated behind `settings.IsCheckpointsV2Enabled` — they are completely skipped when the setting is off, even if v2 refs happen to exist locally.

### New checks (when `checkpoints_v2` is enabled)

**Disconnected v2 `/main` ref** — Detects when local and remote v2 `/main` refs share no common ancestor (the same class of bug that the v1 disconnected metadata branch check catches). Since custom refs don't have remote-tracking refs, discovery uses `git ls-remote` followed by a fetch to a temporary local ref for comparison. Reconciliation reuses the existing cherry-pick strategy from v1: local commits are cherry-picked onto the remote tip, preserving all checkpoint data from both sides. Respects the `checkpoint_remote` setting.

**v2 ref existence** — Verifies that `/main` and `/full/current` refs are consistent: both exist, or neither exists (normal for a fresh repo before first condensation). If only one exists, reports INCONSISTENT — this indicates a partial initialization or failed first condensation.

**v2 checkpoint count consistency** — Compares checkpoint shard counts between `/main` (permanent, accumulates all checkpoints) and `/full/current` (current generation only, resets on rotation). If `/full/current` has more checkpoints than `/main`, a dual-write partially failed.

**v2 generation health** — Validates archived `/full/*` generations: checks for valid `generation.json` with sane timestamps, non-empty checkpoint trees, and contiguous generation sequence numbers.

### Unchanged behavior

Stuck session condensation already dual-writes to v2 via `writeCommittedV2IfEnabled` when the setting is enabled — no changes needed for that path.

## Test plan

- [x] `mise run test:ci` passes (unit + integration + E2E canary)
- [x] `mise run lint` passes with zero issues
- [ ] Verify v2 checks are skipped when `checkpoints_v2` is not enabled
- [ ] Verify v2 checks run and report correctly when `checkpoints_v2` is enabled
- [ ] Verify `--force` auto-fixes disconnected v2 `/main` ref

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `doctor` diagnostics and an auto-repair flow that fetches and cherry-picks Git custom refs (`refs/entire/...`) using shell git commands, which could affect checkpoint ref state if bugs slip through.
> 
> **Overview**
> When `checkpoints_v2` is enabled, `entire doctor` now runs additional v2-specific health checks: detects/repairs disconnected `refs/entire/checkpoints/v2/main`, validates both v2 refs (`/main` and `/full/current`) exist consistently, compares checkpoint counts between those refs, and audits archived `/full/*` generations for valid `generation.json`, non-empty trees, sane timestamps, and sequence gaps.
> 
> To support disconnected v2 ref repair, strategy adds `IsV2MainDisconnected`/`ReconcileDisconnectedV2Ref`, which discover remote custom refs via `git ls-remote`, fetch them into a temporary ref, run `git merge-base` to detect disconnection, then cherry-pick local data commits onto the remote tip (skipping empty-tree commits) and clean up the temp ref.
> 
> `V2GitStore` generation readers were exported (`ReadGeneration*`), and extensive new unit/integration tests were added covering v2 doctor gating, ref consistency/count checks, generation health warnings, and v2 /main disconnection reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc421dcb06e0b8c22b92c2a2630f03f94d45039. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->