### PR TITLE
feat: preserve session linkage after git rewrites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,7 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 - **Worktree-specific branches** - each git worktree gets its own shadow branch namespace, preventing conflicts
 - **Supports multiple concurrent sessions** - checkpoints from different sessions in the same directory interleave on the same shadow branch
 - Condenses session logs to permanent `entire/checkpoints/v1` branch on user commits
+- Uses the `post-rewrite` Git hook to keep local session linkage aligned after amend/rebase rewrites
 - Builds git trees in-memory using go-git plumbing APIs
 - Rewind restores files from shadow branch commit tree (does not use `git reset`)
 - **Location-independent transcript resolution** - transcript paths are always computed dynamically from the current repo location (via `agent.GetSessionDir` + `agent.ResolveSessionFile`), never stored in checkpoint metadata. This ensures restore/rewind works after repo relocation or across machines.
@@ -374,7 +375,7 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 - `manual_commit_rewind.go` - Rewind implementation: file restoration from checkpoint trees
 - `manual_commit_git.go` - Git operations: checkpoint commits, tree building
 - `manual_commit_logs.go` - Session log retrieval and session listing
-- `manual_commit_hooks.go` - Git hook handlers (prepare-commit-msg, post-commit, pre-push)
+- `manual_commit_hooks.go` - Git hook handlers (prepare-commit-msg, post-commit, post-rewrite, pre-push)
 - `manual_commit_reset.go` - Shadow branch reset/cleanup functionality
 - `session_state.go` - Package-level session state functions (`LoadSessionState`, `SaveSessionState`, `ListSessionStates`, `FindMostRecentSession`)
 - `hooks.go` - Git hook installation

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -124,6 +124,7 @@ func newHooksGitCmd() *cobra.Command {
 	cmd.AddCommand(newHooksGitPrepareCommitMsgCmd())
 	cmd.AddCommand(newHooksGitCommitMsgCmd())
 	cmd.AddCommand(newHooksGitPostCommitCmd())
+	cmd.AddCommand(newHooksGitPostRewriteCmd())
 	cmd.AddCommand(newHooksGitPrePushCmd())
 
 	return cmd
@@ -195,6 +196,28 @@ func newHooksGitPostCommitCmd() *cobra.Command {
 			g.logInvoked()
 
 			hookErr := g.strategy.PostCommit(g.ctx)
+			g.logCompleted(hookErr)
+
+			return nil
+		},
+	}
+}
+
+func newHooksGitPostRewriteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "post-rewrite <rewrite-type>",
+		Short: "Handle post-rewrite git hook",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if gitHooksDisabled {
+				return nil
+			}
+
+			g := newGitHookContext(cmd.Context(), "post-rewrite")
+			defer g.span.End()
+			g.logInvoked(slog.String("rewrite_type", args[0]))
+
+			hookErr := g.strategy.PostRewrite(g.ctx, args[0], cmd.InOrStdin())
 			g.logCompleted(hookErr)
 
 			return nil

--- a/cmd/entire/cli/hooks_git_cmd_test.go
+++ b/cmd/entire/cli/hooks_git_cmd_test.go
@@ -245,3 +245,19 @@ func TestHooksGitCmd_DiscoverExternalAgents_WhenEnabled(t *testing.T) {
 		t.Errorf("expected external agent %q to be registered after hook pre-run, got: %v", agentName, err)
 	}
 }
+
+func TestHooksGitCmd_ExposesPostRewriteSubcommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := newHooksGitCmd()
+	found, _, err := cmd.Find([]string{"post-rewrite"})
+	if err != nil {
+		t.Fatalf("could not find post-rewrite subcommand: %v", err)
+	}
+	if found == nil {
+		t.Fatal("expected post-rewrite subcommand, got nil")
+	}
+	if found.Use != "post-rewrite <rewrite-type>" {
+		t.Fatalf("post-rewrite Use = %q, want %q", found.Use, "post-rewrite <rewrite-type>")
+	}
+}

--- a/cmd/entire/cli/integration_test/phase_transitions_test.go
+++ b/cmd/entire/cli/integration_test/phase_transitions_test.go
@@ -384,6 +384,62 @@ func TestShadow_PostRewriteAmendRemapsSessionState(t *testing.T) {
 	}
 }
 
+func TestShadow_PostRewriteAmendMigratesExistingShadowBranch(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+
+	sess := env.NewSession()
+	if err := env.SimulateUserPromptSubmit(sess.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+
+	env.WriteFile("main.go", "package main\n\nfunc main() {}\n")
+	sess.CreateTranscript("Create main.go", []FileChange{
+		{Path: "main.go", Content: "package main\n\nfunc main() {}\n"},
+	})
+	if err := env.SimulateStop(sess.ID, sess.TranscriptPath); err != nil {
+		t.Fatalf("SimulateStop failed: %v", err)
+	}
+
+	originalCommitHash := env.GetHeadHash()
+	originalShadowBranch := env.GetShadowBranchNameForCommit(originalCommitHash)
+	if !env.BranchExists(originalShadowBranch) {
+		t.Fatalf("expected original shadow branch %q to exist", originalShadowBranch)
+	}
+
+	env.GitCommitAmendWithShadowHooks("Initial commit (amended)")
+
+	amendedCommitHash := env.GetHeadHash()
+	if amendedCommitHash == originalCommitHash {
+		t.Fatal("Amended commit should have a different hash")
+	}
+
+	env.GitPostRewriteWithShadowHooks("amend", [2]string{originalCommitHash, amendedCommitHash})
+
+	newShadowBranch := env.GetShadowBranchNameForCommit(amendedCommitHash)
+	if !env.BranchExists(newShadowBranch) {
+		t.Fatalf("expected migrated shadow branch %q to exist", newShadowBranch)
+	}
+	if env.BranchExists(originalShadowBranch) {
+		t.Fatalf("expected original shadow branch %q to be removed", originalShadowBranch)
+	}
+
+	stateAfterRewrite, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState after post-rewrite failed: %v", err)
+	}
+	if stateAfterRewrite == nil {
+		t.Fatal("Session state should exist after post-rewrite")
+	}
+	if stateAfterRewrite.BaseCommit != amendedCommitHash {
+		t.Fatalf("BaseCommit after post-rewrite = %q, want %q", stateAfterRewrite.BaseCommit, amendedCommitHash)
+	}
+	if stateAfterRewrite.AttributionBaseCommit != originalCommitHash {
+		t.Fatalf("AttributionBaseCommit after post-rewrite = %q, want original %q when shadow branch migrates", stateAfterRewrite.AttributionBaseCommit, originalCommitHash)
+	}
+}
+
 func TestShadow_PostRewriteRebaseRemapsSessionState(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/integration_test/phase_transitions_test.go
+++ b/cmd/entire/cli/integration_test/phase_transitions_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -304,4 +305,167 @@ func TestShadow_AmendPreservesTrailer(t *testing.T) {
 	}
 
 	t.Log("AmendPreservesTrailer test completed successfully")
+}
+
+// TestShadow_PostRewriteAmendRemapsSessionState verifies that the git
+// post-rewrite hook updates local session linkage after an amend rewrites the
+// commit SHA.
+func TestShadow_PostRewriteAmendRemapsSessionState(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+
+	sess := env.NewSession()
+	if err := env.SimulateUserPromptSubmit(sess.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+
+	env.WriteFile("main.go", "package main\n\nfunc main() {}\n")
+	sess.CreateTranscript("Create main.go", []FileChange{
+		{Path: "main.go", Content: "package main\n\nfunc main() {}\n"},
+	})
+	if err := env.SimulateStop(sess.ID, sess.TranscriptPath); err != nil {
+		t.Fatalf("SimulateStop failed: %v", err)
+	}
+
+	env.GitCommitWithShadowHooks("Initial implementation", "main.go")
+
+	originalCommitHash := env.GetHeadHash()
+	originalCheckpointID := env.GetCheckpointIDFromCommitMessage(originalCommitHash)
+	if originalCheckpointID == "" {
+		t.Fatal("Original commit should have a checkpoint trailer")
+	}
+
+	stateBeforeAmend, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if stateBeforeAmend == nil {
+		t.Fatal("Session state should exist")
+	}
+	if stateBeforeAmend.BaseCommit != originalCommitHash {
+		t.Fatalf("BaseCommit before amend = %q, want %q", stateBeforeAmend.BaseCommit, originalCommitHash)
+	}
+
+	env.GitCommitAmendWithShadowHooks("Initial implementation (amended)")
+	amendedCommitHash := env.GetHeadHash()
+	if amendedCommitHash == originalCommitHash {
+		t.Fatal("Amended commit should have a different hash")
+	}
+
+	stateAfterAmend, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState after amend failed: %v", err)
+	}
+	if stateAfterAmend == nil {
+		t.Fatal("Session state should exist after amend")
+	}
+	if stateAfterAmend.BaseCommit != originalCommitHash {
+		t.Fatalf("BaseCommit after amend = %q, want original %q before post-rewrite", stateAfterAmend.BaseCommit, originalCommitHash)
+	}
+
+	env.GitPostRewriteWithShadowHooks("amend", [2]string{originalCommitHash, amendedCommitHash})
+
+	stateAfterRewrite, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState after post-rewrite failed: %v", err)
+	}
+	if stateAfterRewrite == nil {
+		t.Fatal("Session state should exist after post-rewrite")
+	}
+	if stateAfterRewrite.BaseCommit != amendedCommitHash {
+		t.Fatalf("BaseCommit after post-rewrite = %q, want %q", stateAfterRewrite.BaseCommit, amendedCommitHash)
+	}
+	if stateAfterRewrite.AttributionBaseCommit != amendedCommitHash {
+		t.Fatalf("AttributionBaseCommit after post-rewrite = %q, want %q", stateAfterRewrite.AttributionBaseCommit, amendedCommitHash)
+	}
+	if stateAfterRewrite.LastCheckpointID.String() != originalCheckpointID {
+		t.Fatalf("LastCheckpointID after post-rewrite = %q, want %q", stateAfterRewrite.LastCheckpointID.String(), originalCheckpointID)
+	}
+}
+
+func TestShadow_PostRewriteRebaseRemapsSessionState(t *testing.T) {
+	t.Parallel()
+
+	env := NewTestEnv(t)
+	defer env.Cleanup()
+
+	env.InitRepo()
+	env.WriteFile("README.md", "base\n")
+	env.GitAdd("README.md")
+	env.GitCommit("Initial commit")
+
+	env.GitCheckoutNewBranch("feature/post-rewrite-rebase")
+	env.InitEntire()
+
+	sess := env.NewSession()
+	if err := env.SimulateUserPromptSubmit(sess.ID); err != nil {
+		t.Fatalf("SimulateUserPromptSubmit failed: %v", err)
+	}
+
+	env.WriteFile("feature.txt", "feature work\n")
+	sess.CreateTranscript("Add feature file", []FileChange{
+		{Path: "feature.txt", Content: "feature work\n"},
+	})
+	if err := env.SimulateStop(sess.ID, sess.TranscriptPath); err != nil {
+		t.Fatalf("SimulateStop failed: %v", err)
+	}
+
+	env.GitCommitWithShadowHooks("Feature work", "feature.txt")
+	originalFeatureCommit := env.GetHeadHash()
+
+	stateBeforeRebase, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if stateBeforeRebase == nil {
+		t.Fatal("Session state should exist")
+	}
+	if stateBeforeRebase.BaseCommit != originalFeatureCommit {
+		t.Fatalf("BaseCommit before rebase = %q, want %q", stateBeforeRebase.BaseCommit, originalFeatureCommit)
+	}
+
+	env.gitCheckout("master")
+	env.WriteFile("upstream.txt", "upstream\n")
+	env.GitAdd("upstream.txt")
+	env.GitCommit("Upstream change")
+	env.gitCheckout("feature/post-rewrite-rebase")
+
+	cmd := exec.Command("git", "rebase", "master")
+	cmd.Dir = env.RepoDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git rebase failed: %v\nOutput: %s", err, output)
+	}
+
+	rebasedFeatureCommit := env.GetHeadHash()
+	if rebasedFeatureCommit == originalFeatureCommit {
+		t.Fatal("Rebased commit should have a different hash")
+	}
+
+	stateAfterRebase, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState after rebase failed: %v", err)
+	}
+	if stateAfterRebase == nil {
+		t.Fatal("Session state should exist after rebase")
+	}
+	if stateAfterRebase.BaseCommit != originalFeatureCommit {
+		t.Fatalf("BaseCommit after rebase = %q, want original %q before post-rewrite", stateAfterRebase.BaseCommit, originalFeatureCommit)
+	}
+
+	env.GitPostRewriteWithShadowHooks("rebase", [2]string{originalFeatureCommit, rebasedFeatureCommit})
+
+	stateAfterRewrite, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState after post-rewrite failed: %v", err)
+	}
+	if stateAfterRewrite == nil {
+		t.Fatal("Session state should exist after post-rewrite")
+	}
+	if stateAfterRewrite.BaseCommit != rebasedFeatureCommit {
+		t.Fatalf("BaseCommit after post-rewrite = %q, want %q", stateAfterRewrite.BaseCommit, rebasedFeatureCommit)
+	}
+	if stateAfterRewrite.AttributionBaseCommit != rebasedFeatureCommit {
+		t.Fatalf("AttributionBaseCommit after post-rewrite = %q, want %q", stateAfterRewrite.AttributionBaseCommit, rebasedFeatureCommit)
+	}
 }

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -1240,6 +1240,28 @@ func (env *TestEnv) GitCommitAmendWithShadowHooks(message string, files ...strin
 	}
 }
 
+// GitPostRewriteWithShadowHooks runs the git post-rewrite hook with the provided
+// old->new commit mappings. Each mapping is a pair of commit SHAs.
+func (env *TestEnv) GitPostRewriteWithShadowHooks(rewriteType string, mappings ...[2]string) {
+	env.T.Helper()
+
+	var input strings.Builder
+	for _, mapping := range mappings {
+		input.WriteString(mapping[0])
+		input.WriteByte(' ')
+		input.WriteString(mapping[1])
+		input.WriteByte('\n')
+	}
+
+	cmd := exec.Command(getTestBinary(), "hooks", "git", "post-rewrite", rewriteType)
+	cmd.Dir = env.RepoDir
+	cmd.Env = env.gitHookEnv()
+	cmd.Stdin = strings.NewReader(input.String())
+	if output, err := cmd.CombinedOutput(); err != nil {
+		env.T.Fatalf("post-rewrite hook failed: %v\nOutput: %s", err, output)
+	}
+}
+
 // GitCommitWithTrailerRemoved stages and commits files, simulating what happens when
 // a user removes the Entire-Checkpoint trailer during commit message editing.
 // This tests the opt-out behavior where removing the trailer skips condensation.

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -73,11 +73,11 @@ func TestPersistentPostRun_SkipsHiddenParent(t *testing.T) {
 
 	root := NewRootCmd()
 
-	// Find the leaf command: entire hooks git post-commit
+	// Find the leaf command: entire hooks git post-rewrite
 	// This exercises the real command tree where "hooks" is Hidden but its descendants are not.
-	leaf, _, err := root.Find([]string{"hooks", "git", "post-commit"})
+	leaf, _, err := root.Find([]string{"hooks", "git", "post-rewrite"})
 	if err != nil {
-		t.Fatalf("could not find hooks git post-commit command: %v", err)
+		t.Fatalf("could not find hooks git post-rewrite command: %v", err)
 	}
 
 	if leaf.Hidden {

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -342,12 +342,34 @@ func RemoveGitHook(ctx context.Context) (int, error) {
 // generateChainedContent appends a chain call to the base hook content,
 // so the pre-existing hook (backed up to .pre-entire) is called after our hook.
 func generateChainedContent(baseContent, hookName string) string {
+	if hookName == "post-rewrite" {
+		return generatePostRewriteChainedContent(baseContent)
+	}
+
 	return baseContent + fmt.Sprintf(`%s
 _entire_hook_dir="$(dirname "$0")"
 if [ -x "$_entire_hook_dir/%s%s" ]; then
     "$_entire_hook_dir/%s%s" "$@"
 fi
 `, chainComment, hookName, backupSuffix, hookName, backupSuffix)
+}
+
+func generatePostRewriteChainedContent(baseContent string) string {
+	const original = `entire hooks git post-rewrite "$1" 2>/dev/null || true`
+	const replacement = `entire hooks git post-rewrite "$1" < "$_entire_stdin" 2>/dev/null || true`
+
+	replayPrefix := `_entire_stdin="$(mktemp "${TMPDIR:-/tmp}/entire-post-rewrite.XXXXXX")"
+cat > "$_entire_stdin"
+trap 'rm -f "$_entire_stdin"' EXIT
+` + replacement
+
+	return strings.Replace(baseContent, original, replayPrefix, 1) + fmt.Sprintf(`
+%s
+_entire_hook_dir="$(dirname "$0")"
+if [ -x "$_entire_hook_dir/post-rewrite%s" ]; then
+    "$_entire_hook_dir/post-rewrite%s" "$@" < "$_entire_stdin"
+fi
+`, chainComment, backupSuffix, backupSuffix)
 }
 
 // hookCmdPrefix returns the command prefix for hook scripts and warning messages.

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -20,7 +20,7 @@ const backupSuffix = ".pre-entire"
 const chainComment = "# Chain: run pre-existing hook"
 
 // gitHookNames are the git hooks managed by Entire CLI
-var gitHookNames = []string{"prepare-commit-msg", "commit-msg", "post-commit", "pre-push"}
+var gitHookNames = []string{"prepare-commit-msg", "commit-msg", "post-commit", "post-rewrite", "pre-push"}
 
 // ManagedGitHookNames returns the list of git hooks managed by Entire CLI.
 // This is useful for tests that need to manipulate hooks.
@@ -188,6 +188,14 @@ func buildHookSpecs(cmdPrefix string) []hookSpec {
 # %s
 # Post-commit hook: condense session data if commit has Entire-Checkpoint trailer
 %s hooks git post-commit 2>/dev/null || true
+`, entireHookMarker, cmdPrefix),
+		},
+		{
+			name: "post-rewrite",
+			content: fmt.Sprintf(`#!/bin/sh
+# %s
+# Post-rewrite hook: remap session linkage after amend/rebase rewrites
+%s hooks git post-rewrite "$1" 2>/dev/null || true
 `, entireHookMarker, cmdPrefix),
 		},
 		{

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -926,6 +927,41 @@ func TestInstallGitHook_BacksUpCustomHook(t *testing.T) {
 	}
 	if !strings.Contains(hookContent, "prepare-commit-msg"+backupSuffix) {
 		t.Error("chain call should reference the backup file")
+	}
+}
+
+func TestManagedGitHookNames_IncludesPostRewrite(t *testing.T) {
+	t.Parallel()
+
+	names := ManagedGitHookNames()
+	if !slices.Contains(names, "post-rewrite") {
+		t.Fatalf("ManagedGitHookNames() = %v, want post-rewrite included", names)
+	}
+}
+
+func TestInstallGitHook_InstallsPostRewrite(t *testing.T) {
+	_, hooksDir := initHooksTestRepo(t)
+
+	count, err := InstallGitHook(context.Background(), true, false, false)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+	if count == 0 {
+		t.Fatal("InstallGitHook() should install hooks")
+	}
+
+	hookPath := filepath.Join(hooksDir, "post-rewrite")
+	hookData, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("post-rewrite hook should exist: %v", err)
+	}
+
+	hookContent := string(hookData)
+	if !strings.Contains(hookContent, entireHookMarker) {
+		t.Error("installed post-rewrite hook should contain Entire marker")
+	}
+	if !strings.Contains(hookContent, `entire hooks git post-rewrite "$1" 2>/dev/null || true`) {
+		t.Errorf("installed post-rewrite hook content missing expected command:\n%s", hookContent)
 	}
 }
 

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -1230,6 +1230,26 @@ func TestGenerateChainedContent(t *testing.T) {
 	}
 }
 
+func TestGenerateChainedContent_PostRewritePreservesStdinForBackup(t *testing.T) {
+	t.Parallel()
+
+	base := "#!/bin/sh\n# Entire CLI hooks\n# Post-rewrite hook: remap session linkage after amend/rebase rewrites\nentire hooks git post-rewrite \"$1\" 2>/dev/null || true\n"
+	result := generateChainedContent(base, "post-rewrite")
+
+	if !strings.Contains(result, `_entire_stdin="$(mktemp "${TMPDIR:-/tmp}/entire-post-rewrite.XXXXXX")"`) {
+		t.Fatalf("post-rewrite chained content should create temp stdin copy, got:\n%s", result)
+	}
+	if !strings.Contains(result, `cat > "$_entire_stdin"`) {
+		t.Fatalf("post-rewrite chained content should capture stdin once, got:\n%s", result)
+	}
+	if !strings.Contains(result, `entire hooks git post-rewrite "$1" < "$_entire_stdin" 2>/dev/null || true`) {
+		t.Fatalf("post-rewrite chained content should replay stdin into Entire handler, got:\n%s", result)
+	}
+	if !strings.Contains(result, `"$_entire_hook_dir/post-rewrite`+backupSuffix+`" "$@" < "$_entire_stdin"`) {
+		t.Fatalf("post-rewrite chained content should replay stdin into backup hook, got:\n%s", result)
+	}
+}
+
 func TestInstallGitHook_InstallRemoveReinstall(t *testing.T) {
 	_, hooksDir := initHooksTestRepo(t)
 

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -260,8 +260,21 @@ func (s *ManualCommitStrategy) PostRewrite(ctx context.Context, rewriteType stri
 		return nil //nolint:nilerr // Hook must be resilient
 	}
 
+	repo, err := OpenRepository(ctx)
+	if err != nil {
+		return nil //nolint:nilerr // Hook must be resilient
+	}
+
 	for _, state := range sessions {
-		if !remapSessionBaseCommit(state, rewrites) {
+		changed, err := s.remapSessionForRewrite(ctx, repo, state, rewrites)
+		if err != nil {
+			logging.Warn(logCtx, "post-rewrite: failed to remap session linkage",
+				slog.String("session_id", state.SessionID),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		if !changed {
 			continue
 		}
 		if err := s.saveSessionState(ctx, state); err != nil {
@@ -290,7 +303,7 @@ func parsePostRewritePairs(r io.Reader) ([]rewritePair, error) {
 			continue
 		}
 		fields := strings.Fields(line)
-		if len(fields) != 2 {
+		if len(fields) < 2 {
 			return nil, fmt.Errorf("invalid post-rewrite mapping line: %q", line)
 		}
 		pairs = append(pairs, rewritePair{
@@ -299,7 +312,7 @@ func parsePostRewritePairs(r io.Reader) ([]rewritePair, error) {
 		})
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("scan post-rewrite input: %w", err)
 	}
 	return pairs, nil
 }

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -230,6 +230,13 @@ func (s *ManualCommitStrategy) CommitMsg(_ context.Context, commitMsgFile string
 	return nil
 }
 
+// PostRewrite is called by the git post-rewrite hook after amend/rebase
+// operations. Task 1 wires the hook surface; rewrite remapping logic is added
+// in the follow-up implementation step.
+func (s *ManualCommitStrategy) PostRewrite(_ context.Context, _ string, _ io.Reader) error {
+	return nil
+}
+
 // hasUserContent checks if the message has any content besides comments and our trailer.
 func hasUserContent(message string) bool {
 	trailerPrefix := trailers.CheckpointTrailerKey + ":"

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -231,10 +231,77 @@ func (s *ManualCommitStrategy) CommitMsg(_ context.Context, commitMsgFile string
 }
 
 // PostRewrite is called by the git post-rewrite hook after amend/rebase
-// operations. Task 1 wires the hook surface; rewrite remapping logic is added
-// in the follow-up implementation step.
-func (s *ManualCommitStrategy) PostRewrite(_ context.Context, _ string, _ io.Reader) error {
+// operations. It keeps session linkage aligned with rewritten commit SHAs in
+// the current worktree.
+func (s *ManualCommitStrategy) PostRewrite(ctx context.Context, rewriteType string, r io.Reader) error {
+	logCtx := logging.WithComponent(ctx, "checkpoint")
+	if rewriteType != "amend" && rewriteType != "rebase" {
+		logging.Debug(logCtx, "post-rewrite: unsupported rewrite type, skipping",
+			slog.String("rewrite_type", rewriteType),
+		)
+		return nil
+	}
+
+	rewrites, err := parsePostRewritePairs(r)
+	if err != nil {
+		return err
+	}
+	if len(rewrites) == 0 {
+		return nil
+	}
+
+	worktreePath, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return nil //nolint:nilerr // Hook must be resilient
+	}
+
+	sessions, err := s.findSessionsForWorktree(ctx, worktreePath)
+	if err != nil || len(sessions) == 0 {
+		return nil //nolint:nilerr // Hook must be resilient
+	}
+
+	for _, state := range sessions {
+		if !remapSessionBaseCommit(state, rewrites) {
+			continue
+		}
+		if err := s.saveSessionState(ctx, state); err != nil {
+			logging.Warn(logCtx, "post-rewrite: failed to save remapped session state",
+				slog.String("session_id", state.SessionID),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		logging.Info(logCtx, "post-rewrite: remapped session linkage",
+			slog.String("session_id", state.SessionID),
+			slog.String("rewrite_type", rewriteType),
+			slog.String("base_commit", truncateHash(state.BaseCommit)),
+		)
+	}
+
 	return nil
+}
+
+func parsePostRewritePairs(r io.Reader) ([]rewritePair, error) {
+	scanner := bufio.NewScanner(r)
+	var pairs []rewritePair
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("invalid post-rewrite mapping line: %q", line)
+		}
+		pairs = append(pairs, rewritePair{
+			OldSHA: fields[0],
+			NewSHA: fields[1],
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return pairs, nil
 }
 
 // hasUserContent checks if the message has any content besides comments and our trailer.

--- a/cmd/entire/cli/strategy/manual_commit_migration.go
+++ b/cmd/entire/cli/strategy/manual_commit_migration.go
@@ -35,14 +35,28 @@ func (s *ManualCommitStrategy) migrateShadowBranchIfNeeded(ctx context.Context, 
 		return false, nil // No migration needed
 	}
 
-	// HEAD changed - check if old shadow branch exists and migrate it
+	return s.migrateShadowBranchToBaseCommit(ctx, repo, state, currentHead)
+}
+
+// migrateShadowBranchToBaseCommit moves the current session's shadow branch to a
+// new base commit-derived name and updates state.BaseCommit. It returns whether
+// an existing shadow branch ref had to be migrated.
+func (s *ManualCommitStrategy) migrateShadowBranchToBaseCommit(ctx context.Context, repo *git.Repository, state *SessionState, newBaseCommit string) (bool, error) {
+	if state == nil || state.BaseCommit == "" || newBaseCommit == "" {
+		return false, nil
+	}
+	if state.BaseCommit == newBaseCommit {
+		return false, nil
+	}
+
+	// Base commit changed - check if old shadow branch exists and migrate it
 	oldShadowBranch := checkpoint.ShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
-	newShadowBranch := checkpoint.ShadowBranchNameForCommit(currentHead, state.WorktreeID)
+	newShadowBranch := checkpoint.ShadowBranchNameForCommit(newBaseCommit, state.WorktreeID)
 
 	// Guard against hash prefix collision: if both commits produce the same
 	// shadow branch name (same 7-char prefix), just update state - no ref rename needed
 	if oldShadowBranch == newShadowBranch {
-		state.BaseCommit = currentHead
+		state.BaseCommit = newBaseCommit
 		return true, nil
 	}
 
@@ -51,10 +65,10 @@ func (s *ManualCommitStrategy) migrateShadowBranchIfNeeded(ctx context.Context, 
 	if err != nil {
 		// Old shadow branch doesn't exist - just update state.BaseCommit
 		// This can happen if this is the first checkpoint after HEAD changed
-		state.BaseCommit = currentHead
-		logging.Info(logging.WithComponent(ctx, "migration"), "updated session base commit (HEAD changed during session)",
-			slog.String("new_base", currentHead[:7]))
-		return true, nil //nolint:nilerr // err is "reference not found" which is fine - just need to update state
+		state.BaseCommit = newBaseCommit
+		logging.Info(logging.WithComponent(ctx, "migration"), "updated session base commit",
+			slog.String("new_base", newBaseCommit[:7]))
+		return false, nil //nolint:nilerr // err is "reference not found" which is fine - just need to update state
 	}
 
 	// Old shadow branch exists - move it to new base commit
@@ -84,7 +98,7 @@ func (s *ManualCommitStrategy) migrateShadowBranchIfNeeded(ctx context.Context, 
 	// renames the shadow branch but its checkpoint trees are still relative to
 	// the original base. Attribution must diff from that original base to
 	// correctly measure agent work captured in those checkpoints.
-	state.BaseCommit = currentHead
+	state.BaseCommit = newBaseCommit
 	return true, nil
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_migration.go
+++ b/cmd/entire/cli/strategy/manual_commit_migration.go
@@ -68,7 +68,7 @@ func (s *ManualCommitStrategy) migrateShadowBranchToBaseCommit(ctx context.Conte
 		state.BaseCommit = newBaseCommit
 		logging.Info(logging.WithComponent(ctx, "migration"), "updated session base commit",
 			slog.String("new_base", newBaseCommit[:7]))
-		return false, nil //nolint:nilerr // err is "reference not found" which is fine - just need to update state
+		return true, nil //nolint:nilerr // err is "reference not found" which is fine - just need to update state
 	}
 
 	// Old shadow branch exists - move it to new base commit

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -162,6 +162,16 @@ func remapRewriteSHA(sha string, rewrites []rewritePair) (string, bool) {
 	return sha, false
 }
 
+func shadowBranchExistsForBaseCommit(repo *git.Repository, baseCommit, worktreeID string) bool {
+	if repo == nil || baseCommit == "" {
+		return false
+	}
+
+	refName := plumbing.NewBranchReferenceName(checkpoint.ShadowBranchNameForCommit(baseCommit, worktreeID))
+	_, err := repo.Reference(refName, true)
+	return err == nil
+}
+
 func (s *ManualCommitStrategy) remapSessionForRewrite(ctx context.Context, repo *git.Repository, state *SessionState, rewrites []rewritePair) (bool, error) {
 	if state == nil {
 		return false, nil
@@ -173,24 +183,24 @@ func (s *ManualCommitStrategy) remapSessionForRewrite(ctx context.Context, repo 
 		return false, nil
 	}
 
-	shadowBranchMigrated := false
+	hadShadowBranch := shadowBranchExistsForBaseCommit(repo, state.BaseCommit, state.WorktreeID)
 	if baseChanged {
-		var err error
-		shadowBranchMigrated, err = s.migrateShadowBranchToBaseCommit(ctx, repo, state, newBaseCommit)
+		changed, err := s.migrateShadowBranchToBaseCommit(ctx, repo, state, newBaseCommit)
 		if err != nil {
 			return false, fmt.Errorf("failed to migrate rewritten shadow branch: %w", err)
 		}
+		baseChanged = changed
 	}
 
 	// If a shadow branch existed, preserve AttributionBaseCommit so future
 	// attribution still diffs against the original checkpoint base captured on
 	// that branch. Without a shadow branch, keep attribution in sync with the
 	// rewritten commit lineage.
-	if attrChanged && !shadowBranchMigrated {
+	if attrChanged && !hadShadowBranch {
 		state.AttributionBaseCommit = newAttrBaseCommit
 	}
 
-	return true, nil
+	return baseChanged || attrChanged, nil
 }
 
 // findSessionsForCommit finds all sessions where base_commit matches the given SHA.

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -148,6 +148,26 @@ func (s *ManualCommitStrategy) findSessionsForWorktree(ctx context.Context, work
 	return matching, nil
 }
 
+type rewritePair struct {
+	OldSHA string
+	NewSHA string
+}
+
+func remapSessionBaseCommit(state *SessionState, rewrites []rewritePair) bool {
+	changed := false
+	for _, pair := range rewrites {
+		if state.BaseCommit == pair.OldSHA {
+			state.BaseCommit = pair.NewSHA
+			changed = true
+		}
+		if state.AttributionBaseCommit == pair.OldSHA {
+			state.AttributionBaseCommit = pair.NewSHA
+			changed = true
+		}
+	}
+	return changed
+}
+
 // findSessionsForCommit finds all sessions where base_commit matches the given SHA.
 func (s *ManualCommitStrategy) findSessionsForCommit(ctx context.Context, baseCommitSHA string) ([]*SessionState, error) {
 	allStates, err := s.listAllSessionStates(ctx)

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -153,19 +153,44 @@ type rewritePair struct {
 	NewSHA string
 }
 
-func remapSessionBaseCommit(state *SessionState, rewrites []rewritePair) bool {
-	changed := false
+func remapRewriteSHA(sha string, rewrites []rewritePair) (string, bool) {
 	for _, pair := range rewrites {
-		if state.BaseCommit == pair.OldSHA {
-			state.BaseCommit = pair.NewSHA
-			changed = true
-		}
-		if state.AttributionBaseCommit == pair.OldSHA {
-			state.AttributionBaseCommit = pair.NewSHA
-			changed = true
+		if sha == pair.OldSHA {
+			return pair.NewSHA, true
 		}
 	}
-	return changed
+	return sha, false
+}
+
+func (s *ManualCommitStrategy) remapSessionForRewrite(ctx context.Context, repo *git.Repository, state *SessionState, rewrites []rewritePair) (bool, error) {
+	if state == nil {
+		return false, nil
+	}
+
+	newBaseCommit, baseChanged := remapRewriteSHA(state.BaseCommit, rewrites)
+	newAttrBaseCommit, attrChanged := remapRewriteSHA(state.AttributionBaseCommit, rewrites)
+	if !baseChanged && !attrChanged {
+		return false, nil
+	}
+
+	shadowBranchMigrated := false
+	if baseChanged {
+		var err error
+		shadowBranchMigrated, err = s.migrateShadowBranchToBaseCommit(ctx, repo, state, newBaseCommit)
+		if err != nil {
+			return false, fmt.Errorf("failed to migrate rewritten shadow branch: %w", err)
+		}
+	}
+
+	// If a shadow branch existed, preserve AttributionBaseCommit so future
+	// attribution still diffs against the original checkpoint base captured on
+	// that branch. Without a shadow branch, keep attribution in sync with the
+	// rewritten commit lineage.
+	if attrChanged && !shadowBranchMigrated {
+		state.AttributionBaseCommit = newAttrBaseCommit
+	}
+
+	return true, nil
 }
 
 // findSessionsForCommit finds all sessions where base_commit matches the given SHA.

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -1658,6 +1658,64 @@ func TestShadowStrategy_PostRewrite_MigratesExistingShadowBranch(t *testing.T) {
 	}
 }
 
+func TestShadowStrategy_MigrateAndPersistIfNeeded_PersistsBaseCommitWithoutShadowBranch(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "tracked.txt", "one\n")
+	testutil.GitAdd(t, dir, "tracked.txt")
+	testutil.GitCommit(t, dir, "initial")
+	t.Chdir(dir)
+
+	repo, err := OpenRepository(context.Background())
+	if err != nil {
+		t.Fatalf("OpenRepository() error = %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("Head() error = %v", err)
+	}
+	oldBaseCommit := head.Hash().String()
+
+	testutil.WriteFile(t, dir, "tracked.txt", "two\n")
+	testutil.GitAdd(t, dir, "tracked.txt")
+	testutil.GitCommit(t, dir, "second")
+	head, err = repo.Head()
+	if err != nil {
+		t.Fatalf("Head() after second commit error = %v", err)
+	}
+	newBaseCommit := head.Hash().String()
+
+	worktreePath, err := paths.WorktreeRoot(context.Background())
+	if err != nil {
+		t.Fatalf("WorktreeRoot() error = %v", err)
+	}
+
+	s := &ManualCommitStrategy{}
+	state := &SessionState{
+		SessionID:             "session-1",
+		BaseCommit:            oldBaseCommit,
+		AttributionBaseCommit: oldBaseCommit,
+		WorktreePath:          worktreePath,
+		StartedAt:             time.Now(),
+		LastCheckpointID:      testTrailerCheckpointID,
+	}
+	if err := s.saveSessionState(context.Background(), state); err != nil {
+		t.Fatalf("saveSessionState() error = %v", err)
+	}
+
+	if err := s.migrateAndPersistIfNeeded(context.Background(), repo, state); err != nil {
+		t.Fatalf("migrateAndPersistIfNeeded() error = %v", err)
+	}
+
+	loaded, err := s.loadSessionState(context.Background(), state.SessionID)
+	if err != nil {
+		t.Fatalf("loadSessionState() error = %v", err)
+	}
+	if loaded.BaseCommit != newBaseCommit {
+		t.Fatalf("BaseCommit = %q, want %q", loaded.BaseCommit, newBaseCommit)
+	}
+}
+
 func TestShadowStrategy_PostRewrite_DoesNotTouchOtherWorktrees(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -1480,7 +1480,7 @@ func TestShadowStrategy_PrepareCommitMsg_ReusesLastCheckpointID(t *testing.T) {
 		StartedAt:                 time.Now(),
 		StepCount:                 1,
 		CheckpointTranscriptStart: 10, // Already condensed
-		LastCheckpointID:          "abc123def456",
+		LastCheckpointID:          testTrailerCheckpointID,
 	}
 	if err := s.saveSessionState(context.Background(), state); err != nil {
 		t.Fatalf("saveSessionState() error = %v", err)
@@ -1495,8 +1495,8 @@ func TestShadowStrategy_PrepareCommitMsg_ReusesLastCheckpointID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadSessionState() error = %v", err)
 	}
-	if loaded.LastCheckpointID != "abc123def456" {
-		t.Errorf("LastCheckpointID = %q, want %q", loaded.LastCheckpointID, "abc123def456")
+	if loaded.LastCheckpointID != testTrailerCheckpointID {
+		t.Errorf("LastCheckpointID = %q, want %q", loaded.LastCheckpointID, testTrailerCheckpointID)
 	}
 }
 
@@ -1516,6 +1516,19 @@ func TestParsePostRewritePairs(t *testing.T) {
 	}
 }
 
+func TestParsePostRewritePairs_AllowsOptionalExtraField(t *testing.T) {
+	pairs, err := parsePostRewritePairs(strings.NewReader("oldsha newsha extra-info\n"))
+	if err != nil {
+		t.Fatalf("parsePostRewritePairs() error = %v", err)
+	}
+	if len(pairs) != 1 {
+		t.Fatalf("len(pairs) = %d, want 1", len(pairs))
+	}
+	if pairs[0].OldSHA != "oldsha" || pairs[0].NewSHA != "newsha" {
+		t.Fatalf("pairs[0] = %+v, want oldsha->newsha", pairs[0])
+	}
+}
+
 func TestParsePostRewritePairs_InvalidLine(t *testing.T) {
 	_, err := parsePostRewritePairs(strings.NewReader("missing-second-column\n"))
 	if err == nil {
@@ -1527,6 +1540,8 @@ func TestShadowStrategy_PostRewrite_RemapsMatchingSessionInWorktree(t *testing.T
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	t.Chdir(dir)
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
 	worktreePath, err := paths.WorktreeRoot(context.Background())
 	if err != nil {
 		t.Fatalf("WorktreeRoot() error = %v", err)
@@ -1535,17 +1550,17 @@ func TestShadowStrategy_PostRewrite_RemapsMatchingSessionInWorktree(t *testing.T
 	s := &ManualCommitStrategy{}
 	state := &SessionState{
 		SessionID:             "session-1",
-		BaseCommit:            "oldsha",
-		AttributionBaseCommit: "oldsha",
+		BaseCommit:            oldSHA,
+		AttributionBaseCommit: oldSHA,
 		WorktreePath:          worktreePath,
 		StartedAt:             time.Now(),
-		LastCheckpointID:      "abc123def456",
+		LastCheckpointID:      testTrailerCheckpointID,
 	}
 	if err := s.saveSessionState(context.Background(), state); err != nil {
 		t.Fatalf("saveSessionState() error = %v", err)
 	}
 
-	if err := s.PostRewrite(context.Background(), "amend", strings.NewReader("oldsha newsha\n")); err != nil {
+	if err := s.PostRewrite(context.Background(), "amend", strings.NewReader(oldSHA+" "+newSHA+"\n")); err != nil {
 		t.Fatalf("PostRewrite() error = %v", err)
 	}
 
@@ -1553,14 +1568,93 @@ func TestShadowStrategy_PostRewrite_RemapsMatchingSessionInWorktree(t *testing.T
 	if err != nil {
 		t.Fatalf("loadSessionState() error = %v", err)
 	}
-	if loaded.BaseCommit != "newsha" {
-		t.Fatalf("BaseCommit = %q, want %q", loaded.BaseCommit, "newsha")
+	if loaded.BaseCommit != newSHA {
+		t.Fatalf("BaseCommit = %q, want %q", loaded.BaseCommit, newSHA)
 	}
-	if loaded.AttributionBaseCommit != "newsha" {
-		t.Fatalf("AttributionBaseCommit = %q, want %q", loaded.AttributionBaseCommit, "newsha")
+	if loaded.AttributionBaseCommit != newSHA {
+		t.Fatalf("AttributionBaseCommit = %q, want %q", loaded.AttributionBaseCommit, newSHA)
 	}
-	if loaded.LastCheckpointID != "abc123def456" {
-		t.Fatalf("LastCheckpointID = %q, want %q", loaded.LastCheckpointID, "abc123def456")
+	if loaded.LastCheckpointID != testTrailerCheckpointID {
+		t.Fatalf("LastCheckpointID = %q, want %q", loaded.LastCheckpointID, testTrailerCheckpointID)
+	}
+}
+
+func TestShadowStrategy_PostRewrite_MigratesExistingShadowBranch(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "tracked.txt", "one\n")
+	testutil.GitAdd(t, dir, "tracked.txt")
+	testutil.GitCommit(t, dir, "initial")
+	t.Chdir(dir)
+
+	repo, err := OpenRepository(context.Background())
+	if err != nil {
+		t.Fatalf("OpenRepository() error = %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("Head() error = %v", err)
+	}
+	oldBaseCommit := head.Hash().String()
+
+	testutil.WriteFile(t, dir, "tracked.txt", "two\n")
+	testutil.GitAdd(t, dir, "tracked.txt")
+	testutil.GitCommit(t, dir, "second")
+	head, err = repo.Head()
+	if err != nil {
+		t.Fatalf("Head() after second commit error = %v", err)
+	}
+	newBaseCommit := head.Hash().String()
+
+	worktreePath, err := paths.WorktreeRoot(context.Background())
+	if err != nil {
+		t.Fatalf("WorktreeRoot() error = %v", err)
+	}
+	worktreeID, err := paths.GetWorktreeID(worktreePath)
+	if err != nil {
+		t.Fatalf("GetWorktreeID() error = %v", err)
+	}
+
+	oldShadowBranch := checkpoint.ShadowBranchNameForCommit(oldBaseCommit, worktreeID)
+	newShadowBranch := checkpoint.ShadowBranchNameForCommit(newBaseCommit, worktreeID)
+	oldShadowRef := plumbing.NewHashReference(plumbing.NewBranchReferenceName(oldShadowBranch), plumbing.NewHash(oldBaseCommit))
+	if err := repo.Storer.SetReference(oldShadowRef); err != nil {
+		t.Fatalf("SetReference(old shadow) error = %v", err)
+	}
+
+	s := &ManualCommitStrategy{}
+	state := &SessionState{
+		SessionID:             "session-1",
+		BaseCommit:            oldBaseCommit,
+		AttributionBaseCommit: oldBaseCommit,
+		WorktreePath:          worktreePath,
+		WorktreeID:            worktreeID,
+		StartedAt:             time.Now(),
+		LastCheckpointID:      testTrailerCheckpointID,
+	}
+	if err := s.saveSessionState(context.Background(), state); err != nil {
+		t.Fatalf("saveSessionState() error = %v", err)
+	}
+
+	if err := s.PostRewrite(context.Background(), "amend", strings.NewReader(oldBaseCommit+" "+newBaseCommit+" extra\n")); err != nil {
+		t.Fatalf("PostRewrite() error = %v", err)
+	}
+
+	loaded, err := s.loadSessionState(context.Background(), state.SessionID)
+	if err != nil {
+		t.Fatalf("loadSessionState() error = %v", err)
+	}
+	if loaded.BaseCommit != newBaseCommit {
+		t.Fatalf("BaseCommit = %q, want %q", loaded.BaseCommit, newBaseCommit)
+	}
+	if loaded.AttributionBaseCommit != oldBaseCommit {
+		t.Fatalf("AttributionBaseCommit = %q, want original %q when shadow branch migrates", loaded.AttributionBaseCommit, oldBaseCommit)
+	}
+	if !referenceExists(t, repo, plumbing.NewBranchReferenceName(newShadowBranch)) {
+		t.Fatalf("expected migrated shadow branch %q to exist", newShadowBranch)
+	}
+	if referenceExists(t, repo, plumbing.NewBranchReferenceName(oldShadowBranch)) {
+		t.Fatalf("expected old shadow branch %q to be removed", oldShadowBranch)
 	}
 }
 
@@ -1568,21 +1662,23 @@ func TestShadowStrategy_PostRewrite_DoesNotTouchOtherWorktrees(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	t.Chdir(dir)
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
 
 	s := &ManualCommitStrategy{}
 	other := &SessionState{
 		SessionID:             "other-worktree",
-		BaseCommit:            "oldsha",
-		AttributionBaseCommit: "oldsha",
+		BaseCommit:            oldSHA,
+		AttributionBaseCommit: oldSHA,
 		WorktreePath:          filepath.Join(dir, "other"),
 		StartedAt:             time.Now(),
-		LastCheckpointID:      "abc123def456",
+		LastCheckpointID:      testTrailerCheckpointID,
 	}
 	if err := s.saveSessionState(context.Background(), other); err != nil {
 		t.Fatalf("saveSessionState() error = %v", err)
 	}
 
-	if err := s.PostRewrite(context.Background(), "amend", strings.NewReader("oldsha newsha\n")); err != nil {
+	if err := s.PostRewrite(context.Background(), "amend", strings.NewReader(oldSHA+" "+newSHA+"\n")); err != nil {
 		t.Fatalf("PostRewrite() error = %v", err)
 	}
 
@@ -1590,15 +1686,22 @@ func TestShadowStrategy_PostRewrite_DoesNotTouchOtherWorktrees(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadSessionState() error = %v", err)
 	}
-	if loaded.BaseCommit != "oldsha" {
-		t.Fatalf("BaseCommit = %q, want %q", loaded.BaseCommit, "oldsha")
+	if loaded.BaseCommit != oldSHA {
+		t.Fatalf("BaseCommit = %q, want %q", loaded.BaseCommit, oldSHA)
 	}
-	if loaded.AttributionBaseCommit != "oldsha" {
-		t.Fatalf("AttributionBaseCommit = %q, want %q", loaded.AttributionBaseCommit, "oldsha")
+	if loaded.AttributionBaseCommit != oldSHA {
+		t.Fatalf("AttributionBaseCommit = %q, want %q", loaded.AttributionBaseCommit, oldSHA)
 	}
-	if loaded.LastCheckpointID != "abc123def456" {
-		t.Fatalf("LastCheckpointID = %q, want %q", loaded.LastCheckpointID, "abc123def456")
+	if loaded.LastCheckpointID != testTrailerCheckpointID {
+		t.Fatalf("LastCheckpointID = %q, want %q", loaded.LastCheckpointID, testTrailerCheckpointID)
 	}
+}
+
+func referenceExists(t *testing.T, repo *git.Repository, refName plumbing.ReferenceName) bool {
+	t.Helper()
+
+	_, err := repo.Reference(refName, true)
+	return err == nil
 }
 
 // TestShadowStrategy_CondenseSession_EphemeralBranchTrailer verifies that checkpoint commits

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -1500,6 +1500,107 @@ func TestShadowStrategy_PrepareCommitMsg_ReusesLastCheckpointID(t *testing.T) {
 	}
 }
 
+func TestParsePostRewritePairs(t *testing.T) {
+	pairs, err := parsePostRewritePairs(strings.NewReader("oldsha newsha\n\nold2 new2\n"))
+	if err != nil {
+		t.Fatalf("parsePostRewritePairs() error = %v", err)
+	}
+	if len(pairs) != 2 {
+		t.Fatalf("len(pairs) = %d, want 2", len(pairs))
+	}
+	if pairs[0].OldSHA != "oldsha" || pairs[0].NewSHA != "newsha" {
+		t.Fatalf("pairs[0] = %+v, want oldsha->newsha", pairs[0])
+	}
+	if pairs[1].OldSHA != "old2" || pairs[1].NewSHA != "new2" {
+		t.Fatalf("pairs[1] = %+v, want old2->new2", pairs[1])
+	}
+}
+
+func TestParsePostRewritePairs_InvalidLine(t *testing.T) {
+	_, err := parsePostRewritePairs(strings.NewReader("missing-second-column\n"))
+	if err == nil {
+		t.Fatal("parsePostRewritePairs() error = nil, want error")
+	}
+}
+
+func TestShadowStrategy_PostRewrite_RemapsMatchingSessionInWorktree(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+	worktreePath, err := paths.WorktreeRoot(context.Background())
+	if err != nil {
+		t.Fatalf("WorktreeRoot() error = %v", err)
+	}
+
+	s := &ManualCommitStrategy{}
+	state := &SessionState{
+		SessionID:             "session-1",
+		BaseCommit:            "oldsha",
+		AttributionBaseCommit: "oldsha",
+		WorktreePath:          worktreePath,
+		StartedAt:             time.Now(),
+		LastCheckpointID:      "abc123def456",
+	}
+	if err := s.saveSessionState(context.Background(), state); err != nil {
+		t.Fatalf("saveSessionState() error = %v", err)
+	}
+
+	if err := s.PostRewrite(context.Background(), "amend", strings.NewReader("oldsha newsha\n")); err != nil {
+		t.Fatalf("PostRewrite() error = %v", err)
+	}
+
+	loaded, err := s.loadSessionState(context.Background(), state.SessionID)
+	if err != nil {
+		t.Fatalf("loadSessionState() error = %v", err)
+	}
+	if loaded.BaseCommit != "newsha" {
+		t.Fatalf("BaseCommit = %q, want %q", loaded.BaseCommit, "newsha")
+	}
+	if loaded.AttributionBaseCommit != "newsha" {
+		t.Fatalf("AttributionBaseCommit = %q, want %q", loaded.AttributionBaseCommit, "newsha")
+	}
+	if loaded.LastCheckpointID != "abc123def456" {
+		t.Fatalf("LastCheckpointID = %q, want %q", loaded.LastCheckpointID, "abc123def456")
+	}
+}
+
+func TestShadowStrategy_PostRewrite_DoesNotTouchOtherWorktrees(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	s := &ManualCommitStrategy{}
+	other := &SessionState{
+		SessionID:             "other-worktree",
+		BaseCommit:            "oldsha",
+		AttributionBaseCommit: "oldsha",
+		WorktreePath:          filepath.Join(dir, "other"),
+		StartedAt:             time.Now(),
+		LastCheckpointID:      "abc123def456",
+	}
+	if err := s.saveSessionState(context.Background(), other); err != nil {
+		t.Fatalf("saveSessionState() error = %v", err)
+	}
+
+	if err := s.PostRewrite(context.Background(), "amend", strings.NewReader("oldsha newsha\n")); err != nil {
+		t.Fatalf("PostRewrite() error = %v", err)
+	}
+
+	loaded, err := s.loadSessionState(context.Background(), other.SessionID)
+	if err != nil {
+		t.Fatalf("loadSessionState() error = %v", err)
+	}
+	if loaded.BaseCommit != "oldsha" {
+		t.Fatalf("BaseCommit = %q, want %q", loaded.BaseCommit, "oldsha")
+	}
+	if loaded.AttributionBaseCommit != "oldsha" {
+		t.Fatalf("AttributionBaseCommit = %q, want %q", loaded.AttributionBaseCommit, "oldsha")
+	}
+	if loaded.LastCheckpointID != "abc123def456" {
+		t.Fatalf("LastCheckpointID = %q, want %q", loaded.LastCheckpointID, "abc123def456")
+	}
+}
+
 // TestShadowStrategy_CondenseSession_EphemeralBranchTrailer verifies that checkpoint commits
 // on the entire/checkpoints/v1 branch include the Ephemeral-branch trailer indicating which shadow
 // branch the checkpoint originated from.


### PR DESCRIPTION
## Summary
Add CLI-side `post-rewrite` tracking so Entire preserves local session linkage after Git rewrites instead of relying on fallback relinking later.

This PR:
- adds managed `post-rewrite` hook support
- adds `entire hooks git post-rewrite <rewrite-type>` wiring
- remaps local session `BaseCommit` and `AttributionBaseCommit` after `amend` and `rebase`
- keeps `LastCheckpointID` unchanged so the checkpoint linkage follows the rewritten commit
- documents the new hook behavior in strategy docs

## Scope
Supported rewrite flows in this PR:
- `git commit --amend`
- `git rebase`
- interactive rebase variants that route through `post-rewrite`, including `reword`, `squash`, and `fixup`

Not in scope here:
- `git reset`
- `filter-repo` / `filter-branch`
- remote-only rewrites the CLI does not observe

## Why
The goal is to keep Entire tracking native Git commands during an active session. Git already provides deterministic old-SHA -> new-SHA mappings through `post-rewrite`, so the CLI can preserve linkage locally without depending on UI/Darwin reconciliation or custom non-Git linkage metrics.

## Verification
- `GOCACHE=/tmp/go-build go test ./cmd/entire/cli/strategy -run 'Test(ParsePostRewritePairs|ShadowStrategy_PostRewrite_)' -count=1 -v`
- `GOCACHE=/tmp/go-build go test -tags=integration ./cmd/entire/cli/integration_test -run 'TestShadow_(AmendPreservesTrailer|PostRewriteAmendRemapsSessionState|PostRewriteRebaseRemapsSessionState)' -count=1 -v`
- Manual `claude -p` smoke test confirmed a real Entire-tracked commit still gets an `Entire-Checkpoint` trailer and session state in `.git/entire-sessions`; the follow-up live amend flow was not used as the primary verifier because Claude hit a write-permission prompt before completing the second turn.

## Follow-up
A later PR can add lightweight reset/head-divergence guidance without coupling that to rewrite handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new managed `post-rewrite` git hook that mutates local session state and migrates shadow branches based on rewrite mappings; mistakes could break checkpoint linkage after rewrites across worktrees.
> 
> **Overview**
> **Adds CLI support for Git `post-rewrite` to preserve Entire session linkage after history rewrites.** The hook wiring now exposes `entire hooks git post-rewrite <rewrite-type>`, installs/manages the `post-rewrite` hook, and updates docs accordingly.
> 
> On `amend`/`rebase`, the manual-commit strategy now parses old→new SHA pairs from stdin, finds sessions for the current worktree, remaps `BaseCommit`/`AttributionBaseCommit`, and migrates existing shadow branch refs when needed while keeping `LastCheckpointID` stable.
> 
> Tests are expanded across unit and integration suites to cover hook installation/chaining (including stdin replay for chained hooks) and amend/rebase rewrite flows, plus command-tree exposure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a6ef559574dc325cd603b426c90e4c2e8e082e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->