### PR TITLE
add single mise run check to execute everything needed for PR to be green

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,12 +145,18 @@ mise run fmt && mise run lint
 **CI will fail if you skip these steps:**
 
 ```bash
+mise run check
+```
+
+Equivalent expanded form:
+
+```bash
 mise run fmt      # Format code (CI enforces gofmt)
 mise run lint     # Lint check (CI enforces golangci-lint)
 mise run test:ci  # Run all tests (unit + integration)
 ```
 
-Or combined: `mise run fmt && mise run lint && mise run test:ci`
+`mise run check` runs the three commands above.
 
 **Common CI failures from skipping this:**
 

--- a/mise.toml
+++ b/mise.toml
@@ -26,6 +26,10 @@ go test -tags=integration -race ./...
 mise run test:e2e:canary
 """
 
+[tasks.check]
+description = "Run formatting, linting, and CI tests"
+depends = ["fmt", "lint", "test:ci"]
+
 [tasks."build:windows"]
 description = "Cross-compile for Windows amd64"
 run = "CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o entire.exe ./cmd/entire/"


### PR DESCRIPTION

Entire-Checkpoint: 5b756ed24e1d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build tooling/documentation only, with no production code changes. Main risk is minor developer friction if the new docs/command example is incorrect.
> 
> **Overview**
> Introduces a new `mise` task, `check`, that depends on `fmt`, `lint`, and `test:ci` so contributors can run the full pre-CI suite via `mise run check`.
> 
> Updates `CLAUDE.md` to require `mise run check` before committing and documents its expanded equivalent, while also altering the lint/format example command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa19dc6b5cbdb52ad12f6d6aee7d7085eb1ad9b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->