### PR TITLE
less duplication between enable and configure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ t.Chdir(tmpDir)                                 // redirect CWD-based git resolu
 mise run fmt && mise run lint
 ```
 
+`mise run fmt` can rewrite files. Treat `mise run fmt && mise run lint` as a single verification sequence: if formatting changes anything, run lint again on the formatted tree rather than assuming a previous lint result still applies.
+
 ### Before Every Commit (REQUIRED)
 
 **CI will fail if you skip these steps:**
@@ -157,6 +159,8 @@ mise run test:ci  # Run all tests (unit + integration)
 ```
 
 `mise run check` runs the three commands above.
+
+Safety note: do not treat a clean `mise run lint` result as final unless it was run after the most recent `mise run fmt` pass.
 
 **Common CI failures from skipping this:**
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ cd your-project && entire enable
 entire status
 ```
 
+After the initial setup, use `entire configure` to add/remove agents or update setup-related options, and use `entire enable` / `entire disable` to toggle Entire on or off.
+
 ## Release Channels
 
 Entire currently ships two release channels:
@@ -97,7 +99,12 @@ How to use each channel:
 entire enable
 ```
 
-This installs agent and Git hooks to work with your AI agent. You'll be prompted to select which agents to enable. To enable a specific agent non-interactively, use `entire enable --agent <name>` (e.g., `entire enable --agent cursor`).
+On a repo that has not been enabled yet, `entire enable` runs the initial enable flow: it creates Entire settings, installs git hooks, and prompts you to choose which agent hooks to install. To enable a specific agent non-interactively, use `entire enable --agent <name>` (for example, `entire enable --agent cursor`).
+
+After setup:
+
+- Use `entire enable` to turn Entire back on if the repo is currently disabled.
+- Use `entire configure` to change which agents are installed or to update setup-related settings.
 
 The hooks capture session data as you work. Checkpoints are created when you or the agent make a git commit. Your code commits stay clean, Entire never creates commits on your active branch. All session metadata is stored on a separate `entire/checkpoints/v1` branch.
 
@@ -225,6 +232,7 @@ go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin
 | Command          | Description                                                                                       |
 | ---------------- | ------------------------------------------------------------------------------------------------- |
 | `entire clean`   | Clean up session data and orphaned Entire data (use `--all` for repo-wide cleanup)                |
+| `entire configure` | Configure agents and setup options for the current repository                                  |
 | `entire disable` | Remove Entire hooks from repository                                                               |
 | `entire doctor`  | Fix or clean up stuck sessions                                                                    |
 | `entire enable`  | Enable Entire in your repository                                                                  |
@@ -251,11 +259,46 @@ go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin
 **Examples:**
 
 ```
-# Force reinstall hooks
+# First-time setup with a specific agent
+entire enable --agent claude-code
+
+# Re-enable a disabled repo
+entire enable
+
+# Re-enable and refresh hooks
 entire enable --force
 
 # Save settings locally (not committed to git)
 entire enable --local
+```
+
+`entire enable` is primarily for turning Entire on. On an unconfigured repo it will also bootstrap setup, but once the repo is already configured, `entire configure` is the clearer command for managing agents and setup options.
+
+### `entire configure`
+
+Use `entire configure` after the repo is already set up and you want to change the configuration without framing the action as an enable/disable toggle.
+
+Typical uses:
+
+- Add another agent
+- Remove an agent
+- Reinstall hooks for selected agents
+- Update settings such as `--checkpoint-remote` or `--skip-push-sessions`
+
+**Examples:**
+
+```bash
+# Add or remove agents interactively
+entire configure
+
+# Install or refresh hooks for one agent non-interactively
+entire configure --agent claude-code --force
+
+# Update setup settings on an existing repo
+entire configure --checkpoint-remote github:myorg/checkpoints-private
+
+# Remove one agent's hooks
+entire configure --remove claude-code
 ```
 
 ## Configuration

--- a/cmd/entire/cli/agent/capabilities.go
+++ b/cmd/entire/cli/agent/capabilities.go
@@ -27,7 +27,7 @@ type DeclaredCaps struct {
 
 // AsHookSupport returns the agent as HookSupport if it both implements the
 // interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsHookSupport(ag Agent) (HookSupport, bool) {
+func AsHookSupport(ag Agent) (HookSupport, bool) { //nolint:ireturn // type-assertion helper must return interface
 	if ag == nil {
 		return nil, false
 	}
@@ -43,7 +43,7 @@ func AsHookSupport(ag Agent) (HookSupport, bool) {
 
 // AsTranscriptAnalyzer returns the agent as TranscriptAnalyzer if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsTranscriptAnalyzer(ag Agent) (TranscriptAnalyzer, bool) {
+func AsTranscriptAnalyzer(ag Agent) (TranscriptAnalyzer, bool) { //nolint:ireturn // type-assertion helper must return interface
 	if ag == nil {
 		return nil, false
 	}
@@ -59,7 +59,7 @@ func AsTranscriptAnalyzer(ag Agent) (TranscriptAnalyzer, bool) {
 
 // AsTranscriptPreparer returns the agent as TranscriptPreparer if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsTranscriptPreparer(ag Agent) (TranscriptPreparer, bool) {
+func AsTranscriptPreparer(ag Agent) (TranscriptPreparer, bool) { //nolint:ireturn // type-assertion helper must return interface
 	if ag == nil {
 		return nil, false
 	}
@@ -75,7 +75,7 @@ func AsTranscriptPreparer(ag Agent) (TranscriptPreparer, bool) {
 
 // AsTokenCalculator returns the agent as TokenCalculator if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsTokenCalculator(ag Agent) (TokenCalculator, bool) {
+func AsTokenCalculator(ag Agent) (TokenCalculator, bool) { //nolint:ireturn // type-assertion helper must return interface
 	if ag == nil {
 		return nil, false
 	}
@@ -91,7 +91,7 @@ func AsTokenCalculator(ag Agent) (TokenCalculator, bool) {
 
 // AsTextGenerator returns the agent as TextGenerator if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsTextGenerator(ag Agent) (TextGenerator, bool) {
+func AsTextGenerator(ag Agent) (TextGenerator, bool) { //nolint:ireturn // type-assertion helper must return interface
 	if ag == nil {
 		return nil, false
 	}
@@ -107,7 +107,7 @@ func AsTextGenerator(ag Agent) (TextGenerator, bool) {
 
 // AsHookResponseWriter returns the agent as HookResponseWriter if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsHookResponseWriter(ag Agent) (HookResponseWriter, bool) {
+func AsHookResponseWriter(ag Agent) (HookResponseWriter, bool) { //nolint:ireturn // type-assertion helper must return interface
 	if ag == nil {
 		return nil, false
 	}
@@ -126,7 +126,7 @@ func AsHookResponseWriter(ag Agent) (HookResponseWriter, bool) {
 // ExtractPrompts is conceptually part of transcript analysis, so it shares the same
 // capability gate — this prevents calling extract-prompts on external agent binaries
 // that never declared transcript_analyzer support.
-func AsPromptExtractor(ag Agent) (PromptExtractor, bool) {
+func AsPromptExtractor(ag Agent) (PromptExtractor, bool) { //nolint:ireturn // type-assertion helper must return interface
 	if ag == nil {
 		return nil, false
 	}
@@ -143,7 +143,7 @@ func AsPromptExtractor(ag Agent) (PromptExtractor, bool) {
 // AsSessionBaseDirProvider returns the agent as SessionBaseDirProvider if it implements
 // the interface. No capability declaration is needed since this is a built-in-only feature
 // (external agents use the agent binary's own session resolution).
-func AsSessionBaseDirProvider(ag Agent) (SessionBaseDirProvider, bool) {
+func AsSessionBaseDirProvider(ag Agent) (SessionBaseDirProvider, bool) { //nolint:ireturn // type-assertion helper must return interface
 	if ag == nil {
 		return nil, false
 	}
@@ -156,7 +156,7 @@ func AsSessionBaseDirProvider(ag Agent) (SessionBaseDirProvider, bool) {
 
 // AsSubagentAwareExtractor returns the agent as SubagentAwareExtractor if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsSubagentAwareExtractor(ag Agent) (SubagentAwareExtractor, bool) {
+func AsSubagentAwareExtractor(ag Agent) (SubagentAwareExtractor, bool) { //nolint:ireturn // type-assertion helper must return interface
 	if ag == nil {
 		return nil, false
 	}

--- a/cmd/entire/cli/agent/capabilities.go
+++ b/cmd/entire/cli/agent/capabilities.go
@@ -27,7 +27,7 @@ type DeclaredCaps struct {
 
 // AsHookSupport returns the agent as HookSupport if it both implements the
 // interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsHookSupport(ag Agent) (HookSupport, bool) { //nolint:ireturn // type-assertion helper must return interface
+func AsHookSupport(ag Agent) (HookSupport, bool) {
 	if ag == nil {
 		return nil, false
 	}
@@ -43,7 +43,7 @@ func AsHookSupport(ag Agent) (HookSupport, bool) { //nolint:ireturn // type-asse
 
 // AsTranscriptAnalyzer returns the agent as TranscriptAnalyzer if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsTranscriptAnalyzer(ag Agent) (TranscriptAnalyzer, bool) { //nolint:ireturn // type-assertion helper must return interface
+func AsTranscriptAnalyzer(ag Agent) (TranscriptAnalyzer, bool) {
 	if ag == nil {
 		return nil, false
 	}
@@ -59,7 +59,7 @@ func AsTranscriptAnalyzer(ag Agent) (TranscriptAnalyzer, bool) { //nolint:iretur
 
 // AsTranscriptPreparer returns the agent as TranscriptPreparer if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsTranscriptPreparer(ag Agent) (TranscriptPreparer, bool) { //nolint:ireturn // type-assertion helper must return interface
+func AsTranscriptPreparer(ag Agent) (TranscriptPreparer, bool) {
 	if ag == nil {
 		return nil, false
 	}
@@ -75,7 +75,7 @@ func AsTranscriptPreparer(ag Agent) (TranscriptPreparer, bool) { //nolint:iretur
 
 // AsTokenCalculator returns the agent as TokenCalculator if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsTokenCalculator(ag Agent) (TokenCalculator, bool) { //nolint:ireturn // type-assertion helper must return interface
+func AsTokenCalculator(ag Agent) (TokenCalculator, bool) {
 	if ag == nil {
 		return nil, false
 	}
@@ -91,7 +91,7 @@ func AsTokenCalculator(ag Agent) (TokenCalculator, bool) { //nolint:ireturn // t
 
 // AsTextGenerator returns the agent as TextGenerator if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsTextGenerator(ag Agent) (TextGenerator, bool) { //nolint:ireturn // type-assertion helper must return interface
+func AsTextGenerator(ag Agent) (TextGenerator, bool) {
 	if ag == nil {
 		return nil, false
 	}
@@ -107,7 +107,7 @@ func AsTextGenerator(ag Agent) (TextGenerator, bool) { //nolint:ireturn // type-
 
 // AsHookResponseWriter returns the agent as HookResponseWriter if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsHookResponseWriter(ag Agent) (HookResponseWriter, bool) { //nolint:ireturn // type-assertion helper must return interface
+func AsHookResponseWriter(ag Agent) (HookResponseWriter, bool) {
 	if ag == nil {
 		return nil, false
 	}
@@ -126,7 +126,7 @@ func AsHookResponseWriter(ag Agent) (HookResponseWriter, bool) { //nolint:iretur
 // ExtractPrompts is conceptually part of transcript analysis, so it shares the same
 // capability gate — this prevents calling extract-prompts on external agent binaries
 // that never declared transcript_analyzer support.
-func AsPromptExtractor(ag Agent) (PromptExtractor, bool) { //nolint:ireturn // type-assertion helper must return interface
+func AsPromptExtractor(ag Agent) (PromptExtractor, bool) {
 	if ag == nil {
 		return nil, false
 	}
@@ -143,7 +143,7 @@ func AsPromptExtractor(ag Agent) (PromptExtractor, bool) { //nolint:ireturn // t
 // AsSessionBaseDirProvider returns the agent as SessionBaseDirProvider if it implements
 // the interface. No capability declaration is needed since this is a built-in-only feature
 // (external agents use the agent binary's own session resolution).
-func AsSessionBaseDirProvider(ag Agent) (SessionBaseDirProvider, bool) { //nolint:ireturn // type-assertion helper must return interface
+func AsSessionBaseDirProvider(ag Agent) (SessionBaseDirProvider, bool) {
 	if ag == nil {
 		return nil, false
 	}
@@ -156,7 +156,7 @@ func AsSessionBaseDirProvider(ag Agent) (SessionBaseDirProvider, bool) { //nolin
 
 // AsSubagentAwareExtractor returns the agent as SubagentAwareExtractor if it both
 // implements the interface and (for CapabilityDeclarer agents) has declared the capability.
-func AsSubagentAwareExtractor(ag Agent) (SubagentAwareExtractor, bool) { //nolint:ireturn // type-assertion helper must return interface
+func AsSubagentAwareExtractor(ag Agent) (SubagentAwareExtractor, bool) {
 	if ag == nil {
 		return nil, false
 	}

--- a/cmd/entire/cli/integration_test/setup_claude_hooks_test.go
+++ b/cmd/entire/cli/integration_test/setup_claude_hooks_test.go
@@ -170,7 +170,91 @@ func TestSetupClaudeHooks_PreservesExistingSettings(t *testing.T) {
 	}
 }
 
+func TestSetupClaudeHooks_ConfigureForce_RewritesExistingEntireHooks(t *testing.T) {
+	t.Parallel()
+	env := NewTestEnv(t)
+	env.InitRepo()
+	env.InitEntire()
+
+	env.WriteFile("README.md", "# Test")
+	env.GitAdd("README.md")
+	env.GitCommit("Initial commit")
+
+	output, err := env.RunCLIWithError("configure", "--agent", "claude-code")
+	if err != nil {
+		t.Fatalf("configure claude-hooks command failed: %v\nOutput: %s", err, output)
+	}
+
+	writeStaleClaudeStopHook(t, env)
+
+	output, err = env.RunCLIWithError("configure", "--agent", "claude-code", "--force")
+	if err != nil {
+		t.Fatalf("configure --force claude-hooks command failed: %v\nOutput: %s", err, output)
+	}
+
+	assertClaudeStopHookRewritten(t, env)
+}
+
+func TestSetupClaudeHooks_EnableForceWithAgent_RewritesExistingEntireHooks(t *testing.T) {
+	t.Parallel()
+	env := NewTestEnv(t)
+	env.InitRepo()
+	env.InitEntire()
+
+	env.WriteFile("README.md", "# Test")
+	env.GitAdd("README.md")
+	env.GitCommit("Initial commit")
+
+	output, err := env.RunCLIWithError("enable", "--agent", "claude-code")
+	if err != nil {
+		t.Fatalf("enable claude-hooks command failed: %v\nOutput: %s", err, output)
+	}
+
+	writeStaleClaudeStopHook(t, env)
+
+	output, err = env.RunCLIWithError("enable", "--agent", "claude-code", "--force")
+	if err != nil {
+		t.Fatalf("enable --agent claude-code --force failed: %v\nOutput: %s", err, output)
+	}
+
+	assertClaudeStopHookRewritten(t, env)
+}
+
 // Helper functions
+
+func writeStaleClaudeStopHook(t *testing.T, env *TestEnv) {
+	t.Helper()
+	settingsPath := filepath.Join(env.RepoDir, ".claude", claudecode.ClaudeSettingsFileName)
+	staleSettings := `{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [{"type": "command", "command": "entire hooks claude-code stop --stale"}]
+      }
+    ]
+  }
+}`
+	if err := os.WriteFile(settingsPath, []byte(staleSettings), 0o644); err != nil {
+		t.Fatalf("failed to write stale Claude settings: %v", err)
+	}
+}
+
+func assertClaudeStopHookRewritten(t *testing.T, env *TestEnv) {
+	t.Helper()
+	settingsPath := filepath.Join(env.RepoDir, ".claude", claudecode.ClaudeSettingsFileName)
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "stop --stale") {
+		t.Fatalf("expected stale Claude hook to be removed, got: %s", content)
+	}
+	if !strings.Contains(content, `"command": "entire hooks claude-code stop"`) {
+		t.Fatalf("expected canonical Claude stop hook to be restored, got: %s", content)
+	}
+}
 
 func readClaudeSettings(t *testing.T, env *TestEnv) ClaudeSettings {
 	t.Helper()

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -91,6 +91,13 @@ func enableUsesSetupFlow(cmd *cobra.Command, agentName string) bool {
 		cmd.Flags().Changed("telemetry")
 }
 
+func enableNeedsAgentManagement(cmd *cobra.Command) bool {
+	return cmd.Flags().Changed("force") ||
+		cmd.Flags().Changed("local-dev") ||
+		cmd.Flags().Changed("absolute-git-hook-path") ||
+		cmd.Flags().Changed("telemetry")
+}
+
 // updateStrategyOptions applies strategy flags to settings without re-running agent setup.
 // Loads and writes only the target file to avoid leaking settings between layers.
 func updateStrategyOptions(ctx context.Context, w io.Writer, opts EnableOptions) error {
@@ -352,12 +359,21 @@ func applyAgentChanges(ctx context.Context, w io.Writer, selectedAgentNames []st
 		fmt.Fprintln(w, "No changes made.")
 		return nil
 	}
-	var installedAgents []agent.Agent
-	for _, ag := range append(addedAgents, reinstalledAgents...) {
+	var successfullyAddedAgents []agent.Agent
+	for _, ag := range addedAgents {
 		if _, err := setupAgentHooks(ctx, w, ag, opts.LocalDev, opts.ForceHooks); err != nil {
 			errs = append(errs, fmt.Errorf("failed to setup %s hooks: %w", ag.Type(), err))
 		} else {
-			installedAgents = append(installedAgents, ag)
+			successfullyAddedAgents = append(successfullyAddedAgents, ag)
+		}
+	}
+
+	var successfullyReinstalledAgents []agent.Agent
+	for _, ag := range reinstalledAgents {
+		if _, err := setupAgentHooks(ctx, w, ag, opts.LocalDev, opts.ForceHooks); err != nil {
+			errs = append(errs, fmt.Errorf("failed to setup %s hooks: %w", ag.Type(), err))
+		} else {
+			successfullyReinstalledAgents = append(successfullyReinstalledAgents, ag)
 		}
 	}
 
@@ -377,7 +393,7 @@ func applyAgentChanges(ctx context.Context, w io.Writer, selectedAgentNames []st
 	}
 
 	// Auto-enable external_agents setting if any new agent is external.
-	for _, ag := range installedAgents {
+	for _, ag := range append(successfullyAddedAgents, successfullyReinstalledAgents...) {
 		if external.IsExternal(ag) {
 			s, loadErr := LoadEntireSettings(ctx)
 			if loadErr != nil {
@@ -400,15 +416,22 @@ func applyAgentChanges(ctx context.Context, w io.Writer, selectedAgentNames []st
 	}
 
 	// Print summary of what succeeded
-	if len(installedAgents) > 0 {
-		names := make([]string, 0, len(installedAgents))
-		for _, ag := range installedAgents {
+	if len(successfullyAddedAgents) > 0 {
+		names := make([]string, 0, len(successfullyAddedAgents))
+		for _, ag := range successfullyAddedAgents {
 			names = append(names, string(ag.Type()))
 		}
 		fmt.Fprintf(w, "✓ Added agents: %s\n", strings.Join(names, ", "))
 	}
+	if len(successfullyReinstalledAgents) > 0 {
+		names := make([]string, 0, len(successfullyReinstalledAgents))
+		for _, ag := range successfullyReinstalledAgents {
+			names = append(names, string(ag.Type()))
+		}
+		fmt.Fprintf(w, "✓ Reinstalled agents: %s\n", strings.Join(names, ", "))
+	}
 	if len(uninstalledAgents) > 0 {
-		if len(installedAgents) == 0 && len(addedAgents) == 0 && len(removedAgents) == len(installedNames) {
+		if len(successfullyAddedAgents) == 0 && len(successfullyReinstalledAgents) == 0 && len(addedAgents) == 0 && len(removedAgents) == len(installedNames) {
 			fmt.Fprintln(w, "All agents have been removed.")
 		} else {
 			names := make([]string, 0, len(uninstalledAgents))
@@ -562,23 +585,24 @@ If Entire is already configured but disabled, this re-enables it.`,
 			// Any setup-mutating flags should behave like `configure` on repos that
 			// are already set up. Bare `enable` remains the lightweight re-enable path.
 			if settings.IsSetUpAny(ctx) {
-				if enableUsesSetupFlow(cmd, agentName) {
+				usedSetupFlow := enableUsesSetupFlow(cmd, agentName)
+				if usedSetupFlow {
 					if hasStrategyFlags(cmd) {
-						return updateStrategyOptions(ctx, cmd.OutOrStdout(), opts)
+						if err := updateStrategyOptions(ctx, cmd.OutOrStdout(), opts); err != nil {
+							return err
+						}
 					}
-					return runManageAgents(ctx, cmd.OutOrStdout(), opts, nil)
+					if enableNeedsAgentManagement(cmd) {
+						if err := runManageAgents(ctx, cmd.OutOrStdout(), opts, nil); err != nil {
+							return err
+						}
+					}
 				}
 
-				updatedStrategy := hasStrategyFlags(cmd)
-				if updatedStrategy {
-					if err := updateStrategyOptions(ctx, cmd.OutOrStdout(), opts); err != nil {
-						return err
-					}
-				}
 				enabled, err := IsEnabled(ctx)
 				if err == nil && enabled {
 					w := cmd.OutOrStdout()
-					if !updatedStrategy {
+					if !usedSetupFlow {
 						fmt.Fprintln(w, "Entire is already enabled.")
 					}
 					printEnabledStatus(ctx, w)

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -31,9 +31,10 @@ const (
 
 // Flag names used across setup commands.
 const (
-	agentFlagName        = "agent"
-	flagCheckpointRemote = "checkpoint-remote"
-	flagSkipPushSessions = "skip-push-sessions"
+	agentFlagName            = "agent"
+	flagCheckpointRemote     = "checkpoint-remote"
+	flagSkipPushSessions     = "skip-push-sessions"
+	checkpointProviderGitHub = "github"
 )
 
 // EnableOptions holds the flags for `entire enable`.
@@ -178,10 +179,10 @@ func parseCheckpointRemoteFlag(value string) (provider, repo string, err error) 
 	repo = parts[1]
 
 	switch provider {
-	case "github":
+	case checkpointProviderGitHub:
 		// valid
 	default:
-		return "", "", fmt.Errorf("unsupported provider %q (supported: github)", provider)
+		return "", "", fmt.Errorf("unsupported provider %q (supported: %s)", provider, checkpointProviderGitHub)
 	}
 
 	repoParts := strings.SplitN(repo, "/", 2)

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -76,6 +76,21 @@ func hasStrategyFlags(cmd *cobra.Command) bool {
 	return cmd.Flags().Changed(flagCheckpointRemote) || cmd.Flags().Changed(flagSkipPushSessions)
 }
 
+// enableUsesSetupFlow reports whether `entire enable` should delegate to the
+// setup/configure flow instead of the lightweight re-enable path.
+// Bare `enable` and `enable --local/--project` remain state-toggle operations;
+// any other setup-mutating flag should share configure's behavior.
+func enableUsesSetupFlow(cmd *cobra.Command, agentName string) bool {
+	if agentName != "" || hasStrategyFlags(cmd) {
+		return true
+	}
+
+	return cmd.Flags().Changed("force") ||
+		cmd.Flags().Changed("local-dev") ||
+		cmd.Flags().Changed("absolute-git-hook-path") ||
+		cmd.Flags().Changed("telemetry")
+}
+
 // updateStrategyOptions applies strategy flags to settings without re-running agent setup.
 // Loads and writes only the target file to avoid leaking settings between layers.
 func updateStrategyOptions(ctx context.Context, w io.Writer, opts EnableOptions) error {
@@ -304,13 +319,17 @@ func applyAgentChanges(ctx context.Context, w io.Writer, selectedAgentNames []st
 	var errs []error
 
 	var addedAgents []agent.Agent
+	var reinstalledAgents []agent.Agent
 	for _, name := range selectedAgentNames {
-		if _, wasInstalled := installedSet[types.AgentName(name)]; wasInstalled {
-			continue
-		}
 		ag, err := agent.Get(types.AgentName(name))
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to get agent %s: %w", name, err))
+			continue
+		}
+		if _, wasInstalled := installedSet[types.AgentName(name)]; wasInstalled {
+			if opts.ForceHooks {
+				reinstalledAgents = append(reinstalledAgents, ag)
+			}
 			continue
 		}
 		addedAgents = append(addedAgents, ag)
@@ -329,12 +348,12 @@ func applyAgentChanges(ctx context.Context, w io.Writer, selectedAgentNames []st
 		removedAgents = append(removedAgents, ag)
 	}
 
-	if len(addedAgents) == 0 && len(removedAgents) == 0 && len(errs) == 0 {
+	if len(addedAgents) == 0 && len(reinstalledAgents) == 0 && len(removedAgents) == 0 && len(errs) == 0 {
 		fmt.Fprintln(w, "No changes made.")
 		return nil
 	}
 	var installedAgents []agent.Agent
-	for _, ag := range addedAgents {
+	for _, ag := range append(addedAgents, reinstalledAgents...) {
 		if _, err := setupAgentHooks(ctx, w, ag, opts.LocalDev, opts.ForceHooks); err != nil {
 			errs = append(errs, fmt.Errorf("failed to setup %s hooks: %w", ag.Type(), err))
 		} else {
@@ -540,8 +559,16 @@ If Entire is already configured but disabled, this re-enables it.`,
 				return setupAgentHooksNonInteractive(ctx, cmd.OutOrStdout(), ag, opts)
 			}
 
-			// If already set up, apply any strategy flags then just enable
+			// Any setup-mutating flags should behave like `configure` on repos that
+			// are already set up. Bare `enable` remains the lightweight re-enable path.
 			if settings.IsSetUpAny(ctx) {
+				if enableUsesSetupFlow(cmd, agentName) {
+					if hasStrategyFlags(cmd) {
+						return updateStrategyOptions(ctx, cmd.OutOrStdout(), opts)
+					}
+					return runManageAgents(ctx, cmd.OutOrStdout(), opts, nil)
+				}
+
 				updatedStrategy := hasStrategyFlags(cmd)
 				if updatedStrategy {
 					if err := updateStrategyOptions(ctx, cmd.OutOrStdout(), opts); err != nil {

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -973,6 +973,8 @@ func TestEnableUsesSetupFlow(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cmd := newEnableCmd()
 			cmd.SetOut(&bytes.Buffer{})
 			cmd.SetErr(&bytes.Buffer{})

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -1014,6 +1014,92 @@ func TestEnableCmd_ForceOnConfiguredRepo_UsesConfigureFlow(t *testing.T) {
 	}
 }
 
+func TestEnableCmd_ForceOnConfiguredDisabledRepo_Reenables(t *testing.T) {
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	writeSettings(t, testSettingsDisabled)
+	writeClaudeHooksFixture(t)
+
+	cmd := newEnableCmd()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--force"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("enable --force error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Cannot show agent selection in non-interactive mode.") {
+		t.Fatalf("expected enable --force to route through manage agents before enabling, got: %s", output)
+	}
+	if !strings.Contains(output, "Entire is now enabled.") {
+		t.Fatalf("expected enable --force to still enable the repo, got: %s", output)
+	}
+
+	enabled, err := IsEnabled(context.Background())
+	if err != nil {
+		t.Fatalf("IsEnabled() error = %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected repo to be enabled after enable --force")
+	}
+}
+
+func TestEnableCmd_ForceAndStrategyFlagsOnConfiguredDisabledRepo_ReenablesAndUpdatesSettings(t *testing.T) {
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	writeSettings(t, testSettingsDisabled)
+	writeClaudeHooksFixture(t)
+
+	cmd := newEnableCmd()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--force", "--checkpoint-remote", "github:org/repo", "--skip-push-sessions"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("enable with force and strategy flags error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Settings updated") {
+		t.Fatalf("expected strategy flags to be applied, got: %s", output)
+	}
+	if !strings.Contains(output, "Cannot show agent selection in non-interactive mode.") {
+		t.Fatalf("expected force handling to still reach manage agents, got: %s", output)
+	}
+	if !strings.Contains(output, "Entire is now enabled.") {
+		t.Fatalf("expected repo to be enabled after updating settings, got: %s", output)
+	}
+
+	enabled, err := IsEnabled(context.Background())
+	if err != nil {
+		t.Fatalf("IsEnabled() error = %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected repo to be enabled after enable with strategy flags")
+	}
+
+	s, err := LoadEntireSettings(context.Background())
+	if err != nil {
+		t.Fatalf("LoadEntireSettings() error = %v", err)
+	}
+	if got := s.StrategyOptions["push_sessions"]; got != false {
+		t.Fatalf("push_sessions = %v, want false", got)
+	}
+	checkpointRemote, ok := s.StrategyOptions["checkpoint_remote"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("checkpoint_remote = %#v, want map", s.StrategyOptions["checkpoint_remote"])
+	}
+	if checkpointRemote["provider"] != "github" || checkpointRemote["repo"] != "org/repo" {
+		t.Fatalf("checkpoint_remote = %#v, want github/org/repo", checkpointRemote)
+	}
+}
+
 // Tests for canPromptInteractively
 
 func TestCanPromptInteractively_EnvVar_True(t *testing.T) {
@@ -1731,6 +1817,31 @@ func TestManageAgents_ForceReinstallsSelectedAgentHooks(t *testing.T) {
 	}
 	if strings.Contains(buf.String(), "No changes made.") {
 		t.Errorf("Force reinstall should not be treated as no-op, got: %s", buf.String())
+	}
+}
+
+func TestManageAgents_ForceReportsReinstalledAgentsSeparately(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+	writeSettings(t, testSettingsEnabled)
+	writeClaudeHooksFixture(t)
+
+	selectFn := func(_ []string) ([]string, error) {
+		return []string{string(agent.AgentNameClaudeCode)}, nil
+	}
+
+	var buf bytes.Buffer
+	err := runManageAgents(context.Background(), &buf, EnableOptions{ForceHooks: true}, selectFn)
+	if err != nil {
+		t.Fatalf("runManageAgents() error = %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "Reinstalled agents") {
+		t.Errorf("Expected force reinstall summary to mention reinstalled agents, got: %s", buf.String())
+	}
+	if strings.Contains(buf.String(), "Added agents") {
+		t.Errorf("Force reinstall should not be reported as added agents, got: %s", buf.String())
 	}
 }
 

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -950,6 +950,70 @@ func TestEnableCmd_AgentFlagEmptyValue(t *testing.T) {
 	}
 }
 
+func TestEnableUsesSetupFlow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		args      []string
+		agentName string
+		want      bool
+	}{
+		{name: "bare enable", args: nil, want: false},
+		{name: "project only", args: []string{"--project"}, want: false},
+		{name: "local only", args: []string{"--local"}, want: false},
+		{name: "force", args: []string{"--force"}, want: true},
+		{name: "local dev", args: []string{"--local-dev"}, want: true},
+		{name: "absolute hook path", args: []string{"--absolute-git-hook-path"}, want: true},
+		{name: "telemetry changed", args: []string{"--telemetry=false"}, want: true},
+		{name: "checkpoint remote", args: []string{"--checkpoint-remote", "github:org/repo"}, want: true},
+		{name: "skip push sessions", args: []string{"--skip-push-sessions"}, want: true},
+		{name: "agent flag", args: []string{"--agent", "claude-code"}, agentName: "claude-code", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newEnableCmd()
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(tt.args)
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("ParseFlags() error = %v", err)
+			}
+
+			if got := enableUsesSetupFlow(cmd, tt.agentName); got != tt.want {
+				t.Fatalf("enableUsesSetupFlow(%v, %q) = %v, want %v", tt.args, tt.agentName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnableCmd_ForceOnConfiguredRepo_UsesConfigureFlow(t *testing.T) {
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	writeSettings(t, testSettingsEnabled)
+	writeClaudeHooksFixture(t)
+
+	cmd := newEnableCmd()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--force"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("enable --force error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Cannot show agent selection in non-interactive mode.") {
+		t.Fatalf("expected enable --force to route to configure flow, got: %s", output)
+	}
+	if strings.Contains(output, "Entire is already enabled.") {
+		t.Fatalf("expected enable --force to avoid the lightweight re-enable path, got: %s", output)
+	}
+}
+
 // Tests for canPromptInteractively
 
 func TestCanPromptInteractively_EnvVar_True(t *testing.T) {
@@ -1623,6 +1687,50 @@ func TestManageAgents_NoChanges(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "No changes made.") {
 		t.Errorf("Expected 'No changes made.' output, got: %s", buf.String())
+	}
+}
+
+func TestManageAgents_ForceReinstallsSelectedAgentHooks(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+	writeSettings(t, testSettingsEnabled)
+	writeClaudeHooksFixture(t)
+
+	// Simulate a stale or locally modified Entire-managed Claude hook.
+	modifiedHooksJSON := `{
+		"hooks": {
+			"Stop": [{"hooks": [{"type": "command", "command": "entire hooks claude-code stop --stale"}]}]
+		}
+	}`
+	if err := os.WriteFile(".claude/settings.json", []byte(modifiedHooksJSON), 0o644); err != nil {
+		t.Fatalf("Failed to mutate .claude/settings.json: %v", err)
+	}
+
+	selectFn := func(_ []string) ([]string, error) {
+		return []string{string(agent.AgentNameClaudeCode)}, nil
+	}
+
+	var buf bytes.Buffer
+	err := runManageAgents(context.Background(), &buf, EnableOptions{ForceHooks: true}, selectFn)
+	if err != nil {
+		t.Fatalf("runManageAgents() error = %v", err)
+	}
+
+	data, err := os.ReadFile(".claude/settings.json")
+	if err != nil {
+		t.Fatalf("Failed to read .claude/settings.json: %v", err)
+	}
+	content := string(data)
+
+	if strings.Contains(content, "stop --stale") {
+		t.Errorf("Expected force reinstall to rewrite stale Claude hook, got: %s", content)
+	}
+	if !strings.Contains(content, `"command": "entire hooks claude-code stop"`) {
+		t.Errorf("Expected force reinstall to restore canonical Claude hook, got: %s", content)
+	}
+	if strings.Contains(buf.String(), "No changes made.") {
+		t.Errorf("Force reinstall should not be treated as no-op, got: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
This fixes an issue with `entire configure --force` not working only if you add `--agent` it worked, it now works in both cases.

Also while we at it let's remove some duplication and make `entire enable` use the same code path as `entire configure` except for the `enabling` part.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `entire enable` control flow on already-configured repos and alters hook installation behavior when `--force` is used, which could impact users’ existing agent hook setups. Risk is mitigated by added unit/integration coverage around the new routing and hook rewrite behavior.
> 
> **Overview**
> Unifies behavior between `entire enable` and `entire configure` on repos that are already set up: when any *setup-mutating* flag is present (e.g. `--force`, strategy flags, telemetry, absolute hook path), `enable` now routes through the same manage/configure flow instead of the lightweight “already enabled” path.
> 
> Extends agent management to treat `--force` as a **reinstall** for already-selected agents, rewriting Entire-managed hooks (e.g. restoring the canonical Claude `Stop` hook) rather than reporting “No changes made.” Adds targeted unit and integration tests to validate `--force` routing and stale hook rewrite behavior for Claude Code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957163b08337612439088e07c5e053358b0f2717. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->