### PR TITLE
Checkpoints v2: support `attach` command

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -172,7 +172,9 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	if err := store.WriteCommitted(ctx, writeOpts); err != nil {
 		return fmt.Errorf("failed to write checkpoint: %w", err)
 	}
-	writeAttachCheckpointV2IfEnabled(logCtx, repo, store, writeOpts, isExistingCheckpoint)
+	if settings.IsCheckpointsV2Enabled(logCtx) {
+		writeAttachCheckpointV2(logCtx, repo, store, writeOpts, isExistingCheckpoint)
+	}
 
 	// Create or update session state.
 	if err := saveAttachSessionState(logCtx, existingState, sessionID, ag.Type(), transcriptPath, checkpointID, meta, tokenUsage); err != nil {
@@ -195,14 +197,10 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	return nil
 }
 
-// writeAttachCheckpointV2IfEnabled mirrors attach-created checkpoints into the
-// v2 refs when checkpoints_v2 is enabled. The v1 write remains authoritative;
+// writeAttachCheckpointV2 mirrors attach-created checkpoints into the v2 refs.
+// The caller is responsible for checking whether checkpoints_v2 is enabled.
 // v2 failures are logged and do not fail attach.
-func writeAttachCheckpointV2IfEnabled(ctx context.Context, repo *git.Repository, v1Store *cpkg.GitStore, opts cpkg.WriteCommittedOptions, isExistingCheckpoint bool) {
-	if !settings.IsCheckpointsV2Enabled(ctx) {
-		return
-	}
-
+func writeAttachCheckpointV2(ctx context.Context, repo *git.Repository, v1Store *cpkg.GitStore, opts cpkg.WriteCommittedOptions, isExistingCheckpoint bool) {
 	v2Store := cpkg.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
 	var err error
 	if isExistingCheckpoint {

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -17,6 +17,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
@@ -148,7 +149,7 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		return fmt.Errorf("failed to redact transcript: %w", redactErr)
 	}
 
-	if err := store.WriteCommitted(ctx, cpkg.WriteCommittedOptions{
+	writeOpts := cpkg.WriteCommittedOptions{
 		CheckpointID: checkpointID,
 		SessionID:    sessionID,
 		Strategy:     strategy.StrategyNameManualCommit,
@@ -159,9 +160,19 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		Agent:        ag.Type(),
 		Model:        meta.Model,
 		TokenUsage:   tokenUsage,
-	}); err != nil {
+	}
+
+	if compacted := compactTranscriptForStartLine(logCtx, redactedTranscript.Bytes(), cpkg.CommittedMetadata{
+		CheckpointID: checkpointID,
+		Agent:        ag.Type(),
+	}, 0); compacted != nil {
+		writeOpts.CompactTranscript = compacted
+	}
+
+	if err := store.WriteCommitted(ctx, writeOpts); err != nil {
 		return fmt.Errorf("failed to write checkpoint: %w", err)
 	}
+	writeAttachCheckpointV2IfEnabled(logCtx, repo, store, writeOpts, isExistingCheckpoint)
 
 	// Create or update session state.
 	if err := saveAttachSessionState(logCtx, existingState, sessionID, ag.Type(), transcriptPath, checkpointID, meta, tokenUsage); err != nil {
@@ -179,6 +190,79 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	if err := promptAmendCommit(logCtx, w, headCommit, cpIDStr, force); err != nil {
 		logging.Warn(logCtx, "failed to amend commit", "error", err)
 		fmt.Fprintf(w, "\nCopy to your commit message to attach:\n\n  Entire-Checkpoint: %s\n", cpIDStr)
+	}
+
+	return nil
+}
+
+// writeAttachCheckpointV2IfEnabled mirrors attach-created checkpoints into the
+// v2 refs when checkpoints_v2 is enabled. The v1 write remains authoritative;
+// v2 failures are logged and do not fail attach.
+func writeAttachCheckpointV2IfEnabled(ctx context.Context, repo *git.Repository, v1Store *cpkg.GitStore, opts cpkg.WriteCommittedOptions, isExistingCheckpoint bool) {
+	if !settings.IsCheckpointsV2Enabled(ctx) {
+		return
+	}
+
+	v2Store := cpkg.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
+	var err error
+	if isExistingCheckpoint {
+		err = backfillAttachCheckpointToV2(ctx, repo, v1Store, v2Store, opts.CheckpointID, opts.AuthorName, opts.AuthorEmail)
+	} else {
+		err = v2Store.WriteCommitted(ctx, opts)
+	}
+	if err != nil {
+		logging.Warn(ctx, "attach v2 dual-write failed",
+			"checkpoint_id", opts.CheckpointID.String(),
+			"error", err,
+		)
+	}
+}
+
+// backfillAttachCheckpointToV2 rewrites the full checkpoint from v1 into v2.
+// This avoids creating a partial v2 shadow when attach adds a session to a
+// legacy v1-only checkpoint.
+func backfillAttachCheckpointToV2(ctx context.Context, repo *git.Repository, v1Store *cpkg.GitStore, v2Store *cpkg.V2GitStore, checkpointID id.CheckpointID, authorName, authorEmail string) error {
+	summary, err := v1Store.ReadCommitted(ctx, checkpointID)
+	if err != nil {
+		return fmt.Errorf("read v1 checkpoint: %w", err)
+	}
+	if summary == nil {
+		return fmt.Errorf("v1 checkpoint %s has no summary", checkpointID)
+	}
+
+	info := cpkg.CommittedInfo{CheckpointID: checkpointID}
+	shouldCopyTaskMetadata := false
+
+	for sessionIdx := range len(summary.Sessions) {
+		content, readErr := v1Store.ReadSessionContent(ctx, checkpointID, sessionIdx)
+		if readErr != nil {
+			return fmt.Errorf("read v1 session %d: %w", sessionIdx, readErr)
+		}
+		if content.Metadata.IsTask {
+			shouldCopyTaskMetadata = true
+		}
+
+		writeOpts := buildMigrateWriteOpts(content, info)
+		writeOpts.AuthorName = authorName
+		writeOpts.AuthorEmail = authorEmail
+
+		if compacted := tryCompactTranscript(ctx, content.Transcript, content.Metadata); compacted != nil {
+			writeOpts.CompactTranscript = compacted
+			writeOpts.CompactTranscriptStart = computeCompactOffset(ctx, content.Transcript, compacted, content.Metadata)
+		}
+
+		if writeErr := v2Store.WriteCommitted(ctx, writeOpts); writeErr != nil {
+			return fmt.Errorf("write v2 session %d: %w", sessionIdx, writeErr)
+		}
+	}
+
+	if shouldCopyTaskMetadata {
+		if taskErr := copyTaskMetadataToV2(repo, v1Store, v2Store, checkpointID, summary); taskErr != nil {
+			logging.Warn(ctx, "attach v2 task metadata copy failed",
+				"checkpoint_id", checkpointID.String(),
+				"error", taskErr,
+			)
+		}
 	}
 
 	return nil

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -173,7 +173,7 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		return fmt.Errorf("failed to write checkpoint: %w", err)
 	}
 	if settings.IsCheckpointsV2Enabled(logCtx) {
-		writeAttachCheckpointV2(logCtx, repo, store, writeOpts, isExistingCheckpoint)
+		writeAttachCheckpointV2(logCtx, repo, writeOpts)
 	}
 
 	// Create or update session state.
@@ -200,70 +200,14 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 // writeAttachCheckpointV2 mirrors attach-created checkpoints into the v2 refs.
 // The caller is responsible for checking whether checkpoints_v2 is enabled.
 // v2 failures are logged and do not fail attach.
-func writeAttachCheckpointV2(ctx context.Context, repo *git.Repository, v1Store *cpkg.GitStore, opts cpkg.WriteCommittedOptions, isExistingCheckpoint bool) {
+func writeAttachCheckpointV2(ctx context.Context, repo *git.Repository, opts cpkg.WriteCommittedOptions) {
 	v2Store := cpkg.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
-	var err error
-	if isExistingCheckpoint {
-		err = backfillAttachCheckpointToV2(ctx, repo, v1Store, v2Store, opts.CheckpointID, opts.AuthorName, opts.AuthorEmail)
-	} else {
-		err = v2Store.WriteCommitted(ctx, opts)
-	}
-	if err != nil {
+	if err := v2Store.WriteCommitted(ctx, opts); err != nil {
 		logging.Warn(ctx, "attach v2 dual-write failed",
 			"checkpoint_id", opts.CheckpointID.String(),
 			"error", err,
 		)
 	}
-}
-
-// backfillAttachCheckpointToV2 rewrites the full checkpoint from v1 into v2.
-// This avoids creating a partial v2 shadow when attach adds a session to a
-// legacy v1-only checkpoint.
-func backfillAttachCheckpointToV2(ctx context.Context, repo *git.Repository, v1Store *cpkg.GitStore, v2Store *cpkg.V2GitStore, checkpointID id.CheckpointID, authorName, authorEmail string) error {
-	summary, err := v1Store.ReadCommitted(ctx, checkpointID)
-	if err != nil {
-		return fmt.Errorf("read v1 checkpoint: %w", err)
-	}
-	if summary == nil {
-		return fmt.Errorf("v1 checkpoint %s has no summary", checkpointID)
-	}
-
-	info := cpkg.CommittedInfo{CheckpointID: checkpointID}
-	shouldCopyTaskMetadata := false
-
-	for sessionIdx := range len(summary.Sessions) {
-		content, readErr := v1Store.ReadSessionContent(ctx, checkpointID, sessionIdx)
-		if readErr != nil {
-			return fmt.Errorf("read v1 session %d: %w", sessionIdx, readErr)
-		}
-		if content.Metadata.IsTask {
-			shouldCopyTaskMetadata = true
-		}
-
-		writeOpts := buildMigrateWriteOpts(content, info)
-		writeOpts.AuthorName = authorName
-		writeOpts.AuthorEmail = authorEmail
-
-		if compacted := tryCompactTranscript(ctx, content.Transcript, content.Metadata); compacted != nil {
-			writeOpts.CompactTranscript = compacted
-			writeOpts.CompactTranscriptStart = computeCompactOffset(ctx, content.Transcript, compacted, content.Metadata)
-		}
-
-		if writeErr := v2Store.WriteCommitted(ctx, writeOpts); writeErr != nil {
-			return fmt.Errorf("write v2 session %d: %w", sessionIdx, writeErr)
-		}
-	}
-
-	if shouldCopyTaskMetadata {
-		if taskErr := copyTaskMetadataToV2(repo, v1Store, v2Store, checkpointID, summary); taskErr != nil {
-			logging.Warn(ctx, "attach v2 task metadata copy failed",
-				"checkpoint_id", checkpointID.String(),
-				"error", taskErr,
-			)
-		}
-	}
-
-	return nil
 }
 
 // getHeadCommit returns the HEAD commit object.

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -16,8 +16,13 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/cursor"         // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid" // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"      // register agent
+	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 func TestAttach_MissingSessionID(t *testing.T) {
@@ -164,6 +169,141 @@ func TestAttach_OutputContainsCheckpointID(t *testing.T) {
 	re := regexp.MustCompile(`Entire-Checkpoint: [0-9a-f]{12}`)
 	if !re.MatchString(output) {
 		t.Errorf("expected 'Entire-Checkpoint: <12-hex-id>' in output, got:\n%s", output)
+	}
+}
+
+func TestAttach_V2DualWriteEnabled(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	repoDir := mustGetwd(t)
+	setAttachCheckpointsV2Enabled(t, repoDir)
+
+	sessionID := "test-attach-v2-dual-write"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"create hello.txt"},"uuid":"uuid-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"Write","input":{"file_path":"hello.txt","content":"hello"}}]},"uuid":"uuid-2"}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_1","content":"wrote file"}]},"uuid":"uuid-3"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done."}]},"uuid":"uuid-4"}
+`)
+
+	var out bytes.Buffer
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, true); err != nil {
+		t.Fatalf("runAttach failed: %v", err)
+	}
+
+	store, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil || state.LastCheckpointID.IsEmpty() {
+		t.Fatal("expected attach to persist a checkpoint ID")
+	}
+
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cpPath := state.LastCheckpointID.Path()
+	mainCompact, found := readFileFromRef(t, repo, paths.V2MainRefName, cpPath+"/0/"+paths.CompactTranscriptFileName)
+	if !found {
+		t.Fatalf("expected %s on %s", paths.CompactTranscriptFileName, paths.V2MainRefName)
+	}
+	if !strings.Contains(mainCompact, "create hello.txt") {
+		t.Errorf("compact transcript missing prompt, got:\n%s", mainCompact)
+	}
+
+	fullTranscript, found := readFileFromRef(t, repo, paths.V2FullCurrentRefName, cpPath+"/0/"+paths.V2RawTranscriptFileName)
+	if !found {
+		t.Fatalf("expected %s on %s", paths.V2RawTranscriptFileName, paths.V2FullCurrentRefName)
+	}
+	if !strings.Contains(fullTranscript, "hello.txt") {
+		t.Errorf("raw transcript missing file content, got:\n%s", fullTranscript)
+	}
+}
+
+func TestAttach_V2BackfillsExistingV1OnlyCheckpoint(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	repoDir := mustGetwd(t)
+
+	session1ID := "test-attach-v1-only-session"
+	setupClaudeTranscript(t, session1ID, `{"type":"user","message":{"role":"user","content":"first prompt"},"uuid":"uuid-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"first answer"}]},"uuid":"uuid-2"}
+`)
+
+	var out bytes.Buffer
+	if err := runAttach(context.Background(), &out, session1ID, agent.AgentNameClaudeCode, true); err != nil {
+		t.Fatalf("first attach failed: %v", err)
+	}
+
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true); err == nil {
+		t.Fatalf("did not expect %s before checkpoints_v2 is enabled", paths.V2MainRefName)
+	}
+	if _, err := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true); err == nil {
+		t.Fatalf("did not expect %s before checkpoints_v2 is enabled", paths.V2FullCurrentRefName)
+	}
+
+	setAttachCheckpointsV2Enabled(t, repoDir)
+
+	session2ID := "test-attach-v2-backfill-session"
+	setupClaudeTranscript(t, session2ID, `{"type":"user","message":{"role":"user","content":"second prompt"},"uuid":"uuid-3"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"second answer"}]},"uuid":"uuid-4"}
+`)
+
+	out.Reset()
+	if err := runAttach(context.Background(), &out, session2ID, agent.AgentNameClaudeCode, true); err != nil {
+		t.Fatalf("second attach failed: %v", err)
+	}
+
+	stateStore, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	state1, err := stateStore.Load(context.Background(), session1ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state2, err := stateStore.Load(context.Background(), session2ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state1 == nil || state2 == nil {
+		t.Fatal("expected both session states to exist")
+	}
+	if state1.LastCheckpointID != state2.LastCheckpointID {
+		t.Fatalf("expected both sessions to share a checkpoint, got %s and %s", state1.LastCheckpointID, state2.LastCheckpointID)
+	}
+
+	v2Store := cpkg.NewV2GitStore(repo, "origin")
+	summary, err := v2Store.ReadCommitted(context.Background(), state2.LastCheckpointID)
+	if err != nil {
+		t.Fatalf("expected checkpoint in v2 after backfill: %v", err)
+	}
+	if got := len(summary.Sessions); got != 2 {
+		t.Fatalf("len(summary.Sessions) = %d, want 2", got)
+	}
+
+	content0, err := v2Store.ReadSessionContent(context.Background(), state2.LastCheckpointID, 0)
+	if err != nil {
+		t.Fatalf("failed reading v2 session 0: %v", err)
+	}
+	content1, err := v2Store.ReadSessionContent(context.Background(), state2.LastCheckpointID, 1)
+	if err != nil {
+		t.Fatalf("failed reading v2 session 1: %v", err)
+	}
+
+	foundSession1 := content0.Metadata.SessionID == session1ID || content1.Metadata.SessionID == session1ID
+	foundSession2 := content0.Metadata.SessionID == session2ID || content1.Metadata.SessionID == session2ID
+	if !foundSession1 || !foundSession2 {
+		t.Fatalf("expected both session IDs in v2, got %q and %q", content0.Metadata.SessionID, content1.Metadata.SessionID)
 	}
 }
 
@@ -639,4 +779,51 @@ func enableEntire(t *testing.T, repoDir string) {
 	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func setAttachCheckpointsV2Enabled(t *testing.T, repoDir string) {
+	t.Helper()
+	entireDir := filepath.Join(repoDir, ".entire")
+	if err := os.MkdirAll(entireDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	settingsContent := `{"enabled": true, "strategy_options": {"checkpoints_v2": true}}`
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustGetwd(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func readFileFromRef(t *testing.T, repo *git.Repository, refName, filePath string) (string, bool) {
+	t.Helper()
+
+	ref, err := repo.Reference(plumbing.ReferenceName(refName), true)
+	if err != nil {
+		return "", false
+	}
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		return "", false
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return "", false
+	}
+	file, err := tree.File(filePath)
+	if err != nil {
+		return "", false
+	}
+	content, err := file.Contents()
+	if err != nil {
+		return "", false
+	}
+	return content, true
 }

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -224,75 +224,32 @@ func TestAttach_V2DualWriteEnabled(t *testing.T) {
 	}
 }
 
-func TestAttach_V2ExistingCheckpointAppendsWithoutBackfill(t *testing.T) {
+func TestAttach_V2DualWriteDisabled(t *testing.T) {
 	setupAttachTestRepo(t)
 
 	repoDir := mustGetwd(t)
-	setAttachCheckpointsV2Enabled(t, repoDir)
 
-	session1ID := "test-attach-v2-existing-session-1"
-	setupClaudeTranscript(t, session1ID, `{"type":"user","message":{"role":"user","content":"first prompt"},"uuid":"uuid-1"}
-{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"first answer"}]},"uuid":"uuid-2"}
+	sessionID := "test-attach-v2-disabled"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"create hello.txt"},"uuid":"uuid-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"Write","input":{"file_path":"hello.txt","content":"hello"}}]},"uuid":"uuid-2"}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_1","content":"wrote file"}]},"uuid":"uuid-3"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done."}]},"uuid":"uuid-4"}
 `)
 
 	var out bytes.Buffer
-	if err := runAttach(context.Background(), &out, session1ID, agent.AgentNameClaudeCode, true); err != nil {
-		t.Fatalf("first attach failed: %v", err)
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, true); err != nil {
+		t.Fatalf("runAttach failed: %v", err)
 	}
 
 	repo, err := git.PlainOpen(repoDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	mainRefBefore, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
-	if err != nil {
-		t.Fatalf("failed to read %s after first attach: %v", paths.V2MainRefName, err)
+	if _, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true); err == nil {
+		t.Fatalf("did not expect %s when checkpoints_v2 is disabled", paths.V2MainRefName)
 	}
-	fullRefBefore, err := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
-	if err != nil {
-		t.Fatalf("failed to read %s after first attach: %v", paths.V2FullCurrentRefName, err)
-	}
-
-	session2ID := "test-attach-v2-existing-session-2"
-	setupClaudeTranscript(t, session2ID, `{"type":"user","message":{"role":"user","content":"second prompt"},"uuid":"uuid-3"}
-{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"second answer"}]},"uuid":"uuid-4"}
-`)
-
-	out.Reset()
-	if err := runAttach(context.Background(), &out, session2ID, agent.AgentNameClaudeCode, true); err != nil {
-		t.Fatalf("second attach failed: %v", err)
-	}
-
-	mainRefAfter, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
-	if err != nil {
-		t.Fatalf("failed to read %s after second attach: %v", paths.V2MainRefName, err)
-	}
-	fullRefAfter, err := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
-	if err != nil {
-		t.Fatalf("failed to read %s after second attach: %v", paths.V2FullCurrentRefName, err)
-	}
-
-	mainCommitAfter, err := repo.CommitObject(mainRefAfter.Hash())
-	if err != nil {
-		t.Fatalf("failed to read v2 main commit: %v", err)
-	}
-	if got, want := len(mainCommitAfter.ParentHashes), 1; got != want {
-		t.Fatalf("len(mainCommitAfter.ParentHashes) = %d, want %d", got, want)
-	}
-	if got := mainCommitAfter.ParentHashes[0]; got != mainRefBefore.Hash() {
-		t.Fatalf("v2 main ref advanced by more than one commit: parent=%s previous=%s", got, mainRefBefore.Hash())
-	}
-
-	fullCommitAfter, err := repo.CommitObject(fullRefAfter.Hash())
-	if err != nil {
-		t.Fatalf("failed to read v2 full/current commit: %v", err)
-	}
-	if got, want := len(fullCommitAfter.ParentHashes), 1; got != want {
-		t.Fatalf("len(fullCommitAfter.ParentHashes) = %d, want %d", got, want)
-	}
-	if got := fullCommitAfter.ParentHashes[0]; got != fullRefBefore.Hash() {
-		t.Fatalf("v2 full/current ref advanced by more than one commit: parent=%s previous=%s", got, fullRefBefore.Hash())
+	if _, err := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true); err == nil {
+		t.Fatalf("did not expect %s when checkpoints_v2 is disabled", paths.V2FullCurrentRefName)
 	}
 }
 

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -16,7 +16,6 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/cursor"         // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid" // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"      // register agent
-	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -225,12 +224,13 @@ func TestAttach_V2DualWriteEnabled(t *testing.T) {
 	}
 }
 
-func TestAttach_V2BackfillsExistingV1OnlyCheckpoint(t *testing.T) {
+func TestAttach_V2ExistingCheckpointAppendsWithoutBackfill(t *testing.T) {
 	setupAttachTestRepo(t)
 
 	repoDir := mustGetwd(t)
+	setAttachCheckpointsV2Enabled(t, repoDir)
 
-	session1ID := "test-attach-v1-only-session"
+	session1ID := "test-attach-v2-existing-session-1"
 	setupClaudeTranscript(t, session1ID, `{"type":"user","message":{"role":"user","content":"first prompt"},"uuid":"uuid-1"}
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"first answer"}]},"uuid":"uuid-2"}
 `)
@@ -244,16 +244,17 @@ func TestAttach_V2BackfillsExistingV1OnlyCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true); err == nil {
-		t.Fatalf("did not expect %s before checkpoints_v2 is enabled", paths.V2MainRefName)
+
+	mainRefBefore, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	if err != nil {
+		t.Fatalf("failed to read %s after first attach: %v", paths.V2MainRefName, err)
 	}
-	if _, err := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true); err == nil {
-		t.Fatalf("did not expect %s before checkpoints_v2 is enabled", paths.V2FullCurrentRefName)
+	fullRefBefore, err := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
+	if err != nil {
+		t.Fatalf("failed to read %s after first attach: %v", paths.V2FullCurrentRefName, err)
 	}
 
-	setAttachCheckpointsV2Enabled(t, repoDir)
-
-	session2ID := "test-attach-v2-backfill-session"
+	session2ID := "test-attach-v2-existing-session-2"
 	setupClaudeTranscript(t, session2ID, `{"type":"user","message":{"role":"user","content":"second prompt"},"uuid":"uuid-3"}
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"second answer"}]},"uuid":"uuid-4"}
 `)
@@ -263,47 +264,35 @@ func TestAttach_V2BackfillsExistingV1OnlyCheckpoint(t *testing.T) {
 		t.Fatalf("second attach failed: %v", err)
 	}
 
-	stateStore, err := session.NewStateStore(context.Background())
+	mainRefAfter, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to read %s after second attach: %v", paths.V2MainRefName, err)
 	}
-	state1, err := stateStore.Load(context.Background(), session1ID)
+	fullRefAfter, err := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
 	if err != nil {
-		t.Fatal(err)
-	}
-	state2, err := stateStore.Load(context.Background(), session2ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if state1 == nil || state2 == nil {
-		t.Fatal("expected both session states to exist")
-	}
-	if state1.LastCheckpointID != state2.LastCheckpointID {
-		t.Fatalf("expected both sessions to share a checkpoint, got %s and %s", state1.LastCheckpointID, state2.LastCheckpointID)
+		t.Fatalf("failed to read %s after second attach: %v", paths.V2FullCurrentRefName, err)
 	}
 
-	v2Store := cpkg.NewV2GitStore(repo, "origin")
-	summary, err := v2Store.ReadCommitted(context.Background(), state2.LastCheckpointID)
+	mainCommitAfter, err := repo.CommitObject(mainRefAfter.Hash())
 	if err != nil {
-		t.Fatalf("expected checkpoint in v2 after backfill: %v", err)
+		t.Fatalf("failed to read v2 main commit: %v", err)
 	}
-	if got := len(summary.Sessions); got != 2 {
-		t.Fatalf("len(summary.Sessions) = %d, want 2", got)
+	if got, want := len(mainCommitAfter.ParentHashes), 1; got != want {
+		t.Fatalf("len(mainCommitAfter.ParentHashes) = %d, want %d", got, want)
+	}
+	if got := mainCommitAfter.ParentHashes[0]; got != mainRefBefore.Hash() {
+		t.Fatalf("v2 main ref advanced by more than one commit: parent=%s previous=%s", got, mainRefBefore.Hash())
 	}
 
-	content0, err := v2Store.ReadSessionContent(context.Background(), state2.LastCheckpointID, 0)
+	fullCommitAfter, err := repo.CommitObject(fullRefAfter.Hash())
 	if err != nil {
-		t.Fatalf("failed reading v2 session 0: %v", err)
+		t.Fatalf("failed to read v2 full/current commit: %v", err)
 	}
-	content1, err := v2Store.ReadSessionContent(context.Background(), state2.LastCheckpointID, 1)
-	if err != nil {
-		t.Fatalf("failed reading v2 session 1: %v", err)
+	if got, want := len(fullCommitAfter.ParentHashes), 1; got != want {
+		t.Fatalf("len(fullCommitAfter.ParentHashes) = %d, want %d", got, want)
 	}
-
-	foundSession1 := content0.Metadata.SessionID == session1ID || content1.Metadata.SessionID == session1ID
-	foundSession2 := content0.Metadata.SessionID == session2ID || content1.Metadata.SessionID == session2ID
-	if !foundSession1 || !foundSession2 {
-		t.Fatalf("expected both session IDs in v2, got %q and %q", content0.Metadata.SessionID, content1.Metadata.SessionID)
+	if got := fullCommitAfter.ParentHashes[0]; got != fullRefBefore.Hash() {
+		t.Fatalf("v2 full/current ref advanced by more than one commit: parent=%s previous=%s", got, fullRefBefore.Hash())
 	}
 }
 


### PR DESCRIPTION
Wires up the `attach` command to support checkpoints v2. Supports dual-write to v1 and v2 checkpoints when v2 is enabled.

This change is not user facing and should not introduce any changes to the checkpoints v1 attach flow.

(Used the `994182ab5aba` test checkpoint in https://github.com/entireio/cli/pull/955/commits/d35e512f17a88dab151db8c16c732bb13e8ba157 to ensure the new v2 checkpoint flow was executed correctly via `attach`.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds conditional dual-write and backfill logic during `attach`, which touches git ref storage and migration paths; failures are logged but could lead to v1/v2 divergence if bugs slip through.
> 
> **Overview**
> `attach` now **optionally mirrors committed checkpoints into checkpoints v2** when `strategy_options.checkpoints_v2` is enabled, while continuing to write to v1 as before.
> 
> When attaching to an *existing v1-only checkpoint*, it **backfills the full checkpoint into v2** (rewriting all sessions and copying task metadata when needed) to avoid creating a partial v2 shadow; v2 write failures are treated as best-effort and only logged.
> 
> Tests add coverage for v2 dual-write output (including compact + raw transcript files in v2 refs) and for backfilling an existing v1 checkpoint after enabling v2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e4598af23783c47877e5552fec9c07079b2eea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->