### PR TITLE
fix: dual-write and preserve v2 task metadata

### DIFF
--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -208,9 +208,17 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 		return err
 	}
 
-	// Clear existing transcript entries at this session path before writing new ones
+	// Clear existing transcript artifacts for this session path before writing new ones.
+	// Preserve non-transcript metadata under the same session (e.g., tasks/*).
+	rawTranscriptPath := sessionPath + paths.V2RawTranscriptFileName
+	rawHashPath := sessionPath + paths.V2RawTranscriptHashFileName
 	for key := range entries {
-		if strings.HasPrefix(key, sessionPath) {
+		switch {
+		case key == rawTranscriptPath:
+			delete(entries, key)
+		case strings.HasPrefix(key, rawTranscriptPath+"."):
+			delete(entries, key)
+		case key == rawHashPath:
 			delete(entries, key)
 		}
 	}

--- a/cmd/entire/cli/checkpoint/v2_store_test.go
+++ b/cmd/entire/cli/checkpoint/v2_store_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
@@ -866,6 +867,66 @@ func TestV2GitStore_UpdateCommitted_CheckpointNotFound(t *testing.T) {
 		Agent:        agent.AgentTypeClaudeCode,
 	})
 	require.Error(t, err)
+}
+
+func TestV2GitStore_UpdateCommitted_PreservesExistingTaskMetadataInFullCurrent(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+	ctx := context.Background()
+
+	cpID := id.MustCheckpointID("cc55dd66ee77")
+
+	// Initial write creates checkpoint/session on both /main and /full/current.
+	err := store.WriteCommitted(ctx, WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "test-session-task-preserve",
+		Strategy:     "manual-commit",
+		Agent:        agent.AgentTypeClaudeCode,
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"initial"}`)),
+		Prompts:      []string{"first prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	// Inject task metadata into /full/current to emulate condensation-time task copy.
+	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+	parentHash, rootTreeHash, err := store.GetRefState(refName)
+	require.NoError(t, err)
+
+	taskPath := []string{string(cpID[:2]), string(cpID[2:]), "0", "tasks", "toolu_01TASK"}
+	checkpointJSON := []byte(`{"session_id":"test-session-task-preserve","tool_use_id":"toolu_01TASK"}`)
+	blobHash, err := CreateBlobFromContent(repo, checkpointJSON)
+	require.NoError(t, err)
+
+	newRootHash, err := UpdateSubtree(repo, rootTreeHash,
+		taskPath,
+		[]object.TreeEntry{{Name: "checkpoint.json", Mode: filemode.Regular, Hash: blobHash}},
+		UpdateSubtreeOptions{MergeMode: MergeKeepExisting},
+	)
+	require.NoError(t, err)
+
+	authorName, authorEmail := GetGitAuthorFromRepo(repo)
+	commitHash, err := CreateCommit(repo, newRootHash, parentHash,
+		fmt.Sprintf("Checkpoint: %s (task metadata)\n", cpID), authorName, authorEmail)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)))
+
+	// Finalize checkpoint with full transcript (the stop-time path).
+	err = store.UpdateCommitted(ctx, UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "test-session-task-preserve",
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"finalized"}`)),
+		Prompts:      []string{"first prompt", "second prompt"},
+		Agent:        agent.AgentTypeClaudeCode,
+	})
+	require.NoError(t, err)
+
+	// Task metadata should still exist after UpdateCommitted.
+	fullTree := v2FullTree(t, repo)
+	_, err = fullTree.File(cpID.Path() + "/0/tasks/toolu_01TASK/checkpoint.json")
+	require.NoError(t, err, "task metadata should be preserved on /full/current during UpdateCommitted")
 }
 
 func TestWriteCommitted_TriggersRotationAtThreshold(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -259,6 +260,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 	writeV2Start := time.Now()
 	writeV2Ctx, writeCommittedV2Span := perf.Start(ctx, "write_committed_v2")
 	writeCommittedV2IfEnabled(writeV2Ctx, repo, writeOpts)
+	writeTaskMetadataV2IfEnabled(writeV2Ctx, repo, checkpointID, state.SessionID, ref)
 	writeCommittedV2Span.End()
 	writeV2Duration := time.Since(writeV2Start)
 
@@ -1291,4 +1293,171 @@ func writeCommittedV2IfEnabled(ctx context.Context, repo *git.Repository, opts c
 			slog.String("error", err.Error()),
 		)
 	}
+}
+
+// writeTaskMetadataV2IfEnabled copies task metadata trees from the shadow branch
+// to v2 /full/current when dual-write is enabled.
+//
+// This mirrors migrate's task backfill behavior for newly created checkpoints so
+// task rewind artifacts (tasks/<tool-use-id>/...) are available in v2 immediately,
+// not only after running `entire migrate --checkpoints v2`.
+func writeTaskMetadataV2IfEnabled(
+	ctx context.Context,
+	repo *git.Repository,
+	checkpointID id.CheckpointID,
+	sessionID string,
+	shadowRef *plumbing.Reference,
+) {
+	if !settings.IsCheckpointsV2Enabled(ctx) || shadowRef == nil {
+		return
+	}
+
+	shadowCommit, err := repo.CommitObject(shadowRef.Hash())
+	if err != nil {
+		logging.Warn(ctx, "v2 dual-write task metadata copy skipped: failed to read shadow commit",
+			slog.String("checkpoint_id", checkpointID.String()),
+			slog.String("session_id", sessionID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	shadowTree, err := shadowCommit.Tree()
+	if err != nil {
+		logging.Warn(ctx, "v2 dual-write task metadata copy skipped: failed to read shadow tree",
+			slog.String("checkpoint_id", checkpointID.String()),
+			slog.String("session_id", sessionID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	tasksPath := paths.SessionMetadataDirFromSessionID(sessionID) + "/tasks"
+	tasksTree, err := shadowTree.Tree(tasksPath)
+	if err != nil {
+		return
+	}
+
+	v2Store := cpkg.NewV2GitStore(repo, ResolveCheckpointURL(ctx, "origin"))
+	sessionIndex, err := resolveV2SessionIndexForCheckpoint(repo, checkpointID, sessionID)
+	if err != nil {
+		logging.Warn(ctx, "v2 dual-write task metadata copy skipped: failed to resolve session index",
+			slog.String("checkpoint_id", checkpointID.String()),
+			slog.String("session_id", sessionID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	if err := spliceTaskTreeToV2FullCurrent(repo, v2Store, checkpointID, sessionIndex, tasksTree.Hash); err != nil {
+		logging.Warn(ctx, "v2 dual-write task metadata copy failed",
+			slog.String("checkpoint_id", checkpointID.String()),
+			slog.String("session_id", sessionID),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+func resolveV2SessionIndexForCheckpoint(repo *git.Repository, checkpointID id.CheckpointID, sessionID string) (int, error) {
+	v2MainRef, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	if err != nil {
+		return 0, fmt.Errorf("read v2 /main ref: %w", err)
+	}
+	v2MainCommit, err := repo.CommitObject(v2MainRef.Hash())
+	if err != nil {
+		return 0, fmt.Errorf("read v2 /main commit: %w", err)
+	}
+	v2MainTree, err := v2MainCommit.Tree()
+	if err != nil {
+		return 0, fmt.Errorf("read v2 /main tree: %w", err)
+	}
+
+	checkpointTree, err := v2MainTree.Tree(checkpointID.Path())
+	if err != nil {
+		return 0, fmt.Errorf("read checkpoint subtree on v2 /main: %w", err)
+	}
+
+	metadataFile, err := checkpointTree.File(paths.MetadataFileName)
+	if err != nil {
+		return 0, fmt.Errorf("read checkpoint summary metadata: %w", err)
+	}
+	metadataContent, err := metadataFile.Contents()
+	if err != nil {
+		return 0, fmt.Errorf("read checkpoint summary contents: %w", err)
+	}
+
+	var summary cpkg.CheckpointSummary
+	if err := json.Unmarshal([]byte(metadataContent), &summary); err != nil {
+		return 0, fmt.Errorf("parse checkpoint summary metadata: %w", err)
+	}
+
+	for i := range len(summary.Sessions) {
+		sessionTree, err := checkpointTree.Tree(strconv.Itoa(i))
+		if err != nil {
+			continue
+		}
+		sessionMetadataFile, err := sessionTree.File(paths.MetadataFileName)
+		if err != nil {
+			continue
+		}
+		sessionMetadataContent, err := sessionMetadataFile.Contents()
+		if err != nil {
+			continue
+		}
+
+		var sessionMeta cpkg.CommittedMetadata
+		if err := json.Unmarshal([]byte(sessionMetadataContent), &sessionMeta); err != nil {
+			continue
+		}
+		if sessionMeta.SessionID == sessionID {
+			return i, nil
+		}
+	}
+
+	return 0, fmt.Errorf("session %q not found in v2 checkpoint %s", sessionID, checkpointID)
+}
+
+func spliceTaskTreeToV2FullCurrent(
+	repo *git.Repository,
+	v2Store *cpkg.V2GitStore,
+	checkpointID id.CheckpointID,
+	sessionIndex int,
+	tasksTreeHash plumbing.Hash,
+) error {
+	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+	parentHash, rootTreeHash, err := v2Store.GetRefState(refName)
+	if err != nil {
+		return fmt.Errorf("get v2 /full/current ref state: %w", err)
+	}
+	incomingTasksTree, err := repo.TreeObject(tasksTreeHash)
+	if err != nil {
+		return fmt.Errorf("read task tree: %w", err)
+	}
+
+	shardPrefix := string(checkpointID[:2])
+	shardSuffix := string(checkpointID[2:])
+	sessionDir := strconv.Itoa(sessionIndex)
+
+	newRootHash, err := cpkg.UpdateSubtree(repo, rootTreeHash,
+		[]string{shardPrefix, shardSuffix, sessionDir, "tasks"},
+		incomingTasksTree.Entries,
+		cpkg.UpdateSubtreeOptions{MergeMode: cpkg.MergeKeepExisting},
+	)
+	if err != nil {
+		return fmt.Errorf("splice task tree into v2 /full/current: %w", err)
+	}
+
+	authorName, authorEmail := cpkg.GetGitAuthorFromRepo(repo)
+	commitHash, err := cpkg.CreateCommit(repo, newRootHash, parentHash,
+		fmt.Sprintf("Checkpoint: %s (task metadata)\n", checkpointID),
+		authorName, authorEmail)
+	if err != nil {
+		return fmt.Errorf("create v2 task metadata commit: %w", err)
+	}
+
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)); err != nil {
+		return fmt.Errorf("update v2 /full/current ref: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -27,6 +27,8 @@ import (
 
 const testTrailerCheckpointID id.CheckpointID = "a1b2c3d4e5f6"
 
+const testCheckpointsV2SettingsJSON = `{"enabled": true, "strategy": "manual-commit", "strategy_options": {"checkpoints_v2": true}}`
+
 // testTranscriptPromptResponse is a minimal transcript used across strategy tests.
 const testTranscriptPromptResponse = "{\"type\":\"human\",\"message\":{\"content\":\"test prompt\"}}\n{\"type\":\"assistant\",\"message\":{\"content\":\"test response\"}}\n"
 
@@ -4202,8 +4204,7 @@ func TestCondenseSession_V2DualWrite(t *testing.T) {
 	// Enable checkpoints_v2 via settings
 	entireDir := filepath.Join(dir, ".entire")
 	require.NoError(t, os.MkdirAll(entireDir, 0o755))
-	settingsJSON := `{"enabled": true, "strategy": "manual-commit", "strategy_options": {"checkpoints_v2": true}}`
-	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(testCheckpointsV2SettingsJSON), 0o644))
 
 	s := &ManualCommitStrategy{}
 	sessionID := "2025-01-15-test-v2-dual-write"
@@ -4308,8 +4309,7 @@ func TestCondenseSession_V2DualWrite_CopiesTaskMetadataToFullCurrent(t *testing.
 
 	entireDir := filepath.Join(dir, ".entire")
 	require.NoError(t, os.MkdirAll(entireDir, 0o755))
-	settingsJSON := `{"enabled": true, "strategy": "manual-commit", "strategy_options": {"checkpoints_v2": true}}`
-	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(testCheckpointsV2SettingsJSON), 0o644))
 
 	s := &ManualCommitStrategy{}
 	sessionID := "2025-01-15-test-v2-task-dual-write"
@@ -4397,8 +4397,7 @@ func TestCondenseSession_V2CompactTranscriptStart(t *testing.T) {
 	// Enable checkpoints_v2 via settings
 	entireDir := filepath.Join(dir, ".entire")
 	require.NoError(t, os.MkdirAll(entireDir, 0o755))
-	settingsJSON := `{"enabled": true, "strategy": "manual-commit", "strategy_options": {"checkpoints_v2": true}}`
-	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(testCheckpointsV2SettingsJSON), 0o644))
 
 	s := &ManualCommitStrategy{}
 	sessionID := "2025-01-15-test-v2-compact-start"

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -4295,19 +4295,14 @@ func TestCondenseSession_V2DualWrite(t *testing.T) {
 
 func TestCondenseSession_V2DualWrite_CopiesTaskMetadataToFullCurrent(t *testing.T) {
 	dir := t.TempDir()
-	repo, err := git.PlainInit(dir, false)
-	require.NoError(t, err)
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "main.go", "package main")
+	testutil.GitAdd(t, dir, "main.go")
+	testutil.GitCommit(t, dir, "Initial commit")
 
-	worktree, err := repo.Worktree()
+	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
-
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o644))
-	_, err = worktree.Add("main.go")
-	require.NoError(t, err)
-	commitHash, err := worktree.Commit("Initial commit", &git.CommitOptions{
-		Author: &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()},
-	})
-	require.NoError(t, err)
+	commitHash := testutil.GetHeadHash(t, dir)
 
 	t.Chdir(dir)
 
@@ -4363,7 +4358,7 @@ func TestCondenseSession_V2DualWrite_CopiesTaskMetadataToFullCurrent(t *testing.
 	state, err := s.loadSessionState(context.Background(), sessionID)
 	require.NoError(t, err)
 	state.TranscriptPath = transcriptPath
-	state.BaseCommit = commitHash.String()[:7]
+	state.BaseCommit = commitHash[:7]
 	state.AgentType = agent.AgentTypeClaudeCode
 
 	checkpointID := id.MustCheckpointID("ab11cd22ef33")

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -4293,6 +4293,97 @@ func TestCondenseSession_V2DualWrite(t *testing.T) {
 	require.NoError(t, err, "raw_transcript should exist on /full/current")
 }
 
+func TestCondenseSession_V2DualWrite_CopiesTaskMetadataToFullCurrent(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o644))
+	_, err = worktree.Add("main.go")
+	require.NoError(t, err)
+	commitHash, err := worktree.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	t.Chdir(dir)
+
+	entireDir := filepath.Join(dir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	settingsJSON := `{"enabled": true, "strategy": "manual-commit", "strategy_options": {"checkpoints_v2": true}}`
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644))
+
+	s := &ManualCommitStrategy{}
+	sessionID := "2025-01-15-test-v2-task-dual-write"
+
+	metadataDir := ".entire/metadata/" + sessionID
+	metadataDirAbs := filepath.Join(dir, metadataDir)
+	require.NoError(t, os.MkdirAll(metadataDirAbs, 0o755))
+
+	transcript := `{"type":"human","message":{"content":"hello"}}
+{"type":"assistant","message":{"content":"hi there"}}
+`
+	transcriptPath := filepath.Join(metadataDirAbs, paths.TranscriptFileName)
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+
+	// Create shadow branch/session checkpoint data.
+	err = s.SaveStep(context.Background(), StepContext{
+		SessionID:      sessionID,
+		ModifiedFiles:  []string{"main.go"},
+		MetadataDir:    metadataDir,
+		MetadataDirAbs: metadataDirAbs,
+		CommitMessage:  "Checkpoint 1",
+		AuthorName:     "Test",
+		AuthorEmail:    "test@test.com",
+	})
+	require.NoError(t, err)
+
+	subagentTranscriptPath := filepath.Join(metadataDirAbs, "subagent.jsonl")
+	require.NoError(t, os.WriteFile(subagentTranscriptPath, []byte("{\"type\":\"event\",\"message\":\"done\"}\n"), 0o644))
+
+	err = s.SaveTaskStep(context.Background(), TaskStepContext{
+		SessionID:              sessionID,
+		ToolUseID:              "toolu_01TASK",
+		AgentID:                "agent-01",
+		ModifiedFiles:          []string{"main.go"},
+		TranscriptPath:         transcriptPath,
+		SubagentTranscriptPath: subagentTranscriptPath,
+		CheckpointUUID:         "uuid-task-001",
+		AuthorName:             "Test",
+		AuthorEmail:            "test@test.com",
+		SubagentType:           "general",
+		TaskDescription:        "Implement task",
+		AgentType:              agent.AgentTypeClaudeCode,
+	})
+	require.NoError(t, err)
+
+	state, err := s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	state.TranscriptPath = transcriptPath
+	state.BaseCommit = commitHash.String()[:7]
+	state.AgentType = agent.AgentTypeClaudeCode
+
+	checkpointID := id.MustCheckpointID("ab11cd22ef33")
+	result, err := s.CondenseSession(context.Background(), repo, checkpointID, state, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	v2FullRef, err := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
+	require.NoError(t, err, "v2 /full/current ref should exist")
+
+	v2FullCommit, err := repo.CommitObject(v2FullRef.Hash())
+	require.NoError(t, err)
+	v2FullTree, err := v2FullCommit.Tree()
+	require.NoError(t, err)
+
+	taskCheckpointPath := checkpointID.Path() + "/0/tasks/toolu_01TASK/checkpoint.json"
+	_, err = v2FullTree.File(taskCheckpointPath)
+	require.NoError(t, err, "task checkpoint metadata should be copied to v2 /full/current")
+}
+
 // TestCondenseSession_V2CompactTranscriptStart verifies v2 /main writes
 // checkpoint_transcript_start from compact transcript offset, not full.jsonl offset.
 func TestCondenseSession_V2CompactTranscriptStart(t *testing.T) {

--- a/cmd/entire/cli/strategy/phase_postcommit_test.go
+++ b/cmd/entire/cli/strategy/phase_postcommit_test.go
@@ -1380,8 +1380,7 @@ func TestHandleTurnEnd_V2FullCurrent_PreservesTaskMetadata(t *testing.T) {
 	// Enable checkpoints_v2 dual-write so PostCommit/HandleTurnEnd update v2 refs.
 	entireDir := filepath.Join(dir, ".entire")
 	require.NoError(t, os.MkdirAll(entireDir, 0o755))
-	settingsJSON := `{"enabled": true, "strategy": "manual-commit", "strategy_options": {"checkpoints_v2": true}}`
-	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(testCheckpointsV2SettingsJSON), 0o644))
 
 	s := &ManualCommitStrategy{}
 	sessionID := "test-turn-end-v2-task-preserve"

--- a/cmd/entire/cli/strategy/phase_postcommit_test.go
+++ b/cmd/entire/cli/strategy/phase_postcommit_test.go
@@ -1370,6 +1370,93 @@ func TestHandleTurnEnd_PartialFailure(t *testing.T) {
 	}
 }
 
+func TestHandleTurnEnd_V2FullCurrent_PreservesTaskMetadata(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	// Enable checkpoints_v2 dual-write so PostCommit/HandleTurnEnd update v2 refs.
+	entireDir := filepath.Join(dir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	settingsJSON := `{"enabled": true, "strategy": "manual-commit", "strategy_options": {"checkpoints_v2": true}}`
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(settingsJSON), 0o644))
+
+	s := &ManualCommitStrategy{}
+	sessionID := "test-turn-end-v2-task-preserve"
+
+	metadataDir := ".entire/metadata/" + sessionID
+	metadataDirAbs := filepath.Join(dir, metadataDir)
+	require.NoError(t, os.MkdirAll(metadataDirAbs, 0o755))
+	transcriptPath := filepath.Join(metadataDirAbs, paths.TranscriptFileName)
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(testTranscriptPromptResponse), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.txt"), []byte("agent modified content"), 0o644))
+	err = s.SaveStep(context.Background(), StepContext{
+		SessionID:      sessionID,
+		ModifiedFiles:  []string{"test.txt"},
+		MetadataDir:    metadataDir,
+		MetadataDirAbs: metadataDirAbs,
+		CommitMessage:  "Checkpoint 1",
+		AuthorName:     "Test",
+		AuthorEmail:    "test@test.com",
+	})
+	require.NoError(t, err)
+
+	subagentTranscriptPath := filepath.Join(metadataDirAbs, "subagent.jsonl")
+	require.NoError(t, os.WriteFile(subagentTranscriptPath, []byte("{\"type\":\"event\",\"message\":\"done\"}\n"), 0o644))
+	err = s.SaveTaskStep(context.Background(), TaskStepContext{
+		SessionID:              sessionID,
+		ToolUseID:              "toolu_01TASK",
+		AgentID:                "agent-01",
+		ModifiedFiles:          []string{"test.txt"},
+		TranscriptPath:         transcriptPath,
+		SubagentTranscriptPath: subagentTranscriptPath,
+		CheckpointUUID:         "uuid-task-001",
+		AuthorName:             "Test",
+		AuthorEmail:            "test@test.com",
+		SubagentType:           "general",
+		TaskDescription:        "Implement task",
+		AgentType:              agent.AgentTypeClaudeCode,
+	})
+	require.NoError(t, err)
+
+	state, err := s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	state.Phase = session.PhaseActive
+	state.TurnCheckpointIDs = nil
+	require.NoError(t, s.saveSessionState(context.Background(), state))
+
+	cpID := "a1b2c3d4e5f6"
+	commitWithCheckpointTrailer(t, repo, dir, cpID)
+	require.NoError(t, s.PostCommit(context.Background()))
+
+	state, err = s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Equal(t, []string{cpID}, state.TurnCheckpointIDs)
+
+	fullTranscript := `{"type":"human","message":{"content":"final user prompt"}}
+{"type":"assistant","message":{"content":"final assistant response"}}
+`
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(fullTranscript), 0o644))
+	state.TranscriptPath = transcriptPath
+	require.NoError(t, s.saveSessionState(context.Background(), state))
+
+	require.NoError(t, s.HandleTurnEnd(context.Background(), state))
+
+	v2FullRef, err := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
+	require.NoError(t, err)
+	v2FullCommit, err := repo.CommitObject(v2FullRef.Hash())
+	require.NoError(t, err)
+	v2FullTree, err := v2FullCommit.Tree()
+	require.NoError(t, err)
+
+	checkpointID := id.MustCheckpointID(cpID)
+	_, err = v2FullTree.File(checkpointID.Path() + "/0/tasks/toolu_01TASK/checkpoint.json")
+	require.NoError(t, err, "task metadata should be preserved after HandleTurnEnd finalization")
+}
+
 // setupSessionWithCheckpoint initializes a session and creates one checkpoint
 // on the shadow branch so there is content available for condensation.
 // Also modifies test.txt to "agent modified content" and includes it in the checkpoint,


### PR DESCRIPTION
## Summary
- dual-write task checkpoint metadata from shadow session trees into `refs/entire/checkpoints/v2/full/current` during condensation so new task checkpoints are available in v2 without requiring migration
- preserve non-transcript session artifacts (including `tasks/*`) during stop-time `UpdateCommitted` by clearing only raw transcript chunks and transcript hash files
- add regression coverage at both store and strategy layers for condensation and `HandleTurnEnd` finalization paths to ensure v2 task metadata survives updates

## Testing
- `go test ./cmd/entire/cli/strategy -run TestCondenseSession_V2DualWrite_CopiesTaskMetadataToFullCurrent -count=1`
- `go test ./cmd/entire/cli/checkpoint -run TestV2GitStore_UpdateCommitted_PreservesExistingTaskMetadataInFullCurrent -count=1`
- `go test ./cmd/entire/cli/strategy -run TestHandleTurnEnd_V2FullCurrent_PreservesTaskMetadata -count=1`
- `go build ./...`
- `go vet ./...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint persistence logic on git-backed refs and changes how subtree entries are deleted/merged, which could impact stored checkpoint artifacts if paths or session indexing are wrong; coverage is added to reduce regression risk.
> 
> **Overview**
> Fixes v2 checkpoint dual-write so *task rewind metadata* (`tasks/*`) is immediately available in `refs/entire/checkpoints/v2/full/current` during condensation, without requiring a later `migrate` backfill.
> 
> Updates `V2GitStore.UpdateCommitted` to only clear raw transcript blobs/hashes when finalizing a session, preserving any other session-scoped artifacts (notably `tasks/*`). Adds regression tests at the store and strategy layers covering condensation and `HandleTurnEnd` finalization to ensure task metadata survives transcript updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f61c15689ccf9b670f3be1f05add2f637cc083c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->