### PR TITLE
fix: nightly workflow fails instead of skipping when tag exists

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Create nightly tag
         run: |
-          TAG=$(scripts/create-nightly-tag.sh)
-          EXIT_CODE=$?
+          TAG=$(scripts/create-nightly-tag.sh) && EXIT_CODE=0 || EXIT_CODE=$?
           if [ "$EXIT_CODE" -eq 2 ]; then
             echo "Skipping — no new nightly needed."
             exit 0


### PR DESCRIPTION
## Summary

- Nightly release workflow marked as failed when tag already existed for HEAD commit, even though the script intended to skip gracefully
- Root cause: GitHub Actions default `bash -e` aborts before `EXIT_CODE=$?` runs, so exit code 2 from `create-nightly-tag.sh` propagates as step failure
- Fix: capture exit code inline (`&& EXIT_CODE=0 || EXIT_CODE=$?`) so the skip logic executes

Example -> https://github.com/entireio/cli/actions/runs/24329879507

## Test plan

- [ ] Trigger nightly workflow on a commit that already has a nightly tag — should show "Skipping" and succeed
- [ ] Trigger on a commit without a nightly tag — should create and push the tag as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI-only change to shell exit-code handling; low risk beyond potentially masking unexpected failures if exit codes are misinterpreted.
> 
> **Overview**
> Fixes the nightly GitHub Actions workflow so it no longer fails when `scripts/create-nightly-tag.sh` exits with the "skip" code.
> 
> The `Create nightly tag` step now captures the script’s exit status inline (compatible with default `bash -e`) so exit code `2` triggers the existing "Skipping — no new nightly needed" path, while other non-zero exits still fail the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6b30cd3adf8c9b09468bc7f41cf91db5b45a6c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->