### PR TITLE
fix hanging summary tty in local tests

### DIFF
--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1309,6 +1309,7 @@ func TestRunExplainCheckpoint_V2UsesCompactTranscriptForIntent(t *testing.T) {
 func TestRunExplainCheckpoint_V2PreferredGenerateWritesBothStores(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	t.Setenv("ENTIRE_TEST_TTY", "0") // prevent interactive summary provider prompt
 
 	testutil.InitRepo(t, tmpDir)
 	repo, err := git.PlainOpen(tmpDir)
@@ -1370,6 +1371,7 @@ func TestRunExplainCheckpoint_V2PreferredGenerateWritesBothStores(t *testing.T) 
 func TestRunExplainCheckpoint_V2OnlyGenerateSucceedsViaV2Store(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	t.Setenv("ENTIRE_TEST_TTY", "0") // prevent interactive summary provider prompt
 
 	testutil.InitRepo(t, tmpDir)
 	repo, err := git.PlainOpen(tmpDir)
@@ -1481,6 +1483,7 @@ func TestRunExplainCheckpoint_V2FallsBackToFullWhenCompactMissing(t *testing.T) 
 func TestRunExplainCheckpoint_V2CompactTranscriptNotUsedForGenerate(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
+	t.Setenv("ENTIRE_TEST_TTY", "0") // prevent interactive summary provider prompt
 
 	testutil.InitRepo(t, tmpDir)
 	repo, err := git.PlainOpen(tmpDir)


### PR DESCRIPTION
```❯ mise run test
[test] $ go test ./...
?       github.com/entireio/cli/cmd/entire      [no test files]
^CError: not a git repository
┃ Choose a summary provider
┃ This choice will be saved. Use `entire configure` to change it later.
┃ > Claude Code
┃   Codex
┃   Copilot CLI
┃   Cursor
┃   Gemini CLI
```

This worked in CI because there is no tty available and also no agents installed but it triggered on my local machine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that sets an env var to avoid interactive prompts; no production behavior changes.
> 
> **Overview**
> Prevents local `go test` runs from hanging by forcing summary-provider selection into non-interactive mode in `explain` checkpoint generation tests.
> 
> Adds `ENTIRE_TEST_TTY=0` to the v2 `--generate`-related tests in `explain_test.go` so they don’t prompt for a TTY-based provider choice when run on a developer machine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 978a2b7a0c5308b45cef1b2186da293126a8011d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->