### PR TITLE
Fix more TTY-dependent local CI tests

### DIFF
--- a/cmd/entire/cli/strategy/condense_skip_test.go
+++ b/cmd/entire/cli/strategy/condense_skip_test.go
@@ -211,6 +211,7 @@ func TestCondenseAndMarkFullyCondensed_SkippedMarksFullyCondensed(t *testing.T) 
 }
 
 func TestTryAgentCommitFastPath_SkipsEmptySession(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
 	dir := setupGitRepo(t)
 	t.Chdir(dir)
 
@@ -241,6 +242,7 @@ func TestTryAgentCommitFastPath_SkipsEmptySession(t *testing.T) {
 }
 
 func TestTryAgentCommitFastPath_AcceptsSessionWithContent(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
 	dir := setupGitRepo(t)
 	t.Chdir(dir)
 
@@ -268,6 +270,7 @@ func TestTryAgentCommitFastPath_AcceptsSessionWithContent(t *testing.T) {
 }
 
 func TestTryAgentCommitFastPath_SkipsEmptyButAcceptsContentSession(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
 	dir := setupGitRepo(t)
 	t.Chdir(dir)
 


### PR DESCRIPTION
tryAgentCommitFastPath() only fires when hasTTY() is false.

This was resulting in local test failures for these tests.

@pfleidi and I were both running into these failures via `mise test:ci` 

```
--- FAIL: TestTryAgentCommitFastPath_AcceptsSessionWithContent (0.01s)
    condense_skip_test.go:262:
                Error Trace:    /Users/pfleidi/entire/cli/cmd/entire/cli/strategy/condense_skip_test.go:262
                Error:          Should be true
                Test:           TestTryAgentCommitFastPath_AcceptsSessionWithContent
                Messages:       fast path should fire for session with content
    condense_skip_test.go:267:
                Error Trace:    /Users/pfleidi/entire/cli/cmd/entire/cli/strategy/condense_skip_test.go:267
                Error:          "test commit\n" does not contain "Entire-Checkpoint"
                Test:           TestTryAgentCommitFastPath_AcceptsSessionWithContent
                Messages:       should add trailer for session with content
--- FAIL: TestTryAgentCommitFastPath_SkipsEmptyButAcceptsContentSession (0.01s)
    condense_skip_test.go:294:
                Error Trace:    /Users/pfleidi/entire/cli/cmd/entire/cli/strategy/condense_skip_test.go:294
                Error:          Should be true
                Test:           TestTryAgentCommitFastPath_SkipsEmptyButAcceptsContentSession
                Messages:       fast path should fire for the content session
    condense_skip_test.go:298:
                Error Trace:    /Users/pfleidi/entire/cli/cmd/entire/cli/strategy/condense_skip_test.go:298
                Error:          "test commit\n" does not contain "Entire-Checkpoint"
                Test:           TestTryAgentCommitFastPath_SkipsEmptyButAcceptsContentSession
                Messages:       should add trailer from the content session
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that sets `ENTIRE_TEST_TTY=0` to make TTY detection deterministic and avoid hangs/failures in local CI; no production logic is modified.
> 
> **Overview**
> Makes the `tryAgentCommitFastPath` regression tests deterministic by explicitly setting `ENTIRE_TEST_TTY=0` so `hasTTY()` is forced false and the non-interactive fast path is exercised consistently.
> 
> This prevents local/CI runs from unexpectedly taking the TTY-dependent path and failing to add the `Entire-Checkpoint` trailer in `condense_skip_test.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700aace0f448981581606b42b42fe5fa5fc7018b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->