### PR TITLE
feat: add sidecar commit log for session timeline reconstruction

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -308,6 +308,11 @@ type WriteCommittedOptions struct {
 	// Written to v2 /main ref alongside metadata. May be nil if compaction
 	// was not performed (unknown agent, compaction error, empty transcript).
 	CompactTranscript []byte
+
+	// CommitLog is the session's accumulated commit log (commits.jsonl) bytes.
+	// Each line is a JSON object recording a condensed commit in the session timeline.
+	// Nil means no commit log to write.
+	CommitLog []byte
 }
 
 // UpdateCommittedOptions contains options for updating an existing committed checkpoint.

--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -425,6 +425,11 @@ type SessionContent struct {
 
 	// Prompts contains user prompts from this session
 	Prompts string
+
+	// CommitLog is the session's accumulated commit timeline (commits.jsonl).
+	// Each line is a JSON object recording a condensed commit. May be empty
+	// for checkpoints created before this feature.
+	CommitLog []byte
 }
 
 // CommittedMetadata contains the metadata stored in metadata.json for each checkpoint.

--- a/cmd/entire/cli/checkpoint/checkpoint_test.go
+++ b/cmd/entire/cli/checkpoint/checkpoint_test.go
@@ -4288,3 +4288,29 @@ func TestWriteTemporaryTask_ExcludesGitIgnoredFiles(t *testing.T) {
 		t.Error("SECURITY: gitignored file .env leaked into task checkpoint tree — secrets exposed on shadow branch via subagent")
 	}
 }
+
+func TestV1CommitLog_WrittenAndReadable(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo)
+	cpID := id.MustCheckpointID("c1c2c3c4c5c6")
+	ctx := context.Background()
+
+	commitLog := []byte(`{"hash":"abc","short_hash":"abc1234","subject":"Test commit","checkpoint_id":"c1c2c3c4c5c6","session_id":"s1"}` + "\n")
+
+	err := store.WriteCommitted(ctx, WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "s1",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(`{"message": "hello"}`)),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+		CommitLog:    commitLog,
+	})
+	require.NoError(t, err)
+
+	content, err := store.ReadSessionContent(ctx, cpID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, content)
+	require.Equal(t, commitLog, content.CommitLog)
+}

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -383,6 +383,19 @@ func (s *GitStore) writeSessionToSubdirectory(ctx context.Context, opts WriteCom
 		filePaths.Prompt = "/" + sessionPath + paths.PromptFileName
 	}
 
+	// Write commit log (session timeline of condensed commits)
+	if len(opts.CommitLog) > 0 {
+		blobHash, err := CreateBlobFromContent(s.repo, opts.CommitLog)
+		if err != nil {
+			return filePaths, err
+		}
+		entries[sessionPath+paths.CommitLogFileName] = object.TreeEntry{
+			Name: sessionPath + paths.CommitLogFileName,
+			Mode: filemode.Regular,
+			Hash: blobHash,
+		}
+	}
+
 	// Write session-level metadata.json (CommittedMetadata with all fields including initial_attribution)
 	sessionMetadata := CommittedMetadata{
 		CheckpointID:                opts.CheckpointID,

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -1013,6 +1013,13 @@ func (s *GitStore) ReadSessionContent(ctx context.Context, checkpointID id.Check
 		}
 	}
 
+	// Read commit log (auto-fetches blob if needed)
+	if file, fileErr := sessionTree.File(paths.CommitLogFileName); fileErr == nil {
+		if content, contentErr := file.Contents(); contentErr == nil {
+			result.CommitLog = []byte(content)
+		}
+	}
+
 	if len(result.Transcript) == 0 {
 		return nil, ErrNoTranscript
 	}

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -444,6 +444,19 @@ func (s *V2GitStore) writeMainSessionToSubdirectory(opts WriteCommittedOptions, 
 	}
 	filePaths.Metadata = "/" + sessionPath + paths.MetadataFileName
 
+	// Write commit log (session timeline of condensed commits)
+	if len(opts.CommitLog) > 0 {
+		blobHash, err := CreateBlobFromContent(s.repo, opts.CommitLog)
+		if err != nil {
+			return filePaths, err
+		}
+		entries[sessionPath+paths.CommitLogFileName] = object.TreeEntry{
+			Name: sessionPath + paths.CommitLogFileName,
+			Mode: filemode.Regular,
+			Hash: blobHash,
+		}
+	}
+
 	return filePaths, nil
 }
 

--- a/cmd/entire/cli/checkpoint/v2_read.go
+++ b/cmd/entire/cli/checkpoint/v2_read.go
@@ -236,6 +236,13 @@ func (s *V2GitStore) ReadSessionMetadataAndPrompts(ctx context.Context, checkpoi
 		}
 	}
 
+	// Read commit log from the same session tree.
+	if file, fileErr := sessionTree.File(paths.CommitLogFileName); fileErr == nil {
+		if content, contentErr := file.Contents(); contentErr == nil {
+			result.CommitLog = []byte(content)
+		}
+	}
+
 	return result, nil
 }
 
@@ -285,6 +292,13 @@ func (s *V2GitStore) ReadSessionContent(ctx context.Context, checkpointID id.Che
 	if file, fileErr := sessionTree.File(paths.PromptFileName); fileErr == nil {
 		if content, contentErr := file.Contents(); contentErr == nil {
 			result.Prompts = content
+		}
+	}
+
+	// Read commit log from /main session tree
+	if file, fileErr := sessionTree.File(paths.CommitLogFileName); fileErr == nil {
+		if content, contentErr := file.Contents(); contentErr == nil {
+			result.CommitLog = []byte(content)
 		}
 	}
 

--- a/cmd/entire/cli/checkpoint/v2_read_test.go
+++ b/cmd/entire/cli/checkpoint/v2_read_test.go
@@ -367,3 +367,60 @@ func TestV2UpdateSummary_NotFound(t *testing.T) {
 	err := store.UpdateSummary(ctx, id.MustCheckpointID("000000000000"), &Summary{Intent: "x"})
 	require.ErrorIs(t, err, ErrCheckpointNotFound)
 }
+
+func TestV2CommitLog_WrittenAndReadable(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+	cpID := id.MustCheckpointID("c1c2c3c4c5c6")
+	ctx := context.Background()
+
+	commitLog := []byte(`{"hash":"abc","short_hash":"abc1234","subject":"Test commit","checkpoint_id":"c1c2c3c4c5c6","session_id":"s1"}` + "\n")
+
+	err := store.WriteCommitted(ctx, WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "s1",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(`{"message": "hello"}`)),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+		CommitLog:    commitLog,
+	})
+	require.NoError(t, err)
+
+	// Read via ReadSessionContent
+	content, err := store.ReadSessionContent(ctx, cpID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, content)
+	assert.Equal(t, commitLog, content.CommitLog)
+
+	// Read via ReadSessionMetadataAndPrompts
+	metaContent, err := store.ReadSessionMetadataAndPrompts(ctx, cpID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, metaContent)
+	assert.Equal(t, commitLog, metaContent.CommitLog)
+}
+
+func TestV2CommitLog_EmptyWhenNotSet(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+	cpID := id.MustCheckpointID("d1d2d3d4d5d6")
+	ctx := context.Background()
+
+	err := store.WriteCommitted(ctx, WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "s1",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(`{"message": "hello"}`)),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+		// No CommitLog
+	})
+	require.NoError(t, err)
+
+	content, err := store.ReadSessionContent(ctx, cpID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, content)
+	assert.Empty(t, content.CommitLog)
+}

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -991,6 +993,19 @@ func formatCheckpointOutput(summary *checkpoint.CheckpointSummary, content *chec
 	} else if associatedCommits != nil {
 		// associatedCommits is non-nil but empty - show "no commits found" message
 		sb.WriteString("\nCommits: No commits found on this branch\n")
+	}
+
+	// Session timeline from sidecar commit log
+	if entries := parseCommitLog(content.CommitLog); len(entries) > 1 {
+		sb.WriteString("\n")
+		fmt.Fprintf(&sb, "Session Timeline: (%d commits)\n", len(entries))
+		for _, e := range entries {
+			marker := "  "
+			if e.CheckpointID == string(checkpointID) {
+				marker = "→ "
+			}
+			fmt.Fprintf(&sb, "  %s%s %s %s [%s]\n", marker, e.ShortHash, e.Timestamp.Format("2006-01-02 15:04"), e.Subject, e.CheckpointID[:7])
+		}
 	}
 
 	sb.WriteString("\n")
@@ -2046,4 +2061,22 @@ func hasAnyChanges(commit *object.Commit) bool {
 		return true
 	}
 	return commit.TreeHash != parent.TreeHash
+}
+
+// parseCommitLog parses the sidecar commits.jsonl bytes into entries.
+func parseCommitLog(data []byte) []strategy.CommitLogEntry {
+	if len(data) == 0 {
+		return nil
+	}
+	var entries []strategy.CommitLogEntry
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var entry strategy.CommitLogEntry
+		if err := json.Unmarshal(line, &entry); err == nil {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
 }

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -5014,3 +5014,102 @@ func createCommitWithTree(t *testing.T, repo *git.Repository, treeHash plumbing.
 	}
 	return hash
 }
+
+func TestParseCommitLog(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		entries := parseCommitLog(nil)
+		require.Empty(t, entries)
+	})
+
+	t.Run("single entry", func(t *testing.T) {
+		data := []byte(`{"hash":"abc","short_hash":"abc123d","subject":"Add login","timestamp":"2026-04-16T12:00:00Z","checkpoint_id":"a3b2c4d5e6f7","session_id":"s1"}` + "\n")
+		entries := parseCommitLog(data)
+		require.Len(t, entries, 1)
+		require.Equal(t, "abc123d", entries[0].ShortHash)
+		require.Equal(t, "Add login", entries[0].Subject)
+	})
+
+	t.Run("multiple entries", func(t *testing.T) {
+		data := []byte(`{"hash":"a","short_hash":"a123456","subject":"First","timestamp":"2026-04-16T12:00:00Z","checkpoint_id":"cp1aaaaaaaaa","session_id":"s1"}
+{"hash":"b","short_hash":"b234567","subject":"Second","timestamp":"2026-04-16T13:00:00Z","checkpoint_id":"cp2bbbbbbbbb","session_id":"s1"}
+`)
+		entries := parseCommitLog(data)
+		require.Len(t, entries, 2)
+		require.Equal(t, "First", entries[0].Subject)
+		require.Equal(t, "Second", entries[1].Subject)
+	})
+}
+
+func TestFormatCheckpointOutput_SessionTimeline(t *testing.T) {
+	cpID := id.MustCheckpointID("b4c3d5e6f7a8")
+
+	commitLog := []byte(`{"hash":"aaa","short_hash":"aaa1234","subject":"First commit","timestamp":"2026-04-16T12:00:00Z","checkpoint_id":"a3b2c4d5e6f7","session_id":"s1"}
+{"hash":"bbb","short_hash":"bbb5678","subject":"Second commit","timestamp":"2026-04-16T13:00:00Z","checkpoint_id":"b4c3d5e6f7a8","session_id":"s1"}
+`)
+
+	content := &checkpoint.SessionContent{
+		Metadata: checkpoint.CommittedMetadata{
+			CheckpointID: cpID,
+			SessionID:    "s1",
+			CreatedAt:    time.Date(2026, 4, 16, 13, 0, 0, 0, time.UTC),
+		},
+		Transcript: []byte(`{"type":"user","message":{"content":"test"}}`),
+		CommitLog:  commitLog,
+	}
+
+	output := formatCheckpointOutput(nil, content, cpID, nil, checkpoint.Author{}, false, false)
+
+	// Should show session timeline with 2 commits
+	require.Contains(t, output, "Session Timeline: (2 commits)")
+	// Should show both commits
+	require.Contains(t, output, "aaa1234")
+	require.Contains(t, output, "First commit")
+	require.Contains(t, output, "bbb5678")
+	require.Contains(t, output, "Second commit")
+	// Current checkpoint should be marked with arrow
+	require.Contains(t, output, "→ bbb5678")
+	// Truncated checkpoint IDs shown
+	require.Contains(t, output, "[a3b2c4d")
+	require.Contains(t, output, "[b4c3d5e")
+}
+
+func TestFormatCheckpointOutput_NoTimelineForSingleCommit(t *testing.T) {
+	cpID := id.MustCheckpointID("a3b2c4d5e6f7")
+
+	commitLog := []byte(`{"hash":"aaa","short_hash":"aaa1234","subject":"Only commit","timestamp":"2026-04-16T12:00:00Z","checkpoint_id":"a3b2c4d5e6f7","session_id":"s1"}
+`)
+
+	content := &checkpoint.SessionContent{
+		Metadata: checkpoint.CommittedMetadata{
+			CheckpointID: cpID,
+			SessionID:    "s1",
+			CreatedAt:    time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC),
+		},
+		Transcript: []byte(`{"type":"user","message":{"content":"test"}}`),
+		CommitLog:  commitLog,
+	}
+
+	output := formatCheckpointOutput(nil, content, cpID, nil, checkpoint.Author{}, false, false)
+
+	// Should NOT show timeline for single commit
+	require.NotContains(t, output, "Session Timeline")
+}
+
+func TestFormatCheckpointOutput_NoTimelineWhenEmpty(t *testing.T) {
+	cpID := id.MustCheckpointID("a3b2c4d5e6f7")
+
+	content := &checkpoint.SessionContent{
+		Metadata: checkpoint.CommittedMetadata{
+			CheckpointID: cpID,
+			SessionID:    "s1",
+			CreatedAt:    time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC),
+		},
+		Transcript: []byte(`{"type":"user","message":{"content":"test"}}`),
+		// No CommitLog — pre-existing checkpoint
+	}
+
+	output := formatCheckpointOutput(nil, content, cpID, nil, checkpoint.Author{}, false, false)
+
+	// Should NOT show timeline when no commit log
+	require.NotContains(t, output, "Session Timeline")
+}

--- a/cmd/entire/cli/paths/paths.go
+++ b/cmd/entire/cli/paths/paths.go
@@ -36,6 +36,7 @@ const (
 	MetadataFileName              = "metadata.json"
 	CheckpointFileName            = "checkpoint.json"
 	ContentHashFileName           = "content_hash.txt"
+	CommitLogFileName             = "commits.jsonl"
 	SettingsFileName              = "settings.json"
 )
 

--- a/cmd/entire/cli/strategy/commit_log.go
+++ b/cmd/entire/cli/strategy/commit_log.go
@@ -26,11 +26,16 @@ type CommitLogEntry struct {
 }
 
 // appendCommitLogEntry appends a single JSON line to the session's commit log.
+// Creates the session metadata directory if it does not exist.
 func appendCommitLogEntry(ctx context.Context, sessionID string, entry CommitLogEntry) error {
 	sessionDir := paths.SessionMetadataDirFromSessionID(sessionID)
 	sessionDirAbs, err := paths.AbsPath(ctx, sessionDir)
 	if err != nil {
 		return fmt.Errorf("resolving session dir: %w", err)
+	}
+
+	if err := os.MkdirAll(sessionDirAbs, 0o750); err != nil {
+		return fmt.Errorf("creating session dir: %w", err)
 	}
 
 	logPath := filepath.Join(sessionDirAbs, paths.CommitLogFileName)
@@ -54,7 +59,7 @@ func appendCommitLogEntry(ctx context.Context, sessionID string, entry CommitLog
 }
 
 // readCommitLog reads all entries from a session's commit log.
-// Returns an empty slice (not an error) if the file does not exist.
+// Returns nil (not an error) if the file does not exist.
 func readCommitLog(ctx context.Context, sessionID string) ([]CommitLogEntry, error) {
 	sessionDir := paths.SessionMetadataDirFromSessionID(sessionID)
 	sessionDirAbs, err := paths.AbsPath(ctx, sessionDir)

--- a/cmd/entire/cli/strategy/commit_log.go
+++ b/cmd/entire/cli/strategy/commit_log.go
@@ -1,0 +1,121 @@
+package strategy
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// CommitLogEntry records a single condensed commit in the session's sidecar log.
+// Stored as one JSON line per commit in .entire/metadata/<session-id>/commits.jsonl.
+type CommitLogEntry struct {
+	Hash         string    `json:"hash"`
+	ShortHash    string    `json:"short_hash"`
+	Subject      string    `json:"subject"`
+	Timestamp    time.Time `json:"timestamp"`
+	CheckpointID string    `json:"checkpoint_id"`
+	SessionID    string    `json:"session_id"`
+}
+
+// appendCommitLogEntry appends a single JSON line to the session's commit log.
+func appendCommitLogEntry(ctx context.Context, sessionID string, entry CommitLogEntry) error {
+	sessionDir := paths.SessionMetadataDirFromSessionID(sessionID)
+	sessionDirAbs, err := paths.AbsPath(ctx, sessionDir)
+	if err != nil {
+		return fmt.Errorf("resolving session dir: %w", err)
+	}
+
+	logPath := filepath.Join(sessionDirAbs, paths.CommitLogFileName)
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshaling commit log entry: %w", err)
+	}
+	data = append(data, '\n')
+
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:gosec // path derived from session ID
+	if err != nil {
+		return fmt.Errorf("opening commit log: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("writing commit log entry: %w", err)
+	}
+	return nil
+}
+
+// readCommitLog reads all entries from a session's commit log.
+// Returns an empty slice (not an error) if the file does not exist.
+func readCommitLog(ctx context.Context, sessionID string) ([]CommitLogEntry, error) {
+	sessionDir := paths.SessionMetadataDirFromSessionID(sessionID)
+	sessionDirAbs, err := paths.AbsPath(ctx, sessionDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving session dir: %w", err)
+	}
+
+	logPath := filepath.Join(sessionDirAbs, paths.CommitLogFileName)
+
+	f, err := os.Open(logPath) //nolint:gosec // path derived from session ID
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("opening commit log: %w", err)
+	}
+	defer f.Close()
+
+	var entries []CommitLogEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var entry CommitLogEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue // skip malformed lines
+		}
+		entries = append(entries, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return entries, fmt.Errorf("scanning commit log: %w", err)
+	}
+	return entries, nil
+}
+
+// buildCommitLog reads the existing commit log from the filesystem and appends
+// a new entry, returning the complete log as bytes for inclusion in a checkpoint.
+// If the existing file is missing or unreadable, returns just the new entry.
+func buildCommitLog(ctx context.Context, sessionID string, newEntry CommitLogEntry) []byte {
+	var existing []byte
+	sessionDir := paths.SessionMetadataDirFromSessionID(sessionID)
+	if sessionDirAbs, err := paths.AbsPath(ctx, sessionDir); err == nil {
+		logPath := filepath.Join(sessionDirAbs, paths.CommitLogFileName)
+		existing, _ = os.ReadFile(logPath) //nolint:errcheck,gosec // best-effort read; missing file is fine
+	}
+
+	newLine, err := json.Marshal(newEntry)
+	if err != nil {
+		return existing
+	}
+	newLine = append(newLine, '\n')
+
+	return append(existing, newLine...)
+}
+
+// commitSubject extracts the first line of a commit message.
+func commitSubject(message string) string {
+	if i := strings.IndexByte(message, '\n'); i >= 0 {
+		return strings.TrimSpace(message[:i])
+	}
+	return strings.TrimSpace(message)
+}

--- a/cmd/entire/cli/strategy/commit_log_test.go
+++ b/cmd/entire/cli/strategy/commit_log_test.go
@@ -1,0 +1,276 @@
+package strategy
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendCommitLogEntry_CreatesAndAppends(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	t.Chdir(tmpDir)
+
+	sessionID := "2026-04-16-test-session"
+	metadataDir := filepath.Join(tmpDir, paths.SessionMetadataDirFromSessionID(sessionID))
+	require.NoError(t, os.MkdirAll(metadataDir, 0o755))
+
+	ctx := t.Context()
+
+	entry1 := CommitLogEntry{
+		Hash:         "abc123def456abc123def456abc123def456abc1",
+		ShortHash:    "abc123d",
+		Subject:      "Add login feature",
+		Timestamp:    time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC),
+		CheckpointID: "a3b2c4d5e6f7",
+		SessionID:    sessionID,
+	}
+	entry2 := CommitLogEntry{
+		Hash:         "def789abc012def789abc012def789abc012def7",
+		ShortHash:    "def789a",
+		Subject:      "Fix validation bug",
+		Timestamp:    time.Date(2026, 4, 16, 13, 0, 0, 0, time.UTC),
+		CheckpointID: "b4c3d5e6f7a8",
+		SessionID:    sessionID,
+	}
+
+	require.NoError(t, appendCommitLogEntry(ctx, sessionID, entry1))
+	require.NoError(t, appendCommitLogEntry(ctx, sessionID, entry2))
+
+	entries, err := readCommitLog(ctx, sessionID)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	assert.Equal(t, "abc123d", entries[0].ShortHash)
+	assert.Equal(t, "Add login feature", entries[0].Subject)
+	assert.Equal(t, "a3b2c4d5e6f7", entries[0].CheckpointID)
+	assert.Equal(t, sessionID, entries[0].SessionID)
+
+	assert.Equal(t, "def789a", entries[1].ShortHash)
+	assert.Equal(t, "Fix validation bug", entries[1].Subject)
+	assert.Equal(t, "b4c3d5e6f7a8", entries[1].CheckpointID)
+}
+
+func TestReadCommitLog_NonexistentFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	t.Chdir(tmpDir)
+
+	ctx := t.Context()
+	entries, err := readCommitLog(ctx, "nonexistent-session")
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestCommitSubject(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{
+			name:    "single line",
+			message: "Add login feature",
+			want:    "Add login feature",
+		},
+		{
+			name:    "multi-line with body",
+			message: "Add login feature\n\nThis adds OAuth support.",
+			want:    "Add login feature",
+		},
+		{
+			name:    "message with trailers",
+			message: "Add login feature\n\nEntire-Checkpoint: a3b2c4d5e6f7",
+			want:    "Add login feature",
+		},
+		{
+			name:    "empty message",
+			message: "",
+			want:    "",
+		},
+		{
+			name:    "whitespace padding",
+			message: "  Add login feature  \n\nbody",
+			want:    "Add login feature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, commitSubject(tt.message))
+		})
+	}
+}
+
+// TestPostCommit_CommitLogInCheckpointTree verifies that after PostCommit
+// condensation, the commits.jsonl sidecar file is present in the
+// entire/checkpoints/v1 tree with the correct entry for this commit.
+func TestPostCommit_CommitLogInCheckpointTree(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	s := &ManualCommitStrategy{}
+	sessionID := "test-commitlog-in-tree"
+
+	setupSessionWithCheckpoint(t, s, repo, dir, sessionID)
+
+	// Set phase to ACTIVE
+	state, err := s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	state.Phase = session.PhaseActive
+	require.NoError(t, s.saveSessionState(context.Background(), state))
+
+	cpID := string(testTrailerCheckpointID)
+	commitWithCheckpointTrailer(t, repo, dir, cpID)
+
+	err = s.PostCommit(context.Background())
+	require.NoError(t, err)
+
+	// Read the commits.jsonl from the v1 checkpoint tree
+	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err, "entire/checkpoints/v1 should exist after condensation")
+
+	v1Commit, err := repo.CommitObject(v1Ref.Hash())
+	require.NoError(t, err)
+
+	v1Tree, err := v1Commit.Tree()
+	require.NoError(t, err)
+
+	checkpointID := id.MustCheckpointID(cpID)
+	commitLogPath := checkpointID.Path() + "/0/" + paths.CommitLogFileName
+
+	commitLogFile, err := v1Tree.File(commitLogPath)
+	require.NoError(t, err, "commits.jsonl should exist in checkpoint tree at %s", commitLogPath)
+
+	content, err := commitLogFile.Contents()
+	require.NoError(t, err)
+
+	// Parse the JSONL content
+	var entry CommitLogEntry
+	require.NoError(t, json.Unmarshal([]byte(content), &entry))
+
+	assert.Equal(t, cpID, entry.CheckpointID)
+	assert.Equal(t, sessionID, entry.SessionID)
+	assert.Equal(t, "test commit", entry.Subject)
+	assert.NotEmpty(t, entry.Hash)
+	assert.Len(t, entry.ShortHash, 7)
+}
+
+// TestPostCommit_CommitLogAccumulatesAcrossCheckpoints verifies that the second
+// checkpoint's commits.jsonl contains entries for BOTH commits, not just the latest.
+func TestPostCommit_CommitLogAccumulatesAcrossCheckpoints(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	s := &ManualCommitStrategy{}
+	sessionID := "test-commitlog-accumulate"
+
+	setupSessionWithCheckpoint(t, s, repo, dir, sessionID)
+
+	// Set phase to ACTIVE
+	state, err := s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	state.Phase = session.PhaseActive
+	require.NoError(t, s.saveSessionState(context.Background(), state))
+
+	// First commit + PostCommit
+	cpID1 := string(testTrailerCheckpointID)
+	commitWithCheckpointTrailer(t, repo, dir, cpID1)
+	require.NoError(t, s.PostCommit(context.Background()))
+
+	// Reload state for next checkpoint setup
+	_, err = s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+
+	// Create new file for second checkpoint
+	secondFile := filepath.Join(dir, "second.txt")
+	require.NoError(t, os.WriteFile(secondFile, []byte("second file"), 0o644))
+
+	metadataDir := ".entire/metadata/" + sessionID
+	metadataDirAbs := filepath.Join(dir, metadataDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(metadataDirAbs, paths.TranscriptFileName),
+		[]byte(testTranscriptPromptResponse), 0o644))
+
+	err = s.SaveStep(context.Background(), StepContext{
+		SessionID:      sessionID,
+		ModifiedFiles:  []string{},
+		NewFiles:       []string{"second.txt"},
+		DeletedFiles:   []string{},
+		MetadataDir:    metadataDir,
+		MetadataDirAbs: metadataDirAbs,
+		CommitMessage:  "Checkpoint 2",
+		AuthorName:     "Test",
+		AuthorEmail:    "test@test.com",
+	})
+	require.NoError(t, err)
+
+	// Second commit + PostCommit
+	cpID2 := "b2c3d4e5f6a7"
+	secondFilePath := filepath.Join(dir, "second.txt")
+	require.NoError(t, os.WriteFile(secondFilePath, []byte("second file content"), 0o644))
+	commitFilesWithTrailer(t, repo, dir, cpID2, "second.txt")
+	require.NoError(t, s.PostCommit(context.Background()))
+
+	// Read commits.jsonl from the SECOND checkpoint tree
+	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+
+	v1Commit, err := repo.CommitObject(v1Ref.Hash())
+	require.NoError(t, err)
+
+	v1Tree, err := v1Commit.Tree()
+	require.NoError(t, err)
+
+	checkpointID2 := id.MustCheckpointID(cpID2)
+	commitLogPath := checkpointID2.Path() + "/0/" + paths.CommitLogFileName
+
+	commitLogFile, err := v1Tree.File(commitLogPath)
+	require.NoError(t, err, "commits.jsonl should exist in second checkpoint tree")
+
+	content, err := commitLogFile.Contents()
+	require.NoError(t, err)
+
+	// Parse all entries — should have 2 (one from each commit)
+	var entries []CommitLogEntry
+	for _, line := range splitNonEmptyLines(content) {
+		var entry CommitLogEntry
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+		entries = append(entries, entry)
+	}
+
+	require.Len(t, entries, 2, "second checkpoint should contain entries for both commits")
+	assert.Equal(t, cpID1, entries[0].CheckpointID, "first entry should be from first commit")
+	assert.Equal(t, cpID2, entries[1].CheckpointID, "second entry should be from second commit")
+}
+
+// splitNonEmptyLines splits a string by newlines and returns non-empty lines.
+func splitNonEmptyLines(s string) []string {
+	var result []string
+	for _, line := range splitLines([]byte(s)) {
+		if len(line) > 0 {
+			result = append(result, line)
+		}
+	}
+	return result
+}

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -103,6 +103,7 @@ type condenseOpts struct {
 	parentCommitHash string              // HEAD's first parent hash for per-commit non-agent file detection
 	headCommitHash   string              // HEAD commit hash (passed through for attribution)
 	allAgentFiles    map[string]struct{} // Union of all sessions' FilesTouched for cross-session exclusion (nil = single-session)
+	commitLog        []byte              // Pre-built commit log (commits.jsonl) bytes to include in checkpoint
 }
 
 var redactSessionJSONLBytes = redact.JSONLBytes
@@ -250,6 +251,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		InitialAttribution:          attribution,
 		PromptAttributionsJSON:      marshalPromptAttributionsIncludingPending(state),
 		Summary:                     summary,
+		CommitLog:                   o.commitLog,
 	}
 
 	compactTranscriptDuration := buildCompactTranscript(ctx, ag, redactedTranscript, state, &writeOpts)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -721,13 +721,26 @@ type postCommitActionHandler struct {
 	shadowRef     *plumbing.Reference // Per-session shadow branch ref (nil if branch doesn't exist)
 	shadowTree    *object.Tree        // Per-session shadow commit tree (nil if branch doesn't exist)
 	allAgentFiles map[string]struct{} // Union of all sessions' FilesTouched for cross-session attribution
-	commitLog     []byte              // Pre-built commit log bytes to include in checkpoint
 
 	// Output: set by handler methods, read by caller after TransitionAndLog.
 	// condensed is true only when CondenseSession wrote data to the metadata branch.
 	// Both failures and skips (no transcript/files) leave condensed=false, which
 	// correctly preserves shadow branches and defers FullyCondensed marking.
 	condensed bool
+}
+
+// buildCommitLogForSession builds commit log bytes for inclusion in a checkpoint.
+// Called only when condensation will proceed, to avoid unnecessary filesystem IO.
+func (h *postCommitActionHandler) buildCommitLogForSession(state *session.State) []byte {
+	entry := CommitLogEntry{
+		Hash:         h.commit.Hash.String(),
+		ShortHash:    h.commit.Hash.String()[:7],
+		Subject:      commitSubject(h.commit.Message),
+		Timestamp:    h.commit.Author.When.UTC(),
+		CheckpointID: h.checkpointID.String(),
+		SessionID:    state.SessionID,
+	}
+	return buildCommitLog(h.ctx, state.SessionID, entry)
 }
 
 // parentCommitHash returns the first parent's hash as a string, or empty for initial commits.
@@ -759,7 +772,7 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 			parentCommitHash: h.parentCommitHash(),
 			headCommitHash:   h.newHead,
 			allAgentFiles:    h.allAgentFiles,
-			commitLog:        h.commitLog,
+			commitLog:        h.buildCommitLogForSession(state),
 		})
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
@@ -789,7 +802,7 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 			parentCommitHash: h.parentCommitHash(),
 			headCommitHash:   h.newHead,
 			allAgentFiles:    h.allAgentFiles,
-			commitLog:        h.commitLog,
+			commitLog:        h.buildCommitLogForSession(state),
 		})
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
@@ -1289,18 +1302,6 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 		slog.Any("files", filesTouchedBefore),
 	)
 
-	// Build commit log entry and full log bytes BEFORE condensation so they
-	// are included in the checkpoint tree written by CondenseSession.
-	newEntry := CommitLogEntry{
-		Hash:         commit.Hash.String(),
-		ShortHash:    commit.Hash.String()[:7],
-		Subject:      commitSubject(commit.Message),
-		Timestamp:    commit.Author.When.UTC(),
-		CheckpointID: checkpointID.String(),
-		SessionID:    state.SessionID,
-	}
-	commitLogBytes := buildCommitLog(ctx, state.SessionID, newEntry)
-
 	// Run the state machine transition with handler for strategy-specific actions.
 	_, transitionAndCondenseSpan := perf.Start(ctx, "transition_and_condense")
 	handler := &postCommitActionHandler{
@@ -1323,7 +1324,6 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 		shadowTree:                 shadowTree,
 		allAgentFiles:              allAgentFiles,
 		sessionsWithCommittedFiles: sessionsWithCommittedFiles,
-		commitLog:                  commitLogBytes,
 	}
 
 	if err := TransitionAndLog(ctx, state, session.EventGitCommit, *transitionCtx, handler); err != nil {
@@ -1344,7 +1344,15 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 	// Persist sidecar commit log entry to filesystem so future checkpoints
 	// in this session accumulate the full timeline.
 	if handler.condensed {
-		if err := appendCommitLogEntry(ctx, state.SessionID, newEntry); err != nil {
+		entry := CommitLogEntry{
+			Hash:         commit.Hash.String(),
+			ShortHash:    commit.Hash.String()[:7],
+			Subject:      commitSubject(commit.Message),
+			Timestamp:    commit.Author.When.UTC(),
+			CheckpointID: checkpointID.String(),
+			SessionID:    state.SessionID,
+		}
+		if err := appendCommitLogEntry(ctx, state.SessionID, entry); err != nil {
 			logging.Warn(logCtx, "failed to append commit log entry",
 				slog.String("session_id", state.SessionID),
 				slog.String("error", err.Error()),

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -721,6 +721,7 @@ type postCommitActionHandler struct {
 	shadowRef     *plumbing.Reference // Per-session shadow branch ref (nil if branch doesn't exist)
 	shadowTree    *object.Tree        // Per-session shadow commit tree (nil if branch doesn't exist)
 	allAgentFiles map[string]struct{} // Union of all sessions' FilesTouched for cross-session attribution
+	commitLog     []byte              // Pre-built commit log bytes to include in checkpoint
 
 	// Output: set by handler methods, read by caller after TransitionAndLog.
 	// condensed is true only when CondenseSession wrote data to the metadata branch.
@@ -758,6 +759,7 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 			parentCommitHash: h.parentCommitHash(),
 			headCommitHash:   h.newHead,
 			allAgentFiles:    h.allAgentFiles,
+			commitLog:        h.commitLog,
 		})
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
@@ -787,6 +789,7 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 			parentCommitHash: h.parentCommitHash(),
 			headCommitHash:   h.newHead,
 			allAgentFiles:    h.allAgentFiles,
+			commitLog:        h.commitLog,
 		})
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
@@ -1286,6 +1289,18 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 		slog.Any("files", filesTouchedBefore),
 	)
 
+	// Build commit log entry and full log bytes BEFORE condensation so they
+	// are included in the checkpoint tree written by CondenseSession.
+	newEntry := CommitLogEntry{
+		Hash:         commit.Hash.String(),
+		ShortHash:    commit.Hash.String()[:7],
+		Subject:      commitSubject(commit.Message),
+		Timestamp:    commit.Author.When.UTC(),
+		CheckpointID: checkpointID.String(),
+		SessionID:    state.SessionID,
+	}
+	commitLogBytes := buildCommitLog(ctx, state.SessionID, newEntry)
+
 	// Run the state machine transition with handler for strategy-specific actions.
 	_, transitionAndCondenseSpan := perf.Start(ctx, "transition_and_condense")
 	handler := &postCommitActionHandler{
@@ -1308,6 +1323,7 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 		shadowTree:                 shadowTree,
 		allAgentFiles:              allAgentFiles,
 		sessionsWithCommittedFiles: sessionsWithCommittedFiles,
+		commitLog:                  commitLogBytes,
 	}
 
 	if err := TransitionAndLog(ctx, state, session.EventGitCommit, *transitionCtx, handler); err != nil {
@@ -1323,6 +1339,17 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 	// transition ever changed, this guard would silently stop recording IDs.
 	if handler.condensed && state.Phase.IsActive() {
 		state.TurnCheckpointIDs = append(state.TurnCheckpointIDs, checkpointID.String())
+	}
+
+	// Persist sidecar commit log entry to filesystem so future checkpoints
+	// in this session accumulate the full timeline.
+	if handler.condensed {
+		if err := appendCommitLogEntry(ctx, state.SessionID, newEntry); err != nil {
+			logging.Warn(logCtx, "failed to append commit log entry",
+				slog.String("session_id", state.SessionID),
+				slog.String("error", err.Error()),
+			)
+		}
 	}
 
 	// Carry forward remaining uncommitted files so the next commit gets its


### PR DESCRIPTION
## Summary

Add a sidecar commit log that enables session timeline reconstruction from any checkpoint, without complex cross-referencing or git log scanning.

### The problem

Today, if you want to see "what commits happened during this session," you'd need to cross-reference checkpoint IDs across git history, session metadata, and the checkpoint branch. For a UI timeline view — where you pick checkpoint 4 and want to see the full session history including checkpoints 1-3 — this requires expensive backward lookups across potentially weeks of git history.

### The approach

Each time PostCommit condenses a session, we append a one-line JSON entry to `.entire/metadata/<session-id>/commits.jsonl`:

```jsonl
{"hash":"abc123...","short_hash":"abc123d","subject":"Add login","timestamp":"2026-04-16T12:11:06Z","checkpoint_id":"a3b2c4d5e6f7","session_id":"..."}
```

This file accumulates across the session. When checkpoint N is condensed, its `commits.jsonl` contains entries for all N commits — no backward lookup needed. The log is:

- **Built in-memory before condensation** so it's included in the checkpoint tree it belongs to (not written too late)
- **Persisted to filesystem after condensation** so the next checkpoint picks up the full timeline
- **Written to both v1 and v2** checkpoint trees via `WriteCommittedOptions.CommitLog`

### What this enables (future)

- **Session timeline UI**: Read one checkpoint → render full commit history with expandable details
- **Orphaned checkpoint detection**: "There was a checkpoint here, but it was rebased away"
- **Foundation for Phase 2**: Adding `Change-Id` trailers to capture mid-turn commits (without checkpoint trailers) in the timeline

### What this does NOT change

- No new git trailers
- No changes to SaveStep, condensation logic, or session state machine
- No tree-building changes (`commits.jsonl` flows through existing `WriteCommittedOptions`)
- No consumers yet — this is write-side plumbing

## Test plan

- [x] Unit tests: append/read round-trip, nonexistent file handling, commit subject extraction
- [x] Integration test: `commits.jsonl` present in v1 checkpoint tree after PostCommit
- [x] Integration test: second checkpoint contains entries for both commits (accumulation)
- [x] `mise run check` (fmt + lint + test:ci + e2e canary) passes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new checkpoint artifacts and hook-time filesystem writes to capture a per-session commit timeline; risk is mainly around correctness of checkpoint tree writes and accumulation behavior across commits (both v1 and v2).
> 
> **Overview**
> Adds a sidecar commit timeline log (`commits.jsonl`) that accumulates one JSONL entry per condensed commit and is included in the checkpoint’s session directory, enabling reconstruction of the full session commit history from any checkpoint.
> 
> This threads `CommitLog` through `WriteCommittedOptions`, writes `commits.jsonl` into both v1 and v2 checkpoint trees, and updates the manual-commit `PostCommit` path to (1) build the full log before condensation, and (2) append the new entry to `.entire/metadata/<session-id>/commits.jsonl` after a successful condensation. Includes unit/integration tests covering append/read behavior and accumulation across multiple checkpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 980eec1360b596687580d2d404647fe6a0a1f076. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->