### PR TITLE
Add `--json` flag to `status` command

### DIFF
--- a/cmd/entire/cli/bench_test.go
+++ b/cmd/entire/cli/bench_test.go
@@ -78,7 +78,7 @@ func benchStatus(sessionCount int, detailed, useGitCommonDirCache bool) func(*te
 				session.ClearGitCommonDirCache()
 			}
 
-			if err := runStatus(context.Background(), io.Discard, detailed); err != nil {
+			if err := runStatus(context.Background(), io.Discard, detailed, false); err != nil {
 				b.Fatalf("runStatus: %v", err)
 			}
 		}

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -855,8 +855,8 @@ func TestInfoCmd_JSONOutput(t *testing.T) {
 	if result["session_id"] != "test-info-json" {
 		t.Errorf("expected session_id 'test-info-json', got: %v", result["session_id"])
 	}
-	if result["agent"] != "Claude Code" {
-		t.Errorf("expected agent 'Claude Code', got: %v", result["agent"])
+	if result["agent"] != testAgentClaude {
+		t.Errorf("expected agent %q, got: %v", testAgentClaude, result["agent"])
 	}
 	if result["status"] != "idle" {
 		t.Errorf("expected status 'idle', got: %v", result["status"])

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -24,22 +25,29 @@ import (
 
 func newStatusCmd() *cobra.Command {
 	var detailed bool
+	var jsonFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show Entire status",
 		Long:  "Show whether Entire is currently enabled or disabled",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runStatus(cmd.Context(), cmd.OutOrStdout(), detailed)
+			return runStatus(cmd.Context(), cmd.OutOrStdout(), detailed, jsonFlag)
 		},
 	}
 
 	cmd.Flags().BoolVar(&detailed, "detailed", false, "Show detailed status for each settings file")
+	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON")
+	cmd.MarkFlagsMutuallyExclusive("detailed", "json")
 
 	return cmd
 }
 
-func runStatus(ctx context.Context, w io.Writer, detailed bool) error {
+func runStatus(ctx context.Context, w io.Writer, detailed, jsonOutput bool) error {
+	if jsonOutput {
+		return runStatusJSON(ctx, w)
+	}
+
 	// Check if we're in a git repository
 	if _, repoErr := paths.WorktreeRoot(ctx); repoErr != nil {
 		fmt.Fprintln(w, "✕ not a git repository")
@@ -426,4 +434,123 @@ func resolveWorktreeBranchGit(ctx context.Context, worktreePath string) string {
 		return strings.TrimPrefix(ref, "refs/heads/")
 	}
 	return detachedHEADDisplay
+}
+
+// statusJSON is the JSON output for `entire status --json`.
+type statusJSON struct {
+	Enabled        bool               `json:"enabled"`
+	Agents         []string           `json:"agents"`
+	ActiveSessions []sessionBriefJSON `json:"active_sessions"`
+	Error          string             `json:"error,omitempty"`
+}
+
+type sessionBriefJSON struct {
+	Agent  string `json:"agent"`
+	Model  string `json:"model,omitempty"`
+	Status string `json:"status"`
+}
+
+func runStatusJSON(ctx context.Context, w io.Writer) error {
+	writeJSON := func(v statusJSON) error {
+		return json.NewEncoder(w).Encode(v)
+	}
+
+	if _, err := paths.WorktreeRoot(ctx); err != nil {
+		return writeJSON(statusJSON{Error: "not a git repository"})
+	}
+
+	settingsPath, err := paths.AbsPath(ctx, EntireSettingsFile)
+	if err != nil {
+		settingsPath = EntireSettingsFile
+	}
+	localSettingsPath, err := paths.AbsPath(ctx, EntireSettingsLocalFile)
+	if err != nil {
+		localSettingsPath = EntireSettingsLocalFile
+	}
+
+	_, projectErr := os.Stat(settingsPath)
+	if projectErr != nil && !errors.Is(projectErr, fs.ErrNotExist) {
+		return writeJSON(statusJSON{Error: fmt.Sprintf("cannot access project settings file: %v", projectErr)})
+	}
+	_, localErr := os.Stat(localSettingsPath)
+	if localErr != nil && !errors.Is(localErr, fs.ErrNotExist) {
+		return writeJSON(statusJSON{Error: fmt.Sprintf("cannot access local settings file: %v", localErr)})
+	}
+
+	if projectErr != nil && localErr != nil {
+		return writeJSON(statusJSON{Error: "not set up"})
+	}
+
+	s, err := LoadEntireSettings(ctx)
+	if err != nil {
+		return writeJSON(statusJSON{Error: fmt.Sprintf("failed to load settings: %v", err)})
+	}
+
+	result := statusJSON{
+		Enabled:        s.Enabled,
+		Agents:         []string{},
+		ActiveSessions: []sessionBriefJSON{},
+	}
+
+	if s.Enabled {
+		if names := InstalledAgentDisplayNames(ctx); len(names) > 0 {
+			result.Agents = names
+		}
+
+		if store, err := session.NewStateStore(ctx); err == nil {
+			if states, err := store.List(ctx); err == nil {
+				// Deduplicate by agent: one entry per agent, "active" wins over "idle".
+				type agentEntry struct {
+					brief    sessionBriefJSON
+					isActive bool
+				}
+				byAgent := make(map[string]*agentEntry)
+				for _, st := range states {
+					if st.EndedAt != nil {
+						continue
+					}
+					agent := string(st.AgentType)
+					if agent == "" {
+						agent = unknownPlaceholder
+					}
+					active := st.Phase == session.PhaseActive
+					if existing, ok := byAgent[agent]; ok {
+						if active && !existing.isActive {
+							existing.brief.Model = st.ModelName
+							existing.brief.Status = sessionStatusLabel(st)
+							existing.isActive = true
+						}
+					} else {
+						byAgent[agent] = &agentEntry{
+							brief: sessionBriefJSON{
+								Agent:  agent,
+								Model:  st.ModelName,
+								Status: sessionStatusLabel(st),
+							},
+							isActive: active,
+						}
+					}
+				}
+				for _, e := range byAgent {
+					result.ActiveSessions = append(result.ActiveSessions, e.brief)
+				}
+				sort.Slice(result.ActiveSessions, func(i, j int) bool {
+					return result.ActiveSessions[i].Agent < result.ActiveSessions[j].Agent
+				})
+			}
+		}
+	}
+
+	return writeJSON(result)
+}
+
+// sessionStatusLabel derives a display status from a session state.
+func sessionStatusLabel(s *session.State) string {
+	if s.EndedAt != nil {
+		return "ended"
+	}
+	if s.Phase != "" {
+		return string(s.Phase)
+	}
+	return string(session.PhaseIdle)
 }

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -198,7 +199,7 @@ func TestRunStatus_Enabled(t *testing.T) {
 	writeSettings(t, testSettingsEnabled)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, false); err != nil {
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -212,7 +213,7 @@ func TestRunStatus_Disabled(t *testing.T) {
 	writeSettings(t, testSettingsDisabled)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, false); err != nil {
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -225,7 +226,7 @@ func TestRunStatus_NotSetUp(t *testing.T) {
 	setupTestRepo(t)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, false); err != nil {
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -242,7 +243,7 @@ func TestRunStatus_NotGitRepository(t *testing.T) {
 	setupTestDir(t) // No git init
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, false); err != nil {
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -256,7 +257,7 @@ func TestRunStatus_LocalSettingsOnly(t *testing.T) {
 	writeLocalSettings(t, `{"enabled": true}`)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, true); err != nil {
+	if err := runStatus(context.Background(), &stdout, true, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -283,7 +284,7 @@ func TestRunStatus_BothProjectAndLocal(t *testing.T) {
 	writeLocalSettings(t, `{"enabled": false}`)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, true); err != nil {
+	if err := runStatus(context.Background(), &stdout, true, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -310,7 +311,7 @@ func TestRunStatus_BothProjectAndLocal_Short(t *testing.T) {
 	writeLocalSettings(t, `{"enabled": false}`)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, false); err != nil {
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -326,7 +327,7 @@ func TestRunStatus_ShowsManualCommitStrategy(t *testing.T) {
 	writeSettings(t, `{"enabled": false}`)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, true); err != nil {
+	if err := runStatus(context.Background(), &stdout, true, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -1014,7 +1015,7 @@ func TestRunStatus_ShowsEnabledAgents(t *testing.T) {
 	writeClaudeHooksFixture(t)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, false); err != nil {
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -1033,7 +1034,7 @@ func TestRunStatus_EnabledNoAgentsHidesHooksLine(t *testing.T) {
 	// No agent hooks installed
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, false); err != nil {
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -1049,7 +1050,7 @@ func TestRunStatus_DetailedShowsEnabledAgents(t *testing.T) {
 	writeClaudeHooksFixture(t)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, true); err != nil {
+	if err := runStatus(context.Background(), &stdout, true, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -1153,7 +1154,7 @@ func TestRunStatus_DetailedDisabledDoesNotShowAgents(t *testing.T) {
 	writeClaudeHooksFixture(t)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, true); err != nil {
+	if err := runStatus(context.Background(), &stdout, true, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -1169,7 +1170,7 @@ func TestRunStatus_DisabledDoesNotShowAgents(t *testing.T) {
 	writeClaudeHooksFixture(t)
 
 	var stdout bytes.Buffer
-	if err := runStatus(context.Background(), &stdout, false); err != nil {
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
@@ -1458,5 +1459,211 @@ func TestFormatSettingsStatus_Separators(t *testing.T) {
 	// Should use · as separator (plain text, no ANSI)
 	if !strings.Contains(result, "·") {
 		t.Errorf("Expected '·' separators in output, got: %q", result)
+	}
+}
+
+func TestRunStatusJSON_Enabled(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	writeClaudeHooksFixture(t)
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, true); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	var result statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if !result.Enabled {
+		t.Error("Expected enabled=true")
+	}
+	found := false
+	for _, a := range result.Agents {
+		if a == "Claude Code" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected agents to contain 'Claude Code', got %v", result.Agents)
+	}
+	if result.Error != "" {
+		t.Errorf("Expected no error, got %q", result.Error)
+	}
+}
+
+func TestRunStatusJSON_Disabled(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsDisabled)
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, true); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	var result statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if result.Enabled {
+		t.Error("Expected enabled=false")
+	}
+}
+
+func TestRunStatusJSON_NotSetUp(t *testing.T) {
+	setupTestRepo(t)
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, true); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	var result statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if result.Enabled {
+		t.Error("Expected enabled=false")
+	}
+	if result.Error != "not set up" {
+		t.Errorf("Expected error='not set up', got %q", result.Error)
+	}
+}
+
+func TestRunStatusJSON_NotGitRepo(t *testing.T) {
+	setupTestDir(t)
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, true); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	var result statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if result.Enabled {
+		t.Error("Expected enabled=false")
+	}
+	if result.Error != "not a git repository" {
+		t.Errorf("Expected error='not a git repository', got %q", result.Error)
+	}
+}
+
+func TestRunStatusJSON_WithActiveSessions(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	writeClaudeHooksFixture(t)
+
+	store, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatalf("NewStateStore() error = %v", err)
+	}
+
+	state := &session.State{
+		SessionID:    "test-json-session",
+		WorktreePath: "/test/repo",
+		StartedAt:    time.Now(),
+		Phase:        session.PhaseActive,
+		AgentType:    "Claude Code",
+		ModelName:    "sonnet-4.1",
+	}
+	if err := store.Save(context.Background(), state); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, true); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	var result statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if len(result.ActiveSessions) != 1 {
+		t.Fatalf("Expected 1 active session, got %d", len(result.ActiveSessions))
+	}
+	s := result.ActiveSessions[0]
+	if s.Agent != "Claude Code" {
+		t.Errorf("Expected agent='Claude Code', got %q", s.Agent)
+	}
+	if s.Model != "sonnet-4.1" {
+		t.Errorf("Expected model='sonnet-4.1', got %q", s.Model)
+	}
+	if s.Status != "active" {
+		t.Errorf("Expected status='active', got %q", s.Status)
+	}
+}
+
+func TestRunStatusJSON_DeduplicatesSessions(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+
+	store, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatalf("NewStateStore() error = %v", err)
+	}
+
+	now := time.Now()
+	states := []*session.State{
+		{
+			SessionID:    "codex-idle-1",
+			WorktreePath: "/test/repo",
+			StartedAt:    now.Add(-30 * time.Minute),
+			Phase:        session.PhaseIdle,
+			AgentType:    "Codex",
+		},
+		{
+			SessionID:    "codex-idle-2",
+			WorktreePath: "/test/repo",
+			StartedAt:    now.Add(-20 * time.Minute),
+			Phase:        session.PhaseIdle,
+			AgentType:    "Codex",
+		},
+		{
+			SessionID:    "codex-active",
+			WorktreePath: "/test/repo",
+			StartedAt:    now.Add(-5 * time.Minute),
+			Phase:        session.PhaseActive,
+			AgentType:    "Codex",
+			ModelName:    "codex-mini",
+		},
+	}
+	for _, s := range states {
+		if err := store.Save(context.Background(), s); err != nil {
+			t.Fatalf("Save() error = %v", err)
+		}
+	}
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, true); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	var result statusJSON
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if len(result.ActiveSessions) != 1 {
+		t.Fatalf("Expected 1 deduplicated session, got %d", len(result.ActiveSessions))
+	}
+	s := result.ActiveSessions[0]
+	if s.Agent != "Codex" {
+		t.Errorf("Expected agent='Codex', got %q", s.Agent)
+	}
+	if s.Status != "active" {
+		t.Errorf("Expected status='active' (active wins over idle), got %q", s.Status)
+	}
+	if s.Model != "codex-mini" {
+		t.Errorf("Expected model='codex-mini' from active session, got %q", s.Model)
 	}
 }


### PR DESCRIPTION
Add machine-readable JSON output to `entire status` for shell prompt integration. The JSON output includes enabled state, installed agents, and active sessions (deduplicated by agent, sorted alphabetically). All error paths return valid JSON with an error field.

This can be used to generate terminal prompt segments, as per below an agnoster-compatible prompt segment that shows per-agent activity indicators (●/○) using cached status data:
<img width="919" height="82" alt="image" src="https://github.com/user-attachments/assets/06947027-e2c1-4f6b-b4ad-27a06d120b0e" />

The segment plugin code:
```bash
#!/usr/bin/env zsh
# Entire prompt segment for oh-my-zsh / Powerlevel10k / custom ZSH themes.
#
# Usage (agnoster or similar themes):
#   Source this file in your .zshrc:
#     source /path/to/prompt.zsh
#
#   Then add `prompt_entire` to your build_prompt() function in your theme,
#   or call it from PROMPT/RPROMPT directly:
#     RPROMPT='$(prompt_entire)'
#
# For agnoster specifically, override build_prompt in your .zshrc:
#     build_prompt() {
#       RETVAL=$?
#       prompt_status
#       prompt_virtualenv
#       prompt_context
#       prompt_dir
#       prompt_entire       # <-- add this line
#       prompt_git
#       prompt_end
#     }
#
# Cache: To avoid running `entire status --json` on every prompt render,
# the result is cached for ENTIRE_PROMPT_TTL seconds (default: 10).
# The cache is invalidated on directory change.

ENTIRE_PROMPT_TTL="${ENTIRE_PROMPT_TTL:-10}"

typeset -g _entire_prompt_cache=""
typeset -g _entire_prompt_cache_time=0
typeset -g _entire_prompt_cache_dir=""

_entire_prompt_data() {
  local now dir
  now=$EPOCHSECONDS
  dir=$PWD

  if [[ "$dir" == "$_entire_prompt_cache_dir" ]] &&
     (( now - _entire_prompt_cache_time < ENTIRE_PROMPT_TTL )) &&
     [[ -n "$_entire_prompt_cache" ]]; then
    printf '%s' "$_entire_prompt_cache"
    return
  fi

  _entire_prompt_cache_dir="$dir"
  _entire_prompt_cache_time=$now
  _entire_prompt_cache=$(command entire status --json 2>/dev/null)
  printf '%s' "$_entire_prompt_cache"
}

# prompt_entire — agnoster-style segment
# Shows first word of each active session's agent (e.g. "claude gemini ●")
# When idle, shows first word of each installed agent (e.g. "claude")
# Each agent gets ● (active) or ○ (idle) individually
prompt_entire() {
  local json enabled error_msg agents active_sessions session_agents segment

  json=$(_entire_prompt_data)
  [[ -z "$json" ]] && return

  # Parse JSON — prefer jq if available; fall back to grep/sed.
  if command -v jq &>/dev/null; then
    enabled=$(printf '%s' "$json" | jq -r '.enabled')
    error_msg=$(printf '%s' "$json" | jq -r '.error // empty')
    agents=$(printf '%s' "$json" | jq -r '(.agents // []) | map(split(" ")[0]) | join(" ")')
    session_agents=$(printf '%s' "$json" | jq -r '(.active_sessions // []) | map(.agent | split(" ")[0]) | unique | join(" ")')
    active_sessions=$(printf '%s' "$json" | jq -r '(.active_sessions // []) | length')
  else
    # Lightweight fallback — works for the compact single-line JSON output
    [[ "$json" == *'"enabled":true'* ]] && enabled=true || enabled=false
    agents=$(printf '%s' "$json" | sed -n 's/.*"agents":\["\([^"]*\)".*/\1/p')
    agents="${agents%% *}"
    active_sessions=$(printf '%s' "$json" | grep -o '"agent":"[^"]*"' | wc -l)
    session_agents=$(printf '%s' "$json" | grep -o '"agent":"[^"]*"' | sed 's/"agent":"//;s/".*//' | awk '{print $1}' | sort -u | tr '\n' ' ')
    session_agents="${session_agents% }"
  fi

  [[ "$enabled" != "true" ]] && return
  [[ -n "$error_msg" ]] && return

  # Nothing to show if no agents are configured
  [[ -z "$agents" ]] && return

  # Build per-agent label: each agent gets ● (active session) or ○ (idle)
  # e.g. "claude● codex○"
  local -a agent_list=( ${(s: :)agents} )
  local -a active_list=( ${(s: :)session_agents} )
  local parts=""
  local any_active=0
  for a in "${agent_list[@]}"; do
    local lower="${(L)a}"
    if (( ${active_list[(Ie)$a]} )); then
      parts+="${parts:+ }${lower}●"
      any_active=1
    else
      parts+="${parts:+ }${lower}○"
    fi
  done

  segment="$parts"

  # Agnoster-style segment rendering (if prompt_segment is available)
  # Avoid green (git clean), yellow (git dirty), blue (context), black (default)
  # Has active session: magenta
  # All idle:           cyan
  if typeset -f prompt_segment &>/dev/null; then
    if (( any_active )); then
      prompt_segment magenta white " $segment "
    else
      prompt_segment cyan black " $segment "
    fi
  else
    # Standalone RPROMPT usage
    if (( any_active )); then
      printf '%%F{magenta}%s%%f' "$segment"
    else
      printf '%%F{cyan}%s%%f' "$segment"
    fi
  fi
}
```



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9681273e878c8acac688d00260af0a48fbdd8b15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->