### PR TITLE
Improved entire enable flow on folders that are not git repos yet

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -647,7 +647,7 @@ Use --remove to remove a specific agent non-interactively:
 	cmd.Flags().StringVar(&summarizeModel, flagSummarizeModel, "", "Set the model hint used by explain --generate")
 	cmd.Flags().BoolVar(&opts.Telemetry, "telemetry", true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, "absolute-git-hook-path", false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
-	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Accept all defaults: enable all agents, accept telemetry, skip prompts")
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Accept all defaults without prompting (in a non-repo directory: init git, create private GitHub repo, commit; then enable all agents and accept telemetry)")
 
 	// Provide a helpful error when --agent is used without a value
 	defaultFlagErr := cmd.FlagErrorFunc()
@@ -806,7 +806,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
 	cmd.Flags().BoolVar(&opts.Telemetry, "telemetry", true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, "absolute-git-hook-path", false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
-	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Accept all defaults: enable all agents, accept telemetry, skip prompts")
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Accept all defaults without prompting (in a non-repo directory: init git, create private GitHub repo, commit; then enable all agents and accept telemetry)")
 
 	// Bootstrap flags for non-git-repo folders.
 	cmd.Flags().BoolVar(&bootstrapOpts.InitRepo, "init-repo", false, "If not a git repo, initialize one non-interactively")

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -948,13 +948,14 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 		return fmt.Errorf("failed to install git hooks: %w", err)
 	}
 	strategy.CheckAndWarnHookManagers(ctx, w, settings.LocalDev, settings.AbsoluteGitHookPath)
-	fmt.Fprintln(w, "✓ Hooks installed")
+	fmt.Fprintln(w, "  ✓ Installed hooks")
 
 	configDisplay := configDisplayProject
 	if shouldUseLocal {
 		configDisplay = configDisplayLocal
 	}
-	fmt.Fprintf(w, "✓ Project configured (%s)\n", configDisplay)
+	fmt.Fprintln(w, "  ✓ Configured project")
+	fmt.Fprintf(w, "    %s\n", configDisplay)
 
 	var vercelPromptFn func() (bool, error)
 	if opts.Yes {
@@ -1348,7 +1349,7 @@ func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(availab
 	for _, ag := range selectedAgents {
 		agentTypes = append(agentTypes, string(ag.Type()))
 	}
-	fmt.Fprintf(w, "\nSelected agents: %s\n\n", strings.Join(agentTypes, ", "))
+	fmt.Fprintf(w, "  Selected agents: %s\n", strings.Join(agentTypes, ", "))
 	return selectedAgents, nil
 }
 
@@ -1391,7 +1392,7 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 		return fmt.Errorf("agent %s does not support hooks", agentName)
 	}
 
-	fmt.Fprintf(w, "Agent: %s\n\n", ag.Type())
+	fmt.Fprintf(w, "  Agent: %s\n", ag.Type())
 
 	// Install agent hooks (agent hooks don't depend on settings)
 	installedHooks, err := setupAgentHooks(ctx, w, ag, opts.LocalDev, opts.ForceHooks)
@@ -1449,16 +1450,17 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 		if ag.IsPreview() {
 			msg += " (Preview)"
 		}
-		fmt.Fprintf(w, "%s\n", msg)
+		fmt.Fprintf(w, "  %s\n", msg)
 	} else {
 		msg := fmt.Sprintf("Installed %d hooks for %s", installedHooks, ag.Description())
 		if ag.IsPreview() {
 			msg += " (Preview)"
 		}
-		fmt.Fprintf(w, "%s\n", msg)
+		fmt.Fprintf(w, "  %s\n", msg)
 	}
 
-	fmt.Fprintf(w, "✓ Project configured (%s)\n", configDisplay)
+	fmt.Fprintln(w, "  ✓ Configured project")
+	fmt.Fprintf(w, "    %s\n", configDisplay)
 
 	if _, err := maybePromptVercelDeploymentDisable(ctx, w, targetFile, nil); err != nil {
 		return err

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -754,6 +754,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().StringVar(&bootstrapOpts.RepoVisibility, "repo-visibility", "", "GitHub repository visibility: public, private, or internal")
 	cmd.Flags().BoolVar(&bootstrapOpts.NoGitHub, "no-github", false, "Initialize local git repo only; skip creating a GitHub remote")
 	cmd.Flags().StringVar(&bootstrapOpts.InitialCommitMessage, "initial-commit-message", "", "Commit message for the initial commit when bootstrapping a new repo")
+	cmd.MarkFlagsMutuallyExclusive("init-repo", "no-init-repo")
 
 	// Provide a helpful error when --agent is used without a value
 	defaultFlagErr := cmd.FlagErrorFunc()

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -640,6 +640,7 @@ func newEnableCmd() *cobra.Command {
 	var opts EnableOptions
 	var ignoreUntracked bool
 	var agentName string
+	var bootstrapOpts GitHubBootstrapOptions
 
 	cmd := &cobra.Command{
 		Use:   "enable",
@@ -647,15 +648,28 @@ func newEnableCmd() *cobra.Command {
 		Long: `Enable Entire with session tracking for your AI agent workflows.
 
 If Entire is not yet configured, this runs the full configuration flow.
-If Entire is already configured but disabled, this re-enables it.`,
+If Entire is already configured but disabled, this re-enables it.
+
+If the current directory is not a git repository, Entire can initialize one
+for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			// Check if we're in a git repository first - this is a prerequisite error,
-			// not a usage error, so we silence Cobra's output and use SilentError
-			// to prevent duplicate error output in main.go
+			// Check if we're in a git repository first. If not, offer to
+			// bootstrap one (git init + optional GitHub repo). If the user
+			// declines, fall back to the legacy prerequisite error.
 			if _, err := paths.WorktreeRoot(ctx); err != nil {
-				fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Please run 'entire enable' from within a git repository.")
-				return NewSilentError(errors.New("not a git repository"))
+				bootstrapErr := runGitHubBootstrap(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), bootstrapOpts)
+				if errors.Is(bootstrapErr, errBootstrapDeclined) {
+					fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Please run 'entire enable' from within a git repository.")
+					return NewSilentError(errors.New("not a git repository"))
+				}
+				if bootstrapErr != nil {
+					return bootstrapErr
+				}
+				// Re-check after bootstrap.
+				if _, err := paths.WorktreeRoot(ctx); err != nil {
+					return fmt.Errorf("bootstrap finished but no git repository detected: %w", err)
+				}
 			}
 
 			if err := validateSetupFlags(opts.UseLocalSettings, opts.UseProjectSettings); err != nil {
@@ -731,6 +745,15 @@ If Entire is already configured but disabled, this re-enables it.`,
 	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
 	cmd.Flags().BoolVar(&opts.Telemetry, "telemetry", true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, "absolute-git-hook-path", false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
+
+	// Bootstrap flags for non-git-repo folders.
+	cmd.Flags().BoolVar(&bootstrapOpts.InitRepo, "init-repo", false, "If not a git repo, initialize one non-interactively")
+	cmd.Flags().BoolVar(&bootstrapOpts.NoInitRepo, "no-init-repo", false, "If not a git repo, exit instead of prompting to initialize one")
+	cmd.Flags().StringVar(&bootstrapOpts.RepoName, "repo-name", "", "GitHub repository name for the new repo (used when bootstrapping)")
+	cmd.Flags().StringVar(&bootstrapOpts.RepoOwner, "repo-owner", "", "GitHub user or organization login for the new repo")
+	cmd.Flags().StringVar(&bootstrapOpts.RepoVisibility, "repo-visibility", "", "GitHub repository visibility: public, private, or internal")
+	cmd.Flags().BoolVar(&bootstrapOpts.NoGitHub, "no-github", false, "Initialize local git repo only; skip creating a GitHub remote")
+	cmd.Flags().StringVar(&bootstrapOpts.InitialCommitMessage, "initial-commit-message", "", "Commit message for the initial commit when bootstrapping a new repo")
 
 	// Provide a helpful error when --agent is used without a value
 	defaultFlagErr := cmd.FlagErrorFunc()

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -778,7 +778,9 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().StringVar(&bootstrapOpts.RepoVisibility, "repo-visibility", "", "GitHub repository visibility: public, private, or internal")
 	cmd.Flags().BoolVar(&bootstrapOpts.NoGitHub, "no-github", false, "Initialize local git repo only; skip creating a GitHub remote")
 	cmd.Flags().StringVar(&bootstrapOpts.InitialCommitMessage, "initial-commit-message", "", "Commit message for the initial commit when bootstrapping a new repo")
+	cmd.Flags().BoolVar(&bootstrapOpts.SkipInitialCommit, "skip-initial-commit", false, "Don't create the initial commit when bootstrapping a new repo")
 	cmd.MarkFlagsMutuallyExclusive("init-repo", "no-init-repo")
+	cmd.MarkFlagsMutuallyExclusive("initial-commit-message", "skip-initial-commit")
 
 	// Provide a helpful error when --agent is used without a value
 	defaultFlagErr := cmd.FlagErrorFunc()

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -672,7 +672,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 			if _, err := paths.WorktreeRoot(ctx); err != nil {
 				state, bootstrapErr := runGitHubBootstrapInit(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), bootstrapOpts)
 				if errors.Is(bootstrapErr, errBootstrapDeclined) {
-					fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Please run 'entire enable' from within a git repository.")
+					fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Please run 'entire enable' from within a git repository, or pass --init-repo to initialize one here.")
 					return NewSilentError(errors.New("not a git repository"))
 				}
 				if errors.Is(bootstrapErr, errBootstrapInterrupted) {

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -51,6 +51,11 @@ type EnableOptions struct {
 	CheckpointRemote    string
 	Telemetry           bool
 	AbsoluteGitHookPath bool
+	// SuppressDoneMessage tells `runEnableInteractive` to skip its final
+	// "Ready." line and the "commit the configuration files" hint. Set
+	// when the caller is running the bootstrap flow, which takes over
+	// presentation of the final state (commit, push, done).
+	SuppressDoneMessage bool
 }
 
 // applyStrategyOptions sets strategy_options on settings from CLI flags.
@@ -678,10 +683,15 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 					return bootstrapErr
 				}
 				bootstrap = state
+				// Let the enable flow know that we'll be handling the final
+				// "done" summary from the bootstrap finalize step.
+				opts.SuppressDoneMessage = true
 				// Re-check after bootstrap.
 				if _, err := paths.WorktreeRoot(ctx); err != nil {
 					return fmt.Errorf("bootstrap finished but no git repository detected: %w", err)
 				}
+				// Visual separator between bootstrap init and agent setup.
+				printBootstrapSection(cmd.OutOrStdout(), "Enabling Entire")
 				// On the way out (if setup succeeded), create the initial
 				// commit and push to the GitHub repo. If setup returned an
 				// error, skip the finalize — the user can fix the issue and
@@ -933,6 +943,12 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 
 	if err := strategy.EnsureSetup(ctx); err != nil {
 		return fmt.Errorf("failed to setup strategy: %w", err)
+	}
+
+	if opts.SuppressDoneMessage {
+		// Bootstrap finalize will print its own completion summary after
+		// making the initial commit and pushing.
+		return nil
 	}
 
 	fmt.Fprintln(w, "\nReady.")
@@ -1403,6 +1419,11 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 
 	if err := strategy.EnsureSetup(ctx); err != nil {
 		return fmt.Errorf("failed to setup strategy: %w", err)
+	}
+
+	if opts.SuppressDoneMessage {
+		// Bootstrap finalize will print its own completion summary.
+		return nil
 	}
 
 	fmt.Fprintln(w, "\nReady.")

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1210,8 +1210,12 @@ func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(availab
 		switch {
 		case len(detected) == 1:
 			if isBuiltInAgent(detected[0]) {
-				fmt.Fprintf(w, "Detected agent: %s\n\n", detected[0].Type())
-				return detected, nil
+				// When a selectFn is provided (e.g. --yes), skip the single-agent
+				// shortcut so the caller's selection logic runs instead.
+				if selectFn == nil {
+					fmt.Fprintf(w, "Detected agent: %s\n\n", detected[0].Type())
+					return detected, nil
+				}
 			}
 
 		case len(detected) > 1:
@@ -1224,8 +1228,9 @@ func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(availab
 		}
 	}
 
-	// Check if we can prompt interactively
-	if !interactive.CanPromptInteractively() {
+	// When no selectFn is provided, check if we can prompt interactively.
+	// A selectFn (e.g. from --yes) bypasses the interactive prompt entirely.
+	if selectFn == nil && !interactive.CanPromptInteractively() {
 		if hasInstalledHooks {
 			// Re-run without TTY — keep currently installed agents
 			agents := make([]agent.Agent, 0, len(installedAgentNames))

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -670,6 +670,10 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 					fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Please run 'entire enable' from within a git repository.")
 					return NewSilentError(errors.New("not a git repository"))
 				}
+				if errors.Is(bootstrapErr, errBootstrapInterrupted) {
+					fmt.Fprintln(cmd.ErrOrStderr(), "Bootstrap cancelled. A local git repository has been initialized but setup didn't complete. Run `entire enable` again to continue.")
+					return NewSilentError(errors.New("bootstrap interrupted"))
+				}
 				if bootstrapErr != nil {
 					return bootstrapErr
 				}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -652,13 +652,20 @@ If Entire is already configured but disabled, this re-enables it.
 
 If the current directory is not a git repository, Entire can initialize one
 for you and (optionally) create a matching GitHub repository via the gh CLI.`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) (runErr error) {
 			ctx := cmd.Context()
 			// Check if we're in a git repository first. If not, offer to
 			// bootstrap one (git init + optional GitHub repo). If the user
 			// declines, fall back to the legacy prerequisite error.
+			//
+			// The bootstrap runs in two phases: phase 1 (git init + identity
+			// + gather GitHub choices) before agent setup, phase 2
+			// (initial commit + gh repo create + push) after agent setup so
+			// the initial commit captures the .entire/, .claude/, hooks, and
+			// settings files that setup writes.
+			var bootstrap *bootstrapState
 			if _, err := paths.WorktreeRoot(ctx); err != nil {
-				bootstrapErr := runGitHubBootstrap(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), bootstrapOpts)
+				state, bootstrapErr := runGitHubBootstrapInit(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), bootstrapOpts)
 				if errors.Is(bootstrapErr, errBootstrapDeclined) {
 					fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Please run 'entire enable' from within a git repository.")
 					return NewSilentError(errors.New("not a git repository"))
@@ -666,10 +673,23 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 				if bootstrapErr != nil {
 					return bootstrapErr
 				}
+				bootstrap = state
 				// Re-check after bootstrap.
 				if _, err := paths.WorktreeRoot(ctx); err != nil {
 					return fmt.Errorf("bootstrap finished but no git repository detected: %w", err)
 				}
+				// On the way out (if setup succeeded), create the initial
+				// commit and push to the GitHub repo. If setup returned an
+				// error, skip the finalize — the user can fix the issue and
+				// re-run; any partial state is just untracked files.
+				defer func() {
+					if runErr != nil || bootstrap == nil {
+						return
+					}
+					if err := runGitHubBootstrapFinalize(ctx, cmd.OutOrStdout(), bootstrap); err != nil {
+						runErr = err
+					}
+				}()
 			}
 
 			if err := validateSetupFlags(opts.UseLocalSettings, opts.UseProjectSettings); err != nil {

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -56,6 +56,7 @@ type EnableOptions struct {
 	// when the caller is running the bootstrap flow, which takes over
 	// presentation of the final state (commit, push, done).
 	SuppressDoneMessage bool
+	Yes                 bool
 }
 
 // applyStrategyOptions sets strategy_options on settings from CLI flags.
@@ -102,14 +103,16 @@ func enableUsesSetupFlow(cmd *cobra.Command, agentName string) bool {
 	return cmd.Flags().Changed("force") ||
 		cmd.Flags().Changed("local-dev") ||
 		cmd.Flags().Changed("absolute-git-hook-path") ||
-		cmd.Flags().Changed("telemetry")
+		cmd.Flags().Changed("telemetry") ||
+		cmd.Flags().Changed("yes")
 }
 
 func enableNeedsAgentManagement(cmd *cobra.Command) bool {
 	return cmd.Flags().Changed("force") ||
 		cmd.Flags().Changed("local-dev") ||
 		cmd.Flags().Changed("absolute-git-hook-path") ||
-		cmd.Flags().Changed("telemetry")
+		cmd.Flags().Changed("telemetry") ||
+		cmd.Flags().Changed("yes")
 }
 
 // updateStrategyOptions applies strategy flags to settings without re-running agent setup.
@@ -275,12 +278,26 @@ func runSetupFlow(ctx context.Context, w io.Writer, opts EnableOptions) error {
 	// during setup the setting doesn't exist yet.
 	external.DiscoverAndRegisterAlways(ctx)
 
-	agents, err := detectOrSelectAgent(ctx, w, nil)
+	var selectFn func(available []string) ([]string, error)
+	if opts.Yes {
+		selectFn = selectAllAgents
+	}
+
+	agents, err := detectOrSelectAgent(ctx, w, selectFn)
 	if err != nil {
 		return fmt.Errorf("agent selection failed: %w", err)
 	}
 
 	return runEnableInteractive(ctx, w, agents, opts)
+}
+
+// selectAllAgents is a selectFn that selects all available agents.
+// Used by --yes to skip the interactive agent selection prompt.
+func selectAllAgents(available []string) ([]string, error) {
+	if len(available) == 0 {
+		return nil, errors.New("no agents available")
+	}
+	return available, nil
 }
 
 // runManageAgents shows which agents are currently enabled and lets the user
@@ -305,15 +322,15 @@ func runManageAgents(ctx context.Context, w io.Writer, opts EnableOptions, selec
 		installedSet[name] = struct{}{}
 	}
 
-	// Check if we can prompt interactively
-	if !interactive.CanPromptInteractively() {
+	// When no selectFn is provided, check if we can prompt interactively.
+	// A selectFn (e.g. from --yes) bypasses the interactive prompt entirely.
+	if selectFn == nil && !interactive.CanPromptInteractively() {
 		fmt.Fprintln(w, "Cannot show agent selection in non-interactive mode.")
 		fmt.Fprintln(w, "Use: entire configure --agent <name>")
 		return nil
 	}
 
-	// Discover external agent plugins after the interactivity check to avoid
-	// scanning PATH (with a 10s timeout) in non-interactive contexts.
+	// Discover external agent plugins so they appear in agent selection.
 	// Use DiscoverAndRegisterAlways to bypass the external_agents setting —
 	// during setup the setting doesn't exist yet.
 	external.DiscoverAndRegisterAlways(ctx)
@@ -605,7 +622,11 @@ Use --remove to remove a specific agent non-interactively:
 
 			// If already set up, show agents and let user add more
 			if settings.IsSetUpAny(ctx) {
-				return runManageAgents(ctx, cmd.OutOrStdout(), opts, nil)
+				var selectFn func(available []string) ([]string, error)
+				if opts.Yes {
+					selectFn = selectAllAgents
+				}
+				return runManageAgents(ctx, cmd.OutOrStdout(), opts, selectFn)
 			}
 
 			// Fresh repo — run full setup flow
@@ -626,6 +647,7 @@ Use --remove to remove a specific agent non-interactively:
 	cmd.Flags().StringVar(&summarizeModel, flagSummarizeModel, "", "Set the model hint used by explain --generate")
 	cmd.Flags().BoolVar(&opts.Telemetry, "telemetry", true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, "absolute-git-hook-path", false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Accept all defaults: enable all agents, accept telemetry, skip prompts")
 
 	// Provide a helpful error when --agent is used without a value
 	defaultFlagErr := cmd.FlagErrorFunc()
@@ -744,7 +766,11 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 						}
 					}
 					if enableNeedsAgentManagement(cmd) {
-						if err := runManageAgents(ctx, cmd.OutOrStdout(), opts, nil); err != nil {
+						var selectFn func(available []string) ([]string, error)
+						if opts.Yes {
+							selectFn = selectAllAgents
+						}
+						if err := runManageAgents(ctx, cmd.OutOrStdout(), opts, selectFn); err != nil {
 							return err
 						}
 					}
@@ -779,6 +805,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().StringVar(&opts.CheckpointRemote, flagCheckpointRemote, "", "Checkpoint remote in provider:owner/repo format (e.g., github:org/checkpoints-repo)")
 	cmd.Flags().BoolVar(&opts.Telemetry, "telemetry", true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, "absolute-git-hook-path", false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Accept all defaults: enable all agents, accept telemetry, skip prompts")
 
 	// Bootstrap flags for non-git-repo folders.
 	cmd.Flags().BoolVar(&bootstrapOpts.InitRepo, "init-repo", false, "If not a git repo, initialize one non-interactively")
@@ -928,12 +955,26 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 	}
 	fmt.Fprintf(w, "✓ Project configured (%s)\n", configDisplay)
 
-	if _, err := maybePromptVercelDeploymentDisable(ctx, w, targetFile, nil); err != nil {
+	var vercelPromptFn func() (bool, error)
+	if opts.Yes {
+		vercelPromptFn = func() (bool, error) { return true, nil }
+	}
+	if _, err := maybePromptVercelDeploymentDisable(ctx, w, targetFile, vercelPromptFn); err != nil {
 		return err
 	}
 
-	// Ask about telemetry consent (only if not already asked)
-	if err := promptTelemetryConsent(settings, opts.Telemetry); err != nil {
+	// Ask about telemetry consent (only if not already asked).
+	// --yes skips the interactive prompt but still respects --telemetry=false
+	// and ENTIRE_TELEMETRY_OPTOUT — it only auto-answers the interactive question.
+	if opts.Yes {
+		if !opts.Telemetry || os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+			f := false
+			settings.Telemetry = &f
+		} else if settings.Telemetry == nil {
+			t := true
+			settings.Telemetry = &t
+		}
+	} else if err := promptTelemetryConsent(settings, opts.Telemetry); err != nil {
 		return fmt.Errorf("telemetry consent: %w", err)
 	}
 	// Save again to persist telemetry choice

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -692,6 +692,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 			// settings files that setup writes.
 			var bootstrap *bootstrapState
 			if _, err := paths.WorktreeRoot(ctx); err != nil {
+				bootstrapOpts.Yes = opts.Yes
 				state, bootstrapErr := runGitHubBootstrapInit(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), bootstrapOpts)
 				if errors.Is(bootstrapErr, errBootstrapDeclined) {
 					fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Please run 'entire enable' from within a git repository, or pass --init-repo to initialize one here.")

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -636,16 +636,26 @@ func doInitialCommit(ctx context.Context, runner bootstrapRunner, dir, message s
 // when available, otherwise prompt (interactive) or fail with a helpful
 // message (non-interactive). Values are written to the local repo config
 // only, so the user's global state is never mutated.
-func ensureGitIdentity(ctx context.Context, w, errW io.Writer, runner bootstrapRunner, dir string) error {
+func ensureGitIdentity(ctx context.Context, w, _ io.Writer, runner bootstrapRunner, dir string) error {
 	// `git config --get` exits non-zero when the key isn't set. Treat any
 	// error as "unset" rather than fatal so we can fall through to sourcing
 	// the identity from elsewhere.
-	existingName, nameErr := runner.RunInDir(ctx, dir, "git", "config", "--get", "user.name")
-	existingEmail, emailErr := runner.RunInDir(ctx, dir, "git", "config", "--get", "user.email")
-	if nameErr == nil && emailErr == nil && strings.TrimSpace(existingName) != "" && strings.TrimSpace(existingEmail) != "" {
+	nameOut, nameErr := runner.RunInDir(ctx, dir, "git", "config", "--get", "user.name")
+	emailOut, emailErr := runner.RunInDir(ctx, dir, "git", "config", "--get", "user.email")
+	var existingName, existingEmail string
+	if nameErr == nil {
+		existingName = strings.TrimSpace(nameOut)
+	}
+	if emailErr == nil {
+		existingEmail = strings.TrimSpace(emailOut)
+	}
+	if existingName != "" && existingEmail != "" {
 		return nil
 	}
 
+	// Only try to fill in what's missing. If the user has a name set
+	// globally but no email, we want to keep their name and just source
+	// the email.
 	var ghName, ghEmail string
 	if ghAvailable(ctx, runner) && ghAuthenticated(ctx, runner) {
 		if n, e, err := ghUserIdentity(ctx, runner); err == nil {
@@ -653,41 +663,64 @@ func ensureGitIdentity(ctx context.Context, w, errW io.Writer, runner bootstrapR
 		}
 	}
 
-	name, email, err := resolveGitIdentity(w, errW, ghName, ghEmail)
+	name, email, err := resolveGitIdentity(w, existingName, existingEmail, ghName, ghEmail)
 	if err != nil {
 		return err
 	}
 
-	if _, err := runner.RunInDir(ctx, dir, "git", "config", "user.name", name); err != nil {
-		return fmt.Errorf("git config user.name: %w", err)
+	// Write only the fields that were missing. Leaving the already-set
+	// field alone means we never silently replace the user's globally
+	// configured name/email.
+	if existingName == "" {
+		if _, err := runner.RunInDir(ctx, dir, "git", "config", "user.name", name); err != nil {
+			return fmt.Errorf("git config user.name: %w", err)
+		}
 	}
-	if _, err := runner.RunInDir(ctx, dir, "git", "config", "user.email", email); err != nil {
-		return fmt.Errorf("git config user.email: %w", err)
+	if existingEmail == "" {
+		if _, err := runner.RunInDir(ctx, dir, "git", "config", "user.email", email); err != nil {
+			return fmt.Errorf("git config user.email: %w", err)
+		}
 	}
 	return nil
 }
 
-// resolveGitIdentity returns the name/email to use, prompting interactively
-// when values aren't already provided by gh.
-func resolveGitIdentity(w, _ io.Writer, ghName, ghEmail string) (string, string, error) {
-	if ghName != "" && ghEmail != "" {
-		fmt.Fprintf(w, "Using git identity from gh: %s <%s>\n", ghName, ghEmail)
-		return ghName, ghEmail, nil
+// resolveGitIdentity returns the name/email to use, given any values
+// already configured at a wider scope and any values from `gh api user`.
+// Only prompts for fields that are still empty after those fallbacks.
+func resolveGitIdentity(w io.Writer, existingName, existingEmail, ghName, ghEmail string) (string, string, error) {
+	name := existingName
+	email := existingEmail
+	if name == "" {
+		name = ghName
 	}
+	if email == "" {
+		email = ghEmail
+	}
+
+	if name != "" && email != "" {
+		// Announce only when we had to fill something in from gh —
+		// silence is fine when the user's existing config covered both.
+		if (existingName == "" && ghName != "") || (existingEmail == "" && ghEmail != "") {
+			fmt.Fprintf(w, "Using git identity: %s <%s>\n", name, email)
+		}
+		return name, email, nil
+	}
+
 	if !interactive.CanPromptInteractively() {
 		return "", "", errors.New(`git identity not configured. Set it with:
   git config --global user.name "Your Name"
   git config --global user.email "you@example.com"`)
 	}
 
-	name := ghName
-	email := ghEmail
-	form := NewAccessibleForm(
-		huh.NewGroup(
-			huh.NewInput().Title("Git user.name").Value(&name),
-			huh.NewInput().Title("Git user.email").Value(&email),
-		),
-	)
+	// Prompt only for the still-missing fields.
+	var fields []huh.Field
+	if name == "" {
+		fields = append(fields, huh.NewInput().Title("Git user.name").Value(&name))
+	}
+	if email == "" {
+		fields = append(fields, huh.NewInput().Title("Git user.email").Value(&email))
+	}
+	form := NewAccessibleForm(huh.NewGroup(fields...))
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return "", "", errBootstrapInterrupted

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -155,9 +156,15 @@ func runGitHubBootstrapWith(ctx context.Context, w, errW io.Writer, opts GitHubB
 		visibility = vis
 	}
 
-	// Step 5: initial commit.
+	// Step 5: initial commit. First ensure the repo has a git identity
+	// configured, then stage+commit with signing disabled so the bootstrap
+	// doesn't fail on fresh machines without a global git config or a
+	// working GPG signer.
 	message, err := resolveCommitMessage(w, opts)
 	if err != nil {
+		return err
+	}
+	if err := ensureGitIdentity(ctx, w, errW, runner, cwd); err != nil {
 		return err
 	}
 	committed, err := doInitialCommit(ctx, runner, cwd, message)
@@ -442,10 +449,116 @@ func doInitialCommit(ctx context.Context, runner bootstrapRunner, dir, message s
 	if strings.TrimSpace(out) == "" {
 		return false, nil
 	}
-	if _, err := runner.RunInDir(ctx, dir, "git", "commit", "-m", message); err != nil {
+	// Disable GPG signing for this commit only. Fresh environments often
+	// have commit.gpgsign=true inherited from a global config but no
+	// working signer; passing -c keeps the user's global config intact.
+	if _, err := runner.RunInDir(ctx, dir, "git", "-c", "commit.gpgsign=false", "commit", "-m", message); err != nil {
 		return false, fmt.Errorf("git commit: %w", err)
 	}
 	return true, nil
+}
+
+// ensureGitIdentity guarantees the repo has a user.name/user.email set at
+// some scope. If neither is configured, we source values from `gh api user`
+// when available, otherwise prompt (interactive) or fail with a helpful
+// message (non-interactive). Values are written to the local repo config
+// only, so the user's global state is never mutated.
+func ensureGitIdentity(ctx context.Context, w, errW io.Writer, runner bootstrapRunner, dir string) error {
+	// `git config --get` exits non-zero when the key isn't set. Treat any
+	// error as "unset" rather than fatal so we can fall through to sourcing
+	// the identity from elsewhere.
+	existingName, nameErr := runner.RunInDir(ctx, dir, "git", "config", "--get", "user.name")
+	existingEmail, emailErr := runner.RunInDir(ctx, dir, "git", "config", "--get", "user.email")
+	if nameErr == nil && emailErr == nil && strings.TrimSpace(existingName) != "" && strings.TrimSpace(existingEmail) != "" {
+		return nil
+	}
+
+	var ghName, ghEmail string
+	if ghAvailable(ctx, runner) && ghAuthenticated(ctx, runner) {
+		if n, e, err := ghUserIdentity(ctx, runner); err == nil {
+			ghName, ghEmail = n, e
+		}
+	}
+
+	name, email, err := resolveGitIdentity(w, errW, ghName, ghEmail)
+	if err != nil {
+		return err
+	}
+
+	if _, err := runner.RunInDir(ctx, dir, "git", "config", "user.name", name); err != nil {
+		return fmt.Errorf("git config user.name: %w", err)
+	}
+	if _, err := runner.RunInDir(ctx, dir, "git", "config", "user.email", email); err != nil {
+		return fmt.Errorf("git config user.email: %w", err)
+	}
+	return nil
+}
+
+// resolveGitIdentity returns the name/email to use, prompting interactively
+// when values aren't already provided by gh.
+func resolveGitIdentity(w, _ io.Writer, ghName, ghEmail string) (string, string, error) {
+	if ghName != "" && ghEmail != "" {
+		fmt.Fprintf(w, "Using git identity from gh: %s <%s>\n", ghName, ghEmail)
+		return ghName, ghEmail, nil
+	}
+	if !interactive.CanPromptInteractively() {
+		return "", "", errors.New(`git identity not configured. Set it with:
+  git config --global user.name "Your Name"
+  git config --global user.email "you@example.com"`)
+	}
+
+	name := ghName
+	email := ghEmail
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewInput().Title("Git user.name").Value(&name),
+			huh.NewInput().Title("Git user.email").Value(&email),
+		),
+	)
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return "", "", errBootstrapDeclined
+		}
+		return "", "", fmt.Errorf("git identity prompt: %w", err)
+	}
+	if strings.TrimSpace(name) == "" || strings.TrimSpace(email) == "" {
+		return "", "", errors.New("git user.name and user.email are both required")
+	}
+	return strings.TrimSpace(name), strings.TrimSpace(email), nil
+}
+
+// ghUserResponse is the subset of `gh api user` fields we care about.
+type ghUserResponse struct {
+	ID    int64  `json:"id"`
+	Login string `json:"login"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// ghUserIdentity returns a best-effort (name, email) from `gh api user`.
+// Missing name falls back to login; missing email falls back to the GitHub
+// no-reply address, which is always accepted by GitHub.
+func ghUserIdentity(ctx context.Context, runner bootstrapRunner) (string, string, error) {
+	out, err := runner.Run(ctx, "gh", "api", "user")
+	if err != nil {
+		return "", "", fmt.Errorf("gh api user: %w", err)
+	}
+	var resp ghUserResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return "", "", fmt.Errorf("parse gh user response: %w", err)
+	}
+	name := resp.Name
+	if name == "" {
+		name = resp.Login
+	}
+	email := resp.Email
+	if email == "" && resp.ID != 0 && resp.Login != "" {
+		email = fmt.Sprintf("%d+%s@users.noreply.github.com", resp.ID, resp.Login)
+	}
+	if name == "" || email == "" {
+		return "", "", errors.New("gh user response missing identity fields")
+	}
+	return name, email, nil
 }
 
 // ghAvailable reports whether the gh CLI is installed.

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -1,0 +1,566 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// GitHubBootstrapOptions holds flags that let `entire enable` run on a folder
+// that isn't yet a git repository. All fields are optional; supplying one
+// skips the matching interactive prompt.
+type GitHubBootstrapOptions struct {
+	// InitRepo is true if --init-repo was passed (accept git init without prompt).
+	InitRepo bool
+	// NoInitRepo is true if --no-init-repo was passed (decline without prompt).
+	NoInitRepo bool
+	// RepoName is the GitHub repository name (no owner).
+	RepoName string
+	// RepoOwner is the GitHub user or org login.
+	RepoOwner string
+	// RepoVisibility is one of "public", "private", "internal".
+	RepoVisibility string
+	// NoGitHub skips the GitHub repo creation step.
+	NoGitHub bool
+	// InitialCommitMessage overrides the default commit message prompt.
+	InitialCommitMessage string
+}
+
+// bootstrapRunner executes external commands. Tests override this to avoid
+// shelling out to git/gh.
+type bootstrapRunner interface {
+	// Run executes the command and returns stdout. Stderr is discarded.
+	Run(ctx context.Context, name string, args ...string) (string, error)
+	// RunInDir is Run with an explicit working directory.
+	RunInDir(ctx context.Context, dir, name string, args ...string) (string, error)
+	// RunInteractive streams stdin/stdout/stderr so tools like `gh repo create`
+	// can print their own progress. Returns an error on non-zero exit.
+	RunInteractive(ctx context.Context, dir, name string, args ...string) error
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, name, args...).Output()
+	return string(out), err
+}
+
+func (execRunner) RunInDir(ctx context.Context, dir, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return string(out), err
+}
+
+func (execRunner) RunInteractive(ctx context.Context, dir, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %s: %w", name, err)
+	}
+	return nil
+}
+
+// errBootstrapDeclined signals that the user chose not to initialize a repo.
+var errBootstrapDeclined = errors.New("bootstrap declined")
+
+// ghRepoNameRe validates GitHub repository names. GitHub allows alphanumerics,
+// hyphens, underscores, and periods; it does not allow spaces or leading dots.
+var ghRepoNameRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+// allowed visibility values.
+const (
+	visibilityPublic   = "public"
+	visibilityPrivate  = "private"
+	visibilityInternal = "internal"
+)
+
+// runGitHubBootstrap handles the "enable on a non-git folder" flow. On
+// success the current directory is a git repo with at least one commit (and
+// optionally a GitHub remote). Returns errBootstrapDeclined if the user
+// declined, in which case the caller should fall back to the legacy
+// "not a git repository" error.
+func runGitHubBootstrap(ctx context.Context, w, errW io.Writer, opts GitHubBootstrapOptions) error {
+	return runGitHubBootstrapWith(ctx, w, errW, opts, execRunner{})
+}
+
+// runGitHubBootstrapWith is the testable entry point that accepts a runner.
+func runGitHubBootstrapWith(ctx context.Context, w, errW io.Writer, opts GitHubBootstrapOptions, runner bootstrapRunner) error {
+	// paths.RepoRoot is unavailable here — we're bootstrapping _before_ a
+	// repo exists. Plain cwd is the correct target for `git init`.
+	cwd, err := os.Getwd() //nolint:forbidigo // no repo yet; git init runs in cwd
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+
+	// Step 1: confirm we should git init here.
+	proceed, err := confirmInitRepo(w, cwd, opts)
+	if err != nil {
+		return err
+	}
+	if !proceed {
+		return errBootstrapDeclined
+	}
+
+	// Step 2: git init.
+	if err := gitInit(ctx, runner, cwd); err != nil {
+		return fmt.Errorf("git init: %w", err)
+	}
+	// Clear cached worktree root so subsequent paths.WorktreeRoot calls pick
+	// up the freshly created repo.
+	paths.ClearWorktreeRootCache()
+	fmt.Fprintln(w, "Initialized empty Git repository.")
+
+	// Step 3: decide whether to create a GitHub repo. If gh is missing or the
+	// user passed --no-github, we skip that branch but still do the initial
+	// commit so the local repo is usable.
+	useGitHub := !opts.NoGitHub
+	if useGitHub {
+		if !ghAvailable(ctx, runner) {
+			fmt.Fprintln(errW, "gh CLI not found. Install it from https://cli.github.com/ and run `gh auth login` to add a GitHub remote.")
+			fmt.Fprintln(errW, "Continuing with local initialization only.")
+			useGitHub = false
+		} else if !ghAuthenticated(ctx, runner) {
+			fmt.Fprintln(errW, "gh CLI is not authenticated. Run `gh auth login` to add a GitHub remote.")
+			fmt.Fprintln(errW, "Continuing with local initialization only.")
+			useGitHub = false
+		}
+	}
+
+	// Step 4: collect GitHub repo details (if we're going to use GitHub).
+	var fullName, visibility string
+	if useGitHub {
+		owner, name, vis, err := selectGitHubRepo(ctx, w, errW, runner, cwd, opts)
+		if err != nil {
+			return err
+		}
+		fullName = owner + "/" + name
+		visibility = vis
+	}
+
+	// Step 5: initial commit.
+	message, err := resolveCommitMessage(w, opts)
+	if err != nil {
+		return err
+	}
+	committed, err := doInitialCommit(ctx, runner, cwd, message)
+	if err != nil {
+		return fmt.Errorf("initial commit: %w", err)
+	}
+	if !committed {
+		fmt.Fprintln(w, "No files to commit; skipping initial commit.")
+	}
+
+	// Step 6: create GitHub repo and push.
+	if useGitHub {
+		if err := ghRepoCreate(ctx, runner, cwd, fullName, visibility, committed); err != nil {
+			return fmt.Errorf("gh repo create: %w", err)
+		}
+		fmt.Fprintf(w, "Created GitHub repository %s.\n", fullName)
+	}
+
+	return nil
+}
+
+// confirmInitRepo returns true if we should proceed with `git init`. It
+// respects --init-repo / --no-init-repo; otherwise prompts.
+func confirmInitRepo(w io.Writer, cwd string, opts GitHubBootstrapOptions) (bool, error) {
+	if opts.NoInitRepo {
+		return false, nil
+	}
+	if opts.InitRepo {
+		return true, nil
+	}
+	if !interactive.CanPromptInteractively() {
+		fmt.Fprintln(w, "Not a git repository. Pass --init-repo to initialize one non-interactively.")
+		return false, nil
+	}
+
+	folder := filepath.Base(cwd)
+	confirmed := true
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title(fmt.Sprintf("No git repository in %q. Initialize one here?", folder)).
+				Value(&confirmed),
+		),
+	)
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return false, nil
+		}
+		return false, fmt.Errorf("init-repo prompt: %w", err)
+	}
+	return confirmed, nil
+}
+
+// selectGitHubRepo gathers owner, repo name, and visibility, respecting
+// supplied flags and falling back to interactive prompts.
+func selectGitHubRepo(ctx context.Context, w, errW io.Writer, runner bootstrapRunner, cwd string, opts GitHubBootstrapOptions) (owner, name, visibility string, err error) {
+	currentUser, userErr := ghCurrentUser(ctx, runner)
+	if userErr != nil {
+		return "", "", "", fmt.Errorf("query current gh user: %w", userErr)
+	}
+	orgs, orgErr := ghListOrgs(ctx, runner)
+	if orgErr != nil {
+		// Missing read:org scope is non-fatal — we can still offer the user
+		// account. Warn and continue.
+		fmt.Fprintf(errW, "Warning: could not list organizations (%v). Only your user account is available.\n", orgErr)
+		orgs = nil
+	}
+
+	owner, err = resolveOwner(w, currentUser, orgs, opts)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	name, err = resolveRepoName(ctx, w, errW, runner, owner, cwd, opts)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	visibility, err = resolveVisibility(w, owner, currentUser, opts)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return owner, name, visibility, nil
+}
+
+func resolveOwner(w io.Writer, currentUser string, orgs []string, opts GitHubBootstrapOptions) (string, error) {
+	owners := append([]string{currentUser}, orgs...)
+	if opts.RepoOwner != "" {
+		for _, candidate := range owners {
+			if candidate == opts.RepoOwner {
+				return opts.RepoOwner, nil
+			}
+		}
+		// Owner not in known list — allow it anyway; gh repo create will
+		// error out later if invalid. This supports orgs the token can't
+		// enumerate (e.g. missing read:org scope).
+		return opts.RepoOwner, nil
+	}
+	if len(owners) == 1 {
+		fmt.Fprintf(w, "Using GitHub owner: %s\n", currentUser)
+		return currentUser, nil
+	}
+	if !interactive.CanPromptInteractively() {
+		return currentUser, nil
+	}
+
+	options := make([]huh.Option[string], 0, len(owners))
+	for _, o := range owners {
+		options = append(options, huh.NewOption(o, o))
+	}
+	selected := currentUser
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Choose the GitHub owner for the new repository").
+				Options(options...).
+				Value(&selected),
+		),
+	)
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return "", errBootstrapDeclined
+		}
+		return "", fmt.Errorf("owner prompt: %w", err)
+	}
+	return selected, nil
+}
+
+func resolveRepoName(ctx context.Context, w, errW io.Writer, runner bootstrapRunner, owner, cwd string, opts GitHubBootstrapOptions) (string, error) {
+	suggested := slugifyRepoName(filepath.Base(cwd))
+
+	if opts.RepoName != "" {
+		if err := validateRepoName(opts.RepoName); err != nil {
+			return "", err
+		}
+		exists, checkErr := ghRepoExists(ctx, runner, owner, opts.RepoName)
+		if checkErr != nil {
+			fmt.Fprintf(errW, "Warning: could not check if %s/%s already exists (%v).\n", owner, opts.RepoName, checkErr)
+		} else if exists {
+			return "", fmt.Errorf("repository %s/%s already exists on GitHub", owner, opts.RepoName)
+		}
+		return opts.RepoName, nil
+	}
+
+	if !interactive.CanPromptInteractively() {
+		return suggested, nil
+	}
+
+	name := suggested
+	for {
+		var input string
+		form := NewAccessibleForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Repository name").
+					Description(fmt.Sprintf("Press enter to use %q", name)).
+					Value(&input),
+			),
+		)
+		if err := form.Run(); err != nil {
+			if errors.Is(err, huh.ErrUserAborted) {
+				return "", errBootstrapDeclined
+			}
+			return "", fmt.Errorf("repo name prompt: %w", err)
+		}
+		if strings.TrimSpace(input) != "" {
+			name = strings.TrimSpace(input)
+		}
+		if err := validateRepoName(name); err != nil {
+			fmt.Fprintf(errW, "Invalid name: %v\n", err)
+			continue
+		}
+		exists, checkErr := ghRepoExists(ctx, runner, owner, name)
+		if checkErr != nil {
+			fmt.Fprintf(errW, "Warning: could not check if %s/%s already exists (%v). Proceeding; gh will error out if it is taken.\n", owner, name, checkErr)
+			return name, nil
+		}
+		if exists {
+			fmt.Fprintf(w, "%s/%s already exists on GitHub. Pick a different name.\n", owner, name)
+			continue
+		}
+		return name, nil
+	}
+}
+
+func resolveVisibility(w io.Writer, owner, currentUser string, opts GitHubBootstrapOptions) (string, error) {
+	isOrg := owner != currentUser
+
+	if opts.RepoVisibility != "" {
+		vis := strings.ToLower(opts.RepoVisibility)
+		switch vis {
+		case visibilityPublic, visibilityPrivate:
+			return vis, nil
+		case visibilityInternal:
+			if !isOrg {
+				return "", errors.New("visibility 'internal' is only available for organization repositories")
+			}
+			return vis, nil
+		default:
+			return "", fmt.Errorf("invalid visibility %q: must be one of public, private, internal", opts.RepoVisibility)
+		}
+	}
+	if !interactive.CanPromptInteractively() {
+		return visibilityPrivate, nil
+	}
+
+	options := []huh.Option[string]{
+		huh.NewOption("Private", visibilityPrivate),
+		huh.NewOption("Public", visibilityPublic),
+	}
+	if isOrg {
+		options = append(options, huh.NewOption("Internal", visibilityInternal))
+	}
+	selected := visibilityPrivate
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Repository visibility").
+				Options(options...).
+				Value(&selected),
+		),
+	)
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return "", errBootstrapDeclined
+		}
+		return "", fmt.Errorf("visibility prompt: %w", err)
+	}
+	_ = w
+	return selected, nil
+}
+
+func resolveCommitMessage(w io.Writer, opts GitHubBootstrapOptions) (string, error) {
+	if opts.InitialCommitMessage != "" {
+		return opts.InitialCommitMessage, nil
+	}
+	defaultMsg := "Initial commit"
+	if !interactive.CanPromptInteractively() {
+		return defaultMsg, nil
+	}
+	input := defaultMsg
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Initial commit message").
+				Value(&input),
+		),
+	)
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return "", errBootstrapDeclined
+		}
+		return "", fmt.Errorf("commit message prompt: %w", err)
+	}
+	_ = w
+	if strings.TrimSpace(input) == "" {
+		return defaultMsg, nil
+	}
+	return input, nil
+}
+
+// gitInit runs `git init` in the given directory.
+func gitInit(ctx context.Context, runner bootstrapRunner, dir string) error {
+	if _, err := runner.RunInDir(ctx, dir, "git", "init"); err != nil {
+		return fmt.Errorf("run git init: %w", err)
+	}
+	return nil
+}
+
+// doInitialCommit stages all files and creates a commit. Returns whether a
+// commit was actually created (false if there were no files to stage).
+func doInitialCommit(ctx context.Context, runner bootstrapRunner, dir, message string) (bool, error) {
+	if _, err := runner.RunInDir(ctx, dir, "git", "add", "-A"); err != nil {
+		return false, fmt.Errorf("git add: %w", err)
+	}
+	// Check if the staging area has anything at all.
+	out, err := runner.RunInDir(ctx, dir, "git", "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("git status: %w", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return false, nil
+	}
+	if _, err := runner.RunInDir(ctx, dir, "git", "commit", "-m", message); err != nil {
+		return false, fmt.Errorf("git commit: %w", err)
+	}
+	return true, nil
+}
+
+// ghAvailable reports whether the gh CLI is installed.
+func ghAvailable(ctx context.Context, runner bootstrapRunner) bool {
+	_, err := runner.Run(ctx, "gh", "--version")
+	return err == nil
+}
+
+// ghAuthenticated reports whether `gh auth status` succeeds.
+func ghAuthenticated(ctx context.Context, runner bootstrapRunner) bool {
+	_, err := runner.Run(ctx, "gh", "auth", "status")
+	return err == nil
+}
+
+// ghCurrentUser returns the authenticated GitHub user's login.
+func ghCurrentUser(ctx context.Context, runner bootstrapRunner) (string, error) {
+	out, err := runner.Run(ctx, "gh", "api", "user", "--jq", ".login")
+	if err != nil {
+		return "", fmt.Errorf("gh api user: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// ghListOrgs returns the orgs the authenticated user belongs to, sorted
+// alphabetically. Requires the `read:org` token scope.
+func ghListOrgs(ctx context.Context, runner bootstrapRunner) ([]string, error) {
+	out, err := runner.Run(ctx, "gh", "api", "user/orgs", "--jq", ".[].login")
+	if err != nil {
+		return nil, fmt.Errorf("gh api user/orgs: %w", err)
+	}
+	var orgs []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			orgs = append(orgs, line)
+		}
+	}
+	sort.Strings(orgs)
+	return orgs, nil
+}
+
+// ghRepoExists checks whether <owner>/<name> exists on GitHub.
+func ghRepoExists(ctx context.Context, runner bootstrapRunner, owner, name string) (bool, error) {
+	_, err := runner.Run(ctx, "gh", "repo", "view", owner+"/"+name, "--json", "name")
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		msg := string(exitErr.Stderr)
+		if strings.Contains(msg, "Could not resolve") || strings.Contains(msg, "not found") || strings.Contains(msg, "Not Found") {
+			return false, nil
+		}
+	}
+	return false, fmt.Errorf("gh repo view: %w", err)
+}
+
+// ghRepoCreate creates a GitHub repo from the local source directory, adds
+// origin as its remote, and pushes if there's anything to push.
+func ghRepoCreate(ctx context.Context, runner bootstrapRunner, dir, fullName, visibility string, hasCommits bool) error {
+	args := []string{
+		"repo", "create", fullName,
+		"--" + visibility,
+		"--source=.",
+		"--remote=origin",
+	}
+	if hasCommits {
+		args = append(args, "--push")
+	}
+	if err := runner.RunInteractive(ctx, dir, "gh", args...); err != nil {
+		return fmt.Errorf("gh repo create: %w", err)
+	}
+	return nil
+}
+
+// slugifyRepoName turns a folder name into a GitHub-safe repo name. Invalid
+// characters are replaced with '-', and runs of '-' are collapsed.
+func slugifyRepoName(folder string) string {
+	var b strings.Builder
+	b.Grow(len(folder))
+	for _, r := range folder {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	slug := b.String()
+	// Collapse repeated dashes.
+	for strings.Contains(slug, "--") {
+		slug = strings.ReplaceAll(slug, "--", "-")
+	}
+	slug = strings.Trim(slug, "-.")
+	if slug == "" {
+		slug = "my-repo"
+	}
+	return slug
+}
+
+// validateRepoName checks whether name is a valid GitHub repo name.
+func validateRepoName(name string) error {
+	if name == "" {
+		return errors.New("name is required")
+	}
+	if len(name) > 100 {
+		return errors.New("name must be at most 100 characters")
+	}
+	if strings.Contains(name, "/") {
+		return errors.New("name must not contain '/' (pass --repo-owner separately)")
+	}
+	if !ghRepoNameRe.MatchString(name) {
+		return errors.New("name may only contain letters, digits, '.', '-', '_' and must start with a letter or digit")
+	}
+	return nil
+}

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -162,6 +162,20 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 		}
 	}
 
+	// Step 3b: ask a simple yes/no before diving into owner/name/visibility
+	// prompts. Skip the confirm when any gh-specific flag is set (the flag
+	// implies intent) or when we're non-interactive (keep the documented
+	// happy path: default to yes).
+	if useGitHub && !ghFlagsProvided(opts) && interactive.CanPromptInteractively() {
+		confirmed, err := confirmCreateGitHubRepo()
+		if err != nil {
+			return nil, err
+		}
+		if !confirmed {
+			useGitHub = false
+		}
+	}
+
 	// Step 4: collect GitHub repo details up front so all prompts are
 	// contiguous.
 	var fullName, visibility string
@@ -226,6 +240,34 @@ func runGitHubBootstrapFinalize(ctx context.Context, w io.Writer, s *bootstrapSt
 		fmt.Fprintf(w, "Created GitHub repository %s.\n", s.fullName)
 	}
 	return nil
+}
+
+// ghFlagsProvided reports whether the caller has already expressed intent
+// to create a GitHub repo via any of the gh-specific flags. Used to skip
+// the "create on GitHub?" confirm prompt in that case.
+func ghFlagsProvided(opts GitHubBootstrapOptions) bool {
+	return opts.RepoName != "" || opts.RepoOwner != "" || opts.RepoVisibility != ""
+}
+
+// confirmCreateGitHubRepo asks the user whether they want to also create
+// a matching GitHub repository. Interactive-only; callers gate on
+// CanPromptInteractively.
+func confirmCreateGitHubRepo() (bool, error) {
+	confirmed := true
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Create a matching repository on GitHub?").
+				Value(&confirmed),
+		),
+	)
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return false, nil
+		}
+		return false, fmt.Errorf("github confirm prompt: %w", err)
+	}
+	return confirmed, nil
 }
 
 // confirmInitRepo returns true if we should proceed with `git init`. It

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -79,8 +79,16 @@ func (execRunner) RunInteractive(ctx context.Context, dir, name string, args ...
 	return nil
 }
 
-// errBootstrapDeclined signals that the user chose not to initialize a repo.
+// errBootstrapDeclined signals that the user chose not to initialize a
+// repo. Returned _before_ `git init` runs; callers fall back to the
+// legacy "Not a git repository" error.
 var errBootstrapDeclined = errors.New("bootstrap declined")
+
+// errBootstrapInterrupted signals that the user aborted a prompt _after_
+// `git init` has already run. The local repo is in place but setup
+// didn't complete; callers should surface that clearly instead of
+// pretending no init happened.
+var errBootstrapInterrupted = errors.New("bootstrap interrupted after init")
 
 // ghRepoNameRe validates GitHub repository names. GitHub allows alphanumerics,
 // hyphens, underscores, and periods; it does not allow spaces or leading dots.
@@ -263,7 +271,7 @@ func confirmCreateGitHubRepo() (bool, error) {
 	)
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
-			return false, nil
+			return false, errBootstrapInterrupted
 		}
 		return false, fmt.Errorf("github confirm prompt: %w", err)
 	}
@@ -371,7 +379,7 @@ func resolveOwner(w io.Writer, currentUser string, orgs []string, opts GitHubBoo
 	)
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
-			return "", errBootstrapDeclined
+			return "", errBootstrapInterrupted
 		}
 		return "", fmt.Errorf("owner prompt: %w", err)
 	}
@@ -411,7 +419,7 @@ func resolveRepoName(ctx context.Context, w, errW io.Writer, runner bootstrapRun
 		)
 		if err := form.Run(); err != nil {
 			if errors.Is(err, huh.ErrUserAborted) {
-				return "", errBootstrapDeclined
+				return "", errBootstrapInterrupted
 			}
 			return "", fmt.Errorf("repo name prompt: %w", err)
 		}
@@ -474,7 +482,7 @@ func resolveVisibility(w io.Writer, owner, currentUser string, opts GitHubBootst
 	)
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
-			return "", errBootstrapDeclined
+			return "", errBootstrapInterrupted
 		}
 		return "", fmt.Errorf("visibility prompt: %w", err)
 	}
@@ -500,7 +508,7 @@ func resolveCommitMessage(w io.Writer, opts GitHubBootstrapOptions) (string, err
 	)
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
-			return "", errBootstrapDeclined
+			return "", errBootstrapInterrupted
 		}
 		return "", fmt.Errorf("commit message prompt: %w", err)
 	}
@@ -601,7 +609,7 @@ func resolveGitIdentity(w, _ io.Writer, ghName, ghEmail string) (string, string,
 	)
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
-			return "", "", errBootstrapDeclined
+			return "", "", errBootstrapInterrupted
 		}
 		return "", "", fmt.Errorf("git identity prompt: %w", err)
 	}

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -37,6 +37,10 @@ type GitHubBootstrapOptions struct {
 	NoGitHub bool
 	// InitialCommitMessage overrides the default commit message prompt.
 	InitialCommitMessage string
+	// SkipInitialCommit leaves the newly-created files unstaged so the
+	// user can commit themselves. The GitHub repo (if requested) is
+	// still created, but nothing is pushed.
+	SkipInitialCommit bool
 }
 
 // bootstrapRunner executes external commands. Tests override this to avoid
@@ -112,7 +116,8 @@ type bootstrapState struct {
 	useGitHub  bool
 	fullName   string // owner/name, if useGitHub
 	visibility string // public/private/internal, if useGitHub
-	message    string // resolved initial commit message
+	commit     bool   // false means the user opted out of the initial commit
+	message    string // resolved initial commit message (empty when !commit)
 }
 
 // runGitHubBootstrapInit handles the pre-setup half of "enable on a non-git
@@ -196,14 +201,21 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 		visibility = vis
 	}
 
-	// Step 5: resolve commit message and ensure git identity. Must run after
-	// `git init` so `git config` reads are scoped correctly.
-	message, err := resolveCommitMessage(w, opts)
+	// Step 5: resolve commit message (+ skip decision) and ensure git
+	// identity. Must run after `git init` so `git config` reads are
+	// scoped correctly. If the user chose to skip the commit we still
+	// need an identity *if* we're going to create the GitHub repo,
+	// because gh may read local config; but we can skip the identity
+	// check when the user is fully opting out of both commit and
+	// remote to keep the flow minimal.
+	message, commit, err := resolveCommitMessage(w, opts)
 	if err != nil {
 		return nil, err
 	}
-	if err := ensureGitIdentity(ctx, w, errW, runner, cwd); err != nil {
-		return nil, err
+	if commit {
+		if err := ensureGitIdentity(ctx, w, errW, runner, cwd); err != nil {
+			return nil, err
+		}
 	}
 
 	return &bootstrapState{
@@ -212,6 +224,7 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 		useGitHub:  useGitHub,
 		fullName:   fullName,
 		visibility: visibility,
+		commit:     commit,
 		message:    message,
 	}, nil
 }
@@ -230,22 +243,36 @@ func runGitHubBootstrapWith(ctx context.Context, w, errW io.Writer, opts GitHubB
 // runGitHubBootstrapFinalize runs the post-setup half: stage + initial
 // commit (now including any `.entire/`, agent hook, and settings files
 // written by the enable flow), then create the GitHub repo and push.
+// If the user opted out of the initial commit we still create the
+// GitHub repo (if they opted in) but skip the push — there's nothing to
+// push — and print next-step instructions.
 func runGitHubBootstrapFinalize(ctx context.Context, w io.Writer, s *bootstrapState) error {
 	if s == nil {
 		return nil
 	}
-	committed, err := doInitialCommit(ctx, s.runner, s.cwd, s.message)
-	if err != nil {
-		return fmt.Errorf("initial commit: %w", err)
-	}
-	if !committed {
-		fmt.Fprintln(w, "No files to commit; skipping initial commit.")
+	var committed bool
+	if s.commit {
+		c, err := doInitialCommit(ctx, s.runner, s.cwd, s.message)
+		if err != nil {
+			return fmt.Errorf("initial commit: %w", err)
+		}
+		committed = c
+		if !committed {
+			fmt.Fprintln(w, "No files to commit; skipping initial commit.")
+		}
 	}
 	if s.useGitHub {
 		if err := ghRepoCreate(ctx, s.runner, s.cwd, s.fullName, s.visibility, committed); err != nil {
 			return fmt.Errorf("gh repo create: %w", err)
 		}
 		fmt.Fprintf(w, "Created GitHub repository %s.\n", s.fullName)
+	}
+	if !s.commit {
+		fmt.Fprintln(w, "Skipped initial commit. When you're ready:")
+		fmt.Fprintln(w, "  git add -A && git commit -m \"Initial commit\"")
+		if s.useGitHub {
+			fmt.Fprintln(w, "  git push -u origin HEAD")
+		}
 	}
 	return nil
 }
@@ -490,33 +517,74 @@ func resolveVisibility(w io.Writer, owner, currentUser string, opts GitHubBootst
 	return selected, nil
 }
 
-func resolveCommitMessage(w io.Writer, opts GitHubBootstrapOptions) (string, error) {
+// resolveCommitMessage returns the message to use for the initial
+// commit. The second return value is false when the user chose to skip
+// the initial commit entirely; callers must skip `doInitialCommit` and
+// any subsequent push.
+func resolveCommitMessage(w io.Writer, opts GitHubBootstrapOptions) (string, bool, error) {
+	const defaultMsg = "Initial commit"
+
+	if opts.SkipInitialCommit {
+		return "", false, nil
+	}
 	if opts.InitialCommitMessage != "" {
-		return opts.InitialCommitMessage, nil
+		return opts.InitialCommitMessage, true, nil
 	}
-	defaultMsg := "Initial commit"
 	if !interactive.CanPromptInteractively() {
-		return defaultMsg, nil
+		return defaultMsg, true, nil
 	}
-	input := defaultMsg
+
+	const (
+		choiceDefault   = "default"
+		choiceCustomize = "custom"
+		choiceSkip      = "skip"
+	)
+	choice := choiceDefault
 	form := NewAccessibleForm(
 		huh.NewGroup(
-			huh.NewInput().
-				Title("Initial commit message").
-				Value(&input),
+			huh.NewSelect[string]().
+				Title("Initial commit").
+				Options(
+					huh.NewOption(`Commit with default message "Initial commit"`, choiceDefault),
+					huh.NewOption("Customize message...", choiceCustomize),
+					huh.NewOption("Skip — I'll commit manually later", choiceSkip),
+				).
+				Value(&choice),
 		),
 	)
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
-			return "", errBootstrapInterrupted
+			return "", false, errBootstrapInterrupted
 		}
-		return "", fmt.Errorf("commit message prompt: %w", err)
+		return "", false, fmt.Errorf("commit message prompt: %w", err)
 	}
 	_ = w
-	if strings.TrimSpace(input) == "" {
-		return defaultMsg, nil
+
+	switch choice {
+	case choiceSkip:
+		return "", false, nil
+	case choiceCustomize:
+		input := defaultMsg
+		custom := NewAccessibleForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Initial commit message").
+					Value(&input),
+			),
+		)
+		if err := custom.Run(); err != nil {
+			if errors.Is(err, huh.ErrUserAborted) {
+				return "", false, errBootstrapInterrupted
+			}
+			return "", false, fmt.Errorf("commit message prompt: %w", err)
+		}
+		if strings.TrimSpace(input) == "" {
+			return defaultMsg, true, nil
+		}
+		return input, true, nil
+	default:
+		return defaultMsg, true, nil
 	}
-	return input, nil
 }
 
 // gitInit runs `git init` in the given directory.

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -76,7 +76,7 @@ func (execRunner) RunInDir(ctx context.Context, dir, name string, args ...string
 // commit & push). Kept simple text so it renders correctly in accessible
 // mode and non-TTY captures.
 func printBootstrapSection(w io.Writer, title string) {
-	fmt.Fprintf(w, "\n── %s\n", title)
+	fmt.Fprintf(w, "\n%s\n", title)
 }
 
 // errBootstrapDeclined signals that the user chose not to initialize a
@@ -158,7 +158,7 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 	// Clear cached worktree root so subsequent paths.WorktreeRoot calls pick
 	// up the freshly created repo.
 	paths.ClearWorktreeRootCache()
-	fmt.Fprintln(w, "✓ Initialized empty git repository")
+	fmt.Fprintln(w, "  ✓ Initialized empty git repository")
 
 	// Step 3: decide whether to create a GitHub repo. If gh is missing or the
 	// user passed --no-github, we skip that branch but still bootstrap the
@@ -272,27 +272,27 @@ func runGitHubBootstrapFinalize(ctx context.Context, w io.Writer, s *bootstrapSt
 		}
 		committed = c
 		if committed {
-			fmt.Fprintf(w, "✓ Created initial commit (%s)\n", s.message)
+			fmt.Fprintln(w, "  ✓ Created initial commit")
 		} else {
-			fmt.Fprintln(w, "✓ Nothing to commit — the folder has no files yet")
+			fmt.Fprintln(w, "  ✓ Nothing to commit — the folder has no files yet")
 		}
 	}
 	if s.useGitHub {
 		if err := ghRepoCreate(ctx, s.runner, s.cwd, s.fullName, s.visibility, committed); err != nil {
 			return fmt.Errorf("gh repo create: %w", err)
 		}
-		fmt.Fprintf(w, "✓ Created %s (%s)\n", s.fullName, s.visibility)
-		fmt.Fprintf(w, "  https://github.com/%s\n", s.fullName)
+		fmt.Fprintf(w, "  ✓ Created %s (%s)\n", s.fullName, s.visibility)
+		fmt.Fprintf(w, "    https://github.com/%s\n", s.fullName)
 		if committed {
-			fmt.Fprintln(w, "✓ Pushed initial commit to origin")
+			fmt.Fprintln(w, "  ✓ Pushed initial commit to origin")
 		}
 	}
 	if !s.commit {
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Skipped initial commit. When you're ready:")
-		fmt.Fprintln(w, "  git add -A && git commit -m \"Initial commit\"")
+		fmt.Fprintln(w, "  Skipped initial commit. When you're ready:")
+		fmt.Fprintln(w, "    git add -A && git commit -m \"Initial commit\"")
 		if s.useGitHub {
-			fmt.Fprintln(w, "  git push -u origin HEAD")
+			fmt.Fprintln(w, "    git push -u origin HEAD")
 		}
 	}
 
@@ -409,7 +409,7 @@ func resolveOwner(w io.Writer, currentUser string, orgs []string, opts GitHubBoo
 		return opts.RepoOwner, nil
 	}
 	if len(owners) == 1 || opts.Yes {
-		fmt.Fprintf(w, "Using GitHub owner: %s\n", currentUser)
+		fmt.Fprintf(w, "  Using GitHub owner: %s\n", currentUser)
 		return currentUser, nil
 	}
 	if !interactive.CanPromptInteractively() {
@@ -469,7 +469,7 @@ func resolveRepoName(ctx context.Context, w, errW io.Writer, runner bootstrapRun
 		// Name taken. If a TTY is available, fall back to the interactive
 		// prompt so the user can pick a different name instead of failing.
 		if interactive.CanPromptInteractively() {
-			fmt.Fprintf(w, "%s/%s already exists on GitHub.\n", owner, suggested)
+			fmt.Fprintf(w, "  %s/%s already exists on GitHub.\n", owner, suggested)
 		} else {
 			return "", fmt.Errorf("repository %s/%s already exists on GitHub (use --repo-name to specify a different name)", owner, suggested)
 		}
@@ -731,7 +731,7 @@ func resolveGitIdentity(w io.Writer, existingName, existingEmail, ghName, ghEmai
 		// Announce only when we had to fill something in from gh —
 		// silence is fine when the user's existing config covered both.
 		if (existingName == "" && ghName != "") || (existingEmail == "" && ghEmail != "") {
-			fmt.Fprintf(w, "Using git identity: %s <%s>\n", name, email)
+			fmt.Fprintf(w, "  Using git identity: %s <%s>\n", name, email)
 		}
 		return name, email, nil
 	}

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -76,7 +76,7 @@ func (execRunner) RunInDir(ctx context.Context, dir, name string, args ...string
 // commit & push). Kept simple text so it renders correctly in accessible
 // mode and non-TTY captures.
 func printBootstrapSection(w io.Writer, title string) {
-	fmt.Fprintf(w, "\n━ %s\n", title)
+	fmt.Fprintf(w, "\n── %s\n", title)
 }
 
 // errBootstrapDeclined signals that the user chose not to initialize a

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -46,13 +46,11 @@ type GitHubBootstrapOptions struct {
 // bootstrapRunner executes external commands. Tests override this to avoid
 // shelling out to git/gh.
 type bootstrapRunner interface {
-	// Run executes the command and returns stdout. Stderr is discarded.
+	// Run executes the command and returns stdout. Stderr is available on
+	// the returned *exec.ExitError for error reporting.
 	Run(ctx context.Context, name string, args ...string) (string, error)
 	// RunInDir is Run with an explicit working directory.
 	RunInDir(ctx context.Context, dir, name string, args ...string) (string, error)
-	// RunInteractive streams stdin/stdout/stderr so tools like `gh repo create`
-	// can print their own progress. Returns an error on non-zero exit.
-	RunInteractive(ctx context.Context, dir, name string, args ...string) error
 }
 
 type execRunner struct{}
@@ -67,20 +65,6 @@ func (execRunner) RunInDir(ctx context.Context, dir, name string, args ...string
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	return string(out), err
-}
-
-func (execRunner) RunInteractive(ctx context.Context, dir, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("run %s: %w", name, err)
-	}
-	return nil
 }
 
 // printBootstrapSection writes a small section header so the bootstrap
@@ -217,7 +201,7 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 	// because gh may read local config; but we can skip the identity
 	// check when the user is fully opting out of both commit and
 	// remote to keep the flow minimal.
-	message, commit, err := resolveCommitMessage(w, opts)
+	message, commit, err := resolveCommitMessage(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +377,7 @@ func selectGitHubRepo(ctx context.Context, w, errW io.Writer, runner bootstrapRu
 		return "", "", "", err
 	}
 
-	visibility, err = resolveVisibility(w, owner, currentUser, opts)
+	visibility, err = resolveVisibility(owner, currentUser, opts)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -501,7 +485,7 @@ func resolveRepoName(ctx context.Context, w, errW io.Writer, runner bootstrapRun
 	}
 }
 
-func resolveVisibility(w io.Writer, owner, currentUser string, opts GitHubBootstrapOptions) (string, error) {
+func resolveVisibility(owner, currentUser string, opts GitHubBootstrapOptions) (string, error) {
 	isOrg := owner != currentUser
 
 	if opts.RepoVisibility != "" {
@@ -544,7 +528,6 @@ func resolveVisibility(w io.Writer, owner, currentUser string, opts GitHubBootst
 		}
 		return "", fmt.Errorf("visibility prompt: %w", err)
 	}
-	_ = w
 	return selected, nil
 }
 
@@ -552,7 +535,7 @@ func resolveVisibility(w io.Writer, owner, currentUser string, opts GitHubBootst
 // commit. The second return value is false when the user chose to skip
 // the initial commit entirely; callers must skip `doInitialCommit` and
 // any subsequent push.
-func resolveCommitMessage(w io.Writer, opts GitHubBootstrapOptions) (string, bool, error) {
+func resolveCommitMessage(opts GitHubBootstrapOptions) (string, bool, error) {
 	const defaultMsg = "Initial commit"
 
 	if opts.SkipInitialCommit {
@@ -589,7 +572,6 @@ func resolveCommitMessage(w io.Writer, opts GitHubBootstrapOptions) (string, boo
 		}
 		return "", false, fmt.Errorf("commit message prompt: %w", err)
 	}
-	_ = w
 
 	switch choice {
 	case choiceSkip:

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -83,6 +83,14 @@ func (execRunner) RunInteractive(ctx context.Context, dir, name string, args ...
 	return nil
 }
 
+// printBootstrapSection writes a small section header so the bootstrap
+// output has visual grouping between phases (git init → agent setup →
+// commit & push). Kept simple text so it renders correctly in accessible
+// mode and non-TTY captures.
+func printBootstrapSection(w io.Writer, title string) {
+	fmt.Fprintf(w, "\n━ %s\n", title)
+}
+
 // errBootstrapDeclined signals that the user chose not to initialize a
 // repo. Returned _before_ `git init` runs; callers fall back to the
 // legacy "Not a git repository" error.
@@ -151,13 +159,14 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 	}
 
 	// Step 2: git init.
+	printBootstrapSection(w, "Setting up git repository")
 	if err := gitInit(ctx, runner, cwd); err != nil {
 		return nil, fmt.Errorf("git init: %w", err)
 	}
 	// Clear cached worktree root so subsequent paths.WorktreeRoot calls pick
 	// up the freshly created repo.
 	paths.ClearWorktreeRootCache()
-	fmt.Fprintln(w, "Initialized empty Git repository.")
+	fmt.Fprintln(w, "✓ Initialized empty git repository")
 
 	// Step 3: decide whether to create a GitHub repo. If gh is missing or the
 	// user passed --no-github, we skip that branch but still bootstrap the
@@ -250,6 +259,19 @@ func runGitHubBootstrapFinalize(ctx context.Context, w io.Writer, s *bootstrapSt
 	if s == nil {
 		return nil
 	}
+
+	// Pick a single section title for this phase based on what we'll do.
+	if s.useGitHub || s.commit {
+		switch {
+		case s.useGitHub && s.commit:
+			printBootstrapSection(w, "Publishing to GitHub")
+		case s.useGitHub:
+			printBootstrapSection(w, "Creating GitHub repository")
+		default:
+			printBootstrapSection(w, "Finalizing")
+		}
+	}
+
 	var committed bool
 	if s.commit {
 		c, err := doInitialCommit(ctx, s.runner, s.cwd, s.message)
@@ -257,23 +279,32 @@ func runGitHubBootstrapFinalize(ctx context.Context, w io.Writer, s *bootstrapSt
 			return fmt.Errorf("initial commit: %w", err)
 		}
 		committed = c
-		if !committed {
-			fmt.Fprintln(w, "No files to commit; skipping initial commit.")
+		if committed {
+			fmt.Fprintf(w, "✓ Created initial commit (%s)\n", s.message)
+		} else {
+			fmt.Fprintln(w, "✓ Nothing to commit — the folder has no files yet")
 		}
 	}
 	if s.useGitHub {
 		if err := ghRepoCreate(ctx, s.runner, s.cwd, s.fullName, s.visibility, committed); err != nil {
 			return fmt.Errorf("gh repo create: %w", err)
 		}
-		fmt.Fprintf(w, "Created GitHub repository %s.\n", s.fullName)
+		fmt.Fprintf(w, "✓ Created %s (%s)\n", s.fullName, s.visibility)
+		fmt.Fprintf(w, "  https://github.com/%s\n", s.fullName)
+		if committed {
+			fmt.Fprintln(w, "✓ Pushed initial commit to origin")
+		}
 	}
 	if !s.commit {
+		fmt.Fprintln(w)
 		fmt.Fprintln(w, "Skipped initial commit. When you're ready:")
 		fmt.Fprintln(w, "  git add -A && git commit -m \"Initial commit\"")
 		if s.useGitHub {
 			fmt.Fprintln(w, "  git push -u origin HEAD")
 		}
 	}
+
+	fmt.Fprintln(w, "\nDone.")
 	return nil
 }
 
@@ -784,21 +815,39 @@ func ghRepoCreate(ctx context.Context, runner bootstrapRunner, dir, fullName, vi
 	// on this first push: the entire/checkpoints/v1 branch has nothing to
 	// checkpoint (no sessions yet), and if it's pushed alongside the
 	// default branch GitHub can pick it as the default.
+	//
+	// Capture `gh repo create`'s stdout instead of streaming it — its own
+	// "✓ Created repository..." / "✓ Added remote..." lines would
+	// duplicate our own summary in runGitHubBootstrapFinalize.
 	args := []string{
 		"repo", "create", fullName,
 		"--" + visibility,
 		"--source=.",
 		"--remote=origin",
 	}
-	if err := runner.RunInteractive(ctx, dir, "gh", args...); err != nil {
-		return fmt.Errorf("gh repo create: %w", err)
+	if _, err := runner.RunInDir(ctx, dir, "gh", args...); err != nil {
+		return fmt.Errorf("gh repo create: %w", ghRunnerErr(err))
 	}
 	if hasCommits {
-		if err := runner.RunInteractive(ctx, dir, "git", "push", "--no-verify", "-u", "origin", "HEAD"); err != nil {
-			return fmt.Errorf("git push: %w", err)
+		// -q silences "Enumerating objects..." etc. --no-verify bypasses
+		// the pre-push hook so entire/checkpoints/v1 isn't pushed
+		// alongside the default branch.
+		if _, err := runner.RunInDir(ctx, dir, "git", "push", "-q", "--no-verify", "-u", "origin", "HEAD"); err != nil {
+			return fmt.Errorf("git push: %w", ghRunnerErr(err))
 		}
 	}
 	return nil
+}
+
+// ghRunnerErr extracts an exec.ExitError's stderr into the returned
+// error so the user sees a useful diagnostic when gh/git fail under a
+// captured-stdout call.
+func ghRunnerErr(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+	}
+	return err
 }
 
 // slugifyRepoName turns a folder name into a GitHub-safe repo name. Invalid

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -86,9 +86,13 @@ var errBootstrapDeclined = errors.New("bootstrap declined")
 // pretending no init happened.
 var errBootstrapInterrupted = errors.New("bootstrap interrupted after init")
 
-// ghRepoNameRe validates GitHub repository names. GitHub allows alphanumerics,
-// hyphens, underscores, and periods; it does not allow spaces or leading dots.
-var ghRepoNameRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+// ghRepoNameRe validates GitHub repository names. GitHub allows
+// alphanumerics, hyphens, underscores, and periods — including as the
+// first character (e.g. `.github`). We don't enforce a leading-char
+// restriction here; `validateRepoName` handles the specific names GitHub
+// reserves (`.`, `..`). Any other edge case is left to GitHub to reject
+// so we don't over-restrict.
+var ghRepoNameRe = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 // allowed visibility values.
 const (
@@ -321,8 +325,11 @@ func confirmCreateGitHubRepo() (bool, error) {
 }
 
 // confirmInitRepo returns true if we should proceed with `git init`. It
-// respects --init-repo / --no-init-repo; otherwise prompts.
-func confirmInitRepo(w io.Writer, cwd string, opts GitHubBootstrapOptions) (bool, error) {
+// respects --init-repo / --no-init-repo; otherwise prompts. In
+// non-interactive mode we return false without printing anything so
+// the caller (setup.go) owns the "Not a git repository" message and
+// doesn't end up with duplicate output on stdout + stderr.
+func confirmInitRepo(_ io.Writer, cwd string, opts GitHubBootstrapOptions) (bool, error) {
 	if opts.NoInitRepo {
 		return false, nil
 	}
@@ -330,7 +337,6 @@ func confirmInitRepo(w io.Writer, cwd string, opts GitHubBootstrapOptions) (bool
 		return true, nil
 	}
 	if !interactive.CanPromptInteractively() {
-		fmt.Fprintln(w, "Not a git repository. Pass --init-repo to initialize one non-interactively.")
 		return false, nil
 	}
 
@@ -903,8 +909,11 @@ func validateRepoName(name string) error {
 	if strings.Contains(name, "/") {
 		return errors.New("name must not contain '/' (pass --repo-owner separately)")
 	}
+	if name == "." || name == ".." {
+		return errors.New("name cannot be '.' or '..'")
+	}
 	if !ghRepoNameRe.MatchString(name) {
-		return errors.New("name may only contain letters, digits, '.', '-', '_' and must start with a letter or digit")
+		return errors.New("name may only contain letters, digits, '.', '-', '_'")
 	}
 	return nil
 }

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -93,36 +93,53 @@ const (
 	visibilityInternal = "internal"
 )
 
-// runGitHubBootstrap handles the "enable on a non-git folder" flow. On
-// success the current directory is a git repo with at least one commit (and
-// optionally a GitHub remote). Returns errBootstrapDeclined if the user
-// declined, in which case the caller should fall back to the legacy
-// "not a git repository" error.
-func runGitHubBootstrap(ctx context.Context, w, errW io.Writer, opts GitHubBootstrapOptions) error {
-	return runGitHubBootstrapWith(ctx, w, errW, opts, execRunner{})
+// bootstrapState carries pre-setup decisions into the post-setup finalize
+// step. The caller runs `runGitHubBootstrapInit` before agent setup to do
+// `git init` + identity + gather GitHub choices, then runs
+// `runGitHubBootstrapFinalize` afterwards so the initial commit captures
+// the `.entire/`, `.claude/`, etc. files written during setup.
+type bootstrapState struct {
+	runner     bootstrapRunner
+	cwd        string
+	useGitHub  bool
+	fullName   string // owner/name, if useGitHub
+	visibility string // public/private/internal, if useGitHub
+	message    string // resolved initial commit message
 }
 
-// runGitHubBootstrapWith is the testable entry point that accepts a runner.
-func runGitHubBootstrapWith(ctx context.Context, w, errW io.Writer, opts GitHubBootstrapOptions, runner bootstrapRunner) error {
+// runGitHubBootstrapInit handles the pre-setup half of "enable on a non-git
+// folder": confirm + `git init`, ensure git identity, and (if we're going
+// to create a GitHub repo) gather owner/name/visibility up front so all
+// prompts happen before agent setup runs.
+//
+// Returns errBootstrapDeclined if the user declined the init prompt.
+// Returns nil, nil if the caller is already inside a git repo and no
+// bootstrap is needed (defensive; the caller typically gates on this).
+func runGitHubBootstrapInit(ctx context.Context, w, errW io.Writer, opts GitHubBootstrapOptions) (*bootstrapState, error) {
+	return runGitHubBootstrapInitWith(ctx, w, errW, opts, execRunner{})
+}
+
+// runGitHubBootstrapInitWith is the testable variant that accepts a runner.
+func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts GitHubBootstrapOptions, runner bootstrapRunner) (*bootstrapState, error) {
 	// paths.RepoRoot is unavailable here — we're bootstrapping _before_ a
 	// repo exists. Plain cwd is the correct target for `git init`.
 	cwd, err := os.Getwd() //nolint:forbidigo // no repo yet; git init runs in cwd
 	if err != nil {
-		return fmt.Errorf("get working directory: %w", err)
+		return nil, fmt.Errorf("get working directory: %w", err)
 	}
 
 	// Step 1: confirm we should git init here.
 	proceed, err := confirmInitRepo(w, cwd, opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !proceed {
-		return errBootstrapDeclined
+		return nil, errBootstrapDeclined
 	}
 
 	// Step 2: git init.
 	if err := gitInit(ctx, runner, cwd); err != nil {
-		return fmt.Errorf("git init: %w", err)
+		return nil, fmt.Errorf("git init: %w", err)
 	}
 	// Clear cached worktree root so subsequent paths.WorktreeRoot calls pick
 	// up the freshly created repo.
@@ -130,8 +147,8 @@ func runGitHubBootstrapWith(ctx context.Context, w, errW io.Writer, opts GitHubB
 	fmt.Fprintln(w, "Initialized empty Git repository.")
 
 	// Step 3: decide whether to create a GitHub repo. If gh is missing or the
-	// user passed --no-github, we skip that branch but still do the initial
-	// commit so the local repo is usable.
+	// user passed --no-github, we skip that branch but still bootstrap the
+	// local repo.
 	useGitHub := !opts.NoGitHub
 	if useGitHub {
 		if !ghAvailable(ctx, runner) {
@@ -145,44 +162,69 @@ func runGitHubBootstrapWith(ctx context.Context, w, errW io.Writer, opts GitHubB
 		}
 	}
 
-	// Step 4: collect GitHub repo details (if we're going to use GitHub).
+	// Step 4: collect GitHub repo details up front so all prompts are
+	// contiguous.
 	var fullName, visibility string
 	if useGitHub {
 		owner, name, vis, err := selectGitHubRepo(ctx, w, errW, runner, cwd, opts)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		fullName = owner + "/" + name
 		visibility = vis
 	}
 
-	// Step 5: initial commit. First ensure the repo has a git identity
-	// configured, then stage+commit with signing disabled so the bootstrap
-	// doesn't fail on fresh machines without a global git config or a
-	// working GPG signer.
+	// Step 5: resolve commit message and ensure git identity. Must run after
+	// `git init` so `git config` reads are scoped correctly.
 	message, err := resolveCommitMessage(w, opts)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureGitIdentity(ctx, w, errW, runner, cwd); err != nil {
+		return nil, err
+	}
+
+	return &bootstrapState{
+		runner:     runner,
+		cwd:        cwd,
+		useGitHub:  useGitHub,
+		fullName:   fullName,
+		visibility: visibility,
+		message:    message,
+	}, nil
+}
+
+// runGitHubBootstrapWith runs the full bootstrap (init + finalize) in one
+// call, used by tests that don't need to assert phasing. The real caller
+// runs the two phases around agent setup.
+func runGitHubBootstrapWith(ctx context.Context, w, errW io.Writer, opts GitHubBootstrapOptions, runner bootstrapRunner) error {
+	state, err := runGitHubBootstrapInitWith(ctx, w, errW, opts, runner)
 	if err != nil {
 		return err
 	}
-	if err := ensureGitIdentity(ctx, w, errW, runner, cwd); err != nil {
-		return err
+	return runGitHubBootstrapFinalize(ctx, w, state)
+}
+
+// runGitHubBootstrapFinalize runs the post-setup half: stage + initial
+// commit (now including any `.entire/`, agent hook, and settings files
+// written by the enable flow), then create the GitHub repo and push.
+func runGitHubBootstrapFinalize(ctx context.Context, w io.Writer, s *bootstrapState) error {
+	if s == nil {
+		return nil
 	}
-	committed, err := doInitialCommit(ctx, runner, cwd, message)
+	committed, err := doInitialCommit(ctx, s.runner, s.cwd, s.message)
 	if err != nil {
 		return fmt.Errorf("initial commit: %w", err)
 	}
 	if !committed {
 		fmt.Fprintln(w, "No files to commit; skipping initial commit.")
 	}
-
-	// Step 6: create GitHub repo and push.
-	if useGitHub {
-		if err := ghRepoCreate(ctx, runner, cwd, fullName, visibility, committed); err != nil {
+	if s.useGitHub {
+		if err := ghRepoCreate(ctx, s.runner, s.cwd, s.fullName, s.visibility, committed); err != nil {
 			return fmt.Errorf("gh repo create: %w", err)
 		}
-		fmt.Fprintf(w, "Created GitHub repository %s.\n", fullName)
+		fmt.Fprintf(w, "Created GitHub repository %s.\n", s.fullName)
 	}
-
 	return nil
 }
 

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -661,17 +661,24 @@ func ghRepoExists(ctx context.Context, runner bootstrapRunner, owner, name strin
 // ghRepoCreate creates a GitHub repo from the local source directory, adds
 // origin as its remote, and pushes if there's anything to push.
 func ghRepoCreate(ctx context.Context, runner bootstrapRunner, dir, fullName, visibility string, hasCommits bool) error {
+	// Create the remote repo and add origin, but don't push yet. We push
+	// separately below with --no-verify so the pre-push hook doesn't run
+	// on this first push: the entire/checkpoints/v1 branch has nothing to
+	// checkpoint (no sessions yet), and if it's pushed alongside the
+	// default branch GitHub can pick it as the default.
 	args := []string{
 		"repo", "create", fullName,
 		"--" + visibility,
 		"--source=.",
 		"--remote=origin",
 	}
-	if hasCommits {
-		args = append(args, "--push")
-	}
 	if err := runner.RunInteractive(ctx, dir, "gh", args...); err != nil {
 		return fmt.Errorf("gh repo create: %w", err)
+	}
+	if hasCommits {
+		if err := runner.RunInteractive(ctx, dir, "git", "push", "--no-verify", "-u", "origin", "HEAD"); err != nil {
+			return fmt.Errorf("git push: %w", err)
+		}
 	}
 	return nil
 }

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -41,6 +41,10 @@ type GitHubBootstrapOptions struct {
 	// user can commit themselves. The GitHub repo (if requested) is
 	// still created, but nothing is pushed.
 	SkipInitialCommit bool
+	// Yes accepts all defaults without prompting: init repo, create GitHub
+	// repo under the user's account (private), default commit message.
+	// Explicit flags (--no-github, --repo-owner, etc.) take precedence.
+	Yes bool
 }
 
 // bootstrapRunner executes external commands. Tests override this to avoid
@@ -176,7 +180,7 @@ func runGitHubBootstrapInitWith(ctx context.Context, w, errW io.Writer, opts Git
 	// prompts. Skip the confirm when any gh-specific flag is set (the flag
 	// implies intent) or when we're non-interactive (keep the documented
 	// happy path: default to yes).
-	if useGitHub && !ghFlagsProvided(opts) && interactive.CanPromptInteractively() {
+	if useGitHub && !opts.Yes && !ghFlagsProvided(opts) && interactive.CanPromptInteractively() {
 		confirmed, err := confirmCreateGitHubRepo()
 		if err != nil {
 			return nil, err
@@ -333,7 +337,7 @@ func confirmInitRepo(_ io.Writer, cwd string, opts GitHubBootstrapOptions) (bool
 	if opts.NoInitRepo {
 		return false, nil
 	}
-	if opts.InitRepo {
+	if opts.InitRepo || opts.Yes {
 		return true, nil
 	}
 	if !interactive.CanPromptInteractively() {
@@ -404,7 +408,7 @@ func resolveOwner(w io.Writer, currentUser string, orgs []string, opts GitHubBoo
 		// enumerate (e.g. missing read:org scope).
 		return opts.RepoOwner, nil
 	}
-	if len(owners) == 1 {
+	if len(owners) == 1 || opts.Yes {
 		fmt.Fprintf(w, "Using GitHub owner: %s\n", currentUser)
 		return currentUser, nil
 	}
@@ -450,7 +454,7 @@ func resolveRepoName(ctx context.Context, w, errW io.Writer, runner bootstrapRun
 		return opts.RepoName, nil
 	}
 
-	if !interactive.CanPromptInteractively() {
+	if opts.Yes || !interactive.CanPromptInteractively() {
 		return suggested, nil
 	}
 
@@ -508,7 +512,7 @@ func resolveVisibility(owner, currentUser string, opts GitHubBootstrapOptions) (
 			return "", fmt.Errorf("invalid visibility %q: must be one of public, private, internal", opts.RepoVisibility)
 		}
 	}
-	if !interactive.CanPromptInteractively() {
+	if opts.Yes || !interactive.CanPromptInteractively() {
 		return visibilityPrivate, nil
 	}
 
@@ -550,7 +554,7 @@ func resolveCommitMessage(opts GitHubBootstrapOptions) (string, bool, error) {
 	if opts.InitialCommitMessage != "" {
 		return opts.InitialCommitMessage, true, nil
 	}
-	if !interactive.CanPromptInteractively() {
+	if opts.Yes || !interactive.CanPromptInteractively() {
 		return defaultMsg, true, nil
 	}
 

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -454,7 +454,27 @@ func resolveRepoName(ctx context.Context, w, errW io.Writer, runner bootstrapRun
 		return opts.RepoName, nil
 	}
 
-	if opts.Yes || !interactive.CanPromptInteractively() {
+	if opts.Yes {
+		// Check availability before blindly using the suggested name.
+		exists, checkErr := ghRepoExists(ctx, runner, owner, suggested)
+		if checkErr != nil {
+			// Check failed — proceed with the suggested name and let gh
+			// error later if the name is actually taken.
+			fmt.Fprintf(errW, "Warning: could not check if %s/%s already exists (%v).\n", owner, suggested, checkErr)
+			return suggested, nil
+		}
+		if !exists {
+			return suggested, nil
+		}
+		// Name taken. If a TTY is available, fall back to the interactive
+		// prompt so the user can pick a different name instead of failing.
+		if interactive.CanPromptInteractively() {
+			fmt.Fprintf(w, "%s/%s already exists on GitHub.\n", owner, suggested)
+		} else {
+			return "", fmt.Errorf("repository %s/%s already exists on GitHub (use --repo-name to specify a different name)", owner, suggested)
+		}
+	}
+	if !interactive.CanPromptInteractively() {
 		return suggested, nil
 	}
 

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -1,0 +1,468 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const testUser = "octocat"
+
+func TestSlugifyRepoName(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"my-project":          "my-project",
+		"My Cool Project":     "My-Cool-Project",
+		"weird@@@name!!":      "weird-name",
+		"":                    "my-repo",
+		"---":                 "my-repo",
+		"foo__bar":            "foo__bar",
+		"a.b.c":               "a.b.c",
+		"leading space":       "leading-space",
+		"double  space  here": "double-space-here",
+	}
+	for in, want := range cases {
+		if got := slugifyRepoName(in); got != want {
+			t.Errorf("slugifyRepoName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestValidateRepoName(t *testing.T) {
+	t.Parallel()
+	valid := []string{"my-repo", "foo_bar", "a.b.c", "Repo123", "x"}
+	for _, name := range valid {
+		if err := validateRepoName(name); err != nil {
+			t.Errorf("validateRepoName(%q) unexpectedly returned error: %v", name, err)
+		}
+	}
+	invalid := []string{"", "-leading", ".leading", "has/slash", "has space", strings.Repeat("a", 101)}
+	for _, name := range invalid {
+		if err := validateRepoName(name); err == nil {
+			t.Errorf("validateRepoName(%q) = nil, want error", name)
+		}
+	}
+}
+
+// fakeRunner is a test seam for bootstrapRunner. Each (name, args[0]) pair
+// maps to a response.
+type fakeRunner struct {
+	mu          sync.Mutex
+	responses   map[string]fakeResponse
+	interactive map[string]error
+	calls       []fakeCall
+}
+
+type fakeResponse struct {
+	stdout string
+	err    error
+}
+
+type fakeCall struct {
+	dir  string
+	name string
+	args []string
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{
+		responses:   make(map[string]fakeResponse),
+		interactive: make(map[string]error),
+	}
+}
+
+func (f *fakeRunner) key(name string, args []string) string {
+	return name + " " + strings.Join(args, " ")
+}
+
+func (f *fakeRunner) set(name string, args []string, stdout string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.responses[f.key(name, args)] = fakeResponse{stdout: stdout, err: err}
+}
+
+func (f *fakeRunner) setInteractive(name string, args []string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.interactive[f.key(name, args)] = err
+}
+
+func (f *fakeRunner) lookup(name string, args []string) (fakeResponse, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.responses[f.key(name, args)]
+	return r, ok
+}
+
+func (f *fakeRunner) record(dir, name string, args []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, fakeCall{dir: dir, name: name, args: args})
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) (string, error) {
+	f.record("", name, args)
+	if r, ok := f.lookup(name, args); ok {
+		return r.stdout, r.err
+	}
+	return "", fmt.Errorf("fakeRunner: unexpected call %s %v", name, args)
+}
+
+func (f *fakeRunner) RunInDir(_ context.Context, dir, name string, args ...string) (string, error) {
+	f.record(dir, name, args)
+	if r, ok := f.lookup(name, args); ok {
+		return r.stdout, r.err
+	}
+	return "", fmt.Errorf("fakeRunner: unexpected call in %s: %s %v", dir, name, args)
+}
+
+func (f *fakeRunner) RunInteractive(_ context.Context, dir, name string, args ...string) error {
+	f.record(dir, name, args)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.interactive[f.key(name, args)]
+}
+
+// hasCall returns whether any recorded call matches the predicate.
+func (f *fakeRunner) hasCall(match func(fakeCall) bool) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.calls {
+		if match(c) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGhHelpers(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r := newFakeRunner()
+
+	r.set("gh", []string{"--version"}, "gh version 2.81.0\n", nil)
+	r.set("gh", []string{"auth", "status"}, "Logged in", nil)
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "octocat\n", nil)
+	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "gamma\nalpha\n\nbeta\n", nil)
+
+	if !ghAvailable(ctx, r) {
+		t.Fatal("ghAvailable should be true")
+	}
+	if !ghAuthenticated(ctx, r) {
+		t.Fatal("ghAuthenticated should be true")
+	}
+	user, err := ghCurrentUser(ctx, r)
+	if err != nil || user != testUser {
+		t.Fatalf("ghCurrentUser = %q, %v; want octocat", user, err)
+	}
+	orgs, err := ghListOrgs(ctx, r)
+	if err != nil {
+		t.Fatalf("ghListOrgs error: %v", err)
+	}
+	// Must be sorted, trimmed, and blank-skipped.
+	want := []string{"alpha", "beta", "gamma"}
+	if len(orgs) != len(want) {
+		t.Fatalf("orgs = %v, want %v", orgs, want)
+	}
+	for i, o := range orgs {
+		if o != want[i] {
+			t.Fatalf("orgs[%d] = %q, want %q", i, o, want[i])
+		}
+	}
+}
+
+func TestGhAvailable_Missing(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.set("gh", []string{"--version"}, "", errors.New("not found"))
+	if ghAvailable(context.Background(), r) {
+		t.Fatal("expected ghAvailable to return false when gh is missing")
+	}
+}
+
+func TestResolveOwner_FlagAcceptsUnknown(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	owner, err := resolveOwner(&buf, testUser, []string{"acme"}, GitHubBootstrapOptions{RepoOwner: "external-org"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != "external-org" {
+		t.Fatalf("owner = %q, want external-org", owner)
+	}
+}
+
+func TestResolveOwner_SingleDefault(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	owner, err := resolveOwner(&buf, testUser, nil, GitHubBootstrapOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if owner != testUser {
+		t.Fatalf("owner = %q, want octocat", owner)
+	}
+	if !strings.Contains(buf.String(), testUser) {
+		t.Fatalf("expected owner announcement, got %q", buf.String())
+	}
+}
+
+func TestResolveVisibility_FlagInternalRequiresOrg(t *testing.T) {
+	t.Parallel()
+	_, err := resolveVisibility(io.Discard, testUser, testUser, GitHubBootstrapOptions{RepoVisibility: "internal"})
+	if err == nil {
+		t.Fatal("expected error for internal visibility on user repo")
+	}
+}
+
+func TestResolveVisibility_FlagValid(t *testing.T) {
+	t.Parallel()
+	for _, v := range []string{"public", "private", "internal"} {
+		owner := testUser
+		current := testUser
+		if v == "internal" {
+			owner = "acme"
+		}
+		got, err := resolveVisibility(io.Discard, owner, current, GitHubBootstrapOptions{RepoVisibility: v})
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", v, err)
+		}
+		if got != v {
+			t.Fatalf("%s: got %q", v, got)
+		}
+	}
+}
+
+func TestResolveVisibility_FlagInvalid(t *testing.T) {
+	t.Parallel()
+	_, err := resolveVisibility(io.Discard, testUser, testUser, GitHubBootstrapOptions{RepoVisibility: "weird"})
+	if err == nil {
+		t.Fatal("expected error for invalid visibility")
+	}
+}
+
+func TestResolveRepoName_FlagValidates(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	// Return a non-ExitError; ghRepoExists then bubbles up, and resolveRepoName
+	// logs a warning but proceeds with the flag-supplied name.
+	r.set("gh", []string{"repo", "view", "octocat/ok-name", "--json", "name"}, "", errors.New("transient"))
+	name, err := resolveRepoName(context.Background(), io.Discard, io.Discard, r, testUser, t.TempDir(), GitHubBootstrapOptions{RepoName: "ok-name"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "ok-name" {
+		t.Fatalf("name = %q", name)
+	}
+}
+
+func TestResolveRepoName_FlagRejectsInvalid(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	_, err := resolveRepoName(context.Background(), io.Discard, io.Discard, r, testUser, t.TempDir(), GitHubBootstrapOptions{RepoName: "has/slash"})
+	if err == nil {
+		t.Fatal("expected error for name containing '/'")
+	}
+}
+
+func TestGhRepoExists_RealErrorPath(t *testing.T) {
+	t.Parallel()
+	// If `gh repo view` succeeds (no error), the repo exists.
+	r := newFakeRunner()
+	r.set("gh", []string{"repo", "view", "octocat/real", "--json", "name"}, "{\"name\":\"real\"}", nil)
+	exists, err := ghRepoExists(context.Background(), r, testUser, "real")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected exists=true")
+	}
+}
+
+func TestDoInitialCommit_EmptyFolder(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	r := newFakeRunner()
+	r.set("git", []string{"add", "-A"}, "", nil)
+	r.set("git", []string{"status", "--porcelain"}, "", nil)
+
+	committed, err := doInitialCommit(context.Background(), r, dir, "msg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if committed {
+		t.Fatal("expected committed=false for empty folder")
+	}
+}
+
+func TestDoInitialCommit_WithFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	r := newFakeRunner()
+	r.set("git", []string{"add", "-A"}, "", nil)
+	r.set("git", []string{"status", "--porcelain"}, " M README.md\n", nil)
+	r.set("git", []string{"commit", "-m", "msg"}, "", nil)
+
+	committed, err := doInitialCommit(context.Background(), r, dir, "msg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !committed {
+		t.Fatal("expected committed=true")
+	}
+}
+
+func TestRunGitHubBootstrap_DeclinedInNonInteractive(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, GitHubBootstrapOptions{}, newFakeRunner())
+	if !errors.Is(err, errBootstrapDeclined) {
+		t.Fatalf("expected errBootstrapDeclined, got %v", err)
+	}
+}
+
+func TestRunGitHubBootstrap_NoGitHubFlow(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.set("git", []string{"init"}, "", nil)
+	r.set("git", []string{"add", "-A"}, "", nil)
+	r.set("git", []string{"status", "--porcelain"}, " M file\n", nil)
+	r.set("git", []string{"commit", "-m", "First!"}, "", nil)
+
+	opts := GitHubBootstrapOptions{
+		InitRepo:             true,
+		NoGitHub:             true,
+		InitialCommitMessage: "First!",
+	}
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify git init ran in the cwd.
+	if !r.hasCall(func(c fakeCall) bool {
+		return c.name == "git" && len(c.args) == 1 && c.args[0] == "init"
+	}) {
+		t.Fatal("expected git init call")
+	}
+	// Verify no gh calls were made.
+	if r.hasCall(func(c fakeCall) bool { return c.name == "gh" }) {
+		t.Fatal("did not expect gh calls with --no-github")
+	}
+}
+
+func TestRunGitHubBootstrap_GhMissingFallsBackToLocal(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.set("gh", []string{"--version"}, "", errors.New("not found"))
+	r.set("git", []string{"init"}, "", nil)
+	r.set("git", []string{"add", "-A"}, "", nil)
+	r.set("git", []string{"status", "--porcelain"}, "", nil)
+
+	opts := GitHubBootstrapOptions{InitRepo: true}
+	var errBuf bytes.Buffer
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, &errBuf, opts, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errBuf.String(), "gh CLI not found") {
+		t.Fatalf("expected hint about installing gh, got %q", errBuf.String())
+	}
+}
+
+func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.set("gh", []string{"--version"}, "gh 2.81.0", nil)
+	r.set("gh", []string{"auth", "status"}, "Logged in", nil)
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "octocat\n", nil)
+	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "", nil)
+	// Name availability check: repo does not exist yet.
+	r.set("gh", []string{"repo", "view", "octocat/my-new", "--json", "name"}, "", errors.New("not found"))
+	r.set("git", []string{"init"}, "", nil)
+	r.set("git", []string{"add", "-A"}, "", nil)
+	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
+	r.set("git", []string{"commit", "-m", "Seed"}, "", nil)
+	r.setInteractive("gh", []string{
+		"repo", "create", "octocat/my-new",
+		"--private",
+		"--source=.",
+		"--remote=origin",
+		"--push",
+	}, nil)
+
+	opts := GitHubBootstrapOptions{
+		InitRepo:             true,
+		RepoName:             "my-new",
+		RepoVisibility:       "private",
+		InitialCommitMessage: "Seed",
+	}
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !r.hasCall(func(c fakeCall) bool {
+		return c.name == "gh" && len(c.args) > 3 && c.args[0] == "repo" && c.args[1] == "create"
+	}) {
+		t.Fatal("expected gh repo create call")
+	}
+}
+
+func TestRunGitHubBootstrap_RepoExistsFails(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.set("gh", []string{"--version"}, "gh", nil)
+	r.set("gh", []string{"auth", "status"}, "", nil)
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "octocat\n", nil)
+	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "", nil)
+	// The name is already taken. Since we aren't returning an *exec.ExitError,
+	// ghRepoExists returns (false, err) and ghRepoExists wraps. To avoid
+	// plumbing ExitError into the test, use the "already exists" path directly
+	// by returning success — meaning the repo was found.
+	r.set("gh", []string{"repo", "view", "octocat/taken", "--json", "name"}, "{\"name\":\"taken\"}", nil)
+	r.set("git", []string{"init"}, "", nil)
+
+	opts := GitHubBootstrapOptions{
+		InitRepo: true,
+		RepoName: "taken",
+	}
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, r)
+	if err == nil {
+		t.Fatal("expected error when repo already exists")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected 'already exists' error, got %v", err)
+	}
+}
+
+// restoreCwd chdirs into dir for the duration of the test.
+func restoreCwd(t *testing.T, dir string) {
+	t.Helper()
+	// macOS resolves /tmp → /private/tmp; canonicalize for safety.
+	canon, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		canon = dir
+	}
+	t.Chdir(canon)
+}

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -60,10 +60,9 @@ func TestValidateRepoName(t *testing.T) {
 // fakeRunner is a test seam for bootstrapRunner. Each (name, args[0]) pair
 // maps to a response.
 type fakeRunner struct {
-	mu          sync.Mutex
-	responses   map[string]fakeResponse
-	interactive map[string]error
-	calls       []fakeCall
+	mu        sync.Mutex
+	responses map[string]fakeResponse
+	calls     []fakeCall
 }
 
 type fakeResponse struct {
@@ -79,8 +78,7 @@ type fakeCall struct {
 
 func newFakeRunner() *fakeRunner {
 	return &fakeRunner{
-		responses:   make(map[string]fakeResponse),
-		interactive: make(map[string]error),
+		responses: make(map[string]fakeResponse),
 	}
 }
 
@@ -121,13 +119,6 @@ func (f *fakeRunner) RunInDir(_ context.Context, dir, name string, args ...strin
 		return r.stdout, r.err
 	}
 	return "", fmt.Errorf("fakeRunner: unexpected call in %s: %s %v", dir, name, args)
-}
-
-func (f *fakeRunner) RunInteractive(_ context.Context, dir, name string, args ...string) error {
-	f.record(dir, name, args)
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.interactive[f.key(name, args)]
 }
 
 // setIdentityConfigured simulates `git config --get user.name/email` returning
@@ -223,7 +214,7 @@ func TestResolveOwner_SingleDefault(t *testing.T) {
 
 func TestResolveVisibility_FlagInternalRequiresOrg(t *testing.T) {
 	t.Parallel()
-	_, err := resolveVisibility(io.Discard, testUser, testUser, GitHubBootstrapOptions{RepoVisibility: "internal"})
+	_, err := resolveVisibility(testUser, testUser, GitHubBootstrapOptions{RepoVisibility: "internal"})
 	if err == nil {
 		t.Fatal("expected error for internal visibility on user repo")
 	}
@@ -237,7 +228,7 @@ func TestResolveVisibility_FlagValid(t *testing.T) {
 		if v == "internal" {
 			owner = "acme"
 		}
-		got, err := resolveVisibility(io.Discard, owner, current, GitHubBootstrapOptions{RepoVisibility: v})
+		got, err := resolveVisibility(owner, current, GitHubBootstrapOptions{RepoVisibility: v})
 		if err != nil {
 			t.Fatalf("%s: unexpected error: %v", v, err)
 		}
@@ -249,7 +240,7 @@ func TestResolveVisibility_FlagValid(t *testing.T) {
 
 func TestResolveVisibility_FlagInvalid(t *testing.T) {
 	t.Parallel()
-	_, err := resolveVisibility(io.Discard, testUser, testUser, GitHubBootstrapOptions{RepoVisibility: "weird"})
+	_, err := resolveVisibility(testUser, testUser, GitHubBootstrapOptions{RepoVisibility: "weird"})
 	if err == nil {
 		t.Fatal("expected error for invalid visibility")
 	}
@@ -479,7 +470,7 @@ func TestRunGitHubBootstrap_RepoExistsFails(t *testing.T) {
 
 func TestResolveCommitMessage_SkipFlag(t *testing.T) {
 	t.Parallel()
-	msg, commit, err := resolveCommitMessage(io.Discard, GitHubBootstrapOptions{SkipInitialCommit: true})
+	msg, commit, err := resolveCommitMessage(GitHubBootstrapOptions{SkipInitialCommit: true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -493,7 +484,7 @@ func TestResolveCommitMessage_SkipFlag(t *testing.T) {
 
 func TestResolveCommitMessage_FlagTakesMessage(t *testing.T) {
 	t.Parallel()
-	msg, commit, err := resolveCommitMessage(io.Discard, GitHubBootstrapOptions{InitialCommitMessage: "custom"})
+	msg, commit, err := resolveCommitMessage(GitHubBootstrapOptions{InitialCommitMessage: "custom"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -507,7 +498,7 @@ func TestResolveCommitMessage_FlagTakesMessage(t *testing.T) {
 
 func TestResolveCommitMessage_NonInteractiveDefault(t *testing.T) {
 	t.Setenv("ENTIRE_TEST_TTY", "0")
-	msg, commit, err := resolveCommitMessage(io.Discard, GitHubBootstrapOptions{})
+	msg, commit, err := resolveCommitMessage(GitHubBootstrapOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -484,6 +484,57 @@ func TestRunGitHubBootstrap_RepoExistsFails(t *testing.T) {
 	}
 }
 
+func TestGhFlagsProvided(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		opts GitHubBootstrapOptions
+		want bool
+	}{
+		{"none", GitHubBootstrapOptions{}, false},
+		{"repo-name", GitHubBootstrapOptions{RepoName: "foo"}, true},
+		{"repo-owner", GitHubBootstrapOptions{RepoOwner: "octocat"}, true},
+		{"repo-visibility", GitHubBootstrapOptions{RepoVisibility: "private"}, true},
+		// NoGitHub intentionally does NOT count as "provided" — it's the
+		// opposite signal. It's handled separately upstream.
+		{"no-github", GitHubBootstrapOptions{NoGitHub: true}, false},
+		{"init-repo only", GitHubBootstrapOptions{InitRepo: true}, false},
+	}
+	for _, tc := range cases {
+		if got := ghFlagsProvided(tc.opts); got != tc.want {
+			t.Errorf("%s: ghFlagsProvided = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestRunGitHubBootstrap_NonInteractive_NoFlagsDefaultsToGitHub confirms the
+// non-interactive happy path still creates a GitHub repo when the user
+// didn't set any explicit flag (the confirm prompt is only interactive).
+func TestRunGitHubBootstrap_NonInteractive_NoFlagsDefaultsToGitHub(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.setIdentityConfigured()
+	r.set("gh", []string{"--version"}, "gh", nil)
+	r.set("gh", []string{"auth", "status"}, "ok", nil)
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "octocat\n", nil)
+	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "", nil)
+	// Default folder slug derived from t.TempDir().
+	suggested := slugifyRepoName(filepath.Base(dir))
+	r.set("gh", []string{"repo", "view", "octocat/" + suggested, "--json", "name"}, "", errors.New("not found"))
+	r.set("git", []string{"init"}, "", nil)
+
+	state, err := runGitHubBootstrapInitWith(context.Background(), io.Discard, io.Discard, GitHubBootstrapOptions{InitRepo: true}, r)
+	if err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	if !state.useGitHub {
+		t.Fatal("non-interactive bootstrap should default to using GitHub")
+	}
+}
+
 // TestRunGitHubBootstrap_InitBeforeFinalize verifies the two-phase split:
 // init runs git init up front, finalize creates the commit + pushes. A
 // simulated "agent setup" step writes a file between the phases; that

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -666,6 +666,23 @@ func TestBootstrap_FreshMachine_NoIdentity_RealGit(t *testing.T) {
 	}
 }
 
+func TestEnableCmd_InitRepoFlagsMutuallyExclusive(t *testing.T) {
+	setupTestRepo(t)
+
+	cmd := newEnableCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--init-repo", "--no-init-repo"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when both --init-repo and --no-init-repo are set")
+	}
+	if !strings.Contains(err.Error(), "init-repo") || !strings.Contains(err.Error(), "no-init-repo") {
+		t.Fatalf("expected error to mention both flags, got: %v", err)
+	}
+}
+
 // restoreCwd chdirs into dir for the duration of the test.
 func restoreCwd(t *testing.T, dir string) {
 	t.Helper()

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -485,6 +485,102 @@ func TestRunGitHubBootstrap_RepoExistsFails(t *testing.T) {
 	}
 }
 
+func TestResolveCommitMessage_SkipFlag(t *testing.T) {
+	t.Parallel()
+	msg, commit, err := resolveCommitMessage(io.Discard, GitHubBootstrapOptions{SkipInitialCommit: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if commit {
+		t.Fatal("commit should be false when SkipInitialCommit is set")
+	}
+	if msg != "" {
+		t.Fatalf("message should be empty when skipping, got %q", msg)
+	}
+}
+
+func TestResolveCommitMessage_FlagTakesMessage(t *testing.T) {
+	t.Parallel()
+	msg, commit, err := resolveCommitMessage(io.Discard, GitHubBootstrapOptions{InitialCommitMessage: "custom"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !commit {
+		t.Fatal("commit should be true with explicit message flag")
+	}
+	if msg != "custom" {
+		t.Fatalf("message = %q, want custom", msg)
+	}
+}
+
+func TestResolveCommitMessage_NonInteractiveDefault(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	msg, commit, err := resolveCommitMessage(io.Discard, GitHubBootstrapOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !commit {
+		t.Fatal("commit should default to true non-interactively")
+	}
+	if msg != "Initial commit" {
+		t.Fatalf("message = %q, want Initial commit", msg)
+	}
+}
+
+// TestRunGitHubBootstrap_SkipCommitKeepsGitHub verifies that passing
+// --skip-initial-commit still creates the GitHub repo (if requested) but
+// skips both commit and push. The local repo's files remain unstaged.
+func TestRunGitHubBootstrap_SkipCommitKeepsGitHub(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.set("gh", []string{"--version"}, "gh", nil)
+	r.set("gh", []string{"auth", "status"}, "ok", nil)
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "octocat\n", nil)
+	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "", nil)
+	r.set("gh", []string{"repo", "view", "octocat/skipme", "--json", "name"}, "", errors.New("not found"))
+	r.set("git", []string{"init"}, "", nil)
+	r.setInteractive("gh", []string{
+		"repo", "create", "octocat/skipme",
+		"--private",
+		"--source=.",
+		"--remote=origin",
+	}, nil)
+
+	opts := GitHubBootstrapOptions{
+		InitRepo:          true,
+		RepoName:          "skipme",
+		RepoVisibility:    "private",
+		SkipInitialCommit: true,
+	}
+	var out bytes.Buffer
+	if err := runGitHubBootstrapWith(context.Background(), &out, io.Discard, opts, r); err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	if r.hasCall(argsMatch("git", []string{"add", "-A"})) {
+		t.Fatal("git add should not run when SkipInitialCommit is set")
+	}
+	if r.hasCall(func(c fakeCall) bool {
+		return c.name == cmdGit && len(c.args) >= 1 && (c.args[0] == gitCmdCommit || (len(c.args) >= 3 && c.args[2] == gitCmdCommit))
+	}) {
+		t.Fatal("git commit should not run when SkipInitialCommit is set")
+	}
+	if r.hasCall(argsMatch("git", []string{"push"})) {
+		t.Fatal("git push should not run when commit was skipped")
+	}
+	// gh repo create should still have run.
+	if !r.hasCall(argsMatch("gh", []string{"repo", "create"})) {
+		t.Fatal("gh repo create should still run when only the commit is skipped")
+	}
+	// Output should mention how to commit manually.
+	if !strings.Contains(out.String(), "git add -A") {
+		t.Fatalf("expected manual-commit hint in output, got: %s", out.String())
+	}
+}
+
 func TestGhFlagsProvided(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -824,6 +920,23 @@ func TestErrSentinels_DistinctPrePostInit(t *testing.T) {
 	t.Parallel()
 	if errors.Is(errBootstrapDeclined, errBootstrapInterrupted) {
 		t.Fatal("errBootstrapDeclined and errBootstrapInterrupted must not match as the same sentinel")
+	}
+}
+
+func TestEnableCmd_InitCommitMessageFlagsMutuallyExclusive(t *testing.T) {
+	setupTestRepo(t)
+
+	cmd := newEnableCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--initial-commit-message", "foo", "--skip-initial-commit"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when both --initial-commit-message and --skip-initial-commit are set")
+	}
+	if !strings.Contains(err.Error(), "initial-commit-message") || !strings.Contains(err.Error(), "skip-initial-commit") {
+		t.Fatalf("expected error to mention both flags, got: %v", err)
 	}
 }
 

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -18,6 +18,7 @@ const (
 	cmdGit       = "git"
 	ghSubcmdRepo = "repo"
 	ghActCreate  = "create"
+	gitCmdCommit = "commit"
 )
 
 func TestSlugifyRepoName(t *testing.T) {
@@ -332,7 +333,7 @@ func TestDoInitialCommit_WithFiles(t *testing.T) {
 	}
 	// Verify gpgsign=false was passed to the commit.
 	if !r.hasCall(func(c fakeCall) bool {
-		return c.name == cmdGit && len(c.args) >= 3 && c.args[0] == "-c" && c.args[1] == "commit.gpgsign=false" && c.args[2] == "commit"
+		return c.name == cmdGit && len(c.args) >= 3 && c.args[0] == "-c" && c.args[1] == "commit.gpgsign=false" && c.args[2] == gitCmdCommit
 	}) {
 		t.Fatal("expected commit to pass -c commit.gpgsign=false")
 	}
@@ -812,6 +813,17 @@ func TestBootstrap_FreshMachine_NoIdentity_RealGit(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "git config --global user.name") {
 		t.Fatalf("expected guidance to set git config, got: %v", err)
+	}
+}
+
+// TestErrSentinels_DistinctPrePostInit documents the contract that the two
+// error sentinels signal: errBootstrapDeclined before `git init`,
+// errBootstrapInterrupted after. setup.go relies on this to show the
+// right user-facing message.
+func TestErrSentinels_DistinctPrePostInit(t *testing.T) {
+	t.Parallel()
+	if errors.Is(errBootstrapDeclined, errBootstrapInterrupted) {
+		t.Fatal("errBootstrapDeclined and errBootstrapInterrupted must not match as the same sentinel")
 	}
 }
 

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -94,13 +94,6 @@ func (f *fakeRunner) set(name string, args []string, stdout string, err error) {
 	f.responses[f.key(name, args)] = fakeResponse{stdout: stdout, err: err}
 }
 
-//nolint:unparam // err is always nil today; keep the parameter so tests can exercise interactive-call failures later without a signature change
-func (f *fakeRunner) setInteractive(name string, args []string, err error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.interactive[f.key(name, args)] = err
-}
-
 func (f *fakeRunner) lookup(name string, args []string) (fakeResponse, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -424,13 +417,13 @@ func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
 	r.set("git", []string{"add", "-A"}, "", nil)
 	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Seed"}, "", nil)
-	r.setInteractive("gh", []string{
+	r.set("gh", []string{
 		"repo", "create", "octocat/my-new",
 		"--private",
 		"--source=.",
 		"--remote=origin",
-	}, nil)
-	r.setInteractive("git", []string{"push", "--no-verify", "-u", "origin", "HEAD"}, nil)
+	}, "", nil)
+	r.set("git", []string{"push", "-q", "--no-verify", "-u", "origin", "HEAD"}, "", nil)
 
 	opts := GitHubBootstrapOptions{
 		InitRepo:             true,
@@ -448,10 +441,9 @@ func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
 	}) {
 		t.Fatal("expected gh repo create call")
 	}
-	// The initial push must bypass hooks so entire/checkpoints/v1 isn't
-	// pushed alongside the default branch.
-	if !r.hasCall(argsMatch("git", []string{"push", "--no-verify", "-u", "origin", "HEAD"})) {
-		t.Fatal("expected git push --no-verify after repo create")
+	// The initial push must bypass hooks (--no-verify) and be quiet (-q).
+	if !r.hasCall(argsMatch("git", []string{"push", "-q", "--no-verify", "-u", "origin", "HEAD"})) {
+		t.Fatal("expected git push -q --no-verify after repo create")
 	}
 }
 
@@ -542,12 +534,12 @@ func TestRunGitHubBootstrap_SkipCommitKeepsGitHub(t *testing.T) {
 	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "", nil)
 	r.set("gh", []string{"repo", "view", "octocat/skipme", "--json", "name"}, "", errors.New("not found"))
 	r.set("git", []string{"init"}, "", nil)
-	r.setInteractive("gh", []string{
+	r.set("gh", []string{
 		"repo", "create", "octocat/skipme",
 		"--private",
 		"--source=.",
 		"--remote=origin",
-	}, nil)
+	}, "", nil)
 
 	opts := GitHubBootstrapOptions{
 		InitRepo:          true,
@@ -653,13 +645,13 @@ func TestRunGitHubBootstrap_InitBeforeFinalize(t *testing.T) {
 	r.set("git", []string{"add", "-A"}, "", nil)
 	r.set("git", []string{"status", "--porcelain"}, " A .entire/settings.json\n", nil)
 	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "First"}, "", nil)
-	r.setInteractive("gh", []string{
+	r.set("gh", []string{
 		"repo", "create", "octocat/phased",
 		"--private",
 		"--source=.",
 		"--remote=origin",
-	}, nil)
-	r.setInteractive("git", []string{"push", "--no-verify", "-u", "origin", "HEAD"}, nil)
+	}, "", nil)
+	r.set("git", []string{"push", "-q", "--no-verify", "-u", "origin", "HEAD"}, "", nil)
 
 	opts := GitHubBootstrapOptions{
 		InitRepo:             true,

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -6,13 +6,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 )
 
-const testUser = "octocat"
+const (
+	testUser = "octocat"
+	cmdGit   = "git"
+)
 
 func TestSlugifyRepoName(t *testing.T) {
 	t.Parallel()
@@ -127,6 +131,13 @@ func (f *fakeRunner) RunInteractive(_ context.Context, dir, name string, args ..
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.interactive[f.key(name, args)]
+}
+
+// setIdentityConfigured simulates `git config --get user.name/email` returning
+// non-empty values, so ensureGitIdentity treats identity as already set.
+func (f *fakeRunner) setIdentityConfigured() {
+	f.set("git", []string{"config", "--get", "user.name"}, "Test User\n", nil)
+	f.set("git", []string{"config", "--get", "user.email"}, "test@example.com\n", nil)
 }
 
 // hasCall returns whether any recorded call matches the predicate.
@@ -307,7 +318,7 @@ func TestDoInitialCommit_WithFiles(t *testing.T) {
 	r := newFakeRunner()
 	r.set("git", []string{"add", "-A"}, "", nil)
 	r.set("git", []string{"status", "--porcelain"}, " M README.md\n", nil)
-	r.set("git", []string{"commit", "-m", "msg"}, "", nil)
+	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "msg"}, "", nil)
 
 	committed, err := doInitialCommit(context.Background(), r, dir, "msg")
 	if err != nil {
@@ -315,6 +326,12 @@ func TestDoInitialCommit_WithFiles(t *testing.T) {
 	}
 	if !committed {
 		t.Fatal("expected committed=true")
+	}
+	// Verify gpgsign=false was passed to the commit.
+	if !r.hasCall(func(c fakeCall) bool {
+		return c.name == cmdGit && len(c.args) >= 3 && c.args[0] == "-c" && c.args[1] == "commit.gpgsign=false" && c.args[2] == "commit"
+	}) {
+		t.Fatal("expected commit to pass -c commit.gpgsign=false")
 	}
 }
 
@@ -335,10 +352,11 @@ func TestRunGitHubBootstrap_NoGitHubFlow(t *testing.T) {
 	restoreCwd(t, dir)
 
 	r := newFakeRunner()
+	r.setIdentityConfigured()
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
 	r.set("git", []string{"status", "--porcelain"}, " M file\n", nil)
-	r.set("git", []string{"commit", "-m", "First!"}, "", nil)
+	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "First!"}, "", nil)
 
 	opts := GitHubBootstrapOptions{
 		InitRepo:             true,
@@ -352,7 +370,7 @@ func TestRunGitHubBootstrap_NoGitHubFlow(t *testing.T) {
 
 	// Verify git init ran in the cwd.
 	if !r.hasCall(func(c fakeCall) bool {
-		return c.name == "git" && len(c.args) == 1 && c.args[0] == "init"
+		return c.name == cmdGit && len(c.args) == 1 && c.args[0] == "init"
 	}) {
 		t.Fatal("expected git init call")
 	}
@@ -368,6 +386,7 @@ func TestRunGitHubBootstrap_GhMissingFallsBackToLocal(t *testing.T) {
 	restoreCwd(t, dir)
 
 	r := newFakeRunner()
+	r.setIdentityConfigured()
 	r.set("gh", []string{"--version"}, "", errors.New("not found"))
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
@@ -390,6 +409,7 @@ func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
 	restoreCwd(t, dir)
 
 	r := newFakeRunner()
+	r.setIdentityConfigured()
 	r.set("gh", []string{"--version"}, "gh 2.81.0", nil)
 	r.set("gh", []string{"auth", "status"}, "Logged in", nil)
 	r.set("gh", []string{"api", "user", "--jq", ".login"}, "octocat\n", nil)
@@ -399,7 +419,7 @@ func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
 	r.set("git", []string{"init"}, "", nil)
 	r.set("git", []string{"add", "-A"}, "", nil)
 	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
-	r.set("git", []string{"commit", "-m", "Seed"}, "", nil)
+	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Seed"}, "", nil)
 	r.setInteractive("gh", []string{
 		"repo", "create", "octocat/my-new",
 		"--private",
@@ -453,6 +473,196 @@ func TestRunGitHubBootstrap_RepoExistsFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "already exists") {
 		t.Fatalf("expected 'already exists' error, got %v", err)
+	}
+}
+
+func TestEnsureGitIdentity_AlreadyConfigured(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.setIdentityConfigured()
+
+	err := ensureGitIdentity(context.Background(), io.Discard, io.Discard, r, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No git config writes should have occurred.
+	if r.hasCall(func(c fakeCall) bool {
+		return c.name == cmdGit && len(c.args) >= 2 && c.args[0] == "config" && (c.args[1] == "user.name" || c.args[1] == "user.email")
+	}) {
+		t.Fatal("did not expect identity writes when already configured")
+	}
+}
+
+func TestEnsureGitIdentity_SourcedFromGh(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	// Identity missing locally (empty stdout).
+	r.set("git", []string{"config", "--get", "user.name"}, "", errors.New("not set"))
+	r.set("git", []string{"config", "--get", "user.email"}, "", errors.New("not set"))
+	// gh available and authenticated.
+	r.set("gh", []string{"--version"}, "gh", nil)
+	r.set("gh", []string{"auth", "status"}, "ok", nil)
+	r.set("gh", []string{"api", "user"}, `{"id":42,"login":"octo","name":"Octo Cat","email":"octo@example.com"}`, nil)
+	// Expect writes with values from gh.
+	r.set("git", []string{"config", "user.name", "Octo Cat"}, "", nil)
+	r.set("git", []string{"config", "user.email", "octo@example.com"}, "", nil)
+
+	err := ensureGitIdentity(context.Background(), io.Discard, io.Discard, r, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureGitIdentity_GhNoreplyFallback(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.set("git", []string{"config", "--get", "user.name"}, "", errors.New("not set"))
+	r.set("git", []string{"config", "--get", "user.email"}, "", errors.New("not set"))
+	r.set("gh", []string{"--version"}, "gh", nil)
+	r.set("gh", []string{"auth", "status"}, "ok", nil)
+	// email is null/missing: should fall back to id+login noreply.
+	r.set("gh", []string{"api", "user"}, `{"id":42,"login":"octo","name":"","email":null}`, nil)
+	r.set("git", []string{"config", "user.name", "octo"}, "", nil)
+	r.set("git", []string{"config", "user.email", "42+octo@users.noreply.github.com"}, "", nil)
+
+	err := ensureGitIdentity(context.Background(), io.Discard, io.Discard, r, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureGitIdentity_NonInteractiveNoGh_Errors(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	r := newFakeRunner()
+	r.set("git", []string{"config", "--get", "user.name"}, "", errors.New("not set"))
+	r.set("git", []string{"config", "--get", "user.email"}, "", errors.New("not set"))
+	r.set("gh", []string{"--version"}, "", errors.New("not found"))
+
+	err := ensureGitIdentity(context.Background(), io.Discard, io.Discard, r, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when identity missing and gh unavailable")
+	}
+	if !strings.Contains(err.Error(), "git config --global user.name") {
+		t.Fatalf("expected guidance to set git config, got %v", err)
+	}
+}
+
+func TestGhUserIdentity_NameFallsBackToLogin(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.set("gh", []string{"api", "user"}, `{"id":7,"login":"dev","name":"","email":"dev@example.com"}`, nil)
+	name, email, err := ghUserIdentity(context.Background(), r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "dev" {
+		t.Fatalf("name = %q", name)
+	}
+	if email != "dev@example.com" {
+		t.Fatalf("email = %q", email)
+	}
+}
+
+// TestBootstrap_FreshMachine_RealGit is an integration-style test that runs
+// real git via execRunner on a temp dir isolated from the user's global git
+// config. Regression guard for the issue where bootstrap commits failed
+// without a configured identity or because of commit.gpgsign=true.
+func TestBootstrap_FreshMachine_RealGit(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+
+	// Isolate from any global git config: point HOME + GIT_CONFIG_* at
+	// empty/missing locations, and force a broken GPG signing config that
+	// would fail any commit if we did not pass -c commit.gpgsign=false.
+	emptyHome := t.TempDir()
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	// A global config that demands signing with a non-existent program. If
+	// our bootstrap did not override gpgsign for its commit, git would
+	// error out here.
+	globalCfg := filepath.Join(emptyHome, ".gitconfig")
+	globalContent := "[user]\n\tname = Fresh User\n\temail = fresh@example.com\n[commit]\n\tgpgsign = true\n[gpg]\n\tprogram = /does/not/exist\n"
+	if err := writeTempFile(globalCfg, globalContent); err != nil {
+		t.Fatalf("write global gitconfig: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", globalCfg)
+	// Ensure no system config interferes.
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+
+	projectDir := t.TempDir()
+	restoreCwd(t, projectDir)
+	// Create a file to commit.
+	if err := writeTempFile(filepath.Join(projectDir, "README.md"), "hello\n"); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	opts := GitHubBootstrapOptions{
+		InitRepo:             true,
+		NoGitHub:             true,
+		InitialCommitMessage: "Initial",
+	}
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, execRunner{})
+	if err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+
+	// Verify a commit actually landed on HEAD.
+	out, err := execRunner{}.RunInDir(context.Background(), projectDir, "git", "log", "--oneline")
+	if err != nil {
+		t.Fatalf("git log failed: %v", err)
+	}
+	if !strings.Contains(out, "Initial") {
+		t.Fatalf("expected 'Initial' commit in log, got: %q", out)
+	}
+}
+
+func writeTempFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+// TestBootstrap_FreshMachine_NoIdentity_RealGit verifies that a fresh machine
+// without any git identity configured fails cleanly in non-interactive mode
+// with a helpful error message, instead of letting git commit fail with a
+// confusing "please tell me who you are" stderr.
+func TestBootstrap_FreshMachine_NoIdentity_RealGit(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+
+	emptyHome := t.TempDir()
+	t.Setenv("HOME", emptyHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	// Empty global config: no user.name/user.email.
+	globalCfg := filepath.Join(emptyHome, ".gitconfig")
+	if err := writeTempFile(globalCfg, ""); err != nil {
+		t.Fatalf("write global gitconfig: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", globalCfg)
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	// Ensure gh isn't authenticated for the purpose of this test — point
+	// PATH at an empty directory so `gh` resolves to "not found".
+	emptyBin := t.TempDir()
+	t.Setenv("PATH", emptyBin)
+
+	projectDir := t.TempDir()
+	restoreCwd(t, projectDir)
+	if err := writeTempFile(filepath.Join(projectDir, "README.md"), "hi\n"); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	opts := GitHubBootstrapOptions{
+		InitRepo:             true,
+		NoGitHub:             true,
+		InitialCommitMessage: "x",
+	}
+	// With PATH wiped, execRunner can't find git either — so use a runner
+	// that keeps git on the original PATH but points gh to nowhere. The
+	// simplest portable way: re-extend PATH with common git locations.
+	t.Setenv("PATH", "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin")
+
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, execRunner{})
+	if err == nil {
+		t.Fatal("expected error when identity missing and gh unavailable")
+	}
+	if !strings.Contains(err.Error(), "git config --global user.name") {
+		t.Fatalf("expected guidance to set git config, got: %v", err)
 	}
 }
 

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -19,6 +19,7 @@ const (
 	ghSubcmdRepo = "repo"
 	ghActCreate  = "create"
 	gitCmdCommit = "commit"
+	gitCmdConfig = "config"
 )
 
 func TestSlugifyRepoName(t *testing.T) {
@@ -716,7 +717,7 @@ func TestEnsureGitIdentity_AlreadyConfigured(t *testing.T) {
 	}
 	// No git config writes should have occurred.
 	if r.hasCall(func(c fakeCall) bool {
-		return c.name == cmdGit && len(c.args) >= 2 && c.args[0] == "config" && (c.args[1] == "user.name" || c.args[1] == "user.email")
+		return c.name == cmdGit && len(c.args) >= 2 && c.args[0] == gitCmdConfig && (c.args[1] == "user.name" || c.args[1] == "user.email")
 	}) {
 		t.Fatal("did not expect identity writes when already configured")
 	}
@@ -757,6 +758,60 @@ func TestEnsureGitIdentity_GhNoreplyFallback(t *testing.T) {
 	err := ensureGitIdentity(context.Background(), io.Discard, io.Discard, r, t.TempDir())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestEnsureGitIdentity_PreservesExistingName covers the partial-config
+// case: `user.name` is set globally but `user.email` is missing. We must
+// source only the email (from gh) and leave the name untouched — we
+// never want to silently replace the user's configured name with a
+// gh-derived login.
+func TestEnsureGitIdentity_PreservesExistingName(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	// Name is set globally, email is not.
+	r.set("git", []string{"config", "--get", "user.name"}, "John Doe\n", nil)
+	r.set("git", []string{"config", "--get", "user.email"}, "", errors.New("not set"))
+	// gh available and returns both values.
+	r.set("gh", []string{"--version"}, "gh", nil)
+	r.set("gh", []string{"auth", "status"}, "ok", nil)
+	r.set("gh", []string{"api", "user"}, `{"id":42,"login":"johndoe","name":"Johnny Dough","email":"john@example.com"}`, nil)
+	// Only the email should be written locally — the name must stay
+	// at the user's global value.
+	r.set("git", []string{"config", "user.email", "john@example.com"}, "", nil)
+
+	err := ensureGitIdentity(context.Background(), io.Discard, io.Discard, r, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No `git config user.name ...` call should have been made.
+	if r.hasCall(func(c fakeCall) bool {
+		return c.name == cmdGit && len(c.args) >= 2 && c.args[0] == gitCmdConfig && c.args[1] == "user.name"
+	}) {
+		t.Fatal("ensureGitIdentity should not write user.name when it's already set globally")
+	}
+}
+
+// TestEnsureGitIdentity_PreservesExistingEmail mirrors the above for the
+// other direction: email set, name missing.
+func TestEnsureGitIdentity_PreservesExistingEmail(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.set("git", []string{"config", "--get", "user.name"}, "", errors.New("not set"))
+	r.set("git", []string{"config", "--get", "user.email"}, "john@example.com\n", nil)
+	r.set("gh", []string{"--version"}, "gh", nil)
+	r.set("gh", []string{"auth", "status"}, "ok", nil)
+	r.set("gh", []string{"api", "user"}, `{"id":42,"login":"johndoe","name":"Johnny","email":"other@example.com"}`, nil)
+	r.set("git", []string{"config", "user.name", "Johnny"}, "", nil)
+
+	err := ensureGitIdentity(context.Background(), io.Discard, io.Discard, r, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.hasCall(func(c fakeCall) bool {
+		return c.name == cmdGit && len(c.args) >= 2 && c.args[0] == gitCmdConfig && c.args[1] == "user.email"
+	}) {
+		t.Fatal("ensureGitIdentity should not write user.email when it's already set globally")
 	}
 }
 

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -44,13 +44,20 @@ func TestSlugifyRepoName(t *testing.T) {
 
 func TestValidateRepoName(t *testing.T) {
 	t.Parallel()
-	valid := []string{"my-repo", "foo_bar", "a.b.c", "Repo123", "x"}
+	// GitHub accepts leading ".", "-", and "_" (e.g. `.github`), so we
+	// accept them too.
+	valid := []string{
+		"my-repo", "foo_bar", "a.b.c", "Repo123", "x",
+		".github", ".leading", "-leading", "_leading",
+	}
 	for _, name := range valid {
 		if err := validateRepoName(name); err != nil {
 			t.Errorf("validateRepoName(%q) unexpectedly returned error: %v", name, err)
 		}
 	}
-	invalid := []string{"", "-leading", ".leading", "has/slash", "has space", strings.Repeat("a", 101)}
+	// "." and ".." are specifically rejected; anything with / or
+	// whitespace is rejected; length is capped.
+	invalid := []string{"", ".", "..", "has/slash", "has space", strings.Repeat("a", 101)}
 	for _, name := range invalid {
 		if err := validateRepoName(name); err == nil {
 			t.Errorf("validateRepoName(%q) = nil, want error", name)
@@ -903,10 +910,36 @@ func writeTempFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o600)
 }
 
-// TestBootstrap_FreshMachine_NoIdentity_RealGit verifies that a fresh machine
-// without any git identity configured fails cleanly in non-interactive mode
-// with a helpful error message, instead of letting git commit fail with a
-// confusing "please tell me who you are" stderr.
+// ghFailingRunner wraps another bootstrapRunner and forces all `gh`
+// invocations to fail, while letting real `git` calls through. This
+// lets tests deterministically exercise the "gh unavailable" path
+// regardless of whether `gh` is installed/authenticated on the host.
+type ghFailingRunner struct {
+	inner bootstrapRunner
+}
+
+func (r ghFailingRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	if name == "gh" {
+		return "", errors.New("gh not available (test)")
+	}
+	return r.inner.Run(ctx, name, args...)
+}
+
+func (r ghFailingRunner) RunInDir(ctx context.Context, dir, name string, args ...string) (string, error) {
+	if name == "gh" {
+		return "", errors.New("gh not available (test)")
+	}
+	return r.inner.RunInDir(ctx, dir, name, args...)
+}
+
+// TestBootstrap_FreshMachine_NoIdentity_RealGit verifies that a fresh
+// machine without any git identity configured fails cleanly in
+// non-interactive mode with a helpful error message, instead of letting
+// `git commit` fail with a confusing "please tell me who you are" stderr.
+//
+// Uses a gh-failing runner wrapper rather than PATH manipulation so the
+// test isn't sensitive to whether `gh` + GH_TOKEN/GITHUB_TOKEN are set
+// on the host.
 func TestBootstrap_FreshMachine_NoIdentity_RealGit(t *testing.T) {
 	t.Setenv("ENTIRE_TEST_TTY", "0")
 
@@ -920,10 +953,10 @@ func TestBootstrap_FreshMachine_NoIdentity_RealGit(t *testing.T) {
 	}
 	t.Setenv("GIT_CONFIG_GLOBAL", globalCfg)
 	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
-	// Ensure gh isn't authenticated for the purpose of this test — point
-	// PATH at an empty directory so `gh` resolves to "not found".
-	emptyBin := t.TempDir()
-	t.Setenv("PATH", emptyBin)
+	// Belt-and-suspenders: unset any GitHub tokens so a wrapper bypass
+	// would still not find credentials.
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 
 	projectDir := t.TempDir()
 	restoreCwd(t, projectDir)
@@ -936,12 +969,8 @@ func TestBootstrap_FreshMachine_NoIdentity_RealGit(t *testing.T) {
 		NoGitHub:             true,
 		InitialCommitMessage: "x",
 	}
-	// With PATH wiped, execRunner can't find git either — so use a runner
-	// that keeps git on the original PATH but points gh to nowhere. The
-	// simplest portable way: re-extend PATH with common git locations.
-	t.Setenv("PATH", "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin")
-
-	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, execRunner{})
+	runner := ghFailingRunner{inner: execRunner{}}
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, runner)
 	if err == nil {
 		t.Fatal("expected error when identity missing and gh unavailable")
 	}

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -1117,6 +1117,40 @@ func TestRunGitHubBootstrap_YesRepoExistsNoTTY_Fails(t *testing.T) {
 	}
 }
 
+func TestResolveRepoName_YesRepoExistsWithTTY_FallsBackToPrompt(t *testing.T) {
+	// When --yes is set, the name is taken, and a TTY is available,
+	// resolveRepoName should print a conflict message and fall through
+	// to the interactive prompt (which we can't complete in a test, but
+	// we can verify it reached the right path via the output).
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	repoName := filepath.Base(dir)
+	// The suggested name exists.
+	r.set("gh", []string{"repo", "view", "myuser/" + repoName, "--json", "name"}, `{"name":"`+repoName+`"}`, nil)
+
+	var stdout bytes.Buffer
+	opts := GitHubBootstrapOptions{Yes: true}
+	// resolveRepoName will print the conflict message, then try to run
+	// the interactive form which will fail without a real TTY — that's fine,
+	// we just need to verify it printed the conflict message (reached the
+	// fallback path) rather than returning the taken name or a hard error.
+	_, err := resolveRepoName(context.Background(), &stdout, io.Discard, r, "myuser", dir, opts)
+
+	output := stdout.String()
+	if !strings.Contains(output, "already exists on GitHub") {
+		t.Errorf("expected conflict message in output, got: %s", output)
+	}
+	// The form.Run() will error since there's no real TTY — that's expected.
+	// The key assertion is that we got the conflict message, proving the
+	// fallback path was taken instead of returning the taken name.
+	if err == nil {
+		t.Error("expected error from form.Run() without a real TTY")
+	}
+}
+
 func TestRunGitHubBootstrap_YesWithNoGitHub(t *testing.T) {
 	// --yes combined with --no-github should skip GitHub but still init + commit.
 	t.Setenv("ENTIRE_TEST_TTY", "0")

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -1088,6 +1088,35 @@ func TestRunGitHubBootstrap_YesAcceptsAllDefaults(t *testing.T) {
 	}
 }
 
+func TestRunGitHubBootstrap_YesRepoExistsNoTTY_Fails(t *testing.T) {
+	// When --yes is set, the repo name is taken, and there's no TTY,
+	// we should get a clear error instead of a silent gh failure.
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.setIdentityConfigured()
+	r.set("gh", []string{"--version"}, "gh 2.81.0", nil)
+	r.set("gh", []string{"auth", "status"}, "Logged in", nil)
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "myuser\n", nil)
+	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "", nil)
+	r.set("git", []string{"init"}, "", nil)
+
+	// The suggested repo name already exists.
+	repoName := filepath.Base(dir)
+	r.set("gh", []string{"repo", "view", "myuser/" + repoName, "--json", "name"}, `{"name":"`+repoName+`"}`, nil)
+
+	opts := GitHubBootstrapOptions{Yes: true}
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, r)
+	if err == nil {
+		t.Fatal("expected error when repo name exists and no TTY")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' in error, got: %v", err)
+	}
+}
+
 func TestRunGitHubBootstrap_YesWithNoGitHub(t *testing.T) {
 	// --yes combined with --no-github should skip GitHub but still init + commit.
 	t.Setenv("ENTIRE_TEST_TTY", "0")

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -93,6 +93,7 @@ func (f *fakeRunner) set(name string, args []string, stdout string, err error) {
 	f.responses[f.key(name, args)] = fakeResponse{stdout: stdout, err: err}
 }
 
+//nolint:unparam // err is always nil today; keep the parameter so tests can exercise interactive-call failures later without a signature change
 func (f *fakeRunner) setInteractive(name string, args []string, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -427,8 +428,8 @@ func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
 		"--private",
 		"--source=.",
 		"--remote=origin",
-		"--push",
 	}, nil)
+	r.setInteractive("git", []string{"push", "--no-verify", "-u", "origin", "HEAD"}, nil)
 
 	opts := GitHubBootstrapOptions{
 		InitRepo:             true,
@@ -445,6 +446,11 @@ func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
 		return c.name == "gh" && len(c.args) > 3 && c.args[0] == ghSubcmdRepo && c.args[1] == ghActCreate
 	}) {
 		t.Fatal("expected gh repo create call")
+	}
+	// The initial push must bypass hooks so entire/checkpoints/v1 isn't
+	// pushed alongside the default branch.
+	if !r.hasCall(argsMatch("git", []string{"push", "--no-verify", "-u", "origin", "HEAD"})) {
+		t.Fatal("expected git push --no-verify after repo create")
 	}
 }
 
@@ -504,8 +510,8 @@ func TestRunGitHubBootstrap_InitBeforeFinalize(t *testing.T) {
 		"--private",
 		"--source=.",
 		"--remote=origin",
-		"--push",
 	}, nil)
+	r.setInteractive("git", []string{"push", "--no-verify", "-u", "origin", "HEAD"}, nil)
 
 	opts := GitHubBootstrapOptions{
 		InitRepo:             true,

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 const (
-	testUser = "octocat"
-	cmdGit   = "git"
+	testUser     = "octocat"
+	cmdGit       = "git"
+	ghSubcmdRepo = "repo"
+	ghActCreate  = "create"
 )
 
 func TestSlugifyRepoName(t *testing.T) {
@@ -440,7 +442,7 @@ func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
 	}
 
 	if !r.hasCall(func(c fakeCall) bool {
-		return c.name == "gh" && len(c.args) > 3 && c.args[0] == "repo" && c.args[1] == "create"
+		return c.name == "gh" && len(c.args) > 3 && c.args[0] == ghSubcmdRepo && c.args[1] == ghActCreate
 	}) {
 		t.Fatal("expected gh repo create call")
 	}
@@ -473,6 +475,96 @@ func TestRunGitHubBootstrap_RepoExistsFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "already exists") {
 		t.Fatalf("expected 'already exists' error, got %v", err)
+	}
+}
+
+// TestRunGitHubBootstrap_InitBeforeFinalize verifies the two-phase split:
+// init runs git init up front, finalize creates the commit + pushes. A
+// simulated "agent setup" step writes a file between the phases; that
+// file must end up in the initial commit (i.e. `git add -A` happens
+// after setup, not before).
+func TestRunGitHubBootstrap_InitBeforeFinalize(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.setIdentityConfigured()
+	r.set("gh", []string{"--version"}, "gh", nil)
+	r.set("gh", []string{"auth", "status"}, "ok", nil)
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "octocat\n", nil)
+	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "", nil)
+	r.set("gh", []string{"repo", "view", "octocat/phased", "--json", "name"}, "", errors.New("not found"))
+	r.set("git", []string{"init"}, "", nil)
+	r.set("git", []string{"add", "-A"}, "", nil)
+	r.set("git", []string{"status", "--porcelain"}, " A .entire/settings.json\n", nil)
+	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "First"}, "", nil)
+	r.setInteractive("gh", []string{
+		"repo", "create", "octocat/phased",
+		"--private",
+		"--source=.",
+		"--remote=origin",
+		"--push",
+	}, nil)
+
+	opts := GitHubBootstrapOptions{
+		InitRepo:             true,
+		RepoName:             "phased",
+		RepoVisibility:       "private",
+		InitialCommitMessage: "First",
+	}
+
+	// Phase 1: init. This must NOT call git add/commit/ gh repo create.
+	state, err := runGitHubBootstrapInitWith(context.Background(), io.Discard, io.Discard, opts, r)
+	if err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state after init")
+	}
+	forbidden := [][]string{
+		{"add", "-A"},
+		{"status", "--porcelain"},
+		{"-c", "commit.gpgsign=false", "commit", "-m", "First"},
+	}
+	for _, args := range forbidden {
+		if r.hasCall(argsMatch("git", args)) {
+			t.Fatalf("git %v was called during init; should have been deferred to finalize", args)
+		}
+	}
+	if r.hasCall(func(c fakeCall) bool {
+		return c.name == "gh" && len(c.args) >= 2 && c.args[0] == ghSubcmdRepo && c.args[1] == ghActCreate
+	}) {
+		t.Fatal("gh repo create was called during init; should have been deferred to finalize")
+	}
+
+	// Phase 2: finalize. Now commit + push.
+	if err := runGitHubBootstrapFinalize(context.Background(), io.Discard, state); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+	if !r.hasCall(argsMatch("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "First"})) {
+		t.Fatal("expected commit during finalize")
+	}
+	if !r.hasCall(func(c fakeCall) bool {
+		return c.name == "gh" && len(c.args) >= 2 && c.args[0] == ghSubcmdRepo && c.args[1] == ghActCreate
+	}) {
+		t.Fatal("expected gh repo create during finalize")
+	}
+}
+
+// argsMatch returns a predicate for hasCall that matches when c.name == name
+// and c.args starts with the given args slice.
+func argsMatch(name string, args []string) func(fakeCall) bool {
+	return func(c fakeCall) bool {
+		if c.name != name || len(c.args) < len(args) {
+			return false
+		}
+		for i, a := range args {
+			if c.args[i] != a {
+				return false
+			}
+		}
+		return true
 	}
 }
 

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -1034,3 +1034,85 @@ func restoreCwd(t *testing.T, dir string) {
 	}
 	t.Chdir(canon)
 }
+
+func TestRunGitHubBootstrap_YesAcceptsAllDefaults(t *testing.T) {
+	// --yes should init repo, create GitHub repo under user's account (private),
+	// and use default commit message — without any interactive prompts.
+	t.Setenv("ENTIRE_TEST_TTY", "0") // non-interactive
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.setIdentityConfigured()
+	r.set("gh", []string{"--version"}, "gh 2.81.0", nil)
+	r.set("gh", []string{"auth", "status"}, "Logged in", nil)
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "myuser\n", nil)
+	r.set("gh", []string{"api", "user/orgs", "--jq", ".[].login"}, "myorg\n", nil)
+	r.set("git", []string{"init"}, "", nil)
+	r.set("git", []string{"add", "-A"}, "", nil)
+	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
+	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"}, "", nil)
+
+	// Expect repo created under the user's account (not org), private
+	repoName := filepath.Base(dir)
+	fullName := "myuser/" + repoName
+	r.set("gh", []string{
+		"repo", "create", fullName,
+		"--private",
+		"--source=.",
+		"--remote=origin",
+	}, "", nil)
+	r.set("git", []string{"push", "-q", "--no-verify", "-u", "origin", "HEAD"}, "", nil)
+
+	opts := GitHubBootstrapOptions{Yes: true}
+	var stdout bytes.Buffer
+	err := runGitHubBootstrapWith(context.Background(), &stdout, io.Discard, opts, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have used user's account, not org
+	output := stdout.String()
+	if !strings.Contains(output, "Using GitHub owner: myuser") {
+		t.Errorf("expected owner to be user's account, got: %s", output)
+	}
+	// Should have committed with default message
+	if !r.hasCall(argsMatch("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"})) {
+		t.Error("expected commit with default 'Initial commit' message")
+	}
+	// Should have created the repo
+	if !r.hasCall(func(c fakeCall) bool {
+		return c.name == "gh" && len(c.args) > 3 && c.args[0] == ghSubcmdRepo && c.args[1] == ghActCreate
+	}) {
+		t.Error("expected gh repo create call")
+	}
+}
+
+func TestRunGitHubBootstrap_YesWithNoGitHub(t *testing.T) {
+	// --yes combined with --no-github should skip GitHub but still init + commit.
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	dir := t.TempDir()
+	restoreCwd(t, dir)
+
+	r := newFakeRunner()
+	r.setIdentityConfigured()
+	r.set("git", []string{"init"}, "", nil)
+	r.set("git", []string{"add", "-A"}, "", nil)
+	r.set("git", []string{"status", "--porcelain"}, " M f\n", nil)
+	r.set("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"}, "", nil)
+
+	opts := GitHubBootstrapOptions{Yes: true, NoGitHub: true}
+	err := runGitHubBootstrapWith(context.Background(), io.Discard, io.Discard, opts, r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT have called gh at all
+	if r.hasCall(func(c fakeCall) bool { return c.name == "gh" }) {
+		t.Error("expected no gh calls with --no-github")
+	}
+	// Should have committed
+	if !r.hasCall(argsMatch("git", []string{"-c", "commit.gpgsign=false", "commit", "-m", "Initial commit"})) {
+		t.Error("expected commit with default message")
+	}
+}

--- a/cmd/entire/cli/setup_subagents.go
+++ b/cmd/entire/cli/setup_subagents.go
@@ -93,16 +93,14 @@ func writeManagedSearchSubagent(targetPath, relPath string, content []byte) (sea
 func reportSearchSubagentScaffold(w io.Writer, ag agent.Agent, result searchSubagentScaffoldResult) {
 	switch result.Status {
 	case searchSubagentCreated:
-		fmt.Fprintf(w, "Installed %s search subagent at %s\n", ag.Type(), result.RelPath)
+		fmt.Fprintf(w, "  ✓ Installed %s search subagent\n", ag.Type())
+		fmt.Fprintf(w, "    %s\n", result.RelPath)
 	case searchSubagentUpdated:
-		fmt.Fprintf(w, "Updated %s search subagent at %s\n", ag.Type(), result.RelPath)
+		fmt.Fprintf(w, "  ✓ Updated %s search subagent\n", ag.Type())
+		fmt.Fprintf(w, "    %s\n", result.RelPath)
 	case searchSubagentSkippedConflict:
-		fmt.Fprintf(
-			w,
-			"Skipped %s search subagent at %s because an unmanaged file already exists there\n",
-			ag.Type(),
-			result.RelPath,
-		)
+		fmt.Fprintf(w, "  Skipped %s search subagent (unmanaged file exists)\n", ag.Type())
+		fmt.Fprintf(w, "    %s\n", result.RelPath)
 	case searchSubagentUnsupported, searchSubagentUnchanged:
 		// Nothing to report.
 	}

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -2646,3 +2646,147 @@ func TestEnableYes_TelemetryRespectsOptOut(t *testing.T) {
 		}
 	})
 }
+
+func TestEnableCmd_YesFreshRepo_SkipsPromptsAndEnables(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	testutil.WriteFile(t, ".", "f.txt", "init")
+	testutil.GitAdd(t, ".", "f.txt")
+	testutil.GitCommit(t, ".", "init")
+	t.Setenv("ENTIRE_TEST_TTY", "0") // non-interactive — proves --yes bypasses prompts
+
+	// Use --yes with --agent to test the realistic CI scenario.
+	// The --yes flag skips telemetry/Vercel prompts while --agent selects a specific agent.
+	// The pure --yes-selects-all-agents path is covered by TestDetectOrSelectAgent_YesSelectsAll.
+	cmd := newEnableCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--yes", "--agent", "claude-code"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("enable --yes --agent claude-code error = %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Ready.") {
+		t.Errorf("expected 'Ready.' in output, got: %s", output)
+	}
+
+	// Verify settings were saved with telemetry enabled (--yes default)
+	s, err := LoadEntireSettings(context.Background())
+	if err != nil {
+		t.Fatalf("failed to load settings: %v", err)
+	}
+	if !s.Enabled {
+		t.Error("expected enabled=true")
+	}
+}
+
+func TestEnableCmd_YesWithAgent_AgentTakesPrecedence(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	testutil.WriteFile(t, ".", "f.txt", "init")
+	testutil.GitAdd(t, ".", "f.txt")
+	testutil.GitCommit(t, ".", "init")
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+
+	cmd := newEnableCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--yes", "--agent", "claude-code"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("enable --yes --agent claude-code error = %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	output := stdout.String()
+	// --agent takes precedence — should show single-agent non-interactive output
+	if !strings.Contains(output, "Agent: Claude Code") {
+		t.Errorf("expected 'Agent: Claude Code' in output, got: %s", output)
+	}
+	// Should NOT have shown multi-select output
+	if strings.Contains(output, "Selected agents:") {
+		t.Errorf("--agent should bypass multi-select, but got 'Selected agents:' in: %s", output)
+	}
+}
+
+func TestEnableCmd_YesOnConfiguredRepo_ManagesAgents(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "0") // non-interactive
+	writeSettings(t, testSettingsEnabled)
+	writeClaudeHooksFixture(t)
+
+	cmd := newEnableCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--yes"})
+
+	// May partially fail due to stale external agents in global registry,
+	// but the key behavior is that it doesn't bail out with the non-interactive message.
+	_ = cmd.Execute() //nolint:errcheck // partial failure from stale test agents is expected
+
+	output := stdout.String()
+	// Should NOT bail out with non-interactive message
+	if strings.Contains(output, "Cannot show agent selection in non-interactive mode") {
+		t.Error("--yes should bypass non-interactive check, but got bail-out message")
+	}
+}
+
+func TestEnableCmd_YesWithTelemetryFalse(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	testutil.WriteFile(t, ".", "f.txt", "init")
+	testutil.GitAdd(t, ".", "f.txt")
+	testutil.GitCommit(t, ".", "init")
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+
+	cmd := newEnableCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--yes", "--agent", "claude-code", "--telemetry=false"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("enable --yes --telemetry=false error = %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	// Verify telemetry was disabled despite --yes
+	s, err := LoadEntireSettings(context.Background())
+	if err != nil {
+		t.Fatalf("failed to load settings: %v", err)
+	}
+	if s.Telemetry == nil || *s.Telemetry != false {
+		t.Errorf("expected telemetry=false when --yes --telemetry=false, got %v", s.Telemetry)
+	}
+}
+
+func TestConfigureCmd_YesOnConfiguredRepo(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	writeSettings(t, testSettingsEnabled)
+	writeClaudeHooksFixture(t)
+
+	cmd := newSetupCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--yes"})
+
+	// May partially fail due to stale external agents in global registry,
+	// but the key behavior is that it doesn't bail out with the non-interactive message.
+	_ = cmd.Execute() //nolint:errcheck // partial failure from stale test agents is expected
+
+	output := stdout.String()
+	if strings.Contains(output, "Cannot show agent selection in non-interactive mode") {
+		t.Error("--yes should bypass non-interactive check, but got bail-out message")
+	}
+	// Should have added at least some built-in agents
+	if !strings.Contains(output, "Added agents:") && !strings.Contains(output, "No changes made.") {
+		t.Errorf("expected agent management output, got: %s", output)
+	}
+}

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -969,6 +969,8 @@ func TestEnableUsesSetupFlow(t *testing.T) {
 		{name: "checkpoint remote", args: []string{"--checkpoint-remote", "github:org/repo"}, want: true},
 		{name: "skip push sessions", args: []string{"--skip-push-sessions"}, want: true},
 		{name: "agent flag", args: []string{"--agent", "claude-code"}, agentName: "claude-code", want: true},
+		{name: "yes flag", args: []string{"--yes"}, want: true},
+		{name: "yes short flag", args: []string{"-y"}, want: true},
 	}
 
 	for _, tt := range tests {
@@ -2495,4 +2497,152 @@ func TestConfigureCmd_SummarizeModel_UsesExistingProvider(t *testing.T) {
 	if s.SummaryGeneration.Model != "sonnet" {
 		t.Fatalf("summary model = %q, want %q", s.SummaryGeneration.Model, "sonnet")
 	}
+}
+
+func TestSelectAllAgents_ReturnsAll(t *testing.T) {
+	t.Parallel()
+	available := []string{"claude-code", "gemini-cli", "opencode"}
+	selected, err := selectAllAgents(available)
+	if err != nil {
+		t.Fatalf("selectAllAgents() error = %v", err)
+	}
+	if !slices.Equal(selected, available) {
+		t.Errorf("selectAllAgents() = %v, want %v", selected, available)
+	}
+}
+
+func TestSelectAllAgents_EmptyReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := selectAllAgents(nil)
+	if err == nil {
+		t.Fatal("expected error for empty input")
+	}
+}
+
+func TestDetectOrSelectAgent_YesSelectsAll(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+
+	var buf bytes.Buffer
+	agents, err := detectOrSelectAgent(context.Background(), &buf, selectAllAgents)
+	if err != nil {
+		t.Fatalf("detectOrSelectAgent() with selectAllAgents error = %v", err)
+	}
+
+	// Should return at least 2 agents (claude-code + gemini-cli are registered in test imports)
+	if len(agents) < 2 {
+		t.Errorf("expected at least 2 agents with selectAllAgents, got %d", len(agents))
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Selected agents:") {
+		t.Errorf("Expected output to contain 'Selected agents:', got: %s", output)
+	}
+}
+
+func TestManageAgents_YesWorksNonInteractive(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
+	setupTestRepo(t)
+	t.Setenv("ENTIRE_TEST_TTY", "0") // non-interactive
+
+	// Install claude-code hooks so there's something installed
+	writeClaudeHooksFixture(t)
+
+	// Use a selectFn that only picks built-in agents to avoid failures
+	// from stale external agent binaries registered by other tests.
+	selectBuiltIn := func(available []string) ([]string, error) {
+		var selected []string
+		for _, name := range available {
+			ag, err := agent.Get(types.AgentName(name))
+			if err != nil {
+				continue
+			}
+			if isBuiltInAgent(ag) {
+				selected = append(selected, name)
+			}
+		}
+		if len(selected) == 0 {
+			return nil, errors.New("no built-in agents available")
+		}
+		return selected, nil
+	}
+
+	var buf bytes.Buffer
+	err := runManageAgents(context.Background(), &buf, EnableOptions{}, selectBuiltIn)
+	if err != nil {
+		t.Fatalf("runManageAgents() with selectFn in non-interactive mode error = %v", err)
+	}
+
+	output := buf.String()
+	// Should NOT print the non-interactive bail-out message
+	if strings.Contains(output, "Cannot show agent selection in non-interactive mode") {
+		t.Error("selectFn should bypass the interactivity check, but got non-interactive message")
+	}
+}
+
+func TestEnableYes_TelemetryRespectsOptOut(t *testing.T) {
+	// Cannot use t.Parallel() because subtests use t.Setenv
+
+	t.Run("yes with telemetry=false", func(t *testing.T) {
+		s := &EntireSettings{}
+		opts := EnableOptions{Yes: true, Telemetry: false}
+		if !opts.Telemetry || os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+			f := false
+			s.Telemetry = &f
+		} else if s.Telemetry == nil {
+			tr := true
+			s.Telemetry = &tr
+		}
+		if s.Telemetry == nil || *s.Telemetry != false {
+			t.Errorf("expected telemetry=false when --yes --telemetry=false, got %v", s.Telemetry)
+		}
+	})
+
+	t.Run("yes with ENTIRE_TELEMETRY_OPTOUT", func(t *testing.T) {
+		t.Setenv("ENTIRE_TELEMETRY_OPTOUT", "1")
+		s := &EntireSettings{}
+		opts := EnableOptions{Yes: true, Telemetry: true}
+		if !opts.Telemetry || os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+			f := false
+			s.Telemetry = &f
+		} else if s.Telemetry == nil {
+			tr := true
+			s.Telemetry = &tr
+		}
+		if s.Telemetry == nil || *s.Telemetry != false {
+			t.Errorf("expected telemetry=false with ENTIRE_TELEMETRY_OPTOUT, got %v", s.Telemetry)
+		}
+	})
+
+	t.Run("yes defaults to telemetry enabled", func(t *testing.T) {
+		s := &EntireSettings{}
+		opts := EnableOptions{Yes: true, Telemetry: true}
+		if !opts.Telemetry {
+			f := false
+			s.Telemetry = &f
+		} else if s.Telemetry == nil {
+			tr := true
+			s.Telemetry = &tr
+		}
+		if s.Telemetry == nil || *s.Telemetry != true {
+			t.Errorf("expected telemetry=true with --yes (default), got %v", s.Telemetry)
+		}
+	})
+
+	t.Run("yes preserves existing telemetry setting", func(t *testing.T) {
+		existing := false
+		s := &EntireSettings{Telemetry: &existing}
+		opts := EnableOptions{Yes: true, Telemetry: true}
+		if !opts.Telemetry || os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+			f := false
+			s.Telemetry = &f
+		} else if s.Telemetry == nil {
+			tr := true
+			s.Telemetry = &tr
+		}
+		if *s.Telemetry != false {
+			t.Errorf("expected existing telemetry=false to be preserved, got %v", *s.Telemetry)
+		}
+	})
 }

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -483,7 +483,7 @@ func EnsureMetadataBranch(repo *git.Repository) error {
 		return fmt.Errorf("failed to create metadata branch: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "✓ Created orphan branch '%s' for session metadata\n", paths.MetadataBranchName)
+	fmt.Fprintf(os.Stderr, "  ✓ Created orphan branch %s for session metadata\n", paths.MetadataBranchName)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Lets `entire enable` bootstrap a brand-new folder all the way to a working repo — `git init`, agent setup, initial commit, and a matching GitHub repository via the `gh` CLI — instead of exiting with "Not a git repository". Also adds `--yes`/`-y` to both `entire enable` and `entire configure` for fully non-interactive setup.

## Flow

```
~ cd my-new-project
~ entire enable

No git repository in "my-new-project". Initialize one here? [Y/n]

Setting up git repository
  ✓ Initialized empty git repository

  Create a matching repository on GitHub? [Y/n]
  Choose the GitHub owner for the new repository:
    > my-username
      my-org
  Repository name:         [my-new-project]
  Repository visibility:   [Private / Public / Internal]
  Initial commit:
    > Commit with default message "Initial commit"
      Customize message...
      Skip — I'll commit manually later

Enabling Entire
  Selected agents: Claude Code, Codex, Gemini CLI
  ✓ Installed Claude Code search subagent
    .claude/agents/entire-search.md
  ✓ Installed Codex search subagent
    .codex/agents/entire-search.toml
  ✓ Installed Gemini CLI search subagent
    .gemini/agents/entire-search.md
  ✓ Installed hooks
  ✓ Configured project
    .entire/settings.json
  ✓ Created orphan branch entire/checkpoints/v1 for session metadata

Publishing to GitHub
  ✓ Created initial commit
  ✓ Created my-username/my-new-project (private)
    https://github.com/my-username/my-new-project
  ✓ Pushed initial commit to origin

Done.
```

Or skip every prompt with a single flag:

```
~ cd my-new-project
~ entire enable --yes

Setting up git repository
  ✓ Initialized empty git repository
  Using GitHub owner: Soph

Enabling Entire
  Selected agents: Claude Code, Codex, Copilot CLI, Cursor, Factory AI Droid, Gemini CLI, OpenCode
  ✓ Installed Claude Code search subagent
    .claude/agents/entire-search.md
  ✓ Installed Codex search subagent
    .codex/agents/entire-search.toml
  ✓ Installed Gemini CLI search subagent
    .gemini/agents/entire-search.md
  ✓ Installed hooks
  ✓ Configured project
    .entire/settings.json
  ✓ Created orphan branch entire/checkpoints/v1 for session metadata

Publishing to GitHub
  ✓ Created initial commit
  ✓ Created Soph/enable-test-4 (private)
    https://github.com/Soph/enable-test-4
  ✓ Pushed initial commit to origin

Done.
```

This runs the full flow with defaults: `git init`, creates a private GitHub repo under your account, commits with "Initial commit", enables all available agents, and accepts telemetry.

All prompts go through `NewAccessibleForm`, so `ACCESSIBLE=1` works as expected.

## Flow details worth calling out

**Fresh-machine safety** — if git identity isn't configured anywhere, we source `user.name` / `user.email` from `gh api user` (falling back to the GitHub no-reply address when the user's email is private), then prompt, then fail with a pointer to `git config --global`. Values are written to the local repo config only. The initial commit also runs with `-c commit.gpgsign=false` so a broken or absent signer doesn't block the first commit.

**Default branch** — the pre-push hook installed during agent setup would otherwise push `entire/checkpoints/v1` alongside `main` on the first push, which GitHub then picks as the repo's default branch. The initial push uses `git push -q --no-verify -u origin HEAD`; only `main` lands on the remote and the checkpoint metadata branch is pushed normally on subsequent pushes.

**Two-phase bootstrap** — phase 1 (`git init`, identity, gather GH choices) runs before agent setup; phase 2 (`git add -A` + commit + `gh repo create` + push) runs after, so the initial commit captures `.entire/`, `.claude/`, agent hooks, and every other file setup writes.

**Repo name conflict with `--yes`** — if the auto-suggested repo name (derived from the directory name) already exists on GitHub, `--yes` falls back to the interactive name prompt when a TTY is available instead of failing. In non-TTY contexts it fails with a clear error pointing to `--repo-name`.

**Error paths:**
- `gh` missing or unauthenticated → print a hint (`brew install gh && gh auth login`) and fall through to local-only bootstrap.
- Ctrl+C *before* `git init` → legacy "Not a git repository" error.
- Ctrl+C *after* `git init` → new "Bootstrap cancelled. A local git repository has been initialized but setup didn't complete. Run `entire enable` again to continue." message.
- Setup fails after init → skip the commit / push; files remain untracked, user can fix and rerun.
- Skipping the commit still creates the GitHub repo and prints the exact `git add -A && git commit && git push` commands to finish.

## Flags

All optional; each suppresses the matching interactive prompt, so automation can drive the flow end-to-end without a TTY.

| Flag | Effect |
| --- | --- |
| `-y`, `--yes` | Accept all defaults for the entire flow. Bootstrap: init repo, create private GitHub repo under user's account, "Initial commit" message. Agent setup: select all available agents, accept telemetry, auto-confirm Vercel deployment blocking. Composes with other flags — explicit overrides like `--no-github`, `--agent`, or `--telemetry=false` take precedence. Works in non-TTY/CI contexts. |
| `--init-repo` | Accept the `git init` prompt |
| `--no-init-repo` | Decline the `git init` prompt (mutually exclusive with `--init-repo`) |
| `--repo-name <name>` | GitHub repo name (validated against GitHub's charset) |
| `--repo-owner <owner>` | GitHub user or org login |
| `--repo-visibility <public\|private\|internal>` | `internal` only valid for orgs |
| `--no-github` | Local `git init` + initial commit only; skip GitHub |
| `--initial-commit-message <msg>` | Override the default commit message |
| `--skip-initial-commit` | Skip the initial commit (mutually exclusive with `--initial-commit-message`) |

Setting any of `--repo-name` / `--repo-owner` / `--repo-visibility` implicitly answers "yes" to the GitHub-confirm prompt.

**Examples:**

```bash
# Full auto — zero prompts, all defaults
entire enable --yes

# Auto setup, but no GitHub
entire enable --yes --no-github

# Auto setup, specific agent, telemetry off
entire enable --yes --agent claude-code --telemetry=false

# Auto setup to a specific org with public visibility
entire enable --yes --repo-owner my-org --repo-visibility public

# Already-configured repo — add all agents non-interactively
entire configure --yes
```

## Output formatting

The enable and bootstrap output uses a consistent visual hierarchy:

- **Section headers** — plain text, no decorators
- **Status lines** — indented 2 spaces with `✓` checkmarks
- **Detail lines** — indented 4 spaces (file paths, URLs)

This matches the visual style used by `entire status`.

## Notes for reviewers

`gh` is shelled out via `exec.Command` rather than pulled in as a Go dep. All calls go through a `bootstrapRunner` interface so unit tests don't hit the network.

The commit-message prompt is a 3-option `huh.NewSelect` (default / customize / skip) rather than a freeform input. "Skip" was the only freeform input where a skip shortcut made sense — repo name and identity have no sensible "no value" semantics — so we didn't try to generalize it.

The full matrix of branches (confirm init → GH yes/no → commit default/custom/skip → various flag combinations) is covered by unit tests with a mocked `bootstrapRunner`. Two integration-style tests (`TestBootstrap_FreshMachine_RealGit`, `TestBootstrap_FreshMachine_NoIdentity_RealGit`) run real `git init`/`git commit` against a temp dir isolated via `HOME` + `GIT_CONFIG_GLOBAL` to prove the identity + gpgsign fixes end-to-end.

## Test plan

- [x] `mise run check` (fmt + lint + unit + integration + Vogon canary + roger-roger external-agent canary) — already green locally
- [x] Manual: fresh empty folder → `entire enable` with no flags walks through prompts and pushes to GitHub; default branch on the remote is `main`, no `entire/checkpoints/v1` on the remote
- [x] Manual: fresh folder → `entire enable --yes` completes with zero prompts — inits repo, creates private GitHub repo under user account, commits, enables all agents
- [x] Manual: fresh folder → `entire enable --yes` where repo name is taken — falls back to name prompt with TTY, fails with `--repo-name` hint without TTY
- [x] Manual: fresh folder → `entire enable --yes --no-github` — local only, no GitHub calls
- [x] Manual: fresh folder → `entire enable --yes --agent claude-code --telemetry=false` — only claude-code, telemetry off
- [x] Manual: fresh folder → `entire enable --init-repo --no-github --initial-commit-message "init" --agent claude-code` completes non-interactively, no GitHub call, one commit
- [x] Manual: fresh folder → `entire enable --init-repo --no-github --skip-initial-commit` leaves files unstaged and prints the manual-commit hint
- [x] Manual: Ctrl+C at owner/name/visibility/commit-message prompt → "Bootstrap cancelled" message, `.git/` still in place
- [x] Manual: `entire enable --init-repo --no-init-repo` → cobra's mutually-exclusive error
- [x] Manual: existing git repo → `entire enable` behaves exactly as before (bootstrap skipped entirely)
- [x] Manual: existing repo → `entire enable --yes` selects all agents, accepts telemetry, no prompts
- [x] Manual: configured repo → `entire configure --yes` in non-TTY adds all available agents
- [x] Manual: machine without `gh` → hint printed, local `git init` + initial commit still succeed
- [x] Verify output formatting: indented `✓` lines with detail paths on separate lines