### PR TITLE
reuse transcript blobs across turn-end checkpoints

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -350,9 +350,15 @@ type UpdateCommittedOptions struct {
 // Blob hashes are content-addressed (SHA-1 of chunk bytes), so the same
 // PrecomputedTranscriptBlobs works for both v1 (full.jsonl) and v2
 // (raw_transcript) paths — only the tree-entry filename differs.
+//
+// Callers should avoid constructing this for empty transcripts; agent.ChunkTranscript
+// would otherwise produce a single zero-length chunk and a hash for an empty
+// blob, which downstream stores would never reference.
 type PrecomputedTranscriptBlobs struct {
 	// ChunkHashes are the blob hashes for each transcript chunk, in order.
-	// Empty for an empty transcript.
+	// Always non-empty when built via PrecomputeTranscriptBlobs (a non-empty
+	// transcript chunks to at least one entry; callers should skip precompute
+	// for empty transcripts).
 	ChunkHashes []plumbing.Hash
 
 	// ContentHashBlob is the blob hash of the "sha256:<hex>" content-hash
@@ -362,6 +368,13 @@ type PrecomputedTranscriptBlobs struct {
 	// ContentHash is the "sha256:<hex>" string itself, so the short-circuit
 	// path can compare without re-reading the blob.
 	ContentHash string
+}
+
+// isUsable reports whether the precomputed blobs satisfy the invariants that
+// consumers depend on: a non-zero content-hash blob and at least one chunk
+// hash. Callers should fall back to the fresh-write path when this is false.
+func (p *PrecomputedTranscriptBlobs) isUsable() bool {
+	return p != nil && !p.ContentHashBlob.IsZero() && len(p.ChunkHashes) > 0
 }
 
 // CommittedInfo contains summary information about a committed checkpoint.

--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -334,6 +334,34 @@ type UpdateCommittedOptions struct {
 	// CompactTranscript is the updated Entire Transcript Format bytes.
 	// If non-nil, replaces the existing transcript.jsonl on v2 /main.
 	CompactTranscript []byte
+
+	// PrecomputedBlobs, if non-nil, provides chunk blob hashes and the
+	// content-hash blob hash computed once for this transcript. When set,
+	// UpdateCommitted skips the per-call ChunkTranscript + zlib work and
+	// reuses these hashes. Used by finalizeAllTurnCheckpoints to avoid
+	// re-compressing identical content N times.
+	PrecomputedBlobs *PrecomputedTranscriptBlobs
+}
+
+// PrecomputedTranscriptBlobs holds blob hashes for a transcript that was
+// chunked and written to the object store once, for reuse across multiple
+// UpdateCommitted calls sharing the same transcript content.
+//
+// Blob hashes are content-addressed (SHA-1 of chunk bytes), so the same
+// PrecomputedTranscriptBlobs works for both v1 (full.jsonl) and v2
+// (raw_transcript) paths — only the tree-entry filename differs.
+type PrecomputedTranscriptBlobs struct {
+	// ChunkHashes are the blob hashes for each transcript chunk, in order.
+	// Empty for an empty transcript.
+	ChunkHashes []plumbing.Hash
+
+	// ContentHashBlob is the blob hash of the "sha256:<hex>" content-hash
+	// string for the transcript.
+	ContentHashBlob plumbing.Hash
+
+	// ContentHash is the "sha256:<hex>" string itself, so the short-circuit
+	// path can compare without re-reading the blob.
+	ContentHash string
 }
 
 // CommittedInfo contains summary information about a committed checkpoint.

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -1318,7 +1319,7 @@ func (s *GitStore) UpdateCommitted(ctx context.Context, opts UpdateCommittedOpti
 	// Replace transcript (full replace, not append).
 	// Transcript is pre-redacted by the caller (enforced by RedactedBytes type).
 	if opts.Transcript.Len() > 0 {
-		if err := s.replaceTranscript(ctx, opts.Transcript, opts.Agent, sessionPath, entries); err != nil {
+		if err := s.replaceTranscript(ctx, opts.Transcript, opts.Agent, opts.PrecomputedBlobs, sessionPath, entries); err != nil {
 			return fmt.Errorf("failed to replace transcript: %w", err)
 		}
 	}
@@ -1365,7 +1366,36 @@ func (s *GitStore) UpdateCommitted(ctx context.Context, opts UpdateCommittedOpti
 
 // replaceTranscript writes the full transcript content, replacing any existing transcript.
 // Also removes any chunk files from a previous write and updates the content hash.
-func (s *GitStore) replaceTranscript(ctx context.Context, transcript redact.RedactedBytes, agentType types.AgentType, sessionPath string, entries map[string]object.TreeEntry) error {
+//
+// Short-circuits when the existing content_hash.txt already matches the new
+// transcript's sha256 — in that case the chunk entries are preserved as-is and
+// no chunking/zlib happens. Use precomputed (non-nil) to reuse blob hashes
+// computed once across multiple checkpoints.
+func (s *GitStore) replaceTranscript(ctx context.Context, transcript redact.RedactedBytes, agentType types.AgentType, precomputed *PrecomputedTranscriptBlobs, sessionPath string, entries map[string]object.TreeEntry) error {
+	// Compute the new content-hash string (cheap — SHA-256 over transcript bytes).
+	var newContentHash string
+	if precomputed != nil {
+		newContentHash = precomputed.ContentHash
+	} else {
+		newContentHash = fmt.Sprintf("sha256:%x", sha256.Sum256(transcript.Bytes()))
+	}
+
+	// Short-circuit: if the existing content_hash.txt already matches, the
+	// chunk entries currently in `entries` represent the same content. Leave
+	// everything as-is and skip chunking + zlib.
+	hashPath := sessionPath + paths.ContentHashFileName
+	if existing, ok := entries[hashPath]; ok {
+		if blob, err := s.repo.BlobObject(existing.Hash); err == nil {
+			if rdr, rerr := blob.Reader(); rerr == nil {
+				existingHash, readErr := io.ReadAll(rdr)
+				_ = rdr.Close()
+				if readErr == nil && string(existingHash) == newContentHash {
+					return nil
+				}
+			}
+		}
+	}
+
 	// Remove existing transcript files (base + any chunks)
 	transcriptBase := sessionPath + paths.TranscriptFileName
 	for key := range entries {
@@ -1374,19 +1404,28 @@ func (s *GitStore) replaceTranscript(ctx context.Context, transcript redact.Reda
 		}
 	}
 
-	// Chunk the transcript (matches writeTranscript behavior)
-	chunks, err := agent.ChunkTranscript(ctx, transcript.Bytes(), agentType)
-	if err != nil {
-		return fmt.Errorf("failed to chunk transcript: %w", err)
+	// Resolve chunk hashes from precompute, or chunk + blob-write now.
+	var chunkHashes []plumbing.Hash
+	if precomputed != nil {
+		chunkHashes = precomputed.ChunkHashes
+	} else {
+		chunks, err := agent.ChunkTranscript(ctx, transcript.Bytes(), agentType)
+		if err != nil {
+			return fmt.Errorf("failed to chunk transcript: %w", err)
+		}
+		chunkHashes = make([]plumbing.Hash, len(chunks))
+		for i, chunk := range chunks {
+			blobHash, err := CreateBlobFromContent(s.repo, chunk)
+			if err != nil {
+				return fmt.Errorf("failed to create transcript blob: %w", err)
+			}
+			chunkHashes[i] = blobHash
+		}
 	}
 
-	// Write chunk files
-	for i, chunk := range chunks {
+	// Record chunk files in the tree at v1 (full.jsonl) naming.
+	for i, blobHash := range chunkHashes {
 		chunkPath := sessionPath + agent.ChunkFileName(paths.TranscriptFileName, i)
-		blobHash, err := CreateBlobFromContent(s.repo, chunk)
-		if err != nil {
-			return fmt.Errorf("failed to create transcript blob: %w", err)
-		}
 		entries[chunkPath] = object.TreeEntry{
 			Name: chunkPath,
 			Mode: filemode.Regular,
@@ -1394,13 +1433,17 @@ func (s *GitStore) replaceTranscript(ctx context.Context, transcript redact.Reda
 		}
 	}
 
-	// Update content hash
-	contentHash := fmt.Sprintf("sha256:%x", sha256.Sum256(transcript.Bytes()))
-	hashBlob, err := CreateBlobFromContent(s.repo, []byte(contentHash))
-	if err != nil {
-		return fmt.Errorf("failed to create content hash blob: %w", err)
+	// Content-hash blob.
+	var hashBlob plumbing.Hash
+	if precomputed != nil {
+		hashBlob = precomputed.ContentHashBlob
+	} else {
+		h, err := CreateBlobFromContent(s.repo, []byte(newContentHash))
+		if err != nil {
+			return fmt.Errorf("failed to create content hash blob: %w", err)
+		}
+		hashBlob = h
 	}
-	hashPath := sessionPath + paths.ContentHashFileName
 	entries[hashPath] = object.TreeEntry{
 		Name: hashPath,
 		Mode: filemode.Regular,
@@ -1408,6 +1451,44 @@ func (s *GitStore) replaceTranscript(ctx context.Context, transcript redact.Reda
 	}
 
 	return nil
+}
+
+// PrecomputeTranscriptBlobs chunks the given transcript and writes each chunk
+// plus the content-hash blob to the object store once, returning the resulting
+// hashes for reuse across multiple UpdateCommitted calls that share the same
+// transcript content.
+//
+// The returned blobs work for both v1 (full.jsonl) and v2 (raw_transcript)
+// paths since blob hashes are content-addressed (SHA-1 of chunk bytes). Only
+// the tree-entry filenames differ between v1 and v2.
+func PrecomputeTranscriptBlobs(ctx context.Context, repo *git.Repository, transcript redact.RedactedBytes, agentType types.AgentType) (*PrecomputedTranscriptBlobs, error) {
+	raw := transcript.Bytes()
+
+	chunks, err := agent.ChunkTranscript(ctx, raw, agentType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to chunk transcript: %w", err)
+	}
+
+	chunkHashes := make([]plumbing.Hash, len(chunks))
+	for i, chunk := range chunks {
+		h, err := CreateBlobFromContent(repo, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create transcript blob: %w", err)
+		}
+		chunkHashes[i] = h
+	}
+
+	contentHash := fmt.Sprintf("sha256:%x", sha256.Sum256(raw))
+	hashBlob, err := CreateBlobFromContent(repo, []byte(contentHash))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create content hash blob: %w", err)
+	}
+
+	return &PrecomputedTranscriptBlobs{
+		ChunkHashes:     chunkHashes,
+		ContentHashBlob: hashBlob,
+		ContentHash:     contentHash,
+	}, nil
 }
 
 // ensureSessionsBranch ensures the entire/checkpoints/v1 branch exists.

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -41,6 +41,12 @@ import (
 // errStopIteration is used to stop commit iteration early in GetCheckpointAuthor.
 var errStopIteration = errors.New("stop iteration")
 
+// chunkTranscript is an indirection over agent.ChunkTranscript so tests can
+// count or intercept chunking calls (e.g., to verify the short-circuit avoids
+// re-chunking identical content). Production code paths always use the
+// unwrapped function.
+var chunkTranscript = agent.ChunkTranscript
+
 // WriteCommitted writes a committed checkpoint to the entire/checkpoints/v1 branch.
 // Checkpoints are stored at sharded paths: <id[:2]>/<id[2:]>/
 //
@@ -1372,6 +1378,11 @@ func (s *GitStore) UpdateCommitted(ctx context.Context, opts UpdateCommittedOpti
 // no chunking/zlib happens. Use precomputed (non-nil) to reuse blob hashes
 // computed once across multiple checkpoints.
 func (s *GitStore) replaceTranscript(ctx context.Context, transcript redact.RedactedBytes, agentType types.AgentType, precomputed *PrecomputedTranscriptBlobs, sessionPath string, entries map[string]object.TreeEntry) error {
+	// Ignore precompute if invariants are violated — fall back to fresh chunking.
+	if precomputed != nil && !precomputed.isUsable() {
+		precomputed = nil
+	}
+
 	// Compute the new content-hash string (cheap — SHA-256 over transcript bytes).
 	var newContentHash string
 	if precomputed != nil {
@@ -1409,7 +1420,7 @@ func (s *GitStore) replaceTranscript(ctx context.Context, transcript redact.Reda
 	if precomputed != nil {
 		chunkHashes = precomputed.ChunkHashes
 	} else {
-		chunks, err := agent.ChunkTranscript(ctx, transcript.Bytes(), agentType)
+		chunks, err := chunkTranscript(ctx, transcript.Bytes(), agentType)
 		if err != nil {
 			return fmt.Errorf("failed to chunk transcript: %w", err)
 		}
@@ -1464,7 +1475,7 @@ func (s *GitStore) replaceTranscript(ctx context.Context, transcript redact.Reda
 func PrecomputeTranscriptBlobs(ctx context.Context, repo *git.Repository, transcript redact.RedactedBytes, agentType types.AgentType) (*PrecomputedTranscriptBlobs, error) {
 	raw := transcript.Bytes()
 
-	chunks, err := agent.ChunkTranscript(ctx, raw, agentType)
+	chunks, err := chunkTranscript(ctx, raw, agentType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to chunk transcript: %w", err)
 	}

--- a/cmd/entire/cli/checkpoint/committed_update_test.go
+++ b/cmd/entire/cli/checkpoint/committed_update_test.go
@@ -586,3 +586,170 @@ func TestGetGitAuthorFromRepo_NoConfig(t *testing.T) {
 
 // Verify go-git config import is used (compile-time check).
 var _ = config.GlobalScope
+
+// TestUpdateCommitted_PrecomputedBlobs_Roundtrip verifies that passing
+// precomputed blob hashes produces the same on-disk tree content as the
+// non-precomputed path.
+func TestUpdateCommitted_PrecomputedBlobs_Roundtrip(t *testing.T) {
+	t.Parallel()
+	_, store, cpID := setupRepoForUpdate(t)
+
+	transcript := redact.AlreadyRedacted([]byte("line1\nline2\nline3 with some payload\n"))
+
+	precomputed, err := PrecomputeTranscriptBlobs(context.Background(), store.repo, transcript, "")
+	if err != nil {
+		t.Fatalf("PrecomputeTranscriptBlobs() error = %v", err)
+	}
+	if len(precomputed.ChunkHashes) == 0 {
+		t.Fatal("precompute returned no chunk hashes")
+	}
+	if precomputed.ContentHashBlob.IsZero() {
+		t.Fatal("precompute returned zero content-hash blob")
+	}
+
+	if err := store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID:     cpID,
+		SessionID:        "session-001",
+		Transcript:       transcript,
+		PrecomputedBlobs: precomputed,
+	}); err != nil {
+		t.Fatalf("UpdateCommitted(precomputed) error = %v", err)
+	}
+
+	content, err := store.ReadSessionContent(context.Background(), cpID, 0)
+	if err != nil {
+		t.Fatalf("ReadSessionContent() error = %v", err)
+	}
+	if string(content.Transcript) != string(transcript.Bytes()) {
+		t.Errorf("transcript mismatch via precomputed path\ngot:  %q\nwant: %q",
+			string(content.Transcript), string(transcript.Bytes()))
+	}
+}
+
+// TestUpdateCommitted_ContentHashShortCircuit verifies that a second update
+// with identical transcript content does not create new transcript blob
+// entries — the existing chunk and content-hash entries are preserved.
+func TestUpdateCommitted_ContentHashShortCircuit(t *testing.T) {
+	t.Parallel()
+	repo, store, cpID := setupRepoForUpdate(t)
+
+	transcript := redact.AlreadyRedacted([]byte("stable transcript content\n"))
+
+	if err := store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Transcript:   transcript,
+	}); err != nil {
+		t.Fatalf("UpdateCommitted(first) error = %v", err)
+	}
+
+	transcriptBlobHashBefore := readTranscriptBlobHash(t, repo, cpID)
+
+	// Second update with the same content — should short-circuit.
+	if err := store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Transcript:   transcript,
+	}); err != nil {
+		t.Fatalf("UpdateCommitted(second) error = %v", err)
+	}
+
+	transcriptBlobHashAfter := readTranscriptBlobHash(t, repo, cpID)
+
+	if transcriptBlobHashBefore != transcriptBlobHashAfter {
+		t.Errorf("short-circuit failed: transcript blob hash changed %v -> %v",
+			transcriptBlobHashBefore, transcriptBlobHashAfter)
+	}
+}
+
+// TestUpdateCommitted_ContentChangedRewrites verifies the short-circuit does
+// not fire when content actually differs.
+func TestUpdateCommitted_ContentChangedRewrites(t *testing.T) {
+	t.Parallel()
+	repo, store, cpID := setupRepoForUpdate(t)
+
+	first := redact.AlreadyRedacted([]byte("first version\n"))
+	second := redact.AlreadyRedacted([]byte("second version with more content\n"))
+
+	if err := store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Transcript:   first,
+	}); err != nil {
+		t.Fatalf("UpdateCommitted(first) error = %v", err)
+	}
+	hashBefore := readTranscriptBlobHash(t, repo, cpID)
+
+	if err := store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Transcript:   second,
+	}); err != nil {
+		t.Fatalf("UpdateCommitted(second) error = %v", err)
+	}
+	hashAfter := readTranscriptBlobHash(t, repo, cpID)
+
+	if hashBefore == hashAfter {
+		t.Errorf("expected transcript blob to change; stayed at %v", hashBefore)
+	}
+
+	content, err := store.ReadSessionContent(context.Background(), cpID, 0)
+	if err != nil {
+		t.Fatalf("ReadSessionContent() error = %v", err)
+	}
+	if string(content.Transcript) != string(second.Bytes()) {
+		t.Errorf("transcript content mismatch\ngot:  %q\nwant: %q",
+			string(content.Transcript), string(second.Bytes()))
+	}
+}
+
+// TestPrecomputeAndReuse_MatchesFreshWrite verifies that precomputed blob
+// hashes match the hashes produced by a fresh chunk + blob-write pass.
+func TestPrecomputeAndReuse_MatchesFreshWrite(t *testing.T) {
+	t.Parallel()
+	_, store, _ := setupRepoForUpdate(t)
+
+	transcript := redact.AlreadyRedacted([]byte("deterministic content for hash comparison\n"))
+
+	precomputed, err := PrecomputeTranscriptBlobs(context.Background(), store.repo, transcript, "")
+	if err != nil {
+		t.Fatalf("PrecomputeTranscriptBlobs() error = %v", err)
+	}
+
+	freshBlob, err := CreateBlobFromContent(store.repo, transcript.Bytes())
+	if err != nil {
+		t.Fatalf("CreateBlobFromContent() error = %v", err)
+	}
+
+	if len(precomputed.ChunkHashes) != 1 {
+		t.Fatalf("expected 1 chunk for small transcript; got %d", len(precomputed.ChunkHashes))
+	}
+	if precomputed.ChunkHashes[0] != freshBlob {
+		t.Errorf("precomputed chunk hash %v != fresh blob hash %v",
+			precomputed.ChunkHashes[0], freshBlob)
+	}
+}
+
+// readTranscriptBlobHash reads the transcript blob hash at session 0 from the
+// metadata branch.
+func readTranscriptBlobHash(t *testing.T, repo *git.Repository, cpID id.CheckpointID) plumbing.Hash {
+	t.Helper()
+	ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	if err != nil {
+		t.Fatalf("failed to get ref: %v", err)
+	}
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		t.Fatalf("failed to get commit: %v", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		t.Fatalf("failed to get tree: %v", err)
+	}
+	transcriptPath := cpID.Path() + "/0/" + paths.TranscriptFileName
+	file, err := tree.File(transcriptPath)
+	if err != nil {
+		t.Fatalf("failed to find transcript blob at %s: %v", transcriptPath, err)
+	}
+	return file.Hash
+}

--- a/cmd/entire/cli/checkpoint/committed_update_test.go
+++ b/cmd/entire/cli/checkpoint/committed_update_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/redact"
@@ -627,11 +628,11 @@ func TestUpdateCommitted_PrecomputedBlobs_Roundtrip(t *testing.T) {
 }
 
 // TestUpdateCommitted_ContentHashShortCircuit verifies that a second update
-// with identical transcript content does not create new transcript blob
-// entries — the existing chunk and content-hash entries are preserved.
+// with identical transcript content skips chunking entirely (short-circuit
+// fires before agent.ChunkTranscript is called).
 func TestUpdateCommitted_ContentHashShortCircuit(t *testing.T) {
-	t.Parallel()
-	repo, store, cpID := setupRepoForUpdate(t)
+	// Cannot run in parallel: patches the package-level chunkTranscript hook.
+	_, store, cpID := setupRepoForUpdate(t)
 
 	transcript := redact.AlreadyRedacted([]byte("stable transcript content\n"))
 
@@ -643,9 +644,10 @@ func TestUpdateCommitted_ContentHashShortCircuit(t *testing.T) {
 		t.Fatalf("UpdateCommitted(first) error = %v", err)
 	}
 
-	transcriptBlobHashBefore := readTranscriptBlobHash(t, repo, cpID)
+	// Install a counter. The second UpdateCommitted with identical content
+	// should never touch the chunking function.
+	calls := installChunkCounter(t)
 
-	// Second update with the same content — should short-circuit.
 	if err := store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
 		CheckpointID: cpID,
 		SessionID:    "session-001",
@@ -654,12 +656,24 @@ func TestUpdateCommitted_ContentHashShortCircuit(t *testing.T) {
 		t.Fatalf("UpdateCommitted(second) error = %v", err)
 	}
 
-	transcriptBlobHashAfter := readTranscriptBlobHash(t, repo, cpID)
-
-	if transcriptBlobHashBefore != transcriptBlobHashAfter {
-		t.Errorf("short-circuit failed: transcript blob hash changed %v -> %v",
-			transcriptBlobHashBefore, transcriptBlobHashAfter)
+	if *calls != 0 {
+		t.Errorf("short-circuit failed: chunkTranscript was called %d time(s) on a no-op re-update; expected 0", *calls)
 	}
+}
+
+// installChunkCounter swaps the package-level chunkTranscript hook for a
+// counter and restores it when the test completes. Returns a pointer the
+// caller can dereference to read the running count.
+func installChunkCounter(t *testing.T) *int {
+	t.Helper()
+	original := chunkTranscript
+	t.Cleanup(func() { chunkTranscript = original })
+	var count int
+	chunkTranscript = func(ctx context.Context, content []byte, agentType types.AgentType) ([][]byte, error) {
+		count++
+		return original(ctx, content, agentType)
+	}
+	return &count
 }
 
 // TestUpdateCommitted_ContentChangedRewrites verifies the short-circuit does

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -209,14 +209,20 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 		return err
 	}
 
+	// Ignore precompute if invariants are violated — fall back to fresh chunking.
+	precomputed := opts.PrecomputedBlobs
+	if precomputed != nil && !precomputed.isUsable() {
+		precomputed = nil
+	}
+
 	// Short-circuit: if the existing raw_transcript_hash.txt already matches
 	// the new transcript's sha256, the existing chunk entries represent the
 	// same content — preserve them and skip chunking + zlib.
 	rawTranscriptPath := sessionPath + paths.V2RawTranscriptFileName
 	rawHashPath := sessionPath + paths.V2RawTranscriptHashFileName
 	var newContentHash string
-	if opts.PrecomputedBlobs != nil {
-		newContentHash = opts.PrecomputedBlobs.ContentHash
+	if precomputed != nil {
+		newContentHash = precomputed.ContentHash
 	} else {
 		newContentHash = fmt.Sprintf("sha256:%x", sha256.Sum256(opts.Transcript.Bytes()))
 	}
@@ -226,14 +232,10 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 				existingHash, readErr := io.ReadAll(rdr)
 				_ = rdr.Close()
 				if readErr == nil && string(existingHash) == newContentHash {
-					// Content unchanged — just splice the existing tree back.
-					newTreeHash, err := s.gs.spliceCheckpointSubtree(ctx, rootTreeHash, opts.CheckpointID, basePath, entries)
-					if err != nil {
-						return err
-					}
-					authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
-					commitMsg := fmt.Sprintf("Finalize checkpoint: %s\n", opts.CheckpointID)
-					return s.updateRef(refName, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
+					// Content unchanged — skip tree surgery and ref advance to
+					// avoid a no-op commit on /full/current. The existing ref
+					// already references the correct tree.
+					return nil
 				}
 			}
 		}
@@ -252,11 +254,11 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 		}
 	}
 
-	if err := s.writeTranscriptBlobs(ctx, opts.Transcript, opts.Agent, opts.PrecomputedBlobs, sessionPath, entries); err != nil {
+	if err := s.writeTranscriptBlobs(ctx, opts.Transcript, opts.Agent, precomputed, sessionPath, entries); err != nil {
 		return err
 	}
 
-	if err := s.writeContentHashFromPrecompute(newContentHash, opts.PrecomputedBlobs, sessionPath, entries); err != nil {
+	if err := s.writeContentHashFromPrecompute(newContentHash, precomputed, sessionPath, entries); err != nil {
 		return err
 	}
 
@@ -568,7 +570,7 @@ func (s *V2GitStore) writeTranscriptBlobs(ctx context.Context, transcript redact
 	if precomputed != nil {
 		chunkHashes = precomputed.ChunkHashes
 	} else {
-		chunks, err := agent.ChunkTranscript(ctx, transcript.Bytes(), agentType)
+		chunks, err := chunkTranscript(ctx, transcript.Bytes(), agentType)
 		if err != nil {
 			return fmt.Errorf("failed to chunk transcript: %w", err)
 		}

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -208,10 +209,38 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 		return err
 	}
 
-	// Clear existing transcript artifacts for this session path before writing new ones.
-	// Preserve non-transcript metadata under the same session (e.g., tasks/*).
+	// Short-circuit: if the existing raw_transcript_hash.txt already matches
+	// the new transcript's sha256, the existing chunk entries represent the
+	// same content — preserve them and skip chunking + zlib.
 	rawTranscriptPath := sessionPath + paths.V2RawTranscriptFileName
 	rawHashPath := sessionPath + paths.V2RawTranscriptHashFileName
+	var newContentHash string
+	if opts.PrecomputedBlobs != nil {
+		newContentHash = opts.PrecomputedBlobs.ContentHash
+	} else {
+		newContentHash = fmt.Sprintf("sha256:%x", sha256.Sum256(opts.Transcript.Bytes()))
+	}
+	if existing, ok := entries[rawHashPath]; ok {
+		if blob, err := s.repo.BlobObject(existing.Hash); err == nil {
+			if rdr, rerr := blob.Reader(); rerr == nil {
+				existingHash, readErr := io.ReadAll(rdr)
+				_ = rdr.Close()
+				if readErr == nil && string(existingHash) == newContentHash {
+					// Content unchanged — just splice the existing tree back.
+					newTreeHash, err := s.gs.spliceCheckpointSubtree(ctx, rootTreeHash, opts.CheckpointID, basePath, entries)
+					if err != nil {
+						return err
+					}
+					authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+					commitMsg := fmt.Sprintf("Finalize checkpoint: %s\n", opts.CheckpointID)
+					return s.updateRef(refName, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
+				}
+			}
+		}
+	}
+
+	// Clear existing transcript artifacts for this session path before writing new ones.
+	// Preserve non-transcript metadata under the same session (e.g., tasks/*).
 	for key := range entries {
 		switch {
 		case key == rawTranscriptPath:
@@ -223,12 +252,11 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 		}
 	}
 
-	redactedTranscript, err := s.writeTranscriptBlobs(ctx, opts.Transcript, opts.Agent, sessionPath, entries)
-	if err != nil {
+	if err := s.writeTranscriptBlobs(ctx, opts.Transcript, opts.Agent, opts.PrecomputedBlobs, sessionPath, entries); err != nil {
 		return err
 	}
 
-	if err := s.writeContentHash(redactedTranscript, sessionPath, entries); err != nil {
+	if err := s.writeContentHashFromPrecompute(newContentHash, opts.PrecomputedBlobs, sessionPath, entries); err != nil {
 		return err
 	}
 
@@ -417,21 +445,6 @@ func (s *V2GitStore) writeMainSessionToSubdirectory(opts WriteCommittedOptions, 
 	return filePaths, nil
 }
 
-// writeContentHash computes and writes the content hash for already-redacted transcript bytes.
-func (s *V2GitStore) writeContentHash(redactedTranscript []byte, sessionPath string, entries map[string]object.TreeEntry) error {
-	contentHash := fmt.Sprintf("sha256:%x", sha256.Sum256(redactedTranscript))
-	hashBlob, err := CreateBlobFromContent(s.repo, []byte(contentHash))
-	if err != nil {
-		return err
-	}
-	entries[sessionPath+paths.V2RawTranscriptHashFileName] = object.TreeEntry{
-		Name: sessionPath + paths.V2RawTranscriptHashFileName,
-		Mode: filemode.Regular,
-		Hash: hashBlob,
-	}
-	return nil
-}
-
 // writeCompactTranscriptHash computes and writes the SHA-256 hash of the compact transcript.
 func (s *V2GitStore) writeCompactTranscriptHash(compactTranscript []byte, sessionPath string, entries map[string]object.TreeEntry) error {
 	hash := fmt.Sprintf("sha256:%x", sha256.Sum256(compactTranscript))
@@ -505,12 +518,12 @@ func (s *V2GitStore) writeCommittedFullTranscript(ctx context.Context, opts Writ
 		}
 	}
 
-	redactedTranscript, err := s.writeTranscriptBlobs(ctx, transcript, opts.Agent, sessionPath, entries)
-	if err != nil {
+	if err := s.writeTranscriptBlobs(ctx, transcript, opts.Agent, nil, sessionPath, entries); err != nil {
 		return err
 	}
 
-	if err := s.writeContentHash(redactedTranscript, sessionPath, entries); err != nil {
+	contentHash := fmt.Sprintf("sha256:%x", sha256.Sum256(transcript.Bytes()))
+	if err := s.writeContentHashFromPrecompute(contentHash, nil, sessionPath, entries); err != nil {
 		return err
 	}
 
@@ -548,20 +561,29 @@ func (s *V2GitStore) writeCommittedFullTranscript(ctx context.Context, opts Writ
 }
 
 // writeTranscriptBlobs writes pre-redacted, chunked transcript blobs to entries.
-// Returns the transcript bytes so the caller can compute the content hash.
-func (s *V2GitStore) writeTranscriptBlobs(ctx context.Context, transcript redact.RedactedBytes, agentType types.AgentType, sessionPath string, entries map[string]object.TreeEntry) ([]byte, error) {
-	raw := transcript.Bytes()
-	chunks, err := agent.ChunkTranscript(ctx, raw, agentType)
-	if err != nil {
-		return nil, fmt.Errorf("failed to chunk transcript: %w", err)
+// When precomputed is non-nil, reuses its chunk blob hashes and skips both
+// ChunkTranscript and CreateBlobFromContent.
+func (s *V2GitStore) writeTranscriptBlobs(ctx context.Context, transcript redact.RedactedBytes, agentType types.AgentType, precomputed *PrecomputedTranscriptBlobs, sessionPath string, entries map[string]object.TreeEntry) error {
+	var chunkHashes []plumbing.Hash
+	if precomputed != nil {
+		chunkHashes = precomputed.ChunkHashes
+	} else {
+		chunks, err := agent.ChunkTranscript(ctx, transcript.Bytes(), agentType)
+		if err != nil {
+			return fmt.Errorf("failed to chunk transcript: %w", err)
+		}
+		chunkHashes = make([]plumbing.Hash, len(chunks))
+		for i, chunk := range chunks {
+			h, err := CreateBlobFromContent(s.repo, chunk)
+			if err != nil {
+				return err
+			}
+			chunkHashes[i] = h
+		}
 	}
 
-	for i, chunk := range chunks {
+	for i, blobHash := range chunkHashes {
 		chunkPath := sessionPath + agent.ChunkFileName(paths.V2RawTranscriptFileName, i)
-		blobHash, err := CreateBlobFromContent(s.repo, chunk)
-		if err != nil {
-			return nil, err
-		}
 		entries[chunkPath] = object.TreeEntry{
 			Name: chunkPath,
 			Mode: filemode.Regular,
@@ -569,7 +591,29 @@ func (s *V2GitStore) writeTranscriptBlobs(ctx context.Context, transcript redact
 		}
 	}
 
-	return raw, nil
+	return nil
+}
+
+// writeContentHashFromPrecompute writes the content-hash blob for the given
+// transcript hash. When precomputed is non-nil, reuses its ContentHashBlob
+// hash; otherwise creates a fresh blob.
+func (s *V2GitStore) writeContentHashFromPrecompute(contentHash string, precomputed *PrecomputedTranscriptBlobs, sessionPath string, entries map[string]object.TreeEntry) error {
+	var hashBlob plumbing.Hash
+	if precomputed != nil {
+		hashBlob = precomputed.ContentHashBlob
+	} else {
+		h, err := CreateBlobFromContent(s.repo, []byte(contentHash))
+		if err != nil {
+			return err
+		}
+		hashBlob = h
+	}
+	entries[sessionPath+paths.V2RawTranscriptHashFileName] = object.TreeEntry{
+		Name: sessionPath + paths.V2RawTranscriptHashFileName,
+		Mode: filemode.Regular,
+		Hash: hashBlob,
+	}
+	return nil
 }
 
 // validateWriteOpts validates identifiers in WriteCommittedOptions.

--- a/cmd/entire/cli/checkpoint/v2_precompute_test.go
+++ b/cmd/entire/cli/checkpoint/v2_precompute_test.go
@@ -74,11 +74,11 @@ func TestV2UpdateCommitted_PrecomputedBlobs_Roundtrip(t *testing.T) {
 	require.Equal(t, string(transcript.Bytes()), got)
 }
 
-// TestV2UpdateCommitted_ContentHashShortCircuit verifies that a second update
-// with identical transcript content preserves the existing transcript blob
-// (no rewrite, no new blob hash).
+// TestV2UpdateCommitted_ContentHashShortCircuit verifies that a second
+// identical update to /full/current skips chunking entirely and does not
+// advance the ref (no no-op commit).
 func TestV2UpdateCommitted_ContentHashShortCircuit(t *testing.T) {
-	t.Parallel()
+	// Cannot run in parallel: patches the package-level chunkTranscript hook.
 	repo, store, cpID := setupV2ForUpdate(t, []byte(`{"type":"assistant","message":"initial"}`))
 
 	transcript := redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"stable content"}`))
@@ -91,10 +91,14 @@ func TestV2UpdateCommitted_ContentHashShortCircuit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	blobBefore := readV2TranscriptBlobHash(t, repo, cpID)
+	fullRefName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+	refBefore, err := repo.Reference(fullRefName, true)
+	require.NoError(t, err)
 
-	// Second update with identical content — should short-circuit the
-	// /full/current transcript rewrite.
+	// Install a counter. The second UpdateCommitted with identical content
+	// should skip chunking and leave /full/current's ref unchanged.
+	calls := installChunkCounter(t)
+
 	err = store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
 		CheckpointID: cpID,
 		SessionID:    "session-001",
@@ -103,9 +107,13 @@ func TestV2UpdateCommitted_ContentHashShortCircuit(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	blobAfter := readV2TranscriptBlobHash(t, repo, cpID)
-	require.Equal(t, blobBefore, blobAfter,
-		"short-circuit failed: /full/current transcript blob hash changed")
+	require.Equal(t, 0, *calls,
+		"short-circuit failed: chunkTranscript was called %d time(s) on a no-op re-update", *calls)
+
+	refAfter, err := repo.Reference(fullRefName, true)
+	require.NoError(t, err)
+	require.Equal(t, refBefore.Hash(), refAfter.Hash(),
+		"short-circuit should skip the ref advance on /full/current to avoid a no-op commit")
 }
 
 // TestV2UpdateCommitted_ContentChangedRewrites verifies the v2 short-circuit

--- a/cmd/entire/cli/checkpoint/v2_precompute_test.go
+++ b/cmd/entire/cli/checkpoint/v2_precompute_test.go
@@ -1,0 +1,142 @@
+package checkpoint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/redact"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// setupV2ForUpdate creates a V2 store and writes an initial committed
+// checkpoint so subsequent UpdateCommitted calls have a target.
+func setupV2ForUpdate(t *testing.T, initialTranscript []byte) (*git.Repository, *V2GitStore, id.CheckpointID) {
+	t.Helper()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+	cpID := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	err := store.WriteCommitted(context.Background(), WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Strategy:     "manual-commit",
+		Agent:        agent.AgentTypeClaudeCode,
+		Transcript:   redact.AlreadyRedacted(initialTranscript),
+		Prompts:      []string{"initial prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	return repo, store, cpID
+}
+
+// readV2TranscriptBlobHash reads the /full/current transcript blob hash at
+// session 0 for the given checkpoint.
+func readV2TranscriptBlobHash(t *testing.T, repo *git.Repository, cpID id.CheckpointID) plumbing.Hash {
+	t.Helper()
+	tree := v2FullTree(t, repo)
+	transcriptPath := cpID.Path() + "/0/" + paths.V2RawTranscriptFileName
+	file, err := tree.File(transcriptPath)
+	require.NoError(t, err, "transcript blob not found at %s", transcriptPath)
+	return file.Hash
+}
+
+// TestV2UpdateCommitted_PrecomputedBlobs_Roundtrip verifies that passing
+// precomputed blob hashes produces the same /full/current transcript content
+// as the non-precomputed path.
+func TestV2UpdateCommitted_PrecomputedBlobs_Roundtrip(t *testing.T) {
+	t.Parallel()
+	repo, store, cpID := setupV2ForUpdate(t, []byte(`{"type":"assistant","message":"initial"}`))
+
+	transcript := redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"finalized content"}`))
+	precomputed, err := PrecomputeTranscriptBlobs(context.Background(), repo, transcript, agent.AgentTypeClaudeCode)
+	require.NoError(t, err)
+	require.NotEmpty(t, precomputed.ChunkHashes)
+	require.False(t, precomputed.ContentHashBlob.IsZero())
+
+	err = store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID:     cpID,
+		SessionID:        "session-001",
+		Transcript:       transcript,
+		Agent:            agent.AgentTypeClaudeCode,
+		PrecomputedBlobs: precomputed,
+	})
+	require.NoError(t, err)
+
+	got := v2ReadFile(t, v2FullTree(t, repo), cpID.Path()+"/0/"+paths.V2RawTranscriptFileName)
+	require.Equal(t, string(transcript.Bytes()), got)
+}
+
+// TestV2UpdateCommitted_ContentHashShortCircuit verifies that a second update
+// with identical transcript content preserves the existing transcript blob
+// (no rewrite, no new blob hash).
+func TestV2UpdateCommitted_ContentHashShortCircuit(t *testing.T) {
+	t.Parallel()
+	repo, store, cpID := setupV2ForUpdate(t, []byte(`{"type":"assistant","message":"initial"}`))
+
+	transcript := redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"stable content"}`))
+
+	err := store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Transcript:   transcript,
+		Agent:        agent.AgentTypeClaudeCode,
+	})
+	require.NoError(t, err)
+
+	blobBefore := readV2TranscriptBlobHash(t, repo, cpID)
+
+	// Second update with identical content — should short-circuit the
+	// /full/current transcript rewrite.
+	err = store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Transcript:   transcript,
+		Agent:        agent.AgentTypeClaudeCode,
+	})
+	require.NoError(t, err)
+
+	blobAfter := readV2TranscriptBlobHash(t, repo, cpID)
+	require.Equal(t, blobBefore, blobAfter,
+		"short-circuit failed: /full/current transcript blob hash changed")
+}
+
+// TestV2UpdateCommitted_ContentChangedRewrites verifies the v2 short-circuit
+// does NOT fire when content actually differs, and that the new content is
+// persisted on /full/current.
+func TestV2UpdateCommitted_ContentChangedRewrites(t *testing.T) {
+	t.Parallel()
+	repo, store, cpID := setupV2ForUpdate(t, []byte(`{"type":"assistant","message":"initial"}`))
+
+	first := redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"first version"}`))
+	second := redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"second version with more content"}`))
+
+	require.NoError(t, store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Transcript:   first,
+		Agent:        agent.AgentTypeClaudeCode,
+	}))
+	blobBefore := readV2TranscriptBlobHash(t, repo, cpID)
+
+	require.NoError(t, store.UpdateCommitted(context.Background(), UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Transcript:   second,
+		Agent:        agent.AgentTypeClaudeCode,
+	}))
+	blobAfter := readV2TranscriptBlobHash(t, repo, cpID)
+
+	require.NotEqual(t, blobBefore, blobAfter,
+		"expected /full/current transcript blob to change on content update")
+
+	got := v2ReadFile(t, v2FullTree(t, repo), cpID.Path()+"/0/"+paths.V2RawTranscriptFileName)
+	require.Equal(t, string(second.Bytes()), got)
+}

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -2729,6 +2729,22 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 		v2Store = checkpoint.NewV2GitStore(repo, ResolveCheckpointURL(logCtx, "origin"))
 	}
 
+	// Chunk + zlib-compress the transcript ONCE. Every checkpoint in this turn
+	// receives the same transcript content, so each store.UpdateCommitted /
+	// v2Store.UpdateCommitted reuses these blob hashes instead of re-chunking
+	// and re-compressing. Blob hashes are content-addressed, so v1 and v2
+	// share the same hashes (only the tree-entry filename differs).
+	_, precomputeSpan := perf.Start(logCtx, "precompute_transcript_blobs")
+	precomputed, precomputeErr := checkpoint.PrecomputeTranscriptBlobs(logCtx, repo, redactedTranscript, state.AgentType)
+	precomputeSpan.End()
+	if precomputeErr != nil {
+		logging.Warn(logCtx, "finalize: precompute transcript blobs failed, falling back to per-checkpoint work",
+			slog.String("session_id", state.SessionID),
+			slog.String("error", precomputeErr.Error()),
+		)
+		precomputed = nil
+	}
+
 	// Update each checkpoint with the full transcript
 	for _, cpIDStr := range state.TurnCheckpointIDs {
 		cpID, parseErr := id.NewCheckpointID(cpIDStr)
@@ -2742,11 +2758,12 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 		}
 
 		updateOpts := checkpoint.UpdateCommittedOptions{
-			CheckpointID: cpID,
-			SessionID:    state.SessionID,
-			Transcript:   redactedTranscript,
-			Prompts:      prompts,
-			Agent:        state.AgentType,
+			CheckpointID:     cpID,
+			SessionID:        state.SessionID,
+			Transcript:       redactedTranscript,
+			Prompts:          prompts,
+			Agent:            state.AgentType,
+			PrecomputedBlobs: precomputed,
 		}
 
 		// Generate compact transcript for v2 /main

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -2625,6 +2625,29 @@ func (s *ManualCommitStrategy) HandleTurnEnd(ctx context.Context, state *Session
 	return nil
 }
 
+// precomputeTranscriptBlobsForFinalize chunks + zlib-compresses the redacted
+// transcript once for reuse across every checkpoint in the turn. Returns nil
+// (without error) when the transcript is empty — downstream stores skip
+// transcript updates in that case, so precompute would only write a wasted
+// empty-chunk blob to the object store. On failure, logs a warning and
+// returns nil so the loop falls back to per-checkpoint chunking.
+func precomputeTranscriptBlobsForFinalize(ctx context.Context, repo *git.Repository, transcript redact.RedactedBytes, state *SessionState) *checkpoint.PrecomputedTranscriptBlobs {
+	if transcript.Len() == 0 {
+		return nil
+	}
+	_, span := perf.Start(ctx, "precompute_transcript_blobs")
+	defer span.End()
+	precomputed, err := checkpoint.PrecomputeTranscriptBlobs(ctx, repo, transcript, state.AgentType)
+	if err != nil {
+		logging.Warn(ctx, "finalize: precompute transcript blobs failed, falling back to per-checkpoint work",
+			slog.String("session_id", state.SessionID),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+	return precomputed
+}
+
 // finalizeAllTurnCheckpoints replaces the provisional transcript in each checkpoint
 // created during this turn with the full session transcript.
 //
@@ -2729,21 +2752,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 		v2Store = checkpoint.NewV2GitStore(repo, ResolveCheckpointURL(logCtx, "origin"))
 	}
 
-	// Chunk + zlib-compress the transcript ONCE. Every checkpoint in this turn
-	// receives the same transcript content, so each store.UpdateCommitted /
-	// v2Store.UpdateCommitted reuses these blob hashes instead of re-chunking
-	// and re-compressing. Blob hashes are content-addressed, so v1 and v2
-	// share the same hashes (only the tree-entry filename differs).
-	_, precomputeSpan := perf.Start(logCtx, "precompute_transcript_blobs")
-	precomputed, precomputeErr := checkpoint.PrecomputeTranscriptBlobs(logCtx, repo, redactedTranscript, state.AgentType)
-	precomputeSpan.End()
-	if precomputeErr != nil {
-		logging.Warn(logCtx, "finalize: precompute transcript blobs failed, falling back to per-checkpoint work",
-			slog.String("session_id", state.SessionID),
-			slog.String("error", precomputeErr.Error()),
-		)
-		precomputed = nil
-	}
+	precomputed := precomputeTranscriptBlobsForFinalize(logCtx, repo, redactedTranscript, state)
 
 	// Update each checkpoint with the full transcript
 	for _, cpIDStr := range state.TurnCheckpointIDs {


### PR DESCRIPTION
This should address some of the issues reported with codex hitting hook timeouts, for example https://github.com/entireio/cli/issues/957

### Summary

Stop hooks were taking ~30 s on 18 MB image-heavy transcripts (reported against Codex, but the code path is agent-agnostic). Two root causes inside `finalizeAllTurnCheckpoints`:

1. For each of N turn-checkpoints, the full redacted transcript was re-chunked and re-zlib-compressed, doubled when v1+v2 dual-write is enabled. Pure-Go zlib on ~18 MB of base64 image data is the bottleneck; go-git v6 does not short-circuit before compression when the loose object already exists on disk.
2. `replaceTranscript` / `updateCommittedFullTranscript` unconditionally rewrote all transcript blobs even when the stored content was identical.

### Changes

- **`PrecomputedTranscriptBlobs`** new type on `UpdateCommittedOptions`: chunk blob hashes + content-hash blob, computed once. Content-addressed hashes are identical for v1 (`full.jsonl`) and v2 (`raw_transcript`) paths, so one precompute serves both stores.
- **`PrecomputeTranscriptBlobs(ctx, repo, transcript, agentType)`** constructor in `checkpoint/committed.go`.
- **`finalizeAllTurnCheckpoints`** now calls `PrecomputeTranscriptBlobs` once above the per-checkpoint loop and threads the result into every `UpdateCommittedOptions`. On precompute failure the loop falls back to the old per-checkpoint path (best-effort, logged).
- **v1 `replaceTranscript`** (`committed.go`): accepts precomputed blobs; short-circuits when existing `content_hash.txt` matches the new sha256.
- **v2 `updateCommittedFullTranscript`** (`v2_committed.go`): same short-circuit against `raw_transcript_hash.txt`; `writeTranscriptBlobs` + new `writeContentHashFromPrecompute` accept precomputed blobs.

### Expected effect on a 30 s, 18 MB, 3-checkpoint finalize

- Chunk + zlib of redacted transcript: **2N → 1** (v1 + v2, one pass).
- Content-hash blob: **2N → 1**, dropping to **0** on no-op re-finalize.
- Estimated ~10–15 s removed from the reported 30 s case.
- `compactTranscriptForV2` is genuinely per-checkpoint (per-checkpoint `startLine`), so it stays in the loop — not addressed here.

### Risk notes

- Short-circuit only fires on byte-identical transcript — redaction output is deterministic so this is safe.
- Fallback path preserved: if `PrecomputeTranscriptBlobs` fails, every checkpoint re-chunks and re-blobs as before.
- No behavior changes visible from the public API (`ReadSessionContent` etc.) — verified by `TestUpdateCommitted_PreservesMetadata` + roundtrip tests.
- No change to on-disk tree shape, ref layout, or commit-message trailers.

### Potential next steps

In decreasing ratio order, not shipped in this PR:

1. **Parse-on-first-use transcript cache.** `lifecycle.go` handleLifecycleTurnEnd runs `ExtractPrompts` + `ExtractAllModifiedFiles` + `CalculateTokenUsage` + `parseTranscriptForCheckpointUUID` — each parses the same bytes independently. A `sync.Once`-guarded shared `[]TranscriptLine` would collapse 3–4 parses into 1 without touching public agent interfaces. Estimated ~3–5 s/turn on image-heavy transcripts. Every agent, every turn — not just stop.
2. **Hoist `compact.Compact` if we can amortize per-startLine.** `compactTranscriptForV2` is currently per-checkpoint because of `startLine`. Worth a follow-up to check whether the expensive part (the JSONL walk) can run once with all chunks shared, and only the startLine slice differs.
3. **In-memory-bytes overloads for `ExtractPrompts` / `parseTranscriptForCheckpointUUID`.** Both currently re-read the same transcript file from disk. ~0.5–1 s/turn. Subsumed by (1) if it lands.
4. **Audit `.entire/metadata/<sid>/full.jsonl` writers/readers.** `lifecycle.go:357` writes ~18 MB to disk every turn, but finalize re-reads the *original* agent transcript, not this copy. Some resume/explain flows may still depend on it — scope before deleting.
5. **Streaming / lazy JSONL parser with `json.RawMessage` for image `content` blocks.** Biggest win for 18 MB base64-heavy transcripts but largest diff; diminishing returns if (1) lands first.

### Test plan

- [ ] Run `mise run check` to confirm fmt/lint/test:ci pass on this branch.
- [ ] Sanity-check on a local repo: start a session, run multiple turn-end commits, `git stop`, confirm `entire/checkpoints/v1` tree and `/full/current` tree both contain the finalized transcript and content hash.
- [ ] If possible, reproduce the customer's 18 MB, multi-image, 3-checkpoint scenario and measure stop-hook wall time before/after.

Want me to push the branch and open the PR with this as the body?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint persistence logic for both v1 and v2, adding new short-circuit paths based on stored content hashes; mistakes could leave transcripts stale or mismatched across refs. Changes are localized and covered by new roundtrip/short-circuit tests plus a fallback-to-old-behavior path if precompute fails.
> 
> **Overview**
> Speeds up turn-end checkpoint finalization by **precomputing transcript chunk blobs once** and reusing their content-addressed hashes across all `UpdateCommitted` calls (and across v1+v2 dual-writes).
> 
> Adds a `PrecomputedTranscriptBlobs` option and `PrecomputeTranscriptBlobs` helper, updates v1 `replaceTranscript` and v2 `/full/current` updates to **skip re-chunking/re-compressing** when the transcript content is unchanged (via existing content-hash files), and threads the precomputed blobs through `finalizeAllTurnCheckpoints`. Includes new tests covering precompute reuse and the content-hash short-circuit behavior for both v1 and v2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da552180af42be7192f24de0e852547549faec84. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->