### PR TITLE
cli: register external agents in attach command

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -50,7 +50,8 @@ the session started, or to attach a research session.
 If the last commit already has a checkpoint, the session is added to it.
 Otherwise a new checkpoint is created.
 
-Supported agents: claude-code, gemini, opencode, codex, cursor, copilot-cli, factoryai-droid`,
+Works with any registered agent, including external agents enabled via
+external_agents in settings. Run 'entire configure' to see the full list.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return cmd.Help()
@@ -66,7 +67,7 @@ Supported agents: claude-code, gemini, opencode, codex, cursor, copilot-cli, fac
 		},
 	}
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation and amend the last commit with the checkpoint trailer")
-	cmd.Flags().StringVarP(&agentFlag, "agent", "a", string(agent.DefaultAgentName), "Agent that created the session (claude-code, gemini, opencode, codex, cursor, copilot-cli, factoryai-droid)")
+	cmd.Flags().StringVarP(&agentFlag, "agent", "a", string(agent.DefaultAgentName), "Agent that created the session (see 'entire configure' for registered agents, including external)")
 	return cmd
 }
 

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -57,6 +58,9 @@ Supported agents: claude-code, gemini, opencode, codex, cursor, copilot-cli, fac
 			if checkDisabledGuard(cmd.Context(), cmd.OutOrStdout()) {
 				return nil
 			}
+			// Discover external agents so --agent <external-name> is recognized
+			// and so auto-detection can find transcripts from external agents.
+			external.DiscoverAndRegister(cmd.Context())
 			agentName := types.AgentName(agentFlag)
 			return runAttach(cmd.Context(), cmd.OutOrStdout(), args[0], agentName, force)
 		},

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/cursor"         // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid" // register agent
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"      // register agent
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -772,4 +774,76 @@ func readFileFromRef(t *testing.T, repo *git.Repository, refName, filePath strin
 		return "", false
 	}
 	return content, true
+}
+
+// TestAttach_DiscoversExternalAgents verifies that `entire attach --agent <external>`
+// gets past the agent registry check when external_agents is enabled and a
+// matching binary is on PATH. Without the DiscoverAndRegister call in the
+// attach command, this would fail with "unknown agent: <name>".
+//
+// This test does not verify end-to-end attach behavior — it asserts only
+// that discovery ran. The command is expected to fail later (transcript
+// resolution) because we don't stand up a real session.
+func TestAttach_DiscoversExternalAgents(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	setupAttachTestRepo(t)
+
+	// Overwrite settings to enable external_agents (enableEntire writes the
+	// file without it).
+	cwd := mustGetwd(t)
+	settingsPath := filepath.Join(cwd, ".entire", "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"enabled":true,"external_agents":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a unique name so concurrent test runs can't collide in the global
+	// agent registry.
+	agentName := types.AgentName("attachtest-discovery-agent")
+
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "entire-agent-"+string(agentName))
+	infoJSON := `{
+  "protocol_version": 1,
+  "name": "` + string(agentName) + `",
+  "type": "Attach Test Agent",
+  "description": "Agent for attach discovery test",
+  "is_preview": false,
+  "protected_dirs": [],
+  "hook_names": [],
+  "capabilities": {}
+}`
+	script := "#!/bin/sh\nif [ \"$1\" = \"info\" ]; then\n  echo '" + infoJSON + "'\nfi\n"
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write mock agent binary: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cmd := newAttachCmd()
+	// Pass a bogus session ID — the point is to exercise the registry check,
+	// not full attach flow.
+	cmd.SetArgs([]string{"--agent", string(agentName), "-f", "fake-session-id"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	err := cmd.Execute()
+	// We expect an error (no transcript), but it must not be the
+	// registry-lookup error. A regression (removing DiscoverAndRegister)
+	// would produce "unknown agent: attachtest-discovery-agent".
+	if err == nil {
+		t.Fatalf("expected attach to fail on missing transcript, got success\noutput: %s", out.String())
+	}
+	if strings.Contains(err.Error(), "unknown agent") {
+		t.Fatalf("attach did not discover external agent — got registry miss: %v", err)
+	}
+
+	// Also confirm the agent actually landed in the registry, so the check
+	// above is meaningful (not merely passing because some other error
+	// short-circuited before the registry lookup).
+	if _, lookupErr := agent.Get(agentName); lookupErr != nil {
+		t.Errorf("expected external agent %q in registry after attach, got: %v", agentName, lookupErr)
+	}
 }

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -487,7 +487,7 @@ func generateSummary(ctx context.Context, redactedTranscript redact.RedactedByte
 // The return type is the summarize.Generator interface rather than the concrete
 // adapter pointer so callers can't accidentally hold a non-nil interface that
 // wraps a nil pointer (the classic Go nil-interface footgun).
-func buildSummaryGenerator(ctx context.Context) summarize.Generator { //nolint:ireturn // interface return is intentional for provider abstraction and nil-safety
+func buildSummaryGenerator(ctx context.Context) summarize.Generator {
 	s, err := settings.Load(ctx)
 	if err != nil {
 		// Warn (not Debug): this is the auto-summarize hot path on every commit.

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -487,7 +487,7 @@ func generateSummary(ctx context.Context, redactedTranscript redact.RedactedByte
 // The return type is the summarize.Generator interface rather than the concrete
 // adapter pointer so callers can't accidentally hold a non-nil interface that
 // wraps a nil pointer (the classic Go nil-interface footgun).
-func buildSummaryGenerator(ctx context.Context) summarize.Generator {
+func buildSummaryGenerator(ctx context.Context) summarize.Generator { //nolint:ireturn // interface return is intentional for provider abstraction and nil-safety
 	s, err := settings.Load(ctx)
 	if err != nil {
 		// Warn (not Debug): this is the auto-summarize hot path on every commit.


### PR DESCRIPTION
`entire attach --agent <external-name>` failed with "unknown agent" because external agent discovery runs in configure, rewind, resume, and the hook commands but not in attach. Discovery is now called before the --agent flag is resolved, matching rewind/resume.

Test plan:
- [ ] `entire attach <session-id> --agent pi` no longer errors on the registry check (requires `entire-agent-pi` on PATH and `external_agents` enabled in settings)
- [ ] `go test ./cmd/entire/cli -run TestAttach` still green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change that only triggers external agent discovery before resolving `--agent`, affecting CLI behavior but not core checkpoint or git mutation logic.
> 
> **Overview**
> Fixes `entire attach --agent <external-name>` failing with "unknown agent" by running external agent discovery/registration in `attach` before the agent flag is resolved.
> 
> This also allows `attach`’s transcript auto-detection to consider externally provided agents when `external_agents` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9d29db12c75c8a684d764a954fa4967feec04c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->