### PR TITLE
Refactor checkpoint remote URL resolution and improve handling of `ENTIRE_CHECKPOINT_TOKEN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,21 @@ Entire derives the git URL automatically using the same protocol (SSH or HTTPS) 
 - Skip pushing if a fork is detected (push remote owner differs from checkpoint repo owner)
 - If the remote is unreachable, warn and continue without blocking your main push
 
+#### `ENTIRE_CHECKPOINT_TOKEN`
+
+`ENTIRE_CHECKPOINT_TOKEN` allows you to provide a dedicated token for checkpoint repository operations, without modifying the credentials used for your primary repository.
+
+When this environment variable is set, Entire behaves as follows:
+
+- Injects the token into HTTPS Git operations used for checkpoint fetch and push
+- If `checkpoint_remote` is configured:
+  - Prefers an HTTPS URL for the checkpoint remote when a token is present, even if the repository’s `origin` uses SSH
+- If `checkpoint_remote` is not configured:
+  - Falls back to using the default `origin` remote
+- If `checkpoint_remote` configuration cannot be loaded:
+  - Falls back to `origin`
+  - If `origin` is a valid SSH or HTTPS Git remote, Entire converts it to an HTTPS URL to enable token-based authentication
+
 ### Auto-Summarization
 
 When enabled, Entire automatically generates AI summaries for checkpoints at commit time. Summaries capture intent, outcome, learnings, friction points, and open items from the session.

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -215,7 +217,14 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 
 // writeAttachCheckpointV2 writes attach-created checkpoints into the v2 refs.
 func writeAttachCheckpointV2(ctx context.Context, repo *git.Repository, opts cpkg.WriteCommittedOptions) error {
-	v2Store := cpkg.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
+	v2URL, err := remote.FetchURL(ctx)
+	if err != nil {
+		logging.Debug(ctx, "attach: using origin for v2 store fetch remote",
+			slog.String("error", err.Error()),
+		)
+		v2URL = "origin"
+	}
+	v2Store := cpkg.NewV2GitStore(repo, v2URL)
 	if err := v2Store.WriteCommitted(ctx, opts); err != nil {
 		return fmt.Errorf("v2 write committed: %w", err)
 	}

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -222,7 +222,6 @@ func writeAttachCheckpointV2(ctx context.Context, repo *git.Repository, opts cpk
 		logging.Debug(ctx, "attach: using origin for v2 store fetch remote",
 			slog.String("error", err.Error()),
 		)
-		v2URL = "origin"
 	}
 	v2Store := cpkg.NewV2GitStore(repo, v2URL)
 	if err := v2Store.WriteCommitted(ctx, opts); err != nil {

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -1,0 +1,354 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+const (
+	originRemote          = "origin"
+	checkpointTokenEnvVar = "ENTIRE_CHECKPOINT_TOKEN"
+)
+
+const (
+	ProtocolSSH   = "ssh"
+	ProtocolHTTPS = "https"
+)
+
+type RemoteInfo struct {
+	Protocol string
+	Host     string
+	Owner    string
+	Repo     string
+}
+
+// FetchURL returns the effective checkpoint fetch URL for the current repository.
+// If strategy_options.checkpoint_remote is configured, the returned URL is derived
+// from the origin remote's protocol/host and the configured checkpoint repo.
+// Otherwise, the origin remote URL is returned directly.
+//
+// If ENTIRE_CHECKPOINT_TOKEN is set and a checkpoint remote is configured, HTTPS is
+// forced so the token can be used even when origin is configured via SSH.
+func FetchURL(ctx context.Context) (string, error) {
+	withToken := strings.TrimSpace(os.Getenv(checkpointTokenEnvVar)) != ""
+
+	originURL, originErr := GetRemoteURL(ctx, originRemote)
+	if originErr != nil {
+		originURL = ""
+	}
+
+	if originURL != "" && withToken {
+		if tokenURL, ok := deriveTokenOriginURL(originURL); ok {
+			originURL = tokenURL
+		}
+	}
+
+	s, err := settings.Load(ctx)
+	if err != nil {
+		if originURL != "" {
+			logFallback(ctx, "fetch", originURL, "load settings", err)
+			return originURL, nil
+		}
+		return "", fmt.Errorf("load settings: %w", err)
+	}
+
+	config := s.GetCheckpointRemote()
+	if config == nil {
+		if originURL == "" {
+			return "", fmt.Errorf("no fetch URL found: %w", originErr)
+		}
+		return originURL, nil
+	}
+
+	if withToken {
+		host, ok := providerHost(config.Provider)
+		if ok {
+			checkpointURL, err := deriveCheckpointURLFromInfo(&RemoteInfo{
+				Protocol: ProtocolHTTPS,
+				Host:     host,
+			}, config)
+			if err == nil {
+				return checkpointURL, nil
+			}
+		}
+
+		// In token-based execution path, short-circuit to avoid additional
+		// change in protocol.
+		if originURL != "" {
+			return originURL, nil
+		}
+	}
+
+	if originURL == "" {
+		return "", fmt.Errorf("no fetch URL found: %w", originErr)
+	}
+
+	info, err := ParseURL(originURL)
+	if err != nil {
+		logFallback(ctx, "fetch", originURL, "parse origin remote URL", err)
+		return originURL, nil
+	}
+
+	checkpointURL, err := deriveCheckpointURLFromInfo(info, config)
+	if err != nil {
+		logFallback(ctx, "fetch", originURL, "derive checkpoint remote URL", err)
+		return originURL, nil
+	}
+
+	return checkpointURL, nil
+}
+
+// PushURL returns the effective checkpoint push URL for the current repository.
+// Unlike FetchURL:
+//   - it derives protocol from the requested push remote, not always origin
+//   - it skips checkpoint remote use when the push remote owner differs
+//     from the configured checkpoint remote owner
+//
+// If ENTIRE_CHECKPOINT_TOKEN is set, HTTPS is forced so the token can be used
+// even when the push remote is configured via SSH.
+//
+// The boolean return value reports whether a dedicated checkpoint_remote is
+// configured and should be used for push. When false, the returned URL is the
+// repository's origin URL as a fallback.
+func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
+	originURL, _ := GetRemoteURL(ctx, originRemote)
+
+	s, err := settings.Load(ctx)
+	if err != nil {
+		fallbackURL, fallbackErr := resolvePushFallbackURL(ctx, pushRemoteName, originURL)
+		if fallbackErr == nil {
+			logFallback(ctx, "push", fallbackURL, "load settings", err,
+				slog.String("push_remote", pushRemoteName),
+			)
+			return fallbackURL, false, nil
+		}
+		return "", false, fmt.Errorf("load settings: %w", err)
+	}
+
+	config := s.GetCheckpointRemote()
+	if config == nil {
+		fallbackURL, fallbackErr := resolvePushFallbackURL(ctx, pushRemoteName, originURL)
+		if fallbackErr != nil {
+			return "", false, fmt.Errorf("no push URL found: %w", fallbackErr)
+		}
+		return fallbackURL, false, nil
+	}
+
+	pushRemoteURL, err := GetRemoteURL(ctx, pushRemoteName)
+	if err != nil {
+		fallbackURL, fallbackErr := resolvePushFallbackURL(ctx, pushRemoteName, originURL)
+		if fallbackErr == nil {
+			logFallback(ctx, "push", fallbackURL, "get push remote URL", err,
+				slog.String("push_remote", pushRemoteName),
+			)
+			return fallbackURL, false, nil
+		}
+		return "", true, fmt.Errorf("no push URL found: %w", err)
+	}
+
+	pushInfo, err := ParseURL(pushRemoteURL)
+	if err != nil {
+		if originURL != "" {
+			logFallback(ctx, "push", originURL, "parse push remote URL", err,
+				slog.String("push_remote", pushRemoteName),
+			)
+			return originURL, false, nil
+		}
+		return "", true, fmt.Errorf("no push URL found: %w", err)
+	}
+	if strings.TrimSpace(os.Getenv(checkpointTokenEnvVar)) != "" {
+		pushInfo = &RemoteInfo{
+			Protocol: ProtocolHTTPS,
+			Host:     pushInfo.Host,
+			Owner:    pushInfo.Owner,
+			Repo:     pushInfo.Repo,
+		}
+	}
+
+	checkpointOwner := config.Owner()
+	if pushInfo.Owner != "" && checkpointOwner != "" && !strings.EqualFold(pushInfo.Owner, checkpointOwner) {
+		fallbackURL, fallbackErr := resolvePushFallbackURL(ctx, pushRemoteName, originURL)
+		if fallbackErr != nil {
+			return "", false, fmt.Errorf("no push URL found: %w", fallbackErr)
+		}
+		return fallbackURL, false, nil
+	}
+
+	pushURL, err := deriveCheckpointURLFromInfo(pushInfo, config)
+	if err != nil {
+		fallbackURL, fallbackErr := resolvePushFallbackURL(ctx, pushRemoteName, originURL)
+		if fallbackErr == nil {
+			logFallback(ctx, "push", fallbackURL, "derive push checkpoint URL", err,
+				slog.String("push_remote", pushRemoteName),
+			)
+			return fallbackURL, false, nil
+		}
+		return "", true, fmt.Errorf("no push URL found: %w", err)
+	}
+
+	return pushURL, true, nil
+}
+
+// Configured reports whether a structured checkpoint_remote is configured.
+func Configured(ctx context.Context) (bool, error) {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		logging.Warn(ctx, "checkpoint remote configuration unavailable; treating as not configured",
+			slog.String("error", err.Error()),
+		)
+		return false, nil
+	}
+	return s.GetCheckpointRemote() != nil, nil
+}
+
+func GetRemoteURL(ctx context.Context, remoteName string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", remoteName)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("remote %q not found", remoteName)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func ParseURL(rawURL string) (*RemoteInfo, error) {
+	rawURL = strings.TrimSpace(rawURL)
+
+	if strings.Contains(rawURL, ":") && !strings.Contains(rawURL, "://") {
+		parts := strings.SplitN(rawURL, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid SSH URL: %s", RedactURL(rawURL))
+		}
+
+		hostPart := parts[0]
+		host := hostPart
+		if idx := strings.Index(hostPart, "@"); idx >= 0 {
+			host = hostPart[idx+1:]
+		}
+
+		pathPart := strings.TrimSuffix(parts[1], ".git")
+		owner, repo, err := splitOwnerRepo(pathPart)
+		if err != nil {
+			return nil, err
+		}
+
+		return &RemoteInfo{Protocol: ProtocolSSH, Host: host, Owner: owner, Repo: repo}, nil
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %s", RedactURL(rawURL))
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no protocol in URL: %s", RedactURL(rawURL))
+	}
+
+	pathPart := strings.TrimPrefix(u.Path, "/")
+	owner, repo, err := splitOwnerRepo(pathPart)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RemoteInfo{Protocol: u.Scheme, Host: u.Hostname(), Owner: owner, Repo: repo}, nil
+}
+
+func DeriveCheckpointURL(pushRemoteURL string, config *settings.CheckpointRemoteConfig) (string, error) {
+	info, err := ParseURL(pushRemoteURL)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse push remote URL: %w", err)
+	}
+	return deriveCheckpointURLFromInfo(info, config)
+}
+
+func ExtractOwnerFromRemoteURL(rawURL string) string {
+	info, err := ParseURL(rawURL)
+	if err != nil {
+		return ""
+	}
+	return info.Owner
+}
+
+func deriveCheckpointURLFromInfo(info *RemoteInfo, config *settings.CheckpointRemoteConfig) (string, error) {
+	switch info.Protocol {
+	case ProtocolSSH:
+		return fmt.Sprintf("git@%s:%s.git", info.Host, config.Repo), nil
+	case ProtocolHTTPS:
+		return fmt.Sprintf("https://%s/%s.git", info.Host, config.Repo), nil
+	default:
+		return "", fmt.Errorf("unsupported protocol %q in origin remote", info.Protocol)
+	}
+}
+
+func deriveTokenOriginURL(originURL string) (string, bool) {
+	info, err := ParseURL(originURL)
+	if err != nil {
+		return "", false
+	}
+	if info.Host == "" || info.Owner == "" || info.Repo == "" {
+		return "", false
+	}
+	return fmt.Sprintf("https://%s/%s/%s.git", info.Host, info.Owner, info.Repo), true
+}
+
+func providerHost(provider string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "github":
+		return "github.com", true
+	case "gitlab":
+		return "gitlab.com", true
+	default:
+		return "", false
+	}
+}
+
+func splitOwnerRepo(path string) (string, string, error) {
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("cannot parse owner/repo from path: %s", path)
+	}
+	return parts[0], parts[1], nil
+}
+
+func RedactURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		if idx := strings.Index(rawURL, "@"); idx >= 0 {
+			if colonIdx := strings.Index(rawURL[idx:], ":"); colonIdx >= 0 {
+				return rawURL[idx+1:idx+colonIdx] + ":***"
+			}
+		}
+		return "<unparseable>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	return u.Scheme + "://" + u.Host + u.Path
+}
+
+func logFallback(ctx context.Context, operation, fallbackURL, reason string, err error, attrs ...any) {
+	logAttrs := []any{
+		slog.String("operation", operation),
+		slog.String("fallback_url", RedactURL(fallbackURL)),
+		slog.String("reason", reason),
+		slog.String("error", err.Error()),
+	}
+	logAttrs = append(logAttrs, attrs...)
+	logging.Warn(ctx, "checkpoint remote URL resolution fell back to alternate remote URL", logAttrs...)
+}
+
+func resolvePushFallbackURL(ctx context.Context, pushRemoteName, originURL string) (string, error) {
+	if originURL != "" {
+		return originURL, nil
+	}
+	if pushRemoteName == "" || pushRemoteName == originRemote {
+		return "", fmt.Errorf("remote %q not found", originRemote)
+	}
+	return GetRemoteURL(ctx, pushRemoteName)
+}

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
-	"os/exec"
 	"strings"
 
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
@@ -19,16 +18,12 @@ const (
 )
 
 const (
-	ProtocolSSH   = "ssh"
-	ProtocolHTTPS = "https"
+	ProtocolSSH   = gitremote.ProtocolSSH
+	ProtocolHTTPS = gitremote.ProtocolHTTPS
 )
 
-type Info struct {
-	Protocol string
-	Host     string
-	Owner    string
-	Repo     string
-}
+// Info is an alias for gitremote.Info.
+type Info = gitremote.Info
 
 // FetchURL returns the effective checkpoint fetch URL for the current repository.
 // If strategy_options.checkpoint_remote is configured, the returned URL is derived
@@ -212,70 +207,35 @@ func Configured(ctx context.Context) bool {
 	return s.GetCheckpointRemote() != nil
 }
 
+// GetRemoteURL returns the URL configured for the named git remote.
 func GetRemoteURL(ctx context.Context, remoteName string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", remoteName)
-	output, err := cmd.Output()
+	url, err := gitremote.GetRemoteURL(ctx, remoteName)
 	if err != nil {
-		return "", fmt.Errorf("remote %q not found", remoteName)
+		return "", fmt.Errorf("get remote URL: %w", err)
 	}
-	return strings.TrimSpace(string(output)), nil
+	return url, nil
 }
 
+// ParseURL parses a git remote URL (SSH SCP-style or HTTPS) into its components.
 func ParseURL(rawURL string) (*Info, error) {
-	rawURL = strings.TrimSpace(rawURL)
-
-	if strings.Contains(rawURL, ":") && !strings.Contains(rawURL, "://") {
-		parts := strings.SplitN(rawURL, ":", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid SSH URL: %s", RedactURL(rawURL))
-		}
-
-		hostPart := parts[0]
-		host := hostPart
-		if idx := strings.Index(hostPart, "@"); idx >= 0 {
-			host = hostPart[idx+1:]
-		}
-
-		pathPart := strings.TrimSuffix(parts[1], ".git")
-		owner, repo, err := splitOwnerRepo(pathPart)
-		if err != nil {
-			return nil, err
-		}
-
-		return &Info{Protocol: ProtocolSSH, Host: host, Owner: owner, Repo: repo}, nil
-	}
-
-	u, err := url.Parse(rawURL)
+	info, err := gitremote.ParseURL(rawURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid URL: %s", RedactURL(rawURL))
+		return nil, fmt.Errorf("parse URL: %w", err)
 	}
-	if u.Scheme == "" {
-		return nil, fmt.Errorf("no protocol in URL: %s", RedactURL(rawURL))
-	}
-
-	pathPart := strings.TrimPrefix(u.Path, "/")
-	owner, repo, err := splitOwnerRepo(pathPart)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Info{Protocol: u.Scheme, Host: u.Hostname(), Owner: owner, Repo: repo}, nil
+	return info, nil
 }
 
 func DeriveCheckpointURL(pushRemoteURL string, config *settings.CheckpointRemoteConfig) (string, error) {
-	info, err := ParseURL(pushRemoteURL)
+	info, err := gitremote.ParseURL(pushRemoteURL)
 	if err != nil {
 		return "", fmt.Errorf("cannot parse push remote URL: %w", err)
 	}
 	return deriveCheckpointURLFromInfo(info, config)
 }
 
+// ExtractOwnerFromRemoteURL extracts the owner component from a git remote URL.
 func ExtractOwnerFromRemoteURL(rawURL string) string {
-	info, err := ParseURL(rawURL)
-	if err != nil {
-		return ""
-	}
-	return info.Owner
+	return gitremote.ExtractOwnerFromRemoteURL(rawURL)
 }
 
 func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteConfig) (string, error) {
@@ -290,7 +250,7 @@ func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteCo
 }
 
 func deriveTokenOriginURL(originURL string) (string, bool) {
-	info, err := ParseURL(originURL)
+	info, err := gitremote.ParseURL(originURL)
 	if err != nil {
 		return "", false
 	}
@@ -311,28 +271,9 @@ func providerHost(provider string) (string, bool) {
 	}
 }
 
-func splitOwnerRepo(path string) (string, string, error) {
-	path = strings.TrimSuffix(path, ".git")
-	parts := strings.SplitN(path, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("cannot parse owner/repo from path: %s", path)
-	}
-	return parts[0], parts[1], nil
-}
-
+// RedactURL removes credentials and query parameters from a URL for safe logging.
 func RedactURL(rawURL string) string {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		if idx := strings.Index(rawURL, "@"); idx >= 0 {
-			if colonIdx := strings.Index(rawURL[idx:], ":"); colonIdx >= 0 {
-				return rawURL[idx+1:idx+colonIdx] + ":***"
-			}
-		}
-		return "<unparseable>"
-	}
-	u.User = nil
-	u.RawQuery = ""
-	return u.Scheme + "://" + u.Host + u.Path
+	return gitremote.RedactURL(rawURL)
 }
 
 func logFallback(ctx context.Context, operation, fallbackURL, reason string, err error, attrs ...any) {

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -23,7 +23,7 @@ const (
 	ProtocolHTTPS = "https"
 )
 
-type RemoteInfo struct {
+type Info struct {
 	Protocol string
 	Host     string
 	Owner    string
@@ -71,7 +71,7 @@ func FetchURL(ctx context.Context) (string, error) {
 	if withToken {
 		host, ok := providerHost(config.Provider)
 		if ok {
-			checkpointURL, err := deriveCheckpointURLFromInfo(&RemoteInfo{
+			checkpointURL, err := deriveCheckpointURLFromInfo(&Info{
 				Protocol: ProtocolHTTPS,
 				Host:     host,
 			}, config)
@@ -119,7 +119,10 @@ func FetchURL(ctx context.Context) (string, error) {
 // configured and should be used for push. When false, the returned URL is the
 // repository's origin URL as a fallback.
 func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
-	originURL, _ := GetRemoteURL(ctx, originRemote)
+	originURL := ""
+	if resolvedOriginURL, err := GetRemoteURL(ctx, originRemote); err == nil {
+		originURL = resolvedOriginURL
+	}
 
 	s, err := settings.Load(ctx)
 	if err != nil {
@@ -165,7 +168,7 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 		return "", true, fmt.Errorf("no push URL found: %w", err)
 	}
 	if strings.TrimSpace(os.Getenv(checkpointTokenEnvVar)) != "" {
-		pushInfo = &RemoteInfo{
+		pushInfo = &Info{
 			Protocol: ProtocolHTTPS,
 			Host:     pushInfo.Host,
 			Owner:    pushInfo.Owner,
@@ -198,15 +201,15 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 }
 
 // Configured reports whether a structured checkpoint_remote is configured.
-func Configured(ctx context.Context) (bool, error) {
+func Configured(ctx context.Context) bool {
 	s, err := settings.Load(ctx)
 	if err != nil {
 		logging.Warn(ctx, "checkpoint remote configuration unavailable; treating as not configured",
 			slog.String("error", err.Error()),
 		)
-		return false, nil
+		return false
 	}
-	return s.GetCheckpointRemote() != nil, nil
+	return s.GetCheckpointRemote() != nil
 }
 
 func GetRemoteURL(ctx context.Context, remoteName string) (string, error) {
@@ -218,7 +221,7 @@ func GetRemoteURL(ctx context.Context, remoteName string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-func ParseURL(rawURL string) (*RemoteInfo, error) {
+func ParseURL(rawURL string) (*Info, error) {
 	rawURL = strings.TrimSpace(rawURL)
 
 	if strings.Contains(rawURL, ":") && !strings.Contains(rawURL, "://") {
@@ -239,7 +242,7 @@ func ParseURL(rawURL string) (*RemoteInfo, error) {
 			return nil, err
 		}
 
-		return &RemoteInfo{Protocol: ProtocolSSH, Host: host, Owner: owner, Repo: repo}, nil
+		return &Info{Protocol: ProtocolSSH, Host: host, Owner: owner, Repo: repo}, nil
 	}
 
 	u, err := url.Parse(rawURL)
@@ -256,7 +259,7 @@ func ParseURL(rawURL string) (*RemoteInfo, error) {
 		return nil, err
 	}
 
-	return &RemoteInfo{Protocol: u.Scheme, Host: u.Hostname(), Owner: owner, Repo: repo}, nil
+	return &Info{Protocol: u.Scheme, Host: u.Hostname(), Owner: owner, Repo: repo}, nil
 }
 
 func DeriveCheckpointURL(pushRemoteURL string, config *settings.CheckpointRemoteConfig) (string, error) {
@@ -275,7 +278,7 @@ func ExtractOwnerFromRemoteURL(rawURL string) string {
 	return info.Owner
 }
 
-func deriveCheckpointURLFromInfo(info *RemoteInfo, config *settings.CheckpointRemoteConfig) (string, error) {
+func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteConfig) (string, error) {
 	switch info.Protocol {
 	case ProtocolSSH:
 		return fmt.Sprintf("git@%s:%s.git", info.Host, config.Repo), nil

--- a/cmd/entire/cli/checkpoint/remote/util_test.go
+++ b/cmd/entire/cli/checkpoint/remote/util_test.go
@@ -1,0 +1,380 @@
+package remote
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6"
+)
+
+func TestFetchURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		originURL    string
+		settingsJSON string
+		token        string
+		wantURL      string
+		wantErr      bool
+	}{
+		{
+			name:         "checkpoint remote with token and https origin returns https checkpoint url",
+			originURL:    "https://github.com/acme/app.git",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			token:        "secret-token",
+			wantURL:      "https://github.com/acme/checkpoints.git",
+		},
+		{
+			name:         "checkpoint remote with token and ssh origin returns https checkpoint url",
+			originURL:    "git@github.com:acme/app.git",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			token:        "secret-token",
+			wantURL:      "https://github.com/acme/checkpoints.git",
+		},
+		{
+			name:         "checkpoint remote without token and https origin reuses https",
+			originURL:    "https://github.com/acme/app.git",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "https://github.com/acme/checkpoints.git",
+		},
+		{
+			name:         "checkpoint remote without token and ssh origin reuses ssh",
+			originURL:    "git@github.com:acme/app.git",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "git@github.com:acme/checkpoints.git",
+		},
+		{
+			name:         "no checkpoint remote with https origin returns origin url",
+			originURL:    "https://github.com/acme/app.git",
+			settingsJSON: `{"enabled":true}`,
+			wantURL:      "https://github.com/acme/app.git",
+		},
+		{
+			name:         "no checkpoint remote with ssh origin returns origin url",
+			originURL:    "git@github.com:acme/app.git",
+			settingsJSON: `{"enabled":true}`,
+			wantURL:      "git@github.com:acme/app.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+			runGit(t, repoDir, "remote", "add", "origin", tt.originURL)
+			writeSettings(t, repoDir, tt.settingsJSON)
+			t.Chdir(repoDir)
+			if tt.token != "" {
+				t.Setenv(checkpointTokenEnvVar, tt.token)
+			}
+
+			got, err := FetchURL(context.Background())
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("FetchURL() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("FetchURL() error = %v", err)
+			}
+			if got != tt.wantURL {
+				t.Fatalf("FetchURL() = %q, want %q", got, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestFetchURL_ErrorsWhenOriginMissing(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	_, err := FetchURL(context.Background())
+	if err == nil {
+		t.Fatal("FetchURL() error = nil, want error")
+	}
+}
+
+func TestFetchURL_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		addOrigin    bool
+		originURL    string
+		settingsJSON string
+		token        string
+		wantURL      string
+		wantErr      bool
+	}{
+		{
+			name:         "unsupported origin protocol without token falls back to origin",
+			addOrigin:    true,
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "",
+		},
+		{
+			name:         "unsupported origin protocol with token returns https checkpoint url",
+			addOrigin:    true,
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			token:        "secret-token",
+			wantURL:      "https://github.com/acme/checkpoints.git",
+		},
+		{
+			name:         "missing origin with token returns https checkpoint url",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			token:        "secret-token",
+			wantURL:      "https://github.com/acme/checkpoints.git",
+		},
+		{
+			name:         "malformed settings with token falls back to origin because checkpoint remote config is unavailable",
+			addOrigin:    true,
+			settingsJSON: `{`,
+			token:        "secret-token",
+			wantURL:      "",
+		},
+		{
+			name:         "malformed settings with token and ssh origin returns https origin url",
+			originURL:    "git@github.com:acme/app.git",
+			settingsJSON: `{`,
+			token:        "secret-token",
+			wantURL:      "https://github.com/acme/app.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+
+			originURL := tt.originURL
+			if tt.addOrigin {
+				originDir := t.TempDir()
+				initBareRepo(t, originDir)
+				originURL = fileURL(originDir)
+			}
+			if originURL != "" {
+				runGit(t, repoDir, "remote", "add", "origin", originURL)
+			}
+
+			writeSettings(t, repoDir, tt.settingsJSON)
+			t.Chdir(repoDir)
+			if tt.token != "" {
+				t.Setenv(checkpointTokenEnvVar, tt.token)
+			}
+
+			got, err := FetchURL(context.Background())
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("FetchURL() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("FetchURL() error = %v", err)
+			}
+
+			wantURL := tt.wantURL
+			if wantURL == "" {
+				wantURL = originURL
+			}
+			if got != wantURL {
+				t.Fatalf("FetchURL() = %q, want %q", got, wantURL)
+			}
+		})
+	}
+}
+
+func TestPushURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		originURL    string
+		pushRemote   string
+		pushURL      string
+		settingsJSON string
+		token        string
+		wantURL      string
+		wantEnabled  bool
+		wantErr      bool
+	}{
+		{
+			name:         "no checkpoint remote falls back to origin https url and reports disabled",
+			originURL:    "https://github.com/acme/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true}`,
+			wantURL:      "https://github.com/acme/app.git",
+			wantEnabled:  false,
+		},
+		{
+			name:         "no checkpoint remote falls back to origin ssh url and reports disabled",
+			originURL:    "git@github.com:acme/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true}`,
+			wantURL:      "git@github.com:acme/app.git",
+			wantEnabled:  false,
+		},
+		{
+			name:         "configured checkpoint remote with https push remote uses https",
+			originURL:    "https://github.com/acme/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "https://github.com/acme/checkpoints.git",
+			wantEnabled:  true,
+		},
+		{
+			name:         "configured checkpoint remote with ssh push remote uses ssh",
+			originURL:    "git@github.com:acme/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "git@github.com:acme/checkpoints.git",
+			wantEnabled:  true,
+		},
+		{
+			name:         "token forces https for push url with ssh remote",
+			originURL:    "git@github.com:acme/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			token:        "push-token",
+			wantURL:      "https://github.com/acme/checkpoints.git",
+			wantEnabled:  true,
+		},
+		{
+			name:         "token keeps https for push url with https remote",
+			originURL:    "https://github.com/acme/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			token:        "push-token",
+			wantURL:      "https://github.com/acme/checkpoints.git",
+			wantEnabled:  true,
+		},
+		{
+			name:         "different push remote owner disables checkpoint push url",
+			originURL:    "https://github.com/fork/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "https://github.com/fork/app.git",
+			wantEnabled:  false,
+		},
+		{
+			name:         "missing push remote falls back to origin when checkpoint remote configured",
+			originURL:    "https://github.com/acme/app.git",
+			pushRemote:   "upstream",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			wantURL:      "https://github.com/acme/app.git",
+			wantEnabled:  false,
+		},
+		{
+			name:         "no checkpoint remote falls back to requested push remote when origin missing",
+			pushRemote:   "upstream",
+			pushURL:      "https://github.com/acme/app.git",
+			settingsJSON: `{"enabled":true}`,
+			wantURL:      "https://github.com/acme/app.git",
+			wantEnabled:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+			if tt.originURL != "" {
+				runGit(t, repoDir, "remote", "add", "origin", tt.originURL)
+			}
+			if tt.pushURL != "" {
+				runGit(t, repoDir, "remote", "add", tt.pushRemote, tt.pushURL)
+			}
+			writeSettings(t, repoDir, tt.settingsJSON)
+			t.Chdir(repoDir)
+			if tt.token != "" {
+				t.Setenv(checkpointTokenEnvVar, tt.token)
+			}
+
+			gotURL, gotEnabled, err := PushURL(context.Background(), tt.pushRemote)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("PushURL() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("PushURL() error = %v", err)
+			}
+			if gotEnabled != tt.wantEnabled {
+				t.Fatalf("PushURL() enabled = %v, want %v", gotEnabled, tt.wantEnabled)
+			}
+			if gotURL != tt.wantURL {
+				t.Fatalf("PushURL() URL = %q, want %q", gotURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestPushURL_ErrorsWhenNoCheckpointRemoteAndOriginMissing(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	writeSettings(t, repoDir, `{"enabled":true}`)
+	t.Chdir(repoDir)
+
+	_, _, err := PushURL(context.Background(), "origin")
+	if err == nil {
+		t.Fatal("PushURL() error = nil, want error")
+	}
+}
+
+func TestConfigured_MalformedSettingsTreatedAsNotConfigured(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	writeSettings(t, repoDir, `{`)
+	t.Chdir(repoDir)
+
+	configured, err := Configured(context.Background())
+	if err != nil {
+		t.Fatalf("Configured() error = %v", err)
+	}
+	if configured {
+		t.Fatal("Configured() = true, want false")
+	}
+}
+
+func writeSettings(t *testing.T, repoDir, content string) {
+	t.Helper()
+	entireDir := filepath.Join(repoDir, ".entire")
+	if err := os.MkdirAll(entireDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", entireDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(settings.json) error = %v", err)
+	}
+}
+
+func TestRunGitHelperUsesGitCLI(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = repoDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git rev-parse failed: %v\nOutput: %s", err, output)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\nOutput: %s", args, err, output)
+	}
+}
+
+func initBareRepo(t *testing.T, repoDir string) {
+	t.Helper()
+	if _, err := git.PlainInit(repoDir, true); err != nil {
+		t.Fatalf("PlainInit(%s, bare) error = %v", repoDir, err)
+	}
+}
+
+func fileURL(path string) string {
+	return "file://" + filepath.ToSlash(path)
+}

--- a/cmd/entire/cli/checkpoint/remote/util_test.go
+++ b/cmd/entire/cli/checkpoint/remote/util_test.go
@@ -329,10 +329,7 @@ func TestConfigured_MalformedSettingsTreatedAsNotConfigured(t *testing.T) {
 	writeSettings(t, repoDir, `{`)
 	t.Chdir(repoDir)
 
-	configured, err := Configured(context.Background())
-	if err != nil {
-		t.Fatalf("Configured() error = %v", err)
-	}
+	configured := Configured(context.Background())
 	if configured {
 		t.Fatal("Configured() = true, want false")
 	}
@@ -352,7 +349,7 @@ func writeSettings(t *testing.T, repoDir, content string) {
 func TestRunGitHelperUsesGitCLI(t *testing.T) {
 	repoDir := t.TempDir()
 	testutil.InitRepo(t, repoDir)
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd := exec.CommandContext(context.Background(), "git", "rev-parse", "--git-dir")
 	cmd.Dir = repoDir
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git rev-parse failed: %v\nOutput: %s", err, output)
@@ -361,7 +358,7 @@ func TestRunGitHelperUsesGitCLI(t *testing.T) {
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.CommandContext(context.Background(), "git", args...)
 	cmd.Dir = dir
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v failed: %v\nOutput: %s", args, err, output)

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -426,15 +427,20 @@ func checkDisconnectedV2Main(cmd *cobra.Command, force bool) error {
 	}
 
 	ctx := cmd.Context()
-	remote, configured, resolveErr := strategy.ResolveCheckpointRemoteURL(ctx)
-	if configured && resolveErr != nil {
-		return fmt.Errorf("checkpoint_remote is configured but could not be resolved: %w", resolveErr)
+	configured, configuredErr := remote.Configured(ctx)
+	if configuredErr != nil {
+		return fmt.Errorf("failed to load checkpoint remote configuration: %w", configuredErr)
 	}
-	if remote == "" {
-		remote = "origin"
+	remoteName := "origin"
+	if configured {
+		resolvedRemote, resolveErr := remote.FetchURL(ctx)
+		if resolveErr != nil {
+			return fmt.Errorf("checkpoint_remote is configured but could not be resolved: %w", resolveErr)
+		}
+		remoteName = resolvedRemote
 	}
 
-	disconnected, err := strategy.IsV2MainDisconnected(ctx, repo, remote)
+	disconnected, err := strategy.IsV2MainDisconnected(ctx, repo, remoteName)
 	if err != nil {
 		// If no checkpoint_remote is configured and origin doesn't exist or is
 		// unreachable, treat as "can't check" rather than a hard failure — mirrors
@@ -478,7 +484,7 @@ func checkDisconnectedV2Main(cmd *cobra.Command, force bool) error {
 		}
 	}
 
-	if fixErr := strategy.ReconcileDisconnectedV2Ref(ctx, repo, remote, cmd.ErrOrStderr()); fixErr != nil {
+	if fixErr := strategy.ReconcileDisconnectedV2Ref(ctx, repo, remoteName, cmd.ErrOrStderr()); fixErr != nil {
 		return fmt.Errorf("failed to reconcile v2 /main ref: %w", fixErr)
 	}
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -427,11 +427,8 @@ func checkDisconnectedV2Main(cmd *cobra.Command, force bool) error {
 	}
 
 	ctx := cmd.Context()
-	configured, configuredErr := remote.Configured(ctx)
-	if configuredErr != nil {
-		return fmt.Errorf("failed to load checkpoint remote configuration: %w", configuredErr)
-	}
-	remoteName := "origin"
+	configured := remote.Configured(ctx)
+	remoteName := migrateRemoteName
 	if configured {
 		resolvedRemote, resolveErr := remote.FetchURL(ctx)
 		if resolveErr != nil {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -20,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -226,7 +227,14 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 	}
 
 	v1Store := checkpoint.NewGitStore(repo)
-	v2Store := checkpoint.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
+	v2URL, err := remote.FetchURL(ctx)
+	if err != nil {
+		logging.Debug(ctx, "explain: using origin for v2 store fetch remote",
+			slog.String("error", err.Error()),
+		)
+		v2URL = "origin"
+	}
+	v2Store := checkpoint.NewV2GitStore(repo, v2URL)
 	preferCheckpointsV2 := settings.IsCheckpointsV2Enabled(ctx)
 
 	// First, try to find in committed checkpoints by checkpoint ID prefix
@@ -264,7 +272,14 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 			if freshRepo, repoErr := openRepository(ctx); repoErr == nil {
 				repo = freshRepo
 				v1Store = checkpoint.NewGitStore(repo)
-				v2Store = checkpoint.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
+				v2URL, err = remote.FetchURL(ctx)
+				if err != nil {
+					logging.Debug(ctx, "explain: using origin for refreshed v2 store fetch remote",
+						slog.String("error", err.Error()),
+					)
+					v2URL = "origin"
+				}
+				v2Store = checkpoint.NewV2GitStore(repo, v2URL)
 				if freshCommitted, listErr := listCommittedForExplain(ctx, v1Store, v2Store, preferCheckpointsV2); listErr == nil {
 					for _, info := range freshCommitted {
 						if strings.HasPrefix(info.CheckpointID.String(), checkpointIDPrefix) {
@@ -1269,7 +1284,14 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	strategy.WarnIfMetadataDisconnected()
 
 	v1Store := checkpoint.NewGitStore(repo)
-	v2Store := checkpoint.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
+	v2URL, err := remote.FetchURL(ctx)
+	if err != nil {
+		logging.Debug(ctx, "explain: using origin for branch checkpoint v2 store fetch remote",
+			slog.String("error", err.Error()),
+		)
+		v2URL = "origin"
+	}
+	v2Store := checkpoint.NewV2GitStore(repo, v2URL)
 	preferCheckpointsV2 := settings.IsCheckpointsV2Enabled(ctx)
 
 	// Get all committed checkpoints for lookup (v2-aware with v1 fallback).

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -220,6 +220,8 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 // When force is true, regenerates even if a summary already exists.
 // When rawTranscript is true, outputs only the raw transcript file (JSONL format).
 // When searchAll is true, searches all commits without branch/depth limits (used for finding associated commits).
+//
+//nolint:maintidx // Command handler intentionally coordinates multiple checkpoint lookup/fetch paths.
 func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPrefix string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
 	repo, err := openRepository(ctx)
 	if err != nil {
@@ -232,7 +234,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 		logging.Debug(ctx, "explain: using origin for v2 store fetch remote",
 			slog.String("error", err.Error()),
 		)
-		v2URL = "origin"
+		v2URL = ""
 	}
 	v2Store := checkpoint.NewV2GitStore(repo, v2URL)
 	preferCheckpointsV2 := settings.IsCheckpointsV2Enabled(ctx)
@@ -277,7 +279,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 					logging.Debug(ctx, "explain: using origin for refreshed v2 store fetch remote",
 						slog.String("error", err.Error()),
 					)
-					v2URL = "origin"
+					v2URL = ""
 				}
 				v2Store = checkpoint.NewV2GitStore(repo, v2URL)
 				if freshCommitted, listErr := listCommittedForExplain(ctx, v1Store, v2Store, preferCheckpointsV2); listErr == nil {
@@ -1289,7 +1291,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 		logging.Debug(ctx, "explain: using origin for branch checkpoint v2 store fetch remote",
 			slog.String("error", err.Error()),
 		)
-		v2URL = "origin"
+		v2URL = ""
 	}
 	v2Store := checkpoint.NewV2GitStore(repo, v2URL)
 	preferCheckpointsV2 := settings.IsCheckpointsV2Enabled(ctx)

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
@@ -21,7 +22,7 @@ import (
 func formatFilteredFetchError(prefix, fetchTarget string, output []byte, fetchErr error) error {
 	redactedTarget := fetchTarget
 	if isFetchTargetURL(fetchTarget) {
-		redactedTarget = strategy.RedactURL(fetchTarget)
+		redactedTarget = remote.RedactURL(fetchTarget)
 	}
 
 	msg := strings.TrimSpace(string(output))
@@ -507,12 +508,16 @@ func fetchV2MainFromOrigin(ctx context.Context, shallow bool) error {
 // configured checkpoint_remote URL.
 // Returns an error if the fetch fails or no checkpoint_remote is configured.
 func FetchV2MetadataFromCheckpointRemote(ctx context.Context) error {
-	checkpointURL, hasCheckpointRemote, resolveErr := strategy.ResolveCheckpointRemoteURL(ctx)
-	if !hasCheckpointRemote {
+	configured, configuredErr := remote.Configured(ctx)
+	if configuredErr != nil {
+		return fmt.Errorf("failed to load checkpoint remote configuration: %w", configuredErr)
+	}
+	if !configured {
 		return errors.New("no checkpoint_remote configured")
 	}
-	if resolveErr != nil {
-		return fmt.Errorf("checkpoint_remote configured but could not resolve URL: %w", resolveErr)
+	checkpointURL, err := remote.FetchURL(ctx)
+	if err != nil {
+		return fmt.Errorf("checkpoint_remote configured but could not resolve URL: %w", err)
 	}
 
 	if err := strategy.FetchV2MainFromURL(ctx, checkpointURL); err != nil {
@@ -525,12 +530,16 @@ func FetchV2MetadataFromCheckpointRemote(ctx context.Context) error {
 // configured checkpoint_remote URL and updates the local branch.
 // Returns an error if the fetch fails or no checkpoint_remote is configured.
 func FetchMetadataFromCheckpointRemote(ctx context.Context) error {
-	checkpointURL, hasCheckpointRemote, resolveErr := strategy.ResolveCheckpointRemoteURL(ctx)
-	if !hasCheckpointRemote {
+	configured, configuredErr := remote.Configured(ctx)
+	if configuredErr != nil {
+		return fmt.Errorf("failed to load checkpoint remote configuration: %w", configuredErr)
+	}
+	if !configured {
 		return errors.New("no checkpoint_remote configured")
 	}
-	if resolveErr != nil {
-		return fmt.Errorf("checkpoint_remote configured but could not resolve URL: %w", resolveErr)
+	checkpointURL, err := remote.FetchURL(ctx)
+	if err != nil {
+		return fmt.Errorf("checkpoint_remote configured but could not resolve URL: %w", err)
 	}
 
 	if err := strategy.FetchMetadataBranch(ctx, checkpointURL); err != nil {
@@ -540,11 +549,12 @@ func FetchMetadataFromCheckpointRemote(ctx context.Context) error {
 }
 
 // resolveCheckpointFetchTarget returns the fetch target for checkpoint data.
-// When a checkpoint_remote is configured in settings, returns its resolved URL.
-// Otherwise falls back to "origin".
+// It prefers the effective URL resolved by checkpoint/remote.FetchURL, which is
+// the source of truth for checkpoint fetch location. If URL resolution fails, it
+// falls back to the origin remote name so callers can still attempt a fetch.
 func resolveCheckpointFetchTarget(ctx context.Context) string {
-	url, has, err := strategy.ResolveCheckpointRemoteURL(ctx)
-	if has && err == nil && url != "" {
+	url, err := remote.FetchURL(ctx)
+	if err == nil && url != "" {
 		return url
 	}
 	return "origin"
@@ -555,9 +565,8 @@ func resolveCheckpointFetchTarget(ctx context.Context) string {
 // unlike fetch-pack which bypasses them. Requires the server to support
 // uploadpack.allowReachableSHA1InWant (GitHub, GitLab, Bitbucket all do).
 //
-// The fetch target is resolved via resolveCheckpointFetchTarget: when a
-// checkpoint_remote is configured, blobs are fetched from there; otherwise
-// from origin.
+// The fetch target is resolved via resolveCheckpointFetchTarget, which defers to
+// checkpoint/remote.FetchURL for the effective remote URL when available.
 //
 // If fetching by hash fails, falls back to a full metadata branch fetch.
 func FetchBlobsByHash(ctx context.Context, hashes []plumbing.Hash) error {

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -508,10 +508,7 @@ func fetchV2MainFromOrigin(ctx context.Context, shallow bool) error {
 // configured checkpoint_remote URL.
 // Returns an error if the fetch fails or no checkpoint_remote is configured.
 func FetchV2MetadataFromCheckpointRemote(ctx context.Context) error {
-	configured, configuredErr := remote.Configured(ctx)
-	if configuredErr != nil {
-		return fmt.Errorf("failed to load checkpoint remote configuration: %w", configuredErr)
-	}
+	configured := remote.Configured(ctx)
 	if !configured {
 		return errors.New("no checkpoint_remote configured")
 	}
@@ -530,10 +527,7 @@ func FetchV2MetadataFromCheckpointRemote(ctx context.Context) error {
 // configured checkpoint_remote URL and updates the local branch.
 // Returns an error if the fetch fails or no checkpoint_remote is configured.
 func FetchMetadataFromCheckpointRemote(ctx context.Context) error {
-	configured, configuredErr := remote.Configured(ctx)
-	if configuredErr != nil {
-		return fmt.Errorf("failed to load checkpoint remote configuration: %w", configuredErr)
-	}
+	configured := remote.Configured(ctx)
 	if !configured {
 		return errors.New("no checkpoint_remote configured")
 	}

--- a/cmd/entire/cli/git_operations_test.go
+++ b/cmd/entire/cli/git_operations_test.go
@@ -654,7 +654,7 @@ func TestResolveCheckpointFetchTarget_NoCheckpointRemote(t *testing.T) {
 	t.Chdir(localDir)
 
 	target := resolveCheckpointFetchTarget(context.Background())
-	assert.Equal(t, "origin", target)
+	assert.Equal(t, "git@github.com:org/main-repo.git", target)
 }
 
 // Not parallel: uses t.Chdir()
@@ -694,7 +694,7 @@ func TestResolveCheckpointFetchTarget_FallsBackOnError(t *testing.T) {
 	testutil.GitAdd(t, localDir, "f.txt")
 	testutil.GitCommit(t, localDir, "init")
 
-	// No origin remote — ResolveCheckpointRemoteURL will fail to get origin URL
+	// No origin remote — FetchURL cannot resolve an effective fetch URL.
 
 	// Settings with checkpoint_remote configured but no origin to derive URL from
 	entireDir := filepath.Join(localDir, ".entire")
@@ -707,7 +707,7 @@ func TestResolveCheckpointFetchTarget_FallsBackOnError(t *testing.T) {
 
 	t.Chdir(localDir)
 
-	// Should fall back to "origin" when URL resolution fails
+	// Falls back to the origin remote name when URL resolution fails.
 	target := resolveCheckpointFetchTarget(context.Background())
 	assert.Equal(t, "origin", target)
 }

--- a/cmd/entire/cli/gitremote/gitremote.go
+++ b/cmd/entire/cli/gitremote/gitremote.go
@@ -77,14 +77,16 @@ func ParseURL(rawURL string) (*Info, error) {
 }
 
 // RedactURL removes credentials and query parameters from a URL for safe logging.
+// SCP-style SSH URLs (e.g., git@github.com:org/repo.git) are returned as-is
+// since they contain no embedded credentials.
 func RedactURL(rawURL string) string {
+	// SCP-style SSH: user@host:path — no credentials to redact.
+	if strings.Contains(rawURL, ":") && !strings.Contains(rawURL, "://") {
+		return rawURL
+	}
+
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		if idx := strings.Index(rawURL, "@"); idx >= 0 {
-			if colonIdx := strings.Index(rawURL[idx:], ":"); colonIdx >= 0 {
-				return rawURL[idx+1:idx+colonIdx] + ":***"
-			}
-		}
 		return "<unparseable>"
 	}
 	u.User = nil

--- a/cmd/entire/cli/gitremote/gitremote.go
+++ b/cmd/entire/cli/gitremote/gitremote.go
@@ -1,0 +1,127 @@
+// Package gitremote provides general-purpose git remote URL utilities:
+// parsing, resolving, and redacting remote URLs. It has no dependency on
+// checkpoint, strategy, or settings packages.
+package gitremote
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strings"
+)
+
+const (
+	ProtocolSSH   = "ssh"
+	ProtocolHTTPS = "https"
+)
+
+// Info holds the parsed components of a git remote URL.
+type Info struct {
+	Protocol string
+	Host     string
+	Owner    string
+	Repo     string
+}
+
+// GetRemoteURL returns the URL configured for the named git remote.
+func GetRemoteURL(ctx context.Context, remoteName string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", remoteName)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("remote %q not found", remoteName)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// ParseURL parses a git remote URL (SSH SCP-style or HTTPS) into its components.
+func ParseURL(rawURL string) (*Info, error) {
+	rawURL = strings.TrimSpace(rawURL)
+
+	if strings.Contains(rawURL, ":") && !strings.Contains(rawURL, "://") {
+		parts := strings.SplitN(rawURL, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid SSH URL: %s", RedactURL(rawURL))
+		}
+
+		hostPart := parts[0]
+		_, host, found := strings.Cut(hostPart, "@")
+		if !found {
+			host = hostPart
+		}
+
+		pathPart := strings.TrimSuffix(parts[1], ".git")
+		owner, repo, err := splitOwnerRepo(pathPart)
+		if err != nil {
+			return nil, err
+		}
+
+		return &Info{Protocol: ProtocolSSH, Host: host, Owner: owner, Repo: repo}, nil
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %s", RedactURL(rawURL))
+	}
+	if u.Scheme == "" {
+		return nil, fmt.Errorf("no protocol in URL: %s", RedactURL(rawURL))
+	}
+
+	pathPart := strings.TrimPrefix(u.Path, "/")
+	owner, repo, err := splitOwnerRepo(pathPart)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Info{Protocol: u.Scheme, Host: u.Hostname(), Owner: owner, Repo: repo}, nil
+}
+
+// RedactURL removes credentials and query parameters from a URL for safe logging.
+func RedactURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		if idx := strings.Index(rawURL, "@"); idx >= 0 {
+			if colonIdx := strings.Index(rawURL[idx:], ":"); colonIdx >= 0 {
+				return rawURL[idx+1:idx+colonIdx] + ":***"
+			}
+		}
+		return "<unparseable>"
+	}
+	u.User = nil
+	u.RawQuery = ""
+	return u.Scheme + "://" + u.Host + u.Path
+}
+
+// ExtractOwnerFromRemoteURL extracts the owner component from a git remote URL.
+// Returns an empty string if the URL cannot be parsed.
+func ExtractOwnerFromRemoteURL(rawURL string) string {
+	info, err := ParseURL(rawURL)
+	if err != nil {
+		return ""
+	}
+	return info.Owner
+}
+
+// ResolveRemoteRepo returns the host, owner, and repo name for the given git remote.
+// It parses the remote URL (SSH or HTTPS) and extracts the components.
+// For example, git@github.com:org/my-repo.git returns ("github.com", "org", "my-repo").
+func ResolveRemoteRepo(ctx context.Context, remoteName string) (host, owner, repo string, err error) {
+	rawURL, err := GetRemoteURL(ctx, remoteName)
+	if err != nil {
+		return "", "", "", fmt.Errorf("get remote URL for %q: %w", remoteName, err)
+	}
+	info, err := ParseURL(rawURL)
+	if err != nil {
+		return "", "", "", fmt.Errorf("parse remote URL: %w", err)
+	}
+	return info.Host, info.Owner, info.Repo, nil
+}
+
+func splitOwnerRepo(path string) (string, string, error) {
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("cannot parse owner/repo from path: %s", path)
+	}
+	return parts[0], parts[1], nil
+}

--- a/cmd/entire/cli/gitremote/gitremote_test.go
+++ b/cmd/entire/cli/gitremote/gitremote_test.go
@@ -1,0 +1,187 @@
+package gitremote
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		url      string
+		wantInfo *Info
+		wantErr  bool
+	}{
+		{
+			name:     "SSH SCP format",
+			url:      "git@github.com:org/repo.git",
+			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:     "SSH SCP without .git",
+			url:      "git@github.com:org/repo",
+			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:     "HTTPS format",
+			url:      "https://github.com/org/repo.git",
+			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:     "HTTPS without .git",
+			url:      "https://github.com/org/repo",
+			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:     "SSH protocol format",
+			url:      "ssh://git@github.com/org/repo.git",
+			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:    "empty string",
+			url:     "",
+			wantErr: true,
+		},
+		{
+			name:    "no path",
+			url:     "https://github.com",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			info, err := ParseURL(tt.url)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantInfo.Protocol, info.Protocol)
+			assert.Equal(t, tt.wantInfo.Host, info.Host)
+			assert.Equal(t, tt.wantInfo.Owner, info.Owner)
+			assert.Equal(t, tt.wantInfo.Repo, info.Repo)
+		})
+	}
+}
+
+func TestExtractOwnerFromRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"SSH", "git@github.com:org/repo.git", "org"},
+		{"HTTPS", "https://github.com/org/repo.git", "org"},
+		{"invalid", "not-a-url", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ExtractOwnerFromRemoteURL(tt.url))
+		})
+	}
+}
+
+func TestRedactURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "HTTPS no creds",
+			url:  "https://github.com/org/repo.git",
+			want: "https://github.com/org/repo.git",
+		},
+		{
+			name: "HTTPS with token",
+			url:  "https://x-token:ghp_abc123@github.com/org/repo.git",
+			want: "https://github.com/org/repo.git",
+		},
+		{
+			name: "HTTPS with query token",
+			url:  "https://github.com/org/repo.git?token=secret",
+			want: "https://github.com/org/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, RedactURL(tt.url))
+		})
+	}
+}
+
+// Not parallel: uses t.Chdir()
+func TestResolveRemoteRepo(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		originURL string
+		wantHost  string
+		wantOwner string
+		wantRepo  string
+	}{
+		{
+			name:      "SSH SCP format",
+			originURL: "git@github.com:acme/my-app.git",
+			wantHost:  "github.com",
+			wantOwner: "acme",
+			wantRepo:  "my-app",
+		},
+		{
+			name:      "HTTPS format",
+			originURL: "https://github.com/acme/my-app.git",
+			wantHost:  "github.com",
+			wantOwner: "acme",
+			wantRepo:  "my-app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			testutil.InitRepo(t, repoDir)
+
+			cmd := exec.CommandContext(ctx, "git", "remote", "add", "origin", tt.originURL)
+			cmd.Dir = repoDir
+			cmd.Env = testutil.GitIsolatedEnv()
+			require.NoError(t, cmd.Run())
+
+			t.Chdir(repoDir)
+
+			host, owner, repo, err := ResolveRemoteRepo(ctx, "origin")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHost, host)
+			assert.Equal(t, tt.wantOwner, owner)
+			assert.Equal(t, tt.wantRepo, repo)
+		})
+	}
+}
+
+// Not parallel: uses t.Chdir()
+func TestResolveRemoteRepo_MissingRemote(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	_, _, _, err := ResolveRemoteRepo(context.Background(), "origin")
+	assert.Error(t, err)
+}

--- a/cmd/entire/cli/gitremote/gitremote_test.go
+++ b/cmd/entire/cli/gitremote/gitremote_test.go
@@ -118,6 +118,11 @@ func TestRedactURL(t *testing.T) {
 			url:  "https://github.com/org/repo.git?token=secret",
 			want: "https://github.com/org/repo.git",
 		},
+		{
+			name: "SSH SCP-style returned as-is",
+			url:  "git@github.com:org/repo.git",
+			want: "git@github.com:org/repo.git",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -717,37 +718,42 @@ func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id
 	}
 
 	// Resolve checkpoint remote URL once; reuse for both fetch and error message.
-	checkpointURL, hasCheckpointRemote, resolveErr := strategy.ResolveCheckpointRemoteURL(ctx)
-	if resolveErr != nil {
+	hasCheckpointRemote, configuredErr := remote.Configured(ctx)
+	if configuredErr != nil {
 		logging.Warn(logCtx, "checkpoint_remote configured but could not resolve URL",
-			slog.String("error", resolveErr.Error()),
+			slog.String("error", configuredErr.Error()),
 		)
 	}
 
 	// Try checkpoint_remote first if configured and resolved (that's where checkpoints are stored)
-	if hasCheckpointRemote && resolveErr == nil {
-		if fetchErr := strategy.FetchMetadataBranch(ctx, checkpointURL); fetchErr == nil {
-			freshRepo, freshErr := openRepository(ctx)
-			if freshErr != nil {
-				logging.Debug(logCtx, "checkpoint remote: open repository failed after fetch",
-					slog.String("error", freshErr.Error()),
-				)
-			} else if metadataTree, treeErr := strategy.GetMetadataBranchTree(freshRepo); treeErr != nil {
-				logging.Debug(logCtx, "checkpoint remote: fetch succeeded but tree read failed",
-					slog.String("error", treeErr.Error()),
-				)
-			} else if metadata, err := tryReadCheckpointFromTree(ctx, metadataTree, freshRepo, checkpointID); err != nil {
-				logging.Debug(logCtx, "checkpoint remote: tree read succeeded but checkpoint metadata read failed",
-					slog.String("checkpoint_id", checkpointID.String()),
-					slog.String("error", err.Error()),
-				)
+	var checkpointURL string
+	var resolveErr error
+	if hasCheckpointRemote {
+		checkpointURL, resolveErr = remote.FetchURL(ctx)
+		if resolveErr == nil {
+			if fetchErr := strategy.FetchMetadataBranch(ctx, checkpointURL); fetchErr == nil {
+				freshRepo, freshErr := openRepository(ctx)
+				if freshErr != nil {
+					logging.Debug(logCtx, "checkpoint remote: open repository failed after fetch",
+						slog.String("error", freshErr.Error()),
+					)
+				} else if metadataTree, treeErr := strategy.GetMetadataBranchTree(freshRepo); treeErr != nil {
+					logging.Debug(logCtx, "checkpoint remote: fetch succeeded but tree read failed",
+						slog.String("error", treeErr.Error()),
+					)
+				} else if metadata, err := tryReadCheckpointFromTree(ctx, metadataTree, freshRepo, checkpointID); err != nil {
+					logging.Debug(logCtx, "checkpoint remote: tree read succeeded but checkpoint metadata read failed",
+						slog.String("checkpoint_id", checkpointID.String()),
+						slog.String("error", err.Error()),
+					)
+				} else {
+					return resumeSession(ctx, w, errW, metadata, false)
+				}
 			} else {
-				return resumeSession(ctx, w, errW, metadata, false)
+				logging.Debug(logCtx, "checkpoint remote fetch failed",
+					slog.String("error", fetchErr.Error()),
+				)
 			}
-		} else {
-			logging.Debug(logCtx, "checkpoint remote fetch failed",
-				slog.String("error", fetchErr.Error()),
-			)
 		}
 	}
 
@@ -907,7 +913,14 @@ func resumeSingleSession(ctx context.Context, w, errW io.Writer, ag agent.Agent,
 	if settings.IsCheckpointsV2Enabled(ctx) {
 		repo, repoErr := openRepository(ctx)
 		if repoErr == nil {
-			v2Store := checkpoint.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
+			v2URL, fetchRemoteErr := remote.FetchURL(ctx)
+			if fetchRemoteErr != nil {
+				logging.Debug(ctx, "resume: using origin for v2 session log fetch remote",
+					slog.String("error", fetchRemoteErr.Error()),
+				)
+				v2URL = "origin"
+			}
+			v2Store := checkpoint.NewV2GitStore(repo, v2URL)
 			var v2Err error
 			logContent, _, v2Err = v2Store.GetSessionLog(ctx, checkpointID)
 			if v2Err != nil {

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -718,12 +718,7 @@ func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id
 	}
 
 	// Resolve checkpoint remote URL once; reuse for both fetch and error message.
-	hasCheckpointRemote, configuredErr := remote.Configured(ctx)
-	if configuredErr != nil {
-		logging.Warn(logCtx, "checkpoint_remote configured but could not resolve URL",
-			slog.String("error", configuredErr.Error()),
-		)
-	}
+	hasCheckpointRemote := remote.Configured(ctx)
 
 	// Try checkpoint_remote first if configured and resolved (that's where checkpoints are stored)
 	var checkpointURL string
@@ -918,7 +913,7 @@ func resumeSingleSession(ctx context.Context, w, errW io.Writer, ag agent.Agent,
 				logging.Debug(ctx, "resume: using origin for v2 session log fetch remote",
 					slog.String("error", fetchRemoteErr.Error()),
 				)
-				v2URL = "origin"
+				v2URL = ""
 			}
 			v2Store := checkpoint.NewV2GitStore(repo, v2URL)
 			var v2Err error

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -109,21 +109,6 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 	return ps
 }
 
-// ResolveRemoteRepo returns the host, owner, and repo name for the given git remote.
-// It parses the remote URL (SSH or HTTPS) and extracts the components.
-// For example, git@github.com:org/my-repo.git returns ("github.com", "org", "my-repo").
-func ResolveRemoteRepo(ctx context.Context, remoteName string) (host, owner, repo string, err error) {
-	rawURL, err := remote.GetRemoteURL(ctx, remoteName)
-	if err != nil {
-		return "", "", "", fmt.Errorf("get remote URL for %q: %w", remoteName, err)
-	}
-	info, err := remote.ParseURL(rawURL)
-	if err != nil {
-		return "", "", "", fmt.Errorf("parse remote URL: %w", err)
-	}
-	return info.Host, info.Owner, info.Repo, nil
-}
-
 // FetchMetadataBranch fetches the metadata branch from the checkpoint remote URL
 // and updates the local branch. Unlike fetchMetadataBranchIfMissing, this always
 // fetches regardless of whether the branch exists locally (for resume scenarios

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -19,12 +18,6 @@ import (
 
 // checkpointRemoteFetchTimeout is the timeout for fetching branches from the checkpoint URL.
 const checkpointRemoteFetchTimeout = 30 * time.Second
-
-// Git remote protocol identifiers.
-const (
-	protocolSSH   = "ssh"
-	protocolHTTPS = "https"
-)
 
 // pushSettings holds the resolved push configuration from a single settings load.
 type pushSettings struct {
@@ -75,45 +68,16 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 	if config == nil {
 		return ps
 	}
-
-	// Get the push remote URL for protocol detection and fork detection
-	pushRemoteURL, err := getRemoteURL(ctx, pushRemoteName)
-	if err != nil {
-		logging.Debug(ctx, "checkpoint-remote: could not get push remote URL, skipping",
-			slog.String("remote", pushRemoteName),
-			slog.String("error", err.Error()),
-		)
-		return ps
-	}
-
-	pushInfo, err := parseGitRemoteURL(pushRemoteURL)
-	if err != nil {
-		logging.Warn(ctx, "checkpoint-remote: could not parse push remote URL",
-			slog.String("remote", pushRemoteName),
-			slog.String("error", err.Error()),
-		)
-		return ps
-	}
-
-	// Fork detection: don't push to a checkpoint repo owned by someone else.
-	// This is push-specific — reading (resume) skips this check.
-	checkpointOwner := config.Owner()
-	if pushInfo.owner != "" && checkpointOwner != "" && !strings.EqualFold(pushInfo.owner, checkpointOwner) {
-		logging.Debug(ctx, "checkpoint-remote: push remote owner differs from checkpoint remote owner, skipping (fork detected)",
-			slog.String("push_owner", pushInfo.owner),
-			slog.String("checkpoint_owner", checkpointOwner),
-		)
-		return ps
-	}
-
-	// Derive checkpoint URL using same protocol as push remote
-	checkpointURL, err := deriveCheckpointURLFromInfo(pushInfo, config)
+	checkpointURL, enabled, err := remote.PushURL(ctx, pushRemoteName)
 	if err != nil {
 		logging.Warn(ctx, "checkpoint-remote: could not derive URL from push remote",
 			slog.String("remote", pushRemoteName),
 			slog.String("repo", config.Repo),
 			slog.String("error", err.Error()),
 		)
+		return ps
+	}
+	if !enabled || checkpointURL == "" {
 		return ps
 	}
 
@@ -145,224 +109,19 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 	return ps
 }
 
-// ResolveCheckpointURL returns the checkpoint remote URL if configured, or empty string
-// if not configured or derivation fails. Uses the push remote's protocol for URL construction.
-func ResolveCheckpointURL(ctx context.Context, pushRemoteName string) string {
-	s, err := settings.Load(ctx)
-	if err != nil {
-		return ""
-	}
-	config := s.GetCheckpointRemote()
-	if config == nil {
-		return ""
-	}
-	pushRemoteURL, err := getRemoteURL(ctx, pushRemoteName)
-	if err != nil {
-		logging.Debug(ctx, "checkpoint-remote: could not get push remote URL for v2 resolution",
-			slog.String("remote", pushRemoteName),
-			slog.String("error", err.Error()),
-		)
-		return ""
-	}
-	url, err := deriveCheckpointURL(pushRemoteURL, config)
-	if err != nil {
-		logging.Debug(ctx, "checkpoint-remote: could not derive v2 checkpoint URL",
-			slog.String("repo", config.Repo),
-			slog.String("error", err.Error()),
-		)
-		return ""
-	}
-	return url
-}
-
 // ResolveRemoteRepo returns the host, owner, and repo name for the given git remote.
 // It parses the remote URL (SSH or HTTPS) and extracts the components.
 // For example, git@github.com:org/my-repo.git returns ("github.com", "org", "my-repo").
 func ResolveRemoteRepo(ctx context.Context, remoteName string) (host, owner, repo string, err error) {
-	rawURL, err := getRemoteURL(ctx, remoteName)
+	rawURL, err := remote.GetRemoteURL(ctx, remoteName)
 	if err != nil {
 		return "", "", "", fmt.Errorf("get remote URL for %q: %w", remoteName, err)
 	}
-	info, err := parseGitRemoteURL(rawURL)
+	info, err := remote.ParseURL(rawURL)
 	if err != nil {
 		return "", "", "", fmt.Errorf("parse remote URL: %w", err)
 	}
-	return info.host, info.owner, info.repo, nil
-}
-
-// OriginURL returns the configured URL for the origin remote.
-func OriginURL(ctx context.Context) (string, error) {
-	return getRemoteURL(ctx, "origin")
-}
-
-// gitRemoteInfo holds parsed components of a git remote URL.
-type gitRemoteInfo struct {
-	protocol string // "ssh" or "https"
-	host     string // e.g., "github.com"
-	owner    string // e.g., "org"
-	repo     string // e.g., "my-repo" (without .git)
-}
-
-// parseGitRemoteURL parses a git remote URL into its components.
-// Supports:
-//   - SSH SCP format: git@github.com:org/repo.git
-//   - HTTPS format: https://github.com/org/repo.git
-//   - SSH protocol format: ssh://git@github.com/org/repo.git
-func parseGitRemoteURL(rawURL string) (*gitRemoteInfo, error) {
-	rawURL = strings.TrimSpace(rawURL)
-
-	// SSH SCP format: git@github.com:org/repo.git
-	if strings.Contains(rawURL, ":") && !strings.Contains(rawURL, "://") {
-		// Split on the first ":"
-		parts := strings.SplitN(rawURL, ":", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid SSH URL: %s", RedactURL(rawURL))
-		}
-		hostPart := parts[0] // e.g., "git@github.com"
-		pathPart := parts[1] // e.g., "org/repo.git"
-
-		host := hostPart
-		if idx := strings.Index(host, "@"); idx >= 0 {
-			host = host[idx+1:]
-		}
-
-		owner, repo, err := splitOwnerRepo(pathPart)
-		if err != nil {
-			return nil, err
-		}
-
-		return &gitRemoteInfo{protocol: protocolSSH, host: host, owner: owner, repo: repo}, nil
-	}
-
-	// URL format: https://github.com/org/repo.git or ssh://git@github.com/org/repo.git
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid URL: %s", RedactURL(rawURL))
-	}
-
-	protocol := u.Scheme
-	if protocol == "" {
-		return nil, fmt.Errorf("no protocol in URL: %s", RedactURL(rawURL))
-	}
-	host := u.Hostname()
-
-	// Path is like /org/repo.git — trim leading slash
-	pathPart := strings.TrimPrefix(u.Path, "/")
-	owner, repo, err := splitOwnerRepo(pathPart)
-	if err != nil {
-		return nil, err
-	}
-
-	return &gitRemoteInfo{protocol: protocol, host: host, owner: owner, repo: repo}, nil
-}
-
-// splitOwnerRepo splits "org/repo.git" into owner and repo (without .git suffix).
-func splitOwnerRepo(path string) (string, string, error) {
-	path = strings.TrimSuffix(path, ".git")
-	parts := strings.SplitN(path, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("cannot parse owner/repo from path: %s", path)
-	}
-	return parts[0], parts[1], nil
-}
-
-// deriveCheckpointURL constructs a checkpoint remote URL using the same protocol
-// as the push remote. For example, if push remote uses SSH, the checkpoint URL
-// will also use SSH.
-func deriveCheckpointURL(pushRemoteURL string, config *settings.CheckpointRemoteConfig) (string, error) {
-	info, err := parseGitRemoteURL(pushRemoteURL)
-	if err != nil {
-		return "", fmt.Errorf("cannot parse push remote URL: %w", err)
-	}
-	return deriveCheckpointURLFromInfo(info, config)
-}
-
-// deriveCheckpointURLFromInfo constructs a checkpoint URL from already-parsed remote info.
-func deriveCheckpointURLFromInfo(info *gitRemoteInfo, config *settings.CheckpointRemoteConfig) (string, error) {
-	switch info.protocol {
-	case protocolSSH:
-		// SCP format: git@host:owner/repo.git
-		return fmt.Sprintf("git@%s:%s.git", info.host, config.Repo), nil
-	case protocolHTTPS:
-		return fmt.Sprintf("https://%s/%s.git", info.host, config.Repo), nil
-	default:
-		return "", fmt.Errorf("unsupported protocol %q in push remote", info.protocol)
-	}
-}
-
-// extractOwnerFromRemoteURL extracts the owner from a git remote URL.
-// Returns empty string if the URL cannot be parsed.
-func extractOwnerFromRemoteURL(rawURL string) string {
-	info, err := parseGitRemoteURL(rawURL)
-	if err != nil {
-		return ""
-	}
-	return info.owner
-}
-
-// getRemoteURL returns the URL configured for a git remote.
-func getRemoteURL(ctx context.Context, remoteName string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", remoteName)
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("remote %q not found", remoteName)
-	}
-	return strings.TrimSpace(string(output)), nil
-}
-
-// RedactURL removes credentials from a URL for safe logging.
-// Handles both HTTPS URLs with embedded credentials and general URLs.
-func RedactURL(rawURL string) string {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		// For non-URL formats (SSH SCP), just return the host portion
-		if idx := strings.Index(rawURL, "@"); idx >= 0 {
-			if colonIdx := strings.Index(rawURL[idx:], ":"); colonIdx >= 0 {
-				return rawURL[idx+1:idx+colonIdx] + ":***"
-			}
-		}
-		return "<unparseable>"
-	}
-	u.User = nil
-	u.RawQuery = ""
-	host := u.Host
-	path := u.Path
-	return u.Scheme + "://" + host + path
-}
-
-// ResolveCheckpointRemoteURL resolves the checkpoint remote URL from settings.
-// Returns (url, true, nil) if a checkpoint_remote is configured and resolved successfully,
-// ("", false, nil) if no checkpoint_remote is configured, or ("", true, err) if configured
-// but resolution failed (e.g., missing origin remote, unparseable URL).
-// Unlike resolvePushSettings, this skips fork detection (reading is always allowed)
-// and has no side effects (no fetching).
-func ResolveCheckpointRemoteURL(ctx context.Context) (string, bool, error) {
-	s, err := settings.Load(ctx)
-	if err != nil {
-		return "", false, nil //nolint:nilerr // settings load failure means "can't determine config" — treat as not configured
-	}
-
-	config := s.GetCheckpointRemote()
-	if config == nil {
-		return "", false, nil
-	}
-
-	remoteURL, err := getRemoteURL(ctx, "origin")
-	if err != nil {
-		return "", true, fmt.Errorf("could not get origin remote URL: %w", err)
-	}
-
-	remoteInfo, err := parseGitRemoteURL(remoteURL)
-	if err != nil {
-		return "", true, fmt.Errorf("could not parse origin remote URL: %w", err)
-	}
-
-	checkpointURL, err := deriveCheckpointURLFromInfo(remoteInfo, config)
-	if err != nil {
-		return "", true, fmt.Errorf("could not derive checkpoint URL: %w", err)
-	}
-
-	return checkpointURL, true, nil
+	return info.Host, info.Owner, info.Repo, nil
 }
 
 // FetchMetadataBranch fetches the metadata branch from the checkpoint remote URL
@@ -412,7 +171,7 @@ func fetchURLIntoTmpRef(ctx context.Context, remoteURL, srcRef, tmpRef, label st
 		return nil
 	}
 
-	redactedURL := RedactURL(remoteURL)
+	redactedURL := remote.RedactURL(remoteURL)
 	msg := strings.TrimSpace(strings.ReplaceAll(string(output), remoteURL, redactedURL))
 	if msg != "" {
 		return fmt.Errorf("fetch %s from %s failed: %s: %w", label, redactedURL, msg, fetchErr)

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -18,69 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseGitRemoteURL(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		url      string
-		wantInfo *remote.Info
-		wantErr  bool
-	}{
-		{
-			name:     "SSH SCP format",
-			url:      "git@github.com:org/repo.git",
-			wantInfo: &remote.Info{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
-		},
-		{
-			name:     "SSH SCP without .git",
-			url:      "git@github.com:org/repo",
-			wantInfo: &remote.Info{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
-		},
-		{
-			name:     "HTTPS format",
-			url:      "https://github.com/org/repo.git",
-			wantInfo: &remote.Info{Protocol: remote.ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
-		},
-		{
-			name:     "HTTPS without .git",
-			url:      "https://github.com/org/repo",
-			wantInfo: &remote.Info{Protocol: remote.ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
-		},
-		{
-			name:     "SSH protocol format",
-			url:      "ssh://git@github.com/org/repo.git",
-			wantInfo: &remote.Info{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
-		},
-		{
-			name:    "empty string",
-			url:     "",
-			wantErr: true,
-		},
-		{
-			name:    "no path",
-			url:     "https://github.com",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			info, err := remote.ParseURL(tt.url)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantInfo.Protocol, info.Protocol)
-			assert.Equal(t, tt.wantInfo.Host, info.Host)
-			assert.Equal(t, tt.wantInfo.Owner, info.Owner)
-			assert.Equal(t, tt.wantInfo.Repo, info.Repo)
-		})
-	}
-}
-
 func TestDeriveCheckpointURL(t *testing.T) {
 	t.Parallel()
 
@@ -134,60 +71,6 @@ func TestDeriveCheckpointURL(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestExtractOwnerFromRemoteURL(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		url  string
-		want string
-	}{
-		{"SSH", "git@github.com:org/repo.git", "org"},
-		{"HTTPS", "https://github.com/org/repo.git", "org"},
-		{"invalid", "not-a-url", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, remote.ExtractOwnerFromRemoteURL(tt.url))
-		})
-	}
-}
-
-func TestRedactURL(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		url  string
-		want string
-	}{
-		{
-			name: "HTTPS no creds",
-			url:  "https://github.com/org/repo.git",
-			want: "https://github.com/org/repo.git",
-		},
-		{
-			name: "HTTPS with token",
-			url:  "https://x-token:ghp_abc123@github.com/org/repo.git",
-			want: "https://github.com/org/repo.git",
-		},
-		{
-			name: "HTTPS with query token",
-			url:  "https://github.com/org/repo.git?token=secret",
-			want: "https://github.com/org/repo.git",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, remote.RedactURL(tt.url))
 		})
 	}
 }

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -23,33 +24,33 @@ func TestParseGitRemoteURL(t *testing.T) {
 	tests := []struct {
 		name     string
 		url      string
-		wantInfo *gitRemoteInfo
+		wantInfo *remote.RemoteInfo
 		wantErr  bool
 	}{
 		{
 			name:     "SSH SCP format",
 			url:      "git@github.com:org/repo.git",
-			wantInfo: &gitRemoteInfo{protocol: protocolSSH, host: "github.com", owner: "org", repo: "repo"},
+			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "SSH SCP without .git",
 			url:      "git@github.com:org/repo",
-			wantInfo: &gitRemoteInfo{protocol: protocolSSH, host: "github.com", owner: "org", repo: "repo"},
+			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "HTTPS format",
 			url:      "https://github.com/org/repo.git",
-			wantInfo: &gitRemoteInfo{protocol: protocolHTTPS, host: "github.com", owner: "org", repo: "repo"},
+			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "HTTPS without .git",
 			url:      "https://github.com/org/repo",
-			wantInfo: &gitRemoteInfo{protocol: protocolHTTPS, host: "github.com", owner: "org", repo: "repo"},
+			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "SSH protocol format",
 			url:      "ssh://git@github.com/org/repo.git",
-			wantInfo: &gitRemoteInfo{protocol: protocolSSH, host: "github.com", owner: "org", repo: "repo"},
+			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:    "empty string",
@@ -66,16 +67,16 @@ func TestParseGitRemoteURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			info, err := parseGitRemoteURL(tt.url)
+			info, err := remote.ParseURL(tt.url)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantInfo.protocol, info.protocol)
-			assert.Equal(t, tt.wantInfo.host, info.host)
-			assert.Equal(t, tt.wantInfo.owner, info.owner)
-			assert.Equal(t, tt.wantInfo.repo, info.repo)
+			assert.Equal(t, tt.wantInfo.Protocol, info.Protocol)
+			assert.Equal(t, tt.wantInfo.Host, info.Host)
+			assert.Equal(t, tt.wantInfo.Owner, info.Owner)
+			assert.Equal(t, tt.wantInfo.Repo, info.Repo)
 		})
 	}
 }
@@ -126,7 +127,7 @@ func TestDeriveCheckpointURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			config := &settings.CheckpointRemoteConfig{Provider: "github", Repo: tt.checkpointRepo}
-			got, err := deriveCheckpointURL(tt.pushRemoteURL, config)
+			got, err := remote.DeriveCheckpointURL(tt.pushRemoteURL, config)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -153,7 +154,7 @@ func TestExtractOwnerFromRemoteURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, extractOwnerFromRemoteURL(tt.url))
+			assert.Equal(t, tt.want, remote.ExtractOwnerFromRemoteURL(tt.url))
 		})
 	}
 }
@@ -186,7 +187,7 @@ func TestRedactURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, RedactURL(tt.url))
+			assert.Equal(t, tt.want, remote.RedactURL(tt.url))
 		})
 	}
 }
@@ -475,7 +476,7 @@ func TestResolvePushSettings_ForkDetection(t *testing.T) {
 	testutil.GitAdd(t, localDir, "f.txt")
 	testutil.GitCommit(t, localDir, "init")
 
-	// Origin is a fork (different owner)
+	// Origin remote owner differs from the configured checkpoint remote owner.
 	cmd := exec.CommandContext(ctx, "git", "remote", "add", "origin", "git@github.com:alice/main-repo.git")
 	cmd.Dir = localDir
 	cmd.Env = testutil.GitIsolatedEnv()
@@ -492,7 +493,7 @@ func TestResolvePushSettings_ForkDetection(t *testing.T) {
 	t.Chdir(localDir)
 
 	ps := resolvePushSettings(ctx, "origin")
-	// Should fall back to origin since fork detected (alice != org)
+	// Should fall back to origin since the remote owner differs (alice != org).
 	assert.False(t, ps.hasCheckpointURL())
 	assert.Equal(t, "origin", ps.pushTarget())
 	assert.False(t, ps.pushDisabled)
@@ -557,7 +558,7 @@ func TestResolvePushSettings_LegacyStringConfigIgnored(t *testing.T) {
 }
 
 // Not parallel: uses t.Chdir()
-func TestResolveCheckpointRemoteURL_ReturnsURL(t *testing.T) {
+func TestFetchURL_ReturnsCheckpointRemoteURL(t *testing.T) {
 	ctx := context.Background()
 
 	localDir := t.TempDir()
@@ -581,14 +582,17 @@ func TestResolveCheckpointRemoteURL_ReturnsURL(t *testing.T) {
 
 	t.Chdir(localDir)
 
-	url, ok, err := ResolveCheckpointRemoteURL(ctx)
-	assert.True(t, ok)
+	configured, err := remote.Configured(ctx)
+	require.NoError(t, err)
+	assert.True(t, configured)
+
+	url, err := remote.FetchURL(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "git@github.com:org/checkpoints.git", url)
 }
 
 // Not parallel: uses t.Chdir()
-func TestResolveCheckpointRemoteURL_NoConfig(t *testing.T) {
+func TestConfigured_NoCheckpointRemote(t *testing.T) {
 	localDir := t.TempDir()
 	testutil.InitRepo(t, localDir)
 	testutil.WriteFile(t, localDir, "f.txt", "init")
@@ -605,17 +609,17 @@ func TestResolveCheckpointRemoteURL_NoConfig(t *testing.T) {
 
 	t.Chdir(localDir)
 
-	url, ok, err := ResolveCheckpointRemoteURL(t.Context())
-	assert.False(t, ok)
+	configured, err := remote.Configured(t.Context())
 	require.NoError(t, err)
-	assert.Empty(t, url)
+	assert.False(t, configured)
 }
 
 // Not parallel: uses t.Chdir()
-// This is the key correctness test: ResolveCheckpointRemoteURL must NOT apply fork
-// detection. A forked clone should still be able to read checkpoints from the upstream
-// checkpoint repo. Fork detection is only for push (resolvePushSettings).
-func TestResolveCheckpointRemoteURL_IgnoresForkDetection(t *testing.T) {
+// This is the key correctness test: FetchURL must NOT apply push-side owner
+// mismatch checks. A clone whose origin owner differs from the checkpoint repo
+// owner should still be able to read checkpoints. That owner check is only for
+// push (resolvePushSettings).
+func TestFetchURL_IgnoresOwnerMismatchCheck(t *testing.T) {
 	ctx := context.Background()
 
 	localDir := t.TempDir()
@@ -624,7 +628,7 @@ func TestResolveCheckpointRemoteURL_IgnoresForkDetection(t *testing.T) {
 	testutil.GitAdd(t, localDir, "f.txt")
 	testutil.GitCommit(t, localDir, "init")
 
-	// Origin is a fork (alice != org)
+	// Origin remote owner differs from checkpoint remote owner (alice != org).
 	cmd := exec.CommandContext(ctx, "git", "remote", "add", "origin", "git@github.com:alice/main-repo.git")
 	cmd.Dir = localDir
 	cmd.Env = testutil.GitIsolatedEnv()
@@ -640,16 +644,19 @@ func TestResolveCheckpointRemoteURL_IgnoresForkDetection(t *testing.T) {
 
 	t.Chdir(localDir)
 
-	// resolvePushSettings would reject this (fork detected), but ResolveCheckpointRemoteURL
+	configured, err := remote.Configured(ctx)
+	require.NoError(t, err)
+	assert.True(t, configured)
+
+	// resolvePushSettings would reject this owner mismatch, but FetchURL
 	// must return the URL — reading checkpoints is always allowed.
-	url, ok, err := ResolveCheckpointRemoteURL(ctx)
-	assert.True(t, ok, "ResolveCheckpointRemoteURL should resolve even from forked clones")
+	url, err := remote.FetchURL(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "git@github.com:org/checkpoints.git", url)
 
 	// Contrast: push settings should reject the same config
 	ps := resolvePushSettings(ctx, "origin")
-	assert.False(t, ps.hasCheckpointURL(), "resolvePushSettings should reject forked origin")
+	assert.False(t, ps.hasCheckpointURL(), "resolvePushSettings should reject an origin with a different owner")
 }
 
 // Not parallel: uses t.Chdir()

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -24,33 +24,33 @@ func TestParseGitRemoteURL(t *testing.T) {
 	tests := []struct {
 		name     string
 		url      string
-		wantInfo *remote.RemoteInfo
+		wantInfo *remote.Info
 		wantErr  bool
 	}{
 		{
 			name:     "SSH SCP format",
 			url:      "git@github.com:org/repo.git",
-			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &remote.Info{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "SSH SCP without .git",
 			url:      "git@github.com:org/repo",
-			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &remote.Info{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "HTTPS format",
 			url:      "https://github.com/org/repo.git",
-			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &remote.Info{Protocol: remote.ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "HTTPS without .git",
 			url:      "https://github.com/org/repo",
-			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &remote.Info{Protocol: remote.ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "SSH protocol format",
 			url:      "ssh://git@github.com/org/repo.git",
-			wantInfo: &remote.RemoteInfo{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &remote.Info{Protocol: remote.ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:    "empty string",
@@ -582,8 +582,7 @@ func TestFetchURL_ReturnsCheckpointRemoteURL(t *testing.T) {
 
 	t.Chdir(localDir)
 
-	configured, err := remote.Configured(ctx)
-	require.NoError(t, err)
+	configured := remote.Configured(ctx)
 	assert.True(t, configured)
 
 	url, err := remote.FetchURL(ctx)
@@ -609,8 +608,7 @@ func TestConfigured_NoCheckpointRemote(t *testing.T) {
 
 	t.Chdir(localDir)
 
-	configured, err := remote.Configured(t.Context())
-	require.NoError(t, err)
+	configured := remote.Configured(t.Context())
 	assert.False(t, configured)
 }
 
@@ -644,8 +642,7 @@ func TestFetchURL_IgnoresOwnerMismatchCheck(t *testing.T) {
 
 	t.Chdir(localDir)
 
-	configured, err := remote.Configured(ctx)
-	require.NoError(t, err)
+	configured := remote.Configured(ctx)
 	assert.True(t, configured)
 
 	// resolvePushSettings would reject this owner mismatch, but FetchURL

--- a/cmd/entire/cli/strategy/checkpoint_token.go
+++ b/cmd/entire/cli/strategy/checkpoint_token.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
@@ -31,9 +32,10 @@ var sshTokenWarningOnce sync.Once
 // For empty/unset tokens, the command is returned unmodified.
 //
 // The target parameter is used ONLY for protocol detection (SSH vs HTTPS) and does
-// not affect the command executed. It can be:
+// not affect the command executed. It should match the effective transport target
+// used in args after any checkpoint remote resolution. It can be:
 //   - A URL (e.g., "https://github.com/org/repo.git")
-//   - A remote name (e.g., "origin") — resolved via `git remote get-url`
+//   - A remote name (e.g., "origin") when the command is actually using that name
 //
 // The actual remote must be specified again inside args, which contains the full
 // git command arguments (e.g., "push", "--no-verify", remote, branch).
@@ -54,12 +56,12 @@ func CheckpointGitCommand(ctx context.Context, target string, args ...string) *e
 	protocol := resolveTargetProtocol(ctx, target)
 
 	switch protocol {
-	case protocolSSH:
+	case remote.ProtocolSSH:
 		sshTokenWarningOnce.Do(func() {
 			fmt.Fprintf(os.Stderr, "[entire] Warning: %s is set but remote uses SSH — token ignored for SSH remotes\n", CheckpointTokenEnvVar)
 		})
 		return cmd
-	case protocolHTTPS:
+	case remote.ProtocolHTTPS:
 		cmd.Env = appendCheckpointTokenEnv(os.Environ(), token)
 		return cmd
 	default:
@@ -110,7 +112,7 @@ func isValidToken(token string) bool {
 }
 
 // resolveTargetProtocol determines whether a push/fetch target uses SSH or HTTPS.
-// Returns protocolSSH, protocolHTTPS, or "" if unknown.
+// Returns remote.ProtocolSSH, remote.ProtocolHTTPS, or "" if unknown.
 func resolveTargetProtocol(ctx context.Context, target string) string {
 	var rawURL string
 	if isURL(target) {
@@ -118,17 +120,17 @@ func resolveTargetProtocol(ctx context.Context, target string) string {
 	} else {
 		// Remote name — resolve to URL
 		var err error
-		rawURL, err = getRemoteURL(ctx, target)
+		rawURL, err = remote.GetRemoteURL(ctx, target)
 		if err != nil {
 			return ""
 		}
 	}
 
-	info, err := parseGitRemoteURL(rawURL)
+	info, err := remote.ParseURL(rawURL)
 	if err != nil {
 		return ""
 	}
-	return info.protocol
+	return info.Protocol
 }
 
 // ResolveFetchTarget returns the git fetch target to use. When filtered
@@ -138,7 +140,7 @@ func ResolveFetchTarget(ctx context.Context, target string) (string, error) {
 	if isURL(target) || !settings.IsFilteredFetchesEnabled(ctx) {
 		return target, nil
 	}
-	return getRemoteURL(ctx, target)
+	return remote.GetRemoteURL(ctx, target)
 }
 
 // AppendFetchFilterArgs appends the partial-clone filter arguments when the

--- a/cmd/entire/cli/strategy/checkpoint_token.go
+++ b/cmd/entire/cli/strategy/checkpoint_token.go
@@ -140,7 +140,11 @@ func ResolveFetchTarget(ctx context.Context, target string) (string, error) {
 	if isURL(target) || !settings.IsFilteredFetchesEnabled(ctx) {
 		return target, nil
 	}
-	return remote.GetRemoteURL(ctx, target)
+	url, err := remote.GetRemoteURL(ctx, target)
+	if err != nil {
+		return "", fmt.Errorf("get remote URL: %w", err)
+	}
+	return url, nil
 }
 
 // AppendFetchFilterArgs appends the partial-clone filter arguments when the

--- a/cmd/entire/cli/strategy/checkpoint_token_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_token_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 
 	"github.com/stretchr/testify/assert"
@@ -23,17 +24,17 @@ func TestResolveTargetProtocol(t *testing.T) {
 
 	t.Run("HTTPS URL", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, protocolHTTPS, resolveTargetProtocol(context.Background(), "https://github.com/org/repo.git"))
+		assert.Equal(t, remote.ProtocolHTTPS, resolveTargetProtocol(context.Background(), "https://github.com/org/repo.git"))
 	})
 
 	t.Run("SSH SCP URL", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, protocolSSH, resolveTargetProtocol(context.Background(), "git@github.com:org/repo.git"))
+		assert.Equal(t, remote.ProtocolSSH, resolveTargetProtocol(context.Background(), "git@github.com:org/repo.git"))
 	})
 
 	t.Run("SSH protocol URL", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, protocolSSH, resolveTargetProtocol(context.Background(), "ssh://git@github.com/org/repo.git"))
+		assert.Equal(t, remote.ProtocolSSH, resolveTargetProtocol(context.Background(), "ssh://git@github.com/org/repo.git"))
 	})
 
 	t.Run("local path returns empty", func(t *testing.T) {
@@ -64,7 +65,7 @@ func TestResolveTargetProtocol_RemoteName(t *testing.T) {
 
 	t.Chdir(tmpDir)
 
-	assert.Equal(t, protocolHTTPS, resolveTargetProtocol(ctx, "origin"))
+	assert.Equal(t, remote.ProtocolHTTPS, resolveTargetProtocol(ctx, "origin"))
 }
 
 // Not parallel: uses t.Chdir()
@@ -84,7 +85,7 @@ func TestResolveTargetProtocol_SSHRemoteName(t *testing.T) {
 
 	t.Chdir(tmpDir)
 
-	assert.Equal(t, protocolSSH, resolveTargetProtocol(ctx, "origin"))
+	assert.Equal(t, remote.ProtocolSSH, resolveTargetProtocol(ctx, "origin"))
 }
 
 // Not parallel: uses t.Chdir()

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -36,6 +36,8 @@ import (
 const (
 	branchMain   = "main"
 	branchMaster = "master"
+	// originRemote is the default git remote name used for fetch/push fallbacks.
+	originRemote = "origin"
 	// Strategy name constants
 	StrategyNameManualCommit = "manual-commit"
 )

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 )
 
@@ -79,7 +81,14 @@ func (s *ManualCommitStrategy) getV2CheckpointStore(ctx context.Context) (*check
 			s.v2CheckpointStoreErr = fmt.Errorf("failed to open repository: %w", err)
 			return
 		}
-		s.v2CheckpointStore = checkpoint.NewV2GitStore(repo, ResolveCheckpointURL(ctx, "origin"))
+		v2URL, err := remote.FetchURL(ctx)
+		if err != nil {
+			logging.Debug(ctx, "manual-commit: using origin for v2 store fetch remote",
+				"error", err.Error(),
+			)
+			v2URL = "origin"
+		}
+		s.v2CheckpointStore = checkpoint.NewV2GitStore(repo, v2URL)
 	})
 	return s.v2CheckpointStore, s.v2CheckpointStoreErr
 }

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -86,7 +86,6 @@ func (s *ManualCommitStrategy) getV2CheckpointStore(ctx context.Context) (*check
 			logging.Debug(ctx, "manual-commit: using origin for v2 store fetch remote",
 				"error", err.Error(),
 			)
-			v2URL = "origin"
 		}
 		s.v2CheckpointStore = checkpoint.NewV2GitStore(repo, v2URL)
 	})

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -21,6 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -1414,7 +1415,14 @@ func computeCompactTranscriptStart(ctx context.Context, ag agent.Agent, state *S
 // writeCommittedV2 writes checkpoint data to v2 refs unconditionally.
 // Callers decide whether to propagate or swallow the error (v2-only vs dual-write).
 func writeCommittedV2(ctx context.Context, repo *git.Repository, opts cpkg.WriteCommittedOptions) error {
-	v2Store := cpkg.NewV2GitStore(repo, ResolveCheckpointURL(ctx, "origin"))
+	v2URL, err := remote.FetchURL(ctx)
+	if err != nil {
+		logging.Debug(ctx, "manual-commit condensation: using origin for v2 write fetch remote",
+			slog.String("error", err.Error()),
+		)
+		v2URL = "origin"
+	}
+	v2Store := cpkg.NewV2GitStore(repo, v2URL)
 	if err := v2Store.WriteCommitted(ctx, opts); err != nil {
 		return fmt.Errorf("v2 write committed: %w", err)
 	}
@@ -1479,7 +1487,14 @@ func writeTaskMetadataV2IfEnabled(
 		return
 	}
 
-	v2Store := cpkg.NewV2GitStore(repo, ResolveCheckpointURL(ctx, "origin"))
+	v2URL, err := remote.FetchURL(ctx)
+	if err != nil {
+		logging.Debug(ctx, "manual-commit condensation: using origin for v2 task metadata fetch remote",
+			slog.String("error", err.Error()),
+		)
+		v2URL = "origin"
+	}
+	v2Store := cpkg.NewV2GitStore(repo, v2URL)
 	sessionIndex, err := resolveV2SessionIndexForCheckpoint(repo, checkpointID, sessionID)
 	if err != nil {
 		logging.Warn(ctx, "v2 dual-write task metadata copy skipped: failed to resolve session index",

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1420,7 +1420,7 @@ func writeCommittedV2(ctx context.Context, repo *git.Repository, opts cpkg.Write
 		logging.Debug(ctx, "manual-commit condensation: using origin for v2 write fetch remote",
 			slog.String("error", err.Error()),
 		)
-		v2URL = "origin"
+		v2URL = originRemote
 	}
 	v2Store := cpkg.NewV2GitStore(repo, v2URL)
 	if err := v2Store.WriteCommitted(ctx, opts); err != nil {
@@ -1492,7 +1492,7 @@ func writeTaskMetadataV2IfEnabled(
 		logging.Debug(ctx, "manual-commit condensation: using origin for v2 task metadata fetch remote",
 			slog.String("error", err.Error()),
 		)
-		v2URL = "origin"
+		v2URL = originRemote
 	}
 	v2Store := cpkg.NewV2GitStore(repo, v2URL)
 	sessionIndex, err := resolveV2SessionIndexForCheckpoint(repo, checkpointID, sessionID)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -2755,7 +2755,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 			logging.Debug(logCtx, "finalize: using origin for v2 store fetch remote",
 				slog.String("error", err.Error()),
 			)
-			v2URL = "origin"
+			v2URL = originRemote
 		}
 		v2Store = checkpoint.NewV2GitStore(repo, v2URL)
 	}

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/gitops"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -2749,7 +2750,14 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 	// Evaluate v2 flag once before the loop to avoid re-reading settings per checkpoint
 	var v2Store *checkpoint.V2GitStore
 	if settings.IsCheckpointsV2Enabled(logCtx) {
-		v2Store = checkpoint.NewV2GitStore(repo, ResolveCheckpointURL(logCtx, "origin"))
+		v2URL, err := remote.FetchURL(logCtx)
+		if err != nil {
+			logging.Debug(logCtx, "finalize: using origin for v2 store fetch remote",
+				slog.String("error", err.Error()),
+			)
+			v2URL = "origin"
+		}
+		v2Store = checkpoint.NewV2GitStore(repo, v2URL)
 	}
 
 	precomputed := precomputeTranscriptBlobsForFinalize(logCtx, repo, redactedTranscript, state)

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	remote "github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 
@@ -359,16 +360,16 @@ func ReconcileDisconnectedV2Ref(
 
 // lsRemoteRef runs git ls-remote and returns the hash for a specific ref.
 // Returns plumbing.ZeroHash if the ref doesn't exist on the remote.
-func lsRemoteRef(ctx context.Context, repoPath, remote, refName string) (plumbing.Hash, error) {
+func lsRemoteRef(ctx context.Context, repoPath, remoteName, refName string) (plumbing.Hash, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	fetchTarget, err := ResolveFetchTarget(ctx, remote)
+	fetchTarget, err := ResolveFetchTarget(ctx, remoteName)
 	if err != nil {
 		return plumbing.ZeroHash, fmt.Errorf("resolve fetch target for ls-remote: %w", err)
 	}
 
-	cmd := CheckpointGitCommand(ctx, remote, "ls-remote", fetchTarget, refName)
+	cmd := CheckpointGitCommand(ctx, fetchTarget, "ls-remote", fetchTarget, refName)
 	cmd.Dir = repoPath
 	if cmd.Env == nil {
 		cmd.Env = os.Environ()
@@ -376,7 +377,7 @@ func lsRemoteRef(ctx context.Context, repoPath, remote, refName string) (plumbin
 	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.Output()
 	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("git ls-remote %s failed: %w", RedactURL(remote), err)
+		return plumbing.ZeroHash, fmt.Errorf("git ls-remote %s failed: %w", remote.RedactURL(fetchTarget), err)
 	}
 
 	line := strings.TrimSpace(string(output))
@@ -393,18 +394,18 @@ func lsRemoteRef(ctx context.Context, repoPath, remote, refName string) (plumbin
 }
 
 // fetchRefToTemp fetches a remote ref to a temporary local ref for comparison.
-func fetchRefToTemp(ctx context.Context, repoPath, remote, srcRef, dstRef string) error {
+func fetchRefToTemp(ctx context.Context, repoPath, remoteName, srcRef, dstRef string) error {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	fetchTarget, err := ResolveFetchTarget(ctx, remote)
+	fetchTarget, err := ResolveFetchTarget(ctx, remoteName)
 	if err != nil {
 		return fmt.Errorf("resolve fetch target for doctor v2 fetch: %w", err)
 	}
 
 	refspec := fmt.Sprintf("+%s:%s", srcRef, dstRef)
 	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refspec})
-	cmd := CheckpointGitCommand(ctx, remote, fetchArgs...)
+	cmd := CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
 	cmd.Dir = repoPath
 	if cmd.Env == nil {
 		cmd.Env = os.Environ()
@@ -412,8 +413,8 @@ func fetchRefToTemp(ctx context.Context, repoPath, remote, srcRef, dstRef string
 	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		redactedURL := RedactURL(remote)
-		msg := strings.TrimSpace(strings.ReplaceAll(string(output), remote, redactedURL))
+		redactedURL := remote.RedactURL(fetchTarget)
+		msg := strings.TrimSpace(strings.ReplaceAll(string(output), fetchTarget, redactedURL))
 		if msg != "" {
 			return fmt.Errorf("git fetch %s failed: %s: %w", redactedURL, msg, err)
 		}

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -411,7 +412,14 @@ func pushV2Refs(ctx context.Context, target string) {
 	if err != nil {
 		return
 	}
-	store := checkpoint.NewV2GitStore(repo, ResolveCheckpointURL(ctx, "origin"))
+	v2URL, err := remote.FetchURL(ctx)
+	if err != nil {
+		logging.Debug(ctx, "push-v2: using origin for archived generation fetch remote",
+			slog.String("error", err.Error()),
+		)
+		v2URL = "origin"
+	}
+	store := checkpoint.NewV2GitStore(repo, v2URL)
 	archived, err := store.ListArchivedGenerations()
 	if err != nil || len(archived) == 0 {
 		return

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -417,7 +417,6 @@ func pushV2Refs(ctx context.Context, target string) {
 		logging.Debug(ctx, "push-v2: using origin for archived generation fetch remote",
 			slog.String("error", err.Error()),
 		)
-		v2URL = "origin"
 	}
 	store := checkpoint.NewV2GitStore(repo, v2URL)
 	archived, err := store.ListArchivedGenerations()

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
 	"github.com/entireio/cli/cmd/entire/cli/trail"
@@ -71,7 +72,7 @@ func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	host, owner, repo, err := strategy.ResolveRemoteRepo(ctx, "origin")
+	host, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve repository: %w", err)
 	}
@@ -134,7 +135,7 @@ func runTrailListAll(ctx context.Context, w io.Writer, statusFilter string, json
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	host, owner, repo, err := strategy.ResolveRemoteRepo(ctx, "origin")
+	host, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve repository: %w", err)
 	}
@@ -321,7 +322,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	host, owner, repoName, err := strategy.ResolveRemoteRepo(ctx, "origin")
+	host, owner, repoName, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve repository: %w", err)
 	}
@@ -408,7 +409,7 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, s
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	host, owner, repoName, err := strategy.ResolveRemoteRepo(ctx, "origin")
+	host, owner, repoName, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve repository: %w", err)
 	}


### PR DESCRIPTION
The primary goal of this PR is to consolidate the handling of URLs so the newly introduced `remote` package becomes the single source of truth for it. Additionally, this PR also consolidates the handling of `ENTIRE_CHECKPOINT_TOKEN`, which is now clarified in `README.md`.

### Changes
- Introduces checkpoint/remote helpers (`FetchURL`, `PushURL`, `Configured`, `URL` parsing/redaction) so fetch vs push rules live in one place; push still applies owner mismatch checks, fetch does not.
- Replaces removed `strategy.ResolveCheckpointURL` / `ResolveCheckpointRemoteURL` call sites across `doctor`, `explain`, `attach`, `resume`, `manual-commit`, `push` v2, and git operations.
- Improves `ENTIRE_CHECKPOINT_TOKEN` handling: can rewrite suitable origins to `HTTPS` and derive `HTTPS` checkpoint URLs when a token is set; documents that exotic or enterprise hosts may still need care.
- `resolveCheckpointFetchTarget` / blob-by-hash fetches use the effective URL from FetchURL when resolution succeeds (often a literal remote URL rather than the name origin).
- On `FetchURL` failure, v2 store paths fall back to the remote name "origin" with debug logging instead of failing silently with an empty target.
- metadata_reconcile passes the resolved fetch target into `CheckpointGitCommand` so protocol/token injection matches the URL actually used for `ls-remote` / `fetch`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how checkpoint fetch/push remotes are resolved and how `ENTIRE_CHECKPOINT_TOKEN` influences protocol selection, which can affect git authentication and remote targeting across multiple commands. Broad call-site refactors reduce duplication but increase risk of regressions in edge-case repo/remote configurations.
> 
> **Overview**
> Centralizes checkpoint remote URL logic into a new `checkpoint/remote` package (`FetchURL`, `PushURL`, `Configured`, URL parsing/redaction) and removes the older scattered resolution helpers from `strategy`.
> 
> Updates checkpoint fetch/push flows across the CLI (e.g., `attach`, `resume`, `explain`, `doctor`, v2 push, and metadata fetches) to use the new resolvers, with consistent fallback behavior (typically back to `origin`) and improved debug/warn logging when resolution fails.
> 
> Extends and documents `ENTIRE_CHECKPOINT_TOKEN` behavior: token presence can force HTTPS URL derivation (even when `origin` is SSH) for checkpoint operations, and token/protocol handling is aligned so `CheckpointGitCommand` uses the effective fetch target for proper auth injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9734071373fcefa7ab4bc0767baa9576f6ee1009. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->