### PR TITLE
Accept checkpoint ID or commit SHA as positional arg to explain

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -89,30 +89,31 @@ func newExplainCmd() *cobra.Command {
 	var searchAllFlag bool
 
 	cmd := &cobra.Command{
-		Use:   "explain",
+		Use:   "explain [checkpoint-id | commit-sha]",
 		Short: "Explain a session, commit, or checkpoint",
 		Long: `Explain provides human-readable context about sessions, commits, and checkpoints.
 
 Use this command to understand what happened during agent-driven development,
 either for self-review or to understand a teammate's work.
 
-By default, shows checkpoints on the current branch. Use flags to filter or
-explain specific items.
+By default, shows checkpoints on the current branch. Pass a checkpoint ID or
+commit SHA as a positional argument to explain a specific item, or use flags.
+
+Viewing specific items:
+  entire explain <id-or-sha>           Auto-detects checkpoint ID or commit SHA
+  entire explain --checkpoint <id>     Force interpretation as checkpoint ID
+  entire explain --commit <ref>        Force interpretation as commit ref
 
 Filtering the list view:
   --session      Filter checkpoints by session ID (or prefix)
 
-Viewing specific items:
-  --commit       Explain a specific commit (shows its associated checkpoint)
-  --checkpoint   Explain a specific checkpoint by ID
-
-Output verbosity levels (for --checkpoint):
+Output verbosity levels (when explaining a specific item):
   Default:         Detailed view with scoped prompts (ID, session, tokens, intent, prompts, files)
   --short          Summary only (ID, session, timestamp, tokens, intent)
   --full           Parsed full transcript (all prompts/responses from entire session)
   --raw-transcript Raw transcript file (JSONL format)
 
-Summary generation (for --checkpoint):
+Summary generation:
   --generate    Generate an AI summary for the checkpoint
   --force       Regenerate even if a summary already exists (requires --generate)
 
@@ -124,14 +125,9 @@ Checkpoint detail view shows:
   - Associated git commits that reference the checkpoint
   - Prompts and responses from the session
 
-Note: --session filters the list view; --commit and --checkpoint are mutually exclusive.`,
-		Args: func(_ *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unexpected argument %q\nHint: use --checkpoint, --session, or --commit to specify what to explain", args[0])
-			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
+Note: --session filters the list view; the positional arg, --commit, and --checkpoint are mutually exclusive.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// Check if Entire is disabled
 			if checkDisabledGuard(cmd.Context(), cmd.OutOrStdout()) {
 				return nil
@@ -146,20 +142,31 @@ Note: --session filters the list view; --commit and --checkpoint are mutually ex
 				}
 			}
 
-			// Validate flag dependencies
-			if generateFlag && checkpointFlag == "" {
-				return errors.New("--generate requires --checkpoint/-c flag")
+			// Positional arg is mutually exclusive with --checkpoint, --commit, --session
+			var positional string
+			if len(args) > 0 {
+				positional = args[0]
+				if checkpointFlag != "" || commitFlag != "" || sessionFlag != "" {
+					return errors.New("cannot combine positional argument with --checkpoint, --commit, or --session")
+				}
+			}
+
+			// Validate flag dependencies. --generate/--raw-transcript need a specific
+			// checkpoint target, which can come from the positional arg or --checkpoint.
+			hasCheckpointTarget := checkpointFlag != "" || positional != ""
+			if generateFlag && !hasCheckpointTarget {
+				return errors.New("--generate requires a checkpoint ID (positional) or --checkpoint/-c flag")
 			}
 			if forceFlag && !generateFlag {
 				return errors.New("--force requires --generate flag")
 			}
-			if rawTranscriptFlag && checkpointFlag == "" {
-				return errors.New("--raw-transcript requires --checkpoint/-c flag")
+			if rawTranscriptFlag && !hasCheckpointTarget {
+				return errors.New("--raw-transcript requires a checkpoint ID (positional) or --checkpoint/-c flag")
 			}
 
 			// Convert short flag to verbose (verbose = !short)
 			verbose := !shortFlag
-			return runExplain(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), sessionFlag, commitFlag, checkpointFlag, noPagerFlag, verbose, fullFlag, rawTranscriptFlag, generateFlag, forceFlag, searchAllFlag)
+			return runExplain(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), sessionFlag, commitFlag, checkpointFlag, positional, noPagerFlag, verbose, fullFlag, rawTranscriptFlag, generateFlag, forceFlag, searchAllFlag)
 		},
 	}
 
@@ -182,8 +189,9 @@ Note: --session filters the list view; --commit and --checkpoint are mutually ex
 	return cmd
 }
 
-// runExplain routes to the appropriate explain function based on flags.
-func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, checkpointID string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
+// runExplain routes to the appropriate explain function based on flags and the
+// optional positional target.
+func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, checkpointID, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
 	// Count mutually exclusive flags (--commit and --checkpoint are mutually exclusive)
 	// --session is now a filter for the list view, not a separate mode
 	flagCount := 0
@@ -202,6 +210,9 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 	}
 
 	// Route to appropriate handler
+	if target != "" {
+		return runExplainAuto(ctx, w, errW, target, noPager, verbose, full, rawTranscript, generate, force, searchAll)
+	}
 	if commitRef != "" {
 		return runExplainCommit(ctx, w, commitRef, noPager, verbose, full, searchAll)
 	}
@@ -211,6 +222,50 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 
 	// Default or with session filter: show list view (optionally filtered by session)
 	return runExplainBranchWithFilter(ctx, w, noPager, sessionID)
+}
+
+// runExplainAuto resolves a target string as either a checkpoint ID (or prefix)
+// or a git commit ref, then delegates to the checkpoint detail view.
+//
+// Resolution order:
+//  1. Try the checkpoint path (committed checkpoints, then shadow-branch temporary
+//     checkpoints). This preserves short-prefix matching for checkpoint IDs.
+//  2. If the target matched nothing, try to resolve it as a git commit ref and
+//     follow its Entire-Checkpoint trailer.
+//
+// Only "not found" errors from the checkpoint path trigger the fallback; other
+// errors (ambiguous prefix, read failure) bubble up unchanged.
+func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
+	checkpointErr := runExplainCheckpoint(ctx, w, errW, target, noPager, verbose, full, rawTranscript, generate, force, searchAll)
+	if checkpointErr == nil {
+		return nil
+	}
+	errStr := checkpointErr.Error()
+	if !strings.Contains(errStr, "checkpoint not found") &&
+		!strings.Contains(errStr, "cannot generate summary for temporary checkpoint") {
+		return checkpointErr
+	}
+
+	repo, repoErr := openRepository(ctx)
+	if repoErr != nil {
+		return checkpointErr
+	}
+	hash, resolveErr := repo.ResolveRevision(plumbing.Revision(target))
+	if resolveErr != nil {
+		return fmt.Errorf("no checkpoint or commit found matching %q", target)
+	}
+	commit, commitErr := repo.CommitObject(*hash)
+	if commitErr != nil {
+		return fmt.Errorf("failed to get commit: %w", commitErr)
+	}
+	cpID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
+	if !hasCheckpoint {
+		fmt.Fprintln(w, "No associated Entire checkpoint")
+		fmt.Fprintf(w, "\nCommit %s does not have an Entire-Checkpoint trailer.\n", hash.String()[:7])
+		fmt.Fprintln(w, "This commit was not created during an Entire session, or the trailer was removed.")
+		return nil
+	}
+	return runExplainCheckpoint(ctx, w, errW, cpID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll)
 }
 
 // runExplainCheckpoint explains a specific checkpoint.

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -283,9 +283,9 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 
 	repo, repoErr := openRepository(ctx)
 	if repoErr != nil {
-		// Surface both errors so the user isn't misled by the stale
-		// "checkpoint not found" message when the real problem is repo access.
-		return errors.Join(checkpointErr, fmt.Errorf("failed to reopen repository for commit fallback: %w", repoErr))
+		// Composed message beats errors.Join here — the latter renders
+		// two lines (one per error) and users act on the first/stale one.
+		return fmt.Errorf("no checkpoint matched %q, and commit fallback failed: %w", target, repoErr)
 	}
 	hash, resolveErr := repo.ResolveRevision(plumbing.Revision(target))
 	if resolveErr != nil {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -35,6 +36,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -61,11 +63,98 @@ func generateOrRawLabel(generate bool) string {
 }
 
 // printNoTrailerMessage renders the friendly message shown when a resolved
-// commit has no Entire-Checkpoint trailer in read-only modes.
-func printNoTrailerMessage(w io.Writer, shortSHA string) {
+// commit has no Entire-Checkpoint trailer in read-only modes. Takes the
+// repo so the hash can be abbreviated to the minimum unique length for
+// this repo's object set (matching git's --abbrev behavior).
+func printNoTrailerMessage(w io.Writer, repo *git.Repository, hash plumbing.Hash) {
 	fmt.Fprintln(w, "No associated Entire checkpoint")
-	fmt.Fprintf(w, "\nCommit %s does not have an Entire-Checkpoint trailer.\n", shortSHA)
+	fmt.Fprintf(w, "\nCommit %s does not have an Entire-Checkpoint trailer.\n", abbreviateCommitHash(repo, hash))
 	fmt.Fprintln(w, "This commit was not created during an Entire session, or the trailer was removed.")
+}
+
+// errAmbiguousCommitPrefix is returned by resolveCommitUnambiguous when a
+// hex prefix matches more than one commit. Callers use errors.Is to detect
+// this case and surface the full wrapped message verbatim.
+var errAmbiguousCommitPrefix = errors.New("ambiguous commit prefix")
+
+// commitHashesWithPrefix enumerates all commit hashes in the repo whose
+// SHA starts with the given hex prefix. Returns nil when the storer is not
+// a *filesystem.Storage or the prefix isn't decodable as hex.
+//
+// Per PR review (discussion_r3113804961): the reviewer specifically
+// suggested repo.Storer.(*filesystem.Storage).HashesWithPrefix followed by
+// commit filtering. Using this primitive both in resolution (detect
+// ambiguous user input) and in display (dynamically abbreviate shown
+// hashes to the minimum unique length).
+func commitHashesWithPrefix(repo *git.Repository, prefix string) []plumbing.Hash {
+	s, ok := repo.Storer.(*filesystem.Storage)
+	if !ok {
+		return nil
+	}
+	evenHex := prefix[:len(prefix)&^1]
+	decoded, err := hex.DecodeString(evenHex)
+	if err != nil || len(decoded) == 0 {
+		return nil
+	}
+	candidates, err := s.HashesWithPrefix(decoded)
+	if err != nil {
+		return nil
+	}
+	var commits []plumbing.Hash
+	for _, h := range candidates {
+		// HashesWithPrefix matches on even byte boundaries; filter the
+		// dangling nybble for odd-length prefixes.
+		if len(evenHex) != len(prefix) && !strings.HasPrefix(h.String(), prefix) {
+			continue
+		}
+		if _, err := repo.CommitObject(h); err != nil {
+			continue
+		}
+		commits = append(commits, h)
+	}
+	return commits
+}
+
+// resolveCommitUnambiguous resolves a ref to a commit hash, returning
+// errAmbiguousCommitPrefix (wrapped) when a hex-prefix input matches more
+// than one commit. go-git v6's ResolveRevision silently picks the first
+// candidate in ambiguous cases (its source explicitly says "for speed
+// purposes don't bother to detect the ambiguity"), which could pick the
+// wrong commit. Non-hex refs (HEAD, branch names, HEAD~1) bypass the
+// ambiguity check via commitHashesWithPrefix returning nil.
+func resolveCommitUnambiguous(repo *git.Repository, ref string) (plumbing.Hash, error) {
+	hash, err := repo.ResolveRevision(plumbing.Revision(ref))
+	if err != nil {
+		return plumbing.ZeroHash, err //nolint:wrapcheck // caller contextualizes
+	}
+	matches := commitHashesWithPrefix(repo, ref)
+	if len(matches) <= 1 {
+		return *hash, nil
+	}
+	examples := make([]string, 0, 5)
+	for i := 0; i < len(matches) && i < 5; i++ {
+		examples = append(examples, abbreviateCommitHash(repo, matches[i]))
+	}
+	return plumbing.ZeroHash, fmt.Errorf("%w %q matches %d commits: %s\nUse a longer prefix or a full SHA", errAmbiguousCommitPrefix, ref, len(matches), strings.Join(examples, ", "))
+}
+
+// abbreviateCommitHash returns the shortest prefix of hash unique among
+// commit objects in the repo, matching git's --abbrev-commit auto-growth
+// so displayed short SHAs stay unambiguous as the repo grows. Falls back
+// to a fixed 12-char prefix if the storer doesn't support fast prefix
+// lookup, or to the full hash if somehow never unique.
+func abbreviateCommitHash(repo *git.Repository, hash plumbing.Hash) string {
+	full := hash.String()
+	for length := 7; length < len(full); length++ {
+		matches := commitHashesWithPrefix(repo, full[:length])
+		if matches == nil {
+			return full[:12]
+		}
+		if len(matches) <= 1 {
+			return full[:length]
+		}
+	}
+	return full
 }
 
 // interaction holds a single prompt and its responses for display.
@@ -287,30 +376,33 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 		// two lines (one per error) and users act on the first/stale one.
 		return fmt.Errorf("no checkpoint matched %q, and commit fallback failed: %w", target, repoErr)
 	}
-	hash, resolveErr := repo.ResolveRevision(plumbing.Revision(target))
+	hash, resolveErr := resolveCommitUnambiguous(repo, target)
 	if resolveErr != nil {
+		if errors.Is(resolveErr, errAmbiguousCommitPrefix) {
+			return resolveErr
+		}
 		logging.Debug(ctx, "explain auto: git ref resolution failed",
 			slog.String("target", target),
 			slog.String("error", resolveErr.Error()))
 		return fmt.Errorf("no checkpoint or commit found matching %q", target)
 	}
-	commit, commitErr := repo.CommitObject(*hash)
+	commit, commitErr := repo.CommitObject(hash)
 	if commitErr != nil {
-		return fmt.Errorf("failed to get commit %s: %w", hash.String()[:7], commitErr)
+		return fmt.Errorf("failed to get commit %s: %w", abbreviateCommitHash(repo, hash), commitErr)
 	}
 	cpID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
 	if !hasCheckpoint {
 		// Side-effect modes must error — silently succeeding would leave
 		// scripts unable to distinguish "done" from "didn't happen".
 		if generate || rawTranscript {
-			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), hash.String()[:7])
+			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), abbreviateCommitHash(repo, hash))
 		}
-		printNoTrailerMessage(w, hash.String()[:7])
+		printNoTrailerMessage(w, repo, hash)
 		return nil
 	}
 	logging.Debug(ctx, "explain auto: resolved commit to checkpoint via trailer",
 		slog.String("target", target),
-		slog.String("commit", hash.String()[:7]),
+		slog.String("commit", abbreviateCommitHash(repo, hash)),
 		slog.String("checkpoint_id", cpID.String()))
 	return runExplainCheckpoint(ctx, w, errW, cpID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll)
 }
@@ -343,7 +435,7 @@ func runExplainAutoAmbiguityGuard(ctx context.Context, target string) error {
 	}
 	for _, info := range committed {
 		if strings.HasPrefix(info.CheckpointID.String(), target) {
-			return fmt.Errorf("ambiguous target %q with --generate: matches both git revision %s and checkpoint prefix (e.g. %s)\nUse --commit <ref> or --checkpoint <id> to disambiguate", target, hash.String()[:7], info.CheckpointID)
+			return fmt.Errorf("ambiguous target %q with --generate: matches both git revision %s and checkpoint prefix (e.g. %s)\nUse --commit <ref> or --checkpoint <id> to disambiguate", target, abbreviateCommitHash(repo, *hash), info.CheckpointID)
 		}
 	}
 	return nil
@@ -1739,13 +1831,17 @@ func runExplainCommit(ctx context.Context, w, errW io.Writer, commitRef string, 
 		return fmt.Errorf("not a git repository: %w", err)
 	}
 
-	// Resolve the commit reference
-	hash, err := repo.ResolveRevision(plumbing.Revision(commitRef))
+	// Resolve the commit reference, erroring on hex-prefix ambiguity
+	// instead of silently picking the first matching commit.
+	hash, err := resolveCommitUnambiguous(repo, commitRef)
 	if err != nil {
+		if errors.Is(err, errAmbiguousCommitPrefix) {
+			return err
+		}
 		return fmt.Errorf("commit not found: %s", commitRef)
 	}
 
-	commit, err := repo.CommitObject(*hash)
+	commit, err := repo.CommitObject(hash)
 	if err != nil {
 		return fmt.Errorf("failed to get commit: %w", err)
 	}
@@ -1756,9 +1852,9 @@ func runExplainCommit(ctx context.Context, w, errW io.Writer, commitRef string, 
 		// Side-effect modes must error so scripts can distinguish "done"
 		// from "didn't happen"; read-only modes print a friendly message.
 		if generate || rawTranscript {
-			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), hash.String()[:7])
+			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), abbreviateCommitHash(repo, hash))
 		}
-		printNoTrailerMessage(w, hash.String()[:7])
+		printNoTrailerMessage(w, repo, hash)
 		return nil
 	}
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -53,6 +53,14 @@ var generateTranscriptSummary = summarize.GenerateFromTranscript
 // to resolving the target as a git commit ref.
 var errCannotGenerateTemporaryCheckpoint = errors.New("cannot generate summary for temporary checkpoint")
 
+type explainCheckpointLookup struct {
+	repo                *git.Repository
+	v1Store             *checkpoint.GitStore
+	v2Store             *checkpoint.V2GitStore
+	preferCheckpointsV2 bool
+	committed           []checkpoint.CommittedInfo
+}
+
 // generateOrRawLabel returns the user-facing verb for the action the user
 // requested, used in error messages when a commit target has no trailer.
 func generateOrRawLabel(generate bool) string {
@@ -91,6 +99,7 @@ func commitHashesWithPrefix(repo *git.Repository, prefix string) []plumbing.Hash
 	if !ok {
 		return nil
 	}
+	// Truncate to even length for byte-aligned hex decoding.
 	evenHex := prefix[:len(prefix)&^1]
 	decoded, err := hex.DecodeString(evenHex)
 	if err != nil || len(decoded) == 0 {
@@ -135,7 +144,7 @@ func resolveCommitUnambiguous(repo *git.Repository, ref string) (plumbing.Hash, 
 	for i := 0; i < len(matches) && i < 5; i++ {
 		examples = append(examples, abbreviateCommitHash(repo, matches[i]))
 	}
-	return plumbing.ZeroHash, fmt.Errorf("%w %q matches %d commits: %s\nUse a longer prefix or a full SHA", errAmbiguousCommitPrefix, ref, len(matches), strings.Join(examples, ", "))
+	return plumbing.ZeroHash, fmt.Errorf("%w: %q matches %d commits: %s\nUse a longer prefix or a full SHA", errAmbiguousCommitPrefix, ref, len(matches), strings.Join(examples, ", "))
 }
 
 // abbreviateCommitHash returns the shortest prefix of hash unique among
@@ -349,12 +358,13 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 // an ambiguity pre-check to avoid writing a summary to the wrong
 // checkpoint on short-prefix collisions.
 func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
+	lookup, lookupErr := newExplainCheckpointLookup(ctx, nil)
 	if generate {
-		if err := runExplainAutoAmbiguityGuard(ctx, target); err != nil {
+		if err := runExplainAutoAmbiguityGuard(ctx, target, lookup, lookupErr); err != nil {
 			return err
 		}
 	}
-	checkpointErr := runExplainCheckpoint(ctx, w, errW, target, noPager, verbose, full, rawTranscript, generate, force, searchAll)
+	checkpointErr := runExplainCheckpointWithLookup(ctx, w, errW, target, noPager, verbose, full, rawTranscript, generate, force, searchAll, lookup, lookupErr)
 	if checkpointErr == nil {
 		return nil
 	}
@@ -370,13 +380,12 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 		slog.String("target", target),
 		slog.String("checkpoint_error", checkpointErr.Error()))
 
-	repo, repoErr := openRepository(ctx)
-	if repoErr != nil {
+	if lookupErr != nil {
 		// Composed message beats errors.Join here — the latter renders
 		// two lines (one per error) and users act on the first/stale one.
-		return fmt.Errorf("no checkpoint matched %q, and commit fallback failed: %w", target, repoErr)
+		return fmt.Errorf("no checkpoint matched %q, and commit fallback failed: %w", target, lookupErr)
 	}
-	hash, resolveErr := resolveCommitUnambiguous(repo, target)
+	hash, resolveErr := resolveCommitUnambiguous(lookup.repo, target)
 	if resolveErr != nil {
 		if errors.Is(resolveErr, errAmbiguousCommitPrefix) {
 			return resolveErr
@@ -386,25 +395,25 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 			slog.String("error", resolveErr.Error()))
 		return fmt.Errorf("no checkpoint or commit found matching %q", target)
 	}
-	commit, commitErr := repo.CommitObject(hash)
+	commit, commitErr := lookup.repo.CommitObject(hash)
 	if commitErr != nil {
-		return fmt.Errorf("failed to get commit %s: %w", abbreviateCommitHash(repo, hash), commitErr)
+		return fmt.Errorf("failed to get commit %s: %w", abbreviateCommitHash(lookup.repo, hash), commitErr)
 	}
 	cpID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
 	if !hasCheckpoint {
 		// Side-effect modes must error — silently succeeding would leave
 		// scripts unable to distinguish "done" from "didn't happen".
 		if generate || rawTranscript {
-			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), abbreviateCommitHash(repo, hash))
+			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), abbreviateCommitHash(lookup.repo, hash))
 		}
-		printNoTrailerMessage(w, repo, hash)
+		printNoTrailerMessage(w, lookup.repo, hash)
 		return nil
 	}
 	logging.Debug(ctx, "explain auto: resolved commit to checkpoint via trailer",
 		slog.String("target", target),
-		slog.String("commit", abbreviateCommitHash(repo, hash)),
+		slog.String("commit", abbreviateCommitHash(lookup.repo, hash)),
 		slog.String("checkpoint_id", cpID.String()))
-	return runExplainCheckpoint(ctx, w, errW, cpID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll)
+	return runExplainCheckpointWithLookup(ctx, w, errW, cpID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll, lookup, nil)
 }
 
 // runExplainAutoAmbiguityGuard refuses --generate when the positional
@@ -414,28 +423,36 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 //
 // Best-effort: on repo/list failures we return nil so the main flow
 // surfaces the real error instead of double-reporting.
-func runExplainAutoAmbiguityGuard(ctx context.Context, target string) error {
+func runExplainAutoAmbiguityGuard(ctx context.Context, target string, lookup *explainCheckpointLookup, lookupErr error) error {
 	// Targets longer than a checkpoint ID can't prefix-match one.
+	// This is coupled to checkpoint IDs being fixed-width; longer targets
+	// cannot be prefixes of committed checkpoint IDs.
 	if len(target) > id.ShortIDLength {
 		return nil
 	}
-	repo, err := openRepository(ctx)
-	if err != nil {
-		return nil //nolint:nilerr // best-effort guard
+	if lookupErr != nil {
+		logging.Warn(ctx, "explain ambiguity guard degraded: failed to prepare checkpoint lookup",
+			"target", target,
+			"error", lookupErr)
+		return nil
 	}
-	hash, err := repo.ResolveRevision(plumbing.Revision(target))
+	hash, err := lookup.repo.ResolveRevision(plumbing.Revision(target))
 	if err != nil {
 		return nil //nolint:nilerr // target isn't a git ref
 	}
-	v1Store := checkpoint.NewGitStore(repo)
-	v2Store := checkpoint.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
-	committed, err := listCommittedForExplain(ctx, v1Store, v2Store, settings.IsCheckpointsV2Enabled(ctx))
-	if err != nil {
-		return nil //nolint:nilerr // best-effort guard
+	if lookup == nil {
+		logging.Warn(ctx, "explain ambiguity guard degraded: checkpoint lookup unavailable",
+			"target", target)
+		return nil
 	}
-	for _, info := range committed {
+	if lookup.committed == nil {
+		logging.Warn(ctx, "explain ambiguity guard degraded: committed checkpoint list unavailable",
+			"target", target)
+		return nil
+	}
+	for _, info := range lookup.committed {
 		if strings.HasPrefix(info.CheckpointID.String(), target) {
-			return fmt.Errorf("ambiguous target %q with --generate: matches both git revision %s and checkpoint prefix (e.g. %s)\nUse --commit <ref> or --checkpoint <id> to disambiguate", target, abbreviateCommitHash(repo, *hash), info.CheckpointID)
+			return fmt.Errorf("ambiguous target %q with --generate: matches both git revision %s and checkpoint prefix (e.g. %s)\nUse --commit <ref> or --checkpoint <id> to disambiguate", target, abbreviateCommitHash(lookup.repo, *hash), info.CheckpointID)
 		}
 	}
 	return nil
@@ -449,33 +466,25 @@ func runExplainAutoAmbiguityGuard(ctx context.Context, target string) error {
 // When rawTranscript is true, outputs only the raw transcript file (JSONL format).
 // When searchAll is true, searches all commits without branch/depth limits (used for finding associated commits).
 //
-//nolint:maintidx // Command handler intentionally coordinates multiple checkpoint lookup/fetch paths.
+
 func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPrefix string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
-	repo, err := openRepository(ctx)
-	if err != nil {
-		return fmt.Errorf("not a git repository: %w", err)
-	}
+	return runExplainCheckpointWithLookup(ctx, w, errW, checkpointIDPrefix, noPager, verbose, full, rawTranscript, generate, force, searchAll, nil, nil)
+}
 
-	v1Store := checkpoint.NewGitStore(repo)
-	v2URL, err := remote.FetchURL(ctx)
-	if err != nil {
-		logging.Debug(ctx, "explain: using origin for v2 store fetch remote",
-			slog.String("error", err.Error()),
-		)
-		v2URL = ""
-	}
-	v2Store := checkpoint.NewV2GitStore(repo, v2URL)
-	preferCheckpointsV2 := settings.IsCheckpointsV2Enabled(ctx)
-
-	// First, try to find in committed checkpoints by checkpoint ID prefix
-	committed, err := listCommittedForExplain(ctx, v1Store, v2Store, preferCheckpointsV2)
-	if err != nil {
-		return fmt.Errorf("failed to list checkpoints: %w", err)
+func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, checkpointIDPrefix string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool, lookup *explainCheckpointLookup, lookupErr error) error {
+	if lookup == nil {
+		var err error
+		lookup, err = newExplainCheckpointLookup(ctx, nil)
+		if err != nil {
+			return err
+		}
+	} else if lookupErr != nil {
+		return lookupErr
 	}
 
 	// Collect all matching checkpoint IDs to detect ambiguity
 	var matches []id.CheckpointID
-	for _, info := range committed {
+	for _, info := range lookup.committed {
 		if strings.HasPrefix(info.CheckpointID.String(), checkpointIDPrefix) {
 			matches = append(matches, info.CheckpointID)
 		}
@@ -491,7 +500,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 		if !anyFetched {
 			anyFetched = FetchMetadataFromCheckpointRemote(ctx) == nil
 		}
-		if preferCheckpointsV2 {
+		if lookup.preferCheckpointsV2 {
 			v2Fetched := FetchV2MainTreeOnly(ctx) == nil
 			if !v2Fetched {
 				v2Fetched = FetchV2MetadataFromCheckpointRemote(ctx) == nil
@@ -499,18 +508,9 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 			anyFetched = anyFetched || v2Fetched
 		}
 		if anyFetched {
-			if freshRepo, repoErr := openRepository(ctx); repoErr == nil {
-				repo = freshRepo
-				v1Store = checkpoint.NewGitStore(repo)
-				v2URL, err = remote.FetchURL(ctx)
-				if err != nil {
-					logging.Debug(ctx, "explain: using origin for refreshed v2 store fetch remote",
-						slog.String("error", err.Error()),
-					)
-					v2URL = ""
-				}
-				v2Store = checkpoint.NewV2GitStore(repo, v2URL)
-				if freshCommitted, listErr := listCommittedForExplain(ctx, v1Store, v2Store, preferCheckpointsV2); listErr == nil {
+			if freshLookup, freshErr := newExplainCheckpointLookup(ctx, nil); freshErr == nil {
+				lookup = freshLookup
+				if freshCommitted := lookup.committed; freshCommitted != nil {
 					for _, info := range freshCommitted {
 						if strings.HasPrefix(info.CheckpointID.String(), checkpointIDPrefix) {
 							matches = append(matches, info.CheckpointID)
@@ -536,7 +536,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 		// layer, so rawTranscript is always false when generate is true; the
 		// direct-to-w write path inside explainTemporaryCheckpoint is not
 		// reachable here and won't leak partial output on error.
-		output, found := explainTemporaryCheckpoint(ctx, w, repo, v1Store, checkpointIDPrefix, verbose, full, rawTranscript)
+		output, found := explainTemporaryCheckpoint(ctx, w, lookup.repo, lookup.v1Store, checkpointIDPrefix, verbose, full, rawTranscript)
 		if found {
 			if generate {
 				return fmt.Errorf("%w %s (only committed checkpoints supported)", errCannotGenerateTemporaryCheckpoint, checkpointIDPrefix)
@@ -561,7 +561,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 	}
 
 	// Resolve store and load checkpoint summary with v2 -> v1 fallback.
-	resolvedReader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, fullCheckpointID, v1Store, v2Store, preferCheckpointsV2)
+	resolvedReader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, fullCheckpointID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
 	if err != nil {
 		return fmt.Errorf("failed to read checkpoint: %w", err)
 	}
@@ -588,7 +588,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 
 	// Handle summary generation — uses raw transcript.
 	if generate {
-		if err := generateCheckpointSummary(ctx, w, errW, v1Store, v2Store, fullCheckpointID, summary, content, force); err != nil {
+		if err := generateCheckpointSummary(ctx, w, errW, lookup.v1Store, lookup.v2Store, fullCheckpointID, summary, content, force); err != nil {
 			return err
 		}
 		// Reload to get the updated summary. After generation we only need
@@ -605,7 +605,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 
 	// Handle raw transcript output
 	if rawTranscript {
-		rawLog, _, rawErr := checkpoint.ResolveRawSessionLogForCheckpoint(ctx, fullCheckpointID, v1Store, v2Store, preferCheckpointsV2)
+		rawLog, _, rawErr := checkpoint.ResolveRawSessionLogForCheckpoint(ctx, fullCheckpointID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
 		if rawErr != nil {
 			return fmt.Errorf("failed to read raw transcript: %w", rawErr)
 		}
@@ -620,7 +620,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 	}
 
 	// Find associated commits (git commits with matching Entire-Checkpoint trailer)
-	associatedCommits, _ := getAssociatedCommits(ctx, repo, fullCheckpointID, searchAll) //nolint:errcheck // Best-effort
+	associatedCommits, _ := getAssociatedCommits(ctx, lookup.repo, fullCheckpointID, searchAll) //nolint:errcheck // Best-effort
 
 	// Derive author from the first associated commit (the user who made the commit).
 	// Fall back to GetCheckpointAuthor (walks entire/checkpoints/v1) for checkpoints
@@ -632,13 +632,45 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 			Email: associatedCommits[0].Email,
 		}
 	} else {
-		author, _ = v1Store.GetCheckpointAuthor(ctx, fullCheckpointID) //nolint:errcheck // Author is optional
+		author, _ = lookup.v1Store.GetCheckpointAuthor(ctx, fullCheckpointID) //nolint:errcheck // Author is optional
 	}
 
 	// Format and output
 	output := formatCheckpointOutput(summary, content, fullCheckpointID, associatedCommits, author, verbose, full)
 	outputExplainContent(w, output, noPager)
 	return nil
+}
+
+func newExplainCheckpointLookup(ctx context.Context, repo *git.Repository) (*explainCheckpointLookup, error) {
+	if repo == nil {
+		var err error
+		repo, err = openRepository(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("not a git repository: %w", err)
+		}
+	}
+
+	v2URL, err := remote.FetchURL(ctx)
+	if err != nil {
+		logging.Debug(ctx, "explain: using origin for v2 store fetch remote",
+			slog.String("error", err.Error()),
+		)
+		v2URL = ""
+	}
+
+	lookup := &explainCheckpointLookup{
+		repo:                repo,
+		v1Store:             checkpoint.NewGitStore(repo),
+		v2Store:             checkpoint.NewV2GitStore(repo, v2URL),
+		preferCheckpointsV2: settings.IsCheckpointsV2Enabled(ctx),
+	}
+
+	committed, err := listCommittedForExplain(ctx, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list checkpoints: %w", err)
+	}
+	lookup.committed = committed
+	return lookup, nil
 }
 
 func listCommittedForExplain(ctx context.Context, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, preferCheckpointsV2 bool) ([]checkpoint.CommittedInfo, error) {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -253,28 +253,12 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 	return runExplainBranchWithFilter(ctx, w, noPager, sessionID)
 }
 
-// runExplainAuto resolves a target string as either a checkpoint ID (or prefix)
-// or a git commit ref, then delegates to the checkpoint detail view.
-//
-// Resolution order:
-//  1. When --generate is set, pre-check for ambiguity: if the target
-//     both resolves as a git revision AND prefix-matches a committed
-//     checkpoint, refuse rather than silently persist a summary onto a
-//     checkpoint the user may not have meant.
-//  2. Try the checkpoint path (committed checkpoints, then shadow-branch
-//     temporary checkpoints). This preserves short-prefix matching for
-//     checkpoint IDs.
-//  3. On checkpoint.ErrCheckpointNotFound, resolve the target as a git
-//     commit ref and follow its Entire-Checkpoint trailer.
-//
-// errCannotGenerateTemporaryCheckpoint (returned when --generate hits a
-// real temp checkpoint) does NOT trigger fallback — the commit path would
-// give a misleading "no trailer" error for the shadow-branch commit.
-//
-// When a resolved commit has no Entire-Checkpoint trailer, a friendly
-// message is printed and nil is returned for read-only modes; --generate
-// or --raw-transcript surfaces an error instead to avoid silently
-// succeeding without doing the requested work.
+// runExplainAuto resolves a positional target as either a checkpoint ID
+// (or prefix) or a git commit ref. Ordering: checkpoint path first (which
+// also handles shadow-branch temp checkpoints), falling back to commit
+// resolution only on checkpoint.ErrCheckpointNotFound. --generate runs
+// an ambiguity pre-check to avoid writing a summary to the wrong
+// checkpoint on short-prefix collisions.
 func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
 	if generate {
 		if err := runExplainAutoAmbiguityGuard(ctx, target); err != nil {
@@ -331,18 +315,15 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 	return runExplainCheckpoint(ctx, w, errW, cpID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll)
 }
 
-// runExplainAutoAmbiguityGuard refuses --generate when the positional target
-// is ambiguous between a git revision and a committed-checkpoint prefix.
-// Writing a summary via --generate mutates checkpoint state, so silently
-// picking one interpretation could persist AI content onto the wrong
-// checkpoint. Read-only flows tolerate the ambiguity by preferring the
-// checkpoint path.
+// runExplainAutoAmbiguityGuard refuses --generate when the positional
+// target resolves as both a git revision and a committed-checkpoint prefix.
+// Writing a summary to the wrong checkpoint is destructive; read-only flows
+// tolerate the same ambiguity by preferring the checkpoint path.
 //
-// Best-effort: on repo/list failures we return nil and let the main flow
-// surface the real error instead of double-reporting.
+// Best-effort: on repo/list failures we return nil so the main flow
+// surfaces the real error instead of double-reporting.
 func runExplainAutoAmbiguityGuard(ctx context.Context, target string) error {
-	// Targets longer than a checkpoint ID can't prefix-match one, so no
-	// collision is possible — skip the git walk.
+	// Targets longer than a checkpoint ID can't prefix-match one.
 	if len(target) > id.ShortIDLength {
 		return nil
 	}

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -45,6 +45,12 @@ var checkpointSummaryTimeout = defaultCheckpointSummaryTimeout
 
 var generateTranscriptSummary = summarize.GenerateFromTranscript
 
+// errCannotGenerateTemporaryCheckpoint is returned by runExplainCheckpoint when
+// --generate is requested for a target that does not match any committed
+// checkpoint. runExplainAuto uses errors.Is to detect this case and fall back
+// to resolving the target as a git commit ref.
+var errCannotGenerateTemporaryCheckpoint = errors.New("cannot generate summary for temporary checkpoint")
+
 // interaction holds a single prompt and its responses for display.
 type interaction struct {
 	Prompt    string
@@ -126,7 +132,12 @@ Checkpoint detail view shows:
   - Prompts and responses from the session
 
 Note: --session filters the list view; the positional arg, --commit, and --checkpoint are mutually exclusive.`,
-		Args: cobra.MaximumNArgs(1),
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				return fmt.Errorf("accepts at most 1 argument (checkpoint ID or commit SHA), received %d\nHint: use --session to filter the list view, or pass a single checkpoint ID / commit SHA", len(args))
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Check if Entire is disabled
 			if checkDisabledGuard(cmd.Context(), cmd.OutOrStdout()) {
@@ -151,17 +162,17 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 				}
 			}
 
-			// Validate flag dependencies. --generate/--raw-transcript need a specific
-			// checkpoint target, which can come from the positional arg or --checkpoint.
+			// --generate and --raw-transcript need a specific target — either the
+			// positional arg (checkpoint ID or commit SHA) or --checkpoint/-c.
 			hasCheckpointTarget := checkpointFlag != "" || positional != ""
 			if generateFlag && !hasCheckpointTarget {
-				return errors.New("--generate requires a checkpoint ID (positional) or --checkpoint/-c flag")
+				return errors.New("--generate requires a checkpoint ID or commit SHA (positional) or --checkpoint/-c flag")
 			}
 			if forceFlag && !generateFlag {
 				return errors.New("--force requires --generate flag")
 			}
 			if rawTranscriptFlag && !hasCheckpointTarget {
-				return errors.New("--raw-transcript requires a checkpoint ID (positional) or --checkpoint/-c flag")
+				return errors.New("--raw-transcript requires a checkpoint ID or commit SHA (positional) or --checkpoint/-c flag")
 			}
 
 			// Convert short flag to verbose (verbose = !short)
@@ -230,33 +241,49 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 // Resolution order:
 //  1. Try the checkpoint path (committed checkpoints, then shadow-branch temporary
 //     checkpoints). This preserves short-prefix matching for checkpoint IDs.
-//  2. If the target matched nothing, try to resolve it as a git commit ref and
-//     follow its Entire-Checkpoint trailer.
+//  2. If the checkpoint path returned checkpoint.ErrCheckpointNotFound or
+//     errCannotGenerateTemporaryCheckpoint, resolve the target as a git commit
+//     ref and follow its Entire-Checkpoint trailer.
 //
-// Only "not found" errors from the checkpoint path trigger the fallback; other
-// errors (ambiguous prefix, read failure) bubble up unchanged.
+// Other errors (ambiguous prefix, read failure, IO) bubble up — they indicate
+// the target DID resolve to something but reading failed, so retrying as a
+// commit would hide the real problem.
+//
+// When the target resolves to a git commit that has no Entire-Checkpoint
+// trailer, a friendly message is printed and nil is returned. This matches
+// runExplainCommit and lets `entire explain <random-sha>` produce a useful
+// message instead of an error.
 func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
 	checkpointErr := runExplainCheckpoint(ctx, w, errW, target, noPager, verbose, full, rawTranscript, generate, force, searchAll)
 	if checkpointErr == nil {
 		return nil
 	}
-	errStr := checkpointErr.Error()
-	if !strings.Contains(errStr, "checkpoint not found") &&
-		!strings.Contains(errStr, "cannot generate summary for temporary checkpoint") {
+	// Only fall back on typed "not found" sentinels so error-message changes
+	// don't silently break routing.
+	if !errors.Is(checkpointErr, checkpoint.ErrCheckpointNotFound) &&
+		!errors.Is(checkpointErr, errCannotGenerateTemporaryCheckpoint) {
 		return checkpointErr
 	}
+	logging.Debug(ctx, "explain auto: checkpoint lookup failed, trying commit fallback",
+		slog.String("target", target),
+		slog.String("checkpoint_error", checkpointErr.Error()))
 
 	repo, repoErr := openRepository(ctx)
 	if repoErr != nil {
-		return checkpointErr
+		// Surface both errors so the user isn't misled by the stale
+		// "checkpoint not found" message when the real problem is repo access.
+		return errors.Join(checkpointErr, fmt.Errorf("failed to reopen repository for commit fallback: %w", repoErr))
 	}
 	hash, resolveErr := repo.ResolveRevision(plumbing.Revision(target))
 	if resolveErr != nil {
+		logging.Debug(ctx, "explain auto: git ref resolution failed",
+			slog.String("target", target),
+			slog.String("error", resolveErr.Error()))
 		return fmt.Errorf("no checkpoint or commit found matching %q", target)
 	}
 	commit, commitErr := repo.CommitObject(*hash)
 	if commitErr != nil {
-		return fmt.Errorf("failed to get commit: %w", commitErr)
+		return fmt.Errorf("failed to get commit %s: %w", hash.String()[:7], commitErr)
 	}
 	cpID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
 	if !hasCheckpoint {
@@ -265,6 +292,10 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 		fmt.Fprintln(w, "This commit was not created during an Entire session, or the trailer was removed.")
 		return nil
 	}
+	logging.Debug(ctx, "explain auto: resolved commit to checkpoint via trailer",
+		slog.String("target", target),
+		slog.String("commit", hash.String()[:7]),
+		slog.String("checkpoint_id", cpID.String()))
 	return runExplainCheckpoint(ctx, w, errW, cpID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll)
 }
 
@@ -353,7 +384,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 	case 0:
 		// Not found in committed, try temporary checkpoints by git SHA
 		if generate {
-			return fmt.Errorf("cannot generate summary for temporary checkpoint %s (only committed checkpoints supported)", checkpointIDPrefix)
+			return fmt.Errorf("%w %s (only committed checkpoints supported)", errCannotGenerateTemporaryCheckpoint, checkpointIDPrefix)
 		}
 		output, found := explainTemporaryCheckpoint(ctx, w, repo, v1Store, checkpointIDPrefix, verbose, full, rawTranscript)
 		if found {
@@ -364,7 +395,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 		if output != "" {
 			return errors.New(output)
 		}
-		return fmt.Errorf("checkpoint not found: %s", checkpointIDPrefix)
+		return fmt.Errorf("checkpoint not found: %s: %w", checkpointIDPrefix, checkpoint.ErrCheckpointNotFound)
 	case 1:
 		fullCheckpointID = matches[0]
 	default:

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -51,6 +51,15 @@ var generateTranscriptSummary = summarize.GenerateFromTranscript
 // to resolving the target as a git commit ref.
 var errCannotGenerateTemporaryCheckpoint = errors.New("cannot generate summary for temporary checkpoint")
 
+// generateOrRawLabel returns the user-facing verb for the action the user
+// requested, used in error messages when a commit target has no trailer.
+func generateOrRawLabel(generate bool) string {
+	if generate {
+		return "generate summary"
+	}
+	return "show raw transcript"
+}
+
 // interaction holds a single prompt and its responses for display.
 type interaction struct {
 	Prompt    string
@@ -287,6 +296,13 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 	}
 	cpID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
 	if !hasCheckpoint {
+		// --generate/--raw-transcript explicitly ask for checkpoint work. If
+		// the resolved commit has no trailer there is nothing to generate
+		// against, so error instead of silently succeeding (which would leave
+		// scripts unable to distinguish "done" from "didn't happen").
+		if generate || rawTranscript {
+			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), hash.String()[:7])
+		}
 		fmt.Fprintln(w, "No associated Entire checkpoint")
 		fmt.Fprintf(w, "\nCommit %s does not have an Entire-Checkpoint trailer.\n", hash.String()[:7])
 		fmt.Fprintln(w, "This commit was not created during an Entire session, or the trailer was removed.")
@@ -395,7 +411,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 		if output != "" {
 			return errors.New(output)
 		}
-		return fmt.Errorf("checkpoint not found: %s: %w", checkpointIDPrefix, checkpoint.ErrCheckpointNotFound)
+		return fmt.Errorf("%w: %s", checkpoint.ErrCheckpointNotFound, checkpointIDPrefix)
 	case 1:
 		fullCheckpointID = matches[0]
 	default:

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -172,16 +172,17 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 			}
 
 			// --generate and --raw-transcript need a specific target — either the
-			// positional arg (checkpoint ID or commit SHA) or --checkpoint/-c.
-			hasCheckpointTarget := checkpointFlag != "" || positional != ""
+			// positional arg, --checkpoint/-c, or --commit (which forwards to
+			// the checkpoint path via the commit's Entire-Checkpoint trailer).
+			hasCheckpointTarget := checkpointFlag != "" || commitFlag != "" || positional != ""
 			if generateFlag && !hasCheckpointTarget {
-				return errors.New("--generate requires a checkpoint ID or commit SHA (positional) or --checkpoint/-c flag")
+				return errors.New("--generate requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
 			}
 			if forceFlag && !generateFlag {
 				return errors.New("--force requires --generate flag")
 			}
 			if rawTranscriptFlag && !hasCheckpointTarget {
-				return errors.New("--raw-transcript requires a checkpoint ID or commit SHA (positional) or --checkpoint/-c flag")
+				return errors.New("--raw-transcript requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
 			}
 
 			// Convert short flag to verbose (verbose = !short)
@@ -234,7 +235,7 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 		return runExplainAuto(ctx, w, errW, target, noPager, verbose, full, rawTranscript, generate, force, searchAll)
 	}
 	if commitRef != "" {
-		return runExplainCommit(ctx, w, commitRef, noPager, verbose, full, searchAll)
+		return runExplainCommit(ctx, w, errW, commitRef, noPager, verbose, full, rawTranscript, generate, force, searchAll)
 	}
 	if checkpointID != "" {
 		return runExplainCheckpoint(ctx, w, errW, checkpointID, noPager, verbose, full, rawTranscript, generate, force, searchAll)
@@ -248,29 +249,40 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 // or a git commit ref, then delegates to the checkpoint detail view.
 //
 // Resolution order:
-//  1. Try the checkpoint path (committed checkpoints, then shadow-branch temporary
-//     checkpoints). This preserves short-prefix matching for checkpoint IDs.
-//  2. If the checkpoint path returned checkpoint.ErrCheckpointNotFound or
-//     errCannotGenerateTemporaryCheckpoint, resolve the target as a git commit
-//     ref and follow its Entire-Checkpoint trailer.
+//  1. When --generate is set, pre-check for ambiguity: if the target
+//     both resolves as a git revision AND prefix-matches a committed
+//     checkpoint, refuse rather than silently persist a summary onto a
+//     checkpoint the user may not have meant.
+//  2. Try the checkpoint path (committed checkpoints, then shadow-branch
+//     temporary checkpoints). This preserves short-prefix matching for
+//     checkpoint IDs.
+//  3. On checkpoint.ErrCheckpointNotFound, resolve the target as a git
+//     commit ref and follow its Entire-Checkpoint trailer.
 //
-// Other errors (ambiguous prefix, read failure, IO) bubble up — they indicate
-// the target DID resolve to something but reading failed, so retrying as a
-// commit would hide the real problem.
+// errCannotGenerateTemporaryCheckpoint (returned when --generate hits a
+// real temp checkpoint) does NOT trigger fallback — the commit path would
+// give a misleading "no trailer" error for the shadow-branch commit.
 //
-// When the target resolves to a git commit that has no Entire-Checkpoint
-// trailer, a friendly message is printed and nil is returned. This matches
-// runExplainCommit and lets `entire explain <random-sha>` produce a useful
-// message instead of an error.
+// When a resolved commit has no Entire-Checkpoint trailer, a friendly
+// message is printed and nil is returned for read-only modes; --generate
+// or --raw-transcript surfaces an error instead to avoid silently
+// succeeding without doing the requested work.
 func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
+	if generate {
+		if err := runExplainAutoAmbiguityGuard(ctx, target); err != nil {
+			return err
+		}
+	}
 	checkpointErr := runExplainCheckpoint(ctx, w, errW, target, noPager, verbose, full, rawTranscript, generate, force, searchAll)
 	if checkpointErr == nil {
 		return nil
 	}
-	// Only fall back on typed "not found" sentinels so error-message changes
-	// don't silently break routing.
-	if !errors.Is(checkpointErr, checkpoint.ErrCheckpointNotFound) &&
-		!errors.Is(checkpointErr, errCannotGenerateTemporaryCheckpoint) {
+	// Fall back to commit resolution ONLY when nothing (committed or temp)
+	// matched the target. errCannotGenerateTemporaryCheckpoint signals that
+	// we DID match a temp checkpoint but --generate is unsupported for it;
+	// falling back to commit in that case would produce a misleading
+	// "no trailer" error for the shadow-branch commit.
+	if !errors.Is(checkpointErr, checkpoint.ErrCheckpointNotFound) {
 		return checkpointErr
 	}
 	logging.Debug(ctx, "explain auto: checkpoint lookup failed, trying commit fallback",
@@ -313,6 +325,47 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 		slog.String("commit", hash.String()[:7]),
 		slog.String("checkpoint_id", cpID.String()))
 	return runExplainCheckpoint(ctx, w, errW, cpID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll)
+}
+
+// runExplainAutoAmbiguityGuard refuses --generate when the positional target
+// is ambiguous between a git revision and a committed-checkpoint prefix.
+// Writing a summary via --generate mutates checkpoint state, so silently
+// picking one interpretation could persist AI content onto the wrong
+// checkpoint. Read-only flows tolerate the same ambiguity by preferring the
+// checkpoint interpretation; users who hit a collision there can re-run with
+// --commit or --checkpoint.
+//
+// The guard is best-effort: failures to open the repo or list checkpoints
+// return nil so normal error reporting downstream still produces useful
+// messages — this function's job is to detect a clear collision, not to
+// replace the main resolution flow.
+func runExplainAutoAmbiguityGuard(ctx context.Context, target string) error {
+	// The guard intentionally swallows errors on the "can't check" paths and
+	// returns nil so the main flow handles them. Downstream code (openRepo in
+	// runExplainCheckpoint, listCommittedForExplain call inside it, etc.) will
+	// produce the appropriate user-facing error. Returning those errors here
+	// would double-report and mask the real resolution path.
+	repo, err := openRepository(ctx)
+	if err != nil {
+		return nil //nolint:nilerr // intentional: best-effort guard, main flow handles repo errors
+	}
+	hash, gitErr := repo.ResolveRevision(plumbing.Revision(target))
+	if gitErr != nil {
+		return nil //nolint:nilerr // intentional: target isn't a git ref → no collision possible
+	}
+	v1Store := checkpoint.NewGitStore(repo)
+	v2Store := checkpoint.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
+	preferV2 := settings.IsCheckpointsV2Enabled(ctx)
+	committed, err := listCommittedForExplain(ctx, v1Store, v2Store, preferV2)
+	if err != nil {
+		return nil //nolint:nilerr // intentional: if we can't enumerate, main flow will surface the real failure
+	}
+	for _, info := range committed {
+		if strings.HasPrefix(info.CheckpointID.String(), target) {
+			return fmt.Errorf("ambiguous target %q with --generate: matches both git revision %s and checkpoint prefix (e.g. %s)\nUse --commit <ref> or --checkpoint <id> to disambiguate", target, hash.String()[:7], info.CheckpointID)
+		}
+	}
+	return nil
 }
 
 // runExplainCheckpoint explains a specific checkpoint.
@@ -398,12 +451,23 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 	var fullCheckpointID id.CheckpointID
 	switch len(matches) {
 	case 0:
-		// Not found in committed, try temporary checkpoints by git SHA
-		if generate {
-			return fmt.Errorf("%w %s (only committed checkpoints supported)", errCannotGenerateTemporaryCheckpoint, checkpointIDPrefix)
-		}
+		// Check temp checkpoints BEFORE returning errCannotGenerateTemporaryCheckpoint
+		// so runExplainAuto can distinguish:
+		//   - target matched a real temp checkpoint (sentinel returned, no fallback)
+		//   - target matched nothing (ErrCheckpointNotFound, safe to fall back to commit)
+		// Previously the --generate path bailed before checking temp checkpoints,
+		// which made runExplainAuto fall back to commit resolution for temp
+		// checkpoint SHAs and produce a misleading "no trailer" error.
+		//
+		// --generate and --raw-transcript are mutually exclusive at the flag
+		// layer, so rawTranscript is always false when generate is true; the
+		// direct-to-w write path inside explainTemporaryCheckpoint is not
+		// reachable here and won't leak partial output on error.
 		output, found := explainTemporaryCheckpoint(ctx, w, repo, v1Store, checkpointIDPrefix, verbose, full, rawTranscript)
 		if found {
+			if generate {
+				return fmt.Errorf("%w %s (only committed checkpoints supported)", errCannotGenerateTemporaryCheckpoint, checkpointIDPrefix)
+			}
 			outputExplainContent(w, output, noPager)
 			return nil
 		}
@@ -1688,7 +1752,7 @@ func outputExplainContent(w io.Writer, content string, noPager bool) {
 // runExplainCommit looks up the checkpoint associated with a commit.
 // Extracts the Entire-Checkpoint trailer and delegates to checkpoint detail view.
 // If no trailer found, shows a message indicating no associated checkpoint.
-func runExplainCommit(ctx context.Context, w io.Writer, commitRef string, noPager, verbose, full, searchAll bool) error {
+func runExplainCommit(ctx context.Context, w, errW io.Writer, commitRef string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
 	repo, err := openRepository(ctx)
 	if err != nil {
 		return fmt.Errorf("not a git repository: %w", err)
@@ -1708,15 +1772,22 @@ func runExplainCommit(ctx context.Context, w io.Writer, commitRef string, noPage
 	// Extract Entire-Checkpoint trailer
 	checkpointID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
 	if !hasCheckpoint {
+		// --generate/--raw-transcript explicitly ask for checkpoint work;
+		// silently succeeding would leave scripts unable to tell success
+		// from no-op. Match runExplainAuto's behavior for trailer-less
+		// commits in those modes.
+		if generate || rawTranscript {
+			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), hash.String()[:7])
+		}
 		fmt.Fprintln(w, "No associated Entire checkpoint")
 		fmt.Fprintf(w, "\nCommit %s does not have an Entire-Checkpoint trailer.\n", hash.String()[:7])
 		fmt.Fprintln(w, "This commit was not created during an Entire session, or the trailer was removed.")
 		return nil
 	}
 
-	// Delegate to checkpoint detail view
-	// Note: errW is only used for generate mode, but we pass w for safety
-	return runExplainCheckpoint(ctx, w, w, checkpointID.String(), noPager, verbose, full, false, false, false, searchAll)
+	// Delegate to checkpoint detail view, forwarding the full flag set so
+	// --generate / --raw-transcript / --force work via --commit as well.
+	return runExplainCheckpoint(ctx, w, errW, checkpointID.String(), noPager, verbose, full, rawTranscript, generate, force, searchAll)
 }
 
 // formatSessionInfo formats session information for display.

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -60,6 +60,14 @@ func generateOrRawLabel(generate bool) string {
 	return "show raw transcript"
 }
 
+// printNoTrailerMessage renders the friendly message shown when a resolved
+// commit has no Entire-Checkpoint trailer in read-only modes.
+func printNoTrailerMessage(w io.Writer, shortSHA string) {
+	fmt.Fprintln(w, "No associated Entire checkpoint")
+	fmt.Fprintf(w, "\nCommit %s does not have an Entire-Checkpoint trailer.\n", shortSHA)
+	fmt.Fprintln(w, "This commit was not created during an Entire session, or the trailer was removed.")
+}
+
 // interaction holds a single prompt and its responses for display.
 type interaction struct {
 	Prompt    string
@@ -308,16 +316,12 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 	}
 	cpID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
 	if !hasCheckpoint {
-		// --generate/--raw-transcript explicitly ask for checkpoint work. If
-		// the resolved commit has no trailer there is nothing to generate
-		// against, so error instead of silently succeeding (which would leave
-		// scripts unable to distinguish "done" from "didn't happen").
+		// Side-effect modes must error — silently succeeding would leave
+		// scripts unable to distinguish "done" from "didn't happen".
 		if generate || rawTranscript {
 			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), hash.String()[:7])
 		}
-		fmt.Fprintln(w, "No associated Entire checkpoint")
-		fmt.Fprintf(w, "\nCommit %s does not have an Entire-Checkpoint trailer.\n", hash.String()[:7])
-		fmt.Fprintln(w, "This commit was not created during an Entire session, or the trailer was removed.")
+		printNoTrailerMessage(w, hash.String()[:7])
 		return nil
 	}
 	logging.Debug(ctx, "explain auto: resolved commit to checkpoint via trailer",
@@ -331,34 +335,30 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 // is ambiguous between a git revision and a committed-checkpoint prefix.
 // Writing a summary via --generate mutates checkpoint state, so silently
 // picking one interpretation could persist AI content onto the wrong
-// checkpoint. Read-only flows tolerate the same ambiguity by preferring the
-// checkpoint interpretation; users who hit a collision there can re-run with
-// --commit or --checkpoint.
+// checkpoint. Read-only flows tolerate the ambiguity by preferring the
+// checkpoint path.
 //
-// The guard is best-effort: failures to open the repo or list checkpoints
-// return nil so normal error reporting downstream still produces useful
-// messages — this function's job is to detect a clear collision, not to
-// replace the main resolution flow.
+// Best-effort: on repo/list failures we return nil and let the main flow
+// surface the real error instead of double-reporting.
 func runExplainAutoAmbiguityGuard(ctx context.Context, target string) error {
-	// The guard intentionally swallows errors on the "can't check" paths and
-	// returns nil so the main flow handles them. Downstream code (openRepo in
-	// runExplainCheckpoint, listCommittedForExplain call inside it, etc.) will
-	// produce the appropriate user-facing error. Returning those errors here
-	// would double-report and mask the real resolution path.
+	// Targets longer than a checkpoint ID can't prefix-match one, so no
+	// collision is possible — skip the git walk.
+	if len(target) > id.ShortIDLength {
+		return nil
+	}
 	repo, err := openRepository(ctx)
 	if err != nil {
-		return nil //nolint:nilerr // intentional: best-effort guard, main flow handles repo errors
+		return nil //nolint:nilerr // best-effort guard
 	}
-	hash, gitErr := repo.ResolveRevision(plumbing.Revision(target))
-	if gitErr != nil {
-		return nil //nolint:nilerr // intentional: target isn't a git ref → no collision possible
+	hash, err := repo.ResolveRevision(plumbing.Revision(target))
+	if err != nil {
+		return nil //nolint:nilerr // target isn't a git ref
 	}
 	v1Store := checkpoint.NewGitStore(repo)
 	v2Store := checkpoint.NewV2GitStore(repo, strategy.ResolveCheckpointURL(ctx, "origin"))
-	preferV2 := settings.IsCheckpointsV2Enabled(ctx)
-	committed, err := listCommittedForExplain(ctx, v1Store, v2Store, preferV2)
+	committed, err := listCommittedForExplain(ctx, v1Store, v2Store, settings.IsCheckpointsV2Enabled(ctx))
 	if err != nil {
-		return nil //nolint:nilerr // intentional: if we can't enumerate, main flow will surface the real failure
+		return nil //nolint:nilerr // best-effort guard
 	}
 	for _, info := range committed {
 		if strings.HasPrefix(info.CheckpointID.String(), target) {
@@ -1772,16 +1772,12 @@ func runExplainCommit(ctx context.Context, w, errW io.Writer, commitRef string, 
 	// Extract Entire-Checkpoint trailer
 	checkpointID, hasCheckpoint := trailers.ParseCheckpoint(commit.Message)
 	if !hasCheckpoint {
-		// --generate/--raw-transcript explicitly ask for checkpoint work;
-		// silently succeeding would leave scripts unable to tell success
-		// from no-op. Match runExplainAuto's behavior for trailer-less
-		// commits in those modes.
+		// Side-effect modes must error so scripts can distinguish "done"
+		// from "didn't happen"; read-only modes print a friendly message.
 		if generate || rawTranscript {
 			return fmt.Errorf("cannot %s: commit %s has no Entire-Checkpoint trailer", generateOrRawLabel(generate), hash.String()[:7])
 		}
-		fmt.Fprintln(w, "No associated Entire checkpoint")
-		fmt.Fprintf(w, "\nCommit %s does not have an Entire-Checkpoint trailer.\n", hash.String()[:7])
-		fmt.Fprintln(w, "This commit was not created during an Entire session, or the trailer was removed.")
+		printNoTrailerMessage(w, hash.String()[:7])
 		return nil
 	}
 

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -33,8 +33,8 @@ import (
 func TestNewExplainCmd(t *testing.T) {
 	cmd := newExplainCmd()
 
-	if cmd.Use != "explain" {
-		t.Errorf("expected Use to be 'explain', got %s", cmd.Use)
+	if cmd.Name() != "explain" {
+		t.Errorf("expected command name to be 'explain', got %s", cmd.Name())
 	}
 
 	// Verify flags exist
@@ -202,14 +202,20 @@ func TestFormatCheckpointSummaryError_Unknown(t *testing.T) {
 	}
 }
 
-func TestExplainCmd_RejectsPositionalArgs(t *testing.T) {
+// TestExplainCmd_PositionalArgConflictsWithFlags verifies that combining a
+// positional target with --checkpoint, --commit, or --session is rejected.
+// A bare positional arg (without conflicting flags) is accepted and routed to
+// the auto-detection path; that routing is covered by runExplainAuto tests
+// elsewhere and does not need a cmd-level reject test.
+func TestExplainCmd_PositionalArgConflictsWithFlags(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string
 	}{
-		{"positional arg without flags", []string{"abc123"}},
-		{"positional arg with checkpoint flag", []string{"abc123", "--checkpoint", "def456"}},
-		{"positional arg after flags", []string{"--checkpoint", "def456", "abc123"}},
+		{"positional arg with --checkpoint", []string{"abc123", "--checkpoint", "def456"}},
+		{"positional arg with -c", []string{"abc123", "-c", "def456"}},
+		{"positional arg with --commit", []string{"abc123", "--commit", "HEAD"}},
+		{"positional arg with --session", []string{"abc123", "--session", "sess-1"}},
 	}
 
 	for _, tt := range tests {
@@ -222,15 +228,10 @@ func TestExplainCmd_RejectsPositionalArgs(t *testing.T) {
 
 			err := cmd.Execute()
 			if err == nil {
-				t.Fatalf("expected error for positional args, got nil")
+				t.Fatalf("expected error when combining positional arg with flags, got nil")
 			}
-
-			// Should show helpful error with hint
-			if !strings.Contains(err.Error(), "unexpected argument") {
-				t.Errorf("expected 'unexpected argument' error, got: %v", err)
-			}
-			if !strings.Contains(err.Error(), "Hint:") {
-				t.Errorf("expected hint in error message, got: %v", err)
+			if !strings.Contains(err.Error(), "cannot combine positional argument") {
+				t.Errorf("expected 'cannot combine positional argument' error, got: %v", err)
 			}
 		})
 	}
@@ -700,7 +701,7 @@ func TestExplainDefault_NoCheckpoints_ShowsHelpfulMessage(t *testing.T) {
 func TestExplainBothFlagsError(t *testing.T) {
 	// Test that providing both --session and --commit returns an error
 	var stdout, stderr bytes.Buffer
-	err := runExplain(context.Background(), &stdout, &stderr, "session-id", "commit-sha", "", false, false, false, false, false, false, false)
+	err := runExplain(context.Background(), &stdout, &stderr, "session-id", "commit-sha", "", "", false, false, false, false, false, false, false)
 
 	if err == nil {
 		t.Error("expected error when both flags provided, got nil")
@@ -1153,7 +1154,7 @@ func TestRunExplain_MutualExclusivityError(t *testing.T) {
 	var buf, errBuf bytes.Buffer
 
 	// Providing both --session and --checkpoint should error
-	err := runExplain(context.Background(), &buf, &errBuf, "session-id", "", "checkpoint-id", false, false, false, false, false, false, false)
+	err := runExplain(context.Background(), &buf, &errBuf, "session-id", "", "checkpoint-id", "", false, false, false, false, false, false, false)
 
 	if err == nil {
 		t.Error("expected error when multiple flags provided")
@@ -3509,7 +3510,7 @@ func TestRunExplain_SessionFlagFiltersListView(t *testing.T) {
 	// When session is specified alone, it should NOT error for mutual exclusivity
 	// It should route to the list view with a filter (which may fail for other reasons
 	// like not being in a git repo, but not for mutual exclusivity)
-	err := runExplain(context.Background(), &buf, &errBuf, "some-session", "", "", false, false, false, false, false, false, false)
+	err := runExplain(context.Background(), &buf, &errBuf, "some-session", "", "", "", false, false, false, false, false, false, false)
 
 	// Should NOT be a mutual exclusivity error
 	if err != nil && strings.Contains(err.Error(), "cannot specify multiple") {
@@ -3521,7 +3522,7 @@ func TestRunExplain_SessionWithCheckpointStillMutuallyExclusive(t *testing.T) {
 	// Test that --session with --checkpoint is still an error
 	var buf, errBuf bytes.Buffer
 
-	err := runExplain(context.Background(), &buf, &errBuf, "some-session", "", "some-checkpoint", false, false, false, false, false, false, false)
+	err := runExplain(context.Background(), &buf, &errBuf, "some-session", "", "some-checkpoint", "", false, false, false, false, false, false, false)
 
 	if err == nil {
 		t.Error("expected error when --session and --checkpoint both specified")
@@ -3535,7 +3536,7 @@ func TestRunExplain_SessionWithCommitStillMutuallyExclusive(t *testing.T) {
 	// Test that --session with --commit is still an error
 	var buf, errBuf bytes.Buffer
 
-	err := runExplain(context.Background(), &buf, &errBuf, "some-session", "some-commit", "", false, false, false, false, false, false, false)
+	err := runExplain(context.Background(), &buf, &errBuf, "some-session", "some-commit", "", "", false, false, false, false, false, false, false)
 
 	if err == nil {
 		t.Error("expected error when --session and --commit both specified")

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -362,6 +362,100 @@ func TestRunExplainCheckpoint_NotFoundSentinels(t *testing.T) {
 	}
 }
 
+// collidingShaPrefix creates commits until two share a 2-char SHA prefix
+// and returns that prefix. 2 chars is the smallest even-byte boundary
+// HashesWithPrefix uses, so a collision at this length reliably exercises
+// the ambiguity detection path without SHA mining.
+func collidingShaPrefix(t *testing.T, repo *git.Repository, tmpDir string) string {
+	t.Helper()
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	seen := make(map[string]int)
+	for i := range 300 {
+		testutil.WriteFile(t, tmpDir, "f.txt", fmt.Sprintf("content-%d", i))
+		_, err = wt.Add("f.txt")
+		require.NoError(t, err)
+		h, err := wt.Commit(fmt.Sprintf("commit %d", i), &git.CommitOptions{
+			Author: &object.Signature{Name: "Test", Email: "t@e.com", When: time.Now().Add(time.Duration(i) * time.Second)},
+		})
+		require.NoError(t, err)
+		p := h.String()[:2]
+		seen[p]++
+		if seen[p] >= 2 {
+			return p
+		}
+	}
+	t.Skip("could not produce colliding 2-char SHA prefix in 300 iterations")
+	return ""
+}
+
+// TestResolveCommitUnambiguous_MultipleCommitMatches verifies the reviewer-
+// flagged bug: go-git v6's ResolveRevision silently returns the first
+// candidate when a hex prefix matches multiple commits. With the helper
+// wrapping it, ambiguity must surface as errAmbiguousCommitPrefix.
+func TestResolveCommitUnambiguous_MultipleCommitMatches(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	testutil.InitRepo(t, tmpDir)
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+
+	prefix := collidingShaPrefix(t, repo, tmpDir)
+
+	_, err = resolveCommitUnambiguous(repo, prefix)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errAmbiguousCommitPrefix)
+	require.ErrorContains(t, err, prefix)
+}
+
+// TestResolveCommitUnambiguous_UniquePrefixSucceeds verifies a full SHA
+// resolves to the expected hash without triggering ambiguity detection.
+func TestResolveCommitUnambiguous_UniquePrefixSucceeds(t *testing.T) {
+	_, initial := runExplainAutoTestRepo(t)
+	repo, err := git.PlainOpen(".")
+	require.NoError(t, err)
+
+	got, err := resolveCommitUnambiguous(repo, initial.String())
+	require.NoError(t, err)
+	require.Equal(t, initial, got)
+}
+
+// TestAbbreviateCommitHash_GrowsOnCollision verifies the helper grows past
+// the default 7 chars when necessary — matching git's --abbrev auto-growth.
+// The same 2-char SHA collision we construct for resolution is enough to
+// force abbreviation beyond 2 chars (though in practice 7 still tends to
+// be unique for ~300 commits).
+func TestAbbreviateCommitHash_GrowsOnCollision(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	testutil.InitRepo(t, tmpDir)
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+
+	prefix := collidingShaPrefix(t, repo, tmpDir)
+
+	// Find a hash whose SHA starts with the colliding prefix.
+	hashes := commitHashesWithPrefix(repo, prefix)
+	require.GreaterOrEqual(t, len(hashes), 2)
+
+	abbrev := abbreviateCommitHash(repo, hashes[0])
+	require.True(t, strings.HasPrefix(hashes[0].String(), abbrev), "abbreviation must be a prefix of the full hash")
+	require.GreaterOrEqual(t, len(abbrev), 7, "abbreviation must be at least git's default of 7 chars")
+	require.LessOrEqual(t, len(abbrev), 40, "abbreviation cannot exceed full hash length")
+}
+
+// TestAbbreviateCommitHash_UsesSevenByDefault verifies the helper returns
+// the 7-char default when there's no collision, matching git's behavior.
+func TestAbbreviateCommitHash_UsesSevenByDefault(t *testing.T) {
+	_, initial := runExplainAutoTestRepo(t)
+	repo, err := git.PlainOpen(".")
+	require.NoError(t, err)
+
+	abbrev := abbreviateCommitHash(repo, initial)
+	require.Equal(t, initial.String()[:7], abbrev)
+}
+
 // TestRunExplainAuto_GenerateAmbiguousPrefixRefused guards the Codex finding
 // that a short positional arg matching both a committed-checkpoint prefix
 // and a git revision must not silently write a summary to the wrong

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -207,6 +207,7 @@ func TestFormatCheckpointSummaryError_Unknown(t *testing.T) {
 // The bare-positional happy path (auto-resolution to a checkpoint ID or commit
 // ref) is covered by the TestRunExplainAuto_* tests in this file.
 func TestExplainCmd_PositionalArgConflictsWithFlags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		args []string
@@ -219,6 +220,7 @@ func TestExplainCmd_PositionalArgConflictsWithFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			cmd := newExplainCmd()
 			var stdout, stderr bytes.Buffer
 			cmd.SetOut(&stdout)

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -36,6 +36,9 @@ func TestNewExplainCmd(t *testing.T) {
 	if cmd.Name() != "explain" {
 		t.Errorf("expected command name to be 'explain', got %s", cmd.Name())
 	}
+	if cmd.Use != "explain [checkpoint-id | commit-sha]" {
+		t.Errorf("expected Use %q, got %q", "explain [checkpoint-id | commit-sha]", cmd.Use)
+	}
 
 	// Verify flags exist
 	sessionFlag := cmd.Flags().Lookup("session")
@@ -360,6 +363,65 @@ func TestRunExplainCheckpoint_NotFoundSentinels(t *testing.T) {
 				"sentinel must not fire unless a real temp checkpoint was matched")
 		})
 	}
+}
+
+func writeTemporaryCheckpointForExplainTest(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	testutil.InitRepo(t, tmpDir)
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	testFile := filepath.Join(tmpDir, "temp.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("initial content"), 0o644))
+	_, err = wt.Add("temp.txt")
+	require.NoError(t, err)
+	initialCommit, err := wt.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	sessionID := "2026-01-27-temp-session"
+	metadataDir := filepath.Join(tmpDir, ".entire", "metadata", sessionID)
+	require.NoError(t, os.MkdirAll(metadataDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(metadataDir, paths.PromptFileName), []byte("temporary checkpoint prompt"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(metadataDir, "full.jsonl"), []byte(`{"type":"user","message":{"content":[{"type":"text","text":"temporary checkpoint"}]}}`+"\n"), 0o644))
+
+	require.NoError(t, os.WriteFile(testFile, []byte("updated content"), 0o644))
+
+	result, err := checkpoint.NewGitStore(repo).WriteTemporary(context.Background(), checkpoint.WriteTemporaryOptions{
+		SessionID:         sessionID,
+		BaseCommit:        initialCommit.String()[:7],
+		ModifiedFiles:     []string{"temp.txt"},
+		MetadataDir:       ".entire/metadata/" + sessionID,
+		MetadataDirAbs:    metadataDir,
+		CommitMessage:     "temporary checkpoint with code changes",
+		AuthorName:        "Test",
+		AuthorEmail:       "test@example.com",
+		IsFirstCheckpoint: false,
+	})
+	require.NoError(t, err)
+	require.False(t, result.Skipped)
+
+	return result.CommitHash.String()
+}
+
+func TestRunExplainAuto_GenerateTemporaryCheckpointDoesNotFallBackToCommit(t *testing.T) {
+	tempCheckpointSHA := writeTemporaryCheckpointForExplainTest(t)
+
+	var out, errOut bytes.Buffer
+	err := runExplainAuto(context.Background(), &out, &errOut, tempCheckpointSHA, true, false, false, false, true, false, false)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errCannotGenerateTemporaryCheckpoint)
+	require.NotErrorIs(t, err, checkpoint.ErrCheckpointNotFound)
+	require.NotContains(t, err.Error(), "no Entire-Checkpoint trailer")
 }
 
 // collidingShaPrefix creates commits until two share a 2-char SHA prefix

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -340,6 +340,49 @@ func TestRunExplainAuto_NoMatch(t *testing.T) {
 	require.ErrorContains(t, err, `no checkpoint or commit found matching "zzzzzz999999"`)
 }
 
+// TestRunExplainAuto_GenerateCommitWithoutTrailer guards against silently
+// dropping --generate when the resolved commit has no Entire-Checkpoint
+// trailer. The user explicitly asked to generate a summary; returning nil
+// (exit 0) would make scripts unable to distinguish success from no-op.
+func TestRunExplainAuto_GenerateCommitWithoutTrailer(t *testing.T) {
+	_, initialCommit := runExplainAutoTestRepo(t)
+
+	var out, errOut bytes.Buffer
+	// Note: args are (noPager, verbose, full, rawTranscript, generate, force, searchAll).
+	err := runExplainAuto(context.Background(), &out, &errOut, initialCommit.String(), true, false, false, false, true, false, false)
+
+	require.Error(t, err, "--generate on a commit without a trailer must surface as an error, not silently succeed")
+	require.ErrorContains(t, err, "cannot generate summary")
+	require.ErrorContains(t, err, initialCommit.String()[:7])
+}
+
+// TestRunExplainAuto_RawTranscriptCommitWithoutTrailer is the --raw-transcript
+// twin of the test above — same silent-success hazard, same fix.
+func TestRunExplainAuto_RawTranscriptCommitWithoutTrailer(t *testing.T) {
+	_, initialCommit := runExplainAutoTestRepo(t)
+
+	var out, errOut bytes.Buffer
+	err := runExplainAuto(context.Background(), &out, &errOut, initialCommit.String(), true, false, false, true, false, false, false)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cannot show raw transcript")
+	require.ErrorContains(t, err, initialCommit.String()[:7])
+}
+
+// TestRunExplainCheckpoint_NotFoundMessageNotDuplicated guards against the
+// "checkpoint not found: X: checkpoint not found" regression from wrapping
+// the sentinel with a format string that also spelled out its text.
+func TestRunExplainCheckpoint_NotFoundMessageNotDuplicated(t *testing.T) {
+	runExplainAutoTestRepo(t)
+
+	var out, errOut bytes.Buffer
+	err := runExplainCheckpoint(context.Background(), &out, &errOut, "abababababab", false, false, false, false, false, false, false)
+
+	require.Error(t, err)
+	require.Equal(t, 1, strings.Count(err.Error(), "checkpoint not found"),
+		"error phrase %q should appear once, got %q", "checkpoint not found", err.Error())
+}
+
 // TestRunExplainCheckpoint_WrapsSentinelNotFound guards the typed-error
 // contract runExplainAuto depends on: runExplainCheckpoint must return an
 // error matching checkpoint.ErrCheckpointNotFound via errors.Is when the

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -254,12 +254,12 @@ func runExplainAutoTestRepo(t *testing.T) (repo *git.Repository, initialCommit p
 	return opened, head.Hash()
 }
 
-// TestRunExplainAuto_ChecksPositionalCheckpointIDFirst verifies that a
-// checkpoint-ID-shaped positional arg routes through the checkpoint path.
-// When the checkpoint does not exist locally, the returned error must wrap
-// checkpoint.ErrCheckpointNotFound so runExplainAuto can detect it via
-// errors.Is rather than substring matching (PR #990 review feedback).
-func TestRunExplainAuto_ChecksPositionalCheckpointIDFirst(t *testing.T) {
+// TestRunExplainAuto_NoMatchReturnsCompositeError verifies that a target
+// that's neither a checkpoint ID/prefix nor a resolvable git ref returns
+// the composite "no checkpoint or commit found" error — proving the
+// checkpoint-first → commit-fallback routing chains correctly all the way
+// to the final error.
+func TestRunExplainAuto_NoMatchReturnsCompositeError(t *testing.T) {
 	runExplainAutoTestRepo(t)
 
 	var out, errOut bytes.Buffer
@@ -269,16 +269,15 @@ func TestRunExplainAuto_ChecksPositionalCheckpointIDFirst(t *testing.T) {
 	require.ErrorContains(t, err, `no checkpoint or commit found matching "abababababab"`)
 }
 
-// TestRunExplainAuto_CommitRefWithCheckpointTrailer verifies that a commit SHA
-// passed positionally falls through to commit resolution and delegates to the
-// checkpoint path with the ID from the Entire-Checkpoint trailer.
+// TestRunExplainAuto_CommitRefWithCheckpointTrailer verifies that a commit
+// SHA passed positionally falls through to commit resolution and delegates
+// to the checkpoint path with the ID from the Entire-Checkpoint trailer.
 func TestRunExplainAuto_CommitRefWithCheckpointTrailer(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()
 
 	cpID := id.MustCheckpointID("deadbeefcafe")
-	v1Store := checkpoint.NewGitStore(repo)
-	require.NoError(t, v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+	require.NoError(t, checkpoint.NewGitStore(repo).WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
 		CheckpointID: cpID,
 		SessionID:    "session-auto",
 		Strategy:     "manual-commit",
@@ -287,7 +286,6 @@ func TestRunExplainAuto_CommitRefWithCheckpointTrailer(t *testing.T) {
 		AuthorEmail:  "test@example.com",
 	}))
 
-	// Create a second commit whose message includes the checkpoint trailer.
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
 	tmpDir := wt.Filesystem.Root()
@@ -305,129 +303,76 @@ func TestRunExplainAuto_CommitRefWithCheckpointTrailer(t *testing.T) {
 	require.Contains(t, out.String(), cpID.String(), "expected checkpoint header resolved via trailer")
 }
 
-// TestRunExplainAuto_CommitRefWithoutTrailer verifies the silent-success path:
-// a valid git commit without an Entire-Checkpoint trailer prints the friendly
-// message and returns nil. This matches runExplainCommit's behavior.
-func TestRunExplainAuto_CommitRefWithoutTrailer(t *testing.T) {
-	_, initialCommit := runExplainAutoTestRepo(t)
+// TestRunExplainAuto_CommitWithoutTrailer covers the trailer-less commit
+// dispatch: read-only modes print a friendly message and exit 0, while
+// --generate / --raw-transcript must error so scripts can distinguish
+// "done" from "didn't happen" (Cursor Bugbot finding on PR #990).
+func TestRunExplainAuto_CommitWithoutTrailer(t *testing.T) {
+	_, initial := runExplainAutoTestRepo(t)
+	shortSHA := initial.String()[:7]
 
-	var out, errOut bytes.Buffer
-	err := runExplainAuto(context.Background(), &out, &errOut, initialCommit.String(), true, false, false, false, false, false, false)
-
-	require.NoError(t, err, "commit without trailer must not error")
-	output := out.String()
-	require.Contains(t, output, "No associated Entire checkpoint")
-	require.Contains(t, output, initialCommit.String()[:7])
-	require.Contains(t, output, "does not have an Entire-Checkpoint trailer")
+	tests := []struct {
+		name        string
+		rawTrans    bool
+		generate    bool
+		wantErr     bool
+		wantContain string // substring required in err (if wantErr) or out (if !wantErr)
+	}{
+		{"read-only prints friendly message", false, false, false, "No associated Entire checkpoint"},
+		{"--generate errors", false, true, true, "cannot generate summary"},
+		{"--raw-transcript errors", true, false, true, "cannot show raw transcript"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			err := runExplainAuto(context.Background(), &out, &errOut, initial.String(), true, false, false, tc.rawTrans, tc.generate, false, false)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantContain)
+				require.ErrorContains(t, err, shortSHA)
+			} else {
+				require.NoError(t, err)
+				require.Contains(t, out.String(), tc.wantContain)
+				require.Contains(t, out.String(), shortSHA)
+			}
+		})
+	}
 }
 
-// TestRunExplainAuto_NoMatch verifies that a target that is neither a
-// checkpoint ID nor a resolvable git ref returns the composite error.
-func TestRunExplainAuto_NoMatch(t *testing.T) {
+// TestRunExplainCheckpoint_NotFoundSentinels verifies the typed-error
+// contract runExplainAuto depends on: non-matching targets return an error
+// wrapping checkpoint.ErrCheckpointNotFound (for errors.Is detection),
+// regardless of --generate. The old code returned the temp-checkpoint
+// sentinel speculatively for --generate, breaking fallback routing.
+func TestRunExplainCheckpoint_NotFoundSentinels(t *testing.T) {
 	runExplainAutoTestRepo(t)
 
-	var out, errOut bytes.Buffer
-	err := runExplainAuto(context.Background(), &out, &errOut, "zzzzzz999999", false, false, false, false, false, false, false)
+	for _, generate := range []bool{false, true} {
+		t.Run(fmt.Sprintf("generate=%v", generate), func(t *testing.T) {
+			var out, errOut bytes.Buffer
+			err := runExplainCheckpoint(context.Background(), &out, &errOut, "abababababab", false, false, false, false, generate, false, false)
 
-	require.Error(t, err)
-	require.ErrorContains(t, err, `no checkpoint or commit found matching "zzzzzz999999"`)
-}
-
-// TestRunExplainAuto_GenerateCommitWithoutTrailer guards against silently
-// dropping --generate when the resolved commit has no Entire-Checkpoint
-// trailer. The user explicitly asked to generate a summary; returning nil
-// (exit 0) would make scripts unable to distinguish success from no-op.
-func TestRunExplainAuto_GenerateCommitWithoutTrailer(t *testing.T) {
-	_, initialCommit := runExplainAutoTestRepo(t)
-
-	var out, errOut bytes.Buffer
-	// Note: args are (noPager, verbose, full, rawTranscript, generate, force, searchAll).
-	err := runExplainAuto(context.Background(), &out, &errOut, initialCommit.String(), true, false, false, false, true, false, false)
-
-	require.Error(t, err, "--generate on a commit without a trailer must surface as an error, not silently succeed")
-	require.ErrorContains(t, err, "cannot generate summary")
-	require.ErrorContains(t, err, initialCommit.String()[:7])
-}
-
-// TestRunExplainAuto_RawTranscriptCommitWithoutTrailer is the --raw-transcript
-// twin of the test above — same silent-success hazard, same fix.
-func TestRunExplainAuto_RawTranscriptCommitWithoutTrailer(t *testing.T) {
-	_, initialCommit := runExplainAutoTestRepo(t)
-
-	var out, errOut bytes.Buffer
-	err := runExplainAuto(context.Background(), &out, &errOut, initialCommit.String(), true, false, false, true, false, false, false)
-
-	require.Error(t, err)
-	require.ErrorContains(t, err, "cannot show raw transcript")
-	require.ErrorContains(t, err, initialCommit.String()[:7])
-}
-
-// TestRunExplainCheckpoint_NotFoundMessageNotDuplicated guards against the
-// "checkpoint not found: X: checkpoint not found" regression from wrapping
-// the sentinel with a format string that also spelled out its text.
-func TestRunExplainCheckpoint_NotFoundMessageNotDuplicated(t *testing.T) {
-	runExplainAutoTestRepo(t)
-
-	var out, errOut bytes.Buffer
-	err := runExplainCheckpoint(context.Background(), &out, &errOut, "abababababab", false, false, false, false, false, false, false)
-
-	require.Error(t, err)
-	require.Equal(t, 1, strings.Count(err.Error(), "checkpoint not found"),
-		"error phrase %q should appear once, got %q", "checkpoint not found", err.Error())
-}
-
-// TestRunExplainCheckpoint_WrapsSentinelNotFound guards the typed-error
-// contract runExplainAuto depends on: runExplainCheckpoint must return an
-// error matching checkpoint.ErrCheckpointNotFound via errors.Is when the
-// target matches no checkpoint (PR #990 review feedback).
-func TestRunExplainCheckpoint_WrapsSentinelNotFound(t *testing.T) {
-	runExplainAutoTestRepo(t)
-
-	var out, errOut bytes.Buffer
-	err := runExplainCheckpoint(context.Background(), &out, &errOut, "abababababab", false, false, false, false, false, false, false)
-
-	require.Error(t, err)
-	require.ErrorIs(t, err, checkpoint.ErrCheckpointNotFound,
-		"runExplainCheckpoint must wrap checkpoint.ErrCheckpointNotFound so runExplainAuto can detect it with errors.Is")
-}
-
-// TestRunExplainCheckpoint_GenerateNonMatchingReturnsNotFound verifies the
-// corrected contract: when --generate is requested for a target that does
-// NOT match any committed or temporary checkpoint, runExplainCheckpoint
-// returns ErrCheckpointNotFound (so runExplainAuto can fall back to commit
-// resolution), not errCannotGenerateTemporaryCheckpoint. The previous
-// behavior returned the temp-checkpoint sentinel speculatively and broke
-// fallback routing for random SHAs with --generate.
-func TestRunExplainCheckpoint_GenerateNonMatchingReturnsNotFound(t *testing.T) {
-	runExplainAutoTestRepo(t)
-
-	var out, errOut bytes.Buffer
-	err := runExplainCheckpoint(context.Background(), &out, &errOut, "abababababab", false, false, false, false, true, false, false)
-
-	require.Error(t, err)
-	require.ErrorIs(t, err, checkpoint.ErrCheckpointNotFound,
-		"non-matching --generate target must return ErrCheckpointNotFound so runExplainAuto can fall back to commit resolution")
-	require.NotErrorIs(t, err, errCannotGenerateTemporaryCheckpoint,
-		"sentinel must not fire unless a real temp checkpoint was matched")
+			require.Error(t, err)
+			require.ErrorIs(t, err, checkpoint.ErrCheckpointNotFound)
+			require.NotErrorIs(t, err, errCannotGenerateTemporaryCheckpoint,
+				"sentinel must not fire unless a real temp checkpoint was matched")
+		})
+	}
 }
 
 // TestRunExplainAuto_GenerateAmbiguousPrefixRefused guards the Codex finding
 // that a short positional arg matching both a committed-checkpoint prefix
 // and a git revision must not silently write a summary to the wrong
-// checkpoint. With --generate set, runExplainAuto should refuse and ask the
-// user to disambiguate via --commit or --checkpoint.
+// checkpoint. SHA mining isn't practical, so we construct the collision by
+// picking a checkpoint ID that starts with the seed commit's abbreviation.
 func TestRunExplainAuto_GenerateAmbiguousPrefixRefused(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()
 
-	// Build a checkpoint ID whose prefix matches the seed commit's SHA so
-	// the positional arg resolves as both a git revision AND a committed-
-	// checkpoint prefix. SHA mining isn't practical here, so we pick a
-	// collision-able ID by prefixing with the real commit's abbreviation.
 	head, err := repo.Head()
 	require.NoError(t, err)
 	commitPrefix := head.Hash().String()[:7]
-	collisionID := id.MustCheckpointID(commitPrefix + "aaaaa") // 7 + 5 = 12 chars
+	collisionID := id.MustCheckpointID(commitPrefix + "aaaaa")
 
 	require.NoError(t, checkpoint.NewGitStore(repo).WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
 		CheckpointID: collisionID,
@@ -441,34 +386,15 @@ func TestRunExplainAuto_GenerateAmbiguousPrefixRefused(t *testing.T) {
 	var out, errOut bytes.Buffer
 	err = runExplainAuto(ctx, &out, &errOut, commitPrefix, true, false, false, false, true, false, false)
 
-	require.Error(t, err, "--generate on an ambiguous target must error, not write to a checkpoint")
+	require.Error(t, err)
 	require.ErrorContains(t, err, "ambiguous target")
 	require.ErrorContains(t, err, "--commit")
 	require.ErrorContains(t, err, "--checkpoint")
 }
 
-// TestRunExplainAuto_GenerateUnambiguousCheckpointIDPasses verifies the
-// ambiguity guard does NOT fire when the target is a valid 12-char
-// checkpoint ID that doesn't resolve as a git revision. Regression guard
-// against over-triggering.
-func TestRunExplainAuto_GenerateUnambiguousCheckpointIDPasses(t *testing.T) {
-	_, _ = runExplainAutoTestRepo(t)
-
-	// A 12-char hex string that is extremely unlikely to resolve as a git
-	// ref in a fresh repo. The ambiguity guard should be a no-op here.
-	var out, errOut bytes.Buffer
-	err := runExplainAuto(context.Background(), &out, &errOut, "ffffffffffff", true, false, false, false, true, false, false)
-
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "ambiguous target",
-		"ambiguity guard must not fire when target does not resolve as a git ref")
-}
-
-// TestExplainCmd_CommitFlagWithGenerateValidates verifies Fix #3: the
-// --commit flag combined with --generate now passes flag validation.
-// Previously hasCheckpointTarget excluded commitFlag, so users of the
-// explicit --commit form couldn't invoke generate/raw-transcript modes
-// even though the positional equivalent worked.
+// TestExplainCmd_CommitFlagWithGenerateValidates verifies --commit +
+// --generate passes flag validation (previously hasCheckpointTarget
+// excluded commitFlag, so the explicit form couldn't invoke generate).
 func TestExplainCmd_CommitFlagWithGenerateValidates(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
@@ -483,13 +409,10 @@ func TestExplainCmd_CommitFlagWithGenerateValidates(t *testing.T) {
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{"--commit", "HEAD", "--generate"})
 
-	err := cmd.Execute()
-	// The command will fail downstream (no trailer on seed commit) but
-	// must get past flag validation. We verify it's NOT the "--generate
-	// requires..." validation error.
-	if err != nil {
-		require.NotContains(t, err.Error(), "--generate requires",
-			"--commit + --generate must pass flag validation")
+	// Command will fail downstream (no trailer on seed commit), but must
+	// not fail at flag validation.
+	if err := cmd.Execute(); err != nil {
+		require.NotContains(t, err.Error(), "--generate requires")
 	}
 }
 

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -398,18 +398,126 @@ func TestRunExplainCheckpoint_WrapsSentinelNotFound(t *testing.T) {
 		"runExplainCheckpoint must wrap checkpoint.ErrCheckpointNotFound so runExplainAuto can detect it with errors.Is")
 }
 
-// TestRunExplainCheckpoint_WrapsSentinelCannotGenerateTemporary guards the
-// second typed-error contract: when --generate is requested for a target
-// that has no committed checkpoint, runExplainCheckpoint must return an
-// error matching errCannotGenerateTemporaryCheckpoint via errors.Is.
-func TestRunExplainCheckpoint_WrapsSentinelCannotGenerateTemporary(t *testing.T) {
+// TestRunExplainCheckpoint_GenerateNonMatchingReturnsNotFound verifies the
+// corrected contract: when --generate is requested for a target that does
+// NOT match any committed or temporary checkpoint, runExplainCheckpoint
+// returns ErrCheckpointNotFound (so runExplainAuto can fall back to commit
+// resolution), not errCannotGenerateTemporaryCheckpoint. The previous
+// behavior returned the temp-checkpoint sentinel speculatively and broke
+// fallback routing for random SHAs with --generate.
+func TestRunExplainCheckpoint_GenerateNonMatchingReturnsNotFound(t *testing.T) {
 	runExplainAutoTestRepo(t)
 
 	var out, errOut bytes.Buffer
 	err := runExplainCheckpoint(context.Background(), &out, &errOut, "abababababab", false, false, false, false, true, false, false)
 
 	require.Error(t, err)
-	require.ErrorIs(t, err, errCannotGenerateTemporaryCheckpoint)
+	require.ErrorIs(t, err, checkpoint.ErrCheckpointNotFound,
+		"non-matching --generate target must return ErrCheckpointNotFound so runExplainAuto can fall back to commit resolution")
+	require.NotErrorIs(t, err, errCannotGenerateTemporaryCheckpoint,
+		"sentinel must not fire unless a real temp checkpoint was matched")
+}
+
+// TestRunExplainAuto_GenerateAmbiguousPrefixRefused guards the Codex finding
+// that a short positional arg matching both a committed-checkpoint prefix
+// and a git revision must not silently write a summary to the wrong
+// checkpoint. With --generate set, runExplainAuto should refuse and ask the
+// user to disambiguate via --commit or --checkpoint.
+func TestRunExplainAuto_GenerateAmbiguousPrefixRefused(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+
+	// Seed a committed checkpoint whose ID starts with a common hex prefix.
+	cpID := id.MustCheckpointID("abcdef123456")
+	v1Store := checkpoint.NewGitStore(repo)
+	require.NoError(t, v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-ambiguous",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n")),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	}))
+
+	// Find a short prefix that resolves as a git revision (the initial
+	// seed commit's SHA abbreviation) AND also prefix-matches the
+	// checkpoint ID. We construct this by using the first few chars of
+	// the commit SHA; git can resolve 4+ char unique abbreviations.
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	head, err := repo.Head()
+	require.NoError(t, err)
+	commitPrefix := head.Hash().String()[:7]
+	require.NotEmpty(t, commitPrefix)
+
+	// To create a real collision, make a new commit whose SHA we force-
+	// select to start with "abcdef". That's impractical without SHA
+	// mining, so instead we rename the checkpoint prefix to match the
+	// real commit prefix we have.
+	_ = wt
+	collisionID := id.MustCheckpointID(commitPrefix + "aaaaa") // 7 + 5 = 12 chars
+	require.NoError(t, v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID: collisionID,
+		SessionID:    "session-collision",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n")),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	}))
+
+	var out, errOut bytes.Buffer
+	err = runExplainAuto(ctx, &out, &errOut, commitPrefix, true, false, false, false, true, false, false)
+
+	require.Error(t, err, "--generate on an ambiguous target must error, not write to a checkpoint")
+	require.ErrorContains(t, err, "ambiguous target")
+	require.ErrorContains(t, err, "--commit")
+	require.ErrorContains(t, err, "--checkpoint")
+}
+
+// TestRunExplainAuto_GenerateUnambiguousCheckpointIDPasses verifies the
+// ambiguity guard does NOT fire when the target is a valid 12-char
+// checkpoint ID that doesn't resolve as a git revision. Regression guard
+// against over-triggering.
+func TestRunExplainAuto_GenerateUnambiguousCheckpointIDPasses(t *testing.T) {
+	_, _ = runExplainAutoTestRepo(t)
+
+	// A 12-char hex string that is extremely unlikely to resolve as a git
+	// ref in a fresh repo. The ambiguity guard should be a no-op here.
+	var out, errOut bytes.Buffer
+	err := runExplainAuto(context.Background(), &out, &errOut, "ffffffffffff", true, false, false, false, true, false, false)
+
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "ambiguous target",
+		"ambiguity guard must not fire when target does not resolve as a git ref")
+}
+
+// TestExplainCmd_CommitFlagWithGenerateValidates verifies Fix #3: the
+// --commit flag combined with --generate now passes flag validation.
+// Previously hasCheckpointTarget excluded commitFlag, so users of the
+// explicit --commit form couldn't invoke generate/raw-transcript modes
+// even though the positional equivalent worked.
+func TestExplainCmd_CommitFlagWithGenerateValidates(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "x")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "seed")
+
+	cmd := newExplainCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--commit", "HEAD", "--generate"})
+
+	err := cmd.Execute()
+	// The command will fail downstream (no trailer on seed commit) but
+	// must get past flag validation. We verify it's NOT the "--generate
+	// requires..." validation error.
+	if err != nil {
+		require.NotContains(t, err.Error(), "--generate requires",
+			"--commit + --generate must pass flag validation")
+	}
 }
 
 func TestGenerateCheckpointAISummary_AddsDefaultTimeoutWithoutParentDeadline(t *testing.T) {
@@ -634,7 +742,7 @@ func TestExplainCommit_NotFound(t *testing.T) {
 	testutil.InitRepo(t, tmpDir)
 
 	var stdout bytes.Buffer
-	err := runExplainCommit(context.Background(), &stdout, "nonexistent", false, false, false, false)
+	err := runExplainCommit(context.Background(), &stdout, &stdout, "nonexistent", false, false, false, false, false, false, false)
 
 	if err == nil {
 		t.Error("expected error for nonexistent commit, got nil")
@@ -677,7 +785,7 @@ func TestExplainCommit_NoEntireData(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	err = runExplainCommit(context.Background(), &stdout, commitHash.String(), false, false, false, false)
+	err = runExplainCommit(context.Background(), &stdout, &stdout, commitHash.String(), false, false, false, false, false, false, false)
 	if err != nil {
 		t.Fatalf("runExplainCommit() should not error for non-Entire commits, got: %v", err)
 	}
@@ -746,7 +854,7 @@ func TestExplainCommit_WithMetadataTrailerButNoCheckpoint(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	err = runExplainCommit(context.Background(), &stdout, commitHash.String(), false, false, false, false)
+	err = runExplainCommit(context.Background(), &stdout, &stdout, commitHash.String(), false, false, false, false, false, false, false)
 	if err != nil {
 		t.Fatalf("runExplainCommit() error = %v", err)
 	}
@@ -3509,7 +3617,7 @@ func TestRunExplainCommit_NoCheckpointTrailer(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err = runExplainCommit(context.Background(), &buf, hash.String()[:7], false, false, false, false)
+	err = runExplainCommit(context.Background(), &buf, &buf, hash.String()[:7], false, false, false, false, false, false, false)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -3556,7 +3664,7 @@ func TestRunExplainCommit_WithCheckpointTrailer(t *testing.T) {
 	var buf bytes.Buffer
 	// This should try to look up the checkpoint and fail (checkpoint doesn't exist in store)
 	// but it should still attempt the lookup rather than showing commit details
-	err = runExplainCommit(context.Background(), &buf, hash.String()[:7], false, false, false, false)
+	err = runExplainCommit(context.Background(), &buf, &buf, hash.String()[:7], false, false, false, false, false, false, false)
 
 	// Should error because the checkpoint doesn't exist in the store
 	if err == nil {

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -204,9 +204,8 @@ func TestFormatCheckpointSummaryError_Unknown(t *testing.T) {
 
 // TestExplainCmd_PositionalArgConflictsWithFlags verifies that combining a
 // positional target with --checkpoint, --commit, or --session is rejected.
-// A bare positional arg (without conflicting flags) is accepted and routed to
-// the auto-detection path; that routing is covered by runExplainAuto tests
-// elsewhere and does not need a cmd-level reject test.
+// The bare-positional happy path (auto-resolution to a checkpoint ID or commit
+// ref) is covered by the TestRunExplainAuto_* tests in this file.
 func TestExplainCmd_PositionalArgConflictsWithFlags(t *testing.T) {
 	tests := []struct {
 		name string
@@ -235,6 +234,139 @@ func TestExplainCmd_PositionalArgConflictsWithFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+// runExplainAutoTestRepo seeds a git repo and returns the initial commit's hash.
+// It configures the repo the way testutil.InitRepo does and matches the setup
+// used by the surrounding TestRunExplainCheckpoint_* tests so the auto-path
+// tests exercise the same production code paths.
+func runExplainAutoTestRepo(t *testing.T) (repo *git.Repository, initialCommit plumbing.Hash) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	testutil.InitRepo(t, tmpDir)
+	repoOpened, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+
+	wt, err := repoOpened.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "seed.txt"), []byte("seed"), 0o644))
+	_, err = wt.Add("seed.txt")
+	require.NoError(t, err)
+	initial, err := wt.Commit("seed commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+	return repoOpened, initial
+}
+
+// TestRunExplainAuto_ChecksPositionalCheckpointIDFirst verifies that a
+// checkpoint-ID-shaped positional arg routes through the checkpoint path.
+// When the checkpoint does not exist locally, the returned error must wrap
+// checkpoint.ErrCheckpointNotFound so runExplainAuto can detect it via
+// errors.Is rather than substring matching (PR #990 review feedback).
+func TestRunExplainAuto_ChecksPositionalCheckpointIDFirst(t *testing.T) {
+	runExplainAutoTestRepo(t)
+
+	var out, errOut bytes.Buffer
+	err := runExplainAuto(context.Background(), &out, &errOut, "abababababab", false, false, false, false, false, false, false)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, `no checkpoint or commit found matching "abababababab"`)
+}
+
+// TestRunExplainAuto_CommitRefWithCheckpointTrailer verifies that a commit SHA
+// passed positionally falls through to commit resolution and delegates to the
+// checkpoint path with the ID from the Entire-Checkpoint trailer.
+func TestRunExplainAuto_CommitRefWithCheckpointTrailer(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+
+	cpID := id.MustCheckpointID("deadbeefcafe")
+	v1Store := checkpoint.NewGitStore(repo)
+	require.NoError(t, v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-auto",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}` + "\n")),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	}))
+
+	// Create a second commit whose message includes the checkpoint trailer.
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	tmpDir := wt.Filesystem.Root()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "feature.txt"), []byte("feature"), 0o644))
+	_, err = wt.Add("feature.txt")
+	require.NoError(t, err)
+	commitHash, err := wt.Commit(trailers.AppendCheckpointTrailer("Implement feature", cpID.String()), &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	var out, errOut bytes.Buffer
+	err = runExplainAuto(ctx, &out, &errOut, commitHash.String(), true, false, false, false, false, false, false)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), cpID.String(), "expected checkpoint header resolved via trailer")
+}
+
+// TestRunExplainAuto_CommitRefWithoutTrailer verifies the silent-success path:
+// a valid git commit without an Entire-Checkpoint trailer prints the friendly
+// message and returns nil. This matches runExplainCommit's behavior.
+func TestRunExplainAuto_CommitRefWithoutTrailer(t *testing.T) {
+	_, initialCommit := runExplainAutoTestRepo(t)
+
+	var out, errOut bytes.Buffer
+	err := runExplainAuto(context.Background(), &out, &errOut, initialCommit.String(), true, false, false, false, false, false, false)
+
+	require.NoError(t, err, "commit without trailer must not error")
+	output := out.String()
+	require.Contains(t, output, "No associated Entire checkpoint")
+	require.Contains(t, output, initialCommit.String()[:7])
+	require.Contains(t, output, "does not have an Entire-Checkpoint trailer")
+}
+
+// TestRunExplainAuto_NoMatch verifies that a target that is neither a
+// checkpoint ID nor a resolvable git ref returns the composite error.
+func TestRunExplainAuto_NoMatch(t *testing.T) {
+	runExplainAutoTestRepo(t)
+
+	var out, errOut bytes.Buffer
+	err := runExplainAuto(context.Background(), &out, &errOut, "zzzzzz999999", false, false, false, false, false, false, false)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, `no checkpoint or commit found matching "zzzzzz999999"`)
+}
+
+// TestRunExplainCheckpoint_WrapsSentinelNotFound guards the typed-error
+// contract runExplainAuto depends on: runExplainCheckpoint must return an
+// error matching checkpoint.ErrCheckpointNotFound via errors.Is when the
+// target matches no checkpoint (PR #990 review feedback).
+func TestRunExplainCheckpoint_WrapsSentinelNotFound(t *testing.T) {
+	runExplainAutoTestRepo(t)
+
+	var out, errOut bytes.Buffer
+	err := runExplainCheckpoint(context.Background(), &out, &errOut, "abababababab", false, false, false, false, false, false, false)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, checkpoint.ErrCheckpointNotFound,
+		"runExplainCheckpoint must wrap checkpoint.ErrCheckpointNotFound so runExplainAuto can detect it with errors.Is")
+}
+
+// TestRunExplainCheckpoint_WrapsSentinelCannotGenerateTemporary guards the
+// second typed-error contract: when --generate is requested for a target
+// that has no committed checkpoint, runExplainCheckpoint must return an
+// error matching errCannotGenerateTemporaryCheckpoint via errors.Is.
+func TestRunExplainCheckpoint_WrapsSentinelCannotGenerateTemporary(t *testing.T) {
+	runExplainAutoTestRepo(t)
+
+	var out, errOut bytes.Buffer
+	err := runExplainCheckpoint(context.Background(), &out, &errOut, "abababababab", false, false, false, false, true, false, false)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, errCannotGenerateTemporaryCheckpoint)
 }
 
 func TestGenerateCheckpointAISummary_AddsDefaultTimeoutWithoutParentDeadline(t *testing.T) {

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -237,28 +237,21 @@ func TestExplainCmd_PositionalArgConflictsWithFlags(t *testing.T) {
 }
 
 // runExplainAutoTestRepo seeds a git repo and returns the initial commit's hash.
-// It configures the repo the way testutil.InitRepo does and matches the setup
-// used by the surrounding TestRunExplainCheckpoint_* tests so the auto-path
-// tests exercise the same production code paths.
 func runExplainAutoTestRepo(t *testing.T) (repo *git.Repository, initialCommit plumbing.Hash) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
 
 	testutil.InitRepo(t, tmpDir)
-	repoOpened, err := git.PlainOpen(tmpDir)
-	require.NoError(t, err)
+	testutil.WriteFile(t, tmpDir, "seed.txt", "seed")
+	testutil.GitAdd(t, tmpDir, "seed.txt")
+	testutil.GitCommit(t, tmpDir, "seed commit")
 
-	wt, err := repoOpened.Worktree()
+	opened, err := git.PlainOpen(tmpDir)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "seed.txt"), []byte("seed"), 0o644))
-	_, err = wt.Add("seed.txt")
+	head, err := opened.Head()
 	require.NoError(t, err)
-	initial, err := wt.Commit("seed commit", &git.CommitOptions{
-		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
-	})
-	require.NoError(t, err)
-	return repoOpened, initial
+	return opened, head.Hash()
 }
 
 // TestRunExplainAuto_ChecksPositionalCheckpointIDFirst verifies that a
@@ -427,36 +420,16 @@ func TestRunExplainAuto_GenerateAmbiguousPrefixRefused(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()
 
-	// Seed a committed checkpoint whose ID starts with a common hex prefix.
-	cpID := id.MustCheckpointID("abcdef123456")
-	v1Store := checkpoint.NewGitStore(repo)
-	require.NoError(t, v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "session-ambiguous",
-		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n")),
-		AuthorName:   "Test",
-		AuthorEmail:  "test@example.com",
-	}))
-
-	// Find a short prefix that resolves as a git revision (the initial
-	// seed commit's SHA abbreviation) AND also prefix-matches the
-	// checkpoint ID. We construct this by using the first few chars of
-	// the commit SHA; git can resolve 4+ char unique abbreviations.
-	wt, err := repo.Worktree()
-	require.NoError(t, err)
+	// Build a checkpoint ID whose prefix matches the seed commit's SHA so
+	// the positional arg resolves as both a git revision AND a committed-
+	// checkpoint prefix. SHA mining isn't practical here, so we pick a
+	// collision-able ID by prefixing with the real commit's abbreviation.
 	head, err := repo.Head()
 	require.NoError(t, err)
 	commitPrefix := head.Hash().String()[:7]
-	require.NotEmpty(t, commitPrefix)
-
-	// To create a real collision, make a new commit whose SHA we force-
-	// select to start with "abcdef". That's impractical without SHA
-	// mining, so instead we rename the checkpoint prefix to match the
-	// real commit prefix we have.
-	_ = wt
 	collisionID := id.MustCheckpointID(commitPrefix + "aaaaa") // 7 + 5 = 12 chars
-	require.NoError(t, v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+
+	require.NoError(t, checkpoint.NewGitStore(repo).WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
 		CheckpointID: collisionID,
 		SessionID:    "session-collision",
 		Strategy:     "manual-commit",


### PR DESCRIPTION
## Summary

- `entire explain <id-or-sha>` now takes a checkpoint ID *or* a commit SHA/ref as a positional argument, so `--generate`/`--raw-transcript` no longer require the user to pick between `-c/--checkpoint` and `--commit`.
- Resolution is checkpoint-first (preserves short-prefix matching for IDs and the existing temp-checkpoint fallback), then falls back to git commit resolution via the `Entire-Checkpoint` trailer.
- `--checkpoint`/`-c` and `--commit` are kept as explicit overrides for backward compatibility and for disambiguating short hex prefixes that could resolve to either.
- Commits without an `Entire-Checkpoint` trailer still print the existing friendly "No associated Entire checkpoint" message and exit cleanly — no behavior change on that path.

## Test plan

- [x] `mise run check` (fmt + lint + unit + integration + E2E canary) passes locally
- [x] Manual simulation against a real repo covering 16 scenarios (success paths, backward-compat flag paths, conflict errors, missing-trailer, gibberish input, `--generate` routing for both forms)
- [x] New `TestExplainCmd_PositionalArgConflictsWithFlags` covers positional + `--checkpoint` / `-c` / `--commit` / `--session` rejection
- [x] Existing `runExplain` call sites updated for the new `target` parameter
- [ ] Reviewer sanity-check that the 7-char-prefix collision tradeoff (checkpoint wins, `--commit` available as override) matches expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `entire explain` routing and error semantics for checkpoint/commit resolution, including side-effect modes (`--generate`, `--raw-transcript`) that write or output checkpoint data. Risk is moderate due to new ambiguity handling and fallback logic that could affect which checkpoint is targeted.
> 
> **Overview**
> `entire explain` now accepts an optional positional `checkpoint-id | commit-sha` argument and auto-resolves it by trying checkpoint IDs (including temp checkpoints) first, then falling back to resolving a git commit and following its `Entire-Checkpoint` trailer.
> 
> Side-effect modes are tightened: `--generate`/`--raw-transcript` are allowed with positional targets and `--commit`, refuse ambiguous short targets when `--generate` is set, and error (instead of exiting 0) when a resolved commit has no trailer. Checkpoint-not-found now returns a typed `checkpoint.ErrCheckpointNotFound` wrapper to enable reliable fallback detection, and tests are expanded to cover the new routing/validation cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733fce210feca07a93269093fb0c225ffbefdb2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->