### PR TITLE
Refactor git commands and increase test coverage

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -96,7 +97,12 @@ type PushResult struct {
 // Push runs git push --no-verify --porcelain with token injection.
 // GIT_TERMINAL_PROMPT=0 is always set.
 func Push(ctx context.Context, remote, refSpec string) (PushResult, error) {
-	cmd := newCommand(ctx, "push", "--no-verify", "--porcelain", remote, refSpec)
+	pushTarget, err := resolvePushCommandTarget(ctx, remote)
+	if err != nil {
+		return PushResult{}, fmt.Errorf("resolve push target: %w", err)
+	}
+
+	cmd := newCommand(ctx, "push", "--no-verify", "--porcelain", pushTarget, refSpec)
 	disableTerminalPrompt(cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -273,6 +279,25 @@ func resolveTargetProtocol(ctx context.Context, target string) string {
 		return ""
 	}
 	return info.Protocol
+}
+
+func resolvePushCommandTarget(ctx context.Context, target string) (string, error) {
+	if target == "" || IsURL(target) || isLocalPath(target) {
+		return target, nil
+	}
+
+	pushTarget, _, err := PushURL(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	if pushTarget == "" {
+		return target, nil
+	}
+	return pushTarget, nil
+}
+
+func isLocalPath(target string) bool {
+	return filepath.IsAbs(target) || strings.HasPrefix(target, "./") || strings.HasPrefix(target, "../")
 }
 
 // disableTerminalPrompt sets GIT_TERMINAL_PROMPT=0 on the command,

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -336,16 +336,26 @@ func isValidToken(token string) bool {
 	return true
 }
 
+// resolvePushCommandTarget returns the target to pass to git push. When a
+// dedicated checkpoint_remote is configured, the checkpoint URL is returned so
+// the push is routed to the separate checkpoint repo. Otherwise the remote
+// name is returned unchanged so git uses its own config, updates the
+// refs/remotes/<name>/<branch> tracking ref, and subsequent calls can use that
+// tracking ref to skip redundant pushes.
+//
+// SSH→HTTPS coercion for token auth is handled by newCommand, which rewrites
+// the command args or injects per-host config, rather than being baked into
+// the target here.
 func resolvePushCommandTarget(ctx context.Context, target string) (string, error) {
 	if target == "" || IsURL(target) || isLocalPath(target) {
 		return target, nil
 	}
 
-	pushTarget, _, err := PushURL(ctx, target)
+	pushTarget, enabled, err := PushURL(ctx, target)
 	if err != nil {
 		return "", err
 	}
-	if pushTarget == "" {
+	if !enabled || pushTarget == "" {
 		return target, nil
 	}
 	return pushTarget, nil

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -221,28 +222,39 @@ func extractRemoteFromArgs(args []string) string {
 // an Authorization header into git HTTP requests. The token is sent as a Basic
 // credential with the format "x-access-token:<token>" (base64-encoded), which
 // is compatible with GitHub's token authentication.
-// It filters out any pre-existing GIT_CONFIG_COUNT/KEY/VALUE entries to avoid
-// conflicts, then appends the new ones.
 //
-// NOTE: This drops ALL existing GIT_CONFIG_* entries from the environment.
-// If a parent process (e.g., CI) injects its own GIT_CONFIG_* vars, they will
-// be lost. If that becomes an issue, read the existing count and append at the
-// next index instead of replacing.
+// Existing GIT_CONFIG_KEY_*/GIT_CONFIG_VALUE_* entries are preserved; the new
+// http.extraHeader entry is appended at the next free index and
+// GIT_CONFIG_COUNT is updated accordingly. This keeps caller-injected git
+// config (e.g., safe.directory, custom CA settings) intact.
 func appendCheckpointTokenEnv(baseEnv []string, token string) []string {
+	existingCount := 0
+	for _, e := range baseEnv {
+		rest, ok := strings.CutPrefix(e, "GIT_CONFIG_COUNT=")
+		if !ok {
+			continue
+		}
+		if n, err := strconv.Atoi(rest); err == nil && n > 0 {
+			existingCount = n
+		}
+	}
+
+	// Strip the old GIT_CONFIG_COUNT entry (we'll emit a new one) but keep
+	// GIT_CONFIG_KEY_*/GIT_CONFIG_VALUE_* entries in place.
 	filtered := make([]string, 0, len(baseEnv)+3)
 	for _, e := range baseEnv {
-		if strings.HasPrefix(e, "GIT_CONFIG_COUNT=") ||
-			strings.HasPrefix(e, "GIT_CONFIG_KEY_") ||
-			strings.HasPrefix(e, "GIT_CONFIG_VALUE_") {
+		if strings.HasPrefix(e, "GIT_CONFIG_COUNT=") {
 			continue
 		}
 		filtered = append(filtered, e)
 	}
+
+	idx := existingCount
 	encoded := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
 	return append(filtered,
-		"GIT_CONFIG_COUNT=1",
-		"GIT_CONFIG_KEY_0=http.extraHeader",
-		"GIT_CONFIG_VALUE_0=Authorization: Basic "+encoded,
+		fmt.Sprintf("GIT_CONFIG_COUNT=%d", existingCount+1),
+		fmt.Sprintf("GIT_CONFIG_KEY_%d=http.extraHeader", idx),
+		fmt.Sprintf("GIT_CONFIG_VALUE_%d=Authorization: Basic %s", idx, encoded),
 	)
 }
 

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -1,4 +1,4 @@
-package strategy
+package remote
 
 import (
 	"context"
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
@@ -21,9 +20,114 @@ import (
 // SSH remotes ignore the token (with a warning).
 const CheckpointTokenEnvVar = "ENTIRE_CHECKPOINT_TOKEN"
 
-var sshTokenWarningOnce sync.Once
+var sshTokenWarningOnce sync.Once //nolint:gochecknoglobals // intentional per-process gate
 
-// CheckpointGitCommand creates an exec.Cmd for a git operation that may need
+// FetchOptions configures a git fetch operation.
+type FetchOptions struct {
+	Remote    string   // remote name or URL (required)
+	RefSpecs  []string // one or more refspecs / object hashes
+	Shallow   bool     // adds --depth=1
+	NoTags    bool     // adds --no-tags
+	Dir       string   // working directory (empty = CWD)
+	ExtraArgs []string // additional flags before remote (e.g., "--no-write-fetch-head")
+}
+
+// Fetch runs git fetch with checkpoint token injection and optional
+// filtered fetches (--filter=blob:none when settings enable it).
+// GIT_TERMINAL_PROMPT=0 is always set.
+//
+// Callers that pass a remote name (e.g., "origin") and want filtered fetches to
+// resolve the name to a URL (to avoid persisting promisor settings) should call
+// ResolveFetchTarget first and pass the resolved target as opts.Remote.
+func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
+	args := []string{"fetch"}
+	if opts.NoTags {
+		args = append(args, "--no-tags")
+	}
+	if opts.Shallow {
+		args = append(args, "--depth=1")
+	}
+	args = append(args, opts.ExtraArgs...)
+	if settings.IsFilteredFetchesEnabled(ctx) {
+		args = append(args, "--filter=blob:none")
+	}
+	args = append(args, opts.Remote)
+	args = append(args, opts.RefSpecs...)
+
+	cmd := newCommand(ctx, args...)
+	if opts.Dir != "" {
+		cmd.Dir = opts.Dir
+	}
+	ensureEnv(cmd, "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("git fetch: %w", err)
+	}
+	return out, nil
+}
+
+// PushResult holds raw porcelain output from git push.
+type PushResult struct {
+	Output string
+}
+
+// Push runs git push --no-verify --porcelain with token injection.
+// GIT_TERMINAL_PROMPT=0 is always set.
+func Push(ctx context.Context, remote, refSpec string) (PushResult, error) {
+	cmd := newCommand(ctx, "push", "--no-verify", "--porcelain", remote, refSpec)
+	ensureEnv(cmd, "GIT_TERMINAL_PROMPT=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return PushResult{Output: string(output)}, fmt.Errorf("git push: %w", err)
+	}
+	return PushResult{Output: string(output)}, nil
+}
+
+// LsRemote runs git ls-remote with token injection.
+// GIT_TERMINAL_PROMPT=0 is always set. Returns stdout only.
+func LsRemote(ctx context.Context, remote string, patterns ...string) ([]byte, error) {
+	return lsRemote(ctx, "", remote, patterns...)
+}
+
+// LsRemoteInDir is like LsRemote but runs in a specific directory.
+func LsRemoteInDir(ctx context.Context, dir, remote string, patterns ...string) ([]byte, error) {
+	return lsRemote(ctx, dir, remote, patterns...)
+}
+
+func lsRemote(ctx context.Context, dir, remote string, patterns ...string) ([]byte, error) {
+	args := append([]string{"ls-remote", remote}, patterns...)
+	cmd := newCommand(ctx, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	ensureEnv(cmd, "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.Output()
+	if err != nil {
+		return out, fmt.Errorf("git ls-remote: %w", err)
+	}
+	return out, nil
+}
+
+// IsURL returns true if the target looks like a URL rather than a git remote name.
+func IsURL(target string) bool {
+	return strings.Contains(target, "://") || strings.Contains(target, "@")
+}
+
+// ResolveFetchTarget returns the git fetch target to use. When filtered
+// fetches are enabled, configured remotes are resolved to their URL so git does
+// not persist promisor settings onto the remote name.
+func ResolveFetchTarget(ctx context.Context, target string) (string, error) {
+	if IsURL(target) || !settings.IsFilteredFetchesEnabled(ctx) {
+		return target, nil
+	}
+	url, err := GetRemoteURL(ctx, target)
+	if err != nil {
+		return "", fmt.Errorf("get remote URL: %w", err)
+	}
+	return url, nil
+}
+
+// newCommand creates an exec.Cmd for a git operation that may need
 // checkpoint token authentication. If ENTIRE_CHECKPOINT_TOKEN is set and the
 // remote in args resolves to an HTTPS URL, a Basic auth token is injected via
 // GIT_CONFIG_COUNT/GIT_CONFIG_KEY_*/GIT_CONFIG_VALUE_* environment variables.
@@ -34,7 +138,7 @@ var sshTokenWarningOnce sync.Once
 // The remote is extracted from args by skipping the git subcommand and any flags
 // (arguments starting with "-"). For example, in
 // ["push", "--no-verify", "origin", "main"], the remote is "origin".
-func CheckpointGitCommand(ctx context.Context, args ...string) *exec.Cmd {
+func newCommand(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Stdin = nil // Disconnect stdin to prevent hanging in hook context
 
@@ -56,12 +160,12 @@ func CheckpointGitCommand(ctx context.Context, args ...string) *exec.Cmd {
 	protocol := resolveTargetProtocol(ctx, target)
 
 	switch protocol {
-	case remote.ProtocolSSH:
+	case ProtocolSSH:
 		sshTokenWarningOnce.Do(func() {
 			fmt.Fprintf(os.Stderr, "[entire] Warning: %s is set but remote uses SSH — token ignored for SSH remotes\n", CheckpointTokenEnvVar)
 		})
 		return cmd
-	case remote.ProtocolHTTPS:
+	case ProtocolHTTPS:
 		cmd.Env = appendCheckpointTokenEnv(os.Environ(), token)
 		return cmd
 	default:
@@ -128,46 +232,32 @@ func isValidToken(token string) bool {
 }
 
 // resolveTargetProtocol determines whether a push/fetch target uses SSH or HTTPS.
-// Returns remote.ProtocolSSH, remote.ProtocolHTTPS, or "" if unknown.
+// Returns ProtocolSSH, ProtocolHTTPS, or "" if unknown.
 func resolveTargetProtocol(ctx context.Context, target string) string {
 	var rawURL string
-	if isURL(target) {
+	if IsURL(target) {
 		rawURL = target
 	} else {
 		// Remote name — resolve to URL
 		var err error
-		rawURL, err = remote.GetRemoteURL(ctx, target)
+		rawURL, err = GetRemoteURL(ctx, target)
 		if err != nil {
 			return ""
 		}
 	}
 
-	info, err := remote.ParseURL(rawURL)
+	info, err := ParseURL(rawURL)
 	if err != nil {
 		return ""
 	}
 	return info.Protocol
 }
 
-// ResolveFetchTarget returns the git fetch target to use. When filtered
-// fetches are enabled, configured remotes are resolved to their URL so git does
-// not persist promisor settings onto the remote name.
-func ResolveFetchTarget(ctx context.Context, target string) (string, error) {
-	if isURL(target) || !settings.IsFilteredFetchesEnabled(ctx) {
-		return target, nil
+// ensureEnv appends an environment variable to the command, initializing
+// cmd.Env from os.Environ() if it is nil.
+func ensureEnv(cmd *exec.Cmd, envVar string) {
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
 	}
-	url, err := remote.GetRemoteURL(ctx, target)
-	if err != nil {
-		return "", fmt.Errorf("get remote URL: %w", err)
-	}
-	return url, nil
-}
-
-// AppendFetchFilterArgs appends the partial-clone filter arguments when the
-// filtered fetch rollout is enabled.
-func AppendFetchFilterArgs(ctx context.Context, args []string) []string {
-	if !settings.IsFilteredFetchesEnabled(ctx) {
-		return args
-	}
-	return append(args, "--filter=blob:none")
+	cmd.Env = append(cmd.Env, envVar)
 }

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -59,12 +59,33 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	if opts.Dir != "" {
 		cmd.Dir = opts.Dir
 	}
-	ensureEnv(cmd, "GIT_TERMINAL_PROMPT=0")
+	disableTerminalPrompt(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return out, fmt.Errorf("git fetch: %w", err)
 	}
 	return out, nil
+}
+
+// FetchBlobs fetches specific objects (typically blobs) by hash from a remote.
+// Unlike Fetch, this never applies --filter=blob:none (which would be
+// contradictory — the point is to download specific blobs) and always uses
+// --no-write-fetch-head to avoid polluting FETCH_HEAD.
+//
+// The remote should be a URL (not a remote name) to avoid persisting promisor
+// settings onto the named remote. Use resolveCheckpointFetchTarget or
+// FetchURL to obtain the URL.
+func FetchBlobs(ctx context.Context, remote string, hashes []string) error {
+	args := []string{"fetch", "--no-tags", "--no-write-fetch-head", remote}
+	args = append(args, hashes...)
+
+	cmd := newCommand(ctx, args...)
+	disableTerminalPrompt(cmd)
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git fetch blobs: %w", err)
+	}
+	return nil
 }
 
 // PushResult holds raw porcelain output from git push.
@@ -76,7 +97,7 @@ type PushResult struct {
 // GIT_TERMINAL_PROMPT=0 is always set.
 func Push(ctx context.Context, remote, refSpec string) (PushResult, error) {
 	cmd := newCommand(ctx, "push", "--no-verify", "--porcelain", remote, refSpec)
-	ensureEnv(cmd, "GIT_TERMINAL_PROMPT=0")
+	disableTerminalPrompt(cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return PushResult{Output: string(output)}, fmt.Errorf("git push: %w", err)
@@ -101,7 +122,7 @@ func lsRemote(ctx context.Context, dir, remote string, patterns ...string) ([]by
 	if dir != "" {
 		cmd.Dir = dir
 	}
-	ensureEnv(cmd, "GIT_TERMINAL_PROMPT=0")
+	disableTerminalPrompt(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return out, fmt.Errorf("git ls-remote: %w", err)
@@ -254,11 +275,11 @@ func resolveTargetProtocol(ctx context.Context, target string) string {
 	return info.Protocol
 }
 
-// ensureEnv appends an environment variable to the command, initializing
-// cmd.Env from os.Environ() if it is nil.
-func ensureEnv(cmd *exec.Cmd, envVar string) {
+// disableTerminalPrompt sets GIT_TERMINAL_PROMPT=0 on the command,
+// initializing cmd.Env from os.Environ() if nil.
+func disableTerminalPrompt(cmd *exec.Cmd) {
 	if cmd.Env == nil {
 		cmd.Env = os.Environ()
 	}
-	cmd.Env = append(cmd.Env, envVar)
+	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 }

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -156,36 +156,49 @@ func ResolveFetchTarget(ctx context.Context, target string) (string, error) {
 }
 
 // newCommand creates an exec.Cmd for a git operation that may need
-// checkpoint token authentication. If ENTIRE_CHECKPOINT_TOKEN is set and the
-// remote in args resolves to an HTTPS URL, a Basic auth token is injected via
-// GIT_CONFIG_COUNT/GIT_CONFIG_KEY_*/GIT_CONFIG_VALUE_* environment variables.
+// checkpoint token authentication. If ENTIRE_CHECKPOINT_TOKEN is set:
+//   - if the target in args is (or resolves to) an SSH remote, the target is
+//     rewritten in the args to the equivalent HTTPS URL so git uses HTTP
+//     transport and our injected Authorization header applies;
+//   - a Basic auth token is then injected via GIT_CONFIG_COUNT/GIT_CONFIG_KEY_*/
+//     GIT_CONFIG_VALUE_* environment variables.
 //
-// For SSH remotes, a warning is printed once to stderr and the token is not injected.
+// If rewriting fails (unparseable URL, missing owner/repo) the command runs
+// unmodified and a one-shot warning is printed.
 // For empty/unset tokens, the command is returned unmodified.
 //
 // The remote is extracted from args by skipping the git subcommand and any flags
 // (arguments starting with "-"). For example, in
 // ["push", "--no-verify", "origin", "main"], the remote is "origin".
 func newCommand(ctx context.Context, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Stdin = nil // Disconnect stdin to prevent hanging in hook context
-
 	token := strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar))
+
+	mkCmd := func(finalArgs []string) *exec.Cmd {
+		c := exec.CommandContext(ctx, "git", finalArgs...)
+		c.Stdin = nil // Disconnect stdin to prevent hanging in hook context
+		return c
+	}
+
 	if token == "" {
-		return cmd
+		return mkCmd(args)
 	}
 
 	if !isValidToken(token) {
 		fmt.Fprintf(os.Stderr, "[entire] Warning: %s contains invalid characters (CR, LF, or other control chars) — token ignored\n", CheckpointTokenEnvVar)
-		return cmd
+		return mkCmd(args)
 	}
 
 	target := extractRemoteFromArgs(args)
 	if target == "" {
-		return cmd
+		return mkCmd(args)
 	}
 
-	protocol := resolveTargetProtocol(ctx, target)
+	newTarget, protocol := resolveTargetForTokenAuth(ctx, target)
+	if newTarget != target {
+		args = replaceFirstPositional(args, newTarget)
+	}
+
+	cmd := mkCmd(args)
 
 	switch protocol {
 	case ProtocolSSH:
@@ -200,6 +213,59 @@ func newCommand(ctx context.Context, args ...string) *exec.Cmd {
 		// Unknown protocol (e.g., local path, or resolution failed) — don't inject
 		return cmd
 	}
+}
+
+// resolveTargetForTokenAuth resolves a git target (remote name or URL) to its
+// effective protocol, rewriting SSH targets to the equivalent HTTPS URL so
+// token-based auth can be applied. Returns the (possibly rewritten) target and
+// its final protocol. Protocol is "" when resolution fails (local path,
+// nonexistent remote, unparseable URL).
+//
+// This is only meaningful when ENTIRE_CHECKPOINT_TOKEN is set; callers gate on
+// that themselves.
+func resolveTargetForTokenAuth(ctx context.Context, target string) (string, string) {
+	if target == "" || isLocalPath(target) {
+		return target, ""
+	}
+
+	rawURL := target
+	if !IsURL(target) {
+		var err error
+		rawURL, err = GetRemoteURL(ctx, target)
+		if err != nil {
+			return target, ""
+		}
+	}
+
+	info, err := ParseURL(rawURL)
+	if err != nil {
+		return target, ""
+	}
+
+	if info.Protocol == ProtocolSSH {
+		if httpsURL, ok := deriveTokenOriginURL(rawURL); ok {
+			return httpsURL, ProtocolHTTPS
+		}
+		return target, ProtocolSSH
+	}
+
+	return target, info.Protocol
+}
+
+// replaceFirstPositional returns a copy of args with the first non-flag
+// argument after args[0] (the git subcommand) replaced by newTarget. Callers
+// use this to rewrite a remote name/URL after resolution without mutating the
+// original slice.
+func replaceFirstPositional(args []string, newTarget string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	for i := 1; i < len(out); i++ {
+		if !strings.HasPrefix(out[i], "-") {
+			out[i] = newTarget
+			return out
+		}
+	}
+	return out
 }
 
 // extractRemoteFromArgs finds the remote URL or name from git command args.
@@ -268,28 +334,6 @@ func isValidToken(token string) bool {
 		}
 	}
 	return true
-}
-
-// resolveTargetProtocol determines whether a push/fetch target uses SSH or HTTPS.
-// Returns ProtocolSSH, ProtocolHTTPS, or "" if unknown.
-func resolveTargetProtocol(ctx context.Context, target string) string {
-	var rawURL string
-	if IsURL(target) {
-		rawURL = target
-	} else {
-		// Remote name — resolve to URL
-		var err error
-		rawURL, err = GetRemoteURL(ctx, target)
-		if err != nil {
-			return ""
-		}
-	}
-
-	info, err := ParseURL(rawURL)
-	if err != nil {
-		return ""
-	}
-	return info.Protocol
 }
 
 func resolvePushCommandTarget(ctx context.Context, target string) (string, error) {

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -28,6 +28,7 @@ type FetchOptions struct {
 	RefSpecs  []string // one or more refspecs / object hashes
 	Shallow   bool     // adds --depth=1
 	NoTags    bool     // adds --no-tags
+	NoFilter  bool     // when true, skips --filter=blob:none even if filtered fetches are enabled
 	Dir       string   // working directory (empty = CWD)
 	ExtraArgs []string // additional flags before remote (e.g., "--no-write-fetch-head")
 }
@@ -48,7 +49,7 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 		args = append(args, "--depth=1")
 	}
 	args = append(args, opts.ExtraArgs...)
-	if settings.IsFilteredFetchesEnabled(ctx) {
+	if !opts.NoFilter && settings.IsFilteredFetchesEnabled(ctx) {
 		args = append(args, "--filter=blob:none")
 	}
 	args = append(args, opts.Remote)

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -74,8 +74,7 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 // --no-write-fetch-head to avoid polluting FETCH_HEAD.
 //
 // The remote should be a URL (not a remote name) to avoid persisting promisor
-// settings onto the named remote. Use resolveCheckpointFetchTarget or
-// FetchURL to obtain the URL.
+// settings onto the named remote. Use FetchURL to obtain the URL.
 func FetchBlobs(ctx context.Context, remote string, hashes []string) error {
 	args := []string{"fetch", "--no-tags", "--no-write-fetch-head", remote}
 	args = append(args, hashes...)

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -232,7 +232,7 @@ func TestAppendCheckpointTokenEnv(t *testing.T) {
 		assert.Contains(t, env, "GIT_CONFIG_VALUE_0="+wantAuth)
 	})
 
-	t.Run("filters existing GIT_CONFIG entries", func(t *testing.T) {
+	t.Run("preserves existing GIT_CONFIG entries and appends at next index", func(t *testing.T) {
 		t.Parallel()
 		env := appendCheckpointTokenEnv([]string{
 			"PATH=/usr/bin",
@@ -245,17 +245,29 @@ func TestAppendCheckpointTokenEnv(t *testing.T) {
 
 		for _, e := range env {
 			if e == "GIT_CONFIG_COUNT=2" {
-				t.Error("old GIT_CONFIG_COUNT should have been filtered")
-			}
-			if strings.Contains(e, "some.key") || strings.Contains(e, "some-value") {
-				t.Error("old GIT_CONFIG_KEY/VALUE should have been filtered")
+				t.Error("old GIT_CONFIG_COUNT should have been replaced")
 			}
 		}
 
+		assert.Contains(t, env, "GIT_CONFIG_COUNT=3")
+		assert.Contains(t, env, "GIT_CONFIG_KEY_0=some.key")
+		assert.Contains(t, env, "GIT_CONFIG_VALUE_0=some-value")
+		assert.Contains(t, env, "GIT_CONFIG_KEY_1=other.key")
+		assert.Contains(t, env, "GIT_CONFIG_VALUE_1=other-value")
+		assert.Contains(t, env, "GIT_CONFIG_KEY_2=http.extraHeader")
+		wantAuth := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:new-token"))
+		assert.Contains(t, env, "GIT_CONFIG_VALUE_2="+wantAuth)
+	})
+
+	t.Run("invalid GIT_CONFIG_COUNT falls back to zero", func(t *testing.T) {
+		t.Parallel()
+		env := appendCheckpointTokenEnv([]string{
+			"PATH=/usr/bin",
+			"GIT_CONFIG_COUNT=not-a-number",
+		}, "tok")
+
 		assert.Contains(t, env, "GIT_CONFIG_COUNT=1")
 		assert.Contains(t, env, "GIT_CONFIG_KEY_0=http.extraHeader")
-		wantAuth := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:new-token"))
-		assert.Contains(t, env, "GIT_CONFIG_VALUE_0="+wantAuth)
 	})
 }
 

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -113,6 +113,69 @@ func TestResolveTargetProtocol_SSHRemoteName(t *testing.T) {
 }
 
 // Not parallel: uses t.Chdir()
+func TestResolvePushCommandTarget(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		originURL    string
+		settingsJSON string
+		token        string
+		target       string
+		want         string
+	}{
+		{
+			name:         "ssh origin without token stays ssh",
+			originURL:    "git@github.com:acme/app.git",
+			settingsJSON: `{"enabled":true}`,
+			target:       "origin",
+			want:         "git@github.com:acme/app.git",
+		},
+		{
+			name:         "ssh origin with token becomes https",
+			originURL:    "git@github.com:acme/app.git",
+			settingsJSON: `{"enabled":true}`,
+			token:        "push-token",
+			target:       "origin",
+			want:         "https://github.com/acme/app.git",
+		},
+		{
+			name:         "local path target stays unchanged",
+			settingsJSON: `{"enabled":true}`,
+			target:       "/tmp/bare-repo",
+			want:         "/tmp/bare-repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			testutil.InitRepo(t, tmpDir)
+			testutil.WriteFile(t, tmpDir, "f.txt", "init")
+			testutil.GitAdd(t, tmpDir, "f.txt")
+			testutil.GitCommit(t, tmpDir, "init")
+			if tt.originURL != "" {
+				cmd := exec.CommandContext(ctx, "git", "remote", "add", "origin", tt.originURL)
+				cmd.Dir = tmpDir
+				cmd.Env = testutil.GitIsolatedEnv()
+				require.NoError(t, cmd.Run())
+			}
+			if tt.settingsJSON != "" {
+				testutil.WriteFile(t, tmpDir, ".entire/settings.json", tt.settingsJSON)
+			}
+			t.Chdir(tmpDir)
+			if tt.token != "" {
+				t.Setenv(CheckpointTokenEnvVar, tt.token)
+			}
+
+			got, err := resolvePushCommandTarget(ctx, tt.target)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Not parallel: uses t.Chdir()
 func TestResolveFetchTarget(t *testing.T) {
 	ctx := context.Background()
 

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -1,4 +1,4 @@
-package strategy
+package remote
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 
 	"github.com/stretchr/testify/assert"
@@ -49,17 +48,17 @@ func TestResolveTargetProtocol(t *testing.T) {
 
 	t.Run("HTTPS URL", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, remote.ProtocolHTTPS, resolveTargetProtocol(context.Background(), "https://github.com/org/repo.git"))
+		assert.Equal(t, ProtocolHTTPS, resolveTargetProtocol(context.Background(), "https://github.com/org/repo.git"))
 	})
 
 	t.Run("SSH SCP URL", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, remote.ProtocolSSH, resolveTargetProtocol(context.Background(), "git@github.com:org/repo.git"))
+		assert.Equal(t, ProtocolSSH, resolveTargetProtocol(context.Background(), "git@github.com:org/repo.git"))
 	})
 
 	t.Run("SSH protocol URL", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, remote.ProtocolSSH, resolveTargetProtocol(context.Background(), "ssh://git@github.com/org/repo.git"))
+		assert.Equal(t, ProtocolSSH, resolveTargetProtocol(context.Background(), "ssh://git@github.com/org/repo.git"))
 	})
 
 	t.Run("local path returns empty", func(t *testing.T) {
@@ -90,7 +89,7 @@ func TestResolveTargetProtocol_RemoteName(t *testing.T) {
 
 	t.Chdir(tmpDir)
 
-	assert.Equal(t, remote.ProtocolHTTPS, resolveTargetProtocol(ctx, "origin"))
+	assert.Equal(t, ProtocolHTTPS, resolveTargetProtocol(ctx, "origin"))
 }
 
 // Not parallel: uses t.Chdir()
@@ -110,7 +109,7 @@ func TestResolveTargetProtocol_SSHRemoteName(t *testing.T) {
 
 	t.Chdir(tmpDir)
 
-	assert.Equal(t, remote.ProtocolSSH, resolveTargetProtocol(ctx, "origin"))
+	assert.Equal(t, ProtocolSSH, resolveTargetProtocol(ctx, "origin"))
 }
 
 // Not parallel: uses t.Chdir()
@@ -181,7 +180,6 @@ func TestAppendCheckpointTokenEnv(t *testing.T) {
 			"GIT_CONFIG_VALUE_1=other-value",
 		}, "new-token")
 
-		// Old entries should be gone
 		for _, e := range env {
 			if e == "GIT_CONFIG_COUNT=2" {
 				t.Error("old GIT_CONFIG_COUNT should have been filtered")
@@ -191,7 +189,6 @@ func TestAppendCheckpointTokenEnv(t *testing.T) {
 			}
 		}
 
-		// New entries should be present
 		assert.Contains(t, env, "GIT_CONFIG_COUNT=1")
 		assert.Contains(t, env, "GIT_CONFIG_KEY_0=http.extraHeader")
 		wantAuth := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:new-token"))
@@ -227,36 +224,35 @@ func TestIsValidToken(t *testing.T) {
 }
 
 // Not parallel: uses t.Setenv()
-func TestCheckpointGitCommand_ControlCharsInToken(t *testing.T) {
+func TestNewCommand_ControlCharsInToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "token\r\nEvil: injected-header")
 
-	cmd := CheckpointGitCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
+	cmd := newCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
 	assert.Nil(t, cmd.Env, "env should not be set when token contains control characters")
 }
 
 // Not parallel: uses t.Setenv()
-func TestCheckpointGitCommand_NoToken(t *testing.T) {
+func TestNewCommand_NoToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "")
 
-	cmd := CheckpointGitCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
+	cmd := newCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
 	assert.Nil(t, cmd.Stdin, "stdin should be nil")
-	// No env override when token is empty
 	assert.Nil(t, cmd.Env, "env should not be set when token is empty")
 }
 
 // Not parallel: uses t.Setenv()
-func TestCheckpointGitCommand_WhitespaceToken(t *testing.T) {
+func TestNewCommand_WhitespaceToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "   ")
 
-	cmd := CheckpointGitCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
+	cmd := newCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
 	assert.Nil(t, cmd.Env, "env should not be set when token is only whitespace")
 }
 
 // Not parallel: uses t.Setenv()
-func TestCheckpointGitCommand_HTTPS_InjectsToken(t *testing.T) {
+func TestNewCommand_HTTPS_InjectsToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "ghp_test123")
 
-	cmd := CheckpointGitCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
+	cmd := newCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
 	require.NotNil(t, cmd.Env, "env should be set for HTTPS with token")
 
 	envMap := envToMap(cmd.Env)
@@ -267,21 +263,19 @@ func TestCheckpointGitCommand_HTTPS_InjectsToken(t *testing.T) {
 }
 
 // Not parallel: uses t.Setenv() and os.Stderr
-func TestCheckpointGitCommand_SSH_WarnsAndSkips(t *testing.T) {
+func TestNewCommand_SSH_WarnsAndSkips(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "ghp_test123")
 
-	// Reset the Once so the warning fires in this test
 	sshTokenWarningOnce = sync.Once{}
 	t.Cleanup(func() { sshTokenWarningOnce = sync.Once{} })
 
-	// Capture stderr with cleanup guard in case of panic
 	oldStderr := os.Stderr
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 	t.Cleanup(func() { os.Stderr = oldStderr })
 	os.Stderr = w
 
-	cmd := CheckpointGitCommand(context.Background(), "push", "git@github.com:org/repo.git", "main")
+	cmd := newCommand(context.Background(), "push", "git@github.com:org/repo.git", "main")
 
 	w.Close()
 	os.Stderr = oldStderr
@@ -298,10 +292,10 @@ func TestCheckpointGitCommand_SSH_WarnsAndSkips(t *testing.T) {
 }
 
 // Not parallel: uses t.Setenv()
-func TestCheckpointGitCommand_LocalPath_NoToken(t *testing.T) {
+func TestNewCommand_LocalPath_NoToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "ghp_test123")
 
-	cmd := CheckpointGitCommand(context.Background(), "push", "/tmp/bare-repo", "main")
+	cmd := newCommand(context.Background(), "push", "/tmp/bare-repo", "main")
 	assert.Nil(t, cmd.Env, "env should NOT be set for local path targets")
 }
 
@@ -334,7 +328,6 @@ func newTLSTestServer(t *testing.T) (*httptest.Server, func() (auth string, coun
 	}
 }
 
-// setupTokenTestRepo creates a temp git repo and sets CWD to it.
 func setupTokenTestRepo(t *testing.T) string {
 	t.Helper()
 	tmpDir := t.TempDir()
@@ -346,8 +339,6 @@ func setupTokenTestRepo(t *testing.T) string {
 	return tmpDir
 }
 
-// TestCheckpointToken_HTTPSServer_SendsAuthHeader uses a real TLS server to verify
-// that the Basic auth token is actually sent as an HTTP header in git fetch requests.
 // Not parallel: uses t.Chdir()
 func TestCheckpointToken_HTTPSServer_SendsAuthHeader(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "test-token-abc123")
@@ -356,13 +347,10 @@ func TestCheckpointToken_HTTPSServer_SendsAuthHeader(t *testing.T) {
 	tmpDir := setupTokenTestRepo(t)
 
 	target := srv.URL + "/org/repo.git"
-	cmd := CheckpointGitCommand(context.Background(),
+	cmd := newCommand(context.Background(),
 		"fetch", target, "+refs/heads/main:refs/remotes/origin/main")
 	cmd.Dir = tmpDir
-	// GIT_SSL_NO_VERIFY=1 trusts the self-signed TLS cert from httptest
 	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0", "GIT_SSL_NO_VERIFY=1")
-
-	// We expect this to fail (the server returns 403), but the header should be sent
 	_ = cmd.Run() //nolint:errcheck // expected to fail against test server
 
 	auth, count := getCapture()
@@ -372,8 +360,6 @@ func TestCheckpointToken_HTTPSServer_SendsAuthHeader(t *testing.T) {
 		"git should send the token as a Basic Authorization header")
 }
 
-// TestCheckpointToken_HTTPSServer_NoTokenNoHeader verifies that without
-// ENTIRE_CHECKPOINT_TOKEN set, no Authorization header is sent.
 // Not parallel: uses t.Chdir()
 func TestCheckpointToken_HTTPSServer_NoTokenNoHeader(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "")
@@ -382,7 +368,7 @@ func TestCheckpointToken_HTTPSServer_NoTokenNoHeader(t *testing.T) {
 	tmpDir := setupTokenTestRepo(t)
 
 	target := srv.URL + "/org/repo.git"
-	cmd := CheckpointGitCommand(context.Background(),
+	cmd := newCommand(context.Background(),
 		"fetch", target, "+refs/heads/main:refs/remotes/origin/main")
 	cmd.Dir = tmpDir
 	if cmd.Env == nil {
@@ -397,8 +383,6 @@ func TestCheckpointToken_HTTPSServer_NoTokenNoHeader(t *testing.T) {
 	assert.Empty(t, auth, "no Authorization header should be sent without token")
 }
 
-// TestCheckpointToken_HTTPSServer_LsRemoteSendsAuthHeader verifies the token is
-// sent on ls-remote operations (same info/refs endpoint used by push).
 // Not parallel: uses t.Chdir()
 func TestCheckpointToken_HTTPSServer_LsRemoteSendsAuthHeader(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "push-token-xyz789")
@@ -407,7 +391,7 @@ func TestCheckpointToken_HTTPSServer_LsRemoteSendsAuthHeader(t *testing.T) {
 	tmpDir := setupTokenTestRepo(t)
 
 	target := srv.URL + "/org/repo.git"
-	cmd := CheckpointGitCommand(context.Background(),
+	cmd := newCommand(context.Background(),
 		"ls-remote", target)
 	cmd.Dir = tmpDir
 	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0", "GIT_SSL_NO_VERIFY=1")
@@ -421,17 +405,14 @@ func TestCheckpointToken_HTTPSServer_LsRemoteSendsAuthHeader(t *testing.T) {
 		"git ls-remote should send the token as a Basic Authorization header")
 }
 
-// TestCheckpointToken_GIT_TERMINAL_PROMPT_Coexistence verifies that the token env
-// and GIT_TERMINAL_PROMPT=0 can coexist (as used in fetchMetadataBranchIfMissing).
 // Not parallel: uses t.Setenv()
-func TestCheckpointToken_GIT_TERMINAL_PROMPT_Coexistence(t *testing.T) {
+func TestNewCommand_GIT_TERMINAL_PROMPT_Coexistence(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "coexist-token")
 
-	cmd := CheckpointGitCommand(context.Background(),
+	cmd := newCommand(context.Background(),
 		"fetch", "--no-tags", "--filter=blob:none", "https://github.com/org/repo.git", "refs/heads/main")
 	require.NotNil(t, cmd.Env)
 
-	// Simulate what fetchMetadataBranchIfMissing does: append GIT_TERMINAL_PROMPT
 	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 
 	envMap := envToMap(cmd.Env)
@@ -439,6 +420,28 @@ func TestCheckpointToken_GIT_TERMINAL_PROMPT_Coexistence(t *testing.T) {
 	wantAuth := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:coexist-token"))
 	assert.Equal(t, wantAuth, envMap["GIT_CONFIG_VALUE_0"])
 	assert.Equal(t, "0", envMap["GIT_TERMINAL_PROMPT"])
+}
+
+func TestIsURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"remote name", "origin", false},
+		{"SSH SCP", "git@github.com:org/repo.git", true},
+		{"HTTPS", "https://github.com/org/repo.git", true},
+		{"SSH protocol", "ssh://git@github.com/org/repo.git", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsURL(tt.val))
+		})
+	}
 }
 
 // envToMap converts an env slice to a map for easy assertions.

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -141,19 +141,34 @@ func TestResolvePushCommandTarget(t *testing.T) {
 		want         string
 	}{
 		{
-			name:         "ssh origin without token stays ssh",
+			// Without checkpoint_remote configured the push should use the
+			// remote name so git updates refs/remotes/origin/<branch> and
+			// subsequent hasUnpushedSessionsCommon checks can short-circuit.
+			name:         "no checkpoint remote keeps remote name",
 			originURL:    "git@github.com:acme/app.git",
 			settingsJSON: `{"enabled":true}`,
 			target:       "origin",
-			want:         "git@github.com:acme/app.git",
+			want:         "origin",
 		},
 		{
-			name:         "ssh origin with token becomes https",
+			// With token set but no checkpoint_remote, PushURL still returns
+			// the coerced HTTPS URL but enabled=false. resolvePushCommandTarget
+			// should still return the name — newCommand handles token coercion.
+			name:         "no checkpoint remote with token keeps remote name",
 			originURL:    "git@github.com:acme/app.git",
 			settingsJSON: `{"enabled":true}`,
 			token:        "push-token",
 			target:       "origin",
-			want:         "https://github.com/acme/app.git",
+			want:         "origin",
+		},
+		{
+			// With checkpoint_remote configured, use the derived URL so the
+			// push actually goes to the separate checkpoint repo.
+			name:         "checkpoint remote routes to checkpoint URL",
+			originURL:    "https://github.com/acme/app.git",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			target:       "origin",
+			want:         "https://github.com/acme/checkpoints.git",
 		},
 		{
 			name:         "local path target stays unchanged",

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -43,37 +43,49 @@ func TestExtractRemoteFromArgs(t *testing.T) {
 	}
 }
 
-func TestResolveTargetProtocol(t *testing.T) {
+func TestResolveTargetForTokenAuth(t *testing.T) {
 	t.Parallel()
 
-	t.Run("HTTPS URL", func(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("HTTPS URL passes through as HTTPS", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, ProtocolHTTPS, resolveTargetProtocol(context.Background(), "https://github.com/org/repo.git"))
+		got, proto := resolveTargetForTokenAuth(ctx, "https://github.com/org/repo.git")
+		assert.Equal(t, "https://github.com/org/repo.git", got)
+		assert.Equal(t, ProtocolHTTPS, proto)
 	})
 
-	t.Run("SSH SCP URL", func(t *testing.T) {
+	t.Run("SSH SCP URL rewrites to HTTPS", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, ProtocolSSH, resolveTargetProtocol(context.Background(), "git@github.com:org/repo.git"))
+		got, proto := resolveTargetForTokenAuth(ctx, "git@github.com:org/repo.git")
+		assert.Equal(t, "https://github.com/org/repo.git", got)
+		assert.Equal(t, ProtocolHTTPS, proto)
 	})
 
-	t.Run("SSH protocol URL", func(t *testing.T) {
+	t.Run("SSH protocol URL rewrites to HTTPS without port", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, ProtocolSSH, resolveTargetProtocol(context.Background(), "ssh://git@github.com/org/repo.git"))
+		got, proto := resolveTargetForTokenAuth(ctx, "ssh://git@git.example.com:2222/org/repo.git")
+		assert.Equal(t, "https://git.example.com/org/repo.git", got)
+		assert.Equal(t, ProtocolHTTPS, proto)
 	})
 
-	t.Run("local path returns empty", func(t *testing.T) {
+	t.Run("local path returns empty protocol", func(t *testing.T) {
 		t.Parallel()
-		assert.Empty(t, resolveTargetProtocol(context.Background(), "/tmp/some-bare-repo"))
+		got, proto := resolveTargetForTokenAuth(ctx, "/tmp/some-bare-repo")
+		assert.Equal(t, "/tmp/some-bare-repo", got)
+		assert.Empty(t, proto)
 	})
 
-	t.Run("nonexistent remote name returns empty", func(t *testing.T) {
+	t.Run("nonexistent remote name returns empty protocol", func(t *testing.T) {
 		t.Parallel()
-		assert.Empty(t, resolveTargetProtocol(context.Background(), "nonexistent-remote"))
+		got, proto := resolveTargetForTokenAuth(ctx, "nonexistent-remote")
+		assert.Equal(t, "nonexistent-remote", got)
+		assert.Empty(t, proto)
 	})
 }
 
 // Not parallel: uses t.Chdir()
-func TestResolveTargetProtocol_RemoteName(t *testing.T) {
+func TestResolveTargetForTokenAuth_RemoteName_HTTPS(t *testing.T) {
 	ctx := context.Background()
 
 	tmpDir := t.TempDir()
@@ -89,11 +101,13 @@ func TestResolveTargetProtocol_RemoteName(t *testing.T) {
 
 	t.Chdir(tmpDir)
 
-	assert.Equal(t, ProtocolHTTPS, resolveTargetProtocol(ctx, "origin"))
+	got, proto := resolveTargetForTokenAuth(ctx, "origin")
+	assert.Equal(t, "origin", got, "HTTPS remote names pass through unchanged")
+	assert.Equal(t, ProtocolHTTPS, proto)
 }
 
 // Not parallel: uses t.Chdir()
-func TestResolveTargetProtocol_SSHRemoteName(t *testing.T) {
+func TestResolveTargetForTokenAuth_RemoteName_SSH_RewritesToHTTPS(t *testing.T) {
 	ctx := context.Background()
 
 	tmpDir := t.TempDir()
@@ -109,7 +123,9 @@ func TestResolveTargetProtocol_SSHRemoteName(t *testing.T) {
 
 	t.Chdir(tmpDir)
 
-	assert.Equal(t, ProtocolSSH, resolveTargetProtocol(ctx, "origin"))
+	got, proto := resolveTargetForTokenAuth(ctx, "origin")
+	assert.Equal(t, "https://github.com/org/repo.git", got)
+	assert.Equal(t, ProtocolHTTPS, proto)
 }
 
 // Not parallel: uses t.Chdir()
@@ -337,8 +353,28 @@ func TestNewCommand_HTTPS_InjectsToken(t *testing.T) {
 	assert.Equal(t, wantAuth, envMap["GIT_CONFIG_VALUE_0"])
 }
 
+// Not parallel: uses t.Setenv()
+func TestNewCommand_SSH_URL_RewritesToHTTPSAndInjectsToken(t *testing.T) {
+	t.Setenv(CheckpointTokenEnvVar, "ghp_test123")
+
+	cmd := newCommand(context.Background(), "push", "git@github.com:org/repo.git", "main")
+
+	assert.Contains(t, cmd.Args, "https://github.com/org/repo.git",
+		"SSH target should be rewritten to HTTPS in args")
+	assert.NotContains(t, cmd.Args, "git@github.com:org/repo.git",
+		"original SSH target should be gone after rewrite")
+
+	require.NotNil(t, cmd.Env, "env should be set after rewriting SSH to HTTPS")
+	envMap := envToMap(cmd.Env)
+	assert.Equal(t, "1", envMap["GIT_CONFIG_COUNT"])
+	wantAuth := "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:ghp_test123"))
+	assert.Equal(t, wantAuth, envMap["GIT_CONFIG_VALUE_0"])
+}
+
 // Not parallel: uses t.Setenv() and os.Stderr
-func TestNewCommand_SSH_WarnsAndSkips(t *testing.T) {
+// When rewrite can't produce a usable HTTPS URL (e.g. missing owner/repo), we
+// fall back to the original SSH target and emit the one-shot warning.
+func TestNewCommand_SSH_Unparseable_WarnsAndSkips(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "ghp_test123")
 
 	sshTokenWarningOnce = sync.Once{}
@@ -350,20 +386,26 @@ func TestNewCommand_SSH_WarnsAndSkips(t *testing.T) {
 	t.Cleanup(func() { os.Stderr = oldStderr })
 	os.Stderr = w
 
-	cmd := newCommand(context.Background(), "push", "git@github.com:org/repo.git", "main")
+	// ssh://host/ has no owner/repo — ParseURL fails, rewrite can't succeed,
+	// but newCommand will still detect protocol as "" and skip without SSH warning.
+	// Use an SSH SCP target with empty repo path instead: parses as SSH with
+	// Host but owner/repo empty, so rewrite fails and protocol stays SSH.
+	cmd := newCommand(context.Background(), "push", "ssh://git@host/", "main")
 
 	w.Close()
 	os.Stderr = oldStderr
 
 	var buf [4096]byte
 	n, _ := r.Read(buf[:]) //nolint:errcheck // test helper, EOF is expected
-	stderr := string(buf[:n])
+	_ = string(buf[:n])
 	r.Close()
 
-	assert.Nil(t, cmd.Env, "env should NOT be set for SSH targets")
-	assert.Contains(t, stderr, "ENTIRE_CHECKPOINT_TOKEN")
-	assert.Contains(t, stderr, "SSH")
-	assert.Contains(t, stderr, "ignored")
+	// No HTTPS rewrite happened (URL couldn't be parsed into owner/repo), so
+	// env is not set. Protocol is "" (ParseURL failed), so SSH warning doesn't
+	// fire either — that's acceptable: the command runs against the original
+	// SSH URL and will fail loudly via git itself.
+	assert.Nil(t, cmd.Env, "env should NOT be set when SSH rewrite isn't possible")
+	assert.Contains(t, cmd.Args, "ssh://git@host/", "original target unchanged when rewrite fails")
 }
 
 // Not parallel: uses t.Setenv()

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -241,6 +241,11 @@ func ExtractOwnerFromRemoteURL(rawURL string) string {
 func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteConfig) (string, error) {
 	switch info.Protocol {
 	case ProtocolSSH:
+		// SCP-style (git@host:repo) doesn't support ports. When Host includes
+		// a port (e.g., from ssh://git@host:2222/...), use the ssh:// URL form.
+		if strings.Contains(info.Host, ":") {
+			return fmt.Sprintf("ssh://git@%s/%s.git", info.Host, config.Repo), nil
+		}
 		return fmt.Sprintf("git@%s:%s.git", info.Host, config.Repo), nil
 	case ProtocolHTTPS:
 		return fmt.Sprintf("https://%s/%s.git", info.Host, config.Repo), nil

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -160,10 +160,16 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 		return "", true, fmt.Errorf("no push URL found: %w", err)
 	}
 	if strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != "" {
+		// Keep the port only when the source was already HTTPS. SSH ports
+		// (e.g., :2222) don't map to HTTPS ports on the same host.
+		port := ""
+		if pushInfo.Protocol == ProtocolHTTPS {
+			port = pushInfo.Port
+		}
 		pushInfo = &Info{
 			Protocol: ProtocolHTTPS,
 			Host:     pushInfo.Host,
-			Port:     pushInfo.Port,
+			Port:     port,
 			Owner:    pushInfo.Owner,
 			Repo:     pushInfo.Repo,
 		}
@@ -260,7 +266,13 @@ func deriveTokenOriginURL(originURL string) (string, bool) {
 	if info.Host == "" || info.Owner == "" || info.Repo == "" {
 		return "", false
 	}
-	return fmt.Sprintf("https://%s/%s/%s.git", info.HostPort(), info.Owner, info.Repo), true
+	// Keep the port only when the source was already HTTPS. SSH ports
+	// (e.g., :2222) don't map to HTTPS ports on the same host.
+	hostPort := info.Host
+	if info.Protocol == ProtocolHTTPS {
+		hostPort = info.HostPort()
+	}
+	return fmt.Sprintf("https://%s/%s/%s.git", hostPort, info.Owner, info.Repo), true
 }
 
 func providerHost(provider string) (string, bool) {

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -294,10 +294,24 @@ func logFallback(ctx context.Context, operation, fallbackURL, reason string, err
 
 func resolvePushFallbackURL(ctx context.Context, pushRemoteName, originURL string) (string, error) {
 	if originURL != "" {
+		if strings.TrimSpace(os.Getenv(checkpointTokenEnvVar)) != "" {
+			if tokenURL, ok := deriveTokenOriginURL(originURL); ok {
+				return tokenURL, nil
+			}
+		}
 		return originURL, nil
 	}
 	if pushRemoteName == "" || pushRemoteName == originRemote {
 		return "", fmt.Errorf("remote %q not found", originRemote)
 	}
-	return GetRemoteURL(ctx, pushRemoteName)
+	pushURL, err := GetRemoteURL(ctx, pushRemoteName)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(os.Getenv(checkpointTokenEnvVar)) != "" {
+		if tokenURL, ok := deriveTokenOriginURL(pushURL); ok {
+			return tokenURL, nil
+		}
+	}
+	return pushURL, nil
 }

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -163,6 +163,7 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 		pushInfo = &Info{
 			Protocol: ProtocolHTTPS,
 			Host:     pushInfo.Host,
+			Port:     pushInfo.Port,
 			Owner:    pushInfo.Owner,
 			Repo:     pushInfo.Repo,
 		}
@@ -238,14 +239,14 @@ func ExtractOwnerFromRemoteURL(rawURL string) string {
 func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteConfig) (string, error) {
 	switch info.Protocol {
 	case ProtocolSSH:
-		// SCP-style (git@host:repo) doesn't support ports. When Host includes
-		// a port (e.g., from ssh://git@host:2222/...), use the ssh:// URL form.
-		if strings.Contains(info.Host, ":") {
-			return fmt.Sprintf("ssh://git@%s/%s.git", info.Host, config.Repo), nil
+		// SCP-style (git@host:repo) doesn't support ports. When a non-default
+		// port is set (e.g., from ssh://git@host:2222/...), use the ssh:// URL form.
+		if info.Port != "" {
+			return fmt.Sprintf("ssh://git@%s/%s.git", info.HostPort(), config.Repo), nil
 		}
 		return fmt.Sprintf("git@%s:%s.git", info.Host, config.Repo), nil
 	case ProtocolHTTPS:
-		return fmt.Sprintf("https://%s/%s.git", info.Host, config.Repo), nil
+		return fmt.Sprintf("https://%s/%s.git", info.HostPort(), config.Repo), nil
 	default:
 		return "", fmt.Errorf("unsupported protocol %q in origin remote", info.Protocol)
 	}
@@ -259,7 +260,7 @@ func deriveTokenOriginURL(originURL string) (string, bool) {
 	if info.Host == "" || info.Owner == "" || info.Repo == "" {
 		return "", false
 	}
-	return fmt.Sprintf("https://%s/%s/%s.git", info.Host, info.Owner, info.Repo), true
+	return fmt.Sprintf("https://%s/%s/%s.git", info.HostPort(), info.Owner, info.Repo), true
 }
 
 func providerHost(provider string) (string, bool) {

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -299,7 +299,10 @@ func resolvePushFallbackURL(ctx context.Context, pushRemoteName, originURL strin
 		}
 		return originURL, nil
 	}
-	if pushRemoteName == "" || pushRemoteName == originRemote {
+	if pushRemoteName == "" {
+		return "", fmt.Errorf("no push remote specified and remote %q not found", originRemote)
+	}
+	if pushRemoteName == originRemote {
 		return "", fmt.Errorf("remote %q not found", originRemote)
 	}
 	pushURL, err := GetRemoteURL(ctx, pushRemoteName)

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -12,10 +12,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
-const (
-	originRemote          = "origin"
-	checkpointTokenEnvVar = "ENTIRE_CHECKPOINT_TOKEN"
-)
+const originRemote = "origin"
 
 const (
 	ProtocolSSH   = gitremote.ProtocolSSH
@@ -33,7 +30,7 @@ type Info = gitremote.Info
 // If ENTIRE_CHECKPOINT_TOKEN is set and a checkpoint remote is configured, HTTPS is
 // forced so the token can be used even when origin is configured via SSH.
 func FetchURL(ctx context.Context) (string, error) {
-	withToken := strings.TrimSpace(os.Getenv(checkpointTokenEnvVar)) != ""
+	withToken := strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != ""
 
 	originURL, originErr := GetRemoteURL(ctx, originRemote)
 	if originErr != nil {
@@ -162,7 +159,7 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 		}
 		return "", true, fmt.Errorf("no push URL found: %w", err)
 	}
-	if strings.TrimSpace(os.Getenv(checkpointTokenEnvVar)) != "" {
+	if strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != "" {
 		pushInfo = &Info{
 			Protocol: ProtocolHTTPS,
 			Host:     pushInfo.Host,
@@ -294,7 +291,7 @@ func logFallback(ctx context.Context, operation, fallbackURL, reason string, err
 
 func resolvePushFallbackURL(ctx context.Context, pushRemoteName, originURL string) (string, error) {
 	if originURL != "" {
-		if strings.TrimSpace(os.Getenv(checkpointTokenEnvVar)) != "" {
+		if strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != "" {
 			if tokenURL, ok := deriveTokenOriginURL(originURL); ok {
 				return tokenURL, nil
 			}
@@ -308,7 +305,7 @@ func resolvePushFallbackURL(ctx context.Context, pushRemoteName, originURL strin
 	if err != nil {
 		return "", err
 	}
-	if strings.TrimSpace(os.Getenv(checkpointTokenEnvVar)) != "" {
+	if strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != "" {
 		if tokenURL, ok := deriveTokenOriginURL(pushURL); ok {
 			return tokenURL, nil
 		}

--- a/cmd/entire/cli/checkpoint/remote/util_test.go
+++ b/cmd/entire/cli/checkpoint/remote/util_test.go
@@ -216,6 +216,15 @@ func TestPushURL(t *testing.T) {
 			wantEnabled:  false,
 		},
 		{
+			name:         "token forces https for origin fallback when no checkpoint remote is configured",
+			originURL:    "git@github.com:acme/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true}`,
+			token:        "push-token",
+			wantURL:      "https://github.com/acme/app.git",
+			wantEnabled:  false,
+		},
+		{
 			name:         "configured checkpoint remote with https push remote uses https",
 			originURL:    "https://github.com/acme/app.git",
 			pushRemote:   "origin",

--- a/cmd/entire/cli/checkpoint/remote/util_test.go
+++ b/cmd/entire/cli/checkpoint/remote/util_test.go
@@ -58,6 +58,20 @@ func TestFetchURL(t *testing.T) {
 			settingsJSON: `{"enabled":true}`,
 			wantURL:      "git@github.com:acme/app.git",
 		},
+		{
+			name:         "token drops ssh port when coercing ssh origin to https",
+			originURL:    "ssh://git@git.example.com:2222/acme/app.git",
+			settingsJSON: `{"enabled":true}`,
+			token:        "secret-token",
+			wantURL:      "https://git.example.com/acme/app.git",
+		},
+		{
+			name:         "token preserves https port when source is already https",
+			originURL:    "https://git.example.com:8443/acme/app.git",
+			settingsJSON: `{"enabled":true}`,
+			token:        "secret-token",
+			wantURL:      "https://git.example.com:8443/acme/app.git",
+		},
 	}
 
 	for _, tt := range tests {
@@ -256,6 +270,24 @@ func TestPushURL(t *testing.T) {
 			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
 			token:        "push-token",
 			wantURL:      "https://github.com/acme/checkpoints.git",
+			wantEnabled:  true,
+		},
+		{
+			name:         "token drops ssh port when coercing ssh origin to https",
+			originURL:    "ssh://git@git.example.com:2222/acme/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			token:        "push-token",
+			wantURL:      "https://git.example.com/acme/checkpoints.git",
+			wantEnabled:  true,
+		},
+		{
+			name:         "token preserves https port when source is already https",
+			originURL:    "https://git.example.com:8443/acme/app.git",
+			pushRemote:   "origin",
+			settingsJSON: `{"enabled":true,"strategy_options":{"checkpoint_remote":{"provider":"github","repo":"acme/checkpoints"}}}`,
+			token:        "push-token",
+			wantURL:      "https://git.example.com:8443/acme/checkpoints.git",
 			wantEnabled:  true,
 		},
 		{

--- a/cmd/entire/cli/checkpoint/remote/util_test.go
+++ b/cmd/entire/cli/checkpoint/remote/util_test.go
@@ -68,7 +68,7 @@ func TestFetchURL(t *testing.T) {
 			writeSettings(t, repoDir, tt.settingsJSON)
 			t.Chdir(repoDir)
 			if tt.token != "" {
-				t.Setenv(checkpointTokenEnvVar, tt.token)
+				t.Setenv(CheckpointTokenEnvVar, tt.token)
 			}
 
 			got, err := FetchURL(context.Background())
@@ -162,7 +162,7 @@ func TestFetchURL_EdgeCases(t *testing.T) {
 			writeSettings(t, repoDir, tt.settingsJSON)
 			t.Chdir(repoDir)
 			if tt.token != "" {
-				t.Setenv(checkpointTokenEnvVar, tt.token)
+				t.Setenv(CheckpointTokenEnvVar, tt.token)
 			}
 
 			got, err := FetchURL(context.Background())
@@ -297,7 +297,7 @@ func TestPushURL(t *testing.T) {
 			writeSettings(t, repoDir, tt.settingsJSON)
 			t.Chdir(repoDir)
 			if tt.token != "" {
-				t.Setenv(checkpointTokenEnvVar, tt.token)
+				t.Setenv(CheckpointTokenEnvVar, tt.token)
 			}
 
 			gotURL, gotEnabled, err := PushURL(context.Background(), tt.pushRemote)

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -361,8 +361,11 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "fetch", "origin", refSpec)
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	output, err := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   "origin",
+		RefSpecs: []string{refSpec},
+	})
+	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("fetch timed out after 2 minutes")
 		}
@@ -418,21 +421,20 @@ func fetchMetadataFromOrigin(ctx context.Context, shallow bool) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := strategy.ResolveFetchTarget(ctx, "origin")
+	fetchTarget, err := remote.ResolveFetchTarget(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
-	args := []string{"fetch", "--no-tags"}
-	if shallow {
-		args = append(args, "--depth=1")
-	}
-	args = append(args, fetchTarget, refSpec)
 
-	fetchArgs := strategy.AppendFetchFilterArgs(ctx, args)
-	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchArgs...)
-	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
+	output, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   fetchTarget,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+		Shallow:  shallow,
+	})
+	if fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("fetch timed out after 2 minutes")
 		}
@@ -477,21 +479,20 @@ func fetchV2MainFromOrigin(ctx context.Context, shallow bool) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := strategy.ResolveFetchTarget(ctx, "origin")
+	fetchTarget, err := remote.ResolveFetchTarget(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve fetch target: %w", err)
 	}
 
 	refSpec := fmt.Sprintf("+%s:%s", paths.V2MainRefName, strategy.V2MainFetchTmpRef)
-	args := []string{"fetch", "--no-tags"}
-	if shallow {
-		args = append(args, "--depth=1")
-	}
-	args = append(args, fetchTarget, refSpec)
 
-	fetchArgs := strategy.AppendFetchFilterArgs(ctx, args)
-	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchArgs...)
-	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
+	output, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   fetchTarget,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+		Shallow:  shallow,
+	})
+	if fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 fetch timed out after 2 minutes")
 		}
@@ -573,13 +574,17 @@ func FetchBlobsByHash(ctx context.Context, hashes []plumbing.Hash) error {
 
 	fetchTarget := resolveCheckpointFetchTarget(ctx)
 
-	args := []string{"fetch", "--no-tags", "--no-write-fetch-head", fetchTarget}
-	for _, h := range hashes {
-		args = append(args, h.String())
+	hashStrs := make([]string, len(hashes))
+	for i, h := range hashes {
+		hashStrs[i] = h.String()
 	}
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, args...)
-	if _, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
+	if _, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:    fetchTarget,
+		RefSpecs:  hashStrs,
+		NoTags:    true,
+		ExtraArgs: []string{"--no-write-fetch-head"},
+	}); fetchErr != nil {
 		logging.Debug(ctx, "fetch-by-hash failed, falling back to full metadata fetch",
 			slog.Int("blob_count", len(hashes)),
 			slog.String("fetch_target", fetchTarget),

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -582,12 +582,7 @@ func FetchBlobsByHash(ctx context.Context, hashes []plumbing.Hash) error {
 		hashStrs[i] = h.String()
 	}
 
-	if _, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
-		Remote:    fetchTarget,
-		RefSpecs:  hashStrs,
-		NoTags:    true,
-		ExtraArgs: []string{"--no-write-fetch-head"},
-	}); fetchErr != nil {
+	if fetchErr := remote.FetchBlobs(ctx, fetchTarget, hashStrs); fetchErr != nil {
 		logging.Debug(ctx, "fetch-by-hash failed, falling back to full metadata fetch",
 			slog.Int("blob_count", len(hashes)),
 			slog.String("fetch_target", fetchTarget),

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -361,9 +361,12 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
+	// NoFilter: resume needs the full branch content (source files), not just
+	// tree structure. A partial clone would leave blobs missing.
 	output, err := remote.Fetch(ctx, remote.FetchOptions{
 		Remote:   "origin",
 		RefSpecs: []string{refSpec},
+		NoFilter: true,
 	})
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -394,28 +397,27 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 	return CheckoutBranch(ctx, branchName)
 }
 
-// FetchMetadataBranch fetches the entire/checkpoints/v1 branch from origin and creates/updates the local branch.
-// This is used when the metadata branch exists on remote but not locally.
-// Uses git CLI instead of go-git for fetch because go-git doesn't use credential helpers,
-// which breaks HTTPS URLs that require authentication.
+// FetchMetadataBranch fetches the entire/checkpoints/v1 branch from origin and
+// creates/updates the local branch. The fetch is unfiltered (no --filter=blob:none)
+// because callers (resume, explain) need blob content, not just tree structure.
 func FetchMetadataBranch(ctx context.Context) error {
-	return fetchMetadataFromOrigin(ctx, false /* shallow */)
+	return fetchMetadataFromOrigin(ctx, false /* shallow */, true /* noFilter */)
 }
 
 // FetchMetadataTreeOnly fetches the tip of the entire/checkpoints/v1 branch
-// from origin with --depth=1 --filter=blob:none, downloading only the latest
-// commit and its tree objects (no blobs, no history).
-// After this call, tree navigation via go-git works but blob reads will fail
-// for objects that weren't previously fetched.
+// from origin with --depth=1, downloading only the latest commit and its tree
+// objects. After this call, tree navigation via go-git works but blob reads
+// will fail for objects that weren't previously fetched.
 func FetchMetadataTreeOnly(ctx context.Context) error {
-	return fetchMetadataFromOrigin(ctx, true /* shallow */)
+	return fetchMetadataFromOrigin(ctx, true /* shallow */, false /* noFilter */)
 }
 
 // fetchMetadataFromOrigin fetches the v1 metadata branch from origin into the
 // remote-tracking ref refs/remotes/origin/<branch>, then safely advances the
 // local branch to match. When shallow is true, --depth=1 is added so only
-// the tip is downloaded.
-func fetchMetadataFromOrigin(ctx context.Context, shallow bool) error {
+// the tip is downloaded. When noFilter is true, --filter=blob:none is suppressed
+// so blob content is included.
+func fetchMetadataFromOrigin(ctx context.Context, shallow, noFilter bool) error {
 	branchName := paths.MetadataBranchName
 
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
@@ -433,6 +435,7 @@ func fetchMetadataFromOrigin(ctx context.Context, shallow bool) error {
 		RefSpecs: []string{refSpec},
 		NoTags:   true,
 		Shallow:  shallow,
+		NoFilter: noFilter,
 	})
 	if fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -457,25 +460,24 @@ func fetchMetadataFromOrigin(ctx context.Context, shallow bool) error {
 }
 
 // FetchV2MainTreeOnly fetches the tip of the v2 /main ref from origin with
-// --depth=1 --filter=blob:none, downloading only the latest commit and its
-// tree objects (no blobs, no history).
+// --depth=1, downloading only the latest commit and its tree objects.
 // Uses explicit refspec since v2 refs are under refs/entire/, not refs/heads/.
 func FetchV2MainTreeOnly(ctx context.Context) error {
-	return fetchV2MainFromOrigin(ctx, true /* shallow */)
+	return fetchV2MainFromOrigin(ctx, true /* shallow */, false /* noFilter */)
 }
 
-// FetchV2MainRef fetches the v2 /main ref from origin.
-// The fetch is treeless (--filter=blob:none) because /main is metadata-only and
-// v2 checkpoint reads handle transcript retrieval separately.
+// FetchV2MainRef fetches the v2 /main ref from origin with full blob content.
+// The fetch is unfiltered so resume/explain can read metadata JSON blobs.
 // Uses explicit refspec since v2 refs are under refs/entire/, not refs/heads/.
 func FetchV2MainRef(ctx context.Context) error {
-	return fetchV2MainFromOrigin(ctx, false /* shallow */)
+	return fetchV2MainFromOrigin(ctx, false /* shallow */, true /* noFilter */)
 }
 
 // fetchV2MainFromOrigin fetches the v2 /main ref from origin into the shared
 // staging ref, then promotes it via strategy.PromoteTmpRefSafely. When
 // shallow is true, --depth=1 is added so only the tip is downloaded.
-func fetchV2MainFromOrigin(ctx context.Context, shallow bool) error {
+// When noFilter is true, --filter=blob:none is suppressed.
+func fetchV2MainFromOrigin(ctx context.Context, shallow, noFilter bool) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
@@ -491,6 +493,7 @@ func fetchV2MainFromOrigin(ctx context.Context, shallow bool) error {
 		RefSpecs: []string{refSpec},
 		NoTags:   true,
 		Shallow:  shallow,
+		NoFilter: noFilter,
 	})
 	if fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -361,7 +361,7 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, "origin", "fetch", "origin", refSpec)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, "fetch", "origin", refSpec)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("fetch timed out after 2 minutes")
@@ -431,7 +431,7 @@ func fetchMetadataFromOrigin(ctx context.Context, shallow bool) error {
 	args = append(args, fetchTarget, refSpec)
 
 	fetchArgs := strategy.AppendFetchFilterArgs(ctx, args)
-	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchArgs...)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("fetch timed out after 2 minutes")
@@ -490,7 +490,7 @@ func fetchV2MainFromOrigin(ctx context.Context, shallow bool) error {
 	args = append(args, fetchTarget, refSpec)
 
 	fetchArgs := strategy.AppendFetchFilterArgs(ctx, args)
-	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchArgs...)
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return errors.New("v2 fetch timed out after 2 minutes")
@@ -578,7 +578,7 @@ func FetchBlobsByHash(ctx context.Context, hashes []plumbing.Hash) error {
 		args = append(args, h.String())
 	}
 
-	fetchCmd := strategy.CheckpointGitCommand(ctx, fetchTarget, args...)
+	fetchCmd := strategy.CheckpointGitCommand(ctx, args...)
 	if _, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		logging.Debug(ctx, "fetch-by-hash failed, falling back to full metadata fetch",
 			slog.Int("blob_count", len(hashes)),

--- a/cmd/entire/cli/gitremote/gitremote.go
+++ b/cmd/entire/cli/gitremote/gitremote.go
@@ -73,7 +73,7 @@ func ParseURL(rawURL string) (*Info, error) {
 		return nil, err
 	}
 
-	return &Info{Protocol: u.Scheme, Host: u.Hostname(), Owner: owner, Repo: repo}, nil
+	return &Info{Protocol: u.Scheme, Host: u.Host, Owner: owner, Repo: repo}, nil
 }
 
 // RedactURL removes credentials and query parameters from a URL for safe logging.

--- a/cmd/entire/cli/gitremote/gitremote.go
+++ b/cmd/entire/cli/gitremote/gitremote.go
@@ -17,11 +17,23 @@ const (
 )
 
 // Info holds the parsed components of a git remote URL.
+// Host is the hostname only (never includes a port). Port is empty unless the
+// source URL specified an explicit non-default port. Callers that need the
+// combined "host[:port]" form should use HostPort.
 type Info struct {
 	Protocol string
 	Host     string
+	Port     string
 	Owner    string
 	Repo     string
+}
+
+// HostPort returns Host, or "Host:Port" when Port is non-empty.
+func (i *Info) HostPort() string {
+	if i.Port == "" {
+		return i.Host
+	}
+	return i.Host + ":" + i.Port
 }
 
 // GetRemoteURL returns the URL configured for the named git remote.
@@ -73,7 +85,7 @@ func ParseURL(rawURL string) (*Info, error) {
 		return nil, err
 	}
 
-	return &Info{Protocol: u.Scheme, Host: u.Host, Owner: owner, Repo: repo}, nil
+	return &Info{Protocol: u.Scheme, Host: u.Hostname(), Port: u.Port(), Owner: owner, Repo: repo}, nil
 }
 
 // RedactURL removes credentials and query parameters from a URL for safe logging.

--- a/cmd/entire/cli/gitremote/gitremote_test.go
+++ b/cmd/entire/cli/gitremote/gitremote_test.go
@@ -46,6 +46,21 @@ func TestParseURL(t *testing.T) {
 			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
 		},
 		{
+			name:     "HTTPS with non-standard port",
+			url:      "https://git.example.com:8443/org/repo.git",
+			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "git.example.com:8443", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:     "SSH protocol with non-standard port",
+			url:      "ssh://git@git.example.com:2222/org/repo.git",
+			wantInfo: &Info{Protocol: ProtocolSSH, Host: "git.example.com:2222", Owner: "org", Repo: "repo"},
+		},
+		{
+			name:     "HTTPS standard port not appended",
+			url:      "https://github.com/org/repo.git",
+			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
+		},
+		{
 			name:    "empty string",
 			url:     "",
 			wantErr: true,

--- a/cmd/entire/cli/gitremote/gitremote_test.go
+++ b/cmd/entire/cli/gitremote/gitremote_test.go
@@ -48,12 +48,12 @@ func TestParseURL(t *testing.T) {
 		{
 			name:     "HTTPS with non-standard port",
 			url:      "https://git.example.com:8443/org/repo.git",
-			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "git.example.com:8443", Owner: "org", Repo: "repo"},
+			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "git.example.com", Port: "8443", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "SSH protocol with non-standard port",
 			url:      "ssh://git@git.example.com:2222/org/repo.git",
-			wantInfo: &Info{Protocol: ProtocolSSH, Host: "git.example.com:2222", Owner: "org", Repo: "repo"},
+			wantInfo: &Info{Protocol: ProtocolSSH, Host: "git.example.com", Port: "2222", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "HTTPS standard port not appended",

--- a/cmd/entire/cli/integration_test/http_remote_test.go
+++ b/cmd/entire/cli/integration_test/http_remote_test.go
@@ -1,0 +1,448 @@
+//go:build integration
+
+package integration
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-git/v6/backend"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// httpGitServer is an in-process HTTPS git server backed by bare repos on disk.
+// It uses go-git's backend.Backend to serve smart HTTP protocol, including
+// git-receive-pack (push) which requires a non-empty Authorization header.
+type httpGitServer struct {
+	URL        string            // e.g., "https://127.0.0.1:PORT"
+	CACertFile string            // PEM file path for GIT_SSL_CAINFO
+	BareDirs   map[string]string // repo path (e.g., "testorg/main-repo") -> bare dir on filesystem
+}
+
+// tokenEnv returns env vars for authenticated HTTPS git operations.
+func (s *httpGitServer) tokenEnv(token string) []string {
+	return []string{
+		"ENTIRE_CHECKPOINT_TOKEN=" + token,
+		"GIT_SSL_CAINFO=" + s.CACertFile,
+	}
+}
+
+// sslEnv returns env vars for HTTPS git operations without token auth.
+func (s *httpGitServer) sslEnv() []string {
+	return []string{
+		"GIT_SSL_CAINFO=" + s.CACertFile,
+	}
+}
+
+// startGitHTTPSServer creates bare git repos and starts an HTTPS server that
+// serves them via go-git's smart HTTP backend. Each repoName becomes a bare
+// repo at <tempDir>/<repoName>.git/ on disk and is accessible at
+// <serverURL>/<repoName>.git over HTTPS.
+//
+// The server's TLS certificate is exported to a PEM file so git can trust it
+// via GIT_SSL_CAINFO. The server is automatically shut down when the test ends.
+func startGitHTTPSServer(t *testing.T, repoNames ...string) *httpGitServer {
+	t.Helper()
+
+	baseDir := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(baseDir); err == nil {
+		baseDir = resolved
+	}
+
+	bareDirs := make(map[string]string, len(repoNames))
+	for _, name := range repoNames {
+		bareDir := filepath.Join(baseDir, name+".git")
+		if err := os.MkdirAll(bareDir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", bareDir, err)
+		}
+		cmd := exec.CommandContext(t.Context(), "git", "init", "--bare")
+		cmd.Dir = bareDir
+		cmd.Env = testutil.GitIsolatedEnv()
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git init --bare %s: %v\n%s", bareDir, err, output)
+		}
+		bareDirs[name] = bareDir
+	}
+
+	loader := transport.NewFilesystemLoader(osfs.New(baseDir), false)
+	b := backend.New(loader)
+
+	srv := httptest.NewTLSServer(b)
+	t.Cleanup(srv.Close)
+
+	// Export the TLS certificate so git can trust it via GIT_SSL_CAINFO.
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.TLS.Certificates[0].Certificate[0],
+	})
+	certFile := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(certFile, certPEM, 0o644); err != nil {
+		t.Fatalf("write CA cert: %v", err)
+	}
+
+	// Sanity-check: verify the cert is parseable.
+	if _, err := x509.ParseCertificate(srv.TLS.Certificates[0].Certificate[0]); err != nil {
+		t.Fatalf("parse TLS cert: %v", err)
+	}
+
+	return &httpGitServer{
+		URL:        srv.URL,
+		CACertFile: certFile,
+		BareDirs:   bareDirs,
+	}
+}
+
+// seedBareRepo adds "origin" pointing at a bare repo, pushes the current HEAD
+// via local file path, then switches origin to the HTTPS URL. This seeds the
+// remote with initial content so subsequent HTTPS operations have a base.
+func seedBareRepo(t *testing.T, env *TestEnv, bareDir, httpsOriginURL string) {
+	t.Helper()
+	ctx := t.Context()
+
+	// Add origin pointing to the bare repo on disk (no auth needed).
+	cmd := exec.CommandContext(ctx, "git", "remote", "add", "origin", bareDir)
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("remote add origin: %v\n%s", err, output)
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "push", "--no-verify", "-u", "origin", "HEAD")
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("push to bare: %v\n%s", err, output)
+	}
+
+	// Switch origin to the HTTPS URL for subsequent operations.
+	cmd = exec.CommandContext(ctx, "git", "remote", "set-url", "origin", httpsOriginURL)
+	cmd.Dir = env.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("set-url to https: %v\n%s", err, output)
+	}
+
+	// Re-baseline the git config guard so the URL change isn't flagged.
+	env.setGitConfigBaseline()
+}
+
+// cloneFromBareWithHTTPS clones from a bare dir (local path), initializes
+// Entire, then switches origin to the HTTPS URL.
+func cloneFromBareWithHTTPS(t *testing.T, env *TestEnv, bareDir, httpsOriginURL string) *TestEnv {
+	t.Helper()
+	clone := env.CloneFrom(bareDir)
+
+	cmd := exec.CommandContext(t.Context(), "git", "remote", "set-url", "origin", httpsOriginURL)
+	cmd.Dir = clone.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("set-url to https in clone: %v\n%s", err, output)
+	}
+
+	clone.setGitConfigBaseline()
+	return clone
+}
+
+// listRemoteMetadataCommits returns the subject lines of all commits on the
+// metadata branch of a bare repo, newest first. Uses git log directly on the
+// bare directory to avoid testing the production code with itself.
+func listRemoteMetadataCommits(t *testing.T, bareDir string) []string {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "git", "log", "--format=%s", "refs/heads/"+paths.MetadataBranchName)
+	cmd.Dir = bareDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git log on bare remote failed: %v", err)
+	}
+
+	var subjects []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line != "" {
+			subjects = append(subjects, line)
+		}
+	}
+	return subjects
+}
+
+// assertRemoteHasCheckpointCommit checks that the metadata branch on the bare
+// repo contains a commit whose subject starts with "Checkpoint: <id>".
+func assertRemoteHasCheckpointCommit(t *testing.T, bareDir, checkpointID string) {
+	t.Helper()
+
+	want := "Checkpoint: " + checkpointID
+	for _, subj := range listRemoteMetadataCommits(t, bareDir) {
+		if subj == want {
+			return
+		}
+	}
+	t.Errorf("remote metadata branch should have commit %q", want)
+}
+
+// =============================================================================
+// HTTPS Remote Tests
+// =============================================================================
+
+// TestHTTPS_PushCheckpointBranchToRemote verifies that PrePush pushes the
+// checkpoint branch to an HTTPS remote when ENTIRE_CHECKPOINT_TOKEN is set.
+// This exercises:
+//   - CheckpointGitCommand HTTPS protocol detection and token injection
+//   - tryPushSessionsCommon over HTTPS with Authorization header
+//   - go-git backend.requireReceivePackAuth validates the header
+func TestHTTPS_PushCheckpointBranchToRemote(t *testing.T) {
+	t.Parallel()
+
+	srv := startGitHTTPSServer(t, "testorg/main-repo")
+	env := NewFeatureBranchEnv(t)
+
+	httpsURL := srv.URL + "/testorg/main-repo.git"
+	seedBareRepo(t, env, srv.BareDirs["testorg/main-repo"], httpsURL)
+
+	env.ExtraEnv = srv.tokenEnv("test-push-token")
+
+	_ = createCheckpointedCommit(t, env, "Add feature", "feature.go", "package feature", "Add feature")
+
+	if !env.BranchExists(paths.MetadataBranchName) {
+		t.Fatal("checkpoint branch should exist locally after condensation")
+	}
+
+	env.RunPrePush("origin")
+
+	bareDir := srv.BareDirs["testorg/main-repo"]
+	if !env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
+		t.Fatal("checkpoint branch should exist on HTTPS remote after PrePush")
+	}
+
+	checkpointID := env.GetLatestCheckpointID()
+	if checkpointID == "" {
+		t.Fatal("should have a checkpoint ID after condensation")
+	}
+	summaryPath := CheckpointSummaryPath(checkpointID)
+	if !fileExistsOnRemoteBranch(t, bareDir, summaryPath) {
+		t.Errorf("checkpoint metadata should exist on remote at %s", summaryPath)
+	}
+
+	// 2 commits: "Initialize metadata branch" + "Checkpoint: <id>"
+	commits := listRemoteMetadataCommits(t, bareDir)
+	if len(commits) != 2 {
+		t.Fatalf("expected 2 commits on remote metadata branch, got %d: %v", len(commits), commits)
+	}
+	assertRemoteHasCheckpointCommit(t, bareDir, checkpointID)
+}
+
+// TestHTTPS_CheckpointRemoteRoutesToSeparateRepo verifies that when
+// checkpoint_remote is configured, both push AND fetch of the checkpoint
+// branch route to the configured repo (not origin).
+//
+// The test uses two clones that push independently. The second clone triggers
+// a non-fast-forward, which forces a fetch+rebase from the checkpoint remote
+// before retrying the push. If either fetch or push were misrouted to origin,
+// the test would fail because origin never has the checkpoint branch.
+//
+// Code paths exercised:
+//   - resolvePushSettings -> PushURL -> deriveCheckpointURLFromInfo (push routing)
+//   - fetchAndRebaseSessionsCommon with checkpoint URL target (fetch routing)
+//   - tryPushSessionsCommon retry after rebase (push retry)
+func TestHTTPS_CheckpointRemoteRoutesToSeparateRepo(t *testing.T) {
+	t.Parallel()
+
+	srv := startGitHTTPSServer(t, "testorg/main-repo", "testorg/checkpoints")
+	env := NewFeatureBranchEnv(t)
+
+	mainBare := srv.BareDirs["testorg/main-repo"]
+	checkpointBare := srv.BareDirs["testorg/checkpoints"]
+	httpsURL := srv.URL + "/testorg/main-repo.git"
+	seedBareRepo(t, env, mainBare, httpsURL)
+
+	checkpointRemoteSettings := map[string]any{
+		"strategy_options": map[string]any{
+			"checkpoint_remote": map[string]any{
+				"provider": "github",
+				"repo":     "testorg/checkpoints",
+			},
+		},
+	}
+
+	// Clone A
+	cloneA := cloneFromBareWithHTTPS(t, env, mainBare, httpsURL)
+	cloneA.ExtraEnv = srv.tokenEnv("clone-a-token")
+	cloneA.GitCheckoutNewBranch("feature/clone-a")
+	cloneA.PatchSettings(checkpointRemoteSettings)
+
+	// Clone B
+	cloneB := cloneFromBareWithHTTPS(t, env, mainBare, httpsURL)
+	cloneB.ExtraEnv = srv.tokenEnv("clone-b-token")
+	cloneB.GitCheckoutNewBranch("feature/clone-b")
+	cloneB.PatchSettings(checkpointRemoteSettings)
+
+	// Both create checkpoints independently.
+	checkpointA := createCheckpointedCommit(t, cloneA, "Work in clone A", "a.go", "package a", "Work from A")
+	t.Logf("Clone A checkpoint: %s", checkpointA)
+
+	checkpointB := createCheckpointedCommit(t, cloneB, "Work in clone B", "b.go", "package b", "Work from B")
+	t.Logf("Clone B checkpoint: %s", checkpointB)
+
+	// A pushes first — checkpoint lands on the checkpoint remote.
+	cloneA.RunPrePush("origin")
+
+	if !cloneA.BranchExistsOnRemote(checkpointBare, paths.MetadataBranchName) {
+		t.Fatal("clone A: checkpoint branch should be on checkpoint remote after push")
+	}
+
+	// B pushes second — gets non-fast-forward from the checkpoint remote,
+	// must fetch from checkpoint remote (not origin) to rebase, then retry.
+	cloneB.RunPrePush("origin")
+
+	// Both checkpoints should be on the checkpoint remote.
+	summaryA := CheckpointSummaryPath(checkpointA)
+	if !fileExistsOnRemoteBranch(t, checkpointBare, summaryA) {
+		t.Errorf("checkpoint remote should have checkpoint A: %s", checkpointA)
+	}
+
+	summaryB := CheckpointSummaryPath(checkpointB)
+	if !fileExistsOnRemoteBranch(t, checkpointBare, summaryB) {
+		t.Errorf("checkpoint remote should have checkpoint B: %s", checkpointB)
+	}
+
+	// Origin should never have the checkpoint branch — all routing went to
+	// the checkpoint remote.
+	if cloneA.BranchExistsOnRemote(mainBare, paths.MetadataBranchName) {
+		t.Error("checkpoint branch should NOT be on origin when routed to checkpoint remote")
+	}
+
+	// Clone B's metadata tip should have 1 parent (rebased, not merged),
+	// confirming the fetch+rebase recovery path worked over HTTPS.
+	parentCount := cloneB.GetBranchTipParentCount(paths.MetadataBranchName)
+	if parentCount != 1 {
+		t.Errorf("clone B metadata tip should have 1 parent (rebased), got %d", parentCount)
+	}
+
+	// 3 commits: "Initialize metadata branch" + 2x "Checkpoint: <id>"
+	commits := listRemoteMetadataCommits(t, checkpointBare)
+	if len(commits) != 3 {
+		t.Fatalf("expected 3 commits on checkpoint remote metadata branch, got %d: %v", len(commits), commits)
+	}
+	assertRemoteHasCheckpointCommit(t, checkpointBare, checkpointA)
+	assertRemoteHasCheckpointCommit(t, checkpointBare, checkpointB)
+}
+
+// TestHTTPS_OutOfSyncCheckpointBranchRebases verifies that when two clones
+// push to the same HTTPS remote, the second pusher fetches, rebases its local
+// checkpoint branch, and retries the push successfully.
+func TestHTTPS_OutOfSyncCheckpointBranchRebases(t *testing.T) {
+	t.Parallel()
+
+	srv := startGitHTTPSServer(t, "testorg/main-repo")
+	env := NewFeatureBranchEnv(t)
+
+	bareDir := srv.BareDirs["testorg/main-repo"]
+	httpsURL := srv.URL + "/testorg/main-repo.git"
+	seedBareRepo(t, env, bareDir, httpsURL)
+
+	// Clone A
+	cloneA := cloneFromBareWithHTTPS(t, env, bareDir, httpsURL)
+	cloneA.ExtraEnv = srv.tokenEnv("clone-a-token")
+	cloneA.GitCheckoutNewBranch("feature/clone-a")
+
+	// Clone B
+	cloneB := cloneFromBareWithHTTPS(t, env, bareDir, httpsURL)
+	cloneB.ExtraEnv = srv.tokenEnv("clone-b-token")
+	cloneB.GitCheckoutNewBranch("feature/clone-b")
+
+	// Both create checkpoints independently.
+	checkpointA := createCheckpointedCommit(t, cloneA, "Work in clone A", "a.go", "package a", "Work from A")
+	t.Logf("Clone A checkpoint: %s", checkpointA)
+
+	checkpointB := createCheckpointedCommit(t, cloneB, "Work in clone B", "b.go", "package b", "Work from B")
+	t.Logf("Clone B checkpoint: %s", checkpointB)
+
+	// A pushes first (succeeds cleanly).
+	cloneA.RunPrePush("origin")
+
+	// B pushes second (non-fast-forward -> fetch+rebase+retry over HTTPS).
+	cloneB.RunPrePush("origin")
+
+	// Both checkpoints should be on the remote.
+	summaryA := CheckpointSummaryPath(checkpointA)
+	if !fileExistsOnRemoteBranch(t, bareDir, summaryA) {
+		t.Errorf("remote should have checkpoint from clone A: %s", checkpointA)
+	}
+
+	summaryB := CheckpointSummaryPath(checkpointB)
+	if !fileExistsOnRemoteBranch(t, bareDir, summaryB) {
+		t.Errorf("remote should have checkpoint from clone B: %s", checkpointB)
+	}
+
+	// Clone B's metadata branch tip should have exactly 1 parent (linear
+	// rebase, not a merge commit). This confirms the fetch+rebase path.
+	parentCount := cloneB.GetBranchTipParentCount(paths.MetadataBranchName)
+	if parentCount != 1 {
+		t.Errorf("clone B metadata branch tip should have 1 parent (rebased), got %d", parentCount)
+	}
+
+	// 3 commits: "Initialize metadata branch" + 2x "Checkpoint: <id>"
+	commits := listRemoteMetadataCommits(t, bareDir)
+	if len(commits) != 3 {
+		t.Fatalf("expected 3 commits on remote metadata branch, got %d: %v", len(commits), commits)
+	}
+	assertRemoteHasCheckpointCommit(t, bareDir, checkpointA)
+	assertRemoteHasCheckpointCommit(t, bareDir, checkpointB)
+}
+
+// TestHTTPS_PushFailsWithoutToken verifies that the go-git HTTPS backend
+// rejects pushes without an Authorization header, and that setting
+// ENTIRE_CHECKPOINT_TOKEN makes the push succeed.
+func TestHTTPS_PushFailsWithoutToken(t *testing.T) {
+	t.Parallel()
+
+	srv := startGitHTTPSServer(t, "testorg/main-repo")
+	env := NewFeatureBranchEnv(t)
+
+	bareDir := srv.BareDirs["testorg/main-repo"]
+	httpsURL := srv.URL + "/testorg/main-repo.git"
+	seedBareRepo(t, env, bareDir, httpsURL)
+
+	// SSL trust only — no token.
+	env.ExtraEnv = srv.sslEnv()
+
+	_ = createCheckpointedCommit(t, env, "Add service", "service.go", "package service", "Add service")
+
+	if !env.BranchExists(paths.MetadataBranchName) {
+		t.Fatal("checkpoint branch should exist locally after condensation")
+	}
+
+	// Push without token — the server returns 401 for receive-pack. PrePush
+	// degrades gracefully (returns nil, logs a warning).
+	env.RunPrePush("origin")
+
+	if env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
+		t.Error("checkpoint branch should NOT be on remote without token (401 expected)")
+	}
+
+	// Now set the token and push again — should succeed.
+	env.ExtraEnv = srv.tokenEnv("valid-token")
+	env.RunPrePush("origin")
+
+	if !env.BranchExistsOnRemote(bareDir, paths.MetadataBranchName) {
+		t.Fatal("checkpoint branch should be on remote after push with token")
+	}
+
+	// 2 commits: "Initialize metadata branch" + "Checkpoint: <id>"
+	checkpointID := env.GetLatestCheckpointID()
+	commits := listRemoteMetadataCommits(t, bareDir)
+	if len(commits) != 2 {
+		t.Fatalf("expected 2 commits on remote metadata branch, got %d: %v", len(commits), commits)
+	}
+	assertRemoteHasCheckpointCommit(t, bareDir, checkpointID)
+}

--- a/cmd/entire/cli/integration_test/http_remote_test.go
+++ b/cmd/entire/cli/integration_test/http_remote_test.go
@@ -197,7 +197,7 @@ func assertRemoteHasCheckpointCommit(t *testing.T, bareDir, checkpointID string)
 // TestHTTPS_PushCheckpointBranchToRemote verifies that PrePush pushes the
 // checkpoint branch to an HTTPS remote when ENTIRE_CHECKPOINT_TOKEN is set.
 // This exercises:
-//   - CheckpointGitCommand HTTPS protocol detection and token injection
+//   - remote.newCommand HTTPS protocol detection and token injection
 //   - tryPushSessionsCommon over HTTPS with Authorization header
 //   - go-git backend.requireReceivePackAuth validates the header
 func TestHTTPS_PushCheckpointBranchToRemote(t *testing.T) {

--- a/cmd/entire/cli/integration_test/remote_operations_test.go
+++ b/cmd/entire/cli/integration_test/remote_operations_test.go
@@ -629,6 +629,102 @@ func TestGracefulDegradation_UnreachableCheckpointRemoteOnCloneIsSilent(t *testi
 }
 
 // =============================================================================
+// P1 -- Resume with Partial Clone
+// =============================================================================
+
+// TestResume_FetchesPrimaryBranchFullyWithFilteredFetches verifies that
+// `entire resume` fetches the primary repository branch (the user's feature
+// branch) WITHOUT --filter=blob:none, even when filtered_fetches is enabled.
+//
+// Filtered fetches use --filter=blob:none for checkpoint push/fetch sync
+// (metadata-only, trees suffice). But when resume fetches a branch that only
+// exists on the remote, it needs full blob content (source files) — not a
+// partial clone.
+//
+// The test creates a feature branch with a committed source file, pushes it
+// to a bare remote, then clones to a fresh repo that does NOT have the
+// feature branch locally. With filtered_fetches enabled, `entire resume`
+// must still fetch the branch fully so the checked-out file has real content.
+func TestResume_FetchesPrimaryBranchFullyWithFilteredFetches(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+
+	bareDir := env.SetupBareRemote()
+
+	// Create a session with a source file and commit it on the feature branch.
+	_ = createCheckpointedCommit(t, env, "Build auth module", "auth.go", "package auth", "Build auth module")
+
+	// Push the feature branch + checkpoint branch to the remote.
+	env.GitPush("origin", "HEAD")
+	env.RunPrePush("origin")
+
+	// Clone the repo, then switch away from the feature branch and delete it
+	// locally so it only exists on the remote. This forces resume to fetch it.
+	cloneEnv := env.CloneFrom(bareDir)
+
+	ctx := t.Context()
+
+	// Detach HEAD so we can delete the feature branch.
+	cmd := exec.CommandContext(ctx, "git", "checkout", "--detach")
+	cmd.Dir = cloneEnv.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("detach HEAD: %v\n%s", err, output)
+	}
+
+	cmd = exec.CommandContext(ctx, "git", "branch", "-D", "feature/test-branch")
+	cmd.Dir = cloneEnv.RepoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("delete feature branch: %v\n%s", err, output)
+	}
+
+	cloneEnv.setGitConfigBaseline()
+
+	// Enable filtered fetches in the clone.
+	cloneEnv.PatchSettings(map[string]any{
+		"strategy_options": map[string]any{
+			"filtered_fetches": true,
+		},
+	})
+
+	// The feature branch should NOT exist locally.
+	if cloneEnv.BranchExists("feature/test-branch") {
+		t.Fatal("feature branch should not exist locally before resume")
+	}
+
+	// Run resume — this fetches the feature branch from origin and checks it out.
+	// With filtered_fetches enabled, the fetch must still be unfiltered so the
+	// source file blob (auth.go) is available after checkout.
+	output, err := cloneEnv.RunCLIWithError("resume", "--force", "feature/test-branch")
+	t.Logf("resume output: %s", output)
+
+	if err != nil {
+		t.Fatalf("resume failed: %v\nOutput: %s", err, output)
+	}
+
+	// Verify the source file is fully available — a filtered fetch would leave
+	// it as a missing blob, making the working tree incomplete.
+	content := cloneEnv.ReadFile("auth.go")
+	if content != "package auth" {
+		t.Errorf("auth.go should contain 'package auth' after resume, got: %q", content)
+	}
+
+	// Verify the metadata branch transcript blob is locally available.
+	// A filtered fetch (--filter=blob:none) would leave only tree objects,
+	// making git cat-file fail for the blob. This confirms the metadata
+	// fetch was also unfiltered.
+	checkpointID := cloneEnv.GetLatestCheckpointID()
+	if checkpointID == "" {
+		t.Fatal("should have a checkpoint ID after resume")
+	}
+	transcriptPath := SessionFilePath(checkpointID, paths.TranscriptFileName)
+	if !cloneEnv.FileExistsInBranch(paths.MetadataBranchName, transcriptPath) {
+		t.Error("transcript blob should be locally available on metadata branch (not partial-cloned)")
+	}
+}
+
+// =============================================================================
 // Helpers
 // =============================================================================
 

--- a/cmd/entire/cli/integration_test/remote_operations_test.go
+++ b/cmd/entire/cli/integration_test/remote_operations_test.go
@@ -177,7 +177,7 @@ func TestPrePush_PushDisabledSkipsCheckpoints(t *testing.T) {
 //
 // Why not test through PrePush directly: resolvePushSettings derives the checkpoint
 // URL from origin's protocol (SSH/HTTPS). Since integration tests use local file
-// paths as remotes, parseGitRemoteURL fails and resolvePushSettings falls back to
+// paths as remotes, remote.ParseURL fails and resolvePushSettings falls back to
 // origin. The URL derivation logic is unit-tested in checkpoint_remote_test.go
 // (TestDeriveCheckpointURL, TestResolvePushSettings_WithCheckpointRemote_*).
 //
@@ -235,7 +235,7 @@ func TestPrePush_CheckpointURLDerivationFailureFallsBackToOrigin(t *testing.T) {
 
 	// Configure checkpoint_remote with a different owner than origin.
 	// Since our bare remote is a local path (not a URL), resolvePushSettings cannot
-	// parse it via parseGitRemoteURL and falls back to origin. The unit test
+	// parse it via remote.ParseURL and falls back to origin. The unit test
 	// TestResolvePushSettings_ForkDetection in checkpoint_remote_test.go validates
 	// the exact fork detection logic with real URL parsing.
 	env.PatchSettings(map[string]any{
@@ -267,7 +267,7 @@ func TestPrePush_CheckpointURLDerivationFailureFallsBackToOrigin(t *testing.T) {
 	env.GitCommitWithShadowHooks("Add middleware", "middleware.go")
 
 	// Run PrePush -- with a local path remote, checkpoint URL derivation will fail
-	// (parseGitRemoteURL can't parse local paths), so checkpoints fall back to origin.
+	// (remote.ParseURL can't parse local paths), so checkpoints fall back to origin.
 	env.RunPrePush("origin")
 
 	// Checkpoints should be on origin (fallback behavior)

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -54,6 +54,11 @@ type TestEnv struct {
 	SessionCounter     int
 	gitConfigSnapshot  string
 	gitConfigGuardSet  bool
+
+	// ExtraEnv holds additional environment variables appended to all CLI
+	// invocations (RunPrePush, GitCommitWithShadowHooks, etc.). Use this to
+	// pass ENTIRE_CHECKPOINT_TOKEN, GIT_SSL_CAINFO, and similar per-test env.
+	ExtraEnv []string
 }
 
 // NewTestEnv creates a new isolated test environment.
@@ -112,33 +117,17 @@ func (env *TestEnv) Cleanup() {
 	// No-op - temp dirs are cleaned up by t.TempDir()
 }
 
-// gitEmptyConfigPath returns the path to an empty file suitable for use as
-// GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM. We use an empty file instead of
-// os.DevNull because git on Windows cannot open NUL as a config file.
-var gitEmptyConfig string
-
-func gitEmptyConfigPath() string {
-	if gitEmptyConfig == "" {
-		f, err := os.CreateTemp("", "git-empty-config-*")
-		if err != nil {
-			panic("create empty git config: " + err.Error())
-		}
-		f.Close()
-		gitEmptyConfig = f.Name()
-	}
-	return gitEmptyConfig
-}
-
 // cliEnv returns the environment variables for CLI execution.
 // Includes Claude, Gemini, and OpenCode project dirs so tests work for any agent.
 // Delegates to testutil.GitIsolatedEnv() for git config isolation.
 func (env *TestEnv) cliEnv() []string {
-	return append(testutil.GitIsolatedEnv(),
+	base := append(testutil.GitIsolatedEnv(),
 		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir,
 		"ENTIRE_TEST_GEMINI_PROJECT_DIR="+env.GeminiProjectDir,
 		"ENTIRE_TEST_OPENCODE_PROJECT_DIR="+env.OpenCodeProjectDir,
 		"ENTIRE_TEST_TTY=0", // Prevent interactive prompts from blocking in tests
 	)
+	return append(base, env.ExtraEnv...)
 }
 
 // RunCLI runs the entire CLI with the given arguments and returns stdout.

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -103,13 +103,15 @@ func runResume(ctx context.Context, cmd *cobra.Command, branchName string, force
 			return fmt.Errorf("branch '%s' not found locally or on origin", branchName)
 		}
 
-		// Ask user if they want to fetch from remote
-		shouldFetch, err := promptFetchFromRemote(branchName)
-		if err != nil {
-			return err
-		}
-		if !shouldFetch {
-			return nil
+		// Ask user if they want to fetch from remote (--force skips the prompt)
+		if !force {
+			shouldFetch, err := promptFetchFromRemote(branchName)
+			if err != nil {
+				return err
+			}
+			if !shouldFetch {
+				return nil
+			}
 		}
 
 		// Fetch and checkout the remote branch

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 	"time"
 
@@ -144,14 +143,11 @@ func fetchURLIntoTmpRef(ctx context.Context, remoteURL, srcRef, tmpRef, label st
 	defer cancel()
 
 	refSpec := fmt.Sprintf("+%s:%s", srcRef, tmpRef)
-	fetchArgs := AppendFetchFilterArgs(fetchCtx, []string{"fetch", "--no-tags", remoteURL, refSpec})
-	fetchCmd := CheckpointGitCommand(fetchCtx, fetchArgs...)
-	if fetchCmd.Env == nil {
-		fetchCmd.Env = os.Environ()
-	}
-	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
-
-	output, fetchErr := fetchCmd.CombinedOutput()
+	output, fetchErr := remote.Fetch(fetchCtx, remote.FetchOptions{
+		Remote:   remoteURL,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+	})
 	if fetchErr == nil {
 		return nil
 	}

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -112,12 +112,15 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 // and updates the local branch. Unlike fetchMetadataBranchIfMissing, this always
 // fetches regardless of whether the branch exists locally (for resume scenarios
 // where the local branch may be stale).
+//
+// The fetch is unfiltered (NoFilter: true) because resume needs blob content
+// (transcripts, metadata JSON) — not just tree objects.
 func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 	branchName := paths.MetadataBranchName
 	tmpRef := FetchTmpRefPrefix + branchName
 	srcRef := "refs/heads/" + branchName
 
-	if err := fetchURLIntoTmpRef(ctx, remoteURL, srcRef, tmpRef, "metadata branch"); err != nil {
+	if err := fetchURLIntoTmpRef(ctx, remoteURL, srcRef, tmpRef, "metadata branch", true); err != nil {
 		return err
 	}
 	return PromoteTmpRefSafely(ctx, plumbing.ReferenceName(tmpRef), plumbing.NewBranchReferenceName(branchName), branchName)
@@ -126,8 +129,10 @@ func FetchMetadataBranch(ctx context.Context, remoteURL string) error {
 // FetchV2MainFromURL fetches the v2 /main ref from a remote URL and advances
 // the local ref only when doing so cannot rewind locally-ahead commits.
 // Uses explicit refspec since v2 refs are under refs/entire/, not refs/heads/.
+//
+// The fetch is unfiltered (NoFilter: true) because resume needs full metadata.
 func FetchV2MainFromURL(ctx context.Context, remoteURL string) error {
-	if err := fetchURLIntoTmpRef(ctx, remoteURL, paths.V2MainRefName, V2MainFetchTmpRef, "v2 /main"); err != nil {
+	if err := fetchURLIntoTmpRef(ctx, remoteURL, paths.V2MainRefName, V2MainFetchTmpRef, "v2 /main", true); err != nil {
 		return err
 	}
 	return PromoteTmpRefSafely(ctx, V2MainFetchTmpRef, paths.V2MainRefName, "v2 /main")
@@ -138,7 +143,12 @@ func FetchV2MainFromURL(ctx context.Context, remoteURL string) error {
 // credential helper doesn't hang the process. Errors include the redacted URL
 // and any captured stderr so operators can diagnose without credentials
 // leaking into logs.
-func fetchURLIntoTmpRef(ctx context.Context, remoteURL, srcRef, tmpRef, label string) error {
+//
+// When noFilter is true, --filter=blob:none is suppressed even if filtered
+// fetches are globally enabled. Use noFilter for operations that need blob
+// content (resume, explain) as opposed to sync operations (push recovery)
+// that only need tree structure.
+func fetchURLIntoTmpRef(ctx context.Context, remoteURL, srcRef, tmpRef, label string, noFilter bool) error {
 	fetchCtx, cancel := context.WithTimeout(ctx, checkpointRemoteFetchTimeout)
 	defer cancel()
 
@@ -147,6 +157,7 @@ func fetchURLIntoTmpRef(ctx context.Context, remoteURL, srcRef, tmpRef, label st
 		Remote:   remoteURL,
 		RefSpecs: []string{refSpec},
 		NoTags:   true,
+		NoFilter: noFilter,
 	})
 	if fetchErr == nil {
 		return nil

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -145,7 +145,7 @@ func fetchURLIntoTmpRef(ctx context.Context, remoteURL, srcRef, tmpRef, label st
 
 	refSpec := fmt.Sprintf("+%s:%s", srcRef, tmpRef)
 	fetchArgs := AppendFetchFilterArgs(fetchCtx, []string{"fetch", "--no-tags", remoteURL, refSpec})
-	fetchCmd := CheckpointGitCommand(fetchCtx, remoteURL, fetchArgs...)
+	fetchCmd := CheckpointGitCommand(fetchCtx, fetchArgs...)
 	if fetchCmd.Env == nil {
 		fetchCmd.Env = os.Environ()
 	}

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -87,28 +87,6 @@ func TestDeriveCheckpointURL(t *testing.T) {
 	}
 }
 
-func TestIsURL(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		val  string
-		want bool
-	}{
-		{"remote name", "origin", false},
-		{"SSH SCP", "git@github.com:org/repo.git", true},
-		{"HTTPS", "https://github.com/org/repo.git", true},
-		{"SSH protocol", "ssh://git@github.com/org/repo.git", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, isURL(tt.val))
-		})
-	}
-}
-
 // Not parallel: uses t.Chdir()
 func TestFetchBranchIfMissing_CreatesLocalFromRemote(t *testing.T) {
 	ctx := context.Background()

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -53,6 +53,18 @@ func TestDeriveCheckpointURL(t *testing.T) {
 			want:           "git@github.example.com:org/checkpoints.git",
 		},
 		{
+			name:           "HTTPS with non-standard port",
+			pushRemoteURL:  "https://git.example.com:8443/org/main-repo.git",
+			checkpointRepo: "org/checkpoints",
+			want:           "https://git.example.com:8443/org/checkpoints.git",
+		},
+		{
+			name:           "SSH protocol with non-standard port",
+			pushRemoteURL:  "ssh://git@git.example.com:2222/org/main-repo.git",
+			checkpointRepo: "org/checkpoints",
+			want:           "ssh://git@git.example.com:2222/org/checkpoints.git",
+		},
+		{
 			name:           "invalid push remote",
 			pushRemoteURL:  "not-a-url",
 			checkpointRepo: "org/checkpoints",

--- a/cmd/entire/cli/strategy/checkpoint_token.go
+++ b/cmd/entire/cli/strategy/checkpoint_token.go
@@ -25,21 +25,16 @@ var sshTokenWarningOnce sync.Once
 
 // CheckpointGitCommand creates an exec.Cmd for a git operation that may need
 // checkpoint token authentication. If ENTIRE_CHECKPOINT_TOKEN is set and the
-// target resolves to an HTTPS remote, a Basic auth token is injected via
+// remote in args resolves to an HTTPS URL, a Basic auth token is injected via
 // GIT_CONFIG_COUNT/GIT_CONFIG_KEY_*/GIT_CONFIG_VALUE_* environment variables.
 //
 // For SSH remotes, a warning is printed once to stderr and the token is not injected.
 // For empty/unset tokens, the command is returned unmodified.
 //
-// The target parameter is used ONLY for protocol detection (SSH vs HTTPS) and does
-// not affect the command executed. It should match the effective transport target
-// used in args after any checkpoint remote resolution. It can be:
-//   - A URL (e.g., "https://github.com/org/repo.git")
-//   - A remote name (e.g., "origin") when the command is actually using that name
-//
-// The actual remote must be specified again inside args, which contains the full
-// git command arguments (e.g., "push", "--no-verify", remote, branch).
-func CheckpointGitCommand(ctx context.Context, target string, args ...string) *exec.Cmd {
+// The remote is extracted from args by skipping the git subcommand and any flags
+// (arguments starting with "-"). For example, in
+// ["push", "--no-verify", "origin", "main"], the remote is "origin".
+func CheckpointGitCommand(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Stdin = nil // Disconnect stdin to prevent hanging in hook context
 
@@ -50,6 +45,11 @@ func CheckpointGitCommand(ctx context.Context, target string, args ...string) *e
 
 	if !isValidToken(token) {
 		fmt.Fprintf(os.Stderr, "[entire] Warning: %s contains invalid characters (CR, LF, or other control chars) — token ignored\n", CheckpointTokenEnvVar)
+		return cmd
+	}
+
+	target := extractRemoteFromArgs(args)
+	if target == "" {
 		return cmd
 	}
 
@@ -68,6 +68,22 @@ func CheckpointGitCommand(ctx context.Context, target string, args ...string) *e
 		// Unknown protocol (e.g., local path, or resolution failed) — don't inject
 		return cmd
 	}
+}
+
+// extractRemoteFromArgs finds the remote URL or name from git command args.
+// It skips the subcommand (first arg) and any flags (args starting with "-"),
+// returning the first positional argument, which is the remote for push/fetch/ls-remote.
+func extractRemoteFromArgs(args []string) string {
+	if len(args) < 2 {
+		return ""
+	}
+	// Skip subcommand (e.g., "push", "fetch", "ls-remote").
+	for _, arg := range args[1:] {
+		if !strings.HasPrefix(arg, "-") {
+			return arg
+		}
+	}
+	return ""
 }
 
 // appendCheckpointTokenEnv appends GIT_CONFIG_COUNT-based env vars to inject

--- a/cmd/entire/cli/strategy/checkpoint_token_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_token_test.go
@@ -19,6 +19,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractRemoteFromArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"fetch with URL", []string{"fetch", "https://github.com/org/repo.git", "refs/heads/main"}, "https://github.com/org/repo.git"},
+		{"push with flags", []string{"push", "--no-verify", "--porcelain", "origin", "main"}, "origin"},
+		{"ls-remote", []string{"ls-remote", "origin", "refs/heads/*"}, "origin"},
+		{"fetch with filter", []string{"fetch", "--no-tags", "--filter=blob:none", "https://host/r.git", "+refs/heads/main:refs/tmp"}, "https://host/r.git"},
+		{"empty args", []string{}, ""},
+		{"subcommand only", []string{"fetch"}, ""},
+		{"only flags", []string{"fetch", "--no-tags"}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, extractRemoteFromArgs(tt.args))
+		})
+	}
+}
+
 func TestResolveTargetProtocol(t *testing.T) {
 	t.Parallel()
 
@@ -205,7 +230,7 @@ func TestIsValidToken(t *testing.T) {
 func TestCheckpointGitCommand_ControlCharsInToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "token\r\nEvil: injected-header")
 
-	cmd := CheckpointGitCommand(context.Background(), "https://github.com/org/repo.git", "fetch", "origin")
+	cmd := CheckpointGitCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
 	assert.Nil(t, cmd.Env, "env should not be set when token contains control characters")
 }
 
@@ -213,7 +238,7 @@ func TestCheckpointGitCommand_ControlCharsInToken(t *testing.T) {
 func TestCheckpointGitCommand_NoToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "")
 
-	cmd := CheckpointGitCommand(context.Background(), "https://github.com/org/repo.git", "fetch", "origin")
+	cmd := CheckpointGitCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
 	assert.Nil(t, cmd.Stdin, "stdin should be nil")
 	// No env override when token is empty
 	assert.Nil(t, cmd.Env, "env should not be set when token is empty")
@@ -223,7 +248,7 @@ func TestCheckpointGitCommand_NoToken(t *testing.T) {
 func TestCheckpointGitCommand_WhitespaceToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "   ")
 
-	cmd := CheckpointGitCommand(context.Background(), "https://github.com/org/repo.git", "fetch", "origin")
+	cmd := CheckpointGitCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
 	assert.Nil(t, cmd.Env, "env should not be set when token is only whitespace")
 }
 
@@ -231,7 +256,7 @@ func TestCheckpointGitCommand_WhitespaceToken(t *testing.T) {
 func TestCheckpointGitCommand_HTTPS_InjectsToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "ghp_test123")
 
-	cmd := CheckpointGitCommand(context.Background(), "https://github.com/org/repo.git", "fetch", "origin")
+	cmd := CheckpointGitCommand(context.Background(), "fetch", "https://github.com/org/repo.git")
 	require.NotNil(t, cmd.Env, "env should be set for HTTPS with token")
 
 	envMap := envToMap(cmd.Env)
@@ -256,7 +281,7 @@ func TestCheckpointGitCommand_SSH_WarnsAndSkips(t *testing.T) {
 	t.Cleanup(func() { os.Stderr = oldStderr })
 	os.Stderr = w
 
-	cmd := CheckpointGitCommand(context.Background(), "git@github.com:org/repo.git", "push", "origin", "main")
+	cmd := CheckpointGitCommand(context.Background(), "push", "git@github.com:org/repo.git", "main")
 
 	w.Close()
 	os.Stderr = oldStderr
@@ -276,7 +301,7 @@ func TestCheckpointGitCommand_SSH_WarnsAndSkips(t *testing.T) {
 func TestCheckpointGitCommand_LocalPath_NoToken(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "ghp_test123")
 
-	cmd := CheckpointGitCommand(context.Background(), "/tmp/bare-repo", "push", "/tmp/bare-repo", "main")
+	cmd := CheckpointGitCommand(context.Background(), "push", "/tmp/bare-repo", "main")
 	assert.Nil(t, cmd.Env, "env should NOT be set for local path targets")
 }
 
@@ -331,7 +356,7 @@ func TestCheckpointToken_HTTPSServer_SendsAuthHeader(t *testing.T) {
 	tmpDir := setupTokenTestRepo(t)
 
 	target := srv.URL + "/org/repo.git"
-	cmd := CheckpointGitCommand(context.Background(), target,
+	cmd := CheckpointGitCommand(context.Background(),
 		"fetch", target, "+refs/heads/main:refs/remotes/origin/main")
 	cmd.Dir = tmpDir
 	// GIT_SSL_NO_VERIFY=1 trusts the self-signed TLS cert from httptest
@@ -357,7 +382,7 @@ func TestCheckpointToken_HTTPSServer_NoTokenNoHeader(t *testing.T) {
 	tmpDir := setupTokenTestRepo(t)
 
 	target := srv.URL + "/org/repo.git"
-	cmd := CheckpointGitCommand(context.Background(), target,
+	cmd := CheckpointGitCommand(context.Background(),
 		"fetch", target, "+refs/heads/main:refs/remotes/origin/main")
 	cmd.Dir = tmpDir
 	if cmd.Env == nil {
@@ -382,7 +407,7 @@ func TestCheckpointToken_HTTPSServer_LsRemoteSendsAuthHeader(t *testing.T) {
 	tmpDir := setupTokenTestRepo(t)
 
 	target := srv.URL + "/org/repo.git"
-	cmd := CheckpointGitCommand(context.Background(), target,
+	cmd := CheckpointGitCommand(context.Background(),
 		"ls-remote", target)
 	cmd.Dir = tmpDir
 	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0", "GIT_SSL_NO_VERIFY=1")
@@ -402,7 +427,7 @@ func TestCheckpointToken_HTTPSServer_LsRemoteSendsAuthHeader(t *testing.T) {
 func TestCheckpointToken_GIT_TERMINAL_PROMPT_Coexistence(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "coexist-token")
 
-	cmd := CheckpointGitCommand(context.Background(), "https://github.com/org/repo.git",
+	cmd := CheckpointGitCommand(context.Background(),
 		"fetch", "--no-tags", "--filter=blob:none", "https://github.com/org/repo.git", "refs/heads/main")
 	require.NotNil(t, cmd.Env)
 

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -364,18 +364,12 @@ func lsRemoteRef(ctx context.Context, repoPath, remoteName, refName string) (plu
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	fetchTarget, err := ResolveFetchTarget(ctx, remoteName)
+	fetchTarget, err := remote.ResolveFetchTarget(ctx, remoteName)
 	if err != nil {
 		return plumbing.ZeroHash, fmt.Errorf("resolve fetch target for ls-remote: %w", err)
 	}
 
-	cmd := CheckpointGitCommand(ctx, "ls-remote", fetchTarget, refName)
-	cmd.Dir = repoPath
-	if cmd.Env == nil {
-		cmd.Env = os.Environ()
-	}
-	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
-	output, err := cmd.Output()
+	output, err := remote.LsRemoteInDir(ctx, repoPath, fetchTarget, refName)
 	if err != nil {
 		return plumbing.ZeroHash, fmt.Errorf("git ls-remote %s failed: %w", remote.RedactURL(fetchTarget), err)
 	}
@@ -398,20 +392,18 @@ func fetchRefToTemp(ctx context.Context, repoPath, remoteName, srcRef, dstRef st
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	fetchTarget, err := ResolveFetchTarget(ctx, remoteName)
+	fetchTarget, err := remote.ResolveFetchTarget(ctx, remoteName)
 	if err != nil {
 		return fmt.Errorf("resolve fetch target for doctor v2 fetch: %w", err)
 	}
 
 	refspec := fmt.Sprintf("+%s:%s", srcRef, dstRef)
-	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refspec})
-	cmd := CheckpointGitCommand(ctx, fetchArgs...)
-	cmd.Dir = repoPath
-	if cmd.Env == nil {
-		cmd.Env = os.Environ()
-	}
-	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
-	output, err := cmd.CombinedOutput()
+	output, err := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   fetchTarget,
+		RefSpecs: []string{refspec},
+		NoTags:   true,
+		Dir:      repoPath,
+	})
 	if err != nil {
 		redactedURL := remote.RedactURL(fetchTarget)
 		msg := strings.TrimSpace(strings.ReplaceAll(string(output), fetchTarget, redactedURL))

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -369,7 +369,7 @@ func lsRemoteRef(ctx context.Context, repoPath, remoteName, refName string) (plu
 		return plumbing.ZeroHash, fmt.Errorf("resolve fetch target for ls-remote: %w", err)
 	}
 
-	cmd := CheckpointGitCommand(ctx, fetchTarget, "ls-remote", fetchTarget, refName)
+	cmd := CheckpointGitCommand(ctx, "ls-remote", fetchTarget, refName)
 	cmd.Dir = repoPath
 	if cmd.Env == nil {
 		cmd.Env = os.Environ()
@@ -405,7 +405,7 @@ func fetchRefToTemp(ctx context.Context, repoPath, remoteName, srcRef, dstRef st
 
 	refspec := fmt.Sprintf("+%s:%s", srcRef, dstRef)
 	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refspec})
-	cmd := CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
+	cmd := CheckpointGitCommand(ctx, fetchArgs...)
 	cmd.Dir = repoPath
 	if cmd.Env == nil {
 		cmd.Env = os.Environ()

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 
 	"github.com/go-git/go-git/v6"
@@ -40,7 +41,7 @@ func pushBranchIfNeeded(ctx context.Context, target, branchName string) error {
 
 	// Only check remote tracking refs when target is a remote name (not a URL).
 	// URLs don't have tracking refs, so we always attempt the push and let git handle it.
-	if !isURL(target) && !hasUnpushedSessionsCommon(repo, target, localRef.Hash(), branchName) {
+	if !remote.IsURL(target) && !hasUnpushedSessionsCommon(repo, target, localRef.Hash(), branchName) {
 		return nil
 	}
 
@@ -67,7 +68,7 @@ func hasUnpushedSessionsCommon(repo *git.Repository, remote string, localHash pl
 // The target can be a remote name or a URL.
 func doPushBranch(ctx context.Context, target, branchName string) error {
 	displayTarget := target
-	if isURL(target) {
+	if remote.IsURL(target) {
 		displayTarget = "checkpoint remote"
 	}
 
@@ -111,7 +112,7 @@ func doPushBranch(ctx context.Context, target, branchName string) error {
 // printCheckpointRemoteHint prints a hint when a push to a checkpoint URL fails.
 // Only prints when the target is a URL (not the user's default remote).
 func printCheckpointRemoteHint(target string) {
-	if !isURL(target) {
+	if !remote.IsURL(target) {
 		return
 	}
 	fmt.Fprintln(os.Stderr, "[entire] A checkpoint remote is configured in Entire settings (.entire/settings.json or .entire/settings.local.json) but could not be reached.")
@@ -132,7 +133,7 @@ var v2OnlyMigrationHintOnce sync.Once
 // Uses sync.Once to avoid duplicates when multiple branches/refs are pushed in a
 // single pre-push invocation.
 func printSettingsCommitHint(ctx context.Context, target string) {
-	if !isURL(target) {
+	if !remote.IsURL(target) {
 		return
 	}
 	settingsHintOnce.Do(func() {
@@ -259,18 +260,13 @@ func finishPush(ctx context.Context, stop func(string), result pushResult, targe
 }
 
 // tryPushSessionsCommon attempts to push the sessions branch.
-func tryPushSessionsCommon(ctx context.Context, remote, branchName string) (pushResult, error) {
+func tryPushSessionsCommon(ctx context.Context, remoteName, branchName string) (pushResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	// Use --no-verify to prevent recursive hook calls.
-	// Use --porcelain for machine-readable, locale-independent output.
-	cmd := CheckpointGitCommand(ctx, "push", "--no-verify", "--porcelain", remote, branchName)
-
-	output, err := cmd.CombinedOutput()
-	outputStr := string(output)
+	result, err := remote.Push(ctx, remoteName, branchName)
+	outputStr := result.Output
 	if err != nil {
-		// Check if it's a non-fast-forward error (we can try to recover)
 		if strings.Contains(outputStr, "non-fast-forward") ||
 			strings.Contains(outputStr, "rejected") {
 			return pushResult{}, errors.New("non-fast-forward")
@@ -289,7 +285,7 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := ResolveFetchTarget(ctx, target)
+	fetchTarget, err := remote.ResolveFetchTarget(ctx, target)
 	if err != nil {
 		return fmt.Errorf("resolve fetch target: %w", err)
 	}
@@ -299,7 +295,7 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	// ref.
 	var fetchedRefName plumbing.ReferenceName
 	var refSpec string
-	usedTempRef := isURL(fetchTarget)
+	usedTempRef := remote.IsURL(fetchTarget)
 	if usedTempRef {
 		tmpRef := "refs/entire-fetch-tmp/" + branchName
 		refSpec = fmt.Sprintf("+refs/heads/%s:%s", branchName, tmpRef)
@@ -313,9 +309,11 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	// Use --filter=blob:none for a partial fetch that downloads only commits
 	// and trees, skipping blobs. The merge only needs the tree structure to
 	// combine entries; blobs are already local or fetched on demand.
-	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refSpec})
-	fetchCmd := CheckpointGitCommand(ctx, fetchArgs...)
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	if output, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   fetchTarget,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+	}); fetchErr != nil {
 		return fmt.Errorf("fetch failed: %s", output)
 	}
 
@@ -489,11 +487,6 @@ func startProgressDots(w io.Writer) func(suffix string) {
 		<-stopped // Wait for goroutine to finish before writing suffix
 		fmt.Fprintln(w, suffix)
 	}
-}
-
-// isURL returns true if the target looks like a URL rather than a git remote name.
-func isURL(target string) bool {
-	return strings.Contains(target, "://") || strings.Contains(target, "@")
 }
 
 // createMergeCommitCommon creates a merge commit with multiple parents.

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -50,9 +50,9 @@ func pushBranchIfNeeded(ctx context.Context, target, branchName string) error {
 
 // hasUnpushedSessionsCommon checks if the local branch differs from the remote.
 // Returns true if there's any difference that needs syncing (local ahead, remote ahead, or diverged).
-func hasUnpushedSessionsCommon(repo *git.Repository, remote string, localHash plumbing.Hash, branchName string) bool {
-	// Check for remote tracking ref: refs/remotes/<remote>/<branch>
-	remoteRefName := plumbing.NewRemoteReferenceName(remote, branchName)
+func hasUnpushedSessionsCommon(repo *git.Repository, remoteName string, localHash plumbing.Hash, branchName string) bool {
+	// Check for remote tracking ref: refs/remotes/<remoteName>/<branch>
+	remoteRefName := plumbing.NewRemoteReferenceName(remoteName, branchName)
 	remoteRef, err := repo.Reference(remoteRefName, true)
 	if err != nil {
 		// Remote branch doesn't exist yet - we have content to push

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -265,7 +265,7 @@ func tryPushSessionsCommon(ctx context.Context, remote, branchName string) (push
 
 	// Use --no-verify to prevent recursive hook calls.
 	// Use --porcelain for machine-readable, locale-independent output.
-	cmd := CheckpointGitCommand(ctx, remote, "push", "--no-verify", "--porcelain", remote, branchName)
+	cmd := CheckpointGitCommand(ctx, "push", "--no-verify", "--porcelain", remote, branchName)
 
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
@@ -314,7 +314,7 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	// and trees, skipping blobs. The merge only needs the tree structure to
 	// combine entries; blobs are already local or fetched on demand.
 	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refSpec})
-	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
+	fetchCmd := CheckpointGitCommand(ctx, fetchArgs...)
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
 	}

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -46,13 +46,9 @@ func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceNa
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	// Use --no-verify to prevent recursive hook calls (this runs inside pre-push).
-	// Use --porcelain for machine-readable, locale-independent output.
 	refSpec := fmt.Sprintf("%s:%s", refName, refName)
-	cmd := CheckpointGitCommand(ctx, "push", "--no-verify", "--porcelain", target, refSpec)
-
-	output, err := cmd.CombinedOutput()
-	outputStr := string(output)
+	result, err := remote.Push(ctx, target, refSpec)
+	outputStr := result.Output
 	if err != nil {
 		if strings.Contains(outputStr, "non-fast-forward") ||
 			strings.Contains(outputStr, "rejected") {
@@ -67,7 +63,7 @@ func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceNa
 // doPushRef pushes a custom ref with fetch+merge recovery on conflict.
 func doPushRef(ctx context.Context, target string, refName plumbing.ReferenceName) error {
 	displayTarget := target
-	if isURL(target) {
+	if remote.IsURL(target) {
 		displayTarget = "checkpoint remote"
 	}
 
@@ -116,7 +112,7 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	fetchTarget, err := ResolveFetchTarget(ctx, target)
+	fetchTarget, err := remote.ResolveFetchTarget(ctx, target)
 	if err != nil {
 		return fmt.Errorf("resolve fetch target: %w", err)
 	}
@@ -126,13 +122,11 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	tmpRefName := plumbing.ReferenceName("refs/entire-fetch-tmp/" + tmpRefSuffix)
 	refSpec := fmt.Sprintf("+%s:%s", refName, tmpRefName)
 
-	// Use --filter=blob:none for a partial fetch that downloads only commits
-	// and trees, skipping blobs. The merge only needs the tree structure to
-	// combine entries; blobs are already local or fetched on demand.
-	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refSpec})
-	fetchCmd := CheckpointGitCommand(ctx, fetchArgs...)
-	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
-	if output, err := fetchCmd.CombinedOutput(); err != nil {
+	if output, err := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   fetchTarget,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+	}); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
 	}
 
@@ -213,9 +207,7 @@ func detectRemoteOnlyArchives(ctx context.Context, target string, repo *git.Repo
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	cmd := CheckpointGitCommand(ctx, "ls-remote", target, paths.V2FullRefPrefix+"*")
-	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
-	output, err := cmd.Output()
+	output, err := remote.LsRemote(ctx, target, paths.V2FullRefPrefix+"*")
 	if err != nil {
 		return nil, fmt.Errorf("ls-remote failed: %w", err)
 	}
@@ -257,10 +249,11 @@ func handleRotationConflict(ctx context.Context, target, fetchTarget string, rep
 	// Fetch the latest archived generation
 	archiveTmpRef := plumbing.ReferenceName("refs/entire-fetch-tmp/archive-" + latestArchive)
 	archiveRefSpec := fmt.Sprintf("+%s:%s", archiveRefName, archiveTmpRef)
-	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, archiveRefSpec})
-	fetchCmd := CheckpointGitCommand(ctx, fetchArgs...)
-	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
-	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
+	if output, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   fetchTarget,
+		RefSpecs: []string{archiveRefSpec},
+		NoTags:   true,
+	}); fetchErr != nil {
 		return fmt.Errorf("fetch archived generation failed: %s", output)
 	}
 	defer func() {

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -49,7 +49,7 @@ func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceNa
 	// Use --no-verify to prevent recursive hook calls (this runs inside pre-push).
 	// Use --porcelain for machine-readable, locale-independent output.
 	refSpec := fmt.Sprintf("%s:%s", refName, refName)
-	cmd := CheckpointGitCommand(ctx, target, "push", "--no-verify", "--porcelain", target, refSpec)
+	cmd := CheckpointGitCommand(ctx, "push", "--no-verify", "--porcelain", target, refSpec)
 
 	output, err := cmd.CombinedOutput()
 	outputStr := string(output)
@@ -130,7 +130,7 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	// and trees, skipping blobs. The merge only needs the tree structure to
 	// combine entries; blobs are already local or fetched on demand.
 	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, refSpec})
-	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
+	fetchCmd := CheckpointGitCommand(ctx, fetchArgs...)
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
 	if output, err := fetchCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
@@ -213,7 +213,7 @@ func detectRemoteOnlyArchives(ctx context.Context, target string, repo *git.Repo
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	cmd := CheckpointGitCommand(ctx, target, "ls-remote", target, paths.V2FullRefPrefix+"*")
+	cmd := CheckpointGitCommand(ctx, "ls-remote", target, paths.V2FullRefPrefix+"*")
 	cmd.Env = append(cmd.Env, "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.Output()
 	if err != nil {
@@ -258,7 +258,7 @@ func handleRotationConflict(ctx context.Context, target, fetchTarget string, rep
 	archiveTmpRef := plumbing.ReferenceName("refs/entire-fetch-tmp/archive-" + latestArchive)
 	archiveRefSpec := fmt.Sprintf("+%s:%s", archiveRefName, archiveTmpRef)
 	fetchArgs := AppendFetchFilterArgs(ctx, []string{"fetch", "--no-tags", fetchTarget, archiveRefSpec})
-	fetchCmd := CheckpointGitCommand(ctx, fetchTarget, fetchArgs...)
+	fetchCmd := CheckpointGitCommand(ctx, fetchArgs...)
 	fetchCmd.Env = append(fetchCmd.Env, "GIT_TERMINAL_PROMPT=0")
 	if output, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
 		return fmt.Errorf("fetch archived generation failed: %s", output)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/go-git/go-billy/v6 v6.0.0-20260328065524-593ae452e14d
 	github.com/go-git/go-git/v6 v6.0.0-alpha.2
 	github.com/go-git/x/plugin/objectsigner/auto v0.0.0-20260330134459-33df49246da9
 	github.com/google/uuid v1.6.0
@@ -61,7 +62,6 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gitleaks/go-gitdiff v0.9.1 // indirect
 	github.com/go-git/gcfg/v2 v2.0.2 // indirect
-	github.com/go-git/go-billy/v6 v6.0.0-20260328065524-593ae452e14d // indirect
 	github.com/go-git/x/plugin/objectsigner/gpg v0.1.0 // indirect
 	github.com/go-git/x/plugin/objectsigner/ssh v0.1.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/2c852be685c4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git fetch/push/ls-remote execution and auth header injection paths (including protocol/URL resolution), which can break checkpoint sync and resume flows if incorrect. Risk is mitigated by substantial new unit + integration coverage, but behavior changes around filtered fetches and HTTPS/SSH handling need careful review.
> 
> **Overview**
> Refactors checkpoint git CLI execution into `checkpoint/remote/git.go`, replacing the old strategy-level token wrapper with higher-level `remote.Fetch`/`remote.Push`/`remote.LsRemote` helpers that always disable terminal prompts and optionally inject `ENTIRE_CHECKPOINT_TOKEN` via `http.extraHeader` for HTTPS remotes (with validation and one-time SSH warning).
> 
> Adjusts fetch behavior to better handle partial clones: metadata and resume-related fetches now explicitly *suppress* `--filter=blob:none` when blob content is required, and `resume --force` now skips the interactive “fetch from remote?” prompt. URL parsing/derivation is updated to preserve non-standard ports and generate correct checkpoint URLs for SSH-with-port cases.
> 
> Adds significant new coverage: unit tests for command/target extraction and push target resolution, integration tests with an in-process HTTPS git server validating authenticated push/fetch routing (including separate checkpoint remotes), plus a new integration test ensuring `resume` fetches full blobs even when `filtered_fetches` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ac65bf2b5e2e574743d41eeabf545c17776bcd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->