### PR TITLE
Checkpoints V2: allow for a `checkpoints_version` setting in settings.json

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -177,17 +177,17 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		writeOpts.CompactTranscript = compacted
 	}
 
-	v2Only := settings.IsCheckpointsV2OnlyEnabled(logCtx)
-	if !v2Only {
+	v2 := settings.CheckpointsVersion(logCtx) == 2
+	if !v2 {
 		if err := store.WriteCommitted(ctx, writeOpts); err != nil {
 			return fmt.Errorf("failed to write checkpoint: %w", err)
 		}
 	}
-	// IsCheckpointsV2Enabled is true whenever v2Only is true, so this covers both
-	// the v2-only and dual-write paths. Only v2-only propagates the error.
+	// IsCheckpointsV2Enabled is true whenever checkpoints_version is 2, so this
+	// covers both the v2 and dual-write paths. Only v2 propagates the error.
 	if settings.IsCheckpointsV2Enabled(logCtx) {
 		if err := writeAttachCheckpointV2(logCtx, repo, writeOpts); err != nil {
-			if v2Only {
+			if v2 {
 				return fmt.Errorf("failed to write checkpoint to v2: %w", err)
 			}
 			logging.Warn(logCtx, "attach v2 dual-write failed", "error", err)

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -183,8 +183,9 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 			return fmt.Errorf("failed to write checkpoint: %w", err)
 		}
 	}
-	// IsCheckpointsV2Enabled is true whenever checkpoints_version is 2, so this
-	// covers both the v2 and dual-write paths. Only v2 propagates the error.
+	// IsCheckpointsV2Enabled is true whenever v2 writes are enabled, including
+	// both v2-only mode (checkpoints_version == 2) and dual-write mode. Only
+	// v2-only mode propagates the error.
 	if settings.IsCheckpointsV2Enabled(logCtx) {
 		if err := writeAttachCheckpointV2(logCtx, repo, writeOpts); err != nil {
 			if v2 {

--- a/cmd/entire/cli/integration_test/v2_dual_write_test.go
+++ b/cmd/entire/cli/integration_test/v2_dual_write_test.go
@@ -245,10 +245,11 @@ func TestV2DualWrite_StopTimeFinalization(t *testing.T) {
 	assert.Contains(t, compactTranscript, `"v":1`)
 }
 
-// TestV2Only_SkipsV1Write verifies the v2-only specific deltas: v1 metadata is
-// not written and v2 refs still exist. The full v2 payload shape is already
-// covered by TestV2DualWrite_FullWorkflow.
-func TestV2Only_SkipsV1Write(t *testing.T) {
+// TestCheckpointsVersion2_SkipsV1Write verifies the specific deltas of running
+// with checkpoints_version: 2 — v1 metadata is not written and v2 refs still
+// exist. The full v2 payload shape is already covered by
+// TestV2DualWrite_FullWorkflow.
+func TestCheckpointsVersion2_SkipsV1Write(t *testing.T) {
 	t.Parallel()
 	env := NewTestEnv(t)
 	defer env.Cleanup()
@@ -259,10 +260,10 @@ func TestV2Only_SkipsV1Write(t *testing.T) {
 	env.GitAdd("README.md")
 	env.GitAdd(".gitignore")
 	env.GitCommit("Initial commit")
-	env.GitCheckoutNewBranch("feature/v2-only-test")
+	env.GitCheckoutNewBranch("feature/checkpoints-v2-test")
 
 	env.InitEntireWithOptions(map[string]any{
-		"checkpoints_v2_only": true,
+		"checkpoints_version": 2,
 	})
 
 	session := env.NewSession()
@@ -287,7 +288,7 @@ func TestV2Only_SkipsV1Write(t *testing.T) {
 	// v1: should NOT be written.
 	_, found := env.ReadFileFromBranch(paths.MetadataBranchName, cpPath+"/"+paths.MetadataFileName)
 	assert.False(t, found,
-		"v1 committed checkpoint metadata should NOT exist when checkpoints_v2_only is enabled")
+		"v1 committed checkpoint metadata should NOT exist when checkpoints_version is 2")
 
 	// v2: smoke check that the checkpoint still landed.
 	assert.True(t, env.RefExists(paths.V2MainRefName), "v2 /main ref should exist")

--- a/cmd/entire/cli/integration_test/v2_push_test.go
+++ b/cmd/entire/cli/integration_test/v2_push_test.go
@@ -124,10 +124,10 @@ func TestV2Push_Disabled_NoV2Refs(t *testing.T) {
 		"v1 metadata branch should still exist on remote")
 }
 
-// TestV2Push_V2OnlySkipsV1Branch verifies that the v1 metadata branch is not
-// pushed when checkpoints_v2_only is enabled; v2 ref pushing itself is covered
+// TestV2Push_Version2SkipsV1Branch verifies that the v1 metadata branch is not
+// pushed when checkpoints_version is set to 2; v2 ref pushing itself is covered
 // by TestV2Push_FullCycle.
-func TestV2Push_V2OnlySkipsV1Branch(t *testing.T) {
+func TestV2Push_Version2SkipsV1Branch(t *testing.T) {
 	t.Parallel()
 	env := NewTestEnv(t)
 	defer env.Cleanup()
@@ -138,10 +138,10 @@ func TestV2Push_V2OnlySkipsV1Branch(t *testing.T) {
 	env.GitAdd("README.md")
 	env.GitAdd(".gitignore")
 	env.GitCommit("Initial commit")
-	env.GitCheckoutNewBranch("feature/v2-only-push-test")
+	env.GitCheckoutNewBranch("feature/checkpoints-v2-push-test")
 
 	env.InitEntireWithOptions(map[string]any{
-		"checkpoints_v2_only": true,
+		"checkpoints_version": 2,
 	})
 
 	bareDir := env.SetupBareRemote()
@@ -162,7 +162,7 @@ func TestV2Push_V2OnlySkipsV1Branch(t *testing.T) {
 	env.RunPrePush("origin")
 
 	assert.False(t, bareRefExists(t, bareDir, "refs/heads/"+paths.MetadataBranchName),
-		"v1 metadata branch should NOT exist on remote when checkpoints_v2_only is enabled")
+		"v1 metadata branch should NOT exist on remote when checkpoints_version is 2")
 	// Smoke: v2 refs still land; full payload asserted in TestV2Push_FullCycle.
 	assert.True(t, bareRefExists(t, bareDir, paths.V2MainRefName),
 		"v2 /main ref should exist on remote after push")

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -607,12 +607,12 @@ func IsCheckpointsV2Enabled(ctx context.Context) bool {
 	return settings.IsCheckpointsV2Enabled()
 }
 
-// CheckpointsVersion returns the configured checkpoints format version, or 0
+// CheckpointsVersion returns the configured checkpoints format version, or 1
 // if settings cannot be loaded or the value is unset/invalid.
 func CheckpointsVersion(ctx context.Context) int {
 	s, err := Load(ctx)
 	if err != nil {
-		return 0
+		return 1
 	}
 	return s.CheckpointsVersion()
 }
@@ -722,15 +722,15 @@ func (s *EntireSettings) IsCheckpointsV2Enabled() bool {
 }
 
 // CheckpointsVersion returns the configured checkpoints format version from
-// strategy_options.checkpoints_version. Returns 0 when unset or when the value
-// is not a positive integer. 2 is the first and only supported version.
+// strategy_options.checkpoints_version. Returns 1 when unset or when the value
+// is not a positive integer. 2 is the only other supported version.
 func (s *EntireSettings) CheckpointsVersion() int {
 	if s.StrategyOptions == nil {
-		return 0
+		return 1
 	}
 	val, ok := s.StrategyOptions["checkpoints_version"]
 	if !ok {
-		return 0
+		return 1
 	}
 	switch v := val.(type) {
 	case int:
@@ -743,7 +743,7 @@ func (s *EntireSettings) CheckpointsVersion() int {
 			return intV
 		}
 	}
-	return 0
+	return 1
 }
 
 // IsPushV2RefsEnabled checks if pushing v2 refs is enabled.

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -745,15 +746,19 @@ func (s *EntireSettings) CheckpointsVersion() int {
 		})
 	}
 
-	switch v := val.(type) {
-	case int:
-		if v == 1 || v == 2 {
-			return v
-		}
-	case float64:
-		intV := int(v)
-		if v == float64(intV) && (intV == 1 || intV == 2) {
-			return intV
+	v, ok := val.(int)
+	if ok && (v == 1 || v == 2) {
+		return v
+	}
+	floatV, ok := val.(float64)
+	if ok && (floatV == 1 || floatV == 2) {
+		return int(floatV)
+	}
+	stringV, ok := val.(string)
+	if ok {
+		parsed, err := strconv.Atoi(stringV)
+		if err == nil && (parsed == 1 || parsed == 2) {
+			return parsed
 		}
 	}
 	warnUnsupported(val)

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -618,7 +618,20 @@ func CheckpointsVersion(ctx context.Context) int {
 	if err != nil {
 		return 1
 	}
-	return s.CheckpointsVersion()
+	version := s.CheckpointsVersion()
+	if s.StrategyOptions != nil {
+		if configured, ok := s.StrategyOptions["checkpoints_version"]; ok {
+			if _, supported := parseCheckpointsVersion(configured); !supported {
+				checkpointsVersionWarningOnce.Do(func() {
+					fmt.Fprintf(os.Stderr,
+						"[entire] unsupported strategy_options.checkpoints_version %v detected in settings. Falling back to the default version (1).\n",
+						configured,
+					)
+				})
+			}
+		}
+	}
+	return version
 }
 
 // IsPushV2RefsEnabled checks if pushing v2 refs is enabled in settings.
@@ -736,33 +749,30 @@ func (s *EntireSettings) CheckpointsVersion() int {
 	if !ok {
 		return 1
 	}
-
-	warnUnsupported := func(configured any) {
-		checkpointsVersionWarningOnce.Do(func() {
-			fmt.Fprintf(os.Stderr,
-				"[entire] unsupported checkpoints version %v detected in settings. Falling back to the default version (1).\n",
-				configured,
-			)
-		})
+	version, ok := parseCheckpointsVersion(val)
+	if ok {
+		return version
 	}
+	return 1
+}
 
+func parseCheckpointsVersion(val any) (int, bool) {
 	v, ok := val.(int)
 	if ok && (v == 1 || v == 2) {
-		return v
+		return v, true
 	}
 	floatV, ok := val.(float64)
 	if ok && (floatV == 1 || floatV == 2) {
-		return int(floatV)
+		return int(floatV), true
 	}
 	stringV, ok := val.(string)
 	if ok {
 		parsed, err := strconv.Atoi(stringV)
 		if err == nil && (parsed == 1 || parsed == 2) {
-			return parsed
+			return parsed, true
 		}
 	}
-	warnUnsupported(val)
-	return 1
+	return 1, false
 }
 
 // IsPushV2RefsEnabled checks if pushing v2 refs is enabled.

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -607,14 +607,14 @@ func IsCheckpointsV2Enabled(ctx context.Context) bool {
 	return settings.IsCheckpointsV2Enabled()
 }
 
-// IsCheckpointsV2OnlyEnabled checks if checkpoints should be written and pushed
-// only via v2 refs.
-func IsCheckpointsV2OnlyEnabled(ctx context.Context) bool {
+// CheckpointsVersion returns the configured checkpoints format version, or 0
+// if settings cannot be loaded or the value is unset/invalid.
+func CheckpointsVersion(ctx context.Context) int {
 	s, err := Load(ctx)
 	if err != nil {
-		return false
+		return 0
 	}
-	return s.IsCheckpointsV2OnlyEnabled()
+	return s.CheckpointsVersion()
 }
 
 // IsPushV2RefsEnabled checks if pushing v2 refs is enabled in settings.
@@ -709,9 +709,9 @@ func (s *EntireSettings) GetCheckpointRemote() *CheckpointRemoteConfig {
 }
 
 // IsCheckpointsV2Enabled checks if checkpoints v2 is enabled.
-// Returns true when either checkpoints_v2 or checkpoints_v2_only is enabled.
+// Returns true when either checkpoints_v2 is set or checkpoints_version is 2.
 func (s *EntireSettings) IsCheckpointsV2Enabled() bool {
-	if s.IsCheckpointsV2OnlyEnabled() {
+	if s.CheckpointsVersion() == 2 {
 		return true
 	}
 	if s.StrategyOptions == nil {
@@ -721,20 +721,35 @@ func (s *EntireSettings) IsCheckpointsV2Enabled() bool {
 	return ok && val
 }
 
-// IsCheckpointsV2OnlyEnabled checks if checkpoints should be written and pushed
-// only via v2 refs, with no v1 dual-write.
-func (s *EntireSettings) IsCheckpointsV2OnlyEnabled() bool {
+// CheckpointsVersion returns the configured checkpoints format version from
+// strategy_options.checkpoints_version. Returns 0 when unset or when the value
+// is not a positive integer. 2 is the first and only supported version.
+func (s *EntireSettings) CheckpointsVersion() int {
 	if s.StrategyOptions == nil {
-		return false
+		return 0
 	}
-	val, ok := s.StrategyOptions["checkpoints_v2_only"].(bool)
-	return ok && val
+	val, ok := s.StrategyOptions["checkpoints_version"]
+	if !ok {
+		return 0
+	}
+	switch v := val.(type) {
+	case int:
+		if v > 0 {
+			return v
+		}
+	case float64:
+		intV := int(v)
+		if intV > 0 && v == float64(intV) {
+			return intV
+		}
+	}
+	return 0
 }
 
 // IsPushV2RefsEnabled checks if pushing v2 refs is enabled.
-// checkpoints_v2_only forces v2 ref pushes on, regardless of push_v2_refs.
+// checkpoints_version: 2 forces v2 ref pushes on, regardless of push_v2_refs.
 func (s *EntireSettings) IsPushV2RefsEnabled() bool {
-	if s.IsCheckpointsV2OnlyEnabled() {
+	if s.CheckpointsVersion() == 2 {
 		return true
 	}
 	if !s.IsCheckpointsV2Enabled() {

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -739,7 +739,7 @@ func (s *EntireSettings) CheckpointsVersion() int {
 	warnUnsupported := func(configured any) {
 		checkpointsVersionWarningOnce.Do(func() {
 			fmt.Fprintf(os.Stderr,
-				"[entire] unsupported checkpoints version %v detected in settings. Falling back to latest supported version (1).\n",
+				"[entire] unsupported checkpoints version %v detected in settings. Falling back to the default version (1).\n",
 				configured,
 			)
 		})

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
@@ -26,6 +27,8 @@ const (
 	// checkpoints v2 raw-transcript generations when no override is configured.
 	defaultGenerationRetentionDays = 60
 )
+
+var checkpointsVersionWarningOnce sync.Once
 
 // Commit linking mode constants.
 const (
@@ -722,8 +725,8 @@ func (s *EntireSettings) IsCheckpointsV2Enabled() bool {
 }
 
 // CheckpointsVersion returns the configured checkpoints format version from
-// strategy_options.checkpoints_version. Returns 1 when unset or when the value
-// is not a positive integer. 2 is the only other supported version.
+// strategy_options.checkpoints_version. Returns 1 when unset, invalid, or
+// unsupported. The currently supported versions are 1 and 2.
 func (s *EntireSettings) CheckpointsVersion() int {
 	if s.StrategyOptions == nil {
 		return 1
@@ -732,17 +735,28 @@ func (s *EntireSettings) CheckpointsVersion() int {
 	if !ok {
 		return 1
 	}
+
+	warnUnsupported := func(configured any) {
+		checkpointsVersionWarningOnce.Do(func() {
+			fmt.Fprintf(os.Stderr,
+				"[entire] unsupported checkpoints version %v detected in settings. Falling back to latest supported version (1).\n",
+				configured,
+			)
+		})
+	}
+
 	switch v := val.(type) {
 	case int:
-		if v > 0 {
+		if v == 1 || v == 2 {
 			return v
 		}
 	case float64:
 		intV := int(v)
-		if intV > 0 && v == float64(intV) {
+		if v == float64(intV) && (intV == 1 || intV == 2) {
 			return intV
 		}
 	}
+	warnUnsupported(val)
 	return 1
 }
 

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -796,16 +796,16 @@ func TestCheckpointsVersion(t *testing.T) {
 		opts map[string]any
 		want int
 	}{
-		{"unset returns zero", nil, 0},
-		{"empty options returns zero", map[string]any{}, 0},
+		{"unset defaults to one", nil, 1},
+		{"empty options defaults to one", map[string]any{}, 1},
 		{"integer 2", map[string]any{"checkpoints_version": 2}, 2},
 		{"float 2 from json", map[string]any{"checkpoints_version": float64(2)}, 2},
 		{"integer 3 (not yet supported but surfaced)", map[string]any{"checkpoints_version": 3}, 3},
-		{"zero is ignored", map[string]any{"checkpoints_version": 0}, 0},
-		{"negative is ignored", map[string]any{"checkpoints_version": -1}, 0},
-		{"non-integer float ignored", map[string]any{"checkpoints_version": 2.5}, 0},
-		{"string is ignored", map[string]any{"checkpoints_version": "2"}, 0},
-		{"bool is ignored", map[string]any{"checkpoints_version": true}, 0},
+		{"zero falls back to default", map[string]any{"checkpoints_version": 0}, 1},
+		{"negative falls back to default", map[string]any{"checkpoints_version": -1}, 1},
+		{"non-integer float falls back to default", map[string]any{"checkpoints_version": 2.5}, 1},
+		{"string falls back to default", map[string]any{"checkpoints_version": "2"}, 1},
+		{"bool falls back to default", map[string]any{"checkpoints_version": true}, 1},
 	}
 
 	for _, tt := range tests {

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -804,7 +804,7 @@ func TestCheckpointsVersion(t *testing.T) {
 		{"zero falls back to default", map[string]any{"checkpoints_version": 0}, 1},
 		{"negative falls back to default", map[string]any{"checkpoints_version": -1}, 1},
 		{"non-integer float falls back to default", map[string]any{"checkpoints_version": 2.5}, 1},
-		{"string falls back to default", map[string]any{"checkpoints_version": "2"}, 1},
+		{"string 2", map[string]any{"checkpoints_version": "2"}, 2},
 		{"bool falls back to default", map[string]any{"checkpoints_version": true}, 1},
 	}
 

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -692,14 +692,14 @@ func TestIsCheckpointsV2Enabled_True(t *testing.T) {
 	}
 }
 
-func TestIsCheckpointsV2Enabled_V2Only(t *testing.T) {
+func TestIsCheckpointsV2Enabled_CheckpointsVersion2(t *testing.T) {
 	t.Parallel()
 	s := &EntireSettings{
 		Enabled:         true,
-		StrategyOptions: map[string]any{"checkpoints_v2_only": true},
+		StrategyOptions: map[string]any{"checkpoints_version": 2},
 	}
 	if !s.IsCheckpointsV2Enabled() {
-		t.Error("expected IsCheckpointsV2Enabled to be true when checkpoints_v2_only is enabled")
+		t.Error("expected IsCheckpointsV2Enabled to be true when checkpoints_version is 2")
 	}
 }
 
@@ -788,33 +788,34 @@ func TestIsCheckpointsV2Enabled_LocalOverride(t *testing.T) {
 	}
 }
 
-func TestIsCheckpointsV2OnlyEnabled_DefaultsFalse(t *testing.T) {
+func TestCheckpointsVersion(t *testing.T) {
 	t.Parallel()
-	s := &EntireSettings{Enabled: true}
-	if s.IsCheckpointsV2OnlyEnabled() {
-		t.Error("expected IsCheckpointsV2OnlyEnabled to default to false")
-	}
-}
 
-func TestIsCheckpointsV2OnlyEnabled_True(t *testing.T) {
-	t.Parallel()
-	s := &EntireSettings{
-		Enabled:         true,
-		StrategyOptions: map[string]any{"checkpoints_v2_only": true},
+	tests := []struct {
+		name string
+		opts map[string]any
+		want int
+	}{
+		{"unset returns zero", nil, 0},
+		{"empty options returns zero", map[string]any{}, 0},
+		{"integer 2", map[string]any{"checkpoints_version": 2}, 2},
+		{"float 2 from json", map[string]any{"checkpoints_version": float64(2)}, 2},
+		{"integer 3 (not yet supported but surfaced)", map[string]any{"checkpoints_version": 3}, 3},
+		{"zero is ignored", map[string]any{"checkpoints_version": 0}, 0},
+		{"negative is ignored", map[string]any{"checkpoints_version": -1}, 0},
+		{"non-integer float ignored", map[string]any{"checkpoints_version": 2.5}, 0},
+		{"string is ignored", map[string]any{"checkpoints_version": "2"}, 0},
+		{"bool is ignored", map[string]any{"checkpoints_version": true}, 0},
 	}
-	if !s.IsCheckpointsV2OnlyEnabled() {
-		t.Error("expected IsCheckpointsV2OnlyEnabled to be true")
-	}
-}
 
-func TestIsCheckpointsV2OnlyEnabled_WrongType(t *testing.T) {
-	t.Parallel()
-	s := &EntireSettings{
-		Enabled:         true,
-		StrategyOptions: map[string]any{"checkpoints_v2_only": "yes"},
-	}
-	if s.IsCheckpointsV2OnlyEnabled() {
-		t.Error("expected IsCheckpointsV2OnlyEnabled to be false for non-bool value")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &EntireSettings{StrategyOptions: tt.opts}
+			if got := s.CheckpointsVersion(); got != tt.want {
+				t.Errorf("CheckpointsVersion() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -834,7 +835,7 @@ func TestIsPushV2RefsEnabled_RequiresBothFlags(t *testing.T) {
 		opts     map[string]any
 		expected bool
 	}{
-		{"v2 only supersedes both", map[string]any{"checkpoints_v2": false, "push_v2_refs": false, "checkpoints_v2_only": true}, true},
+		{"checkpoints_version 2 supersedes both", map[string]any{"checkpoints_v2": false, "push_v2_refs": false, "checkpoints_version": 2}, true},
 		{"both true", map[string]any{"checkpoints_v2": true, "push_v2_refs": true}, true},
 		{"only checkpoints_v2", map[string]any{"checkpoints_v2": true}, false},
 		{"only push_v2_refs", map[string]any{"push_v2_refs": true}, false},

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -800,7 +800,7 @@ func TestCheckpointsVersion(t *testing.T) {
 		{"empty options defaults to one", map[string]any{}, 1},
 		{"integer 2", map[string]any{"checkpoints_version": 2}, 2},
 		{"float 2 from json", map[string]any{"checkpoints_version": float64(2)}, 2},
-		{"integer 3 (not yet supported but surfaced)", map[string]any{"checkpoints_version": 3}, 3},
+		{"integer 3 falls back to default", map[string]any{"checkpoints_version": 3}, 1},
 		{"zero falls back to default", map[string]any{"checkpoints_version": 0}, 1},
 		{"negative falls back to default", map[string]any{"checkpoints_version": -1}, 1},
 		{"non-integer float falls back to default", map[string]any{"checkpoints_version": 2.5}, 1},

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -83,9 +83,9 @@ func resolvePushSettings(ctx context.Context, pushRemoteName string) pushSetting
 
 	ps.checkpointURL = checkpointURL
 
-	// Skip the v1 metadata-branch fetch entirely in v2-only mode — there is no
-	// v1 branch being written or pushed, so there is nothing to sync.
-	if !s.IsCheckpointsV2OnlyEnabled() {
+	// Skip the v1 metadata-branch fetch entirely when checkpoints_version is 2 —
+	// there is no v1 branch being written or pushed, so there is nothing to sync.
+	if s.CheckpointsVersion() != 2 {
 		// If the v1 checkpoint branch doesn't exist locally, try to fetch it from the URL.
 		// This is a one-time operation — once the branch exists locally, subsequent pushes
 		// skip the fetch entirely. Only fetch the metadata branch; trails are always pushed

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -254,12 +254,12 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 
 	compactTranscriptDuration := buildCompactTranscript(ctx, ag, redactedTranscript, state, &writeOpts)
 
-	v2Only := settings.IsCheckpointsV2OnlyEnabled(ctx)
+	v2 := settings.CheckpointsVersion(ctx) == 2
 
 	// Write checkpoint metadata to the primary store.
 	writeV1Start := time.Now()
 	writeCtx, writeCommittedSpan := perf.Start(ctx, "write_committed_v1")
-	if !v2Only {
+	if !v2 {
 		if err := store.WriteCommitted(writeCtx, writeOpts); err != nil {
 			writeCommittedSpan.RecordError(err)
 			writeCommittedSpan.End()
@@ -271,7 +271,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 
 	writeV2Start := time.Now()
 	writeV2Ctx, writeCommittedV2Span := perf.Start(ctx, "write_committed_v2")
-	if v2Only {
+	if v2 {
 		if err := writeCommittedV2(writeV2Ctx, repo, writeOpts); err != nil {
 			writeCommittedV2Span.RecordError(err)
 			writeCommittedV2Span.End()

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -2745,7 +2745,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 	}
 
 	store := checkpoint.NewGitStore(repo)
-	v2Only := settings.IsCheckpointsV2OnlyEnabled(logCtx)
+	v2 := settings.CheckpointsVersion(logCtx) == 2
 
 	// Evaluate v2 flag once before the loop to avoid re-reading settings per checkpoint
 	var v2Store *checkpoint.V2GitStore
@@ -2790,7 +2790,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 				content *checkpoint.SessionContent
 				readErr error
 			)
-			if v2Only {
+			if v2 {
 				content, readErr = v2Store.ReadSessionContentByID(ctx, cpID, state.SessionID)
 			} else {
 				content, readErr = store.ReadSessionContentByID(ctx, cpID, state.SessionID)
@@ -2812,7 +2812,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 			updateOpts.CompactTranscript = compactTranscriptForV2(logCtx, finalAg, redactedTranscript, startLine)
 		}
 
-		if !v2Only {
+		if !v2 {
 			updateErr := store.UpdateCommitted(ctx, updateOpts)
 			if updateErr != nil {
 				logging.Warn(logCtx, "finalize: failed to update checkpoint",
@@ -2830,7 +2830,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 					slog.String("checkpoint_id", cpIDStr),
 					slog.String("error", v2Err.Error()),
 				}
-				if v2Only {
+				if v2 {
 					logging.Warn(logCtx, "finalize: failed to update checkpoint in v2", attrs...)
 					errCount++
 					continue

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -10,9 +10,9 @@ import (
 
 // PrePush is called by the git pre-push hook before pushing to a remote.
 // It pushes the entire/checkpoints/v1 branch alongside the user's push (unless
-// v1 writes are disabled by checkpoints_v2_only), and pushes v2 refs whenever
+// v1 writes are disabled by checkpoints_version: 2), and pushes v2 refs whenever
 // IsPushV2RefsEnabled is true — i.e. either checkpoints_v2 + push_v2_refs, or
-// checkpoints_v2_only.
+// checkpoints_version: 2.
 //
 // If a checkpoint_remote is configured in settings, checkpoint branches/refs
 // are pushed to the derived URL instead of the user's push remote.
@@ -21,7 +21,7 @@ import (
 //   - push_sessions: false to disable automatic pushing of checkpoints
 //   - checkpoint_remote: {"provider": "github", "repo": "org/repo"} to push to a separate repo
 //   - push_v2_refs: true to enable pushing v2 refs (requires checkpoints_v2)
-//   - checkpoints_v2_only: true to skip the v1 metadata branch entirely and force v2 ref pushes on
+//   - checkpoints_version: 2 to skip the v1 metadata branch entirely and force v2 ref pushes on
 func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error {
 	// Load settings once for remote resolution and push_sessions check
 	ps := resolvePushSettings(ctx, remote)
@@ -31,7 +31,7 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 	}
 
 	var err error
-	if !settings.IsCheckpointsV2OnlyEnabled(ctx) {
+	if settings.CheckpointsVersion(ctx) != 2 {
 		_, pushCheckpointsSpan := perf.Start(ctx, "push_checkpoints_branch")
 		err = pushBranchIfNeeded(ctx, ps.pushTarget(), paths.MetadataBranchName)
 		if err != nil {

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -121,8 +121,8 @@ func printCheckpointRemoteHint(target string) {
 // settingsHintOnce ensures the settings commit hint prints at most once per process.
 var settingsHintOnce sync.Once
 
-// v2OnlyMigrationHintOnce ensures the v2-only migration hint prints at most once per process.
-var v2OnlyMigrationHintOnce sync.Once
+// checkpointsV2MigrationHintOnce ensures the checkpoints v2 migration hint prints at most once per process.
+var checkpointsV2MigrationHintOnce sync.Once
 
 // printSettingsCommitHint prints a hint after a successful checkpoint remote push
 // when the committed .entire/settings.json does not contain a checkpoint_remote config.
@@ -143,20 +143,20 @@ func printSettingsCommitHint(ctx context.Context, target string) {
 	})
 }
 
-// printCheckpointsV2OnlyMigrationHint prints a hint when the committed project
-// settings enable checkpoints_v2_only AND there are v1 checkpoints that have
+// printCheckpointsV2MigrationHint prints a hint when the committed project
+// settings enable checkpoints_version: 2 AND there are v1 checkpoints that have
 // not yet been mirrored into v2. Suppressed when v2 already has every v1
 // checkpoint (nothing to migrate) so the hint does not become noise once the
 // migration is done.
-func printCheckpointsV2OnlyMigrationHint(ctx context.Context) {
-	v2OnlyMigrationHintOnce.Do(func() {
-		if !isCheckpointsV2OnlyCommitted(ctx) {
+func printCheckpointsV2MigrationHint(ctx context.Context) {
+	checkpointsV2MigrationHintOnce.Do(func() {
+		if !isCheckpointsVersion2Committed(ctx) {
 			return
 		}
 		if !hasUnmigratedV1Checkpoints(ctx) {
 			return
 		}
-		fmt.Fprintln(os.Stderr, "[entire] Note: .entire/settings.json enables checkpoints_v2_only. Run 'entire migrate --checkpoints v2' to migrate existing checkpoints to v2.")
+		fmt.Fprintln(os.Stderr, "[entire] Note: .entire/settings.json sets checkpoints_version: 2. Run 'entire migrate --checkpoints v2' to migrate existing checkpoints to v2.")
 		fmt.Fprintln(os.Stderr, "[entire] Use 'entire migrate --checkpoints v2 --force' to rewrite all checkpoints in v2.")
 	})
 }
@@ -208,9 +208,9 @@ func isCheckpointRemoteCommitted(ctx context.Context) bool {
 	return committed.GetCheckpointRemote() != nil
 }
 
-// isCheckpointsV2OnlyCommitted returns true if the committed .entire/settings.json
-// at HEAD enables checkpoints_v2_only.
-func isCheckpointsV2OnlyCommitted(ctx context.Context) bool {
+// isCheckpointsVersion2Committed returns true if the committed .entire/settings.json
+// at HEAD sets checkpoints_version to 2.
+func isCheckpointsVersion2Committed(ctx context.Context) bool {
 	cmd := exec.CommandContext(ctx, "git", "show", "HEAD:.entire/settings.json")
 	output, err := cmd.Output()
 	if err != nil {
@@ -220,7 +220,7 @@ func isCheckpointsV2OnlyCommitted(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	return committed.IsCheckpointsV2OnlyEnabled()
+	return committed.CheckpointsVersion() == 2
 }
 
 // pushResult describes what happened during a push attempt.
@@ -255,7 +255,7 @@ func finishPush(ctx context.Context, stop func(string), result pushResult, targe
 		stop(" done")
 		printSettingsCommitHint(ctx, target)
 	}
-	printCheckpointsV2OnlyMigrationHint(ctx)
+	printCheckpointsV2MigrationHint(ctx)
 }
 
 // tryPushSessionsCommon attempts to push the sessions branch.

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -1206,7 +1206,7 @@ func TestPrintSettingsCommitHint(t *testing.T) {
 	})
 }
 
-func TestIsCheckpointsV2OnlyCommitted(t *testing.T) {
+func TestIsCheckpointsVersion2Committed(t *testing.T) {
 	t.Run("false when settings.json not committed", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.InitRepo(t, tmpDir)
@@ -1217,13 +1217,13 @@ func TestIsCheckpointsV2OnlyCommitted(t *testing.T) {
 		entireDir := filepath.Join(tmpDir, ".entire")
 		require.NoError(t, os.MkdirAll(entireDir, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"),
-			[]byte(`{"strategy_options":{"checkpoints_v2_only":true}}`), 0o644))
+			[]byte(`{"strategy_options":{"checkpoints_version":2}}`), 0o644))
 
 		t.Chdir(tmpDir)
-		assert.False(t, isCheckpointsV2OnlyCommitted(context.Background()))
+		assert.False(t, isCheckpointsVersion2Committed(context.Background()))
 	})
 
-	t.Run("true when checkpoints_v2_only is committed", func(t *testing.T) {
+	t.Run("true when checkpoints_version 2 is committed", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.InitRepo(t, tmpDir)
 		testutil.WriteFile(t, tmpDir, "f.txt", "init")
@@ -1233,19 +1233,19 @@ func TestIsCheckpointsV2OnlyCommitted(t *testing.T) {
 		entireDir := filepath.Join(tmpDir, ".entire")
 		require.NoError(t, os.MkdirAll(entireDir, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"),
-			[]byte(`{"strategy_options":{"checkpoints_v2_only":true}}`), 0o644))
+			[]byte(`{"strategy_options":{"checkpoints_version":2}}`), 0o644))
 		testutil.GitAdd(t, tmpDir, ".entire/settings.json")
-		testutil.GitCommit(t, tmpDir, "enable checkpoints_v2_only")
+		testutil.GitCommit(t, tmpDir, "enable checkpoints_version 2")
 
 		t.Chdir(tmpDir)
-		assert.True(t, isCheckpointsV2OnlyCommitted(context.Background()))
+		assert.True(t, isCheckpointsVersion2Committed(context.Background()))
 	})
 }
 
-// setupV2OnlyCommittedRepo creates a temp repo with checkpoints_v2_only enabled
-// in the committed .entire/settings.json and chdirs into it. Returns an opened
+// setupCheckpointsV2CommittedRepo creates a temp repo with checkpoints_version: 2
+// set in the committed .entire/settings.json and chdirs into it. Returns an opened
 // *git.Repository for populating checkpoints.
-func setupV2OnlyCommittedRepo(t *testing.T) *git.Repository {
+func setupCheckpointsV2CommittedRepo(t *testing.T) *git.Repository {
 	t.Helper()
 
 	tmpDir := t.TempDir()
@@ -1257,9 +1257,9 @@ func setupV2OnlyCommittedRepo(t *testing.T) *git.Repository {
 	entireDir := filepath.Join(tmpDir, ".entire")
 	require.NoError(t, os.MkdirAll(entireDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"),
-		[]byte(`{"strategy_options":{"checkpoints_v2_only":true}}`), 0o644))
+		[]byte(`{"strategy_options":{"checkpoints_version":2}}`), 0o644))
 	testutil.GitAdd(t, tmpDir, ".entire/settings.json")
-	testutil.GitCommit(t, tmpDir, "enable checkpoints_v2_only")
+	testutil.GitCommit(t, tmpDir, "enable checkpoints_version 2")
 	t.Chdir(tmpDir)
 
 	repo, err := git.PlainOpen(tmpDir)
@@ -1281,41 +1281,41 @@ func writeV1Checkpoint(t *testing.T, repo *git.Repository, cpID id.CheckpointID,
 	require.NoError(t, err)
 }
 
-func TestPrintCheckpointsV2OnlyMigrationHint(t *testing.T) {
+func TestPrintCheckpointsV2MigrationHint(t *testing.T) {
 	t.Run("suppressed when no v1 checkpoints exist", func(t *testing.T) {
-		v2OnlyMigrationHintOnce = sync.Once{}
-		setupV2OnlyCommittedRepo(t)
+		checkpointsV2MigrationHintOnce = sync.Once{}
+		setupCheckpointsV2CommittedRepo(t)
 
 		restore := captureStderr(t)
-		printCheckpointsV2OnlyMigrationHint(context.Background())
+		printCheckpointsV2MigrationHint(context.Background())
 		output := restore()
 
 		assert.Empty(t, output, "hint should not print when there are no v1 checkpoints to migrate")
 	})
 
 	t.Run("suppressed when every v1 checkpoint is already in v2", func(t *testing.T) {
-		v2OnlyMigrationHintOnce = sync.Once{}
-		repo := setupV2OnlyCommittedRepo(t)
+		checkpointsV2MigrationHintOnce = sync.Once{}
+		repo := setupCheckpointsV2CommittedRepo(t)
 
 		cpID := id.MustCheckpointID("aabbccddeeff")
 		writeV1Checkpoint(t, repo, cpID, "session-1")
 		writeV2Checkpoint(t, repo, cpID, "session-1")
 
 		restore := captureStderr(t)
-		printCheckpointsV2OnlyMigrationHint(context.Background())
+		printCheckpointsV2MigrationHint(context.Background())
 		output := restore()
 
 		assert.Empty(t, output, "hint should not print once v2 already mirrors every v1 checkpoint")
 	})
 
 	t.Run("prints when v1 has checkpoints not in v2", func(t *testing.T) {
-		v2OnlyMigrationHintOnce = sync.Once{}
-		repo := setupV2OnlyCommittedRepo(t)
+		checkpointsV2MigrationHintOnce = sync.Once{}
+		repo := setupCheckpointsV2CommittedRepo(t)
 
 		writeV1Checkpoint(t, repo, id.MustCheckpointID("111111111111"), "session-1")
 
 		restore := captureStderr(t)
-		printCheckpointsV2OnlyMigrationHint(context.Background())
+		printCheckpointsV2MigrationHint(context.Background())
 		output := restore()
 
 		assert.Contains(t, output, "entire migrate --checkpoints v2")
@@ -1323,14 +1323,14 @@ func TestPrintCheckpointsV2OnlyMigrationHint(t *testing.T) {
 	})
 
 	t.Run("prints only once per process", func(t *testing.T) {
-		v2OnlyMigrationHintOnce = sync.Once{}
-		repo := setupV2OnlyCommittedRepo(t)
+		checkpointsV2MigrationHintOnce = sync.Once{}
+		repo := setupCheckpointsV2CommittedRepo(t)
 
 		writeV1Checkpoint(t, repo, id.MustCheckpointID("222222222222"), "session-2")
 
 		restore := captureStderr(t)
-		printCheckpointsV2OnlyMigrationHint(context.Background())
-		printCheckpointsV2OnlyMigrationHint(context.Background())
+		printCheckpointsV2MigrationHint(context.Background())
+		printCheckpointsV2MigrationHint(context.Background())
 		output := restore()
 
 		// --force appears in exactly one line, so its count equals the number of
@@ -1342,12 +1342,12 @@ func TestPrintCheckpointsV2OnlyMigrationHint(t *testing.T) {
 
 func TestHasUnmigratedV1Checkpoints(t *testing.T) {
 	t.Run("false when no v1 checkpoints exist", func(t *testing.T) {
-		setupV2OnlyCommittedRepo(t)
+		setupCheckpointsV2CommittedRepo(t)
 		assert.False(t, hasUnmigratedV1Checkpoints(context.Background()))
 	})
 
 	t.Run("false when every v1 checkpoint is in v2", func(t *testing.T) {
-		repo := setupV2OnlyCommittedRepo(t)
+		repo := setupCheckpointsV2CommittedRepo(t)
 		cpID := id.MustCheckpointID("333333333333")
 		writeV1Checkpoint(t, repo, cpID, "session-a")
 		writeV2Checkpoint(t, repo, cpID, "session-a")
@@ -1356,7 +1356,7 @@ func TestHasUnmigratedV1Checkpoints(t *testing.T) {
 	})
 
 	t.Run("true when at least one v1 checkpoint is missing from v2", func(t *testing.T) {
-		repo := setupV2OnlyCommittedRepo(t)
+		repo := setupCheckpointsV2CommittedRepo(t)
 		mirrored := id.MustCheckpointID("444444444444")
 		missing := id.MustCheckpointID("555555555555")
 		writeV1Checkpoint(t, repo, mirrored, "session-b")


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/d442cf06fd5f

(Not intended for production use at this time, followup to https://github.com/entireio/cli/pull/970).

Replaces `checkpoints_v2_only` with a `checkpoints_version` setting. The default for now is "1", though "2" is also supported. Same as `checkpoints_v2_only`, when checkpoints_version is set to 2, checkpoints v1 writes are disabled.

Allows for `2` or `"2"` as options, but any unsupported version or string value will fall back to version `1` as the default for now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint write/push behavior based on a new numeric `checkpoints_version` setting, which can disable v1 metadata writes and affect sync/migration flows. Risk is moderate due to touching commit hooks, push logic, and settings parsing (with fallback behavior).
> 
> **Overview**
> Introduces `strategy_options.checkpoints_version` (defaulting to `1`) as the new switch for checkpoint format selection, replacing the prior `checkpoints_v2_only` boolean. A value of `2` disables v1 checkpoint metadata writes/pushes while keeping v2 refs enabled; invalid/unsupported values fall back to `1` with a one-time stderr warning.
> 
> Updates attach/condensation/finalization and pre-push paths to key off `CheckpointsVersion()==2` for v1 skipping and error propagation semantics, and adjusts migration hinting to detect committed `checkpoints_version: 2`. Integration and unit tests are updated/expanded to cover version parsing and the “version 2 skips v1” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42959df223d11f7b0b88845f18fb92216f94e43. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->