### PR TITLE
Require lint before pushing remote code updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,10 @@ mise run test:ci  # Run all tests (unit + integration)
 
 Safety note: do not treat a clean `mise run lint` result as final unless it was run after the most recent `mise run fmt` pass.
 
+### Before Any Push Or Remote Code Update (REQUIRED)
+
+Before pushing commits or otherwise sending code changes to any remote, run `mise run lint` on the current tree and ensure it passes. If `mise run fmt` changed files, rerun `mise run lint` on the formatted tree before pushing.
+
 **Common CI failures from skipping this:**
 
 - `gofmt` formatting differences → run `mise run fmt`


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/9ae25d16129b

## Summary
Add explicit repo guidance requiring agents to run `mise run lint` and confirm it passes before pushing or otherwise sending code changes to a remote.

## Implementation
Update the repo-level agent instructions to:
- require a passing `mise run lint` before any push or remote code update
- require rerunning lint after formatting if `mise run fmt` changed files

## Verification
- `mise run check`