### PR TITLE
Consolidate TTY detection and narrow ACCESSIBLE to output format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,25 +619,19 @@ Trailers:
 - Handle all errors explicitly—don't leave them unchecked.
 - Reference `.golangci.yml` for enabled linters before writing Go code.
 
-## Accessibility
+## Interactive prompts and accessibility
 
-The CLI supports an accessibility mode for users who rely on screen readers. This mode uses simpler text prompts instead of interactive TUI elements.
+The CLI separates two concerns:
 
-### Environment Variable
+1. **Can we prompt at all?** — handled by `interactive.CanPromptInteractively()`. Returns false when no `/dev/tty` is available, or when running inside a known AI-agent subprocess (`GEMINI_CLI`, `COPILOT_CLI`, `PI_CODING_AGENT`, `GIT_TERMINAL_PROMPT=0`). Single source of truth.
+2. **If we do prompt, render in plain-text mode?** — controlled by the `ACCESSIBLE` environment variable. Set `ACCESSIBLE=1` for screen-reader users, or when an agent subprocess has a real TTY (tmux) but needs plain-text output for downstream parsing (integration tests, e2e agents).
 
-- `ACCESSIBLE=1` (or any non-empty value) enables accessibility mode
-- Users can set this in their shell profile (`.bashrc`, `.zshrc`) for persistent use
+### Writing forms in the `cli` package
 
-### Implementation Guidelines
-
-When adding new interactive forms or prompts using `huh`:
-
-**In the `cli` package:**
-Use `NewAccessibleForm()` instead of `huh.NewForm()`:
+Use `NewForm()` — it wraps `huh.Form` with automatic TTY gating and accessible-mode opt-in. When no TTY is available, `Run()` returns nil with field values left at their defaults, so callers do not need any guard:
 
 ```go
-// Good - respects ACCESSIBLE env var
-form := NewAccessibleForm(
+form := NewForm(
     huh.NewGroup(
         huh.NewSelect[string]().
             Title("Choose an option").
@@ -645,30 +639,39 @@ form := NewAccessibleForm(
             Value(&choice),
     ),
 )
-
-// Bad - ignores accessibility setting
-form := huh.NewForm(...)
+if err := form.Run(); err != nil {
+    return err
+}
 ```
 
-**In the `strategy` package:**
-Use the `isAccessibleMode()` helper. Note that `WithAccessible()` is only available on forms, not individual fields, so wrap confirmations in a form:
+Do not call `huh.NewForm` directly — it bypasses the TTY gate.
+
+### Writing forms in the `strategy` package
+
+The `strategy` package cannot import `cli` (cycle), but it can import `interactive`. Gate your own forms manually:
 
 ```go
+if !interactive.CanPromptInteractively() {
+    // non-interactive fallback
+    return fallback
+}
+
 form := huh.NewForm(
     huh.NewGroup(
-        huh.NewConfirm().
-            Title("Confirm action?").
-            Value(&confirmed),
+        huh.NewConfirm().Title("Confirm action?").Value(&confirmed),
     ),
 )
-if isAccessibleMode() {
+if os.Getenv("ACCESSIBLE") != "" {
     form = form.WithAccessible(true)
 }
 if err := form.Run(); err != nil { ... }
 ```
 
-### Key Points
+For TTY-level prompts that read `/dev/tty` directly (e.g. `askConfirmTTY`), assign them to a package-level function variable so tests can swap the implementation — see `askConfirmTTY` and `overrideAskConfirmForTest` in `manual_commit_hooks.go`.
 
-- Always use the accessibility helpers for any `huh` forms/prompts
-- Test new interactive features with `ACCESSIBLE=1` to ensure they work
-- The accessible mode is documented in `--help` output
+### Tests
+
+- Unit tests in the `cli` and `strategy` packages use `forceInteractive(t)` / `forceNonInteractive(t)` helpers, which swap `interactive.CanPromptInteractively()` via `interactive.OverrideForTest` for the duration of the test.
+- Tests that need a deterministic `/dev/tty` confirmation response use `stubAskConfirm(t, ttyResultLink)` (strategy package) to replace `askConfirmTTY` with a fixed-result stub.
+- Integration-test subprocesses never have a `/dev/tty`, so they always take the non-interactive path. Tests that need to exercise the "human at terminal" branch belong in the `strategy` package as unit tests using `stubAskConfirm`.
+- `ENTIRE_TEST_TTY` exists only as a subprocess escape hatch for integration tests: `=1` forces `CanPromptInteractively` true, `=0` forces false. Do not read it from production code paths — in-process tests use `interactive.OverrideForTest`. If you find yourself reaching for this variable outside `cmd/entire/cli/integration_test/`, the test belongs in a different package.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -621,10 +621,11 @@ Trailers:
 
 ## Interactive prompts and accessibility
 
-The CLI separates two concerns:
+The CLI separates three concerns:
 
-1. **Can we prompt at all?** — handled by `interactive.CanPromptInteractively()`. Returns false when no `/dev/tty` is available, or when running inside a known AI-agent subprocess (`GEMINI_CLI`, `COPILOT_CLI`, `PI_CODING_AGENT`, `GIT_TERMINAL_PROMPT=0`). Single source of truth.
-2. **If we do prompt, render in plain-text mode?** — controlled by the `ACCESSIBLE` environment variable. Set `ACCESSIBLE=1` for screen-reader users, or when an agent subprocess has a real TTY (tmux) but needs plain-text output for downstream parsing (integration tests, e2e agents).
+1. **Can a cobra command prompt?** — `interactive.CanPromptInteractively()` uses `term.IsTerminal(os.Stdin.Fd())` plus agent-subprocess detection. Returns false when stdin is a pipe or the process runs inside a known AI-agent subprocess (`GEMINI_CLI`, `COPILOT_CLI`, `PI_CODING_AGENT`, `GIT_TERMINAL_PROMPT=0`). Use this from every cobra command.
+2. **Can a git hook prompt?** — `interactive.CanPromptFromHook()` uses `/dev/tty` because git redirects hook stdin. Same agent-subprocess filter. Only the git-hook code paths (`strategy/manual_commit_hooks.go`) should call this. The `ENTIRE_TEST_TTY` env var is honored here as a subprocess escape hatch for integration tests.
+3. **If we do prompt, render in plain-text mode?** — controlled by the `ACCESSIBLE` environment variable. Set `ACCESSIBLE=1` for screen-reader users, or when an agent subprocess has a real TTY (tmux) but needs plain-text output for downstream parsing (integration tests, e2e agents).
 
 ### Writing forms in the `cli` package
 
@@ -671,7 +672,7 @@ For TTY-level prompts that read `/dev/tty` directly (e.g. `askConfirmTTY`), assi
 
 ### Tests
 
-- Unit tests in the `cli` and `strategy` packages use `forceInteractive(t)` / `forceNonInteractive(t)` helpers, which swap `interactive.CanPromptInteractively()` via `interactive.OverrideForTest` for the duration of the test.
+- Unit tests in the `cli` and `strategy` packages use `forceInteractive(t)` / `forceNonInteractive(t)` helpers. These call `interactive.OverrideForTest`, which swaps **both** `CanPromptInteractively` and `CanPromptFromHook` at once for the duration of the test.
 - Tests that need a deterministic `/dev/tty` confirmation response use `stubAskConfirm(t, ttyResultLink)` (strategy package) to replace `askConfirmTTY` with a fixed-result stub.
 - Integration-test subprocesses never have a `/dev/tty`, so they always take the non-interactive path. Tests that need to exercise the "human at terminal" branch belong in the `strategy` package as unit tests using `stubAskConfirm`.
-- `ENTIRE_TEST_TTY` exists only as a subprocess escape hatch for integration tests: `=1` forces `CanPromptInteractively` true, `=0` forces false. Do not read it from production code paths — in-process tests use `interactive.OverrideForTest`. If you find yourself reaching for this variable outside `cmd/entire/cli/integration_test/`, the test belongs in a different package.
+- `ENTIRE_TEST_TTY` exists only as a subprocess escape hatch for integration tests that spawn the entire CLI as a git-hook subprocess: `=1` forces `CanPromptFromHook` true, `=0` forces false. It has no effect on `CanPromptInteractively`, which always uses real stdin detection. Do not read it from production code paths — in-process tests use `interactive.OverrideForTest`. If you find yourself reaching for this variable outside `cmd/entire/cli/integration_test/`, the test belongs in a different package.

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -443,7 +443,7 @@ func promptAmendCommit(ctx context.Context, w io.Writer, headCommit *object.Comm
 			fmt.Fprintf(w, "\nCopy to your commit message to attach:\n\n  Entire-Checkpoint: %s\n", checkpointIDStr)
 			return nil
 		}
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title("Amend the last commit in this branch?").

--- a/cmd/entire/cli/clean.go
+++ b/cmd/entire/cli/clean.go
@@ -131,7 +131,7 @@ func runCleanCurrentHead(ctx context.Context, cmd *cobra.Command, force, dryRun 
 	if !force {
 		var confirmed bool
 
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title("Clean session data for current HEAD?").
@@ -241,7 +241,7 @@ func runCleanSession(ctx context.Context, cmd *cobra.Command, strat *strategy.Ma
 		title := fmt.Sprintf("%s session %s?", actionVerb, sessionID)
 		description := fmt.Sprintf("Phase: %s, Checkpoints: %d", state.Phase, state.StepCount)
 
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(title).
@@ -372,7 +372,7 @@ func runCleanAllWithItems(ctx context.Context, cmd *cobra.Command, force, dryRun
 
 		// Prompt for confirmation
 		var confirmed bool
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Delete %d %s?", totalItems, itemWord(totalItems))).

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -322,7 +322,7 @@ func promptSessionAction(ss stuckSession) (string, error) {
 		huh.NewOption("Skip (leave as-is)", "skip"),
 	)
 
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title(fmt.Sprintf("Fix session %s?", ss.State.SessionID)).
@@ -391,7 +391,7 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 
 	if !force {
 		var confirmed bool
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title("Fix disconnected metadata branches?").
@@ -462,7 +462,7 @@ func checkDisconnectedV2Main(cmd *cobra.Command, force bool) error {
 
 	if !force {
 		var confirmed bool
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title("Fix disconnected v2 /main ref?").

--- a/cmd/entire/cli/explain_summary_provider.go
+++ b/cmd/entire/cli/explain_summary_provider.go
@@ -122,7 +122,7 @@ func promptForSummaryProvider(providers []checkpointSummaryProvider) (types.Agen
 	}
 
 	var selected string
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Choose a summary provider").

--- a/cmd/entire/cli/explain_summary_provider_test.go
+++ b/cmd/entire/cli/explain_summary_provider_test.go
@@ -190,7 +190,7 @@ func TestResolveCheckpointSummaryProvider_NonInteractiveMultiCandidatePicksFirst
 	tmpDir := t.TempDir()
 	testutil.InitRepo(t, tmpDir)
 	t.Chdir(tmpDir)
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 
 	originalLoad := loadSummarySettings
 	originalGet := getSummaryAgent

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1821,7 +1821,7 @@ func TestRunExplainCheckpoint_V2UsesCompactTranscriptForIntent(t *testing.T) {
 func TestRunExplainCheckpoint_V2PreferredGenerateWritesBothStores(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	t.Setenv("ENTIRE_TEST_TTY", "0") // prevent interactive summary provider prompt
+	forceNonInteractive(t) // prevent interactive summary provider prompt
 
 	testutil.InitRepo(t, tmpDir)
 	repo, err := git.PlainOpen(tmpDir)
@@ -1883,7 +1883,7 @@ func TestRunExplainCheckpoint_V2PreferredGenerateWritesBothStores(t *testing.T) 
 func TestRunExplainCheckpoint_V2OnlyGenerateSucceedsViaV2Store(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	t.Setenv("ENTIRE_TEST_TTY", "0") // prevent interactive summary provider prompt
+	forceNonInteractive(t) // prevent interactive summary provider prompt
 
 	testutil.InitRepo(t, tmpDir)
 	repo, err := git.PlainOpen(tmpDir)
@@ -1995,7 +1995,7 @@ func TestRunExplainCheckpoint_V2FallsBackToFullWhenCompactMissing(t *testing.T) 
 func TestRunExplainCheckpoint_V2CompactTranscriptNotUsedForGenerate(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	t.Setenv("ENTIRE_TEST_TTY", "0") // prevent interactive summary provider prompt
+	forceNonInteractive(t) // prevent interactive summary provider prompt
 
 	testutil.InitRepo(t, tmpDir)
 	repo, err := git.PlainOpen(tmpDir)

--- a/cmd/entire/cli/integration_test/deferred_finalization_test.go
+++ b/cmd/entire/cli/integration_test/deferred_finalization_test.go
@@ -77,7 +77,7 @@ func TestShadow_DeferredTranscriptFinalization(t *testing.T) {
 		// Run prepare-commit-msg
 		prepCmd := exec.Command(getTestBinary(), "hooks", "git", "prepare-commit-msg", msgFile, "message")
 		prepCmd.Dir = env.RepoDir
-		prepCmd.Env = append(testutil.GitIsolatedEnv(), "ENTIRE_TEST_TTY=1")
+		prepCmd.Env = testutil.GitIsolatedEnv()
 		prepOutput, prepErr := prepCmd.CombinedOutput()
 		t.Logf("prepare-commit-msg output: %s (err: %v)", prepOutput, prepErr)
 

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -200,7 +200,6 @@ func runLoginProcess(t *testing.T, apiBaseURL string) *loginProcess {
 		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir,
 		"ENTIRE_TEST_GEMINI_PROJECT_DIR="+env.GeminiProjectDir,
 		"ENTIRE_TEST_OPENCODE_PROJECT_DIR="+env.OpenCodeProjectDir,
-		"ENTIRE_TEST_TTY=0",
 		"ENTIRE_API_BASE_URL="+apiBaseURL,
 	)
 

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -133,11 +133,12 @@ func gitEmptyConfigPath() string {
 // Includes Claude, Gemini, and OpenCode project dirs so tests work for any agent.
 // Delegates to testutil.GitIsolatedEnv() for git config isolation.
 func (env *TestEnv) cliEnv() []string {
+	// No TTY toggle needed: integration-test subprocesses run without a PTY,
+	// so interactive.CanPromptInteractively() returns false naturally.
 	return append(testutil.GitIsolatedEnv(),
 		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir,
 		"ENTIRE_TEST_GEMINI_PROJECT_DIR="+env.GeminiProjectDir,
 		"ENTIRE_TEST_OPENCODE_PROJECT_DIR="+env.OpenCodeProjectDir,
-		"ENTIRE_TEST_TTY=0", // Prevent interactive prompts from blocking in tests
 	)
 }
 
@@ -1095,8 +1096,12 @@ func (env *TestEnv) GitCommitWithShadowHooksAsAgent(message string, files ...str
 }
 
 // gitCommitWithShadowHooks is the shared implementation for committing with shadow hooks.
-// When simulateTTY is true, sets ENTIRE_TEST_TTY=1 to simulate a human at the terminal.
-// When false, filters it out to simulate an agent subprocess (no controlling terminal).
+// When simulateTTY is true the subprocess is told via ENTIRE_TEST_TTY=1 to pretend a
+// /dev/tty is available, so the hook takes the human-at-terminal branch (which stubs
+// the actual prompt to its default answer). When false, the subprocess runs with no
+// /dev/tty and takes the agent/fast-path branch. This env var is read only by
+// interactive.checkCanPrompt and only exists as a subprocess escape hatch for
+// integration tests; in-process tests use interactive.OverrideForTest instead.
 func (env *TestEnv) gitCommitWithShadowHooks(message string, simulateTTY bool, files ...string) {
 	env.T.Helper()
 
@@ -1116,12 +1121,8 @@ func (env *TestEnv) gitCommitWithShadowHooks(message string, simulateTTY bool, f
 	prepCmd := exec.Command(getTestBinary(), "hooks", "git", "prepare-commit-msg", msgFile, "message")
 	prepCmd.Dir = env.RepoDir
 	if simulateTTY {
-		// Simulate human at terminal: ENTIRE_TEST_TTY=1 makes hasTTY() return true
-		// and askConfirmTTY() return defaultYes without reading from /dev/tty.
 		prepCmd.Env = env.gitHookEnv("ENTIRE_TEST_TTY=1")
 	} else {
-		// Simulate agent: ENTIRE_TEST_TTY=0 makes hasTTY() return false,
-		// triggering the fast path that adds trailers for ACTIVE sessions.
 		prepCmd.Env = env.gitHookEnv("ENTIRE_TEST_TTY=0")
 	}
 	if output, err := prepCmd.CombinedOutput(); err != nil {
@@ -1194,7 +1195,7 @@ func (env *TestEnv) GitCommitAmendWithShadowHooks(message string, files ...strin
 	}
 
 	// Run prepare-commit-msg hook with "commit" source (indicates amend).
-	// Set ENTIRE_TEST_TTY=1 to simulate human (amend is always a human operation).
+	// Amend is a human operation — signal TTY via ENTIRE_TEST_TTY=1.
 	prepCmd := exec.Command(getTestBinary(), "hooks", "git", "prepare-commit-msg", msgFile, "commit")
 	prepCmd.Dir = env.RepoDir
 	prepCmd.Env = env.gitHookEnv("ENTIRE_TEST_TTY=1")
@@ -1280,8 +1281,8 @@ func (env *TestEnv) GitCommitWithTrailerRemoved(message string, files ...string)
 	}
 
 	// Run prepare-commit-msg hook using the shared binary.
-	// Set ENTIRE_TEST_TTY=1 to simulate human (this tests the editor flow where
-	// the user removes the trailer before committing).
+	// Simulate human editor flow via ENTIRE_TEST_TTY=1; the hook adds the
+	// trailer, then the test removes it to exercise the opt-out behavior.
 	prepCmd := exec.Command(getTestBinary(), "hooks", "git", "prepare-commit-msg", msgFile)
 	prepCmd.Dir = env.RepoDir
 	prepCmd.Env = env.gitHookEnv("ENTIRE_TEST_TTY=1")
@@ -1366,6 +1367,7 @@ func (env *TestEnv) GitCommitStagedWithShadowHooks(message string) {
 }
 
 // gitCommitStagedWithShadowHooks is the shared implementation for committing staged changes with hooks.
+// See gitCommitWithShadowHooks for the simulateTTY semantics.
 func (env *TestEnv) gitCommitStagedWithShadowHooks(message string, simulateTTY bool) {
 	env.T.Helper()
 

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -5,26 +5,67 @@ package interactive
 
 import "os"
 
+// canPrompt is the swappable TTY detection function. Tests replace it via
+// OverrideForTest; production uses checkCanPrompt.
+var canPrompt = checkCanPrompt
+
 // CanPromptInteractively reports whether interactive confirmation prompts
-// (huh forms, yes/no questions, etc.) can be shown. Returns false in CI,
-// tests without ENTIRE_TEST_TTY=1, and other environments without a
-// controlling TTY.
-//
-// ENTIRE_TEST_TTY overrides /dev/tty detection so tests can exercise both
-// interactive and non-interactive paths deterministically without needing
-// a real pty:
-//   - ENTIRE_TEST_TTY=1 forces interactive mode on
-//   - any other non-empty value forces interactive mode off
-//   - unset falls through to /dev/tty availability
+// (huh forms, yes/no questions, etc.) can be shown. Returns false when
+// there is no controlling terminal, or when running inside a known AI
+// coding agent subprocess that inherits the user's TTY but cannot respond
+// to prompts on the user's behalf.
 func CanPromptInteractively() bool {
+	return canPrompt()
+}
+
+func checkCanPrompt() bool {
+	// Subprocess escape hatch for integration tests.
+	// Production callers do not set this variable. In-process unit tests use
+	// OverrideForTest instead. The only consumers are integration tests that
+	// spawn the entire CLI as a subprocess and cannot use OverrideForTest.
+	// Keeping the check *before* /dev/tty detection means it also lets tests
+	// force the non-interactive path deterministically (value "0" or similar)
+	// on systems where /dev/tty happens to be accessible.
 	if v, ok := os.LookupEnv("ENTIRE_TEST_TTY"); ok {
 		return v == "1"
 	}
-
+	if isAgentSubprocess() {
+		return false
+	}
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
 	if err != nil {
 		return false
 	}
 	_ = tty.Close()
 	return true
+}
+
+// isAgentSubprocess returns true when the process is a subprocess of a
+// known AI coding agent. These agents may pass through a real TTY (e.g.
+// tmux) but cannot respond to interactive prompts on the user's behalf,
+// so the CLI must treat them as non-interactive regardless of /dev/tty.
+func isAgentSubprocess() bool {
+	switch {
+	case os.Getenv("GEMINI_CLI") != "":
+		return true
+	case os.Getenv("COPILOT_CLI") != "":
+		return true
+	case os.Getenv("PI_CODING_AGENT") != "":
+		return true
+	case os.Getenv("GIT_TERMINAL_PROMPT") == "0":
+		return true
+	}
+	return false
+}
+
+// OverrideForTest replaces TTY detection for the duration of a test.
+// Returns a restore function that must be deferred (or passed to
+// t.Cleanup).
+//
+//	restore := interactive.OverrideForTest(func() bool { return false })
+//	defer restore()
+func OverrideForTest(fn func() bool) func() {
+	old := canPrompt
+	canPrompt = fn
+	return func() { canPrompt = old }
 }

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -3,29 +3,54 @@
 // import cli).
 package interactive
 
-import "os"
+import (
+	"os"
 
-// canPrompt is the swappable TTY detection function. Tests replace it via
-// OverrideForTest; production uses checkCanPrompt.
-var canPrompt = checkCanPrompt
+	"golang.org/x/term"
+)
 
-// CanPromptInteractively reports whether interactive confirmation prompts
-// (huh forms, yes/no questions, etc.) can be shown. Returns false when
-// there is no controlling terminal, or when running inside a known AI
-// coding agent subprocess that inherits the user's TTY but cannot respond
-// to prompts on the user's behalf.
+// canPromptCLI and canPromptHook are swappable detection functions. Tests
+// replace them via OverrideForTest; production uses checkCLIPrompt /
+// checkHookPrompt.
+var (
+	canPromptCLI  = checkCLIPrompt
+	canPromptHook = checkHookPrompt
+)
+
+// CanPromptInteractively reports whether a regular CLI command (cobra
+// subcommand) can show interactive prompts. Uses term.IsTerminal on stdin,
+// which is the standard Go idiom. Returns false when stdin is a pipe, the
+// process runs inside a known AI agent subprocess, or stdin is not a
+// terminal for any other reason.
+//
+// Callers inside git hooks must use CanPromptFromHook instead — git
+// redirects stdin, so stdin-based detection always reports false there.
 func CanPromptInteractively() bool {
-	return canPrompt()
+	return canPromptCLI()
 }
 
-func checkCanPrompt() bool {
-	// Subprocess escape hatch for integration tests.
-	// Production callers do not set this variable. In-process unit tests use
-	// OverrideForTest instead. The only consumers are integration tests that
-	// spawn the entire CLI as a subprocess and cannot use OverrideForTest.
-	// Keeping the check *before* /dev/tty detection means it also lets tests
-	// force the non-interactive path deterministically (value "0" or similar)
-	// on systems where /dev/tty happens to be accessible.
+// CanPromptFromHook reports whether a git hook subprocess can show
+// interactive prompts. Git hooks run with redirected stdin/stdout, so
+// CanPromptInteractively would always report false. CanPromptFromHook
+// opens /dev/tty (the controlling terminal) instead, which survives git's
+// redirection.
+//
+// This path also honors ENTIRE_TEST_TTY as a subprocess escape hatch for
+// integration tests that spawn the entire CLI as a hook subprocess and
+// cannot use OverrideForTest. Production code outside the test harness
+// does not set this variable.
+func CanPromptFromHook() bool {
+	return canPromptHook()
+}
+
+func checkCLIPrompt() bool {
+	if isAgentSubprocess() {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // stdin fd is 0; uintptr->int cannot overflow
+}
+
+func checkHookPrompt() bool {
 	if v, ok := os.LookupEnv("ENTIRE_TEST_TTY"); ok {
 		return v == "1"
 	}
@@ -58,14 +83,18 @@ func isAgentSubprocess() bool {
 	return false
 }
 
-// OverrideForTest replaces TTY detection for the duration of a test.
-// Returns a restore function that must be deferred (or passed to
-// t.Cleanup).
+// OverrideForTest replaces both CanPromptInteractively and CanPromptFromHook
+// detection for the duration of a test. Returns a restore function that
+// must be deferred (or passed to t.Cleanup).
 //
 //	restore := interactive.OverrideForTest(func() bool { return false })
 //	defer restore()
 func OverrideForTest(fn func() bool) func() {
-	old := canPrompt
-	canPrompt = fn
-	return func() { canPrompt = old }
+	oldCLI, oldHook := canPromptCLI, canPromptHook
+	canPromptCLI = fn
+	canPromptHook = fn
+	return func() {
+		canPromptCLI = oldCLI
+		canPromptHook = oldHook
+	}
 }

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -5,8 +5,18 @@ package interactive
 
 import (
 	"os"
+	"strings"
 
 	"golang.org/x/term"
+)
+
+const (
+	// PromptModeEnv controls CLI prompt policy.
+	PromptModeEnv = "ENTIRE_PROMPTS"
+
+	promptModeAuto  = "auto"
+	promptModeNever = "never"
+	promptModePlain = "plain"
 )
 
 // canPromptCLI and canPromptHook are swappable detection functions. Tests
@@ -43,18 +53,42 @@ func CanPromptFromHook() bool {
 	return canPromptHook()
 }
 
-func checkCLIPrompt() bool {
-	if isAgentSubprocess() {
-		return false
+// PromptMode returns the configured prompt policy.
+func PromptMode() string {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(PromptModeEnv))) {
+	case "", promptModeAuto:
+		return promptModeAuto
+	case promptModeNever:
+		return promptModeNever
+	case promptModePlain:
+		return promptModePlain
+	default:
+		return promptModeAuto
 	}
-	return term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // stdin fd is 0; uintptr->int cannot overflow
+}
+
+func checkCLIPrompt() bool {
+	switch PromptMode() {
+	case promptModeNever:
+		return false
+	case promptModePlain:
+		return term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // stdin fd is 0; uintptr->int cannot overflow
+	default:
+		if isAgentSubprocess() {
+			return false
+		}
+		return term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // stdin fd is 0; uintptr->int cannot overflow
+	}
 }
 
 func checkHookPrompt() bool {
 	if v, ok := os.LookupEnv("ENTIRE_TEST_TTY"); ok {
 		return v == "1"
 	}
-	if isAgentSubprocess() {
+	if PromptMode() == promptModeNever {
+		return false
+	}
+	if PromptMode() == promptModeAuto && isAgentSubprocess() {
 		return false
 	}
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)

--- a/cmd/entire/cli/interactive/interactive_test.go
+++ b/cmd/entire/cli/interactive/interactive_test.go
@@ -3,15 +3,70 @@ package interactive
 import "testing"
 
 func TestCanPromptInteractively_ForcedOn(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	restore := OverrideForTest(func() bool { return true })
+	defer restore()
 	if !CanPromptInteractively() {
-		t.Error("CanPromptInteractively() = false; want true when ENTIRE_TEST_TTY=1")
+		t.Error("CanPromptInteractively() = false; want true when override returns true")
 	}
 }
 
 func TestCanPromptInteractively_ForcedOff(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	restore := OverrideForTest(func() bool { return false })
+	defer restore()
 	if CanPromptInteractively() {
-		t.Error("CanPromptInteractively() = true; want false when ENTIRE_TEST_TTY=0")
+		t.Error("CanPromptInteractively() = true; want false when override returns false")
+	}
+}
+
+func TestOverrideForTest_RestoresOriginal(t *testing.T) {
+	orig := CanPromptInteractively()
+
+	restore := OverrideForTest(func() bool { return !orig })
+	if CanPromptInteractively() == orig {
+		t.Error("override did not take effect")
+	}
+	restore()
+
+	if CanPromptInteractively() != orig {
+		t.Error("restore did not return to original detection")
+	}
+}
+
+func TestIsAgentSubprocess_GeminiCli(t *testing.T) {
+	t.Setenv("GEMINI_CLI", "1")
+	if !isAgentSubprocess() {
+		t.Error("isAgentSubprocess() = false; want true when GEMINI_CLI is set")
+	}
+}
+
+func TestIsAgentSubprocess_CopilotCli(t *testing.T) {
+	t.Setenv("COPILOT_CLI", "1")
+	if !isAgentSubprocess() {
+		t.Error("isAgentSubprocess() = false; want true when COPILOT_CLI is set")
+	}
+}
+
+func TestIsAgentSubprocess_PiCodingAgent(t *testing.T) {
+	t.Setenv("PI_CODING_AGENT", "1")
+	if !isAgentSubprocess() {
+		t.Error("isAgentSubprocess() = false; want true when PI_CODING_AGENT is set")
+	}
+}
+
+func TestIsAgentSubprocess_GitTerminalPromptZero(t *testing.T) {
+	t.Setenv("GIT_TERMINAL_PROMPT", "0")
+	if !isAgentSubprocess() {
+		t.Error("isAgentSubprocess() = false; want true when GIT_TERMINAL_PROMPT=0")
+	}
+}
+
+func TestIsAgentSubprocess_GitTerminalPromptOne(t *testing.T) {
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	// Clear other agent env vars so only GIT_TERMINAL_PROMPT drives detection.
+	t.Setenv("GEMINI_CLI", "")
+	t.Setenv("COPILOT_CLI", "")
+	t.Setenv("PI_CODING_AGENT", "")
+	if isAgentSubprocess() {
+		t.Error("isAgentSubprocess() = true; want false when GIT_TERMINAL_PROMPT=1")
 	}
 }

--- a/cmd/entire/cli/interactive/interactive_test.go
+++ b/cmd/entire/cli/interactive/interactive_test.go
@@ -2,33 +2,54 @@ package interactive
 
 import "testing"
 
-func TestCanPromptInteractively_ForcedOn(t *testing.T) {
+func TestOverrideForTest_ForcedOn(t *testing.T) {
 	restore := OverrideForTest(func() bool { return true })
 	defer restore()
 	if !CanPromptInteractively() {
 		t.Error("CanPromptInteractively() = false; want true when override returns true")
 	}
+	if !CanPromptFromHook() {
+		t.Error("CanPromptFromHook() = false; want true when override returns true")
+	}
 }
 
-func TestCanPromptInteractively_ForcedOff(t *testing.T) {
+func TestOverrideForTest_ForcedOff(t *testing.T) {
 	restore := OverrideForTest(func() bool { return false })
 	defer restore()
 	if CanPromptInteractively() {
 		t.Error("CanPromptInteractively() = true; want false when override returns false")
 	}
+	if CanPromptFromHook() {
+		t.Error("CanPromptFromHook() = true; want false when override returns false")
+	}
 }
 
 func TestOverrideForTest_RestoresOriginal(t *testing.T) {
-	orig := CanPromptInteractively()
+	origCLI := CanPromptInteractively()
+	origHook := CanPromptFromHook()
 
-	restore := OverrideForTest(func() bool { return !orig })
-	if CanPromptInteractively() == orig {
-		t.Error("override did not take effect")
-	}
+	restore := OverrideForTest(func() bool { return !origCLI })
 	restore()
 
-	if CanPromptInteractively() != orig {
-		t.Error("restore did not return to original detection")
+	if CanPromptInteractively() != origCLI {
+		t.Error("restore did not return CLI detection to original")
+	}
+	if CanPromptFromHook() != origHook {
+		t.Error("restore did not return hook detection to original")
+	}
+}
+
+func TestCanPromptFromHook_EnvVarForceOn(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+	if !CanPromptFromHook() {
+		t.Error("CanPromptFromHook() = false; want true when ENTIRE_TEST_TTY=1")
+	}
+}
+
+func TestCanPromptFromHook_EnvVarForceOff(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "0")
+	if CanPromptFromHook() {
+		t.Error("CanPromptFromHook() = true; want false when ENTIRE_TEST_TTY=0")
 	}
 }
 
@@ -57,16 +78,5 @@ func TestIsAgentSubprocess_GitTerminalPromptZero(t *testing.T) {
 	t.Setenv("GIT_TERMINAL_PROMPT", "0")
 	if !isAgentSubprocess() {
 		t.Error("isAgentSubprocess() = false; want true when GIT_TERMINAL_PROMPT=0")
-	}
-}
-
-func TestIsAgentSubprocess_GitTerminalPromptOne(t *testing.T) {
-	t.Setenv("GIT_TERMINAL_PROMPT", "1")
-	// Clear other agent env vars so only GIT_TERMINAL_PROMPT drives detection.
-	t.Setenv("GEMINI_CLI", "")
-	t.Setenv("COPILOT_CLI", "")
-	t.Setenv("PI_CODING_AGENT", "")
-	if isAgentSubprocess() {
-		t.Error("isAgentSubprocess() = true; want false when GIT_TERMINAL_PROMPT=1")
 	}
 }

--- a/cmd/entire/cli/interactive/interactive_test.go
+++ b/cmd/entire/cli/interactive/interactive_test.go
@@ -53,6 +53,27 @@ func TestCanPromptFromHook_EnvVarForceOff(t *testing.T) {
 	}
 }
 
+func TestPromptMode_DefaultsToAuto(t *testing.T) {
+	t.Setenv(PromptModeEnv, "")
+	if got := PromptMode(); got != "auto" {
+		t.Fatalf("PromptMode() = %q, want auto", got)
+	}
+}
+
+func TestPromptMode_Plain(t *testing.T) {
+	t.Setenv(PromptModeEnv, "plain")
+	if got := PromptMode(); got != "plain" {
+		t.Fatalf("PromptMode() = %q, want plain", got)
+	}
+}
+
+func TestPromptMode_InvalidFallsBackToAuto(t *testing.T) {
+	t.Setenv(PromptModeEnv, "bogus")
+	if got := PromptMode(); got != "auto" {
+		t.Fatalf("PromptMode() = %q, want auto", got)
+	}
+}
+
 func TestIsAgentSubprocess_GeminiCli(t *testing.T) {
 	t.Setenv("GEMINI_CLI", "1")
 	if !isAgentSubprocess() {

--- a/cmd/entire/cli/interactive_test_helpers_test.go
+++ b/cmd/entire/cli/interactive_test_helpers_test.go
@@ -6,15 +6,15 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 )
 
-// forceInteractive makes interactive.CanPromptInteractively() return true
-// for the duration of the test. Replaces the old t.Setenv("ENTIRE_TEST_TTY", "1").
+// forceInteractive makes both interactive.CanPromptInteractively and
+// interactive.CanPromptFromHook return true for the duration of the test.
 func forceInteractive(t *testing.T) {
 	t.Helper()
 	t.Cleanup(interactive.OverrideForTest(func() bool { return true }))
 }
 
-// forceNonInteractive makes interactive.CanPromptInteractively() return false
-// for the duration of the test. Replaces the old t.Setenv("ENTIRE_TEST_TTY", "0").
+// forceNonInteractive makes both interactive detection paths return false
+// for the duration of the test.
 func forceNonInteractive(t *testing.T) {
 	t.Helper()
 	t.Cleanup(interactive.OverrideForTest(func() bool { return false }))

--- a/cmd/entire/cli/interactive_test_helpers_test.go
+++ b/cmd/entire/cli/interactive_test_helpers_test.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+)
+
+// forceInteractive makes interactive.CanPromptInteractively() return true
+// for the duration of the test. Replaces the old t.Setenv("ENTIRE_TEST_TTY", "1").
+func forceInteractive(t *testing.T) {
+	t.Helper()
+	t.Cleanup(interactive.OverrideForTest(func() bool { return true }))
+}
+
+// forceNonInteractive makes interactive.CanPromptInteractively() return false
+// for the duration of the test. Replaces the old t.Setenv("ENTIRE_TEST_TTY", "0").
+func forceNonInteractive(t *testing.T) {
+	t.Helper()
+	t.Cleanup(interactive.OverrideForTest(func() bool { return false }))
+}

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -27,6 +27,14 @@ const maxTransientErrors = 5
 // browserOpenFunc is the signature for opening a URL in the user's browser.
 type browserOpenFunc func(ctx context.Context, url string) error
 
+type tokenStore interface {
+	SaveToken(baseURL, token string) error
+}
+
+var newAuthStore = func() tokenStore {
+	return auth.NewStore()
+}
+
 // deviceAuthClient abstracts the auth client so runLogin and waitForApproval can be unit-tested.
 type deviceAuthClient interface {
 	StartDeviceAuth(ctx context.Context) (*auth.DeviceAuthStart, error)
@@ -36,6 +44,7 @@ type deviceAuthClient interface {
 
 func newLoginCmd() *cobra.Command {
 	var insecureHTTPAuth bool
+	var noBrowser bool
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -49,11 +58,12 @@ func newLoginCmd() *cobra.Command {
 				}
 			}
 
-			return runLogin(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), client, openBrowser)
+			return runLogin(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), client, openBrowser, noBrowser)
 		},
 	}
 
 	cmd.Flags().BoolVar(&insecureHTTPAuth, "insecure-http-auth", false, "Allow authentication over plain HTTP (insecure, for local development only)")
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Print the approval URL instead of waiting to open a browser interactively")
 	if err := cmd.Flags().MarkHidden("insecure-http-auth"); err != nil {
 		panic(fmt.Sprintf("hide insecure-http-auth flag: %v", err))
 	}
@@ -61,7 +71,7 @@ func newLoginCmd() *cobra.Command {
 	return cmd
 }
 
-func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc) error {
+func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc, noBrowser bool) error {
 	start, err := client.StartDeviceAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("start login: %w", err)
@@ -71,7 +81,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 
 	approvalURL := start.VerificationURI
 
-	if interactive.CanPromptInteractively() {
+	if !noBrowser && interactive.CanPromptInteractively() {
 		fmt.Fprintf(outW, "Press Enter to open %s in your browser and enter the generated device code...", approvalURL)
 
 		// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
@@ -96,7 +106,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		return fmt.Errorf("complete login: %w", err)
 	}
 
-	store := auth.NewStore()
+	store := newAuthStore()
 
 	if err := store.SaveToken(client.BaseURL(), token); err != nil {
 		return fmt.Errorf("save auth token: %w", err)

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -12,6 +13,8 @@ import (
 
 // mockClient implements deviceAuthClient for unit tests.
 type mockClient struct {
+	start     *auth.DeviceAuthStart
+	startErr  error
 	responses []pollResponse
 	calls     int
 }
@@ -22,6 +25,12 @@ type pollResponse struct {
 }
 
 func (m *mockClient) StartDeviceAuth(_ context.Context) (*auth.DeviceAuthStart, error) {
+	if m.startErr != nil {
+		return nil, m.startErr
+	}
+	if m.start != nil {
+		return m.start, nil
+	}
 	return nil, errors.New("not implemented in mock")
 }
 
@@ -36,6 +45,63 @@ func (m *mockClient) PollDeviceAuth(_ context.Context, _ string) (*auth.DeviceAu
 	r := m.responses[m.calls]
 	m.calls++
 	return r.result, r.err
+}
+
+type stubTokenStore struct {
+	baseURL string
+	token   string
+}
+
+func (s *stubTokenStore) SaveToken(baseURL, token string) error {
+	s.baseURL = baseURL
+	s.token = token
+	return nil
+}
+
+func TestRunLogin_NoBrowser_PrintsApprovalURL(t *testing.T) {
+	t.Parallel()
+
+	client := &mockClient{
+		start: &auth.DeviceAuthStart{
+			UserCode:        "USER-CODE",
+			VerificationURI: "https://example.com/approve",
+			DeviceCode:      "device-code",
+			ExpiresIn:       60,
+			Interval:        0,
+		},
+		responses: []pollResponse{
+			{result: &auth.DeviceAuthPoll{AccessToken: "tok-123"}},
+		},
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	var openCalls int
+
+	store := &stubTokenStore{}
+	oldNewAuthStore := newAuthStore
+	newAuthStore = func() tokenStore { return store }
+	t.Cleanup(func() { newAuthStore = oldNewAuthStore })
+
+	err := runLogin(context.Background(), &out, &errOut, client, func(context.Context, string) error {
+		openCalls++
+		return nil
+	}, true)
+	if err != nil {
+		t.Fatalf("runLogin() error = %v", err)
+	}
+	if openCalls != 0 {
+		t.Fatalf("openBrowser called %d times, want 0", openCalls)
+	}
+	if got := out.String(); !strings.Contains(got, "Approval URL: https://example.com/approve") {
+		t.Fatalf("output missing approval URL:\n%s", got)
+	}
+	if strings.Contains(out.String(), "Press Enter to open") {
+		t.Fatalf("output should not contain interactive browser prompt:\n%s", out.String())
+	}
+	if store.baseURL != client.BaseURL() || store.token != "tok-123" {
+		t.Fatalf("saved token = (%q, %q), want (%q, %q)", store.baseURL, store.token, client.BaseURL(), "tok-123")
+	}
 }
 
 func TestWaitForApproval_ImmediateSuccess(t *testing.T) {

--- a/cmd/entire/cli/reset.go
+++ b/cmd/entire/cli/reset.go
@@ -61,7 +61,7 @@ func newResetCmd() *cobra.Command {
 			if !forceFlag {
 				var confirmed bool
 
-				form := NewAccessibleForm(
+				form := NewForm(
 					huh.NewGroup(
 						huh.NewConfirm().
 							Title("Reset session data?").

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -658,7 +658,7 @@ func findCheckpointInHistory(start *object.Commit, stopAt *plumbing.Hash) *branc
 func promptResumeFromOlderCheckpoint() (bool, error) {
 	var confirmed bool
 
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Resume from this older checkpoint?").
@@ -1011,7 +1011,7 @@ func resumeSingleSession(ctx context.Context, w, errW io.Writer, ag agent.Agent,
 func promptFetchFromRemote(branchName string) (bool, error) {
 	var confirmed bool
 
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title(fmt.Sprintf("Branch '%s' not found locally. Fetch from origin?", branchName)).

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -163,7 +163,7 @@ func runRewindInteractive(ctx context.Context, w, errW io.Writer) error { //noli
 	options = append(options, huh.NewOption("Cancel", "cancel"))
 
 	var selectedID string
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Select a checkpoint to restore").
@@ -237,7 +237,7 @@ func runRewindInteractive(ctx context.Context, w, errW io.Writer) error { //noli
 	// Confirm rewind
 	var confirm bool
 	description := fmt.Sprintf("This will reset to: %s\nChanges after this point may be lost!", selectedPoint.Message)
-	confirmForm := NewAccessibleForm(
+	confirmForm := NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title(fmt.Sprintf("Reset to %s?", shortID)).
@@ -805,7 +805,7 @@ func restoreTaskCheckpointTranscript(ctx context.Context, w io.Writer, strat *st
 func handleLogsOnlyRewindInteractive(ctx context.Context, w, errW io.Writer, start *strategy.ManualCommitStrategy, point strategy.RewindPoint, shortID string) error {
 	var action string
 
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Logs-only point: "+shortID).
@@ -907,7 +907,7 @@ func handleLogsOnlyCheckout(ctx context.Context, w, errW io.Writer, start *strat
 
 	// Show warning about detached HEAD
 	var confirm bool
-	confirmForm := NewAccessibleForm(
+	confirmForm := NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Create detached HEAD?").
@@ -1005,7 +1005,7 @@ func handleLogsOnlyReset(ctx context.Context, w, errW io.Writer, start *strategy
 	}
 
 	var confirm bool
-	confirmForm := NewAccessibleForm(
+	confirmForm := NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title(confirmTitle).

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -26,6 +26,9 @@ Environment Variables:
   ACCESSIBLE    Set to any value (e.g., ACCESSIBLE=1) to enable accessibility
                 mode. This uses simpler text prompts instead of interactive
                 TUI elements, which works better with screen readers.
+  ENTIRE_PROMPTS
+                Control prompt policy. Use 'never' to disable prompts, or
+                'plain' to force plain-text prompts when a TTY is available.
 `
 
 func NewRootCmd() *cobra.Command {

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -70,7 +70,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			hasFilters := authorFlag != "" || dateFlag != "" || branchFlag != "" || len(repos) > 0
 
 			// Fast-fail: no query + non-interactive mode = error (before auth/git checks)
-			if query == "" && !hasFilters && (jsonOutput || !isTerminal || IsAccessibleMode()) {
+			if query == "" && !hasFilters && (jsonOutput || !isTerminal || os.Getenv("ACCESSIBLE") != "") {
 				return errors.New("query required when using --json, accessible mode, or piped output. Usage: entire search <query>")
 			}
 
@@ -163,7 +163,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			styles := newStatusStyles(w)
 
 			// Accessible mode: static table
-			if IsAccessibleMode() {
+			if os.Getenv("ACCESSIBLE") != "" {
 				if len(resp.Results) == 0 {
 					fmt.Fprintln(w, "No results found.")
 					return nil

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -480,7 +480,7 @@ func runStopSession(ctx context.Context, cmd *cobra.Command, sessionID string, f
 
 	if !force {
 		var confirmed bool
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Stop session %s?", sessionID)).
@@ -508,7 +508,7 @@ func runStopAll(ctx context.Context, cmd *cobra.Command, activeSessions []*strat
 
 	if !force {
 		var confirmed bool
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Stop %d session(s)?", len(activeSessions))).
@@ -541,7 +541,7 @@ func runStopMultiSelect(ctx context.Context, cmd *cobra.Command, activeSessions 
 	}
 
 	var selectedIDs []string
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("Select sessions to stop").
@@ -568,7 +568,7 @@ func runStopMultiSelect(ctx context.Context, cmd *cobra.Command, activeSessions 
 	// Confirm only if not forcing
 	if !force {
 		var confirmed bool
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Stop %d session(s)?", len(selectedIDs))).

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -374,7 +374,7 @@ func runManageAgents(ctx context.Context, w io.Writer, opts EnableOptions, selec
 			return fmt.Errorf("agent selection cancelled: %w", err)
 		}
 	} else {
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewMultiSelect[string]().
 					Title("Manage agents").
@@ -1316,7 +1316,7 @@ func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(availab
 			return nil, errors.New("no agents selected")
 		}
 	} else {
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewMultiSelect[string]().
 					Title("Select the agents you want to use").
@@ -1648,7 +1648,7 @@ func promptShellCompletion(w io.Writer) error {
 	}
 
 	var selected string
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title(fmt.Sprintf("Enable shell completion? (detected: %s)", shellName)).
@@ -1732,7 +1732,7 @@ func promptTelemetryConsent(settings *EntireSettings, telemetryFlag bool) error 
 	}
 
 	consent := true // Default to Yes
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Help improve Entire CLI?").
@@ -1837,7 +1837,7 @@ func maybePromptVercelDeploymentDisable(ctx context.Context, w io.Writer, target
 
 func promptVercelDeploymentDisable() (bool, error) {
 	disableDeployments := true
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Disable Vercel deployments for Entire metadata branch?").
@@ -1904,7 +1904,7 @@ func runUninstall(ctx context.Context, w, errW io.Writer, force bool) error {
 		fmt.Fprintln(w)
 
 		var confirmed bool
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title("Are you sure you want to uninstall Entire?").

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -312,7 +312,7 @@ func ghFlagsProvided(opts GitHubBootstrapOptions) bool {
 // CanPromptInteractively.
 func confirmCreateGitHubRepo() (bool, error) {
 	confirmed := true
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Create a matching repository on GitHub?").
@@ -346,7 +346,7 @@ func confirmInitRepo(_ io.Writer, cwd string, opts GitHubBootstrapOptions) (bool
 
 	folder := filepath.Base(cwd)
 	confirmed := true
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title(fmt.Sprintf("No git repository in %q. Initialize one here?", folder)).
@@ -421,7 +421,7 @@ func resolveOwner(w io.Writer, currentUser string, orgs []string, opts GitHubBoo
 		options = append(options, huh.NewOption(o, o))
 	}
 	selected := currentUser
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Choose the GitHub owner for the new repository").
@@ -481,7 +481,7 @@ func resolveRepoName(ctx context.Context, w, errW io.Writer, runner bootstrapRun
 	name := suggested
 	for {
 		var input string
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewInput().
 					Title("Repository name").
@@ -544,7 +544,7 @@ func resolveVisibility(owner, currentUser string, opts GitHubBootstrapOptions) (
 		options = append(options, huh.NewOption("Internal", visibilityInternal))
 	}
 	selected := visibilityPrivate
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Repository visibility").
@@ -584,7 +584,7 @@ func resolveCommitMessage(opts GitHubBootstrapOptions) (string, bool, error) {
 		choiceSkip      = "skip"
 	)
 	choice := choiceDefault
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Initial commit").
@@ -608,7 +608,7 @@ func resolveCommitMessage(opts GitHubBootstrapOptions) (string, bool, error) {
 		return "", false, nil
 	case choiceCustomize:
 		input := defaultMsg
-		custom := NewAccessibleForm(
+		custom := NewForm(
 			huh.NewGroup(
 				huh.NewInput().
 					Title("Initial commit message").
@@ -750,7 +750,7 @@ func resolveGitIdentity(w io.Writer, existingName, existingEmail, ghName, ghEmai
 	if email == "" {
 		fields = append(fields, huh.NewInput().Title("Git user.email").Value(&email))
 	}
-	form := NewAccessibleForm(huh.NewGroup(fields...))
+	form := NewForm(huh.NewGroup(fields...))
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {
 			return "", "", errBootstrapInterrupted

--- a/cmd/entire/cli/setup_github_test.go
+++ b/cmd/entire/cli/setup_github_test.go
@@ -332,7 +332,7 @@ func TestDoInitialCommit_WithFiles(t *testing.T) {
 }
 
 func TestRunGitHubBootstrap_DeclinedInNonInteractive(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -343,7 +343,7 @@ func TestRunGitHubBootstrap_DeclinedInNonInteractive(t *testing.T) {
 }
 
 func TestRunGitHubBootstrap_NoGitHubFlow(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -377,7 +377,7 @@ func TestRunGitHubBootstrap_NoGitHubFlow(t *testing.T) {
 }
 
 func TestRunGitHubBootstrap_GhMissingFallsBackToLocal(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -400,7 +400,7 @@ func TestRunGitHubBootstrap_GhMissingFallsBackToLocal(t *testing.T) {
 }
 
 func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -447,7 +447,7 @@ func TestRunGitHubBootstrap_FullNonInteractive(t *testing.T) {
 }
 
 func TestRunGitHubBootstrap_RepoExistsFails(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -505,7 +505,7 @@ func TestResolveCommitMessage_FlagTakesMessage(t *testing.T) {
 }
 
 func TestResolveCommitMessage_NonInteractiveDefault(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	msg, commit, err := resolveCommitMessage(GitHubBootstrapOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -522,7 +522,7 @@ func TestResolveCommitMessage_NonInteractiveDefault(t *testing.T) {
 // --skip-initial-commit still creates the GitHub repo (if requested) but
 // skips both commit and push. The local repo's files remain unstaged.
 func TestRunGitHubBootstrap_SkipCommitKeepsGitHub(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -599,7 +599,7 @@ func TestGhFlagsProvided(t *testing.T) {
 // non-interactive happy path still creates a GitHub repo when the user
 // didn't set any explicit flag (the confirm prompt is only interactive).
 func TestRunGitHubBootstrap_NonInteractive_NoFlagsDefaultsToGitHub(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -629,7 +629,7 @@ func TestRunGitHubBootstrap_NonInteractive_NoFlagsDefaultsToGitHub(t *testing.T)
 // file must end up in the initial commit (i.e. `git add -A` happens
 // after setup, not before).
 func TestRunGitHubBootstrap_InitBeforeFinalize(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -823,7 +823,7 @@ func TestEnsureGitIdentity_PreservesExistingEmail(t *testing.T) {
 }
 
 func TestEnsureGitIdentity_NonInteractiveNoGh_Errors(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	r := newFakeRunner()
 	r.set("git", []string{"config", "--get", "user.name"}, "", errors.New("not set"))
 	r.set("git", []string{"config", "--get", "user.email"}, "", errors.New("not set"))
@@ -859,7 +859,7 @@ func TestGhUserIdentity_NameFallsBackToLogin(t *testing.T) {
 // config. Regression guard for the issue where bootstrap commits failed
 // without a configured identity or because of commit.gpgsign=true.
 func TestBootstrap_FreshMachine_RealGit(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 
 	// Isolate from any global git config: point HOME + GIT_CONFIG_* at
 	// empty/missing locations, and force a broken GPG signing config that
@@ -941,7 +941,7 @@ func (r ghFailingRunner) RunInDir(ctx context.Context, dir, name string, args ..
 // test isn't sensitive to whether `gh` + GH_TOKEN/GITHUB_TOKEN are set
 // on the host.
 func TestBootstrap_FreshMachine_NoIdentity_RealGit(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 
 	emptyHome := t.TempDir()
 	t.Setenv("HOME", emptyHome)
@@ -1038,7 +1038,7 @@ func restoreCwd(t *testing.T, dir string) {
 func TestRunGitHubBootstrap_YesAcceptsAllDefaults(t *testing.T) {
 	// --yes should init repo, create GitHub repo under user's account (private),
 	// and use default commit message — without any interactive prompts.
-	t.Setenv("ENTIRE_TEST_TTY", "0") // non-interactive
+	forceNonInteractive(t) // non-interactive
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -1091,7 +1091,7 @@ func TestRunGitHubBootstrap_YesAcceptsAllDefaults(t *testing.T) {
 func TestRunGitHubBootstrap_YesRepoExistsNoTTY_Fails(t *testing.T) {
 	// When --yes is set, the repo name is taken, and there's no TTY,
 	// we should get a clear error instead of a silent gh failure.
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 
@@ -1122,7 +1122,7 @@ func TestResolveRepoName_YesRepoExistsWithTTY_FallsBackToPrompt(t *testing.T) {
 	// resolveRepoName should print a conflict message and fall through
 	// to the interactive prompt. We verify the conflict message was
 	// printed (proving the fallback path was taken).
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	// Force accessible (text-based) mode so the huh form reads from
 	// os.Stdin instead of trying to open /dev/tty via bubbletea.
@@ -1172,7 +1172,7 @@ func TestResolveRepoName_YesRepoExistsWithTTY_FallsBackToPrompt(t *testing.T) {
 
 func TestRunGitHubBootstrap_YesWithNoGitHub(t *testing.T) {
 	// --yes combined with --no-github should skip GitHub but still init + commit.
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := t.TempDir()
 	restoreCwd(t, dir)
 

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -994,7 +994,7 @@ func TestEnableUsesSetupFlow(t *testing.T) {
 
 func TestEnableCmd_ForceOnConfiguredRepo_UsesConfigureFlow(t *testing.T) {
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	writeSettings(t, testSettingsEnabled)
 	writeClaudeHooksFixture(t)
 
@@ -1020,7 +1020,7 @@ func TestEnableCmd_ForceOnConfiguredRepo_UsesConfigureFlow(t *testing.T) {
 
 func TestEnableCmd_ForceOnConfiguredDisabledRepo_Reenables(t *testing.T) {
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	writeSettings(t, testSettingsDisabled)
 	writeClaudeHooksFixture(t)
 
@@ -1054,7 +1054,7 @@ func TestEnableCmd_ForceOnConfiguredDisabledRepo_Reenables(t *testing.T) {
 
 func TestEnableCmd_ForceAndStrategyFlagsOnConfiguredDisabledRepo_ReenablesAndUpdatesSettings(t *testing.T) {
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	writeSettings(t, testSettingsDisabled)
 	writeClaudeHooksFixture(t)
 
@@ -1174,7 +1174,7 @@ func TestDetectOrSelectAgent_OnlyExternalDetected_WithTTY_PromptsUser(t *testing
 	}
 
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	externalAgentName := "ext-prompt-pi"
 	externalDir := t.TempDir()
@@ -1254,7 +1254,7 @@ func TestIsBuiltInAgent_BuiltInAgent_True(t *testing.T) {
 func TestDetectOrSelectAgent_NoDetection_NoTTY_FallsBackToDefault(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "0") // No TTY available
+	forceNonInteractive(t) // No TTY available
 
 	// No .claude or .gemini directory - detection will fail
 
@@ -1284,7 +1284,7 @@ func TestDetectOrSelectAgent_NoDetection_NoTTY_FallsBackToDefault(t *testing.T) 
 func TestDetectOrSelectAgent_NoDetection_WithTTY_ShowsPromptMessages(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	// No .claude or .gemini directory - detection will fail
 
@@ -1320,7 +1320,7 @@ func TestDetectOrSelectAgent_NoDetection_WithTTY_ShowsPromptMessages(t *testing.
 func TestDetectOrSelectAgent_SelectionCancelled(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	selectFn := func(_ []string) ([]string, error) {
 		return nil, errors.New("user cancelled")
@@ -1339,7 +1339,7 @@ func TestDetectOrSelectAgent_SelectionCancelled(t *testing.T) {
 func TestDetectOrSelectAgent_NoneSelected(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	selectFn := func(_ []string) ([]string, error) {
 		return []string{}, nil // user deselected everything
@@ -1358,7 +1358,7 @@ func TestDetectOrSelectAgent_NoneSelected(t *testing.T) {
 func TestDetectOrSelectAgent_BothDirectoriesExist_PromptsUser(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	// Create both .claude and .gemini directories
 	if err := os.MkdirAll(".claude", 0o755); err != nil {
@@ -1405,7 +1405,7 @@ func TestDetectOrSelectAgent_BothDirectoriesExist_PromptsUser(t *testing.T) {
 func TestDetectOrSelectAgent_BothDirectoriesExist_NoTTY_UsesAll(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "0") // No TTY available
+	forceNonInteractive(t) // No TTY available
 
 	// Create both .claude and .gemini directories
 	if err := os.MkdirAll(".claude", 0o755); err != nil {
@@ -1465,7 +1465,7 @@ func writeGeminiHooksFixture(t *testing.T) {
 func TestDetectOrSelectAgent_ReRun_AlwaysPromptsWithInstalledPreSelected(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	// Install Claude Code hooks (simulates a previous `entire enable` run)
 	writeClaudeHooksFixture(t)
@@ -1510,7 +1510,7 @@ func TestDetectOrSelectAgent_ReRun_AlwaysPromptsWithInstalledPreSelected(t *test
 func TestDetectOrSelectAgent_ReRun_NoTTY_KeepsInstalled(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "0") // No TTY available
+	forceNonInteractive(t) // No TTY available
 
 	// Install Claude Code hooks
 	writeClaudeHooksFixture(t)
@@ -1661,7 +1661,7 @@ func TestUninstallDeselectedAgentHooks_MultipleInstalled_DeselectOne(t *testing.
 func TestManageAgents_DeselectRemovesAgent(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 	writeSettings(t, testSettingsEnabled)
 
 	// Install Claude Code hooks
@@ -1697,7 +1697,7 @@ func TestManageAgents_DeselectRemovesAgent(t *testing.T) {
 func TestManageAgents_DeselectAll_RemovesAllAndShowsGuidance(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 	writeSettings(t, testSettingsEnabled)
 	writeClaudeHooksFixture(t)
 
@@ -1731,7 +1731,7 @@ func TestManageAgents_DeselectAll_RemovesAllAndShowsGuidance(t *testing.T) {
 func TestManageAgents_NoChanges(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 	writeSettings(t, testSettingsEnabled)
 	writeClaudeHooksFixture(t)
 
@@ -1753,7 +1753,7 @@ func TestManageAgents_NoChanges(t *testing.T) {
 
 func TestManageAgents_NoChanges_StillPersistsVercelSetting(t *testing.T) {
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 	writeSettings(t, testSettingsEnabled)
 	writeClaudeHooksFixture(t)
 
@@ -1796,7 +1796,7 @@ func TestManageAgents_NoChanges_StillPersistsVercelSetting(t *testing.T) {
 func TestManageAgents_ForceReinstallsSelectedAgentHooks(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 	writeSettings(t, testSettingsEnabled)
 	writeClaudeHooksFixture(t)
 
@@ -1840,7 +1840,7 @@ func TestManageAgents_ForceReinstallsSelectedAgentHooks(t *testing.T) {
 func TestManageAgents_ForceReportsReinstalledAgentsSeparately(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 	writeSettings(t, testSettingsEnabled)
 	writeClaudeHooksFixture(t)
 
@@ -1865,7 +1865,7 @@ func TestManageAgents_ForceReportsReinstalledAgentsSeparately(t *testing.T) {
 func TestManageAgents_AddAndRemove(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 	writeSettings(t, testSettingsEnabled)
 
 	// Install Claude Code hooks
@@ -2086,7 +2086,7 @@ func TestConfigureCmd_RemoveFlag_StillWorks(t *testing.T) {
 func TestDetectOrSelectAgent_ReRun_NewlyDetectedAgentAvailableNotPreSelected(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	// Simulate: Claude Code hooks installed from a previous run
 	writeClaudeHooksFixture(t)
@@ -2129,7 +2129,7 @@ func TestDetectOrSelectAgent_ReRun_NewlyDetectedAgentAvailableNotPreSelected(t *
 func TestDetectOrSelectAgent_ReRun_EmptySelection_ReturnsError(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	// Install Claude Code hooks (re-run scenario)
 	writeClaudeHooksFixture(t)
@@ -2522,7 +2522,7 @@ func TestSelectAllAgents_EmptyReturnsError(t *testing.T) {
 func TestDetectOrSelectAgent_YesSelectsAll(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
 
 	var buf bytes.Buffer
 	agents, err := detectOrSelectAgent(context.Background(), &buf, selectAllAgents)
@@ -2544,7 +2544,7 @@ func TestDetectOrSelectAgent_YesSelectsAll(t *testing.T) {
 func TestManageAgents_YesWorksNonInteractive(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "0") // non-interactive
+	forceNonInteractive(t) // non-interactive
 
 	// Install claude-code hooks so there's something installed
 	writeClaudeHooksFixture(t)
@@ -2653,7 +2653,7 @@ func TestEnableCmd_YesFreshRepo_SkipsPromptsAndEnables(t *testing.T) {
 	testutil.WriteFile(t, ".", "f.txt", "init")
 	testutil.GitAdd(t, ".", "f.txt")
 	testutil.GitCommit(t, ".", "init")
-	t.Setenv("ENTIRE_TEST_TTY", "0") // non-interactive — proves --yes bypasses prompts
+	forceNonInteractive(t) // non-interactive — proves --yes bypasses prompts
 
 	// Use --yes with --agent to test the realistic CI scenario.
 	// The --yes flag skips telemetry/Vercel prompts while --agent selects a specific agent.
@@ -2689,7 +2689,7 @@ func TestEnableCmd_YesWithAgent_AgentTakesPrecedence(t *testing.T) {
 	testutil.WriteFile(t, ".", "f.txt", "init")
 	testutil.GitAdd(t, ".", "f.txt")
 	testutil.GitCommit(t, ".", "init")
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 
 	cmd := newEnableCmd()
 	var stdout, stderr bytes.Buffer
@@ -2715,7 +2715,7 @@ func TestEnableCmd_YesWithAgent_AgentTakesPrecedence(t *testing.T) {
 func TestEnableCmd_YesOnConfiguredRepo_ManagesAgents(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "0") // non-interactive
+	forceNonInteractive(t) // non-interactive
 	writeSettings(t, testSettingsEnabled)
 	writeClaudeHooksFixture(t)
 
@@ -2742,7 +2742,7 @@ func TestEnableCmd_YesWithTelemetryFalse(t *testing.T) {
 	testutil.WriteFile(t, ".", "f.txt", "init")
 	testutil.GitAdd(t, ".", "f.txt")
 	testutil.GitCommit(t, ".", "init")
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 
 	cmd := newEnableCmd()
 	var stdout, stderr bytes.Buffer
@@ -2767,7 +2767,7 @@ func TestEnableCmd_YesWithTelemetryFalse(t *testing.T) {
 func TestConfigureCmd_YesOnConfiguredRepo(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir and t.Setenv
 	setupTestRepo(t)
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	writeSettings(t, testSettingsEnabled)
 	writeClaudeHooksFixture(t)
 

--- a/cmd/entire/cli/strategy/commit_hook_perf_test.go
+++ b/cmd/entire/cli/strategy/commit_hook_perf_test.go
@@ -92,7 +92,8 @@ func TestCommitHookPerformance(t *testing.T) {
 			seedHookPerfSessions(t, dir, baseCommits, sc.ended, sc.idle, sc.active)
 
 			// Simulate TTY path with commit_linking=always.
-			t.Setenv("ENTIRE_TEST_TTY", "1")
+			forceInteractive(t)
+			stubAskConfirm(t, ttyResultLink)
 			paths.ClearWorktreeRootCache()
 			session.ClearGitCommonDirCache()
 

--- a/cmd/entire/cli/strategy/condense_skip_test.go
+++ b/cmd/entire/cli/strategy/condense_skip_test.go
@@ -211,7 +211,7 @@ func TestCondenseAndMarkFullyCondensed_SkippedMarksFullyCondensed(t *testing.T) 
 }
 
 func TestTryAgentCommitFastPath_SkipsEmptySession(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := setupGitRepo(t)
 	t.Chdir(dir)
 
@@ -242,7 +242,7 @@ func TestTryAgentCommitFastPath_SkipsEmptySession(t *testing.T) {
 }
 
 func TestTryAgentCommitFastPath_AcceptsSessionWithContent(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := setupGitRepo(t)
 	t.Chdir(dir)
 
@@ -270,7 +270,7 @@ func TestTryAgentCommitFastPath_AcceptsSessionWithContent(t *testing.T) {
 }
 
 func TestTryAgentCommitFastPath_SkipsEmptyButAcceptsContentSession(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 	dir := setupGitRepo(t)
 	t.Chdir(dir)
 

--- a/cmd/entire/cli/strategy/interactive_test_helpers_test.go
+++ b/cmd/entire/cli/strategy/interactive_test_helpers_test.go
@@ -1,0 +1,33 @@
+package strategy
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+)
+
+// forceInteractive makes interactive.CanPromptInteractively() return true
+// for the duration of the test. Replaces the old t.Setenv("ENTIRE_TEST_TTY", "1").
+// When the hook path would try to read /dev/tty via askConfirmTTY, tests should
+// additionally override askConfirmTTY via overrideAskConfirmForTest to control the response.
+func forceInteractive(t testing.TB) {
+	t.Helper()
+	t.Cleanup(interactive.OverrideForTest(func() bool { return true }))
+}
+
+// forceNonInteractive makes interactive.CanPromptInteractively() return false
+// for the duration of the test. Replaces the old t.Setenv("ENTIRE_TEST_TTY", "0").
+func forceNonInteractive(t testing.TB) {
+	t.Helper()
+	t.Cleanup(interactive.OverrideForTest(func() bool { return false }))
+}
+
+// stubAskConfirm replaces askConfirmTTY with a fixed-result stub for the
+// duration of the test. Tests that exercise the interactive-commit path
+// use this to pick a deterministic ttyResult without touching /dev/tty.
+func stubAskConfirm(t testing.TB, result ttyResult) {
+	t.Helper()
+	t.Cleanup(overrideAskConfirmForTest(func(_ string, _ []string, _ string, _ bool) ttyResult {
+		return result
+	}))
+}

--- a/cmd/entire/cli/strategy/interactive_test_helpers_test.go
+++ b/cmd/entire/cli/strategy/interactive_test_helpers_test.go
@@ -6,17 +6,18 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 )
 
-// forceInteractive makes interactive.CanPromptInteractively() return true
-// for the duration of the test. Replaces the old t.Setenv("ENTIRE_TEST_TTY", "1").
-// When the hook path would try to read /dev/tty via askConfirmTTY, tests should
-// additionally override askConfirmTTY via overrideAskConfirmForTest to control the response.
+// forceInteractive makes both interactive.CanPromptInteractively and
+// interactive.CanPromptFromHook return true for the duration of the test.
+// When the hook path would try to read /dev/tty via askConfirmTTY, tests
+// should additionally call stubAskConfirm to control the response without
+// touching a real terminal.
 func forceInteractive(t testing.TB) {
 	t.Helper()
 	t.Cleanup(interactive.OverrideForTest(func() bool { return true }))
 }
 
-// forceNonInteractive makes interactive.CanPromptInteractively() return false
-// for the duration of the test. Replaces the old t.Setenv("ENTIRE_TEST_TTY", "0").
+// forceNonInteractive makes both interactive detection paths return false
+// for the duration of the test.
 func forceNonInteractive(t testing.TB) {
 	t.Helper()
 	t.Cleanup(interactive.OverrideForTest(func() bool { return false }))

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -62,7 +62,7 @@ func overrideAskConfirmForTest(fn func(header string, details []string, prompt s
 }
 
 // realAskConfirmTTY prompts the user via /dev/tty whether to link a commit to session context.
-// This requires a controlling terminal — callers must check interactive.CanPromptInteractively()
+// This requires a controlling terminal — callers must check interactive.CanPromptFromHook()
 // first and handle the no-TTY case (agent subprocesses, CI) themselves.
 //
 // header is displayed as the first line (e.g., "Entire: Active Claude Code session").
@@ -514,7 +514,7 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 	case "message":
 		// Using -m or -F: behavior depends on TTY availability and commit_linking setting
 		switch {
-		case !interactive.CanPromptInteractively():
+		case !interactive.CanPromptFromHook():
 			// No TTY (agent subprocess, CI) — auto-link without prompting
 			message = addCheckpointTrailer(message, checkpointID)
 		case commitLinking == settings.CommitLinkingAlways:
@@ -2019,7 +2019,7 @@ func (s *ManualCommitStrategy) warnIfAttributionDiverged(ctx context.Context, se
 //     have /dev/tty but can't respond to prompts, and content detection fails
 //     since the shadow branch doesn't exist yet).
 func (s *ManualCommitStrategy) tryAgentCommitFastPath(ctx context.Context, commitMsgFile string, sessions []*SessionState, source string) bool {
-	noTTY := !interactive.CanPromptInteractively()
+	noTTY := !interactive.CanPromptFromHook()
 	skipContentDetection := noTTY
 	if !skipContentDetection {
 		if stngs, err := settings.Load(ctx); err == nil {

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -22,6 +22,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/gitops"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -37,55 +38,6 @@ import (
 	"github.com/go-git/go-git/v6/utils/binary"
 )
 
-// hasTTY checks if /dev/tty is available for interactive prompts.
-// Returns false when running as an agent subprocess (no controlling terminal).
-//
-// In test environments, ENTIRE_TEST_TTY overrides the real check:
-//   - ENTIRE_TEST_TTY=1 → simulate human (TTY available)
-//   - ENTIRE_TEST_TTY=0 → simulate agent (no TTY)
-func hasTTY() bool {
-	if v := os.Getenv("ENTIRE_TEST_TTY"); v != "" {
-		return v == "1"
-	}
-
-	// Gemini CLI sets GEMINI_CLI=1 when running shell commands.
-	// Gemini subprocesses may have access to the user's TTY, but they can't
-	// actually respond to interactive prompts. Treat them as non-TTY.
-	// See: https://geminicli.com/docs/tools/shell/
-	if os.Getenv("GEMINI_CLI") != "" {
-		return false
-	}
-
-	// Copilot CLI sets COPILOT_CLI=1 when running hook subprocesses (v0.0.421+).
-	// Like Gemini, the subprocess may inherit the user's TTY but can't respond
-	// to interactive prompts.
-	if os.Getenv("COPILOT_CLI") != "" {
-		return false
-	}
-
-	// Pi Coding Agent sets PI_CODING_AGENT=true when running shell commands.
-	// Like other agents, the subprocess may inherit the TTY but can't respond
-	// to interactive prompts.
-	if os.Getenv("PI_CODING_AGENT") != "" {
-		return false
-	}
-
-	// GIT_TERMINAL_PROMPT=0 disables git's own terminal prompts.
-	// Factory AI Droid (and other non-interactive environments like CI) set this.
-	// Since we run as a git hook, respect it — if the environment doesn't want
-	// git prompting, our hook shouldn't prompt either.
-	if os.Getenv("GIT_TERMINAL_PROMPT") == "0" {
-		return false
-	}
-
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
-	if err != nil {
-		return false
-	}
-	_ = tty.Close()
-	return true
-}
-
 // ttyResult represents the outcome of a TTY confirmation prompt.
 type ttyResult int
 
@@ -95,22 +47,38 @@ const (
 	ttyResultLinkAlways                  // Link and remember: add trailer + save "always" preference
 )
 
-// askConfirmTTY prompts the user via /dev/tty whether to link a commit to session context.
-// This requires a controlling terminal — callers must check hasTTY() first and handle
-// the no-TTY case (agent subprocesses, CI) themselves.
+// askConfirmTTY is the package-level function variable that drives
+// /dev/tty confirmation prompts. Tests replace it via overrideAskConfirmForTest
+// so they don't need to drive a real terminal. Production always points to
+// realAskConfirmTTY.
+var askConfirmTTY = realAskConfirmTTY
+
+// overrideAskConfirmForTest swaps askConfirmTTY for the duration of a test.
+// The returned function restores the original implementation.
+func overrideAskConfirmForTest(fn func(header string, details []string, prompt string, defaultYes bool) ttyResult) func() {
+	old := askConfirmTTY
+	askConfirmTTY = fn
+	return func() { askConfirmTTY = old }
+}
+
+// realAskConfirmTTY prompts the user via /dev/tty whether to link a commit to session context.
+// This requires a controlling terminal — callers must check interactive.CanPromptInteractively()
+// first and handle the no-TTY case (agent subprocesses, CI) themselves.
 //
 // header is displayed as the first line (e.g., "Entire: Active Claude Code session").
 // detail lines are displayed indented below the header.
-func askConfirmTTY(header string, details []string, prompt string, defaultYes bool) ttyResult {
+func realAskConfirmTTY(header string, details []string, prompt string, defaultYes bool) ttyResult {
 	defaultResult := ttyResultSkip
 	if defaultYes {
 		defaultResult = ttyResultLink
 	}
 
-	// In test mode, don't try to interact with the real TTY — just use the default.
-	// ENTIRE_TEST_TTY=1 simulates "a human is present" for the hasTTY() check
-	// but we can't actually read from the TTY in tests.
-	if os.Getenv("ENTIRE_TEST_TTY") != "" {
+	// Integration-test subprocess bypass. In-process tests swap askConfirmTTY
+	// via overrideAskConfirmForTest; this check exists because subprocess tests
+	// cannot use that seam. When ENTIRE_TEST_TTY is set, return the default
+	// answer without touching /dev/tty so the hook never blocks on a real
+	// terminal read during tests.
+	if _, ok := os.LookupEnv("ENTIRE_TEST_TTY"); ok {
 		return defaultResult
 	}
 
@@ -546,7 +514,7 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 	case "message":
 		// Using -m or -F: behavior depends on TTY availability and commit_linking setting
 		switch {
-		case !hasTTY():
+		case !interactive.CanPromptInteractively():
 			// No TTY (agent subprocess, CI) — auto-link without prompting
 			message = addCheckpointTrailer(message, checkpointID)
 		case commitLinking == settings.CommitLinkingAlways:
@@ -2051,7 +2019,7 @@ func (s *ManualCommitStrategy) warnIfAttributionDiverged(ctx context.Context, se
 //     have /dev/tty but can't respond to prompts, and content detection fails
 //     since the shadow branch doesn't exist yet).
 func (s *ManualCommitStrategy) tryAgentCommitFastPath(ctx context.Context, commitMsgFile string, sessions []*SessionState, source string) bool {
-	noTTY := !hasTTY()
+	noTTY := !interactive.CanPromptInteractively()
 	skipContentDetection := noTTY
 	if !skipContentDetection {
 		if stngs, err := settings.Load(ctx); err == nil {

--- a/cmd/entire/cli/strategy/manual_commit_reset.go
+++ b/cmd/entire/cli/strategy/manual_commit_reset.go
@@ -4,18 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 
 	"github.com/go-git/go-git/v6/plumbing"
 )
-
-// isAccessibleMode returns true if accessibility mode should be enabled.
-// This checks the ACCESSIBLE environment variable.
-func isAccessibleMode() bool {
-	return os.Getenv("ACCESSIBLE") != ""
-}
 
 // Reset deletes the shadow branch and session state for the current HEAD.
 // This allows starting fresh without existing checkpoints.

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -996,7 +996,7 @@ func PromptOverwriteNewerLogs(errW io.Writer, sessions []SessionRestoreInfo) (bo
 				Value(&confirmed),
 		),
 	)
-	if isAccessibleMode() {
+	if os.Getenv("ACCESSIBLE") != "" {
 		form = form.WithAccessible(true)
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -835,7 +835,8 @@ func TestShadowStrategy_PrepareCommitMsg_SkipSources(t *testing.T) {
 func TestShadowStrategy_PrepareCommitMsg_SkipsSessionWhenContentCheckFails(t *testing.T) {
 	dir := setupGitRepo(t)
 	t.Chdir(dir)
-	t.Setenv("ENTIRE_TEST_TTY", "1")
+	forceInteractive(t)
+	stubAskConfirm(t, ttyResultLink)
 
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)

--- a/cmd/entire/cli/strategy/preparecommitmsg_bench_test.go
+++ b/cmd/entire/cli/strategy/preparecommitmsg_bench_test.go
@@ -152,9 +152,9 @@ func benchSetupPrepareCommitMsgRepo(b *testing.B, fileCount, sessionCount int) (
 		b.Fatalf("write commit msg: %v", err)
 	}
 
-	// Set ENTIRE_TEST_TTY=0 so hasTTY() returns false (simulates agent subprocess).
-	// This avoids interactive TTY prompts during benchmarks.
-	b.Setenv("ENTIRE_TEST_TTY", "0")
+	// Force non-interactive so the commit hook treats this as an agent subprocess.
+	// Avoids interactive TTY prompts during benchmarks.
+	forceNonInteractive(b)
 
 	return br.Dir, commitMsgFile
 }

--- a/cmd/entire/cli/strategy/rewind_test.go
+++ b/cmd/entire/cli/strategy/rewind_test.go
@@ -270,7 +270,7 @@ func TestResolveAgentForRewind(t *testing.T) {
 }
 
 func TestPromptOverwriteNewerLogs_NonInteractiveRequiresForce(t *testing.T) {
-	t.Setenv("ENTIRE_TEST_TTY", "0")
+	forceNonInteractive(t)
 
 	var errW bytes.Buffer
 	_, err := PromptOverwriteNewerLogs(&errW, []SessionRestoreInfo{

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -357,7 +357,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		shouldCheckout := checkout
 		if !shouldCheckout && !cmd.Flags().Changed("checkout") {
 			// Interactive: ask whether to checkout
-			form := NewAccessibleForm(
+			form := NewForm(
 				huh.NewGroup(
 					huh.NewConfirm().
 						Title(fmt.Sprintf("Check out branch %s?", branch)).
@@ -451,7 +451,7 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, s
 		title = metadata.Title
 		body = metadata.Body
 
-		form := NewAccessibleForm(
+		form := NewForm(
 			huh.NewGroup(
 				huh.NewSelect[string]().
 					Title("Status").
@@ -559,7 +559,7 @@ func formatValidStatuses() string {
 // Prompts for title, body, branch (derived from title), and status.
 func runTrailCreateInteractive(title, body, branch, statusStr *string) error {
 	// Step 1: Title and body
-	form := NewAccessibleForm(
+	form := NewForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Trail title").
@@ -594,7 +594,7 @@ func runTrailCreateInteractive(title, body, branch, statusStr *string) error {
 		*statusStr = string(trail.StatusDraft)
 	}
 
-	form = NewAccessibleForm(
+	form = NewForm(
 		huh.NewGroup(
 			huh.NewInput().
 				Title("Branch name").

--- a/cmd/entire/cli/utils.go
+++ b/cmd/entire/cli/utils.go
@@ -10,33 +10,55 @@ import (
 
 	"github.com/charmbracelet/huh"
 
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
-
-// IsAccessibleMode returns true if accessibility mode should be enabled.
-// This checks the ACCESSIBLE environment variable.
-// Set ACCESSIBLE=1 (or any non-empty value) to enable accessible mode,
-// which uses simpler prompts that work better with screen readers.
-func IsAccessibleMode() bool {
-	return os.Getenv("ACCESSIBLE") != ""
-}
 
 // entireTheme returns the Dracula theme for consistent styling.
 func entireTheme() *huh.Theme {
 	return huh.ThemeDracula()
 }
 
-// NewAccessibleForm creates a new huh form with accessibility mode
-// enabled if the ACCESSIBLE environment variable is set.
-// Note: WithAccessible() is only available on forms, not individual fields.
-// Always wrap confirmations and other prompts in a form to enable accessibility.
-func NewAccessibleForm(groups ...*huh.Group) *huh.Form {
-	form := huh.NewForm(groups...).WithTheme(entireTheme())
-	if IsAccessibleMode() {
-		form = form.WithAccessible(true)
+// forcePlainOutput reports whether the CLI should render huh forms in
+// plain-text (accessible) mode instead of the TUI. Controlled by the
+// ACCESSIBLE environment variable. This does NOT gate whether prompts run
+// at all — that is governed by interactive.CanPromptInteractively().
+// ACCESSIBLE is intended for screen-reader users and for agent
+// subprocesses (e2e tests, integration tests) that inherit a real TTY
+// but need plain-text output to parse.
+func forcePlainOutput() bool {
+	return os.Getenv("ACCESSIBLE") != ""
+}
+
+// Form wraps *huh.Form with automatic TTY gating and accessible-output
+// opt-in. Use NewForm to construct one.
+type Form struct {
+	inner *huh.Form
+}
+
+// NewForm creates a themed huh form. The returned form's Run method
+// automatically returns nil (leaving field values at their defaults)
+// when no controlling terminal is available, so callers do not need
+// to guard it themselves.
+func NewForm(groups ...*huh.Group) *Form {
+	return &Form{inner: huh.NewForm(groups...).WithTheme(entireTheme())}
+}
+
+// Run executes the form when a TTY is available. When ACCESSIBLE is set,
+// the form renders in plain-text accessible mode. Returns nil immediately
+// when no terminal is present (CI, piped input, known agent subprocesses).
+func (f *Form) Run() error {
+	if !interactive.CanPromptInteractively() {
+		return nil
 	}
-	return form
+	if forcePlainOutput() {
+		f.inner = f.inner.WithAccessible(true)
+	}
+	if err := f.inner.Run(); err != nil {
+		return fmt.Errorf("form run: %w", err)
+	}
+	return nil
 }
 
 // handleFormCancellation handles cancellation from huh form prompts.

--- a/cmd/entire/cli/utils.go
+++ b/cmd/entire/cli/utils.go
@@ -28,7 +28,7 @@ func entireTheme() *huh.Theme {
 // subprocesses (e2e tests, integration tests) that inherit a real TTY
 // but need plain-text output to parse.
 func forcePlainOutput() bool {
-	return os.Getenv("ACCESSIBLE") != ""
+	return os.Getenv("ACCESSIBLE") != "" || interactive.PromptMode() == "plain"
 }
 
 // Form wraps *huh.Form with automatic TTY gating and accessible-output
@@ -37,21 +37,35 @@ type Form struct {
 	inner *huh.Form
 }
 
+// ErrPromptUnavailable reports that a command required a prompt but no
+// interactive prompt path is available under the current environment/policy.
+var ErrPromptUnavailable = errors.New("interactive prompt unavailable; rerun with a TTY or pass flags to skip prompting")
+
 // NewForm creates a themed huh form. The returned form's Run method
-// automatically returns nil (leaving field values at their defaults)
-// when no controlling terminal is available, so callers do not need
-// to guard it themselves.
+// is for required prompts. Use RunOptional when the prompt may be skipped.
 func NewForm(groups ...*huh.Group) *Form {
 	return &Form{inner: huh.NewForm(groups...).WithTheme(entireTheme())}
 }
 
-// Run executes the form when a TTY is available. When ACCESSIBLE is set,
-// the form renders in plain-text accessible mode. Returns nil immediately
-// when no terminal is present (CI, piped input, known agent subprocesses).
+// Run executes a required form. When ACCESSIBLE or ENTIRE_PROMPTS=plain is
+// set, the form renders in plain-text accessible mode.
 func (f *Form) Run() error {
+	if !interactive.CanPromptInteractively() {
+		return ErrPromptUnavailable
+	}
+	return f.runInner()
+}
+
+// RunOptional executes the form when prompting is available and otherwise
+// returns nil, leaving field values at their defaults.
+func (f *Form) RunOptional() error {
 	if !interactive.CanPromptInteractively() {
 		return nil
 	}
+	return f.runInner()
+}
+
+func (f *Form) runInner() error {
 	if forcePlainOutput() {
 		f.inner = f.inner.WithAccessible(true)
 	}

--- a/cmd/entire/cli/utils_test.go
+++ b/cmd/entire/cli/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/huh"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,6 +66,30 @@ func TestHandleFormCancellation(t *testing.T) {
 			assert.Equal(t, tt.wantOut, out.String())
 		})
 	}
+}
+
+func TestFormRun_NoPromptAvailable_ReturnsErrPromptUnavailable(t *testing.T) {
+	t.Parallel()
+
+	forceNonInteractive(t)
+
+	form := NewForm(huh.NewGroup(huh.NewConfirm()))
+	err := form.Run()
+	require.ErrorIs(t, err, ErrPromptUnavailable)
+}
+
+func TestFormRunOptional_NoPromptAvailable_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	forceNonInteractive(t)
+
+	form := NewForm(huh.NewGroup(huh.NewConfirm()))
+	require.NoError(t, form.RunOptional())
+}
+
+func TestForcePlainOutput_UsesPromptModePlain(t *testing.T) {
+	t.Setenv(interactive.PromptModeEnv, "plain")
+	assert.True(t, forcePlainOutput())
 }
 
 func TestCopyFile_HappyPath(t *testing.T) {

--- a/e2e/agents/agent.go
+++ b/e2e/agents/agent.go
@@ -114,8 +114,8 @@ func All() []Agent {
 }
 
 // filterEnv returns env with entries matching any of the given variable names
-// removed. Used to strip test-only overrides (e.g. ENTIRE_TEST_TTY) from agent
-// processes so they exercise real detection paths.
+// removed. Used to strip host env vars (e.g. CI, GITHUB_ACTIONS) that would
+// otherwise force agents into headless mode inside the test runner.
 func filterEnv(env []string, names ...string) []string {
 	out := make([]string, 0, len(env))
 	for _, e := range env {

--- a/e2e/agents/claude.go
+++ b/e2e/agents/claude.go
@@ -13,13 +13,12 @@ import (
 )
 
 // cleanEnv returns os.Environ() with agent-incompatible variables removed.
-// It strips CLAUDECODE (so Claude Code doesn't refuse to start inside this
-// test runner) and ENTIRE_TEST_TTY (so agents exercise the real TTY detection
-// paths instead of the test override).
+// It strips CLAUDECODE so Claude Code doesn't refuse to start inside this
+// test runner.
 func cleanEnv() []string {
 	var env []string
 	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "CLAUDECODE=") || strings.HasPrefix(e, "ENTIRE_TEST_TTY=") {
+		if strings.HasPrefix(e, "CLAUDECODE=") {
 			continue
 		}
 		env = append(env, e)
@@ -163,7 +162,7 @@ func (c *Claude) StartSession(ctx context.Context, dir string) (Session, error) 
 
 	args := append([]string{"env"}, envArgs...)
 	args = append(args, c.Binary(), "--dangerously-skip-permissions")
-	s, err := NewTmuxSession(name, dir, []string{"CLAUDECODE", "ENTIRE_TEST_TTY"}, args[0], args[1:]...)
+	s, err := NewTmuxSession(name, dir, []string{"CLAUDECODE"}, args[0], args[1:]...)
 	if err != nil {
 		_ = os.RemoveAll(configDir)
 		return nil, err

--- a/e2e/agents/codex.go
+++ b/e2e/agents/codex.go
@@ -103,7 +103,7 @@ func (c *Codex) RunPrompt(ctx context.Context, dir string, prompt string, opts .
 	}
 	args = append(args, prompt)
 
-	env := append(filterEnv(os.Environ(), "ENTIRE_TEST_TTY", "CODEX_HOME"),
+	env := append(filterEnv(os.Environ(), "CODEX_HOME"),
 		"CODEX_HOME="+home,
 	)
 
@@ -212,7 +212,7 @@ func (c *Codex) ResumeSession(ctx context.Context, dir, home, sessionID string) 
 
 func (c *Codex) startTmuxSession(name, dir, home string, args ...string) (*TmuxSession, error) {
 	tmuxArgs := append([]string{"CODEX_HOME=" + home, "HOME=" + os.Getenv("HOME"), "TERM=" + os.Getenv("TERM")}, args...)
-	return NewTmuxSession(name, dir, []string{"CODEX_HOME", "ENTIRE_TEST_TTY"}, "env", tmuxArgs...)
+	return NewTmuxSession(name, dir, []string{"CODEX_HOME"}, "env", tmuxArgs...)
 }
 
 // seedCodexHome writes trust + feature flag config and links auth credentials

--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -74,7 +74,7 @@ func (c *CopilotCLI) RunPrompt(ctx context.Context, dir string, prompt string, o
 	cmd := exec.CommandContext(promptCtx, c.Binary(), args...)
 	cmd.Dir = dir
 	cmd.Stdin = nil
-	cmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0")
+	cmd.Env = os.Environ()
 	setupProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
 
@@ -301,7 +301,7 @@ func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, err
 
 	name := fmt.Sprintf("copilot-test-%d", time.Now().UnixNano())
 	// Strip CI env vars that may affect interactive mode.
-	unset := []string{"CI", "GITHUB_ACTIONS", "ENTIRE_TEST_TTY"}
+	unset := []string{"CI", "GITHUB_ACTIONS"}
 	s, err := NewTmuxSession(name, dir, unset, args[0], args[1:]...)
 	if err != nil {
 		return nil, err

--- a/e2e/agents/droid.go
+++ b/e2e/agents/droid.go
@@ -151,7 +151,7 @@ func (d *Droid) RunPrompt(ctx context.Context, dir string, prompt string, opts .
 	cmd := exec.CommandContext(ctx, d.Binary(), args...)
 	cmd.Dir = dir
 	cmd.Stdin = nil
-	cmd.Env = filterEnv(os.Environ(), "ENTIRE_TEST_TTY", "CI", "GITHUB_ACTIONS")
+	cmd.Env = filterEnv(os.Environ(), "CI", "GITHUB_ACTIONS")
 	setupProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
 
@@ -182,7 +182,7 @@ func (d *Droid) StartSession(ctx context.Context, dir string) (Session, error) {
 	name := fmt.Sprintf("droid-test-%d", time.Now().UnixNano())
 	// Unset CI and GITHUB_ACTIONS so Droid doesn't enter single-turn/headless
 	// mode — it checks these vars and skips interactive input after the first turn.
-	s, err := NewTmuxSession(name, dir, []string{"CI", "GITHUB_ACTIONS", "ENTIRE_TEST_TTY"}, d.Binary())
+	s, err := NewTmuxSession(name, dir, []string{"CI", "GITHUB_ACTIONS"}, d.Binary())
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -75,8 +75,7 @@ func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 	cmd := exec.CommandContext(promptCtx, g.Binary(), args...)
 	cmd.Dir = dir
 	cmd.Stdin = nil
-	cmd.Env = append(
-		filterEnv(os.Environ(), "ENTIRE_TEST_TTY"),
+	cmd.Env = append(os.Environ(),
 		"ACCESSIBLE=1",
 		"HOME="+geminiTestHomeDir(dir),
 	)
@@ -125,7 +124,7 @@ func (g *Gemini) StartSession(_ context.Context, dir string) (Session, error) {
 	// it checks both in isHeadlessMode() and skips interactive TUI entirely.
 	args := append([]string{"env"}, envArgs...)
 	args = append(args, g.Binary(), "--model", geminiDefaultModel, "-y")
-	s, err := NewTmuxSession(name, dir, []string{"CI", "GITHUB_ACTIONS", "ENTIRE_TEST_TTY", "HOME"}, args[0], args[1:]...)
+	s, err := NewTmuxSession(name, dir, []string{"CI", "GITHUB_ACTIONS", "HOME"}, args[0], args[1:]...)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -110,7 +110,7 @@ func (a *openCodeAgent) RunPrompt(ctx context.Context, dir string, prompt string
 
 	cmd := exec.CommandContext(ctx, a.Binary(), args...)
 	cmd.Dir = dir
-	cmd.Env = filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+	cmd.Env = os.Environ()
 
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
@@ -144,7 +144,7 @@ func (a *openCodeAgent) StartSession(ctx context.Context, dir string) (Session, 
 	for attempt := range 2 {
 		name := fmt.Sprintf("opencode-test-%d", time.Now().UnixNano())
 		var err error
-		s, err = NewTmuxSession(name, dir, []string{"ENTIRE_TEST_TTY"}, a.Binary(), "--model", a.model)
+		s, err = NewTmuxSession(name, dir, nil, a.Binary(), "--model", a.model)
 		if err != nil {
 			return nil, err
 		}

--- a/e2e/agents/roger_roger.go
+++ b/e2e/agents/roger_roger.go
@@ -47,7 +47,7 @@ func (r *RogerRoger) RunPrompt(ctx context.Context, dir string, prompt string, o
 	cmd := exec.CommandContext(ctx, r.Binary())
 	cmd.Dir = dir
 	cmd.Stdin = strings.NewReader(prompt + "\n\n")
-	cmd.Env = filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+	cmd.Env = os.Environ()
 	setupProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
 
@@ -76,7 +76,7 @@ func (r *RogerRoger) RunPrompt(ctx context.Context, dir string, prompt string, o
 
 func (r *RogerRoger) StartSession(_ context.Context, dir string) (Session, error) {
 	name := fmt.Sprintf("rr-test-%d", time.Now().UnixNano())
-	s, err := NewTmuxSession(name, dir, []string{"ENTIRE_TEST_TTY"}, r.Binary())
+	s, err := NewTmuxSession(name, dir, nil, r.Binary())
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/agents/vogon.go
+++ b/e2e/agents/vogon.go
@@ -43,7 +43,7 @@ func (v *Vogon) RunPrompt(ctx context.Context, dir string, prompt string, opts .
 	cmd := exec.CommandContext(ctx, v.Binary(), args...)
 	cmd.Dir = dir
 	cmd.Stdin = nil
-	cmd.Env = filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+	cmd.Env = os.Environ()
 	setupProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
 
@@ -72,7 +72,7 @@ func (v *Vogon) RunPrompt(ctx context.Context, dir string, prompt string, opts .
 
 func (v *Vogon) StartSession(_ context.Context, dir string) (Session, error) {
 	name := fmt.Sprintf("vogon-test-%d", time.Now().UnixNano())
-	s, err := NewTmuxSession(name, dir, []string{"ENTIRE_TEST_TTY"}, v.Binary())
+	s, err := NewTmuxSession(name, dir, nil, v.Binary())
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/entire/entire.go
+++ b/e2e/entire/entire.go
@@ -74,7 +74,7 @@ func run(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command(BinPath(), args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0")
+	cmd.Env = os.Environ()
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -87,7 +87,7 @@ func run(t *testing.T, dir string, args ...string) string {
 func runErr(dir string, args ...string) error {
 	cmd := exec.Command(BinPath(), args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0")
+	cmd.Env = os.Environ()
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -151,8 +151,7 @@ func runOutput(dir string, args ...string) (string, error) {
 func runOutputEnv(dir string, extraEnv []string, args ...string) (string, error) {
 	cmd := exec.Command(BinPath(), args...)
 	cmd.Dir = dir
-	cmd.Env = append(append([]string{}, os.Environ()...), "ENTIRE_TEST_TTY=0")
-	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd.Env = append(append([]string{}, os.Environ()...), extraEnv...)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/e2e/tests/resume_test.go
+++ b/e2e/tests/resume_test.go
@@ -147,7 +147,7 @@ func TestResumeSquashMergeMultipleCheckpoints(t *testing.T) {
 		// it use .git/SQUASH_MSG natively with all hooks running.
 		commitCmd := exec.Command("git", "commit")
 		commitCmd.Dir = s.Dir
-		commitCmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0", "GIT_EDITOR=true")
+		commitCmd.Env = append(os.Environ(), "GIT_EDITOR=true")
 		commitOut, commitErr := commitCmd.CombinedOutput()
 		fmt.Fprintf(s.ConsoleLog, "> git commit (GIT_EDITOR=true)\n%s\n", commitOut)
 		require.NoError(t, commitErr, "git commit with squash message failed: %s", commitOut)

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -545,7 +545,7 @@ func Git(t *testing.T, dir string, args ...string) {
 	if dir != "" {
 		cmd.Dir = dir
 	}
-	cmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0")
+	cmd.Env = os.Environ()
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/e2e/vogon/main.go
+++ b/e2e/vogon/main.go
@@ -488,7 +488,7 @@ func fireHook(dir, hookName string, payload any) {
 	cmd := exec.Command("entire", "hooks", "vogon", hookName)
 	cmd.Dir = dir
 	cmd.Stdin = bytes.NewReader(data)
-	cmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0")
+	cmd.Env = os.Environ()
 	// Capture output but don't show it — hooks may output banners
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/scripts/local-device-auth-smoke.sh
+++ b/scripts/local-device-auth-smoke.sh
@@ -18,7 +18,7 @@ trap cleanup EXIT
 cd "${REPO_ROOT}"
 
 echo "Starting device auth login against ${ENTIRE_API_BASE_URL}"
-ENTIRE_TEST_TTY=0 ENTIRE_API_BASE_URL="${ENTIRE_API_BASE_URL}" go run ./cmd/entire login --insecure-http-auth >"${LOG_FILE}" 2>&1 &
+ENTIRE_API_BASE_URL="${ENTIRE_API_BASE_URL}" ENTIRE_PROMPTS=never go run ./cmd/entire login --insecure-http-auth --no-browser >"${LOG_FILE}" 2>&1 &
 LOGIN_PID=$!
 
 for _ in {1..100}; do


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/56bb41c9cd0b

## Summary

Make prompt behavior explicit for CLI flows so subprocesses do not need fake TTY overrides and required prompts do not silently succeed in headless runs.

## What Changed

- Added `ENTIRE_PROMPTS=auto|never|plain` in `interactive` so prompt policy is explicit instead of inferred solely from TTY detection.
- Kept the hook-specific `ENTIRE_TEST_TTY` override for subprocess-based hook tests, while moving regular CLI subprocess control to `ENTIRE_PROMPTS`.
- Changed `cli.NewForm().Run()` to return `ErrPromptUnavailable` when a prompt is required but no interactive path exists.
- Added `RunOptional()` for the cases where skipping a prompt in headless mode is intentional.
- Added `entire login --no-browser` so non-interactive login flows can print the approval URL directly instead of relying on fake TTY behavior.
- Updated `scripts/local-device-auth-smoke.sh` to use `ENTIRE_PROMPTS=never` and `--no-browser`.
- Documented `ENTIRE_PROMPTS` in root help and added focused unit tests around prompt mode parsing, required prompt behavior, and the no-browser login path.

## Verification

- `go test ./cmd/entire/cli ./cmd/entire/cli/interactive -run 'TestRunLogin_NoBrowser_PrintsApprovalURL|TestFormRun_NoPromptAvailable_ReturnsErrPromptUnavailable|TestFormRunOptional_NoPromptAvailable_ReturnsNil|TestForcePlainOutput_UsesPromptModePlain|TestPromptMode_'`
- `mise run lint`
  - Fails in this environment because the installed `golangci-lint` is `v1.64.8` while the repo config expects golangci-lint v2.
