### PR TITLE
one more pass on top of feat/entire-review

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -269,6 +269,36 @@ type Launcher interface {
 	LaunchCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error)
 }
 
+// DiscoveredSkill describes one review-adjacent skill found on disk by a
+// SkillDiscoverer. Name is the agent-native invocation form (e.g. a
+// slash-prefixed command); Description is scraped from on-disk metadata
+// if available; SourcePath is kept for debug logging and is not shown to
+// the user.
+type DiscoveredSkill struct {
+	Name        string
+	Description string
+	SourcePath  string
+}
+
+// SkillDiscoverer is implemented by agents that can enumerate review-adjacent
+// skills installed locally on disk (e.g. plugin skills under
+// ~/.claude/plugins/...). This powers the "Installed plugin skills" section
+// of the `entire review` picker and the runtime verification that configured
+// skills still exist before spawn.
+//
+// Contract:
+//   - Safe to call on fresh installs where no plugin dir exists yet —
+//     return (nil, nil), not an error.
+//   - Malformed individual skill metadata must be skipped with a Debug log,
+//     not propagated as an error.
+//   - A (nil, non-nil) error means "discovery could not run at all" (e.g.
+//     home dir inaccessible). Callers may treat all errors as "found nothing"
+//     and log at Debug — discovery must never block the picker.
+type SkillDiscoverer interface {
+	Agent
+	DiscoverReviewSkills(ctx context.Context) ([]DiscoveredSkill, error)
+}
+
 // SessionBaseDirProvider is implemented by agents that store transcripts in a
 // home-directory-based structure with per-project subdirectories. This enables
 // cross-project transcript search (e.g., when a session was started from a

--- a/cmd/entire/cli/agent/architecture_test.go
+++ b/cmd/entire/cli/agent/architecture_test.go
@@ -126,9 +126,10 @@ func discoverAgentPackages(t *testing.T, agentDir string) []string {
 	t.Helper()
 
 	skipDirs := map[string]bool{
-		"types":    true, // contract types, not an agent implementation
-		"testutil": true, // shared test utilities
-		"external": true, // external agent adapter, not a self-registering agent
+		"types":          true, // contract types, not an agent implementation
+		"testutil":       true, // shared test utilities
+		"external":       true, // external agent adapter, not a self-registering agent
+		"skilldiscovery": true, // shared capability helper (registries, match), not an agent
 	}
 
 	entries, err := os.ReadDir(agentDir)

--- a/cmd/entire/cli/agent/claudecode/discovery.go
+++ b/cmd/entire/cli/agent/claudecode/discovery.go
@@ -1,0 +1,148 @@
+package claudecode
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/skilldiscovery"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+)
+
+// DiscoverReviewSkills walks ~/.claude/plugins/cache/ and ~/.claude/skills/
+// for SKILL.md files whose name or description indicates review-adjacent
+// intent. Returns (nil, nil) when HOME is unreadable or directories are
+// missing — discovery is best-effort.
+//
+//nolint:unparam // error return is part of SkillDiscoverer contract; future implementations may report hard failures
+func (c *ClaudeCodeAgent) DiscoverReviewSkills(ctx context.Context) ([]agent.DiscoveredSkill, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		logging.Debug(ctx, "claude-code discovery: UserHomeDir failed", slog.String("error", err.Error()))
+		return nil, nil
+	}
+
+	var found []agent.DiscoveredSkill
+	found = append(found, scanPluginCache(ctx, filepath.Join(home, ".claude", "plugins", "cache"))...)
+	found = append(found, scanUserSkills(ctx, filepath.Join(home, ".claude", "skills"))...)
+	if len(found) == 0 {
+		return nil, nil
+	}
+	return found, nil
+}
+
+// scanPluginCache walks <root>/<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md
+func scanPluginCache(ctx context.Context, root string) []agent.DiscoveredSkill {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		logging.Debug(ctx, "claude-code discovery: plugin cache unreadable",
+			slog.String("root", root), slog.String("error", err.Error()))
+		return nil
+	}
+	var found []agent.DiscoveredSkill
+	for _, marketEntry := range entries {
+		if !marketEntry.IsDir() {
+			continue
+		}
+		marketRoot := filepath.Join(root, marketEntry.Name())
+		pluginEntries, err := os.ReadDir(marketRoot)
+		if err != nil {
+			continue
+		}
+		for _, pluginEntry := range pluginEntries {
+			if !pluginEntry.IsDir() {
+				continue
+			}
+			pluginName := pluginEntry.Name()
+			pluginRoot := filepath.Join(marketRoot, pluginName)
+			versionEntries, err := os.ReadDir(pluginRoot)
+			if err != nil {
+				continue
+			}
+			for _, verEntry := range versionEntries {
+				if !verEntry.IsDir() {
+					continue
+				}
+				skillsRoot := filepath.Join(pluginRoot, verEntry.Name(), "skills")
+				found = append(found, readSkillsDir(ctx, skillsRoot, pluginName)...)
+			}
+		}
+	}
+	return found
+}
+
+// scanUserSkills walks ~/.claude/skills/<skill>/SKILL.md.
+func scanUserSkills(ctx context.Context, root string) []agent.DiscoveredSkill {
+	return readSkillsDir(ctx, root, "" /* no plugin prefix */)
+}
+
+// readSkillsDir reads each skill subdirectory's SKILL.md, parses frontmatter,
+// and emits a DiscoveredSkill if Matches() returns true.
+func readSkillsDir(ctx context.Context, dir, pluginName string) []agent.DiscoveredSkill {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var found []agent.DiscoveredSkill
+	for _, skillEntry := range entries {
+		if !skillEntry.IsDir() {
+			continue
+		}
+		skillDir := filepath.Join(dir, skillEntry.Name())
+		skillFile := filepath.Join(skillDir, "SKILL.md")
+		data, err := os.ReadFile(skillFile) //nolint:gosec // G304: skillFile is constructed from a ReadDir walk under HOME, not user input
+		if err != nil {
+			continue
+		}
+		name, description, parseErr := parseSkillFrontmatter(data)
+		if parseErr != nil {
+			logging.Debug(ctx, "claude-code discovery: skipping malformed SKILL.md",
+				slog.String("path", skillFile), slog.String("error", parseErr.Error()))
+			continue
+		}
+		if name == "" {
+			name = skillEntry.Name()
+		}
+		invocation := "/" + name
+		if pluginName != "" {
+			invocation = "/" + pluginName + ":" + name
+		}
+		if !skilldiscovery.Matches(invocation, description) {
+			continue
+		}
+		found = append(found, agent.DiscoveredSkill{
+			Name:        invocation,
+			Description: description,
+			SourcePath:  skillFile,
+		})
+	}
+	return found
+}
+
+// parseSkillFrontmatter extracts `name:` and `description:` from a minimal
+// YAML frontmatter block. Purpose-built for the tiny subset of YAML these
+// SKILL.md files actually use.
+func parseSkillFrontmatter(data []byte) (name, description string, err error) {
+	s := string(data)
+	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
+		return "", "", errors.New("no frontmatter delimiter")
+	}
+	body := strings.TrimPrefix(strings.TrimPrefix(s, "---\r\n"), "---\n")
+	end := strings.Index(body, "\n---")
+	if end < 0 {
+		return "", "", errors.New("no closing frontmatter delimiter")
+	}
+	for _, line := range strings.Split(body[:end], "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "name:") {
+			name = strings.TrimSpace(strings.TrimPrefix(line, "name:"))
+		} else if strings.HasPrefix(line, "description:") {
+			description = strings.TrimSpace(strings.TrimPrefix(line, "description:"))
+		}
+	}
+	return name, description, nil
+}

--- a/cmd/entire/cli/agent/claudecode/discovery.go
+++ b/cmd/entire/cli/agent/claudecode/discovery.go
@@ -13,10 +13,21 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
 
-// DiscoverReviewSkills walks ~/.claude/plugins/cache/ and ~/.claude/skills/
-// for SKILL.md files whose name or description indicates review-adjacent
-// intent. Returns (nil, nil) when HOME is unreadable or directories are
-// missing — discovery is best-effort.
+// DiscoverReviewSkills walks Claude Code's on-disk plugin layout and user-
+// level directories looking for review-adjacent invocations. Returns
+// (nil, nil) when HOME is unreadable or directories are missing — discovery
+// is best-effort.
+//
+// Claude Code exposes three kinds of invocable content per plugin:
+//   - skills:   <plugin>/skills/<name>/SKILL.md   (YAML frontmatter with name + description)
+//   - commands: <plugin>/commands/<name>.md       (YAML frontmatter with description; name = filename)
+//   - agents:   <plugin>/agents/<name>.md         (YAML frontmatter with description; name = filename)
+//
+// All three are walked because users invoke them via the same slash-prefix
+// syntax (`/plugin:name`) and any of them can be a review tool. The
+// pr-review-toolkit plugin, for example, ships its review skills as
+// commands/agents (not skills/), and was silently missed by a skills-only
+// walker.
 //
 //nolint:unparam // error return is part of SkillDiscoverer contract; future implementations may report hard failures
 func (c *ClaudeCodeAgent) DiscoverReviewSkills(ctx context.Context) ([]agent.DiscoveredSkill, error) {
@@ -29,13 +40,16 @@ func (c *ClaudeCodeAgent) DiscoverReviewSkills(ctx context.Context) ([]agent.Dis
 	var found []agent.DiscoveredSkill
 	found = append(found, scanPluginCache(ctx, filepath.Join(home, ".claude", "plugins", "cache"))...)
 	found = append(found, scanUserSkills(ctx, filepath.Join(home, ".claude", "skills"))...)
+	found = append(found, scanFlatMarkdownDir(ctx, filepath.Join(home, ".claude", "commands"), "")...)
+	found = append(found, scanFlatMarkdownDir(ctx, filepath.Join(home, ".claude", "agents"), "")...)
 	if len(found) == 0 {
 		return nil, nil
 	}
 	return found, nil
 }
 
-// scanPluginCache walks <root>/<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md
+// scanPluginCache walks <root>/<marketplace>/<plugin>/<version>/{skills,commands,agents}/
+// One plugin can contribute through any or all three directories.
 func scanPluginCache(ctx context.Context, root string) []agent.DiscoveredSkill {
 	entries, err := os.ReadDir(root)
 	if err != nil {
@@ -67,8 +81,10 @@ func scanPluginCache(ctx context.Context, root string) []agent.DiscoveredSkill {
 				if !verEntry.IsDir() {
 					continue
 				}
-				skillsRoot := filepath.Join(pluginRoot, verEntry.Name(), "skills")
-				found = append(found, readSkillsDir(ctx, skillsRoot, pluginName)...)
+				versionRoot := filepath.Join(pluginRoot, verEntry.Name())
+				found = append(found, readSkillsDir(ctx, filepath.Join(versionRoot, "skills"), pluginName)...)
+				found = append(found, scanFlatMarkdownDir(ctx, filepath.Join(versionRoot, "commands"), pluginName)...)
+				found = append(found, scanFlatMarkdownDir(ctx, filepath.Join(versionRoot, "agents"), pluginName)...)
 			}
 		}
 	}
@@ -107,10 +123,7 @@ func readSkillsDir(ctx context.Context, dir, pluginName string) []agent.Discover
 		if name == "" {
 			name = skillEntry.Name()
 		}
-		invocation := "/" + name
-		if pluginName != "" {
-			invocation = "/" + pluginName + ":" + name
-		}
+		invocation := invocationName(name, pluginName)
 		if !skilldiscovery.Matches(invocation, description) {
 			continue
 		}
@@ -123,9 +136,67 @@ func readSkillsDir(ctx context.Context, dir, pluginName string) []agent.Discover
 	return found
 }
 
+// scanFlatMarkdownDir reads *.md files directly under dir (no nesting), parses
+// their YAML frontmatter for `description:`, and derives the invocation name
+// from the filename (stripping the .md suffix). Used for both plugin
+// commands/agents and user-level ~/.claude/commands and ~/.claude/agents.
+//
+// Frontmatter shape differs from SKILL.md — no `name:` field, so the
+// filename is the source of truth for the invocation name.
+func scanFlatMarkdownDir(ctx context.Context, dir, pluginName string) []agent.DiscoveredSkill {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var found []agent.DiscoveredSkill
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		baseName := strings.TrimSuffix(entry.Name(), ".md")
+		if strings.EqualFold(baseName, "README") {
+			continue
+		}
+		filePath := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(filePath) //nolint:gosec // G304: filePath is constructed from a ReadDir walk under HOME, not user input
+		if err != nil {
+			continue
+		}
+		_, description, parseErr := parseSkillFrontmatter(data)
+		if parseErr != nil {
+			logging.Debug(ctx, "claude-code discovery: skipping malformed command/agent",
+				slog.String("path", filePath), slog.String("error", parseErr.Error()))
+			continue
+		}
+		invocation := invocationName(baseName, pluginName)
+		if !skilldiscovery.Matches(invocation, description) {
+			continue
+		}
+		found = append(found, agent.DiscoveredSkill{
+			Name:        invocation,
+			Description: description,
+			SourcePath:  filePath,
+		})
+	}
+	return found
+}
+
+// invocationName builds the slash-prefixed invocation form. Plugin-prefixed
+// names use "/plugin:name"; bare names use "/name".
+func invocationName(name, pluginName string) string {
+	if pluginName == "" {
+		return "/" + name
+	}
+	return "/" + pluginName + ":" + name
+}
+
 // parseSkillFrontmatter extracts `name:` and `description:` from a minimal
 // YAML frontmatter block. Purpose-built for the tiny subset of YAML these
-// SKILL.md files actually use.
+// SKILL.md / command / agent files actually use.
+//
+// Trims surrounding double-quotes from values so `description: "foo bar"`
+// is returned as `foo bar` — the command/agent frontmatter quotes values;
+// SKILL.md files usually don't.
 func parseSkillFrontmatter(data []byte) (name, description string, err error) {
 	s := string(data)
 	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
@@ -138,10 +209,11 @@ func parseSkillFrontmatter(data []byte) (name, description string, err error) {
 	}
 	for _, line := range strings.Split(body[:end], "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "name:") {
-			name = strings.TrimSpace(strings.TrimPrefix(line, "name:"))
-		} else if strings.HasPrefix(line, "description:") {
-			description = strings.TrimSpace(strings.TrimPrefix(line, "description:"))
+		switch {
+		case strings.HasPrefix(line, "name:"):
+			name = strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "name:")), `"`)
+		case strings.HasPrefix(line, "description:"):
+			description = strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "description:")), `"`)
 		}
 	}
 	return name, description, nil

--- a/cmd/entire/cli/agent/claudecode/discovery_test.go
+++ b/cmd/entire/cli/agent/claudecode/discovery_test.go
@@ -126,6 +126,132 @@ func TestDiscoverReviewSkills_MalformedSkillSkipped(t *testing.T) {
 	}
 }
 
+// TestDiscoverReviewSkills_FindsPluginCommand covers the pr-review-toolkit
+// shape: slash commands live as flat *.md files under <plugin>/commands/,
+// with description in YAML frontmatter and the invocation name derived
+// from the filename (no `name:` field).
+func TestDiscoverReviewSkills_FindsPluginCommand(t *testing.T) {
+	home := withFakeHome(t)
+	cmdDir := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "pr-review-toolkit", "unknown", "commands")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Frontmatter with quoted description and no `name:` field — exactly
+	// the shape pr-review-toolkit ships (verified on-disk).
+	content := `---
+description: "Comprehensive PR review using specialized agents"
+argument-hint: "[review-aspects]"
+allowed-tools: ["Bash", "Read"]
+---
+
+# Comprehensive PR Review
+`
+	if err := os.WriteFile(filepath.Join(cmdDir, "review-pr.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 plugin command, got %d: %+v", len(skills), skills)
+	}
+	if skills[0].Name != "/pr-review-toolkit:review-pr" {
+		t.Errorf("Name = %q, want /pr-review-toolkit:review-pr", skills[0].Name)
+	}
+	if skills[0].Description != "Comprehensive PR review using specialized agents" {
+		t.Errorf("Description = %q", skills[0].Description)
+	}
+}
+
+// TestDiscoverReviewSkills_FindsPluginAgent covers the same shape for
+// <plugin>/agents/ — pr-review-toolkit ships subagents (code-reviewer,
+// silent-failure-hunter, etc.) there. Same flat .md file format.
+func TestDiscoverReviewSkills_FindsPluginAgent(t *testing.T) {
+	home := withFakeHome(t)
+	agentDir := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "pr-review-toolkit", "unknown", "agents")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `---
+description: "Audit code against project style"
+---
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "code-reviewer.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 plugin agent, got %d: %+v", len(skills), skills)
+	}
+	if skills[0].Name != "/pr-review-toolkit:code-reviewer" {
+		t.Errorf("Name = %q, want /pr-review-toolkit:code-reviewer", skills[0].Name)
+	}
+}
+
+// TestDiscoverReviewSkills_SkipsNonReviewCommand verifies that commands
+// whose filename doesn't match keywords (and whose plugin prefix doesn't
+// either) are dropped by the name-only Matches filter.
+func TestDiscoverReviewSkills_SkipsNonReviewCommand(t *testing.T) {
+	home := withFakeHome(t)
+	cmdDir := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "unrelated-plugin", "1.0.0", "commands")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `---
+description: "Format your code nicely"
+---
+`
+	if err := os.WriteFile(filepath.Join(cmdDir, "format.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 0 {
+		t.Errorf("unrelated command should be skipped, got %+v", skills)
+	}
+}
+
+// TestDiscoverReviewSkills_SkipsReadme verifies README.md files sitting
+// alongside commands/agents don't get parsed as skills (pr-review-toolkit
+// and several other plugins ship a README.md next to commands/).
+func TestDiscoverReviewSkills_SkipsReadme(t *testing.T) {
+	home := withFakeHome(t)
+	cmdDir := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "pr-review-toolkit", "unknown", "commands")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// README has no frontmatter and would otherwise trigger parse errors.
+	if err := os.WriteFile(filepath.Join(cmdDir, "README.md"),
+		[]byte("# PR Review Toolkit\n\nSome prose.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 0 {
+		t.Errorf("README.md should be skipped, got %+v", skills)
+	}
+}
+
 func TestDiscoverReviewSkills_UserSkillsDir(t *testing.T) {
 	home := withFakeHome(t)
 	userSkillDir := filepath.Join(home, ".claude", "skills", "my-review")

--- a/cmd/entire/cli/agent/claudecode/discovery_test.go
+++ b/cmd/entire/cli/agent/claudecode/discovery_test.go
@@ -1,0 +1,151 @@
+package claudecode_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+)
+
+// Compile-time pin: ClaudeCodeAgent must satisfy SkillDiscoverer.
+var _ agent.SkillDiscoverer = (*claudecode.ClaudeCodeAgent)(nil)
+
+func withFakeHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+func TestDiscoverReviewSkills_NoPluginsDirReturnsNilNil(t *testing.T) {
+	// Cannot t.Parallel — uses t.Setenv.
+	withFakeHome(t)
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if skills != nil {
+		t.Errorf("skills = %v, want nil", skills)
+	}
+}
+
+func TestDiscoverReviewSkills_FindsPluginReviewSkill(t *testing.T) {
+	home := withFakeHome(t)
+	skillDir := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "pr-review-toolkit", "0.1.0", "skills", "review-pr")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `---
+name: review-pr
+description: Full PR review
+---
+
+Review the PR.
+`
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("skills count = %d, want 1", len(skills))
+	}
+	if skills[0].Name != "/pr-review-toolkit:review-pr" {
+		t.Errorf("skills[0].Name = %q, want /pr-review-toolkit:review-pr", skills[0].Name)
+	}
+	if skills[0].Description != "Full PR review" {
+		t.Errorf("skills[0].Description = %q", skills[0].Description)
+	}
+}
+
+func TestDiscoverReviewSkills_SkipsNonReviewSkill(t *testing.T) {
+	home := withFakeHome(t)
+	skillDir := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "unrelated-plugin", "1.0.0", "skills", "format-code")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `---
+name: format-code
+description: Reformat code according to project style
+---
+`
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(skills) != 0 {
+		t.Errorf("non-review skill should be skipped, got %+v", skills)
+	}
+}
+
+func TestDiscoverReviewSkills_MalformedSkillSkipped(t *testing.T) {
+	home := withFakeHome(t)
+	goodDir := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "good-plugin", "1.0.0", "skills", "review-pr")
+	badDir := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "bad-plugin", "1.0.0", "skills", "audit")
+	if err := os.MkdirAll(goodDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(badDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(goodDir, "SKILL.md"),
+		[]byte("---\nname: review-pr\ndescription: PR review\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Malformed: no closing frontmatter delimiter.
+	if err := os.WriteFile(filepath.Join(badDir, "SKILL.md"),
+		[]byte("---\nname: audit\ndescription: uh oh"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatalf("malformed SKILL.md should not abort discovery; got err=%v", err)
+	}
+	if len(skills) != 1 {
+		t.Errorf("good skill should still appear, got %+v", skills)
+	}
+}
+
+func TestDiscoverReviewSkills_UserSkillsDir(t *testing.T) {
+	home := withFakeHome(t)
+	userSkillDir := filepath.Join(home, ".claude", "skills", "my-review")
+	if err := os.MkdirAll(userSkillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userSkillDir, "SKILL.md"),
+		[]byte("---\nname: my-review\ndescription: personal review skill\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 user skill, got %d", len(skills))
+	}
+	if skills[0].Name != "/my-review" {
+		t.Errorf("user skill name = %q, want /my-review", skills[0].Name)
+	}
+}

--- a/cmd/entire/cli/agent/codex/discovery.go
+++ b/cmd/entire/cli/agent/codex/discovery.go
@@ -1,0 +1,15 @@
+package codex
+
+import (
+	"context"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// DiscoverReviewSkills is a stub until the Codex on-disk plugin layout is
+// verified against codex-rs source (see codex-rs/tui/src/slash_command.rs).
+// Returns (nil, nil) so the picker treats Codex as "built-ins + install
+// hint only" for Phase 1.
+func (c *CodexAgent) DiscoverReviewSkills(_ context.Context) ([]agent.DiscoveredSkill, error) {
+	return nil, nil
+}

--- a/cmd/entire/cli/agent/codex/discovery_test.go
+++ b/cmd/entire/cli/agent/codex/discovery_test.go
@@ -1,0 +1,24 @@
+package codex_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
+)
+
+// Compile-time pin: CodexAgent must satisfy SkillDiscoverer.
+var _ agent.SkillDiscoverer = (*codex.CodexAgent)(nil)
+
+func TestCodexAgent_DiscoverReviewSkills_Stub(t *testing.T) {
+	t.Parallel()
+	a := &codex.CodexAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatalf("stub should not error; got %v", err)
+	}
+	if skills != nil {
+		t.Errorf("stub should return nil skills; got %+v", skills)
+	}
+}

--- a/cmd/entire/cli/agent/geminicli/discovery.go
+++ b/cmd/entire/cli/agent/geminicli/discovery.go
@@ -1,0 +1,14 @@
+package geminicli
+
+import (
+	"context"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// DiscoverReviewSkills is a stub until the Gemini CLI on-disk extension layout
+// is verified. Returns (nil, nil) so the picker relies on the per-agent
+// install hint for Phase 1.
+func (g *GeminiCLIAgent) DiscoverReviewSkills(_ context.Context) ([]agent.DiscoveredSkill, error) {
+	return nil, nil
+}

--- a/cmd/entire/cli/agent/geminicli/discovery_test.go
+++ b/cmd/entire/cli/agent/geminicli/discovery_test.go
@@ -1,0 +1,24 @@
+package geminicli_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+)
+
+// Compile-time pin: GeminiCLIAgent must satisfy SkillDiscoverer.
+var _ agent.SkillDiscoverer = (*geminicli.GeminiCLIAgent)(nil)
+
+func TestGeminiCLIAgent_DiscoverReviewSkills_Stub(t *testing.T) {
+	t.Parallel()
+	a := &geminicli.GeminiCLIAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatalf("stub should not error; got %v", err)
+	}
+	if skills != nil {
+		t.Errorf("stub should return nil skills; got %+v", skills)
+	}
+}

--- a/cmd/entire/cli/agent/registry.go
+++ b/cmd/entire/cli/agent/registry.go
@@ -202,7 +202,7 @@ func AllProtectedFiles() []string {
 
 // LauncherFor returns the Launcher implementation for the given agent name,
 // or ok=false if the agent does not support subprocess launching. Callers
-// should fall back to "--track-only" mode in that case.
+// should tell the user to start the agent manually in that case.
 func LauncherFor(name types.AgentName) (Launcher, bool) {
 	a, err := Get(name)
 	if err != nil {

--- a/cmd/entire/cli/agent/skilldiscovery/match.go
+++ b/cmd/entire/cli/agent/skilldiscovery/match.go
@@ -17,13 +17,26 @@ var reviewKeywords = []string{
 	"security-scan",
 }
 
-// Matches reports whether the given skill name or description contains any
-// review-adjacent keyword (case-insensitive).
+// Matches reports whether the given skill invocation contains any
+// review-adjacent keyword (case-insensitive) in its name.
+//
+// We deliberately match on name only. Descriptions often contain words like
+// "review" or "inspect" in non-review contexts — "review the plan",
+// "inspect recent sessions", "review checkpoints" — which would pull in
+// unrelated skills. Legitimate review skills either have the keyword in
+// their name directly (e.g. /test-auditor, /superpowers:receiving-code-review)
+// or live under a plugin whose prefix contains it (e.g.
+// /pr-review-toolkit:silent-failure-hunter matches via "review" in
+// "pr-review-toolkit").
+//
+// The description parameter is retained for signature stability — callers
+// still supply it so the picker can show descriptions — but it does not
+// affect match decisions.
 func Matches(name, description string) bool {
+	_ = description
 	lname := strings.ToLower(name)
-	ldesc := strings.ToLower(description)
 	for _, kw := range reviewKeywords {
-		if strings.Contains(lname, kw) || strings.Contains(ldesc, kw) {
+		if strings.Contains(lname, kw) {
 			return true
 		}
 	}

--- a/cmd/entire/cli/agent/skilldiscovery/match.go
+++ b/cmd/entire/cli/agent/skilldiscovery/match.go
@@ -1,0 +1,31 @@
+// Package skilldiscovery holds the per-agent registries (curated built-ins,
+// install hints) and the keyword match helper that the `entire review`
+// picker uses to discover review-adjacent skills.
+package skilldiscovery
+
+import "strings"
+
+// reviewKeywords are the substrings that mark a skill as review-adjacent.
+// Kept narrow on purpose — see the spec's "Keyword set — deliberate
+// omissions" section for why "lint" is NOT here.
+var reviewKeywords = []string{
+	"review",
+	"audit",
+	"inspect",
+	"critique",
+	"assess",
+	"security-scan",
+}
+
+// Matches reports whether the given skill name or description contains any
+// review-adjacent keyword (case-insensitive).
+func Matches(name, description string) bool {
+	lname := strings.ToLower(name)
+	ldesc := strings.ToLower(description)
+	for _, kw := range reviewKeywords {
+		if strings.Contains(lname, kw) || strings.Contains(ldesc, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/agent/skilldiscovery/match_test.go
+++ b/cmd/entire/cli/agent/skilldiscovery/match_test.go
@@ -19,13 +19,49 @@ func TestMatches_NameKeywords(t *testing.T) {
 	}
 }
 
-func TestMatches_DescriptionKeywords(t *testing.T) {
+// TestMatches_DescriptionIgnored pins the deliberate name-only matching.
+// Skills whose descriptions mention review-adjacent words but whose names do
+// not (e.g. "review the plan", "inspect recent sessions") must NOT match —
+// those were the false positives that crowded the picker with non-review
+// skills in real discovery runs.
+func TestMatches_DescriptionIgnored(t *testing.T) {
 	t.Parallel()
-	if !skilldiscovery.Matches("/unrelated", "Find silent failures during code review") {
-		t.Error("description containing 'review' should match")
+	cases := []struct {
+		name, desc string
+	}{
+		{"/entire:session-handoff", "inspect recent sessions or summarize a saved session"},
+		{"/codex:gpt-5-4-prompting", "composing prompts for coding, review, diagnosis, research"},
+		{"/superpowers:executing-plans", "execute plans in a separate session with review checkpoints"},
+		{"/unrelated", "Audit test coverage on changed files"},
 	}
-	if !skilldiscovery.Matches("/unrelated", "Audit test coverage on changed files") {
-		t.Error("description containing 'audit' should match")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if skilldiscovery.Matches(c.name, c.desc) {
+				t.Errorf("Matches(%q, %q) = true; want false (description should not match)", c.name, c.desc)
+			}
+		})
+	}
+}
+
+// TestMatches_PluginPrefixProvidesKeyword pins that plugin-prefix invocations
+// count for matching — this is how /pr-review-toolkit:silent-failure-hunter
+// still gets discovered even though its own skill name doesn't contain
+// "review".
+func TestMatches_PluginPrefixProvidesKeyword(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"/pr-review-toolkit:silent-failure-hunter",
+		"/pr-review-toolkit:type-design-analyzer",
+		"/security-audit-bundle:scan-for-leaks",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if !skilldiscovery.Matches(name, "") {
+				t.Errorf("Matches(%q, \"\") = false, want true (plugin-prefix match)", name)
+			}
+		})
 	}
 }
 
@@ -34,8 +70,8 @@ func TestMatches_CaseInsensitive(t *testing.T) {
 	if !skilldiscovery.Matches("/REVIEW", "") {
 		t.Error("uppercase name keyword should match")
 	}
-	if !skilldiscovery.Matches("/run", "Deeply INSPECT the diff") {
-		t.Error("uppercase description keyword should match")
+	if !skilldiscovery.Matches("/Inspect-PR", "") {
+		t.Error("mixed-case name keyword should match")
 	}
 }
 

--- a/cmd/entire/cli/agent/skilldiscovery/match_test.go
+++ b/cmd/entire/cli/agent/skilldiscovery/match_test.go
@@ -1,0 +1,50 @@
+package skilldiscovery_test
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/skilldiscovery"
+)
+
+func TestMatches_NameKeywords(t *testing.T) {
+	t.Parallel()
+	cases := []string{"/review", "/security-audit", "/inspect-pr", "/critique", "/assess"}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if !skilldiscovery.Matches(name, "") {
+				t.Errorf("Matches(%q, \"\") = false, want true", name)
+			}
+		})
+	}
+}
+
+func TestMatches_DescriptionKeywords(t *testing.T) {
+	t.Parallel()
+	if !skilldiscovery.Matches("/unrelated", "Find silent failures during code review") {
+		t.Error("description containing 'review' should match")
+	}
+	if !skilldiscovery.Matches("/unrelated", "Audit test coverage on changed files") {
+		t.Error("description containing 'audit' should match")
+	}
+}
+
+func TestMatches_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	if !skilldiscovery.Matches("/REVIEW", "") {
+		t.Error("uppercase name keyword should match")
+	}
+	if !skilldiscovery.Matches("/run", "Deeply INSPECT the diff") {
+		t.Error("uppercase description keyword should match")
+	}
+}
+
+func TestMatches_NoMatchWhenNeitherContains(t *testing.T) {
+	t.Parallel()
+	if skilldiscovery.Matches("/format", "Reformat code") {
+		t.Error("format/reformat should not match review keywords")
+	}
+	if skilldiscovery.Matches("/lint-fix", "Auto-fix lint errors") {
+		t.Error("lint is no longer in the keyword set — see spec §Keyword Set")
+	}
+}

--- a/cmd/entire/cli/agent/skilldiscovery/registry.go
+++ b/cmd/entire/cli/agent/skilldiscovery/registry.go
@@ -1,0 +1,125 @@
+package skilldiscovery
+
+// CuratedSkill is an entry in the curated per-agent built-in list. Name is
+// the skill's invocation form (slash-prefixed); Desc is the picker-visible
+// description.
+type CuratedSkill struct {
+	Name string
+	Desc string
+}
+
+// InstallHint is a per-agent message shown in the "Install more" section of
+// the picker. ProvidesAny lists the discovered skill names whose presence
+// means "this plugin is already installed" — if any of those appear in the
+// discovered set, the hint is suppressed.
+//
+// When ProvidesAny is nil, the hint is always shown — use this for
+// ecosystems where we can't predict plugin skill names (e.g. Gemini).
+type InstallHint struct {
+	Message     string
+	ProvidesAny []string
+}
+
+// curatedBuiltins lists the review-adjacent commands that ship with each
+// agent binary (no plugin install required). See
+// docs/superpowers/specs/2026-04-22-entire-review-picker-install-awareness-design.md
+// §Data model for the sources these names came from. Gemini CLI has no
+// built-in review command and relies on the install hint below.
+var curatedBuiltins = map[string][]CuratedSkill{
+	"claude-code": {
+		{Name: "/review", Desc: "Review changes and find issues"},
+		{Name: "/security-review", Desc: "Scan git diff for security issues"},
+		{Name: "/simplify", Desc: "Review recent changes for code quality"},
+	},
+	"codex":      {{Name: "/review", Desc: "Review current changes and find issues"}},
+	"gemini-cli": {},
+}
+
+// installHints lists the passive install pointers shown in the picker when
+// discovery didn't surface the plugin already. Messages are free-form text;
+// ProvidesAny is the suppression fingerprint.
+//
+// Install commands below are placeholders until marketplace URLs are pinned.
+// Tests do not assert on Message text — only on ProvidesAny semantics — so
+// prose revisions do not break the suite.
+var installHints = map[string][]InstallHint{
+	"claude-code": {
+		{
+			Message: "Install `pr-review-toolkit` via `claude plugin install entireio/pr-review-toolkit`",
+			ProvidesAny: []string{
+				"/pr-review-toolkit:review-pr",
+				"/pr-review-toolkit:code-reviewer",
+				"/pr-review-toolkit:silent-failure-hunter",
+			},
+		},
+		{
+			Message:     "Install `test-auditor` via the superpowers plugin",
+			ProvidesAny: []string{"/test-auditor"},
+		},
+	},
+	"codex": {
+		{
+			Message:     "Install `codex-review-pack` via `codex plugins add <url>`",
+			ProvidesAny: []string{"/codex:adversarial-review"},
+		},
+	},
+	"gemini-cli": {
+		{
+			Message:     "Install `gemini-code-review` via `gemini extensions install <url>`",
+			ProvidesAny: nil,
+		},
+	},
+}
+
+// CuratedBuiltinsFor returns the curated built-in list for agentName, or
+// an empty slice if the agent is unknown. Callers must treat the return
+// value as read-only.
+func CuratedBuiltinsFor(agentName string) []CuratedSkill {
+	return curatedBuiltins[agentName]
+}
+
+// ActiveInstallHintsFor returns the subset of installHints[agentName] whose
+// ProvidesAny does NOT intersect the discovered set. When ProvidesAny is
+// nil, the hint is always active.
+//
+// discovered is a set of skill names (map for O(1) membership); pass nil
+// or an empty map when no skills have been discovered.
+func ActiveInstallHintsFor(agentName string, discovered map[string]struct{}) []InstallHint {
+	raw := installHints[agentName]
+	if len(raw) == 0 {
+		return nil
+	}
+	active := make([]InstallHint, 0, len(raw))
+	for _, h := range raw {
+		if isSuppressed(h, discovered) {
+			continue
+		}
+		active = append(active, h)
+	}
+	return active
+}
+
+func isSuppressed(h InstallHint, discovered map[string]struct{}) bool {
+	if len(h.ProvidesAny) == 0 {
+		return false
+	}
+	for _, name := range h.ProvidesAny {
+		if _, ok := discovered[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// IsEligible reports whether the given agent has any registry entry — either
+// a curated built-in or an install hint. The picker uses this (intersected
+// with "hooks installed") to decide whether to show a section for the agent.
+func IsEligible(agentName string) bool {
+	if len(curatedBuiltins[agentName]) > 0 {
+		return true
+	}
+	if len(installHints[agentName]) > 0 {
+		return true
+	}
+	return false
+}

--- a/cmd/entire/cli/agent/skilldiscovery/registry_test.go
+++ b/cmd/entire/cli/agent/skilldiscovery/registry_test.go
@@ -1,0 +1,72 @@
+package skilldiscovery_test
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/skilldiscovery"
+)
+
+func TestCuratedBuiltinsFor_KnownAgents(t *testing.T) {
+	t.Parallel()
+	claude := skilldiscovery.CuratedBuiltinsFor("claude-code")
+	if len(claude) != 3 {
+		t.Fatalf("claude-code built-ins: got %d entries, want 3", len(claude))
+	}
+	codex := skilldiscovery.CuratedBuiltinsFor("codex")
+	if len(codex) != 1 || codex[0].Name != "/review" {
+		t.Errorf("codex built-ins: got %+v, want 1x /review", codex)
+	}
+	gemini := skilldiscovery.CuratedBuiltinsFor("gemini-cli")
+	if len(gemini) != 0 {
+		t.Errorf("gemini-cli built-ins: got %d, want 0", len(gemini))
+	}
+}
+
+func TestCuratedBuiltinsFor_UnknownAgentReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	if got := skilldiscovery.CuratedBuiltinsFor("nonexistent"); len(got) != 0 {
+		t.Errorf("unknown agent: got %d entries, want 0", len(got))
+	}
+}
+
+func TestActiveInstallHintsFor_SuppressesWhenProvidesAnyDiscovered(t *testing.T) {
+	t.Parallel()
+	discovered := map[string]struct{}{"/pr-review-toolkit:review-pr": {}}
+	hints := skilldiscovery.ActiveInstallHintsFor("claude-code", discovered)
+	for _, h := range hints {
+		for _, name := range h.ProvidesAny {
+			if name == "/pr-review-toolkit:review-pr" {
+				t.Errorf("pr-review-toolkit hint should have been suppressed, got %+v", h)
+			}
+		}
+	}
+}
+
+func TestActiveInstallHintsFor_ShowsAllWhenNothingDiscovered(t *testing.T) {
+	t.Parallel()
+	hints := skilldiscovery.ActiveInstallHintsFor("claude-code", nil)
+	if len(hints) == 0 {
+		t.Fatal("expected at least one hint when discovery set is empty")
+	}
+}
+
+func TestActiveInstallHintsFor_GeminiAlwaysShownRegardlessOfDiscovery(t *testing.T) {
+	t.Parallel()
+	hints := skilldiscovery.ActiveInstallHintsFor("gemini-cli", map[string]struct{}{"/anything": {}})
+	if len(hints) == 0 {
+		t.Error("gemini hint with nil ProvidesAny should always show")
+	}
+}
+
+func TestIsEligible_IncludesAgentWithOnlyInstallHint(t *testing.T) {
+	t.Parallel()
+	if !skilldiscovery.IsEligible("gemini-cli") {
+		t.Error("gemini-cli should be eligible via install hint alone")
+	}
+	if !skilldiscovery.IsEligible("claude-code") {
+		t.Error("claude-code should be eligible via built-ins")
+	}
+	if skilldiscovery.IsEligible("nonexistent") {
+		t.Error("unknown agent should not be eligible")
+	}
+}

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -212,6 +212,10 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	// Determine checkpoint ID: reuse from HEAD if one exists, otherwise generate new.
 	checkpointID, isExistingCheckpoint := resolveCheckpointID(headCommit)
 
+	// Refresh the metadata branch if HEAD already references a checkpoint.
+	// Returns a possibly-freshly-opened repo handle; see refreshForExistingCheckpoint.
+	repo = refreshForExistingCheckpoint(ctx, logCtx, repo, isExistingCheckpoint)
+
 	// Write directly to entire/checkpoints/v1.
 	store := cpkg.NewGitStore(repo)
 
@@ -219,7 +223,8 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	// check only fires when the session's state file records its
 	// checkpoint. A session already stored in the HEAD checkpoint but
 	// whose state is missing/stale (state file deleted, never written,
-	// condensed without LastCheckpointID update) would bypass that guard.
+	// condensed without LastCheckpointID update, or pulled from a remote
+	// that wasn't reflected locally) would bypass that guard.
 	// findSessionIndex matches by SessionID — without this check, a
 	// review-attach on such a session silently overwrites the existing
 	// session's metadata in the checkpoint.
@@ -348,6 +353,40 @@ func getHeadCommit(repo *git.Repository) (*object.Commit, error) {
 // If HEAD already has an Entire-Checkpoint trailer, reuses that ID (the session
 // gets added as an additional session in the existing checkpoint).
 // Otherwise generates a new ID.
+// refreshForExistingCheckpoint refreshes the entire/checkpoints/v1 branch
+// before reading or writing when HEAD already references a checkpoint.
+// Two concerns both require fresh state:
+//
+//  1. Conflict detection (review mode): a session already recorded in the
+//     checkpoint — locally OR on the remote — must not be silently
+//     overwritten. Without a fetch, a stale local branch makes the
+//     sessionID-dedup check miss remote-only entries.
+//  2. Correct append-as-next-session: findSessionIndex returns
+//     len(Sessions) when the sessionID isn't already present. With a stale
+//     local view, this returns a too-low index and collides with an
+//     existing remote-only session on push.
+//
+// Mirrors the fallback chain `entire resume` uses in getMetadataTree:
+// checkpoint-remote → treeless fetch → local → full fetch → remote-tracking
+// ref. Returns a freshly-opened repo handle (so go-git's packfile cache
+// sees any newly-fetched objects), or the original repo on fetch failure.
+func refreshForExistingCheckpoint(ctx, logCtx context.Context, repo *git.Repository, isExistingCheckpoint bool) *git.Repository {
+	if !isExistingCheckpoint {
+		return repo
+	}
+	_, freshRepo, fetchErr := getMetadataTree(ctx)
+	if fetchErr != nil {
+		// Non-fatal: proceed with local state. Guards downstream catch
+		// what's visible locally; on push the user may still hit a
+		// conflict. Better than blocking attach on a transient fetch
+		// failure.
+		logging.Warn(logCtx, "failed to refresh metadata branch before attach; proceeding with local state",
+			slog.String("error", fetchErr.Error()))
+		return repo
+	}
+	return freshRepo
+}
+
 func resolveCheckpointID(headCommit *object.Commit) (id.CheckpointID, bool) {
 	existing := trailers.ParseAllCheckpoints(headCommit.Message)
 	if len(existing) > 0 {

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -36,13 +36,20 @@ import (
 )
 
 // attachOptions carries optional flags for runAttach. Force is the original
-// flag; ReviewSkills/ReviewPrompt opt the attach into recording the session
-// as an agent_review in the checkpoint metadata.
+// flag; Review opts the attach into recording the session as an
+// agent_review in the checkpoint metadata.
 type attachOptions struct {
 	Force bool
-	// ReviewSkills, when non-nil, tags the attached session as a review and
-	// records the skill list in checkpoint metadata. nil = not a review attach.
-	ReviewSkills []string
+	// Review, when true, tags the attached session as a review. Skills are
+	// resolved inside runAttach after the real agent is known (via session
+	// state or transcript auto-detection), not at the cobra layer — the
+	// --agent flag's default points at claude-code, which would otherwise
+	// make a Gemini session incorrectly look up review.claude-code config.
+	Review bool
+	// ReviewSkillsOverride, when non-empty, overrides the agent's
+	// configured review skills. Empty means "read review.<agent> from
+	// settings after resolving the real agent". Ignored when Review=false.
+	ReviewSkillsOverride []string
 }
 
 func newAttachCmd() *cobra.Command {
@@ -81,17 +88,12 @@ external_agents in settings. Run 'entire configure' to see the full list.`,
 			// and so auto-detection can find transcripts from external agents.
 			external.DiscoverAndRegister(cmd.Context())
 			agentName := types.AgentName(agentFlag)
-			opts := attachOptions{Force: force}
-			if reviewFlag {
-				skills, err := resolveReviewSkills(cmd.Context(), agentName, skillsFlag)
-				if err != nil {
-					cmd.SilenceUsage = true
-					fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
-					return NewSilentError(err)
-				}
-				opts.ReviewSkills = skills
+			opts := attachOptions{
+				Force:                force,
+				Review:               reviewFlag,
+				ReviewSkillsOverride: skillsFlag,
 			}
-			return runAttach(cmd.Context(), cmd.OutOrStdout(), args[0], agentName, opts)
+			return runAttachSurfaceReviewErrors(cmd, args[0], agentName, opts)
 		},
 	}
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation and amend the last commit with the checkpoint trailer")
@@ -122,6 +124,19 @@ func resolveReviewSkills(ctx context.Context, agentName types.AgentName, flagSki
 		"no review skills configured for agent %q and --skills not provided; run `entire review --edit`",
 		agentName,
 	)
+}
+
+// runAttachSurfaceReviewErrors wraps runAttach so review-mode errors reach
+// the user as clear stderr messages rather than generic cobra error output.
+// The non-review path preserves the existing runAttach return-err behavior.
+func runAttachSurfaceReviewErrors(cmd *cobra.Command, sessionID string, agentName types.AgentName, opts attachOptions) error {
+	err := runAttach(cmd.Context(), cmd.OutOrStdout(), sessionID, agentName, opts)
+	if err != nil && opts.Review {
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+		return NewSilentError(err)
+	}
+	return err
 }
 
 func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName types.AgentName, opts attachOptions) error {
@@ -156,7 +171,7 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		// ReviewPrompt set, and a new commit pushed onto entire/checkpoints/v1.
 		// Error out with a concrete message rather than silently linking the
 		// checkpoint without the review metadata.
-		if opts.ReviewSkills != nil {
+		if opts.Review {
 			return fmt.Errorf(
 				"session %s already has checkpoint %s; rewriting an existing checkpoint as a review is not supported yet",
 				sessionID, existingState.LastCheckpointID.String(),
@@ -175,6 +190,18 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	ag, transcriptPath, err := resolveAgentAndTranscript(logCtx, w, sessionID, agentName, existingState)
 	if err != nil {
 		return err
+	}
+
+	// Resolve review skills AFTER agent detection so the real agent's
+	// configured skills (not the --agent flag default) are consulted. The
+	// flag-based --agent default is claude-code, which would make a
+	// Gemini session incorrectly look up review.claude-code.
+	var reviewSkills []string
+	if opts.Review {
+		reviewSkills, err = resolveReviewSkills(ctx, ag.Name(), opts.ReviewSkillsOverride)
+		if err != nil {
+			return err
+		}
 	}
 
 	transcriptData, err := ag.ReadTranscript(transcriptPath)
@@ -231,9 +258,9 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		Model:        meta.Model,
 		TokenUsage:   tokenUsage,
 	}
-	if opts.ReviewSkills != nil {
+	if opts.Review {
 		writeOpts.Kind = string(session.KindAgentReview)
-		writeOpts.ReviewSkills = opts.ReviewSkills
+		writeOpts.ReviewSkills = reviewSkills
 		writeOpts.ReviewPrompt = meta.FirstPrompt
 		writeOpts.HasReview = true
 	}
@@ -264,7 +291,7 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	}
 
 	// Create or update session state.
-	if err := saveAttachSessionState(logCtx, existingState, sessionID, ag.Type(), transcriptPath, checkpointID, meta, tokenUsage, opts); err != nil {
+	if err := saveAttachSessionState(logCtx, existingState, sessionID, ag.Type(), transcriptPath, checkpointID, meta, tokenUsage, opts, reviewSkills); err != nil {
 		logging.Warn(logCtx, "failed to save session state", "error", err)
 	}
 
@@ -333,7 +360,8 @@ func resolveCheckpointID(headCommit *object.Commit) (id.CheckpointID, bool) {
 
 // saveAttachSessionState creates or updates the session state file for the attached session.
 // If existingState is non-nil, it is updated in place (avoids a redundant disk load).
-func saveAttachSessionState(ctx context.Context, existingState *session.State, sessionID string, agentType types.AgentType, transcriptPath string, checkpointID id.CheckpointID, meta transcriptMetadata, tokenUsage *agent.TokenUsage, opts attachOptions) error {
+// reviewSkills is the resolved skills list when opts.Review is true; ignored otherwise.
+func saveAttachSessionState(ctx context.Context, existingState *session.State, sessionID string, agentType types.AgentType, transcriptPath string, checkpointID id.CheckpointID, meta transcriptMetadata, tokenUsage *agent.TokenUsage, opts attachOptions, reviewSkills []string) error {
 	stateStore, err := session.NewStateStore(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to open session store: %w", err)
@@ -367,9 +395,9 @@ func saveAttachSessionState(ctx context.Context, existingState *session.State, s
 	if tokenUsage != nil {
 		state.TokenUsage = tokenUsage
 	}
-	if opts.ReviewSkills != nil {
+	if opts.Review {
 		state.Kind = session.KindAgentReview
-		state.ReviewSkills = opts.ReviewSkills
+		state.ReviewSkills = reviewSkills
 		state.ReviewPrompt = meta.FirstPrompt
 	}
 

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -215,6 +215,23 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	// Write directly to entire/checkpoints/v1.
 	store := cpkg.NewGitStore(repo)
 
+	// Defense-in-depth guard: the earlier existingState.LastCheckpointID
+	// check only fires when the session's state file records its
+	// checkpoint. A session already stored in the HEAD checkpoint but
+	// whose state is missing/stale (state file deleted, never written,
+	// condensed without LastCheckpointID update) would bypass that guard.
+	// findSessionIndex matches by SessionID — without this check, a
+	// review-attach on such a session silently overwrites the existing
+	// session's metadata in the checkpoint.
+	if opts.Review && isExistingCheckpoint {
+		if existing, readErr := store.ReadSessionContentByID(ctx, checkpointID, sessionID); readErr == nil && existing != nil {
+			return fmt.Errorf(
+				"session %s is already recorded in checkpoint %s; rewriting an existing checkpoint as a review is not supported yet",
+				sessionID, checkpointID.String(),
+			)
+		}
+	}
+
 	author, err := GetGitAuthor(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get git author: %w", err)

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -73,9 +73,8 @@ Otherwise a new checkpoint is created.
 
 Use --review to tag the attached session as an agent review. The
 first user prompt in the transcript is recorded as the review prompt.
-The skills list defaults to whatever is configured under review.<agent>
-in .entire/settings.json; pass --skills to override, or leave both
-empty to attach a review without a declared skills list.
+Pass --skills to declare which skills were actually run; omit to
+attach a review without a declared skills list.
 
 Works with any registered agent, including external agents enabled via
 external_agents in settings. Run 'entire configure' to see the full list.`,
@@ -101,32 +100,25 @@ external_agents in settings. Run 'entire configure' to see the full list.`,
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation and amend the last commit with the checkpoint trailer")
 	cmd.Flags().StringVarP(&agentFlag, "agent", "a", string(agent.DefaultAgentName), "Agent that created the session (see 'entire configure' for registered agents, including external)")
 	cmd.Flags().BoolVar(&reviewFlag, "review", false, "Tag the attached session as an agent review")
-	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Optional review skills that were run. Default: configured skills for the agent; empty is allowed. Only used with --review")
+	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Optional: declare which review skills were run in this session. Only used with --review")
 	return cmd
 }
 
-// resolveReviewSkills returns the skills list to record on an attach-as-review.
-// Precedence: --skills flag > settings.Review[agent] > empty.
+// resolveReviewSkills returns the skills list to record on an
+// attach-as-review. Only the user's --skills flag counts: configured
+// settings.Review[agent] is the spawn-path default ("what I'd run if I
+// used 'entire review'"), not a claim about what actually happened in a
+// given manual session. Silently attaching configured skills would
+// misrepresent the session as having run skills it may not have.
 //
-// Empty is a valid result — the attach still tags the session as a review
-// via Kind + ReviewPrompt (the session's first user prompt). The skills
-// list is a queryable convenience, not the source of truth for "was this
-// a review". Blocking attach just because the user hasn't run
-// `entire review --edit` would force unrelated setup onto the manual flow.
-func resolveReviewSkills(ctx context.Context, agentName types.AgentName, flagSkills []string) ([]string, error) {
-	if len(flagSkills) > 0 {
-		return flagSkills, nil
+// Empty is a valid result — the attach still tags the session as a
+// review via Kind + ReviewPrompt (the session's first user prompt). The
+// skills list is a queryable convenience, not the source of truth.
+func resolveReviewSkills(flagSkills []string) []string {
+	if len(flagSkills) == 0 {
+		return nil
 	}
-	s, err := settings.Load(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("load settings: %w", err)
-	}
-	if s != nil {
-		if skills := s.ReviewSkillsFor(string(agentName)); len(skills) > 0 {
-			return skills, nil
-		}
-	}
-	return nil, nil
+	return flagSkills
 }
 
 // runAttachSurfaceReviewErrors wraps runAttach so review-mode errors reach
@@ -195,16 +187,9 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		return err
 	}
 
-	// Resolve review skills AFTER agent detection so the real agent's
-	// configured skills (not the --agent flag default) are consulted. The
-	// flag-based --agent default is claude-code, which would make a
-	// Gemini session incorrectly look up review.claude-code.
 	var reviewSkills []string
 	if opts.Review {
-		reviewSkills, err = resolveReviewSkills(ctx, ag.Name(), opts.ReviewSkillsOverride)
-		if err != nil {
-			return err
-		}
+		reviewSkills = resolveReviewSkills(opts.ReviewSkillsOverride)
 	}
 
 	transcriptData, err := ag.ReadTranscript(transcriptPath)

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -71,9 +71,11 @@ the session started, or to attach a research session.
 If the last commit already has a checkpoint, the session is added to it.
 Otherwise a new checkpoint is created.
 
-Use --review to tag the attached session as an agent review. The skills
-list defaults to whatever is configured under review.<agent> in
-.entire/settings.json; pass --skills to override.
+Use --review to tag the attached session as an agent review. The
+first user prompt in the transcript is recorded as the review prompt.
+The skills list defaults to whatever is configured under review.<agent>
+in .entire/settings.json; pass --skills to override, or leave both
+empty to attach a review without a declared skills list.
 
 Works with any registered agent, including external agents enabled via
 external_agents in settings. Run 'entire configure' to see the full list.`,
@@ -99,14 +101,18 @@ external_agents in settings. Run 'entire configure' to see the full list.`,
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation and amend the last commit with the checkpoint trailer")
 	cmd.Flags().StringVarP(&agentFlag, "agent", "a", string(agent.DefaultAgentName), "Agent that created the session (see 'entire configure' for registered agents, including external)")
 	cmd.Flags().BoolVar(&reviewFlag, "review", false, "Tag the attached session as an agent review")
-	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Review skills that were run (default: configured skills for the agent). Only used with --review")
+	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Optional review skills that were run. Default: configured skills for the agent; empty is allowed. Only used with --review")
 	return cmd
 }
 
 // resolveReviewSkills returns the skills list to record on an attach-as-review.
-// If flagSkills is non-empty, it wins. Otherwise the configured review skills
-// for the agent are used; if none are configured, returns an error pointing
-// the user at `entire review --edit`.
+// Precedence: --skills flag > settings.Review[agent] > empty.
+//
+// Empty is a valid result — the attach still tags the session as a review
+// via Kind + ReviewPrompt (the session's first user prompt). The skills
+// list is a queryable convenience, not the source of truth for "was this
+// a review". Blocking attach just because the user hasn't run
+// `entire review --edit` would force unrelated setup onto the manual flow.
 func resolveReviewSkills(ctx context.Context, agentName types.AgentName, flagSkills []string) ([]string, error) {
 	if len(flagSkills) > 0 {
 		return flagSkills, nil
@@ -120,10 +126,7 @@ func resolveReviewSkills(ctx context.Context, agentName types.AgentName, flagSki
 			return skills, nil
 		}
 	}
-	return nil, fmt.Errorf(
-		"no review skills configured for agent %q and --skills not provided; run `entire review --edit`",
-		agentName,
-	)
+	return nil, nil
 }
 
 // runAttachSurfaceReviewErrors wraps runAttach so review-mode errors reach

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -35,10 +35,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// attachOptions carries optional flags for runAttach. Force is the original
+// flag; ReviewSkills/ReviewPrompt opt the attach into recording the session
+// as an agent_review in the checkpoint metadata.
+type attachOptions struct {
+	Force bool
+	// ReviewSkills, when non-nil, tags the attached session as a review and
+	// records the skill list in checkpoint metadata. nil = not a review attach.
+	ReviewSkills []string
+}
+
 func newAttachCmd() *cobra.Command {
 	var (
-		force     bool
-		agentFlag string
+		force      bool
+		agentFlag  string
+		reviewFlag bool
+		skillsFlag []string
 	)
 	cmd := &cobra.Command{
 		Use:   "attach <session-id>",
@@ -51,6 +63,10 @@ the session started, or to attach a research session.
 
 If the last commit already has a checkpoint, the session is added to it.
 Otherwise a new checkpoint is created.
+
+Use --review to tag the attached session as an agent review. The skills
+list defaults to whatever is configured under review.<agent> in
+.entire/settings.json; pass --skills to override.
 
 Works with any registered agent, including external agents enabled via
 external_agents in settings. Run 'entire configure' to see the full list.`,
@@ -65,15 +81,50 @@ external_agents in settings. Run 'entire configure' to see the full list.`,
 			// and so auto-detection can find transcripts from external agents.
 			external.DiscoverAndRegister(cmd.Context())
 			agentName := types.AgentName(agentFlag)
-			return runAttach(cmd.Context(), cmd.OutOrStdout(), args[0], agentName, force)
+			opts := attachOptions{Force: force}
+			if reviewFlag {
+				skills, err := resolveReviewSkills(cmd.Context(), agentName, skillsFlag)
+				if err != nil {
+					cmd.SilenceUsage = true
+					fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+					return NewSilentError(err)
+				}
+				opts.ReviewSkills = skills
+			}
+			return runAttach(cmd.Context(), cmd.OutOrStdout(), args[0], agentName, opts)
 		},
 	}
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation and amend the last commit with the checkpoint trailer")
 	cmd.Flags().StringVarP(&agentFlag, "agent", "a", string(agent.DefaultAgentName), "Agent that created the session (see 'entire configure' for registered agents, including external)")
+	cmd.Flags().BoolVar(&reviewFlag, "review", false, "Tag the attached session as an agent review")
+	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Review skills that were run (default: configured skills for the agent). Only used with --review")
 	return cmd
 }
 
-func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName types.AgentName, force bool) error {
+// resolveReviewSkills returns the skills list to record on an attach-as-review.
+// If flagSkills is non-empty, it wins. Otherwise the configured review skills
+// for the agent are used; if none are configured, returns an error pointing
+// the user at `entire review --edit`.
+func resolveReviewSkills(ctx context.Context, agentName types.AgentName, flagSkills []string) ([]string, error) {
+	if len(flagSkills) > 0 {
+		return flagSkills, nil
+	}
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load settings: %w", err)
+	}
+	if s != nil {
+		if skills := s.ReviewSkillsFor(string(agentName)); len(skills) > 0 {
+			return skills, nil
+		}
+	}
+	return nil, fmt.Errorf(
+		"no review skills configured for agent %q and --skills not provided; run `entire review --edit`",
+		agentName,
+	)
+}
+
+func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName types.AgentName, opts attachOptions) error {
 	// Initialize structured logger so logging.Warn/Info write to .entire/logs/ not stderr.
 	if err := logging.Init(ctx, sessionID); err != nil {
 		// Init failed — logging will use stderr fallback, non-fatal.
@@ -100,9 +151,20 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 
 	// If session already has a checkpoint, just offer to link it.
 	if existingState != nil && !existingState.LastCheckpointID.IsEmpty() {
+		// Review-upgrade isn't supported yet: the existing checkpoint's
+		// metadata tree would need to be rewritten with Kind/ReviewSkills/
+		// ReviewPrompt set, and a new commit pushed onto entire/checkpoints/v1.
+		// Error out with a concrete message rather than silently linking the
+		// checkpoint without the review metadata.
+		if opts.ReviewSkills != nil {
+			return fmt.Errorf(
+				"session %s already has checkpoint %s; rewriting an existing checkpoint as a review is not supported yet",
+				sessionID, existingState.LastCheckpointID.String(),
+			)
+		}
 		cpID := existingState.LastCheckpointID.String()
 		fmt.Fprintf(w, "Session %s already has checkpoint %s\n", sessionID, cpID)
-		if err := promptAmendCommit(logCtx, w, headCommit, cpID, force); err != nil {
+		if err := promptAmendCommit(logCtx, w, headCommit, cpID, opts.Force); err != nil {
 			logging.Warn(logCtx, "failed to amend commit", "error", err)
 			fmt.Fprintf(w, "\nCopy to your commit message to attach:\n\n  Entire-Checkpoint: %s\n", cpID)
 		}
@@ -169,6 +231,12 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		Model:        meta.Model,
 		TokenUsage:   tokenUsage,
 	}
+	if opts.ReviewSkills != nil {
+		writeOpts.Kind = string(session.KindAgentReview)
+		writeOpts.ReviewSkills = opts.ReviewSkills
+		writeOpts.ReviewPrompt = meta.FirstPrompt
+		writeOpts.HasReview = true
+	}
 
 	if compacted := compactTranscriptForStartLine(logCtx, redactedTranscript.Bytes(), cpkg.CommittedMetadata{
 		CheckpointID: checkpointID,
@@ -196,7 +264,7 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	}
 
 	// Create or update session state.
-	if err := saveAttachSessionState(logCtx, existingState, sessionID, ag.Type(), transcriptPath, checkpointID, meta, tokenUsage); err != nil {
+	if err := saveAttachSessionState(logCtx, existingState, sessionID, ag.Type(), transcriptPath, checkpointID, meta, tokenUsage, opts); err != nil {
 		logging.Warn(logCtx, "failed to save session state", "error", err)
 	}
 
@@ -208,7 +276,7 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 
 	fmt.Fprintf(w, "  Created checkpoint %s\n", checkpointID)
 	cpIDStr := checkpointID.String()
-	if err := promptAmendCommit(logCtx, w, headCommit, cpIDStr, force); err != nil {
+	if err := promptAmendCommit(logCtx, w, headCommit, cpIDStr, opts.Force); err != nil {
 		logging.Warn(logCtx, "failed to amend commit", "error", err)
 		fmt.Fprintf(w, "\nCopy to your commit message to attach:\n\n  Entire-Checkpoint: %s\n", cpIDStr)
 	}
@@ -265,7 +333,7 @@ func resolveCheckpointID(headCommit *object.Commit) (id.CheckpointID, bool) {
 
 // saveAttachSessionState creates or updates the session state file for the attached session.
 // If existingState is non-nil, it is updated in place (avoids a redundant disk load).
-func saveAttachSessionState(ctx context.Context, existingState *session.State, sessionID string, agentType types.AgentType, transcriptPath string, checkpointID id.CheckpointID, meta transcriptMetadata, tokenUsage *agent.TokenUsage) error {
+func saveAttachSessionState(ctx context.Context, existingState *session.State, sessionID string, agentType types.AgentType, transcriptPath string, checkpointID id.CheckpointID, meta transcriptMetadata, tokenUsage *agent.TokenUsage, opts attachOptions) error {
 	stateStore, err := session.NewStateStore(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to open session store: %w", err)
@@ -298,6 +366,11 @@ func saveAttachSessionState(ctx context.Context, existingState *session.State, s
 	}
 	if tokenUsage != nil {
 		state.TokenUsage = tokenUsage
+	}
+	if opts.ReviewSkills != nil {
+		state.Kind = session.KindAgentReview
+		state.ReviewSkills = opts.ReviewSkills
+		state.ReviewPrompt = meta.FirstPrompt
 	}
 
 	if err := stateStore.Save(ctx, state); err != nil {

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -54,7 +54,7 @@ func TestAttach_TranscriptNotFound(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	var out bytes.Buffer
-	err := runAttach(context.Background(), &out, "nonexistent-session-id", agent.AgentNameClaudeCode, true)
+	err := runAttach(context.Background(), &out, "nonexistent-session-id", agent.AgentNameClaudeCode, attachOptions{Force: true})
 	if err == nil {
 		t.Fatal("expected error for missing transcript")
 	}
@@ -71,7 +71,7 @@ func TestAttach_Success(t *testing.T) {
 `)
 
 	var out bytes.Buffer
-	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, true)
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true})
 	if err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestAttach_SessionAlreadyTracked_NoCheckpoint(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err = runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, true)
+	err = runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true})
 	if err != nil {
 		t.Fatalf("expected attach to handle already-tracked session, got error: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestAttach_OutputContainsCheckpointID(t *testing.T) {
 `)
 
 	var out bytes.Buffer
-	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, true)
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true})
 	if err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestAttach_V2DualWriteEnabled(t *testing.T) {
 `)
 
 	var out bytes.Buffer
-	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, true); err != nil {
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
 
@@ -239,7 +239,7 @@ func TestAttach_V2DualWriteDisabled(t *testing.T) {
 `)
 
 	var out bytes.Buffer
-	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, true); err != nil {
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
 
@@ -264,7 +264,7 @@ func TestAttach_PopulatesTokenUsage(t *testing.T) {
 `)
 
 	var out bytes.Buffer
-	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, true); err != nil {
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
 
@@ -295,7 +295,7 @@ func TestAttach_SetsSessionTurnCount(t *testing.T) {
 `)
 
 	var out bytes.Buffer
-	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, true); err != nil {
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
 
@@ -437,7 +437,7 @@ func TestAttach_GeminiSubdirectorySession(t *testing.T) {
 	t.Setenv("ENTIRE_TEST_GEMINI_PROJECT_DIR", emptyProjectDir)
 
 	var out bytes.Buffer
-	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameGemini, true)
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameGemini, attachOptions{Force: true})
 	if err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
@@ -482,7 +482,7 @@ func TestAttach_GeminiSuccess(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameGemini, true)
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameGemini, attachOptions{Force: true})
 	if err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
@@ -530,7 +530,7 @@ func TestAttach_CursorSuccess(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameCursor, true)
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameCursor, attachOptions{Force: true})
 	if err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
@@ -579,7 +579,7 @@ func TestAttach_CodexSuccess(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameCodex, true)
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameCodex, attachOptions{Force: true})
 	if err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
@@ -628,7 +628,7 @@ func TestAttach_FactoryAIDroidSuccess(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameFactoryAIDroid, true)
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameFactoryAIDroid, attachOptions{Force: true})
 	if err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
@@ -676,13 +676,181 @@ func TestAttach_CursorNestedLayout(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameCursor, true)
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameCursor, attachOptions{Force: true})
 	if err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
 
 	if !strings.Contains(out.String(), "Attached session") {
 		t.Errorf("expected 'Attached session' in output, got: %s", out.String())
+	}
+}
+
+// TestAttach_WithReviewFlag exercises runAttach with review mode: the
+// attached session must be tagged Kind=agent_review with the given skills
+// and the transcript's first prompt captured as ReviewPrompt.
+func TestAttach_WithReviewFlag(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	sessionID := "test-attach-review-001"
+	firstPrompt := "please review the auth module for security issues"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"`+firstPrompt+`"},"uuid":"uuid-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Reviewing now."}]},"uuid":"uuid-2"}
+`)
+
+	var out bytes.Buffer
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{
+		Force:        true,
+		ReviewSkills: []string{"/pr-review-toolkit:review-pr", "/test-auditor"},
+	})
+	if err != nil {
+		t.Fatalf("runAttach failed: %v", err)
+	}
+
+	store, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil {
+		t.Fatal("expected session state to be created")
+	}
+	if state.Kind != session.KindAgentReview {
+		t.Errorf("Kind = %q, want %q", state.Kind, session.KindAgentReview)
+	}
+	if len(state.ReviewSkills) != 2 {
+		t.Errorf("ReviewSkills = %v, want 2 entries", state.ReviewSkills)
+	}
+	if state.ReviewPrompt != firstPrompt {
+		t.Errorf("ReviewPrompt = %q, want %q", state.ReviewPrompt, firstPrompt)
+	}
+}
+
+// TestAttach_ReviewWithExistingCheckpointErrors: attempting to tag a session
+// that already has a checkpoint is refused. Upgrading an existing
+// checkpoint's metadata to carry review fields would require rewriting the
+// entire/checkpoints/v1 tree — not supported in this first cut.
+func TestAttach_ReviewWithExistingCheckpointErrors(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	sessionID := "test-attach-review-existing"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"hello"},"uuid":"uuid-1"}
+`)
+
+	// First attach (non-review) creates a checkpoint.
+	var out bytes.Buffer
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
+		t.Fatalf("first attach failed: %v", err)
+	}
+
+	// Second attach with --review should error rather than silently
+	// linking the existing checkpoint.
+	out.Reset()
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{
+		Force:        true,
+		ReviewSkills: []string{"/pr-review-toolkit:review-pr"},
+	})
+	if err == nil {
+		t.Fatal("expected error when review-attaching a session that already has a checkpoint")
+	}
+	if !strings.Contains(err.Error(), "already has checkpoint") {
+		t.Errorf("error should mention 'already has checkpoint'; got: %v", err)
+	}
+}
+
+// TestAttachCmd_ReviewFlagUsesConfiguredSkills drives `entire attach --review`
+// end-to-end: the skills list is resolved from settings.Review when --skills
+// is not provided.
+func TestAttachCmd_ReviewFlagUsesConfiguredSkills(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	sessionID := "test-attach-review-cmd-001"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"review please"},"uuid":"uuid-1"}
+`)
+
+	// Seed review config so resolveReviewSkills has something to return.
+	if err := saveReviewConfig(context.Background(), map[string][]string{
+		"claude-code": {"/pr-review-toolkit:review-pr"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rootCmd := NewRootCmd()
+	rootCmd.SetArgs([]string{"attach", "--force", "--review", sessionID})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("attach --review failed: %v", err)
+	}
+
+	store, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil || state.Kind != session.KindAgentReview {
+		t.Errorf("expected session tagged as review; got state=%+v", state)
+	}
+	if len(state.ReviewSkills) != 1 || state.ReviewSkills[0] != "/pr-review-toolkit:review-pr" {
+		t.Errorf("ReviewSkills from config not applied: %v", state.ReviewSkills)
+	}
+}
+
+// TestReviewAttachCmd_TagsSession drives `entire review attach <id>`,
+// verifying the subcommand reaches runAttach with review options set.
+func TestReviewAttachCmd_TagsSession(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	sessionID := "test-review-attach-cmd-001"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"check this out"},"uuid":"uuid-1"}
+`)
+
+	rootCmd := NewRootCmd()
+	rootCmd.SetArgs([]string{"review", "attach", "--force", "--skills", "/custom-review", sessionID})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("review attach failed: %v", err)
+	}
+
+	store, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil || state.Kind != session.KindAgentReview {
+		t.Errorf("expected session tagged as review; got state=%+v", state)
+	}
+	if len(state.ReviewSkills) != 1 || state.ReviewSkills[0] != "/custom-review" {
+		t.Errorf("--skills override not applied: %v", state.ReviewSkills)
+	}
+}
+
+// TestAttachCmd_ReviewWithoutSkillsOrConfigErrors: the --review flag
+// requires either a --skills override or configured skills. Otherwise we
+// error rather than tagging a review with an empty skills list.
+func TestAttachCmd_ReviewWithoutSkillsOrConfigErrors(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	sessionID := "test-attach-review-no-skills"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"x"},"uuid":"uuid-1"}
+`)
+
+	rootCmd := NewRootCmd()
+	var errBuf bytes.Buffer
+	rootCmd.SetErr(&errBuf)
+	rootCmd.SetArgs([]string{"attach", "--force", "--review", sessionID})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --review is set but no skills are configured or passed")
+	}
+	if !strings.Contains(errBuf.String(), "no review skills configured") {
+		t.Errorf("expected helpful error text in stderr; got: %s", errBuf.String())
 	}
 }
 

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -763,17 +763,19 @@ func TestAttach_ReviewWithExistingCheckpointErrors(t *testing.T) {
 	}
 }
 
-// TestAttachCmd_ReviewFlagUsesConfiguredSkills drives `entire attach --review`
-// end-to-end: the skills list is resolved from settings.Review when --skills
-// is not provided.
-func TestAttachCmd_ReviewFlagUsesConfiguredSkills(t *testing.T) {
+// Regression: attach must NOT silently attach skills from the spawn-path
+// config. settings.Review[agent] is what the user would run if they used
+// `entire review`, not a claim about what ran in a given manual session.
+// Only explicit --skills counts as a user assertion; without it,
+// ReviewSkills must be empty even when config exists.
+func TestAttachCmd_ReviewDoesNotInferSkillsFromConfig(t *testing.T) {
 	setupAttachTestRepo(t)
 
-	sessionID := "test-attach-review-cmd-001"
+	sessionID := "test-attach-review-no-leak"
 	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"review please"},"uuid":"uuid-1"}
 `)
 
-	// Seed review config so resolveReviewSkills has something to return.
+	// Seed review config — the spawn-path default. Attach must ignore this.
 	if err := saveReviewConfig(context.Background(), map[string][]string{
 		"claude-code": {"/pr-review-toolkit:review-pr"},
 	}); err != nil {
@@ -797,8 +799,8 @@ func TestAttachCmd_ReviewFlagUsesConfiguredSkills(t *testing.T) {
 	if state == nil || state.Kind != session.KindAgentReview {
 		t.Errorf("expected session tagged as review; got state=%+v", state)
 	}
-	if len(state.ReviewSkills) != 1 || state.ReviewSkills[0] != "/pr-review-toolkit:review-pr" {
-		t.Errorf("ReviewSkills from config not applied: %v", state.ReviewSkills)
+	if len(state.ReviewSkills) != 0 {
+		t.Errorf("ReviewSkills leaked from spawn config: %v; want empty (no --skills passed)", state.ReviewSkills)
 	}
 }
 
@@ -877,15 +879,13 @@ func TestAttachCmd_ReviewWithoutSkillsOrConfigSucceeds(t *testing.T) {
 	}
 }
 
-// Regression: review-attach must resolve skills against the real agent,
-// not the --agent flag's default (claude-code). If a user runs
-// `entire attach --review <gemini-session-id>` without --agent, the plain
-// attach flow would auto-detect Gemini from the transcript. The review
-// path must honor that detection too — previously the cobra RunE resolved
-// review.claude-code before runAttach had a chance to detect Gemini,
-// erroring out with "no review.claude-code configured" on sessions that
-// would have attached fine without --review.
-func TestAttachCmd_ReviewAutoDetectsAgentForSkills(t *testing.T) {
+// Regression: `entire attach --review <gemini-session-id>` without
+// --agent must attach successfully. The plain attach flow already
+// auto-detects Gemini from the transcript; the review path must not
+// add a blocking pre-check against the --agent flag's default
+// (claude-code), which would have failed when claude-code had no
+// matching transcript/config.
+func TestAttachCmd_ReviewAutoDetectsAgent(t *testing.T) {
 	setupAttachTestRepo(t)
 
 	// Force claude-code transcript lookup to fail so auto-detect kicks in.
@@ -902,18 +902,8 @@ func TestAttachCmd_ReviewAutoDetectsAgentForSkills(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Seed review config for Gemini only — no claude-code entry, which is
-	// what the pre-fix code would have erroneously looked up.
-	if err := saveReviewConfig(context.Background(), map[string][]string{
-		string(agent.AgentNameGemini): {"/gemini-review-skill"},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Invoke without --agent (so the flag falls through to DefaultAgentName =
-	// claude-code). The review flow must still work because runAttach
-	// auto-detects Gemini from the transcript, then resolves
-	// review.gemini-cli post-detection.
+	// Invoke without --agent (flag falls through to DefaultAgentName =
+	// claude-code). runAttach's auto-detect should find Gemini.
 	rootCmd := NewRootCmd()
 	var errBuf, outBuf bytes.Buffer
 	rootCmd.SetErr(&errBuf)
@@ -936,9 +926,6 @@ func TestAttachCmd_ReviewAutoDetectsAgentForSkills(t *testing.T) {
 	}
 	if state.AgentType != agent.AgentTypeGemini {
 		t.Errorf("AgentType = %q, want %q (auto-detect should have found Gemini)", state.AgentType, agent.AgentTypeGemini)
-	}
-	if len(state.ReviewSkills) != 1 || state.ReviewSkills[0] != "/gemini-review-skill" {
-		t.Errorf("ReviewSkills = %v, want the Gemini-configured skill — config lookup used the wrong agent", state.ReviewSkills)
 	}
 }
 

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -764,6 +764,54 @@ func TestAttach_ReviewWithExistingCheckpointErrors(t *testing.T) {
 	}
 }
 
+// Regression for the "review-attach overwrote the existing session"
+// bug: the LastCheckpointID guard in session state only catches the case
+// where the state file tracks the checkpoint. A session that's already
+// in a checkpoint on HEAD but whose state file is missing, stale, or
+// has an empty LastCheckpointID would bypass that guard — findSessionIndex
+// would then match by SessionID and overwrite the existing session's
+// metadata. Defense-in-depth check against the on-disk checkpoint must
+// catch it too.
+func TestAttach_ReviewWithExistingCheckpointErrorsEvenWithoutSessionState(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	sessionID := "test-attach-review-no-state"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"hello"},"uuid":"uuid-1"}
+`)
+
+	// First attach (non-review) creates a checkpoint and writes session state.
+	var out bytes.Buffer
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
+		t.Fatalf("first attach failed: %v", err)
+	}
+
+	// Delete the session state file to simulate the gap: state lost but
+	// the checkpoint on disk still has the session. (Real-world triggers:
+	// state never written, state file manually removed, condensation path
+	// that didn't update LastCheckpointID.)
+	repoRoot := mustGetwd(t)
+	stateFile := filepath.Join(repoRoot, ".git", "entire-sessions", sessionID+".json")
+	if err := os.Remove(stateFile); err != nil {
+		t.Fatalf("remove state file: %v", err)
+	}
+
+	// Second attach with --review must error. Without the defense-in-depth
+	// guard, this call would silently overwrite the existing session's
+	// metadata in the checkpoint with review-flavored metadata.
+	out.Reset()
+	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{
+		Force:                true,
+		Review:               true,
+		ReviewSkillsOverride: []string{"/pr-review-toolkit:review-pr"},
+	})
+	if err == nil {
+		t.Fatal("expected error when review-attaching a session already recorded in HEAD's checkpoint, even without session state")
+	}
+	if !strings.Contains(err.Error(), "already recorded in checkpoint") {
+		t.Errorf("error should mention 'already recorded in checkpoint'; got: %v", err)
+	}
+}
+
 // Regression: attach must NOT silently attach skills from the spawn-path
 // config. settings.Review[agent] is what the user would run if they used
 // `entire review`, not a claim about what ran in a given manual session.

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -700,8 +700,9 @@ func TestAttach_WithReviewFlag(t *testing.T) {
 
 	var out bytes.Buffer
 	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{
-		Force:        true,
-		ReviewSkills: []string{"/pr-review-toolkit:review-pr", "/test-auditor"},
+		Force:                true,
+		Review:               true,
+		ReviewSkillsOverride: []string{"/pr-review-toolkit:review-pr", "/test-auditor"},
 	})
 	if err != nil {
 		t.Fatalf("runAttach failed: %v", err)
@@ -750,8 +751,9 @@ func TestAttach_ReviewWithExistingCheckpointErrors(t *testing.T) {
 	// linking the existing checkpoint.
 	out.Reset()
 	err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{
-		Force:        true,
-		ReviewSkills: []string{"/pr-review-toolkit:review-pr"},
+		Force:                true,
+		Review:               true,
+		ReviewSkillsOverride: []string{"/pr-review-toolkit:review-pr"},
 	})
 	if err == nil {
 		t.Fatal("expected error when review-attaching a session that already has a checkpoint")
@@ -851,6 +853,71 @@ func TestAttachCmd_ReviewWithoutSkillsOrConfigErrors(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "no review skills configured") {
 		t.Errorf("expected helpful error text in stderr; got: %s", errBuf.String())
+	}
+}
+
+// Regression: review-attach must resolve skills against the real agent,
+// not the --agent flag's default (claude-code). If a user runs
+// `entire attach --review <gemini-session-id>` without --agent, the plain
+// attach flow would auto-detect Gemini from the transcript. The review
+// path must honor that detection too — previously the cobra RunE resolved
+// review.claude-code before runAttach had a chance to detect Gemini,
+// erroring out with "no review.claude-code configured" on sessions that
+// would have attached fine without --review.
+func TestAttachCmd_ReviewAutoDetectsAgentForSkills(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	// Force claude-code transcript lookup to fail so auto-detect kicks in.
+	t.Setenv("ENTIRE_TEST_CLAUDE_PROJECT_DIR", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	// Create a valid Gemini transcript in the expected project dir.
+	geminiDir := t.TempDir()
+	t.Setenv("ENTIRE_TEST_GEMINI_PROJECT_DIR", geminiDir)
+	sessionID := "abcd1234-review-gemini-autodetect"
+	transcriptContent := `{"messages":[{"type":"user","content":"review this"},{"type":"gemini","content":"reviewing"}]}`
+	transcriptFile := filepath.Join(geminiDir, "session-2026-01-01T10-00-abcd1234.json")
+	if err := os.WriteFile(transcriptFile, []byte(transcriptContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed review config for Gemini only — no claude-code entry, which is
+	// what the pre-fix code would have erroneously looked up.
+	if err := saveReviewConfig(context.Background(), map[string][]string{
+		string(agent.AgentNameGemini): {"/gemini-review-skill"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Invoke without --agent (so the flag falls through to DefaultAgentName =
+	// claude-code). The review flow must still work because runAttach
+	// auto-detects Gemini from the transcript, then resolves
+	// review.gemini-cli post-detection.
+	rootCmd := NewRootCmd()
+	var errBuf, outBuf bytes.Buffer
+	rootCmd.SetErr(&errBuf)
+	rootCmd.SetOut(&outBuf)
+	rootCmd.SetArgs([]string{"attach", "--force", "--review", sessionID})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("attach --review with auto-detect failed: %v\nstderr: %s", err, errBuf.String())
+	}
+
+	store, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil || state.Kind != session.KindAgentReview {
+		t.Fatalf("expected session tagged as review; got state=%+v", state)
+	}
+	if state.AgentType != agent.AgentTypeGemini {
+		t.Errorf("AgentType = %q, want %q (auto-detect should have found Gemini)", state.AgentType, agent.AgentTypeGemini)
+	}
+	if len(state.ReviewSkills) != 1 || state.ReviewSkills[0] != "/gemini-review-skill" {
+		t.Errorf("ReviewSkills = %v, want the Gemini-configured skill — config lookup used the wrong agent", state.ReviewSkills)
 	}
 }
 

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -836,23 +836,44 @@ func TestReviewAttachCmd_TagsSession(t *testing.T) {
 // TestAttachCmd_ReviewWithoutSkillsOrConfigErrors: the --review flag
 // requires either a --skills override or configured skills. Otherwise we
 // error rather than tagging a review with an empty skills list.
-func TestAttachCmd_ReviewWithoutSkillsOrConfigErrors(t *testing.T) {
+// TestAttachCmd_ReviewWithoutSkillsOrConfigSucceeds: --review must not
+// block attach when neither --skills nor configured skills exist. The
+// review is still tagged via Kind + ReviewPrompt (the session's first
+// user prompt); ReviewSkills is the queryable convenience, not the
+// source of truth, and is allowed to be empty.
+func TestAttachCmd_ReviewWithoutSkillsOrConfigSucceeds(t *testing.T) {
 	setupAttachTestRepo(t)
 
 	sessionID := "test-attach-review-no-skills"
-	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"x"},"uuid":"uuid-1"}
+	firstPrompt := "please review this change end-to-end"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"`+firstPrompt+`"},"uuid":"uuid-1"}
 `)
 
 	rootCmd := NewRootCmd()
-	var errBuf bytes.Buffer
-	rootCmd.SetErr(&errBuf)
 	rootCmd.SetArgs([]string{"attach", "--force", "--review", sessionID})
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error when --review is set but no skills are configured or passed")
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("attach --review without skills config should succeed; got error: %v", err)
 	}
-	if !strings.Contains(errBuf.String(), "no review skills configured") {
-		t.Errorf("expected helpful error text in stderr; got: %s", errBuf.String())
+
+	store, err := session.NewStateStore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state == nil {
+		t.Fatal("expected session state to be created")
+	}
+	if state.Kind != session.KindAgentReview {
+		t.Errorf("Kind = %q, want %q", state.Kind, session.KindAgentReview)
+	}
+	if state.ReviewPrompt != firstPrompt {
+		t.Errorf("ReviewPrompt = %q, want %q", state.ReviewPrompt, firstPrompt)
+	}
+	if len(state.ReviewSkills) != 0 {
+		t.Errorf("ReviewSkills = %v, want empty (no --skills, no config)", state.ReviewSkills)
 	}
 }
 

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 
 	"github.com/go-git/go-git/v6"
@@ -776,8 +777,8 @@ func TestAttachCmd_ReviewDoesNotInferSkillsFromConfig(t *testing.T) {
 `)
 
 	// Seed review config — the spawn-path default. Attach must ignore this.
-	if err := saveReviewConfig(context.Background(), map[string][]string{
-		"claude-code": {"/pr-review-toolkit:review-pr"},
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		"claude-code": {Skills: []string{"/pr-review-toolkit:review-pr"}},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -313,7 +313,13 @@ type WriteCommittedOptions struct {
 	Kind string
 
 	// ReviewSkills is the snapshot of skills used (only meaningful when Kind is a review kind).
+	// May be empty when a review is attached post-hoc without declared skills.
 	ReviewSkills []string
+
+	// ReviewPrompt is the actual text of the review request (composed prompt
+	// for spawn, first user prompt for attach). Only meaningful when Kind is
+	// a review kind.
+	ReviewPrompt string
 
 	// HasReview is set by the caller when this session should mark its
 	// checkpoint as reviewed. The caller computes this (e.g. via
@@ -489,7 +495,13 @@ type CommittedMetadata struct {
 	Kind string `json:"kind,omitempty"`
 
 	// ReviewSkills lists the review skills that were run (only set when Kind is a review kind).
+	// May be empty when a review was attached post-hoc without declared skills.
 	ReviewSkills []string `json:"review_skills,omitempty"`
+
+	// ReviewPrompt is the actual text of the review request (composed prompt
+	// for spawn, first user prompt for attach). Only set when Kind is a
+	// review kind.
+	ReviewPrompt string `json:"review_prompt,omitempty"`
 }
 
 // GetTranscriptStart returns the transcript line offset at which this checkpoint's data begins.

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -408,6 +408,7 @@ func (s *GitStore) writeSessionToSubdirectory(ctx context.Context, opts WriteCom
 		CLIVersion:                  versioninfo.Version,
 		Kind:                        opts.Kind,
 		ReviewSkills:                opts.ReviewSkills,
+		ReviewPrompt:                opts.ReviewPrompt,
 	}
 
 	metadataJSON, err := jsonutil.MarshalIndentWithNewline(sessionMetadata, "", "  ")

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -429,6 +429,7 @@ func (s *V2GitStore) writeMainSessionToSubdirectory(opts WriteCommittedOptions, 
 		CLIVersion:                  versioninfo.Version,
 		Kind:                        opts.Kind,
 		ReviewSkills:                opts.ReviewSkills,
+		ReviewPrompt:                opts.ReviewPrompt,
 	}
 
 	metadataJSON, err := jsonutil.MarshalIndentWithNewline(sessionMetadata, "", "  ")

--- a/cmd/entire/cli/integration_test/review_test.go
+++ b/cmd/entire/cli/integration_test/review_test.go
@@ -14,21 +14,23 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/session"
 )
 
-func TestReview_TrackOnly_CondensesReviewMetadataOnNextCommit(t *testing.T) {
+// TestReview_MarkerAdoptionCondensesReviewMetadataOnNextCommit exercises
+// the full adoption pipeline: a pending marker written before the agent
+// session is adopted on UserPromptSubmit, then condensed into checkpoint
+// metadata on the next git commit. The marker is written directly rather
+// than through a CLI subcommand so the test focuses on adoption behavior,
+// not on CLI wiring.
+func TestReview_MarkerAdoptionCondensesReviewMetadataOnNextCommit(t *testing.T) {
 	t.Parallel()
 
 	env := NewFeatureBranchEnv(t)
 	enableReviewAgent(t, env, "claude-code")
-	env.PatchSettings(map[string]any{
-		"review": map[string][]string{
-			"claude-code": {"/pr-review-toolkit:review-pr", "/test-auditor"},
-		},
-	})
 
-	output := env.RunCLI("review", "--track-only", "--agent", "claude-code")
-	if !strings.Contains(output, "Pending review marker written.") {
-		t.Fatalf("expected track-only confirmation, got:\n%s", output)
-	}
+	env.WritePendingReviewMarker(
+		"claude-code",
+		[]string{"/pr-review-toolkit:review-pr", "/test-auditor"},
+		env.GetHeadHash(),
+	)
 
 	sess := env.NewSession()
 	reviewPrompt := "review the branch for correctness and missing tests"
@@ -146,19 +148,18 @@ func TestReviewAttach_TagsAttachedSessionAsReview(t *testing.T) {
 	}
 }
 
-func TestReview_TrackOnly_WrongAgentDoesNotAdoptMarker(t *testing.T) {
+func TestReview_MarkerAdoption_WrongAgentDoesNotAdoptMarker(t *testing.T) {
 	t.Parallel()
 
 	env := NewFeatureBranchEnv(t)
 	enableReviewAgent(t, env, "claude-code")
 	enableReviewAgent(t, env, "gemini")
-	env.PatchSettings(map[string]any{
-		"review": map[string][]string{
-			"claude-code": {"/pr-review-toolkit:review-pr"},
-		},
-	})
 
-	env.RunCLI("review", "--track-only", "--agent", "claude-code")
+	env.WritePendingReviewMarker(
+		"claude-code",
+		[]string{"/pr-review-toolkit:review-pr"},
+		env.GetHeadHash(),
+	)
 
 	geminiSession := env.NewGeminiSession()
 	if err := env.SimulateGeminiBeforeAgent(geminiSession.ID); err != nil {
@@ -199,18 +200,17 @@ func TestReview_TrackOnly_WrongAgentDoesNotAdoptMarker(t *testing.T) {
 	}
 }
 
-func TestReview_TrackOnly_StaleMarkerIsIgnoredAfterHeadMoves(t *testing.T) {
+func TestReview_MarkerAdoption_StaleMarkerIsIgnoredAfterHeadMoves(t *testing.T) {
 	t.Parallel()
 
 	env := NewFeatureBranchEnv(t)
 	enableReviewAgent(t, env, "claude-code")
-	env.PatchSettings(map[string]any{
-		"review": map[string][]string{
-			"claude-code": {"/pr-review-toolkit:review-pr"},
-		},
-	})
 
-	env.RunCLI("review", "--track-only", "--agent", "claude-code")
+	env.WritePendingReviewMarker(
+		"claude-code",
+		[]string{"/pr-review-toolkit:review-pr"},
+		env.GetHeadHash(),
+	)
 
 	env.WriteFile("head_move.txt", "new head\n")
 	env.GitAdd("head_move.txt")

--- a/cmd/entire/cli/integration_test/review_test.go
+++ b/cmd/entire/cli/integration_test/review_test.go
@@ -1,0 +1,276 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+)
+
+func TestReview_TrackOnly_CondensesReviewMetadataOnNextCommit(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	enableReviewAgent(t, env, "claude-code")
+	env.PatchSettings(map[string]any{
+		"review": map[string][]string{
+			"claude-code": {"/pr-review-toolkit:review-pr", "/test-auditor"},
+		},
+	})
+
+	output := env.RunCLI("review", "--track-only", "--agent", "claude-code")
+	if !strings.Contains(output, "Pending review marker written.") {
+		t.Fatalf("expected track-only confirmation, got:\n%s", output)
+	}
+
+	sess := env.NewSession()
+	reviewPrompt := "review the branch for correctness and missing tests"
+	if err := env.SimulateUserPromptSubmitWithPrompt(sess.ID, reviewPrompt); err != nil {
+		t.Fatalf("SimulateUserPromptSubmitWithPrompt failed: %v", err)
+	}
+
+	state, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected review session state to be created")
+	}
+	if state.Kind != session.KindAgentReview {
+		t.Fatalf("state.Kind = %q, want %q", state.Kind, session.KindAgentReview)
+	}
+	if len(state.ReviewSkills) != 2 || state.ReviewSkills[0] != "/pr-review-toolkit:review-pr" || state.ReviewSkills[1] != "/test-auditor" {
+		t.Fatalf("state.ReviewSkills = %v", state.ReviewSkills)
+	}
+	if !strings.Contains(state.ReviewPrompt, "/pr-review-toolkit:review-pr") || !strings.Contains(state.ReviewPrompt, "/test-auditor") {
+		t.Fatalf("state.ReviewPrompt missing configured skills: %q", state.ReviewPrompt)
+	}
+
+	env.WriteFile("review_target.go", "package main\n\nfunc ReviewTarget() string { return \"ok\" }\n")
+	sess.CreateTranscript(reviewPrompt, []FileChange{
+		{Path: "review_target.go", Content: "package main\n\nfunc ReviewTarget() string { return \"ok\" }\n"},
+	})
+	if err := env.SimulateStop(sess.ID, sess.TranscriptPath); err != nil {
+		t.Fatalf("SimulateStop failed: %v", err)
+	}
+
+	env.GitCommitWithShadowHooks("add review target", "review_target.go")
+
+	checkpointID := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
+	if checkpointID == "" {
+		t.Fatal("expected Entire-Checkpoint trailer on HEAD after commit")
+	}
+
+	summary := readCheckpointSummary(t, env, checkpointID)
+	if !summary.HasReview {
+		t.Fatalf("summary.HasReview = false for checkpoint %s", checkpointID)
+	}
+
+	metadata := readSessionMetadata(t, env, checkpointID)
+	if metadata.SessionID != sess.ID {
+		t.Fatalf("metadata.SessionID = %q, want %q", metadata.SessionID, sess.ID)
+	}
+	if metadata.Kind != string(session.KindAgentReview) {
+		t.Fatalf("metadata.Kind = %q, want %q", metadata.Kind, session.KindAgentReview)
+	}
+	if len(metadata.ReviewSkills) != 2 || metadata.ReviewSkills[0] != "/pr-review-toolkit:review-pr" || metadata.ReviewSkills[1] != "/test-auditor" {
+		t.Fatalf("metadata.ReviewSkills = %v", metadata.ReviewSkills)
+	}
+	if metadata.ReviewPrompt != state.ReviewPrompt {
+		t.Fatalf("metadata.ReviewPrompt = %q, want %q", metadata.ReviewPrompt, state.ReviewPrompt)
+	}
+}
+
+func TestReviewAttach_TagsAttachedSessionAsReview(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+
+	sessionID := "review-attach-session"
+	tb := NewTranscriptBuilder()
+	tb.AddUserMessage("review the branch for security regressions")
+	tb.AddAssistantMessage("I found a few areas to check.")
+	transcriptPath := filepath.Join(env.ClaudeProjectDir, sessionID+".jsonl")
+	if err := tb.WriteToFile(transcriptPath); err != nil {
+		t.Fatalf("failed to write transcript: %v", err)
+	}
+
+	output := env.RunCLI("review", "attach", sessionID, "--force", "--agent", "claude-code", "--skills", "/pr-review-toolkit:review-pr")
+	if !strings.Contains(output, "Attached session") {
+		t.Fatalf("expected attached session output, got:\n%s", output)
+	}
+
+	checkpointID := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
+	if checkpointID == "" {
+		t.Fatal("expected Entire-Checkpoint trailer on HEAD after review attach")
+	}
+
+	state, err := env.GetSessionState(sessionID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected attached session state to be created")
+	}
+	if state.Kind != session.KindAgentReview {
+		t.Fatalf("state.Kind = %q, want %q", state.Kind, session.KindAgentReview)
+	}
+	if len(state.ReviewSkills) != 1 || state.ReviewSkills[0] != "/pr-review-toolkit:review-pr" {
+		t.Fatalf("state.ReviewSkills = %v", state.ReviewSkills)
+	}
+	if state.ReviewPrompt != "review the branch for security regressions" {
+		t.Fatalf("state.ReviewPrompt = %q", state.ReviewPrompt)
+	}
+
+	summary := readCheckpointSummary(t, env, checkpointID)
+	if !summary.HasReview {
+		t.Fatalf("summary.HasReview = false for checkpoint %s", checkpointID)
+	}
+
+	metadata := readSessionMetadata(t, env, checkpointID)
+	if metadata.Kind != string(session.KindAgentReview) {
+		t.Fatalf("metadata.Kind = %q, want %q", metadata.Kind, session.KindAgentReview)
+	}
+	if len(metadata.ReviewSkills) != 1 || metadata.ReviewSkills[0] != "/pr-review-toolkit:review-pr" {
+		t.Fatalf("metadata.ReviewSkills = %v", metadata.ReviewSkills)
+	}
+	if metadata.ReviewPrompt != "review the branch for security regressions" {
+		t.Fatalf("metadata.ReviewPrompt = %q", metadata.ReviewPrompt)
+	}
+}
+
+func TestReview_TrackOnly_WrongAgentDoesNotAdoptMarker(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	enableReviewAgent(t, env, "claude-code")
+	enableReviewAgent(t, env, "gemini")
+	env.PatchSettings(map[string]any{
+		"review": map[string][]string{
+			"claude-code": {"/pr-review-toolkit:review-pr"},
+		},
+	})
+
+	env.RunCLI("review", "--track-only", "--agent", "claude-code")
+
+	geminiSession := env.NewGeminiSession()
+	if err := env.SimulateGeminiBeforeAgent(geminiSession.ID); err != nil {
+		t.Fatalf("SimulateGeminiBeforeAgent failed: %v", err)
+	}
+
+	geminiState, err := env.GetSessionState(geminiSession.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState for Gemini session failed: %v", err)
+	}
+	if geminiState == nil {
+		t.Fatal("expected Gemini session state to be created")
+	}
+	if geminiState.Kind != "" {
+		t.Fatalf("geminiState.Kind = %q, want empty", geminiState.Kind)
+	}
+	if _, err := os.Stat(pendingReviewMarkerPath(env)); err != nil {
+		t.Fatalf("expected pending review marker to remain after wrong-agent session: %v", err)
+	}
+
+	claudeSession := env.NewSession()
+	if err := env.SimulateUserPromptSubmitWithPrompt(claudeSession.ID, "run the configured review"); err != nil {
+		t.Fatalf("SimulateUserPromptSubmitWithPrompt failed: %v", err)
+	}
+
+	claudeState, err := env.GetSessionState(claudeSession.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState for Claude session failed: %v", err)
+	}
+	if claudeState == nil {
+		t.Fatal("expected Claude session state to be created")
+	}
+	if claudeState.Kind != session.KindAgentReview {
+		t.Fatalf("claudeState.Kind = %q, want %q", claudeState.Kind, session.KindAgentReview)
+	}
+	if _, err := os.Stat(pendingReviewMarkerPath(env)); !os.IsNotExist(err) {
+		t.Fatalf("expected marker to be cleared after correct-agent adoption, err=%v", err)
+	}
+}
+
+func TestReview_TrackOnly_StaleMarkerIsIgnoredAfterHeadMoves(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	enableReviewAgent(t, env, "claude-code")
+	env.PatchSettings(map[string]any{
+		"review": map[string][]string{
+			"claude-code": {"/pr-review-toolkit:review-pr"},
+		},
+	})
+
+	env.RunCLI("review", "--track-only", "--agent", "claude-code")
+
+	env.WriteFile("head_move.txt", "new head\n")
+	env.GitAdd("head_move.txt")
+	env.GitCommit("move head before review session starts")
+
+	sess := env.NewSession()
+	if err := env.SimulateUserPromptSubmitWithPrompt(sess.ID, "run the configured review"); err != nil {
+		t.Fatalf("SimulateUserPromptSubmitWithPrompt failed: %v", err)
+	}
+
+	state, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected session state to be created")
+	}
+	if state.Kind != "" {
+		t.Fatalf("state.Kind = %q, want empty because marker is stale", state.Kind)
+	}
+	if _, err := os.Stat(pendingReviewMarkerPath(env)); !os.IsNotExist(err) {
+		t.Fatalf("expected stale marker to be cleared, err=%v", err)
+	}
+}
+
+func enableReviewAgent(t *testing.T, env *TestEnv, name string) {
+	t.Helper()
+	env.RunCLI("enable", "--agent", name, "--telemetry=false")
+}
+
+func pendingReviewMarkerPath(env *TestEnv) string {
+	return filepath.Join(env.RepoDir, ".git", "entire-sessions", "review-pending.json")
+}
+
+func readCheckpointSummary(t *testing.T, env *TestEnv, checkpointID string) checkpoint.CheckpointSummary {
+	t.Helper()
+
+	content, found := env.ReadFileFromBranch(paths.MetadataBranchName, CheckpointSummaryPath(checkpointID))
+	if !found {
+		t.Fatalf("checkpoint summary not found for %s", checkpointID)
+	}
+
+	var summary checkpoint.CheckpointSummary
+	if err := json.Unmarshal([]byte(content), &summary); err != nil {
+		t.Fatalf("failed to parse checkpoint summary: %v\n%s", err, content)
+	}
+	return summary
+}
+
+func readSessionMetadata(t *testing.T, env *TestEnv, checkpointID string) checkpoint.CommittedMetadata {
+	t.Helper()
+
+	content, found := env.ReadFileFromBranch(paths.MetadataBranchName, SessionMetadataPath(checkpointID))
+	if !found {
+		t.Fatalf("session metadata not found for %s", checkpointID)
+	}
+
+	var metadata checkpoint.CommittedMetadata
+	if err := json.Unmarshal([]byte(content), &metadata); err != nil {
+		t.Fatalf("failed to parse session metadata: %v\n%s", err, content)
+	}
+	return metadata
+}

--- a/cmd/entire/cli/integration_test/review_test.go
+++ b/cmd/entire/cli/integration_test/review_test.go
@@ -236,6 +236,35 @@ func TestReview_MarkerAdoption_StaleMarkerIsIgnoredAfterHeadMoves(t *testing.T) 
 	}
 }
 
+// TestReview_MissingSkillAtSpawn_ErrorsCleanly pins the runtime verification
+// guard: a settings file naming a nonexistent skill must cause entire review
+// to exit non-zero with a clear stderr message and leave no pending marker.
+func TestReview_MissingSkillAtSpawn_ErrorsCleanly(t *testing.T) {
+	t.Parallel()
+
+	env := NewFeatureBranchEnv(t)
+	enableReviewAgent(t, env, "claude-code")
+
+	env.WriteSettings(map[string]any{
+		"review": map[string]any{
+			"claude-code": map[string]any{
+				"skills": []string{"/nonexistent:skill-xyz"},
+			},
+		},
+	})
+
+	output, exitErr := env.RunCLIWithError("review")
+	if exitErr == nil {
+		t.Fatalf("expected non-zero exit; output:\n%s", output)
+	}
+	if !strings.Contains(output, "not installed") {
+		t.Errorf("stderr should mention skill not installed; got:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(env.RepoDir, ".git", "entire-sessions", "review-pending.json")); !os.IsNotExist(err) {
+		t.Errorf("pending marker should not exist; stat err=%v", err)
+	}
+}
+
 func enableReviewAgent(t *testing.T, env *TestEnv, name string) {
 	t.Helper()
 	env.RunCLI("enable", "--agent", name, "--telemetry=false")

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -661,6 +661,24 @@ func (env *TestEnv) WritePendingReviewMarker(agentName string, skills []string, 
 	}
 }
 
+// WriteSettings writes arbitrary JSON to .entire/settings.json. Used in
+// tests that need to seed specific config shapes before running a CLI
+// command. Overwrites any existing file.
+func (env *TestEnv) WriteSettings(m map[string]any) {
+	env.T.Helper()
+	dir := filepath.Join(env.RepoDir, ".entire")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		env.T.Fatalf("mkdir .entire: %v", err)
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		env.T.Fatalf("marshal settings: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), data, 0o600); err != nil {
+		env.T.Fatalf("write settings.json: %v", err)
+	}
+}
+
 // composeReviewPromptForTest mirrors the prompt shape runReview composes
 // so integration tests can assert against the same ReviewPrompt format
 // that spawn would produce.

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -623,6 +623,59 @@ func (env *TestEnv) GitCommitWithMultipleCheckpoints(message string, checkpointI
 	}
 }
 
+// WritePendingReviewMarker writes a review-pending marker under
+// .git/entire-sessions/, mirroring the on-disk shape that `entire
+// review` produces before spawning an agent. Used by integration tests
+// to set up adoption scenarios without running the full spawn pipeline.
+//
+// The JSON shape is duplicated here intentionally: the test shouldn't
+// import the cli package just for a struct literal, and the marker
+// format is small + stable.
+func (env *TestEnv) WritePendingReviewMarker(agentName string, skills []string, startingSHA string) {
+	env.T.Helper()
+	marker := struct {
+		AgentName    string    `json:"agent_name"`
+		Skills       []string  `json:"skills"`
+		Prompt       string    `json:"prompt,omitempty"`
+		StartingSHA  string    `json:"starting_sha"`
+		StartedAt    time.Time `json:"started_at"`
+		WorktreePath string    `json:"worktree_path,omitempty"`
+	}{
+		AgentName:    agentName,
+		Skills:       skills,
+		Prompt:       composeReviewPromptForTest(skills),
+		StartingSHA:  startingSHA,
+		StartedAt:    time.Now().UTC(),
+		WorktreePath: env.RepoDir,
+	}
+	dir := filepath.Join(env.RepoDir, ".git", "entire-sessions")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		env.T.Fatalf("failed to create sessions dir: %v", err)
+	}
+	data, err := json.MarshalIndent(marker, "", "  ")
+	if err != nil {
+		env.T.Fatalf("failed to marshal marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "review-pending.json"), data, 0o600); err != nil {
+		env.T.Fatalf("failed to write marker: %v", err)
+	}
+}
+
+// composeReviewPromptForTest mirrors the prompt shape runReview composes
+// so integration tests can assert against the same ReviewPrompt format
+// that spawn would produce.
+func composeReviewPromptForTest(skills []string) string {
+	if len(skills) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("Please run these review skills in order:\n")
+	for i, skill := range skills {
+		fmt.Fprintf(&sb, "  %d. %s\n", i+1, skill)
+	}
+	return sb.String()
+}
+
 // GetHeadHash returns the current HEAD commit hash.
 func (env *TestEnv) GetHeadHash() string {
 	env.T.Helper()

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -277,7 +277,7 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 		logging.Warn(logCtx, "failed to load session state for review marker adoption",
 			slog.String("error", loadErr.Error()))
 	} else if state != nil {
-		if updated, modified, adoptErr := adoptPendingReviewMarkerInto(logCtx, *state); adoptErr != nil {
+		if updated, modified, adoptErr := adoptPendingReviewMarkerInto(logCtx, *state, ag.Name()); adoptErr != nil {
 			logging.Warn(logCtx, "failed to adopt pending review marker",
 				slog.String("error", adoptErr.Error()))
 		} else if modified {

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -962,11 +962,12 @@ func TestAdoptPendingReviewMarker(t *testing.T) {
 	t.Chdir(tmp)
 
 	const reviewPrompt = "Please run these review skills in order:\n  1. /pr-review-toolkit:review-pr\n"
+	headSHA := testutil.GetHeadHash(t, tmp)
 	if err := WritePendingReviewMarker(context.Background(), PendingReviewMarker{
 		AgentName:   "claude-code",
 		Skills:      []string{"/pr-review-toolkit:review-pr"},
 		Prompt:      reviewPrompt,
-		StartingSHA: "abc",
+		StartingSHA: headSHA,
 		StartedAt:   time.Now().UTC(),
 	}); err != nil {
 		t.Fatal(err)
@@ -1072,10 +1073,13 @@ func TestAdoptPendingReviewMarker_OtherWorktreeLeavesMarker(t *testing.T) {
 	testutil.GitCommit(t, tmp, "init")
 	t.Chdir(tmp)
 
+	// Use the real HEAD SHA so the SHA binding doesn't interfere with the
+	// worktree-scope path this test exercises.
+	headSHA := testutil.GetHeadHash(t, tmp)
 	if err := WritePendingReviewMarker(context.Background(), PendingReviewMarker{
 		AgentName:    "claude-code",
 		Skills:       []string{"/pr-review-toolkit:review-pr"},
-		StartingSHA:  "abc",
+		StartingSHA:  headSHA,
 		StartedAt:    time.Now().UTC(),
 		WorktreePath: "/repo/main",
 	}); err != nil {
@@ -1123,6 +1127,60 @@ func TestAdoptPendingReviewMarker_OtherWorktreeLeavesMarker(t *testing.T) {
 	}
 }
 
+// Reproduces the stale-marker problem: `entire review --track-only`
+// writes a marker at SHA A, then the user commits (HEAD moves to SHA B)
+// before starting the review session. The later session must NOT adopt
+// the now-stale marker — that would tag an unrelated session as a review
+// of code that has already moved on. The stale marker is discarded so
+// future sessions start clean.
+func TestAdoptPendingReviewMarker_StaleSHAClearsMarker(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "x")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "init")
+	t.Chdir(tmp)
+
+	// Marker written at a SHA that isn't current HEAD (simulating HEAD
+	// having moved since `entire review --track-only` was invoked).
+	const staleSHA = "0000000000000000000000000000000000000000"
+	if err := WritePendingReviewMarker(context.Background(), PendingReviewMarker{
+		AgentName:    string(agent.AgentNameClaudeCode),
+		Skills:       []string{"/pr-review-toolkit:review-pr"},
+		StartingSHA:  staleSHA,
+		StartedAt:    time.Now().UTC(),
+		WorktreePath: tmp,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Matching agent + worktree, but SHA has drifted — discard the marker.
+	got, modified, err := adoptPendingReviewMarkerInto(context.Background(), session.State{
+		SessionID:    "later-session",
+		WorktreePath: tmp,
+	}, agent.AgentNameClaudeCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modified {
+		t.Fatal("expected modified=false when marker SHA != current HEAD SHA")
+	}
+	if got.Kind != "" {
+		t.Errorf("Kind = %q, want empty (stale marker must not tag session)", got.Kind)
+	}
+
+	// Marker must be CLEARED (not left in place) — no future session will
+	// legitimately match the stale SHA, so leaving it would let it mis-tag
+	// subsequent unrelated sessions.
+	_, markerPresent, readErr := ReadPendingReviewMarker(context.Background())
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if markerPresent {
+		t.Error("expected stale marker to be cleared, not preserved")
+	}
+}
+
 // Reproduces the agent-mismatch steal: `entire review` writes a marker for
 // claude-code, but a cursor session fires its UserPromptSubmit hook first in
 // the same worktree. The wrong-agent session must NOT claim the marker —
@@ -1136,10 +1194,13 @@ func TestAdoptPendingReviewMarker_DifferentAgentLeavesMarker(t *testing.T) {
 	testutil.GitCommit(t, tmp, "init")
 	t.Chdir(tmp)
 
+	// Use the real HEAD SHA so the SHA binding doesn't interfere with the
+	// agent-scope path this test exercises.
+	headSHA := testutil.GetHeadHash(t, tmp)
 	if err := WritePendingReviewMarker(context.Background(), PendingReviewMarker{
 		AgentName:    string(agent.AgentNameClaudeCode),
 		Skills:       []string{"/pr-review-toolkit:review-pr"},
-		StartingSHA:  "abc",
+		StartingSHA:  headSHA,
 		StartedAt:    time.Now().UTC(),
 		WorktreePath: tmp,
 	}); err != nil {

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -1127,12 +1127,12 @@ func TestAdoptPendingReviewMarker_OtherWorktreeLeavesMarker(t *testing.T) {
 	}
 }
 
-// Reproduces the stale-marker problem: `entire review --track-only`
-// writes a marker at SHA A, then the user commits (HEAD moves to SHA B)
-// before starting the review session. The later session must NOT adopt
-// the now-stale marker — that would tag an unrelated session as a review
-// of code that has already moved on. The stale marker is discarded so
-// future sessions start clean.
+// Reproduces the stale-marker problem: `entire review` for a non-
+// launchable agent writes a marker at SHA A, then the user commits
+// (HEAD moves to SHA B) before starting the review session. The later
+// session must NOT adopt the now-stale marker — that would tag an
+// unrelated session as a review of code that has already moved on.
+// The stale marker is discarded so future sessions start clean.
 func TestAdoptPendingReviewMarker_StaleSHAClearsMarker(t *testing.T) {
 	tmp := t.TempDir()
 	testutil.InitRepo(t, tmp)
@@ -1142,7 +1142,8 @@ func TestAdoptPendingReviewMarker_StaleSHAClearsMarker(t *testing.T) {
 	t.Chdir(tmp)
 
 	// Marker written at a SHA that isn't current HEAD (simulating HEAD
-	// having moved since `entire review --track-only` was invoked).
+	// having moved since `entire review` was invoked for a non-launchable
+	// agent and the user then committed before starting the session).
 	const staleSHA = "0000000000000000000000000000000000000000"
 	if err := WritePendingReviewMarker(context.Background(), PendingReviewMarker{
 		AgentName:    string(agent.AgentNameClaudeCode),

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -976,7 +976,7 @@ func TestAdoptPendingReviewMarker(t *testing.T) {
 	got, modified, err := adoptPendingReviewMarkerInto(context.Background(), session.State{
 		SessionID: "s1",
 		Kind:      "",
-	})
+	}, agent.AgentNameClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1012,7 +1012,7 @@ func TestAdoptPendingReviewMarker_NoMarker(t *testing.T) {
 	t.Chdir(tmp)
 
 	// No marker written.
-	got, modified, err := adoptPendingReviewMarkerInto(context.Background(), session.State{SessionID: "s2"})
+	got, modified, err := adoptPendingReviewMarkerInto(context.Background(), session.State{SessionID: "s2"}, agent.AgentNameClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1040,7 +1040,7 @@ func TestAdoptPendingReviewMarker_AlreadyReview(t *testing.T) {
 	}
 	// State already tagged — adoption should be a no-op (not a second re-tag).
 	in := session.State{SessionID: "s3", Kind: session.KindAgentReview, ReviewSkills: []string{"/y"}}
-	got, modified, err := adoptPendingReviewMarkerInto(context.Background(), in)
+	got, modified, err := adoptPendingReviewMarkerInto(context.Background(), in, agent.AgentNameClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1087,7 +1087,7 @@ func TestAdoptPendingReviewMarker_OtherWorktreeLeavesMarker(t *testing.T) {
 	got, modified, err := adoptPendingReviewMarkerInto(context.Background(), session.State{
 		SessionID:    "other-worktree-session",
 		WorktreePath: "/repo/.worktrees/feature",
-	})
+	}, agent.AgentNameClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1111,12 +1111,76 @@ func TestAdoptPendingReviewMarker_OtherWorktreeLeavesMarker(t *testing.T) {
 	got, modified, err = adoptPendingReviewMarkerInto(context.Background(), session.State{
 		SessionID:    "matching-worktree-session",
 		WorktreePath: "/repo/main",
-	})
+	}, agent.AgentNameClaudeCode)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !modified {
 		t.Fatal("expected modified=true when worktree matches")
+	}
+	if got.Kind != session.KindAgentReview {
+		t.Errorf("Kind = %q, want review", got.Kind)
+	}
+}
+
+// Reproduces the agent-mismatch steal: `entire review` writes a marker for
+// claude-code, but a cursor session fires its UserPromptSubmit hook first in
+// the same worktree. The wrong-agent session must NOT claim the marker —
+// whichever agent's hook happens to fire first would otherwise silently
+// steal a review meant for a different agent (with different skills).
+func TestAdoptPendingReviewMarker_DifferentAgentLeavesMarker(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "x")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "init")
+	t.Chdir(tmp)
+
+	if err := WritePendingReviewMarker(context.Background(), PendingReviewMarker{
+		AgentName:    string(agent.AgentNameClaudeCode),
+		Skills:       []string{"/pr-review-toolkit:review-pr"},
+		StartingSHA:  "abc",
+		StartedAt:    time.Now().UTC(),
+		WorktreePath: tmp,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ClearPendingReviewMarker(context.Background()) }) //nolint:errcheck // test cleanup, best-effort
+
+	// A cursor session in the same worktree must NOT adopt a claude-code marker.
+	got, modified, err := adoptPendingReviewMarkerInto(context.Background(), session.State{
+		SessionID:    "cursor-session",
+		WorktreePath: tmp,
+	}, agent.AgentNameCursor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modified {
+		t.Fatal("expected modified=false when session's agent differs from marker's agent")
+	}
+	if got.Kind != "" {
+		t.Errorf("Kind = %q, want empty (should not be tagged)", got.Kind)
+	}
+
+	// Marker must survive so the correct claude-code session can adopt later.
+	_, ok, readErr := ReadPendingReviewMarker(context.Background())
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !ok {
+		t.Fatal("expected marker preserved after mismatched-agent adoption attempt")
+	}
+
+	// Now the correct agent adopts.
+	got, modified, err = adoptPendingReviewMarkerInto(context.Background(), session.State{
+		SessionID:    "claude-session",
+		WorktreePath: tmp,
+	}, agent.AgentNameClaudeCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true when agent matches")
 	}
 	if got.Kind != session.KindAgentReview {
 		t.Errorf("Kind = %q, want review", got.Kind)

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -961,9 +961,11 @@ func TestAdoptPendingReviewMarker(t *testing.T) {
 	testutil.GitCommit(t, tmp, "init")
 	t.Chdir(tmp)
 
+	const reviewPrompt = "Please run these review skills in order:\n  1. /pr-review-toolkit:review-pr\n"
 	if err := WritePendingReviewMarker(context.Background(), PendingReviewMarker{
 		AgentName:   "claude-code",
 		Skills:      []string{"/pr-review-toolkit:review-pr"},
+		Prompt:      reviewPrompt,
 		StartingSHA: "abc",
 		StartedAt:   time.Now().UTC(),
 	}); err != nil {
@@ -986,6 +988,9 @@ func TestAdoptPendingReviewMarker(t *testing.T) {
 	}
 	if len(got.ReviewSkills) != 1 || got.ReviewSkills[0] != "/pr-review-toolkit:review-pr" {
 		t.Errorf("ReviewSkills = %v", got.ReviewSkills)
+	}
+	if got.ReviewPrompt != reviewPrompt {
+		t.Errorf("ReviewPrompt = %q, want %q", got.ReviewPrompt, reviewPrompt)
 	}
 
 	// Marker should be cleared after adoption.

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -442,9 +442,8 @@ the current commit's checkpoint. Use this when you ran a review manually
 the fact.
 
 The first user prompt in the transcript is recorded as the review
-prompt. The skills list defaults to whatever is configured under
-review.<agent> in .entire/settings.json; pass --skills to override, or
-leave both empty to attach a review without a declared skills list.
+prompt. Pass --skills to declare which skills were actually run; omit
+to attach a review without a declared skills list.
 
 Equivalent to 'entire attach --review <session-id>' — provided here for
 discoverability alongside the other review subcommands.`,
@@ -469,7 +468,7 @@ discoverability alongside the other review subcommands.`,
 	}
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation and amend the last commit with the checkpoint trailer")
 	cmd.Flags().StringVarP(&agentFlag, "agent", "a", string(agent.DefaultAgentName), "Agent that created the session")
-	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Optional review skills that were run. Default: configured skills for the agent; empty is allowed")
+	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Optional: declare which review skills were run in this session")
 	return cmd
 }
 

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -307,11 +307,44 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]str
 	if len(selected) == 0 {
 		return nil, errors.New("no review skills selected")
 	}
-	if err := saveReviewConfig(ctx, selected); err != nil {
+
+	// Merge the picker's output with existing entries the picker could not
+	// surface. Without the merge, save would replace s.Review wholesale and
+	// silently drop entries the user had configured for external agents,
+	// uncurated agents, or agents whose hooks are temporarily uninstalled —
+	// exactly the "edit settings.json manually" case the help text suggests.
+	offered := make(map[string]struct{}, len(configurable))
+	for _, c := range configurable {
+		offered[string(c.name)] = struct{}{}
+	}
+	merged := mergePickerResults(existing, offered, selected)
+
+	if err := saveReviewConfig(ctx, merged); err != nil {
 		return nil, err
 	}
 	fmt.Fprintln(out, "Saved review config to .entire/settings.json. Edit directly or run `entire review --edit`.")
-	return selected, nil
+	return merged, nil
+}
+
+// mergePickerResults combines the picker's output with existing review
+// config entries that the picker did not surface. Agents in `offered` are
+// fully controlled by the picker: if they appear in `selected` with picks
+// the entry is set, otherwise the entry is removed. Agents not in `offered`
+// keep their existing skills untouched.
+//
+// Exported via lowercase helper for testability — the picker itself can't
+// be driven headless.
+func mergePickerResults(existing map[string][]string, offered map[string]struct{}, selected map[string][]string) map[string][]string {
+	merged := make(map[string][]string, len(existing)+len(selected))
+	for name, skills := range existing {
+		if _, wasOffered := offered[name]; !wasOffered {
+			merged[name] = skills
+		}
+	}
+	for name, skills := range selected {
+		merged[name] = skills
+	}
+	return merged
 }
 
 func newReviewCmd() *cobra.Command {

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -441,8 +441,10 @@ the current commit's checkpoint. Use this when you ran a review manually
 (without 'entire review') and want the review metadata attached after
 the fact.
 
-The skills list defaults to whatever is configured under review.<agent>
-in .entire/settings.json; pass --skills to override.
+The first user prompt in the transcript is recorded as the review
+prompt. The skills list defaults to whatever is configured under
+review.<agent> in .entire/settings.json; pass --skills to override, or
+leave both empty to attach a review without a declared skills list.
 
 Equivalent to 'entire attach --review <session-id>' — provided here for
 discoverability alongside the other review subcommands.`,
@@ -467,7 +469,7 @@ discoverability alongside the other review subcommands.`,
 	}
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation and amend the last commit with the checkpoint trailer")
 	cmd.Flags().StringVarP(&agentFlag, "agent", "a", string(agent.DefaultAgentName), "Agent that created the session")
-	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Review skills that were run (default: configured skills for the agent)")
+	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Optional review skills that were run. Default: configured skills for the agent; empty is allowed")
 	return cmd
 }
 

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -335,10 +335,6 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]str
 			selected[string(c.name)] = picks
 		}
 	}
-	if len(selected) == 0 {
-		return nil, errors.New("no review skills selected")
-	}
-
 	// Merge the picker's output with existing entries the picker could not
 	// surface. Without the merge, save would replace s.Review wholesale and
 	// silently drop entries the user had configured for external agents,
@@ -349,6 +345,15 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]str
 		offered[string(c.name)] = struct{}{}
 	}
 	merged := mergePickerResults(existing, offered, selected)
+
+	// The emptiness check runs on `merged`, not `selected`: a user
+	// deliberately deselecting all curated agents while keeping existing
+	// external-agent entries is a valid outcome that must be saveable. Only
+	// refuse if the final config would be empty — i.e., no picks AND no
+	// pre-existing entries to preserve.
+	if len(merged) == 0 {
+		return nil, errors.New("no review skills selected")
+	}
 
 	if err := saveReviewConfig(ctx, merged); err != nil {
 		return nil, err

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -157,8 +157,9 @@ func sameWorktreePath(a, b string) bool {
 // the marker is left in place and modified=false — adoption only happens on
 // first tag. The marker is cleared on successful first adoption.
 //
-// Scoping rules — the marker is left untouched (not cleared) when any of
-// these don't match, so the correct session has a chance to claim it:
+// Scoping rules — the marker is left untouched (not cleared) when a scope
+// mismatch still leaves open the possibility that a future session could
+// legitimately claim it:
 //
 //   - WorktreePath: a Claude session in worktree A must not claim a marker
 //     meant for a session `entire review` spawned in worktree B. Both
@@ -168,8 +169,13 @@ func sameWorktreePath(a, b string) bool {
 //     and whichever session fires its UserPromptSubmit hook first would
 //     otherwise silently steal the wrong agent's review metadata.
 //
-// Pre-fix markers with empty WorktreePath/AgentName fall back to unscoped
-// adoption for each missing field (backwards compat).
+// StartingSHA is different: once HEAD moves past the marker's commit, no
+// future session will meaningfully match the original review intent.
+// A stale marker is cleared rather than left to mis-tag a later unrelated
+// session.
+//
+// Pre-fix markers with empty fields fall back to unscoped adoption for
+// each missing field (backwards compat).
 func adoptPendingReviewMarkerInto(ctx context.Context, s session.State, agentName types.AgentName) (session.State, bool, error) {
 	// Already tagged — don't re-apply on subsequent turns.
 	if s.Kind != "" {
@@ -193,6 +199,31 @@ func adoptPendingReviewMarkerInto(ctx context.Context, s session.State, agentNam
 		// correct agent's session will reach its own hook and claim the
 		// marker.
 		return s, false, nil
+	}
+	// SHA drift: the marker was written for a specific commit. If HEAD has
+	// moved since, the user's intent (review THAT commit) no longer applies
+	// to this session, and we'd otherwise silently tag an unrelated session
+	// as a review. Discard the stale marker rather than adopting it or
+	// leaving it in place to mis-tag a later session.
+	//
+	// Failure to resolve HEAD is non-fatal: adoption is best-effort, and
+	// crashing a legitimate review because git rev-parse hiccupped would be
+	// worse than skipping the check.
+	if m.StartingSHA != "" {
+		headSHA, headErr := currentHeadSHA(ctx)
+		switch {
+		case headErr != nil:
+			logging.Debug(ctx, "adopt marker: resolve HEAD failed, skipping SHA check",
+				slog.String("error", headErr.Error()))
+		case headSHA != m.StartingSHA:
+			logging.Warn(ctx, "adopt marker: HEAD moved since marker was written; discarding stale marker",
+				slog.String("marker_sha", m.StartingSHA),
+				slog.String("head_sha", headSHA))
+			if clearErr := ClearPendingReviewMarker(ctx); clearErr != nil {
+				logging.Debug(ctx, "failed to clear stale marker", slog.String("error", clearErr.Error()))
+			}
+			return s, false, nil
+		}
 	}
 	s.Kind = session.KindAgentReview
 	s.ReviewSkills = m.Skills

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -45,8 +45,12 @@ const pendingReviewMarkerFilename = "review-pending.json"
 // blank WorktreePath (pre-fix markers) falls back to the legacy unscoped
 // behavior — any session can adopt.
 type PendingReviewMarker struct {
-	AgentName    string    `json:"agent_name"`
-	Skills       []string  `json:"skills"`
+	AgentName string   `json:"agent_name"`
+	Skills    []string `json:"skills"`
+	// Prompt is the composed review prompt the agent will receive.
+	// Stored on the marker (rather than recomputed on adoption) so session
+	// metadata records exactly what the agent was asked to do.
+	Prompt       string    `json:"prompt,omitempty"`
 	StartingSHA  string    `json:"starting_sha"`
 	StartedAt    time.Time `json:"started_at"`
 	WorktreePath string    `json:"worktree_path,omitempty"`
@@ -179,6 +183,7 @@ func adoptPendingReviewMarkerInto(ctx context.Context, s session.State) (session
 	}
 	s.Kind = session.KindAgentReview
 	s.ReviewSkills = m.Skills
+	s.ReviewPrompt = m.Prompt
 	if err := ClearPendingReviewMarker(ctx); err != nil {
 		// Tagging succeeded; leftover marker self-heals on next session start
 		// (since Kind is now set, the next turn will return modified=false
@@ -416,10 +421,15 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool, agentOve
 		return fmt.Errorf("resolve worktree root: %w", err)
 	}
 
-	// 6. Write pending marker (agent hook will adopt it).
+	// 6. Compose the review prompt once, then write the pending marker. The
+	// composed prompt is carried on the marker so adoption records exactly
+	// what the agent was asked to do (the same string passed to LaunchCmd
+	// below), rather than recomposing from skills on the hook side.
+	prompt := composeReviewPrompt(skills)
 	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
 		AgentName:    agentName,
 		Skills:       skills,
+		Prompt:       prompt,
 		StartingSHA:  headSHA,
 		StartedAt:    time.Now().UTC(),
 		WorktreePath: worktreeRoot,
@@ -469,7 +479,6 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool, agentOve
 	if scope, scopeErr := detectReviewScope(ctx); scopeErr == nil {
 		fmt.Fprintln(out, formatReviewScope(scope))
 	}
-	prompt := composeReviewPrompt(skills)
 	execCmd, err := launcher.LaunchCmd(ctx, prompt)
 	if err != nil {
 		return fmt.Errorf("launch %s: %w", agentName, err)

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -558,6 +558,20 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string) er
 		return NewSilentError(fmt.Errorf("hooks not installed for %s", agentName))
 	}
 
+	// 3.6. Verify configured skills are actually installed on disk. Catches
+	// the hand-edited-settings.json case where the user named a skill that
+	// doesn't exist; without this guard the agent would spawn and fail
+	// silently with "I don't have that skill".
+	ag, agErr := agent.Get(types.AgentName(agentName))
+	if agErr != nil {
+		return fmt.Errorf("resolve agent %s: %w", agentName, agErr)
+	}
+	if err := verifyConfiguredSkillsInstalled(ctx, ag, cfg); err != nil {
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+		return NewSilentError(err)
+	}
+
 	// 4. Re-run guard: check if HEAD's checkpoint already has a review.
 	if reviewed, meta := headHasReviewCheckpoint(ctx); reviewed {
 		var proceed bool
@@ -680,6 +694,48 @@ func selectReviewAgent(review map[string]settings.ReviewConfig, override string)
 	}
 	pick := names[0]
 	return pick, review[pick], nil
+}
+
+// verifyConfiguredSkillsInstalled is the spawn-time backstop for the
+// silent-failure vector. For each skill in cfg.Skills, check it's either a
+// curated built-in or returned by the agent's SkillDiscoverer; fail with a
+// user-facing error if any skill is missing. Empty Skills (prompt-only
+// config) short-circuits to nil — a freeform prompt has no skill list to
+// validate against.
+func verifyConfiguredSkillsInstalled(ctx context.Context, ag agent.Agent, cfg settings.ReviewConfig) error {
+	if len(cfg.Skills) == 0 {
+		return nil
+	}
+	builtins := builtinNameSet(skilldiscovery.CuratedBuiltinsFor(string(ag.Name())))
+	discoveredNames := map[string]struct{}{}
+	if d, ok := ag.(agent.SkillDiscoverer); ok {
+		if skills, err := d.DiscoverReviewSkills(ctx); err == nil {
+			for _, s := range skills {
+				discoveredNames[s.Name] = struct{}{}
+			}
+		} else {
+			logging.Debug(ctx, "skill verification discovery failed",
+				slog.String("agent", string(ag.Name())), slog.String("error", err.Error()))
+		}
+	}
+	var missing []string
+	for _, s := range cfg.Skills {
+		if _, ok := builtins[s]; ok {
+			continue
+		}
+		if _, ok := discoveredNames[s]; ok {
+			continue
+		}
+		missing = append(missing, s)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"configured review skill(s) not installed: %s\n"+
+			"run `entire review --edit` to reconfigure, or install the plugin and retry",
+		strings.Join(missing, ", "),
+	)
 }
 
 // composeReviewPrompt builds the prompt sent to the agent from a

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -238,6 +238,41 @@ func adoptPendingReviewMarkerInto(ctx context.Context, s session.State, agentNam
 	return s, true, nil
 }
 
+// confirmFirstRunSetup prints a banner framing the picker as first-run
+// setup (rather than the review itself) and waits for the user to confirm.
+// Returns false if the user cancels; caller should bail gracefully.
+//
+// Signposting matters here because `entire review` with no config silently
+// drops into the picker — users running the command to start a review can
+// mistake the picker for the review. The banner + confirmation makes the
+// setup phase explicit, and the trailing "running review now" line in the
+// caller closes the loop on what comes next.
+func confirmFirstRunSetup(out io.Writer) bool {
+	fmt.Fprintln(out, "No review config found — let's set one up first.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "You'll pick skills for each installed agent. They're saved to")
+	fmt.Fprintln(out, ".entire/settings.json; edit later with `entire review --edit`.")
+	fmt.Fprintln(out, "After setup, the review will run with your selection.")
+	fmt.Fprintln(out)
+
+	proceed := true
+	form := NewAccessibleForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title("Set up review skills now?").
+			Affirmative("Yes").
+			Negative("Cancel").
+			Value(&proceed),
+	))
+	if err := form.Run(); err != nil {
+		fmt.Fprintln(out, "Setup cancelled.")
+		return false
+	}
+	if !proceed {
+		fmt.Fprintln(out, "Setup cancelled.")
+	}
+	return proceed
+}
+
 // runReviewConfigPicker presents a huh multi-select for each installed agent
 // that has curated review skills, and saves the selection to
 // .entire/settings.json. Previously-saved skills are pre-checked via
@@ -495,6 +530,9 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool, agentOve
 		return NewSilentError(err)
 	}
 	if s == nil || len(s.Review) == 0 {
+		if !confirmFirstRunSetup(out) {
+			return nil
+		}
 		picked, pickErr := runReviewConfigPicker(ctx, out)
 		if pickErr != nil {
 			return pickErr
@@ -503,6 +541,8 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool, agentOve
 			s = &settings.EntireSettings{}
 		}
 		s.Review = picked
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, "Setup complete — running review now.")
 	}
 
 	// 3. Pick agent.

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -405,6 +405,19 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool) error {
 		return nil
 	}
 
+	// 7. Resolve launcher BEFORE installing the cleanup defer. Non-launchable
+	// agents fall back to the same persist-marker behavior as --track-only:
+	// the user starts the agent manually and its UserPromptSubmit hook adopts
+	// the marker. If we registered the defer first, it would wipe the marker
+	// on this return path, silently breaking the fallback the message
+	// promises the user.
+	launcher, ok := agent.LauncherFor(types.AgentName(agentName))
+	if !ok {
+		fmt.Fprintf(out, "%s does not support subprocess launch yet. Falling back to --track-only.\n", agentName)
+		fmt.Fprintf(out, "Start %s manually and run: %s\n", agentName, strings.Join(skills, ", "))
+		return nil
+	}
+
 	// From this point on, the marker lives on disk until either (a) the
 	// spawned agent's hook adopts and clears it, or (b) we clear it here
 	// as a fallback. The defer covers every spawn/launch/run failure path,
@@ -420,14 +433,6 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool) error {
 			logging.Debug(ctx, "cleanup unadopted review marker", slog.String("error", clearErr.Error()))
 		}
 	}()
-
-	// 7. Spawn agent with the composed initial prompt.
-	launcher, ok := agent.LauncherFor(types.AgentName(agentName))
-	if !ok {
-		fmt.Fprintf(out, "%s does not support subprocess launch yet. Falling back to --track-only.\n", agentName)
-		fmt.Fprintf(out, "Start %s manually and run: %s\n", agentName, strings.Join(skills, ", "))
-		return nil
-	}
 	// Best-effort: show the user what's in scope so they can tell whether
 	// the review target is what they expected. Failures are silent — scope
 	// is informational, not load-bearing.

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
+	"github.com/entireio/cli/cmd/entire/cli/agent/skilldiscovery"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
@@ -117,32 +118,7 @@ func ClearPendingReviewMarker(ctx context.Context) error {
 	return nil
 }
 
-// curatedSkill represents a known review skill/command surfaced by the
-// first-run picker. Users can add custom skills by editing
-// .entire/settings.json directly.
-type curatedSkill struct {
-	Name string
-	Desc string
-}
-
-// curatedReviewSkills groups known review skills by agent name (as a string
-// matching types.AgentName values). Agents not listed here still work via
-// the picker — users just see an empty list and should edit settings.json
-// manually to add skills.
-var curatedReviewSkills = map[string][]curatedSkill{
-	"claude-code": {
-		{Name: "/pr-review-toolkit:review-pr", Desc: "Full PR review"},
-		{Name: "/pr-review-toolkit:code-reviewer", Desc: "Code review for standards"},
-		{Name: "/test-auditor", Desc: "Test coverage audit"},
-		{Name: "/verification-before-completion", Desc: "Verify before marking done"},
-		{Name: "/requesting-code-review", Desc: "Prepare code for review"},
-		{Name: "/pr-review-toolkit:silent-failure-hunter", Desc: "Find suppressed errors"},
-	},
-	"codex": {
-		{Name: "/codex:review", Desc: "Codex review"},
-		{Name: "/codex:adversarial-review", Desc: "Adversarial review — red-team"},
-	},
-}
+// Curated built-ins and install hints live in package skilldiscovery.
 
 // sameWorktreePath compares two worktree paths after filepath.Clean. Both
 // paths come from paths.WorktreeRoot, so an exact-bytes match is expected in
@@ -296,8 +272,7 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string]setti
 	}
 	var configurable []configurableAgent
 	for _, name := range installed {
-		curated, ok := curatedReviewSkills[string(name)]
-		if !ok || len(curated) == 0 {
+		if !skilldiscovery.IsEligible(string(name)) {
 			continue
 		}
 		ag, err := agent.Get(name)
@@ -338,49 +313,53 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string]setti
 
 	selected := map[string]settings.ReviewConfig{}
 	for i, c := range configurable {
-		curated := curatedReviewSkills[string(c.name)]
-		savedSet := map[string]struct{}{}
-		for _, s := range existing[string(c.name)].Skills {
-			savedSet[s] = struct{}{}
-		}
+		curated := skilldiscovery.CuratedBuiltinsFor(string(c.name))
 
-		options := make([]huh.Option[string], 0, len(curated))
-		for _, s := range curated {
-			opt := huh.NewOption(fmt.Sprintf("%s — %s", s.Name, s.Desc), s.Name)
-			if _, ok := savedSet[s.Name]; ok {
-				opt = opt.Selected(true)
+		// Discover + dedupe + filter hints.
+		var discovered []agent.DiscoveredSkill
+		if d, ok := c.ag.(agent.SkillDiscoverer); ok {
+			if ds, dErr := d.DiscoverReviewSkills(ctx); dErr == nil {
+				discovered = ds
+			} else {
+				logging.Debug(ctx, "review discovery failed",
+					slog.String("agent", string(c.name)), slog.String("error", dErr.Error()))
 			}
-			options = append(options, opt)
 		}
+		builtinNames := builtinNameSet(curated)
+		discovered = filterOutBuiltinCollisions(discovered, builtinNames)
 
-		// huh populates picks from Option.Selected(true) — do NOT pre-seed,
-		// matching the convention used in detectOrSelectAgent (setup.go).
-		var picks []string
-		// Seed prompt input with the previously-saved value so users can
-		// tweak it without retyping.
+		discoveredSet := make(map[string]struct{}, len(discovered))
+		for _, d := range discovered {
+			discoveredSet[d.Name] = struct{}{}
+		}
+		activeHints := skilldiscovery.ActiveInstallHintsFor(string(c.name), discoveredSet)
+
+		var builtinPicks, discoveredPicks []string
 		prompt := existing[string(c.name)].Prompt
 
-		title := fmt.Sprintf("[%d/%d] Review skills for %s", i+1, len(configurable), c.ag.Type())
-		form := NewAccessibleForm(
-			huh.NewGroup(
-				huh.NewMultiSelect[string]().
-					Title(title).
-					Description(fmt.Sprintf("Agent: %s", c.ag.Type())).
-					Options(options...).
-					Value(&picks),
-			),
-			huh.NewGroup(
-				huh.NewText().
-					Title("Additional instructions (optional)").
-					Description("Used verbatim as the review prompt when set. Leave blank to use the default 'run these skills in order' template.").
-					Value(&prompt),
-			),
+		fields := buildReviewPickerFields(
+			string(c.name), curated, discovered, activeHints, prompt,
+			&builtinPicks, &discoveredPicks, &prompt,
 		)
+
+		// huh's Group has no .Title(), so the counter goes on the first field
+		// via type assertion. If the interface assertion fails (e.g. future huh
+		// refactor changes method sets), we silently skip the counter — UI nit,
+		// not a correctness issue.
+		title := fmt.Sprintf("[%d/%d] Review skills for %s", i+1, len(configurable), c.ag.Type())
+		if titleable, ok := fields[0].(interface {
+			Title(t string) huh.Field
+		}); ok {
+			fields[0] = titleable.Title(title)
+		}
+
+		form := NewAccessibleForm(huh.NewGroup(fields...))
 		if err := form.Run(); err != nil {
 			return nil, fmt.Errorf("picker for %s: %w", c.name, err)
 		}
+
 		cfg := settings.ReviewConfig{
-			Skills: picks,
+			Skills: dedupeStrings(append(builtinPicks, discoveredPicks...)),
 			Prompt: strings.TrimSpace(prompt),
 		}
 		if !cfg.IsZero() {
@@ -928,4 +907,129 @@ func saveReviewConfig(ctx context.Context, review map[string]settings.ReviewConf
 		return fmt.Errorf("save settings: %w", err)
 	}
 	return nil
+}
+
+// buildReviewPickerFields composes the per-agent group fields for the
+// review picker. Returns a slice of huh.Field in render order:
+//
+//	0: built-in commands (multiselect) OR note
+//	1: installed plugin skills (multiselect) OR note
+//	2: install hints (note with all active hint messages) — OMITTED if empty
+//	3: additional instructions (text) — always present
+//
+// Pure function — no side effects, no huh form running — so unit-testable.
+// Value bindings (builtinPicksOut, discoveredPicksOut, promptOut) may be
+// nil when the caller only needs the field count (tests).
+func buildReviewPickerFields(
+	agentName string,
+	builtins []skilldiscovery.CuratedSkill,
+	discovered []agent.DiscoveredSkill,
+	activeHints []skilldiscovery.InstallHint,
+	previousPrompt string,
+	builtinPicksOut, discoveredPicksOut *[]string,
+	promptOut *string,
+) []huh.Field {
+	var fields []huh.Field
+
+	if len(builtins) > 0 {
+		opts := make([]huh.Option[string], 0, len(builtins))
+		for _, b := range builtins {
+			opts = append(opts, huh.NewOption(fmt.Sprintf("%s — %s", b.Name, b.Desc), b.Name))
+		}
+		ms := huh.NewMultiSelect[string]().Title("Built-in commands").Options(opts...)
+		if builtinPicksOut != nil {
+			ms = ms.Value(builtinPicksOut)
+		}
+		fields = append(fields, ms)
+	} else {
+		fields = append(fields, huh.NewNote().
+			Title("Built-in commands").
+			Description(fmt.Sprintf("No built-in review commands in %s.", agentName)))
+	}
+
+	if len(discovered) > 0 {
+		opts := make([]huh.Option[string], 0, len(discovered))
+		for _, d := range discovered {
+			label := d.Name
+			if d.Description != "" {
+				label = fmt.Sprintf("%s — %s", d.Name, d.Description)
+			}
+			opts = append(opts, huh.NewOption(label, d.Name))
+		}
+		ms := huh.NewMultiSelect[string]().Title("Installed plugin skills").Options(opts...)
+		if discoveredPicksOut != nil {
+			ms = ms.Value(discoveredPicksOut)
+		}
+		fields = append(fields, ms)
+	} else {
+		fields = append(fields, huh.NewNote().
+			Title("Installed plugin skills").
+			Description("No plugin review skills detected on disk."))
+	}
+
+	if len(activeHints) > 0 {
+		var sb strings.Builder
+		for i, h := range activeHints {
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString("• ")
+			sb.WriteString(h.Message)
+		}
+		fields = append(fields, huh.NewNote().
+			Title("Install more").
+			Description(sb.String()))
+	}
+
+	text := huh.NewText().
+		Title("Additional instructions (optional)").
+		Description("Used verbatim as the review prompt when set. Leave blank to use the default 'run these skills in order' template.")
+	if promptOut != nil {
+		*promptOut = previousPrompt
+		text = text.Value(promptOut)
+	}
+	fields = append(fields, text)
+
+	return fields
+}
+
+func builtinNameSet(curated []skilldiscovery.CuratedSkill) map[string]struct{} {
+	set := make(map[string]struct{}, len(curated))
+	for _, c := range curated {
+		set[c.Name] = struct{}{}
+	}
+	return set
+}
+
+// filterOutBuiltinCollisions drops any discovered skill whose name collides
+// with a curated built-in. Built-in wins because it carries a richer,
+// hand-authored description.
+func filterOutBuiltinCollisions(discovered []agent.DiscoveredSkill, builtins map[string]struct{}) []agent.DiscoveredSkill {
+	if len(discovered) == 0 || len(builtins) == 0 {
+		return discovered
+	}
+	out := make([]agent.DiscoveredSkill, 0, len(discovered))
+	for _, d := range discovered {
+		if _, clash := builtins[d.Name]; clash {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+func dedupeStrings(xs []string) []string {
+	if len(xs) == 0 {
+		return xs
+	}
+	seen := make(map[string]struct{}, len(xs))
+	out := make([]string, 0, len(xs))
+	for _, x := range xs {
+		if _, ok := seen[x]; ok {
+			continue
+		}
+		seen[x] = struct{}{}
+		out = append(out, x)
+	}
+	return out
 }

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -376,12 +377,7 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool, agentOve
 	// pending marker and the review metadata will never be recorded — a
 	// silent failure mode. Stale config (e.g. user ran `entire disable`
 	// without removing the agent from review settings) hits this same path.
-	installed := GetAgentsWithHooksInstalled(ctx)
-	installedSet := make(map[string]struct{}, len(installed))
-	for _, name := range installed {
-		installedSet[string(name)] = struct{}{}
-	}
-	if _, ok := installedSet[agentName]; !ok {
+	if !slices.Contains(GetAgentsWithHooksInstalled(ctx), types.AgentName(agentName)) {
 		cmd.SilenceUsage = true
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"Hooks are not installed for %q. Run `entire configure --agent %s` first, "+
@@ -504,10 +500,8 @@ func selectReviewAgent(review map[string][]string, override string) (string, []s
 	}
 	sort.Strings(names)
 	if override != "" {
-		for _, name := range names {
-			if name == override {
-				return override, review[override], nil
-			}
+		if skills, ok := review[override]; ok && len(skills) > 0 {
+			return override, skills, nil
 		}
 		return "", nil, fmt.Errorf(
 			"agent %q is not configured for review; configured agents: %s",

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -452,17 +452,10 @@ discoverability alongside the other review subcommands.`,
 			if checkDisabledGuard(cmd.Context(), cmd.OutOrStdout()) {
 				return nil
 			}
-			ctx := cmd.Context()
-			agentName := types.AgentName(agentFlag)
-			skills, err := resolveReviewSkills(ctx, agentName, skillsFlag)
-			if err != nil {
-				cmd.SilenceUsage = true
-				fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
-				return NewSilentError(err)
-			}
-			return runAttach(ctx, cmd.OutOrStdout(), args[0], agentName, attachOptions{
-				Force:        force,
-				ReviewSkills: skills,
+			return runAttachSurfaceReviewErrors(cmd, args[0], types.AgentName(agentFlag), attachOptions{
+				Force:                force,
+				Review:               true,
+				ReviewSkillsOverride: skillsFlag,
 			})
 		},
 	}

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -21,6 +21,7 @@ import (
 	git "github.com/go-git/go-git/v6"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
@@ -452,6 +453,11 @@ discoverability alongside the other review subcommands.`,
 			if checkDisabledGuard(cmd.Context(), cmd.OutOrStdout()) {
 				return nil
 			}
+			// Discover external agents so --agent <external-name> is
+			// recognized and auto-detection covers them. Mirrors the
+			// contract of `entire attach` so the two entry points stay
+			// behaviorally equivalent.
+			external.DiscoverAndRegister(cmd.Context())
 			return runAttachSurfaceReviewErrors(cmd, args[0], types.AgentName(agentFlag), attachOptions{
 				Force:                force,
 				Review:               true,

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -36,6 +36,22 @@ import (
 
 const pendingReviewMarkerFilename = "review-pending.json"
 
+// agentChoice is one row in the spawn-time picker. Name is the agent
+// registry key (used for marker/override); Label is the picker-visible
+// string ("<name>   (N skills configured)" or "<name>   (prompt-only)").
+type agentChoice struct {
+	Name  string
+	Label string
+}
+
+// runReviewDeps collects the runtime-injectable hooks runReview uses.
+// Tests stub fields on this struct to drive branches that would otherwise
+// require a real TTY. Production wiring leaves fields nil and defaults
+// are resolved inside runReview.
+type runReviewDeps struct {
+	promptForAgentFn func(ctx context.Context, eligible []agentChoice) (string, error)
+}
+
 // PendingReviewMarker is written by `entire review` before spawning the agent.
 // The next agent session's UserPromptSubmit hook reads it, tags the session
 // kind/review-skills, then clears the marker (so a second review run doesn't
@@ -415,6 +431,15 @@ func mergePickerResults(existing map[string]settings.ReviewConfig, offered map[s
 }
 
 func newReviewCmd() *cobra.Command {
+	return newReviewCmdWithDeps(runReviewDeps{})
+}
+
+// newReviewCmdWithDeps returns the review subcommand wired against the
+// provided deps. Tests use this constructor directly to inject stubs for
+// branches that would otherwise require a real TTY. Callers should pass
+// runReviewDeps{} in production; runReview fills in defaults for any nil
+// fields.
+func newReviewCmdWithDeps(deps runReviewDeps) *cobra.Command {
 	var edit bool
 	var agentOverride string
 
@@ -441,7 +466,7 @@ Subcommands:
 				_, err := runReviewConfigPicker(ctx, cmd.OutOrStdout())
 				return err
 			}
-			return runReview(ctx, cmd, agentOverride)
+			return runReview(ctx, cmd, agentOverride, deps)
 		},
 	}
 	cmd.Flags().BoolVar(&edit, "edit", false, "re-open the review config picker")
@@ -498,7 +523,7 @@ discoverability alongside the other review subcommands.`,
 	return cmd
 }
 
-func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string) error {
+func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string, deps runReviewDeps) error {
 	out := cmd.OutOrStdout()
 
 	// 1. Pre-flight: must be in a git repo.
@@ -536,7 +561,38 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string) er
 		fmt.Fprintln(out, "Setup complete — running review now.")
 	}
 
-	// 3. Pick agent.
+	// 3. Pick agent. When multiple agents are configured with hooks installed
+	// and no --agent override is provided, prompt the user to pick one.
+	// Skipped when --agent is passed, and skipped when only one eligible
+	// agent is configured (selectReviewAgent's alphabetical default handles
+	// the single-agent case deterministically).
+	if agentOverride == "" {
+		eligible := computeEligibleConfigured(ctx, s)
+		if len(eligible) > 1 {
+			fn := deps.promptForAgentFn
+			if fn == nil {
+				fn = promptForAgent
+			}
+			picked, pickErr := fn(ctx, eligible)
+			if pickErr != nil {
+				cmd.SilenceUsage = true
+				fmt.Fprintln(cmd.ErrOrStderr(), pickErr.Error())
+				return NewSilentError(pickErr)
+			}
+			if picked == "" {
+				// Defensive: a nil-or-empty return from the picker must NOT
+				// fall through to selectReviewAgent's alphabetical-first
+				// default. That's exactly the silent-masking shape the
+				// picker was added to eliminate. Refuse to proceed.
+				cmd.SilenceUsage = true
+				emptyErr := errors.New("agent picker returned empty agent name")
+				fmt.Fprintln(cmd.ErrOrStderr(), emptyErr.Error())
+				return NewSilentError(emptyErr)
+			}
+			agentOverride = picked
+		}
+	}
+
 	agentName, cfg, err := selectReviewAgent(s.Review, agentOverride)
 	if err != nil {
 		cmd.SilenceUsage = true
@@ -662,6 +718,76 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string) er
 		return fmt.Errorf("agent exited: %w", err)
 	}
 	return nil
+}
+
+// computeEligibleConfigured returns the sorted list of agents that are both
+// configured (non-zero ReviewConfig entry) AND have hooks installed. Only
+// eligible agents are valid picker targets — spawning a review for an agent
+// without hooks would silently drop the review metadata.
+func computeEligibleConfigured(ctx context.Context, s *settings.EntireSettings) []agentChoice {
+	if s == nil {
+		return nil
+	}
+	installed := GetAgentsWithHooksInstalled(ctx)
+	installedSet := make(map[types.AgentName]struct{}, len(installed))
+	for _, name := range installed {
+		installedSet[name] = struct{}{}
+	}
+	out := make([]agentChoice, 0, len(s.Review))
+	for name, cfg := range s.Review {
+		if cfg.IsZero() {
+			continue
+		}
+		if _, ok := installedSet[types.AgentName(name)]; !ok {
+			continue
+		}
+		out = append(out, agentChoice{Name: name, Label: labelForAgentChoice(name, cfg)})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// labelForAgentChoice builds the picker-visible label for an agent row.
+// Annotates with "(N skills configured)" when skills are set, "(prompt-only)"
+// when only a freeform prompt is configured, and falls back to the bare name
+// otherwise (defensive — computeEligibleConfigured filters zero configs out
+// before we get here).
+func labelForAgentChoice(name string, cfg settings.ReviewConfig) string {
+	switch {
+	case len(cfg.Skills) > 0:
+		return fmt.Sprintf("%s   (%d skills configured)", name, len(cfg.Skills))
+	case cfg.Prompt != "":
+		return name + "   (prompt-only)"
+	default:
+		return name
+	}
+}
+
+// promptForAgent renders the single-select agent picker shown when more than
+// one eligible agent is configured. Returns the chosen agent name. Respects
+// accessibility mode via NewAccessibleForm.
+func promptForAgent(ctx context.Context, eligible []agentChoice) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("agent picker: %w", err)
+	}
+	if len(eligible) == 0 {
+		return "", errors.New("no eligible agents to prompt for")
+	}
+	options := make([]huh.Option[string], 0, len(eligible))
+	for _, c := range eligible {
+		options = append(options, huh.NewOption(c.Label, c.Name))
+	}
+	picked := eligible[0].Name
+	form := NewAccessibleForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Which agent should run this review?").
+			Options(options...).
+			Value(&picked),
+	))
+	if err := form.Run(); err != nil {
+		return "", fmt.Errorf("agent picker: %w", err)
+	}
+	return picked, nil
 }
 
 // selectReviewAgent picks an agent from the configured review map.

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -157,13 +157,20 @@ func sameWorktreePath(a, b string) bool {
 // the marker is left in place and modified=false — adoption only happens on
 // first tag. The marker is cleared on successful first adoption.
 //
-// Worktree scoping: when the marker carries a WorktreePath, only a session
-// whose own WorktreePath matches will adopt it. This prevents a Claude
-// session in worktree A from racing to claim a marker that was meant for a
-// session `entire review` just launched in worktree B (both worktrees share
-// the same .git/entire-sessions/ directory where the marker lives).
-// Pre-fix markers with no WorktreePath fall back to unscoped adoption.
-func adoptPendingReviewMarkerInto(ctx context.Context, s session.State) (session.State, bool, error) {
+// Scoping rules — the marker is left untouched (not cleared) when any of
+// these don't match, so the correct session has a chance to claim it:
+//
+//   - WorktreePath: a Claude session in worktree A must not claim a marker
+//     meant for a session `entire review` spawned in worktree B. Both
+//     worktrees share the same .git/entire-sessions/ directory.
+//   - AgentName: a cursor session must not claim a marker that records a
+//     claude-code review — the review config and skills are agent-specific,
+//     and whichever session fires its UserPromptSubmit hook first would
+//     otherwise silently steal the wrong agent's review metadata.
+//
+// Pre-fix markers with empty WorktreePath/AgentName fall back to unscoped
+// adoption for each missing field (backwards compat).
+func adoptPendingReviewMarkerInto(ctx context.Context, s session.State, agentName types.AgentName) (session.State, bool, error) {
 	// Already tagged — don't re-apply on subsequent turns.
 	if s.Kind != "" {
 		return s, false, nil
@@ -179,6 +186,12 @@ func adoptPendingReviewMarkerInto(ctx context.Context, s session.State) (session
 		// Marker belongs to a different worktree — leave it for the session
 		// `entire review` actually spawned, which will reach its own hook
 		// and claim the marker.
+		return s, false, nil
+	}
+	if m.AgentName != "" && m.AgentName != string(agentName) {
+		// Marker was written for a different agent — leave it alone. The
+		// correct agent's session will reach its own hook and claim the
+		// marker.
 		return s, false, nil
 	}
 	s.Kind = session.KindAgentReview

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -195,7 +195,11 @@ func adoptPendingReviewMarkerInto(ctx context.Context, s session.State) (session
 func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]string, error) {
 	installed := GetAgentsWithHooksInstalled(ctx)
 	if len(installed) == 0 {
-		return nil, errors.New("no agents installed; run 'entire enable' first")
+		return nil, errors.New(
+			"no agents with hooks installed; " +
+				"run 'entire configure --agent <name>' to install hooks for one, " +
+				"or 'entire enable' to set up the repo",
+		)
 	}
 
 	// Narrow to agents that have a curated skills list; others need manual
@@ -354,6 +358,25 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool) error {
 	agentName, skills, err := selectReviewAgent(s.Review)
 	if err != nil {
 		return err
+	}
+
+	// 3.5. Verify hooks are installed for the selected agent. Without the
+	// agent's lifecycle hooks firing, UserPromptSubmit will never adopt the
+	// pending marker and the review metadata will never be recorded — a
+	// silent failure mode. Stale config (e.g. user ran `entire disable`
+	// without removing the agent from review settings) hits this same path.
+	installed := GetAgentsWithHooksInstalled(ctx)
+	installedSet := make(map[string]struct{}, len(installed))
+	for _, name := range installed {
+		installedSet[string(name)] = struct{}{}
+	}
+	if _, ok := installedSet[agentName]; !ok {
+		cmd.SilenceUsage = true
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"Hooks are not installed for %q. Run `entire configure --agent %s` first, "+
+				"or remove %q from review settings.\n",
+			agentName, agentName, agentName)
+		return NewSilentError(fmt.Errorf("hooks not installed for %s", agentName))
 	}
 
 	// 4. Re-run guard: check if HEAD's checkpoint already has a review.

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -278,7 +278,7 @@ func confirmFirstRunSetup(out io.Writer) bool {
 // .entire/settings.json. Previously-saved skills are pre-checked via
 // huh.Option.Selected(true), mirroring how `entire enable` preserves prior
 // selections in its own agent picker.
-func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]string, error) {
+func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string]settings.ReviewConfig, error) {
 	installed := GetAgentsWithHooksInstalled(ctx)
 	if len(installed) == 0 {
 		return nil, errors.New(
@@ -313,12 +313,12 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]str
 		)
 	}
 
-	// Load existing config so we can pre-check saved skills. A load error
-	// here means the settings file is malformed; log at Warn so users
-	// debugging "my saved skills aren't pre-checked" can see why, but keep
-	// going with an empty prefill — runReview already surfaces the same
-	// error distinctly when it's the first load.
-	existing := map[string][]string{}
+	// Load existing config so we can pre-check saved skills and seed saved
+	// prompts. A load error here means the settings file is malformed; log
+	// at Warn so users debugging "my saved skills aren't pre-checked" can
+	// see why, but keep going with an empty prefill — runReview already
+	// surfaces the same error distinctly when it's the first load.
+	existing := map[string]settings.ReviewConfig{}
 	if s, err := settings.Load(ctx); err != nil {
 		logging.Warn(ctx, "settings.Load failed when pre-filling picker", slog.String("error", err.Error()))
 	} else if s != nil {
@@ -332,15 +332,15 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]str
 	for _, c := range configurable {
 		labels = append(labels, string(c.ag.Type()))
 	}
-	fmt.Fprintf(out, "Configuring review skills for %d agent(s): %s\n", len(configurable), strings.Join(labels, ", "))
+	fmt.Fprintf(out, "Configuring review for %d agent(s): %s\n", len(configurable), strings.Join(labels, ", "))
 	fmt.Fprintln(out, "(Previously-saved skills are pre-checked. Space to toggle, enter to confirm.)")
 	fmt.Fprintln(out)
 
-	selected := map[string][]string{}
+	selected := map[string]settings.ReviewConfig{}
 	for i, c := range configurable {
 		curated := curatedReviewSkills[string(c.name)]
 		savedSet := map[string]struct{}{}
-		for _, s := range existing[string(c.name)] {
+		for _, s := range existing[string(c.name)].Skills {
 			savedSet[s] = struct{}{}
 		}
 
@@ -356,19 +356,35 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]str
 		// huh populates picks from Option.Selected(true) — do NOT pre-seed,
 		// matching the convention used in detectOrSelectAgent (setup.go).
 		var picks []string
+		// Seed prompt input with the previously-saved value so users can
+		// tweak it without retyping.
+		prompt := existing[string(c.name)].Prompt
+
 		title := fmt.Sprintf("[%d/%d] Review skills for %s", i+1, len(configurable), c.ag.Type())
-		form := NewAccessibleForm(huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title(title).
-				Description(fmt.Sprintf("Agent: %s", c.ag.Type())).
-				Options(options...).
-				Value(&picks),
-		))
+		form := NewAccessibleForm(
+			huh.NewGroup(
+				huh.NewMultiSelect[string]().
+					Title(title).
+					Description(fmt.Sprintf("Agent: %s", c.ag.Type())).
+					Options(options...).
+					Value(&picks),
+			),
+			huh.NewGroup(
+				huh.NewText().
+					Title("Additional instructions (optional)").
+					Description("Used verbatim as the review prompt when set. Leave blank to use the default 'run these skills in order' template.").
+					Value(&prompt),
+			),
+		)
 		if err := form.Run(); err != nil {
 			return nil, fmt.Errorf("picker for %s: %w", c.name, err)
 		}
-		if len(picks) > 0 {
-			selected[string(c.name)] = picks
+		cfg := settings.ReviewConfig{
+			Skills: picks,
+			Prompt: strings.TrimSpace(prompt),
+		}
+		if !cfg.IsZero() {
+			selected[string(c.name)] = cfg
 		}
 	}
 	// Merge the picker's output with existing entries the picker could not
@@ -385,10 +401,10 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]str
 	// The emptiness check runs on `merged`, not `selected`: a user
 	// deliberately deselecting all curated agents while keeping existing
 	// external-agent entries is a valid outcome that must be saveable. Only
-	// refuse if the final config would be empty — i.e., no picks AND no
-	// pre-existing entries to preserve.
+	// refuse if the final config would be empty — i.e., no picks/prompt
+	// AND no pre-existing entries to preserve.
 	if len(merged) == 0 {
-		return nil, errors.New("no review skills selected")
+		return nil, errors.New("no review skills or prompt configured")
 	}
 
 	if err := saveReviewConfig(ctx, merged); err != nil {
@@ -400,21 +416,21 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]str
 
 // mergePickerResults combines the picker's output with existing review
 // config entries that the picker did not surface. Agents in `offered` are
-// fully controlled by the picker: if they appear in `selected` with picks
-// the entry is set, otherwise the entry is removed. Agents not in `offered`
-// keep their existing skills untouched.
+// fully controlled by the picker: if they appear in `selected` with a
+// non-zero config the entry is set, otherwise the entry is removed.
+// Agents not in `offered` keep their existing config untouched.
 //
-// Exported via lowercase helper for testability — the picker itself can't
-// be driven headless.
-func mergePickerResults(existing map[string][]string, offered map[string]struct{}, selected map[string][]string) map[string][]string {
-	merged := make(map[string][]string, len(existing)+len(selected))
-	for name, skills := range existing {
+// Exposed as a helper so tests can drive it directly — the picker itself
+// can't run headless.
+func mergePickerResults(existing map[string]settings.ReviewConfig, offered map[string]struct{}, selected map[string]settings.ReviewConfig) map[string]settings.ReviewConfig {
+	merged := make(map[string]settings.ReviewConfig, len(existing)+len(selected))
+	for name, cfg := range existing {
 		if _, wasOffered := offered[name]; !wasOffered {
-			merged[name] = skills
+			merged[name] = cfg
 		}
 	}
-	for name, skills := range selected {
-		merged[name] = skills
+	for name, cfg := range selected {
+		merged[name] = cfg
 	}
 	return merged
 }
@@ -542,7 +558,7 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string) er
 	}
 
 	// 3. Pick agent.
-	agentName, skills, err := selectReviewAgent(s.Review, agentOverride)
+	agentName, cfg, err := selectReviewAgent(s.Review, agentOverride)
 	if err != nil {
 		cmd.SilenceUsage = true
 		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
@@ -596,11 +612,13 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string) er
 	// 6. Compose the review prompt once, then write the pending marker. The
 	// composed prompt is carried on the marker so adoption records exactly
 	// what the agent was asked to do (the same string passed to LaunchCmd
-	// below), rather than recomposing from skills on the hook side.
-	prompt := composeReviewPrompt(skills)
+	// below), rather than recomposing on the hook side. When the user has
+	// configured a custom Prompt, it wins verbatim; otherwise Skills are
+	// composed into the default "run these in order" template.
+	prompt := composeReviewPrompt(cfg)
 	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
 		AgentName:    agentName,
-		Skills:       skills,
+		Skills:       cfg.Skills,
 		Prompt:       prompt,
 		StartingSHA:  headSHA,
 		StartedAt:    time.Now().UTC(),
@@ -618,7 +636,7 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string) er
 	launcher, ok := agent.LauncherFor(types.AgentName(agentName))
 	if !ok {
 		fmt.Fprintf(out, "%s does not support subprocess launch yet. Marker written.\n", agentName)
-		fmt.Fprintf(out, "Start %s manually and run: %s\n", agentName, strings.Join(skills, ", "))
+		fmt.Fprintf(out, "Start %s manually and use this prompt:\n\n%s\n", agentName, prompt)
 		return nil
 	}
 
@@ -655,28 +673,28 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string) er
 
 // selectReviewAgent picks an agent from the configured review map.
 //
-// If override is non-empty, returns the skills for that agent or an error
+// If override is non-empty, returns the config for that agent or an error
 // listing the configured alternatives. Otherwise returns the alphabetically
 // first configured agent — deterministic but user-overridable via --agent.
-func selectReviewAgent(review map[string][]string, override string) (string, []string, error) {
+func selectReviewAgent(review map[string]settings.ReviewConfig, override string) (string, settings.ReviewConfig, error) {
 	if len(review) == 0 {
-		return "", nil, errors.New("no review skills configured")
+		return "", settings.ReviewConfig{}, errors.New("no review config found")
 	}
 	var names []string
-	for name, skills := range review {
-		if len(skills) > 0 {
+	for name, cfg := range review {
+		if !cfg.IsZero() {
 			names = append(names, name)
 		}
 	}
 	if len(names) == 0 {
-		return "", nil, errors.New("no review skills configured")
+		return "", settings.ReviewConfig{}, errors.New("no review config found")
 	}
 	sort.Strings(names)
 	if override != "" {
-		if skills, ok := review[override]; ok && len(skills) > 0 {
-			return override, skills, nil
+		if cfg, ok := review[override]; ok && !cfg.IsZero() {
+			return override, cfg, nil
 		}
-		return "", nil, fmt.Errorf(
+		return "", settings.ReviewConfig{}, fmt.Errorf(
 			"agent %q is not configured for review; configured agents: %s",
 			override, strings.Join(names, ", "),
 		)
@@ -685,11 +703,21 @@ func selectReviewAgent(review map[string][]string, override string) (string, []s
 	return pick, review[pick], nil
 }
 
-// composeReviewPrompt builds the initial prompt the agent receives.
-func composeReviewPrompt(skills []string) string {
+// composeReviewPrompt builds the prompt sent to the agent from a
+// ReviewConfig. If the config carries an explicit Prompt it wins
+// verbatim — the user's words are the source of truth. Otherwise the
+// skills list is composed into the default "run these in order"
+// template. Empty config returns "" (caller should avoid that case).
+func composeReviewPrompt(cfg settings.ReviewConfig) string {
+	if cfg.Prompt != "" {
+		return cfg.Prompt
+	}
+	if len(cfg.Skills) == 0 {
+		return ""
+	}
 	var sb strings.Builder
 	sb.WriteString("Please run these review skills in order:\n")
-	for i, skill := range skills {
+	for i, skill := range cfg.Skills {
 		fmt.Fprintf(&sb, "  %d. %s\n", i+1, skill)
 	}
 	return sb.String()
@@ -887,7 +915,7 @@ func headHasReviewCheckpoint(ctx context.Context) (bool, string) {
 // malformed — we must NOT silently overwrite it with an empty struct, or
 // every unrelated setting the user had configured would be wiped. Return the
 // error so the caller can surface it instead.
-func saveReviewConfig(ctx context.Context, review map[string][]string) error {
+func saveReviewConfig(ctx context.Context, review map[string]settings.ReviewConfig) error {
 	s, err := settings.Load(ctx)
 	if err != nil {
 		return fmt.Errorf("load settings before save: %w", err)

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -987,10 +987,14 @@ func buildReviewPickerFields(
 ) []huh.Field {
 	var fields []huh.Field
 
+	// Picker labels show only the invocation name — no descriptions. Agent
+	// descriptions in particular can be pages of embedded usage examples,
+	// which makes the picker unreadable. Users recognize skills by name;
+	// the stored value is the name either way.
 	if len(builtins) > 0 {
 		opts := make([]huh.Option[string], 0, len(builtins))
 		for _, b := range builtins {
-			opts = append(opts, huh.NewOption(fmt.Sprintf("%s — %s", b.Name, b.Desc), b.Name))
+			opts = append(opts, huh.NewOption(b.Name, b.Name))
 		}
 		ms := huh.NewMultiSelect[string]().Title("Built-in commands").Options(opts...)
 		if builtinPicksOut != nil {
@@ -1006,11 +1010,7 @@ func buildReviewPickerFields(
 	if len(discovered) > 0 {
 		opts := make([]huh.Option[string], 0, len(discovered))
 		for _, d := range discovered {
-			label := d.Name
-			if d.Description != "" {
-				label = fmt.Sprintf("%s — %s", d.Name, d.Description)
-			}
-			opts = append(opts, huh.NewOption(label, d.Name))
+			opts = append(opts, huh.NewOption(d.Name, d.Name))
 		}
 		ms := huh.NewMultiSelect[string]().Title("Installed plugin skills").Options(opts...)
 		if discoveredPicksOut != nil {

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -298,6 +298,7 @@ func runReviewConfigPicker(ctx context.Context, out io.Writer) (map[string][]str
 func newReviewCmd() *cobra.Command {
 	var edit bool
 	var trackOnly bool
+	var agentOverride string
 
 	cmd := &cobra.Command{
 		Use:   "review",
@@ -306,22 +307,30 @@ func newReviewCmd() *cobra.Command {
 the current branch. On first run, an interactive picker writes the config.
 
 The review session is recorded as part of the next checkpoint, so the
-review metadata is permanently attached to the commit it covers.`,
+review metadata is permanently attached to the commit it covers.
+
+Flags:
+  --edit         re-open the review config picker
+  --track-only   write the pending marker without spawning the agent (you
+                 start the agent manually; its hook adopts the marker)
+  --agent NAME   select a specific configured agent when more than one is
+                 configured (default: alphabetically first)`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			if edit {
 				_, err := runReviewConfigPicker(ctx, cmd.OutOrStdout())
 				return err
 			}
-			return runReview(ctx, cmd, trackOnly)
+			return runReview(ctx, cmd, trackOnly, agentOverride)
 		},
 	}
 	cmd.Flags().BoolVar(&edit, "edit", false, "re-open the review config picker")
 	cmd.Flags().BoolVar(&trackOnly, "track-only", false, "write pending marker without spawning agent")
+	cmd.Flags().StringVar(&agentOverride, "agent", "", "select a specific configured agent (default: alphabetically first)")
 	return cmd
 }
 
-func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool) error {
+func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool, agentOverride string) error {
 	out := cmd.OutOrStdout()
 
 	// 1. Pre-flight: must be in a git repo.
@@ -355,9 +364,11 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool) error {
 	}
 
 	// 3. Pick agent.
-	agentName, skills, err := selectReviewAgent(s.Review)
+	agentName, skills, err := selectReviewAgent(s.Review, agentOverride)
 	if err != nil {
-		return err
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+		return NewSilentError(err)
 	}
 
 	// 3.5. Verify hooks are installed for the selected agent. Without the
@@ -473,14 +484,15 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool) error {
 	return nil
 }
 
-// selectReviewAgent picks an agent from the configured review map. v1: single
-// agent. If multiple are configured, returns the one that sorts first by name
-// (deterministic default). Returns an error if the map is empty.
-func selectReviewAgent(review map[string][]string) (string, []string, error) {
+// selectReviewAgent picks an agent from the configured review map.
+//
+// If override is non-empty, returns the skills for that agent or an error
+// listing the configured alternatives. Otherwise returns the alphabetically
+// first configured agent — deterministic but user-overridable via --agent.
+func selectReviewAgent(review map[string][]string, override string) (string, []string, error) {
 	if len(review) == 0 {
 		return "", nil, errors.New("no review skills configured")
 	}
-	// Deterministic pick: alphabetical by agent name.
 	var names []string
 	for name, skills := range review {
 		if len(skills) > 0 {
@@ -491,6 +503,17 @@ func selectReviewAgent(review map[string][]string) (string, []string, error) {
 		return "", nil, errors.New("no review skills configured")
 	}
 	sort.Strings(names)
+	if override != "" {
+		for _, name := range names {
+			if name == override {
+				return override, review[override], nil
+			}
+		}
+		return "", nil, fmt.Errorf(
+			"agent %q is not configured for review; configured agents: %s",
+			override, strings.Join(names, ", "),
+		)
+	}
 	pick := names[0]
 	return pick, review[pick], nil
 }

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -421,7 +421,6 @@ func mergePickerResults(existing map[string][]string, offered map[string]struct{
 
 func newReviewCmd() *cobra.Command {
 	var edit bool
-	var trackOnly bool
 	var agentOverride string
 
 	cmd := &cobra.Command{
@@ -435,8 +434,6 @@ review metadata is permanently attached to the commit it covers.
 
 Flags:
   --edit         re-open the review config picker
-  --track-only   write the pending marker without spawning the agent (you
-                 start the agent manually; its hook adopts the marker)
   --agent NAME   select a specific configured agent when more than one is
                  configured (default: alphabetically first)
 
@@ -449,11 +446,10 @@ Subcommands:
 				_, err := runReviewConfigPicker(ctx, cmd.OutOrStdout())
 				return err
 			}
-			return runReview(ctx, cmd, trackOnly, agentOverride)
+			return runReview(ctx, cmd, agentOverride)
 		},
 	}
 	cmd.Flags().BoolVar(&edit, "edit", false, "re-open the review config picker")
-	cmd.Flags().BoolVar(&trackOnly, "track-only", false, "write pending marker without spawning agent")
 	cmd.Flags().StringVar(&agentOverride, "agent", "", "select a specific configured agent (default: alphabetically first)")
 	cmd.AddCommand(newReviewAttachCmd())
 	return cmd
@@ -507,7 +503,7 @@ discoverability alongside the other review subcommands.`,
 	return cmd
 }
 
-func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool, agentOverride string) error {
+func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string) error {
 	out := cmd.OutOrStdout()
 
 	// 1. Pre-flight: must be in a git repo.
@@ -613,23 +609,15 @@ func runReview(ctx context.Context, cmd *cobra.Command, trackOnly bool, agentOve
 		return fmt.Errorf("write pending marker: %w", err)
 	}
 
-	if trackOnly {
-		// Marker must persist — the user will start the agent manually and
-		// its hook will adopt the marker.
-		fmt.Fprintln(out, "Pending review marker written.")
-		fmt.Fprintf(out, "Start %s and run these skills manually: %s\n", agentName, strings.Join(skills, ", "))
-		return nil
-	}
-
 	// 7. Resolve launcher BEFORE installing the cleanup defer. Non-launchable
-	// agents fall back to the same persist-marker behavior as --track-only:
-	// the user starts the agent manually and its UserPromptSubmit hook adopts
-	// the marker. If we registered the defer first, it would wipe the marker
-	// on this return path, silently breaking the fallback the message
-	// promises the user.
+	// agents (cursor, opencode, factoryai-droid, etc.) can't be spawned as
+	// subprocesses, so the marker must persist on disk for the user's
+	// manually-started session to adopt. If we registered the defer first,
+	// it would wipe the marker on this return path, silently breaking the
+	// hand-off the message promises.
 	launcher, ok := agent.LauncherFor(types.AgentName(agentName))
 	if !ok {
-		fmt.Fprintf(out, "%s does not support subprocess launch yet. Falling back to --track-only.\n", agentName)
+		fmt.Fprintf(out, "%s does not support subprocess launch yet. Marker written.\n", agentName)
 		fmt.Fprintf(out, "Start %s manually and run: %s\n", agentName, strings.Join(skills, ", "))
 		return nil
 	}

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -320,7 +320,11 @@ Flags:
   --track-only   write the pending marker without spawning the agent (you
                  start the agent manually; its hook adopts the marker)
   --agent NAME   select a specific configured agent when more than one is
-                 configured (default: alphabetically first)`,
+                 configured (default: alphabetically first)
+
+Subcommands:
+  attach <id>    tag an existing session as a review (equivalent to
+                 'entire attach --review <id>')`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			if edit {
@@ -333,6 +337,56 @@ Flags:
 	cmd.Flags().BoolVar(&edit, "edit", false, "re-open the review config picker")
 	cmd.Flags().BoolVar(&trackOnly, "track-only", false, "write pending marker without spawning agent")
 	cmd.Flags().StringVar(&agentOverride, "agent", "", "select a specific configured agent (default: alphabetically first)")
+	cmd.AddCommand(newReviewAttachCmd())
+	return cmd
+}
+
+// newReviewAttachCmd is a thin wrapper around `entire attach --review`. It
+// shares all wiring with runAttach; only the UX surface differs, letting
+// users discover review-attach through `entire review` in help output.
+func newReviewAttachCmd() *cobra.Command {
+	var (
+		force      bool
+		agentFlag  string
+		skillsFlag []string
+	)
+	cmd := &cobra.Command{
+		Use:   "attach <session-id>",
+		Short: "Tag an existing agent session as a review",
+		Long: `Tag an existing agent session as an agent_review and link it to
+the current commit's checkpoint. Use this when you ran a review manually
+(without 'entire review') and want the review metadata attached after
+the fact.
+
+The skills list defaults to whatever is configured under review.<agent>
+in .entire/settings.json; pass --skills to override.
+
+Equivalent to 'entire attach --review <session-id>' — provided here for
+discoverability alongside the other review subcommands.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return cmd.Help()
+			}
+			if checkDisabledGuard(cmd.Context(), cmd.OutOrStdout()) {
+				return nil
+			}
+			ctx := cmd.Context()
+			agentName := types.AgentName(agentFlag)
+			skills, err := resolveReviewSkills(ctx, agentName, skillsFlag)
+			if err != nil {
+				cmd.SilenceUsage = true
+				fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+				return NewSilentError(err)
+			}
+			return runAttach(ctx, cmd.OutOrStdout(), args[0], agentName, attachOptions{
+				Force:        force,
+				ReviewSkills: skills,
+			})
+		},
+	}
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip confirmation and amend the last commit with the checkpoint trailer")
+	cmd.Flags().StringVarP(&agentFlag, "agent", "a", string(agent.DefaultAgentName), "Agent that created the session")
+	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Review skills that were run (default: configured skills for the agent)")
 	return cmd
 }
 

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -205,8 +205,14 @@ func TestRunReview_NonLaunchableAgentPreservesMarker(t *testing.T) {
 		t.Skipf("%s now implements Launcher; pick another non-launchable agent for this regression test", nonLaunchableAgent)
 	}
 
+	// Use a prompt-only config here: cursor has no curated built-ins and
+	// no SkillDiscoverer, so listing a Skills value would trip the
+	// spawn-time installed-skill guard (see
+	// TestRunReview_MissingConfiguredSkillAbortsBeforeMarker) before we
+	// reach the non-launchable code path this test pins. Prompt-only
+	// configs skip verification and still exercise the same fallback.
 	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
-		nonLaunchableAgent: {Skills: []string{testReviewSkill}},
+		nonLaunchableAgent: {Prompt: "review the diff"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -685,5 +691,70 @@ func TestPickerForm_AllHintsSuppressedHidesSection(t *testing.T) {
 	)
 	if len(fields) != 3 {
 		t.Errorf("fields count = %d, want 3 (hint section omitted when empty)", len(fields))
+	}
+}
+
+// Regression: when settings.json names a review skill that isn't installed
+// as a built-in or on-disk plugin skill, `entire review` must abort with a
+// user-facing error before writing the pending marker. Without this guard,
+// the marker gets claimed by the agent's session and the agent silently
+// fails with "I don't have that skill" — no recoverable signal to the user.
+func TestRunReview_MissingConfiguredSkillAbortsBeforeMarker(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, testAgentName)
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testAgentName: {Skills: []string{"/bogus:skill-does-not-exist"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rootCmd := NewRootCmd()
+	errBuf := &bytes.Buffer{}
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"review"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when configured skill not installed")
+	}
+	if !strings.Contains(errBuf.String(), "not installed") {
+		t.Errorf("stderr should mention 'not installed', got: %s", errBuf.String())
+	}
+	_, markerExists, markerErr := ReadPendingReviewMarker(context.Background())
+	if markerErr != nil {
+		t.Fatalf("ReadPendingReviewMarker: %v", markerErr)
+	}
+	if markerExists {
+		t.Error("pending marker should not exist when verification fails")
+	}
+}
+
+// Prompt-only configs (no Skills list) must skip the installed-skill
+// verification: a freeform review prompt can't be validated against any
+// registry, and blocking would break a documented use case. The marker
+// must still be written normally.
+func TestRunReview_PromptOnlyConfigSkipsVerification(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, "cursor")
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		"cursor": {Prompt: "review the diff"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rootCmd := NewRootCmd()
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"review"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, markerExists, markerErr := ReadPendingReviewMarker(context.Background())
+	if markerErr != nil {
+		t.Fatalf("ReadPendingReviewMarker: %v", markerErr)
+	}
+	if !markerExists {
+		t.Error("marker should exist for prompt-only config")
 	}
 }

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -149,36 +149,6 @@ func TestSaveReviewConfig_PersistsSettings(t *testing.T) {
 	}
 }
 
-func TestRunReview_TrackOnlyWritesMarker(t *testing.T) {
-	// t.Chdir + first-run picker — no t.Parallel.
-	setupReviewTestRepoWithCommit(t)
-	installHooksForTest(t, testAgentName)
-
-	// Seed config so first-run picker doesn't fire.
-	if err := saveReviewConfig(context.Background(), map[string][]string{
-		testAgentName: {testReviewSkill},
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	rootCmd := NewRootCmd()
-	rootCmd.SetArgs([]string{"review", "--track-only"})
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
-	}
-
-	m, ok, err := ReadPendingReviewMarker(context.Background())
-	if err != nil || !ok {
-		t.Fatalf("expected marker present: ok=%v err=%v", ok, err)
-	}
-	if m.AgentName != testAgentName {
-		t.Errorf("AgentName = %q, want %s", m.AgentName, testAgentName)
-	}
-	if len(m.Skills) != 1 || m.Skills[0] != testReviewSkill {
-		t.Errorf("Skills = %v", m.Skills)
-	}
-}
-
 // Regression: running `entire review` when the configured agent has no hooks
 // installed must abort with a clear error instead of writing a marker no
 // hook will ever adopt. Covers both stale config (user edited settings.json
@@ -212,14 +182,15 @@ func TestRunReview_MissingHooksAborts(t *testing.T) {
 	}
 }
 
-// Regression: non-launchable agents must preserve the pending marker so the
-// manually-started agent can adopt it. Previously the cleanup defer was
-// registered before the LauncherFor check, so the !ok fallback printed
-// "falling back to --track-only" but then wiped the marker on return.
+// Regression: non-launchable agents must preserve the pending marker so
+// the manually-started agent can adopt it. Previously the cleanup defer
+// was registered before the LauncherFor check, so the !ok fallback
+// printed its "start manually" message but then wiped the marker on
+// return, silently breaking the hand-off.
 //
-// Uses cursor because it has HookSupport but no Launcher, triggering the
-// !ok fallback.
-func TestRunReview_FallbackToTrackOnlyPreservesMarker(t *testing.T) {
+// Uses cursor because it has HookSupport but no Launcher, triggering
+// the !ok fallback.
+func TestRunReview_NonLaunchableAgentPreservesMarker(t *testing.T) {
 	setupReviewTestRepoWithCommit(t)
 
 	const nonLaunchableAgent = "cursor"
@@ -241,14 +212,14 @@ func TestRunReview_FallbackToTrackOnlyPreservesMarker(t *testing.T) {
 	rootCmd := NewRootCmd()
 	buf := &bytes.Buffer{}
 	rootCmd.SetOut(buf)
-	rootCmd.SetArgs([]string{"review"}) // not --track-only; rely on the fallback
+	rootCmd.SetArgs([]string{"review"})
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 
 	out := buf.String()
-	if !strings.Contains(out, "Falling back to --track-only") {
-		t.Errorf("expected fallback message, got: %s", out)
+	if !strings.Contains(out, "Marker written") {
+		t.Errorf("expected marker-written message, got: %s", out)
 	}
 
 	m, ok, err := ReadPendingReviewMarker(context.Background())
@@ -256,7 +227,7 @@ func TestRunReview_FallbackToTrackOnlyPreservesMarker(t *testing.T) {
 		t.Fatalf("ReadPendingReviewMarker: %v", err)
 	}
 	if !ok {
-		t.Fatal("marker was cleared by defer on !ok fallback — the 'falling back to --track-only' message is a lie")
+		t.Fatal("marker was cleared by defer on !ok fallback — the hand-off message is a lie")
 	}
 	if m.AgentName != nonLaunchableAgent {
 		t.Errorf("AgentName = %q, want %s", m.AgentName, nonLaunchableAgent)

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -50,6 +50,7 @@ func TestReviewMarker_RoundTrip(t *testing.T) {
 	m := PendingReviewMarker{
 		AgentName:   "claude-code",
 		Skills:      []string{testReviewSkill},
+		Prompt:      "Please run these review skills in order:\n  1. " + testReviewSkill + "\n",
 		StartingSHA: "deadbeef",
 		StartedAt:   time.Now().UTC(),
 	}
@@ -66,6 +67,9 @@ func TestReviewMarker_RoundTrip(t *testing.T) {
 	}
 	if got.AgentName != m.AgentName || got.StartingSHA != m.StartingSHA {
 		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+	if got.Prompt != m.Prompt {
+		t.Errorf("Prompt roundtrip mismatch: got %q want %q", got.Prompt, m.Prompt)
 	}
 	if err := ClearPendingReviewMarker(ctx); err != nil {
 		t.Fatalf("clear: %v", err)

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/skilldiscovery"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -634,5 +635,55 @@ func TestSaveReviewConfig_ReturnsErrorOnMalformedSettings(t *testing.T) {
 	}
 	if !bytes.Equal(before, after) {
 		t.Errorf("settings.json was overwritten on load error:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+func TestPickerForm_StructureWithDiscovery(t *testing.T) {
+	t.Parallel()
+	fields := buildReviewPickerFields(
+		"claude-code",
+		[]skilldiscovery.CuratedSkill{{Name: "/review", Desc: "x"}},
+		[]agent.DiscoveredSkill{{Name: "/pr-review-toolkit:review-pr", Description: "y"}},
+		[]skilldiscovery.InstallHint{{Message: "install more"}},
+		"",                                                           /* previousPrompt */
+		nil /* builtinPicksOut */, nil /* discoveredPicksOut */, nil, /* promptOut */
+	)
+	if len(fields) != 4 {
+		t.Fatalf("picker fields = %d, want 4 (built-in, discovered, hint, prompt)", len(fields))
+	}
+}
+
+func TestPickerForm_EmptyBuiltinsRendersNote(t *testing.T) {
+	t.Parallel()
+	fields := buildReviewPickerFields(
+		"gemini-cli",
+		nil,
+		nil,
+		[]skilldiscovery.InstallHint{{Message: "install gemini-code-review"}},
+		"",
+		nil, nil, nil,
+	)
+	if len(fields) != 4 {
+		t.Fatalf("fields = %d, want 4 even with empty built-ins and discovered", len(fields))
+	}
+	for i, f := range fields {
+		if f == nil {
+			t.Errorf("fields[%d] is nil — every slot must be populated", i)
+		}
+	}
+}
+
+func TestPickerForm_AllHintsSuppressedHidesSection(t *testing.T) {
+	t.Parallel()
+	fields := buildReviewPickerFields(
+		"claude-code",
+		[]skilldiscovery.CuratedSkill{{Name: "/review", Desc: "x"}},
+		nil,
+		nil, /* no active hints */
+		"",
+		nil, nil, nil,
+	)
+	if len(fields) != 3 {
+		t.Errorf("fields count = %d, want 3 (hint section omitted when empty)", len(fields))
 	}
 }

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -130,8 +130,8 @@ func TestSaveReviewConfig_PersistsSettings(t *testing.T) {
 	testutil.InitRepo(t, tmp)
 	t.Chdir(tmp)
 
-	err := saveReviewConfig(context.Background(), map[string][]string{
-		"claude-code": {testReviewSkill, "/test-auditor"},
+	err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		"claude-code": {Skills: []string{testReviewSkill, "/test-auditor"}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -141,11 +141,12 @@ func TestSaveReviewConfig_PersistsSettings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load settings: %v", err)
 	}
-	if len(s.Review["claude-code"]) != 2 {
-		t.Errorf("expected 2 skills saved, got %v", s.Review)
+	cfg := s.Review["claude-code"]
+	if len(cfg.Skills) != 2 {
+		t.Errorf("expected 2 skills saved, got %v", cfg.Skills)
 	}
-	if s.Review["claude-code"][0] != testReviewSkill {
-		t.Errorf("first skill = %q", s.Review["claude-code"][0])
+	if cfg.Skills[0] != testReviewSkill {
+		t.Errorf("first skill = %q", cfg.Skills[0])
 	}
 }
 
@@ -158,8 +159,8 @@ func TestRunReview_MissingHooksAborts(t *testing.T) {
 	setupReviewTestRepoWithCommit(t)
 
 	// No installHooksForTest — this is the point.
-	if err := saveReviewConfig(context.Background(), map[string][]string{
-		testAgentName: {testReviewSkill},
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testAgentName: {Skills: []string{testReviewSkill}},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -203,8 +204,8 @@ func TestRunReview_NonLaunchableAgentPreservesMarker(t *testing.T) {
 		t.Skipf("%s now implements Launcher; pick another non-launchable agent for this regression test", nonLaunchableAgent)
 	}
 
-	if err := saveReviewConfig(context.Background(), map[string][]string{
-		nonLaunchableAgent: {testReviewSkill},
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		nonLaunchableAgent: {Skills: []string{testReviewSkill}},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -234,9 +235,11 @@ func TestRunReview_NonLaunchableAgentPreservesMarker(t *testing.T) {
 	}
 }
 
-func TestComposeReviewPrompt_NoFinishSkill(t *testing.T) {
+func TestComposeReviewPrompt_SkillsOnly(t *testing.T) {
 	t.Parallel()
-	prompt := composeReviewPrompt([]string{"/review-pr", "/test-auditor"})
+	prompt := composeReviewPrompt(settings.ReviewConfig{
+		Skills: []string{"/review-pr", "/test-auditor"},
+	})
 	if strings.Contains(prompt, "entire-review:finish") {
 		t.Errorf("prompt should not reference finish skill; got: %s", prompt)
 	}
@@ -245,22 +248,45 @@ func TestComposeReviewPrompt_NoFinishSkill(t *testing.T) {
 	}
 }
 
+// Custom Prompt wins verbatim over skills — the user's words are the
+// source of truth for what the agent receives.
+func TestComposeReviewPrompt_CustomPromptWinsOverSkills(t *testing.T) {
+	t.Parallel()
+	custom := "Focus on security regressions this week."
+	prompt := composeReviewPrompt(settings.ReviewConfig{
+		Skills: []string{"/review-pr"},
+		Prompt: custom,
+	})
+	if prompt != custom {
+		t.Errorf("composeReviewPrompt = %q, want verbatim custom prompt %q", prompt, custom)
+	}
+}
+
+// Empty config returns an empty string — callers should avoid invoking
+// the spawn path with empty config.
+func TestComposeReviewPrompt_EmptyConfigReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	if got := composeReviewPrompt(settings.ReviewConfig{}); got != "" {
+		t.Errorf("empty config = %q, want empty", got)
+	}
+}
+
 // --agent flag resolves a non-default configured agent when the map has
 // multiple entries. Previously the alphabetically-first agent always won
 // silently.
 func TestSelectReviewAgent_OverrideResolvesSpecificAgent(t *testing.T) {
 	t.Parallel()
-	review := map[string][]string{
-		testAgentName:  {"/a"},
-		testCodexAgent: {"/b"},
+	review := map[string]settings.ReviewConfig{
+		testAgentName:  {Skills: []string{"/a"}},
+		testCodexAgent: {Skills: []string{"/b"}},
 	}
 
-	name, skills, err := selectReviewAgent(review, testCodexAgent)
+	name, cfg, err := selectReviewAgent(review, testCodexAgent)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if name != testCodexAgent || len(skills) != 1 || skills[0] != "/b" {
-		t.Errorf("override=%s returned name=%q skills=%v", testCodexAgent, name, skills)
+	if name != testCodexAgent || len(cfg.Skills) != 1 || cfg.Skills[0] != "/b" {
+		t.Errorf("override=%s returned name=%q cfg=%+v", testCodexAgent, name, cfg)
 	}
 
 	// Default (no override) must remain the alphabetically-first agent for
@@ -292,56 +318,69 @@ func TestMergePickerResults(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
-		existing map[string][]string
+		existing map[string]settings.ReviewConfig
 		offered  map[string]struct{}
-		selected map[string][]string
-		want     map[string][]string
+		selected map[string]settings.ReviewConfig
+		want     map[string]settings.ReviewConfig
 	}{
 		{
 			name: "preserves uncurated/external entries the picker did not surface",
-			existing: map[string][]string{
-				testAgentName:     {"/old-pick"},
-				testExternalAgent: {testExternalSkill},
+			existing: map[string]settings.ReviewConfig{
+				testAgentName:     {Skills: []string{"/old-pick"}},
+				testExternalAgent: {Skills: []string{testExternalSkill}},
 			},
 			offered:  map[string]struct{}{testAgentName: {}},
-			selected: map[string][]string{testAgentName: {"/new-pick"}},
-			want: map[string][]string{
-				testAgentName:     {"/new-pick"},
-				testExternalAgent: {testExternalSkill}, // MUST survive
+			selected: map[string]settings.ReviewConfig{testAgentName: {Skills: []string{"/new-pick"}}},
+			want: map[string]settings.ReviewConfig{
+				testAgentName:     {Skills: []string{"/new-pick"}},
+				testExternalAgent: {Skills: []string{testExternalSkill}}, // MUST survive
 			},
 		},
 		{
 			name: "offered agent with no picks is removed (user unconfiguring)",
-			existing: map[string][]string{
-				testAgentName:  {"/old-pick"},
-				testCodexAgent: {"/codex-pick"},
+			existing: map[string]settings.ReviewConfig{
+				testAgentName:  {Skills: []string{"/old-pick"}},
+				testCodexAgent: {Skills: []string{"/codex-pick"}},
 			},
 			offered:  map[string]struct{}{testAgentName: {}, testCodexAgent: {}},
-			selected: map[string][]string{testAgentName: {"/new-pick"}},
-			want: map[string][]string{
-				testAgentName: {"/new-pick"},
+			selected: map[string]settings.ReviewConfig{testAgentName: {Skills: []string{"/new-pick"}}},
+			want: map[string]settings.ReviewConfig{
+				testAgentName: {Skills: []string{"/new-pick"}},
 			},
 		},
 		{
 			name:     "empty existing: merge is identity on selected",
-			existing: map[string][]string{},
+			existing: map[string]settings.ReviewConfig{},
 			offered:  map[string]struct{}{testAgentName: {}},
-			selected: map[string][]string{testAgentName: {"/a"}},
-			want:     map[string][]string{testAgentName: {"/a"}},
+			selected: map[string]settings.ReviewConfig{testAgentName: {Skills: []string{"/a"}}},
+			want:     map[string]settings.ReviewConfig{testAgentName: {Skills: []string{"/a"}}},
 		},
 		{
 			// Regression: deselecting all curated agents while external
 			// config remains must yield a non-empty merged map, so --edit
 			// can save the "only external agent left" state.
 			name: "deselected curated agent leaves only external entry",
-			existing: map[string][]string{
-				testAgentName:     {"/old-pick"},
-				testExternalAgent: {testExternalSkill},
+			existing: map[string]settings.ReviewConfig{
+				testAgentName:     {Skills: []string{"/old-pick"}},
+				testExternalAgent: {Skills: []string{testExternalSkill}},
 			},
 			offered:  map[string]struct{}{testAgentName: {}},
-			selected: map[string][]string{}, // user deselected everything offered
-			want: map[string][]string{
-				testExternalAgent: {testExternalSkill},
+			selected: map[string]settings.ReviewConfig{}, // user deselected everything offered
+			want: map[string]settings.ReviewConfig{
+				testExternalAgent: {Skills: []string{testExternalSkill}},
+			},
+		},
+		{
+			// A custom prompt without skills is a valid, non-zero entry.
+			// Users can configure a freeform review with no skills list.
+			name:     "prompt-only entry is preserved",
+			existing: map[string]settings.ReviewConfig{},
+			offered:  map[string]struct{}{testAgentName: {}},
+			selected: map[string]settings.ReviewConfig{
+				testAgentName: {Prompt: "Focus on security regressions."},
+			},
+			want: map[string]settings.ReviewConfig{
+				testAgentName: {Prompt: "Focus on security regressions."},
 			},
 		},
 	}
@@ -582,8 +621,8 @@ func TestSaveReviewConfig_ReturnsErrorOnMalformedSettings(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = saveReviewConfig(context.Background(), map[string][]string{
-		testAgentName: {testReviewSkill},
+	err = saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testAgentName: {Skills: []string{testReviewSkill}},
 	})
 	if err == nil {
 		t.Fatal("expected saveReviewConfig to error on malformed settings; returned nil (data-loss bug)")

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -135,6 +135,7 @@ func TestRunReview_TrackOnlyWritesMarker(t *testing.T) {
 	testutil.GitAdd(t, tmp, "f.txt")
 	testutil.GitCommit(t, tmp, "init")
 	t.Chdir(tmp)
+	installHooksForTest(t, testAgentName)
 
 	// Seed config so first-run picker doesn't fire.
 	if err := saveReviewConfig(context.Background(), map[string][]string{
@@ -158,6 +159,44 @@ func TestRunReview_TrackOnlyWritesMarker(t *testing.T) {
 	}
 	if len(m.Skills) != 1 || m.Skills[0] != testReviewSkill {
 		t.Errorf("Skills = %v", m.Skills)
+	}
+}
+
+// Regression: running `entire review` when the configured agent has no hooks
+// installed must abort with a clear error instead of writing a marker no
+// hook will ever adopt. Covers both stale config (user edited settings.json
+// by hand) and post-disable state (user ran `entire disable` without
+// cleaning up review settings).
+func TestRunReview_MissingHooksAborts(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "x")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "init")
+	t.Chdir(tmp)
+
+	// No installHooksForTest — this is the point.
+	if err := saveReviewConfig(context.Background(), map[string][]string{
+		testAgentName: {testReviewSkill},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rootCmd := NewRootCmd()
+	errBuf := &bytes.Buffer{}
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"review"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when hooks are not installed")
+	}
+	if !strings.Contains(errBuf.String(), "Hooks are not installed") {
+		t.Errorf("expected 'Hooks are not installed' in stderr, got: %s", errBuf.String())
+	}
+
+	// Marker must not leak — the gate runs before WritePendingReviewMarker.
+	if _, ok, readErr := ReadPendingReviewMarker(context.Background()); readErr != nil || ok {
+		t.Errorf("marker should not exist when hooks are missing: ok=%v err=%v", ok, readErr)
 	}
 }
 

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -35,17 +36,30 @@ func installHooksForTest(t *testing.T, agentName types.AgentName) {
 }
 
 const (
-	testReviewSkill = "/pr-review-toolkit:review-pr"
-	testMainBranch  = "main"
+	testReviewSkill   = "/pr-review-toolkit:review-pr"
+	testMainBranch    = "main"
+	testCodexAgent    = "codex"
+	testExternalAgent = "my-external"
+	testExternalSkill = "/external-skill"
 )
 
-func TestReviewMarker_RoundTrip(t *testing.T) {
+// setupReviewTestRepoWithCommit initializes a temp git repo with a single
+// commit and chdirs into it. Returns the tmp dir. Use for tests that just
+// need "a git repo with at least one commit" — tests that care about
+// specific filenames or commit content should set up explicitly.
+func setupReviewTestRepoWithCommit(t *testing.T) string {
+	t.Helper()
 	tmp := t.TempDir()
 	testutil.InitRepo(t, tmp)
 	testutil.WriteFile(t, tmp, "f.txt", "x")
 	testutil.GitAdd(t, tmp, "f.txt")
 	testutil.GitCommit(t, tmp, "init")
 	t.Chdir(tmp)
+	return tmp
+}
+
+func TestReviewMarker_RoundTrip(t *testing.T) {
+	tmp := setupReviewTestRepoWithCommit(t)
 
 	m := PendingReviewMarker{
 		AgentName:   "claude-code",
@@ -71,6 +85,18 @@ func TestReviewMarker_RoundTrip(t *testing.T) {
 	if got.Prompt != m.Prompt {
 		t.Errorf("Prompt roundtrip mismatch: got %q want %q", got.Prompt, m.Prompt)
 	}
+
+	// Marker file must live under .git/entire-sessions/, not the worktree.
+	// Check before clearing so the file is actually present on disk.
+	markerGlob := filepath.Join(tmp, ".git", "entire-sessions", "*")
+	entries, err := filepath.Glob(markerGlob)
+	if err != nil {
+		t.Fatalf("glob sessions dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Errorf("no marker file found under %s — path resolution may have regressed", markerGlob)
+	}
+
 	if err := ClearPendingReviewMarker(ctx); err != nil {
 		t.Fatalf("clear: %v", err)
 	}
@@ -81,14 +107,6 @@ func TestReviewMarker_RoundTrip(t *testing.T) {
 	if ok {
 		t.Error("expected marker absent after clear")
 	}
-
-	// Ensure the file lived under .git/entire-sessions/, not the worktree.
-	gitDir := filepath.Join(tmp, ".git")
-	entries, err := filepath.Glob(filepath.Join(gitDir, "entire-sessions", "*"))
-	if err != nil {
-		t.Fatalf("glob sessions dir: %v", err)
-	}
-	_ = entries // sanity check only
 }
 
 func TestReviewCmd_Help(t *testing.T) {
@@ -133,12 +151,7 @@ func TestSaveReviewConfig_PersistsSettings(t *testing.T) {
 
 func TestRunReview_TrackOnlyWritesMarker(t *testing.T) {
 	// t.Chdir + first-run picker — no t.Parallel.
-	tmp := t.TempDir()
-	testutil.InitRepo(t, tmp)
-	testutil.WriteFile(t, tmp, "f.txt", "x")
-	testutil.GitAdd(t, tmp, "f.txt")
-	testutil.GitCommit(t, tmp, "init")
-	t.Chdir(tmp)
+	setupReviewTestRepoWithCommit(t)
 	installHooksForTest(t, testAgentName)
 
 	// Seed config so first-run picker doesn't fire.
@@ -172,12 +185,7 @@ func TestRunReview_TrackOnlyWritesMarker(t *testing.T) {
 // by hand) and post-disable state (user ran `entire disable` without
 // cleaning up review settings).
 func TestRunReview_MissingHooksAborts(t *testing.T) {
-	tmp := t.TempDir()
-	testutil.InitRepo(t, tmp)
-	testutil.WriteFile(t, tmp, "f.txt", "x")
-	testutil.GitAdd(t, tmp, "f.txt")
-	testutil.GitCommit(t, tmp, "init")
-	t.Chdir(tmp)
+	setupReviewTestRepoWithCommit(t)
 
 	// No installHooksForTest — this is the point.
 	if err := saveReviewConfig(context.Background(), map[string][]string{
@@ -212,12 +220,7 @@ func TestRunReview_MissingHooksAborts(t *testing.T) {
 // Uses cursor because it has HookSupport but no Launcher, triggering the
 // !ok fallback.
 func TestRunReview_FallbackToTrackOnlyPreservesMarker(t *testing.T) {
-	tmp := t.TempDir()
-	testutil.InitRepo(t, tmp)
-	testutil.WriteFile(t, tmp, "f.txt", "x")
-	testutil.GitAdd(t, tmp, "f.txt")
-	testutil.GitCommit(t, tmp, "init")
-	t.Chdir(tmp)
+	setupReviewTestRepoWithCommit(t)
 
 	const nonLaunchableAgent = "cursor"
 	installHooksForTest(t, types.AgentName(nonLaunchableAgent))
@@ -276,18 +279,17 @@ func TestComposeReviewPrompt_NoFinishSkill(t *testing.T) {
 // silently.
 func TestSelectReviewAgent_OverrideResolvesSpecificAgent(t *testing.T) {
 	t.Parallel()
-	const codexAgent = "codex"
 	review := map[string][]string{
-		testAgentName: {"/a"},
-		codexAgent:    {"/b"},
+		testAgentName:  {"/a"},
+		testCodexAgent: {"/b"},
 	}
 
-	name, skills, err := selectReviewAgent(review, codexAgent)
+	name, skills, err := selectReviewAgent(review, testCodexAgent)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if name != codexAgent || len(skills) != 1 || skills[0] != "/b" {
-		t.Errorf("override=%s returned name=%q skills=%v", codexAgent, name, skills)
+	if name != testCodexAgent || len(skills) != 1 || skills[0] != "/b" {
+		t.Errorf("override=%s returned name=%q skills=%v", testCodexAgent, name, skills)
 	}
 
 	// Default (no override) must remain the alphabetically-first agent for
@@ -297,7 +299,7 @@ func TestSelectReviewAgent_OverrideResolvesSpecificAgent(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if name != testAgentName {
-		t.Errorf("default pick = %q, want %s", name, testAgentName)
+		t.Errorf("default pick = %q, want %q", name, testAgentName)
 	}
 
 	// Unknown override must surface a helpful error listing the configured
@@ -306,7 +308,7 @@ func TestSelectReviewAgent_OverrideResolvesSpecificAgent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unconfigured --agent value")
 	}
-	if !strings.Contains(err.Error(), testAgentName) || !strings.Contains(err.Error(), codexAgent) {
+	if !strings.Contains(err.Error(), testAgentName) || !strings.Contains(err.Error(), testCodexAgent) {
 		t.Errorf("error should list configured agents; got: %v", err)
 	}
 }
@@ -327,23 +329,23 @@ func TestMergePickerResults(t *testing.T) {
 		{
 			name: "preserves uncurated/external entries the picker did not surface",
 			existing: map[string][]string{
-				testAgentName: {"/old-pick"},
-				"my-external": {"/external-skill"},
+				testAgentName:     {"/old-pick"},
+				testExternalAgent: {testExternalSkill},
 			},
 			offered:  map[string]struct{}{testAgentName: {}},
 			selected: map[string][]string{testAgentName: {"/new-pick"}},
 			want: map[string][]string{
-				testAgentName: {"/new-pick"},
-				"my-external": {"/external-skill"}, // MUST survive
+				testAgentName:     {"/new-pick"},
+				testExternalAgent: {testExternalSkill}, // MUST survive
 			},
 		},
 		{
 			name: "offered agent with no picks is removed (user unconfiguring)",
 			existing: map[string][]string{
-				testAgentName: {"/old-pick"},
-				"codex":       {"/codex-pick"},
+				testAgentName:  {"/old-pick"},
+				testCodexAgent: {"/codex-pick"},
 			},
-			offered:  map[string]struct{}{testAgentName: {}, "codex": {}},
+			offered:  map[string]struct{}{testAgentName: {}, testCodexAgent: {}},
 			selected: map[string][]string{testAgentName: {"/new-pick"}},
 			want: map[string][]string{
 				testAgentName: {"/new-pick"},
@@ -362,13 +364,13 @@ func TestMergePickerResults(t *testing.T) {
 			// can save the "only external agent left" state.
 			name: "deselected curated agent leaves only external entry",
 			existing: map[string][]string{
-				testAgentName: {"/old-pick"},
-				"my-external": {"/external-skill"},
+				testAgentName:     {"/old-pick"},
+				testExternalAgent: {testExternalSkill},
 			},
 			offered:  map[string]struct{}{testAgentName: {}},
 			selected: map[string][]string{}, // user deselected everything offered
 			want: map[string][]string{
-				"my-external": {"/external-skill"},
+				testExternalAgent: {testExternalSkill},
 			},
 		},
 	}
@@ -376,18 +378,8 @@ func TestMergePickerResults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := mergePickerResults(tc.existing, tc.offered, tc.selected)
-			if len(got) != len(tc.want) {
-				t.Fatalf("length mismatch: got %d entries, want %d: got=%v want=%v", len(got), len(tc.want), got, tc.want)
-			}
-			for k, v := range tc.want {
-				gv, ok := got[k]
-				if !ok {
-					t.Errorf("missing key %q", k)
-					continue
-				}
-				if len(gv) != len(v) || (len(v) > 0 && gv[0] != v[0]) {
-					t.Errorf("key %q: got %v, want %v", k, gv, v)
-				}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("mergePickerResults =\n  %v\nwant\n  %v", got, tc.want)
 			}
 		})
 	}

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -9,10 +9,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
+
+// installHooksForTest installs the given agent's hooks into CWD-relative
+// repo paths, so tests that exercise code paths gated on hook presence can
+// proceed past agent selection.
+func installHooksForTest(t *testing.T, agentName types.AgentName) {
+	t.Helper()
+	ag, err := agent.Get(agentName)
+	if err != nil {
+		t.Fatalf("agent.Get(%q): %v", agentName, err)
+	}
+	hs, ok := agent.AsHookSupport(ag)
+	if !ok {
+		t.Fatalf("agent %q does not support hooks", agentName)
+	}
+	if _, err := hs.InstallHooks(context.Background(), false, false); err != nil {
+		t.Fatalf("InstallHooks(%q): %v", agentName, err)
+	}
+}
 
 const (
 	testReviewSkill = "/pr-review-toolkit:review-pr"
@@ -138,6 +158,62 @@ func TestRunReview_TrackOnlyWritesMarker(t *testing.T) {
 	}
 	if len(m.Skills) != 1 || m.Skills[0] != testReviewSkill {
 		t.Errorf("Skills = %v", m.Skills)
+	}
+}
+
+// Regression: non-launchable agents must preserve the pending marker so the
+// manually-started agent can adopt it. Previously the cleanup defer was
+// registered before the LauncherFor check, so the !ok fallback printed
+// "falling back to --track-only" but then wiped the marker on return.
+//
+// Uses cursor because it has HookSupport but no Launcher, triggering the
+// !ok fallback.
+func TestRunReview_FallbackToTrackOnlyPreservesMarker(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "x")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "init")
+	t.Chdir(tmp)
+
+	const nonLaunchableAgent = "cursor"
+	installHooksForTest(t, types.AgentName(nonLaunchableAgent))
+
+	// Confirm the precondition: cursor really has no Launcher. If a future
+	// change adds one, this test's premise is invalid and needs a different
+	// agent.
+	if _, hasLauncher := agent.LauncherFor(types.AgentName(nonLaunchableAgent)); hasLauncher {
+		t.Skipf("%s now implements Launcher; pick another non-launchable agent for this regression test", nonLaunchableAgent)
+	}
+
+	if err := saveReviewConfig(context.Background(), map[string][]string{
+		nonLaunchableAgent: {testReviewSkill},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rootCmd := NewRootCmd()
+	buf := &bytes.Buffer{}
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"review"}) // not --track-only; rely on the fallback
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Falling back to --track-only") {
+		t.Errorf("expected fallback message, got: %s", out)
+	}
+
+	m, ok, err := ReadPendingReviewMarker(context.Background())
+	if err != nil {
+		t.Fatalf("ReadPendingReviewMarker: %v", err)
+	}
+	if !ok {
+		t.Fatal("marker was cleared by defer on !ok fallback — the 'falling back to --track-only' message is a lie")
+	}
+	if m.AgentName != nonLaunchableAgent {
+		t.Errorf("AgentName = %q, want %s", m.AgentName, nonLaunchableAgent)
 	}
 }
 

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -311,6 +311,73 @@ func TestSelectReviewAgent_OverrideResolvesSpecificAgent(t *testing.T) {
 	}
 }
 
+// mergePickerResults unit tests — the picker itself can't run headless, but
+// its post-processing step is pure. Together these pin the data-loss
+// regression where a manually-configured external-agent entry would be
+// silently deleted the first time the user ran `entire review --edit`.
+func TestMergePickerResults(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		existing map[string][]string
+		offered  map[string]struct{}
+		selected map[string][]string
+		want     map[string][]string
+	}{
+		{
+			name: "preserves uncurated/external entries the picker did not surface",
+			existing: map[string][]string{
+				testAgentName: {"/old-pick"},
+				"my-external": {"/external-skill"},
+			},
+			offered:  map[string]struct{}{testAgentName: {}},
+			selected: map[string][]string{testAgentName: {"/new-pick"}},
+			want: map[string][]string{
+				testAgentName: {"/new-pick"},
+				"my-external": {"/external-skill"}, // MUST survive
+			},
+		},
+		{
+			name: "offered agent with no picks is removed (user unconfiguring)",
+			existing: map[string][]string{
+				testAgentName: {"/old-pick"},
+				"codex":       {"/codex-pick"},
+			},
+			offered:  map[string]struct{}{testAgentName: {}, "codex": {}},
+			selected: map[string][]string{testAgentName: {"/new-pick"}},
+			want: map[string][]string{
+				testAgentName: {"/new-pick"},
+			},
+		},
+		{
+			name:     "empty existing: merge is identity on selected",
+			existing: map[string][]string{},
+			offered:  map[string]struct{}{testAgentName: {}},
+			selected: map[string][]string{testAgentName: {"/a"}},
+			want:     map[string][]string{testAgentName: {"/a"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := mergePickerResults(tc.existing, tc.offered, tc.selected)
+			if len(got) != len(tc.want) {
+				t.Fatalf("length mismatch: got %d entries, want %d: got=%v want=%v", len(got), len(tc.want), got, tc.want)
+			}
+			for k, v := range tc.want {
+				gv, ok := got[k]
+				if !ok {
+					t.Errorf("missing key %q", k)
+					continue
+				}
+				if len(gv) != len(v) || (len(v) > 0 && gv[0] != v[0]) {
+					t.Errorf("key %q: got %v, want %v", k, gv, v)
+				}
+			}
+		})
+	}
+}
+
 func TestNewReviewCmd_NoHiddenFlags(t *testing.T) {
 	t.Parallel()
 	cmd := newReviewCmd()

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -758,3 +758,157 @@ func TestRunReview_PromptOnlyConfigSkipsVerification(t *testing.T) {
 		t.Error("marker should exist for prompt-only config")
 	}
 }
+
+// Non-launchable agents used by the picker tests below. Non-launchable is
+// important: runReview registers a defer that clears the marker on exit
+// for launchable agents, which would defeat the "marker was written with
+// agent X" assertion. See TestRunReview_NonLaunchableAgentPreservesMarker
+// for the same pattern.
+const (
+	testPickerAgentA = "cursor"   // alphabetically first
+	testPickerAgentB = "opencode" // alphabetically second
+)
+
+// TestPromptForAgent_SingleEligibleSkipsPicker: when only one agent is
+// configured AND has hooks, the picker never fires and runReview proceeds
+// directly to spawn.
+func TestPromptForAgent_SingleEligibleSkipsPicker(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, testPickerAgentA)
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testPickerAgentA: {Prompt: "review the diff"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	deps := runReviewDeps{
+		promptForAgentFn: func(_ context.Context, _ []agentChoice) (string, error) {
+			called = true
+			return "", nil
+		},
+	}
+
+	reviewCmd := newReviewCmdWithDeps(deps)
+	if err := reviewCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("promptForAgentFn should not be called when only one eligible agent is configured")
+	}
+}
+
+// TestPromptForAgent_FlagOverrideSkipsPicker: when --agent is passed, the
+// picker is skipped even with multiple eligible agents configured.
+func TestPromptForAgent_FlagOverrideSkipsPicker(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, testPickerAgentA)
+	installHooksForTest(t, testPickerAgentB)
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testPickerAgentA: {Prompt: "review the diff"},
+		testPickerAgentB: {Prompt: "review the diff"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	deps := runReviewDeps{
+		promptForAgentFn: func(_ context.Context, _ []agentChoice) (string, error) {
+			called = true
+			return "", nil
+		},
+	}
+
+	reviewCmd := newReviewCmdWithDeps(deps)
+	reviewCmd.SetArgs([]string{"--agent", testPickerAgentB})
+	if err := reviewCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("promptForAgentFn should not be called when --agent is passed")
+	}
+
+	m, ok, err := ReadPendingReviewMarker(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("marker should be written: ok=%v err=%v", ok, err)
+	}
+	if m.AgentName != testPickerAgentB {
+		t.Errorf("AgentName = %q, want %s", m.AgentName, testPickerAgentB)
+	}
+}
+
+// TestPromptForAgent_FlagOverrideMustBeEligibleAgent: --agent NAME where
+// NAME is configured but has no hooks → clear error via existing gate.
+func TestPromptForAgent_FlagOverrideMustBeEligibleAgent(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, testPickerAgentA)
+	// Configure a second agent too but do NOT install its hooks.
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testPickerAgentA: {Prompt: "review the diff"},
+		testPickerAgentB: {Prompt: "review the diff"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rootCmd := NewRootCmd()
+	errBuf := &bytes.Buffer{}
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"review", "--agent", testPickerAgentB})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --agent points at hookless agent")
+	}
+	if !strings.Contains(errBuf.String(), "Hooks are not installed") {
+		t.Errorf("stderr should mention 'Hooks are not installed', got: %s", errBuf.String())
+	}
+}
+
+// TestRunReview_MultiAgentNoFlagTriggersPicker: canonical picker-fires path.
+// Two eligible agents, no flag, stubbed promptForAgentFn returns the second
+// (alphabetically) → marker written with that agent.
+func TestRunReview_MultiAgentNoFlagTriggersPicker(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, testPickerAgentA)
+	installHooksForTest(t, testPickerAgentB)
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testPickerAgentA: {Prompt: "review the diff"},
+		testPickerAgentB: {Prompt: "review the diff"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var seen []string
+	deps := runReviewDeps{
+		promptForAgentFn: func(_ context.Context, eligible []agentChoice) (string, error) {
+			for _, e := range eligible {
+				seen = append(seen, e.Name)
+			}
+			if len(eligible) < 2 {
+				t.Fatalf("expected >=2 eligible, got %d", len(eligible))
+			}
+			// Alphabetical ordering; pick the second one.
+			return eligible[1].Name, nil
+		},
+	}
+
+	reviewCmd := newReviewCmdWithDeps(deps)
+	if err := reviewCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(seen) < 2 || seen[0] != testPickerAgentA || seen[1] != testPickerAgentB {
+		t.Errorf("eligible presented to picker = %v, want [%s %s]", seen, testPickerAgentA, testPickerAgentB)
+	}
+
+	m, ok, err := ReadPendingReviewMarker(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("marker should be written: ok=%v err=%v", ok, err)
+	}
+	if m.AgentName != testPickerAgentB {
+		t.Errorf("AgentName = %q, want %s", m.AgentName, testPickerAgentB)
+	}
+}

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -267,6 +267,46 @@ func TestComposeReviewPrompt_NoFinishSkill(t *testing.T) {
 	}
 }
 
+// --agent flag resolves a non-default configured agent when the map has
+// multiple entries. Previously the alphabetically-first agent always won
+// silently.
+func TestSelectReviewAgent_OverrideResolvesSpecificAgent(t *testing.T) {
+	t.Parallel()
+	const codexAgent = "codex"
+	review := map[string][]string{
+		testAgentName: {"/a"},
+		codexAgent:    {"/b"},
+	}
+
+	name, skills, err := selectReviewAgent(review, codexAgent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != codexAgent || len(skills) != 1 || skills[0] != "/b" {
+		t.Errorf("override=%s returned name=%q skills=%v", codexAgent, name, skills)
+	}
+
+	// Default (no override) must remain the alphabetically-first agent for
+	// backwards compatibility.
+	name, _, err = selectReviewAgent(review, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != testAgentName {
+		t.Errorf("default pick = %q, want %s", name, testAgentName)
+	}
+
+	// Unknown override must surface a helpful error listing the configured
+	// agents instead of silently falling back.
+	_, _, err = selectReviewAgent(review, "gemini")
+	if err == nil {
+		t.Fatal("expected error for unconfigured --agent value")
+	}
+	if !strings.Contains(err.Error(), testAgentName) || !strings.Contains(err.Error(), codexAgent) {
+		t.Errorf("error should list configured agents; got: %v", err)
+	}
+}
+
 func TestNewReviewCmd_NoHiddenFlags(t *testing.T) {
 	t.Parallel()
 	cmd := newReviewCmd()

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -356,6 +356,21 @@ func TestMergePickerResults(t *testing.T) {
 			selected: map[string][]string{testAgentName: {"/a"}},
 			want:     map[string][]string{testAgentName: {"/a"}},
 		},
+		{
+			// Regression: deselecting all curated agents while external
+			// config remains must yield a non-empty merged map, so --edit
+			// can save the "only external agent left" state.
+			name: "deselected curated agent leaves only external entry",
+			existing: map[string][]string{
+				testAgentName: {"/old-pick"},
+				"my-external": {"/external-skill"},
+			},
+			offered:  map[string]struct{}{testAgentName: {}},
+			selected: map[string][]string{}, // user deselected everything offered
+			want: map[string][]string{
+				"my-external": {"/external-skill"},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -106,8 +106,15 @@ type State struct {
 	Kind Kind `json:"kind,omitempty"`
 
 	// ReviewSkills is the snapshot of configured review skills at session start.
-	// Preserved so checkpoint metadata records which skills were run.
+	// Preserved so checkpoint metadata records which skills were run. May be
+	// empty when a review was attached post-hoc and skills were not declared;
+	// ReviewPrompt is the ground truth in that case.
 	ReviewSkills []string `json:"review_skills,omitempty"`
+
+	// ReviewPrompt is the actual text of the review request — the composed
+	// prompt sent to the agent (spawn path) or the session's first user
+	// prompt (attach path). Always populated when Kind is a review kind.
+	ReviewPrompt string `json:"review_prompt,omitempty"`
 
 	// TurnID is a unique identifier for the current agent turn.
 	// Lifecycle:

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -69,10 +69,9 @@ type EntireSettings struct {
 	// Redaction configures PII redaction behavior for transcripts and metadata.
 	Redaction *RedactionSettings `json:"redaction,omitempty"`
 
-	// Review maps agent name (e.g. "claude-code") to the list of review
-	// skills/commands that `entire review` should run for that agent.
-	// When empty, `entire review` triggers the first-run picker.
-	Review map[string][]string `json:"review,omitempty"`
+	// Review maps agent name (e.g. "claude-code") to the review config for
+	// that agent. When empty, `entire review` triggers the first-run picker.
+	Review map[string]ReviewConfig `json:"review,omitempty"`
 
 	// CommitLinking controls how commits are linked to agent sessions.
 	// "always" = auto-link without prompting, "prompt" = ask on each commit.
@@ -188,12 +187,41 @@ func (s *EntireSettings) SummaryTimeoutValue() time.Duration {
 	return time.Duration(s.SummaryTimeoutSeconds) * time.Second
 }
 
-// ReviewSkillsFor returns the configured review skills for the given agent.
-// Returns nil when the agent has no configuration; callers should treat
-// this as "not yet configured."
-func (s *EntireSettings) ReviewSkillsFor(agentName string) []string {
+// ReviewConfig holds the per-agent review configuration. Both fields are
+// optional; together they describe what `entire review` should ask the
+// agent to do.
+//
+// Precedence when composing the review prompt sent to the agent:
+//   - If Prompt is non-empty, it is used verbatim.
+//   - Otherwise, Skills are composed into a default template
+//     ("Please run these review skills in order: 1. /X 2. /Y").
+//
+// Skills are always recorded on the checkpoint metadata regardless of
+// which path composed the prompt — they're the structured, queryable
+// tag alongside ReviewPrompt (which is the ground truth).
+type ReviewConfig struct {
+	// Skills is the list of slash-prefixed skill invocations configured
+	// for this agent. May be empty when Prompt carries the full request.
+	Skills []string `json:"skills,omitempty"`
+
+	// Prompt, when non-empty, is used verbatim as the review prompt
+	// instead of the skills-composed template. Lets users include
+	// context (e.g. "focus on security issues, then run /X").
+	Prompt string `json:"prompt,omitempty"`
+}
+
+// IsZero reports whether the config is effectively unset.
+func (c ReviewConfig) IsZero() bool {
+	return len(c.Skills) == 0 && c.Prompt == ""
+}
+
+// ReviewConfigFor returns the configured review config for the given agent.
+// Returns a zero-value config when the agent has no entry; callers should
+// check IsZero (or the individual fields) to decide whether configuration
+// is present.
+func (s *EntireSettings) ReviewConfigFor(agentName string) ReviewConfig {
 	if s == nil {
-		return nil
+		return ReviewConfig{}
 	}
 	return s.Review[agentName]
 }

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -979,31 +979,67 @@ func TestEntireSettings_ReviewRoundTrip(t *testing.T) {
 	raw := []byte(`{
       "enabled": true,
       "review": {
-        "claude-code": ["/pr-review-toolkit:review-pr", "/test-auditor"],
-        "codex": ["/codex:adversarial-review"]
+        "claude-code": {
+          "skills": ["/pr-review-toolkit:review-pr", "/test-auditor"],
+          "prompt": "Focus on security regressions."
+        },
+        "codex": {
+          "skills": ["/codex:adversarial-review"]
+        }
       }
     }`)
 	var s EntireSettings
 	if err := json.Unmarshal(raw, &s); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if got := s.Review["claude-code"]; len(got) != 2 || got[0] != "/pr-review-toolkit:review-pr" {
-		t.Fatalf("unexpected claude skills: %v", got)
+	claude := s.Review["claude-code"]
+	if len(claude.Skills) != 2 || claude.Skills[0] != "/pr-review-toolkit:review-pr" {
+		t.Fatalf("unexpected claude skills: %v", claude.Skills)
 	}
-	if got := s.Review["codex"]; len(got) != 1 {
-		t.Fatalf("unexpected codex skills: %v", got)
+	if claude.Prompt != "Focus on security regressions." {
+		t.Fatalf("unexpected claude prompt: %q", claude.Prompt)
+	}
+	codex := s.Review["codex"]
+	if len(codex.Skills) != 1 {
+		t.Fatalf("unexpected codex skills: %v", codex.Skills)
+	}
+	if codex.Prompt != "" {
+		t.Fatalf("expected empty prompt for codex, got %q", codex.Prompt)
 	}
 }
 
-func TestEntireSettings_ReviewSkillsFor(t *testing.T) {
+func TestEntireSettings_ReviewConfigFor(t *testing.T) {
 	t.Parallel()
-	s := &EntireSettings{Review: map[string][]string{
-		"claude-code": {"/pr-review-toolkit:review-pr"},
+	s := &EntireSettings{Review: map[string]ReviewConfig{
+		"claude-code": {Skills: []string{"/pr-review-toolkit:review-pr"}},
 	}}
-	if got := s.ReviewSkillsFor("claude-code"); len(got) != 1 {
-		t.Fatalf("expected 1 skill, got %v", got)
+	if cfg := s.ReviewConfigFor("claude-code"); len(cfg.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %v", cfg.Skills)
 	}
-	if got := s.ReviewSkillsFor("codex"); len(got) != 0 {
-		t.Fatalf("expected 0 skills for unconfigured agent, got %v", got)
+	if cfg := s.ReviewConfigFor("codex"); !cfg.IsZero() {
+		t.Fatalf("expected zero config for unconfigured agent, got %+v", cfg)
+	}
+}
+
+func TestReviewConfig_IsZero(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  ReviewConfig
+		want bool
+	}{
+		{"empty", ReviewConfig{}, true},
+		{"skills-only", ReviewConfig{Skills: []string{"/x"}}, false},
+		{"prompt-only", ReviewConfig{Prompt: "hello"}, false},
+		{"both", ReviewConfig{Skills: []string{"/x"}, Prompt: "y"}, false},
+		{"empty-slice", ReviewConfig{Skills: []string{}}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.cfg.IsZero(); got != tc.want {
+				t.Errorf("IsZero() = %v, want %v (cfg=%+v)", got, tc.want, tc.cfg)
+			}
+		})
 	}
 }

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -252,6 +252,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		Summary:                     summary,
 		Kind:                        string(state.Kind),
 		ReviewSkills:                state.ReviewSkills,
+		ReviewPrompt:                state.ReviewPrompt,
 		HasReview:                   state.Kind.IsReview(),
 	}
 


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/3eaecdfe2315

A few review / bug fixes.

- removed `--track-only` replaced it with `entire review attach` instead - I think `--track-only` is to complicated and easy to forget (both to do it before, but also to remove it after)
- allow specifying a "prompt" instead of just using skills (is not great yet, the page after the skill pick asks you for a prompt)

```
  {
    "review": {
      "claude-code": {
        "skills": ["/pr-review-toolkit:review-pr", "/test-auditor"],
        "prompt": "Focus on security regressions this week, then run the skills above."
      }
    }
  }
```

- `--agent <name>` flag (`47c40ada2`) — select a specific configured agent when more than one is in `review:`; unknown value surfaces a concrete error listing the configured alternatives.

- Hooks-installed gate(`d420e6671`) — aborts with a clear `entire configure --agent <name>` pointer when the selected agent's hooks aren't installed (silent failure shape: marker would otherwise be written with no hook to adopt it).

- `ReviewPrompt` field (`7d9aadb91`) — records the ground-truth text of the review request alongside the structured `ReviewSkills` list. Composed prompt for spawn; first user prompt from the transcript for attach.

- Review-attach surfaces (`2505c5fd2`) — two equivalent ways to tag an existing session as a review:

```
entire attach <session-id> --review [--skills "/a,/b"]
entire review attach <session-id> [--skills "/a,/b"]
```

Both funnel into `runAttach` via an `attachOptions` struct. Skills resolve after agent detection (`d81953ed5`) so a Gemini session attached without `--agent` correctly auto-detects. External agents work on both surfaces (`76535a29d`).

This also adds the first prompt from the log as review_prompt


### UX polish

**First-run banner** (`7f2fdb06b`) — running `entire review` with no config used to silently drop into the picker. Now prints an explicit "first-run setup" banner, gates the picker on a huh confirmation, and signposts "Setup complete — running review now." when transitioning to the actual review.

**Helpful error text** in the empty-installed-agents case.

### Internal cleanups

- `runAttach` grew an `attachOptions` struct to avoid a 6th positional param.
- Extracted `runAttachSurfaceReviewErrors` so review-mode errors reach stderr under root's `SilenceErrors=true`.
- `review_test.go` got a shared `setupReviewTestRepoWithCommit` helper, test constants for repeated agent/skill names, and a `reflect.DeepEqual` merge-result assertion fixing a bug where multi-element skill slices weren't compared element-wise.
- `slices.Contains` replaces a throwaway map build in the hooks gate; direct map lookup replaces a linear scan in `selectReviewAgent`'s override path.

### Test coverage

- Regression tests for every correctness fix (marker agent/SHA binding, picker wipes, fallback marker survival, existing-checkpoint review refusal).
- End-to-end integration tests for both attach surfaces, including Gemini auto-detection without `--agent`.
- Pinned behavior tests for the data model: `ReviewPrompt` roundtrip, marker location, `Kind.IsReview` umbrella, config-doesn't-leak-into-attach.

All unit + integration + canary E2E tests green. No API calls consumed — Vogon canary + external-agent canary cover the checkpointing paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the persisted review configuration schema and checkpoint/session metadata (adds `review_prompt`), plus modifies review marker adoption logic; this can affect backward compatibility and how reviews are tagged/recorded across agents and repos.
> 
> **Overview**
> Adds **review-mode attach** support via `entire attach --review` (plus new `entire review attach` alias), recording review metadata (`kind=agent_review`, optional `review_skills`, and new **`review_prompt`** captured from the transcript’s first user prompt) into session state and committed checkpoint metadata.
> 
> Upgrades `entire review` configuration from `review: {agent: [skills...]}` to `review: {agent: {skills, prompt}}`, adds first-run setup confirmation UX, supports `--agent` selection when multiple agents are configured, and prevents silent failure by aborting when the chosen agent’s hooks are not installed.
> 
> Hardens pending-review marker adoption by scoping to **worktree + agent name** and discarding stale markers when HEAD SHA has moved; also fixes non-launchable-agent behavior to preserve the marker and instruct users to start the agent manually instead of relying on the removed `--track-only` path. Extensive new unit/integration tests cover these regressions and end-to-end flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ffaef2c56e365974deb8a429df4da0a2c0c0043. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->