### PR TITLE
Consolidate TTY detection into interactive package

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -22,6 +22,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -1981,7 +1982,7 @@ func formatSessionInfo(session *strategy.Session, sourceRef string, checkpoints 
 func outputWithPager(w io.Writer, content string) {
 	// Check if we're writing to stdout and it's a terminal
 	//nolint:gosec // G115: uintptr->int is safe for fd on 64-bit platforms
-	if f, ok := w.(*os.File); ok && f == os.Stdout && term.IsTerminal(int(f.Fd())) {
+	if f, ok := w.(*os.File); ok && f == os.Stdout && interactive.IsTerminalWriter(w) {
 		// Get terminal height
 		_, height, err := term.GetSize(int(f.Fd())) //nolint:gosec // G115: same as above
 		if err != nil {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1981,7 +1981,6 @@ func formatSessionInfo(session *strategy.Session, sourceRef string, checkpoints 
 // outputWithPager outputs content through a pager if stdout is a terminal and content is long.
 func outputWithPager(w io.Writer, content string) {
 	// Check if we're writing to stdout and it's a terminal
-	//nolint:gosec // G115: uintptr->int is safe for fd on 64-bit platforms
 	if f, ok := w.(*os.File); ok && f == os.Stdout && interactive.IsTerminalWriter(w) {
 		// Get terminal height
 		_, height, err := term.GetSize(int(f.Fd())) //nolint:gosec // G115: same as above

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -1116,12 +1116,14 @@ func (env *TestEnv) gitCommitWithShadowHooks(message string, simulateTTY bool, f
 	prepCmd := exec.Command(getTestBinary(), "hooks", "git", "prepare-commit-msg", msgFile, "message")
 	prepCmd.Dir = env.RepoDir
 	if simulateTTY {
-		// Simulate human at terminal: ENTIRE_TEST_TTY=1 makes hasTTY() return true
-		// and askConfirmTTY() return defaultYes without reading from /dev/tty.
+		// Simulate human at terminal: ENTIRE_TEST_TTY=1 makes
+		// interactive.CanPromptInteractively() return true and askConfirmTTY()
+		// return defaultYes without reading from /dev/tty.
 		prepCmd.Env = env.gitHookEnv("ENTIRE_TEST_TTY=1")
 	} else {
-		// Simulate agent: ENTIRE_TEST_TTY=0 makes hasTTY() return false,
-		// triggering the fast path that adds trailers for ACTIVE sessions.
+		// Simulate agent: ENTIRE_TEST_TTY=0 makes
+		// interactive.CanPromptInteractively() return false, triggering the
+		// fast path that adds trailers for ACTIVE sessions.
 		prepCmd.Env = env.gitHookEnv("ENTIRE_TEST_TTY=0")
 	}
 	if output, err := prepCmd.CombinedOutput(); err != nil {

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -3,22 +3,41 @@
 // import cli).
 package interactive
 
-import "os"
+import (
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
 
 // CanPromptInteractively reports whether interactive confirmation prompts
 // (huh forms, yes/no questions, etc.) can be shown. Returns false in CI,
-// tests without ENTIRE_TEST_TTY=1, and other environments without a
+// tests without ENTIRE_TEST_TTY=1, agent subprocesses that inherit a TTY
+// but can't respond to prompts, and other environments without a
 // controlling TTY.
 //
-// ENTIRE_TEST_TTY overrides /dev/tty detection so tests can exercise both
-// interactive and non-interactive paths deterministically without needing
-// a real pty:
+// ENTIRE_TEST_TTY overrides every other check so tests can exercise both
+// interactive and non-interactive paths deterministically without a real pty:
 //   - ENTIRE_TEST_TTY=1 forces interactive mode on
 //   - any other non-empty value forces interactive mode off
-//   - unset falls through to /dev/tty availability
+//   - unset falls through to agent-env guards and /dev/tty probing
 func CanPromptInteractively() bool {
 	if v, ok := os.LookupEnv("ENTIRE_TEST_TTY"); ok {
 		return v == "1"
+	}
+
+	// Agent subprocesses may inherit the user's TTY but can't respond to
+	// interactive prompts. Treat them as non-TTY.
+	//   - GEMINI_CLI=1: Gemini CLI shell tool (https://geminicli.com/docs/tools/shell/)
+	//   - COPILOT_CLI=1: Copilot CLI hook subprocesses (v0.0.421+)
+	//   - PI_CODING_AGENT=true: Pi Coding Agent shell tool
+	//   - GIT_TERMINAL_PROMPT=0: caller (CI, Factory AI Droid, etc.) asked
+	//     git to stop prompting; respect it from git-hook context too.
+	if os.Getenv("GEMINI_CLI") != "" ||
+		os.Getenv("COPILOT_CLI") != "" ||
+		os.Getenv("PI_CODING_AGENT") != "" ||
+		os.Getenv("GIT_TERMINAL_PROMPT") == "0" {
+		return false
 	}
 
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
@@ -27,4 +46,15 @@ func CanPromptInteractively() bool {
 	}
 	_ = tty.Close()
 	return true
+}
+
+// IsTerminalWriter reports whether w is an *os.File backed by a terminal.
+// Use for deciding on color, pager, progress bars, or other writer-scoped
+// TTY formatting. For "can I prompt the user?" use CanPromptInteractively.
+func IsTerminalWriter(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd())) //nolint:gosec // G115: uintptr->int is safe for fd
 }

--- a/cmd/entire/cli/interactive/interactive.go
+++ b/cmd/entire/cli/interactive/interactive.go
@@ -12,15 +12,18 @@ import (
 
 // CanPromptInteractively reports whether interactive confirmation prompts
 // (huh forms, yes/no questions, etc.) can be shown. Returns false in CI,
-// tests without ENTIRE_TEST_TTY=1, agent subprocesses that inherit a TTY
-// but can't respond to prompts, and other environments without a
-// controlling TTY.
+// agent subprocesses that inherit a TTY but can't respond to prompts,
+// and other environments without a controlling TTY.
 //
-// ENTIRE_TEST_TTY overrides every other check so tests can exercise both
-// interactive and non-interactive paths deterministically without a real pty:
+// When ENTIRE_TEST_TTY is set (to any value, including empty) it is treated
+// as a test override and the result is determined solely by whether the
+// value equals "1":
 //   - ENTIRE_TEST_TTY=1 forces interactive mode on
-//   - any other non-empty value forces interactive mode off
-//   - unset falls through to agent-env guards and /dev/tty probing
+//   - any other value (including empty) forces interactive mode off
+//   - ENTIRE_TEST_TTY unset falls through to agent-env guards and
+//     /dev/tty probing. In that case the return value depends on the
+//     actual environment, so tests that need a specific answer should set
+//     ENTIRE_TEST_TTY explicitly rather than assume a non-interactive host.
 func CanPromptInteractively() bool {
 	if v, ok := os.LookupEnv("ENTIRE_TEST_TTY"); ok {
 		return v == "1"

--- a/cmd/entire/cli/interactive/interactive_test.go
+++ b/cmd/entire/cli/interactive/interactive_test.go
@@ -1,6 +1,10 @@
 package interactive
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"testing"
+)
 
 func TestCanPromptInteractively_ForcedOn(t *testing.T) {
 	t.Setenv("ENTIRE_TEST_TTY", "1")
@@ -13,5 +17,49 @@ func TestCanPromptInteractively_ForcedOff(t *testing.T) {
 	t.Setenv("ENTIRE_TEST_TTY", "0")
 	if CanPromptInteractively() {
 		t.Error("CanPromptInteractively() = true; want false when ENTIRE_TEST_TTY=0")
+	}
+}
+
+func TestCanPromptInteractively_AgentEnvGuards(t *testing.T) {
+	// Unset ENTIRE_TEST_TTY so agent-env guards run. Force an explicit unset
+	// since the top-level check short-circuits on presence, not value.
+	t.Setenv("ENTIRE_TEST_TTY", "")
+	_ = os.Unsetenv("ENTIRE_TEST_TTY")
+
+	cases := []struct {
+		name, key, val string
+	}{
+		{"gemini", "GEMINI_CLI", "1"},
+		{"copilot", "COPILOT_CLI", "1"},
+		{"pi", "PI_CODING_AGENT", "true"},
+		{"git-terminal-prompt-off", "GIT_TERMINAL_PROMPT", "0"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv(c.key, c.val)
+			if CanPromptInteractively() {
+				t.Errorf("CanPromptInteractively() = true; want false when %s=%s", c.key, c.val)
+			}
+		})
+	}
+}
+
+func TestIsTerminalWriter_NonFile(t *testing.T) {
+	t.Parallel()
+	if IsTerminalWriter(&bytes.Buffer{}) {
+		t.Error("IsTerminalWriter(*bytes.Buffer) = true; want false")
+	}
+}
+
+func TestIsTerminalWriter_Pipe(t *testing.T) {
+	t.Parallel()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+	if IsTerminalWriter(w) {
+		t.Error("IsTerminalWriter(pipe) = true; want false")
 	}
 }

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/search"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
@@ -66,7 +67,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			}
 
 			w := cmd.OutOrStdout()
-			isTerminal := isTerminalWriter(w)
+			isTerminal := interactive.IsTerminalWriter(w)
 			hasFilters := authorFlag != "" || dateFlag != "" || branchFlag != "" || len(repos) > 0
 
 			// Fast-fail: no query + non-interactive mode = error (before auth/git checks)

--- a/cmd/entire/cli/status_style.go
+++ b/cmd/entire/cli/status_style.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 
 	"golang.org/x/term"
 )
@@ -62,20 +63,12 @@ func (s statusStyles) render(style lipgloss.Style, text string) string {
 	return style.Render(text)
 }
 
-// isTerminalWriter returns true if the writer is connected to a terminal.
-func isTerminalWriter(w io.Writer) bool {
-	if f, ok := w.(*os.File); ok {
-		return term.IsTerminal(int(f.Fd())) //nolint:gosec // G115: uintptr->int is safe for fd
-	}
-	return false
-}
-
 // shouldUseColor returns true if the writer supports color output.
 func shouldUseColor(w io.Writer) bool {
 	if os.Getenv("NO_COLOR") != "" {
 		return false
 	}
-	return isTerminalWriter(w)
+	return interactive.IsTerminalWriter(w)
 }
 
 // getTerminalWidth returns the terminal width, capped at 80 with a fallback of 60.

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -22,6 +22,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/gitops"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -37,55 +38,6 @@ import (
 	"github.com/go-git/go-git/v6/utils/binary"
 )
 
-// hasTTY checks if /dev/tty is available for interactive prompts.
-// Returns false when running as an agent subprocess (no controlling terminal).
-//
-// In test environments, ENTIRE_TEST_TTY overrides the real check:
-//   - ENTIRE_TEST_TTY=1 → simulate human (TTY available)
-//   - ENTIRE_TEST_TTY=0 → simulate agent (no TTY)
-func hasTTY() bool {
-	if v := os.Getenv("ENTIRE_TEST_TTY"); v != "" {
-		return v == "1"
-	}
-
-	// Gemini CLI sets GEMINI_CLI=1 when running shell commands.
-	// Gemini subprocesses may have access to the user's TTY, but they can't
-	// actually respond to interactive prompts. Treat them as non-TTY.
-	// See: https://geminicli.com/docs/tools/shell/
-	if os.Getenv("GEMINI_CLI") != "" {
-		return false
-	}
-
-	// Copilot CLI sets COPILOT_CLI=1 when running hook subprocesses (v0.0.421+).
-	// Like Gemini, the subprocess may inherit the user's TTY but can't respond
-	// to interactive prompts.
-	if os.Getenv("COPILOT_CLI") != "" {
-		return false
-	}
-
-	// Pi Coding Agent sets PI_CODING_AGENT=true when running shell commands.
-	// Like other agents, the subprocess may inherit the TTY but can't respond
-	// to interactive prompts.
-	if os.Getenv("PI_CODING_AGENT") != "" {
-		return false
-	}
-
-	// GIT_TERMINAL_PROMPT=0 disables git's own terminal prompts.
-	// Factory AI Droid (and other non-interactive environments like CI) set this.
-	// Since we run as a git hook, respect it — if the environment doesn't want
-	// git prompting, our hook shouldn't prompt either.
-	if os.Getenv("GIT_TERMINAL_PROMPT") == "0" {
-		return false
-	}
-
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
-	if err != nil {
-		return false
-	}
-	_ = tty.Close()
-	return true
-}
-
 // ttyResult represents the outcome of a TTY confirmation prompt.
 type ttyResult int
 
@@ -96,8 +48,9 @@ const (
 )
 
 // askConfirmTTY prompts the user via /dev/tty whether to link a commit to session context.
-// This requires a controlling terminal — callers must check hasTTY() first and handle
-// the no-TTY case (agent subprocesses, CI) themselves.
+// This requires a controlling terminal — callers must check
+// interactive.CanPromptInteractively() first and handle the no-TTY case
+// (agent subprocesses, CI) themselves.
 //
 // header is displayed as the first line (e.g., "Entire: Active Claude Code session").
 // detail lines are displayed indented below the header.
@@ -108,7 +61,7 @@ func askConfirmTTY(header string, details []string, prompt string, defaultYes bo
 	}
 
 	// In test mode, don't try to interact with the real TTY — just use the default.
-	// ENTIRE_TEST_TTY=1 simulates "a human is present" for the hasTTY() check
+	// ENTIRE_TEST_TTY=1 simulates "a human is present" for CanPromptInteractively(),
 	// but we can't actually read from the TTY in tests.
 	if os.Getenv("ENTIRE_TEST_TTY") != "" {
 		return defaultResult
@@ -546,7 +499,7 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 	case "message":
 		// Using -m or -F: behavior depends on TTY availability and commit_linking setting
 		switch {
-		case !hasTTY():
+		case !interactive.CanPromptInteractively():
 			// No TTY (agent subprocess, CI) — auto-link without prompting
 			message = addCheckpointTrailer(message, checkpointID)
 		case commitLinking == settings.CommitLinkingAlways:
@@ -2051,7 +2004,7 @@ func (s *ManualCommitStrategy) warnIfAttributionDiverged(ctx context.Context, se
 //     have /dev/tty but can't respond to prompts, and content detection fails
 //     since the shadow branch doesn't exist yet).
 func (s *ManualCommitStrategy) tryAgentCommitFastPath(ctx context.Context, commitMsgFile string, sessions []*SessionState, source string) bool {
-	noTTY := !hasTTY()
+	noTTY := !interactive.CanPromptInteractively()
 	skipContentDetection := noTTY
 	if !skipContentDetection {
 		if stngs, err := settings.Load(ctx); err == nil {

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -61,8 +61,9 @@ func askConfirmTTY(header string, details []string, prompt string, defaultYes bo
 	}
 
 	// In test mode, don't try to interact with the real TTY — just use the default.
-	// ENTIRE_TEST_TTY=1 simulates "a human is present" for CanPromptInteractively(),
-	// but we can't actually read from the TTY in tests.
+	// Any non-empty ENTIRE_TEST_TTY value is treated as test mode here. Tests may use
+	// this to simulate "a human is present" for CanPromptInteractively(), but we can't
+	// actually read from the TTY in tests.
 	if os.Getenv("ENTIRE_TEST_TTY") != "" {
 		return defaultResult
 	}

--- a/cmd/entire/cli/strategy/preparecommitmsg_bench_test.go
+++ b/cmd/entire/cli/strategy/preparecommitmsg_bench_test.go
@@ -152,7 +152,7 @@ func benchSetupPrepareCommitMsgRepo(b *testing.B, fileCount, sessionCount int) (
 		b.Fatalf("write commit msg: %v", err)
 	}
 
-	// Set ENTIRE_TEST_TTY=0 so hasTTY() returns false (simulates agent subprocess).
+	// Set ENTIRE_TEST_TTY=0 so interactive.CanPromptInteractively() returns false (simulates agent subprocess).
 	// This avoids interactive TTY prompts during benchmarks.
 	b.Setenv("ENTIRE_TEST_TTY", "0")
 

--- a/e2e/cmd/testreport/main.go
+++ b/e2e/cmd/testreport/main.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"golang.org/x/term"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 )
 
 type TestEvent struct {
@@ -41,7 +41,7 @@ func main() {
 	outputFile := flag.String("o", "", "Write output to file (ANSI + .nocolor.txt)")
 	flag.Parse()
 
-	useColor := *colorFlag || term.IsTerminal(int(os.Stdout.Fd()))
+	useColor := *colorFlag || interactive.IsTerminalWriter(os.Stdout)
 
 	r, err := openInput(flag.Arg(0))
 	if err != nil {

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -94,10 +94,11 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 	}
 	// commit_linking=always ensures the prepare-commit-msg hook adds the
 	// Entire-Checkpoint trailer unconditionally. This is needed because
-	// interactive agents run inside tmux (hasTTY()=true) but can't respond to
-	// prompts, and content detection may fail on the first checkpoint when no
-	// shadow branch exists yet. Prompt-mode agents still exercise the !hasTTY()
-	// fast path since they have no TTY regardless of this setting.
+	// interactive agents run inside tmux (CanPromptInteractively()=true) but
+	// can't respond to prompts, and content detection may fail on the first
+	// checkpoint when no shadow branch exists yet. Prompt-mode agents still
+	// exercise the !CanPromptInteractively() fast path since they have no TTY
+	// regardless of this setting.
 	PatchSettings(t, dir, map[string]any{"log_level": "debug", "commit_linking": "always"})
 
 	// Copilot CLI blocks on a "No copilot instructions found" notice in fresh


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/e9827b1ca445

## Summary
- Collapsed 5 near-duplicate TTY checks into 2 helpers in `cmd/entire/cli/interactive`.
- `CanPromptInteractively()` — `/dev/tty` probe + `ENTIRE_TEST_TTY` override + agent-env guards (`GEMINI_CLI`, `COPILOT_CLI`, `PI_CODING_AGENT`, `GIT_TERMINAL_PROMPT=0`). Replaces `strategy.hasTTY()`.
- `IsTerminalWriter(w)` — fd-backed terminal check for writer-scoped formatting (color, pager). Replaces `cli.isTerminalWriter` and inline `term.IsTerminal` calls in `explain.go`, `search_cmd.go`, `e2e/cmd/testreport/main.go`.

## Why
Two orthogonal questions were each answered in multiple places:
- "Can I prompt the user?" — needs `/dev/tty` probe (stdin may be a pipe in git hooks). `strategy.hasTTY()` was bulletproof (agent-env guards) but duplicated the simpler `interactive.CanPromptInteractively()`.
- "Is this writer a terminal?" — needs `term.IsTerminal(fd)`. `cli.isTerminalWriter` plus two inline copies.

Net: 5 → 2. Agent-env guards now apply everywhere prompts fire (login, setup, attach, summary provider), not just the git-hook fast path.

## Test plan
- [x] `mise run test` (includes new `interactive` pkg coverage for agent-env guards + `IsTerminalWriter` with non-file and pipe writers)
- [x] `mise run test:integration`
- [x] `mise run test:e2e:canary` (roger-roger + vogon)
- [ ] CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mainly consolidates environment/TTY detection and updates call sites; behavior changes are limited to when prompts/pagers/colors are suppressed in agent/CI-like environments.
> 
> **Overview**
> Consolidates terminal detection into `cmd/entire/cli/interactive` by expanding `CanPromptInteractively()` (adds agent/CI environment guards and makes `ENTIRE_TEST_TTY` override all checks) and introducing `IsTerminalWriter(w)` for writer-scoped TTY formatting.
> 
> Updates CLI features (pager in `explain`, color in `status_style`, interactive gating in `search`), git-hook commit linking fast paths (`manual_commit_hooks.go`), and e2e/test utilities to use these shared helpers, removing duplicated `hasTTY`/`isTerminalWriter` logic and adding focused unit tests for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d61f45eeaa03f0f2b3b9c7ba40e08ed7832e32c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->