### PR TITLE
Fix build: qualify isTerminalWriter in activity_cmd.go

### DIFF
--- a/cmd/entire/cli/activity_cmd.go
+++ b/cmd/entire/cli/activity_cmd.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -62,7 +63,7 @@ func runActivity(ctx context.Context, w, errW io.Writer) error {
 	}
 
 	// Non-interactive fallback: piped output or accessibility mode
-	if !isTerminalWriter(w) || IsAccessibleMode() {
+	if !interactive.IsTerminalWriter(w) || IsAccessibleMode() {
 		return runActivityStatic(ctx, w, client)
 	}
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/058a346a8f5c
<!-- entire-trail-link-end -->

## Summary

- main is red: `cmd/entire/cli/activity_cmd.go:65` calls unqualified `isTerminalWriter`, which doesn't exist in package `cli` — the helper lives in `interactive` (`interactive.IsTerminalWriter`).
- Sibling call sites (`status_style.go`, `search_cmd.go`, `explain.go`) already qualify it correctly. The mismatch slipped in when PR #999 (`Add entire activity`) landed alongside PR #1011 (`simplify-tty-detection`) without reconciliation.
- Seen in CI: https://github.com/entireio/cli/actions/runs/24833277985 — all e2e jobs fail at `go build` with `undefined: isTerminalWriter`.

## Fix

Add the `interactive` import and qualify the call. One-line change plus import.

## Test plan

- [x] `go build ./...` succeeds locally
- [x] `mise run fmt && mise run lint` clean
- [ ] CI green (e2e jobs unblocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: fixes a compile-time undefined symbol by calling the existing `interactive.IsTerminalWriter`, with no behavioral change beyond restoring the intended terminal detection.
> 
> **Overview**
> Fixes a build break in `activity_cmd.go` by importing `interactive` and switching the non-interactive fallback check from an undefined `isTerminalWriter` to `interactive.IsTerminalWriter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56b7ac719dd999db6419e0dc1a2d03d917496bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->