### PR TITLE
Avoid noisy SSH signing failures during push

### DIFF
--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/go-git/go-git/v6"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/x/plugin"
@@ -31,9 +31,7 @@ func RegisterObjectSigner() {
 			sysCfg := loadScopedConfig(cfgSource, config.SystemScope)
 			globalCfg := loadScopedConfig(cfgSource, config.GlobalScope)
 			localCfg := loadLocalConfig()
-			hasCustomSSHProgram := hasCustomSSHSignProgram(sysCfg.Raw) ||
-				hasCustomSSHSignProgram(globalCfg.Raw) ||
-				hasCustomSSHSignProgram(localCfg.Raw)
+			sshSignProgram := effectiveSSHSignProgram(sysCfg.Raw, globalCfg.Raw, localCfg.Raw)
 
 			// Merge system, global, then local so local settings take precedence.
 			merged := config.Merge(sysCfg, globalCfg, localCfg)
@@ -48,7 +46,7 @@ func RegisterObjectSigner() {
 			// will be unsigned, which is acceptable since signing is best-effort.
 			// The default program is "ssh-keygen", which works with go-git's
 			// native SSH agent signing and does not need to be skipped.
-			if auto.Format(merged.GPG.Format) == auto.FormatSSH && hasCustomSSHProgram {
+			if auto.Format(merged.GPG.Format) == auto.FormatSSH && isCustomSSHSignProgram(sshSignProgram) {
 				logging.Debug(context.Background(), "skipping native SSH commit signing: custom gpg.ssh.program is configured")
 				return nil
 			}
@@ -103,9 +101,27 @@ func hasCustomSSHSignProgram(raw *format.Config) bool {
 		return false
 	}
 
-	program := raw.Section("gpg").Subsection("ssh").Option("program")
+	return isCustomSSHSignProgram(raw.Section("gpg").Subsection("ssh").Option("program"))
+}
 
+func isCustomSSHSignProgram(program string) bool {
 	return program != "" && program != "ssh-keygen"
+}
+
+func effectiveSSHSignProgram(raws ...*format.Config) string {
+	for i := len(raws) - 1; i >= 0; i-- {
+		raw := raws[i]
+		if raw == nil {
+			continue
+		}
+
+		program := raw.Section("gpg").Subsection("ssh").Option("program")
+		if program != "" {
+			return program
+		}
+	}
+
+	return ""
 }
 
 func loadScopedConfig(source plugin.ConfigSource, scope config.Scope) *config.Config {

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/go-git/go-git/v6"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/go-git/go-git/v6/config"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
@@ -29,10 +30,13 @@ func RegisterObjectSigner() {
 
 			sysCfg := loadScopedConfig(cfgSource, config.SystemScope)
 			globalCfg := loadScopedConfig(cfgSource, config.GlobalScope)
-			hasCustomSSHProgram := hasCustomSSHSignProgram(sysCfg.Raw) || hasCustomSSHSignProgram(globalCfg.Raw)
+			localCfg := loadLocalConfig()
+			hasCustomSSHProgram := hasCustomSSHSignProgram(sysCfg.Raw) ||
+				hasCustomSSHSignProgram(globalCfg.Raw) ||
+				hasCustomSSHSignProgram(localCfg.Raw)
 
-			// Merge system then global so that global settings take precedence.
-			merged := config.Merge(sysCfg, globalCfg)
+			// Merge system, global, then local so local settings take precedence.
+			merged := config.Merge(sysCfg, globalCfg, localCfg)
 
 			if !merged.Commit.GpgSign.IsTrue() {
 				return nil
@@ -116,6 +120,21 @@ func loadScopedConfig(source plugin.ConfigSource, scope config.Scope) *config.Co
 	cfg, err := storer.Config()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to parse %s git config: %v\n", name, err)
+		return config.NewConfig()
+	}
+
+	return cfg
+}
+
+func loadLocalConfig() *config.Config {
+	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return config.NewConfig()
+	}
+
+	cfg, err := repo.Storer.Config()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to parse local git config: %v\n", err)
 		return config.NewConfig()
 	}
 

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
-	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/x/plugin"
@@ -28,13 +27,7 @@ func RegisterObjectSigner() {
 				return nil
 			}
 
-			var repo *git.Repository
-			repo, err = git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
-			if err != nil {
-				repo = nil
-			}
-
-			merged, sshSignProgram := loadObjectSignerConfig(cfgSource, repo)
+			merged, sshSignProgram := loadObjectSignerConfig(cfgSource)
 
 			if !merged.Commit.GpgSign.IsTrue() {
 				return nil
@@ -68,15 +61,11 @@ func RegisterObjectSigner() {
 	})
 }
 
-func loadObjectSignerConfig(source plugin.ConfigSource, repo *git.Repository) (*config.Config, string) {
+func loadObjectSignerConfig(source plugin.ConfigSource) (*config.Config, string) {
 	sysCfg := loadScopedConfig(source, config.SystemScope)
 	globalCfg := loadScopedConfig(source, config.GlobalScope)
-	localCfg := config.NewConfig()
-	if repo != nil {
-		localCfg = loadRepoLocalConfig(repo)
-	}
-	sshSignProgram := effectiveSSHSignProgram(sysCfg.Raw, globalCfg.Raw, localCfg.Raw)
-	merged := config.Merge(sysCfg, globalCfg, localCfg)
+	sshSignProgram := effectiveSSHSignProgram(sysCfg.Raw, globalCfg.Raw)
+	merged := config.Merge(sysCfg, globalCfg)
 	return &merged, sshSignProgram
 }
 
@@ -142,16 +131,6 @@ func loadScopedConfig(source plugin.ConfigSource, scope config.Scope) *config.Co
 	cfg, err := storer.Config()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to parse %s git config: %v\n", name, err)
-		return config.NewConfig()
-	}
-
-	return cfg
-}
-
-func loadRepoLocalConfig(repo *git.Repository) *config.Config {
-	cfg, err := repo.Storer.Config()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to parse local git config: %v\n", err)
 		return config.NewConfig()
 	}
 

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -33,16 +33,7 @@ func RegisterObjectSigner() {
 				return nil
 			}
 
-			sysCfg := loadScopedConfig(cfgSource, config.SystemScope)
-			globalCfg := loadScopedConfig(cfgSource, config.GlobalScope)
-			localCfg := loadRepoLocalConfig(repo)
-			sshSignProgram := effectiveSSHSignProgram(sysCfg.Raw, globalCfg.Raw, localCfg.Raw)
-
-			merged, err := repo.ConfigScoped(config.SystemScope)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "warning: failed to load merged git config: %v\n", err)
-				return nil
-			}
+			merged, sshSignProgram := loadObjectSignerConfig(cfgSource, repo)
 
 			if !merged.Commit.GpgSign.IsTrue() {
 				return nil
@@ -74,6 +65,15 @@ func RegisterObjectSigner() {
 			return signer
 		})
 	})
+}
+
+func loadObjectSignerConfig(source plugin.ConfigSource, repo *git.Repository) (*config.Config, string) {
+	sysCfg := loadScopedConfig(source, config.SystemScope)
+	globalCfg := loadScopedConfig(source, config.GlobalScope)
+	localCfg := loadRepoLocalConfig(repo)
+	sshSignProgram := effectiveSSHSignProgram(sysCfg.Raw, globalCfg.Raw, localCfg.Raw)
+	merged := config.Merge(sysCfg, globalCfg, localCfg)
+	return &merged, sshSignProgram
 }
 
 // connectSSHAgent connects to the SSH agent via SSH_AUTH_SOCK.

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -17,9 +17,13 @@ import (
 )
 
 var registerObjectSignerOnce sync.Once
+var loadLocalConfigFunc = loadLocalConfig
 
 func RegisterObjectSigner() {
 	registerObjectSignerOnce.Do(func() {
+		var localCfgOnce sync.Once
+		var localCfg *config.Config
+
 		//nolint:errcheck,gosec // best-effort; if registration fails, commits are left unsigned
 		plugin.Register(plugin.ObjectSigner(), func() plugin.Signer {
 			cfgSource, err := plugin.Get(plugin.ConfigLoader())
@@ -30,7 +34,9 @@ func RegisterObjectSigner() {
 
 			sysCfg := loadScopedConfig(cfgSource, config.SystemScope)
 			globalCfg := loadScopedConfig(cfgSource, config.GlobalScope)
-			localCfg := loadLocalConfig()
+			localCfgOnce.Do(func() {
+				localCfg = loadLocalConfigFunc()
+			})
 			sshSignProgram := effectiveSSHSignProgram(sysCfg.Raw, globalCfg.Raw, localCfg.Raw)
 
 			// Merge system, global, then local so local settings take precedence.

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -17,13 +17,9 @@ import (
 )
 
 var registerObjectSignerOnce sync.Once
-var loadLocalConfigFunc = loadLocalConfig
 
 func RegisterObjectSigner() {
 	registerObjectSignerOnce.Do(func() {
-		var localCfgOnce sync.Once
-		var localCfg *config.Config
-
 		//nolint:errcheck,gosec // best-effort; if registration fails, commits are left unsigned
 		plugin.Register(plugin.ObjectSigner(), func() plugin.Signer {
 			cfgSource, err := plugin.Get(plugin.ConfigLoader())
@@ -32,15 +28,21 @@ func RegisterObjectSigner() {
 				return nil
 			}
 
+			repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+			if err != nil {
+				return nil
+			}
+
 			sysCfg := loadScopedConfig(cfgSource, config.SystemScope)
 			globalCfg := loadScopedConfig(cfgSource, config.GlobalScope)
-			localCfgOnce.Do(func() {
-				localCfg = loadLocalConfigFunc()
-			})
+			localCfg := loadRepoLocalConfig(repo)
 			sshSignProgram := effectiveSSHSignProgram(sysCfg.Raw, globalCfg.Raw, localCfg.Raw)
 
-			// Merge system, global, then local so local settings take precedence.
-			merged := config.Merge(sysCfg, globalCfg, localCfg)
+			merged, err := repo.ConfigScoped(config.SystemScope)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to load merged git config: %v\n", err)
+				return nil
+			}
 
 			if !merged.Commit.GpgSign.IsTrue() {
 				return nil
@@ -96,18 +98,12 @@ var scopeName = map[config.Scope]string{
 	config.SystemScope: "system",
 }
 
-// hasCustomSSHSignProgram checks whether gpg.ssh.program is set to a
-// non-default value in the raw config. The git default is "ssh-keygen",
-// which works with go-git's native SSH agent signing. Custom programs
-// (e.g. 1Password's op-ssh-sign) use a separate signing mechanism that
-// go-git cannot invoke.
-// go-git's Config struct does not expose this field, so we read it directly.
-func hasCustomSSHSignProgram(raw *format.Config) bool {
+func rawSSHSignProgram(raw *format.Config) string {
 	if raw == nil {
-		return false
+		return ""
 	}
 
-	return isCustomSSHSignProgram(raw.Section("gpg").Subsection("ssh").Option("program"))
+	return raw.Section("gpg").Subsection("ssh").Option("program")
 }
 
 func isCustomSSHSignProgram(program string) bool {
@@ -121,7 +117,7 @@ func effectiveSSHSignProgram(raws ...*format.Config) string {
 			continue
 		}
 
-		program := raw.Section("gpg").Subsection("ssh").Option("program")
+		program := rawSSHSignProgram(raw)
 		if program != "" {
 			return program
 		}
@@ -148,12 +144,7 @@ func loadScopedConfig(source plugin.ConfigSource, scope config.Scope) *config.Co
 	return cfg
 }
 
-func loadLocalConfig() *config.Config {
-	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
-	if err != nil {
-		return config.NewConfig()
-	}
-
+func loadRepoLocalConfig(repo *git.Repository) *config.Config {
 	cfg, err := repo.Storer.Config()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to parse local git config: %v\n", err)

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
+	"strings"
 	"sync"
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -100,7 +102,14 @@ func rawSSHSignProgram(raw *format.Config) string {
 }
 
 func isCustomSSHSignProgram(program string) bool {
-	return program != "" && program != "ssh-keygen"
+	program = strings.TrimSpace(program)
+	program = strings.Trim(program, `"'`)
+	if program == "" {
+		return false
+	}
+
+	name := path.Base(strings.ReplaceAll(program, `\`, "/"))
+	return !strings.EqualFold(name, "ssh-keygen") && !strings.EqualFold(name, "ssh-keygen.exe")
 }
 
 func effectiveSSHSignProgram(raws ...*format.Config) string {

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -29,6 +29,7 @@ func RegisterObjectSigner() {
 
 			sysCfg := loadScopedConfig(cfgSource, config.SystemScope)
 			globalCfg := loadScopedConfig(cfgSource, config.GlobalScope)
+			hasCustomSSHProgram := hasCustomSSHSignProgram(sysCfg.Raw) || hasCustomSSHSignProgram(globalCfg.Raw)
 
 			// Merge system then global so that global settings take precedence.
 			merged := config.Merge(sysCfg, globalCfg)
@@ -43,7 +44,7 @@ func RegisterObjectSigner() {
 			// will be unsigned, which is acceptable since signing is best-effort.
 			// The default program is "ssh-keygen", which works with go-git's
 			// native SSH agent signing and does not need to be skipped.
-			if auto.Format(merged.GPG.Format) == auto.FormatSSH && hasCustomSSHSignProgram(merged.Raw) {
+			if auto.Format(merged.GPG.Format) == auto.FormatSSH && hasCustomSSHProgram {
 				logging.Debug(context.Background(), "skipping native SSH commit signing: custom gpg.ssh.program is configured")
 				return nil
 			}

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -28,9 +28,10 @@ func RegisterObjectSigner() {
 				return nil
 			}
 
-			repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+			var repo *git.Repository
+			repo, err = git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
 			if err != nil {
-				return nil
+				repo = nil
 			}
 
 			merged, sshSignProgram := loadObjectSignerConfig(cfgSource, repo)
@@ -70,7 +71,10 @@ func RegisterObjectSigner() {
 func loadObjectSignerConfig(source plugin.ConfigSource, repo *git.Repository) (*config.Config, string) {
 	sysCfg := loadScopedConfig(source, config.SystemScope)
 	globalCfg := loadScopedConfig(source, config.GlobalScope)
-	localCfg := loadRepoLocalConfig(repo)
+	localCfg := config.NewConfig()
+	if repo != nil {
+		localCfg = loadRepoLocalConfig(repo)
+	}
 	sshSignProgram := effectiveSSHSignProgram(sysCfg.Raw, globalCfg.Raw, localCfg.Raw)
 	merged := config.Merge(sysCfg, globalCfg, localCfg)
 	return &merged, sshSignProgram

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -45,6 +45,33 @@ func TestIsCustomSSHSignProgram(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "absolute ssh-keygen path is not custom",
+			raw: func() *format.Config {
+				c := format.New()
+				c.Section("gpg").Subsection("ssh").SetOption("program", "/usr/bin/ssh-keygen")
+				return c
+			}(),
+			want: false,
+		},
+		{
+			name: "quoted ssh-keygen path is not custom",
+			raw: func() *format.Config {
+				c := format.New()
+				c.Section("gpg").Subsection("ssh").SetOption("program", "\"/usr/bin/ssh-keygen\"")
+				return c
+			}(),
+			want: false,
+		},
+		{
+			name: "windows ssh-keygen exe is not custom",
+			raw: func() *format.Config {
+				c := format.New()
+				c.Section("gpg").Subsection("ssh").SetOption("program", `C:\Windows\System32\OpenSSH\ssh-keygen.exe`)
+				return c
+			}(),
+			want: false,
+		},
+		{
 			name: "gpg section exists but no ssh.program",
 			raw: func() *format.Config {
 				c := format.New()

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/go-git/go-git/v6/config"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/x/plugin"
-	pluginconfig "github.com/go-git/go-git/v6/x/plugin/config"
 	"github.com/go-git/x/plugin/objectsigner/auto"
 )
+
+const localSigningKey = "local-signing-key"
 
 func TestHasCustomSSHSignProgram(t *testing.T) {
 	t.Parallel()
@@ -225,7 +226,7 @@ func TestObjectSignerConfigMerge_LocalConfigTakesPrecedence(t *testing.T) { //no
 	localCfg := config.NewConfig()
 	localCfg.Commit.GpgSign = config.NewOptBool(true)
 	localCfg.GPG.Format = string(auto.FormatSSH)
-	localCfg.User.SigningKey = "local-signing-key"
+	localCfg.User.SigningKey = localSigningKey
 	localCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
 	if err := repo.SetConfig(localCfg); err != nil {
 		t.Fatalf("repo.SetConfig() error = %v", err)
@@ -244,8 +245,8 @@ func TestObjectSignerConfigMerge_LocalConfigTakesPrecedence(t *testing.T) { //no
 	if got := merged.GPG.Format; got != string(auto.FormatSSH) {
 		t.Fatalf("merged GPG.Format = %q, want %q", got, auto.FormatSSH)
 	}
-	if got := merged.User.SigningKey; got != "local-signing-key" {
-		t.Fatalf("merged User.SigningKey = %q, want %q", got, "local-signing-key")
+	if got := merged.User.SigningKey; got != localSigningKey {
+		t.Fatalf("merged User.SigningKey = %q, want %q", got, localSigningKey)
 	}
 	if !hasCustomSSHSignProgram(loadLocalConfig().Raw) {
 		t.Fatal("expected merged setup to see local custom gpg.ssh.program")
@@ -253,12 +254,8 @@ func TestObjectSignerConfigMerge_LocalConfigTakesPrecedence(t *testing.T) { //no
 }
 
 func TestRegisterObjectSigner_CachesLocalConfigAcrossGets(t *testing.T) {
-	t.Parallel()
-
-	resetPluginEntry("config_loader")
 	resetPluginEntry("object_signer")
 	t.Cleanup(func() {
-		resetPluginEntry("config_loader")
 		resetPluginEntry("object_signer")
 		registerObjectSignerOnce = sync.Once{}
 		loadLocalConfigFunc = loadLocalConfig
@@ -276,12 +273,6 @@ func TestRegisterObjectSigner_CachesLocalConfigAcrossGets(t *testing.T) {
 		cfg.User.SigningKey = "local-signing-key"
 
 		return cfg
-	}
-
-	if err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
-		return pluginconfig.NewEmpty()
-	}); err != nil {
-		t.Fatalf("plugin.Register(config loader) error = %v", err)
 	}
 
 	RegisterObjectSigner()

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -65,9 +65,9 @@ func TestHasCustomSSHSignProgram(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := hasCustomSSHSignProgram(tt.raw)
+			got := isCustomSSHSignProgram(rawSSHSignProgram(tt.raw))
 			if got != tt.want {
-				t.Errorf("hasCustomSSHSignProgram() = %v, want %v", got, tt.want)
+				t.Errorf("isCustomSSHSignProgram(rawSSHSignProgram()) = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -82,11 +82,11 @@ func TestConfigMerge_DropsCustomSSHSignProgramFromRaw(t *testing.T) {
 
 	merged := config.Merge(sysCfg, config.NewConfig())
 
-	if !hasCustomSSHSignProgram(sysCfg.Raw) {
+	if !isCustomSSHSignProgram(rawSSHSignProgram(sysCfg.Raw)) {
 		t.Fatal("expected scoped raw config to report custom gpg.ssh.program")
 	}
 
-	if hasCustomSSHSignProgram(merged.Raw) {
+	if isCustomSSHSignProgram(rawSSHSignProgram(merged.Raw)) {
 		t.Fatal("expected merged raw config to lose custom gpg.ssh.program")
 	}
 }
@@ -154,13 +154,13 @@ func TestCustomSSHSignProgramDetection_UsesScopedRawBeforeMerge(t *testing.T) {
 			globalCfg.GPG.Format = string(auto.FormatSSH)
 			globalCfg.Raw = tt.globalRaw
 
-			got := hasCustomSSHSignProgram(sysCfg.Raw) || hasCustomSSHSignProgram(globalCfg.Raw)
+			got := isCustomSSHSignProgram(rawSSHSignProgram(sysCfg.Raw)) || isCustomSSHSignProgram(rawSSHSignProgram(globalCfg.Raw))
 			if got != tt.want {
 				t.Fatalf("scoped raw detection = %v, want %v", got, tt.want)
 			}
 
 			merged := config.Merge(sysCfg, globalCfg)
-			if got && hasCustomSSHSignProgram(merged.Raw) {
+			if got && isCustomSSHSignProgram(rawSSHSignProgram(merged.Raw)) {
 				t.Fatal("expected merged raw config not to preserve custom gpg.ssh.program")
 			}
 		})
@@ -207,8 +207,8 @@ func TestLoadLocalConfig_ReadsCustomSSHSignProgram(t *testing.T) { //nolint:para
 		t.Fatalf("repo.SetConfig() error = %v", err)
 	}
 
-	localCfg := loadLocalConfig()
-	if !hasCustomSSHSignProgram(localCfg.Raw) {
+	localCfg := loadRepoLocalConfig(repo)
+	if !isCustomSSHSignProgram(rawSSHSignProgram(localCfg.Raw)) {
 		t.Fatal("expected local config to report custom gpg.ssh.program")
 	}
 }
@@ -237,7 +237,7 @@ func TestObjectSignerConfigMerge_LocalConfigTakesPrecedence(t *testing.T) { //no
 	globalCfg.GPG.Format = "openpgp"
 	globalCfg.User.SigningKey = "global-signing-key"
 
-	merged := config.Merge(config.NewConfig(), globalCfg, loadLocalConfig())
+	merged := config.Merge(config.NewConfig(), globalCfg, loadRepoLocalConfig(repo))
 
 	if !merged.Commit.GpgSign.IsTrue() {
 		t.Fatal("expected local commit.gpgsign to override global config")
@@ -248,44 +248,44 @@ func TestObjectSignerConfigMerge_LocalConfigTakesPrecedence(t *testing.T) { //no
 	if got := merged.User.SigningKey; got != localSigningKey {
 		t.Fatalf("merged User.SigningKey = %q, want %q", got, localSigningKey)
 	}
-	if !hasCustomSSHSignProgram(loadLocalConfig().Raw) {
+	if !isCustomSSHSignProgram(rawSSHSignProgram(loadRepoLocalConfig(repo).Raw)) {
 		t.Fatal("expected merged setup to see local custom gpg.ssh.program")
 	}
 }
 
-func TestRegisterObjectSigner_CachesLocalConfigAcrossGets(t *testing.T) {
-	resetPluginEntry("object_signer")
+func TestRegisterObjectSigner_ReturnsNilSignerForLocalCustomSSHProgram(t *testing.T) { //nolint:paralleltest // t.Chdir and plugin registry are process-global
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		t.Fatalf("git.PlainOpen() error = %v", err)
+	}
+
+	localCfg := config.NewConfig()
+	localCfg.Commit.GpgSign = config.NewOptBool(true)
+	localCfg.GPG.Format = string(auto.FormatSSH)
+	localCfg.User.SigningKey = localSigningKey
+	localCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
+	if err := repo.SetConfig(localCfg); err != nil {
+		t.Fatalf("repo.SetConfig() error = %v", err)
+	}
+
+	resetPluginEntry("object-signer")
 	t.Cleanup(func() {
-		resetPluginEntry("object_signer")
+		resetPluginEntry("object-signer")
 		registerObjectSignerOnce = sync.Once{}
-		loadLocalConfigFunc = loadLocalConfig
 	})
 
 	registerObjectSignerOnce = sync.Once{}
-
-	var loadCalls int
-	loadLocalConfigFunc = func() *config.Config {
-		loadCalls++
-
-		cfg := config.NewConfig()
-		cfg.Commit.GpgSign = config.NewOptBool(true)
-		cfg.GPG.Format = string(auto.FormatSSH)
-		cfg.User.SigningKey = "local-signing-key"
-
-		return cfg
-	}
-
 	RegisterObjectSigner()
 
-	for range 2 {
-		signer, err := plugin.Get(plugin.ObjectSigner())
-		if err != nil {
-			t.Fatalf("plugin.Get(object signer) error = %v", err)
-		}
-		_ = signer
+	signer, err := plugin.Get(plugin.ObjectSigner())
+	if err != nil {
+		t.Fatalf("plugin.Get(object signer) error = %v", err)
 	}
-
-	if loadCalls != 1 {
-		t.Fatalf("loadLocalConfigFunc() calls = %d, want 1", loadCalls)
+	if signer != nil {
+		t.Fatal("expected nil signer when local gpg.ssh.program uses a custom signer")
 	}
 }

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -163,6 +163,28 @@ func TestCustomSSHSignProgramDetection_UsesScopedRawBeforeMerge(t *testing.T) {
 	}
 }
 
+func TestEffectiveSSHSignProgram_UsesHighestPrecedenceScope(t *testing.T) {
+	t.Parallel()
+
+	sysRaw := format.New()
+	sysRaw.Section("gpg").Subsection("ssh").SetOption("program", "/usr/local/bin/custom-system-signer")
+
+	globalRaw := format.New()
+	globalRaw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
+
+	localRaw := format.New()
+	localRaw.Section("gpg").Subsection("ssh").SetOption("program", "ssh-keygen")
+
+	got := effectiveSSHSignProgram(sysRaw, globalRaw, localRaw)
+	if got != "ssh-keygen" {
+		t.Fatalf("effectiveSSHSignProgram() = %q, want %q", got, "ssh-keygen")
+	}
+
+	if isCustomSSHSignProgram(got) {
+		t.Fatal("expected highest-precedence ssh-keygen override not to be treated as custom")
+	}
+}
+
 func TestLoadLocalConfig_ReadsCustomSSHSignProgram(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
 	repoDir := t.TempDir()
 	testutil.InitRepo(t, repoDir)

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/x/plugin/objectsigner/auto"
@@ -158,5 +160,69 @@ func TestCustomSSHSignProgramDetection_UsesScopedRawBeforeMerge(t *testing.T) {
 				t.Fatal("expected merged raw config not to preserve custom gpg.ssh.program")
 			}
 		})
+	}
+}
+
+func TestLoadLocalConfig_ReadsCustomSSHSignProgram(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	repoCfg := config.NewConfig()
+	repoCfg.GPG.Format = string(auto.FormatSSH)
+	repoCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
+
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		t.Fatalf("git.PlainOpen() error = %v", err)
+	}
+
+	if err := repo.SetConfig(repoCfg); err != nil {
+		t.Fatalf("repo.SetConfig() error = %v", err)
+	}
+
+	localCfg := loadLocalConfig()
+	if !hasCustomSSHSignProgram(localCfg.Raw) {
+		t.Fatal("expected local config to report custom gpg.ssh.program")
+	}
+}
+
+func TestObjectSignerConfigMerge_LocalConfigTakesPrecedence(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	t.Chdir(repoDir)
+
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		t.Fatalf("git.PlainOpen() error = %v", err)
+	}
+
+	localCfg := config.NewConfig()
+	localCfg.Commit.GpgSign = config.NewOptBool(true)
+	localCfg.GPG.Format = string(auto.FormatSSH)
+	localCfg.User.SigningKey = "local-signing-key"
+	localCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
+	if err := repo.SetConfig(localCfg); err != nil {
+		t.Fatalf("repo.SetConfig() error = %v", err)
+	}
+
+	globalCfg := config.NewConfig()
+	globalCfg.Commit.GpgSign = config.NewOptBool(false)
+	globalCfg.GPG.Format = "openpgp"
+	globalCfg.User.SigningKey = "global-signing-key"
+
+	merged := config.Merge(config.NewConfig(), globalCfg, loadLocalConfig())
+
+	if !merged.Commit.GpgSign.IsTrue() {
+		t.Fatal("expected local commit.gpgsign to override global config")
+	}
+	if got := merged.GPG.Format; got != string(auto.FormatSSH) {
+		t.Fatalf("merged GPG.Format = %q, want %q", got, auto.FormatSSH)
+	}
+	if got := merged.User.SigningKey; got != "local-signing-key" {
+		t.Fatalf("merged User.SigningKey = %q, want %q", got, "local-signing-key")
+	}
+	if !hasCustomSSHSignProgram(loadLocalConfig().Raw) {
+		t.Fatal("expected merged setup to see local custom gpg.ssh.program")
 	}
 }

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -253,6 +254,42 @@ func TestObjectSignerConfigMerge_LocalConfigTakesPrecedence(t *testing.T) { //no
 	}
 }
 
+func TestLoadObjectSignerConfig_IgnoresUpperScopeLoadFailures(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		t.Fatalf("git.PlainOpen() error = %v", err)
+	}
+
+	localCfg := config.NewConfig()
+	localCfg.Commit.GpgSign = config.NewOptBool(true)
+	localCfg.GPG.Format = string(auto.FormatSSH)
+	localCfg.User.SigningKey = localSigningKey
+	localCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
+	if err := repo.SetConfig(localCfg); err != nil {
+		t.Fatalf("repo.SetConfig() error = %v", err)
+	}
+
+	merged, sshSignProgram := loadObjectSignerConfig(failingConfigSource{}, repo)
+
+	if !merged.Commit.GpgSign.IsTrue() {
+		t.Fatal("expected local commit.gpgsign to survive upper-scope load failures")
+	}
+	if got := merged.GPG.Format; got != string(auto.FormatSSH) {
+		t.Fatalf("merged GPG.Format = %q, want %q", got, auto.FormatSSH)
+	}
+	if got := merged.User.SigningKey; got != localSigningKey {
+		t.Fatalf("merged User.SigningKey = %q, want %q", got, localSigningKey)
+	}
+	if !isCustomSSHSignProgram(sshSignProgram) {
+		t.Fatal("expected local custom gpg.ssh.program to survive upper-scope load failures")
+	}
+}
+
 func TestRegisterObjectSigner_ReturnsNilSignerForLocalCustomSSHProgram(t *testing.T) { //nolint:paralleltest // t.Chdir and plugin registry are process-global
 	repoDir := t.TempDir()
 	testutil.InitRepo(t, repoDir)
@@ -288,4 +325,10 @@ func TestRegisterObjectSigner_ReturnsNilSignerForLocalCustomSSHProgram(t *testin
 	if signer != nil {
 		t.Fatal("expected nil signer when local gpg.ssh.program uses a custom signer")
 	}
+}
+
+type failingConfigSource struct{}
+
+func (failingConfigSource) Load(scope config.Scope) (config.ConfigStorer, error) {
+	return nil, errors.New("boom")
 }

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -1,19 +1,12 @@
 package cli
 
 import (
-	"errors"
-	"sync"
 	"testing"
 
-	"github.com/entireio/cli/cmd/entire/cli/testutil"
-	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
-	"github.com/go-git/go-git/v6/x/plugin"
 	"github.com/go-git/x/plugin/objectsigner/auto"
 )
-
-const localSigningKey = "local-signing-key"
 
 func TestIsCustomSSHSignProgram(t *testing.T) {
 	t.Parallel()
@@ -177,158 +170,12 @@ func TestEffectiveSSHSignProgram_UsesHighestPrecedenceScope(t *testing.T) {
 	globalRaw := format.New()
 	globalRaw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
 
-	localRaw := format.New()
-	localRaw.Section("gpg").Subsection("ssh").SetOption("program", "ssh-keygen")
-
-	got := effectiveSSHSignProgram(sysRaw, globalRaw, localRaw)
-	if got != "ssh-keygen" {
-		t.Fatalf("effectiveSSHSignProgram() = %q, want %q", got, "ssh-keygen")
+	got := effectiveSSHSignProgram(sysRaw, globalRaw)
+	if got != "/Applications/1Password.app/Contents/MacOS/op-ssh-sign" {
+		t.Fatalf("effectiveSSHSignProgram() = %q, want %q", got, "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
 	}
 
-	if isCustomSSHSignProgram(got) {
-		t.Fatal("expected highest-precedence ssh-keygen override not to be treated as custom")
+	if !isCustomSSHSignProgram(got) {
+		t.Fatal("expected highest-precedence global override to be treated as custom")
 	}
-}
-
-func TestLoadLocalConfig_ReadsCustomSSHSignProgram(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
-	repoDir := t.TempDir()
-	testutil.InitRepo(t, repoDir)
-	t.Chdir(repoDir)
-
-	repoCfg := config.NewConfig()
-	repoCfg.GPG.Format = string(auto.FormatSSH)
-	repoCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
-
-	repo, err := git.PlainOpen(repoDir)
-	if err != nil {
-		t.Fatalf("git.PlainOpen() error = %v", err)
-	}
-
-	if err := repo.SetConfig(repoCfg); err != nil {
-		t.Fatalf("repo.SetConfig() error = %v", err)
-	}
-
-	localCfg := loadRepoLocalConfig(repo)
-	if !isCustomSSHSignProgram(rawSSHSignProgram(localCfg.Raw)) {
-		t.Fatal("expected local config to report custom gpg.ssh.program")
-	}
-}
-
-func TestObjectSignerConfigMerge_LocalConfigTakesPrecedence(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
-	repoDir := t.TempDir()
-	testutil.InitRepo(t, repoDir)
-	t.Chdir(repoDir)
-
-	repo, err := git.PlainOpen(repoDir)
-	if err != nil {
-		t.Fatalf("git.PlainOpen() error = %v", err)
-	}
-
-	localCfg := config.NewConfig()
-	localCfg.Commit.GpgSign = config.NewOptBool(true)
-	localCfg.GPG.Format = string(auto.FormatSSH)
-	localCfg.User.SigningKey = localSigningKey
-	localCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
-	if err := repo.SetConfig(localCfg); err != nil {
-		t.Fatalf("repo.SetConfig() error = %v", err)
-	}
-
-	globalCfg := config.NewConfig()
-	globalCfg.Commit.GpgSign = config.NewOptBool(false)
-	globalCfg.GPG.Format = "openpgp"
-	globalCfg.User.SigningKey = "global-signing-key"
-
-	merged := config.Merge(config.NewConfig(), globalCfg, loadRepoLocalConfig(repo))
-
-	if !merged.Commit.GpgSign.IsTrue() {
-		t.Fatal("expected local commit.gpgsign to override global config")
-	}
-	if got := merged.GPG.Format; got != string(auto.FormatSSH) {
-		t.Fatalf("merged GPG.Format = %q, want %q", got, auto.FormatSSH)
-	}
-	if got := merged.User.SigningKey; got != localSigningKey {
-		t.Fatalf("merged User.SigningKey = %q, want %q", got, localSigningKey)
-	}
-	if !isCustomSSHSignProgram(rawSSHSignProgram(loadRepoLocalConfig(repo).Raw)) {
-		t.Fatal("expected merged setup to see local custom gpg.ssh.program")
-	}
-}
-
-func TestLoadObjectSignerConfig_IgnoresUpperScopeLoadFailures(t *testing.T) {
-	t.Parallel()
-
-	repoDir := t.TempDir()
-	testutil.InitRepo(t, repoDir)
-
-	repo, err := git.PlainOpen(repoDir)
-	if err != nil {
-		t.Fatalf("git.PlainOpen() error = %v", err)
-	}
-
-	localCfg := config.NewConfig()
-	localCfg.Commit.GpgSign = config.NewOptBool(true)
-	localCfg.GPG.Format = string(auto.FormatSSH)
-	localCfg.User.SigningKey = localSigningKey
-	localCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
-	if err := repo.SetConfig(localCfg); err != nil {
-		t.Fatalf("repo.SetConfig() error = %v", err)
-	}
-
-	merged, sshSignProgram := loadObjectSignerConfig(failingConfigSource{}, repo)
-
-	if !merged.Commit.GpgSign.IsTrue() {
-		t.Fatal("expected local commit.gpgsign to survive upper-scope load failures")
-	}
-	if got := merged.GPG.Format; got != string(auto.FormatSSH) {
-		t.Fatalf("merged GPG.Format = %q, want %q", got, auto.FormatSSH)
-	}
-	if got := merged.User.SigningKey; got != localSigningKey {
-		t.Fatalf("merged User.SigningKey = %q, want %q", got, localSigningKey)
-	}
-	if !isCustomSSHSignProgram(sshSignProgram) {
-		t.Fatal("expected local custom gpg.ssh.program to survive upper-scope load failures")
-	}
-}
-
-func TestRegisterObjectSigner_ReturnsNilSignerForLocalCustomSSHProgram(t *testing.T) { //nolint:paralleltest // t.Chdir and plugin registry are process-global
-	repoDir := t.TempDir()
-	testutil.InitRepo(t, repoDir)
-	t.Chdir(repoDir)
-
-	repo, err := git.PlainOpen(repoDir)
-	if err != nil {
-		t.Fatalf("git.PlainOpen() error = %v", err)
-	}
-
-	localCfg := config.NewConfig()
-	localCfg.Commit.GpgSign = config.NewOptBool(true)
-	localCfg.GPG.Format = string(auto.FormatSSH)
-	localCfg.User.SigningKey = localSigningKey
-	localCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
-	if err := repo.SetConfig(localCfg); err != nil {
-		t.Fatalf("repo.SetConfig() error = %v", err)
-	}
-
-	resetPluginEntry("object-signer")
-	t.Cleanup(func() {
-		resetPluginEntry("object-signer")
-		registerObjectSignerOnce = sync.Once{}
-	})
-
-	registerObjectSignerOnce = sync.Once{}
-	RegisterObjectSigner()
-
-	signer, err := plugin.Get(plugin.ObjectSigner())
-	if err != nil {
-		t.Fatalf("plugin.Get(object signer) error = %v", err)
-	}
-	if signer != nil {
-		t.Fatal("expected nil signer when local gpg.ssh.program uses a custom signer")
-	}
-}
-
-type failingConfigSource struct{}
-
-func (failingConfigSource) Load(_ config.Scope) (config.ConfigStorer, error) { //nolint:ireturn // required by plugin.ConfigSource
-	return nil, errors.New("boom")
 }

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -329,6 +329,6 @@ func TestRegisterObjectSigner_ReturnsNilSignerForLocalCustomSSHProgram(t *testin
 
 type failingConfigSource struct{}
 
-func (failingConfigSource) Load(scope config.Scope) (config.ConfigStorer, error) {
+func (failingConfigSource) Load(_ config.Scope) (config.ConfigStorer, error) { //nolint:ireturn // required by plugin.ConfigSource
 	return nil, errors.New("boom")
 }

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -15,7 +15,7 @@ import (
 
 const localSigningKey = "local-signing-key"
 
-func TestHasCustomSSHSignProgram(t *testing.T) {
+func TestIsCustomSSHSignProgram(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -1,12 +1,15 @@
 package cli
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/x/plugin"
+	pluginconfig "github.com/go-git/go-git/v6/x/plugin/config"
 	"github.com/go-git/x/plugin/objectsigner/auto"
 )
 
@@ -246,5 +249,52 @@ func TestObjectSignerConfigMerge_LocalConfigTakesPrecedence(t *testing.T) { //no
 	}
 	if !hasCustomSSHSignProgram(loadLocalConfig().Raw) {
 		t.Fatal("expected merged setup to see local custom gpg.ssh.program")
+	}
+}
+
+func TestRegisterObjectSigner_CachesLocalConfigAcrossGets(t *testing.T) {
+	t.Parallel()
+
+	resetPluginEntry("config_loader")
+	resetPluginEntry("object_signer")
+	t.Cleanup(func() {
+		resetPluginEntry("config_loader")
+		resetPluginEntry("object_signer")
+		registerObjectSignerOnce = sync.Once{}
+		loadLocalConfigFunc = loadLocalConfig
+	})
+
+	registerObjectSignerOnce = sync.Once{}
+
+	var loadCalls int
+	loadLocalConfigFunc = func() *config.Config {
+		loadCalls++
+
+		cfg := config.NewConfig()
+		cfg.Commit.GpgSign = config.NewOptBool(true)
+		cfg.GPG.Format = string(auto.FormatSSH)
+		cfg.User.SigningKey = "local-signing-key"
+
+		return cfg
+	}
+
+	if err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
+		return pluginconfig.NewEmpty()
+	}); err != nil {
+		t.Fatalf("plugin.Register(config loader) error = %v", err)
+	}
+
+	RegisterObjectSigner()
+
+	for range 2 {
+		signer, err := plugin.Get(plugin.ObjectSigner())
+		if err != nil {
+			t.Fatalf("plugin.Get(object signer) error = %v", err)
+		}
+		_ = signer
+	}
+
+	if loadCalls != 1 {
+		t.Fatalf("loadLocalConfigFunc() calls = %d, want 1", loadCalls)
 	}
 }

--- a/cmd/entire/cli/objectsigner_test.go
+++ b/cmd/entire/cli/objectsigner_test.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"testing"
 
+	"github.com/go-git/go-git/v6/config"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/x/plugin/objectsigner/auto"
 )
 
 func TestHasCustomSSHSignProgram(t *testing.T) {
@@ -60,6 +62,100 @@ func TestHasCustomSSHSignProgram(t *testing.T) {
 			got := hasCustomSSHSignProgram(tt.raw)
 			if got != tt.want {
 				t.Errorf("hasCustomSSHSignProgram() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigMerge_DropsCustomSSHSignProgramFromRaw(t *testing.T) {
+	t.Parallel()
+
+	sysCfg := config.NewConfig()
+	sysCfg.GPG.Format = string(auto.FormatSSH)
+	sysCfg.Raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
+
+	merged := config.Merge(sysCfg, config.NewConfig())
+
+	if !hasCustomSSHSignProgram(sysCfg.Raw) {
+		t.Fatal("expected scoped raw config to report custom gpg.ssh.program")
+	}
+
+	if hasCustomSSHSignProgram(merged.Raw) {
+		t.Fatal("expected merged raw config to lose custom gpg.ssh.program")
+	}
+}
+
+func TestCustomSSHSignProgramDetection_UsesScopedRawBeforeMerge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		sysRaw    *format.Config
+		globalRaw *format.Config
+		want      bool
+	}{
+		{
+			name: "system scope custom program",
+			sysRaw: func() *format.Config {
+				raw := format.New()
+				raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
+				return raw
+			}(),
+			globalRaw: format.New(),
+			want:      true,
+		},
+		{
+			name:   "global scope custom program",
+			sysRaw: format.New(),
+			globalRaw: func() *format.Config {
+				raw := format.New()
+				raw.Section("gpg").Subsection("ssh").SetOption("program", "/Applications/1Password.app/Contents/MacOS/op-ssh-sign")
+				return raw
+			}(),
+			want: true,
+		},
+		{
+			name: "default ssh-keygen in both scopes",
+			sysRaw: func() *format.Config {
+				raw := format.New()
+				raw.Section("gpg").Subsection("ssh").SetOption("program", "ssh-keygen")
+				return raw
+			}(),
+			globalRaw: func() *format.Config {
+				raw := format.New()
+				raw.Section("gpg").Subsection("ssh").SetOption("program", "ssh-keygen")
+				return raw
+			}(),
+			want: false,
+		},
+		{
+			name:      "no custom program configured",
+			sysRaw:    format.New(),
+			globalRaw: format.New(),
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sysCfg := config.NewConfig()
+			sysCfg.GPG.Format = string(auto.FormatSSH)
+			sysCfg.Raw = tt.sysRaw
+
+			globalCfg := config.NewConfig()
+			globalCfg.GPG.Format = string(auto.FormatSSH)
+			globalCfg.Raw = tt.globalRaw
+
+			got := hasCustomSSHSignProgram(sysCfg.Raw) || hasCustomSSHSignProgram(globalCfg.Raw)
+			if got != tt.want {
+				t.Fatalf("scoped raw detection = %v, want %v", got, tt.want)
+			}
+
+			merged := config.Merge(sysCfg, globalCfg)
+			if got && hasCustomSSHSignProgram(merged.Raw) {
+				t.Fatal("expected merged raw config not to preserve custom gpg.ssh.program")
 			}
 		})
 	}

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -631,7 +631,7 @@ func generateSummary(ctx context.Context, redactedTranscript redact.RedactedByte
 // The return type is the summarize.Generator interface rather than the concrete
 // adapter pointer so callers can't accidentally hold a non-nil interface that
 // wraps a nil pointer (the classic Go nil-interface footgun).
-func buildSummaryGenerator(ctx context.Context) summarize.Generator { //nolint:ireturn // interface return for nil-safety
+func buildSummaryGenerator(ctx context.Context) summarize.Generator { //nolint:ireturn // interface return prevents a non-nil interface wrapping a nil adapter pointer
 	s, err := settings.Load(ctx)
 	if err != nil {
 		// Warn (not Debug): this is the auto-summarize hot path on every commit.

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -631,7 +631,7 @@ func generateSummary(ctx context.Context, redactedTranscript redact.RedactedByte
 // The return type is the summarize.Generator interface rather than the concrete
 // adapter pointer so callers can't accidentally hold a non-nil interface that
 // wraps a nil pointer (the classic Go nil-interface footgun).
-func buildSummaryGenerator(ctx context.Context) summarize.Generator {
+func buildSummaryGenerator(ctx context.Context) summarize.Generator { //nolint:ireturn // interface return for nil-safety
 	s, err := settings.Load(ctx)
 	if err != nil {
 		// Warn (not Debug): this is the auto-summarize hot path on every commit.

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -631,7 +631,7 @@ func generateSummary(ctx context.Context, redactedTranscript redact.RedactedByte
 // The return type is the summarize.Generator interface rather than the concrete
 // adapter pointer so callers can't accidentally hold a non-nil interface that
 // wraps a nil pointer (the classic Go nil-interface footgun).
-func buildSummaryGenerator(ctx context.Context) summarize.Generator { //nolint:ireturn // interface return prevents a non-nil interface wrapping a nil adapter pointer
+func buildSummaryGenerator(ctx context.Context) summarize.Generator {
 	s, err := settings.Load(ctx)
 	if err != nil {
 		// Warn (not Debug): this is the auto-summarize hot path on every commit.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/f00e8cc8686b
<!-- entire-trail-link-end -->

## What
This PR narrows the object signer behavior to avoid noisy commit-signing failures during git push when Git is configured to use a custom SSH signing program that go-git cannot invoke.

## How
- detect custom `gpg.ssh.program` values from system and global raw Git config before merge
- skip native SSH signing when that custom SSH signer is configured
- keep the change scoped to the existing system/global config behavior
- add focused tests for raw-config detection and scope precedence

## Notes
This PR does not change repo-local signer configuration behavior.