### PR TITLE
Feat/entire review multi agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -603,55 +603,96 @@ Trailers:
 
 ### `entire review` Command
 
-`entire review` runs a set of configured review skills inside a single agent session. The review session is an immutable fact attached to a checkpoint — no verdict, no status tracking, no empty commits. On the next `git commit`, the review session is condensed into the checkpoint metadata alongside normal sessions, permanently recording that the code was reviewed and which skills were run.
+`entire review` runs a set of configured review skills inside one or more agent sessions. The review session(s) are an immutable fact attached to a checkpoint — no verdict, no status tracking, no empty commits. On the next `git commit`, each review session is condensed into the checkpoint metadata alongside normal sessions, permanently recording that the code was reviewed, by which agents, and which skills they ran.
 
 #### Command Surface
 
 ```
-entire review                          # Normal run: load config, spawn configured agent
+entire review                          # Normal run: load config, pick agent(s), spawn
 entire review --edit                   # Re-open the skills picker before running
 entire review --track-only             # Write the pending-review marker; do not spawn agent
+entire review --agent <name>           # Override the agent picker; run the named agent only
 ```
+
+#### Single-agent vs multi-agent flow
+
+The picker behavior depends on how many agents have a non-empty review config:
+
+- **One eligible agent** → spawn it directly (no picker).
+- **Multiple eligible agents that don't all support headless mode** → single-select picker.
+- **Multiple eligible agents that all implement `agent.HeadlessLauncher` (claude-code, codex, gemini-cli)** → multi-select picker. If the user picks one, the run proceeds as single-agent. Picking 2+ dispatches to the parallel orchestrator.
+
+After agent selection (single or multi), the user gets a per-run prompt textarea (`pickMultiAgent` / `runReview` both call `resolveRunContext`) — empty/Enter-only is treated as "use the persistent config verbatim"; non-empty text is appended to the agent's prompt under a `For this review:` marker so per-run intent is distinguishable from persistent preferences.
+
+In the multi-agent path, `multiReviewOrchestrator.Run` (`cmd/entire/cli/review_multi.go`) spawns N headless subprocesses under a shared cancellation context, renders a Bubble Tea status table when stdout is a TTY, and dumps per-agent results once the run finishes. Ctrl+O during a run drills into any agent's live buffer (alt-screen so the table doesn't tear); Esc returns. Ctrl+C cancels with a 5s SIGKILL watchdog.
+
+#### Cross-agent verdict synthesis
+
+When 2+ agents finished successfully and stdin is a TTY, the orchestrator prompts (default **No**): *"Synthesize a combined verdict across agents?"*. If accepted, it resolves the configured summary provider via `resolveCheckpointSummaryProvider` (the same picker `entire explain` uses) and asks it to produce a unified verdict with sections for common findings, unique findings, disagreements, and priority order. The synthesis prompt is built in `buildVerdictSynthesisPrompt` and the call goes through `agent.TextGenerator.GenerateText`. Output is currently stdout-only — it does **not** persist into checkpoint metadata. Provider failures degrade to a one-line warning rather than blocking the user from committing.
+
+#### Review prompt scope clause
+
+The composed review prompt appends a scope clause that pins agents to "commits unique to this branch vs the closest ancestor branch." `detectScopeBaseRef` (`review.go`) finds the nearest non-self local branch whose tip is an ancestor of `HEAD~1`, preferring the most recently authored tip; falls back to `detectBaseBranch` (origin/HEAD or main/master). This prevents codex's default `origin/main...HEAD` from pulling in commits inherited from sibling branches. Commits-only — uncommitted bytecode and editor temp files are explicitly excluded.
 
 #### Settings Schema
 
-Review skills are configured per-agent in `.entire/settings.json`:
+Review config is per-agent in `.entire/settings.json`:
 
 ```json
 {
   "review": {
-    "claude-code": ["/pr-review-toolkit:review-pr", "/test-auditor"],
-    "codex": ["/codex:adversarial-review"]
+    "claude-code": {
+      "skills": ["/pr-review-toolkit:review-pr", "/test-auditor"]
+    },
+    "codex": {
+      "skills": ["/codex:adversarial-review"],
+      "prompt": "Focus on security regressions this week"
+    }
   }
 }
 ```
 
-The key is the agent name (matching the agent's `Name()` return value). The value is a list of skill invocations passed verbatim to the agent. Settings field: `EntireSettings.Review` in `cmd/entire/cli/settings/settings.go`.
+Each entry is a `ReviewConfig` struct (`cmd/entire/cli/settings/settings.go`):
+
+- `skills`: list of slash-prefixed skill invocations passed verbatim to the agent.
+- `prompt`: optional verbatim prompt that wins over the skills-composed template — used when the user has a long-running review philosophy that doesn't map to slash commands.
+
+A non-empty `prompt` and an empty `skills` is valid (prompt-only config). Both empty causes the picker to refuse to spawn.
 
 #### How It Works
 
-1. `entire review` writes a pending-review marker (scoped to the current worktree) before spawning the agent
-2. The agent's `UserPromptSubmit` lifecycle hook adopts the marker, tagging the session with `Kind = "agent_review"` and recording the configured skills in `ReviewSkills`. The marker is only adopted by a session whose worktree matches — sessions in other worktrees of the same repo leave it untouched
-3. The agent runs the review skills and the session ends naturally
-4. On the next `git commit`, the PostCommit hook condenses the review session into the checkpoint on `entire/checkpoints/v1`, with `Kind` and `ReviewSkills` recorded in `CommittedMetadata`
-5. The `CheckpointSummary` sets `HasReview = true` for O(1) lookup. `HasReview` is an umbrella "any review happened" flag — future review kinds (e.g. manual review) should also set it so callers don't have to disjunction a growing list of booleans
-6. `entire status` and the re-run guard in `entire review` read `HasReview` from the checkpoint metadata (no commit history walking)
+1. `entire review` resolves configured + eligible agents, runs the picker, optionally collects per-run context.
+2. Writes a pending-review marker to `.git/entire-sessions/review-pending.json`. The marker carries:
+   - `agent_name` (single-agent) **or** `agent_names` + `agent_entries` map (multi-agent — each entry is `{skills, prompt}` so the adopting hook records what *that* agent actually ran, not a union)
+   - `starting_sha` (HEAD at invocation; SHA-drift detection discards stale markers)
+   - `worktree_path` (so concurrent worktrees don't race for the marker)
+3. The agent's `UserPromptSubmit` lifecycle hook adopts the marker, tagging its session with `Kind = "agent_review"`, copying its own `ReviewSkills`/`ReviewPrompt` from the per-agent entry (or top-level fields in single-agent mode). Multi-agent adopters leave the marker for sibling agents; the orchestrator owns the final clear.
+4. Each agent runs its review skills and exits.
+5. On the next `git commit`, the PostCommit hook condenses each review session into the checkpoint on `entire/checkpoints/v1`, recording `Kind` + `ReviewSkills` + `ReviewPrompt` in `CommittedMetadata` per session. Multiple agents' reviews land as multiple per-session subfolders in the checkpoint.
+6. `CheckpointSummary.HasReview` flips to true for O(1) "any review happened" lookup. Future review kinds (e.g. manual review) should also set it so callers don't have to disjunction a growing list of booleans.
+7. `entire status` and the re-run guard in `entire review` read `HasReview` from checkpoint metadata.
 
 #### Checkpoint Metadata
 
 Review metadata is stored at two levels on `entire/checkpoints/v1`:
 
-- **`CommittedMetadata` (per-session)**: `kind: "agent_review"`, `review_skills: ["/skill1", "/skill2"]`
-- **`CheckpointSummary` (per-checkpoint)**: `has_review: true` (umbrella; set when any session in the checkpoint has a review-kind `Kind`)
+- **`CommittedMetadata` (per-session)**: `kind: "agent_review"`, `review_skills: ["/skill1", "/skill2"]`, `review_prompt: "..."`. One per agent in a multi-agent run.
+- **`CheckpointSummary` (per-checkpoint)**: `has_review: true` (umbrella; set when any session in the checkpoint has a review-kind `Kind`).
+
+The cross-agent synthesis output is **not** stored in checkpoint metadata today — it's an ephemeral terminal-only convenience. Persisting it is tracked as future work.
 
 #### Key Files
 
-- `cmd/entire/cli/review.go` - Command registration, config picker, agent spawn, re-run guard, pending marker management (including `WorktreePath`-scoped adoption)
-- `cmd/entire/cli/lifecycle.go` - Session adoption: pending-review marker promotes to `Kind=agent_review` on `UserPromptSubmit` when worktrees match
-- `cmd/entire/cli/agent/agent.go` - `Launcher` interface used by `entire review` to spawn agents
-- `cmd/entire/cli/agent/{claudecode,codex,geminicli}/` - Per-agent `Launcher` implementations
-- `cmd/entire/cli/checkpoint/checkpoint.go` - `Kind` and `ReviewSkills` fields on `WriteCommittedOptions`, `CommittedMetadata`, and `HasReview` on `CheckpointSummary`
-- `cmd/entire/cli/settings/settings.go` - `EntireSettings.Review` field (`map[string][]string`) and `ReviewSkillsFor` helper
+- `cmd/entire/cli/review.go` - Command registration, config picker, single-agent spawn, marker schema (`PendingReviewMarker`, `AgentMarkerEntry`), multi-agent dispatch wiring, `composeReviewPrompt` + scope clause + `detectScopeBaseRef`
+- `cmd/entire/cli/review_multi.go` - `multiReviewOrchestrator`, parallel headless spawn, signal handling + SIGKILL watchdog, codex output filter (`filterCodexOutput`, `extractCodexFinal`), result dump helpers (`dumpPerAgentReviews`, `dumpRunCounts`, `dumpRunFooter`)
+- `cmd/entire/cli/review_tui.go` - `reviewTUIModel`, status table rendering, Ctrl+O alt-screen drill-in, per-row run-start timestamps, rune-safe preview truncation
+- `cmd/entire/cli/review_synthesize.go` - Cross-agent verdict synthesis: opt-in prompt, prompt construction, `TextGenerator` invocation
+- `cmd/entire/cli/lifecycle.go` - Session adoption: pending-review marker promotes to `Kind=agent_review` on `UserPromptSubmit` when worktree + agent name match; per-agent entry lookup for multi-agent markers
+- `cmd/entire/cli/agent/agent.go` - `Launcher` (interactive spawn) + `HeadlessLauncher` (parallel review subprocess) capability interfaces
+- `cmd/entire/cli/agent/{claudecode,codex,geminicli}/headless.go` - Per-agent `LaunchHeadlessCmd` implementations; binary lookup deferred to `Cmd.Start` so construction is testable without binaries on PATH
+- `cmd/entire/cli/checkpoint/checkpoint.go` - `Kind`, `ReviewSkills`, `ReviewPrompt` fields on `WriteCommittedOptions` + `CommittedMetadata`, `HasReview` on `CheckpointSummary`
+- `cmd/entire/cli/settings/settings.go` - `EntireSettings.Review` (`map[string]ReviewConfig`) and `ReviewSkillsFor` helper
+- `cmd/entire/cli/explain_summary_provider.go` - `resolveCheckpointSummaryProvider` (shared with `entire explain`) — picks the synthesis agent
 
 # Important Notes
 

--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -269,6 +269,28 @@ type Launcher interface {
 	LaunchCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error)
 }
 
+// HeadlessLauncher is implemented by agents that support running a prompt
+// in non-interactive mode. The subprocess writes its native transcript to
+// disk (same file as an interactive session) and exits when the prompt
+// completes. Used by `entire review`'s multi-agent TUI to spawn N parallel
+// reviews; agents that implement only Launcher (interactive TTY only)
+// remain reachable via the single-agent spawn path from Sub-phase 2.1.
+//
+// Contract:
+//   - LaunchHeadlessCmd returns an *exec.Cmd with Stdout/Stderr pipes left
+//     for the caller to assign (orchestrator wires them to tees + buffers).
+//   - Stdin is left nil; the prompt is passed as the positional arg or
+//     equivalent per-agent flag.
+//   - UserPromptSubmit hook must fire during the run so the pending-review
+//     marker adoption pipeline works.
+//   - Subprocess must terminate on its own once the prompt completes. The
+//     orchestrator does not send a graceful signal to end the run — only
+//     to cancel it (SIGTERM via ctx cancel).
+type HeadlessLauncher interface {
+	Agent
+	LaunchHeadlessCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error)
+}
+
 // DiscoveredSkill describes one review-adjacent skill found on disk by a
 // SkillDiscoverer. Name is the agent-native invocation form (e.g. a
 // slash-prefixed command); Description is scraped from on-disk metadata

--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -279,8 +279,9 @@ type Launcher interface {
 // Contract:
 //   - LaunchHeadlessCmd returns an *exec.Cmd with Stdout/Stderr pipes left
 //     for the caller to assign (orchestrator wires them to tees + buffers).
-//   - Stdin is left nil; the prompt is passed as the positional arg or
-//     equivalent per-agent flag.
+//   - Stdin MAY be set by the agent when the prompt must be piped (e.g.
+//     codex, gemini). Stdout and Stderr are always left unwired so the
+//     caller can pipe/capture them.
 //   - UserPromptSubmit hook must fire during the run so the pending-review
 //     marker adoption pipeline works.
 //   - Subprocess must terminate on its own once the prompt completes. The

--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -282,6 +282,13 @@ type Launcher interface {
 //   - Stdin MAY be set by the agent when the prompt must be piped (e.g.
 //     codex, gemini). Stdout and Stderr are always left unwired so the
 //     caller can pipe/capture them.
+//   - Binary lookup is deferred to *exec.Cmd.Start. Implementations
+//     pass the bare binary name to exec.CommandContext rather than
+//     calling exec.LookPath up front, so construction is infallible
+//     and unit tests can verify argv shape without the binary on PATH.
+//     Missing-binary errors surface from cmd.Run() / cmd.Start() at
+//     execution time, where the orchestrator already classifies them
+//     as AgentRunFailed.
 //   - UserPromptSubmit hook must fire during the run so the pending-review
 //     marker adoption pipeline works.
 //   - Subprocess must terminate on its own once the prompt completes. The

--- a/cmd/entire/cli/agent/claudecode/discovery.go
+++ b/cmd/entire/cli/agent/claudecode/discovery.go
@@ -42,10 +42,32 @@ func (c *ClaudeCodeAgent) DiscoverReviewSkills(ctx context.Context) ([]agent.Dis
 	found = append(found, scanUserSkills(ctx, filepath.Join(home, ".claude", "skills"))...)
 	found = append(found, scanFlatMarkdownDir(ctx, filepath.Join(home, ".claude", "commands"), "")...)
 	found = append(found, scanFlatMarkdownDir(ctx, filepath.Join(home, ".claude", "agents"), "")...)
+	found = dedupeDiscoveredSkills(found)
 	if len(found) == 0 {
 		return nil, nil
 	}
 	return found, nil
+}
+
+// dedupeDiscoveredSkills collapses entries sharing the same invocation
+// Name. Arises when the same plugin is cached under multiple marketplaces
+// or multiple versions (e.g. pr-review-toolkit cached as both `unknown`
+// and a content-hash version directory). First-seen wins; ordering is
+// otherwise preserved.
+func dedupeDiscoveredSkills(in []agent.DiscoveredSkill) []agent.DiscoveredSkill {
+	if len(in) < 2 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]agent.DiscoveredSkill, 0, len(in))
+	for _, s := range in {
+		if _, dup := seen[s.Name]; dup {
+			continue
+		}
+		seen[s.Name] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 // scanPluginCache walks <root>/<marketplace>/<plugin>/<version>/{skills,commands,agents}/

--- a/cmd/entire/cli/agent/claudecode/discovery_test.go
+++ b/cmd/entire/cli/agent/claudecode/discovery_test.go
@@ -13,6 +13,8 @@ import (
 // Compile-time pin: ClaudeCodeAgent must satisfy SkillDiscoverer.
 var _ agent.SkillDiscoverer = (*claudecode.ClaudeCodeAgent)(nil)
 
+const prReviewToolkitInvocation = "/pr-review-toolkit:review-pr"
+
 func withFakeHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
@@ -60,8 +62,8 @@ Review the PR.
 	if len(skills) != 1 {
 		t.Fatalf("skills count = %d, want 1", len(skills))
 	}
-	if skills[0].Name != "/pr-review-toolkit:review-pr" {
-		t.Errorf("skills[0].Name = %q, want /pr-review-toolkit:review-pr", skills[0].Name)
+	if skills[0].Name != prReviewToolkitInvocation {
+		t.Errorf("skills[0].Name = %q, want %s", skills[0].Name, prReviewToolkitInvocation)
 	}
 	if skills[0].Description != "Full PR review" {
 		t.Errorf("skills[0].Description = %q", skills[0].Description)
@@ -159,8 +161,8 @@ allowed-tools: ["Bash", "Read"]
 	if len(skills) != 1 {
 		t.Fatalf("expected 1 plugin command, got %d: %+v", len(skills), skills)
 	}
-	if skills[0].Name != "/pr-review-toolkit:review-pr" {
-		t.Errorf("Name = %q, want /pr-review-toolkit:review-pr", skills[0].Name)
+	if skills[0].Name != prReviewToolkitInvocation {
+		t.Errorf("Name = %q, want %s", skills[0].Name, prReviewToolkitInvocation)
 	}
 	if skills[0].Description != "Comprehensive PR review using specialized agents" {
 		t.Errorf("Description = %q", skills[0].Description)
@@ -249,6 +251,41 @@ func TestDiscoverReviewSkills_SkipsReadme(t *testing.T) {
 	}
 	if len(skills) != 0 {
 		t.Errorf("README.md should be skipped, got %+v", skills)
+	}
+}
+
+// TestDiscoverReviewSkills_DedupesAcrossVersions verifies that when the
+// same plugin is cached under multiple version directories (e.g., after
+// an update leaves the old content-hash version alongside the new one),
+// the discovery walker emits each invocation name exactly once.
+func TestDiscoverReviewSkills_DedupesAcrossVersions(t *testing.T) {
+	home := withFakeHome(t)
+	pluginRoot := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "pr-review-toolkit")
+	content := `---
+description: "Comprehensive PR review using specialized agents"
+---
+`
+	for _, version := range []string{"cf62a6c02dc0", "unknown"} {
+		cmdDir := filepath.Join(pluginRoot, version, "commands")
+		if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cmdDir, "review-pr.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 dedup'd skill, got %d: %+v", len(skills), skills)
+	}
+	if skills[0].Name != prReviewToolkitInvocation {
+		t.Errorf("Name = %q, want %s", skills[0].Name, prReviewToolkitInvocation)
 	}
 }
 

--- a/cmd/entire/cli/agent/claudecode/headless.go
+++ b/cmd/entire/cli/agent/claudecode/headless.go
@@ -2,7 +2,6 @@ package claudecode
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 )
 
@@ -12,10 +11,14 @@ import (
 // the run so pending-review marker adoption works. Stdio is left unwired
 // for the caller to assign (orchestrator uses teeWriters to capture
 // stdout into both a final-response buffer and a preview channel).
+//
+// Binary lookup is deferred to *exec.Cmd.Start: passing the bare name
+// "claude" lets exec.CommandContext stash an "executable not found"
+// error on cmd.Err that surfaces when the orchestrator runs the
+// command. This keeps construction infallible so unit tests can verify
+// argv shape without requiring the claude binary on PATH.
+//
+//nolint:unparam // interface signature requires (*exec.Cmd, error); construction is infallible by design (binary lookup deferred to Cmd.Start).
 func (c *ClaudeCodeAgent) LaunchHeadlessCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error) {
-	bin, err := exec.LookPath("claude")
-	if err != nil {
-		return nil, fmt.Errorf("claude binary not on PATH: %w", err)
-	}
-	return exec.CommandContext(ctx, bin, "--print", initialPrompt), nil
+	return exec.CommandContext(ctx, "claude", "--print", initialPrompt), nil
 }

--- a/cmd/entire/cli/agent/claudecode/headless.go
+++ b/cmd/entire/cli/agent/claudecode/headless.go
@@ -1,0 +1,21 @@
+package claudecode
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// LaunchHeadlessCmd builds an *exec.Cmd for `claude --print "<initialPrompt>"`.
+// Non-interactive mode — Claude processes the prompt, prints the final
+// response to stdout, and exits. The UserPromptSubmit hook fires during
+// the run so pending-review marker adoption works. Stdio is left unwired
+// for the caller to assign (orchestrator uses teeWriters to capture
+// stdout into both a final-response buffer and a preview channel).
+func (c *ClaudeCodeAgent) LaunchHeadlessCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error) {
+	bin, err := exec.LookPath("claude")
+	if err != nil {
+		return nil, fmt.Errorf("claude binary not on PATH: %w", err)
+	}
+	return exec.CommandContext(ctx, bin, "--print", initialPrompt), nil
+}

--- a/cmd/entire/cli/agent/claudecode/headless_test.go
+++ b/cmd/entire/cli/agent/claudecode/headless_test.go
@@ -2,6 +2,7 @@ package claudecode_test
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -11,6 +12,27 @@ import (
 
 // Compile-time pin — ClaudeCodeAgent must satisfy HeadlessLauncher.
 var _ agent.HeadlessLauncher = (*claudecode.ClaudeCodeAgent)(nil)
+
+// LaunchHeadlessCmd must be infallible at construction time even when
+// the claude binary isn't on PATH — missing-binary errors surface at
+// cmd.Run() instead, so unit tests and CI runners without claude
+// installed still verify the argv contract. Regression: an earlier
+// implementation called exec.LookPath up front, breaking CI.
+func TestClaudeCodeAgent_LaunchHeadlessCmd_NoBinaryOnPath(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent")
+	if _, err := os.Stat("/nonexistent/claude"); err == nil {
+		t.Skip("PATH-scrub didn't take effect on this runner")
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	cmd, err := a.LaunchHeadlessCmd(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("LaunchHeadlessCmd must not return an error when binary is missing; got %v", err)
+	}
+	if cmd == nil {
+		t.Fatal("returned nil cmd")
+	}
+}
 
 func TestClaudeCodeAgent_LaunchHeadlessCmd(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/agent/claudecode/headless_test.go
+++ b/cmd/entire/cli/agent/claudecode/headless_test.go
@@ -1,0 +1,40 @@
+package claudecode_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+)
+
+// Compile-time pin — ClaudeCodeAgent must satisfy HeadlessLauncher.
+var _ agent.HeadlessLauncher = (*claudecode.ClaudeCodeAgent)(nil)
+
+func TestClaudeCodeAgent_LaunchHeadlessCmd(t *testing.T) {
+	t.Parallel()
+	a := &claudecode.ClaudeCodeAgent{}
+	cmd, err := a.LaunchHeadlessCmd(context.Background(), "review please")
+	if err != nil {
+		t.Fatalf("LaunchHeadlessCmd: %v", err)
+	}
+	if cmd == nil {
+		t.Fatal("returned nil cmd")
+	}
+	// Program path is resolved via exec.LookPath("claude"); we can't assert
+	// on that (binary may not be installed in CI). But we can assert the
+	// --print flag and prompt arg are present in order.
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.Contains(joined, "--print") {
+		t.Errorf("expected --print in args; got %q", joined)
+	}
+	if !strings.Contains(joined, "review please") {
+		t.Errorf("expected prompt in args; got %q", joined)
+	}
+	// Stdio MUST NOT be wired to os.Stdin/Stdout/Stderr — caller wires it.
+	if cmd.Stdin != nil || cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Errorf("Stdio pipes should be left nil for caller to wire; got stdin=%v stdout=%v stderr=%v",
+			cmd.Stdin, cmd.Stdout, cmd.Stderr)
+	}
+}

--- a/cmd/entire/cli/agent/codex/headless.go
+++ b/cmd/entire/cli/agent/codex/headless.go
@@ -4,15 +4,26 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
-// LaunchHeadlessCmd builds an *exec.Cmd for `codex exec "<initialPrompt>"`.
-// Non-interactive mode — Codex processes the prompt and exits. Hooks fire
-// during the run. Stdio is left unwired for the caller to assign.
+// LaunchHeadlessCmd builds an *exec.Cmd for
+// `codex exec --skip-git-repo-check -`, mirroring the args+stdin pattern
+// that GenerateText uses. The trailing "-" tells codex to read the prompt
+// from stdin (argv cannot carry large prompts).
+//
+// Unlike GenerateText (which isolates the subprocess via
+// RunIsolatedTextGeneratorCLI to prevent hooks from firing for meta
+// calls), review MUST fire the agent's UserPromptSubmit hook so the
+// pending-review marker gets adopted. So cmd.Dir and cmd.Env are left
+// unset — the subprocess inherits the user's repo CWD and env. Stdout
+// and Stderr are left nil for the caller to wire.
 func (c *CodexAgent) LaunchHeadlessCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error) {
 	bin, err := exec.LookPath("codex")
 	if err != nil {
 		return nil, fmt.Errorf("codex binary not on PATH: %w", err)
 	}
-	return exec.CommandContext(ctx, bin, "exec", initialPrompt), nil
+	cmd := exec.CommandContext(ctx, bin, "exec", "--skip-git-repo-check", "-")
+	cmd.Stdin = strings.NewReader(initialPrompt)
+	return cmd, nil
 }

--- a/cmd/entire/cli/agent/codex/headless.go
+++ b/cmd/entire/cli/agent/codex/headless.go
@@ -2,7 +2,6 @@ package codex
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -18,12 +17,16 @@ import (
 // pending-review marker gets adopted. So cmd.Dir and cmd.Env are left
 // unset — the subprocess inherits the user's repo CWD and env. Stdout
 // and Stderr are left nil for the caller to wire.
+//
+// Binary lookup is deferred to *exec.Cmd.Start: passing the bare name
+// "codex" lets exec.CommandContext stash an "executable not found"
+// error on cmd.Err that surfaces when the orchestrator runs the
+// command. This keeps construction infallible so unit tests can verify
+// argv shape without requiring the codex binary on PATH.
+//
+//nolint:unparam // interface signature requires (*exec.Cmd, error); construction is infallible by design (binary lookup deferred to Cmd.Start).
 func (c *CodexAgent) LaunchHeadlessCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error) {
-	bin, err := exec.LookPath("codex")
-	if err != nil {
-		return nil, fmt.Errorf("codex binary not on PATH: %w", err)
-	}
-	cmd := exec.CommandContext(ctx, bin, "exec", "--skip-git-repo-check", "-")
+	cmd := exec.CommandContext(ctx, "codex", "exec", "--skip-git-repo-check", "-")
 	cmd.Stdin = strings.NewReader(initialPrompt)
 	return cmd, nil
 }

--- a/cmd/entire/cli/agent/codex/headless.go
+++ b/cmd/entire/cli/agent/codex/headless.go
@@ -1,0 +1,18 @@
+package codex
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// LaunchHeadlessCmd builds an *exec.Cmd for `codex exec "<initialPrompt>"`.
+// Non-interactive mode — Codex processes the prompt and exits. Hooks fire
+// during the run. Stdio is left unwired for the caller to assign.
+func (c *CodexAgent) LaunchHeadlessCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error) {
+	bin, err := exec.LookPath("codex")
+	if err != nil {
+		return nil, fmt.Errorf("codex binary not on PATH: %w", err)
+	}
+	return exec.CommandContext(ctx, bin, "exec", initialPrompt), nil
+}

--- a/cmd/entire/cli/agent/codex/headless_test.go
+++ b/cmd/entire/cli/agent/codex/headless_test.go
@@ -2,6 +2,7 @@ package codex_test
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -10,6 +11,30 @@ import (
 )
 
 var _ agent.HeadlessLauncher = (*codex.CodexAgent)(nil)
+
+// LaunchHeadlessCmd must be infallible at construction time even when
+// the codex binary isn't on PATH — missing-binary errors surface at
+// cmd.Run() instead, so unit tests and CI runners without codex
+// installed still verify the argv contract. Regression: an earlier
+// implementation called exec.LookPath up front, breaking CI.
+func TestCodexAgent_LaunchHeadlessCmd_NoBinaryOnPath(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent")
+	// Defensive: confirm the binary really isn't reachable in the
+	// scrubbed PATH so a polluted runner can't make this test pass for
+	// the wrong reason.
+	if _, err := os.Stat("/nonexistent/codex"); err == nil {
+		t.Skip("PATH-scrub didn't take effect on this runner")
+	}
+
+	a := &codex.CodexAgent{}
+	cmd, err := a.LaunchHeadlessCmd(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("LaunchHeadlessCmd must not return an error when binary is missing; got %v", err)
+	}
+	if cmd == nil {
+		t.Fatal("returned nil cmd")
+	}
+}
 
 func TestCodexAgent_LaunchHeadlessCmd(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/agent/codex/headless_test.go
+++ b/cmd/entire/cli/agent/codex/headless_test.go
@@ -1,0 +1,34 @@
+package codex_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
+)
+
+var _ agent.HeadlessLauncher = (*codex.CodexAgent)(nil)
+
+func TestCodexAgent_LaunchHeadlessCmd(t *testing.T) {
+	t.Parallel()
+	a := &codex.CodexAgent{}
+	cmd, err := a.LaunchHeadlessCmd(context.Background(), "review please")
+	if err != nil {
+		t.Fatalf("LaunchHeadlessCmd: %v", err)
+	}
+	if cmd == nil {
+		t.Fatal("returned nil cmd")
+	}
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.Contains(joined, "exec") {
+		t.Errorf("expected 'exec' subcommand in args; got %q", joined)
+	}
+	if !strings.Contains(joined, "review please") {
+		t.Errorf("expected prompt in args; got %q", joined)
+	}
+	if cmd.Stdin != nil || cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Error("stdio pipes should be left nil for caller")
+	}
+}

--- a/cmd/entire/cli/agent/codex/headless_test.go
+++ b/cmd/entire/cli/agent/codex/headless_test.go
@@ -25,10 +25,31 @@ func TestCodexAgent_LaunchHeadlessCmd(t *testing.T) {
 	if !strings.Contains(joined, "exec") {
 		t.Errorf("expected 'exec' subcommand in args; got %q", joined)
 	}
-	if !strings.Contains(joined, "review please") {
-		t.Errorf("expected prompt in args; got %q", joined)
+	if !strings.Contains(joined, "--skip-git-repo-check") {
+		t.Errorf("expected --skip-git-repo-check flag in args; got %q", joined)
 	}
-	if cmd.Stdin != nil || cmd.Stdout != nil || cmd.Stderr != nil {
-		t.Error("stdio pipes should be left nil for caller")
+	// Trailing "-" tells codex to read prompt from stdin.
+	hasStdinMarker := false
+	for _, a := range cmd.Args {
+		if a == "-" {
+			hasStdinMarker = true
+			break
+		}
+	}
+	if !hasStdinMarker {
+		t.Errorf("expected trailing '-' stdin marker in args; got %q", joined)
+	}
+	// Prompt must NOT appear in argv — it travels via stdin.
+	if strings.Contains(joined, "review please") {
+		t.Errorf("prompt should not appear in argv (piped via stdin); got %q", joined)
+	}
+	// Stdin MUST be wired (the prompt pipe); Stdout and Stderr stay nil
+	// for the caller to assign.
+	if cmd.Stdin == nil {
+		t.Error("expected Stdin to be wired with the prompt reader")
+	}
+	if cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Errorf("Stdout/Stderr should be left nil for caller; got stdout=%v stderr=%v",
+			cmd.Stdout, cmd.Stderr)
 	}
 }

--- a/cmd/entire/cli/agent/geminicli/headless.go
+++ b/cmd/entire/cli/agent/geminicli/headless.go
@@ -1,0 +1,17 @@
+package geminicli
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// LaunchHeadlessCmd builds an *exec.Cmd for `gemini -p "<initialPrompt>"`.
+// Non-interactive mode — Gemini processes the prompt and exits.
+func (g *GeminiCLIAgent) LaunchHeadlessCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error) {
+	bin, err := exec.LookPath("gemini")
+	if err != nil {
+		return nil, fmt.Errorf("gemini binary not on PATH: %w", err)
+	}
+	return exec.CommandContext(ctx, bin, "-p", initialPrompt), nil
+}

--- a/cmd/entire/cli/agent/geminicli/headless.go
+++ b/cmd/entire/cli/agent/geminicli/headless.go
@@ -2,7 +2,6 @@ package geminicli
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -19,12 +18,16 @@ import (
 // pending-review marker gets adopted. So cmd.Dir and cmd.Env are left
 // unset — the subprocess inherits the user's repo CWD and env. Stdout
 // and Stderr are left nil for the caller to wire.
+//
+// Binary lookup is deferred to *exec.Cmd.Start: passing the bare name
+// "gemini" lets exec.CommandContext stash an "executable not found"
+// error on cmd.Err that surfaces when the orchestrator runs the
+// command. This keeps construction infallible so unit tests can verify
+// argv shape without requiring the gemini binary on PATH.
+//
+//nolint:unparam // interface signature requires (*exec.Cmd, error); construction is infallible by design (binary lookup deferred to Cmd.Start).
 func (g *GeminiCLIAgent) LaunchHeadlessCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error) {
-	bin, err := exec.LookPath("gemini")
-	if err != nil {
-		return nil, fmt.Errorf("gemini binary not on PATH: %w", err)
-	}
-	cmd := exec.CommandContext(ctx, bin, "-p", " ")
+	cmd := exec.CommandContext(ctx, "gemini", "-p", " ")
 	cmd.Stdin = strings.NewReader(initialPrompt)
 	return cmd, nil
 }

--- a/cmd/entire/cli/agent/geminicli/headless.go
+++ b/cmd/entire/cli/agent/geminicli/headless.go
@@ -4,14 +4,27 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
-// LaunchHeadlessCmd builds an *exec.Cmd for `gemini -p "<initialPrompt>"`.
-// Non-interactive mode — Gemini processes the prompt and exits.
+// LaunchHeadlessCmd builds an *exec.Cmd for `gemini -p " "`, mirroring the
+// args+stdin pattern that GenerateText uses. Per `gemini --help`, the
+// -p/--prompt flag is appended to any input read from stdin; we pass a
+// single-space placeholder to trigger headless (non-interactive) mode and
+// let stdin carry the actual prompt, avoiding argv size limits.
+//
+// Unlike GenerateText (which isolates the subprocess via
+// RunIsolatedTextGeneratorCLI to prevent hooks from firing for meta
+// calls), review MUST fire the agent's UserPromptSubmit hook so the
+// pending-review marker gets adopted. So cmd.Dir and cmd.Env are left
+// unset — the subprocess inherits the user's repo CWD and env. Stdout
+// and Stderr are left nil for the caller to wire.
 func (g *GeminiCLIAgent) LaunchHeadlessCmd(ctx context.Context, initialPrompt string) (*exec.Cmd, error) {
 	bin, err := exec.LookPath("gemini")
 	if err != nil {
 		return nil, fmt.Errorf("gemini binary not on PATH: %w", err)
 	}
-	return exec.CommandContext(ctx, bin, "-p", initialPrompt), nil
+	cmd := exec.CommandContext(ctx, bin, "-p", " ")
+	cmd.Stdin = strings.NewReader(initialPrompt)
+	return cmd, nil
 }

--- a/cmd/entire/cli/agent/geminicli/headless_test.go
+++ b/cmd/entire/cli/agent/geminicli/headless_test.go
@@ -1,0 +1,34 @@
+package geminicli_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+)
+
+var _ agent.HeadlessLauncher = (*geminicli.GeminiCLIAgent)(nil)
+
+func TestGeminiCLIAgent_LaunchHeadlessCmd(t *testing.T) {
+	t.Parallel()
+	a := &geminicli.GeminiCLIAgent{}
+	cmd, err := a.LaunchHeadlessCmd(context.Background(), "review please")
+	if err != nil {
+		t.Fatalf("LaunchHeadlessCmd: %v", err)
+	}
+	if cmd == nil {
+		t.Fatal("returned nil cmd")
+	}
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.Contains(joined, "-p") {
+		t.Errorf("expected '-p' flag in args; got %q", joined)
+	}
+	if !strings.Contains(joined, "review please") {
+		t.Errorf("expected prompt in args; got %q", joined)
+	}
+	if cmd.Stdin != nil || cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Error("stdio pipes should be left nil for caller")
+	}
+}

--- a/cmd/entire/cli/agent/geminicli/headless_test.go
+++ b/cmd/entire/cli/agent/geminicli/headless_test.go
@@ -2,6 +2,7 @@ package geminicli_test
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -10,6 +11,27 @@ import (
 )
 
 var _ agent.HeadlessLauncher = (*geminicli.GeminiCLIAgent)(nil)
+
+// LaunchHeadlessCmd must be infallible at construction time even when
+// the gemini binary isn't on PATH — missing-binary errors surface at
+// cmd.Run() instead, so unit tests and CI runners without gemini
+// installed still verify the argv contract. Regression: an earlier
+// implementation called exec.LookPath up front, breaking CI.
+func TestGeminiCLIAgent_LaunchHeadlessCmd_NoBinaryOnPath(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent")
+	if _, err := os.Stat("/nonexistent/gemini"); err == nil {
+		t.Skip("PATH-scrub didn't take effect on this runner")
+	}
+
+	a := &geminicli.GeminiCLIAgent{}
+	cmd, err := a.LaunchHeadlessCmd(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("LaunchHeadlessCmd must not return an error when binary is missing; got %v", err)
+	}
+	if cmd == nil {
+		t.Fatal("returned nil cmd")
+	}
+}
 
 func TestGeminiCLIAgent_LaunchHeadlessCmd(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/agent/geminicli/headless_test.go
+++ b/cmd/entire/cli/agent/geminicli/headless_test.go
@@ -25,10 +25,30 @@ func TestGeminiCLIAgent_LaunchHeadlessCmd(t *testing.T) {
 	if !strings.Contains(joined, "-p") {
 		t.Errorf("expected '-p' flag in args; got %q", joined)
 	}
-	if !strings.Contains(joined, "review please") {
-		t.Errorf("expected prompt in args; got %q", joined)
+	// The -p flag carries a single-space placeholder; the real prompt is
+	// piped via stdin. Verify the placeholder is present as its own argv
+	// entry so the flag parses correctly in headless mode.
+	hasSpacePlaceholder := false
+	for i, a := range cmd.Args {
+		if a == "-p" && i+1 < len(cmd.Args) && cmd.Args[i+1] == " " {
+			hasSpacePlaceholder = true
+			break
+		}
 	}
-	if cmd.Stdin != nil || cmd.Stdout != nil || cmd.Stderr != nil {
-		t.Error("stdio pipes should be left nil for caller")
+	if !hasSpacePlaceholder {
+		t.Errorf("expected '-p' followed by single-space placeholder; got %q", joined)
+	}
+	// Prompt must NOT appear in argv — it travels via stdin.
+	if strings.Contains(joined, "review please") {
+		t.Errorf("prompt should not appear in argv (piped via stdin); got %q", joined)
+	}
+	// Stdin MUST be wired (the prompt pipe); Stdout and Stderr stay nil
+	// for the caller to assign.
+	if cmd.Stdin == nil {
+		t.Error("expected Stdin to be wired with the prompt reader")
+	}
+	if cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Errorf("Stdout/Stderr should be left nil for caller; got stdout=%v stderr=%v",
+			cmd.Stdout, cmd.Stderr)
 	}
 }

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -1316,6 +1316,68 @@ func TestAdoptMarker_MultiAgent_AgentInList(t *testing.T) {
 	}
 }
 
+// TestAdoptMarker_MultiAgent_PerAgentEntriesWin pins that when the
+// orchestrator populates AgentEntries (each agent's actual skills+
+// prompt), the adopting hook reads its own entry — not the top-level
+// Skills/Prompt fields. This is the bug the multi-agent orchestrator
+// originally exposed: it omitted Skills/Prompt entirely and adoption
+// silently recorded empty metadata, so checkpoints lost the "what was
+// reviewed" trail.
+func TestAdoptMarker_MultiAgent_PerAgentEntriesWin(t *testing.T) {
+	// Cannot t.Parallel — uses the global pending-review marker file.
+	ctx := context.Background()
+	env := setupAdoptionEnv(t)
+
+	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
+		AgentNames: []string{"claude-code", "codex"},
+		// Top-level Skills/Prompt deliberately omitted — the multi-agent
+		// orchestrator no longer sets them. Per-agent entries are the
+		// source of truth.
+		AgentEntries: map[string]AgentMarkerEntry{
+			"claude-code": {
+				Skills: []string{"/pr-review-toolkit:review-pr"},
+				Prompt: "claude prompt",
+			},
+			"codex": {
+				Skills: []string{"/codex:adversarial-review"},
+				Prompt: "codex prompt",
+			},
+		},
+		StartingSHA:  env.HeadSHA,
+		StartedAt:    time.Now(),
+		WorktreePath: env.WorktreePath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ClearPendingReviewMarker(ctx) }) //nolint:errcheck // test cleanup, best-effort
+
+	// Claude's hook adopts: should see claude's entry, not codex's.
+	claudeState, modified, err := adoptPendingReviewMarkerInto(ctx, session.State{WorktreePath: env.WorktreePath}, agent.AgentNameClaudeCode)
+	if err != nil || !modified {
+		t.Fatalf("claude adopt: modified=%v err=%v", modified, err)
+	}
+	if len(claudeState.ReviewSkills) != 1 || claudeState.ReviewSkills[0] != "/pr-review-toolkit:review-pr" {
+		t.Errorf("claude ReviewSkills = %v, want [/pr-review-toolkit:review-pr]", claudeState.ReviewSkills)
+	}
+	if claudeState.ReviewPrompt != "claude prompt" {
+		t.Errorf("claude ReviewPrompt = %q, want %q", claudeState.ReviewPrompt, "claude prompt")
+	}
+
+	// Codex's hook adopts the same marker independently: should see codex's
+	// entry. Marker stays in place across both adoptions because the
+	// orchestrator owns cleanup.
+	codexState, modified, err := adoptPendingReviewMarkerInto(ctx, session.State{WorktreePath: env.WorktreePath}, agent.AgentNameCodex)
+	if err != nil || !modified {
+		t.Fatalf("codex adopt: modified=%v err=%v", modified, err)
+	}
+	if len(codexState.ReviewSkills) != 1 || codexState.ReviewSkills[0] != "/codex:adversarial-review" {
+		t.Errorf("codex ReviewSkills = %v, want [/codex:adversarial-review]", codexState.ReviewSkills)
+	}
+	if codexState.ReviewPrompt != "codex prompt" {
+		t.Errorf("codex ReviewPrompt = %q, want %q", codexState.ReviewPrompt, "codex prompt")
+	}
+}
+
 // TestAdoptMarker_MultiAgent_AgentNotInList pins that an agent whose name
 // is absent from AgentNames leaves the marker untouched and does not tag
 // its session — protecting sibling agents from stealing the wrong config.

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -1248,3 +1248,174 @@ func TestAdoptPendingReviewMarker_DifferentAgentLeavesMarker(t *testing.T) {
 		t.Errorf("Kind = %q, want review", got.Kind)
 	}
 }
+
+// adoptionEnv bundles the state the multi-agent adoption tests below need:
+// a temp git repo, the current HEAD SHA, and the worktree path. The
+// existing single-agent tests inline this setup; collecting it behind a
+// helper keeps the new multi-agent tests compact.
+type adoptionEnv struct {
+	WorktreePath string
+	HeadSHA      string
+}
+
+func setupAdoptionEnv(t *testing.T) adoptionEnv {
+	t.Helper()
+	tmp := setupReviewTestRepoWithCommit(t)
+	sha, err := currentHeadSHA(context.Background())
+	if err != nil {
+		t.Fatalf("currentHeadSHA: %v", err)
+	}
+	return adoptionEnv{WorktreePath: tmp, HeadSHA: sha}
+}
+
+// TestAdoptMarker_MultiAgent_AgentInList pins that a session whose agent
+// name appears in the marker's AgentNames list is tagged as a review but
+// the marker is deliberately left in place — the orchestrator owns cleanup.
+func TestAdoptMarker_MultiAgent_AgentInList(t *testing.T) {
+	// Cannot t.Parallel — uses the global pending-review marker file.
+	ctx := context.Background()
+	env := setupAdoptionEnv(t)
+
+	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
+		AgentNames:   []string{"claude-code", "codex"},
+		Skills:       []string{"/review"},
+		Prompt:       "review the diff",
+		StartingSHA:  env.HeadSHA,
+		StartedAt:    time.Now(),
+		WorktreePath: env.WorktreePath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ClearPendingReviewMarker(ctx) }) //nolint:errcheck // test cleanup, best-effort
+
+	state := session.State{WorktreePath: env.WorktreePath}
+	updated, modified, err := adoptPendingReviewMarkerInto(ctx, state, agent.AgentNameClaudeCode)
+	if err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	if !modified {
+		t.Error("expected session to be tagged")
+	}
+	if updated.Kind != session.KindAgentReview {
+		t.Errorf("Kind = %q, want agent_review", updated.Kind)
+	}
+	if len(updated.ReviewSkills) != 1 || updated.ReviewSkills[0] != "/review" {
+		t.Errorf("ReviewSkills = %v", updated.ReviewSkills)
+	}
+	if updated.ReviewPrompt != "review the diff" {
+		t.Errorf("ReviewPrompt = %q", updated.ReviewPrompt)
+	}
+
+	// Marker must remain — orchestrator clears it after all agents finish.
+	_, markerOK, markerErr := ReadPendingReviewMarker(ctx)
+	if markerErr != nil {
+		t.Fatalf("read marker: %v", markerErr)
+	}
+	if !markerOK {
+		t.Error("marker should still exist after multi-agent adopt")
+	}
+}
+
+// TestAdoptMarker_MultiAgent_AgentNotInList pins that an agent whose name
+// is absent from AgentNames leaves the marker untouched and does not tag
+// its session — protecting sibling agents from stealing the wrong config.
+func TestAdoptMarker_MultiAgent_AgentNotInList(t *testing.T) {
+	// Cannot t.Parallel — uses the global pending-review marker file.
+	ctx := context.Background()
+	env := setupAdoptionEnv(t)
+
+	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
+		AgentNames:   []string{"claude-code", "codex"},
+		Skills:       []string{"/review"},
+		StartingSHA:  env.HeadSHA,
+		StartedAt:    time.Now(),
+		WorktreePath: env.WorktreePath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ClearPendingReviewMarker(ctx) }) //nolint:errcheck // test cleanup, best-effort
+
+	state := session.State{WorktreePath: env.WorktreePath}
+	got, modified, err := adoptPendingReviewMarkerInto(ctx, state, agent.AgentNameGemini)
+	if err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	if modified {
+		t.Error("agent not in AgentNames should not tag session")
+	}
+	if got.Kind != "" {
+		t.Errorf("Kind = %q, want empty (session should not be tagged)", got.Kind)
+	}
+	// Marker must remain — the correct agents still need to adopt it.
+	_, markerOK, markerErr := ReadPendingReviewMarker(ctx)
+	if markerErr != nil {
+		t.Fatalf("read marker: %v", markerErr)
+	}
+	if !markerOK {
+		t.Error("marker should survive when agent is not in AgentNames")
+	}
+}
+
+// TestAdoptMarker_MultiAgent_WorktreeMismatchIgnores pins that the
+// worktree-path guard still applies in the multi-agent branch — a
+// matching-name agent in the wrong worktree must not adopt.
+func TestAdoptMarker_MultiAgent_WorktreeMismatchIgnores(t *testing.T) {
+	// Cannot t.Parallel — uses the global pending-review marker file.
+	ctx := context.Background()
+	env := setupAdoptionEnv(t)
+
+	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
+		AgentNames:   []string{"claude-code"},
+		StartingSHA:  env.HeadSHA,
+		StartedAt:    time.Now(),
+		WorktreePath: "/some/other/worktree",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ClearPendingReviewMarker(ctx) }) //nolint:errcheck // test cleanup, best-effort
+
+	state := session.State{WorktreePath: env.WorktreePath}
+	_, modified, err := adoptPendingReviewMarkerInto(ctx, state, agent.AgentNameClaudeCode)
+	if err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	if modified {
+		t.Error("worktree mismatch should prevent adopt even for multi-agent")
+	}
+}
+
+// TestAdoptMarker_SingleAgent_BackwardsCompat pins that the pre-existing
+// single-agent (AgentName) path is untouched by the new multi-agent
+// branch: the marker is cleared on successful adoption, and the session
+// is tagged exactly as before.
+func TestAdoptMarker_SingleAgent_BackwardsCompat(t *testing.T) {
+	// Cannot t.Parallel — uses the global pending-review marker file.
+	ctx := context.Background()
+	env := setupAdoptionEnv(t)
+
+	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
+		AgentName:    "claude-code",
+		Skills:       []string{"/review"},
+		StartingSHA:  env.HeadSHA,
+		StartedAt:    time.Now(),
+		WorktreePath: env.WorktreePath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	state := session.State{WorktreePath: env.WorktreePath}
+	_, modified, err := adoptPendingReviewMarkerInto(ctx, state, agent.AgentNameClaudeCode)
+	if err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	if !modified {
+		t.Error("single-agent path should still tag session")
+	}
+	_, markerOK, markerErr := ReadPendingReviewMarker(ctx)
+	if markerErr != nil {
+		t.Fatalf("read marker: %v", markerErr)
+	}
+	if markerOK {
+		t.Error("single-agent adopt should clear the marker")
+	}
+}

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -49,8 +49,66 @@ type agentChoice struct {
 // require a real TTY. Production wiring leaves fields nil and defaults
 // are resolved inside runReview.
 type runReviewDeps struct {
-	promptForAgentFn func(ctx context.Context, eligible []agentChoice) (string, error)
+	promptForAgentFn  func(ctx context.Context, eligible []agentChoice) (string, error)
+	promptForAgentsFn func(ctx context.Context, eligible []agentChoice) ([]string, error)
+	runMultiAgentFn   func(ctx context.Context, tasks []MultiAgentTask, out io.Writer) (MultiRunResult, error)
 }
+
+// MultiAgentTask is a forward-declared type that Chunk 3's orchestrator
+// populates. For Chunk 2 only the name/prompt matter for dispatch tests.
+type MultiAgentTask struct {
+	Agent  agent.HeadlessLauncher // set by dispatcher when routing to multi-agent
+	Name   string                 // agent registry key
+	Prompt string                 // composed via composeReviewPrompt(cfg)
+}
+
+// MultiRunResult is a placeholder — full shape lands in Chunk 3. Kept
+// minimal here so dispatch compile-checks; orchestrator in Chunk 3
+// expands Runs/Duration/Cancelled fields.
+type MultiRunResult struct {
+	Runs      []AgentRunResult
+	Duration  time.Duration
+	Cancelled bool
+}
+
+// AgentRunStatus / AgentRunResult — full shape lands in Chunk 3. Minimal
+// definitions here so MultiRunResult compiles. Chunk 3 may expand these.
+type AgentRunStatus int
+
+const (
+	AgentRunQueued AgentRunStatus = iota
+	AgentRunRunning
+	AgentRunDone
+	AgentRunFailed
+	AgentRunCancelled
+)
+
+// AgentRunResult reports the outcome of a single agent run inside a
+// multi-agent review. Forward-declared here; Chunk 3 wires real values.
+type AgentRunResult struct {
+	Name           string
+	Status         AgentRunStatus
+	ExitCode       int
+	Duration       time.Duration
+	FinalOutput    []byte
+	Err            error
+	TokenUsage     *agent.TokenUsage
+	TranscriptPath string
+}
+
+// Package-level anchor — keeps forward-declared types referenced until
+// the orchestrator in Chunk 3 consumes them. Removed or replaced when
+// Chunk 3 lands real usages.
+var (
+	_ = MultiAgentTask{}
+	_ = MultiRunResult{}
+	_ = AgentRunResult{}
+	_ = AgentRunQueued
+	_ = AgentRunRunning
+	_ = AgentRunDone
+	_ = AgentRunFailed
+	_ = AgentRunCancelled
+)
 
 // PendingReviewMarker is written by `entire review` before spawning the agent.
 // The next agent session's UserPromptSubmit hook reads it, tags the session
@@ -580,35 +638,21 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string, de
 	}
 
 	// 3. Pick agent. When multiple agents are configured with hooks installed
-	// and no --agent override is provided, prompt the user to pick one.
-	// Skipped when --agent is passed, and skipped when only one eligible
-	// agent is configured (selectReviewAgent's alphabetical default handles
-	// the single-agent case deterministically).
+	// and no --agent override is provided, prompt the user to pick one (or
+	// many, for multi-agent review). Skipped when --agent is passed, and
+	// skipped when only one eligible agent is configured (selectReviewAgent's
+	// alphabetical default handles the single-agent case deterministically).
 	if agentOverride == "" {
-		eligible := computeEligibleConfigured(ctx, s)
-		if len(eligible) > 1 {
-			fn := deps.promptForAgentFn
-			if fn == nil {
-				fn = promptForAgent
-			}
-			picked, pickErr := fn(ctx, eligible)
-			if pickErr != nil {
-				cmd.SilenceUsage = true
-				fmt.Fprintln(cmd.ErrOrStderr(), pickErr.Error())
-				return NewSilentError(pickErr)
-			}
-			if picked == "" {
-				// Defensive: a nil-or-empty return from the picker must NOT
-				// fall through to selectReviewAgent's alphabetical-first
-				// default. That's exactly the silent-masking shape the
-				// picker was added to eliminate. Refuse to proceed.
-				cmd.SilenceUsage = true
-				emptyErr := errors.New("agent picker returned empty agent name")
-				fmt.Fprintln(cmd.ErrOrStderr(), emptyErr.Error())
-				return NewSilentError(emptyErr)
-			}
-			agentOverride = picked
+		override, dispatched, pickErr := pickAgentForReview(ctx, cmd, s, deps)
+		if dispatched {
+			// Multi-agent orchestrator took over; nothing more for runReview
+			// to do. Propagate any error verbatim (may be nil).
+			return pickErr
 		}
+		if pickErr != nil {
+			return pickErr
+		}
+		agentOverride = override
 	}
 
 	agentName, cfg, err := selectReviewAgent(s.Review, agentOverride)
@@ -738,6 +782,151 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string, de
 	return nil
 }
 
+// pickAgentForReview runs the agent-selection picker. Returns:
+//
+//   - override: the chosen agent name for the single-agent spawn path,
+//     empty if no picker fired (caller falls through to selectReviewAgent's
+//     alphabetical default).
+//   - dispatched: true when the multi-agent orchestrator has already been
+//     invoked; caller should return immediately.
+//   - err: picker error or a silent-error shell used to print a user-facing
+//     message without a usage dump.
+//
+// Dispatch order:
+//
+//   - If 2+ eligible agents implement HeadlessLauncher → multi-select
+//     picker. Selecting 1 falls through to single-agent path; selecting
+//     2+ routes to the orchestrator.
+//   - Otherwise, if 2+ eligible → fall back to the 2.1 single-select.
+//   - Otherwise, single-eligible case is handled by selectReviewAgent in
+//     the caller (alphabetically first, deterministic).
+func pickAgentForReview(ctx context.Context, cmd *cobra.Command, s *settings.EntireSettings, deps runReviewDeps) (override string, dispatched bool, err error) {
+	eligibleConfigured := computeEligibleConfigured(ctx, s)
+
+	// Filter to agents implementing HeadlessLauncher. The multi-agent
+	// picker only offers these, because the orchestrator spawns them
+	// headlessly. Single-agent fallback below operates on the full
+	// eligible set.
+	var runnable []agentChoice
+	for _, e := range eligibleConfigured {
+		ag, getErr := agent.Get(types.AgentName(e.Name))
+		if getErr != nil {
+			continue // already reported by earlier gates
+		}
+		if _, ok := ag.(agent.HeadlessLauncher); ok {
+			runnable = append(runnable, e)
+		}
+	}
+
+	switch {
+	case len(runnable) >= 2:
+		return pickMultiAgent(ctx, cmd, s, runnable, deps)
+	case len(eligibleConfigured) > 1:
+		return pickSingleAgent(ctx, cmd, eligibleConfigured, deps)
+	}
+	// <=1 eligible → no picker; selectReviewAgent picks alphabetically-first.
+	return "", false, nil
+}
+
+// pickMultiAgent runs the multi-select picker over runnable agents. Returns
+// override + dispatched=false when the user picks exactly one agent (caller
+// continues with single-agent path), dispatched=true when the orchestrator
+// has been invoked (caller should return).
+func pickMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.EntireSettings, runnable []agentChoice, deps runReviewDeps) (string, bool, error) {
+	fn := deps.promptForAgentsFn
+	if fn == nil {
+		fn = promptForAgents
+	}
+	selected, pickErr := fn(ctx, runnable)
+	if pickErr != nil {
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), pickErr.Error())
+		return "", false, NewSilentError(pickErr)
+	}
+	if len(selected) == 0 {
+		// User cancelled.
+		return "", false, NewSilentError(errors.New("multi-agent picker cancelled"))
+	}
+	if len(selected) == 1 {
+		// Drop into single-agent path.
+		return selected[0], false, nil
+	}
+	// Route to multi-agent orchestrator.
+	if err := dispatchMultiAgent(ctx, cmd, s, selected, deps); err != nil {
+		return "", true, err
+	}
+	return "", true, nil
+}
+
+// pickSingleAgent runs the 2.1 single-select picker over the eligible set.
+// Returns override=<picked> when the user picks a valid agent.
+func pickSingleAgent(ctx context.Context, cmd *cobra.Command, eligible []agentChoice, deps runReviewDeps) (string, bool, error) {
+	fn := deps.promptForAgentFn
+	if fn == nil {
+		fn = promptForAgent
+	}
+	picked, pickErr := fn(ctx, eligible)
+	if pickErr != nil {
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), pickErr.Error())
+		return "", false, NewSilentError(pickErr)
+	}
+	if picked == "" {
+		// Defensive: a nil-or-empty return from the picker must NOT fall
+		// through to selectReviewAgent's alphabetical-first default. That's
+		// exactly the silent-masking shape the picker was added to
+		// eliminate. Refuse to proceed.
+		cmd.SilenceUsage = true
+		emptyErr := errors.New("agent picker returned empty agent name")
+		fmt.Fprintln(cmd.ErrOrStderr(), emptyErr.Error())
+		return "", false, NewSilentError(emptyErr)
+	}
+	return picked, false, nil
+}
+
+// dispatchMultiAgent composes per-agent tasks, resolves HeadlessLauncher
+// capabilities, and hands off to the orchestrator via deps.runMultiAgentFn.
+// Marker write, hook adoption, and cleanup are the orchestrator's
+// responsibility — this function only prepares the task list and dispatches.
+func dispatchMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.EntireSettings, selected []string, deps runReviewDeps) error {
+	out := cmd.OutOrStdout()
+	tasks := make([]MultiAgentTask, 0, len(selected))
+	for _, name := range selected {
+		cfg := s.Review[name]
+		if cfg.IsZero() {
+			return fmt.Errorf("internal error: agent %q selected but has no configured review config", name)
+		}
+		ag, err := agent.Get(types.AgentName(name))
+		if err != nil {
+			return fmt.Errorf("resolve agent %s: %w", name, err)
+		}
+		hl, ok := ag.(agent.HeadlessLauncher)
+		if !ok {
+			return fmt.Errorf("agent %s does not implement HeadlessLauncher (should have been filtered by picker)", name)
+		}
+		tasks = append(tasks, MultiAgentTask{
+			Agent:  hl,
+			Name:   name,
+			Prompt: composeReviewPrompt(cfg),
+		})
+	}
+
+	fn := deps.runMultiAgentFn
+	if fn == nil {
+		// Real orchestrator lands in Chunk 3. Until then this is a
+		// compile-time sentinel.
+		return errors.New("multi-agent orchestrator not implemented (Chunk 3)")
+	}
+	result, err := fn(ctx, tasks, out)
+	if err != nil {
+		return err
+	}
+	// Result is informational for Chunk 2's test stub. Chunk 4 wires
+	// the completion dump; Chunk 3 wires the marker writes / cleanup.
+	_ = result
+	return nil
+}
+
 // computeEligibleConfigured returns the sorted list of agents that are both
 // configured (non-zero ReviewConfig entry) AND have hooks installed. Only
 // eligible agents are valid picker targets — spawning a review for an agent
@@ -804,6 +993,34 @@ func promptForAgent(ctx context.Context, eligible []agentChoice) (string, error)
 	))
 	if err := form.Run(); err != nil {
 		return "", fmt.Errorf("agent picker: %w", err)
+	}
+	return picked, nil
+}
+
+// promptForAgents runs a multi-select huh picker over the given eligible
+// agents and returns selected names. An empty return is an explicit user
+// cancel — caller should exit silently, no marker written.
+func promptForAgents(ctx context.Context, eligible []agentChoice) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("multi-agent picker: %w", err)
+	}
+	if len(eligible) == 0 {
+		return nil, errors.New("no eligible agents to prompt for")
+	}
+	options := make([]huh.Option[string], 0, len(eligible))
+	for _, c := range eligible {
+		options = append(options, huh.NewOption(c.Label, c.Name))
+	}
+	var picked []string
+	form := NewAccessibleForm(huh.NewGroup(
+		huh.NewMultiSelect[string]().
+			Title("Which agents should run this review?").
+			Description("Space to toggle, Enter to confirm. Select 2+ for parallel run; 1 drops into single-agent mode.").
+			Options(options...).
+			Value(&picked),
+	))
+	if err := form.Run(); err != nil {
+		return nil, fmt.Errorf("multi-agent picker: %w", err)
 	}
 	return picked, nil
 }

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -902,7 +902,10 @@ func pickMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.EntireS
 		return "", false, NewSilentError(pickErr)
 	}
 	if len(selected) == 0 {
-		// User cancelled.
+		// User cancelled. SilenceUsage prevents cobra from dumping help
+		// text on a deliberate cancel — the user clicked away from the
+		// picker, they don't need usage instructions.
+		cmd.SilenceUsage = true
 		return "", false, NewSilentError(errors.New("multi-agent picker cancelled"))
 	}
 	if len(selected) == 1 {
@@ -915,8 +918,13 @@ func pickMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.EntireS
 	if err != nil {
 		return "", false, err
 	}
-	// Route to multi-agent orchestrator.
+	// Route to multi-agent orchestrator. SilenceUsage on dispatch errors
+	// matches the single-agent picker path: failure modes here (resolve
+	// agent, write marker, launcher capability missing) are runtime
+	// problems, not invocation problems, so cobra usage output would be
+	// noise.
 	if err := dispatchMultiAgent(ctx, cmd, s, selected, runContext, deps); err != nil {
+		cmd.SilenceUsage = true
 		return "", true, err
 	}
 	return "", true, nil

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -1266,7 +1266,12 @@ func composeReviewPrompt(cfg settings.ReviewConfig, runContext string, scope rev
 		if base == "" {
 			base = runContext
 		} else {
-			base = base + "\n\nFor this review: " + runContext
+			// strings.TrimRight strips the trailing newline the skills
+			// template emits before its last entry — without this, joining
+			// with "\n\nFor this review:" produced three consecutive
+			// newlines (the template's \n + the joiner's \n\n) and a
+			// visually hollow gap in the agent prompt.
+			base = strings.TrimRight(base, "\n") + "\n\nFor this review: " + runContext
 		}
 	}
 

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -54,25 +54,28 @@ type runReviewDeps struct {
 	runMultiAgentFn   func(ctx context.Context, tasks []MultiAgentTask, out io.Writer) (MultiRunResult, error)
 }
 
-// MultiAgentTask is a forward-declared type that Chunk 3's orchestrator
-// populates. For Chunk 2 only the name/prompt matter for dispatch tests.
+// MultiAgentTask describes one agent's slot in a parallel review run.
+// The dispatcher populates all three fields; the orchestrator passes the
+// task straight through to HeadlessLauncher.LaunchHeadlessCmd.
 type MultiAgentTask struct {
 	Agent  agent.HeadlessLauncher // set by dispatcher when routing to multi-agent
 	Name   string                 // agent registry key
 	Prompt string                 // composed via composeReviewPrompt(cfg)
 }
 
-// MultiRunResult is a placeholder — full shape lands in Chunk 3. Kept
-// minimal here so dispatch compile-checks; orchestrator in Chunk 3
-// expands Runs/Duration/Cancelled fields.
+// MultiRunResult is the aggregated result of a multi-agent review. Runs
+// contains one entry per task (in task order); Duration is wall-clock
+// span (max of per-agent durations, not sum); Cancelled reports whether
+// the orchestrator was signal-cancelled during the run.
 type MultiRunResult struct {
 	Runs      []AgentRunResult
 	Duration  time.Duration
 	Cancelled bool
 }
 
-// AgentRunStatus / AgentRunResult — full shape lands in Chunk 3. Minimal
-// definitions here so MultiRunResult compiles. Chunk 3 may expand these.
+// AgentRunStatus tracks one agent's lifecycle through a multi-agent
+// review run. Transitions are Queued → Running → {Done, Failed,
+// Cancelled}; the last three are terminal.
 type AgentRunStatus int
 
 const (
@@ -84,7 +87,7 @@ const (
 )
 
 // AgentRunResult reports the outcome of a single agent run inside a
-// multi-agent review. Forward-declared here; Chunk 3 wires real values.
+// multi-agent review.
 type AgentRunResult struct {
 	Name           string
 	Status         AgentRunStatus
@@ -939,8 +942,8 @@ func dispatchMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.Ent
 	if err != nil {
 		return err
 	}
-	// Result is informational for Chunk 2's test stub. Chunk 4 wires
-	// the completion dump; Chunk 3 wires the marker writes / cleanup.
+	// The orchestrator prints its own completion dump + summary line to
+	// out; the returned result is informational for test assertions.
 	_ = result
 	return nil
 }

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -96,20 +96,6 @@ type AgentRunResult struct {
 	TranscriptPath string
 }
 
-// Package-level anchor — keeps forward-declared types referenced until
-// the orchestrator in Chunk 3 consumes them. Removed or replaced when
-// Chunk 3 lands real usages.
-var (
-	_ = MultiAgentTask{}
-	_ = MultiRunResult{}
-	_ = AgentRunResult{}
-	_ = AgentRunQueued
-	_ = AgentRunRunning
-	_ = AgentRunDone
-	_ = AgentRunFailed
-	_ = AgentRunCancelled
-)
-
 // PendingReviewMarker is written by `entire review` before spawning the agent.
 // The next agent session's UserPromptSubmit hook reads it, tags the session
 // kind/review-skills, then clears the marker (so a second review run doesn't
@@ -121,8 +107,13 @@ var (
 // blank WorktreePath (pre-fix markers) falls back to the legacy unscoped
 // behavior — any session can adopt.
 type PendingReviewMarker struct {
-	AgentName string   `json:"agent_name"`
-	Skills    []string `json:"skills"`
+	AgentName string `json:"agent_name,omitempty"`
+	// AgentNames is set by the multi-agent orchestrator. Any agent whose
+	// name appears in this list is allowed to adopt the marker (tagging
+	// its session as a review); the orchestrator — not the adopting hook
+	// — owns clearing the marker once the parallel run finishes.
+	AgentNames []string `json:"agent_names,omitempty"`
+	Skills     []string `json:"skills"`
 	// Prompt is the composed review prompt the agent will receive.
 	// Stored on the marker (rather than recomputed on adoption) so session
 	// metadata records exactly what the agent was asked to do.
@@ -245,7 +236,25 @@ func adoptPendingReviewMarkerInto(ctx context.Context, s session.State, agentNam
 		// and claim the marker.
 		return s, false, nil
 	}
-	if m.AgentName != "" && m.AgentName != string(agentName) {
+	// Multi-agent markers (written by multiReviewOrchestrator) carry a
+	// list of eligible agent names. Any agent in the list may adopt, but
+	// the orchestrator — not the adopting hook — owns clearing the marker
+	// once the whole parallel run exits.
+	multiAgent := len(m.AgentNames) > 0
+	if multiAgent {
+		inList := false
+		for _, n := range m.AgentNames {
+			if n == string(agentName) {
+				inList = true
+				break
+			}
+		}
+		if !inList {
+			// Agent not in the orchestrator's list — leave marker so the
+			// other configured agents' hooks can still adopt.
+			return s, false, nil
+		}
+	} else if m.AgentName != "" && m.AgentName != string(agentName) {
 		// Marker was written for a different agent — leave it alone. The
 		// correct agent's session will reach its own hook and claim the
 		// marker.
@@ -279,6 +288,12 @@ func adoptPendingReviewMarkerInto(ctx context.Context, s session.State, agentNam
 	s.Kind = session.KindAgentReview
 	s.ReviewSkills = m.Skills
 	s.ReviewPrompt = m.Prompt
+	if multiAgent {
+		// The orchestrator owns marker cleanup for multi-agent runs; a per-
+		// hook clear here would race the sibling agents still waiting to
+		// adopt.
+		return s, true, nil
+	}
 	if err := ClearPendingReviewMarker(ctx); err != nil {
 		// Tagging succeeded; leftover marker self-heals on next session start
 		// (since Kind is now set, the next turn will return modified=false
@@ -913,9 +928,12 @@ func dispatchMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.Ent
 
 	fn := deps.runMultiAgentFn
 	if fn == nil {
-		// Real orchestrator lands in Chunk 3. Until then this is a
-		// compile-time sentinel.
-		return errors.New("multi-agent orchestrator not implemented (Chunk 3)")
+		worktreeRoot, err := paths.WorktreeRoot(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve worktree root: %w", err)
+		}
+		orch := newMultiReviewOrchestrator(worktreeRoot)
+		fn = orch.Run
 	}
 	result, err := fn(ctx, tasks, out)
 	if err != nil {

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -62,6 +62,7 @@ type MultiAgentTask struct {
 	Agent  agent.HeadlessLauncher // set by dispatcher when routing to multi-agent
 	Name   string                 // agent registry key
 	Prompt string                 // composed via composeReviewPrompt(cfg, runContext, scope)
+	Skills []string               // configured skills for this agent; carried into the marker so adoption can record them per-agent
 }
 
 // MultiRunResult is the aggregated result of a multi-agent review. Runs
@@ -121,10 +122,24 @@ type PendingReviewMarker struct {
 	// Prompt is the composed review prompt the agent will receive.
 	// Stored on the marker (rather than recomputed on adoption) so session
 	// metadata records exactly what the agent was asked to do.
-	Prompt       string    `json:"prompt,omitempty"`
-	StartingSHA  string    `json:"starting_sha"`
-	StartedAt    time.Time `json:"started_at"`
-	WorktreePath string    `json:"worktree_path,omitempty"`
+	Prompt string `json:"prompt,omitempty"`
+	// AgentEntries carries per-agent skills and prompts for multi-agent
+	// runs. Each agent's hook looks up its own entry by agent name on
+	// adoption so its session records the skills+prompt it actually ran,
+	// not the union or an arbitrary representative. Single-agent markers
+	// leave this empty and use the top-level Skills/Prompt fields.
+	AgentEntries map[string]AgentMarkerEntry `json:"agent_entries,omitempty"`
+	StartingSHA  string                      `json:"starting_sha"`
+	StartedAt    time.Time                   `json:"started_at"`
+	WorktreePath string                      `json:"worktree_path,omitempty"`
+}
+
+// AgentMarkerEntry is the per-agent payload inside a multi-agent
+// PendingReviewMarker. Adoption copies these onto the agent's session
+// state so checkpoint metadata reflects what each agent actually ran.
+type AgentMarkerEntry struct {
+	Skills []string `json:"skills,omitempty"`
+	Prompt string   `json:"prompt,omitempty"`
 }
 
 func pendingMarkerPath(ctx context.Context) (string, error) {
@@ -290,8 +305,18 @@ func adoptPendingReviewMarkerInto(ctx context.Context, s session.State, agentNam
 		}
 	}
 	s.Kind = session.KindAgentReview
-	s.ReviewSkills = m.Skills
-	s.ReviewPrompt = m.Prompt
+	// Per-agent lookup wins for multi-agent markers — each agent's
+	// session records the skills/prompt it actually ran, not a union or
+	// representative. Top-level Skills/Prompt is the single-agent path
+	// and the fallback when an entry is missing (legacy markers, or a
+	// new agent whose hook fired without a registered entry).
+	if entry, ok := m.AgentEntries[string(agentName)]; ok && multiAgent {
+		s.ReviewSkills = entry.Skills
+		s.ReviewPrompt = entry.Prompt
+	} else {
+		s.ReviewSkills = m.Skills
+		s.ReviewPrompt = m.Prompt
+	}
 	if multiAgent {
 		// The orchestrator owns marker cleanup for multi-agent runs; a per-
 		// hook clear here would race the sibling agents still waiting to
@@ -961,6 +986,7 @@ func dispatchMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.Ent
 			Agent:  hl,
 			Name:   name,
 			Prompt: composeReviewPrompt(cfg, runContext, scope),
+			Skills: cfg.Skills,
 		})
 	}
 

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -61,7 +61,7 @@ type runReviewDeps struct {
 type MultiAgentTask struct {
 	Agent  agent.HeadlessLauncher // set by dispatcher when routing to multi-agent
 	Name   string                 // agent registry key
-	Prompt string                 // composed via composeReviewPrompt(cfg, runContext)
+	Prompt string                 // composed via composeReviewPrompt(cfg, runContext, scope)
 }
 
 // MultiRunResult is the aggregated result of a multi-agent review. Runs
@@ -753,8 +753,13 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string, de
 	// what the agent was asked to do (the same string passed to LaunchCmd
 	// below), rather than recomposing on the hook side. When the user has
 	// configured a custom Prompt, it wins verbatim; otherwise Skills are
-	// composed into the default "run these in order" template.
-	prompt := composeReviewPrompt(cfg, runContext)
+	// composed into the default "run these in order" template. The scope
+	// clause pins agents to "commits unique to this branch vs the closest
+	// ancestor branch," excluding work inherited from sibling branches.
+	prompt := composeReviewPrompt(cfg, runContext, reviewPromptScope{
+		Branch:  currentBranch(ctx),
+		BaseRef: detectScopeBaseRef(ctx, worktreeRoot),
+	})
 	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
 		AgentName:    agentName,
 		Skills:       cfg.Skills,
@@ -926,6 +931,18 @@ func pickSingleAgent(ctx context.Context, cmd *cobra.Command, eligible []agentCh
 // composed into every selected agent's prompt alongside the persistent cfg.
 func dispatchMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.EntireSettings, selected []string, runContext string, deps runReviewDeps) error {
 	out := cmd.OutOrStdout()
+	// Resolve scope once before composing per-agent prompts. Failures are
+	// non-fatal — composeReviewPrompt drops the scope clause for any
+	// missing field rather than refusing to spawn.
+	repoRoot, rootErr := paths.WorktreeRoot(ctx)
+	if rootErr != nil {
+		logging.Debug(ctx, "multi-agent dispatch: repo root resolve failed; scope clause omitted",
+			slog.String("error", rootErr.Error()))
+	}
+	scope := reviewPromptScope{
+		Branch:  currentBranch(ctx),
+		BaseRef: detectScopeBaseRef(ctx, repoRoot),
+	}
 	tasks := make([]MultiAgentTask, 0, len(selected))
 	for _, name := range selected {
 		cfg := s.Review[name]
@@ -943,7 +960,7 @@ func dispatchMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.Ent
 		tasks = append(tasks, MultiAgentTask{
 			Agent:  hl,
 			Name:   name,
-			Prompt: composeReviewPrompt(cfg, runContext),
+			Prompt: composeReviewPrompt(cfg, runContext, scope),
 		})
 	}
 
@@ -1176,13 +1193,29 @@ func verifyConfiguredSkillsInstalled(ctx context.Context, ag agent.Agent, cfg se
 	)
 }
 
+// reviewPromptScope is best-effort context about the surface to review.
+// All fields are optional: empty values shrink or omit the scope clause
+// rather than failing. Branch is the short branch name ("" = detached).
+// BaseRef is the upstream comparison point — typically the closest
+// non-self ancestor branch (for branch-on-branch workflows) or the
+// repo's default base branch — used to scope the review to "commits
+// unique to this branch."
+type reviewPromptScope struct {
+	Branch  string
+	BaseRef string
+}
+
 // composeReviewPrompt builds the prompt sent to the agent from a
-// ReviewConfig plus optional per-run context. The base is whichever of
-// cfg.Prompt (persistent) or a skills-composed template is set; per-run
-// context, when non-empty, is appended with a clear marker so the agent
-// can distinguish persistent preferences from per-run intent. Empty
-// cfg + empty runContext returns "".
-func composeReviewPrompt(cfg settings.ReviewConfig, runContext string) string {
+// ReviewConfig plus optional per-run context and scope. The base is
+// whichever of cfg.Prompt (persistent) or a skills-composed template is
+// set; per-run context, when non-empty, is appended with a clear marker
+// so the agent can distinguish persistent preferences from per-run
+// intent. The scope clause, when scope has a BaseRef, pins the review
+// surface to "commits unique to this branch vs the base ref" — making
+// claude and codex agree on what to review and excluding work
+// inherited from sibling branches. Empty cfg + empty runContext +
+// zero scope returns "".
+func composeReviewPrompt(cfg settings.ReviewConfig, runContext string, scope reviewPromptScope) string {
 	var base string
 	if cfg.Prompt != "" {
 		base = cfg.Prompt
@@ -1195,13 +1228,48 @@ func composeReviewPrompt(cfg settings.ReviewConfig, runContext string) string {
 		base = sb.String()
 	}
 
-	if runContext == "" {
+	if runContext != "" {
+		if base == "" {
+			base = runContext
+		} else {
+			base = base + "\n\nFor this review: " + runContext
+		}
+	}
+
+	clause := scopeClause(scope)
+	if clause == "" {
 		return base
 	}
 	if base == "" {
-		return runContext
+		return clause
 	}
-	return base + "\n\nFor this review: " + runContext
+	return base + "\n\n" + clause
+}
+
+// scopeClause renders the scope hint appended to the agent prompt.
+// Returns "" when scope carries no usable information (no BaseRef),
+// since without a comparison point the clause would be lying about what
+// to review.
+//
+// The clause is deliberately commits-only — uncommitted working-tree
+// changes (e.g. regenerated .pyc bytecode, editor lockfiles) are noise
+// that pollutes the review when the user just wants feedback on
+// committed work. Users who want uncommitted work reviewed should
+// either commit it first or say so in the per-run prompt textarea.
+func scopeClause(scope reviewPromptScope) string {
+	if scope.BaseRef == "" {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("Review scope: only the commits unique to this branch")
+	if scope.Branch != "" {
+		fmt.Fprintf(&sb, " (`%s`)", scope.Branch)
+	}
+	fmt.Fprintf(&sb, " vs base `%s`.\n", scope.BaseRef)
+	fmt.Fprintf(&sb, "Use `git diff %s...HEAD` to find the surface to review. ", scope.BaseRef)
+	fmt.Fprintf(&sb, "The three-dot syntax (`%s...HEAD`) excludes commits that came from sibling branches and are already on `%s` — do not review those. ", scope.BaseRef, scope.BaseRef)
+	sb.WriteString("Do not review uncommitted working-tree changes (regenerated bytecode, editor temp files, etc.) unless explicitly asked.")
+	return sb.String()
 }
 
 // currentHeadSHA returns the current HEAD commit hash as a 40-char hex string.
@@ -1216,6 +1284,74 @@ func currentHeadSHA(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("git rev-parse HEAD: %w", err)
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+// currentBranch returns the short branch name, or "" when HEAD is
+// detached or the lookup fails. Best-effort by design: callers use it to
+// label the scope clause, not to drive control flow.
+func currentBranch(ctx context.Context) string {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return ""
+	}
+	name := gitString(ctx, repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	if name == detachedHEADDisplay {
+		return ""
+	}
+	return name
+}
+
+// detectScopeBaseRef finds the most appropriate base for "commits unique
+// to this branch." Strategy:
+//
+//  1. Find local branches whose tip is an ancestor of HEAD~1 (i.e. the
+//     branch's history flows through them, but they're not just HEAD
+//     itself). Skip the current branch and entire/* internal branches.
+//  2. Pick the candidate whose tip is most recently authored — that's
+//     the branch this one was forked from.
+//  3. Fall back to the repo's default base (`detectBaseBranch`, which
+//     resolves origin/HEAD or main/master).
+//
+// Returns "" only when no usable base is found (e.g., orphan branch,
+// missing git remote). Callers treat empty as "skip the scope clause."
+func detectScopeBaseRef(ctx context.Context, repoRoot string) string {
+	// HEAD~1 doesn't exist on root commits — guard for it explicitly
+	// rather than letting later commands fail with confusing output.
+	if !gitOK(ctx, repoRoot, "rev-parse", "--verify", "HEAD~1") {
+		return detectBaseBranch(ctx, repoRoot)
+	}
+	headBranch := gitString(ctx, repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	branchesRaw := gitString(ctx, repoRoot, "for-each-ref", "--format=%(refname:short)", "refs/heads/")
+	if branchesRaw == "" {
+		return detectBaseBranch(ctx, repoRoot)
+	}
+	type candidate struct {
+		ref      string
+		unixTime int64
+	}
+	var best candidate
+	for _, b := range strings.Split(branchesRaw, "\n") {
+		b = strings.TrimSpace(b)
+		if b == "" || b == headBranch || strings.HasPrefix(b, "entire/") {
+			continue
+		}
+		// Branch tip must be an ancestor of HEAD's parent — ancestor of
+		// HEAD itself would also match the current branch's prior tip.
+		if !gitOK(ctx, repoRoot, "merge-base", "--is-ancestor", b, "HEAD~1") {
+			continue
+		}
+		ts, ok := gitCount(ctx, repoRoot, "log", "-1", "--format=%ct", b)
+		if !ok {
+			continue
+		}
+		if int64(ts) > best.unixTime {
+			best = candidate{ref: b, unixTime: int64(ts)}
+		}
+	}
+	if best.ref != "" {
+		return best.ref
+	}
+	return detectBaseBranch(ctx, repoRoot)
 }
 
 // reviewScope summarizes what's about to be reviewed, surfaced to the user

--- a/cmd/entire/cli/review.go
+++ b/cmd/entire/cli/review.go
@@ -49,9 +49,10 @@ type agentChoice struct {
 // require a real TTY. Production wiring leaves fields nil and defaults
 // are resolved inside runReview.
 type runReviewDeps struct {
-	promptForAgentFn  func(ctx context.Context, eligible []agentChoice) (string, error)
-	promptForAgentsFn func(ctx context.Context, eligible []agentChoice) ([]string, error)
-	runMultiAgentFn   func(ctx context.Context, tasks []MultiAgentTask, out io.Writer) (MultiRunResult, error)
+	promptForAgentFn      func(ctx context.Context, eligible []agentChoice) (string, error)
+	promptForAgentsFn     func(ctx context.Context, eligible []agentChoice) ([]string, error)
+	runMultiAgentFn       func(ctx context.Context, tasks []MultiAgentTask, out io.Writer) (MultiRunResult, error)
+	promptForRunContextFn func(ctx context.Context) (string, error)
 }
 
 // MultiAgentTask describes one agent's slot in a parallel review run.
@@ -60,7 +61,7 @@ type runReviewDeps struct {
 type MultiAgentTask struct {
 	Agent  agent.HeadlessLauncher // set by dispatcher when routing to multi-agent
 	Name   string                 // agent registry key
-	Prompt string                 // composed via composeReviewPrompt(cfg)
+	Prompt string                 // composed via composeReviewPrompt(cfg, runContext)
 }
 
 // MultiRunResult is the aggregated result of a multi-agent review. Runs
@@ -738,13 +739,22 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride string, de
 		return fmt.Errorf("resolve worktree root: %w", err)
 	}
 
+	// 5.5. Prompt the user for per-run context (optional). Fires between
+	// agent selection and marker write so the ephemeral context text is
+	// composed into the prompt the session's hook records. Empty/Enter-
+	// only is treated as "skip" — base prompt is used verbatim.
+	runContext, err := resolveRunContext(ctx, cmd, deps)
+	if err != nil {
+		return err
+	}
+
 	// 6. Compose the review prompt once, then write the pending marker. The
 	// composed prompt is carried on the marker so adoption records exactly
 	// what the agent was asked to do (the same string passed to LaunchCmd
 	// below), rather than recomposing on the hook side. When the user has
 	// configured a custom Prompt, it wins verbatim; otherwise Skills are
 	// composed into the default "run these in order" template.
-	prompt := composeReviewPrompt(cfg)
+	prompt := composeReviewPrompt(cfg, runContext)
 	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
 		AgentName:    agentName,
 		Skills:       cfg.Skills,
@@ -869,8 +879,14 @@ func pickMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.EntireS
 		// Drop into single-agent path.
 		return selected[0], false, nil
 	}
+	// Per-run context prompt fires after selection but before dispatch so
+	// the same ephemeral text is composed into every task's prompt.
+	runContext, err := resolveRunContext(ctx, cmd, deps)
+	if err != nil {
+		return "", false, err
+	}
 	// Route to multi-agent orchestrator.
-	if err := dispatchMultiAgent(ctx, cmd, s, selected, deps); err != nil {
+	if err := dispatchMultiAgent(ctx, cmd, s, selected, runContext, deps); err != nil {
 		return "", true, err
 	}
 	return "", true, nil
@@ -906,7 +922,9 @@ func pickSingleAgent(ctx context.Context, cmd *cobra.Command, eligible []agentCh
 // capabilities, and hands off to the orchestrator via deps.runMultiAgentFn.
 // Marker write, hook adoption, and cleanup are the orchestrator's
 // responsibility — this function only prepares the task list and dispatches.
-func dispatchMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.EntireSettings, selected []string, deps runReviewDeps) error {
+// runContext is the optional per-run text gathered by pickMultiAgent; it is
+// composed into every selected agent's prompt alongside the persistent cfg.
+func dispatchMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.EntireSettings, selected []string, runContext string, deps runReviewDeps) error {
 	out := cmd.OutOrStdout()
 	tasks := make([]MultiAgentTask, 0, len(selected))
 	for _, name := range selected {
@@ -925,7 +943,7 @@ func dispatchMultiAgent(ctx context.Context, cmd *cobra.Command, s *settings.Ent
 		tasks = append(tasks, MultiAgentTask{
 			Agent:  hl,
 			Name:   name,
-			Prompt: composeReviewPrompt(cfg),
+			Prompt: composeReviewPrompt(cfg, runContext),
 		})
 	}
 
@@ -1046,6 +1064,44 @@ func promptForAgents(ctx context.Context, eligible []agentChoice) ([]string, err
 	return picked, nil
 }
 
+// promptForRunContext presents a small optional textarea for per-run
+// context. Empty return = user skipped (Enter on empty). Never saved to
+// settings — ephemeral per run.
+func promptForRunContext(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("run-context prompt: %w", err)
+	}
+	var text string
+	form := NewAccessibleForm(huh.NewGroup(
+		huh.NewText().
+			Title("Additional context for this review (optional)").
+			Description("What are you asking the agent(s) to focus on? Press Enter to skip.").
+			Value(&text),
+	))
+	if err := form.Run(); err != nil {
+		return "", fmt.Errorf("run-context prompt: %w", err)
+	}
+	return strings.TrimSpace(text), nil
+}
+
+// resolveRunContext runs the injection-hookable run-context prompt. Used
+// by both the single-agent path (in runReview) and the multi-agent path
+// (in pickMultiAgent) so the same ephemeral per-run text is composed
+// into every selected agent's prompt.
+func resolveRunContext(ctx context.Context, cmd *cobra.Command, deps runReviewDeps) (string, error) {
+	fn := deps.promptForRunContextFn
+	if fn == nil {
+		fn = promptForRunContext
+	}
+	runContext, err := fn(ctx)
+	if err != nil {
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+		return "", NewSilentError(err)
+	}
+	return runContext, nil
+}
+
 // selectReviewAgent picks an agent from the configured review map.
 //
 // If override is non-empty, returns the config for that agent or an error
@@ -1121,23 +1177,31 @@ func verifyConfiguredSkillsInstalled(ctx context.Context, ag agent.Agent, cfg se
 }
 
 // composeReviewPrompt builds the prompt sent to the agent from a
-// ReviewConfig. If the config carries an explicit Prompt it wins
-// verbatim — the user's words are the source of truth. Otherwise the
-// skills list is composed into the default "run these in order"
-// template. Empty config returns "" (caller should avoid that case).
-func composeReviewPrompt(cfg settings.ReviewConfig) string {
+// ReviewConfig plus optional per-run context. The base is whichever of
+// cfg.Prompt (persistent) or a skills-composed template is set; per-run
+// context, when non-empty, is appended with a clear marker so the agent
+// can distinguish persistent preferences from per-run intent. Empty
+// cfg + empty runContext returns "".
+func composeReviewPrompt(cfg settings.ReviewConfig, runContext string) string {
+	var base string
 	if cfg.Prompt != "" {
-		return cfg.Prompt
+		base = cfg.Prompt
+	} else if len(cfg.Skills) > 0 {
+		var sb strings.Builder
+		sb.WriteString("Please run these review skills in order:\n")
+		for i, skill := range cfg.Skills {
+			fmt.Fprintf(&sb, "  %d. %s\n", i+1, skill)
+		}
+		base = sb.String()
 	}
-	if len(cfg.Skills) == 0 {
-		return ""
+
+	if runContext == "" {
+		return base
 	}
-	var sb strings.Builder
-	sb.WriteString("Please run these review skills in order:\n")
-	for i, skill := range cfg.Skills {
-		fmt.Fprintf(&sb, "  %d. %s\n", i+1, skill)
+	if base == "" {
+		return runContext
 	}
-	return sb.String()
+	return base + "\n\nFor this review: " + runContext
 }
 
 // currentHeadSHA returns the current HEAD commit hash as a 40-char hex string.

--- a/cmd/entire/cli/review_multi.go
+++ b/cmd/entire/cli/review_multi.go
@@ -256,9 +256,21 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 		close(allDone)
 	}
 
-	// 10. Dump per-agent outputs + summary. Runs after the TUI exits so
-	// the final table paint stays above the full responses.
-	dumpMultiAgentResults(out, tasks, results, cancelled.load())
+	// 10. Dump per-agent outputs. Runs after the TUI exits so the final
+	// table paint stays above the full responses.
+	dumpPerAgentReviews(out, tasks, results, cancelled.load())
+	dumpRunCounts(out, results)
+
+	// 11. Optional cross-agent synthesis. Opt-in (default N) so a stray
+	// extra LLM call doesn't surprise users on every multi-agent run.
+	// Skipped silently when stdin isn't a TTY (CI, piped output) — there
+	// is no user to prompt.
+	maybeSynthesizeCombinedVerdict(ctx, out, tasks, results, cancelled.load())
+
+	// 12. Run-summary footer (commit hint + transcript paths). Printed
+	// after any synthesis so the "Run git commit" line is the last thing
+	// the user sees before their shell prompt.
+	dumpRunFooter(out, results, cancelled.load())
 
 	return MultiRunResult{
 		Runs:      results,
@@ -575,9 +587,11 @@ func extractCodexFinal(cleaned string) string {
 	return strings.Join(lines[lastCodexMarker+1:tokensUsedIdx], "\n")
 }
 
-// dumpMultiAgentResults prints per-agent headers + FinalOutput, then a
-// summary line, then transcript paths for successful agents.
-func dumpMultiAgentResults(out io.Writer, tasks []MultiAgentTask, results []AgentRunResult, cancelled bool) {
+// dumpPerAgentReviews prints a "─────── <agent> review ───────" header
+// followed by the filtered narrative for each agent. Failed agents show
+// their exit code; cancelled agents are noted without dumping their
+// (typically truncated, noisy) buffered stdout.
+func dumpPerAgentReviews(out io.Writer, tasks []MultiAgentTask, results []AgentRunResult, _ bool) {
 	for i, r := range results {
 		fmt.Fprintf(out, "\n─────── %s review ───────\n", tasks[i].Name)
 		switch r.Status {
@@ -605,7 +619,12 @@ func dumpMultiAgentResults(out io.Writer, tasks []MultiAgentTask, results []Agen
 			return
 		}
 	}
+}
 
+// dumpRunCounts prints the "N agents done in <wall-clock> (S succeeded,
+// F failed, C cancelled)" line. Always emits regardless of cancel state
+// so users see what completed before the SIGINT landed.
+func dumpRunCounts(out io.Writer, results []AgentRunResult) {
 	var nSucc, nFail, nCancel int
 	for _, r := range results {
 		switch r.Status {
@@ -622,6 +641,18 @@ func dumpMultiAgentResults(out io.Writer, tasks []MultiAgentTask, results []Agen
 	fmt.Fprintln(out)
 	fmt.Fprintf(out, "%d agents done in %s (%d succeeded, %d failed, %d cancelled)\n",
 		len(results), computeTotalDuration(results), nSucc, nFail, nCancel)
+}
+
+// dumpRunFooter prints the commit hint (when at least one agent
+// succeeded and the run wasn't cancelled) and the per-agent transcript
+// paths. Last thing emitted on a run.
+func dumpRunFooter(out io.Writer, results []AgentRunResult, cancelled bool) {
+	var nSucc int
+	for _, r := range results {
+		if r.Status == AgentRunDone {
+			nSucc++
+		}
+	}
 	if !cancelled && nSucc > 0 {
 		fmt.Fprintln(out, "  Run `git commit` to attach the review to the next checkpoint.")
 	}

--- a/cmd/entire/cli/review_multi.go
+++ b/cmd/entire/cli/review_multi.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"regexp"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -424,6 +426,127 @@ func (p *previewTeeWriter) Write(data []byte) (int, error) {
 	return n, nil
 }
 
+// outputFilter cleans an agent's raw stdout buffer into something
+// suitable for the completion dump. Different agents have wildly
+// different output verbosity; this lets each agent apply its own noise
+// patterns. Nil / missing filter means the agent's output is used as-is.
+type outputFilter func(raw []byte) []byte
+
+var outputFilters = map[string]outputFilter{
+	string(agent.AgentNameCodex): filterCodexOutput,
+	// claude-code, gemini-cli: pass-through for now. Claude's --print
+	// mode already emits only the final message; gemini has no observed
+	// format to filter.
+}
+
+// applyOutputFilter looks up the per-agent filter and runs it, falling
+// back to raw output when no filter exists.
+func applyOutputFilter(agentName string, raw []byte) []byte {
+	filter, ok := outputFilters[agentName]
+	if !ok || filter == nil {
+		return raw
+	}
+	return filter(raw)
+}
+
+// codexNoisePatterns matches lines that codex exec-mode emits as session
+// chrome — headers, separators, hook firings, error logs. Each pattern
+// is anchored to ^ so partial matches mid-line (which could be real
+// narrative content) are left alone.
+var codexNoisePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T.+ ERROR codex_`),
+	regexp.MustCompile(`^hook: `),
+	regexp.MustCompile(`^(workdir|model|provider|approval|sandbox|reasoning|session id): `),
+	regexp.MustCompile(`^OpenAI Codex v`),
+	regexp.MustCompile(`^-{4,}$`),
+}
+
+func isCodexNoise(line string) bool {
+	for _, re := range codexNoisePatterns {
+		if re.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// filterCodexOutput strips codex exec-mode noise: session banner lines,
+// `exec <command>\n succeeded in Xms:\n<output>\n\n` tool-call blocks,
+// `hook:` firing messages, and timestamped codex_ error logs. Collapses
+// consecutive blank lines left behind by stripped blocks. Narrative
+// text (including the `codex` / `user` speaker markers downstream
+// extractors rely on) stays intact.
+func filterCodexOutput(raw []byte) []byte {
+	var out strings.Builder
+	lines := strings.Split(string(raw), "\n")
+	inExec := false
+	lastBlank := false
+	for _, line := range lines {
+		if inExec {
+			if strings.TrimSpace(line) == "" {
+				inExec = false
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "exec") {
+			inExec = true
+			continue
+		}
+		if isCodexNoise(line) {
+			continue
+		}
+		blank := strings.TrimSpace(line) == ""
+		if blank && lastBlank {
+			continue
+		}
+		lastBlank = blank
+		out.WriteString(line)
+		out.WriteByte('\n')
+	}
+	return []byte(strings.TrimSpace(out.String()) + "\n")
+}
+
+// extractFinalMessage pulls the agent's last narrative response from the
+// cleaned (post-filter) output. Per-agent heuristics because different
+// agents delimit responses differently. Unknown agents pass through.
+func extractFinalMessage(agentName, cleaned string) string {
+	if agentName == string(agent.AgentNameCodex) {
+		return extractCodexFinal(cleaned)
+	}
+	return cleaned
+}
+
+// codexSpeakerMarker is the literal line codex prints before each
+// assistant turn in exec-mode output. Distinct from agent.AgentNameCodex
+// even though the strings happen to match today — this one is a payload-
+// parsing anchor.
+const codexSpeakerMarker = "codex"
+
+// extractCodexFinal slices out the text between the last `^codex$` line
+// and the `tokens used` marker. Codex emits the final assistant
+// response right before printing token usage, so those two anchors
+// bracket the payload we actually want. Falls back to the full cleaned
+// input if either marker is missing — format drift shouldn't silently
+// eat the response.
+func extractCodexFinal(cleaned string) string {
+	lines := strings.Split(cleaned, "\n")
+	lastCodexMarker := -1
+	tokensUsedIdx := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == codexSpeakerMarker {
+			lastCodexMarker = i
+		}
+		if strings.HasPrefix(line, "tokens used") && lastCodexMarker != -1 {
+			tokensUsedIdx = i
+			break
+		}
+	}
+	if lastCodexMarker == -1 || tokensUsedIdx == -1 {
+		return cleaned
+	}
+	return strings.Join(lines[lastCodexMarker+1:tokensUsedIdx], "\n")
+}
+
 // dumpMultiAgentResults prints per-agent headers + FinalOutput, then a
 // summary line, then transcript paths for successful agents.
 func dumpMultiAgentResults(out io.Writer, tasks []MultiAgentTask, results []AgentRunResult, cancelled bool) {
@@ -444,10 +567,12 @@ func dumpMultiAgentResults(out io.Writer, tasks []MultiAgentTask, results []Agen
 			// explicitly asked to stop — dumping would be adversarial.
 			continue
 		case AgentRunQueued, AgentRunRunning, AgentRunDone:
-			// Done: no header; buffered output follows.
+			// Done: no header; filtered narrative follows.
 			// Queued/Running would indicate a logic bug; fall through.
 		}
-		if _, err := out.Write(r.FinalOutput); err != nil {
+		cleaned := applyOutputFilter(tasks[i].Name, r.FinalOutput)
+		final := extractFinalMessage(tasks[i].Name, string(cleaned))
+		if _, err := fmt.Fprintln(out, strings.TrimSpace(final)); err != nil {
 			// Writer failed mid-dump; further writes will also fail, so stop.
 			return
 		}

--- a/cmd/entire/cli/review_multi.go
+++ b/cmd/entire/cli/review_multi.go
@@ -187,16 +187,34 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 		// enough to render the "cancelling" banner and drain subprocess
 		// output. Opt out so cancellation is driven explicitly.
 		//
-		// Passing cancelRun as the model's onCancel is what actually tears
-		// down subprocesses when Ctrl+C is pressed inside the TUI. In raw
-		// mode the terminal captures byte 0x03 and bubbletea hands it to
-		// the model as tea.KeyCtrlC, so the SIGINT never reaches the
-		// orchestrator's signal.Notify goroutine. The model calls
-		// onCancel() which cancels runCtx, SIGTERM propagates to the
-		// subprocesses via exec.CommandContext, and the 5-second watchdog
-		// above escalates to SIGKILL if anything is still alive.
+		// In raw mode the terminal captures byte 0x03 and bubbletea hands
+		// it to the model as tea.KeyCtrlC, so the SIGINT never reaches
+		// the orchestrator's signal.Notify goroutine above. Routing the
+		// model's onCancel through tuiCancel makes an in-TUI Ctrl+C
+		// behave exactly like an out-of-TUI SIGINT: cancel runCtx (which
+		// SIGTERMs subprocesses via exec.CommandContext), set the
+		// cancelled flag so callers see Cancelled=true, and arm the same
+		// 5s SIGKILL watchdog that escalates if subprocesses ignore
+		// SIGTERM. Without this routing, in-TUI cancels reported
+		// Cancelled=false and stuck subprocesses never got force-killed.
+		var tuiCancelOnce sync.Once
+		tuiCancel := func() {
+			tuiCancelOnce.Do(func() {
+				cancelled.store(true)
+				cancelRun()
+				go func() {
+					watchdog := time.NewTimer(5 * time.Second)
+					defer watchdog.Stop()
+					select {
+					case <-watchdog.C:
+						forceKillAll(snapshotCmds())
+					case <-allDone:
+					}
+				}()
+			})
+		}
 		program = tea.NewProgram(
-			newReviewTUIModel(tasks, cancelRun, buffers),
+			newReviewTUIModel(tasks, tuiCancel, buffers),
 			tea.WithOutput(out),
 			tea.WithoutSignalHandler(),
 		)

--- a/cmd/entire/cli/review_multi.go
+++ b/cmd/entire/cli/review_multi.go
@@ -137,7 +137,24 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 	// plain io.Writer dump instead of escape-code garbage.
 	var program *tea.Program
 	if isTerminalWriter(out) {
-		program = tea.NewProgram(newReviewTUIModel(tasks), tea.WithOutput(out))
+		// WithoutSignalHandler: bubbletea's default handler would quit the
+		// program on its own SIGINT handler; we need to stay alive long
+		// enough to render the "cancelling" banner and drain subprocess
+		// output. Opt out so cancellation is driven explicitly.
+		//
+		// Passing cancelRun as the model's onCancel is what actually tears
+		// down subprocesses when Ctrl+C is pressed inside the TUI. In raw
+		// mode the terminal captures byte 0x03 and bubbletea hands it to
+		// the model as tea.KeyCtrlC, so the SIGINT never reaches the
+		// orchestrator's signal.Notify goroutine. The model calls
+		// onCancel() which cancels runCtx, SIGTERM propagates to the
+		// subprocesses via exec.CommandContext, and the 5-second watchdog
+		// above escalates to SIGKILL if anything is still alive.
+		program = tea.NewProgram(
+			newReviewTUIModel(tasks, cancelRun),
+			tea.WithOutput(out),
+			tea.WithoutSignalHandler(),
+		)
 	}
 	send := sendFunc(program)
 
@@ -245,12 +262,20 @@ func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(in
 	exitCode := 0
 	if runErr != nil {
 		var exitErr *exec.ExitError
+		hasExit := errors.As(runErr, &exitErr)
 		switch {
-		case errors.As(runErr, &exitErr):
+		case errors.Is(ctx.Err(), context.Canceled):
+			// Orchestrator cancelled the run (Ctrl+C or explicit cancel).
+			// Classify as Cancelled even though Go's exec.CommandContext
+			// delivers the kill as an *exec.ExitError with exit -1
+			// ("signal: killed"). Record the exit code for transparency.
+			status = AgentRunCancelled
+			if hasExit {
+				exitCode = exitErr.ExitCode()
+			}
+		case hasExit:
 			exitCode = exitErr.ExitCode()
 			status = AgentRunFailed
-		case errors.Is(ctx.Err(), context.Canceled):
-			status = AgentRunCancelled
 		default:
 			status = AgentRunFailed
 		}
@@ -379,6 +404,11 @@ func dumpMultiAgentResults(out io.Writer, tasks []MultiAgentTask, results []Agen
 		case AgentRunCancelled:
 			fmt.Fprintln(out, "(cancelled)")
 			fmt.Fprintln(out)
+			// Skip the FinalOutput dump for cancelled agents. The buffered
+			// partial stdout is rarely useful (often 100+ lines of noise
+			// from agents like codex that stream verbosely) and the user
+			// explicitly asked to stop — dumping would be adversarial.
+			continue
 		case AgentRunQueued, AgentRunRunning, AgentRunDone:
 			// Done: no header; buffered output follows.
 			// Queued/Running would indicate a logic bug; fall through.

--- a/cmd/entire/cli/review_multi.go
+++ b/cmd/entire/cli/review_multi.go
@@ -1,0 +1,395 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+)
+
+// multiReviewOrchestrator owns the lifecycle of an N-agent parallel review:
+// writes the shared pending marker, spawns one goroutine per agent, drives
+// cancellation, cleans up on exit. Chunk 3 dumps results to an io.Writer on
+// completion; Chunk 4 swaps in a bubbletea program that consumes live
+// messages emitted by the same goroutines.
+type multiReviewOrchestrator struct {
+	worktreePath string
+}
+
+func newMultiReviewOrchestrator(worktreePath string) *multiReviewOrchestrator {
+	return &multiReviewOrchestrator{worktreePath: worktreePath}
+}
+
+// Run spawns all tasks, waits for completion or cancellation, cleans up the
+// marker, and dumps final per-agent responses to out.
+//
+// Run returns a non-nil MultiRunResult even when individual agents fail —
+// callers use it to distinguish "N of M succeeded" from "could not run at
+// all". An error return means the orchestrator itself could not start
+// (missing tasks, marker write failure).
+func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTask, out io.Writer) (MultiRunResult, error) {
+	if len(tasks) == 0 {
+		return MultiRunResult{}, errNoMultiAgentTasks
+	}
+
+	// 1. Write shared marker so UserPromptSubmit hooks in each spawned
+	// agent can adopt and tag their session. HEAD lookup is best-effort —
+	// adoption tolerates an empty StartingSHA.
+	headSHA, headErr := currentHeadSHA(ctx)
+	if headErr != nil {
+		logging.Debug(ctx, "orchestrator: HEAD resolve failed",
+			slog.String("error", headErr.Error()))
+	}
+	agentNames := make([]string, len(tasks))
+	for i, t := range tasks {
+		agentNames[i] = t.Name
+	}
+	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
+		AgentNames:   agentNames,
+		StartingSHA:  headSHA,
+		StartedAt:    time.Now().UTC(),
+		WorktreePath: o.worktreePath,
+	}); err != nil {
+		return MultiRunResult{}, fmt.Errorf("write marker: %w", err)
+	}
+
+	// 2. Defer marker cleanup regardless of exit path. A fresh context is
+	// used because ctx may already be cancelled by the time we run.
+	defer func() {
+		if err := ClearPendingReviewMarker(context.Background()); err != nil {
+			logging.Debug(ctx, "orchestrator: marker cleanup failed",
+				slog.String("error", err.Error()))
+		}
+	}()
+
+	// 3. Cancel-aware child context. Subprocesses launched via
+	// exec.CommandContext inherit this, so cancelling it fires SIGTERM.
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+
+	// 4. tasksCmds stores the live *exec.Cmd for each task. Declared
+	// before the signal-handler goroutine because that goroutine may snapshot
+	// it from a different goroutine — the mutex guards the shared state.
+	tasksCmds := make([]*exec.Cmd, len(tasks))
+	var tasksCmdsMu sync.Mutex
+	setCmd := func(i int, cmd *exec.Cmd) {
+		tasksCmdsMu.Lock()
+		defer tasksCmdsMu.Unlock()
+		tasksCmds[i] = cmd
+	}
+	snapshotCmds := func() []*exec.Cmd {
+		tasksCmdsMu.Lock()
+		defer tasksCmdsMu.Unlock()
+		cp := make([]*exec.Cmd, len(tasksCmds))
+		copy(cp, tasksCmds)
+		return cp
+	}
+
+	// 5. Signal handler: first Ctrl+C → cancel runCtx (SIGTERM to
+	// subprocesses via exec.CommandContext); 5s watchdog or second Ctrl+C
+	// escalates to SIGKILL.
+	sigCh := make(chan os.Signal, 2)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	cancelled := &atomicBool{}
+	allDone := make(chan struct{})
+	go func() {
+		select {
+		case <-sigCh:
+			cancelled.store(true)
+			cancelRun()
+			watchdog := time.NewTimer(5 * time.Second)
+			defer watchdog.Stop()
+			select {
+			case <-sigCh:
+				forceKillAll(snapshotCmds())
+			case <-watchdog.C:
+				forceKillAll(snapshotCmds())
+			case <-allDone:
+			}
+		case <-allDone:
+		}
+	}()
+
+	// 6. Spawn one goroutine per task.
+	var wg sync.WaitGroup
+	results := make([]AgentRunResult, len(tasks))
+	for i, task := range tasks {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = runSingleAgentTask(runCtx, task, setCmd, i)
+		}()
+	}
+	wg.Wait()
+	close(allDone)
+
+	// 7. Dump per-agent outputs + summary.
+	dumpMultiAgentResults(out, tasks, results, cancelled.load())
+
+	return MultiRunResult{
+		Runs:      results,
+		Duration:  computeTotalDuration(results),
+		Cancelled: cancelled.load(),
+	}, nil
+}
+
+// errNoMultiAgentTasks is the sentinel returned when Run is invoked with
+// an empty task list — a programmer error the caller should surface.
+var errNoMultiAgentTasks = errors.New("orchestrator: no tasks")
+
+// runSingleAgentTask launches one headless agent subprocess, buffers its
+// stdout/stderr, and classifies the exit. Called once per task by Run.
+func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(int, *exec.Cmd), idx int) AgentRunResult {
+	startTime := time.Now()
+
+	cmd, err := task.Agent.LaunchHeadlessCmd(ctx, task.Prompt)
+	if err != nil {
+		return AgentRunResult{
+			Name:     task.Name,
+			Status:   AgentRunFailed,
+			Duration: time.Since(startTime),
+			Err:      fmt.Errorf("launch %s: %w", task.Name, err),
+		}
+	}
+	setCmd(idx, cmd)
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	// WaitDelay protects against subprocesses whose children hold stdio
+	// pipes open after the root pid has been killed (e.g. `sh -c "sleep
+	// N"`). Without it, cmd.Wait() blocks on pipe close even though the
+	// context is already cancelled. 500ms is generous for normal child
+	// cleanup while keeping Ctrl+C responsive.
+	if cmd.WaitDelay == 0 {
+		cmd.WaitDelay = 500 * time.Millisecond
+	}
+
+	runErr := cmd.Run()
+	duration := time.Since(startTime)
+
+	status := AgentRunDone
+	exitCode := 0
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		switch {
+		case errors.As(runErr, &exitErr):
+			exitCode = exitErr.ExitCode()
+			status = AgentRunFailed
+		case errors.Is(ctx.Err(), context.Canceled):
+			status = AgentRunCancelled
+		default:
+			status = AgentRunFailed
+		}
+	}
+
+	// Post-exit: resolve transcript path + token usage for successful runs.
+	// Best-effort — transcripts may legitimately be unresolvable for some
+	// fake/minimal agents in tests.
+	var transcriptPath string
+	var tokenUsage *agent.TokenUsage
+	if status == AgentRunDone {
+		if sbp, ok := task.Agent.(agent.SessionBaseDirProvider); ok {
+			if dir, dirErr := sbp.GetSessionBaseDir(); dirErr == nil {
+				transcriptPath = resolveLatestTranscript(dir)
+				if transcriptPath != "" {
+					data, readErr := os.ReadFile(transcriptPath) //nolint:gosec // path derived from agent's own session dir
+					if readErr == nil {
+						if tc, tok := task.Agent.(agent.TokenCalculator); tok {
+							usage, calcErr := tc.CalculateTokenUsage(data, 0)
+							if calcErr == nil {
+								tokenUsage = usage
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return AgentRunResult{
+		Name:           task.Name,
+		Status:         status,
+		ExitCode:       exitCode,
+		Duration:       duration,
+		FinalOutput:    buf.Bytes(),
+		Err:            runErr,
+		TokenUsage:     tokenUsage,
+		TranscriptPath: transcriptPath,
+	}
+}
+
+// dumpMultiAgentResults prints per-agent headers + FinalOutput, then a
+// summary line, then transcript paths for successful agents.
+func dumpMultiAgentResults(out io.Writer, tasks []MultiAgentTask, results []AgentRunResult, cancelled bool) {
+	for i, r := range results {
+		fmt.Fprintf(out, "\n─────── %s review ───────\n", tasks[i].Name)
+		switch r.Status {
+		case AgentRunFailed:
+			fmt.Fprintf(out, "(failed — exit %d)\n", r.ExitCode)
+			if r.Err != nil {
+				fmt.Fprintf(out, "%v\n\n", r.Err)
+			}
+		case AgentRunCancelled:
+			fmt.Fprintln(out, "(cancelled)")
+			fmt.Fprintln(out)
+		case AgentRunQueued, AgentRunRunning, AgentRunDone:
+			// Done: no header; buffered output follows.
+			// Queued/Running would indicate a logic bug; fall through.
+		}
+		if _, err := out.Write(r.FinalOutput); err != nil {
+			// Writer failed mid-dump; further writes will also fail, so stop.
+			return
+		}
+	}
+
+	var nSucc, nFail, nCancel int
+	for _, r := range results {
+		switch r.Status {
+		case AgentRunDone:
+			nSucc++
+		case AgentRunFailed:
+			nFail++
+		case AgentRunCancelled:
+			nCancel++
+		case AgentRunQueued, AgentRunRunning:
+			// Should not occur after Wait; ignore for summary stats.
+		}
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "%d agents done in %s (%d succeeded, %d failed, %d cancelled)\n",
+		len(results), computeTotalDuration(results), nSucc, nFail, nCancel)
+	if !cancelled && nSucc > 0 {
+		fmt.Fprintln(out, "  Run `git commit` to attach the review to the next checkpoint.")
+	}
+
+	anyPath := false
+	for _, r := range results {
+		if r.TranscriptPath == "" {
+			continue
+		}
+		if !anyPath {
+			fmt.Fprintln(out, "\n  Full transcripts (including tool calls + reasoning):")
+			anyPath = true
+		}
+		fmt.Fprintf(out, "    %-12s → %s\n", r.Name, r.TranscriptPath)
+	}
+}
+
+// computeTotalDuration returns the maximum Duration across results — the
+// wall-clock span of the whole parallel run, not the sum of per-agent
+// runtimes.
+func computeTotalDuration(results []AgentRunResult) time.Duration {
+	var longest time.Duration
+	for _, r := range results {
+		if r.Duration > longest {
+			longest = r.Duration
+		}
+	}
+	return longest
+}
+
+// forceKillAll sends SIGKILL to every live subprocess. Null cmds (agents
+// whose LaunchHeadlessCmd call had not returned yet when cancellation
+// arrived) are skipped.
+func forceKillAll(cmds []*exec.Cmd) {
+	for _, cmd := range cmds {
+		if cmd == nil || cmd.Process == nil {
+			continue
+		}
+		_ = cmd.Process.Kill() //nolint:errcheck // best-effort cleanup after cancel
+	}
+}
+
+// resolveLatestTranscript returns the newest .jsonl (or .json) file under
+// baseDir, searched recursively. Returns "" if baseDir is empty, unreadable,
+// or contains no transcript files. Chunk 3 uses a best-effort newest-file
+// heuristic; Chunk 4 may refine to a session-ID-specific resolver.
+func resolveLatestTranscript(baseDir string) string {
+	if baseDir == "" {
+		return ""
+	}
+	var latestPath string
+	var latestMod time.Time
+	walkErr := walkTranscriptFiles(baseDir, func(path string, info os.FileInfo) {
+		if info.ModTime().After(latestMod) {
+			latestMod = info.ModTime()
+			latestPath = path
+		}
+	})
+	if walkErr != nil {
+		return ""
+	}
+	return latestPath
+}
+
+// walkTranscriptFiles walks baseDir recursively, invoking visit for every
+// file whose extension is .jsonl or .json. Non-existent or unreadable
+// directories return an error; individual read errors inside are silently
+// skipped (best-effort resolution).
+func walkTranscriptFiles(baseDir string, visit func(path string, info os.FileInfo)) error {
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		return fmt.Errorf("read transcript dir: %w", err)
+	}
+	for _, e := range entries {
+		full := baseDir + string(os.PathSeparator) + e.Name()
+		if e.IsDir() {
+			_ = walkTranscriptFiles(full, visit) //nolint:errcheck // best-effort
+			continue
+		}
+		name := e.Name()
+		if !hasTranscriptExt(name) {
+			continue
+		}
+		info, infoErr := e.Info()
+		if infoErr != nil {
+			continue
+		}
+		visit(full, info)
+	}
+	return nil
+}
+
+func hasTranscriptExt(name string) bool {
+	for _, ext := range []string{".jsonl", ".json"} {
+		if len(name) >= len(ext) && name[len(name)-len(ext):] == ext {
+			return true
+		}
+	}
+	return false
+}
+
+// atomicBool is a tiny mutex-guarded boolean used to flip the "cancelled"
+// flag from the signal goroutine and read it from the completion path.
+// Using sync/atomic.Bool would work too, but a mutex keeps the call sites
+// explicit and matches the plan's spec.
+type atomicBool struct {
+	mu sync.Mutex
+	v  bool
+}
+
+func (b *atomicBool) store(v bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.v = v
+}
+
+func (b *atomicBool) load() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.v
+}

--- a/cmd/entire/cli/review_multi.go
+++ b/cmd/entire/cli/review_multi.go
@@ -87,11 +87,21 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 			slog.String("error", headErr.Error()))
 	}
 	agentNames := make([]string, len(tasks))
+	// AgentEntries carries each task's skills+prompt onto the marker so
+	// the adopting hook can record what THIS agent actually ran (not a
+	// union across agents). Without this map, multi-agent sessions
+	// previously persisted with empty ReviewSkills/ReviewPrompt fields.
+	agentEntries := make(map[string]AgentMarkerEntry, len(tasks))
 	for i, t := range tasks {
 		agentNames[i] = t.Name
+		agentEntries[t.Name] = AgentMarkerEntry{
+			Skills: t.Skills,
+			Prompt: t.Prompt,
+		}
 	}
 	if err := WritePendingReviewMarker(ctx, PendingReviewMarker{
 		AgentNames:   agentNames,
+		AgentEntries: agentEntries,
 		StartingSHA:  headSHA,
 		StartedAt:    time.Now().UTC(),
 		WorktreePath: o.worktreePath,

--- a/cmd/entire/cli/review_multi.go
+++ b/cmd/entire/cli/review_multi.go
@@ -14,15 +14,24 @@ import (
 	"syscall"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
 
+// previewRateWindow caps the rate at which preview tees forward stdout
+// lines to the TUI — roughly 10/sec per agent. Keeps the bubbletea
+// program's inbound message queue manageable even when a subprocess
+// floods stdout.
+const previewRateWindow = 100 * time.Millisecond
+
 // multiReviewOrchestrator owns the lifecycle of an N-agent parallel review:
 // writes the shared pending marker, spawns one goroutine per agent, drives
-// cancellation, cleans up on exit. Chunk 3 dumps results to an io.Writer on
-// completion; Chunk 4 swaps in a bubbletea program that consumes live
-// messages emitted by the same goroutines.
+// cancellation, cleans up on exit. When stdout is a terminal, it drives a
+// bubbletea reviewTUIModel with per-agent live status rows; otherwise it
+// falls back to an io.Writer dump of all per-agent outputs. Either way the
+// final dump runs after the TUI exits so transcripts follow the table.
 type multiReviewOrchestrator struct {
 	worktreePath string
 }
@@ -123,20 +132,52 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 		}
 	}()
 
-	// 6. Spawn one goroutine per task.
+	// 6. Optional bubbletea program. Only spin up the TUI when out is a
+	// real terminal — piping to a file or CI log pipe should get the
+	// plain io.Writer dump instead of escape-code garbage.
+	var program *tea.Program
+	if isTerminalWriter(out) {
+		program = tea.NewProgram(newReviewTUIModel(tasks), tea.WithOutput(out))
+	}
+	send := sendFunc(program)
+
+	// 7. Spawn one goroutine per task. Each goroutine also posts state +
+	// preview messages to the TUI (no-op when program is nil).
 	var wg sync.WaitGroup
 	results := make([]AgentRunResult, len(tasks))
 	for i, task := range tasks {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			results[i] = runSingleAgentTask(runCtx, task, setCmd, i)
+			results[i] = runSingleAgentTask(runCtx, task, setCmd, i, send)
 		}()
 	}
-	wg.Wait()
-	close(allDone)
 
-	// 7. Dump per-agent outputs + summary.
+	// 8. If we have a TUI, run program in the foreground while a small
+	// goroutine waits for all agents to finish and then signals quit.
+	// Without a TUI, just wait for the goroutines to finish synchronously.
+	if program != nil {
+		go func() {
+			wg.Wait()
+			close(allDone)
+			// Last chance for the TUI to repaint with final state before
+			// allRowsTerminal triggers its own tea.Quit. Sending Quit here
+			// is a safety net in case some row never reached a terminal
+			// status (shouldn't happen, but a silent hang would be worse).
+			program.Quit()
+		}()
+		if _, runErr := program.Run(); runErr != nil {
+			logging.Debug(ctx, "orchestrator: tea.Program exited with error",
+				slog.String("error", runErr.Error()))
+		}
+		wg.Wait()
+	} else {
+		wg.Wait()
+		close(allDone)
+	}
+
+	// 9. Dump per-agent outputs + summary. Runs after the TUI exits so
+	// the final table paint stays above the full responses.
 	dumpMultiAgentResults(out, tasks, results, cancelled.load())
 
 	return MultiRunResult{
@@ -146,17 +187,30 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 	}, nil
 }
 
+// sendFunc returns a tea-message sender bound to program. If program is
+// nil (non-TTY output), returns a no-op so call sites don't have to
+// branch on nil at every post.
+func sendFunc(program *tea.Program) func(msg tea.Msg) {
+	if program == nil {
+		return func(_ tea.Msg) {}
+	}
+	return program.Send
+}
+
 // errNoMultiAgentTasks is the sentinel returned when Run is invoked with
 // an empty task list — a programmer error the caller should surface.
 var errNoMultiAgentTasks = errors.New("orchestrator: no tasks")
 
 // runSingleAgentTask launches one headless agent subprocess, buffers its
 // stdout/stderr, and classifies the exit. Called once per task by Run.
-func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(int, *exec.Cmd), idx int) AgentRunResult {
+// send posts lifecycle + preview messages to the TUI; a no-op sender is
+// used when the caller output isn't a terminal.
+func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(int, *exec.Cmd), idx int, send func(tea.Msg)) AgentRunResult {
 	startTime := time.Now()
 
 	cmd, err := task.Agent.LaunchHeadlessCmd(ctx, task.Prompt)
 	if err != nil {
+		send(agentStateMsg{Name: task.Name, Status: AgentRunFailed, Duration: time.Since(startTime)})
 		return AgentRunResult{
 			Name:     task.Name,
 			Status:   AgentRunFailed,
@@ -167,8 +221,9 @@ func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(in
 	setCmd(idx, cmd)
 
 	var buf bytes.Buffer
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
+	tee := newPreviewTeeWriter(&buf, send, task.Name)
+	cmd.Stdout = tee
+	cmd.Stderr = tee
 	// WaitDelay protects against subprocesses whose children hold stdio
 	// pipes open after the root pid has been killed (e.g. `sh -c "sleep
 	// N"`). Without it, cmd.Wait() blocks on pipe close even though the
@@ -177,6 +232,11 @@ func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(in
 	if cmd.WaitDelay == 0 {
 		cmd.WaitDelay = 500 * time.Millisecond
 	}
+
+	// Notify the TUI that this agent is now running. Posted after
+	// LaunchHeadlessCmd so failures above never advertise a "running"
+	// state the orchestrator never actually observed.
+	send(agentStateMsg{Name: task.Name, Status: AgentRunRunning})
 
 	runErr := cmd.Run()
 	duration := time.Since(startTime)
@@ -220,6 +280,21 @@ func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(in
 		}
 	}
 
+	totalTokens := 0
+	if tokenUsage != nil {
+		totalTokens = tokenUsage.InputTokens +
+			tokenUsage.CacheCreationTokens +
+			tokenUsage.CacheReadTokens +
+			tokenUsage.OutputTokens
+	}
+	send(agentStateMsg{
+		Name:     task.Name,
+		Status:   status,
+		Duration: duration,
+		ExitCode: exitCode,
+		Tokens:   totalTokens,
+	})
+
 	return AgentRunResult{
 		Name:           task.Name,
 		Status:         status,
@@ -230,6 +305,64 @@ func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(in
 		TokenUsage:     tokenUsage,
 		TranscriptPath: transcriptPath,
 	}
+}
+
+// previewTeeWriter tees subprocess stdout/stderr bytes into a buffer
+// (for the final per-agent dump) and — rate-limited — emits preview
+// lines to the TUI as agentPreviewMsg. The rate limit is per-agent:
+// at most one message per previewRateWindow.
+type previewTeeWriter struct {
+	buf        io.Writer
+	send       func(tea.Msg)
+	agentName  string
+	mu         sync.Mutex
+	partial    []byte
+	lastSentAt time.Time
+}
+
+func newPreviewTeeWriter(buf io.Writer, send func(tea.Msg), agentName string) *previewTeeWriter {
+	return &previewTeeWriter{buf: buf, send: send, agentName: agentName}
+}
+
+// Write implements io.Writer: captures into the buffer for the final
+// response dump, then scans for newline-terminated lines and forwards
+// the last-complete one as a preview message, subject to the rate
+// window. A partial line without a trailing newline is carried forward.
+func (p *previewTeeWriter) Write(data []byte) (int, error) {
+	n, err := p.buf.Write(data)
+	if err != nil {
+		return n, fmt.Errorf("tee buf write: %w", err)
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.partial = append(p.partial, data[:n]...)
+	// Only scan on newline; short writes with no newline just accumulate.
+	lastNL := bytes.LastIndexByte(p.partial, '\n')
+	if lastNL < 0 {
+		return n, nil
+	}
+	// The last complete line is the segment right before lastNL.
+	completed := p.partial[:lastNL]
+	p.partial = p.partial[lastNL+1:]
+	prevNL := bytes.LastIndexByte(completed, '\n')
+	var last []byte
+	if prevNL < 0 {
+		last = completed
+	} else {
+		last = completed[prevNL+1:]
+	}
+	if len(last) == 0 {
+		return n, nil
+	}
+	now := time.Now()
+	if now.Sub(p.lastSentAt) < previewRateWindow {
+		return n, nil
+	}
+	p.lastSentAt = now
+	// Copy into a new buffer because p.partial's backing array is reused.
+	line := string(bytes.TrimRight(last, "\r"))
+	p.send(agentPreviewMsg{Name: p.agentName, Line: line})
+	return n, nil
 }
 
 // dumpMultiAgentResults prints per-agent headers + FinalOutput, then a
@@ -316,8 +449,9 @@ func forceKillAll(cmds []*exec.Cmd) {
 
 // resolveLatestTranscript returns the newest .jsonl (or .json) file under
 // baseDir, searched recursively. Returns "" if baseDir is empty, unreadable,
-// or contains no transcript files. Chunk 3 uses a best-effort newest-file
-// heuristic; Chunk 4 may refine to a session-ID-specific resolver.
+// or contains no transcript files. Uses a best-effort newest-file
+// heuristic; a future refinement could switch to a session-ID-specific
+// resolver.
 func resolveLatestTranscript(baseDir string) string {
 	if baseDir == "" {
 		return ""

--- a/cmd/entire/cli/review_multi.go
+++ b/cmd/entire/cli/review_multi.go
@@ -501,6 +501,20 @@ var codexNoisePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^-{4,}$`),
 }
 
+// codexExecBlockStart matches codex exec-mode tool-call block headers
+// in either form codex emits:
+//
+//   - bare "exec" on its own line (multi-line variant — the command +
+//     cwd land on the next line)
+//   - "exec <command> in /<cwd>" inline (single-line variant)
+//
+// The bare form is anchored to end-of-line so words like "execution"
+// or "executed" don't match; the inline form requires the conventional
+// ` in /` cwd anchor for the same reason. Without these anchors a
+// previous implementation matched any line starting with "exec",
+// swallowing legitimate narrative like "Examining the file…".
+var codexExecBlockStart = regexp.MustCompile(`^(exec$|exec .+ in /)`)
+
 func isCodexNoise(line string) bool {
 	for _, re := range codexNoisePatterns {
 		if re.MatchString(line) {
@@ -528,7 +542,7 @@ func filterCodexOutput(raw []byte) []byte {
 			}
 			continue
 		}
-		if strings.HasPrefix(line, "exec") {
+		if codexExecBlockStart.MatchString(line) {
 			inExec = true
 			continue
 		}

--- a/cmd/entire/cli/review_multi.go
+++ b/cmd/entire/cli/review_multi.go
@@ -26,6 +26,30 @@ import (
 // floods stdout.
 const previewRateWindow = 100 * time.Millisecond
 
+// agentBuffer is a thread-safe byte accumulator. The orchestrator
+// goroutine writes via the io.Writer path (for stdout tee-ing); the TUI
+// reads via Snapshot() on Ctrl+O drill-in. One per task.
+type agentBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *agentBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n, err := b.buf.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("agentBuffer write: %w", err)
+	}
+	return n, nil
+}
+
+func (b *agentBuffer) Snapshot() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]byte(nil), b.buf.Bytes()...)
+}
+
 // multiReviewOrchestrator owns the lifecycle of an N-agent parallel review:
 // writes the shared pending marker, spawns one goroutine per agent, drives
 // cancellation, cleans up on exit. When stdout is a terminal, it drives a
@@ -132,7 +156,16 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 		}
 	}()
 
-	// 6. Optional bubbletea program. Only spin up the TUI when out is a
+	// 6. Shared per-agent buffers. Each task's tee writes into its buffer,
+	// which doubles as the FinalOutput source after Wait and as the TUI's
+	// read target for Ctrl+O drill-in. Allocated before the TUI so the
+	// model can observe the same underlying bytes.
+	buffers := make([]*agentBuffer, len(tasks))
+	for i := range buffers {
+		buffers[i] = &agentBuffer{}
+	}
+
+	// 7. Optional bubbletea program. Only spin up the TUI when out is a
 	// real terminal — piping to a file or CI log pipe should get the
 	// plain io.Writer dump instead of escape-code garbage.
 	var program *tea.Program
@@ -151,14 +184,14 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 		// subprocesses via exec.CommandContext, and the 5-second watchdog
 		// above escalates to SIGKILL if anything is still alive.
 		program = tea.NewProgram(
-			newReviewTUIModel(tasks, cancelRun),
+			newReviewTUIModel(tasks, cancelRun, buffers),
 			tea.WithOutput(out),
 			tea.WithoutSignalHandler(),
 		)
 	}
 	send := sendFunc(program)
 
-	// 7. Spawn one goroutine per task. Each goroutine also posts state +
+	// 8. Spawn one goroutine per task. Each goroutine also posts state +
 	// preview messages to the TUI (no-op when program is nil).
 	var wg sync.WaitGroup
 	results := make([]AgentRunResult, len(tasks))
@@ -166,11 +199,11 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			results[i] = runSingleAgentTask(runCtx, task, setCmd, i, send)
+			results[i] = runSingleAgentTask(runCtx, task, setCmd, i, send, buffers[i])
 		}()
 	}
 
-	// 8. If we have a TUI, run program in the foreground while a small
+	// 9. If we have a TUI, run program in the foreground while a small
 	// goroutine waits for all agents to finish and then signals quit.
 	// Without a TUI, just wait for the goroutines to finish synchronously.
 	if program != nil {
@@ -193,7 +226,7 @@ func (o *multiReviewOrchestrator) Run(ctx context.Context, tasks []MultiAgentTas
 		close(allDone)
 	}
 
-	// 9. Dump per-agent outputs + summary. Runs after the TUI exits so
+	// 10. Dump per-agent outputs + summary. Runs after the TUI exits so
 	// the final table paint stays above the full responses.
 	dumpMultiAgentResults(out, tasks, results, cancelled.load())
 
@@ -218,11 +251,13 @@ func sendFunc(program *tea.Program) func(msg tea.Msg) {
 // an empty task list — a programmer error the caller should surface.
 var errNoMultiAgentTasks = errors.New("orchestrator: no tasks")
 
-// runSingleAgentTask launches one headless agent subprocess, buffers its
-// stdout/stderr, and classifies the exit. Called once per task by Run.
-// send posts lifecycle + preview messages to the TUI; a no-op sender is
-// used when the caller output isn't a terminal.
-func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(int, *exec.Cmd), idx int, send func(tea.Msg)) AgentRunResult {
+// runSingleAgentTask launches one headless agent subprocess, tees its
+// stdout/stderr into the provided shared buffer, and classifies the exit.
+// Called once per task by Run. send posts lifecycle + preview messages to
+// the TUI; a no-op sender is used when the caller output isn't a terminal.
+// buffer doubles as the FinalOutput source and as the TUI's read target
+// for Ctrl+O drill-in.
+func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(int, *exec.Cmd), idx int, send func(tea.Msg), buffer *agentBuffer) AgentRunResult {
 	startTime := time.Now()
 
 	cmd, err := task.Agent.LaunchHeadlessCmd(ctx, task.Prompt)
@@ -237,8 +272,7 @@ func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(in
 	}
 	setCmd(idx, cmd)
 
-	var buf bytes.Buffer
-	tee := newPreviewTeeWriter(&buf, send, task.Name)
+	tee := newPreviewTeeWriter(buffer, send, task.Name)
 	cmd.Stdout = tee
 	cmd.Stderr = tee
 	// WaitDelay protects against subprocesses whose children hold stdio
@@ -325,7 +359,7 @@ func runSingleAgentTask(ctx context.Context, task MultiAgentTask, setCmd func(in
 		Status:         status,
 		ExitCode:       exitCode,
 		Duration:       duration,
-		FinalOutput:    buf.Bytes(),
+		FinalOutput:    buffer.Snapshot(),
 		Err:            runErr,
 		TokenUsage:     tokenUsage,
 		TranscriptPath: transcriptPath,

--- a/cmd/entire/cli/review_multi_test.go
+++ b/cmd/entire/cli/review_multi_test.go
@@ -287,3 +287,96 @@ func TestOrchestrator_NoTasks(t *testing.T) {
 		t.Fatal("Run with no tasks should return an error")
 	}
 }
+
+// TestFilterCodexOutput_StripsSessionBanner covers the real noise patterns
+// observed in codex exec-mode output: session banner, workdir/model/etc.
+// headers, the `exec <cmd>\n succeeded in...\n<output>\n\n` tool-call
+// blocks, and hook-firing lines. Narrative text and markers stay intact
+// so the downstream extractor can still find them.
+func TestFilterCodexOutput_StripsSessionBanner(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`OpenAI Codex v0.124.0 (research preview)
+--------
+workdir: /tmp/foo
+model: gpt-5.4
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: medium
+reasoning summaries: none
+session id: 019dbea3-7f20-7922-a962-d9fd85d22ac4
+--------
+user
+Please run these review skills in order: 1. /review
+
+codex
+Using superpowers:using-superpowers first, then code-reviewer.
+exec
+/bin/zsh -lc "sed -n '1,220p' /.../SKILL.md" in /tmp/foo
+ succeeded in 0ms:
+[200 lines of skill content]
+
+codex
+No findings.
+
+Residual risk: ...
+tokens used
+12,826
+`)
+	cleaned := string(filterCodexOutput(raw))
+	if strings.Contains(cleaned, "OpenAI Codex v") {
+		t.Error("session banner should be stripped")
+	}
+	if strings.Contains(cleaned, "workdir:") {
+		t.Error("workdir line should be stripped")
+	}
+	if strings.Contains(cleaned, "/bin/zsh -lc") {
+		t.Error("exec block should be stripped")
+	}
+	if strings.Contains(cleaned, "200 lines of skill content") {
+		t.Error("exec block body should be stripped")
+	}
+	if !strings.Contains(cleaned, "No findings.") {
+		t.Error("narrative content should be preserved")
+	}
+	if !strings.Contains(cleaned, "Using superpowers") {
+		t.Error("narrative content should be preserved")
+	}
+}
+
+// TestApplyOutputFilter_UnknownAgentPassesThrough pins that agents
+// without a registered filter (claude-code, gemini-cli, fakes) get their
+// raw output back unchanged — no accidental mutation via shared slices.
+func TestApplyOutputFilter_UnknownAgentPassesThrough(t *testing.T) {
+	t.Parallel()
+	raw := []byte("some random output\n")
+	got := applyOutputFilter("unknown-agent", raw)
+	if !bytes.Equal(got, raw) {
+		t.Errorf("unknown agent: output %q != input %q", got, raw)
+	}
+}
+
+// TestExtractCodexFinal_WithMarkers pins the marker-based slicing: text
+// between the last `^codex$` line and the `tokens used` marker is the
+// final narrative response.
+func TestExtractCodexFinal_WithMarkers(t *testing.T) {
+	t.Parallel()
+	input := "codex\nNo findings.\n\nResidual risk: something.\ntokens used\n12826\n"
+	got := extractCodexFinal(input)
+	want := "No findings.\n\nResidual risk: something."
+	if strings.TrimSpace(got) != want {
+		t.Errorf("extractCodexFinal =\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestExtractCodexFinal_FallsBackWhenMarkersMissing pins the defensive
+// fallback: if codex's output format drifts so the markers aren't found,
+// we return the full cleaned input rather than silently dropping it.
+func TestExtractCodexFinal_FallsBackWhenMarkersMissing(t *testing.T) {
+	t.Parallel()
+	input := "some text without codex marker or tokens used line\n"
+	got := extractCodexFinal(input)
+	if got != input {
+		t.Errorf("extractCodexFinal fallback: got %q; want input unchanged", got)
+	}
+}

--- a/cmd/entire/cli/review_multi_test.go
+++ b/cmd/entire/cli/review_multi_test.go
@@ -86,8 +86,10 @@ func (f *fakeHeadlessAgent) LaunchHeadlessCmd(ctx context.Context, _ string) (*e
 	return exec.CommandContext(ctx, "sh", "-c", script), nil
 }
 
-// shellQuote wraps s in single quotes with embedded single quotes escaped
-// via the conventional '\'' trick. Output is always a valid sh word.
+// shellQuote wraps s in single quotes, escaping any embedded single quote
+// by closing the quoted run, emitting a backslash-quoted single quote,
+// and reopening — the standard POSIX-sh idiom (see the implementation
+// for the literal escape sequence). Output is always a valid sh word.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/cmd/entire/cli/review_multi_test.go
+++ b/cmd/entire/cli/review_multi_test.go
@@ -87,7 +87,7 @@ func (f *fakeHeadlessAgent) LaunchHeadlessCmd(ctx context.Context, _ string) (*e
 }
 
 // shellQuote wraps s in single quotes with embedded single quotes escaped
-// via the conventional '\” trick. Output is always a valid sh word.
+// via the conventional '\'' trick. Output is always a valid sh word.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/cmd/entire/cli/review_multi_test.go
+++ b/cmd/entire/cli/review_multi_test.go
@@ -346,6 +346,27 @@ tokens used
 	}
 }
 
+// TestFilterCodexOutput_PreservesNarrativeStartingWithExec pins that
+// the exec-block anchor doesn't swallow legitimate narrative whose
+// first word happens to be "exec…" — the previous strings.HasPrefix
+// check matched anything starting with those four bytes, including
+// "Examining" (capital E starts with 'E' so was safe) and "executed"
+// (lowercase, was eaten). Anchoring on either bare `^exec$` or the
+// `exec <cmd> in /` shape codex actually emits keeps narrative intact.
+func TestFilterCodexOutput_PreservesNarrativeStartingWithExec(t *testing.T) {
+	t.Parallel()
+	raw := []byte("codex\nexecuted by the runner.\nexecution succeeded with no findings.\nexec ls in /tmp\n succeeded in 0ms:\nfile.txt\n\nMore narrative.\ntokens used\n100\n")
+	cleaned := string(filterCodexOutput(raw))
+	for _, want := range []string{"executed by the runner.", "execution succeeded with no findings.", "More narrative."} {
+		if !strings.Contains(cleaned, want) {
+			t.Errorf("legitimate narrative %q was filtered out:\n%s", want, cleaned)
+		}
+	}
+	if strings.Contains(cleaned, "exec ls in /tmp") {
+		t.Error("real exec block header should still be stripped")
+	}
+}
+
 // TestApplyOutputFilter_UnknownAgentPassesThrough pins that agents
 // without a registered filter (claude-code, gemini-cli, fakes) get their
 // raw output back unchanged — no accidental mutation via shared slices.

--- a/cmd/entire/cli/review_multi_test.go
+++ b/cmd/entire/cli/review_multi_test.go
@@ -1,0 +1,289 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+)
+
+// fakeHeadlessAgent is the orchestrator-test double. It runs a controllable
+// `sh -c` script so the orchestrator sees real stdout and exit codes
+// without depending on any real agent binary. Only the Agent methods the
+// orchestrator actually invokes (Name, LaunchHeadlessCmd) are implemented;
+// any other Agent method panics if invoked, by design — tests should not
+// exercise the rest of the interface surface.
+type fakeHeadlessAgent struct {
+	name     string
+	output   string
+	exitCode int
+	delay    time.Duration
+}
+
+var _ agent.HeadlessLauncher = (*fakeHeadlessAgent)(nil)
+
+func (f *fakeHeadlessAgent) Name() types.AgentName { return types.AgentName(f.name) }
+func (f *fakeHeadlessAgent) Type() types.AgentType { return types.AgentType(f.name) }
+func (f *fakeHeadlessAgent) Description() string   { return "fake headless agent for tests" }
+func (f *fakeHeadlessAgent) IsPreview() bool       { return false }
+func (f *fakeHeadlessAgent) DetectPresence(_ context.Context) (bool, error) {
+	return true, nil
+}
+func (f *fakeHeadlessAgent) ProtectedDirs() []string { return nil }
+
+func (f *fakeHeadlessAgent) ReadTranscript(_ string) ([]byte, error) {
+	panic("fakeHeadlessAgent.ReadTranscript should not be called")
+}
+
+func (f *fakeHeadlessAgent) ChunkTranscript(_ context.Context, _ []byte, _ int) ([][]byte, error) {
+	panic("fakeHeadlessAgent.ChunkTranscript should not be called")
+}
+
+func (f *fakeHeadlessAgent) ReassembleTranscript(_ [][]byte) ([]byte, error) {
+	panic("fakeHeadlessAgent.ReassembleTranscript should not be called")
+}
+
+func (f *fakeHeadlessAgent) GetSessionID(_ *agent.HookInput) string {
+	panic("fakeHeadlessAgent.GetSessionID should not be called")
+}
+
+func (f *fakeHeadlessAgent) GetSessionDir(_ string) (string, error) {
+	panic("fakeHeadlessAgent.GetSessionDir should not be called")
+}
+
+func (f *fakeHeadlessAgent) ResolveSessionFile(_, _ string) string {
+	panic("fakeHeadlessAgent.ResolveSessionFile should not be called")
+}
+
+func (f *fakeHeadlessAgent) ReadSession(_ *agent.HookInput) (*agent.AgentSession, error) {
+	panic("fakeHeadlessAgent.ReadSession should not be called")
+}
+
+func (f *fakeHeadlessAgent) WriteSession(_ context.Context, _ *agent.AgentSession) error {
+	panic("fakeHeadlessAgent.WriteSession should not be called")
+}
+
+func (f *fakeHeadlessAgent) FormatResumeCommand(_ string) string {
+	panic("fakeHeadlessAgent.FormatResumeCommand should not be called")
+}
+
+func (f *fakeHeadlessAgent) LaunchHeadlessCmd(ctx context.Context, _ string) (*exec.Cmd, error) {
+	script := "printf '%s' " + shellQuote(f.output)
+	if f.delay > 0 {
+		script += fmt.Sprintf("; sleep %.3f", f.delay.Seconds())
+	}
+	if f.exitCode != 0 {
+		script += fmt.Sprintf("; exit %d", f.exitCode)
+	}
+	return exec.CommandContext(ctx, "sh", "-c", script), nil
+}
+
+// shellQuote wraps s in single quotes with embedded single quotes escaped
+// via the conventional '\” trick. Output is always a valid sh word.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// TestOrchestrator_HappyPath exercises N agents all succeeding, verifies
+// each produced FinalOutput, and confirms the marker is cleaned up on
+// normal exit.
+func TestOrchestrator_HappyPath(t *testing.T) {
+	// Cannot t.Parallel — writes and reads the global pending-review marker.
+	tmp := setupReviewTestRepoWithCommit(t)
+
+	tasks := []MultiAgentTask{
+		{Name: "fake-a", Prompt: "review", Agent: &fakeHeadlessAgent{name: "fake-a", output: "A result\n"}},
+		{Name: "fake-b", Prompt: "review", Agent: &fakeHeadlessAgent{name: "fake-b", output: "B result\n"}},
+		{Name: "fake-c", Prompt: "review", Agent: &fakeHeadlessAgent{name: "fake-c", output: "C result\n"}},
+	}
+
+	var buf bytes.Buffer
+	orch := newMultiReviewOrchestrator(tmp)
+	result, err := orch.Run(context.Background(), tasks, &buf)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Runs) != 3 {
+		t.Fatalf("Runs count = %d, want 3", len(result.Runs))
+	}
+	for _, r := range result.Runs {
+		if r.Status != AgentRunDone {
+			t.Errorf("agent %s status = %d, want Done", r.Name, r.Status)
+		}
+		if len(r.FinalOutput) == 0 {
+			t.Errorf("agent %s has empty FinalOutput", r.Name)
+		}
+	}
+	_, ok, readErr := ReadPendingReviewMarker(context.Background())
+	if readErr != nil {
+		t.Fatalf("read marker: %v", readErr)
+	}
+	if ok {
+		t.Error("marker should be cleared on happy exit")
+	}
+}
+
+// TestOrchestrator_WritesSharedMarker pins that the marker written during
+// a multi-agent run carries AgentNames (enabling sibling-agent adoption)
+// and is visible to hooks while the run is in flight.
+func TestOrchestrator_WritesSharedMarker(t *testing.T) {
+	// Cannot t.Parallel — reads the global pending-review marker.
+	tmp := setupReviewTestRepoWithCommit(t)
+
+	// A delay long enough to reliably observe the marker while the agents
+	// are still running. We use .delay to block subprocess exit; 500ms is
+	// generous compared to the 50ms poll.
+	tasks := []MultiAgentTask{
+		{Name: "fake-a", Prompt: "review", Agent: &fakeHeadlessAgent{name: "fake-a", output: "A\n", delay: 500 * time.Millisecond}},
+		{Name: "fake-b", Prompt: "review", Agent: &fakeHeadlessAgent{name: "fake-b", output: "B\n", delay: 500 * time.Millisecond}},
+	}
+
+	orch := newMultiReviewOrchestrator(tmp)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if _, runErr := orch.Run(context.Background(), tasks, io.Discard); runErr != nil {
+			t.Errorf("orch.Run: %v", runErr)
+		}
+	}()
+
+	// Poll briefly for the marker — the orchestrator writes it before
+	// spawning goroutines, so 10×50ms should be more than enough.
+	var marker PendingReviewMarker
+	var markerOK bool
+	for range 10 {
+		m, ok, err := ReadPendingReviewMarker(context.Background())
+		if err != nil {
+			t.Fatalf("read marker: %v", err)
+		}
+		if ok {
+			marker = m
+			markerOK = true
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !markerOK {
+		t.Fatal("marker was never written mid-run")
+	}
+	if len(marker.AgentNames) != 2 {
+		t.Errorf("marker.AgentNames = %v, want 2 entries", marker.AgentNames)
+	}
+	if marker.WorktreePath != tmp {
+		t.Errorf("marker.WorktreePath = %q, want %q", marker.WorktreePath, tmp)
+	}
+	wg.Wait()
+
+	// Post-exit, marker must be cleared.
+	_, postOK, postErr := ReadPendingReviewMarker(context.Background())
+	if postErr != nil {
+		t.Fatalf("read marker: %v", postErr)
+	}
+	if postOK {
+		t.Error("marker should be cleared after Run returns")
+	}
+}
+
+// TestOrchestrator_FailurePerAgentIndependent pins that one agent's
+// non-zero exit does not cancel the others — Run classifies each
+// independently and still returns a result.
+func TestOrchestrator_FailurePerAgentIndependent(t *testing.T) {
+	// Cannot t.Parallel — writes the global pending-review marker.
+	tmp := setupReviewTestRepoWithCommit(t)
+
+	tasks := []MultiAgentTask{
+		{Name: "fake-ok", Prompt: "r", Agent: &fakeHeadlessAgent{name: "fake-ok", output: "OK\n"}},
+		{Name: "fake-fail", Prompt: "r", Agent: &fakeHeadlessAgent{name: "fake-fail", output: "", exitCode: 1}},
+	}
+
+	orch := newMultiReviewOrchestrator(tmp)
+	result, err := orch.Run(context.Background(), tasks, io.Discard)
+	if err != nil {
+		t.Fatalf("Run should return non-nil result even with failures: %v", err)
+	}
+
+	var succ, fail int
+	for _, r := range result.Runs {
+		switch r.Status {
+		case AgentRunDone:
+			succ++
+		case AgentRunFailed:
+			fail++
+		case AgentRunQueued, AgentRunRunning, AgentRunCancelled:
+			t.Errorf("unexpected status %d for agent %s", r.Status, r.Name)
+		}
+	}
+	if succ != 1 || fail != 1 {
+		t.Errorf("succ=%d fail=%d, want 1 and 1", succ, fail)
+	}
+}
+
+// TestOrchestrator_CancelCleansMarker pins that cancelling the context
+// reliably fires SIGTERM to subprocesses (via exec.CommandContext), flips
+// result.Cancelled, and clears the marker.
+func TestOrchestrator_CancelCleansMarker(t *testing.T) {
+	// Cannot t.Parallel — reads the global pending-review marker.
+	tmp := setupReviewTestRepoWithCommit(t)
+
+	tasks := []MultiAgentTask{
+		{Name: "slow", Prompt: "r", Agent: &fakeHeadlessAgent{name: "slow", output: "", delay: 2 * time.Second}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	orch := newMultiReviewOrchestrator(tmp)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	result, err := orch.Run(ctx, tasks, io.Discard)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Errorf("cancel didn't kill subprocess fast enough: %v", elapsed)
+	}
+	if !result.Cancelled {
+		// Cancellation flows through signal goroutine when os signal fires;
+		// a context-only cancel skips that path. Accept not-cancelled as long
+		// as the subprocess did exit quickly (already asserted above).
+		t.Logf("result.Cancelled = false (acceptable when cancel came via ctx, not signal)")
+	}
+	_, markerOK, markerErr := ReadPendingReviewMarker(context.Background())
+	if markerErr != nil {
+		t.Fatalf("read marker: %v", markerErr)
+	}
+	if markerOK {
+		t.Error("marker should be cleared after cancel")
+	}
+	// Status should reflect cancellation via context error.
+	if len(result.Runs) != 1 {
+		t.Fatalf("Runs count = %d, want 1", len(result.Runs))
+	}
+	if result.Runs[0].Status != AgentRunCancelled && result.Runs[0].Status != AgentRunFailed {
+		t.Errorf("slow agent status = %d, want Cancelled or Failed", result.Runs[0].Status)
+	}
+}
+
+// TestOrchestrator_NoTasks returns a sentinel error without touching the marker.
+func TestOrchestrator_NoTasks(t *testing.T) {
+	t.Parallel()
+
+	orch := newMultiReviewOrchestrator(t.TempDir())
+	_, err := orch.Run(context.Background(), nil, io.Discard)
+	if err == nil {
+		t.Fatal("Run with no tasks should return an error")
+	}
+}

--- a/cmd/entire/cli/review_synthesize.go
+++ b/cmd/entire/cli/review_synthesize.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+)
+
+// synthesizeCombinedVerdictTimeout caps how long we wait for the
+// summarizer to respond. Generous because cross-review synthesis is
+// genuinely useful work, but bounded so a stuck CLI doesn't wedge the
+// user's terminal indefinitely after the agents have already finished.
+const synthesizeCombinedVerdictMinAgents = 2
+
+// maybeSynthesizeCombinedVerdict offers the user an opt-in cross-agent
+// synthesis after the per-agent dumps and the counts line. Skipped
+// silently when:
+//   - run was cancelled (user already opted out of finishing this work);
+//   - fewer than 2 agents produced usable output (nothing to synthesize);
+//   - stdin isn't a TTY (CI or piped output — nobody to prompt);
+//   - the user answers no to the confirm prompt.
+//
+// Failures from the prompt provider are non-fatal — synthesis is value-
+// added, not load-bearing — they print a one-line note and fall through.
+func maybeSynthesizeCombinedVerdict(ctx context.Context, out io.Writer, tasks []MultiAgentTask, results []AgentRunResult, cancelled bool) {
+	if cancelled {
+		return
+	}
+	usable := collectUsableReviews(tasks, results)
+	if len(usable) < synthesizeCombinedVerdictMinAgents {
+		return
+	}
+	if !interactive.CanPromptInteractively() {
+		return
+	}
+
+	confirm := false
+	form := NewAccessibleForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title("Synthesize a combined verdict across agents?").
+			Description("Calls your configured summary provider once. Skip to commit reviews as-is.").
+			Affirmative("Yes").
+			Negative("No").
+			Value(&confirm),
+	))
+	if err := form.Run(); err != nil {
+		// Form errors here are typically the user pressing ctrl+c at the
+		// prompt — treat as "no synthesis" and continue. Log at debug so
+		// real errors aren't lost.
+		logging.Debug(ctx, "synthesize verdict: prompt cancelled or failed",
+			slog.String("error", err.Error()))
+		return
+	}
+	if !confirm {
+		return
+	}
+
+	verdict, err := synthesizeCombinedVerdict(ctx, out, usable)
+	if err != nil {
+		// Soft failure — the agents already did their work; missing
+		// synthesis is a degradation, not a crash. Tell the user once
+		// and move on.
+		fmt.Fprintf(out, "\n  Synthesis unavailable: %v\n", err)
+		return
+	}
+	fmt.Fprintln(out, "\n─────── combined verdict ───────")
+	fmt.Fprintln(out, strings.TrimSpace(verdict))
+}
+
+// reviewForSynthesis pairs an agent name with the cleaned narrative
+// fed into the synthesis prompt. Mirrors the shape dumpPerAgentReviews
+// emits to the user so the LLM sees the same content the user did.
+type reviewForSynthesis struct {
+	Name    string
+	Content string
+}
+
+// collectUsableReviews filters results down to ones that produced
+// meaningful output. Failed/cancelled/empty agents are excluded — the
+// synthesis prompt is more useful with two real reviews than with one
+// real review and one "agent failed" stub.
+func collectUsableReviews(tasks []MultiAgentTask, results []AgentRunResult) []reviewForSynthesis {
+	usable := make([]reviewForSynthesis, 0, len(results))
+	for i, r := range results {
+		if r.Status != AgentRunDone {
+			continue
+		}
+		cleaned := applyOutputFilter(tasks[i].Name, r.FinalOutput)
+		final := strings.TrimSpace(extractFinalMessage(tasks[i].Name, string(cleaned)))
+		if final == "" {
+			continue
+		}
+		usable = append(usable, reviewForSynthesis{Name: tasks[i].Name, Content: final})
+	}
+	return usable
+}
+
+// synthesizeCombinedVerdict resolves the configured summary provider
+// (claude/codex/gemini whichever is installed; see
+// resolveCheckpointSummaryProvider) and asks it to synthesize a single
+// verdict from the per-agent reviews.
+func synthesizeCombinedVerdict(ctx context.Context, w io.Writer, reviews []reviewForSynthesis) (string, error) {
+	provider, err := resolveCheckpointSummaryProvider(ctx, w)
+	if err != nil {
+		return "", fmt.Errorf("resolve summary provider: %w", err)
+	}
+	ag, err := getSummaryAgent(provider.Name)
+	if err != nil {
+		return "", fmt.Errorf("get summary agent %s: %w", provider.Name, err)
+	}
+	tg, ok := agent.AsTextGenerator(ag)
+	if !ok {
+		return "", fmt.Errorf("agent %s does not support text generation", provider.Name)
+	}
+	prompt := buildVerdictSynthesisPrompt(reviews)
+	out, err := tg.GenerateText(ctx, prompt, provider.Model)
+	if err != nil {
+		return "", fmt.Errorf("generate verdict via %s: %w", provider.Name, err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return "", errors.New("synthesis returned empty output")
+	}
+	return out, nil
+}
+
+// buildVerdictSynthesisPrompt composes the LLM prompt that turns N
+// per-agent reviews into a single unified verdict. Structured to favor
+// agreement (high confidence), divergence (single-source claims), and
+// priority — what a user actually needs to act on after a review.
+func buildVerdictSynthesisPrompt(reviews []reviewForSynthesis) string {
+	var sb strings.Builder
+	sb.WriteString("You are synthesizing ")
+	fmt.Fprintf(&sb, "%d", len(reviews))
+	sb.WriteString(" independent code reviews of the same change. Each agent reviewed the same diff and produced findings independently below.\n\n")
+	for _, r := range reviews {
+		fmt.Fprintf(&sb, "─── %s ───\n%s\n\n", r.Name, r.Content)
+	}
+	sb.WriteString("Produce a unified verdict with these sections:\n")
+	sb.WriteString("1. **Common findings** — issues multiple agents flagged (high confidence). Include the originating agents in parens.\n")
+	sb.WriteString("2. **Unique findings** — issues only one agent raised. Group by agent. Note whether they look meaningful or noise.\n")
+	sb.WriteString("3. **Disagreements** — places where agents took conflicting positions. Resolve if you can; flag if you can't.\n")
+	sb.WriteString("4. **Priority order** — what the user should act on first, ordered by impact.\n\n")
+	sb.WriteString("Be concise. Use bullet points. No preamble, no closing pleasantries. Reference filenames and line numbers when the underlying reviews provided them.")
+	return sb.String()
+}

--- a/cmd/entire/cli/review_synthesize_test.go
+++ b/cmd/entire/cli/review_synthesize_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCollectUsableReviews_FiltersStatusAndEmpty pins that the
+// synthesis input only includes successful agents with non-empty
+// post-filter narrative. Failed/cancelled/empty entries would dilute
+// the prompt with stub text the LLM has nothing useful to do with.
+func TestCollectUsableReviews_FiltersStatusAndEmpty(t *testing.T) {
+	t.Parallel()
+	tasks := []MultiAgentTask{
+		{Name: "ok-a"},
+		{Name: "failed"},
+		{Name: "cancelled"},
+		{Name: "empty"},
+		{Name: "ok-b"},
+	}
+	results := []AgentRunResult{
+		{Name: "ok-a", Status: AgentRunDone, FinalOutput: []byte("first finding\n")},
+		{Name: "failed", Status: AgentRunFailed, ExitCode: 1, FinalOutput: []byte("partial output")},
+		{Name: "cancelled", Status: AgentRunCancelled, FinalOutput: []byte("partial output")},
+		{Name: "empty", Status: AgentRunDone, FinalOutput: []byte("")},
+		{Name: "ok-b", Status: AgentRunDone, FinalOutput: []byte("second finding\n")},
+	}
+
+	got := collectUsableReviews(tasks, results)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 usable reviews, got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "ok-a" || got[1].Name != "ok-b" {
+		t.Errorf("usable agents = [%s, %s], want [ok-a, ok-b]", got[0].Name, got[1].Name)
+	}
+	for _, r := range got {
+		if strings.TrimSpace(r.Content) == "" {
+			t.Errorf("usable review %s has empty content", r.Name)
+		}
+	}
+}
+
+// TestBuildVerdictSynthesisPrompt_StructureAndAttribution pins that the
+// prompt fed to the summarizer (a) names every agent so the LLM can
+// attribute findings, (b) embeds each agent's content under a clear
+// delimiter, and (c) requests the four-section verdict shape the user
+// sees in the rendered output.
+func TestBuildVerdictSynthesisPrompt_StructureAndAttribution(t *testing.T) {
+	t.Parallel()
+	reviews := []reviewForSynthesis{
+		{Name: "claude-code", Content: "issue X in file.go:10"},
+		{Name: "codex", Content: "issue Y in file.go:20"},
+	}
+	prompt := buildVerdictSynthesisPrompt(reviews)
+
+	wantSubstrs := []string{
+		"2 independent code reviews", // count anchors the framing
+		"─── claude-code ───",
+		"─── codex ───",
+		"issue X in file.go:10",
+		"issue Y in file.go:20",
+		"Common findings",
+		"Unique findings",
+		"Disagreements",
+		"Priority order",
+	}
+	for _, want := range wantSubstrs {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("prompt missing %q in:\n%s", want, prompt)
+		}
+	}
+
+	// No preamble: agents being asked to be terse must themselves see a
+	// terse prompt. Guard against accidental "Hi assistant," style
+	// preambles being added in the future.
+	if strings.HasPrefix(prompt, "Hi") || strings.HasPrefix(prompt, "Hello") {
+		t.Errorf("prompt should not open with a greeting; got: %q", prompt[:50])
+	}
+}

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -303,7 +303,10 @@ func TestComposeReviewPrompt_AppendsRunContext(t *testing.T) {
 			name:       "context + skills",
 			cfg:        settings.ReviewConfig{Skills: []string{"/review"}},
 			runContext: "focus on auth",
-			want:       "Please run these review skills in order:\n  1. /review\n\n\nFor this review: focus on auth",
+			// Exactly two newlines between the skills list and "For this
+			// review:" — the skills template's trailing \n is trimmed
+			// before joining so the gap doesn't grow to a hollow three.
+			want: "Please run these review skills in order:\n  1. /review\n\nFor this review: focus on auth",
 		},
 		{
 			name:       "context + persistent prompt",

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -251,7 +251,7 @@ func TestComposeReviewPrompt_SkillsOnly(t *testing.T) {
 	t.Parallel()
 	prompt := composeReviewPrompt(settings.ReviewConfig{
 		Skills: []string{"/review-pr", "/test-auditor"},
-	}, "")
+	}, "", reviewPromptScope{})
 	if strings.Contains(prompt, "entire-review:finish") {
 		t.Errorf("prompt should not reference finish skill; got: %s", prompt)
 	}
@@ -268,7 +268,7 @@ func TestComposeReviewPrompt_CustomPromptWinsOverSkills(t *testing.T) {
 	prompt := composeReviewPrompt(settings.ReviewConfig{
 		Skills: []string{"/review-pr"},
 		Prompt: custom,
-	}, "")
+	}, "", reviewPromptScope{})
 	if prompt != custom {
 		t.Errorf("composeReviewPrompt = %q, want verbatim custom prompt %q", prompt, custom)
 	}
@@ -278,7 +278,7 @@ func TestComposeReviewPrompt_CustomPromptWinsOverSkills(t *testing.T) {
 // the spawn path with empty config.
 func TestComposeReviewPrompt_EmptyConfigReturnsEmpty(t *testing.T) {
 	t.Parallel()
-	if got := composeReviewPrompt(settings.ReviewConfig{}, ""); got != "" {
+	if got := composeReviewPrompt(settings.ReviewConfig{}, "", reviewPromptScope{}); got != "" {
 		t.Errorf("empty config = %q, want empty", got)
 	}
 }
@@ -321,11 +321,162 @@ func TestComposeReviewPrompt_AppendsRunContext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := composeReviewPrompt(tt.cfg, tt.runContext)
+			got := composeReviewPrompt(tt.cfg, tt.runContext, reviewPromptScope{})
 			if got != tt.want {
 				t.Errorf("composeReviewPrompt(%+v, %q) =\n%q\nwant:\n%q", tt.cfg, tt.runContext, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestComposeReviewPrompt_AppendsScopeClause locks the format and
+// presence rules for the scope clause: empty BaseRef omits it; BaseRef
+// alone renders without the branch label; branch+BaseRef renders the
+// full clause after the base prompt.
+func TestComposeReviewPrompt_AppendsScopeClause(t *testing.T) {
+	t.Parallel()
+	cfg := settings.ReviewConfig{Skills: []string{"/review"}}
+	tests := []struct {
+		name           string
+		scope          reviewPromptScope
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:           "no BaseRef, no clause",
+			scope:          reviewPromptScope{Branch: "main"},
+			wantNotContain: []string{"Review scope:"},
+		},
+		{
+			name:         "BaseRef only, no branch label",
+			scope:        reviewPromptScope{BaseRef: "main"},
+			wantContains: []string{"Review scope:", "vs base `main`", "git diff main...HEAD"},
+			wantNotContain: []string{
+				"(``)",                   // empty branch label
+				"git status --porcelain", // commits-only — uncommitted is noise
+			},
+		},
+		{
+			name:  "branch + BaseRef",
+			scope: reviewPromptScope{Branch: "hackathon-slides", BaseRef: "audit-traceability"},
+			wantContains: []string{
+				"(`hackathon-slides`)",
+				"vs base `audit-traceability`",
+				"git diff audit-traceability...HEAD",
+				"Do not review uncommitted",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := composeReviewPrompt(cfg, "", tt.scope)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("missing %q in:\n%s", want, got)
+				}
+			}
+			for _, unwant := range tt.wantNotContain {
+				if strings.Contains(got, unwant) {
+					t.Errorf("unexpected %q in:\n%s", unwant, got)
+				}
+			}
+		})
+	}
+}
+
+// Empty cfg + empty runContext + scope-only should still produce the
+// scope clause (an agent run with no skills configured still gets a
+// useful instruction).
+func TestComposeReviewPrompt_ScopeOnlyNoBase(t *testing.T) {
+	t.Parallel()
+	got := composeReviewPrompt(settings.ReviewConfig{}, "", reviewPromptScope{BaseRef: "main"})
+	if !strings.HasPrefix(got, "Review scope:") {
+		t.Errorf("scope-only should produce clause as full prompt; got:\n%s", got)
+	}
+}
+
+// TestDetectScopeBaseRef_PicksClosestAncestorBranch reproduces the
+// branch-on-branch topology that motivated the scope rework: HEAD is on
+// `feature` which was forked from `intermediate` (forked from `main`).
+// The scope base must resolve to `intermediate`, not `main`, so the
+// review covers only the commits unique to `feature` (mirroring the
+// demo-repo `hackathon-slides` / `audit-traceability` / `main` setup).
+func TestDetectScopeBaseRef_PicksClosestAncestorBranch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "main")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "main commit")
+
+	// Fork `intermediate` off main, add a commit there.
+	testutil.GitCheckoutNewBranch(t, tmp, "intermediate")
+	testutil.WriteFile(t, tmp, "f.txt", "intermediate")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "intermediate commit")
+
+	// Fork `feature` off intermediate, add a commit there.
+	testutil.GitCheckoutNewBranch(t, tmp, "feature")
+	testutil.WriteFile(t, tmp, "f.txt", "feature")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "feature commit")
+
+	got := detectScopeBaseRef(context.Background(), tmp)
+	if got != "intermediate" {
+		t.Errorf("detectScopeBaseRef = %q, want \"intermediate\" (closest ancestor branch, not main)", got)
+	}
+}
+
+// TestDetectScopeBaseRef_FallsBackToDefaultBaseBranch covers the simple
+// case where the branch was forked directly from the default base —
+// there's no intermediate branch tip to find, so we fall through to
+// detectBaseBranch (which resolves origin/HEAD or main/master).
+func TestDetectScopeBaseRef_FallsBackToDefaultBaseBranch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "main")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "main commit")
+
+	testutil.GitCheckoutNewBranch(t, tmp, "feature")
+	testutil.WriteFile(t, tmp, "f.txt", "feature")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "feature commit")
+
+	got := detectScopeBaseRef(context.Background(), tmp)
+	// detectBaseBranch returns main (or master) for the fallback. Either
+	// is acceptable — the point is we didn't pick "feature" itself.
+	if got != "main" && got != "master" {
+		t.Errorf("detectScopeBaseRef = %q, want \"main\" or \"master\" (fallback)", got)
+	}
+}
+
+// TestDetectScopeBaseRef_SkipsEntireInternalBranches makes sure the
+// `entire/*` shadow branches the strategy creates don't get picked as
+// scope bases — that would produce scope clauses pointed at internal
+// state and produce empty diffs.
+func TestDetectScopeBaseRef_SkipsEntireInternalBranches(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "main")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "main commit")
+
+	// An entire/* branch with the same tip as main shouldn't be
+	// preferred over main.
+	testutil.CreateBranch(t, tmp, "entire/abc1234-def567")
+
+	testutil.GitCheckoutNewBranch(t, tmp, "feature")
+	testutil.WriteFile(t, tmp, "f.txt", "feature")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "feature commit")
+
+	got := detectScopeBaseRef(context.Background(), tmp)
+	if strings.HasPrefix(got, "entire/") {
+		t.Errorf("detectScopeBaseRef = %q, must not pick an entire/* internal branch", got)
 	}
 }
 
@@ -363,9 +514,12 @@ func TestRunReview_CallsPromptForRunContextBeforeSpawn(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("marker should exist (non-launchable fallback): ok=%v err=%v", ok, err)
 	}
-	want := "always flag side effects\n\nFor this review: focus on auth refactor"
-	if m.Prompt != want {
-		t.Errorf("marker.Prompt = %q\nwant %q", m.Prompt, want)
+	// Match on the run-context composition pinned by this test; the scope
+	// clause is asserted separately in TestComposeReviewPrompt_AppendsScopeClause
+	// so we don't lock its exact wording here.
+	wantSubstr := "always flag side effects\n\nFor this review: focus on auth refactor"
+	if !strings.Contains(m.Prompt, wantSubstr) {
+		t.Errorf("marker.Prompt missing %q; got:\n%s", wantSubstr, m.Prompt)
 	}
 }
 
@@ -410,10 +564,10 @@ func TestRunReview_MultiAgent_PassesRunContextToAllTasks(t *testing.T) {
 	if len(gotPrompts) != 2 {
 		t.Fatalf("expected 2 prompts, got %d", len(gotPrompts))
 	}
-	want := "always flag side effects\n\nFor this review: focus on auth"
+	wantSubstr := "always flag side effects\n\nFor this review: focus on auth"
 	for i, prompt := range gotPrompts {
-		if prompt != want {
-			t.Errorf("task[%d].Prompt =\n%q\nwant:\n%q", i, prompt, want)
+		if !strings.Contains(prompt, wantSubstr) {
+			t.Errorf("task[%d].Prompt missing %q; got:\n%s", i, wantSubstr, prompt)
 		}
 	}
 }

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -218,11 +218,15 @@ func TestRunReview_NonLaunchableAgentPreservesMarker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootCmd := NewRootCmd()
+	// Stub the run-context prompt so the test doesn't hit the real huh
+	// textarea (no TTY in tests).
+	deps := runReviewDeps{
+		promptForRunContextFn: func(_ context.Context) (string, error) { return "", nil },
+	}
+	reviewCmd := newReviewCmdWithDeps(deps)
 	buf := &bytes.Buffer{}
-	rootCmd.SetOut(buf)
-	rootCmd.SetArgs([]string{"review"})
-	if err := rootCmd.Execute(); err != nil {
+	reviewCmd.SetOut(buf)
+	if err := reviewCmd.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 
@@ -247,7 +251,7 @@ func TestComposeReviewPrompt_SkillsOnly(t *testing.T) {
 	t.Parallel()
 	prompt := composeReviewPrompt(settings.ReviewConfig{
 		Skills: []string{"/review-pr", "/test-auditor"},
-	})
+	}, "")
 	if strings.Contains(prompt, "entire-review:finish") {
 		t.Errorf("prompt should not reference finish skill; got: %s", prompt)
 	}
@@ -264,7 +268,7 @@ func TestComposeReviewPrompt_CustomPromptWinsOverSkills(t *testing.T) {
 	prompt := composeReviewPrompt(settings.ReviewConfig{
 		Skills: []string{"/review-pr"},
 		Prompt: custom,
-	})
+	}, "")
 	if prompt != custom {
 		t.Errorf("composeReviewPrompt = %q, want verbatim custom prompt %q", prompt, custom)
 	}
@@ -274,8 +278,143 @@ func TestComposeReviewPrompt_CustomPromptWinsOverSkills(t *testing.T) {
 // the spawn path with empty config.
 func TestComposeReviewPrompt_EmptyConfigReturnsEmpty(t *testing.T) {
 	t.Parallel()
-	if got := composeReviewPrompt(settings.ReviewConfig{}); got != "" {
+	if got := composeReviewPrompt(settings.ReviewConfig{}, ""); got != "" {
 		t.Errorf("empty config = %q, want empty", got)
+	}
+}
+
+// TestComposeReviewPrompt_AppendsRunContext covers the four composition cases
+// when per-run context is provided alongside persistent cfg fields.
+func TestComposeReviewPrompt_AppendsRunContext(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		cfg        settings.ReviewConfig
+		runContext string
+		want       string
+	}{
+		{
+			name:       "no context, skills only",
+			cfg:        settings.ReviewConfig{Skills: []string{"/review"}},
+			runContext: "",
+			want:       "Please run these review skills in order:\n  1. /review\n",
+		},
+		{
+			name:       "context + skills",
+			cfg:        settings.ReviewConfig{Skills: []string{"/review"}},
+			runContext: "focus on auth",
+			want:       "Please run these review skills in order:\n  1. /review\n\n\nFor this review: focus on auth",
+		},
+		{
+			name:       "context + persistent prompt",
+			cfg:        settings.ReviewConfig{Prompt: "always flag side effects"},
+			runContext: "review the migration",
+			want:       "always flag side effects\n\nFor this review: review the migration",
+		},
+		{
+			name:       "context only, no cfg",
+			cfg:        settings.ReviewConfig{},
+			runContext: "one-off review",
+			want:       "one-off review",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := composeReviewPrompt(tt.cfg, tt.runContext)
+			if got != tt.want {
+				t.Errorf("composeReviewPrompt(%+v, %q) =\n%q\nwant:\n%q", tt.cfg, tt.runContext, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunReview_CallsPromptForRunContextBeforeSpawn pins that runReview
+// calls the injection hook between agent selection and marker write/spawn,
+// and that the returned run-context text is composed into the final
+// prompt stored on PendingReviewMarker.Prompt.
+func TestRunReview_CallsPromptForRunContextBeforeSpawn(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, "cursor") // non-launchable so !ok fallback preserves marker
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		"cursor": {Prompt: "always flag side effects"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	deps := runReviewDeps{
+		promptForRunContextFn: func(_ context.Context) (string, error) {
+			called = true
+			return "focus on auth refactor", nil
+		},
+	}
+
+	reviewCmd := newReviewCmdWithDeps(deps)
+	if err := reviewCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !called {
+		t.Error("promptForRunContextFn was not called")
+	}
+
+	m, ok, err := ReadPendingReviewMarker(context.Background())
+	if err != nil || !ok {
+		t.Fatalf("marker should exist (non-launchable fallback): ok=%v err=%v", ok, err)
+	}
+	want := "always flag side effects\n\nFor this review: focus on auth refactor"
+	if m.Prompt != want {
+		t.Errorf("marker.Prompt = %q\nwant %q", m.Prompt, want)
+	}
+}
+
+// TestRunReview_MultiAgent_PassesRunContextToAllTasks pins that the per-run
+// context fires in the multi-agent path and is composed into each task's
+// prompt before reaching the orchestrator.
+func TestRunReview_MultiAgent_PassesRunContextToAllTasks(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, testAgentName)
+	installHooksForTest(t, testCodexAgent)
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testAgentName:  {Prompt: "always flag side effects"},
+		testCodexAgent: {Prompt: "always flag side effects"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotPrompts []string
+	deps := runReviewDeps{
+		promptForAgentsFn: func(_ context.Context, eligible []agentChoice) ([]string, error) {
+			return []string{eligible[0].Name, eligible[1].Name}, nil
+		},
+		promptForRunContextFn: func(_ context.Context) (string, error) {
+			return "focus on auth", nil
+		},
+		runMultiAgentFn: func(_ context.Context, tasks []MultiAgentTask, _ io.Writer) (MultiRunResult, error) {
+			for _, task := range tasks {
+				gotPrompts = append(gotPrompts, task.Prompt)
+			}
+			return MultiRunResult{Runs: []AgentRunResult{
+				{Name: tasks[0].Name, Status: AgentRunDone},
+				{Name: tasks[1].Name, Status: AgentRunDone},
+			}}, nil
+		},
+	}
+
+	reviewCmd := newReviewCmdWithDeps(deps)
+	if err := reviewCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(gotPrompts) != 2 {
+		t.Fatalf("expected 2 prompts, got %d", len(gotPrompts))
+	}
+	want := "always flag side effects\n\nFor this review: focus on auth"
+	for i, prompt := range gotPrompts {
+		if prompt != want {
+			t.Errorf("task[%d].Prompt =\n%q\nwant:\n%q", i, prompt, want)
+		}
 	}
 }
 
@@ -839,11 +978,14 @@ func TestRunReview_PromptOnlyConfigSkipsVerification(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootCmd := NewRootCmd()
+	// Stub the run-context prompt — no TTY in tests.
+	deps := runReviewDeps{
+		promptForRunContextFn: func(_ context.Context) (string, error) { return "", nil },
+	}
+	reviewCmd := newReviewCmdWithDeps(deps)
 	buf := &bytes.Buffer{}
-	rootCmd.SetOut(buf)
-	rootCmd.SetArgs([]string{"review"})
-	if err := rootCmd.Execute(); err != nil {
+	reviewCmd.SetOut(buf)
+	if err := reviewCmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	_, markerExists, markerErr := ReadPendingReviewMarker(context.Background())
@@ -884,6 +1026,8 @@ func TestPromptForAgent_SingleEligibleSkipsPicker(t *testing.T) {
 			called = true
 			return "", nil
 		},
+		// Stub run-context prompt — no TTY in tests.
+		promptForRunContextFn: func(_ context.Context) (string, error) { return "", nil },
 	}
 
 	reviewCmd := newReviewCmdWithDeps(deps)
@@ -915,6 +1059,8 @@ func TestPromptForAgent_FlagOverrideSkipsPicker(t *testing.T) {
 			called = true
 			return "", nil
 		},
+		// Stub run-context prompt — no TTY in tests.
+		promptForRunContextFn: func(_ context.Context) (string, error) { return "", nil },
 	}
 
 	reviewCmd := newReviewCmdWithDeps(deps)
@@ -989,6 +1135,8 @@ func TestRunReview_MultiAgentNoFlagTriggersPicker(t *testing.T) {
 			// Alphabetical ordering; pick the second one.
 			return eligible[1].Name, nil
 		},
+		// Stub run-context prompt — no TTY in tests.
+		promptForRunContextFn: func(_ context.Context) (string, error) { return "", nil },
 	}
 
 	reviewCmd := newReviewCmdWithDeps(deps)
@@ -1038,6 +1186,8 @@ func TestPromptForAgents_CallsInjection(t *testing.T) {
 			}
 			return []string{eligible[0].Name, eligible[1].Name}, nil
 		},
+		// Stub run-context prompt — no TTY in tests.
+		promptForRunContextFn: func(_ context.Context) (string, error) { return "", nil },
 		runMultiAgentFn: func(_ context.Context, tasks []MultiAgentTask, _ io.Writer) (MultiRunResult, error) {
 			multiCalled = true
 			if len(tasks) != 2 {

--- a/cmd/entire/cli/review_test.go
+++ b/cmd/entire/cli/review_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1005,5 +1006,169 @@ func TestRunReview_MultiAgentNoFlagTriggersPicker(t *testing.T) {
 	}
 	if m.AgentName != testPickerAgentB {
 		t.Errorf("AgentName = %q, want %s", m.AgentName, testPickerAgentB)
+	}
+}
+
+// TestPromptForAgents_CallsInjection pins the dispatch contract: when the
+// deps hook is set and ≥2 HeadlessLauncher agents are eligible, runReview
+// routes to the multi-select picker AND the multi-agent orchestrator. Proves
+// the injection wiring works before Chunk 3's real orchestrator lands.
+//
+// Uses claude-code + codex because they implement HeadlessLauncher — only
+// these get offered in the multi-agent picker per the dispatch switch.
+func TestPromptForAgents_CallsInjection(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, testAgentName)
+	installHooksForTest(t, testCodexAgent)
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testAgentName:  {Prompt: "review the diff"},
+		testCodexAgent: {Prompt: "review the diff"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	promptCalled := false
+	multiCalled := false
+	deps := runReviewDeps{
+		promptForAgentsFn: func(_ context.Context, eligible []agentChoice) ([]string, error) {
+			promptCalled = true
+			if len(eligible) < 2 {
+				t.Fatalf("expected >=2 eligible, got %d", len(eligible))
+			}
+			return []string{eligible[0].Name, eligible[1].Name}, nil
+		},
+		runMultiAgentFn: func(_ context.Context, tasks []MultiAgentTask, _ io.Writer) (MultiRunResult, error) {
+			multiCalled = true
+			if len(tasks) != 2 {
+				t.Fatalf("expected 2 tasks, got %d", len(tasks))
+			}
+			// Minimal MultiRunResult so the dispatch returns OK.
+			return MultiRunResult{
+				Runs: []AgentRunResult{
+					{Name: tasks[0].Name, Status: AgentRunDone},
+					{Name: tasks[1].Name, Status: AgentRunDone},
+				},
+			}, nil
+		},
+	}
+
+	reviewCmd := newReviewCmdWithDeps(deps)
+	if err := reviewCmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !promptCalled {
+		t.Error("promptForAgentsFn should have been called")
+	}
+	if !multiCalled {
+		t.Error("runMultiAgentFn should have been called")
+	}
+}
+
+// TestPromptForAgents_SingleSelectionFallsBackToSingleAgent pins that
+// selecting exactly one agent in the multi-select picker routes to the 2.1
+// single-agent path rather than the orchestrator.
+//
+// Deviation from plan: the plan proposes using non-launchable agents
+// (cursor, opencode) to avoid spawning a real subprocess. But the dispatch
+// switch filters the multi-select picker to HeadlessLauncher agents only —
+// cursor/opencode wouldn't reach promptForAgentsFn at all. Using
+// claude-code/codex (HeadlessLauncher) fires the picker, then the picker
+// callback cancels the shared context so the downstream single-agent spawn
+// aborts immediately (rather than actually running an agent). We assert on
+// runMultiAgentFn NOT being called rather than on marker state, since the
+// spawn-failure defer clears the marker anyway.
+func TestPromptForAgents_SingleSelectionFallsBackToSingleAgent(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, testAgentName)
+	installHooksForTest(t, testCodexAgent)
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testAgentName:  {Prompt: "review"},
+		testCodexAgent: {Prompt: "review"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancellable context so the single-agent fallback's spawn is aborted
+	// before it actually runs the agent. The picker callback cancels right
+	// after it returns a single selection.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	promptCalled := false
+	multiCalled := false
+	deps := runReviewDeps{
+		promptForAgentsFn: func(_ context.Context, eligible []agentChoice) ([]string, error) {
+			promptCalled = true
+			// Cancel so the single-agent fallback's exec.CommandContext
+			// is already cancelled when Run() fires — exits immediately
+			// instead of running a real agent.
+			cancel()
+			// Return just one — single-agent fallback expected.
+			return []string{eligible[0].Name}, nil
+		},
+		runMultiAgentFn: func(_ context.Context, _ []MultiAgentTask, _ io.Writer) (MultiRunResult, error) {
+			multiCalled = true
+			return MultiRunResult{}, nil
+		},
+	}
+
+	reviewCmd := newReviewCmdWithDeps(deps)
+	// The final error is expected (the single-agent fallback's spawn is
+	// cancelled via the shared ctx). What matters for dispatch is the call
+	// sites below — if execute unexpectedly succeeds, that's fine too.
+	if err := reviewCmd.ExecuteContext(ctx); err != nil {
+		t.Logf("execute (ctx-cancelled, expected): %v", err)
+	}
+
+	if !promptCalled {
+		t.Error("promptForAgentsFn should have been called")
+	}
+	if multiCalled {
+		t.Error("runMultiAgentFn should NOT have been called for single-selection fallback")
+	}
+}
+
+// TestPromptForAgents_EmptySelectionCancels pins that returning [] from the
+// multi-select picker is treated as user cancel — silent error, no marker
+// written, no orchestrator call.
+func TestPromptForAgents_EmptySelectionCancels(t *testing.T) {
+	setupReviewTestRepoWithCommit(t)
+	installHooksForTest(t, testAgentName)
+	installHooksForTest(t, testCodexAgent)
+
+	if err := saveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testAgentName:  {Prompt: "review"},
+		testCodexAgent: {Prompt: "review"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	multiCalled := false
+	deps := runReviewDeps{
+		promptForAgentsFn: func(_ context.Context, _ []agentChoice) ([]string, error) {
+			return []string{}, nil // empty = cancel
+		},
+		runMultiAgentFn: func(_ context.Context, _ []MultiAgentTask, _ io.Writer) (MultiRunResult, error) {
+			multiCalled = true
+			return MultiRunResult{}, nil
+		},
+	}
+
+	reviewCmd := newReviewCmdWithDeps(deps)
+	err := reviewCmd.Execute()
+	if err == nil {
+		t.Fatal("expected silent cancel error, got nil")
+	}
+	if multiCalled {
+		t.Error("runMultiAgentFn should NOT have been called after user cancel")
+	}
+	_, markerExists, readErr := ReadPendingReviewMarker(context.Background())
+	if readErr != nil {
+		t.Fatalf("ReadPendingReviewMarker: %v", readErr)
+	}
+	if markerExists {
+		t.Error("marker should not have been written on cancel")
 	}
 }

--- a/cmd/entire/cli/review_tui.go
+++ b/cmd/entire/cli/review_tui.go
@@ -1,0 +1,284 @@
+package cli
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// reviewTUIModel renders the multi-agent status table: one row per agent
+// with spinner, status, duration, token usage, and a faint preview line.
+// The model is a pure tea.Model — orchestration and subprocess wiring live
+// in review_multi.go, which posts agentStateMsg / agentPreviewMsg as the
+// underlying agents progress.
+//
+// On every row reaching a terminal state (Done, Failed, or Cancelled),
+// Update returns tea.Quit so the program exits and the caller can dump
+// full final responses.
+type reviewTUIModel struct {
+	tasks      []MultiAgentTask
+	rows       []rowState
+	spinner    spinner.Model
+	startTime  time.Time
+	termWidth  int
+	allDone    bool
+	cancelling bool
+}
+
+// rowState is the per-agent render state. Mutated only from Update via the
+// incoming tea messages — never shared with orchestrator goroutines.
+type rowState struct {
+	name     string
+	status   AgentRunStatus
+	duration time.Duration
+	tokens   int
+	preview  string
+	exitCode int
+}
+
+// agentStateMsg is posted by the orchestrator when an agent transitions
+// between lifecycle states (queued → running → done/failed/cancelled) or
+// when token usage becomes known after exit.
+type agentStateMsg struct {
+	Name     string
+	Status   AgentRunStatus
+	Duration time.Duration
+	ExitCode int
+	Tokens   int
+}
+
+// agentPreviewMsg is posted (rate-limited by the teeWriter) when an agent
+// emits a new non-empty stdout line. The model ANSI-strips and width-
+// truncates before rendering.
+type agentPreviewMsg struct {
+	Name string
+	Line string
+}
+
+// cancelMsg toggles the "cancelling" banner. The orchestrator posts it
+// when it starts to SIGTERM subprocesses after a user Ctrl+C.
+type cancelMsg struct{}
+
+// tickMsg fires every 100ms; drives per-row duration counters for rows
+// still in AgentRunRunning. Avoids the need for the orchestrator to push
+// periodic state updates just for the timer.
+type tickMsg time.Time
+
+// ansiRe matches standard CSI escape sequences. Agent stdout is rarely
+// colored but users can pipe through `--color=always` wrappers — strip
+// them so the TUI's own styling remains consistent.
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// stripANSI removes CSI color codes from s so preview lines don't inject
+// escape sequences into the TUI render.
+func stripANSI(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
+
+// newReviewTUIModel constructs a model pre-populated with one queued row
+// per task. Callers pass the same task list they'll hand the orchestrator,
+// so row names line up with the agentStateMsg.Name values posted later.
+func newReviewTUIModel(tasks []MultiAgentTask) reviewTUIModel {
+	rows := make([]rowState, len(tasks))
+	for i, t := range tasks {
+		rows[i] = rowState{name: t.Name, status: AgentRunQueued}
+	}
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	return reviewTUIModel{
+		tasks:     tasks,
+		rows:      rows,
+		spinner:   sp,
+		startTime: time.Now(),
+		termWidth: 80,
+	}
+}
+
+// Init kicks off the spinner animation and the duration-tick timer.
+func (m reviewTUIModel) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, tickEvery())
+}
+
+// tickEvery schedules the next tickMsg 100ms in the future. Update
+// re-schedules itself in response to each tickMsg it receives.
+func tickEvery() tea.Cmd {
+	return tea.Tick(100*time.Millisecond, func(t time.Time) tea.Msg { return tickMsg(t) })
+}
+
+// Update handles all model messages. Mutates m by value (tea.Model
+// contract) and returns the updated model plus any follow-up commands.
+//
+//nolint:ireturn // tea.Model interface contract — bubbletea requires returning the interface.
+func (m reviewTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.termWidth = msg.Width
+	case agentStateMsg:
+		for i, r := range m.rows {
+			if r.name == msg.Name {
+				m.rows[i].status = msg.Status
+				if msg.Duration > 0 {
+					m.rows[i].duration = msg.Duration
+				}
+				m.rows[i].exitCode = msg.ExitCode
+				m.rows[i].tokens = msg.Tokens
+				break
+			}
+		}
+		if m.allRowsTerminal() {
+			m.allDone = true
+			return m, tea.Quit
+		}
+	case agentPreviewMsg:
+		for i, r := range m.rows {
+			if r.name == msg.Name {
+				m.rows[i].preview = truncatePreview(msg.Line, m.termWidth)
+				break
+			}
+		}
+	case cancelMsg:
+		m.cancelling = true
+	case tickMsg:
+		now := time.Now()
+		for i, r := range m.rows {
+			if r.status == AgentRunRunning {
+				m.rows[i].duration = now.Sub(m.startTime)
+			}
+		}
+		return m, tickEvery()
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+// truncatePreview ANSI-strips line then trims to fit terminal width minus
+// the row-prefix padding. A 20-char floor guards against absurdly narrow
+// terminals where trimming would leave nothing meaningful.
+func truncatePreview(line string, termWidth int) string {
+	stripped := stripANSI(line)
+	maxLine := termWidth - 18
+	if maxLine < 20 {
+		maxLine = 20
+	}
+	if len(stripped) > maxLine {
+		stripped = stripped[:maxLine-1] + "…"
+	}
+	return stripped
+}
+
+// View renders the full status table. Called on every Update cycle.
+func (m reviewTUIModel) View() string {
+	var sb strings.Builder
+	sb.WriteString("Running ")
+	fmt.Fprintf(&sb, "%d agents — Ctrl+C to cancel all\n\n", len(m.rows))
+	if m.cancelling {
+		sb.WriteString("Cancelling — sending SIGTERM to subprocesses…\n\n")
+	}
+	sb.WriteString(strings.Repeat("─", 44) + "\n")
+	for _, r := range m.rows {
+		icon := rowIcon(r.status, m.spinner.View())
+		status := statusString(r.status)
+		dur := formatDuration(r.duration)
+		tok := "—"
+		if r.tokens > 0 {
+			tok = fmt.Sprintf("%dk", r.tokens/1000)
+		}
+		line := fmt.Sprintf("  %s  %-15s %-10s %7s  %5s\n",
+			icon, r.name, status, dur, tok)
+		sb.WriteString(line)
+		if r.preview != "" {
+			sb.WriteString("       ")
+			sb.WriteString(lipgloss.NewStyle().Faint(true).Render("… " + r.preview))
+			sb.WriteString("\n")
+		}
+	}
+	sb.WriteString(strings.Repeat("─", 44) + "\n")
+	completed := 0
+	for _, r := range m.rows {
+		if isTerminalStatus(r.status) {
+			completed++
+		}
+	}
+	fmt.Fprintf(&sb, "%d of %d complete\n", completed, len(m.rows))
+	return sb.String()
+}
+
+// allRowsTerminal returns true iff every row has a final status. Used to
+// decide when to emit tea.Quit.
+func (m reviewTUIModel) allRowsTerminal() bool {
+	for _, r := range m.rows {
+		if !isTerminalStatus(r.status) {
+			return false
+		}
+	}
+	return true
+}
+
+// isTerminalStatus reports whether an agent run has reached an endpoint
+// (Done, Failed, or Cancelled) and will not transition further.
+func isTerminalStatus(s AgentRunStatus) bool {
+	switch s {
+	case AgentRunDone, AgentRunFailed, AgentRunCancelled:
+		return true
+	case AgentRunQueued, AgentRunRunning:
+		return false
+	}
+	return false
+}
+
+// rowIcon maps a status to its leading glyph; running rows render the
+// live spinner character.
+func rowIcon(status AgentRunStatus, spin string) string {
+	switch status {
+	case AgentRunDone:
+		return "✓"
+	case AgentRunFailed:
+		return "✗"
+	case AgentRunCancelled:
+		return "⊘"
+	case AgentRunRunning:
+		return spin
+	case AgentRunQueued:
+		return " "
+	}
+	return " "
+}
+
+// statusString maps a status to a short lowercase label shown in the row.
+func statusString(status AgentRunStatus) string {
+	switch status {
+	case AgentRunDone:
+		return "done"
+	case AgentRunFailed:
+		return "failed"
+	case AgentRunCancelled:
+		return "cancelled"
+	case AgentRunRunning:
+		return "running"
+	case AgentRunQueued:
+		return "queued"
+	}
+	return "queued"
+}
+
+// formatDuration renders a duration as "Ns" under a minute, "Nm Ms"
+// beyond. Zero duration renders as an em-dash so queued rows show blank-
+// ish rather than "0s".
+func formatDuration(d time.Duration) string {
+	if d == 0 {
+		return "—"
+	}
+	s := int(d.Seconds())
+	if s < 60 {
+		return fmt.Sprintf("%ds", s)
+	}
+	return fmt.Sprintf("%dm %ds", s/60, s%60)
+}

--- a/cmd/entire/cli/review_tui.go
+++ b/cmd/entire/cli/review_tui.go
@@ -87,10 +87,11 @@ type cancelMsg struct{}
 // periodic state updates just for the timer.
 type tickMsg time.Time
 
-// ansiRe matches standard CSI escape sequences. Agent stdout is rarely
-// colored but users can pipe through `--color=always` wrappers — strip
-// them so the TUI's own styling remains consistent.
-var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+// ansiRe matches standard CSI escape sequences, including private-mode
+// forms like `\x1b[?25l` (cursor hide) that codex uses. Agent stdout is
+// rarely colored but users can pipe through `--color=always` wrappers —
+// strip them so the TUI's own styling remains consistent.
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;?]*[a-zA-Z]`)
 
 // stripANSI removes CSI color codes from s so preview lines don't inject
 // escape sequences into the TUI render.
@@ -157,6 +158,10 @@ func (m reviewTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch msg.Type { //nolint:exhaustive // only navigation keys matter in detail mode; every other key is a no-op
 			case tea.KeyEsc:
 				m.detailMode = false
+				// Exit alt-screen so the dashboard re-renders over the
+				// primary screen buffer, leaving the drill-in history out
+				// of terminal scrollback.
+				return m, tea.ExitAltScreen
 			case tea.KeyCtrlO, tea.KeyRight:
 				m.detailIdx = (m.detailIdx + 1) % len(m.tasks)
 				m.detailScroll = 0
@@ -174,12 +179,14 @@ func (m reviewTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Dashboard: Ctrl+O enters the drill-in view. Requires buffers
 		// to be wired — without them the detail view has nothing to
-		// render.
+		// render. Enter alt-screen so the full-screen transcript view
+		// doesn't leave scrollback artifacts when the buffer grows mid-
+		// view; dashboard stays on the primary screen.
 		if msg.Type == tea.KeyCtrlO && len(m.buffers) > 0 {
 			m.detailMode = true
 			m.detailIdx = 0
 			m.detailScroll = 0
-			return m, nil
+			return m, tea.EnterAltScreen
 		}
 		// Ctrl+C (or 'q') flips the cancelling banner immediately for
 		// user feedback and fires the orchestrator-supplied cancel hook.
@@ -332,12 +339,30 @@ func (m reviewTUIModel) detailView() string {
 		end = start
 	}
 
+	maxLineWidth := m.termWidth
+	if maxLineWidth < 20 {
+		maxLineWidth = 20
+	}
+
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "< %s > (agent %d of %d) — Esc: back | ←/→: switch | ↑/↓: scroll\n",
 		task.Name, m.detailIdx+1, len(m.tasks))
-	sb.WriteString(strings.Repeat("─", 60) + "\n")
+	sb.WriteString(strings.Repeat("─", min(60, maxLineWidth)) + "\n")
+	rendered := 0
 	for _, line := range lines[start:end] {
+		// Truncate wide lines so they can't wrap and throw off bubbletea's
+		// frame-line count. Scroll with ↑/↓ if you need to see the tail.
+		if len(line) > maxLineWidth {
+			line = line[:maxLineWidth-1] + "…"
+		}
 		sb.WriteString(line + "\n")
+		rendered++
+	}
+	// Pad to fixed viewport height so every frame returns the same line
+	// count — required for bubbletea's inline frame diff (even in alt-
+	// screen, a stable line count avoids repaint flicker).
+	for i := rendered; i < viewport; i++ {
+		sb.WriteByte('\n')
 	}
 	return sb.String()
 }

--- a/cmd/entire/cli/review_tui.go
+++ b/cmd/entire/cli/review_tui.go
@@ -26,6 +26,7 @@ type reviewTUIModel struct {
 	spinner    spinner.Model
 	startTime  time.Time
 	termWidth  int
+	termHeight int
 	allDone    bool
 	cancelling bool
 	// onCancel, if non-nil, is invoked the first time the user triggers
@@ -34,6 +35,17 @@ type reviewTUIModel struct {
 	// still tears down subprocesses — bubbletea intercepts byte 0x03 before
 	// it can reach the orchestrator's signal.Notify handler.
 	onCancel func()
+	// buffers holds one shared tee-buffer per task, aligned with tasks by
+	// index. The TUI snapshots the active agent's buffer on every repaint
+	// while detailMode is on. nil when cancellation/test harnesses don't
+	// need drill-in.
+	buffers []*agentBuffer
+	// detailMode toggles the full-screen transcript view entered via
+	// Ctrl+O. While on, arrow keys navigate between agents and scroll the
+	// buffer; Esc returns to the dashboard.
+	detailMode   bool
+	detailIdx    int
+	detailScroll int
 }
 
 // rowState is the per-agent render state. Mutated only from Update via the
@@ -92,7 +104,9 @@ func stripANSI(s string) string {
 // onCancel, if non-nil, is invoked the first time the user presses Ctrl+C
 // or 'q' inside the TUI so the orchestrator can tear down subprocesses.
 // Pass nil when cancellation wiring isn't needed (e.g. in unit tests).
-func newReviewTUIModel(tasks []MultiAgentTask, onCancel func()) reviewTUIModel {
+// buffers, when non-nil, enables the Ctrl+O drill-in: one entry per task,
+// aligned by index, sharing the same tees the orchestrator feeds.
+func newReviewTUIModel(tasks []MultiAgentTask, onCancel func(), buffers []*agentBuffer) reviewTUIModel {
 	rows := make([]rowState, len(tasks))
 	for i, t := range tasks {
 		rows[i] = rowState{name: t.Name, status: AgentRunQueued}
@@ -100,12 +114,14 @@ func newReviewTUIModel(tasks []MultiAgentTask, onCancel func()) reviewTUIModel {
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
 	return reviewTUIModel{
-		tasks:     tasks,
-		rows:      rows,
-		spinner:   sp,
-		startTime: time.Now(),
-		termWidth: 80,
-		onCancel:  onCancel,
+		tasks:      tasks,
+		rows:       rows,
+		spinner:    sp,
+		startTime:  time.Now(),
+		termWidth:  80,
+		termHeight: 24,
+		onCancel:   onCancel,
+		buffers:    buffers,
 	}
 }
 
@@ -128,7 +144,43 @@ func (m reviewTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.termWidth = msg.Width
+		m.termHeight = msg.Height
 	case tea.KeyMsg:
+		// Detail-mode key handling is a separate state: arrow keys
+		// navigate + scroll, Esc exits, Ctrl+O cycles agents. Ctrl+C is
+		// deliberately ignored here — the user must Esc back to the
+		// dashboard before cancelling so they don't accidentally kill a
+		// run while scrolling. Guarded on len(m.tasks) > 0 so an empty
+		// task list (defensive — shouldn't occur in practice) can't hit
+		// a modulo-by-zero panic.
+		if m.detailMode && len(m.tasks) > 0 {
+			switch msg.Type { //nolint:exhaustive // only navigation keys matter in detail mode; every other key is a no-op
+			case tea.KeyEsc:
+				m.detailMode = false
+			case tea.KeyCtrlO, tea.KeyRight:
+				m.detailIdx = (m.detailIdx + 1) % len(m.tasks)
+				m.detailScroll = 0
+			case tea.KeyLeft:
+				m.detailIdx = (m.detailIdx - 1 + len(m.tasks)) % len(m.tasks)
+				m.detailScroll = 0
+			case tea.KeyUp:
+				m.detailScroll++
+			case tea.KeyDown:
+				if m.detailScroll > 0 {
+					m.detailScroll--
+				}
+			}
+			return m, nil
+		}
+		// Dashboard: Ctrl+O enters the drill-in view. Requires buffers
+		// to be wired — without them the detail view has nothing to
+		// render.
+		if msg.Type == tea.KeyCtrlO && len(m.buffers) > 0 {
+			m.detailMode = true
+			m.detailIdx = 0
+			m.detailScroll = 0
+			return m, nil
+		}
 		// Ctrl+C (or 'q') flips the cancelling banner immediately for
 		// user feedback and fires the orchestrator-supplied cancel hook.
 		// The hook must be called from here — bubbletea puts the terminal
@@ -200,10 +252,14 @@ func truncatePreview(line string, termWidth int) string {
 }
 
 // View renders the full status table. Called on every Update cycle.
+// Dispatches to detailView when the Ctrl+O drill-in is active.
 func (m reviewTUIModel) View() string {
+	if m.detailMode {
+		return m.detailView()
+	}
 	var sb strings.Builder
 	sb.WriteString("Running ")
-	fmt.Fprintf(&sb, "%d agents — Ctrl+C to cancel all\n\n", len(m.rows))
+	fmt.Fprintf(&sb, "%d agents — Ctrl+C to cancel · Ctrl+O to view agent\n\n", len(m.rows))
 	if m.cancelling {
 		sb.WriteString("Cancelling — sending SIGTERM to subprocesses…\n\n")
 	}
@@ -233,6 +289,56 @@ func (m reviewTUIModel) View() string {
 		}
 	}
 	fmt.Fprintf(&sb, "%d of %d complete\n", completed, len(m.rows))
+	return sb.String()
+}
+
+// detailView renders a full-screen, scrollable slice of the active
+// agent's stdout buffer. The header shows the agent name, position in
+// the list, and available keybindings. Scroll offset counts lines back
+// from the newest: detailScroll=0 pins the tail (the most recent output),
+// positive values page upward through history.
+func (m reviewTUIModel) detailView() string {
+	task := m.tasks[m.detailIdx]
+	var data []byte
+	if m.detailIdx < len(m.buffers) && m.buffers[m.detailIdx] != nil {
+		data = m.buffers[m.detailIdx].Snapshot()
+	}
+	lines := strings.Split(stripANSI(string(data)), "\n")
+
+	viewport := m.termHeight - 3
+	if viewport < 5 {
+		viewport = 5
+	}
+
+	// Clamp scroll so pressing Up past the top of the buffer doesn't
+	// leave start/end inverted.
+	maxScroll := len(lines) - viewport
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.detailScroll > maxScroll {
+		m.detailScroll = maxScroll
+	}
+
+	end := len(lines) - m.detailScroll
+	if end > len(lines) {
+		end = len(lines)
+	}
+	start := end - viewport
+	if start < 0 {
+		start = 0
+	}
+	if end < start {
+		end = start
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "< %s > (agent %d of %d) — Esc: back | ←/→: switch | ↑/↓: scroll\n",
+		task.Name, m.detailIdx+1, len(m.tasks))
+	sb.WriteString(strings.Repeat("─", 60) + "\n")
+	for _, line := range lines[start:end] {
+		sb.WriteString(line + "\n")
+	}
 	return sb.String()
 }
 

--- a/cmd/entire/cli/review_tui.go
+++ b/cmd/entire/cli/review_tui.go
@@ -28,6 +28,12 @@ type reviewTUIModel struct {
 	termWidth  int
 	allDone    bool
 	cancelling bool
+	// onCancel, if non-nil, is invoked the first time the user triggers
+	// cancellation from within the TUI (Ctrl+C or 'q'). The orchestrator
+	// wires this to its runCtx cancel function so raw-mode-captured Ctrl+C
+	// still tears down subprocesses — bubbletea intercepts byte 0x03 before
+	// it can reach the orchestrator's signal.Notify handler.
+	onCancel func()
 }
 
 // rowState is the per-agent render state. Mutated only from Update via the
@@ -83,7 +89,10 @@ func stripANSI(s string) string {
 // newReviewTUIModel constructs a model pre-populated with one queued row
 // per task. Callers pass the same task list they'll hand the orchestrator,
 // so row names line up with the agentStateMsg.Name values posted later.
-func newReviewTUIModel(tasks []MultiAgentTask) reviewTUIModel {
+// onCancel, if non-nil, is invoked the first time the user presses Ctrl+C
+// or 'q' inside the TUI so the orchestrator can tear down subprocesses.
+// Pass nil when cancellation wiring isn't needed (e.g. in unit tests).
+func newReviewTUIModel(tasks []MultiAgentTask, onCancel func()) reviewTUIModel {
 	rows := make([]rowState, len(tasks))
 	for i, t := range tasks {
 		rows[i] = rowState{name: t.Name, status: AgentRunQueued}
@@ -96,6 +105,7 @@ func newReviewTUIModel(tasks []MultiAgentTask) reviewTUIModel {
 		spinner:   sp,
 		startTime: time.Now(),
 		termWidth: 80,
+		onCancel:  onCancel,
 	}
 }
 
@@ -118,6 +128,21 @@ func (m reviewTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.termWidth = msg.Width
+	case tea.KeyMsg:
+		// Ctrl+C (or 'q') flips the cancelling banner immediately for
+		// user feedback and fires the orchestrator-supplied cancel hook.
+		// The hook must be called from here — bubbletea puts the terminal
+		// in raw mode, so byte 0x03 is captured as a KeyMsg and never
+		// reaches the OS as SIGINT. The orchestrator's signal.Notify
+		// handler therefore never fires for in-TUI Ctrl+C; we have to
+		// cancel runCtx directly via m.onCancel. Guarded on !m.cancelling
+		// so repeat key presses don't re-fire the hook.
+		if msg.Type == tea.KeyCtrlC || msg.String() == "q" {
+			if !m.cancelling && m.onCancel != nil {
+				m.onCancel()
+			}
+			m.cancelling = true
+		}
 	case agentStateMsg:
 		for i, r := range m.rows {
 			if r.name == msg.Name {

--- a/cmd/entire/cli/review_tui.go
+++ b/cmd/entire/cli/review_tui.go
@@ -9,6 +9,8 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/entireio/cli/cmd/entire/cli/stringutil"
 )
 
 // reviewTUIModel renders the multi-agent status table: one row per agent
@@ -257,17 +259,17 @@ func (m reviewTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // truncatePreview ANSI-strips line then trims to fit terminal width minus
 // the row-prefix padding. A 20-char floor guards against absurdly narrow
-// terminals where trimming would leave nothing meaningful.
+// terminals where trimming would leave nothing meaningful. Rune-based
+// truncation via stringutil.TruncateRunes keeps multi-byte UTF-8 (e.g.
+// non-ASCII narrative output from codex/gemini) from being split mid-
+// rune, which would otherwise emit invalid bytes into the TUI render.
 func truncatePreview(line string, termWidth int) string {
 	stripped := stripANSI(line)
 	maxLine := termWidth - 18
 	if maxLine < 20 {
 		maxLine = 20
 	}
-	if len(stripped) > maxLine {
-		stripped = stripped[:maxLine-1] + "…"
-	}
-	return stripped
+	return stringutil.TruncateRunes(stripped, maxLine, "…")
 }
 
 // View renders the full status table. Called on every Update cycle.

--- a/cmd/entire/cli/review_tui.go
+++ b/cmd/entire/cli/review_tui.go
@@ -86,10 +86,6 @@ type agentPreviewMsg struct {
 	Line string
 }
 
-// cancelMsg toggles the "cancelling" banner. The orchestrator posts it
-// when it starts to SIGTERM subprocesses after a user Ctrl+C.
-type cancelMsg struct{}
-
 // tickMsg fires every 100ms; drives per-row duration counters for rows
 // still in AgentRunRunning. Avoids the need for the orchestrator to push
 // periodic state updates just for the timer.
@@ -239,8 +235,6 @@ func (m reviewTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 		}
-	case cancelMsg:
-		m.cancelling = true
 	case tickMsg:
 		now := time.Now()
 		for i, r := range m.rows {

--- a/cmd/entire/cli/review_tui.go
+++ b/cmd/entire/cli/review_tui.go
@@ -57,6 +57,12 @@ type rowState struct {
 	tokens   int
 	preview  string
 	exitCode int
+	// runStart is set when the row transitions to AgentRunRunning and
+	// drives the live duration counter on tickMsg. Using m.startTime
+	// (TUI start) instead inflated durations for agents that started
+	// later — e.g., a second-spawned agent showed time-since-TUI rather
+	// than time-since-its-own-start.
+	runStart time.Time
 }
 
 // agentStateMsg is posted by the orchestrator when an agent transitions
@@ -205,6 +211,12 @@ func (m reviewTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case agentStateMsg:
 		for i, r := range m.rows {
 			if r.name == msg.Name {
+				// Stamp runStart on the queued→running transition so the
+				// live duration counter measures from this agent's actual
+				// launch, not the TUI's startTime.
+				if msg.Status == AgentRunRunning && r.status != AgentRunRunning {
+					m.rows[i].runStart = time.Now()
+				}
 				m.rows[i].status = msg.Status
 				if msg.Duration > 0 {
 					m.rows[i].duration = msg.Duration
@@ -230,8 +242,8 @@ func (m reviewTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		now := time.Now()
 		for i, r := range m.rows {
-			if r.status == AgentRunRunning {
-				m.rows[i].duration = now.Sub(m.startTime)
+			if r.status == AgentRunRunning && !r.runStart.IsZero() {
+				m.rows[i].duration = now.Sub(r.runStart)
 			}
 		}
 		return m, tickEvery()

--- a/cmd/entire/cli/review_tui.go
+++ b/cmd/entire/cli/review_tui.go
@@ -360,9 +360,9 @@ func (m reviewTUIModel) detailView() string {
 	for _, line := range lines[start:end] {
 		// Truncate wide lines so they can't wrap and throw off bubbletea's
 		// frame-line count. Scroll with ↑/↓ if you need to see the tail.
-		if len(line) > maxLineWidth {
-			line = line[:maxLineWidth-1] + "…"
-		}
+		// Rune-based truncation matches the preview path (truncatePreview)
+		// so multi-byte UTF-8 in agent narrative doesn't get split mid-rune.
+		line = stringutil.TruncateRunes(line, maxLineWidth, "…")
 		sb.WriteString(line + "\n")
 		rendered++
 	}

--- a/cmd/entire/cli/review_tui_test.go
+++ b/cmd/entire/cli/review_tui_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/exp/teatest"
+)
+
+// TestTUIModel_InitialViewAllQueued pins that newReviewTUIModel renders all
+// configured agents as "queued" before any state messages arrive.
+func TestTUIModel_InitialViewAllQueued(t *testing.T) {
+	t.Parallel()
+	m := newReviewTUIModel([]MultiAgentTask{
+		{Name: "a"}, {Name: "b"}, {Name: "c"},
+	})
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
+
+	// Force quit quickly so FinalOutput terminates. The model exits on
+	// its own only when all rows are terminal; here we haven't sent any
+	// state msgs, so we need an explicit Quit.
+	if err := tm.Quit(); err != nil {
+		t.Fatalf("Quit: %v", err)
+	}
+	out, readErr := io.ReadAll(tm.FinalOutput(t, teatest.WithFinalTimeout(time.Second)))
+	if readErr != nil {
+		t.Fatalf("read FinalOutput: %v", readErr)
+	}
+	view := string(out)
+	if !strings.Contains(view, "queued") {
+		t.Errorf("initial view should contain 'queued'; got:\n%s", view)
+	}
+	if !strings.Contains(view, "a") || !strings.Contains(view, "b") || !strings.Contains(view, "c") {
+		t.Errorf("initial view should list all 3 agents; got:\n%s", view)
+	}
+}
+
+// TestTUIModel_TransitionsToRunningOnMsg pins that sending an agentStateMsg
+// with Status=AgentRunRunning causes the view to reflect "running".
+func TestTUIModel_TransitionsToRunningOnMsg(t *testing.T) {
+	t.Parallel()
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}})
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
+	tm.Send(agentStateMsg{Name: "a", Status: AgentRunRunning})
+	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
+		return strings.Contains(string(b), "running")
+	}, teatest.WithDuration(time.Second))
+	if err := tm.Quit(); err != nil {
+		t.Fatalf("Quit: %v", err)
+	}
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
+}
+
+// TestTUIModel_DoneQuits pins that once every agent reaches a terminal
+// state, the model returns tea.Quit without an explicit Quit call.
+func TestTUIModel_DoneQuits(t *testing.T) {
+	t.Parallel()
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}})
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
+	tm.Send(agentStateMsg{Name: "a", Status: AgentRunDone, Duration: time.Second})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
+}
+
+// TestTUIModel_PreviewTruncates pins that a preview line longer than the
+// terminal width is truncated in the rendered view.
+func TestTUIModel_PreviewTruncates(t *testing.T) {
+	t.Parallel()
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}})
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(60, 20))
+	longLine := strings.Repeat("x", 300)
+	tm.Send(agentPreviewMsg{Name: "a", Line: longLine})
+	// Drive to a terminal state so the model can exit naturally.
+	tm.Send(agentStateMsg{Name: "a", Status: AgentRunDone})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
+
+	out, readErr := io.ReadAll(tm.FinalOutput(t, teatest.WithFinalTimeout(time.Second)))
+	if readErr != nil {
+		t.Fatalf("read FinalOutput: %v", readErr)
+	}
+	view := string(out)
+	// View must not contain a 100-char unbroken run of 'x' — that would
+	// mean truncation was disabled or mis-sized for the terminal width.
+	if strings.Contains(view, strings.Repeat("x", 100)) {
+		t.Errorf("preview should truncate at terminal width; got:\n%s", view)
+	}
+}

--- a/cmd/entire/cli/review_tui_test.go
+++ b/cmd/entire/cli/review_tui_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 )
 
@@ -15,7 +16,7 @@ func TestTUIModel_InitialViewAllQueued(t *testing.T) {
 	t.Parallel()
 	m := newReviewTUIModel([]MultiAgentTask{
 		{Name: "a"}, {Name: "b"}, {Name: "c"},
-	})
+	}, nil)
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
 
 	// Force quit quickly so FinalOutput terminates. The model exits on
@@ -41,7 +42,7 @@ func TestTUIModel_InitialViewAllQueued(t *testing.T) {
 // with Status=AgentRunRunning causes the view to reflect "running".
 func TestTUIModel_TransitionsToRunningOnMsg(t *testing.T) {
 	t.Parallel()
-	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}})
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil)
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
 	tm.Send(agentStateMsg{Name: "a", Status: AgentRunRunning})
 	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
@@ -57,7 +58,7 @@ func TestTUIModel_TransitionsToRunningOnMsg(t *testing.T) {
 // state, the model returns tea.Quit without an explicit Quit call.
 func TestTUIModel_DoneQuits(t *testing.T) {
 	t.Parallel()
-	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}})
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil)
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
 	tm.Send(agentStateMsg{Name: "a", Status: AgentRunDone, Duration: time.Second})
 	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
@@ -67,7 +68,7 @@ func TestTUIModel_DoneQuits(t *testing.T) {
 // terminal width is truncated in the rendered view.
 func TestTUIModel_PreviewTruncates(t *testing.T) {
 	t.Parallel()
-	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}})
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil)
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(60, 20))
 	longLine := strings.Repeat("x", 300)
 	tm.Send(agentPreviewMsg{Name: "a", Line: longLine})
@@ -84,5 +85,24 @@ func TestTUIModel_PreviewTruncates(t *testing.T) {
 	// mean truncation was disabled or mis-sized for the terminal width.
 	if strings.Contains(view, strings.Repeat("x", 100)) {
 		t.Errorf("preview should truncate at terminal width; got:\n%s", view)
+	}
+}
+
+// TestTUIModel_KeyCtrlCCallsOnCancel pins the fix for the raw-mode Ctrl+C
+// bug: when bubbletea delivers KeyCtrlC to the model, the onCancel hook
+// must fire so the orchestrator can tear down subprocesses. Without this,
+// Ctrl+C only flips the banner and the subprocesses keep running because
+// the terminal swallowed the 0x03 byte before it could become a SIGINT.
+func TestTUIModel_KeyCtrlCCallsOnCancel(t *testing.T) {
+	t.Parallel()
+	called := false
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, func() { called = true })
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
+	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+	// Send a terminal state so the model quits and the test finishes.
+	tm.Send(agentStateMsg{Name: "a", Status: AgentRunCancelled, Duration: time.Second})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(500*time.Millisecond))
+	if !called {
+		t.Error("onCancel was not called on Ctrl+C")
 	}
 }

--- a/cmd/entire/cli/review_tui_test.go
+++ b/cmd/entire/cli/review_tui_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
@@ -197,6 +198,26 @@ func TestTUIModel_KeyCtrlCCallsOnCancel(t *testing.T) {
 	tm.WaitFinished(t, teatest.WithFinalTimeout(500*time.Millisecond))
 	if !called {
 		t.Error("onCancel was not called on Ctrl+C")
+	}
+}
+
+// TestTruncatePreview_RuneSafe pins that multi-byte UTF-8 input doesn't
+// get split mid-rune. The previous byte-slice implementation could
+// truncate inside a multi-byte sequence and emit an invalid UTF-8 byte
+// followed by the ellipsis, which broke TUI rendering for non-ASCII
+// narrative output (e.g., codex output containing em-dashes or
+// CJK characters).
+func TestTruncatePreview_RuneSafe(t *testing.T) {
+	t.Parallel()
+	// 100 em-dashes (3 bytes each in UTF-8) — any byte-aligned slice
+	// that doesn't land on a rune boundary corrupts the output.
+	in := strings.Repeat("—", 100)
+	got := truncatePreview(in, 60)
+	if !utf8.ValidString(got) {
+		t.Errorf("truncatePreview produced invalid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis suffix on truncated output; got %q", got)
 	}
 }
 

--- a/cmd/entire/cli/review_tui_test.go
+++ b/cmd/entire/cli/review_tui_test.go
@@ -227,16 +227,28 @@ func TestTruncatePreview_RuneSafe(t *testing.T) {
 // durations on every tick.
 func TestTUIModel_TickUsesPerRowRunStart(t *testing.T) {
 	t.Parallel()
+	// asReviewTUIModel asserts the type or fails the test loudly — Update
+	// returns tea.Model (interface) but reviewTUIModel is the only
+	// concrete type the model returns from itself, so a panic here would
+	// indicate a real regression worth exposing as a test failure.
+	asReviewTUIModel := func(m tea.Model) reviewTUIModel {
+		t.Helper()
+		concrete, ok := m.(reviewTUIModel)
+		if !ok {
+			t.Fatalf("Update returned %T, want reviewTUIModel", m)
+		}
+		return concrete
+	}
+
 	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}, {Name: "b"}}, nil, nil)
 	// Pretend the TUI started 10 minutes ago — that's the upper bound
 	// the buggy implementation would report; with the fix, durations
 	// reflect the per-row runStart we set just now.
 	m.startTime = time.Now().Add(-10 * time.Minute)
-	updated, _ := m.Update(agentStateMsg{Name: "a", Status: AgentRunRunning})
-	updated, _ = updated.(reviewTUIModel).Update(agentStateMsg{Name: "b", Status: AgentRunRunning})
-	updated, _ = updated.(reviewTUIModel).Update(tickMsg(time.Now()))
-	final := updated.(reviewTUIModel)
-	for _, r := range final.rows {
+	step1, _ := m.Update(agentStateMsg{Name: "a", Status: AgentRunRunning})
+	step2, _ := asReviewTUIModel(step1).Update(agentStateMsg{Name: "b", Status: AgentRunRunning})
+	step3, _ := asReviewTUIModel(step2).Update(tickMsg(time.Now()))
+	for _, r := range asReviewTUIModel(step3).rows {
 		if r.duration > time.Second {
 			t.Errorf("row %s duration = %s; should be near-zero (since runStart was set this tick), not relative to TUI startTime", r.name, r.duration)
 		}

--- a/cmd/entire/cli/review_tui_test.go
+++ b/cmd/entire/cli/review_tui_test.go
@@ -199,3 +199,25 @@ func TestTUIModel_KeyCtrlCCallsOnCancel(t *testing.T) {
 		t.Error("onCancel was not called on Ctrl+C")
 	}
 }
+
+// TestTUIModel_TickUsesPerRowRunStart pins that the running-row duration
+// counter measures from each agent's own runStart, not the TUI's
+// startTime — otherwise late-starting agents would render inflated
+// durations on every tick.
+func TestTUIModel_TickUsesPerRowRunStart(t *testing.T) {
+	t.Parallel()
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}, {Name: "b"}}, nil, nil)
+	// Pretend the TUI started 10 minutes ago — that's the upper bound
+	// the buggy implementation would report; with the fix, durations
+	// reflect the per-row runStart we set just now.
+	m.startTime = time.Now().Add(-10 * time.Minute)
+	updated, _ := m.Update(agentStateMsg{Name: "a", Status: AgentRunRunning})
+	updated, _ = updated.(reviewTUIModel).Update(agentStateMsg{Name: "b", Status: AgentRunRunning})
+	updated, _ = updated.(reviewTUIModel).Update(tickMsg(time.Now()))
+	final := updated.(reviewTUIModel)
+	for _, r := range final.rows {
+		if r.duration > time.Second {
+			t.Errorf("row %s duration = %s; should be near-zero (since runStart was set this tick), not relative to TUI startTime", r.name, r.duration)
+		}
+	}
+}

--- a/cmd/entire/cli/review_tui_test.go
+++ b/cmd/entire/cli/review_tui_test.go
@@ -16,7 +16,7 @@ func TestTUIModel_InitialViewAllQueued(t *testing.T) {
 	t.Parallel()
 	m := newReviewTUIModel([]MultiAgentTask{
 		{Name: "a"}, {Name: "b"}, {Name: "c"},
-	}, nil)
+	}, nil, nil)
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
 
 	// Force quit quickly so FinalOutput terminates. The model exits on
@@ -42,7 +42,7 @@ func TestTUIModel_InitialViewAllQueued(t *testing.T) {
 // with Status=AgentRunRunning causes the view to reflect "running".
 func TestTUIModel_TransitionsToRunningOnMsg(t *testing.T) {
 	t.Parallel()
-	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil)
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil, nil)
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
 	tm.Send(agentStateMsg{Name: "a", Status: AgentRunRunning})
 	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
@@ -58,7 +58,7 @@ func TestTUIModel_TransitionsToRunningOnMsg(t *testing.T) {
 // state, the model returns tea.Quit without an explicit Quit call.
 func TestTUIModel_DoneQuits(t *testing.T) {
 	t.Parallel()
-	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil)
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil, nil)
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
 	tm.Send(agentStateMsg{Name: "a", Status: AgentRunDone, Duration: time.Second})
 	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second))
@@ -68,7 +68,7 @@ func TestTUIModel_DoneQuits(t *testing.T) {
 // terminal width is truncated in the rendered view.
 func TestTUIModel_PreviewTruncates(t *testing.T) {
 	t.Parallel()
-	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil)
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil, nil)
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(60, 20))
 	longLine := strings.Repeat("x", 300)
 	tm.Send(agentPreviewMsg{Name: "a", Line: longLine})
@@ -88,6 +88,99 @@ func TestTUIModel_PreviewTruncates(t *testing.T) {
 	}
 }
 
+// TestTUIModel_CtrlOEntersDetailMode pins that Ctrl+O switches the TUI
+// into the full-screen drill-in view and renders the active agent's
+// buffered stdout.
+func TestTUIModel_CtrlOEntersDetailMode(t *testing.T) {
+	t.Parallel()
+	buf := &agentBuffer{}
+	if _, err := buf.Write([]byte("some content\n")); err != nil {
+		t.Fatalf("buf.Write: %v", err)
+	}
+	m := newReviewTUIModel(
+		[]MultiAgentTask{{Name: "a"}},
+		nil,
+		[]*agentBuffer{buf},
+	)
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
+	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlO})
+	tm.Send(agentStateMsg{Name: "a", Status: AgentRunDone, Duration: time.Second})
+	out, readErr := io.ReadAll(tm.FinalOutput(t, teatest.WithFinalTimeout(500*time.Millisecond)))
+	if readErr != nil {
+		t.Fatalf("read FinalOutput: %v", readErr)
+	}
+	view := string(out)
+	if !strings.Contains(view, "agent 1 of 1") {
+		t.Errorf("expected detail view header; got:\n%s", view)
+	}
+	if !strings.Contains(view, "some content") {
+		t.Errorf("expected buffer content in detail view; got:\n%s", view)
+	}
+}
+
+// TestTUIModel_EscExitsDetailMode pins that Esc returns the TUI to the
+// dashboard. After Esc the final repaint must be in dashboard format
+// (the "N of M complete" footer), not the detail-mode header.
+func TestTUIModel_EscExitsDetailMode(t *testing.T) {
+	t.Parallel()
+	buf := &agentBuffer{}
+	if _, err := buf.Write([]byte("content\n")); err != nil {
+		t.Fatalf("buf.Write: %v", err)
+	}
+	m := newReviewTUIModel(
+		[]MultiAgentTask{{Name: "a"}},
+		nil,
+		[]*agentBuffer{buf},
+	)
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
+	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlO})
+	tm.Send(tea.KeyMsg{Type: tea.KeyEsc})
+	tm.Send(agentStateMsg{Name: "a", Status: AgentRunDone, Duration: time.Second})
+	out, readErr := io.ReadAll(tm.FinalOutput(t, teatest.WithFinalTimeout(500*time.Millisecond)))
+	if readErr != nil {
+		t.Fatalf("read FinalOutput: %v", readErr)
+	}
+	view := string(out)
+	if strings.Contains(view, "agent 1 of 1") {
+		t.Errorf("detail header should not be in final output after Esc; got:\n%s", view)
+	}
+	if !strings.Contains(view, "1 of 1 complete") {
+		t.Errorf("dashboard footer missing after Esc; got:\n%s", view)
+	}
+}
+
+// TestTUIModel_RightArrowSwitchesAgent pins that Right arrow in detail
+// mode advances detailIdx so the next agent's buffer is rendered.
+func TestTUIModel_RightArrowSwitchesAgent(t *testing.T) {
+	t.Parallel()
+	bufA := &agentBuffer{}
+	if _, err := bufA.Write([]byte("A-content\n")); err != nil {
+		t.Fatalf("bufA.Write: %v", err)
+	}
+	bufB := &agentBuffer{}
+	if _, err := bufB.Write([]byte("B-content\n")); err != nil {
+		t.Fatalf("bufB.Write: %v", err)
+	}
+	m := newReviewTUIModel(
+		[]MultiAgentTask{{Name: "a"}, {Name: "b"}},
+		nil,
+		[]*agentBuffer{bufA, bufB},
+	)
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
+	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlO})
+	tm.Send(tea.KeyMsg{Type: tea.KeyRight})
+	tm.Send(agentStateMsg{Name: "a", Status: AgentRunDone, Duration: time.Second})
+	tm.Send(agentStateMsg{Name: "b", Status: AgentRunDone, Duration: time.Second})
+	out, readErr := io.ReadAll(tm.FinalOutput(t, teatest.WithFinalTimeout(500*time.Millisecond)))
+	if readErr != nil {
+		t.Fatalf("read FinalOutput: %v", readErr)
+	}
+	view := string(out)
+	if !strings.Contains(view, "agent 2 of 2") {
+		t.Errorf("right arrow should switch to agent 2 of 2; got:\n%s", view)
+	}
+}
+
 // TestTUIModel_KeyCtrlCCallsOnCancel pins the fix for the raw-mode Ctrl+C
 // bug: when bubbletea delivers KeyCtrlC to the model, the onCancel hook
 // must fire so the orchestrator can tear down subprocesses. Without this,
@@ -96,7 +189,7 @@ func TestTUIModel_PreviewTruncates(t *testing.T) {
 func TestTUIModel_KeyCtrlCCallsOnCancel(t *testing.T) {
 	t.Parallel()
 	called := false
-	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, func() { called = true })
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, func() { called = true }, nil)
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 20))
 	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
 	// Send a terminal state so the model quits and the test finishes.

--- a/cmd/entire/cli/review_tui_test.go
+++ b/cmd/entire/cli/review_tui_test.go
@@ -201,6 +201,27 @@ func TestTUIModel_KeyCtrlCCallsOnCancel(t *testing.T) {
 	}
 }
 
+// TestDetailView_RuneSafeTruncation pins that the Ctrl+O drill-in
+// renderer truncates each line by runes, not bytes — same failure mode
+// as TestTruncatePreview_RuneSafe but in the detail view's inline
+// truncation. A buffer full of em-dashes wider than the terminal would
+// otherwise have produced invalid UTF-8 in the alt-screen frame.
+func TestDetailView_RuneSafeTruncation(t *testing.T) {
+	t.Parallel()
+	buf := &agentBuffer{}
+	// 200 em-dashes (600 bytes) — comfortably wider than the 80-col
+	// default termWidth so detailView's truncation has to fire.
+	if _, err := buf.Write([]byte(strings.Repeat("—", 200))); err != nil {
+		t.Fatalf("buffer write: %v", err)
+	}
+	m := newReviewTUIModel([]MultiAgentTask{{Name: "a"}}, nil, []*agentBuffer{buf})
+	m.detailMode = true
+	rendered := m.View()
+	if !utf8.ValidString(rendered) {
+		t.Errorf("detail view produced invalid UTF-8 (rune-truncation regression):\n%q", rendered)
+	}
+}
+
 // TestTruncatePreview_RuneSafe pins that multi-byte UTF-8 input doesn't
 // get split mid-rune. The previous byte-slice implementation could
 // truncate inside a multi-byte sequence and emit an invalid UTF-8 byte

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/exp/teatest v0.0.0-20260422141420-a6cbdff8a7e2
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/go-git/go-git/v6 v6.0.0-alpha.2
@@ -37,6 +38,7 @@ require (
 	github.com/andybalholm/brotli v1.1.2-0.20250424173009-453214e765f3 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.0 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
@@ -44,6 +46,7 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.5 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
+	github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payR
 github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 h1:qko3AQ4gK1MTS/de7F5hPGx6/k1u0w4TeYmBFwzYVP4=
 github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0/go.mod h1:pBhA0ybfXv6hDjQUZ7hk1lVxBiUbupdw5R31yPUViVQ=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20260422141420-a6cbdff8a7e2 h1:FBYm3qSLjd51O4JkD3tDc/np9lJQlqq8RQSIy/3R09w=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20260422141420-a6cbdff8a7e2/go.mod h1:aPVjFrBwbJgj5Qz1F0IXsnbcOVJcMKgu1ySUfTAxh7k=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=


### PR DESCRIPTION
## Summary

Adds a multi-agent mode to `entire review`. When multiple eligible agents support headless execution, the CLI multi-selects agents, prompts for optional per-run context, runs N reviews in parallel with a Bubble Tea status table, and (optionally) synthesizes a unified cross-agent verdict at the end.

Closes Phase 2 of the `entire review` redesign (items 1–4) on top of PR #993 / #1009. Phase 1 (install-aware skill picker) shipped separately.

## Phase 2 — what landed

### 1. Pick the review agent
- Spawn-time picker when 2+ agents are configured (`81c4c1192`).
- Per-run prompt textarea after agent selection so users can scope a single run without editing settings (`434a6ae96`).

### 2. Parallel headless spawn + status table
- New `agent.HeadlessLauncher` capability interface; per-agent implementations for claude-code, codex, gemini-cli (`b53d82f1e`).
- Binary lookup deferred to `Cmd.Start` so construction is infallible and unit tests verify argv/stdin contracts without the agent binaries on PATH (`880bae867`).
- Codex / gemini headless invocation + Ctrl+C cancellation cascade with a 5s SIGKILL watchdog (`8e82e407a`).
- `multiReviewOrchestrator` runs N agents in parallel under a shared cancellation context, owns the pending-review marker lifecycle, and dumps per-agent results once the TUI exits (`b0036d737`).
- `reviewTUIModel` (Bubble Tea) renders a live status table with spinner, per-row duration, token count, and a faint preview line (`701bf3948`).
- Codex exec-mode noise filter strips session chrome (banners, hook firings, `exec ...` blocks, timestamped errors) before the per-agent dump so findings aren't buried (`d0f05d1bd`).

### 3. Ctrl+O drill-in + aggregated dumps
- Press Ctrl+O during a run to drill into any agent's live buffer; ←/→ to switch agents, Esc to return (`21920e4f5`). Drill-in uses the alt-screen so the table doesn't tear underneath (`b2466e5c0`).
- After all agents finish, the orchestrator emits one `─────── <agent> review ───────` block per agent containing the filtered narrative.

### 4. AI-synthesized cross-agent verdict
- New opt-in (`y/N`) prompt after the per-agent dumps. Reuses `resolveCheckpointSummaryProvider` (the same picker `entire explain` uses) to resolve a configured summary agent and asks it to produce a unified verdict with sections for common findings, unique findings, disagreements, and priority order (`840239d32`).
- Skipped silently when stdin isn't a TTY, when the run was cancelled, or when fewer than two agents produced usable output. Provider failures degrade to a one-line "synthesis unavailable" notice — the user can still commit the underlying reviews.

## Other improvements

- **Per-agent marker entries.** Multi-agent markers carry a per-agent map of `{Skills, Prompt}` so each adopting hook records the skills/prompt that *that* agent actually ran. Single-agent markers keep the legacy top-level fields. Fixes the Bugbot HIGH where multi-agent reviews previously persisted with empty `ReviewSkills`/`ReviewPrompt` (`52546abf3`).
- **Scope clause in the prompt.** Without guidance, agents picked their own review surface (codex defaulted to `origin/main...HEAD`, claude defaulted to working-tree-only). The composed prompt now appends a clause that pins agents to "commits unique to this branch vs the closest ancestor branch," with `detectScopeBaseRef` finding that ancestor by tip-timestamp (falling back to `main`) (`b9ed9c074`). Commits-only — uncommitted bytecode and editor temp files were polluting findings.
- **Skill-discovery dedupe.** Same plugin cached under multiple versions no longer produces duplicate `/foo:bar` entries in the picker (`92d7a98e7`).
- **TUI cancellation correctness.** In-TUI Ctrl+C now routes through the same path as out-of-TUI SIGINT — sets the cancelled flag, arms the SIGKILL watchdog, returns `Cancelled=true` (`26ebe72e1`).
- **TUI rendering correctness.** Per-row run-start timestamps so late-starting agents don't show inflated durations (`1744d5402`); rune-safe preview truncation so multi-byte UTF-8 doesn't get split mid-rune (`68f5a3707`).
- **Cobra usage silenced** on multi-agent picker cancel and dispatch errors so the error message stays scannable (`a42912e89`).

## Test plan

- [x] `mise run check` — fmt + lint + unit + integration + canary
- [x] Manual smoke: `entire-dev review` in a multi-branch repo with both claude-code and codex configured; verified scope clause limits review to commits unique to current branch and synthesis prompt fires only when at least two agents succeed.
- [x] Manual smoke: Ctrl+O drill-in switches between agents and returns cleanly via Esc.
- [x] Manual smoke: Ctrl+C during a run produces "(cancelled)" rows, marker is cleaned up.
- [x] CI green on the latest commit (test, test-core, test-integration a/b/c, test-canary, lint, license-check, binary-size).

## Review-feedback addressed

All 12 PR comments from Cursor Bugbot + Copilot triaged; 11 fixed across the commits above, 1 (`for i, task := range tasks` capture) is a false positive on Go 1.22+ (project is on 1.26.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)