### PR TITLE
stop opencode from saving package-lock.json files

### DIFF
--- a/.opencode/.npmrc
+++ b/.opencode/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/9972caf7443d
<!-- entire-trail-link-end -->

## Summary
- Add `.opencode/.npmrc` with `package-lock=false` so opencode npm invocations skip writing `package-lock.json`
- We don't pin deps with a lock file here, so the generated file was noise

## Test plan
- [ ] Run opencode install flow and confirm no `package-lock.json` is created

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just alters npm behavior for OpenCode runs by preventing `package-lock.json` writes.
> 
> **Overview**
> Prevents OpenCode-driven npm installs from generating `package-lock.json` by adding `.opencode/.npmrc` with `package-lock=false`, reducing lockfile noise in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7e0071fe1c825d8d10cc919c6e840e83b8b9f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->