### PR TITLE
Move objectsigner checks before registration

### DIFF
--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -35,9 +36,12 @@ import (
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/utils/binary"
 	"github.com/go-git/go-git/v6/x/plugin"
+	"github.com/go-git/x/plugin/objectsigner/auto"
+	sshagent "golang.org/x/crypto/ssh/agent"
 )
 
 // errStopIteration is used to stop commit iteration early in GetCheckpointAuthor.
@@ -48,6 +52,14 @@ var errStopIteration = errors.New("stop iteration")
 // re-chunking identical content). Production code paths always use the
 // unwrapped function.
 var chunkTranscript = agent.ChunkTranscript
+
+var (
+	objectSignerLoader = loadObjectSigner
+	scopeName          = map[config.Scope]string{
+		config.GlobalScope: "global",
+		config.SystemScope: "system",
+	}
+)
 
 // WriteCommitted writes a committed checkpoint to the entire/checkpoints/v1 branch.
 // Checkpoints are stored at sharded paths: <id[:2]>/<id[2:]>/
@@ -1818,22 +1830,16 @@ func CreateCommit(ctx context.Context, repo *git.Repository, treeHash, parentHas
 	return hash, nil
 }
 
-// SignCommitBestEffort signs the commit using the registered ObjectSigner plugin.
-// If no signer is registered, signing is disabled via settings, or signing fails,
-// the commit is left unsigned and the error is logged.
+// SignCommitBestEffort signs the commit using an on-demand object signer.
+// If signing is disabled, no signer can be created, or signing fails, the commit
+// is left unsigned and the error is logged.
 func SignCommitBestEffort(ctx context.Context, commit *object.Commit) {
-	// Check plugin availability first (in-memory) before hitting disk for settings.
-	if !plugin.Has(plugin.ObjectSigner()) {
-		return
-	}
-
 	if !settings.IsSignCheckpointCommitsEnabled(ctx) {
 		return
 	}
 
-	signer, err := plugin.Get(plugin.ObjectSigner())
-	if err != nil {
-		logging.Warn(ctx, "failed to get object signer", slog.String("error", err.Error()))
+	signer, ok := objectSignerLoader(ctx)
+	if !ok {
 		return
 	}
 
@@ -1842,6 +1848,7 @@ func SignCommitBestEffort(ctx context.Context, commit *object.Commit) {
 	}
 
 	encoded := &plumbing.MemoryObject{}
+	var err error
 	if err = commit.EncodeWithoutSignature(encoded); err != nil {
 		logging.Warn(ctx, "failed to encode commit for signing", slog.String("error", err.Error()))
 		return
@@ -1861,6 +1868,92 @@ func SignCommitBestEffort(ctx context.Context, commit *object.Commit) {
 	}
 
 	commit.Signature = string(sig)
+}
+
+func loadObjectSigner(ctx context.Context) (plugin.Signer, bool) { //nolint:ireturn // signing uses the plugin.Signer interface
+	cfgSource, err := plugin.Get(plugin.ConfigLoader())
+	if err != nil {
+		// No config loader registered; signing not possible.
+		return nil, false
+	}
+
+	sysCfg := loadScopedConfig(cfgSource, config.SystemScope)
+	globalCfg := loadScopedConfig(cfgSource, config.GlobalScope)
+
+	// Merge system then global so that global settings take precedence.
+	merged := config.Merge(sysCfg, globalCfg)
+
+	if !merged.Commit.GpgSign.IsTrue() {
+		return nil, false
+	}
+
+	// Custom gpg.ssh.program values use an external signer flow that go-git
+	// cannot invoke, so fall back to unsigned checkpoint commits.
+	if auto.Format(merged.GPG.Format) == auto.FormatSSH && hasCustomSSHSignProgram(merged.Raw) {
+		logging.Debug(ctx, "skipping native SSH commit signing: custom gpg.ssh.program is configured")
+		return nil, false
+	}
+
+	signer, err := auto.FromConfig(auto.Config{
+		SigningKey: merged.User.SigningKey,
+		Format:     auto.Format(merged.GPG.Format),
+		SSHAgent:   connectSSHAgent(ctx),
+	})
+	if err != nil {
+		logging.Debug(ctx, "failed to create object signer", "error", err.Error())
+		return nil, false
+	}
+
+	return signer, true
+}
+
+// connectSSHAgent connects to the SSH agent via SSH_AUTH_SOCK.
+// Returns nil if the agent is unavailable.
+func connectSSHAgent(ctx context.Context) sshagent.Agent { //nolint:ireturn // must return the ssh agent interface
+	sock := os.Getenv("SSH_AUTH_SOCK")
+	if sock == "" {
+		return nil
+	}
+
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", sock)
+	if err != nil {
+		return nil
+	}
+
+	return sshagent.NewClient(conn)
+}
+
+// hasCustomSSHSignProgram checks whether gpg.ssh.program is set to a
+// non-default value in the raw config. The git default is "ssh-keygen",
+// which works with go-git's native SSH agent signing. Custom programs use
+// a separate signing mechanism that go-git cannot invoke.
+func hasCustomSSHSignProgram(raw *format.Config) bool {
+	if raw == nil {
+		return false
+	}
+
+	program := raw.Section("gpg").Subsection("ssh").Option("program")
+
+	return program != "" && program != "ssh-keygen"
+}
+
+func loadScopedConfig(source plugin.ConfigSource, scope config.Scope) *config.Config {
+	name := scopeName[scope]
+
+	storer, err := source.Load(scope)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to load %s git config: %v\n", name, err)
+		return config.NewConfig()
+	}
+
+	cfg, err := storer.Config()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to parse %s git config: %v\n", name, err)
+		return config.NewConfig()
+	}
+
+	return cfg
 }
 
 // readTranscriptFromTree reads a transcript from a git tree, handling both chunked and non-chunked formats.

--- a/cmd/entire/cli/checkpoint/committed_signing_test.go
+++ b/cmd/entire/cli/checkpoint/committed_signing_test.go
@@ -50,7 +50,7 @@ func setupSigningEnv(t *testing.T, disableSigning bool) {
 	paths.ClearWorktreeRootCache()
 	t.Chdir(dir)
 	t.Cleanup(func() {
-		resetPluginEntry("object-signer")
+		objectSignerLoader = loadObjectSigner
 		paths.ClearWorktreeRootCache()
 	})
 }
@@ -72,11 +72,8 @@ func newTestCommit() *object.Commit {
 func TestSignCommitBestEffort_Signs(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
 	setupSigningEnv(t, false)
 
-	err := plugin.Register(plugin.ObjectSigner(), func() plugin.Signer {
-		return &stubSigner{sig: []byte("FAKESIG")}
-	})
-	if err != nil {
-		t.Fatal(err)
+	objectSignerLoader = func(context.Context) (plugin.Signer, bool) {
+		return &stubSigner{sig: []byte("FAKESIG")}, true
 	}
 
 	commit := newTestCommit()
@@ -90,12 +87,9 @@ func TestSignCommitBestEffort_Signs(t *testing.T) { //nolint:paralleltest // t.C
 func TestSignCommitBestEffort_SkipsWhenDisabled(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
 	setupSigningEnv(t, true)
 
-	err := plugin.Register(plugin.ObjectSigner(), func() plugin.Signer {
+	objectSignerLoader = func(context.Context) (plugin.Signer, bool) {
 		t.Fatal("signer should not be called when signing is disabled")
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
+		return nil, true
 	}
 
 	commit := newTestCommit()
@@ -109,11 +103,8 @@ func TestSignCommitBestEffort_SkipsWhenDisabled(t *testing.T) { //nolint:paralle
 func TestSignCommitBestEffort_ErrorIsBestEffort(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
 	setupSigningEnv(t, false)
 
-	err := plugin.Register(plugin.ObjectSigner(), func() plugin.Signer {
-		return &stubSigner{err: errors.New("signing failed")}
-	})
-	if err != nil {
-		t.Fatal(err)
+	objectSignerLoader = func(context.Context) (plugin.Signer, bool) {
+		return &stubSigner{err: errors.New("signing failed")}, true
 	}
 
 	commit := newTestCommit()
@@ -127,6 +118,10 @@ func TestSignCommitBestEffort_ErrorIsBestEffort(t *testing.T) { //nolint:paralle
 func TestSignCommitBestEffort_NoSignerRegistered(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
 	setupSigningEnv(t, false)
 
+	objectSignerLoader = func(context.Context) (plugin.Signer, bool) {
+		return nil, false
+	}
+
 	commit := newTestCommit()
 	SignCommitBestEffort(context.Background(), commit)
 
@@ -138,11 +133,8 @@ func TestSignCommitBestEffort_NoSignerRegistered(t *testing.T) { //nolint:parall
 func TestSignCommitBestEffort_NilSigner(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
 	setupSigningEnv(t, false)
 
-	err := plugin.Register(plugin.ObjectSigner(), func() plugin.Signer {
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
+	objectSignerLoader = func(context.Context) (plugin.Signer, bool) {
+		return nil, true
 	}
 
 	commit := newTestCommit()

--- a/cmd/entire/cli/dispatch.go
+++ b/cmd/entire/cli/dispatch.go
@@ -8,13 +8,14 @@ import (
 	"os"
 
 	dispatchpkg "github.com/entireio/cli/cmd/entire/cli/dispatch"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
 
 var runDispatch = dispatchpkg.Run
 var renderDispatchMarkdown = dispatchpkg.RenderMarkdown
-var dispatchTerminalMode = isTerminalWriter
+var dispatchTerminalMode = interactive.IsTerminalWriter
 var runInteractiveDispatch = defaultRunInteractiveDispatch
 var renderTerminalMarkdown = defaultRenderTerminalMarkdown
 
@@ -45,7 +46,7 @@ Examples:
 				err  error
 			)
 
-			if shouldRunDispatchWizard(cmd.Flags().NFlag(), isTerminalStdin(os.Stdin), isTerminalWriter(cmd.OutOrStdout())) {
+			if shouldRunDispatchWizard(cmd.Flags().NFlag(), isTerminalStdin(os.Stdin), interactive.IsTerminalWriter(cmd.OutOrStdout())) {
 				opts, err = runDispatchWizard(cmd)
 			} else {
 				opts, err = parseDispatchFlags(cmd, flagLocal, flagSince, flagUntil, flagAllBranches, flagRepos, flagVoice, flagInsecureHTTPAuth)

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -66,7 +66,7 @@ func loadObjectSigner() (plugin.Signer, bool) { //nolint:ireturn // plugin regis
 		SSHAgent:   connectSSHAgent(),
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to create object signer: %v\n", err)
+		logging.Debug(context.Background(), "failed to create object signer", "error", err.Error())
 		return nil, false
 	}
 

--- a/cmd/entire/cli/objectsigner.go
+++ b/cmd/entire/cli/objectsigner.go
@@ -16,53 +16,61 @@ import (
 )
 
 var registerObjectSignerOnce sync.Once
+var objectSignerLoader = loadObjectSigner
 
 func RegisterObjectSigner() {
 	registerObjectSignerOnce.Do(func() {
+		signer, ok := objectSignerLoader()
+		if !ok {
+			return
+		}
+
 		//nolint:errcheck,gosec // best-effort; if registration fails, commits are left unsigned
 		plugin.Register(plugin.ObjectSigner(), func() plugin.Signer {
-			cfgSource, err := plugin.Get(plugin.ConfigLoader())
-			if err != nil {
-				// No config loader registered; signing not possible.
-				return nil
-			}
-
-			sysCfg := loadScopedConfig(cfgSource, config.SystemScope)
-			globalCfg := loadScopedConfig(cfgSource, config.GlobalScope)
-
-			// Merge system then global so that global settings take precedence.
-			merged := config.Merge(sysCfg, globalCfg)
-
-			if !merged.Commit.GpgSign.IsTrue() {
-				return nil
-			}
-
-			// When a custom gpg.ssh.program is configured (e.g. 1Password's
-			// op-ssh-sign), signing happens via an external binary that go-git
-			// cannot invoke. Skip native signing silently — checkpoint commits
-			// will be unsigned, which is acceptable since signing is best-effort.
-			// The default program is "ssh-keygen", which works with go-git's
-			// native SSH agent signing and does not need to be skipped.
-			if auto.Format(merged.GPG.Format) == auto.FormatSSH && hasCustomSSHSignProgram(merged.Raw) {
-				logging.Debug(context.Background(), "skipping native SSH commit signing: custom gpg.ssh.program is configured")
-				return nil
-			}
-
-			cfg := auto.Config{
-				SigningKey: merged.User.SigningKey,
-				Format:     auto.Format(merged.GPG.Format),
-				SSHAgent:   connectSSHAgent(),
-			}
-
-			signer, err := auto.FromConfig(cfg)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "warning: failed to create object signer: %v\n", err)
-				return nil
-			}
-
 			return signer
 		})
 	})
+}
+
+func loadObjectSigner() (plugin.Signer, bool) { //nolint:ireturn // plugin registration requires the plugin.Signer interface
+	cfgSource, err := plugin.Get(plugin.ConfigLoader())
+	if err != nil {
+		// No config loader registered; signing not possible.
+		return nil, false
+	}
+
+	sysCfg := loadScopedConfig(cfgSource, config.SystemScope)
+	globalCfg := loadScopedConfig(cfgSource, config.GlobalScope)
+
+	// Merge system then global so that global settings take precedence.
+	merged := config.Merge(sysCfg, globalCfg)
+
+	if !merged.Commit.GpgSign.IsTrue() {
+		return nil, false
+	}
+
+	// When a custom gpg.ssh.program is configured (e.g. 1Password's
+	// op-ssh-sign), signing happens via an external binary that go-git
+	// cannot invoke. Skip native signing silently — checkpoint commits
+	// will be unsigned, which is acceptable since signing is best-effort.
+	// The default program is "ssh-keygen", which works with go-git's
+	// native SSH agent signing and does not need to be skipped.
+	if auto.Format(merged.GPG.Format) == auto.FormatSSH && hasCustomSSHSignProgram(merged.Raw) {
+		logging.Debug(context.Background(), "skipping native SSH commit signing: custom gpg.ssh.program is configured")
+		return nil, false
+	}
+
+	signer, err := auto.FromConfig(auto.Config{
+		SigningKey: merged.User.SigningKey,
+		Format:     auto.Format(merged.GPG.Format),
+		SSHAgent:   connectSSHAgent(),
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to create object signer: %v\n", err)
+		return nil, false
+	}
+
+	return signer, true
 }
 
 // connectSSHAgent connects to the SSH agent via SSH_AUTH_SOCK.

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -2,22 +2,13 @@ package cli
 
 import (
 	"bytes"
-	"io"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
-	"github.com/go-git/go-git/v6/x/plugin"
 	"github.com/spf13/cobra"
 )
-
-type rootTestSigner struct{}
-
-func (rootTestSigner) Sign(io.Reader) ([]byte, error) {
-	return []byte("sig"), nil
-}
 
 func TestVersionFlag_OutputMatchesVersionCmd(t *testing.T) {
 	t.Parallel()
@@ -74,44 +65,6 @@ func TestVersionFlag_ContainsExpectedInfo(t *testing.T) {
 		if !strings.Contains(output, c.contains) {
 			t.Errorf("--version output missing %s (%q):\n%s", c.name, c.contains, output)
 		}
-	}
-}
-
-func TestRegisterObjectSigner_RegistersPlugin(t *testing.T) {
-	resetPluginEntry("object-signer")
-	registerObjectSignerOnce = sync.Once{}
-	objectSignerLoader = func() (plugin.Signer, bool) {
-		return rootTestSigner{}, true
-	}
-	t.Cleanup(func() {
-		resetPluginEntry("object-signer")
-		registerObjectSignerOnce = sync.Once{}
-		objectSignerLoader = loadObjectSigner
-	})
-
-	RegisterObjectSigner()
-
-	if !plugin.Has(plugin.ObjectSigner()) {
-		t.Fatal("expected object signer plugin to be registered")
-	}
-}
-
-func TestRegisterObjectSigner_SkipsRegistrationWhenSigningDisabled(t *testing.T) {
-	resetPluginEntry("object-signer")
-	registerObjectSignerOnce = sync.Once{}
-	objectSignerLoader = func() (plugin.Signer, bool) {
-		return nil, false
-	}
-	t.Cleanup(func() {
-		resetPluginEntry("object-signer")
-		registerObjectSignerOnce = sync.Once{}
-		objectSignerLoader = loadObjectSigner
-	})
-
-	RegisterObjectSigner()
-
-	if plugin.Has(plugin.ObjectSigner()) {
-		t.Fatal("expected object signer plugin to be skipped when signing is disabled")
 	}
 }
 

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"io"
 	"runtime"
 	"strings"
 	"sync"
@@ -11,6 +12,12 @@ import (
 	"github.com/go-git/go-git/v6/x/plugin"
 	"github.com/spf13/cobra"
 )
+
+type rootTestSigner struct{}
+
+func (rootTestSigner) Sign(io.Reader) ([]byte, error) {
+	return []byte("sig"), nil
+}
 
 func TestVersionFlag_OutputMatchesVersionCmd(t *testing.T) {
 	t.Parallel()
@@ -73,15 +80,38 @@ func TestVersionFlag_ContainsExpectedInfo(t *testing.T) {
 func TestRegisterObjectSigner_RegistersPlugin(t *testing.T) {
 	resetPluginEntry("object-signer")
 	registerObjectSignerOnce = sync.Once{}
+	objectSignerLoader = func() (plugin.Signer, bool) {
+		return rootTestSigner{}, true
+	}
 	t.Cleanup(func() {
 		resetPluginEntry("object-signer")
 		registerObjectSignerOnce = sync.Once{}
+		objectSignerLoader = loadObjectSigner
 	})
 
 	RegisterObjectSigner()
 
 	if !plugin.Has(plugin.ObjectSigner()) {
 		t.Fatal("expected object signer plugin to be registered")
+	}
+}
+
+func TestRegisterObjectSigner_SkipsRegistrationWhenSigningDisabled(t *testing.T) {
+	resetPluginEntry("object-signer")
+	registerObjectSignerOnce = sync.Once{}
+	objectSignerLoader = func() (plugin.Signer, bool) {
+		return nil, false
+	}
+	t.Cleanup(func() {
+		resetPluginEntry("object-signer")
+		registerObjectSignerOnce = sync.Once{}
+		objectSignerLoader = loadObjectSigner
+	})
+
+	RegisterObjectSigner()
+
+	if plugin.Has(plugin.ObjectSigner()) {
+		t.Fatal("expected object signer plugin to be skipped when signing is disabled")
 	}
 }
 

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -15,8 +15,6 @@ import (
 )
 
 func main() {
-	cli.RegisterObjectSigner()
-
 	// Create context that cancels on interrupt
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/8718bac46a1e
<!-- entire-trail-link-end -->

Avoid object signer registration when it won't be needed. This results on it only running once, instead of multiple times to get to the same result of **not** signing a given commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes when/if the go-git object signer plugin is registered, which could affect commit signing behavior depending on git config/agent availability.
> 
> **Overview**
> Moves git config checks and signer construction *before* `plugin.Register` so the object signer plugin is only registered when signing is enabled and supported (and not re-evaluated on each plugin invocation).
> 
> Adds a small indirection (`objectSignerLoader`) and tests to assert both registration and the new “skip registration when disabled” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb514d44eed1a7ce3812a2843c2f761c6a568eea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->