### PR TITLE
Fix Codex token usage normalization

### DIFF
--- a/cmd/entire/cli/agent/codex/transcript.go
+++ b/cmd/entire/cli/agent/codex/transcript.go
@@ -238,19 +238,26 @@ func (c *CodexAgent) CalculateTokenUsage(transcriptData []byte, fromOffset int) 
 	}
 
 	// Subtract baseline to get the delta for this checkpoint range
-	result := &agent.TokenUsage{
-		InputTokens:     lastUsage.InputTokens,
-		CacheReadTokens: lastUsage.CachedInputTokens,
-		OutputTokens:    lastUsage.OutputTokens + lastUsage.ReasoningOutputTokens,
-		APICallCount:    apiCalls,
-	}
+	inputTokens := lastUsage.InputTokens
+	cacheReadTokens := lastUsage.CachedInputTokens
+	outputTokens := lastUsage.OutputTokens
 	if baselineUsage != nil {
-		result.InputTokens -= baselineUsage.InputTokens
-		result.CacheReadTokens -= baselineUsage.CachedInputTokens
-		result.OutputTokens -= baselineUsage.OutputTokens + baselineUsage.ReasoningOutputTokens
+		inputTokens -= baselineUsage.InputTokens
+		cacheReadTokens -= baselineUsage.CachedInputTokens
+		outputTokens -= baselineUsage.OutputTokens
 	}
 
-	return result, nil
+	freshInputTokens := inputTokens - cacheReadTokens
+	if freshInputTokens < 0 {
+		freshInputTokens = 0
+	}
+
+	return &agent.TokenUsage{
+		InputTokens:     freshInputTokens,
+		CacheReadTokens: cacheReadTokens,
+		OutputTokens:    outputTokens,
+		APICallCount:    apiCalls,
+	}, nil
 }
 
 // ExtractPrompts returns user prompts from the transcript starting at the given offset.

--- a/cmd/entire/cli/agent/codex/transcript_test.go
+++ b/cmd/entire/cli/agent/codex/transcript_test.go
@@ -11,14 +11,14 @@ import (
 const sampleRollout = `{"timestamp":"2026-03-25T11:31:11.752Z","type":"session_meta","payload":{"id":"019d24c3","timestamp":"2026-03-25T11:31:10.922Z","cwd":"/tmp/repo","originator":"codex_exec","cli_version":"0.116.0","source":"exec"}}
 {"timestamp":"2026-03-25T11:31:11.754Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}
 {"timestamp":"2026-03-25T11:31:11.754Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Create a file called hello.txt"}]}}
-{"timestamp":"2026-03-25T11:31:12.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":5000,"cached_input_tokens":4000,"output_tokens":100,"reasoning_output_tokens":20,"total_tokens":5120}}}}
+{"timestamp":"2026-03-25T11:31:12.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":5000,"cached_input_tokens":4000,"output_tokens":100,"reasoning_output_tokens":20,"total_tokens":5100}}}}
 {"timestamp":"2026-03-25T11:31:13.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Creating the file now."}]}}
 {"timestamp":"2026-03-25T11:31:14.000Z","type":"response_item","payload":{"type":"custom_tool_call","status":"completed","call_id":"call_1","name":"apply_patch","input":"*** Begin Patch\n*** Add File: hello.txt\n+Hello World\n*** End Patch\n"}}
 {"timestamp":"2026-03-25T11:31:14.500Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_1","output":{"type":"text","text":"Success. Updated: A hello.txt"}}}
-{"timestamp":"2026-03-25T11:31:15.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10000,"cached_input_tokens":8000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":10250}}}}
+{"timestamp":"2026-03-25T11:31:15.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10000,"cached_input_tokens":8000,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":10200}}}}
 {"timestamp":"2026-03-25T11:31:16.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Now create docs/readme.md too"}]}}
 {"timestamp":"2026-03-25T11:31:17.000Z","type":"response_item","payload":{"type":"custom_tool_call","status":"completed","call_id":"call_2","name":"apply_patch","input":"*** Begin Patch\n*** Add File: docs/readme.md\n+# Readme\n*** Update File: hello.txt\n-Hello World\n+Hello World!\n*** End Patch\n"}}
-{"timestamp":"2026-03-25T11:31:18.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15000,"cached_input_tokens":12000,"output_tokens":300,"reasoning_output_tokens":80,"total_tokens":15380}}}}
+{"timestamp":"2026-03-25T11:31:18.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":15000,"cached_input_tokens":12000,"output_tokens":300,"reasoning_output_tokens":80,"total_tokens":15300}}}}
 {"timestamp":"2026-03-25T11:31:19.000Z","type":"event_msg","payload":{"type":"task_complete"}}
 `
 
@@ -102,26 +102,28 @@ func TestCalculateTokenUsage(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 
-	require.Equal(t, 15000, usage.InputTokens)
+	require.Equal(t, 3000, usage.InputTokens)
 	require.Equal(t, 12000, usage.CacheReadTokens)
-	require.Equal(t, 380, usage.OutputTokens) // 300 + 80 reasoning
+	require.Equal(t, 300, usage.OutputTokens)
 	require.Equal(t, 3, usage.APICallCount)
+	require.Equal(t, 15300, usage.InputTokens+usage.CacheReadTokens+usage.OutputTokens)
 }
 
 func TestCalculateTokenUsage_WithOffset(t *testing.T) {
 	t.Parallel()
 	ag := &CodexAgent{}
 
-	// Skip past first token_count (line 4) — baseline is {5000, 4000, 120}
-	// Last after offset is {15000, 12000, 380} → delta = {10000, 8000, 260}
+	// Skip past first token_count (line 4) — baseline is {5000, 4000, 100}
+	// Last after offset is {15000, 12000, 300} → delta = {10000, 8000, 200}
 	usage, err := ag.CalculateTokenUsage([]byte(sampleRollout), 4)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 
-	require.Equal(t, 10000, usage.InputTokens)    // 15000 - 5000
+	require.Equal(t, 2000, usage.InputTokens)     // (15000 - 5000) - (12000 - 4000)
 	require.Equal(t, 8000, usage.CacheReadTokens) // 12000 - 4000
-	require.Equal(t, 260, usage.OutputTokens)     // (300+80) - (100+20)
+	require.Equal(t, 200, usage.OutputTokens)     // 300 - 100
 	require.Equal(t, 2, usage.APICallCount)
+	require.Equal(t, 10200, usage.InputTokens+usage.CacheReadTokens+usage.OutputTokens)
 }
 
 func TestCalculateTokenUsage_NoData(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/759acc58d35b
<!-- entire-trail-link-end -->

## Summary
- Normalize Codex token usage before storing it in the shared additive `agent.TokenUsage` model
- Split Codex cached input out of inclusive input totals so status and explain output stop double-counting cache reads
- Stop adding Codex reasoning output on top of output tokens, because Codex output already includes reasoning output
- Update Codex token usage tests so the normalized Entire field sum matches Codex `total_tokens`, including checkpoint offset deltas

## Investigation Notes
<img width="1590" height="373" alt="image" src="https://github.com/user-attachments/assets/498dbf81-8252-4f0a-a042-816b71ded1dc" />
I was trying out codex for one of our other repos, and noticed the codex token count seemed massive for a relatively small number of sessions.

We investigated the Codex rollout `event_msg` / `token_count` records and found that Codex reports inclusive counters:

```text
total_tokens = input_tokens + output_tokens
cached_input_tokens is included in input_tokens
reasoning_output_tokens is included in output_tokens
```

One real Codex `0.124.0` rollout record showed:

```text
input_tokens: 123302
cached_input_tokens: 96128
output_tokens: 1944
reasoning_output_tokens: 1129
total_tokens: 125246
```

The invariant matches Codex totals:

```text
123302 + 1944 = 125246
```

The old Entire mapping treated these fields as if they were all independent additive buckets:

```text
InputTokens = input_tokens
CacheReadTokens = cached_input_tokens
OutputTokens = output_tokens + reasoning_output_tokens
```

That made Entire display/store an inflated total:

```text
123302 + 96128 + 1944 + 1129 = 222503
```

The fix converts Codex inclusive usage into the shared additive model:

```text
InputTokens = input_tokens_delta - cached_input_tokens_delta
CacheReadTokens = cached_input_tokens_delta
OutputTokens = output_tokens_delta
```

For the example above, the normalized Entire sum becomes:

```text
(123302 - 96128) + 96128 + 1944 = 125246
```

## Why Not Store Codex total_tokens Directly
The shared `TokenUsage` model does not have a `TotalTokens` field. It stores component buckets used by multiple agents and sums them for display, checkpoint metadata, and session status. Codex still needs a breakdown for fresh input, cached input, and output, so `total_tokens` is best used as an invariant/test oracle rather than the stored representation.

## Test Plan
- `env TZ=UTC mise run check`
- `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1fdb787f0debfd463f7d0d7905a88a223ed21b61. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->