### PR TITLE
strategy: guard against empty-session metadata stubs

### DIFF
--- a/cmd/entire/cli/strategy/condense_skip_test.go
+++ b/cmd/entire/cli/strategy/condense_skip_test.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/redact"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/stretchr/testify/assert"
@@ -109,6 +111,153 @@ func TestCondenseSession_DoesNotSkipWhenFilesTouchedButNoTranscript(t *testing.T
 	result, err := s.CondenseSession(context.Background(), repo, checkpointID, state, committedFiles)
 	require.NoError(t, err)
 	assert.False(t, result.Skipped, "should not skip when files are touched even without transcript")
+}
+
+// Regression: a session whose tracked files don't overlap with this commit AND
+// whose transcript is dropped by redaction (malformed JSONL) must be skipped
+// instead of writing a metadata-only stub. The pre-redaction skip gate cannot
+// catch this combination because both Transcript and FilesTouched are non-empty
+// before the filter and redaction run.
+func TestCondenseSession_SkipsWhenNoOverlapAndRedactionFails(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	// Commit a file so committedFiles is non-empty.
+	committedTestFile := filepath.Join(dir, "committed.txt")
+	require.NoError(t, os.WriteFile(committedTestFile, []byte("committed change"), 0o644))
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("committed.txt")
+	require.NoError(t, err)
+	commitHash, err := wt.Commit("modify committed.txt", &git.CommitOptions{})
+	require.NoError(t, err)
+
+	// Session tracks an UNRELATED file so the intersect in filterFilesTouched
+	// produces an empty result. Transcript is readable so the pre-redaction
+	// skip gate won't fire.
+	sessionID := "redaction-failure-no-overlap"
+	transcriptPath := filepath.Join(dir, "fake-rollout.jsonl")
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(`{"any":"jsonl line"}`+"\n"), 0o644))
+
+	state := &SessionState{
+		SessionID:      sessionID,
+		AgentType:      "Codex",
+		BaseCommit:     commitHash.String(),
+		Phase:          session.PhaseActive,
+		TranscriptPath: transcriptPath,
+		FilesTouched:   []string{"unrelated.txt"}, // not in committedFiles
+	}
+
+	// Force the redactor to fail so redactedTranscript ends up empty.
+	originalRedactor := redactSessionJSONLBytes
+	redactSessionJSONLBytes = func(_ []byte) (redact.RedactedBytes, error) {
+		return redact.RedactedBytes{}, errors.New("simulated redaction failure")
+	}
+	t.Cleanup(func() { redactSessionJSONLBytes = originalRedactor })
+
+	s := &ManualCommitStrategy{}
+	checkpointID := id.MustCheckpointID("d4e5f6a1b2c3")
+	committedFiles := map[string]struct{}{"committed.txt": {}}
+
+	result, err := s.CondenseSession(context.Background(), repo, checkpointID, state, committedFiles)
+	require.NoError(t, err)
+	assert.True(t, result.Skipped, "should skip when no file overlap AND redaction drops transcript")
+}
+
+// filterFilesTouched should still apply the all-committed-files fallback for a
+// legitimate mid-turn commit where the session has run SaveStep before but
+// hasn't recorded files for the current turn yet (StepCount > 0 is the
+// evidence-of-work signal).
+func TestFilterFilesTouched_AppliesFallbackForMidTurnCommit(t *testing.T) {
+	t.Parallel()
+
+	sessionData := &ExtractedSessionData{
+		Transcript:   nil,
+		FilesTouched: nil,
+	}
+	state := &SessionState{
+		SessionID: "mid-turn",
+		StepCount: 2, // prior SaveStep evidence
+	}
+	committedFiles := map[string]struct{}{
+		"app/foo.go":       {},
+		".entire/internal": {},
+		"app/bar.go":       {},
+	}
+
+	filterFilesTouched(sessionData, committedFiles, state)
+
+	require.ElementsMatch(t, []string{"app/foo.go", "app/bar.go"}, sessionData.FilesTouched,
+		"should fall back to committed files (excluding .entire/) when session has SaveStep evidence")
+}
+
+// A first-turn mid-session commit can happen before SaveStep records the
+// touched files. In that case StepCount==0 but we have a non-empty transcript,
+// which is enough evidence to apply the committed-files fallback. This is the
+// happy-path case for the fallback (e.g. Claude Code mid-turn user commits).
+func TestFilterFilesTouched_AppliesFallbackWithTranscriptEvidence(t *testing.T) {
+	t.Parallel()
+
+	sessionData := &ExtractedSessionData{
+		Transcript:   []byte(`{"role":"user","content":"hi"}` + "\n"),
+		FilesTouched: nil,
+	}
+	state := &SessionState{
+		SessionID: "first-turn",
+		StepCount: 0,
+	}
+	committedFiles := map[string]struct{}{"app/foo.go": {}}
+
+	filterFilesTouched(sessionData, committedFiles, state)
+
+	require.Equal(t, []string{"app/foo.go"}, sessionData.FilesTouched,
+		"should fall back when transcript is non-empty even without StepCount")
+}
+
+// filterFilesTouched must NOT apply the fallback when there is no evidence the
+// session did anything (no transcript, no prior SaveStep). This is the bug
+// scenario that produced false attribution to ephemeral Codex sessions.
+func TestFilterFilesTouched_SkipsFallbackWithoutEvidence(t *testing.T) {
+	t.Parallel()
+
+	sessionData := &ExtractedSessionData{
+		Transcript:   nil,
+		FilesTouched: nil,
+	}
+	state := &SessionState{
+		SessionID: "no-evidence",
+		StepCount: 0,
+	}
+	committedFiles := map[string]struct{}{"app/foo.go": {}, "app/bar.go": {}}
+
+	filterFilesTouched(sessionData, committedFiles, state)
+
+	assert.Empty(t, sessionData.FilesTouched,
+		"must not attribute committed files to a session with no evidence of work")
+}
+
+// filterFilesTouched should still intersect when sessionData already has
+// FilesTouched populated, regardless of evidence-of-work signals.
+func TestFilterFilesTouched_IntersectsWhenFilesTouchedPopulated(t *testing.T) {
+	t.Parallel()
+
+	sessionData := &ExtractedSessionData{
+		Transcript:   nil,
+		FilesTouched: []string{"app/foo.go", "app/bar.go", "app/unrelated.go"},
+	}
+	state := &SessionState{
+		SessionID: "intersect-case",
+		StepCount: 0, // no evidence of work, but FilesTouched is populated
+	}
+	committedFiles := map[string]struct{}{"app/foo.go": {}, "app/bar.go": {}}
+
+	filterFilesTouched(sessionData, committedFiles, state)
+
+	require.ElementsMatch(t, []string{"app/foo.go", "app/bar.go"}, sessionData.FilesTouched,
+		"should intersect existing FilesTouched with committedFiles")
 }
 
 func TestCondenseSessionByID_SkippedPreservesState(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -170,24 +170,14 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 			slog.Bool("has_shadow_branch", hasShadowBranch),
 			slog.String("transcript_path", state.TranscriptPath),
 		)
-		return &CondenseResult{
-			CheckpointID: checkpointID,
-			SessionID:    state.SessionID,
-			Skipped:      true,
-		}, nil
+		return newSkippedResult(checkpointID, state.SessionID), nil
 	}
 
-	filterFilesTouched(sessionData, committedFiles)
+	filterFilesTouched(sessionData, committedFiles, state)
 
-	// On failure: drop transcript, continue with metadata (no retry path in hooks).
-	redactedTranscript, redactDuration, err := redactSessionTranscript(ctx, sessionData.Transcript)
-	if err != nil {
-		logging.Warn(logCtx, "failed to redact transcript secrets, dropping transcript for checkpoint",
-			slog.String("session_id", state.SessionID),
-			slog.String("checkpoint_id", checkpointID.String()),
-			slog.String("error", err.Error()),
-		)
-		redactedTranscript = redact.RedactedBytes{}
+	redactedTranscript, redactDuration := redactOrDrop(logCtx, sessionData.Transcript, state.SessionID, checkpointID)
+	if skipped := skipIfPostRedactionEmpty(logCtx, redactedTranscript, sessionData, state, checkpointID); skipped != nil {
+		return skipped, nil
 	}
 
 	// Get checkpoint store
@@ -324,6 +314,46 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 	}, nil
 }
 
+// redactOrDrop runs redactSessionTranscript and, on failure, logs a warning
+// and returns empty bytes. Drop-on-failure is the long-standing contract here:
+// hooks have no retry path, and a failed redaction must not block the commit.
+func redactOrDrop(logCtx context.Context, transcript []byte, sessionID string, checkpointID id.CheckpointID) (redact.RedactedBytes, time.Duration) {
+	redactedTranscript, redactDuration, err := redactSessionTranscript(logCtx, transcript)
+	if err != nil {
+		logging.Warn(logCtx, "failed to redact transcript secrets, dropping transcript for checkpoint",
+			slog.String("session_id", sessionID),
+			slog.String("checkpoint_id", checkpointID.String()),
+			slog.String("error", err.Error()),
+		)
+		return redact.RedactedBytes{}, redactDuration
+	}
+	return redactedTranscript, redactDuration
+}
+
+// skipIfPostRedactionEmpty returns a Skipped result when redaction emptied the
+// transcript AND the filtered FilesTouched is also empty. Without this, a
+// session that passed the pre-redaction gate but got its transcript dropped by
+// a malformed-JSONL redaction error would write a metadata-only stub.
+func skipIfPostRedactionEmpty(logCtx context.Context, redactedTranscript redact.RedactedBytes, sessionData *ExtractedSessionData, state *SessionState, checkpointID id.CheckpointID) *CondenseResult {
+	if redactedTranscript.Len() > 0 || len(sessionData.FilesTouched) > 0 {
+		return nil
+	}
+	logging.Info(logCtx, "session skipped: nothing to persist after redaction",
+		slog.String("session_id", state.SessionID),
+		slog.String("agent_type", string(state.AgentType)),
+		slog.String("checkpoint_id", checkpointID.String()),
+	)
+	return newSkippedResult(checkpointID, state.SessionID)
+}
+
+func newSkippedResult(checkpointID id.CheckpointID, sessionID string) *CondenseResult {
+	return &CondenseResult{
+		CheckpointID: checkpointID,
+		SessionID:    sessionID,
+		Skipped:      true,
+	}
+}
+
 // redactSessionTranscript redacts the transcript once for use by both the compact
 // package and the checkpoint stores. Returns the redacted bytes and the duration
 // of the redaction operation for perf logging.
@@ -358,10 +388,14 @@ func resolveShadowRef(repo *git.Repository, branchName string, preResolved *plum
 	return resolved, true
 }
 
-// filterFilesTouched narrows sessionData.FilesTouched to only files present in
-// committedFiles. When no prior files were recorded (mid-turn commit), it falls
-// back to the committed set minus Entire metadata paths.
-func filterFilesTouched(sessionData *ExtractedSessionData, committedFiles map[string]struct{}) {
+// filterFilesTouched narrows sessionData.FilesTouched to files present in
+// committedFiles. When no prior files were recorded, it falls back to the
+// committed set (minus Entire metadata) — but only when sessionHasEvidenceOfWork
+// is true. The fallback was originally unconditional, which let sessions that
+// were registered at SessionStart but never produced anything (e.g. ephemeral
+// Codex sessions whose hooks fired with a null transcript_path and never
+// reached SaveStep) inherit another session's committed files.
+func filterFilesTouched(sessionData *ExtractedSessionData, committedFiles map[string]struct{}, state *SessionState) {
 	if len(committedFiles) == 0 {
 		return
 	}
@@ -373,13 +407,24 @@ func filterFilesTouched(sessionData *ExtractedSessionData, committedFiles map[st
 			}
 		}
 		sessionData.FilesTouched = filtered
-	} else {
-		// Mid-turn commits can happen before SaveStep records FilesTouched.
-		// In that case, fall back to the actual committed files, excluding
-		// Entire's own metadata paths, so the checkpoint still reflects the
-		// files captured by this commit.
-		sessionData.FilesTouched = committedFilesExcludingMetadata(committedFiles)
+		return
 	}
+	if !sessionHasEvidenceOfWork(sessionData, state) {
+		return
+	}
+	sessionData.FilesTouched = committedFilesExcludingMetadata(committedFiles)
+}
+
+// sessionHasEvidenceOfWork returns true when the session looks like a real
+// participant — either it produced a readable transcript or a prior SaveStep
+// recorded a checkpoint (StepCount > 0). False means the session was likely
+// registered but never did anything; treating such a session as the author of
+// the committed files would attribute another session's work to it.
+func sessionHasEvidenceOfWork(sessionData *ExtractedSessionData, state *SessionState) bool {
+	if len(sessionData.Transcript) > 0 {
+		return true
+	}
+	return state != nil && state.StepCount > 0
 }
 
 // extractOrCreateSessionData tries to extract session data from the shadow branch,


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/a7fd3b96a21d
<!-- entire-trail-link-end -->

Two defensive guards in CondenseSession to prevent writing metadata.json checkpoints with no transcript and no real session attribution behind them:

1. Post-redaction skip gate (skipIfPostRedactionEmpty). The existing pre-redaction gate at line 165 catches sessions with neither a transcript nor tracked files. It cannot catch the case where the transcript was non-empty pre-redaction but redaction silently dropped it (malformed JSONL from an external agent), AND the session's tracked files don't overlap with the committed file set. The new gate runs after redaction and after filterFilesTouched so it sees the post-filter view; if both transcript and FilesTouched are now empty, return Skipped instead of writing a stub.

2. Narrow the filterFilesTouched fallback (sessionHasEvidenceOfWork). The old fallback assigned every committed file (minus .entire/) to any session with empty FilesTouched. That was designed for mid-turn commits before SaveStep ran, but it also fired for sessions registered at SessionStart that never produced anything — e.g., a Codex companion session whose hooks ran with a null transcript_path and never reached SaveStep. The fallback now requires evidence the session is a real participant: either a non-empty transcript was extracted, or a prior SaveStep recorded a checkpoint (StepCount > 0).

Also extracts redactOrDrop helper so CondenseSession stays under the maintidx threshold after the new skip gate is added.

Tests cover the post-redaction skip in the no-overlap + redaction-fail case, plus four unit tests for the narrowed filterFilesTouched contract: applies fallback with StepCount evidence, applies fallback with transcript evidence, skips fallback when neither is present, and intersects normally when FilesTouched is already populated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes condensation skip/attribution behavior and could affect which sessions get persisted or credited for a commit, especially around mid-turn commits and redaction failures.
> 
> **Overview**
> **Prevents empty-session checkpoint stubs during manual-commit condensation.** `CondenseSession` now performs an additional *post-redaction* skip check, so if redaction drops the transcript and `FilesTouched` filters to empty, the session is skipped instead of persisting a metadata-only checkpoint.
> 
> **Tightens file attribution fallback.** `filterFilesTouched` only falls back to “all committed files (excluding `.entire/`)” when the session has evidence of work (non-empty transcript or `StepCount > 0`), avoiding false attribution to sessions that never produced output.
> 
> Adds focused regression/unit tests covering the new post-redaction skip and the updated `filterFilesTouched` fallback/intersection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323d8fb6365f9aa64bfafc971d4628b74822d258. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->