### PR TITLE
Replace gh CLI with /api/v1/repositories for dispatch wizard

### DIFF
--- a/cmd/entire/cli/api/repositories.go
+++ b/cmd/entire/cli/api/repositories.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// Repository is a single entry returned by GET /api/v1/repositories.
+// Only fields currently consumed by callers are decoded; extras are ignored.
+type Repository struct {
+	FullName        string `json:"full_name"`
+	CheckpointCount int    `json:"checkpoint_count"`
+}
+
+// RepositoriesResponse is the envelope returned by GET /api/v1/repositories.
+type RepositoriesResponse struct {
+	Repositories []Repository `json:"repositories"`
+}
+
+type RepositorySort string
+
+const (
+	RepositorySortRecent RepositorySort = "recent"
+	RepositorySortName   RepositorySort = "name"
+)
+
+// ListRepositories lists the authenticated user's repositories.
+// An empty sort uses the server default.
+func (c *Client) ListRepositories(ctx context.Context, sort RepositorySort) ([]Repository, error) {
+	path := "/api/v1/repositories"
+	if sort != "" {
+		path += "?" + url.Values{"sort": []string{string(sort)}}.Encode()
+	}
+
+	resp, err := c.Get(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("list repositories: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := CheckResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var out RepositoriesResponse
+	if err := DecodeJSON(resp, &out); err != nil {
+		return nil, fmt.Errorf("list repositories: %w", err)
+	}
+	return out.Repositories, nil
+}

--- a/cmd/entire/cli/api/repositories_test.go
+++ b/cmd/entire/cli/api/repositories_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClient_ListRepositories_SendsSortAndDecodesResponse(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotRawQuery, gotAuth string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotRawQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"repositories":[` + //nolint:errcheck // test handler
+			`{"full_name":"entireio/cli","checkpoint_count":12},` +
+			`{"full_name":"entireio/entire.io","checkpoint_count":3}` +
+			`]}`))
+	}))
+	defer server.Close()
+
+	c := NewClient("tok")
+	c.baseURL = server.URL
+
+	repos, err := c.ListRepositories(context.Background(), RepositorySortRecent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotPath != "/api/v1/repositories" {
+		t.Errorf("path = %q, want /api/v1/repositories", gotPath)
+	}
+	if gotRawQuery != "sort=recent" {
+		t.Errorf("query = %q, want sort=recent", gotRawQuery)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("Authorization = %q, want Bearer tok", gotAuth)
+	}
+
+	if len(repos) != 2 {
+		t.Fatalf("len(repos) = %d, want 2", len(repos))
+	}
+	if repos[0].FullName != "entireio/cli" || repos[0].CheckpointCount != 12 {
+		t.Errorf("repos[0] = %+v", repos[0])
+	}
+	if repos[1].FullName != "entireio/entire.io" || repos[1].CheckpointCount != 3 {
+		t.Errorf("repos[1] = %+v", repos[1])
+	}
+}
+
+func TestClient_ListRepositories_OmitsQueryWhenSortEmpty(t *testing.T) {
+	t.Parallel()
+
+	var gotRawQuery string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"repositories":[]}`)) //nolint:errcheck // test handler
+	}))
+	defer server.Close()
+
+	c := NewClient("tok")
+	c.baseURL = server.URL
+
+	if _, err := c.ListRepositories(context.Background(), ""); err != nil {
+		t.Fatal(err)
+	}
+	if gotRawQuery != "" {
+		t.Errorf("query = %q, want empty", gotRawQuery)
+	}
+}
+
+func TestClient_ListRepositories_ErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"Failed to fetch repositories"}`)) //nolint:errcheck // test handler
+	}))
+	defer server.Close()
+
+	c := NewClient("tok")
+	c.baseURL = server.URL
+
+	_, err := c.ListRepositories(context.Background(), RepositorySortRecent)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	if !strings.Contains(err.Error(), "Failed to fetch repositories") {
+		t.Errorf("error = %v, want message from body", err)
+	}
+}

--- a/cmd/entire/cli/dispatch_wizard.go
+++ b/cmd/entire/cli/dispatch_wizard.go
@@ -12,7 +12,9 @@ import (
 	"sync"
 
 	"github.com/charmbracelet/huh"
+	"github.com/entireio/cli/cmd/entire/cli/api"
 	dispatchpkg "github.com/entireio/cli/cmd/entire/cli/dispatch"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	searchpkg "github.com/entireio/cli/cmd/entire/cli/search"
 	"github.com/go-git/go-git/v6"
@@ -21,8 +23,21 @@ import (
 
 var errDispatchCancelled = errors.New("dispatch cancelled")
 var listDispatchWizardRepos = discoverAuthenticatedDispatchWizardRepos
+var listDispatchWizardRepoResources = defaultListDispatchWizardRepoResources
 var resolveDispatchWizardTopLevel = resolveGitTopLevel
 var getDispatchWizardCurrentBranch = GetCurrentBranch
+
+func defaultListDispatchWizardRepoResources(ctx context.Context) ([]api.Repository, error) {
+	client, err := NewAuthenticatedAPIClient(false)
+	if err != nil {
+		return nil, err
+	}
+	repos, err := client.ListRepositories(ctx, api.RepositorySortRecent)
+	if err != nil {
+		return nil, fmt.Errorf("list dispatch repos: %w", err)
+	}
+	return repos, nil
+}
 
 const (
 	dispatchWizardRepoDiscoveryConcurrencyLimit = 8
@@ -365,8 +380,11 @@ func newLazyOptions(loader func() []huh.Option[string]) func() []huh.Option[stri
 	}
 }
 
+// buildDispatchRepoOptions preserves the caller's ordering so the API's
+// recent-first sort surfaces first in the picker. Callers that want
+// alphabetical ordering (e.g. the local-discovery fallback) sort before
+// calling.
 func buildDispatchRepoOptions(slugs []string) []huh.Option[string] {
-	sort.Strings(slugs)
 	options := make([]huh.Option[string], 0, len(slugs))
 	seen := make(map[string]struct{}, len(slugs))
 	for _, slug := range slugs {
@@ -482,36 +500,28 @@ func resolveGitTopLevel(ctx context.Context, path string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+// discoverAuthenticatedDispatchWizardRepos drops repos with zero checkpoints —
+// dispatching them would produce nothing. Server order (recent-first) is
+// preserved.
 func discoverAuthenticatedDispatchWizardRepos(ctx context.Context) ([]string, error) {
-	cmd := exec.CommandContext(
-		ctx,
-		"gh",
-		"api",
-		"--paginate",
-		"user/repos?per_page=100&affiliation=owner,collaborator,organization_member&sort=full_name",
-		"--jq",
-		".[].full_name",
-	)
-	output, err := cmd.Output()
+	repos, err := listDispatchWizardRepoResources(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("gh api user/repos: %w", err)
+		logging.Warn(ctx, "dispatch wizard repo list failed", "error", err)
+		return nil, err
 	}
 
-	repos := make([]string, 0)
-	seen := make(map[string]struct{})
-	for _, line := range strings.Split(string(output), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
+	slugs := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		if repo.CheckpointCount <= 0 {
 			continue
 		}
-		if _, ok := seen[line]; ok {
+		slug := strings.TrimSpace(repo.FullName)
+		if slug == "" {
 			continue
 		}
-		seen[line] = struct{}{}
-		repos = append(repos, line)
+		slugs = append(slugs, slug)
 	}
-	sort.Strings(repos)
-	return repos, nil
+	return slugs, nil
 }
 
 func discoverRepoSlug(repoRoot string) string {

--- a/cmd/entire/cli/dispatch_wizard.go
+++ b/cmd/entire/cli/dispatch_wizard.go
@@ -380,10 +380,9 @@ func newLazyOptions(loader func() []huh.Option[string]) func() []huh.Option[stri
 	}
 }
 
-// buildDispatchRepoOptions preserves the caller's ordering so the API's
-// recent-first sort surfaces first in the picker. Callers that want
-// alphabetical ordering (e.g. the local-discovery fallback) sort before
-// calling.
+// buildDispatchRepoOptions dedupes but preserves the caller's order so each
+// source can pick its own order: the API path surfaces recent-first, and the
+// local-discovery fallback surfaces the current repo first.
 func buildDispatchRepoOptions(slugs []string) []huh.Option[string] {
 	options := make([]huh.Option[string], 0, len(slugs))
 	seen := make(map[string]struct{}, len(slugs))

--- a/cmd/entire/cli/dispatch_wizard_test.go
+++ b/cmd/entire/cli/dispatch_wizard_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/huh"
+	"github.com/entireio/cli/cmd/entire/cli/api"
 	dispatchpkg "github.com/entireio/cli/cmd/entire/cli/dispatch"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/spf13/cobra"
@@ -91,8 +92,8 @@ func TestBuildDispatchRepoOptions_UsesFullSlugLabels(t *testing.T) {
 	t.Parallel()
 
 	options := buildDispatchRepoOptions([]string{"entireio/entire.io", "entireio/cli"})
-	if got := strings.Join(optionKeys(options), ","); got != "entireio/cli,entireio/entire.io" {
-		t.Fatalf("expected repo options to use org/repo labels sorted, got %q", got)
+	if got := strings.Join(optionKeys(options), ","); got != "entireio/entire.io,entireio/cli" {
+		t.Fatalf("expected repo options to use org/repo labels in caller order, got %q", got)
 	}
 }
 
@@ -285,11 +286,11 @@ func TestBuildDispatchCommand_AllBranches(t *testing.T) {
 	}
 }
 
-func TestBuildDispatchRepoOptions_DedupesAndSorts(t *testing.T) {
+func TestBuildDispatchRepoOptions_DedupesAndPreservesOrder(t *testing.T) {
 	t.Parallel()
 
 	options := buildDispatchRepoOptions([]string{"entireio/entire.io", "entireio/cli", "entireio/cli"})
-	if got := strings.Join(optionValues(options), ","); got != "entireio/cli,entireio/entire.io" {
+	if got := strings.Join(optionValues(options), ","); got != "entireio/entire.io,entireio/cli" {
 		t.Fatalf("unexpected repo options: %v", optionValues(options))
 	}
 }
@@ -374,6 +375,31 @@ func TestDispatchWizardState_CloudIgnoresCurrentBranchResolutionError(t *testing
 	}
 	if got := strings.Join(opts.RepoPaths, ","); got != "entireio/cli" {
 		t.Fatalf("expected selected repo path to propagate, got %q", got)
+	}
+}
+
+func TestDiscoverAuthenticatedDispatchWizardRepos_FiltersEmptyCheckpointsAndPreservesRecentOrder(t *testing.T) {
+	t.Parallel()
+
+	old := listDispatchWizardRepoResources
+	listDispatchWizardRepoResources = func(context.Context) ([]api.Repository, error) {
+		return []api.Repository{
+			{FullName: "entireio/most-recent", CheckpointCount: 3},
+			{FullName: "entireio/never-dispatched", CheckpointCount: 0},
+			{FullName: "entireio/older", CheckpointCount: 1},
+			{FullName: "", CheckpointCount: 5},
+		}, nil
+	}
+	t.Cleanup(func() {
+		listDispatchWizardRepoResources = old
+	})
+
+	slugs, err := discoverAuthenticatedDispatchWizardRepos(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(slugs, ","); got != "entireio/most-recent,entireio/older" {
+		t.Fatalf("expected recent-first order with empty-checkpoint and blank repos filtered, got %q", got)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/23a58f348df1
<!-- entire-trail-link-end -->

https://github.com/entirehq/entire.io/pull/1642 <- API on the other side.

Swaps the cloud-dispatch repo picker from shelling out to `gh api user/repos` to calling the Entire API's new /api/v1/repositories endpoint via the existing authenticated api.Client. Removes the hard dependency on a locally-installed, logged-in gh.

Repos with zero checkpoints are filtered out of the picker since dispatching them would produce nothing. Server order (recent-first) is preserved; buildDispatchRepoOptions no longer alphabetizes so the API's ordering surfaces in the picker — `/` filtering handles search.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the cloud dispatch repo discovery path to depend on a new authenticated `/api/v1/repositories` call and different ordering/filtering behavior, which could impact who sees which repos and in what order. Risk is moderate because it alters a user-facing workflow but doesn’t touch auth/token handling beyond reusing the existing client.
> 
> **Overview**
> The dispatch wizard’s *cloud* repo picker now fetches repositories via the CLI’s authenticated Entire API client (`GET /api/v1/repositories`, with `sort=recent`) instead of shelling out to `gh api`, removing the hard dependency on a locally installed/logged-in GitHub CLI.
> 
> Repo options no longer get alphabetized in `buildDispatchRepoOptions`, so the server-provided recent-first ordering is preserved, and repos with `checkpoint_count <= 0` (or blank `full_name`) are filtered out of the picker. Tests were updated/added to validate ordering, deduping, and checkpoint filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c683c712ff95d441c6ded86207014bfbe19010c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->