### PR TITLE
prevent test timeout waiting for interactive input

### DIFF
--- a/cmd/entire/cli/dispatch_wizard.go
+++ b/cmd/entire/cli/dispatch_wizard.go
@@ -26,6 +26,7 @@ var listDispatchWizardRepos = discoverAuthenticatedDispatchWizardRepos
 var listDispatchWizardRepoResources = defaultListDispatchWizardRepoResources
 var resolveDispatchWizardTopLevel = resolveGitTopLevel
 var getDispatchWizardCurrentBranch = GetCurrentBranch
+var runDispatchWizardForm = func(form *huh.Form) error { return form.Run() }
 
 func defaultListDispatchWizardRepoResources(ctx context.Context) ([]api.Repository, error) {
 	client, err := NewAuthenticatedAPIClient(false)
@@ -351,7 +352,7 @@ func runDispatchWizard(cmd *cobra.Command) (dispatchpkg.Options, error) {
 
 	fmt.Fprintln(cmd.OutOrStdout())
 
-	if err := form.Run(); err != nil {
+	if err := runDispatchWizardForm(form); err != nil {
 		if handled := handleFormCancellation(cmd.OutOrStdout(), "dispatch", err); handled == nil {
 			return dispatchpkg.Options{}, errDispatchCancelled
 		}

--- a/cmd/entire/cli/dispatch_wizard_test.go
+++ b/cmd/entire/cli/dispatch_wizard_test.go
@@ -352,6 +352,18 @@ func TestRunDispatchWizard_ProceedsWhenCurrentBranchCannotBeResolved(t *testing.
 		getDispatchWizardCurrentBranch = oldGetCurrentBranch
 	})
 
+	// Stub form execution so the test does not block on a TTY when run from a
+	// terminal. The "run dispatch wizard" error wrapper only exists after the
+	// wizard proceeds past branch resolution, so the assertion below is
+	// sufficient to prove form execution was reached.
+	oldRunForm := runDispatchWizardForm
+	runDispatchWizardForm = func(*huh.Form) error {
+		return errors.New("form execution stubbed")
+	}
+	t.Cleanup(func() {
+		runDispatchWizardForm = oldRunForm
+	})
+
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/6bb3a182c922
<!-- entire-trail-link-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only refactors how the form is executed (via an overridable function) and adjusts a test to stub the interactive call path.
> 
> **Overview**
> Prevents `dispatch_wizard` tests from blocking on interactive `huh` input by routing `form.Run()` through an overridable `runDispatchWizardForm` function.
> 
> Updates `TestRunDispatchWizard_ProceedsWhenCurrentBranchCannotBeResolved` to stub form execution and assert the wizard reaches the form-running path (via the `run dispatch wizard` error wrapper) instead of hanging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00542422e3c7755bfd7733ce83b830a852f29aad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->