### PR TITLE
fix: move Codex E2E CODEX_HOME out of /tmp

### DIFF
--- a/.github/workflows/e2e-isolated.yml
+++ b/.github/workflows/e2e-isolated.yml
@@ -70,7 +70,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          E2E_CODEX_MODEL: ${{ inputs.agent == 'codex' && 'gpt-5.1-codex-mini' || '' }}
+          E2E_CODEX_MODEL: ${{ inputs.agent == 'codex' && 'gpt-5.5' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/e2e-isolated.yml
+++ b/.github/workflows/e2e-isolated.yml
@@ -70,7 +70,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          E2E_CODEX_MODEL: ${{ inputs.agent == 'codex' && 'gpt-5.4' || '' }}
+          E2E_CODEX_MODEL: ${{ inputs.agent == 'codex' && 'gpt-5.4-mini' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/e2e-isolated.yml
+++ b/.github/workflows/e2e-isolated.yml
@@ -70,7 +70,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          E2E_CODEX_MODEL: ${{ inputs.agent == 'codex' && 'gpt-5.5' || '' }}
+          E2E_CODEX_MODEL: ${{ inputs.agent == 'codex' && 'gpt-5.4' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,7 +103,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.4' || '' }}
+          E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.4-mini' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,7 +103,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.1-codex-mini' || '' }}
+          E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.5' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,7 +103,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.5' || '' }}
+          E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.4' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ github.token }}

--- a/e2e/agents/codex.go
+++ b/e2e/agents/codex.go
@@ -67,17 +67,17 @@ func (c *Codex) IsTransientError(out Output, err error) bool {
 // recent Codex versions refuse to install PATH helper binaries when CODEX_HOME
 // sits under /tmp, which breaks subsequent tool calls.
 func codexHome() (string, func(), error) {
-	home, err := os.UserHomeDir()
+	cache, err := os.UserCacheDir()
 	if err != nil {
-		return "", nil, fmt.Errorf("resolve user home dir: %w", err)
+		return "", nil, fmt.Errorf("resolve user cache dir: %w", err)
 	}
-	base := filepath.Join(home, ".cache", "entire-e2e")
+	base := filepath.Join(cache, "entire-e2e")
 	if err := os.MkdirAll(base, 0o755); err != nil {
 		return "", nil, fmt.Errorf("create codex home base %q: %w", base, err)
 	}
 	dir, err := os.MkdirTemp(base, "codex-home-*")
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("create temporary codex home under %q: %w", base, err)
 	}
 	return dir, func() { _ = os.RemoveAll(dir) }, nil
 }

--- a/e2e/agents/codex.go
+++ b/e2e/agents/codex.go
@@ -62,8 +62,20 @@ func (c *Codex) IsTransientError(out Output, err error) bool {
 
 // codexHome creates an isolated CODEX_HOME for a test run.
 // Auth still works via OPENAI_API_KEY env var or symlinked auth.json.
+//
+// The directory lives under the user's home (not the system temp dir) because
+// recent Codex versions refuse to install PATH helper binaries when CODEX_HOME
+// sits under /tmp, which breaks subsequent tool calls.
 func codexHome() (string, func(), error) {
-	dir, err := os.MkdirTemp("", "codex-home-*")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve user home dir: %w", err)
+	}
+	base := filepath.Join(home, ".cache", "entire-e2e")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		return "", nil, fmt.Errorf("create codex home base %q: %w", base, err)
+	}
+	dir, err := os.MkdirTemp(base, "codex-home-*")
 	if err != nil {
 		return "", nil, err
 	}

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -53,18 +53,18 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 	// $HOME/.cache/entire-e2e-repos/ instead.
 	root := ""
 	if agent.Name() == "codex" {
-		home, herr := os.UserHomeDir()
-		if herr != nil {
-			t.Fatalf("resolve user home dir: %v", herr)
+		cache, cerr := os.UserCacheDir()
+		if cerr != nil {
+			t.Fatalf("resolve user cache dir: %v", cerr)
 		}
-		root = filepath.Join(home, ".cache", "entire-e2e-repos")
+		root = filepath.Join(cache, "entire-e2e-repos")
 		if err := os.MkdirAll(root, 0o755); err != nil {
 			t.Fatalf("create e2e repo root %q: %v", root, err)
 		}
 	}
 	dir, err := os.MkdirTemp(root, "e2e-repo-*")
 	if err != nil {
-		t.Fatalf("create temp dir: %v", err)
+		t.Fatalf("create temporary e2e repo under %q: %v", root, err)
 	}
 	if keepRepos {
 		t.Logf("E2E_KEEP_REPOS: repo will be preserved at %s", dir)

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -47,7 +47,22 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 	// Always use os.MkdirTemp instead of t.TempDir(). Go's t.TempDir()
 	// creates nested subdirectories (TestName.../001/) whose structure
 	// confuses some agents' (e.g. opencode) working-directory resolution.
-	dir, err := os.MkdirTemp("", "e2e-repo-*")
+	//
+	// Codex refuses to operate from /tmp (e.g. "Refusing to create helper
+	// binaries under temporary dir"), so for codex we place the repo under
+	// $HOME/.cache/entire-e2e-repos/ instead.
+	root := ""
+	if agent.Name() == "codex" {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			t.Fatalf("resolve user home dir: %v", herr)
+		}
+		root = filepath.Join(home, ".cache", "entire-e2e-repos")
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatalf("create e2e repo root %q: %v", root, err)
+		}
+	}
+	dir, err := os.MkdirTemp(root, "e2e-repo-*")
 	if err != nil {
 		t.Fatalf("create temp dir: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Move per-run `CODEX_HOME` under `$HOME/.cache/entire-e2e/` — recent Codex
  refuses to install PATH helper binaries when `CODEX_HOME` is under `/tmp`.
- Move per-test working repositories under `$HOME/.cache/entire-e2e-repos/`
  for the `codex` agent — same refusal extends to the workdir.
- Switch CI `E2E_CODEX_MODEL` from `gpt-5.1-codex-mini` to `gpt-5.4-mini`.
  The mini-codex model with reasoning effort `none` was bailing mid-task
  (e.g. `mkdir docs/` then stopping without writing the file) and emitting
  malformed tool calls (`missing field \`cmd\``).

## Context
Failures on https://github.com/entireio/cli/actions/runs/24898092786/job/72908274849
(`soph/investigate-codex`) traced back to `/tmp` refusals. After the first fix
landed, run https://github.com/entireio/cli/actions/runs/24901275226/job/72919302748
showed the remaining failures were model-quality issues rather than test
infrastructure, hence the model bump.

## Test plan
- [ ] `e2e-tests (codex)` run shows zero `Refusing to create helper binaries under temporary dir` occurrences
- [ ] No `/tmp/e2e-repo-*` workdirs in Codex logs; repos live under `$HOME/.cache/entire-e2e-repos/`
- [ ] Codex E2E suite passes on `gpt-5.4-mini`

🤖 Generated with [Claude Code](https://claude.com/claude-code)