### PR TITLE
headless gemini rejects untrusted temp repos now, let' fix that

### DIFF
--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -20,7 +20,8 @@ func init() {
 }
 
 const geminiDefaultModel = "gemini-2.5-flash"
-const geminiTrustWorkspaceEnv = "GEMINI_CLI_TRUST_WORKSPACE=true"
+const geminiTrustWorkspaceEnvKey = "GEMINI_CLI_TRUST_WORKSPACE"
+const geminiTrustWorkspaceEnv = geminiTrustWorkspaceEnvKey + "=true"
 
 type Gemini struct{}
 
@@ -151,7 +152,7 @@ func geminiTestHomeDir(repoDir string) string {
 
 func geminiPromptEnv(repoDir string) []string {
 	return append(
-		filterEnv(os.Environ(), "ENTIRE_TEST_TTY", "GEMINI_CLI_TRUST_WORKSPACE"),
+		filterEnv(os.Environ(), "ENTIRE_TEST_TTY", geminiTrustWorkspaceEnvKey),
 		"ACCESSIBLE=1",
 		geminiTrustWorkspaceEnv,
 		"HOME="+geminiTestHomeDir(repoDir),

--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -20,6 +20,7 @@ func init() {
 }
 
 const geminiDefaultModel = "gemini-2.5-flash"
+const geminiTrustWorkspaceEnv = "GEMINI_CLI_TRUST_WORKSPACE=true"
 
 type Gemini struct{}
 
@@ -75,11 +76,7 @@ func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 	cmd := exec.CommandContext(promptCtx, g.Binary(), args...)
 	cmd.Dir = dir
 	cmd.Stdin = nil
-	cmd.Env = append(
-		filterEnv(os.Environ(), "ENTIRE_TEST_TTY"),
-		"ACCESSIBLE=1",
-		"HOME="+geminiTestHomeDir(dir),
-	)
+	cmd.Env = geminiPromptEnv(dir)
 	setupProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
 
@@ -114,7 +111,7 @@ func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 func (g *Gemini) StartSession(_ context.Context, dir string) (Session, error) {
 	name := fmt.Sprintf("gemini-test-%d", time.Now().UnixNano())
 
-	envArgs := []string{"ACCESSIBLE=1", "HOME=" + geminiTestHomeDir(dir)}
+	envArgs := []string{"ACCESSIBLE=1", geminiTrustWorkspaceEnv, "HOME=" + geminiTestHomeDir(dir)}
 	for _, key := range []string{"TERM"} {
 		if v := os.Getenv(key); v != "" {
 			envArgs = append(envArgs, key+"="+v)
@@ -150,4 +147,13 @@ func (g *Gemini) StartSession(_ context.Context, dir string) (Session, error) {
 
 func geminiTestHomeDir(repoDir string) string {
 	return filepath.Join(filepath.Dir(repoDir), filepath.Base(repoDir)+"-gemini-home")
+}
+
+func geminiPromptEnv(repoDir string) []string {
+	return append(
+		filterEnv(os.Environ(), "ENTIRE_TEST_TTY", "GEMINI_CLI_TRUST_WORKSPACE"),
+		"ACCESSIBLE=1",
+		geminiTrustWorkspaceEnv,
+		"HOME="+geminiTestHomeDir(repoDir),
+	)
 }

--- a/e2e/agents/gemini_test.go
+++ b/e2e/agents/gemini_test.go
@@ -8,28 +8,28 @@ import (
 
 func TestGeminiPromptEnv_TrustsWorkspaceForHeadlessRuns(t *testing.T) {
 	t.Setenv("ENTIRE_TEST_TTY", "1")
-	t.Setenv("GEMINI_CLI_TRUST_WORKSPACE", "false")
+	t.Setenv(geminiTrustWorkspaceEnvKey, "false")
 
 	repoDir := filepath.Join(t.TempDir(), "repo")
 	env := geminiPromptEnv(repoDir)
 
-	if got := envValue(env, "GEMINI_CLI_TRUST_WORKSPACE"); got != "true" {
-		t.Fatalf("GEMINI_CLI_TRUST_WORKSPACE = %q, want true", got)
+	if got, _ := envValue(env, geminiTrustWorkspaceEnvKey); got != "true" {
+		t.Fatalf("%s = %q, want true", geminiTrustWorkspaceEnvKey, got)
 	}
-	if got := envValue(env, "ENTIRE_TEST_TTY"); got != "" {
+	if got, ok := envValue(env, "ENTIRE_TEST_TTY"); ok {
 		t.Fatalf("ENTIRE_TEST_TTY = %q, want unset", got)
 	}
-	if got := envValue(env, "HOME"); got != geminiTestHomeDir(repoDir) {
+	if got, _ := envValue(env, "HOME"); got != geminiTestHomeDir(repoDir) {
 		t.Fatalf("HOME = %q, want %q", got, geminiTestHomeDir(repoDir))
 	}
 }
 
-func envValue(env []string, key string) string {
+func envValue(env []string, key string) (string, bool) {
 	prefix := key + "="
 	for i := len(env) - 1; i >= 0; i-- {
 		if strings.HasPrefix(env[i], prefix) {
-			return strings.TrimPrefix(env[i], prefix)
+			return strings.TrimPrefix(env[i], prefix), true
 		}
 	}
-	return ""
+	return "", false
 }

--- a/e2e/agents/gemini_test.go
+++ b/e2e/agents/gemini_test.go
@@ -1,0 +1,35 @@
+package agents
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGeminiPromptEnv_TrustsWorkspaceForHeadlessRuns(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+	t.Setenv("GEMINI_CLI_TRUST_WORKSPACE", "false")
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	env := geminiPromptEnv(repoDir)
+
+	if got := envValue(env, "GEMINI_CLI_TRUST_WORKSPACE"); got != "true" {
+		t.Fatalf("GEMINI_CLI_TRUST_WORKSPACE = %q, want true", got)
+	}
+	if got := envValue(env, "ENTIRE_TEST_TTY"); got != "" {
+		t.Fatalf("ENTIRE_TEST_TTY = %q, want unset", got)
+	}
+	if got := envValue(env, "HOME"); got != geminiTestHomeDir(repoDir) {
+		t.Fatalf("HOME = %q, want %q", got, geminiTestHomeDir(repoDir))
+	}
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix)
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1f31cd3deeb4
<!-- entire-trail-link-end -->

fixes gemini E2E

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E harness environment construction for the Gemini agent, with a new unit test to guard behavior.
> 
> **Overview**
> Ensures headless Gemini CLI E2E runs don’t fail due to untrusted temporary repos by always setting `GEMINI_CLI_TRUST_WORKSPACE=true` for prompt and session execution, while filtering any preexisting `GEMINI_CLI_TRUST_WORKSPACE`/`ENTIRE_TEST_TTY` values from the inherited environment.
> 
> Extracts prompt environment setup into `geminiPromptEnv` and adds a focused test (`gemini_test.go`) verifying the trust flag is forced, `ENTIRE_TEST_TTY` is unset, and `HOME` is redirected to the per-test Gemini home directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f183b8d865cf3c47135bb9e2a48452fec0fdfd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->