### PR TITLE
Checkpoints V2: Expose cli version to external agents for compact transcripts

### DIFF
--- a/cmd/entire/cli/agent/external/external.go
+++ b/cmd/entire/cli/agent/external/external.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 // defaultRunTimeout is the maximum time an external binary call may take when
@@ -434,9 +435,10 @@ func (e *Agent) run(ctx context.Context, stdin []byte, args ...string) ([]byte, 
 	// so cmd.Run() doesn't block waiting for pipe reads.
 	cmd.WaitDelay = 3 * time.Second
 
-	// Set environment: repo root + protocol version
+	// Set environment: repo root + protocol version + CLI version
 	cmd.Env = append(cmd.Environ(),
 		"ENTIRE_PROTOCOL_VERSION="+strconv.Itoa(ProtocolVersion),
+		"ENTIRE_CLI_VERSION="+versioninfo.Version,
 	)
 	if repoRoot, err := paths.WorktreeRoot(ctx); err == nil {
 		cmd.Env = append(cmd.Env, "ENTIRE_REPO_ROOT="+repoRoot)

--- a/cmd/entire/cli/agent/external/external.go
+++ b/cmd/entire/cli/agent/external/external.go
@@ -435,7 +435,6 @@ func (e *Agent) run(ctx context.Context, stdin []byte, args ...string) ([]byte, 
 	// so cmd.Run() doesn't block waiting for pipe reads.
 	cmd.WaitDelay = 3 * time.Second
 
-	// Set environment: repo root + protocol version + CLI version
 	cmd.Env = append(cmd.Environ(),
 		"ENTIRE_PROTOCOL_VERSION="+strconv.Itoa(ProtocolVersion),
 		"ENTIRE_CLI_VERSION="+versioninfo.Version,

--- a/cmd/entire/cli/agent/external/external_test.go
+++ b/cmd/entire/cli/agent/external/external_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 // testBinaryDir creates a temp directory with a mock entire-agent-test binary.

--- a/cmd/entire/cli/agent/external/external_test.go
+++ b/cmd/entire/cli/agent/external/external_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
-	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 // testBinaryDir creates a temp directory with a mock entire-agent-test binary.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/6dd818fd36d9
<!-- entire-trail-link-end -->

The `cli_version` field for external agents was falling back to `unknown` because we weren't exposing it. This allows external agents to see the CLI version for the compact transcripts. Tested locally with the Kiro agent in https://github.com/entireio/external-agents/pull/13 and verified it works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new environment variable to external agent subprocess execution without changing control flow or data handling.
> 
> **Overview**
> External agent invocations now include `ENTIRE_CLI_VERSION` (sourced from `versioninfo.Version`) in the environment passed to the external binary, alongside `ENTIRE_PROTOCOL_VERSION`, so agents can reliably record the CLI version (e.g., for compact transcript metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9832d1a16b6965a3c4908803c163c444693cfe4a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->