### PR TITLE
Clean up v1-named transcript files on /full/current during `entire migrate`

### DIFF
--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -223,18 +223,15 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 	v1TranscriptPath := sessionPath + paths.TranscriptFileName
 	v1HashPath := sessionPath + paths.ContentHashFileName
 
-	hasLegacyV1Files := false
-	for key := range entries {
-		switch {
-		case key == v1TranscriptPath:
-			hasLegacyV1Files = true
-		case strings.HasPrefix(key, v1TranscriptPath+"."):
-			hasLegacyV1Files = true
-		case key == v1HashPath:
-			hasLegacyV1Files = true
-		}
-		if hasLegacyV1Files {
-			break
+	_, hasV1Transcript := entries[v1TranscriptPath]
+	_, hasV1Hash := entries[v1HashPath]
+	hasLegacyV1Files := hasV1Transcript || hasV1Hash
+	if !hasLegacyV1Files {
+		for key := range entries {
+			if strings.HasPrefix(key, v1TranscriptPath+".") {
+				hasLegacyV1Files = true
+				break
+			}
 		}
 	}
 

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -220,6 +220,24 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 	// same content — preserve them and skip chunking + zlib.
 	rawTranscriptPath := sessionPath + paths.V2RawTranscriptFileName
 	rawHashPath := sessionPath + paths.V2RawTranscriptHashFileName
+	v1TranscriptPath := sessionPath + paths.TranscriptFileName
+	v1HashPath := sessionPath + paths.ContentHashFileName
+
+	hasLegacyV1Files := false
+	for key := range entries {
+		switch {
+		case key == v1TranscriptPath:
+			hasLegacyV1Files = true
+		case strings.HasPrefix(key, v1TranscriptPath+"."):
+			hasLegacyV1Files = true
+		case key == v1HashPath:
+			hasLegacyV1Files = true
+		}
+		if hasLegacyV1Files {
+			break
+		}
+	}
+
 	var newContentHash string
 	if precomputed != nil {
 		newContentHash = precomputed.ContentHash
@@ -231,7 +249,7 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 			if rdr, rerr := blob.Reader(); rerr == nil {
 				existingHash, readErr := io.ReadAll(rdr)
 				_ = rdr.Close()
-				if readErr == nil && string(existingHash) == newContentHash {
+				if readErr == nil && string(existingHash) == newContentHash && !hasLegacyV1Files {
 					// Content unchanged — skip tree surgery and ref advance to
 					// avoid a no-op commit on /full/current. The existing ref
 					// already references the correct tree.
@@ -245,8 +263,6 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 	// Preserve non-transcript metadata under the same session (e.g., tasks/*).
 	// Also clean up v1-named files (full.jsonl, content_hash.txt) that may have been
 	// written by older CLI versions to /full/current before the v2 rename to raw_transcript.
-	v1TranscriptPath := sessionPath + paths.TranscriptFileName
-	v1HashPath := sessionPath + paths.ContentHashFileName
 	for key := range entries {
 		switch {
 		case key == rawTranscriptPath:

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -220,23 +220,6 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 	// same content — preserve them and skip chunking + zlib.
 	rawTranscriptPath := sessionPath + paths.V2RawTranscriptFileName
 	rawHashPath := sessionPath + paths.V2RawTranscriptHashFileName
-	v1TranscriptPath := sessionPath + paths.TranscriptFileName
-	v1HashPath := sessionPath + paths.ContentHashFileName
-
-	// Detect legacy v1 files so the content-hash short-circuit below doesn't
-	// skip cleanup when the transcript content is unchanged.
-	_, hasV1Transcript := entries[v1TranscriptPath]
-	_, hasV1Hash := entries[v1HashPath]
-	hasLegacyV1Files := hasV1Transcript || hasV1Hash
-	if !hasLegacyV1Files {
-		for key := range entries {
-			if strings.HasPrefix(key, v1TranscriptPath+".") {
-				hasLegacyV1Files = true
-				break
-			}
-		}
-	}
-
 	var newContentHash string
 	if precomputed != nil {
 		newContentHash = precomputed.ContentHash
@@ -248,7 +231,7 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 			if rdr, rerr := blob.Reader(); rerr == nil {
 				existingHash, readErr := io.ReadAll(rdr)
 				_ = rdr.Close()
-				if readErr == nil && string(existingHash) == newContentHash && !hasLegacyV1Files {
+				if readErr == nil && string(existingHash) == newContentHash {
 					// Content unchanged — skip tree surgery and ref advance to
 					// avoid a no-op commit on /full/current. The existing ref
 					// already references the correct tree.
@@ -260,8 +243,6 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 
 	// Clear existing transcript artifacts for this session path before writing new ones.
 	// Preserve non-transcript metadata under the same session (e.g., tasks/*).
-	// Also clean up v1-named files (full.jsonl, content_hash.txt) that may have been
-	// written by older CLI versions to /full/current before the v2 rename to raw_transcript.
 	for key := range entries {
 		switch {
 		case key == rawTranscriptPath:
@@ -269,12 +250,6 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 		case strings.HasPrefix(key, rawTranscriptPath+"."):
 			delete(entries, key)
 		case key == rawHashPath:
-			delete(entries, key)
-		case key == v1TranscriptPath:
-			delete(entries, key)
-		case strings.HasPrefix(key, v1TranscriptPath+"."):
-			delete(entries, key)
-		case key == v1HashPath:
 			delete(entries, key)
 		}
 	}
@@ -752,4 +727,55 @@ func (s *V2GitStore) UpdateSummary(ctx context.Context, checkpointID id.Checkpoi
 	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
 	commitMsg := fmt.Sprintf("Update summary for checkpoint %s (session: %s)", checkpointID, metadata.SessionID)
 	return s.updateRef(ctx, refName, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
+}
+
+// CleanupV1TranscriptFiles removes legacy v1-named transcript files (full.jsonl,
+// full.jsonl.*, content_hash.txt) from /full/current for a given checkpoint.
+// Older CLI versions wrote these before the rename to raw_transcript.
+// Returns nil if /full/current doesn't exist or no v1 files were found.
+func (s *V2GitStore) CleanupV1TranscriptFiles(ctx context.Context, checkpointID id.CheckpointID, sessionCount int) error {
+	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+	parentHash, rootTreeHash, err := s.GetRefState(refName)
+	if err != nil {
+		return nil //nolint:nilerr // /full/current doesn't exist yet — nothing to clean
+	}
+
+	checkpointPath := checkpointID.Path()
+	basePath := checkpointPath + "/"
+
+	entries, err := s.gs.flattenCheckpointEntries(rootTreeHash, checkpointPath)
+	if err != nil {
+		return nil //nolint:nilerr // Checkpoint not in tree — nothing to clean
+	}
+
+	changed := false
+	for sessionIdx := range sessionCount {
+		sessionPath := fmt.Sprintf("%s%d/", basePath, sessionIdx)
+		v1TranscriptPath := sessionPath + paths.TranscriptFileName
+		v1HashPath := sessionPath + paths.ContentHashFileName
+
+		for key := range entries {
+			switch {
+			case key == v1TranscriptPath,
+				strings.HasPrefix(key, v1TranscriptPath+"."),
+				key == v1HashPath:
+				delete(entries, key)
+				changed = true
+			}
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	newTreeHash, err := s.gs.spliceCheckpointSubtree(ctx, rootTreeHash, checkpointID, basePath, entries)
+	if err != nil {
+		return fmt.Errorf("tree surgery failed: %w", err)
+	}
+
+	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+	return s.updateRef(ctx, refName, newTreeHash, parentHash,
+		fmt.Sprintf("Clean up v1 transcript files for %s\n", checkpointID),
+		authorName, authorEmail)
 }

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -243,6 +243,10 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 
 	// Clear existing transcript artifacts for this session path before writing new ones.
 	// Preserve non-transcript metadata under the same session (e.g., tasks/*).
+	// Also clean up v1-named files (full.jsonl, content_hash.txt) that may have been
+	// written by older CLI versions to /full/current before the v2 rename to raw_transcript.
+	v1TranscriptPath := sessionPath + paths.TranscriptFileName
+	v1HashPath := sessionPath + paths.ContentHashFileName
 	for key := range entries {
 		switch {
 		case key == rawTranscriptPath:
@@ -250,6 +254,12 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 		case strings.HasPrefix(key, rawTranscriptPath+"."):
 			delete(entries, key)
 		case key == rawHashPath:
+			delete(entries, key)
+		case key == v1TranscriptPath:
+			delete(entries, key)
+		case strings.HasPrefix(key, v1TranscriptPath+"."):
+			delete(entries, key)
+		case key == v1HashPath:
 			delete(entries, key)
 		}
 	}

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -223,6 +223,8 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 	v1TranscriptPath := sessionPath + paths.TranscriptFileName
 	v1HashPath := sessionPath + paths.ContentHashFileName
 
+	// Detect legacy v1 files so the content-hash short-circuit below doesn't
+	// skip cleanup when the transcript content is unchanged.
 	_, hasV1Transcript := entries[v1TranscriptPath]
 	_, hasV1Hash := entries[v1HashPath]
 	hasLegacyV1Files := hasV1Transcript || hasV1Hash

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -737,7 +737,10 @@ func (s *V2GitStore) CleanupV1TranscriptFiles(ctx context.Context, checkpointID 
 	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
 	parentHash, rootTreeHash, err := s.GetRefState(refName)
 	if err != nil {
-		return nil //nolint:nilerr // /full/current doesn't exist yet — nothing to clean
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return nil // /full/current doesn't exist yet — nothing to clean
+		}
+		return err
 	}
 
 	checkpointPath := checkpointID.Path()
@@ -745,7 +748,7 @@ func (s *V2GitStore) CleanupV1TranscriptFiles(ctx context.Context, checkpointID 
 
 	entries, err := s.gs.flattenCheckpointEntries(rootTreeHash, checkpointPath)
 	if err != nil {
-		return nil //nolint:nilerr // Checkpoint not in tree — nothing to clean
+		return err
 	}
 
 	changed := false

--- a/cmd/entire/cli/checkpoint/v2_store_test.go
+++ b/cmd/entire/cli/checkpoint/v2_store_test.go
@@ -1023,3 +1023,110 @@ func TestWriteCommitted_NoRotationBelowThreshold(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, noRotCount)
 }
+
+// TestV2GitStore_UpdateCommittedFullTranscript_CleansUpV1NamedFiles verifies that
+// updateCommittedFullTranscript removes legacy v1-named files (full.jsonl,
+// content_hash.txt) that may have been written by older CLI versions, preventing
+// duplicate transcript files on /full/current.
+func TestV2GitStore_UpdateCommittedFullTranscript_CleansUpV1NamedFiles(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+	ctx := context.Background()
+
+	cpID := id.MustCheckpointID("851fcec4a874")
+
+	// Step 1: Write initial checkpoint via WriteCommitted (sets up both /main and /full/current).
+	initialTranscript := []byte(`{"type":"human","message":"initial"}` + "\n")
+	err := store.WriteCommitted(ctx, WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "test-session-v1-cleanup",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted(initialTranscript),
+		Agent:        agent.AgentTypeClaudeCode,
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	// Step 2: Inject v1-named files (full.jsonl, full.jsonl.001, content_hash.txt)
+	// directly into the /full/current tree to simulate legacy data.
+	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+	parentHash, rootTreeHash, err := store.GetRefState(refName)
+	require.NoError(t, err)
+
+	basePath := cpID.Path() + "/"
+	sessionPath := basePath + "0/"
+
+	entries, err := store.gs.flattenCheckpointEntries(rootTreeHash, cpID.Path())
+	require.NoError(t, err)
+
+	// Add v1-named files
+	v1Blob, err := CreateBlobFromContent(repo, []byte(`{"type":"human","message":"v1 data"}`+"\n"))
+	require.NoError(t, err)
+	v1HashBlob, err := CreateBlobFromContent(repo, []byte("sha256:v1hash"))
+	require.NoError(t, err)
+	v1ChunkBlob, err := CreateBlobFromContent(repo, []byte(`{"type":"assistant","message":"v1 chunk"}`+"\n"))
+	require.NoError(t, err)
+
+	entries[sessionPath+paths.TranscriptFileName] = object.TreeEntry{
+		Name: sessionPath + paths.TranscriptFileName,
+		Mode: filemode.Regular,
+		Hash: v1Blob,
+	}
+	entries[sessionPath+paths.TranscriptFileName+".001"] = object.TreeEntry{
+		Name: sessionPath + paths.TranscriptFileName + ".001",
+		Mode: filemode.Regular,
+		Hash: v1ChunkBlob,
+	}
+	entries[sessionPath+paths.ContentHashFileName] = object.TreeEntry{
+		Name: sessionPath + paths.ContentHashFileName,
+		Mode: filemode.Regular,
+		Hash: v1HashBlob,
+	}
+
+	newTreeHash, err := store.gs.spliceCheckpointSubtree(ctx, rootTreeHash, cpID, basePath, entries)
+	require.NoError(t, err)
+	err = store.updateRef(ctx, refName, newTreeHash, parentHash, "Inject v1 files", "Test", "test@test.com")
+	require.NoError(t, err)
+
+	// Verify v1-named files exist alongside v2-named files before the update.
+	tree := v2FullTree(t, repo)
+	cpPath := cpID.Path()
+	sessionTree, err := tree.Tree(cpPath + "/0")
+	require.NoError(t, err)
+	v1FileNames := make(map[string]bool)
+	for _, entry := range sessionTree.Entries {
+		v1FileNames[entry.Name] = true
+	}
+	assert.True(t, v1FileNames[paths.TranscriptFileName], "full.jsonl should exist before update")
+	assert.True(t, v1FileNames[paths.TranscriptFileName+".001"], "full.jsonl.001 should exist before update")
+	assert.True(t, v1FileNames[paths.ContentHashFileName], "content_hash.txt should exist before update")
+	assert.True(t, v1FileNames[paths.V2RawTranscriptFileName], "raw_transcript should exist before update")
+
+	// Step 3: Call UpdateCommitted, which calls updateCommittedFullTranscript.
+	updatedTranscript := []byte(`{"type":"human","message":"updated"}` + "\n")
+	err = store.UpdateCommitted(ctx, UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "test-session-v1-cleanup",
+		Transcript:   redact.AlreadyRedacted(updatedTranscript),
+		Agent:        agent.AgentTypeClaudeCode,
+	})
+	require.NoError(t, err)
+
+	// Step 4: Verify v1-named files are gone, v2-named files are present.
+	tree = v2FullTree(t, repo)
+	sessionTree, err = tree.Tree(cpPath + "/0")
+	require.NoError(t, err)
+
+	fileNames := make(map[string]bool)
+	for _, entry := range sessionTree.Entries {
+		fileNames[entry.Name] = true
+	}
+
+	assert.True(t, fileNames[paths.V2RawTranscriptFileName], "raw_transcript should exist after update")
+	assert.True(t, fileNames[paths.V2RawTranscriptHashFileName], "raw_transcript_hash.txt should exist after update")
+	assert.False(t, fileNames[paths.TranscriptFileName], "full.jsonl should be cleaned up after update")
+	assert.False(t, fileNames[paths.TranscriptFileName+".001"], "full.jsonl.001 should be cleaned up after update")
+	assert.False(t, fileNames[paths.ContentHashFileName], "content_hash.txt should be cleaned up after update")
+}

--- a/cmd/entire/cli/checkpoint/v2_store_test.go
+++ b/cmd/entire/cli/checkpoint/v2_store_test.go
@@ -1130,3 +1130,76 @@ func TestV2GitStore_UpdateCommittedFullTranscript_CleansUpV1NamedFiles(t *testin
 	assert.False(t, fileNames[paths.TranscriptFileName+".001"], "full.jsonl.001 should be cleaned up after update")
 	assert.False(t, fileNames[paths.ContentHashFileName], "content_hash.txt should be cleaned up after update")
 }
+
+// TestV2GitStore_UpdateCommittedFullTranscript_SameContentCleansUpV1Files verifies
+// that v1-named files are cleaned up even when the transcript content is identical
+// (hash matches), which would normally trigger the short-circuit that skips tree surgery.
+func TestV2GitStore_UpdateCommittedFullTranscript_SameContentCleansUpV1Files(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+	ctx := context.Background()
+
+	cpID := id.MustCheckpointID("962fcec4a874")
+	transcript := []byte(`{"type":"human","message":"same content"}` + "\n")
+
+	// Write initial checkpoint.
+	err := store.WriteCommitted(ctx, WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "test-session-same-content",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted(transcript),
+		Agent:        agent.AgentTypeClaudeCode,
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	// Inject v1-named files into /full/current.
+	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+	parentHash, rootTreeHash, err := store.GetRefState(refName)
+	require.NoError(t, err)
+
+	basePath := cpID.Path() + "/"
+	sessionPath := basePath + "0/"
+
+	entries, err := store.gs.flattenCheckpointEntries(rootTreeHash, cpID.Path())
+	require.NoError(t, err)
+
+	v1Blob, err := CreateBlobFromContent(repo, []byte(`{"type":"human","message":"v1 data"}`+"\n"))
+	require.NoError(t, err)
+
+	entries[sessionPath+paths.TranscriptFileName] = object.TreeEntry{
+		Name: sessionPath + paths.TranscriptFileName,
+		Mode: filemode.Regular,
+		Hash: v1Blob,
+	}
+
+	newTreeHash, err := store.gs.spliceCheckpointSubtree(ctx, rootTreeHash, cpID, basePath, entries)
+	require.NoError(t, err)
+	err = store.updateRef(ctx, refName, newTreeHash, parentHash, "Inject v1 file", "Test", "test@test.com")
+	require.NoError(t, err)
+
+	// Call UpdateCommitted with the SAME transcript content (hash will match raw_transcript_hash.txt).
+	// Without the !hasLegacyV1Files guard, the short-circuit would return early and leave full.jsonl.
+	err = store.UpdateCommitted(ctx, UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "test-session-same-content",
+		Transcript:   redact.AlreadyRedacted(transcript),
+		Agent:        agent.AgentTypeClaudeCode,
+	})
+	require.NoError(t, err)
+
+	// Verify v1 file is gone despite identical content.
+	tree := v2FullTree(t, repo)
+	sessionTree, err := tree.Tree(cpID.Path() + "/0")
+	require.NoError(t, err)
+
+	fileNames := make(map[string]bool)
+	for _, entry := range sessionTree.Entries {
+		fileNames[entry.Name] = true
+	}
+
+	assert.True(t, fileNames[paths.V2RawTranscriptFileName], "raw_transcript should exist")
+	assert.False(t, fileNames[paths.TranscriptFileName], "full.jsonl should be cleaned up even with identical content")
+}

--- a/cmd/entire/cli/checkpoint/v2_store_test.go
+++ b/cmd/entire/cli/checkpoint/v2_store_test.go
@@ -1024,11 +1024,10 @@ func TestWriteCommitted_NoRotationBelowThreshold(t *testing.T) {
 	assert.Equal(t, 3, noRotCount)
 }
 
-// TestV2GitStore_UpdateCommittedFullTranscript_CleansUpV1NamedFiles verifies that
-// updateCommittedFullTranscript removes legacy v1-named files (full.jsonl,
-// content_hash.txt) that may have been written by older CLI versions, preventing
-// duplicate transcript files on /full/current.
-func TestV2GitStore_UpdateCommittedFullTranscript_CleansUpV1NamedFiles(t *testing.T) {
+// TestV2GitStore_CleanupV1TranscriptFiles verifies that CleanupV1TranscriptFiles
+// removes legacy v1-named files (full.jsonl, full.jsonl.*, content_hash.txt)
+// from /full/current while preserving v2-named files.
+func TestV2GitStore_CleanupV1TranscriptFiles(t *testing.T) {
 	t.Parallel()
 	repo := initTestRepo(t)
 	store := NewV2GitStore(repo, "origin")
@@ -1036,20 +1035,19 @@ func TestV2GitStore_UpdateCommittedFullTranscript_CleansUpV1NamedFiles(t *testin
 
 	cpID := id.MustCheckpointID("851fcec4a874")
 
-	// Step 1: Write initial checkpoint via WriteCommitted (sets up both /main and /full/current).
-	initialTranscript := []byte(`{"type":"human","message":"initial"}` + "\n")
+	// Write initial checkpoint (sets up both /main and /full/current with v2 naming).
 	err := store.WriteCommitted(ctx, WriteCommittedOptions{
 		CheckpointID: cpID,
 		SessionID:    "test-session-v1-cleanup",
 		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted(initialTranscript),
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"human","message":"initial"}` + "\n")),
 		Agent:        agent.AgentTypeClaudeCode,
 		AuthorName:   "Test",
 		AuthorEmail:  "test@test.com",
 	})
 	require.NoError(t, err)
 
-	// Step 2: Inject v1-named files (full.jsonl, full.jsonl.001, content_hash.txt)
+	// Inject v1-named files (full.jsonl, full.jsonl.001, content_hash.txt)
 	// directly into the /full/current tree to simulate legacy data.
 	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
 	parentHash, rootTreeHash, err := store.GetRefState(refName)
@@ -1061,7 +1059,6 @@ func TestV2GitStore_UpdateCommittedFullTranscript_CleansUpV1NamedFiles(t *testin
 	entries, err := store.gs.flattenCheckpointEntries(rootTreeHash, cpID.Path())
 	require.NoError(t, err)
 
-	// Add v1-named files
 	v1Blob, err := CreateBlobFromContent(repo, []byte(`{"type":"human","message":"v1 data"}`+"\n"))
 	require.NoError(t, err)
 	v1HashBlob, err := CreateBlobFromContent(repo, []byte("sha256:v1hash"))
@@ -1090,116 +1087,72 @@ func TestV2GitStore_UpdateCommittedFullTranscript_CleansUpV1NamedFiles(t *testin
 	err = store.updateRef(ctx, refName, newTreeHash, parentHash, "Inject v1 files", "Test", "test@test.com")
 	require.NoError(t, err)
 
-	// Verify v1-named files exist alongside v2-named files before the update.
+	// Verify v1-named files exist before cleanup.
 	tree := v2FullTree(t, repo)
 	cpPath := cpID.Path()
 	sessionTree, err := tree.Tree(cpPath + "/0")
 	require.NoError(t, err)
-	v1FileNames := make(map[string]bool)
+	preCleanup := make(map[string]bool)
 	for _, entry := range sessionTree.Entries {
-		v1FileNames[entry.Name] = true
+		preCleanup[entry.Name] = true
 	}
-	assert.True(t, v1FileNames[paths.TranscriptFileName], "full.jsonl should exist before update")
-	assert.True(t, v1FileNames[paths.TranscriptFileName+".001"], "full.jsonl.001 should exist before update")
-	assert.True(t, v1FileNames[paths.ContentHashFileName], "content_hash.txt should exist before update")
-	assert.True(t, v1FileNames[paths.V2RawTranscriptFileName], "raw_transcript should exist before update")
+	assert.True(t, preCleanup[paths.TranscriptFileName], "full.jsonl should exist before cleanup")
+	assert.True(t, preCleanup[paths.TranscriptFileName+".001"], "full.jsonl.001 should exist before cleanup")
+	assert.True(t, preCleanup[paths.ContentHashFileName], "content_hash.txt should exist before cleanup")
+	assert.True(t, preCleanup[paths.V2RawTranscriptFileName], "raw_transcript should exist before cleanup")
 
-	// Step 3: Call UpdateCommitted, which calls updateCommittedFullTranscript.
-	updatedTranscript := []byte(`{"type":"human","message":"updated"}` + "\n")
-	err = store.UpdateCommitted(ctx, UpdateCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "test-session-v1-cleanup",
-		Transcript:   redact.AlreadyRedacted(updatedTranscript),
-		Agent:        agent.AgentTypeClaudeCode,
-	})
+	// Run cleanup.
+	err = store.CleanupV1TranscriptFiles(ctx, cpID, 1)
 	require.NoError(t, err)
 
-	// Step 4: Verify v1-named files are gone, v2-named files are present.
+	// Verify v1-named files are gone, v2-named files are preserved.
 	tree = v2FullTree(t, repo)
 	sessionTree, err = tree.Tree(cpPath + "/0")
 	require.NoError(t, err)
 
-	fileNames := make(map[string]bool)
+	postCleanup := make(map[string]bool)
 	for _, entry := range sessionTree.Entries {
-		fileNames[entry.Name] = true
+		postCleanup[entry.Name] = true
 	}
 
-	assert.True(t, fileNames[paths.V2RawTranscriptFileName], "raw_transcript should exist after update")
-	assert.True(t, fileNames[paths.V2RawTranscriptHashFileName], "raw_transcript_hash.txt should exist after update")
-	assert.False(t, fileNames[paths.TranscriptFileName], "full.jsonl should be cleaned up after update")
-	assert.False(t, fileNames[paths.TranscriptFileName+".001"], "full.jsonl.001 should be cleaned up after update")
-	assert.False(t, fileNames[paths.ContentHashFileName], "content_hash.txt should be cleaned up after update")
+	assert.True(t, postCleanup[paths.V2RawTranscriptFileName], "raw_transcript should exist after cleanup")
+	assert.True(t, postCleanup[paths.V2RawTranscriptHashFileName], "raw_transcript_hash.txt should exist after cleanup")
+	assert.False(t, postCleanup[paths.TranscriptFileName], "full.jsonl should be removed after cleanup")
+	assert.False(t, postCleanup[paths.TranscriptFileName+".001"], "full.jsonl.001 should be removed after cleanup")
+	assert.False(t, postCleanup[paths.ContentHashFileName], "content_hash.txt should be removed after cleanup")
 }
 
-// TestV2GitStore_UpdateCommittedFullTranscript_SameContentCleansUpV1Files verifies
-// that v1-named files are cleaned up even when the transcript content is identical
-// (hash matches), which would normally trigger the short-circuit that skips tree surgery.
-func TestV2GitStore_UpdateCommittedFullTranscript_SameContentCleansUpV1Files(t *testing.T) {
+// TestV2GitStore_CleanupV1TranscriptFiles_NoopWhenClean verifies that
+// CleanupV1TranscriptFiles is a no-op when no v1 files exist.
+func TestV2GitStore_CleanupV1TranscriptFiles_NoopWhenClean(t *testing.T) {
 	t.Parallel()
 	repo := initTestRepo(t)
 	store := NewV2GitStore(repo, "origin")
 	ctx := context.Background()
 
 	cpID := id.MustCheckpointID("962fcec4a874")
-	transcript := []byte(`{"type":"human","message":"same content"}` + "\n")
 
-	// Write initial checkpoint.
 	err := store.WriteCommitted(ctx, WriteCommittedOptions{
 		CheckpointID: cpID,
-		SessionID:    "test-session-same-content",
+		SessionID:    "test-session-noop",
 		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted(transcript),
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"human","message":"clean"}` + "\n")),
 		Agent:        agent.AgentTypeClaudeCode,
 		AuthorName:   "Test",
 		AuthorEmail:  "test@test.com",
 	})
 	require.NoError(t, err)
 
-	// Inject v1-named files into /full/current.
-	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
-	parentHash, rootTreeHash, err := store.GetRefState(refName)
+	// Get tree hash before cleanup.
+	_, treeBefore, err := store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
 	require.NoError(t, err)
 
-	basePath := cpID.Path() + "/"
-	sessionPath := basePath + "0/"
-
-	entries, err := store.gs.flattenCheckpointEntries(rootTreeHash, cpID.Path())
+	// Cleanup should be a no-op (no v1 files to remove).
+	err = store.CleanupV1TranscriptFiles(ctx, cpID, 1)
 	require.NoError(t, err)
 
-	v1Blob, err := CreateBlobFromContent(repo, []byte(`{"type":"human","message":"v1 data"}`+"\n"))
+	// Tree hash should be unchanged (no commit created).
+	_, treeAfter, err := store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
 	require.NoError(t, err)
-
-	entries[sessionPath+paths.TranscriptFileName] = object.TreeEntry{
-		Name: sessionPath + paths.TranscriptFileName,
-		Mode: filemode.Regular,
-		Hash: v1Blob,
-	}
-
-	newTreeHash, err := store.gs.spliceCheckpointSubtree(ctx, rootTreeHash, cpID, basePath, entries)
-	require.NoError(t, err)
-	err = store.updateRef(ctx, refName, newTreeHash, parentHash, "Inject v1 file", "Test", "test@test.com")
-	require.NoError(t, err)
-
-	// Call UpdateCommitted with the SAME transcript content (hash will match raw_transcript_hash.txt).
-	// Without the !hasLegacyV1Files guard, the short-circuit would return early and leave full.jsonl.
-	err = store.UpdateCommitted(ctx, UpdateCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "test-session-same-content",
-		Transcript:   redact.AlreadyRedacted(transcript),
-		Agent:        agent.AgentTypeClaudeCode,
-	})
-	require.NoError(t, err)
-
-	// Verify v1 file is gone despite identical content.
-	tree := v2FullTree(t, repo)
-	sessionTree, err := tree.Tree(cpID.Path() + "/0")
-	require.NoError(t, err)
-
-	fileNames := make(map[string]bool)
-	for _, entry := range sessionTree.Entries {
-		fileNames[entry.Name] = true
-	}
-
-	assert.True(t, fileNames[paths.V2RawTranscriptFileName], "raw_transcript should exist")
-	assert.False(t, fileNames[paths.TranscriptFileName], "full.jsonl should be cleaned up even with identical content")
+	assert.Equal(t, treeBefore, treeAfter, "tree should be unchanged when no v1 files exist")
 }

--- a/cmd/entire/cli/checkpoint/v2_store_test.go
+++ b/cmd/entire/cli/checkpoint/v2_store_test.go
@@ -1156,3 +1156,17 @@ func TestV2GitStore_CleanupV1TranscriptFiles_NoopWhenClean(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, treeBefore, treeAfter, "tree should be unchanged when no v1 files exist")
 }
+
+func TestV2GitStore_CleanupV1TranscriptFiles_ReturnsCorruptRefError(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+
+	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+	missingCommit := plumbing.NewHash("1111111111111111111111111111111111111111")
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, missingCommit)))
+
+	err := store.CleanupV1TranscriptFiles(context.Background(), id.MustCheckpointID("962fcec4a874"), 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get commit")
+}

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -174,6 +174,10 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 			return fmt.Errorf("v2 checkpoint %s disappeared during migration", info.CheckpointID)
 		}
 
+		// Clean up v1-named transcript files (full.jsonl, content_hash.txt) that older
+		// CLI versions may have written to /full/current before the rename to raw_transcript.
+		cleanupV1TranscriptFiles(ctx, repo, v2Store, info.CheckpointID, len(currentV2.Sessions))
+
 		backfillErr := backfillCompactTranscripts(ctx, v1Store, v2Store, info, currentV2, out, prefix)
 		if errors.Is(backfillErr, errAlreadyMigrated) && repaired {
 			fmt.Fprintf(out, "%s repaired partial v2 checkpoint state\n", prefix)
@@ -578,6 +582,19 @@ func resolveV1CheckpointTree(repo *git.Repository, cpID id.CheckpointID) (*objec
 	}
 
 	return cpTree, nil
+}
+
+// cleanupV1TranscriptFiles removes legacy v1-named transcript files (full.jsonl,
+// full.jsonl.*, content_hash.txt) from /full/current. Older CLI versions wrote
+// these before the rename to raw_transcript; they are inert but waste space.
+// Best-effort: failures are logged and do not block migration.
+func cleanupV1TranscriptFiles(ctx context.Context, _ *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionCount int) {
+	if err := v2Store.CleanupV1TranscriptFiles(ctx, cpID, sessionCount); err != nil {
+		logging.Warn(ctx, "v1 transcript cleanup failed",
+			slog.String("checkpoint_id", string(cpID)),
+			slog.String("error", err.Error()),
+		)
+	}
 }
 
 func spliceTasksTreeToV2(ctx context.Context, repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int, tasksTreeHash plumbing.Hash) error {


### PR DESCRIPTION
## Summary

- `updateCommittedFullTranscript` only cleared v2-named files (`raw_transcript`, `raw_transcript_hash.txt`) before writing new transcript data to `/full/current`. Legacy v1-named files (`full.jsonl`, `full.jsonl.*` chunks, `content_hash.txt`) written by older CLI versions were preserved, causing duplicate transcripts.
- Added `CleanupV1TranscriptFiles` to `V2GitStore` that removes v1-named files from `/full/current` for a given checkpoint.
- Called from the migration repair path in `entire migrate` — this is migration-specific cleanup that should not run during normal operation (stop-time finalization).
- Added regression tests for both the cleanup and the no-op case.

## Test plan

- [x] `mise run check` passes (unit + integration + canary)
- [x] `TestV2GitStore_CleanupV1TranscriptFiles` passes — injects v1 files, runs cleanup, verifies removal
- [x] `TestV2GitStore_CleanupV1TranscriptFiles_NoopWhenClean` passes — verifies no commit when no v1 files exist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git tree-surgery logic on the v2 `/full/current` ref and adds an extra commit during migration repair, which could affect stored transcript data if path matching/session counts are wrong; changes are scoped to removing legacy filenames and are covered by new tests.
> 
> **Overview**
> Adds `V2GitStore.CleanupV1TranscriptFiles` to delete legacy v1 transcript artifacts (`full.jsonl`, `full.jsonl.*`, `content_hash.txt`) from the v2 `/full/current` ref for a checkpoint/session range, creating a commit only when removals occur.
> 
> Hooks this cleanup into the v1→v2 migration *repair* path so already-migrated checkpoints can drop duplicate/inert v1-named transcript files without blocking migration on failure, and adds regression tests covering both removal and no-op behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19e13c4a6484829f7068b5101ac42b42cba4cfc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->