### PR TITLE
Fix v1-to-v2 migration dropping attribution metadata

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -296,6 +296,11 @@ type WriteCommittedOptions struct {
 	// Uses json.RawMessage to avoid importing session package.
 	PromptAttributionsJSON json.RawMessage
 
+	// CombinedAttribution is holistic attribution across all sessions.
+	// Used during migration to preserve v1 root summary attribution.
+	// During normal condensation this is nil (computed post-commit via UpdateCheckpointSummary).
+	CombinedAttribution *InitialAttribution
+
 	// Summary is an optional AI-generated summary for this checkpoint.
 	// This field may be nil when:
 	//   - summarization is disabled in settings

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -471,12 +471,14 @@ func (s *GitStore) writeCheckpointSummary(opts WriteCommittedOptions, basePath s
 		return fmt.Errorf("failed to aggregate session stats: %w", err)
 	}
 
-	var combinedAttribution *InitialAttribution
-	rootMetadataPath := basePath + paths.MetadataFileName
-	if entry, exists := entries[rootMetadataPath]; exists {
-		existingSummary, readErr := s.readSummaryFromBlob(entry.Hash)
-		if readErr == nil {
-			combinedAttribution = existingSummary.CombinedAttribution
+	combinedAttribution := opts.CombinedAttribution
+	if combinedAttribution == nil {
+		rootMetadataPath := basePath + paths.MetadataFileName
+		if entry, exists := entries[rootMetadataPath]; exists {
+			existingSummary, readErr := s.readSummaryFromBlob(entry.Hash)
+			if readErr == nil {
+				combinedAttribution = existingSummary.CombinedAttribution
+			}
 		}
 	}
 

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -206,7 +206,7 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 			shouldCopyTaskMetadata = true
 		}
 
-		opts := buildMigrateWriteOpts(content, info)
+		opts := buildMigrateWriteOpts(content, info, summary.CombinedAttribution)
 
 		compacted := tryCompactTranscript(ctx, content.Transcript, content.Metadata)
 		if compacted != nil {
@@ -392,7 +392,7 @@ func backfillCompactTranscripts(ctx context.Context, v1Store *checkpoint.GitStor
 	return nil
 }
 
-func buildMigrateWriteOpts(content *checkpoint.SessionContent, info checkpoint.CommittedInfo) checkpoint.WriteCommittedOptions {
+func buildMigrateWriteOpts(content *checkpoint.SessionContent, info checkpoint.CommittedInfo, combinedAttribution *checkpoint.InitialAttribution) checkpoint.WriteCommittedOptions {
 	m := content.Metadata
 
 	prompts := checkpoint.SplitPromptContent(content.Prompts)
@@ -414,6 +414,8 @@ func buildMigrateWriteOpts(content *checkpoint.SessionContent, info checkpoint.C
 		TokenUsage:                  m.TokenUsage,
 		SessionMetrics:              m.SessionMetrics,
 		InitialAttribution:          m.InitialAttribution,
+		PromptAttributionsJSON:      m.PromptAttributions,
+		CombinedAttribution:         combinedAttribution,
 		Summary:                     m.Summary,
 		CheckpointTranscriptStart:   m.GetTranscriptStart(),
 		TranscriptIdentifierAtStart: m.TranscriptIdentifierAtStart,

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -600,7 +601,7 @@ func TestBuildMigrateWriteOpts_PromptSeparatorRoundTrip(t *testing.T) {
 		Prompts: rawPrompts,
 	}, checkpoint.CommittedInfo{
 		CheckpointID: cpID,
-	})
+	}, nil)
 
 	require.Len(t, opts.Prompts, 2)
 	assert.Equal(t, "first line\nwith newline", opts.Prompts[0])
@@ -640,4 +641,116 @@ func TestSpliceTasksTreeToV2_MergesTaskDirectories(t *testing.T) {
 	require.NoError(t, err, "root task metadata should be preserved")
 	_, err = rootTree.File(cpID.Path() + "/0/tasks/toolu_session/checkpoint.json")
 	require.NoError(t, err, "session task metadata should be preserved")
+}
+
+func TestMigrateCheckpointsV2_PreservesPromptAttributions(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+	ctx := context.Background()
+
+	cpID := id.MustCheckpointID("aabb22334455")
+	promptAttrs := json.RawMessage(`[{"prompt_index":0,"user_lines":["main.go:10"]}]`)
+
+	err := v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID:           cpID,
+		SessionID:              "session-pa-001",
+		Strategy:               "manual-commit",
+		Transcript:             redact.AlreadyRedacted([]byte("{\"type\":\"assistant\",\"message\":\"pa test\"}\n")),
+		Prompts:                []string{"test prompt"},
+		PromptAttributionsJSON: promptAttrs,
+		AuthorName:             "Test",
+		AuthorEmail:            "test@test.com",
+	})
+	require.NoError(t, err)
+
+	// Verify v1 has prompt_attributions
+	v1Content, err := v1Store.ReadSessionContent(ctx, cpID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, v1Content.Metadata.PromptAttributions, "v1 should have prompt_attributions")
+
+	// Migrate
+	var stdout bytes.Buffer
+	result, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.migrated)
+
+	// Read v2 session metadata from /main ref and verify prompt_attributions preserved
+	v2MainRef, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	require.NoError(t, err)
+	v2MainCommit, err := repo.CommitObject(v2MainRef.Hash())
+	require.NoError(t, err)
+	v2MainTree, err := v2MainCommit.Tree()
+	require.NoError(t, err)
+
+	metadataFile, err := v2MainTree.File(cpID.Path() + "/0/" + paths.MetadataFileName)
+	require.NoError(t, err)
+	metadataContent, err := metadataFile.Contents()
+	require.NoError(t, err)
+
+	var metadata checkpoint.CommittedMetadata
+	require.NoError(t, json.Unmarshal([]byte(metadataContent), &metadata))
+	assert.JSONEq(t, string(promptAttrs), string(metadata.PromptAttributions),
+		"v2 session metadata should preserve prompt_attributions from v1")
+}
+
+func TestMigrateCheckpointsV2_PreservesCombinedAttribution(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+	ctx := context.Background()
+
+	cpID := id.MustCheckpointID("ccdd55667788")
+
+	// Write two sessions so combined attribution is meaningful
+	writeV1Checkpoint(t, v1Store, cpID, "session-ca-001",
+		[]byte("{\"type\":\"assistant\",\"message\":\"session 1\"}\n"),
+		[]string{"prompt 1"},
+	)
+	writeV1Checkpoint(t, v1Store, cpID, "session-ca-002",
+		[]byte("{\"type\":\"assistant\",\"message\":\"session 2\"}\n"),
+		[]string{"prompt 2"},
+	)
+
+	// Inject CombinedAttribution into v1 root summary
+	combined := &checkpoint.InitialAttribution{
+		CalculatedAt:      time.Date(2026, 4, 15, 0, 18, 47, 0, time.UTC),
+		AgentLines:        119,
+		AgentRemoved:      94,
+		HumanAdded:        3,
+		HumanModified:     0,
+		HumanRemoved:      1,
+		TotalCommitted:    122,
+		TotalLinesChanged: 217,
+		AgentPercentage:   98.15668202764977,
+		MetricVersion:     2,
+	}
+	err := v1Store.UpdateCheckpointSummary(ctx, cpID, combined)
+	require.NoError(t, err)
+
+	// Verify v1 root summary has CombinedAttribution
+	v1Summary, err := v1Store.ReadCommitted(ctx, cpID)
+	require.NoError(t, err)
+	require.NotNil(t, v1Summary.CombinedAttribution, "v1 should have combined_attribution")
+
+	// Migrate
+	var stdout bytes.Buffer
+	result, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.migrated)
+
+	// Read v2 root summary and verify CombinedAttribution preserved
+	v2Summary, err := v2Store.ReadCommitted(ctx, cpID)
+	require.NoError(t, err)
+	require.NotNil(t, v2Summary)
+	require.NotNil(t, v2Summary.CombinedAttribution,
+		"v2 root summary should preserve combined_attribution from v1")
+	assert.Equal(t, combined.AgentLines, v2Summary.CombinedAttribution.AgentLines)
+	assert.Equal(t, combined.AgentRemoved, v2Summary.CombinedAttribution.AgentRemoved)
+	assert.Equal(t, combined.HumanAdded, v2Summary.CombinedAttribution.HumanAdded)
+	assert.Equal(t, combined.HumanRemoved, v2Summary.CombinedAttribution.HumanRemoved)
+	assert.Equal(t, combined.TotalCommitted, v2Summary.CombinedAttribution.TotalCommitted)
+	assert.Equal(t, combined.TotalLinesChanged, v2Summary.CombinedAttribution.TotalLinesChanged)
+	assert.InDelta(t, combined.AgentPercentage, v2Summary.CombinedAttribution.AgentPercentage, 0.001)
+	assert.Equal(t, combined.MetricVersion, v2Summary.CombinedAttribution.MetricVersion)
 }

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -745,9 +745,11 @@ func TestMigrateCheckpointsV2_PreservesCombinedAttribution(t *testing.T) {
 	require.NotNil(t, v2Summary)
 	require.NotNil(t, v2Summary.CombinedAttribution,
 		"v2 root summary should preserve combined_attribution from v1")
+	assert.Equal(t, combined.CalculatedAt, v2Summary.CombinedAttribution.CalculatedAt)
 	assert.Equal(t, combined.AgentLines, v2Summary.CombinedAttribution.AgentLines)
 	assert.Equal(t, combined.AgentRemoved, v2Summary.CombinedAttribution.AgentRemoved)
 	assert.Equal(t, combined.HumanAdded, v2Summary.CombinedAttribution.HumanAdded)
+	assert.Equal(t, combined.HumanModified, v2Summary.CombinedAttribution.HumanModified)
 	assert.Equal(t, combined.HumanRemoved, v2Summary.CombinedAttribution.HumanRemoved)
 	assert.Equal(t, combined.TotalCommitted, v2Summary.CombinedAttribution.TotalCommitted)
 	assert.Equal(t, combined.TotalLinesChanged, v2Summary.CombinedAttribution.TotalLinesChanged)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/5558d19b2501
<!-- entire-trail-link-end -->

## What

The v1-to-v2 checkpoint migration silently dropped two types of attribution metadata:

1. **Session-level `prompt_attributions`** (71 sessions affected in validation repo) — `buildMigrateWriteOpts` omitted `PromptAttributionsJSON` from the write options, so the diagnostic payload was never passed to the v2 writer.

2. **Root-level `combined_attribution`** (2 checkpoints affected) — `writeCheckpointSummary` only preserved `CombinedAttribution` from an already-existing target summary. During fresh migration the target doesn't exist yet, so the v1 value was lost.

All functional checkpoint data (transcripts, prompts, content hashes) migrated correctly — these are metadata-only losses.

## How

- Added `PromptAttributionsJSON: m.PromptAttributions` to `buildMigrateWriteOpts`.
- Added `CombinedAttribution *InitialAttribution` field to `WriteCommittedOptions`.
- Updated `writeCheckpointSummary` to prefer `opts.CombinedAttribution` when non-nil, falling back to the existing summary value. This is backward-compatible: normal condensation never sets this field (combined attribution is computed post-commit via `UpdateCheckpointSummary`).
- Plumbed `summary.CombinedAttribution` from the v1 root summary through `buildMigrateWriteOpts` in `migrateOneCheckpoint`.
- Added two regression tests covering both bugs.

## Note

The broader gap where `updateCombinedAttributionForCheckpoint` in hooks only writes to the v1 store (not v2) is a separate issue affecting new v2-only checkpoints, not migration. Tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only plumb and persist additional attribution metadata during migration and summary writing, with regression tests covering the previously dropped fields.
> 
> **Overview**
> Fixes v1→v2 checkpoint migration to **preserve attribution metadata** that was previously dropped.
> 
> `buildMigrateWriteOpts` now carries session-level `prompt_attributions` into v2 writes, and `WriteCommittedOptions` gains `CombinedAttribution` so `writeCheckpointSummary` can persist the v1 root-level `combined_attribution` even on first-time migrations (falling back to any existing summary when not provided).
> 
> Adds regression tests ensuring both `prompt_attributions` and `combined_attribution` survive migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5175de5db20aac39a7fde74ab2580470fc12a6e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->