### PR TITLE
Fix false installer PATH conflict detection

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -254,7 +254,7 @@ main() {
     # Check if the installed binary is the one that will be found in PATH
     local path_binary
     path_binary=$(command -v "entire" 2>/dev/null || true)
-    if [[ -n "$path_binary" && "$path_binary" != "$install_path" ]]; then
+    if [[ -n "$path_binary" && ! "$path_binary" -ef "$install_path" ]]; then
         # This case is a bit weird, because some other 'entire' is found on PATH.  Warn user.
         echo ""
         echo -e "${YELLOW}!${NC} ${BOLD}WARNING: PATH conflict detected${NC}"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1840641e6931
<!-- entire-trail-link-end -->

## Summary
- compare the installed binary and PATH-resolved binary by file identity instead of raw path text
- avoid false PATH conflict errors when `command -v entire` returns a non-canonical but equivalent path

This was reported by a user in Discord.

Closes #1037 

## Verification
- `bash -n scripts/install.sh`
- `mise run check`
- shell repro showing old check reports a conflict while the new `-ef` check does not for equivalent paths