### PR TITLE
Brew: Prompt users to update when new version is released

### DIFF
--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -89,12 +89,14 @@ func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVer
 
 func maybeBrewAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVersion string) AutoUpdateAction {
 	cmdStr := updateCommand(currentVersion)
-	printBrewUpdateMessage(w, currentVersion, latestVersion, cmdStr)
 
 	if os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
+		printNotification(w, currentVersion, latestVersion)
 		fmt.Fprintf(w, "To update, run:\n  %s\n", cmdStr)
 		return autoUpdateActionSkip
 	}
+
+	printBrewUpdateMessage(w, currentVersion, latestVersion, cmdStr)
 
 	action, err := chooseBrewUpdate(w)
 	if err != nil {
@@ -126,12 +128,19 @@ func printBrewUpdateMessage(w io.Writer, currentVersion, latestVersion, cmdStr s
 }
 
 func realChooseBrewUpdate(w io.Writer) (AutoUpdateAction, error) {
-	reader := bufio.NewReader(os.Stdin)
+	return chooseBrewUpdateFromReader(w, os.Stdin)
+}
+
+func chooseBrewUpdateFromReader(w io.Writer, input io.Reader) (AutoUpdateAction, error) {
+	reader := bufio.NewReader(input)
 	for {
 		fmt.Fprint(w, "Choose an option [1]: ")
 		line, err := reader.ReadString('\n')
 		if err != nil && !errors.Is(err, io.EOF) {
 			return autoUpdateActionSkip, fmt.Errorf("read update choice: %w", err)
+		}
+		if errors.Is(err, io.EOF) && strings.TrimSpace(line) == "" {
+			return autoUpdateActionSkip, nil
 		}
 
 		action, ok := parseBrewUpdateChoice(line)

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -1,6 +1,7 @@
 package versioncheck
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 
@@ -18,16 +20,25 @@ import (
 // envKillSwitch disables the interactive update prompt regardless of TTY.
 const envKillSwitch = "ENTIRE_NO_AUTO_UPDATE"
 
-// Test seams.
-var (
-	runInstaller  = realRunInstaller
-	confirmUpdate = realConfirmUpdate
-	isTerminalOut = interactive.IsTerminalWriter
+// AutoUpdateAction describes the result of an update prompt.
+type AutoUpdateAction string
+
+const (
+	autoUpdateActionSkip                 AutoUpdateAction = "skip"
+	autoUpdateActionUpdate               AutoUpdateAction = "update"
+	autoUpdateActionSkipUntilNextVersion AutoUpdateAction = "skip_until_next_version"
 )
 
-// MaybeAutoUpdate offers an interactive upgrade after the standard
-// "version available" notification has been printed. Silent on every
-// failure path — it must never interrupt the CLI.
+// Test seams.
+var (
+	runInstaller     = realRunInstaller
+	confirmUpdate    = realConfirmUpdate
+	chooseBrewUpdate = realChooseBrewUpdate
+	isTerminalOut    = interactive.IsTerminalWriter
+)
+
+// MaybeAutoUpdate prints an update notification and offers an interactive
+// upgrade. Silent on every failure path — it must never interrupt the CLI.
 //
 // If the installer command fails, a hint with the exact command is
 // printed so the user can retry manually. The 24h version-check cache
@@ -38,35 +49,113 @@ var (
 // When the prompt cannot be shown (kill switch set, or non-interactive
 // environment like CI / agent subprocess / no TTY) the installer
 // command is printed so the user still learns what to run manually.
-func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion string) {
+func MaybeAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVersion string) AutoUpdateAction {
+	if installManagerForCurrentBinary() == installManagerBrew {
+		return maybeBrewAutoUpdate(ctx, w, currentVersion, latestVersion)
+	}
+
+	printNotification(w, currentVersion, latestVersion)
+
 	// Windows + unknown install manager: the POSIX curl-pipe-bash fallback
 	// would error if auto-run, and there's no safe native equivalent. Point
 	// the user at the releases page so they can download manually.
 	if !canAutoInstall() {
 		fmt.Fprintf(w, "To update, download the latest release from:\n  %s\n", downloadsURL)
-		return
+		return autoUpdateActionSkip
 	}
 	if os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
 		fmt.Fprintf(w, "To update, run:\n  %s\n", updateCommand(currentVersion))
-		return
+		return autoUpdateActionSkip
 	}
 
 	confirmed, err := confirmUpdate()
 	if err != nil {
 		logging.Debug(ctx, "auto-update: prompt failed", "error", err.Error())
-		return
+		return autoUpdateActionSkip
 	}
 	if !confirmed {
-		return
+		return autoUpdateActionSkip
 	}
 
 	cmdStr := updateCommand(currentVersion)
 	fmt.Fprintf(w, "\nUpdating Entire CLI: %s\n", cmdStr)
 	if err := runInstaller(ctx, cmdStr); err != nil {
 		fmt.Fprintf(w, "Update failed: %v\nTry again later running:\n  %s\n", err, cmdStr)
-		return
+		return autoUpdateActionUpdate
 	}
 	fmt.Fprintln(w, "Update complete. Re-run entire to use the new version.")
+	return autoUpdateActionUpdate
+}
+
+func maybeBrewAutoUpdate(ctx context.Context, w io.Writer, currentVersion, latestVersion string) AutoUpdateAction {
+	cmdStr := updateCommand(currentVersion)
+	printBrewUpdateMessage(w, currentVersion, latestVersion, cmdStr)
+
+	if os.Getenv(envKillSwitch) != "" || !interactive.CanPromptInteractively() || !isTerminalOut(w) {
+		fmt.Fprintf(w, "To update, run:\n  %s\n", cmdStr)
+		return autoUpdateActionSkip
+	}
+
+	action, err := chooseBrewUpdate(w)
+	if err != nil {
+		logging.Debug(ctx, "auto-update: brew prompt failed", "error", err.Error())
+		return autoUpdateActionSkip
+	}
+
+	switch action {
+	case autoUpdateActionUpdate:
+		fmt.Fprintf(w, "\nUpdating Entire CLI: %s\n", cmdStr)
+		if err := runInstaller(ctx, cmdStr); err != nil {
+			fmt.Fprintf(w, "Update failed: %v\nTry again later running:\n  %s\n", err, cmdStr)
+			return autoUpdateActionUpdate
+		}
+		fmt.Fprintln(w, "Update complete. Re-run entire to use the new version.")
+		return autoUpdateActionUpdate
+	case autoUpdateActionSkipUntilNextVersion:
+		return autoUpdateActionSkipUntilNextVersion
+	case autoUpdateActionSkip:
+		return autoUpdateActionSkip
+	default:
+		return autoUpdateActionSkip
+	}
+}
+
+func printBrewUpdateMessage(w io.Writer, currentVersion, latestVersion, cmdStr string) {
+	fmt.Fprintf(w, "\nUpdate available! %s -> %s\nRelease notes: %s\n1. Update now (runs `%s`)\n2. Skip\n3. Skip until next version\n\nPress enter to continue\n",
+		displayVersion(currentVersion), displayVersion(latestVersion), releaseNotesURL(latestVersion), cmdStr)
+}
+
+func realChooseBrewUpdate(w io.Writer) (AutoUpdateAction, error) {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Fprint(w, "Choose an option [1]: ")
+		line, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return autoUpdateActionSkip, fmt.Errorf("read update choice: %w", err)
+		}
+
+		action, ok := parseBrewUpdateChoice(line)
+		if ok {
+			return action, nil
+		}
+		if errors.Is(err, io.EOF) {
+			return autoUpdateActionSkip, nil
+		}
+		fmt.Fprintln(w, "Please choose 1, 2, or 3.")
+	}
+}
+
+func parseBrewUpdateChoice(input string) (AutoUpdateAction, bool) {
+	switch strings.TrimSpace(input) {
+	case "", "1":
+		return autoUpdateActionUpdate, true
+	case "2":
+		return autoUpdateActionSkip, true
+	case "3":
+		return autoUpdateActionSkipUntilNextVersion, true
+	default:
+		return autoUpdateActionSkip, false
+	}
 }
 
 func realConfirmUpdate() (bool, error) {

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -16,6 +16,8 @@ type autoUpdateFixture struct {
 	lastCommand  string
 	confirmValue bool
 	confirmErr   error
+	chooseValue  AutoUpdateAction
+	chooseErr    error
 }
 
 func newAutoUpdateFixture(t *testing.T) *autoUpdateFixture {
@@ -25,7 +27,7 @@ func newAutoUpdateFixture(t *testing.T) *autoUpdateFixture {
 	// Force interactive mode on by default; individual tests can opt out.
 	t.Setenv("ENTIRE_TEST_TTY", "1")
 
-	f := &autoUpdateFixture{confirmValue: true}
+	f := &autoUpdateFixture{confirmValue: true, chooseValue: autoUpdateActionUpdate}
 
 	origRun := runInstaller
 	runInstaller = func(_ context.Context, cmd string) error {
@@ -35,12 +37,15 @@ func newAutoUpdateFixture(t *testing.T) *autoUpdateFixture {
 	}
 	origConfirm := confirmUpdate
 	confirmUpdate = func() (bool, error) { return f.confirmValue, f.confirmErr }
+	origChoose := chooseBrewUpdate
+	chooseBrewUpdate = func(io.Writer) (AutoUpdateAction, error) { return f.chooseValue, f.chooseErr }
 	origIsTerminalOut := isTerminalOut
 	isTerminalOut = func(_ io.Writer) bool { return true }
 
 	t.Cleanup(func() {
 		runInstaller = origRun
 		confirmUpdate = origConfirm
+		chooseBrewUpdate = origChoose
 		isTerminalOut = origIsTerminalOut
 	})
 	return f
@@ -63,7 +68,7 @@ func assertManualHint(t *testing.T, out string) {
 	if !strings.Contains(out, "To update, run:") {
 		t.Errorf("missing manual-update hint: %q", out)
 	}
-	if !strings.Contains(out, "brew upgrade --cask entire") {
+	if !strings.Contains(out, "brew upgrade entire") {
 		t.Errorf("manual hint missing installer command: %q", out)
 	}
 }
@@ -74,7 +79,7 @@ func TestMaybeAutoUpdate_KillSwitch(t *testing.T) {
 	t.Setenv(envKillSwitch, "1")
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0")
+	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called with kill-switch set")
@@ -88,7 +93,7 @@ func TestMaybeAutoUpdate_NoTTY(t *testing.T) {
 	t.Setenv("ENTIRE_TEST_TTY", "0")
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0")
+	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called without TTY")
@@ -104,7 +109,7 @@ func TestMaybeAutoUpdate_CIEnv(t *testing.T) {
 	t.Setenv("CI", "true")
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0")
+	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called on CI (CI=true)")
@@ -118,7 +123,7 @@ func TestMaybeAutoUpdate_NonTerminalWriter(t *testing.T) {
 	isTerminalOut = func(_ io.Writer) bool { return false }
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0")
+	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called with non-terminal output writer")
@@ -145,7 +150,7 @@ func TestMaybeAutoUpdate_WindowsUnknownInstallerNoAutoRun(t *testing.T) {
 	t.Cleanup(func() { goos = origGOOS })
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0")
+	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer was auto-run on Windows + unknown install manager")
@@ -176,7 +181,7 @@ func TestMaybeAutoUpdate_WindowsScoopStillAutoRuns(t *testing.T) {
 	t.Cleanup(func() { goos = origGOOS })
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0")
+	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 1 {
 		t.Fatalf("scoop install should auto-run on Windows; calls=%d", f.installCalls)
@@ -189,13 +194,45 @@ func TestMaybeAutoUpdate_WindowsScoopStillAutoRuns(t *testing.T) {
 func TestMaybeAutoUpdate_UserDeclines(t *testing.T) {
 	f := newAutoUpdateFixture(t)
 	useBrewExecutable(t)
-	f.confirmValue = false
+	f.chooseValue = autoUpdateActionSkip
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0")
+	action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 0 {
 		t.Errorf("installer called after user declined")
+	}
+	if action != autoUpdateActionSkip {
+		t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
+	}
+}
+
+func TestMaybeAutoUpdate_BrewSkipUntilNextVersion(t *testing.T) {
+	f := newAutoUpdateFixture(t)
+	useBrewExecutable(t)
+	f.chooseValue = autoUpdateActionSkipUntilNextVersion
+
+	var buf bytes.Buffer
+	action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
+
+	if f.installCalls != 0 {
+		t.Errorf("installer called after skip-until-next-version")
+	}
+	if action != autoUpdateActionSkipUntilNextVersion {
+		t.Errorf("action = %q, want %q", action, autoUpdateActionSkipUntilNextVersion)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"Update available! 1.0.0 -> 2.0.0",
+		"Release notes: https://github.com/entireio/cli/releases/tag/v2.0.0",
+		"1. Update now (runs `brew upgrade entire`)",
+		"2. Skip",
+		"3. Skip until next version",
+		"Press enter to continue",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output: %q", want, out)
+		}
 	}
 }
 
@@ -204,13 +241,16 @@ func TestMaybeAutoUpdate_HappyPath(t *testing.T) {
 	useBrewExecutable(t)
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0")
+	action := MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 1 {
 		t.Fatalf("installer called %d times, want 1", f.installCalls)
 	}
-	if f.lastCommand != "brew upgrade --cask entire" {
-		t.Errorf("installer got %q, want brew upgrade --cask entire", f.lastCommand)
+	if f.lastCommand != "brew upgrade entire" {
+		t.Errorf("installer got %q, want brew upgrade entire", f.lastCommand)
+	}
+	if action != autoUpdateActionUpdate {
+		t.Errorf("action = %q, want %q", action, autoUpdateActionUpdate)
 	}
 	if !strings.Contains(buf.String(), "Update complete") {
 		t.Errorf("missing success message: %q", buf.String())
@@ -223,7 +263,7 @@ func TestMaybeAutoUpdate_InstallerFailurePrintedToUser(t *testing.T) {
 	f.installErr = errors.New("boom")
 
 	var buf bytes.Buffer
-	MaybeAutoUpdate(context.Background(), &buf, "1.0.0")
+	MaybeAutoUpdate(context.Background(), &buf, "1.0.0", "v2.0.0")
 
 	if f.installCalls != 1 {
 		t.Fatalf("installer called %d times, want 1", f.installCalls)
@@ -236,7 +276,32 @@ func TestMaybeAutoUpdate_InstallerFailurePrintedToUser(t *testing.T) {
 	if !strings.Contains(out, "Try again later running:") {
 		t.Errorf("missing retry hint: %q", out)
 	}
-	if !strings.Contains(out, "brew upgrade --cask entire") {
+	if !strings.Contains(out, "brew upgrade entire") {
 		t.Errorf("retry hint missing installer command: %q", out)
+	}
+}
+
+func TestParseBrewUpdateChoice(t *testing.T) {
+	tests := []struct {
+		input string
+		want  AutoUpdateAction
+		ok    bool
+	}{
+		{input: "", want: autoUpdateActionUpdate, ok: true},
+		{input: "\n", want: autoUpdateActionUpdate, ok: true},
+		{input: "1", want: autoUpdateActionUpdate, ok: true},
+		{input: "2", want: autoUpdateActionSkip, ok: true},
+		{input: "3", want: autoUpdateActionSkipUntilNextVersion, ok: true},
+		{input: "nope", want: autoUpdateActionSkip, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, ok := parseBrewUpdateChoice(tt.input)
+			if got != tt.want || ok != tt.ok {
+				t.Errorf("parseBrewUpdateChoice(%q) = (%q, %v), want (%q, %v)",
+					tt.input, got, ok, tt.want, tt.ok)
+			}
+		})
 	}
 }

--- a/cmd/entire/cli/versioncheck/autoupdate_test.go
+++ b/cmd/entire/cli/versioncheck/autoupdate_test.go
@@ -71,6 +71,12 @@ func assertManualHint(t *testing.T, out string) {
 	if !strings.Contains(out, "brew upgrade entire") {
 		t.Errorf("manual hint missing installer command: %q", out)
 	}
+	if strings.Contains(out, "1. Update now") ||
+		strings.Contains(out, "2. Skip") ||
+		strings.Contains(out, "3. Skip until next version") ||
+		strings.Contains(out, "Press enter to continue") {
+		t.Errorf("non-interactive output included interactive menu: %q", out)
+	}
 }
 
 func TestMaybeAutoUpdate_KillSwitch(t *testing.T) {
@@ -303,5 +309,27 @@ func TestParseBrewUpdateChoice(t *testing.T) {
 					tt.input, got, ok, tt.want, tt.ok)
 			}
 		})
+	}
+}
+
+func TestChooseBrewUpdateFromReader_EmptyEOFSkips(t *testing.T) {
+	var buf bytes.Buffer
+	action, err := chooseBrewUpdateFromReader(&buf, strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("chooseBrewUpdateFromReader() error = %v", err)
+	}
+	if action != autoUpdateActionSkip {
+		t.Errorf("action = %q, want %q", action, autoUpdateActionSkip)
+	}
+}
+
+func TestChooseBrewUpdateFromReader_EnterUpdates(t *testing.T) {
+	var buf bytes.Buffer
+	action, err := chooseBrewUpdateFromReader(&buf, strings.NewReader("\n"))
+	if err != nil {
+		t.Fatalf("chooseBrewUpdateFromReader() error = %v", err)
+	}
+	if action != autoUpdateActionUpdate {
+		t.Errorf("action = %q, want %q", action, autoUpdateActionUpdate)
 	}
 }

--- a/cmd/entire/cli/versioncheck/types.go
+++ b/cmd/entire/cli/versioncheck/types.go
@@ -4,7 +4,8 @@ import "time"
 
 // VersionCache represents the cached version check data.
 type VersionCache struct {
-	LastCheckTime time.Time `json:"last_check_time"`
+	LastCheckTime  time.Time `json:"last_check_time"`
+	SkippedVersion string    `json:"skipped_version,omitempty"`
 }
 
 // GitHubRelease represents the GitHub API response for a release.

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -82,8 +82,18 @@ func CheckAndNotify(ctx context.Context, w io.Writer, currentVersion string) {
 
 	// Show notification and offer an interactive upgrade when outdated
 	if isOutdated(currentVersion, latestVersion) {
-		printNotification(w, currentVersion, latestVersion)
-		MaybeAutoUpdate(ctx, w, currentVersion)
+		if cache.SkippedVersion == versionCacheKey(latestVersion) {
+			return
+		}
+
+		action := MaybeAutoUpdate(ctx, w, currentVersion, latestVersion)
+		if action == autoUpdateActionSkipUntilNextVersion {
+			cache.SkippedVersion = versionCacheKey(latestVersion)
+			if saveErr := saveCache(cache); saveErr != nil {
+				logging.Debug(ctx, "version check: failed to save skipped version",
+					"error", saveErr.Error())
+			}
+		}
 	}
 }
 
@@ -309,6 +319,21 @@ func isOutdated(current, latest string) bool {
 	return semver.Compare(current, latest) < 0
 }
 
+func versionCacheKey(version string) string {
+	if version == "" || strings.HasPrefix(version, "v") {
+		return version
+	}
+	return "v" + version
+}
+
+func displayVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
+}
+
+func releaseNotesURL(version string) string {
+	return downloadsURL + "/tag/" + versionCacheKey(version)
+}
+
 // executablePath is the function used to get the current executable path.
 // It's a variable so tests can override it.
 var executablePath = os.Executable
@@ -372,9 +397,9 @@ func updateCommand(currentVersion string) string {
 	switch installManagerForCurrentBinary() {
 	case installManagerBrew:
 		if releaseChannel(currentVersion) == installChannelNightly {
-			return "brew upgrade --cask entire@nightly"
+			return "brew upgrade entire@nightly"
 		}
-		return "brew upgrade --cask entire"
+		return "brew upgrade entire"
 	case installManagerMise:
 		return "mise upgrade entire"
 	case installManagerScoop:
@@ -389,7 +414,6 @@ func updateCommand(currentVersion string) string {
 
 // printNotification prints the version update notification to the user.
 func printNotification(w io.Writer, current, latest string) {
-	msg := fmt.Sprintf("\nA newer version of Entire CLI is available: %s (current: %s)\n",
-		latest, current)
-	fmt.Fprint(w, msg)
+	fmt.Fprintf(w, "\nUpdate available! %s -> %s\nRelease notes: %s\n",
+		displayVersion(current), displayVersion(latest), releaseNotesURL(latest))
 }

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -319,28 +319,28 @@ func TestUpdateCommand(t *testing.T) {
 		want           string
 	}{
 		{
-			name:           "homebrew stable cellar path uses cask command",
+			name:           "homebrew stable cellar path uses brew command",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return "/opt/homebrew/Cellar/entire/1.0.0/bin/entire", nil },
-			want:           "brew upgrade --cask entire",
+			want:           "brew upgrade entire",
 		},
 		{
-			name:           "homebrew stable cask path uses cask command",
+			name:           "homebrew stable cask path uses brew command",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return "/opt/homebrew/bin/entire", nil },
-			want:           "brew upgrade --cask entire",
+			want:           "brew upgrade entire",
 		},
 		{
-			name:           "homebrew nightly path uses cask command",
+			name:           "homebrew nightly path uses brew command",
 			currentVersion: "1.0.1-nightly.202604101200.abc1234",
 			execPath:       func() (string, error) { return "/opt/homebrew/bin/entire", nil },
-			want:           "brew upgrade --cask entire@nightly",
+			want:           "brew upgrade entire@nightly",
 		},
 		{
 			name:           "linuxbrew path",
 			currentVersion: "1.0.0",
 			execPath:       func() (string, error) { return "/home/linuxbrew/.linuxbrew/bin/entire", nil },
-			want:           "brew upgrade --cask entire",
+			want:           "brew upgrade entire",
 		},
 		{
 			name:           "mise path",
@@ -423,6 +423,16 @@ func newVersionServer(t *testing.T, version string) *httptest.Server {
 	return server
 }
 
+func seedVersionCache(t *testing.T, cache *VersionCache) {
+	t.Helper()
+	if err := ensureGlobalConfigDir(); err != nil {
+		t.Fatalf("ensureGlobalConfigDir() error = %v", err)
+	}
+	if err := saveCache(cache); err != nil {
+		t.Fatalf("saveCache() error = %v", err)
+	}
+}
+
 func TestCheckAndNotify_SkipsDevVersion(t *testing.T) {
 	server := newVersionServer(t, "v9.9.9")
 	cmd, buf := setupCheckAndNotifyTest(t, server.URL)
@@ -484,6 +494,50 @@ func TestCheckAndNotify_PrintsNotificationWhenOutdated(t *testing.T) {
 	}
 }
 
+func TestCheckAndNotify_BrewSkipUntilNextVersionCachesLatest(t *testing.T) {
+	server := newVersionServer(t, "v2.0.0")
+	cmd, buf := setupCheckAndNotifyTest(t, server.URL)
+	f := newAutoUpdateFixture(t)
+	useBrewExecutable(t)
+	f.chooseValue = autoUpdateActionSkipUntilNextVersion
+
+	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
+
+	if f.installCalls != 0 {
+		t.Fatalf("installer called %d times, want 0", f.installCalls)
+	}
+	cache, err := loadCache()
+	if err != nil {
+		t.Fatalf("loadCache() error = %v", err)
+	}
+	if cache.SkippedVersion != "v2.0.0" {
+		t.Errorf("SkippedVersion = %q, want v2.0.0", cache.SkippedVersion)
+	}
+	if !strings.Contains(buf.String(), "3. Skip until next version") {
+		t.Errorf("expected brew update options, got %q", buf.String())
+	}
+}
+
+func TestCheckAndNotify_SkipsVersionMarkedSkipped(t *testing.T) {
+	server := newVersionServer(t, "v2.0.0")
+	cmd, buf := setupCheckAndNotifyTest(t, server.URL)
+	f := newAutoUpdateFixture(t)
+	useBrewExecutable(t)
+	seedVersionCache(t, &VersionCache{
+		LastCheckTime:  time.Now().Add(-checkInterval - time.Minute),
+		SkippedVersion: "v2.0.0",
+	})
+
+	CheckAndNotify(context.Background(), cmd.OutOrStdout(), "1.0.0")
+
+	if f.installCalls != 0 {
+		t.Fatalf("installer called %d times for skipped version, want 0", f.installCalls)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for skipped version, got %q", buf.String())
+	}
+}
+
 func TestCheckAndNotify_NoNotificationWhenUpToDate(t *testing.T) {
 	server := newVersionServer(t, "v1.0.0")
 	cmd, buf := setupCheckAndNotifyTest(t, server.URL)
@@ -507,6 +561,12 @@ func TestCheckAndNotify_InstallerFailureKeepsCacheFresh(t *testing.T) {
 	origConfirm := confirmUpdate
 	confirmUpdate = func() (bool, error) { return true, nil }
 	t.Cleanup(func() { confirmUpdate = origConfirm })
+
+	origChoose := chooseBrewUpdate
+	chooseBrewUpdate = func(io.Writer) (AutoUpdateAction, error) {
+		return autoUpdateActionUpdate, nil
+	}
+	t.Cleanup(func() { chooseBrewUpdate = origChoose })
 
 	origRun := runInstaller
 	runInstaller = func(_ context.Context, _ string) error { return errors.New("boom") }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/246
<!-- entire-trail-link-end -->

When there is a new version of the CLI available, offer for the user to `brew upgrade` to increase discoverability and promote adoption of newer releases.

Inspired by @pfleidi's discovery of Codex's auto-update prompt:
<img width="1130" height="356" alt="image (1)" src="https://github.com/user-attachments/assets/39987575-e7da-4c75-8d2c-7e87749701dc" />

Tested via a local test binary:

```
TEST_ROOT=/private/tmp/entire-pr1057-test
FAKE_HOME="$TEST_ROOT/home"
FAKE_BIN="$TEST_ROOT/bin"
FAKE_CELLAR="$TEST_ROOT/fakebrew/Cellar/entire/0.0.1/bin"

mkdir -p "$FAKE_HOME" "$FAKE_BIN" "$FAKE_CELLAR"

cat > "$FAKE_BIN/brew" <<'EOF'
#!/bin/sh
echo "[fake brew] brew $*"
exit 0
EOF
chmod +x "$FAKE_BIN/brew"

go build \
  -ldflags "-X github.com/entireio/cli/cmd/entire/cli/versioninfo.Version=0.0.1" \
  -o "$FAKE_CELLAR/entire" \
  ./cmd/entire

env -u ENTIRE_NO_AUTO_UPDATE -u CI -u ENTIRE_TEST_TTY \
  HOME="$FAKE_HOME" \
  PATH="$FAKE_BIN:$PATH" \
  "$FAKE_CELLAR/entire" version

Update available! 0.0.1 -> 0.5.6
Release notes: https://github.com/entireio/cli/releases/tag/v0.5.6
1. Update now (runs `brew upgrade entire`)
2. Skip
3. Skip until next version
Press enter to continue
Choose an option [1]: 1

Updating Entire CLI: brew upgrade entire
[fake brew] brew upgrade entire
Update complete. Re-run entire to use the new version.

➜  cli git:(brew-update-msg) ✗ command -v entire
/private/tmp/entire-pr1057-test/fakebrew/Cellar/entire/0.0.1/bin/entire -v
/Users/ninawork/entire/devenv/cli/entire
Entire CLI 0.0.1 (unknown)
Go version: go1.26.2
OS/Arch: darwin/arm64

```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate behavior change in the CLI update flow: introduces a new interactive prompt path for Homebrew installs and persists a new `SkippedVersion` field to the version-check cache, which could affect when users are notified or prompted to update.
> 
> **Overview**
> Adds a Homebrew-specific auto-update prompt that shows release notes and offers **Update now / Skip / Skip until next version**, running `brew upgrade entire` when accepted.
> 
> Extends the version-check cache with `SkippedVersion` and wires `CheckAndNotify` to suppress notifications for the skipped latest tag until a newer release is available. Also standardizes update messaging ("Update available!" + release notes link) and switches Homebrew update commands from `brew upgrade --cask ...` to `brew upgrade ...`, with expanded test coverage for the new prompt and caching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab7a8151baa7af0308b42127880ad9330328dcb2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->