### PR TITLE
Align search TUI navigation help

### DIFF
--- a/cmd/entire/cli/dispatch_tui_test.go
+++ b/cmd/entire/cli/dispatch_tui_test.go
@@ -25,8 +25,6 @@ func (p fakeDispatchProgram) Run() (tea.Model, error) {
 }
 
 func TestDefaultRunInteractiveDispatch_DoesNotUseAltScreen(t *testing.T) {
-	t.Parallel()
-
 	oldProgramFactory := newDispatchProgram
 	newDispatchProgram = func(model tea.Model, _ io.Writer, altScreen bool) dispatchProgram {
 		if altScreen {
@@ -73,8 +71,6 @@ func TestDispatchStatusModel_ViewRendersInlineCard(t *testing.T) {
 }
 
 func TestDefaultRunInteractiveDispatch_ClearsLoadingCardBeforeReturn(t *testing.T) {
-	t.Parallel()
-
 	oldProgramFactory := newDispatchProgram
 	newDispatchProgram = func(model tea.Model, _ io.Writer, _ bool) dispatchProgram {
 		return fakeDispatchProgram{model: model}

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -250,7 +250,7 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn
 
 func (m searchModel) updateSearchMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) { //nolint:ireturn // bubbletea pattern
 	switch msg.String() {
-	case "esc":
+	case tuiEscKey:
 		m.mode = modeBrowse
 		m.input.Blur()
 		m = m.refreshBrowseContent()
@@ -292,7 +292,7 @@ func (m searchModel) updateSearchMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) { //n
 func (m searchModel) updateBrowseMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) { //nolint:ireturn // bubbletea pattern
 	pageLen := len(m.pageResults())
 	switch msg.String() {
-	case "q", "ctrl+c":
+	case "q", "ctrl+c", tuiEscKey, "h":
 		return m, tea.Quit
 	case "up", "k":
 		if m.cursor > 0 {
@@ -304,6 +304,21 @@ func (m searchModel) updateBrowseMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) { //n
 			m.cursor++
 			m = m.refreshBrowseContent()
 		}
+	case "home", "g":
+		m.page = 0
+		m.cursor = 0
+		m = m.refreshBrowseContent()
+		m.browseVP.GotoTop()
+	case "end", "G":
+		if len(m.results) > 0 {
+			lastLoaded := len(m.results) - 1
+			m.page = min(lastLoaded/resultsPerPage, m.totalPages()-1)
+			if pageLen := len(m.pageResults()); pageLen > 0 {
+				m.cursor = pageLen - 1
+			}
+			m = m.refreshBrowseContent()
+		}
+		m.browseVP.GotoBottom()
 	case "n", "right":
 		if m.page < m.totalPages()-1 {
 			m.page++
@@ -348,7 +363,7 @@ func (m searchModel) updateBrowseMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) { //n
 
 func (m searchModel) updateDetailMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) { //nolint:ireturn // bubbletea pattern
 	switch msg.String() {
-	case "esc", "backspace":
+	case tuiEscKey, "backspace":
 		m.mode = modeBrowse
 		return m, nil
 	case "q", "ctrl+c":
@@ -680,7 +695,7 @@ func (m searchModel) viewDetailFull() string {
 	scrollPct := m.styles.render(m.styles.dim, fmt.Sprintf("%3.f%%", m.detailVP.ScrollPercent()*100))
 	help := m.styles.render(m.styles.helpKey, "j/k") + " scroll" +
 		m.styles.render(m.styles.helpSep, " · ") +
-		m.styles.render(m.styles.helpKey, "esc") + " back" +
+		m.styles.render(m.styles.helpKey, tuiEscKey) + " back" +
 		m.styles.render(m.styles.helpSep, " · ") +
 		m.styles.render(m.styles.helpKey, "q") + " quit"
 
@@ -698,14 +713,14 @@ func (m searchModel) viewHelp() string {
 
 	if m.mode == modeSearch {
 		return m.styles.render(m.styles.helpKey, "enter") + " search" + dot +
-			m.styles.render(m.styles.helpKey, "esc") + " cancel" + "\n"
+			m.styles.render(m.styles.helpKey, tuiEscKey) + " cancel" + "\n"
 	}
 
 	pages := m.totalPages()
 
 	left := m.styles.render(m.styles.helpKey, "/") + " search" + dot +
-		m.styles.render(m.styles.helpKey, "j/k") + " navigate" + dot +
-		m.styles.render(m.styles.helpKey, "enter") + " detail"
+		m.styles.render(m.styles.helpKey, "↑/↓, j/k") + " scroll" + dot +
+		m.styles.render(m.styles.helpKey, "home/end, g/G") + " top/bottom"
 	if pages > 1 {
 		left += dot + m.styles.render(m.styles.helpKey, "n/p") + " page"
 	}

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -317,8 +317,8 @@ func (m searchModel) updateBrowseMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) { //n
 				m.cursor = pageLen - 1
 			}
 			m = m.refreshBrowseContent()
+			m.browseVP.GotoBottom()
 		}
-		m.browseVP.GotoBottom()
 	case "n", "right":
 		if m.page < m.totalPages()-1 {
 			m.page++

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -119,6 +119,93 @@ func TestSearchModel_Navigation(t *testing.T) {
 	}
 }
 
+func TestSearchModel_VimNavigationAliases(t *testing.T) {
+	t.Parallel()
+	m := testModel()
+
+	m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.cursor != 1 {
+		t.Errorf("after j: cursor = %d, want 1", m.cursor)
+	}
+
+	m = updateModel(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if m.cursor != 0 {
+		t.Errorf("after k: cursor = %d, want 0", m.cursor)
+	}
+}
+
+func TestSearchModel_TopBottomNavigation(t *testing.T) {
+	t.Parallel()
+
+	results := make([]search.Result, 30)
+	for i := range results {
+		results[i] = search.Result{Data: search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+
+	tests := []struct {
+		name        string
+		key         tea.KeyMsg
+		startPage   int
+		startCursor int
+		wantPage    int
+		wantCursor  int
+	}{
+		{
+			name:        "home",
+			key:         tea.KeyMsg{Type: tea.KeyHome},
+			startPage:   1,
+			startCursor: 4,
+			wantPage:    0,
+			wantCursor:  0,
+		},
+		{
+			name:        "g",
+			key:         tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}},
+			startPage:   1,
+			startCursor: 4,
+			wantPage:    0,
+			wantCursor:  0,
+		},
+		{
+			name:        "end",
+			key:         tea.KeyMsg{Type: tea.KeyEnd},
+			startPage:   0,
+			startCursor: 0,
+			wantPage:    1,
+			wantCursor:  4,
+		},
+		{
+			name:        "G",
+			key:         tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}},
+			startPage:   0,
+			startCursor: 0,
+			wantPage:    1,
+			wantCursor:  4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ss := statusStyles{colorEnabled: false, width: 100}
+			cfg := search.Config{}
+			m := initTestViewport(newSearchModel(results, "q", len(results), cfg, ss))
+			m.page = tt.startPage
+			m.cursor = tt.startCursor
+			m = m.refreshBrowseContent()
+
+			m = updateModel(t, m, tt.key)
+			if m.page != tt.wantPage {
+				t.Errorf("page = %d, want %d", m.page, tt.wantPage)
+			}
+			if m.cursor != tt.wantCursor {
+				t.Errorf("cursor = %d, want %d", m.cursor, tt.wantCursor)
+			}
+		})
+	}
+}
+
 func TestSearchModel_Quit(t *testing.T) {
 	t.Parallel()
 	m := testModel()
@@ -126,6 +213,8 @@ func TestSearchModel_Quit(t *testing.T) {
 	quitKeys := []tea.KeyMsg{
 		{Type: tea.KeyRunes, Runes: []rune{'q'}},
 		{Type: tea.KeyCtrlC},
+		{Type: tea.KeyEsc},
+		{Type: tea.KeyRunes, Runes: []rune{'h'}},
 	}
 
 	for _, key := range quitKeys {
@@ -258,12 +347,73 @@ func TestSearchModel_View(t *testing.T) {
 		t.Error("detail missing files or truncation hint")
 	}
 
-	// Footer
-	if !strings.Contains(view, "navigate") {
-		t.Error("view missing footer help")
-	}
 	if !strings.Contains(view, "2 results") {
 		t.Error("view missing results count in footer")
+	}
+}
+
+func TestSearchModel_BrowseFooterHelp(t *testing.T) {
+	t.Parallel()
+	m := testModel()
+
+	footer := m.viewHelp()
+	wantParts := []string{
+		"/ search",
+		"↑/↓, j/k scroll",
+		"home/end, g/G top/bottom",
+		"q quit",
+	}
+	lastIndex := -1
+	for _, want := range wantParts {
+		idx := strings.Index(footer, want)
+		if idx == -1 {
+			t.Fatalf("footer missing %q: %q", want, footer)
+		}
+		if idx < lastIndex {
+			t.Fatalf("footer control %q rendered out of order: %q", want, footer)
+		}
+		lastIndex = idx
+	}
+
+	for _, unwanted := range []string{"detail", "open", "back", "navigate"} {
+		if strings.Contains(footer, unwanted) {
+			t.Fatalf("footer should not mention %q: %q", unwanted, footer)
+		}
+	}
+	if strings.Contains(footer, "n/p page") {
+		t.Fatalf("single-page footer should not mention paging: %q", footer)
+	}
+}
+
+func TestSearchModel_BrowseFooterHelpIncludesPagingForMultiplePages(t *testing.T) {
+	t.Parallel()
+
+	results := make([]search.Result, 30)
+	for i := range results {
+		results[i] = search.Result{Data: search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+
+	ss := statusStyles{colorEnabled: false, width: 120}
+	m := newSearchModel(results, "q", len(results), search.Config{}, ss)
+
+	footer := m.viewHelp()
+	wantParts := []string{
+		"/ search",
+		"↑/↓, j/k scroll",
+		"home/end, g/G top/bottom",
+		"n/p page",
+		"q quit",
+	}
+	lastIndex := -1
+	for _, want := range wantParts {
+		idx := strings.Index(footer, want)
+		if idx == -1 {
+			t.Fatalf("footer missing %q: %q", want, footer)
+		}
+		if idx < lastIndex {
+			t.Fatalf("footer control %q rendered out of order: %q", want, footer)
+		}
+		lastIndex = idx
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/247
<!-- entire-trail-link-end -->

## What
- Aligns the `entire search` TUI help and navigation vocabulary with the newer interactive command conventions.
- Keeps search as a single-screen TUI and preserves existing `/` search plus conditional `n/p` paging help.
- Fixes dispatch TUI tests that mutated a package-level test hook while running in parallel.

## How
- Adds hidden vim-style and top/bottom browse-mode aliases: `j/k`, `h`, `g/G`, `home/end`.
- Updates the footer to compact dot-separated hints: `/ search · ↑/↓, j/k scroll · home/end, g/G top/bottom · q quit`, with `n/p page` still conditional.
- Adds focused model tests for the new search key behavior and help text.
- Removes `t.Parallel()` from dispatch tests that override `newDispatchProgram`.

## Verification
- `go test -race ./cmd/entire/cli -run 'TestDefaultRunInteractiveDispatch_(DoesNotUseAltScreen|ClearsLoadingCardBeforeReturn)' -count=1`
- `mise run build`
- `mise run lint`
- `mise run test:ci:core`
- `mise run test:ci:integration:shard -- a`
- `mise run test:ci:integration:shard -- b`
- `mise run test:ci:integration:shard -- c`
- `mise run test:e2e:canary`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to interactive search TUI keybindings/help text plus additional tests, and removes parallelism in two dispatch tests to avoid a package-level hook race.
> 
> **Overview**
> Aligns the `entire search` interactive TUI navigation and footer help with newer conventions by standardizing escape handling via `tuiEscKey`, adding browse-mode aliases (`h`/Esc quit, `home`/`g` top, `end`/`G` bottom), and updating the on-screen help text accordingly.
> 
> Expands `search_tui_test.go` coverage for the new key behaviors and revised footer rendering (including conditional `n/p` paging hints), and fixes dispatch TUI flakiness by removing `t.Parallel()` from tests that override the package-level `newDispatchProgram` hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8746bc0d0c4cf37bb2916150f684e21a41a7771. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->