### PR TITLE
Checkpoints V2: Update migration completion message

### DIFF
--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -88,8 +88,7 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 		return err
 	}
 
-	fmt.Fprintf(out, "\nMigration complete: %d migrated, %d skipped, %d failed\n",
-		result.migrated, result.skipped, result.failed)
+	printMigrateCheckpointsV2Completion(out, result)
 
 	if result.failed > 0 {
 		fmt.Fprintf(out, "%d checkpoint(s) failed to migrate. Check .entire/logs/ for details.\n", result.failed)
@@ -97,6 +96,14 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 	}
 
 	return nil
+}
+
+func printMigrateCheckpointsV2Completion(out io.Writer, result *migrateResult) {
+	fmt.Fprintf(out, "\nMigration complete: %d migrated, %d skipped, %d failed\n",
+		result.migrated, result.skipped, result.failed)
+	fmt.Fprintln(out, "Note, V2 checkpoints are stored as custom refs under refs/entire/checkpoints/v2/*, not as a branch visible in the GitHub UI.")
+	fmt.Fprintf(out, "To inspect pushed v2 checkpoint refs locally, run: git ls-remote %s 'refs/entire/checkpoints/v2/*'\n", migrateRemoteName)
+	fmt.Fprintln(out, `You may also open a checkpoint's details in entire.io and click the "session logs" link to view the log files and metadata.`)
 }
 
 var (

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -90,9 +90,9 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 
 	fmt.Fprintf(out, "\nMigration complete: %d migrated, %d skipped, %d failed\n",
 		result.migrated, result.skipped, result.failed)
-	fmt.Fprintln(out, "Note, V2 checkpoints are stored as custom refs under refs/entire/checkpoints/v2/*, not as a branch visible in the GitHub UI.")
-	fmt.Fprintf(out, "To inspect pushed v2 checkpoint refs locally, run: git ls-remote %s 'refs/entire/checkpoints/v2/*'\n", migrateRemoteName)
-	fmt.Fprintln(out, `You may also open a checkpoint's details in entire.io and click the "session logs" link to view the log files and metadata.`)
+	fmt.Fprintln(out, "Note: V2 checkpoints are stored as custom refs under refs/entire/checkpoints/v2/*, not as a branch visible in the GitHub UI.")
+	fmt.Fprintf(out, "To inspect pushed v2 checkpoint refs locally, run: git ls-remote %s \"refs/entire/checkpoints/v2/*\"\n", migrateRemoteName)
+	fmt.Fprintln(out, `You may also open a checkpoint's details in the Entire web app and click the "session logs" link to view the log files and metadata.`)
 
 	if result.failed > 0 {
 		fmt.Fprintf(out, "%d checkpoint(s) failed to migrate. Check .entire/logs/ for details.\n", result.failed)

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -88,7 +88,11 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 		return err
 	}
 
-	printMigrateCheckpointsV2Completion(out, result)
+	fmt.Fprintf(out, "\nMigration complete: %d migrated, %d skipped, %d failed\n",
+		result.migrated, result.skipped, result.failed)
+	fmt.Fprintln(out, "Note, V2 checkpoints are stored as custom refs under refs/entire/checkpoints/v2/*, not as a branch visible in the GitHub UI.")
+	fmt.Fprintf(out, "To inspect pushed v2 checkpoint refs locally, run: git ls-remote %s 'refs/entire/checkpoints/v2/*'\n", migrateRemoteName)
+	fmt.Fprintln(out, `You may also open a checkpoint's details in entire.io and click the "session logs" link to view the log files and metadata.`)
 
 	if result.failed > 0 {
 		fmt.Fprintf(out, "%d checkpoint(s) failed to migrate. Check .entire/logs/ for details.\n", result.failed)
@@ -96,14 +100,6 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 	}
 
 	return nil
-}
-
-func printMigrateCheckpointsV2Completion(out io.Writer, result *migrateResult) {
-	fmt.Fprintf(out, "\nMigration complete: %d migrated, %d skipped, %d failed\n",
-		result.migrated, result.skipped, result.failed)
-	fmt.Fprintln(out, "Note, V2 checkpoints are stored as custom refs under refs/entire/checkpoints/v2/*, not as a branch visible in the GitHub UI.")
-	fmt.Fprintf(out, "To inspect pushed v2 checkpoint refs locally, run: git ls-remote %s 'refs/entire/checkpoints/v2/*'\n", migrateRemoteName)
-	fmt.Fprintln(out, `You may also open a checkpoint's details in entire.io and click the "session logs" link to view the log files and metadata.`)
 }
 
 var (


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/248
<!-- entire-trail-link-end -->

Add more helpful information to the migration completion message so folks know where to see the logs and metadata if desired.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CLI post-migration messaging and extracts it into a helper, with no changes to migration logic or data writes.
> 
> **Overview**
> Improves the `checkpoints v2` migration completion output by extracting it into `printMigrateCheckpointsV2Completion` and adding guidance on where v2 checkpoints live and how to inspect them.
> 
> The completion message now explains that v2 checkpoints are stored as custom refs under `refs/entire/checkpoints/v2/*`, provides a `git ls-remote` command to list them, and points users to entire.io session logs for viewing log files and metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfb873fd4c16f918bd11c089b24e74daaf72716. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->