### PR TITLE
feat(cli): align activity TUI navigation help

### DIFF
--- a/cmd/entire/cli/activity_tui.go
+++ b/cmd/entire/cli/activity_tui.go
@@ -117,6 +117,18 @@ func (m activityModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:iretu
 		if key.Matches(msg, keys.Quit) || key.Matches(msg, keys.Back) {
 			return m, tea.Quit
 		}
+		if key.Matches(msg, keys.Home) {
+			if m.ready {
+				m.viewport.GotoTop()
+			}
+			return m, nil
+		}
+		if key.Matches(msg, keys.End) {
+			if m.ready {
+				m.viewport.GotoBottom()
+			}
+			return m, nil
+		}
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -216,15 +228,38 @@ func (m activityModel) renderFooter() string {
 	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Bold(true)
 	sep := helpStyle.Render(" · ")
 
-	scrollPct := ""
-	if m.viewport.TotalLineCount() > m.viewport.Height {
-		pct := int(m.viewport.ScrollPercent() * 100)
-		scrollPct = sep + helpStyle.Render(strings.Repeat(" ", max(0, m.width-40))+padLeft(pct)+"%")
+	fullHelp := keyStyle.Render("↑/↓, j/k") + helpStyle.Render(" scroll") +
+		sep + keyStyle.Render("home/end, g/G") + helpStyle.Render(" top/bottom") +
+		sep + keyStyle.Render(keys.Quit.Help().Key) + helpStyle.Render(" "+keys.Quit.Help().Desc)
+	standardHelp := keyStyle.Render("↑/↓") + helpStyle.Render(" scroll") +
+		sep + keyStyle.Render("home/end") + helpStyle.Render(" top/bottom") +
+		sep + keyStyle.Render(keys.Quit.Help().Key) + helpStyle.Render(" "+keys.Quit.Help().Desc)
+	shortHelp := keyStyle.Render("↑/↓") + helpStyle.Render(" scroll")
+	quitHelp := keyStyle.Render(keys.Quit.Help().Key) + helpStyle.Render(" "+keys.Quit.Help().Desc)
+	helpChoices := []string{fullHelp, standardHelp, shortHelp, quitHelp}
+
+	if m.viewport.TotalLineCount() <= m.viewport.Height {
+		for _, help := range helpChoices {
+			if m.width <= 0 || lipgloss.Width(help) <= m.width {
+				return help
+			}
+		}
+		return ""
 	}
 
-	return keyStyle.Render("↑↓") + helpStyle.Render(" scroll") +
-		sep + keyStyle.Render(keys.Quit.Help().Key) + helpStyle.Render(" "+keys.Quit.Help().Desc) +
-		scrollPct
+	pct := helpStyle.Render(padLeft(int(m.viewport.ScrollPercent()*100)) + "%")
+	for _, help := range helpChoices {
+		gap := m.width - lipgloss.Width(help) - lipgloss.Width(sep) - lipgloss.Width(pct)
+		if gap >= 1 {
+			return help + sep + helpStyle.Render(strings.Repeat(" ", gap)) + pct
+		}
+	}
+
+	pctWidth := lipgloss.Width(pct)
+	if m.width < pctWidth {
+		return helpStyle.Render(strings.Repeat(" ", max(m.width, 0)))
+	}
+	return helpStyle.Render(strings.Repeat(" ", m.width-pctWidth)) + pct
 }
 
 func newActivityStylesWithWidth(width int, useColor bool) activityStyles {

--- a/cmd/entire/cli/activity_tui_test.go
+++ b/cmd/entire/cli/activity_tui_test.go
@@ -178,7 +178,7 @@ func TestActivityModel_FooterScrollPercentFitsWidth(t *testing.T) {
 	if got := lipgloss.Width(footer); got != m.width {
 		t.Fatalf("compact footer width = %d, want %d: %q", got, m.width, footer)
 	}
-	for _, want := range []string{"↑/↓ scroll", "home/end top/bottom", "q quit"} {
+	for _, want := range []string{"↑/↓", " scroll", "home/end", " top/bottom", "q", " quit"} {
 		if !strings.Contains(footer, want) {
 			t.Fatalf("compact footer missing %q: %q", want, footer)
 		}

--- a/cmd/entire/cli/activity_tui_test.go
+++ b/cmd/entire/cli/activity_tui_test.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func testActivityTUIModel() activityModel {
+	vp := viewport.New(80, 3)
+	vp.SetContent(strings.Join([]string{
+		"line 1",
+		"line 2",
+		"line 3",
+		"line 4",
+		"line 5",
+		"line 6",
+	}, "\n"))
+
+	return activityModel{
+		viewport: vp,
+		ready:    true,
+		width:    80,
+		height:   4,
+	}
+}
+
+func updateActivityModel(t *testing.T, m activityModel, msg tea.Msg) (activityModel, tea.Cmd) {
+	t.Helper()
+
+	updated, cmd := m.Update(msg)
+	result, ok := updated.(activityModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want activityModel", updated)
+	}
+	return result, cmd
+}
+
+func activityRuneKey(r rune) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+}
+
+func TestActivityModel_ScrollKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "arrow down", key: tea.KeyMsg{Type: tea.KeyDown}},
+		{name: "vim down", key: activityRuneKey('j')},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m, _ := updateActivityModel(t, testActivityTUIModel(), tt.key)
+			if m.viewport.YOffset != 1 {
+				t.Fatalf("YOffset = %d, want 1", m.viewport.YOffset)
+			}
+		})
+	}
+}
+
+func TestActivityModel_ScrollUpKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "arrow up", key: tea.KeyMsg{Type: tea.KeyUp}},
+		{name: "vim up", key: activityRuneKey('k')},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := testActivityTUIModel()
+			m.viewport.SetYOffset(2)
+			m, _ = updateActivityModel(t, m, tt.key)
+			if m.viewport.YOffset != 1 {
+				t.Fatalf("YOffset = %d, want 1", m.viewport.YOffset)
+			}
+		})
+	}
+}
+
+func TestActivityModel_TopBottomKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		key      tea.KeyMsg
+		gotoTop  bool
+		wantDesc string
+	}{
+		{name: "home", key: tea.KeyMsg{Type: tea.KeyHome}, gotoTop: true, wantDesc: "top"},
+		{name: "vim top", key: activityRuneKey('g'), gotoTop: true, wantDesc: "top"},
+		{name: "end", key: tea.KeyMsg{Type: tea.KeyEnd}, wantDesc: "bottom"},
+		{name: "vim bottom", key: activityRuneKey('G'), wantDesc: "bottom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := testActivityTUIModel()
+			if tt.gotoTop {
+				m.viewport.GotoBottom()
+			}
+			m, _ = updateActivityModel(t, m, tt.key)
+
+			if tt.gotoTop && !m.viewport.AtTop() {
+				t.Fatalf("viewport should be at %s, YOffset = %d", tt.wantDesc, m.viewport.YOffset)
+			}
+			if !tt.gotoTop && !m.viewport.AtBottom() {
+				t.Fatalf("viewport should be at %s, YOffset = %d", tt.wantDesc, m.viewport.YOffset)
+			}
+		})
+	}
+}
+
+func TestActivityModel_QuitKeys(t *testing.T) {
+	t.Parallel()
+
+	quitKeys := []tea.KeyMsg{
+		activityRuneKey('q'),
+		{Type: tea.KeyCtrlC},
+		{Type: tea.KeyEsc},
+	}
+
+	for _, key := range quitKeys {
+		_, cmd := updateActivityModel(t, testActivityTUIModel(), key)
+		if cmd == nil {
+			t.Fatalf("key %v: expected quit command, got nil", key)
+		}
+		if _, ok := cmd().(tea.QuitMsg); !ok {
+			t.Fatalf("key %v: expected QuitMsg", key)
+		}
+	}
+}
+
+func TestActivityModel_FooterDocumentsVisibleControlsOnly(t *testing.T) {
+	t.Parallel()
+
+	m := testActivityTUIModel()
+	m.sty = newActivityStylesWithWidth(m.width, true)
+
+	footer := m.renderFooter()
+	for _, want := range []string{"↑/↓, j/k", " scroll", "home/end, g/G", " top/bottom", "q", " quit"} {
+		if !strings.Contains(footer, want) {
+			t.Fatalf("footer missing %q: %q", want, footer)
+		}
+	}
+}
+
+func TestActivityModel_FooterScrollPercentFitsWidth(t *testing.T) {
+	t.Parallel()
+
+	m := testActivityTUIModel()
+	m.sty = newActivityStylesWithWidth(m.width, true)
+
+	footer := m.renderFooter()
+	if got := lipgloss.Width(footer); got != m.width {
+		t.Fatalf("wide footer width = %d, want %d: %q", got, m.width, footer)
+	}
+
+	m.width = 50
+	m.sty = newActivityStylesWithWidth(m.width, true)
+
+	footer = m.renderFooter()
+	if got := lipgloss.Width(footer); got != m.width {
+		t.Fatalf("compact footer width = %d, want %d: %q", got, m.width, footer)
+	}
+	for _, want := range []string{"↑/↓ scroll", "home/end top/bottom", "q quit"} {
+		if !strings.Contains(footer, want) {
+			t.Fatalf("compact footer missing %q: %q", want, footer)
+		}
+	}
+	for _, hidden := range []string{"j/k", "g/G"} {
+		if strings.Contains(footer, hidden) {
+			t.Fatalf("compact footer should drop %q: %q", hidden, footer)
+		}
+	}
+
+	m.width = 20
+	m.sty = newActivityStylesWithWidth(m.width, true)
+
+	footer = m.renderFooter()
+	if got := lipgloss.Width(footer); got != m.width {
+		t.Fatalf("narrow footer width = %d, want %d: %q", got, m.width, footer)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/253
<!-- entire-trail-link-end -->

This is a redo of https://github.com/entireio/cli/pull/1056

## What
- Aligns entire activity keyboard behavior with the repo's newer TUI navigation vocabulary while keeping it single-screen.
- Documents both arrow and vim-style navigation controls in the footer: up/down/j/k scrolling, home/end/g/G top/bottom, and q quit.

<img width="1295" height="109" alt="image" src="https://github.com/user-attachments/assets/44277aa0-db01-4319-ad1d-922040ca1625" />

Uses now the same bindings introduced in https://github.com/entireio/cli/pull/1060