### PR TITLE
fix(cli): discover external agents in `entire status`

### DIFF
--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -51,6 +52,8 @@ func newStatusCmd() *cobra.Command {
 }
 
 func runStatus(ctx context.Context, w io.Writer, detailed, jsonOutput bool) error {
+	external.DiscoverAndRegisterAlways(ctx)
+
 	if jsonOutput {
 		return runStatusJSON(ctx, w)
 	}

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1856,5 +1857,49 @@ func TestRunStatusJSON_DeduplicatesSessions(t *testing.T) {
 	}
 	if s.Model != "codex-mini" {
 		t.Errorf("Expected model='codex-mini' from active session, got %q", s.Model)
+	}
+}
+
+// TestRunStatus_DiscoversExternalAgents verifies that `entire status` registers
+// external agents on PATH even when external_agents is not enabled in settings.
+// Without DiscoverAndRegisterAlways in runStatus, an external agent that is
+// otherwise correctly installed on the user's PATH would never appear in the
+// status command's agent enumeration.
+func TestRunStatus_DiscoversExternalAgents(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+
+	setupTestRepo(t)
+	// Settings deliberately omit external_agents — the point is to verify
+	// discovery runs regardless of that flag.
+	writeSettings(t, testSettingsEnabled)
+
+	agentName := types.AgentName("statustest-discovery-agent")
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "entire-agent-"+string(agentName))
+	infoJSON := `{
+  "protocol_version": 1,
+  "name": "` + string(agentName) + `",
+  "type": "Status Test Agent",
+  "description": "Agent for status discovery test",
+  "is_preview": false,
+  "protected_dirs": [],
+  "hook_names": [],
+  "capabilities": {}
+}`
+	script := "#!/bin/sh\nif [ \"$1\" = \"info\" ]; then\n  echo '" + infoJSON + "'\nfi\n"
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write mock agent binary: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout bytes.Buffer
+	if err := runStatus(context.Background(), &stdout, false, false); err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	if _, err := agent.Get(agentName); err != nil {
+		t.Errorf("expected external agent %q in registry after runStatus, got: %v", agentName, err)
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/255
<!-- entire-trail-link-end -->

Picks up the status.go pach from issue #983.

Without this, `entire status` enumerates only built-in agents through the agent registry, so external agents installed via $PATH never appear in the "Agents ·" hooks line. Call DiscoverAndRegisterAlways before rendering, matching the pattern used in setup. Bypassing the external_agents settings gate matches the behavior the user already gets from `entire configure`, and avoids silently hiding agents when the settings file isn't perfectly resolvable.

Adds TestRunStatus_DiscoversExternalAgents, which stands up a fake entire-agent-<name> on PATH (with external_agents deliberately not enabled) and asserts the agent lands in the registry after runStatus.

Entire-Checkpoint: b912fcbe79b8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `entire status` now scans `$PATH` and executes external agent binaries’ `info` subcommand on every run, which could affect performance or surface issues with misbehaving agents despite being bounded by a timeout.
> 
> **Overview**
> `entire status` now **always discovers and registers external agents on `$PATH`** by calling `external.DiscoverAndRegisterAlways(ctx)` before rendering output, so external agents appear in the "Agents" line even when `external_agents` isn’t enabled in settings.
> 
> Adds a regression test that installs a fake `entire-agent-<name>` script onto `PATH` and asserts it gets registered after running `runStatus`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533d5aa81beb2d312204c5fed4d1aa25234db243. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->