### PR TITLE
tighten redaction coverage

### DIFF
--- a/redact/redact.go
+++ b/redact/redact.go
@@ -383,15 +383,45 @@ func isPlaceholderSecretValue(value string) bool {
 	if strings.HasPrefix(normalized, "${") && strings.HasSuffix(normalized, "}") {
 		return true
 	}
+	// Documentation placeholders like <password> or <your-db-password>.
+	if strings.HasPrefix(normalized, "<") && strings.HasSuffix(normalized, ">") && len(normalized) > 2 {
+		return true
+	}
 	if _, ok := redactedPlaceholderForms[normalized]; ok {
 		return true
 	}
+	if isRepeatedCharPlaceholder(normalized) {
+		return true
+	}
 	switch normalized {
-	case "xxx", "xxxx", "changeme", "example":
+	case "changeme", "example", "placeholder",
+		"your_password", "your_db_password", "your_secret",
+		"secret_here":
 		return true
 	default:
 		return false
 	}
+}
+
+// isRepeatedCharPlaceholder reports whether s is a non-empty run of a single
+// masking character commonly used to redact values in docs and screenshots,
+// e.g. "***", "xxxx", "....", "----".
+func isRepeatedCharPlaceholder(s string) bool {
+	if s == "" {
+		return false
+	}
+	first := s[0]
+	switch first {
+	case '*', 'x', '.', '-':
+	default:
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		if s[i] != first {
+			return false
+		}
+	}
+	return true
 }
 
 func isCredentialJSONSecretKey(key string, credentialContext bool) bool {
@@ -422,6 +452,9 @@ func normalizeCredentialJSONKey(key string) string {
 	key = strings.ToLower(strings.TrimSpace(key))
 	key = strings.ReplaceAll(key, "-", "_")
 	key = strings.ReplaceAll(key, " ", "_")
+	// Flattened-config exporters (Spring, dotnet, Hashicorp Vault) emit dotted keys
+	// like "db.password" or "mysql.root.password"; treat them like underscored.
+	key = strings.ReplaceAll(key, ".", "_")
 	return key
 }
 

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -25,33 +25,30 @@ var secretPattern = regexp.MustCompile(`[A-Za-z0-9+_=-]{10,}`)
 // moderate entropy and are not reliably covered by vendor-specific scanners.
 var credentialedURIPattern = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]{1,31}://[^\s/?#@"'` + "`" + `<>:]*:[^\s/?#@"'` + "`" + `<>]+@[^\s"'` + "`" + `<>]+`)
 
+// dbPasswordKeyShape matches a DB-prefixed credential key (vendor prefix +
+// optional `_word`/`-word` segments + `password`/`passwd`/`pwd`). Used to
+// compose both the env-var assignment regex and the JSON-key regex so the
+// vendor list stays in one place.
+const dbPasswordKeyShape = `(?:db|database|pg|postgres|postgresql|mysql|mariadb|redis|mongo|mongodb|sqlserver|mssql|jdbc)(?:[_-]+[a-z0-9]+)*[_-]*(?:password|passwd|pwd)` //nolint:gosec // regex literal, not a credential
+
 var (
-	jdbcPattern        = regexp.MustCompile(`(?i)\bjdbc:[^\s"'<>` + "`" + `]+`)
-	databaseURLPattern = regexp.MustCompile(`(?i)\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis)://[^\s"'<>` + "`" + `]+`)
-	keywordDSNPattern  = regexp.MustCompile(`(?i)\b[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)(?:\s+[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)){2,}`)
-	// semicolonConnPattern matches ADO.NET / ODBC style connection strings.
-	// The value class accepts `{…}`, `"…"`, and `'…'` so quoted ADO.NET values
-	// with embedded semicolons (e.g. `Password="se;cret;here"`) are captured
-	// as a single value rather than splitting at the inner `;`.
+	jdbcPattern          = regexp.MustCompile(`(?i)\bjdbc:[^\s"'<>` + "`" + `]+`)
+	databaseURLPattern   = regexp.MustCompile(`(?i)\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis)://[^\s"'<>` + "`" + `]+`)
+	keywordDSNPattern    = regexp.MustCompile(`(?i)\b[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)(?:\s+[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)){2,}`)
 	semicolonConnPattern = regexp.MustCompile(`(?i)\b[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|"[^"]*"|'[^']*'|[^=;"'\s]+)(?:;[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|"[^"]*"|'[^']*'|[^=;"'\s]+)){2,}`)
-	// credentialValuePattern matches DB-prefixed credential assignments. The prefix
-	// must start at a non-alphanumeric boundary (so APP_DB_PASSWORD matches via the
-	// leading `_`, but mydbpassword does not). Between the vendor prefix and the
-	// password/passwd/pwd suffix we allow zero or more `_word`/`-word` segments and
-	// any run of `_`/`-` separators, so MYSQL_ROOT_PASSWORD, MARIADB_ROOT_PASSWORD,
-	// MONGO_INITDB_ROOT_PASSWORD, MSSQL_SA_PASSWORD, and DB__PASSWORD all match.
-	credentialValuePattern = regexp.MustCompile(`(?i)(?:^|[^A-Za-z0-9])((?:db|database|pg|postgres|postgresql|mysql|mariadb|redis|mongo|mongodb|sqlserver|mssql|jdbc)(?:[_-]+[a-z0-9]+)*[_-]*(?:password|passwd|pwd))\s*=\s*("[^"]*"|'[^']*'|[^\s,;&]+)`)
+	// credentialValuePattern requires the prefix to start at a non-alphanumeric
+	// boundary, so APP_DB_PASSWORD matches via the leading `_` but mydbpassword
+	// does not.
+	credentialValuePattern = regexp.MustCompile(`(?i)(?:^|[^A-Za-z0-9])(` + dbPasswordKeyShape + `)\s*=\s*("[^"]*"|'[^']*'|[^\s,;&]+)`)
 
 	keywordHostPattern      = regexp.MustCompile(`(?i)(?:^|\s)host=`)
 	keywordUserPattern      = regexp.MustCompile(`(?i)(?:^|\s)user=`)
 	semicolonServerPattern  = regexp.MustCompile(`(?i)(?:^|;)\s*(?:server|data source|datasource|addr|address|network address)\s*=`)
 	semicolonUserPattern    = regexp.MustCompile(`(?i)(?:^|;)\s*(?:user id|userid|user|uid)\s*=`)
 	passwordAssignmentRegex = regexp.MustCompile(`(?i)(?:^|[?&;\s])(?:password|pwd)=("[^"]*"|'[^']*'|[^&;\s"']+)`)
-	// credentialJSONKeyRegex matches normalized JSON credential keys. Mirrors the
-	// internal-segment shape of credentialValuePattern so keys like
-	// mysql_root_password and mongo_initdb_root_password are recognized.
-	// Operates on output of normalizeCredentialJSONKey (lowercased, `-`/` ` → `_`).
-	credentialJSONKeyRegex  = regexp.MustCompile(`^(?:db|database|pg|postgres|postgresql|mysql|mariadb|redis|mongo|mongodb|sqlserver|mssql|jdbc)(?:[_-]+[a-z0-9]+)*[_-]*(?:password|passwd|pwd)$`)
+	// credentialJSONKeyRegex operates on output of normalizeCredentialJSONKey
+	// (already lowercased, `-`/` `/`.` → `_`), so the `(?i)` flag is unnecessary.
+	credentialJSONKeyRegex  = regexp.MustCompile(`^` + dbPasswordKeyShape + `$`)
 	genericPasswordKeyRegex = regexp.MustCompile(`(?i)^(?:password|passwd|pwd)$`)
 )
 
@@ -64,15 +61,24 @@ const entropyThreshold = 4.5
 // RedactedPlaceholder is the replacement text used for redacted secrets.
 const RedactedPlaceholder = "REDACTED"
 
-// redactedPlaceholderForms holds the lowercase variants of RedactedPlaceholder
-// used to recognize already-redacted values (so we don't double-redact).
-var redactedPlaceholderForms = func() map[string]struct{} {
+// placeholderSecretValues lists lowercase values that should be treated as
+// non-secrets when they appear as a credential value: prior redactions
+// (REDACTED / [REDACTED] / <REDACTED>), common documentation placeholders,
+// and obviously-non-real defaults. Values matched by shape (mask runs,
+// `<…>` brackets, `${…}` shell expansion) are handled separately.
+var placeholderSecretValues = func() map[string]struct{} {
 	lower := strings.ToLower(RedactedPlaceholder)
-	return map[string]struct{}{
-		lower:             {},
-		"[" + lower + "]": {},
-		"<" + lower + ">": {},
+	values := []string{
+		lower, "[" + lower + "]", "<" + lower + ">",
+		"changeme", "example", "placeholder",
+		"your_password", "your_db_password", "your_secret",
+		"secret_here",
 	}
+	out := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		out[v] = struct{}{}
+	}
+	return out
 }()
 
 // RedactedBytes represents transcript data that has been through secret
@@ -383,24 +389,13 @@ func isPlaceholderSecretValue(value string) bool {
 	if strings.HasPrefix(normalized, "${") && strings.HasSuffix(normalized, "}") {
 		return true
 	}
-	// Documentation placeholders like <password> or <your-db-password>.
-	if strings.HasPrefix(normalized, "<") && strings.HasSuffix(normalized, ">") && len(normalized) > 2 {
+	if len(normalized) > 2 && strings.HasPrefix(normalized, "<") && strings.HasSuffix(normalized, ">") {
 		return true
 	}
-	if _, ok := redactedPlaceholderForms[normalized]; ok {
+	if _, ok := placeholderSecretValues[normalized]; ok {
 		return true
 	}
-	if isRepeatedCharPlaceholder(normalized) {
-		return true
-	}
-	switch normalized {
-	case "changeme", "example", "placeholder",
-		"your_password", "your_db_password", "your_secret",
-		"secret_here":
-		return true
-	default:
-		return false
-	}
+	return isRepeatedCharPlaceholder(normalized)
 }
 
 // isRepeatedCharPlaceholder reports whether s is a non-empty run of a single

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -381,15 +381,15 @@ func hasNonPlaceholderPasswordValue(value string) bool {
 }
 
 func isPlaceholderSecretValue(value string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(value))
-	normalized = strings.Trim(normalized, `"'`)
-	if normalized == "" {
+	trimmed := strings.Trim(strings.TrimSpace(value), `"'`)
+	if trimmed == "" {
 		return true
 	}
+	if isBracketedPlaceholder(trimmed) {
+		return true
+	}
+	normalized := strings.ToLower(trimmed)
 	if strings.HasPrefix(normalized, "${") && strings.HasSuffix(normalized, "}") {
-		return true
-	}
-	if len(normalized) > 2 && strings.HasPrefix(normalized, "<") && strings.HasSuffix(normalized, ">") {
 		return true
 	}
 	if _, ok := placeholderSecretValues[normalized]; ok {
@@ -398,11 +398,28 @@ func isPlaceholderSecretValue(value string) bool {
 	return isRepeatedCharPlaceholder(normalized)
 }
 
-// isRepeatedCharPlaceholder reports whether s is a non-empty run of a single
-// masking character commonly used to redact values in docs and screenshots,
-// e.g. "***", "xxxx", "....", "----".
+// bracketedPlaceholderInteriorRE matches the inside of a "<…>" placeholder
+// shape: lowercase letters joined by `-` or `_`. Digits, mixed case, and
+// special chars are rejected so values like `<hunter2>` or `<RealPassword>`
+// still fall through to redaction.
+var bracketedPlaceholderInteriorRE = regexp.MustCompile(`^[a-z][a-z_-]*$`)
+
+// isBracketedPlaceholder reports whether s is a "<name>" doc placeholder
+// (e.g. "<password>", "<your-db-password>"). The minimum total length of 5
+// keeps this from firing on `<a>` / `<ab>`.
+func isBracketedPlaceholder(s string) bool {
+	if len(s) < 5 || s[0] != '<' || s[len(s)-1] != '>' {
+		return false
+	}
+	return bracketedPlaceholderInteriorRE.MatchString(s[1 : len(s)-1])
+}
+
+// isRepeatedCharPlaceholder reports whether s is a run of a single masking
+// character commonly used to redact values in docs and screenshots, e.g.
+// "***", "xxxx", "....", "----". The minimum length of 3 keeps single-char
+// or 2-char values like `x` or `**` from being treated as masks.
 func isRepeatedCharPlaceholder(s string) bool {
-	if s == "" {
+	if len(s) < 3 {
 		return false
 	}
 	first := s[0]

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -26,10 +26,14 @@ var secretPattern = regexp.MustCompile(`[A-Za-z0-9+_=-]{10,}`)
 var credentialedURIPattern = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]{1,31}://[^\s/?#@"'` + "`" + `<>:]*:[^\s/?#@"'` + "`" + `<>]+@[^\s"'` + "`" + `<>]+`)
 
 var (
-	jdbcPattern          = regexp.MustCompile(`(?i)\bjdbc:[^\s"'<>` + "`" + `]+`)
-	databaseURLPattern   = regexp.MustCompile(`(?i)\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis)://[^\s"'<>` + "`" + `]+`)
-	keywordDSNPattern    = regexp.MustCompile(`(?i)\b[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)(?:\s+[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)){2,}`)
-	semicolonConnPattern = regexp.MustCompile(`(?i)\b[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|[^=;"'\s]+)(?:;[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|[^=;"'\s]+)){2,}`)
+	jdbcPattern        = regexp.MustCompile(`(?i)\bjdbc:[^\s"'<>` + "`" + `]+`)
+	databaseURLPattern = regexp.MustCompile(`(?i)\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis)://[^\s"'<>` + "`" + `]+`)
+	keywordDSNPattern  = regexp.MustCompile(`(?i)\b[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)(?:\s+[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)){2,}`)
+	// semicolonConnPattern matches ADO.NET / ODBC style connection strings.
+	// The value class accepts `{…}`, `"…"`, and `'…'` so quoted ADO.NET values
+	// with embedded semicolons (e.g. `Password="se;cret;here"`) are captured
+	// as a single value rather than splitting at the inner `;`.
+	semicolonConnPattern = regexp.MustCompile(`(?i)\b[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|"[^"]*"|'[^']*'|[^=;"'\s]+)(?:;[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|"[^"]*"|'[^']*'|[^=;"'\s]+)){2,}`)
 	// credentialValuePattern matches DB-prefixed credential assignments. The prefix
 	// must start at a non-alphanumeric boundary (so APP_DB_PASSWORD matches via the
 	// leading `_`, but mydbpassword does not). Between the vendor prefix and the

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -26,18 +26,28 @@ var secretPattern = regexp.MustCompile(`[A-Za-z0-9+_=-]{10,}`)
 var credentialedURIPattern = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]{1,31}://[^\s/?#@"'` + "`" + `<>:]*:[^\s/?#@"'` + "`" + `<>]+@[^\s"'` + "`" + `<>]+`)
 
 var (
-	jdbcPattern            = regexp.MustCompile(`(?i)\bjdbc:[^\s"'<>` + "`" + `]+`)
-	databaseURLPattern     = regexp.MustCompile(`(?i)\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis)://[^\s"'<>` + "`" + `]+`)
-	keywordDSNPattern      = regexp.MustCompile(`(?i)\b[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)(?:\s+[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)){2,}`)
-	semicolonConnPattern   = regexp.MustCompile(`(?i)\b[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|[^=;"'\s]+)(?:;[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|[^=;"'\s]+)){2,}`)
-	credentialValuePattern = regexp.MustCompile(`(?i)(?:^|[^A-Za-z0-9])((?:db|database|pg|postgres|postgresql|mysql|mariadb|redis|mongo|mongodb|sqlserver|mssql|jdbc)[_-]?(?:password|passwd|pwd)|pgpassword|mysql_pwd|redis_password|mongo_password|mongodb_password)\s*=\s*("[^"]*"|'[^']*'|[^\s,;&]+)`)
+	jdbcPattern          = regexp.MustCompile(`(?i)\bjdbc:[^\s"'<>` + "`" + `]+`)
+	databaseURLPattern   = regexp.MustCompile(`(?i)\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis)://[^\s"'<>` + "`" + `]+`)
+	keywordDSNPattern    = regexp.MustCompile(`(?i)\b[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)(?:\s+[a-z_][a-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s"']+)){2,}`)
+	semicolonConnPattern = regexp.MustCompile(`(?i)\b[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|[^=;"'\s]+)(?:;[a-z][a-z0-9 _-]*=(?:\{[^}]*\}|[^=;"'\s]+)){2,}`)
+	// credentialValuePattern matches DB-prefixed credential assignments. The prefix
+	// must start at a non-alphanumeric boundary (so APP_DB_PASSWORD matches via the
+	// leading `_`, but mydbpassword does not). Between the vendor prefix and the
+	// password/passwd/pwd suffix we allow zero or more `_word`/`-word` segments and
+	// any run of `_`/`-` separators, so MYSQL_ROOT_PASSWORD, MARIADB_ROOT_PASSWORD,
+	// MONGO_INITDB_ROOT_PASSWORD, MSSQL_SA_PASSWORD, and DB__PASSWORD all match.
+	credentialValuePattern = regexp.MustCompile(`(?i)(?:^|[^A-Za-z0-9])((?:db|database|pg|postgres|postgresql|mysql|mariadb|redis|mongo|mongodb|sqlserver|mssql|jdbc)(?:[_-]+[a-z0-9]+)*[_-]*(?:password|passwd|pwd))\s*=\s*("[^"]*"|'[^']*'|[^\s,;&]+)`)
 
 	keywordHostPattern      = regexp.MustCompile(`(?i)(?:^|\s)host=`)
 	keywordUserPattern      = regexp.MustCompile(`(?i)(?:^|\s)user=`)
 	semicolonServerPattern  = regexp.MustCompile(`(?i)(?:^|;)\s*(?:server|data source|datasource|addr|address|network address)\s*=`)
 	semicolonUserPattern    = regexp.MustCompile(`(?i)(?:^|;)\s*(?:user id|userid|user|uid)\s*=`)
 	passwordAssignmentRegex = regexp.MustCompile(`(?i)(?:^|[?&;\s])(?:password|pwd)=("[^"]*"|'[^']*'|[^&;\s"']+)`)
-	credentialJSONKeyRegex  = regexp.MustCompile(`(?i)^(?:(?:db|database|pg|postgres|postgresql|mysql|mariadb|redis|mongo|mongodb|sqlserver|mssql|jdbc)[_-]?(?:password|passwd|pwd)|pgpassword|mysql_pwd|redis_password|mongo_password|mongodb_password)$`)
+	// credentialJSONKeyRegex matches normalized JSON credential keys. Mirrors the
+	// internal-segment shape of credentialValuePattern so keys like
+	// mysql_root_password and mongo_initdb_root_password are recognized.
+	// Operates on output of normalizeCredentialJSONKey (lowercased, `-`/` ` → `_`).
+	credentialJSONKeyRegex  = regexp.MustCompile(`^(?:db|database|pg|postgres|postgresql|mysql|mariadb|redis|mongo|mongodb|sqlserver|mssql|jdbc)(?:[_-]+[a-z0-9]+)*[_-]*(?:password|passwd|pwd)$`)
 	genericPasswordKeyRegex = regexp.MustCompile(`(?i)^(?:password|passwd|pwd)$`)
 )
 

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -529,6 +529,31 @@ func TestString_BoundedCredentialValueRedaction(t *testing.T) {
 			input: "PROD_MYSQL_PWD=secret123",
 			want:  "PROD_MYSQL_PWD=REDACTED",
 		},
+		{
+			name:  "mysql root password env var",
+			input: "MYSQL_ROOT_PASSWORD=secret123",
+			want:  "MYSQL_ROOT_PASSWORD=REDACTED",
+		},
+		{
+			name:  "mariadb root password env var",
+			input: "MARIADB_ROOT_PASSWORD=secret123",
+			want:  "MARIADB_ROOT_PASSWORD=REDACTED",
+		},
+		{
+			name:  "mongo initdb root password env var",
+			input: "MONGO_INITDB_ROOT_PASSWORD=secret123",
+			want:  "MONGO_INITDB_ROOT_PASSWORD=REDACTED",
+		},
+		{
+			name:  "mssql sa password env var",
+			input: "MSSQL_SA_PASSWORD=secret123",
+			want:  "MSSQL_SA_PASSWORD=REDACTED",
+		},
+		{
+			name:  "double underscore separator",
+			input: "DB__PASSWORD=secret123",
+			want:  "DB__PASSWORD=REDACTED",
+		},
 	})
 }
 
@@ -574,6 +599,16 @@ func TestString_BoundedCredentialValueOverRedactionGuards(t *testing.T) {
 			name:  "generic https password query is preserved",
 			input: "https://example.com/callback?user=svc&password=not-a-db-credential&debug=true",
 			want:  "https://example.com/callback?user=svc&password=not-a-db-credential&debug=true",
+		},
+		{
+			name:  "db password hash field is preserved",
+			input: "DB_PASSWORD_HASH=abcdef",
+			want:  "DB_PASSWORD_HASH=abcdef",
+		},
+		{
+			name:  "non-credential mysql field is preserved",
+			input: "MYSQL_USER_ID=alice",
+			want:  "MYSQL_USER_ID=alice",
 		},
 	})
 }
@@ -692,6 +727,30 @@ func TestJSONLContent_NormalizedCredentialKeysRedacted(t *testing.T) {
 	}
 	if strings.Contains(result, `"DB Password":"correct-horse-db"`) {
 		t.Fatalf("expected normalized credential key to be redacted, got: %s", result)
+	}
+}
+
+func TestJSONLContent_RootPasswordJSONKeysRedacted(t *testing.T) {
+	t.Parallel()
+	input := `{"env":{"MYSQL_ROOT_PASSWORD":"correct-horse-mysql","MONGO_INITDB_ROOT_PASSWORD":"correct-horse-mongo","MSSQL_SA_PASSWORD":"correct-horse-mssql"}}`
+
+	result, err := JSONLContent(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, redacted := range []string{
+		`"MYSQL_ROOT_PASSWORD":"REDACTED"`,
+		`"MONGO_INITDB_ROOT_PASSWORD":"REDACTED"`,
+		`"MSSQL_SA_PASSWORD":"REDACTED"`,
+	} {
+		if !strings.Contains(result, redacted) {
+			t.Fatalf("expected %q in output, got: %s", redacted, result)
+		}
+	}
+	for _, leaked := range []string{"correct-horse-mysql", "correct-horse-mongo", "correct-horse-mssql"} {
+		if strings.Contains(result, leaked) {
+			t.Fatalf("expected %q to be redacted, got: %s", leaked, result)
+		}
 	}
 }
 

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -658,6 +658,46 @@ func TestString_BoundedCredentialValueOverRedactionGuards(t *testing.T) {
 	})
 }
 
+// Pins that single-char "masks" and arbitrary <…> wrappers do NOT count as
+// placeholders, so credentials that happen to be short or bracket-wrapped
+// still get redacted. The opposite cases (`***`, `<password>`, etc.) are
+// covered above in TestString_BoundedCredentialValueOverRedactionGuards.
+func TestString_ShortAndOpaquePlaceholdersFallThrough(t *testing.T) {
+	t.Parallel()
+	assertStringRedactionCases(t, []stringRedactionCase{
+		{
+			name:  "single x is not a mask",
+			input: "DB_PASSWORD=x",
+			want:  "DB_PASSWORD=REDACTED",
+		},
+		{
+			name:  "single dash is not a mask",
+			input: "DB_PASSWORD=-",
+			want:  "DB_PASSWORD=REDACTED",
+		},
+		{
+			name:  "single asterisk is not a mask",
+			input: "DB_PASSWORD=*",
+			want:  "DB_PASSWORD=REDACTED",
+		},
+		{
+			name:  "two-char repeat is not a mask",
+			input: "DB_PASSWORD=xx",
+			want:  "DB_PASSWORD=REDACTED",
+		},
+		{
+			name:  "bracketed value with digits is not a placeholder",
+			input: "DB_PASSWORD=<hunter2>",
+			want:  "DB_PASSWORD=REDACTED",
+		},
+		{
+			name:  "bracketed mixed-case value is not a placeholder",
+			input: "DB_PASSWORD=<RealPassword>",
+			want:  "DB_PASSWORD=REDACTED",
+		},
+	})
+}
+
 func TestString_OpenSSHPrivateKeyBlock(t *testing.T) {
 	input := "key:\n" + fakeOpenSSHPrivateKey + "\nend"
 	want := "key:\nREDACTED\nend"

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -1189,12 +1189,8 @@ func TestJSONLContent_SecretsInContentStillCaught(t *testing.T) {
 	}
 }
 
-// TestString_MysqlShellShorthandIsNotRedacted pins current behavior: a CLI
-// shell invocation like `mysql --password=...` is not redacted because none of
-// the layered detectors match `--password=` (no DB-prefix on the assignment
-// key, no semicolon/keyword DSN structure, no URI scheme). This is a known
-// gap; flipping it to redaction would require a shell-shorthand detector
-// scoped narrowly enough not to over-match real prose.
+// Pins a known gap: shell shorthand `--password=...` is not redacted because
+// no detector matches `--password=` (no DB-prefix, no DSN structure, no URI).
 func TestString_MysqlShellShorthandIsNotRedacted(t *testing.T) {
 	t.Parallel()
 	assertStringRedactionCases(t, []stringRedactionCase{
@@ -1211,11 +1207,8 @@ func TestString_MysqlShellShorthandIsNotRedacted(t *testing.T) {
 	})
 }
 
-// TestString_RedactionIsIdempotent pins that String is idempotent on its own
-// output. After one pass, the credentialed URI / DSN regions have collapsed
-// to "REDACTED" and a second pass leaves the result unchanged. Regression
-// guard against any future change that would cause "REDACTED" itself to
-// match a detector.
+// Pins f(f(x)) == f(x): once-redacted output must not match any detector on
+// a second pass.
 func TestString_RedactionIsIdempotent(t *testing.T) {
 	t.Parallel()
 	inputs := []string{
@@ -1237,13 +1230,9 @@ func TestString_RedactionIsIdempotent(t *testing.T) {
 	}
 }
 
-// TestJSONLContent_CrossContextValueCollision pins current behavior of the
-// keyed-JSON replacement scanner: when the same value (e.g. "shared-secret")
-// appears under a credential key (db.password) and a non-credential key
-// (misc.password), both occurrences are redacted because replacement is
-// keyed by (key, value), not (path, value). This errs on the side of safety
-// — the cost is a small over-redaction of unrelated fields that happen to
-// share both the key name and the value with a real credential.
+// Pins keyed-JSON replacement as (key, value) rather than (path, value): a
+// shared value under the same key name redacts in every context, not just
+// the credential one. Conservative on purpose — flag if changed.
 func TestJSONLContent_CrossContextValueCollision(t *testing.T) {
 	t.Parallel()
 	input := `{"db":{"host":"db.example.com","user":"svc","password":"shared-secret"},"misc":{"password":"shared-secret"}}`

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -620,6 +620,41 @@ func TestString_BoundedCredentialValueOverRedactionGuards(t *testing.T) {
 			input: "MYSQL_USER_ID=alice",
 			want:  "MYSQL_USER_ID=alice",
 		},
+		{
+			name:  "angle bracket placeholder is preserved",
+			input: "DB_PASSWORD=<password>",
+			want:  "DB_PASSWORD=<password>",
+		},
+		{
+			name:  "your_password placeholder is preserved",
+			input: "DB_PASSWORD=your_password",
+			want:  "DB_PASSWORD=your_password",
+		},
+		{
+			name:  "your-db-password placeholder is preserved",
+			input: "DB_PASSWORD=<your-db-password>",
+			want:  "DB_PASSWORD=<your-db-password>",
+		},
+		{
+			name:  "asterisk mask placeholder is preserved",
+			input: "DB_PASSWORD=*****",
+			want:  "DB_PASSWORD=*****",
+		},
+		{
+			name:  "dot mask placeholder is preserved",
+			input: "DB_PASSWORD=......",
+			want:  "DB_PASSWORD=......",
+		},
+		{
+			name:  "secret_here placeholder is preserved",
+			input: "DB_PASSWORD=secret_here",
+			want:  "DB_PASSWORD=secret_here",
+		},
+		{
+			name:  "placeholder literal is preserved",
+			input: "DB_PASSWORD=placeholder",
+			want:  "DB_PASSWORD=placeholder",
+		},
 	})
 }
 
@@ -737,6 +772,27 @@ func TestJSONLContent_NormalizedCredentialKeysRedacted(t *testing.T) {
 	}
 	if strings.Contains(result, `"DB Password":"correct-horse-db"`) {
 		t.Fatalf("expected normalized credential key to be redacted, got: %s", result)
+	}
+}
+
+func TestJSONLContent_DottedCredentialKeysRedacted(t *testing.T) {
+	t.Parallel()
+	input := `{"config":{"db.password":"correct-horse-db","mysql.root.password":"correct-horse-mysql","note":"correct-horse-db"}}`
+
+	result, err := JSONLContent(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, redacted := range []string{
+		`"db.password":"REDACTED"`,
+		`"mysql.root.password":"REDACTED"`,
+	} {
+		if !strings.Contains(result, redacted) {
+			t.Fatalf("expected %q in output, got: %s", redacted, result)
+		}
+	}
+	if !strings.Contains(result, `"note":"correct-horse-db"`) {
+		t.Fatalf("expected unrelated note field to be preserved, got: %s", result)
 	}
 }
 

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -1188,3 +1188,74 @@ func TestJSONLContent_SecretsInContentStillCaught(t *testing.T) {
 		t.Error("expected REDACTED in output")
 	}
 }
+
+// TestString_MysqlShellShorthandIsNotRedacted pins current behavior: a CLI
+// shell invocation like `mysql --password=...` is not redacted because none of
+// the layered detectors match `--password=` (no DB-prefix on the assignment
+// key, no semicolon/keyword DSN structure, no URI scheme). This is a known
+// gap; flipping it to redaction would require a shell-shorthand detector
+// scoped narrowly enough not to over-match real prose.
+func TestString_MysqlShellShorthandIsNotRedacted(t *testing.T) {
+	t.Parallel()
+	assertStringRedactionCases(t, []stringRedactionCase{
+		{
+			name:  "mysql cli flag",
+			input: "mysql -u svc --password=hunter2 -h db.example.com app",
+			want:  "mysql -u svc --password=hunter2 -h db.example.com app",
+		},
+		{
+			name:  "psql cli flag",
+			input: "psql --password=hunter2 -U svc -h db.example.com app",
+			want:  "psql --password=hunter2 -U svc -h db.example.com app",
+		},
+	})
+}
+
+// TestString_RedactionIsIdempotent pins that String is idempotent on its own
+// output. After one pass, the credentialed URI / DSN regions have collapsed
+// to "REDACTED" and a second pass leaves the result unchanged. Regression
+// guard against any future change that would cause "REDACTED" itself to
+// match a detector.
+func TestString_RedactionIsIdempotent(t *testing.T) {
+	t.Parallel()
+	inputs := []string{
+		"DATABASE_URL=postgres://svc:hunter2@db.example.com/app",
+		"DB_PASSWORD=hunter2",
+		`conn=Server=db.example.com;User ID=svc;Password="se;cret;here";Encrypt=true`,
+		"jdbc:postgresql://db.example.com:5432/app?user=svc&password=hunter2",
+		"my key is " + highEntropySecret + " ok",
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			once := String(input)
+			twice := String(once)
+			if once != twice {
+				t.Errorf("not idempotent for %q:\n  once:  %q\n  twice: %q", input, once, twice)
+			}
+		})
+	}
+}
+
+// TestJSONLContent_CrossContextValueCollision pins current behavior of the
+// keyed-JSON replacement scanner: when the same value (e.g. "shared-secret")
+// appears under a credential key (db.password) and a non-credential key
+// (misc.password), both occurrences are redacted because replacement is
+// keyed by (key, value), not (path, value). This errs on the side of safety
+// — the cost is a small over-redaction of unrelated fields that happen to
+// share both the key name and the value with a real credential.
+func TestJSONLContent_CrossContextValueCollision(t *testing.T) {
+	t.Parallel()
+	input := `{"db":{"host":"db.example.com","user":"svc","password":"shared-secret"},"misc":{"password":"shared-secret"}}`
+
+	result, err := JSONLContent(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(result, "shared-secret") {
+		t.Errorf("expected shared-secret to be redacted in both contexts, got: %s", result)
+	}
+	if strings.Count(result, `"password":"REDACTED"`) != 2 {
+		t.Errorf("expected both password fields redacted, got: %s", result)
+	}
+}

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -449,6 +449,16 @@ func TestString_DatabaseConnectionStringRedaction(t *testing.T) {
 			input: "jdbc:sqlserver://db.example.com:1433;databaseName=app;user=svc;password=secret;encrypt=true",
 			want:  "REDACTED",
 		},
+		{
+			name:  "ado.net quoted password with embedded semicolons",
+			input: `conn=Server=db.example.com;User ID=svc;Password="se;cret;here";Encrypt=true`,
+			want:  "conn=REDACTED",
+		},
+		{
+			name:  "ado.net single-quoted password with embedded semicolons",
+			input: `conn=Server=db.example.com;User ID=svc;Password='se;cret;here';Encrypt=true`,
+			want:  "conn=REDACTED",
+		},
 	})
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/254
<!-- entire-trail-link-end -->

## Follow-up to #1045: tighten redaction coverage

Addresses the review findings on the merged redact PR — gaps that don't break correctness today but leak common DB credential shapes.

### Changes

- **fix(redact): match `*_ROOT_PASSWORD` style env vars** — Allow internal segments and multi-char separators between vendor prefix and `password`/`passwd`/`pwd`. Covers `MYSQL_ROOT_PASSWORD`, `MARIADB_ROOT_PASSWORD`, `MONGO_INITDB_ROOT_PASSWORD`, `MSSQL_SA_PASSWORD`, `DB__PASSWORD`. Applied to both env-var and JSON-key regexes.
- **fix(redact): redact ADO.NET quoted password values** — `Password="se;cret;here"` (semicolons inside the quoted value) was leaking. Added `"…"`/`'…'` to the semicolon-DSN value class.
- **fix(redact): expand placeholder set and normalize dotted JSON keys** — `<password>`, `your_password`, `*****`, mask-char runs, `placeholder`, `secret_here` etc. now recognized as docs placeholders (no false redaction). `db.password` / `mysql.root.password` from flattened-config exporters normalize to `_`-form so they hit the credential key regex.
- **test(redact): pin shell shorthand, idempotency, and cross-context collision** — Pins three previously-unasserted behaviors: `mysql --password=…` is *not* redacted (known gap), `String` is idempotent (`f(f(x)) == f(x)`), and the keyed-JSON scanner is keyed by `(key, value)` not `(path, value)`.
- **refactor(redact): collapse duplicated shape regex and split state** — Vendor alternation extracted to a single `dbPasswordKeyShape` const composed into both regexes. Placeholder values consolidated into one map.

### Test plan

- [x] `mise run check` (fmt + lint + unit + integration + canary) passes
- [x] Positive tests for each broadened shape
- [x] Negative tests pin no over-redaction (`DB_PASSWORD_HASH`, `MYSQL_USER_ID`, all mask placeholders)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core redaction regexes and placeholder heuristics, which could cause new false positives/negatives in log/transcript output despite added tests.
> 
> **Overview**
> **Tightens secret redaction coverage for database credentials** by unifying vendor/password key matching into a shared `dbPasswordKeyShape`, expanding it to catch common env/JSON keys like `*_ROOT_PASSWORD` (and multi-separator variants), and treating dotted keys (e.g. `db.password`) as credential keys during JSON normalization.
> 
> Improves connection-string parsing to redact ADO.NET/semicolon DSNs where `Password` values are quoted and contain embedded semicolons, and expands “placeholder” detection (e.g. `<password>`, `your_password`, mask runs) to avoid redacting obvious documentation defaults.
> 
> Adds tests to cover the new credential shapes, placeholder edge cases, idempotent redaction (`String(String(x)) == String(x)`), dotted JSON keys, cross-context value collisions, and explicitly pins the known non-redaction gap for `--password=...` CLI flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe3760750a232417df7f0089c6f876f98af4bbc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->