### PR TITLE
Make `entire explain` work with partial-clone

### DIFF
--- a/cmd/entire/cli/checkpoint/fetching_tree.go
+++ b/cmd/entire/cli/checkpoint/fetching_tree.go
@@ -51,56 +51,57 @@ func NewFetchingTree(ctx context.Context, tree *object.Tree, s storer.EncodedObj
 	}
 }
 
-// File returns the file at the given path. If the blob is not available
-// locally (e.g. after a treeless fetch), it is fetched on demand. If go-git's
-// storer still can't see the blob after fetching (due to cached packfile index),
-// the blob is read via "git cat-file" and an in-memory File is returned.
+// File returns the file at the given path. Resolution order:
+//  1. go-git's storer (fast path, in-memory).
+//  2. `git cat-file -p` against the on-disk object store (handles
+//     partial-clone-filtered blobs that go-git can't see, plus packfiles
+//     created by external git commands after this process opened the repo).
+//  3. Remote fetch via the configured fetcher, then cat-file again.
+//
+// Trying cat-file BEFORE the remote fetch is critical: in partial-clone
+// repos, blobs are commonly on disk but invisible to go-git's storer
+// (filtered out, or in a packfile not in go-git's index cache). Without
+// this short-circuit, every File() would burn a multi-second network
+// round-trip even though the blob is already local.
 func (t *FetchingTree) File(path string) (*object.File, error) {
-	// Fast path: blob already available in go-git's storer.
-	file, err := t.inner.File(path)
-	if err == nil {
+	if file, err := t.inner.File(path); err == nil {
 		return file, nil
 	}
 
-	if t.fetch == nil {
-		return nil, err //nolint:wrapcheck // pass-through wrapper
-	}
-
-	// Find the tree entry to get the blob hash without resolving the blob.
-	// FindEntry only navigates tree objects (available after --filter=blob:none).
 	entry, findErr := t.inner.FindEntry(path)
 	if findErr != nil {
 		logging.Debug(t.ctx, "FetchingTree.File: entry not found",
 			slog.String("path", path),
 			slog.String("error", findErr.Error()),
 		)
-		return nil, err //nolint:wrapcheck // return original File() error
+		return nil, findErr //nolint:wrapcheck // return original error
 	}
 
-	logging.Debug(t.ctx, "FetchingTree.File: blob missing, fetching",
+	if file, gitErr := t.readFileViaGit(path, entry); gitErr == nil {
+		return file, nil
+	}
+
+	if t.fetch == nil {
+		return nil, fmt.Errorf("blob %s not available locally and no fetcher configured", entry.Hash.String()[:12])
+	}
+
+	logging.Debug(t.ctx, "FetchingTree.File: blob missing locally, fetching from remote",
 		slog.String("path", path),
 		slog.String("hash", entry.Hash.String()[:12]),
 	)
-
-	// Fetch the blob from the remote.
 	if fetchErr := t.fetch(t.ctx, []plumbing.Hash{entry.Hash}); fetchErr != nil {
 		logging.Warn(t.ctx, "FetchingTree.File: blob fetch failed",
 			slog.String("path", path),
 			slog.String("hash", entry.Hash.String()[:12]),
 			slog.String("error", fetchErr.Error()),
 		)
-		return nil, err //nolint:wrapcheck // return original File() error
+		return nil, fetchErr
 	}
 
-	// Try go-git again — works if blob was stored as a loose object.
-	file, err = t.inner.File(path)
-	if err == nil {
+	if file, err := t.inner.File(path); err == nil {
 		return file, nil
 	}
 
-	// go-git's storer caches the packfile index and won't see new packs
-	// created by external git commands. Fall back to "git cat-file" which
-	// reads directly from the on-disk object store.
 	logging.Debug(t.ctx, "FetchingTree.File: storer cache stale, reading via git cat-file",
 		slog.String("path", path),
 		slog.String("hash", entry.Hash.String()[:12]),
@@ -140,7 +141,7 @@ func (t *FetchingTree) collectMissingBlobs(tree *object.Tree) []plumbing.Hash {
 	var missing []plumbing.Hash
 	for _, entry := range tree.Entries {
 		if entry.Mode.IsFile() {
-			if t.storer.HasEncodedObject(entry.Hash) != nil {
+			if t.storer.HasEncodedObject(entry.Hash) != nil && !t.blobOnDisk(entry.Hash) {
 				missing = append(missing, entry.Hash)
 			}
 		} else {
@@ -152,6 +153,16 @@ func (t *FetchingTree) collectMissingBlobs(tree *object.Tree) []plumbing.Hash {
 		}
 	}
 	return missing
+}
+
+// blobOnDisk returns true if `git cat-file -e <hash>` finds the blob in
+// the local object store. Used as a second-opinion check before deciding
+// a blob needs to be fetched: in partial-clone repos a blob can be on
+// disk but invisible to go-git's storer (filtered out, or in a packfile
+// not in the cached index). We'd rather skip a wasted network round-trip.
+func (t *FetchingTree) blobOnDisk(hash plumbing.Hash) bool {
+	cmd := exec.CommandContext(t.ctx, "git", "cat-file", "-e", hash.String())
+	return cmd.Run() == nil
 }
 
 // readFileViaGit reads a blob via "git cat-file -p <hash>" and returns an

--- a/cmd/entire/cli/checkpoint/fetching_tree.go
+++ b/cmd/entire/cli/checkpoint/fetching_tree.go
@@ -135,6 +135,14 @@ func (t *FetchingTree) PreFetch() (int, error) {
 	return len(missing), nil
 }
 
+// CollectMissingBlobs returns the hashes of every blob entry in this tree
+// (recursively) that isn't present in the local object store. Useful for
+// callers that want to decide whether network work is needed before
+// running PreFetch (e.g., to avoid showing a spinner in fast no-op cases).
+func (t *FetchingTree) CollectMissingBlobs() []plumbing.Hash {
+	return t.collectMissingBlobs(t.inner)
+}
+
 // collectMissingBlobs recursively walks a tree and returns hashes of blob
 // entries that are not present in the local object store.
 func (t *FetchingTree) collectMissingBlobs(tree *object.Tree) []plumbing.Hash {

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -70,21 +70,29 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 }
 
 // FetchBlobs fetches specific objects (typically blobs) by hash from a remote.
-// Unlike Fetch, this never applies --filter=blob:none (which would be
-// contradictory — the point is to download specific blobs) and always uses
-// --no-write-fetch-head to avoid polluting FETCH_HEAD.
+// Uses `git fetch-pack` rather than `git fetch` because the high-level
+// porcelain enforces partial-clone integrity checks that reject blob-only
+// responses with "did not send all necessary objects". Plumbing skips those
+// checks — it just downloads the requested objects into .git/objects/pack
+// and exits — which is exactly what we want when grabbing individual blobs
+// by SHA. Works against GitHub for any reachable object, including blobs.
 //
 // The remote should be a URL (not a remote name) to avoid persisting promisor
 // settings onto the named remote. Use FetchURL to obtain the URL.
 func FetchBlobs(ctx context.Context, remote string, hashes []string) error {
-	args := []string{"fetch", "--no-tags", "--no-write-fetch-head", remote}
+	args := []string{"fetch-pack", remote}
 	args = append(args, hashes...)
 
 	cmd := newCommand(ctx, args...)
 	disableTerminalPrompt(cmd)
-	_, err := cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("git fetch blobs: %w", err)
+		redactedURL := RedactURL(remote)
+		msg := strings.TrimSpace(strings.ReplaceAll(string(output), remote, redactedURL))
+		if msg != "" {
+			return fmt.Errorf("git fetch-pack from %s: %s: %w", redactedURL, msg, err)
+		}
+		return fmt.Errorf("git fetch-pack from %s: %w", redactedURL, err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/checkpoint/v2_read.go
+++ b/cmd/entire/cli/checkpoint/v2_read.go
@@ -44,7 +44,8 @@ func (s *V2GitStore) ReadCommitted(ctx context.Context, checkpointID id.Checkpoi
 		return nil, nil //nolint:nilnil,nilerr // Checkpoint subtree not found
 	}
 
-	metadataFile, err := cpTree.File(paths.MetadataFileName)
+	cpFT := s.wrapWithFetcher(ctx, cpTree)
+	metadataFile, err := cpFT.File(paths.MetadataFileName)
 	if err != nil {
 		return nil, nil //nolint:nilnil,nilerr // metadata.json not found
 	}
@@ -165,7 +166,8 @@ func (s *V2GitStore) ReadSessionCompactTranscript(ctx context.Context, checkpoin
 		return nil, ErrCheckpointNotFound
 	}
 
-	compactFile, err := sessionTree.File(paths.CompactTranscriptFileName)
+	sessionFT := s.wrapWithFetcher(ctx, sessionTree)
+	compactFile, err := sessionFT.File(paths.CompactTranscriptFileName)
 	if err != nil {
 		return nil, ErrNoTranscript
 	}
@@ -214,8 +216,9 @@ func (s *V2GitStore) ReadSessionMetadataAndPrompts(ctx context.Context, checkpoi
 	}
 
 	result := &SessionContent{}
+	sessionFT := s.wrapWithFetcher(ctx, sessionTree)
 
-	if metadataFile, fileErr := sessionTree.File(paths.MetadataFileName); fileErr == nil {
+	if metadataFile, fileErr := sessionFT.File(paths.MetadataFileName); fileErr == nil {
 		if content, contentErr := metadataFile.Contents(); contentErr == nil {
 			if jsonErr := json.Unmarshal([]byte(content), &result.Metadata); jsonErr != nil {
 				return nil, fmt.Errorf("failed to parse session metadata: %w", jsonErr)
@@ -223,14 +226,14 @@ func (s *V2GitStore) ReadSessionMetadataAndPrompts(ctx context.Context, checkpoi
 		}
 	}
 
-	if file, fileErr := sessionTree.File(paths.PromptFileName); fileErr == nil {
+	if file, fileErr := sessionFT.File(paths.PromptFileName); fileErr == nil {
 		if content, contentErr := file.Contents(); contentErr == nil {
 			result.Prompts = content
 		}
 	}
 
 	// Read compact transcript from the same session tree (avoids a second tree walk).
-	if compactFile, fileErr := sessionTree.File(paths.CompactTranscriptFileName); fileErr == nil {
+	if compactFile, fileErr := sessionFT.File(paths.CompactTranscriptFileName); fileErr == nil {
 		if content, contentErr := compactFile.Contents(); contentErr == nil && content != "" {
 			result.Transcript = []byte(content)
 		}
@@ -273,8 +276,9 @@ func (s *V2GitStore) ReadSessionContent(ctx context.Context, checkpointID id.Che
 	}
 
 	result := &SessionContent{}
+	sessionFT := s.wrapWithFetcher(ctx, sessionTree)
 
-	if metadataFile, fileErr := sessionTree.File(paths.MetadataFileName); fileErr == nil {
+	if metadataFile, fileErr := sessionFT.File(paths.MetadataFileName); fileErr == nil {
 		if content, contentErr := metadataFile.Contents(); contentErr == nil {
 			if jsonErr := json.Unmarshal([]byte(content), &result.Metadata); jsonErr != nil {
 				return nil, fmt.Errorf("failed to parse session metadata: %w", jsonErr)
@@ -282,7 +286,7 @@ func (s *V2GitStore) ReadSessionContent(ctx context.Context, checkpointID id.Che
 		}
 	}
 
-	if file, fileErr := sessionTree.File(paths.PromptFileName); fileErr == nil {
+	if file, fileErr := sessionFT.File(paths.PromptFileName); fileErr == nil {
 		if content, contentErr := file.Contents(); contentErr == nil {
 			result.Prompts = content
 		}

--- a/cmd/entire/cli/checkpoint/v2_store.go
+++ b/cmd/entire/cli/checkpoint/v2_store.go
@@ -30,6 +30,12 @@ type V2GitStore struct {
 	// fetching /full/* refs during entire resume). Defaults to "origin".
 	// Set to the checkpoint remote URL when checkpoint_remote is configured.
 	FetchRemote string
+
+	// blobFetcher fetches missing blobs by hash. When set, read paths wrap
+	// trees with FetchingTree so missing blobs are auto-recovered (and the
+	// cat-file fallback covers partial-clone-filtered blobs that go-git's
+	// storer can't see).
+	blobFetcher BlobFetchFunc
 }
 
 // maxCheckpoints returns the effective rotation threshold.
@@ -52,6 +58,22 @@ func NewV2GitStore(repo *git.Repository, fetchRemote string) *V2GitStore {
 		gs:          &GitStore{repo: repo},
 		FetchRemote: fetchRemote,
 	}
+}
+
+// SetBlobFetcher configures the store to automatically fetch missing blobs
+// on demand when reading from /main trees. Mirrors GitStore.SetBlobFetcher.
+// Required for reads against partial-clone repos where blobs may be absent
+// or invisible to go-git's cached packfile index.
+func (s *V2GitStore) SetBlobFetcher(f BlobFetchFunc) {
+	s.blobFetcher = f
+}
+
+// wrapWithFetcher returns the input tree wrapped in a FetchingTree using
+// the configured blob fetcher. Callers use the returned tree's File() /
+// Tree() methods instead of the raw go-git ones so missing blobs are
+// recovered via the fetcher and the cat-file fallback.
+func (s *V2GitStore) wrapWithFetcher(ctx context.Context, tree *object.Tree) *FetchingTree {
+	return NewFetchingTree(ctx, tree, s.repo.Storer, s.blobFetcher)
 }
 
 // ensureRef ensures that a custom ref exists, creating an orphan commit

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -360,7 +360,7 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 // an ambiguity pre-check to avoid writing a summary to the wrong
 // checkpoint on short-prefix collisions.
 func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
-	lookup, lookupErr := newExplainCheckpointLookup(ctx, nil)
+	lookup, lookupErr := newExplainCheckpointLookup(ctx)
 	if generate {
 		if err := runExplainAutoAmbiguityGuard(ctx, target, lookup, lookupErr); err != nil {
 			return err
@@ -476,7 +476,7 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, checkpointIDPrefix string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool, lookup *explainCheckpointLookup, lookupErr error) error {
 	if lookup == nil {
 		var err error
-		lookup, err = newExplainCheckpointLookup(ctx, nil)
+		lookup, err = newExplainCheckpointLookup(ctx)
 		if err != nil {
 			return err
 		}
@@ -492,31 +492,23 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		}
 	}
 
-	// If not found locally, fetch metadata from remote and retry.
-	// This handles the case where we're looking at a checkpoint from another
-	// collaborator's PR whose metadata hasn't been fetched yet.
-	// Try origin first (fast treeless fetch, ~1-2s), then checkpoint_remote
-	// if configured and origin didn't have it. Fetch both v1 and v2 refs.
+	// If not found locally, fetch metadata from remote and retry. Reuses
+	// resume's getMetadataTree / getV2MetadataTree helpers — they already
+	// implement the checkpoint_remote → treeless origin → full origin chain
+	// and return a fresh repo handle (which we discard; the post-fetch
+	// rebuild via newExplainCheckpointLookup opens its own).
 	if len(matches) == 0 {
-		anyFetched := FetchMetadataTreeOnly(ctx) == nil
-		if !anyFetched {
-			anyFetched = FetchMetadataFromCheckpointRemote(ctx) == nil
-		}
+		_, _, v1Err := getMetadataTree(ctx)
+		var v2Err error
 		if lookup.preferCheckpointsV2 {
-			v2Fetched := FetchV2MainTreeOnly(ctx) == nil
-			if !v2Fetched {
-				v2Fetched = FetchV2MetadataFromCheckpointRemote(ctx) == nil
-			}
-			anyFetched = anyFetched || v2Fetched
+			_, _, v2Err = getV2MetadataTree(ctx)
 		}
-		if anyFetched {
-			if freshLookup, freshErr := newExplainCheckpointLookup(ctx, nil); freshErr == nil {
+		if v1Err == nil || v2Err == nil {
+			if freshLookup, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {
 				lookup = freshLookup
-				if freshCommitted := lookup.committed; freshCommitted != nil {
-					for _, info := range freshCommitted {
-						if strings.HasPrefix(info.CheckpointID.String(), checkpointIDPrefix) {
-							matches = append(matches, info.CheckpointID)
-						}
+				for _, info := range lookup.committed {
+					if strings.HasPrefix(info.CheckpointID.String(), checkpointIDPrefix) {
+						matches = append(matches, info.CheckpointID)
 					}
 				}
 			}
@@ -561,6 +553,11 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		}
 		return fmt.Errorf("ambiguous checkpoint prefix %q matches %d checkpoints: %s", checkpointIDPrefix, len(matches), strings.Join(examples, ", "))
 	}
+
+	// Batch-prefetch all blobs in the checkpoint's subtree in one network
+	// round-trip via fetch-pack. Best-effort: if prefetch fails, the
+	// per-File fallback fetcher on v1Store still recovers individual blobs.
+	prefetchCheckpointBlobs(ctx, lookup.repo, fullCheckpointID)
 
 	// Resolve store and load checkpoint summary with v2 -> v1 fallback.
 	resolvedReader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, fullCheckpointID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
@@ -643,13 +640,43 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	return nil
 }
 
-func newExplainCheckpointLookup(ctx context.Context, repo *git.Repository) (*explainCheckpointLookup, error) {
-	if repo == nil {
-		var err error
-		repo, err = openRepository(ctx)
+// prefetchCheckpointBlobs navigates to the checkpoint's subtree, collects
+// every locally-missing blob in one pass, and fetches them all in a single
+// `git fetch-pack <url> <hash1> <hash2>...` invocation. Best-effort —
+// failure is logged and the read path falls back to the FetchingTree's
+// per-File fetcher.
+func prefetchCheckpointBlobs(ctx context.Context, repo *git.Repository, cpID id.CheckpointID) {
+	rootTree, err := strategy.GetMetadataBranchTree(repo)
+	if err != nil {
+		rootTree, err = strategy.GetRemoteMetadataBranchTree(repo)
 		if err != nil {
-			return nil, fmt.Errorf("not a git repository: %w", err)
+			logging.Debug(ctx, "explain prefetch: no v1 metadata tree", slog.String("error", err.Error()))
+			return
 		}
+	}
+	cpSubtree, err := rootTree.Tree(cpID.Path())
+	if err != nil {
+		logging.Debug(ctx, "explain prefetch: cp subtree not found", slog.String("checkpoint_id", cpID.String()), slog.String("error", err.Error()))
+		return
+	}
+	ft := checkpoint.NewFetchingTree(ctx, cpSubtree, repo.Storer, FetchBlobsByHash)
+	prefetched, err := ft.PreFetch()
+	if err != nil {
+		logging.Debug(ctx, "explain prefetch: PreFetch failed", slog.String("checkpoint_id", cpID.String()), slog.String("error", err.Error()))
+		return
+	}
+	if prefetched > 0 {
+		logging.Debug(ctx, "explain prefetch: blobs fetched in one round-trip",
+			slog.String("checkpoint_id", cpID.String()),
+			slog.Int("blob_count", prefetched),
+		)
+	}
+}
+
+func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, error) {
+	repo, err := openRepository(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("not a git repository: %w", err)
 	}
 
 	v2URL, err := remote.FetchURL(ctx)
@@ -660,9 +687,16 @@ func newExplainCheckpointLookup(ctx context.Context, repo *git.Repository) (*exp
 		v2URL = ""
 	}
 
+	v1Store := checkpoint.NewGitStore(repo)
+	// FetchBlobsByHash now uses `git fetch-pack` under the hood, which
+	// works against GitHub for individual blob SHAs (porcelain `git fetch`
+	// fails them due to partial-clone integrity checks). Falls back to a
+	// full metadata-branch fetch if even fetch-pack can't get the blobs.
+	v1Store.SetBlobFetcher(FetchBlobsByHash)
+
 	lookup := &explainCheckpointLookup{
 		repo:                repo,
-		v1Store:             checkpoint.NewGitStore(repo),
+		v1Store:             v1Store,
 		v2Store:             checkpoint.NewV2GitStore(repo, v2URL),
 		preferCheckpointsV2: settings.IsCheckpointsV2Enabled(ctx),
 	}

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -499,11 +499,13 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// rebuild via newExplainCheckpointLookup opens its own).
 	if len(matches) == 0 {
 		_, _, v1Err := getMetadataTree(ctx)
-		var v2Err error
+		v2OK := false
 		if lookup.preferCheckpointsV2 {
-			_, _, v2Err = getV2MetadataTree(ctx)
+			if _, _, v2Err := getV2MetadataTree(ctx); v2Err == nil {
+				v2OK = true
+			}
 		}
-		if v1Err == nil || v2Err == nil {
+		if v1Err == nil || v2OK {
 			if freshLookup, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {
 				lookup = freshLookup
 				for _, info := range lookup.committed {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -560,46 +560,21 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		return fmt.Errorf("ambiguous checkpoint prefix %q matches %d checkpoints: %s", checkpointIDPrefix, len(matches), strings.Join(examples, ", "))
 	}
 
-	// Batch-prefetch all blobs in the checkpoint's subtree in one network
-	// round-trip via fetch-pack. Best-effort: if prefetch fails, the
-	// per-File fallback fetcher on v1Store / v2Store still recovers
-	// individual blobs.
-	prefetchCheckpointBlobs(ctx, errW, lookup.repo, fullCheckpointID, lookup.preferCheckpointsV2)
-
-	// Cover the rest of the data-loading pipeline (summary read, session
-	// content reads via cat-file, getAssociatedCommits' git log walk) with
-	// a single spinner. Stop strictly before any write to w (stdout) so
-	// stderr spinner frames and stdout output never interleave.
+	// One spinner covers the entire data-loading pipeline: prefetch's
+	// missing-blob analysis (which spawns one cat-file -e per blob and
+	// can take seconds on a deep checkpoint subtree), the prefetch fetch
+	// itself, ResolveCommittedReader's metadata read, session content
+	// reads, and getAssociatedCommits' git log walk. Stop strictly before
+	// any write to w (stdout) so stderr spinner frames and stdout output
+	// never interleave.
 	stopLoad := startSpinner(errW, fmt.Sprintf("Loading checkpoint %s", fullCheckpointID))
 
-	// Resolve store and load checkpoint summary with v2 -> v1 fallback.
-	resolvedReader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, fullCheckpointID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
+	resolvedReader, summary, content, err := loadCheckpointForExplain(ctx, errW, lookup, fullCheckpointID, full, generate, rawTranscript)
 	if err != nil {
 		stopLoad("")
-		return fmt.Errorf("failed to read checkpoint: %w", err)
+		return err
 	}
-
-	// For v2 checkpoints in default display modes (not --full, --generate, or
-	// --raw-transcript), read only from /main — metadata, prompts, and the
-	// compact transcript.jsonl. The raw transcript on /full/* is never needed
-	// for human-readable output and may be unavailable (rotated, not fetched).
-	needsRawTranscript := full || generate || rawTranscript
 	v2Reader, isCheckpointsV2 := resolvedReader.(*checkpoint.V2GitStore)
-
-	var content *checkpoint.SessionContent
-	if isCheckpointsV2 && !needsRawTranscript {
-		content, err = readV2ContentFromMain(ctx, v2Reader, fullCheckpointID, summary)
-		if err != nil {
-			stopLoad("")
-			return fmt.Errorf("failed to read checkpoint content: %w", err)
-		}
-	} else {
-		content, err = readLatestSessionContentForExplain(ctx, resolvedReader, fullCheckpointID, summary)
-		if err != nil {
-			stopLoad("")
-			return fmt.Errorf("failed to read checkpoint content: %w", err)
-		}
-	}
 
 	// Handle summary generation — uses raw transcript.
 	if generate {
@@ -662,15 +637,49 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	return nil
 }
 
+// loadCheckpointForExplain runs prefetchCheckpointBlobs + summary read +
+// session content read for the given checkpoint. Extracts the bulk of the
+// data-load pipeline out of runExplainCheckpointWithLookup so that
+// function stays under maintidx limits. Caller is responsible for the
+// surrounding spinner.
+func loadCheckpointForExplain(ctx context.Context, errW io.Writer, lookup *explainCheckpointLookup, cpID id.CheckpointID, full, generate, rawTranscript bool) (checkpoint.CommittedReader, *checkpoint.CheckpointSummary, *checkpoint.SessionContent, error) {
+	prefetchCheckpointBlobs(ctx, errW, lookup.repo, cpID, lookup.preferCheckpointsV2)
+
+	reader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, cpID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to read checkpoint: %w", err)
+	}
+
+	// Default display modes for v2 checkpoints read only from /main —
+	// metadata, prompts, and the compact transcript. The raw transcript
+	// on /full/* refs is never needed for human-readable output and may
+	// be unavailable (rotated, not fetched).
+	needsRawTranscript := full || generate || rawTranscript
+	if v2Reader, ok := reader.(*checkpoint.V2GitStore); ok && !needsRawTranscript {
+		content, contentErr := readV2ContentFromMain(ctx, v2Reader, cpID, summary)
+		if contentErr != nil {
+			return nil, nil, nil, fmt.Errorf("failed to read checkpoint content: %w", contentErr)
+		}
+		return reader, summary, content, nil
+	}
+	content, contentErr := readLatestSessionContentForExplain(ctx, reader, cpID, summary)
+	if contentErr != nil {
+		return nil, nil, nil, fmt.Errorf("failed to read checkpoint content: %w", contentErr)
+	}
+	return reader, summary, content, nil
+}
+
 // prefetchCheckpointBlobs navigates to the checkpoint's subtree(s) — v1
 // always, v2 when enabled — collects every locally-missing blob, and
-// fetches them all in a single `git fetch-pack` invocation per store. A
-// spinner with a count message shows on errW only when blobs are actually
-// missing, so warm runs (everything already local) stay silent.
-//
+// fetches them all in a single `git fetch-pack` invocation per store.
 // Best-effort — failure is logged and the read path falls back to the
 // FetchingTree's per-File fetcher.
-func prefetchCheckpointBlobs(ctx context.Context, errW io.Writer, repo *git.Repository, cpID id.CheckpointID, preferV2 bool) {
+//
+// Caller is expected to wrap this with a spinner; both the missing-blob
+// analysis (one cat-file -e per blob) and the actual fetch are silent
+// inside this function so the caller's spinner provides continuous
+// feedback.
+func prefetchCheckpointBlobs(ctx context.Context, _ io.Writer, repo *git.Repository, cpID id.CheckpointID, preferV2 bool) {
 	v1FT := buildCheckpointFetchingTree(ctx, repo, cpID, "v1", loadV1MetadataRootTree)
 	var v2FT *checkpoint.FetchingTree
 	if preferV2 {
@@ -687,9 +696,10 @@ func prefetchCheckpointBlobs(ctx context.Context, errW io.Writer, repo *git.Repo
 	if missingCount == 0 {
 		return
 	}
-
-	stop := startSpinner(errW, fmt.Sprintf("Fetching %d checkpoint blob(s) from remote", missingCount))
-	defer stop("")
+	logging.Debug(ctx, "explain prefetch: fetching missing checkpoint blobs",
+		slog.String("checkpoint_id", cpID.String()),
+		slog.Int("blob_count", missingCount),
+	)
 
 	runPreFetch(ctx, v1FT, cpID, "v1")
 	runPreFetch(ctx, v2FT, cpID, "v2")

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -498,6 +498,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// and return a fresh repo handle (which we discard; the post-fetch
 	// rebuild via newExplainCheckpointLookup opens its own).
 	if len(matches) == 0 {
+		stop := startSpinner(errW, "Fetching checkpoint metadata from remote")
 		_, _, v1Err := getMetadataTree(ctx)
 		v2OK := false
 		if lookup.preferCheckpointsV2 {
@@ -505,6 +506,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 				v2OK = true
 			}
 		}
+		stop("")
 		if v1Err == nil || v2OK {
 			if freshLookup, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {
 				lookup = freshLookup
@@ -560,7 +562,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// round-trip via fetch-pack. Best-effort: if prefetch fails, the
 	// per-File fallback fetcher on v1Store / v2Store still recovers
 	// individual blobs.
-	prefetchCheckpointBlobs(ctx, lookup.repo, fullCheckpointID, lookup.preferCheckpointsV2)
+	prefetchCheckpointBlobs(ctx, errW, lookup.repo, fullCheckpointID, lookup.preferCheckpointsV2)
 
 	// Resolve store and load checkpoint summary with v2 -> v1 fallback.
 	resolvedReader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, fullCheckpointID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
@@ -645,21 +647,45 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 
 // prefetchCheckpointBlobs navigates to the checkpoint's subtree(s) — v1
 // always, v2 when enabled — collects every locally-missing blob, and
-// fetches them all in a single `git fetch-pack <url> <hash1> <hash2>...`
-// invocation per store. Best-effort — failure is logged and the read path
-// falls back to the FetchingTree's per-File fetcher.
-func prefetchCheckpointBlobs(ctx context.Context, repo *git.Repository, cpID id.CheckpointID, preferV2 bool) {
-	if rootTree, err := loadV1MetadataRootTree(repo); err == nil {
-		prefetchSubtreeBlobs(ctx, repo, rootTree, cpID, "v1")
-	}
+// fetches them all in a single `git fetch-pack` invocation per store. A
+// spinner with a count message shows on errW only when blobs are actually
+// missing, so warm runs (everything already local) stay silent.
+//
+// Best-effort — failure is logged and the read path falls back to the
+// FetchingTree's per-File fetcher.
+func prefetchCheckpointBlobs(ctx context.Context, errW io.Writer, repo *git.Repository, cpID id.CheckpointID, preferV2 bool) {
+	v1FT := buildCheckpointFetchingTree(ctx, repo, cpID, "v1", loadV1MetadataRootTree)
+	var v2FT *checkpoint.FetchingTree
 	if preferV2 {
-		if rootTree, err := loadV2MainRootTree(repo); err == nil {
-			prefetchSubtreeBlobs(ctx, repo, rootTree, cpID, "v2")
-		}
+		v2FT = buildCheckpointFetchingTree(ctx, repo, cpID, "v2", loadV2MainRootTree)
 	}
+
+	missingCount := 0
+	if v1FT != nil {
+		missingCount += len(v1FT.CollectMissingBlobs())
+	}
+	if v2FT != nil {
+		missingCount += len(v2FT.CollectMissingBlobs())
+	}
+	if missingCount == 0 {
+		return
+	}
+
+	stop := startSpinner(errW, fmt.Sprintf("Fetching %d checkpoint blob(s) from remote", missingCount))
+	defer stop("")
+
+	runPreFetch(ctx, v1FT, cpID, "v1")
+	runPreFetch(ctx, v2FT, cpID, "v2")
 }
 
-func prefetchSubtreeBlobs(ctx context.Context, repo *git.Repository, rootTree *object.Tree, cpID id.CheckpointID, label string) {
+// buildCheckpointFetchingTree navigates to the checkpoint subtree using
+// loadRoot and wraps it in a FetchingTree with FetchBlobsByHash. Returns
+// nil when the root tree or cp subtree isn't navigable.
+func buildCheckpointFetchingTree(ctx context.Context, repo *git.Repository, cpID id.CheckpointID, label string, loadRoot func(*git.Repository) (*object.Tree, error)) *checkpoint.FetchingTree {
+	rootTree, err := loadRoot(repo)
+	if err != nil {
+		return nil
+	}
 	cpSubtree, err := rootTree.Tree(cpID.Path())
 	if err != nil {
 		logging.Debug(ctx, "explain prefetch: cp subtree not found",
@@ -667,9 +693,15 @@ func prefetchSubtreeBlobs(ctx context.Context, repo *git.Repository, rootTree *o
 			slog.String("checkpoint_id", cpID.String()),
 			slog.String("error", err.Error()),
 		)
+		return nil
+	}
+	return checkpoint.NewFetchingTree(ctx, cpSubtree, repo.Storer, FetchBlobsByHash)
+}
+
+func runPreFetch(ctx context.Context, ft *checkpoint.FetchingTree, cpID id.CheckpointID, label string) {
+	if ft == nil {
 		return
 	}
-	ft := checkpoint.NewFetchingTree(ctx, cpSubtree, repo.Storer, FetchBlobsByHash)
 	prefetched, err := ft.PreFetch()
 	if err != nil {
 		logging.Debug(ctx, "explain prefetch: PreFetch failed",

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -360,7 +360,9 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 // an ambiguity pre-check to avoid writing a summary to the wrong
 // checkpoint on short-prefix collisions.
 func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
+	stop := startSpinner(errW, "Loading checkpoints")
 	lookup, lookupErr := newExplainCheckpointLookup(ctx)
+	stop("")
 	if generate {
 		if err := runExplainAutoAmbiguityGuard(ctx, target, lookup, lookupErr); err != nil {
 			return err

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -556,8 +556,9 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 
 	// Batch-prefetch all blobs in the checkpoint's subtree in one network
 	// round-trip via fetch-pack. Best-effort: if prefetch fails, the
-	// per-File fallback fetcher on v1Store still recovers individual blobs.
-	prefetchCheckpointBlobs(ctx, lookup.repo, fullCheckpointID)
+	// per-File fallback fetcher on v1Store / v2Store still recovers
+	// individual blobs.
+	prefetchCheckpointBlobs(ctx, lookup.repo, fullCheckpointID, lookup.preferCheckpointsV2)
 
 	// Resolve store and load checkpoint summary with v2 -> v1 fallback.
 	resolvedReader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, fullCheckpointID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
@@ -640,37 +641,76 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	return nil
 }
 
-// prefetchCheckpointBlobs navigates to the checkpoint's subtree, collects
-// every locally-missing blob in one pass, and fetches them all in a single
-// `git fetch-pack <url> <hash1> <hash2>...` invocation. Best-effort —
-// failure is logged and the read path falls back to the FetchingTree's
-// per-File fetcher.
-func prefetchCheckpointBlobs(ctx context.Context, repo *git.Repository, cpID id.CheckpointID) {
-	rootTree, err := strategy.GetMetadataBranchTree(repo)
-	if err != nil {
-		rootTree, err = strategy.GetRemoteMetadataBranchTree(repo)
-		if err != nil {
-			logging.Debug(ctx, "explain prefetch: no v1 metadata tree", slog.String("error", err.Error()))
-			return
+// prefetchCheckpointBlobs navigates to the checkpoint's subtree(s) — v1
+// always, v2 when enabled — collects every locally-missing blob, and
+// fetches them all in a single `git fetch-pack <url> <hash1> <hash2>...`
+// invocation per store. Best-effort — failure is logged and the read path
+// falls back to the FetchingTree's per-File fetcher.
+func prefetchCheckpointBlobs(ctx context.Context, repo *git.Repository, cpID id.CheckpointID, preferV2 bool) {
+	if rootTree, err := loadV1MetadataRootTree(repo); err == nil {
+		prefetchSubtreeBlobs(ctx, repo, rootTree, cpID, "v1")
+	}
+	if preferV2 {
+		if rootTree, err := loadV2MainRootTree(repo); err == nil {
+			prefetchSubtreeBlobs(ctx, repo, rootTree, cpID, "v2")
 		}
 	}
+}
+
+func prefetchSubtreeBlobs(ctx context.Context, repo *git.Repository, rootTree *object.Tree, cpID id.CheckpointID, label string) {
 	cpSubtree, err := rootTree.Tree(cpID.Path())
 	if err != nil {
-		logging.Debug(ctx, "explain prefetch: cp subtree not found", slog.String("checkpoint_id", cpID.String()), slog.String("error", err.Error()))
+		logging.Debug(ctx, "explain prefetch: cp subtree not found",
+			slog.String("store", label),
+			slog.String("checkpoint_id", cpID.String()),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 	ft := checkpoint.NewFetchingTree(ctx, cpSubtree, repo.Storer, FetchBlobsByHash)
 	prefetched, err := ft.PreFetch()
 	if err != nil {
-		logging.Debug(ctx, "explain prefetch: PreFetch failed", slog.String("checkpoint_id", cpID.String()), slog.String("error", err.Error()))
+		logging.Debug(ctx, "explain prefetch: PreFetch failed",
+			slog.String("store", label),
+			slog.String("checkpoint_id", cpID.String()),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 	if prefetched > 0 {
 		logging.Debug(ctx, "explain prefetch: blobs fetched in one round-trip",
+			slog.String("store", label),
 			slog.String("checkpoint_id", cpID.String()),
 			slog.Int("blob_count", prefetched),
 		)
 	}
+}
+
+func loadV1MetadataRootTree(repo *git.Repository) (*object.Tree, error) {
+	if tree, err := strategy.GetMetadataBranchTree(repo); err == nil {
+		return tree, nil
+	}
+	tree, err := strategy.GetRemoteMetadataBranchTree(repo)
+	if err != nil {
+		return nil, fmt.Errorf("read v1 metadata tree (local + remote-tracking): %w", err)
+	}
+	return tree, nil
+}
+
+func loadV2MainRootTree(repo *git.Repository) (*object.Tree, error) {
+	ref, err := repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	if err != nil {
+		return nil, fmt.Errorf("v2 /main ref not found: %w", err)
+	}
+	commit, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("read v2 /main commit: %w", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return nil, fmt.Errorf("read v2 /main tree: %w", err)
+	}
+	return tree, nil
 }
 
 func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, error) {
@@ -687,17 +727,20 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 		v2URL = ""
 	}
 
+	// FetchBlobsByHash uses `git fetch-pack` for blob SHAs (porcelain
+	// `git fetch` fails against partial-clone repos with "did not send all
+	// necessary objects"). Falls back to a full metadata-branch fetch if
+	// fetch-pack also can't reach the blobs.
 	v1Store := checkpoint.NewGitStore(repo)
-	// FetchBlobsByHash now uses `git fetch-pack` under the hood, which
-	// works against GitHub for individual blob SHAs (porcelain `git fetch`
-	// fails them due to partial-clone integrity checks). Falls back to a
-	// full metadata-branch fetch if even fetch-pack can't get the blobs.
 	v1Store.SetBlobFetcher(FetchBlobsByHash)
+
+	v2Store := checkpoint.NewV2GitStore(repo, v2URL)
+	v2Store.SetBlobFetcher(FetchBlobsByHash)
 
 	lookup := &explainCheckpointLookup{
 		repo:                repo,
 		v1Store:             v1Store,
-		v2Store:             checkpoint.NewV2GitStore(repo, v2URL),
+		v2Store:             v2Store,
 		preferCheckpointsV2: settings.IsCheckpointsV2Enabled(ctx),
 	}
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -566,9 +566,16 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// individual blobs.
 	prefetchCheckpointBlobs(ctx, errW, lookup.repo, fullCheckpointID, lookup.preferCheckpointsV2)
 
+	// Cover the rest of the data-loading pipeline (summary read, session
+	// content reads via cat-file, getAssociatedCommits' git log walk) with
+	// a single spinner. Stop strictly before any write to w (stdout) so
+	// stderr spinner frames and stdout output never interleave.
+	stopLoad := startSpinner(errW, fmt.Sprintf("Loading checkpoint %s", fullCheckpointID))
+
 	// Resolve store and load checkpoint summary with v2 -> v1 fallback.
 	resolvedReader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, fullCheckpointID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
 	if err != nil {
+		stopLoad("")
 		return fmt.Errorf("failed to read checkpoint: %w", err)
 	}
 
@@ -583,34 +590,40 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	if isCheckpointsV2 && !needsRawTranscript {
 		content, err = readV2ContentFromMain(ctx, v2Reader, fullCheckpointID, summary)
 		if err != nil {
+			stopLoad("")
 			return fmt.Errorf("failed to read checkpoint content: %w", err)
 		}
 	} else {
 		content, err = readLatestSessionContentForExplain(ctx, resolvedReader, fullCheckpointID, summary)
 		if err != nil {
+			stopLoad("")
 			return fmt.Errorf("failed to read checkpoint content: %w", err)
 		}
 	}
 
 	// Handle summary generation — uses raw transcript.
 	if generate {
+		stopLoad("") // generation prints its own progress to w/errW
 		if err := generateCheckpointSummary(ctx, w, errW, lookup.v1Store, lookup.v2Store, fullCheckpointID, summary, content, force); err != nil {
 			return err
 		}
 		// Reload to get the updated summary. After generation we only need
 		// /main data for display, so use the /main-only path for v2.
+		stopLoad = startSpinner(errW, fmt.Sprintf("Reloading checkpoint %s", fullCheckpointID))
 		if isCheckpointsV2 {
 			content, err = readV2ContentFromMain(ctx, v2Reader, fullCheckpointID, summary)
 		} else {
 			content, err = readLatestSessionContentForExplain(ctx, resolvedReader, fullCheckpointID, summary)
 		}
 		if err != nil {
+			stopLoad("")
 			return fmt.Errorf("failed to reload checkpoint: %w", err)
 		}
 	}
 
 	// Handle raw transcript output
 	if rawTranscript {
+		stopLoad("")
 		rawLog, _, rawErr := checkpoint.ResolveRawSessionLogForCheckpoint(ctx, fullCheckpointID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
 		if rawErr != nil {
 			return fmt.Errorf("failed to read raw transcript: %w", rawErr)
@@ -641,8 +654,10 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		author, _ = lookup.v1Store.GetCheckpointAuthor(ctx, fullCheckpointID) //nolint:errcheck // Author is optional
 	}
 
-	// Format and output
+	// Format and output. Stop spinner BEFORE any write to w to keep stderr
+	// frames and stdout content from interleaving.
 	output := formatCheckpointOutput(summary, content, fullCheckpointID, associatedCommits, author, verbose, full)
+	stopLoad("")
 	outputExplainContent(w, output, noPager)
 	return nil
 }

--- a/cmd/entire/cli/integration_test/explain_test.go
+++ b/cmd/entire/cli/integration_test/explain_test.go
@@ -4,12 +4,18 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/redact"
 	"github.com/stretchr/testify/require"
 
@@ -787,4 +793,225 @@ func TestExplain_BranchListingV2OnlyAfterV1Deleted(t *testing.T) {
 		"checkpoint should be visible from v2 after v1 deletion")
 	require.Contains(t, output, "Create v2 resilience file",
 		"prompt/intent should be readable from v2 after v1 deletion")
+}
+
+// TestExplain_CheckpointSucceedsAfterTreelessFetch is the regression test
+// for the partial-clone bug: when a metadata blob is on the remote but
+// absent locally (the typical aftermath of a `--filter=blob:none` fetch),
+// `entire explain --checkpoint <id>` used to fail with "checkpoint not
+// found" because go-git's `Tree.File()` returns ErrFileNotFound for
+// missing blobs and ReadCommitted treated that as "checkpoint doesn't
+// exist".
+//
+// To genuinely reproduce the bug, the test runs explain in a *fresh*
+// clone of the bare remote — one that never held the blobs locally. Just
+// deleting refs in the original env wouldn't suffice because the blobs
+// remain on disk in the existing pack files, hiding the bug.
+func TestExplain_CheckpointSucceedsAfterTreelessFetch(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+	bareURL := env.SetupBareRemote()
+
+	checkpointID := createAndPushCheckpoint(t, env, "treeless_v1.go", "Treeless v1 prompt")
+
+	cloneDir := setupTreelessClone(t, bareURL, "+refs/heads/"+paths.MetadataBranchName+":refs/heads/"+paths.MetadataBranchName)
+	requireBlobMissing(t, cloneDir, checkpointID, false /* v1 */)
+
+	output := runExplainInDir(t, cloneDir, checkpointID)
+	require.Contains(t, output, "Treeless v1 prompt",
+		"explain should succeed and surface the prompt despite blobs being absent locally")
+}
+
+// TestExplain_CheckpointV2SucceedsAfterTreelessFetch is the v2 mirror —
+// guards V2GitStore's read path against the same blob-missing regression.
+// Required because v2 will be enabled by default soon and reaches the
+// same Tree.File() trap as v1.
+func TestExplain_CheckpointV2SucceedsAfterTreelessFetch(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+
+	env.PatchSettings(map[string]any{
+		"strategy_options": map[string]any{
+			"checkpoints_v2": true,
+			"push_v2_refs":   true,
+		},
+	})
+
+	bareURL := env.SetupBareRemote()
+	checkpointID := createAndPushCheckpoint(t, env, "treeless_v2.go", "Treeless v2 prompt")
+
+	cloneDir := setupTreelessClone(t, bareURL, "+"+paths.V2MainRefName+":"+paths.V2MainRefName)
+	writeV2Settings(t, cloneDir)
+	requireBlobMissing(t, cloneDir, checkpointID, true /* v2 */)
+
+	output := runExplainInDir(t, cloneDir, checkpointID)
+	require.Contains(t, output, "Treeless v2 prompt",
+		"explain should succeed against v2 with blobs absent locally")
+}
+
+// createAndPushCheckpoint runs a session-create-stop cycle in env and
+// pushes the resulting checkpoint to origin. Returns the checkpoint ID.
+func createAndPushCheckpoint(t *testing.T, env *TestEnv, fileName, prompt string) string {
+	t.Helper()
+	session := env.NewSession()
+	transcriptPath := session.CreateTranscript(prompt, []FileChange{
+		{Path: fileName, Content: "package treeless"},
+	})
+	require.NoError(t, env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(session.ID, prompt, transcriptPath))
+	env.WriteFile(fileName, "package treeless")
+	env.GitAdd(fileName)
+	require.NoError(t, env.SimulateStop(session.ID, transcriptPath))
+	env.GitCommitWithShadowHooks("Add "+fileName, fileName)
+	cpID := env.GetLatestCheckpointID()
+	require.NotEmpty(t, cpID, "expected a checkpoint after condensation")
+	env.RunPrePush("origin")
+	return cpID
+}
+
+// setupTreelessClone creates a fresh git repo in a fresh TempDir, fetches
+// the given refspec from bareURL with --filter=blob:none --depth=1 (so
+// trees but no blobs land locally), and writes a minimal entire settings
+// file pointing at bareURL as the checkpoint_remote. Returns the new dir.
+//
+// Note: the bare and the fetch must go through the smart protocol for
+// --filter to be honored; the default local-path transport optimization
+// copies packs verbatim and ignores filters. We set
+// uploadpack.allowFilter=true on the bare and use a file:// URL with
+// protocol.file.allow=always to force the smart path.
+func setupTreelessClone(t *testing.T, barePath, refspec string) string {
+	t.Helper()
+	gitEnv := testutil.GitIsolatedEnv()
+	enableFilterOnBare(t, barePath, gitEnv)
+
+	cloneDir := t.TempDir()
+	fileURL := "file://" + barePath
+
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"-c", "protocol.file.allow=always", "fetch", "--filter=blob:none", "--depth=1", "--no-tags", fileURL, refspec},
+	} {
+		cmd := exec.CommandContext(t.Context(), "git", args...)
+		cmd.Dir = cloneDir
+		cmd.Env = gitEnv
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	require.NoError(t, writeMinimalEntireSettings(cloneDir, barePath))
+	return cloneDir
+}
+
+// enableFilterOnBare sets uploadpack.allowFilter=true on the bare repo so
+// that --filter=blob:none on fetch is honored.
+func enableFilterOnBare(t *testing.T, barePath string, gitEnv []string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "-C", barePath, "config", "uploadpack.allowFilter", "true")
+	cmd.Env = gitEnv
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to set uploadpack.allowFilter on bare: %v\n%s", err, out)
+	}
+	cmd = exec.CommandContext(t.Context(), "git", "-C", barePath, "config", "uploadpack.allowAnySHA1InWant", "true")
+	cmd.Env = gitEnv
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to set uploadpack.allowAnySHA1InWant on bare: %v\n%s", err, out)
+	}
+}
+
+// writeMinimalEntireSettings writes the smallest valid settings.json that
+// configures the manual-commit strategy with filtered_fetches enabled and
+// a custom checkpoint_remote URL — the partial-clone setup that triggered
+// the original bug.
+func writeMinimalEntireSettings(dir, bareURL string) error {
+	entireDir := filepath.Join(dir, ".entire")
+	if err := os.MkdirAll(entireDir, 0o755); err != nil {
+		return err
+	}
+	settings := map[string]any{
+		"enabled":   true,
+		"local_dev": true,
+		"strategy":  "manual-commit",
+		"strategy_options": map[string]any{
+			"filtered_fetches": true,
+			"checkpoint_remote": map[string]any{
+				"provider": "url",
+				"url":      bareURL,
+			},
+		},
+	}
+	data, err := jsonutil.MarshalIndentWithNewline(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(entireDir, paths.SettingsFileName), data, 0o644)
+}
+
+// writeV2Settings overlays checkpoints_v2 enablement on the settings written
+// by writeMinimalEntireSettings.
+func writeV2Settings(t *testing.T, dir string) {
+	t.Helper()
+	settingsPath := filepath.Join(dir, ".entire", paths.SettingsFileName)
+	data, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+
+	var settings map[string]any
+	require.NoError(t, json.Unmarshal(data, &settings))
+
+	opts, _ := settings["strategy_options"].(map[string]any)
+	opts["checkpoints_v2"] = true
+	settings["strategy_options"] = opts
+
+	updated, err := jsonutil.MarshalIndentWithNewline(settings, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(settingsPath, updated, 0o644))
+}
+
+// runExplainInDir runs `entire explain --checkpoint <id>` in dir and
+// returns combined output. Fails the test if the command errors.
+func runExplainInDir(t *testing.T, dir, checkpointID string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), getTestBinary(), "explain", "--checkpoint", checkpointID)
+	cmd.Dir = dir
+	cmd.Env = append(testutil.GitIsolatedEnv(), "ENTIRE_TEST_TTY=0")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("explain failed: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+// requireBlobMissing asserts that at least one metadata blob for the
+// checkpoint is genuinely absent from the local object store. Confirms the
+// treeless-clone setup actually reproduces the bug-triggering state — if
+// every blob were locally available, the test would pass without
+// exercising the fix.
+func requireBlobMissing(t *testing.T, dir, checkpointID string, isV2 bool) {
+	t.Helper()
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	var ref *plumbing.Reference
+	if isV2 {
+		ref, err = repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	} else {
+		ref, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	}
+	require.NoError(t, err, "metadata ref should exist after treeless fetch")
+
+	commit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	rootTree, err := commit.Tree()
+	require.NoError(t, err)
+	cpSubtree, err := rootTree.Tree(checkpointID[:2] + "/" + checkpointID[2:])
+	require.NoError(t, err, "cp subtree should be navigable from local trees")
+
+	for _, entry := range cpSubtree.Entries {
+		if !entry.Mode.IsFile() {
+			continue
+		}
+		if _, err := repo.BlobObject(entry.Hash); err != nil {
+			return // confirmed: at least one blob is missing
+		}
+	}
+	t.Fatalf("expected at least one metadata blob to be missing in fresh treeless clone (cp=%s, v2=%v)", checkpointID, isV2)
 }

--- a/cmd/entire/cli/integration_test/explain_test.go
+++ b/cmd/entire/cli/integration_test/explain_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/execx"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -967,12 +968,14 @@ func writeV2Settings(t *testing.T, dir string) {
 }
 
 // runExplainInDir runs `entire explain --checkpoint <id>` in dir and
-// returns combined output. Fails the test if the command errors.
+// returns combined output. Fails the test if the command errors. Uses
+// execx.NonInteractive (project rule for spawning the entire binary in
+// tests) so the child has no controlling terminal.
 func runExplainInDir(t *testing.T, dir, checkpointID string) string {
 	t.Helper()
-	cmd := exec.CommandContext(t.Context(), getTestBinary(), "explain", "--checkpoint", checkpointID)
+	cmd := execx.NonInteractive(t.Context(), getTestBinary(), "explain", "--checkpoint", checkpointID)
 	cmd.Dir = dir
-	cmd.Env = append(testutil.GitIsolatedEnv(), "ENTIRE_TEST_TTY=0")
+	cmd.Env = testutil.GitIsolatedEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("explain failed: %v\n%s", err, out)

--- a/cmd/entire/cli/progress.go
+++ b/cmd/entire/cli/progress.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+)
+
+// spinnerFrames matches the bubbles/spinner Dot frames used by the activity
+// TUI, so a CLI spinner here visually matches `entire activity`.
+var spinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
+
+const spinnerInterval = 100 * time.Millisecond
+
+// startSpinner prints msg followed by an animated spinner to w until the
+// returned stop function is called. The stop function clears the spinner
+// line and prints suffix (with a newline) if non-empty.
+//
+// When w is not a terminal (CI, redirected output, agent subprocess), the
+// spinner is suppressed and msg is printed once with a trailing "..." so
+// non-interactive callers still see what's happening without ANSI noise.
+func startSpinner(w io.Writer, msg string) func(suffix string) {
+	if !interactive.IsTerminalWriter(w) {
+		fmt.Fprintln(w, msg+"...")
+		return func(suffix string) {
+			if suffix != "" {
+				fmt.Fprintln(w, suffix)
+			}
+		}
+	}
+
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(spinnerInterval)
+		defer ticker.Stop()
+		frame := 0
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				fmt.Fprintf(w, "\r%s %s", spinnerFrames[frame], msg)
+				frame = (frame + 1) % len(spinnerFrames)
+			}
+		}
+	}()
+	return func(suffix string) {
+		close(done)
+		<-stopped
+		fmt.Fprint(w, "\r\033[K") // clear current line
+		if suffix != "" {
+			fmt.Fprintln(w, suffix)
+		}
+	}
+}

--- a/cmd/entire/cli/progress.go
+++ b/cmd/entire/cli/progress.go
@@ -12,18 +12,25 @@ import (
 // TUI, so a CLI spinner here visually matches `entire activity`.
 var spinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 
-const spinnerInterval = 100 * time.Millisecond
+const (
+	spinnerInterval = 100 * time.Millisecond
+	// spinnerInitialDelay is how long an operation must run before the
+	// spinner appears at all. Faster operations don't get a spinner —
+	// avoids flicker on warm runs that complete in under a quarter second.
+	spinnerInitialDelay = 250 * time.Millisecond
+)
 
-// startSpinner prints msg followed by an animated spinner to w until the
-// returned stop function is called. The stop function clears the spinner
-// line and prints suffix (with a newline) if non-empty.
+// startSpinner prints msg followed by an animated spinner to w when the
+// operation takes longer than spinnerInitialDelay. Returns a stop function
+// that clears the spinner line and prints suffix (with a newline) if
+// non-empty. Fast operations that call stop before the initial delay
+// elapses produce no output at all.
 //
 // When w is not a terminal (CI, redirected output, agent subprocess), the
-// spinner is suppressed and msg is printed once with a trailing "..." so
-// non-interactive callers still see what's happening without ANSI noise.
+// spinner and the suppression message are both omitted — non-interactive
+// callers get clean output without progress chatter.
 func startSpinner(w io.Writer, msg string) func(suffix string) {
 	if !interactive.IsTerminalWriter(w) {
-		fmt.Fprintln(w, msg+"...")
 		return func(suffix string) {
 			if suffix != "" {
 				fmt.Fprintln(w, suffix)
@@ -35,9 +42,16 @@ func startSpinner(w io.Writer, msg string) func(suffix string) {
 	stopped := make(chan struct{})
 	go func() {
 		defer close(stopped)
+		select {
+		case <-done:
+			return // operation finished before the spinner would appear
+		case <-time.After(spinnerInitialDelay):
+		}
 		ticker := time.NewTicker(spinnerInterval)
 		defer ticker.Stop()
 		frame := 0
+		fmt.Fprintf(w, "\r%s %s", spinnerFrames[frame], msg)
+		frame = (frame + 1) % len(spinnerFrames)
 		for {
 			select {
 			case <-done:
@@ -51,7 +65,9 @@ func startSpinner(w io.Writer, msg string) func(suffix string) {
 	return func(suffix string) {
 		close(done)
 		<-stopped
-		fmt.Fprint(w, "\r\033[K") // clear current line
+		// \r\033[K is a no-op on a line that was never drawn; on a drawn
+		// line it returns the cursor and clears it.
+		fmt.Fprint(w, "\r\033[K")
 		if suffix != "" {
 			fmt.Fprintln(w, suffix)
 		}


### PR DESCRIPTION
## Problem

`entire explain <checkpoint-id>` failed with "no checkpoint or commit found" against a `checkpoint_remote`-backed setup with `filtered_fetches: true`. The checkpoint was on the remote and discoverable in the local tree, but the metadata blob was absent locally — and go-git's `Tree.File()` returns `ErrFileNotFound` for missing blobs, which the v1 / v2 read paths treated as "checkpoint doesn't exist." Even when it eventually returned correct data, it could take 10+ seconds on a cold cache with **zero progress feedback** — easy to mistake for a hang.

## Fix — correctness

Three coordinated changes:

1. **Configure blob fetcher on both stores.** v1Store had `SetBlobFetcher` but explain wasn't calling it. Added the same to V2GitStore and wired both.
2. **Wrap v2 reads in `FetchingTree`.** v1's read path already used FetchingTree (with cat-file fallback for partial-clone-filtered blobs). Mirrored that for v2's `ReadCommitted` / `ReadSession*` methods.
3. **Use `git fetch-pack` for blob SHAs.** Porcelain `git fetch <url> <hash>` enforces partial-clone integrity checks that reject blob-only responses; plumbing skips those checks. Switched `FetchBlobs` accordingly.

Plus: `FetchingTree.File` now tries `git cat-file` BEFORE the network fetch — saves multi-second round-trips when a blob is on disk but invisible to go-git's storer (typical partial-clone state).

## Fix — progress feedback

Wrapped the entire pre-output pipeline with two sequential spinners on stderr:

- **`⣾ Loading checkpoints`** during `newExplainCheckpointLookup` (the slow `ListCommitted` walk that reads every checkpoint's metadata.json via `git cat-file`)
- **`⣾ Loading checkpoint <id>`** during `prefetchCheckpointBlobs` (including its `cat-file -e` analysis loop), the actual fetch, summary + session reads, and `getAssociatedCommits` git log walk

Same Braille frames as the activity TUI for visual consistency. 250ms initial delay so warm/fast runs stay silent — no flicker. Stops strictly before any write to stdout so spinner frames and output never interleave. Suppressed entirely when stderr isn't a terminal (CI, redirected output, agent subprocesses).

## Tests

Two new integration tests reproduce the partial-clone state in a fresh TempDir clone (`file://` URL + `uploadpack.allowFilter=true` on the bare so `--filter=blob:none` is actually honored — the local-path transport ignores filters) and verify explain succeeds:

- `TestExplain_CheckpointSucceedsAfterTreelessFetch` (v1)
- `TestExplain_CheckpointV2SucceedsAfterTreelessFetch` (v2)

Both assert at least one metadata blob is genuinely missing locally before running explain — without that pre-condition the tests could silently pass against a fully-cloned repo. Verified for regression: stashing the v2 fix makes the v2 test fail with the exact original symptom (`failed to read checkpoint: checkpoint not found`).

## Performance

- **Cold run** (blobs missing locally): ~1-2s — one batched `fetch-pack` call covers all blobs in the checkpoint subtree, no per-blob round-trips
- **Warm run** (blobs on disk): sub-second — `cat-file` reads local blobs directly, no network