### PR TITLE
Checkpoints v2: Handle stale v1 checkpoint sessions during migration

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint_test.go
+++ b/cmd/entire/cli/checkpoint/checkpoint_test.go
@@ -1379,6 +1379,9 @@ func TestReadSessionContent_InvalidIndex(t *testing.T) {
 	if !strings.Contains(err.Error(), "session 1 not found") {
 		t.Errorf("error should mention session not found, got: %v", err)
 	}
+	if !errors.Is(err, ErrCheckpointNotFound) {
+		t.Errorf("ReadSessionContent(1) error = %v, want ErrCheckpointNotFound", err)
+	}
 }
 
 // TestReadLatestSessionContent verifies that ReadLatestSessionContent returns

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -966,7 +966,7 @@ func (s *GitStore) ReadSessionMetadata(ctx context.Context, checkpointID id.Chec
 	sessionPath := fmt.Sprintf("%s/%d", checkpointPath, sessionIndex)
 	sessionTree, err := ft.Tree(sessionPath)
 	if err != nil {
-		return nil, fmt.Errorf("session %d not found: %w", sessionIndex, err)
+		return nil, fmt.Errorf("%w: session %d not found: %w", ErrCheckpointNotFound, sessionIndex, err)
 	}
 
 	metadataFile, err := sessionTree.File(paths.MetadataFileName)
@@ -1012,7 +1012,7 @@ func (s *GitStore) ReadSessionContent(ctx context.Context, checkpointID id.Check
 	sessionDir := strconv.Itoa(sessionIndex)
 	sessionTree, err := checkpointTree.Tree(sessionDir)
 	if err != nil {
-		return nil, fmt.Errorf("session %d not found: %w", sessionIndex, err)
+		return nil, fmt.Errorf("%w: session %d not found: %w", ErrCheckpointNotFound, sessionIndex, err)
 	}
 
 	result := &SessionContent{}

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -105,6 +105,7 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 var (
 	errAlreadyMigrated          = errors.New("already migrated")
 	errTranscriptNotGeneratable = errors.New("transcript.jsonl could not be generated")
+	errNoMigratableSessions     = errors.New("no migratable v1 sessions")
 )
 
 const migrateRemoteName = "origin"
@@ -138,6 +139,9 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 				result.skipped++
 			case errors.Is(migrateErr, errTranscriptNotGeneratable):
 				fmt.Fprintf(out, "%s in v2, but %s\n", prefix, migrateErr.Error())
+				result.skipped++
+			case errors.Is(migrateErr, errNoMigratableSessions):
+				fmt.Fprintf(out, "%s skipped (%s)\n", prefix, migrateErr.Error())
 				result.skipped++
 			default:
 				fmt.Fprintf(out, "%s failed\n", prefix)
@@ -203,9 +207,15 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 
 	compactFailed := false
 	shouldCopyTaskMetadata := false
+	skippedMissingSessions := 0
+	migratedSessions := 0
 
 	for sessionIdx := range len(summary.Sessions) {
-		content, readErr := v1Store.ReadSessionContent(ctx, info.CheckpointID, sessionIdx)
+		content, skipped, readErr := readV1SessionForMigration(ctx, out, prefix, v1Store, info.CheckpointID, sessionIdx)
+		if skipped {
+			skippedMissingSessions++
+			continue
+		}
 		if readErr != nil {
 			return fmt.Errorf("failed to read v1 session %d: %w", sessionIdx, readErr)
 		}
@@ -226,6 +236,11 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 		if writeErr := v2Store.WriteCommitted(ctx, opts); writeErr != nil {
 			return fmt.Errorf("failed to write v2 session %d: %w", sessionIdx, writeErr)
 		}
+		migratedSessions++
+	}
+
+	if migratedSessions == 0 {
+		return fmt.Errorf("%w: v1 metadata lists %d session(s), but no transcript/session content exists for any of them", errNoMigratableSessions, len(summary.Sessions))
 	}
 
 	// Copy task metadata trees from v1 to v2 /full/current
@@ -238,13 +253,39 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 		}
 	}
 
-	if compactFailed {
+	switch {
+	case compactFailed && skippedMissingSessions > 0:
+		fmt.Fprintf(out, "%s done (compact transcript not generated; skipped %d session(s) with missing transcript/session content)\n", prefix, skippedMissingSessions)
+	case compactFailed:
 		fmt.Fprintf(out, "%s done (compact transcript not generated)\n", prefix)
-	} else {
+	case skippedMissingSessions > 0:
+		fmt.Fprintf(out, "%s done (skipped %d session(s) with missing transcript/session content)\n", prefix, skippedMissingSessions)
+	default:
 		fmt.Fprintf(out, "%s done\n", prefix)
 	}
 
 	return nil
+}
+
+func readV1SessionForMigration(ctx context.Context, out io.Writer, prefix string, v1Store *checkpoint.GitStore, checkpointID id.CheckpointID, sessionIdx int) (*checkpoint.SessionContent, bool, error) {
+	content, readErr := v1Store.ReadSessionContent(ctx, checkpointID, sessionIdx)
+	if readErr != nil {
+		if errors.Is(readErr, checkpoint.ErrNoTranscript) || errors.Is(readErr, checkpoint.ErrCheckpointNotFound) {
+			warnMissingV1Session(ctx, out, prefix, checkpointID, sessionIdx, readErr)
+			return nil, true, nil
+		}
+		return nil, false, fmt.Errorf("read v1 session content: %w", readErr)
+	}
+	return content, false, nil
+}
+
+func warnMissingV1Session(ctx context.Context, out io.Writer, prefix string, checkpointID id.CheckpointID, sessionIdx int, err error) {
+	fmt.Fprintf(out, "%s warning: skipping v1 session %d because checkpoint metadata lists it, but no transcript/session content exists for that session\n", prefix, sessionIdx)
+	logging.Warn(ctx, "skipping v1 session with missing transcript during checkpoint migration",
+		slog.String("checkpoint_id", checkpointID.String()),
+		slog.Int("session_index", sessionIdx),
+		slog.String("error", err.Error()),
+	)
 }
 
 func repairPartialV2Checkpoint(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, v2Summary *checkpoint.CheckpointSummary) (bool, error) {

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -238,6 +238,159 @@ func TestMigrateCheckpointsV2_MultiSession(t *testing.T) {
 	assert.GreaterOrEqual(t, len(summary.Sessions), 2, "should have at least 2 sessions")
 }
 
+func TestMigrateCheckpointsV2_SkipsV1SessionWithoutTranscript(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+
+	cpID := id.MustCheckpointID("445566778899")
+
+	writeV1Checkpoint(t, v1Store, cpID, "session-real",
+		[]byte("{\"type\":\"assistant\",\"message\":\"real session\"}\n"),
+		[]string{"real prompt"},
+	)
+
+	err := v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-without-transcript",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted(nil),
+		Prompts:      []string{"metadata-only prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	result, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, migrateErr)
+	assert.Equal(t, 1, result.migrated)
+	assert.Equal(t, 0, result.skipped)
+	assert.Equal(t, 0, result.failed)
+
+	output := stdout.String()
+	assert.Contains(t, output, "warning: skipping v1 session 1")
+	assert.Contains(t, output, "no transcript/session content exists for that session")
+	assert.Contains(t, output, "skipped 1 session(s) with missing transcript/session content")
+
+	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
+	require.NoError(t, readErr)
+	require.NotNil(t, summary)
+	require.Len(t, summary.Sessions, 1)
+	assert.Equal(t, "/"+cpID.Path()+"/0/metadata.json", summary.Sessions[0].Metadata)
+}
+
+func TestMigrateCheckpointsV2_SkipsV1SessionWithMissingDirectory(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+
+	cpID := id.MustCheckpointID("4455667788aa")
+	writeV1Checkpoint(t, v1Store, cpID, "session-real",
+		[]byte("{\"type\":\"assistant\",\"message\":\"real session\"}\n"),
+		[]string{"real prompt"},
+	)
+	appendMissingV1SessionReference(t, repo, v1Store, cpID)
+
+	var stdout bytes.Buffer
+	result, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, migrateErr)
+	assert.Equal(t, 1, result.migrated)
+	assert.Equal(t, 0, result.skipped)
+	assert.Equal(t, 0, result.failed)
+
+	output := stdout.String()
+	assert.Contains(t, output, "warning: skipping v1 session 1")
+	assert.Contains(t, output, "skipped 1 session(s) with missing transcript/session content")
+
+	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
+	require.NoError(t, readErr)
+	require.NotNil(t, summary)
+	require.Len(t, summary.Sessions, 1)
+	assert.Equal(t, "/"+cpID.Path()+"/0/metadata.json", summary.Sessions[0].Metadata)
+}
+
+func TestMigrateCheckpointsV2_SkipsCheckpointWhenAllV1SessionsMissingTranscript(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+
+	cpID := id.MustCheckpointID("5566778899bb")
+	err := v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "metadata-only-session",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted(nil),
+		Prompts:      []string{"metadata-only prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	result, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, migrateErr)
+	assert.Equal(t, 0, result.migrated)
+	assert.Equal(t, 1, result.skipped)
+	assert.Equal(t, 0, result.failed)
+
+	output := stdout.String()
+	assert.Contains(t, output, "warning: skipping v1 session 0")
+	assert.Contains(t, output, "skipped (no migratable v1 sessions")
+
+	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
+	require.NoError(t, readErr)
+	assert.Nil(t, summary)
+}
+
+func appendMissingV1SessionReference(t *testing.T, repo *git.Repository, v1Store *checkpoint.GitStore, cpID id.CheckpointID) {
+	t.Helper()
+
+	ctx := context.Background()
+	summary, err := v1Store.ReadCommitted(ctx, cpID)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+
+	missingIndex := len(summary.Sessions)
+	missingBase := "/" + cpID.Path() + "/" + strconv.Itoa(missingIndex) + "/"
+	summary.Sessions = append(summary.Sessions, checkpoint.SessionFilePaths{
+		Metadata:    missingBase + paths.MetadataFileName,
+		Transcript:  missingBase + paths.TranscriptFileName,
+		ContentHash: missingBase + paths.ContentHashFileName,
+		Prompt:      missingBase + paths.PromptFileName,
+	})
+
+	metadataJSON, err := json.MarshalIndent(summary, "", "  ")
+	require.NoError(t, err)
+	metadataJSON = append(metadataJSON, '\n')
+
+	metadataHash, err := checkpoint.CreateBlobFromContent(repo, metadataJSON)
+	require.NoError(t, err)
+
+	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+	ref, err := repo.Reference(refName, true)
+	require.NoError(t, err)
+	commit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+
+	newTreeHash, err := checkpoint.UpdateSubtree(
+		repo,
+		commit.TreeHash,
+		[]string{string(cpID[:2]), string(cpID[2:])},
+		[]object.TreeEntry{{
+			Name: paths.MetadataFileName,
+			Mode: filemode.Regular,
+			Hash: metadataHash,
+		}},
+		checkpoint.UpdateSubtreeOptions{MergeMode: checkpoint.MergeKeepExisting},
+	)
+	require.NoError(t, err)
+
+	newCommitHash, err := checkpoint.CreateCommit(ctx, repo, newTreeHash, ref.Hash(), "test: stale v1 session reference\n", "Test", "test@test.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, newCommitHash)))
+}
+
 func TestMigrateCheckpointsV2_NoV1Branch(t *testing.T) {
 	t.Parallel()
 	repo := initMigrateTestRepo(t)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/262
<!-- entire-trail-link-end -->

Handles an issue in some repos where `metadata.json` stated there were multiple sessions when there was only one session, which caused the migration command to fail to process those checkpoints.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 15ae6563d4a0873e440761c85df16305599f51de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->