### PR TITLE
Checkpoints v2: Fix issue where migrations didn't check archived v2 transcripts

### DIFF
--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -51,11 +51,13 @@ func (s *V2GitStore) WriteCommitted(ctx context.Context, opts WriteCommittedOpti
 	return nil
 }
 
-// UpdateCommitted replaces the prompts and/or transcript for an existing v2 checkpoint.
-// Called at stop time to finalize checkpoints with the complete session transcript.
+// UpdateCommitted replaces the prompts and/or transcript for an existing v2
+// checkpoint. Called at stop time to finalize checkpoints with the complete
+// session transcript.
 //
 // On /main: replaces prompts and compact transcript (if provided).
-// On /full/current: replaces the raw transcript (if provided).
+// On /full/*: replaces the raw transcript where the session artifacts already
+// live, or writes to /full/current if the session has no full artifacts yet.
 //
 // Returns ErrCheckpointNotFound if the checkpoint doesn't exist on /main.
 func (s *V2GitStore) UpdateCommitted(ctx context.Context, opts UpdateCommittedOptions) error {
@@ -70,16 +72,16 @@ func (s *V2GitStore) UpdateCommitted(ctx context.Context, opts UpdateCommittedOp
 
 	if opts.Transcript.Len() > 0 {
 		if err := s.updateCommittedFullTranscript(ctx, opts, sessionIndex); err != nil {
-			return fmt.Errorf("v2 /full/current update failed: %w", err)
+			return fmt.Errorf("v2 /full/* update failed: %w", err)
 		}
 	}
 
 	return nil
 }
 
-// FullSessionArtifacts describes where a checkpoint session's raw transcript
+// fullSessionArtifacts describes where a checkpoint session's raw transcript
 // artifacts live across the v2 /full/* refs.
-type FullSessionArtifacts struct {
+type fullSessionArtifacts struct {
 	RefName       plumbing.ReferenceName
 	Found         bool
 	HasTranscript bool
@@ -96,17 +98,17 @@ func (s *V2GitStore) HasFullSessionArtifacts(checkpointID id.CheckpointID, sessi
 	return artifacts.Found && artifacts.HasTranscript && artifacts.HasHash, nil
 }
 
-func (s *V2GitStore) findFullSessionArtifacts(checkpointID id.CheckpointID, sessionIndex int) (FullSessionArtifacts, error) {
+func (s *V2GitStore) findFullSessionArtifacts(checkpointID id.CheckpointID, sessionIndex int) (fullSessionArtifacts, error) {
 	refNames, err := s.fullRefSearchOrder()
 	if err != nil {
-		return FullSessionArtifacts{}, err
+		return fullSessionArtifacts{}, err
 	}
 
-	var firstFound FullSessionArtifacts
+	var firstFound fullSessionArtifacts
 	for _, refName := range refNames {
 		artifacts, inspectErr := s.inspectFullSessionArtifacts(refName, checkpointID, sessionIndex)
 		if inspectErr != nil {
-			return FullSessionArtifacts{}, inspectErr
+			return fullSessionArtifacts{}, inspectErr
 		}
 		if !artifacts.Found {
 			continue
@@ -123,7 +125,7 @@ func (s *V2GitStore) findFullSessionArtifacts(checkpointID id.CheckpointID, sess
 		return firstFound, nil
 	}
 
-	return FullSessionArtifacts{}, nil
+	return fullSessionArtifacts{}, nil
 }
 
 func (s *V2GitStore) fullRefSearchOrder() ([]plumbing.ReferenceName, error) {
@@ -140,30 +142,30 @@ func (s *V2GitStore) fullRefSearchOrder() ([]plumbing.ReferenceName, error) {
 	return refNames, nil
 }
 
-func (s *V2GitStore) inspectFullSessionArtifacts(refName plumbing.ReferenceName, checkpointID id.CheckpointID, sessionIndex int) (FullSessionArtifacts, error) {
+func (s *V2GitStore) inspectFullSessionArtifacts(refName plumbing.ReferenceName, checkpointID id.CheckpointID, sessionIndex int) (fullSessionArtifacts, error) {
 	_, rootTreeHash, err := s.GetRefState(refName)
 	if err != nil {
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
-			return FullSessionArtifacts{}, nil
+			return fullSessionArtifacts{}, nil
 		}
-		return FullSessionArtifacts{}, err
+		return fullSessionArtifacts{}, err
 	}
 
 	rootTree, err := s.repo.TreeObject(rootTreeHash)
 	if err != nil {
-		return FullSessionArtifacts{}, fmt.Errorf("failed to read %s tree: %w", refName, err)
+		return fullSessionArtifacts{}, fmt.Errorf("failed to read %s tree: %w", refName, err)
 	}
 
 	sessionPath := fmt.Sprintf("%s/%d", checkpointID.Path(), sessionIndex)
 	sessionTree, err := rootTree.Tree(sessionPath)
 	if err != nil {
 		if errors.Is(err, object.ErrDirectoryNotFound) {
-			return FullSessionArtifacts{}, nil
+			return fullSessionArtifacts{}, nil
 		}
-		return FullSessionArtifacts{}, fmt.Errorf("failed to read %s session tree %s: %w", refName, sessionPath, err)
+		return fullSessionArtifacts{}, fmt.Errorf("failed to read %s session tree %s: %w", refName, sessionPath, err)
 	}
 
-	artifacts := FullSessionArtifacts{RefName: refName, Found: true}
+	artifacts := fullSessionArtifacts{RefName: refName, Found: true}
 	for _, entry := range sessionTree.Entries {
 		switch {
 		case entry.Name == paths.V2RawTranscriptFileName:

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -77,6 +77,107 @@ func (s *V2GitStore) UpdateCommitted(ctx context.Context, opts UpdateCommittedOp
 	return nil
 }
 
+// FullSessionArtifacts describes where a checkpoint session's raw transcript
+// artifacts live across the v2 /full/* refs.
+type FullSessionArtifacts struct {
+	RefName       plumbing.ReferenceName
+	Found         bool
+	HasTranscript bool
+	HasHash       bool
+}
+
+// HasFullSessionArtifacts reports whether the raw transcript and content hash
+// for a checkpoint session exist in any local v2 /full/* ref.
+func (s *V2GitStore) HasFullSessionArtifacts(checkpointID id.CheckpointID, sessionIndex int) (bool, error) {
+	artifacts, err := s.findFullSessionArtifacts(checkpointID, sessionIndex)
+	if err != nil {
+		return false, err
+	}
+	return artifacts.Found && artifacts.HasTranscript && artifacts.HasHash, nil
+}
+
+func (s *V2GitStore) findFullSessionArtifacts(checkpointID id.CheckpointID, sessionIndex int) (FullSessionArtifacts, error) {
+	refNames, err := s.fullRefSearchOrder()
+	if err != nil {
+		return FullSessionArtifacts{}, err
+	}
+
+	var firstFound FullSessionArtifacts
+	for _, refName := range refNames {
+		artifacts, inspectErr := s.inspectFullSessionArtifacts(refName, checkpointID, sessionIndex)
+		if inspectErr != nil {
+			return FullSessionArtifacts{}, inspectErr
+		}
+		if !artifacts.Found {
+			continue
+		}
+		if artifacts.HasTranscript && artifacts.HasHash {
+			return artifacts, nil
+		}
+		if !firstFound.Found {
+			firstFound = artifacts
+		}
+	}
+
+	if firstFound.Found {
+		return firstFound, nil
+	}
+
+	return FullSessionArtifacts{}, nil
+}
+
+func (s *V2GitStore) fullRefSearchOrder() ([]plumbing.ReferenceName, error) {
+	refNames := []plumbing.ReferenceName{plumbing.ReferenceName(paths.V2FullCurrentRefName)}
+
+	archived, err := s.ListArchivedGenerations()
+	if err != nil {
+		return nil, err
+	}
+	for i := len(archived) - 1; i >= 0; i-- {
+		refNames = append(refNames, plumbing.ReferenceName(paths.V2FullRefPrefix+archived[i]))
+	}
+
+	return refNames, nil
+}
+
+func (s *V2GitStore) inspectFullSessionArtifacts(refName plumbing.ReferenceName, checkpointID id.CheckpointID, sessionIndex int) (FullSessionArtifacts, error) {
+	_, rootTreeHash, err := s.GetRefState(refName)
+	if err != nil {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return FullSessionArtifacts{}, nil
+		}
+		return FullSessionArtifacts{}, err
+	}
+
+	rootTree, err := s.repo.TreeObject(rootTreeHash)
+	if err != nil {
+		return FullSessionArtifacts{}, fmt.Errorf("failed to read %s tree: %w", refName, err)
+	}
+
+	sessionPath := fmt.Sprintf("%s/%d", checkpointID.Path(), sessionIndex)
+	sessionTree, err := rootTree.Tree(sessionPath)
+	if err != nil {
+		if errors.Is(err, object.ErrDirectoryNotFound) {
+			return FullSessionArtifacts{}, nil
+		}
+		return FullSessionArtifacts{}, fmt.Errorf("failed to read %s session tree %s: %w", refName, sessionPath, err)
+	}
+
+	artifacts := FullSessionArtifacts{RefName: refName, Found: true}
+	for _, entry := range sessionTree.Entries {
+		switch {
+		case entry.Name == paths.V2RawTranscriptFileName:
+			artifacts.HasTranscript = true
+		case strings.HasPrefix(entry.Name, paths.V2RawTranscriptFileName+"."):
+			artifacts.HasTranscript = true
+		case entry.Name == paths.V2RawTranscriptHashFileName:
+			artifacts.HasHash = true
+		}
+	}
+
+	return artifacts, nil
+}
+
 // updateCommittedMain updates prompts and compact transcript on the /main ref for an existing checkpoint.
 // Returns the session index for coordination with /full/current.
 func (s *V2GitStore) updateCommittedMain(ctx context.Context, opts UpdateCommittedOptions) (int, error) {
@@ -187,11 +288,24 @@ func (s *V2GitStore) updateCommittedMain(ctx context.Context, opts UpdateCommitt
 }
 
 // updateCommittedFullTranscript replaces the transcript for a specific checkpoint
-// on /full/current while preserving other checkpoints' transcripts in the tree.
+// on the /full/* ref where that checkpoint session already lives, while
+// preserving other checkpoints' transcripts in the tree. If the session has no
+// full-transcript artifacts yet, it writes to /full/current.
 func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts UpdateCommittedOptions, sessionIndex int) error {
 	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
-	if err := s.ensureRef(ctx, refName); err != nil {
-		return fmt.Errorf("failed to ensure /full/current ref: %w", err)
+
+	existing, findErr := s.findFullSessionArtifacts(opts.CheckpointID, sessionIndex)
+	if findErr != nil {
+		return findErr
+	}
+	if existing.Found {
+		refName = existing.RefName
+	}
+
+	if refName == plumbing.ReferenceName(paths.V2FullCurrentRefName) {
+		if err := s.ensureRef(ctx, refName); err != nil {
+			return fmt.Errorf("failed to ensure /full/current ref: %w", err)
+		}
 	}
 
 	parentHash, rootTreeHash, err := s.GetRefState(refName)
@@ -270,7 +384,15 @@ func (s *V2GitStore) updateCommittedFullTranscript(ctx context.Context, opts Upd
 
 	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
 	commitMsg := fmt.Sprintf("Finalize checkpoint: %s\n", opts.CheckpointID)
-	return s.updateRef(ctx, refName, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
+	if err := s.updateRef(ctx, refName, newTreeHash, parentHash, commitMsg, authorName, authorEmail); err != nil {
+		return err
+	}
+
+	if refName == plumbing.ReferenceName(paths.V2FullCurrentRefName) {
+		s.rotateCurrentIfNeeded(ctx, newTreeHash)
+	}
+
+	return nil
 }
 
 // writeCommittedMain writes metadata entries to the /main ref.
@@ -563,26 +685,28 @@ func (s *V2GitStore) writeCommittedFullTranscript(ctx context.Context, opts Writ
 		return err
 	}
 
-	// Check if rotation is needed after successful write.
-	// Count checkpoints by walking the tree (no generation.json on /full/current).
-	checkpointCount, countErr := s.CountCheckpointsInTree(newTreeHash)
+	s.rotateCurrentIfNeeded(ctx, newTreeHash)
+	return nil
+}
+
+func (s *V2GitStore) rotateCurrentIfNeeded(ctx context.Context, treeHash plumbing.Hash) {
+	checkpointCount, countErr := s.CountCheckpointsInTree(treeHash)
 	if countErr != nil {
 		logging.Warn(ctx, "failed to count checkpoints for rotation check",
 			slog.String("error", countErr.Error()),
 		)
-		return nil
+		return
 	}
-	if checkpointCount >= s.maxCheckpoints() {
-		if rotErr := s.rotateGeneration(ctx); rotErr != nil {
-			logging.Warn(ctx, "generation rotation failed",
-				slog.String("error", rotErr.Error()),
-				slog.Int("checkpoint_count", checkpointCount),
-			)
-			// Non-fatal: rotation failure doesn't invalidate the write
-		}
+	if checkpointCount < s.maxCheckpoints() {
+		return
 	}
-
-	return nil
+	if rotErr := s.rotateGeneration(ctx); rotErr != nil {
+		logging.Warn(ctx, "generation rotation failed",
+			slog.String("error", rotErr.Error()),
+			slog.Int("checkpoint_count", checkpointCount),
+		)
+		// Non-fatal: rotation failure doesn't invalidate the write
+	}
 }
 
 // writeTranscriptBlobs writes pre-redacted, chunked transcript blobs to entries.

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -437,6 +437,58 @@ func TestRotateGeneration_ArchivesCurrentAndCreatesNewOrphan(t *testing.T) {
 	assert.Empty(t, freshTree.Entries, "fresh tree should be empty (no generation.json)")
 }
 
+func TestUpdateCommittedFullTranscript_UpdatesArchivedGeneration(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+	store.maxCheckpointsPerGeneration = 1
+	ctx := context.Background()
+
+	cpID := id.MustCheckpointID("abc123def456")
+	err := store.WriteCommitted(ctx, WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-archived-update",
+		Strategy:     "manual-commit",
+		Agent:        agent.AgentTypeClaudeCode,
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"provisional"}`)),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	archived, err := store.ListArchivedGenerations()
+	require.NoError(t, err)
+	require.Len(t, archived, 1)
+
+	_, currentTreeHash, err := store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
+	require.NoError(t, err)
+	currentCount, err := store.CountCheckpointsInTree(currentTreeHash)
+	require.NoError(t, err)
+	require.Equal(t, 0, currentCount, "rotation should leave /full/current empty")
+
+	finalTranscript := redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"final"}`))
+	err = store.UpdateCommitted(ctx, UpdateCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-archived-update",
+		Transcript:   finalTranscript,
+		Agent:        agent.AgentTypeClaudeCode,
+	})
+	require.NoError(t, err)
+
+	_, currentTreeHash, err = store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
+	require.NoError(t, err)
+	currentCount, err = store.CountCheckpointsInTree(currentTreeHash)
+	require.NoError(t, err)
+	assert.Equal(t, 0, currentCount, "finalization must not rehydrate archived checkpoints into /full/current")
+
+	_, archiveTreeHash, err := store.GetRefState(plumbing.ReferenceName(paths.V2FullRefPrefix + archived[0]))
+	require.NoError(t, err)
+	archiveTree, err := repo.TreeObject(archiveTreeHash)
+	require.NoError(t, err)
+	got := v2ReadFile(t, archiveTree, cpID.Path()+"/0/"+paths.V2RawTranscriptFileName)
+	assert.Equal(t, string(finalTranscript.Bytes()), got)
+}
+
 func TestRotateGeneration_SequentialNumbering(t *testing.T) {
 	t.Parallel()
 	repo := initTestRepo(t)

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"strconv"
-	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
@@ -164,7 +163,7 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 
 	// Already in v2 — when not forcing, check if any aspect of sessions are missing and backfill
 	if existing != nil && !force {
-		repaired, repairErr := repairPartialV2Checkpoint(ctx, repo, v1Store, v2Store, info, existing)
+		repaired, repairErr := repairPartialV2Checkpoint(ctx, v1Store, v2Store, info, existing)
 		if repairErr != nil {
 			return repairErr
 		}
@@ -247,13 +246,13 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 	return nil
 }
 
-func repairPartialV2Checkpoint(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, v2Summary *checkpoint.CheckpointSummary) (bool, error) {
+func repairPartialV2Checkpoint(ctx context.Context, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, v2Summary *checkpoint.CheckpointSummary) (bool, error) {
 	repaired := false
 
-	// Spot-check already present sessions: ensure required /full/current artifacts exist.
+	// Spot-check already present sessions: ensure required /full/* artifacts exist.
 	existingSessionCount := len(v2Summary.Sessions)
 	for sessionIdx := range existingSessionCount {
-		ok, checkErr := hasCurrentFullSessionArtifacts(repo, v2Store, info.CheckpointID, sessionIdx)
+		ok, checkErr := hasFullSessionArtifacts(v2Store, info.CheckpointID, sessionIdx)
 		if checkErr != nil {
 			return false, fmt.Errorf("failed to check v2 session %d artifacts: %w", sessionIdx, checkErr)
 		}
@@ -288,39 +287,12 @@ func repairPartialV2Checkpoint(ctx context.Context, repo *git.Repository, v1Stor
 	return repaired, nil
 }
 
-func hasCurrentFullSessionArtifacts(repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int) (bool, error) {
-	_, rootTreeHash, err := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
+func hasFullSessionArtifacts(v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int) (bool, error) {
+	ok, err := v2Store.HasFullSessionArtifacts(cpID, sessionIdx)
 	if err != nil {
-		return false, nil //nolint:nilerr // Missing /full/current ref means required artifacts are absent.
+		return false, fmt.Errorf("failed to check v2 full artifacts for session %d: %w", sessionIdx, err)
 	}
-
-	rootTree, err := repo.TreeObject(rootTreeHash)
-	if err != nil {
-		return false, fmt.Errorf("failed to read /full/current tree: %w", err)
-	}
-
-	sessionPath := fmt.Sprintf("%s/%d", cpID.Path(), sessionIdx)
-	sessionTree, err := rootTree.Tree(sessionPath)
-	if err != nil {
-		return false, nil //nolint:nilerr // Missing session path means artifacts are absent, not a hard error.
-	}
-
-	hasTranscript := false
-	for _, entry := range sessionTree.Entries {
-		if entry.Name == paths.V2RawTranscriptFileName || strings.HasPrefix(entry.Name, paths.V2RawTranscriptFileName+".") {
-			hasTranscript = true
-			break
-		}
-	}
-	if !hasTranscript {
-		return false, nil
-	}
-
-	if _, err := sessionTree.File(paths.V2RawTranscriptHashFileName); err != nil {
-		return false, nil //nolint:nilerr // Missing content hash indicates incomplete /full/current artifacts.
-	}
-
-	return true, nil
+	return ok, nil
 }
 
 // backfillCompactTranscripts checks sessions in an already-migrated v2 checkpoint

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -512,7 +512,7 @@ func TestMigrateCheckpointsV2_RepairsMissingFullTranscriptBeforeBackfill(t *test
 	assert.NotEmpty(t, content.Transcript, "raw full transcript should be restored in /full/current")
 }
 
-func TestMigrateCheckpointsV2_RepairsCurrentFullEvenWhenArchiveExists(t *testing.T) {
+func TestMigrateCheckpointsV2_SkipsRepairWhenArchivedFullExists(t *testing.T) {
 	t.Parallel()
 	repo := initMigrateTestRepo(t)
 	v1Store, v2Store := newMigrateStores(repo)
@@ -543,16 +543,20 @@ func TestMigrateCheckpointsV2_RepairsCurrentFullEvenWhenArchiveExists(t *testing
 	require.NoError(t, archivedReadErr)
 	assert.NotEmpty(t, archivedRead.Transcript)
 
-	// Re-run migration: should still repair /full/current.
+	// Re-run migration: archived /full/* artifacts are sufficient, so it should
+	// not rehydrate old raw transcripts into /full/current.
 	var rerun bytes.Buffer
 	result2, rerunErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &rerun, false)
 	require.NoError(t, rerunErr)
-	assert.Equal(t, 1, result2.migrated)
-	assert.Contains(t, rerun.String(), "repaired partial v2 checkpoint state")
+	assert.Equal(t, 0, result2.migrated)
+	assert.Equal(t, 1, result2.skipped)
+	assert.NotContains(t, rerun.String(), "repaired partial v2 checkpoint state")
 
-	ok, checkErr := hasCurrentFullSessionArtifacts(repo, v2Store, cpID, 0)
+	ok, checkErr := hasFullSessionArtifacts(v2Store, cpID, 0)
 	require.NoError(t, checkErr)
-	assert.True(t, ok, "expected /full/current artifacts to be restored")
+	assert.True(t, ok, "expected archived /full/* artifacts to count as present")
+	assert.False(t, hasCurrentFullSessionArtifactsForTest(t, repo, v2Store, cpID, 0),
+		"migration rerun must not copy archived artifacts back into /full/current")
 }
 
 func removeV2SessionTranscriptFiles(t *testing.T, repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int) {
@@ -582,6 +586,36 @@ func removeV2SessionTranscriptFiles(t *testing.T, repo *git.Repository, v2Store 
 	commitHash, commitErr := checkpoint.CreateCommit(context.Background(), repo, newRootHash, parentHash, "test: remove full transcript\n", "Test", "test@test.com")
 	require.NoError(t, commitErr)
 	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)))
+}
+
+func hasCurrentFullSessionArtifactsForTest(t *testing.T, repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int) bool {
+	t.Helper()
+
+	_, rootTreeHash, err := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
+	require.NoError(t, err)
+
+	rootTree, err := repo.TreeObject(rootTreeHash)
+	require.NoError(t, err)
+
+	sessionPath := cpID.Path() + "/" + strconv.Itoa(sessionIdx)
+	sessionTree, err := rootTree.Tree(sessionPath)
+	if err != nil {
+		return false
+	}
+
+	hasTranscript := false
+	for _, entry := range sessionTree.Entries {
+		if entry.Name == paths.V2RawTranscriptFileName || strings.HasPrefix(entry.Name, paths.V2RawTranscriptFileName+".") {
+			hasTranscript = true
+			break
+		}
+	}
+	if !hasTranscript {
+		return false
+	}
+
+	_, err = sessionTree.File(paths.V2RawTranscriptHashFileName)
+	return err == nil
 }
 
 func TestBuildMigrateWriteOpts_PromptSeparatorRoundTrip(t *testing.T) {

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -171,7 +171,8 @@ func hasUnmigratedV1Checkpoints(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	v1List, err := checkpoint.NewGitStore(repo).ListCommitted(ctx)
+	v1Store := checkpoint.NewGitStore(repo)
+	v1List, err := v1Store.ListCommitted(ctx)
 	if err != nil || len(v1List) == 0 {
 		return false
 	}
@@ -185,6 +186,10 @@ func hasUnmigratedV1Checkpoints(ctx context.Context) bool {
 	}
 	for _, info := range v1List {
 		if _, ok := v2Set[info.CheckpointID.String()]; !ok {
+			summary, readErr := v1Store.ReadCommitted(ctx, info.CheckpointID)
+			if readErr != nil || summary == nil {
+				continue
+			}
 			return true
 		}
 	}

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
 
 	"github.com/stretchr/testify/assert"
@@ -1281,6 +1282,28 @@ func writeV1Checkpoint(t *testing.T, repo *git.Repository, cpID id.CheckpointID,
 	require.NoError(t, err)
 }
 
+func writeMalformedV1CheckpointWithoutSummary(t *testing.T, repo *git.Repository, cpID id.CheckpointID) {
+	t.Helper()
+	ctx := context.Background()
+
+	blobHash, err := checkpoint.CreateBlobFromContent(repo, []byte("transcript without root metadata"))
+	require.NoError(t, err)
+
+	treeHash, err := checkpoint.BuildTreeFromEntries(ctx, repo, map[string]object.TreeEntry{
+		cpID.Path() + "/0/" + paths.TranscriptFileName: {
+			Mode: filemode.Regular,
+			Hash: blobHash,
+		},
+	})
+	require.NoError(t, err)
+
+	commitHash, err := checkpoint.CreateCommit(ctx, repo, treeHash, plumbing.ZeroHash, "malformed v1 checkpoint", "Test", "test@test.com")
+	require.NoError(t, err)
+
+	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)))
+}
+
 func TestPrintCheckpointsV2MigrationHint(t *testing.T) {
 	t.Run("suppressed when no v1 checkpoints exist", func(t *testing.T) {
 		checkpointsV2MigrationHintOnce = sync.Once{}
@@ -1364,6 +1387,13 @@ func TestHasUnmigratedV1Checkpoints(t *testing.T) {
 		writeV1Checkpoint(t, repo, missing, "session-c")
 
 		assert.True(t, hasUnmigratedV1Checkpoints(context.Background()))
+	})
+
+	t.Run("false when only malformed v1 checkpoint entries are missing from v2", func(t *testing.T) {
+		repo := setupCheckpointsV2CommittedRepo(t)
+		writeMalformedV1CheckpointWithoutSummary(t, repo, id.MustCheckpointID("666666666666"))
+
+		assert.False(t, hasUnmigratedV1Checkpoints(context.Background()))
 	})
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/267
<!-- entire-trail-link-end -->

Fixes a bug where the migration repair path checked only `v2/full/current` to decide whether a migrated checkpoint still had its raw transcript. If that transcript had already been rotated into an archived ref like `v2/full/0000000000001`, rerunning the migration treated it as missing and copied old historical data back into `current`. That made current exceed the rotation threshold, so each later checkpoint/push kept creating more bogus archived generations.

1. Migration wrote/rotated some v2 full artifacts into archived refs like v2/full/0000000000001.
1. Migration was rerun.
1. The repair path checked only v2/full/current, did not see the archived raw transcript, and copied old checkpoint data back into current.
1. That made current look full of historical checkpoints, so later writes kept tripping the generation threshold and producing 0000000000002, 0000000000003, etc.


Pre-fix:

```
➜  gitsync git:(test-checkpoints-v2) git push origin HEAD
[entire] Pushing v2/main to origin....
[entire] Syncing v2/main with remote..... done
[entire] Pushing v2/main to origin.... done
[entire] Pushing v2/full/current to origin...
[entire] Syncing v2/full/current with remote............... done
[entire] Pushing v2/full/current to origin... already up-to-date
[entire] Pushing v2/full/0000000000008 to origin... already up-to-date
```

Post-fix:
```
➜  gitsync git:(test-checkpoints-v2) git push origin HEAD
[entire] Pushing v2/main to origin.... done
[entire] Pushing v2/full/current to origin.... done
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 10 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 343 bytes | 343.00 KiB/s, done.
Total 3 (delta 2), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To https://github.com/entireio/gitsync.git
   a0b43db..5b29a9b  HEAD -> test-checkpoints-v2
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git-ref selection and rotation behavior for v2 checkpoint transcripts plus migration repair heuristics; mistakes could write transcripts to the wrong generation or skip needed repairs, affecting checkpoint integrity.
> 
> **Overview**
> Fixes v2 checkpoint finalization/repair logic to **avoid rewriting `/full/current` when the raw transcript already lives in an archived `/full/*` generation** (preventing repeated rotations and “rehydrating” old checkpoints back into current).
> 
> Adds `/full/*` artifact discovery (`HasFullSessionArtifacts`) and updates `UpdateCommitted`/migration repair to use it, including writing finalized transcripts back to the archived generation where they belong and factoring rotation checks into `rotateCurrentIfNeeded` (only triggered when `/full/current` is updated). Push migration hinting is also tightened to ignore malformed v1 checkpoint entries so the CLI doesn’t suggest migration when only broken v1 data is present; tests are updated/added to cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e6b10fc49bcc07cc806d3fae30c937e628bd7f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->