### PR TITLE
fix: agent-neutral message for empty explain output

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -2145,7 +2145,7 @@ func formatBranchCheckpoints(branchName string, points []strategy.RewindPoint, s
 			fmt.Fprintf(&sb, "Filtered by session: %s\n", sessionFilter)
 		}
 		sb.WriteString("\nNo checkpoints found on this branch.\n")
-		sb.WriteString("Checkpoints will appear here after you save changes during a Claude session.\n")
+		sb.WriteString("Checkpoints will appear here after you save changes during an agent session.\n")
 		return sb.String()
 	}
 

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1079,7 +1079,7 @@ func TestExplainDefault_NoCheckpoints_ShowsHelpfulMessage(t *testing.T) {
 		t.Errorf("expected 'Checkpoints: 0' in output, got: %s", output)
 	}
 	// Should show helpful message about checkpoints appearing after saves
-	if !strings.Contains(output, "Checkpoints will appear") || !strings.Contains(output, "Claude session") {
+	if !strings.Contains(output, "Checkpoints will appear") || !strings.Contains(output, "agent session") {
 		t.Errorf("expected helpful message about checkpoints, got: %s", output)
 	}
 }


### PR DESCRIPTION
Closes #1079.

## Description

`entire explain` printed the line:

> Checkpoints will appear here after you save changes during a Claude session.

That phrasing assumes Claude Code is the only agent. Per the issue, the empty-state message should be agent-neutral so it reads correctly when Claude Code is disabled and another supported agent (Copilot CLI, Gemini, OpenCode, Cursor, Factory AI Droid, Vogon) is configured.

Change `cmd/entire/cli/explain.go` to print `"... during an agent session."` and update the matching `TestExplain_NoCheckpoints` assertion in `cmd/entire/cli/explain_test.go` to look for `"agent session"` instead of `"Claude session"`.

## Verification

```
go build ./...
go test ./cmd/entire/cli/ -run TestExplain
```

Both pass.
