### PR TITLE
Generate Homebrew cask completions at install time

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,10 +90,13 @@ homebrew_casks:
     description: "CLI for Entire"
     binaries:
       - entire
-    completions:
-      bash: "completions/entire.bash"
-      zsh: "completions/entire.zsh"
-      fish: "completions/entire.fish"
+    generate_completions_from_executable:
+      executable: entire
+      shell_parameter_format: cobra
+      shells:
+        - bash
+        - zsh
+        - fish
     conflicts:
       - cask: entire@nightly
     skip_upload: auto
@@ -108,10 +111,13 @@ homebrew_casks:
     description: "CLI for Entire (nightly build)"
     binaries:
       - entire
-    completions:
-      bash: "completions/entire.bash"
-      zsh: "completions/entire.zsh"
-      fish: "completions/entire.fish"
+    generate_completions_from_executable:
+      executable: entire
+      shell_parameter_format: cobra
+      shells:
+        - bash
+        - zsh
+        - fish
     conflicts:
       - cask: entire
     skip_upload: "{{ if not .Prerelease }}true{{ end }}"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/271
<!-- entire-trail-link-end -->

## Summary

- Switch both `homebrew_casks` (`entire`, `entire@nightly`) from a static `completions:` block to goreleaser v2.15+ `generate_completions_from_executable`. Brew now runs the installed binary at cask install time to emit `bash` / `zsh` / `fish` completions, so completions can never drift from the binary they ship next to.
- `shell_parameter_format: cobra` is sufficient — Homebrew's cask DSL already appends `completion <shell>`. (Initial draft also passed `args: [completion]` which produced doubled `entire completion completion bash` and was killed by Gatekeeper before the cask install error surfaced.)
- Build-time generation kept untouched: the `before:` hook still runs `mise run completions`, and `archives.files: completions/*` still bundles the files for tarball and Scoop users (the new field is homebrew-cask-only).

## Test plan

- [x] `goreleaser check` passes against the new config.
- [x] `goreleaser release --snapshot --clean --skip=publish,announce,sign,notarize` produces a cask containing `generate_completions_from_executable "entire", shell_parameter_format: :cobra, shells: [:bash, :zsh, :fish]`.
- [x] Local-tap install (`brew tap-new local/entire-test` → copy snapshot cask → `HOMEBREW_CASK_OPTS=--no-quarantine brew install --cask local/entire-test/entire`) installs cleanly with no completion-generation warnings.
- [x] Files land in `/opt/homebrew/etc/bash_completion.d/entire` (16 KB), `/opt/homebrew/share/zsh/site-functions/_entire` (7.7 KB), `/opt/homebrew/share/fish/vendor_completions.d/entire.fish` (9.6 KB); zsh file starts with `#compdef entire` / `compdef _entire entire` (real cobra output).
- [x] CI uses `goreleaser-pro` action with `version: latest` — already ≥ v2.15, no version pin bump needed.

## Notes

- `--no-quarantine` was only needed to bypass Gatekeeper on the unsigned snapshot binary during local validation. Production releases go through the existing `notarize:` block, so end users will not need any flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Homebrew cask packaging behavior by generating shell completions at install time, which could break installs if the CLI’s completion command or Cobra parameters change.
> 
> **Overview**
> Switches both Homebrew casks (`entire` and `entire@nightly`) from shipping static completion files to using GoReleaser’s `generate_completions_from_executable` so Homebrew generates `bash`/`zsh`/`fish` completions from the installed `entire` binary at install time.
> 
> This aligns completions with the exact binary being installed and removes the per-shell `completions:` file references from the cask config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b11faa5b3c90a879c7f4189e69a1de1edb449453. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->