### PR TITLE
fix: use agent-neutral wording in explain empty-state message

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -2636,7 +2636,7 @@ func formatBranchCheckpoints(w io.Writer, branchName string, points []strategy.R
 
 	if len(groups) == 0 {
 		sb.WriteString("No checkpoints found on this branch.\n")
-		sb.WriteString("Checkpoints will appear here after you save changes during a Claude session.\n")
+		sb.WriteString("Checkpoints will appear here after you save changes during an agent session.\n")
 		return sb.String()
 	}
 

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1254,7 +1254,7 @@ func TestExplainDefault_NoCheckpoints_ShowsHelpfulMessage(t *testing.T) {
 		t.Errorf("expected 'checkpoints  0' in output, got: %s", output)
 	}
 	// Should show helpful message about checkpoints appearing after saves
-	if !strings.Contains(output, "Checkpoints will appear") || !strings.Contains(output, "Claude session") {
+	if !strings.Contains(output, "Checkpoints will appear") || !strings.Contains(output, "agent session") {
 		t.Errorf("expected helpful message about checkpoints, got: %s", output)
 	}
 }


### PR DESCRIPTION
## Problem

The `entire explain` command's empty-state message (when no checkpoints exist) hardcodes `"a Claude session"` — so it always references Claude even when a different agent (Copilot CLI, Gemini CLI, etc.) is configured.

## Fix

Changed the message from `"a Claude session"` to `"an agent session"` in:
1. `cmd/entire/cli/explain.go:2286` — source message
2. `cmd/entire/cli/explain_test.go:1082` — test assertion

**2 files, 2 lines changed.**

Fixes #1079