### PR TITLE
Checkpoints v2: Use checkpoint creation time for migration generation calc + lower default generation retention

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -207,6 +207,11 @@ type WriteCommittedOptions struct {
 	// SessionID is the session identifier
 	SessionID string
 
+	// CreatedAt is when the checkpoint was originally created.
+	// When zero, writers use the current time. Migration sets this to preserve
+	// the original v1 checkpoint time in v2 metadata and retention decisions.
+	CreatedAt time.Time
+
 	// Strategy is the name of the strategy that created this checkpoint
 	Strategy string
 

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -425,7 +425,7 @@ func (s *GitStore) writeSessionToSubdirectory(ctx context.Context, opts WriteCom
 		CheckpointID:                opts.CheckpointID,
 		SessionID:                   opts.SessionID,
 		Strategy:                    opts.Strategy,
-		CreatedAt:                   time.Now().UTC(),
+		CreatedAt:                   checkpointCreatedAt(opts),
 		Branch:                      opts.Branch,
 		CheckpointsCount:            opts.CheckpointsCount,
 		FilesTouched:                opts.FilesTouched,
@@ -629,6 +629,13 @@ func (s *GitStore) reaggregateFromEntries(basePath string, sessionCount int, ent
 	}
 
 	return totalCount, allFiles, totalTokens, nil
+}
+
+func checkpointCreatedAt(opts WriteCommittedOptions) time.Time {
+	if opts.CreatedAt.IsZero() {
+		return time.Now().UTC()
+	}
+	return opts.CreatedAt.UTC()
 }
 
 // readJSONFromBlob reads JSON from a blob hash and decodes it to the given type.

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -102,15 +102,40 @@ type PushResult struct {
 	Output string
 }
 
+// PushOptions configures a git push operation.
+type PushOptions struct {
+	Remote    string
+	RefSpecs  []string
+	ExtraArgs []string // additional flags before remote
+	Dir       string
+}
+
 // Push runs git push --no-verify --porcelain with token injection.
 // GIT_TERMINAL_PROMPT=0 is always set.
 func Push(ctx context.Context, remote, refSpec string) (PushResult, error) {
-	pushTarget, err := resolvePushCommandTarget(ctx, remote)
+	return PushWithOptions(ctx, PushOptions{
+		Remote:   remote,
+		RefSpecs: []string{refSpec},
+	})
+}
+
+// PushWithOptions runs git push --no-verify --porcelain with token injection.
+// GIT_TERMINAL_PROMPT=0 is always set.
+func PushWithOptions(ctx context.Context, opts PushOptions) (PushResult, error) {
+	pushTarget, err := resolvePushCommandTarget(ctx, opts.Remote)
 	if err != nil {
 		return PushResult{}, fmt.Errorf("resolve push target: %w", err)
 	}
 
-	cmd := newCommand(ctx, "push", "--no-verify", "--porcelain", pushTarget, refSpec)
+	args := []string{"push", "--no-verify", "--porcelain"}
+	args = append(args, opts.ExtraArgs...)
+	args = append(args, pushTarget)
+	args = append(args, opts.RefSpecs...)
+
+	cmd := newCommand(ctx, args...)
+	if opts.Dir != "" {
+		cmd.Dir = opts.Dir
+	}
 	disableTerminalPrompt(cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
@@ -565,7 +564,7 @@ func (s *V2GitStore) writeMainSessionToSubdirectory(opts WriteCommittedOptions, 
 		CheckpointID:                opts.CheckpointID,
 		SessionID:                   opts.SessionID,
 		Strategy:                    opts.Strategy,
-		CreatedAt:                   time.Now().UTC(),
+		CreatedAt:                   checkpointCreatedAt(opts),
 		Branch:                      opts.Branch,
 		CheckpointsCount:            opts.CheckpointsCount,
 		FilesTouched:                opts.FilesTouched,

--- a/cmd/entire/cli/checkpoint/v2_generation.go
+++ b/cmd/entire/cli/checkpoint/v2_generation.go
@@ -183,6 +183,7 @@ func (s *V2GitStore) ComputeGenerationCheckpointTimestamps(rootTreeHash plumbing
 
 		cpTree, treeErr := s.repo.TreeObject(cpTreeHash)
 		if treeErr != nil {
+			missingCheckpointTimestamp = true
 			return nil //nolint:nilerr // Skip unreadable checkpoint trees and fall back to generation.json.
 		}
 		if cpGen, ok := checkpointTimestampRangeFromFullTree(cpTree); ok {

--- a/cmd/entire/cli/checkpoint/v2_generation.go
+++ b/cmd/entire/cli/checkpoint/v2_generation.go
@@ -1,10 +1,13 @@
 package checkpoint
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"regexp"
 	"sort"
@@ -149,12 +152,67 @@ func (s *V2GitStore) AddGenerationJSONToTree(rootTreeHash plumbing.Hash, gen Gen
 		UpdateSubtreeOptions{MergeMode: MergeKeepExisting})
 }
 
+// ComputeGenerationCheckpointTimestamps derives timestamps from the checkpoints
+// present in a /full/* tree. It prefers created_at from v2 /main metadata and
+// falls back to top-level transcript event timestamps for older or partial v2 data.
+func (s *V2GitStore) ComputeGenerationCheckpointTimestamps(rootTreeHash plumbing.Hash) (GenerationMetadata, bool, error) {
+	if rootTreeHash == plumbing.ZeroHash {
+		return GenerationMetadata{}, false, nil
+	}
+
+	rootTree, err := s.repo.TreeObject(rootTreeHash)
+	if err != nil {
+		return GenerationMetadata{}, false, fmt.Errorf("failed to read generation tree: %w", err)
+	}
+
+	mainTree, mainTreeErr := s.v2MainTree()
+	if mainTreeErr != nil {
+		mainTree = nil
+	}
+
+	var gen GenerationMetadata
+	found := false
+	missingCheckpointTimestamp := false
+	err = WalkCheckpointShards(s.repo, rootTree, func(cpID id.CheckpointID, cpTreeHash plumbing.Hash) error {
+		if mainTree != nil {
+			if cpGen, ok := s.checkpointTimestampRangeFromMain(mainTree, cpID); ok {
+				mergeGenerationRange(&gen, &found, cpGen)
+				return nil
+			}
+		}
+
+		cpTree, treeErr := s.repo.TreeObject(cpTreeHash)
+		if treeErr != nil {
+			return nil //nolint:nilerr // Skip unreadable checkpoint trees and fall back to generation.json.
+		}
+		if cpGen, ok := checkpointTimestampRangeFromFullTree(cpTree); ok {
+			mergeGenerationRange(&gen, &found, cpGen)
+			return nil
+		}
+		missingCheckpointTimestamp = true
+		return nil
+	})
+	if err != nil {
+		return GenerationMetadata{}, false, err
+	}
+	if missingCheckpointTimestamp {
+		return GenerationMetadata{}, false, nil
+	}
+
+	return gen, found, nil
+}
+
 // computeGenerationTimestamps derives timestamps for a generation being archived.
-// Uses the commit history of the /full/current ref: oldest = first commit time,
-// newest = latest commit time. Falls back to time.Now() if the ref has no history.
-// Note: /full/* trees don't contain session metadata (that's on /main), so we
-// derive timestamps from git commit times rather than walking the tree.
-func (s *V2GitStore) computeGenerationTimestamps() GenerationMetadata {
+// It uses checkpoint metadata/transcript timestamps rather than git commit times
+// so migration and ref-repair commits don't reset retention age.
+func (s *V2GitStore) computeGenerationTimestamps(rootTreeHash plumbing.Hash) GenerationMetadata {
+	if gen, ok, err := s.ComputeGenerationCheckpointTimestamps(rootTreeHash); err == nil && ok {
+		return gen
+	}
+	return s.computeGenerationTimestampsFromCommitHistory()
+}
+
+func (s *V2GitStore) computeGenerationTimestampsFromCommitHistory() GenerationMetadata {
 	now := time.Now().UTC()
 	fallback := GenerationMetadata{OldestCheckpointAt: now, NewestCheckpointAt: now}
 
@@ -185,6 +243,135 @@ func (s *V2GitStore) computeGenerationTimestamps() GenerationMetadata {
 	return GenerationMetadata{
 		OldestCheckpointAt: oldest,
 		NewestCheckpointAt: newest,
+	}
+}
+
+func (s *V2GitStore) v2MainTree() (*object.Tree, error) {
+	ref, err := s.repo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read v2 main ref: %w", err)
+	}
+	commit, err := s.repo.CommitObject(ref.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("failed to read v2 main commit: %w", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read v2 main tree: %w", err)
+	}
+	return tree, nil
+}
+
+func (s *V2GitStore) checkpointTimestampRangeFromMain(mainTree *object.Tree, cpID id.CheckpointID) (GenerationMetadata, bool) {
+	cpTree, err := mainTree.Tree(cpID.Path())
+	if err != nil {
+		return GenerationMetadata{}, false
+	}
+
+	var gen GenerationMetadata
+	found := false
+	for _, entry := range cpTree.Entries {
+		if entry.Mode != filemode.Dir {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name); err != nil {
+			continue
+		}
+		sessionTree, err := s.repo.TreeObject(entry.Hash)
+		if err != nil {
+			continue
+		}
+		metadataFile, err := sessionTree.File(paths.MetadataFileName)
+		if err != nil {
+			continue
+		}
+		metadataContent, err := metadataFile.Contents()
+		if err != nil {
+			continue
+		}
+		var metadata CommittedMetadata
+		if err := json.Unmarshal([]byte(metadataContent), &metadata); err != nil || metadata.CreatedAt.IsZero() {
+			continue
+		}
+		mergeGenerationTime(&gen, &found, metadata.CreatedAt.UTC())
+	}
+	return gen, found
+}
+
+func checkpointTimestampRangeFromFullTree(cpTree *object.Tree) (GenerationMetadata, bool) {
+	var gen GenerationMetadata
+	found := false
+	for _, entry := range cpTree.Entries {
+		if entry.Mode != filemode.Dir {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name); err != nil {
+			continue
+		}
+		sessionTree, err := cpTree.Tree(entry.Name)
+		if err != nil {
+			continue
+		}
+		transcript, err := readTranscriptFromObjectTree(sessionTree, "")
+		if err != nil || len(transcript) == 0 {
+			continue
+		}
+		if transcriptGen, ok := timestampRangeFromTranscript(transcript); ok {
+			mergeGenerationRange(&gen, &found, transcriptGen)
+		}
+	}
+	return gen, found
+}
+
+func timestampRangeFromTranscript(transcript []byte) (GenerationMetadata, bool) {
+	reader := bufio.NewReader(bytes.NewReader(transcript))
+	var gen GenerationMetadata
+	found := false
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		if trimmed := bytes.TrimSpace(line); len(trimmed) > 0 {
+			var event struct {
+				Timestamp string `json:"timestamp"`
+			}
+			if jsonErr := json.Unmarshal(trimmed, &event); jsonErr == nil && event.Timestamp != "" {
+				if ts, parseErr := time.Parse(time.RFC3339Nano, event.Timestamp); parseErr == nil {
+					mergeGenerationTime(&gen, &found, ts.UTC())
+				}
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	return gen, found
+}
+
+func mergeGenerationRange(dst *GenerationMetadata, found *bool, src GenerationMetadata) {
+	mergeGenerationTime(dst, found, src.OldestCheckpointAt)
+	mergeGenerationTime(dst, found, src.NewestCheckpointAt)
+}
+
+func mergeGenerationTime(gen *GenerationMetadata, found *bool, ts time.Time) {
+	if ts.IsZero() {
+		return
+	}
+	ts = ts.UTC()
+	if !*found {
+		gen.OldestCheckpointAt = ts
+		gen.NewestCheckpointAt = ts
+		*found = true
+		return
+	}
+	if ts.Before(gen.OldestCheckpointAt) {
+		gen.OldestCheckpointAt = ts
+	}
+	if ts.After(gen.NewestCheckpointAt) {
+		gen.NewestCheckpointAt = ts
 	}
 }
 
@@ -305,7 +492,7 @@ func (s *V2GitStore) rotateGeneration(ctx context.Context) error {
 	}
 
 	// Write generation.json to the current tree before archiving.
-	gen := s.computeGenerationTimestamps()
+	gen := s.computeGenerationTimestamps(currentTreeHash)
 	archiveTreeHash, err := s.AddGenerationJSONToTree(currentTreeHash, gen)
 	if err != nil {
 		return fmt.Errorf("rotation: failed to add generation.json: %w", err)

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -437,6 +437,72 @@ func TestRotateGeneration_ArchivesCurrentAndCreatesNewOrphan(t *testing.T) {
 	assert.Empty(t, freshTree.Entries, "fresh tree should be empty (no generation.json)")
 }
 
+func TestRotateGeneration_UsesCheckpointCreatedAt(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+	store.maxCheckpointsPerGeneration = 2
+	ctx := context.Background()
+
+	oldest := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	newest := time.Date(2026, 1, 5, 6, 7, 8, 0, time.UTC)
+
+	for i, createdAt := range []time.Time{oldest, newest} {
+		err := store.WriteCommitted(ctx, WriteCommittedOptions{
+			CheckpointID: id.MustCheckpointID(fmt.Sprintf("%012x", i+1)),
+			SessionID:    fmt.Sprintf("session-created-at-%d", i),
+			CreatedAt:    createdAt,
+			Strategy:     "manual-commit",
+			Agent:        agent.AgentTypeClaudeCode,
+			Transcript:   redact.AlreadyRedacted([]byte(fmt.Sprintf(`{"type":"assistant","timestamp":%q}`, createdAt.Format(time.RFC3339Nano)))),
+			AuthorName:   "Test",
+			AuthorEmail:  "test@test.com",
+		})
+		require.NoError(t, err)
+	}
+
+	archived, err := store.ListArchivedGenerations()
+	require.NoError(t, err)
+	require.Len(t, archived, 1)
+
+	gen, err := store.ReadGenerationFromRef(plumbing.ReferenceName(paths.V2FullRefPrefix + archived[0]))
+	require.NoError(t, err)
+	assert.True(t, gen.OldestCheckpointAt.Equal(oldest), "oldest should come from checkpoint metadata")
+	assert.True(t, gen.NewestCheckpointAt.Equal(newest), "newest should come from checkpoint metadata")
+}
+
+func TestComputeGenerationCheckpointTimestamps_FallsBackToRawTranscript(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+
+	oldest := time.Date(2025, 12, 23, 10, 27, 44, 0, time.UTC)
+	newest := time.Date(2025, 12, 23, 10, 31, 37, 0, time.UTC)
+	transcript := fmt.Sprintf(
+		"{\"type\":\"user\",\"timestamp\":%q}\n{\"type\":\"assistant\",\"timestamp\":%q}\n",
+		oldest.Format(time.RFC3339Nano),
+		newest.Format(time.RFC3339Nano),
+	)
+	blobHash, err := CreateBlobFromContent(repo, []byte(transcript))
+	require.NoError(t, err)
+
+	cpID := id.MustCheckpointID("aabbccddeeff")
+	rootTreeHash, err := BuildTreeFromEntries(context.Background(), repo, map[string]object.TreeEntry{
+		cpID.Path() + "/0/" + paths.V2RawTranscriptFileName: {
+			Name: paths.V2RawTranscriptFileName,
+			Mode: 0o100644,
+			Hash: blobHash,
+		},
+	})
+	require.NoError(t, err)
+
+	gen, ok, err := store.ComputeGenerationCheckpointTimestamps(rootTreeHash)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.True(t, gen.OldestCheckpointAt.Equal(oldest))
+	assert.True(t, gen.NewestCheckpointAt.Equal(newest))
+}
+
 func TestUpdateCommittedFullTranscript_UpdatesArchivedGeneration(t *testing.T) {
 	t.Parallel()
 	repo := initTestRepo(t)

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/entireio/cli/redact"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -501,6 +502,55 @@ func TestComputeGenerationCheckpointTimestamps_FallsBackToRawTranscript(t *testi
 	require.True(t, ok)
 	assert.True(t, gen.OldestCheckpointAt.Equal(oldest))
 	assert.True(t, gen.NewestCheckpointAt.Equal(newest))
+}
+
+func TestComputeGenerationCheckpointTimestamps_UnreadableCheckpointForcesFallback(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+
+	timestamp := time.Date(2025, 12, 23, 10, 27, 44, 0, time.UTC)
+	transcript := fmt.Sprintf("{\"type\":\"user\",\"timestamp\":%q}\n", timestamp.Format(time.RFC3339Nano))
+	transcriptBlobHash, err := CreateBlobFromContent(repo, []byte(transcript))
+	require.NoError(t, err)
+
+	readableCheckpointTree, err := BuildTreeFromEntries(context.Background(), repo, map[string]object.TreeEntry{
+		"0/" + paths.V2RawTranscriptFileName: {
+			Name: paths.V2RawTranscriptFileName,
+			Mode: filemode.Regular,
+			Hash: transcriptBlobHash,
+		},
+	})
+	require.NoError(t, err)
+
+	bucketTree, err := storeTree(repo, []object.TreeEntry{
+		{
+			Name: "bbccddeeff",
+			Mode: filemode.Dir,
+			Hash: readableCheckpointTree,
+		},
+		{
+			Name: "ccddeeff00",
+			Mode: filemode.Dir,
+			Hash: plumbing.NewHash("1111111111111111111111111111111111111111"),
+		},
+	})
+	require.NoError(t, err)
+
+	rootTreeHash, err := storeTree(repo, []object.TreeEntry{
+		{
+			Name: "aa",
+			Mode: filemode.Dir,
+			Hash: bucketTree,
+		},
+	})
+	require.NoError(t, err)
+
+	gen, ok, err := store.ComputeGenerationCheckpointTimestamps(rootTreeHash)
+	require.NoError(t, err)
+	assert.False(t, ok, "partial checkpoint timestamp coverage should force fallback")
+	assert.True(t, gen.OldestCheckpointAt.IsZero())
+	assert.True(t, gen.NewestCheckpointAt.IsZero())
 }
 
 func TestUpdateCommittedFullTranscript_UpdatesArchivedGeneration(t *testing.T) {

--- a/cmd/entire/cli/clean_test.go
+++ b/cmd/entire/cli/clean_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -124,6 +125,28 @@ func writeCleanSettingsFile(t *testing.T, repoRoot, content string) {
 	}
 }
 
+func runCleanGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %s: %v", strings.Join(args, " "), strings.TrimSpace(string(output)), err)
+	}
+	return string(output)
+}
+
+func addCleanBareOrigin(t *testing.T, repoRoot string) {
+	t.Helper()
+
+	remoteDir := filepath.Join(t.TempDir(), "origin.git")
+	runCleanGit(t, "", "init", "--bare", remoteDir)
+	runCleanGit(t, repoRoot, "remote", "add", "origin", remoteDir)
+}
+
 func TestCleanLongDescription_DefaultIsGeneric(t *testing.T) {
 	repo, _ := setupCleanTestRepo(t)
 
@@ -231,6 +254,29 @@ func createArchivedGenerationRef(t *testing.T, repo *git.Repository, generation 
 	if err := repo.Storer.SetReference(ref); err != nil {
 		t.Fatalf("failed to create archived generation ref %s: %v", refName, err)
 	}
+}
+
+func createRemoteOnlyArchivedGenerationRef(
+	t *testing.T,
+	repo *git.Repository,
+	repoRoot string,
+	generation string,
+	oldest time.Time,
+	newest time.Time,
+) string {
+	t.Helper()
+
+	createArchivedGenerationRef(t, repo, generation, oldest, newest)
+	refName := paths.V2FullRefPrefix + generation
+	ref, err := repo.Reference(plumbing.ReferenceName(refName), true)
+	if err != nil {
+		t.Fatalf("failed to read archived generation ref %s: %v", refName, err)
+	}
+	runCleanGit(t, repoRoot, "push", "origin", refName+":"+refName)
+	if err := strategy.DeleteRefCLI(context.Background(), refName, ref.Hash().String()); err != nil {
+		t.Fatalf("failed to remove local archived generation ref %s: %v", refName, err)
+	}
+	return ref.Hash().String()
 }
 
 func createV2MainMetadataRef(t *testing.T, repo *git.Repository, cpID id.CheckpointID, createdAt time.Time) {
@@ -917,6 +963,44 @@ func TestCleanCmd_All_DryRunListsEligibleV2Generations(t *testing.T) {
 	}
 }
 
+func TestCleanCmd_All_DryRunListsRemoteOnlyEligibleV2Generations(t *testing.T) {
+	repo, _ := setupCleanTestRepo(t)
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %v", err)
+	}
+	repoRoot := wt.Filesystem.Root()
+
+	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
+	addCleanBareOrigin(t, repoRoot)
+	createRemoteOnlyArchivedGenerationRef(t, repo, repoRoot, "0000000000001", time.Now().AddDate(0, 0, -20), time.Now().AddDate(0, 0, -15))
+
+	cmd := newCleanCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--all", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("clean --all --dry-run error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Archived v2 generations (1):") {
+		t.Fatalf("expected archived v2 generation section, got: %s", output)
+	}
+	if !strings.Contains(output, "0000000000001") {
+		t.Fatalf("expected remote-only archived generation ref in output, got: %s", output)
+	}
+	if _, err := repo.Reference(plumbing.ReferenceName(paths.V2FullRefPrefix+"0000000000001"), true); err == nil {
+		t.Fatal("dry-run should not leave remote-only archived generation as a local ref")
+	}
+	if _, err := repo.Reference(plumbing.ReferenceName("refs/entire-clean-tmp/v2/full/0000000000001"), true); err == nil {
+		t.Fatal("dry-run should remove temporary fetched generation ref")
+	}
+}
+
 func TestCleanCmd_All_UsesCheckpointTimeForV2GenerationRetention(t *testing.T) {
 	repo, _ := setupCleanTestRepo(t)
 
@@ -949,6 +1033,41 @@ func TestCleanCmd_All_UsesCheckpointTimeForV2GenerationRetention(t *testing.T) {
 	}
 	if !strings.Contains(output, "0000000000005") {
 		t.Fatalf("expected generation to be eligible by checkpoint created_at, got: %s", output)
+	}
+}
+
+func TestCleanCmd_All_ForceDeletesRemoteOnlyEligibleV2Generations(t *testing.T) {
+	repo, _ := setupCleanTestRepo(t)
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %v", err)
+	}
+	repoRoot := wt.Filesystem.Root()
+
+	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
+	addCleanBareOrigin(t, repoRoot)
+	refOID := createRemoteOnlyArchivedGenerationRef(t, repo, repoRoot, "0000000000006", time.Now().AddDate(0, 0, -20), time.Now().AddDate(0, 0, -15))
+
+	cmd := newCleanCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--all", "--force"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("clean --all --force error = %v", err)
+	}
+
+	if _, err := repo.Reference(plumbing.ReferenceName(paths.V2FullRefPrefix+"0000000000006"), true); err == nil {
+		t.Fatal("remote-only archived generation should not be left locally")
+	}
+	remoteOutput := runCleanGit(t, repoRoot, "ls-remote", "origin", paths.V2FullRefPrefix+"0000000000006")
+	if strings.Contains(remoteOutput, refOID) {
+		t.Fatalf("expected remote archived generation to be deleted, got: %s", remoteOutput)
+	}
+	if !strings.Contains(stdout.String(), "Archived v2 generations") {
+		t.Fatalf("expected deletion output to include archived v2 generations, got: %s", stdout.String())
 	}
 }
 

--- a/cmd/entire/cli/clean_test.go
+++ b/cmd/entire/cli/clean_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/go-git/go-git/v6"
@@ -229,6 +230,67 @@ func createArchivedGenerationRef(t *testing.T, repo *git.Repository, generation 
 	ref := plumbing.NewHashReference(refName, commitHash)
 	if err := repo.Storer.SetReference(ref); err != nil {
 		t.Fatalf("failed to create archived generation ref %s: %v", refName, err)
+	}
+}
+
+func createV2MainMetadataRef(t *testing.T, repo *git.Repository, cpID id.CheckpointID, createdAt time.Time) {
+	t.Helper()
+
+	sessionMetadata := checkpoint.CommittedMetadata{
+		CheckpointID: cpID,
+		SessionID:    "session-" + cpID.String(),
+		Strategy:     "manual-commit",
+		CreatedAt:    createdAt.UTC(),
+	}
+	sessionMetadataJSON, err := json.Marshal(sessionMetadata)
+	if err != nil {
+		t.Fatalf("failed to marshal session metadata: %v", err)
+	}
+	sessionMetadataHash, err := checkpoint.CreateBlobFromContent(repo, sessionMetadataJSON)
+	if err != nil {
+		t.Fatalf("failed to create session metadata blob: %v", err)
+	}
+
+	summary := checkpoint.CheckpointSummary{
+		CheckpointID: cpID,
+		Strategy:     "manual-commit",
+		Sessions: []checkpoint.SessionFilePaths{
+			{Metadata: "/" + cpID.Path() + "/0/" + paths.MetadataFileName},
+		},
+	}
+	summaryJSON, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("failed to marshal checkpoint summary: %v", err)
+	}
+	summaryHash, err := checkpoint.CreateBlobFromContent(repo, summaryJSON)
+	if err != nil {
+		t.Fatalf("failed to create checkpoint summary blob: %v", err)
+	}
+
+	entries := map[string]object.TreeEntry{
+		cpID.Path() + "/" + paths.MetadataFileName: {
+			Name: paths.MetadataFileName,
+			Mode: filemode.Regular,
+			Hash: summaryHash,
+		},
+		cpID.Path() + "/0/" + paths.MetadataFileName: {
+			Name: paths.MetadataFileName,
+			Mode: filemode.Regular,
+			Hash: sessionMetadataHash,
+		},
+	}
+
+	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, entries)
+	if err != nil {
+		t.Fatalf("failed to build v2 main tree: %v", err)
+	}
+	commitHash, err := checkpoint.CreateCommit(context.Background(), repo, treeHash, plumbing.ZeroHash, "v2 main", "test", "test@test.com")
+	if err != nil {
+		t.Fatalf("failed to create v2 main commit: %v", err)
+	}
+	ref := plumbing.NewHashReference(plumbing.ReferenceName(paths.V2MainRefName), commitHash)
+	if err := repo.Storer.SetReference(ref); err != nil {
+		t.Fatalf("failed to create v2 main ref: %v", err)
 	}
 }
 
@@ -852,6 +914,41 @@ func TestCleanCmd_All_DryRunListsEligibleV2Generations(t *testing.T) {
 	}
 	if !strings.Contains(output, "0000000000001") {
 		t.Fatalf("expected archived generation ref in output, got: %s", output)
+	}
+}
+
+func TestCleanCmd_All_UsesCheckpointTimeForV2GenerationRetention(t *testing.T) {
+	repo, _ := setupCleanTestRepo(t)
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %v", err)
+	}
+	repoRoot := wt.Filesystem.Root()
+
+	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
+
+	cpID := id.MustCheckpointID("aabbccddeeff")
+	checkpointCreatedAt := time.Now().AddDate(0, 0, -20)
+	createV2MainMetadataRef(t, repo, cpID, checkpointCreatedAt)
+	createArchivedGenerationRef(t, repo, "0000000000005", time.Now(), time.Now())
+
+	cmd := newCleanCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--all", "--dry-run"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("clean --all --dry-run error = %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Archived v2 generations (1):") {
+		t.Fatalf("expected archived v2 generation section, got: %s", output)
+	}
+	if !strings.Contains(output, "0000000000005") {
+		t.Fatalf("expected generation to be eligible by checkpoint created_at, got: %s", output)
 	}
 }
 

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -524,6 +524,7 @@ func buildMigrateWriteOpts(content *checkpoint.SessionContent, info checkpoint.C
 	return checkpoint.WriteCommittedOptions{
 		CheckpointID: info.CheckpointID,
 		SessionID:    m.SessionID,
+		CreatedAt:    m.CreatedAt,
 		Strategy:     m.Strategy,
 		Branch:       m.Branch,
 		// content.Transcript comes from persisted checkpoint storage and is

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -127,6 +127,34 @@ func TestMigrateCheckpointsV2_Basic(t *testing.T) {
 	assert.Equal(t, cpID, summary.CheckpointID)
 }
 
+func TestMigrateCheckpointsV2_PreservesCreatedAt(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+
+	createdAt := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	cpID := id.MustCheckpointID("b1c2d3e4f5a6")
+	err := v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-created-at",
+		CreatedAt:    createdAt,
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("{\"type\":\"assistant\",\"message\":\"hello\"}\n")),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	result, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.migrated)
+
+	content, err := v2Store.ReadSessionContent(context.Background(), cpID, 0)
+	require.NoError(t, err)
+	assert.True(t, content.Metadata.CreatedAt.Equal(createdAt))
+}
+
 func TestMigrateCheckpointsV2_Idempotent(t *testing.T) {
 	t.Parallel()
 	repo := initMigrateTestRepo(t)

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -26,7 +26,7 @@ const (
 	EntireSettingsLocalFile = ".entire/settings.local.json"
 	// defaultGenerationRetentionDays is the default retention window for archived
 	// checkpoints v2 raw-transcript generations when no override is configured.
-	defaultGenerationRetentionDays = 60
+	defaultGenerationRetentionDays = 14
 )
 
 var checkpointsVersionWarningOnce sync.Once

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -867,9 +867,9 @@ func TestGetFullTranscriptGenerationRetentionDays(t *testing.T) {
 		want int
 	}{
 		{
-			name: "defaults to sixty when missing",
+			name: "defaults to fourteen when missing",
 			opts: nil,
-			want: 60,
+			want: 14,
 		},
 		{
 			name: "returns configured integer",
@@ -884,22 +884,22 @@ func TestGetFullTranscriptGenerationRetentionDays(t *testing.T) {
 		{
 			name: "returns default for wrong type",
 			opts: map[string]any{"full_transcript_generation_retention_days": "30"},
-			want: 60,
+			want: 14,
 		},
 		{
 			name: "returns default for zero",
 			opts: map[string]any{"full_transcript_generation_retention_days": 0},
-			want: 60,
+			want: 14,
 		},
 		{
 			name: "returns default for negative",
 			opts: map[string]any{"full_transcript_generation_retention_days": -5},
-			want: 60,
+			want: 14,
 		},
 		{
 			name: "returns default for non integral float",
 			opts: map[string]any{"full_transcript_generation_retention_days": 1.5},
-			want: 60,
+			want: 14,
 		},
 	}
 

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -367,10 +367,18 @@ func ListEligibleV2Generations(ctx context.Context, s *settings.EntireSettings) 
 			continue
 		}
 
-		gen, genErr := store.ReadGeneration(treeHash)
-		if genErr != nil {
-			warnings = append(warnings, fmt.Sprintf("generation %s: failed to read generation.json: %v", name, genErr))
+		gen, foundCheckpointTimes, timestampErr := store.ComputeGenerationCheckpointTimestamps(treeHash)
+		if timestampErr != nil {
+			warnings = append(warnings, fmt.Sprintf("generation %s: failed to compute checkpoint timestamps: %v", name, timestampErr))
 			continue
+		}
+		if !foundCheckpointTimes {
+			var genErr error
+			gen, genErr = store.ReadGeneration(treeHash)
+			if genErr != nil {
+				warnings = append(warnings, fmt.Sprintf("generation %s: failed to read generation.json: %v", name, genErr))
+				continue
+			}
 		}
 
 		hasOldest := !gen.OldestCheckpointAt.IsZero()

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -2,19 +2,23 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 
+	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
@@ -350,33 +354,32 @@ func ListEligibleV2Generations(ctx context.Context, s *settings.EntireSettings) 
 	}
 
 	store := checkpoint.NewV2GitStore(repo, "origin")
-	archived, err := store.ListArchivedGenerations()
+	candidates, tempRefs, warnings, err := listArchivedV2GenerationCandidates(ctx, repo, store)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list archived generations: %w", err)
 	}
+	defer removeTempRefs(repo, tempRefs)
 
 	cutoff := time.Now().AddDate(0, 0, -s.GetFullTranscriptGenerationRetentionDays())
-	cleanupItems := make([]CleanupItem, 0, len(archived))
-	var warnings []string
+	cleanupItems := make([]CleanupItem, 0, len(candidates))
 
-	for _, name := range archived {
-		refName := plumbing.ReferenceName(paths.V2FullRefPrefix + name)
-		commitHash, treeHash, refErr := store.GetRefState(refName)
+	for _, candidate := range candidates {
+		commitHash, treeHash, refErr := store.GetRefState(candidate.RefName)
 		if refErr != nil {
-			warnings = append(warnings, fmt.Sprintf("generation %s: cannot read ref: %v", name, refErr))
+			warnings = append(warnings, fmt.Sprintf("generation %s: cannot read ref: %v", candidate.Name, refErr))
 			continue
 		}
 
 		gen, foundCheckpointTimes, timestampErr := store.ComputeGenerationCheckpointTimestamps(treeHash)
 		if timestampErr != nil {
-			warnings = append(warnings, fmt.Sprintf("generation %s: failed to compute checkpoint timestamps: %v", name, timestampErr))
+			warnings = append(warnings, fmt.Sprintf("generation %s: failed to compute checkpoint timestamps: %v", candidate.Name, timestampErr))
 			continue
 		}
 		if !foundCheckpointTimes {
 			var genErr error
 			gen, genErr = store.ReadGeneration(treeHash)
 			if genErr != nil {
-				warnings = append(warnings, fmt.Sprintf("generation %s: failed to read generation.json: %v", name, genErr))
+				warnings = append(warnings, fmt.Sprintf("generation %s: failed to read generation.json: %v", candidate.Name, genErr))
 				continue
 			}
 		}
@@ -385,28 +388,153 @@ func ListEligibleV2Generations(ctx context.Context, s *settings.EntireSettings) 
 		hasNewest := !gen.NewestCheckpointAt.IsZero()
 		switch {
 		case !hasOldest && !hasNewest:
-			warnings = append(warnings, fmt.Sprintf("generation %s: missing generation.json", name))
+			warnings = append(warnings, fmt.Sprintf("generation %s: missing generation.json", candidate.Name))
 			continue
 		case hasOldest != hasNewest:
-			warnings = append(warnings, fmt.Sprintf("generation %s: incomplete generation.json", name))
+			warnings = append(warnings, fmt.Sprintf("generation %s: incomplete generation.json", candidate.Name))
 			continue
 		case gen.OldestCheckpointAt.After(gen.NewestCheckpointAt):
-			warnings = append(warnings, fmt.Sprintf("generation %s: invalid timestamps", name))
+			warnings = append(warnings, fmt.Sprintf("generation %s: invalid timestamps", candidate.Name))
 			continue
 		}
 		if !gen.NewestCheckpointAt.Before(cutoff) {
 			continue
 		}
 
+		refOID := candidate.RefOID
+		if refOID == "" {
+			refOID = commitHash.String()
+		}
 		cleanupItems = append(cleanupItems, CleanupItem{
 			Type:   CleanupTypeV2Generation,
-			ID:     name,
-			RefOID: commitHash.String(),
+			ID:     candidate.Name,
+			RefOID: refOID,
 			Reason: "expired archived full transcript generation",
 		})
 	}
 
 	return cleanupItems, warnings, nil
+}
+
+type archivedV2GenerationCandidate struct {
+	Name    string
+	RefName plumbing.ReferenceName
+	RefOID  string
+}
+
+func listArchivedV2GenerationCandidates(
+	ctx context.Context,
+	repo *git.Repository,
+	store *checkpoint.V2GitStore,
+) ([]archivedV2GenerationCandidate, []plumbing.ReferenceName, []string, error) {
+	localNames, err := store.ListArchivedGenerations()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("list local archived generations: %w", err)
+	}
+
+	candidatesByName := make(map[string]archivedV2GenerationCandidate, len(localNames))
+	for _, name := range localNames {
+		refName := plumbing.ReferenceName(paths.V2FullRefPrefix + name)
+		ref, refErr := repo.Reference(refName, true)
+		if refErr != nil {
+			continue
+		}
+		candidatesByName[name] = archivedV2GenerationCandidate{
+			Name:    name,
+			RefName: refName,
+			RefOID:  ref.Hash().String(),
+		}
+	}
+
+	var warnings []string
+	var tempRefs []plumbing.ReferenceName
+	target, targetErr := remote.FetchURL(ctx)
+	if targetErr == nil && target != "" {
+		remoteRefs, remoteErr := listRemoteArchivedV2GenerationRefs(ctx, target)
+		if remoteErr != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to list remote v2 generations: %v", remoteErr))
+		} else {
+			fetchTarget, fetchTargetErr := remote.ResolveFetchTarget(ctx, target)
+			if fetchTargetErr != nil {
+				warnings = append(warnings, fmt.Sprintf("failed to resolve remote for v2 generation fetch: %v", fetchTargetErr))
+			} else {
+				for name, remoteOID := range remoteRefs {
+					if candidate, ok := candidatesByName[name]; ok && candidate.RefOID == remoteOID {
+						continue
+					}
+					tempRef, fetchErr := fetchArchivedV2Generation(ctx, fetchTarget, name)
+					if fetchErr != nil {
+						warnings = append(warnings, fmt.Sprintf("generation %s: failed to fetch remote ref: %v", name, fetchErr))
+						continue
+					}
+					tempRefs = append(tempRefs, tempRef)
+					candidatesByName[name] = archivedV2GenerationCandidate{
+						Name:    name,
+						RefName: tempRef,
+						RefOID:  remoteOID,
+					}
+				}
+			}
+		}
+	}
+
+	names := make([]string, 0, len(candidatesByName))
+	for name := range candidatesByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	candidates := make([]archivedV2GenerationCandidate, 0, len(names))
+	for _, name := range names {
+		candidates = append(candidates, candidatesByName[name])
+	}
+	return candidates, tempRefs, warnings, nil
+}
+
+func listRemoteArchivedV2GenerationRefs(ctx context.Context, target string) (map[string]string, error) {
+	output, err := remote.LsRemote(ctx, target, paths.V2FullRefPrefix+"*")
+	if err != nil {
+		return nil, fmt.Errorf("ls remote v2 generations: %w", err)
+	}
+
+	refs := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		refName := parts[1]
+		suffix := strings.TrimPrefix(refName, paths.V2FullRefPrefix)
+		if suffix == "current" || !checkpoint.GenerationRefPattern.MatchString(suffix) {
+			continue
+		}
+		refs[suffix] = parts[0]
+	}
+	return refs, nil
+}
+
+func fetchArchivedV2Generation(ctx context.Context, fetchTarget, name string) (plumbing.ReferenceName, error) {
+	refName := paths.V2FullRefPrefix + name
+	tempRef := plumbing.ReferenceName("refs/entire-clean-tmp/v2/full/" + name)
+	refSpec := fmt.Sprintf("+%s:%s", refName, tempRef)
+	if output, err := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   fetchTarget,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+		NoFilter: true,
+	}); err != nil {
+		return "", fmt.Errorf("%s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return tempRef, nil
+}
+
+func removeTempRefs(repo *git.Repository, refs []plumbing.ReferenceName) {
+	for _, ref := range refs {
+		_ = repo.Storer.RemoveReference(ref) //nolint:errcheck // cleanup is best-effort
+	}
 }
 
 // V2GenerationRef pairs a generation name with the OID observed at listing time.
@@ -423,16 +551,48 @@ func DeleteV2Generations(ctx context.Context, generations []V2GenerationRef) (de
 		return []string{}, []string{}, nil
 	}
 
+	pushTarget, _, pushTargetErr := remote.PushURL(ctx, "origin")
+
 	for _, gen := range generations {
 		refName := plumbing.ReferenceName(paths.V2FullRefPrefix + gen.Name)
-		if err := DeleteRefCLI(ctx, refName.String(), gen.RefOID); err != nil {
+		localErr := DeleteRefCLI(ctx, refName.String(), gen.RefOID)
+		if errors.Is(localErr, ErrRefNotFound) {
+			localErr = nil
+		}
+		if localErr != nil {
 			failed = append(failed, gen.Name)
 			continue
+		}
+		if pushTargetErr == nil && pushTarget != "" {
+			if remoteErr := deleteRemoteRef(ctx, pushTarget, refName.String(), gen.RefOID); remoteErr != nil {
+				failed = append(failed, gen.Name)
+				continue
+			}
 		}
 		deleted = append(deleted, gen.Name)
 	}
 
 	return deleted, failed, nil
+}
+
+func deleteRemoteRef(ctx context.Context, target, refName, expectedOID string) error {
+	extraArgs := []string{}
+	if expectedOID != "" {
+		extraArgs = append(extraArgs, fmt.Sprintf("--force-with-lease=%s:%s", refName, expectedOID))
+	}
+	result, err := remote.PushWithOptions(ctx, remote.PushOptions{
+		Remote:    target,
+		RefSpecs:  []string{":" + refName},
+		ExtraArgs: extraArgs,
+	})
+	if err != nil {
+		output := strings.TrimSpace(result.Output)
+		if output != "" {
+			return fmt.Errorf("%s: %w", output, err)
+		}
+		return fmt.Errorf("delete remote ref %s: %w", refName, err)
+	}
+	return nil
 }
 
 // ListAllItems returns all Entire items for full cleanup.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/273
<!-- entire-trail-link-end -->

* Preserves original checkpoint created_at during v1 to v2 migration so retention age does not reset to migration/write time.
* Updates v2 generation rotation to compute archive timestamps from checkpoint metadata, with raw transcript timestamps as fallback.
* Updates cleanup to recompute v2 generation checkpoint times before trusting generation.json, fixing old migrated data.
* Lowers the default full transcript generation retention from 60 days to 14 days.
* Adds tests covering migration preservation, rotation timestamps, transcript fallback, cleanup eligibility, and settings defaults.
* Updates `clean --all` to account for remote generation refs as well (based on the retention setting)

```
➜  entiredb git:(test) entire clean --all

Found 7 items to clean:

Archived v2 generations (7):
  0000000000008
  0000000000009
  0000000000010
  0000000000011
  0000000000012
  0000000000013
  0000000000014

✓ Deleted 7 items:

Archived v2 generations (7):
  0000000000008
  0000000000009
  0000000000010
  0000000000011
  0000000000012
  0000000000013
  0000000000014
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retention eligibility for v2 archived transcript generations by switching timestamp sources and reducing the default retention window, which could cause earlier-than-expected cleanup of stored transcripts if timestamp derivation is wrong or metadata is missing.
> 
> **Overview**
> **V2 checkpoint retention now uses the checkpoint’s original creation time instead of git commit time.** `WriteCommittedOptions` adds `CreatedAt`, migration passes v1 `created_at` through, and both v1/v2 committed writers persist `created_at` via a shared helper.
> 
> Generation rotation and cleanup were updated to compute archived generation timestamp ranges by walking checkpoints: prefer v2 `/main` `metadata.json` `created_at`, fall back to parsing `timestamp` fields from raw transcript events, and only fall back to existing `generation.json`/commit history when needed.
> 
> The default `full_transcript_generation_retention_days` was lowered from **60 → 14**, with tests added/updated to cover created-at preservation, timestamp computation fallbacks, and cleanup eligibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a87cd3f5e89ae9981eff16d0e6dd4375ba8f9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->