### PR TITLE
Clean up migration output

### DIFF
--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -65,9 +65,14 @@ func newMigrateCmd() *cobra.Command {
 }
 
 type migrateResult struct {
-	migrated int
-	skipped  int
-	failed   int
+	total                        int
+	migrated                     int
+	skipped                      int
+	failed                       int
+	missingSessions              int
+	compactTranscriptSkipped     int
+	backfilledCompactTranscripts int
+	repaired                     int
 }
 
 func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool) error {
@@ -81,25 +86,46 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 	v1Store := checkpoint.NewGitStore(repo)
 	v2Store := checkpoint.NewV2GitStore(repo, migrateRemoteName)
 	out := cmd.OutOrStdout()
+	progressOut := cmd.ErrOrStderr()
 
-	result, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, out, force)
+	result, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, progressOut, force)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(out, "\nMigration complete: %d migrated, %d skipped, %d failed\n",
-		result.migrated, result.skipped, result.failed)
-	fmt.Fprintln(out)
+	printMigrateCompletion(out, result)
 	fmt.Fprintln(out, "Note: V2 checkpoints are stored as custom refs under refs/entire/checkpoints/v2/*, not as a branch visible in the GitHub UI.")
 	fmt.Fprintf(out, "To inspect pushed v2 checkpoint refs locally, run: git ls-remote %s \"refs/entire/checkpoints/v2/*\"\n", migrateRemoteName)
 	fmt.Fprintln(out, `You may also open a checkpoint's details in the Entire web app and click the "session logs" link to view the log files and metadata.`)
 
 	if result.failed > 0 {
-		fmt.Fprintf(out, "%d checkpoint(s) failed to migrate. Check .entire/logs/ for details.\n", result.failed)
 		return NewSilentError(fmt.Errorf("%d checkpoint(s) failed to migrate", result.failed))
 	}
 
 	return nil
+}
+
+const migrationLogFile = logging.LogsDir + "/entire.log"
+
+func printMigrateCompletion(out io.Writer, result *migrateResult) {
+	if result.total == 0 {
+		fmt.Fprintln(out, "Nothing to migrate: no v1 checkpoints found")
+		fmt.Fprintln(out)
+		return
+	}
+
+	fmt.Fprintf(out, "Migration complete: %d migrated, %d skipped, %d failed\n",
+		result.migrated, result.skipped, result.failed)
+
+	if result.hasLoggedDetails() {
+		fmt.Fprintf(out, "Details for skipped, missing, incomplete, or failed checkpoints were logged to %s.\n", migrationLogFile)
+	}
+
+	fmt.Fprintln(out)
+}
+
+func (r *migrateResult) hasLoggedDetails() bool {
+	return r.skipped > 0 || r.failed > 0 || r.missingSessions > 0 || r.compactTranscriptSkipped > 0
 }
 
 var (
@@ -110,105 +136,128 @@ var (
 
 const migrateRemoteName = "origin"
 
-func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, out io.Writer, force bool) (*migrateResult, error) {
+func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, progressOut io.Writer, force bool) (*migrateResult, error) {
 	v1List, err := v1Store.ListCommitted(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list v1 checkpoints: %w", err)
 	}
 
 	if len(v1List) == 0 {
-		fmt.Fprintln(out, "Nothing to migrate: no v1 checkpoints found")
 		return &migrateResult{}, nil
 	}
 
-	if force {
-		fmt.Fprintln(out, "Force-migrating v1 checkpoints to v2 (overwriting existing)...")
-	} else {
-		fmt.Fprintln(out, "Migrating v1 checkpoints to v2...")
-	}
 	total := len(v1List)
-	result := &migrateResult{}
+	result := &migrateResult{total: total}
+	progress := startProgressBar(progressOut, "Migrating checkpoints", total)
+	defer progress.Finish()
 
-	for i, info := range v1List {
-		prefix := fmt.Sprintf("  [%d/%d] Migrating checkpoint %s...", i+1, total, info.CheckpointID)
+	for _, info := range v1List {
+		outcome, migrateErr := migrateOneCheckpoint(ctx, repo, v1Store, v2Store, info, force)
+		result.missingSessions += outcome.missingSessions
+		result.backfilledCompactTranscripts += outcome.backfilledCompactTranscripts
+		if outcome.compactTranscriptSkipped {
+			result.compactTranscriptSkipped++
+		}
+		if outcome.repaired {
+			result.repaired++
+		}
 
-		if migrateErr := migrateOneCheckpoint(ctx, repo, v1Store, v2Store, info, out, prefix, force); migrateErr != nil {
+		if migrateErr != nil {
 			switch {
 			case errors.Is(migrateErr, errAlreadyMigrated):
-				fmt.Fprintf(out, "%s skipped (already in v2)\n", prefix)
+				logCheckpointMigrationSkip(ctx, info.CheckpointID, "already in v2", migrateErr)
 				result.skipped++
 			case errors.Is(migrateErr, errTranscriptNotGeneratable):
-				fmt.Fprintf(out, "%s in v2, but %s\n", prefix, migrateErr.Error())
+				logCheckpointMigrationSkip(ctx, info.CheckpointID, "transcript.jsonl could not be generated", migrateErr)
 				result.skipped++
 			case errors.Is(migrateErr, errNoMigratableSessions):
-				fmt.Fprintf(out, "%s skipped (%s)\n", prefix, migrateErr.Error())
+				logCheckpointMigrationSkip(ctx, info.CheckpointID, "no migratable v1 sessions", migrateErr)
 				result.skipped++
 			default:
-				fmt.Fprintf(out, "%s failed\n", prefix)
 				logging.Error(ctx, "checkpoint migration failed",
 					slog.String("checkpoint_id", string(info.CheckpointID)),
 					slog.String("error", migrateErr.Error()),
 				)
 				result.failed++
 			}
+			progress.Increment()
 			continue
 		}
 
 		result.migrated++
+		progress.Increment()
 	}
 
 	return result, nil
 }
 
-func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, out io.Writer, prefix string, force bool) error {
+func logCheckpointMigrationSkip(ctx context.Context, checkpointID id.CheckpointID, reason string, err error) {
+	logging.Info(ctx, "checkpoint migration skipped",
+		slog.String("checkpoint_id", string(checkpointID)),
+		slog.String("reason", reason),
+		slog.String("error", err.Error()),
+	)
+}
+
+type migrateCheckpointOutcome struct {
+	missingSessions              int
+	compactTranscriptSkipped     bool
+	backfilledCompactTranscripts int
+	repaired                     bool
+}
+
+func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, force bool) (migrateCheckpointOutcome, error) {
+	var outcome migrateCheckpointOutcome
+
 	existing, err := v2Store.ReadCommitted(ctx, info.CheckpointID)
 	if err != nil {
-		return fmt.Errorf("failed to check v2 for checkpoint %s: %w", info.CheckpointID, err)
+		return outcome, fmt.Errorf("failed to check v2 for checkpoint %s: %w", info.CheckpointID, err)
 	}
 
 	// Already in v2 — when not forcing, check if any aspect of sessions are missing and backfill
 	if existing != nil && !force {
 		repaired, repairErr := repairPartialV2Checkpoint(ctx, v1Store, v2Store, info, existing)
 		if repairErr != nil {
-			return repairErr
+			return outcome, repairErr
 		}
+		outcome.repaired = repaired
 
 		currentV2, readCurrentErr := v2Store.ReadCommitted(ctx, info.CheckpointID)
 		if readCurrentErr != nil {
-			return fmt.Errorf("failed to re-read v2 checkpoint %s: %w", info.CheckpointID, readCurrentErr)
+			return outcome, fmt.Errorf("failed to re-read v2 checkpoint %s: %w", info.CheckpointID, readCurrentErr)
 		}
 		if currentV2 == nil {
-			return fmt.Errorf("v2 checkpoint %s disappeared during migration", info.CheckpointID)
+			return outcome, fmt.Errorf("v2 checkpoint %s disappeared during migration", info.CheckpointID)
 		}
 
 		// Clean up v1-named transcript files (full.jsonl, content_hash.txt) that older
 		// CLI versions may have written to /full/current before the rename to raw_transcript.
 		cleanupV1TranscriptFiles(ctx, repo, v2Store, info.CheckpointID, len(currentV2.Sessions))
 
-		backfillErr := backfillCompactTranscripts(ctx, v1Store, v2Store, info, currentV2, out, prefix)
+		backfilled, backfillErr := backfillCompactTranscripts(ctx, v1Store, v2Store, info, currentV2)
+		outcome.backfilledCompactTranscripts = backfilled
 		if errors.Is(backfillErr, errAlreadyMigrated) && repaired {
-			fmt.Fprintf(out, "%s repaired partial v2 checkpoint state\n", prefix)
-			return nil
+			return outcome, nil
 		}
 		if errors.Is(backfillErr, errTranscriptNotGeneratable) && repaired {
-			fmt.Fprintf(out, "%s repaired partial v2 checkpoint state (compact transcript not generated)\n", prefix)
-			return nil
+			outcome.compactTranscriptSkipped = true
+			return outcome, nil
 		}
-		return backfillErr
+		return outcome, backfillErr
 	}
 
 	if existing != nil && force {
 		if pruneErr := pruneV2CheckpointForForce(ctx, repo, v2Store, info.CheckpointID); pruneErr != nil {
-			return fmt.Errorf("failed to reset existing v2 checkpoint %s before force migration: %w", info.CheckpointID, pruneErr)
+			return outcome, fmt.Errorf("failed to reset existing v2 checkpoint %s before force migration: %w", info.CheckpointID, pruneErr)
 		}
 	}
 
 	summary, err := v1Store.ReadCommitted(ctx, info.CheckpointID)
 	if err != nil {
-		return fmt.Errorf("failed to read v1 summary: %w", err)
+		return outcome, fmt.Errorf("failed to read v1 summary: %w", err)
 	}
 	if summary == nil {
-		return fmt.Errorf("v1 checkpoint %s has no summary", info.CheckpointID)
+		return outcome, fmt.Errorf("v1 checkpoint %s has no summary", info.CheckpointID)
 	}
 
 	compactFailed := false
@@ -218,13 +267,14 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 	v1ToV2SessionIdx := make(map[int]int, len(summary.Sessions))
 
 	for sessionIdx := range len(summary.Sessions) {
-		content, skipped, readErr := readV1SessionForMigration(ctx, out, prefix, v1Store, info.CheckpointID, sessionIdx)
+		content, skipped, readErr := readV1SessionForMigration(ctx, v1Store, info.CheckpointID, sessionIdx)
 		if skipped {
 			skippedMissingSessions++
+			outcome.missingSessions++
 			continue
 		}
 		if readErr != nil {
-			return fmt.Errorf("failed to read v1 session %d: %w", sessionIdx, readErr)
+			return outcome, fmt.Errorf("failed to read v1 session %d: %w", sessionIdx, readErr)
 		}
 		if content.Metadata.IsTask {
 			shouldCopyTaskMetadata = true
@@ -242,14 +292,14 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 
 		v2SessionIdx, writeErr := v2Store.WriteCommittedWithSessionIndex(ctx, opts)
 		if writeErr != nil {
-			return fmt.Errorf("failed to write v2 session %d: %w", sessionIdx, writeErr)
+			return outcome, fmt.Errorf("failed to write v2 session %d: %w", sessionIdx, writeErr)
 		}
 		v1ToV2SessionIdx[sessionIdx] = v2SessionIdx
 		migratedSessions++
 	}
 
 	if migratedSessions == 0 {
-		return fmt.Errorf("%w: v1 metadata lists %d session(s), but no transcript/session content exists for any of them", errNoMigratableSessions, len(summary.Sessions))
+		return outcome, fmt.Errorf("%w: v1 metadata lists %d session(s), but no transcript/session content exists for any of them", errNoMigratableSessions, len(summary.Sessions))
 	}
 
 	// Copy task metadata trees from v1 to v2 /full/current
@@ -262,25 +312,28 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 		}
 	}
 
-	switch {
-	case compactFailed && skippedMissingSessions > 0:
-		fmt.Fprintf(out, "%s done (compact transcript not generated; skipped %d session(s) with missing transcript/session content)\n", prefix, skippedMissingSessions)
-	case compactFailed:
-		fmt.Fprintf(out, "%s done (compact transcript not generated)\n", prefix)
-	case skippedMissingSessions > 0:
-		fmt.Fprintf(out, "%s done (skipped %d session(s) with missing transcript/session content)\n", prefix, skippedMissingSessions)
-	default:
-		fmt.Fprintf(out, "%s done\n", prefix)
+	if compactFailed {
+		outcome.compactTranscriptSkipped = true
+		logging.Warn(ctx, "compact transcript not generated during checkpoint migration",
+			slog.String("checkpoint_id", string(info.CheckpointID)),
+			slog.Int("migrated_sessions", migratedSessions),
+		)
+	}
+	if skippedMissingSessions > 0 {
+		logging.Warn(ctx, "checkpoint migration skipped v1 sessions with missing transcript/session content",
+			slog.String("checkpoint_id", string(info.CheckpointID)),
+			slog.Int("missing_sessions", skippedMissingSessions),
+		)
 	}
 
-	return nil
+	return outcome, nil
 }
 
-func readV1SessionForMigration(ctx context.Context, out io.Writer, prefix string, v1Store *checkpoint.GitStore, checkpointID id.CheckpointID, sessionIdx int) (*checkpoint.SessionContent, bool, error) {
+func readV1SessionForMigration(ctx context.Context, v1Store *checkpoint.GitStore, checkpointID id.CheckpointID, sessionIdx int) (*checkpoint.SessionContent, bool, error) {
 	content, readErr := v1Store.ReadSessionContent(ctx, checkpointID, sessionIdx)
 	if readErr != nil {
 		if errors.Is(readErr, checkpoint.ErrNoTranscript) || errors.Is(readErr, checkpoint.ErrCheckpointNotFound) {
-			warnMissingV1Session(ctx, out, prefix, checkpointID, sessionIdx, readErr)
+			warnMissingV1Session(ctx, checkpointID, sessionIdx, readErr)
 			return nil, true, nil
 		}
 		return nil, false, fmt.Errorf("read v1 session content: %w", readErr)
@@ -288,8 +341,7 @@ func readV1SessionForMigration(ctx context.Context, out io.Writer, prefix string
 	return content, false, nil
 }
 
-func warnMissingV1Session(ctx context.Context, out io.Writer, prefix string, checkpointID id.CheckpointID, sessionIdx int, err error) {
-	fmt.Fprintf(out, "%s warning: skipping v1 session %d because checkpoint metadata lists it, but no transcript/session content exists for that session\n", prefix, sessionIdx)
+func warnMissingV1Session(ctx context.Context, checkpointID id.CheckpointID, sessionIdx int, err error) {
 	logging.Warn(ctx, "skipping v1 session with missing transcript during checkpoint migration",
 		slog.String("checkpoint_id", checkpointID.String()),
 		slog.Int("session_index", sessionIdx),
@@ -443,7 +495,7 @@ func hasFullSessionArtifacts(v2Store *checkpoint.V2GitStore, cpID id.CheckpointI
 // backfillCompactTranscripts checks sessions in an already-migrated v2 checkpoint
 // for missing transcript.jsonl and attempts to generate + write them from v1 data.
 // Returns errAlreadyMigrated if all sessions already have compact transcripts.
-func backfillCompactTranscripts(ctx context.Context, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, v2Summary *checkpoint.CheckpointSummary, out io.Writer, prefix string) error {
+func backfillCompactTranscripts(ctx context.Context, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, v2Summary *checkpoint.CheckpointSummary) (int, error) {
 	// Find sessions missing transcript.jsonl
 	var needsBackfill []int
 	for i, session := range v2Summary.Sessions {
@@ -453,7 +505,7 @@ func backfillCompactTranscripts(ctx context.Context, v1Store *checkpoint.GitStor
 	}
 
 	if len(needsBackfill) == 0 {
-		return errAlreadyMigrated
+		return 0, errAlreadyMigrated
 	}
 
 	backfilled := 0
@@ -506,14 +558,12 @@ func backfillCompactTranscripts(ctx context.Context, v1Store *checkpoint.GitStor
 
 	if backfilled == 0 {
 		if lastAgent != "" {
-			return fmt.Errorf("%w: agent %q", errTranscriptNotGeneratable, lastAgent)
+			return 0, fmt.Errorf("%w: agent %q", errTranscriptNotGeneratable, lastAgent)
 		}
-		return fmt.Errorf("%w: no agent type in metadata", errTranscriptNotGeneratable)
+		return 0, fmt.Errorf("%w: no agent type in metadata", errTranscriptNotGeneratable)
 	}
 
-	fmt.Fprintf(out, "%s added transcript.jsonl for %d session(s)\n", prefix, backfilled)
-
-	return nil
+	return backfilled, nil
 }
 
 func buildMigrateWriteOpts(content *checkpoint.SessionContent, info checkpoint.CommittedInfo, combinedAttribution *checkpoint.InitialAttribution) checkpoint.WriteCommittedOptions {

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -213,7 +213,7 @@ func TestMigrateCheckpointsV2_ForceOverwritesExisting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, result3.migrated)
 	assert.Equal(t, 0, result3.skipped)
-	assert.Contains(t, stdout.String(), "Force-migrating")
+	assert.Empty(t, stdout.String())
 
 	// Verify checkpoint still readable in v2
 	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
@@ -323,11 +323,11 @@ func TestMigrateCheckpointsV2_SkipsV1SessionWithoutTranscript(t *testing.T) {
 	assert.Equal(t, 1, result.migrated)
 	assert.Equal(t, 0, result.skipped)
 	assert.Equal(t, 0, result.failed)
+	assert.Equal(t, 1, result.missingSessions)
 
 	output := stdout.String()
-	assert.Contains(t, output, "warning: skipping v1 session 1")
-	assert.Contains(t, output, "no transcript/session content exists for that session")
-	assert.Contains(t, output, "done (compact transcript not generated; skipped 1 session(s) with missing transcript/session content)")
+	assert.NotContains(t, output, "warning: skipping v1 session 1")
+	assert.NotContains(t, output, "Migrating checkpoint")
 
 	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, readErr)
@@ -354,10 +354,11 @@ func TestMigrateCheckpointsV2_SkipsV1SessionWithMissingDirectory(t *testing.T) {
 	assert.Equal(t, 1, result.migrated)
 	assert.Equal(t, 0, result.skipped)
 	assert.Equal(t, 0, result.failed)
+	assert.Equal(t, 1, result.missingSessions)
 
 	output := stdout.String()
-	assert.Contains(t, output, "warning: skipping v1 session 1")
-	assert.Contains(t, output, "skipped 1 session(s) with missing transcript/session content")
+	assert.NotContains(t, output, "warning: skipping v1 session 1")
+	assert.NotContains(t, output, "skipped 1 session(s) with missing transcript/session content")
 
 	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, readErr)
@@ -450,10 +451,11 @@ func TestMigrateCheckpointsV2_SkipsCheckpointWhenAllV1SessionsMissingTranscript(
 	assert.Equal(t, 0, result.migrated)
 	assert.Equal(t, 1, result.skipped)
 	assert.Equal(t, 0, result.failed)
+	assert.Equal(t, 1, result.missingSessions)
 
 	output := stdout.String()
-	assert.Contains(t, output, "warning: skipping v1 session 0")
-	assert.Contains(t, output, "skipped (no migratable v1 sessions")
+	assert.NotContains(t, output, "warning: skipping v1 session 0")
+	assert.NotContains(t, output, "skipped (no migratable v1 sessions")
 
 	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, readErr)
@@ -501,7 +503,8 @@ func TestMigrateCheckpointsV2_ForcePrunesSkippedV2Sessions(t *testing.T) {
 	require.NoError(t, rerunErr)
 	assert.Equal(t, 1, result2.migrated)
 	assert.Equal(t, 0, result2.skipped)
-	assert.Contains(t, stdout.String(), "warning: skipping v1 session 1")
+	assert.Equal(t, 1, result2.missingSessions)
+	assert.NotContains(t, stdout.String(), "warning: skipping v1 session 1")
 
 	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, readErr)
@@ -549,7 +552,8 @@ func TestMigrateCheckpointsV2_ForcePruneRemovesEmptyShardWhenAllSessionsSkipped(
 	require.NoError(t, rerunErr)
 	assert.Equal(t, 0, result2.migrated)
 	assert.Equal(t, 1, result2.skipped)
-	assert.Contains(t, stdout.String(), "no migratable v1 sessions")
+	assert.Equal(t, 1, result2.missingSessions)
+	assert.NotContains(t, stdout.String(), "no migratable v1 sessions")
 
 	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, readErr)
@@ -630,7 +634,37 @@ func TestMigrateCheckpointsV2_NoV1Branch(t *testing.T) {
 	result, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.migrated)
-	assert.Contains(t, stdout.String(), "Nothing to migrate")
+	assert.Empty(t, stdout.String())
+}
+
+func TestPrintMigrateCompletion_LogPathForSkippedOrMissing(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	printMigrateCompletion(&stdout, &migrateResult{
+		total:           2,
+		migrated:        1,
+		skipped:         1,
+		missingSessions: 1,
+	})
+
+	output := stdout.String()
+	assert.Contains(t, output, "Migration complete: 1 migrated, 1 skipped, 0 failed")
+	assert.Contains(t, output, ".entire/logs/entire.log")
+}
+
+func TestPrintMigrateCompletion_CleanRunOmitsLogPath(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	printMigrateCompletion(&stdout, &migrateResult{
+		total:    1,
+		migrated: 1,
+	})
+
+	output := stdout.String()
+	assert.Contains(t, output, "Migration complete: 1 migrated, 0 skipped, 0 failed")
+	assert.NotContains(t, output, ".entire/logs/entire.log")
 }
 
 func TestMigrateCmd_InvalidFlag(t *testing.T) {
@@ -666,7 +700,8 @@ func TestMigrateCheckpointsV2_CompactionSkipped(t *testing.T) {
 	result, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated)
-	assert.Contains(t, stdout.String(), "compact transcript not generated")
+	assert.Equal(t, 1, result.compactTranscriptSkipped)
+	assert.Empty(t, stdout.String())
 }
 
 func TestMigrateCheckpointsV2_TaskCheckpoint(t *testing.T) {
@@ -785,7 +820,8 @@ func TestMigrateCheckpointsV2_BackfillCompactTranscript(t *testing.T) {
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated, "backfill should count as migrated")
 	assert.Equal(t, 0, result.skipped)
-	assert.Contains(t, stdout.String(), "added transcript.jsonl")
+	assert.Equal(t, 1, result.backfilledCompactTranscripts)
+	assert.Empty(t, stdout.String())
 
 	// Verify transcript.jsonl now exists
 	summary2, err := v2Store.ReadCommitted(context.Background(), cpID)
@@ -887,7 +923,8 @@ func TestMigrateCheckpointsV2_RepairsMissingFullTranscriptBeforeBackfill(t *test
 	require.NoError(t, rerunErr)
 	assert.Equal(t, 1, result2.migrated)
 	assert.Equal(t, 0, result2.failed)
-	assert.Contains(t, rerun.String(), "repaired partial v2 checkpoint state")
+	assert.Equal(t, 1, result2.repaired)
+	assert.Empty(t, rerun.String())
 
 	content, readErr := v2Store.ReadSessionContent(context.Background(), cpID, 0)
 	require.NoError(t, readErr)

--- a/cmd/entire/cli/progress.go
+++ b/cmd/entire/cli/progress.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
@@ -72,4 +73,67 @@ func startSpinner(w io.Writer, msg string) func(suffix string) {
 			fmt.Fprintln(w, suffix)
 		}
 	}
+}
+
+type progressBar struct {
+	w       io.Writer
+	label   string
+	total   int
+	current int
+	width   int
+	enabled bool
+}
+
+func startProgressBar(w io.Writer, label string, total int) *progressBar {
+	p := &progressBar{
+		w:       w,
+		label:   label,
+		total:   total,
+		width:   24,
+		enabled: total > 0 && interactive.IsTerminalWriter(w),
+	}
+	if !p.enabled {
+		return p
+	}
+
+	counter := fmt.Sprintf(" %d/%d (100%%)", total, total)
+	available := getTerminalWidth(w) - len(label) - len(counter) - len(" []")
+	p.width = min(max(available, 10), 32)
+	p.render()
+	return p
+}
+
+func (p *progressBar) Increment() {
+	p.current++
+	if p.current > p.total {
+		p.current = p.total
+	}
+	p.render()
+}
+
+func (p *progressBar) Finish() {
+	if !p.enabled {
+		return
+	}
+	fmt.Fprint(p.w, "\r\033[K")
+}
+
+func (p *progressBar) render() {
+	if !p.enabled {
+		return
+	}
+
+	filled := 0
+	percent := 0
+	if p.total > 0 {
+		filled = p.current * p.width / p.total
+		percent = p.current * 100 / p.total
+	}
+	if p.current >= p.total {
+		filled = p.width
+		percent = 100
+	}
+
+	bar := strings.Repeat("#", filled) + strings.Repeat("-", p.width-filled)
+	fmt.Fprintf(p.w, "\r%s [%s] %d/%d (%d%%)", p.label, bar, p.current, p.total, percent)
 }


### PR DESCRIPTION
Cleans up the migration output such that it's a prettier progress bar rather than a long list of logged checkpoints. It prints out the # of checkpoints that were migrated, skipped, or failed at the end (and mentions where to find more info if needed in the logs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly changes user-facing output and observability for v1→v2 checkpoint migration, but it refactors migration control flow and return values (e.g., backfill/repair outcomes) which could subtly affect migration counting and error handling.
> 
> **Overview**
> Refactors v1→v2 checkpoint migration output to be *quiet by default*: migration now renders a terminal progress bar (to stderr) and prints only a final completion summary, with skip/missing/compaction/backfill/repair details written to `.entire/logs/entire.log`.
> 
> Migration now tracks richer results (`missingSessions`, `compactTranscriptSkipped`, `backfilledCompactTranscripts`, `repaired`) and converts previously printed per-checkpoint warnings/notes into structured log entries; `backfillCompactTranscripts` also returns a backfilled count instead of printing output.
> 
> Updates tests to assert on the new result counters and the absence/presence of stdout text, and adds `printMigrateCompletion` coverage for when log-path guidance should be shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b4404bc7f695a84c5cb2efff5a759548d790f56. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->