### PR TITLE
Fix v2 checkpoint migration generation packing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -458,6 +458,8 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 - `manual_commit_logs.go` - Session log retrieval and session listing
 - `manual_commit_hooks.go` - Git hook handlers (prepare-commit-msg, post-commit, post-rewrite, pre-push)
 - `manual_commit_reset.go` - Shadow branch reset/cleanup functionality
+- `cleanup.go` - Cleanup discovery/deletion, including archived v2 generation retention
+- `generation_repair.go` - Archived v2 generation metadata repair from raw transcript timestamps
 - `session_state.go` - Package-level session state functions (`LoadSessionState`, `SaveSessionState`, `ListSessionStates`, `FindMostRecentSession`)
 - `hooks.go` - Git hook installation
 

--- a/cmd/entire/cli/checkpoint/v2_generation.go
+++ b/cmd/entire/cli/checkpoint/v2_generation.go
@@ -203,6 +203,44 @@ func (s *V2GitStore) ComputeGenerationCheckpointTimestamps(rootTreeHash plumbing
 	return gen, found, nil
 }
 
+// ComputeGenerationRawTranscriptTimestamps derives timestamps from raw
+// transcripts in the checkpoints present in a /full/* tree.
+func (s *V2GitStore) ComputeGenerationRawTranscriptTimestamps(rootTreeHash plumbing.Hash) (GenerationMetadata, bool, error) {
+	if rootTreeHash == plumbing.ZeroHash {
+		return GenerationMetadata{}, false, nil
+	}
+
+	rootTree, err := s.repo.TreeObject(rootTreeHash)
+	if err != nil {
+		return GenerationMetadata{}, false, fmt.Errorf("failed to read generation tree: %w", err)
+	}
+
+	var gen GenerationMetadata
+	found := false
+	missingCheckpointTimestamp := false
+	err = WalkCheckpointShards(s.repo, rootTree, func(_ id.CheckpointID, cpTreeHash plumbing.Hash) error {
+		cpTree, treeErr := s.repo.TreeObject(cpTreeHash)
+		if treeErr != nil {
+			missingCheckpointTimestamp = true
+			return nil //nolint:nilerr // Skip unreadable checkpoint trees and fall back to generation.json.
+		}
+		if cpGen, ok := checkpointTimestampRangeFromFullTree(cpTree); ok {
+			mergeGenerationRange(&gen, &found, cpGen)
+			return nil
+		}
+		missingCheckpointTimestamp = true
+		return nil
+	})
+	if err != nil {
+		return GenerationMetadata{}, false, err
+	}
+	if missingCheckpointTimestamp {
+		return GenerationMetadata{}, false, nil
+	}
+
+	return gen, found, nil
+}
+
 // computeGenerationTimestamps derives timestamps for a generation being archived.
 // It uses checkpoint metadata/transcript timestamps rather than git commit times
 // so migration and ref-repair commits don't reset retention age.

--- a/cmd/entire/cli/checkpoint/v2_generation.go
+++ b/cmd/entire/cli/checkpoint/v2_generation.go
@@ -156,6 +156,25 @@ func (s *V2GitStore) AddGenerationJSONToTree(rootTreeHash plumbing.Hash, gen Gen
 // present in a /full/* tree. It prefers created_at from v2 /main metadata and
 // falls back to top-level transcript event timestamps for older or partial v2 data.
 func (s *V2GitStore) ComputeGenerationCheckpointTimestamps(rootTreeHash plumbing.Hash) (GenerationMetadata, bool, error) {
+	mainTree, mainTreeErr := s.v2MainTree()
+	if mainTreeErr != nil {
+		mainTree = nil
+	}
+	return s.computeGenerationTimestampsFromTrees(rootTreeHash, mainTree)
+}
+
+// ComputeGenerationRawTranscriptTimestamps derives timestamps from raw
+// transcripts in the checkpoints present in a /full/* tree.
+func (s *V2GitStore) ComputeGenerationRawTranscriptTimestamps(rootTreeHash plumbing.Hash) (GenerationMetadata, bool, error) {
+	return s.computeGenerationTimestampsFromTrees(rootTreeHash, nil)
+}
+
+// computeGenerationTimestampsFromTrees walks every checkpoint in rootTreeHash
+// and aggregates per-checkpoint timestamps. When mainTree is non-nil, /main
+// metadata.json is consulted before falling back to the raw transcript inside
+// the checkpoint's full-tree. Returns found=false when any checkpoint cannot
+// produce a timestamp, signaling callers to fall back to generation.json.
+func (s *V2GitStore) computeGenerationTimestampsFromTrees(rootTreeHash plumbing.Hash, mainTree *object.Tree) (GenerationMetadata, bool, error) {
 	if rootTreeHash == plumbing.ZeroHash {
 		return GenerationMetadata{}, false, nil
 	}
@@ -163,11 +182,6 @@ func (s *V2GitStore) ComputeGenerationCheckpointTimestamps(rootTreeHash plumbing
 	rootTree, err := s.repo.TreeObject(rootTreeHash)
 	if err != nil {
 		return GenerationMetadata{}, false, fmt.Errorf("failed to read generation tree: %w", err)
-	}
-
-	mainTree, mainTreeErr := s.v2MainTree()
-	if mainTreeErr != nil {
-		mainTree = nil
 	}
 
 	var gen GenerationMetadata
@@ -181,44 +195,6 @@ func (s *V2GitStore) ComputeGenerationCheckpointTimestamps(rootTreeHash plumbing
 			}
 		}
 
-		cpTree, treeErr := s.repo.TreeObject(cpTreeHash)
-		if treeErr != nil {
-			missingCheckpointTimestamp = true
-			return nil //nolint:nilerr // Skip unreadable checkpoint trees and fall back to generation.json.
-		}
-		if cpGen, ok := checkpointTimestampRangeFromFullTree(cpTree); ok {
-			mergeGenerationRange(&gen, &found, cpGen)
-			return nil
-		}
-		missingCheckpointTimestamp = true
-		return nil
-	})
-	if err != nil {
-		return GenerationMetadata{}, false, err
-	}
-	if missingCheckpointTimestamp {
-		return GenerationMetadata{}, false, nil
-	}
-
-	return gen, found, nil
-}
-
-// ComputeGenerationRawTranscriptTimestamps derives timestamps from raw
-// transcripts in the checkpoints present in a /full/* tree.
-func (s *V2GitStore) ComputeGenerationRawTranscriptTimestamps(rootTreeHash plumbing.Hash) (GenerationMetadata, bool, error) {
-	if rootTreeHash == plumbing.ZeroHash {
-		return GenerationMetadata{}, false, nil
-	}
-
-	rootTree, err := s.repo.TreeObject(rootTreeHash)
-	if err != nil {
-		return GenerationMetadata{}, false, fmt.Errorf("failed to read generation tree: %w", err)
-	}
-
-	var gen GenerationMetadata
-	found := false
-	missingCheckpointTimestamp := false
-	err = WalkCheckpointShards(s.repo, rootTree, func(_ id.CheckpointID, cpTreeHash plumbing.Hash) error {
 		cpTree, treeErr := s.repo.TreeObject(cpTreeHash)
 		if treeErr != nil {
 			missingCheckpointTimestamp = true

--- a/cmd/entire/cli/checkpoint/v2_generation.go
+++ b/cmd/entire/cli/checkpoint/v2_generation.go
@@ -167,7 +167,8 @@ func (s *V2GitStore) ComputeGenerationCheckpointTimestamps(rootTreeHash plumbing
 // and aggregates per-checkpoint timestamps. When mainTree is non-nil, /main
 // metadata.json is consulted before falling back to the raw transcript inside
 // the checkpoint's full-tree. Returns found=false when any checkpoint cannot
-// produce a timestamp, signaling callers to fall back to generation.json.
+// produce a timestamp; callers decide their own fallback (e.g. read existing
+// generation.json, recompute from in-memory data, or surface an error).
 func (s *V2GitStore) ComputeGenerationTimestampsFromTrees(rootTreeHash plumbing.Hash, mainTree *object.Tree) (GenerationMetadata, bool, error) {
 	if rootTreeHash == plumbing.ZeroHash {
 		return GenerationMetadata{}, false, nil

--- a/cmd/entire/cli/checkpoint/v2_generation.go
+++ b/cmd/entire/cli/checkpoint/v2_generation.go
@@ -332,7 +332,7 @@ func (s *V2GitStore) checkpointTimestampRangeFromMain(mainTree *object.Tree, cpI
 		if err := json.Unmarshal([]byte(metadataContent), &metadata); err != nil || metadata.CreatedAt.IsZero() {
 			continue
 		}
-		mergeGenerationTime(&gen, &found, metadata.CreatedAt.UTC())
+		MergeGenerationTime(&gen, &found, metadata.CreatedAt.UTC())
 	}
 	return gen, found
 }
@@ -375,7 +375,7 @@ func timestampRangeFromTranscript(transcript []byte) (GenerationMetadata, bool) 
 			}
 			if jsonErr := json.Unmarshal(trimmed, &event); jsonErr == nil && event.Timestamp != "" {
 				if ts, parseErr := time.Parse(time.RFC3339Nano, event.Timestamp); parseErr == nil {
-					mergeGenerationTime(&gen, &found, ts.UTC())
+					MergeGenerationTime(&gen, &found, ts.UTC())
 				}
 			}
 		}
@@ -391,11 +391,13 @@ func timestampRangeFromTranscript(transcript []byte) (GenerationMetadata, bool) 
 }
 
 func mergeGenerationRange(dst *GenerationMetadata, found *bool, src GenerationMetadata) {
-	mergeGenerationTime(dst, found, src.OldestCheckpointAt)
-	mergeGenerationTime(dst, found, src.NewestCheckpointAt)
+	MergeGenerationTime(dst, found, src.OldestCheckpointAt)
+	MergeGenerationTime(dst, found, src.NewestCheckpointAt)
 }
 
-func mergeGenerationTime(gen *GenerationMetadata, found *bool, ts time.Time) {
+// MergeGenerationTime expands the generation timestamp envelope to include ts.
+// The found flag is set the first time a non-zero timestamp is observed.
+func MergeGenerationTime(gen *GenerationMetadata, found *bool, ts time.Time) {
 	if ts.IsZero() {
 		return
 	}
@@ -449,9 +451,9 @@ func (s *V2GitStore) ListArchivedGenerations() ([]string, error) {
 	return archived, nil
 }
 
-// nextGenerationNumber returns the next sequential generation number for archiving.
+// NextGenerationNumber returns the next sequential generation number for archiving.
 // Scans existing archived refs and returns max+1. Returns 1 if no archives exist.
-func (s *V2GitStore) nextGenerationNumber() (int, error) {
+func (s *V2GitStore) NextGenerationNumber() (int, error) {
 	archived, err := s.ListArchivedGenerations()
 	if err != nil {
 		return 0, err
@@ -499,7 +501,7 @@ func (s *V2GitStore) rotateGeneration(ctx context.Context) error {
 		return fmt.Errorf("rotation: failed to read /full/current ref: %w", err)
 	}
 
-	archiveNumber, err := s.nextGenerationNumber()
+	archiveNumber, err := s.NextGenerationNumber()
 	if err != nil {
 		return fmt.Errorf("rotation: failed to determine next generation number: %w", err)
 	}

--- a/cmd/entire/cli/checkpoint/v2_generation.go
+++ b/cmd/entire/cli/checkpoint/v2_generation.go
@@ -160,21 +160,15 @@ func (s *V2GitStore) ComputeGenerationCheckpointTimestamps(rootTreeHash plumbing
 	if mainTreeErr != nil {
 		mainTree = nil
 	}
-	return s.computeGenerationTimestampsFromTrees(rootTreeHash, mainTree)
+	return s.ComputeGenerationTimestampsFromTrees(rootTreeHash, mainTree)
 }
 
-// ComputeGenerationRawTranscriptTimestamps derives timestamps from raw
-// transcripts in the checkpoints present in a /full/* tree.
-func (s *V2GitStore) ComputeGenerationRawTranscriptTimestamps(rootTreeHash plumbing.Hash) (GenerationMetadata, bool, error) {
-	return s.computeGenerationTimestampsFromTrees(rootTreeHash, nil)
-}
-
-// computeGenerationTimestampsFromTrees walks every checkpoint in rootTreeHash
+// ComputeGenerationTimestampsFromTrees walks every checkpoint in rootTreeHash
 // and aggregates per-checkpoint timestamps. When mainTree is non-nil, /main
 // metadata.json is consulted before falling back to the raw transcript inside
 // the checkpoint's full-tree. Returns found=false when any checkpoint cannot
 // produce a timestamp, signaling callers to fall back to generation.json.
-func (s *V2GitStore) computeGenerationTimestampsFromTrees(rootTreeHash plumbing.Hash, mainTree *object.Tree) (GenerationMetadata, bool, error) {
+func (s *V2GitStore) ComputeGenerationTimestampsFromTrees(rootTreeHash plumbing.Hash, mainTree *object.Tree) (GenerationMetadata, bool, error) {
 	if rootTreeHash == plumbing.ZeroHash {
 		return GenerationMetadata{}, false, nil
 	}

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -504,7 +504,7 @@ func TestComputeGenerationCheckpointTimestamps_FallsBackToRawTranscript(t *testi
 	assert.True(t, gen.NewestCheckpointAt.Equal(newest))
 }
 
-func TestComputeGenerationRawTranscriptTimestamps_IgnoresMainMetadata(t *testing.T) {
+func TestComputeGenerationTimestampsFromTrees_IgnoresMainMetadataWhenNil(t *testing.T) {
 	t.Parallel()
 	repo := initTestRepo(t)
 	store := NewV2GitStore(repo, "origin")
@@ -542,7 +542,7 @@ func TestComputeGenerationRawTranscriptTimestamps_IgnoresMainMetadata(t *testing
 	})
 	require.NoError(t, err)
 
-	gen, ok, err := store.ComputeGenerationRawTranscriptTimestamps(rootTreeHash)
+	gen, ok, err := store.ComputeGenerationTimestampsFromTrees(rootTreeHash, nil)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.True(t, gen.OldestCheckpointAt.Equal(rawOldest))

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -349,7 +349,7 @@ func TestNextGenerationNumber_NoArchives(t *testing.T) {
 	repo := initTestRepo(t)
 	store := NewV2GitStore(repo, "origin")
 
-	next, err := store.nextGenerationNumber()
+	next, err := store.NextGenerationNumber()
 	require.NoError(t, err)
 	assert.Equal(t, 1, next)
 }
@@ -362,7 +362,7 @@ func TestNextGenerationNumber_WithExisting(t *testing.T) {
 	createArchivedRef(t, repo, 1)
 	createArchivedRef(t, repo, 2)
 
-	next, err := store.nextGenerationNumber()
+	next, err := store.NextGenerationNumber()
 	require.NoError(t, err)
 	assert.Equal(t, 3, next)
 }

--- a/cmd/entire/cli/checkpoint/v2_generation_test.go
+++ b/cmd/entire/cli/checkpoint/v2_generation_test.go
@@ -504,6 +504,51 @@ func TestComputeGenerationCheckpointTimestamps_FallsBackToRawTranscript(t *testi
 	assert.True(t, gen.NewestCheckpointAt.Equal(newest))
 }
 
+func TestComputeGenerationRawTranscriptTimestamps_IgnoresMainMetadata(t *testing.T) {
+	t.Parallel()
+	repo := initTestRepo(t)
+	store := NewV2GitStore(repo, "origin")
+
+	cpID := id.MustCheckpointID("aabbccddeeff")
+	mainCreatedAt := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	err := store.WriteCommitted(context.Background(), WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-main-created-at",
+		CreatedAt:    mainCreatedAt,
+		Strategy:     "manual-commit",
+		Agent:        agent.AgentTypeClaudeCode,
+		Transcript:   redact.AlreadyRedacted([]byte(fmt.Sprintf(`{"type":"assistant","timestamp":%q}`, mainCreatedAt.Format(time.RFC3339Nano)))),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	rawOldest := time.Date(2025, 12, 23, 10, 27, 44, 0, time.UTC)
+	rawNewest := time.Date(2025, 12, 23, 10, 31, 37, 0, time.UTC)
+	transcript := fmt.Sprintf(
+		"{\"type\":\"user\",\"timestamp\":%q}\n{\"type\":\"assistant\",\"timestamp\":%q}\n",
+		rawOldest.Format(time.RFC3339Nano),
+		rawNewest.Format(time.RFC3339Nano),
+	)
+	blobHash, err := CreateBlobFromContent(repo, []byte(transcript))
+	require.NoError(t, err)
+
+	rootTreeHash, err := BuildTreeFromEntries(context.Background(), repo, map[string]object.TreeEntry{
+		cpID.Path() + "/0/" + paths.V2RawTranscriptFileName: {
+			Name: paths.V2RawTranscriptFileName,
+			Mode: filemode.Regular,
+			Hash: blobHash,
+		},
+	})
+	require.NoError(t, err)
+
+	gen, ok, err := store.ComputeGenerationRawTranscriptTimestamps(rootTreeHash)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.True(t, gen.OldestCheckpointAt.Equal(rawOldest))
+	assert.True(t, gen.NewestCheckpointAt.Equal(rawNewest))
+}
+
 func TestComputeGenerationCheckpointTimestamps_UnreadableCheckpointForcesFallback(t *testing.T) {
 	t.Parallel()
 	repo := initTestRepo(t)

--- a/cmd/entire/cli/clean_test.go
+++ b/cmd/entire/cli/clean_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -234,6 +235,68 @@ func createArchivedGenerationRef(t *testing.T, repo *git.Repository, generation 
 		},
 		"aa/bbccddeeff/0/" + paths.TranscriptFileName: {
 			Name: paths.TranscriptFileName,
+			Mode: filemode.Regular,
+			Hash: transcriptBlobHash,
+		},
+	}
+
+	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, entries)
+	if err != nil {
+		t.Fatalf("failed to build archived generation tree: %v", err)
+	}
+
+	commitHash, err := checkpoint.CreateCommit(context.Background(), repo, treeHash, plumbing.ZeroHash, "archived generation", "test", "test@test.com")
+	if err != nil {
+		t.Fatalf("failed to create archived generation commit: %v", err)
+	}
+
+	refName := plumbing.ReferenceName(paths.V2FullRefPrefix + generation)
+	ref := plumbing.NewHashReference(refName, commitHash)
+	if err := repo.Storer.SetReference(ref); err != nil {
+		t.Fatalf("failed to create archived generation ref %s: %v", refName, err)
+	}
+}
+
+func createArchivedGenerationRefWithRawTranscript(
+	t *testing.T,
+	repo *git.Repository,
+	generation string,
+	cpID id.CheckpointID,
+	generationOldest time.Time,
+	generationNewest time.Time,
+	rawOldest time.Time,
+	rawNewest time.Time,
+) {
+	t.Helper()
+
+	gen := checkpoint.GenerationMetadata{
+		OldestCheckpointAt: generationOldest.UTC(),
+		NewestCheckpointAt: generationNewest.UTC(),
+	}
+	genJSON, err := json.Marshal(gen)
+	if err != nil {
+		t.Fatalf("failed to marshal generation metadata: %v", err)
+	}
+	genBlobHash, err := checkpoint.CreateBlobFromContent(repo, genJSON)
+	if err != nil {
+		t.Fatalf("failed to create generation blob: %v", err)
+	}
+
+	transcript := `{"type":"user","timestamp":` + strconv.Quote(rawOldest.UTC().Format(time.RFC3339Nano)) + "}\n" +
+		`{"type":"assistant","timestamp":` + strconv.Quote(rawNewest.UTC().Format(time.RFC3339Nano)) + "}\n"
+	transcriptBlobHash, err := checkpoint.CreateBlobFromContent(repo, []byte(transcript))
+	if err != nil {
+		t.Fatalf("failed to create transcript blob: %v", err)
+	}
+
+	entries := map[string]object.TreeEntry{
+		paths.GenerationFileName: {
+			Name: paths.GenerationFileName,
+			Mode: filemode.Regular,
+			Hash: genBlobHash,
+		},
+		cpID.Path() + "/0/" + paths.V2RawTranscriptFileName: {
+			Name: paths.V2RawTranscriptFileName,
 			Mode: filemode.Regular,
 			Hash: transcriptBlobHash,
 		},
@@ -1001,7 +1064,7 @@ func TestCleanCmd_All_DryRunListsRemoteOnlyEligibleV2Generations(t *testing.T) {
 	}
 }
 
-func TestCleanCmd_All_UsesCheckpointTimeForV2GenerationRetention(t *testing.T) {
+func TestCleanCmd_All_UsesRawTranscriptTimeForV2GenerationRetention(t *testing.T) {
 	repo, _ := setupCleanTestRepo(t)
 
 	wt, err := repo.Worktree()
@@ -1013,9 +1076,10 @@ func TestCleanCmd_All_UsesCheckpointTimeForV2GenerationRetention(t *testing.T) {
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 
 	cpID := id.MustCheckpointID("aabbccddeeff")
-	checkpointCreatedAt := time.Now().AddDate(0, 0, -20)
-	createV2MainMetadataRef(t, repo, cpID, checkpointCreatedAt)
-	createArchivedGenerationRef(t, repo, "0000000000005", time.Now(), time.Now())
+	createV2MainMetadataRef(t, repo, cpID, time.Now())
+	createArchivedGenerationRefWithRawTranscript(t, repo, "0000000000005", cpID,
+		time.Now(), time.Now(),
+		time.Now().AddDate(0, 0, -20), time.Now().AddDate(0, 0, -15))
 
 	cmd := newCleanCmd()
 	var stdout, stderr bytes.Buffer
@@ -1032,7 +1096,7 @@ func TestCleanCmd_All_UsesCheckpointTimeForV2GenerationRetention(t *testing.T) {
 		t.Fatalf("expected archived v2 generation section, got: %s", output)
 	}
 	if !strings.Contains(output, "0000000000005") {
-		t.Fatalf("expected generation to be eligible by checkpoint created_at, got: %s", output)
+		t.Fatalf("expected generation to be eligible by raw transcript timestamps, got: %s", output)
 	}
 }
 

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -140,7 +140,11 @@ var (
 	errNoMigratableSessions     = errors.New("no migratable v1 sessions")
 )
 
-const migrateRemoteName = "origin"
+const (
+	migrateRemoteName  = "origin"
+	migrateAuthorName  = "Entire Migration"
+	migrateAuthorEmail = "migration@entire.dev"
+)
 
 var migrateMaxCheckpointsPerGeneration = checkpoint.DefaultMaxCheckpointsPerGeneration
 
@@ -174,7 +178,8 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 	sortMigratableCheckpoints(v1List)
 	total := len(v1List)
 	result := &migrateResult{}
-	fullCurrentExistsBefore := v2RefExists(repo, plumbing.ReferenceName(paths.V2FullCurrentRefName))
+	_, fullCurrentRefErr := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
+	fullCurrentExistsBefore := fullCurrentRefErr == nil
 	var migratedFullCheckpoints []migratedFullCheckpoint
 
 	for i, info := range v1List {
@@ -238,18 +243,12 @@ func sortMigratableCheckpoints(checkpoints []checkpoint.CommittedInfo) {
 	})
 }
 
-func v2RefExists(repo *git.Repository, refName plumbing.ReferenceName) bool {
-	_, err := repo.Reference(refName, true)
-	return err == nil
-}
-
 func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, out io.Writer, prefix string, force bool) (*migratedFullCheckpoint, error) {
 	existing, err := v2Store.ReadCommitted(ctx, info.CheckpointID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check v2 for checkpoint %s: %w", info.CheckpointID, err)
 	}
 
-	// Already in v2 — when not forcing, check if any aspect of sessions are missing and backfill
 	if existing != nil && !force {
 		fullCheckpoint, queuedFullRepair, repairErr := collectMissingFullCheckpointForPacking(ctx, repo, v1Store, v2Store, info, existing)
 		if repairErr != nil {
@@ -269,22 +268,23 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 		cleanupV1TranscriptFiles(ctx, repo, v2Store, info.CheckpointID, len(currentV2.Sessions))
 
 		backfillErr := backfillCompactTranscripts(ctx, v1Store, v2Store, info, currentV2, out, prefix)
-		if errors.Is(backfillErr, errAlreadyMigrated) && queuedFullRepair {
-			fmt.Fprintf(out, "%s queued missing raw transcript artifacts for generation packing\n", prefix)
-			return fullCheckpoint, nil
+		if !queuedFullRepair {
+			if backfillErr != nil {
+				return nil, backfillErr
+			}
+			return &migratedFullCheckpoint{}, nil
 		}
-		if errors.Is(backfillErr, errTranscriptNotGeneratable) && queuedFullRepair {
-			fmt.Fprintf(out, "%s queued missing raw transcript artifacts for generation packing (compact transcript not generated)\n", prefix)
-			return fullCheckpoint, nil
-		}
-		if backfillErr != nil {
+		if backfillErr != nil &&
+			!errors.Is(backfillErr, errAlreadyMigrated) &&
+			!errors.Is(backfillErr, errTranscriptNotGeneratable) {
 			return nil, backfillErr
 		}
-		if queuedFullRepair {
-			fmt.Fprintf(out, "%s queued missing raw transcript artifacts for generation packing\n", prefix)
-			return fullCheckpoint, nil
+		suffix := ""
+		if errors.Is(backfillErr, errTranscriptNotGeneratable) {
+			suffix = " (compact transcript not generated)"
 		}
-		return &migratedFullCheckpoint{}, nil
+		fmt.Fprintf(out, "%s queued missing raw transcript artifacts for generation packing%s\n", prefix, suffix)
+		return fullCheckpoint, nil
 	}
 
 	if existing != nil && force {
@@ -390,9 +390,9 @@ func packMigratedFullGenerations(ctx context.Context, repo *git.Repository, v2St
 		batchSize = checkpoint.DefaultMaxCheckpointsPerGeneration
 	}
 
-	nextGeneration, err := nextMigratedGenerationNumber(v2Store)
+	nextGeneration, err := v2Store.NextGenerationNumber()
 	if err != nil {
-		return err
+		return fmt.Errorf("list archived v2 generations: %w", err)
 	}
 
 	for start := 0; start < len(checkpoints); start += batchSize {
@@ -411,24 +411,6 @@ func packMigratedFullGenerations(ctx context.Context, repo *git.Repository, v2St
 	return nil
 }
 
-func nextMigratedGenerationNumber(v2Store *checkpoint.V2GitStore) (int, error) {
-	archived, err := v2Store.ListArchivedGenerations()
-	if err != nil {
-		return 0, fmt.Errorf("list archived v2 generations: %w", err)
-	}
-	next := 1
-	for _, name := range archived {
-		n, parseErr := strconv.Atoi(name)
-		if parseErr != nil {
-			continue
-		}
-		if n >= next {
-			next = n + 1
-		}
-	}
-	return next, nil
-}
-
 func writeMigratedFullGeneration(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, checkpoints []migratedFullCheckpoint) error {
 	entries := make(map[string]object.TreeEntry)
 	var gen checkpoint.GenerationMetadata
@@ -439,7 +421,7 @@ func writeMigratedFullGeneration(ctx context.Context, repo *git.Repository, refN
 			if err := writeMigratedFullSessionEntries(ctx, repo, cp, session, entries); err != nil {
 				return fmt.Errorf("write full session entries for checkpoint %s session %d: %w", cp.checkpointID, session.sessionIndex, err)
 			}
-			mergeMigratedGenerationTime(&gen, &foundTime, session.content.Metadata.CreatedAt)
+			checkpoint.MergeGenerationTime(&gen, &foundTime, session.content.Metadata.CreatedAt)
 		}
 	}
 
@@ -464,7 +446,7 @@ func writeMigratedFullGeneration(ctx context.Context, repo *git.Repository, refN
 
 	commitHash, err := checkpoint.CreateCommit(ctx, repo, treeHash, plumbing.ZeroHash,
 		fmt.Sprintf("Archive migrated generation: %s\n", refName),
-		"Entire Migration", "migration@entire.dev")
+		migrateAuthorName, migrateAuthorEmail)
 	if err != nil {
 		return fmt.Errorf("create migrated generation commit: %w", err)
 	}
@@ -521,25 +503,6 @@ func writeMigratedFullSessionEntries(ctx context.Context, repo *git.Repository, 
 	return nil
 }
 
-func mergeMigratedGenerationTime(gen *checkpoint.GenerationMetadata, found *bool, ts time.Time) {
-	if ts.IsZero() {
-		return
-	}
-	ts = ts.UTC()
-	if !*found {
-		gen.OldestCheckpointAt = ts
-		gen.NewestCheckpointAt = ts
-		*found = true
-		return
-	}
-	if ts.Before(gen.OldestCheckpointAt) {
-		gen.OldestCheckpointAt = ts
-	}
-	if ts.After(gen.NewestCheckpointAt) {
-		gen.NewestCheckpointAt = ts
-	}
-}
-
 func ensureEmptyV2FullCurrent(ctx context.Context, repo *git.Repository) error {
 	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
 	if _, err := repo.Reference(refName, true); err == nil {
@@ -553,7 +516,7 @@ func ensureEmptyV2FullCurrent(ctx context.Context, repo *git.Repository) error {
 
 	commitHash, err := checkpoint.CreateCommit(ctx, repo, emptyTreeHash, plumbing.ZeroHash,
 		"Start generation\n",
-		"Entire Migration", "migration@entire.dev")
+		migrateAuthorName, migrateAuthorEmail)
 	if err != nil {
 		return fmt.Errorf("create empty v2 full/current commit: %w", err)
 	}
@@ -638,7 +601,7 @@ func pruneV2CheckpointRef(ctx context.Context, repo *git.Repository, v2Store *ch
 
 	commitHash, err := checkpoint.CreateCommit(ctx, repo, newRoot, parentHash,
 		fmt.Sprintf("Reset checkpoint before force migration: %s\n", cpID),
-		"Entire Migration", "migration@entire.dev")
+		migrateAuthorName, migrateAuthorEmail)
 	if err != nil {
 		return fmt.Errorf("failed to create v2 prune commit for %s: %w", refName, err)
 	}
@@ -694,7 +657,7 @@ func pruneV2ArchivedCheckpointRef(ctx context.Context, repo *git.Repository, v2S
 
 	commitHash, err := checkpoint.CreateCommit(ctx, repo, newRoot, parentHash,
 		fmt.Sprintf("Reset checkpoint before force migration: %s\n", cpID),
-		"Entire Migration", "migration@entire.dev")
+		migrateAuthorName, migrateAuthorEmail)
 	if err != nil {
 		return fmt.Errorf("failed to create v2 prune commit for %s: %w", refName, err)
 	}
@@ -987,8 +950,8 @@ func buildMigrateWriteOpts(content *checkpoint.SessionContent, info checkpoint.C
 		TranscriptIdentifierAtStart: m.TranscriptIdentifierAtStart,
 		IsTask:                      m.IsTask,
 		ToolUseID:                   m.ToolUseID,
-		AuthorName:                  "Entire Migration",
-		AuthorEmail:                 "migration@entire.dev",
+		AuthorName:                  migrateAuthorName,
+		AuthorEmail:                 migrateAuthorEmail,
 	}
 }
 
@@ -1198,7 +1161,7 @@ func spliceTasksTreeToV2(ctx context.Context, repo *git.Repository, v2Store *che
 
 	commitHash, err := checkpoint.CreateCommit(ctx, repo, newRoot, parentHash,
 		fmt.Sprintf("Add task metadata for %s\n", cpID),
-		"Entire Migration", "migration@entire.dev")
+		migrateAuthorName, migrateAuthorEmail)
 	if err != nil {
 		return fmt.Errorf("failed to create commit: %w", err)
 	}

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -92,6 +92,12 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 		return err
 	}
 
+	repairResult, repairErr := strategy.RepairV2GenerationMetadata(ctx)
+	if repairErr != nil {
+		return fmt.Errorf("failed to repair archived v2 generation metadata: %w", repairErr)
+	}
+	printV2GenerationRepairResult(out, cmd.ErrOrStderr(), repairResult)
+
 	fmt.Fprintf(out, "\nMigration complete: %d migrated, %d skipped, %d failed\n",
 		result.migrated, result.skipped, result.failed)
 	fmt.Fprintln(out)
@@ -103,8 +109,29 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 		fmt.Fprintf(out, "%d checkpoint(s) failed to migrate. Check .entire/logs/ for details.\n", result.failed)
 		return NewSilentError(fmt.Errorf("%d checkpoint(s) failed to migrate", result.failed))
 	}
+	if repairResult != nil && len(repairResult.Failed) > 0 {
+		fmt.Fprintf(out, "%d archived generation(s) failed metadata repair. Check warnings above for details.\n", len(repairResult.Failed))
+		return NewSilentError(fmt.Errorf("%d archived generation(s) failed metadata repair", len(repairResult.Failed)))
+	}
 
 	return nil
+}
+
+func printV2GenerationRepairResult(out, errOut io.Writer, result *strategy.RepairV2GenerationMetadataResult) {
+	if result == nil {
+		return
+	}
+
+	for _, warning := range result.Warnings {
+		fmt.Fprintf(errOut, "Warning: %s\n", warning)
+	}
+
+	if len(result.Repaired) == 0 && len(result.Failed) == 0 {
+		return
+	}
+
+	fmt.Fprintf(out, "Archived generation metadata repair: %d repaired, %d skipped, %d failed\n",
+		len(result.Repaired), len(result.Skipped), len(result.Failed))
 }
 
 var (
@@ -224,7 +251,7 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 
 	// Already in v2 — when not forcing, check if any aspect of sessions are missing and backfill
 	if existing != nil && !force {
-		repaired, repairErr := repairPartialV2Checkpoint(ctx, v1Store, v2Store, info, existing)
+		fullCheckpoint, queuedFullRepair, repairErr := collectMissingFullCheckpointForPacking(ctx, repo, v1Store, v2Store, info, existing)
 		if repairErr != nil {
 			return nil, repairErr
 		}
@@ -242,16 +269,20 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 		cleanupV1TranscriptFiles(ctx, repo, v2Store, info.CheckpointID, len(currentV2.Sessions))
 
 		backfillErr := backfillCompactTranscripts(ctx, v1Store, v2Store, info, currentV2, out, prefix)
-		if errors.Is(backfillErr, errAlreadyMigrated) && repaired {
-			fmt.Fprintf(out, "%s repaired partial v2 checkpoint state\n", prefix)
-			return &migratedFullCheckpoint{}, nil
+		if errors.Is(backfillErr, errAlreadyMigrated) && queuedFullRepair {
+			fmt.Fprintf(out, "%s queued missing raw transcript artifacts for generation packing\n", prefix)
+			return fullCheckpoint, nil
 		}
-		if errors.Is(backfillErr, errTranscriptNotGeneratable) && repaired {
-			fmt.Fprintf(out, "%s repaired partial v2 checkpoint state (compact transcript not generated)\n", prefix)
-			return &migratedFullCheckpoint{}, nil
+		if errors.Is(backfillErr, errTranscriptNotGeneratable) && queuedFullRepair {
+			fmt.Fprintf(out, "%s queued missing raw transcript artifacts for generation packing (compact transcript not generated)\n", prefix)
+			return fullCheckpoint, nil
 		}
 		if backfillErr != nil {
 			return nil, backfillErr
+		}
+		if queuedFullRepair {
+			fmt.Fprintf(out, "%s queued missing raw transcript artifacts for generation packing\n", prefix)
+			return fullCheckpoint, nil
 		}
 		return &migratedFullCheckpoint{}, nil
 	}
@@ -648,45 +679,108 @@ func pruneCheckpointFromRoot(repo *git.Repository, rootTreeHash plumbing.Hash, s
 	return prunedRoot, nil
 }
 
-func repairPartialV2Checkpoint(ctx context.Context, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, v2Summary *checkpoint.CheckpointSummary) (bool, error) {
-	repaired := false
+func collectMissingFullCheckpointForPacking(
+	ctx context.Context,
+	repo *git.Repository,
+	v1Store *checkpoint.GitStore,
+	v2Store *checkpoint.V2GitStore,
+	info checkpoint.CommittedInfo,
+	v2Summary *checkpoint.CheckpointSummary,
+) (*migratedFullCheckpoint, bool, error) {
+	v1Summary, err := v1Store.ReadCommitted(ctx, info.CheckpointID)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read v1 summary while checking v2 raw artifacts: %w", err)
+	}
+	if v1Summary == nil {
+		return nil, false, fmt.Errorf("v1 checkpoint %s has no summary", info.CheckpointID)
+	}
 
-	// Spot-check already present sessions: ensure required /full/* artifacts exist.
-	existingSessionCount := len(v2Summary.Sessions)
-	for sessionIdx := range existingSessionCount {
+	v1BySessionID, v1ByIndex, err := collectV1SessionsForPacking(ctx, v1Store, info.CheckpointID, v1Summary)
+	if err != nil {
+		return nil, false, err
+	}
+
+	fullCheckpoint := &migratedFullCheckpoint{
+		checkpointID: info.CheckpointID,
+	}
+	v1ToV2SessionIdx := make(map[int]int)
+
+	for sessionIdx := range len(v2Summary.Sessions) {
 		ok, checkErr := hasFullSessionArtifacts(v2Store, info.CheckpointID, sessionIdx)
 		if checkErr != nil {
-			return false, fmt.Errorf("failed to check v2 session %d artifacts: %w", sessionIdx, checkErr)
+			return nil, false, fmt.Errorf("failed to check v2 session %d artifacts: %w", sessionIdx, checkErr)
 		}
 		if ok {
 			continue
 		}
 
-		content, readErr := v1Store.ReadSessionContent(ctx, info.CheckpointID, sessionIdx)
+		v2Content, readErr := v2Store.ReadSessionMetadataAndPrompts(ctx, info.CheckpointID, sessionIdx)
 		if readErr != nil {
-			return false, fmt.Errorf("failed to read v1 session %d while repairing v2: %w", sessionIdx, readErr)
+			return nil, false, fmt.Errorf("failed to read v2 session %d metadata while checking raw artifacts: %w", sessionIdx, readErr)
 		}
 
-		updateOpts := checkpoint.UpdateCommittedOptions{
-			CheckpointID: info.CheckpointID,
-			SessionID:    content.Metadata.SessionID,
-			// content.Transcript was read from v1 checkpoint storage and is
-			// already redacted at write time.
-			Transcript: redact.AlreadyRedacted(content.Transcript),
-			Prompts:    checkpoint.SplitPromptContent(content.Prompts),
-			Agent:      content.Metadata.Agent,
+		v1Session, ok := v1BySessionID[v2Content.Metadata.SessionID]
+		if !ok {
+			v1Session, ok = v1ByIndex[sessionIdx]
 		}
-		if compacted := tryCompactTranscript(ctx, content.Transcript, content.Metadata); compacted != nil {
-			updateOpts.CompactTranscript = compacted
+		if !ok {
+			return nil, false, fmt.Errorf("failed to find v1 session for v2 session %d while checking raw artifacts", sessionIdx)
 		}
 
-		if updateErr := v2Store.UpdateCommitted(ctx, updateOpts); updateErr != nil {
-			return false, fmt.Errorf("failed to repair v2 session %d: %w", sessionIdx, updateErr)
-		}
-		repaired = true
+		fullCheckpoint.sessions = append(fullCheckpoint.sessions, migratedFullSession{
+			sessionIndex: sessionIdx,
+			content:      v1Session.content,
+		})
+		v1ToV2SessionIdx[v1Session.sessionIndex] = sessionIdx
 	}
 
-	return repaired, nil
+	if len(fullCheckpoint.sessions) == 0 {
+		return &migratedFullCheckpoint{}, false, nil
+	}
+
+	taskTrees, taskErr := collectTaskMetadataForMigratedFullGeneration(repo, info.CheckpointID, v1Summary, v1ToV2SessionIdx)
+	if taskErr != nil {
+		return nil, false, fmt.Errorf("failed to collect task metadata while checking raw artifacts: %w", taskErr)
+	}
+	fullCheckpoint.taskTrees = taskTrees
+
+	return fullCheckpoint, true, nil
+}
+
+type v1SessionForPacking struct {
+	sessionIndex int
+	content      *checkpoint.SessionContent
+}
+
+func collectV1SessionsForPacking(
+	ctx context.Context,
+	v1Store *checkpoint.GitStore,
+	checkpointID id.CheckpointID,
+	summary *checkpoint.CheckpointSummary,
+) (map[string]v1SessionForPacking, map[int]v1SessionForPacking, error) {
+	bySessionID := make(map[string]v1SessionForPacking)
+	byIndex := make(map[int]v1SessionForPacking)
+
+	for sessionIdx := range len(summary.Sessions) {
+		content, err := v1Store.ReadSessionContent(ctx, checkpointID, sessionIdx)
+		if err != nil {
+			if errors.Is(err, checkpoint.ErrNoTranscript) || errors.Is(err, checkpoint.ErrCheckpointNotFound) {
+				continue
+			}
+			return nil, nil, fmt.Errorf("failed to read v1 session %d while checking raw artifacts: %w", sessionIdx, err)
+		}
+
+		session := v1SessionForPacking{
+			sessionIndex: sessionIdx,
+			content:      content,
+		}
+		byIndex[sessionIdx] = session
+		if content.Metadata.SessionID != "" {
+			bySessionID[content.Metadata.SessionID] = session
+		}
+	}
+
+	return bySessionID, byIndex, nil
 }
 
 func hasFullSessionArtifacts(v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int) (bool, error) {

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -594,6 +594,18 @@ func pruneV2CheckpointForForce(ctx context.Context, repo *git.Repository, v2Stor
 			return err
 		}
 	}
+
+	archived, err := v2Store.ListArchivedGenerations()
+	if err != nil {
+		return fmt.Errorf("failed to list archived v2 generations while pruning checkpoint %s: %w", cpID, err)
+	}
+	for _, generation := range archived {
+		refName := plumbing.ReferenceName(paths.V2FullRefPrefix + generation)
+		if err := pruneV2ArchivedCheckpointRef(ctx, repo, v2Store, refName, cpID); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -635,6 +647,84 @@ func pruneV2CheckpointRef(ctx context.Context, repo *git.Repository, v2Store *ch
 		return fmt.Errorf("failed to update ref %s: %w", refName, err)
 	}
 	return nil
+}
+
+func pruneV2ArchivedCheckpointRef(ctx context.Context, repo *git.Repository, v2Store *checkpoint.V2GitStore, refName plumbing.ReferenceName, cpID id.CheckpointID) error {
+	parentHash, rootTreeHash, err := v2Store.GetRefState(refName)
+	if err != nil {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return nil
+		}
+		return fmt.Errorf("failed to get v2 ref state for %s: %w", refName, err)
+	}
+
+	rootTree, err := repo.TreeObject(rootTreeHash)
+	if err != nil {
+		return fmt.Errorf("failed to read v2 tree for %s: %w", refName, err)
+	}
+	if _, err := rootTree.Tree(cpID.Path()); err != nil {
+		return nil //nolint:nilerr // Checkpoint is absent from this ref, so there is nothing to prune.
+	}
+
+	shardPrefix := string(cpID[:2])
+	shardSuffix := string(cpID[2:])
+	newRoot, err := pruneCheckpointFromRoot(repo, rootTreeHash, shardPrefix, shardSuffix)
+	if err != nil {
+		return fmt.Errorf("failed to remove checkpoint subtree from %s: %w", refName, err)
+	}
+	if newRoot == rootTreeHash {
+		return nil
+	}
+
+	count, err := v2Store.CountCheckpointsInTree(newRoot)
+	if err != nil {
+		return fmt.Errorf("failed to count checkpoints in pruned %s: %w", refName, err)
+	}
+	if count == 0 {
+		if err := repo.Storer.RemoveReference(refName); err != nil {
+			return fmt.Errorf("failed to remove empty archived v2 generation %s: %w", refName, err)
+		}
+		return nil
+	}
+
+	newRoot, err = addRecomputedGenerationJSON(v2Store, newRoot)
+	if err != nil {
+		return fmt.Errorf("failed to recompute generation metadata for %s: %w", refName, err)
+	}
+
+	commitHash, err := checkpoint.CreateCommit(ctx, repo, newRoot, parentHash,
+		fmt.Sprintf("Reset checkpoint before force migration: %s\n", cpID),
+		"Entire Migration", "migration@entire.dev")
+	if err != nil {
+		return fmt.Errorf("failed to create v2 prune commit for %s: %w", refName, err)
+	}
+
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)); err != nil {
+		return fmt.Errorf("failed to update ref %s: %w", refName, err)
+	}
+	return nil
+}
+
+func addRecomputedGenerationJSON(v2Store *checkpoint.V2GitStore, treeHash plumbing.Hash) (plumbing.Hash, error) {
+	gen, found, err := v2Store.ComputeGenerationRawTranscriptTimestamps(treeHash)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("compute raw transcript timestamps: %w", err)
+	}
+	if !found {
+		gen, found, err = v2Store.ComputeGenerationCheckpointTimestamps(treeHash)
+		if err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("compute checkpoint timestamps: %w", err)
+		}
+	}
+	if !found {
+		return treeHash, nil
+	}
+
+	newTreeHash, err := v2Store.AddGenerationJSONToTree(treeHash, gen)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("add generation metadata: %w", err)
+	}
+	return newTreeHash, nil
 }
 
 func pruneCheckpointFromRoot(repo *git.Repository, rootTreeHash plumbing.Hash, shardPrefix, shardSuffix string) (plumbing.Hash, error) {

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -163,7 +163,7 @@ var (
 	errAlreadyMigrated          = errors.New("already migrated")
 	errTranscriptNotGeneratable = errors.New("transcript.jsonl could not be generated")
 	errNoMigratableSessions     = errors.New("no migratable v1 sessions")
-	errNoFullArtifactsToPack    = errors.New("no missing full artifacts to pack")
+	errNoFullPackingNeeded      = errors.New("no full packing needed")
 )
 
 const (
@@ -228,7 +228,7 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 			case errors.Is(migrateErr, errNoMigratableSessions):
 				logCheckpointMigrationSkip(ctx, info.CheckpointID, "no migratable v1 sessions", migrateErr)
 				result.skipped++
-			case errors.Is(migrateErr, errNoFullArtifactsToPack):
+			case errors.Is(migrateErr, errNoFullPackingNeeded):
 				result.migrated++
 			default:
 				logging.Error(ctx, "checkpoint migration failed",
@@ -324,7 +324,7 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 			if backfillErr != nil {
 				return nil, outcome, backfillErr
 			}
-			return nil, outcome, errNoFullArtifactsToPack
+			return nil, outcome, errNoFullPackingNeeded
 		}
 		if errors.Is(backfillErr, errTranscriptNotGeneratable) {
 			outcome.compactTranscriptSkipped = true
@@ -893,7 +893,15 @@ func collectMissingFullCheckpointForPacking(
 		v1ToV2SessionIdx[v1Session.sessionIndex] = missingSession.sessionIndex
 	}
 
-	taskTrees, taskErr := collectTaskMetadataForMigratedFullGeneration(repo, info.CheckpointID, v1Summary, v1ToV2SessionIdx)
+	latestV2SessionIdx := len(v2Summary.Sessions) - 1
+	taskTrees, taskErr := collectTaskMetadataForMigratedFullGenerationWithRootSession(
+		repo,
+		info.CheckpointID,
+		v1Summary,
+		v1ToV2SessionIdx,
+		latestV2SessionIdx,
+		latestV2SessionIdx >= 0,
+	)
 	if taskErr != nil {
 		return nil, false, fmt.Errorf("failed to collect task metadata while checking raw artifacts: %w", taskErr)
 	}
@@ -1231,6 +1239,18 @@ func computeCompactOffset(ctx context.Context, fullTranscript, fullCompact []byt
 }
 
 func collectTaskMetadataForMigratedFullGeneration(repo *git.Repository, cpID id.CheckpointID, summary *checkpoint.CheckpointSummary, v1ToV2SessionIdx map[int]int) (map[int][]plumbing.Hash, error) {
+	rootTaskV2SessionIdx, attachRootTasks := latestMigratedV2SessionIndex(v1ToV2SessionIdx)
+	return collectTaskMetadataForMigratedFullGenerationWithRootSession(repo, cpID, summary, v1ToV2SessionIdx, rootTaskV2SessionIdx, attachRootTasks)
+}
+
+func collectTaskMetadataForMigratedFullGenerationWithRootSession(
+	repo *git.Repository,
+	cpID id.CheckpointID,
+	summary *checkpoint.CheckpointSummary,
+	v1ToV2SessionIdx map[int]int,
+	rootTaskV2SessionIdx int,
+	attachRootTasks bool,
+) (map[int][]plumbing.Hash, error) {
 	v1Tree, err := resolveV1CheckpointTree(repo, cpID)
 	if err != nil {
 		return nil, err
@@ -1241,8 +1261,8 @@ func collectTaskMetadataForMigratedFullGeneration(repo *git.Repository, cpID id.
 	// Legacy v1 layout stores task metadata at checkpoint root: <cp>/tasks/<tool-use-id>/...
 	// Prefer attaching this tree to the latest session in v2.
 	if rootTasksTree, rootTasksErr := v1Tree.Tree("tasks"); rootTasksErr == nil {
-		if latestSessionIdx, ok := latestMigratedV2SessionIndex(v1ToV2SessionIdx); ok {
-			taskTrees[latestSessionIdx] = append(taskTrees[latestSessionIdx], rootTasksTree.Hash)
+		if attachRootTasks {
+			taskTrees[rootTaskV2SessionIdx] = append(taskTrees[rootTaskV2SessionIdx], rootTasksTree.Hash)
 		}
 	}
 

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"sort"
 	"strconv"
-	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -502,23 +501,12 @@ func (p *generationPacker) finalize(ctx context.Context, ensureEmptyCurrent bool
 
 func writeMigratedFullGeneration(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, checkpoints []migratedFullCheckpoint) error {
 	entries := make(map[string]object.TreeEntry)
-	var gen checkpoint.GenerationMetadata
-	foundTime := false
 
 	for _, cp := range checkpoints {
 		for _, session := range cp.sessions {
 			if err := writeMigratedFullSessionEntries(ctx, repo, cp, session, entries); err != nil {
 				return fmt.Errorf("write full session entries for checkpoint %s session %d: %w", cp.checkpointID, session.sessionIndex, err)
 			}
-			checkpoint.MergeGenerationTime(&gen, &foundTime, session.content.Metadata.CreatedAt)
-		}
-	}
-
-	if !foundTime {
-		now := time.Now().UTC()
-		gen = checkpoint.GenerationMetadata{
-			OldestCheckpointAt: now,
-			NewestCheckpointAt: now,
 		}
 	}
 
@@ -528,6 +516,23 @@ func writeMigratedFullGeneration(ctx context.Context, repo *git.Repository, refN
 	}
 
 	v2Store := checkpoint.NewV2GitStore(repo, migrateRemoteName)
+	gen, found, err := v2Store.ComputeGenerationTimestampsFromTrees(treeHash, nil)
+	if err != nil {
+		return fmt.Errorf("compute raw transcript timestamps: %w", err)
+	}
+	if !found {
+		gen, found, err = v2Store.ComputeGenerationCheckpointTimestamps(treeHash)
+		if err != nil {
+			return fmt.Errorf("compute checkpoint timestamps: %w", err)
+		}
+	}
+	if !found {
+		gen, found = generationMetadataFromMigratedSessions(checkpoints)
+	}
+	if !found {
+		return fmt.Errorf("no timestamps found for migrated generation %s", refName)
+	}
+
 	treeHash, err = v2Store.AddGenerationJSONToTree(treeHash, gen)
 	if err != nil {
 		return fmt.Errorf("add generation metadata: %w", err)
@@ -544,6 +549,17 @@ func writeMigratedFullGeneration(ctx context.Context, repo *git.Repository, refN
 		return fmt.Errorf("update migrated generation ref %s: %w", refName, err)
 	}
 	return nil
+}
+
+func generationMetadataFromMigratedSessions(checkpoints []migratedFullCheckpoint) (checkpoint.GenerationMetadata, bool) {
+	var gen checkpoint.GenerationMetadata
+	found := false
+	for _, cp := range checkpoints {
+		for _, session := range cp.sessions {
+			checkpoint.MergeGenerationTime(&gen, &found, session.content.Metadata.CreatedAt)
+		}
+	}
+	return gen, found
 }
 
 func writeMigratedFullSessionEntries(ctx context.Context, repo *git.Repository, cp migratedFullCheckpoint, session migratedFullSession, entries map[string]object.TreeEntry) error {
@@ -584,8 +600,15 @@ func writeMigratedFullSessionEntries(ctx context.Context, repo *git.Repository, 
 		if treeErr != nil {
 			return fmt.Errorf("read task metadata tree: %w", treeErr)
 		}
-		if flattenErr := checkpoint.FlattenTree(repo, taskTree, sessionPath+"tasks", entries); flattenErr != nil {
+		taskEntries := make(map[string]object.TreeEntry)
+		if flattenErr := checkpoint.FlattenTree(repo, taskTree, sessionPath+"tasks", taskEntries); flattenErr != nil {
 			return fmt.Errorf("flatten task metadata tree: %w", flattenErr)
+		}
+		for path, entry := range taskEntries {
+			if _, exists := entries[path]; exists {
+				continue
+			}
+			entries[path] = entry
 		}
 	}
 
@@ -757,7 +780,7 @@ func pruneV2ArchivedCheckpointRef(ctx context.Context, repo *git.Repository, v2S
 }
 
 func addRecomputedGenerationJSON(v2Store *checkpoint.V2GitStore, treeHash plumbing.Hash) (plumbing.Hash, error) {
-	gen, found, err := v2Store.ComputeGenerationRawTranscriptTimestamps(treeHash)
+	gen, found, err := v2Store.ComputeGenerationTimestampsFromTrees(treeHash, nil)
 	if err != nil {
 		return plumbing.ZeroHash, fmt.Errorf("compute raw transcript timestamps: %w", err)
 	}

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -3,12 +3,16 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"strconv"
+	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -19,6 +23,7 @@ import (
 	"github.com/entireio/cli/redact"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/spf13/cobra"
 )
@@ -110,6 +115,19 @@ var (
 
 const migrateRemoteName = "origin"
 
+var migrateMaxCheckpointsPerGeneration = checkpoint.DefaultMaxCheckpointsPerGeneration
+
+type migratedFullCheckpoint struct {
+	checkpointID id.CheckpointID
+	sessions     []migratedFullSession
+	taskTrees    map[int][]plumbing.Hash
+}
+
+type migratedFullSession struct {
+	sessionIndex int
+	content      *checkpoint.SessionContent
+}
+
 func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, out io.Writer, force bool) (*migrateResult, error) {
 	v1List, err := v1Store.ListCommitted(ctx)
 	if err != nil {
@@ -126,13 +144,17 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 	} else {
 		fmt.Fprintln(out, "Migrating v1 checkpoints to v2...")
 	}
+	sortMigratableCheckpoints(v1List)
 	total := len(v1List)
 	result := &migrateResult{}
+	fullCurrentExistsBefore := v2RefExists(repo, plumbing.ReferenceName(paths.V2FullCurrentRefName))
+	var migratedFullCheckpoints []migratedFullCheckpoint
 
 	for i, info := range v1List {
 		prefix := fmt.Sprintf("  [%d/%d] Migrating checkpoint %s...", i+1, total, info.CheckpointID)
 
-		if migrateErr := migrateOneCheckpoint(ctx, repo, v1Store, v2Store, info, out, prefix, force); migrateErr != nil {
+		fullCheckpoint, migrateErr := migrateOneCheckpoint(ctx, repo, v1Store, v2Store, info, out, prefix, force)
+		if migrateErr != nil {
 			switch {
 			case errors.Is(migrateErr, errAlreadyMigrated):
 				fmt.Fprintf(out, "%s skipped (already in v2)\n", prefix)
@@ -154,31 +176,65 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 			continue
 		}
 
+		if fullCheckpoint != nil && len(fullCheckpoint.sessions) > 0 {
+			migratedFullCheckpoints = append(migratedFullCheckpoints, *fullCheckpoint)
+		}
 		result.migrated++
+	}
+
+	if len(migratedFullCheckpoints) > 0 {
+		fmt.Fprintf(out, "Packing raw transcripts into v2 archived generations...\n")
+		if packErr := packMigratedFullGenerations(ctx, repo, v2Store, migratedFullCheckpoints, !fullCurrentExistsBefore); packErr != nil {
+			return result, fmt.Errorf("failed to pack migrated raw transcripts: %w", packErr)
+		}
 	}
 
 	return result, nil
 }
 
-func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, out io.Writer, prefix string, force bool) error {
+func sortMigratableCheckpoints(checkpoints []checkpoint.CommittedInfo) {
+	sort.SliceStable(checkpoints, func(i, j int) bool {
+		left := checkpoints[i].CreatedAt
+		right := checkpoints[j].CreatedAt
+		switch {
+		case left.IsZero() && right.IsZero():
+			return checkpoints[i].CheckpointID.String() < checkpoints[j].CheckpointID.String()
+		case left.IsZero():
+			return false
+		case right.IsZero():
+			return true
+		case left.Equal(right):
+			return checkpoints[i].CheckpointID.String() < checkpoints[j].CheckpointID.String()
+		default:
+			return left.Before(right)
+		}
+	})
+}
+
+func v2RefExists(repo *git.Repository, refName plumbing.ReferenceName) bool {
+	_, err := repo.Reference(refName, true)
+	return err == nil
+}
+
+func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, out io.Writer, prefix string, force bool) (*migratedFullCheckpoint, error) {
 	existing, err := v2Store.ReadCommitted(ctx, info.CheckpointID)
 	if err != nil {
-		return fmt.Errorf("failed to check v2 for checkpoint %s: %w", info.CheckpointID, err)
+		return nil, fmt.Errorf("failed to check v2 for checkpoint %s: %w", info.CheckpointID, err)
 	}
 
 	// Already in v2 — when not forcing, check if any aspect of sessions are missing and backfill
 	if existing != nil && !force {
 		repaired, repairErr := repairPartialV2Checkpoint(ctx, v1Store, v2Store, info, existing)
 		if repairErr != nil {
-			return repairErr
+			return nil, repairErr
 		}
 
 		currentV2, readCurrentErr := v2Store.ReadCommitted(ctx, info.CheckpointID)
 		if readCurrentErr != nil {
-			return fmt.Errorf("failed to re-read v2 checkpoint %s: %w", info.CheckpointID, readCurrentErr)
+			return nil, fmt.Errorf("failed to re-read v2 checkpoint %s: %w", info.CheckpointID, readCurrentErr)
 		}
 		if currentV2 == nil {
-			return fmt.Errorf("v2 checkpoint %s disappeared during migration", info.CheckpointID)
+			return nil, fmt.Errorf("v2 checkpoint %s disappeared during migration", info.CheckpointID)
 		}
 
 		// Clean up v1-named transcript files (full.jsonl, content_hash.txt) that older
@@ -188,27 +244,30 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 		backfillErr := backfillCompactTranscripts(ctx, v1Store, v2Store, info, currentV2, out, prefix)
 		if errors.Is(backfillErr, errAlreadyMigrated) && repaired {
 			fmt.Fprintf(out, "%s repaired partial v2 checkpoint state\n", prefix)
-			return nil
+			return &migratedFullCheckpoint{}, nil
 		}
 		if errors.Is(backfillErr, errTranscriptNotGeneratable) && repaired {
 			fmt.Fprintf(out, "%s repaired partial v2 checkpoint state (compact transcript not generated)\n", prefix)
-			return nil
+			return &migratedFullCheckpoint{}, nil
 		}
-		return backfillErr
+		if backfillErr != nil {
+			return nil, backfillErr
+		}
+		return &migratedFullCheckpoint{}, nil
 	}
 
 	if existing != nil && force {
 		if pruneErr := pruneV2CheckpointForForce(ctx, repo, v2Store, info.CheckpointID); pruneErr != nil {
-			return fmt.Errorf("failed to reset existing v2 checkpoint %s before force migration: %w", info.CheckpointID, pruneErr)
+			return nil, fmt.Errorf("failed to reset existing v2 checkpoint %s before force migration: %w", info.CheckpointID, pruneErr)
 		}
 	}
 
 	summary, err := v1Store.ReadCommitted(ctx, info.CheckpointID)
 	if err != nil {
-		return fmt.Errorf("failed to read v1 summary: %w", err)
+		return nil, fmt.Errorf("failed to read v1 summary: %w", err)
 	}
 	if summary == nil {
-		return fmt.Errorf("v1 checkpoint %s has no summary", info.CheckpointID)
+		return nil, fmt.Errorf("v1 checkpoint %s has no summary", info.CheckpointID)
 	}
 
 	compactFailed := false
@@ -216,6 +275,9 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 	skippedMissingSessions := 0
 	migratedSessions := 0
 	v1ToV2SessionIdx := make(map[int]int, len(summary.Sessions))
+	fullCheckpoint := &migratedFullCheckpoint{
+		checkpointID: info.CheckpointID,
+	}
 
 	for sessionIdx := range len(summary.Sessions) {
 		content, skipped, readErr := readV1SessionForMigration(ctx, out, prefix, v1Store, info.CheckpointID, sessionIdx)
@@ -224,7 +286,7 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 			continue
 		}
 		if readErr != nil {
-			return fmt.Errorf("failed to read v1 session %d: %w", sessionIdx, readErr)
+			return nil, fmt.Errorf("failed to read v1 session %d: %w", sessionIdx, readErr)
 		}
 		if content.Metadata.IsTask {
 			shouldCopyTaskMetadata = true
@@ -240,25 +302,33 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 			compactFailed = true
 		}
 
-		v2SessionIdx, writeErr := v2Store.WriteCommittedWithSessionIndex(ctx, opts)
+		mainOpts := opts
+		mainOpts.Transcript = redact.AlreadyRedacted(nil)
+		v2SessionIdx, writeErr := v2Store.WriteCommittedWithSessionIndex(ctx, mainOpts)
 		if writeErr != nil {
-			return fmt.Errorf("failed to write v2 session %d: %w", sessionIdx, writeErr)
+			return nil, fmt.Errorf("failed to write v2 session %d: %w", sessionIdx, writeErr)
 		}
 		v1ToV2SessionIdx[sessionIdx] = v2SessionIdx
+		fullCheckpoint.sessions = append(fullCheckpoint.sessions, migratedFullSession{
+			sessionIndex: v2SessionIdx,
+			content:      content,
+		})
 		migratedSessions++
 	}
 
 	if migratedSessions == 0 {
-		return fmt.Errorf("%w: v1 metadata lists %d session(s), but no transcript/session content exists for any of them", errNoMigratableSessions, len(summary.Sessions))
+		return nil, fmt.Errorf("%w: v1 metadata lists %d session(s), but no transcript/session content exists for any of them", errNoMigratableSessions, len(summary.Sessions))
 	}
 
-	// Copy task metadata trees from v1 to v2 /full/current
 	if shouldCopyTaskMetadata {
-		if taskErr := copyTaskMetadataToV2(ctx, repo, v1Store, v2Store, info.CheckpointID, summary, v1ToV2SessionIdx); taskErr != nil {
+		taskTrees, taskErr := collectTaskMetadataForMigratedFullGeneration(repo, info.CheckpointID, summary, v1ToV2SessionIdx)
+		if taskErr != nil {
 			logging.Warn(ctx, "failed to copy task metadata to v2",
 				slog.String("checkpoint_id", string(info.CheckpointID)),
 				slog.String("error", taskErr.Error()),
 			)
+		} else {
+			fullCheckpoint.taskTrees = taskTrees
 		}
 	}
 
@@ -273,6 +343,193 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 		fmt.Fprintf(out, "%s done\n", prefix)
 	}
 
+	return fullCheckpoint, nil
+}
+
+func packMigratedFullGenerations(ctx context.Context, repo *git.Repository, v2Store *checkpoint.V2GitStore, checkpoints []migratedFullCheckpoint, ensureEmptyCurrent bool) error {
+	if len(checkpoints) == 0 {
+		if ensureEmptyCurrent {
+			return ensureEmptyV2FullCurrent(ctx, repo)
+		}
+		return nil
+	}
+
+	batchSize := migrateMaxCheckpointsPerGeneration
+	if batchSize <= 0 {
+		batchSize = checkpoint.DefaultMaxCheckpointsPerGeneration
+	}
+
+	nextGeneration, err := nextMigratedGenerationNumber(v2Store)
+	if err != nil {
+		return err
+	}
+
+	for start := 0; start < len(checkpoints); start += batchSize {
+		end := min(start+batchSize, len(checkpoints))
+
+		refName := plumbing.ReferenceName(fmt.Sprintf("%s%013d", paths.V2FullRefPrefix, nextGeneration))
+		if err := writeMigratedFullGeneration(ctx, repo, refName, checkpoints[start:end]); err != nil {
+			return err
+		}
+		nextGeneration++
+	}
+
+	if ensureEmptyCurrent {
+		return ensureEmptyV2FullCurrent(ctx, repo)
+	}
+	return nil
+}
+
+func nextMigratedGenerationNumber(v2Store *checkpoint.V2GitStore) (int, error) {
+	archived, err := v2Store.ListArchivedGenerations()
+	if err != nil {
+		return 0, fmt.Errorf("list archived v2 generations: %w", err)
+	}
+	next := 1
+	for _, name := range archived {
+		n, parseErr := strconv.Atoi(name)
+		if parseErr != nil {
+			continue
+		}
+		if n >= next {
+			next = n + 1
+		}
+	}
+	return next, nil
+}
+
+func writeMigratedFullGeneration(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, checkpoints []migratedFullCheckpoint) error {
+	entries := make(map[string]object.TreeEntry)
+	var gen checkpoint.GenerationMetadata
+	foundTime := false
+
+	for _, cp := range checkpoints {
+		for _, session := range cp.sessions {
+			if err := writeMigratedFullSessionEntries(ctx, repo, cp, session, entries); err != nil {
+				return fmt.Errorf("write full session entries for checkpoint %s session %d: %w", cp.checkpointID, session.sessionIndex, err)
+			}
+			mergeMigratedGenerationTime(&gen, &foundTime, session.content.Metadata.CreatedAt)
+		}
+	}
+
+	if !foundTime {
+		now := time.Now().UTC()
+		gen = checkpoint.GenerationMetadata{
+			OldestCheckpointAt: now,
+			NewestCheckpointAt: now,
+		}
+	}
+
+	treeHash, err := checkpoint.BuildTreeFromEntries(ctx, repo, entries)
+	if err != nil {
+		return fmt.Errorf("build migrated generation tree: %w", err)
+	}
+
+	v2Store := checkpoint.NewV2GitStore(repo, migrateRemoteName)
+	treeHash, err = v2Store.AddGenerationJSONToTree(treeHash, gen)
+	if err != nil {
+		return fmt.Errorf("add generation metadata: %w", err)
+	}
+
+	commitHash, err := checkpoint.CreateCommit(ctx, repo, treeHash, plumbing.ZeroHash,
+		fmt.Sprintf("Archive migrated generation: %s\n", refName),
+		"Entire Migration", "migration@entire.dev")
+	if err != nil {
+		return fmt.Errorf("create migrated generation commit: %w", err)
+	}
+
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)); err != nil {
+		return fmt.Errorf("update migrated generation ref %s: %w", refName, err)
+	}
+	return nil
+}
+
+func writeMigratedFullSessionEntries(ctx context.Context, repo *git.Repository, cp migratedFullCheckpoint, session migratedFullSession, entries map[string]object.TreeEntry) error {
+	sessionPath := fmt.Sprintf("%s/%d/", cp.checkpointID.Path(), session.sessionIndex)
+	transcript := session.content.Transcript
+
+	chunks, err := agent.ChunkTranscript(ctx, transcript, session.content.Metadata.Agent)
+	if err != nil {
+		return fmt.Errorf("chunk transcript: %w", err)
+	}
+	for i, chunk := range chunks {
+		blobHash, blobErr := checkpoint.CreateBlobFromContent(repo, chunk)
+		if blobErr != nil {
+			return fmt.Errorf("create transcript blob: %w", blobErr)
+		}
+		path := sessionPath + agent.ChunkFileName(paths.V2RawTranscriptFileName, i)
+		entries[path] = object.TreeEntry{
+			Name: path,
+			Mode: filemode.Regular,
+			Hash: blobHash,
+		}
+	}
+
+	hashPath := sessionPath + paths.V2RawTranscriptHashFileName
+	contentHash := fmt.Sprintf("sha256:%x", sha256.Sum256(transcript))
+	hashBlob, err := checkpoint.CreateBlobFromContent(repo, []byte(contentHash))
+	if err != nil {
+		return fmt.Errorf("create transcript hash blob: %w", err)
+	}
+	entries[hashPath] = object.TreeEntry{
+		Name: hashPath,
+		Mode: filemode.Regular,
+		Hash: hashBlob,
+	}
+
+	for _, taskTreeHash := range cp.taskTrees[session.sessionIndex] {
+		taskTree, treeErr := repo.TreeObject(taskTreeHash)
+		if treeErr != nil {
+			return fmt.Errorf("read task metadata tree: %w", treeErr)
+		}
+		if flattenErr := checkpoint.FlattenTree(repo, taskTree, sessionPath+"tasks", entries); flattenErr != nil {
+			return fmt.Errorf("flatten task metadata tree: %w", flattenErr)
+		}
+	}
+
+	return nil
+}
+
+func mergeMigratedGenerationTime(gen *checkpoint.GenerationMetadata, found *bool, ts time.Time) {
+	if ts.IsZero() {
+		return
+	}
+	ts = ts.UTC()
+	if !*found {
+		gen.OldestCheckpointAt = ts
+		gen.NewestCheckpointAt = ts
+		*found = true
+		return
+	}
+	if ts.Before(gen.OldestCheckpointAt) {
+		gen.OldestCheckpointAt = ts
+	}
+	if ts.After(gen.NewestCheckpointAt) {
+		gen.NewestCheckpointAt = ts
+	}
+}
+
+func ensureEmptyV2FullCurrent(ctx context.Context, repo *git.Repository) error {
+	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+	if _, err := repo.Reference(refName, true); err == nil {
+		return nil
+	}
+
+	emptyTreeHash, err := checkpoint.BuildTreeFromEntries(ctx, repo, map[string]object.TreeEntry{})
+	if err != nil {
+		return fmt.Errorf("build empty v2 full/current tree: %w", err)
+	}
+
+	commitHash, err := checkpoint.CreateCommit(ctx, repo, emptyTreeHash, plumbing.ZeroHash,
+		"Start generation\n",
+		"Entire Migration", "migration@entire.dev")
+	if err != nil {
+		return fmt.Errorf("create empty v2 full/current commit: %w", err)
+	}
+
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)); err != nil {
+		return fmt.Errorf("update %s: %w", refName, err)
+	}
 	return nil
 }
 
@@ -636,22 +893,19 @@ func computeCompactOffset(ctx context.Context, fullTranscript, fullCompact []byt
 	return offset
 }
 
-// copyTaskMetadataToV2 copies task metadata files (subagent transcripts, checkpoint JSONs)
-// from the v1 branch to the v2 /full/current ref via tree surgery.
-func copyTaskMetadataToV2(ctx context.Context, repo *git.Repository, _ *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, summary *checkpoint.CheckpointSummary, v1ToV2SessionIdx map[int]int) error {
-	// Resolve the v1 branch tree
+func collectTaskMetadataForMigratedFullGeneration(repo *git.Repository, cpID id.CheckpointID, summary *checkpoint.CheckpointSummary, v1ToV2SessionIdx map[int]int) (map[int][]plumbing.Hash, error) {
 	v1Tree, err := resolveV1CheckpointTree(repo, cpID)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	taskTrees := make(map[int][]plumbing.Hash)
 
 	// Legacy v1 layout stores task metadata at checkpoint root: <cp>/tasks/<tool-use-id>/...
 	// Prefer attaching this tree to the latest session in v2.
 	if rootTasksTree, rootTasksErr := v1Tree.Tree("tasks"); rootTasksErr == nil {
 		if latestSessionIdx, ok := latestMigratedV2SessionIndex(v1ToV2SessionIdx); ok {
-			if spliceErr := spliceTasksTreeToV2(ctx, repo, v2Store, cpID, latestSessionIdx, rootTasksTree.Hash); spliceErr != nil {
-				return fmt.Errorf("latest session task tree splice failed: %w", spliceErr)
-			}
+			taskTrees[latestSessionIdx] = append(taskTrees[latestSessionIdx], rootTasksTree.Hash)
 		}
 	}
 
@@ -664,20 +918,17 @@ func copyTaskMetadataToV2(ctx context.Context, repo *git.Repository, _ *checkpoi
 
 		tasksTree, tasksErr := sessionTree.Tree("tasks")
 		if tasksErr != nil {
-			continue // No tasks directory in this session
+			continue
 		}
 
 		v2SessionIdx, ok := v1ToV2SessionIdx[sessionIdx]
 		if !ok {
 			continue
 		}
-
-		if spliceErr := spliceTasksTreeToV2(ctx, repo, v2Store, cpID, v2SessionIdx, tasksTree.Hash); spliceErr != nil {
-			return fmt.Errorf("session %d task tree splice failed: %w", sessionIdx, spliceErr)
-		}
+		taskTrees[v2SessionIdx] = append(taskTrees[v2SessionIdx], tasksTree.Hash)
 	}
 
-	return nil
+	return taskTrees, nil
 }
 
 func latestMigratedV2SessionIndex(v1ToV2SessionIdx map[int]int) (int, bool) {

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -740,6 +740,14 @@ func collectMissingFullCheckpointForPacking(
 	info checkpoint.CommittedInfo,
 	v2Summary *checkpoint.CheckpointSummary,
 ) (*migratedFullCheckpoint, bool, error) {
+	missingSessions, err := collectMissingFullSessionsForPacking(ctx, v2Store, info.CheckpointID, v2Summary)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(missingSessions) == 0 {
+		return &migratedFullCheckpoint{}, false, nil
+	}
+
 	v1Summary, err := v1Store.ReadCommitted(ctx, info.CheckpointID)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to read v1 summary while checking v2 raw artifacts: %w", err)
@@ -748,7 +756,7 @@ func collectMissingFullCheckpointForPacking(
 		return nil, false, fmt.Errorf("v1 checkpoint %s has no summary", info.CheckpointID)
 	}
 
-	v1BySessionID, v1ByIndex, err := collectV1SessionsForPacking(ctx, v1Store, info.CheckpointID, v1Summary)
+	v1BySessionID, err := collectV1SessionIndexesForPacking(ctx, v1Store, info.CheckpointID, v1Summary, missingSessions)
 	if err != nil {
 		return nil, false, err
 	}
@@ -758,37 +766,20 @@ func collectMissingFullCheckpointForPacking(
 	}
 	v1ToV2SessionIdx := make(map[int]int)
 
-	for sessionIdx := range len(v2Summary.Sessions) {
-		ok, checkErr := hasFullSessionArtifacts(v2Store, info.CheckpointID, sessionIdx)
-		if checkErr != nil {
-			return nil, false, fmt.Errorf("failed to check v2 session %d artifacts: %w", sessionIdx, checkErr)
-		}
-		if ok {
-			continue
-		}
-
-		v2Content, readErr := v2Store.ReadSessionMetadataAndPrompts(ctx, info.CheckpointID, sessionIdx)
+	for _, missingSession := range missingSessions {
+		v1Session, ok, readErr := readV1SessionForMissingFullArtifact(ctx, v1Store, info.CheckpointID, v1Summary, v1BySessionID, missingSession)
 		if readErr != nil {
-			return nil, false, fmt.Errorf("failed to read v2 session %d metadata while checking raw artifacts: %w", sessionIdx, readErr)
-		}
-
-		v1Session, ok := v1BySessionID[v2Content.Metadata.SessionID]
-		if !ok {
-			v1Session, ok = v1ByIndex[sessionIdx]
+			return nil, false, readErr
 		}
 		if !ok {
-			return nil, false, fmt.Errorf("failed to find v1 session for v2 session %d while checking raw artifacts", sessionIdx)
+			return nil, false, fmt.Errorf("failed to find v1 session for v2 session %d while checking raw artifacts", missingSession.sessionIndex)
 		}
 
 		fullCheckpoint.sessions = append(fullCheckpoint.sessions, migratedFullSession{
-			sessionIndex: sessionIdx,
+			sessionIndex: missingSession.sessionIndex,
 			content:      v1Session.content,
 		})
-		v1ToV2SessionIdx[v1Session.sessionIndex] = sessionIdx
-	}
-
-	if len(fullCheckpoint.sessions) == 0 {
-		return &migratedFullCheckpoint{}, false, nil
+		v1ToV2SessionIdx[v1Session.sessionIndex] = missingSession.sessionIndex
 	}
 
 	taskTrees, taskErr := collectTaskMetadataForMigratedFullGeneration(repo, info.CheckpointID, v1Summary, v1ToV2SessionIdx)
@@ -800,40 +791,130 @@ func collectMissingFullCheckpointForPacking(
 	return fullCheckpoint, true, nil
 }
 
+type missingFullSessionForPacking struct {
+	sessionIndex int
+	sessionID    string
+}
+
 type v1SessionForPacking struct {
 	sessionIndex int
 	content      *checkpoint.SessionContent
 }
 
-func collectV1SessionsForPacking(
+func collectMissingFullSessionsForPacking(
+	ctx context.Context,
+	v2Store *checkpoint.V2GitStore,
+	checkpointID id.CheckpointID,
+	summary *checkpoint.CheckpointSummary,
+) ([]missingFullSessionForPacking, error) {
+	missingSessions := make([]missingFullSessionForPacking, 0)
+	for sessionIdx := range len(summary.Sessions) {
+		ok, checkErr := hasFullSessionArtifacts(v2Store, checkpointID, sessionIdx)
+		if checkErr != nil {
+			return nil, fmt.Errorf("failed to check v2 session %d artifacts: %w", sessionIdx, checkErr)
+		}
+		if ok {
+			continue
+		}
+
+		v2Content, readErr := v2Store.ReadSessionMetadataAndPrompts(ctx, checkpointID, sessionIdx)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read v2 session %d metadata while checking raw artifacts: %w", sessionIdx, readErr)
+		}
+
+		missingSessions = append(missingSessions, missingFullSessionForPacking{
+			sessionIndex: sessionIdx,
+			sessionID:    v2Content.Metadata.SessionID,
+		})
+	}
+
+	return missingSessions, nil
+}
+
+func collectV1SessionIndexesForPacking(
 	ctx context.Context,
 	v1Store *checkpoint.GitStore,
 	checkpointID id.CheckpointID,
 	summary *checkpoint.CheckpointSummary,
-) (map[string]v1SessionForPacking, map[int]v1SessionForPacking, error) {
-	bySessionID := make(map[string]v1SessionForPacking)
-	byIndex := make(map[int]v1SessionForPacking)
-
-	for sessionIdx := range len(summary.Sessions) {
-		content, err := v1Store.ReadSessionContent(ctx, checkpointID, sessionIdx)
-		if err != nil {
-			if errors.Is(err, checkpoint.ErrNoTranscript) || errors.Is(err, checkpoint.ErrCheckpointNotFound) {
-				continue
-			}
-			return nil, nil, fmt.Errorf("failed to read v1 session %d while checking raw artifacts: %w", sessionIdx, err)
-		}
-
-		session := v1SessionForPacking{
-			sessionIndex: sessionIdx,
-			content:      content,
-		}
-		byIndex[sessionIdx] = session
-		if content.Metadata.SessionID != "" {
-			bySessionID[content.Metadata.SessionID] = session
+	missingSessions []missingFullSessionForPacking,
+) (map[string][]int, error) {
+	neededSessionIDs := make(map[string]struct{})
+	for _, session := range missingSessions {
+		if session.sessionID != "" {
+			neededSessionIDs[session.sessionID] = struct{}{}
 		}
 	}
 
-	return bySessionID, byIndex, nil
+	bySessionID := make(map[string][]int)
+	if len(neededSessionIDs) == 0 {
+		return bySessionID, nil
+	}
+
+	for sessionIdx := range len(summary.Sessions) {
+		metadata, err := v1Store.ReadSessionMetadata(ctx, checkpointID, sessionIdx)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, fmt.Errorf("context canceled while reading v1 session metadata: %w", ctxErr)
+			}
+			continue
+		}
+		if _, ok := neededSessionIDs[metadata.SessionID]; ok {
+			bySessionID[metadata.SessionID] = append(bySessionID[metadata.SessionID], sessionIdx)
+		}
+	}
+
+	return bySessionID, nil
+}
+
+func readV1SessionForMissingFullArtifact(
+	ctx context.Context,
+	v1Store *checkpoint.GitStore,
+	checkpointID id.CheckpointID,
+	summary *checkpoint.CheckpointSummary,
+	bySessionID map[string][]int,
+	missingSession missingFullSessionForPacking,
+) (v1SessionForPacking, bool, error) {
+	var triedSessionIndexes map[int]struct{}
+	if missingSession.sessionID != "" {
+		indexes := bySessionID[missingSession.sessionID]
+		triedSessionIndexes = make(map[int]struct{}, len(indexes))
+		for i := len(indexes) - 1; i >= 0; i-- {
+			sessionIdx := indexes[i]
+			triedSessionIndexes[sessionIdx] = struct{}{}
+			session, found, err := readV1SessionForPacking(ctx, v1Store, checkpointID, sessionIdx)
+			if err != nil || found {
+				return session, found, err
+			}
+		}
+	}
+
+	if missingSession.sessionIndex >= len(summary.Sessions) {
+		return v1SessionForPacking{}, false, nil
+	}
+	if _, tried := triedSessionIndexes[missingSession.sessionIndex]; tried {
+		return v1SessionForPacking{}, false, nil
+	}
+	return readV1SessionForPacking(ctx, v1Store, checkpointID, missingSession.sessionIndex)
+}
+
+func readV1SessionForPacking(
+	ctx context.Context,
+	v1Store *checkpoint.GitStore,
+	checkpointID id.CheckpointID,
+	sessionIdx int,
+) (v1SessionForPacking, bool, error) {
+	content, err := v1Store.ReadSessionContent(ctx, checkpointID, sessionIdx)
+	if err != nil {
+		if errors.Is(err, checkpoint.ErrNoTranscript) || errors.Is(err, checkpoint.ErrCheckpointNotFound) {
+			return v1SessionForPacking{}, false, nil
+		}
+		return v1SessionForPacking{}, false, fmt.Errorf("failed to read v1 session %d while checking raw artifacts: %w", sessionIdx, err)
+	}
+
+	return v1SessionForPacking{
+		sessionIndex: sessionIdx,
+		content:      content,
+	}, true, nil
 }
 
 func hasFullSessionArtifacts(v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int) (bool, error) {
@@ -1133,41 +1214,4 @@ func cleanupV1TranscriptFiles(ctx context.Context, _ *git.Repository, v2Store *c
 			slog.String("error", err.Error()),
 		)
 	}
-}
-
-func spliceTasksTreeToV2(ctx context.Context, repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int, tasksTreeHash plumbing.Hash) error {
-	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
-	parentHash, rootTreeHash, err := v2Store.GetRefState(refName)
-	if err != nil {
-		return fmt.Errorf("failed to get v2 ref state: %w", err)
-	}
-	incomingTasksTree, err := repo.TreeObject(tasksTreeHash)
-	if err != nil {
-		return fmt.Errorf("failed to read tasks tree: %w", err)
-	}
-
-	shardPrefix := string(cpID[:2])
-	shardSuffix := string(cpID[2:])
-	sessionDir := strconv.Itoa(sessionIdx)
-
-	newRoot, err := checkpoint.UpdateSubtree(repo, rootTreeHash,
-		[]string{shardPrefix, shardSuffix, sessionDir, "tasks"},
-		incomingTasksTree.Entries,
-		checkpoint.UpdateSubtreeOptions{MergeMode: checkpoint.MergeKeepExisting},
-	)
-	if err != nil {
-		return fmt.Errorf("tree surgery failed: %w", err)
-	}
-
-	commitHash, err := checkpoint.CreateCommit(ctx, repo, newRoot, parentHash,
-		fmt.Sprintf("Add task metadata for %s\n", cpID),
-		migrateAuthorName, migrateAuthorEmail)
-	if err != nil {
-		return fmt.Errorf("failed to create commit: %w", err)
-	}
-
-	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)); err != nil {
-		return fmt.Errorf("failed to update ref %s: %w", refName, err)
-	}
-	return nil
 }

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -138,6 +138,7 @@ var (
 	errAlreadyMigrated          = errors.New("already migrated")
 	errTranscriptNotGeneratable = errors.New("transcript.jsonl could not be generated")
 	errNoMigratableSessions     = errors.New("no migratable v1 sessions")
+	errNoFullArtifactsToPack    = errors.New("no missing full artifacts to pack")
 )
 
 const (
@@ -180,7 +181,8 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 	result := &migrateResult{}
 	_, fullCurrentRefErr := repo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
 	fullCurrentExistsBefore := fullCurrentRefErr == nil
-	var migratedFullCheckpoints []migratedFullCheckpoint
+
+	packer := newGenerationPacker(repo, v2Store, out)
 
 	for i, info := range v1List {
 		prefix := fmt.Sprintf("  [%d/%d] Migrating checkpoint %s...", i+1, total, info.CheckpointID)
@@ -197,6 +199,8 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 			case errors.Is(migrateErr, errNoMigratableSessions):
 				fmt.Fprintf(out, "%s skipped (%s)\n", prefix, migrateErr.Error())
 				result.skipped++
+			case errors.Is(migrateErr, errNoFullArtifactsToPack):
+				result.migrated++
 			default:
 				fmt.Fprintf(out, "%s failed\n", prefix)
 				logging.Error(ctx, "checkpoint migration failed",
@@ -208,17 +212,14 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 			continue
 		}
 
-		if fullCheckpoint != nil && len(fullCheckpoint.sessions) > 0 {
-			migratedFullCheckpoints = append(migratedFullCheckpoints, *fullCheckpoint)
+		if packErr := packer.add(ctx, *fullCheckpoint); packErr != nil {
+			return result, fmt.Errorf("failed to pack migrated raw transcripts: %w", packErr)
 		}
 		result.migrated++
 	}
 
-	if len(migratedFullCheckpoints) > 0 {
-		fmt.Fprintf(out, "Packing raw transcripts into v2 archived generations...\n")
-		if packErr := packMigratedFullGenerations(ctx, repo, v2Store, migratedFullCheckpoints, !fullCurrentExistsBefore); packErr != nil {
-			return result, fmt.Errorf("failed to pack migrated raw transcripts: %w", packErr)
-		}
+	if err := packer.finalize(ctx, !fullCurrentExistsBefore); err != nil {
+		return result, fmt.Errorf("failed to pack migrated raw transcripts: %w", err)
 	}
 
 	return result, nil
@@ -272,7 +273,7 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 			if backfillErr != nil {
 				return nil, backfillErr
 			}
-			return &migratedFullCheckpoint{}, nil
+			return nil, errNoFullArtifactsToPack
 		}
 		if backfillErr != nil &&
 			!errors.Is(backfillErr, errAlreadyMigrated) &&
@@ -377,36 +378,75 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 	return fullCheckpoint, nil
 }
 
-func packMigratedFullGenerations(ctx context.Context, repo *git.Repository, v2Store *checkpoint.V2GitStore, checkpoints []migratedFullCheckpoint, ensureEmptyCurrent bool) error {
-	if len(checkpoints) == 0 {
-		if ensureEmptyCurrent {
-			return ensureEmptyV2FullCurrent(ctx, repo)
-		}
-		return nil
-	}
+// generationPacker buffers up to batchSize migrated checkpoints and flushes
+// them into a single archived /full/<n> ref each time the buffer fills, so
+// peak heap stays bounded by one batch worth of transcripts instead of
+// growing with the total v1 list. The next generation number is resolved
+// lazily on first flush so force-migration prune steps that remove existing
+// archived refs are visible before we pick the next slot.
+type generationPacker struct {
+	repo           *git.Repository
+	v2Store        *checkpoint.V2GitStore
+	out            io.Writer
+	batchSize      int
+	nextGeneration int
+	numbered       bool
+	pending        []migratedFullCheckpoint
+	flushed        bool
+}
 
+func newGenerationPacker(repo *git.Repository, v2Store *checkpoint.V2GitStore, out io.Writer) *generationPacker {
 	batchSize := migrateMaxCheckpointsPerGeneration
 	if batchSize <= 0 {
 		batchSize = checkpoint.DefaultMaxCheckpointsPerGeneration
 	}
-
-	nextGeneration, err := v2Store.NextGenerationNumber()
-	if err != nil {
-		return fmt.Errorf("list archived v2 generations: %w", err)
+	return &generationPacker{
+		repo:      repo,
+		v2Store:   v2Store,
+		out:       out,
+		batchSize: batchSize,
 	}
+}
 
-	for start := 0; start < len(checkpoints); start += batchSize {
-		end := min(start+batchSize, len(checkpoints))
+func (p *generationPacker) add(ctx context.Context, cp migratedFullCheckpoint) error {
+	p.pending = append(p.pending, cp)
+	if len(p.pending) >= p.batchSize {
+		return p.flush(ctx)
+	}
+	return nil
+}
 
-		refName := plumbing.ReferenceName(fmt.Sprintf("%s%013d", paths.V2FullRefPrefix, nextGeneration))
-		if err := writeMigratedFullGeneration(ctx, repo, refName, checkpoints[start:end]); err != nil {
-			return err
+func (p *generationPacker) flush(ctx context.Context) error {
+	if len(p.pending) == 0 {
+		return nil
+	}
+	if !p.numbered {
+		next, err := p.v2Store.NextGenerationNumber()
+		if err != nil {
+			return fmt.Errorf("list archived v2 generations: %w", err)
 		}
-		nextGeneration++
+		p.nextGeneration = next
+		p.numbered = true
 	}
+	if !p.flushed {
+		fmt.Fprintf(p.out, "Packing raw transcripts into v2 archived generations...\n")
+	}
+	refName := plumbing.ReferenceName(fmt.Sprintf("%s%013d", paths.V2FullRefPrefix, p.nextGeneration))
+	if err := writeMigratedFullGeneration(ctx, p.repo, refName, p.pending); err != nil {
+		return err
+	}
+	p.nextGeneration++
+	p.pending = nil
+	p.flushed = true
+	return nil
+}
 
-	if ensureEmptyCurrent {
-		return ensureEmptyV2FullCurrent(ctx, repo)
+func (p *generationPacker) finalize(ctx context.Context, ensureEmptyCurrent bool) error {
+	if err := p.flush(ctx); err != nil {
+		return err
+	}
+	if p.flushed && ensureEmptyCurrent {
+		return ensureEmptyV2FullCurrent(ctx, p.repo)
 	}
 	return nil
 }
@@ -745,7 +785,7 @@ func collectMissingFullCheckpointForPacking(
 		return nil, false, err
 	}
 	if len(missingSessions) == 0 {
-		return &migratedFullCheckpoint{}, false, nil
+		return nil, false, nil
 	}
 
 	v1Summary, err := v1Store.ReadCommitted(ctx, info.CheckpointID)

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -397,6 +397,16 @@ func TestMigrateCheckpointsV2_ForceOverwritesExisting(t *testing.T) {
 	require.NoError(t, readErr)
 	require.NotNil(t, summary)
 	assert.Equal(t, cpID, summary.CheckpointID)
+
+	archived, err := v2Store.ListArchivedGenerations()
+	require.NoError(t, err)
+	require.Equal(t, []string{"0000000000001"}, archived, "force migration should replace archived raw transcripts instead of duplicating them into a later generation")
+
+	_, currentTreeHash, err := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
+	require.NoError(t, err)
+	currentCount, err := v2Store.CountCheckpointsInTree(currentTreeHash)
+	require.NoError(t, err)
+	assert.Equal(t, 0, currentCount, "force migration should leave /full/current empty for post-migration writes")
 }
 
 func TestMigrateCheckpointsV2_ForceMultipleCheckpoints(t *testing.T) {

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -439,6 +439,67 @@ func TestMigrateCheckpointsV2_ForceMultipleCheckpoints(t *testing.T) {
 	assert.Equal(t, 0, result2.skipped)
 }
 
+func TestPruneV2CheckpointForForce_RecomputesPartialArchivedGeneration(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+	ctx := context.Background()
+
+	cpID1 := id.MustCheckpointID("101010101010")
+	cpID2 := id.MustCheckpointID("202020202020")
+	cp1CreatedAt := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	cp2CreatedAt := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	for _, cp := range []struct {
+		id        id.CheckpointID
+		sessionID string
+		createdAt time.Time
+	}{
+		{cpID1, "session-force-prune-1", cp1CreatedAt},
+		{cpID2, "session-force-prune-2", cp2CreatedAt},
+	} {
+		err := v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+			CheckpointID: cp.id,
+			SessionID:    cp.sessionID,
+			CreatedAt:    cp.createdAt,
+			Strategy:     "manual-commit",
+			Transcript:   redact.AlreadyRedacted([]byte("{\"type\":\"assistant\",\"message\":\"force prune\"}\n")),
+			AuthorName:   "Test",
+			AuthorEmail:  "test@test.com",
+		})
+		require.NoError(t, err)
+	}
+
+	var stdout bytes.Buffer
+	result, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.migrated)
+
+	require.NoError(t, pruneV2CheckpointForForce(ctx, repo, v2Store, cpID1))
+
+	archived, err := v2Store.ListArchivedGenerations()
+	require.NoError(t, err)
+	require.Equal(t, []string{"0000000000001"}, archived)
+
+	refName := plumbing.ReferenceName(paths.V2FullRefPrefix + archived[0])
+	_, treeHash, err := v2Store.GetRefState(refName)
+	require.NoError(t, err)
+	count, err := v2Store.CountCheckpointsInTree(treeHash)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	rootTree, err := repo.TreeObject(treeHash)
+	require.NoError(t, err)
+	_, err = rootTree.Tree(cpID1.Path())
+	require.Error(t, err, "force prune should remove the target checkpoint from archived generations")
+	_, err = rootTree.Tree(cpID2.Path())
+	require.NoError(t, err, "force prune should preserve other checkpoints in the archived generation")
+
+	gen, err := v2Store.ReadGenerationFromRef(refName)
+	require.NoError(t, err)
+	assert.True(t, gen.OldestCheckpointAt.Equal(cp2CreatedAt))
+	assert.True(t, gen.NewestCheckpointAt.Equal(cp2CreatedAt))
+}
+
 func TestMigrateCmd_ForceFlag(t *testing.T) {
 	t.Parallel()
 	cmd := newMigrateCmd()

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -1457,3 +1457,86 @@ func TestMigrateCheckpointsV2_PreservesCombinedAttribution(t *testing.T) {
 	assert.InDelta(t, combined.AgentPercentage, v2Summary.CombinedAttribution.AgentPercentage, 0.001)
 	assert.Equal(t, combined.MetricVersion, v2Summary.CombinedAttribution.MetricVersion)
 }
+
+func TestSortMigratableCheckpoints(t *testing.T) {
+	t.Parallel()
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		input []checkpoint.CommittedInfo
+		want  []id.CheckpointID
+	}{
+		{
+			name: "chronological order",
+			input: []checkpoint.CommittedInfo{
+				{CheckpointID: id.MustCheckpointID("000000000003"), CreatedAt: t3},
+				{CheckpointID: id.MustCheckpointID("000000000001"), CreatedAt: t1},
+				{CheckpointID: id.MustCheckpointID("000000000002"), CreatedAt: t2},
+			},
+			want: []id.CheckpointID{
+				id.MustCheckpointID("000000000001"),
+				id.MustCheckpointID("000000000002"),
+				id.MustCheckpointID("000000000003"),
+			},
+		},
+		{
+			name: "ties on CreatedAt break by checkpoint ID",
+			input: []checkpoint.CommittedInfo{
+				{CheckpointID: id.MustCheckpointID("0000000000bb"), CreatedAt: t1},
+				{CheckpointID: id.MustCheckpointID("0000000000aa"), CreatedAt: t1},
+				{CheckpointID: id.MustCheckpointID("0000000000cc"), CreatedAt: t1},
+			},
+			want: []id.CheckpointID{
+				id.MustCheckpointID("0000000000aa"),
+				id.MustCheckpointID("0000000000bb"),
+				id.MustCheckpointID("0000000000cc"),
+			},
+		},
+		{
+			name: "zero CreatedAt sorts after non-zero, ties by ID",
+			input: []checkpoint.CommittedInfo{
+				{CheckpointID: id.MustCheckpointID("0000000000aa")},
+				{CheckpointID: id.MustCheckpointID("000000000002"), CreatedAt: t2},
+				{CheckpointID: id.MustCheckpointID("0000000000bb")},
+				{CheckpointID: id.MustCheckpointID("000000000001"), CreatedAt: t1},
+			},
+			want: []id.CheckpointID{
+				id.MustCheckpointID("000000000001"),
+				id.MustCheckpointID("000000000002"),
+				id.MustCheckpointID("0000000000aa"),
+				id.MustCheckpointID("0000000000bb"),
+			},
+		},
+		{
+			name: "all-zero CreatedAt sorts by ID",
+			input: []checkpoint.CommittedInfo{
+				{CheckpointID: id.MustCheckpointID("0000000000cc")},
+				{CheckpointID: id.MustCheckpointID("0000000000aa")},
+				{CheckpointID: id.MustCheckpointID("0000000000bb")},
+			},
+			want: []id.CheckpointID{
+				id.MustCheckpointID("0000000000aa"),
+				id.MustCheckpointID("0000000000bb"),
+				id.MustCheckpointID("0000000000cc"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := make([]checkpoint.CommittedInfo, len(tt.input))
+			copy(input, tt.input)
+			sortMigratableCheckpoints(input)
+			got := make([]id.CheckpointID, len(input))
+			for i, c := range input {
+				got[i] = c.CheckpointID
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -155,6 +155,94 @@ func TestMigrateCheckpointsV2_PreservesCreatedAt(t *testing.T) {
 	assert.True(t, content.Metadata.CreatedAt.Equal(createdAt))
 }
 
+func TestMigrateCheckpointsV2_PacksFullGenerationsOldestFirst(t *testing.T) {
+	oldMax := migrateMaxCheckpointsPerGeneration
+	migrateMaxCheckpointsPerGeneration = 2
+	t.Cleanup(func() {
+		migrateMaxCheckpointsPerGeneration = oldMax
+	})
+
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+	ctx := context.Background()
+
+	checkpointIDs := []id.CheckpointID{
+		id.MustCheckpointID("000000000001"),
+		id.MustCheckpointID("000000000002"),
+		id.MustCheckpointID("000000000003"),
+		id.MustCheckpointID("000000000004"),
+		id.MustCheckpointID("000000000005"),
+	}
+	createdAt := []time.Time{
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 4, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+	}
+
+	// Write in non-chronological order to prove migration repacks by checkpoint time,
+	// not v1 tree traversal or v1 ListCommitted's newest-first order.
+	for _, idx := range []int{3, 1, 4, 0, 2} {
+		err := v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+			CheckpointID: checkpointIDs[idx],
+			SessionID:    "session-pack-" + strconv.Itoa(idx),
+			CreatedAt:    createdAt[idx],
+			Strategy:     "manual-commit",
+			Transcript: redact.AlreadyRedacted([]byte(
+				`{"type":"assistant","message":"checkpoint ` + strconv.Itoa(idx) + `"}` + "\n",
+			)),
+			Prompts:     []string{"prompt " + strconv.Itoa(idx)},
+			AuthorName:  "Test",
+			AuthorEmail: "test@test.com",
+		})
+		require.NoError(t, err)
+	}
+
+	var stdout bytes.Buffer
+	result, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, err)
+	assert.Equal(t, 5, result.migrated)
+	assert.Equal(t, 0, result.skipped)
+	assert.Equal(t, 0, result.failed)
+
+	archived, err := v2Store.ListArchivedGenerations()
+	require.NoError(t, err)
+	require.Equal(t, []string{"0000000000001", "0000000000002", "0000000000003"}, archived)
+
+	expectedBatches := [][]int{
+		{0, 1},
+		{2, 3},
+		{4},
+	}
+	for genIdx, batch := range expectedBatches {
+		refName := plumbing.ReferenceName(paths.V2FullRefPrefix + archived[genIdx])
+		gen, genErr := v2Store.ReadGenerationFromRef(refName)
+		require.NoError(t, genErr)
+		assert.True(t, gen.OldestCheckpointAt.Equal(createdAt[batch[0]]), "generation %s oldest", archived[genIdx])
+		assert.True(t, gen.NewestCheckpointAt.Equal(createdAt[batch[len(batch)-1]]), "generation %s newest", archived[genIdx])
+
+		_, treeHash, refErr := v2Store.GetRefState(refName)
+		require.NoError(t, refErr)
+		count, countErr := v2Store.CountCheckpointsInTree(treeHash)
+		require.NoError(t, countErr)
+		assert.Equal(t, len(batch), count)
+
+		tree, treeErr := repo.TreeObject(treeHash)
+		require.NoError(t, treeErr)
+		for _, idx := range batch {
+			_, treeErr = tree.Tree(checkpointIDs[idx].Path())
+			require.NoError(t, treeErr, "generation %s should contain checkpoint %s", archived[genIdx], checkpointIDs[idx])
+		}
+	}
+
+	_, currentTreeHash, err := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
+	require.NoError(t, err)
+	currentCount, err := v2Store.CountCheckpointsInTree(currentTreeHash)
+	require.NoError(t, err)
+	assert.Equal(t, 0, currentCount, "fresh migration should leave /full/current empty for post-migration writes")
+}
+
 func TestMigrateCheckpointsV2_Idempotent(t *testing.T) {
 	t.Parallel()
 	repo := initMigrateTestRepo(t)
@@ -414,10 +502,7 @@ func TestMigrateCheckpointsV2_TaskMetadataUsesMigratedSessionIndexAfterSkip(t *t
 	require.Len(t, summary.Sessions, 2)
 	assert.Equal(t, "/"+cpID.Path()+"/1/metadata.json", summary.Sessions[1].Metadata)
 
-	_, rootTreeHash, refErr := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
-	require.NoError(t, refErr)
-	rootTree, treeErr := repo.TreeObject(rootTreeHash)
-	require.NoError(t, treeErr)
+	rootTree := v2FullTreeForCheckpoint(t, repo, v2Store, cpID)
 
 	_, err = rootTree.File(cpID.Path() + "/1/tasks/toolu_root_shifted/checkpoint.json")
 	require.NoError(t, err, "root task metadata should follow the shifted v2 session index")
@@ -699,13 +784,10 @@ func TestMigrateCheckpointsV2_TaskCheckpoint(t *testing.T) {
 	require.NoError(t, readErr)
 	require.NotNil(t, summary)
 
-	// Verify task metadata tree was copied into v2 /full/current.
-	_, rootTreeHash, refErr := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
-	require.NoError(t, refErr)
-	rootTree, treeErr := repo.TreeObject(rootTreeHash)
-	require.NoError(t, treeErr)
+	// Verify task metadata tree was copied into the migrated v2 /full/* generation.
+	rootTree := v2FullTreeForCheckpoint(t, repo, v2Store, cpID)
 	_, taskFileErr := rootTree.File(cpID.Path() + "/0/tasks/toolu_01ABC/checkpoint.json")
-	require.NoError(t, taskFileErr, "expected migrated task checkpoint metadata in /full/current")
+	require.NoError(t, taskFileErr, "expected migrated task checkpoint metadata in /full/*")
 }
 
 func TestMigrateCheckpointsV2_AllSkippedOnRerun(t *testing.T) {
@@ -878,7 +960,7 @@ func TestMigrateCheckpointsV2_RepairsMissingFullTranscriptBeforeBackfill(t *test
 	require.NoError(t, err)
 	assert.Equal(t, 1, result1.migrated)
 
-	// Simulate interrupted migration by removing raw transcript files from /full/current.
+	// Simulate interrupted migration by removing raw transcript files from every /full/* ref.
 	removeV2SessionTranscriptFiles(t, repo, v2Store, cpID, 0)
 
 	// Re-run migration: should repair /full/current and count as migrated (not skipped).
@@ -911,16 +993,8 @@ func TestMigrateCheckpointsV2_SkipsRepairWhenArchivedFullExists(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, result1.migrated)
 
-	// Preserve current generation as an archived ref to simulate fallback availability.
-	currentCommitHash, _, refErr := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
-	require.NoError(t, refErr)
-	archiveRef := plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000001")
-	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(archiveRef, currentCommitHash)))
-
-	// Remove current /full/current transcript artifacts.
-	removeV2SessionTranscriptFiles(t, repo, v2Store, cpID, 0)
-
-	// Sanity-check fallback exists: ReadSessionContent can still read from archive.
+	// Fresh migration packs raw transcripts into an archived generation and
+	// leaves /full/current empty.
 	archivedRead, archivedReadErr := v2Store.ReadSessionContent(context.Background(), cpID, 0)
 	require.NoError(t, archivedReadErr)
 	assert.NotEmpty(t, archivedRead.Transcript)
@@ -944,9 +1018,18 @@ func TestMigrateCheckpointsV2_SkipsRepairWhenArchivedFullExists(t *testing.T) {
 func removeV2SessionTranscriptFiles(t *testing.T, repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int) {
 	t.Helper()
 
-	refName := plumbing.ReferenceName(paths.V2FullCurrentRefName)
+	for _, refName := range v2FullRefSearchOrderForTest(t, v2Store) {
+		removeV2SessionTranscriptFilesFromRef(t, repo, v2Store, refName, cpID, sessionIdx)
+	}
+}
+
+func removeV2SessionTranscriptFilesFromRef(t *testing.T, repo *git.Repository, v2Store *checkpoint.V2GitStore, refName plumbing.ReferenceName, cpID id.CheckpointID, sessionIdx int) {
+	t.Helper()
+
 	parentHash, rootTreeHash, err := v2Store.GetRefState(refName)
-	require.NoError(t, err)
+	if err != nil {
+		return
+	}
 
 	newRootHash, updateErr := checkpoint.UpdateSubtree(
 		repo,
@@ -964,10 +1047,44 @@ func removeV2SessionTranscriptFiles(t *testing.T, repo *git.Repository, v2Store 
 		},
 	)
 	require.NoError(t, updateErr)
+	if newRootHash == rootTreeHash {
+		return
+	}
 
 	commitHash, commitErr := checkpoint.CreateCommit(context.Background(), repo, newRootHash, parentHash, "test: remove full transcript\n", "Test", "test@test.com")
 	require.NoError(t, commitErr)
 	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)))
+}
+
+func v2FullTreeForCheckpoint(t *testing.T, repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID) *object.Tree {
+	t.Helper()
+
+	for _, refName := range v2FullRefSearchOrderForTest(t, v2Store) {
+		_, rootTreeHash, err := v2Store.GetRefState(refName)
+		if err != nil {
+			continue
+		}
+		rootTree, err := repo.TreeObject(rootTreeHash)
+		require.NoError(t, err)
+		if _, treeErr := rootTree.Tree(cpID.Path()); treeErr == nil {
+			return rootTree
+		}
+	}
+
+	t.Fatalf("checkpoint %s not found in any v2 /full/* ref", cpID)
+	return nil
+}
+
+func v2FullRefSearchOrderForTest(t *testing.T, v2Store *checkpoint.V2GitStore) []plumbing.ReferenceName {
+	t.Helper()
+
+	refNames := []plumbing.ReferenceName{plumbing.ReferenceName(paths.V2FullCurrentRefName)}
+	archived, err := v2Store.ListArchivedGenerations()
+	require.NoError(t, err)
+	for i := len(archived) - 1; i >= 0; i-- {
+		refNames = append(refNames, plumbing.ReferenceName(paths.V2FullRefPrefix+archived[i]))
+	}
+	return refNames
 }
 
 func hasCurrentFullSessionArtifactsForTest(t *testing.T, repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, sessionIdx int) bool {

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -814,6 +814,56 @@ func TestMigrateCheckpointsV2_TaskMetadataKeepsFirstConflictingTaskTree(t *testi
 	assert.JSONEq(t, `{"source":"root"}`, content)
 }
 
+func TestMigrateCheckpointsV2_PartialRepairDoesNotMoveRootTaskMetadataToMissingSession(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+
+	cpID := id.MustCheckpointID("99aabbccddee")
+	rootToolUseID := "toolu_root_partial"
+	err := v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-old",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("{\"type\":\"assistant\",\"message\":\"old\"}\n")),
+		Prompts:      []string{"old prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+	err = v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-latest",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("{\"type\":\"assistant\",\"message\":\"latest\"}\n")),
+		Prompts:      []string{"latest prompt"},
+		IsTask:       true,
+		ToolUseID:    rootToolUseID,
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+	addV1RootTasksTreeWithContent(t, repo, cpID, rootToolUseID, `{"source":"root"}`)
+
+	var initialRun bytes.Buffer
+	result1, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &initialRun, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result1.migrated)
+	assert.True(t, v2FullFileExistsForCheckpoint(t, repo, v2Store, cpID, "1/tasks/"+rootToolUseID+"/checkpoint.json"))
+
+	removeV2SessionTranscriptFiles(t, repo, v2Store, cpID, 0)
+
+	var rerun bytes.Buffer
+	result2, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &rerun, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result2.migrated)
+	assert.Equal(t, 1, result2.repaired)
+	assert.False(t, v2FullFileExistsForCheckpoint(t, repo, v2Store, cpID, "0/tasks/"+rootToolUseID+"/checkpoint.json"),
+		"partial repair must not attach root task metadata to the older missing session")
+	assert.True(t, v2FullFileExistsForCheckpoint(t, repo, v2Store, cpID, "1/tasks/"+rootToolUseID+"/checkpoint.json"),
+		"root task metadata should stay attached to the latest v2 session")
+}
+
 func TestMigrateCheckpointsV2_SkipsCheckpointWhenAllV1SessionsMissingTranscript(t *testing.T) {
 	t.Parallel()
 	repo := initMigrateTestRepo(t)
@@ -1384,6 +1434,24 @@ func v2FullTreeForCheckpoint(t *testing.T, repo *git.Repository, v2Store *checkp
 
 	t.Fatalf("checkpoint %s not found in any v2 /full/* ref", cpID)
 	return nil
+}
+
+func v2FullFileExistsForCheckpoint(t *testing.T, repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID, relPath string) bool {
+	t.Helper()
+
+	for _, refName := range v2FullRefSearchOrderForTest(t, v2Store) {
+		_, rootTreeHash, err := v2Store.GetRefState(refName)
+		if err != nil {
+			continue
+		}
+		rootTree, err := repo.TreeObject(rootTreeHash)
+		require.NoError(t, err)
+		if _, err := rootTree.File(cpID.Path() + "/" + relPath); err == nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 func v2FullRefSearchOrderForTest(t *testing.T, v2Store *checkpoint.V2GitStore) []plumbing.ReferenceName {

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -1344,41 +1344,6 @@ func TestLatestMigratedV2SessionIndex_Empty(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestSpliceTasksTreeToV2_MergesTaskDirectories(t *testing.T) {
-	t.Parallel()
-
-	repo := initMigrateTestRepo(t)
-	_, v2Store := newMigrateStores(repo)
-	cpID := id.MustCheckpointID("123abc456def")
-
-	err := v2Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "session-001",
-		Strategy:     "manual-commit",
-		Agent:        "Cursor",
-		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"assistant","message":"seed"}`)),
-		AuthorName:   "Test",
-		AuthorEmail:  "test@test.com",
-	})
-	require.NoError(t, err)
-
-	rootTasksHash := buildTasksTreeHash(t, repo, "toolu_root")
-	sessionTasksHash := buildTasksTreeHash(t, repo, "toolu_session")
-
-	require.NoError(t, spliceTasksTreeToV2(context.Background(), repo, v2Store, cpID, 0, rootTasksHash))
-	require.NoError(t, spliceTasksTreeToV2(context.Background(), repo, v2Store, cpID, 0, sessionTasksHash))
-
-	_, rootTreeHash, refErr := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
-	require.NoError(t, refErr)
-	rootTree, treeErr := repo.TreeObject(rootTreeHash)
-	require.NoError(t, treeErr)
-
-	_, err = rootTree.File(cpID.Path() + "/0/tasks/toolu_root/checkpoint.json")
-	require.NoError(t, err, "root task metadata should be preserved")
-	_, err = rootTree.File(cpID.Path() + "/0/tasks/toolu_session/checkpoint.json")
-	require.NoError(t, err, "session task metadata should be preserved")
-}
-
 func TestMigrateCheckpointsV2_PreservesPromptAttributions(t *testing.T) {
 	t.Parallel()
 	repo := initMigrateTestRepo(t)

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -243,6 +243,95 @@ func TestMigrateCheckpointsV2_PacksFullGenerationsOldestFirst(t *testing.T) {
 	assert.Equal(t, 0, currentCount, "fresh migration should leave /full/current empty for post-migration writes")
 }
 
+func TestMigrateCheckpointsV2_RerunPacksCheckpointsMissingFullArtifacts(t *testing.T) {
+	oldMax := migrateMaxCheckpointsPerGeneration
+	migrateMaxCheckpointsPerGeneration = 2
+	t.Cleanup(func() {
+		migrateMaxCheckpointsPerGeneration = oldMax
+	})
+
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+	ctx := context.Background()
+
+	checkpointIDs := []id.CheckpointID{
+		id.MustCheckpointID("000000000011"),
+		id.MustCheckpointID("000000000012"),
+		id.MustCheckpointID("000000000013"),
+	}
+	createdAt := []time.Time{
+		time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 2, 3, 0, 0, 0, 0, time.UTC),
+	}
+
+	for i, cpID := range checkpointIDs {
+		err := v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+			CheckpointID: cpID,
+			SessionID:    "session-interrupt-" + strconv.Itoa(i),
+			CreatedAt:    createdAt[i],
+			Strategy:     "manual-commit",
+			Transcript: redact.AlreadyRedacted([]byte(
+				`{"type":"assistant","message":"checkpoint ` + strconv.Itoa(i) + `"}` + "\n",
+			)),
+			Prompts:     []string{"prompt " + strconv.Itoa(i)},
+			AuthorName:  "Test",
+			AuthorEmail: "test@test.com",
+		})
+		require.NoError(t, err)
+	}
+
+	v1List, err := v1Store.ListCommitted(ctx)
+	require.NoError(t, err)
+	sortMigratableCheckpoints(v1List)
+	var interruptedRun bytes.Buffer
+	for i, info := range v1List {
+		fullCheckpoint, migrateErr := migrateOneCheckpoint(ctx, repo, v1Store, v2Store, info, &interruptedRun, "interrupted "+strconv.Itoa(i), false)
+		require.NoError(t, migrateErr)
+		require.NotNil(t, fullCheckpoint)
+		require.NotEmpty(t, fullCheckpoint.sessions)
+	}
+
+	_, _, err = v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
+	require.Error(t, err, "interrupted migration should not have written /full/current")
+
+	var rerun bytes.Buffer
+	result, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &rerun, false)
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.migrated)
+	assert.Equal(t, 0, result.skipped)
+	assert.Equal(t, 0, result.failed)
+	assert.Contains(t, rerun.String(), "Packing raw transcripts into v2 archived generations")
+
+	archived, err := v2Store.ListArchivedGenerations()
+	require.NoError(t, err)
+	require.Equal(t, []string{"0000000000001", "0000000000002"}, archived)
+
+	expectedBatches := [][]int{{0, 1}, {2}}
+	for genIdx, batch := range expectedBatches {
+		refName := plumbing.ReferenceName(paths.V2FullRefPrefix + archived[genIdx])
+		gen, genErr := v2Store.ReadGenerationFromRef(refName)
+		require.NoError(t, genErr)
+		assert.True(t, gen.OldestCheckpointAt.Equal(createdAt[batch[0]]), "generation %s oldest", archived[genIdx])
+		assert.True(t, gen.NewestCheckpointAt.Equal(createdAt[batch[len(batch)-1]]), "generation %s newest", archived[genIdx])
+
+		_, treeHash, refErr := v2Store.GetRefState(refName)
+		require.NoError(t, refErr)
+		tree, treeErr := repo.TreeObject(treeHash)
+		require.NoError(t, treeErr)
+		for _, idx := range batch {
+			_, treeErr = tree.Tree(checkpointIDs[idx].Path())
+			require.NoError(t, treeErr, "generation %s should contain checkpoint %s", archived[genIdx], checkpointIDs[idx])
+		}
+	}
+
+	_, currentTreeHash, err := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
+	require.NoError(t, err)
+	currentCount, err := v2Store.CountCheckpointsInTree(currentTreeHash)
+	require.NoError(t, err)
+	assert.Equal(t, 0, currentCount, "rerun packing should leave /full/current empty for post-migration writes")
+}
+
 func TestMigrateCheckpointsV2_Idempotent(t *testing.T) {
 	t.Parallel()
 	repo := initMigrateTestRepo(t)
@@ -348,6 +437,38 @@ func TestMigrateCmd_ForceFlag(t *testing.T) {
 	flag := cmd.Flags().Lookup("force")
 	require.NotNil(t, flag, "--force flag should be registered")
 	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestMigrateCmd_RepairsArchivedGenerationMetadata(t *testing.T) {
+	repo := initMigrateTestRepo(t)
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	t.Chdir(wt.Filesystem.Root())
+	paths.ClearWorktreeRootCache()
+
+	cpID := id.MustCheckpointID("123456789abc")
+	rawOldest := time.Date(2025, 12, 20, 8, 0, 0, 0, time.UTC)
+	rawNewest := time.Date(2025, 12, 20, 8, 5, 0, 0, time.UTC)
+	createArchivedGenerationRefWithRawTranscript(t, repo, "0000000000007", cpID,
+		time.Date(2026, 1, 7, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 7, 1, 0, 0, 0, time.UTC),
+		rawOldest, rawNewest)
+
+	cmd := newMigrateCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--checkpoints", "v2"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, stdout.String(), "Archived generation metadata repair: 1 repaired")
+	assert.Empty(t, stderr.String())
+
+	v2Store := checkpoint.NewV2GitStore(repo, migrateRemoteName)
+	gen, genErr := v2Store.ReadGenerationFromRef(plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000007"))
+	require.NoError(t, genErr)
+	assert.True(t, gen.OldestCheckpointAt.Equal(rawOldest))
+	assert.True(t, gen.NewestCheckpointAt.Equal(rawNewest))
 }
 
 func TestMigrateCheckpointsV2_MultiSession(t *testing.T) {
@@ -963,17 +1084,20 @@ func TestMigrateCheckpointsV2_RepairsMissingFullTranscriptBeforeBackfill(t *test
 	// Simulate interrupted migration by removing raw transcript files from every /full/* ref.
 	removeV2SessionTranscriptFiles(t, repo, v2Store, cpID, 0)
 
-	// Re-run migration: should repair /full/current and count as migrated (not skipped).
+	// Re-run migration: should requeue the missing raw transcript for final
+	// generation packing and count as migrated (not skipped).
 	var rerun bytes.Buffer
 	result2, rerunErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &rerun, false)
 	require.NoError(t, rerunErr)
 	assert.Equal(t, 1, result2.migrated)
 	assert.Equal(t, 0, result2.failed)
-	assert.Contains(t, rerun.String(), "repaired partial v2 checkpoint state")
+	assert.Contains(t, rerun.String(), "queued missing raw transcript artifacts for generation packing")
 
 	content, readErr := v2Store.ReadSessionContent(context.Background(), cpID, 0)
 	require.NoError(t, readErr)
-	assert.NotEmpty(t, content.Transcript, "raw full transcript should be restored in /full/current")
+	assert.NotEmpty(t, content.Transcript, "raw full transcript should be restored in a packed /full/* generation")
+	assert.False(t, hasCurrentFullSessionArtifactsForTest(t, repo, v2Store, cpID, 0),
+		"rerun repair must not rehydrate migrated raw transcripts into /full/current")
 }
 
 func TestMigrateCheckpointsV2_SkipsRepairWhenArchivedFullExists(t *testing.T) {

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -59,10 +59,10 @@ func newMigrateStores(repo *git.Repository) (*checkpoint.GitStore, *checkpoint.V
 	return checkpoint.NewGitStore(repo), checkpoint.NewV2GitStore(repo, migrateRemoteName)
 }
 
-func buildTasksTreeHash(t *testing.T, repo *git.Repository, toolUseID string) plumbing.Hash {
+func buildTasksTreeHashWithContent(t *testing.T, repo *git.Repository, toolUseID string, content string) plumbing.Hash {
 	t.Helper()
 
-	blobHash, err := checkpoint.CreateBlobFromContent(repo, []byte(`{"tool_use_id":"`+toolUseID+`"}`))
+	blobHash, err := checkpoint.CreateBlobFromContent(repo, []byte(content))
 	require.NoError(t, err)
 
 	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, map[string]object.TreeEntry{
@@ -75,8 +75,13 @@ func buildTasksTreeHash(t *testing.T, repo *git.Repository, toolUseID string) pl
 
 func addV1SessionTasksTree(t *testing.T, repo *git.Repository, cpID id.CheckpointID, sessionIdx int, toolUseID string) {
 	t.Helper()
+	addV1SessionTasksTreeWithContent(t, repo, cpID, sessionIdx, toolUseID, `{"tool_use_id":"`+toolUseID+`"}`)
+}
 
-	tasksTreeHash := buildTasksTreeHash(t, repo, toolUseID)
+func addV1SessionTasksTreeWithContent(t *testing.T, repo *git.Repository, cpID id.CheckpointID, sessionIdx int, toolUseID string, content string) {
+	t.Helper()
+
+	tasksTreeHash := buildTasksTreeHashWithContent(t, repo, toolUseID, content)
 	tasksTree, err := repo.TreeObject(tasksTreeHash)
 	require.NoError(t, err)
 
@@ -96,6 +101,34 @@ func addV1SessionTasksTree(t *testing.T, repo *git.Repository, cpID id.Checkpoin
 
 	commitHash, err := checkpoint.CreateCommit(context.Background(), repo, newRoot, ref.Hash(),
 		"Add test session task metadata\n",
+		"Test", "test@test.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)))
+}
+
+func addV1RootTasksTreeWithContent(t *testing.T, repo *git.Repository, cpID id.CheckpointID, toolUseID string, content string) {
+	t.Helper()
+
+	tasksTreeHash := buildTasksTreeHashWithContent(t, repo, toolUseID, content)
+	tasksTree, err := repo.TreeObject(tasksTreeHash)
+	require.NoError(t, err)
+
+	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+	ref, err := repo.Reference(refName, true)
+	require.NoError(t, err)
+
+	commit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+
+	newRoot, err := checkpoint.UpdateSubtree(repo, commit.TreeHash,
+		[]string{string(cpID[:2]), string(cpID[2:]), "tasks"},
+		tasksTree.Entries,
+		checkpoint.UpdateSubtreeOptions{MergeMode: checkpoint.MergeKeepExisting},
+	)
+	require.NoError(t, err)
+
+	commitHash, err := checkpoint.CreateCommit(context.Background(), repo, newRoot, ref.Hash(),
+		"Add test root task metadata\n",
 		"Test", "test@test.com")
 	require.NoError(t, err)
 	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)))
@@ -241,6 +274,48 @@ func TestMigrateCheckpointsV2_PacksFullGenerationsOldestFirst(t *testing.T) {
 	currentCount, err := v2Store.CountCheckpointsInTree(currentTreeHash)
 	require.NoError(t, err)
 	assert.Equal(t, 0, currentCount, "fresh migration should leave /full/current empty for post-migration writes")
+}
+
+func TestMigrateCheckpointsV2_PacksFullGenerationMetadataFromRawTranscriptTimestamps(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+
+	cpID := id.MustCheckpointID("101112131415")
+	createdAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rawOldest := time.Date(2026, 3, 10, 9, 0, 0, 0, time.UTC)
+	rawNewest := time.Date(2026, 3, 10, 9, 5, 0, 0, time.UTC)
+	transcript := []byte(
+		`{"type":"user","timestamp":"` + rawOldest.Format(time.RFC3339Nano) + `"}` + "\n" +
+			`{"type":"assistant","timestamp":"` + rawNewest.Format(time.RFC3339Nano) + `"}` + "\n",
+	)
+
+	err := v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-raw-timestamps",
+		CreatedAt:    createdAt,
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted(transcript),
+		Prompts:      []string{"raw timestamp prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	var stdout bytes.Buffer
+	result, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.migrated)
+
+	archived, err := v2Store.ListArchivedGenerations()
+	require.NoError(t, err)
+	require.Equal(t, []string{"0000000000001"}, archived)
+
+	gen, err := v2Store.ReadGenerationFromRef(plumbing.ReferenceName(paths.V2FullRefPrefix + archived[0]))
+	require.NoError(t, err)
+	assert.True(t, gen.OldestCheckpointAt.Equal(rawOldest))
+	assert.True(t, gen.NewestCheckpointAt.Equal(rawNewest))
+	assert.False(t, gen.OldestCheckpointAt.Equal(createdAt), "raw transcript timestamps should take precedence over checkpoint metadata")
 }
 
 func TestMigrateCheckpointsV2_RerunPacksCheckpointsMissingFullArtifacts(t *testing.T) {
@@ -702,6 +777,41 @@ func TestMigrateCheckpointsV2_TaskMetadataUsesMigratedSessionIndexAfterSkip(t *t
 	require.NoError(t, err, "session task metadata should follow the shifted v2 session index")
 	_, err = rootTree.File(cpID.Path() + "/2/tasks/toolu_root_shifted/checkpoint.json")
 	require.Error(t, err, "task metadata must not be written under a non-existent v2 session")
+}
+
+func TestMigrateCheckpointsV2_TaskMetadataKeepsFirstConflictingTaskTree(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+
+	cpID := id.MustCheckpointID("8899aabbccdd")
+	toolUseID := "toolu_conflict"
+	err := v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-conflict",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("{\"type\":\"assistant\",\"message\":\"conflict\"}\n")),
+		Prompts:      []string{"conflict prompt"},
+		IsTask:       true,
+		ToolUseID:    toolUseID,
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+	addV1RootTasksTreeWithContent(t, repo, cpID, toolUseID, `{"source":"root"}`)
+	addV1SessionTasksTreeWithContent(t, repo, cpID, 0, toolUseID, `{"source":"session"}`)
+
+	var stdout bytes.Buffer
+	result, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	require.NoError(t, migrateErr)
+	assert.Equal(t, 1, result.migrated)
+
+	rootTree := v2FullTreeForCheckpoint(t, repo, v2Store, cpID)
+	file, err := rootTree.File(cpID.Path() + "/0/tasks/" + toolUseID + "/checkpoint.json")
+	require.NoError(t, err)
+	content, err := file.Contents()
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"source":"root"}`, content)
 }
 
 func TestMigrateCheckpointsV2_SkipsCheckpointWhenAllV1SessionsMissingTranscript(t *testing.T) {

--- a/cmd/entire/cli/strategy/clean_test.go
+++ b/cmd/entire/cli/strategy/clean_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -296,6 +298,52 @@ func TestListEligibleV2Generations_UsesProvidedSettings(t *testing.T) {
 	}
 	if len(warnings) != 0 {
 		t.Fatalf("ListEligibleV2Generations() warnings = %d, want 0", len(warnings))
+	}
+}
+
+func TestListArchivedV2GenerationCandidates_SkipsDivergedLocalAndRemote(t *testing.T) {
+	repo, repoRoot := initGenerationRepairTestRepo(t)
+	remoteRoot := filepath.Join(t.TempDir(), "origin.git")
+	runGenerationRepairGit(t, "", "init", "--bare", remoteRoot)
+	runGenerationRepairGit(t, repoRoot, "remote", "add", "origin", remoteRoot)
+
+	refName := plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000009")
+	staleGen := checkpoint.GenerationMetadata{
+		OldestCheckpointAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		NewestCheckpointAt: time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+	}
+	createRepairArchivedGenerationRef(t, repo, refName, id.MustCheckpointID("100000000009"), staleGen,
+		time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 2, 1, 1, 0, 0, 0, time.UTC),
+	)
+	runGenerationRepairGit(t, repoRoot, "push", "origin", refName.String()+":"+refName.String())
+
+	localOID := createRepairArchivedGenerationRef(t, repo, refName, id.MustCheckpointID("200000000009"), staleGen,
+		time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 3, 1, 1, 0, 0, 0, time.UTC),
+	)
+
+	store := checkpoint.NewV2GitStore(repo, "origin")
+	candidates, tempRefs, warnings, err := listArchivedV2GenerationCandidates(context.Background(), repo, store)
+	if err != nil {
+		t.Fatalf("listArchivedV2GenerationCandidates() error = %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("listArchivedV2GenerationCandidates() candidates = %d, want 0", len(candidates))
+	}
+	if len(tempRefs) != 0 {
+		t.Fatalf("listArchivedV2GenerationCandidates() tempRefs = %d, want 0", len(tempRefs))
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "differs from remote") {
+		t.Fatalf("warnings = %#v, want divergence warning", warnings)
+	}
+
+	ref, err := repo.Reference(refName, true)
+	if err != nil {
+		t.Fatalf("local ref should remain readable: %v", err)
+	}
+	if ref.Hash() != localOID {
+		t.Fatalf("local ref hash = %s, want %s", ref.Hash(), localOID)
 	}
 }
 

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -370,9 +370,9 @@ func ListEligibleV2Generations(ctx context.Context, s *settings.EntireSettings) 
 			continue
 		}
 
-		gen, foundCheckpointTimes, timestampErr := store.ComputeGenerationCheckpointTimestamps(treeHash)
+		gen, foundCheckpointTimes, timestampErr := store.ComputeGenerationRawTranscriptTimestamps(treeHash)
 		if timestampErr != nil {
-			warnings = append(warnings, fmt.Sprintf("generation %s: failed to compute checkpoint timestamps: %v", candidate.Name, timestampErr))
+			warnings = append(warnings, fmt.Sprintf("generation %s: failed to compute raw transcript timestamps: %v", candidate.Name, timestampErr))
 			continue
 		}
 		if !foundCheckpointTimes {
@@ -417,9 +417,10 @@ func ListEligibleV2Generations(ctx context.Context, s *settings.EntireSettings) 
 }
 
 type archivedV2GenerationCandidate struct {
-	Name    string
-	RefName plumbing.ReferenceName
-	RefOID  string
+	Name      string
+	RefName   plumbing.ReferenceName
+	RefOID    string
+	RemoteOID string
 }
 
 func listArchivedV2GenerationCandidates(
@@ -460,6 +461,8 @@ func listArchivedV2GenerationCandidates(
 			} else {
 				for name, remoteOID := range remoteRefs {
 					if candidate, ok := candidatesByName[name]; ok && candidate.RefOID == remoteOID {
+						candidate.RemoteOID = remoteOID
+						candidatesByName[name] = candidate
 						continue
 					}
 					tempRef, fetchErr := fetchArchivedV2Generation(ctx, fetchTarget, name)
@@ -469,9 +472,10 @@ func listArchivedV2GenerationCandidates(
 					}
 					tempRefs = append(tempRefs, tempRef)
 					candidatesByName[name] = archivedV2GenerationCandidate{
-						Name:    name,
-						RefName: tempRef,
-						RefOID:  remoteOID,
+						Name:      name,
+						RefName:   tempRef,
+						RefOID:    remoteOID,
+						RemoteOID: remoteOID,
 					}
 				}
 			}

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -460,9 +460,14 @@ func listArchivedV2GenerationCandidates(
 				warnings = append(warnings, fmt.Sprintf("failed to resolve remote for v2 generation fetch: %v", fetchTargetErr))
 			} else {
 				for name, remoteOID := range remoteRefs {
-					if candidate, ok := candidatesByName[name]; ok && candidate.RefOID == remoteOID {
-						candidate.HasRemote = true
-						candidatesByName[name] = candidate
+					if candidate, ok := candidatesByName[name]; ok {
+						if candidate.RefOID == remoteOID {
+							candidate.HasRemote = true
+							candidatesByName[name] = candidate
+							continue
+						}
+						warnings = append(warnings, fmt.Sprintf("generation %s: local archived ref OID %s differs from remote OID %s; skipping cleanup", name, candidate.RefOID, remoteOID))
+						delete(candidatesByName, name)
 						continue
 					}
 					tempRef, fetchErr := fetchArchivedV2Generation(ctx, fetchTarget, name)

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -420,7 +420,7 @@ type archivedV2GenerationCandidate struct {
 	Name      string
 	RefName   plumbing.ReferenceName
 	RefOID    string
-	RemoteOID string
+	HasRemote bool
 }
 
 func listArchivedV2GenerationCandidates(
@@ -461,7 +461,7 @@ func listArchivedV2GenerationCandidates(
 			} else {
 				for name, remoteOID := range remoteRefs {
 					if candidate, ok := candidatesByName[name]; ok && candidate.RefOID == remoteOID {
-						candidate.RemoteOID = remoteOID
+						candidate.HasRemote = true
 						candidatesByName[name] = candidate
 						continue
 					}
@@ -475,7 +475,7 @@ func listArchivedV2GenerationCandidates(
 						Name:      name,
 						RefName:   tempRef,
 						RefOID:    remoteOID,
-						RemoteOID: remoteOID,
+						HasRemote: true,
 					}
 				}
 			}

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -370,7 +370,7 @@ func ListEligibleV2Generations(ctx context.Context, s *settings.EntireSettings) 
 			continue
 		}
 
-		gen, foundCheckpointTimes, timestampErr := store.ComputeGenerationRawTranscriptTimestamps(treeHash)
+		gen, foundCheckpointTimes, timestampErr := store.ComputeGenerationTimestampsFromTrees(treeHash, nil)
 		if timestampErr != nil {
 			warnings = append(warnings, fmt.Sprintf("generation %s: failed to compute raw transcript timestamps: %v", candidate.Name, timestampErr))
 			continue

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -580,13 +580,21 @@ func DeleteV2Generations(ctx context.Context, generations []V2GenerationRef) (de
 }
 
 func deleteRemoteRef(ctx context.Context, target, refName, expectedOID string) error {
+	return pushWithLease(ctx, target, ":"+refName, refName, expectedOID,
+		"delete remote ref "+refName)
+}
+
+// pushWithLease runs `git push <target> <refSpec>` with an optional
+// `--force-with-lease=<leaseRef>:<expectedOID>` guard. errCtx prefixes the
+// error message when no stderr output is available from the push.
+func pushWithLease(ctx context.Context, target, refSpec, leaseRef, expectedOID, errCtx string) error {
 	extraArgs := []string{}
 	if expectedOID != "" {
-		extraArgs = append(extraArgs, fmt.Sprintf("--force-with-lease=%s:%s", refName, expectedOID))
+		extraArgs = append(extraArgs, fmt.Sprintf("--force-with-lease=%s:%s", leaseRef, expectedOID))
 	}
 	result, err := remote.PushWithOptions(ctx, remote.PushOptions{
 		Remote:    target,
-		RefSpecs:  []string{":" + refName},
+		RefSpecs:  []string{refSpec},
 		ExtraArgs: extraArgs,
 	})
 	if err != nil {
@@ -594,7 +602,7 @@ func deleteRemoteRef(ctx context.Context, target, refName, expectedOID string) e
 		if output != "" {
 			return fmt.Errorf("%s: %w", output, err)
 		}
-		return fmt.Errorf("delete remote ref %s: %w", refName, err)
+		return fmt.Errorf("%s: %w", errCtx, err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/strategy/generation_repair.go
+++ b/cmd/entire/cli/strategy/generation_repair.go
@@ -82,7 +82,7 @@ func repairOneV2GenerationMetadata(
 		return false, fmt.Errorf("cannot read ref: %w", refErr)
 	}
 
-	gen, found, timestampErr := store.ComputeGenerationRawTranscriptTimestamps(treeHash)
+	gen, found, timestampErr := store.ComputeGenerationTimestampsFromTrees(treeHash, nil)
 	if timestampErr != nil {
 		return false, fmt.Errorf("failed to compute raw transcript timestamps: %w", timestampErr)
 	}

--- a/cmd/entire/cli/strategy/generation_repair.go
+++ b/cmd/entire/cli/strategy/generation_repair.go
@@ -1,0 +1,173 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// RepairV2GenerationMetadataResult describes archived v2 generation metadata
+// repair work performed by RepairV2GenerationMetadata.
+type RepairV2GenerationMetadataResult struct {
+	Repaired []string
+	Skipped  []string
+	Failed   []string
+	Warnings []string
+}
+
+// RepairV2GenerationMetadata rewrites generation.json for archived v2 /full/*
+// generation refs using the timestamp envelope from raw transcripts. Remote
+// archived refs are repaired with force-with-lease when they exist on the
+// checkpoint remote.
+func RepairV2GenerationMetadata(ctx context.Context) (*RepairV2GenerationMetadataResult, error) {
+	repo, err := OpenRepository(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open git repository: %w", err)
+	}
+
+	store := checkpoint.NewV2GitStore(repo, "origin")
+	return repairV2GenerationMetadata(ctx, repo, store)
+}
+
+func repairV2GenerationMetadata(ctx context.Context, repo *git.Repository, store *checkpoint.V2GitStore) (*RepairV2GenerationMetadataResult, error) {
+	candidates, tempRefs, warnings, err := listArchivedV2GenerationCandidates(ctx, repo, store)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list archived generations: %w", err)
+	}
+	defer removeTempRefs(repo, tempRefs)
+
+	result := &RepairV2GenerationMetadataResult{
+		Warnings: warnings,
+	}
+
+	pushTarget, pushTargetErr := repairPushTarget(ctx, candidates)
+	if pushTargetErr != nil {
+		result.Warnings = append(result.Warnings, pushTargetErr.Error())
+	}
+
+	for _, candidate := range candidates {
+		repaired, repairErr := repairOneV2GenerationMetadata(ctx, repo, store, candidate, pushTarget, pushTargetErr)
+		if repairErr != nil {
+			result.Failed = append(result.Failed, candidate.Name)
+			result.Warnings = append(result.Warnings, fmt.Sprintf("generation %s: %v", candidate.Name, repairErr))
+			continue
+		}
+		if repaired {
+			result.Repaired = append(result.Repaired, candidate.Name)
+		} else {
+			result.Skipped = append(result.Skipped, candidate.Name)
+		}
+	}
+
+	return result, nil
+}
+
+func repairOneV2GenerationMetadata(
+	ctx context.Context,
+	repo *git.Repository,
+	store *checkpoint.V2GitStore,
+	candidate archivedV2GenerationCandidate,
+	pushTarget string,
+	pushTargetErr error,
+) (bool, error) {
+	oldCommitHash, treeHash, refErr := store.GetRefState(candidate.RefName)
+	if refErr != nil {
+		return false, fmt.Errorf("cannot read ref: %w", refErr)
+	}
+
+	gen, found, timestampErr := store.ComputeGenerationRawTranscriptTimestamps(treeHash)
+	if timestampErr != nil {
+		return false, fmt.Errorf("failed to compute raw transcript timestamps: %w", timestampErr)
+	}
+	if !found {
+		return false, nil
+	}
+
+	current, genErr := store.ReadGeneration(treeHash)
+	if genErr != nil {
+		return false, fmt.Errorf("failed to read generation.json: %w", genErr)
+	}
+	if generationMetadataEqual(current, gen) {
+		return false, nil
+	}
+
+	newTreeHash, addErr := store.AddGenerationJSONToTree(treeHash, gen)
+	if addErr != nil {
+		return false, fmt.Errorf("failed to rewrite generation.json: %w", addErr)
+	}
+	if newTreeHash == treeHash {
+		return false, nil
+	}
+
+	newCommitHash, commitErr := checkpoint.CreateCommit(ctx, repo, newTreeHash, oldCommitHash,
+		fmt.Sprintf("Repair generation metadata: %s\n", candidate.Name),
+		"Entire Migration", "migration@entire.dev")
+	if commitErr != nil {
+		return false, fmt.Errorf("failed to create repair commit: %w", commitErr)
+	}
+
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(candidate.RefName, newCommitHash)); err != nil {
+		return false, fmt.Errorf("failed to update ref %s: %w", candidate.RefName, err)
+	}
+
+	if candidate.RemoteOID == "" {
+		return true, nil
+	}
+	if pushTargetErr != nil {
+		return false, fmt.Errorf("failed to resolve remote for generation metadata repair push: %w", pushTargetErr)
+	}
+	if pushTarget == "" {
+		return false, errors.New("no push target available for remote generation metadata repair")
+	}
+
+	remoteRefName := paths.V2FullRefPrefix + candidate.Name
+	if err := pushRepairedV2Generation(ctx, pushTarget, candidate.RefName.String(), remoteRefName, candidate.RemoteOID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func repairPushTarget(ctx context.Context, candidates []archivedV2GenerationCandidate) (string, error) {
+	for _, candidate := range candidates {
+		if candidate.RemoteOID != "" {
+			target, _, err := remote.PushURL(ctx, "origin")
+			if err != nil {
+				return "", fmt.Errorf("push URL: %w", err)
+			}
+			return target, nil
+		}
+	}
+	return "", nil
+}
+
+func pushRepairedV2Generation(ctx context.Context, target, sourceRef, remoteRef, expectedOID string) error {
+	extraArgs := []string{}
+	if expectedOID != "" {
+		extraArgs = append(extraArgs, fmt.Sprintf("--force-with-lease=%s:%s", remoteRef, expectedOID))
+	}
+	result, err := remote.PushWithOptions(ctx, remote.PushOptions{
+		Remote:    target,
+		RefSpecs:  []string{sourceRef + ":" + remoteRef},
+		ExtraArgs: extraArgs,
+	})
+	if err != nil {
+		output := strings.TrimSpace(result.Output)
+		if output != "" {
+			return fmt.Errorf("%s: %w", output, err)
+		}
+		return fmt.Errorf("push repaired generation ref %s: %w", remoteRef, err)
+	}
+	return nil
+}
+
+func generationMetadataEqual(left, right checkpoint.GenerationMetadata) bool {
+	return left.OldestCheckpointAt.Equal(right.OldestCheckpointAt) &&
+		left.NewestCheckpointAt.Equal(right.NewestCheckpointAt)
+}

--- a/cmd/entire/cli/strategy/generation_repair.go
+++ b/cmd/entire/cli/strategy/generation_repair.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
@@ -88,7 +87,13 @@ func repairOneV2GenerationMetadata(
 		return false, fmt.Errorf("failed to compute raw transcript timestamps: %w", timestampErr)
 	}
 	if !found {
-		return false, nil
+		gen, found, timestampErr = store.ComputeGenerationCheckpointTimestamps(treeHash)
+		if timestampErr != nil {
+			return false, fmt.Errorf("failed to compute checkpoint timestamps: %w", timestampErr)
+		}
+		if !found {
+			return false, nil
+		}
 	}
 
 	current, genErr := store.ReadGeneration(treeHash)
@@ -124,17 +129,26 @@ func repairOneV2GenerationMetadata(
 
 	target, err := pushTarget.resolve(ctx)
 	if err != nil {
+		rollbackRepairLocalRef(repo, candidate.RefName, oldCommitHash)
 		return false, fmt.Errorf("failed to resolve remote for generation metadata repair push: %w", err)
 	}
 	if target == "" {
+		rollbackRepairLocalRef(repo, candidate.RefName, oldCommitHash)
 		return false, errors.New("no push target available for remote generation metadata repair")
 	}
 
 	remoteRefName := paths.V2FullRefPrefix + candidate.Name
 	if err := pushRepairedV2Generation(ctx, target, candidate.RefName.String(), remoteRefName, candidate.RefOID); err != nil {
+		rollbackRepairLocalRef(repo, candidate.RefName, oldCommitHash)
 		return false, err
 	}
 	return true, nil
+}
+
+// rollbackRepairLocalRef restores the local ref to its pre-repair commit when
+// the remote push fails, so local does not silently diverge from origin.
+func rollbackRepairLocalRef(repo *git.Repository, refName plumbing.ReferenceName, oldCommitHash plumbing.Hash) {
+	_ = repo.Storer.SetReference(plumbing.NewHashReference(refName, oldCommitHash)) //nolint:errcheck // best-effort rollback; the original push error is what we report
 }
 
 // repairPushTarget memoizes the push URL lookup so the remote is resolved at
@@ -160,23 +174,8 @@ func (r *repairPushTarget) resolve(ctx context.Context) (string, error) {
 }
 
 func pushRepairedV2Generation(ctx context.Context, target, sourceRef, remoteRef, expectedOID string) error {
-	extraArgs := []string{}
-	if expectedOID != "" {
-		extraArgs = append(extraArgs, fmt.Sprintf("--force-with-lease=%s:%s", remoteRef, expectedOID))
-	}
-	result, err := remote.PushWithOptions(ctx, remote.PushOptions{
-		Remote:    target,
-		RefSpecs:  []string{sourceRef + ":" + remoteRef},
-		ExtraArgs: extraArgs,
-	})
-	if err != nil {
-		output := strings.TrimSpace(result.Output)
-		if output != "" {
-			return fmt.Errorf("%s: %w", output, err)
-		}
-		return fmt.Errorf("push repaired generation ref %s: %w", remoteRef, err)
-	}
-	return nil
+	return pushWithLease(ctx, target, sourceRef+":"+remoteRef, remoteRef, expectedOID,
+		"push repaired generation ref "+remoteRef)
 }
 
 func generationMetadataEqual(left, right checkpoint.GenerationMetadata) bool {

--- a/cmd/entire/cli/strategy/generation_repair.go
+++ b/cmd/entire/cli/strategy/generation_repair.go
@@ -13,6 +13,11 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
+const (
+	repairAuthorName  = "Entire Migration"
+	repairAuthorEmail = "migration@entire.dev"
+)
+
 // RepairV2GenerationMetadataResult describes archived v2 generation metadata
 // repair work performed by RepairV2GenerationMetadata.
 type RepairV2GenerationMetadataResult struct {
@@ -47,13 +52,10 @@ func repairV2GenerationMetadata(ctx context.Context, repo *git.Repository, store
 		Warnings: warnings,
 	}
 
-	pushTarget, pushTargetErr := repairPushTarget(ctx, candidates)
-	if pushTargetErr != nil {
-		result.Warnings = append(result.Warnings, pushTargetErr.Error())
-	}
+	pushTarget := &repairPushTarget{}
 
 	for _, candidate := range candidates {
-		repaired, repairErr := repairOneV2GenerationMetadata(ctx, repo, store, candidate, pushTarget, pushTargetErr)
+		repaired, repairErr := repairOneV2GenerationMetadata(ctx, repo, store, candidate, pushTarget)
 		if repairErr != nil {
 			result.Failed = append(result.Failed, candidate.Name)
 			result.Warnings = append(result.Warnings, fmt.Sprintf("generation %s: %v", candidate.Name, repairErr))
@@ -74,8 +76,7 @@ func repairOneV2GenerationMetadata(
 	repo *git.Repository,
 	store *checkpoint.V2GitStore,
 	candidate archivedV2GenerationCandidate,
-	pushTarget string,
-	pushTargetErr error,
+	pushTarget *repairPushTarget,
 ) (bool, error) {
 	oldCommitHash, treeHash, refErr := store.GetRefState(candidate.RefName)
 	if refErr != nil {
@@ -108,7 +109,7 @@ func repairOneV2GenerationMetadata(
 
 	newCommitHash, commitErr := checkpoint.CreateCommit(ctx, repo, newTreeHash, oldCommitHash,
 		fmt.Sprintf("Repair generation metadata: %s\n", candidate.Name),
-		"Entire Migration", "migration@entire.dev")
+		repairAuthorName, repairAuthorEmail)
 	if commitErr != nil {
 		return false, fmt.Errorf("failed to create repair commit: %w", commitErr)
 	}
@@ -117,34 +118,45 @@ func repairOneV2GenerationMetadata(
 		return false, fmt.Errorf("failed to update ref %s: %w", candidate.RefName, err)
 	}
 
-	if candidate.RemoteOID == "" {
+	if !candidate.HasRemote {
 		return true, nil
 	}
-	if pushTargetErr != nil {
-		return false, fmt.Errorf("failed to resolve remote for generation metadata repair push: %w", pushTargetErr)
+
+	target, err := pushTarget.resolve(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve remote for generation metadata repair push: %w", err)
 	}
-	if pushTarget == "" {
+	if target == "" {
 		return false, errors.New("no push target available for remote generation metadata repair")
 	}
 
 	remoteRefName := paths.V2FullRefPrefix + candidate.Name
-	if err := pushRepairedV2Generation(ctx, pushTarget, candidate.RefName.String(), remoteRefName, candidate.RemoteOID); err != nil {
+	if err := pushRepairedV2Generation(ctx, target, candidate.RefName.String(), remoteRefName, candidate.RefOID); err != nil {
 		return false, err
 	}
 	return true, nil
 }
 
-func repairPushTarget(ctx context.Context, candidates []archivedV2GenerationCandidate) (string, error) {
-	for _, candidate := range candidates {
-		if candidate.RemoteOID != "" {
-			target, _, err := remote.PushURL(ctx, "origin")
-			if err != nil {
-				return "", fmt.Errorf("push URL: %w", err)
-			}
-			return target, nil
-		}
+// repairPushTarget memoizes the push URL lookup so the remote is resolved at
+// most once, only when a candidate actually needs to push.
+type repairPushTarget struct {
+	resolved bool
+	target   string
+	err      error
+}
+
+func (r *repairPushTarget) resolve(ctx context.Context) (string, error) {
+	if r.resolved {
+		return r.target, r.err
 	}
-	return "", nil
+	r.resolved = true
+	target, _, err := remote.PushURL(ctx, "origin")
+	if err != nil {
+		r.err = fmt.Errorf("push URL: %w", err)
+		return "", r.err
+	}
+	r.target = target
+	return target, nil
 }
 
 func pushRepairedV2Generation(ctx context.Context, target, sourceRef, remoteRef, expectedOID string) error {

--- a/cmd/entire/cli/strategy/generation_repair_test.go
+++ b/cmd/entire/cli/strategy/generation_repair_test.go
@@ -1,0 +1,191 @@
+package strategy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepairV2GenerationMetadata_RewritesGenerationJSONFromRawTranscripts(t *testing.T) {
+	repo, _ := initGenerationRepairTestRepo(t)
+
+	cpID := id.MustCheckpointID("aabbccddeeff")
+	rawOldest := time.Date(2025, 12, 23, 10, 27, 44, 0, time.UTC)
+	rawNewest := time.Date(2025, 12, 23, 10, 31, 37, 0, time.UTC)
+	refName := plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000001")
+	oldCommitHash := createRepairArchivedGenerationRef(t, repo, refName, cpID, checkpoint.GenerationMetadata{
+		OldestCheckpointAt: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+		NewestCheckpointAt: time.Date(2026, 1, 2, 1, 0, 0, 0, time.UTC),
+	}, rawOldest, rawNewest)
+
+	result, err := RepairV2GenerationMetadata(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"0000000000001"}, result.Repaired)
+	assert.Empty(t, result.Failed)
+
+	ref, err := repo.Reference(refName, true)
+	require.NoError(t, err)
+	require.NotEqual(t, oldCommitHash, ref.Hash())
+
+	commit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	require.Len(t, commit.ParentHashes, 1)
+	assert.Equal(t, oldCommitHash, commit.ParentHashes[0])
+
+	store := checkpoint.NewV2GitStore(repo, "origin")
+	gen, err := store.ReadGenerationFromRef(refName)
+	require.NoError(t, err)
+	assert.True(t, gen.OldestCheckpointAt.Equal(rawOldest))
+	assert.True(t, gen.NewestCheckpointAt.Equal(rawNewest))
+	assertRepairRawTranscriptPresent(t, repo, refName, cpID)
+}
+
+func TestRepairV2GenerationMetadata_RepairsRemoteOnlyGenerationWithLease(t *testing.T) {
+	repo, repoRoot := initGenerationRepairTestRepo(t)
+	remoteRoot := filepath.Join(t.TempDir(), "origin.git")
+	runGenerationRepairGit(t, "", "init", "--bare", remoteRoot)
+	runGenerationRepairGit(t, repoRoot, "remote", "add", "origin", remoteRoot)
+
+	cpID := id.MustCheckpointID("bbccddeeff00")
+	rawOldest := time.Date(2025, 11, 1, 9, 0, 0, 0, time.UTC)
+	rawNewest := time.Date(2025, 11, 1, 9, 5, 0, 0, time.UTC)
+	refName := plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000002")
+	oldCommitHash := createRepairArchivedGenerationRef(t, repo, refName, cpID, checkpoint.GenerationMetadata{
+		OldestCheckpointAt: time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC),
+		NewestCheckpointAt: time.Date(2026, 1, 3, 1, 0, 0, 0, time.UTC),
+	}, rawOldest, rawNewest)
+	runGenerationRepairGit(t, repoRoot, "push", "origin", refName.String()+":"+refName.String())
+	require.NoError(t, DeleteRefCLI(context.Background(), refName.String(), oldCommitHash.String()))
+
+	result, err := RepairV2GenerationMetadata(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"0000000000002"}, result.Repaired)
+	assert.Empty(t, result.Failed)
+
+	if _, err := repo.Reference(refName, true); err == nil {
+		t.Fatal("remote-only repair should not leave the archived ref as a local canonical ref")
+	}
+	if _, err := repo.Reference(plumbing.ReferenceName("refs/entire-clean-tmp/v2/full/0000000000002"), true); err == nil {
+		t.Fatal("remote-only repair should remove the temporary fetched ref")
+	}
+
+	remoteRepo, err := git.PlainOpen(remoteRoot)
+	require.NoError(t, err)
+	remoteRef, err := remoteRepo.Reference(refName, true)
+	require.NoError(t, err)
+	require.NotEqual(t, oldCommitHash, remoteRef.Hash())
+
+	remoteCommit, err := remoteRepo.CommitObject(remoteRef.Hash())
+	require.NoError(t, err)
+	require.Len(t, remoteCommit.ParentHashes, 1)
+	assert.Equal(t, oldCommitHash, remoteCommit.ParentHashes[0])
+
+	remoteStore := checkpoint.NewV2GitStore(remoteRepo, "origin")
+	gen, err := remoteStore.ReadGenerationFromRef(refName)
+	require.NoError(t, err)
+	assert.True(t, gen.OldestCheckpointAt.Equal(rawOldest))
+	assert.True(t, gen.NewestCheckpointAt.Equal(rawNewest))
+}
+
+func initGenerationRepairTestRepo(t *testing.T) (*git.Repository, string) {
+	t.Helper()
+
+	repoRoot := t.TempDir()
+	testutil.InitRepo(t, repoRoot)
+	testutil.WriteFile(t, repoRoot, "README.md", "init")
+	testutil.GitAdd(t, repoRoot, "README.md")
+	testutil.GitCommit(t, repoRoot, "initial")
+	t.Chdir(repoRoot)
+	paths.ClearWorktreeRootCache()
+
+	repo, err := git.PlainOpen(repoRoot)
+	require.NoError(t, err)
+	return repo, repoRoot
+}
+
+func createRepairArchivedGenerationRef(
+	t *testing.T,
+	repo *git.Repository,
+	refName plumbing.ReferenceName,
+	cpID id.CheckpointID,
+	staleGen checkpoint.GenerationMetadata,
+	rawOldest time.Time,
+	rawNewest time.Time,
+) plumbing.Hash {
+	t.Helper()
+
+	genJSON, err := json.Marshal(staleGen)
+	require.NoError(t, err)
+	genBlobHash, err := checkpoint.CreateBlobFromContent(repo, genJSON)
+	require.NoError(t, err)
+
+	transcript := fmt.Sprintf(
+		"{\"type\":\"user\",\"timestamp\":%q}\n{\"type\":\"assistant\",\"timestamp\":%q}\n",
+		rawOldest.Format(time.RFC3339Nano),
+		rawNewest.Format(time.RFC3339Nano),
+	)
+	transcriptBlobHash, err := checkpoint.CreateBlobFromContent(repo, []byte(transcript))
+	require.NoError(t, err)
+
+	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, map[string]object.TreeEntry{
+		paths.GenerationFileName: {
+			Name: paths.GenerationFileName,
+			Mode: filemode.Regular,
+			Hash: genBlobHash,
+		},
+		cpID.Path() + "/0/" + paths.V2RawTranscriptFileName: {
+			Name: paths.V2RawTranscriptFileName,
+			Mode: filemode.Regular,
+			Hash: transcriptBlobHash,
+		},
+	})
+	require.NoError(t, err)
+
+	commitHash, err := checkpoint.CreateCommit(context.Background(), repo, treeHash, plumbing.ZeroHash,
+		"archived generation\n", "Test", "test@test.com")
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)))
+	return commitHash
+}
+
+func assertRepairRawTranscriptPresent(t *testing.T, repo *git.Repository, refName plumbing.ReferenceName, cpID id.CheckpointID) {
+	t.Helper()
+
+	ref, err := repo.Reference(refName, true)
+	require.NoError(t, err)
+	commit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	tree, err := commit.Tree()
+	require.NoError(t, err)
+	_, err = tree.File(cpID.Path() + "/0/" + paths.V2RawTranscriptFileName)
+	require.NoError(t, err)
+}
+
+func runGenerationRepairGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %s: %v", strings.Join(args, " "), strings.TrimSpace(string(output)), err)
+	}
+}

--- a/cmd/entire/cli/strategy/generation_repair_test.go
+++ b/cmd/entire/cli/strategy/generation_repair_test.go
@@ -103,6 +103,40 @@ func TestRepairV2GenerationMetadata_RepairsRemoteOnlyGenerationWithLease(t *test
 	assert.True(t, gen.NewestCheckpointAt.Equal(rawNewest))
 }
 
+func TestRepairV2GenerationMetadata_NoCandidatesIsNoOp(t *testing.T) {
+	initGenerationRepairTestRepo(t)
+
+	result, err := RepairV2GenerationMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result.Repaired)
+	assert.Empty(t, result.Skipped)
+	assert.Empty(t, result.Failed)
+	assert.Empty(t, result.Warnings)
+}
+
+func TestRepairV2GenerationMetadata_AlreadyCorrectIsSkipped(t *testing.T) {
+	repo, _ := initGenerationRepairTestRepo(t)
+
+	cpID := id.MustCheckpointID("ccddeeff0011")
+	rawOldest := time.Date(2025, 10, 1, 8, 0, 0, 0, time.UTC)
+	rawNewest := time.Date(2025, 10, 1, 8, 30, 0, 0, time.UTC)
+	refName := plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000003")
+	oldCommitHash := createRepairArchivedGenerationRef(t, repo, refName, cpID, checkpoint.GenerationMetadata{
+		OldestCheckpointAt: rawOldest,
+		NewestCheckpointAt: rawNewest,
+	}, rawOldest, rawNewest)
+
+	result, err := RepairV2GenerationMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"0000000000003"}, result.Skipped)
+	assert.Empty(t, result.Repaired)
+	assert.Empty(t, result.Failed)
+
+	ref, err := repo.Reference(refName, true)
+	require.NoError(t, err)
+	assert.Equal(t, oldCommitHash, ref.Hash(), "ref must not advance when generation.json already matches")
+}
+
 func initGenerationRepairTestRepo(t *testing.T) (*git.Repository, string) {
 	t.Helper()
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/275
<!-- entire-trail-link-end -->

## What
- Pack migrated v1 checkpoints into v2 archived full generations chronologically, so lower generation refs contain older migrated checkpoints.
- Repair archived v2 generation metadata for already-migrated repositories without renumbering refs or recopying transcripts.
- Keep force migration and rerun repair paths consistent by pruning stale archived generations and repacking only missing raw full artifacts.

## How
- Sort migratable checkpoints oldest-first, write v2/main, then build archived v2/full generation refs directly from sorted batches.
- Recompute archived generation timestamp envelopes from raw transcripts and update local/remote refs with lease-aware pushes.
- Add cleanup and migration coverage for chronological packing, generation repair, stale archived refs, partial repairs, and idempotent reruns.

## Verification
- mise run check
- mise run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint migration/cleanup logic and rewrites archived `refs/entire/checkpoints/v2/full/*` refs (including optional remote pushes with `--force-with-lease`), so bugs could corrupt or delete retained transcript generations if edge cases are missed.
> 
> **Overview**
> Fixes v2 checkpoint migration so migrated v1 checkpoints are **packed into archived v2 `/full/<n>` generations in oldest-first order** and `/full/current` is left empty/ready for post-migration writes, rather than relying on incremental writes that could invert generation ordering.
> 
> Adds a new **archived generation metadata repair** flow that recomputes `generation.json` timestamp envelopes from raw transcript timestamps (falling back to checkpoint metadata/generation.json) and can update remote-only archived refs via lease-guarded pushes; `migrate --checkpoints v2` now runs this repair and fails if any generations can’t be repaired.
> 
> Updates retention cleanup to determine v2 generation age from **raw transcript timestamps** (with safer remote candidate tracking), refactors v2 generation timestamp computation to be reusable (`ComputeGenerationTimestampsFromTrees`, exported `NextGenerationNumber`/`MergeGenerationTime`), and expands tests to cover chronological packing, rerun/force pruning of archived generations, task-metadata merge behavior, and metadata repair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb658bc754d848d827cb467f9ab7eaef272fd8b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->