### PR TITLE
Checkpoints v2: Push v2 refs in parallel and clean up output

### DIFF
--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 
 	"github.com/go-git/go-git/v6"
@@ -284,7 +286,7 @@ func tryPushSessionsCommon(ctx context.Context, remoteName, branchName string) (
 	result, err := remote.Push(ctx, remoteName, branchName)
 	outputStr := result.Output
 	if err != nil {
-		return pushResult{}, classifyPushOutput(outputStr)
+		return pushResult{}, classifyPushFailure(ctx, outputStr, err)
 	}
 
 	return parsePushResult(outputStr), nil
@@ -306,16 +308,52 @@ func isProtectedRefRejection(output string) bool {
 		strings.Contains(output, "protected branch hook declined")
 }
 
+var errNonFastForward = errors.New("non-fast-forward")
+
+func isNonFastForwardRejection(output string) bool {
+	if strings.Contains(output, "non-fast-forward") {
+		return true
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "[rejected]") && strings.Contains(line, "(fetch first)") {
+			return true
+		}
+	}
+	return strings.Contains(output, "Updates were rejected because the tip of your current branch is behind") ||
+		strings.Contains(output, "Updates were rejected because the remote contains work that you do not have locally")
+}
+
 // classifyPushOutput maps failing push stderr to a typed error.
 func classifyPushOutput(output string) error {
 	if isProtectedRefRejection(output) {
 		return &protectedRefError{output: output}
 	}
-	if strings.Contains(output, "non-fast-forward") ||
-		strings.Contains(output, "rejected") {
-		return errors.New("non-fast-forward")
+	if isNonFastForwardRejection(output) {
+		return errNonFastForward
+	}
+	if strings.TrimSpace(output) == "" {
+		return errors.New("push failed")
 	}
 	return fmt.Errorf("push failed: %s", output)
+}
+
+func classifyPushFailure(ctx context.Context, output string, pushErr error) error {
+	if strings.TrimSpace(output) != "" {
+		if pushErr != nil {
+			logging.Debug(ctx, "git push failed",
+				slog.String("error", pushErr.Error()),
+				slog.String("output", output),
+			)
+		}
+		return classifyPushOutput(output)
+	}
+	if pushErr != nil {
+		logging.Debug(ctx, "git push failed without output",
+			slog.String("error", pushErr.Error()),
+		)
+		return fmt.Errorf("push failed: %w", pushErr)
+	}
+	return errors.New("push failed")
 }
 
 // printProtectedRefBlock explains that checkpoint syncing was blocked remotely.

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1538,13 +1539,40 @@ func TestClassifyPushOutput(t *testing.T) {
 
 		var perr *protectedRefError
 		assert.NotErrorAs(t, err, &perr)
+		require.ErrorIs(t, err, errNonFastForward)
 		assert.EqualError(t, err, "non-fast-forward")
+	})
+
+	t.Run("fetch-first maps to NFF error", func(t *testing.T) {
+		t.Parallel()
+		err := classifyPushOutput("!\trefs/heads/main:refs/heads/main\t[rejected] (fetch first)")
+
+		assert.ErrorIs(t, err, errNonFastForward)
+	})
+
+	t.Run("generic rejected output stays generic", func(t *testing.T) {
+		t.Parallel()
+		err := classifyPushOutput("remote: rejected credentials")
+
+		require.Error(t, err)
+		require.NotErrorIs(t, err, errNonFastForward)
+		assert.ErrorContains(t, err, "push failed: remote: rejected credentials")
 	})
 
 	t.Run("other output is wrapped as push failed", func(t *testing.T) {
 		t.Parallel()
 		err := classifyPushOutput("fatal: Could not resolve host")
 		assert.ErrorContains(t, err, "push failed: fatal: Could not resolve host")
+	})
+
+	t.Run("empty output preserves push error", func(t *testing.T) {
+		t.Parallel()
+		pushErr := errors.New("exit status 128")
+		err := classifyPushFailure(context.Background(), "", pushErr)
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, pushErr)
+		assert.ErrorContains(t, err, "push failed")
 	})
 }
 

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -58,6 +59,36 @@ func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceNa
 	}
 
 	return parsePushResult(outputStr), nil
+}
+
+type v2RefPushResult struct {
+	result pushResult
+	err    error
+}
+
+// pushV2RefWithRecovery pushes a v2 ref with fetch+merge recovery on conflict.
+// Callers own user-facing output so multiple refs can be pushed concurrently
+// without interleaving progress lines.
+func pushV2RefWithRecovery(ctx context.Context, target string, refName plumbing.ReferenceName) v2RefPushResult {
+	if result, err := tryPushRef(ctx, target, refName); err == nil {
+		return v2RefPushResult{result: result}
+	}
+
+	shortRef := shortRefName(refName)
+	if err := fetchAndMergeRef(ctx, target, refName); err != nil {
+		return v2RefPushResult{
+			err: fmt.Errorf("couldn't sync %s: %w", shortRef, err),
+		}
+	}
+
+	result, err := tryPushRef(ctx, target, refName)
+	if err != nil {
+		return v2RefPushResult{
+			err: fmt.Errorf("failed to push %s after sync: %w", shortRef, err),
+		}
+	}
+
+	return v2RefPushResult{result: result}
 }
 
 // doPushRef pushes a custom ref with fetch+merge recovery on conflict.
@@ -123,9 +154,10 @@ func fetchAndMergeRef(ctx context.Context, target string, refName plumbing.Refer
 	refSpec := fmt.Sprintf("+%s:%s", refName, tmpRefName)
 
 	if output, err := remote.Fetch(ctx, remote.FetchOptions{
-		Remote:   fetchTarget,
-		RefSpecs: []string{refSpec},
-		NoTags:   true,
+		Remote:    fetchTarget,
+		RefSpecs:  []string{refSpec},
+		NoTags:    true,
+		ExtraArgs: []string{"--no-write-fetch-head"},
 	}); err != nil {
 		return fmt.Errorf("fetch failed: %s", output)
 	}
@@ -250,9 +282,10 @@ func handleRotationConflict(ctx context.Context, target, fetchTarget string, rep
 	archiveTmpRef := plumbing.ReferenceName("refs/entire-fetch-tmp/archive-" + latestArchive)
 	archiveRefSpec := fmt.Sprintf("+%s:%s", archiveRefName, archiveTmpRef)
 	if output, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
-		Remote:   fetchTarget,
-		RefSpecs: []string{archiveRefSpec},
-		NoTags:   true,
+		Remote:    fetchTarget,
+		RefSpecs:  []string{archiveRefSpec},
+		NoTags:    true,
+		ExtraArgs: []string{"--no-write-fetch-head"},
 	}); fetchErr != nil {
 		return fmt.Errorf("fetch archived generation failed: %s", output)
 	}
@@ -394,30 +427,93 @@ func updateGenerationTimestamps(repo *git.Repository, genBlobHash plumbing.Hash,
 }
 
 // pushV2Refs pushes v2 checkpoint refs to the target.
-// Pushes /main, /full/current, and the latest archived generation (if any).
-// Older archived generations are immutable and were pushed when created.
+// Pushes /main, /full/current, and the latest archived generation (if any)
+// concurrently. Older archived generations are immutable and were pushed when created.
 func pushV2Refs(ctx context.Context, target string) {
-	_ = pushRefIfNeeded(ctx, target, plumbing.ReferenceName(paths.V2MainRefName))        //nolint:errcheck // pushRefIfNeeded handles errors internally
-	_ = pushRefIfNeeded(ctx, target, plumbing.ReferenceName(paths.V2FullCurrentRefName)) //nolint:errcheck // pushRefIfNeeded handles errors internally
+	refs := v2RefsToPush(ctx)
+	if len(refs) == 0 {
+		return
+	}
 
-	// Push only the latest archived generation (most likely to be newly created)
+	fmt.Fprintln(os.Stderr, "[entire] Syncing and pushing v2 checkpoints...")
+	fmt.Fprintf(os.Stderr, "[entire] Pushing %s...\n", strings.Join(shortRefNames(refs), ", "))
+
+	results := pushV2RefsParallel(ctx, target, refs)
+	var failures []error
+	pushedContent := false
+	for _, result := range results {
+		if result.err != nil {
+			failures = append(failures, result.err)
+			continue
+		}
+		if !result.result.upToDate {
+			pushedContent = true
+		}
+	}
+
+	if len(failures) > 0 {
+		for _, err := range failures {
+			fmt.Fprintf(os.Stderr, "[entire] Warning: %v\n", err)
+		}
+		printCheckpointRemoteHint(target)
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "[entire] All v2 checkpoints pushed")
+	if pushedContent {
+		printSettingsCommitHint(ctx, target)
+	}
+	printCheckpointsV2MigrationHint(ctx)
+}
+
+func v2RefsToPush(ctx context.Context) []plumbing.ReferenceName {
 	repo, err := OpenRepository(ctx)
 	if err != nil {
-		return
+		return nil
 	}
-	v2URL, err := remote.FetchURL(ctx)
-	if err != nil {
-		logging.Debug(ctx, "push-v2: using origin for archived generation fetch remote",
-			slog.String("error", err.Error()),
-		)
+
+	var refs []plumbing.ReferenceName
+	for _, refName := range []plumbing.ReferenceName{
+		plumbing.ReferenceName(paths.V2MainRefName),
+		plumbing.ReferenceName(paths.V2FullCurrentRefName),
+	} {
+		if _, err := repo.Reference(refName, true); err == nil {
+			refs = append(refs, refName)
+		}
 	}
-	store := checkpoint.NewV2GitStore(repo, v2URL)
+
+	// Push only the latest archived generation (most likely to be newly created).
+	store := checkpoint.NewV2GitStore(repo, "")
 	archived, err := store.ListArchivedGenerations()
 	if err != nil || len(archived) == 0 {
-		return
+		return refs
 	}
 	latest := archived[len(archived)-1]
-	_ = pushRefIfNeeded(ctx, target, plumbing.ReferenceName(paths.V2FullRefPrefix+latest)) //nolint:errcheck // pushRefIfNeeded handles errors internally
+	refs = append(refs, plumbing.ReferenceName(paths.V2FullRefPrefix+latest))
+
+	return refs
+}
+
+func pushV2RefsParallel(ctx context.Context, target string, refs []plumbing.ReferenceName) []v2RefPushResult {
+	results := make([]v2RefPushResult, len(refs))
+	var wg sync.WaitGroup
+	for i, refName := range refs {
+		wg.Add(1)
+		go func(i int, refName plumbing.ReferenceName) {
+			defer wg.Done()
+			results[i] = pushV2RefWithRecovery(ctx, target, refName)
+		}(i, refName)
+	}
+	wg.Wait()
+	return results
+}
+
+func shortRefNames(refs []plumbing.ReferenceName) []string {
+	names := make([]string, 0, len(refs))
+	for _, refName := range refs {
+		names = append(names, shortRefName(refName))
+	}
+	return names
 }
 
 // shortRefName returns a human-readable short form of a ref name for log output.

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -440,22 +440,31 @@ func pushV2Refs(ctx context.Context, target string) {
 
 	results := pushV2RefsParallel(ctx, target, refs)
 	var failures []error
+	var successfulRefs []plumbing.ReferenceName
 	pushedContent := false
-	for _, result := range results {
+	for i, result := range results {
 		if result.err != nil {
 			failures = append(failures, result.err)
 			continue
 		}
+		successfulRefs = append(successfulRefs, refs[i])
 		if !result.result.upToDate {
 			pushedContent = true
 		}
 	}
 
 	if len(failures) > 0 {
+		if len(successfulRefs) > 0 {
+			fmt.Fprintf(os.Stderr, "[entire] Successfully pushed %s\n", strings.Join(shortRefNames(successfulRefs), ", "))
+		}
 		for _, err := range failures {
 			fmt.Fprintf(os.Stderr, "[entire] Warning: %v\n", err)
 		}
 		printCheckpointRemoteHint(target)
+		if pushedContent {
+			printSettingsCommitHint(ctx, target)
+		}
+		printCheckpointsV2MigrationHint(ctx)
 		return
 	}
 

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -62,33 +61,152 @@ func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceNa
 }
 
 type v2RefPushResult struct {
-	result pushResult
-	err    error
+	refName plumbing.ReferenceName
+	result  pushResult
+	err     error
 }
 
-// pushV2RefWithRecovery pushes a v2 ref with fetch+merge recovery on conflict.
-// Callers own user-facing output so multiple refs can be pushed concurrently
-// without interleaving progress lines.
-func pushV2RefWithRecovery(ctx context.Context, target string, refName plumbing.ReferenceName) v2RefPushResult {
-	if result, err := tryPushRef(ctx, target, refName); err == nil {
-		return v2RefPushResult{result: result}
+func tryPushV2Refs(ctx context.Context, target string, refs []plumbing.ReferenceName) []v2RefPushResult {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	result, err := remote.PushWithOptions(ctx, remote.PushOptions{
+		Remote:   target,
+		RefSpecs: refSpecsForRefs(refs),
+	})
+	return parsePushRefResults(result.Output, refs, err)
+}
+
+func pushV2RefsWithRecovery(ctx context.Context, target string, refs []plumbing.ReferenceName) []v2RefPushResult {
+	resultsByRef := make(map[plumbing.ReferenceName]v2RefPushResult, len(refs))
+	var retryRefs []plumbing.ReferenceName
+
+	for _, result := range tryPushV2Refs(ctx, target, refs) {
+		if result.err == nil {
+			resultsByRef[result.refName] = result
+			continue
+		}
+
+		shortRef := shortRefName(result.refName)
+		if err := fetchAndMergeRef(ctx, target, result.refName); err != nil {
+			resultsByRef[result.refName] = v2RefPushResult{
+				refName: result.refName,
+				err:     fmt.Errorf("couldn't sync %s: %w", shortRef, err),
+			}
+			continue
+		}
+		retryRefs = append(retryRefs, result.refName)
 	}
 
-	shortRef := shortRefName(refName)
-	if err := fetchAndMergeRef(ctx, target, refName); err != nil {
-		return v2RefPushResult{
-			err: fmt.Errorf("couldn't sync %s: %w", shortRef, err),
+	if len(retryRefs) > 0 {
+		for _, result := range tryPushV2Refs(ctx, target, retryRefs) {
+			if result.err != nil {
+				result.err = fmt.Errorf("failed to push %s after sync: %w", shortRefName(result.refName), result.err)
+			}
+			resultsByRef[result.refName] = result
 		}
 	}
 
-	result, err := tryPushRef(ctx, target, refName)
-	if err != nil {
-		return v2RefPushResult{
-			err: fmt.Errorf("failed to push %s after sync: %w", shortRef, err),
+	results := make([]v2RefPushResult, 0, len(refs))
+	for _, refName := range refs {
+		result, ok := resultsByRef[refName]
+		if !ok {
+			result = v2RefPushResult{
+				refName: refName,
+				err:     errors.New("push result missing"),
+			}
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func refSpecsForRefs(refs []plumbing.ReferenceName) []string {
+	refSpecs := make([]string, 0, len(refs))
+	for _, refName := range refs {
+		refSpecs = append(refSpecs, fmt.Sprintf("%s:%s", refName, refName))
+	}
+	return refSpecs
+}
+
+func parsePushRefResults(output string, refs []plumbing.ReferenceName, pushErr error) []v2RefPushResult {
+	parsed := make(map[plumbing.ReferenceName]v2RefPushResult, len(refs))
+	for _, line := range strings.Split(output, "\n") {
+		result, ok := parsePushRefStatusLine(line)
+		if ok {
+			parsed[result.refName] = result
 		}
 	}
 
-	return v2RefPushResult{result: result}
+	var fallbackErr error
+	if pushErr != nil {
+		fallbackErr = pushErrorFromOutput(output)
+	}
+
+	results := make([]v2RefPushResult, 0, len(refs))
+	for _, refName := range refs {
+		if result, ok := parsed[refName]; ok {
+			results = append(results, result)
+			continue
+		}
+		results = append(results, v2RefPushResult{
+			refName: refName,
+			err:     fallbackErr,
+		})
+	}
+	return results
+}
+
+func parsePushRefStatusLine(line string) (v2RefPushResult, bool) {
+	fields := strings.Split(line, "\t")
+	if len(fields) < 2 || fields[0] == "" {
+		return v2RefPushResult{}, false
+	}
+
+	refName, ok := pushStatusRef(fields[1])
+	if !ok {
+		return v2RefPushResult{}, false
+	}
+
+	switch fields[0][0] {
+	case '!':
+		return v2RefPushResult{
+			refName: refName,
+			err:     pushStatusError(strings.Join(fields[2:], "\t")),
+		}, true
+	case '=':
+		return v2RefPushResult{
+			refName: refName,
+			result:  pushResult{upToDate: true},
+		}, true
+	default:
+		return v2RefPushResult{refName: refName}, true
+	}
+}
+
+func pushStatusRef(statusRef string) (plumbing.ReferenceName, bool) {
+	_, dst, ok := strings.Cut(statusRef, ":")
+	if !ok || dst == "" {
+		return "", false
+	}
+	return plumbing.ReferenceName(dst), true
+}
+
+func pushStatusError(summary string) error {
+	if strings.Contains(summary, "non-fast-forward") || strings.Contains(summary, "rejected") {
+		return errors.New("non-fast-forward")
+	}
+	if strings.TrimSpace(summary) == "" {
+		return errors.New("push failed")
+	}
+	return fmt.Errorf("push failed: %s", summary)
+}
+
+func pushErrorFromOutput(output string) error {
+	if strings.Contains(output, "non-fast-forward") || strings.Contains(output, "rejected") {
+		return errors.New("non-fast-forward")
+	}
+	return fmt.Errorf("push failed: %s", output)
 }
 
 // doPushRef pushes a custom ref with fetch+merge recovery on conflict.
@@ -427,8 +545,8 @@ func updateGenerationTimestamps(repo *git.Repository, genBlobHash plumbing.Hash,
 }
 
 // pushV2Refs pushes v2 checkpoint refs to the target.
-// Pushes /main, /full/current, and the latest archived generation (if any)
-// concurrently. Older archived generations are immutable and were pushed when created.
+// Pushes /main, /full/current, and the latest archived generation (if any) in
+// one git push. Older archived generations are immutable and were pushed when created.
 func pushV2Refs(ctx context.Context, target string) {
 	refs := v2RefsToPush(ctx)
 	if len(refs) == 0 {
@@ -438,28 +556,23 @@ func pushV2Refs(ctx context.Context, target string) {
 	fmt.Fprintln(os.Stderr, "[entire] Syncing and pushing v2 checkpoints...")
 	fmt.Fprintf(os.Stderr, "[entire] Pushing %s...\n", strings.Join(shortRefNames(refs), ", "))
 
-	results := pushV2RefsParallel(ctx, target, refs)
+	results := pushV2RefsWithRecovery(ctx, target, refs)
 	var failures []error
 	var successfulRefs []plumbing.ReferenceName
 	pushedContent := false
-	for i, result := range results {
+	for _, result := range results {
 		if result.err != nil {
 			failures = append(failures, result.err)
 			continue
 		}
-		successfulRefs = append(successfulRefs, refs[i])
+		successfulRefs = append(successfulRefs, result.refName)
 		if !result.result.upToDate {
 			pushedContent = true
 		}
 	}
 
 	if len(failures) > 0 {
-		if len(successfulRefs) > 0 {
-			fmt.Fprintf(os.Stderr, "[entire] Successfully pushed %s\n", strings.Join(shortRefNames(successfulRefs), ", "))
-		}
-		for _, err := range failures {
-			fmt.Fprintf(os.Stderr, "[entire] Warning: %v\n", err)
-		}
+		printV2PartialPushResult(os.Stderr, successfulRefs, failures)
 		printCheckpointRemoteHint(target)
 		if pushedContent {
 			printSettingsCommitHint(ctx, target)
@@ -473,6 +586,15 @@ func pushV2Refs(ctx context.Context, target string) {
 		printSettingsCommitHint(ctx, target)
 	}
 	printCheckpointsV2MigrationHint(ctx)
+}
+
+func printV2PartialPushResult(w io.Writer, successfulRefs []plumbing.ReferenceName, failures []error) {
+	if len(successfulRefs) > 0 {
+		fmt.Fprintf(w, "[entire] Successfully pushed %s\n", strings.Join(shortRefNames(successfulRefs), ", "))
+	}
+	for _, err := range failures {
+		fmt.Fprintf(w, "[entire] Warning: %v\n", err)
+	}
 }
 
 func v2RefsToPush(ctx context.Context) []plumbing.ReferenceName {
@@ -501,20 +623,6 @@ func v2RefsToPush(ctx context.Context) []plumbing.ReferenceName {
 	refs = append(refs, plumbing.ReferenceName(paths.V2FullRefPrefix+latest))
 
 	return refs
-}
-
-func pushV2RefsParallel(ctx context.Context, target string, refs []plumbing.ReferenceName) []v2RefPushResult {
-	results := make([]v2RefPushResult, len(refs))
-	var wg sync.WaitGroup
-	for i, refName := range refs {
-		wg.Add(1)
-		go func(i int, refName plumbing.ReferenceName) {
-			defer wg.Done()
-			results[i] = pushV2RefWithRecovery(ctx, target, refName)
-		}(i, refName)
-	}
-	wg.Wait()
-	return results
 }
 
 func shortRefNames(refs []plumbing.ReferenceName) []string {

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -24,23 +24,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
-// pushRefIfNeeded pushes a custom ref to the given target if it exists locally.
-// Custom refs (under refs/entire/) don't have remote-tracking refs, so there's
-// no "has unpushed" optimization — we always attempt the push and let git handle
-// the no-op case.
-func pushRefIfNeeded(ctx context.Context, target string, refName plumbing.ReferenceName) error {
-	repo, err := OpenRepository(ctx)
-	if err != nil {
-		return nil //nolint:nilerr // Hook must be silent on failure
-	}
-
-	if _, err := repo.Reference(refName, true); err != nil {
-		return nil //nolint:nilerr // Ref doesn't exist locally, nothing to push
-	}
-
-	return doPushRef(ctx, target, refName)
-}
-
 // tryPushRef attempts to push a custom ref using an explicit refspec.
 func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceName) (pushResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
@@ -50,11 +33,7 @@ func tryPushRef(ctx context.Context, target string, refName plumbing.ReferenceNa
 	result, err := remote.Push(ctx, target, refSpec)
 	outputStr := result.Output
 	if err != nil {
-		if strings.Contains(outputStr, "non-fast-forward") ||
-			strings.Contains(outputStr, "rejected") {
-			return pushResult{}, errors.New("non-fast-forward")
-		}
-		return pushResult{}, fmt.Errorf("push failed: %s", outputStr)
+		return pushResult{}, classifyPushFailure(ctx, outputStr, err)
 	}
 
 	return parsePushResult(outputStr), nil
@@ -74,7 +53,7 @@ func tryPushV2Refs(ctx context.Context, target string, refs []plumbing.Reference
 		Remote:   target,
 		RefSpecs: refSpecsForRefs(refs),
 	})
-	return parsePushRefResults(result.Output, refs, err)
+	return parsePushRefResults(ctx, result.Output, refs, err)
 }
 
 func pushV2RefsWithRecovery(ctx context.Context, target string, refs []plumbing.ReferenceName) []v2RefPushResult {
@@ -83,6 +62,10 @@ func pushV2RefsWithRecovery(ctx context.Context, target string, refs []plumbing.
 
 	for _, result := range tryPushV2Refs(ctx, target, refs) {
 		if result.err == nil {
+			resultsByRef[result.refName] = result
+			continue
+		}
+		if !errors.Is(result.err, errNonFastForward) {
 			resultsByRef[result.refName] = result
 			continue
 		}
@@ -129,7 +112,7 @@ func refSpecsForRefs(refs []plumbing.ReferenceName) []string {
 	return refSpecs
 }
 
-func parsePushRefResults(output string, refs []plumbing.ReferenceName, pushErr error) []v2RefPushResult {
+func parsePushRefResults(ctx context.Context, output string, refs []plumbing.ReferenceName, pushErr error) []v2RefPushResult {
 	parsed := make(map[plumbing.ReferenceName]v2RefPushResult, len(refs))
 	for _, line := range strings.Split(output, "\n") {
 		result, ok := parsePushRefStatusLine(line)
@@ -140,7 +123,15 @@ func parsePushRefResults(output string, refs []plumbing.ReferenceName, pushErr e
 
 	var fallbackErr error
 	if pushErr != nil {
-		fallbackErr = pushErrorFromOutput(output)
+		fallbackErr = classifyPushFailure(ctx, output, pushErr)
+		if len(parsed) > 0 && len(parsed) < len(refs) {
+			logging.Debug(ctx, "push-v2: incomplete push porcelain output",
+				slog.Int("parsed_refs", len(parsed)),
+				slog.Int("expected_refs", len(refs)),
+				slog.String("error", pushErr.Error()),
+				slog.String("output", output),
+			)
+		}
 	}
 
 	results := make([]v2RefPushResult, 0, len(refs))
@@ -149,9 +140,20 @@ func parsePushRefResults(output string, refs []plumbing.ReferenceName, pushErr e
 			results = append(results, result)
 			continue
 		}
+		if pushErr != nil && len(parsed) > 0 {
+			results = append(results, v2RefPushResult{
+				refName: refName,
+				err:     fmt.Errorf("status missing for %s", shortRefName(refName)),
+			})
+			continue
+		}
+		err := fallbackErr
+		if err != nil {
+			err = fmt.Errorf("failed to push %s: %w", shortRefName(refName), err)
+		}
 		results = append(results, v2RefPushResult{
 			refName: refName,
-			err:     fallbackErr,
+			err:     err,
 		})
 	}
 	return results
@@ -170,9 +172,10 @@ func parsePushRefStatusLine(line string) (v2RefPushResult, bool) {
 
 	switch fields[0][0] {
 	case '!':
+		err := classifyPushOutput(strings.Join(fields[2:], "\t"))
 		return v2RefPushResult{
 			refName: refName,
-			err:     pushStatusError(strings.Join(fields[2:], "\t")),
+			err:     fmt.Errorf("failed to push %s: %w", shortRefName(refName), err),
 		}, true
 	case '=':
 		return v2RefPushResult{
@@ -190,65 +193,6 @@ func pushStatusRef(statusRef string) (plumbing.ReferenceName, bool) {
 		return "", false
 	}
 	return plumbing.ReferenceName(dst), true
-}
-
-func pushStatusError(summary string) error {
-	if strings.Contains(summary, "non-fast-forward") || strings.Contains(summary, "rejected") {
-		return errors.New("non-fast-forward")
-	}
-	if strings.TrimSpace(summary) == "" {
-		return errors.New("push failed")
-	}
-	return fmt.Errorf("push failed: %s", summary)
-}
-
-func pushErrorFromOutput(output string) error {
-	if strings.Contains(output, "non-fast-forward") || strings.Contains(output, "rejected") {
-		return errors.New("non-fast-forward")
-	}
-	return fmt.Errorf("push failed: %s", output)
-}
-
-// doPushRef pushes a custom ref with fetch+merge recovery on conflict.
-func doPushRef(ctx context.Context, target string, refName plumbing.ReferenceName) error {
-	displayTarget := target
-	if remote.IsURL(target) {
-		displayTarget = "checkpoint remote"
-	}
-
-	shortRef := shortRefName(refName)
-	fmt.Fprintf(os.Stderr, "[entire] Pushing %s to %s...", shortRef, displayTarget)
-	stop := startProgressDots(os.Stderr)
-
-	if result, err := tryPushRef(ctx, target, refName); err == nil {
-		finishPush(ctx, stop, result, target)
-		return nil
-	}
-	stop("")
-
-	fmt.Fprintf(os.Stderr, "[entire] Syncing %s with remote...", shortRef)
-	stop = startProgressDots(os.Stderr)
-
-	if err := fetchAndMergeRef(ctx, target, refName); err != nil {
-		stop("")
-		fmt.Fprintf(os.Stderr, "[entire] Warning: couldn't sync %s: %v\n", shortRef, err)
-		printCheckpointRemoteHint(target)
-		return nil
-	}
-	stop(" done")
-
-	fmt.Fprintf(os.Stderr, "[entire] Pushing %s to %s...", shortRef, displayTarget)
-	stop = startProgressDots(os.Stderr)
-
-	if result, err := tryPushRef(ctx, target, refName); err != nil {
-		stop("")
-		fmt.Fprintf(os.Stderr, "[entire] Warning: failed to push %s after sync: %v\n", shortRef, err)
-		printCheckpointRemoteHint(target)
-	} else {
-		finishPush(ctx, stop, result, target)
-	}
-
-	return nil
 }
 
 // fetchAndMergeRef fetches a remote custom ref and merges it into the local ref.

--- a/cmd/entire/cli/strategy/push_v2_test.go
+++ b/cmd/entire/cli/strategy/push_v2_test.go
@@ -242,7 +242,9 @@ func TestPushV2Refs_PushesAllRefs(t *testing.T) {
 	initCmd.Env = testutil.GitIsolatedEnv()
 	require.NoError(t, initCmd.Run())
 
+	restore := captureStderr(t)
 	pushV2Refs(ctx, bareDir)
+	output := restore()
 
 	// Verify all three refs exist in bare repo
 	bareRepo, err := git.PlainOpen(bareDir)
@@ -258,7 +260,33 @@ func TestPushV2Refs_PushesAllRefs(t *testing.T) {
 	require.NoError(t, err, "latest archived generation should exist in bare repo")
 
 	_, err = bareRepo.Reference(plumbing.ReferenceName(paths.V2FullRefPrefix+"0000000000001"), true)
-	assert.Error(t, err, "older archived generation should NOT be pushed")
+	require.Error(t, err, "older archived generation should NOT be pushed")
+
+	assert.Contains(t, output, "[entire] Syncing and pushing v2 checkpoints...")
+	assert.Contains(t, output, "[entire] Pushing v2/main, v2/full/current, v2/full/0000000000002...")
+	assert.Contains(t, output, "[entire] All v2 checkpoints pushed")
+	assert.NotContains(t, output, "Pushing v2/main to", "per-ref progress should stay quiet")
+	assert.NotContains(t, output, "Syncing v2/main with remote", "per-ref sync progress should stay quiet")
+}
+
+// TestPushV2Refs_UnreachableTarget_NamesFailedRef verifies that aggregated v2
+// push output still identifies the ref that could not be pushed.
+//
+// Not parallel: uses t.Chdir() and os.Stderr redirection.
+func TestPushV2Refs_UnreachableTarget_NamesFailedRef(t *testing.T) {
+	tmpDir := setupRepoWithV2Ref(t)
+	t.Chdir(tmpDir)
+
+	nonExistentPath := filepath.Join(t.TempDir(), "does-not-exist")
+	restore := captureStderr(t)
+	pushV2Refs(context.Background(), nonExistentPath)
+	output := restore()
+
+	assert.Contains(t, output, "[entire] Syncing and pushing v2 checkpoints...")
+	assert.Contains(t, output, "[entire] Pushing v2/main...")
+	assert.Contains(t, output, "[entire] Warning: couldn't sync v2/main:")
+	assert.NotContains(t, output, "[entire] All v2 checkpoints pushed")
+	assert.NotContains(t, output, "Pushing v2/main to", "failed aggregated pushes should avoid per-ref progress")
 }
 
 // TestFetchAndMergeRef_RotationConflict verifies that when /full/current push

--- a/cmd/entire/cli/strategy/push_v2_test.go
+++ b/cmd/entire/cli/strategy/push_v2_test.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -270,43 +271,47 @@ func TestPushV2Refs_PushesAllRefs(t *testing.T) {
 	assert.NotContains(t, output, "Syncing v2/main with remote", "per-ref sync progress should stay quiet")
 }
 
-// TestPushV2Refs_PartialFailurePrintsSuccessfulRefs verifies that when one
-// v2 ref succeeds and another fails, the failure output names the successful refs.
-//
-// Not parallel: uses t.Chdir() and os.Stderr redirection.
-func TestPushV2Refs_PartialFailurePrintsSuccessfulRefs(t *testing.T) {
-	ctx := context.Background()
+func TestPrintV2PartialPushResult(t *testing.T) {
+	t.Parallel()
 
-	tmpDir := setupRepoWithV2Ref(t)
-	repo, err := git.PlainOpen(tmpDir)
-	require.NoError(t, err)
-	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(
+	var output strings.Builder
+	printV2PartialPushResult(
+		&output,
+		[]plumbing.ReferenceName{plumbing.ReferenceName(paths.V2MainRefName)},
+		[]error{errors.New("couldn't sync v2/full/current: fetch failed")},
+	)
+
+	assert.Contains(t, output.String(), "[entire] Successfully pushed v2/main")
+	assert.Contains(t, output.String(), "[entire] Warning: couldn't sync v2/full/current: fetch failed")
+	assert.NotContains(t, output.String(), "[entire] All v2 checkpoints pushed")
+}
+
+func TestParsePushRefResults_MultiRefPorcelain(t *testing.T) {
+	t.Parallel()
+
+	refs := []plumbing.ReferenceName{
+		plumbing.ReferenceName(paths.V2MainRefName),
 		plumbing.ReferenceName(paths.V2FullCurrentRefName),
-		plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-	)))
+		plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000002"),
+	}
+	output := strings.Join([]string{
+		"To https://example.com/repo.git",
+		"*\trefs/entire/checkpoints/v2/main:refs/entire/checkpoints/v2/main\t[new reference]",
+		"!\trefs/entire/checkpoints/v2/full/current:refs/entire/checkpoints/v2/full/current\t[rejected] (non-fast-forward)",
+		"=\trefs/entire/checkpoints/v2/full/0000000000002:refs/entire/checkpoints/v2/full/0000000000002\tup to date",
+	}, "\n")
 
-	t.Chdir(tmpDir)
+	results := parsePushRefResults(output, refs, errors.New("git push failed"))
 
-	bareDir := t.TempDir()
-	initCmd := exec.CommandContext(ctx, "git", "init", "--bare")
-	initCmd.Dir = bareDir
-	initCmd.Env = testutil.GitIsolatedEnv()
-	require.NoError(t, initCmd.Run())
-
-	restore := captureStderr(t)
-	pushV2Refs(ctx, bareDir)
-	output := restore()
-
-	bareRepo, err := git.PlainOpen(bareDir)
-	require.NoError(t, err)
-	_, err = bareRepo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
-	require.NoError(t, err, "/main ref should exist in bare repo")
-	_, err = bareRepo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
-	require.Error(t, err, "/full/current ref should not exist after failed push")
-
-	assert.Contains(t, output, "[entire] Successfully pushed v2/main")
-	assert.Contains(t, output, "[entire] Warning: couldn't sync v2/full/current:")
-	assert.NotContains(t, output, "[entire] All v2 checkpoints pushed")
+	require.Len(t, results, 3)
+	assert.Equal(t, plumbing.ReferenceName(paths.V2MainRefName), results[0].refName)
+	require.NoError(t, results[0].err)
+	assert.False(t, results[0].result.upToDate)
+	assert.Equal(t, plumbing.ReferenceName(paths.V2FullCurrentRefName), results[1].refName)
+	require.ErrorContains(t, results[1].err, "non-fast-forward")
+	assert.Equal(t, plumbing.ReferenceName(paths.V2FullRefPrefix+"0000000000002"), results[2].refName)
+	require.NoError(t, results[2].err)
+	assert.True(t, results[2].result.upToDate)
 }
 
 // TestPushV2Refs_UnreachableTarget_NamesFailedRef verifies that aggregated v2

--- a/cmd/entire/cli/strategy/push_v2_test.go
+++ b/cmd/entire/cli/strategy/push_v2_test.go
@@ -51,54 +51,6 @@ func setupRepoWithV2Ref(t *testing.T) string {
 	return tmpDir
 }
 
-// Not parallel: uses t.Chdir()
-func TestPushRefIfNeeded_NoLocalRef_ReturnsNil(t *testing.T) {
-	tmpDir := t.TempDir()
-	testutil.InitRepo(t, tmpDir)
-	testutil.WriteFile(t, tmpDir, "f.txt", "init")
-	testutil.GitAdd(t, tmpDir, "f.txt")
-	testutil.GitCommit(t, tmpDir, "init")
-	t.Chdir(tmpDir)
-
-	ctx := context.Background()
-	err := pushRefIfNeeded(ctx, "origin", plumbing.ReferenceName(paths.V2MainRefName))
-	assert.NoError(t, err)
-}
-
-// Not parallel: uses t.Chdir()
-func TestPushRefIfNeeded_LocalBareRepo_PushesSuccessfully(t *testing.T) {
-	ctx := context.Background()
-
-	tmpDir := setupRepoWithV2Ref(t)
-	t.Chdir(tmpDir)
-
-	bareDir := t.TempDir()
-	initCmd := exec.CommandContext(ctx, "git", "init", "--bare")
-	initCmd.Dir = bareDir
-	initCmd.Env = testutil.GitIsolatedEnv()
-	require.NoError(t, initCmd.Run())
-
-	err := pushRefIfNeeded(ctx, bareDir, plumbing.ReferenceName(paths.V2MainRefName))
-	require.NoError(t, err)
-
-	// Verify ref exists in bare repo
-	bareRepo, err := git.PlainOpen(bareDir)
-	require.NoError(t, err)
-	_, err = bareRepo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
-	assert.NoError(t, err, "v2 /main ref should exist in bare repo after push")
-}
-
-// Not parallel: uses t.Chdir()
-func TestPushRefIfNeeded_UnreachableTarget_ReturnsNil(t *testing.T) {
-	tmpDir := setupRepoWithV2Ref(t)
-	t.Chdir(tmpDir)
-
-	ctx := context.Background()
-	nonExistentPath := filepath.Join(t.TempDir(), "does-not-exist")
-	err := pushRefIfNeeded(ctx, nonExistentPath, plumbing.ReferenceName(paths.V2MainRefName))
-	assert.NoError(t, err, "pushRefIfNeeded should return nil when target is unreachable")
-}
-
 func TestShortRefName(t *testing.T) {
 	t.Parallel()
 
@@ -301,7 +253,7 @@ func TestParsePushRefResults_MultiRefPorcelain(t *testing.T) {
 		"=\trefs/entire/checkpoints/v2/full/0000000000002:refs/entire/checkpoints/v2/full/0000000000002\tup to date",
 	}, "\n")
 
-	results := parsePushRefResults(output, refs, errors.New("git push failed"))
+	results := parsePushRefResults(context.Background(), output, refs, errors.New("git push failed"))
 
 	require.Len(t, results, 3)
 	assert.Equal(t, plumbing.ReferenceName(paths.V2MainRefName), results[0].refName)
@@ -312,6 +264,39 @@ func TestParsePushRefResults_MultiRefPorcelain(t *testing.T) {
 	assert.Equal(t, plumbing.ReferenceName(paths.V2FullRefPrefix+"0000000000002"), results[2].refName)
 	require.NoError(t, results[2].err)
 	assert.True(t, results[2].result.upToDate)
+}
+
+func TestParsePushRefResults_MissingStatusUsesStatusMissing(t *testing.T) {
+	t.Parallel()
+
+	refs := []plumbing.ReferenceName{
+		plumbing.ReferenceName(paths.V2MainRefName),
+		plumbing.ReferenceName(paths.V2FullCurrentRefName),
+	}
+	output := strings.Join([]string{
+		"To https://example.com/repo.git",
+		"*\trefs/entire/checkpoints/v2/main:refs/entire/checkpoints/v2/main\t[new reference]",
+	}, "\n")
+
+	results := parsePushRefResults(context.Background(), output, refs, errors.New("git push failed"))
+
+	require.Len(t, results, 2)
+	require.NoError(t, results[0].err)
+	require.ErrorContains(t, results[1].err, "status missing for v2/full/current")
+}
+
+func TestParsePushRefResults_GenericRejectionDoesNotBecomeNonFastForward(t *testing.T) {
+	t.Parallel()
+
+	refs := []plumbing.ReferenceName{plumbing.ReferenceName(paths.V2MainRefName)}
+	output := "!\trefs/entire/checkpoints/v2/main:refs/entire/checkpoints/v2/main\t[remote rejected] auth rejected by server"
+
+	results := parsePushRefResults(context.Background(), output, refs, errors.New("git push failed"))
+
+	require.Len(t, results, 1)
+	require.Error(t, results[0].err)
+	require.NotErrorIs(t, results[0].err, errNonFastForward)
+	assert.ErrorContains(t, results[0].err, "push failed")
 }
 
 // TestPushV2Refs_UnreachableTarget_NamesFailedRef verifies that aggregated v2
@@ -329,7 +314,8 @@ func TestPushV2Refs_UnreachableTarget_NamesFailedRef(t *testing.T) {
 
 	assert.Contains(t, output, "[entire] Syncing and pushing v2 checkpoints...")
 	assert.Contains(t, output, "[entire] Pushing v2/main...")
-	assert.Contains(t, output, "[entire] Warning: couldn't sync v2/main:")
+	assert.Contains(t, output, "[entire] Warning: failed to push v2/main:")
+	assert.NotContains(t, output, "[entire] Warning: couldn't sync v2/main:")
 	assert.NotContains(t, output, "[entire] All v2 checkpoints pushed")
 	assert.NotContains(t, output, "Pushing v2/main to", "failed aggregated pushes should avoid per-ref progress")
 }

--- a/cmd/entire/cli/strategy/push_v2_test.go
+++ b/cmd/entire/cli/strategy/push_v2_test.go
@@ -265,8 +265,48 @@ func TestPushV2Refs_PushesAllRefs(t *testing.T) {
 	assert.Contains(t, output, "[entire] Syncing and pushing v2 checkpoints...")
 	assert.Contains(t, output, "[entire] Pushing v2/main, v2/full/current, v2/full/0000000000002...")
 	assert.Contains(t, output, "[entire] All v2 checkpoints pushed")
+	assert.NotContains(t, output, "[entire] Successfully pushed", "successful refs should only be listed on partial failure")
 	assert.NotContains(t, output, "Pushing v2/main to", "per-ref progress should stay quiet")
 	assert.NotContains(t, output, "Syncing v2/main with remote", "per-ref sync progress should stay quiet")
+}
+
+// TestPushV2Refs_PartialFailurePrintsSuccessfulRefs verifies that when one
+// v2 ref succeeds and another fails, the failure output names the successful refs.
+//
+// Not parallel: uses t.Chdir() and os.Stderr redirection.
+func TestPushV2Refs_PartialFailurePrintsSuccessfulRefs(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := setupRepoWithV2Ref(t)
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(
+		plumbing.ReferenceName(paths.V2FullCurrentRefName),
+		plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+	)))
+
+	t.Chdir(tmpDir)
+
+	bareDir := t.TempDir()
+	initCmd := exec.CommandContext(ctx, "git", "init", "--bare")
+	initCmd.Dir = bareDir
+	initCmd.Env = testutil.GitIsolatedEnv()
+	require.NoError(t, initCmd.Run())
+
+	restore := captureStderr(t)
+	pushV2Refs(ctx, bareDir)
+	output := restore()
+
+	bareRepo, err := git.PlainOpen(bareDir)
+	require.NoError(t, err)
+	_, err = bareRepo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	require.NoError(t, err, "/main ref should exist in bare repo")
+	_, err = bareRepo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
+	require.Error(t, err, "/full/current ref should not exist after failed push")
+
+	assert.Contains(t, output, "[entire] Successfully pushed v2/main")
+	assert.Contains(t, output, "[entire] Warning: couldn't sync v2/full/current:")
+	assert.NotContains(t, output, "[entire] All v2 checkpoints pushed")
 }
 
 // TestPushV2Refs_UnreachableTarget_NamesFailedRef verifies that aggregated v2


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/277
<!-- entire-trail-link-end -->

Push v2 checkpoints in parallel + reduce verbosity in output messaging.

```
[entire] Pushing v2/main to dogfood....
[entire] Syncing v2/main with remote.......... done
[entire] Pushing v2/main to dogfood...... done
[entire] Pushing v2/full/current to dogfood....
[entire] Syncing v2/full/current with remote........ done
[entire] Pushing v2/full/current to dogfood...... done
[entire] Pushing v2/full/0000000000023 to dogfood....
[entire] Syncing v2/full/0000000000023 with remote........... done
[entire] Pushing v2/full/0000000000023 to dogfood...... done
```

```
➜  test-repo git:(main) ✗ git push origin hEAD
[entire] Syncing and pushing v2 checkpoints...
[entire] Pushing v2/main, v2/full/current...
[entire] All v2 checkpoints pushed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the checkpoint push flow to run ref pushes concurrently and alters recovery/error reporting; concurrency could surface racey git/working-dir assumptions or make failures harder to reproduce.
> 
> **Overview**
> Updates v2 checkpoint pushing to **sync/push `v2/main`, `v2/full/current`, and the latest archived generation concurrently**, replacing per-ref progress spam with a single aggregated header, per-ref warnings, and a final success message.
> 
> Refactors the v2 push path to return structured results (`v2RefPushResult`) and perform fetch+merge recovery per ref without emitting interleaved output, and adds `--no-write-fetch-head` to checkpoint `git fetch` calls to avoid updating `FETCH_HEAD`.
> 
> Tests are updated to capture stderr and assert the new aggregated messaging, and add coverage that failed pushes still name the specific ref that couldn’t be synced/pushed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb95c197b9b799f8bec34c5da59a29b76951f7fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->