### PR TITLE
copilot cli guards hooks for direct prompt runs

### DIFF
--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -74,7 +74,12 @@ func (c *CopilotCLI) RunPrompt(ctx context.Context, dir string, prompt string, o
 	cmd := exec.CommandContext(promptCtx, c.Binary(), args...)
 	cmd.Dir = dir
 	cmd.Stdin = nil
-	cmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0")
+	// GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS opts in to .github/hooks/*.json loading
+	// in -p mode; gated since Copilot 1.0.40 (2026-05-01).
+	cmd.Env = append(os.Environ(),
+		"ENTIRE_TEST_TTY=0",
+		"GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS=true",
+	)
 	setupProcessGroup(cmd)
 	cmd.WaitDelay = 5 * time.Second
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/281
<!-- entire-trail-link-end -->

copilot cli guards now hooks in prompt mode, see: 

https://github.com/github/copilot-cli/releases/tag/v1.0.40

> Prompt mode (-p) now gates repo hooks and workspace MCP behind opt-in env vars (GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS and GITHUB_COPILOT_PROMPT_MODE_WORKSPACE_MCP) for secure-by-default behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts environment variables passed to the Copilot CLI during E2E `-p` prompt execution, with no changes to core business logic or data handling; main risk is altered test behavior due to enabling repo hook loading.
> 
> **Overview**
> Updates the Copilot CLI E2E `RunPrompt` path to explicitly opt in to repo hook loading in `-p` prompt mode by setting `GITHUB_COPILOT_PROMPT_MODE_REPO_HOOKS=true` (alongside `ENTIRE_TEST_TTY=0`), aligning tests with Copilot CLI v1.0.40’s new secure-by-default gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561acdc45ed8a51a3624d910be5928641a9b0050. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->