### PR TITLE
Fix failing cursor-cli E2E tests

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -950,13 +950,20 @@ func calculateSessionAttributions(ctx context.Context, repo *git.Repository, sha
 	return attribution
 }
 
-// committedFilesExcludingMetadata returns committed files with CLI metadata paths filtered out.
-// `.entire/` files are created by `entire enable`, not by the agent, and should not be
-// attributed as agent work when used as a fallback for sessions with no FilesTouched.
+// committedFilesExcludingMetadata returns committed files with CLI- and
+// agent-managed paths filtered out. Files under `.entire/`, `.git/`, agent
+// config directories (e.g. `.cursor/`, `.claude/`), and registered protected
+// files (e.g. `opencode.json`) are created by `entire enable` or the agent
+// integration itself, not by user-prompted work, so they should not appear in
+// files_touched when this fallback fires for sessions with no FilesTouched.
 func committedFilesExcludingMetadata(committedFiles map[string]struct{}) []string {
+	protectedFiles := agent.AllProtectedFiles()
 	result := make([]string, 0, len(committedFiles))
 	for f := range committedFiles {
-		if strings.HasPrefix(f, ".entire/") || strings.HasPrefix(f, paths.EntireMetadataDir+"/") {
+		if isProtectedPath(f) {
+			continue
+		}
+		if slices.Contains(protectedFiles, f) {
 			continue
 		}
 		result = append(result, f)

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -4662,11 +4662,13 @@ func TestCommittedFilesExcludingMetadata(t *testing.T) {
 		".entire/settings.json": {},
 		".entire/.gitignore":    {},
 		".claude/settings.json": {},
+		".cursor/hooks.json":    {},
+		"opencode.json":         {},
 	}
 
 	result := committedFilesExcludingMetadata(input)
 
-	// .entire/ files should be excluded, everything else kept
+	// .entire/, agent ProtectedDirs, and agent ProtectedFiles all excluded.
 	resultSet := make(map[string]struct{}, len(result))
 	for _, f := range result {
 		resultSet[f] = struct{}{}
@@ -4674,10 +4676,12 @@ func TestCommittedFilesExcludingMetadata(t *testing.T) {
 
 	require.Contains(t, resultSet, "docs/blue.md")
 	require.Contains(t, resultSet, "docs/red.md")
-	require.Contains(t, resultSet, ".claude/settings.json")
 	require.NotContains(t, resultSet, ".entire/settings.json", ".entire/ should be excluded")
 	require.NotContains(t, resultSet, ".entire/.gitignore", ".entire/ should be excluded")
-	require.Len(t, result, 3)
+	require.NotContains(t, resultSet, ".claude/settings.json", ".claude/ should be excluded (claude-code ProtectedDirs)")
+	require.NotContains(t, resultSet, ".cursor/hooks.json", ".cursor/ should be excluded (cursor ProtectedDirs)")
+	require.NotContains(t, resultSet, "opencode.json", "opencode.json should be excluded (opencode ProtectedFiles)")
+	require.Len(t, result, 2)
 }
 
 func TestMarshalPromptAttributionsIncludingPending_IncludesPending(t *testing.T) {

--- a/e2e/agents/cursor_cli.go
+++ b/e2e/agents/cursor_cli.go
@@ -132,10 +132,13 @@ func (a *CursorCLI) RunPrompt(ctx context.Context, dir string, prompt string, op
 			fmt.Errorf("sending prompt: %w", err)
 	}
 
-	// Wait for the "Add a follow-up" completion marker that appears after the
-	// agent finishes processing. We cannot reuse PromptPattern() here because
-	// it matches ready-state UI markers that can already be visible while the
-	// model is still thinking, causing WaitFor to settle prematurely.
+	// Wait for the "Add a follow-up" input placeholder. This alone isn't
+	// sufficient — Cursor renders the placeholder while the agent is still
+	// editing, alongside a busy-state hint "ctrl+c to stop" on the same line
+	// (and the "Editing N tokens" spinner above). If we return now, the
+	// caller's defer s.Close() kills tmux mid-turn, the cursor process exits
+	// before its `stop` hook fires, SaveStep never runs, and the resulting
+	// checkpoint has empty FilesTouched.
 	content, waitErr := s.WaitFor(`Add a follow-up`, timeout)
 	if waitErr != nil {
 		// Check for deadline exceeded to allow transient error detection.
@@ -145,7 +148,22 @@ func (a *CursorCLI) RunPrompt(ctx context.Context, dir string, prompt string, op
 		return Output{Command: displayCmd, Stdout: content, ExitCode: -1}, waitErr
 	}
 
-	return Output{Command: displayCmd, Stdout: content, ExitCode: 0}, nil
+	// Then wait for the busy hint to disappear, confirming the agent has
+	// finished its turn so the `stop` hook can fire before tmux is torn down.
+	idleDeadline := time.Now().Add(timeout)
+	for time.Now().Before(idleDeadline) {
+		content = s.Capture()
+		if !strings.Contains(content, "ctrl+c to stop") {
+			return Output{Command: displayCmd, Stdout: content, ExitCode: 0}, nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return Output{Command: displayCmd, Stdout: content, ExitCode: -1},
+			fmt.Errorf("cursor agent did not finish turn (ctrl+c to stop still visible) within %s: %w", timeout, context.DeadlineExceeded)
+	}
+	return Output{Command: displayCmd, Stdout: content, ExitCode: -1},
+		fmt.Errorf("cursor agent did not finish turn (ctrl+c to stop still visible) within %s", timeout)
 }
 
 func (a *CursorCLI) StartSession(ctx context.Context, dir string) (Session, error) {

--- a/e2e/agents/cursor_cli.go
+++ b/e2e/agents/cursor_cli.go
@@ -132,6 +132,11 @@ func (a *CursorCLI) RunPrompt(ctx context.Context, dir string, prompt string, op
 			fmt.Errorf("sending prompt: %w", err)
 	}
 
+	// One absolute deadline covers both the "Add a follow-up" wait and the
+	// subsequent busy-hint wait, so the whole RunPrompt call honors the
+	// caller-provided timeout (rather than ~2× it across two stages).
+	deadline := time.Now().Add(timeout)
+
 	// Wait for the "Add a follow-up" input placeholder. This alone isn't
 	// sufficient — Cursor renders the placeholder while the agent is still
 	// editing, alongside a busy-state hint "ctrl+c to stop" on the same line
@@ -139,7 +144,7 @@ func (a *CursorCLI) RunPrompt(ctx context.Context, dir string, prompt string, op
 	// caller's defer s.Close() kills tmux mid-turn, the cursor process exits
 	// before its `stop` hook fires, SaveStep never runs, and the resulting
 	// checkpoint has empty FilesTouched.
-	content, waitErr := s.WaitFor(`Add a follow-up`, timeout)
+	content, waitErr := s.WaitFor(`Add a follow-up`, time.Until(deadline))
 	if waitErr != nil {
 		// Check for deadline exceeded to allow transient error detection.
 		if ctx.Err() == context.DeadlineExceeded {
@@ -150,20 +155,30 @@ func (a *CursorCLI) RunPrompt(ctx context.Context, dir string, prompt string, op
 
 	// Then wait for the busy hint to disappear, confirming the agent has
 	// finished its turn so the `stop` hook can fire before tmux is torn down.
-	idleDeadline := time.Now().Add(timeout)
-	for time.Now().Before(idleDeadline) {
-		content = s.Capture()
+	for {
 		if !strings.Contains(content, "ctrl+c to stop") {
 			return Output{Command: displayCmd, Stdout: content, ExitCode: 0}, nil
 		}
-		time.Sleep(200 * time.Millisecond)
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			err := fmt.Errorf("cursor agent did not finish turn (ctrl+c to stop still visible) within %s", timeout)
+			if ctx.Err() == context.DeadlineExceeded {
+				err = fmt.Errorf("%w: %w", err, context.DeadlineExceeded)
+			}
+			return Output{Command: displayCmd, Stdout: content, ExitCode: -1}, err
+		}
+		sleep := 200 * time.Millisecond
+		if remaining < sleep {
+			sleep = remaining
+		}
+		select {
+		case <-ctx.Done():
+			return Output{Command: displayCmd, Stdout: content, ExitCode: -1},
+				fmt.Errorf("waiting for cursor agent to finish turn: %w", ctx.Err())
+		case <-time.After(sleep):
+		}
+		content = s.Capture()
 	}
-	if ctx.Err() == context.DeadlineExceeded {
-		return Output{Command: displayCmd, Stdout: content, ExitCode: -1},
-			fmt.Errorf("cursor agent did not finish turn (ctrl+c to stop still visible) within %s: %w", timeout, context.DeadlineExceeded)
-	}
-	return Output{Command: displayCmd, Stdout: content, ExitCode: -1},
-		fmt.Errorf("cursor agent did not finish turn (ctrl+c to stop still visible) within %s", timeout)
 }
 
 func (a *CursorCLI) StartSession(ctx context.Context, dir string) (Session, error) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/282
<!-- entire-trail-link-end -->

Two fixes: 

- now filters all agent ProtectedDirs/Files that cursor might touch
- cursor RunPrompt also waits for "ctrl+c to stop" to disappear, so cursor finishes its turn and fires the stop hook before tmux is torn down.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `files_touched` is derived during fallback condensation, which can affect checkpoint attribution/metadata; the Cursor E2E wait logic also changes timing and could introduce new timeouts.
> 
> **Overview**
> Fixes checkpoint `files_touched` fallback to exclude **all agent-owned paths**, not just `.entire/`, by filtering protected dirs (e.g. `.cursor/`, `.claude/`, `.git/`) and registered protected files (e.g. `opencode.json`) from `committedFilesExcludingMetadata`.
> 
> Stabilizes Cursor CLI E2E runs by waiting for Cursor to become truly idle (the "ctrl+c to stop" busy hint disappears) before tearing down tmux, ensuring the `stop` hook fires and `SaveStep` populates `FilesTouched`; updates the related unit test expectations accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7db0b5bb846bea6ca3922fba66da27524b74d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->