### PR TITLE
drop trailer instruction from TestMidTurnCommit prompt

### DIFF
--- a/e2e/tests/mid_turn_commit_test.go
+++ b/e2e/tests/mid_turn_commit_test.go
@@ -39,7 +39,7 @@ func TestMidTurnCommit_DifferentFilesThanPreviousTurn(t *testing.T) {
 		// The committed files (turn2a.md, turn2b.md) do NOT overlap with
 		// Turn 1's tracked files (turn1.md).
 		_, err = s.RunPrompt(t, ctx,
-			"create two markdown files: docs/turn2a.md about bananas and docs/turn2b.md about cherries. Then git add and git commit both files with a short message. Do not commit any other files. Do not ask for confirmation, just make the changes. Do not add Co-authored-by or Signed-off-by trailers. Do not use worktrees.")
+			"create two markdown files: docs/turn2a.md about bananas and docs/turn2b.md about cherries. Then git add and git commit both files with a short message. Do not commit any other files. Do not ask for confirmation, just make the changes. Do not use worktrees.")
 		if err != nil {
 			t.Fatalf("agent prompt 2 (turn 2) failed: %v", err)
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/283
<!-- entire-trail-link-end -->

Cursor was bypassing the prepare-commit-msg hook (core.hooksPath=<empty dir>) to strip the Entire-Checkpoint trailer along with Co-authored-by/Signed-off-by, failing AssertHasCheckpointTrailer on HEAD. The trailer instruction was unmotivated boilerplate from the test's introduction; removing it is safer than narrowing the wording again, which already drifted once.

I checked the old session introducing this, and this was not a concrete ask of the author (me) but instead the agent just made it so it's super specific. But we can leave other trailers, shouldn't hurt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tweaks an E2E test prompt string to avoid constraining git commit trailers; it may change agent behavior/commit message content expectations but doesn’t affect production logic.
> 
> **Overview**
> Updates `TestMidTurnCommit_DifferentFilesThanPreviousTurn` to stop instructing the agent to avoid `Co-authored-by`/`Signed-off-by` trailers during the mid-turn `git commit`, leaving only the constraints about which files to commit and avoiding worktrees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb37c0dc948fb0dc2525660159d7ddee3dac9f5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->