### PR TITLE
refactor(review): add per-agent reviewers and orchestrator (2/3)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -108,6 +108,7 @@ linters:
         - grpc.DialOption
         - github.com/entireio/cli/cmd/entire/cli/summarize.Generator
         - github.com/entireio/cli/cmd/entire/cli/agent\..+
+        - github.com/entireio/cli/cmd/entire/cli/review/types.Process
         - github.com/entireio/cli/cmd/entire/cli/checkpoint.CommittedReader
         - github.com/entireio/cli/cmd/entire/cli/strategy.Strategy
         - github.com/go-git/go-git/v6/x/plugin.Signer

--- a/cmd/entire/cli/agent/architecture_test.go
+++ b/cmd/entire/cli/agent/architecture_test.go
@@ -54,6 +54,7 @@ func TestAgentPackages_NoForbiddenImports(t *testing.T) {
 		repoPrefix + "telemetry",  // telemetry
 		repoPrefix + "validation", // validation utilities
 		repoPrefix + "settings",   // settings (read-only access)
+		repoPrefix + "review",     // review env contract + AgentReviewer types (used by per-agent reviewer.go files)
 	}
 
 	agentDir := findAgentDir(t)

--- a/cmd/entire/cli/agent/claudecode/reviewer.go
+++ b/cmd/entire/cli/agent/claudecode/reviewer.go
@@ -12,42 +12,21 @@ import (
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
 
-// Reviewer is the AgentReviewer implementation for claude-code.
+// NewReviewer returns the AgentReviewer for claude-code.
 //
-// Argv shape: claude -p "<prompt>".
-// Prompt is passed as a command-line argument; stdin is unused.
+// Argv shape: claude -p <prompt>. Plain-text stdout.
+// The prompt is passed as a command-line argument; stdin is unused.
 // Stdout in -p mode is the assistant's plain-text response (no JSON envelope).
-type Reviewer struct{}
-
-// NewReviewer creates a new claude-code AgentReviewer.
-func NewReviewer() *Reviewer { return &Reviewer{} }
-
-// Compile-time interface check.
-var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
-
-// Name returns the agent's registry key.
-func (*Reviewer) Name() string { return "claude-code" }
-
-// Start spawns claude with the review prompt and returns a streaming Process.
-// Binary lookup is deferred to exec.Cmd.Start, so a missing binary surfaces
-// as an error from this call (Start propagates os/exec's "executable not found"
-// error immediately when cmd.Start fails).
-func (r *Reviewer) Start(ctx context.Context, cfg reviewtypes.RunConfig) (reviewtypes.Process, error) {
-	cmd := buildReviewCmd(ctx, cfg)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("claude-code: stdout pipe: %w", err)
+func NewReviewer() *reviewtypes.ReviewerTemplate {
+	return &reviewtypes.ReviewerTemplate{
+		AgentName: "claude-code",
+		BuildCmd:  buildReviewCmd,
+		Parser:    parseClaudeOutput,
 	}
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("claude-code: start: %w", err)
-	}
-	p := &reviewProcess{cmd: cmd, events: make(chan reviewtypes.Event, 32)}
-	go p.run(stdout)
-	return p, nil
 }
 
 // buildReviewCmd builds the exec.Cmd for a claude review run.
-// Exported at package level for test inspection of argv and env.
+// Exposed at package level for test inspection of argv and env.
 func buildReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
 	prompt := review.ComposeReviewPrompt(cfg)
 	cmd := exec.CommandContext(ctx, "claude", "-p", prompt)
@@ -84,23 +63,4 @@ func parseClaudeOutput(r io.Reader) <-chan reviewtypes.Event {
 		out <- reviewtypes.Finished{Success: true}
 	}()
 	return out
-}
-
-// reviewProcess is the running claude review process.
-type reviewProcess struct {
-	cmd    *exec.Cmd
-	events chan reviewtypes.Event
-}
-
-func (p *reviewProcess) Events() <-chan reviewtypes.Event { return p.events }
-
-// Wait implements Process.Wait. The *exec.ExitError passes through unwrapped
-// per the Process.Wait contract; callers may errors.As for *exec.ExitError.
-func (p *reviewProcess) Wait() error { return p.cmd.Wait() } //nolint:wrapcheck // Process.Wait contract allows *exec.ExitError passthrough
-
-func (p *reviewProcess) run(stdout io.Reader) {
-	defer close(p.events)
-	for ev := range parseClaudeOutput(stdout) {
-		p.events <- ev
-	}
 }

--- a/cmd/entire/cli/agent/claudecode/reviewer.go
+++ b/cmd/entire/cli/agent/claudecode/reviewer.go
@@ -1,0 +1,144 @@
+package claudecode
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/review"
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// Reviewer is the AgentReviewer implementation for claude-code.
+//
+// Argv shape: claude -p "<prompt>".
+// Prompt is passed as a command-line argument; stdin is unused.
+// Stdout in -p mode is the assistant's plain-text response (no JSON envelope).
+type Reviewer struct{}
+
+// NewReviewer creates a new claude-code AgentReviewer.
+func NewReviewer() *Reviewer { return &Reviewer{} }
+
+// Compile-time interface check.
+var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
+
+// Name returns the agent's registry key.
+func (*Reviewer) Name() string { return "claude-code" }
+
+// Start spawns claude with the review prompt and returns a streaming Process.
+// Binary lookup is deferred to exec.Cmd.Start, so a missing binary surfaces
+// as an error from this call (Start propagates os/exec's "executable not found"
+// error immediately when cmd.Start fails).
+func (r *Reviewer) Start(ctx context.Context, cfg reviewtypes.RunConfig) (reviewtypes.Process, error) {
+	cmd := buildReviewCmd(ctx, cfg)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("claude-code: stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("claude-code: start: %w", err)
+	}
+	p := &reviewProcess{cmd: cmd, events: make(chan reviewtypes.Event, 32)}
+	go p.run(stdout)
+	return p, nil
+}
+
+// buildReviewCmd builds the exec.Cmd for a claude review run.
+// Exported at package level for test inspection of argv and env.
+func buildReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
+	prompt := composeReviewPrompt(cfg)
+	cmd := exec.CommandContext(ctx, "claude", "-p", prompt)
+	cmd.Env = appendReviewEnv(os.Environ(), "claude-code", cfg, prompt)
+	return cmd
+}
+
+// appendReviewEnv appends ENTIRE_REVIEW_* vars to the given base environment.
+func appendReviewEnv(base []string, agentName string, cfg reviewtypes.RunConfig, prompt string) []string {
+	skillsJSON, _ := review.EncodeSkills(cfg.Skills) //nolint:errcheck // EncodeSkills only fails on json.Marshal([]string), which is infallible
+	return append(base,
+		review.EnvSession+"=1",
+		review.EnvAgent+"="+agentName,
+		review.EnvSkills+"="+skillsJSON,
+		review.EnvPrompt+"="+prompt,
+		review.EnvStartingSHA+"="+cfg.StartingSHA,
+	)
+}
+
+// composeReviewPrompt concatenates Skills, AlwaysPrompt, and PerRunPrompt
+// (skipping empty strings) with double-newline separators.
+// Full composition with a scope clause lands in CU5.
+func composeReviewPrompt(cfg reviewtypes.RunConfig) string {
+	parts := make([]string, 0, len(cfg.Skills)+2)
+	parts = append(parts, cfg.Skills...)
+	parts = append(parts, cfg.AlwaysPrompt, cfg.PerRunPrompt)
+	return joinNonEmpty(parts, "\n\n")
+}
+
+// joinNonEmpty joins non-empty strings with the given separator.
+func joinNonEmpty(parts []string, sep string) string {
+	var out strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if out.Len() > 0 {
+			out.WriteString(sep)
+		}
+		out.WriteString(p)
+	}
+	return out.String()
+}
+
+// parseClaudeOutput converts claude's -p mode stdout into a stream of Events.
+// In -p mode claude emits the assistant's response as plain text (one line per
+// stdout line). The parser emits Started once, then one AssistantText per
+// non-empty line, then Finished{Success: true} on clean EOF or
+// RunError + Finished{Success: false} on a torn stream (scanner error).
+//
+// Exposed for golden-file contract testing.
+func parseClaudeOutput(r io.Reader) <-chan reviewtypes.Event {
+	out := make(chan reviewtypes.Event, 32)
+	go func() {
+		defer close(out)
+		out <- reviewtypes.Started{}
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			out <- reviewtypes.AssistantText{Text: line}
+		}
+		if err := scanner.Err(); err != nil {
+			out <- reviewtypes.RunError{Err: fmt.Errorf("read stdout: %w", err)}
+			out <- reviewtypes.Finished{Success: false}
+			return
+		}
+		out <- reviewtypes.Finished{Success: true}
+	}()
+	return out
+}
+
+// reviewProcess is the running claude review process.
+type reviewProcess struct {
+	cmd    *exec.Cmd
+	events chan reviewtypes.Event
+}
+
+func (p *reviewProcess) Events() <-chan reviewtypes.Event { return p.events }
+
+// Wait implements Process.Wait. The *exec.ExitError passes through unwrapped
+// per the Process.Wait contract; callers may errors.As for *exec.ExitError.
+func (p *reviewProcess) Wait() error { return p.cmd.Wait() } //nolint:wrapcheck // Process.Wait contract allows *exec.ExitError passthrough
+
+func (p *reviewProcess) run(stdout io.Reader) {
+	defer close(p.events)
+	for ev := range parseClaudeOutput(stdout) {
+		p.events <- ev
+	}
+}

--- a/cmd/entire/cli/agent/claudecode/reviewer.go
+++ b/cmd/entire/cli/agent/claudecode/reviewer.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/review"
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
@@ -50,47 +49,10 @@ func (r *Reviewer) Start(ctx context.Context, cfg reviewtypes.RunConfig) (review
 // buildReviewCmd builds the exec.Cmd for a claude review run.
 // Exported at package level for test inspection of argv and env.
 func buildReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
-	prompt := composeReviewPrompt(cfg)
+	prompt := review.ComposeReviewPrompt(cfg)
 	cmd := exec.CommandContext(ctx, "claude", "-p", prompt)
-	cmd.Env = appendReviewEnv(os.Environ(), "claude-code", cfg, prompt)
+	cmd.Env = review.AppendReviewEnv(os.Environ(), "claude-code", cfg, prompt)
 	return cmd
-}
-
-// appendReviewEnv appends ENTIRE_REVIEW_* vars to the given base environment.
-func appendReviewEnv(base []string, agentName string, cfg reviewtypes.RunConfig, prompt string) []string {
-	skillsJSON, _ := review.EncodeSkills(cfg.Skills) //nolint:errcheck // EncodeSkills only fails on json.Marshal([]string), which is infallible
-	return append(base,
-		review.EnvSession+"=1",
-		review.EnvAgent+"="+agentName,
-		review.EnvSkills+"="+skillsJSON,
-		review.EnvPrompt+"="+prompt,
-		review.EnvStartingSHA+"="+cfg.StartingSHA,
-	)
-}
-
-// composeReviewPrompt concatenates Skills, AlwaysPrompt, and PerRunPrompt
-// (skipping empty strings) with double-newline separators.
-// Full composition with a scope clause lands in CU5.
-func composeReviewPrompt(cfg reviewtypes.RunConfig) string {
-	parts := make([]string, 0, len(cfg.Skills)+2)
-	parts = append(parts, cfg.Skills...)
-	parts = append(parts, cfg.AlwaysPrompt, cfg.PerRunPrompt)
-	return joinNonEmpty(parts, "\n\n")
-}
-
-// joinNonEmpty joins non-empty strings with the given separator.
-func joinNonEmpty(parts []string, sep string) string {
-	var out strings.Builder
-	for _, p := range parts {
-		if p == "" {
-			continue
-		}
-		if out.Len() > 0 {
-			out.WriteString(sep)
-		}
-		out.WriteString(p)
-	}
-	return out.String()
 }
 
 // parseClaudeOutput converts claude's -p mode stdout into a stream of Events.

--- a/cmd/entire/cli/agent/claudecode/reviewer_test.go
+++ b/cmd/entire/cli/agent/claudecode/reviewer_test.go
@@ -1,0 +1,248 @@
+package claudecode
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/review"
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// Compile-time interface check lives in reviewer.go via var _ AgentReviewer = (*Reviewer)(nil).
+// Keep a second check here to surface errors in the test binary.
+var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
+
+const wantAgentName = "claude-code"
+
+func TestReviewer_Name(t *testing.T) {
+	t.Parallel()
+	r := NewReviewer()
+	if got := r.Name(); got != wantAgentName {
+		t.Errorf("Name() = %q, want %q", got, wantAgentName)
+	}
+}
+
+func TestReviewer_EnvVarsSet(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/pr-review-toolkit:review-pr", "/test-auditor"},
+		AlwaysPrompt: "Always check for security issues.",
+		PerRunPrompt: "Focus on the auth module.",
+		StartingSHA:  "abc123def456",
+	}
+	cmd := buildReviewCmd(context.Background(), cfg)
+
+	wantEnvKeys := []string{
+		review.EnvSession,
+		review.EnvAgent,
+		review.EnvSkills,
+		review.EnvPrompt,
+		review.EnvStartingSHA,
+	}
+	envMap := make(map[string]string)
+	for _, e := range cmd.Env {
+		idx := strings.IndexByte(e, '=')
+		if idx < 0 {
+			continue
+		}
+		envMap[e[:idx]] = e[idx+1:]
+	}
+
+	for _, key := range wantEnvKeys {
+		if _, ok := envMap[key]; !ok {
+			t.Errorf("env var %s not set on cmd", key)
+		}
+	}
+
+	if envMap[review.EnvSession] != "1" {
+		t.Errorf("%s = %q, want %q", review.EnvSession, envMap[review.EnvSession], "1")
+	}
+	if envMap[review.EnvAgent] != wantAgentName {
+		t.Errorf("%s = %q, want %q", review.EnvAgent, envMap[review.EnvAgent], wantAgentName)
+	}
+	if envMap[review.EnvStartingSHA] != "abc123def456" {
+		t.Errorf("%s = %q, want %q", review.EnvStartingSHA, envMap[review.EnvStartingSHA], "abc123def456")
+	}
+	// Skills must be a valid JSON array.
+	if !strings.HasPrefix(envMap[review.EnvSkills], "[") {
+		t.Errorf("%s = %q, want JSON array", review.EnvSkills, envMap[review.EnvSkills])
+	}
+}
+
+func TestReviewer_ArgvShape(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/skill-a"},
+		PerRunPrompt: "extra context",
+	}
+	cmd := buildReviewCmd(context.Background(), cfg)
+
+	// Expect: claude -p <prompt>
+	if len(cmd.Args) < 3 {
+		t.Fatalf("expected at least 3 args, got %d: %v", len(cmd.Args), cmd.Args)
+	}
+	if cmd.Args[0] != "claude" {
+		t.Errorf("Args[0] = %q, want %q", cmd.Args[0], "claude")
+	}
+	if cmd.Args[1] != "-p" {
+		t.Errorf("Args[1] = %q, want %q", cmd.Args[1], "-p")
+	}
+	// Args[2] is the composed prompt — must be non-empty.
+	if cmd.Args[2] == "" {
+		t.Error("Args[2] (prompt) is empty")
+	}
+	// Stdin must be nil — claude receives prompt via argv, not stdin.
+	if cmd.Stdin != nil {
+		t.Errorf("cmd.Stdin = %v, want nil (claude uses argv, not stdin)", cmd.Stdin)
+	}
+}
+
+func TestReviewer_NoBinaryRequiredAtConstruction(t *testing.T) {
+	// No t.Parallel — uses t.Setenv.
+	t.Setenv("PATH", "")
+
+	r := NewReviewer()
+	cfg := reviewtypes.RunConfig{
+		Skills:      []string{"/test"},
+		StartingSHA: "abc123",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Construction (NewReviewer) MUST NOT touch PATH. Start may or may
+	// not error depending on whether the OS-level cmd.Start tries to
+	// resolve before fork — that's fine. The contract is just "no panic
+	// and no upfront LookPath call".
+	proc, err := r.Start(ctx, cfg)
+	// Either Start succeeded (deferred lookup; binary error surfaces in Wait)
+	// or Start failed with exec.ErrNotFound (immediate lookup at Cmd.Start).
+	// Both satisfy the deferred-lookup contract — what we explicitly DON'T
+	// want is a panic or error from NewReviewer itself.
+	if err != nil && !errors.Is(err, exec.ErrNotFound) {
+		// Tolerate "no such file" wrapping variations
+		if !strings.Contains(err.Error(), "executable file not found") &&
+			!strings.Contains(err.Error(), "no such file") {
+			t.Errorf("unexpected error type: %v", err)
+		}
+	}
+	if proc != nil {
+		// Drain events to let parser goroutine exit cleanly.
+		drainEvents(proc.Events())
+		_ = proc.Wait() //nolint:errcheck // best-effort cleanup in test
+	}
+}
+
+func TestParseClaudeOutput_ReportsScannerError(t *testing.T) {
+	t.Parallel()
+	// Trigger bufio.Scanner's "token too long" error: produce a "line"
+	// that exceeds the 16MB max buffer without containing a newline.
+	r, w := io.Pipe()
+	go func() {
+		defer w.Close()
+		// 17MB of contiguous bytes without a newline
+		buf := make([]byte, 1024*1024)
+		for range 17 {
+			_, _ = w.Write(buf) //nolint:errcheck // best-effort write in test goroutine
+		}
+	}()
+
+	events := collectEvents(parseClaudeOutput(r))
+
+	if len(events) < 2 {
+		t.Fatalf("expected at least Started + Finished, got %d events", len(events))
+	}
+	last := events[len(events)-1]
+	fin, ok := last.(reviewtypes.Finished)
+	if !ok {
+		t.Fatalf("last event must be Finished, got %T", last)
+	}
+	if fin.Success {
+		t.Error("Finished.Success must be false on scanner error")
+	}
+	// Also assert at least one RunError event was emitted before Finished.
+	sawRunError := false
+	for _, ev := range events {
+		if _, ok := ev.(reviewtypes.RunError); ok {
+			sawRunError = true
+			break
+		}
+	}
+	if !sawRunError {
+		t.Error("expected RunError event before Finished{Success: false}")
+	}
+}
+
+func TestReviewer_EventStream(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("testdata/canned_session.txt")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	events := collectEvents(parseClaudeOutput(strings.NewReader(string(data))))
+
+	if len(events) < 3 {
+		t.Fatalf("expected at least 3 events (Started + at least one AssistantText + Finished), got %d", len(events))
+	}
+
+	// First event must be Started.
+	if _, ok := events[0].(reviewtypes.Started); !ok {
+		t.Errorf("events[0] = %T, want Started", events[0])
+	}
+
+	// Last event must be Finished{Success: true}.
+	last := events[len(events)-1]
+	fin, ok := last.(reviewtypes.Finished)
+	if !ok {
+		t.Errorf("last event = %T, want Finished", last)
+	} else if !fin.Success {
+		t.Errorf("Finished.Success = false, want true")
+	}
+
+	// All middle events must be AssistantText (no empty lines emitted).
+	for i := 1; i < len(events)-1; i++ {
+		at, ok := events[i].(reviewtypes.AssistantText)
+		if !ok {
+			t.Errorf("events[%d] = %T, want AssistantText", i, events[i])
+			continue
+		}
+		if at.Text == "" {
+			t.Errorf("events[%d].Text is empty (empty lines must be skipped)", i)
+		}
+	}
+
+	// Verify fixture content appears somewhere in the text events.
+	var combined strings.Builder
+	for _, ev := range events {
+		if at, ok := ev.(reviewtypes.AssistantText); ok {
+			combined.WriteString(at.Text)
+			combined.WriteString("\n")
+		}
+	}
+	if !strings.Contains(combined.String(), "AgentReviewer") {
+		t.Error("expected fixture content mentioning 'AgentReviewer' to appear in AssistantText events")
+	}
+}
+
+// collectEvents drains an event channel into a slice.
+func collectEvents(ch <-chan reviewtypes.Event) []reviewtypes.Event {
+	var events []reviewtypes.Event
+	for ev := range ch {
+		events = append(events, ev)
+	}
+	return events
+}
+
+// drainEvents consumes all events from ch without recording them.
+func drainEvents(ch <-chan reviewtypes.Event) {
+	for ev := range ch {
+		_ = ev
+	}
+}

--- a/cmd/entire/cli/agent/claudecode/reviewer_test.go
+++ b/cmd/entire/cli/agent/claudecode/reviewer_test.go
@@ -13,9 +13,8 @@ import (
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
 
-// Compile-time interface check lives in reviewer.go via var _ AgentReviewer = (*Reviewer)(nil).
-// Keep a second check here to surface errors in the test binary.
-var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
+// Compile-time interface check: ReviewerTemplate implements AgentReviewer.
+var _ reviewtypes.AgentReviewer = (*reviewtypes.ReviewerTemplate)(nil)
 
 const wantAgentName = "claude-code"
 

--- a/cmd/entire/cli/agent/claudecode/testdata/canned_session.txt
+++ b/cmd/entire/cli/agent/claudecode/testdata/canned_session.txt
@@ -1,0 +1,13 @@
+I'll review the changes on this branch against the base ref.
+
+Looking at the diff, the primary change adds a new `AgentReviewer` interface and associated types in `cmd/entire/cli/review/types/`. The implementation is clean and well-structured.
+
+**Findings:**
+
+1. The interface is correctly sealed via the unexported `isEvent()` method — external packages cannot add event variants without a contract change, which is the intended design.
+
+2. `RunConfig` uses a zero-value-friendly struct with no required-field constructors. This is consistent with Go conventions.
+
+3. The `Process.Wait()` contract is clearly documented: callers must call it exactly once. This is a reasonable constraint.
+
+**No blocking issues found.** The implementation matches the spec requirements from CU2.

--- a/cmd/entire/cli/agent/codex/output_filter.go
+++ b/cmd/entire/cli/agent/codex/output_filter.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
@@ -99,20 +100,159 @@ func Strip(r io.Reader) io.Reader {
 	go func() {
 		scanner := bufio.NewScanner(r)
 		scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+		state := codexStripNormal
+		var currentAssistant []string
 		for scanner.Scan() {
-			if line, ok := FilterLine(scanner.Text()); ok {
-				_, err := pw.Write([]byte(line + "\n"))
-				if err != nil {
-					_ = pw.CloseWithError(err)
-					return
-				}
+			done, err := collectFinalCodexLine(scanner.Text(), &state, &currentAssistant, pw)
+			if err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+			if done {
+				state = codexStripAfterTokens
 			}
 		}
 		if err := scanner.Err(); err != nil {
 			_ = pw.CloseWithError(err)
 			return
 		}
+		if state != codexStripAfterTokens {
+			if err := writeCodexAssistantBlock(pw, currentAssistant); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+		}
 		_ = pw.Close()
 	}()
 	return pr
+}
+
+type codexStripState int
+
+const (
+	codexStripNormal codexStripState = iota
+	codexStripUserBlock
+	codexStripAssistantBlock
+	codexStripExecBlock
+	codexStripAfterTokens
+)
+
+func collectFinalCodexLine(raw string, state *codexStripState, currentAssistant *[]string, w io.Writer) (bool, error) {
+	cleaned := csiRegex.ReplaceAllString(raw, "")
+	trimmed := strings.TrimSpace(cleaned)
+	trimmedRight := strings.TrimRight(cleaned, " \t")
+
+	if *state == codexStripAfterTokens {
+		return true, nil
+	}
+	if isTokensUsedMarker(trimmed) {
+		return true, writeCodexAssistantBlock(w, *currentAssistant)
+	}
+
+	switch *state {
+	case codexStripUserBlock:
+		if isCodexRoleMarker(trimmed) {
+			*state = codexStripAssistantBlock
+			*currentAssistant = nil
+		}
+		return false, nil
+	case codexStripAssistantBlock:
+		if isCodexRoleMarker(trimmed) {
+			*currentAssistant = nil
+			return false, nil
+		}
+		if isUserRoleMarker(trimmed) {
+			*state = codexStripUserBlock
+			return false, nil
+		}
+		if trimmedRight == "exec" || execBlockRegex.MatchString(trimmedRight) {
+			*state = codexStripExecBlock
+			return false, nil
+		}
+		if isCodexMetadataLine(trimmed) {
+			return false, nil
+		}
+		if line, ok := FilterLine(raw); ok {
+			*currentAssistant = append(*currentAssistant, line)
+		}
+		return false, nil
+	case codexStripExecBlock:
+		if trimmed == "" {
+			*state = codexStripNormal
+			return false, nil
+		}
+		if isCodexRoleMarker(trimmed) {
+			*state = codexStripAssistantBlock
+			*currentAssistant = nil
+			return false, nil
+		}
+		return false, nil
+	case codexStripNormal:
+		// Continue below.
+	case codexStripAfterTokens:
+		return true, nil
+	}
+
+	if isUserRoleMarker(trimmed) {
+		*state = codexStripUserBlock
+		return false, nil
+	}
+	if isCodexRoleMarker(trimmed) {
+		*state = codexStripAssistantBlock
+		*currentAssistant = nil
+		return false, nil
+	}
+	if isCodexMetadataLine(trimmed) {
+		return false, nil
+	}
+	if trimmedRight == "exec" {
+		*state = codexStripExecBlock
+		return false, nil
+	}
+	if execBlockRegex.MatchString(trimmedRight) {
+		return false, nil
+	}
+
+	return false, nil
+}
+
+func writeCodexAssistantBlock(w io.Writer, lines []string) error {
+	for _, line := range lines {
+		if _, err := w.Write([]byte(line + "\n")); err != nil {
+			return fmt.Errorf("write filtered codex output: %w", err)
+		}
+	}
+	return nil
+}
+
+func isTokensUsedMarker(trimmed string) bool {
+	return strings.EqualFold(trimmed, "tokens used")
+}
+
+func isUserRoleMarker(trimmed string) bool {
+	return trimmed == "user"
+}
+
+func isCodexRoleMarker(trimmed string) bool {
+	return trimmed == "codex"
+}
+
+func isCodexMetadataLine(trimmed string) bool {
+	if strings.HasPrefix(trimmed, "OpenAI Codex v") {
+		return true
+	}
+	for _, prefix := range []string{
+		"workdir:",
+		"model:",
+		"provider:",
+		"approval:",
+		"sandbox:",
+		"reasoning:",
+		"session id:",
+	} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/entire/cli/agent/codex/output_filter.go
+++ b/cmd/entire/cli/agent/codex/output_filter.go
@@ -1,0 +1,118 @@
+package codex
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// csiRegex matches ANSI/CSI escape sequences including extended parameter forms.
+// Matches: ESC [ [?;0-9]* [a-zA-Z]
+// Examples: \x1b[?25l (cursor hide), \x1b[?25h (cursor show), \x1b[2K (erase line)
+var csiRegex = regexp.MustCompile(`\x1b\[[?;0-9]*[a-zA-Z]`)
+
+// execBlockRegex matches codex exec-block lines in two forms:
+//   - Bare "exec" (exactly, possibly with trailing whitespace)
+//   - "exec <cmd> in /<path>" (exec block header reporting cwd)
+//
+// Anchored with ^ and $ to avoid matching narrative text that contains "exec"
+// as a substring (e.g. "execute the following", "exec succeeded").
+var execBlockRegex = regexp.MustCompile(`^exec(?:\s+\S.*\s+in\s+/\S*)?$`)
+
+// hookFiringRegex matches codex hook-firing notice lines.
+// Example: "[hooks] firing user-prompt-submit for session abc123"
+var hookFiringRegex = regexp.MustCompile(`^\[hooks\]`)
+
+// timestampLogRegex matches ISO-8601 timestamped log lines emitted by codex.
+// Requires a log-level word (ERROR, WARN, INFO, DEBUG) after the timestamp to
+// avoid false-positives on benign narrative like
+// "2026-01-13T10:00:00 was the deploy time, see changelog".
+// Example: "2026-04-30T10:00:00.000Z ERROR: something failed"
+var timestampLogRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z?\s+(ERROR|WARN|INFO|DEBUG)\b`)
+
+// bannerRegex matches codex banner/header lines. These appear at the start of
+// a codex exec session and include:
+//   - Visual separator lines: "─────── codex ───────", "─────────────────────"
+//   - Version header lines:   "version 0.1.0 (linux)"
+//
+// The version alternative is anchored at both ends and allows an optional patch
+// segment and a parenthesized platform suffix so that narrative text like
+// "version 1.2.3 of go-git fixes the issue" is NOT dropped.
+var bannerRegex = regexp.MustCompile(`^[─\-\s]+(?:codex|version)[─\-\s]*$|^[─\-]+$|^version\s+\d+\.\d+(?:\.\d+)?\s*(?:\([^)]+\))?\s*$`)
+
+// FilterLine applies all codex-specific chrome filters to a single line.
+// It returns the cleaned line and true if the line should be emitted, or
+// ("", false) if the line is chrome and must be dropped.
+//
+// Filtering order:
+//  1. Strip CSI/ANSI escape sequences.
+//  2. Drop blank lines after stripping.
+//  3. Drop banner/header lines.
+//  4. Drop exec-block lines (anchored to avoid false positives).
+//  5. Drop hook-firing notice lines.
+//  6. Drop timestamped error/log lines.
+func FilterLine(line string) (string, bool) {
+	// 1. Strip CSI sequences.
+	cleaned := csiRegex.ReplaceAllString(line, "")
+
+	// 2. Drop blank after stripping. Use TrimSpace ONLY for the empty-check;
+	// the returned line preserves leading whitespace so markdown/code-block
+	// indentation in narrative output is not flattened.
+	if strings.TrimSpace(cleaned) == "" {
+		return "", false
+	}
+
+	// Use the trim-right form for chrome-pattern matching (so trailing
+	// whitespace doesn't break anchored regexes) while keeping the leading
+	// whitespace on the returned value.
+	trimmedRight := strings.TrimRight(cleaned, " \t")
+
+	// 3. Drop banner/separator lines.
+	if bannerRegex.MatchString(trimmedRight) {
+		return "", false
+	}
+
+	// 4. Drop exec-block lines.
+	if execBlockRegex.MatchString(trimmedRight) {
+		return "", false
+	}
+
+	// 5. Drop hook-firing notices.
+	if hookFiringRegex.MatchString(trimmedRight) {
+		return "", false
+	}
+
+	// 6. Drop timestamped log lines.
+	if timestampLogRegex.MatchString(trimmedRight) {
+		return "", false
+	}
+
+	return trimmedRight, true
+}
+
+// Strip wraps r in a filtered reader that removes codex chrome line-by-line.
+// The returned reader emits only lines that pass FilterLine, each terminated
+// by a newline.
+func Strip(r io.Reader) io.Reader {
+	pr, pw := io.Pipe()
+	go func() {
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+		for scanner.Scan() {
+			if line, ok := FilterLine(scanner.Text()); ok {
+				_, err := pw.Write([]byte(line + "\n"))
+				if err != nil {
+					_ = pw.CloseWithError(err)
+					return
+				}
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		_ = pw.Close()
+	}()
+	return pr
+}

--- a/cmd/entire/cli/agent/codex/output_filter_test.go
+++ b/cmd/entire/cli/agent/codex/output_filter_test.go
@@ -1,0 +1,239 @@
+package codex
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestFilterLine_BannerDropped(t *testing.T) {
+	t.Parallel()
+	banners := []string{
+		"─────── codex ───────",
+		"─────────────────────",
+		"version 0.1.0 (linux)",
+	}
+	for _, line := range banners {
+		t.Run(line, func(t *testing.T) {
+			t.Parallel()
+			_, ok := FilterLine(line)
+			if ok {
+				t.Errorf("FilterLine(%q) returned ok=true; expected banner to be dropped", line)
+			}
+		})
+	}
+}
+
+func TestFilterLine_ExecBlockDropped(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"exec",
+		"exec node /usr/local/lib/codex/hooks.js in /repo",
+		"exec git diff HEAD in /home/user/project",
+	}
+	for _, line := range cases {
+		t.Run(line, func(t *testing.T) {
+			t.Parallel()
+			_, ok := FilterLine(line)
+			if ok {
+				t.Errorf("FilterLine(%q) returned ok=true; expected exec block to be dropped", line)
+			}
+		})
+	}
+}
+
+func TestFilterLine_ExecNarrativeKept(t *testing.T) {
+	t.Parallel()
+	// Lines that contain "exec" but are not exec-block headers must pass through.
+	narratives := []string{
+		"The executor completed the task successfully.",
+		"exec succeeded (exit 0)",
+		"Running the executable with --flag",
+		"codex will execute the review skills",
+	}
+	for _, line := range narratives {
+		t.Run(line, func(t *testing.T) {
+			t.Parallel()
+			got, ok := FilterLine(line)
+			if !ok {
+				t.Errorf("FilterLine(%q) dropped a narrative line; expected it to pass through", line)
+			}
+			if got == "" {
+				t.Errorf("FilterLine(%q) returned empty string for passing line", line)
+			}
+		})
+	}
+}
+
+func TestFilterLine_HookFiringDropped(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"[hooks] firing user-prompt-submit for session abc123",
+		"[hooks] firing stop for session abc123",
+		"[hooks] some hook notice",
+	}
+	for _, line := range cases {
+		t.Run(line, func(t *testing.T) {
+			t.Parallel()
+			_, ok := FilterLine(line)
+			if ok {
+				t.Errorf("FilterLine(%q) returned ok=true; expected hook notice to be dropped", line)
+			}
+		})
+	}
+}
+
+func TestFilterLine_CSISequenceStripped(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		// Cursor hide — line becomes empty after stripping → dropped.
+		{"\x1b[?25l", ""},
+		// Cursor show — same.
+		{"\x1b[?25h", ""},
+		// Erase line — same.
+		{"\x1b[2K", ""},
+		// CSI embedded in narrative — stripped but line remains.
+		{"\x1b[32mgreen text\x1b[0m", "green text"},
+		// Semicolon in CSI parameter.
+		{"\x1b[1;32mbolded\x1b[0m", "bolded"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Parallel()
+			got, ok := FilterLine(tc.raw)
+			if tc.want == "" {
+				if ok {
+					t.Errorf("FilterLine(%q) returned ok=true; expected CSI-only line to be dropped", tc.raw)
+				}
+			} else {
+				if !ok {
+					t.Errorf("FilterLine(%q) dropped line; expected %q", tc.raw, tc.want)
+				}
+				if got != tc.want {
+					t.Errorf("FilterLine(%q) = %q, want %q", tc.raw, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterLine_TimestampLogDropped(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"2026-04-30T10:00:00.000Z ERROR: hook failed",
+		"2026-04-30T10:00:00Z INFO: session started",
+		"2026-01-01T00:00:00.000Z DEBUG: verbose output",
+	}
+	for _, line := range cases {
+		t.Run(line, func(t *testing.T) {
+			t.Parallel()
+			_, ok := FilterLine(line)
+			if ok {
+				t.Errorf("FilterLine(%q) returned ok=true; expected timestamp log to be dropped", line)
+			}
+		})
+	}
+}
+
+func TestFilterLine_NarrativePassThrough(t *testing.T) {
+	t.Parallel()
+	narratives := []string{
+		"I've reviewed the changes on this branch.",
+		"The `AgentReviewer` interface provides a clean abstraction.",
+		"**Key observations:**",
+		"1. The `Event` sealed sum type is correctly implemented.",
+		"No blocking issues found.",
+	}
+	for _, line := range narratives {
+		t.Run(line, func(t *testing.T) {
+			t.Parallel()
+			got, ok := FilterLine(line)
+			if !ok {
+				t.Errorf("FilterLine(%q) dropped narrative; expected passthrough", line)
+			}
+			if got == "" {
+				t.Errorf("FilterLine(%q) returned empty string for narrative", line)
+			}
+		})
+	}
+}
+
+func TestFilterLine_VersionNarrativeKept(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"version 1.2.3 of go-git fixes the issue",
+		"The version 1.0 release notes mention this regression.",
+		"Bump version 2.5.7 — see changelog.",
+	}
+	for _, line := range cases {
+		t.Run(line, func(t *testing.T) {
+			t.Parallel()
+			got, ok := FilterLine(line)
+			if !ok {
+				t.Errorf("benign narrative %q got dropped", line)
+			}
+			if got == "" {
+				t.Errorf("benign narrative %q returned empty string", line)
+			}
+		})
+	}
+}
+
+func TestStrip_FullFixture(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		"─────── codex ───────",
+		"version 0.1.0 (linux)",
+		"",
+		"[hooks] firing user-prompt-submit for session abc123",
+		"exec node /usr/local/lib/codex/hooks.js in /repo",
+		"",
+		"\x1b[?25l",
+		"This is the narrative output from the agent.",
+		"It spans multiple lines.",
+		"\x1b[?25h",
+		"exec git diff HEAD in /repo",
+		"2026-04-30T10:00:00.000Z ERROR: something logged",
+		"Final conclusion: no issues found.",
+	}, "\n")
+
+	filtered := Strip(strings.NewReader(input))
+	data, err := io.ReadAll(filtered)
+	if err != nil {
+		t.Fatalf("Strip read: %v", err)
+	}
+	output := string(data)
+
+	// Chrome must be absent.
+	chromeMustBeAbsent := []string{
+		"─────── codex",
+		"version 0.1.0",
+		"[hooks]",
+		"exec node",
+		"exec git diff",
+		"\x1b[",
+		"2026-04-30T",
+		"ERROR:",
+	}
+	for _, pattern := range chromeMustBeAbsent {
+		if strings.Contains(output, pattern) {
+			t.Errorf("chrome pattern %q must not appear in filtered output; got:\n%s", pattern, output)
+		}
+	}
+
+	// Narrative must survive.
+	narrativeMustSurvive := []string{
+		"This is the narrative output from the agent.",
+		"It spans multiple lines.",
+		"Final conclusion: no issues found.",
+	}
+	for _, want := range narrativeMustSurvive {
+		if !strings.Contains(output, want) {
+			t.Errorf("narrative %q missing from filtered output; got:\n%s", want, output)
+		}
+	}
+}

--- a/cmd/entire/cli/agent/codex/output_filter_test.go
+++ b/cmd/entire/cli/agent/codex/output_filter_test.go
@@ -193,11 +193,13 @@ func TestStrip_FullFixture(t *testing.T) {
 		"exec node /usr/local/lib/codex/hooks.js in /repo",
 		"",
 		"\x1b[?25l",
+		"codex",
 		"This is the narrative output from the agent.",
 		"It spans multiple lines.",
 		"\x1b[?25h",
 		"exec git diff HEAD in /repo",
 		"2026-04-30T10:00:00.000Z ERROR: something logged",
+		"codex",
 		"Final conclusion: no issues found.",
 	}, "\n")
 
@@ -227,13 +229,84 @@ func TestStrip_FullFixture(t *testing.T) {
 
 	// Narrative must survive.
 	narrativeMustSurvive := []string{
-		"This is the narrative output from the agent.",
-		"It spans multiple lines.",
 		"Final conclusion: no issues found.",
 	}
 	for _, want := range narrativeMustSurvive {
 		if !strings.Contains(output, want) {
 			t.Errorf("narrative %q missing from filtered output; got:\n%s", want, output)
 		}
+	}
+	for _, unwanted := range []string{
+		"This is the narrative output from the agent.",
+		"It spans multiple lines.",
+	} {
+		if strings.Contains(output, unwanted) {
+			t.Errorf("pre-final narrative %q should not appear in filtered output; got:\n%s", unwanted, output)
+		}
+	}
+}
+
+func TestStrip_DropsExecBlocksAndDuplicateSummary(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		"OpenAI Codex v0.124.0 (research preview)",
+		"--------",
+		"workdir: /private/tmp/review-output-test",
+		"model: gpt-5.4",
+		"--------",
+		"user",
+		"Please run these review skills in order.",
+		"",
+		"codex",
+		"I will inspect the code.",
+		"exec",
+		`/bin/zsh -lc "git status --short" in /private/tmp/review-output-test`,
+		" succeeded in 0ms:",
+		" M cmd/entire/cli/review.go",
+		"",
+		"exec",
+		`/bin/zsh -lc "go test ./..." in /private/tmp/review-output-test`,
+		" failed in 1s:",
+		"--- FAIL: TestExample",
+		"",
+		"codex",
+		"No findings.",
+		"",
+		"Residual risk: tests were not run in this sandbox.",
+		"tokens used",
+		"12,826",
+		"No findings.",
+		"",
+		"Residual risk: tests were not run in this sandbox.",
+	}, "\n")
+
+	data, err := io.ReadAll(Strip(strings.NewReader(input)))
+	if err != nil {
+		t.Fatalf("Strip read: %v", err)
+	}
+	output := string(data)
+
+	for _, forbidden := range []string{
+		"OpenAI Codex",
+		"workdir:",
+		"Please run these review skills",
+		"I will inspect the code.",
+		"git status",
+		"cmd/entire/cli/review.go",
+		"go test ./...",
+		"TestExample",
+		"tokens used",
+		"12,826",
+	} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("filtered output leaked %q:\n%s", forbidden, output)
+		}
+	}
+	if strings.Count(output, "No findings.") != 1 {
+		t.Fatalf("filtered output should contain final response once, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Residual risk: tests were not run in this sandbox.") {
+		t.Fatalf("filtered output missing final residual-risk line:\n%s", output)
 	}
 }

--- a/cmd/entire/cli/agent/codex/reviewer.go
+++ b/cmd/entire/cli/agent/codex/reviewer.go
@@ -48,42 +48,11 @@ func (r *Reviewer) Start(ctx context.Context, cfg reviewtypes.RunConfig) (review
 // buildCodexReviewCmd builds the exec.Cmd for a codex review run.
 // Exported at package level for test inspection of argv, stdin, and env.
 func buildCodexReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
-	prompt := composeCodexReviewPrompt(cfg)
+	prompt := review.ComposeReviewPrompt(cfg)
 	cmd := exec.CommandContext(ctx, "codex", "exec", "--skip-git-repo-check", "-")
 	cmd.Stdin = strings.NewReader(prompt)
-	cmd.Env = appendCodexReviewEnv(os.Environ(), cfg, prompt)
+	cmd.Env = review.AppendReviewEnv(os.Environ(), "codex", cfg, prompt)
 	return cmd
-}
-
-// appendCodexReviewEnv appends ENTIRE_REVIEW_* vars to the given base environment.
-func appendCodexReviewEnv(base []string, cfg reviewtypes.RunConfig, prompt string) []string {
-	skillsJSON, _ := review.EncodeSkills(cfg.Skills) //nolint:errcheck // EncodeSkills only fails on json.Marshal([]string), which is infallible
-	return append(base,
-		review.EnvSession+"=1",
-		review.EnvAgent+"=codex",
-		review.EnvSkills+"="+skillsJSON,
-		review.EnvPrompt+"="+prompt,
-		review.EnvStartingSHA+"="+cfg.StartingSHA,
-	)
-}
-
-// composeCodexReviewPrompt concatenates Skills, AlwaysPrompt, and PerRunPrompt
-// (skipping empty strings) with double-newline separators.
-func composeCodexReviewPrompt(cfg reviewtypes.RunConfig) string {
-	parts := make([]string, 0, len(cfg.Skills)+2)
-	parts = append(parts, cfg.Skills...)
-	parts = append(parts, cfg.AlwaysPrompt, cfg.PerRunPrompt)
-	var out strings.Builder
-	for _, p := range parts {
-		if p == "" {
-			continue
-		}
-		if out.Len() > 0 {
-			out.WriteString("\n\n")
-		}
-		out.WriteString(p)
-	}
-	return out.String()
 }
 
 // parseCodexOutput wraps the reader with the chrome filter and converts

--- a/cmd/entire/cli/agent/codex/reviewer.go
+++ b/cmd/entire/cli/agent/codex/reviewer.go
@@ -13,40 +13,22 @@ import (
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
 
-// Reviewer is the AgentReviewer implementation for codex.
+// NewReviewer returns the AgentReviewer for codex.
 //
 // Argv shape: codex exec --skip-git-repo-check -.
 // Prompt is piped via stdin (the trailing "-" tells codex to read from stdin).
 // Stdout includes chrome (banners, hook notices, exec blocks, CSI sequences)
 // that output_filter.go strips before emitting AssistantText events.
-type Reviewer struct{}
-
-// NewReviewer creates a new codex AgentReviewer.
-func NewReviewer() *Reviewer { return &Reviewer{} }
-
-// Compile-time interface check.
-var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
-
-// Name returns the agent's registry key.
-func (*Reviewer) Name() string { return "codex" }
-
-// Start spawns codex with the review prompt on stdin and returns a streaming Process.
-func (r *Reviewer) Start(ctx context.Context, cfg reviewtypes.RunConfig) (reviewtypes.Process, error) {
-	cmd := buildCodexReviewCmd(ctx, cfg)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("codex: stdout pipe: %w", err)
+func NewReviewer() *reviewtypes.ReviewerTemplate {
+	return &reviewtypes.ReviewerTemplate{
+		AgentName: "codex",
+		BuildCmd:  buildCodexReviewCmd,
+		Parser:    parseCodexOutput,
 	}
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("codex: start: %w", err)
-	}
-	p := &codexReviewProcess{cmd: cmd, events: make(chan reviewtypes.Event, 32)}
-	go p.run(stdout)
-	return p, nil
 }
 
 // buildCodexReviewCmd builds the exec.Cmd for a codex review run.
-// Exported at package level for test inspection of argv, stdin, and env.
+// Exposed at package level for test inspection of argv, stdin, and env.
 func buildCodexReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
 	prompt := review.ComposeReviewPrompt(cfg)
 	cmd := exec.CommandContext(ctx, "codex", "exec", "--skip-git-repo-check", "-")
@@ -84,23 +66,4 @@ func parseCodexOutput(r io.Reader) <-chan reviewtypes.Event {
 		out <- reviewtypes.Finished{Success: true}
 	}()
 	return out
-}
-
-// codexReviewProcess is the running codex review process.
-type codexReviewProcess struct {
-	cmd    *exec.Cmd
-	events chan reviewtypes.Event
-}
-
-func (p *codexReviewProcess) Events() <-chan reviewtypes.Event { return p.events }
-
-// Wait implements Process.Wait. The *exec.ExitError passes through unwrapped
-// per the Process.Wait contract; callers may errors.As for *exec.ExitError.
-func (p *codexReviewProcess) Wait() error { return p.cmd.Wait() } //nolint:wrapcheck // Process.Wait contract allows *exec.ExitError passthrough
-
-func (p *codexReviewProcess) run(stdout io.Reader) {
-	defer close(p.events)
-	for ev := range parseCodexOutput(stdout) {
-		p.events <- ev
-	}
 }

--- a/cmd/entire/cli/agent/codex/reviewer.go
+++ b/cmd/entire/cli/agent/codex/reviewer.go
@@ -1,0 +1,137 @@
+package codex
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/review"
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// Reviewer is the AgentReviewer implementation for codex.
+//
+// Argv shape: codex exec --skip-git-repo-check -.
+// Prompt is piped via stdin (the trailing "-" tells codex to read from stdin).
+// Stdout includes chrome (banners, hook notices, exec blocks, CSI sequences)
+// that output_filter.go strips before emitting AssistantText events.
+type Reviewer struct{}
+
+// NewReviewer creates a new codex AgentReviewer.
+func NewReviewer() *Reviewer { return &Reviewer{} }
+
+// Compile-time interface check.
+var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
+
+// Name returns the agent's registry key.
+func (*Reviewer) Name() string { return "codex" }
+
+// Start spawns codex with the review prompt on stdin and returns a streaming Process.
+func (r *Reviewer) Start(ctx context.Context, cfg reviewtypes.RunConfig) (reviewtypes.Process, error) {
+	cmd := buildCodexReviewCmd(ctx, cfg)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("codex: stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("codex: start: %w", err)
+	}
+	p := &codexReviewProcess{cmd: cmd, events: make(chan reviewtypes.Event, 32)}
+	go p.run(stdout)
+	return p, nil
+}
+
+// buildCodexReviewCmd builds the exec.Cmd for a codex review run.
+// Exported at package level for test inspection of argv, stdin, and env.
+func buildCodexReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
+	prompt := composeCodexReviewPrompt(cfg)
+	cmd := exec.CommandContext(ctx, "codex", "exec", "--skip-git-repo-check", "-")
+	cmd.Stdin = strings.NewReader(prompt)
+	cmd.Env = appendCodexReviewEnv(os.Environ(), cfg, prompt)
+	return cmd
+}
+
+// appendCodexReviewEnv appends ENTIRE_REVIEW_* vars to the given base environment.
+func appendCodexReviewEnv(base []string, cfg reviewtypes.RunConfig, prompt string) []string {
+	skillsJSON, _ := review.EncodeSkills(cfg.Skills) //nolint:errcheck // EncodeSkills only fails on json.Marshal([]string), which is infallible
+	return append(base,
+		review.EnvSession+"=1",
+		review.EnvAgent+"=codex",
+		review.EnvSkills+"="+skillsJSON,
+		review.EnvPrompt+"="+prompt,
+		review.EnvStartingSHA+"="+cfg.StartingSHA,
+	)
+}
+
+// composeCodexReviewPrompt concatenates Skills, AlwaysPrompt, and PerRunPrompt
+// (skipping empty strings) with double-newline separators.
+func composeCodexReviewPrompt(cfg reviewtypes.RunConfig) string {
+	parts := make([]string, 0, len(cfg.Skills)+2)
+	parts = append(parts, cfg.Skills...)
+	parts = append(parts, cfg.AlwaysPrompt, cfg.PerRunPrompt)
+	var out strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if out.Len() > 0 {
+			out.WriteString("\n\n")
+		}
+		out.WriteString(p)
+	}
+	return out.String()
+}
+
+// parseCodexOutput wraps the reader with the chrome filter and converts
+// remaining lines into a stream of Events.
+// On clean EOF emits Finished{Success: true}. On a scanner error (including
+// errors propagated from Strip via pipe CloseWithError) emits RunError then
+// Finished{Success: false}.
+//
+// Exposed for golden-file contract testing.
+func parseCodexOutput(r io.Reader) <-chan reviewtypes.Event {
+	out := make(chan reviewtypes.Event, 32)
+	go func() {
+		defer close(out)
+		out <- reviewtypes.Started{}
+		scanner := bufio.NewScanner(Strip(r))
+		scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			out <- reviewtypes.AssistantText{Text: line}
+		}
+		if err := scanner.Err(); err != nil {
+			out <- reviewtypes.RunError{Err: fmt.Errorf("read stdout: %w", err)}
+			out <- reviewtypes.Finished{Success: false}
+			return
+		}
+		out <- reviewtypes.Finished{Success: true}
+	}()
+	return out
+}
+
+// codexReviewProcess is the running codex review process.
+type codexReviewProcess struct {
+	cmd    *exec.Cmd
+	events chan reviewtypes.Event
+}
+
+func (p *codexReviewProcess) Events() <-chan reviewtypes.Event { return p.events }
+
+// Wait implements Process.Wait. The *exec.ExitError passes through unwrapped
+// per the Process.Wait contract; callers may errors.As for *exec.ExitError.
+func (p *codexReviewProcess) Wait() error { return p.cmd.Wait() } //nolint:wrapcheck // Process.Wait contract allows *exec.ExitError passthrough
+
+func (p *codexReviewProcess) run(stdout io.Reader) {
+	defer close(p.events)
+	for ev := range parseCodexOutput(stdout) {
+		p.events <- ev
+	}
+}

--- a/cmd/entire/cli/agent/codex/reviewer_test.go
+++ b/cmd/entire/cli/agent/codex/reviewer_test.go
@@ -1,0 +1,257 @@
+package codex
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/review"
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// Compile-time interface check (mirrors the one in reviewer.go).
+var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
+
+const wantCodexAgentName = "codex"
+
+func TestCodexReviewer_Name(t *testing.T) {
+	t.Parallel()
+	r := NewReviewer()
+	if got := r.Name(); got != wantCodexAgentName {
+		t.Errorf("Name() = %q, want %q", got, wantCodexAgentName)
+	}
+}
+
+func TestCodexReviewer_EnvVarsSet(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/codex:review", "/test-auditor"},
+		AlwaysPrompt: "Always check error handling.",
+		PerRunPrompt: "Focus on the storage layer.",
+		StartingSHA:  "deadbeef1234",
+	}
+	cmd := buildCodexReviewCmd(context.Background(), cfg)
+
+	wantKeys := []string{
+		review.EnvSession,
+		review.EnvAgent,
+		review.EnvSkills,
+		review.EnvPrompt,
+		review.EnvStartingSHA,
+	}
+	envMap := envToMap(cmd.Env)
+
+	for _, key := range wantKeys {
+		if _, ok := envMap[key]; !ok {
+			t.Errorf("env var %s not set on cmd", key)
+		}
+	}
+
+	if envMap[review.EnvSession] != "1" {
+		t.Errorf("%s = %q, want %q", review.EnvSession, envMap[review.EnvSession], "1")
+	}
+	if envMap[review.EnvAgent] != wantCodexAgentName {
+		t.Errorf("%s = %q, want %q", review.EnvAgent, envMap[review.EnvAgent], wantCodexAgentName)
+	}
+	if envMap[review.EnvStartingSHA] != "deadbeef1234" {
+		t.Errorf("%s = %q, want %q", review.EnvStartingSHA, envMap[review.EnvStartingSHA], "deadbeef1234")
+	}
+	if !strings.HasPrefix(envMap[review.EnvSkills], "[") {
+		t.Errorf("%s = %q, want JSON array", review.EnvSkills, envMap[review.EnvSkills])
+	}
+}
+
+func TestCodexReviewer_ArgvShape(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{Skills: []string{"/skill"}}
+	cmd := buildCodexReviewCmd(context.Background(), cfg)
+
+	// Expect: codex exec --skip-git-repo-check -
+	want := []string{wantCodexAgentName, "exec", "--skip-git-repo-check", "-"}
+	if len(cmd.Args) != len(want) {
+		t.Fatalf("len(Args) = %d, want %d: %v", len(cmd.Args), len(want), cmd.Args)
+	}
+	for i, w := range want {
+		if cmd.Args[i] != w {
+			t.Errorf("Args[%d] = %q, want %q", i, cmd.Args[i], w)
+		}
+	}
+	// Stdin must be non-nil — codex reads prompt from stdin.
+	if cmd.Stdin == nil {
+		t.Error("cmd.Stdin is nil; codex requires prompt via stdin")
+	}
+}
+
+func TestCodexReviewer_NoBinaryRequiredAtConstruction(t *testing.T) {
+	// No t.Parallel — uses t.Setenv.
+	t.Setenv("PATH", "")
+
+	r := NewReviewer()
+	cfg := reviewtypes.RunConfig{
+		Skills:      []string{"/test"},
+		StartingSHA: "abc123",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Construction (NewReviewer) MUST NOT touch PATH. Start may or may
+	// not error depending on whether the OS-level cmd.Start tries to
+	// resolve before fork — that's fine. The contract is just "no panic
+	// and no upfront LookPath call".
+	proc, err := r.Start(ctx, cfg)
+	// Either Start succeeded (deferred lookup; binary error surfaces in Wait)
+	// or Start failed with exec.ErrNotFound (immediate lookup at Cmd.Start).
+	// Both satisfy the deferred-lookup contract — what we explicitly DON'T
+	// want is a panic or error from NewReviewer itself.
+	if err != nil && !errors.Is(err, exec.ErrNotFound) {
+		// Tolerate "no such file" wrapping variations
+		if !strings.Contains(err.Error(), "executable file not found") &&
+			!strings.Contains(err.Error(), "no such file") {
+			t.Errorf("unexpected error type: %v", err)
+		}
+	}
+	if proc != nil {
+		// Drain events to let parser goroutine exit cleanly.
+		drainCodexEvents(proc.Events())
+		_ = proc.Wait() //nolint:errcheck // best-effort cleanup in test
+	}
+}
+
+func TestParseCodexOutput_ReportsScannerError(t *testing.T) {
+	t.Parallel()
+	// Trigger bufio.Scanner's "token too long" error: produce a "line"
+	// that exceeds the 16MB max buffer without containing a newline.
+	// Strip's internal scanner has its own 16MB buffer, so we need to
+	// exceed that to propagate the error through the pipe chain.
+	r, w := io.Pipe()
+	go func() {
+		defer w.Close()
+		// 17MB of contiguous bytes without a newline — exceeds Strip's scanner buffer
+		buf := make([]byte, 1024*1024)
+		for range 17 {
+			_, _ = w.Write(buf) //nolint:errcheck // best-effort write in test goroutine
+		}
+	}()
+
+	events := collectCodexEvents(parseCodexOutput(r))
+
+	if len(events) < 2 {
+		t.Fatalf("expected at least Started + Finished, got %d events", len(events))
+	}
+	last := events[len(events)-1]
+	fin, ok := last.(reviewtypes.Finished)
+	if !ok {
+		t.Fatalf("last event must be Finished, got %T", last)
+	}
+	if fin.Success {
+		t.Error("Finished.Success must be false on scanner error")
+	}
+	// Also assert at least one RunError event was emitted before Finished.
+	sawRunError := false
+	for _, ev := range events {
+		if _, ok := ev.(reviewtypes.RunError); ok {
+			sawRunError = true
+			break
+		}
+	}
+	if !sawRunError {
+		t.Error("expected RunError event before Finished{Success: false}")
+	}
+}
+
+func TestCodexReviewer_EventStream(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("testdata/canned_exec.txt")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	events := collectCodexEvents(parseCodexOutput(strings.NewReader(string(data))))
+
+	if len(events) < 3 {
+		t.Fatalf("expected at least 3 events (Started + AssistantText + Finished), got %d", len(events))
+	}
+
+	// First event must be Started.
+	if _, ok := events[0].(reviewtypes.Started); !ok {
+		t.Errorf("events[0] = %T, want Started", events[0])
+	}
+
+	// Last event must be Finished{Success: true}.
+	last := events[len(events)-1]
+	fin, ok := last.(reviewtypes.Finished)
+	if !ok {
+		t.Errorf("last event = %T, want Finished", last)
+	} else if !fin.Success {
+		t.Errorf("Finished.Success = false, want true")
+	}
+
+	// Verify narrative content appears and chrome is absent.
+	var combined strings.Builder
+	for _, ev := range events {
+		if at, ok := ev.(reviewtypes.AssistantText); ok {
+			combined.WriteString(at.Text)
+			combined.WriteString("\n")
+		}
+	}
+	text := combined.String()
+
+	// Narrative should appear.
+	if !strings.Contains(text, "AgentReviewer") {
+		t.Error("expected fixture content mentioning 'AgentReviewer' in AssistantText events")
+	}
+
+	// Chrome must be absent.
+	chromePatterns := []string{
+		"─────── codex",
+		"[hooks]",
+		"firing user-prompt-submit",
+	}
+	for _, pattern := range chromePatterns {
+		if strings.Contains(text, pattern) {
+			t.Errorf("chrome pattern %q must not appear in AssistantText events", pattern)
+		}
+	}
+
+	// CSI escape sequences must not leak into AssistantText events.
+	for _, ev := range events {
+		if at, ok := ev.(reviewtypes.AssistantText); ok {
+			if strings.Contains(at.Text, "\x1b[") {
+				t.Errorf("CSI bytes leaked into AssistantText: %q", at.Text)
+			}
+		}
+	}
+}
+
+func collectCodexEvents(ch <-chan reviewtypes.Event) []reviewtypes.Event {
+	var events []reviewtypes.Event
+	for ev := range ch {
+		events = append(events, ev)
+	}
+	return events
+}
+
+// drainCodexEvents consumes all events from ch without recording them.
+func drainCodexEvents(ch <-chan reviewtypes.Event) {
+	for ev := range ch {
+		_ = ev
+	}
+}
+
+func envToMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, e := range env {
+		idx := strings.IndexByte(e, '=')
+		if idx < 0 {
+			continue
+		}
+		m[e[:idx]] = e[idx+1:]
+	}
+	return m
+}

--- a/cmd/entire/cli/agent/codex/reviewer_test.go
+++ b/cmd/entire/cli/agent/codex/reviewer_test.go
@@ -13,8 +13,8 @@ import (
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
 
-// Compile-time interface check (mirrors the one in reviewer.go).
-var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
+// Compile-time interface check: ReviewerTemplate implements AgentReviewer.
+var _ reviewtypes.AgentReviewer = (*reviewtypes.ReviewerTemplate)(nil)
 
 const wantCodexAgentName = "codex"
 

--- a/cmd/entire/cli/agent/codex/reviewer_test.go
+++ b/cmd/entire/cli/agent/codex/reviewer_test.go
@@ -203,20 +203,32 @@ func TestCodexReviewer_EventStream(t *testing.T) {
 	text := combined.String()
 
 	// Narrative should appear.
-	if !strings.Contains(text, "AgentReviewer") {
-		t.Error("expected fixture content mentioning 'AgentReviewer' in AssistantText events")
+	if !strings.Contains(text, "No findings.") {
+		t.Error("expected fixture final response in AssistantText events")
+	}
+	if !strings.Contains(text, "Important finding: all error paths are covered.") {
+		t.Error("expected ANSI-cleaned fixture content in AssistantText events")
 	}
 
 	// Chrome must be absent.
 	chromePatterns := []string{
-		"─────── codex",
+		"OpenAI Codex",
+		"workdir:",
 		"[hooks]",
 		"firing user-prompt-submit",
+		"I will inspect the reviewer contracts.",
+		"git status",
+		"go test ./cmd/entire/cli/review",
+		"TestExample",
+		"tokens used",
 	}
 	for _, pattern := range chromePatterns {
 		if strings.Contains(text, pattern) {
 			t.Errorf("chrome pattern %q must not appear in AssistantText events", pattern)
 		}
+	}
+	if strings.Count(text, "No findings.") != 1 {
+		t.Errorf("final response should appear once after duplicate summary filtering; got:\n%s", text)
 	}
 
 	// CSI escape sequences must not leak into AssistantText events.

--- a/cmd/entire/cli/agent/codex/testdata/canned_exec.txt
+++ b/cmd/entire/cli/agent/codex/testdata/canned_exec.txt
@@ -1,0 +1,25 @@
+─────── codex ───────
+version 0.1.0 (linux)
+
+[hooks] firing user-prompt-submit for session abc123
+exec node /usr/local/lib/codex/hooks.js in /repo
+
+[hooks] firing stop for session abc123
+
+I've reviewed the changes on this branch.
+
+The `AgentReviewer` interface provides a clean abstraction for per-agent review implementations. Each agent's quirks (argv shape, stdin vs argv prompt delivery, output chrome) are fully encapsulated.
+
+**Key observations:**
+
+1. The `Event` sealed sum type (via unexported `isEvent()`) prevents external extension — this is the right trade-off for a stable shared contract.
+
+2. `Process.Events()` returns a channel that is closed after `Finished` or `RunError`, which enables clean `range` loops in consumers.
+
+3. `RunConfig.StartingSHA` ensures the lifecycle hook records exactly which commit was reviewed, without requiring history walking later.
+
+exec git diff HEAD in /repo
+
+**Conclusion:** The implementation is sound. No blocking issues.
+[?25lThe agent should still see this clean line[?25h
+[32mImportant finding:[0m all error paths are covered.

--- a/cmd/entire/cli/agent/codex/testdata/canned_exec.txt
+++ b/cmd/entire/cli/agent/codex/testdata/canned_exec.txt
@@ -1,25 +1,33 @@
-─────── codex ───────
-version 0.1.0 (linux)
+OpenAI Codex v0.124.0 (research preview)
+--------
+workdir: /repo
+model: gpt-5.4
+approval: never
+sandbox: read-only
+--------
+user
+Please run these review skills in order.
 
-[hooks] firing user-prompt-submit for session abc123
-exec node /usr/local/lib/codex/hooks.js in /repo
+codex
+I will inspect the reviewer contracts.
+exec
+/bin/zsh -lc "git status --short" in /repo
+ succeeded in 0ms:
+ M cmd/entire/cli/review.go
 
-[hooks] firing stop for session abc123
+exec
+/bin/zsh -lc "go test ./cmd/entire/cli/review" in /repo
+ failed in 1s:
+--- FAIL: TestExample
 
-I've reviewed the changes on this branch.
+codex
+No findings.
 
-The `AgentReviewer` interface provides a clean abstraction for per-agent review implementations. Each agent's quirks (argv shape, stdin vs argv prompt delivery, output chrome) are fully encapsulated.
-
-**Key observations:**
-
-1. The `Event` sealed sum type (via unexported `isEvent()`) prevents external extension — this is the right trade-off for a stable shared contract.
-
-2. `Process.Events()` returns a channel that is closed after `Finished` or `RunError`, which enables clean `range` loops in consumers.
-
-3. `RunConfig.StartingSHA` ensures the lifecycle hook records exactly which commit was reviewed, without requiring history walking later.
-
-exec git diff HEAD in /repo
-
-**Conclusion:** The implementation is sound. No blocking issues.
+Residual risk: I could not run the full suite in this sandbox.
 [?25lThe agent should still see this clean line[?25h
 [32mImportant finding:[0m all error paths are covered.
+tokens used
+12,826
+No findings.
+
+Residual risk: I could not run the full suite in this sandbox.

--- a/cmd/entire/cli/agent/geminicli/reviewer.go
+++ b/cmd/entire/cli/agent/geminicli/reviewer.go
@@ -13,40 +13,22 @@ import (
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
 
-// Reviewer is the AgentReviewer implementation for gemini-cli.
+// NewReviewer returns the AgentReviewer for gemini-cli.
 //
 // Argv shape: gemini -p " " (space placeholder to trigger headless mode).
 // Prompt is piped via stdin; per gemini --help the -p flag appends to stdin
 // content, so passing a single space lets stdin carry the actual prompt.
 // Stdout in this mode is clean assistant output — no chrome filtering needed.
-type Reviewer struct{}
-
-// NewReviewer creates a new gemini-cli AgentReviewer.
-func NewReviewer() *Reviewer { return &Reviewer{} }
-
-// Compile-time interface check.
-var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
-
-// Name returns the agent's registry key.
-func (*Reviewer) Name() string { return "gemini-cli" }
-
-// Start spawns gemini with the review prompt on stdin and returns a streaming Process.
-func (r *Reviewer) Start(ctx context.Context, cfg reviewtypes.RunConfig) (reviewtypes.Process, error) {
-	cmd := buildGeminiReviewCmd(ctx, cfg)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("gemini-cli: stdout pipe: %w", err)
+func NewReviewer() *reviewtypes.ReviewerTemplate {
+	return &reviewtypes.ReviewerTemplate{
+		AgentName: "gemini-cli",
+		BuildCmd:  buildGeminiReviewCmd,
+		Parser:    parseGeminiOutput,
 	}
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("gemini-cli: start: %w", err)
-	}
-	p := &geminiReviewProcess{cmd: cmd, events: make(chan reviewtypes.Event, 32)}
-	go p.run(stdout)
-	return p, nil
 }
 
 // buildGeminiReviewCmd builds the exec.Cmd for a gemini review run.
-// Exported at package level for test inspection of argv, stdin, and env.
+// Exposed at package level for test inspection of argv, stdin, and env.
 func buildGeminiReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
 	prompt := review.ComposeReviewPrompt(cfg)
 	// Per the existing GenerateText implementation: pass "-p " " " as the
@@ -86,23 +68,4 @@ func parseGeminiOutput(r io.Reader) <-chan reviewtypes.Event {
 		out <- reviewtypes.Finished{Success: true}
 	}()
 	return out
-}
-
-// geminiReviewProcess is the running gemini review process.
-type geminiReviewProcess struct {
-	cmd    *exec.Cmd
-	events chan reviewtypes.Event
-}
-
-func (p *geminiReviewProcess) Events() <-chan reviewtypes.Event { return p.events }
-
-// Wait implements Process.Wait. The *exec.ExitError passes through unwrapped
-// per the Process.Wait contract; callers may errors.As for *exec.ExitError.
-func (p *geminiReviewProcess) Wait() error { return p.cmd.Wait() } //nolint:wrapcheck // Process.Wait contract allows *exec.ExitError passthrough
-
-func (p *geminiReviewProcess) run(stdout io.Reader) {
-	defer close(p.events)
-	for ev := range parseGeminiOutput(stdout) {
-		p.events <- ev
-	}
 }

--- a/cmd/entire/cli/agent/geminicli/reviewer.go
+++ b/cmd/entire/cli/agent/geminicli/reviewer.go
@@ -48,45 +48,14 @@ func (r *Reviewer) Start(ctx context.Context, cfg reviewtypes.RunConfig) (review
 // buildGeminiReviewCmd builds the exec.Cmd for a gemini review run.
 // Exported at package level for test inspection of argv, stdin, and env.
 func buildGeminiReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
-	prompt := composeGeminiReviewPrompt(cfg)
+	prompt := review.ComposeReviewPrompt(cfg)
 	// Per the existing GenerateText implementation: pass "-p " " " as the
 	// argv placeholder to trigger headless (non-interactive) mode, and pipe
 	// the actual prompt via stdin to avoid argv size limits.
 	cmd := exec.CommandContext(ctx, "gemini", "-p", " ")
 	cmd.Stdin = strings.NewReader(prompt)
-	cmd.Env = appendGeminiReviewEnv(os.Environ(), cfg, prompt)
+	cmd.Env = review.AppendReviewEnv(os.Environ(), "gemini-cli", cfg, prompt)
 	return cmd
-}
-
-// appendGeminiReviewEnv appends ENTIRE_REVIEW_* vars to the given base environment.
-func appendGeminiReviewEnv(base []string, cfg reviewtypes.RunConfig, prompt string) []string {
-	skillsJSON, _ := review.EncodeSkills(cfg.Skills) //nolint:errcheck // EncodeSkills only fails on json.Marshal([]string), which is infallible
-	return append(base,
-		review.EnvSession+"=1",
-		review.EnvAgent+"=gemini-cli",
-		review.EnvSkills+"="+skillsJSON,
-		review.EnvPrompt+"="+prompt,
-		review.EnvStartingSHA+"="+cfg.StartingSHA,
-	)
-}
-
-// composeGeminiReviewPrompt concatenates Skills, AlwaysPrompt, and PerRunPrompt
-// (skipping empty strings) with double-newline separators.
-func composeGeminiReviewPrompt(cfg reviewtypes.RunConfig) string {
-	parts := make([]string, 0, len(cfg.Skills)+2)
-	parts = append(parts, cfg.Skills...)
-	parts = append(parts, cfg.AlwaysPrompt, cfg.PerRunPrompt)
-	var out strings.Builder
-	for _, p := range parts {
-		if p == "" {
-			continue
-		}
-		if out.Len() > 0 {
-			out.WriteString("\n\n")
-		}
-		out.WriteString(p)
-	}
-	return out.String()
 }
 
 // parseGeminiOutput converts gemini's -p mode stdout into a stream of Events.

--- a/cmd/entire/cli/agent/geminicli/reviewer.go
+++ b/cmd/entire/cli/agent/geminicli/reviewer.go
@@ -1,0 +1,139 @@
+package geminicli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/review"
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// Reviewer is the AgentReviewer implementation for gemini-cli.
+//
+// Argv shape: gemini -p " " (space placeholder to trigger headless mode).
+// Prompt is piped via stdin; per gemini --help the -p flag appends to stdin
+// content, so passing a single space lets stdin carry the actual prompt.
+// Stdout in this mode is clean assistant output — no chrome filtering needed.
+type Reviewer struct{}
+
+// NewReviewer creates a new gemini-cli AgentReviewer.
+func NewReviewer() *Reviewer { return &Reviewer{} }
+
+// Compile-time interface check.
+var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
+
+// Name returns the agent's registry key.
+func (*Reviewer) Name() string { return "gemini-cli" }
+
+// Start spawns gemini with the review prompt on stdin and returns a streaming Process.
+func (r *Reviewer) Start(ctx context.Context, cfg reviewtypes.RunConfig) (reviewtypes.Process, error) {
+	cmd := buildGeminiReviewCmd(ctx, cfg)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("gemini-cli: stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("gemini-cli: start: %w", err)
+	}
+	p := &geminiReviewProcess{cmd: cmd, events: make(chan reviewtypes.Event, 32)}
+	go p.run(stdout)
+	return p, nil
+}
+
+// buildGeminiReviewCmd builds the exec.Cmd for a gemini review run.
+// Exported at package level for test inspection of argv, stdin, and env.
+func buildGeminiReviewCmd(ctx context.Context, cfg reviewtypes.RunConfig) *exec.Cmd {
+	prompt := composeGeminiReviewPrompt(cfg)
+	// Per the existing GenerateText implementation: pass "-p " " " as the
+	// argv placeholder to trigger headless (non-interactive) mode, and pipe
+	// the actual prompt via stdin to avoid argv size limits.
+	cmd := exec.CommandContext(ctx, "gemini", "-p", " ")
+	cmd.Stdin = strings.NewReader(prompt)
+	cmd.Env = appendGeminiReviewEnv(os.Environ(), cfg, prompt)
+	return cmd
+}
+
+// appendGeminiReviewEnv appends ENTIRE_REVIEW_* vars to the given base environment.
+func appendGeminiReviewEnv(base []string, cfg reviewtypes.RunConfig, prompt string) []string {
+	skillsJSON, _ := review.EncodeSkills(cfg.Skills) //nolint:errcheck // EncodeSkills only fails on json.Marshal([]string), which is infallible
+	return append(base,
+		review.EnvSession+"=1",
+		review.EnvAgent+"=gemini-cli",
+		review.EnvSkills+"="+skillsJSON,
+		review.EnvPrompt+"="+prompt,
+		review.EnvStartingSHA+"="+cfg.StartingSHA,
+	)
+}
+
+// composeGeminiReviewPrompt concatenates Skills, AlwaysPrompt, and PerRunPrompt
+// (skipping empty strings) with double-newline separators.
+func composeGeminiReviewPrompt(cfg reviewtypes.RunConfig) string {
+	parts := make([]string, 0, len(cfg.Skills)+2)
+	parts = append(parts, cfg.Skills...)
+	parts = append(parts, cfg.AlwaysPrompt, cfg.PerRunPrompt)
+	var out strings.Builder
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if out.Len() > 0 {
+			out.WriteString("\n\n")
+		}
+		out.WriteString(p)
+	}
+	return out.String()
+}
+
+// parseGeminiOutput converts gemini's -p mode stdout into a stream of Events.
+// Gemini emits clean assistant output with no chrome — the parser emits Started
+// once, then one AssistantText per non-empty line, then Finished{Success: true}
+// on clean EOF or RunError + Finished{Success: false} on a torn stream.
+//
+// Exposed for golden-file contract testing.
+func parseGeminiOutput(r io.Reader) <-chan reviewtypes.Event {
+	out := make(chan reviewtypes.Event, 32)
+	go func() {
+		defer close(out)
+		out <- reviewtypes.Started{}
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+			out <- reviewtypes.AssistantText{Text: line}
+		}
+		if err := scanner.Err(); err != nil {
+			out <- reviewtypes.RunError{Err: fmt.Errorf("read stdout: %w", err)}
+			out <- reviewtypes.Finished{Success: false}
+			return
+		}
+		out <- reviewtypes.Finished{Success: true}
+	}()
+	return out
+}
+
+// geminiReviewProcess is the running gemini review process.
+type geminiReviewProcess struct {
+	cmd    *exec.Cmd
+	events chan reviewtypes.Event
+}
+
+func (p *geminiReviewProcess) Events() <-chan reviewtypes.Event { return p.events }
+
+// Wait implements Process.Wait. The *exec.ExitError passes through unwrapped
+// per the Process.Wait contract; callers may errors.As for *exec.ExitError.
+func (p *geminiReviewProcess) Wait() error { return p.cmd.Wait() } //nolint:wrapcheck // Process.Wait contract allows *exec.ExitError passthrough
+
+func (p *geminiReviewProcess) run(stdout io.Reader) {
+	defer close(p.events)
+	for ev := range parseGeminiOutput(stdout) {
+		p.events <- ev
+	}
+}

--- a/cmd/entire/cli/agent/geminicli/reviewer_test.go
+++ b/cmd/entire/cli/agent/geminicli/reviewer_test.go
@@ -13,8 +13,8 @@ import (
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
 
-// Compile-time interface check (mirrors the one in reviewer.go).
-var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
+// Compile-time interface check: ReviewerTemplate implements AgentReviewer.
+var _ reviewtypes.AgentReviewer = (*reviewtypes.ReviewerTemplate)(nil)
 
 const wantGeminiAgentName = "gemini-cli"
 

--- a/cmd/entire/cli/agent/geminicli/reviewer_test.go
+++ b/cmd/entire/cli/agent/geminicli/reviewer_test.go
@@ -1,0 +1,246 @@
+package geminicli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/review"
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// Compile-time interface check (mirrors the one in reviewer.go).
+var _ reviewtypes.AgentReviewer = (*Reviewer)(nil)
+
+const wantGeminiAgentName = "gemini-cli"
+
+func TestGeminiReviewer_Name(t *testing.T) {
+	t.Parallel()
+	r := NewReviewer()
+	if got := r.Name(); got != wantGeminiAgentName {
+		t.Errorf("Name() = %q, want %q", got, wantGeminiAgentName)
+	}
+}
+
+func TestGeminiReviewer_EnvVarsSet(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/gemini:review", "/security-review"},
+		AlwaysPrompt: "Always check for security vulnerabilities.",
+		PerRunPrompt: "Focus on the API layer.",
+		StartingSHA:  "cafebabe0000",
+	}
+	cmd := buildGeminiReviewCmd(context.Background(), cfg)
+
+	wantKeys := []string{
+		review.EnvSession,
+		review.EnvAgent,
+		review.EnvSkills,
+		review.EnvPrompt,
+		review.EnvStartingSHA,
+	}
+	envMap := geminiEnvToMap(cmd.Env)
+
+	for _, key := range wantKeys {
+		if _, ok := envMap[key]; !ok {
+			t.Errorf("env var %s not set on cmd", key)
+		}
+	}
+
+	if envMap[review.EnvSession] != "1" {
+		t.Errorf("%s = %q, want %q", review.EnvSession, envMap[review.EnvSession], "1")
+	}
+	if envMap[review.EnvAgent] != wantGeminiAgentName {
+		t.Errorf("%s = %q, want %q", review.EnvAgent, envMap[review.EnvAgent], wantGeminiAgentName)
+	}
+	if envMap[review.EnvStartingSHA] != "cafebabe0000" {
+		t.Errorf("%s = %q, want %q", review.EnvStartingSHA, envMap[review.EnvStartingSHA], "cafebabe0000")
+	}
+	if !strings.HasPrefix(envMap[review.EnvSkills], "[") {
+		t.Errorf("%s = %q, want JSON array", review.EnvSkills, envMap[review.EnvSkills])
+	}
+}
+
+func TestGeminiReviewer_ArgvShape(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{Skills: []string{"/skill"}}
+	cmd := buildGeminiReviewCmd(context.Background(), cfg)
+
+	// Expect: gemini -p " "
+	if len(cmd.Args) != 3 {
+		t.Fatalf("len(Args) = %d, want 3: %v", len(cmd.Args), cmd.Args)
+	}
+	if cmd.Args[0] != "gemini" {
+		t.Errorf("Args[0] = %q, want %q", cmd.Args[0], "gemini")
+	}
+	if cmd.Args[1] != "-p" {
+		t.Errorf("Args[1] = %q, want %q", cmd.Args[1], "-p")
+	}
+	if cmd.Args[2] != " " {
+		t.Errorf("Args[2] = %q, want %q (space placeholder)", cmd.Args[2], " ")
+	}
+	// Stdin must be non-nil — gemini receives prompt via stdin.
+	if cmd.Stdin == nil {
+		t.Error("cmd.Stdin is nil; gemini requires prompt via stdin")
+	}
+}
+
+func TestGeminiReviewer_NoBinaryRequiredAtConstruction(t *testing.T) {
+	// No t.Parallel — uses t.Setenv.
+	t.Setenv("PATH", "")
+
+	r := NewReviewer()
+	cfg := reviewtypes.RunConfig{
+		Skills:      []string{"/test"},
+		StartingSHA: "abc123",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Construction (NewReviewer) MUST NOT touch PATH. Start may or may
+	// not error depending on whether the OS-level cmd.Start tries to
+	// resolve before fork — that's fine. The contract is just "no panic
+	// and no upfront LookPath call".
+	proc, err := r.Start(ctx, cfg)
+	// Either Start succeeded (deferred lookup; binary error surfaces in Wait)
+	// or Start failed with exec.ErrNotFound (immediate lookup at Cmd.Start).
+	// Both satisfy the deferred-lookup contract — what we explicitly DON'T
+	// want is a panic or error from NewReviewer itself.
+	if err != nil && !errors.Is(err, exec.ErrNotFound) {
+		// Tolerate "no such file" wrapping variations
+		if !strings.Contains(err.Error(), "executable file not found") &&
+			!strings.Contains(err.Error(), "no such file") {
+			t.Errorf("unexpected error type: %v", err)
+		}
+	}
+	if proc != nil {
+		// Drain events to let parser goroutine exit cleanly.
+		drainGeminiEvents(proc.Events())
+		_ = proc.Wait() //nolint:errcheck // best-effort cleanup in test
+	}
+}
+
+func TestParseGeminiOutput_ReportsScannerError(t *testing.T) {
+	t.Parallel()
+	// Trigger bufio.Scanner's "token too long" error: produce a "line"
+	// that exceeds the 16MB max buffer without containing a newline.
+	r, w := io.Pipe()
+	go func() {
+		defer w.Close()
+		// 17MB of contiguous bytes without a newline
+		buf := make([]byte, 1024*1024)
+		for range 17 {
+			_, _ = w.Write(buf) //nolint:errcheck // best-effort write in test goroutine
+		}
+	}()
+
+	events := collectGeminiEvents(parseGeminiOutput(r))
+
+	if len(events) < 2 {
+		t.Fatalf("expected at least Started + Finished, got %d events", len(events))
+	}
+	last := events[len(events)-1]
+	fin, ok := last.(reviewtypes.Finished)
+	if !ok {
+		t.Fatalf("last event must be Finished, got %T", last)
+	}
+	if fin.Success {
+		t.Error("Finished.Success must be false on scanner error")
+	}
+	// Also assert at least one RunError event was emitted before Finished.
+	sawRunError := false
+	for _, ev := range events {
+		if _, ok := ev.(reviewtypes.RunError); ok {
+			sawRunError = true
+			break
+		}
+	}
+	if !sawRunError {
+		t.Error("expected RunError event before Finished{Success: false}")
+	}
+}
+
+func TestGeminiReviewer_EventStream(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("testdata/canned_session.txt")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	events := collectGeminiEvents(parseGeminiOutput(strings.NewReader(string(data))))
+
+	if len(events) < 3 {
+		t.Fatalf("expected at least 3 events (Started + AssistantText + Finished), got %d", len(events))
+	}
+
+	// First event must be Started.
+	if _, ok := events[0].(reviewtypes.Started); !ok {
+		t.Errorf("events[0] = %T, want Started", events[0])
+	}
+
+	// Last event must be Finished{Success: true}.
+	last := events[len(events)-1]
+	fin, ok := last.(reviewtypes.Finished)
+	if !ok {
+		t.Errorf("last event = %T, want Finished", last)
+	} else if !fin.Success {
+		t.Errorf("Finished.Success = false, want true")
+	}
+
+	// All middle events must be AssistantText with non-empty text.
+	for i := 1; i < len(events)-1; i++ {
+		at, ok := events[i].(reviewtypes.AssistantText)
+		if !ok {
+			t.Errorf("events[%d] = %T, want AssistantText", i, events[i])
+			continue
+		}
+		if at.Text == "" {
+			t.Errorf("events[%d].Text is empty (empty lines must be skipped)", i)
+		}
+	}
+
+	// Verify fixture content appears in text events.
+	var combined strings.Builder
+	for _, ev := range events {
+		if at, ok := ev.(reviewtypes.AssistantText); ok {
+			combined.WriteString(at.Text)
+			combined.WriteString("\n")
+		}
+	}
+	if !strings.Contains(combined.String(), "AgentReviewer") {
+		t.Error("expected fixture content mentioning 'AgentReviewer' to appear in AssistantText events")
+	}
+}
+
+func collectGeminiEvents(ch <-chan reviewtypes.Event) []reviewtypes.Event {
+	var events []reviewtypes.Event
+	for ev := range ch {
+		events = append(events, ev)
+	}
+	return events
+}
+
+// drainGeminiEvents consumes all events from ch without recording them.
+func drainGeminiEvents(ch <-chan reviewtypes.Event) {
+	for ev := range ch {
+		_ = ev
+	}
+}
+
+func geminiEnvToMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, e := range env {
+		idx := strings.IndexByte(e, '=')
+		if idx < 0 {
+			continue
+		}
+		m[e[:idx]] = e[idx+1:]
+	}
+	return m
+}

--- a/cmd/entire/cli/agent/geminicli/testdata/canned_session.txt
+++ b/cmd/entire/cli/agent/geminicli/testdata/canned_session.txt
@@ -1,0 +1,11 @@
+I've reviewed the changes on this branch.
+
+The `AgentReviewer` interface and `Process` type are well-designed abstractions. The sealed `Event` sum type prevents external packages from extending the event taxonomy — a sound design choice for a stable contract.
+
+**Summary of findings:**
+
+- Interface segregation is clean: `AgentReviewer` owns construction, `Process` owns the runtime lifecycle.
+- The buffered channel (capacity 32) is appropriate for backpressure without blocking agent output parsing.
+- `RunConfig` fields are all optional; zero value is safe to use.
+
+Overall the implementation looks correct. Ready to proceed to CU3 implementations.

--- a/cmd/entire/cli/review/dump.go
+++ b/cmd/entire/cli/review/dump.go
@@ -1,0 +1,100 @@
+// Package review — see env.go for package-level rationale.
+//
+// dump.go provides DumpSink, a Sink implementation that writes a
+// per-agent narrative dump to an io.Writer after the run completes.
+// AgentEvent is a no-op; events are read from RunSummary.AgentRuns[].Buffer
+// in RunFinished.
+package review
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// DumpSink writes per-agent narrative blocks to W after the run completes.
+type DumpSink struct {
+	W io.Writer
+}
+
+// Compile-time interface check.
+var _ reviewtypes.Sink = DumpSink{}
+
+// AgentEvent is intentionally a no-op. DumpSink renders post-run from
+// the AgentRun.Buffer slices in RunFinished.
+func (DumpSink) AgentEvent(_ string, _ reviewtypes.Event) {}
+
+// RunFinished writes a narrative block per agent, then a counts line.
+func (s DumpSink) RunFinished(summary reviewtypes.RunSummary) {
+	for _, run := range summary.AgentRuns {
+		s.dumpAgent(run)
+	}
+	s.dumpCounts(summary)
+}
+
+func (s DumpSink) dumpAgent(run reviewtypes.AgentRun) {
+	fmt.Fprintf(s.W, "─────── %s review ───────\n", run.Name)
+	if run.Status == reviewtypes.AgentStatusCancelled {
+		fmt.Fprintln(s.W, "(cancelled)")
+		return
+	}
+	if run.Status == reviewtypes.AgentStatusFailed {
+		// Surface the wait error if any (process exit failure), then any
+		// agent-level RunError events the parser emitted (typically a torn
+		// stdout stream — caught at the orchestrator level by classifyStatus
+		// even when the process itself exited 0).
+		if run.Err != nil {
+			fmt.Fprintf(s.W, "(failed: %v)\n", run.Err)
+		} else {
+			fmt.Fprintln(s.W, "(failed)")
+		}
+		for _, ev := range run.Buffer {
+			if re, ok := ev.(reviewtypes.RunError); ok && re.Err != nil {
+				fmt.Fprintf(s.W, "  agent error: %v\n", re.Err)
+			}
+		}
+		// Render any narrative text the agent produced before the failure
+		// surfaced — useful when the parser tore mid-response so reviewers
+		// can see partial output instead of a bare "(failed)" line.
+		if narrative := joinAssistantText(run.Buffer); narrative != "" {
+			fmt.Fprintln(s.W, narrative)
+		}
+		return
+	}
+	if narrative := joinAssistantText(run.Buffer); narrative != "" {
+		fmt.Fprintln(s.W, narrative)
+	}
+}
+
+// joinAssistantText extracts AssistantText events from a buffer and joins
+// them with newlines, trimming the result to keep dump output tight.
+func joinAssistantText(buf []reviewtypes.Event) string {
+	var b strings.Builder
+	for _, ev := range buf {
+		if at, ok := ev.(reviewtypes.AssistantText); ok {
+			b.WriteString(at.Text)
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func (s DumpSink) dumpCounts(summary reviewtypes.RunSummary) {
+	succ, fail, canc := 0, 0, 0
+	for _, r := range summary.AgentRuns {
+		switch r.Status {
+		case reviewtypes.AgentStatusSucceeded:
+			succ++
+		case reviewtypes.AgentStatusFailed:
+			fail++
+		case reviewtypes.AgentStatusCancelled:
+			canc++
+		case reviewtypes.AgentStatusUnknown:
+			// Unknown status: not counted in any bucket.
+		}
+	}
+	fmt.Fprintf(s.W, "%d agent(s) done — %d succeeded, %d failed, %d cancelled\n",
+		len(summary.AgentRuns), succ, fail, canc)
+}

--- a/cmd/entire/cli/review/dump_test.go
+++ b/cmd/entire/cli/review/dump_test.go
@@ -1,0 +1,162 @@
+package review
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+func makeSummary(runs ...reviewtypes.AgentRun) reviewtypes.RunSummary {
+	return reviewtypes.RunSummary{AgentRuns: runs}
+}
+
+func TestDumpSink_SucceededAgent(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sink := DumpSink{W: &buf}
+
+	run := reviewtypes.AgentRun{
+		Name:   "claude-code",
+		Status: reviewtypes.AgentStatusSucceeded,
+		Buffer: []reviewtypes.Event{
+			reviewtypes.AssistantText{Text: "First finding"},
+			reviewtypes.AssistantText{Text: "Second finding"},
+		},
+	}
+	sink.RunFinished(makeSummary(run))
+
+	out := buf.String()
+	if !strings.Contains(out, "─────── claude-code review ───────") {
+		t.Errorf("expected agent header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "First finding") {
+		t.Errorf("expected first finding in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Second finding") {
+		t.Errorf("expected second finding in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 agent(s) done — 1 succeeded, 0 failed, 0 cancelled") {
+		t.Errorf("expected counts line, got:\n%s", out)
+	}
+}
+
+func TestDumpSink_FailedAgentWithErr(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sink := DumpSink{W: &buf}
+
+	run := reviewtypes.AgentRun{
+		Name:   "codex",
+		Status: reviewtypes.AgentStatusFailed,
+		Err:    errors.New("binary not found"),
+	}
+	sink.RunFinished(makeSummary(run))
+
+	out := buf.String()
+	if !strings.Contains(out, "(failed: binary not found)") {
+		t.Errorf("expected error message in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "1 agent(s) done — 0 succeeded, 1 failed, 0 cancelled") {
+		t.Errorf("expected counts line, got:\n%s", out)
+	}
+}
+
+func TestDumpSink_FailedAgentNoErr(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sink := DumpSink{W: &buf}
+
+	run := reviewtypes.AgentRun{
+		Name:   "codex",
+		Status: reviewtypes.AgentStatusFailed,
+		Err:    nil,
+	}
+	sink.RunFinished(makeSummary(run))
+
+	out := buf.String()
+	if !strings.Contains(out, "(failed)") {
+		t.Errorf("expected (failed) in output, got:\n%s", out)
+	}
+	// Must not contain "(failed: " which would indicate an error was printed.
+	if strings.Contains(out, "(failed: ") {
+		t.Errorf("unexpected error detail in output, got:\n%s", out)
+	}
+}
+
+func TestDumpSink_CancelledAgent(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sink := DumpSink{W: &buf}
+
+	run := reviewtypes.AgentRun{
+		Name:   "gemini-cli",
+		Status: reviewtypes.AgentStatusCancelled,
+		Buffer: []reviewtypes.Event{
+			reviewtypes.AssistantText{Text: "partial output"},
+		},
+	}
+	sink.RunFinished(makeSummary(run))
+
+	out := buf.String()
+	if !strings.Contains(out, "(cancelled)") {
+		t.Errorf("expected (cancelled) in output, got:\n%s", out)
+	}
+	// Narrative should not be dumped for cancelled runs.
+	if strings.Contains(out, "partial output") {
+		t.Errorf("narrative should not appear for cancelled agent, got:\n%s", out)
+	}
+}
+
+func TestDumpSink_Mixed(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sink := DumpSink{W: &buf}
+
+	summary := makeSummary(
+		reviewtypes.AgentRun{
+			Name:   "claude-code",
+			Status: reviewtypes.AgentStatusSucceeded,
+			Buffer: []reviewtypes.Event{reviewtypes.AssistantText{Text: "looks good"}},
+		},
+		reviewtypes.AgentRun{
+			Name:   "codex",
+			Status: reviewtypes.AgentStatusFailed,
+			Err:    errors.New("timeout"),
+		},
+		reviewtypes.AgentRun{
+			Name:   "gemini-cli",
+			Status: reviewtypes.AgentStatusCancelled,
+		},
+	)
+	sink.RunFinished(summary)
+
+	out := buf.String()
+	if !strings.Contains(out, "─────── claude-code review ───────") {
+		t.Errorf("expected claude-code header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "─────── codex review ───────") {
+		t.Errorf("expected codex header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "─────── gemini-cli review ───────") {
+		t.Errorf("expected gemini-cli header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "3 agent(s) done — 1 succeeded, 1 failed, 1 cancelled") {
+		t.Errorf("expected mixed counts line, got:\n%s", out)
+	}
+}
+
+func TestDumpSink_EmptyAgentRuns(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sink := DumpSink{W: &buf}
+
+	sink.RunFinished(reviewtypes.RunSummary{})
+
+	out := buf.String()
+	if !strings.Contains(out, "0 agent(s) done — 0 succeeded, 0 failed, 0 cancelled") {
+		t.Errorf("expected empty counts line, got:\n%s", out)
+	}
+}

--- a/cmd/entire/cli/review/env.go
+++ b/cmd/entire/cli/review/env.go
@@ -13,6 +13,9 @@ package review
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
 
 const (
@@ -72,4 +75,53 @@ func DecodeSkills(encoded string) ([]string, error) {
 		return nil, fmt.Errorf("decode skills: %w", err)
 	}
 	return skills, nil
+}
+
+// AppendReviewEnv adds the ENTIRE_REVIEW_* env vars to base, returning
+// the new slice. Used by per-agent reviewers in their AgentReviewer.Start
+// implementations to propagate the review-session contract to spawned
+// agent processes.
+//
+// agentName must be the agent's stable registry key (e.g. "claude-code").
+// cfg carries skills and the starting SHA. prompt is the full composed
+// prompt text (result of ComposeReviewPrompt).
+//
+// Any pre-existing ENTIRE_REVIEW_* entries in base are stripped before the
+// new values are appended. This handles nested invocations (an `entire
+// review` run spawning another agent that calls `entire review`) and stale
+// inheritance from a parent shell — the most-recent values must win, with
+// no chance of duplicate keys whose precedence is implementation-defined.
+func AppendReviewEnv(base []string, agentName string, cfg reviewtypes.RunConfig, prompt string) []string {
+	skillsJSON, _ := EncodeSkills(cfg.Skills) //nolint:errcheck // EncodeSkills only fails on json.Marshal([]string), which is infallible
+	out := make([]string, 0, len(base)+5)
+	for _, kv := range base {
+		if isReviewEnvEntry(kv) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out,
+		EnvSession+"=1",
+		EnvAgent+"="+agentName,
+		EnvSkills+"="+skillsJSON,
+		EnvPrompt+"="+prompt,
+		EnvStartingSHA+"="+cfg.StartingSHA,
+	)
+}
+
+// isReviewEnvEntry reports whether kv is a "KEY=VALUE" entry whose key is
+// one of the ENTIRE_REVIEW_* contract variables.
+func isReviewEnvEntry(kv string) bool {
+	for _, prefix := range []string{
+		EnvSession + "=",
+		EnvAgent + "=",
+		EnvSkills + "=",
+		EnvPrompt + "=",
+		EnvStartingSHA + "=",
+	} {
+		if strings.HasPrefix(kv, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/entire/cli/review/env_test.go
+++ b/cmd/entire/cli/review/env_test.go
@@ -2,6 +2,8 @@ package review
 
 import (
 	"testing"
+
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
 
 func TestEnvSkillsRoundtrip(t *testing.T) {
@@ -71,5 +73,73 @@ func TestDecodeSkillsRejectsInvalidJSON(t *testing.T) {
 	}
 	if _, err := DecodeSkills(""); err != nil {
 		t.Errorf("expected empty string to decode as empty slice, got error: %v", err)
+	}
+}
+
+// TestAppendReviewEnv_StripsPreExistingReviewVars pins the contract that
+// AppendReviewEnv removes any pre-existing ENTIRE_REVIEW_* entries before
+// appending the new values. Defense against nested invocations and stale
+// env inheritance from a parent shell — duplicate keys would otherwise have
+// implementation-defined precedence.
+func TestAppendReviewEnv_StripsPreExistingReviewVars(t *testing.T) {
+	t.Parallel()
+	base := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/u",
+		EnvSession + "=stale",
+		EnvAgent + "=stale-agent",
+		EnvSkills + "=[\"/stale\"]",
+		EnvPrompt + "=stale prompt",
+		EnvStartingSHA + "=stalehash",
+	}
+	got := AppendReviewEnv(base, "claude-code", reviewtypes.RunConfig{
+		Skills:      []string{"/fresh"},
+		StartingSHA: "freshhash",
+	}, "fresh prompt")
+
+	// Each ENTIRE_REVIEW_* key should appear exactly once with the fresh value.
+	want := map[string]string{
+		EnvSession:     "1",
+		EnvAgent:       "claude-code",
+		EnvSkills:      `["/fresh"]`,
+		EnvPrompt:      "fresh prompt",
+		EnvStartingSHA: "freshhash",
+	}
+	counts := make(map[string]int)
+	values := make(map[string]string)
+	for _, kv := range got {
+		for key := range want {
+			prefix := key + "="
+			if len(kv) > len(prefix) && kv[:len(prefix)] == prefix {
+				counts[key]++
+				values[key] = kv[len(prefix):]
+			} else if kv == prefix {
+				counts[key]++
+				values[key] = ""
+			}
+		}
+	}
+	for key, wantVal := range want {
+		if counts[key] != 1 {
+			t.Errorf("%s: expected exactly 1 occurrence, got %d", key, counts[key])
+		}
+		if values[key] != wantVal {
+			t.Errorf("%s: got %q, want %q", key, values[key], wantVal)
+		}
+	}
+
+	// Non-review entries (PATH, HOME) must survive unchanged.
+	pathSeen := false
+	homeSeen := false
+	for _, kv := range got {
+		if kv == "PATH=/usr/bin" {
+			pathSeen = true
+		}
+		if kv == "HOME=/home/u" {
+			homeSeen = true
+		}
+	}
+	if !pathSeen || !homeSeen {
+		t.Errorf("non-review env entries should survive: PATH=%v HOME=%v", pathSeen, homeSeen)
 	}
 }

--- a/cmd/entire/cli/review/prompt.go
+++ b/cmd/entire/cli/review/prompt.go
@@ -1,0 +1,46 @@
+// Package review — see env.go for package-level rationale.
+//
+// prompt.go implements the shared prompt composer used by all per-agent
+// reviewers. The scope clause pins agents to "commits unique to this branch
+// vs the closest ancestor" — preventing the divergent-default problem where
+// codex defaulted to origin/main...HEAD and claude defaulted to
+// working-tree-only on the same invocation (regression class from #1018
+// commit b9ed9c074; enforced structurally here).
+package review
+
+import (
+	"strings"
+
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// ComposeReviewPrompt assembles the prompt sent to the agent. It joins
+// the configured skill invocations, the always-prompt, the per-run
+// prompt, and a scope clause that pins the agent to commits unique
+// to the current branch vs the closest ancestor.
+//
+// Empty sections are skipped (no triple-newline gaps). The scope clause
+// is only added when cfg.ScopeBaseRef is non-empty.
+func ComposeReviewPrompt(cfg reviewtypes.RunConfig) string {
+	var sections []string
+
+	// Skills: one per line, joined as a single section.
+	if len(cfg.Skills) > 0 {
+		sections = append(sections, strings.Join(cfg.Skills, "\n"))
+	}
+
+	// AlwaysPrompt and PerRunPrompt: each is its own section if non-empty after trim.
+	if trimmed := strings.TrimRight(cfg.AlwaysPrompt, "\n\r "); trimmed != "" {
+		sections = append(sections, trimmed)
+	}
+	if trimmed := strings.TrimRight(cfg.PerRunPrompt, "\n\r "); trimmed != "" {
+		sections = append(sections, trimmed)
+	}
+
+	// Scope clause: only when a base ref was detected.
+	if cfg.ScopeBaseRef != "" {
+		sections = append(sections, "Scope: review only the commits unique to this branch vs "+cfg.ScopeBaseRef+".")
+	}
+
+	return strings.Join(sections, "\n\n")
+}

--- a/cmd/entire/cli/review/prompt_test.go
+++ b/cmd/entire/cli/review/prompt_test.go
@@ -1,0 +1,117 @@
+package review
+
+import (
+	"testing"
+
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+func TestComposeReviewPrompt_SkillsOnly(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{
+		Skills: []string{"/skill-a", "/skill-b"},
+	}
+	got := ComposeReviewPrompt(cfg)
+	want := "/skill-a\n/skill-b"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComposeReviewPrompt_SkillsPlusAlwaysPrompt(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/skill-a", "/skill-b"},
+		AlwaysPrompt: "be thorough",
+	}
+	got := ComposeReviewPrompt(cfg)
+	want := "/skill-a\n/skill-b\n\nbe thorough"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComposeReviewPrompt_SkillsPlusAlwaysPlusPerRun(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/skill-a", "/skill-b"},
+		AlwaysPrompt: "be thorough",
+		PerRunPrompt: "focus on auth",
+	}
+	got := ComposeReviewPrompt(cfg)
+	want := "/skill-a\n/skill-b\n\nbe thorough\n\nfocus on auth"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComposeReviewPrompt_AllSectionsWithScope(t *testing.T) {
+	t.Parallel()
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/x"},
+		AlwaysPrompt: "be thorough",
+		PerRunPrompt: "focus on auth",
+		ScopeBaseRef: "main",
+	}
+	got := ComposeReviewPrompt(cfg)
+	want := "/x\n\nbe thorough\n\nfocus on auth\n\nScope: review only the commits unique to this branch vs main."
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComposeReviewPrompt_EmptyAlwaysPromptNoExtraBlankLine(t *testing.T) {
+	t.Parallel()
+	// Skills + PerRunPrompt only — empty AlwaysPrompt must not produce triple-newline.
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/x"},
+		PerRunPrompt: "y",
+	}
+	got := ComposeReviewPrompt(cfg)
+	want := "/x\n\ny"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComposeReviewPrompt_EmptySkillsAlwaysPromptOnly(t *testing.T) {
+	t.Parallel()
+	// No skills, AlwaysPrompt only — must not produce a leading blank line.
+	cfg := reviewtypes.RunConfig{
+		AlwaysPrompt: "review carefully",
+	}
+	got := ComposeReviewPrompt(cfg)
+	want := "review carefully"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComposeReviewPrompt_NoScopeBaseRef(t *testing.T) {
+	t.Parallel()
+	// Empty ScopeBaseRef — scope clause must be omitted entirely.
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/x"},
+		ScopeBaseRef: "",
+	}
+	got := ComposeReviewPrompt(cfg)
+	want := "/x"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestComposeReviewPrompt_TrailingWhitespaceStripped(t *testing.T) {
+	t.Parallel()
+	// AlwaysPrompt with trailing newlines — must not produce extra blank lines.
+	cfg := reviewtypes.RunConfig{
+		Skills:       []string{"/x"},
+		AlwaysPrompt: "be thorough\n\n",
+		PerRunPrompt: "focus",
+	}
+	got := ComposeReviewPrompt(cfg)
+	want := "/x\n\nbe thorough\n\nfocus"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/cmd/entire/cli/review/run.go
+++ b/cmd/entire/cli/review/run.go
@@ -1,0 +1,138 @@
+// Package review — see env.go for package-level rationale.
+//
+// run.go implements the single-agent orchestrator. CU8 generalizes
+// to N agents with a sibling RunMulti that re-uses the same
+// AgentRun classification and Sink fan-out.
+package review
+
+import (
+	"context"
+	"time"
+
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// Run executes a single-agent review. Events from the agent are forwarded
+// to all sinks via AgentEvent as they arrive; on completion, RunFinished
+// is called on each sink with the populated RunSummary.
+//
+// Returns the summary plus the agent's wait error (nil on clean exit,
+// ctx.Err() on cancellation, *exec.ExitError on non-zero exit). Callers
+// can inspect both — the summary is always populated even on error.
+func Run(
+	ctx context.Context,
+	reviewer reviewtypes.AgentReviewer,
+	cfg reviewtypes.RunConfig,
+	sinks []reviewtypes.Sink,
+) (reviewtypes.RunSummary, error) {
+	started := time.Now()
+
+	proc, err := reviewer.Start(ctx, cfg)
+	if err != nil {
+		// Construction failed — classify (cancellation vs failure), fan out, return.
+		// No event-stream signals available since Start failed before producing any.
+		finished := time.Now()
+		status := classifyStatus(ctx, err, eventOutcome{})
+		summary := reviewtypes.RunSummary{
+			StartedAt:  started,
+			FinishedAt: finished,
+			Cancelled:  status == reviewtypes.AgentStatusCancelled,
+			AgentRuns: []reviewtypes.AgentRun{{
+				Name:      reviewer.Name(),
+				Status:    status,
+				Err:       err,
+				StartedAt: started,
+				Duration:  finished.Sub(started),
+			}},
+		}
+		for _, sink := range sinks {
+			sink.RunFinished(summary)
+		}
+		return summary, err //nolint:wrapcheck // interface-boundary passthrough; wrapping breaks classifyStatus's ctx.Err() identity check for cancelled-during-Start scenarios
+	}
+
+	var (
+		buffer       []reviewtypes.Event
+		tokens       reviewtypes.Tokens
+		finishedSeen bool // saw Finished{...} event from the parser
+		finishedOk   bool // its Success field
+		sawRunError  bool // saw at least one RunError event
+	)
+	for ev := range proc.Events() {
+		buffer = append(buffer, ev)
+		switch e := ev.(type) {
+		case reviewtypes.Tokens:
+			tokens = e // Tokens is cumulative per CU2 contract — overwrite.
+		case reviewtypes.Finished:
+			finishedSeen = true
+			finishedOk = e.Success
+		case reviewtypes.RunError:
+			sawRunError = true
+		}
+		for _, sink := range sinks {
+			sink.AgentEvent(reviewer.Name(), ev)
+		}
+	}
+
+	waitErr := proc.Wait()
+	finished := time.Now()
+	status := classifyStatus(ctx, waitErr, eventOutcome{finishedSeen: finishedSeen, finishedOk: finishedOk, sawRunError: sawRunError})
+
+	summary := reviewtypes.RunSummary{
+		StartedAt:  started,
+		FinishedAt: finished,
+		Cancelled:  status == reviewtypes.AgentStatusCancelled,
+		AgentRuns: []reviewtypes.AgentRun{{
+			Name:      reviewer.Name(),
+			Status:    status,
+			Tokens:    tokens,
+			Buffer:    buffer,
+			StartedAt: started,
+			Duration:  finished.Sub(started),
+			Err:       waitErr,
+		}},
+	}
+	for _, sink := range sinks {
+		sink.RunFinished(summary)
+	}
+	return summary, waitErr //nolint:wrapcheck // interface boundary passthrough; wrapping hides ctx.Err() and *exec.ExitError from callers
+}
+
+// eventOutcome summarises agent-level signals observed in the event stream.
+// Used by classifyStatus to downgrade a process-level "exit 0" run that the
+// parser flagged as torn (RunError + Finished{Success: false}) — a clean
+// process exit doesn't imply a clean review result.
+type eventOutcome struct {
+	finishedSeen bool // a Finished event was emitted (parser ran to completion)
+	finishedOk   bool // Finished.Success
+	sawRunError  bool // at least one RunError event was emitted
+}
+
+// classifyStatus maps a process Wait error AND the event-stream outcome to
+// a terminal AgentStatus.
+//
+// Order matters: ctx-cancelled + signal-killed delivers an *exec.ExitError
+// with exit code -1, which would otherwise be misclassified as Failed.
+// Check ctx.Err() FIRST so cancelled runs are reported as Cancelled.
+// (Reference: PR #1018 commit 8e82e407a.)
+//
+// Event-level signals override process-level success: if the parser saw a
+// RunError or emitted Finished{Success: false}, the run is Failed even when
+// the process exits 0. This catches torn stdout streams the parser surfaces
+// via RunError + Finished{Success: false} (CU3 fix-loop guarantee).
+func classifyStatus(ctx context.Context, waitErr error, outcome eventOutcome) reviewtypes.AgentStatus {
+	if ctx.Err() != nil {
+		return reviewtypes.AgentStatusCancelled
+	}
+	if waitErr != nil {
+		return reviewtypes.AgentStatusFailed
+	}
+	// Process exited cleanly (exit 0). Honor agent-level signals.
+	if outcome.sawRunError {
+		return reviewtypes.AgentStatusFailed
+	}
+	if outcome.finishedSeen && !outcome.finishedOk {
+		return reviewtypes.AgentStatusFailed
+	}
+	return reviewtypes.AgentStatusSucceeded
+}

--- a/cmd/entire/cli/review/run.go
+++ b/cmd/entire/cli/review/run.go
@@ -7,6 +7,7 @@ package review
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
@@ -16,9 +17,10 @@ import (
 // to all sinks via AgentEvent as they arrive; on completion, RunFinished
 // is called on each sink with the populated RunSummary.
 //
-// Returns the summary plus the agent's wait error (nil on clean exit,
-// ctx.Err() on cancellation, *exec.ExitError on non-zero exit). Callers
-// can inspect both — the summary is always populated even on error.
+// Returns the summary plus the agent's terminal error (nil on clean exit,
+// ctx.Err() on cancellation, an error wrapping *exec.ExitError on non-zero
+// exit, or an agent-level error when the event stream reports failure).
+// Callers can inspect both: the summary is always populated even on error.
 func Run(
 	ctx context.Context,
 	reviewer reviewtypes.AgentReviewer,
@@ -57,6 +59,7 @@ func Run(
 		finishedSeen bool // saw Finished{...} event from the parser
 		finishedOk   bool // its Success field
 		sawRunError  bool // saw at least one RunError event
+		firstRunErr  error
 	)
 	for ev := range proc.Events() {
 		buffer = append(buffer, ev)
@@ -68,6 +71,9 @@ func Run(
 			finishedOk = e.Success
 		case reviewtypes.RunError:
 			sawRunError = true
+			if firstRunErr == nil {
+				firstRunErr = e.Err
+			}
 		}
 		for _, sink := range sinks {
 			sink.AgentEvent(reviewer.Name(), ev)
@@ -77,6 +83,10 @@ func Run(
 	waitErr := proc.Wait()
 	finished := time.Now()
 	status := classifyStatus(ctx, waitErr, eventOutcome{finishedSeen: finishedSeen, finishedOk: finishedOk, sawRunError: sawRunError})
+	runErr := waitErr
+	if runErr == nil && status == reviewtypes.AgentStatusFailed {
+		runErr = agentRunFailureError(reviewer.Name(), firstRunErr)
+	}
 
 	summary := reviewtypes.RunSummary{
 		StartedAt:  started,
@@ -89,13 +99,20 @@ func Run(
 			Buffer:    buffer,
 			StartedAt: started,
 			Duration:  finished.Sub(started),
-			Err:       waitErr,
+			Err:       runErr,
 		}},
 	}
 	for _, sink := range sinks {
 		sink.RunFinished(summary)
 	}
-	return summary, waitErr //nolint:wrapcheck // interface boundary passthrough; wrapping hides ctx.Err() and *exec.ExitError from callers
+	return summary, runErr
+}
+
+func agentRunFailureError(agent string, cause error) error {
+	if cause != nil {
+		return fmt.Errorf("review agent %s reported failure: %w", agent, cause)
+	}
+	return fmt.Errorf("review agent %s reported failure", agent)
 }
 
 // eventOutcome summarises agent-level signals observed in the event stream.

--- a/cmd/entire/cli/review/run_test.go
+++ b/cmd/entire/cli/review/run_test.go
@@ -1,0 +1,389 @@
+package review
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+)
+
+// stubReviewer is a test double for reviewtypes.AgentReviewer.
+type stubReviewer struct {
+	name     string
+	events   []reviewtypes.Event
+	waitErr  error
+	startErr error
+}
+
+func (s *stubReviewer) Name() string { return s.name }
+func (s *stubReviewer) Start(_ context.Context, _ reviewtypes.RunConfig) (reviewtypes.Process, error) {
+	if s.startErr != nil {
+		return nil, s.startErr
+	}
+	return &stubProcess{events: s.events, waitErr: s.waitErr}, nil
+}
+
+// Compile-time interface check.
+var _ reviewtypes.AgentReviewer = (*stubReviewer)(nil)
+
+// stubProcess is a test double for reviewtypes.Process.
+type stubProcess struct {
+	events  []reviewtypes.Event
+	waitErr error
+}
+
+func (p *stubProcess) Events() <-chan reviewtypes.Event {
+	out := make(chan reviewtypes.Event, len(p.events))
+	for _, ev := range p.events {
+		out <- ev
+	}
+	close(out)
+	return out
+}
+
+func (p *stubProcess) Wait() error { return p.waitErr }
+
+// Compile-time interface check.
+var _ reviewtypes.Process = (*stubProcess)(nil)
+
+// stubSinkRecorder records every call for assertion.
+type stubSinkRecorder struct {
+	agentEvents   []stubAgentEvent
+	finishedCalls []reviewtypes.RunSummary
+}
+
+type stubAgentEvent struct {
+	agent string
+	ev    reviewtypes.Event
+}
+
+func (r *stubSinkRecorder) AgentEvent(agent string, ev reviewtypes.Event) {
+	r.agentEvents = append(r.agentEvents, stubAgentEvent{agent, ev})
+}
+
+func (r *stubSinkRecorder) RunFinished(summary reviewtypes.RunSummary) {
+	r.finishedCalls = append(r.finishedCalls, summary)
+}
+
+// Compile-time interface check.
+var _ reviewtypes.Sink = (*stubSinkRecorder)(nil)
+
+func TestRun_SuccessfulRun(t *testing.T) {
+	t.Parallel()
+	reviewer := &stubReviewer{
+		name: "claude-code",
+		events: []reviewtypes.Event{
+			reviewtypes.Started{},
+			reviewtypes.AssistantText{Text: "looks good"},
+			reviewtypes.Finished{Success: true},
+		},
+		waitErr: nil,
+	}
+	rec := &stubSinkRecorder{}
+
+	summary, err := Run(context.Background(), reviewer, reviewtypes.RunConfig{}, []reviewtypes.Sink{rec})
+
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if summary.Cancelled {
+		t.Errorf("expected Cancelled=false")
+	}
+	if len(summary.AgentRuns) != 1 {
+		t.Fatalf("expected 1 AgentRun, got %d", len(summary.AgentRuns))
+	}
+	run := summary.AgentRuns[0]
+	if run.Status != reviewtypes.AgentStatusSucceeded {
+		t.Errorf("expected Status=Succeeded, got %v", run.Status)
+	}
+	if len(run.Buffer) != 3 {
+		t.Errorf("expected 3 events in buffer, got %d", len(run.Buffer))
+	}
+	if run.Duration <= 0 {
+		t.Errorf("expected Duration > 0, got %v", run.Duration)
+	}
+}
+
+func TestRun_CancelledRun(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Build a process that cancels the ctx when drained, then returns ctx.Err from Wait.
+	proc := &cancellingProcess{cancel: cancel}
+	reviewer := &funcReviewer{
+		name:    "claude-code",
+		process: proc,
+	}
+
+	summary, err := Run(ctx, reviewer, reviewtypes.RunConfig{}, nil)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got %v", err)
+	}
+	if !summary.Cancelled {
+		t.Errorf("expected summary.Cancelled=true")
+	}
+	if len(summary.AgentRuns) != 1 {
+		t.Fatalf("expected 1 AgentRun, got %d", len(summary.AgentRuns))
+	}
+	if summary.AgentRuns[0].Status != reviewtypes.AgentStatusCancelled {
+		t.Errorf("expected AgentStatusCancelled, got %v", summary.AgentRuns[0].Status)
+	}
+}
+
+// cancellingProcess cancels the context when the Events channel is drained,
+// then returns ctx.Err() from Wait — simulating a signal-killed process.
+type cancellingProcess struct {
+	cancel context.CancelFunc
+}
+
+func (p *cancellingProcess) Events() <-chan reviewtypes.Event {
+	ch := make(chan reviewtypes.Event)
+	close(ch) // no events; draining immediately triggers Wait
+	return ch
+}
+
+func (p *cancellingProcess) Wait() error {
+	p.cancel()
+	return context.Canceled
+}
+
+// Compile-time interface check.
+var _ reviewtypes.Process = (*cancellingProcess)(nil)
+
+// funcReviewer lets tests inject an already-constructed Process.
+type funcReviewer struct {
+	name    string
+	process reviewtypes.Process
+}
+
+func (r *funcReviewer) Name() string { return r.name }
+func (r *funcReviewer) Start(_ context.Context, _ reviewtypes.RunConfig) (reviewtypes.Process, error) {
+	return r.process, nil
+}
+
+// Compile-time interface check.
+var _ reviewtypes.AgentReviewer = (*funcReviewer)(nil)
+
+func TestRun_FailedRun(t *testing.T) {
+	t.Parallel()
+	fakeErr := errors.New("exit status 1")
+	reviewer := &stubReviewer{
+		name: "codex",
+		events: []reviewtypes.Event{
+			reviewtypes.Started{},
+			reviewtypes.Finished{Success: false},
+		},
+		waitErr: fakeErr,
+	}
+	rec := &stubSinkRecorder{}
+
+	summary, err := Run(context.Background(), reviewer, reviewtypes.RunConfig{}, []reviewtypes.Sink{rec})
+
+	if !errors.Is(err, fakeErr) {
+		t.Errorf("expected fakeErr, got %v", err)
+	}
+	if len(summary.AgentRuns) != 1 {
+		t.Fatalf("expected 1 AgentRun, got %d", len(summary.AgentRuns))
+	}
+	if summary.AgentRuns[0].Status != reviewtypes.AgentStatusFailed {
+		t.Errorf("expected AgentStatusFailed, got %v", summary.AgentRuns[0].Status)
+	}
+}
+
+// TestRun_TornStreamCleanExitClassifiedAsFailed pins the orchestrator-level
+// guarantee that a process exiting cleanly (waitErr == nil) but reporting
+// agent-level failure via the event stream (RunError or
+// Finished{Success: false}) is classified as Failed, not Succeeded. This is
+// the upstream complement of the CU3 fix-loop's parser-side scanner.Err
+// handling — the parser emits the right events; this test ensures the
+// orchestrator honors them.
+func TestRun_TornStreamCleanExitClassifiedAsFailed(t *testing.T) {
+	t.Parallel()
+	parserErr := errors.New("read stdout: token too long")
+	reviewer := &stubReviewer{
+		name: "codex",
+		events: []reviewtypes.Event{
+			reviewtypes.Started{},
+			reviewtypes.AssistantText{Text: "partial response before tear..."},
+			reviewtypes.RunError{Err: parserErr},
+			reviewtypes.Finished{Success: false},
+		},
+		waitErr: nil, // process exited 0 despite torn stream
+	}
+	rec := &stubSinkRecorder{}
+
+	summary, err := Run(context.Background(), reviewer, reviewtypes.RunConfig{}, []reviewtypes.Sink{rec})
+	if err != nil {
+		t.Fatalf("expected nil wait-err on clean exit, got %v", err)
+	}
+	if len(summary.AgentRuns) != 1 {
+		t.Fatalf("expected 1 AgentRun, got %d", len(summary.AgentRuns))
+	}
+	if got := summary.AgentRuns[0].Status; got != reviewtypes.AgentStatusFailed {
+		t.Errorf("expected AgentStatusFailed (torn-stream override), got %v", got)
+	}
+}
+
+// TestRun_FinishedFailureCleanExitClassifiedAsFailed covers the case where
+// the parser emitted Finished{Success: false} without a RunError preceding
+// it. The orchestrator must still downgrade the run to Failed.
+func TestRun_FinishedFailureCleanExitClassifiedAsFailed(t *testing.T) {
+	t.Parallel()
+	reviewer := &stubReviewer{
+		name: "codex",
+		events: []reviewtypes.Event{
+			reviewtypes.Started{},
+			reviewtypes.Finished{Success: false},
+		},
+		waitErr: nil,
+	}
+	rec := &stubSinkRecorder{}
+
+	summary, err := Run(context.Background(), reviewer, reviewtypes.RunConfig{}, []reviewtypes.Sink{rec})
+	if err != nil {
+		t.Fatalf("expected nil wait-err, got %v", err)
+	}
+	if got := summary.AgentRuns[0].Status; got != reviewtypes.AgentStatusFailed {
+		t.Errorf("expected AgentStatusFailed (Finished{Success:false} override), got %v", got)
+	}
+}
+
+func TestRun_StartError(t *testing.T) {
+	t.Parallel()
+	startErr := errors.New("binary not on PATH")
+	reviewer := &stubReviewer{
+		name:     "gemini-cli",
+		startErr: startErr,
+	}
+	rec := &stubSinkRecorder{}
+
+	summary, err := Run(context.Background(), reviewer, reviewtypes.RunConfig{}, []reviewtypes.Sink{rec})
+
+	if !errors.Is(err, startErr) {
+		t.Errorf("expected startErr, got %v", err)
+	}
+	if len(summary.AgentRuns) != 1 {
+		t.Fatalf("expected 1 AgentRun, got %d", len(summary.AgentRuns))
+	}
+	run := summary.AgentRuns[0]
+	if run.Status != reviewtypes.AgentStatusFailed {
+		t.Errorf("expected AgentStatusFailed, got %v", run.Status)
+	}
+	if !errors.Is(run.Err, startErr) {
+		t.Errorf("expected run.Err = startErr, got %v", run.Err)
+	}
+	// Sink must still receive RunFinished.
+	if len(rec.finishedCalls) != 1 {
+		t.Errorf("expected 1 RunFinished call to sink, got %d", len(rec.finishedCalls))
+	}
+}
+
+func TestRun_StartErrorWithCancelledCtx(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel BEFORE calling Run
+
+	r := &stubReviewer{
+		name:     "claude-code",
+		startErr: ctx.Err(), // simulate Start observing cancellation
+	}
+	rec := &stubSinkRecorder{}
+
+	summary, err := Run(ctx, r, reviewtypes.RunConfig{}, []reviewtypes.Sink{rec})
+	if err == nil {
+		t.Fatal("expected Run to return the start error")
+	}
+	if len(summary.AgentRuns) != 1 {
+		t.Fatalf("expected 1 AgentRun, got %d", len(summary.AgentRuns))
+	}
+	run := summary.AgentRuns[0]
+	if run.Status != reviewtypes.AgentStatusCancelled {
+		t.Errorf("Status: got %v, want Cancelled", run.Status)
+	}
+	if !summary.Cancelled {
+		t.Error("summary.Cancelled should be true when start error is ctx.Err()")
+	}
+	// Sinks still get RunFinished even on start error.
+	if len(rec.finishedCalls) != 1 {
+		t.Errorf("RunFinished calls: got %d, want 1", len(rec.finishedCalls))
+	}
+}
+
+func TestRun_TokenTracking(t *testing.T) {
+	t.Parallel()
+	// Two Tokens events — second should overwrite, not sum.
+	reviewer := &stubReviewer{
+		name: "claude-code",
+		events: []reviewtypes.Event{
+			reviewtypes.Started{},
+			reviewtypes.Tokens{In: 10, Out: 5},
+			reviewtypes.Tokens{In: 20, Out: 15}, // cumulative; second supersedes first
+			reviewtypes.Finished{Success: true},
+		},
+		waitErr: nil,
+	}
+
+	summary, err := Run(context.Background(), reviewer, reviewtypes.RunConfig{}, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	run := summary.AgentRuns[0]
+	if run.Tokens.In != 20 {
+		t.Errorf("expected Tokens.In=20 (latest), got %d", run.Tokens.In)
+	}
+	if run.Tokens.Out != 15 {
+		t.Errorf("expected Tokens.Out=15 (latest), got %d", run.Tokens.Out)
+	}
+}
+
+func TestRun_SinkFanOut(t *testing.T) {
+	t.Parallel()
+	events := []reviewtypes.Event{
+		reviewtypes.Started{},
+		reviewtypes.AssistantText{Text: "hello"},
+		reviewtypes.Finished{Success: true},
+	}
+	reviewer := &stubReviewer{
+		name:    "claude-code",
+		events:  events,
+		waitErr: nil,
+	}
+	rec1 := &stubSinkRecorder{}
+	rec2 := &stubSinkRecorder{}
+
+	_, err := Run(context.Background(), reviewer, reviewtypes.RunConfig{}, []reviewtypes.Sink{rec1, rec2})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both sinks must receive exactly 3 AgentEvent calls.
+	if len(rec1.agentEvents) != 3 {
+		t.Errorf("sink1: expected 3 AgentEvent calls, got %d", len(rec1.agentEvents))
+	}
+	if len(rec2.agentEvents) != 3 {
+		t.Errorf("sink2: expected 3 AgentEvent calls, got %d", len(rec2.agentEvents))
+	}
+
+	// Both sinks must receive exactly 1 RunFinished call.
+	if len(rec1.finishedCalls) != 1 {
+		t.Errorf("sink1: expected 1 RunFinished call, got %d", len(rec1.finishedCalls))
+	}
+	if len(rec2.finishedCalls) != 1 {
+		t.Errorf("sink2: expected 1 RunFinished call, got %d", len(rec2.finishedCalls))
+	}
+
+	// Both sinks must see events in the same order (serial-dispatch contract).
+	if len(rec1.agentEvents) != len(rec2.agentEvents) {
+		t.Fatalf("sinks disagree on event count: %d vs %d", len(rec1.agentEvents), len(rec2.agentEvents))
+	}
+	for i := range rec1.agentEvents {
+		if rec1.agentEvents[i] != rec2.agentEvents[i] {
+			t.Errorf("sinks disagree at event %d: %v vs %v",
+				i, rec1.agentEvents[i], rec2.agentEvents[i])
+		}
+	}
+}

--- a/cmd/entire/cli/review/run_test.go
+++ b/cmd/entire/cli/review/run_test.go
@@ -215,8 +215,11 @@ func TestRun_TornStreamCleanExitClassifiedAsFailed(t *testing.T) {
 	rec := &stubSinkRecorder{}
 
 	summary, err := Run(context.Background(), reviewer, reviewtypes.RunConfig{}, []reviewtypes.Sink{rec})
-	if err != nil {
-		t.Fatalf("expected nil wait-err on clean exit, got %v", err)
+	if err == nil {
+		t.Fatal("expected parser failure to return an error even when process exits 0")
+	}
+	if !errors.Is(err, parserErr) {
+		t.Fatalf("expected returned error to wrap parserErr, got %v", err)
 	}
 	if len(summary.AgentRuns) != 1 {
 		t.Fatalf("expected 1 AgentRun, got %d", len(summary.AgentRuns))
@@ -242,8 +245,8 @@ func TestRun_FinishedFailureCleanExitClassifiedAsFailed(t *testing.T) {
 	rec := &stubSinkRecorder{}
 
 	summary, err := Run(context.Background(), reviewer, reviewtypes.RunConfig{}, []reviewtypes.Sink{rec})
-	if err != nil {
-		t.Fatalf("expected nil wait-err, got %v", err)
+	if err == nil {
+		t.Fatal("expected Finished{Success:false} to return an error even when process exits 0")
 	}
 	if got := summary.AgentRuns[0].Status; got != reviewtypes.AgentStatusFailed {
 		t.Errorf("expected AgentStatusFailed (Finished{Success:false} override), got %v", got)

--- a/cmd/entire/cli/review/scope.go
+++ b/cmd/entire/cli/review/scope.go
@@ -1,0 +1,418 @@
+// Package review — see env.go for package-level rationale.
+//
+// scope.go implements scope detection for `entire review`. The scope is the
+// git ref the review is bounded by: "commits unique to this branch vs
+// <baseRef>". Pinning the scope at launch time prevents the divergent-default
+// problem where different agents default to different comparison points (e.g.
+// codex used origin/main...HEAD, claude used working-tree-only) on the same
+// invocation.
+package review
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+)
+
+// ScopeStats summarises the scope of a review for the banner.
+type ScopeStats struct {
+	BaseRef       string
+	CurrentBranch string // empty for detached HEAD
+	Commits       int    // commits unique to current branch vs BaseRef
+	FilesChanged  int    // files changed across those commits
+	Uncommitted   int    // uncommitted file changes in the working tree
+}
+
+// formatScopeBanner produces the line printed before agent launch:
+//
+//	"Reviewing feat/X vs main: 3 commits, 7 files changed, 2 uncommitted"
+//
+// Pluralisation: "1 commit" / "2 commits", "1 file" / "N files",
+// always "uncommitted" (a count, not a noun phrase).
+func formatScopeBanner(stats ScopeStats) string {
+	subject := stats.CurrentBranch
+	if subject == "" {
+		subject = "detached HEAD"
+	}
+
+	commitWord := "commits"
+	if stats.Commits == 1 {
+		commitWord = "commit"
+	}
+	fileWord := "files"
+	if stats.FilesChanged == 1 {
+		fileWord = "file"
+	}
+
+	return fmt.Sprintf(
+		"Reviewing %s vs %s: %d %s, %d %s changed, %d uncommitted",
+		subject,
+		stats.BaseRef,
+		stats.Commits,
+		commitWord,
+		stats.FilesChanged,
+		fileWord,
+		stats.Uncommitted,
+	)
+}
+
+// ComputeScopeStats gathers the data formatScopeBanner needs.
+// Used by CU6 to build the banner before launching agents.
+func ComputeScopeStats(ctx context.Context, repo *git.Repository) (ScopeStats, error) {
+	baseRef, err := detectScopeBaseRef(ctx, repo)
+	if err != nil {
+		return ScopeStats{}, fmt.Errorf("detect scope base ref: %w", err)
+	}
+
+	repoRoot, err := repoWorktreePath(repo)
+	if err != nil {
+		return ScopeStats{}, fmt.Errorf("get repo root: %w", err)
+	}
+
+	currentBranch := currentBranchName(repo)
+
+	commits, err := countCommits(ctx, repoRoot, baseRef)
+	if err != nil {
+		return ScopeStats{}, fmt.Errorf("count commits: %w", err)
+	}
+
+	filesChanged, err := countFilesChanged(ctx, repoRoot, baseRef)
+	if err != nil {
+		return ScopeStats{}, fmt.Errorf("count files changed: %w", err)
+	}
+
+	uncommitted, err := countUncommitted(ctx, repoRoot)
+	if err != nil {
+		return ScopeStats{}, fmt.Errorf("count uncommitted: %w", err)
+	}
+
+	return ScopeStats{
+		BaseRef:       baseRef,
+		CurrentBranch: currentBranch,
+		Commits:       commits,
+		FilesChanged:  filesChanged,
+		Uncommitted:   uncommitted,
+	}, nil
+}
+
+// detectScopeBaseRef finds the closest non-self ancestor branch the
+// review should be scoped against. Strategy:
+//
+//  1. Find local + remote branches whose tips are ancestors of HEAD
+//     (i.e., branches the current branch is descended from). Exclude
+//     the current branch itself.
+//  2. Pick the one with the most recent commit timestamp at its tip.
+//     This handles stacked PRs where a feature branches off another
+//     feature: prefer the immediate parent over a more distant one.
+//  3. Fallback chain when no ancestor is found:
+//     origin/HEAD → origin/main → origin/master → main → master
+//  4. If none of those exist either, return an error.
+//
+// Returns the ref name (e.g., "main", "origin/main", "feat/parent")
+// suitable for use in `git diff <ref>...HEAD`.
+func detectScopeBaseRef(ctx context.Context, repo *git.Repository) (string, error) {
+	head, err := repo.Head()
+	if err != nil {
+		return fallbackScopeRef(repo)
+	}
+	headHash := head.Hash()
+
+	// Determine the current branch's symbolic ref name (empty for detached HEAD).
+	currentBranchShort := ""
+	if head.Name().IsBranch() {
+		currentBranchShort = head.Name().Short() // e.g. "feat/x"
+	}
+
+	repoRoot, rootErr := repoWorktreePath(repo)
+	if rootErr != nil {
+		return fallbackScopeRef(repo)
+	}
+
+	// Enumerate ancestor branches in a single git invocation. for-each-ref
+	// --merged HEAD lets git use its commit-graph index to answer "is this
+	// ref an ancestor of HEAD?" in O(1) per ref via packed reachability
+	// rather than the previous O(branches × commits) repo.Log walks.
+	type candidate struct {
+		name    string
+		tipUnix int64
+	}
+	var candidates []candidate
+
+	out, runErr := runGit(ctx, repoRoot,
+		"for-each-ref",
+		"--merged", "HEAD",
+		"--format=%(refname:short)%09%(committerdate:unix)",
+		"refs/heads/", "refs/remotes/",
+	)
+	if runErr != nil {
+		// git for-each-ref unavailable or repo state confused — fall back
+		// to a slow walk via go-git, mirroring the prior behaviour rather
+		// than failing the review launch.
+		return slowDetectScopeBaseRef(ctx, repo, headHash, currentBranchShort)
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		if ctx.Err() != nil {
+			return "", ctx.Err() //nolint:wrapcheck // propagate context cancellation
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := parts[0]
+		// Skip the current branch itself (and its full ref form, both shapes
+		// for-each-ref might emit).
+		if name == currentBranchShort {
+			continue
+		}
+		// Skip refs that resolve to the same commit as HEAD — same hash,
+		// different name (e.g. an unmoved freshly-merged feature).
+		if hash, lookupErr := repo.ResolveRevision(plumbing.Revision(name)); lookupErr == nil && hash != nil && *hash == headHash {
+			continue
+		}
+		unix, parseErr := strconv.ParseInt(parts[1], 10, 64)
+		if parseErr != nil {
+			continue
+		}
+		candidates = append(candidates, candidate{name: name, tipUnix: unix})
+	}
+
+	if len(candidates) > 0 {
+		// Pick the candidate with the most recent tip (closest ancestor).
+		best := candidates[0]
+		for _, c := range candidates[1:] {
+			if c.tipUnix > best.tipUnix {
+				best = c
+			}
+		}
+		return best.name, nil
+	}
+
+	return fallbackScopeRef(repo)
+}
+
+// slowDetectScopeBaseRef is the pre-optimization fallback used only when the
+// `git for-each-ref --merged` shell-out fails. It walks all refs and checks
+// ancestry via repo.Log per ref (O(branches × commits)). Kept as a defense
+// against environments where git CLI is unavailable but go-git can still
+// resolve refs.
+func slowDetectScopeBaseRef(ctx context.Context, repo *git.Repository, headHash plumbing.Hash, currentBranchShort string) (string, error) {
+	refs, err := repo.References()
+	if err != nil {
+		return fallbackScopeRef(repo)
+	}
+
+	type candidate struct {
+		name    string
+		tipTime time.Time
+	}
+	var candidates []candidate
+
+	_ = refs.ForEach(func(ref *plumbing.Reference) error { //nolint:errcheck // best-effort search
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !ref.Name().IsBranch() && !ref.Name().IsRemote() {
+			return nil
+		}
+		if ref.Name().Short() == currentBranchShort {
+			return nil
+		}
+		tipHash := ref.Hash()
+		if tipHash == headHash {
+			return nil
+		}
+		isAnc, ancErr := isAncestorOf(ctx, repo, tipHash, headHash)
+		if ancErr != nil {
+			return nil //nolint:nilerr // best-effort: skip unresolvable refs
+		}
+		if !isAnc {
+			return nil
+		}
+		commit, cErr := repo.CommitObject(tipHash)
+		if cErr != nil {
+			return nil //nolint:nilerr // best-effort: skip refs with no commit object
+		}
+		candidates = append(candidates, candidate{
+			name:    ref.Name().Short(),
+			tipTime: commit.Committer.When,
+		})
+		return nil
+	})
+	if ctx.Err() != nil {
+		return "", ctx.Err() //nolint:wrapcheck // propagate context cancellation
+	}
+	if len(candidates) > 0 {
+		best := candidates[0]
+		for _, c := range candidates[1:] {
+			if c.tipTime.After(best.tipTime) {
+				best = c
+			}
+		}
+		return best.name, nil
+	}
+	return fallbackScopeRef(repo)
+}
+
+// repoWorktreePath returns the working-tree path for repo, or an error if the
+// repo is bare or its worktree can't be resolved. detectScopeBaseRef needs
+// this to invoke `git for-each-ref` with the right working directory.
+func repoWorktreePath(repo *git.Repository) (string, error) {
+	wt, err := repo.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree: %w", err)
+	}
+	return wt.Filesystem.Root(), nil
+}
+
+// fallbackScopeRef returns the first existing ref from the fallback chain:
+// origin/HEAD → origin/main → origin/master → main → master.
+// Returns an error if none exist.
+func fallbackScopeRef(repo *git.Repository) (string, error) {
+	chain := []string{"origin/HEAD", "origin/main", "origin/master", "main", "master"}
+	for _, name := range chain {
+		if refExists(repo, name) {
+			return name, nil
+		}
+	}
+	return "", errors.New("no suitable ancestor branch found; configure a base ref explicitly")
+}
+
+// refExists reports whether a ref with the given short name exists in repo.
+func refExists(repo *git.Repository, shortName string) bool {
+	refs, err := repo.References()
+	if err != nil {
+		return false
+	}
+	found := false
+	_ = refs.ForEach(func(ref *plumbing.Reference) error { //nolint:errcheck // best-effort search
+		if ref.Name().Short() == shortName {
+			found = true
+			return storer.ErrStop
+		}
+		return nil
+	})
+	return found
+}
+
+// isAncestorOf checks if candidate is an ancestor of (or equal to) target
+// by walking the commit graph from target backwards.
+func isAncestorOf(ctx context.Context, repo *git.Repository, candidate, target plumbing.Hash) (bool, error) {
+	if candidate == target {
+		return true, nil
+	}
+
+	iter, err := repo.Log(&git.LogOptions{From: target})
+	if err != nil {
+		return false, fmt.Errorf("log from target: %w", err)
+	}
+	defer iter.Close()
+
+	found := false
+	_ = iter.ForEach(func(c *object.Commit) error { //nolint:errcheck // storer.ErrStop is expected
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if c.Hash == candidate {
+			found = true
+			return storer.ErrStop
+		}
+		return nil
+	})
+	// Context cancellation: surface. storer.ErrStop or log exhaustion: ignore.
+	if ctx.Err() != nil {
+		return false, ctx.Err() //nolint:wrapcheck // propagate context cancellation
+	}
+	return found, nil
+}
+
+// currentBranchName returns the short branch name for the current HEAD,
+// or "" for detached HEAD.
+func currentBranchName(repo *git.Repository) string {
+	head, err := repo.Head()
+	if err != nil {
+		return ""
+	}
+	if !head.Name().IsBranch() {
+		return "" // detached HEAD
+	}
+	return head.Name().Short()
+}
+
+// countCommits returns the number of commits in <baseRef>..HEAD
+// (commits on the current branch not in baseRef).
+func countCommits(ctx context.Context, repoRoot, baseRef string) (int, error) {
+	out, err := runGit(ctx, repoRoot, "rev-list", "--count", baseRef+"..HEAD")
+	if err != nil {
+		return 0, err
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("parse commit count: %w", err)
+	}
+	return n, nil
+}
+
+// countFilesChanged returns the number of unique files changed in <baseRef>..HEAD.
+func countFilesChanged(ctx context.Context, repoRoot, baseRef string) (int, error) {
+	out, err := runGit(ctx, repoRoot, "diff", "--name-only", baseRef+"..HEAD")
+	if err != nil {
+		return 0, err
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return 0, nil
+	}
+	return len(strings.Split(trimmed, "\n")), nil
+}
+
+// countUncommitted returns the number of lines in `git status --porcelain`
+// (each line corresponds to one changed or untracked file).
+func countUncommitted(ctx context.Context, repoRoot string) (int, error) {
+	out, err := runGit(ctx, repoRoot, "status", "--porcelain")
+	if err != nil {
+		return 0, err
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return 0, nil
+	}
+	return len(strings.Split(trimmed, "\n")), nil
+}
+
+// runGit runs `git <args>` in repoDir and returns stdout as a string.
+// stderr is captured separately and surfaced in the error wrap on non-zero
+// exit. Stdout and stderr are NOT combined — git emits warnings on stderr
+// even on successful commands (shallow-clone notices, safe.directory
+// advisories, etc.) and merging them would corrupt parsed output (e.g.,
+// strconv.Atoi on the result of `rev-list --count` would fail).
+func runGit(ctx context.Context, repoRoot string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = repoRoot
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		// Surface stderr so callers see why git rejected the command,
+		// not just "exit status 128".
+		stderrTxt := strings.TrimSpace(stderr.String())
+		if stderrTxt != "" {
+			return "", fmt.Errorf("git %s: %w (stderr: %s)", args[0], err, stderrTxt)
+		}
+		return "", fmt.Errorf("git %s: %w", args[0], err)
+	}
+	return string(out), nil
+}

--- a/cmd/entire/cli/review/scope_test.go
+++ b/cmd/entire/cli/review/scope_test.go
@@ -1,0 +1,433 @@
+package review
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// defaultBranchName is the normalised default branch name used by initRepoOnMain.
+const defaultBranchName = "main"
+
+// openTestRepo opens a go-git repository from a directory.
+func openTestRepo(t *testing.T, dir string) *git.Repository {
+	t.Helper()
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("PlainOpen(%s): %v", dir, err)
+	}
+	return repo
+}
+
+// commitFile creates, stages, and commits a new file in dir.
+func commitFile(t *testing.T, dir, filename, content, message string) {
+	t.Helper()
+	testutil.WriteFile(t, dir, filename, content)
+	testutil.GitAdd(t, dir, filename)
+	testutil.GitCommit(t, dir, message)
+}
+
+// initRepoOnMain initializes a repo and ensures the default branch is "main".
+// go-git's PlainInit creates "master" regardless of the host's
+// init.defaultBranch setting; this helper normalises tests across environments
+// by renaming via git CLI before the first commit.
+func initRepoOnMain(t *testing.T, dir string) {
+	t.Helper()
+	testutil.InitRepo(t, dir)
+	// Rename whatever go-git created (master) to "main". Works before any commits.
+	//nolint:noctx // test helper
+	cmd := exec.Command("git", "symbolic-ref", "HEAD", "refs/heads/main")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("set HEAD to main: %v\n%s", err, out)
+	}
+}
+
+// TestFormatScopeBanner_Pluralisation verifies plural/singular forms.
+func TestFormatScopeBanner_Pluralisation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		stats ScopeStats
+		want  string
+	}{
+		{
+			name: "singular commit and file",
+			stats: ScopeStats{
+				CurrentBranch: "feat/x",
+				BaseRef:       defaultBranchName,
+				Commits:       1,
+				FilesChanged:  1,
+				Uncommitted:   0,
+			},
+			want: "Reviewing feat/x vs main: 1 commit, 1 file changed, 0 uncommitted",
+		},
+		{
+			name: "plural commits and files",
+			stats: ScopeStats{
+				CurrentBranch: "feat/y",
+				BaseRef:       defaultBranchName,
+				Commits:       3,
+				FilesChanged:  7,
+				Uncommitted:   2,
+			},
+			want: "Reviewing feat/y vs main: 3 commits, 7 files changed, 2 uncommitted",
+		},
+		{
+			name: "zero commits and files (plural for zero)",
+			stats: ScopeStats{
+				CurrentBranch: defaultBranchName,
+				BaseRef:       defaultBranchName,
+				Commits:       0,
+				FilesChanged:  0,
+				Uncommitted:   0,
+			},
+			want: "Reviewing main vs main: 0 commits, 0 files changed, 0 uncommitted",
+		},
+		{
+			name: "detached HEAD",
+			stats: ScopeStats{
+				CurrentBranch: "",
+				BaseRef:       defaultBranchName,
+				Commits:       3,
+				FilesChanged:  2,
+				Uncommitted:   1,
+			},
+			want: "Reviewing detached HEAD vs main: 3 commits, 2 files changed, 1 uncommitted",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatScopeBanner(tc.stats)
+			if got != tc.want {
+				t.Errorf("formatScopeBanner() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsAncestorOf tests the isAncestorOf helper with a real temp repo.
+func TestIsAncestorOf(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	initRepoOnMain(t, dir)
+
+	commitFile(t, dir, "a.go", "package main", "commit A")
+	hashAStr := testutil.GetHeadHash(t, dir)
+
+	commitFile(t, dir, "b.go", "package main", "commit B")
+	hashBStr := testutil.GetHeadHash(t, dir)
+
+	repo := openTestRepo(t, dir)
+	ctx := context.Background()
+
+	hashA := plumbing.NewHash(hashAStr)
+	hashB := plumbing.NewHash(hashBStr)
+
+	// A is an ancestor of B.
+	isAnc, err := isAncestorOf(ctx, repo, hashA, hashB)
+	if err != nil {
+		t.Fatalf("isAncestorOf(A, B): %v", err)
+	}
+	if !isAnc {
+		t.Error("A should be ancestor of B")
+	}
+
+	// B is NOT an ancestor of A.
+	isAnc, err = isAncestorOf(ctx, repo, hashB, hashA)
+	if err != nil {
+		t.Fatalf("isAncestorOf(B, A): %v", err)
+	}
+	if isAnc {
+		t.Error("B should not be ancestor of A")
+	}
+
+	// A is its own ancestor (equal hashes → true).
+	isAnc, err = isAncestorOf(ctx, repo, hashA, hashA)
+	if err != nil {
+		t.Fatalf("isAncestorOf(A, A): %v", err)
+	}
+	if !isAnc {
+		t.Error("A should be ancestor of itself (equal)")
+	}
+}
+
+// TestDetectScopeBaseRef_BranchOffMain checks that a feature branch off main
+// returns "main" and the commit/file counts are correct.
+// Cannot use t.Parallel because it modifies disk state.
+func TestDetectScopeBaseRef_BranchOffMain(t *testing.T) {
+	dir := t.TempDir()
+	initRepoOnMain(t, dir)
+
+	// Create initial commit on main.
+	commitFile(t, dir, "README.md", "hello", "init")
+
+	// Create feat/x with 3 commits.
+	testutil.GitCheckoutNewBranch(t, dir, "feat/x")
+	commitFile(t, dir, "a.go", "package main", "add a.go")
+	commitFile(t, dir, "b.go", "package main", "add b.go")
+	commitFile(t, dir, "c.go", "package main", "add c.go")
+
+	ctx := context.Background()
+	repo := openTestRepo(t, dir)
+
+	baseRef, err := detectScopeBaseRef(ctx, repo)
+	if err != nil {
+		t.Fatalf("detectScopeBaseRef: %v", err)
+	}
+	if baseRef != defaultBranchName {
+		t.Errorf("baseRef = %q, want %q", baseRef, defaultBranchName)
+	}
+
+	// Verify commit count.
+	commits, err := countCommits(ctx, dir, baseRef)
+	if err != nil {
+		t.Fatalf("countCommits: %v", err)
+	}
+	if commits != 3 {
+		t.Errorf("commits = %d, want 3", commits)
+	}
+
+	// Verify files changed count.
+	filesChanged, err := countFilesChanged(ctx, dir, baseRef)
+	if err != nil {
+		t.Fatalf("countFilesChanged: %v", err)
+	}
+	if filesChanged != 3 {
+		t.Errorf("filesChanged = %d, want 3", filesChanged)
+	}
+}
+
+// TestDetectScopeBaseRef_ClosestAncestorPreferred verifies that a branch
+// stacked on top of another feature branch returns the immediate parent
+// (more recent tip), not the more distant main.
+// Cannot use t.Parallel because it modifies the repo state.
+func TestDetectScopeBaseRef_ClosestAncestorPreferred(t *testing.T) {
+	dir := t.TempDir()
+	initRepoOnMain(t, dir)
+
+	// main: one initial commit.
+	commitFile(t, dir, "root.go", "package main", "init")
+
+	// feat/parent: one commit off main.
+	testutil.GitCheckoutNewBranch(t, dir, "feat/parent")
+	commitFile(t, dir, "parent.go", "package main", "parent commit")
+
+	// feat/child: two commits off feat/parent.
+	testutil.GitCheckoutNewBranch(t, dir, "feat/child")
+	commitFile(t, dir, "child1.go", "package main", "child commit 1")
+	commitFile(t, dir, "child2.go", "package main", "child commit 2")
+
+	ctx := context.Background()
+	repo := openTestRepo(t, dir)
+
+	baseRef, err := detectScopeBaseRef(ctx, repo)
+	if err != nil {
+		t.Fatalf("detectScopeBaseRef: %v", err)
+	}
+	// feat/parent has the most recent tip among ancestors of feat/child.
+	if baseRef != "feat/parent" {
+		t.Errorf("baseRef = %q, want %q", baseRef, "feat/parent")
+	}
+}
+
+// TestDetectScopeBaseRef_DetachedHEAD verifies that detached HEAD falls
+// back to the fallback chain.
+// Cannot use t.Parallel because it modifies the repo state.
+func TestDetectScopeBaseRef_DetachedHEAD(t *testing.T) {
+	dir := t.TempDir()
+	initRepoOnMain(t, dir)
+
+	// Commit so we have a detachable commit.
+	commitFile(t, dir, "file.go", "package main", "init")
+	headSHA := testutil.GetHeadHash(t, dir)
+
+	// Detach HEAD by checking out the SHA directly.
+	//nolint:noctx // test helper
+	cmd := exec.Command("git", "checkout", "--detach", headSHA)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("detach HEAD: %v\n%s", err, out)
+	}
+
+	ctx := context.Background()
+	repo := openTestRepo(t, dir)
+
+	baseRef, err := detectScopeBaseRef(ctx, repo)
+	if err != nil {
+		t.Fatalf("detectScopeBaseRef: %v", err)
+	}
+	// With no ancestor branches (detached HEAD, no origin), falls back to "main".
+	if baseRef != defaultBranchName {
+		t.Errorf("baseRef = %q, want one of the fallback refs (e.g. %s)", baseRef, defaultBranchName)
+	}
+
+	// Banner should show "detached HEAD".
+	stats := ScopeStats{
+		BaseRef:       baseRef,
+		CurrentBranch: "",
+		Commits:       0,
+		FilesChanged:  0,
+		Uncommitted:   0,
+	}
+	banner := formatScopeBanner(stats)
+	if !strings.Contains(banner, "detached HEAD") {
+		t.Errorf("banner %q does not mention 'detached HEAD'", banner)
+	}
+}
+
+// TestDetectScopeBaseRef_CleanDefaultBranch verifies that checking out main
+// produces 0 commits vs itself.
+// Cannot use t.Parallel because it modifies the repo state.
+func TestDetectScopeBaseRef_CleanDefaultBranch(t *testing.T) {
+	dir := t.TempDir()
+	initRepoOnMain(t, dir)
+
+	// Single commit on main.
+	commitFile(t, dir, "file.go", "package main", "init")
+
+	ctx := context.Background()
+	repo := openTestRepo(t, dir)
+
+	baseRef, err := detectScopeBaseRef(ctx, repo)
+	if err != nil {
+		t.Fatalf("detectScopeBaseRef: %v", err)
+	}
+
+	commits, err := countCommits(ctx, dir, baseRef)
+	if err != nil {
+		t.Fatalf("countCommits: %v", err)
+	}
+	if commits != 0 {
+		t.Errorf("commits = %d, want 0 (main vs itself)", commits)
+	}
+
+	stats := ScopeStats{
+		BaseRef:       baseRef,
+		CurrentBranch: currentBranchName(repo),
+		Commits:       commits,
+		FilesChanged:  0,
+		Uncommitted:   0,
+	}
+	banner := formatScopeBanner(stats)
+	wantBanner := "Reviewing main vs main: 0 commits, 0 files changed, 0 uncommitted"
+	if banner != wantBanner {
+		t.Errorf("banner = %q, want %q", banner, wantBanner)
+	}
+}
+
+// TestDetectScopeBaseRef_UncommittedChanges verifies that uncommitted file
+// changes are counted correctly.
+// Cannot use t.Parallel because it modifies disk state.
+func TestDetectScopeBaseRef_UncommittedChanges(t *testing.T) {
+	dir := t.TempDir()
+	initRepoOnMain(t, dir)
+
+	// Initial commit on main.
+	commitFile(t, dir, "tracked.go", "package main", "init")
+
+	// Branch off main.
+	testutil.GitCheckoutNewBranch(t, dir, "feat/dirty")
+
+	// Modify a tracked file (not committed).
+	testutil.WriteFile(t, dir, "tracked.go", "package main\n// modified")
+	// Add an untracked file.
+	testutil.WriteFile(t, dir, "untracked.go", "package main")
+
+	ctx := context.Background()
+
+	uncommitted, err := countUncommitted(ctx, dir)
+	if err != nil {
+		t.Fatalf("countUncommitted: %v", err)
+	}
+	if uncommitted != 2 {
+		t.Errorf("uncommitted = %d, want 2 (1 modified tracked + 1 untracked)", uncommitted)
+	}
+}
+
+// TestDetectScopeBaseRef_NoSuitableAncestor verifies that a fresh repo with
+// no main/master/origin returns an error.
+// Cannot use t.Parallel because it modifies the repo state.
+func TestDetectScopeBaseRef_NoSuitableAncestor(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir) // intentionally NOT initRepoOnMain — we rename below
+
+	// Commit so HEAD resolves (git init sets default branch to "master" or "main").
+	commitFile(t, dir, "file.go", "package main", "init")
+
+	// Determine which default branch was created.
+	//nolint:noctx // test helper
+	branchOut, err := exec.Command("git", "-C", dir, "branch", "--show-current").Output()
+	if err != nil {
+		t.Fatalf("get current branch: %v", err)
+	}
+	defaultBranch := strings.TrimSpace(string(branchOut))
+
+	// Rename default branch to a non-fallback name so detectScopeBaseRef
+	// cannot resolve any fallback.
+	//nolint:noctx // test helper
+	cmd := exec.Command("git", "branch", "-m", defaultBranch, "custom-branch")
+	cmd.Dir = dir
+	if out, cmdErr := cmd.CombinedOutput(); cmdErr != nil {
+		t.Fatalf("rename branch: %v\n%s", cmdErr, out)
+	}
+
+	ctx := context.Background()
+
+	// Re-open repo after rename.
+	repo := openTestRepo(t, dir)
+
+	_, detectErr := detectScopeBaseRef(ctx, repo)
+	if detectErr == nil {
+		t.Error("expected error when no suitable ancestor branch exists, got nil")
+	}
+}
+
+// TestComputeScopeStats_Integration verifies the full ComputeScopeStats
+// function produces consistent results.
+// Cannot use t.Parallel because it modifies the filesystem.
+func TestComputeScopeStats_Integration(t *testing.T) {
+	dir := t.TempDir()
+	initRepoOnMain(t, dir)
+
+	// main: one commit.
+	commitFile(t, dir, "main.go", "package main", "init")
+
+	// feat/stats: 2 commits.
+	testutil.GitCheckoutNewBranch(t, dir, "feat/stats")
+	commitFile(t, dir, "x.go", "package main", "add x")
+	commitFile(t, dir, "y.go", "package main", "add y")
+
+	ctx := context.Background()
+	repo := openTestRepo(t, dir)
+
+	stats, err := ComputeScopeStats(ctx, repo)
+	if err != nil {
+		t.Fatalf("ComputeScopeStats: %v", err)
+	}
+
+	if stats.BaseRef != defaultBranchName {
+		t.Errorf("BaseRef = %q, want %q", stats.BaseRef, defaultBranchName)
+	}
+	if stats.CurrentBranch != "feat/stats" {
+		t.Errorf("CurrentBranch = %q, want %q", stats.CurrentBranch, "feat/stats")
+	}
+	if stats.Commits != 2 {
+		t.Errorf("Commits = %d, want 2", stats.Commits)
+	}
+	if stats.FilesChanged != 2 {
+		t.Errorf("FilesChanged = %d, want 2", stats.FilesChanged)
+	}
+	if stats.Uncommitted != 0 {
+		t.Errorf("Uncommitted = %d, want 0", stats.Uncommitted)
+	}
+}

--- a/cmd/entire/cli/review/types/reviewer.go
+++ b/cmd/entire/cli/review/types/reviewer.go
@@ -52,7 +52,7 @@ type Process interface {
 	// Wait blocks until the process exits and returns:
 	//   - nil on clean exit (exit code 0)
 	//   - ctx.Err() on cancellation
-	//   - *exec.ExitError on non-zero exit
+	//   - an error wrapping *exec.ExitError on non-zero exit
 	//   - other error types for I/O or pipe failures
 	//
 	// Wait must be called exactly once per Process. It is safe to call Wait

--- a/cmd/entire/cli/review/types/sink.go
+++ b/cmd/entire/cli/review/types/sink.go
@@ -1,0 +1,96 @@
+// Package types — see reviewer.go for package-level rationale.
+//
+// sink.go defines the consumer-side abstractions for review runs:
+// Sink (event consumer interface), RunSummary (post-run record),
+// AgentRun (per-agent post-run data), and AgentStatus (terminal state enum).
+package types
+
+import "time"
+
+// Sink consumes events from a review run. Sinks are passed to the
+// orchestrator at construction time; selecting which sinks compose
+// is the caller's job (TUI vs. non-TTY, synthesis on/off).
+//
+// Concurrency: AgentEvent and RunFinished are guaranteed to be invoked
+// from a single goroutine — the orchestrator serializes calls even under
+// multi-agent runs (CU8 fans events from N agents into one dispatch
+// loop). Sinks need not internally synchronize.
+//
+// Sinks MUST NOT block. AgentEvent runs on the dispatch goroutine; a
+// slow sink stalls the entire run and starves all other sinks.
+type Sink interface {
+	// AgentEvent is called for every event emitted by an agent's
+	// process during the run. Events are delivered in-order within a
+	// single agent; across agents (CU8 multi-agent) the orchestrator
+	// serializes calls so sinks see one event at a time.
+	AgentEvent(agent string, ev Event)
+
+	// RunFinished is called once when the run terminates (cleanly,
+	// failed, or cancelled). Sinks that only act post-run (DumpSink,
+	// synthesis sink) implement only this method (with a no-op
+	// AgentEvent).
+	RunFinished(summary RunSummary)
+}
+
+// RunSummary is the post-run record passed to all sinks.
+type RunSummary struct {
+	StartedAt  time.Time
+	FinishedAt time.Time
+
+	// Cancelled is true iff the orchestrator's run context was cancelled
+	// during the run (or before it started). For single-agent runs this
+	// is equivalent to AgentRuns[0].Status == AgentStatusCancelled. Under
+	// multi-agent runs (CU8), Cancelled means "the run as a whole was
+	// cancelled" — individual AgentRuns may have other terminal states
+	// if they finished before cancellation propagated.
+	Cancelled bool
+
+	AgentRuns []AgentRun
+}
+
+// AgentRun is per-agent post-run data.
+type AgentRun struct {
+	Name   string
+	Status AgentStatus
+	Tokens Tokens
+
+	// Buffer accumulates the full event log per agent for post-hoc
+	// rendering (DumpSink, TUI dump, synthesis).
+	//
+	// TODO(memory): At review lengths typical today (~100s of events,
+	// ~few KB) this is fine. If profiling shows reviews regularly
+	// exceed ~10MB of buffered events or ~10000 events, swap to a
+	// token-budgeted ring or stream events to sinks incrementally
+	// and drop the buffer.
+	Buffer []Event
+
+	StartedAt time.Time
+	Duration  time.Duration
+	Err       error
+}
+
+// AgentStatus is the terminal state for an agent.
+type AgentStatus int
+
+const (
+	AgentStatusUnknown AgentStatus = iota
+	AgentStatusSucceeded
+	AgentStatusFailed
+	AgentStatusCancelled
+)
+
+// String returns a human-readable status (used in dump output and TUI).
+func (s AgentStatus) String() string {
+	switch s {
+	case AgentStatusUnknown:
+		return "unknown"
+	case AgentStatusSucceeded:
+		return "succeeded"
+	case AgentStatusFailed:
+		return "failed"
+	case AgentStatusCancelled:
+		return "cancelled"
+	default:
+		return "unknown"
+	}
+}

--- a/cmd/entire/cli/review/types/sink_test.go
+++ b/cmd/entire/cli/review/types/sink_test.go
@@ -1,0 +1,68 @@
+package types
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAgentStatus_String(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		status AgentStatus
+		want   string
+	}{
+		{AgentStatusSucceeded, "succeeded"},
+		{AgentStatusFailed, "failed"},
+		{AgentStatusCancelled, "cancelled"},
+		{AgentStatusUnknown, "unknown"},
+		{AgentStatus(99), "unknown"}, // any unrecognised value falls to default
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.status.String(); got != tc.want {
+				t.Errorf("AgentStatus(%d).String() = %q, want %q", int(tc.status), got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunSummary_ZeroValueIsValid(t *testing.T) {
+	t.Parallel()
+	// Zero value should be usable without any constructor — mirrors
+	// TestRunConfigZeroValueIsValid in reviewer_test.go.
+	var s RunSummary
+	if s.AgentRuns != nil {
+		t.Errorf("zero RunSummary.AgentRuns should be nil, got %v", s.AgentRuns)
+	}
+	if !s.StartedAt.IsZero() {
+		t.Errorf("zero RunSummary.StartedAt should be zero time, got %v", s.StartedAt)
+	}
+	if !s.FinishedAt.IsZero() {
+		t.Errorf("zero RunSummary.FinishedAt should be zero time, got %v", s.FinishedAt)
+	}
+	if s.Cancelled {
+		t.Errorf("zero RunSummary.Cancelled should be false")
+	}
+}
+
+// stubSink is a minimal Sink used only for the compile-time check below.
+type stubSink struct{}
+
+func (stubSink) AgentEvent(_ string, _ Event) {}
+func (stubSink) RunFinished(_ RunSummary)     {}
+
+// Compile-time assertion: stubSink must satisfy Sink.
+var _ Sink = stubSink{}
+
+func TestSinkInterface_CompileTimeCheck(t *testing.T) {
+	t.Parallel()
+	// The var _ declaration above is the real check; this test ensures the
+	// file is compiled (and keeps the stub from being dead code in tests).
+	var s Sink = stubSink{}
+	s.AgentEvent("agent", Started{})
+	s.RunFinished(RunSummary{
+		StartedAt:  time.Now(),
+		FinishedAt: time.Now(),
+	})
+}

--- a/cmd/entire/cli/review/types/template.go
+++ b/cmd/entire/cli/review/types/template.go
@@ -120,10 +120,10 @@ func (p *templateProcess) Events() <-chan Event { return p.events }
 // with stderr; other types for I/O or pipe failures. ProcessError implements
 // Unwrap so callers can use errors.As and errors.Is to classify.
 func (p *templateProcess) Wait() error {
-	err := p.cmd.Wait()
 	if p.stderrDone != nil {
 		<-p.stderrDone
 	}
+	err := p.cmd.Wait()
 	if err != nil && p.ctx.Err() != nil {
 		return p.ctx.Err() //nolint:wrapcheck // preserve Process cancellation contract
 	}

--- a/cmd/entire/cli/review/types/template.go
+++ b/cmd/entire/cli/review/types/template.go
@@ -17,7 +17,10 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 )
+
+const maxProcessStderrBytes = 64 * 1024
 
 // ReviewerTemplate implements AgentReviewer for agents whose only per-agent
 // quirks are argv/env construction and stdout parsing. Both fields must be
@@ -70,11 +73,23 @@ func (t *ReviewerTemplate) Start(ctx context.Context, cfg RunConfig) (Process, e
 	if err != nil {
 		return nil, fmt.Errorf("%s: stdout pipe: %w", t.AgentName, err)
 	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("%s: stderr pipe: %w", t.AgentName, err)
+	}
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("%s: start: %w", t.AgentName, err)
 	}
-	p := &templateProcess{cmd: cmd, events: make(chan Event, 32)}
+	p := &templateProcess{
+		ctx:        ctx,
+		agentName:  t.AgentName,
+		cmd:        cmd,
+		events:     make(chan Event, 32),
+		stderr:     &boundedStderrBuffer{limit: maxProcessStderrBytes},
+		stderrDone: make(chan struct{}),
+	}
 	go p.run(stdout, t.Parser)
+	go p.captureStderr(stderr)
 	return p, nil
 }
 
@@ -87,21 +102,37 @@ var ErrTemplateMisconfigured = errors.New("ReviewerTemplate misconfigured")
 
 // templateProcess is the shared Process implementation for ReviewerTemplate.
 type templateProcess struct {
-	cmd    *exec.Cmd
-	events chan Event
+	ctx        context.Context
+	agentName  string
+	cmd        *exec.Cmd
+	events     chan Event
+	stderr     *boundedStderrBuffer
+	stderrDone chan struct{}
 }
 
 // Events returns the channel that streams parsed events from the agent process.
 func (p *templateProcess) Events() <-chan Event { return p.events }
 
-// Wait returns the agent process's exit error.
+// Wait returns the agent process's exit error with bounded stderr diagnostics.
 //
 // Per CU2's Process contract: nil on clean exit (exit code 0); ctx.Err()
-// on cancellation; *exec.ExitError on non-zero exit; other types for I/O
-// or pipe failures. The error type is preserved (not wrapped) so callers
-// can use errors.As and errors.Is to classify.
+// on cancellation; ProcessError wrapping *exec.ExitError on non-zero exit
+// with stderr; other types for I/O or pipe failures. ProcessError implements
+// Unwrap so callers can use errors.As and errors.Is to classify.
 func (p *templateProcess) Wait() error {
-	return p.cmd.Wait() //nolint:wrapcheck // interface boundary; classifyStatus needs raw type
+	err := p.cmd.Wait()
+	if p.stderrDone != nil {
+		<-p.stderrDone
+	}
+	if err != nil && p.ctx.Err() != nil {
+		return p.ctx.Err() //nolint:wrapcheck // preserve Process cancellation contract
+	}
+	if err != nil {
+		if stderr := p.stderr.String(); stderr != "" {
+			return &ProcessError{AgentName: p.agentName, Err: err, Stderr: stderr}
+		}
+	}
+	return err //nolint:wrapcheck // interface boundary; classifyStatus needs raw type
 }
 
 func (p *templateProcess) run(stdout io.Reader, parser func(io.Reader) <-chan Event) {
@@ -109,4 +140,63 @@ func (p *templateProcess) run(stdout io.Reader, parser func(io.Reader) <-chan Ev
 	for ev := range parser(stdout) {
 		p.events <- ev
 	}
+}
+
+func (p *templateProcess) captureStderr(stderr io.Reader) {
+	defer close(p.stderrDone)
+	_, _ = io.Copy(p.stderr, stderr) //nolint:errcheck // stderr is best-effort diagnostic context
+}
+
+// ProcessError wraps a process failure with bounded stderr diagnostics.
+// Unwrap preserves the underlying error, so callers can still use errors.As
+// for *exec.ExitError or errors.Is for lower-level sentinels.
+type ProcessError struct {
+	AgentName string
+	Err       error
+	Stderr    string
+}
+
+func (e *ProcessError) Error() string {
+	if e.Stderr == "" {
+		return fmt.Sprintf("%s: %v", e.AgentName, e.Err)
+	}
+	return fmt.Sprintf("%s: %v: stderr: %s", e.AgentName, e.Err, e.Stderr)
+}
+
+func (e *ProcessError) Unwrap() error { return e.Err }
+
+type boundedStderrBuffer struct {
+	limit     int
+	buf       []byte
+	truncated bool
+}
+
+func (b *boundedStderrBuffer) Write(p []byte) (int, error) {
+	if b.limit <= 0 {
+		b.truncated = true
+		return len(p), nil
+	}
+	remaining := b.limit - len(b.buf)
+	if remaining > 0 {
+		if len(p) <= remaining {
+			b.buf = append(b.buf, p...)
+		} else {
+			b.buf = append(b.buf, p[:remaining]...)
+			b.truncated = true
+		}
+	} else if len(p) > 0 {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *boundedStderrBuffer) String() string {
+	out := strings.TrimSpace(string(b.buf))
+	if out == "" {
+		return ""
+	}
+	if b.truncated {
+		return out + "\n[stderr truncated]"
+	}
+	return out
 }

--- a/cmd/entire/cli/review/types/template.go
+++ b/cmd/entire/cli/review/types/template.go
@@ -1,0 +1,112 @@
+// Package types — see reviewer.go for package-level rationale.
+//
+// template.go provides ReviewerTemplate, a struct that implements
+// AgentReviewer using two caller-supplied functions: BuildCmd (per-agent
+// argv/env construction) and Parser (per-agent stdout-to-Event stream).
+//
+// All three currently-supported agents (claude-code, codex, gemini-cli)
+// share the Start/Process/Wait/Events scaffolding. Only the build-cmd
+// step and the stdout parser genuinely differ. The template owns the
+// shared lifecycle (spawn → pipe stdout → run parser → forward events
+// → close on exit); each agent supplies the two unique pieces.
+package types
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+// ReviewerTemplate implements AgentReviewer for agents whose only per-agent
+// quirks are argv/env construction and stdout parsing. Both fields must be
+// set before Start is called; nil values cause Start to panic immediately.
+type ReviewerTemplate struct {
+	// AgentName is returned by Name(). Stable identifier per agent.
+	AgentName string
+
+	// BuildCmd constructs the *exec.Cmd to spawn the agent process,
+	// including argv, stdin (if any), and ENTIRE_REVIEW_* env vars.
+	// The command MUST NOT have started yet; the template will call Start.
+	BuildCmd func(ctx context.Context, cfg RunConfig) *exec.Cmd
+
+	// Parser converts the agent's stdout stream into a sequence of Events.
+	// The returned channel must close when stdout closes. Implementations
+	// must emit Started first, Finished{Success: ...} or RunError last,
+	// and check scanner.Err() before emitting Finished{Success: true}.
+	Parser func(stdout io.Reader) <-chan Event
+}
+
+// Compile-time check.
+var _ AgentReviewer = (*ReviewerTemplate)(nil)
+
+// Name returns the agent's stable identifier.
+func (t *ReviewerTemplate) Name() string { return t.AgentName }
+
+// Start spawns the agent process, wires stdout through the parser, and
+// returns a Process whose Events channel streams the parsed event sequence.
+//
+// Returns ErrTemplateMisconfigured if AgentName, BuildCmd, or Parser is unset,
+// or if BuildCmd returns nil. These are programmer errors but failing fast
+// with a typed error is friendlier than a downstream nil deref — and it
+// keeps Start from panicking inside a multi-agent fan-out (CU8) where one
+// misconfigured template would otherwise kill the whole run.
+func (t *ReviewerTemplate) Start(ctx context.Context, cfg RunConfig) (Process, error) {
+	if t.AgentName == "" {
+		return nil, fmt.Errorf("ReviewerTemplate.Start: %w (empty AgentName)", ErrTemplateMisconfigured)
+	}
+	if t.BuildCmd == nil {
+		return nil, fmt.Errorf("ReviewerTemplate.Start: %w (nil BuildCmd for agent %q)", ErrTemplateMisconfigured, t.AgentName)
+	}
+	if t.Parser == nil {
+		return nil, fmt.Errorf("ReviewerTemplate.Start: %w (nil Parser for agent %q)", ErrTemplateMisconfigured, t.AgentName)
+	}
+	cmd := t.BuildCmd(ctx, cfg)
+	if cmd == nil {
+		return nil, fmt.Errorf("ReviewerTemplate.Start: %w (BuildCmd returned nil for agent %q)", ErrTemplateMisconfigured, t.AgentName)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("%s: stdout pipe: %w", t.AgentName, err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("%s: start: %w", t.AgentName, err)
+	}
+	p := &templateProcess{cmd: cmd, events: make(chan Event, 32)}
+	go p.run(stdout, t.Parser)
+	return p, nil
+}
+
+// ErrTemplateMisconfigured is returned by ReviewerTemplate.Start when one of
+// the required fields (AgentName, BuildCmd, Parser) is unset, or when
+// BuildCmd returns nil. Use errors.Is to detect this in tests or higher
+// layers (e.g., a multi-agent orchestrator that needs to skip a misconfigured
+// agent rather than crashing the whole run).
+var ErrTemplateMisconfigured = errors.New("ReviewerTemplate misconfigured")
+
+// templateProcess is the shared Process implementation for ReviewerTemplate.
+type templateProcess struct {
+	cmd    *exec.Cmd
+	events chan Event
+}
+
+// Events returns the channel that streams parsed events from the agent process.
+func (p *templateProcess) Events() <-chan Event { return p.events }
+
+// Wait returns the agent process's exit error.
+//
+// Per CU2's Process contract: nil on clean exit (exit code 0); ctx.Err()
+// on cancellation; *exec.ExitError on non-zero exit; other types for I/O
+// or pipe failures. The error type is preserved (not wrapped) so callers
+// can use errors.As and errors.Is to classify.
+func (p *templateProcess) Wait() error {
+	return p.cmd.Wait() //nolint:wrapcheck // interface boundary; classifyStatus needs raw type
+}
+
+func (p *templateProcess) run(stdout io.Reader, parser func(io.Reader) <-chan Event) {
+	defer close(p.events)
+	for ev := range parser(stdout) {
+		p.events <- ev
+	}
+}

--- a/cmd/entire/cli/review/types/template_test.go
+++ b/cmd/entire/cli/review/types/template_test.go
@@ -1,0 +1,170 @@
+package types
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"testing"
+)
+
+// Compile-time interface check.
+var _ AgentReviewer = (*ReviewerTemplate)(nil)
+
+func TestReviewerTemplate_Name(t *testing.T) {
+	t.Parallel()
+	tmpl := &ReviewerTemplate{
+		AgentName: "test-agent",
+		BuildCmd: func(ctx context.Context, _ RunConfig) *exec.Cmd {
+			return exec.CommandContext(ctx, "true")
+		},
+		Parser: func(_ io.Reader) <-chan Event {
+			ch := make(chan Event)
+			close(ch)
+			return ch
+		},
+	}
+	if got := tmpl.Name(); got != "test-agent" {
+		t.Errorf("Name() = %q, want %q", got, "test-agent")
+	}
+}
+
+func TestReviewerTemplate_EventsForwarded(t *testing.T) {
+	t.Parallel()
+
+	// A stub parser that emits a fixed sequence of events.
+	wantEvents := []Event{
+		Started{},
+		AssistantText{Text: "line 1"},
+		AssistantText{Text: "line 2"},
+		Finished{Success: true},
+	}
+
+	stubParser := func(_ io.Reader) <-chan Event {
+		ch := make(chan Event, len(wantEvents))
+		for _, ev := range wantEvents {
+			ch <- ev
+		}
+		close(ch)
+		return ch
+	}
+
+	tmpl := &ReviewerTemplate{
+		AgentName: "stub-agent",
+		BuildCmd: func(ctx context.Context, _ RunConfig) *exec.Cmd {
+			// "true" exits 0 immediately; stdin/stdout pipes are still valid.
+			return exec.CommandContext(ctx, "true")
+		},
+		Parser: stubParser,
+	}
+
+	ctx := context.Background()
+	proc, err := tmpl.Start(ctx, RunConfig{Skills: []string{"/test"}})
+	if err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+
+	var got []Event
+	for ev := range proc.Events() {
+		got = append(got, ev)
+	}
+
+	if err := proc.Wait(); err != nil {
+		t.Fatalf("Wait() error: %v", err)
+	}
+
+	if len(got) != len(wantEvents) {
+		t.Fatalf("got %d events, want %d: %v", len(got), len(wantEvents), got)
+	}
+	for i, want := range wantEvents {
+		if got[i] != want {
+			t.Errorf("events[%d] = %v, want %v", i, got[i], want)
+		}
+	}
+}
+
+func TestReviewerTemplate_ProcessWaitReturnsExitError(t *testing.T) {
+	t.Parallel()
+
+	tmpl := &ReviewerTemplate{
+		AgentName: "exit1-agent",
+		BuildCmd: func(ctx context.Context, _ RunConfig) *exec.Cmd {
+			return exec.CommandContext(ctx, "false") // exits with code 1
+		},
+		Parser: func(_ io.Reader) <-chan Event {
+			ch := make(chan Event)
+			close(ch)
+			return ch
+		},
+	}
+
+	ctx := context.Background()
+	proc, err := tmpl.Start(ctx, RunConfig{})
+	if err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	// Drain events.
+	for ev := range proc.Events() {
+		_ = ev
+	}
+	waitErr := proc.Wait()
+	if waitErr == nil {
+		t.Error("Wait() should return non-nil error for exit code 1")
+	}
+}
+
+// TestReviewerTemplate_StartReturnsErrTemplateMisconfigured pins the typed
+// validation errors Start returns when required fields are missing. The
+// previous behaviour panicked here, which would crash a whole multi-agent
+// fan-out (CU8) when one agent's template is misconfigured. Returning a
+// typed error lets callers skip that agent and continue.
+func TestReviewerTemplate_StartReturnsErrTemplateMisconfigured(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		tmpl ReviewerTemplate
+	}{
+		{
+			name: "empty AgentName",
+			tmpl: ReviewerTemplate{
+				BuildCmd: func(ctx context.Context, _ RunConfig) *exec.Cmd { return exec.CommandContext(ctx, "true") },
+				Parser:   func(_ io.Reader) <-chan Event { c := make(chan Event); close(c); return c },
+			},
+		},
+		{
+			name: "nil BuildCmd",
+			tmpl: ReviewerTemplate{
+				AgentName: "test",
+				Parser:    func(_ io.Reader) <-chan Event { c := make(chan Event); close(c); return c },
+			},
+		},
+		{
+			name: "nil Parser",
+			tmpl: ReviewerTemplate{
+				AgentName: "test",
+				BuildCmd:  func(ctx context.Context, _ RunConfig) *exec.Cmd { return exec.CommandContext(ctx, "true") },
+			},
+		},
+		{
+			name: "BuildCmd returns nil",
+			tmpl: ReviewerTemplate{
+				AgentName: "test",
+				BuildCmd:  func(_ context.Context, _ RunConfig) *exec.Cmd { return nil },
+				Parser:    func(_ io.Reader) <-chan Event { c := make(chan Event); close(c); return c },
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpl := tc.tmpl
+			_, err := tmpl.Start(context.Background(), RunConfig{})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, ErrTemplateMisconfigured) {
+				t.Errorf("expected ErrTemplateMisconfigured, got %v", err)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/review/types/template_test.go
+++ b/cmd/entire/cli/review/types/template_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"os/exec"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -110,6 +112,79 @@ func TestReviewerTemplate_ProcessWaitReturnsExitError(t *testing.T) {
 	waitErr := proc.Wait()
 	if waitErr == nil {
 		t.Error("Wait() should return non-nil error for exit code 1")
+	}
+}
+
+func TestReviewerTemplate_WaitReturnsContextErrorOnCancellation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses POSIX shell")
+	}
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tmpl := &ReviewerTemplate{
+		AgentName: "cancel-agent",
+		BuildCmd: func(ctx context.Context, _ RunConfig) *exec.Cmd {
+			return exec.CommandContext(ctx, "sh", "-c", "sleep 10")
+		},
+		Parser: func(_ io.Reader) <-chan Event {
+			ch := make(chan Event)
+			close(ch)
+			return ch
+		},
+	}
+
+	proc, err := tmpl.Start(ctx, RunConfig{})
+	if err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	for ev := range proc.Events() {
+		_ = ev
+	}
+	cancel()
+
+	waitErr := proc.Wait()
+	if !errors.Is(waitErr, context.Canceled) {
+		t.Fatalf("Wait() = %T %v, want context.Canceled", waitErr, waitErr)
+	}
+}
+
+func TestReviewerTemplate_WaitIncludesStderrOnFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses POSIX shell")
+	}
+	t.Parallel()
+
+	tmpl := &ReviewerTemplate{
+		AgentName: "stderr-agent",
+		BuildCmd: func(ctx context.Context, _ RunConfig) *exec.Cmd {
+			return exec.CommandContext(ctx, "sh", "-c", "echo 'auth failed: login required' >&2; exit 7")
+		},
+		Parser: func(_ io.Reader) <-chan Event {
+			ch := make(chan Event)
+			close(ch)
+			return ch
+		},
+	}
+
+	proc, err := tmpl.Start(context.Background(), RunConfig{})
+	if err != nil {
+		t.Fatalf("Start() error: %v", err)
+	}
+	for ev := range proc.Events() {
+		_ = ev
+	}
+
+	waitErr := proc.Wait()
+	if waitErr == nil {
+		t.Fatal("Wait() returned nil, want failure")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(waitErr, &exitErr) {
+		t.Fatalf("Wait() = %T %v, want error wrapping *exec.ExitError", waitErr, waitErr)
+	}
+	if !strings.Contains(waitErr.Error(), "auth failed: login required") {
+		t.Fatalf("Wait() error missing stderr diagnostics: %v", waitErr)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/287
<!-- entire-trail-link-end -->

## Summary

Second of three stacked PRs rebuilding \`entire review\`'s internals. Stacked on PR-A1 (#1105). Implements the abstractions PR-A1 declared: per-agent \`AgentReviewer\` for the three launchable agents, the \`Sink\`/\`Run\` orchestrator that consumes them, and the prompt + scope composition layer. **Still no user-visible behaviour change** — \`runReview\` is rewired in PR-A3.

Stack:
- A1 (#1105 — merge first): env-var handshake + types
- **A2 (this PR):** per-agent reviewers, orchestrator, prompt composition, scope detection
- A3 → a2: wire \`entire review\` on the new architecture; delete legacy \`review.go\`

## What's in this PR

**CU3 — Per-agent reviewers** (\`74133788e\`)
- \`agent/claudecode/reviewer.go\`, \`agent/codex/reviewer.go\` + \`output_filter.go\` (chrome stripping), \`agent/geminicli/reviewer.go\`
- Each implements \`AgentReviewer\` with per-agent quirks (claude argv, codex stdin + chrome filter, gemini stdin) **owned inside that agent's package**
- Anchored regexes in codex's filter prevent eating narrative containing \`exec\` / \`version N.M\` (regression-tested)
- All three parsers correctly surface scanner errors as \`RunError\` + \`Finished{Success: false}\` instead of false-success

**CU4 — Sink + DumpSink + single-agent orchestrator** (\`a7b916143\`)
- \`review/types/sink.go\`: \`Sink\` interface (with serial-dispatch concurrency contract), \`RunSummary\`, \`AgentRun\`, \`AgentStatus\` enum
- \`review/dump.go\`: \`DumpSink\` post-run terminal renderer
- \`review/run.go\`: \`Run(ctx, reviewer, cfg, sinks) (RunSummary, error)\` orchestrator
- \`classifyStatus\` checks \`ctx.Err()\` before \`waitErr\` so signal-killed processes are correctly classified as \`Cancelled\` (regression from PR #1018)

**CU5 — Prompt composition + scope detection** (\`2bc20b166\`)
- \`review/prompt.go\`: \`ComposeReviewPrompt(cfg)\` joins skills + always-prompt + per-run-prompt + scope clause
- \`review/scope.go\`: \`detectScopeBaseRef\` finds closest non-self ancestor branch by tip timestamp (fallback chain origin/HEAD → origin/main → origin/master → main → master); \`ComputeScopeStats\`/\`formatScopeBanner\` produce \"Reviewing feat/X vs main: 3 commits, 7 files changed, 2 uncommitted\"
- Consolidates the three placeholder \`composePrompt\` helpers from CU3 into a single shared composer

**CU5b — Extract ReviewerTemplate refactor** (\`013d5f4a2\`)
- \`review/types/template.go\`: shared scaffolding (\`Spawn → pipe stdout → run parser → forward events → close\`) for per-agent reviewers
- Each agent file shrinks from ~140 lines to ~70-80 — agent files are now genuinely just \"this agent's quirks\" (argv + parser)
- Pure refactor; all CU3 tests pass unchanged

## Test plan

- [x] \`mise run check\` (fmt + lint + test:ci) green
- [x] Per-agent contract tests: \`go test ./cmd/entire/cli/agent/{claudecode,codex,geminicli}/\` (each agent's argv, stdin, env vars, parser, scanner.Err handling)
- [x] Orchestrator tests: \`go test ./cmd/entire/cli/review/\` (15 new tests covering Run() success/cancel/start-error paths, token overwrite semantics, sink fan-out)
- [x] Output filter tests: \`go test ./cmd/entire/cli/agent/codex/\` covering banner/exec-block/CSI/hook/timestamp drops + narrative passthrough including \"version N.M\" and \"exec succeeded\"

## Smoke test (package-level contract)

The per-agent reviewer tests exercise each reviewer end-to-end with golden-file fixtures (real argv construction, real env, real parser pipeline). Plus the orchestrator tests drive \`Run()\` against stub reviewers under success/cancel/error paths.

\`\`\`bash
git checkout feat/entire-review-v2-a2
go build -o /tmp/entire-smoke-a2 ./cmd/entire   # confirms compilation
go test ./cmd/entire/cli/agent/{claudecode,codex,geminicli}/ \\
        ./cmd/entire/cli/review/ \\
        ./cmd/entire/cli/review/types/ -count=1
\`\`\`

**Expected:** all 5 packages green.

**Actual output (verified locally on \`feat/entire-review-v2-a2\` @ 013d5f4a2):**
\`\`\`
ok  cmd/entire/cli/agent/claudecode      3.999s
ok  cmd/entire/cli/agent/codex           0.543s
ok  cmd/entire/cli/agent/geminicli       0.833s
ok  cmd/entire/cli/review                1.202s
ok  cmd/entire/cli/review/types          1.101s
\`\`\`
✓ All package-level smoke green.

A real-agent end-to-end smoke (orchestrator + DumpSink against live claude-code) is more meaningful at PR-A3 where \`entire review\` actually invokes this layer; deferred to that PR's smoke procedure.

## Anti-features explicitly NOT recreated

- \`Launcher\` + \`HeadlessLauncher\` as separate interfaces (single \`AgentReviewer\` instead)
- \`filterCodexOutput\` in shared multi-agent code (lives in \`agent/codex/output_filter.go\`)
- \`sync.Once\`-guarded onCancel + parallel \`signal.Notify\` goroutine (single cancel function from start; multi-agent fan-in preserves it)
- Default scope divergence between agents (\`origin/main...HEAD\` vs working-tree-only) — \`ComposeReviewPrompt\` adds an explicit scope clause for all agents

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new review execution plumbing (process spawning, event parsing, git scope detection, and status classification), which could affect correctness of review runs and cancellation/error reporting despite being well-tested.
> 
> **Overview**
> Adds the next layer of the `entire review` rewrite: per-agent `AgentReviewer` implementations for `claude-code`, `codex`, and `gemini-cli`, including codex stdout *chrome* stripping and consistent parser error reporting as `RunError` + `Finished{Success:false}`.
> 
> Introduces a single-agent `Run()` orchestrator with `Sink`/`RunSummary`/`AgentRun`/`AgentStatus` and a `DumpSink` renderer, plus shared `ComposeReviewPrompt` and git-based scope detection (`detectScopeBaseRef`/`ComputeScopeStats`) to standardize what commits the agents should review.
> 
> Also tightens the env-var handshake with `AppendReviewEnv` (deduping stale `ENTIRE_REVIEW_*` entries), updates agent import-architecture allowlists, and expands unit/golden tests across agents, orchestrator, prompt, env, and scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce17205008a2e43a2c111e7af722f7940dfb03c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->