### PR TITLE
Add fast path checks for checkpoints migrations

### DIFF
--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -300,6 +300,12 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 	}
 
 	if existing != nil && !force {
+		// Fast-path: when every session already has a compact transcript and
+		// /full/<n> artifacts, the repair branch below is a guaranteed no-op.
+		if v2CheckpointFullyMigrated(v2Store, info, existing) {
+			return nil, outcome, errAlreadyMigrated
+		}
+
 		fullCheckpoint, queuedFullRepair, repairErr := collectMissingFullCheckpointForPacking(ctx, repo, v1Store, v2Store, info, existing)
 		if repairErr != nil {
 			return nil, outcome, repairErr
@@ -1044,6 +1050,24 @@ func hasFullSessionArtifacts(v2Store *checkpoint.V2GitStore, cpID id.CheckpointI
 	return ok, nil
 }
 
+// v2CheckpointFullyMigrated reports whether every session already has a compact
+// transcript and /full/<n> artifacts. Returns false on any uncertainty.
+func v2CheckpointFullyMigrated(v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, existing *checkpoint.CheckpointSummary) bool {
+	if existing == nil || info.SessionCount == 0 || info.SessionCount != len(existing.Sessions) {
+		return false
+	}
+	for i, session := range existing.Sessions {
+		if session.Transcript == "" {
+			return false
+		}
+		ok, err := hasFullSessionArtifacts(v2Store, info.CheckpointID, i)
+		if err != nil || !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // backfillCompactTranscripts checks sessions in an already-migrated v2 checkpoint
 // for missing transcript.jsonl and attempts to generate + write them from v1 data.
 // Returns errAlreadyMigrated if all sessions already have compact transcripts.
@@ -1064,6 +1088,12 @@ func backfillCompactTranscripts(ctx context.Context, v1Store *checkpoint.GitStor
 	var lastAgent string
 
 	for _, sessionIdx := range needsBackfill {
+		// Sessions with no agent type recorded in v2 are permanently
+		// unrecoverable; skip without reading v1 to keep reruns cheap.
+		if v2Meta, metaErr := v2Store.ReadSessionMetadataAndPrompts(ctx, info.CheckpointID, sessionIdx); metaErr == nil && v2Meta != nil && v2Meta.Metadata.Agent == "" {
+			continue
+		}
+
 		content, readErr := v1Store.ReadSessionContent(ctx, info.CheckpointID, sessionIdx)
 		if readErr != nil {
 			logging.Warn(ctx, "transcript.jsonl backfill: could not read v1 session",

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -1177,6 +1177,114 @@ func TestMigrateCheckpointsV2_AllSkippedOnRerun(t *testing.T) {
 	assert.Equal(t, 2, result2.skipped)
 }
 
+func TestMigrateCheckpointsV2_FastPathSkipsFullyMigratedCheckpoint(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+
+	cpID := id.MustCheckpointID("ccdd11223344")
+
+	// Agent type is required for the first migration to produce a compact transcript.
+	err := v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-fastpath",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"yo\"}]}}\n")),
+		Prompts:      []string{"hi"},
+		Agent:        agent.AgentTypeClaudeCode,
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	})
+	require.NoError(t, err)
+
+	var discard bytes.Buffer
+	first, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &discard, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, first.migrated)
+
+	summary, err := v2Store.ReadCommitted(context.Background(), cpID)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	require.NotEmpty(t, summary.Sessions[0].Transcript)
+	hasFull, err := v2Store.HasFullSessionArtifacts(cpID, 0)
+	require.NoError(t, err)
+	require.True(t, hasFull)
+
+	// The fast-path predicate requires a non-zero v1 SessionCount.
+	list, err := v1Store.ListCommitted(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	require.Equal(t, 1, list[0].SessionCount)
+
+	assert.True(t, v2CheckpointFullyMigrated(v2Store, list[0], summary))
+
+	second, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &discard, false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, second.migrated)
+	assert.Equal(t, 1, second.skipped)
+	assert.Equal(t, 0, second.backfilledCompactTranscripts,
+		"fast-path must short-circuit before backfillCompactTranscripts runs")
+}
+
+func TestV2CheckpointFullyMigrated(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	_, v2Store := newMigrateStores(repo)
+
+	cpID := id.MustCheckpointID("ddee22334455")
+
+	// Predicate is false when there's no existing summary.
+	assert.False(t, v2CheckpointFullyMigrated(v2Store, checkpoint.CommittedInfo{CheckpointID: cpID, SessionCount: 1}, nil))
+
+	// Predicate is false when info reports no sessions (cannot validate count).
+	emptySummary := &checkpoint.CheckpointSummary{Sessions: []checkpoint.SessionFilePaths{{Transcript: "x"}}}
+	assert.False(t, v2CheckpointFullyMigrated(v2Store, checkpoint.CommittedInfo{CheckpointID: cpID, SessionCount: 0}, emptySummary))
+
+	// Predicate is false when v1 reports more sessions than v2 has stored.
+	mismatchSummary := &checkpoint.CheckpointSummary{Sessions: []checkpoint.SessionFilePaths{{Transcript: "x"}}}
+	assert.False(t, v2CheckpointFullyMigrated(v2Store, checkpoint.CommittedInfo{CheckpointID: cpID, SessionCount: 2}, mismatchSummary))
+
+	// Predicate is false when any session is missing the compact transcript.
+	noCompactSummary := &checkpoint.CheckpointSummary{Sessions: []checkpoint.SessionFilePaths{{Transcript: ""}}}
+	assert.False(t, v2CheckpointFullyMigrated(v2Store, checkpoint.CommittedInfo{CheckpointID: cpID, SessionCount: 1}, noCompactSummary))
+}
+
+func TestMigrateCheckpointsV2_BackfillSkipsV1ReadWhenV2HasNoAgent(t *testing.T) {
+	t.Parallel()
+	repo := initMigrateTestRepo(t)
+	v1Store, v2Store := newMigrateStores(repo)
+	ctx := context.Background()
+
+	cpID := id.MustCheckpointID("eeff33445566")
+
+	// v2 has the checkpoint with no agent and no compact transcript — the
+	// permanently unrecoverable state we re-encounter on every rerun.
+	err := v2Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-noagent",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("{\"type\":\"assistant\",\"message\":\"x\"}\n")),
+		Prompts:      []string{"p"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+		// Agent intentionally empty; CompactTranscript intentionally nil.
+	})
+	require.NoError(t, err)
+
+	v2Summary, err := v2Store.ReadCommitted(ctx, cpID)
+	require.NoError(t, err)
+	require.NotNil(t, v2Summary)
+	require.Empty(t, v2Summary.Sessions[0].Transcript)
+
+	// v1 has nothing for this checkpoint; the skip path must return without consulting v1.
+	info := checkpoint.CommittedInfo{CheckpointID: cpID, SessionCount: 1}
+	backfilled, backfillErr := backfillCompactTranscripts(ctx, v1Store, v2Store, info, v2Summary)
+	assert.Equal(t, 0, backfilled)
+	require.ErrorIs(t, backfillErr, errTranscriptNotGeneratable)
+	// "no agent type" message only appears when lastAgent stays empty — i.e. we never read v1.
+	assert.Contains(t, backfillErr.Error(), "no agent type in metadata")
+}
+
 func TestMigrateCheckpointsV2_BackfillCompactTranscript(t *testing.T) {
 	t.Parallel()
 	repo := initMigrateTestRepo(t)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/289
<!-- entire-trail-link-end -->

Speed up `entire migrate --checkpoints v2` reruns by short-circuiting checkpoints that are already fully migrated and avoiding redundant v1 reads for permanently unmigratable compact transcripts.

- Add a fast-path guard in `migrateOneCheckpoint` that returns `errAlreadyMigrated` when the v2 checkpoint already has a compact transcript and `/full/<n>` artifacts for every session
- In `backfillCompactTranscripts`, read the v2 session metadata first and skip the v1 transcript decode when `Agent == ""` (compact is permanently unrecoverable for those sessions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint migration control-flow to short-circuit work on reruns, which could affect whether repairs/backfills run for partially migrated data. Covered by new tests, but it still touches a data-migration path.
> 
> **Overview**
> Speeds up `entire migrate --checkpoints v2` reruns by adding a **fast-path** in `migrateOneCheckpoint` that immediately skips checkpoints already fully migrated (all sessions have compact transcripts and archived `/full/<n>` artifacts).
> 
> Optimizes compact transcript backfill by first checking v2 session metadata and **skipping v1 reads** for sessions with no recorded agent type (permanently non-generatable compact transcripts). Adds focused tests for the new predicate, fast-path behavior, and the no-agent skip case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d09b51a48b92677a8d33b866146c4863740cc8f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->