### PR TITLE
Checkpoints v2 migration: Keep user in the loop after the progress bar completes

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -377,7 +377,7 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool) error {
 	stop := startSpinner(errW, "Loading checkpoints")
 	lookup, lookupErr := newExplainCheckpointLookup(ctx)
-	stop("")
+	stop(false)
 	if generate {
 		if err := runExplainAutoAmbiguityGuard(ctx, target, lookup, lookupErr); err != nil {
 			return err
@@ -524,7 +524,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 				v2OK = true
 			}
 		}
-		stop("")
+		stop(false)
 		if v1Err == nil || v2OK {
 			if freshLookup, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {
 				lookup = freshLookup
@@ -586,14 +586,14 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 
 	resolvedReader, summary, content, err := loadCheckpointForExplain(ctx, errW, lookup, fullCheckpointID, full, generate, rawTranscript)
 	if err != nil {
-		stopLoad("")
+		stopLoad(false)
 		return err
 	}
 	v2Reader, isCheckpointsV2 := resolvedReader.(*checkpoint.V2GitStore)
 
 	// Handle summary generation — uses raw transcript.
 	if generate {
-		stopLoad("") // generation prints its own progress to w/errW
+		stopLoad(false) // generation prints its own progress to w/errW
 		if err := generateCheckpointSummary(ctx, w, errW, lookup.v1Store, lookup.v2Store, fullCheckpointID, summary, content, force); err != nil {
 			return err
 		}
@@ -606,14 +606,14 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 			content, err = readLatestSessionContentForExplain(ctx, resolvedReader, fullCheckpointID, summary)
 		}
 		if err != nil {
-			stopLoad("")
+			stopLoad(false)
 			return fmt.Errorf("failed to reload checkpoint: %w", err)
 		}
 	}
 
 	// Handle raw transcript output
 	if rawTranscript {
-		stopLoad("")
+		stopLoad(false)
 		rawLog, _, rawErr := checkpoint.ResolveRawSessionLogForCheckpoint(ctx, fullCheckpointID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
 		if rawErr != nil {
 			return fmt.Errorf("failed to read raw transcript: %w", rawErr)
@@ -646,7 +646,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 
 	// Format and output. Stop spinner BEFORE any write to w to keep stderr
 	// frames and stdout content from interleaving.
-	stopLoad("")
+	stopLoad(false)
 	output := formatCheckpointOutput(summary, content, fullCheckpointID, associatedCommits, author, verbose, full, w)
 	outputExplainContent(w, output, noPager)
 	return nil

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -105,10 +105,11 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 		stopRepair := startSpinner(cmd.ErrOrStderr(), "Repairing archived generation metadata")
 		var repairErr error
 		repairResult, repairErr = strategy.RepairV2GenerationMetadata(ctx, freshlyPackedRefs)
-		stopRepair("")
 		if repairErr != nil {
+			stopRepair(false)
 			return fmt.Errorf("failed to repair archived v2 generation metadata: %w", repairErr)
 		}
+		stopRepair(true)
 		printV2GenerationRepairResult(out, cmd.ErrOrStderr(), repairResult)
 	}
 
@@ -258,12 +259,13 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 		progress.Increment()
 	}
 
+	progress.Finish()
 	stopFinalize := startSpinner(progressOut, "Packing migrated raw transcripts")
 	if err := packer.finalize(ctx, !fullCurrentExistsBefore); err != nil {
-		stopFinalize("")
+		stopFinalize(false)
 		return result, packer.writtenRefs, fmt.Errorf("failed to pack migrated raw transcripts: %w", err)
 	}
-	stopFinalize("")
+	stopFinalize(true)
 
 	return result, packer.writtenRefs, nil
 }

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -97,7 +97,9 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 		return err
 	}
 
+	stopRepair := startSpinner(cmd.ErrOrStderr(), "Repairing archived generation metadata")
 	repairResult, repairErr := strategy.RepairV2GenerationMetadata(ctx)
+	stopRepair("")
 	if repairErr != nil {
 		return fmt.Errorf("failed to repair archived v2 generation metadata: %w", repairErr)
 	}
@@ -250,9 +252,12 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 		progress.Increment()
 	}
 
+	stopFinalize := startSpinner(progressOut, "Packing migrated raw transcripts")
 	if err := packer.finalize(ctx, !fullCurrentExistsBefore); err != nil {
+		stopFinalize("")
 		return result, fmt.Errorf("failed to pack migrated raw transcripts: %w", err)
 	}
+	stopFinalize("")
 
 	return result, nil
 }

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -425,7 +425,7 @@ func TestMigrateCheckpointsV2_ForceOverwritesExisting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, result3.migrated)
 	assert.Equal(t, 0, result3.skipped)
-	assert.Empty(t, stdout.String())
+	assert.Equal(t, "✓ Packing migrated raw transcripts\n", stdout.String())
 
 	// Verify checkpoint still readable in v2
 	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
@@ -580,7 +580,7 @@ func TestMigrateCmd_RepairsArchivedGenerationMetadata(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.Contains(t, stdout.String(), "Archived generation metadata repair: 1 repaired")
-	assert.Empty(t, stderr.String())
+	assert.Equal(t, "✓ Packing migrated raw transcripts\n✓ Repairing archived generation metadata\n", stderr.String())
 
 	v2Store := checkpoint.NewV2GitStore(repo, migrateRemoteName)
 	gen, genErr := v2Store.ReadGenerationFromRef(plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000007"))
@@ -1129,7 +1129,7 @@ func TestMigrateCheckpointsV2_CompactionSkipped(t *testing.T) {
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated)
 	assert.Equal(t, 1, result.compactTranscriptSkipped)
-	assert.Empty(t, stdout.String())
+	assert.Equal(t, "✓ Packing migrated raw transcripts\n", stdout.String())
 }
 
 func TestMigrateCheckpointsV2_TaskCheckpoint(t *testing.T) {

--- a/cmd/entire/cli/progress.go
+++ b/cmd/entire/cli/progress.go
@@ -115,6 +115,14 @@ func (p *progressBar) Finish() {
 	if !p.enabled {
 		return
 	}
+	// On completion, leave the rendered 100% bar in place and just terminate
+	// the line so any post-loop work renders below it. On early exit
+	// (current < total), erase the bar so a stale partial line doesn't stick
+	// around above the error message.
+	if p.current >= p.total {
+		fmt.Fprintln(p.w)
+		return
+	}
 	fmt.Fprint(p.w, "\r\033[K")
 }
 

--- a/cmd/entire/cli/progress.go
+++ b/cmd/entire/cli/progress.go
@@ -22,19 +22,15 @@ const (
 )
 
 // startSpinner prints msg followed by an animated spinner to w when the
-// operation takes longer than spinnerInitialDelay. Returns a stop function
-// that clears the spinner line and prints suffix (with a newline) if
-// non-empty. Fast operations that call stop before the initial delay
-// elapses produce no output at all.
-//
-// When w is not a terminal (CI, redirected output, agent subprocess), the
-// spinner and the suppression message are both omitted — non-interactive
-// callers get clean output without progress chatter.
-func startSpinner(w io.Writer, msg string) func(suffix string) {
+// operation takes longer than spinnerInitialDelay. stop(true) leaves
+// "✓ msg" on the line; stop(false) erases the line and writes nothing.
+// On non-terminal writers the animation is omitted but stop(true) still
+// prints the completion line.
+func startSpinner(w io.Writer, msg string) func(success bool) {
 	if !interactive.IsTerminalWriter(w) {
-		return func(suffix string) {
-			if suffix != "" {
-				fmt.Fprintln(w, suffix)
+		return func(success bool) {
+			if success {
+				fmt.Fprintf(w, "✓ %s\n", msg)
 			}
 		}
 	}
@@ -63,25 +59,25 @@ func startSpinner(w io.Writer, msg string) func(suffix string) {
 			}
 		}
 	}()
-	return func(suffix string) {
+	return func(success bool) {
 		close(done)
 		<-stopped
-		// \r\033[K is a no-op on a line that was never drawn; on a drawn
-		// line it returns the cursor and clears it.
-		fmt.Fprint(w, "\r\033[K")
-		if suffix != "" {
-			fmt.Fprintln(w, suffix)
+		if success {
+			fmt.Fprintf(w, "\r\033[K✓ %s\n", msg)
+			return
 		}
+		fmt.Fprint(w, "\r\033[K")
 	}
 }
 
 type progressBar struct {
-	w       io.Writer
-	label   string
-	total   int
-	current int
-	width   int
-	enabled bool
+	w        io.Writer
+	label    string
+	total    int
+	current  int
+	width    int
+	enabled  bool
+	finished bool
 }
 
 func startProgressBar(w io.Writer, label string, total int) *progressBar {
@@ -112,13 +108,10 @@ func (p *progressBar) Increment() {
 }
 
 func (p *progressBar) Finish() {
-	if !p.enabled {
+	if !p.enabled || p.finished {
 		return
 	}
-	// On completion, leave the rendered 100% bar in place and just terminate
-	// the line so any post-loop work renders below it. On early exit
-	// (current < total), erase the bar so a stale partial line doesn't stick
-	// around above the error message.
+	p.finished = true
 	if p.current >= p.total {
 		fmt.Fprintln(p.w)
 		return


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/291
<!-- entire-trail-link-end -->

Previously the checkpoints v2 migration progress bar would just disappear after a migration was complete. For repos with <1k checkpoints, that was fine because the processing was fast enough, but now the migration seems to "hang" after it reaches 100% and the progress bar disappears. This adds more text and info so it doesn't seem like the tool is broken.

```
➜  cli git:(migration-completion-output) ✗ entire migrate --checkpoints v2
Migrating checkpoints [################################] 3272/3272 (100%)
✓ Packing migrated raw transcripts
✓ Repairing archived generation metadata
Migration complete: 6 migrated, 3239 skipped, 27 failed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3f0824f1d34a7c23cba2590c5682f0c3f7ea12bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->