### PR TITLE
Add interactive recap TUI

### DIFF
--- a/cmd/entire/cli/activity_render_test.go
+++ b/cmd/entire/cli/activity_render_test.go
@@ -8,6 +8,8 @@ import (
 	"unicode/utf8"
 )
 
+const activityTestAgentClaude = "claude"
+
 func TestUniqueCommitAgents_UsesAgentsSlice(t *testing.T) {
 	t.Parallel()
 	c := userCommit{
@@ -19,7 +21,7 @@ func TestUniqueCommitAgents_UsesAgentsSlice(t *testing.T) {
 	if len(agents) != 2 {
 		t.Fatalf("got %d agents, want 2", len(agents))
 	}
-	if agents[0] != "claude" || agents[1] != "gemini" {
+	if agents[0] != activityTestAgentClaude || agents[1] != "gemini" {
 		t.Errorf("got %v, want [claude gemini]", agents)
 	}
 }
@@ -32,7 +34,7 @@ func TestUniqueCommitAgents_FallsBackToSingularAgent(t *testing.T) {
 		},
 	}
 	agents := uniqueCommitAgents(c)
-	if len(agents) != 1 || agents[0] != "claude" {
+	if len(agents) != 1 || agents[0] != activityTestAgentClaude {
 		t.Errorf("got %v, want [claude] (should fall back to Agent field)", agents)
 	}
 }
@@ -54,8 +56,8 @@ func TestUniqueCommitAgents_Dedupes(t *testing.T) {
 	t.Parallel()
 	c := userCommit{
 		Checkpoints: []userCommitCheckpoint{
-			{Agent: "claude", Agents: []string{"Claude Code"}},
-			{Agent: "claude", Agents: []string{"Claude Code"}},
+			{Agent: activityTestAgentClaude, Agents: []string{"Claude Code"}},
+			{Agent: activityTestAgentClaude, Agents: []string{"Claude Code"}},
 		},
 	}
 	agents := uniqueCommitAgents(c)
@@ -150,7 +152,7 @@ func TestRenderCommitList_SingularPlural(t *testing.T) {
 					CommitMsg:    strPtr("msg"),
 					RepoFullName: "org/repo",
 					FilesChanged: 1,
-					Checkpoints:  []userCommitCheckpoint{{Agent: "claude"}},
+					Checkpoints:  []userCommitCheckpoint{{Agent: activityTestAgentClaude}},
 				},
 			}},
 		}
@@ -226,10 +228,10 @@ func TestRenderContributionChart_MonthAxisWideWidth(t *testing.T) {
 	var buf bytes.Buffer
 	sty := activityStyles{width: 200}
 	hourly := []hourlyPoint{
-		{Date: "2026-04-01", Hour: 12, Value: 3, AgentID: "claude"},
+		{Date: "2026-04-01", Hour: 12, Value: 3, AgentID: activityTestAgentClaude},
 	}
 	repos := []repoContribution{
-		{Repo: "org/repo", Total: 1, Agents: map[string]int{"claude": 1}},
+		{Repo: "org/repo", Total: 1, Agents: map[string]int{activityTestAgentClaude: 1}},
 	}
 
 	renderContributionChart(&buf, sty, hourly, repos)
@@ -252,7 +254,7 @@ func TestRenderRepoChart_LimitsToFive(t *testing.T) {
 		repos = append(repos, repoContribution{
 			Repo:   strings.Repeat("r", i+1),
 			Total:  8 - i,
-			Agents: map[string]int{"claude": 8 - i},
+			Agents: map[string]int{activityTestAgentClaude: 8 - i},
 		})
 	}
 

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -103,8 +103,8 @@ func (f *recapFlags) colorEnabled(w io.Writer) (bool, error) {
 	}
 }
 
-func (f *recapFlags) useTUI(isTerminal, accessible bool) bool {
-	return isTerminal && !accessible && !f.static
+func (f *recapFlags) useTUI(isTerminal, canPrompt, accessible bool) bool {
+	return isTerminal && canPrompt && !accessible && !f.static
 }
 
 func runRecap(ctx context.Context, w io.Writer, f *recapFlags) error {
@@ -127,7 +127,7 @@ func runRecap(ctx context.Context, w io.Writer, f *recapFlags) error {
 	}
 	rangeKey := f.rangeKey()
 	repoSlug := currentRepoSlug(ctx)
-	if f.useTUI(interactive.IsTerminalWriter(w), IsAccessibleMode()) {
+	if f.useTUI(interactive.IsTerminalWriter(w), interactive.CanPromptInteractively(), IsAccessibleMode()) {
 		return runRecapTUI(ctx, client, recapTUIOptions{
 			Range: rangeKey,
 			View:  mode,

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/recap"
 )
@@ -23,6 +24,7 @@ type recapFlags struct {
 	view                  string
 	agent                 string
 	color                 string
+	static                bool
 	insecureHTTP          bool
 }
 
@@ -48,6 +50,7 @@ func newRecapCmd() *cobra.Command {
 	cmd.Flags().StringVar(&f.agent, "agent", recap.AgentAll, "Agent id to show, or all")
 	cmd.Flags().StringVar(&f.view, "view", string(recap.ViewBoth), "Which columns to show: you, team, or both")
 	cmd.Flags().StringVar(&f.color, "color", recapColorAuto, "Color output: auto, always, or never")
+	cmd.Flags().BoolVar(&f.static, "static", false, "Print static output instead of opening the interactive recap")
 	cmd.Flags().BoolVar(&f.insecureHTTP, "insecure-http-auth", false, "Allow plain-HTTP auth (local dev only)")
 	cmd.MarkFlagsMutuallyExclusive("day", "week", "month", "90")
 	return cmd
@@ -100,6 +103,10 @@ func (f *recapFlags) colorEnabled(w io.Writer) (bool, error) {
 	}
 }
 
+func (f *recapFlags) useTUI(isTerminal, accessible bool) bool {
+	return isTerminal && !accessible && !f.static
+}
+
 func runRecap(ctx context.Context, w io.Writer, f *recapFlags) error {
 	if _, err := paths.WorktreeRoot(ctx); err != nil {
 		fmt.Fprintln(w, "Not a git repository. Run 'entire recap' from within a git repository.")
@@ -119,8 +126,18 @@ func runRecap(ctx context.Context, w io.Writer, f *recapFlags) error {
 		return NewSilentError(err)
 	}
 	rangeKey := f.rangeKey()
+	repoSlug := currentRepoSlug(ctx)
+	if f.useTUI(interactive.IsTerminalWriter(w), IsAccessibleMode()) {
+		return runRecapTUI(ctx, client, recapTUIOptions{
+			Range: rangeKey,
+			View:  mode,
+			Agent: f.agentName(),
+			Repo:  repoSlug,
+			Color: color,
+		})
+	}
 	start, end := rangeKey.Bounds(time.Now())
-	resp, err := recap.FetchMeRecap(ctx, client, start, end, currentRepoSlug(ctx), 0)
+	resp, err := recap.FetchMeRecap(ctx, client, start, end, repoSlug, 0)
 	if err != nil {
 		return fmt.Errorf("fetch recap: %w", err)
 	}

--- a/cmd/entire/cli/recap/render_static.go
+++ b/cmd/entire/cli/recap/render_static.go
@@ -52,8 +52,10 @@ func RenderStaticRecap(resp *MeRecapResponse, opts RenderOptions) string {
 	b.WriteString(renderControls(opts, styles))
 	b.WriteString("\n\n")
 	b.WriteString(renderSummary(resp, opts, width, styles))
-	b.WriteString("\n\n")
-	b.WriteString(renderActivity(resp, opts, width, styles))
+	if !hasAgentFilter(opts) {
+		b.WriteString("\n\n")
+		b.WriteString(renderActivity(resp, opts, width, styles))
+	}
 	b.WriteString("\n\n")
 	b.WriteString(renderAgents(resp, opts, width, styles))
 	b.WriteString("\n\n  ")
@@ -106,7 +108,7 @@ func renderViewSelector(view ViewMode, styles staticStyles) string {
 
 func renderSummary(resp *MeRecapResponse, opts RenderOptions, width int, styles staticStyles) string {
 	me := resp.Summary.Me
-	agentFiltered := opts.Agent != "" && opts.Agent != AgentAll
+	agentFiltered := hasAgentFilter(opts)
 	if agentFiltered || me == (SummaryTotals{}) {
 		me = sumMe(resp, opts)
 	}
@@ -145,9 +147,15 @@ func renderSummary(resp *MeRecapResponse, opts RenderOptions, width int, styles 
 	if resp.Summary.RepoCount > 0 {
 		context = append(context, plural(resp.Summary.RepoCount, "repo"))
 	}
-	context = append(context, plural(resp.Summary.ActiveDays, "active day"))
+	if !agentFiltered {
+		context = append(context, plural(resp.Summary.ActiveDays, "active day"))
+	}
 	lines = append(lines, "", styles.muted.Render(strings.Join(context, " · ")))
 	return renderBox("", lines, width, styles)
+}
+
+func hasAgentFilter(opts RenderOptions) bool {
+	return opts.Agent != "" && opts.Agent != AgentAll
 }
 
 func renderActivity(resp *MeRecapResponse, opts RenderOptions, width int, styles staticStyles) string {

--- a/cmd/entire/cli/recap/render_static.go
+++ b/cmd/entire/cli/recap/render_static.go
@@ -106,11 +106,18 @@ func renderViewSelector(view ViewMode, styles staticStyles) string {
 
 func renderSummary(resp *MeRecapResponse, opts RenderOptions, width int, styles staticStyles) string {
 	me := resp.Summary.Me
-	if me == (SummaryTotals{}) {
+	agentFiltered := opts.Agent != "" && opts.Agent != AgentAll
+	if agentFiltered || me == (SummaryTotals{}) {
 		me = sumMe(resp, opts)
 	}
 	team := resp.Summary.Team
-	if team == nil {
+	if agentFiltered {
+		if totals := sumTeam(resp, opts); totals != (SummaryTotals{}) {
+			team = &totals
+		} else {
+			team = nil
+		}
+	} else if team == nil {
 		if totals := sumTeam(resp, opts); totals != (SummaryTotals{}) {
 			team = &totals
 		}

--- a/cmd/entire/cli/recap/static_server_test.go
+++ b/cmd/entire/cli/recap/static_server_test.go
@@ -104,8 +104,14 @@ func TestRenderStaticRecap_AgentFilterSummarizesFilteredAgent(t *testing.T) {
 	t.Parallel()
 	resp := &MeRecapResponse{
 		Summary: Summary{
-			Me:   SummaryTotals{Sessions: 99, Checkpoints: 99, Tokens: 99_000},
-			Team: &SummaryTotals{Sessions: 88, Checkpoints: 88, Tokens: 88_000},
+			Me:         SummaryTotals{Sessions: 99, Checkpoints: 99, Tokens: 99_000},
+			Team:       &SummaryTotals{Sessions: 88, Checkpoints: 88, Tokens: 88_000},
+			RepoCount:  1,
+			ActiveDays: 12,
+		},
+		Daily: []DailyCount{
+			{Date: "2026-04-01", Count: 9},
+			{Date: "2026-04-02", Count: 4},
 		},
 		Agents: map[string]AgentEntry{
 			"claude": {
@@ -148,6 +154,12 @@ func TestRenderStaticRecap_AgentFilterSummarizesFilteredAgent(t *testing.T) {
 	}
 	if strings.Contains(got, "99 sessions") || strings.Contains(got, "88 sessions") {
 		t.Fatalf("agent-filtered summary should not use all-agent totals:\n%s", got)
+	}
+	if strings.Contains(got, "Activity · week") {
+		t.Fatalf("agent-filtered output should not show all-agent activity:\n%s", got)
+	}
+	if strings.Contains(got, "12 active days") {
+		t.Fatalf("agent-filtered output should not show all-agent active days:\n%s", got)
 	}
 	if strings.Contains(got, "Claude Code") {
 		t.Fatalf("agent-filtered output should omit other agents:\n%s", got)

--- a/cmd/entire/cli/recap/static_server_test.go
+++ b/cmd/entire/cli/recap/static_server_test.go
@@ -100,6 +100,60 @@ func TestRenderStaticRecap_TeamViewOmitsYouSummary(t *testing.T) {
 	}
 }
 
+func TestRenderStaticRecap_AgentFilterSummarizesFilteredAgent(t *testing.T) {
+	t.Parallel()
+	resp := &MeRecapResponse{
+		Summary: Summary{
+			Me:   SummaryTotals{Sessions: 99, Checkpoints: 99, Tokens: 99_000},
+			Team: &SummaryTotals{Sessions: 88, Checkpoints: 88, Tokens: 88_000},
+		},
+		Agents: map[string]AgentEntry{
+			"claude": {
+				AgentID:    "claude",
+				AgentLabel: "Claude Code",
+				Me: AgentAggregate{
+					Sessions:    10,
+					Checkpoints: 20,
+					Tokens:      30_000,
+				},
+			},
+			"codex": {
+				AgentID:    "codex",
+				AgentLabel: "Codex",
+				Me: AgentAggregate{
+					Sessions:    2,
+					Checkpoints: 3,
+					Tokens:      400,
+				},
+				Contributors: &AgentAggregate{
+					Sessions:    4,
+					Checkpoints: 5,
+					Tokens:      600,
+				},
+			},
+		},
+	}
+
+	got := RenderStaticRecap(resp, RenderOptions{Range: RangeWeek, View: ViewBoth, Agent: "codex", Width: 78})
+	for _, want := range []string{
+		"agent: [codex]",
+		"you   2 sessions    3 checkpoints    400 tok",
+		"team  4 sessions    5 checkpoints    600 tok",
+		"1 agent",
+		"Codex",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "99 sessions") || strings.Contains(got, "88 sessions") {
+		t.Fatalf("agent-filtered summary should not use all-agent totals:\n%s", got)
+	}
+	if strings.Contains(got, "Claude Code") {
+		t.Fatalf("agent-filtered output should omit other agents:\n%s", got)
+	}
+}
+
 func TestRenderStaticRecap_ColorWhenEnabled(t *testing.T) {
 	t.Parallel()
 	resp := &MeRecapResponse{

--- a/cmd/entire/cli/recap_test.go
+++ b/cmd/entire/cli/recap_test.go
@@ -72,18 +72,20 @@ func TestRecapFlags_UseTUI(t *testing.T) {
 		name       string
 		flags      recapFlags
 		terminal   bool
+		canPrompt  bool
 		accessible bool
 		want       bool
 	}{
-		{name: "terminal default", terminal: true, want: true},
-		{name: "non terminal static", terminal: false, want: false},
-		{name: "static flag", flags: recapFlags{static: true}, terminal: true, want: false},
-		{name: "accessible static", terminal: true, accessible: true, want: false},
+		{name: "terminal default", terminal: true, canPrompt: true, want: true},
+		{name: "non terminal static", terminal: false, canPrompt: true, want: false},
+		{name: "cannot prompt static", terminal: true, canPrompt: false, want: false},
+		{name: "static flag", flags: recapFlags{static: true}, terminal: true, canPrompt: true, want: false},
+		{name: "accessible static", terminal: true, canPrompt: true, accessible: true, want: false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			if got := c.flags.useTUI(c.terminal, c.accessible); got != c.want {
+			if got := c.flags.useTUI(c.terminal, c.canPrompt, c.accessible); got != c.want {
 				t.Fatalf("useTUI() = %v, want %v", got, c.want)
 			}
 		})

--- a/cmd/entire/cli/recap_test.go
+++ b/cmd/entire/cli/recap_test.go
@@ -58,10 +58,35 @@ func TestRecapFlags_Mode(t *testing.T) {
 func TestRecapCmd_RegistersStaticFlags(t *testing.T) {
 	t.Parallel()
 	cmd := newRecapCmd()
-	for _, name := range []string{"day", "week", "month", "90", "agent", "view", "color", "insecure-http-auth"} {
+	for _, name := range []string{"day", "week", "month", "90", "agent", "view", "color", "static", "insecure-http-auth"} {
 		if flag := cmd.Flag(name); flag == nil {
 			t.Errorf("flag --%s not registered", name)
 		}
+	}
+}
+
+func TestRecapFlags_UseTUI(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		flags      recapFlags
+		terminal   bool
+		accessible bool
+		want       bool
+	}{
+		{name: "terminal default", terminal: true, want: true},
+		{name: "non terminal static", terminal: false, want: false},
+		{name: "static flag", flags: recapFlags{static: true}, terminal: true, want: false},
+		{name: "accessible static", terminal: true, accessible: true, want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := c.flags.useTUI(c.terminal, c.accessible); got != c.want {
+				t.Fatalf("useTUI() = %v, want %v", got, c.want)
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/recap_tui.go
+++ b/cmd/entire/cli/recap_tui.go
@@ -1,0 +1,348 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/recap"
+)
+
+type recapTUIOptions struct {
+	Range recap.RangeKey
+	View  recap.ViewMode
+	Agent string
+	Repo  string
+	Color bool
+}
+
+type recapDataMsg struct {
+	resp *recap.MeRecapResponse
+}
+
+type recapErrMsg struct {
+	err error
+}
+
+type recapTUIModel struct {
+	ctx    context.Context
+	client *api.Client
+	repo   string
+
+	rangeKey recap.RangeKey
+	view     recap.ViewMode
+	agent    string
+	color    bool
+
+	resp    *recap.MeRecapResponse
+	loadErr error
+	loading bool
+
+	viewport viewport.Model
+	width    int
+	height   int
+	ready    bool
+}
+
+func runRecapTUI(ctx context.Context, client *api.Client, opts recapTUIOptions) error {
+	p := tea.NewProgram(newRecapTUIModel(ctx, client, opts))
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("recap TUI: %w", err)
+	}
+	return nil
+}
+
+func newRecapTUIModel(ctx context.Context, client *api.Client, opts recapTUIOptions) recapTUIModel {
+	if opts.Range == "" {
+		opts.Range = recap.RangeDay
+	}
+	if opts.View == "" {
+		opts.View = recap.ViewBoth
+	}
+	if opts.Agent == "" {
+		opts.Agent = recap.AgentAll
+	}
+	return recapTUIModel{
+		ctx:      ctx,
+		client:   client,
+		repo:     opts.Repo,
+		rangeKey: opts.Range,
+		view:     opts.View,
+		agent:    opts.Agent,
+		color:    opts.Color,
+		loading:  true,
+		width:    recap.DefaultWidth,
+		height:   24,
+		viewport: viewport.New(viewport.WithWidth(recap.DefaultWidth), viewport.WithHeight(23)),
+	}
+}
+
+func (m recapTUIModel) Init() tea.Cmd {
+	return m.fetch
+}
+
+func (m recapTUIModel) fetch() tea.Msg { //nolint:ireturn // bubbletea Cmd signature requires tea.Msg return
+	start, end := m.rangeKey.Bounds(time.Now())
+	resp, err := recap.FetchMeRecap(m.ctx, m.client, start, end, m.repo, 0)
+	if err != nil {
+		return recapErrMsg{err: err}
+	}
+	return recapDataMsg{resp: resp}
+}
+
+func (m recapTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn // bubbletea interface
+	switch msg := msg.(type) {
+	case recapDataMsg:
+		m.loading = false
+		m.loadErr = nil
+		m.resp = msg.resp
+		m = m.withViewport()
+		return m, nil
+
+	case recapErrMsg:
+		m.loading = false
+		m.loadErr = msg.err
+		return m, nil
+
+	case tea.WindowSizeMsg:
+		if msg.Width > 0 {
+			m.width = msg.Width
+		}
+		m.height = max(msg.Height, 1)
+		m = m.withViewport()
+		return m, nil
+
+	case tea.KeyPressMsg:
+		if key.Matches(msg, keys.Quit) || key.Matches(msg, keys.Back) {
+			return m, tea.Quit
+		}
+		switch msg.String() {
+		case "t":
+			m.rangeKey = nextRecapRange(m.rangeKey)
+			m.loading = true
+			m.loadErr = nil
+			m.resp = nil
+			return m.withViewport(), m.fetch
+		case "v":
+			m.view = nextRecapView(m.view)
+			return m.withViewport(), nil
+		case "a":
+			m.agent = m.nextAgent()
+			return m.withViewport(), nil
+		case "r":
+			m.loading = true
+			m.loadErr = nil
+			return m, m.fetch
+		}
+		if key.Matches(msg, keys.Home) {
+			m.viewport.GotoTop()
+			return m, nil
+		}
+		if key.Matches(msg, keys.End) {
+			m.viewport.GotoBottom()
+			return m, nil
+		}
+	}
+
+	if m.ready {
+		var cmd tea.Cmd
+		m.viewport, cmd = m.viewport.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m recapTUIModel) View() tea.View {
+	v := tea.View{AltScreen: true}
+	if m.loadErr != nil {
+		v.SetContent(fmt.Sprintf("\n  Failed to load recap: %s\n\n  Press r to retry or q to quit.\n", m.loadErr))
+		return v
+	}
+	if m.loading && m.resp == nil {
+		v.SetContent("\n  Loading recap...\n\n  Press q to quit.\n")
+		return v
+	}
+	if !m.ready {
+		return v
+	}
+
+	var b strings.Builder
+	b.WriteString(m.viewport.View())
+	b.WriteString("\n")
+	b.WriteString(m.renderFooter())
+	v.SetContent(b.String())
+	return v
+}
+
+func (m recapTUIModel) withViewport() recapTUIModel {
+	vpHeight := m.height - 1
+	if vpHeight < 1 {
+		vpHeight = 1
+	}
+	if !m.ready {
+		m.viewport = viewport.New(viewport.WithWidth(m.width), viewport.WithHeight(vpHeight))
+		m.ready = true
+	} else {
+		m.viewport.SetWidth(m.width)
+		m.viewport.SetHeight(vpHeight)
+	}
+	if m.resp != nil {
+		m.viewport.SetContent(recap.RenderStaticRecap(m.resp, recap.RenderOptions{
+			Range: m.rangeKey,
+			View:  m.view,
+			Agent: m.agent,
+			Width: m.width,
+			Color: m.color,
+		}))
+	}
+	return m
+}
+
+func (m recapTUIModel) renderFooter() string {
+	choices := []string{
+		recapFooterLine(m.color, []recapHelpItem{
+			{"t", "range"},
+			{"v", "view"},
+			{"a", "agent"},
+			{"r", "refresh"},
+			{"↑/↓", "scroll"},
+			{"q", "quit"},
+		}),
+		recapFooterLine(m.color, []recapHelpItem{
+			{"t", "range"},
+			{"v", "view"},
+			{"a", "agent"},
+			{"q", "quit"},
+		}),
+		recapFooterLine(m.color, []recapHelpItem{
+			{"t", "range"},
+			{"v", "view"},
+			{"q", "quit"},
+		}),
+		recapFooterLine(m.color, []recapHelpItem{
+			{"q", "quit"},
+		}),
+	}
+	for _, choice := range choices {
+		if m.width <= 0 || lipgloss.Width(choice) <= m.width {
+			return choice
+		}
+	}
+	return ""
+}
+
+type recapHelpItem struct {
+	key  string
+	desc string
+}
+
+func recapFooterLine(color bool, items []recapHelpItem) string {
+	if !color {
+		parts := make([]string, 0, len(items))
+		for _, item := range items {
+			parts = append(parts, item.key+" "+item.desc)
+		}
+		return strings.Join(parts, " · ")
+	}
+	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Bold(true)
+	item := func(k, desc string) string {
+		return keyStyle.Render(k) + helpStyle.Render(" "+desc)
+	}
+	parts := make([]string, 0, len(items))
+	for _, helpItem := range items {
+		parts = append(parts, item(helpItem.key, helpItem.desc))
+	}
+	return strings.Join(parts, helpStyle.Render(" · "))
+}
+
+func nextRecapRange(current recap.RangeKey) recap.RangeKey {
+	switch current {
+	case recap.RangeDay:
+		return recap.RangeWeek
+	case recap.RangeWeek:
+		return recap.RangeMonth
+	case recap.RangeMonth:
+		return recap.Range90d
+	case recap.Range90d:
+		return recap.RangeDay
+	default:
+		return recap.RangeDay
+	}
+}
+
+func nextRecapView(current recap.ViewMode) recap.ViewMode {
+	switch current {
+	case recap.ViewBoth:
+		return recap.ViewYou
+	case recap.ViewYou:
+		return recap.ViewTeam
+	case recap.ViewTeam:
+		return recap.ViewBoth
+	default:
+		return recap.ViewBoth
+	}
+}
+
+func (m recapTUIModel) nextAgent() string {
+	agents := m.agentIDs()
+	if len(agents) == 0 {
+		return recap.AgentAll
+	}
+	if m.agent == "" || m.agent == recap.AgentAll {
+		return agents[0]
+	}
+	for i, agentID := range agents {
+		if agentID == m.agent {
+			if i == len(agents)-1 {
+				return recap.AgentAll
+			}
+			return agents[i+1]
+		}
+	}
+	return recap.AgentAll
+}
+
+func (m recapTUIModel) agentIDs() []string {
+	if m.resp == nil {
+		return nil
+	}
+	type agentItem struct {
+		id    string
+		label string
+	}
+	items := make([]agentItem, 0, len(m.resp.Agents))
+	for key, entry := range m.resp.Agents {
+		id := entry.AgentID
+		if id == "" {
+			id = key
+		}
+		if id == "" {
+			continue
+		}
+		label := entry.AgentLabel
+		if label == "" {
+			label = id
+		}
+		items = append(items, agentItem{id: id, label: label})
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].label != items[j].label {
+			return items[i].label < items[j].label
+		}
+		return items[i].id < items[j].id
+	})
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.id)
+	}
+	return ids
+}

--- a/cmd/entire/cli/recap_tui.go
+++ b/cmd/entire/cli/recap_tui.go
@@ -25,11 +25,13 @@ type recapTUIOptions struct {
 }
 
 type recapDataMsg struct {
-	resp *recap.MeRecapResponse
+	requestID int
+	resp      *recap.MeRecapResponse
 }
 
 type recapErrMsg struct {
-	err error
+	requestID int
+	err       error
 }
 
 type recapTUIModel struct {
@@ -42,9 +44,10 @@ type recapTUIModel struct {
 	agent    string
 	color    bool
 
-	resp    *recap.MeRecapResponse
-	loadErr error
-	loading bool
+	resp      *recap.MeRecapResponse
+	loadErr   error
+	loading   bool
+	requestID int
 
 	viewport viewport.Model
 	width    int
@@ -71,36 +74,42 @@ func newRecapTUIModel(ctx context.Context, client *api.Client, opts recapTUIOpti
 		opts.Agent = recap.AgentAll
 	}
 	return recapTUIModel{
-		ctx:      ctx,
-		client:   client,
-		repo:     opts.Repo,
-		rangeKey: opts.Range,
-		view:     opts.View,
-		agent:    opts.Agent,
-		color:    opts.Color,
-		loading:  true,
-		width:    recap.DefaultWidth,
-		height:   24,
-		viewport: viewport.New(viewport.WithWidth(recap.DefaultWidth), viewport.WithHeight(23)),
+		ctx:       ctx,
+		client:    client,
+		repo:      opts.Repo,
+		rangeKey:  opts.Range,
+		view:      opts.View,
+		agent:     opts.Agent,
+		color:     opts.Color,
+		loading:   true,
+		requestID: 1,
+		width:     recap.DefaultWidth,
+		height:    24,
+		viewport:  viewport.New(viewport.WithWidth(recap.DefaultWidth), viewport.WithHeight(23)),
 	}
 }
 
 func (m recapTUIModel) Init() tea.Cmd {
-	return m.fetch
+	return m.fetch(m.requestID)
 }
 
-func (m recapTUIModel) fetch() tea.Msg { //nolint:ireturn // bubbletea Cmd signature requires tea.Msg return
-	start, end := m.rangeKey.Bounds(time.Now())
-	resp, err := recap.FetchMeRecap(m.ctx, m.client, start, end, m.repo, 0)
-	if err != nil {
-		return recapErrMsg{err: err}
+func (m recapTUIModel) fetch(requestID int) tea.Cmd {
+	return func() tea.Msg {
+		start, end := m.rangeKey.Bounds(time.Now())
+		resp, err := recap.FetchMeRecap(m.ctx, m.client, start, end, m.repo, 0)
+		if err != nil {
+			return recapErrMsg{requestID: requestID, err: err}
+		}
+		return recapDataMsg{requestID: requestID, resp: resp}
 	}
-	return recapDataMsg{resp: resp}
 }
 
 func (m recapTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn // bubbletea interface
 	switch msg := msg.(type) {
 	case recapDataMsg:
+		if msg.requestID != m.requestID {
+			return m, nil
+		}
 		m.loading = false
 		m.loadErr = nil
 		m.resp = msg.resp
@@ -108,6 +117,9 @@ func (m recapTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:iretu
 		return m, nil
 
 	case recapErrMsg:
+		if msg.requestID != m.requestID {
+			return m, nil
+		}
 		m.loading = false
 		m.loadErr = msg.err
 		return m, nil
@@ -127,10 +139,11 @@ func (m recapTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:iretu
 		switch msg.String() {
 		case "t":
 			m.rangeKey = nextRecapRange(m.rangeKey)
+			m.requestID++
 			m.loading = true
 			m.loadErr = nil
 			m.resp = nil
-			return m.withViewport(), m.fetch
+			return m.withViewport(), m.fetch(m.requestID)
 		case "v":
 			m.view = nextRecapView(m.view)
 			return m.withViewport(), nil
@@ -138,9 +151,10 @@ func (m recapTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:iretu
 			m.agent = m.nextAgent()
 			return m.withViewport(), nil
 		case "r":
+			m.requestID++
 			m.loading = true
 			m.loadErr = nil
-			return m, m.fetch
+			return m, m.fetch(m.requestID)
 		}
 		if key.Matches(msg, keys.Home) {
 			m.viewport.GotoTop()

--- a/cmd/entire/cli/recap_tui_test.go
+++ b/cmd/entire/cli/recap_tui_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/entireio/cli/cmd/entire/cli/recap"
+)
+
+func testRecapTUIModel() recapTUIModel {
+	return recapTUIModel{
+		rangeKey: recap.RangeDay,
+		view:     recap.ViewBoth,
+		agent:    recap.AgentAll,
+		resp: &recap.MeRecapResponse{
+			Agents: map[string]recap.AgentEntry{
+				recapTestAgentCodex: {
+					AgentID:    recapTestAgentCodex,
+					AgentLabel: "Codex",
+				},
+				"claude": {
+					AgentID:    "claude",
+					AgentLabel: "Claude Code",
+				},
+			},
+		},
+	}
+}
+
+func updateRecapTUIModel(t *testing.T, m recapTUIModel, msg tea.Msg) (recapTUIModel, tea.Cmd) {
+	t.Helper()
+
+	updated, cmd := m.Update(msg)
+	result, ok := updated.(recapTUIModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want recapTUIModel", updated)
+	}
+	return result, cmd
+}
+
+func recapRuneKey(r rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: r, Text: string(r)}
+}
+
+func TestRecapTUIModel_TogglesRange(t *testing.T) {
+	t.Parallel()
+
+	m, cmd := updateRecapTUIModel(t, testRecapTUIModel(), recapRuneKey('t'))
+	if m.rangeKey != recap.RangeWeek {
+		t.Fatalf("range = %q, want %q", m.rangeKey, recap.RangeWeek)
+	}
+	if !m.loading {
+		t.Fatal("range toggle should mark model loading")
+	}
+	if cmd == nil {
+		t.Fatal("range toggle should refetch recap data")
+	}
+}
+
+func TestRecapTUIModel_TogglesView(t *testing.T) {
+	t.Parallel()
+
+	m, cmd := updateRecapTUIModel(t, testRecapTUIModel(), recapRuneKey('v'))
+	if m.view != recap.ViewYou {
+		t.Fatalf("view = %q, want %q", m.view, recap.ViewYou)
+	}
+	if cmd != nil {
+		t.Fatal("view toggle should reuse fetched data")
+	}
+}
+
+func TestRecapTUIModel_CyclesAgent(t *testing.T) {
+	t.Parallel()
+
+	m, cmd := updateRecapTUIModel(t, testRecapTUIModel(), recapRuneKey('a'))
+	if m.agent != "claude" {
+		t.Fatalf("agent = %q, want claude", m.agent)
+	}
+	if cmd != nil {
+		t.Fatal("agent toggle should reuse fetched data")
+	}
+
+	m, _ = updateRecapTUIModel(t, m, recapRuneKey('a'))
+	if m.agent != recapTestAgentCodex {
+		t.Fatalf("agent = %q, want %s", m.agent, recapTestAgentCodex)
+	}
+
+	m, _ = updateRecapTUIModel(t, m, recapRuneKey('a'))
+	if m.agent != recap.AgentAll {
+		t.Fatalf("agent = %q, want all", m.agent)
+	}
+}
+
+func TestRecapTUIModel_QuitKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []tea.KeyPressMsg{
+		recapRuneKey('q'),
+		{Code: 'c', Mod: tea.ModCtrl},
+		{Code: tea.KeyEscape},
+	} {
+		_, cmd := updateRecapTUIModel(t, testRecapTUIModel(), key)
+		if cmd == nil {
+			t.Fatalf("key %v: expected quit command, got nil", key)
+		}
+		if _, ok := cmd().(tea.QuitMsg); !ok {
+			t.Fatalf("key %v: expected QuitMsg", key)
+		}
+	}
+}

--- a/cmd/entire/cli/recap_tui_test.go
+++ b/cmd/entire/cli/recap_tui_test.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/entireio/cli/cmd/entire/cli/recap"
 )
 
@@ -40,6 +44,64 @@ func updateRecapTUIModel(t *testing.T, m recapTUIModel, msg tea.Msg) (recapTUIMo
 
 func recapRuneKey(r rune) tea.KeyPressMsg {
 	return tea.KeyPressMsg{Code: r, Text: string(r)}
+}
+
+func testRecapTUIScrollModel() recapTUIModel {
+	vp := viewport.New(viewport.WithWidth(80), viewport.WithHeight(3))
+	vp.SetContent(strings.Join([]string{
+		"line 1",
+		"line 2",
+		"line 3",
+		"line 4",
+		"line 5",
+		"line 6",
+	}, "\n"))
+
+	m := testRecapTUIModel()
+	m.viewport = vp
+	m.ready = true
+	m.width = 80
+	m.height = 4
+	return m
+}
+
+func TestRecapTUIModel_IgnoresStaleFetchResults(t *testing.T) {
+	t.Parallel()
+
+	m := testRecapTUIModel()
+	m.requestID = 2
+	m.loading = true
+	m.resp = nil
+
+	staleResp := &recap.MeRecapResponse{Summary: recap.Summary{
+		Me: recap.SummaryTotals{Sessions: 99},
+	}}
+	m, cmd := updateRecapTUIModel(t, m, recapDataMsg{requestID: 1, resp: staleResp})
+	if cmd != nil {
+		t.Fatal("stale data should not return a command")
+	}
+	if m.resp != nil {
+		t.Fatalf("stale data should not replace current response: %#v", m.resp)
+	}
+	if !m.loading {
+		t.Fatal("stale data should leave current request loading")
+	}
+
+	m, _ = updateRecapTUIModel(t, m, recapErrMsg{requestID: 1, err: errors.New("old failure")})
+	if m.loadErr != nil {
+		t.Fatalf("stale error should be ignored: %v", m.loadErr)
+	}
+
+	freshResp := &recap.MeRecapResponse{Summary: recap.Summary{
+		Me: recap.SummaryTotals{Sessions: 1},
+	}}
+	m, _ = updateRecapTUIModel(t, m, recapDataMsg{requestID: 2, resp: freshResp})
+	if m.resp != freshResp {
+		t.Fatal("current data should update the response")
+	}
+	if m.loading {
+		t.Fatal("current data should clear loading")
+	}
 }
 
 func TestRecapTUIModel_TogglesRange(t *testing.T) {
@@ -88,6 +150,84 @@ func TestRecapTUIModel_CyclesAgent(t *testing.T) {
 	m, _ = updateRecapTUIModel(t, m, recapRuneKey('a'))
 	if m.agent != recap.AgentAll {
 		t.Fatalf("agent = %q, want all", m.agent)
+	}
+}
+
+func TestRecapTUIModel_ScrollKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{name: "arrow down", key: tea.KeyPressMsg{Code: tea.KeyDown}},
+		{name: "vim down", key: recapRuneKey('j')},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m, _ := updateRecapTUIModel(t, testRecapTUIScrollModel(), tt.key)
+			if m.viewport.YOffset() != 1 {
+				t.Fatalf("YOffset = %d, want 1", m.viewport.YOffset())
+			}
+		})
+	}
+}
+
+func TestRecapTUIModel_TopBottomKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		key     tea.KeyPressMsg
+		wantTop bool
+	}{
+		{name: "home", key: tea.KeyPressMsg{Code: tea.KeyHome}, wantTop: true},
+		{name: "vim top", key: recapRuneKey('g'), wantTop: true},
+		{name: "end", key: tea.KeyPressMsg{Code: tea.KeyEnd}},
+		{name: "vim bottom", key: recapRuneKey('G')},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := testRecapTUIScrollModel()
+			if tt.wantTop {
+				m.viewport.GotoBottom()
+			}
+			m, _ = updateRecapTUIModel(t, m, tt.key)
+
+			if tt.wantTop && !m.viewport.AtTop() {
+				t.Fatalf("viewport should be at top, YOffset = %d", m.viewport.YOffset())
+			}
+			if !tt.wantTop && !m.viewport.AtBottom() {
+				t.Fatalf("viewport should be at bottom, YOffset = %d", m.viewport.YOffset())
+			}
+		})
+	}
+}
+
+func TestRecapTUIModel_FooterFitsWidth(t *testing.T) {
+	t.Parallel()
+
+	m := testRecapTUIModel()
+	m.width = 80
+	footer := m.renderFooter()
+	if got := lipgloss.Width(footer); got > m.width {
+		t.Fatalf("wide footer width = %d, want <= %d: %q", got, m.width, footer)
+	}
+	for _, want := range []string{"t range", "v view", "a agent", "r refresh", "↑/↓ scroll", "q quit"} {
+		if !strings.Contains(footer, want) {
+			t.Fatalf("wide footer missing %q: %q", want, footer)
+		}
+	}
+
+	m.width = 18
+	footer = m.renderFooter()
+	if got := lipgloss.Width(footer); got > m.width {
+		t.Fatalf("narrow footer width = %d, want <= %d: %q", got, m.width, footer)
+	}
+	if !strings.Contains(footer, "q quit") {
+		t.Fatalf("narrow footer should keep quit help: %q", footer)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/297
<!-- entire-trail-link-end -->

## Summary

Adds the interactive `entire recap` TUI as a stacked follow-up to #1015.

- Opens the recap TUI automatically when stdout is an interactive terminal and accessibility mode is not enabled.
- Keeps non-TTY, `ACCESSIBLE=1`, and `--static` output on the existing static renderer.
- Reuses the server-backed recap fetch and static renderer for the TUI content.
- Adds range, view, agent, refresh, scroll, and quit controls.
- Fixes agent-filtered static summaries so `--agent` and the TUI agent toggle summarize the selected agent instead of showing all-agent top totals.

## Validation

- `mise run check`
- `mise run lint`
- Partial staged API static smoke: `ENTIRE_API_BASE_URL=https://partial.to go run ./cmd/entire recap --90 --view both --color never --static`
- Partial staged API agent smoke: `ENTIRE_API_BASE_URL=https://partial.to go run ./cmd/entire recap --90 --agent codex --view both --color never --static`
- Partial staged API TUI smoke: `ENTIRE_API_BASE_URL=https://partial.to go run ./cmd/entire recap --90 --view both --color never`
- Live TUI `a` toggle smoke against Partial staged data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Bubble Tea TUI execution path for `entire recap` and changes when output is interactive vs static, which could affect CLI behavior in terminals. Also adjusts recap summary aggregation when filtering by `--agent`, impacting displayed totals.
> 
> **Overview**
> `entire recap` now **opens an interactive Bubble Tea TUI by default** when writing to a terminal (and not in accessible mode), with a new `--static` flag to force the existing static output.
> 
> The new TUI (`recap_tui.go`) reuses the existing server fetch + `RenderStaticRecap` content inside a scrollable viewport and adds key controls for range/view/agent cycling, refresh, and quit. Static recap rendering is fixed so `--agent` (and the TUI agent toggle) recomputes the **summary totals for the selected agent** instead of showing the precomputed all-agent summary; tests were added/updated to cover the new flag, TUI behavior, and agent-filtered summaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a63c9f0c07c8b0ef2588fdd3666017715964b91. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->