### PR TITLE
fix: sign the orphan "Initialize metadata branch" commit

### DIFF
--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -470,6 +470,14 @@ func EnsureMetadataBranch(repo *git.Repository) error {
 	}
 	// Note: No ParentHashes - this is an orphan commit
 
+	// Sign the orphan commit when signing is enabled, matching the path used
+	// for every other metadata-branch commit (see metadata_reconcile.go and
+	// push_common.go). Without this, repos that enforce a "verified
+	// signatures" ruleset on entire/* refs reject the very first push of
+	// the metadata branch with GH013, even though every later commit on it
+	// is correctly signed.
+	checkpoint.SignCommitBestEffort(context.Background(), commit)
+
 	commitObj := repo.Storer.NewEncodedObject()
 	if err := commit.Encode(commitObj); err != nil {
 		return fmt.Errorf("failed to encode orphan commit: %w", err)


### PR DESCRIPTION
## Summary

Fixes #1115.

The orphan commit that bootstraps `entire/checkpoints/v1` is constructed with go-git plumbing and stored directly in `EnsureMetadataBranch` (`strategy/common.go`), bypassing the `SignCommitBestEffort` helper that's used for every other metadata-branch commit (`strategy/metadata_reconcile.go:596`, `strategy/push_common.go:603`).

On repositories that enforce a "Commits must have verified signatures" ruleset on `entire/*` refs (or repo-wide), the unsigned bootstrap commit causes GitHub to reject the **very first** push of the metadata branch with `GH013`, even when every subsequent checkpoint commit is correctly signed (which has been the case since v0.5.6 thanks to `SignCommitBestEffort`):

```
remote: error: GH013: Repository rule violations found for refs/heads/entire/checkpoints/v1.
remote: - Commits must have verified signatures.
remote:   Found 1 violation:
remote:   3540952a9c4ccc9f46b39afa0572f66b67b08318
```

`git cat-file -p` on that commit confirms no `gpgsig` header — it was never offered to a signer.

## Change

One call added to `EnsureMetadataBranch`, between commit construction and encoding, matching the canonical pattern in the rest of the package:

```go
checkpoint.SignCommitBestEffort(context.Background(), commit)
```

`context.Background()` is used because `EnsureMetadataBranch` does not currently take a `context.Context` (and several call sites — including tests — rely on the existing signature). This matches the pattern already used in this file by `EnsureRedactionConfigured`. Threading a real context through can be done in a follow-up if you'd like; happy to do it as a separate PR.

`SignCommitBestEffort` is itself a no-op when signing is disabled or no signer is registered, so this change is safe for users who have not configured signing.

## Test Plan

- `go build ./...` — clean.
- `go test ./cmd/entire/cli/strategy/ ./cmd/entire/cli/checkpoint/` — clean.
- Existing `TestEnsureMetadataBranch/creates_empty_orphan_when_no_remote` still passes (the orphan-creation path is exercised; signing is disabled by default in the test env via no-signer-registered fallback, so the resulting commit is unsigned and the test's tree-emptiness assertion is unaffected).

I did not add a new signing-specific regression test because the existing tests for `SignCommitBestEffort` itself live in the `checkpoint` package (`committed_signing_test.go`) and stub `objectSignerLoader` directly, which is not exposed across packages. Happy to add one in whatever shape you'd like — an exported test helper, an integration test using a real ssh-keygen-generated key, or extending one of the existing `TestEnsureMetadataBranch` subtests.

## Reproduction Steps (for reviewers)

1. Set `commit.gpgsign=true`, `gpg.format=ssh`, and a working `user.signingkey` in your global git config.
2. In an empty repo on GitHub, create a repository ruleset requiring "Commits must have verified signatures" on the ref pattern `entire/**` (or repo-wide).
3. `entire configure --agent <agent> --project --checkpoint-remote github:<owner>/<repo>` in a local clone.
4. Trigger a normal `git push` of any working branch — Entire's `pre-push` hook attempts to sync `entire/checkpoints/v1` and is rejected with `GH013` on the bootstrap commit.

After this fix the bootstrap commit is signed via the user's configured signer, the push succeeds, and the metadata branch is established on the remote.