### PR TITLE
Fix enable agent re-enabling disabled repos

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1468,7 +1468,7 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 	}
 
 	targetFile, configDisplay := settingsTargetFile(ctx, opts.UseLocalSettings, opts.UseProjectSettings)
-	if err := saveSettingsToTarget(ctx, settings, targetFile); err != nil {
+	if err := saveEnabledState(ctx, settings, targetFile == EntireSettingsFile); err != nil {
 		return fmt.Errorf("failed to save settings: %w", err)
 	}
 

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -288,6 +288,43 @@ func TestRunEnable_DefaultFlag_ClearsLocalDisable(t *testing.T) {
 	}
 }
 
+func TestSetupAgentHooksNonInteractive_ClearsLocalDisable(t *testing.T) {
+	setupTestRepo(t)
+	writeSettings(t, testSettingsEnabled)
+	writeClaudeHooksFixture(t)
+
+	var buf bytes.Buffer
+	if err := runDisable(context.Background(), &buf, false); err != nil {
+		t.Fatalf("runDisable() error = %v", err)
+	}
+
+	enabled, err := IsEnabled(context.Background())
+	if err != nil {
+		t.Fatalf("IsEnabled() error = %v", err)
+	}
+	if enabled {
+		t.Fatal("expected disabled after runDisable")
+	}
+
+	ag, err := agent.Get(types.AgentName("claude-code"))
+	if err != nil {
+		t.Fatalf("agent.Get(claude-code) error = %v", err)
+	}
+
+	buf.Reset()
+	if err := setupAgentHooksNonInteractive(context.Background(), &buf, ag, EnableOptions{}); err != nil {
+		t.Fatalf("setupAgentHooksNonInteractive() error = %v", err)
+	}
+
+	enabled, err = IsEnabled(context.Background())
+	if err != nil {
+		t.Fatalf("IsEnabled() error = %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected enabled after setupAgentHooksNonInteractive")
+	}
+}
+
 func TestRunDisable(t *testing.T) {
 	setupTestDir(t)
 	writeSettings(t, testSettingsEnabled)


### PR DESCRIPTION
## Summary

Fixes #988.

`entire enable --agent <name>` already set `Enabled = true`, but it saved through the single-target settings path. When `.entire/settings.local.json` still contained `enabled:false` from a previous `entire disable`, that local override continued to win and the repo remained effectively disabled.

This updates the non-interactive agent setup path to use the same enabled-state save behavior as `entire enable`, keeping project and existing local settings in sync for the enabled state.

## Testing

- `mise run lint`
- `mise run test`
- Added regression coverage for the disabled local-settings override case