### PR TITLE
feat: machine-readable export surface for sessions and checkpoints

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -228,6 +228,7 @@ func newExplainCmd() *cobra.Command {
 	var jsonFlag bool
 	var transcriptFlag bool
 	sessionIndex := -1
+	listLimit := 0 // 0 means "use default (branchCheckpointsLimit)"
 
 	cmd := &cobra.Command{
 		Use:   "explain [checkpoint-id | commit-sha]",
@@ -264,6 +265,9 @@ Machine-readable export modes (additive surface for external consumers):
   --session-index  Pick a session within a multi-session checkpoint (0-based).
                    Defaults to the latest session. Only meaningful with
                    --transcript or --raw-transcript.
+  --limit          Cap the number of checkpoints returned by the list view.
+                   Defaults to 100. When the cap is hit, a stderr note
+                   says how many were skipped. Only meaningful with --json.
 
 Summary generation:
   --generate    Generate an AI summary for the checkpoint
@@ -332,6 +336,14 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 					return errors.New("--session-index must be non-negative")
 				}
 			}
+			if cmd.Flags().Changed("limit") {
+				if !jsonFlag {
+					return errors.New("--limit only applies with --json")
+				}
+				if listLimit <= 0 {
+					return errors.New("--limit must be positive")
+				}
+			}
 
 			// Export modes — emit machine-readable output and skip the prose pipeline.
 			// --raw-transcript also routes here when --session-index is explicit; the
@@ -348,6 +360,7 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 					transcript:     transcriptFlag,
 					rawTranscript:  rawTranscriptFlag,
 					sessionIndex:   sessionIndex,
+					listLimit:      listLimit,
 				})
 			}
 
@@ -370,6 +383,7 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output metadata as JSON (no transcript bytes)")
 	cmd.Flags().BoolVar(&transcriptFlag, "transcript", false, "Stream compact normalized transcript bytes to stdout (pair with --raw-transcript for the per-agent raw transcript)")
 	cmd.Flags().IntVar(&sessionIndex, "session-index", -1, "Session index within a multi-session checkpoint (0-based, defaults to latest)")
+	cmd.Flags().IntVar(&listLimit, "limit", 0, "Cap the list view at N checkpoints (default: 100). Only meaningful with --json.")
 
 	// Verbosity / transcript output modes are mutually exclusive
 	cmd.MarkFlagsMutuallyExclusive("short", "full", "raw-transcript", "transcript", "json")

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -225,6 +225,9 @@ func newExplainCmd() *cobra.Command {
 	var generateFlag bool
 	var forceFlag bool
 	var searchAllFlag bool
+	var jsonFlag bool
+	var transcriptFlag bool
+	sessionIndex := -1
 
 	cmd := &cobra.Command{
 		Use:   "explain [checkpoint-id | commit-sha]",
@@ -250,6 +253,17 @@ Output verbosity levels (when explaining a specific item):
   --short          Summary only (ID, session, timestamp, tokens, intent)
   --full           Parsed full transcript (all prompts/responses from entire session)
   --raw-transcript Raw transcript file (JSONL format)
+
+Machine-readable export modes (additive surface for external consumers):
+  --json           Metadata-only JSON. Lists checkpoints when no target is given;
+                   emits a single checkpoint envelope when a target is supplied.
+                   Transcript bytes are NEVER embedded in the JSON envelope.
+  --transcript     Stream the normalized compact transcript bytes (JSONL on
+                   /main) to stdout for the selected session. Pair with
+                   --raw-transcript for the per-agent raw transcript instead.
+  --session-index  Pick a session within a multi-session checkpoint (0-based).
+                   Defaults to the latest session. Only meaningful with
+                   --transcript or --raw-transcript.
 
 Summary generation:
   --generate    Generate an AI summary for the checkpoint
@@ -307,6 +321,35 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 			if rawTranscriptFlag && !hasCheckpointTarget {
 				return errors.New("--raw-transcript requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
 			}
+			if transcriptFlag && !hasCheckpointTarget {
+				return errors.New("--transcript requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
+			}
+			if cmd.Flags().Changed("session-index") {
+				if !transcriptFlag && !rawTranscriptFlag {
+					return errors.New("--session-index only applies with --transcript or --raw-transcript")
+				}
+				if sessionIndex < 0 {
+					return errors.New("--session-index must be non-negative")
+				}
+			}
+
+			// Export modes — emit machine-readable output and skip the prose pipeline.
+			// --raw-transcript also routes here when --session-index is explicit; the
+			// legacy raw-transcript path (with spinner + prefetch) handles the default
+			// case where the caller wants the latest session.
+			rawWithSessionIndex := rawTranscriptFlag && cmd.Flags().Changed("session-index")
+			if jsonFlag || transcriptFlag || rawWithSessionIndex {
+				return runExplainExport(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), explainExportOptions{
+					sessionFilter:  sessionFlag,
+					commitRef:      commitFlag,
+					checkpointFlag: checkpointFlag,
+					target:         positional,
+					json:           jsonFlag,
+					transcript:     transcriptFlag,
+					rawTranscript:  rawTranscriptFlag,
+					sessionIndex:   sessionIndex,
+				})
+			}
 
 			// Convert short flag to verbose (verbose = !short)
 			verbose := !shortFlag
@@ -324,11 +367,17 @@ Note: --session filters the list view; the positional arg, --commit, and --check
 	cmd.Flags().BoolVar(&generateFlag, "generate", false, "Generate an AI summary for the checkpoint")
 	cmd.Flags().BoolVar(&forceFlag, "force", false, "Regenerate summary even if one already exists (requires --generate)")
 	cmd.Flags().BoolVar(&searchAllFlag, "search-all", false, "Search all commits (no branch/depth limit, may be slow)")
+	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output metadata as JSON (no transcript bytes)")
+	cmd.Flags().BoolVar(&transcriptFlag, "transcript", false, "Stream compact normalized transcript bytes to stdout (pair with --raw-transcript for the per-agent raw transcript)")
+	cmd.Flags().IntVar(&sessionIndex, "session-index", -1, "Session index within a multi-session checkpoint (0-based, defaults to latest)")
 
-	// Make --short, --full, and --raw-transcript mutually exclusive
-	cmd.MarkFlagsMutuallyExclusive("short", "full", "raw-transcript")
+	// Verbosity / transcript output modes are mutually exclusive
+	cmd.MarkFlagsMutuallyExclusive("short", "full", "raw-transcript", "transcript", "json")
 	// --generate and --raw-transcript are incompatible (summary would be generated but not shown)
 	cmd.MarkFlagsMutuallyExclusive("generate", "raw-transcript")
+	// --generate is a write op; export modes are reader-only
+	cmd.MarkFlagsMutuallyExclusive("generate", "json")
+	cmd.MarkFlagsMutuallyExclusive("generate", "transcript")
 
 	return cmd
 }

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -551,40 +551,8 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		return lookupErr
 	}
 
-	// Collect all matching checkpoint IDs to detect ambiguity
-	var matches []id.CheckpointID
-	for _, info := range lookup.committed {
-		if strings.HasPrefix(info.CheckpointID.String(), checkpointIDPrefix) {
-			matches = append(matches, info.CheckpointID)
-		}
-	}
-
-	// If not found locally, fetch metadata from remote and retry. Reuses
-	// resume's getMetadataTree / getV2MetadataTree helpers — they already
-	// implement the checkpoint_remote → treeless origin → full origin chain
-	// and return a fresh repo handle (which we discard; the post-fetch
-	// rebuild via newExplainCheckpointLookup opens its own).
-	if len(matches) == 0 {
-		stop := startSpinner(errW, "Fetching checkpoint metadata from remote")
-		_, _, v1Err := getMetadataTree(ctx)
-		v2OK := false
-		if lookup.preferCheckpointsV2 {
-			if _, _, v2Err := getV2MetadataTree(ctx); v2Err == nil {
-				v2OK = true
-			}
-		}
-		stop(false)
-		if v1Err == nil || v2OK {
-			if freshLookup, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {
-				lookup = freshLookup
-				for _, info := range lookup.committed {
-					if strings.HasPrefix(info.CheckpointID.String(), checkpointIDPrefix) {
-						matches = append(matches, info.CheckpointID)
-					}
-				}
-			}
-		}
-	}
+	// Match the prefix locally; on miss, fetch from remote and retry once.
+	matches, lookup := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, checkpointIDPrefix)
 
 	var fullCheckpointID id.CheckpointID
 	switch len(matches) {

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -11,8 +11,26 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 )
+
+// checkpointMatchesSessionFilter returns true when any session that
+// contributed to this checkpoint has an ID prefixed by sessionFilter.
+// Multi-session checkpoints expose archived contributors via SessionIDs;
+// matching only against SessionID (the latest contributor) silently drops
+// any checkpoint where the requested session was archived.
+func checkpointMatchesSessionFilter(p strategy.RewindPoint, sessionFilter string) bool {
+	if strings.HasPrefix(p.SessionID, sessionFilter) {
+		return true
+	}
+	for _, sid := range p.SessionIDs {
+		if strings.HasPrefix(sid, sessionFilter) {
+			return true
+		}
+	}
+	return false
+}
 
 // explainExportOptions describes a request for one of the machine-readable
 // output modes of `entire checkpoint explain`. Exactly one of json,
@@ -248,6 +266,12 @@ func runExplainStreamTranscript(ctx context.Context, w, errW io.Writer, opts exp
 // checkpointExportJSON is the metadata-only envelope returned by
 // `entire checkpoint explain --json`. It exposes only existing CheckpointSummary
 // and CommittedMetadata fields — no schema invention, no transcript bytes.
+//
+// `partial` is true when any session metadata read failed; the offending
+// entries surface their cause via Sessions[].error. Consumers that don't
+// want to inspect every entry can branch on this single top-level flag.
+// The command also exits non-zero in that case so automation doesn't
+// mistake incomplete data for a clean export.
 type checkpointExportJSON struct {
 	CheckpointID     string                  `json:"checkpoint_id"`
 	Strategy         string                  `json:"strategy,omitempty"`
@@ -257,6 +281,7 @@ type checkpointExportJSON struct {
 	HasReview        bool                    `json:"has_review,omitempty"`
 	SessionCount     int                     `json:"session_count"`
 	Sessions         []checkpointSessionJSON `json:"sessions"`
+	Partial          bool                    `json:"partial,omitempty"`
 }
 
 type checkpointSessionJSON struct {
@@ -317,25 +342,39 @@ func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts expla
 	}
 
 	envelope.Sessions = make([]checkpointSessionJSON, 0, len(summary.Sessions))
+	var failedSessions []int
 	for idx := range summary.Sessions {
 		meta, metaErr := readSessionMetadataForExport(ctx, reader, cpID, idx)
 		if metaErr != nil {
 			// Surface the per-session error as a stub entry with an explicit
 			// error string rather than failing the whole envelope or silently
-			// returning empty fields. Consumers branch on the `error` field.
+			// returning empty fields. Consumers branch on the `error` field
+			// and the top-level `partial` flag.
 			envelope.Sessions = append(envelope.Sessions, checkpointSessionJSON{
 				Index: idx,
 				Error: metaErr.Error(),
 			})
+			failedSessions = append(failedSessions, idx)
 			continue
 		}
 		envelope.Sessions = append(envelope.Sessions, sessionMetadataToJSON(idx, meta))
 	}
+	envelope.Partial = len(failedSessions) > 0
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(envelope); err != nil {
 		return fmt.Errorf("failed to encode checkpoint json: %w", err)
+	}
+
+	// Fail hard so automation can't mistake incomplete metadata for a clean
+	// export. The envelope (with its `partial` flag and per-session error
+	// fields) has already been written to stdout; using SilentError keeps
+	// the diagnostic on stderr from interleaving with that output.
+	if envelope.Partial {
+		fmt.Fprintf(errW, "checkpoint %s: failed to read metadata for %d session(s) (indexes %v)\n",
+			cpID, len(failedSessions), failedSessions)
+		return NewSilentError(fmt.Errorf("checkpoint %s export incomplete: %d session(s) unreadable", cpID, len(failedSessions)))
 	}
 	return nil
 }
@@ -441,7 +480,7 @@ func runExplainListJSON(ctx context.Context, w io.Writer, sessionFilter string) 
 
 	out := make([]branchCheckpointJSON, 0, len(points))
 	for _, p := range points {
-		if sessionFilter != "" && !strings.HasPrefix(p.SessionID, sessionFilter) {
+		if sessionFilter != "" && !checkpointMatchesSessionFilter(p, sessionFilter) {
 			continue
 		}
 		entry := branchCheckpointJSON{

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -37,7 +37,8 @@ type explainExportOptions struct {
 func runExplainExport(ctx context.Context, w, errW io.Writer, opts explainExportOptions) error {
 	hasTarget := opts.target != "" || opts.commitRef != "" || opts.checkpointFlag != ""
 
-	if opts.transcript || opts.rawTranscript {
+	switch {
+	case opts.transcript || opts.rawTranscript:
 		if !hasTarget {
 			flagName := "--transcript"
 			if opts.rawTranscript {
@@ -46,13 +47,17 @@ func runExplainExport(ctx context.Context, w, errW io.Writer, opts explainExport
 			return fmt.Errorf("%s requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag", flagName)
 		}
 		return runExplainStreamTranscript(ctx, w, errW, opts)
+	case opts.json:
+		if !hasTarget {
+			return runExplainListJSON(ctx, w, opts.sessionFilter)
+		}
+		return runExplainCheckpointJSON(ctx, w, errW, opts)
+	default:
+		// The cobra layer guarantees at least one mode flag is set before
+		// dispatching here; this branch is a defensive guard against a
+		// future caller invoking runExplainExport directly with no mode.
+		return errors.New("internal: runExplainExport called without an output mode (json, transcript, or raw-transcript)")
 	}
-
-	// JSON mode.
-	if !hasTarget {
-		return runExplainListJSON(ctx, w, opts.sessionFilter)
-	}
-	return runExplainCheckpointJSON(ctx, w, errW, opts)
 }
 
 // resolveExplainCheckpointID resolves a target to a fully-qualified checkpoint

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -46,6 +46,9 @@ type explainExportOptions struct {
 	transcript     bool
 	rawTranscript  bool
 	sessionIndex   int
+	// listLimit caps the JSON list view at N entries. 0 means use the
+	// default (branchCheckpointsLimit). Only consulted in list mode.
+	listLimit int
 }
 
 // runExplainExport handles --json, --transcript, and --raw-transcript with an
@@ -67,7 +70,7 @@ func runExplainExport(ctx context.Context, w, errW io.Writer, opts explainExport
 		return runExplainStreamTranscript(ctx, w, errW, opts)
 	case opts.json:
 		if !hasTarget {
-			return runExplainListJSON(ctx, w, opts.sessionFilter)
+			return runExplainListJSON(ctx, w, errW, opts.sessionFilter, opts.listLimit)
 		}
 		return runExplainCheckpointJSON(ctx, w, errW, opts)
 	default:
@@ -81,14 +84,16 @@ func runExplainExport(ctx context.Context, w, errW io.Writer, opts explainExport
 // resolveExplainCheckpointID resolves a target to a fully-qualified checkpoint
 // ID. Resolution order matches the prose explain command:
 //
-//  1. --commit <ref>  → resolve as a git commit, read Entire-Checkpoint trailer.
+//  1. --commit <ref>  → resolve as a git commit, read Entire-Checkpoint
+//     trailer; remote metadata fetch-on-miss when the trailer points at
+//     an unknown checkpoint.
 //  2. --checkpoint <id> or positional checkpoint-id-prefix → match against
 //     committed checkpoints, with remote metadata fetch-on-miss.
 //  3. Positional that fails as a checkpoint prefix falls back to commit-ref
 //     resolution (mirrors runExplainAuto).
 func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explainExportOptions) (id.CheckpointID, *explainCheckpointLookup, error) {
 	if opts.commitRef != "" {
-		return resolveCheckpointFromCommitRef(ctx, opts.commitRef)
+		return resolveCheckpointFromCommitRef(ctx, errW, opts.commitRef)
 	}
 
 	prefix := opts.checkpointFlag
@@ -113,7 +118,7 @@ func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explai
 		// one more shot as a commit ref before failing — mirrors the prose
 		// runExplainAuto behavior so `--json <commit-sha>` works.
 		if opts.target != "" && opts.checkpointFlag == "" {
-			cpID, freshLookup, commitErr := resolveCheckpointFromCommitRef(ctx, opts.target)
+			cpID, freshLookup, commitErr := resolveCheckpointFromCommitRef(ctx, errW, opts.target)
 			if commitErr == nil {
 				return cpID, freshLookup, nil
 			}
@@ -124,10 +129,13 @@ func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explai
 	}
 }
 
-// resolveCheckpointFromCommitRef opens the repo, resolves a git commit-ish, and
-// extracts the Entire-Checkpoint trailer. Returns a fresh lookup so the caller
-// can read the checkpoint metadata.
-func resolveCheckpointFromCommitRef(ctx context.Context, commitRef string) (id.CheckpointID, *explainCheckpointLookup, error) {
+// resolveCheckpointFromCommitRef opens the repo, resolves a git commit-ish,
+// and extracts the Entire-Checkpoint trailer. If the resolved checkpoint
+// isn't present in the local committed list, retries once after fetching
+// metadata from the remote — symmetry with the prefix path so
+// `--commit <sha>` and `--checkpoint <prefix>` share the same fetch
+// behavior.
+func resolveCheckpointFromCommitRef(ctx context.Context, errW io.Writer, commitRef string) (id.CheckpointID, *explainCheckpointLookup, error) {
 	repo, err := openRepository(ctx)
 	if err != nil {
 		return id.CheckpointID(""), nil, fmt.Errorf("not a git repository: %w", err)
@@ -148,7 +156,27 @@ func resolveCheckpointFromCommitRef(ctx context.Context, commitRef string) (id.C
 	if lookupErr != nil {
 		return id.CheckpointID(""), nil, lookupErr
 	}
+
+	// If the trailer points at a checkpoint we don't have locally, do the
+	// same remote-fetch retry the prefix path uses; otherwise downstream
+	// metadata reads would fail with an immediate "not found".
+	if !lookupHasCheckpoint(lookup, cpID) {
+		if matches, fresh := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, cpID.String()); len(matches) == 1 {
+			lookup = fresh
+		}
+	}
 	return cpID, lookup, nil
+}
+
+// lookupHasCheckpoint reports whether cpID is in the lookup's local committed
+// list. Callers use this before triggering a remote-fetch retry.
+func lookupHasCheckpoint(lookup *explainCheckpointLookup, cpID id.CheckpointID) bool {
+	for _, info := range lookup.committed {
+		if info.CheckpointID == cpID {
+			return true
+		}
+	}
+	return false
 }
 
 // matchCheckpointPrefixWithRemoteFallback returns all committed checkpoints
@@ -216,7 +244,11 @@ func resolveSessionIndex(summary *checkpoint.CheckpointSummary, requested int) (
 
 // runExplainStreamTranscript streams either the compact transcript (default)
 // or the raw transcript (when --raw-transcript is set) for the selected
-// session of the resolved checkpoint.
+// session of the resolved checkpoint. When --transcript is used on a
+// v1-only checkpoint (compact transcripts are a v2-only artifact), falls
+// through to the raw transcript with a one-line stderr note rather than
+// erroring — the consumer's stated intent is "give me transcript bytes",
+// and we have a way to satisfy it without making them re-run.
 func runExplainStreamTranscript(ctx context.Context, w, errW io.Writer, opts explainExportOptions) error {
 	cpID, lookup, err := resolveExplainCheckpointID(ctx, errW, opts)
 	if err != nil {
@@ -228,29 +260,30 @@ func runExplainStreamTranscript(ctx context.Context, w, errW io.Writer, opts exp
 		return fmt.Errorf("failed to read checkpoint: %w", err)
 	}
 
+	v2Reader, isV2 := reader.(*checkpoint.V2GitStore)
+	wantCompact := !opts.rawTranscript
+
 	idx, err := resolveSessionIndex(summary, opts.sessionIndex)
 	if err != nil {
 		return err
 	}
 
-	if opts.rawTranscript {
+	// Compact transcripts are only stored on v2; transparently fall through
+	// to raw on v1 so consumers don't need to retry.
+	if wantCompact && !isV2 {
+		fmt.Fprintln(errW, "note: compact transcript unavailable on v1 checkpoint, falling back to raw transcript")
+		wantCompact = false
+	}
+
+	if !wantCompact {
 		content, readErr := reader.ReadSessionContent(ctx, cpID, idx)
 		if readErr != nil {
 			return fmt.Errorf("failed to read session content: %w", readErr)
-		}
-		if len(content.Transcript) == 0 {
-			return fmt.Errorf("checkpoint %s session %d has no raw transcript", cpID, idx)
 		}
 		if _, err := w.Write(content.Transcript); err != nil {
 			return fmt.Errorf("failed to write transcript: %w", err)
 		}
 		return nil
-	}
-
-	// Compact transcript path: only v2 stores have a normalized transcript.jsonl.
-	v2Reader, ok := reader.(*checkpoint.V2GitStore)
-	if !ok {
-		return errors.New("compact transcript is only available for v2 checkpoints (try --raw-transcript)")
 	}
 
 	compact, err := v2Reader.ReadSessionCompactTranscript(ctx, cpID, idx)
@@ -331,6 +364,34 @@ func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts expla
 		return fmt.Errorf("failed to read checkpoint: %w", err)
 	}
 
+	envelope, failedSessions := buildCheckpointJSONEnvelope(ctx, reader, summary, cpID)
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(envelope); err != nil {
+		return fmt.Errorf("failed to encode checkpoint json: %w", err)
+	}
+
+	// Fail hard so automation can't mistake incomplete metadata for a clean
+	// export. The envelope (with its `partial` flag and per-session error
+	// fields) has already been written to stdout; using SilentError keeps
+	// the diagnostic on stderr from interleaving with that output.
+	if envelope.Partial {
+		fmt.Fprintf(errW, "checkpoint %s: failed to read metadata for %d session(s) (indexes %v)\n",
+			cpID, len(failedSessions), failedSessions)
+		return NewSilentError(fmt.Errorf("checkpoint %s export incomplete: %d session(s) unreadable", cpID, len(failedSessions)))
+	}
+	return nil
+}
+
+// buildCheckpointJSONEnvelope builds the JSON envelope for a single checkpoint,
+// reading each session's metadata via the supplied reader. Returns the envelope
+// plus the list of session indexes that failed to read; a non-empty failed
+// list means envelope.Partial is true. Extracted from runExplainCheckpointJSON
+// so the envelope-building behavior (per-session error fields, partial flag)
+// can be tested independently of the v2 git tree, which the cli package
+// can't easily corrupt.
+func buildCheckpointJSONEnvelope(ctx context.Context, reader checkpoint.CommittedReader, summary *checkpoint.CheckpointSummary, cpID id.CheckpointID) (checkpointExportJSON, []int) {
 	envelope := checkpointExportJSON{
 		CheckpointID:     cpID.String(),
 		Strategy:         summary.Strategy,
@@ -360,23 +421,7 @@ func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts expla
 		envelope.Sessions = append(envelope.Sessions, sessionMetadataToJSON(idx, meta))
 	}
 	envelope.Partial = len(failedSessions) > 0
-
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(envelope); err != nil {
-		return fmt.Errorf("failed to encode checkpoint json: %w", err)
-	}
-
-	// Fail hard so automation can't mistake incomplete metadata for a clean
-	// export. The envelope (with its `partial` flag and per-session error
-	// fields) has already been written to stdout; using SilentError keeps
-	// the diagnostic on stderr from interleaving with that output.
-	if envelope.Partial {
-		fmt.Fprintf(errW, "checkpoint %s: failed to read metadata for %d session(s) (indexes %v)\n",
-			cpID, len(failedSessions), failedSessions)
-		return NewSilentError(fmt.Errorf("checkpoint %s export incomplete: %d session(s) unreadable", cpID, len(failedSessions)))
-	}
-	return nil
+	return envelope, failedSessions
 }
 
 // readSessionMetadataForExport reads only metadata.json for a session — no
@@ -460,14 +505,27 @@ type branchCheckpointJSON struct {
 }
 
 // runExplainListJSON emits a JSON array of branch checkpoints, optionally
-// filtered by session ID prefix (mirrors the prose list view).
-func runExplainListJSON(ctx context.Context, w io.Writer, sessionFilter string) error {
+// filtered by session ID prefix (mirrors the prose list view). The cap
+// defaults to branchCheckpointsLimit; pass listLimit > 0 to override.
+//
+// Truncation detection: we ask the underlying lister for one more than the
+// effective cap. If we got that many back, we know there were at least
+// `cap` checkpoints we didn't return — emit a stderr note so the consumer
+// knows to set --limit higher. The JSON shape stays a flat array so jq
+// pipelines don't have to unwrap.
+func runExplainListJSON(ctx context.Context, w, errW io.Writer, sessionFilter string, listLimit int) error {
 	repo, err := openRepository(ctx)
 	if err != nil {
 		return fmt.Errorf("not a git repository: %w", err)
 	}
 
-	points, err := getBranchCheckpoints(ctx, repo, branchCheckpointsLimit)
+	limit := listLimit
+	if limit <= 0 {
+		limit = branchCheckpointsLimit
+	}
+
+	// Probe one extra so we can detect truncation.
+	points, err := getBranchCheckpoints(ctx, repo, limit+1)
 	if err != nil {
 		if ctx.Err() != nil {
 			return NewSilentError(ctx.Err())
@@ -476,6 +534,10 @@ func runExplainListJSON(ctx context.Context, w io.Writer, sessionFilter string) 
 		// swallow the error. Surface it so scripts get a non-zero exit and
 		// a real diagnostic instead of silently degraded output.
 		return fmt.Errorf("failed to list checkpoints: %w", err)
+	}
+	truncated := len(points) > limit
+	if truncated {
+		points = points[:limit]
 	}
 
 	out := make([]branchCheckpointJSON, 0, len(points))
@@ -505,6 +567,10 @@ func runExplainListJSON(ctx context.Context, w io.Writer, sessionFilter string) 
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(out); err != nil {
 		return fmt.Errorf("failed to encode checkpoint list: %w", err)
+	}
+
+	if truncated {
+		fmt.Fprintf(errW, "note: list capped at %d checkpoints; rerun with --limit <N> to see more\n", limit)
 	}
 	return nil
 }

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -15,8 +15,10 @@ import (
 )
 
 // explainExportOptions describes a request for one of the machine-readable
-// output modes of `entire checkpoint explain`. Exactly one of the json or
-// transcript flags is set when this struct is dispatched.
+// output modes of `entire checkpoint explain`. Exactly one of json,
+// transcript, or rawTranscript is set when this struct reaches
+// runExplainExport. sessionIndex is meaningful only for transcript /
+// rawTranscript requests; cobra-layer validation rejects it elsewhere.
 type explainExportOptions struct {
 	sessionFilter  string
 	commitRef      string
@@ -228,11 +230,11 @@ func runExplainStreamTranscript(ctx context.Context, w, errW io.Writer, opts exp
 		return errors.New("compact transcript is only available for v2 checkpoints (try --raw-transcript)")
 	}
 
-	bytes, err := v2Reader.ReadSessionCompactTranscript(ctx, cpID, idx)
+	compact, err := v2Reader.ReadSessionCompactTranscript(ctx, cpID, idx)
 	if err != nil {
 		return fmt.Errorf("failed to read compact transcript: %w", err)
 	}
-	if _, err := w.Write(bytes); err != nil {
+	if _, err := w.Write(compact); err != nil {
 		return fmt.Errorf("failed to write transcript: %w", err)
 	}
 	return nil

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -37,7 +37,11 @@ func runExplainExport(ctx context.Context, w, errW io.Writer, opts explainExport
 
 	if opts.transcript || opts.rawTranscript {
 		if !hasTarget {
-			return errors.New("--transcript requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
+			flagName := "--transcript"
+			if opts.rawTranscript {
+				flagName = "--raw-transcript"
+			}
+			return fmt.Errorf("%s requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag", flagName)
 		}
 		return runExplainStreamTranscript(ctx, w, errW, opts)
 	}
@@ -49,32 +53,17 @@ func runExplainExport(ctx context.Context, w, errW io.Writer, opts explainExport
 	return runExplainCheckpointJSON(ctx, w, errW, opts)
 }
 
-// resolveExplainCheckpointID resolves a target (positional, --checkpoint, or
-// --commit) to a fully-qualified checkpoint ID using the existing lookup
-// infrastructure (including remote metadata fetch on miss).
+// resolveExplainCheckpointID resolves a target to a fully-qualified checkpoint
+// ID. Resolution order matches the prose explain command:
+//
+//  1. --commit <ref>  → resolve as a git commit, read Entire-Checkpoint trailer.
+//  2. --checkpoint <id> or positional checkpoint-id-prefix → match against
+//     committed checkpoints, with remote metadata fetch-on-miss.
+//  3. Positional that fails as a checkpoint prefix falls back to commit-ref
+//     resolution (mirrors runExplainAuto).
 func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explainExportOptions) (id.CheckpointID, *explainCheckpointLookup, error) {
 	if opts.commitRef != "" {
-		repo, err := openRepository(ctx)
-		if err != nil {
-			return id.CheckpointID(""), nil, fmt.Errorf("not a git repository: %w", err)
-		}
-		hash, _, err := resolveCommitUnambiguous(repo, opts.commitRef)
-		if err != nil {
-			return id.CheckpointID(""), nil, fmt.Errorf("commit not found: %s: %w", opts.commitRef, err)
-		}
-		commit, err := repo.CommitObject(hash)
-		if err != nil {
-			return id.CheckpointID(""), nil, fmt.Errorf("failed to read commit: %w", err)
-		}
-		cpID, found := trailers.ParseCheckpoint(commit.Message)
-		if !found {
-			return id.CheckpointID(""), nil, fmt.Errorf("commit %s has no Entire-Checkpoint trailer", commit.Hash)
-		}
-		lookup, lookupErr := newExplainCheckpointLookup(ctx)
-		if lookupErr != nil {
-			return id.CheckpointID(""), nil, lookupErr
-		}
-		return cpID, lookup, nil
+		return resolveCheckpointFromCommitRef(ctx, opts.commitRef)
 	}
 
 	prefix := opts.checkpointFlag
@@ -90,33 +79,80 @@ func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explai
 		return id.CheckpointID(""), nil, lookupErr
 	}
 
-	matches := matchCheckpointPrefix(lookup, prefix)
-	if len(matches) == 0 {
-		stop := startSpinner(errW, "Fetching checkpoint metadata from remote")
-		_, _, v1Err := getMetadataTree(ctx)
-		v2OK := false
-		if lookup.preferCheckpointsV2 {
-			if _, _, v2Err := getV2MetadataTree(ctx); v2Err == nil {
-				v2OK = true
-			}
-		}
-		stop(false)
-		if v1Err == nil || v2OK {
-			if fresh, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {
-				lookup = fresh
-				matches = matchCheckpointPrefix(lookup, prefix)
-			}
-		}
-	}
-
+	matches, lookup := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, prefix)
 	switch len(matches) {
-	case 0:
-		return id.CheckpointID(""), lookup, fmt.Errorf("%w: %s", checkpoint.ErrCheckpointNotFound, prefix)
 	case 1:
 		return matches[0], lookup, nil
+	case 0:
+		// If the user passed a positional target (not --checkpoint), give it
+		// one more shot as a commit ref before failing — mirrors the prose
+		// runExplainAuto behavior so `--json <commit-sha>` works.
+		if opts.target != "" && opts.checkpointFlag == "" {
+			cpID, freshLookup, commitErr := resolveCheckpointFromCommitRef(ctx, opts.target)
+			if commitErr == nil {
+				return cpID, freshLookup, nil
+			}
+		}
+		return id.CheckpointID(""), lookup, fmt.Errorf("%w: %s", checkpoint.ErrCheckpointNotFound, prefix)
 	default:
 		return id.CheckpointID(""), lookup, fmt.Errorf("%w: %s matches %d checkpoints", errAmbiguousCommitPrefix, prefix, len(matches))
 	}
+}
+
+// resolveCheckpointFromCommitRef opens the repo, resolves a git commit-ish, and
+// extracts the Entire-Checkpoint trailer. Returns a fresh lookup so the caller
+// can read the checkpoint metadata.
+func resolveCheckpointFromCommitRef(ctx context.Context, commitRef string) (id.CheckpointID, *explainCheckpointLookup, error) {
+	repo, err := openRepository(ctx)
+	if err != nil {
+		return id.CheckpointID(""), nil, fmt.Errorf("not a git repository: %w", err)
+	}
+	hash, _, err := resolveCommitUnambiguous(repo, commitRef)
+	if err != nil {
+		return id.CheckpointID(""), nil, fmt.Errorf("commit not found: %s: %w", commitRef, err)
+	}
+	commit, err := repo.CommitObject(hash)
+	if err != nil {
+		return id.CheckpointID(""), nil, fmt.Errorf("failed to read commit: %w", err)
+	}
+	cpID, found := trailers.ParseCheckpoint(commit.Message)
+	if !found {
+		return id.CheckpointID(""), nil, fmt.Errorf("commit %s has no Entire-Checkpoint trailer", commit.Hash)
+	}
+	lookup, lookupErr := newExplainCheckpointLookup(ctx)
+	if lookupErr != nil {
+		return id.CheckpointID(""), nil, lookupErr
+	}
+	return cpID, lookup, nil
+}
+
+// matchCheckpointPrefixWithRemoteFallback returns all committed checkpoints
+// whose ID starts with prefix. On a local miss, fetches metadata from the
+// remote (treeless origin → full origin chain) and retries once with a fresh
+// lookup. The returned lookup may differ from the input on retry.
+func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer, lookup *explainCheckpointLookup, prefix string) ([]id.CheckpointID, *explainCheckpointLookup) {
+	matches := matchCheckpointPrefix(lookup, prefix)
+	if len(matches) > 0 {
+		return matches, lookup
+	}
+
+	stop := startSpinner(errW, "Fetching checkpoint metadata from remote")
+	_, _, v1Err := getMetadataTree(ctx)
+	v2OK := false
+	if lookup.preferCheckpointsV2 {
+		if _, _, v2Err := getV2MetadataTree(ctx); v2Err == nil {
+			v2OK = true
+		}
+	}
+	stop(false)
+	if v1Err != nil && !v2OK {
+		return nil, lookup
+	}
+	fresh, freshErr := newExplainCheckpointLookup(ctx)
+	if freshErr != nil {
+		return nil, lookup
+	}
+	return matchCheckpointPrefix(fresh, prefix), fresh
 }
 
 func matchCheckpointPrefix(lookup *explainCheckpointLookup, prefix string) []id.CheckpointID {
@@ -129,12 +165,20 @@ func matchCheckpointPrefix(lookup *explainCheckpointLookup, prefix string) []id.
 	return matches
 }
 
+// errCheckpointHasNoSessions distinguishes "this checkpoint has zero sessions"
+// from checkpoint.ErrCheckpointNotFound — callers using errors.Is on the
+// not-found sentinel were getting wrong-fault UX (e.g. "did you mistype the
+// ID?") for a legitimate empty-checkpoint edge case.
+var errCheckpointHasNoSessions = errors.New("checkpoint has no sessions")
+
 // resolveSessionIndex maps the user's --session-index value (or the implicit
-// default) onto a valid 0-based offset within summary.Sessions. Returns an
-// error when the requested index exceeds the available range.
+// default) onto a valid 0-based offset within summary.Sessions.
 func resolveSessionIndex(summary *checkpoint.CheckpointSummary, requested int) (int, error) {
-	if summary == nil || len(summary.Sessions) == 0 {
+	if summary == nil {
 		return 0, checkpoint.ErrCheckpointNotFound
+	}
+	if len(summary.Sessions) == 0 {
+		return 0, errCheckpointHasNoSessions
 	}
 	if requested < 0 {
 		return len(summary.Sessions) - 1, nil
@@ -222,6 +266,11 @@ type checkpointSessionJSON struct {
 	FilesTouched []string                  `json:"files_touched,omitempty"`
 	TokenUsage   *checkpointSessionTokens  `json:"token_usage,omitempty"`
 	Summary      *checkpointSessionSummary `json:"summary,omitempty"`
+
+	// Error is set when this session's metadata could not be read. The Index
+	// field remains valid; all other content fields are zero. Consumers can
+	// detect this by checking for a non-empty Error.
+	Error string `json:"error,omitempty"`
 }
 
 type checkpointSessionTokens struct {
@@ -264,9 +313,13 @@ func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts expla
 	for idx := range summary.Sessions {
 		meta, metaErr := readSessionMetadataForExport(ctx, reader, cpID, idx)
 		if metaErr != nil {
-			// Surface the per-session error as a stub entry rather than failing
-			// the whole envelope — partial metadata is still useful to consumers.
-			envelope.Sessions = append(envelope.Sessions, checkpointSessionJSON{Index: idx})
+			// Surface the per-session error as a stub entry with an explicit
+			// error string rather than failing the whole envelope or silently
+			// returning empty fields. Consumers branch on the `error` field.
+			envelope.Sessions = append(envelope.Sessions, checkpointSessionJSON{
+				Index: idx,
+				Error: metaErr.Error(),
+			})
 			continue
 		}
 		envelope.Sessions = append(envelope.Sessions, sessionMetadataToJSON(idx, meta))
@@ -281,22 +334,35 @@ func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts expla
 }
 
 // readSessionMetadataForExport reads only metadata.json for a session — no
-// transcript or prompt bytes. Prefers v2's cheap metadata-only reader when
-// available, falls back to the v1 ReadSessionContent path otherwise.
+// transcript or prompt bytes. Both v1 and v2 stores expose a metadata-only
+// reader, so this never depends on transcript availability (which would
+// cause an unrelated ErrNoTranscript on v1 checkpoints whose raw transcript
+// has been pruned).
 func readSessionMetadataForExport(ctx context.Context, reader checkpoint.CommittedReader, cpID id.CheckpointID, idx int) (*checkpoint.CommittedMetadata, error) {
-	if v2, ok := reader.(*checkpoint.V2GitStore); ok {
-		meta, err := v2.ReadSessionMetadata(ctx, cpID, idx)
+	switch r := reader.(type) {
+	case *checkpoint.V2GitStore:
+		meta, err := r.ReadSessionMetadata(ctx, cpID, idx)
 		if err != nil {
 			return nil, fmt.Errorf("read v2 session metadata: %w", err)
 		}
 		return meta, nil
+	case *checkpoint.GitStore:
+		meta, err := r.ReadSessionMetadata(ctx, cpID, idx)
+		if err != nil {
+			return nil, fmt.Errorf("read v1 session metadata: %w", err)
+		}
+		return meta, nil
+	default:
+		// CommittedReader doesn't promise a metadata-only method; fall back
+		// to the heavier ReadSessionContent path. Reachable only if a third
+		// store implementation is added without updating this switch.
+		content, err := reader.ReadSessionContent(ctx, cpID, idx)
+		if err != nil {
+			return nil, fmt.Errorf("read session content: %w", err)
+		}
+		meta := content.Metadata
+		return &meta, nil
 	}
-	content, err := reader.ReadSessionContent(ctx, cpID, idx)
-	if err != nil {
-		return nil, fmt.Errorf("read session content: %w", err)
-	}
-	meta := content.Metadata
-	return &meta, nil
 }
 
 func sessionMetadataToJSON(idx int, meta *checkpoint.CommittedMetadata) checkpointSessionJSON {
@@ -360,7 +426,10 @@ func runExplainListJSON(ctx context.Context, w io.Writer, sessionFilter string) 
 		if ctx.Err() != nil {
 			return NewSilentError(ctx.Err())
 		}
-		points = nil
+		// JSON consumers cannot distinguish "[]" from "fetch failed" if we
+		// swallow the error. Surface it so scripts get a non-zero exit and
+		// a real diagnostic instead of silently degraded output.
+		return fmt.Errorf("failed to list checkpoints: %w", err)
 	}
 
 	out := make([]branchCheckpointJSON, 0, len(points))

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -1,0 +1,395 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+)
+
+// explainExportOptions describes a request for one of the machine-readable
+// output modes of `entire checkpoint explain`. Exactly one of the json or
+// transcript flags is set when this struct is dispatched.
+type explainExportOptions struct {
+	sessionFilter  string
+	commitRef      string
+	checkpointFlag string
+	target         string
+	json           bool
+	transcript     bool
+	rawTranscript  bool
+	sessionIndex   int
+}
+
+// runExplainExport handles --json, --transcript, and --raw-transcript with an
+// explicit --session-index. JSON is metadata-only (no transcript bytes
+// embedded); transcript bytes always stream to stdout from a flag, never from
+// the JSON envelope.
+func runExplainExport(ctx context.Context, w, errW io.Writer, opts explainExportOptions) error {
+	hasTarget := opts.target != "" || opts.commitRef != "" || opts.checkpointFlag != ""
+
+	if opts.transcript || opts.rawTranscript {
+		if !hasTarget {
+			return errors.New("--transcript requires a checkpoint ID or commit SHA (positional), --checkpoint/-c, or --commit flag")
+		}
+		return runExplainStreamTranscript(ctx, w, errW, opts)
+	}
+
+	// JSON mode.
+	if !hasTarget {
+		return runExplainListJSON(ctx, w, opts.sessionFilter)
+	}
+	return runExplainCheckpointJSON(ctx, w, errW, opts)
+}
+
+// resolveExplainCheckpointID resolves a target (positional, --checkpoint, or
+// --commit) to a fully-qualified checkpoint ID using the existing lookup
+// infrastructure (including remote metadata fetch on miss).
+func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explainExportOptions) (id.CheckpointID, *explainCheckpointLookup, error) {
+	if opts.commitRef != "" {
+		repo, err := openRepository(ctx)
+		if err != nil {
+			return id.CheckpointID(""), nil, fmt.Errorf("not a git repository: %w", err)
+		}
+		hash, _, err := resolveCommitUnambiguous(repo, opts.commitRef)
+		if err != nil {
+			return id.CheckpointID(""), nil, fmt.Errorf("commit not found: %s: %w", opts.commitRef, err)
+		}
+		commit, err := repo.CommitObject(hash)
+		if err != nil {
+			return id.CheckpointID(""), nil, fmt.Errorf("failed to read commit: %w", err)
+		}
+		cpID, found := trailers.ParseCheckpoint(commit.Message)
+		if !found {
+			return id.CheckpointID(""), nil, fmt.Errorf("commit %s has no Entire-Checkpoint trailer", commit.Hash)
+		}
+		lookup, lookupErr := newExplainCheckpointLookup(ctx)
+		if lookupErr != nil {
+			return id.CheckpointID(""), nil, lookupErr
+		}
+		return cpID, lookup, nil
+	}
+
+	prefix := opts.checkpointFlag
+	if prefix == "" {
+		prefix = opts.target
+	}
+	if prefix == "" {
+		return id.CheckpointID(""), nil, errors.New("missing checkpoint target")
+	}
+
+	lookup, lookupErr := newExplainCheckpointLookup(ctx)
+	if lookupErr != nil {
+		return id.CheckpointID(""), nil, lookupErr
+	}
+
+	matches := matchCheckpointPrefix(lookup, prefix)
+	if len(matches) == 0 {
+		stop := startSpinner(errW, "Fetching checkpoint metadata from remote")
+		_, _, v1Err := getMetadataTree(ctx)
+		v2OK := false
+		if lookup.preferCheckpointsV2 {
+			if _, _, v2Err := getV2MetadataTree(ctx); v2Err == nil {
+				v2OK = true
+			}
+		}
+		stop(false)
+		if v1Err == nil || v2OK {
+			if fresh, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {
+				lookup = fresh
+				matches = matchCheckpointPrefix(lookup, prefix)
+			}
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return id.CheckpointID(""), lookup, fmt.Errorf("%w: %s", checkpoint.ErrCheckpointNotFound, prefix)
+	case 1:
+		return matches[0], lookup, nil
+	default:
+		return id.CheckpointID(""), lookup, fmt.Errorf("%w: %s matches %d checkpoints", errAmbiguousCommitPrefix, prefix, len(matches))
+	}
+}
+
+func matchCheckpointPrefix(lookup *explainCheckpointLookup, prefix string) []id.CheckpointID {
+	var matches []id.CheckpointID
+	for _, info := range lookup.committed {
+		if strings.HasPrefix(info.CheckpointID.String(), prefix) {
+			matches = append(matches, info.CheckpointID)
+		}
+	}
+	return matches
+}
+
+// resolveSessionIndex maps the user's --session-index value (or the implicit
+// default) onto a valid 0-based offset within summary.Sessions. Returns an
+// error when the requested index exceeds the available range.
+func resolveSessionIndex(summary *checkpoint.CheckpointSummary, requested int) (int, error) {
+	if summary == nil || len(summary.Sessions) == 0 {
+		return 0, checkpoint.ErrCheckpointNotFound
+	}
+	if requested < 0 {
+		return len(summary.Sessions) - 1, nil
+	}
+	if requested >= len(summary.Sessions) {
+		return 0, fmt.Errorf("session index %d out of range (checkpoint has %d sessions)", requested, len(summary.Sessions))
+	}
+	return requested, nil
+}
+
+// runExplainStreamTranscript streams either the compact transcript (default)
+// or the raw transcript (when --raw-transcript is set) for the selected
+// session of the resolved checkpoint.
+func runExplainStreamTranscript(ctx context.Context, w, errW io.Writer, opts explainExportOptions) error {
+	cpID, lookup, err := resolveExplainCheckpointID(ctx, errW, opts)
+	if err != nil {
+		return err
+	}
+
+	reader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, cpID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
+	if err != nil {
+		return fmt.Errorf("failed to read checkpoint: %w", err)
+	}
+
+	idx, err := resolveSessionIndex(summary, opts.sessionIndex)
+	if err != nil {
+		return err
+	}
+
+	if opts.rawTranscript {
+		content, readErr := reader.ReadSessionContent(ctx, cpID, idx)
+		if readErr != nil {
+			return fmt.Errorf("failed to read session content: %w", readErr)
+		}
+		if len(content.Transcript) == 0 {
+			return fmt.Errorf("checkpoint %s session %d has no raw transcript", cpID, idx)
+		}
+		if _, err := w.Write(content.Transcript); err != nil {
+			return fmt.Errorf("failed to write transcript: %w", err)
+		}
+		return nil
+	}
+
+	// Compact transcript path: only v2 stores have a normalized transcript.jsonl.
+	v2Reader, ok := reader.(*checkpoint.V2GitStore)
+	if !ok {
+		return errors.New("compact transcript is only available for v2 checkpoints (try --raw-transcript)")
+	}
+
+	bytes, err := v2Reader.ReadSessionCompactTranscript(ctx, cpID, idx)
+	if err != nil {
+		return fmt.Errorf("failed to read compact transcript: %w", err)
+	}
+	if _, err := w.Write(bytes); err != nil {
+		return fmt.Errorf("failed to write transcript: %w", err)
+	}
+	return nil
+}
+
+// checkpointExportJSON is the metadata-only envelope returned by
+// `entire checkpoint explain --json`. It exposes only existing CheckpointSummary
+// and CommittedMetadata fields — no schema invention, no transcript bytes.
+type checkpointExportJSON struct {
+	CheckpointID     string                  `json:"checkpoint_id"`
+	Strategy         string                  `json:"strategy,omitempty"`
+	Branch           string                  `json:"branch,omitempty"`
+	CheckpointsCount int                     `json:"checkpoints_count"`
+	FilesTouched     []string                `json:"files_touched,omitempty"`
+	HasReview        bool                    `json:"has_review,omitempty"`
+	SessionCount     int                     `json:"session_count"`
+	Sessions         []checkpointSessionJSON `json:"sessions"`
+}
+
+type checkpointSessionJSON struct {
+	Index        int                       `json:"index"`
+	SessionID    string                    `json:"session_id,omitempty"`
+	Agent        string                    `json:"agent,omitempty"`
+	Model        string                    `json:"model,omitempty"`
+	Kind         string                    `json:"kind,omitempty"`
+	ReviewSkills []string                  `json:"review_skills,omitempty"`
+	CreatedAt    *time.Time                `json:"created_at,omitempty"`
+	TurnID       string                    `json:"turn_id,omitempty"`
+	IsTask       bool                      `json:"is_task,omitempty"`
+	ToolUseID    string                    `json:"tool_use_id,omitempty"`
+	FilesTouched []string                  `json:"files_touched,omitempty"`
+	TokenUsage   *checkpointSessionTokens  `json:"token_usage,omitempty"`
+	Summary      *checkpointSessionSummary `json:"summary,omitempty"`
+}
+
+type checkpointSessionTokens struct {
+	InputTokens         int `json:"input_tokens"`
+	OutputTokens        int `json:"output_tokens"`
+	CacheReadTokens     int `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+}
+
+type checkpointSessionSummary struct {
+	Intent  string `json:"intent,omitempty"`
+	Outcome string `json:"outcome,omitempty"`
+}
+
+// runExplainCheckpointJSON resolves a single checkpoint and emits a metadata-only
+// JSON envelope. Reads each session's metadata.json from /main; never reads any
+// transcript file.
+func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts explainExportOptions) error {
+	cpID, lookup, err := resolveExplainCheckpointID(ctx, errW, opts)
+	if err != nil {
+		return err
+	}
+
+	reader, summary, err := checkpoint.ResolveCommittedReaderForCheckpoint(ctx, cpID, lookup.v1Store, lookup.v2Store, lookup.preferCheckpointsV2)
+	if err != nil {
+		return fmt.Errorf("failed to read checkpoint: %w", err)
+	}
+
+	envelope := checkpointExportJSON{
+		CheckpointID:     cpID.String(),
+		Strategy:         summary.Strategy,
+		Branch:           summary.Branch,
+		CheckpointsCount: summary.CheckpointsCount,
+		FilesTouched:     summary.FilesTouched,
+		HasReview:        summary.HasReview,
+		SessionCount:     len(summary.Sessions),
+	}
+
+	envelope.Sessions = make([]checkpointSessionJSON, 0, len(summary.Sessions))
+	for idx := range summary.Sessions {
+		meta, metaErr := readSessionMetadataForExport(ctx, reader, cpID, idx)
+		if metaErr != nil {
+			// Surface the per-session error as a stub entry rather than failing
+			// the whole envelope — partial metadata is still useful to consumers.
+			envelope.Sessions = append(envelope.Sessions, checkpointSessionJSON{Index: idx})
+			continue
+		}
+		envelope.Sessions = append(envelope.Sessions, sessionMetadataToJSON(idx, meta))
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(envelope); err != nil {
+		return fmt.Errorf("failed to encode checkpoint json: %w", err)
+	}
+	return nil
+}
+
+// readSessionMetadataForExport reads only metadata.json for a session — no
+// transcript or prompt bytes. Prefers v2's cheap metadata-only reader when
+// available, falls back to the v1 ReadSessionContent path otherwise.
+func readSessionMetadataForExport(ctx context.Context, reader checkpoint.CommittedReader, cpID id.CheckpointID, idx int) (*checkpoint.CommittedMetadata, error) {
+	if v2, ok := reader.(*checkpoint.V2GitStore); ok {
+		meta, err := v2.ReadSessionMetadata(ctx, cpID, idx)
+		if err != nil {
+			return nil, fmt.Errorf("read v2 session metadata: %w", err)
+		}
+		return meta, nil
+	}
+	content, err := reader.ReadSessionContent(ctx, cpID, idx)
+	if err != nil {
+		return nil, fmt.Errorf("read session content: %w", err)
+	}
+	meta := content.Metadata
+	return &meta, nil
+}
+
+func sessionMetadataToJSON(idx int, meta *checkpoint.CommittedMetadata) checkpointSessionJSON {
+	out := checkpointSessionJSON{
+		Index:        idx,
+		SessionID:    meta.SessionID,
+		Agent:        string(meta.Agent),
+		Model:        meta.Model,
+		Kind:         meta.Kind,
+		ReviewSkills: meta.ReviewSkills,
+		TurnID:       meta.TurnID,
+		IsTask:       meta.IsTask,
+		ToolUseID:    meta.ToolUseID,
+		FilesTouched: meta.FilesTouched,
+	}
+	if !meta.CreatedAt.IsZero() {
+		ts := meta.CreatedAt
+		out.CreatedAt = &ts
+	}
+	if meta.TokenUsage != nil {
+		out.TokenUsage = &checkpointSessionTokens{
+			InputTokens:         meta.TokenUsage.InputTokens,
+			OutputTokens:        meta.TokenUsage.OutputTokens,
+			CacheReadTokens:     meta.TokenUsage.CacheReadTokens,
+			CacheCreationTokens: meta.TokenUsage.CacheCreationTokens,
+		}
+	}
+	if meta.Summary != nil {
+		out.Summary = &checkpointSessionSummary{
+			Intent:  meta.Summary.Intent,
+			Outcome: meta.Summary.Outcome,
+		}
+	}
+	return out
+}
+
+// branchCheckpointJSON is one entry in the list emitted by
+// `entire checkpoint explain --json` (no target).
+type branchCheckpointJSON struct {
+	CheckpointID     string    `json:"checkpoint_id"`
+	SessionID        string    `json:"session_id,omitempty"`
+	Agent            string    `json:"agent,omitempty"`
+	Date             time.Time `json:"date"`
+	Message          string    `json:"message,omitempty"`
+	IsTaskCheckpoint bool      `json:"is_task_checkpoint,omitempty"`
+	IsLogsOnly       bool      `json:"is_logs_only,omitempty"`
+	SessionCount     int       `json:"session_count,omitempty"`
+	SessionIDs       []string  `json:"session_ids,omitempty"`
+}
+
+// runExplainListJSON emits a JSON array of branch checkpoints, optionally
+// filtered by session ID prefix (mirrors the prose list view).
+func runExplainListJSON(ctx context.Context, w io.Writer, sessionFilter string) error {
+	repo, err := openRepository(ctx)
+	if err != nil {
+		return fmt.Errorf("not a git repository: %w", err)
+	}
+
+	points, err := getBranchCheckpoints(ctx, repo, branchCheckpointsLimit)
+	if err != nil {
+		if ctx.Err() != nil {
+			return NewSilentError(ctx.Err())
+		}
+		points = nil
+	}
+
+	out := make([]branchCheckpointJSON, 0, len(points))
+	for _, p := range points {
+		if sessionFilter != "" && !strings.HasPrefix(p.SessionID, sessionFilter) {
+			continue
+		}
+		entry := branchCheckpointJSON{
+			SessionID:        p.SessionID,
+			Agent:            string(p.Agent),
+			Date:             p.Date,
+			Message:          p.Message,
+			IsTaskCheckpoint: p.IsTaskCheckpoint,
+			IsLogsOnly:       p.IsLogsOnly,
+			SessionCount:     p.SessionCount,
+			SessionIDs:       p.SessionIDs,
+		}
+		if !p.CheckpointID.IsEmpty() {
+			entry.CheckpointID = p.CheckpointID.String()
+		} else {
+			entry.CheckpointID = p.ID
+		}
+		out = append(out, entry)
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("failed to encode checkpoint list: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -383,6 +383,24 @@ func TestExplainCmd_SessionIndexRequiresTranscriptFlag(t *testing.T) {
 	)
 }
 
+// TestRunExplainExport_NoModeFlagFailsLoudly guards the bugbot finding that
+// `opts.json` was never read: previously, calling runExplainExport with all
+// three mode flags false would silently dispatch to JSON output. The
+// explicit default branch now returns an internal error so future
+// regressions don't silently produce JSON for unmoded callers.
+func TestRunExplainExport_NoModeFlagFailsLoudly(t *testing.T) {
+	setupExportRepo(t)
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		target:       "any",
+		sessionIndex: -1,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "without an output mode")
+	require.Empty(t, stdout.String(), "must not emit JSON when no mode is set")
+}
+
 func TestExplainCmd_TranscriptAndJSONMutuallyExclusive(t *testing.T) {
 	setupExportRepo(t)
 

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -232,6 +233,50 @@ func TestExplainCmd_RawTranscriptWithSessionIndexRoutesToExportPath(t *testing.T
 	require.Equal(t, raw0, stdout.Bytes())
 }
 
+// TestExplainCmd_RawTranscriptMultiSessionDistinctContent guards the H2
+// finding from the code review: the previous one-session test could not
+// catch a regression where --session-index was silently ignored. This
+// fixture has two sessions with byte-distinct transcripts; we assert
+// that index 0 and index 1 return different content matching the
+// per-session transcript that was written.
+func TestExplainCmd_RawTranscriptMultiSessionDistinctContent(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	cpID := id.MustCheckpointID("9999bbbb1111")
+	rawSession0 := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"SESSION-ZERO-MARKER"}]}}` + "\n")
+	rawSession1 := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"SESSION-ONE-DIFFERENT-MARKER"}]}}` + "\n")
+
+	writeV2CheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:  "session-zero",
+		Transcript: redact.AlreadyRedacted(rawSession0),
+	})
+	// Second WriteCommitted with the same checkpoint ID appends session 1.
+	writeV2CheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:  "session-one",
+		Transcript: redact.AlreadyRedacted(rawSession1),
+	})
+
+	runIdx := func(idx string) []byte {
+		t.Helper()
+		cmd := newExplainCmd()
+		var stdout, stderr bytes.Buffer
+		cmd.SetOut(&stdout)
+		cmd.SetErr(&stderr)
+		cmd.SetArgs([]string{"9999bbbb", "--raw-transcript", "--session-index", idx})
+		require.NoError(t, cmd.ExecuteContext(context.Background()))
+		return stdout.Bytes()
+	}
+
+	got0 := runIdx("0")
+	got1 := runIdx("1")
+
+	require.NotEqual(t, got0, got1, "session 0 and session 1 must yield different bytes")
+	require.Contains(t, string(got0), "SESSION-ZERO-MARKER")
+	require.Contains(t, string(got1), "SESSION-ONE-DIFFERENT-MARKER")
+	require.NotContains(t, string(got0), "SESSION-ONE-DIFFERENT-MARKER",
+		"session 0 output must not leak session 1 content")
+}
+
 func TestRunExplainExport_TranscriptRequiresTarget(t *testing.T) {
 	setupExportRepo(t)
 
@@ -400,6 +445,74 @@ func TestRunExplainExport_NoModeFlagFailsLoudly(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "without an output mode")
 	require.Empty(t, stdout.String(), "must not emit JSON when no mode is set")
+}
+
+// stubCommittedReader is a minimal CommittedReader that returns canned
+// metadata or errors per session index. Used to exercise the partial-failure
+// path in buildCheckpointJSONEnvelope without corrupting a real git tree.
+type stubCommittedReader struct {
+	summary  *checkpoint.CheckpointSummary
+	contents map[int]*checkpoint.SessionContent // idx -> content (nil ⇒ return error)
+	err      error                              // err returned for indexes not in contents
+}
+
+func (s *stubCommittedReader) ReadCommitted(_ context.Context, _ id.CheckpointID) (*checkpoint.CheckpointSummary, error) {
+	return s.summary, nil
+}
+
+func (s *stubCommittedReader) ReadSessionContent(_ context.Context, _ id.CheckpointID, idx int) (*checkpoint.SessionContent, error) {
+	if c, ok := s.contents[idx]; ok && c != nil {
+		return c, nil
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return nil, errors.New("stub: session not configured")
+}
+
+// TestBuildCheckpointJSONEnvelope_PartialFailureFromMockReader exercises the
+// H3 partial-failure path end-to-end against the envelope builder. A real
+// v2-tree corruption test isn't feasible from the cli package (the splice
+// helper is unexported); the mock reader hits the same default branch in
+// readSessionMetadataForExport that a v3-or-future store would hit, which
+// IS the public surface this contract guarantees.
+func TestBuildCheckpointJSONEnvelope_PartialFailureFromMockReader(t *testing.T) {
+	t.Parallel()
+
+	cpID := id.MustCheckpointID("eeee99998888")
+	summary := &checkpoint.CheckpointSummary{
+		Strategy:         "manual-commit",
+		CheckpointsCount: 2,
+		Sessions: []checkpoint.SessionFilePaths{
+			{Metadata: "ee/ee99998888/0/metadata.json"},
+			{Metadata: "ee/ee99998888/1/metadata.json"},
+		},
+	}
+	reader := &stubCommittedReader{
+		summary: summary,
+		contents: map[int]*checkpoint.SessionContent{
+			0: {Metadata: checkpoint.CommittedMetadata{
+				SessionID: "good-session",
+				Agent:     "Claude Code",
+			}},
+			// idx 1 not configured ⇒ stub returns error, simulating an
+			// unreadable session metadata blob.
+		},
+	}
+
+	envelope, failed := buildCheckpointJSONEnvelope(context.Background(), reader, summary, cpID)
+
+	require.True(t, envelope.Partial, "envelope.Partial must be true when any session metadata read fails")
+	require.Equal(t, []int{1}, failed, "failed-sessions slice must list the broken indexes")
+	require.Len(t, envelope.Sessions, 2)
+
+	require.Equal(t, "good-session", envelope.Sessions[0].SessionID)
+	require.Empty(t, envelope.Sessions[0].Error)
+
+	require.Equal(t, 1, envelope.Sessions[1].Index)
+	require.Empty(t, envelope.Sessions[1].SessionID, "stub entry must not carry data that looks real")
+	require.Empty(t, envelope.Sessions[1].Agent)
+	require.NotEmpty(t, envelope.Sessions[1].Error, "stub entry must surface the underlying read error")
 }
 
 // TestCheckpointExportJSON_PartialContract pins the JSON shape that signals

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/redact"
 	"github.com/go-git/go-git/v6"
@@ -399,6 +400,83 @@ func TestRunExplainExport_NoModeFlagFailsLoudly(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "without an output mode")
 	require.Empty(t, stdout.String(), "must not emit JSON when no mode is set")
+}
+
+// TestCheckpointExportJSON_PartialContract pins the JSON shape that signals
+// a partial-failure export to consumers (codex finding 3): the top-level
+// `partial` flag plus per-session `error` fields. Consumers branch on
+// either; the command also exits non-zero so automation can't trust an
+// envelope where partial=true.
+func TestCheckpointExportJSON_PartialContract(t *testing.T) {
+	t.Parallel()
+
+	envelope := checkpointExportJSON{
+		CheckpointID: "abcdef123456",
+		SessionCount: 2,
+		Sessions: []checkpointSessionJSON{
+			{Index: 0, SessionID: "good", Agent: "Claude Code"},
+			{Index: 1, Error: "read v2 session metadata: blob 0xdead missing"},
+		},
+		Partial: true,
+	}
+
+	buf, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf, &got))
+
+	require.Equal(t, true, got["partial"], "envelope must surface partial=true at top level")
+	sessions, ok := got["sessions"].([]any)
+	require.True(t, ok)
+	require.Len(t, sessions, 2)
+
+	failed, ok := sessions[1].(map[string]any)
+	require.True(t, ok)
+	idx, ok := failed["index"].(float64)
+	require.True(t, ok)
+	require.InEpsilon(t, float64(1), idx, 0.0001)
+	require.Equal(t, "read v2 session metadata: blob 0xdead missing", failed["error"])
+	// The unreadable session must NOT carry stub fields that look like real data.
+	require.NotContains(t, failed, "session_id")
+	require.NotContains(t, failed, "agent")
+}
+
+// TestCheckpointMatchesSessionFilter guards the codex high finding: when a
+// caller asks for `entire checkpoint explain --json --session <prefix>`, the
+// filter must match against ALL contributing sessions, not just the latest.
+// Multi-session checkpoints expose archived contributors via SessionIDs.
+func TestCheckpointMatchesSessionFilter(t *testing.T) {
+	t.Parallel()
+
+	multi := strategy.RewindPoint{
+		SessionID:  "9f44f514-b012", // latest
+		SessionIDs: []string{"older-session-aaaa", "9f44f514-b012"},
+	}
+	single := strategy.RewindPoint{
+		SessionID: "lone-session-bbbb",
+	}
+
+	tests := []struct {
+		name   string
+		point  strategy.RewindPoint
+		filter string
+		want   bool
+	}{
+		{name: "matches latest session id", point: multi, filter: "9f44f514", want: true},
+		{name: "matches archived session id", point: multi, filter: "older-session", want: true},
+		{name: "no match", point: multi, filter: "deadbeef", want: false},
+		{name: "single-session match", point: single, filter: "lone", want: true},
+		{name: "single-session miss", point: single, filter: "older-session", want: false},
+		{name: "empty filter not handled here", point: multi, filter: "", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := checkpointMatchesSessionFilter(tc.point, tc.filter)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func TestExplainCmd_TranscriptAndJSONMutuallyExclusive(t *testing.T) {

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -102,6 +102,45 @@ func TestRunExplainExport_JSONSingleCheckpoint(t *testing.T) {
 	require.Equal(t, 0, envelope.Sessions[0].Index)
 }
 
+// TestRunExplainExport_JSONUsesMetadataOnlyReader verifies the codex finding 3:
+// the v1 fallback for --json must read metadata.json directly, not via
+// ReadSessionContent (which depends on transcript availability). We exercise
+// this by writing a v1 checkpoint with v2 disabled, then asserting the
+// envelope has populated per-session fields (not a stub entry).
+func TestRunExplainExport_JSONUsesMetadataOnlyReader(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	// Disable v2 in settings to force the v1 path. setupExportRepo wrote
+	// `checkpoints_v2: true`; overwrite it.
+	require.NoError(t, os.WriteFile(".entire/settings.json", []byte(`{"enabled": true}`), 0o600))
+
+	cpID := id.MustCheckpointID("777711112222")
+	v1 := checkpoint.NewGitStore(repo)
+	require.NoError(t, v1.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-v1-only",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"raw"}]}}` + "\n")),
+		AuthorName:   exportTestAuthorName,
+		AuthorEmail:  exportTestAuthorEmail,
+	}))
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		target:       "777711",
+		json:         true,
+		sessionIndex: -1,
+	})
+	require.NoError(t, err)
+
+	var envelope checkpointExportJSON
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	require.Len(t, envelope.Sessions, 1)
+	require.Equal(t, "session-v1-only", envelope.Sessions[0].SessionID,
+		"v1 envelope must populate session_id from metadata-only reader (not stub entry)")
+	require.Empty(t, envelope.Sessions[0].Error, "well-formed v1 read must not surface a per-session error")
+}
+
 func TestRunExplainExport_JSONNeverEmbedsTranscript(t *testing.T) {
 	repo := setupExportRepo(t)
 
@@ -243,25 +282,88 @@ func TestResolveSessionIndex(t *testing.T) {
 		{name: "explicit middle", summary: threeSessions, requested: 1, want: 1},
 		{name: "explicit last", summary: threeSessions, requested: 2, want: 2},
 		{name: "out of range", summary: threeSessions, requested: 3, wantErr: "out of range"},
-		{name: "empty summary", summary: &checkpoint.CheckpointSummary{}, requested: -1, wantErr: ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := resolveSessionIndex(tc.summary, tc.requested)
-			switch {
-			case tc.wantErr == "" && tc.summary != nil && len(tc.summary.Sessions) > 0:
-				require.NoError(t, err)
-				require.Equal(t, tc.want, got)
-			case tc.wantErr != "":
+			if tc.wantErr != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.wantErr)
-			default:
-				// empty-summary case returns ErrCheckpointNotFound; just ensure we got an error.
-				require.Error(t, err)
+				return
 			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestResolveSessionIndex_EmptyVsMissing distinguishes the two error sentinels
+// after the Claude D fix: nil summary means "checkpoint not found", empty
+// Sessions means "checkpoint exists but has no sessions".
+func TestResolveSessionIndex_EmptyVsMissing(t *testing.T) {
+	t.Parallel()
+
+	_, errNil := resolveSessionIndex(nil, -1)
+	require.ErrorIs(t, errNil, checkpoint.ErrCheckpointNotFound)
+
+	_, errEmpty := resolveSessionIndex(&checkpoint.CheckpointSummary{}, -1)
+	require.ErrorIs(t, errEmpty, errCheckpointHasNoSessions)
+	require.NotErrorIs(t, errEmpty, checkpoint.ErrCheckpointNotFound,
+		"empty-checkpoint case must not look like 'checkpoint not found'")
+}
+
+// TestRunExplainExport_RawTranscriptRequiresTarget guards the error message
+// contract: when --raw-transcript reaches runExplainExport without a target,
+// the error must reference --raw-transcript (not --transcript).
+func TestRunExplainExport_RawTranscriptRequiresTarget(t *testing.T) {
+	setupExportRepo(t)
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		rawTranscript: true,
+		sessionIndex:  -1,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--raw-transcript requires")
+}
+
+// TestRunExplainExport_PositionalCommitSHAFallback covers the codex finding:
+// a positional that doesn't match a checkpoint prefix should be re-resolved
+// as a commit ref (with Entire-Checkpoint trailer) before failing.
+func TestRunExplainExport_PositionalCommitSHAFallback(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	cpID := id.MustCheckpointID("aaaabbbb1234")
+	writeV2CheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:         "session-via-commit",
+		Transcript:        redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n")),
+		CompactTranscript: []byte(`{"v":1}` + "\n"),
+	})
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, "trailing.txt"), []byte("trailing"), 0o600))
+	_, err = wt.Add("trailing.txt")
+	require.NoError(t, err)
+	commitHash, err := wt.Commit("trailing\n\nEntire-Checkpoint: "+cpID.String()+"\n", &git.CommitOptions{
+		Author: &object.Signature{Name: exportTestAuthorName, Email: exportTestAuthorEmail, When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	err = runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		target:       commitHash.String(),
+		json:         true,
+		sessionIndex: -1,
+	})
+	require.NoError(t, err, "positional commit SHA should fall back to commit-ref resolution")
+
+	var envelope checkpointExportJSON
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	require.Equal(t, cpID.String(), envelope.CheckpointID)
 }
 
 func TestExplainCmd_SessionIndexRequiresTranscriptFlag(t *testing.T) {

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -1,0 +1,295 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/redact"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	exportTestAuthorName  = "Test"
+	exportTestAuthorEmail = "export-test@entire.local"
+)
+
+// setupExportRepo creates a git repo with v2 checkpoints enabled and an
+// initial commit (required for HEAD-resolving operations). The caller is
+// responsible for chdir; this helper does NOT call t.Parallel because tests
+// using t.Chdir cannot parallelize.
+func setupExportRepo(t *testing.T) *git.Repository {
+	t.Helper()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	t.Chdir(tmpDir)
+
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	testFile := filepath.Join(tmpDir, "f.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("init"), 0o600))
+	_, err = wt.Add("f.txt")
+	require.NoError(t, err)
+	_, err = wt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: exportTestAuthorName, Email: exportTestAuthorEmail, When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, ".entire", "settings.json"),
+		[]byte(`{"enabled": true, "strategy_options": {"checkpoints_v2": true}}`),
+		0o600,
+	))
+
+	return repo
+}
+
+func writeV2CheckpointForExport(t *testing.T, repo *git.Repository, cpID id.CheckpointID, opts checkpoint.WriteCommittedOptions) {
+	t.Helper()
+	store := checkpoint.NewV2GitStore(repo, "origin")
+	opts.CheckpointID = cpID
+	if opts.AuthorName == "" {
+		opts.AuthorName = exportTestAuthorName
+	}
+	if opts.AuthorEmail == "" {
+		opts.AuthorEmail = exportTestAuthorEmail
+	}
+	if opts.Strategy == "" {
+		opts.Strategy = "manual-commit"
+	}
+	require.NoError(t, store.WriteCommitted(context.Background(), opts))
+}
+
+func TestRunExplainExport_JSONSingleCheckpoint(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	cpID := id.MustCheckpointID("aaaa11112222")
+	writeV2CheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:         "session-json",
+		Transcript:        redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n")),
+		CompactTranscript: []byte(`{"v":1,"type":"user"}` + "\n"),
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		target:       "aaaa1111",
+		json:         true,
+		sessionIndex: -1,
+	})
+	require.NoError(t, err)
+
+	var envelope checkpointExportJSON
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope), "output: %s", stdout.String())
+
+	require.Equal(t, cpID.String(), envelope.CheckpointID)
+	require.Equal(t, 1, envelope.SessionCount)
+	require.Len(t, envelope.Sessions, 1)
+	require.Equal(t, "session-json", envelope.Sessions[0].SessionID)
+	require.Equal(t, 0, envelope.Sessions[0].Index)
+}
+
+func TestRunExplainExport_JSONNeverEmbedsTranscript(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	cpID := id.MustCheckpointID("bbbb11112222")
+	writeV2CheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:         "session-no-leak",
+		Transcript:        redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"SECRET-RAW"}]}}` + "\n")),
+		CompactTranscript: []byte(`{"v":1,"text":"SECRET-COMPACT"}` + "\n"),
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		target:       "bbbb1111",
+		json:         true,
+		sessionIndex: -1,
+	})
+	require.NoError(t, err)
+
+	out := stdout.String()
+	require.NotContains(t, out, "SECRET-RAW", "JSON envelope must not embed raw transcript")
+	require.NotContains(t, out, "SECRET-COMPACT", "JSON envelope must not embed compact transcript")
+}
+
+func TestRunExplainExport_TranscriptStreamsCompactBytes(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	cpID := id.MustCheckpointID("cccc11112222")
+	compact := []byte(`{"v":1,"type":"user","content":[{"text":"compact line 1"}]}` + "\n" + `{"v":1,"type":"assistant","content":[{"text":"compact line 2"}]}` + "\n")
+	writeV2CheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:         "session-compact",
+		Transcript:        redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"raw line"}]}}` + "\n")),
+		CompactTranscript: compact,
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		target:       "cccc1111",
+		transcript:   true,
+		sessionIndex: -1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, compact, stdout.Bytes())
+}
+
+func TestRunExplainExport_RawTranscriptStreamsRawBytes(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	cpID := id.MustCheckpointID("dddd11112222")
+	raw := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"hello raw"}]}}` + "\n")
+	writeV2CheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:         "session-raw",
+		Transcript:        redact.AlreadyRedacted(raw),
+		CompactTranscript: []byte(`{"v":1,"type":"user"}` + "\n"),
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		target:        "dddd1111",
+		rawTranscript: true,
+		sessionIndex:  -1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, raw, stdout.Bytes())
+}
+
+// TestExplainCmd_RawTranscriptWithSessionIndexRoutesToExportPath guards the
+// cobra-layer dispatch: --raw-transcript --session-index must reach the
+// export path (which honors the index). Before the fix, the legacy
+// raw-transcript path silently ignored --session-index because the dispatch
+// only forked on --json or --transcript.
+func TestExplainCmd_RawTranscriptWithSessionIndexRoutesToExportPath(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	cpID := id.MustCheckpointID("ffff11112222")
+	raw0 := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"hello session 0"}]}}` + "\n")
+	writeV2CheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:  "session-zero",
+		Transcript: redact.AlreadyRedacted(raw0),
+	})
+
+	cmd := newExplainCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"ffff1111", "--raw-transcript", "--session-index", "0"})
+
+	require.NoError(t, cmd.ExecuteContext(context.Background()))
+	require.Equal(t, raw0, stdout.Bytes())
+}
+
+func TestRunExplainExport_TranscriptRequiresTarget(t *testing.T) {
+	setupExportRepo(t)
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		transcript:   true,
+		sessionIndex: -1,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--transcript requires")
+}
+
+func TestRunExplainExport_TranscriptOutOfRangeSessionIndex(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	cpID := id.MustCheckpointID("eeee11112222")
+	writeV2CheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:         "session-only",
+		Transcript:        redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n")),
+		CompactTranscript: []byte(`{"v":1}` + "\n"),
+	})
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		target:       "eeee1111",
+		transcript:   true,
+		sessionIndex: 5,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "out of range")
+}
+
+func TestResolveSessionIndex(t *testing.T) {
+	t.Parallel()
+
+	threeSessions := &checkpoint.CheckpointSummary{
+		Sessions: make([]checkpoint.SessionFilePaths, 3),
+	}
+
+	tests := []struct {
+		name      string
+		summary   *checkpoint.CheckpointSummary
+		requested int
+		want      int
+		wantErr   string
+	}{
+		{name: "default picks latest", summary: threeSessions, requested: -1, want: 2},
+		{name: "explicit 0", summary: threeSessions, requested: 0, want: 0},
+		{name: "explicit middle", summary: threeSessions, requested: 1, want: 1},
+		{name: "explicit last", summary: threeSessions, requested: 2, want: 2},
+		{name: "out of range", summary: threeSessions, requested: 3, wantErr: "out of range"},
+		{name: "empty summary", summary: &checkpoint.CheckpointSummary{}, requested: -1, wantErr: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveSessionIndex(tc.summary, tc.requested)
+			switch {
+			case tc.wantErr == "" && tc.summary != nil && len(tc.summary.Sessions) > 0:
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+			case tc.wantErr != "":
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+			default:
+				// empty-summary case returns ErrCheckpointNotFound; just ensure we got an error.
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestExplainCmd_SessionIndexRequiresTranscriptFlag(t *testing.T) {
+	setupExportRepo(t)
+
+	cmd := newExplainCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"some-checkpoint", "--session-index", "1"})
+
+	err := cmd.ExecuteContext(context.Background())
+	require.Error(t, err)
+	require.Contains(t,
+		err.Error(), "--session-index only applies",
+		"expected --session-index validation error, got: %v", err,
+	)
+}
+
+func TestExplainCmd_TranscriptAndJSONMutuallyExclusive(t *testing.T) {
+	setupExportRepo(t)
+
+	cmd := newExplainCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"some-checkpoint", "--json", "--transcript"})
+
+	err := cmd.ExecuteContext(context.Background())
+	require.Error(t, err)
+}

--- a/cmd/entire/cli/session_current.go
+++ b/cmd/entire/cli/session_current.go
@@ -45,7 +45,7 @@ Examples:
 				return nil
 			}
 
-			return runSessionInfo(ctx, cmd, sessionID, jsonFlag, transcriptFlag)
+			return runSessionInfo(ctx, cmd, sessionID, sessionOutputModeFromFlags(jsonFlag, transcriptFlag))
 		},
 	}
 

--- a/cmd/entire/cli/session_current.go
+++ b/cmd/entire/cli/session_current.go
@@ -11,6 +11,7 @@ import (
 
 func newSessionCurrentCmd() *cobra.Command {
 	var jsonFlag bool
+	var transcriptFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "current",
@@ -22,9 +23,15 @@ preferring sessions from the current worktree and falling back to the most
 recent session if no state matches this worktree. Equivalent to running
 'sessions info' on the session ID returned by FindMostRecentSession.
 
+Output modes:
+  Default       Human-readable summary.
+  --json        Metadata-only JSON envelope (no transcript bytes).
+  --transcript  Stream the live raw agent transcript bytes to stdout.
+
 Examples:
   entire session current
-  entire session current --json`,
+  entire session current --json
+  entire session current --transcript > session.jsonl`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			if _, err := paths.WorktreeRoot(ctx); err != nil {
@@ -38,10 +45,12 @@ Examples:
 				return nil
 			}
 
-			return runSessionInfo(ctx, cmd, sessionID, jsonFlag)
+			return runSessionInfo(ctx, cmd, sessionID, jsonFlag, transcriptFlag)
 		},
 	}
 
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&transcriptFlag, "transcript", false, "Stream raw agent transcript bytes to stdout")
+	cmd.MarkFlagsMutuallyExclusive("json", "transcript")
 	return cmd
 }

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -26,17 +26,31 @@ import (
 // <-ctx.Done(), so io.ReadAll returns promptly when the user hits Ctrl-C on a
 // multi-MB transcript instead of blocking until EOF.
 //
-// Snapshot semantics: if the agent is mid-write when we hit EOF the trailing
-// partial line is trimmed so consumers never see a truncated JSONL record.
+// Snapshot semantics: the read is bounded to the file size observed at open
+// (via io.LimitReader) so writes the agent appends after command start are
+// excluded. Output shaping is content-aware:
 //
-// state.TranscriptPath comes from a session-state file that Entire writes
-// exclusively under the user's own .git/. The path is therefore as trusted
-// as any other entry the local user has on disk; we do not validate it
-// against a confinement root.
+//   - Whole-document JSON transcripts (e.g. Gemini's session-*.json) are
+//     emitted intact. Trimming would cut off the closing brace.
+//   - JSONL transcripts (Claude Code, Cursor, Codex, etc.) get a trailing
+//     partial-line trim so consumers never see a truncated record.
+//
+// path comes from a session-state file that Entire writes exclusively
+// under the user's own .git/. The path is therefore as trusted as any
+// other entry the local user has on disk; we do not validate it against a
+// confinement root.
 func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string) error {
 	f, err := os.Open(path) //nolint:gosec // see comment above on trust model
 	if err != nil {
 		return fmt.Errorf("open transcript: %w", err)
+	}
+
+	// Bound the snapshot to the file size at open. Without this, io.ReadAll
+	// would also include bytes the agent appends while the read is in flight,
+	// silently extending the "snapshot" past command-start.
+	var snapshotSize int64 = -1
+	if info, statErr := f.Stat(); statErr == nil {
+		snapshotSize = info.Size()
 	}
 
 	closeOnDone := make(chan struct{})
@@ -52,10 +66,11 @@ func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string) err
 		_ = f.Close()
 	}()
 
-	// Read into memory so we can shape-clean the trailing partial line. A
-	// single session transcript is bounded (low MB to ~100 MB at the
-	// extreme), which is fine for buffered handling.
-	buf, err := io.ReadAll(f)
+	var reader io.Reader = f
+	if snapshotSize >= 0 {
+		reader = io.LimitReader(f, snapshotSize)
+	}
+	buf, err := io.ReadAll(reader)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr //nolint:wrapcheck // propagating context cancellation
@@ -63,17 +78,25 @@ func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string) err
 		return fmt.Errorf("read transcript: %w", err)
 	}
 
-	if i := bytes.LastIndexByte(buf, '\n'); i >= 0 {
-		buf = buf[:i+1]
-	} else {
-		// File holds a single non-terminated record — return empty rather
-		// than a truncated record. Vanishingly rare for live transcripts.
-		buf = nil
-	}
-
-	if _, err := w.Write(buf); err != nil {
+	if _, err := w.Write(shapeTranscriptSnapshot(buf)); err != nil {
 		return fmt.Errorf("write transcript: %w", err)
 	}
+	return nil
+}
+
+// shapeTranscriptSnapshot returns the snapshot bytes a consumer should see.
+// If the buffer is a single valid JSON document (Gemini-style), it is emitted
+// intact. Otherwise it is treated as JSONL and trimmed to the last newline so
+// no partial trailing record reaches the consumer.
+func shapeTranscriptSnapshot(buf []byte) []byte {
+	if json.Valid(buf) {
+		return buf
+	}
+	if i := bytes.LastIndexByte(buf, '\n'); i >= 0 {
+		return buf[:i+1]
+	}
+	// Single non-terminated, non-JSON record (vanishingly rare for live
+	// transcripts) — return empty rather than a truncated record.
 	return nil
 }
 
@@ -396,10 +419,11 @@ and files touched. Works for both active and ended sessions.
 Output modes:
   Default       Human-readable summary.
   --json        Metadata-only JSON envelope (no transcript bytes).
-  --transcript  Stream the live raw agent transcript bytes to stdout
-                (per-agent JSONL format from the on-disk transcript).
-                Snapshot semantics: ends at EOF at command-start; trailing
-                partial line (if the agent is mid-write) is trimmed.
+  --transcript  Stream the live raw agent transcript bytes to stdout in
+                the agent's native format (JSONL for Claude/Cursor/Codex,
+                JSON for Gemini). Snapshot is bounded to the file size
+                observed at open. JSONL streams have a trailing partial
+                line trimmed; JSON documents are emitted intact.
 
 Examples:
   entire sessions info <session-id>

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -239,6 +239,8 @@ func sessionPhaseLabel(s *strategy.SessionState) string {
 }
 
 func newListCmd() *cobra.Command {
+	var jsonFlag bool
+
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all sessions",
@@ -247,16 +249,18 @@ func newListCmd() *cobra.Command {
 For active sessions only, use 'entire status'.
 
 Examples:
-  entire sessions list    List all sessions across all worktrees`,
+  entire sessions list           List all sessions across all worktrees
+  entire sessions list --json    Same list as a metadata-only JSON array`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runSessionList(cmd.Context(), cmd)
+			return runSessionList(cmd.Context(), cmd, jsonFlag)
 		},
 	}
 
+	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON")
 	return cmd
 }
 
-func runSessionList(ctx context.Context, cmd *cobra.Command) error {
+func runSessionList(ctx context.Context, cmd *cobra.Command, jsonOutput bool) error {
 	states, err := strategy.ListSessionStates(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list sessions: %w", err)
@@ -269,17 +273,21 @@ func runSessionList(ctx context.Context, cmd *cobra.Command) error {
 		}
 	}
 
+	// Sort by StartedAt descending (newest first); same order as the prose view.
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].StartedAt.After(filtered[j].StartedAt)
+	})
+
 	w := cmd.OutOrStdout()
+
+	if jsonOutput {
+		return writeSessionListJSON(w, filtered)
+	}
 
 	if len(filtered) == 0 {
 		fmt.Fprintln(w, "No sessions.")
 		return nil
 	}
-
-	// Sort by StartedAt descending (newest first)
-	sort.Slice(filtered, func(i, j int) bool {
-		return filtered[i].StartedAt.After(filtered[j].StartedAt)
-	})
 
 	sty := newStatusStyles(w)
 
@@ -299,6 +307,24 @@ func runSessionList(ctx context.Context, cmd *cobra.Command) error {
 	}
 	fmt.Fprintln(w)
 
+	return nil
+}
+
+// writeSessionListJSON emits the list as a JSON array of the same per-session
+// envelope returned by `entire session info --json`. Always emits a valid
+// array (`[]` for the empty case) so consumers can pipe through `jq` without
+// special-casing "no sessions".
+func writeSessionListJSON(w io.Writer, states []*strategy.SessionState) error {
+	out := make([]sessionInfoJSON, 0, len(states))
+	for _, state := range states {
+		out = append(out, buildSessionInfoJSON(state, sessionPhaseLabel(state)))
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("failed to encode session list: %w", err)
+	}
 	return nil
 }
 
@@ -477,7 +503,9 @@ type tokenInfoJSON struct {
 	Output     int `json:"output"`
 }
 
-func writeSessionInfoJSON(w io.Writer, state *strategy.SessionState, status string) error {
+// buildSessionInfoJSON converts a SessionState into the JSON envelope shared
+// by `session info --json`, `session current --json`, and `session list --json`.
+func buildSessionInfoJSON(state *strategy.SessionState, status string) sessionInfoJSON {
 	agentLabel := string(state.AgentType)
 	if agentLabel == "" {
 		agentLabel = unknownPlaceholder
@@ -507,10 +535,13 @@ func writeSessionInfoJSON(w io.Writer, state *strategy.SessionState, status stri
 			Output:     state.TokenUsage.OutputTokens,
 		}
 	}
+	return info
+}
 
+func writeSessionInfoJSON(w io.Writer, state *strategy.SessionState, status string) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(info); err != nil {
+	if err := enc.Encode(buildSessionInfoJSON(state, status)); err != nil {
 		return fmt.Errorf("failed to encode session info: %w", err)
 	}
 	return nil

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"bytes"
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"charm.land/huh/v2"
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
@@ -24,40 +26,47 @@ import (
 
 // streamTranscriptToStdout copies the contents of the file at path to w.
 // Cancellation is wired through a goroutine that closes the file on
-// <-ctx.Done(), so io.ReadAll returns promptly when the user hits Ctrl-C on a
+// <-ctx.Done(), so reads return promptly when the user hits Ctrl-C on a
 // multi-MB transcript instead of blocking until EOF.
 //
 // Snapshot semantics: the read is bounded to the file size observed at open
 // (via io.LimitReader) so writes the agent appends after command start are
-// excluded. Output shaping is content-aware:
+// excluded.
 //
-//   - Whole-document JSON transcripts (e.g. Gemini's session-*.json) are
-//     emitted intact. Trimming would cut off the closing brace.
-//   - JSONL transcripts (Claude Code, Cursor, Codex, etc.) get a trailing
-//     partial-line trim so consumers never see a truncated record.
+// Output shaping is agent-aware so the streaming path stays bounded-memory
+// for the unbounded case (JSONL transcripts grow with conversation length):
+//
+//   - JSONL agents (Claude Code, Cursor, Codex, etc.) — line-buffered copy.
+//     Only one line is held in memory at a time. A trailing partial line
+//     (agent mid-write) is silently dropped so consumers never see a
+//     truncated record.
+//   - Whole-document JSON agents (Gemini) — read snapshot into memory and
+//     validate with json.Valid before emitting. These transcripts are
+//     bounded by conversation size and rarely exceed a few MB even for
+//     long sessions, so buffering is acceptable here.
 //
 // path comes from a session-state file that Entire writes exclusively
 // under the user's own .git/. The path is therefore as trusted as any
 // other entry the local user has on disk; we do not validate it against a
 // confinement root.
-func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string) error {
+func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string, agentType types.AgentType) error {
 	f, err := os.Open(path) //nolint:gosec // see comment above on trust model
 	if err != nil {
 		return fmt.Errorf("open transcript: %w", err)
 	}
 
-	// Bound the snapshot to the file size at open. Without this, io.ReadAll
-	// would also include bytes the agent appends while the read is in flight,
-	// silently extending the "snapshot" past command-start.
+	// Bound the snapshot to the file size at open. Without this, the read
+	// would also include bytes the agent appends while in flight, silently
+	// extending the "snapshot" past command-start.
 	var snapshotSize int64 = -1
 	if info, statErr := f.Stat(); statErr == nil {
 		snapshotSize = info.Size()
 	}
 
-	// Single owner of the Close() call. Either the cancel goroutine fires
-	// it (to unblock io.ReadAll) or the defer fires it (normal path);
-	// sync.Once prevents the double close that would otherwise trip the
-	// race detector under heavy fd reuse.
+	// Single owner of Close. Either the cancel goroutine fires it (to
+	// unblock the read) or the defer fires it (normal path); sync.Once
+	// prevents the double close that would otherwise trip the race
+	// detector under heavy fd reuse.
 	var closeOnce sync.Once
 	closeFn := func() { closeOnce.Do(func() { _ = f.Close() }) }
 
@@ -78,33 +87,62 @@ func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string) err
 	if snapshotSize >= 0 {
 		reader = io.LimitReader(f, snapshotSize)
 	}
-	buf, err := io.ReadAll(reader)
+
+	if isWholeDocumentJSONAgent(agentType) {
+		return writeWholeDocumentJSONTranscript(ctx, w, reader)
+	}
+	return writeJSONLTranscript(ctx, w, reader)
+}
+
+// isWholeDocumentJSONAgent reports whether an agent's on-disk transcript is
+// a single JSON document (e.g. Gemini's session-*.json) versus JSONL.
+func isWholeDocumentJSONAgent(agentType types.AgentType) bool {
+	return agentType == agent.AgentTypeGemini
+}
+
+// writeJSONLTranscript copies a JSONL transcript line-by-line. Each completed
+// line (including its newline) is written to w. A trailing partial line at
+// EOF is dropped so consumers never see a truncated record.
+func writeJSONLTranscript(ctx context.Context, w io.Writer, r io.Reader) error {
+	br := bufio.NewReader(r)
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 && line[len(line)-1] == '\n' {
+			if _, werr := w.Write(line); werr != nil {
+				return fmt.Errorf("write transcript: %w", werr)
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr //nolint:wrapcheck // propagating context cancellation
+			}
+			return fmt.Errorf("read transcript: %w", err)
+		}
+	}
+}
+
+// writeWholeDocumentJSONTranscript reads the snapshot, validates it parses as
+// JSON, and emits it intact. Trim-to-last-newline would cut the closing
+// brace and produce malformed output for these agents.
+func writeWholeDocumentJSONTranscript(ctx context.Context, w io.Writer, r io.Reader) error {
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr //nolint:wrapcheck // propagating context cancellation
 		}
 		return fmt.Errorf("read transcript: %w", err)
 	}
-
-	if _, err := w.Write(shapeTranscriptSnapshot(buf)); err != nil {
+	if !json.Valid(buf) {
+		// Snapshot is mid-write or otherwise malformed; emit nothing rather
+		// than a truncated document. Consumer can re-run the export.
+		return nil
+	}
+	if _, err := w.Write(buf); err != nil {
 		return fmt.Errorf("write transcript: %w", err)
 	}
-	return nil
-}
-
-// shapeTranscriptSnapshot returns the snapshot bytes a consumer should see.
-// If the buffer is a single valid JSON document (Gemini-style), it is emitted
-// intact. Otherwise it is treated as JSONL and trimmed to the last newline so
-// no partial trailing record reaches the consumer.
-func shapeTranscriptSnapshot(buf []byte) []byte {
-	if json.Valid(buf) {
-		return buf
-	}
-	if i := bytes.LastIndexByte(buf, '\n'); i >= 0 {
-		return buf[:i+1]
-	}
-	// Single non-terminated, non-JSON record (vanishingly rare for live
-	// transcripts) — return empty rather than a truncated record.
 	return nil
 }
 
@@ -505,7 +543,7 @@ func writeSessionTranscript(ctx context.Context, cmd *cobra.Command, state *stra
 		return NewSilentError(fmt.Errorf("transcript unavailable: %w", err))
 	}
 
-	return streamTranscriptToStdout(ctx, cmd.OutOrStdout(), path)
+	return streamTranscriptToStdout(ctx, cmd.OutOrStdout(), path, state.AgentType)
 }
 
 // sessionInfoJSON is the JSON output structure for sessions info --json.

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -127,7 +127,11 @@ func writeJSONLTranscript(ctx context.Context, w io.Writer, r io.Reader) error {
 
 // writeWholeDocumentJSONTranscript reads the snapshot, validates it parses as
 // JSON, and emits it intact. Trim-to-last-newline would cut the closing
-// brace and produce malformed output for these agents.
+// brace and produce malformed output for these agents. An invalid snapshot
+// (agent mid-write or genuinely corrupt) is reported as an error rather
+// than emitting empty output, so machine consumers can distinguish "no
+// data" from "data unavailable, retry" — exit-code 0 + empty stdout would
+// otherwise look identical to a successfully-empty transcript.
 func writeWholeDocumentJSONTranscript(ctx context.Context, w io.Writer, r io.Reader) error {
 	buf, err := io.ReadAll(r)
 	if err != nil {
@@ -136,10 +140,13 @@ func writeWholeDocumentJSONTranscript(ctx context.Context, w io.Writer, r io.Rea
 		}
 		return fmt.Errorf("read transcript: %w", err)
 	}
-	if !json.Valid(buf) {
-		// Snapshot is mid-write or otherwise malformed; emit nothing rather
-		// than a truncated document. Consumer can re-run the export.
+	// Empty file is a valid snapshot for an agent that hasn't yet written
+	// anything; emit nothing and succeed. Non-empty but invalid is an error.
+	if len(buf) == 0 {
 		return nil
+	}
+	if !json.Valid(buf) {
+		return errors.New("transcript snapshot is not valid JSON (agent may be mid-write); retry the command")
 	}
 	if _, err := w.Write(buf); err != nil {
 		return fmt.Errorf("write transcript: %w", err)
@@ -544,6 +551,10 @@ func writeSessionTranscript(ctx context.Context, cmd *cobra.Command, state *stra
 		return NewSilentError(fmt.Errorf("transcript unavailable: %w", err))
 	}
 
+	// Errors from streaming are runtime issues (Stat failure, mid-write JSON,
+	// etc.), not flag-usage problems — don't print cobra's usage block on top
+	// of any partial stdout output.
+	cmd.SilenceUsage = true
 	return streamTranscriptToStdout(ctx, cmd.OutOrStdout(), path, state.AgentType)
 }
 

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -57,11 +57,15 @@ func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string, age
 
 	// Bound the snapshot to the file size at open. Without this, the read
 	// would also include bytes the agent appends while in flight, silently
-	// extending the "snapshot" past command-start.
-	var snapshotSize int64 = -1
-	if info, statErr := f.Stat(); statErr == nil {
-		snapshotSize = info.Size()
+	// extending the "snapshot" past command-start. Stat() failure here means
+	// we can't honor the snapshot guarantee — fail loudly rather than
+	// emitting an unbounded read with a misleading "snapshot" promise.
+	info, statErr := f.Stat()
+	if statErr != nil {
+		_ = f.Close()
+		return fmt.Errorf("stat transcript (snapshot bound unavailable): %w", statErr)
 	}
+	snapshotSize := info.Size()
 
 	// Single owner of Close. Either the cancel goroutine fires it (to
 	// unblock the read) or the defer fires it (normal path); sync.Once
@@ -83,10 +87,7 @@ func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string, age
 		closeFn()
 	}()
 
-	var reader io.Reader = f
-	if snapshotSize >= 0 {
-		reader = io.LimitReader(f, snapshotSize)
-	}
+	reader := io.LimitReader(f, snapshotSize)
 
 	if isWholeDocumentJSONAgent(agentType) {
 		return writeWholeDocumentJSONTranscript(ctx, w, reader)

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"charm.land/huh/v2"
@@ -53,17 +54,24 @@ func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string) err
 		snapshotSize = info.Size()
 	}
 
+	// Single owner of the Close() call. Either the cancel goroutine fires
+	// it (to unblock io.ReadAll) or the defer fires it (normal path);
+	// sync.Once prevents the double close that would otherwise trip the
+	// race detector under heavy fd reuse.
+	var closeOnce sync.Once
+	closeFn := func() { closeOnce.Do(func() { _ = f.Close() }) }
+
 	closeOnDone := make(chan struct{})
 	go func() {
 		select {
 		case <-ctx.Done():
-			_ = f.Close()
+			closeFn()
 		case <-closeOnDone:
 		}
 	}()
 	defer func() {
 		close(closeOnDone)
-		_ = f.Close()
+		closeFn()
 	}()
 
 	var reader io.Reader = f

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -18,6 +19,21 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
 	"github.com/spf13/cobra"
 )
+
+// openSessionTranscript opens the session transcript file for streaming.
+// Indirected via a package var so tests can stub the os.Open call.
+var openSessionTranscript = func(path string) (io.ReadCloser, error) {
+	return os.Open(path) //nolint:gosec // path is resolved from validated session state
+}
+
+// copySessionTranscript copies transcript bytes to w, honoring ctx cancellation.
+// Indirected via a package var so tests can swap behavior.
+var copySessionTranscript = func(ctx context.Context, w io.Writer, r io.Reader) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err //nolint:wrapcheck // Propagating context cancellation
+	}
+	return io.Copy(w, r)
+}
 
 func newSessionsCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -287,6 +303,7 @@ func writeSessionCard(w io.Writer, s *strategy.SessionState, sty statusStyles) {
 
 func newInfoCmd() *cobra.Command {
 	var jsonFlag bool
+	var transcriptFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "info <session-id>",
@@ -296,21 +313,30 @@ func newInfoCmd() *cobra.Command {
 Shows agent, model, status, worktree, timing, token usage, checkpoint linkage,
 and files touched. Works for both active and ended sessions.
 
+Output modes:
+  Default       Human-readable summary.
+  --json        Metadata-only JSON envelope (no transcript bytes).
+  --transcript  Stream the live raw agent transcript bytes to stdout
+                (per-agent JSONL format from the on-disk transcript).
+
 Examples:
   entire sessions info <session-id>
-  entire sessions info <session-id> --json`,
+  entire sessions info <session-id> --json
+  entire sessions info <session-id> --transcript > session.jsonl`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSessionInfo(cmd.Context(), cmd, args[0], jsonFlag)
+			return runSessionInfo(cmd.Context(), cmd, args[0], jsonFlag, transcriptFlag)
 		},
 	}
 
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&transcriptFlag, "transcript", false, "Stream raw agent transcript bytes to stdout")
+	cmd.MarkFlagsMutuallyExclusive("json", "transcript")
 
 	return cmd
 }
 
-func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, jsonOutput bool) error {
+func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, jsonOutput, transcriptOutput bool) error {
 	state, err := strategy.LoadSessionState(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("failed to load session: %w", err)
@@ -323,10 +349,41 @@ func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, j
 
 	status := sessionPhaseLabel(state)
 
+	if transcriptOutput {
+		return writeSessionTranscript(ctx, cmd, state)
+	}
 	if jsonOutput {
 		return writeSessionInfoJSON(cmd.OutOrStdout(), state, status)
 	}
 	return writeSessionInfoText(cmd.OutOrStdout(), state, status)
+}
+
+// writeSessionTranscript streams the live raw agent transcript for a session
+// to stdout. The transcript bytes are exactly what the agent has written to
+// disk in its native per-agent format (JSONL for Claude Code/Cursor, JSON for
+// Gemini, etc.) — Entire performs no normalization here.
+func writeSessionTranscript(ctx context.Context, cmd *cobra.Command, state *strategy.SessionState) error {
+	if state.TranscriptPath == "" {
+		cmd.SilenceUsage = true
+		return NewSilentError(fmt.Errorf("session %s has no transcript path recorded", state.SessionID))
+	}
+
+	path, err := strategy.ResolveTranscriptPath(state)
+	if err != nil {
+		cmd.SilenceUsage = true
+		return NewSilentError(fmt.Errorf("transcript unavailable: %w", err))
+	}
+
+	f, err := openSessionTranscript(path)
+	if err != nil {
+		return fmt.Errorf("failed to open transcript: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := copySessionTranscript(ctx, cmd.OutOrStdout(), f); err != nil {
+		return fmt.Errorf("failed to stream transcript: %w", err)
+	}
+	return nil
 }
 
 // sessionInfoJSON is the JSON output structure for sessions info --json.

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -20,19 +21,60 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// openSessionTranscript opens the session transcript file for streaming.
-// Indirected via a package var so tests can stub the os.Open call.
-var openSessionTranscript = func(path string) (io.ReadCloser, error) {
-	return os.Open(path) //nolint:gosec // path is resolved from validated session state
-}
-
-// copySessionTranscript copies transcript bytes to w, honoring ctx cancellation.
-// Indirected via a package var so tests can swap behavior.
-var copySessionTranscript = func(ctx context.Context, w io.Writer, r io.Reader) (int64, error) {
-	if err := ctx.Err(); err != nil {
-		return 0, err //nolint:wrapcheck // Propagating context cancellation
+// streamTranscriptToStdout copies the contents of the file at path to w.
+// Cancellation is wired through a goroutine that closes the file on
+// <-ctx.Done(), so io.ReadAll returns promptly when the user hits Ctrl-C on a
+// multi-MB transcript instead of blocking until EOF.
+//
+// Snapshot semantics: if the agent is mid-write when we hit EOF the trailing
+// partial line is trimmed so consumers never see a truncated JSONL record.
+//
+// state.TranscriptPath comes from a session-state file that Entire writes
+// exclusively under the user's own .git/. The path is therefore as trusted
+// as any other entry the local user has on disk; we do not validate it
+// against a confinement root.
+func streamTranscriptToStdout(ctx context.Context, w io.Writer, path string) error {
+	f, err := os.Open(path) //nolint:gosec // see comment above on trust model
+	if err != nil {
+		return fmt.Errorf("open transcript: %w", err)
 	}
-	return io.Copy(w, r)
+
+	closeOnDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = f.Close()
+		case <-closeOnDone:
+		}
+	}()
+	defer func() {
+		close(closeOnDone)
+		_ = f.Close()
+	}()
+
+	// Read into memory so we can shape-clean the trailing partial line. A
+	// single session transcript is bounded (low MB to ~100 MB at the
+	// extreme), which is fine for buffered handling.
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr //nolint:wrapcheck // propagating context cancellation
+		}
+		return fmt.Errorf("read transcript: %w", err)
+	}
+
+	if i := bytes.LastIndexByte(buf, '\n'); i >= 0 {
+		buf = buf[:i+1]
+	} else {
+		// File holds a single non-terminated record — return empty rather
+		// than a truncated record. Vanishingly rare for live transcripts.
+		buf = nil
+	}
+
+	if _, err := w.Write(buf); err != nil {
+		return fmt.Errorf("write transcript: %w", err)
+	}
+	return nil
 }
 
 func newSessionsCmd() *cobra.Command {
@@ -301,6 +343,18 @@ func writeSessionCard(w io.Writer, s *strategy.SessionState, sty statusStyles) {
 	fmt.Fprintln(w)
 }
 
+// sessionOutputMode describes how `entire session info` / `session current`
+// should render the resolved session. Cobra enforces mutual exclusion at the
+// flag layer; the enum makes the trichotomy total in code so we can't
+// accidentally combine modes by passing two booleans.
+type sessionOutputMode int
+
+const (
+	sessionOutputText sessionOutputMode = iota
+	sessionOutputJSON
+	sessionOutputTranscript
+)
+
 func newInfoCmd() *cobra.Command {
 	var jsonFlag bool
 	var transcriptFlag bool
@@ -318,6 +372,8 @@ Output modes:
   --json        Metadata-only JSON envelope (no transcript bytes).
   --transcript  Stream the live raw agent transcript bytes to stdout
                 (per-agent JSONL format from the on-disk transcript).
+                Snapshot semantics: ends at EOF at command-start; trailing
+                partial line (if the agent is mid-write) is trimmed.
 
 Examples:
   entire sessions info <session-id>
@@ -325,7 +381,7 @@ Examples:
   entire sessions info <session-id> --transcript > session.jsonl`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSessionInfo(cmd.Context(), cmd, args[0], jsonFlag, transcriptFlag)
+			return runSessionInfo(cmd.Context(), cmd, args[0], sessionOutputModeFromFlags(jsonFlag, transcriptFlag))
 		},
 	}
 
@@ -336,7 +392,18 @@ Examples:
 	return cmd
 }
 
-func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, jsonOutput, transcriptOutput bool) error {
+func sessionOutputModeFromFlags(jsonFlag, transcriptFlag bool) sessionOutputMode {
+	switch {
+	case transcriptFlag:
+		return sessionOutputTranscript
+	case jsonFlag:
+		return sessionOutputJSON
+	default:
+		return sessionOutputText
+	}
+}
+
+func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, mode sessionOutputMode) error {
 	state, err := strategy.LoadSessionState(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("failed to load session: %w", err)
@@ -349,13 +416,16 @@ func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, j
 
 	status := sessionPhaseLabel(state)
 
-	if transcriptOutput {
+	switch mode {
+	case sessionOutputTranscript:
 		return writeSessionTranscript(ctx, cmd, state)
-	}
-	if jsonOutput {
+	case sessionOutputJSON:
 		return writeSessionInfoJSON(cmd.OutOrStdout(), state, status)
+	case sessionOutputText:
+		return writeSessionInfoText(cmd.OutOrStdout(), state, status)
+	default:
+		return fmt.Errorf("unknown session output mode: %d", mode)
 	}
-	return writeSessionInfoText(cmd.OutOrStdout(), state, status)
 }
 
 // writeSessionTranscript streams the live raw agent transcript for a session
@@ -365,25 +435,19 @@ func runSessionInfo(ctx context.Context, cmd *cobra.Command, sessionID string, j
 func writeSessionTranscript(ctx context.Context, cmd *cobra.Command, state *strategy.SessionState) error {
 	if state.TranscriptPath == "" {
 		cmd.SilenceUsage = true
-		return NewSilentError(fmt.Errorf("session %s has no transcript path recorded", state.SessionID))
+		msg := fmt.Sprintf("session %s has no transcript path recorded", state.SessionID)
+		fmt.Fprintln(cmd.ErrOrStderr(), msg)
+		return NewSilentError(errors.New(msg))
 	}
 
 	path, err := strategy.ResolveTranscriptPath(state)
 	if err != nil {
 		cmd.SilenceUsage = true
+		fmt.Fprintf(cmd.ErrOrStderr(), "transcript unavailable: %v\n", err)
 		return NewSilentError(fmt.Errorf("transcript unavailable: %w", err))
 	}
 
-	f, err := openSessionTranscript(path)
-	if err != nil {
-		return fmt.Errorf("failed to open transcript: %w", err)
-	}
-	defer f.Close()
-
-	if _, err := copySessionTranscript(ctx, cmd.OutOrStdout(), f); err != nil {
-		return fmt.Errorf("failed to stream transcript: %w", err)
-	}
-	return nil
+	return streamTranscriptToStdout(ctx, cmd.OutOrStdout(), path)
 }
 
 // sessionInfoJSON is the JSON output structure for sessions info --json.

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	testAgentClaude    = "Claude Code"
+	testAgentGemini    = "Gemini CLI"
 	testCheckpointID   = "a3b2c4d5e6f7"
 	testPromptFixLogin = "fix the login bug"
 )
@@ -654,7 +655,7 @@ func TestListCmd_ShowsAllSessions(t *testing.T) {
 	active.StartedAt = time.Now().Add(-1 * time.Hour)
 
 	idle := makeSessionState("test-list-idle", session.PhaseIdle)
-	idle.AgentType = "Gemini CLI"
+	idle.AgentType = testAgentGemini
 	idle.WorktreeID = "other-wt"
 	idle.LastCheckpointID = testCheckpointID
 	idle.StartedAt = time.Now().Add(-2 * time.Hour)
@@ -706,6 +707,92 @@ func TestListCmd_ShowsAllSessions(t *testing.T) {
 	endedIdx := strings.Index(out, "test-list-ended")
 	if activeIdx > idleIdx || idleIdx > endedIdx {
 		t.Errorf("expected newest-first sort order, got active@%d idle@%d ended@%d", activeIdx, idleIdx, endedIdx)
+	}
+}
+
+func TestListCmd_JSONNoSessionsEmitsEmptyArray(t *testing.T) {
+	setupStopTestRepo(t)
+
+	cmd := newListCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--json"})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+
+	var got []sessionInfoJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("expected valid JSON array, got parse error: %v\noutput: %s", err, stdout.String())
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty array, got %d entries", len(got))
+	}
+}
+
+func TestListCmd_JSONReturnsAllSessionsSorted(t *testing.T) {
+	setupStopTestRepo(t)
+	ctx := context.Background()
+
+	older := makeSessionState("test-list-json-older", session.PhaseIdle)
+	older.AgentType = testAgentClaude
+	older.StartedAt = time.Now().Add(-2 * time.Hour)
+	older.WorktreeID = "wt-a"
+	older.LastCheckpointID = testCheckpointID
+
+	newer := makeSessionState("test-list-json-newer", session.PhaseActive)
+	newer.AgentType = testAgentGemini
+	newer.ModelName = "gemini-2.5-pro"
+	newer.StartedAt = time.Now().Add(-30 * time.Minute)
+	newer.WorktreeID = "wt-b"
+	newer.LastPrompt = testPromptFixLogin
+
+	for _, s := range []*strategy.SessionState{older, newer} {
+		if err := strategy.SaveSessionState(ctx, s); err != nil {
+			t.Fatalf("SaveSessionState: %v", err)
+		}
+	}
+
+	cmd := newListCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--json"})
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+
+	var got []sessionInfoJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("expected valid JSON array, got parse error: %v\noutput: %s", err, stdout.String())
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+
+	// Newest first — same order as the prose view.
+	if got[0].SessionID != "test-list-json-newer" {
+		t.Errorf("expected newest session first, got %q", got[0].SessionID)
+	}
+	if got[1].SessionID != "test-list-json-older" {
+		t.Errorf("expected older session second, got %q", got[1].SessionID)
+	}
+
+	// Envelope must carry the same fields a Baton-style consumer needs.
+	if got[0].Agent != testAgentGemini {
+		t.Errorf("expected agent='Gemini CLI', got %q", got[0].Agent)
+	}
+	if got[0].Model != "gemini-2.5-pro" {
+		t.Errorf("expected model='gemini-2.5-pro', got %q", got[0].Model)
+	}
+	if got[0].LastPrompt != testPromptFixLogin {
+		t.Errorf("expected last_prompt set, got %q", got[0].LastPrompt)
+	}
+	if got[0].WorktreeID != "wt-b" {
+		t.Errorf("expected worktree_id='wt-b', got %q", got[0].WorktreeID)
+	}
+	if got[1].LastCheckpoint != testCheckpointID {
+		t.Errorf("expected last_checkpoint_id=%q, got %q", testCheckpointID, got[1].LastCheckpoint)
 	}
 }
 

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -1144,6 +1144,48 @@ func TestInfoCmd_TranscriptEmitsWholeJSONDocument(t *testing.T) {
 	}
 }
 
+// TestInfoCmd_TranscriptInvalidJSONErrorsLoudly guards the bugbot finding
+// that whole-document JSON agents (Gemini) silently produced empty output
+// when the snapshot didn't parse as JSON. Machine consumers can't tell
+// "no data" from "data unavailable, retry" if exit-code 0 + empty stdout
+// is the same in both cases. The mid-write case must now error.
+func TestInfoCmd_TranscriptInvalidJSONErrorsLoudly(t *testing.T) {
+	setupStopTestRepo(t)
+	ctx := context.Background()
+
+	transcriptDir := t.TempDir()
+	transcriptPath := filepath.Join(transcriptDir, "session.json")
+	// Truncated JSON document — what Gemini would produce mid-write.
+	written := `{"sessionId":"abc","messages":[{"role":"user","content":"trun`
+	if err := os.WriteFile(transcriptPath, []byte(written), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	state := makeSessionState("test-info-invalid-json", session.PhaseActive)
+	state.AgentType = testAgentGemini
+	state.TranscriptPath = transcriptPath
+	if err := strategy.SaveSessionState(ctx, state); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	cmd := newInfoCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"test-info-invalid-json", "--transcript"})
+
+	err := cmd.ExecuteContext(ctx)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON snapshot, got nil")
+	}
+	if !strings.Contains(err.Error(), "not valid JSON") {
+		t.Errorf("expected 'not valid JSON' in error, got: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("expected empty stdout on JSON-validation failure, got: %q", stdout.String())
+	}
+}
+
 // TestInfoCmd_TranscriptBoundsSnapshotAtOpen verifies copilot finding 2:
 // bytes the agent appends after the command opens the file must NOT appear
 // in the output (snapshot is bounded at command start, not "current EOF").

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -1067,7 +1067,7 @@ func TestInfoCmd_TranscriptMissingPath(t *testing.T) {
 }
 
 // TestInfoCmd_TranscriptTrimsPartialTrailingLine verifies the snapshot-shape
-// guarantee documented in --help: if the agent is mid-write of a JSONL line
+// guarantee for JSONL transcripts: if the agent is mid-write of a JSONL line
 // when we hit EOF, consumers receive only the complete prefix.
 func TestInfoCmd_TranscriptTrimsPartialTrailingLine(t *testing.T) {
 	setupStopTestRepo(t)
@@ -1099,6 +1099,107 @@ func TestInfoCmd_TranscriptTrimsPartialTrailingLine(t *testing.T) {
 
 	if got := stdout.String(); got != full {
 		t.Errorf("expected partial trailing line trimmed.\n  want: %q\n  got:  %q", full, got)
+	}
+}
+
+// TestInfoCmd_TranscriptEmitsWholeJSONDocument verifies the Gemini-style case:
+// transcripts that are a single valid JSON document (no trailing newline) must
+// be emitted intact. Trim-to-last-newline would cut the closing brace and
+// produce malformed output. Regression test for copilot review feedback.
+func TestInfoCmd_TranscriptEmitsWholeJSONDocument(t *testing.T) {
+	setupStopTestRepo(t)
+	ctx := context.Background()
+
+	transcriptDir := t.TempDir()
+	transcriptPath := filepath.Join(transcriptDir, "session.json")
+	// Pretty-printed JSON (newlines inside) but no trailing newline at EOF.
+	want := `{
+  "sessionId": "abc",
+  "messages": [
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": "hello"}
+  ]
+}`
+	if err := os.WriteFile(transcriptPath, []byte(want), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	state := makeSessionState("test-info-json-doc", session.PhaseActive)
+	state.AgentType = testAgentGemini
+	state.TranscriptPath = transcriptPath
+	if err := strategy.SaveSessionState(ctx, state); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	cmd := newInfoCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"test-info-json-doc", "--transcript"})
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+
+	if got := stdout.String(); got != want {
+		t.Errorf("expected whole JSON document preserved.\n  want: %q\n  got:  %q", want, got)
+	}
+}
+
+// TestInfoCmd_TranscriptBoundsSnapshotAtOpen verifies copilot finding 2:
+// bytes the agent appends after the command opens the file must NOT appear
+// in the output (snapshot is bounded at command start, not "current EOF").
+func TestInfoCmd_TranscriptBoundsSnapshotAtOpen(t *testing.T) {
+	setupStopTestRepo(t)
+	ctx := context.Background()
+
+	transcriptDir := t.TempDir()
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	initial := `{"v":1,"role":"user"}` + "\n"
+	if err := os.WriteFile(transcriptPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	state := makeSessionState("test-info-snapshot", session.PhaseActive)
+	state.AgentType = testAgentClaude
+	state.TranscriptPath = transcriptPath
+	if err := strategy.SaveSessionState(ctx, state); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	// Append after command construction but before execution. With a properly
+	// bounded snapshot the appended bytes must not appear in stdout.
+	f, err := os.OpenFile(transcriptPath, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	if _, err := f.WriteString(`{"v":1,"role":"assistant","appended":"AFTER-OPEN"}` + "\n"); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	_ = f.Close()
+
+	cmd := newInfoCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"test-info-snapshot", "--transcript"})
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+
+	// We can't make this test deterministic against ordering of "open" vs
+	// "append" within a single goroutine — both have already happened by the
+	// time io.ReadAll runs. The real snapshot-vs-current-EOF distinction
+	// matters for in-flight appends across goroutines, which we can't
+	// reliably orchestrate in unit-test scope. The minimum we assert: when
+	// the snapshot bound is correctly anchored at f.Stat().Size(), the
+	// output is one of the two well-defined sizes (initial-only or
+	// initial+append), never half a record. This guards against the
+	// no-bound regression where an in-flight write produced truncated
+	// output.
+	got := stdout.String()
+	switch got {
+	case initial, initial + `{"v":1,"role":"assistant","appended":"AFTER-OPEN"}` + "\n":
+		// Either is well-formed.
+	default:
+		t.Errorf("expected snapshot to land on a record boundary, got: %q", got)
 	}
 }
 

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -922,7 +923,7 @@ func TestInfoCmd_TranscriptStreamsRawAgentBytes(t *testing.T) {
 	ctx := context.Background()
 
 	transcriptDir := t.TempDir()
-	transcriptPath := transcriptDir + "/session.jsonl"
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
 	want := []byte(`{"role":"user","content":"hi"}` + "\n" + `{"role":"assistant","content":"hello"}` + "\n")
 	if err := os.WriteFile(transcriptPath, want, 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
@@ -971,6 +972,46 @@ func TestInfoCmd_TranscriptMissingPath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no transcript path") {
 		t.Errorf("expected 'no transcript path' error, got: %v", err)
+	}
+	// User-visible cause: must be on stderr (not silently swallowed by SilentError).
+	if !strings.Contains(stderr.String(), "no transcript path") {
+		t.Errorf("expected stderr to surface 'no transcript path', got: %q", stderr.String())
+	}
+}
+
+// TestInfoCmd_TranscriptTrimsPartialTrailingLine verifies the snapshot-shape
+// guarantee documented in --help: if the agent is mid-write of a JSONL line
+// when we hit EOF, consumers receive only the complete prefix.
+func TestInfoCmd_TranscriptTrimsPartialTrailingLine(t *testing.T) {
+	setupStopTestRepo(t)
+	ctx := context.Background()
+
+	transcriptDir := t.TempDir()
+	transcriptPath := filepath.Join(transcriptDir, "session.jsonl")
+	// Two complete records + one truncated record (no trailing newline).
+	full := `{"v":1,"role":"user"}` + "\n" + `{"v":1,"role":"assistant"}` + "\n"
+	written := full + `{"v":1,"role":"user","content":"trunc`
+	if err := os.WriteFile(transcriptPath, []byte(written), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	state := makeSessionState("test-info-trim", session.PhaseActive)
+	state.AgentType = testAgentClaude
+	state.TranscriptPath = transcriptPath
+	if err := strategy.SaveSessionState(ctx, state); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	cmd := newInfoCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"test-info-trim", "--transcript"})
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+
+	if got := stdout.String(); got != full {
+		t.Errorf("expected partial trailing line trimmed.\n  want: %q\n  got:  %q", full, got)
 	}
 }
 

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -912,6 +913,79 @@ func TestInfoCmd_EndedSession(t *testing.T) {
 	}
 	if !strings.Contains(out, "Checkpoint:  b79b35cd956d") {
 		t.Errorf("expected checkpoint ID in output, got:\n%s", out)
+	}
+}
+
+func TestInfoCmd_TranscriptStreamsRawAgentBytes(t *testing.T) {
+	setupStopTestRepo(t)
+
+	ctx := context.Background()
+
+	transcriptDir := t.TempDir()
+	transcriptPath := transcriptDir + "/session.jsonl"
+	want := []byte(`{"role":"user","content":"hi"}` + "\n" + `{"role":"assistant","content":"hello"}` + "\n")
+	if err := os.WriteFile(transcriptPath, want, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	state := makeSessionState("test-info-transcript", session.PhaseActive)
+	state.AgentType = testAgentClaude
+	state.TranscriptPath = transcriptPath
+	if err := strategy.SaveSessionState(ctx, state); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	cmd := newInfoCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"test-info-transcript", "--transcript"})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("ExecuteContext: %v", err)
+	}
+
+	if !bytes.Equal(stdout.Bytes(), want) {
+		t.Errorf("transcript output mismatch.\n  want: %q\n  got:  %q", want, stdout.Bytes())
+	}
+}
+
+func TestInfoCmd_TranscriptMissingPath(t *testing.T) {
+	setupStopTestRepo(t)
+
+	ctx := context.Background()
+	state := makeSessionState("test-info-no-transcript", session.PhaseActive)
+	state.AgentType = testAgentClaude
+	if err := strategy.SaveSessionState(ctx, state); err != nil {
+		t.Fatalf("SaveSessionState: %v", err)
+	}
+
+	cmd := newInfoCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"test-info-no-transcript", "--transcript"})
+
+	err := cmd.ExecuteContext(ctx)
+	if err == nil {
+		t.Fatal("expected error when transcript path is empty")
+	}
+	if !strings.Contains(err.Error(), "no transcript path") {
+		t.Errorf("expected 'no transcript path' error, got: %v", err)
+	}
+}
+
+func TestInfoCmd_TranscriptAndJSONMutuallyExclusive(t *testing.T) {
+	setupStopTestRepo(t)
+
+	cmd := newInfoCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"some-id", "--json", "--transcript"})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error when --json and --transcript are combined")
 	}
 }
 

--- a/cmd/entire/cli/strategy/resolve_transcript.go
+++ b/cmd/entire/cli/strategy/resolve_transcript.go
@@ -10,6 +10,14 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 )
 
+// ResolveTranscriptPath is the exported wrapper around resolveTranscriptPath
+// for callers outside the strategy package (e.g. CLI commands streaming a
+// live transcript to stdout). The underlying function may update
+// state.TranscriptPath when an agent has relocated the file mid-session.
+func ResolveTranscriptPath(state *SessionState) (string, error) {
+	return resolveTranscriptPath(state)
+}
+
 // resolveTranscriptPath returns the current path to the session's transcript file.
 // If the file exists at state.TranscriptPath, that path is returned immediately.
 //


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/320
<!-- entire-trail-link-end -->

## Summary

Adds a thin, additive CLI surface that exposes session and checkpoint data
as a stable contract for external consumers (Baton, eval pipelines, the
`session-handoff` skill). Closes #1125.

No new top-level commands, no schema invention. JSON envelopes are
metadata-only; transcript bytes always stream to stdout from a flag.

**New flags:**
- `entire session info <id> --transcript` / `entire session current --transcript`
  — stream the live raw agent transcript to stdout (snapshot semantics:
  trailing partial JSONL line is trimmed; `<-ctx.Done()` cancels the read).
- `entire session list --json` — same per-entry envelope as
  `session info --json`, emitted as an array (`[]` for empty).
- `entire checkpoint explain --json` — metadata-only envelope. List view
  if no target, single-checkpoint object if a target is given. Per-session
  read failures surface an explicit `error` field (no silent stub entries);
  list-view non-context errors propagate (no swallowed `[]`).
- `entire checkpoint explain <id> --transcript` — stream the normalized
  compact transcript (V2 `transcript.jsonl` on `/main`).
- `entire checkpoint explain <id> --raw-transcript --session-index N` —
  pick a specific session in a multi-session checkpoint (default: latest).
  `--session-index` also works with `--transcript`.

**Internal:**
- Shared `matchCheckpointPrefixWithRemoteFallback` helper used by both the
  prose `runExplainCheckpointWithLookup` and the new export resolver.
- New `sessionOutputMode` enum replaces `(jsonOutput, transcriptOutput bool)`
  so the trichotomy is total in code.
- New exported `strategy.ResolveTranscriptPath` for live-transcript callers
  outside the strategy package.
- New `errCheckpointHasNoSessions` sentinel — distinguishes empty vs
  missing checkpoints for callers using `errors.Is`.

## Test plan

- [x] Unit + integration tests pass (`mise run test:ci`)
- [x] Lint clean (`mise run lint`)
- [x] Manual smoke test against a real repo with v1 + v2 checkpoints
- [x] `--json` envelope verified to never embed transcript bytes
  (`TestRunExplainExport_JSONNeverEmbedsTranscript`)
- [x] `--session-index` distinct content per session verified end-to-end
  (264KB session 0 vs 1.4MB session 1, distinct sessionIds)
- [x] Positional commit-SHA fallback verified end-to-end
- [x] `<-ctx.Done()` cancellation contract verified via close-on-done pattern
- [x] Partial trailing line trimmed
  (`TestInfoCmd_TranscriptTrimsPartialTrailingLine`)
- [x] Missing transcript path surfaces cause to stderr (not silent SilentError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new machine-readable CLI output modes that stream transcript bytes and emit JSON envelopes, which could affect scripting/automation and output/exit-code behavior if edge cases are missed.
> 
> **Overview**
> Adds a **machine-readable export surface** to existing CLI commands.
> 
> `entire checkpoint explain` gains `--json` (metadata-only list or single-checkpoint envelope with `partial` + per-session `error` reporting), `--transcript` (stream v2 compact transcript), `--session-index` (select session in multi-session checkpoints), and `--limit` (cap JSON list output with truncation note). Export resolution now retries missing checkpoint prefixes via a shared remote-metadata fetch helper, and supports positional fallback to commit-trailer resolution.
> 
> `entire session info` and `entire session current` gain `--transcript` to stream the live on-disk agent transcript with snapshot/cancellation semantics and agent-aware shaping (JSONL line streaming vs whole-JSON validation), while `entire session list` gains `--json` to emit the same per-session JSON envelopes as `session info --json`. Also exports `strategy.ResolveTranscriptPath` for non-strategy callers and adds comprehensive tests for the new flags and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eedeadd791f4f9456bdcabfb9034d33cf502d2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->