### PR TITLE
feat(review): add findings fix workflow

### DIFF
--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -161,14 +161,14 @@ Subcommands:
 				return err
 			}
 			if findings {
-				return runReviewFindings(ctx, cmd)
+				return runReviewFindings(ctx, cmd, deps.NewSilentError)
 			}
 			if fix {
 				target := ""
 				if len(args) == 1 {
 					target = args[0]
 				}
-				return runReviewFix(ctx, cmd, target, all, agentOverride)
+				return runReviewFix(ctx, cmd, target, all, agentOverride, deps.NewSilentError)
 			}
 			innerDeps := runReviewDeps{
 				promptForAgentFn: deps.PromptForAgentFn,

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -97,6 +97,9 @@ type runReviewDeps struct {
 func NewCommand(deps Deps) *cobra.Command {
 	var edit bool
 	var agentOverride string
+	var findings bool
+	var fix bool
+	var all bool
 
 	cmd := &cobra.Command{
 		Use: "review",
@@ -116,22 +119,56 @@ review metadata is permanently attached to the commit it covers.
 
 Flags:
   --edit         re-open the review config picker
+  --findings     browse local review findings
+  --fix          apply review findings in a normal agent session
+  --all          with --fix, apply all sources/findings without selectors
   --agent NAME   select a specific configured agent when more than one is
                  configured (default: alphabetically first)
 
 Subcommands:
   attach <id>    tag an existing session as a review (equivalent to
                  'entire attach --review <id>')`,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				return fmt.Errorf("accepts at most one review session id, received %d", len(args))
+			}
+			if len(args) == 1 && !fix {
+				return errors.New("review session id is only valid with --fix")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			// Discover external agents so review configs that target them
 			// resolve correctly — without this, GetAgentsWithHooksInstalled
 			// and agent.Get can't see them.
 			external.DiscoverAndRegister(ctx)
 
+			if all && !fix {
+				return errors.New("--all requires --fix")
+			}
+			modes := 0
+			for _, enabled := range []bool{edit, findings, fix} {
+				if enabled {
+					modes++
+				}
+			}
+			if modes > 1 {
+				return errors.New("--edit, --findings, and --fix are mutually exclusive")
+			}
 			if edit {
 				_, err := RunReviewConfigPicker(ctx, cmd.OutOrStdout(), deps.GetAgentsWithHooksInstalled)
 				return err
+			}
+			if findings {
+				return runReviewFindings(ctx, cmd)
+			}
+			if fix {
+				target := ""
+				if len(args) == 1 {
+					target = args[0]
+				}
+				return runReviewFix(ctx, cmd, target, all, agentOverride)
 			}
 			innerDeps := runReviewDeps{
 				promptForAgentFn: deps.PromptForAgentFn,
@@ -141,6 +178,9 @@ Subcommands:
 		},
 	}
 	cmd.Flags().BoolVar(&edit, "edit", false, "re-open the review config picker")
+	cmd.Flags().BoolVar(&findings, "findings", false, "browse local review findings")
+	cmd.Flags().BoolVar(&fix, "fix", false, "apply review findings in a normal agent session")
+	cmd.Flags().BoolVar(&all, "all", false, "with --fix, apply all sources/findings without selectors")
 	cmd.Flags().StringVar(&agentOverride, "agent", "", "select a specific configured agent (default: alphabetically first)")
 	if deps.AttachCmd != nil {
 		cmd.AddCommand(deps.AttachCmd)
@@ -363,7 +403,8 @@ func runSingleAgentPath(
 		defer tuiSink.Wait()
 	}
 
-	_, waitErr := Run(runCtx, reviewer, runCfg, sinks)
+	summary, waitErr := Run(runCtx, reviewer, runCfg, sinks)
+	writePostReviewManifest(ctx, out, worktreeRoot, headSHA, summary, "")
 	if waitErr != nil && runCtx.Err() == nil && ctx.Err() == nil {
 		// Non-cancellation error: surface to caller.
 		return fmt.Errorf("review run: %w", waitErr)
@@ -480,6 +521,7 @@ func runMultiAgentPath(
 	for i, r := range reviewers {
 		agentNames[i] = r.Name()
 	}
+	aggregateOutput := ""
 
 	// TUI requires both:
 	//   - terminal stdout (otherwise ANSI codes corrupt redirected output)
@@ -497,13 +539,17 @@ func runMultiAgentPath(
 		synthesisProvider: deps.SynthesisProvider,
 		promptYN:          deps.PromptYN,
 		perRunPrompt:      picked.PerRun,
+		onSynthesisResult: func(result string) {
+			aggregateOutput = result
+		},
 	})
 	if tuiSink, ok := findTUISink(sinks); ok {
 		tuiSink.Start()
 		defer tuiSink.Wait()
 	}
 
-	_, waitErr := RunMulti(runCtx, reviewers, reviewtypes.RunConfig{}, sinks)
+	summary, waitErr := RunMulti(runCtx, reviewers, reviewtypes.RunConfig{}, sinks)
+	writePostReviewManifest(ctx, out, worktreeRoot, headSHA, summary, aggregateOutput)
 	if waitErr != nil && runCtx.Err() == nil && ctx.Err() == nil {
 		return fmt.Errorf("review run: %w", waitErr)
 	}
@@ -544,6 +590,7 @@ type multiAgentSinkInputs struct {
 	synthesisProvider SynthesisProvider
 	promptYN          func(ctx context.Context, question string, def bool) (bool, error)
 	perRunPrompt      string
+	onSynthesisResult func(result string)
 }
 
 type singleAgentSinkInputs struct {
@@ -581,9 +628,37 @@ func composeMultiAgentSinks(in multiAgentSinkInputs) []reviewtypes.Sink {
 			PromptYN:     in.promptYN,
 			PerRunPrompt: in.perRunPrompt,
 			RunContext:   in.runContext,
+			OnResult:     in.onSynthesisResult,
 		})
 	}
 	return sinks
+}
+
+func writePostReviewManifest(
+	ctx context.Context,
+	out io.Writer,
+	worktreeRoot string,
+	headSHA string,
+	summary reviewtypes.RunSummary,
+	aggregateOutput string,
+) {
+	if summary.Cancelled || len(summary.AgentRuns) == 0 {
+		return
+	}
+	manifest, err := localReviewManifestFromCurrentState(ctx, worktreeRoot, headSHA, summary, aggregateOutput)
+	if err != nil {
+		logging.Debug(ctx, "review manifest not written", slog.String("error", err.Error()))
+		return
+	}
+	if len(manifest.Sources) == 0 {
+		logging.Debug(ctx, "review manifest not written: no matching review sessions")
+		return
+	}
+	if err := writeLocalReviewManifest(ctx, manifest); err != nil {
+		logging.Debug(ctx, "review manifest write failed", slog.String("error", err.Error()))
+		return
+	}
+	writeReviewCompletionFooter(out, manifest)
 }
 
 func composeSingleAgentSinks(in singleAgentSinkInputs) []reviewtypes.Sink {

--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -55,7 +55,7 @@ func TestReviewCmd_Help(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"review", "--edit", "--agent", "attach", "Labs entry"} {
+	for _, want := range []string{"review", "--edit", "--findings", "--fix", "--all", "--agent", "attach", "Labs entry"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("--help output missing %q: %s", want, out)
 		}
@@ -460,7 +460,7 @@ func TestDispatchFork_MultiAgentPassesPerAgentConfigs(t *testing.T) {
 			Skills: []string{"/review"},
 			Prompt: "Claude saved prompt.",
 		},
-		"codex": {
+		testCodexAgent: {
 			Skills: []string{"/review"},
 			Prompt: "Codex saved prompt.",
 		},
@@ -469,17 +469,17 @@ func TestDispatchFork_MultiAgentPassesPerAgentConfigs(t *testing.T) {
 	}
 
 	claudeReviewer := &captureRunConfigReviewer{name: "claude-code"}
-	codexReviewer := &captureRunConfigReviewer{name: "codex"}
+	codexReviewer := &captureRunConfigReviewer{name: testCodexAgent}
 	multiPickerFn := func(_ context.Context, _ []review.AgentChoice) (review.PickedAgents, error) {
 		return review.PickedAgents{
-			Names:  []string{"claude-code", "codex"},
+			Names:  []string{"claude-code", testCodexAgent},
 			PerRun: "Focus this run on regressions.",
 		}, nil
 	}
 
 	deps := review.Deps{
 		GetAgentsWithHooksInstalled: func(_ context.Context) []types.AgentName {
-			return []types.AgentName{"claude-code", "codex"}
+			return []types.AgentName{"claude-code", testCodexAgent}
 		},
 		NewSilentError: func(err error) error { return err },
 		MultiPickerFn:  multiPickerFn,
@@ -490,7 +490,7 @@ func TestDispatchFork_MultiAgentPassesPerAgentConfigs(t *testing.T) {
 			switch agentName {
 			case "claude-code":
 				return claudeReviewer
-			case "codex":
+			case testCodexAgent:
 				return codexReviewer
 			default:
 				return nil

--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -81,6 +81,48 @@ func TestNewReviewCmd_NoHiddenFlags(t *testing.T) {
 	}
 }
 
+func TestReviewFindings_NotGitRepoReturnsSilentError(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	rootCmd := cli.NewRootCmd()
+	errBuf := &bytes.Buffer{}
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"review", "--findings"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error outside a git repo")
+	}
+	var silentErr *cli.SilentError
+	if !errors.As(err, &silentErr) {
+		t.Fatalf("expected SilentError, got %T: %v", err, err)
+	}
+	if got := strings.Count(errBuf.String(), "Not a git repository"); got != 1 {
+		t.Fatalf("not-git message count = %d, want 1; stderr:\n%s", got, errBuf.String())
+	}
+}
+
+func TestReviewFix_NotGitRepoReturnsSilentError(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	rootCmd := cli.NewRootCmd()
+	errBuf := &bytes.Buffer{}
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"review", "--fix", "review-session"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error outside a git repo")
+	}
+	var silentErr *cli.SilentError
+	if !errors.As(err, &silentErr) {
+		t.Fatalf("expected SilentError, got %T: %v", err, err)
+	}
+	if got := strings.Count(errBuf.String(), "Not a git repository"); got != 1 {
+		t.Fatalf("not-git message count = %d, want 1; stderr:\n%s", got, errBuf.String())
+	}
+}
+
 // TestRunReview_MissingHooksAborts verifies that `entire review` aborts with a
 // clear error when the configured agent has no lifecycle hooks installed.
 func TestRunReview_MissingHooksAborts(t *testing.T) {

--- a/cmd/entire/cli/review/env.go
+++ b/cmd/entire/cli/review/env.go
@@ -109,6 +109,17 @@ func AppendReviewEnv(base []string, agentName string, cfg reviewtypes.RunConfig,
 	)
 }
 
+func withoutReviewEnv(base []string) []string {
+	out := make([]string, 0, len(base))
+	for _, kv := range base {
+		if isReviewEnvEntry(kv) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
 // isReviewEnvEntry reports whether kv is a "KEY=VALUE" entry whose key is
 // one of the ENTIRE_REVIEW_* contract variables.
 func isReviewEnvEntry(kv string) bool {

--- a/cmd/entire/cli/review/fix.go
+++ b/cmd/entire/cli/review/fix.go
@@ -45,12 +45,12 @@ type reviewFinding struct {
 	Body  string
 }
 
-func runReviewFindings(ctx context.Context, cmd *cobra.Command) error {
+func runReviewFindings(ctx context.Context, cmd *cobra.Command, silentErr func(error) error) error {
 	worktreeRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		cmd.SilenceUsage = true
 		fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Run `entire enable` first.")
-		return fmt.Errorf("resolve worktree root: %w", err)
+		return wrapReviewSilentError(silentErr, errors.New("not a git repository"))
 	}
 	manifests, err := loadLocalReviewManifests(ctx, worktreeRoot)
 	if err != nil {
@@ -72,12 +72,19 @@ func runReviewFindings(ctx context.Context, cmd *cobra.Command) error {
 	return nil
 }
 
-func runReviewFix(ctx context.Context, cmd *cobra.Command, target string, all bool, agentOverride string) error {
+func runReviewFix(
+	ctx context.Context,
+	cmd *cobra.Command,
+	target string,
+	all bool,
+	agentOverride string,
+	silentErr func(error) error,
+) error {
 	worktreeRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		cmd.SilenceUsage = true
 		fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Run `entire enable` first.")
-		return fmt.Errorf("resolve worktree root: %w", err)
+		return wrapReviewSilentError(silentErr, errors.New("not a git repository"))
 	}
 
 	manifest, err := resolveReviewFixManifest(ctx, cmd, worktreeRoot, target)
@@ -99,6 +106,13 @@ func runReviewFix(ctx context.Context, cmd *cobra.Command, target string, all bo
 	}
 	prompt := composeReviewFixPrompt(manifest, reviewFixSourcesFromFindings(findings))
 	return launchReviewFixAgent(ctx, fixAgent, prompt)
+}
+
+func wrapReviewSilentError(silentErr func(error) error, err error) error {
+	if silentErr == nil {
+		return err
+	}
+	return silentErr(err)
 }
 
 func resolveReviewFixManifest(ctx context.Context, cmd *cobra.Command, worktreeRoot string, target string) (LocalReviewManifest, error) {

--- a/cmd/entire/cli/review/fix.go
+++ b/cmd/entire/cli/review/fix.go
@@ -1,0 +1,693 @@
+package review
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+
+	"charm.land/huh/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	agenttypes "github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/mdrender"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/stringutil"
+)
+
+type reviewFixSourceKind string
+
+const (
+	reviewFixSourceAgent     reviewFixSourceKind = "agent"
+	reviewFixSourceAggregate reviewFixSourceKind = "aggregate"
+	reviewCommandBinary                          = "entire"
+)
+
+type reviewFixSource struct {
+	Kind      reviewFixSourceKind
+	Agent     string
+	Label     string
+	Output    string
+	Synthetic bool
+}
+
+type reviewFinding struct {
+	ID    string
+	Title string
+	Body  string
+}
+
+func runReviewFindings(ctx context.Context, cmd *cobra.Command) error {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Run `entire enable` first.")
+		return fmt.Errorf("resolve worktree root: %w", err)
+	}
+	manifests, err := loadLocalReviewManifests(ctx, worktreeRoot)
+	if err != nil {
+		return err
+	}
+	if len(manifests) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No local review findings found.")
+		return nil
+	}
+	if interactive.IsTerminalWriter(cmd.OutOrStdout()) && interactive.CanPromptInteractively() {
+		manifest, pickErr := promptForReviewManifest(ctx, manifests)
+		if pickErr != nil {
+			return pickErr
+		}
+		printReviewManifestDetail(cmd.OutOrStdout(), manifest)
+		return nil
+	}
+	printReviewFindingsList(cmd.OutOrStdout(), manifests)
+	return nil
+}
+
+func runReviewFix(ctx context.Context, cmd *cobra.Command, target string, all bool, agentOverride string) error {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Run `entire enable` first.")
+		return fmt.Errorf("resolve worktree root: %w", err)
+	}
+
+	manifest, err := resolveReviewFixManifest(ctx, cmd, worktreeRoot, target)
+	if err != nil {
+		return err
+	}
+	sources, err := selectReviewFixSources(ctx, cmd, manifest, all)
+	if err != nil {
+		return err
+	}
+	findings, err := selectReviewFindings(ctx, cmd, sources, all)
+	if err != nil {
+		return err
+	}
+
+	fixAgent, err := resolveReviewFixAgent(ctx, cmd, sources, agentOverride)
+	if err != nil {
+		return err
+	}
+	prompt := composeReviewFixPrompt(manifest, reviewFixSourcesFromFindings(findings))
+	return launchReviewFixAgent(ctx, fixAgent, prompt)
+}
+
+func resolveReviewFixManifest(ctx context.Context, cmd *cobra.Command, worktreeRoot string, target string) (LocalReviewManifest, error) {
+	if target != "" {
+		manifest, _, err := resolveLocalReviewManifestBySessionID(ctx, worktreeRoot, target)
+		return manifest, err
+	}
+	manifests, err := loadLocalReviewManifests(ctx, worktreeRoot)
+	if err != nil {
+		return LocalReviewManifest{}, err
+	}
+	switch len(manifests) {
+	case 0:
+		return LocalReviewManifest{}, errors.New("no local review findings found")
+	case 1:
+		return manifests[0], nil
+	default:
+		if !interactive.IsTerminalWriter(cmd.OutOrStdout()) || !interactive.CanPromptInteractively() {
+			printReviewFindingsList(cmd.OutOrStdout(), manifests)
+			return LocalReviewManifest{}, errors.New("multiple review runs found; pass a session id")
+		}
+		return promptForReviewManifest(ctx, manifests)
+	}
+}
+
+func promptForReviewManifest(ctx context.Context, manifests []LocalReviewManifest) (LocalReviewManifest, error) {
+	options := make([]huh.Option[int], len(manifests))
+	for i, manifest := range manifests {
+		options[i] = huh.NewOption(reviewManifestListLabel(manifest), i)
+	}
+	picked := 0
+	form := newAccessibleForm(huh.NewGroup(
+		huh.NewSelect[int]().
+			Title("Select review findings").
+			Options(options...).
+			Height(min(len(options)+1, 10)).
+			Value(&picked),
+	))
+	if err := form.RunWithContext(ctx); err != nil {
+		return LocalReviewManifest{}, fmt.Errorf("review findings picker: %w", err)
+	}
+	return manifests[picked], nil
+}
+
+func selectReviewFixSources(ctx context.Context, cmd *cobra.Command, manifest LocalReviewManifest, all bool) ([]reviewFixSource, error) {
+	sources := reviewFixSourcesForManifest(manifest)
+	if len(sources) == 0 {
+		return nil, errors.New("selected review has no output to fix")
+	}
+	if all {
+		return reviewFixSourcesForAll(sources), nil
+	}
+	if len(sources) == 1 {
+		return sources, nil
+	}
+	if !interactive.IsTerminalWriter(cmd.OutOrStdout()) || !interactive.CanPromptInteractively() {
+		return nil, errors.New("multiple review sources found; rerun with --all or use an interactive terminal")
+	}
+
+	values := make([]string, len(sources))
+	options := make([]huh.Option[string], len(sources))
+	defaults := defaultReviewFixSourceSelection(sources)
+	for i, source := range sources {
+		value := strconv.Itoa(i)
+		values[i] = value
+		options[i] = huh.NewOption(source.Label, value)
+	}
+	picked := defaults
+	form := newAccessibleForm(huh.NewGroup(
+		huh.NewMultiSelect[string]().
+			Title(reviewFixSourcePickerTitle(manifest)).
+			Description("ctrl+a select all · space toggle · enter continue").
+			Options(options...).
+			Height(reviewPickerHeight(len(options))).
+			Value(&picked),
+	))
+	if err := form.RunWithContext(ctx); err != nil {
+		return nil, fmt.Errorf("review source picker: %w", err)
+	}
+	if len(picked) == 0 {
+		return nil, errors.New("no review sources selected")
+	}
+	selected := make([]reviewFixSource, 0, len(picked))
+	for _, value := range picked {
+		idx := slices.Index(values, value)
+		if idx >= 0 {
+			selected = append(selected, sources[idx])
+		}
+	}
+	return selected, nil
+}
+
+func selectReviewFindings(ctx context.Context, cmd *cobra.Command, sources []reviewFixSource, all bool) ([]reviewFinding, error) {
+	findings := extractReviewFindings(sources)
+	if all || len(findings) <= 1 {
+		return findings, nil
+	}
+	if !interactive.IsTerminalWriter(cmd.OutOrStdout()) || !interactive.CanPromptInteractively() {
+		return nil, errors.New("multiple findings found; rerun with --all or use an interactive terminal")
+	}
+	options := make([]huh.Option[string], len(findings))
+	picked := make([]string, len(findings))
+	for i, finding := range findings {
+		picked[i] = finding.ID
+		options[i] = huh.NewOption(finding.Title, finding.ID)
+	}
+	form := newAccessibleForm(huh.NewGroup(
+		huh.NewMultiSelect[string]().
+			Title("Select findings to fix").
+			Description("ctrl+a select all · space toggle · enter fix").
+			Options(options...).
+			Height(reviewPickerHeight(len(options))).
+			Value(&picked),
+	))
+	if err := form.RunWithContext(ctx); err != nil {
+		return nil, fmt.Errorf("review finding picker: %w", err)
+	}
+	if len(picked) == 0 {
+		return nil, errors.New("no findings selected")
+	}
+	selected := make([]reviewFinding, 0, len(picked))
+	for _, finding := range findings {
+		if slices.Contains(picked, finding.ID) {
+			selected = append(selected, finding)
+		}
+	}
+	return selected, nil
+}
+
+func composeReviewFixPrompt(manifest LocalReviewManifest, sources []reviewFixSource) string {
+	var b strings.Builder
+	b.WriteString("Fix only the selected review findings.\n")
+	b.WriteString("Do not rewrite unrelated code. Run targeted tests where practical, then report what changed and what verification passed.\n")
+	if manifest.StartingSHA != "" {
+		fmt.Fprintf(&b, "\nReviewed commit: %s\n", manifest.StartingSHA)
+	}
+	if manifest.WorktreePath != "" {
+		fmt.Fprintf(&b, "Worktree: %s\n", manifest.WorktreePath)
+	}
+	for _, source := range sources {
+		if strings.TrimSpace(source.Output) == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "\n## %s\n\n%s\n", source.Label, strings.TrimSpace(source.Output))
+	}
+	return strings.TrimSpace(b.String()) + "\n"
+}
+
+func reviewFixSourcesForManifest(manifest LocalReviewManifest) []reviewFixSource {
+	sources := make([]reviewFixSource, 0, len(manifest.Sources)+1)
+	for _, source := range manifest.Sources {
+		if strings.TrimSpace(source.Output) == "" {
+			continue
+		}
+		label := source.Label
+		if label == "" {
+			label = source.Agent
+		}
+		sources = append(sources, reviewFixSource{
+			Kind:   reviewFixSourceAgent,
+			Agent:  source.Agent,
+			Label:  label + " findings",
+			Output: source.Output,
+		})
+	}
+	if strings.TrimSpace(manifest.AggregateOutput) != "" {
+		sources = append(sources, reviewFixSource{
+			Kind:   reviewFixSourceAggregate,
+			Label:  "Aggregate summary",
+			Output: manifest.AggregateOutput,
+		})
+	} else if len(sources) > 1 {
+		sources = append(sources, reviewFixSource{
+			Kind:      reviewFixSourceAggregate,
+			Label:     "Aggregate findings",
+			Output:    selectedSourcesOutput(sources),
+			Synthetic: true,
+		})
+	}
+	return sources
+}
+
+func reviewPickerHeight(optionCount int) int {
+	// huh.MultiSelect subtracts the title and description from Height before
+	// sizing the option viewport, so reserve those two lines explicitly.
+	return min(optionCount+3, 14)
+}
+
+func reviewFixSourcePickerTitle(manifest LocalReviewManifest) string {
+	handle := reviewManifestHandle(manifest)
+	if handle == "" {
+		return "Choose findings source"
+	}
+	return "Choose findings source (" + handle + ")"
+}
+
+func reviewFixSourcesForAll(sources []reviewFixSource) []reviewFixSource {
+	selected := make([]reviewFixSource, 0, len(sources))
+	for _, source := range sources {
+		if source.Synthetic {
+			continue
+		}
+		selected = append(selected, source)
+	}
+	if len(selected) == 0 {
+		return sources
+	}
+	return selected
+}
+
+func defaultReviewFixSourceSelection(sources []reviewFixSource) []string {
+	var aggregate []string
+	var agents []string
+	for i, source := range sources {
+		value := strconv.Itoa(i)
+		if source.Kind == reviewFixSourceAggregate {
+			aggregate = append(aggregate, value)
+			continue
+		}
+		agents = append(agents, value)
+	}
+	if len(aggregate) > 0 {
+		return aggregate
+	}
+	return agents
+}
+
+func extractReviewFindings(sources []reviewFixSource) []reviewFinding {
+	var findings []reviewFinding
+	for i, source := range sources {
+		sourceFindings := extractSourceFindings(source, i)
+		findings = append(findings, sourceFindings...)
+	}
+	if len(findings) > 0 {
+		return findings
+	}
+	combined := selectedSourcesOutput(sources)
+	if combined == "" {
+		return nil
+	}
+	return []reviewFinding{{
+		ID:    "full-output",
+		Title: "Full selected review output",
+		Body:  combined,
+	}}
+}
+
+func extractSourceFindings(source reviewFixSource, sourceIndex int) []reviewFinding {
+	lines := strings.Split(source.Output, "\n")
+	var findings []reviewFinding
+	var current *reviewFinding
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		title, ok := reviewFindingTitle(trimmed)
+		if ok {
+			if current != nil {
+				findings = append(findings, *current)
+			}
+			current = &reviewFinding{
+				ID:    fmt.Sprintf("source-%d-%d", sourceIndex, len(findings)+1),
+				Title: source.Label + ": " + stringutil.TruncateRunes(title, 90, "..."),
+				Body:  title,
+			}
+			continue
+		}
+		if current != nil {
+			current.Body = strings.TrimSpace(current.Body + "\n" + line)
+		}
+	}
+	if current != nil {
+		findings = append(findings, *current)
+	}
+	return findings
+}
+
+func reviewFindingTitle(line string) (string, bool) {
+	line = strings.TrimLeft(line, "#*- \t")
+	line = strings.TrimSpace(line)
+	if len(line) < 3 {
+		return "", false
+	}
+	if isSeverityNumberedTitle(line) {
+		return line, true
+	}
+	lower := strings.ToLower(line)
+	for _, prefix := range []string{"blocker", "critical", "high", "medium", "low"} {
+		if strings.HasPrefix(lower, prefix+":") || strings.HasPrefix(lower, prefix+" -") || strings.HasPrefix(lower, prefix+".") {
+			return line, true
+		}
+	}
+	return "", false
+}
+
+func isSeverityNumberedTitle(line string) bool {
+	if len(line) < 3 {
+		return false
+	}
+	switch line[0] {
+	case 'H', 'M', 'L':
+	default:
+		return false
+	}
+	return line[1] >= '0' && line[1] <= '9' && (line[2] == '.' || line[2] == ')')
+}
+
+func reviewFixSourcesFromFindings(findings []reviewFinding) []reviewFixSource {
+	var b strings.Builder
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.Body) == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "## %s\n\n%s\n\n", finding.Title, strings.TrimSpace(finding.Body))
+	}
+	return []reviewFixSource{{
+		Kind:   reviewFixSourceAgent,
+		Label:  "Selected findings",
+		Output: strings.TrimSpace(b.String()),
+	}}
+}
+
+func selectedSourcesOutput(sources []reviewFixSource) string {
+	var b strings.Builder
+	for _, source := range sources {
+		if strings.TrimSpace(source.Output) == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "## %s\n\n%s\n\n", source.Label, strings.TrimSpace(source.Output))
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func resolveReviewFixAgent(ctx context.Context, cmd *cobra.Command, sources []reviewFixSource, agentOverride string) (string, error) {
+	if agentOverride != "" {
+		return agentOverride, nil
+	}
+	if agentName, ok := reviewFixAgentFromSelectedSources(sources); ok {
+		return agentName, nil
+	}
+
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return "", fmt.Errorf("load review fix settings: %w", err)
+	}
+	choices := reviewFixAgentChoices(s.Review)
+	if len(choices) == 0 {
+		choices = reviewFixAgentChoicesFromSources(sources)
+	}
+	switch len(choices) {
+	case 0:
+		return "", errors.New("cannot determine fix agent; rerun with --agent")
+	case 1:
+		return choices[0].Name, nil
+	}
+	if pick, ok := savedReviewFixAgentPick(choices, s.ReviewFixAgent); ok {
+		return pick, nil
+	}
+
+	if !interactive.IsTerminalWriter(cmd.OutOrStdout()) || !interactive.CanPromptInteractively() {
+		return "", errors.New("multiple fix agents configured; rerun with --agent or run `entire review --edit`")
+	}
+
+	picked, err := promptForReviewFixAgent(ctx, choices, s.ReviewFixAgent)
+	if err != nil {
+		return "", err
+	}
+	if err := SaveReviewFixAgent(ctx, picked); err != nil {
+		return "", err
+	}
+	return picked, nil
+}
+
+func reviewFixAgentFromSelectedSources(sources []reviewFixSource) (string, bool) {
+	if len(sources) != 1 {
+		return "", false
+	}
+	source := sources[0]
+	if source.Kind != reviewFixSourceAgent || source.Agent == "" {
+		return "", false
+	}
+	return source.Agent, true
+}
+
+func reviewFixAgentChoices(configured map[string]settings.ReviewConfig) []AgentChoice {
+	choices := make([]AgentChoice, 0, len(configured))
+	for name, cfg := range configured {
+		if cfg.IsZero() {
+			continue
+		}
+		choice, ok := reviewFixAgentChoice(name)
+		if ok {
+			choices = append(choices, choice)
+		}
+	}
+	slices.SortFunc(choices, func(a, b AgentChoice) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return choices
+}
+
+func reviewFixAgentChoicesFromSources(sources []reviewFixSource) []AgentChoice {
+	seen := map[string]struct{}{}
+	var choices []AgentChoice
+	for _, source := range sources {
+		if source.Agent == "" {
+			continue
+		}
+		if _, ok := seen[source.Agent]; ok {
+			continue
+		}
+		choice, ok := reviewFixAgentChoice(source.Agent)
+		if !ok {
+			continue
+		}
+		seen[source.Agent] = struct{}{}
+		choices = append(choices, choice)
+	}
+	slices.SortFunc(choices, func(a, b AgentChoice) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return choices
+}
+
+func reviewFixAgentChoice(name string) (AgentChoice, bool) {
+	if _, ok := agent.LauncherFor(agenttypes.AgentName(name)); !ok {
+		return AgentChoice{}, false
+	}
+	label := name
+	if ag, err := agent.Get(agenttypes.AgentName(name)); err == nil {
+		label = string(ag.Type())
+	}
+	return AgentChoice{Name: name, Label: label}, true
+}
+
+func defaultReviewFixAgentPick(choices []AgentChoice, saved string) string {
+	if pick, ok := savedReviewFixAgentPick(choices, saved); ok {
+		return pick
+	}
+	if len(choices) == 0 {
+		return ""
+	}
+	return choices[0].Name
+}
+
+func savedReviewFixAgentPick(choices []AgentChoice, saved string) (string, bool) {
+	for _, choice := range choices {
+		if choice.Name == saved {
+			return saved, true
+		}
+	}
+	return "", false
+}
+
+func promptForReviewFixAgent(ctx context.Context, choices []AgentChoice, saved string) (string, error) {
+	options := make([]huh.Option[string], 0, len(choices))
+	for _, choice := range choices {
+		options = append(options, huh.NewOption(choice.Label, choice.Name))
+	}
+	picked := defaultReviewFixAgentPick(choices, saved)
+	form := newAccessibleForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Choose fix agent").
+			Description("Used for aggregate or multi-agent review findings. Saved for next time.").
+			Options(options...).
+			Height(reviewPickerHeight(len(options))).
+			Value(&picked),
+	))
+	if err := form.RunWithContext(ctx); err != nil {
+		return "", fmt.Errorf("fix agent picker: %w", err)
+	}
+	return picked, nil
+}
+
+func launchReviewFixAgent(ctx context.Context, agentName string, prompt string) error {
+	ag, err := agent.Get(agenttypes.AgentName(agentName))
+	if err != nil {
+		return fmt.Errorf("resolve fix agent %s: %w", agentName, err)
+	}
+	launcher, ok := agent.LauncherFor(ag.Name())
+	if !ok {
+		return fmt.Errorf("agent %s cannot be launched for review fixes", agentName)
+	}
+	cmd, err := launcher.LaunchCmd(ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("build fix command: %w", err)
+	}
+	cmd.Env = withoutReviewEnv(cmd.Env)
+	if len(cmd.Env) == 0 {
+		cmd.Env = withoutReviewEnv(os.Environ())
+	}
+	if err := cmd.Run(); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return fmt.Errorf("fix agent cancelled: %w", err)
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return fmt.Errorf("fix agent exited with status %d: %w", exitErr.ExitCode(), err)
+		}
+		return fmt.Errorf("run fix agent: %w", err)
+	}
+	return nil
+}
+
+func writeReviewCompletionFooter(w io.Writer, manifest LocalReviewManifest) {
+	handle := reviewManifestHandle(manifest)
+	if handle == "" {
+		return
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Review complete.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "To apply all review findings:")
+	fmt.Fprintf(w, "  %s review --fix %s --all\n", reviewCommandBinary, handle)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "To choose findings:")
+	fmt.Fprintf(w, "  %s review --fix %s\n", reviewCommandBinary, handle)
+}
+
+func reviewManifestHandle(manifest LocalReviewManifest) string {
+	for _, source := range manifest.Sources {
+		if source.SessionID != "" {
+			return source.SessionID
+		}
+	}
+	return ""
+}
+
+func printReviewFindingsList(w io.Writer, manifests []LocalReviewManifest) {
+	fmt.Fprintln(w, "Review Findings")
+	fmt.Fprintln(w)
+	commandName := reviewCommandBinary
+	for _, manifest := range manifests {
+		fmt.Fprintf(w, "%s\n", reviewManifestListLabel(manifest))
+		fmt.Fprintf(w, "  fix all: %s review --fix %s --all\n", commandName, reviewManifestHandle(manifest))
+		fmt.Fprintf(w, "  choose:  %s review --fix %s\n", commandName, reviewManifestHandle(manifest))
+	}
+}
+
+func printReviewManifestDetail(w io.Writer, manifest LocalReviewManifest) {
+	fmt.Fprintf(w, "Review findings from %s\n\n", reviewManifestListLabel(manifest))
+	for _, source := range manifest.Sources {
+		printRenderedReviewSection(w, source.Label, source.Output)
+	}
+	if strings.TrimSpace(manifest.AggregateOutput) != "" {
+		printRenderedReviewSection(w, "Aggregate summary", manifest.AggregateOutput)
+	}
+	writeReviewCompletionFooter(w, manifest)
+}
+
+func printRenderedReviewSection(w io.Writer, title string, body string) {
+	markdown := fmt.Sprintf("## %s\n\n%s\n", title, strings.TrimSpace(body))
+	rendered, err := mdrender.RenderForWriter(w, markdown)
+	if err != nil {
+		rendered = markdown
+	}
+	fmt.Fprint(w, rendered)
+	if !strings.HasSuffix(rendered, "\n") {
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintln(w)
+}
+
+func reviewManifestListLabel(manifest LocalReviewManifest) string {
+	handle := reviewManifestHandle(manifest)
+	if handle == "" {
+		handle = "unknown-session"
+	}
+	agents := make([]string, 0, len(manifest.Sources))
+	for _, source := range manifest.Sources {
+		if source.Label != "" {
+			agents = append(agents, source.Label)
+			continue
+		}
+		agents = append(agents, source.Agent)
+	}
+	preview := reviewManifestPreview(manifest)
+	if preview != "" {
+		return fmt.Sprintf("%s · local · %s · %s", handle, strings.Join(agents, ", "), preview)
+	}
+	return fmt.Sprintf("%s · local · %s", handle, strings.Join(agents, ", "))
+}
+
+func reviewManifestPreview(manifest LocalReviewManifest) string {
+	for _, source := range manifest.Sources {
+		if text := strings.TrimSpace(source.Output); text != "" {
+			return stringutil.TruncateRunes(strings.Join(strings.Fields(text), " "), 70, "...")
+		}
+	}
+	if text := strings.TrimSpace(manifest.AggregateOutput); text != "" {
+		return stringutil.TruncateRunes(strings.Join(strings.Fields(text), " "), 70, "...")
+	}
+	return ""
+}

--- a/cmd/entire/cli/review/manifest.go
+++ b/cmd/entire/cli/review/manifest.go
@@ -193,6 +193,7 @@ func resolveLocalReviewManifestBySessionID(ctx context.Context, worktreeRoot, se
 			if source.SessionID == sessionID || strings.HasPrefix(source.SessionID, sessionID) {
 				matches = append(matches, manifest)
 				sourceMatches = append(sourceMatches, source)
+				break
 			}
 		}
 	}

--- a/cmd/entire/cli/review/manifest.go
+++ b/cmd/entire/cli/review/manifest.go
@@ -1,0 +1,287 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	agenttypes "github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+)
+
+const localReviewManifestVersion = 1
+
+// LocalReviewManifest records one local `entire review` invocation. It lets
+// `entire review --fix <session-id>` use a single session id as the lookup
+// handle while still loading sibling agent outputs from the same review run.
+type LocalReviewManifest struct {
+	Version         int              `json:"version"`
+	WorktreePath    string           `json:"worktree_path"`
+	CreatedAt       time.Time        `json:"created_at"`
+	StartingSHA     string           `json:"starting_sha,omitempty"`
+	Sources         []ManifestSource `json:"sources"`
+	AggregateOutput string           `json:"aggregate_output,omitempty"`
+}
+
+type ManifestSource struct {
+	SessionID string `json:"session_id"`
+	Agent     string `json:"agent"`
+	Label     string `json:"label"`
+	Status    string `json:"status,omitempty"`
+	Output    string `json:"output,omitempty"`
+}
+
+func buildLocalReviewManifestFromSummary(
+	worktreeRoot string,
+	headSHA string,
+	summary reviewtypes.RunSummary,
+	states []*session.State,
+	aggregateOutput string,
+) LocalReviewManifest {
+	manifest := LocalReviewManifest{
+		Version:         localReviewManifestVersion,
+		WorktreePath:    worktreeRoot,
+		CreatedAt:       summary.StartedAt,
+		StartingSHA:     headSHA,
+		AggregateOutput: strings.TrimSpace(aggregateOutput),
+	}
+	usedSessions := map[string]bool{}
+	for _, run := range summary.AgentRuns {
+		st := matchReviewSessionState(worktreeRoot, headSHA, summary.StartedAt, run.Name, states, usedSessions)
+		if st == nil || st.SessionID == "" {
+			continue
+		}
+		usedSessions[st.SessionID] = true
+		manifest.Sources = append(manifest.Sources, ManifestSource{
+			SessionID: st.SessionID,
+			Agent:     run.Name,
+			Label:     labelForReviewAgent(run.Name),
+			Status:    run.Status.String(),
+			Output:    agentRunOutput(run),
+		})
+	}
+	return manifest
+}
+
+func localReviewManifestFromCurrentState(
+	ctx context.Context,
+	worktreeRoot string,
+	headSHA string,
+	summary reviewtypes.RunSummary,
+	aggregateOutput string,
+) (LocalReviewManifest, error) {
+	store, err := session.NewStateStore(ctx)
+	if err != nil {
+		return LocalReviewManifest{}, fmt.Errorf("create session state store: %w", err)
+	}
+	states, err := store.List(ctx)
+	if err != nil {
+		return LocalReviewManifest{}, fmt.Errorf("list session states: %w", err)
+	}
+	return buildLocalReviewManifestFromSummary(worktreeRoot, headSHA, summary, states, aggregateOutput), nil
+}
+
+func matchReviewSessionState(
+	worktreeRoot string,
+	headSHA string,
+	runStartedAt time.Time,
+	agentName string,
+	states []*session.State,
+	used map[string]bool,
+) *session.State {
+	wantAgentType := agentTypeForReviewAgent(agentName)
+	var best *session.State
+	for _, st := range states {
+		if st == nil || used[st.SessionID] || st.Kind != session.KindAgentReview {
+			continue
+		}
+		if worktreeRoot != "" && st.WorktreePath != "" && st.WorktreePath != worktreeRoot {
+			continue
+		}
+		if headSHA != "" && st.BaseCommit != "" && st.BaseCommit != headSHA {
+			continue
+		}
+		if !runStartedAt.IsZero() && st.StartedAt.Before(runStartedAt.Add(-5*time.Second)) {
+			continue
+		}
+		if wantAgentType != "" && st.AgentType != "" && st.AgentType != wantAgentType {
+			continue
+		}
+		if best == nil || st.StartedAt.After(best.StartedAt) {
+			best = st
+		}
+	}
+	return best
+}
+
+func agentTypeForReviewAgent(agentName string) agenttypes.AgentType {
+	ag, err := agent.Get(agenttypes.AgentName(agentName))
+	if err != nil {
+		return ""
+	}
+	return ag.Type()
+}
+
+func labelForReviewAgent(agentName string) string {
+	if typ := agentTypeForReviewAgent(agentName); typ != "" {
+		return string(typ)
+	}
+	return agentName
+}
+
+func agentRunOutput(run reviewtypes.AgentRun) string {
+	if narrative := joinAssistantText(run.Buffer); narrative != "" {
+		return narrative
+	}
+	if run.Err != nil {
+		return "Failed: " + run.Err.Error()
+	}
+	return ""
+}
+
+func writeLocalReviewManifest(ctx context.Context, manifest LocalReviewManifest) error {
+	if len(manifest.Sources) == 0 {
+		return errors.New("review manifest has no sources")
+	}
+	if manifest.Version == 0 {
+		manifest.Version = localReviewManifestVersion
+	}
+	if manifest.CreatedAt.IsZero() {
+		manifest.CreatedAt = time.Now()
+	}
+
+	dir, err := localReviewManifestDir(ctx)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create review manifest dir: %w", err)
+	}
+
+	b, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode review manifest: %w", err)
+	}
+	path := filepath.Join(dir, localReviewManifestFilename(manifest))
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return fmt.Errorf("write review manifest: %w", err)
+	}
+	return nil
+}
+
+func resolveLocalReviewManifestBySessionID(ctx context.Context, worktreeRoot, sessionID string) (LocalReviewManifest, ManifestSource, error) {
+	manifests, err := loadLocalReviewManifests(ctx, worktreeRoot)
+	if err != nil {
+		return LocalReviewManifest{}, ManifestSource{}, err
+	}
+
+	var (
+		matches       []LocalReviewManifest
+		sourceMatches []ManifestSource
+	)
+	for _, manifest := range manifests {
+		for _, source := range manifest.Sources {
+			if source.SessionID == sessionID || strings.HasPrefix(source.SessionID, sessionID) {
+				matches = append(matches, manifest)
+				sourceMatches = append(sourceMatches, source)
+			}
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return LocalReviewManifest{}, ManifestSource{}, fmt.Errorf("review session %q not found", sessionID)
+	case 1:
+		return matches[0], sourceMatches[0], nil
+	default:
+		return LocalReviewManifest{}, ManifestSource{}, fmt.Errorf("review session prefix %q is ambiguous", sessionID)
+	}
+}
+
+func loadLocalReviewManifests(ctx context.Context, worktreeRoot string) ([]LocalReviewManifest, error) {
+	dir, err := localReviewManifestDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read review manifest dir: %w", err)
+	}
+
+	manifests := make([]LocalReviewManifest, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		b, readErr := os.ReadFile(filepath.Join(dir, entry.Name())) //nolint:gosec // entry names come directly from os.ReadDir(dir).
+		if readErr != nil {
+			return nil, fmt.Errorf("read review manifest %s: %w", entry.Name(), readErr)
+		}
+		var manifest LocalReviewManifest
+		if err := json.Unmarshal(b, &manifest); err != nil {
+			return nil, fmt.Errorf("decode review manifest %s: %w", entry.Name(), err)
+		}
+		if worktreeRoot != "" && manifest.WorktreePath != "" && manifest.WorktreePath != worktreeRoot {
+			continue
+		}
+		manifests = append(manifests, manifest)
+	}
+	sort.SliceStable(manifests, func(i, j int) bool {
+		return manifests[i].CreatedAt.After(manifests[j].CreatedAt)
+	})
+	return manifests, nil
+}
+
+func localReviewManifestDir(ctx context.Context) (string, error) {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree root: %w", err)
+	}
+	commonDir, err := runGit(ctx, worktreeRoot, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return "", fmt.Errorf("resolve git common dir: %w", err)
+	}
+	commonDir = strings.TrimSpace(commonDir)
+	if commonDir == "" {
+		return "", errors.New("git common dir is empty")
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(worktreeRoot, commonDir)
+	}
+	return filepath.Join(commonDir, "entire-review", "manifests"), nil
+}
+
+func localReviewManifestFilename(manifest LocalReviewManifest) string {
+	name := manifest.CreatedAt.UTC().Format("20060102T150405")
+	if len(manifest.Sources) > 0 && manifest.Sources[0].SessionID != "" {
+		name += "-" + safeManifestFilenamePart(manifest.Sources[0].SessionID)
+	}
+	return name + ".json"
+}
+
+func safeManifestFilenamePart(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "review"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('-')
+	}
+	return b.String()
+}

--- a/cmd/entire/cli/review/manifest_test.go
+++ b/cmd/entire/cli/review/manifest_test.go
@@ -1,0 +1,328 @@
+package review
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	agenttypes "github.com/entireio/cli/cmd/entire/cli/agent/types"
+	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+func TestLocalReviewManifest_ResolveByAnySessionID(t *testing.T) {
+	repoRoot := t.TempDir()
+	testutil.InitRepo(t, repoRoot)
+	t.Chdir(repoRoot)
+
+	manifest := LocalReviewManifest{
+		Version:      1,
+		WorktreePath: repoRoot,
+		CreatedAt:    time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+		StartingSHA:  "abc123",
+		Sources: []ManifestSource{
+			{
+				SessionID: "claude-session",
+				Agent:     "claude-code",
+				Label:     "Claude Code",
+				Output:    "H1. Claude finding",
+			},
+			{
+				SessionID: "codex-session",
+				Agent:     "codex",
+				Label:     "Codex",
+				Output:    "M1. Codex finding",
+			},
+		},
+		AggregateOutput: "Combined summary",
+	}
+
+	if err := writeLocalReviewManifest(context.Background(), manifest); err != nil {
+		t.Fatalf("writeLocalReviewManifest: %v", err)
+	}
+
+	got, matched, err := resolveLocalReviewManifestBySessionID(context.Background(), repoRoot, "codex-session")
+	if err != nil {
+		t.Fatalf("resolveLocalReviewManifestBySessionID: %v", err)
+	}
+	if matched.SessionID != "codex-session" {
+		t.Fatalf("matched session = %q, want codex-session", matched.SessionID)
+	}
+	if len(got.Sources) != 2 {
+		t.Fatalf("sources = %d, want 2", len(got.Sources))
+	}
+	if got.AggregateOutput != "Combined summary" {
+		t.Fatalf("aggregate output = %q", got.AggregateOutput)
+	}
+}
+
+func TestComposeReviewFixPrompt_UsesSelectedSources(t *testing.T) {
+	manifest := LocalReviewManifest{
+		WorktreePath: "/repo",
+		Sources: []ManifestSource{
+			{
+				SessionID: "claude-session",
+				Agent:     "claude-code",
+				Label:     "Claude Code",
+				Output:    "H1. Claude finding",
+			},
+			{
+				SessionID: "codex-session",
+				Agent:     "codex",
+				Label:     "Codex",
+				Output:    "M1. Codex finding",
+			},
+		},
+		AggregateOutput: "Aggregate finding",
+	}
+
+	prompt := composeReviewFixPrompt(manifest, []reviewFixSource{
+		{Kind: reviewFixSourceAgent, Label: "Codex", Output: "M1. Codex finding"},
+		{Kind: reviewFixSourceAggregate, Label: "Aggregate summary", Output: "Aggregate finding"},
+	})
+
+	for _, want := range []string{
+		"Fix only the selected review findings.",
+		"Codex",
+		"M1. Codex finding",
+		"Aggregate summary",
+		"Aggregate finding",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "H1. Claude finding") {
+		t.Fatalf("prompt should not include unselected Claude output:\n%s", prompt)
+	}
+}
+
+func TestWriteReviewCompletionFooter_PrintsExactFixCommands(t *testing.T) {
+	manifest := LocalReviewManifest{
+		Sources: []ManifestSource{{SessionID: "claude-session", Label: "Claude Code"}},
+	}
+	var b strings.Builder
+
+	writeReviewCompletionFooter(&b, manifest)
+
+	got := b.String()
+	for _, want := range []string{
+		"Review complete.",
+		"entire review --fix claude-session --all",
+		"entire review --fix claude-session",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("footer missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintReviewFindingsList_PrintsProductionCommandName(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+	os.Args = []string{"/tmp/local-build/entire"}
+
+	manifest := LocalReviewManifest{
+		CreatedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+		Sources: []ManifestSource{{
+			SessionID: "claude-session",
+			Label:     "Claude Code",
+			Output:    "H1. finding",
+		}},
+	}
+	var b strings.Builder
+
+	printReviewFindingsList(&b, []LocalReviewManifest{manifest})
+
+	got := b.String()
+	if strings.Contains(got, "/tmp/local-build/entire") {
+		t.Fatalf("findings list should not print local binary path:\n%s", got)
+	}
+	if !strings.Contains(got, "entire review --fix claude-session --all") {
+		t.Fatalf("findings list missing production command:\n%s", got)
+	}
+}
+
+func TestReviewFixSourcesForManifest_AddsAggregateFallbackForMultipleAgents(t *testing.T) {
+	manifest := LocalReviewManifest{
+		Sources: []ManifestSource{
+			{
+				SessionID: "claude-session",
+				Agent:     "claude-code",
+				Label:     "Claude Code",
+				Output:    "H1. Claude finding",
+			},
+			{
+				SessionID: "codex-session",
+				Agent:     "codex",
+				Label:     "Codex",
+				Output:    "M1. Codex finding",
+			},
+		},
+	}
+
+	sources := reviewFixSourcesForManifest(manifest)
+
+	if len(sources) != 3 {
+		t.Fatalf("sources = %d, want 3: %#v", len(sources), sources)
+	}
+	aggregate := sources[2]
+	if aggregate.Kind != reviewFixSourceAggregate {
+		t.Fatalf("aggregate kind = %q, want %q", aggregate.Kind, reviewFixSourceAggregate)
+	}
+	if aggregate.Label != "Aggregate findings" {
+		t.Fatalf("aggregate label = %q", aggregate.Label)
+	}
+	for _, want := range []string{"Claude Code findings", "H1. Claude finding", "Codex findings", "M1. Codex finding"} {
+		if !strings.Contains(aggregate.Output, want) {
+			t.Fatalf("aggregate output missing %q:\n%s", want, aggregate.Output)
+		}
+	}
+}
+
+func TestReviewPickerHeight_ShowsAllSmallOptionSets(t *testing.T) {
+	for _, optionCount := range []int{1, 2, 3, 4} {
+		if got := reviewPickerHeight(optionCount); got < optionCount+2 {
+			t.Fatalf("height for %d options = %d, want at least %d", optionCount, got, optionCount+2)
+		}
+	}
+}
+
+func TestReviewFixSourcePickerTitle_IncludesSessionHandle(t *testing.T) {
+	manifest := LocalReviewManifest{
+		Sources: []ManifestSource{{SessionID: "073be48b-2a68-473e-b783-9fa7b78a85aa"}},
+	}
+
+	got := reviewFixSourcePickerTitle(manifest)
+
+	if !strings.Contains(got, "073be48b-2a68-473e-b783-9fa7b78a85aa") {
+		t.Fatalf("title = %q, want session id", got)
+	}
+}
+
+func TestReviewFixAgentFromSelectedSources_UsesSingleAgentSource(t *testing.T) {
+	got, ok := reviewFixAgentFromSelectedSources([]reviewFixSource{
+		{Kind: reviewFixSourceAgent, Agent: "codex", Label: "Codex findings"},
+	})
+
+	if !ok {
+		t.Fatal("expected single-source agent inference")
+	}
+	if got != "codex" {
+		t.Fatalf("agent = %q, want codex", got)
+	}
+}
+
+func TestReviewFixAgentFromSelectedSources_DoesNotInferForAggregateOrMultiple(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []reviewFixSource
+	}{
+		{
+			name: "aggregate",
+			sources: []reviewFixSource{
+				{Kind: reviewFixSourceAggregate, Label: "Aggregate summary"},
+			},
+		},
+		{
+			name: "multiple agents",
+			sources: []reviewFixSource{
+				{Kind: reviewFixSourceAgent, Agent: "claude-code"},
+				{Kind: reviewFixSourceAgent, Agent: "codex"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := reviewFixAgentFromSelectedSources(tc.sources)
+			if ok {
+				t.Fatalf("agent = %q, want no inference", got)
+			}
+		})
+	}
+}
+
+func TestSavedReviewFixAgentPick_UsesSavedWhenAvailable(t *testing.T) {
+	choices := []AgentChoice{
+		{Name: "claude-code", Label: "Claude Code"},
+		{Name: "codex", Label: "Codex"},
+	}
+
+	got, ok := savedReviewFixAgentPick(choices, "codex")
+
+	if !ok {
+		t.Fatal("expected saved agent match")
+	}
+	if got != "codex" {
+		t.Fatalf("saved pick = %q, want codex", got)
+	}
+}
+
+func TestSavedReviewFixAgentPick_RejectsUnknownSavedAgent(t *testing.T) {
+	choices := []AgentChoice{{Name: "claude-code", Label: "Claude Code"}}
+
+	got, ok := savedReviewFixAgentPick(choices, "codex")
+
+	if ok {
+		t.Fatalf("saved pick = %q, want no match", got)
+	}
+}
+
+func TestBuildLocalReviewManifestFromSummary_GroupsAgentSessionsAndAggregate(t *testing.T) {
+	started := time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC)
+	summary := reviewtypes.RunSummary{
+		StartedAt: started,
+		AgentRuns: []reviewtypes.AgentRun{
+			{
+				Name:   "claude-code",
+				Status: reviewtypes.AgentStatusSucceeded,
+				Buffer: []reviewtypes.Event{
+					reviewtypes.AssistantText{Text: "Claude finding"},
+				},
+			},
+			{
+				Name:   "codex",
+				Status: reviewtypes.AgentStatusSucceeded,
+				Buffer: []reviewtypes.Event{
+					reviewtypes.AssistantText{Text: "Codex finding"},
+				},
+			},
+		},
+	}
+	states := []*session.State{
+		{
+			SessionID:    "claude-session",
+			Kind:         session.KindAgentReview,
+			WorktreePath: "/repo",
+			BaseCommit:   "abc123",
+			StartedAt:    started.Add(time.Second),
+			AgentType:    agenttypes.AgentType("Claude Code"),
+		},
+		{
+			SessionID:    "codex-session",
+			Kind:         session.KindAgentReview,
+			WorktreePath: "/repo",
+			BaseCommit:   "abc123",
+			StartedAt:    started.Add(2 * time.Second),
+			AgentType:    agenttypes.AgentType("Codex"),
+		},
+	}
+
+	manifest := buildLocalReviewManifestFromSummary("/repo", "abc123", summary, states, "Aggregate finding")
+
+	if len(manifest.Sources) != 2 {
+		t.Fatalf("sources = %d, want 2", len(manifest.Sources))
+	}
+	if manifest.Sources[0].SessionID != "claude-session" || manifest.Sources[0].Output != "Claude finding" {
+		t.Fatalf("claude source mismatch: %#v", manifest.Sources[0])
+	}
+	if manifest.Sources[1].SessionID != "codex-session" || manifest.Sources[1].Output != "Codex finding" {
+		t.Fatalf("codex source mismatch: %#v", manifest.Sources[1])
+	}
+	if manifest.AggregateOutput != "Aggregate finding" {
+		t.Fatalf("AggregateOutput = %q", manifest.AggregateOutput)
+	}
+}

--- a/cmd/entire/cli/review/manifest_test.go
+++ b/cmd/entire/cli/review/manifest_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
+const manifestTestCodexAgent = "codex"
+
 func TestLocalReviewManifest_ResolveByAnySessionID(t *testing.T) {
 	repoRoot := t.TempDir()
 	testutil.InitRepo(t, repoRoot)
@@ -32,7 +34,7 @@ func TestLocalReviewManifest_ResolveByAnySessionID(t *testing.T) {
 			},
 			{
 				SessionID: "codex-session",
-				Agent:     "codex",
+				Agent:     manifestTestCodexAgent,
 				Label:     "Codex",
 				Output:    "M1. Codex finding",
 			},
@@ -59,6 +61,45 @@ func TestLocalReviewManifest_ResolveByAnySessionID(t *testing.T) {
 	}
 }
 
+func TestLocalReviewManifest_PrefixMatchWithinSameManifestDoesNotAmbiguate(t *testing.T) {
+	repoRoot := t.TempDir()
+	testutil.InitRepo(t, repoRoot)
+	t.Chdir(repoRoot)
+
+	manifest := LocalReviewManifest{
+		Version:      1,
+		WorktreePath: repoRoot,
+		CreatedAt:    time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+		StartingSHA:  "abc123",
+		Sources: []ManifestSource{
+			{
+				SessionID: "review-session-claude",
+				Agent:     "claude-code",
+				Label:     "Claude Code",
+				Output:    "H1. Claude finding",
+			},
+			{
+				SessionID: "review-session-codex",
+				Agent:     manifestTestCodexAgent,
+				Label:     "Codex",
+				Output:    "M1. Codex finding",
+			},
+		},
+	}
+
+	if err := writeLocalReviewManifest(context.Background(), manifest); err != nil {
+		t.Fatalf("writeLocalReviewManifest: %v", err)
+	}
+
+	got, _, err := resolveLocalReviewManifestBySessionID(context.Background(), repoRoot, "review-session")
+	if err != nil {
+		t.Fatalf("resolveLocalReviewManifestBySessionID: %v", err)
+	}
+	if len(got.Sources) != 2 {
+		t.Fatalf("sources = %d, want 2", len(got.Sources))
+	}
+}
+
 func TestComposeReviewFixPrompt_UsesSelectedSources(t *testing.T) {
 	manifest := LocalReviewManifest{
 		WorktreePath: "/repo",
@@ -71,7 +112,7 @@ func TestComposeReviewFixPrompt_UsesSelectedSources(t *testing.T) {
 			},
 			{
 				SessionID: "codex-session",
-				Agent:     "codex",
+				Agent:     manifestTestCodexAgent,
 				Label:     "Codex",
 				Output:    "M1. Codex finding",
 			},
@@ -157,7 +198,7 @@ func TestReviewFixSourcesForManifest_AddsAggregateFallbackForMultipleAgents(t *t
 			},
 			{
 				SessionID: "codex-session",
-				Agent:     "codex",
+				Agent:     manifestTestCodexAgent,
 				Label:     "Codex",
 				Output:    "M1. Codex finding",
 			},
@@ -205,13 +246,13 @@ func TestReviewFixSourcePickerTitle_IncludesSessionHandle(t *testing.T) {
 
 func TestReviewFixAgentFromSelectedSources_UsesSingleAgentSource(t *testing.T) {
 	got, ok := reviewFixAgentFromSelectedSources([]reviewFixSource{
-		{Kind: reviewFixSourceAgent, Agent: "codex", Label: "Codex findings"},
+		{Kind: reviewFixSourceAgent, Agent: manifestTestCodexAgent, Label: "Codex findings"},
 	})
 
 	if !ok {
 		t.Fatal("expected single-source agent inference")
 	}
-	if got != "codex" {
+	if got != manifestTestCodexAgent {
 		t.Fatalf("agent = %q, want codex", got)
 	}
 }
@@ -231,7 +272,7 @@ func TestReviewFixAgentFromSelectedSources_DoesNotInferForAggregateOrMultiple(t 
 			name: "multiple agents",
 			sources: []reviewFixSource{
 				{Kind: reviewFixSourceAgent, Agent: "claude-code"},
-				{Kind: reviewFixSourceAgent, Agent: "codex"},
+				{Kind: reviewFixSourceAgent, Agent: manifestTestCodexAgent},
 			},
 		},
 	}
@@ -248,15 +289,15 @@ func TestReviewFixAgentFromSelectedSources_DoesNotInferForAggregateOrMultiple(t 
 func TestSavedReviewFixAgentPick_UsesSavedWhenAvailable(t *testing.T) {
 	choices := []AgentChoice{
 		{Name: "claude-code", Label: "Claude Code"},
-		{Name: "codex", Label: "Codex"},
+		{Name: manifestTestCodexAgent, Label: "Codex"},
 	}
 
-	got, ok := savedReviewFixAgentPick(choices, "codex")
+	got, ok := savedReviewFixAgentPick(choices, manifestTestCodexAgent)
 
 	if !ok {
 		t.Fatal("expected saved agent match")
 	}
-	if got != "codex" {
+	if got != manifestTestCodexAgent {
 		t.Fatalf("saved pick = %q, want codex", got)
 	}
 }
@@ -264,10 +305,22 @@ func TestSavedReviewFixAgentPick_UsesSavedWhenAvailable(t *testing.T) {
 func TestSavedReviewFixAgentPick_RejectsUnknownSavedAgent(t *testing.T) {
 	choices := []AgentChoice{{Name: "claude-code", Label: "Claude Code"}}
 
-	got, ok := savedReviewFixAgentPick(choices, "codex")
+	got, ok := savedReviewFixAgentPick(choices, manifestTestCodexAgent)
 
 	if ok {
 		t.Fatalf("saved pick = %q, want no match", got)
+	}
+}
+
+func TestPickReviewFixAgentPreference_PreservesCurrentWhenNoChoices(t *testing.T) {
+	t.Parallel()
+
+	got, err := pickReviewFixAgentPreference(context.Background(), nil, manifestTestCodexAgent)
+	if err != nil {
+		t.Fatalf("pickReviewFixAgentPreference: %v", err)
+	}
+	if got != manifestTestCodexAgent {
+		t.Fatalf("fix agent = %q, want codex", got)
 	}
 }
 
@@ -284,7 +337,7 @@ func TestBuildLocalReviewManifestFromSummary_GroupsAgentSessionsAndAggregate(t *
 				},
 			},
 			{
-				Name:   "codex",
+				Name:   manifestTestCodexAgent,
 				Status: reviewtypes.AgentStatusSucceeded,
 				Buffer: []reviewtypes.Event{
 					reviewtypes.AssistantText{Text: "Codex finding"},

--- a/cmd/entire/cli/review/picker.go
+++ b/cmd/entire/cli/review/picker.go
@@ -126,10 +126,12 @@ func RunReviewConfigPicker(ctx context.Context, out io.Writer, getInstalled func
 	// see why, but keep going with an empty prefill — runReview already
 	// surfaces the same error distinctly when it's the first load.
 	existing := map[string]settings.ReviewConfig{}
+	existingFixAgent := ""
 	if s, err := settings.Load(ctx); err != nil {
 		logging.Warn(ctx, "settings.Load failed when pre-filling picker", slog.String("error", err.Error()))
 	} else if s != nil {
 		existing = s.Review
+		existingFixAgent = s.ReviewFixAgent
 	}
 
 	// Up-front header: make the order and count obvious so users can spot
@@ -215,7 +217,11 @@ func RunReviewConfigPicker(ctx context.Context, out io.Writer, getInstalled func
 		return nil, errors.New("no review skills or prompt configured")
 	}
 
-	if err := SaveReviewConfig(ctx, merged); err != nil {
+	fixAgent, err := pickReviewFixAgentPreference(ctx, merged, existingFixAgent)
+	if err != nil {
+		return nil, err
+	}
+	if err := saveReviewConfigAndFixAgent(ctx, merged, fixAgent); err != nil {
 		return nil, err
 	}
 	fmt.Fprintln(out, "Saved review config to .entire/settings.json. Edit directly or run `entire review --edit`.")
@@ -261,6 +267,49 @@ func SaveReviewConfig(ctx context.Context, review map[string]settings.ReviewConf
 		return fmt.Errorf("save settings: %w", err)
 	}
 	return nil
+}
+
+func SaveReviewFixAgent(ctx context.Context, agentName string) error {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return fmt.Errorf("load settings before save: %w", err)
+	}
+	if s == nil {
+		s = &settings.EntireSettings{}
+	}
+	s.ReviewFixAgent = agentName
+	if err := settings.Save(ctx, s); err != nil {
+		return fmt.Errorf("save settings: %w", err)
+	}
+	return nil
+}
+
+func saveReviewConfigAndFixAgent(ctx context.Context, review map[string]settings.ReviewConfig, fixAgent string) error {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return fmt.Errorf("load settings before save: %w", err)
+	}
+	if s == nil {
+		s = &settings.EntireSettings{}
+	}
+	s.Review = review
+	s.ReviewFixAgent = fixAgent
+	if err := settings.Save(ctx, s); err != nil {
+		return fmt.Errorf("save settings: %w", err)
+	}
+	return nil
+}
+
+func pickReviewFixAgentPreference(ctx context.Context, review map[string]settings.ReviewConfig, current string) (string, error) {
+	choices := reviewFixAgentChoices(review)
+	switch len(choices) {
+	case 0:
+		return "", nil
+	case 1:
+		return choices[0].Name, nil
+	default:
+		return promptForReviewFixAgent(ctx, choices, current)
+	}
 }
 
 // ComputeEligibleConfigured returns the sorted list of agents that are both

--- a/cmd/entire/cli/review/picker.go
+++ b/cmd/entire/cli/review/picker.go
@@ -304,7 +304,7 @@ func pickReviewFixAgentPreference(ctx context.Context, review map[string]setting
 	choices := reviewFixAgentChoices(review)
 	switch len(choices) {
 	case 0:
-		return "", nil
+		return current, nil
 	case 1:
 		return choices[0].Name, nil
 	default:

--- a/cmd/entire/cli/review/picker_test.go
+++ b/cmd/entire/cli/review/picker_test.go
@@ -316,6 +316,54 @@ func TestSaveReviewConfig_PersistsSettings(t *testing.T) {
 	}
 }
 
+func TestSaveReviewConfig_PreservesReviewFixAgent(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	t.Chdir(tmp)
+
+	entireDir := filepath.Join(tmp, ".entire")
+	if err := os.MkdirAll(entireDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	before := []byte(`{"enabled":true,"review_fix_agent":"` + testCodexAgent + `"}`)
+	if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), before, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+		testAgentName: {Skills: []string{testReviewSkill}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := settings.Load(context.Background())
+	if err != nil {
+		t.Fatalf("load settings: %v", err)
+	}
+	if s.ReviewFixAgent != testCodexAgent {
+		t.Fatalf("ReviewFixAgent = %q, want %s", s.ReviewFixAgent, testCodexAgent)
+	}
+}
+
+func TestSaveReviewFixAgent_PersistsSettings(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	t.Chdir(tmp)
+
+	if err := review.SaveReviewFixAgent(context.Background(), testCodexAgent); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := settings.Load(context.Background())
+	if err != nil {
+		t.Fatalf("load settings: %v", err)
+	}
+	if s.ReviewFixAgent != testCodexAgent {
+		t.Fatalf("ReviewFixAgent = %q, want %s", s.ReviewFixAgent, testCodexAgent)
+	}
+}
+
 // TestSaveReviewConfig_ReturnsErrorOnMalformedSettings ensures SaveReviewConfig
 // does not overwrite existing settings when settings.json is malformed.
 func TestSaveReviewConfig_ReturnsErrorOnMalformedSettings(t *testing.T) {

--- a/cmd/entire/cli/review/synthesis_sink.go
+++ b/cmd/entire/cli/review/synthesis_sink.go
@@ -47,6 +47,7 @@ type SynthesisSink struct {
 	PerRunPrompt    string          // if non-empty, included in the synthesis prompt for context
 	RunContext      context.Context // optional; nil falls back to context.Background()
 	ProviderTimeout time.Duration   // optional; zero uses defaultSynthesisProviderTimeout
+	OnResult        func(result string)
 }
 
 // Compile-time interface check.
@@ -106,6 +107,9 @@ func (s SynthesisSink) RunFinished(summary reviewtypes.RunSummary) {
 	if provErr != nil {
 		fmt.Fprintf(s.Writer, "synthesis unavailable: %v\n", provErr)
 		return
+	}
+	if s.OnResult != nil {
+		s.OnResult(result)
 	}
 	// The synthesis verdict is markdown — render it through the same palette
 	// dispatch / DumpSink use, so multi-agent reviews finish with a visually

--- a/cmd/entire/cli/review/synthesis_sink_test.go
+++ b/cmd/entire/cli/review/synthesis_sink_test.go
@@ -275,6 +275,26 @@ func TestSynthesisSink_UserPicksYes(t *testing.T) {
 	}
 }
 
+func TestSynthesisSink_OnResultReceivesSummary(t *testing.T) {
+	t.Parallel()
+	w := &bytes.Buffer{}
+	stub := &stubSynthesisProvider{response: "Unified verdict: fix H1."}
+	promptFn := func(_ context.Context, _ string, _ bool) (bool, error) {
+		return true, nil
+	}
+	var captured string
+	sink := buildSink(stub, w, true, promptFn, "")
+	sink.OnResult = func(result string) {
+		captured = result
+	}
+
+	sink.RunFinished(makeTwoAgentSummary())
+
+	if captured != "Unified verdict: fix H1." {
+		t.Fatalf("OnResult captured %q", captured)
+	}
+}
+
 // TestSynthesisSink_ProviderUsesRunContext verifies the provider receives the
 // cancellable context supplied by the orchestrator instead of Background.
 func TestSynthesisSink_ProviderUsesRunContext(t *testing.T) {

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -73,6 +73,10 @@ type EntireSettings struct {
 	// that agent. When empty, `entire review` triggers the first-run picker.
 	Review map[string]ReviewConfig `json:"review,omitempty"`
 
+	// ReviewFixAgent is the default agent used when applying aggregate or
+	// multi-agent review findings with `entire review --fix`.
+	ReviewFixAgent string `json:"review_fix_agent,omitempty"`
+
 	// CommitLinking controls how commits are linked to agent sessions.
 	// "always" = auto-link without prompting, "prompt" = ask on each commit.
 	// Defaults to "prompt" (preserves existing user behavior).
@@ -394,6 +398,9 @@ func mergeScalarFields(settings *EntireSettings, raw map[string]json.RawMessage)
 		return err
 	}
 	if err := mergeRawStringNonEmpty(raw, "log_level", &settings.LogLevel); err != nil {
+		return err
+	}
+	if err := mergeRawStringNonEmpty(raw, "review_fix_agent", &settings.ReviewFixAgent); err != nil {
 		return err
 	}
 	if err := mergeRawInt(raw, "summary_timeout_seconds", &settings.SummaryTimeoutSeconds); err != nil {

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -978,6 +978,7 @@ func TestEntireSettings_ReviewRoundTrip(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{
       "enabled": true,
+      "review_fix_agent": "codex",
       "review": {
         "claude-code": {
           "skills": ["/pr-review-toolkit:review-pr", "/test-auditor"],
@@ -991,6 +992,9 @@ func TestEntireSettings_ReviewRoundTrip(t *testing.T) {
 	var s EntireSettings
 	if err := json.Unmarshal(raw, &s); err != nil {
 		t.Fatalf("unmarshal: %v", err)
+	}
+	if s.ReviewFixAgent != "codex" {
+		t.Fatalf("review_fix_agent = %q, want codex", s.ReviewFixAgent)
 	}
 	claude := s.Review["claude-code"]
 	if len(claude.Skills) != 2 || claude.Skills[0] != "/pr-review-toolkit:review-pr" {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/322
<!-- entire-trail-link-end -->

## Summary
- add local review manifests so one review session id resolves sibling agent outputs and aggregate summaries
- add `entire review --findings` and `entire review --fix [session-id]` / `--all` workflows
- add source/finding selectors plus saved `review_fix_agent` preference for aggregate or multi-agent fixes
- print follow-up fix commands after review completion

## Verification
- `go test ./cmd/entire/cli/review ./cmd/entire/cli ./cmd/entire/cli/settings -count=1`
- `mise run lint`
- `mise run test`
- `mise run build`
- local smoke with PATH override: `entire review --findings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `entire review` sub-modes that persist local manifests under the git directory and can spawn a follow-up agent session to apply findings, so regressions could impact review UX/CLI behavior and local state handling.
> 
> **Overview**
> Adds a local review findings workflow to `entire review`: new `--findings` mode to browse stored outputs and new `--fix [session-id]` (optionally `--all`) mode to select sources/findings and launch a normal agent session with a targeted “fix these findings” prompt.
> 
> Persists each completed review run as a local manifest (per-agent outputs plus optional multi-agent synthesized aggregate) and prints follow-up `entire review --fix ...` commands after review completion; multi-agent synthesis now exposes its final result via an `OnResult` callback so it can be captured into the manifest.
> 
> Extends settings with a `review_fix_agent` preference (picked/saved during `--edit` and used for aggregate/multi-agent fixes) and ensures fix runs strip `ENTIRE_REVIEW_*` env vars before launching the fix agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e472fb3bb17f28fd201d18597fe0c63edad1d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->