### PR TITLE
fix(settings): activate hooks for entire enable --local

### DIFF
--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -631,10 +631,13 @@ func IsSetUpAny(ctx context.Context) bool {
 }
 
 // IsSetUpAndEnabled returns true if Entire is both set up and enabled.
-// This checks if .entire/settings.json exists AND has enabled: true.
+// This checks if either .entire/settings.json or .entire/settings.local.json
+// exists AND the merged settings have enabled: true. Using IsSetUpAny here
+// ensures hooks fire for `entire enable --local` setups, where only the
+// local settings file exists.
 // Use this for hooks that should be no-ops when Entire is not active.
 func IsSetUpAndEnabled(ctx context.Context) bool {
-	if !IsSetUp(ctx) {
+	if !IsSetUpAny(ctx) {
 		return false
 	}
 	s, err := Load(ctx)

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
 const (
@@ -1041,5 +1043,65 @@ func TestReviewConfig_IsZero(t *testing.T) {
 				t.Errorf("IsZero() = %v, want %v (cfg=%+v)", got, tc.want, tc.cfg)
 			}
 		})
+	}
+}
+
+// setupSettingsRepo initializes a real git repository in a temp dir, writes
+// optional base/local settings files into .entire/, and chdirs into the
+// repo. Unlike setupSettingsDir it creates a real repo so that
+// paths.WorktreeRoot() (which calls `git rev-parse`) succeeds — required by
+// IsSetUp / IsSetUpAny / IsSetUpAndEnabled.
+func setupSettingsRepo(t *testing.T, base, local string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	entireDir := filepath.Join(tmpDir, ".entire")
+	if err := os.MkdirAll(entireDir, 0o755); err != nil {
+		t.Fatalf("failed to create .entire directory: %v", err)
+	}
+	if base != "" {
+		if err := os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(base), 0o644); err != nil {
+			t.Fatalf("failed to write settings file: %v", err)
+		}
+	}
+	if local != "" {
+		if err := os.WriteFile(filepath.Join(entireDir, "settings.local.json"), []byte(local), 0o644); err != nil {
+			t.Fatalf("failed to write local settings file: %v", err)
+		}
+	}
+	t.Chdir(tmpDir)
+}
+
+// TestIsSetUpAndEnabled_LocalOnly is a regression test for issue #1123:
+// `entire enable --local` creates only .entire/settings.local.json, but
+// IsSetUpAndEnabled previously called IsSetUp which only checks for the
+// shared settings.json. Hooks calling IsSetUpAndEnabled then silently
+// no-op on every commit. Switching to IsSetUpAny fixes this; this test
+// locks the behavior in.
+func TestIsSetUpAndEnabled_LocalOnly(t *testing.T) {
+	setupSettingsRepo(t, "", `{"enabled": true}`)
+	if !IsSetUpAndEnabled(context.Background()) {
+		t.Fatal("IsSetUpAndEnabled() = false; want true when only settings.local.json exists with enabled: true")
+	}
+}
+
+func TestIsSetUpAndEnabled_LocalOnlyDisabled(t *testing.T) {
+	setupSettingsRepo(t, "", `{"enabled": false}`)
+	if IsSetUpAndEnabled(context.Background()) {
+		t.Fatal("IsSetUpAndEnabled() = true; want false when local-only settings have enabled: false")
+	}
+}
+
+func TestIsSetUpAndEnabled_NoFiles(t *testing.T) {
+	setupSettingsRepo(t, "", "")
+	if IsSetUpAndEnabled(context.Background()) {
+		t.Fatal("IsSetUpAndEnabled() = true; want false when no settings files exist")
+	}
+}
+
+func TestIsSetUpAndEnabled_BaseOnlyEnabled(t *testing.T) {
+	setupSettingsRepo(t, `{"enabled": true}`, "")
+	if !IsSetUpAndEnabled(context.Background()) {
+		t.Fatal("IsSetUpAndEnabled() = false; want true when settings.json has enabled: true")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1123.

This PR switches `IsSetUpAndEnabled` to `IsSetUpAny`, which already exists and correctly checks for either file. `Load()` already merges both files and defaults `Enabled: true` when only the local file is present, so the loaded value was always correct. The only broken piece was the presence check.

## Changes

- `cmd/entire/cli/settings/settings.go`
  - One-line fix: `IsSetUpAndEnabled` now calls `IsSetUpAny(ctx)` instead of `IsSetUp(ctx)`.
  - Updated the doc comment to explain the local-only setup case.

- `cmd/entire/cli/settings/settings_test.go`
  - Added regression coverage:
    - `TestIsSetUpAndEnabled_LocalOnly`
    - `TestIsSetUpAndEnabled_LocalOnlyDisabled`
    - `TestIsSetUpAndEnabled_NoFiles`
    - `TestIsSetUpAndEnabled_BaseOnlyEnabled`
  - Added a new `setupSettingsRepo` helper using `testutil.InitRepo` so `paths.WorktreeRoot()` resolves correctly through `AbsPath`.
  - Kept the existing `setupSettingsDir` for fake `.git` directory cases, but avoided using it for tests that need real path resolution.

## Verification

```bash
mise run check
```

Result:

```text
fmt + lint + test:ci — all green
```

```bash
go test ./cmd/entire/cli/settings/ -run TestIsSetUpAndEnabled -v
```

Result:

```text
passed
```

I also confirmed the new `TestIsSetUpAndEnabled_LocalOnly` regression test fails on `main` without the one-line fix and passes with it. That confirms the test locks in the actual fix instead of asserting tautologically.

End-to-end smoke test:

- Created a scratch repo.
- Ran:

```bash
entire enable --local
```

- Made a commit.
- Confirmed a checkpoint was saved on `entire/checkpoints/v1`.

Before the fix, the same flow produced no shadow branch and no checkpoint.