### PR TITLE
Ensure support for checkpoint creation in SHA-256 repositories

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint_test.go
+++ b/cmd/entire/cli/checkpoint/checkpoint_test.go
@@ -459,9 +459,9 @@ func TestEnsureSessionsBranch_WritesVercelConfigWhenEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("repo.Worktree() error = %v", err)
 	}
-	t.Chdir(worktree.Filesystem.Root())
+	t.Chdir(worktree.Filesystem().Root())
 
-	entireDir := filepath.Join(worktree.Filesystem.Root(), ".entire")
+	entireDir := filepath.Join(worktree.Filesystem().Root(), ".entire")
 	if err := os.MkdirAll(entireDir, 0o755); err != nil {
 		t.Fatalf("mkdir .entire: %v", err)
 	}
@@ -513,7 +513,7 @@ func TestWriteCommitted_MergesVercelConfigOnMetadataBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("repo.Worktree() error = %v", err)
 	}
-	repoRoot := worktree.Filesystem.Root()
+	repoRoot := worktree.Filesystem().Root()
 	t.Chdir(repoRoot)
 
 	entireDir := filepath.Join(repoRoot, ".entire")

--- a/cmd/entire/cli/checkpoint/temporary.go
+++ b/cmd/entire/cli/checkpoint/temporary.go
@@ -1139,7 +1139,7 @@ func filterGitIgnoredFiles(ctx context.Context, repo *git.Repository, files []st
 			slog.String("error", err.Error()))
 		return nil
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	// Use git check-ignore to identify which files are ignored.
 	// Pass files via stdin (-z for NUL-separated, --stdin) to handle special characters.
@@ -1208,7 +1208,7 @@ func collectChangedFiles(ctx context.Context, repo *git.Repository) (changedFile
 	if err != nil {
 		return changedFilesResult{}, fmt.Errorf("failed to get worktree: %w", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	// Use -z for NUL-separated output (handles quoted filenames with spaces/special chars)
 	// Use -uall to list individual untracked files instead of collapsed directories.

--- a/cmd/entire/cli/checkpoint/v2_read_test.go
+++ b/cmd/entire/cli/checkpoint/v2_read_test.go
@@ -250,7 +250,7 @@ func TestV2ReadSessionMetadata_FetchesMissingMetadataBlob(t *testing.T) {
 
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 	mainTree := v2MainTree(t, repo)
 	sessionTree, err := mainTree.Tree(cpID.Path() + "/0")
 	require.NoError(t, err)

--- a/cmd/entire/cli/clean_test.go
+++ b/cmd/entire/cli/clean_test.go
@@ -155,7 +155,7 @@ func TestCleanLongDescription_DefaultIsGeneric(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {}}`)
 
@@ -175,7 +175,7 @@ func TestCleanLongDescription_IncludesV2CleanupWhenEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 
@@ -460,7 +460,7 @@ func TestCleanCmd_DefaultMode_WithForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	worktreePath := wt.Filesystem.Root()
+	worktreePath := wt.Filesystem().Root()
 	worktreeID, err := paths.GetWorktreeID(worktreePath)
 	if err != nil {
 		t.Fatalf("failed to get worktree ID: %v", err)
@@ -506,7 +506,7 @@ func TestCleanCmd_DefaultMode_DryRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	worktreePath := wt.Filesystem.Root()
+	worktreePath := wt.Filesystem().Root()
 	worktreeID, err := paths.GetWorktreeID(worktreePath)
 	if err != nil {
 		t.Fatalf("failed to get worktree ID: %v", err)
@@ -581,7 +581,7 @@ func TestCleanCmd_DefaultMode_SessionsWithoutShadowBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	worktreePath := wt.Filesystem.Root()
+	worktreePath := wt.Filesystem().Root()
 
 	// Create session state files WITHOUT a shadow branch
 	sessionFile := createSessionStateFile(t, worktreePath, "2026-02-02-orphaned", commitHash)
@@ -610,7 +610,7 @@ func TestCleanCmd_DefaultMode_MultipleSessions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	worktreePath := wt.Filesystem.Root()
+	worktreePath := wt.Filesystem().Root()
 	worktreeID, err := paths.GetWorktreeID(worktreePath)
 	if err != nil {
 		t.Fatalf("failed to get worktree ID: %v", err)
@@ -881,7 +881,7 @@ func TestCleanCmd_All_InvalidSettingsWarnsAndContinues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true,`)
 
@@ -915,9 +915,9 @@ func TestCleanCmd_All_Subdirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 	subDir := filepath.Join(repoRoot, "subdir")
-	if err := wt.Filesystem.MkdirAll("subdir", 0o755); err != nil {
+	if err := wt.Filesystem().MkdirAll("subdir", 0o755); err != nil {
 		t.Fatalf("failed to create subdir: %v", err)
 	}
 
@@ -950,7 +950,7 @@ func TestCleanCmd_All_FindsSessionWithShadowBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	worktreePath := wt.Filesystem.Root()
+	worktreePath := wt.Filesystem().Root()
 	worktreeID, err := paths.GetWorktreeID(worktreePath)
 	if err != nil {
 		t.Fatalf("failed to get worktree ID: %v", err)
@@ -1002,7 +1002,7 @@ func TestCleanCmd_All_DryRunListsEligibleV2Generations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 	createArchivedGenerationRef(t, repo, "0000000000001", time.Now().AddDate(0, 0, -20), time.Now().AddDate(0, 0, -15))
@@ -1033,7 +1033,7 @@ func TestCleanCmd_All_DryRunListsRemoteOnlyEligibleV2Generations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 	addCleanBareOrigin(t, repoRoot)
@@ -1071,7 +1071,7 @@ func TestCleanCmd_All_UsesRawTranscriptTimeForV2GenerationRetention(t *testing.T
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 
@@ -1107,7 +1107,7 @@ func TestCleanCmd_All_ForceDeletesRemoteOnlyEligibleV2Generations(t *testing.T) 
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 	addCleanBareOrigin(t, repoRoot)
@@ -1142,7 +1142,7 @@ func TestCleanCmd_All_ForceDeletesEligibleV2Generations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 	createCleanV2Ref(t, repo, plumbing.ReferenceName(paths.V2MainRefName))
@@ -1177,7 +1177,7 @@ func TestCleanCmd_All_DryRunSkipsV2GenerationsWithinRetention(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 	createArchivedGenerationRef(t, repo, "0000000000003", time.Now().AddDate(0, 0, -5), time.Now().AddDate(0, 0, -1))
@@ -1208,7 +1208,7 @@ func TestCleanCmd_All_ForceSkipsV2GenerationMissingMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 	createArchivedGenerationRefWithoutMetadata(t, repo, "0000000000001")
@@ -1238,7 +1238,7 @@ func TestCleanCmd_All_ForceSkipsV2GenerationWithInvalidTimestamps(t *testing.T) 
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 	createArchivedGenerationRef(t, repo, "0000000000004", time.Now().AddDate(0, 0, -1), time.Now().AddDate(0, 0, -20))
@@ -1268,7 +1268,7 @@ func TestCleanCmd_All_ForceWarnsWithErrorDetailsForUnreadableV2Ref(t *testing.T)
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	repoRoot := wt.Filesystem.Root()
+	repoRoot := wt.Filesystem().Root()
 
 	writeCleanSettingsFile(t, repoRoot, `{"enabled": true, "strategy_options": {"checkpoints_v2": true, "full_transcript_generation_retention_days": 14}}`)
 

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -358,7 +358,7 @@ func TestRunExplainAuto_CommitRefWithCheckpointTrailer(t *testing.T) {
 
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
-	tmpDir := wt.Filesystem.Root()
+	tmpDir := wt.Filesystem().Root()
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "feature.txt"), []byte("feature"), 0o644))
 	_, err = wt.Add("feature.txt")
 	require.NoError(t, err)

--- a/cmd/entire/cli/integration_test/sha256_repo_test.go
+++ b/cmd/entire/cli/integration_test/sha256_repo_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package integration
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+func TestSHA256Repository_EnableAndFirstCheckpoint(t *testing.T) {
+	t.Parallel()
+	requireGitSHA256Support(t)
+
+	env := NewTestEnv(t)
+	env.ExtraEnv = append(env.ExtraEnv,
+		"GIT_DEFAULT_HASH=sha256",
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=user.name",
+		"GIT_CONFIG_VALUE_0=Test User",
+		"GIT_CONFIG_KEY_1=user.email",
+		"GIT_CONFIG_VALUE_1=test@example.com",
+	)
+
+	output := env.RunCLI(
+		"enable",
+		"--init-repo",
+		"--no-github",
+		"--agent", "claude-code",
+		"--telemetry=false",
+		"--initial-commit-message", "Initial SHA-256 commit",
+	)
+	if !strings.Contains(output, "Initialized empty git repository") {
+		t.Fatalf("expected enable to initialize git repo, got output:\n%s", output)
+	}
+
+	if got := gitOutput(t, env.RepoDir, "rev-parse", "--show-object-format=storage"); got != "sha256" {
+		t.Fatalf("repository object format = %q, want sha256", got)
+	}
+
+	initialHead := gitOutput(t, env.RepoDir, "rev-parse", "HEAD")
+	requireHexLen(t, "initial HEAD", initialHead, 64)
+	initialMetadataHead := gitOutput(t, env.RepoDir, "rev-parse", paths.MetadataBranchName)
+	requireHexLen(t, "initial metadata branch HEAD", initialMetadataHead, 64)
+
+	// Persist local identity for later git/go-git helper commits and hook subprocesses.
+	gitOutput(t, env.RepoDir, "config", "user.name", "Test User")
+	gitOutput(t, env.RepoDir, "config", "user.email", "test@example.com")
+	gitOutput(t, env.RepoDir, "config", "commit.gpgsign", "false")
+
+	sess := env.NewSession()
+	prompt := "Create a file in the SHA-256 repo"
+	if err := env.SimulateUserPromptSubmitWithPromptAndTranscriptPath(sess.ID, prompt, sess.TranscriptPath); err != nil {
+		t.Fatalf("user-prompt-submit failed: %v", err)
+	}
+
+	const mainContent = "package main\n\nfunc main() {}\n"
+	env.WriteFile("main.go", mainContent)
+	sess.CreateTranscript(prompt, []FileChange{{Path: "main.go", Content: mainContent}})
+	if err := env.SimulateStop(sess.ID, sess.TranscriptPath); err != nil {
+		t.Fatalf("stop hook failed creating first checkpoint: %v", err)
+	}
+
+	state, err := env.GetSessionState(sess.ID)
+	if err != nil {
+		t.Fatalf("GetSessionState failed: %v", err)
+	}
+	if state == nil || state.StepCount != 1 {
+		t.Fatalf("session StepCount after first checkpoint = %#v, want 1", state)
+	}
+
+	shadowBranch := env.GetShadowBranchNameForCommit(initialHead)
+	shadowHead := gitOutput(t, env.RepoDir, "rev-parse", shadowBranch)
+	requireHexLen(t, "shadow checkpoint commit", shadowHead, 64)
+
+	env.GitCommitWithShadowHooks("Add SHA-256 main", "main.go")
+	userHead := gitOutput(t, env.RepoDir, "rev-parse", "HEAD")
+	requireHexLen(t, "user commit", userHead, 64)
+	if userHead == initialHead {
+		t.Fatal("expected user commit to advance HEAD")
+	}
+
+	metadataHead := gitOutput(t, env.RepoDir, "rev-parse", paths.MetadataBranchName)
+	requireHexLen(t, "checkpoint metadata commit", metadataHead, 64)
+	if metadataHead == initialMetadataHead {
+		t.Fatal("expected metadata branch to advance after condensing the first checkpoint")
+	}
+
+	subject := gitOutput(t, env.RepoDir, "log", "-1", "--format=%s", paths.MetadataBranchName)
+	if !strings.HasPrefix(subject, "Checkpoint: ") {
+		t.Fatalf("metadata branch latest subject = %q, want Checkpoint: <id>", subject)
+	}
+	checkpointID := strings.TrimPrefix(subject, "Checkpoint: ")
+	if len(checkpointID) != 12 {
+		t.Fatalf("checkpoint ID length = %d, want 12: %q", len(checkpointID), checkpointID)
+	}
+	if _, found := env.ReadFileFromBranch(paths.MetadataBranchName, SessionMetadataPath(checkpointID)); !found {
+		t.Fatalf("expected session metadata for checkpoint %s on %s", checkpointID, paths.MetadataBranchName)
+	}
+}
+
+func requireGitSHA256Support(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "--object-format=sha256", dir) //nolint:noctx // test capability probe
+	cmd.Env = testutil.GitIsolatedEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("git does not support SHA-256 repositories: %v\n%s", err, output)
+	}
+	if got := gitOutput(t, dir, "rev-parse", "--show-object-format=storage"); got != "sha256" {
+		t.Skipf("git initialized object format %q, not sha256", got)
+	}
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...) //nolint:noctx // test helper
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func requireHexLen(t *testing.T, label, value string, want int) {
+	t.Helper()
+
+	if len(value) != want {
+		t.Fatalf("%s length = %d, want %d: %q", label, len(value), want, value)
+	}
+	for _, r := range value {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			t.Fatalf("%s contains non-hex character %q: %q", label, r, value)
+		}
+	}
+}

--- a/cmd/entire/cli/integration_test/sha256_repo_test.go
+++ b/cmd/entire/cli/integration_test/sha256_repo_test.go
@@ -16,25 +16,29 @@ func TestSHA256Repository_EnableAndFirstCheckpoint(t *testing.T) {
 	requireGitSHA256Support(t)
 
 	env := NewTestEnv(t)
-	env.ExtraEnv = append(env.ExtraEnv,
-		"GIT_DEFAULT_HASH=sha256",
-		"GIT_CONFIG_COUNT=2",
-		"GIT_CONFIG_KEY_0=user.name",
-		"GIT_CONFIG_VALUE_0=Test User",
-		"GIT_CONFIG_KEY_1=user.email",
-		"GIT_CONFIG_VALUE_1=test@example.com",
-	)
+
+	// Set up the SHA-256 repo and initial commit directly via git CLI rather
+	// than going through `entire enable --init-repo`. The bootstrap path
+	// installs hooks that shell out to `entire` on PATH and then runs
+	// `git commit` itself; on CI runners (no `entire` on PATH) the commit-msg
+	// hook fails with "entire: not found". Integration tests deliberately
+	// avoid that path — they invoke hooks via getTestBinary() instead.
+	gitOutput(t, "", "init", "--object-format=sha256", env.RepoDir)
+	gitOutput(t, env.RepoDir, "config", "user.name", "Test User")
+	gitOutput(t, env.RepoDir, "config", "user.email", "test@example.com")
+	gitOutput(t, env.RepoDir, "config", "commit.gpgsign", "false")
+	env.WriteFile("README.md", "# SHA-256 repo\n")
+	gitOutput(t, env.RepoDir, "add", "README.md")
+	gitOutput(t, env.RepoDir, "commit", "-m", "Initial SHA-256 commit")
 
 	output := env.RunCLI(
 		"enable",
-		"--init-repo",
 		"--no-github",
 		"--agent", "claude-code",
 		"--telemetry=false",
-		"--initial-commit-message", "Initial SHA-256 commit",
 	)
-	if !strings.Contains(output, "Initialized empty git repository") {
-		t.Fatalf("expected enable to initialize git repo, got output:\n%s", output)
+	if !strings.Contains(output, paths.MetadataBranchName) {
+		t.Fatalf("expected enable to create %s branch, got output:\n%s", paths.MetadataBranchName, output)
 	}
 
 	if got := gitOutput(t, env.RepoDir, "rev-parse", "--show-object-format=storage"); got != "sha256" {
@@ -45,11 +49,6 @@ func TestSHA256Repository_EnableAndFirstCheckpoint(t *testing.T) {
 	requireHexLen(t, "initial HEAD", initialHead, 64)
 	initialMetadataHead := gitOutput(t, env.RepoDir, "rev-parse", paths.MetadataBranchName)
 	requireHexLen(t, "initial metadata branch HEAD", initialMetadataHead, 64)
-
-	// Persist local identity for later git/go-git helper commits and hook subprocesses.
-	gitOutput(t, env.RepoDir, "config", "user.name", "Test User")
-	gitOutput(t, env.RepoDir, "config", "user.email", "test@example.com")
-	gitOutput(t, env.RepoDir, "config", "commit.gpgsign", "false")
 
 	sess := env.NewSession()
 	prompt := "Create a file in the SHA-256 repo"
@@ -116,11 +115,16 @@ func requireGitSHA256Support(t *testing.T) {
 	}
 }
 
+// gitOutput runs `git <args...>` and returns trimmed combined output. An empty
+// dir leaves cmd.Dir unset, which is appropriate for commands that take a path
+// argument (e.g. `git init <dir>`).
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 
 	cmd := exec.Command("git", args...) //nolint:noctx // test helper
-	cmd.Dir = dir
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	cmd.Env = testutil.GitIsolatedEnv()
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -660,7 +660,7 @@ func repoWorktreeRoot(repo *git.Repository) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("open worktree: %w", err)
 	}
-	root := worktree.Filesystem.Root()
+	root := worktree.Filesystem().Root()
 	if root == "" {
 		return "", errors.New("repository worktree filesystem has no root path")
 	}

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -1304,7 +1304,7 @@ func TestMigrateCmd_FailsFastWhenLockHeld(t *testing.T) {
 	repo := initMigrateTestRepo(t)
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
-	t.Chdir(wt.Filesystem.Root())
+	t.Chdir(wt.Filesystem().Root())
 	paths.ClearWorktreeRootCache()
 
 	commonDir, err := strategy.GetGitCommonDir(t.Context())
@@ -1345,7 +1345,7 @@ func TestAcquireCommandLock_SetupFailuresReturnVisibleError(t *testing.T) {
 		repo := initMigrateTestRepo(t)
 		wt, err := repo.Worktree()
 		require.NoError(t, err)
-		t.Chdir(wt.Filesystem.Root())
+		t.Chdir(wt.Filesystem().Root())
 
 		cmd := newMigrateCmd()
 		release, err := acquireCommandLock(t.Context(), cmd, filepath.Join("missing-dir", "entire-migrate.lock"), "migrate")

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -741,7 +741,7 @@ func TestMigrateCmd_RepairsArchivedGenerationMetadata(t *testing.T) {
 	repo := initMigrateTestRepo(t)
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
-	t.Chdir(wt.Filesystem.Root())
+	t.Chdir(wt.Filesystem().Root())
 	paths.ClearWorktreeRootCache()
 
 	// A pre-existing archived generation with wrong generation.json
@@ -787,7 +787,7 @@ func TestMigrateCmd_NoOpRerunSkipsGenerationMetadataRepair(t *testing.T) {
 	repo := initMigrateTestRepo(t)
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
-	t.Chdir(wt.Filesystem.Root())
+	t.Chdir(wt.Filesystem().Root())
 	paths.ClearWorktreeRootCache()
 
 	v1Store, v2Store := newMigrateStores(repo)

--- a/cmd/entire/cli/reset_test.go
+++ b/cmd/entire/cli/reset_test.go
@@ -103,7 +103,7 @@ func TestResetCmd_WithForce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get worktree: %v", err)
 	}
-	worktreePath := wt.Filesystem.Root()
+	worktreePath := wt.Filesystem().Root()
 	worktreeID, err := paths.GetWorktreeID(worktreePath)
 	if err != nil {
 		t.Fatalf("failed to get worktree ID: %v", err)

--- a/cmd/entire/cli/review/scope.go
+++ b/cmd/entire/cli/review/scope.go
@@ -275,7 +275,7 @@ func repoWorktreePath(repo *git.Repository) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve worktree: %w", err)
 	}
-	return wt.Filesystem.Root(), nil
+	return wt.Filesystem().Root(), nil
 }
 
 // fallbackScopeRef returns the first existing ref from the fallback chain:

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -642,12 +642,12 @@ func gitInit(ctx context.Context, runner bootstrapRunner, dir string) error {
 // commit was actually created (false if there were no files to stage).
 func doInitialCommit(ctx context.Context, runner bootstrapRunner, dir, message string) (bool, error) {
 	if _, err := runner.RunInDir(ctx, dir, "git", "add", "-A"); err != nil {
-		return false, fmt.Errorf("git add: %w", err)
+		return false, wrapExecError("git add", err)
 	}
 	// Check if the staging area has anything at all.
 	out, err := runner.RunInDir(ctx, dir, "git", "status", "--porcelain")
 	if err != nil {
-		return false, fmt.Errorf("git status: %w", err)
+		return false, wrapExecError("git status", err)
 	}
 	if strings.TrimSpace(out) == "" {
 		return false, nil
@@ -656,9 +656,21 @@ func doInitialCommit(ctx context.Context, runner bootstrapRunner, dir, message s
 	// have commit.gpgsign=true inherited from a global config but no
 	// working signer; passing -c keeps the user's global config intact.
 	if _, err := runner.RunInDir(ctx, dir, "git", "-c", "commit.gpgsign=false", "commit", "-m", message); err != nil {
-		return false, fmt.Errorf("git commit: %w", err)
+		return false, wrapExecError("git commit", err)
 	}
 	return true, nil
+}
+
+// wrapExecError formats err with stderr from *exec.ExitError when available,
+// so callers see git's actual complaint instead of an opaque "exit status N".
+func wrapExecError(prefix string, err error) error {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		if stderr := strings.TrimSpace(string(ee.Stderr)); stderr != "" {
+			return fmt.Errorf("%s: %w: %s", prefix, err, stderr)
+		}
+	}
+	return fmt.Errorf("%s: %w", prefix, err)
 }
 
 // ensureGitIdentity guarantees the repo has a user.name/user.email set at

--- a/cmd/entire/cli/strategy/content_overlap.go
+++ b/cmd/entire/cli/strategy/content_overlap.go
@@ -442,7 +442,7 @@ func filesWithRemainingAgentChanges(
 	// differs from shadow (distinguishes replacement from partial staging).
 	var worktreeRoot string
 	if wt, wtErr := repo.Worktree(); wtErr == nil {
-		worktreeRoot = wt.Filesystem.Root()
+		worktreeRoot = wt.Filesystem().Root()
 	}
 
 	var remaining []string

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -2429,7 +2429,7 @@ func (s *ManualCommitStrategy) calculatePromptAttributionAtStart(
 		return result
 	}
 
-	worktreeRoot := worktree.Filesystem.Root()
+	worktreeRoot := worktree.Filesystem().Root()
 
 	// Build map of changed files with their worktree content
 	// IMPORTANT: We read from worktree (not staging area) to match what WriteTemporary

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -614,5 +614,5 @@ func getRepoPath(repo *git.Repository) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get worktree: %w", err)
 	}
-	return wt.Filesystem.Root(), nil
+	return wt.Filesystem().Root(), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/go-git/go-billy/v6 v6.0.0-20260424211911-732291493fb8
-	github.com/go-git/go-git/v6 v6.0.0-alpha.3
+	github.com/go-git/go-git/v6 v6.0.0-alpha.3.0.20260507221227-c9084f20dee2
 	github.com/go-git/x/plugin/objectsigner/auto v0.1.0
 	github.com/go-git/x/plugin/objectsigner/program v0.0.0-20260506121155-e7fc238fcab6
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/go-git/go-billy/v6 v6.0.0-20260424211911-732291493fb8 h1:QRpwB1ans3fB
 github.com/go-git/go-billy/v6 v6.0.0-20260424211911-732291493fb8/go.mod h1:CdBVp7CXl9l3sOyNEog46cP1Pvx/hjCe9AD0mtaIUYU=
 github.com/go-git/go-git-fixtures/v6 v6.0.0-20260422085740-0c07409f52ec h1:FpCNUs50xfQyJJs31uO3mDnqU855OhzAzfkkTgE6/DI=
 github.com/go-git/go-git-fixtures/v6 v6.0.0-20260422085740-0c07409f52ec/go.mod h1:F1SpxOny2UYXu62DzjEH4UqBjk4AoGs27cA8I9buK+o=
-github.com/go-git/go-git/v6 v6.0.0-alpha.3 h1:lJGritJ5AcC0X7buV0lReZ4cEHqcKB3Ab2ZjD3Ku+Ss=
-github.com/go-git/go-git/v6 v6.0.0-alpha.3/go.mod h1:DGnqu+twdAgtDx/4tQTWFrVE1an+2ACph3W9yOfSJZM=
+github.com/go-git/go-git/v6 v6.0.0-alpha.3.0.20260507221227-c9084f20dee2 h1:WGQWikXciN5yYwTtPiJkbmrUqJX07tWbBVV6VeSo19A=
+github.com/go-git/go-git/v6 v6.0.0-alpha.3.0.20260507221227-c9084f20dee2/go.mod h1:DGnqu+twdAgtDx/4tQTWFrVE1an+2ACph3W9yOfSJZM=
 github.com/go-git/x/plugin/objectsigner/auto v0.1.0 h1:RcLW29RgwSCmqrNSs7QOxvWkRbM1vPu0Vp9TCECZjMs=
 github.com/go-git/x/plugin/objectsigner/auto v0.1.0/go.mod h1:iP2cXPyXc//9v9THS3y/MLi0jnt7vEqwUDj11qQfFPg=
 github.com/go-git/x/plugin/objectsigner/gpg v0.1.0 h1:NEGVSOD+LPnus6j4iNkAZaHVTc4DNY223y1/I2Jq2yI=


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/325
<!-- entire-trail-link-end -->

Fixes #1133.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades core `go-git` dependencies and adjusts worktree filesystem accessors across checkpoint/clean/migrate/review code paths, which could subtly affect repository path resolution. Adds an integration test to catch regressions in SHA-256 object-format repos, reducing but not eliminating risk.
> 
> **Overview**
> Ensures the CLI can create and persist checkpoints in **SHA-256 object-format** git repositories by adding an integration test that runs `enable`, creates a first checkpoint via hooks, and asserts SHA-256-length object IDs and metadata branch updates.
> 
> Updates `go-git`/`go-billy` (and `sha1cd`) and refactors various call sites to use the newer `Worktree.Filesystem()` API (replacing direct `Filesystem.Root()`/`Filesystem.MkdirAll` access) across checkpointing, cleaning, migration, and review scope logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50e6e9b5ac01664bccb7481ff0d2c5190919057. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->