### PR TITLE
Clarify keyboard exit behavior

### DIFF
--- a/cmd/entire/cli/activity_tui.go
+++ b/cmd/entire/cli/activity_tui.go
@@ -177,12 +177,12 @@ func (m activityModel) withViewport() activityModel {
 func (m activityModel) View() tea.View {
 	v := tea.View{AltScreen: true}
 	if m.loadErr != nil {
-		v.SetContent(fmt.Sprintf("\n  Failed to load activity: %s\n\n  Press q to quit.\n", m.loadErr))
+		v.SetContent(fmt.Sprintf("\n  Failed to load activity: %s\n\n  %s\n", m.loadErr, topLevelExitHelp))
 		return v
 	}
 
 	if m.loading {
-		v.SetContent(fmt.Sprintf("\n  %s Loading activity...\n", m.spinner.View()))
+		v.SetContent(fmt.Sprintf("\n  %s Loading activity...\n\n  %s\n", m.spinner.View(), topLevelExitHelp))
 		return v
 	}
 
@@ -231,15 +231,17 @@ func (m activityModel) renderFooter() string {
 	helpStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Bold(true)
 	sep := helpStyle.Render(" · ")
+	exitHelp := keyStyle.Render(keys.Back.Help().Key) + helpStyle.Render(" exit") +
+		sep + keyStyle.Render(keys.Quit.Help().Key) + helpStyle.Render(" "+keys.Quit.Help().Desc)
 
 	fullHelp := keyStyle.Render("↑/↓, j/k") + helpStyle.Render(" scroll") +
 		sep + keyStyle.Render("home/end, g/G") + helpStyle.Render(" top/bottom") +
-		sep + keyStyle.Render(keys.Quit.Help().Key) + helpStyle.Render(" "+keys.Quit.Help().Desc)
+		sep + exitHelp
 	standardHelp := keyStyle.Render("↑/↓") + helpStyle.Render(" scroll") +
 		sep + keyStyle.Render("home/end") + helpStyle.Render(" top/bottom") +
-		sep + keyStyle.Render(keys.Quit.Help().Key) + helpStyle.Render(" "+keys.Quit.Help().Desc)
-	shortHelp := keyStyle.Render("↑/↓") + helpStyle.Render(" scroll")
-	quitHelp := keyStyle.Render(keys.Quit.Help().Key) + helpStyle.Render(" "+keys.Quit.Help().Desc)
+		sep + exitHelp
+	shortHelp := keyStyle.Render("↑/↓") + helpStyle.Render(" scroll") + sep + exitHelp
+	quitHelp := exitHelp
 	helpChoices := []string{fullHelp, standardHelp, shortHelp, quitHelp}
 
 	if m.viewport.TotalLineCount() <= m.viewport.Height() {

--- a/cmd/entire/cli/activity_tui_test.go
+++ b/cmd/entire/cli/activity_tui_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -146,6 +147,24 @@ func TestActivityModel_QuitKeys(t *testing.T) {
 	}
 }
 
+func TestActivityModel_LoadingAndErrorViewsDocumentExitKeys(t *testing.T) {
+	t.Parallel()
+
+	loading := activityModel{loading: true}.View().Content
+	for _, want := range []string{"q", "esc", "ctrl+c", "quit"} {
+		if !strings.Contains(loading, want) {
+			t.Fatalf("loading view missing %q: %q", want, loading)
+		}
+	}
+
+	failure := activityModel{loadErr: errors.New("boom")}.View().Content
+	for _, want := range []string{"q", "esc", "ctrl+c", "quit"} {
+		if !strings.Contains(failure, want) {
+			t.Fatalf("error view missing %q: %q", want, failure)
+		}
+	}
+}
+
 func TestActivityModel_FooterDocumentsVisibleControlsOnly(t *testing.T) {
 	t.Parallel()
 
@@ -153,7 +172,7 @@ func TestActivityModel_FooterDocumentsVisibleControlsOnly(t *testing.T) {
 	m.sty = newActivityStylesWithWidth(m.width, true)
 
 	footer := m.renderFooter()
-	for _, want := range []string{"↑/↓, j/k", " scroll", "home/end, g/G", " top/bottom", "q", " quit"} {
+	for _, want := range []string{"↑/↓, j/k", " scroll", "home/end, g/G", " top/bottom", "esc", " exit", "q/ctrl+c", " quit"} {
 		if !strings.Contains(footer, want) {
 			t.Fatalf("footer missing %q: %q", want, footer)
 		}
@@ -178,12 +197,12 @@ func TestActivityModel_FooterScrollPercentFitsWidth(t *testing.T) {
 	if got := lipgloss.Width(footer); got != m.width {
 		t.Fatalf("compact footer width = %d, want %d: %q", got, m.width, footer)
 	}
-	for _, want := range []string{"↑/↓", " scroll", "home/end", " top/bottom", "q", " quit"} {
+	for _, want := range []string{"↑/↓", " scroll", "esc", " exit", "q/ctrl+c", " quit"} {
 		if !strings.Contains(footer, want) {
 			t.Fatalf("compact footer missing %q: %q", want, footer)
 		}
 	}
-	for _, hidden := range []string{"j/k", "g/G"} {
+	for _, hidden := range []string{"j/k", "home/end", "top/bottom", "g/G"} {
 		if strings.Contains(footer, hidden) {
 			t.Fatalf("compact footer should drop %q: %q", hidden, footer)
 		}

--- a/cmd/entire/cli/dispatch_tui.go
+++ b/cmd/entire/cli/dispatch_tui.go
@@ -118,7 +118,7 @@ func newDispatchStatusModel(
 		title:    title,
 		subtitle: subtitle,
 		details:  dispatchStatusDetails(opts),
-		footer:   "Press ctrl+c to cancel",
+		footer:   "Press q, esc, or ctrl+c to cancel",
 		width:    ss.width,
 		height:   12,
 		run:      run,

--- a/cmd/entire/cli/dispatch_tui_test.go
+++ b/cmd/entire/cli/dispatch_tui_test.go
@@ -72,6 +72,20 @@ func TestDispatchStatusModel_ViewRendersInlineCard(t *testing.T) {
 	}
 }
 
+func TestDispatchStatusModel_FooterDocumentsCancelKeys(t *testing.T) {
+	t.Parallel()
+
+	model := newDispatchStatusModel(io.Discard, dispatchpkg.Options{Since: "7d"}, func(context.Context) (string, error) {
+		return "", nil
+	})
+
+	for _, want := range []string{"q", "ctrl+c", "esc", "cancel"} {
+		if !strings.Contains(model.footer, want) {
+			t.Fatalf("footer missing %q: %q", want, model.footer)
+		}
+	}
+}
+
 func TestDefaultRenderTerminalMarkdown_RendersHyperlinks(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/dispatch_wizard.go
+++ b/cmd/entire/cli/dispatch_wizard.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/huh/v2"
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	dispatchpkg "github.com/entireio/cli/cmd/entire/cli/dispatch"
@@ -348,7 +349,7 @@ func runDispatchWizard(cmd *cobra.Command) (dispatchpkg.Options, error) {
 				Negative("Cancel").
 				Value(&state.confirmRun),
 		).Title("Confirm").Description("Review the resolved command and run it."),
-	)
+	).WithKeyMap(dispatchWizardKeyMap())
 
 	fmt.Fprintln(cmd.OutOrStdout())
 
@@ -364,6 +365,15 @@ func runDispatchWizard(cmd *cobra.Command) (dispatchpkg.Options, error) {
 	}
 
 	return state.resolve()
+}
+
+func dispatchWizardKeyMap() *huh.KeyMap {
+	keymap := huh.NewDefaultKeyMap()
+	keymap.Quit = key.NewBinding(
+		key.WithKeys("esc", "ctrl+c"),
+		key.WithHelp("esc/ctrl+c", "cancel"),
+	)
+	return keymap
 }
 
 // newLazyOptions returns a func that runs loader once (under sync.Once) and

--- a/cmd/entire/cli/dispatch_wizard_test.go
+++ b/cmd/entire/cli/dispatch_wizard_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -370,6 +371,20 @@ func TestRunDispatchWizard_ProceedsWhenCurrentBranchCannotBeResolved(t *testing.
 	_, err := runDispatchWizard(cmd)
 	if err == nil || !strings.Contains(err.Error(), "run dispatch wizard") {
 		t.Fatalf("expected form execution error instead of eager branch failure, got %v", err)
+	}
+}
+
+func TestDispatchWizardKeyMapQuitsWithEscAndCtrlC(t *testing.T) {
+	t.Parallel()
+
+	quitKeys := dispatchWizardKeyMap().Quit.Keys()
+	for _, want := range []string{"esc", "ctrl+c"} {
+		if !slices.Contains(quitKeys, want) {
+			t.Fatalf("dispatch wizard quit keys = %v, missing %q", quitKeys, want)
+		}
+	}
+	if slices.Contains(quitKeys, "q") {
+		t.Fatalf("dispatch wizard quit keys = %v, should not include q because custom voice is a text input", quitKeys)
 	}
 }
 

--- a/cmd/entire/cli/keys.go
+++ b/cmd/entire/cli/keys.go
@@ -2,26 +2,33 @@ package cli
 
 import "charm.land/bubbles/v2/key"
 
+const topLevelExitHelp = "Press q, esc, or ctrl+c to quit."
+
 // keyMap defines the keybindings used across the CLI's TUIs. Single source of
 // truth so help text and matching logic stay aligned, and so the strings "esc",
 // "ctrl+c", etc. live in exactly one place.
 type keyMap struct {
-	Quit     key.Binding
-	Back     key.Binding
-	Search   key.Binding
-	Confirm  key.Binding
-	Up       key.Binding
-	Down     key.Binding
-	NextPage key.Binding
-	PrevPage key.Binding
-	Home     key.Binding
-	End      key.Binding
+	Quit      key.Binding
+	Interrupt key.Binding
+	Back      key.Binding
+	Search    key.Binding
+	Confirm   key.Binding
+	Up        key.Binding
+	Down      key.Binding
+	NextPage  key.Binding
+	PrevPage  key.Binding
+	Home      key.Binding
+	End       key.Binding
 }
 
 var keys = keyMap{
 	Quit: key.NewBinding(
 		key.WithKeys("q", "ctrl+c"),
-		key.WithHelp("q", "quit"),
+		key.WithHelp("q/ctrl+c", "quit"),
+	),
+	Interrupt: key.NewBinding(
+		key.WithKeys("ctrl+c"),
+		key.WithHelp("ctrl+c", "quit"),
 	),
 	Back: key.NewBinding(
 		key.WithKeys("esc"),

--- a/cmd/entire/cli/recap_tui.go
+++ b/cmd/entire/cli/recap_tui.go
@@ -177,11 +177,11 @@ func (m recapTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:iretu
 func (m recapTUIModel) View() tea.View {
 	v := tea.View{AltScreen: true}
 	if m.loadErr != nil {
-		v.SetContent(fmt.Sprintf("\n  Failed to load recap: %s\n\n  Press r to retry or q to quit.\n", m.loadErr))
+		v.SetContent(fmt.Sprintf("\n  Failed to load recap: %s\n\n  Press r to retry. %s\n", m.loadErr, topLevelExitHelp))
 		return v
 	}
 	if m.loading && m.resp == nil {
-		v.SetContent("\n  Loading recap...\n\n  Press q to quit.\n")
+		v.SetContent("\n  Loading recap...\n\n  " + topLevelExitHelp + "\n")
 		return v
 	}
 	if !m.ready {
@@ -228,21 +228,28 @@ func (m recapTUIModel) renderFooter() string {
 			{"a", "agent"},
 			{"r", "refresh"},
 			{"↑/↓", "scroll"},
-			{"q", "quit"},
+			{keys.Back.Help().Key, "exit"},
+			{keys.Quit.Help().Key, keys.Quit.Help().Desc},
 		}),
 		recapFooterLine(m.color, []recapHelpItem{
 			{"t", "range"},
 			{"v", "view"},
 			{"a", "agent"},
-			{"q", "quit"},
+			{keys.Back.Help().Key, "exit"},
+			{keys.Quit.Help().Key, keys.Quit.Help().Desc},
 		}),
 		recapFooterLine(m.color, []recapHelpItem{
 			{"t", "range"},
 			{"v", "view"},
-			{"q", "quit"},
+			{keys.Back.Help().Key, "exit"},
+			{keys.Quit.Help().Key, keys.Quit.Help().Desc},
 		}),
 		recapFooterLine(m.color, []recapHelpItem{
-			{"q", "quit"},
+			{keys.Back.Help().Key, "exit"},
+			{keys.Quit.Help().Key, keys.Quit.Help().Desc},
+		}),
+		recapFooterLine(m.color, []recapHelpItem{
+			{keys.Quit.Help().Key, keys.Quit.Help().Desc},
 		}),
 	}
 	for _, choice := range choices {

--- a/cmd/entire/cli/recap_tui_test.go
+++ b/cmd/entire/cli/recap_tui_test.go
@@ -215,7 +215,7 @@ func TestRecapTUIModel_FooterFitsWidth(t *testing.T) {
 	if got := lipgloss.Width(footer); got > m.width {
 		t.Fatalf("wide footer width = %d, want <= %d: %q", got, m.width, footer)
 	}
-	for _, want := range []string{"t range", "v view", "a agent", "r refresh", "↑/↓ scroll", "q quit"} {
+	for _, want := range []string{"t range", "v view", "a agent", "r refresh", "↑/↓ scroll", "esc exit", "q/ctrl+c quit"} {
 		if !strings.Contains(footer, want) {
 			t.Fatalf("wide footer missing %q: %q", want, footer)
 		}
@@ -226,8 +226,26 @@ func TestRecapTUIModel_FooterFitsWidth(t *testing.T) {
 	if got := lipgloss.Width(footer); got > m.width {
 		t.Fatalf("narrow footer width = %d, want <= %d: %q", got, m.width, footer)
 	}
-	if !strings.Contains(footer, "q quit") {
+	if !strings.Contains(footer, "q/ctrl+c quit") {
 		t.Fatalf("narrow footer should keep quit help: %q", footer)
+	}
+}
+
+func TestRecapTUIModel_LoadingAndErrorViewsDocumentExitKeys(t *testing.T) {
+	t.Parallel()
+
+	loading := recapTUIModel{loading: true}.View().Content
+	for _, want := range []string{"q", "esc", "ctrl+c", "quit"} {
+		if !strings.Contains(loading, want) {
+			t.Fatalf("loading view missing %q: %q", want, loading)
+		}
+	}
+
+	failure := recapTUIModel{loadErr: errors.New("boom")}.View().Content
+	for _, want := range []string{"q", "esc", "ctrl+c", "quit"} {
+		if !strings.Contains(failure, want) {
+			t.Fatalf("error view missing %q: %q", want, failure)
+		}
 	}
 }
 

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -262,7 +262,12 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:ireturn
 
 func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) { //nolint:ireturn // bubbletea pattern
 	switch {
+	case key.Matches(msg, keys.Interrupt):
+		return m, tea.Quit
 	case key.Matches(msg, keys.Back):
+		if !m.hasBrowseContext() {
+			return m, tea.Quit
+		}
 		m.mode = modeBrowse
 		m.input.Blur()
 		m = m.refreshBrowseContent()
@@ -299,6 +304,10 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 	var cmd tea.Cmd
 	m.input, cmd = m.input.Update(msg)
 	return m, cmd
+}
+
+func (m searchModel) hasBrowseContext() bool {
+	return m.results != nil || m.apiPage > 0 || m.total > 0
 }
 
 func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) { //nolint:ireturn // bubbletea pattern
@@ -724,7 +733,8 @@ func (m searchModel) viewHelp() string {
 
 	if m.mode == modeSearch {
 		return m.styles.helpItem(keys.Confirm.Help().Key, "search") + dot +
-			m.styles.helpItem(keys.Back.Help().Key, "cancel") + "\n"
+			m.styles.helpItem(keys.Back.Help().Key, "cancel") + dot +
+			m.styles.helpItem(keys.Interrupt.Help().Key, keys.Interrupt.Help().Desc) + "\n"
 	}
 
 	pages := m.totalPages()
@@ -735,7 +745,8 @@ func (m searchModel) viewHelp() string {
 	if pages > 1 {
 		left += dot + m.styles.helpItem("n/p", "page")
 	}
-	left += dot + m.styles.helpItem(keys.Quit.Help().Key, keys.Quit.Help().Desc)
+	left += dot + m.styles.helpItem(keys.Back.Help().Key, "exit") + dot +
+		m.styles.helpItem(keys.Quit.Help().Key, keys.Quit.Help().Desc)
 
 	right := fmt.Sprintf("%d results", m.total)
 	if pages > 1 {

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -230,6 +230,74 @@ func TestSearchModel_Quit(t *testing.T) {
 	}
 }
 
+func TestSearchModel_BrowseEscQuitsAtTopLevel(t *testing.T) {
+	t.Parallel()
+	m := testModel()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected esc in browse mode to quit")
+	}
+	if msg := cmd(); msg != (tea.QuitMsg{}) {
+		t.Fatalf("expected QuitMsg, got %T", msg)
+	}
+}
+
+func TestSearchModel_SearchModeCtrlCQuits(t *testing.T) {
+	t.Parallel()
+	m := testModel()
+	m = updateModel(t, m, tea.KeyPressMsg{Code: '/', Text: "/"})
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("expected ctrl+c in search mode to quit")
+	}
+	if msg := cmd(); msg != (tea.QuitMsg{}) {
+		t.Fatalf("expected QuitMsg, got %T", msg)
+	}
+}
+
+func TestSearchModel_SearchModeQEditsInput(t *testing.T) {
+	t.Parallel()
+	m := testModel()
+	m = updateModel(t, m, tea.KeyPressMsg{Code: '/', Text: "/"})
+	m.input.SetValue("")
+
+	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	if cmd != nil {
+		if msg := cmd(); msg == (tea.QuitMsg{}) {
+			t.Fatal("q in search mode should edit text, not quit")
+		}
+	}
+	m, ok := updated.(searchModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want searchModel", updated)
+	}
+	if m.input.Value() != "q" {
+		t.Fatalf("input value = %q, want q", m.input.Value())
+	}
+	if m.mode != modeSearch {
+		t.Fatalf("mode = %d, want modeSearch", m.mode)
+	}
+}
+
+func TestSearchModel_DetailModeQQuits(t *testing.T) {
+	t.Parallel()
+	m := testModel()
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.mode != modeDetail {
+		t.Fatalf("mode = %d, want modeDetail", m.mode)
+	}
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'q', Text: "q"})
+	if cmd == nil {
+		t.Fatal("expected q in detail mode to quit")
+	}
+	if msg := cmd(); msg != (tea.QuitMsg{}) {
+		t.Fatalf("expected QuitMsg, got %T", msg)
+	}
+}
+
 func TestSearchModel_SearchMode(t *testing.T) {
 	t.Parallel()
 	m := testModel()
@@ -246,6 +314,22 @@ func TestSearchModel_SearchMode(t *testing.T) {
 	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyEscape})
 	if m.mode != modeBrowse {
 		t.Errorf("after esc: mode = %d, want modeBrowse", m.mode)
+	}
+}
+
+func TestSearchModel_InitialSearchModeEscQuitsWithoutBrowseContext(t *testing.T) {
+	t.Parallel()
+	ss := statusStyles{colorEnabled: false, width: 100}
+	m := newSearchModel(nil, "", 0, search.Config{}, ss)
+	m.mode = modeSearch
+	m.input.Focus()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if cmd == nil {
+		t.Fatal("expected esc in initial search mode to quit")
+	}
+	if msg := cmd(); msg != (tea.QuitMsg{}) {
+		t.Fatalf("expected QuitMsg, got %T", msg)
 	}
 }
 
@@ -361,7 +445,8 @@ func TestSearchModel_BrowseFooterHelp(t *testing.T) {
 		"/ search",
 		"↑/↓, j/k scroll",
 		"home/end, g/G top/bottom",
-		"q quit",
+		"esc exit",
+		"q/ctrl+c quit",
 	}
 	lastIndex := -1
 	for _, want := range wantParts {
@@ -402,7 +487,8 @@ func TestSearchModel_BrowseFooterHelpIncludesPagingForMultiplePages(t *testing.T
 		"↑/↓, j/k scroll",
 		"home/end, g/G top/bottom",
 		"n/p page",
-		"q quit",
+		"esc exit",
+		"q/ctrl+c quit",
 	}
 	lastIndex := -1
 	for _, want := range wantParts {
@@ -414,6 +500,33 @@ func TestSearchModel_BrowseFooterHelpIncludesPagingForMultiplePages(t *testing.T
 			t.Fatalf("footer control %q rendered out of order: %q", want, footer)
 		}
 		lastIndex = idx
+	}
+}
+
+func TestSearchModel_ViewSearchModeAdvertisesCtrlCQuit(t *testing.T) {
+	t.Parallel()
+	m := testModel()
+	m.mode = modeSearch
+	m.input.Focus()
+
+	view := m.View().Content
+	for _, want := range []string{"esc", "cancel", "ctrl+c", "quit"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("search view missing %q in help: %s", want, view)
+		}
+	}
+}
+
+func TestSearchModel_DetailModeAdvertisesCtrlCQuit(t *testing.T) {
+	t.Parallel()
+	m := testModel()
+	m = updateModel(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	view := m.View().Content
+	for _, want := range []string{"esc", "back", "q/ctrl+c", "quit"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("detail view missing %q in help: %s", want, view)
+		}
 	}
 }
 

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -494,7 +494,6 @@ func runStopSession(ctx context.Context, cmd *cobra.Command, sessionID string, f
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Stop session %s?", sessionID)).
-					Description(stopSessionConfirmDescription()).
 					Value(&confirmed),
 			),
 		)
@@ -523,7 +522,6 @@ func runStopAll(ctx context.Context, cmd *cobra.Command, activeSessions []*strat
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Stop %d session(s)?", len(activeSessions))).
-					Description(stopSessionConfirmDescription()).
 					Value(&confirmed),
 			),
 		)
@@ -584,7 +582,6 @@ func runStopMultiSelect(ctx context.Context, cmd *cobra.Command, activeSessions 
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Stop %d session(s)?", len(selectedIDs))).
-					Description(stopSessionConfirmDescription()).
 					Value(&confirmed),
 			),
 		)
@@ -615,10 +612,6 @@ func runStopMultiSelect(ctx context.Context, cmd *cobra.Command, activeSessions 
 
 func stopSessionSelectionDescription() string {
 	return "Use space to select, enter to confirm, ctrl+c to cancel."
-}
-
-func stopSessionConfirmDescription() string {
-	return "Press enter to submit, y/n to choose, or ctrl+c to cancel."
 }
 
 // stopSelectedSessions stops each session in the list and prints a result line.

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -494,6 +494,7 @@ func runStopSession(ctx context.Context, cmd *cobra.Command, sessionID string, f
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Stop session %s?", sessionID)).
+					Description(stopSessionConfirmDescription()).
 					Value(&confirmed),
 			),
 		)
@@ -522,6 +523,7 @@ func runStopAll(ctx context.Context, cmd *cobra.Command, activeSessions []*strat
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Stop %d session(s)?", len(activeSessions))).
+					Description(stopSessionConfirmDescription()).
 					Value(&confirmed),
 			),
 		)
@@ -582,6 +584,7 @@ func runStopMultiSelect(ctx context.Context, cmd *cobra.Command, activeSessions 
 			huh.NewGroup(
 				huh.NewConfirm().
 					Title(fmt.Sprintf("Stop %d session(s)?", len(selectedIDs))).
+					Description(stopSessionConfirmDescription()).
 					Value(&confirmed),
 			),
 		)
@@ -612,6 +615,10 @@ func runStopMultiSelect(ctx context.Context, cmd *cobra.Command, activeSessions 
 
 func stopSessionSelectionDescription() string {
 	return "Use space to select, enter to confirm, ctrl+c to cancel."
+}
+
+func stopSessionConfirmDescription() string {
+	return "Press enter to submit, y/n to choose, or ctrl+c to cancel."
 }
 
 // stopSelectedSessions stops each session in the list and prints a result line.

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -555,7 +555,7 @@ func runStopMultiSelect(ctx context.Context, cmd *cobra.Command, activeSessions 
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("Select sessions to stop").
-				Description("Use space to select, enter to confirm.").
+				Description(stopSessionSelectionDescription()).
 				Options(options...).
 				Value(&selectedIDs),
 		),
@@ -608,6 +608,10 @@ func runStopMultiSelect(ctx context.Context, cmd *cobra.Command, activeSessions 
 		return nil
 	}
 	return stopSelectedSessions(ctx, cmd, toStop)
+}
+
+func stopSessionSelectionDescription() string {
+	return "Use space to select, enter to confirm, ctrl+c to cancel."
 }
 
 // stopSelectedSessions stops each session in the list and prints a result line.

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -46,6 +46,17 @@ func makeSessionState(id string, phase session.Phase) *strategy.SessionState {
 	}
 }
 
+func TestStopSessionConfirmDescription(t *testing.T) {
+	t.Parallel()
+
+	got := stopSessionConfirmDescription()
+	for _, want := range []string{"enter", "y", "n", "ctrl+c", "cancel"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stopSessionConfirmDescription() = %q, missing %q", got, want)
+		}
+	}
+}
+
 func TestStopCmd_NoActiveSessions(t *testing.T) {
 	setupStopTestRepo(t)
 

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -46,17 +46,6 @@ func makeSessionState(id string, phase session.Phase) *strategy.SessionState {
 	}
 }
 
-func TestStopSessionConfirmDescription(t *testing.T) {
-	t.Parallel()
-
-	got := stopSessionConfirmDescription()
-	for _, want := range []string{"enter", "y", "n", "ctrl+c", "cancel"} {
-		if !strings.Contains(got, want) {
-			t.Fatalf("stopSessionConfirmDescription() = %q, missing %q", got, want)
-		}
-	}
-}
-
 func TestStopCmd_NoActiveSessions(t *testing.T) {
 	setupStopTestRepo(t)
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -20,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/vercelconfig"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -441,15 +442,16 @@ func runManageAgents(ctx context.Context, w io.Writer, opts EnableOptions, selec
 			return fmt.Errorf("agent selection cancelled: %w", err)
 		}
 	} else {
+		printAccessiblePromptGuidance(w, accessibleManageAgentsDescription())
 		form := NewAccessibleForm(
 			huh.NewGroup(
 				huh.NewMultiSelect[string]().
 					Title("Manage agents").
-					Description("Use space to select/deselect, enter to confirm.").
+					Description(manageAgentsDescription()).
 					Options(options...).
 					Value(&selectedAgentNames),
 			),
-		)
+		).WithKeyMap(agentMenuKeyMap())
 		if err := form.Run(); err != nil {
 			return fmt.Errorf("agent selection cancelled: %w", err)
 		}
@@ -1068,6 +1070,37 @@ func runEnable(ctx context.Context, w io.Writer, useProjectSettings bool) error 
 	return nil
 }
 
+func manageAgentsDescription() string {
+	return "Use space to select/deselect, enter to confirm, q/esc/ctrl+c to cancel. No changes: leave selections unchanged and press enter."
+}
+
+func agentSelectionDescription() string {
+	return "Use space to select, enter to confirm, q/esc/ctrl+c to cancel."
+}
+
+func accessibleManageAgentsDescription() string {
+	return "Enter a number to select/deselect an agent. Enter 0 to confirm; press ctrl+c to cancel. No changes: leave selections unchanged and enter 0."
+}
+
+func accessibleAgentSelectionDescription() string {
+	return "Enter a number to select/deselect an agent. Enter 0 to confirm; press ctrl+c to cancel."
+}
+
+func agentMenuKeyMap() *huh.KeyMap {
+	keymap := huh.NewDefaultKeyMap()
+	keymap.Quit = key.NewBinding(
+		key.WithKeys("q", "esc", "ctrl+c"),
+		key.WithHelp("q/esc/ctrl+c", "cancel"),
+	)
+	return keymap
+}
+
+func printAccessiblePromptGuidance(w io.Writer, guidance string) {
+	if IsAccessibleMode() {
+		fmt.Fprintln(w, guidance)
+	}
+}
+
 func runDisable(ctx context.Context, w io.Writer, useProjectSettings bool) error {
 	s, err := LoadEntireSettings(ctx)
 	if err != nil {
@@ -1350,11 +1383,12 @@ func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(availab
 			return nil, errors.New("no agents selected")
 		}
 	} else {
+		printAccessiblePromptGuidance(w, accessibleAgentSelectionDescription())
 		form := NewAccessibleForm(
 			huh.NewGroup(
 				huh.NewMultiSelect[string]().
 					Title("Select the agents you want to use").
-					Description("Use space to select, enter to confirm.").
+					Description(agentSelectionDescription()).
 					Options(options...).
 					Validate(func(selected []string) error {
 						if len(selected) == 0 {
@@ -1364,7 +1398,7 @@ func detectOrSelectAgent(ctx context.Context, w io.Writer, selectFn func(availab
 					}).
 					Value(&selectedAgentNames),
 			),
-		)
+		).WithKeyMap(agentMenuKeyMap())
 		if err := form.Run(); err != nil {
 			return nil, fmt.Errorf("agent selection cancelled: %w", err)
 		}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1079,11 +1079,11 @@ func agentSelectionDescription() string {
 }
 
 func accessibleManageAgentsDescription() string {
-	return "Enter a number to select/deselect an agent. Enter 0 to confirm; press ctrl+c to cancel. No changes: leave selections unchanged and enter 0."
+	return "Enter a number to select/deselect an agent. Enter 0 to confirm. No changes: leave selections unchanged and enter 0."
 }
 
 func accessibleAgentSelectionDescription() string {
-	return "Enter a number to select/deselect an agent. Enter 0 to confirm; press ctrl+c to cancel."
+	return "Enter a number to select/deselect an agent. Enter 0 to confirm."
 }
 
 func agentMenuKeyMap() *huh.KeyMap {

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -1150,6 +1150,26 @@ func TestManageAgentsDescription(t *testing.T) {
 	}
 }
 
+func TestAccessibleAgentDescriptionsDoNotAdvertiseUnsupportedCancelKeys(t *testing.T) {
+	t.Parallel()
+
+	for name, got := range map[string]string{
+		"manage": accessibleManageAgentsDescription(),
+		"setup":  accessibleAgentSelectionDescription(),
+	} {
+		for _, want := range []string{"Enter a number", "Enter 0 to confirm"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("%s accessible description = %q, missing %q", name, got, want)
+			}
+		}
+		for _, wrong := range []string{"q", "esc", "ctrl+c", "cancel"} {
+			if strings.Contains(strings.ToLower(got), wrong) {
+				t.Fatalf("%s accessible description = %q, should not advertise unsupported %q", name, got, wrong)
+			}
+		}
+	}
+}
+
 func TestAgentMenuKeyMapQuitsWithQEscAndCtrlC(t *testing.T) {
 	t.Parallel()
 
@@ -1855,12 +1875,12 @@ func TestManageAgents_AccessiblePromptShowsCancellationGuidance(t *testing.T) {
 	}
 
 	output := buf.String()
-	for _, want := range []string{"Enter 0 to confirm", "ctrl+c to cancel"} {
+	for _, want := range []string{"Enter 0 to confirm", "leave selections unchanged and enter 0"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("accessible agent prompt output = %q, missing %q", output, want)
 		}
 	}
-	for _, wrong := range []string{"q/esc", "esc/ctrl+c"} {
+	for _, wrong := range []string{"q", "esc", "ctrl+c", "cancel"} {
 		if strings.Contains(output, wrong) {
 			t.Fatalf("accessible agent prompt output = %q, should not advertise unsupported %q cancellation", output, wrong)
 		}

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -1128,6 +1128,50 @@ func TestEnableCmd_ForceAndStrategyFlagsOnConfiguredDisabledRepo_ReenablesAndUpd
 
 // Tests for detectOrSelectAgent
 
+func TestAgentSelectionDescription(t *testing.T) {
+	t.Parallel()
+
+	got := agentSelectionDescription()
+	for _, want := range []string{"space", "enter", "q", "esc", "ctrl+c", "cancel"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("agentSelectionDescription() = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestManageAgentsDescription(t *testing.T) {
+	t.Parallel()
+
+	got := manageAgentsDescription()
+	for _, want := range []string{"space", "enter", "q", "esc", "ctrl+c", "cancel", "No changes"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("manageAgentsDescription() = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestAgentMenuKeyMapQuitsWithQEscAndCtrlC(t *testing.T) {
+	t.Parallel()
+
+	quitKeys := agentMenuKeyMap().Quit.Keys()
+	for _, want := range []string{"q", "esc", "ctrl+c"} {
+		if !slices.Contains(quitKeys, want) {
+			t.Fatalf("agent menu quit keys = %v, missing %q", quitKeys, want)
+		}
+	}
+}
+
+func TestStopSessionSelectionDescription(t *testing.T) {
+	t.Parallel()
+
+	got := stopSessionSelectionDescription()
+	for _, want := range []string{"space", "enter", "ctrl+c", "cancel"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stopSessionSelectionDescription() = %q, missing %q", got, want)
+		}
+	}
+}
+
 func TestDetectOrSelectAgent_AgentDetected(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir
 	setupTestRepo(t)
@@ -1767,6 +1811,59 @@ func TestManageAgents_NoChanges(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "No changes made.") {
 		t.Errorf("Expected 'No changes made.' output, got: %s", buf.String())
+	}
+}
+
+func TestManageAgents_AccessiblePromptShowsCancellationGuidance(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir, t.Setenv, and os.Stdin.
+	setupTestRepo(t)
+	t.Setenv("ACCESSIBLE", "1")
+	t.Setenv("ENTIRE_TEST_TTY", "1")
+	writeSettings(t, testSettingsEnabled)
+	writeClaudeHooksFixture(t)
+
+	stdin := os.Stdin
+	r, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = stdin
+		_ = r.Close()
+		_ = pipeW.Close()
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, writeErr := pipeW.WriteString("0\n")
+		closeErr := pipeW.Close()
+		if writeErr != nil {
+			done <- writeErr
+			return
+		}
+		done <- closeErr
+	}()
+
+	var buf bytes.Buffer
+	err = runManageAgents(context.Background(), &buf, EnableOptions{}, nil)
+	if err != nil {
+		t.Fatalf("runManageAgents() error = %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{"Enter 0 to confirm", "ctrl+c to cancel"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("accessible agent prompt output = %q, missing %q", output, want)
+		}
+	}
+	for _, wrong := range []string{"q/esc", "esc/ctrl+c"} {
+		if strings.Contains(output, wrong) {
+			t.Fatalf("accessible agent prompt output = %q, should not advertise unsupported %q cancellation", output, wrong)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Standardize visible quit/back guidance across search, activity, recap, and dispatch TUIs.
- Add targeted agent-menu cancellation keys for normal huh multiselects while keeping text-input `q` behavior intact.
- Add accessible-mode guidance for agent management that matches huh's numeric prompt behavior.

## Verification
- `go test ./cmd/entire/cli -run 'TestManageAgents_AccessiblePromptShowsCancellationGuidance|Test(AgentSelectionDescription|ManageAgentsDescription|AgentMenuKeyMapQuitsWithQEscAndCtrlC)' -count=1`
- `go test ./cmd/entire/cli -run 'Test(SearchModel_|ActivityModel_|DispatchStatusModel_|RecapTUIModel_|AgentSelectionDescription|ManageAgentsDescription|AgentMenuKeyMapQuitsWithQEscAndCtrlC|ManageAgents_AccessiblePromptShowsCancellationGuidance|StopSessionSelectionDescription)' -count=1`
- `mise run lint`
- `printf '0\\n' | ACCESSIBLE=1 ENTIRE_TEST_TTY=1 go run ./cmd/entire agent`

## Known Failure
- `mise run check` fails on existing unrelated `TestExplainCmd_PositionalArgConflictsWithFlags` cases in `cmd/entire/cli/explain_test.go`; no explain files are changed in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX-only changes that adjust keybindings/help text in TUIs and `huh` multiselect prompts; primary risk is minor behavioral regressions in interactive navigation/quit handling.
> 
> **Overview**
> Standardizes visible *exit/cancel* guidance across the `activity`, `recap`, `search`, and `dispatch` TUIs, including showing `q`, `esc`, and `ctrl+c` consistently in loading/error states and footers.
> 
> Refines `search` key handling so `ctrl+c` always quits, `esc` quits only when there’s no browse context (otherwise it backs out of search), and help text distinguishes *exit* (`esc`) from *quit* (`q/ctrl+c`).
> 
> Updates agent-management and session-stop `huh` multiselect prompts to advertise and support `q/esc/ctrl+c` cancellation (while printing accessible-mode numeric guidance), and adds tests to lock in the new behavior/help strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e804b1efe7461df18845052ef026446c046535. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->