### PR TITLE
Improve local test reliability and output

### DIFF
--- a/cmd/entire/cli/activity_cmd_test.go
+++ b/cmd/entire/cli/activity_cmd_test.go
@@ -46,10 +46,15 @@ func TestNormalizeAgentString(t *testing.T) {
 
 func TestGroupCommitsByDay_SortsNewestFirst(t *testing.T) {
 	t.Parallel()
+
+	localDate := func(year int, month time.Month, day int) *string {
+		return strPtr(time.Date(year, month, day, 12, 0, 0, 0, time.Local).Format(time.RFC3339))
+	}
+
 	commits := []userCommit{
-		{CommitSHA: "aaa", CommitDate: strPtr("2026-01-10T12:00:00Z")},
-		{CommitSHA: "bbb", CommitDate: strPtr("2026-01-12T08:00:00Z")},
-		{CommitSHA: "ccc", CommitDate: strPtr("2026-01-11T15:00:00Z")},
+		{CommitSHA: "aaa", CommitDate: localDate(2026, time.January, 10)},
+		{CommitSHA: "bbb", CommitDate: localDate(2026, time.January, 12)},
+		{CommitSHA: "ccc", CommitDate: localDate(2026, time.January, 11)},
 	}
 	days := groupCommitsByDay(commits)
 

--- a/cmd/entire/cli/auth/store.go
+++ b/cmd/entire/cli/auth/store.go
@@ -26,15 +26,19 @@ type Store struct {
 
 // NewStore returns a Store backed by the system keyring.
 func NewStore() *Store {
+	return newStoreWithService(keyringService)
+}
+
+func newStoreWithService(service string) *Store {
 	return &Store{
-		service:       keyringService,
+		service:       service,
 		testStoreFile: os.Getenv(testAuthStoreFileEnv),
 	}
 }
 
 // NewStoreWithService returns a Store with a custom keyring service name (for testing).
 func NewStoreWithService(service string) *Store {
-	return &Store{service: service}
+	return newStoreWithService(service)
 }
 
 // SaveToken persists an access token for the given base URL.
@@ -170,6 +174,9 @@ func (s *Store) writeTokenFile(tokens map[string]map[string]string) error {
 	}
 	if err := os.WriteFile(s.testStoreFile, data, 0o600); err != nil {
 		return fmt.Errorf("write test auth store: %w", err)
+	}
+	if err := os.Chmod(s.testStoreFile, 0o600); err != nil {
+		return fmt.Errorf("restrict test auth store permissions: %w", err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/auth/store.go
+++ b/cmd/entire/cli/auth/store.go
@@ -1,44 +1,52 @@
 package auth
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/zalando/go-keyring"
 )
 
-const (
-	keyringService       = "entire-cli"
-	testAuthStoreFileEnv = "ENTIRE_TEST_AUTH_STORE_FILE"
-)
+const keyringService = "entire-cli"
 
-// Store manages CLI authentication tokens. Production uses the OS keyring;
-// subprocess tests can opt into a file-backed store with testAuthStoreFileEnv.
+// Store manages CLI authentication tokens via a pluggable backend. The
+// production binary always resolves to the OS keyring. A file-backed
+// backend is available only in builds tagged `authfilestore` (used by
+// integration tests to avoid the OS keychain).
 type Store struct {
-	service       string
-	testStoreFile string
+	service string
+	backend tokenBackend
 }
 
-// NewStore returns a Store backed by the system keyring.
+// tokenBackend abstracts token persistence. Implementations must treat
+// "missing key" as a non-error: get returns ("", nil) and delete is a
+// no-op so callers don't have to plumb backend-specific sentinels.
+type tokenBackend interface {
+	save(service, key, value string) error
+	get(service, key string) (string, error)
+	delete(service, key string) error
+}
+
+// chooseBackend returns the backend used by NewStore and
+// NewStoreWithService. The default returns the keyring backend; the
+// `authfilestore` build adds an init() that may swap in a file-backed
+// backend when the test env var is set.
+var chooseBackend = func() tokenBackend { return keyringBackend{} }
+
+// NewStore returns a Store backed by the system keyring (or, in
+// `authfilestore` builds, optionally a file-backed test store).
 func NewStore() *Store {
-	return newStoreWithService(keyringService)
-}
-
-func newStoreWithService(service string) *Store {
-	return &Store{
-		service:       service,
-		testStoreFile: os.Getenv(testAuthStoreFileEnv),
-	}
+	return &Store{service: keyringService, backend: chooseBackend()}
 }
 
 // NewStoreWithService returns a Store with a custom keyring service name (for testing).
+// Honors the same backend selection as NewStore so tests that opt into the
+// file-backed test store via env var see consistent behavior across both
+// constructors.
 func NewStoreWithService(service string) *Store {
-	return newStoreWithService(service)
+	return &Store{service: service, backend: chooseBackend()}
 }
 
 // SaveToken persists an access token for the given base URL.
@@ -47,51 +55,19 @@ func (s *Store) SaveToken(baseURL, token string) error {
 	if token == "" {
 		return errors.New("refusing to save empty token")
 	}
-
-	if s.testStoreFile != "" {
-		return s.saveTokenToFile(baseURL, token)
-	}
-
-	if err := keyring.Set(s.service, baseURL, token); err != nil {
-		return fmt.Errorf("save token to keyring: %w", err)
-	}
-
-	return nil
+	return s.backend.save(s.service, baseURL, token)
 }
 
 // GetToken retrieves a stored token for the given base URL.
 // Returns an empty string (and no error) if no token is stored.
 func (s *Store) GetToken(baseURL string) (string, error) {
-	if s.testStoreFile != "" {
-		return s.getTokenFromFile(baseURL)
-	}
-
-	token, err := keyring.Get(s.service, baseURL)
-	if errors.Is(err, keyring.ErrNotFound) {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("get token from keyring: %w", err)
-	}
-
-	return token, nil
+	return s.backend.get(s.service, baseURL)
 }
 
 // DeleteToken removes a stored token for the given base URL.
+// Returns no error if the token does not exist.
 func (s *Store) DeleteToken(baseURL string) error {
-	if s.testStoreFile != "" {
-		return s.deleteTokenFromFile(baseURL)
-	}
-
-	err := keyring.Delete(s.service, baseURL)
-	if errors.Is(err, keyring.ErrNotFound) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("delete token from keyring: %w", err)
-	}
-
-	return nil
+	return s.backend.delete(s.service, baseURL)
 }
 
 // LookupCurrentToken retrieves the token for the current base URL.
@@ -100,83 +76,33 @@ func LookupCurrentToken() (string, error) {
 	return store.GetToken(api.BaseURL())
 }
 
-func (s *Store) saveTokenToFile(baseURL, token string) error {
-	tokens, err := s.readTokenFile()
-	if err != nil {
-		return err
-	}
+type keyringBackend struct{}
 
-	serviceTokens := tokens[s.service]
-	if serviceTokens == nil {
-		serviceTokens = make(map[string]string)
-		tokens[s.service] = serviceTokens
-	}
-	serviceTokens[baseURL] = token
-
-	if err := s.writeTokenFile(tokens); err != nil {
-		return err
+func (keyringBackend) save(service, key, value string) error {
+	if err := keyring.Set(service, key, value); err != nil {
+		return fmt.Errorf("save token to keyring: %w", err)
 	}
 	return nil
 }
 
-func (s *Store) getTokenFromFile(baseURL string) (string, error) {
-	tokens, err := s.readTokenFile()
-	if err != nil {
-		return "", err
+func (keyringBackend) get(service, key string) (string, error) {
+	token, err := keyring.Get(service, key)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return "", nil
 	}
-	return tokens[s.service][baseURL], nil
+	if err != nil {
+		return "", fmt.Errorf("get token from keyring: %w", err)
+	}
+	return token, nil
 }
 
-func (s *Store) deleteTokenFromFile(baseURL string) error {
-	tokens, err := s.readTokenFile()
-	if err != nil {
-		return err
-	}
-	if serviceTokens := tokens[s.service]; serviceTokens != nil {
-		delete(serviceTokens, baseURL)
-		if len(serviceTokens) == 0 {
-			delete(tokens, s.service)
-		}
-	}
-	return s.writeTokenFile(tokens)
-}
-
-func (s *Store) readTokenFile() (map[string]map[string]string, error) {
-	data, err := os.ReadFile(s.testStoreFile)
-	if errors.Is(err, os.ErrNotExist) {
-		return make(map[string]map[string]string), nil
+func (keyringBackend) delete(service, key string) error {
+	err := keyring.Delete(service, key)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("read test auth store: %w", err)
-	}
-	if len(data) == 0 {
-		return make(map[string]map[string]string), nil
-	}
-
-	var tokens map[string]map[string]string
-	if err := json.Unmarshal(data, &tokens); err != nil {
-		return nil, fmt.Errorf("parse test auth store: %w", err)
-	}
-	if tokens == nil {
-		tokens = make(map[string]map[string]string)
-	}
-	return tokens, nil
-}
-
-func (s *Store) writeTokenFile(tokens map[string]map[string]string) error {
-	if err := os.MkdirAll(filepath.Dir(s.testStoreFile), 0o700); err != nil {
-		return fmt.Errorf("create test auth store directory: %w", err)
-	}
-
-	data, err := json.Marshal(tokens)
-	if err != nil {
-		return fmt.Errorf("marshal test auth store: %w", err)
-	}
-	if err := os.WriteFile(s.testStoreFile, data, 0o600); err != nil {
-		return fmt.Errorf("write test auth store: %w", err)
-	}
-	if err := os.Chmod(s.testStoreFile, 0o600); err != nil {
-		return fmt.Errorf("restrict test auth store permissions: %w", err)
+		return fmt.Errorf("delete token from keyring: %w", err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/auth/store.go
+++ b/cmd/entire/cli/auth/store.go
@@ -1,24 +1,35 @@
 package auth
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/zalando/go-keyring"
 )
 
-const keyringService = "entire-cli"
+const (
+	keyringService       = "entire-cli"
+	testAuthStoreFileEnv = "ENTIRE_TEST_AUTH_STORE_FILE"
+)
 
-// Store manages CLI authentication tokens in the OS keyring.
+// Store manages CLI authentication tokens. Production uses the OS keyring;
+// subprocess tests can opt into a file-backed store with testAuthStoreFileEnv.
 type Store struct {
-	service string
+	service       string
+	testStoreFile string
 }
 
 // NewStore returns a Store backed by the system keyring.
 func NewStore() *Store {
-	return &Store{service: keyringService}
+	return &Store{
+		service:       keyringService,
+		testStoreFile: os.Getenv(testAuthStoreFileEnv),
+	}
 }
 
 // NewStoreWithService returns a Store with a custom keyring service name (for testing).
@@ -33,6 +44,10 @@ func (s *Store) SaveToken(baseURL, token string) error {
 		return errors.New("refusing to save empty token")
 	}
 
+	if s.testStoreFile != "" {
+		return s.saveTokenToFile(baseURL, token)
+	}
+
 	if err := keyring.Set(s.service, baseURL, token); err != nil {
 		return fmt.Errorf("save token to keyring: %w", err)
 	}
@@ -43,6 +58,10 @@ func (s *Store) SaveToken(baseURL, token string) error {
 // GetToken retrieves a stored token for the given base URL.
 // Returns an empty string (and no error) if no token is stored.
 func (s *Store) GetToken(baseURL string) (string, error) {
+	if s.testStoreFile != "" {
+		return s.getTokenFromFile(baseURL)
+	}
+
 	token, err := keyring.Get(s.service, baseURL)
 	if errors.Is(err, keyring.ErrNotFound) {
 		return "", nil
@@ -56,6 +75,10 @@ func (s *Store) GetToken(baseURL string) (string, error) {
 
 // DeleteToken removes a stored token for the given base URL.
 func (s *Store) DeleteToken(baseURL string) error {
+	if s.testStoreFile != "" {
+		return s.deleteTokenFromFile(baseURL)
+	}
+
 	err := keyring.Delete(s.service, baseURL)
 	if errors.Is(err, keyring.ErrNotFound) {
 		return nil
@@ -71,4 +94,82 @@ func (s *Store) DeleteToken(baseURL string) error {
 func LookupCurrentToken() (string, error) {
 	store := NewStore()
 	return store.GetToken(api.BaseURL())
+}
+
+func (s *Store) saveTokenToFile(baseURL, token string) error {
+	tokens, err := s.readTokenFile()
+	if err != nil {
+		return err
+	}
+
+	serviceTokens := tokens[s.service]
+	if serviceTokens == nil {
+		serviceTokens = make(map[string]string)
+		tokens[s.service] = serviceTokens
+	}
+	serviceTokens[baseURL] = token
+
+	if err := s.writeTokenFile(tokens); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Store) getTokenFromFile(baseURL string) (string, error) {
+	tokens, err := s.readTokenFile()
+	if err != nil {
+		return "", err
+	}
+	return tokens[s.service][baseURL], nil
+}
+
+func (s *Store) deleteTokenFromFile(baseURL string) error {
+	tokens, err := s.readTokenFile()
+	if err != nil {
+		return err
+	}
+	if serviceTokens := tokens[s.service]; serviceTokens != nil {
+		delete(serviceTokens, baseURL)
+		if len(serviceTokens) == 0 {
+			delete(tokens, s.service)
+		}
+	}
+	return s.writeTokenFile(tokens)
+}
+
+func (s *Store) readTokenFile() (map[string]map[string]string, error) {
+	data, err := os.ReadFile(s.testStoreFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return make(map[string]map[string]string), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read test auth store: %w", err)
+	}
+	if len(data) == 0 {
+		return make(map[string]map[string]string), nil
+	}
+
+	var tokens map[string]map[string]string
+	if err := json.Unmarshal(data, &tokens); err != nil {
+		return nil, fmt.Errorf("parse test auth store: %w", err)
+	}
+	if tokens == nil {
+		tokens = make(map[string]map[string]string)
+	}
+	return tokens, nil
+}
+
+func (s *Store) writeTokenFile(tokens map[string]map[string]string) error {
+	if err := os.MkdirAll(filepath.Dir(s.testStoreFile), 0o700); err != nil {
+		return fmt.Errorf("create test auth store directory: %w", err)
+	}
+
+	data, err := json.Marshal(tokens)
+	if err != nil {
+		return fmt.Errorf("marshal test auth store: %w", err)
+	}
+	if err := os.WriteFile(s.testStoreFile, data, 0o600); err != nil {
+		return fmt.Errorf("write test auth store: %w", err)
+	}
+	return nil
 }

--- a/cmd/entire/cli/auth/store_filebackend.go
+++ b/cmd/entire/cli/auth/store_filebackend.go
@@ -1,0 +1,116 @@
+//go:build authfilestore
+
+// File-backed auth store backend. Compiled only under the `authfilestore`
+// build tag, which is enabled by:
+//   - the integration test subprocess build (cmd/entire/cli/integration_test/setup_test.go)
+//   - test:integration / test:ci tasks (mise.toml) for running this package's
+//     tagged tests
+//
+// Production builds (no tag) do not include this file, so the env var below
+// has no effect outside test environments.
+
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// testAuthStoreFileEnv, when set, redirects token storage to a JSON file at
+// the given path instead of the OS keyring. Only honored in `authfilestore`
+// builds.
+const testAuthStoreFileEnv = "ENTIRE_TEST_AUTH_STORE_FILE"
+
+func init() {
+	chooseBackend = func() tokenBackend {
+		if path := os.Getenv(testAuthStoreFileEnv); path != "" {
+			return &fileBackend{path: path}
+		}
+		return keyringBackend{}
+	}
+}
+
+type fileBackend struct {
+	path string
+}
+
+func (b *fileBackend) save(service, key, value string) error {
+	tokens, err := b.read()
+	if err != nil {
+		return err
+	}
+	svc := tokens[service]
+	if svc == nil {
+		svc = make(map[string]string)
+		tokens[service] = svc
+	}
+	svc[key] = value
+	return b.write(tokens)
+}
+
+func (b *fileBackend) get(service, key string) (string, error) {
+	tokens, err := b.read()
+	if err != nil {
+		return "", err
+	}
+	return tokens[service][key], nil
+}
+
+func (b *fileBackend) delete(service, key string) error {
+	tokens, err := b.read()
+	if err != nil {
+		return err
+	}
+	if svc := tokens[service]; svc != nil {
+		delete(svc, key)
+		if len(svc) == 0 {
+			delete(tokens, service)
+		}
+	}
+	return b.write(tokens)
+}
+
+func (b *fileBackend) read() (map[string]map[string]string, error) {
+	data, err := os.ReadFile(b.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return make(map[string]map[string]string), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read test auth store: %w", err)
+	}
+	if len(data) == 0 {
+		return make(map[string]map[string]string), nil
+	}
+
+	var tokens map[string]map[string]string
+	if err := json.Unmarshal(data, &tokens); err != nil {
+		return nil, fmt.Errorf("parse test auth store: %w", err)
+	}
+	if tokens == nil {
+		tokens = make(map[string]map[string]string)
+	}
+	return tokens, nil
+}
+
+func (b *fileBackend) write(tokens map[string]map[string]string) error {
+	if err := os.MkdirAll(filepath.Dir(b.path), 0o700); err != nil {
+		return fmt.Errorf("create test auth store directory: %w", err)
+	}
+	data, err := json.Marshal(tokens)
+	if err != nil {
+		return fmt.Errorf("marshal test auth store: %w", err)
+	}
+	if err := os.WriteFile(b.path, data, 0o600); err != nil {
+		return fmt.Errorf("write test auth store: %w", err)
+	}
+	// os.WriteFile preserves an existing file's permission bits, so an
+	// already-broad file (e.g. 0o644 from an earlier test setup) would
+	// keep those bits. Force 0o600 to make the post-condition unconditional.
+	if err := os.Chmod(b.path, 0o600); err != nil {
+		return fmt.Errorf("restrict test auth store permissions: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/auth/store_filebackend_test.go
+++ b/cmd/entire/cli/auth/store_filebackend_test.go
@@ -1,0 +1,69 @@
+//go:build authfilestore
+
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewStore_UsesTestStoreFile(t *testing.T) {
+	storeFile := filepath.Join(t.TempDir(), "auth-store.json")
+	t.Setenv(testAuthStoreFileEnv, storeFile)
+
+	store := NewStore()
+	if err := store.SaveToken("http://localhost:8787", "  file-token  "); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+
+	otherProcessStore := NewStore()
+	got, err := otherProcessStore.GetToken("http://localhost:8787")
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got != "file-token" {
+		t.Fatalf("GetToken() = %q, want %q", got, "file-token")
+	}
+
+	info, err := os.Stat(storeFile)
+	if err != nil {
+		t.Fatalf("stat store file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("store file mode = %v, want 0600", got)
+	}
+}
+
+func TestNewStoreWithService_UsesTestStoreFileAndRestrictsExistingFile(t *testing.T) {
+	storeFile := filepath.Join(t.TempDir(), "auth-store.json")
+	t.Setenv(testAuthStoreFileEnv, storeFile)
+	if err := os.WriteFile(storeFile, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("precreate store file: %v", err)
+	}
+	if err := os.Chmod(storeFile, 0o644); err != nil {
+		t.Fatalf("set broad store file permissions: %v", err)
+	}
+
+	store := NewStoreWithService("custom-service")
+	if err := store.SaveToken("http://localhost:8787", "service-token"); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+
+	otherProcessStore := NewStoreWithService("custom-service")
+	got, err := otherProcessStore.GetToken("http://localhost:8787")
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got != "service-token" {
+		t.Fatalf("GetToken() = %q, want %q", got, "service-token")
+	}
+
+	info, err := os.Stat(storeFile)
+	if err != nil {
+		t.Fatalf("stat store file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("store file mode = %v, want 0600", got)
+	}
+}

--- a/cmd/entire/cli/auth/store_invariants_test.go
+++ b/cmd/entire/cli/auth/store_invariants_test.go
@@ -1,0 +1,89 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestProductionAuthStoreIsKeyringOnly enforces that the file-backed auth
+// store backend stays fully gated behind //go:build authfilestore. The
+// production CLI binary (no build tag) must not contain code that reads
+// the test env var or persists tokens to disk — otherwise an end user
+// can flip the variable in their shell and silently bypass the OS
+// keyring.
+//
+// This runs as part of the regular (untagged) test suite, so any new
+// production-compiled .go file in this package that mentions the
+// forbidden symbols will fail CI immediately. The remediation is to
+// move the offending code into a //go:build authfilestore file
+// alongside store_filebackend.go.
+func TestProductionAuthStoreIsKeyringOnly(t *testing.T) {
+	t.Parallel()
+
+	// Symbols that may only appear in authfilestore-tagged files.
+	// Keep this list tight — these are the load-bearing markers of
+	// "we are persisting auth tokens to a file from production code".
+	forbidden := []string{
+		"ENTIRE_TEST_AUTH_STORE_FILE", // the test env-var hook
+		"os.WriteFile",                // token-on-disk write
+		"os.ReadFile",                 // token-on-disk read
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("readdir auth pkg: %v", err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// _test.go files are never in the production binary, so they
+		// cannot reintroduce the file backend regardless of contents.
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		src := string(data)
+
+		if hasAuthFileStoreBuildTag(src) {
+			continue
+		}
+
+		for _, sym := range forbidden {
+			if strings.Contains(src, sym) {
+				t.Errorf(
+					"%s references %q outside a //go:build authfilestore file. "+
+						"File-backed auth storage must stay gated so production "+
+						"builds cannot opt into it. Move this code into a tagged "+
+						"file (see store_filebackend.go).",
+					name, sym,
+				)
+			}
+		}
+	}
+}
+
+// hasAuthFileStoreBuildTag reports whether the file's build constraint
+// requires the authfilestore tag. Build constraints must appear before
+// the package clause, so we only scan up to that point.
+func hasAuthFileStoreBuildTag(src string) bool {
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "package ") {
+			return false
+		}
+		if strings.HasPrefix(trimmed, "//go:build ") &&
+			strings.Contains(trimmed, "authfilestore") {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/auth/store_test.go
+++ b/cmd/entire/cli/auth/store_test.go
@@ -176,3 +176,36 @@ func TestNewStore_UsesTestStoreFile(t *testing.T) {
 		t.Fatalf("store file mode = %v, want 0600", got)
 	}
 }
+
+func TestNewStoreWithService_UsesTestStoreFileAndRestrictsExistingFile(t *testing.T) {
+	storeFile := filepath.Join(t.TempDir(), "auth-store.json")
+	t.Setenv(testAuthStoreFileEnv, storeFile)
+	if err := os.WriteFile(storeFile, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("precreate store file: %v", err)
+	}
+	if err := os.Chmod(storeFile, 0o644); err != nil {
+		t.Fatalf("set broad store file permissions: %v", err)
+	}
+
+	store := NewStoreWithService("custom-service")
+	if err := store.SaveToken("http://localhost:8787", "service-token"); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+
+	otherProcessStore := NewStoreWithService("custom-service")
+	got, err := otherProcessStore.GetToken("http://localhost:8787")
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got != "service-token" {
+		t.Fatalf("GetToken() = %q, want %q", got, "service-token")
+	}
+
+	info, err := os.Stat(storeFile)
+	if err != nil {
+		t.Fatalf("stat store file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("store file mode = %v, want 0600", got)
+	}
+}

--- a/cmd/entire/cli/auth/store_test.go
+++ b/cmd/entire/cli/auth/store_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -146,5 +147,32 @@ func TestLookupCurrentToken(t *testing.T) {
 	}
 	if got != "local-token" {
 		t.Fatalf("LookupCurrentToken() = %q, want %q", got, "local-token")
+	}
+}
+
+func TestNewStore_UsesTestStoreFile(t *testing.T) {
+	storeFile := filepath.Join(t.TempDir(), "auth-store.json")
+	t.Setenv(testAuthStoreFileEnv, storeFile)
+
+	store := NewStore()
+	if err := store.SaveToken("http://localhost:8787", "  file-token  "); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+
+	otherProcessStore := NewStore()
+	got, err := otherProcessStore.GetToken("http://localhost:8787")
+	if err != nil {
+		t.Fatalf("GetToken() error = %v", err)
+	}
+	if got != "file-token" {
+		t.Fatalf("GetToken() = %q, want %q", got, "file-token")
+	}
+
+	info, err := os.Stat(storeFile)
+	if err != nil {
+		t.Fatalf("stat store file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("store file mode = %v, want 0600", got)
 	}
 }

--- a/cmd/entire/cli/auth/store_test.go
+++ b/cmd/entire/cli/auth/store_test.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -147,65 +146,5 @@ func TestLookupCurrentToken(t *testing.T) {
 	}
 	if got != "local-token" {
 		t.Fatalf("LookupCurrentToken() = %q, want %q", got, "local-token")
-	}
-}
-
-func TestNewStore_UsesTestStoreFile(t *testing.T) {
-	storeFile := filepath.Join(t.TempDir(), "auth-store.json")
-	t.Setenv(testAuthStoreFileEnv, storeFile)
-
-	store := NewStore()
-	if err := store.SaveToken("http://localhost:8787", "  file-token  "); err != nil {
-		t.Fatalf("SaveToken() error = %v", err)
-	}
-
-	otherProcessStore := NewStore()
-	got, err := otherProcessStore.GetToken("http://localhost:8787")
-	if err != nil {
-		t.Fatalf("GetToken() error = %v", err)
-	}
-	if got != "file-token" {
-		t.Fatalf("GetToken() = %q, want %q", got, "file-token")
-	}
-
-	info, err := os.Stat(storeFile)
-	if err != nil {
-		t.Fatalf("stat store file: %v", err)
-	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("store file mode = %v, want 0600", got)
-	}
-}
-
-func TestNewStoreWithService_UsesTestStoreFileAndRestrictsExistingFile(t *testing.T) {
-	storeFile := filepath.Join(t.TempDir(), "auth-store.json")
-	t.Setenv(testAuthStoreFileEnv, storeFile)
-	if err := os.WriteFile(storeFile, []byte(`{}`), 0o644); err != nil {
-		t.Fatalf("precreate store file: %v", err)
-	}
-	if err := os.Chmod(storeFile, 0o644); err != nil {
-		t.Fatalf("set broad store file permissions: %v", err)
-	}
-
-	store := NewStoreWithService("custom-service")
-	if err := store.SaveToken("http://localhost:8787", "service-token"); err != nil {
-		t.Fatalf("SaveToken() error = %v", err)
-	}
-
-	otherProcessStore := NewStoreWithService("custom-service")
-	got, err := otherProcessStore.GetToken("http://localhost:8787")
-	if err != nil {
-		t.Fatalf("GetToken() error = %v", err)
-	}
-	if got != "service-token" {
-		t.Fatalf("GetToken() = %q, want %q", got, "service-token")
-	}
-
-	info, err := os.Stat(storeFile)
-	if err != nil {
-		t.Fatalf("stat store file: %v", err)
-	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("store file mode = %v, want 0600", got)
 	}
 }

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -202,6 +203,7 @@ func runLoginProcess(t *testing.T, apiBaseURL string) *loginProcess {
 		"ENTIRE_TEST_GEMINI_PROJECT_DIR="+env.GeminiProjectDir,
 		"ENTIRE_TEST_OPENCODE_PROJECT_DIR="+env.OpenCodeProjectDir,
 		"ENTIRE_API_BASE_URL="+apiBaseURL,
+		"ENTIRE_TEST_AUTH_STORE_FILE="+filepath.Join(env.RepoDir, ".entire-test-auth-store.json"),
 	)
 
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/cmd/entire/cli/integration_test/setup_cmd_test.go
+++ b/cmd/entire/cli/integration_test/setup_cmd_test.go
@@ -3,13 +3,14 @@
 package integration
 
 import (
+	"context"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/execx"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
@@ -21,7 +22,7 @@ func (env *TestEnv) RunEnableWithAccessibleMode() string {
 
 	// Run CLI with ACCESSIBLE=1 for non-interactive prompts
 	// Provide "no" for telemetry
-	cmd := exec.Command(getTestBinary(), "enable")
+	cmd := execx.NonInteractive(context.Background(), getTestBinary(), "enable")
 	cmd.Dir = env.RepoDir
 	cmd.Env = append(env.cliEnv(), "ACCESSIBLE=1")
 	// Provide input for telemetry prompt

--- a/cmd/entire/cli/integration_test/setup_test.go
+++ b/cmd/entire/cli/integration_test/setup_test.go
@@ -22,7 +22,10 @@ func TestMain(m *testing.M) {
 	testBinaryPath = filepath.Join(tmpDir, "entire")
 
 	moduleRoot := findModuleRoot()
-	buildCmd := exec.Command("go", "build", "-o", testBinaryPath, ".")
+	// -tags=authfilestore enables the file-backed auth store backend so the
+	// subprocess can opt into ENTIRE_TEST_AUTH_STORE_FILE instead of touching
+	// the real OS keychain. Production builds omit this tag.
+	buildCmd := exec.Command("go", "build", "-tags=authfilestore", "-o", testBinaryPath, ".")
 	buildCmd.Dir = filepath.Join(moduleRoot, "cmd", "entire")
 
 	buildOutput, err := buildCmd.CombinedOutput()

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 
 	"charm.land/huh/v2"
@@ -617,7 +618,7 @@ func composeMultiAgentSinks(in multiAgentSinkInputs) []reviewtypes.Sink {
 		return []reviewtypes.Sink{DumpSink{W: in.out}}
 	}
 	sinks := []reviewtypes.Sink{
-		NewTUISink(in.agentNames, in.cancelRun, in.out),
+		NewTUISink(in.agentNames, in.cancelRun, in.out, os.Stdin),
 		DumpSink{W: in.out},
 	}
 	if in.synthesisProvider != nil && in.canPrompt {
@@ -667,7 +668,7 @@ func composeSingleAgentSinks(in singleAgentSinkInputs) []reviewtypes.Sink {
 		return []reviewtypes.Sink{DumpSink{W: in.out}}
 	}
 	return []reviewtypes.Sink{
-		NewTUISink([]string{in.agentName}, in.cancelRun, in.out),
+		NewTUISink([]string{in.agentName}, in.cancelRun, in.out, os.Stdin),
 		DumpSink{W: in.out},
 	}
 }

--- a/cmd/entire/cli/review/multipicker.go
+++ b/cmd/entire/cli/review/multipicker.go
@@ -48,6 +48,9 @@ func PickAgents(ctx context.Context, eligible []AgentChoice) (PickedAgents, erro
 	if len(eligible) < 2 {
 		return PickedAgents{}, fmt.Errorf("PickAgents requires at least 2 eligible agents, got %d", len(eligible))
 	}
+	if ctx.Err() != nil {
+		return PickedAgents{}, ErrPickerCancelled
+	}
 
 	// Sort alphabetically for stable display order regardless of how the
 	// caller populated the slice.

--- a/cmd/entire/cli/review/tui_sink.go
+++ b/cmd/entire/cli/review/tui_sink.go
@@ -45,16 +45,20 @@ var _ reviewtypes.Sink = (*TUISink)(nil)
 // the ordered list of agent names that will run; the dashboard pre-renders one
 // row per agent so the user sees the full run shape from the first frame.
 // output is the writer the Bubble Tea program renders into (typically
-// cmd.OutOrStdout()).
+// cmd.OutOrStdout()). input is the reader Bubble Tea reads keypresses from
+// (typically os.Stdin in production); tests must pass a non-TTY reader (e.g.
+// bytes.NewReader(nil)) so Bubble Tea does not put the inherited terminal
+// into raw mode and corrupt sibling test output.
 //
 // tea.WithoutSignalHandler keeps SIGINT routing on the cobra root's existing
 // handler (which cancels the run context), so the TUI's KeyCtrlC path and the
 // OS signal path share a single cancel function with no race.
-func NewTUISink(agents []string, cancel context.CancelFunc, output io.Writer) *TUISink {
+func NewTUISink(agents []string, cancel context.CancelFunc, output io.Writer, input io.Reader) *TUISink {
 	model := newReviewTUIModel(agents, cancel)
 	prog := tea.NewProgram(
 		model,
 		tea.WithOutput(output),
+		tea.WithInput(input),
 		tea.WithoutSignalHandler(), // SIGINT handled by cobra root; KeyCtrlC calls cancel directly
 	)
 	return &TUISink{

--- a/cmd/entire/cli/review/tui_sink_test.go
+++ b/cmd/entire/cli/review/tui_sink_test.go
@@ -40,7 +40,7 @@ func finishAndDismissTUI(t *testing.T, sink *TUISink, summary reviewtypes.RunSum
 func TestTUISink_StartIsIdempotent(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf)
+	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf, bytes.NewReader(nil))
 
 	// Start twice — the second call must be a no-op (no panic, no deadlock).
 	sink.Start()
@@ -69,7 +69,7 @@ func TestTUISink_StartIsIdempotent(t *testing.T) {
 func TestTUISink_WaitBeforeStart_IsNoOp(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf)
+	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf, bytes.NewReader(nil))
 
 	done := make(chan struct{})
 	go func() {
@@ -90,7 +90,7 @@ func TestTUISink_WaitBeforeStart_IsNoOp(t *testing.T) {
 func TestTUISink_AgentEvent_BeforeStart_IsNoOp(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf)
+	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf, bytes.NewReader(nil))
 
 	// Must not panic.
 	sink.AgentEvent("agent-a", reviewtypes.Started{})
@@ -102,7 +102,7 @@ func TestTUISink_AgentEvent_BeforeStart_IsNoOp(t *testing.T) {
 func TestTUISink_RunFinished_EventuallyUnblocks(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf)
+	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf, bytes.NewReader(nil))
 	sink.Start()
 
 	// Send some events before finishing.
@@ -122,7 +122,7 @@ func TestTUISink_RunFinished_EventuallyUnblocks(t *testing.T) {
 func TestTUISink_RunFinished_AfterSecondCall_IsNoOp(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf)
+	sink := NewTUISink([]string{"agent-a"}, func() {}, &buf, bytes.NewReader(nil))
 	sink.Start()
 
 	// First RunFinished should unblock the program.
@@ -148,5 +148,5 @@ func TestTUISink_RunFinished_AfterSecondCall_IsNoOp(t *testing.T) {
 func TestTUISink_ImplementsSink(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	var _ reviewtypes.Sink = NewTUISink(nil, func() {}, &buf)
+	var _ reviewtypes.Sink = NewTUISink(nil, func() {}, &buf, bytes.NewReader(nil))
 }

--- a/cmd/entire/cli/review/tui_sink_test.go
+++ b/cmd/entire/cli/review/tui_sink_test.go
@@ -97,18 +97,8 @@ func TestTUISink_AgentEvent_BeforeStart_IsNoOp(t *testing.T) {
 	sink.AgentEvent("agent-a", reviewtypes.AssistantText{Text: "hello"})
 }
 
-// TestTUISink_RunFinished_UnblockAfterQuit verifies that RunFinished unblocks
-// when the Bubble Tea program receives a quit (sent via the model's any-key
-// handler after finished=true).
-//
-// We cannot easily drive keystrokes into the Bubble Tea program in a unit
-// test without a real terminal, so we trigger the quit path by sending
-// RunFinished which sets finished=true in the model, then the program exits
-// on the first internal message that causes tea.Quit.
-//
-// In practice: after RunFinished is sent, the program sets finished=true and
-// the next tick or key press causes Quit. Since we're not in a TTY environment
-// here the program exits quickly because it can't read from stdin.
+// TestTUISink_RunFinished_EventuallyUnblocks verifies that RunFinished unblocks
+// once the finished TUI receives the same any-key dismissal used by a user.
 func TestTUISink_RunFinished_EventuallyUnblocks(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer

--- a/cmd/entire/cli/review/tui_sink_test.go
+++ b/cmd/entire/cli/review/tui_sink_test.go
@@ -5,8 +5,35 @@ import (
 	"testing"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
+
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
+
+func finishAndDismissTUI(t *testing.T, sink *TUISink, summary reviewtypes.RunSummary) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		sink.RunFinished(summary)
+		close(done)
+	}()
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			sink.program.Send(tea.KeyPressMsg(tea.Key{Code: 'x', Text: "x"}))
+		case <-timeout:
+			t.Fatal("RunFinished() did not return within 10 seconds")
+		}
+	}
+}
 
 // TestTUISink_StartIsIdempotent verifies that calling Start multiple times
 // does not panic or spawn extra goroutines.
@@ -20,7 +47,7 @@ func TestTUISink_StartIsIdempotent(t *testing.T) {
 	sink.Start()
 
 	// Clean up: send RunFinished so the program exits, then Wait.
-	sink.RunFinished(reviewtypes.RunSummary{})
+	finishAndDismissTUI(t, sink, reviewtypes.RunSummary{})
 
 	// Wait with a timeout to avoid hanging the test suite on failure.
 	done := make(chan struct{})
@@ -93,22 +120,11 @@ func TestTUISink_RunFinished_EventuallyUnblocks(t *testing.T) {
 	sink.AgentEvent("agent-a", reviewtypes.AssistantText{Text: "reviewing…"})
 	sink.AgentEvent("agent-a", reviewtypes.Finished{Success: true})
 
-	done := make(chan struct{})
-	go func() {
-		sink.RunFinished(reviewtypes.RunSummary{
-			AgentRuns: []reviewtypes.AgentRun{
-				{Name: "agent-a", Status: reviewtypes.AgentStatusSucceeded},
-			},
-		})
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// OK — RunFinished returned (program exited).
-	case <-time.After(10 * time.Second):
-		t.Fatal("RunFinished() did not return within 10 seconds")
-	}
+	finishAndDismissTUI(t, sink, reviewtypes.RunSummary{
+		AgentRuns: []reviewtypes.AgentRun{
+			{Name: "agent-a", Status: reviewtypes.AgentStatusSucceeded},
+		},
+	})
 }
 
 // TestTUISink_RunFinished_AfterSecondCall_IsNoOp verifies that calling
@@ -120,17 +136,7 @@ func TestTUISink_RunFinished_AfterSecondCall_IsNoOp(t *testing.T) {
 	sink.Start()
 
 	// First RunFinished should unblock the program.
-	done := make(chan struct{})
-	go func() {
-		sink.RunFinished(reviewtypes.RunSummary{})
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("first RunFinished did not return in time")
-	}
+	finishAndDismissTUI(t, sink, reviewtypes.RunSummary{})
 
 	// Second call should return immediately (no-op after finished=true).
 	secondDone := make(chan struct{})

--- a/cmd/entire/cli/setup_github.go
+++ b/cmd/entire/cli/setup_github.go
@@ -488,7 +488,7 @@ func resolveRepoName(ctx context.Context, w, errW io.Writer, runner bootstrapRun
 					Description(fmt.Sprintf("Press enter to use %q", name)).
 					Value(&input),
 			),
-		)
+		).WithOutput(w)
 		if err := form.Run(); err != nil {
 			if errors.Is(err, huh.ErrUserAborted) {
 				return "", errBootstrapInterrupted

--- a/mise.toml
+++ b/mise.toml
@@ -17,12 +17,12 @@ run = "gotestsum --format pkgname --format-icons text --format-hide-empty-pkg --
 
 [tasks."test:integration"]
 description = "Run integration tests"
-run = "gotestsum --format testname --format-icons text --hide-summary skipped -- -tags=integration ./cmd/entire/cli/integration_test/..."
+run = "gotestsum --format testname --format-icons text --hide-summary skipped -- -tags=integration,authfilestore ./cmd/entire/cli/integration_test/... ./cmd/entire/cli/auth/..."
 
 [tasks."test:ci"]
 description = "Run all tests (unit + integration + E2E canary) with race detection"
 run = """
-go test -tags=integration -race ./...
+go test -tags=integration,authfilestore -race ./...
 mise run test:e2e:canary
 """
 

--- a/mise.toml
+++ b/mise.toml
@@ -13,11 +13,11 @@ run = "gofmt -s -w ."
 
 [tasks.test]
 description = "Run tests"
-run = "go test ./..."
+run = "gotestsum --format pkgname --format-icons text --format-hide-empty-pkg --hide-summary skipped -- ./..."
 
 [tasks."test:integration"]
 description = "Run integration tests"
-run = "go test -tags=integration ./cmd/entire/cli/integration_test/..."
+run = "gotestsum --format testname --format-icons text --hide-summary skipped -- -tags=integration ./cmd/entire/cli/integration_test/..."
 
 [tasks."test:ci"]
 description = "Run all tests (unit + integration + E2E canary) with race detection"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/328
<!-- entire-trail-link-end -->

## Summary
- switch local test tasks to gotestsum formats that avoid garbled output and show integration test progress
- prevent integration subprocesses from hanging on inherited TTY prompts
- isolate login integration auth storage from the local OS keyring
- make the activity grouping test stable across local time zones and clean up test prompt spew

## Test Plan
- go test -tags=integration ./cmd/entire/cli/integration_test/... -run '^(TestEnableDefaultStrategy|TestLogin_SavesTokenAfterApproval)$' -count=1 -v
- gotestsum --format testname --format-icons text --hide-summary skipped -- -tags=integration ./cmd/entire/cli/integration_test/... -count=1
- mise run test:integration
- mise run test
- mise run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it touches authentication token persistence logic (adding an alternate file-backed path), though it’s gated behind a test-only env var; most other changes are test/task reliability tweaks.
> 
> **Overview**
> Improves local and integration test reliability by forcing CLI subprocesses to run detached from the parent TTY (via `execx.NonInteractive`) so they can’t hang on interactive prompts.
> 
> Adds an optional file-backed auth token store controlled by `ENTIRE_TEST_AUTH_STORE_FILE`, letting integration login tests persist tokens across subprocesses without using the OS keyring (with secure `0700/0600` perms).
> 
> Stabilizes and de-flakes tests and output: activity commit grouping tests now use local-time timestamps, the agent multipicker exits early on cancelled contexts, TUI sink tests actively dismiss the UI, the GitHub repo-name prompt writes to the provided output, and `mise` test tasks switch to `gotestsum` for cleaner progress/reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3c01424527013a83bfe2773554911c14759f86. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->