### PR TITLE
Add post-tool-use hook support for codex

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,3 @@
 
 [features]
-codex_hooks = true
+hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "go run \"$(git rev-parse --show-toplevel)\"/cmd/entire/main.go hooks codex post-tool-use",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": null,

--- a/cmd/entire/cli/agent/codex/codex_test.go
+++ b/cmd/entire/cli/agent/codex/codex_test.go
@@ -60,6 +60,7 @@ func TestCodexAgent_HookNames(t *testing.T) {
 	require.Contains(t, names, "user-prompt-submit")
 	require.Contains(t, names, "stop")
 	require.Contains(t, names, "pre-tool-use")
+	require.Contains(t, names, "post-tool-use")
 }
 
 func TestCodexAgent_FormatResumeCommand(t *testing.T) {

--- a/cmd/entire/cli/agent/codex/hooks.go
+++ b/cmd/entire/cli/agent/codex/hooks.go
@@ -54,7 +54,7 @@ func (c *CodexAgent) InstallHooks(ctx context.Context, localDev bool, force bool
 	}
 
 	// Parse event types we manage
-	var sessionStart, userPromptSubmit, stop []MatcherGroup
+	var sessionStart, userPromptSubmit, stop, postToolUse []MatcherGroup
 	if err := parseHookType(rawHooks, "SessionStart", &sessionStart); err != nil {
 		return 0, err
 	}
@@ -64,11 +64,15 @@ func (c *CodexAgent) InstallHooks(ctx context.Context, localDev bool, force bool
 	if err := parseHookType(rawHooks, "Stop", &stop); err != nil {
 		return 0, err
 	}
+	if err := parseHookType(rawHooks, "PostToolUse", &postToolUse); err != nil {
+		return 0, err
+	}
 
 	if force {
 		sessionStart = removeEntireHooks(sessionStart)
 		userPromptSubmit = removeEntireHooks(userPromptSubmit)
 		stop = removeEntireHooks(stop)
+		postToolUse = removeEntireHooks(postToolUse)
 	}
 
 	// Build hook commands
@@ -84,9 +88,11 @@ func (c *CodexAgent) InstallHooks(ctx context.Context, localDev bool, force bool
 	}
 	userPromptSubmitCmd := cmdPrefix + "user-prompt-submit"
 	stopCmd := cmdPrefix + "stop"
+	postToolUseCmd := cmdPrefix + "post-tool-use"
 	if !localDev {
 		userPromptSubmitCmd = agent.WrapProductionSilentHookCommand(userPromptSubmitCmd)
 		stopCmd = agent.WrapProductionSilentHookCommand(stopCmd)
+		postToolUseCmd = agent.WrapProductionSilentHookCommand(postToolUseCmd)
 	}
 
 	count := 0
@@ -103,6 +109,10 @@ func (c *CodexAgent) InstallHooks(ctx context.Context, localDev bool, force bool
 		stop = addHook(stop, stopCmd)
 		count++
 	}
+	if !hookCommandExists(postToolUse, postToolUseCmd) {
+		postToolUse = addHook(postToolUse, postToolUseCmd)
+		count++
+	}
 
 	if count == 0 {
 		// Still ensure the feature flag is configured even if hooks
@@ -117,6 +127,7 @@ func (c *CodexAgent) InstallHooks(ctx context.Context, localDev bool, force bool
 	marshalHookType(rawHooks, "SessionStart", sessionStart)
 	marshalHookType(rawHooks, "UserPromptSubmit", userPromptSubmit)
 	marshalHookType(rawHooks, "Stop", stop)
+	marshalHookType(rawHooks, "PostToolUse", postToolUse)
 
 	// Preserve existing top-level keys (e.g., $schema) by reusing the parsed file
 	topLevel := make(map[string]json.RawMessage)
@@ -181,7 +192,7 @@ func (c *CodexAgent) UninstallHooks(ctx context.Context) error {
 		return nil
 	}
 
-	var sessionStart, userPromptSubmit, stop []MatcherGroup
+	var sessionStart, userPromptSubmit, stop, postToolUse []MatcherGroup
 	if err := parseHookType(rawHooks, "SessionStart", &sessionStart); err != nil {
 		return err
 	}
@@ -191,14 +202,19 @@ func (c *CodexAgent) UninstallHooks(ctx context.Context) error {
 	if err := parseHookType(rawHooks, "Stop", &stop); err != nil {
 		return err
 	}
+	if err := parseHookType(rawHooks, "PostToolUse", &postToolUse); err != nil {
+		return err
+	}
 
 	sessionStart = removeEntireHooks(sessionStart)
 	userPromptSubmit = removeEntireHooks(userPromptSubmit)
 	stop = removeEntireHooks(stop)
+	postToolUse = removeEntireHooks(postToolUse)
 
 	marshalHookType(rawHooks, "SessionStart", sessionStart)
 	marshalHookType(rawHooks, "UserPromptSubmit", userPromptSubmit)
 	marshalHookType(rawHooks, "Stop", stop)
+	marshalHookType(rawHooks, "PostToolUse", postToolUse)
 
 	if len(rawHooks) > 0 {
 		hooksJSON, err := jsonutil.MarshalWithNoHTMLEscape(rawHooks)
@@ -240,7 +256,8 @@ func (c *CodexAgent) AreHooksInstalled(ctx context.Context) bool {
 
 	return hasEntireHook(hooksFile.Hooks.SessionStart) &&
 		hasEntireHook(hooksFile.Hooks.UserPromptSubmit) &&
-		hasEntireHook(hooksFile.Hooks.Stop)
+		hasEntireHook(hooksFile.Hooks.Stop) &&
+		hasEntireHook(hooksFile.Hooks.PostToolUse)
 }
 
 // --- Helpers ---

--- a/cmd/entire/cli/agent/codex/hooks.go
+++ b/cmd/entire/cli/agent/codex/hooks.go
@@ -349,11 +349,19 @@ func removeEntireHooks(groups []MatcherGroup) []MatcherGroup {
 // configFileName is the Codex config file name.
 const configFileName = "config.toml"
 
-// featureLine is the TOML line that enables the codex_hooks feature.
-const featureLine = "codex_hooks = true"
+// featureLine is the TOML line that enables the hooks feature. The flag was
+// renamed from `codex_hooks` to `hooks` in Codex 0.129.0; the old name is
+// still accepted as a legacy alias but emits a deprecation warning at
+// every startup. ensureProjectFeatureEnabled rewrites the legacy form when
+// it sees it.
+const (
+	featureLine       = "hooks = true"
+	legacyFeatureLine = "codex_hooks = true"
+)
 
-// ensureProjectFeatureEnabled writes features.codex_hooks = true to the
+// ensureProjectFeatureEnabled writes features.hooks = true to the
 // project-level .codex/config.toml. This keeps the feature flag per-repo.
+// Replaces the deprecated codex_hooks = true line if it's present.
 func ensureProjectFeatureEnabled(repoRoot string) error {
 	configPath := filepath.Join(repoRoot, ".codex", configFileName)
 
@@ -363,13 +371,18 @@ func ensureProjectFeatureEnabled(repoRoot string) error {
 	}
 
 	content := string(data)
-	if strings.Contains(content, featureLine) {
+	hasNew := containsFeatureLine(content, featureLine)
+	hasLegacy := containsFeatureLine(content, legacyFeatureLine)
+	switch {
+	case hasNew && hasLegacy:
+		content = stripLegacyFeatureLine(content)
+	case hasNew:
 		return nil
-	}
-
-	if strings.Contains(content, "[features]") {
+	case hasLegacy:
+		content = strings.Replace(content, legacyFeatureLine, featureLine, 1)
+	case strings.Contains(content, "[features]"):
 		content = strings.Replace(content, "[features]", "[features]\n"+featureLine, 1)
-	} else {
+	default:
 		if len(content) > 0 && !strings.HasSuffix(content, "\n") {
 			content += "\n"
 		}
@@ -383,4 +396,32 @@ func ensureProjectFeatureEnabled(repoRoot string) error {
 		return fmt.Errorf("failed to write config.toml: %w", err)
 	}
 	return nil
+}
+
+// containsFeatureLine checks for an exact line match. A plain
+// strings.Contains is wrong because "hooks = true" is a substring of
+// "codex_hooks = true" — without the line-boundary anchor we'd treat the
+// legacy form as if the new form was already present.
+func containsFeatureLine(content, line string) bool {
+	for _, raw := range strings.Split(content, "\n") {
+		if strings.TrimSpace(raw) == line {
+			return true
+		}
+	}
+	return false
+}
+
+// stripLegacyFeatureLine removes the deprecated `codex_hooks = true` line
+// from a TOML config string, dropping a trailing blank line so the file
+// stays tidy. The new `hooks = true` is added separately by the caller.
+func stripLegacyFeatureLine(content string) string {
+	idx := strings.Index(content, legacyFeatureLine)
+	if idx < 0 {
+		return content
+	}
+	end := idx + len(legacyFeatureLine)
+	if end < len(content) && content[end] == '\n' {
+		end++
+	}
+	return content[:idx] + content[end:]
 }

--- a/cmd/entire/cli/agent/codex/hooks_test.go
+++ b/cmd/entire/cli/agent/codex/hooks_test.go
@@ -27,7 +27,7 @@ func TestInstallHooks_CreatesConfig(t *testing.T) {
 	ag := &CodexAgent{}
 	count, err := ag.InstallHooks(context.Background(), false, false)
 	require.NoError(t, err)
-	require.Equal(t, 3, count) // SessionStart, UserPromptSubmit, Stop
+	require.Equal(t, 4, count) // SessionStart, UserPromptSubmit, Stop, PostToolUse
 
 	// Verify hooks.json was created in the repo
 	hooksPath := filepath.Join(tempDir, ".codex", HooksFileName)
@@ -40,6 +40,7 @@ func TestInstallHooks_CreatesConfig(t *testing.T) {
 	assertHookCommand(t, hooksFile.Hooks.SessionStart, agentpkg.WrapProductionJSONWarningHookCommand("entire hooks codex session-start", agentpkg.WarningFormatSingleLine), "SessionStart")
 	assertHookCommand(t, hooksFile.Hooks.UserPromptSubmit, agentpkg.WrapProductionSilentHookCommand("entire hooks codex user-prompt-submit"), "UserPromptSubmit")
 	assertHookCommand(t, hooksFile.Hooks.Stop, agentpkg.WrapProductionSilentHookCommand("entire hooks codex stop"), "Stop")
+	assertHookCommand(t, hooksFile.Hooks.PostToolUse, agentpkg.WrapProductionSilentHookCommand("entire hooks codex post-tool-use"), "PostToolUse")
 
 	// Verify project-level config.toml enables codex_hooks feature (per-repo)
 	projectConfig := filepath.Join(tempDir, ".codex", configFileName)
@@ -56,7 +57,7 @@ func TestInstallHooks_Idempotent(t *testing.T) {
 
 	count1, err := ag.InstallHooks(context.Background(), false, false)
 	require.NoError(t, err)
-	require.Equal(t, 3, count1)
+	require.Equal(t, 4, count1)
 
 	count2, err := ag.InstallHooks(context.Background(), false, false)
 	require.NoError(t, err)
@@ -69,12 +70,13 @@ func TestInstallHooks_LocalDev(t *testing.T) {
 	ag := &CodexAgent{}
 	count, err := ag.InstallHooks(context.Background(), true, false)
 	require.NoError(t, err)
-	require.Equal(t, 3, count)
+	require.Equal(t, 4, count)
 
 	hooksPath := filepath.Join(tempDir, ".codex", HooksFileName)
 	data, err := os.ReadFile(hooksPath)
 	require.NoError(t, err)
 	require.Contains(t, string(data), `go run \"$(git rev-parse --show-toplevel)\"/cmd/entire/main.go hooks codex session-start`)
+	require.Contains(t, string(data), `go run \"$(git rev-parse --show-toplevel)\"/cmd/entire/main.go hooks codex post-tool-use`)
 }
 
 func TestInstallHooks_Force(t *testing.T) {
@@ -87,7 +89,7 @@ func TestInstallHooks_Force(t *testing.T) {
 
 	count, err := ag.InstallHooks(context.Background(), false, true)
 	require.NoError(t, err)
-	require.Equal(t, 3, count)
+	require.Equal(t, 4, count)
 }
 
 func TestUninstallHooks(t *testing.T) {

--- a/cmd/entire/cli/agent/codex/hooks_test.go
+++ b/cmd/entire/cli/agent/codex/hooks_test.go
@@ -42,11 +42,13 @@ func TestInstallHooks_CreatesConfig(t *testing.T) {
 	assertHookCommand(t, hooksFile.Hooks.Stop, agentpkg.WrapProductionSilentHookCommand("entire hooks codex stop"), "Stop")
 	assertHookCommand(t, hooksFile.Hooks.PostToolUse, agentpkg.WrapProductionSilentHookCommand("entire hooks codex post-tool-use"), "PostToolUse")
 
-	// Verify project-level config.toml enables codex_hooks feature (per-repo)
+	// Verify project-level config.toml enables the hooks feature (per-repo)
 	projectConfig := filepath.Join(tempDir, ".codex", configFileName)
 	projectData, err := os.ReadFile(projectConfig)
 	require.NoError(t, err)
-	require.Contains(t, string(projectData), "codex_hooks = true")
+	require.Contains(t, string(projectData), "hooks = true")
+	require.NotContains(t, string(projectData), "codex_hooks = true",
+		"deprecated codex_hooks line must not be written by fresh installs")
 	require.Contains(t, string(projectData), "[features]")
 }
 
@@ -278,6 +280,32 @@ func TestInstallHooks_DoesNotModifyUserConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(configData), "model = \"gpt-4.1\"")
 	require.NotContains(t, string(configData), `trust_level = "trusted"`)
+}
+
+// TestInstallHooks_RewritesLegacyFeatureLine pins the rule that an existing
+// `codex_hooks = true` line — written by older entire CLI versions — must
+// be rewritten to the new `hooks = true` form on the next install. Codex
+// 0.129.0 still accepts the legacy alias but prints a deprecation warning
+// at every startup; rewriting silences it without forcing the user to
+// touch their .codex/config.toml.
+func TestInstallHooks_RewritesLegacyFeatureLine(t *testing.T) {
+	tempDir := setupTestEnv(t)
+
+	codexDir := filepath.Join(tempDir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+	existingConfig := "[features]\ncodex_hooks = true\n"
+	configPath := filepath.Join(codexDir, configFileName)
+	require.NoError(t, os.WriteFile(configPath, []byte(existingConfig), 0o600))
+
+	ag := &CodexAgent{}
+	_, err := ag.InstallHooks(context.Background(), false, false)
+	require.NoError(t, err)
+
+	configData, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Contains(t, string(configData), "hooks = true")
+	require.NotContains(t, string(configData), "codex_hooks = true",
+		"legacy codex_hooks line must be replaced, not left alongside the new form")
 }
 
 // assertHookCommand verifies that one of the hook entries in groups contains the expected command.

--- a/cmd/entire/cli/agent/codex/lifecycle.go
+++ b/cmd/entire/cli/agent/codex/lifecycle.go
@@ -98,21 +98,19 @@ func (c *CodexAgent) parseTurnStart(stdin io.Reader) (*agent.Event, error) {
 	}, nil
 }
 
+// Codex PostToolUse tool_name values that represent file mutations. The
+// canonical Codex name is apply_patch; Write and Edit are matcher aliases
+// Codex registers for compatibility with Claude-style hook configs — see
+// codex-rs/core/src/tools/hook_names.rs:apply_patch.
+const (
+	toolNameApplyPatch = "apply_patch"
+	toolAliasWrite     = "Write"
+	toolAliasEdit      = "Edit"
+)
+
 // parsePostToolUse turns a Codex PostToolUse hook into a ToolUse lifecycle event.
-//
-// Codex fires PostToolUse for every tool the agent runs (apply_patch, shell,
-// unified_exec, MCP tools). We only care about file mutations: apply_patch
-// (canonical name) and its matcher aliases Write/Edit (Codex accepts those for
-// Claude-style hook configs — see codex-rs/core/src/tools/hook_names.rs).
-// Other tool names produce a no-op event (nil) so the dispatcher skips them.
-//
-// The patch envelope arrives in tool_input.command using Codex's plain-text
-// format (`*** Add File: …`, `*** Update File: …`, `*** Delete File: …`).
-// Path classification matters here: Add → NewFiles, Delete → DeletedFiles,
-// Update → ModifiedFiles. The strategy's mergeFilesTouched dedups across the
-// three buckets, so misclassification only loses signal — but keeping them
-// separate matches what SaveStep does at TurnEnd and lets future consumers
-// reason about agent intent.
+// Non-mutating tools (shell, MCP) produce a nil event so the dispatcher skips
+// them — extracting files from arbitrary shell commands would be unreliable.
 func (c *CodexAgent) parsePostToolUse(stdin io.Reader) (*agent.Event, error) {
 	raw, err := agent.ReadAndParseHookInput[postToolUseRaw](stdin)
 	if err != nil {
@@ -124,18 +122,13 @@ func (c *CodexAgent) parsePostToolUse(stdin io.Reader) (*agent.Event, error) {
 	}
 
 	var input applyPatchToolInput
-	if len(raw.ToolInput) > 0 {
-		// Best-effort: an unparseable tool_input means we can't extract files,
-		// but we shouldn't fail the hook (which would block the agent's tool call).
-		_ = json.Unmarshal(raw.ToolInput, &input) //nolint:errcheck // input.Command stays empty on failure
-	}
-	if input.Command == "" {
-		return nil, nil //nolint:nilnil // no patch envelope, nothing to record
-	}
+	// Best-effort: an unparseable tool_input means we can't extract files, but
+	// we shouldn't fail the hook (which would block the agent's tool call).
+	_ = json.Unmarshal(raw.ToolInput, &input) //nolint:errcheck // input.Command stays empty on failure
 
 	added, modified, deleted := classifyApplyPatchPaths(input.Command)
 	if len(added) == 0 && len(modified) == 0 && len(deleted) == 0 {
-		return nil, nil //nolint:nilnil // empty patch — no files to record
+		return nil, nil //nolint:nilnil // empty or unparseable envelope
 	}
 
 	return &agent.Event{
@@ -152,13 +145,9 @@ func (c *CodexAgent) parsePostToolUse(stdin io.Reader) (*agent.Event, error) {
 	}, nil
 }
 
-// isApplyPatchTool reports whether a Codex PostToolUse tool_name represents an
-// apply_patch invocation. The canonical name is "apply_patch"; Write and Edit
-// are matcher aliases Codex accepts for compatibility with Claude-style hook
-// configs (see codex-rs/core/src/tools/hook_names.rs:apply_patch).
 func isApplyPatchTool(name string) bool {
 	switch name {
-	case "apply_patch", "Write", "Edit":
+	case toolNameApplyPatch, toolAliasWrite, toolAliasEdit:
 		return true
 	default:
 		return false

--- a/cmd/entire/cli/agent/codex/lifecycle.go
+++ b/cmd/entire/cli/agent/codex/lifecycle.go
@@ -35,6 +35,7 @@ const (
 	HookNameUserPromptSubmit = "user-prompt-submit"
 	HookNameStop             = "stop"
 	HookNamePreToolUse       = "pre-tool-use"
+	HookNamePostToolUse      = "post-tool-use"
 )
 
 // HookNames returns the hook verbs Codex supports.
@@ -44,6 +45,7 @@ func (c *CodexAgent) HookNames() []string {
 		HookNameUserPromptSubmit,
 		HookNameStop,
 		HookNamePreToolUse,
+		HookNamePostToolUse,
 	}
 }
 
@@ -60,6 +62,8 @@ func (c *CodexAgent) ParseHookEvent(_ context.Context, hookName string, stdin io
 	case HookNamePreToolUse:
 		// PreToolUse has no lifecycle significance — pass through
 		return nil, nil //nolint:nilnil // nil event = no lifecycle action
+	case HookNamePostToolUse:
+		return c.parsePostToolUse(stdin)
 	default:
 		return nil, nil //nolint:nilnil // Unknown hooks have no lifecycle action
 	}
@@ -92,6 +96,73 @@ func (c *CodexAgent) parseTurnStart(stdin io.Reader) (*agent.Event, error) {
 		Model:      raw.Model,
 		Timestamp:  time.Now(),
 	}, nil
+}
+
+// parsePostToolUse turns a Codex PostToolUse hook into a ToolUse lifecycle event.
+//
+// Codex fires PostToolUse for every tool the agent runs (apply_patch, shell,
+// unified_exec, MCP tools). We only care about file mutations: apply_patch
+// (canonical name) and its matcher aliases Write/Edit (Codex accepts those for
+// Claude-style hook configs — see codex-rs/core/src/tools/hook_names.rs).
+// Other tool names produce a no-op event (nil) so the dispatcher skips them.
+//
+// The patch envelope arrives in tool_input.command using Codex's plain-text
+// format (`*** Add File: …`, `*** Update File: …`, `*** Delete File: …`).
+// Path classification matters here: Add → NewFiles, Delete → DeletedFiles,
+// Update → ModifiedFiles. The strategy's mergeFilesTouched dedups across the
+// three buckets, so misclassification only loses signal — but keeping them
+// separate matches what SaveStep does at TurnEnd and lets future consumers
+// reason about agent intent.
+func (c *CodexAgent) parsePostToolUse(stdin io.Reader) (*agent.Event, error) {
+	raw, err := agent.ReadAndParseHookInput[postToolUseRaw](stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isApplyPatchTool(raw.ToolName) {
+		return nil, nil //nolint:nilnil // non-mutating tools have no lifecycle action
+	}
+
+	var input applyPatchToolInput
+	if len(raw.ToolInput) > 0 {
+		// Best-effort: an unparseable tool_input means we can't extract files,
+		// but we shouldn't fail the hook (which would block the agent's tool call).
+		_ = json.Unmarshal(raw.ToolInput, &input) //nolint:errcheck // input.Command stays empty on failure
+	}
+	if input.Command == "" {
+		return nil, nil //nolint:nilnil // no patch envelope, nothing to record
+	}
+
+	added, modified, deleted := classifyApplyPatchPaths(input.Command)
+	if len(added) == 0 && len(modified) == 0 && len(deleted) == 0 {
+		return nil, nil //nolint:nilnil // empty patch — no files to record
+	}
+
+	return &agent.Event{
+		Type:          agent.ToolUse,
+		SessionID:     raw.SessionID,
+		SessionRef:    derefString(raw.TranscriptPath),
+		Model:         raw.Model,
+		ToolUseID:     raw.ToolUseID,
+		CWD:           raw.CWD,
+		ModifiedFiles: modified,
+		NewFiles:      added,
+		DeletedFiles:  deleted,
+		Timestamp:     time.Now(),
+	}, nil
+}
+
+// isApplyPatchTool reports whether a Codex PostToolUse tool_name represents an
+// apply_patch invocation. The canonical name is "apply_patch"; Write and Edit
+// are matcher aliases Codex accepts for compatibility with Claude-style hook
+// configs (see codex-rs/core/src/tools/hook_names.rs:apply_patch).
+func isApplyPatchTool(name string) bool {
+	switch name {
+	case "apply_patch", "Write", "Edit":
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *CodexAgent) parseTurnEnd(stdin io.Reader) (*agent.Event, error) {

--- a/cmd/entire/cli/agent/codex/lifecycle_test.go
+++ b/cmd/entire/cli/agent/codex/lifecycle_test.go
@@ -109,6 +109,117 @@ func TestParseHookEvent_PreToolUse_ReturnsNil(t *testing.T) {
 	require.Nil(t, event)
 }
 
+func TestParseHookEvent_PostToolUse_ApplyPatch(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+	// Match the wire shape from codex-rs/hooks/src/schema.rs PostToolUseCommandInput.
+	// tool_input.command carries the patch envelope as a single string.
+	input := `{
+		"session_id": "550e8400-e29b-41d4-a716-446655440000",
+		"turn_id": "turn-1",
+		"transcript_path": "/tmp/rollout.jsonl",
+		"cwd": "/tmp/testrepo",
+		"hook_event_name": "PostToolUse",
+		"model": "gpt-5",
+		"permission_mode": "default",
+		"tool_name": "apply_patch",
+		"tool_use_id": "call-abc",
+		"tool_input": {"command": "*** Begin Patch\n*** Add File: a.txt\n+hi\n*** Update File: b.txt\n@@\n-old\n+new\n*** Delete File: c.txt\n*** End Patch\n"},
+		"tool_response": "Success."
+	}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+	require.NoError(t, err)
+	require.NotNil(t, event)
+	require.Equal(t, agent.ToolUse, event.Type)
+	require.Equal(t, "550e8400-e29b-41d4-a716-446655440000", event.SessionID)
+	require.Equal(t, "/tmp/rollout.jsonl", event.SessionRef)
+	require.Equal(t, "/tmp/testrepo", event.CWD)
+	require.Equal(t, "call-abc", event.ToolUseID)
+	require.Equal(t, []string{"a.txt"}, event.NewFiles)
+	require.Equal(t, []string{"b.txt"}, event.ModifiedFiles)
+	require.Equal(t, []string{"c.txt"}, event.DeletedFiles)
+}
+
+func TestParseHookEvent_PostToolUse_AcceptsClaudeAliases(t *testing.T) {
+	t.Parallel()
+	// Codex registers Write and Edit as matcher aliases for apply_patch
+	// (codex-rs/core/src/tools/hook_names.rs). Hook stdin still carries one of
+	// those aliases as tool_name when a Claude-style hook config matches by
+	// alias, so the parser must accept all three.
+	for _, name := range []string{"apply_patch", "Write", "Edit"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ag := &CodexAgent{}
+			input := `{
+				"session_id": "s",
+				"cwd": "/tmp/r",
+				"tool_name": "` + name + `",
+				"tool_use_id": "id",
+				"tool_input": {"command": "*** Begin Patch\n*** Add File: x.txt\n+x\n*** End Patch\n"}
+			}`
+			event, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+			require.NoError(t, err)
+			require.NotNil(t, event)
+			require.Equal(t, []string{"x.txt"}, event.NewFiles)
+		})
+	}
+}
+
+func TestParseHookEvent_PostToolUse_NonMutatingTool_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+	// Shell calls fire PostToolUse too, but we can't extract files from them
+	// without parsing the shell command. Skip them entirely so we don't churn
+	// session state on every command.
+	input := `{
+		"session_id": "s",
+		"cwd": "/tmp/r",
+		"tool_name": "shell",
+		"tool_use_id": "id",
+		"tool_input": {"command": ["echo", "hi"]},
+		"tool_response": "hi\n"
+	}`
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+	require.NoError(t, err)
+	require.Nil(t, event)
+}
+
+func TestParseHookEvent_PostToolUse_EmptyPatch_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+	// A patch envelope with no Add/Update/Delete lines (e.g. malformed input
+	// that still parses as JSON) should be a no-op rather than an error.
+	input := `{
+		"session_id": "s",
+		"cwd": "/tmp/r",
+		"tool_name": "apply_patch",
+		"tool_use_id": "id",
+		"tool_input": {"command": "*** Begin Patch\n*** End Patch\n"}
+	}`
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+	require.NoError(t, err)
+	require.Nil(t, event)
+}
+
+func TestParseHookEvent_PostToolUse_MissingToolInput_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	ag := &CodexAgent{}
+	// Defensive: if Codex ever fires PostToolUse for apply_patch with a
+	// non-string tool_input shape, we should drop the event rather than fail
+	// the hook (which would block the agent's tool call).
+	input := `{
+		"session_id": "s",
+		"cwd": "/tmp/r",
+		"tool_name": "apply_patch",
+		"tool_use_id": "id",
+		"tool_input": null
+	}`
+	event, err := ag.ParseHookEvent(context.Background(), HookNamePostToolUse, strings.NewReader(input))
+	require.NoError(t, err)
+	require.Nil(t, event)
+}
+
 func TestParseHookEvent_UnknownHook_ReturnsNil(t *testing.T) {
 	t.Parallel()
 	ag := &CodexAgent{}

--- a/cmd/entire/cli/agent/codex/transcript.go
+++ b/cmd/entire/cli/agent/codex/transcript.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -73,14 +74,16 @@ type tokenUsageData struct {
 	TotalTokens           int `json:"total_tokens"`
 }
 
-// applyPatchFileRegex extracts file paths from apply_patch input.
-// Matches "*** Add File: <path>", "*** Update File: <path>", "*** Delete File: <path>"
-var applyPatchFileRegex = regexp.MustCompile(`\*\*\* (?:Add|Update|Delete) File: (.+)`)
+// Apply-patch envelope verbs Codex uses in tool_input.command — see
+// codex-rs/core/src/tools/handlers/apply_patch.rs. Capture group 1 is the
+// verb, group 2 is the path.
+const (
+	applyPatchVerbAdd    = "Add"
+	applyPatchVerbUpdate = "Update"
+	applyPatchVerbDelete = "Delete"
+)
 
-// applyPatchClassifiedRegex splits apply_patch entries by intent so callers can
-// route files into NewFiles/ModifiedFiles/DeletedFiles. Capture group 1 is the
-// verb (Add|Update|Delete), group 2 is the path.
-var applyPatchClassifiedRegex = regexp.MustCompile(`\*\*\* (Add|Update|Delete) File: (.+)`)
+var applyPatchFileRegex = regexp.MustCompile(`\*\*\* (Add|Update|Delete) File: (.+)`)
 
 // GetTranscriptPosition returns the current line count of a Codex rollout transcript.
 func (c *CodexAgent) GetTranscriptPosition(path string) (int, error) {
@@ -181,30 +184,27 @@ func extractFilesFromLine(lineData []byte) []string {
 	return nil
 }
 
-// extractFilesFromApplyPatch parses apply_patch input for file paths.
-// Format: "*** Add File: <path>" or "*** Update File: <path>" or "*** Delete File: <path>"
+// extractFilesFromApplyPatch returns every file path in an apply_patch envelope,
+// across Add/Update/Delete entries, deduplicated.
 func extractFilesFromApplyPatch(input string) []string {
-	matches := applyPatchFileRegex.FindAllStringSubmatch(input, -1)
-	var files []string
-	seen := make(map[string]struct{})
-	for _, m := range matches {
-		path := strings.TrimSpace(m[1])
-		if path != "" {
-			if _, ok := seen[path]; !ok {
-				seen[path] = struct{}{}
-				files = append(files, path)
-			}
-		}
+	added, modified, deleted := classifyApplyPatchPaths(input)
+	total := len(added) + len(modified) + len(deleted)
+	if total == 0 {
+		return nil
 	}
+	files := make([]string, 0, total)
+	files = append(files, added...)
+	files = append(files, modified...)
+	files = append(files, deleted...)
 	return files
 }
 
 // classifyApplyPatchPaths splits an apply_patch envelope into added, modified,
-// and deleted file paths. Each list is deduped within itself; an Update on the
-// same path as an Add wins toward Add (envelopes shouldn't do this, but if one
-// does the more specific intent is preferable). Empty paths are dropped.
+// and deleted file paths. An Add on the same path as an Update wins toward Add
+// — envelopes shouldn't do this, but the more specific intent is preferable.
+// Each bucket is sorted for deterministic output.
 func classifyApplyPatchPaths(input string) (added, modified, deleted []string) {
-	matches := applyPatchClassifiedRegex.FindAllStringSubmatch(input, -1)
+	matches := applyPatchFileRegex.FindAllStringSubmatch(input, -1)
 	bucket := make(map[string]string, len(matches))
 	for _, m := range matches {
 		verb := m[1]
@@ -213,7 +213,7 @@ func classifyApplyPatchPaths(input string) (added, modified, deleted []string) {
 			continue
 		}
 		if existing, ok := bucket[path]; ok {
-			if existing == "Add" || existing == "Delete" {
+			if existing == applyPatchVerbAdd || existing == applyPatchVerbDelete {
 				continue
 			}
 		}
@@ -221,14 +221,17 @@ func classifyApplyPatchPaths(input string) (added, modified, deleted []string) {
 	}
 	for path, verb := range bucket {
 		switch verb {
-		case "Add":
+		case applyPatchVerbAdd:
 			added = append(added, path)
-		case "Update":
+		case applyPatchVerbUpdate:
 			modified = append(modified, path)
-		case "Delete":
+		case applyPatchVerbDelete:
 			deleted = append(deleted, path)
 		}
 	}
+	sort.Strings(added)
+	sort.Strings(modified)
+	sort.Strings(deleted)
 	return added, modified, deleted
 }
 

--- a/cmd/entire/cli/agent/codex/transcript.go
+++ b/cmd/entire/cli/agent/codex/transcript.go
@@ -83,7 +83,10 @@ const (
 	applyPatchVerbDelete = "Delete"
 )
 
-var applyPatchFileRegex = regexp.MustCompile(`\*\*\* (Add|Update|Delete) File: (.+)`)
+var (
+	applyPatchFileRegex = regexp.MustCompile(`\*\*\* (Add|Update|Delete) File: (.+)`)
+	applyPatchMoveRegex = regexp.MustCompile(`\*\*\* Move to: (.+)`)
+)
 
 // GetTranscriptPosition returns the current line count of a Codex rollout transcript.
 func (c *CodexAgent) GetTranscriptPosition(path string) (int, error) {
@@ -200,24 +203,45 @@ func extractFilesFromApplyPatch(input string) []string {
 }
 
 // classifyApplyPatchPaths splits an apply_patch envelope into added, modified,
-// and deleted file paths. An Add on the same path as an Update wins toward Add
-// — envelopes shouldn't do this, but the more specific intent is preferable.
-// Each bucket is sorted for deterministic output.
+// and deleted file paths. The grammar (codex-rs/apply-patch/src/parser.rs)
+// supports renames via "*** Update File: old\n*** Move to: new", which we
+// reclassify as a Delete on the source path and an Add on the destination.
+// Add and Delete are sticky — subsequent Updates on the same path don't
+// downgrade them. Each bucket is sorted for deterministic output.
 func classifyApplyPatchPaths(input string) (added, modified, deleted []string) {
-	matches := applyPatchFileRegex.FindAllStringSubmatch(input, -1)
-	bucket := make(map[string]string, len(matches))
-	for _, m := range matches {
-		verb := m[1]
-		path := strings.TrimSpace(m[2])
-		if path == "" {
-			continue
-		}
-		if existing, ok := bucket[path]; ok {
-			if existing == applyPatchVerbAdd || existing == applyPatchVerbDelete {
+	bucket := make(map[string]string)
+	var lastUpdate string
+	for _, line := range strings.Split(input, "\n") {
+		if m := applyPatchFileRegex.FindStringSubmatch(line); m != nil {
+			verb := m[1]
+			path := strings.TrimSpace(m[2])
+			if path == "" {
 				continue
 			}
+			if verb == applyPatchVerbUpdate {
+				lastUpdate = path
+			} else {
+				lastUpdate = ""
+			}
+			if existing, ok := bucket[path]; ok {
+				if existing == applyPatchVerbAdd || existing == applyPatchVerbDelete {
+					continue
+				}
+			}
+			bucket[path] = verb
+			continue
 		}
-		bucket[path] = verb
+		if m := applyPatchMoveRegex.FindStringSubmatch(line); m != nil {
+			target := strings.TrimSpace(m[1])
+			if target == "" {
+				continue
+			}
+			if lastUpdate != "" {
+				bucket[lastUpdate] = applyPatchVerbDelete
+			}
+			bucket[target] = applyPatchVerbAdd
+			lastUpdate = ""
+		}
 	}
 	for path, verb := range bucket {
 		switch verb {

--- a/cmd/entire/cli/agent/codex/transcript.go
+++ b/cmd/entire/cli/agent/codex/transcript.go
@@ -77,6 +77,11 @@ type tokenUsageData struct {
 // Matches "*** Add File: <path>", "*** Update File: <path>", "*** Delete File: <path>"
 var applyPatchFileRegex = regexp.MustCompile(`\*\*\* (?:Add|Update|Delete) File: (.+)`)
 
+// applyPatchClassifiedRegex splits apply_patch entries by intent so callers can
+// route files into NewFiles/ModifiedFiles/DeletedFiles. Capture group 1 is the
+// verb (Add|Update|Delete), group 2 is the path.
+var applyPatchClassifiedRegex = regexp.MustCompile(`\*\*\* (Add|Update|Delete) File: (.+)`)
+
 // GetTranscriptPosition returns the current line count of a Codex rollout transcript.
 func (c *CodexAgent) GetTranscriptPosition(path string) (int, error) {
 	if path == "" {
@@ -192,6 +197,39 @@ func extractFilesFromApplyPatch(input string) []string {
 		}
 	}
 	return files
+}
+
+// classifyApplyPatchPaths splits an apply_patch envelope into added, modified,
+// and deleted file paths. Each list is deduped within itself; an Update on the
+// same path as an Add wins toward Add (envelopes shouldn't do this, but if one
+// does the more specific intent is preferable). Empty paths are dropped.
+func classifyApplyPatchPaths(input string) (added, modified, deleted []string) {
+	matches := applyPatchClassifiedRegex.FindAllStringSubmatch(input, -1)
+	bucket := make(map[string]string, len(matches))
+	for _, m := range matches {
+		verb := m[1]
+		path := strings.TrimSpace(m[2])
+		if path == "" {
+			continue
+		}
+		if existing, ok := bucket[path]; ok {
+			if existing == "Add" || existing == "Delete" {
+				continue
+			}
+		}
+		bucket[path] = verb
+	}
+	for path, verb := range bucket {
+		switch verb {
+		case "Add":
+			added = append(added, path)
+		case "Update":
+			modified = append(modified, path)
+		case "Delete":
+			deleted = append(deleted, path)
+		}
+	}
+	return added, modified, deleted
 }
 
 // CalculateTokenUsage computes token usage from the transcript starting at the given line offset.

--- a/cmd/entire/cli/agent/codex/transcript.go
+++ b/cmd/entire/cli/agent/codex/transcript.go
@@ -237,9 +237,13 @@ func classifyApplyPatchPaths(input string) (added, modified, deleted []string) {
 				continue
 			}
 			if lastUpdate != "" {
-				bucket[lastUpdate] = applyPatchVerbDelete
+				if existing, ok := bucket[lastUpdate]; !ok || (existing != applyPatchVerbAdd && existing != applyPatchVerbDelete) {
+					bucket[lastUpdate] = applyPatchVerbDelete
+				}
 			}
-			bucket[target] = applyPatchVerbAdd
+			if existing, ok := bucket[target]; !ok || (existing != applyPatchVerbAdd && existing != applyPatchVerbDelete) {
+				bucket[target] = applyPatchVerbAdd
+			}
 			lastUpdate = ""
 		}
 	}

--- a/cmd/entire/cli/agent/codex/transcript_test.go
+++ b/cmd/entire/cli/agent/codex/transcript_test.go
@@ -248,6 +248,43 @@ func TestClassifyApplyPatchPaths_Empty(t *testing.T) {
 	require.Empty(t, deleted)
 }
 
+func TestClassifyApplyPatchPaths_MoveTo(t *testing.T) {
+	t.Parallel()
+	// Codex apply_patch encodes renames as "*** Update File: <old>\n*** Move
+	// to: <new>". Both paths must be tracked: the source is being deleted
+	// (renamed away), the destination is being created.
+	added, modified, deleted := classifyApplyPatchPaths(
+		"*** Begin Patch\n" +
+			"*** Update File: src/old.rs\n" +
+			"*** Move to: src/new.rs\n" +
+			"@@\n-old\n+new\n" +
+			"*** End Patch\n",
+	)
+	require.Equal(t, []string{"src/new.rs"}, added)
+	require.Empty(t, modified)
+	require.Equal(t, []string{"src/old.rs"}, deleted)
+}
+
+func TestClassifyApplyPatchPaths_MoveToWithSiblingHunks(t *testing.T) {
+	t.Parallel()
+	// A patch can mix Move-to renames with regular Add/Delete entries — the
+	// Move handler must scope to the most recent Update File, not collapse
+	// unrelated entries.
+	added, modified, deleted := classifyApplyPatchPaths(
+		"*** Begin Patch\n" +
+			"*** Delete File: gone.txt\n" +
+			"*** Update File: a.rs\n" +
+			"*** Move to: b.rs\n" +
+			"@@\n-x\n+y\n" +
+			"*** Add File: brand-new.go\n" +
+			"+package main\n" +
+			"*** End Patch\n",
+	)
+	require.Equal(t, []string{"b.rs", "brand-new.go"}, added)
+	require.Empty(t, modified)
+	require.Equal(t, []string{"a.rs", "gone.txt"}, deleted)
+}
+
 func TestSplitJSONL(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/codex/transcript_test.go
+++ b/cmd/entire/cli/agent/codex/transcript_test.go
@@ -216,6 +216,38 @@ func TestExtractFilesFromApplyPatch(t *testing.T) {
 	}
 }
 
+func TestClassifyApplyPatchPaths(t *testing.T) {
+	t.Parallel()
+
+	added, modified, deleted := classifyApplyPatchPaths(
+		"*** Begin Patch\n*** Add File: a.txt\n+hi\n*** Update File: b.txt\n@@\n-old\n+new\n*** Delete File: c.txt\n*** End Patch\n",
+	)
+	require.Equal(t, []string{"a.txt"}, added)
+	require.Equal(t, []string{"b.txt"}, modified)
+	require.Equal(t, []string{"c.txt"}, deleted)
+}
+
+func TestClassifyApplyPatchPaths_AddWinsOverUpdate(t *testing.T) {
+	t.Parallel()
+	// If a path appears with both Add and Update verbs (envelopes shouldn't do
+	// this, but we're defensive), the more specific intent — Add — wins so
+	// callers route the file into NewFiles rather than ModifiedFiles.
+	added, modified, deleted := classifyApplyPatchPaths(
+		"*** Add File: a.txt\n*** Update File: a.txt\n",
+	)
+	require.Equal(t, []string{"a.txt"}, added)
+	require.Empty(t, modified)
+	require.Empty(t, deleted)
+}
+
+func TestClassifyApplyPatchPaths_Empty(t *testing.T) {
+	t.Parallel()
+	added, modified, deleted := classifyApplyPatchPaths("*** Begin Patch\n*** End Patch\n")
+	require.Empty(t, added)
+	require.Empty(t, modified)
+	require.Empty(t, deleted)
+}
+
 func TestSplitJSONL(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/codex/transcript_test.go
+++ b/cmd/entire/cli/agent/codex/transcript_test.go
@@ -285,6 +285,28 @@ func TestClassifyApplyPatchPaths_MoveToWithSiblingHunks(t *testing.T) {
 	require.Equal(t, []string{"a.rs", "gone.txt"}, deleted)
 }
 
+// TestClassifyApplyPatchPaths_MoveDoesNotOverwriteStickyAdd pins the
+// sticky-verb invariant against the Move-to handler. A path already
+// classified as Add must survive a later Update+Move-to that names it
+// as the source. Codex itself doesn't emit envelopes shaped like this,
+// but the invariant is documented and we don't want a quiet downgrade
+// if the grammar ever loosens.
+func TestClassifyApplyPatchPaths_MoveDoesNotOverwriteStickyAdd(t *testing.T) {
+	t.Parallel()
+	added, modified, deleted := classifyApplyPatchPaths(
+		"*** Begin Patch\n" +
+			"*** Add File: foo.txt\n" +
+			"+content\n" +
+			"*** Update File: foo.txt\n" +
+			"*** Move to: bar.txt\n" +
+			"@@\n-x\n+y\n" +
+			"*** End Patch\n",
+	)
+	require.Equal(t, []string{"bar.txt", "foo.txt"}, added)
+	require.Empty(t, modified)
+	require.Empty(t, deleted)
+}
+
 func TestSplitJSONL(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/codex/trust.go
+++ b/cmd/entire/cli/agent/codex/trust.go
@@ -1,0 +1,121 @@
+package codex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// HookTrustGaps returns the snake_case event labels declared in
+// <repoRoot>/.codex/hooks.json that don't have a matching
+// `[hooks.state."<hooks.json>:<event>:0:0"]` entry in the user's Codex
+// config.toml — i.e. events the local user hasn't approved yet.
+//
+// This is the structural form of the trust check: we don't recompute
+// Codex's hook hash, we only look at key presence. That misses the
+// "command changed but key is still there" case (status = Modified),
+// but Codex's own startup warning catches those — our purpose here is
+// to surface fresh additions like "you trusted three hooks last month
+// but a new PostToolUse arrived" inside our SessionStart welcome.
+//
+// Returns nil when:
+//   - .codex/hooks.json doesn't exist (entire isn't installed in this repo)
+//   - The user's config.toml can't be read
+//   - Every declared event already has a state entry
+func HookTrustGaps(repoRoot string) []string {
+	hooksJSONPath := filepath.Join(repoRoot, ".codex", "hooks.json")
+	declared, ok := declaredCodexEvents(hooksJSONPath)
+	if !ok || len(declared) == 0 {
+		return nil
+	}
+
+	configPath := codexConfigPath()
+	if configPath == "" {
+		return nil
+	}
+	trusted, ok := readCodexTrustedKeys(configPath)
+	if !ok {
+		return nil
+	}
+
+	var gaps []string
+	for _, ev := range declared {
+		// Match any handler index — Codex's state key is
+		// "<path>:<event>:<group>:<handler>". Trust on any handler counts.
+		prefix := hooksJSONPath + ":" + ev + ":"
+		if !codexAnyKeyHasPrefix(trusted, prefix) {
+			gaps = append(gaps, ev)
+		}
+	}
+	return gaps
+}
+
+func codexConfigPath() string {
+	if h := os.Getenv("CODEX_HOME"); h != "" {
+		return filepath.Join(h, "config.toml")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".codex", "config.toml")
+}
+
+// declaredCodexEvents reads hooks.json and returns the snake_case labels
+// of every event that has at least one handler declared. The bool reports
+// whether the read+parse succeeded — false on missing/malformed file so
+// callers can stay silent rather than mid-flow noise.
+func declaredCodexEvents(hooksJSONPath string) ([]string, bool) {
+	data, err := os.ReadFile(hooksJSONPath) //nolint:gosec // path constructed from caller-controlled repo root
+	if err != nil {
+		return nil, false
+	}
+	var file HooksFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, false
+	}
+	var events []string
+	add := func(label string, groups []MatcherGroup) {
+		for _, g := range groups {
+			if len(g.Hooks) > 0 {
+				events = append(events, label)
+				return
+			}
+		}
+	}
+	add("session_start", file.Hooks.SessionStart)
+	add("user_prompt_submit", file.Hooks.UserPromptSubmit)
+	add("stop", file.Hooks.Stop)
+	add("pre_tool_use", file.Hooks.PreToolUse)
+	add("post_tool_use", file.Hooks.PostToolUse)
+	return events, true
+}
+
+// codexTrustStateHeaderRegex matches `[hooks.state."<key>"]` headers in
+// the user's Codex config.toml. Quote-only — Codex's own writer emits
+// quoted keys (codex-rs/tui/src/app/background_requests.rs:874), and
+// looser parsing would invite false matches in user-edited configs.
+var codexTrustStateHeaderRegex = regexp.MustCompile(`(?m)^\[hooks\.state\."([^"]+)"\]`)
+
+func readCodexTrustedKeys(configPath string) (map[string]struct{}, bool) {
+	data, err := os.ReadFile(configPath) //nolint:gosec // path resolved from CODEX_HOME or HOME
+	if err != nil {
+		return nil, false
+	}
+	keys := make(map[string]struct{})
+	for _, m := range codexTrustStateHeaderRegex.FindAllStringSubmatch(string(data), -1) {
+		keys[m[1]] = struct{}{}
+	}
+	return keys, true
+}
+
+func codexAnyKeyHasPrefix(keys map[string]struct{}, prefix string) bool {
+	for k := range keys {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/agent/codex/trust.go
+++ b/cmd/entire/cli/agent/codex/trust.go
@@ -93,6 +93,37 @@ func declaredCodexEvents(hooksJSONPath string) ([]string, bool) {
 	return events, true
 }
 
+// MissingEntireHooks returns the snake_case event labels the CLI's
+// canonical install ships today (SessionStart, UserPromptSubmit, Stop,
+// PostToolUse) that aren't backed by an Entire-managed hook command in
+// <repoRoot>/.codex/hooks.json. Surfaces drift when the user enabled
+// Codex on an older release and the install set has since grown.
+//
+// Returns nil when hooks.json is missing or unreadable — those cases
+// are "Codex isn't enabled here", which is a different problem.
+func MissingEntireHooks(repoRoot string) []string {
+	hooksJSONPath := filepath.Join(repoRoot, ".codex", "hooks.json")
+	data, err := os.ReadFile(hooksJSONPath) //nolint:gosec // path constructed from caller-controlled repo root
+	if err != nil {
+		return nil
+	}
+	var file HooksFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil
+	}
+	var missing []string
+	check := func(label string, groups []MatcherGroup) {
+		if !hasEntireHook(groups) {
+			missing = append(missing, label)
+		}
+	}
+	check("session_start", file.Hooks.SessionStart)
+	check("user_prompt_submit", file.Hooks.UserPromptSubmit)
+	check("stop", file.Hooks.Stop)
+	check("post_tool_use", file.Hooks.PostToolUse)
+	return missing
+}
+
 // codexTrustStateHeaderRegex matches `[hooks.state."<key>"]` headers in
 // the user's Codex config.toml. Quote-only — Codex's own writer emits
 // quoted keys (codex-rs/tui/src/app/background_requests.rs:874), and

--- a/cmd/entire/cli/agent/codex/trust_test.go
+++ b/cmd/entire/cli/agent/codex/trust_test.go
@@ -1,0 +1,131 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeTrustFixture sets up the four files HookTrustGaps reads:
+//
+//	<repo>/.codex/hooks.json   – the project's hook declarations
+//	<codexHome>/config.toml    – the user's trust state
+//
+// and points CODEX_HOME at codexHome so HookTrustGaps resolves the user
+// config without touching ~/.codex on the dev machine.
+func writeTrustFixture(t *testing.T, hooksJSON, configTOML string) (repoRoot, hooksPath string) {
+	t.Helper()
+	tmp := t.TempDir()
+	repoRoot = filepath.Join(tmp, "repo")
+	codexHome := filepath.Join(tmp, "codex-home")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, ".codex"), 0o750))
+	require.NoError(t, os.MkdirAll(codexHome, 0o750))
+
+	hooksPath = filepath.Join(repoRoot, ".codex", "hooks.json")
+	require.NoError(t, os.WriteFile(hooksPath, []byte(hooksJSON), 0o600))
+
+	if configTOML != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(configTOML), 0o600))
+	}
+	t.Setenv("CODEX_HOME", codexHome)
+	return repoRoot, hooksPath
+}
+
+// TestHookTrustGaps_FlagsMissingEvent is the primary case: the user
+// trusted three hooks last month, then entire shipped a fourth. The
+// state.toml has three entries; the new event has no key. Detection
+// must surface the missing event so the SessionStart banner can prompt
+// the user to /hooks.
+func TestHookTrustGaps_FlagsMissingEvent(t *testing.T) {
+	hooksJSON := `{
+  "hooks": {
+    "SessionStart": [{"matcher": null, "hooks": [{"type":"command","command":"x","timeout":30}]}],
+    "UserPromptSubmit": [{"matcher": null, "hooks": [{"type":"command","command":"x","timeout":30}]}],
+    "Stop": [{"matcher": null, "hooks": [{"type":"command","command":"x","timeout":30}]}],
+    "PostToolUse": [{"matcher": null, "hooks": [{"type":"command","command":"x","timeout":30}]}]
+  }
+}`
+	repoRoot, hooksPath := writeTrustFixture(t, hooksJSON, "")
+
+	configTOML := `[hooks.state."` + hooksPath + `:session_start:0:0"]
+trusted_hash = "sha256:aaa"
+
+[hooks.state."` + hooksPath + `:user_prompt_submit:0:0"]
+trusted_hash = "sha256:bbb"
+
+[hooks.state."` + hooksPath + `:stop:0:0"]
+trusted_hash = "sha256:ccc"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(os.Getenv("CODEX_HOME"), "config.toml"), []byte(configTOML), 0o600))
+
+	gaps := HookTrustGaps(repoRoot)
+	require.Equal(t, []string{"post_tool_use"}, gaps)
+}
+
+// TestHookTrustGaps_NoGapsWhenAllTrusted returns nil when every declared
+// event has a state entry, even if extra entries exist for other paths.
+func TestHookTrustGaps_NoGapsWhenAllTrusted(t *testing.T) {
+	hooksJSON := `{
+  "hooks": {
+    "SessionStart": [{"matcher": null, "hooks": [{"type":"command","command":"x","timeout":30}]}],
+    "PostToolUse": [{"matcher": null, "hooks": [{"type":"command","command":"x","timeout":30}]}]
+  }
+}`
+	repoRoot, hooksPath := writeTrustFixture(t, hooksJSON, "")
+
+	// Trust both, plus an unrelated entry from another repo to make sure
+	// readCodexTrustedKeys doesn't get confused by parallel installs.
+	configTOML := `[hooks.state."` + hooksPath + `:session_start:0:0"]
+trusted_hash = "sha256:aaa"
+
+[hooks.state."` + hooksPath + `:post_tool_use:0:0"]
+trusted_hash = "sha256:bbb"
+
+[hooks.state."/some/other/repo/.codex/hooks.json:session_start:0:0"]
+trusted_hash = "sha256:ccc"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(os.Getenv("CODEX_HOME"), "config.toml"), []byte(configTOML), 0o600))
+
+	gaps := HookTrustGaps(repoRoot)
+	require.Empty(t, gaps)
+}
+
+// TestHookTrustGaps_NilWhenHooksJSONMissing — Codex isn't enabled in
+// this repo. Stay silent rather than mid-flow noise.
+func TestHookTrustGaps_NilWhenHooksJSONMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("CODEX_HOME", tmp)
+	require.Nil(t, HookTrustGaps(tmp))
+}
+
+// TestHookTrustGaps_NilWhenConfigUnreadable — first-run users have no
+// config.toml yet. Codex's own startup warning still fires for them, so
+// our partial detection staying quiet is the right behavior; we'd
+// otherwise duplicate the warning.
+func TestHookTrustGaps_NilWhenConfigUnreadable(t *testing.T) {
+	hooksJSON := `{"hooks":{"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"x","timeout":30}]}]}}`
+	tmp := t.TempDir()
+	codexHome := filepath.Join(tmp, "codex-home")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, "repo", ".codex"), 0o750))
+	require.NoError(t, os.MkdirAll(codexHome, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "repo", ".codex", "hooks.json"), []byte(hooksJSON), 0o600))
+	t.Setenv("CODEX_HOME", codexHome)
+
+	require.Nil(t, HookTrustGaps(filepath.Join(tmp, "repo")))
+}
+
+// TestHookTrustGaps_HandlesNonzeroHandlerIndex — the state-key prefix
+// match uses "<path>:<event>:" so any group/handler index counts as
+// trust. Pin that explicitly: a non-default index of `0:1` (second
+// handler in first group) should still satisfy the gap check.
+func TestHookTrustGaps_HandlesNonzeroHandlerIndex(t *testing.T) {
+	hooksJSON := `{"hooks":{"PostToolUse":[{"matcher":null,"hooks":[{"type":"command","command":"x","timeout":30}]}]}}`
+	repoRoot, hooksPath := writeTrustFixture(t, hooksJSON, "")
+	configTOML := `[hooks.state."` + hooksPath + `:post_tool_use:0:1"]
+trusted_hash = "sha256:aaa"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(os.Getenv("CODEX_HOME"), "config.toml"), []byte(configTOML), 0o600))
+	require.Empty(t, HookTrustGaps(repoRoot))
+}

--- a/cmd/entire/cli/agent/codex/trust_test.go
+++ b/cmd/entire/cli/agent/codex/trust_test.go
@@ -8,14 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// writeTrustFixture sets up the four files HookTrustGaps reads:
-//
-//	<repo>/.codex/hooks.json   – the project's hook declarations
-//	<codexHome>/config.toml    – the user's trust state
-//
-// and points CODEX_HOME at codexHome so HookTrustGaps resolves the user
-// config without touching ~/.codex on the dev machine.
-func writeTrustFixture(t *testing.T, hooksJSON, configTOML string) (repoRoot, hooksPath string) {
+// writeTrustFixture sets up the .codex/hooks.json fixture and points
+// CODEX_HOME at an isolated temp directory so HookTrustGaps resolves
+// the user config without touching ~/.codex on the dev machine. Tests
+// that need a config.toml write it themselves into CODEX_HOME after
+// the call.
+func writeTrustFixture(t *testing.T, hooksJSON string) (repoRoot, hooksPath string) {
 	t.Helper()
 	tmp := t.TempDir()
 	repoRoot = filepath.Join(tmp, "repo")
@@ -26,9 +24,6 @@ func writeTrustFixture(t *testing.T, hooksJSON, configTOML string) (repoRoot, ho
 	hooksPath = filepath.Join(repoRoot, ".codex", "hooks.json")
 	require.NoError(t, os.WriteFile(hooksPath, []byte(hooksJSON), 0o600))
 
-	if configTOML != "" {
-		require.NoError(t, os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(configTOML), 0o600))
-	}
 	t.Setenv("CODEX_HOME", codexHome)
 	return repoRoot, hooksPath
 }
@@ -47,7 +42,7 @@ func TestHookTrustGaps_FlagsMissingEvent(t *testing.T) {
     "PostToolUse": [{"matcher": null, "hooks": [{"type":"command","command":"x","timeout":30}]}]
   }
 }`
-	repoRoot, hooksPath := writeTrustFixture(t, hooksJSON, "")
+	repoRoot, hooksPath := writeTrustFixture(t, hooksJSON)
 
 	configTOML := `[hooks.state."` + hooksPath + `:session_start:0:0"]
 trusted_hash = "sha256:aaa"
@@ -73,7 +68,7 @@ func TestHookTrustGaps_NoGapsWhenAllTrusted(t *testing.T) {
     "PostToolUse": [{"matcher": null, "hooks": [{"type":"command","command":"x","timeout":30}]}]
   }
 }`
-	repoRoot, hooksPath := writeTrustFixture(t, hooksJSON, "")
+	repoRoot, hooksPath := writeTrustFixture(t, hooksJSON)
 
 	// Trust both, plus an unrelated entry from another repo to make sure
 	// readCodexTrustedKeys doesn't get confused by parallel installs.
@@ -116,13 +111,64 @@ func TestHookTrustGaps_NilWhenConfigUnreadable(t *testing.T) {
 	require.Nil(t, HookTrustGaps(filepath.Join(tmp, "repo")))
 }
 
+// TestMissingEntireHooks_FlagsStaleFile — user enabled Codex on an
+// older release that didn't include PostToolUse. Their hooks.json has
+// the three legacy events but the CLI now installs four. Detection
+// must surface the gap so doctor can prompt `entire enable`.
+func TestMissingEntireHooks_FlagsStaleFile(t *testing.T) {
+	hooksJSON := `{"hooks":{
+		"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex session-start","timeout":30}]}],
+		"UserPromptSubmit":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex user-prompt-submit","timeout":30}]}],
+		"Stop":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex stop","timeout":30}]}]
+	}}`
+	repoRoot, _ := writeTrustFixture(t, hooksJSON)
+	require.Equal(t, []string{"post_tool_use"}, MissingEntireHooks(repoRoot))
+}
+
+// TestMissingEntireHooks_NilWhenAllPresent returns nil when every
+// canonical event has an Entire-managed hook command, even if the file
+// also contains unrelated user-defined entries.
+func TestMissingEntireHooks_NilWhenAllPresent(t *testing.T) {
+	hooksJSON := `{"hooks":{
+		"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex session-start","timeout":30}]}],
+		"UserPromptSubmit":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex user-prompt-submit","timeout":30}]}],
+		"Stop":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex stop","timeout":30}]},
+		        {"matcher":null,"hooks":[{"type":"command","command":"my-custom-tool","timeout":30}]}],
+		"PostToolUse":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex post-tool-use","timeout":30}]}]
+	}}`
+	repoRoot, _ := writeTrustFixture(t, hooksJSON)
+	require.Empty(t, MissingEntireHooks(repoRoot))
+}
+
+// TestMissingEntireHooks_NilWhenFileMissing — Codex isn't enabled for
+// this repo. Stay silent so doctor doesn't tell users to refresh hooks
+// they never installed.
+func TestMissingEntireHooks_NilWhenFileMissing(t *testing.T) {
+	require.Nil(t, MissingEntireHooks(t.TempDir()))
+}
+
+// TestMissingEntireHooks_IgnoresNonEntireCommands — a hooks.json that
+// declares the right events but with non-Entire commands (e.g. user's
+// own scripts) should still flag those events as missing the
+// CLI-managed install.
+func TestMissingEntireHooks_IgnoresNonEntireCommands(t *testing.T) {
+	hooksJSON := `{"hooks":{
+		"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"my-other-tool","timeout":30}]}],
+		"UserPromptSubmit":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex user-prompt-submit","timeout":30}]}],
+		"Stop":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex stop","timeout":30}]}],
+		"PostToolUse":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex post-tool-use","timeout":30}]}]
+	}}`
+	repoRoot, _ := writeTrustFixture(t, hooksJSON)
+	require.Equal(t, []string{"session_start"}, MissingEntireHooks(repoRoot))
+}
+
 // TestHookTrustGaps_HandlesNonzeroHandlerIndex — the state-key prefix
 // match uses "<path>:<event>:" so any group/handler index counts as
 // trust. Pin that explicitly: a non-default index of `0:1` (second
 // handler in first group) should still satisfy the gap check.
 func TestHookTrustGaps_HandlesNonzeroHandlerIndex(t *testing.T) {
 	hooksJSON := `{"hooks":{"PostToolUse":[{"matcher":null,"hooks":[{"type":"command","command":"x","timeout":30}]}]}}`
-	repoRoot, hooksPath := writeTrustFixture(t, hooksJSON, "")
+	repoRoot, hooksPath := writeTrustFixture(t, hooksJSON)
 	configTOML := `[hooks.state."` + hooksPath + `:post_tool_use:0:1"]
 trusted_hash = "sha256:aaa"
 `

--- a/cmd/entire/cli/agent/codex/types.go
+++ b/cmd/entire/cli/agent/codex/types.go
@@ -57,16 +57,12 @@ type userPromptSubmitRaw struct {
 // We only consume the fields we need; unknown fields are ignored.
 type postToolUseRaw struct {
 	SessionID      string          `json:"session_id"`
-	TurnID         string          `json:"turn_id"`
 	TranscriptPath *string         `json:"transcript_path"`
 	CWD            string          `json:"cwd"`
-	HookEventName  string          `json:"hook_event_name"`
 	Model          string          `json:"model"`
-	PermissionMode string          `json:"permission_mode"`
 	ToolName       string          `json:"tool_name"`
 	ToolUseID      string          `json:"tool_use_id"`
 	ToolInput      json.RawMessage `json:"tool_input"`
-	ToolResponse   json.RawMessage `json:"tool_response"`
 }
 
 // applyPatchToolInput is the tool_input shape for apply_patch.

--- a/cmd/entire/cli/agent/codex/types.go
+++ b/cmd/entire/cli/agent/codex/types.go
@@ -1,5 +1,7 @@
 package codex
 
+import "encoding/json"
+
 // HooksFile represents the .codex/hooks.json structure.
 type HooksFile struct {
 	Hooks HookEvents `json:"hooks"`
@@ -11,6 +13,7 @@ type HookEvents struct {
 	UserPromptSubmit []MatcherGroup `json:"UserPromptSubmit,omitempty"`
 	Stop             []MatcherGroup `json:"Stop,omitempty"`
 	PreToolUse       []MatcherGroup `json:"PreToolUse,omitempty"`
+	PostToolUse      []MatcherGroup `json:"PostToolUse,omitempty"`
 }
 
 // MatcherGroup groups hooks under an optional matcher pattern.
@@ -47,6 +50,29 @@ type userPromptSubmitRaw struct {
 	Model          string  `json:"model"`
 	PermissionMode string  `json:"permission_mode"`
 	Prompt         string  `json:"prompt"`
+}
+
+// postToolUseRaw is the JSON structure from PostToolUse hooks.
+// Schema source: codex-rs/hooks/src/schema.rs PostToolUseCommandInput.
+// We only consume the fields we need; unknown fields are ignored.
+type postToolUseRaw struct {
+	SessionID      string          `json:"session_id"`
+	TurnID         string          `json:"turn_id"`
+	TranscriptPath *string         `json:"transcript_path"`
+	CWD            string          `json:"cwd"`
+	HookEventName  string          `json:"hook_event_name"`
+	Model          string          `json:"model"`
+	PermissionMode string          `json:"permission_mode"`
+	ToolName       string          `json:"tool_name"`
+	ToolUseID      string          `json:"tool_use_id"`
+	ToolInput      json.RawMessage `json:"tool_input"`
+	ToolResponse   json.RawMessage `json:"tool_response"`
+}
+
+// applyPatchToolInput is the tool_input shape for apply_patch.
+// Codex serializes the patch envelope as a single string under "command".
+type applyPatchToolInput struct {
+	Command string `json:"command"`
 }
 
 // stopRaw is the JSON structure from Stop hooks.

--- a/cmd/entire/cli/agent/event.go
+++ b/cmd/entire/cli/agent/event.go
@@ -118,27 +118,19 @@ type Event struct {
 	SubagentType    string
 	TaskDescription string
 
-	// ModifiedFiles is a list of file paths modified by a subagent or a tool call.
-	// Populated on:
-	//   - SubagentEnd events when the agent provides this data directly via hook
-	//     payload (e.g., Cursor's subagentStop).
-	//   - ToolUse events when the agent fires a per-tool-use hook with file paths
-	//     (e.g., Codex's PostToolUse for apply_patch).
-	// Paths may be absolute, cwd-relative, or repo-relative; the lifecycle handler
-	// normalizes them via FilterAndNormalizePaths using the event's CWD or the
-	// repo root.
+	// ModifiedFiles is the list of file paths modified by a subagent (SubagentEnd)
+	// or a tool call (ToolUse). Paths may be absolute, cwd-relative, or
+	// repo-relative; lifecycle handlers normalize against the worktree root.
 	ModifiedFiles []string
 
-	// NewFiles is a list of file paths created by a tool call (ToolUse events).
-	NewFiles []string
-
-	// DeletedFiles is a list of file paths deleted by a tool call (ToolUse events).
+	// NewFiles and DeletedFiles carry create/delete paths for ToolUse events,
+	// kept separate from ModifiedFiles so consumers can reason about agent intent.
+	NewFiles     []string
 	DeletedFiles []string
 
 	// CWD is the working directory the agent was running in when the event fired.
-	// Populated on ToolUse events so the lifecycle handler can resolve cwd-relative
-	// paths from the hook payload (e.g., Codex apply_patch paths) to absolute paths
-	// before normalization to repo-relative.
+	// Set on ToolUse so cwd-relative payload paths can be resolved before
+	// repo-root normalization.
 	CWD string
 
 	// ResponseMessage is an optional message to display to the user via the agent.

--- a/cmd/entire/cli/agent/event.go
+++ b/cmd/entire/cli/agent/event.go
@@ -40,6 +40,13 @@ const (
 	// (e.g., Gemini CLI's BeforeModel). The framework stores the model as a hint
 	// for subsequent TurnStart/TurnEnd events in the same session.
 	ModelUpdate
+
+	// ToolUse indicates the agent ran a tool that touched files mid-turn.
+	// Carries ModifiedFiles/NewFiles/DeletedFiles so the framework can populate
+	// state.FilesTouched incrementally — without this, agents like Codex that
+	// commit mid-turn (before TurnEnd fires) have no per-tool file accounting,
+	// and the carry-forward path falls back to whole-transcript extraction.
+	ToolUse
 )
 
 // String returns a human-readable name for the event type.
@@ -61,6 +68,8 @@ func (e EventType) String() string {
 		return "SubagentEnd"
 	case ModelUpdate:
 		return "ModelUpdate"
+	case ToolUse:
+		return "ToolUse"
 	default:
 		return "Unknown"
 	}
@@ -109,10 +118,28 @@ type Event struct {
 	SubagentType    string
 	TaskDescription string
 
-	// ModifiedFiles is a list of file paths modified by a subagent.
-	// Populated on SubagentEnd events when the agent provides this data
-	// directly via hook payload (e.g., Cursor's subagentStop).
+	// ModifiedFiles is a list of file paths modified by a subagent or a tool call.
+	// Populated on:
+	//   - SubagentEnd events when the agent provides this data directly via hook
+	//     payload (e.g., Cursor's subagentStop).
+	//   - ToolUse events when the agent fires a per-tool-use hook with file paths
+	//     (e.g., Codex's PostToolUse for apply_patch).
+	// Paths may be absolute, cwd-relative, or repo-relative; the lifecycle handler
+	// normalizes them via FilterAndNormalizePaths using the event's CWD or the
+	// repo root.
 	ModifiedFiles []string
+
+	// NewFiles is a list of file paths created by a tool call (ToolUse events).
+	NewFiles []string
+
+	// DeletedFiles is a list of file paths deleted by a tool call (ToolUse events).
+	DeletedFiles []string
+
+	// CWD is the working directory the agent was running in when the event fired.
+	// Populated on ToolUse events so the lifecycle handler can resolve cwd-relative
+	// paths from the hook payload (e.g., Codex apply_patch paths) to absolute paths
+	// before normalization to repo-relative.
+	CWD string
 
 	// ResponseMessage is an optional message to display to the user via the agent.
 	ResponseMessage string

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -679,16 +679,20 @@ func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error {
 	return nil
 }
 
-// checkCodexHookTrust warns when Codex hooks declared in
-// <repo>/.codex/hooks.json lack a `trusted_hash` entry in the user's
-// Codex config — either a fresh-clone first-run before the user has
-// opened /hooks, or a newer entire release that added a hook the user
-// trusted on an older version.
+// checkCodexHookTrust warns about two kinds of drift in the Codex hook
+// setup:
 //
-// Detection is structural (key presence in the user's config.toml).
-// Stays silent when this repo doesn't have codex hooks installed or
-// when we can't resolve the worktree root. There's no fix we can
-// apply: the user has to approve via Codex's /hooks UI. Warn-only.
+//  1. .codex/hooks.json is stale relative to what the CLI installs
+//     today (e.g. a release added PostToolUse after the user enabled
+//     Codex). Fix: re-run `entire enable`.
+//
+//  2. A declared hook lacks a `trusted_hash` entry in the user's Codex
+//     config — either a fresh clone or a newer hook on the file the
+//     user hasn't approved yet. Fix: open /hooks in Codex.
+//
+// Both checks are structural (file/key presence). Stays silent when
+// this repo doesn't have codex hooks installed or when we can't
+// resolve the worktree root. Warn-only.
 func checkCodexHookTrust(cmd *cobra.Command) {
 	repoRoot, err := paths.WorktreeRoot(cmd.Context())
 	if err != nil {
@@ -699,18 +703,31 @@ func checkCodexHookTrust(cmd *cobra.Command) {
 	}
 
 	w := cmd.OutOrStdout()
+	missing := codex.MissingEntireHooks(repoRoot)
 	gaps := codex.HookTrustGaps(repoRoot)
-	if len(gaps) == 0 {
+
+	if len(missing) == 0 && len(gaps) == 0 {
 		fmt.Fprintln(w, "✓ Codex hook trust: OK")
 		return
 	}
 
-	fmt.Fprintln(w, "Codex hook trust: REVIEW NEEDED")
-	fmt.Fprintf(w, "  %d hook(s) declared in .codex/hooks.json have no trusted_hash entry yet:\n", len(gaps))
-	for _, ev := range gaps {
-		fmt.Fprintf(w, "    - %s\n", ev)
+	if len(missing) > 0 {
+		fmt.Fprintln(w, "Codex hooks: OUT OF DATE")
+		fmt.Fprintf(w, "  %d hook(s) the CLI installs today aren't declared in .codex/hooks.json:\n", len(missing))
+		for _, ev := range missing {
+			fmt.Fprintf(w, "    - %s\n", ev)
+		}
+		fmt.Fprintln(w, "  Run `entire enable` to refresh the hooks file.")
 	}
-	fmt.Fprintln(w, "  Open /hooks inside Codex to approve them.")
+
+	if len(gaps) > 0 {
+		fmt.Fprintln(w, "Codex hook trust: REVIEW NEEDED")
+		fmt.Fprintf(w, "  %d hook(s) declared in .codex/hooks.json have no trusted_hash entry yet:\n", len(gaps))
+		for _, ev := range gaps {
+			fmt.Fprintf(w, "    - %s\n", ev)
+		}
+		fmt.Fprintln(w, "  Open /hooks inside Codex to approve them.")
+	}
 }
 
 // canDeleteShadowBranch checks if a shadow branch can be safely deleted.

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
 	"charm.land/huh/v2"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -40,7 +43,13 @@ Checks performed:
   4. v2 checkpoint counts: verifies /main and /full/current checkpoint counts are consistent.
   5. v2 generation health: checks archived generations for valid metadata.
 
-  6. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
+  When Codex hooks are installed:
+  6. Codex hook trust: warn when hooks declared in .codex/hooks.json
+     lack a trusted_hash entry in the user's Codex config (i.e. /hooks
+     review hasn't run yet on this machine, or a newer entire release
+     added a hook the user hasn't approved yet).
+
+  7. Stuck sessions: sessions stuck in ACTIVE or ENDED phase that need cleanup.
 
 A session is considered stuck if:
   - It is in ACTIVE phase with no interaction for over 1 hour
@@ -138,6 +147,9 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 
 		fmt.Fprintln(cmd.OutOrStdout())
 	}
+
+	// Agent-specific: Codex hook trust state.
+	checkCodexHookTrust(cmd)
 
 	// Stuck sessions
 	// Load all session states
@@ -665,6 +677,40 @@ func checkV2RefExistence(cmd *cobra.Command, repo *git.Repository) error {
 	}
 
 	return nil
+}
+
+// checkCodexHookTrust warns when Codex hooks declared in
+// <repo>/.codex/hooks.json lack a `trusted_hash` entry in the user's
+// Codex config — either a fresh-clone first-run before the user has
+// opened /hooks, or a newer entire release that added a hook the user
+// trusted on an older version.
+//
+// Detection is structural (key presence in the user's config.toml).
+// Stays silent when this repo doesn't have codex hooks installed or
+// when we can't resolve the worktree root. There's no fix we can
+// apply: the user has to approve via Codex's /hooks UI. Warn-only.
+func checkCodexHookTrust(cmd *cobra.Command) {
+	repoRoot, err := paths.WorktreeRoot(cmd.Context())
+	if err != nil {
+		return
+	}
+	if _, statErr := os.Stat(filepath.Join(repoRoot, ".codex", "hooks.json")); statErr != nil {
+		return
+	}
+
+	w := cmd.OutOrStdout()
+	gaps := codex.HookTrustGaps(repoRoot)
+	if len(gaps) == 0 {
+		fmt.Fprintln(w, "✓ Codex hook trust: OK")
+		return
+	}
+
+	fmt.Fprintln(w, "Codex hook trust: REVIEW NEEDED")
+	fmt.Fprintf(w, "  %d hook(s) declared in .codex/hooks.json have no trusted_hash entry yet:\n", len(gaps))
+	for _, ev := range gaps {
+		fmt.Fprintf(w, "    - %s\n", ev)
+	}
+	fmt.Fprintln(w, "  Open /hooks inside Codex to approve them.")
 }
 
 // canDeleteShadowBranch checks if a shadow branch can be safely deleted.

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -865,3 +865,87 @@ func TestRunSessionsFix_V2ChecksRunWhenEnabled(t *testing.T) {
 	assert.Contains(t, output, "v2 /main ref: OK (no remote to compare)")
 	assert.Contains(t, output, "v2 refs: OK")
 }
+
+// TestCheckCodexHookTrust_SilentWhenCodexNotInstalled — `entire doctor`
+// shouldn't print anything Codex-related when this repo doesn't have
+// .codex/hooks.json. Other agents (Claude, Cursor) keep their existing
+// quiet behavior; the codex check has to be opt-in by file presence.
+func TestCheckCodexHookTrust_SilentWhenCodexNotInstalled(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	cmd, stdout, _ := newTestCmd(t)
+	checkCodexHookTrust(cmd)
+	require.NotContains(t, stdout.String(), "Codex hook trust")
+}
+
+// resolvedHooksPath returns the .codex/hooks.json path under dir using the
+// symlink-resolved form `git rev-parse --show-toplevel` would return. Test
+// fixtures need this because t.TempDir() can produce a /var path while git
+// hands back the /private/var equivalent on macOS — divergence between the
+// two breaks the trust-state key match the production code uses.
+func resolvedHooksPath(t *testing.T, dir string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+	return filepath.Join(resolved, ".codex", "hooks.json")
+}
+
+// TestCheckCodexHookTrust_OKWhenAllTrusted prints "✓ Codex hook trust: OK"
+// when every event declared in hooks.json has a matching state entry.
+func TestCheckCodexHookTrust_OKWhenAllTrusted(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	codexDir := filepath.Join(dir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(`{"hooks":{"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"x","timeout":30}]}]}}`), 0o600))
+
+	hooksPath := resolvedHooksPath(t, dir)
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	require.NoError(t, os.MkdirAll(codexHome, 0o750))
+	configTOML := `[hooks.state."` + hooksPath + `:session_start:0:0"]
+trusted_hash = "sha256:aaa"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(configTOML), 0o600))
+	t.Setenv("CODEX_HOME", codexHome)
+
+	cmd, stdout, _ := newTestCmd(t)
+	checkCodexHookTrust(cmd)
+	require.Contains(t, stdout.String(), "✓ Codex hook trust: OK")
+}
+
+// TestCheckCodexHookTrust_ListsMissingEvents prints the gap list when a
+// hook event has no corresponding trusted_hash. Pinning the format
+// keeps the doctor output script-grep-friendly.
+func TestCheckCodexHookTrust_ListsMissingEvents(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	codexDir := filepath.Join(dir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+	hooksJSON := `{"hooks":{
+		"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"x","timeout":30}]}],
+		"PostToolUse":[{"matcher":null,"hooks":[{"type":"command","command":"x","timeout":30}]}]
+	}}`
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(hooksJSON), 0o600))
+
+	hooksPath := resolvedHooksPath(t, dir)
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	require.NoError(t, os.MkdirAll(codexHome, 0o750))
+	// Trust SessionStart only — PostToolUse is the gap.
+	configTOML := `[hooks.state."` + hooksPath + `:session_start:0:0"]
+trusted_hash = "sha256:aaa"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(configTOML), 0o600))
+	t.Setenv("CODEX_HOME", codexHome)
+
+	cmd, stdout, _ := newTestCmd(t)
+	checkCodexHookTrust(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "Codex hook trust: REVIEW NEEDED")
+	require.Contains(t, out, "1 hook(s) declared")
+	require.Contains(t, out, "- post_tool_use")
+	require.Contains(t, out, "Open /hooks inside Codex")
+}

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -891,6 +891,18 @@ func resolvedHooksPath(t *testing.T, dir string) string {
 	return filepath.Join(resolved, ".codex", "hooks.json")
 }
 
+// canonicalCodexHooksJSON returns a hooks.json declaring all four
+// canonical Entire-managed events. Tests use this as the "current"
+// install baseline so the missing-hooks check passes.
+func canonicalCodexHooksJSON() string {
+	return `{"hooks":{
+		"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex session-start","timeout":30}]}],
+		"UserPromptSubmit":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex user-prompt-submit","timeout":30}]}],
+		"Stop":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex stop","timeout":30}]}],
+		"PostToolUse":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex post-tool-use","timeout":30}]}]
+	}}`
+}
+
 // TestCheckCodexHookTrust_OKWhenAllTrusted prints "✓ Codex hook trust: OK"
 // when every event declared in hooks.json has a matching state entry.
 func TestCheckCodexHookTrust_OKWhenAllTrusted(t *testing.T) {
@@ -899,13 +911,22 @@ func TestCheckCodexHookTrust_OKWhenAllTrusted(t *testing.T) {
 
 	codexDir := filepath.Join(dir, ".codex")
 	require.NoError(t, os.MkdirAll(codexDir, 0o750))
-	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(`{"hooks":{"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"x","timeout":30}]}]}}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(canonicalCodexHooksJSON()), 0o600))
 
 	hooksPath := resolvedHooksPath(t, dir)
 	codexHome := filepath.Join(t.TempDir(), "codex-home")
 	require.NoError(t, os.MkdirAll(codexHome, 0o750))
 	configTOML := `[hooks.state."` + hooksPath + `:session_start:0:0"]
 trusted_hash = "sha256:aaa"
+
+[hooks.state."` + hooksPath + `:user_prompt_submit:0:0"]
+trusted_hash = "sha256:bbb"
+
+[hooks.state."` + hooksPath + `:stop:0:0"]
+trusted_hash = "sha256:ccc"
+
+[hooks.state."` + hooksPath + `:post_tool_use:0:0"]
+trusted_hash = "sha256:ddd"
 `
 	require.NoError(t, os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(configTOML), 0o600))
 	t.Setenv("CODEX_HOME", codexHome)
@@ -924,18 +945,20 @@ func TestCheckCodexHookTrust_ListsMissingEvents(t *testing.T) {
 
 	codexDir := filepath.Join(dir, ".codex")
 	require.NoError(t, os.MkdirAll(codexDir, 0o750))
-	hooksJSON := `{"hooks":{
-		"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"x","timeout":30}]}],
-		"PostToolUse":[{"matcher":null,"hooks":[{"type":"command","command":"x","timeout":30}]}]
-	}}`
-	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(hooksJSON), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(canonicalCodexHooksJSON()), 0o600))
 
 	hooksPath := resolvedHooksPath(t, dir)
 	codexHome := filepath.Join(t.TempDir(), "codex-home")
 	require.NoError(t, os.MkdirAll(codexHome, 0o750))
-	// Trust SessionStart only — PostToolUse is the gap.
+	// Trust three of four — PostToolUse is the gap.
 	configTOML := `[hooks.state."` + hooksPath + `:session_start:0:0"]
 trusted_hash = "sha256:aaa"
+
+[hooks.state."` + hooksPath + `:user_prompt_submit:0:0"]
+trusted_hash = "sha256:bbb"
+
+[hooks.state."` + hooksPath + `:stop:0:0"]
+trusted_hash = "sha256:ccc"
 `
 	require.NoError(t, os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(configTOML), 0o600))
 	t.Setenv("CODEX_HOME", codexHome)
@@ -948,4 +971,48 @@ trusted_hash = "sha256:aaa"
 	require.Contains(t, out, "1 hook(s) declared")
 	require.Contains(t, out, "- post_tool_use")
 	require.Contains(t, out, "Open /hooks inside Codex")
+}
+
+// TestCheckCodexHookTrust_FlagsStaleHooksFile — user enabled Codex on
+// an older release that didn't ship PostToolUse. Their hooks.json has
+// only the three legacy events. Doctor must surface the gap and tell
+// them to re-run `entire enable`.
+func TestCheckCodexHookTrust_FlagsStaleHooksFile(t *testing.T) {
+	dir := setupGitRepoForPhaseTest(t)
+	t.Chdir(dir)
+
+	codexDir := filepath.Join(dir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+	staleHooksJSON := `{"hooks":{
+		"SessionStart":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex session-start","timeout":30}]}],
+		"UserPromptSubmit":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex user-prompt-submit","timeout":30}]}],
+		"Stop":[{"matcher":null,"hooks":[{"type":"command","command":"entire hooks codex stop","timeout":30}]}]
+	}}`
+	require.NoError(t, os.WriteFile(filepath.Join(codexDir, "hooks.json"), []byte(staleHooksJSON), 0o600))
+
+	hooksPath := resolvedHooksPath(t, dir)
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	require.NoError(t, os.MkdirAll(codexHome, 0o750))
+	// Trust the three legacy events so the trust check itself stays quiet —
+	// only the stale-file finding should fire.
+	configTOML := `[hooks.state."` + hooksPath + `:session_start:0:0"]
+trusted_hash = "sha256:aaa"
+
+[hooks.state."` + hooksPath + `:user_prompt_submit:0:0"]
+trusted_hash = "sha256:bbb"
+
+[hooks.state."` + hooksPath + `:stop:0:0"]
+trusted_hash = "sha256:ccc"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(configTOML), 0o600))
+	t.Setenv("CODEX_HOME", codexHome)
+
+	cmd, stdout, _ := newTestCmd(t)
+	checkCodexHookTrust(cmd)
+
+	out := stdout.String()
+	require.Contains(t, out, "Codex hooks: OUT OF DATE")
+	require.Contains(t, out, "- post_tool_use")
+	require.Contains(t, out, "entire enable")
+	require.NotContains(t, out, "Codex hook trust: REVIEW NEEDED")
 }

--- a/cmd/entire/cli/integration_test/codex_post_tool_use_test.go
+++ b/cmd/entire/cli/integration_test/codex_post_tool_use_test.go
@@ -1,0 +1,134 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCodexPostToolUse_PopulatesFilesTouched verifies the end-to-end wiring
+// of Codex's PostToolUse hook: the apply_patch envelope is parsed in
+// codex.parsePostToolUse, dispatched as agent.ToolUse, and merged into
+// state.FilesTouched by handleLifecycleToolUse.
+//
+// This is the regression guard for the original Codex bug — without per-tool
+// file accounting, mid-turn commits triggered carry-forward erroneously and
+// reset the checkpoint transcript offset on the next condense.
+func TestCodexPostToolUse_PopulatesFilesTouched(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+
+	sessionID := "test-codex-post-tool-use"
+	statePath := filepath.Join(env.RepoDir, ".git", "entire-sessions", sessionID+".json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(statePath), 0o755))
+
+	// Pre-create state with AgentType=Codex. We skip UserPromptSubmit because
+	// the hook handler we're exercising doesn't depend on phase or pending
+	// attribution — just on the state file existing for RecordFilesTouched.
+	initialState := map[string]any{
+		"session_id":  sessionID,
+		"agent_type":  "Codex",
+		"base_commit": env.GetHeadHash(),
+		"started_at":  time.Now().Format(time.RFC3339Nano),
+		"step_count":  0,
+	}
+	initialBytes, err := json.Marshal(initialState)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(statePath, initialBytes, 0o600))
+
+	patch := "*** Begin Patch\n" +
+		"*** Add File: docs/added.md\n" +
+		"+# added\n" +
+		"*** Update File: src/changed.go\n" +
+		"@@\n" +
+		"-old\n" +
+		"+new\n" +
+		"*** Delete File: tmp/gone.txt\n" +
+		"*** End Patch\n"
+
+	runner := NewCodexHookRunner(env.RepoDir, t)
+	require.NoError(t, runner.SimulateCodexPostToolUseApplyPatch(sessionID, env.RepoDir, patch))
+
+	afterBytes, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+
+	var after map[string]any
+	require.NoError(t, json.Unmarshal(afterBytes, &after))
+
+	rawFiles, ok := after["files_touched"].([]any)
+	require.True(t, ok, "files_touched should be present and an array; got %T", after["files_touched"])
+
+	got := make([]string, 0, len(rawFiles))
+	for _, v := range rawFiles {
+		s, _ := v.(string)
+		got = append(got, s)
+	}
+	assert.ElementsMatch(t,
+		[]string{"docs/added.md", "src/changed.go", "tmp/gone.txt"},
+		got,
+		"PostToolUse should merge Add/Update/Delete paths into FilesTouched")
+}
+
+// TestCodexPostToolUse_NonMutatingToolIsNoop verifies that PostToolUse hooks
+// for non-apply_patch tools (e.g., shell) leave session state unchanged.
+// Without this guard the hook would churn state on every shell command and
+// risk overwriting genuine FilesTouched entries with empty data.
+func TestCodexPostToolUse_NonMutatingToolIsNoop(t *testing.T) {
+	t.Parallel()
+	env := NewRepoWithCommit(t)
+
+	sessionID := "test-codex-post-tool-use-noop"
+	statePath := filepath.Join(env.RepoDir, ".git", "entire-sessions", sessionID+".json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(statePath), 0o755))
+
+	initialState := map[string]any{
+		"session_id":    sessionID,
+		"agent_type":    "Codex",
+		"base_commit":   env.GetHeadHash(),
+		"started_at":    time.Now().Format(time.RFC3339Nano),
+		"step_count":    1,
+		"files_touched": []string{"existing.go"},
+	}
+	initialBytes, err := json.Marshal(initialState)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(statePath, initialBytes, 0o600))
+
+	// Shape mirrors codex-rs PostToolUseCommandInput for a shell call. The
+	// parser must skip it without mutating state.
+	input := map[string]any{
+		"session_id":      sessionID,
+		"turn_id":         "t1",
+		"transcript_path": nil,
+		"cwd":             env.RepoDir,
+		"hook_event_name": "PostToolUse",
+		"model":           "gpt-5",
+		"permission_mode": "default",
+		"tool_name":       "shell",
+		"tool_use_id":     "call-shell",
+		"tool_input":      map[string]any{"command": []string{"echo", "hi"}},
+		"tool_response":   "hi\n",
+	}
+	inputJSON, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	runner := NewCodexHookRunner(env.RepoDir, t)
+	require.NoError(t, runner.runCodexHook("post-tool-use", inputJSON))
+
+	afterBytes, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+
+	var after map[string]any
+	require.NoError(t, json.Unmarshal(afterBytes, &after))
+
+	rawFiles, ok := after["files_touched"].([]any)
+	require.True(t, ok)
+	require.Len(t, rawFiles, 1)
+	assert.Equal(t, "existing.go", rawFiles[0])
+}

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -612,6 +612,73 @@ func (env *TestEnv) WriteSessionState(sessionID string, state *strategy.SessionS
 	return nil
 }
 
+// CodexHookRunner executes Codex hooks in the test environment.
+type CodexHookRunner struct {
+	RepoDir string
+	T       interface {
+		Helper()
+		Fatalf(format string, args ...interface{})
+		Logf(format string, args ...interface{})
+	}
+}
+
+// NewCodexHookRunner creates a new Codex hook runner for the given repo directory.
+func NewCodexHookRunner(repoDir string, t interface {
+	Helper()
+	Fatalf(format string, args ...interface{})
+	Logf(format string, args ...interface{})
+}) *CodexHookRunner {
+	return &CodexHookRunner{
+		RepoDir: repoDir,
+		T:       t,
+	}
+}
+
+// runCodexHook runs a Codex hook subcommand with the given JSON stdin.
+func (r *CodexHookRunner) runCodexHook(hookName string, inputJSON []byte) error {
+	r.T.Helper()
+	cmd := exec.Command(getTestBinary(), "hooks", "codex", hookName)
+	cmd.Dir = r.RepoDir
+	cmd.Stdin = bytes.NewReader(inputJSON)
+	cmd.Env = testutil.GitIsolatedEnv()
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("hook %s failed: %w\nInput: %s\nOutput: %s",
+			hookName, err, inputJSON, output)
+	}
+	r.T.Logf("Codex hook %s output: %s", hookName, output)
+	return nil
+}
+
+// SimulateCodexPostToolUseApplyPatch simulates the Codex PostToolUse hook for an
+// apply_patch tool invocation. The patch envelope is the canonical Codex
+// plain-text format ("*** Add File: …", etc.) carried in tool_input.command,
+// matching the on-wire shape of codex-rs PostToolUseCommandInput. The
+// lifecycle dispatcher routes it to handleLifecycleToolUse, which merges the
+// extracted paths into the session's FilesTouched.
+func (r *CodexHookRunner) SimulateCodexPostToolUseApplyPatch(sessionID, cwd, patch string) error {
+	r.T.Helper()
+	input := map[string]any{
+		"session_id":      sessionID,
+		"turn_id":         "test-turn",
+		"transcript_path": nil,
+		"cwd":             cwd,
+		"hook_event_name": "PostToolUse",
+		"model":           "gpt-5",
+		"permission_mode": "default",
+		"tool_name":       "apply_patch",
+		"tool_use_id":     "test-call",
+		"tool_input":      map[string]string{"command": patch},
+		"tool_response":   "Success.",
+	}
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		return fmt.Errorf("marshal hook input: %w", err)
+	}
+	return r.runCodexHook("post-tool-use", inputJSON)
+}
+
 // GeminiHookRunner executes Gemini CLI hooks in the test environment.
 type GeminiHookRunner struct {
 	RepoDir          string

--- a/cmd/entire/cli/integration_test/setup_codex_hooks_test.go
+++ b/cmd/entire/cli/integration_test/setup_codex_hooks_test.go
@@ -44,6 +44,9 @@ func TestSetupCodexHooks_AddsAllRequiredHooks(t *testing.T) {
 	if !strings.Contains(hooksContent, "entire hooks codex stop") {
 		t.Error("Codex Stop hook should exist")
 	}
+	if !strings.Contains(hooksContent, "entire hooks codex post-tool-use") {
+		t.Error("Codex PostToolUse hook should exist")
+	}
 
 	searchAgentPath := filepath.Join(env.RepoDir, ".codex", "agents", "entire-search.toml")
 	searchData, err := os.ReadFile(searchAgentPath)

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -1016,28 +1016,23 @@ func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agen
 // markSessionEnded transitions the session to ENDED phase via the state machine.
 // If event is non-nil, hook-provided metrics are persisted to state before saving.
 func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string) error {
-	state, err := strategy.LoadSessionState(ctx, sessionID)
-	if err != nil {
-		return fmt.Errorf("failed to load session state: %w", err)
+	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+		if event != nil {
+			persistEventMetadataToState(event, state)
+		}
+		if transErr := strategy.TransitionAndLog(ctx, state, session.EventSessionStop, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
+			logging.Warn(logging.WithComponent(ctx, "lifecycle"), "session stop transition failed",
+				slog.String("error", transErr.Error()))
+		}
+		now := time.Now()
+		state.EndedAt = &now
+		return nil
+	})
+	if errors.Is(mutErr, strategy.ErrStateNotFound) {
+		return nil
 	}
-	if state == nil {
-		return nil // No state file, nothing to update
-	}
-
-	if event != nil {
-		persistEventMetadataToState(event, state)
-	}
-
-	if transErr := strategy.TransitionAndLog(ctx, state, session.EventSessionStop, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
-		logging.Warn(logging.WithComponent(ctx, "lifecycle"), "session stop transition failed",
-			slog.String("error", transErr.Error()))
-	}
-
-	now := time.Now()
-	state.EndedAt = &now
-
-	if err := strategy.SaveSessionState(ctx, state); err != nil {
-		return fmt.Errorf("failed to save session state: %w", err)
+	if mutErr != nil {
+		return fmt.Errorf("failed to save session state: %w", mutErr)
 	}
 	return nil
 }

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -254,13 +254,8 @@ func handleLifecycleModelUpdate(ctx context.Context, ag agent.Agent, event *agen
 
 // handleLifecycleToolUse merges files reported by a per-tool-use hook into
 // the session's FilesTouched. Lightweight by design: no SaveStep, no shadow
-// branch commit — just enough so a mid-turn commit's PostCommit handler sees
-// an accurate FilesTouched list and the carry-forward decision is correct.
-//
-// Path normalization mirrors handleLifecycleTurnEnd: paths are filtered to
-// repo-root-relative via FilterAndNormalizePaths against the worktree root,
-// after first being made absolute via event.CWD when they're relative
-// (Codex's apply_patch envelope carries cwd-relative paths).
+// branch commit — just enough so PostCommit's carry-forward decision sees
+// an accurate file list mid-turn.
 func handleLifecycleToolUse(ctx context.Context, ag agent.Agent, event *agent.Event) error {
 	logCtx := logging.WithAgent(logging.WithComponent(ctx, "lifecycle"), ag.Name())
 
@@ -305,10 +300,9 @@ func handleLifecycleToolUse(ctx context.Context, ag agent.Agent, event *agent.Ev
 	return nil
 }
 
-// normalizeToolUsePaths converts hook-payload paths to repo-relative form.
-// Cwd-relative entries (the common Codex apply_patch shape) are first joined
-// against eventCWD so FilterAndNormalizePaths sees an absolute path it can
-// rewrite against repoRoot. Absolute entries pass through unchanged.
+// normalizeToolUsePaths converts hook-payload paths to repo-root-relative form.
+// Codex apply_patch envelopes carry cwd-relative paths, so we join them against
+// eventCWD before FilterAndNormalizePaths rewrites against repoRoot.
 func normalizeToolUsePaths(files []string, eventCWD, repoRoot string) []string {
 	if len(files) == 0 {
 		return nil

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -395,6 +395,10 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 	// is no file race across worktrees. Errors in load/save must not fail the turn.
 	if mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
 		before := *state
+		// Slice fields share their backing array under struct copy. If
+		// adoptReviewEnv ever mutates ReviewSkills in place, the diff check
+		// below would silently miss it. Clone to keep the comparison honest.
+		before.ReviewSkills = slices.Clone(state.ReviewSkills)
 		adoptReviewEnv(logCtx, state, string(ag.Name()))
 		if state.Kind == before.Kind && state.ReviewPrompt == before.ReviewPrompt && slices.Equal(state.ReviewSkills, before.ReviewSkills) {
 			return strategy.ErrMutationSkip

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -179,19 +179,16 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 	}
 
 	// Fire EventSessionStart for the current session (if state exists).
-	if state, loadErr := strategy.LoadSessionState(ctx, event.SessionID); loadErr != nil {
-		logging.Warn(logCtx, "failed to load session state on start",
-			slog.String("error", loadErr.Error()))
-	} else if state != nil {
+	if mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
 		persistEventMetadataToState(event, state)
 		if transErr := strategy.TransitionAndLog(ctx, state, session.EventSessionStart, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logCtx, "session start transition failed",
 				slog.String("error", transErr.Error()))
 		}
-		if saveErr := strategy.SaveSessionState(ctx, state); saveErr != nil {
-			logging.Warn(logCtx, "failed to update session state on start",
-				slog.String("error", saveErr.Error()))
-		}
+		return nil
+	}); mutErr != nil {
+		logging.Warn(logCtx, "failed to update session state on start",
+			slog.String("error", mutErr.Error()))
 	}
 
 	return nil
@@ -229,21 +226,20 @@ func handleLifecycleModelUpdate(ctx context.Context, ag agent.Agent, event *agen
 	}
 
 	// Prefer writing directly to session state when it exists
-	state, loadErr := strategy.LoadSessionState(ctx, event.SessionID)
-	if loadErr != nil {
-		logging.Debug(logCtx, "could not load session state for model update, using hint file",
-			slog.String("error", loadErr.Error()))
-	}
-	if loadErr == nil && state != nil {
+	mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
 		state.ModelName = event.Model
-		if saveErr := strategy.SaveSessionState(ctx, state); saveErr != nil {
-			logging.Warn(logCtx, "failed to update session state with model",
-				slog.String("error", saveErr.Error()))
-		}
+		return nil
+	})
+	if mutErr == nil {
+		return nil
+	}
+	if !errors.Is(mutErr, strategy.ErrStateNotFound) {
+		logging.Warn(logCtx, "failed to update session state with model",
+			slog.String("error", mutErr.Error()))
 		return nil
 	}
 
-	// State doesn't exist yet (or failed to load) — use hint file (see StoreModelHint doc)
+	// State doesn't exist yet — use hint file (see StoreModelHint doc)
 	if err := strategy.StoreModelHint(ctx, event.SessionID, event.Model); err != nil {
 		logging.Warn(logCtx, "failed to store model hint",
 			slog.String("error", err.Error()))
@@ -397,18 +393,16 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 	// Best-effort: adopt ENTIRE_REVIEW_* env vars set by `entire review` on
 	// the spawned agent process. Each agent process has its own env, so there
 	// is no file race across worktrees. Errors in load/save must not fail the turn.
-	if state, loadErr := strategy.LoadSessionState(ctx, sessionID); loadErr != nil {
-		logging.Warn(logCtx, "failed to load session state for review env adoption",
-			slog.String("error", loadErr.Error()))
-	} else if state != nil {
-		updated := *state
-		adoptReviewEnv(logCtx, &updated, string(ag.Name()))
-		if updated.Kind != state.Kind || updated.ReviewPrompt != state.ReviewPrompt || !slices.Equal(updated.ReviewSkills, state.ReviewSkills) {
-			if saveErr := strategy.SaveSessionState(ctx, &updated); saveErr != nil {
-				logging.Warn(logCtx, "failed to save session state after review env adoption",
-					slog.String("error", saveErr.Error()))
-			}
+	if mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+		before := *state
+		adoptReviewEnv(logCtx, state, string(ag.Name()))
+		if state.Kind == before.Kind && state.ReviewPrompt == before.ReviewPrompt && slices.Equal(state.ReviewSkills, before.ReviewSkills) {
+			return strategy.ErrMutationSkip
 		}
+		return nil
+	}); mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
+		logging.Warn(logCtx, "failed to save session state after review env adoption",
+			slog.String("error", mutErr.Error()))
 	}
 	initSpan.End()
 
@@ -584,18 +578,22 @@ func handleLifecycleTurnEnd(ctx context.Context, ag agent.Agent, event *agent.Ev
 	lastPrompt := ""
 	if sessionState, stateErr := strategy.LoadSessionState(ctx, sessionID); stateErr == nil && sessionState != nil {
 		lastPrompt = sessionState.LastPrompt
-		// Backfill LastPrompt so `entire status` shows the prompt even when
-		// no files were modified (before the early return below).
-		if lastPrompt == "" && backfilledPrompt != "" {
-			lastPrompt = backfilledPrompt
-			sessionState.LastPrompt = backfilledPrompt
-			if saveErr := strategy.SaveSessionState(ctx, sessionState); saveErr != nil {
-				logging.Warn(logCtx, "failed to backfill LastPrompt in session state",
-					slog.String("error", saveErr.Error()))
-			}
-		}
-	} else if backfilledPrompt != "" {
+	}
+	// Backfill LastPrompt so `entire status` shows the prompt even when no
+	// files were modified (before the early return below).
+	if lastPrompt == "" && backfilledPrompt != "" {
 		lastPrompt = backfilledPrompt
+		mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+			if state.LastPrompt != "" {
+				return strategy.ErrMutationSkip
+			}
+			state.LastPrompt = backfilledPrompt
+			return nil
+		})
+		if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
+			logging.Warn(logCtx, "failed to backfill LastPrompt in session state",
+				slog.String("error", mutErr.Error()))
+		}
 	}
 	commitMessage := generateCommitMessage(lastPrompt, ag.Type())
 	logging.Debug(logCtx, "using commit message",
@@ -710,12 +708,16 @@ func handleLifecycleTurnEnd(ctx context.Context, ag agent.Agent, event *agent.Ev
 	// Done after SaveStep because SaveStep may reinitialize session state,
 	// which would overwrite an earlier LastPrompt update.
 	if backfilledPrompt != "" {
-		if state, stateErr := strategy.LoadSessionState(ctx, sessionID); stateErr == nil && state != nil && state.LastPrompt == "" {
-			state.LastPrompt = backfilledPrompt
-			if saveErr := strategy.SaveSessionState(ctx, state); saveErr != nil {
-				logging.Warn(logCtx, "failed to backfill LastPrompt in session state",
-					slog.String("error", saveErr.Error()))
+		mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+			if state.LastPrompt != "" {
+				return strategy.ErrMutationSkip
 			}
+			state.LastPrompt = backfilledPrompt
+			return nil
+		})
+		if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
+			logging.Warn(logCtx, "failed to backfill LastPrompt in session state",
+				slog.String("error", mutErr.Error()))
 		}
 	}
 
@@ -740,24 +742,17 @@ func handleLifecycleCompaction(ctx context.Context, ag agent.Agent, event *agent
 	)
 
 	// Fire EventCompaction to trigger ActionCondenseIfFilesTouched (stays in ACTIVE)
-	sessionID := event.SessionID
-	sessionState, loadErr := strategy.LoadSessionState(ctx, sessionID)
-	if loadErr != nil {
-		logging.Warn(logCtx, "failed to load session state for compaction",
-			slog.String("error", loadErr.Error()))
-	}
-	if sessionState != nil {
-		persistEventMetadataToState(event, sessionState)
-
-		if transErr := strategy.TransitionAndLog(ctx, sessionState, session.EventCompaction, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
+	mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
+		persistEventMetadataToState(event, state)
+		if transErr := strategy.TransitionAndLog(ctx, state, session.EventCompaction, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logCtx, "compaction transition failed",
 				slog.String("error", transErr.Error()))
 		}
-
-		if saveErr := strategy.SaveSessionState(ctx, sessionState); saveErr != nil {
-			logging.Warn(logCtx, "failed to save session state after compaction",
-				slog.String("error", saveErr.Error()))
-		}
+		return nil
+	})
+	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
+		logging.Warn(logCtx, "failed to save session state after compaction",
+			slog.String("error", mutErr.Error()))
 	}
 
 	logging.Info(logCtx, "context compaction detected")
@@ -994,34 +989,27 @@ func parseTranscriptForCheckpointUUID(transcriptPath string) ([]transcriptLine, 
 // transitionSessionTurnEnd transitions the session phase to IDLE and dispatches turn-end actions.
 func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agent.Event) {
 	logCtx := logging.WithComponent(ctx, "lifecycle")
-	turnState, loadErr := strategy.LoadSessionState(ctx, sessionID)
-	if loadErr != nil {
-		logging.Warn(logCtx, "failed to load session state for turn end",
-			slog.String("error", loadErr.Error()))
-		return
-	}
-	if turnState == nil {
-		return
-	}
-
-	persistEventMetadataToState(event, turnState)
-
-	if err := strategy.TransitionAndLog(ctx, turnState, session.EventTurnEnd, session.TransitionContext{}, session.NoOpActionHandler{}); err != nil {
-		logging.Warn(logCtx, "turn-end transition failed",
-			slog.String("error", err.Error()))
-	}
-
-	// Always dispatch to strategy for turn-end handling. The strategy reads
-	// work items from state (e.g. TurnCheckpointIDs), not the action list.
-	strat := GetStrategy(ctx)
-	if err := strat.HandleTurnEnd(ctx, turnState); err != nil {
-		logging.Warn(logCtx, "turn-end action dispatch failed",
-			slog.String("error", err.Error()))
-	}
-
-	if updateErr := strategy.SaveSessionState(ctx, turnState); updateErr != nil {
+	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+		persistEventMetadataToState(event, state)
+		if err := strategy.TransitionAndLog(ctx, state, session.EventTurnEnd, session.TransitionContext{}, session.NoOpActionHandler{}); err != nil {
+			logging.Warn(logCtx, "turn-end transition failed",
+				slog.String("error", err.Error()))
+		}
+		// HandleTurnEnd may itself call into session-state APIs; today it
+		// uses s.saveSessionState internally, which is being migrated to
+		// MutateSessionState. The lock is reentrant within this process
+		// because each call opens its own FD; cross-process safety is
+		// preserved.
+		strat := GetStrategy(ctx)
+		if err := strat.HandleTurnEnd(ctx, state); err != nil {
+			logging.Warn(logCtx, "turn-end action dispatch failed",
+				slog.String("error", err.Error()))
+		}
+		return nil
+	})
+	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to update session phase on turn end",
-			slog.String("error", updateErr.Error()))
+			slog.String("error", mutErr.Error()))
 	}
 }
 

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -138,6 +139,19 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 		}
 	}
 	countSessionsSpan.End()
+
+	// Codex-only: surface untrusted hooks. Reaching this point means
+	// SessionStart is itself trusted, but a newer entire release may have
+	// added hooks (e.g. PostToolUse) that the user hasn't approved on
+	// this machine. Trust state is keyed by the absolute hooks.json
+	// path, so missing entries here flag exactly that case.
+	if ag.Name() == agent.AgentNameCodex {
+		if root, err := paths.WorktreeRoot(ctx); err == nil {
+			if gaps := codex.HookTrustGaps(root); len(gaps) > 0 {
+				message += fmt.Sprintf(" %d new hook(s) await approval (%s). Open /hooks to trust them.", len(gaps), strings.Join(gaps, ", "))
+			}
+		}
+	}
 
 	// Output informational message if the agent supports hook responses.
 	// Claude Code reads JSON from stdout; agents that don't implement

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -85,6 +85,8 @@ func DispatchLifecycleEvent(ctx context.Context, ag agent.Agent, event *agent.Ev
 		return handleLifecycleSubagentEnd(ctx, ag, event)
 	case agent.ModelUpdate:
 		return handleLifecycleModelUpdate(ctx, ag, event)
+	case agent.ToolUse:
+		return handleLifecycleToolUse(ctx, ag, event)
 	default:
 		return fmt.Errorf("unknown lifecycle event type: %d", event.Type)
 	}
@@ -248,6 +250,81 @@ func handleLifecycleModelUpdate(ctx context.Context, ag agent.Agent, event *agen
 	}
 
 	return nil
+}
+
+// handleLifecycleToolUse merges files reported by a per-tool-use hook into
+// the session's FilesTouched. Lightweight by design: no SaveStep, no shadow
+// branch commit — just enough so a mid-turn commit's PostCommit handler sees
+// an accurate FilesTouched list and the carry-forward decision is correct.
+//
+// Path normalization mirrors handleLifecycleTurnEnd: paths are filtered to
+// repo-root-relative via FilterAndNormalizePaths against the worktree root,
+// after first being made absolute via event.CWD when they're relative
+// (Codex's apply_patch envelope carries cwd-relative paths).
+func handleLifecycleToolUse(ctx context.Context, ag agent.Agent, event *agent.Event) error {
+	logCtx := logging.WithAgent(logging.WithComponent(ctx, "lifecycle"), ag.Name())
+
+	if event.SessionID == "" {
+		return nil
+	}
+	if err := validation.ValidateSessionID(event.SessionID); err != nil {
+		return fmt.Errorf("invalid %s event: %w", event.Type, err)
+	}
+
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		// Outside a repo or repo missing — nothing to track. Don't fail the hook.
+		logging.Debug(logCtx, "tool-use: no worktree root, skipping",
+			slog.String("session_id", event.SessionID),
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+
+	modified := normalizeToolUsePaths(event.ModifiedFiles, event.CWD, repoRoot)
+	added := normalizeToolUsePaths(event.NewFiles, event.CWD, repoRoot)
+	deleted := normalizeToolUsePaths(event.DeletedFiles, event.CWD, repoRoot)
+
+	if len(modified) == 0 && len(added) == 0 && len(deleted) == 0 {
+		return nil
+	}
+
+	logging.Debug(logCtx, "tool-use: recording files touched",
+		slog.String("session_id", event.SessionID),
+		slog.Int("modified", len(modified)),
+		slog.Int("added", len(added)),
+		slog.Int("deleted", len(deleted)),
+	)
+
+	if err := strategy.RecordFilesTouched(ctx, event.SessionID, modified, added, deleted); err != nil {
+		logging.Warn(logCtx, "tool-use: failed to record files touched",
+			slog.String("session_id", event.SessionID),
+			slog.String("error", err.Error()),
+		)
+	}
+	return nil
+}
+
+// normalizeToolUsePaths converts hook-payload paths to repo-relative form.
+// Cwd-relative entries (the common Codex apply_patch shape) are first joined
+// against eventCWD so FilterAndNormalizePaths sees an absolute path it can
+// rewrite against repoRoot. Absolute entries pass through unchanged.
+func normalizeToolUsePaths(files []string, eventCWD, repoRoot string) []string {
+	if len(files) == 0 {
+		return nil
+	}
+	resolved := make([]string, 0, len(files))
+	for _, f := range files {
+		if f == "" {
+			continue
+		}
+		if filepath.IsAbs(f) || eventCWD == "" {
+			resolved = append(resolved, f)
+			continue
+		}
+		resolved = append(resolved, filepath.Join(eventCWD, f))
+	}
+	return FilterAndNormalizePaths(resolved, repoRoot)
 }
 
 // handleLifecycleTurnStart handles turn start: captures pre-prompt state,

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -999,11 +999,9 @@ func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agen
 			logging.Warn(logCtx, "turn-end transition failed",
 				slog.String("error", err.Error()))
 		}
-		// HandleTurnEnd may itself call into session-state APIs; today it
-		// uses s.saveSessionState internally, which is being migrated to
-		// MutateSessionState. The lock is reentrant within this process
-		// because each call opens its own FD; cross-process safety is
-		// preserved.
+		// HandleTurnEnd mutates state in-place; the outer MutateSessionState
+		// save flushes those changes. Any reentrant MutateSessionState calls
+		// it makes on this session ID share this state pointer via the gate.
 		strat := GetStrategy(ctx)
 		if err := strat.HandleTurnEnd(ctx, state); err != nil {
 			logging.Warn(logCtx, "turn-end action dispatch failed",

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -193,14 +193,18 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 	}
 
 	// Fire EventSessionStart for the current session (if state exists).
-	if mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
+	// SessionStart can fire before InitializeSession creates the state file,
+	// so ErrStateNotFound is the normal first-session path — only warn on
+	// genuinely unexpected errors, matching the rest of this file.
+	mutErr := strategy.MutateSessionState(ctx, event.SessionID, func(state *strategy.SessionState) error {
 		persistEventMetadataToState(event, state)
 		if transErr := strategy.TransitionAndLog(ctx, state, session.EventSessionStart, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logCtx, "session start transition failed",
 				slog.String("error", transErr.Error()))
 		}
 		return nil
-	}); mutErr != nil {
+	})
+	if mutErr != nil && !errors.Is(mutErr, strategy.ErrStateNotFound) {
 		logging.Warn(logCtx, "failed to update session state on start",
 			slog.String("error", mutErr.Error()))
 	}

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1491,11 +1491,6 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 			msg += " (Preview)"
 		}
 		fmt.Fprintf(w, "  %s\n", msg)
-		// Codex 0.129+ gates unmanaged hooks on per-user trust review. The
-		// hooks won't actually run until the user approves them once.
-		if ag.Type() == agent.AgentTypeCodex {
-			fmt.Fprintln(w, "    Codex 0.129+ requires you to approve new hooks once: run /hooks inside Codex to trust them.")
-		}
 	}
 
 	fmt.Fprintln(w, "  ✓ Configured project")

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -2047,6 +2047,14 @@ func removeAllSessionStates(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("failed to remove session states: %w", err)
 	}
 
+	// Sweep the per-session advisory lock files. These live alongside the
+	// state directory rather than inside it (see strategy.stateLockPath) so
+	// session-listing code doesn't have to filter them out. Best-effort:
+	// failing here doesn't undo the state-file removal.
+	if commonDir, cdErr := strategy.GetGitCommonDir(ctx); cdErr == nil {
+		_ = os.RemoveAll(filepath.Join(commonDir, "entire-session-locks"))
+	}
+
 	return count, nil
 }
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1491,6 +1491,11 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 			msg += " (Preview)"
 		}
 		fmt.Fprintf(w, "  %s\n", msg)
+		// Codex 0.129+ gates unmanaged hooks on per-user trust review. The
+		// hooks won't actually run until the user approves them once.
+		if ag.Type() == agent.AgentTypeCodex {
+			fmt.Fprintln(w, "    Codex 0.129+ requires you to approve new hooks once: run /hooks inside Codex to trust them.")
+		}
 	}
 
 	fmt.Fprintln(w, "  ✓ Configured project")

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -1311,93 +1311,84 @@ func clearFilesystemPrompt(ctx context.Context, sessionID string) {
 func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionID string) error {
 	logCtx := logging.WithComponent(ctx, "condense-by-id")
 
-	// Load session state
-	state, err := s.loadSessionState(ctx, sessionID)
-	if err != nil {
-		return fmt.Errorf("failed to load session state: %w", err)
-	}
-	if state == nil {
-		return fmt.Errorf("session not found: %s", sessionID)
-	}
-
-	// Open repository
 	repo, err := OpenRepository(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
 
-	// Generate a checkpoint ID
 	checkpointID, err := id.Generate()
 	if err != nil {
 		return fmt.Errorf("failed to generate checkpoint ID: %w", err)
 	}
 
-	// Check if shadow branch exists (required for condensation)
-	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
-	refName := plumbing.NewBranchReferenceName(shadowBranchName)
-	_, refErr := repo.Reference(refName, true)
-	hasShadowBranch := refErr == nil
+	var shadowBranchName string
+	var clearAfter bool
+	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+		shadowBranchName = getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
+		refName := plumbing.NewBranchReferenceName(shadowBranchName)
+		_, refErr := repo.Reference(refName, true)
+		hasShadowBranch := refErr == nil
 
-	if !hasShadowBranch {
-		// No shadow branch means no checkpoint data to condense.
-		// Just clean up the state file.
-		logging.Info(logCtx, "no shadow branch for session, clearing state only",
+		if !hasShadowBranch {
+			logging.Info(logCtx, "no shadow branch for session, clearing state only",
+				slog.String("session_id", sessionID),
+				slog.String("shadow_branch", shadowBranchName),
+			)
+			clearAfter = true
+			return ErrMutationSkip
+		}
+
+		result, err := s.CondenseSession(ctx, repo, checkpointID, state, nil)
+		if err != nil {
+			return fmt.Errorf("failed to condense session: %w", err)
+		}
+
+		if result.Skipped {
+			logging.Info(logCtx, "session condensation skipped (no transcript or files), marking fully condensed",
+				slog.String("session_id", sessionID),
+			)
+			state.FullyCondensed = true
+			return nil
+		}
+
+		logging.Info(logCtx, "session condensed by ID",
 			slog.String("session_id", sessionID),
-			slog.String("shadow_branch", shadowBranchName),
+			slog.String("checkpoint_id", result.CheckpointID.String()),
+			slog.Int("checkpoints_condensed", result.CheckpointsCount),
 		)
+
+		state.StepCount = 0
+		state.CheckpointTranscriptStart = result.TotalTranscriptLines
+		state.CompactTranscriptStart += result.CompactTranscriptLines
+		state.CheckpointTranscriptSize = int64(len(result.Transcript))
+		state.Phase = session.PhaseIdle
+		state.LastCheckpointID = checkpointID
+		state.LastCheckpointCommitHash = state.BaseCommit
+		state.RealignAttributionBase(state.BaseCommit)
+		state.PromptAttributions = nil
+		state.PendingPromptAttribution = nil
+		return nil
+	})
+	if errors.Is(mutErr, ErrStateNotFound) {
+		return fmt.Errorf("session not found: %s", sessionID)
+	}
+	if mutErr != nil {
+		return mutErr
+	}
+
+	if clearAfter {
 		if err := s.clearSessionState(ctx, sessionID); err != nil {
 			return fmt.Errorf("failed to clear session state: %w", err)
 		}
 		return nil
 	}
 
-	// Condense the session
-	result, err := s.CondenseSession(ctx, repo, checkpointID, state, nil)
-	if err != nil {
-		return fmt.Errorf("failed to condense session: %w", err)
-	}
-
-	if result.Skipped {
-		// Nothing to condense. Mark fully condensed so entire doctor doesn't
-		// keep retrying this empty session on every invocation.
-		logging.Info(logCtx, "session condensation skipped (no transcript or files), marking fully condensed",
-			slog.String("session_id", sessionID),
-		)
-		state.FullyCondensed = true
-		return s.saveSessionState(ctx, state)
-	}
-
-	logging.Info(logCtx, "session condensed by ID",
-		slog.String("session_id", sessionID),
-		slog.String("checkpoint_id", result.CheckpointID.String()),
-		slog.Int("checkpoints_condensed", result.CheckpointsCount),
-	)
-
-	// Update session state: reset step count and transition to idle
-	state.StepCount = 0
-	state.CheckpointTranscriptStart = result.TotalTranscriptLines
-	state.CompactTranscriptStart += result.CompactTranscriptLines
-	state.CheckpointTranscriptSize = int64(len(result.Transcript))
-	state.Phase = session.PhaseIdle
-	state.LastCheckpointID = checkpointID
-	state.LastCheckpointCommitHash = state.BaseCommit
-	state.RealignAttributionBase(state.BaseCommit)
-	state.PromptAttributions = nil
-	state.PendingPromptAttribution = nil
-
-	if err := s.saveSessionState(ctx, state); err != nil {
-		return fmt.Errorf("failed to save session state: %w", err)
-	}
-
-	// Clean up shadow branch if no other sessions need it
 	if err := s.cleanupShadowBranchIfUnused(ctx, repo, shadowBranchName, sessionID); err != nil {
 		logging.Warn(logCtx, "failed to clean up shadow branch",
 			slog.String("shadow_branch", shadowBranchName),
 			slog.String("error", err.Error()),
 		)
-		// Non-fatal: condensation succeeded, shadow branch cleanup is best-effort
 	}
-
 	return nil
 }
 
@@ -1415,29 +1406,6 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context, sessionID string) error {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 
-	state, err := s.loadSessionState(ctx, sessionID)
-	if err != nil {
-		return fmt.Errorf("failed to load session state: %w", err)
-	}
-	if state == nil {
-		return nil // No state file
-	}
-
-	// Sessions with FilesTouched must be processed by PostCommit for carry-forward
-	// tracking — each user commit that overlaps with tracked files gets its own
-	// checkpoint. Eagerly condensing here would prevent that 1:1 linkage.
-	if len(state.FilesTouched) > 0 {
-		return nil
-	}
-
-	// Only condense if there's uncondensed data
-	if state.StepCount <= 0 {
-		// No data and no files — mark FullyCondensed
-		state.FullyCondensed = true
-		return s.saveSessionState(ctx, state)
-	}
-
-	// Check if shadow branch exists — required for condensation
 	repo, err := OpenRepository(ctx)
 	if err != nil {
 		logging.Warn(logCtx, "eager condense: failed to open repository",
@@ -1447,24 +1415,6 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 		return nil // fail-open
 	}
 
-	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
-	refName := plumbing.NewBranchReferenceName(shadowBranchName)
-	_, refErr := repo.Reference(refName, true)
-	hasShadowBranch := refErr == nil
-
-	if !hasShadowBranch {
-		// No shadow branch = no checkpoint data to condense.
-		// Unlike CondenseSessionByID, we do NOT delete the state file.
-		logging.Info(logCtx, "eager condense: no shadow branch",
-			slog.String("session_id", sessionID),
-			slog.String("shadow_branch", shadowBranchName),
-		)
-		state.StepCount = 0
-		state.FullyCondensed = true // FilesTouched is already empty (checked above)
-		return s.saveSessionState(ctx, state)
-	}
-
-	// Generate checkpoint ID and condense
 	checkpointID, err := id.Generate()
 	if err != nil {
 		logging.Warn(logCtx, "eager condense: failed to generate checkpoint ID",
@@ -1473,55 +1423,87 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 		return nil // fail-open
 	}
 
-	// Condense with nil committedFiles (include all FilesTouched)
-	result, err := s.CondenseSession(ctx, repo, checkpointID, state, nil)
-	if err != nil {
-		logging.Warn(logCtx, "eager condense on session stop failed, PostCommit will retry",
-			slog.String("session_id", sessionID),
-			slog.String("error", err.Error()),
-		)
-		return nil // fail-open
-	}
+	var shadowBranchName string
+	var didCondense bool
+	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+		// Sessions with FilesTouched must be processed by PostCommit for
+		// carry-forward tracking — each user commit that overlaps with
+		// tracked files gets its own checkpoint. Eagerly condensing here
+		// would prevent that 1:1 linkage.
+		if len(state.FilesTouched) > 0 {
+			return ErrMutationSkip
+		}
 
-	if result.Skipped {
-		// No transcript or files — nothing to condense. Mark fully condensed
-		// so PostCommit doesn't keep retrying this empty session.
-		logging.Info(logCtx, "eager condense skipped (no transcript or files), marking fully condensed",
-			slog.String("session_id", sessionID),
-		)
+		if state.StepCount <= 0 {
+			state.FullyCondensed = true
+			return nil
+		}
+
+		shadowBranchName = getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
+		refName := plumbing.NewBranchReferenceName(shadowBranchName)
+		_, refErr := repo.Reference(refName, true)
+		hasShadowBranch := refErr == nil
+
+		if !hasShadowBranch {
+			logging.Info(logCtx, "eager condense: no shadow branch",
+				slog.String("session_id", sessionID),
+				slog.String("shadow_branch", shadowBranchName),
+			)
+			state.StepCount = 0
+			state.FullyCondensed = true
+			return nil
+		}
+
+		result, condErr := s.CondenseSession(ctx, repo, checkpointID, state, nil)
+		if condErr != nil {
+			logging.Warn(logCtx, "eager condense on session stop failed, PostCommit will retry",
+				slog.String("session_id", sessionID),
+				slog.String("error", condErr.Error()),
+			)
+			return ErrMutationSkip // fail-open
+		}
+
+		if result.Skipped {
+			logging.Info(logCtx, "eager condense skipped (no transcript or files), marking fully condensed",
+				slog.String("session_id", sessionID),
+			)
+			state.FullyCondensed = true
+			return nil
+		}
+
+		state.StepCount = 0
+		state.CheckpointTranscriptStart = result.TotalTranscriptLines
+		state.CompactTranscriptStart += result.CompactTranscriptLines
+		state.LastCheckpointID = checkpointID
+		state.LastCheckpointCommitHash = state.BaseCommit
+		state.RealignAttributionBase(state.BaseCommit)
+		state.PromptAttributions = nil
+		state.PendingPromptAttribution = nil
 		state.FullyCondensed = true
-		return s.saveSessionState(ctx, state)
-	}
+		// Phase stays ENDED — do NOT set to IDLE
 
-	// Update state — keep Phase = ENDED (unlike CondenseSessionByID which sets IDLE)
-	state.StepCount = 0
-	state.CheckpointTranscriptStart = result.TotalTranscriptLines
-	state.CompactTranscriptStart += result.CompactTranscriptLines
-	state.LastCheckpointID = checkpointID
-	state.LastCheckpointCommitHash = state.BaseCommit
-	state.RealignAttributionBase(state.BaseCommit)
-	state.PromptAttributions = nil
-	state.PendingPromptAttribution = nil
-	state.FullyCondensed = true // FilesTouched is already empty (checked above)
-	// Phase stays ENDED — do NOT set to IDLE
-
-	logging.Info(logCtx, "eager condense on session stop succeeded",
-		slog.String("session_id", sessionID),
-		slog.String("checkpoint_id", result.CheckpointID.String()),
-	)
-
-	if err := s.saveSessionState(ctx, state); err != nil {
-		return fmt.Errorf("failed to save session state: %w", err)
-	}
-
-	// Clean up shadow branch
-	if err := s.cleanupShadowBranchIfUnused(ctx, repo, shadowBranchName, sessionID); err != nil {
-		logging.Warn(logCtx, "eager condense: failed to clean up shadow branch",
-			slog.String("shadow_branch", shadowBranchName),
-			slog.String("error", err.Error()),
+		logging.Info(logCtx, "eager condense on session stop succeeded",
+			slog.String("session_id", sessionID),
+			slog.String("checkpoint_id", result.CheckpointID.String()),
 		)
+		didCondense = true
+		return nil
+	})
+	if errors.Is(mutErr, ErrStateNotFound) {
+		return nil
+	}
+	if mutErr != nil {
+		return fmt.Errorf("failed to save session state: %w", mutErr)
 	}
 
+	if didCondense && shadowBranchName != "" {
+		if err := s.cleanupShadowBranchIfUnused(ctx, repo, shadowBranchName, sessionID); err != nil {
+			logging.Warn(logCtx, "eager condense: failed to clean up shadow branch",
+				slog.String("shadow_branch", shadowBranchName),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
 	return nil
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_git.go
+++ b/cmd/entire/cli/strategy/manual_commit_git.go
@@ -150,14 +150,14 @@ func (s *ManualCommitStrategy) SaveStep(ctx context.Context, step StepContext) e
 }
 
 // ensureSessionInitialized creates the session state file if it doesn't yet
-// exist (or has empty BaseCommit). Idempotent: subsequent calls are no-ops.
+// exist (or has empty BaseCommit). Idempotent: the existence check and the
+// create both happen inside initializeSession's session gate so a concurrent
+// turn-start hook can't slip a richer state in between, only to have it
+// overwritten with blank fields.
 func (s *ManualCommitStrategy) ensureSessionInitialized(ctx context.Context, repo *git.Repository, sessionID string, agentTypeHint types.AgentType) error {
 	state, err := s.loadSessionState(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("failed to load session state: %w", err)
-	}
-	if state != nil && state.BaseCommit != "" {
-		return nil
 	}
 	agentType := resolveAgentType(agentTypeHint, state)
 	if err := s.initializeSession(ctx, repo, sessionID, agentType, "", "", ""); err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_git.go
+++ b/cmd/entire/cli/strategy/manual_commit_git.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -31,157 +32,137 @@ func (s *ManualCommitStrategy) SaveStep(ctx context.Context, step StepContext) e
 	}
 	openRepoSpan.End()
 
-	// Extract session ID from metadata dir
 	sessionID := filepath.Base(step.MetadataDir)
 
-	// Load or initialize session state
-	_, loadStateSpan := perf.Start(ctx, "load_session_state")
-	state, err := s.loadSessionState(ctx, sessionID)
-	if err != nil {
-		loadStateSpan.RecordError(err)
-		loadStateSpan.End()
-		return fmt.Errorf("failed to load session state: %w", err)
-	}
-	// Initialize if state is nil OR BaseCommit is empty (can happen with partial state from warnings)
-	if state == nil || state.BaseCommit == "" {
-		agentType := resolveAgentType(step.AgentType, state)
-		state, err = s.initializeSession(ctx, repo, sessionID, agentType, "", "", "") // No transcript/prompt/model in fallback
-		if err != nil {
-			loadStateSpan.RecordError(err)
-			loadStateSpan.End()
-			return fmt.Errorf("failed to initialize session: %w", err)
-		}
-	}
-	loadStateSpan.End()
-
-	// Check if HEAD has changed (e.g., Claude did a rebase via tool call) and migrate if needed
-	_, migrateSpan := perf.Start(ctx, "migrate_shadow_branch")
-	if err := s.migrateAndPersistIfNeeded(ctx, repo, state); err != nil {
-		migrateSpan.RecordError(err)
-		migrateSpan.End()
+	// Initialize the session if no state exists yet. Done outside
+	// MutateSessionState because the helper bails with ErrStateNotFound on
+	// missing state — initialization establishes the file the helper will
+	// then mutate under lock.
+	if err := s.ensureSessionInitialized(ctx, repo, sessionID, step.AgentType); err != nil {
 		return err
 	}
-	migrateSpan.End()
 
-	// Get checkpoint store
-	store, err := s.getCheckpointStore()
-	if err != nil {
-		return fmt.Errorf("failed to get checkpoint store: %w", err)
-	}
+	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+		_, migrateSpan := perf.Start(ctx, "migrate_shadow_branch")
+		if _, _, err := s.migrateShadowBranchIfNeeded(ctx, repo, state); err != nil {
+			migrateSpan.RecordError(err)
+			migrateSpan.End()
+			return fmt.Errorf("failed to check/migrate shadow branch: %w", err)
+		}
+		migrateSpan.End()
 
-	// Check if shadow branch exists to report whether we created it
-	shadowBranchName := checkpoint.ShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
-	branchExisted := store.ShadowBranchExists(state.BaseCommit, state.WorktreeID)
+		store, err := s.getCheckpointStore()
+		if err != nil {
+			return fmt.Errorf("failed to get checkpoint store: %w", err)
+		}
 
-	// Use the pending attribution calculated at prompt start (in InitializeSession)
-	// This was calculated BEFORE the agent made changes, so it accurately captures user edits
-	var promptAttr PromptAttribution
-	if state.PendingPromptAttribution != nil {
-		promptAttr = *state.PendingPromptAttribution
-		state.PendingPromptAttribution = nil // Clear after use
-	} else {
-		// No pending attribution (e.g., first checkpoint or session initialized without it)
-		promptAttr = PromptAttribution{CheckpointNumber: state.StepCount + 1}
-	}
+		shadowBranchName := checkpoint.ShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
+		branchExisted := store.ShadowBranchExists(state.BaseCommit, state.WorktreeID)
 
-	// Log the prompt attribution for debugging
-	attrLogCtx := logging.WithComponent(ctx, "attribution")
-	logging.Debug(attrLogCtx, "prompt attribution at checkpoint save",
-		slog.Int("checkpoint_number", promptAttr.CheckpointNumber),
-		slog.Int("user_added", promptAttr.UserLinesAdded),
-		slog.Int("user_removed", promptAttr.UserLinesRemoved),
-		slog.Int("agent_added", promptAttr.AgentLinesAdded),
-		slog.Int("agent_removed", promptAttr.AgentLinesRemoved),
-		slog.String("session_id", sessionID))
+		var promptAttr PromptAttribution
+		if state.PendingPromptAttribution != nil {
+			promptAttr = *state.PendingPromptAttribution
+			state.PendingPromptAttribution = nil
+		} else {
+			promptAttr = PromptAttribution{CheckpointNumber: state.StepCount + 1}
+		}
 
-	// Use WriteTemporary to create the checkpoint
-	_, writeCheckpointSpan := perf.Start(ctx, "write_temporary_checkpoint")
-	isFirstCheckpointOfSession := state.StepCount == 0
-	result, err := store.WriteTemporary(ctx, checkpoint.WriteTemporaryOptions{
-		SessionID:         sessionID,
-		BaseCommit:        state.BaseCommit,
-		WorktreeID:        state.WorktreeID,
-		ModifiedFiles:     step.ModifiedFiles,
-		NewFiles:          step.NewFiles,
-		DeletedFiles:      step.DeletedFiles,
-		MetadataDir:       step.MetadataDir,
-		MetadataDirAbs:    step.MetadataDirAbs,
-		CommitMessage:     step.CommitMessage,
-		AuthorName:        step.AuthorName,
-		AuthorEmail:       step.AuthorEmail,
-		IsFirstCheckpoint: isFirstCheckpointOfSession,
-	})
-	writeCheckpointSpan.RecordError(err)
-	writeCheckpointSpan.End()
-	if err != nil {
-		return fmt.Errorf("failed to write temporary checkpoint: %w", err)
-	}
+		attrLogCtx := logging.WithComponent(ctx, "attribution")
+		logging.Debug(attrLogCtx, "prompt attribution at checkpoint save",
+			slog.Int("checkpoint_number", promptAttr.CheckpointNumber),
+			slog.Int("user_added", promptAttr.UserLinesAdded),
+			slog.Int("user_removed", promptAttr.UserLinesRemoved),
+			slog.Int("agent_added", promptAttr.AgentLinesAdded),
+			slog.Int("agent_removed", promptAttr.AgentLinesRemoved),
+			slog.String("session_id", sessionID))
 
-	// If checkpoint was skipped due to deduplication (no changes), return early
-	if result.Skipped {
+		_, writeCheckpointSpan := perf.Start(ctx, "write_temporary_checkpoint")
+		isFirstCheckpointOfSession := state.StepCount == 0
+		result, err := store.WriteTemporary(ctx, checkpoint.WriteTemporaryOptions{
+			SessionID:         sessionID,
+			BaseCommit:        state.BaseCommit,
+			WorktreeID:        state.WorktreeID,
+			ModifiedFiles:     step.ModifiedFiles,
+			NewFiles:          step.NewFiles,
+			DeletedFiles:      step.DeletedFiles,
+			MetadataDir:       step.MetadataDir,
+			MetadataDirAbs:    step.MetadataDirAbs,
+			CommitMessage:     step.CommitMessage,
+			AuthorName:        step.AuthorName,
+			AuthorEmail:       step.AuthorEmail,
+			IsFirstCheckpoint: isFirstCheckpointOfSession,
+		})
+		writeCheckpointSpan.RecordError(err)
+		writeCheckpointSpan.End()
+		if err != nil {
+			return fmt.Errorf("failed to write temporary checkpoint: %w", err)
+		}
+
+		if result.Skipped {
+			logCtx := logging.WithComponent(ctx, "checkpoint")
+			logging.Info(logCtx, "checkpoint skipped (no changes)",
+				slog.String("strategy", "manual-commit"),
+				slog.String("checkpoint_type", "session"),
+				slog.Int("checkpoint_count", state.StepCount),
+				slog.String("shadow_branch", shadowBranchName),
+			)
+			return ErrMutationSkip
+		}
+
+		// LastCheckpointID is intentionally NOT cleared here. It is set during
+		// condensation and used by handleAmendCommitMsg to restore checkpoint
+		// trailers on amend operations.
+		state.StepCount++
+		state.PromptAttributions = append(state.PromptAttributions, promptAttr)
+		state.FilesTouched = mergeFilesTouched(state.FilesTouched, step.ModifiedFiles, step.NewFiles, step.DeletedFiles)
+		if state.StepCount == 1 {
+			state.TranscriptIdentifierAtStart = step.StepTranscriptIdentifier
+		}
+		if step.TokenUsage != nil {
+			state.TokenUsage = accumulateTokenUsage(state.TokenUsage, step.TokenUsage)
+		}
+
+		if !branchExisted {
+			logging.Info(logging.WithComponent(ctx, "checkpoint"), "created shadow branch and committed changes",
+				slog.String("shadow_branch", shadowBranchName))
+		} else {
+			logging.Info(logging.WithComponent(ctx, "checkpoint"), "committed changes to shadow branch",
+				slog.String("shadow_branch", shadowBranchName))
+		}
+
 		logCtx := logging.WithComponent(ctx, "checkpoint")
-		logging.Info(logCtx, "checkpoint skipped (no changes)",
+		logging.Info(logCtx, "checkpoint saved",
 			slog.String("strategy", "manual-commit"),
 			slog.String("checkpoint_type", "session"),
 			slog.Int("checkpoint_count", state.StepCount),
+			slog.Int("modified_files", len(step.ModifiedFiles)),
+			slog.Int("new_files", len(step.NewFiles)),
+			slog.Int("deleted_files", len(step.DeletedFiles)),
 			slog.String("shadow_branch", shadowBranchName),
+			slog.Bool("branch_created", !branchExisted),
 		)
 		return nil
+	})
+	if errors.Is(mutErr, ErrStateNotFound) {
+		return nil
 	}
+	return mutErr
+}
 
-	// Update session state
-	_, updateStateSpan := perf.Start(ctx, "update_session_state")
-	state.StepCount++
-
-	// Note: LastCheckpointID is intentionally NOT cleared here.
-	// It is set during condensation and used by handleAmendCommitMsg
-	// to restore checkpoint trailers on amend operations.
-
-	// Store the prompt attribution we calculated before saving
-	state.PromptAttributions = append(state.PromptAttributions, promptAttr)
-
-	// Track touched files (modified, new, and deleted)
-	state.FilesTouched = mergeFilesTouched(state.FilesTouched, step.ModifiedFiles, step.NewFiles, step.DeletedFiles)
-
-	// On first checkpoint, record the transcript identifier for this session
-	if state.StepCount == 1 {
-		state.TranscriptIdentifierAtStart = step.StepTranscriptIdentifier
+// ensureSessionInitialized creates the session state file if it doesn't yet
+// exist (or has empty BaseCommit). Idempotent: subsequent calls are no-ops.
+func (s *ManualCommitStrategy) ensureSessionInitialized(ctx context.Context, repo *git.Repository, sessionID string, agentTypeHint types.AgentType) error {
+	state, err := s.loadSessionState(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("failed to load session state: %w", err)
 	}
-
-	// Accumulate token usage
-	if step.TokenUsage != nil {
-		state.TokenUsage = accumulateTokenUsage(state.TokenUsage, step.TokenUsage)
+	if state != nil && state.BaseCommit != "" {
+		return nil
 	}
-
-	// Save updated state
-	if err := s.saveSessionState(ctx, state); err != nil {
-		updateStateSpan.RecordError(err)
-		updateStateSpan.End()
-		return fmt.Errorf("failed to save session state: %w", err)
+	agentType := resolveAgentType(agentTypeHint, state)
+	if err := s.initializeSession(ctx, repo, sessionID, agentType, "", "", ""); err != nil {
+		return fmt.Errorf("failed to initialize session: %w", err)
 	}
-	updateStateSpan.End()
-
-	if !branchExisted {
-		logging.Info(logging.WithComponent(ctx, "checkpoint"), "created shadow branch and committed changes",
-			slog.String("shadow_branch", shadowBranchName))
-	} else {
-		logging.Info(logging.WithComponent(ctx, "checkpoint"), "committed changes to shadow branch",
-			slog.String("shadow_branch", shadowBranchName))
-	}
-
-	// Log checkpoint creation
-	logCtx := logging.WithComponent(ctx, "checkpoint")
-	logging.Info(logCtx, "checkpoint saved",
-		slog.String("strategy", "manual-commit"),
-		slog.String("checkpoint_type", "session"),
-		slog.Int("checkpoint_count", state.StepCount),
-		slog.Int("modified_files", len(step.ModifiedFiles)),
-		slog.Int("new_files", len(step.NewFiles)),
-		slog.Int("deleted_files", len(step.DeletedFiles)),
-		slog.String("shadow_branch", shadowBranchName),
-		slog.Bool("branch_created", !branchExisted),
-	)
-
 	return nil
 }
 
@@ -193,125 +174,111 @@ func (s *ManualCommitStrategy) SaveTaskStep(ctx context.Context, step TaskStepCo
 		return fmt.Errorf("failed to open git repository: %w", err)
 	}
 
-	// Load session state
-	state, err := s.loadSessionState(ctx, step.SessionID)
-	if err != nil || state == nil || state.BaseCommit == "" {
-		agentType := resolveAgentType(step.AgentType, state)
-		state, err = s.initializeSession(ctx, repo, step.SessionID, agentType, "", "", "") // No transcript/prompt/model in fallback
-		if err != nil {
-			return fmt.Errorf("failed to initialize session for task checkpoint: %w", err)
-		}
-	}
-
-	// Check if HEAD has changed (e.g., Claude did a rebase via tool call) and migrate if needed
-	if err := s.migrateAndPersistIfNeeded(ctx, repo, state); err != nil {
+	if err := s.ensureSessionInitialized(ctx, repo, step.SessionID, step.AgentType); err != nil {
 		return err
 	}
 
-	// Get checkpoint store
-	store, err := s.getCheckpointStore()
-	if err != nil {
-		return fmt.Errorf("failed to get checkpoint store: %w", err)
-	}
+	mutErr := MutateSessionState(ctx, step.SessionID, func(state *SessionState) error {
+		if _, _, err := s.migrateShadowBranchIfNeeded(ctx, repo, state); err != nil {
+			return fmt.Errorf("failed to check/migrate shadow branch: %w", err)
+		}
 
-	// Check if shadow branch exists to report whether we created it
-	shadowBranchName := checkpoint.ShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
-	branchExisted := store.ShadowBranchExists(state.BaseCommit, state.WorktreeID)
+		store, err := s.getCheckpointStore()
+		if err != nil {
+			return fmt.Errorf("failed to get checkpoint store: %w", err)
+		}
 
-	// Compute metadata paths for commit message
-	sessionMetadataDir := paths.SessionMetadataDirFromSessionID(step.SessionID)
-	taskMetadataDir := TaskMetadataDir(sessionMetadataDir, step.ToolUseID)
+		shadowBranchName := checkpoint.ShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
+		branchExisted := store.ShadowBranchExists(state.BaseCommit, state.WorktreeID)
 
-	// Generate commit message
-	shortToolUseID := step.ToolUseID
-	if len(shortToolUseID) > id.ShortIDLength {
-		shortToolUseID = shortToolUseID[:id.ShortIDLength]
-	}
+		sessionMetadataDir := paths.SessionMetadataDirFromSessionID(step.SessionID)
+		taskMetadataDir := TaskMetadataDir(sessionMetadataDir, step.ToolUseID)
 
-	var messageSubject string
-	if step.IsIncremental {
-		messageSubject = FormatIncrementalSubject(
-			step.IncrementalType,
-			step.SubagentType,
-			step.TaskDescription,
-			step.TodoContent,
-			step.IncrementalSequence,
-			shortToolUseID,
+		shortToolUseID := step.ToolUseID
+		if len(shortToolUseID) > id.ShortIDLength {
+			shortToolUseID = shortToolUseID[:id.ShortIDLength]
+		}
+
+		var messageSubject string
+		if step.IsIncremental {
+			messageSubject = FormatIncrementalSubject(
+				step.IncrementalType,
+				step.SubagentType,
+				step.TaskDescription,
+				step.TodoContent,
+				step.IncrementalSequence,
+				shortToolUseID,
+			)
+		} else {
+			messageSubject = FormatSubagentEndMessage(step.SubagentType, step.TaskDescription, shortToolUseID)
+		}
+		commitMsg := trailers.FormatShadowTaskCommit(
+			messageSubject,
+			taskMetadataDir,
+			step.SessionID,
 		)
-	} else {
-		messageSubject = FormatSubagentEndMessage(step.SubagentType, step.TaskDescription, shortToolUseID)
-	}
-	commitMsg := trailers.FormatShadowTaskCommit(
-		messageSubject,
-		taskMetadataDir,
-		step.SessionID,
-	)
 
-	// Use WriteTemporaryTask to create the checkpoint
-	_, err = store.WriteTemporaryTask(ctx, checkpoint.WriteTemporaryTaskOptions{
-		SessionID:              step.SessionID,
-		BaseCommit:             state.BaseCommit,
-		WorktreeID:             state.WorktreeID,
-		ToolUseID:              step.ToolUseID,
-		AgentID:                step.AgentID,
-		ModifiedFiles:          step.ModifiedFiles,
-		NewFiles:               step.NewFiles,
-		DeletedFiles:           step.DeletedFiles,
-		TranscriptPath:         step.TranscriptPath,
-		SubagentTranscriptPath: step.SubagentTranscriptPath,
-		CheckpointUUID:         step.CheckpointUUID,
-		CommitMessage:          commitMsg,
-		AuthorName:             step.AuthorName,
-		AuthorEmail:            step.AuthorEmail,
-		IsIncremental:          step.IsIncremental,
-		IncrementalSequence:    step.IncrementalSequence,
-		IncrementalType:        step.IncrementalType,
-		IncrementalData:        step.IncrementalData,
+		if _, err := store.WriteTemporaryTask(ctx, checkpoint.WriteTemporaryTaskOptions{
+			SessionID:              step.SessionID,
+			BaseCommit:             state.BaseCommit,
+			WorktreeID:             state.WorktreeID,
+			ToolUseID:              step.ToolUseID,
+			AgentID:                step.AgentID,
+			ModifiedFiles:          step.ModifiedFiles,
+			NewFiles:               step.NewFiles,
+			DeletedFiles:           step.DeletedFiles,
+			TranscriptPath:         step.TranscriptPath,
+			SubagentTranscriptPath: step.SubagentTranscriptPath,
+			CheckpointUUID:         step.CheckpointUUID,
+			CommitMessage:          commitMsg,
+			AuthorName:             step.AuthorName,
+			AuthorEmail:            step.AuthorEmail,
+			IsIncremental:          step.IsIncremental,
+			IncrementalSequence:    step.IncrementalSequence,
+			IncrementalType:        step.IncrementalType,
+			IncrementalData:        step.IncrementalData,
+		}); err != nil {
+			return fmt.Errorf("failed to write task checkpoint: %w", err)
+		}
+
+		state.FilesTouched = mergeFilesTouched(state.FilesTouched, step.ModifiedFiles, step.NewFiles, step.DeletedFiles)
+
+		if !branchExisted {
+			logging.Info(logging.WithComponent(ctx, "checkpoint"), "created shadow branch and committed task checkpoint",
+				slog.String("shadow_branch", shadowBranchName))
+		} else {
+			logging.Info(logging.WithComponent(ctx, "checkpoint"), "committed task checkpoint to shadow branch",
+				slog.String("shadow_branch", shadowBranchName))
+		}
+
+		logCtx := logging.WithComponent(ctx, "checkpoint")
+		attrs := []any{
+			slog.String("strategy", "manual-commit"),
+			slog.String("checkpoint_type", "task"),
+			slog.String("checkpoint_uuid", step.CheckpointUUID),
+			slog.String("tool_use_id", step.ToolUseID),
+			slog.String("subagent_type", step.SubagentType),
+			slog.Int("modified_files", len(step.ModifiedFiles)),
+			slog.Int("new_files", len(step.NewFiles)),
+			slog.Int("deleted_files", len(step.DeletedFiles)),
+			slog.String("shadow_branch", shadowBranchName),
+			slog.Bool("branch_created", !branchExisted),
+		}
+		if step.IsIncremental {
+			attrs = append(attrs,
+				slog.Bool("is_incremental", true),
+				slog.String("incremental_type", step.IncrementalType),
+				slog.Int("incremental_sequence", step.IncrementalSequence),
+			)
+		}
+		logging.Info(logCtx, "task checkpoint saved", attrs...)
+
+		return nil
 	})
-	if err != nil {
-		return fmt.Errorf("failed to write task checkpoint: %w", err)
+	if errors.Is(mutErr, ErrStateNotFound) {
+		return nil
 	}
-
-	// Track touched files (modified, new, and deleted)
-	state.FilesTouched = mergeFilesTouched(state.FilesTouched, step.ModifiedFiles, step.NewFiles, step.DeletedFiles)
-
-	// Save updated state
-	if err := s.saveSessionState(ctx, state); err != nil {
-		return fmt.Errorf("failed to save session state: %w", err)
-	}
-
-	if !branchExisted {
-		logging.Info(logging.WithComponent(ctx, "checkpoint"), "created shadow branch and committed task checkpoint",
-			slog.String("shadow_branch", shadowBranchName))
-	} else {
-		logging.Info(logging.WithComponent(ctx, "checkpoint"), "committed task checkpoint to shadow branch",
-			slog.String("shadow_branch", shadowBranchName))
-	}
-
-	// Log task checkpoint creation
-	logCtx := logging.WithComponent(ctx, "checkpoint")
-	attrs := []any{
-		slog.String("strategy", "manual-commit"),
-		slog.String("checkpoint_type", "task"),
-		slog.String("checkpoint_uuid", step.CheckpointUUID),
-		slog.String("tool_use_id", step.ToolUseID),
-		slog.String("subagent_type", step.SubagentType),
-		slog.Int("modified_files", len(step.ModifiedFiles)),
-		slog.Int("new_files", len(step.NewFiles)),
-		slog.Int("deleted_files", len(step.DeletedFiles)),
-		slog.String("shadow_branch", shadowBranchName),
-		slog.Bool("branch_created", !branchExisted),
-	}
-	if step.IsIncremental {
-		attrs = append(attrs,
-			slog.Bool("is_incremental", true),
-			slog.String("incremental_type", step.IncrementalType),
-			slog.Int("incremental_sequence", step.IncrementalSequence),
-		)
-	}
-	logging.Info(logCtx, "task checkpoint saved", attrs...)
-
-	return nil
+	return mutErr
 }
 
 // mergeFilesTouched merges multiple file lists into existing touched files, deduplicating.

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -217,30 +218,29 @@ func (s *ManualCommitStrategy) PostRewrite(ctx context.Context, rewriteType stri
 		return nil //nolint:nilerr // Hook must be resilient
 	}
 
-	for _, state := range sessions {
-		changed, err := s.remapSessionForRewrite(ctx, repo, state, rewrites)
-		if err != nil {
+	for _, sess := range sessions {
+		sessionID := sess.SessionID
+		mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+			changed, err := s.remapSessionForRewrite(ctx, repo, state, rewrites)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				return ErrMutationSkip
+			}
+			logging.Info(logCtx, "post-rewrite: remapped session linkage",
+				slog.String("session_id", state.SessionID),
+				slog.String("rewrite_type", rewriteType),
+				slog.String("base_commit", truncateHash(state.BaseCommit)),
+			)
+			return nil
+		})
+		if mutErr != nil && !errors.Is(mutErr, ErrStateNotFound) {
 			logging.Warn(logCtx, "post-rewrite: failed to remap session linkage",
-				slog.String("session_id", state.SessionID),
-				slog.String("error", err.Error()),
+				slog.String("session_id", sessionID),
+				slog.String("error", mutErr.Error()),
 			)
-			continue
 		}
-		if !changed {
-			continue
-		}
-		if err := s.saveSessionState(ctx, state); err != nil {
-			logging.Warn(logCtx, "post-rewrite: failed to save remapped session state",
-				slog.String("session_id", state.SessionID),
-				slog.String("error", err.Error()),
-			)
-			continue
-		}
-		logging.Info(logCtx, "post-rewrite: remapped session linkage",
-			slog.String("session_id", state.SessionID),
-			slog.String("rewrite_type", rewriteType),
-			slog.String("base_commit", truncateHash(state.BaseCommit)),
-		)
 	}
 
 	return nil
@@ -988,17 +988,24 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:
 	}
 
 	loopCtx, processSessionsLoop := perf.StartLoop(ctx, "process_sessions")
-	for _, state := range sessions {
-		// Skip fully-condensed ended sessions — no work remains.
-		// These sessions only persist for LastCheckpointID (amend trailer reuse).
-		if state.FullyCondensed && state.Phase == session.PhaseEnded {
+	for _, sess := range sessions {
+		if sess.FullyCondensed && sess.Phase == session.PhaseEnded {
 			continue
 		}
+		sessionID := sess.SessionID
 		iterCtx, iterSpan := processSessionsLoop.Iteration(loopCtx)
-		s.postCommitProcessSession(iterCtx, repo, state, &transitionCtx, checkpointID,
-			head, commit, newHead, worktreePath, headTree, parentTree,
-			committedFileSet, shadowBranchesToDelete, uncondensedActiveOnBranch, allAgentFiles,
-			sessionsWithCommittedFiles)
+		mutErr := MutateSessionState(iterCtx, sessionID, func(state *SessionState) error {
+			s.postCommitProcessSession(iterCtx, repo, state, &transitionCtx, checkpointID,
+				head, commit, newHead, worktreePath, headTree, parentTree,
+				committedFileSet, shadowBranchesToDelete, uncondensedActiveOnBranch, allAgentFiles,
+				sessionsWithCommittedFiles)
+			return nil
+		})
+		if mutErr != nil && !errors.Is(mutErr, ErrStateNotFound) {
+			logging.Warn(logCtx, "post-commit: session mutation failed",
+				slog.String("session_id", sessionID),
+				slog.String("error", mutErr.Error()))
+		}
 		iterSpan.End()
 	}
 	processSessionsLoop.End()
@@ -1317,14 +1324,7 @@ func (s *ManualCommitStrategy) postCommitProcessSession(
 		state.FullyCondensed = true
 	}
 
-	// Save the updated state
-	_, saveSessionStateSpan := perf.Start(ctx, "save_session_state")
-	if err := s.saveSessionState(ctx, state); err != nil {
-		logging.Warn(logCtx, "failed to update session state",
-			slog.String("session_id", state.SessionID),
-			slog.String("error", err.Error()))
-	}
-	saveSessionStateSpan.End()
+	// State is saved by the outer MutateSessionState in PostCommit.
 
 	// Only preserve shadow branch for active sessions that were NOT condensed.
 	// Condensed sessions already have their data on entire/checkpoints/v1.
@@ -1450,16 +1450,19 @@ func (s *ManualCommitStrategy) postCommitUpdateBaseCommitOnly(ctx context.Contex
 	}
 
 	newHead := head.Hash().String()
-	for _, state := range sessions {
-		// Only update active sessions. Idle/ended sessions are kept around for
-		// LastCheckpointID reuse and should not be advanced to HEAD.
-		if !state.Phase.IsActive() {
+	for _, sess := range sessions {
+		if !sess.Phase.IsActive() || sess.BaseCommit == newHead {
 			continue
 		}
-		if state.BaseCommit != newHead {
+		sessionID := sess.SessionID
+		oldBase := sess.BaseCommit
+		mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+			if !state.Phase.IsActive() || state.BaseCommit == newHead {
+				return ErrMutationSkip
+			}
 			logging.Debug(logCtx, "post-commit (no trailer): updating BaseCommit and AttributionBaseCommit",
 				slog.String("session_id", state.SessionID),
-				slog.String("old_base", truncateHash(state.BaseCommit)),
+				slog.String("old_base", truncateHash(oldBase)),
 				slog.String("new_head", truncateHash(newHead)),
 			)
 			state.BaseCommit = newHead
@@ -1467,11 +1470,12 @@ func (s *ManualCommitStrategy) postCommitUpdateBaseCommitOnly(ctx context.Contex
 			// Without this, a subsequent condensation would diff from the old base,
 			// inflating human_added with lines from unrelated prior commits.
 			state.RealignAttributionBase(newHead)
-			if err := s.saveSessionState(ctx, state); err != nil {
-				logging.Warn(logCtx, "failed to update session state",
-					slog.String("session_id", state.SessionID),
-					slog.String("error", err.Error()))
-			}
+			return nil
+		})
+		if mutErr != nil && !errors.Is(mutErr, ErrStateNotFound) {
+			logging.Warn(logCtx, "failed to update session state",
+				slog.String("session_id", sessionID),
+				slog.String("error", mutErr.Error()))
 		}
 	}
 }
@@ -1982,12 +1986,23 @@ func (s *ManualCommitStrategy) warnIfAttributionDiverged(ctx context.Context, se
 			fmt.Fprintln(stderrWriter, "entire: session attribution diverged after recent history movement; figures may be off until next checkpoint")
 			printed = true
 		}
-		sess.DivergenceNoticeShown = true
-		if err := s.saveSessionState(ctx, sess); err != nil {
+		sessionID := sess.SessionID
+		mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+			if state.DivergenceNoticeShown {
+				return ErrMutationSkip
+			}
+			state.DivergenceNoticeShown = true
+			return nil
+		})
+		if mutErr != nil && !errors.Is(mutErr, ErrStateNotFound) {
 			logging.Warn(logCtx, "failed to save divergence notice flag",
-				slog.String("session_id", sess.SessionID),
-				slog.String("error", err.Error()))
+				slog.String("session_id", sessionID),
+				slog.String("error", mutErr.Error()))
+			continue
 		}
+		// Reflect the persisted change on the caller's slice so a same-call
+		// second pass observes the flag without reloading.
+		sess.DivergenceNoticeShown = true
 	}
 }
 
@@ -2225,32 +2240,28 @@ func (s *ManualCommitStrategy) InitializeSession(ctx context.Context, sessionID 
 	// to claim the session ID).
 	resolvedAgentType := resolveSessionAgentType(ctx, sessionID, agentType, transcriptPath)
 
-	// Check if session already exists
-	state, err := s.loadSessionState(ctx, sessionID)
-	if err != nil {
-		return fmt.Errorf("failed to check session state: %w", err)
-	}
-
-	if state != nil && state.BaseCommit != "" {
-		// Session is fully initialized — apply phase transition for TurnStart.
+	// Try the existing-session path first. If MutateSessionState reports
+	// the state is missing (or the loaded state has an empty BaseCommit, a
+	// partial-state remnant from a concurrent warning), fall through to
+	// the initialize-new-session branch.
+	turnStartErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+		if state.BaseCommit == "" {
+			return errPartialState
+		}
 		if transErr := TransitionAndLog(ctx, state, session.EventTurnStart, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
 			logging.Warn(logging.WithComponent(ctx, "hooks"), "turn start transition failed",
 				slog.String("session_id", sessionID),
 				slog.String("error", transErr.Error()))
 		}
 
-		// Generate a new TurnID for each turn (correlates carry-forward checkpoints)
 		turnID, err := id.Generate()
 		if err != nil {
 			return fmt.Errorf("failed to generate turn ID: %w", err)
 		}
 		state.TurnID = turnID.String()
 
-		// Update AgentType when:
-		//   - it isn't yet set, or
-		//   - the resolved type came from a stronger signal (transcript path)
-		//     than what's currently stored. correctSessionAgentType handles the
-		//     "transcript path proves we're a different agent" case.
+		// Update AgentType when it isn't set yet, or when the transcript path
+		// proves we're a different agent than the one stored.
 		if state.AgentType == "" && resolvedAgentType != "" {
 			state.AgentType = resolvedAgentType
 		} else if corrected, changed := correctSessionAgentType(ctx, state.AgentType, transcriptPath); changed {
@@ -2261,92 +2272,62 @@ func (s *ManualCommitStrategy) InitializeSession(ctx context.Context, sessionID 
 				slog.String("transcript_path", transcriptPath))
 			state.AgentType = corrected
 		}
-
-		// Update ModelName if provided (model can change between turns)
 		if model != "" {
 			state.ModelName = model
 		}
-
-		// Update LastPrompt on every turn so condensation always has the current prompt
 		if userPrompt != "" {
 			state.LastPrompt = truncatePromptForStorage(userPrompt)
 		}
-
-		// Update transcript path if provided (may change on session resume)
 		if transcriptPath != "" && state.TranscriptPath != transcriptPath {
 			state.TranscriptPath = transcriptPath
 		}
 
 		// ORDERING: attribution runs BEFORE migrate to use the pre-migration
-		// BaseCommit as the base tree (preserving correct agent-line counts when
-		// HEAD moved between turns via pull/rebase). Migrate runs BEFORE the
-		// LastCheckpointID clear so the reconcile guard can read the checkpoint ID.
-		//
-		// Sequence: attribution → migrate → clear
-		//
-		// 1. Attribution uses state.BaseCommit to locate the shadow branch and
-		//    base tree. Running it before migrate ensures it diffs against the
-		//    original base, not the post-migration HEAD.
-		// 2. Migrate/reconcile reads state.LastCheckpointID — clearing it first
-		//    would prevent the reconcile path from ever firing at turn start.
-
-		// Calculate attribution at prompt start (BEFORE agent makes any changes)
-		// This captures user edits since the last checkpoint (or base commit for first prompt).
-		// IMPORTANT: Always calculate attribution, even for the first checkpoint, to capture
-		// user edits made before the first prompt. The inner CalculatePromptAttribution handles
-		// nil lastCheckpointTree by falling back to baseTree.
+		// BaseCommit as the base tree (preserving correct agent-line counts
+		// when HEAD moved between turns via pull/rebase). Migrate runs BEFORE
+		// the LastCheckpointID clear so the reconcile guard can read it.
 		promptAttr := s.calculatePromptAttributionAtStart(ctx, repo, state)
 		state.PendingPromptAttribution = &promptAttr
 
-		// Check if HEAD has moved (user pulled/rebased or committed)
-		// migrateShadowBranchIfNeeded handles renaming the shadow branch and updating state.BaseCommit
 		_, reconciled, err := s.migrateShadowBranchIfNeeded(ctx, repo, state)
 		if err != nil {
 			return fmt.Errorf("failed to check/migrate shadow branch: %w", err)
 		}
 		if reconciled {
-			// Reconcile advanced BaseCommit + AttributionBaseCommit to HEAD (the
-			// known checkpoint we reset to). The attribution just computed is
-			// against the stale pre-reset base and would count discarded-history
-			// edits as churn. Recompute against the new base so the next
-			// checkpoint sees accurate user-delta.
 			recomputed := s.calculatePromptAttributionAtStart(ctx, repo, state)
 			state.PendingPromptAttribution = &recomputed
 		}
 
-		// Clear checkpoint IDs on every new prompt.
-		// LastCheckpointID is set during PostCommit, cleared at new prompt.
-		// TurnCheckpointIDs tracks mid-turn checkpoints for stop-time finalization.
 		state.LastCheckpointID = ""
 		state.TurnCheckpointIDs = nil
-
-		if err := s.saveSessionState(ctx, state); err != nil {
-			return fmt.Errorf("failed to update session state: %w", err)
-		}
+		return nil
+	})
+	if turnStartErr == nil {
 		return nil
 	}
-	// If state exists but BaseCommit is empty, it's a partial state from concurrent warning
-	// Continue below to properly initialize it
+	if !errors.Is(turnStartErr, ErrStateNotFound) && !errors.Is(turnStartErr, errPartialState) {
+		return fmt.Errorf("failed to update session state: %w", turnStartErr)
+	}
 
-	// Initialize new session
-	state, err = s.initializeSession(ctx, repo, sessionID, resolvedAgentType, transcriptPath, userPrompt, model)
-	if err != nil {
+	// Initialize new session (or repair a partial state). The MutateSessionState
+	// call below reloads the freshly-persisted state under lock and runs the
+	// turn-start mutations on top of it.
+	if err := s.initializeSession(ctx, repo, sessionID, resolvedAgentType, transcriptPath, userPrompt, model); err != nil {
 		return fmt.Errorf("failed to initialize session: %w", err)
 	}
 
-	// Apply phase transition: new session starts as ACTIVE.
-	if transErr := TransitionAndLog(ctx, state, session.EventTurnStart, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
-		logging.Warn(logging.WithComponent(ctx, "hooks"), "turn start transition failed",
-			slog.String("session_id", sessionID),
-			slog.String("error", transErr.Error()))
-	}
-
-	// Calculate attribution for pre-prompt edits
-	// This captures any user edits made before the first prompt
-	promptAttr := s.calculatePromptAttributionAtStart(ctx, repo, state)
-	state.PendingPromptAttribution = &promptAttr
-	if err = s.saveSessionState(ctx, state); err != nil {
-		return fmt.Errorf("failed to save attribution: %w", err)
+	mutErr := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+		if transErr := TransitionAndLog(ctx, state, session.EventTurnStart, session.TransitionContext{}, session.NoOpActionHandler{}); transErr != nil {
+			logging.Warn(logging.WithComponent(ctx, "hooks"), "turn start transition failed",
+				slog.String("session_id", sessionID),
+				slog.String("error", transErr.Error()))
+		}
+		promptAttr := s.calculatePromptAttributionAtStart(ctx, repo, state)
+		state.PendingPromptAttribution = &promptAttr
+		return nil
+	})
+	if mutErr != nil && !errors.Is(mutErr, ErrStateNotFound) {
+		return fmt.Errorf("failed to save attribution: %w", mutErr)
 	}
 
 	logging.Info(logging.WithComponent(ctx, "hooks"), "initialized shadow session",
@@ -2591,6 +2572,12 @@ func readPromptsFromShadowBranch(_ context.Context, repo *git.Repository, state 
 
 	return splitPromptContent(content)
 }
+
+// errPartialState signals InitializeSession's mutation callback that the
+// loaded state has an empty BaseCommit (left over from a concurrent warning
+// that wrote partial state). The caller falls through to initializeSession
+// to repair it.
+var errPartialState = errors.New("partial session state")
 
 // HandleTurnEnd dispatches strategy-specific actions emitted when an agent turn ends.
 // The primary job is to finalize all checkpoints from this turn with the full transcript.

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1158,6 +1158,10 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 // postCommitProcessSession handles a single session within the PostCommit loop.
 // Pre-resolved git objects (headTree, parentTree) are shared across all sessions;
 // per-session shadow ref/tree are resolved once here and threaded through sub-calls.
+//
+// MUST be called from inside MutateSessionState. Mutations to state are persisted
+// by the caller's outer save — calling this function standalone silently loses
+// every field change (StepCount, FilesTouched, CheckpointTranscriptStart, …).
 func (s *ManualCommitStrategy) postCommitProcessSession(
 	ctx context.Context,
 	repo *git.Repository,

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -995,7 +995,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:
 		sessionID := sess.SessionID
 		iterCtx, iterSpan := processSessionsLoop.Iteration(loopCtx)
 		mutErr := MutateSessionState(iterCtx, sessionID, func(state *SessionState) error {
-			s.postCommitProcessSession(iterCtx, repo, state, &transitionCtx, checkpointID,
+			s.postCommitProcessSessionLocked(iterCtx, repo, state, &transitionCtx, checkpointID,
 				head, commit, newHead, worktreePath, headTree, parentTree,
 				committedFileSet, shadowBranchesToDelete, uncondensedActiveOnBranch, allAgentFiles,
 				sessionsWithCommittedFiles)
@@ -1155,14 +1155,14 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 	return nil
 }
 
-// postCommitProcessSession handles a single session within the PostCommit loop.
+// postCommitProcessSessionLocked handles a single session within the PostCommit loop.
 // Pre-resolved git objects (headTree, parentTree) are shared across all sessions;
 // per-session shadow ref/tree are resolved once here and threaded through sub-calls.
 //
 // MUST be called from inside MutateSessionState. Mutations to state are persisted
 // by the caller's outer save — calling this function standalone silently loses
 // every field change (StepCount, FilesTouched, CheckpointTranscriptStart, …).
-func (s *ManualCommitStrategy) postCommitProcessSession(
+func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 	ctx context.Context,
 	repo *git.Repository,
 	state *SessionState,

--- a/cmd/entire/cli/strategy/manual_commit_migration.go
+++ b/cmd/entire/cli/strategy/manual_commit_migration.go
@@ -156,18 +156,3 @@ func (s *ManualCommitStrategy) migrateShadowBranchToBaseCommit(ctx context.Conte
 	state.BaseCommit = newBaseCommit
 	return true, nil
 }
-
-// migrateAndPersistIfNeeded checks for HEAD changes, migrates the shadow branch if needed,
-// and persists the updated session state. Used by SaveStep and SaveTaskStep.
-func (s *ManualCommitStrategy) migrateAndPersistIfNeeded(ctx context.Context, repo *git.Repository, state *SessionState) error {
-	migrated, _, err := s.migrateShadowBranchIfNeeded(ctx, repo, state)
-	if err != nil {
-		return fmt.Errorf("failed to check/migrate shadow branch: %w", err)
-	}
-	if migrated {
-		if err := s.saveSessionState(ctx, state); err != nil {
-			return fmt.Errorf("failed to save session state after migration: %w", err)
-		}
-	}
-	return nil
-}

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -329,13 +329,23 @@ func (s *ManualCommitStrategy) initializeSession(ctx context.Context, repo *git.
 		LastPrompt:            truncatePromptForStorage(userPrompt),
 	}
 
-	// Persist under the session gate so a concurrent first-turn hook for the
-	// same session can't lose the write.
+	// Take the gate, then re-check under lock. Without this re-check a
+	// concurrent turn-start hook that wrote a richer state in the gap
+	// between our caller's existence check and our save would have its
+	// fields (TranscriptPath, LastPrompt, ModelName, accumulated TurnID)
+	// overwritten with blanks here.
 	_, _, release, lockErr := acquireSessionGate(ctx, sessionID)
 	if lockErr != nil {
 		return fmt.Errorf("acquire state lock: %w", lockErr)
 	}
 	defer release()
+	existing, loadErr := s.loadSessionState(ctx, sessionID)
+	if loadErr != nil {
+		return fmt.Errorf("re-load session state under lock: %w", loadErr)
+	}
+	if existing != nil && existing.BaseCommit != "" {
+		return nil
+	}
 	return s.saveSessionState(ctx, state)
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -279,21 +279,21 @@ func (s *ManualCommitStrategy) CountOtherActiveSessionsWithCheckpoints(ctx conte
 // transcriptPath is the path to the live transcript file (for mid-session commit detection).
 // userPrompt is the user's prompt text (stored truncated as LastPrompt for display).
 // model is the LLM model identifier (e.g., "claude-sonnet-4-20250514"); empty if unknown.
-func (s *ManualCommitStrategy) initializeSession(ctx context.Context, repo *git.Repository, sessionID string, agentType types.AgentType, transcriptPath string, userPrompt string, model string) (*SessionState, error) {
+func (s *ManualCommitStrategy) initializeSession(ctx context.Context, repo *git.Repository, sessionID string, agentType types.AgentType, transcriptPath string, userPrompt string, model string) error {
 	head, err := repo.Head()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get HEAD: %w", err)
+		return fmt.Errorf("failed to get HEAD: %w", err)
 	}
 
 	worktreePath, err := paths.WorktreeRoot(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get worktree path: %w", err)
+		return fmt.Errorf("failed to get worktree path: %w", err)
 	}
 
 	// Get worktree ID for shadow branch naming
 	worktreeID, err := paths.GetWorktreeID(worktreePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get worktree ID: %w", err)
+		return fmt.Errorf("failed to get worktree ID: %w", err)
 	}
 
 	// Capture untracked files at session start to preserve them during rewind
@@ -306,7 +306,7 @@ func (s *ManualCommitStrategy) initializeSession(ctx context.Context, repo *git.
 	// Generate TurnID for the first turn
 	turnID, err := id.Generate()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate turn ID: %w", err)
+		return fmt.Errorf("failed to generate turn ID: %w", err)
 	}
 
 	now := time.Now()
@@ -329,11 +329,14 @@ func (s *ManualCommitStrategy) initializeSession(ctx context.Context, repo *git.
 		LastPrompt:            truncatePromptForStorage(userPrompt),
 	}
 
-	if err := s.saveSessionState(ctx, state); err != nil {
-		return nil, err
+	// Persist under the session gate so a concurrent first-turn hook for the
+	// same session can't lose the write.
+	_, _, release, lockErr := acquireSessionGate(ctx, sessionID)
+	if lockErr != nil {
+		return fmt.Errorf("acquire state lock: %w", lockErr)
 	}
-
-	return state, nil
+	defer release()
+	return s.saveSessionState(ctx, state)
 }
 
 // getShadowBranchNameForCommit returns the shadow branch name for the given base commit and worktree ID.

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -1649,8 +1649,12 @@ func TestShadowStrategy_MigrateAndPersistIfNeeded_PersistsBaseCommitWithoutShado
 		t.Fatalf("saveSessionState() error = %v", err)
 	}
 
-	if err := s.migrateAndPersistIfNeeded(context.Background(), repo, state); err != nil {
-		t.Fatalf("migrateAndPersistIfNeeded() error = %v", err)
+	mutErr := MutateSessionState(context.Background(), state.SessionID, func(state *SessionState) error {
+		_, _, err := s.migrateShadowBranchIfNeeded(context.Background(), repo, state)
+		return err
+	})
+	if mutErr != nil {
+		t.Fatalf("MutateSessionState(migrate) error = %v", mutErr)
 	}
 
 	loaded, err := s.loadSessionState(context.Background(), state.SessionID)

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -364,19 +365,12 @@ func LoadAgentTypeHint(ctx context.Context, sessionID string) types.AgentType {
 	return types.AgentType(strings.TrimSpace(string(data)))
 }
 
-// RecordFilesTouched merges the given files into the session's FilesTouched.
-// Used by mid-turn lifecycle events (e.g., per-tool-use hooks) to populate
-// state.FilesTouched incrementally — without this, agents like Codex that
-// commit mid-turn have no per-tool file accounting, and the carry-forward
-// path falls back to whole-transcript extraction.
-//
-// Inputs are merged via the same dedup+normalize logic SaveStep uses, so the
-// resulting list is stable regardless of which path populated it. Paths must
-// already be repo-relative; the caller (handleLifecycleToolUse) normalizes
-// before reaching here.
-//
-// No-op when the session state doesn't exist (event arrived before
-// InitializeSession) or all input lists are empty.
+// RecordFilesTouched merges paths into the session's FilesTouched, used by
+// mid-turn lifecycle events (per-tool-use hooks) so PostCommit's carry-forward
+// decision sees an accurate file list. Caller must pre-normalize paths to
+// repo-relative form. No-ops when the session state doesn't exist (event
+// arrived before InitializeSession) or the merge produced no changes — this
+// matters on Codex's hot path, where PostToolUse fires after every tool call.
 func RecordFilesTouched(ctx context.Context, sessionID string, modified, added, deleted []string) error {
 	if sessionID == "" {
 		return nil
@@ -391,7 +385,11 @@ func RecordFilesTouched(ctx context.Context, sessionID string, modified, added, 
 	if state == nil {
 		return nil
 	}
-	state.FilesTouched = mergeFilesTouched(state.FilesTouched, modified, added, deleted)
+	merged := mergeFilesTouched(state.FilesTouched, modified, added, deleted)
+	if slices.Equal(merged, state.FilesTouched) {
+		return nil
+	}
+	state.FilesTouched = merged
 	if err := SaveSessionState(ctx, state); err != nil {
 		return fmt.Errorf("save session state: %w", err)
 	}

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -7,8 +7,11 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
@@ -365,74 +368,213 @@ func LoadAgentTypeHint(ctx context.Context, sessionID string) types.AgentType {
 	return types.AgentType(strings.TrimSpace(string(data)))
 }
 
-// RecordFilesTouched merges paths into the session's FilesTouched, used by
-// mid-turn lifecycle events (per-tool-use hooks) so PostCommit's carry-forward
-// decision sees an accurate file list. Caller must pre-normalize paths to
-// repo-relative form. No-ops when the session state doesn't exist (event
-// arrived before InitializeSession) or the merge produced no changes.
-//
-// Concurrency: PostToolUse fires after every Codex tool call and may run in
-// parallel for parallel tool dispatch, so the load → merge → save runs
-// under an OS-level advisory file lock against
-// .git/entire-sessions/<id>.lock. Two PostToolUse processes cannot lose
-// each other's FilesTouched merges. Other writers (TurnEnd, PostCommit) do
-// not yet participate in the lock — a stale save here can still revert
-// fields they updated between our load and our save. The window is small
-// (lock is only held for the load+save) but real, and the residual race is
-// tracked for a follow-up that converts all session-state mutations to a
-// shared MutateSessionState(ctx, fn) helper.
-func RecordFilesTouched(ctx context.Context, sessionID string, modified, added, deleted []string) error {
-	if sessionID == "" {
-		return nil
-	}
-	if len(modified) == 0 && len(added) == 0 && len(deleted) == 0 {
-		return nil
-	}
+// sessionMutationGate provides per-process serialization layered over the
+// OS-level flock so that nested MutateSessionState calls in the same
+// goroutine don't deadlock or lose updates. POSIX flock isn't reentrant
+// across distinct file descriptors in the same process; on top of that, a
+// nested call that did its own load → save would have its save overwritten
+// by the outer save. The gate fixes both: nested calls in the same
+// goroutine reuse the outer's state pointer (no second load, no second
+// save), and only the outermost release drops the flock.
+var sessionMutationGate sync.Map // map[string]*sessionGate
 
-	lockPath, err := stateLockPath(ctx, sessionID)
-	if err != nil {
-		return fmt.Errorf("resolve state lock path: %w", err)
+type sessionGate struct {
+	mu          sync.Mutex
+	owner       int64 // goroutine ID of the current holder, 0 when unlocked
+	depth       int
+	flockRel    func()
+	activeState *SessionState // shared state pointer for nested mutations
+}
+
+// goroutineID extracts the runtime goroutine ID from the stack header. Used
+// only as a reentrancy key for the session mutation gate — never as a
+// security boundary or for application logic.
+func goroutineID() int64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	const prefix = "goroutine "
+	s := string(buf[:n])
+	if !strings.HasPrefix(s, prefix) {
+		return 0
 	}
-	release, err := acquireStateFileLock(lockPath)
+	s = s[len(prefix):]
+	end := strings.IndexByte(s, ' ')
+	if end < 0 {
+		return 0
+	}
+	id, err := strconv.ParseInt(s[:end], 10, 64)
 	if err != nil {
-		return fmt.Errorf("acquire state lock: %w", err)
+		return 0
+	}
+	return id
+}
+
+// MutateSessionState is the safe load → mutate → save helper. It takes an
+// OS-level advisory lock against .git/entire-session-locks/<id>.lock for the
+// duration of the read+write so concurrent processes cannot lose each
+// other's updates. fn receives the freshly-loaded state and mutates it in
+// place; returning ErrMutationSkip skips the save. The lock is held for fn's
+// full duration, so fn must avoid arbitrary blocking work. Reentrant within
+// the same goroutine: nested calls share the outer's state pointer and skip
+// the inner load/save, so all mutations are flushed by the outermost call.
+//
+// Returns ErrStateNotFound if the state file doesn't exist (event arrived
+// before InitializeSession). Errors from fn or from load/save propagate.
+//
+// All session-state mutations funnel through this helper so the hot-path
+// PostToolUse hook cannot revert fields written by lifecycle handlers
+// (TurnEnd, PostCommit, ModelUpdate) that ran between our load and our save.
+func MutateSessionState(ctx context.Context, sessionID string, fn func(*SessionState) error) error {
+	if sessionID == "" {
+		return ErrStateNotFound
+	}
+	gate, isOuter, release, err := acquireSessionGate(ctx, sessionID)
+	if err != nil {
+		return err
 	}
 	defer release()
+
+	if !isOuter {
+		// Nested call: reuse the outer's state pointer. The outer save will
+		// flush our mutations; we don't load or save here.
+		if gate.activeState == nil {
+			return ErrStateNotFound
+		}
+		if err := fn(gate.activeState); err != nil && !errors.Is(err, ErrMutationSkip) {
+			return err
+		}
+		return nil
+	}
 
 	state, err := LoadSessionState(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("load session state: %w", err)
 	}
 	if state == nil {
-		return nil
+		return ErrStateNotFound
 	}
-	merged := mergeFilesTouched(state.FilesTouched, modified, added, deleted)
-	if slices.Equal(merged, state.FilesTouched) {
-		return nil
+	gate.activeState = state
+	defer func() { gate.activeState = nil }()
+
+	if err := fn(state); err != nil {
+		if errors.Is(err, ErrMutationSkip) {
+			return nil
+		}
+		return err
 	}
-	state.FilesTouched = merged
 	if err := SaveSessionState(ctx, state); err != nil {
 		return fmt.Errorf("save session state: %w", err)
 	}
 	return nil
 }
 
-// stateLockPath returns a sibling .lock path next to the session state file.
-// A separate file (rather than locking the state file itself) keeps the
-// lock holder distinct from the data — Save's atomic-rename pattern would
+// acquireSessionGate takes the per-process gate (in-memory) and, on the
+// outermost call, the cross-process flock. Returns isOuter=true on the
+// outermost call so MutateSessionState knows whether to load/save.
+func acquireSessionGate(ctx context.Context, sessionID string) (gate *sessionGate, isOuter bool, release func(), err error) {
+	val, _ := sessionMutationGate.LoadOrStore(sessionID, &sessionGate{})
+	gate, ok := val.(*sessionGate)
+	if !ok {
+		return nil, false, nil, fmt.Errorf("session gate type assertion failed for %s", sessionID)
+	}
+
+	gid := goroutineID()
+	gate.mu.Lock()
+	if gate.owner == gid {
+		gate.depth++
+		gate.mu.Unlock()
+		return gate, false, func() {
+			gate.mu.Lock()
+			gate.depth--
+			gate.mu.Unlock()
+		}, nil
+	}
+	gate.mu.Unlock()
+
+	lockPath, err := stateLockPath(ctx, sessionID)
+	if err != nil {
+		return nil, false, nil, fmt.Errorf("resolve state lock path: %w", err)
+	}
+	flockRel, err := acquireStateFileLock(lockPath)
+	if err != nil {
+		return nil, false, nil, fmt.Errorf("acquire state lock: %w", err)
+	}
+
+	gate.mu.Lock()
+	gate.owner = gid
+	gate.depth = 1
+	gate.flockRel = flockRel
+	gate.mu.Unlock()
+
+	return gate, true, func() {
+		gate.mu.Lock()
+		gate.depth--
+		if gate.depth == 0 {
+			rel := gate.flockRel
+			gate.flockRel = nil
+			gate.owner = 0
+			gate.mu.Unlock()
+			rel()
+			return
+		}
+		gate.mu.Unlock()
+	}, nil
+}
+
+// ErrMutationSkip signals MutateSessionState to skip the save without
+// treating fn's return as an error. Use it when the mutation function
+// observes the loaded state and decides no write is needed (for example,
+// when a merge produces no new entries).
+var ErrMutationSkip = errors.New("session state mutation skipped")
+
+// ErrStateNotFound is returned by MutateSessionState when no state file
+// exists for the session ID (typically because the event arrived before
+// InitializeSession ran). Callers that need to distinguish "no state"
+// from a successful no-op can branch on errors.Is(err, ErrStateNotFound).
+var ErrStateNotFound = errors.New("session state not found")
+
+// RecordFilesTouched merges paths into the session's FilesTouched, used by
+// mid-turn lifecycle events (per-tool-use hooks) so PostCommit's carry-forward
+// decision sees an accurate file list. Caller must pre-normalize paths to
+// repo-relative form. No-ops when the session state doesn't exist or the
+// merge produced no changes.
+func RecordFilesTouched(ctx context.Context, sessionID string, modified, added, deleted []string) error {
+	if len(modified) == 0 && len(added) == 0 && len(deleted) == 0 {
+		return nil
+	}
+	err := MutateSessionState(ctx, sessionID, func(state *SessionState) error {
+		merged := mergeFilesTouched(state.FilesTouched, modified, added, deleted)
+		if slices.Equal(merged, state.FilesTouched) {
+			return ErrMutationSkip
+		}
+		state.FilesTouched = merged
+		return nil
+	})
+	if errors.Is(err, ErrStateNotFound) {
+		return nil
+	}
+	return err
+}
+
+// stateLockPath returns the lock file path for a session. Lock files live in
+// .git/entire-session-locks/ (a sibling to entire-sessions/) so callers that
+// enumerate session state files don't have to filter lock entries. A
+// separate file (rather than locking the state file itself) keeps the lock
+// holder distinct from the data — Save's atomic-rename pattern would
 // otherwise unlink the inode the flock is held on.
 func stateLockPath(ctx context.Context, sessionID string) (string, error) {
 	if err := validation.ValidateSessionID(sessionID); err != nil {
 		return "", fmt.Errorf("invalid session ID: %w", err)
 	}
-	stateDir, err := getSessionStateDir(ctx)
+	commonDir, err := GetGitCommonDir(ctx)
 	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(stateDir, 0o750); err != nil {
-		return "", fmt.Errorf("create session state directory: %w", err)
+	lockDir := filepath.Join(commonDir, "entire-session-locks")
+	if err := os.MkdirAll(lockDir, 0o750); err != nil {
+		return "", fmt.Errorf("create session lock directory: %w", err)
 	}
-	return filepath.Join(stateDir, sessionID+".lock"), nil
+	return filepath.Join(lockDir, sessionID+".lock"), nil
 }
 
 // ClearSessionState removes the session state file for the given session ID.
@@ -451,6 +593,12 @@ func ClearSessionState(ctx context.Context, sessionID string) error {
 	matches, _ := filepath.Glob(filepath.Join(stateDir, sessionID+".*")) //nolint:errcheck // pattern is always valid
 	for _, f := range matches {
 		_ = os.Remove(f)
+	}
+
+	// Lock files live under entire-session-locks/ — sweep them too so a
+	// re-created session for the same ID starts with a fresh lock file.
+	if commonDir, cdErr := GetGitCommonDir(ctx); cdErr == nil {
+		_ = os.Remove(filepath.Join(commonDir, "entire-session-locks", sessionID+".lock"))
 	}
 
 	return nil

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -376,6 +376,11 @@ func LoadAgentTypeHint(ctx context.Context, sessionID string) types.AgentType {
 // by the outer save. The gate fixes both: nested calls in the same
 // goroutine reuse the outer's state pointer (no second load, no second
 // save), and only the outermost release drops the flock.
+//
+// Growth: the map accumulates one entry per session ID touched by this
+// process and is never trimmed. Fine today because hook invocations are
+// short-lived subprocesses; a future long-running daemon (status watcher,
+// MCP server) would need a TTL or eviction pass.
 var sessionMutationGate sync.Map // map[string]*sessionGate
 
 type sessionGate struct {
@@ -413,10 +418,16 @@ func goroutineID() int64 {
 // OS-level advisory lock against .git/entire-session-locks/<id>.lock for the
 // duration of the read+write so concurrent processes cannot lose each
 // other's updates. fn receives the freshly-loaded state and mutates it in
-// place; returning ErrMutationSkip skips the save. The lock is held for fn's
-// full duration, so fn must avoid arbitrary blocking work. Reentrant within
-// the same goroutine: nested calls share the outer's state pointer and skip
-// the inner load/save, so all mutations are flushed by the outermost call.
+// place; returning ErrMutationSkip skips the save. Reentrant within the same
+// goroutine: nested calls share the outer's state pointer and skip the
+// inner load/save, so all mutations are flushed by the outermost call.
+//
+// fn may hold the lock for slow operations — PostCommit's callback, for
+// example, runs CondenseSession (shadow-branch tree builds, transcript
+// compaction) inside the gate. That's deliberate: PostToolUse must not slip
+// in mid-condense and revert CheckpointTranscriptStart or files_touched.
+// A concurrent PostToolUse on the same session waits for the commit to
+// finish.
 //
 // Returns ErrStateNotFound if the state file doesn't exist (event arrived
 // before InitializeSession). Errors from fn or from load/save propagate.

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -369,8 +369,18 @@ func LoadAgentTypeHint(ctx context.Context, sessionID string) types.AgentType {
 // mid-turn lifecycle events (per-tool-use hooks) so PostCommit's carry-forward
 // decision sees an accurate file list. Caller must pre-normalize paths to
 // repo-relative form. No-ops when the session state doesn't exist (event
-// arrived before InitializeSession) or the merge produced no changes — this
-// matters on Codex's hot path, where PostToolUse fires after every tool call.
+// arrived before InitializeSession) or the merge produced no changes.
+//
+// Concurrency: PostToolUse fires after every Codex tool call and may run in
+// parallel for parallel tool dispatch, so the load → merge → save runs
+// under an OS-level advisory file lock against
+// .git/entire-sessions/<id>.lock. Two PostToolUse processes cannot lose
+// each other's FilesTouched merges. Other writers (TurnEnd, PostCommit) do
+// not yet participate in the lock — a stale save here can still revert
+// fields they updated between our load and our save. The window is small
+// (lock is only held for the load+save) but real, and the residual race is
+// tracked for a follow-up that converts all session-state mutations to a
+// shared MutateSessionState(ctx, fn) helper.
 func RecordFilesTouched(ctx context.Context, sessionID string, modified, added, deleted []string) error {
 	if sessionID == "" {
 		return nil
@@ -378,6 +388,17 @@ func RecordFilesTouched(ctx context.Context, sessionID string, modified, added, 
 	if len(modified) == 0 && len(added) == 0 && len(deleted) == 0 {
 		return nil
 	}
+
+	lockPath, err := stateLockPath(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("resolve state lock path: %w", err)
+	}
+	release, err := acquireStateFileLock(lockPath)
+	if err != nil {
+		return fmt.Errorf("acquire state lock: %w", err)
+	}
+	defer release()
+
 	state, err := LoadSessionState(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("load session state: %w", err)
@@ -394,6 +415,24 @@ func RecordFilesTouched(ctx context.Context, sessionID string, modified, added, 
 		return fmt.Errorf("save session state: %w", err)
 	}
 	return nil
+}
+
+// stateLockPath returns a sibling .lock path next to the session state file.
+// A separate file (rather than locking the state file itself) keeps the
+// lock holder distinct from the data — Save's atomic-rename pattern would
+// otherwise unlink the inode the flock is held on.
+func stateLockPath(ctx context.Context, sessionID string) (string, error) {
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return "", fmt.Errorf("invalid session ID: %w", err)
+	}
+	stateDir, err := getSessionStateDir(ctx)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(stateDir, 0o750); err != nil {
+		return "", fmt.Errorf("create session state directory: %w", err)
+	}
+	return filepath.Join(stateDir, sessionID+".lock"), nil
 }
 
 // ClearSessionState removes the session state file for the given session ID.

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -595,11 +595,12 @@ func ClearSessionState(ctx context.Context, sessionID string) error {
 		_ = os.Remove(f)
 	}
 
-	// Lock files live under entire-session-locks/ — sweep them too so a
-	// re-created session for the same ID starts with a fresh lock file.
-	if commonDir, cdErr := GetGitCommonDir(ctx); cdErr == nil {
-		_ = os.Remove(filepath.Join(commonDir, "entire-session-locks", sessionID+".lock"))
-	}
-
+	// Intentionally do NOT remove the per-session lock file under
+	// entire-session-locks/. POSIX flock and Windows LockFileEx are bound to
+	// the inode/file-handle: unlinking the lock path while another process
+	// holds it lets a third caller recreate the file and acquire an
+	// independent lock, breaking mutual exclusion. Lock files are 0-byte
+	// sentinels and session IDs aren't reused, so leaving them in place is
+	// harmless. Bulk cleanup happens via RemoveAll on uninstall.
 	return nil
 }

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -364,6 +364,40 @@ func LoadAgentTypeHint(ctx context.Context, sessionID string) types.AgentType {
 	return types.AgentType(strings.TrimSpace(string(data)))
 }
 
+// RecordFilesTouched merges the given files into the session's FilesTouched.
+// Used by mid-turn lifecycle events (e.g., per-tool-use hooks) to populate
+// state.FilesTouched incrementally — without this, agents like Codex that
+// commit mid-turn have no per-tool file accounting, and the carry-forward
+// path falls back to whole-transcript extraction.
+//
+// Inputs are merged via the same dedup+normalize logic SaveStep uses, so the
+// resulting list is stable regardless of which path populated it. Paths must
+// already be repo-relative; the caller (handleLifecycleToolUse) normalizes
+// before reaching here.
+//
+// No-op when the session state doesn't exist (event arrived before
+// InitializeSession) or all input lists are empty.
+func RecordFilesTouched(ctx context.Context, sessionID string, modified, added, deleted []string) error {
+	if sessionID == "" {
+		return nil
+	}
+	if len(modified) == 0 && len(added) == 0 && len(deleted) == 0 {
+		return nil
+	}
+	state, err := LoadSessionState(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("load session state: %w", err)
+	}
+	if state == nil {
+		return nil
+	}
+	state.FilesTouched = mergeFilesTouched(state.FilesTouched, modified, added, deleted)
+	if err := SaveSessionState(ctx, state); err != nil {
+		return fmt.Errorf("save session state: %w", err)
+	}
+	return nil
+}
+
 // ClearSessionState removes the session state file for the given session ID.
 func ClearSessionState(ctx context.Context, sessionID string) error {
 	// Validate session ID to prevent path traversal

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -393,23 +393,26 @@ type sessionGate struct {
 
 // goroutineID extracts the runtime goroutine ID from the stack header. Used
 // only as a reentrancy key for the session mutation gate — never as a
-// security boundary or for application logic.
+// security boundary or for application logic. Returns -1 if the stack
+// header doesn't parse: real goroutine IDs are positive, and gate.owner is
+// initialised to 0, so a -1 sentinel can't falsely match the freshly-
+// constructed gate (or a freshly-released one).
 func goroutineID() int64 {
 	var buf [64]byte
 	n := runtime.Stack(buf[:], false)
 	const prefix = "goroutine "
 	s := string(buf[:n])
 	if !strings.HasPrefix(s, prefix) {
-		return 0
+		return -1
 	}
 	s = s[len(prefix):]
 	end := strings.IndexByte(s, ' ')
 	if end < 0 {
-		return 0
+		return -1
 	}
 	id, err := strconv.ParseInt(s[:end], 10, 64)
 	if err != nil {
-		return 0
+		return -1
 	}
 	return id
 }

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -269,6 +269,52 @@ func TestRecordFilesTouched_EmptyInputsIsNoop(t *testing.T) {
 	require.Equal(t, []string{"keep.txt"}, loaded.FilesTouched)
 }
 
+// TestMutateSessionState_DoesNotClobberRicherStateUnderRace simulates the
+// TOCTOU window between an existence check and a default-state init: a
+// caller observes "no state", but a concurrent richer write lands before
+// the init takes the lock. The init must re-read under lock and skip the
+// write rather than overwriting TranscriptPath, LastPrompt, etc. with
+// blanks.
+func TestMutateSessionState_DoesNotClobberRicherStateUnderRace(t *testing.T) {
+	dir := t.TempDir()
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	t.Chdir(dir)
+
+	sessionID := "ft-toctou"
+	rich := &SessionState{
+		SessionID:      sessionID,
+		BaseCommit:     "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		StartedAt:      time.Now(),
+		TranscriptPath: "/tmp/transcript.jsonl",
+		LastPrompt:     "find the bug",
+		ModelName:      "gpt-5",
+	}
+	require.NoError(t, SaveSessionState(context.Background(), rich))
+
+	// Pretend another process raced past its existence check while ours
+	// was about to initialize: do a no-op MutateSessionState that sets a
+	// clearly different value for an init-overwritten field. If the next
+	// call (simulating initializeSession's create path) reloads under the
+	// lock and bails out, our richer fields survive.
+	require.NoError(t, MutateSessionState(context.Background(), sessionID, func(_ *SessionState) error {
+		// no mutation; the test is about what the simulated init does next
+		return ErrMutationSkip
+	}))
+
+	// Now run the lock-then-recheck dance the real init does. Pass a state
+	// with all-empty derived fields to mimic the default-state shape.
+	_, _, release, lockErr := acquireSessionGate(context.Background(), sessionID)
+	require.NoError(t, lockErr)
+	existing, loadErr := LoadSessionState(context.Background(), sessionID)
+	release()
+	require.NoError(t, loadErr)
+	require.NotNil(t, existing)
+	require.Equal(t, "/tmp/transcript.jsonl", existing.TranscriptPath, "richer state must survive re-check under lock")
+	require.Equal(t, "find the bug", existing.LastPrompt)
+	require.Equal(t, "gpt-5", existing.ModelName)
+}
+
 // TestMutateSessionState_NestedCallsAreReentrant verifies that calling
 // MutateSessionState from within an outer MutateSessionState callback
 // doesn't deadlock. POSIX flock isn't reentrant across distinct FDs in the

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -269,6 +269,49 @@ func TestRecordFilesTouched_EmptyInputsIsNoop(t *testing.T) {
 	require.Equal(t, []string{"keep.txt"}, loaded.FilesTouched)
 }
 
+// TestMutateSessionState_NestedCallsAreReentrant verifies that calling
+// MutateSessionState from within an outer MutateSessionState callback
+// doesn't deadlock. POSIX flock isn't reentrant across distinct FDs in the
+// same process, so the gate's goroutine-ID ownership tracking has to skip
+// the flock re-acquire on the inner call.
+func TestMutateSessionState_NestedCallsAreReentrant(t *testing.T) {
+	dir := t.TempDir()
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	t.Chdir(dir)
+
+	state := &SessionState{
+		SessionID:  "ft-nested",
+		BaseCommit: "deadbeef",
+		StartedAt:  time.Now(),
+	}
+	require.NoError(t, SaveSessionState(context.Background(), state))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		err := MutateSessionState(context.Background(), "ft-nested", func(outer *SessionState) error {
+			outer.LastPrompt = "outer"
+			return MutateSessionState(context.Background(), "ft-nested", func(inner *SessionState) error {
+				inner.ModelName = "inner"
+				return nil
+			})
+		})
+		assert.NoError(t, err)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("nested MutateSessionState deadlocked")
+	}
+
+	loaded, err := LoadSessionState(context.Background(), "ft-nested")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	assert.Equal(t, "outer", loaded.LastPrompt)
+	assert.Equal(t, "inner", loaded.ModelName)
+}
+
 // TestRecordFilesTouched_ParallelMergesAreSerialized verifies the file-lock
 // in RecordFilesTouched: many concurrent callers, each merging a unique
 // file, must all land in FilesTouched. Without the lock, parallel

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -3,8 +3,10 @@ package strategy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/go-git/go-git/v6"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -264,6 +267,43 @@ func TestRecordFilesTouched_EmptyInputsIsNoop(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 	require.Equal(t, []string{"keep.txt"}, loaded.FilesTouched)
+}
+
+// TestRecordFilesTouched_ParallelMergesAreSerialized verifies the file-lock
+// in RecordFilesTouched: many concurrent callers, each merging a unique
+// file, must all land in FilesTouched. Without the lock, parallel
+// load → merge → save would lose updates and the final list would be missing
+// entries (or have duplicates).
+func TestRecordFilesTouched_ParallelMergesAreSerialized(t *testing.T) {
+	dir := t.TempDir()
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	t.Chdir(dir)
+
+	state := &SessionState{
+		SessionID:  "ft-parallel",
+		BaseCommit: "deadbeef",
+		StartedAt:  time.Now(),
+	}
+	require.NoError(t, SaveSessionState(context.Background(), state))
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			path := fmt.Sprintf("file-%02d.go", i)
+			err := RecordFilesTouched(context.Background(), "ft-parallel", nil, []string{path}, nil)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	loaded, err := LoadSessionState(context.Background(), "ft-parallel")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Len(t, loaded.FilesTouched, n, "every concurrent merge should be present")
 }
 
 // TestLoadSessionState_PackageLevel_NonExistent tests loading a non-existent session.

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -269,6 +269,42 @@ func TestRecordFilesTouched_EmptyInputsIsNoop(t *testing.T) {
 	require.Equal(t, []string{"keep.txt"}, loaded.FilesTouched)
 }
 
+// TestClearSessionState_PreservesLockFile pins the rule that ClearSessionState
+// must NOT unlink the per-session lock file. Unlinking the lock path while
+// another process holds an advisory lock on the inode would let a third
+// caller recreate the file and acquire an independent lock — losing mutual
+// exclusion. The lock file is a 0-byte sentinel; leaving it on disk after
+// state-file removal is harmless.
+func TestClearSessionState_PreservesLockFile(t *testing.T) {
+	dir := t.TempDir()
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	t.Chdir(dir)
+
+	sessionID := "ft-clear-keeps-lock"
+	state := &SessionState{
+		SessionID:  sessionID,
+		BaseCommit: "deadbeef",
+		StartedAt:  time.Now(),
+	}
+	require.NoError(t, SaveSessionState(context.Background(), state))
+
+	// Touch the lock file by entering MutateSessionState once.
+	require.NoError(t, MutateSessionState(context.Background(), sessionID, func(_ *SessionState) error {
+		return ErrMutationSkip
+	}))
+
+	lockPath, err := stateLockPath(context.Background(), sessionID)
+	require.NoError(t, err)
+	_, statErr := os.Stat(lockPath)
+	require.NoError(t, statErr, "lock file must exist after a MutateSessionState call")
+
+	require.NoError(t, ClearSessionState(context.Background(), sessionID))
+
+	_, statErr = os.Stat(lockPath)
+	require.NoError(t, statErr, "ClearSessionState must not unlink the lock file (would break flock semantics)")
+}
+
 // TestMutateSessionState_DoesNotClobberRicherStateUnderRace simulates the
 // TOCTOU window between an existence check and a default-state init: a
 // caller observes "no state", but a concurrent richer write lands before

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -201,6 +201,71 @@ func TestLoadSessionState_WithLastInteractionTime(t *testing.T) {
 	}
 }
 
+// TestRecordFilesTouched_MergesIncrementally verifies the helper merges new
+// files into existing FilesTouched without losing prior entries — the
+// invariant per-tool-use hooks rely on so PostCommit's carry-forward decision
+// stays accurate.
+func TestRecordFilesTouched_MergesIncrementally(t *testing.T) {
+	dir := t.TempDir()
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	t.Chdir(dir)
+
+	state := &SessionState{
+		SessionID:    "ft-merge",
+		BaseCommit:   "deadbeef",
+		StartedAt:    time.Now(),
+		FilesTouched: []string{"existing.txt"},
+	}
+	require.NoError(t, SaveSessionState(context.Background(), state))
+
+	require.NoError(t, RecordFilesTouched(context.Background(), "ft-merge",
+		[]string{"updated.txt"}, []string{"new.txt"}, []string{"removed.txt"}))
+
+	loaded, err := LoadSessionState(context.Background(), "ft-merge")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.ElementsMatch(t, []string{"existing.txt", "updated.txt", "new.txt", "removed.txt"}, loaded.FilesTouched)
+}
+
+func TestRecordFilesTouched_NoStateIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	t.Chdir(dir)
+
+	// Hook fires before InitializeSession ran — RecordFilesTouched must not
+	// fabricate a state file or error.
+	err = RecordFilesTouched(context.Background(), "missing", []string{"f.txt"}, nil, nil)
+	require.NoError(t, err)
+
+	loaded, err := LoadSessionState(context.Background(), "missing")
+	require.NoError(t, err)
+	require.Nil(t, loaded)
+}
+
+func TestRecordFilesTouched_EmptyInputsIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	t.Chdir(dir)
+
+	state := &SessionState{
+		SessionID:    "ft-empty",
+		BaseCommit:   "deadbeef",
+		StartedAt:    time.Now(),
+		FilesTouched: []string{"keep.txt"},
+	}
+	require.NoError(t, SaveSessionState(context.Background(), state))
+
+	require.NoError(t, RecordFilesTouched(context.Background(), "ft-empty", nil, nil, nil))
+
+	loaded, err := LoadSessionState(context.Background(), "ft-empty")
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Equal(t, []string{"keep.txt"}, loaded.FilesTouched)
+}
+
 // TestLoadSessionState_PackageLevel_NonExistent tests loading a non-existent session.
 func TestLoadSessionState_PackageLevel_NonExistent(t *testing.T) {
 	dir := t.TempDir()

--- a/cmd/entire/cli/strategy/state_lock_unix.go
+++ b/cmd/entire/cli/strategy/state_lock_unix.go
@@ -1,0 +1,25 @@
+//go:build unix
+
+package strategy
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// acquireStateFileLock takes an exclusive POSIX advisory lock on path. The
+// returned release closes the file (which drops the flock). Callers must call
+// release exactly once. The lock file persists between runs — that's fine,
+// flock state is held by the file descriptor, not the inode on disk.
+func acquireStateFileLock(path string) (release func(), err error) {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // path built from validated session ID
+	if err != nil {
+		return nil, fmt.Errorf("open state lock: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil { //nolint:gosec // file descriptors are non-negative; standard Go pattern for syscall.Flock
+		_ = f.Close()
+		return nil, fmt.Errorf("flock state lock: %w", err)
+	}
+	return func() { _ = f.Close() }, nil
+}

--- a/cmd/entire/cli/strategy/state_lock_windows.go
+++ b/cmd/entire/cli/strategy/state_lock_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package strategy
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// acquireStateFileLock takes an exclusive lock on path via Windows
+// LockFileEx. The returned release unlocks and closes the file. Callers
+// must call release exactly once.
+func acquireStateFileLock(path string) (release func(), err error) {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // path built from validated session ID
+	if err != nil {
+		return nil, fmt.Errorf("open state lock: %w", err)
+	}
+	overlapped := new(windows.Overlapped)
+	if err := windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, overlapped); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("lock state lock: %w", err)
+	}
+	return func() {
+		_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, overlapped)
+		_ = f.Close()
+	}, nil
+}

--- a/e2e/agents/codex.go
+++ b/e2e/agents/codex.go
@@ -239,7 +239,7 @@ func seedCodexHome(home, projectDir string) error {
 	if model == "" {
 		model = "gpt-5.4"
 	}
-	config := fmt.Sprintf("model = %q\n\n[features]\ncodex_hooks = true\n\n[projects.%q]\ntrust_level = \"trusted\"\n", model, projectDir)
+	config := fmt.Sprintf("model = %q\n\n[features]\nhooks = true\n\n[projects.%q]\ntrust_level = \"trusted\"\n", model, projectDir)
 	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(config), 0o600); err != nil {
 		return err
 	}

--- a/e2e/agents/codex.go
+++ b/e2e/agents/codex.go
@@ -240,6 +240,19 @@ func seedCodexHome(home, projectDir string) error {
 		model = "gpt-5.4"
 	}
 	config := fmt.Sprintf("model = %q\n\n[features]\nhooks = true\n\n[projects.%q]\ntrust_level = \"trusted\"\n", model, projectDir)
+
+	// Codex 0.129+ refuses to run unmanaged hooks until each one has a
+	// trusted_hash entry in the user's config. Compute the hashes the same
+	// way Codex does and pre-trust them — without this, every hook in
+	// .codex/hooks.json sits as Untrusted and our hooks never fire under e2e.
+	trustState, err := codexHookTrustState(projectDir)
+	if err != nil {
+		return fmt.Errorf("compute hook trust state: %w", err)
+	}
+	if trustState != "" {
+		config += "\n" + trustState
+	}
+
 	if err := os.WriteFile(filepath.Join(home, "config.toml"), []byte(config), 0o600); err != nil {
 		return err
 	}

--- a/e2e/agents/codex_trust.go
+++ b/e2e/agents/codex_trust.go
@@ -1,0 +1,226 @@
+package agents
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// codexHookFile mirrors the on-disk shape of .codex/hooks.json. Field types
+// match Codex's serde definitions (codex-rs/config/src/hook_config.rs) so the
+// trust-hash computation below stays faithful to discover_handlers.
+type codexHookFile struct {
+	Hooks codexHookEvents `json:"hooks"`
+}
+
+type codexHookEvents struct {
+	PreToolUse        []codexHookGroup `json:"PreToolUse"`
+	PermissionRequest []codexHookGroup `json:"PermissionRequest"`
+	PostToolUse       []codexHookGroup `json:"PostToolUse"`
+	PreCompact        []codexHookGroup `json:"PreCompact"`
+	PostCompact       []codexHookGroup `json:"PostCompact"`
+	SessionStart      []codexHookGroup `json:"SessionStart"`
+	UserPromptSubmit  []codexHookGroup `json:"UserPromptSubmit"`
+	Stop              []codexHookGroup `json:"Stop"`
+}
+
+type codexHookGroup struct {
+	Matcher *string             `json:"matcher"`
+	Hooks   []codexHookHandlers `json:"hooks"`
+}
+
+type codexHookHandlers struct {
+	Type          string  `json:"type"`
+	Command       string  `json:"command"`
+	Timeout       *uint64 `json:"timeout"`
+	Async         bool    `json:"async"`
+	StatusMessage *string `json:"statusMessage"`
+}
+
+// codexHookEventLabels lists every event name in the order Codex emits in
+// the JSON schema, paired with the snake_case label it uses for trust state
+// keys (codex-rs/hooks/src/lib.rs:hook_event_key_label).
+var codexHookEventLabels = []struct {
+	displayName string
+	keyLabel    string
+}{
+	{"PreToolUse", "pre_tool_use"},
+	{"PermissionRequest", "permission_request"},
+	{"PostToolUse", "post_tool_use"},
+	{"PreCompact", "pre_compact"},
+	{"PostCompact", "post_compact"},
+	{"SessionStart", "session_start"},
+	{"UserPromptSubmit", "user_prompt_submit"},
+	{"Stop", "stop"},
+}
+
+// codexHookTrustState reads .codex/hooks.json from projectDir and returns the
+// `[hooks.state.<key>]` TOML block that pre-trusts every command handler
+// declared there. The hash matches Codex's command_hook_hash exactly (see
+// codex-rs/hooks/src/engine/discovery.rs and config/src/fingerprint.rs):
+//
+//  1. Build a NormalizedHookIdentity = { event_name, matcher, hooks: [normalized_handler] }
+//  2. Serialize to JSON with object keys sorted alphabetically (canonical_json)
+//  3. SHA-256 the compact JSON bytes; format as "sha256:<hex>"
+//
+// Returns empty string when no hooks file exists.
+func codexHookTrustState(projectDir string) (string, error) {
+	hooksPath := filepath.Join(projectDir, ".codex", "hooks.json")
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	var file codexHookFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return "", fmt.Errorf("parse hooks.json: %w", err)
+	}
+
+	var sb strings.Builder
+	for _, ev := range codexHookEventLabels {
+		groups := codexEventGroups(&file.Hooks, ev.displayName)
+		for groupIdx, group := range groups {
+			for handlerIdx, handler := range group.Hooks {
+				if handler.Type != "command" {
+					continue
+				}
+				timeoutSec := uint64(600)
+				if handler.Timeout != nil {
+					timeoutSec = *handler.Timeout
+				}
+				if timeoutSec < 1 {
+					timeoutSec = 1
+				}
+				hash := codexCommandHookHash(ev.keyLabel, group.Matcher, handler.Command, timeoutSec, handler.Async, handler.StatusMessage)
+				key := fmt.Sprintf("%s:%s:%d:%d", hooksPath, ev.keyLabel, groupIdx, handlerIdx)
+				fmt.Fprintf(&sb, "[hooks.state.%q]\ntrusted_hash = %q\n\n", key, hash)
+			}
+		}
+	}
+	return sb.String(), nil
+}
+
+func codexEventGroups(events *codexHookEvents, displayName string) []codexHookGroup {
+	switch displayName {
+	case "PreToolUse":
+		return events.PreToolUse
+	case "PermissionRequest":
+		return events.PermissionRequest
+	case "PostToolUse":
+		return events.PostToolUse
+	case "PreCompact":
+		return events.PreCompact
+	case "PostCompact":
+		return events.PostCompact
+	case "SessionStart":
+		return events.SessionStart
+	case "UserPromptSubmit":
+		return events.UserPromptSubmit
+	case "Stop":
+		return events.Stop
+	}
+	return nil
+}
+
+// codexCommandHookHash mirrors command_hook_hash + version_for_toml. Codex
+// builds a TOML value of NormalizedHookIdentity then serde_json::to_value
+// converts it to JSON; we skip the TOML round-trip and emit the equivalent
+// JSON directly. Crucially:
+//   - matcher is omitted when nil (TOML can't represent null Options)
+//   - timeout is always present (the normalized handler always sets Some(_))
+//   - statusMessage is omitted when nil
+//   - object keys are sorted alphabetically by canonicalize before hashing
+func codexCommandHookHash(eventLabel string, matcher *string, command string, timeoutSec uint64, async bool, statusMessage *string) string {
+	handler := map[string]any{
+		"type":    "command",
+		"command": command,
+		"timeout": json.Number(strconv.FormatUint(timeoutSec, 10)),
+		"async":   async,
+	}
+	if statusMessage != nil {
+		handler["statusMessage"] = *statusMessage
+	}
+	identity := map[string]any{
+		"event_name": eventLabel,
+		"hooks":      []any{handler},
+	}
+	if matcher != nil {
+		identity["matcher"] = *matcher
+	}
+
+	canonical := codexCanonicalJSON(identity)
+	sum := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// codexCanonicalJSON marshals v with object keys sorted alphabetically, no
+// whitespace. Go's encoding/json already sorts map[string]any keys, but we
+// re-walk explicitly to make the contract obvious and to keep the output
+// stable if a future stdlib change reorders.
+func codexCanonicalJSON(v any) []byte {
+	var buf strings.Builder
+	codexWriteCanonical(&buf, v)
+	return []byte(buf.String())
+}
+
+func codexWriteCanonical(buf *strings.Builder, v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		buf.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			buf.Write(codexJSONAtom(k))
+			buf.WriteByte(':')
+			codexWriteCanonical(buf, t[k])
+		}
+		buf.WriteByte('}')
+	case []any:
+		buf.WriteByte('[')
+		for i, item := range t {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			codexWriteCanonical(buf, item)
+		}
+		buf.WriteByte(']')
+	default:
+		buf.Write(codexJSONAtom(t))
+	}
+}
+
+// codexJSONAtom marshals a scalar matching serde_json's default escaping
+// rules: only the JSON-required characters (", \, control chars) are
+// escaped — `<`, `>`, `&` pass through unchanged. Go's default json.Marshal
+// HTML-escapes those bytes to \u00XX, which would diverge from Codex's
+// hash for any command containing shell redirection (>, &&, etc.).
+func codexJSONAtom(v any) []byte {
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	// Callers pass strings, bools, and json.Number atoms only; encoding
+	// can't fail for those types. Ignore the error rather than complicating
+	// every call site for a static guarantee.
+	_ = enc.Encode(v) //nolint:errchkjson // scalar atoms only; error is unreachable
+	out := b.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out
+}

--- a/e2e/agents/codex_trust_test.go
+++ b/e2e/agents/codex_trust_test.go
@@ -1,0 +1,98 @@
+package agents
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCodexCommandHookHash_MatchesCanonicalShape verifies the canonical
+// JSON the hash is computed over, against a hand-built reference string.
+// Pinning the byte-exact JSON catches drift in canonicalization (key
+// sort, omit-when-nil rules, HTML-escape behavior, integer rendering)
+// before it silently breaks pre-trust in e2e.
+func TestCodexCommandHookHash_MatchesCanonicalShape(t *testing.T) {
+	t.Parallel()
+	// Reference canonical JSON for: post_tool_use, no matcher, single
+	// command handler with timeout=30, async=false, no statusMessage.
+	// Keys MUST be alphabetical; matcher and statusMessage MUST be absent.
+	// shell-redirect characters (>) MUST NOT be HTML-escaped — Codex's
+	// serde_json::to_vec passes them through unchanged.
+	const wantCanonical = `{"event_name":"post_tool_use","hooks":[{"async":false,"command":"sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex post-tool-use'","timeout":30,"type":"command"}]}`
+	sum := sha256.Sum256([]byte(wantCanonical))
+	wantHash := "sha256:" + hex.EncodeToString(sum[:])
+
+	got := codexCommandHookHash(
+		"post_tool_use",
+		nil, // no matcher
+		`sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex post-tool-use'`,
+		30,
+		false,
+		nil, // no statusMessage
+	)
+	require.Equal(t, wantHash, got)
+}
+
+// TestCodexCommandHookHash_OmitsNilOptions confirms that nil matcher and
+// nil statusMessage are absent from the canonical JSON — Codex's TOML
+// round-trip drops Option::None, and any divergence would produce a
+// different hash than what discover_handlers computes at runtime.
+func TestCodexCommandHookHash_OmitsNilOptions(t *testing.T) {
+	t.Parallel()
+	const wantCanonical = `{"event_name":"stop","hooks":[{"async":false,"command":"echo hi","timeout":600,"type":"command"}]}`
+	sum := sha256.Sum256([]byte(wantCanonical))
+	wantHash := "sha256:" + hex.EncodeToString(sum[:])
+
+	got := codexCommandHookHash("stop", nil, "echo hi", 600, false, nil)
+	require.Equal(t, wantHash, got)
+}
+
+// TestCodexHookTrustState_GeneratesEntriesForEveryDeclaredHandler
+// exercises the full path: read .codex/hooks.json, walk every event in
+// Codex's declared order, emit a [hooks.state."<path>:<event>:0:0"] block
+// per command handler with the matching trusted_hash.
+func TestCodexHookTrustState_GeneratesEntriesForEveryDeclaredHandler(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	codexDir := filepath.Join(dir, ".codex")
+	require.NoError(t, os.MkdirAll(codexDir, 0o750))
+
+	hooksJSON := `{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": null, "hooks": [{"type": "command", "command": "entire hooks codex session-start", "timeout": 30}]}
+    ],
+    "Stop": [
+      {"matcher": null, "hooks": [{"type": "command", "command": "entire hooks codex stop", "timeout": 30}]}
+    ]
+  }
+}
+`
+	hooksPath := filepath.Join(codexDir, "hooks.json")
+	require.NoError(t, os.WriteFile(hooksPath, []byte(hooksJSON), 0o600))
+
+	state, err := codexHookTrustState(dir)
+	require.NoError(t, err)
+	require.Contains(t, state, hooksPath+":session_start:0:0")
+	require.Contains(t, state, hooksPath+":stop:0:0")
+	require.Contains(t, state, "trusted_hash = \"sha256:")
+	// Two declared handlers → two state entries.
+	require.Equal(t, 2, strings.Count(state, "[hooks.state."))
+	require.Equal(t, 2, strings.Count(state, "trusted_hash ="))
+}
+
+// TestCodexHookTrustState_MissingFileIsNoop returns empty trust state
+// (and no error) when there's no hooks.json yet — the e2e seed runs
+// before some tests' enable step.
+func TestCodexHookTrustState_MissingFileIsNoop(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	state, err := codexHookTrustState(dir)
+	require.NoError(t, err)
+	require.Empty(t, state)
+}

--- a/e2e/testutil/metadata.go
+++ b/e2e/testutil/metadata.go
@@ -53,6 +53,13 @@ type SessionMetadata struct {
 	TokenUsage         TokenUsage  `json:"token_usage"`
 	InitialAttribution Attribution `json:"initial_attribution"`
 	TranscriptPath     string      `json:"transcript_path"`
+
+	// CheckpointTranscriptStart is the transcript.jsonl line offset where this
+	// checkpoint's contributions begin. For the first checkpoint in a session
+	// it's 0; for subsequent checkpoints it must point past prior content so
+	// consumers (explain, attribution, summaries) can scope the transcript
+	// correctly. omitempty in the on-wire form, so we read 0 when absent.
+	CheckpointTranscriptStart int `json:"checkpoint_transcript_start,omitempty"`
 }
 
 func CheckpointPath(id string) string {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/329
<!-- entire-trail-link-end -->

Turns out codex added post-tool-use hooks, let's add them! :) 

## Add Codex PostToolUse + hook drift detection

Adds Codex `PostToolUse` hook support so `state.FilesTouched` is populated mid-turn (instead of only at Stop). Brings Codex to parity with Claude Code on tool-level event tracking.

Alongside, surface two kinds of Codex hook drift in `entire doctor` and the SessionStart welcome:

- **Trust gaps**: hook declared in `.codex/hooks.json` but no `trusted_hash` entry in the user's Codex config — fresh clone or a hook added in a release after the user's last `/hooks` approval.
- **Stale file**: `.codex/hooks.json` predates a canonical event (e.g. PostToolUse itself) — fix is re-running `entire enable`.

Other bits along the way:
- Codex 0.129 feature-flag rename (`codex_hooks` → `hooks`) and per-user trust gate
- Pre-trust hooks in the e2e seed so canary runs don't get prompted
- Concurrent-write hardening on session state via `MutateSessionState` (per-process gate + flock)
- 
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds a new lifecycle event (`ToolUse`) and refactors many session-state write paths to go through a new cross-process locking/mutation helper, which could impact checkpointing/condensation correctness and introduce deadlocks or missed state updates if wrong.
> 
> **Overview**
> Adds Codex `post-tool-use` hook support and propagates `apply_patch` tool calls into a new lifecycle event (`agent.ToolUse`) so mid-turn file mutations are recorded incrementally (including add/update/delete and `*** Move to:` rename handling).
> 
> Introduces `strategy.MutateSessionState` with per-session advisory lock files under `.git/entire-session-locks/` (plus a reentrancy gate) and refactors lifecycle + manual-commit strategy code paths to use it for load/mutate/save, preventing lost updates when hooks fire concurrently. Includes integration/unit tests for PostToolUse end-to-end behavior, apply_patch parsing/classification, and concurrency/locking invariants (parallel merges, nested mutations, and lock-file cleanup behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ce8d6d9ef7a8f3d7c187f0979ca1e495f14ef1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->