### PR TITLE
Improve recap API error messages

### DIFF
--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -139,7 +141,7 @@ func runRecap(ctx context.Context, w io.Writer, f *recapFlags) error {
 	start, end := rangeKey.Bounds(time.Now())
 	resp, err := recap.FetchMeRecap(ctx, client, start, end, repoSlug, 0)
 	if err != nil {
-		return fmt.Errorf("fetch recap: %w", err)
+		return handleRecapFetchError(w, err)
 	}
 	fmt.Fprint(w, recap.RenderStaticRecap(resp, recap.RenderOptions{
 		Range: rangeKey,
@@ -150,6 +152,25 @@ func runRecap(ctx context.Context, w io.Writer, f *recapFlags) error {
 	}))
 	fmt.Fprintln(w)
 	return nil
+}
+
+func handleRecapFetchError(w io.Writer, err error) error {
+	if shouldShowRecapLoadErrorMessage(err) {
+		fmt.Fprintln(w, recapLoadErrorMessage(err))
+		return NewSilentError(err)
+	}
+	return fmt.Errorf("fetch recap: %w", err)
+}
+
+func shouldShowRecapLoadErrorMessage(err error) bool {
+	var apiErr *api.HTTPError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusUnauthorized ||
+			apiErr.StatusCode == http.StatusBadRequest ||
+			apiErr.StatusCode == http.StatusNotFound ||
+			apiErr.StatusCode >= http.StatusInternalServerError
+	}
+	return isRecapNetworkError(err)
 }
 
 func terminalWidth(w io.Writer) int {

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -42,7 +42,7 @@ func newRecapCmd() *cobra.Command {
 		Use:   "recap",
 		Short: "Summarize recent checkpoint activity",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runRecap(cmd.Context(), cmd.OutOrStdout(), f)
+			return runRecap(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), f)
 		},
 	}
 	cmd.Flags().BoolVar(&f.day, "day", false, "Today only (default)")
@@ -109,9 +109,9 @@ func (f *recapFlags) useTUI(isTerminal, canPrompt, accessible bool) bool {
 	return isTerminal && canPrompt && !accessible && !f.static
 }
 
-func runRecap(ctx context.Context, w io.Writer, f *recapFlags) error {
+func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 	if _, err := paths.WorktreeRoot(ctx); err != nil {
-		fmt.Fprintln(w, "Not a git repository. Run 'entire recap' from within a git repository.")
+		fmt.Fprintln(errW, "Not a git repository. Run 'entire recap' from within a git repository.")
 		return NewSilentError(errors.New("not a git repository"))
 	}
 	mode := f.mode()
@@ -124,7 +124,7 @@ func runRecap(ctx context.Context, w io.Writer, f *recapFlags) error {
 	}
 	client, err := NewAuthenticatedAPIClient(f.insecureHTTP)
 	if err != nil {
-		fmt.Fprintln(w, "Sign in with `entire login` to use `entire recap`.")
+		fmt.Fprintln(errW, "Sign in with `entire login` to use `entire recap`.")
 		return NewSilentError(err)
 	}
 	rangeKey := f.rangeKey()
@@ -141,7 +141,7 @@ func runRecap(ctx context.Context, w io.Writer, f *recapFlags) error {
 	start, end := rangeKey.Bounds(time.Now())
 	resp, err := recap.FetchMeRecap(ctx, client, start, end, repoSlug, 0)
 	if err != nil {
-		return handleRecapFetchError(w, err)
+		return handleRecapFetchError(errW, err)
 	}
 	fmt.Fprint(w, recap.RenderStaticRecap(resp, recap.RenderOptions{
 		Range: rangeKey,

--- a/cmd/entire/cli/recap/me_recap.go
+++ b/cmd/entire/cli/recap/me_recap.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"strconv"
 	"time"
@@ -126,9 +125,8 @@ func FetchMeRecap(
 		return nil, fmt.Errorf("me/recap get: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body) //nolint:errcheck // best-effort error body
-		return nil, fmt.Errorf("me/recap: http %d: %s", resp.StatusCode, string(body))
+	if err := api.CheckResponse(resp); err != nil {
+		return nil, fmt.Errorf("me/recap: %w", err)
 	}
 	var out MeRecapResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {

--- a/cmd/entire/cli/recap/me_recap_test.go
+++ b/cmd/entire/cli/recap/me_recap_test.go
@@ -1,0 +1,42 @@
+package recap
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+)
+
+func TestFetchMeRecap_ReturnsTypedUnauthorizedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		if _, err := w.Write([]byte(`{"error":"Token expired"}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv(api.BaseURLEnvVar, server.URL)
+
+	_, err := FetchMeRecap(
+		context.Background(),
+		api.NewClient("expired-token"),
+		time.Date(2026, 5, 8, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 9, 0, 0, 0, 0, time.UTC),
+		"",
+		0,
+	)
+	if err == nil {
+		t.Fatal("FetchMeRecap error = nil, want unauthorized error")
+	}
+	if !api.IsHTTPErrorStatus(err, http.StatusUnauthorized) {
+		t.Fatalf("FetchMeRecap error = %v, want typed 401", err)
+	}
+	if !strings.Contains(err.Error(), "Token expired") {
+		t.Fatalf("FetchMeRecap error = %v, want token-expired message", err)
+	}
+}

--- a/cmd/entire/cli/recap_errors.go
+++ b/cmd/entire/cli/recap_errors.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+)
+
+func recapLoadErrorMessage(err error) string {
+	if errors.Is(err, context.Canceled) {
+		return "Recap request was canceled."
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Sprintf("Recap request timed out. Check your internet connection and retry. Details: %v", err)
+	}
+
+	var apiErr *api.HTTPError
+	if errors.As(err, &apiErr) {
+		detail := recapErrorDetail(apiErr)
+		switch apiErr.StatusCode {
+		case http.StatusUnauthorized:
+			return "Run `entire login` to re-authenticate."
+		case http.StatusBadRequest:
+			return "Entire sent an invalid recap time range. Please update Entire CLI and retry. Details: " + detail
+		case http.StatusNotFound:
+			return "entire.io could not find your account. Run `entire logout` then `entire login`; if it still fails, contact Entire support. Details: " + detail
+		default:
+			if apiErr.StatusCode >= http.StatusInternalServerError {
+				return "entire.io could not build the recap. Please retry in a moment; if it still fails, contact Entire support. Details: " + detail
+			}
+			return err.Error()
+		}
+	}
+	if isRecapNetworkError(err) {
+		return fmt.Sprintf("Could not reach entire.io. Check your internet connection and ENTIRE_API_BASE_URL if you use a custom API host. Details: %v", err)
+	}
+	return err.Error()
+}
+
+func recapErrorDetail(err *api.HTTPError) string {
+	if strings.TrimSpace(err.Message) != "" {
+		return fmt.Sprintf("HTTP %d: %s", err.StatusCode, err.Message)
+	}
+	if text := http.StatusText(err.StatusCode); text != "" {
+		return fmt.Sprintf("HTTP %d: %s", err.StatusCode, text)
+	}
+	return fmt.Sprintf("HTTP %d", err.StatusCode)
+}
+
+func isRecapNetworkError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+	var dnsErr *net.DNSError
+	return errors.As(err, &dnsErr)
+}

--- a/cmd/entire/cli/recap_test.go
+++ b/cmd/entire/cli/recap_test.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -138,6 +140,25 @@ func TestRecapFlags_ColorEnabled(t *testing.T) {
 
 	if _, err := (&recapFlags{color: "rainbow"}).colorEnabled(&out); err == nil {
 		t.Fatal("colorEnabled(invalid) error = nil, want error")
+	}
+}
+
+func TestRunRecap_PrerequisiteErrorsUseErrorWriter(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	err := runRecap(context.Background(), &out, &errOut, &recapFlags{})
+	var silent *SilentError
+	if !errors.As(err, &silent) {
+		t.Fatalf("error = %T %v, want SilentError", err, err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", out.String())
+	}
+	if !strings.Contains(errOut.String(), "Not a git repository") {
+		t.Fatalf("stderr missing git prerequisite message: %q", errOut.String())
 	}
 }
 
@@ -290,5 +311,39 @@ func TestRecapLoadErrorMessage_NetworkError(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("message missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestRecapLoadErrorMessage_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	canceled := fmt.Errorf("me/recap get: %w", &url.Error{
+		Op:  "Get",
+		URL: "https://entire.io/api/v1/me/recap",
+		Err: context.Canceled,
+	})
+	got := recapLoadErrorMessage(canceled)
+	if strings.Contains(got, "Could not reach entire.io") {
+		t.Fatalf("cancellation should not be reported as a network failure:\n%s", got)
+	}
+	if !strings.Contains(got, "Recap request was canceled") {
+		t.Fatalf("message missing cancellation explanation:\n%s", got)
+	}
+}
+
+func TestRecapLoadErrorMessage_ContextDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	deadline := fmt.Errorf("me/recap get: %w", &url.Error{
+		Op:  "Get",
+		URL: "https://entire.io/api/v1/me/recap",
+		Err: context.DeadlineExceeded,
+	})
+	got := recapLoadErrorMessage(deadline)
+	if strings.Contains(got, "Could not reach entire.io") {
+		t.Fatalf("timeout should not be reported as a generic network failure:\n%s", got)
+	}
+	if !strings.Contains(got, "Recap request timed out") {
+		t.Fatalf("message missing timeout explanation:\n%s", got)
 	}
 }

--- a/cmd/entire/cli/recap_test.go
+++ b/cmd/entire/cli/recap_test.go
@@ -2,8 +2,14 @@ package cli
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/recap"
 )
 
@@ -132,5 +138,157 @@ func TestRecapFlags_ColorEnabled(t *testing.T) {
 
 	if _, err := (&recapFlags{color: "rainbow"}).colorEnabled(&out); err == nil {
 		t.Fatal("colorEnabled(invalid) error = nil, want error")
+	}
+}
+
+func TestHandleRecapFetchError_UnauthorizedPromptsLogin(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := handleRecapFetchError(&out, &api.HTTPError{
+		StatusCode: http.StatusUnauthorized,
+		Message:    "Token expired",
+	})
+	var silent *SilentError
+	if !errors.As(err, &silent) {
+		t.Fatalf("error = %T %v, want SilentError", err, err)
+	}
+	if !strings.Contains(out.String(), "Run `entire login` to re-authenticate.") {
+		t.Fatalf("output missing re-authentication prompt: %q", out.String())
+	}
+}
+
+func TestHandleRecapFetchError_PrintsMappedMessage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "bad request",
+			err: &api.HTTPError{
+				StatusCode: http.StatusBadRequest,
+				Message:    "since must be on or before until",
+			},
+			want: "invalid recap time range",
+		},
+		{
+			name: "missing account",
+			err: &api.HTTPError{
+				StatusCode: http.StatusNotFound,
+				Message:    "User not found",
+			},
+			want: "could not find your account",
+		},
+		{
+			name: "server failure",
+			err: &api.HTTPError{
+				StatusCode: http.StatusInternalServerError,
+				Message:    "Failed to build recap",
+			},
+			want: "entire.io could not build the recap",
+		},
+		{
+			name: "network",
+			err:  &net.DNSError{Name: "entire.io", Err: "no such host"},
+			want: "Could not reach entire.io",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			err := handleRecapFetchError(&out, c.err)
+			var silent *SilentError
+			if !errors.As(err, &silent) {
+				t.Fatalf("error = %T %v, want SilentError", err, err)
+			}
+			if !strings.Contains(out.String(), c.want) {
+				t.Fatalf("output missing %q: %q", c.want, out.String())
+			}
+		})
+	}
+}
+
+func TestRecapLoadErrorMessage_HTTPStatuses(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "bad recap time range",
+			err: &api.HTTPError{
+				StatusCode: http.StatusBadRequest,
+				Message:    "since must be on or before until",
+			},
+			want: []string{
+				"Entire sent an invalid recap time range.",
+				"update Entire CLI",
+				"HTTP 400",
+				"since must be on or before until",
+			},
+		},
+		{
+			name: "missing server user",
+			err: &api.HTTPError{
+				StatusCode: http.StatusNotFound,
+				Message:    "User not found",
+			},
+			want: []string{
+				"entire.io could not find your account",
+				"entire logout",
+				"entire login",
+				"HTTP 404",
+				"User not found",
+			},
+		},
+		{
+			name: "server failure",
+			err: &api.HTTPError{
+				StatusCode: http.StatusInternalServerError,
+				Message:    "Failed to build recap",
+			},
+			want: []string{
+				"entire.io could not build the recap",
+				"retry",
+				"HTTP 500",
+				"Failed to build recap",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := recapLoadErrorMessage(fmt.Errorf("me/recap: %w", c.err))
+			for _, want := range c.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("message missing %q:\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRecapLoadErrorMessage_NetworkError(t *testing.T) {
+	t.Parallel()
+
+	dnsErr := &net.DNSError{Name: "entire.io", Err: "no such host"}
+	got := recapLoadErrorMessage(fmt.Errorf("me/recap get: %w", dnsErr))
+	for _, want := range []string{
+		"Could not reach entire.io",
+		"Check your internet connection",
+		"ENTIRE_API_BASE_URL",
+		"no such host",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("message missing %q:\n%s", want, got)
+		}
 	}
 }

--- a/cmd/entire/cli/recap_tui.go
+++ b/cmd/entire/cli/recap_tui.go
@@ -2,7 +2,11 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -177,7 +181,7 @@ func (m recapTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m recapTUIModel) View() tea.View {
 	v := tea.View{AltScreen: true}
 	if m.loadErr != nil {
-		v.SetContent(fmt.Sprintf("\n  Failed to load recap: %s\n\n  Press r to retry or q to quit.\n", m.loadErr))
+		v.SetContent(fmt.Sprintf("\n  Failed to load recap: %s\n\n  Press r to retry or q to quit.\n", recapLoadErrorMessage(m.loadErr)))
 		return v
 	}
 	if m.loading && m.resp == nil {
@@ -194,6 +198,49 @@ func (m recapTUIModel) View() tea.View {
 	b.WriteString(m.renderFooter())
 	v.SetContent(b.String())
 	return v
+}
+
+func recapLoadErrorMessage(err error) string {
+	var apiErr *api.HTTPError
+	if errors.As(err, &apiErr) {
+		detail := recapErrorDetail(apiErr)
+		switch apiErr.StatusCode {
+		case http.StatusUnauthorized:
+			return "Run `entire login` to re-authenticate."
+		case http.StatusBadRequest:
+			return "Entire sent an invalid recap time range. Please update Entire CLI and retry. Details: " + detail
+		case http.StatusNotFound:
+			return "entire.io could not find your account. Run `entire logout` then `entire login`; if it still fails, contact Entire support. Details: " + detail
+		default:
+			if apiErr.StatusCode >= http.StatusInternalServerError {
+				return "entire.io could not build the recap. Please retry in a moment; if it still fails, contact Entire support. Details: " + detail
+			}
+			return err.Error()
+		}
+	}
+	if isRecapNetworkError(err) {
+		return fmt.Sprintf("Could not reach entire.io. Check your internet connection and ENTIRE_API_BASE_URL if you use a custom API host. Details: %v", err)
+	}
+	return err.Error()
+}
+
+func recapErrorDetail(err *api.HTTPError) string {
+	if strings.TrimSpace(err.Message) != "" {
+		return fmt.Sprintf("HTTP %d: %s", err.StatusCode, err.Message)
+	}
+	if text := http.StatusText(err.StatusCode); text != "" {
+		return fmt.Sprintf("HTTP %d: %s", err.StatusCode, text)
+	}
+	return fmt.Sprintf("HTTP %d", err.StatusCode)
+}
+
+func isRecapNetworkError(err error) bool {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+	var dnsErr *net.DNSError
+	return errors.As(err, &dnsErr)
 }
 
 func (m recapTUIModel) withViewport() recapTUIModel {

--- a/cmd/entire/cli/recap_tui.go
+++ b/cmd/entire/cli/recap_tui.go
@@ -2,11 +2,7 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net"
-	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -198,49 +194,6 @@ func (m recapTUIModel) View() tea.View {
 	b.WriteString(m.renderFooter())
 	v.SetContent(b.String())
 	return v
-}
-
-func recapLoadErrorMessage(err error) string {
-	var apiErr *api.HTTPError
-	if errors.As(err, &apiErr) {
-		detail := recapErrorDetail(apiErr)
-		switch apiErr.StatusCode {
-		case http.StatusUnauthorized:
-			return "Run `entire login` to re-authenticate."
-		case http.StatusBadRequest:
-			return "Entire sent an invalid recap time range. Please update Entire CLI and retry. Details: " + detail
-		case http.StatusNotFound:
-			return "entire.io could not find your account. Run `entire logout` then `entire login`; if it still fails, contact Entire support. Details: " + detail
-		default:
-			if apiErr.StatusCode >= http.StatusInternalServerError {
-				return "entire.io could not build the recap. Please retry in a moment; if it still fails, contact Entire support. Details: " + detail
-			}
-			return err.Error()
-		}
-	}
-	if isRecapNetworkError(err) {
-		return fmt.Sprintf("Could not reach entire.io. Check your internet connection and ENTIRE_API_BASE_URL if you use a custom API host. Details: %v", err)
-	}
-	return err.Error()
-}
-
-func recapErrorDetail(err *api.HTTPError) string {
-	if strings.TrimSpace(err.Message) != "" {
-		return fmt.Sprintf("HTTP %d: %s", err.StatusCode, err.Message)
-	}
-	if text := http.StatusText(err.StatusCode); text != "" {
-		return fmt.Sprintf("HTTP %d: %s", err.StatusCode, text)
-	}
-	return fmt.Sprintf("HTTP %d", err.StatusCode)
-}
-
-func isRecapNetworkError(err error) bool {
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		return true
-	}
-	var dnsErr *net.DNSError
-	return errors.As(err, &dnsErr)
 }
 
 func (m recapTUIModel) withViewport() recapTUIModel {

--- a/cmd/entire/cli/recap_tui_test.go
+++ b/cmd/entire/cli/recap_tui_test.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/recap"
 )
 
@@ -228,6 +231,24 @@ func TestRecapTUIModel_FooterFitsWidth(t *testing.T) {
 	}
 	if !strings.Contains(footer, "q quit") {
 		t.Fatalf("narrow footer should keep quit help: %q", footer)
+	}
+}
+
+func TestRecapTUIModel_ViewShowsLoginPromptForUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	m := testRecapTUIModel()
+	m.loadErr = fmt.Errorf("me/recap: %w", &api.HTTPError{
+		StatusCode: http.StatusUnauthorized,
+		Message:    "Token expired",
+	})
+
+	got := m.View().Content
+	if !strings.Contains(got, "Run `entire login` to re-authenticate.") {
+		t.Fatalf("View() missing re-authentication prompt:\n%s", got)
+	}
+	if strings.Contains(got, `{"error":"Token expired"}`) {
+		t.Fatalf("View() should not render raw API JSON:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/331
<!-- entire-trail-link-end -->

Entire-Checkpoint: 76826089ae0f

## Summary
- Preserve typed API errors for `/api/v1/me/recap` by using `api.CheckResponse` instead of flattening non-2xx responses into raw body strings.
- Show actionable recap load errors in both the interactive TUI and `--static` output for expired auth, invalid ranges, missing accounts, server failures, and network/DNS/TLS failures.
- Add regression coverage for typed recap API errors and the mapped user-facing messages.

## Testing
- `mise run lint`
- `go test -count=1 ./cmd/entire/cli/recap ./cmd/entire/cli`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error parsing/mapping and user-facing messaging for `recap`, with added tests; no core auth flows or data mutations are modified.
> 
> **Overview**
> Improves `entire recap` error handling by converting `/api/v1/me/recap` failures into typed `api.HTTPError`s (via `api.CheckResponse`) and mapping common statuses/network issues to actionable, non-raw messages.
> 
> Both the static CLI path and the TUI now show consistent guidance (e.g., re-login on 401, update CLI on 400, account/help text on 404, retry/support on 5xx, connectivity hints for network errors), and new tests cover the typed error behavior and message mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c5f4bb4424fc1386a2f03dc4365d7829a210763. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
