### PR TITLE
Fix review TUI wrapping

### DIFF
--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -918,6 +918,49 @@ func TestComposeSingleAgentSinks(t *testing.T) {
 	}
 }
 
+func TestComposeSinks_TUIWritersRunBeforePostRunWriters(t *testing.T) {
+	t.Parallel()
+	provider := &stubSynthesisProvider{}
+
+	multi := review.ExposedComposeMultiAgentSinks(review.SinkComposeInputs{
+		Out:               &bytes.Buffer{},
+		IsTTY:             true,
+		CanPrompt:         true,
+		AgentNames:        []string{"a", "b"},
+		CancelRun:         func() {},
+		SynthesisProvider: provider,
+	})
+	if len(multi) != 3 {
+		t.Fatalf("multi sinks len = %d, want 3", len(multi))
+	}
+	if _, ok := multi[0].(*review.TUISink); !ok {
+		t.Fatalf("multi sink[0] = %T, want *TUISink", multi[0])
+	}
+	if _, ok := multi[1].(review.DumpSink); !ok {
+		t.Fatalf("multi sink[1] = %T, want DumpSink", multi[1])
+	}
+	if _, ok := multi[2].(review.SynthesisSink); !ok {
+		t.Fatalf("multi sink[2] = %T, want SynthesisSink", multi[2])
+	}
+
+	single := review.ExposedComposeSingleAgentSinks(review.SingleAgentSinkComposeInputs{
+		Out:       &bytes.Buffer{},
+		IsTTY:     true,
+		CanPrompt: true,
+		AgentName: "a",
+		CancelRun: func() {},
+	})
+	if len(single) != 2 {
+		t.Fatalf("single sinks len = %d, want 2", len(single))
+	}
+	if _, ok := single[0].(*review.TUISink); !ok {
+		t.Fatalf("single sink[0] = %T, want *TUISink", single[0])
+	}
+	if _, ok := single[1].(review.DumpSink); !ok {
+		t.Fatalf("single sink[1] = %T, want DumpSink", single[1])
+	}
+}
+
 // TestFindTUISink_NoTUIInSlice covers the not-found path so the caller's
 // `if tuiSink, ok := findTUISink(sinks); ok` branch is exercised in both
 // directions.

--- a/cmd/entire/cli/review/tui_detail.go
+++ b/cmd/entire/cli/review/tui_detail.go
@@ -9,29 +9,14 @@ package review
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
-	"github.com/entireio/cli/cmd/entire/cli/stringutil"
 )
 
-// ansiCSIRegex strips ANSI/CSI escape sequences including cursor-control bytes
-// that agents (e.g. codex) emit on stdout. The pattern catches:
-//   - Standard CSI: \x1b[ followed by optional digits/semicolons and a letter.
-//   - Extended CSI with ? prefix: \x1b[? used for cursor-hide (\x1b[?25l) etc.
-//
-// Pattern: \x1b\[[?;0-9]*[a-zA-Z]
-var ansiCSIRegex = regexp.MustCompile(`\x1b\[[?;0-9]*[a-zA-Z]`)
-
-// stripANSI removes ANSI/CSI escape sequences from s so the text renders
-// cleanly in the alt-screen without shifting the cursor.
-func stripANSI(s string) string {
-	return ansiCSIRegex.ReplaceAllString(s, "")
-}
-
 // eventLine converts a single Event to a single display line for the detail
-// view. The line is stripped of ANSI sequences and truncated to maxWidth runes.
+// view. The line is stripped of control sequences and truncated to maxWidth
+// display cells.
 func eventLine(ev reviewtypes.Event, maxWidth int) string {
 	var raw string
 	switch e := ev.(type) {
@@ -59,12 +44,7 @@ func eventLine(ev reviewtypes.Event, maxWidth int) string {
 		raw = "[unknown event]"
 	}
 
-	// Collapse to a single line (remove embedded newlines) so each event maps
-	// to exactly one display row.
-	line := strings.ReplaceAll(raw, "\n", " ")
-	line = strings.ReplaceAll(line, "\r", "")
-	line = stripANSI(line)
-	return stringutil.TruncateRunes(line, maxWidth, "…")
+	return truncateDisplayWidth(sanitizeDisplayText(raw), maxWidth)
 }
 
 // detailView renders the alt-screen drill-in for one agent. row is the agentRow
@@ -73,7 +53,7 @@ func eventLine(ev reviewtypes.Event, maxWidth int) string {
 // Rendering:
 //  1. Header line: "─── <name> (<n> events) ─────────────" (filled to termWidth)
 //  2. Body: events from row.buffer scrolled to detailScroll, one line each,
-//     truncated to termWidth via TruncateRunes. ANSI/CSI stripped.
+//     sanitized and truncated to termWidth display cells.
 //  3. Footer line: "←/→ switch agent · Esc back · ↑/↓ scroll"
 //
 // CRITICAL: the rendered string is padded to exactly termHeight lines so every
@@ -94,13 +74,8 @@ func detailView(row agentRow, detailScroll, termWidth, termHeight int) string {
 	}
 
 	// 1. Header line.
-	headerContent := fmt.Sprintf("─── %s (%d events) ", row.name, len(row.buffer))
-	remaining := termWidth - len([]rune(headerContent))
-	if remaining < 0 {
-		remaining = 0
-	}
-	header := headerContent + strings.Repeat("─", remaining)
-	header = stringutil.TruncateRunes(header, termWidth, "")
+	headerContent := fmt.Sprintf("─── %s (%d events) ", sanitizeDisplayText(row.name), len(row.buffer))
+	header := padDisplayWidthWith(headerContent, termWidth, "─")
 
 	// 2. Body lines.
 	lines := buildBodyLines(row.buffer, detailScroll, bodyHeight, termWidth)
@@ -112,12 +87,7 @@ func detailView(row agentRow, detailScroll, termWidth, termHeight int) string {
 
 	// 3. Footer line.
 	footerText := "←/→ switch agent · Esc back · ↑/↓ scroll"
-	footer := stringutil.TruncateRunes(footerText, termWidth, "")
-	// Pad footer to termWidth.
-	footerRunes := len([]rune(footer))
-	if footerRunes < termWidth {
-		footer += strings.Repeat(" ", termWidth-footerRunes)
-	}
+	footer := padDisplayWidth(footerText, termWidth)
 
 	// Assemble: header + body + footer = termHeight lines total.
 	var b strings.Builder

--- a/cmd/entire/cli/review/tui_detail_test.go
+++ b/cmd/entire/cli/review/tui_detail_test.go
@@ -2,9 +2,12 @@ package review
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
 
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
@@ -72,6 +75,9 @@ func TestDetailView_HeaderContainsAgentNameAndCount(t *testing.T) {
 	if !strings.Contains(firstLine, "3 events") {
 		t.Errorf("header missing event count: %q", firstLine)
 	}
+	if !strings.HasSuffix(firstLine, "─") {
+		t.Errorf("header should fill remaining width with rule characters: %q", firstLine)
+	}
 }
 
 func TestDetailView_FooterPresent(t *testing.T) {
@@ -101,6 +107,30 @@ func TestDetailView_LineTruncation_RuneSafe(t *testing.T) {
 		if runes > termWidth {
 			t.Errorf("line %d has %d runes (>%d): %q", i, runes, termWidth, line)
 		}
+	}
+}
+
+func TestDetailView_LinesFitTerminalWidth(t *testing.T) {
+	t.Parallel()
+	row := agentRow{
+		name: "claude-code-with-a-very-wide-name",
+		buffer: []reviewtypes.Event{
+			reviewtypes.AssistantText{Text: strings.Repeat("界", 20)},
+			reviewtypes.ToolCall{Name: "wide", Args: strings.Repeat("🚀", 20)},
+			reviewtypes.RunError{Err: errors.New(strings.Repeat("日", 20))},
+		},
+	}
+
+	for _, width := range []int{1, 2, 5, 10, 20, 40, 80} {
+		t.Run(fmt.Sprintf("width %d", width), func(t *testing.T) {
+			t.Parallel()
+			out := detailView(row, 2, width, 8)
+			for i, line := range strings.Split(out, "\n") {
+				if got := ansi.StringWidth(line); got > width {
+					t.Fatalf("line %d width = %d, want <= %d:\n%q", i, got, width, line)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/review/tui_model.go
+++ b/cmd/entire/cli/review/tui_model.go
@@ -29,7 +29,7 @@ type agentRow struct {
 	runStart time.Time          // stamped on first event from this agent
 	runEnd   time.Time          // stamped on Finished/RunError event
 	tokens   reviewtypes.Tokens // cumulative
-	preview  string             // last ~80 runes of latest AssistantText
+	preview  string             // latest AssistantText preview, capped by display width
 	buffer   []reviewtypes.Event
 	err      error
 }
@@ -185,8 +185,8 @@ func (m reviewTUIModel) handleAgentEvent(msg agentEventMsg) (tea.Model, tea.Cmd)
 	case reviewtypes.Started:
 		// runStart already set; no other state update needed.
 	case reviewtypes.AssistantText:
-		collapsed := stringutil.CollapseWhitespace(e.Text)
-		row.preview = stringutil.TruncateRunes(collapsed, 80, "…")
+		collapsed := stringutil.CollapseWhitespace(sanitizeDisplayText(e.Text))
+		row.preview = truncateDisplayWidth(collapsed, 80)
 	case reviewtypes.Tokens:
 		row.tokens = e // cumulative: overwrite, not sum
 	case reviewtypes.Finished:
@@ -335,36 +335,42 @@ func (m reviewTUIModel) View() tea.View {
 func (m reviewTUIModel) dashboardView() string {
 	var b strings.Builder
 
-	b.WriteString(m.headerLine())
-	b.WriteString("\n")
+	m.writeDashboardLine(&b, m.headerLine())
 
 	for _, row := range m.rows {
-		b.WriteString(m.renderRow(row))
-		b.WriteString("\n")
+		m.writeDashboardLine(&b, m.renderRow(row))
 	}
 	b.WriteString("\n")
 
 	if m.finished {
-		b.WriteString(m.countsLine())
-		b.WriteString("\n")
-		b.WriteString("Press any key to exit.")
-		b.WriteString("\n")
+		m.writeDashboardLine(&b, m.countsLine())
+		m.writeDashboardLine(&b, "Press any key to exit.")
 	} else {
-		b.WriteString("Ctrl+O: drill in · Ctrl+C: cancel")
-		b.WriteString("\n")
+		m.writeDashboardLine(&b, "Ctrl+O: drill in · Ctrl+C: cancel")
 	}
 	return b.String()
 }
 
+func (m reviewTUIModel) writeDashboardLine(b *strings.Builder, line string) {
+	b.WriteString(truncateDisplayWidth(line, m.dashboardWidth()))
+	b.WriteString("\n")
+}
+
+func (m reviewTUIModel) dashboardWidth() int {
+	if m.termWidth <= 0 {
+		return 80
+	}
+	return m.termWidth
+}
+
 // headerLine returns the column header row.
 func (m reviewTUIModel) headerLine() string {
-	return fmt.Sprintf("%-20s  %-10s  %-8s  %-8s  %s",
-		"AGENT", "STATUS", "DURATION", "TOKENS", "PREVIEW")
+	return m.renderTableLine("AGENT", "STATUS", "DURATION", "TOKENS", "PREVIEW")
 }
 
 // renderRow renders one agent row.
 func (m reviewTUIModel) renderRow(row agentRow) string {
-	name := stringutil.TruncateRunes(row.name, 20, "…")
+	name := row.name
 
 	var statusStr string
 	switch row.status {
@@ -396,10 +402,31 @@ func (m reviewTUIModel) renderRow(row agentRow) string {
 		tokStr = fmt.Sprintf("%s/%s", formatCompact(row.tokens.In), formatCompact(row.tokens.Out))
 	}
 
-	preview := stringutil.TruncateRunes(row.preview, 40, "…")
+	return m.renderTableLine(name, statusStr, durStr, tokStr, row.preview)
+}
 
-	return fmt.Sprintf("%-20s  %-10s  %-8s  %-8s  %s",
-		name, statusStr, durStr, tokStr, preview)
+func (m reviewTUIModel) renderTableLine(agent, status, duration, tokens, preview string) string {
+	const (
+		agentWidth    = 20
+		statusWidth   = 10
+		durationWidth = 8
+		tokensWidth   = 8
+		minWidth      = agentWidth + statusWidth + durationWidth + tokensWidth + 8 // four two-space separators
+	)
+	termWidth := m.dashboardWidth()
+
+	previewWidth := termWidth - minWidth
+	if previewWidth < 0 {
+		previewWidth = 0
+	}
+
+	line := fmt.Sprintf("%s  %s  %s  %s  %s",
+		padDisplayWidth(agent, agentWidth),
+		padDisplayWidth(status, statusWidth),
+		padDisplayWidth(duration, durationWidth),
+		padDisplayWidth(tokens, tokensWidth),
+		truncateDisplayWidth(preview, previewWidth))
+	return truncateDisplayWidth(line, termWidth)
 }
 
 // countsLine produces the summary line shown after the run finishes.

--- a/cmd/entire/cli/review/tui_model_test.go
+++ b/cmd/entire/cli/review/tui_model_test.go
@@ -2,12 +2,14 @@ package review
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
@@ -334,6 +336,90 @@ func TestTUIModel_View_DashboardMode(t *testing.T) {
 	for _, name := range []string{"agent-a", "agent-b"} {
 		if !strings.Contains(v.Content, name) {
 			t.Errorf("View() missing agent %q", name)
+		}
+	}
+}
+
+func TestTUIModel_DashboardLinesFitTerminalWidth(t *testing.T) {
+	t.Parallel()
+
+	for _, width := range []int{1, 2, 10, 20, 24, 30, 40, 53, 54, 55, 60, 80, 120} {
+		t.Run(fmt.Sprintf("running width %d", width), func(t *testing.T) {
+			t.Parallel()
+			m := runningDashboardModel(t, width)
+			assertDashboardFitsWidth(t, m)
+		})
+		t.Run(fmt.Sprintf("finished width %d", width), func(t *testing.T) {
+			t.Parallel()
+			m := runningDashboardModel(t, width)
+			for _, name := range []string{"claude-code-with-a-long-name", "codex"} {
+				updated, _ := m.Update(agentEventMsg{agent: name, ev: reviewtypes.Finished{Success: true}})
+				m = mustModel(t, updated)
+			}
+			updated, _ := m.Update(runFinishedMsg{summary: reviewtypes.RunSummary{
+				AgentRuns: []reviewtypes.AgentRun{
+					{Name: "claude-code-with-a-long-name", Status: reviewtypes.AgentStatusSucceeded},
+					{Name: "codex", Status: reviewtypes.AgentStatusSucceeded},
+				},
+			}})
+			m = mustModel(t, updated)
+			assertDashboardFitsWidth(t, m)
+		})
+	}
+}
+
+func TestTUIModel_DashboardPreviewStripsControlSequences(t *testing.T) {
+	t.Parallel()
+	m := newReviewTUIModel([]string{"codex"}, nil)
+	m.termWidth = 80
+
+	updated, _ := m.Update(agentEventMsg{
+		agent: "codex",
+		ev:    reviewtypes.AssistantText{Text: "hello\x1b[?25lworld\x1b[?25h"},
+	})
+	m = mustModel(t, updated)
+	out := m.dashboardView()
+
+	if strings.Contains(out, "\x1b[?25") {
+		t.Fatalf("dashboard preview leaked control sequence:\n%q", out)
+	}
+	if !strings.Contains(out, "helloworld") {
+		t.Fatalf("dashboard preview missing stripped text:\n%s", out)
+	}
+}
+
+func TestTUIModel_WindowResizeKeepsDashboardWithinNewWidth(t *testing.T) {
+	t.Parallel()
+	m := runningDashboardModel(t, 120)
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 30, Height: 24})
+	m = mustModel(t, updated)
+
+	assertDashboardFitsWidth(t, m)
+}
+
+func runningDashboardModel(t *testing.T, width int) reviewTUIModel {
+	t.Helper()
+	m := newReviewTUIModel([]string{"claude-code-with-a-long-name", "codex"}, nil)
+	m.termWidth = width
+
+	longPreview := strings.Repeat("review finding with enough text to overflow ", 4)
+	for _, name := range []string{"claude-code-with-a-long-name", "codex"} {
+		updated, _ := m.Update(agentEventMsg{agent: name, ev: reviewtypes.Started{}})
+		m = mustModel(t, updated)
+		updated, _ = m.Update(agentEventMsg{agent: name, ev: reviewtypes.Tokens{In: 1_234_567, Out: 987_654}})
+		m = mustModel(t, updated)
+		updated, _ = m.Update(agentEventMsg{agent: name, ev: reviewtypes.AssistantText{Text: longPreview}})
+		m = mustModel(t, updated)
+	}
+	return m
+}
+
+func assertDashboardFitsWidth(t *testing.T, m reviewTUIModel) {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSuffix(m.dashboardView(), "\n"), "\n") {
+		if got := ansi.StringWidth(line); got > m.termWidth {
+			t.Fatalf("dashboard line width = %d, want <= %d:\n%s", got, m.termWidth, line)
 		}
 	}
 }

--- a/cmd/entire/cli/review/tui_text.go
+++ b/cmd/entire/cli/review/tui_text.go
@@ -1,0 +1,58 @@
+// Package review — see env.go for package-level rationale.
+package review
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func stripANSI(s string) string {
+	return ansi.Strip(s)
+}
+
+func sanitizeDisplayText(s string) string {
+	stripped := stripANSI(s)
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\t':
+			return ' '
+		case '\r':
+			return -1
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, stripped)
+}
+
+func padDisplayWidth(s string, width int) string {
+	return padDisplayWidthWith(s, width, " ")
+}
+
+func padDisplayWidthWith(s string, width int, pad string) string {
+	s = truncateDisplayWidth(s, width)
+	remaining := width - ansi.StringWidth(s)
+	if remaining <= 0 {
+		return s
+	}
+	if ansi.StringWidth(pad) != 1 {
+		return s + strings.Repeat(" ", remaining)
+	}
+	return s + strings.Repeat(pad, remaining)
+}
+
+func truncateDisplayWidth(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if ansi.StringWidth(s) <= width {
+		return s
+	}
+	if width == 1 {
+		return ansi.Truncate(s, width, "")
+	}
+	return ansi.Truncate(s, width, "…")
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/332
<!-- entire-trail-link-end -->

## Summary

Fixes `entire review` dashboard rendering corruption when multiple agents are running in narrow terminals.

The dashboard could emit table rows wider than the terminal. Bubble Tea then hard-wrapped those redraw frames, leaving stale header and row fragments on screen. This PR makes dashboard and detail rendering width-aware and sanitizes agent text before it reaches table cells.

## Changes

- Clamp every dashboard line to the current terminal display width.
- Allocate preview width from the remaining table width instead of using a fixed rune count.
- Add shared display text helpers for ANSI stripping, control-character removal, display-cell padding, and display-cell truncation.
- Apply the same display-width handling to detail view header/body/footer rendering.
- Pin TUI sink ordering so live TUI rendering remains isolated from post-run writers.
- Add regression coverage for very narrow terminals, resized terminals, wide characters, emoji, ANSI cursor sequences, finished dashboards, and sink ordering.

## Validation

- `mise run test:ci`
- `mise run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how TUI text is sanitized and width-truncated/padded (including emoji/wide chars), which could alter on-screen output and edge-case formatting but is isolated to review UI rendering and sink ordering.
> 
> **Overview**
> Fixes `entire review` TUI rendering in narrow/resized terminals by making both the dashboard and detail views **display-width aware** (cell-based truncation/padding) and by sanitizing agent text to strip ANSI/control sequences before rendering.
> 
> The dashboard now derives preview column width from the current terminal width, clamps every rendered line to that width, and adds regression tests covering very small widths, window resizes, wide characters/emoji, and control-sequence leakage. It also adds a test to pin sink ordering so the `TUISink` runs before post-run writers like `DumpSink`/`SynthesisSink`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9044dc5393a07a4d7d8f5fa14e81c90dc61c3636. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->