### PR TITLE
Show trail discussion comments in CLI

### DIFF
--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/trail"
@@ -16,6 +17,7 @@ type TrailListResponse struct {
 
 // TrailResource represents a single trail from the API.
 type TrailResource struct {
+	Number          int              `json:"number,omitempty"`
 	TrailID         string           `json:"trail_id"`
 	Branch          string           `json:"branch"`
 	Base            string           `json:"base"`
@@ -86,9 +88,9 @@ type TrailCreateResponse struct {
 
 // TrailDetailResponse is the response from GET /api/v1/trails/:org/:repo/:trailId.
 type TrailDetailResponse struct {
-	Trail       TrailResource     `json:"trail"`
-	Discussion  trail.Discussion  `json:"discussion"`
-	Checkpoints trail.Checkpoints `json:"checkpoints"`
+	Trail       TrailResource    `json:"trail"`
+	Discussion  trail.Discussion `json:"discussion"`
+	Checkpoints json.RawMessage  `json:"checkpoints"`
 }
 
 // TrailUpdateRequest is the body for PATCH /api/v1/trails/:host/:owner/:repo/:trailId.

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -85,13 +85,52 @@ func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
 		return runTrailListAll(ctx, w, "", false, false, insecureHTTP)
 	}
 
-	printTrailDetails(w, found.ToMetadata())
+	detail, err := fetchTrailDetail(ctx, client, host, owner, repo, found)
+	if err != nil {
+		return err
+	}
+
+	printTrailDetails(w, detail.Trail.ToMetadata(), &detail.Discussion)
 	return nil
 }
 
-func printTrailDetails(w io.Writer, m *trail.Metadata) {
+func fetchTrailDetail(ctx context.Context, client *api.Client, host, owner, repo string, found *api.TrailResource) (*api.TrailDetailResponse, error) {
+	trailPathID := trailResourcePathID(found)
+	if trailPathID == "" {
+		return &api.TrailDetailResponse{Trail: *found}, nil
+	}
+
+	resp, err := client.Get(ctx, trailsBasePath(host, owner, repo)+"/"+trailPathID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch trail detail: %w", err)
+	}
+	defer resp.Body.Close()
+	if err := checkTrailResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var detail api.TrailDetailResponse
+	if err := api.DecodeJSON(resp, &detail); err != nil {
+		return nil, fmt.Errorf("failed to decode trail detail: %w", err)
+	}
+	return &detail, nil
+}
+
+func trailResourcePathID(resource *api.TrailResource) string {
+	if resource.TrailID != "" {
+		return resource.TrailID
+	}
+	if resource.Number > 0 {
+		return fmt.Sprintf("%d", resource.Number)
+	}
+	return ""
+}
+
+func printTrailDetails(w io.Writer, m *trail.Metadata, discussion *trail.Discussion) {
 	fmt.Fprintf(w, "Trail: %s\n", m.Title)
-	fmt.Fprintf(w, "  ID:      %s\n", m.TrailID)
+	if !m.TrailID.IsEmpty() {
+		fmt.Fprintf(w, "  ID:      %s\n", m.TrailID)
+	}
 	fmt.Fprintf(w, "  Branch:  %s\n", m.Branch)
 	fmt.Fprintf(w, "  Base:    %s\n", m.Base)
 	fmt.Fprintf(w, "  Status:  %s\n", m.Status)
@@ -107,6 +146,43 @@ func printTrailDetails(w io.Writer, m *trail.Metadata) {
 	}
 	fmt.Fprintf(w, "  Created: %s\n", m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
 	fmt.Fprintf(w, "  Updated: %s\n", m.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	printTrailDiscussion(w, discussion)
+}
+
+func printTrailDiscussion(w io.Writer, discussion *trail.Discussion) {
+	if discussion == nil || len(discussion.Comments) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Comments:")
+	for _, comment := range discussion.Comments {
+		status := "open"
+		if comment.Resolved {
+			status = "resolved"
+		}
+		fmt.Fprintf(w, "  %s %s (%s)\n", comment.Author, comment.CreatedAt.Format("2006-01-02T15:04:05Z07:00"), status)
+		for _, line := range strings.Split(stripTrailCommentMarkers(comment.Body), "\n") {
+			if strings.TrimSpace(line) == "" {
+				fmt.Fprintln(w)
+				continue
+			}
+			fmt.Fprintf(w, "    %s\n", line)
+		}
+	}
+}
+
+func stripTrailCommentMarkers(body string) string {
+	lines := strings.Split(body, "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "<!-- entire-run:") && strings.HasSuffix(trimmed, "-->") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
 }
 
 func newTrailListCmd() *cobra.Command {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/trail"
+)
+
+func TestPrintTrailDetailsIncludesDiscussionComments(t *testing.T) {
+	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+	metadata := &trail.Metadata{
+		TrailID:   trail.ID("abcdef123456"),
+		Branch:    "feature/review-visible",
+		Base:      "main",
+		Title:     "Make review visible",
+		Status:    trail.StatusInReview,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	discussion := &trail.Discussion{Comments: []trail.Comment{
+		{
+			ID:        "comment-123",
+			Author:    "Marvin",
+			CreatedAt: now,
+			Body:      "<!-- entire-run:trail-pr-review:run-123 -->\n\n### Marvin Review\n\nFound 1 finding.",
+			Resolved:  false,
+		},
+	}}
+
+	var out bytes.Buffer
+	printTrailDetails(&out, metadata, discussion)
+	got := out.String()
+
+	for _, want := range []string{"Comments:", "Marvin", "### Marvin Review", "Found 1 finding."} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "entire-run:trail-pr-review") {
+		t.Fatalf("output exposed hidden marker:\n%s", got)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/334
<!-- entire-trail-link-end -->

## Summary
- Fetch Trail detail for the current branch so CLI output can include Trail discussion comments.
- Render Trail discussion comments while hiding internal `entire-run` markers.
- Add a display test for Marvin review comments surfaced through Trails.

## Companion
- API PR: https://github.com/entirehq/entire.io/pull/1883

## Verification
- `go test ./cmd/entire/cli -run TestPrintTrailDetailsIncludesDiscussionComments`
- `go test ./cmd/entire/cli`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an extra trails detail API call and changes the `TrailDetailResponse` decoding (notably `checkpoints` now as `json.RawMessage`), which could affect CLI behavior if the API payload differs or scripts rely on the previous output format.
> 
> **Overview**
> When showing the trail for the current branch, the CLI now fetches the trail *detail* endpoint and includes the trail’s discussion comments in the output.
> 
> Comment rendering hides internal `<!-- entire-run:... -->` markers, and the trail ID line is omitted when no ID is available (falling back to a numeric `number` for the detail URL when needed). A new test validates that comments are printed and markers are not leaked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4249cfb1d3c03ce2a8ed5e70759cdd87705222d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->