### PR TITLE
Expose trail number in CLI output and JSON

### DIFF
--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -16,6 +16,7 @@ type TrailListResponse struct {
 
 // TrailResource represents a single trail from the API.
 type TrailResource struct {
+	Number          int              `json:"number,omitempty"`
 	TrailID         string           `json:"trail_id"`
 	Branch          string           `json:"branch"`
 	Base            string           `json:"base"`
@@ -40,6 +41,7 @@ type TrailResource struct {
 // ToMetadata converts a TrailResource to a trail.Metadata for display.
 func (r *TrailResource) ToMetadata() *trail.Metadata {
 	m := &trail.Metadata{
+		Number:    r.Number,
 		TrailID:   trail.ID(r.TrailID),
 		Branch:    r.Branch,
 		Base:      r.Base,

--- a/cmd/entire/cli/trail/trail.go
+++ b/cmd/entire/cli/trail/trail.go
@@ -152,6 +152,7 @@ type Author struct {
 
 // Metadata represents the metadata for a trail, matching the web PR format.
 type Metadata struct {
+	Number    int        `json:"number,omitempty"`
 	TrailID   ID         `json:"trail_id"`
 	Branch    string     `json:"branch"`
 	Base      string     `json:"base"`

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -91,7 +91,12 @@ func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
 
 func printTrailDetails(w io.Writer, m *trail.Metadata) {
 	fmt.Fprintf(w, "Trail: %s\n", m.Title)
-	fmt.Fprintf(w, "  ID:      %s\n", m.TrailID)
+	if m.Number > 0 {
+		fmt.Fprintf(w, "  Number:  %d\n", m.Number)
+	}
+	if !m.TrailID.IsEmpty() {
+		fmt.Fprintf(w, "  ID:      %s\n", m.TrailID)
+	}
 	fmt.Fprintf(w, "  Branch:  %s\n", m.Branch)
 	fmt.Fprintf(w, "  Base:    %s\n", m.Base)
 	fmt.Fprintf(w, "  Status:  %s\n", m.Status)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/337
<!-- entire-trail-link-end -->

The API already returns a per-repo sequential `number` for every trail, but the CLI was not surfacing it.

### Changes

- **`TrailResource`** — added `Number int` field to decode `number` from the API response
- **`Metadata`** — added `Number int` field so it's included in JSON serialization (`entire trail list --json`)
- **`printTrailDetails`** — prints `Number:` line in human-readable output (`entire trail`)

### Why

The number is the canonical trail identifier used in URLs (e.g. `/trails/750/fix-mobile-overlay-layout`). Exposing it in the CLI enables tooling (like Pi extensions) to construct direct trail links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new decoded/serialized field and conditionally prints it, without changing API calls or update/create behavior.
> 
> **Overview**
> Exposes the API-provided sequential trail `number` end-to-end in the CLI.
> 
> `TrailResource` now decodes `number` from the trails API and maps it into `trail.Metadata`, which in turn includes it in `--json` output; the `entire trail` detail view conditionally prints a `Number:` line and avoids printing an empty `ID:` when unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15a79f769bf29620c971d6f5c4ca48257d7cff70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->