### PR TITLE
Dedupe review skill discovery by invocation name

### DIFF
--- a/cmd/entire/cli/agent/claudecode/discovery.go
+++ b/cmd/entire/cli/agent/claudecode/discovery.go
@@ -45,10 +45,35 @@ func (c *ClaudeCodeAgent) DiscoverReviewSkills(ctx context.Context) ([]agent.Dis
 	found = append(found, scanUserSkills(ctx, filepath.Join(home, ".claude", "skills"))...)
 	found = append(found, scanFlatMarkdownDir(ctx, filepath.Join(home, ".claude", "commands"), "")...)
 	found = append(found, scanFlatMarkdownDir(ctx, filepath.Join(home, ".claude", "agents"), "")...)
+	found = dedupeByInvocation(found)
 	if len(found) == 0 {
 		return nil, nil
 	}
 	return found, nil
+}
+
+// dedupeByInvocation collapses entries that share an invocation name. A
+// single plugin commonly ships both `skills/<name>/SKILL.md` (the real
+// implementation) and `commands/<name>.md` (a thin wrapper that forwards
+// args to the skill); both produce the same `/<plugin>:<name>` invocation
+// and would otherwise show up as duplicate rows in the picker. First-seen
+// wins, which — given scan order skills/ → commands/ → agents/, then user
+// skills/ → user commands/ → user agents/ — keeps the skill (the real
+// implementation) over its command wrapper.
+func dedupeByInvocation(in []agent.DiscoveredSkill) []agent.DiscoveredSkill {
+	if len(in) < 2 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]agent.DiscoveredSkill, 0, len(in))
+	for _, s := range in {
+		if _, dup := seen[s.Name]; dup {
+			continue
+		}
+		seen[s.Name] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 // scanPluginCache walks <root>/<marketplace>/<plugin>/<version>/{skills,commands,agents}/

--- a/cmd/entire/cli/agent/claudecode/discovery.go
+++ b/cmd/entire/cli/agent/claudecode/discovery.go
@@ -52,14 +52,9 @@ func (c *ClaudeCodeAgent) DiscoverReviewSkills(ctx context.Context) ([]agent.Dis
 	return found, nil
 }
 
-// dedupeByInvocation collapses entries that share an invocation name. A
-// single plugin commonly ships both `skills/<name>/SKILL.md` (the real
-// implementation) and `commands/<name>.md` (a thin wrapper that forwards
-// args to the skill); both produce the same `/<plugin>:<name>` invocation
-// and would otherwise show up as duplicate rows in the picker. First-seen
-// wins, which — given scan order skills/ → commands/ → agents/, then user
-// skills/ → user commands/ → user agents/ — keeps the skill (the real
-// implementation) over its command wrapper.
+// dedupeByInvocation collapses entries sharing an invocation name. Plugins
+// can ship a skill and a same-named command wrapper that forwards to it;
+// scan order keeps the skill over its wrapper.
 func dedupeByInvocation(in []agent.DiscoveredSkill) []agent.DiscoveredSkill {
 	if len(in) < 2 {
 		return in

--- a/cmd/entire/cli/agent/claudecode/discovery_test.go
+++ b/cmd/entire/cli/agent/claudecode/discovery_test.go
@@ -380,3 +380,49 @@ func TestDiscoverReviewSkills_UserSkillsDir(t *testing.T) {
 		t.Errorf("user skill name = %q, want /my-review", skills[0].Name)
 	}
 }
+
+// TestDiscoverReviewSkills_DedupesSkillAndCommandSameName covers the
+// real-world paxos plugin shape: a `skills/<name>/SKILL.md` (the actual
+// implementation) plus a thin `commands/<name>.md` wrapper that forwards
+// $ARGUMENTS to the skill. Both produce the same `/<plugin>:<name>`
+// invocation, so the picker would otherwise show two identical rows.
+// First-seen wins, and skills are scanned before commands, so the skill
+// is the entry kept.
+func TestDiscoverReviewSkills_DedupesSkillAndCommandSameName(t *testing.T) {
+	home := withFakeHome(t)
+	versionDir := filepath.Join(home, ".claude", "plugins", "cache",
+		"fake-market", "paxos", "0.1.0")
+
+	skillDir := filepath.Join(versionDir, "skills", "review")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\nname: review\ndescription: real review skill\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdDir := filepath.Join(versionDir, "commands")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmdDir, "review.md"),
+		[]byte("---\ndescription: \"thin command wrapper\"\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &claudecode.ClaudeCodeAgent{}
+	skills, err := a.DiscoverReviewSkills(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 deduped entry, got %d: %+v", len(skills), skills)
+	}
+	if skills[0].Name != "/paxos:review" {
+		t.Errorf("Name = %q, want /paxos:review", skills[0].Name)
+	}
+	if skills[0].Description != "real review skill" {
+		t.Errorf("Description = %q; want skill description (skills scanned before commands, first-seen wins)", skills[0].Description)
+	}
+}

--- a/cmd/entire/cli/agent/claudecode/discovery_test.go
+++ b/cmd/entire/cli/agent/claudecode/discovery_test.go
@@ -381,13 +381,6 @@ func TestDiscoverReviewSkills_UserSkillsDir(t *testing.T) {
 	}
 }
 
-// TestDiscoverReviewSkills_DedupesSkillAndCommandSameName covers the
-// real-world paxos plugin shape: a `skills/<name>/SKILL.md` (the actual
-// implementation) plus a thin `commands/<name>.md` wrapper that forwards
-// $ARGUMENTS to the skill. Both produce the same `/<plugin>:<name>`
-// invocation, so the picker would otherwise show two identical rows.
-// First-seen wins, and skills are scanned before commands, so the skill
-// is the entry kept.
 func TestDiscoverReviewSkills_DedupesSkillAndCommandSameName(t *testing.T) {
 	home := withFakeHome(t)
 	versionDir := filepath.Join(home, ".claude", "plugins", "cache",
@@ -423,6 +416,6 @@ func TestDiscoverReviewSkills_DedupesSkillAndCommandSameName(t *testing.T) {
 		t.Errorf("Name = %q, want /paxos:review", skills[0].Name)
 	}
 	if skills[0].Description != "real review skill" {
-		t.Errorf("Description = %q; want skill description (skills scanned before commands, first-seen wins)", skills[0].Description)
+		t.Errorf("Description = %q; want skill description", skills[0].Description)
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/339
<!-- entire-trail-link-end -->

## Summary

- A plugin can ship both `skills/<name>/SKILL.md` (the real implementation) and a thin `commands/<name>.md` wrapper that forwards args to the skill — paxos does this for `/paxos:review`. The CLI's discovery walked `skills/`, `commands/`, and `agents/` independently, so the review-skill picker showed two identical rows for the same invocation.
- Collapse by invocation name with first-seen wins. Existing scan order (`skills/` → `commands/` → `agents/`, then user dirs in the same order) keeps the skill over its command wrapper, which matches plugin authors' intent and gives the picker the skill's description.
- The dedupe sits at the top of `DiscoverReviewSkills`, so it also covers analogous user-dir collisions (e.g. a user `~/.claude/skills/foo` plus `~/.claude/commands/foo.md`).

No downstream behavior changes besides the picker row count: callers (`filterOutBuiltinCollisions`, `SplitSavedPicks`, `ValidateSkills`) all reduce the discovered list to a name-set and produce identical results on deduped input. Saved-picks already pass through `dedupeStrings`, so no config migration.

## Test plan

- [x] `go test ./cmd/entire/cli/agent/claudecode/ -run TestDiscoverReviewSkills_DedupesSkillAndCommandSameName` — new fixture pairs `skills/review/SKILL.md` with `commands/review.md` and asserts a single deduped entry with the skill's description.
- [x] `go test ./cmd/entire/cli/review/... ./cmd/entire/cli/agent/...`
- [x] `mise run fmt && mise run lint`
- [x] `mise run test:ci`
- [ ] Manual: build from this branch, run `entire review --edit` against a `~/.claude` that has the paxos plugin installed; confirm `/paxos:review` appears once (with the SKILL.md description) and the other `/paxos:*` entries are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only filters duplicate discovered skills by invocation name, primarily affecting picker row counts and which description wins when duplicates exist.
> 
> **Overview**
> Prevents duplicate entries in the Claude Code review-skill picker by deduping discovered skills that share the same invocation name (e.g., a plugin providing both `skills/<name>/SKILL.md` and `commands/<name>.md`).
> 
> Adds `dedupeByInvocation` to `DiscoverReviewSkills` (first-seen wins based on scan order) and a new test fixture ensuring a skill beats its thin command wrapper and keeps the skill’s description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80bc9b6c84635986e0c704d712891509d9063818. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->