### PR TITLE
feat(review): warn user when review manifest is not persisted

### DIFF
--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -1113,9 +1113,10 @@ func adoptReviewEnv(ctx context.Context, state *session.State, expectedAgent str
 	if state.Kind != "" {
 		return
 	}
-	if os.Getenv(review.EnvSession) != "1" {
-		logging.Debug(ctx, "review env adoption skipped: ENTIRE_REVIEW_SESSION not set",
-			slog.String("expected_agent", expectedAgent))
+	if envSession := os.Getenv(review.EnvSession); envSession != "1" {
+		logging.Debug(ctx, "review env adoption skipped: ENTIRE_REVIEW_SESSION is not \"1\"",
+			slog.String("expected_agent", expectedAgent),
+			slog.String("observed_value", envSession))
 		return
 	}
 	envAgent := os.Getenv(review.EnvAgent)

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -1040,6 +1040,8 @@ func adoptReviewEnv(ctx context.Context, state *session.State, expectedAgent str
 		return
 	}
 	if os.Getenv(review.EnvSession) != "1" {
+		logging.Debug(ctx, "review env adoption skipped: ENTIRE_REVIEW_SESSION not set",
+			slog.String("expected_agent", expectedAgent))
 		return
 	}
 	envAgent := os.Getenv(review.EnvAgent)

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -648,17 +648,33 @@ func writePostReviewManifest(
 	manifest, err := localReviewManifestFromCurrentState(ctx, worktreeRoot, headSHA, summary, aggregateOutput)
 	if err != nil {
 		logging.Debug(ctx, "review manifest not written", slog.String("error", err.Error()))
+		warnManifestNotWritten(out, "could not load session state: "+err.Error())
 		return
 	}
 	if len(manifest.Sources) == 0 {
 		logging.Debug(ctx, "review manifest not written: no matching review sessions")
+		warnManifestNotWritten(out, "review session was not tagged as a review (env-var handshake did not reach the hook)")
 		return
 	}
 	if err := writeLocalReviewManifest(ctx, manifest); err != nil {
 		logging.Debug(ctx, "review manifest write failed", slog.String("error", err.Error()))
+		warnManifestNotWritten(out, "write to disk failed: "+err.Error())
 		return
 	}
 	writeReviewCompletionFooter(out, manifest)
+}
+
+// warnManifestNotWritten prints a user-visible note explaining that the
+// review skills ran but findings were not persisted, so `entire review
+// --findings` and `entire review --fix` will not see this run. The reason
+// string is appended verbatim and should describe the underlying cause in
+// terms the user can act on (or at least diagnose with debug logs).
+func warnManifestNotWritten(out io.Writer, reason string) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Note: review skills ran successfully but findings were not persisted.")
+	fmt.Fprintf(out, "  Reason: %s\n", reason)
+	fmt.Fprintln(out, "  `entire review --findings` and `entire review --fix` will not see this run.")
+	fmt.Fprintln(out, "  Re-run with `ENTIRE_LOG_LEVEL=debug` for diagnostic detail.")
 }
 
 func composeSingleAgentSinks(in singleAgentSinkInputs) []reviewtypes.Sink {

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -671,7 +671,7 @@ func writePostReviewManifest(
 // terms the user can act on (or at least diagnose with debug logs).
 func warnManifestNotWritten(out io.Writer, reason string) {
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Note: review skills ran successfully but findings were not persisted.")
+	fmt.Fprintln(out, "Note: review skills ran but findings were not persisted.")
 	fmt.Fprintf(out, "  Reason: %s\n", reason)
 	fmt.Fprintln(out, "  `entire review --findings` and `entire review --fix` will not see this run.")
 	fmt.Fprintln(out, "  Re-run with `ENTIRE_LOG_LEVEL=debug` for diagnostic detail.")

--- a/cmd/entire/cli/review/manifest_test.go
+++ b/cmd/entire/cli/review/manifest_test.go
@@ -379,3 +379,49 @@ func TestBuildLocalReviewManifestFromSummary_GroupsAgentSessionsAndAggregate(t *
 		t.Fatalf("AggregateOutput = %q", manifest.AggregateOutput)
 	}
 }
+
+func TestWarnManifestNotWritten_PrintsReasonAndDiagnosticHints(t *testing.T) {
+	var b strings.Builder
+
+	warnManifestNotWritten(&b, "test reason text")
+
+	got := b.String()
+	for _, want := range []string{
+		"Note: review skills ran successfully but findings were not persisted.",
+		"Reason: test reason text",
+		"`entire review --findings` and `entire review --fix` will not see this run.",
+		"`ENTIRE_LOG_LEVEL=debug`",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warning missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWritePostReviewManifest_WarnsWhenNoMatchingSessions(t *testing.T) {
+	repoRoot := t.TempDir()
+	testutil.InitRepo(t, repoRoot)
+	t.Chdir(repoRoot)
+
+	var out strings.Builder
+	summary := reviewtypes.RunSummary{
+		StartedAt: time.Now(),
+		AgentRuns: []reviewtypes.AgentRun{
+			{Name: "claude-code", Status: reviewtypes.AgentStatusSucceeded},
+		},
+	}
+
+	// SHA is irrelevant: matcher never runs since no session states exist.
+	writePostReviewManifest(context.Background(), &out, repoRoot, "abc123", summary, "")
+
+	got := out.String()
+	if !strings.Contains(got, "Note: review skills ran successfully but findings were not persisted.") {
+		t.Fatalf("expected warning to fire when no sessions match; got:\n%s", got)
+	}
+	if !strings.Contains(got, "env-var handshake did not reach the hook") {
+		t.Fatalf("expected handshake-failure reason; got:\n%s", got)
+	}
+	if strings.Contains(got, "Review complete.") {
+		t.Fatalf("happy-path footer must not print when manifest is empty; got:\n%s", got)
+	}
+}

--- a/cmd/entire/cli/review/manifest_test.go
+++ b/cmd/entire/cli/review/manifest_test.go
@@ -387,7 +387,7 @@ func TestWarnManifestNotWritten_PrintsReasonAndDiagnosticHints(t *testing.T) {
 
 	got := b.String()
 	for _, want := range []string{
-		"Note: review skills ran successfully but findings were not persisted.",
+		"Note: review skills ran but findings were not persisted.",
 		"Reason: test reason text",
 		"`entire review --findings` and `entire review --fix` will not see this run.",
 		"`ENTIRE_LOG_LEVEL=debug`",
@@ -415,7 +415,7 @@ func TestWritePostReviewManifest_WarnsWhenNoMatchingSessions(t *testing.T) {
 	writePostReviewManifest(context.Background(), &out, repoRoot, "abc123", summary, "")
 
 	got := out.String()
-	if !strings.Contains(got, "Note: review skills ran successfully but findings were not persisted.") {
+	if !strings.Contains(got, "Note: review skills ran but findings were not persisted.") {
 		t.Fatalf("expected warning to fire when no sessions match; got:\n%s", got)
 	}
 	if !strings.Contains(got, "env-var handshake did not reach the hook") {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/340
<!-- entire-trail-link-end -->

## Summary

- Silent-failure observability fix for `entire review`: when manifest persistence skips (env-handshake didn't reach the hook, state-store load fails, or disk write fails), the user now sees a clear note explaining what happened and how to diagnose.
- Adds a debug log on the previously-silent `EnvSession`-not-set return in `adoptReviewEnv`, completing observability across all five adoption decisions.
- Happy path is unchanged: successful reviews print identical output.

## Background

After running `entire review`, three downstream features (`entire review --findings`, `entire review --fix`, and the end-of-run "To apply all review findings:" footer) all read from the local manifest at `.git/entire-review/manifests/`. If the spawned agent's lifecycle hook does not adopt the `ENTIRE_REVIEW_*` env vars set by `entire review` — for any reason — the session is never tagged as `KindAgentReview`, the manifest matcher finds zero sources, and `writePostReviewManifest` returns silently. All three features then quietly no-op with no error, no warning, no missing-file message that a user could grep.

We hit this in practice today: a review ran end-to-end, agents produced findings, the synthesis verdict printed — and then `entire review --findings` claimed there was nothing to show, with no breadcrumb in the user-visible output explaining why. The actual root cause for that specific reproduction is still unidentified (running from a fresh terminal worked; running from the same shell a few hours earlier did not, with identical shell env). Without observability in the failure path, every future reproduction will be equally opaque.

## What this PR does

**`cmd/entire/cli/lifecycle.go`** — Two-line debug log added to the `EnvSession`-not-set silent return. The other four branches in `adoptReviewEnv` already log at WARN (agent mismatch, SHA mismatch, malformed skills JSON) or DEBUG (success). This was the only branch with no breadcrumb, so a "review env didn't take" failure produced zero log lines diagnosing it.

**`cmd/entire/cli/review/cmd.go`** — Each of the three silent early returns in `writePostReviewManifest` now also calls a new helper `warnManifestNotWritten` which prints a user-visible four-line note to the same `out` writer the success-path footer uses. The helper is centralized so the wording is consistent and editable in one place.

## What this PR does NOT do

- Does not attempt to fix the root-cause env-propagation problem. The conditions under which the handshake breaks are not yet reliably reproducible. This PR makes the *next* reproduction debuggable in 30 seconds (one log grep) instead of an hour (reverse-engineering process state from logs).
- Does not change behavior on the happy path. Working reviews print the same output they do today.
- Does not touch the matcher logic, spawn path, or contract between agents and hooks.

## User-visible change

**Today, when manifest persistence skips:**
```
2 agent(s) done — 2 succeeded, 0 failed, 0 cancelled
Generating summary...
[synthesis output]

[end of output — no error, no warning, no signal that --findings won't see this run]
```

**After this PR, same scenario:**
```
2 agent(s) done — 2 succeeded, 0 failed, 0 cancelled
Generating summary...
[synthesis output]

Note: review skills ran successfully but findings were not persisted.
  Reason: review session was not tagged as a review (env-var handshake did not reach the hook)
  `entire review --findings` and `entire review --fix` will not see this run.
  Re-run with `ENTIRE_LOG_LEVEL=debug` for diagnostic detail.
```

## Test plan

- [x] `mise run fmt` clean
- [x] `mise run lint` — 0 issues
- [x] `go test ./cmd/entire/cli/review/` passes (incl. two new tests: `TestWarnManifestNotWritten_PrintsReasonAndDiagnosticHints`, `TestWritePostReviewManifest_WarnsWhenNoMatchingSessions`)
- [x] `go test ./cmd/entire/cli/` passes
- [x] `mise run test:integration` passes (incl. existing `TestReview_EnvVarAdoptionCondensesReviewMetadataOnNextCommit` — confirms happy-path env adoption still works)
- [x] Manual smoke test: real `entire review --agent codex` from a fresh terminal on this branch successfully writes a manifest and prints the existing "Review complete." footer with `--fix <id>` commands. Warning correctly does **not** fire on success.

## Decisions worth flagging for review

- **Debug-level (not WARN) for the new lifecycle log.** This branch fires on every normal coding turn (any session that isn't a review), so logging at WARN/INFO would flood the operator's log with one line per user prompt. DEBUG keeps it silent unless someone explicitly opts in via `ENTIRE_LOG_LEVEL=debug`.
- **No log-capture test for the new lifecycle log line.** The logging package's package-level singleton makes log assertions heavy. The existing behavioral test (`TestAdoptReviewEnv_NormalSession`) covers the path; if the log line is ever removed, behavior is unchanged but observability degrades silently. Acceptable risk for v1; revisit if a future reproduction shows this matters.
- **Wording of the failure note.** The "env-var handshake did not reach the hook" phrasing is precise but jargony. Open to wording suggestions from review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to logging/user messaging on failure paths and new tests, with the successful review flow unchanged.
> 
> **Overview**
> Prevents silent failures in `entire review` when local manifest persistence is skipped: `writePostReviewManifest` now prints a **user-visible note** (via new `warnManifestNotWritten`) when session state can’t be loaded, no matching review sessions are found, or manifest disk writes fail.
> 
> Adds a missing `Debug` log in `adoptReviewEnv` when `ENTIRE_REVIEW_SESSION` is not set, improving diagnostics for env-var adoption issues, and includes new tests covering the warning output and the “no matching sessions” warning path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4189e7c5b7d199cec634856fc11c17be11a1253e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->