### PR TITLE
Add checkpoint sync destination picker to entire enable

### DIFF
--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -58,7 +58,7 @@ const (
 	checkpointSyncLocal      = "local"
 )
 
-const checkpointSyncFooter = "Transcripts may contain sensitive data. Redaction is best-effort."
+const checkpointSyncFooter = "Transcripts may contain sensitive data. Review before sharing."
 
 // promptCheckpointSync shows an interactive picker for checkpoint sync
 // destination. Modifies opts based on the user's selection.

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -73,7 +73,8 @@ func promptCheckpointSync(w io.Writer, opts *EnableOptions) error {
 	}
 
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, checkpointSyncFooter)
+	fmt.Fprintln(w, "  "+checkpointSyncFooter)
+	fmt.Fprintln(w)
 
 	choice := checkpointSyncThisRemote
 	form := NewAccessibleForm(

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -72,8 +72,8 @@ func promptCheckpointSync(w io.Writer, opts *EnableOptions) error {
 		return nil
 	}
 
-	fmt.Fprintln(w, checkpointSyncFooter)
 	fmt.Fprintln(w)
+	fmt.Fprintln(w, checkpointSyncFooter)
 
 	choice := checkpointSyncThisRemote
 	form := NewAccessibleForm(

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -51,6 +51,96 @@ const (
 // underlying flag name or discovery mechanics.
 const externalAgentsAutoEnabledNotice = "Note: external agents are now enabled for the rest of Entire too — not just summaries."
 
+// Checkpoint sync destination values used by the interactive picker.
+const (
+	checkpointSyncThisRemote = "this-remote"
+	checkpointSyncSeparate   = "separate"
+	checkpointSyncLocal      = "local"
+)
+
+const checkpointSyncFooter = "Transcripts may contain sensitive data. Redaction is best-effort."
+
+// promptCheckpointSync shows an interactive picker for checkpoint sync
+// destination. Modifies opts based on the user's selection.
+// In non-interactive or --yes mode, prints an informational notice instead.
+func promptCheckpointSync(w io.Writer, opts *EnableOptions) error {
+	if opts.Yes || !interactive.CanPromptInteractively() {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Checkpoints will sync to this repo's remote.")
+		fmt.Fprintf(w, "To use a private checkpoint repo: entire configure --checkpoint-remote github:org/private-repo\n\n")
+		fmt.Fprintln(w, checkpointSyncFooter)
+		return nil
+	}
+
+	fmt.Fprintln(w, checkpointSyncFooter)
+	fmt.Fprintln(w)
+
+	choice := checkpointSyncThisRemote
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Where should checkpoints sync?").
+				Options(
+					huh.NewOption("This repo's remote", checkpointSyncThisRemote),
+					huh.NewOption("A separate private checkpoint repo", checkpointSyncSeparate),
+					huh.NewOption("Keep checkpoints local only", checkpointSyncLocal),
+				).
+				Value(&choice),
+		),
+	)
+
+	if err := form.Run(); err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return NewSilentError(errors.New("checkpoint sync selection cancelled"))
+		}
+		return fmt.Errorf("checkpoint sync prompt: %w", err)
+	}
+
+	if choice == checkpointSyncSeparate {
+		var repo string
+		inputForm := NewAccessibleForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title("Checkpoint repo (format: github:owner/repo)").
+					Placeholder("github:org/private-checkpoints").
+					Value(&repo),
+			),
+		)
+		if err := inputForm.Run(); err != nil {
+			if errors.Is(err, huh.ErrUserAborted) {
+				return NewSilentError(errors.New("checkpoint repo input cancelled"))
+			}
+			return fmt.Errorf("checkpoint repo prompt: %w", err)
+		}
+		repo = strings.TrimSpace(repo)
+		if repo == "" {
+			return NewSilentError(errors.New("no checkpoint repo provided"))
+		}
+		choice = repo // pass the raw input to applyCheckpointSyncChoice for validation
+	}
+
+	return applyCheckpointSyncChoice(choice, opts)
+}
+
+// applyCheckpointSyncChoice applies the checkpoint sync picker result to opts.
+// choice is one of the checkpointSync* constants, or a raw "provider:owner/repo"
+// string when the user selected "separate" and entered a repo.
+func applyCheckpointSyncChoice(choice string, opts *EnableOptions) error {
+	switch choice {
+	case checkpointSyncThisRemote:
+		// Default — no changes needed.
+	case checkpointSyncLocal:
+		opts.SkipPushSessions = true
+	default:
+		// Treat as a checkpoint remote value (e.g. "github:org/repo").
+		if _, _, err := parseCheckpointRemoteFlag(choice); err != nil {
+			return fmt.Errorf("invalid checkpoint repo: %w", err)
+		}
+		opts.CheckpointRemote = choice
+	}
+	return nil
+}
+
 // EnableOptions holds the flags for `entire enable`.
 type EnableOptions struct {
 	LocalDev            bool
@@ -909,6 +999,11 @@ To completely remove Entire integrations from this repository, use --uninstall:
 // runEnableInteractive runs the interactive enable flow.
 // agents must be provided by the caller (via detectOrSelectAgent).
 func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent, opts EnableOptions) error {
+	// Ask where checkpoints should sync (interactive picker or printed notice).
+	if err := promptCheckpointSync(w, &opts); err != nil {
+		return err
+	}
+
 	// Uninstall hooks for agents that were previously active but are no longer selected
 	if err := uninstallDeselectedAgentHooks(ctx, w, agents); err != nil {
 		return fmt.Errorf("failed to clean up deselected agents: %w", err)

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -64,6 +64,11 @@ const checkpointSyncFooter = "Transcripts may contain sensitive data. Redaction 
 // destination. Modifies opts based on the user's selection.
 // In non-interactive or --yes mode, prints an informational notice instead.
 func promptCheckpointSync(w io.Writer, opts *EnableOptions) error {
+	// Skip if the user already specified a checkpoint destination via flags.
+	if opts.CheckpointRemote != "" || opts.SkipPushSessions {
+		return nil
+	}
+
 	if opts.Yes || !interactive.CanPromptInteractively() {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "Checkpoints will sync to this repo's remote.")
@@ -129,8 +134,10 @@ func promptCheckpointSync(w io.Writer, opts *EnableOptions) error {
 func applyCheckpointSyncChoice(choice string, opts *EnableOptions) error {
 	switch choice {
 	case checkpointSyncThisRemote:
-		// Default — no changes needed.
+		opts.CheckpointRemote = ""
+		opts.SkipPushSessions = false
 	case checkpointSyncLocal:
+		opts.CheckpointRemote = ""
 		opts.SkipPushSessions = true
 	default:
 		// Treat as a checkpoint remote value (e.g. "github:org/repo").
@@ -138,6 +145,7 @@ func applyCheckpointSyncChoice(choice string, opts *EnableOptions) error {
 			return fmt.Errorf("invalid checkpoint repo: %w", err)
 		}
 		opts.CheckpointRemote = choice
+		opts.SkipPushSessions = false
 	}
 	return nil
 }

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -2984,3 +2984,114 @@ func TestConfigureCmd_FreshRepo_PointsAtEnable(t *testing.T) {
 		t.Errorf("expected hint pointing at 'entire enable', got stderr: %s", stderr.String())
 	}
 }
+
+func TestPromptCheckpointSync_NonInteractive(t *testing.T) {
+	t.Parallel()
+	// --yes mode should print the notice without prompting.
+	var buf bytes.Buffer
+	opts := EnableOptions{Yes: true}
+	err := promptCheckpointSync(&buf, &opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "Checkpoints will sync") {
+		t.Error("notice should mention checkpoint syncing")
+	}
+	if !strings.Contains(out, "--checkpoint-remote") {
+		t.Error("notice should suggest --checkpoint-remote")
+	}
+	if !strings.Contains(out, "sensitive data") {
+		t.Error("notice should mention sensitive data")
+	}
+	if !strings.Contains(out, "best-effort") {
+		t.Error("notice should mention best-effort redaction")
+	}
+	// opts should remain unchanged (defaults)
+	if opts.SkipPushSessions {
+		t.Error("SkipPushSessions should not be set in --yes mode")
+	}
+	if opts.CheckpointRemote != "" {
+		t.Error("CheckpointRemote should not be set in --yes mode")
+	}
+}
+
+func TestApplyCheckpointSyncChoice_ThisRemote(t *testing.T) {
+	t.Parallel()
+	opts := EnableOptions{}
+	err := applyCheckpointSyncChoice(checkpointSyncThisRemote, &opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.SkipPushSessions {
+		t.Error("SkipPushSessions should not be set for this-remote")
+	}
+	if opts.CheckpointRemote != "" {
+		t.Error("CheckpointRemote should not be set for this-remote")
+	}
+}
+
+func TestApplyCheckpointSyncChoice_Local(t *testing.T) {
+	t.Parallel()
+	opts := EnableOptions{}
+	err := applyCheckpointSyncChoice(checkpointSyncLocal, &opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !opts.SkipPushSessions {
+		t.Error("SkipPushSessions should be set for local-only")
+	}
+	if opts.CheckpointRemote != "" {
+		t.Error("CheckpointRemote should not be set for local-only")
+	}
+}
+
+func TestApplyCheckpointSyncChoice_SeparateRepo(t *testing.T) {
+	t.Parallel()
+	opts := EnableOptions{}
+	err := applyCheckpointSyncChoice("github:myorg/private-checkpoints", &opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.CheckpointRemote != "github:myorg/private-checkpoints" {
+		t.Errorf("expected CheckpointRemote to be set, got %q", opts.CheckpointRemote)
+	}
+	if opts.SkipPushSessions {
+		t.Error("SkipPushSessions should not be set for separate repo")
+	}
+}
+
+func TestApplyCheckpointSyncChoice_InvalidRepo(t *testing.T) {
+	t.Parallel()
+	opts := EnableOptions{}
+	err := applyCheckpointSyncChoice("not-valid", &opts)
+	if err == nil {
+		t.Fatal("expected error for invalid repo format")
+	}
+	if !strings.Contains(err.Error(), "invalid checkpoint repo") {
+		t.Errorf("expected 'invalid checkpoint repo' in error, got: %v", err)
+	}
+}
+
+func TestApplyCheckpointSyncChoice_UnsupportedProvider(t *testing.T) {
+	t.Parallel()
+	opts := EnableOptions{}
+	err := applyCheckpointSyncChoice("gitlab:org/repo", &opts)
+	if err == nil {
+		t.Fatal("expected error for unsupported provider")
+	}
+	if !strings.Contains(err.Error(), "unsupported provider") {
+		t.Errorf("expected 'unsupported provider' in error, got: %v", err)
+	}
+}
+
+func TestCheckpointSyncFooter_Content(t *testing.T) {
+	t.Parallel()
+	if !strings.Contains(checkpointSyncFooter, "sensitive data") {
+		t.Error("footer should mention sensitive data")
+	}
+	if !strings.Contains(checkpointSyncFooter, "best-effort") {
+		t.Error("footer should mention best-effort redaction")
+	}
+}

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -3005,8 +3005,8 @@ func TestPromptCheckpointSync_NonInteractive(t *testing.T) {
 	if !strings.Contains(out, "sensitive data") {
 		t.Error("notice should mention sensitive data")
 	}
-	if !strings.Contains(out, "best-effort") {
-		t.Error("notice should mention best-effort redaction")
+	if !strings.Contains(out, "Review before sharing") {
+		t.Error("notice should mention Review before sharing redaction")
 	}
 	// opts should remain unchanged (defaults)
 	if opts.SkipPushSessions {
@@ -3148,7 +3148,7 @@ func TestCheckpointSyncFooter_Content(t *testing.T) {
 	if !strings.Contains(checkpointSyncFooter, "sensitive data") {
 		t.Error("footer should mention sensitive data")
 	}
-	if !strings.Contains(checkpointSyncFooter, "best-effort") {
-		t.Error("footer should mention best-effort redaction")
+	if !strings.Contains(checkpointSyncFooter, "Review before sharing") {
+		t.Error("footer should mention Review before sharing redaction")
 	}
 }

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -3019,16 +3019,17 @@ func TestPromptCheckpointSync_NonInteractive(t *testing.T) {
 
 func TestApplyCheckpointSyncChoice_ThisRemote(t *testing.T) {
 	t.Parallel()
-	opts := EnableOptions{}
+	// Verify this-remote clears any previously-set fields.
+	opts := EnableOptions{CheckpointRemote: "github:old/repo", SkipPushSessions: true}
 	err := applyCheckpointSyncChoice(checkpointSyncThisRemote, &opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if opts.SkipPushSessions {
-		t.Error("SkipPushSessions should not be set for this-remote")
+		t.Error("SkipPushSessions should be cleared for this-remote")
 	}
 	if opts.CheckpointRemote != "" {
-		t.Error("CheckpointRemote should not be set for this-remote")
+		t.Error("CheckpointRemote should be cleared for this-remote")
 	}
 }
 
@@ -3083,6 +3084,62 @@ func TestApplyCheckpointSyncChoice_UnsupportedProvider(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported provider") {
 		t.Errorf("expected 'unsupported provider' in error, got: %v", err)
+	}
+}
+
+func TestPromptCheckpointSync_SkipsWhenCheckpointRemoteSet(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := EnableOptions{Yes: true, CheckpointRemote: "github:org/repo"}
+	err := promptCheckpointSync(&buf, &opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("expected no output when --checkpoint-remote already set, got: %s", buf.String())
+	}
+}
+
+func TestPromptCheckpointSync_SkipsWhenSkipPushSet(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := EnableOptions{Yes: true, SkipPushSessions: true}
+	err := promptCheckpointSync(&buf, &opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("expected no output when --skip-push-sessions already set, got: %s", buf.String())
+	}
+}
+
+func TestApplyCheckpointSyncChoice_LocalClearsRemote(t *testing.T) {
+	t.Parallel()
+	opts := EnableOptions{CheckpointRemote: "github:old/repo"}
+	err := applyCheckpointSyncChoice(checkpointSyncLocal, &opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.CheckpointRemote != "" {
+		t.Error("CheckpointRemote should be cleared when selecting local")
+	}
+	if !opts.SkipPushSessions {
+		t.Error("SkipPushSessions should be set for local-only")
+	}
+}
+
+func TestApplyCheckpointSyncChoice_SeparateRepoClearsSkipPush(t *testing.T) {
+	t.Parallel()
+	opts := EnableOptions{SkipPushSessions: true}
+	err := applyCheckpointSyncChoice("github:org/new-repo", &opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.SkipPushSessions {
+		t.Error("SkipPushSessions should be cleared when selecting separate repo")
+	}
+	if opts.CheckpointRemote != "github:org/new-repo" {
+		t.Errorf("expected CheckpointRemote to be set, got %q", opts.CheckpointRemote)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/346
<!-- entire-trail-link-end -->

## Summary

https://github.com/user-attachments/assets/780c02c4-dc14-4a66-a5bb-04e3ac80d0e4


- Adds an interactive picker during `entire enable` asking where checkpoints should sync: this repo's remote, a separate private checkpoint repo, or local-only
- Non-interactive mode (`--yes`/CI) prints an informational notice with the `entire configure --checkpoint-remote` command
- Selecting "A separate private checkpoint repo" prompts for the repo in `github:owner/repo` format and validates the input
- Selecting "Keep checkpoints local only" sets `--skip-push-sessions`
- Includes footer: "Transcripts may contain sensitive data. Redaction is best-effort."

## Test plan
- [x] Unit tests for all three picker branches (`this-remote`, `local`, `separate-repo`)
- [x] Unit tests for invalid input (bad format, unsupported provider)
- [x] Unit test for non-interactive `--yes` mode output
- [x] All existing CLI tests pass
- [x] `mise run fmt && mise run lint` clean
- [ ] Manual test: run `entire enable` interactively and verify picker renders correctly
- [ ] Manual test: run `entire enable --yes` and verify notice prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `entire enable` interactive flow to set checkpoint-sync related strategy options, which could affect where session transcripts get pushed and introduce new prompt/CI behavior.
> 
> **Overview**
> Adds an interactive checkpoint-sync destination picker to `entire enable`, letting users choose syncing to the current repo remote, a separate private checkpoint repo (validated `github:owner/repo`), or local-only (sets `--skip-push-sessions`).
> 
> In `--yes`/non-interactive mode, it skips prompting and prints a notice with guidance for `entire configure --checkpoint-remote`, plus a sensitivity/redaction footer. Includes unit tests covering all branches, skip conditions, and invalid/unsupported repo inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5741a6c8c6ce24af1785c7d90265063a1a14432b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->