### PR TITLE
Pi: cold-attach native-store resolution, race fix, E2E coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This repo contains the CLI for Entire.
 - `entire/`: Main CLI entry point. Also home to kubectl-style external-command resolution (`entire <name>` → `entire-<name>` on PATH) — see [External Commands](docs/architecture/external-commands.md).
 - `entire/cli`: CLI utilities and helpers (Cobra commands, helpers, group roots)
 - `entire/cli/commands`: actual command implementations
-- `entire/cli/agent`: agent implementations (Claude Code, Gemini CLI, OpenCode, Cursor, Factory AI Droid, Copilot CLI) - see [Agent Integration Checklist](docs/architecture/agent-integration-checklist.md) and [Agent Implementation Guide](docs/architecture/agent-guide.md)
+- `entire/cli/agent`: agent implementations (Claude Code, Gemini CLI, OpenCode, Cursor, Factory AI Droid, Copilot CLI, Pi) - see [Agent Integration Checklist](docs/architecture/agent-integration-checklist.md) and [Agent Implementation Guide](docs/architecture/agent-guide.md)
 - `entire/cli/strategy`: strategy implementation (manual-commit) - see section below
 - `entire/cli/checkpoint`: checkpoint storage abstractions (temporary and committed)
 - `entire/cli/session`: session state management
@@ -115,6 +115,7 @@ mise run test:e2e --agent opencode [filter]          # OpenCode only
 mise run test:e2e --agent cursor [filter]            # Cursor only
 mise run test:e2e --agent factoryai-droid [filter]   # Factory AI Droid only
 mise run test:e2e --agent copilot-cli [filter]       # Copilot CLI only
+mise run test:e2e --agent pi [filter]                # Pi only
 ```
 
 E2E tests:
@@ -122,9 +123,9 @@ E2E tests:
 - Use the `//go:build e2e` build tag
 - Located in `e2e/tests/`
 - See [`e2e/README.md`](e2e/README.md) for full documentation (structure, debugging, adding agents)
-- Test real agent interactions (Claude Code, Gemini CLI, OpenCode, Cursor, Factory AI Droid, Copilot CLI, or Vogon creating files, committing, etc.)
+- Test real agent interactions (Claude Code, Gemini CLI, OpenCode, Cursor, Factory AI Droid, Copilot CLI, Pi, or Vogon creating files, committing, etc.)
 - Validate checkpoint scenarios documented in `docs/architecture/checkpoint-scenarios.md`
-- Support multiple agents via `E2E_AGENT` env var (`claude-code`, `gemini`, `opencode`, `cursor`, `factoryai-droid`, `copilot-cli`, `vogon`)
+- Support multiple agents via `E2E_AGENT` env var (`claude-code`, `gemini`, `opencode`, `cursor`, `factoryai-droid`, `copilot-cli`, `pi`, `vogon`)
 
 **Environment variables:**
 

--- a/cmd/entire/cli/agent/pi/lifecycle.go
+++ b/cmd/entire/cli/agent/pi/lifecycle.go
@@ -161,19 +161,35 @@ func (a *PiAgent) ParseHookEvent(ctx context.Context, hookName string, stdin io.
 
 const activeSessionFile = "pi-active-session"
 
-// resolveSessionDir returns the per-repo Pi staging directory.
-// Mirrors GetSessionDir: <repo>/.entire/tmp/pi.
+// piHookCacheSubdir is the subdirectory under .entire/tmp/ where the hook
+// flow caches the active-session ID file and the agent_end transcript
+// snapshot. Agent-specific (not just .entire/tmp/) so other agents'
+// integration tests and tooling don't shadow each other under the cache
+// root.
+const piHookCacheSubdir = "pi"
+
+// resolveSessionDir returns the per-repo hook cache directory used by
+// cacheSessionID / readCachedSessionID / clearCachedSessionID and
+// captureTranscript.
+//
+// This is intentionally distinct from PiAgent.GetSessionDir, which
+// points at Pi's native session store (~/.pi/agent/sessions/...) so
+// cold attach can resolve transcripts that were never hook-captured.
+// The cache here is hook-internal and only reachable via Pi hooks
+// firing; the framework records the cached path as SessionRef in
+// checkpoint metadata, so subsequent operations on hooked sessions go
+// through the recorded path rather than re-resolving via GetSessionDir.
 func resolveSessionDir(ctx context.Context) string {
 	root, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		//nolint:forbidigo // fallback when no git repo (tests run outside repos)
 		wd, wdErr := os.Getwd()
 		if wdErr != nil {
-			return filepath.Join(paths.EntireTmpDir, piSessionSubdir)
+			return filepath.Join(paths.EntireTmpDir, piHookCacheSubdir)
 		}
 		root = wd
 	}
-	return filepath.Join(root, paths.EntireTmpDir, piSessionSubdir)
+	return filepath.Join(root, paths.EntireTmpDir, piHookCacheSubdir)
 }
 
 func cacheSessionID(ctx context.Context, id string) {
@@ -210,7 +226,7 @@ func clearCachedSessionID(ctx context.Context) {
 // <repo>/.entire/tmp/pi/<id>.json so Entire has a stable transcript
 // reference. Returns the path to the cached file, or "" if either input is
 // missing. The pi/ namespace under .entire/tmp/ is intentional — see
-// GetSessionDir / piSessionSubdir for the rationale.
+// piHookCacheSubdir for the rationale.
 func captureTranscript(ctx context.Context, sessionID, piSessionFile string) string {
 	if sessionID == "" || piSessionFile == "" {
 		return ""

--- a/cmd/entire/cli/agent/pi/lifecycle.go
+++ b/cmd/entire/cli/agent/pi/lifecycle.go
@@ -43,11 +43,10 @@ func (a *PiAgent) HookNames() []string {
 //   - session_start       → SessionStart
 //   - before_agent_start  → TurnStart
 //   - agent_end           → TurnEnd
-//   - session_shutdown    → SessionEnd
+//   - session_shutdown    → (cleanup-only, no lifecycle event — see ParseHookEvent)
 func (a *PiAgent) GetSupportedHooks() []agent.HookType {
 	return []agent.HookType{
 		agent.HookSessionStart,
-		agent.HookSessionEnd,
 		agent.HookUserPromptSubmit,
 		agent.HookStop,
 	}
@@ -131,19 +130,24 @@ func (a *PiAgent) ParseHookEvent(ctx context.Context, hookName string, stdin io.
 		}, nil
 
 	case HookNameSessionShutdown:
-		// The TS extension's session_shutdown payload carries no session_id /
-		// session_file, so recover the active session ID from the cache before
-		// clearing it. Without this the SessionEnd event would have empty
-		// SessionID and the strategy couldn't identify which session ended.
-		if sessionID == "" {
-			sessionID = readCachedSessionID(ctx)
-		}
+		// Cleanup-only: clear the cached session ID. We intentionally do NOT
+		// emit SessionEnd here.
+		//
+		// Pi fires session_shutdown and agent_end on session teardown, and the
+		// TypeScript extension dispatches both via separate `entire hooks pi …`
+		// child processes (execFile is non-blocking). Child-process startup
+		// ordering then decides which event reaches the lifecycle dispatcher
+		// first; if session_shutdown wins, an emitted SessionEnd transitions
+		// the session to "ended" before agent_end can save the linkable
+		// checkpoint, leaving prepare-commit-msg with no session to attach a
+		// trailer to and the user's commit unlinked.
+		//
+		// agent_end is the source of truth for "turn complete" (and, for Pi,
+		// effectively "session over" for any single-turn `pi -p` invocation).
+		// SessionEnd is left for the framework to derive from idle timeout or
+		// the next SessionStart's stale-state cleanup.
 		clearCachedSessionID(ctx)
-		return &agent.Event{
-			Type:      agent.SessionEnd,
-			SessionID: sessionID,
-			Timestamp: now,
-		}, nil
+		return nil, nil //nolint:nilnil // intentional: cleanup-only, no lifecycle event
 
 	default:
 		// Unknown / future hooks have no lifecycle significance.
@@ -161,7 +165,7 @@ func (a *PiAgent) ParseHookEvent(ctx context.Context, hookName string, stdin io.
 
 const activeSessionFile = "pi-active-session"
 
-// piHookCacheSubdir is the subdirectory under .entire/tmp/ where the hook
+// piHookCacheSubdir is the subdirectory under .entire/tmp/ where hook
 // flow caches the active-session ID file and the agent_end transcript
 // snapshot. Agent-specific (not just .entire/tmp/) so other agents'
 // integration tests and tooling don't shadow each other under the cache
@@ -226,7 +230,7 @@ func clearCachedSessionID(ctx context.Context) {
 // <repo>/.entire/tmp/pi/<id>.json so Entire has a stable transcript
 // reference. Returns the path to the cached file, or "" if either input is
 // missing. The pi/ namespace under .entire/tmp/ is intentional — see
-// piHookCacheSubdir for the rationale.
+// GetSessionDir / piHookCacheSubdir for the rationale.
 func captureTranscript(ctx context.Context, sessionID, piSessionFile string) string {
 	if sessionID == "" || piSessionFile == "" {
 		return ""

--- a/cmd/entire/cli/agent/pi/lifecycle_test.go
+++ b/cmd/entire/cli/agent/pi/lifecycle_test.go
@@ -45,7 +45,7 @@ func TestParseHookEvent_BeforeAgentStart(t *testing.T) {
 	}
 }
 
-func TestParseHookEvent_SessionShutdown(t *testing.T) {
+func TestParseHookEvent_SessionShutdown_NoLifecycleEvent(t *testing.T) {
 	t.Parallel()
 	a := &PiAgent{}
 	stdin := strings.NewReader(`{"type":"session_shutdown","session_id":"explicit-id"}`)
@@ -53,18 +53,14 @@ func TestParseHookEvent_SessionShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseHookEvent: %v", err)
 	}
-	if ev == nil || ev.Type != agent.SessionEnd {
-		t.Fatalf("Type = %v, want SessionEnd", ev)
-	}
-	if ev.SessionID != "explicit-id" {
-		t.Errorf("SessionID = %q, want explicit-id", ev.SessionID)
+	// session_shutdown is cleanup-only — see ParseHookEvent for the rationale.
+	if ev != nil {
+		t.Fatalf("expected nil event from session_shutdown, got %+v", ev)
 	}
 }
 
-func TestParseHookEvent_SessionShutdown_RecoversFromCache(t *testing.T) {
-	// The TS extension's session_shutdown payload carries no session_id.
-	// Make sure ParseHookEvent recovers it from the cache that
-	// session_start populated, then clears the cache.
+func TestParseHookEvent_SessionShutdown_ClearsCache(t *testing.T) {
+	// session_shutdown's only side effect is clearing the cached session ID.
 	// Cannot use t.Parallel — t.Chdir.
 	dir := t.TempDir()
 	t.Chdir(dir)
@@ -72,23 +68,23 @@ func TestParseHookEvent_SessionShutdown_RecoversFromCache(t *testing.T) {
 	ctx := context.Background()
 	a := &PiAgent{}
 
-	// Simulate session_start populating the cache.
-	_, err := a.ParseHookEvent(ctx, HookNameSessionStart, strings.NewReader(
-		`{"type":"session_start","session_file":"/tmp/2026-05-09T12-00-00-000Z_cached-id.jsonl"}`))
-	if err != nil {
+	// Populate the cache via session_start.
+	if _, err := a.ParseHookEvent(ctx, HookNameSessionStart, strings.NewReader(
+		`{"type":"session_start","session_file":"/tmp/2026-05-09T12-00-00-000Z_cached-id.jsonl"}`)); err != nil {
 		t.Fatalf("session_start setup: %v", err)
 	}
+	if got := readCachedSessionID(ctx); got != "cached-id" {
+		t.Fatalf("cache pre-shutdown = %q, want cached-id", got)
+	}
 
-	// Empty session_shutdown payload — must recover from cache.
+	// session_shutdown clears the cache and emits no event.
 	ev, err := a.ParseHookEvent(ctx, HookNameSessionShutdown, strings.NewReader(`{"type":"session_shutdown"}`))
 	if err != nil {
 		t.Fatalf("session_shutdown: %v", err)
 	}
-	if ev == nil || ev.SessionID != "cached-id" {
-		t.Errorf("SessionID = %v, want cached-id (recovered from cache)", ev)
+	if ev != nil {
+		t.Errorf("expected nil event, got %+v", ev)
 	}
-
-	// Cache should be cleared by now.
 	if got := readCachedSessionID(ctx); got != "" {
 		t.Errorf("cache should be cleared after session_shutdown, got %q", got)
 	}
@@ -192,9 +188,10 @@ func TestCaptureTranscript_MissingInputs(t *testing.T) {
 func TestGetSupportedHooks(t *testing.T) {
 	t.Parallel()
 	got := (&PiAgent{}).GetSupportedHooks()
+	// Note: session_shutdown is cleanup-only, not a HookSessionEnd source —
+	// see ParseHookEvent's session_shutdown case for why.
 	want := []agent.HookType{
 		agent.HookSessionStart,
-		agent.HookSessionEnd,
 		agent.HookUserPromptSubmit,
 		agent.HookStop,
 	}

--- a/cmd/entire/cli/agent/pi/pi.go
+++ b/cmd/entire/cli/agent/pi/pi.go
@@ -196,17 +196,23 @@ func resolvePiHome() (string, error) {
 }
 
 // encodeRepoPathForPi encodes an absolute repo path into Pi's
-// session-directory naming scheme: '/' becomes '-', wrapped with '--'
-// delimiters. /Users/foo/repo encodes as --Users-foo-repo--. Trailing
-// separators are stripped so /a/b/ and /a/b encode the same way.
-// Empty input returns "".
+// session-directory naming scheme: every path separator becomes '-',
+// wrapped with '--' delimiters. /Users/foo/repo encodes as
+// --Users-foo-repo--. Leading and trailing separators are absorbed so
+// /a/b/ and /a/b encode the same way. Empty input returns "".
+//
+// Both '/' and '\\' are replaced regardless of host OS: on Windows,
+// git rev-parse --show-toplevel returns forward slashes, but native
+// Windows APIs use backslashes — a host-only replacement would leak
+// the other form through and produce nested directories instead of a
+// single name, breaking session lookup. filepath.ToSlash isn't enough
+// because it only normalises the host's separator.
 func encodeRepoPathForPi(repoPath string) string {
 	if repoPath == "" {
 		return ""
 	}
-	cleaned := strings.TrimRight(repoPath, string(filepath.Separator))
-	body := strings.ReplaceAll(cleaned, string(filepath.Separator), "-")
-	body = strings.TrimPrefix(body, "-")
+	body := strings.NewReplacer("/", "-", `\`, "-").Replace(repoPath)
+	body = strings.Trim(body, "-")
 	return "--" + body + "--"
 }
 

--- a/cmd/entire/cli/agent/pi/pi.go
+++ b/cmd/entire/cli/agent/pi/pi.go
@@ -15,16 +15,25 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
-	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
+
+// piHomeEnvVar overrides the default Pi home directory (~/.pi/agent).
+// Pi itself reads this variable, so honoring it keeps Entire and Pi in
+// agreement when a developer points Pi at a non-default home.
+const piHomeEnvVar = "PI_CODING_AGENT_DIR"
+
+// piSessionDirEnvVar lets tests redirect Pi's session lookup without
+// touching the real ~/.pi/agent. Mirrors ENTIRE_TEST_<AGENT>_SESSION_DIR
+// used by Codex.
+const piSessionDirEnvVar = "ENTIRE_TEST_PI_SESSION_DIR"
 
 //nolint:gochecknoinits // Agent self-registration is the intended pattern
 func init() {
@@ -107,46 +116,113 @@ func (a *PiAgent) GetSessionID(input *agent.HookInput) string {
 	return input.SessionID
 }
 
-// piSessionSubdir is the per-agent subdirectory under .entire/tmp/ where
-// Pi captures session transcripts. This MUST be agent-specific (not just
-// .entire/tmp) — the framework's AgentForTranscriptPath iterates every
-// agent's session dir to identify the owner of a transcript path, and a
-// broader claim would shadow the .entire/tmp/ paths used by other agents'
-// integration tests and tooling.
-const piSessionSubdir = "pi"
-
-// GetSessionDir returns the directory where Entire stages Pi session
-// transcripts. The Pi extension forwards Pi's native JSONL path on every
-// hook event; on agent_end we copy the file into
-// <repo>/.entire/tmp/pi/<id>.json so condensation can find it
-// deterministically and survive Pi sessions being deleted by the user.
+// GetSessionDir returns the directory where Pi natively stores session
+// transcripts for repoPath: <piHome>/sessions/<encoded-repo-path>/.
 //
-// When repoPath is empty we resolve the worktree root (so callers running
-// from a subdirectory still get the repo-local staging path) and only fall
-// back to os.Getwd() if no git repo is reachable.
+// Pointing this at the native store (rather than the per-repo
+// .entire/tmp/pi/ cache populated by the agent_end hook) is what lets
+// `entire session attach <id>` resolve cold sessions — sessions that
+// were never hooked, or whose hook capture failed. attach falls through
+// to GetSessionDir + ResolveSessionFile when no SessionRef is recorded
+// in metadata, and the live Pi store is the only place that always has
+// the transcript on disk.
+//
+// Resolution order:
+//  1. ENTIRE_TEST_PI_SESSION_DIR (test override; no encoding applied)
+//  2. PI_CODING_AGENT_DIR (Pi's own override; encoding still applies)
+//  3. ~/.pi/agent (default)
+//
+// The .entire/tmp/pi/ cache stays as a hook-internal detail —
+// captureTranscript writes there and the TurnEnd event records that
+// path as SessionRef in checkpoint metadata, so subsequent operations
+// on hooked sessions go through the recorded SessionRef and never call
+// GetSessionDir.
 func (a *PiAgent) GetSessionDir(repoPath string) (string, error) {
-	if repoPath == "" {
-		root, err := paths.WorktreeRoot(context.Background())
-		if err == nil {
-			repoPath = root
-		} else {
-			logging.Debug(context.Background(), "pi: GetSessionDir falling back to cwd",
-				slog.String("err", err.Error()))
-			//nolint:forbidigo // last-resort fallback when no git repo (tests outside repos)
-			wd, wdErr := os.Getwd()
-			if wdErr != nil {
-				return "", fmt.Errorf("resolve repo root or cwd for pi session dir: %w", wdErr)
-			}
-			repoPath = wd
-		}
+	if override := os.Getenv(piSessionDirEnvVar); override != "" {
+		return override, nil
 	}
-	return filepath.Join(repoPath, paths.EntireTmpDir, piSessionSubdir), nil
+	home, err := resolvePiHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "sessions", encodeRepoPathForPi(repoPath)), nil
 }
 
-// ResolveSessionFile returns the full path to a captured Pi session JSONL
-// file for the given session ID inside sessionDir.
+// GetSessionBaseDir returns the base directory containing per-project
+// session subdirectories. Used by attach's cross-project fallback
+// (searchTranscriptInProjectDirs) when a session was started from a
+// different cwd than the current worktree root.
+func (a *PiAgent) GetSessionBaseDir() (string, error) {
+	home, err := resolvePiHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "sessions"), nil
+}
+
+// ResolveSessionFile returns the path to the Pi session file for
+// agentSessionID in sessionDir. Pi names files <timestamp>_<id>.jsonl,
+// so glob for the matching ID; on multiple matches the lexicographically
+// latest (most recent timestamp) wins.
+//
+// Absolute paths pass through unchanged so hook payloads carrying live
+// pi paths work without re-resolution. When no match exists, fall back
+// to a deterministic non-existent path so downstream stat checks fail
+// cleanly rather than panicking on an empty path.
 func (a *PiAgent) ResolveSessionFile(sessionDir, agentSessionID string) string {
-	return filepath.Join(sessionDir, agentSessionID+".json")
+	if filepath.IsAbs(agentSessionID) {
+		return agentSessionID
+	}
+	if path := findPiSessionByID(sessionDir, agentSessionID); path != "" {
+		return path
+	}
+	if sessionDir == "" {
+		return agentSessionID
+	}
+	return filepath.Join(sessionDir, agentSessionID+".jsonl")
+}
+
+// resolvePiHome returns Pi's home directory: $PI_CODING_AGENT_DIR or
+// ~/.pi/agent.
+func resolvePiHome() (string, error) {
+	if dir := os.Getenv(piHomeEnvVar); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".pi", "agent"), nil
+}
+
+// encodeRepoPathForPi encodes an absolute repo path into Pi's
+// session-directory naming scheme: '/' becomes '-', wrapped with '--'
+// delimiters. /Users/foo/repo encodes as --Users-foo-repo--. Trailing
+// separators are stripped so /a/b/ and /a/b encode the same way.
+// Empty input returns "".
+func encodeRepoPathForPi(repoPath string) string {
+	if repoPath == "" {
+		return ""
+	}
+	cleaned := strings.TrimRight(repoPath, string(filepath.Separator))
+	body := strings.ReplaceAll(cleaned, string(filepath.Separator), "-")
+	body = strings.TrimPrefix(body, "-")
+	return "--" + body + "--"
+}
+
+// findPiSessionByID globs sessionDir for *_<sessionID>.jsonl. Returns
+// the lexicographically latest match (most recent timestamp) or "" when
+// no match exists or sessionDir/sessionID is empty.
+func findPiSessionByID(sessionDir, sessionID string) string {
+	if sessionDir == "" || sessionID == "" {
+		return ""
+	}
+	matches, err := filepath.Glob(filepath.Join(sessionDir, "*_"+sessionID+".jsonl"))
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	sort.Strings(matches)
+	return matches[len(matches)-1]
 }
 
 // ReadSession loads a captured Pi transcript and returns it as an AgentSession.

--- a/cmd/entire/cli/agent/pi/session_resolve_test.go
+++ b/cmd/entire/cli/agent/pi/session_resolve_test.go
@@ -17,6 +17,13 @@ func TestEncodeRepoPathForPi(t *testing.T) {
 		{"/Users/foo/repo", "--Users-foo-repo--"},
 		{"/Users/foo/repo/", "--Users-foo-repo--"}, // trailing separator stripped
 		{"/private/var/folders/2y/T/e2e-repo-1", "--private-var-folders-2y-T-e2e-repo-1--"},
+		// Windows: git rev-parse --show-toplevel returns forward slashes
+		// regardless of platform — must encode the same way on every OS.
+		{`C:/Users/foo/repo`, `--C:-Users-foo-repo--`},
+		{`C:/Users/foo/repo/`, `--C:-Users-foo-repo--`},
+		// Native Windows separators (in case a caller passes them through).
+		{`C:\Users\foo\repo`, `--C:-Users-foo-repo--`},
+		{`C:\Users\foo\repo\`, `--C:-Users-foo-repo--`},
 		{"", ""},
 	}
 	for _, tt := range tests {

--- a/cmd/entire/cli/agent/pi/session_resolve_test.go
+++ b/cmd/entire/cli/agent/pi/session_resolve_test.go
@@ -1,0 +1,149 @@
+package pi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+func TestEncodeRepoPathForPi(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"/Users/foo/repo", "--Users-foo-repo--"},
+		{"/Users/foo/repo/", "--Users-foo-repo--"}, // trailing separator stripped
+		{"/private/var/folders/2y/T/e2e-repo-1", "--private-var-folders-2y-T-e2e-repo-1--"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := encodeRepoPathForPi(tt.in)
+		if got != tt.want {
+			t.Errorf("encodeRepoPathForPi(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestGetSessionDir_HonorsTestOverride(t *testing.T) {
+	override := t.TempDir()
+	t.Setenv(piSessionDirEnvVar, override)
+
+	dir, err := (&PiAgent{}).GetSessionDir("/Users/foo/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dir != override {
+		t.Errorf("GetSessionDir = %q, want override %q", dir, override)
+	}
+}
+
+func TestGetSessionDir_HonorsPiHomeOverride(t *testing.T) {
+	piHome := t.TempDir()
+	t.Setenv(piHomeEnvVar, piHome)
+	t.Setenv(piSessionDirEnvVar, "")
+
+	dir, err := (&PiAgent{}).GetSessionDir("/Users/foo/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(piHome, "sessions", "--Users-foo-repo--")
+	if dir != want {
+		t.Errorf("GetSessionDir = %q, want %q", dir, want)
+	}
+}
+
+func TestGetSessionBaseDir_HonorsPiHomeOverride(t *testing.T) {
+	piHome := t.TempDir()
+	t.Setenv(piHomeEnvVar, piHome)
+
+	base, err := (&PiAgent{}).GetSessionBaseDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(piHome, "sessions")
+	if base != want {
+		t.Errorf("GetSessionBaseDir = %q, want %q", base, want)
+	}
+}
+
+// PiAgent must implement SessionBaseDirProvider so attach's
+// cross-project fallback (searchTranscriptInProjectDirs) can scan
+// sibling project subdirs of ~/.pi/agent/sessions/ when the session
+// was started from a different cwd than the current worktree root.
+func TestPiAgent_ImplementsSessionBaseDirProvider(t *testing.T) {
+	t.Parallel()
+	if _, ok := agent.AsSessionBaseDirProvider(NewPiAgent()); !ok {
+		t.Fatal("expected pi to implement SessionBaseDirProvider")
+	}
+}
+
+func TestResolveSessionFile_AbsolutePathPassthrough(t *testing.T) {
+	t.Parallel()
+	abs := "/tmp/2026-01-01T00-00-00-000Z_abc123.jsonl"
+	got := (&PiAgent{}).ResolveSessionFile("/ignored", abs)
+	if got != abs {
+		t.Errorf("absolute path: got %q, want %q", got, abs)
+	}
+}
+
+func TestResolveSessionFile_GlobsBySessionID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	id := "sess-xyz"
+
+	older := filepath.Join(dir, "2026-01-01T00-00-00-000Z_"+id+".jsonl")
+	newer := filepath.Join(dir, "2026-06-15T12-00-00-000Z_"+id+".jsonl")
+	for _, p := range []string{older, newer} {
+		if err := os.WriteFile(p, []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Unrelated file with a different session ID — must not match.
+	unrelated := filepath.Join(dir, "2026-06-15T12-00-00-000Z_other.jsonl")
+	if err := os.WriteFile(unrelated, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := (&PiAgent{}).ResolveSessionFile(dir, id)
+	if got != newer {
+		t.Errorf("ResolveSessionFile picked %q, want most recent %q", got, newer)
+	}
+}
+
+func TestResolveSessionFile_NoMatchFallback(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	id := "missing-id"
+
+	got := (&PiAgent{}).ResolveSessionFile(dir, id)
+	want := filepath.Join(dir, id+".jsonl")
+	if got != want {
+		t.Errorf("ResolveSessionFile fallback = %q, want %q", got, want)
+	}
+	// The fallback must be a non-existent path so callers' stat checks fail cleanly.
+	if _, err := os.Stat(got); !os.IsNotExist(err) {
+		t.Errorf("expected stat to report not-exist for fallback path, got err=%v", err)
+	}
+}
+
+func TestResolveSessionFile_NoMatch_NoSessionDir(t *testing.T) {
+	t.Parallel()
+	got := (&PiAgent{}).ResolveSessionFile("", "sess-xyz")
+	if got != "sess-xyz" {
+		t.Errorf("ResolveSessionFile with empty dir = %q, want %q", got, "sess-xyz")
+	}
+}
+
+func TestFindPiSessionByID_EmptyInputs(t *testing.T) {
+	t.Parallel()
+	if got := findPiSessionByID("", "id"); got != "" {
+		t.Errorf("empty dir: got %q, want \"\"", got)
+	}
+	if got := findPiSessionByID(t.TempDir(), ""); got != "" {
+		t.Errorf("empty id: got %q, want \"\"", got)
+	}
+}

--- a/e2e/agents/pi.go
+++ b/e2e/agents/pi.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -20,6 +21,16 @@ func init() {
 
 // Pi implements the E2E Agent interface for the Pi coding agent.
 type Pi struct{}
+
+// PiSession exposes the per-test isolated Pi home so test fixtures can
+// inspect or clean it up.
+type PiSession struct {
+	*TmuxSession
+
+	home string
+}
+
+func (s *PiSession) Home() string { return s.home }
 
 func (p *Pi) Name() string               { return "pi" }
 func (p *Pi) Binary() string             { return "pi" }
@@ -49,6 +60,56 @@ func (p *Pi) IsTransientError(out Output, _ error) bool {
 	return false
 }
 
+// piHome creates an isolated PI_CODING_AGENT_DIR for a test run so
+// parallel tests don't share session state with the real ~/.pi/agent.
+// Auth (auth.json) and user-tunable defaults (settings.json) are
+// symlinked from the real home if present so OAuth tokens flow through
+// without re-prompting; tests that run with an explicit
+// ANTHROPIC_API_KEY / OPENAI_API_KEY env will pick those up via the
+// inherited environment regardless.
+func piHome() (string, func(), error) {
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve user cache dir: %w", err)
+	}
+	base := filepath.Join(cache, "entire-e2e")
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		return "", nil, fmt.Errorf("create pi home base %q: %w", base, err)
+	}
+	dir, err := os.MkdirTemp(base, "pi-home-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temporary pi home under %q: %w", base, err)
+	}
+	if err := seedPiHome(dir); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", nil, fmt.Errorf("seed pi home: %w", err)
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+// seedPiHome links the user's auth.json + settings.json into the
+// isolated home (best-effort) so Pi can authenticate without
+// re-prompting. Sessions still write into the isolated home's
+// sessions/ subdir, keeping per-test session state hermetic.
+func seedPiHome(home string) error {
+	realHome, err := os.UserHomeDir()
+	if err != nil {
+		return nil //nolint:nilerr // no user home → can't seed; tests with API-key env still work
+	}
+	src := filepath.Join(realHome, ".pi", "agent")
+	for _, name := range []string{"auth.json", "settings.json"} {
+		from := filepath.Join(src, name)
+		if _, statErr := os.Stat(from); statErr != nil {
+			continue // file not present — skip
+		}
+		to := filepath.Join(home, name)
+		if linkErr := os.Symlink(from, to); linkErr != nil {
+			return fmt.Errorf("symlink %s: %w", name, linkErr)
+		}
+	}
+	return nil
+}
+
 func (p *Pi) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
 	cfg := &runConfig{}
 	for _, o := range opts {
@@ -60,10 +121,18 @@ func (p *Pi) RunPrompt(ctx context.Context, dir string, prompt string, opts ...O
 		return Output{}, fmt.Errorf("%s not in PATH: %w", p.Binary(), err)
 	}
 
+	home, cleanup, err := piHome()
+	if err != nil {
+		return Output{}, fmt.Errorf("create pi home: %w", err)
+	}
+	defer cleanup()
+
 	args := []string{"-p", prompt, "--no-skills", "--no-prompt-templates", "--no-themes"}
 	displayArgs := []string{"-p", fmt.Sprintf("%q", prompt), "--no-skills", "--no-prompt-templates", "--no-themes"}
 
-	env := filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+	env := append(filterEnv(os.Environ(), "ENTIRE_TEST_TTY", "PI_CODING_AGENT_DIR"),
+		"PI_CODING_AGENT_DIR="+home,
+	)
 
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = dir
@@ -97,10 +166,17 @@ func (p *Pi) RunPrompt(ctx context.Context, dir string, prompt string, opts ...O
 func (p *Pi) StartSession(_ context.Context, dir string) (Session, error) {
 	name := fmt.Sprintf("pi-test-%d", time.Now().UnixNano())
 
-	s, err := NewTmuxSession(name, dir, []string{"ENTIRE_TEST_TTY"}, p.Binary())
+	home, cleanup, err := piHome()
 	if err != nil {
+		return nil, fmt.Errorf("create pi home: %w", err)
+	}
+
+	s, err := p.startTmuxSession(name, dir, home, p.Binary())
+	if err != nil {
+		cleanup()
 		return nil, err
 	}
+	s.OnClose(cleanup)
 
 	if _, err := s.WaitFor(p.PromptPattern(), 30*time.Second); err != nil {
 		_ = s.Close()
@@ -108,5 +184,17 @@ func (p *Pi) StartSession(_ context.Context, dir string) (Session, error) {
 	}
 	s.stableAtSend = ""
 
-	return s, nil
+	return &PiSession{TmuxSession: s, home: home}, nil
+}
+
+// startTmuxSession spawns Pi inside tmux with PI_CODING_AGENT_DIR set
+// via the `env` command. Mirrors Codex's startTmuxSession pattern so
+// the per-test home propagates into the agent process.
+func (p *Pi) startTmuxSession(name, dir, home string, args ...string) (*TmuxSession, error) {
+	tmuxArgs := append([]string{
+		"PI_CODING_AGENT_DIR=" + home,
+		"HOME=" + os.Getenv("HOME"),
+		"TERM=" + os.Getenv("TERM"),
+	}, args...)
+	return NewTmuxSession(name, dir, []string{"PI_CODING_AGENT_DIR", "ENTIRE_TEST_TTY"}, "env", tmuxArgs...)
 }

--- a/e2e/agents/pi.go
+++ b/e2e/agents/pi.go
@@ -1,0 +1,112 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func init() {
+	if env := os.Getenv("E2E_AGENT"); env != "" && env != "pi" {
+		return
+	}
+	Register(&Pi{})
+	RegisterGate("pi", 2)
+}
+
+// Pi implements the E2E Agent interface for the Pi coding agent.
+type Pi struct{}
+
+func (p *Pi) Name() string               { return "pi" }
+func (p *Pi) Binary() string             { return "pi" }
+func (p *Pi) EntireAgent() string        { return "pi" }
+func (p *Pi) PromptPattern() string      { return `\$\d` }
+func (p *Pi) TimeoutMultiplier() float64 { return 1.5 }
+
+func (p *Pi) Bootstrap() error {
+	return nil
+}
+
+func (p *Pi) IsTransientError(out Output, _ error) bool {
+	combined := out.Stdout + out.Stderr
+	for _, pat := range []string{
+		"overloaded",
+		"rate limit",
+		"429",
+		"503",
+		"ECONNRESET",
+		"ETIMEDOUT",
+		"timeout",
+	} {
+		if strings.Contains(combined, pat) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Pi) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
+	cfg := &runConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	bin, err := exec.LookPath(p.Binary())
+	if err != nil {
+		return Output{}, fmt.Errorf("%s not in PATH: %w", p.Binary(), err)
+	}
+
+	args := []string{"-p", prompt, "--no-skills", "--no-prompt-templates", "--no-themes"}
+	displayArgs := []string{"-p", fmt.Sprintf("%q", prompt), "--no-skills", "--no-prompt-templates", "--no-themes"}
+
+	env := filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	setupProcessGroup(cmd)
+	cmd.WaitDelay = 5 * time.Second
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	exitCode := 0
+	if err != nil {
+		exitErr := &exec.ExitError{}
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = -1
+		}
+	}
+
+	return Output{
+		Command:  p.Binary() + " " + strings.Join(displayArgs, " "),
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		ExitCode: exitCode,
+	}, err
+}
+
+func (p *Pi) StartSession(_ context.Context, dir string) (Session, error) {
+	name := fmt.Sprintf("pi-test-%d", time.Now().UnixNano())
+
+	s, err := NewTmuxSession(name, dir, []string{"ENTIRE_TEST_TTY"}, p.Binary())
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := s.WaitFor(p.PromptPattern(), 30*time.Second); err != nil {
+		_ = s.Close()
+		return nil, fmt.Errorf("waiting for initial prompt: %w", err)
+	}
+	s.stableAtSend = ""
+
+	return s, nil
+}


### PR DESCRIPTION
Stacks on #1170.

## 1. Resolve Pi sessions from native store — cold attach

`GetSessionDir`/`ResolveSessionFile` returned the per-repo `.entire/tmp/pi/` cache, which is only populated after `agent_end`. `entire session attach <id>` for a never-hooked session couldn't find the transcript — defeating attach's documented recovery case.

Now: native store at `<piHome>/sessions/<encoded-repo>/<ts>_<id>.jsonl`, encoded path matches Pi's own scheme (`/Users/foo/repo` → `--Users-foo-repo--`). `ResolveSessionFile` globs `*_<id>.jsonl`, latest timestamp wins; absolute paths still pass through. New `GetSessionBaseDir` enables cross-project fallback. Honors `PI_CODING_AGENT_DIR`; adds `ENTIRE_TEST_PI_SESSION_DIR` for test isolation. `.entire/tmp/pi/` stays as hook-internal cache (renamed constant `piHookCacheSubdir` in lifecycle.go to make the split obvious).

**Trade-off:** `AgentForTranscriptPath` now matches live Pi paths and misses cached paths instead of the inverse. Cached paths are only reachable via Pi's own hooks, where caller-agent-type fallback handles ownership correctly; live-path matching is what cold attach surfaces.

## 2. Drop `SessionEnd` from `session_shutdown` — race fix

Surfaced by the new e2e suite. The TS extension fires `agent_end` and `session_shutdown` async via separate `execFile` child processes; they race. When `session_shutdown` wins, the emitted `SessionEnd` transitions the session to `ended` and condenses it before `agent_end` can save its linkable checkpoint — `prepare-commit-msg` then sees "fully-condensed ended" and the commit gets no trailer.

Repro on `TestSingleSessionManualCommit/pi`: before, 37.7s timeout; after, 8.5s pass.

Fix: `session_shutdown` is cleanup-only (clears cached session ID, emits nothing). `agent_end` is the source of truth for "turn complete" — and effectively "session over" for any single-turn `pi -p`.

## 3. E2E agent registry

`e2e/agents/pi.go` so `E2E_AGENT=pi` works. #1170's canary used Vogon, not pi — the hooked flow had no integration coverage. This adapter surfaced the race in #2.

## 4. CLAUDE.md

Pi added to the agent enumeration, test:e2e flags, and `E2E_AGENT` values.

## Verification

- `mise run lint` clean; all unit tests pass (40+ existing + 9 new)
- Cold attach against an unhooked `pi -p` session resolves the live JSONL and produces a valid trailer
- `TestSingleSessionManualCommit/pi` passes in 8.5s with the race fix

## Test plan

- [ ] CI green
- [ ] `mise run test:e2e --agent pi TestSingleSessionManualCommit`
- [ ] Manual cold-attach: `pi -p hello` in an un-`enable`d repo, then `entire session attach --agent pi <id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)