### PR TITLE
Ignore mise.local.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ go.work.sum
 .env
 .envrc
 
+# Local mise overrides (per-developer task/env tweaks)
+mise.local.toml
+
 .DS_Store
 
 # Editor/IDE


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/349
<!-- entire-trail-link-end -->

mise reads `mise.local.toml` as a per-developer override for tasks and environment on top of the checked-in `mise.toml` — same role as `.env` / `.envrc` (already ignored). Adding it to `.gitignore` so local-only task tweaks don't leak into commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a single `.gitignore` entry to prevent local developer overrides from being committed; no runtime or production code is affected.
> 
> **Overview**
> Ignores `mise.local.toml` so per-developer mise task/environment overrides stay local and don’t leak into commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f675742b190683aeef5fd9ae27d5d8fe529e9537. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->