### PR TITLE
Add CodeQL workflow to scan GitHub Actions

### DIFF
--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -33,3 +33,7 @@ jobs:
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           category: /language:actions
+          # Fork PRs receive a read-only GITHUB_TOKEN, so SARIF upload to the
+          # code-scanning API would fail. Analyze still runs and surfaces
+          # findings in the job log; same-repo PRs upload as normal.
+          upload: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'always' || 'never' }}

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,0 +1,35 @@
+name: CodeQL (GitHub Actions)
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze workflows
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          languages: actions
+          queries: security-extended,security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          category: /language:actions


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/351
<!-- entire-trail-link-end -->

Runs CodeQL's actions language analysis with `security-extended` and `security-and-quality` query suites on PRs that touch `workflow` or `action` files, catching workflow injection and other supply-chain risks before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CI workflow only, with minimal read permissions plus `security-events: write` to upload results.
> 
> **Overview**
> Adds a new `.github/workflows/codeql-actions.yml` workflow that runs CodeQL analysis for the `actions` language on demand and on PRs that modify workflow/action files.
> 
> The job checks out the PR head SHA, runs the `security-extended` and `security-and-quality` query suites, and uploads findings to GitHub Security with scoped permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 256a66fbaa90f576704f101aaf59672945795c68. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->