### PR TITLE
Add trail watch for live code-review comments

### DIFF
--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -62,6 +62,34 @@ func (c *Client) Get(ctx context.Context, path string) (*http.Response, error) {
 	return c.do(ctx, http.MethodGet, path, nil)
 }
 
+// GetStream sends an authenticated GET request with optional extra request
+// headers (e.g. Accept: text/event-stream, Last-Event-ID) and returns the
+// response with the body still open. Callers are responsible for reading and
+// closing resp.Body. Intended for streaming endpoints such as Server-Sent
+// Events; for normal JSON requests use Get.
+func (c *Client) GetStream(ctx context.Context, path string, headers http.Header) (*http.Response, error) {
+	endpoint, err := ResolveURLFromBase(c.baseURL, path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve URL %s: %w", path, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	for k, vs := range headers {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", path, err)
+	}
+	return resp, nil
+}
+
 // Post sends an authenticated POST request with a JSON body to the given API-relative path.
 func (c *Client) Post(ctx context.Context, path string, body any) (*http.Response, error) {
 	var reader io.Reader

--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -59,7 +59,7 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // Get sends an authenticated GET request to the given API-relative path.
 func (c *Client) Get(ctx context.Context, path string) (*http.Response, error) {
-	return c.do(ctx, http.MethodGet, path, nil)
+	return c.do(ctx, http.MethodGet, path, nil, nil)
 }
 
 // GetStream sends an authenticated GET request with optional extra request
@@ -68,26 +68,7 @@ func (c *Client) Get(ctx context.Context, path string) (*http.Response, error) {
 // closing resp.Body. Intended for streaming endpoints such as Server-Sent
 // Events; for normal JSON requests use Get.
 func (c *Client) GetStream(ctx context.Context, path string, headers http.Header) (*http.Response, error) {
-	endpoint, err := ResolveURLFromBase(c.baseURL, path)
-	if err != nil {
-		return nil, fmt.Errorf("resolve URL %s: %w", path, err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	for k, vs := range headers {
-		for _, v := range vs {
-			req.Header.Add(k, v)
-		}
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", path, err)
-	}
-	return resp, nil
+	return c.do(ctx, http.MethodGet, path, nil, headers)
 }
 
 // Post sends an authenticated POST request with a JSON body to the given API-relative path.
@@ -100,7 +81,7 @@ func (c *Client) Post(ctx context.Context, path string, body any) (*http.Respons
 		}
 		reader = bytes.NewReader(data)
 	}
-	return c.do(ctx, http.MethodPost, path, reader)
+	return c.do(ctx, http.MethodPost, path, reader, nil)
 }
 
 // Put sends an authenticated PUT request with a JSON body to the given API-relative path.
@@ -113,7 +94,7 @@ func (c *Client) Put(ctx context.Context, path string, body any) (*http.Response
 		}
 		reader = bytes.NewReader(data)
 	}
-	return c.do(ctx, http.MethodPut, path, reader)
+	return c.do(ctx, http.MethodPut, path, reader, nil)
 }
 
 // Patch sends an authenticated PATCH request with a JSON body to the given API-relative path.
@@ -126,15 +107,15 @@ func (c *Client) Patch(ctx context.Context, path string, body any) (*http.Respon
 		}
 		reader = bytes.NewReader(data)
 	}
-	return c.do(ctx, http.MethodPatch, path, reader)
+	return c.do(ctx, http.MethodPatch, path, reader, nil)
 }
 
 // Delete sends an authenticated DELETE request to the given API-relative path.
 func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error) {
-	return c.do(ctx, http.MethodDelete, path, nil)
+	return c.do(ctx, http.MethodDelete, path, nil, nil)
 }
 
-func (c *Client) do(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+func (c *Client) do(ctx context.Context, method, path string, body io.Reader, headers http.Header) (*http.Response, error) {
 	endpoint, err := ResolveURLFromBase(c.baseURL, path)
 	if err != nil {
 		return nil, fmt.Errorf("resolve URL %s: %w", path, err)
@@ -143,6 +124,12 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader) (*
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	for k, vs := range headers {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
 	}
 
 	if body != nil {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -50,6 +50,7 @@ branch, or lists all trails if no trail exists for the current branch.`,
 	cmd.AddCommand(newTrailListCmd())
 	cmd.AddCommand(newTrailCreateCmd())
 	cmd.AddCommand(newTrailUpdateCmd())
+	cmd.AddCommand(newTrailWatchCmd())
 
 	return cmd
 }

--- a/cmd/entire/cli/trail_watch_cmd.go
+++ b/cmd/entire/cli/trail_watch_cmd.go
@@ -1,0 +1,444 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
+	"github.com/entireio/cli/cmd/entire/cli/trail"
+
+	"github.com/spf13/cobra"
+)
+
+// SSE constants for the trail code-review stream. Field names mirror the
+// client spec in entirehq/entire.io docs/trail-code-review-stream.md.
+const (
+	sseEventReady          = "ready"
+	sseEventComment        = "comment"
+	sseEventCommentDeleted = "comment_deleted"
+	sseEventReconnect      = "reconnect"
+	sseEventDeleted        = "deleted"
+	sseEventError          = "error"
+)
+
+// reconnectBackoffMin / Max bound the exponential backoff used after network
+// errors. The server's max stream duration (~50s) closes cleanly with an
+// `event: reconnect`; in that case we reconnect immediately with no backoff.
+const (
+	reconnectBackoffInitial = 500 * time.Millisecond
+	reconnectBackoffCap     = 30 * time.Second
+)
+
+func newTrailWatchCmd() *cobra.Command {
+	var (
+		jsonOutput bool
+		showPings  bool
+		once       bool
+		number     int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "watch [<number>]",
+		Short: "Tail a trail's code review (discussion) live",
+		Long: `Subscribe to the SSE stream of a trail's code-review discussion and
+print events as they arrive. Reconnects automatically when the server
+caps the connection (~50s) and on transient network errors.
+
+If <number> is omitted, the trail for the current branch is used.
+
+Events emitted by the server:
+  ready              initial frame, includes existing comment count
+  comment            comment added or edited (with full payload)
+  comment_deleted    comment removed
+  reconnect          server cap reached; re-establishing
+  deleted            trail row deleted; stream ends
+  error              server-side error; treated as reconnect`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				n, err := strconv.Atoi(args[0])
+				if err != nil || n <= 0 {
+					return fmt.Errorf("invalid trail number %q", args[0])
+				}
+				number = n
+			}
+			return runTrailWatch(cmd, number, jsonOutput, showPings, once)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print each event as a single JSON line")
+	cmd.Flags().BoolVar(&showPings, "show-pings", false, "Print SSE keepalive pings (otherwise suppressed)")
+	cmd.Flags().BoolVar(&once, "once", false, "Drain the initial replay then exit (no reconnect, no live tail)")
+
+	return cmd
+}
+
+func runTrailWatch(cmd *cobra.Command, number int, jsonOutput, showPings, once bool) error {
+	ctx := cmd.Context()
+	w := cmd.OutOrStdout()
+	errW := cmd.ErrOrStderr()
+
+	client, err := NewAuthenticatedAPIClient(trailInsecureHTTP(cmd))
+	if err != nil {
+		return fmt.Errorf("authentication required: %w", err)
+	}
+
+	host, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	if err != nil {
+		return fmt.Errorf("failed to resolve repository: %w", err)
+	}
+
+	// Resolve trail number if not provided: look it up by current branch.
+	if number == 0 {
+		branch, err := GetCurrentBranch(ctx)
+		if err != nil {
+			return fmt.Errorf("no trail number given and current branch is unknown: %w", err)
+		}
+		found, err := findTrailByBranch(ctx, client, host, owner, repo, branch)
+		if err != nil {
+			return err
+		}
+		if found == nil {
+			return fmt.Errorf("no trail found for branch %q (pass an explicit trail number)", branch)
+		}
+		if found.Number <= 0 {
+			return fmt.Errorf("trail for branch %q has no numeric identifier yet", branch)
+		}
+		number = found.Number
+	}
+
+	streamPath := fmt.Sprintf("%s/%d/code-review/stream", trailsBasePath(host, owner, repo), number)
+
+	fmt.Fprintf(errW, "Watching trail #%d on %s/%s/%s — Ctrl+C to stop\n", number, host, owner, repo)
+
+	backoff := reconnectBackoffInitial
+	lastEventID := ""
+	resumed := false
+
+	for {
+		closeReason, lastSeenID, err := streamOnce(ctx, client, streamPath, lastEventID, resumed, jsonOutput, showPings, once, w, errW)
+		if lastSeenID != "" {
+			lastEventID = lastSeenID
+		}
+
+		// Context cancelled (Ctrl+C) — exit cleanly.
+		if ctx.Err() != nil {
+			return nil //nolint:nilerr // ctx.Err() is the expected cancellation path; surface as clean exit
+		}
+
+		switch closeReason {
+		case streamCloseDeleted, streamCloseDone:
+			return nil
+		case streamCloseReconnect:
+			// Clean server-initiated reconnect (max_duration). No backoff.
+			resumed = true
+			backoff = reconnectBackoffInitial
+			continue
+		case streamCloseError:
+			// Server emitted `event: error` — reconnect with backoff.
+			fmt.Fprintf(errW, "stream error reported by server, reconnecting in %s\n", backoff)
+		case streamCloseTransport:
+			// Network/transport error.
+			if err != nil {
+				fmt.Fprintf(errW, "stream disconnected (%v), reconnecting in %s\n", err, backoff)
+			}
+		}
+
+		// Sleep with cancellation.
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > reconnectBackoffCap {
+			backoff = reconnectBackoffCap
+		}
+		resumed = true
+	}
+}
+
+type streamCloseReason int
+
+const (
+	streamCloseTransport streamCloseReason = iota // network/transport error
+	streamCloseReconnect                          // server `event: reconnect`
+	streamCloseDeleted                            // server `event: deleted`
+	streamCloseError                              // server `event: error`
+	streamCloseDone                               // local --once / EOF after replay
+)
+
+// streamOnce opens a single SSE connection, prints events until it closes for
+// any reason, and returns the close reason plus the last `id:` observed (so
+// the caller can pass it as `Last-Event-ID` on reconnect).
+//
+//nolint:cyclop,gocognit // SSE framing parser is naturally branchy; splitting hurts readability
+func streamOnce(
+	ctx context.Context,
+	client *api.Client,
+	path string,
+	lastEventID string,
+	resumed bool,
+	jsonOutput, showPings, once bool,
+	w, errW io.Writer,
+) (streamCloseReason, string, error) {
+	headers := http.Header{}
+	headers.Set("Accept", "text/event-stream")
+	headers.Set("Cache-Control", "no-cache")
+	if lastEventID != "" {
+		headers.Set("Last-Event-ID", lastEventID)
+	} else if resumed {
+		// First reconnect after a transport error with no id seen: use the
+		// query-param form to suppress replay anyway.
+		path += "?replay=false"
+	}
+
+	resp, err := client.GetStream(ctx, path, headers)
+	if err != nil {
+		return streamCloseTransport, "", fmt.Errorf("open SSE stream: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := checkTrailResponse(resp); err != nil {
+		// 401/403/429/etc. — surface and don't auto-reconnect on auth errors.
+		if api.IsHTTPErrorStatus(err, http.StatusUnauthorized) ||
+			api.IsHTTPErrorStatus(err, http.StatusForbidden) {
+			return streamCloseDone, "", err
+		}
+		return streamCloseTransport, "", err
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	// SSE frames can be larger than the default 64KiB scanner buffer when a
+	// trail has long comment bodies; bump to 1 MiB to match the API's
+	// per-comment limits.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+
+	var (
+		eventName    string
+		dataLines    []string
+		eventID      string // id of the in-progress frame (reset on flush)
+		lastSeenID   string // most recent id from a ready/comment/comment_deleted frame
+		seenReady    bool
+		remainReplay int  // --once: comment events still to drain after ready
+		onceExitNext bool // --once: exit after this flush
+	)
+
+	flush := func() (streamCloseReason, bool) {
+		defer func() {
+			eventName = ""
+			dataLines = nil
+			eventID = ""
+		}()
+		if eventName == "" && len(dataLines) == 0 {
+			return streamCloseTransport, false
+		}
+		data := strings.Join(dataLines, "\n")
+		printSSEEvent(w, errW, eventName, data, jsonOutput)
+
+		if eventID != "" {
+			lastSeenID = eventID
+		}
+
+		switch eventName {
+		case sseEventReady:
+			seenReady = true
+			if once {
+				var p struct {
+					CommentCount int  `json:"commentCount"`
+					Resumed      bool `json:"resumed"`
+				}
+				if jerr := json.Unmarshal([]byte(data), &p); jerr != nil {
+					fmt.Fprintf(errW, "warn: malformed ready payload: %v\n", jerr)
+				}
+				if p.Resumed || p.CommentCount == 0 {
+					onceExitNext = true
+				} else {
+					remainReplay = p.CommentCount
+				}
+			}
+		case sseEventComment:
+			if once && seenReady && remainReplay > 0 {
+				remainReplay--
+				if remainReplay == 0 {
+					onceExitNext = true
+				}
+			}
+		case sseEventReconnect:
+			return streamCloseReconnect, true
+		case sseEventDeleted:
+			return streamCloseDeleted, true
+		case sseEventError:
+			return streamCloseError, true
+		}
+		if onceExitNext {
+			return streamCloseDone, true
+		}
+		return streamCloseTransport, false
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Blank line dispatches the event.
+		if line == "" {
+			if reason, done := flush(); done {
+				return reason, lastSeenID, nil
+			}
+			continue
+		}
+
+		// Comment / keepalive line.
+		if strings.HasPrefix(line, ":") {
+			if showPings {
+				fmt.Fprintln(errW, "ping:", strings.TrimPrefix(line, ":"))
+			}
+			continue
+		}
+
+		field, value, ok := strings.Cut(line, ":")
+		if !ok {
+			// Field-only line (no colon) — per spec the value is empty.
+			field = line
+			value = ""
+		}
+		// Per SSE spec: a single leading space after the colon is ignored.
+		value = strings.TrimPrefix(value, " ")
+
+		switch field {
+		case "event":
+			eventName = value
+		case "data":
+			dataLines = append(dataLines, value)
+		case "id":
+			eventID = value
+		case "retry":
+			// Ignored — we manage backoff client-side.
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		// Context cancellation surfaces here as a wrapped "context canceled".
+		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+			return streamCloseDone, lastSeenID, nil
+		}
+		return streamCloseTransport, lastSeenID, fmt.Errorf("read SSE stream: %w", err)
+	}
+	return streamCloseTransport, lastSeenID, io.ErrUnexpectedEOF
+}
+
+// printSSEEvent renders a single SSE event in either human-readable or
+// json-line form. `data` may be empty (e.g. for the rare frame with only an
+// `event:` line) — we still print something so the caller sees it.
+func printSSEEvent(w, errW io.Writer, eventName, data string, jsonOutput bool) {
+	if jsonOutput {
+		// Emit a JSON envelope so consumers can reliably parse with
+		// `jq`/scripts. The data field is preserved verbatim if it isn't
+		// valid JSON; otherwise it's inlined as a sub-object.
+		envelope := map[string]any{"event": eventName}
+		if data != "" {
+			var sub any
+			if err := json.Unmarshal([]byte(data), &sub); err == nil {
+				envelope["data"] = sub
+			} else {
+				envelope["data"] = data
+			}
+		}
+		out, err := json.Marshal(envelope)
+		if err != nil {
+			fmt.Fprintf(errW, "failed to marshal event: %v\n", err)
+			return
+		}
+		fmt.Fprintln(w, string(out))
+		return
+	}
+
+	switch eventName {
+	case sseEventReady:
+		var p struct {
+			Repo         string `json:"repo"`
+			TrailNumber  int    `json:"trailNumber"`
+			CommentCount int    `json:"commentCount"`
+			Resumed      bool   `json:"resumed"`
+		}
+		if err := json.Unmarshal([]byte(data), &p); err == nil {
+			if p.Resumed {
+				fmt.Fprintf(w, "● connected to %s trail #%d (resumed; %d comment(s))\n",
+					p.Repo, p.TrailNumber, p.CommentCount)
+			} else {
+				fmt.Fprintf(w, "● connected to %s trail #%d (%d comment(s))\n",
+					p.Repo, p.TrailNumber, p.CommentCount)
+			}
+			return
+		}
+	case sseEventComment:
+		var p struct {
+			UpdatedAt time.Time     `json:"updatedAt"`
+			Comment   trail.Comment `json:"comment"`
+		}
+		if err := json.Unmarshal([]byte(data), &p); err == nil {
+			ts := p.UpdatedAt.Local().Format("15:04:05")
+			body := truncateForLog(p.Comment.Body, 200)
+			fmt.Fprintf(w, "[%s] %s: %s\n", ts, p.Comment.Author, body)
+			for _, r := range p.Comment.Replies {
+				fmt.Fprintf(w, "    └─ %s: %s\n", r.Author, truncateForLog(r.Body, 200))
+			}
+			return
+		}
+	case sseEventCommentDeleted:
+		var p struct {
+			UpdatedAt time.Time `json:"updatedAt"`
+			CommentID string    `json:"commentId"`
+		}
+		if err := json.Unmarshal([]byte(data), &p); err == nil {
+			ts := p.UpdatedAt.Local().Format("15:04:05")
+			fmt.Fprintf(w, "[%s] (deleted comment %s)\n", ts, p.CommentID)
+			return
+		}
+	case sseEventReconnect:
+		fmt.Fprintln(errW, "↻ server requested reconnect")
+		return
+	case sseEventDeleted:
+		fmt.Fprintln(errW, "✖ trail was deleted")
+		return
+	case sseEventError:
+		var p struct {
+			Message string `json:"message"`
+		}
+		if jerr := json.Unmarshal([]byte(data), &p); jerr != nil {
+			// Best-effort: server payload may be missing or malformed; we still
+			// want to surface that an error event arrived.
+			fmt.Fprintf(errW, "warn: malformed error payload: %v\n", jerr)
+		}
+		if p.Message != "" {
+			fmt.Fprintf(errW, "✖ stream error: %s\n", p.Message)
+		} else {
+			fmt.Fprintln(errW, "✖ stream error")
+		}
+		return
+	}
+
+	// Fallback for unknown events or unparseable payloads: print raw.
+	fmt.Fprintf(w, "%s: %s\n", eventName, data)
+}
+
+// truncateForLog clips body text on a rune boundary so a single multi-line
+// comment doesn't blow up the watch view. Newlines collapse to spaces.
+func truncateForLog(s string, maxRunes int) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	rs := []rune(s)
+	if len(rs) <= maxRunes {
+		return s
+	}
+	return string(rs[:maxRunes]) + "…"
+}

--- a/cmd/entire/cli/trail_watch_cmd.go
+++ b/cmd/entire/cli/trail_watch_cmd.go
@@ -30,9 +30,10 @@ const (
 	sseEventError          = "error"
 )
 
-// reconnectBackoffMin / Max bound the exponential backoff used after network
-// errors. The server's max stream duration (~50s) closes cleanly with an
-// `event: reconnect`; in that case we reconnect immediately with no backoff.
+// reconnectBackoffInitial / reconnectBackoffCap bound the exponential backoff
+// used after network errors. The server's max stream duration (~50s) closes
+// cleanly with an `event: reconnect`; in that case we reconnect immediately
+// with no backoff.
 const (
 	reconnectBackoffInitial = 500 * time.Millisecond
 	reconnectBackoffCap     = 30 * time.Second
@@ -250,7 +251,7 @@ func streamOnce(
 		eventName    string
 		dataLines    []string
 		eventID      string // id of the in-progress frame (reset on flush)
-		lastSeenID   string // most recent id from a ready/comment/comment_deleted frame
+		lastSeenID   string // most recent SSE id from any frame that includes one
 		seenReady    bool
 		remainReplay int  // --once: comment events still to drain after ready
 		onceExitNext bool // --once: exit after this flush
@@ -281,7 +282,7 @@ func streamOnce(
 					Resumed      bool `json:"resumed"`
 				}
 				if jerr := json.Unmarshal([]byte(data), &p); jerr != nil {
-					fmt.Fprintf(errW, "warn: malformed ready payload: %v\n", jerr)
+					fmt.Fprintf(errW, "Warning: malformed ready payload: %v\n", jerr)
 				}
 				if p.Resumed || p.CommentCount == 0 {
 					onceExitNext = true
@@ -323,7 +324,7 @@ func streamOnce(
 		// Comment / keepalive line.
 		if strings.HasPrefix(line, ":") {
 			if showPings {
-				fmt.Fprintln(errW, "ping:", strings.TrimPrefix(line, ":"))
+				fmt.Fprintln(errW, "ping:", strings.TrimSpace(strings.TrimPrefix(line, ":")))
 			}
 			continue
 		}
@@ -440,7 +441,7 @@ func printSSEEvent(w, errW io.Writer, eventName, data string, jsonOutput bool) {
 		if jerr := json.Unmarshal([]byte(data), &p); jerr != nil {
 			// Best-effort: server payload may be missing or malformed; we still
 			// want to surface that an error event arrived.
-			fmt.Fprintf(errW, "warn: malformed error payload: %v\n", jerr)
+			fmt.Fprintf(errW, "Warning: malformed error payload: %v\n", jerr)
 		}
 		if p.Message != "" {
 			fmt.Fprintf(errW, "✖ stream error: %s\n", p.Message)

--- a/cmd/entire/cli/trail_watch_cmd.go
+++ b/cmd/entire/cli/trail_watch_cmd.go
@@ -136,6 +136,8 @@ func runTrailWatch(cmd *cobra.Command, number int, jsonOutput, showPings, once b
 		}
 
 		switch closeReason {
+		case streamCloseTerminal:
+			return err
 		case streamCloseDeleted, streamCloseDone:
 			return nil
 		case streamCloseReconnect:
@@ -175,7 +177,28 @@ const (
 	streamCloseDeleted                            // server `event: deleted`
 	streamCloseError                              // server `event: error`
 	streamCloseDone                               // local --once / EOF after replay
+	streamCloseTerminal                           // non-recoverable HTTP status (401/403/404/410)
 )
+
+// terminalHTTPStatuses are HTTP response codes for which retrying the SSE
+// stream cannot succeed: auth failures (401/403) and resource-not-found-style
+// errors (404/410). 429 is intentionally *not* terminal — it's a transient
+// rate-limit signal that should back off and retry.
+var terminalHTTPStatuses = [...]int{
+	http.StatusUnauthorized, // 401
+	http.StatusForbidden,    // 403
+	http.StatusNotFound,     // 404
+	http.StatusGone,         // 410
+}
+
+func isTerminalHTTPError(err error) bool {
+	for _, code := range terminalHTTPStatuses {
+		if api.IsHTTPErrorStatus(err, code) {
+			return true
+		}
+	}
+	return false
+}
 
 // streamOnce opens a single SSE connection, prints events until it closes for
 // any reason, and returns the close reason plus the last `id:` observed (so
@@ -209,10 +232,10 @@ func streamOnce(
 	defer resp.Body.Close()
 
 	if err := checkTrailResponse(resp); err != nil {
-		// 401/403/429/etc. — surface and don't auto-reconnect on auth errors.
-		if api.IsHTTPErrorStatus(err, http.StatusUnauthorized) ||
-			api.IsHTTPErrorStatus(err, http.StatusForbidden) {
-			return streamCloseDone, "", err
+		// Terminal: surface the error and don't reconnect. 429 deliberately
+		// falls through to streamCloseTransport so the caller backs off.
+		if isTerminalHTTPError(err) {
+			return streamCloseTerminal, "", err
 		}
 		return streamCloseTransport, "", err
 	}

--- a/cmd/entire/cli/trail_watch_cmd_test.go
+++ b/cmd/entire/cli/trail_watch_cmd_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+)
+
+// fakeSSEServer streams a fixed sequence of frames with optional terminal
+// behavior and records the Last-Event-ID header sent by the client.
+func fakeSSEServer(t *testing.T, frames []string) (*httptest.Server, *string) {
+	t.Helper()
+	var lastEventID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastEventID = r.Header.Get("Last-Event-ID")
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("ResponseWriter is not a Flusher")
+			return
+		}
+		for _, f := range frames {
+			if _, err := fmt.Fprint(w, f); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}))
+	return srv, &lastEventID
+}
+
+func TestStreamOnce_PrintsReadyAndComment(t *testing.T) {
+	frames := []string{
+		"event: ready\ndata: {\"repo\":\"acme/web\",\"trailNumber\":42,\"commentCount\":1,\"resumed\":false}\nid: 1700000000000:ready\n\n",
+		"event: comment\ndata: {\"repo\":\"acme/web\",\"trailNumber\":42,\"updatedAt\":\"2026-01-01T00:00:00Z\",\"comment\":{\"id\":\"c1\",\"author\":\"alice\",\"body\":\"hello world\",\"created_at\":\"2026-01-01T00:00:00Z\",\"resolved\":false,\"resolved_by\":null,\"resolved_at\":null}}\nid: 1700000000000:c1\n\n",
+	}
+	srv, _ := fakeSSEServer(t, frames)
+	defer srv.Close()
+
+	t.Setenv(api.BaseURLEnvVar, srv.URL)
+	client := api.NewClient("tok")
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	reason, lastID, err := streamOnce(ctx, client, "/stream", "", false, false, false, true, &stdout, &stderr)
+	// `--once` with commentCount=1 should exit cleanly after seeing ready+comment.
+	if err != nil {
+		t.Fatalf("streamOnce error: %v", err)
+	}
+	if reason != streamCloseDone {
+		t.Errorf("close reason = %d, want streamCloseDone", reason)
+	}
+	if lastID != "1700000000000:c1" {
+		t.Errorf("lastID = %q, want %q", lastID, "1700000000000:c1")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "trail #42") {
+		t.Errorf("expected ready summary in output, got: %q", out)
+	}
+	if !strings.Contains(out, "alice") || !strings.Contains(out, "hello world") {
+		t.Errorf("expected comment line in output, got: %q", out)
+	}
+}
+
+func TestStreamOnce_JSONOutputEnvelope(t *testing.T) {
+	frames := []string{
+		"event: ready\ndata: {\"commentCount\":0}\nid: x\n\n",
+	}
+	srv, _ := fakeSSEServer(t, frames)
+	defer srv.Close()
+
+	t.Setenv(api.BaseURLEnvVar, srv.URL)
+	client := api.NewClient("tok")
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if _, _, err := streamOnce(ctx, client, "/stream", "", false, true, false, true, &stdout, &stderr); err != nil {
+		t.Fatalf("streamOnce error: %v", err)
+	}
+
+	line := strings.TrimSpace(stdout.String())
+	var env map[string]any
+	if err := json.Unmarshal([]byte(line), &env); err != nil {
+		t.Fatalf("output is not JSON: %v\nline=%q", err, line)
+	}
+	if env["event"] != "ready" {
+		t.Errorf("event = %v, want ready", env["event"])
+	}
+}
+
+func TestStreamOnce_ReconnectEvent(t *testing.T) {
+	frames := []string{
+		"event: ready\ndata: {\"commentCount\":0}\nid: r1\n\n",
+		"event: reconnect\ndata: {\"reason\":\"max_duration\"}\n\n",
+	}
+	srv, _ := fakeSSEServer(t, frames)
+	defer srv.Close()
+
+	t.Setenv(api.BaseURLEnvVar, srv.URL)
+	client := api.NewClient("tok")
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	reason, lastID, err := streamOnce(ctx, client, "/stream", "", false, false, false, false, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("streamOnce error: %v", err)
+	}
+	if reason != streamCloseReconnect {
+		t.Errorf("reason = %d, want streamCloseReconnect", reason)
+	}
+	if lastID != "r1" {
+		t.Errorf("lastID = %q, want r1 (reconnect frame has no id; should preserve last ready id)", lastID)
+	}
+}
+
+func TestStreamOnce_SendsLastEventIDHeader(t *testing.T) {
+	frames := []string{
+		"event: deleted\ndata: {}\n\n",
+	}
+	srv, gotLastID := fakeSSEServer(t, frames)
+	defer srv.Close()
+
+	t.Setenv(api.BaseURLEnvVar, srv.URL)
+	client := api.NewClient("tok")
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if _, _, err := streamOnce(ctx, client, "/stream", "abc:c1", true, false, false, false, &stdout, &stderr); err != nil {
+		t.Fatalf("streamOnce error: %v", err)
+	}
+	if *gotLastID != "abc:c1" {
+		t.Errorf("server saw Last-Event-ID = %q, want %q", *gotLastID, "abc:c1")
+	}
+}

--- a/cmd/entire/cli/trail_watch_cmd_test.go
+++ b/cmd/entire/cli/trail_watch_cmd_test.go
@@ -101,6 +101,29 @@ func TestStreamOnce_JSONOutputEnvelope(t *testing.T) {
 	}
 }
 
+func TestStreamOnce_ShowPingsTrimsSSECommentWhitespace(t *testing.T) {
+	frames := []string{
+		": ping 123\n",
+	}
+	srv, _ := fakeSSEServer(t, frames)
+	defer srv.Close()
+
+	t.Setenv(api.BaseURLEnvVar, srv.URL)
+	client := api.NewClient("tok")
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, _, err := streamOnce(ctx, client, "/stream", "", false, false, true, false, &stdout, &stderr)
+	if err == nil {
+		t.Errorf("expected EOF after fixed test stream")
+	}
+	if got := stderr.String(); !strings.Contains(got, "ping: ping 123\n") {
+		t.Errorf("stderr = %q, want trimmed ping output", got)
+	}
+}
+
 func TestStreamOnce_ReconnectEvent(t *testing.T) {
 	frames := []string{
 		"event: ready\ndata: {\"commentCount\":0}\nid: r1\n\n",

--- a/cmd/entire/cli/trail_watch_cmd_test.go
+++ b/cmd/entire/cli/trail_watch_cmd_test.go
@@ -128,6 +128,65 @@ func TestStreamOnce_ReconnectEvent(t *testing.T) {
 	}
 }
 
+func TestStreamOnce_TerminalHTTPStatusesDoNotReconnect(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+	}{
+		{"unauthorized", http.StatusUnauthorized},
+		{"forbidden", http.StatusForbidden},
+		{"not_found", http.StatusNotFound},
+		{"gone", http.StatusGone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.code)
+				_, _ = fmt.Fprintf(w, "{\"error\":\"%s\"}", http.StatusText(tc.code))
+			}))
+			defer srv.Close()
+
+			t.Setenv(api.BaseURLEnvVar, srv.URL)
+			client := api.NewClient("tok")
+
+			var stdout, stderr bytes.Buffer
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			reason, _, err := streamOnce(ctx, client, "/stream", "", false, false, false, false, &stdout, &stderr)
+			if reason != streamCloseTerminal {
+				t.Errorf("reason = %d, want streamCloseTerminal for %d", reason, tc.code)
+			}
+			if err == nil {
+				t.Errorf("want non-nil error for HTTP %d", tc.code)
+			}
+		})
+	}
+}
+
+func TestStreamOnce_TooManyRequestsIsRecoverable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"error":"rate limited"}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv(api.BaseURLEnvVar, srv.URL)
+	client := api.NewClient("tok")
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	reason, _, err := streamOnce(ctx, client, "/stream", "", false, false, false, false, &stdout, &stderr)
+	if reason != streamCloseTransport {
+		t.Errorf("reason = %d, want streamCloseTransport (429 should be retryable)", reason)
+	}
+	if err == nil {
+		t.Errorf("want non-nil error so caller can log the backoff reason")
+	}
+}
+
 func TestStreamOnce_SendsLastEventIDHeader(t *testing.T) {
 	frames := []string{
 		"event: deleted\ndata: {}\n\n",


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/348
<!-- entire-trail-link-end -->

## Summary

Adds `entire trail watch` for the Trail code-review SSE endpoint introduced in entirehq/entire.io#1888.

- Resolves the Trail number from the current branch when omitted
- Streams `ready`, `comment`, `comment_deleted`, `reconnect`, `deleted`, and `error` events
- Supports `--json` for automation/Pi integrations, `--once` for draining replay, and `--show-pings` for keepalive debugging
- Reconnects immediately on server `reconnect` events and uses exponential backoff for transient transport/server errors
- Propagates `Last-Event-ID` across reconnects and uses `?replay=false` when reconnecting before any id was seen
- Treats 401/403/404/410 as terminal errors while keeping 429 retryable
- Adds `api.Client.GetStream` for authenticated streaming GETs with custom headers

## Review notes

I re-reviewed the implementation before opening this PR. The command is intentionally named `trail watch` for now; help text scopes it to code-review discussion/comments.

## Verification

- `mise run fmt`
- `mise run lint`
- `env -u PI_CODING_AGENT mise run test`

Note: plain `mise run test` under this Pi agent harness sets `PI_CODING_AGENT=true`, which trips an existing environment-sensitive interactive test that expects only `GIT_TERMINAL_PROMPT=1` to be set. Rerunning with that harness sentinel removed passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new SSE-based streaming command with reconnection/backoff and last-event-id resume logic, which could affect CLI behavior under network errors and API status handling. No authentication/authorization logic changes, but introduces new long-lived HTTP request patterns.
> 
> **Overview**
> Adds `entire trail watch` to live-tail a trail’s code-review discussion via the API’s Server-Sent Events stream, including optional trail-number resolution from the current branch and support for `--json`, `--once`, and `--show-pings` output modes.
> 
> Implements an SSE parser and reconnect loop that preserves `Last-Event-ID`, reconnects immediately on server `reconnect` events, backs off on transport/server errors, and treats HTTP `401/403/404/410` as terminal while keeping `429` retryable. Extends the API client with `Client.GetStream` to issue authenticated streaming GET requests with custom headers, and adds focused tests around SSE parsing/output and status-code behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b37565cc92ee788da99ddd8dfcd86b424015be92. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->