### PR TITLE
Fix failed commit bug during checkpoints v2 migrations 

### DIFF
--- a/cmd/entire/cli/checkpoint/parse_tree.go
+++ b/cmd/entire/cli/checkpoint/parse_tree.go
@@ -211,18 +211,13 @@ func ApplyTreeChanges(
 		return rootTreeHash, nil
 	}
 
-	// Read the current root tree. Fall back to `git ls-tree` when go-git can't
-	// read the object: in partial-clone repos a tree can live in a promisor
-	// pack that go-git's storer has lost track of (stale pack index cache),
-	// while the native git CLI still resolves it. See FetchingTree.blobOnDisk
-	// for the analogous blob-side workaround.
 	var currentEntries []object.TreeEntry
 	if rootTreeHash != plumbing.ZeroHash {
 		tree, err := repo.TreeObject(rootTreeHash)
 		if err != nil {
 			cliEntries, cliErr := readTreeEntriesViaCLI(ctx, rootTreeHash)
 			if cliErr != nil {
-				return plumbing.ZeroHash, fmt.Errorf("failed to read tree: %w (CLI fallback also failed: %w)", err, cliErr)
+				return plumbing.ZeroHash, fmt.Errorf("failed to read tree: %w", errors.Join(err, cliErr))
 			}
 			logging.Warn(ctx, "ApplyTreeChanges: go-git tree read failed, used git ls-tree fallback",
 				slog.String("tree", rootTreeHash.String()[:12]),
@@ -310,33 +305,37 @@ func ApplyTreeChanges(
 	return storeTree(repo, result)
 }
 
-// readTreeEntriesViaCLI parses the output of `git ls-tree <hash>` into
-// go-git TreeEntry values. It is a fallback for go-git tree reads that fail
-// in partial-clone repos where the storer's packfile index has gone stale.
+// readTreeEntriesViaCLI parses `git ls-tree <hash>` into go-git TreeEntry
+// values. Fallback for go-git tree reads that fail in partial-clone repos
+// where the storer's packfile index has gone stale — analogous to the
+// blob-side workaround in FetchingTree.blobOnDisk.
 func readTreeEntriesViaCLI(ctx context.Context, hash plumbing.Hash) ([]object.TreeEntry, error) {
+	short := hash.String()[:12]
 	cmd := exec.CommandContext(ctx, "git", "ls-tree", hash.String())
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("git ls-tree %s: %w", hash.String()[:12], err)
+		return nil, fmt.Errorf("git ls-tree %s: %w", short, err)
 	}
-	var entries []object.TreeEntry
-	for _, line := range strings.Split(strings.TrimRight(string(output), "\n"), "\n") {
-		if line == "" {
-			continue
-		}
+	trimmed := strings.TrimRight(string(output), "\n")
+	if trimmed == "" {
+		return nil, nil
+	}
+	lines := strings.Split(trimmed, "\n")
+	entries := make([]object.TreeEntry, 0, len(lines))
+	for _, line := range lines {
 		// Format: "<mode> <type> <hash>\t<name>"
 		tab := strings.IndexByte(line, '\t')
 		if tab < 0 {
-			return nil, fmt.Errorf("git ls-tree %s: malformed line %q", hash.String()[:12], line)
+			return nil, fmt.Errorf("git ls-tree %s: malformed line %q", short, line)
 		}
 		name := line[tab+1:]
 		fields := strings.Fields(line[:tab])
 		if len(fields) != 3 {
-			return nil, fmt.Errorf("git ls-tree %s: malformed entry %q", hash.String()[:12], line)
+			return nil, fmt.Errorf("git ls-tree %s: malformed entry %q", short, line)
 		}
 		mode, modeErr := filemode.New(fields[0])
 		if modeErr != nil {
-			return nil, fmt.Errorf("git ls-tree %s: invalid mode %q: %w", hash.String()[:12], fields[0], modeErr)
+			return nil, fmt.Errorf("git ls-tree %s: invalid mode %q: %w", short, fields[0], modeErr)
 		}
 		entries = append(entries, object.TreeEntry{
 			Name: name,

--- a/cmd/entire/cli/checkpoint/parse_tree.go
+++ b/cmd/entire/cli/checkpoint/parse_tree.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -210,15 +211,28 @@ func ApplyTreeChanges(
 		return rootTreeHash, nil
 	}
 
-	// Read the current root tree
+	// Read the current root tree. Fall back to `git ls-tree` when go-git can't
+	// read the object: in partial-clone repos a tree can live in a promisor
+	// pack that go-git's storer has lost track of (stale pack index cache),
+	// while the native git CLI still resolves it. See FetchingTree.blobOnDisk
+	// for the analogous blob-side workaround.
 	var currentEntries []object.TreeEntry
 	if rootTreeHash != plumbing.ZeroHash {
 		tree, err := repo.TreeObject(rootTreeHash)
 		if err != nil {
-			return plumbing.ZeroHash, fmt.Errorf("failed to read tree: %w", err)
+			cliEntries, cliErr := readTreeEntriesViaCLI(ctx, rootTreeHash)
+			if cliErr != nil {
+				return plumbing.ZeroHash, fmt.Errorf("failed to read tree: %w (CLI fallback also failed: %w)", err, cliErr)
+			}
+			logging.Warn(ctx, "ApplyTreeChanges: go-git tree read failed, used git ls-tree fallback",
+				slog.String("tree", rootTreeHash.String()[:12]),
+				slog.String("gogit_error", err.Error()),
+			)
+			currentEntries = cliEntries
+		} else {
+			currentEntries = make([]object.TreeEntry, len(tree.Entries))
+			copy(currentEntries, tree.Entries)
 		}
-		currentEntries = make([]object.TreeEntry, len(tree.Entries))
-		copy(currentEntries, tree.Entries)
 	}
 
 	// Group changes by first path segment
@@ -294,6 +308,43 @@ func ApplyTreeChanges(
 	}
 	sortTreeEntries(result)
 	return storeTree(repo, result)
+}
+
+// readTreeEntriesViaCLI parses the output of `git ls-tree <hash>` into
+// go-git TreeEntry values. It is a fallback for go-git tree reads that fail
+// in partial-clone repos where the storer's packfile index has gone stale.
+func readTreeEntriesViaCLI(ctx context.Context, hash plumbing.Hash) ([]object.TreeEntry, error) {
+	cmd := exec.CommandContext(ctx, "git", "ls-tree", hash.String())
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-tree %s: %w", hash.String()[:12], err)
+	}
+	var entries []object.TreeEntry
+	for _, line := range strings.Split(strings.TrimRight(string(output), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		// Format: "<mode> <type> <hash>\t<name>"
+		tab := strings.IndexByte(line, '\t')
+		if tab < 0 {
+			return nil, fmt.Errorf("git ls-tree %s: malformed line %q", hash.String()[:12], line)
+		}
+		name := line[tab+1:]
+		fields := strings.Fields(line[:tab])
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("git ls-tree %s: malformed entry %q", hash.String()[:12], line)
+		}
+		mode, modeErr := filemode.New(fields[0])
+		if modeErr != nil {
+			return nil, fmt.Errorf("git ls-tree %s: invalid mode %q: %w", hash.String()[:12], fields[0], modeErr)
+		}
+		entries = append(entries, object.TreeEntry{
+			Name: name,
+			Mode: mode,
+			Hash: plumbing.NewHash(fields[2]),
+		})
+	}
+	return entries, nil
 }
 
 // WalkCheckpointShards iterates over the two-level shard structure (<id[:2]>/<id[2:]>/)

--- a/cmd/entire/cli/checkpoint/v2_store.go
+++ b/cmd/entire/cli/checkpoint/v2_store.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -127,7 +128,7 @@ func (s *V2GitStore) GetRefState(refName plumbing.ReferenceName) (parentHash, tr
 	if err != nil {
 		cliTreeHash, cliErr := commitTreeHashViaCLI(context.Background(), ref.Hash())
 		if cliErr != nil {
-			return plumbing.ZeroHash, plumbing.ZeroHash, fmt.Errorf("failed to get commit for ref %s: %w (CLI fallback also failed: %w)", refName, err, cliErr)
+			return plumbing.ZeroHash, plumbing.ZeroHash, fmt.Errorf("failed to get commit for ref %s: %w", refName, errors.Join(err, cliErr))
 		}
 		logging.Warn(context.Background(), "GetRefState: go-git commit read failed, used git rev-parse fallback",
 			slog.String("ref", refName.String()),

--- a/cmd/entire/cli/checkpoint/v2_store.go
+++ b/cmd/entire/cli/checkpoint/v2_store.go
@@ -3,7 +3,12 @@ package checkpoint
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
 	"sync"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -109,6 +114,9 @@ func (s *V2GitStore) ensureRef(ctx context.Context, refName plumbing.ReferenceNa
 }
 
 // GetRefState returns the parent commit hash and root tree hash for a ref.
+// Falls back to `git rev-parse <hash>^{tree}` when go-git can't load the
+// commit object — same partial-clone / stale-packfile-cache reason as
+// readTreeEntriesViaCLI in parse_tree.go.
 func (s *V2GitStore) GetRefState(refName plumbing.ReferenceName) (parentHash, treeHash plumbing.Hash, err error) {
 	ref, err := s.repo.Reference(refName, true)
 	if err != nil {
@@ -117,10 +125,34 @@ func (s *V2GitStore) GetRefState(refName plumbing.ReferenceName) (parentHash, tr
 
 	commit, err := s.repo.CommitObject(ref.Hash())
 	if err != nil {
-		return plumbing.ZeroHash, plumbing.ZeroHash, fmt.Errorf("failed to get commit for ref %s: %w", refName, err)
+		cliTreeHash, cliErr := commitTreeHashViaCLI(context.Background(), ref.Hash())
+		if cliErr != nil {
+			return plumbing.ZeroHash, plumbing.ZeroHash, fmt.Errorf("failed to get commit for ref %s: %w (CLI fallback also failed: %w)", refName, err, cliErr)
+		}
+		logging.Warn(context.Background(), "GetRefState: go-git commit read failed, used git rev-parse fallback",
+			slog.String("ref", refName.String()),
+			slog.String("commit", ref.Hash().String()[:12]),
+			slog.String("gogit_error", err.Error()),
+		)
+		return ref.Hash(), cliTreeHash, nil
 	}
 
 	return ref.Hash(), commit.TreeHash, nil
+}
+
+// commitTreeHashViaCLI resolves the tree hash of a commit via
+// `git rev-parse <hash>^{tree}`. See GetRefState for the rationale.
+func commitTreeHashViaCLI(ctx context.Context, commitHash plumbing.Hash) (plumbing.Hash, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", commitHash.String()+"^{tree}")
+	output, err := cmd.Output()
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("git rev-parse %s^{tree}: %w", commitHash.String()[:12], err)
+	}
+	hex := strings.TrimSpace(string(output))
+	if hex == "" {
+		return plumbing.ZeroHash, fmt.Errorf("git rev-parse %s^{tree}: empty output", commitHash.String()[:12])
+	}
+	return plumbing.NewHash(hex), nil
 }
 
 // updateRef creates a new commit on a ref with the given tree, updating the ref to point to it.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/354
<!-- entire-trail-link-end -->

 ## Summary

  `entire migrate --checkpoints v2` was failing partway through on partial-clone repos because go-git's pack-index cache occasionally loses track of objects that live in promisor packs. Native
   `git` resolves the same hashes fine. This branch adds CLI fallbacks at the two call sites that produced the failures.

  ### Errors fixed

  Migrate would crash with one of these (the specific symptom shifts with go-git's pack-cache state between runs):

  failed to write batched v2 /main entries: failed to get commit for ref refs/entire/checkpoints/v2/main: object not found

  failed to write batched v2 /main entries: failed to apply batched /main checkpoint trees: failed to apply changes in 3b: failed to read tree: packfile not found

  failed to write batched v2 /main entries: failed to get commit for ref refs/entire/checkpoints/v2/main: packfile not found

  ### Fix

  - **`checkpoint/parse_tree.go`** — in `ApplyTreeChanges`, if `repo.TreeObject(rootTreeHash)` fails, fall back to `git ls-tree <hash>` via a new `readTreeEntriesViaCLI` helper that parses
  each line into `[]object.TreeEntry`.
  - **`checkpoint/v2_store.go`** — in `GetRefState`, if `repo.CommitObject(ref.Hash())` fails, fall back to `git rev-parse <hash>^{tree}` via a new `commitTreeHashViaCLI` helper to recover
  just the tree hash (all the caller needs).

  Both fallbacks emit a single `logging.Warn` so we can see in `entire doctor logs` how often the path fires, and `errors.Join` both errors when even the CLI can't resolve the object so the
  original go-git error is preserved. Same pattern as the blob-side workaround in `FetchingTree.blobOnDisk` / `readFileViaGit`.

  ## Test plan

  - [x] `mise run check` (fmt + lint + unit + integration + e2e canary) — all 58 + 4 tests pass.
  - [x] `./entire migrate --checkpoints v2` against the local repo where the bug originally reproduced — migration completes, `/main` advances, no shard left unwritten.
  - [ ] Verify the warn lines appear in `.entire/logs/entire.log` next time go-git's pack cache wedges (couldn't force the trigger; the path is wired into the exact failure sites, but didn't
  fire during the validation run because go-git's state self-corrected).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new fallback paths that shell out to `git` when go-git cannot read commit/tree objects, which changes behavior in object resolution and adds reliance on external command execution during migrations.
> 
> **Overview**
> Fixes v2 checkpoint migration failures in partial-clone repos by adding **CLI fallbacks when go-git can’t load objects**.
> 
> `ApplyTreeChanges` now falls back to `git ls-tree` to read tree entries, and `V2GitStore.GetRefState` falls back to `git rev-parse <commit>^{tree}` to recover the tree hash; both paths emit a `logging.Warn` and join errors when the fallback also fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2123cb3aab088b9ff230284d636b0fb258bab968. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->