### PR TITLE
Remove --force flag from `entire migrate --checkpoints v2`

### DIFF
--- a/cmd/entire/cli/migrate.go
+++ b/cmd/entire/cli/migrate.go
@@ -38,7 +38,6 @@ import (
 
 func newMigrateCmd() *cobra.Command {
 	var checkpointsFlag string
-	var forceFlag bool
 	var dryRunFlag bool
 
 	cmd := &cobra.Command{
@@ -52,9 +51,6 @@ func newMigrateCmd() *cobra.Command {
 			}
 			if checkpointsFlag != "v2" {
 				return fmt.Errorf("unsupported checkpoints version: %q (only \"v2\" is supported)", checkpointsFlag)
-			}
-			if dryRunFlag && forceFlag {
-				return errors.New("--dry-run and --force cannot be combined")
 			}
 
 			ctx := cmd.Context()
@@ -82,12 +78,11 @@ func newMigrateCmd() *cobra.Command {
 				return runMigrateCheckpointsV2DryRun(ctx, cmd)
 			}
 
-			return runMigrateCheckpointsV2(ctx, cmd, forceFlag)
+			return runMigrateCheckpointsV2(ctx, cmd)
 		},
 	}
 
 	cmd.Flags().StringVar(&checkpointsFlag, "checkpoints", "", "Target checkpoint format version (e.g., \"v2\")")
-	cmd.Flags().BoolVar(&forceFlag, "force", false, "Force re-migration of all checkpoints, overwriting existing v2 data")
 	cmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "List v1 checkpoints not yet in v2 without migrating")
 
 	return cmd
@@ -141,7 +136,7 @@ type migrateResult struct {
 	compactTranscriptSkipped int
 }
 
-func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool) error {
+func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command) error {
 	repo, err := strategy.OpenRepository(ctx)
 	if err != nil {
 		cmd.SilenceUsage = true
@@ -160,7 +155,7 @@ func runMigrateCheckpointsV2(ctx context.Context, cmd *cobra.Command, force bool
 	ctx, rootSpan := perf.Start(ctx, "migrate_checkpoints")
 	defer rootSpan.End()
 
-	result, freshlyPackedRefs, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, progressOut, force)
+	result, freshlyPackedRefs, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, progressOut)
 	if err != nil {
 		rootSpan.RecordError(err)
 		return err
@@ -404,7 +399,7 @@ type migratedFullSession struct {
 
 // migrateCheckpointsV2 returns the /full/<n> refs migration wrote so callers
 // can pass them as exclusions to the generation-metadata repair pass.
-func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, progressOut io.Writer, force bool) (*migrateResult, []plumbing.ReferenceName, error) {
+func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, progressOut io.Writer) (*migrateResult, []plumbing.ReferenceName, error) {
 	_, listSpan := perf.Start(ctx, "list_v1_checkpoints")
 	v1List, err := v1Store.ListCommitted(ctx)
 	if err != nil {
@@ -460,7 +455,7 @@ func migrateCheckpointsV2(ctx context.Context, repo *git.Repository, v1Store *ch
 			continue
 		}
 
-		fullCheckpoint, mainOpts, outcome, migrateErr := migrateOneCheckpoint(ctx, repo, v1Store, v2Store, info, existing, force, fullArtifactsIndex, state.compactOffsets)
+		fullCheckpoint, mainOpts, outcome, migrateErr := migrateOneCheckpoint(ctx, repo, v1Store, v2Store, info, existing, fullArtifactsIndex, state.compactOffsets)
 		result.missingSessions += outcome.missingSessions
 		if outcome.compactTranscriptSkipped {
 			result.compactTranscriptSkipped++
@@ -575,8 +570,8 @@ func (s *migrateLoopState) packCurrentBatch(ctx context.Context, repo *git.Repos
 		return err
 	}
 	if s.nextGeneration == 0 {
-		// Resolve the archive slot only when the first full batch is ready;
-		// force migration may prune existing archived refs earlier in the loop.
+		// Resolve the archive slot only when the first full batch is ready,
+		// so no-op reruns skip the ref-iteration.
 		next, err := v2Store.NextGenerationNumber()
 		if err != nil {
 			return fmt.Errorf("list archived v2 generations: %w", err)
@@ -661,12 +656,12 @@ type migrateCheckpointOutcome struct {
 // WriteCommittedOptions alongside the in-memory full-checkpoint structure.
 // The caller batches the /main writes across many checkpoints into a single
 // ref CAS via V2GitStore.WriteCommittedMainBatch. The resume path
-// (already-in-v2 without force) returns nil mainOpts; its /main updates flow
-// through backfillCompactTranscripts which uses UpdateCommitted.
-func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, existing *checkpoint.CheckpointSummary, force bool, fullArtifacts checkpoint.FullSessionArtifactsIndex, compactOffsets *migrateCompactOffsetCache) (*migratedFullCheckpoint, []checkpoint.WriteCommittedOptions, migrateCheckpointOutcome, error) {
+// (already-in-v2) returns nil mainOpts; its /main updates flow through
+// backfillCompactTranscripts which uses UpdateCommitted.
+func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *checkpoint.GitStore, v2Store *checkpoint.V2GitStore, info checkpoint.CommittedInfo, existing *checkpoint.CheckpointSummary, fullArtifacts checkpoint.FullSessionArtifactsIndex, compactOffsets *migrateCompactOffsetCache) (*migratedFullCheckpoint, []checkpoint.WriteCommittedOptions, migrateCheckpointOutcome, error) {
 	var outcome migrateCheckpointOutcome
 
-	if existing != nil && !force {
+	if existing != nil {
 		// Already in v2. Pack sessions whose /full/* artifacts are missing
 		// (resume an interrupted run) and backfill transcript.jsonl on /main
 		// where it's missing. With nothing to do on either front, return
@@ -688,12 +683,6 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 			return nil, nil, outcome, errAlreadyMigrated
 		}
 		return fullCheckpoint, nil, outcome, nil
-	}
-
-	if existing != nil && force {
-		if pruneErr := pruneV2CheckpointForForce(ctx, repo, v2Store, info.CheckpointID); pruneErr != nil {
-			return nil, nil, outcome, fmt.Errorf("failed to reset existing v2 checkpoint %s before force migration: %w", info.CheckpointID, pruneErr)
-		}
 	}
 
 	summary, err := v1Store.ReadCommitted(ctx, info.CheckpointID)
@@ -744,10 +733,9 @@ func migrateOneCheckpoint(ctx context.Context, repo *git.Repository, v1Store *ch
 		mainOpts.Transcript = redact.AlreadyRedacted(nil)
 		mainOptsBatch = append(mainOptsBatch, mainOpts)
 
-		// The checkpoint is empty in v2 here (new, or just pruned by force),
-		// so WriteCommittedMainBatch will assign sessions sequentially in
-		// input order. The local migratedSessions counter is the predicted
-		// v2 session index.
+		// The checkpoint is absent from v2 here, so WriteCommittedMainBatch
+		// will assign sessions sequentially in input order. The local
+		// migratedSessions counter is the predicted v2 session index.
 		v2SessionIdx := migratedSessions
 		v1ToV2SessionIdx[sessionIdx] = v2SessionIdx
 		fullCheckpoint.sessions = append(fullCheckpoint.sessions, migratedFullSession{
@@ -1175,190 +1163,6 @@ func warnMissingV1Session(ctx context.Context, checkpointID id.CheckpointID, ses
 		slog.Int("session_index", sessionIdx),
 		slog.String("error", err.Error()),
 	)
-}
-
-func pruneV2CheckpointForForce(ctx context.Context, repo *git.Repository, v2Store *checkpoint.V2GitStore, cpID id.CheckpointID) error {
-	for _, refName := range []plumbing.ReferenceName{
-		plumbing.ReferenceName(paths.V2MainRefName),
-		plumbing.ReferenceName(paths.V2FullCurrentRefName),
-	} {
-		if err := pruneV2CheckpointRef(ctx, repo, v2Store, refName, cpID); err != nil {
-			return err
-		}
-	}
-
-	archived, err := v2Store.ListArchivedGenerations()
-	if err != nil {
-		return fmt.Errorf("failed to list archived v2 generations while pruning checkpoint %s: %w", cpID, err)
-	}
-	for _, generation := range archived {
-		refName := plumbing.ReferenceName(paths.V2FullRefPrefix + generation)
-		if err := pruneV2ArchivedCheckpointRef(ctx, repo, v2Store, refName, cpID); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func pruneV2CheckpointRef(ctx context.Context, repo *git.Repository, v2Store *checkpoint.V2GitStore, refName plumbing.ReferenceName, cpID id.CheckpointID) error {
-	parentHash, rootTreeHash, err := v2Store.GetRefState(refName)
-	if err != nil {
-		if errors.Is(err, plumbing.ErrReferenceNotFound) {
-			return nil
-		}
-		return fmt.Errorf("failed to get v2 ref state for %s: %w", refName, err)
-	}
-
-	rootTree, err := repo.TreeObject(rootTreeHash)
-	if err != nil {
-		return fmt.Errorf("failed to read v2 tree for %s: %w", refName, err)
-	}
-	if _, err := rootTree.Tree(cpID.Path()); err != nil {
-		return nil //nolint:nilerr // Checkpoint is absent from this ref, so there is nothing to prune.
-	}
-
-	shardPrefix := string(cpID[:2])
-	shardSuffix := string(cpID[2:])
-	newRoot, err := pruneCheckpointFromRoot(repo, rootTreeHash, shardPrefix, shardSuffix)
-	if err != nil {
-		return fmt.Errorf("failed to remove checkpoint subtree from %s: %w", refName, err)
-	}
-	if newRoot == rootTreeHash {
-		return nil
-	}
-
-	commitHash, err := checkpoint.CreateCommit(ctx, repo, newRoot, parentHash,
-		fmt.Sprintf("Reset checkpoint before force migration: %s\n", cpID),
-		migrateAuthorName, migrateAuthorEmail)
-	if err != nil {
-		return fmt.Errorf("failed to create v2 prune commit for %s: %w", refName, err)
-	}
-
-	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)); err != nil {
-		return fmt.Errorf("failed to update ref %s: %w", refName, err)
-	}
-	return nil
-}
-
-func pruneV2ArchivedCheckpointRef(ctx context.Context, repo *git.Repository, v2Store *checkpoint.V2GitStore, refName plumbing.ReferenceName, cpID id.CheckpointID) error {
-	parentHash, rootTreeHash, err := v2Store.GetRefState(refName)
-	if err != nil {
-		if errors.Is(err, plumbing.ErrReferenceNotFound) {
-			return nil
-		}
-		return fmt.Errorf("failed to get v2 ref state for %s: %w", refName, err)
-	}
-
-	rootTree, err := repo.TreeObject(rootTreeHash)
-	if err != nil {
-		return fmt.Errorf("failed to read v2 tree for %s: %w", refName, err)
-	}
-	if _, err := rootTree.Tree(cpID.Path()); err != nil {
-		return nil //nolint:nilerr // Checkpoint is absent from this ref, so there is nothing to prune.
-	}
-
-	shardPrefix := string(cpID[:2])
-	shardSuffix := string(cpID[2:])
-	newRoot, err := pruneCheckpointFromRoot(repo, rootTreeHash, shardPrefix, shardSuffix)
-	if err != nil {
-		return fmt.Errorf("failed to remove checkpoint subtree from %s: %w", refName, err)
-	}
-	if newRoot == rootTreeHash {
-		return nil
-	}
-
-	count, err := v2Store.CountCheckpointsInTree(newRoot)
-	if err != nil {
-		return fmt.Errorf("failed to count checkpoints in pruned %s: %w", refName, err)
-	}
-	if count == 0 {
-		if err := repo.Storer.RemoveReference(refName); err != nil {
-			return fmt.Errorf("failed to remove empty archived v2 generation %s: %w", refName, err)
-		}
-		return nil
-	}
-
-	newRoot, err = addRecomputedGenerationJSON(v2Store, newRoot)
-	if err != nil {
-		return fmt.Errorf("failed to recompute generation metadata for %s: %w", refName, err)
-	}
-
-	commitHash, err := checkpoint.CreateCommit(ctx, repo, newRoot, parentHash,
-		fmt.Sprintf("Reset checkpoint before force migration: %s\n", cpID),
-		migrateAuthorName, migrateAuthorEmail)
-	if err != nil {
-		return fmt.Errorf("failed to create v2 prune commit for %s: %w", refName, err)
-	}
-
-	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)); err != nil {
-		return fmt.Errorf("failed to update ref %s: %w", refName, err)
-	}
-	return nil
-}
-
-func addRecomputedGenerationJSON(v2Store *checkpoint.V2GitStore, treeHash plumbing.Hash) (plumbing.Hash, error) {
-	gen, found, err := v2Store.ComputeGenerationTimestampsFromTrees(treeHash, nil)
-	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("compute raw transcript timestamps: %w", err)
-	}
-	if !found {
-		gen, found, err = v2Store.ComputeGenerationCheckpointTimestamps(treeHash)
-		if err != nil {
-			return plumbing.ZeroHash, fmt.Errorf("compute checkpoint timestamps: %w", err)
-		}
-	}
-	if !found {
-		return treeHash, nil
-	}
-
-	newTreeHash, err := v2Store.AddGenerationJSONToTree(treeHash, gen)
-	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("add generation metadata: %w", err)
-	}
-	return newTreeHash, nil
-}
-
-func pruneCheckpointFromRoot(repo *git.Repository, rootTreeHash plumbing.Hash, shardPrefix, shardSuffix string) (plumbing.Hash, error) {
-	newRoot, err := checkpoint.UpdateSubtree(repo, rootTreeHash,
-		[]string{shardPrefix},
-		nil,
-		checkpoint.UpdateSubtreeOptions{
-			MergeMode:   checkpoint.MergeKeepExisting,
-			DeleteNames: []string{shardSuffix},
-		},
-	)
-	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("failed to prune checkpoint from shard: %w", err)
-	}
-	if newRoot == rootTreeHash {
-		return newRoot, nil
-	}
-
-	newRootTree, err := repo.TreeObject(newRoot)
-	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("failed to read pruned root tree: %w", err)
-	}
-	shardTree, err := newRootTree.Tree(shardPrefix)
-	if err != nil {
-		return newRoot, nil //nolint:nilerr // The shard prefix was already absent after pruning.
-	}
-	if len(shardTree.Entries) > 0 {
-		return newRoot, nil
-	}
-
-	prunedRoot, err := checkpoint.UpdateSubtree(repo, rootTreeHash,
-		nil,
-		nil,
-		checkpoint.UpdateSubtreeOptions{
-			MergeMode:   checkpoint.MergeKeepExisting,
-			DeleteNames: []string{shardPrefix},
-		},
-	)
-	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("failed to prune empty shard prefix: %w", err)
-	}
-	return prunedRoot, nil
 }
 
 func buildMigrateWriteOpts(content *checkpoint.SessionContent, info checkpoint.CommittedInfo, combinedAttribution *checkpoint.InitialAttribution) checkpoint.WriteCommittedOptions {

--- a/cmd/entire/cli/migrate_test.go
+++ b/cmd/entire/cli/migrate_test.go
@@ -182,7 +182,7 @@ func TestMigrateCheckpointsV2_Basic(t *testing.T) {
 
 	var stdout bytes.Buffer
 
-	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.migrated)
 	assert.Equal(t, 0, result.skipped)
@@ -207,7 +207,7 @@ func TestMigrateCheckpointsV2_ReusesV1RawTranscriptBlob(t *testing.T) {
 	v1Hash := treeEntryHash(t, repo, plumbing.NewBranchReferenceName(paths.MetadataBranchName), cpID.Path()+"/0/"+paths.TranscriptFileName)
 
 	var stdout bytes.Buffer
-	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.migrated)
 
@@ -234,7 +234,7 @@ func TestMigrateCheckpointsV2_PreservesCreatedAt(t *testing.T) {
 	require.NoError(t, err)
 
 	var stdout bytes.Buffer
-	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.migrated)
 
@@ -267,7 +267,7 @@ func TestMigrateCheckpointsV2_UnderThresholdKeepsFullGenerationInCurrent(t *test
 	}
 
 	var stdout bytes.Buffer
-	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 3, result.migrated)
 	assert.Equal(t, 0, result.skipped)
@@ -324,7 +324,7 @@ func TestMigrateCheckpointsV2_RotatesCurrentWhenFinalPartialReachesThreshold(t *
 	writeV1Checkpoint(t, v1Store, migratedID, "session-migrated-current", migratedTranscript, []string{"migrated prompt"})
 
 	var stdout bytes.Buffer
-	result, writtenRefs, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	result, writtenRefs, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.migrated)
 	require.Equal(t, []plumbing.ReferenceName{plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000001")}, writtenRefs)
@@ -400,7 +400,7 @@ func TestMigrateCheckpointsV2_PacksFullGenerationsOldestFirst(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 5, result.migrated)
 	assert.Equal(t, 0, result.skipped)
@@ -479,7 +479,7 @@ func TestMigrateCheckpointsV2_RollsBackArchiveWhenPublicationQueueFails(t *testi
 	require.NoError(t, os.WriteFile(blockingPath, []byte("not a directory"), 0o600))
 
 	var stdout bytes.Buffer
-	result, writtenRefs, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	result, writtenRefs, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to queue migrated raw transcript generation for push")
 	assert.Empty(t, writtenRefs)
@@ -576,7 +576,7 @@ func TestMigrateCheckpointsV2_PacksFullGenerationMetadataFromCheckpointCreatedAt
 	require.NoError(t, err)
 
 	var stdout bytes.Buffer
-	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.migrated)
 
@@ -592,7 +592,7 @@ func TestMigrateCheckpointsV2_PacksFullGenerationMetadataFromCheckpointCreatedAt
 }
 
 // A migration interrupted between the /main write and the packer flush must
-// resume on a non-force rerun and finish packing the missing /full artifacts.
+// resume on rerun and finish packing the missing /full artifacts.
 func TestMigrateCheckpointsV2_RerunResumesInterruptedMigration(t *testing.T) {
 	t.Parallel()
 	repo := initMigrateTestRepo(t)
@@ -612,7 +612,7 @@ func TestMigrateCheckpointsV2_RerunResumesInterruptedMigration(t *testing.T) {
 	v1List, err := v1Store.ListCommitted(ctx)
 	require.NoError(t, err)
 	require.Len(t, v1List, 1)
-	fullCheckpoint, mainOpts, _, migrateErr := migrateOneCheckpoint(ctx, repo, v1Store, v2Store, v1List[0], nil, false, nil, newMigrateCompactOffsetCache())
+	fullCheckpoint, mainOpts, _, migrateErr := migrateOneCheckpoint(ctx, repo, v1Store, v2Store, v1List[0], nil, nil, newMigrateCompactOffsetCache())
 	require.NoError(t, migrateErr)
 	require.NotNil(t, fullCheckpoint)
 	require.NotEmpty(t, mainOpts)
@@ -622,10 +622,10 @@ func TestMigrateCheckpointsV2_RerunResumesInterruptedMigration(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, hasFullBefore, "precondition: full artifacts should be missing")
 
-	// Rerun without --force: must pick up the interrupted checkpoint and
-	// finish packing it. Counted as migrated, not skipped.
+	// Rerun must pick up the interrupted checkpoint and finish packing it.
+	// Counted as migrated, not skipped.
 	var rerun bytes.Buffer
-	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &rerun, false)
+	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &rerun)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.migrated)
 	assert.Equal(t, 0, result.skipped)
@@ -637,7 +637,7 @@ func TestMigrateCheckpointsV2_RerunResumesInterruptedMigration(t *testing.T) {
 
 	// A second rerun once everything is packed must skip (no further work).
 	var second bytes.Buffer
-	result2, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &second, false)
+	result2, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &second)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result2.migrated)
 	assert.Equal(t, 1, result2.skipped)
@@ -657,173 +657,17 @@ func TestMigrateCheckpointsV2_Idempotent(t *testing.T) {
 	var stdout bytes.Buffer
 
 	// First run: should migrate
-	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result1.migrated)
 	assert.Equal(t, 0, result1.skipped)
 
 	// Second run: should skip (no agent type means backfill also can't produce compact transcript)
 	stdout.Reset()
-	result2, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result2, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result2.migrated)
 	assert.Equal(t, 1, result2.skipped)
-}
-
-func TestMigrateCheckpointsV2_ForceOverwritesExisting(t *testing.T) {
-	t.Parallel()
-	repo := initMigrateTestRepo(t)
-	v1Store, v2Store := newMigrateStores(repo)
-
-	cpID := id.MustCheckpointID("f0f1f2f3f4f5")
-	writeV1Checkpoint(t, v1Store, cpID, "session-force",
-		[]byte("{\"type\":\"assistant\",\"message\":\"original\"}\n"),
-		[]string{"original prompt"},
-	)
-
-	var stdout bytes.Buffer
-
-	// First run: normal migration
-	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
-	require.NoError(t, err)
-	assert.Equal(t, 1, result1.migrated)
-
-	// Second run without force: should skip
-	stdout.Reset()
-	result2, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
-	require.NoError(t, err)
-	assert.Equal(t, 0, result2.migrated)
-	assert.Equal(t, 1, result2.skipped)
-
-	// Third run with force: should re-migrate
-	stdout.Reset()
-	result3, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, true)
-	require.NoError(t, err)
-	assert.Equal(t, 1, result3.migrated)
-	assert.Equal(t, 0, result3.skipped)
-	assert.Equal(t, "✓ Packing migrated raw transcripts\n", stdout.String())
-
-	// Verify checkpoint still readable in v2
-	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
-	require.NoError(t, readErr)
-	require.NotNil(t, summary)
-	assert.Equal(t, cpID, summary.CheckpointID)
-
-	archived, err := v2Store.ListArchivedGenerations()
-	require.NoError(t, err)
-	require.Empty(t, archived, "under-threshold force migration should not create archived raw transcripts")
-
-	_, currentTreeHash, err := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
-	require.NoError(t, err)
-	currentCount, err := v2Store.CountCheckpointsInTree(currentTreeHash)
-	require.NoError(t, err)
-	assert.Equal(t, 1, currentCount, "under-threshold force migration should leave raw transcripts in /full/current")
-}
-
-func TestMigrateCheckpointsV2_ForceMultipleCheckpoints(t *testing.T) {
-	t.Parallel()
-	repo := initMigrateTestRepo(t)
-	v1Store, v2Store := newMigrateStores(repo)
-
-	cpID1 := id.MustCheckpointID("a0a1a2a3a4a5")
-	cpID2 := id.MustCheckpointID("b0b1b2b3b4b5")
-	writeV1Checkpoint(t, v1Store, cpID1, "session-force-1",
-		[]byte("{\"type\":\"assistant\",\"message\":\"first\"}\n"),
-		[]string{"prompt 1"},
-	)
-	writeV1Checkpoint(t, v1Store, cpID2, "session-force-2",
-		[]byte("{\"type\":\"assistant\",\"message\":\"second\"}\n"),
-		[]string{"prompt 2"},
-	)
-
-	// First run: migrates both
-	var discard bytes.Buffer
-	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &discard, false)
-	require.NoError(t, err)
-	assert.Equal(t, 2, result1.migrated)
-
-	// Force re-migrate: should re-migrate both (0 skipped)
-	var stdout bytes.Buffer
-	result2, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, true)
-	require.NoError(t, err)
-	assert.Equal(t, 2, result2.migrated)
-	assert.Equal(t, 0, result2.skipped)
-}
-
-func TestPruneV2CheckpointForForce_RecomputesPartialArchivedGeneration(t *testing.T) {
-	oldMax := migrateMaxCheckpointsPerGeneration
-	migrateMaxCheckpointsPerGeneration = 2
-	t.Cleanup(func() {
-		migrateMaxCheckpointsPerGeneration = oldMax
-	})
-
-	repo := initMigrateTestRepo(t)
-	v1Store, v2Store := newMigrateStores(repo)
-	ctx := context.Background()
-
-	cpID1 := id.MustCheckpointID("101010101010")
-	cpID2 := id.MustCheckpointID("202020202020")
-	cp1CreatedAt := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
-	cp2CreatedAt := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
-	for _, cp := range []struct {
-		id        id.CheckpointID
-		sessionID string
-		createdAt time.Time
-	}{
-		{cpID1, "session-force-prune-1", cp1CreatedAt},
-		{cpID2, "session-force-prune-2", cp2CreatedAt},
-	} {
-		err := v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
-			CheckpointID: cp.id,
-			SessionID:    cp.sessionID,
-			CreatedAt:    cp.createdAt,
-			Strategy:     "manual-commit",
-			Transcript:   redact.AlreadyRedacted([]byte("{\"type\":\"assistant\",\"message\":\"force prune\"}\n")),
-			AuthorName:   "Test",
-			AuthorEmail:  "test@test.com",
-		})
-		require.NoError(t, err)
-	}
-
-	var stdout bytes.Buffer
-	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
-	require.NoError(t, err)
-	assert.Equal(t, 2, result.migrated)
-
-	require.NoError(t, pruneV2CheckpointForForce(ctx, repo, v2Store, cpID1))
-
-	archived, err := v2Store.ListArchivedGenerations()
-	require.NoError(t, err)
-	require.Equal(t, []string{"0000000000001"}, archived)
-
-	refName := plumbing.ReferenceName(paths.V2FullRefPrefix + archived[0])
-	_, treeHash, err := v2Store.GetRefState(refName)
-	require.NoError(t, err)
-	count, err := v2Store.CountCheckpointsInTree(treeHash)
-	require.NoError(t, err)
-	assert.Equal(t, 1, count)
-
-	rootTree, err := repo.TreeObject(treeHash)
-	require.NoError(t, err)
-	_, err = rootTree.Tree(cpID1.Path())
-	require.Error(t, err, "force prune should remove the target checkpoint from archived generations")
-	_, err = rootTree.Tree(cpID2.Path())
-	require.NoError(t, err, "force prune should preserve other checkpoints in the archived generation")
-
-	gen, err := v2Store.ReadGenerationFromRef(refName)
-	require.NoError(t, err)
-	assert.True(t, gen.OldestCheckpointAt.Equal(cp2CreatedAt))
-	assert.True(t, gen.NewestCheckpointAt.Equal(cp2CreatedAt))
-}
-
-func TestMigrateCmd_ForceFlag(t *testing.T) {
-	t.Parallel()
-	cmd := newMigrateCmd()
-
-	// Verify --force flag exists
-	flag := cmd.Flags().Lookup("force")
-	require.NotNil(t, flag, "--force flag should be registered")
-	assert.Equal(t, "false", flag.DefValue)
 }
 
 func TestMigrateCmd_RepairsArchivedGenerationMetadata(t *testing.T) {
@@ -938,7 +782,7 @@ func TestMigrateCheckpointsV2_MultiSession(t *testing.T) {
 
 	var stdout bytes.Buffer
 
-	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.migrated)
 
@@ -973,7 +817,7 @@ func TestMigrateCheckpointsV2_SkipsV1SessionWithoutTranscript(t *testing.T) {
 	require.NoError(t, err)
 
 	var stdout bytes.Buffer
-	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated)
 	assert.Equal(t, 0, result.skipped)
@@ -1004,7 +848,7 @@ func TestMigrateCheckpointsV2_SkipsV1SessionWithMissingDirectory(t *testing.T) {
 	appendMissingV1SessionReference(t, repo, v1Store, cpID)
 
 	var stdout bytes.Buffer
-	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated)
 	assert.Equal(t, 0, result.skipped)
@@ -1060,7 +904,7 @@ func TestMigrateCheckpointsV2_TaskMetadataUsesMigratedSessionIndexAfterSkip(t *t
 	addV1SessionTasksTree(t, repo, cpID, 2, "toolu_session_shifted")
 
 	var stdout bytes.Buffer
-	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated)
 
@@ -1103,7 +947,7 @@ func TestMigrateCheckpointsV2_TaskMetadataKeepsFirstConflictingTaskTree(t *testi
 	addV1SessionTasksTreeWithContent(t, repo, cpID, 0, toolUseID, `{"source":"session"}`)
 
 	var stdout bytes.Buffer
-	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated)
 
@@ -1151,7 +995,7 @@ func TestMigrateCheckpointsV2_RerunPartialPackDoesNotMoveRootTaskMetadataToMissi
 	addV1RootTasksTreeWithContent(t, repo, cpID, rootToolUseID, `{"source":"root"}`)
 
 	var initialRun bytes.Buffer
-	result1, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &initialRun, false)
+	result1, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &initialRun)
 	require.NoError(t, err)
 	require.Equal(t, 1, result1.migrated)
 	require.True(t, v2FullFileExistsForCheckpoint(t, repo, v2Store, cpID, "1/tasks/"+rootToolUseID+"/checkpoint.json"),
@@ -1163,7 +1007,7 @@ func TestMigrateCheckpointsV2_RerunPartialPackDoesNotMoveRootTaskMetadataToMissi
 	removeV2SessionTranscriptFiles(t, repo, v2Store, cpID, 0)
 
 	var rerun bytes.Buffer
-	result2, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &rerun, false)
+	result2, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &rerun)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result2.migrated, "resume must repack the missing session")
 
@@ -1191,7 +1035,7 @@ func TestMigrateCheckpointsV2_SkipsCheckpointWhenAllV1SessionsMissingTranscript(
 	require.NoError(t, err)
 
 	var stdout bytes.Buffer
-	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 0, result.migrated)
 	assert.Equal(t, 1, result.skipped)
@@ -1205,120 +1049,6 @@ func TestMigrateCheckpointsV2_SkipsCheckpointWhenAllV1SessionsMissingTranscript(
 	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, readErr)
 	assert.Nil(t, summary)
-}
-
-func TestMigrateCheckpointsV2_ForcePrunesSkippedV2Sessions(t *testing.T) {
-	t.Parallel()
-	repo := initMigrateTestRepo(t)
-	v1Store, v2Store := newMigrateStores(repo)
-
-	cpID := id.MustCheckpointID("778899aabbcc")
-	writeV1Checkpoint(t, v1Store, cpID, "session-keep",
-		[]byte("{\"type\":\"assistant\",\"message\":\"keep\"}\n"),
-		[]string{"keep prompt"},
-	)
-	writeV1Checkpoint(t, v1Store, cpID, "session-stale",
-		[]byte("{\"type\":\"assistant\",\"message\":\"stale\"}\n"),
-		[]string{"stale prompt"},
-	)
-
-	var initialRun bytes.Buffer
-	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &initialRun, false)
-	require.NoError(t, err)
-	assert.Equal(t, 1, result1.migrated)
-
-	initialSummary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
-	require.NoError(t, readErr)
-	require.NotNil(t, initialSummary)
-	require.Len(t, initialSummary.Sessions, 2)
-
-	err = v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "session-stale",
-		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted(nil),
-		Prompts:      []string{"metadata-only stale prompt"},
-		AuthorName:   "Test",
-		AuthorEmail:  "test@test.com",
-	})
-	require.NoError(t, err)
-
-	var stdout bytes.Buffer
-	result2, _, rerunErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, true)
-	require.NoError(t, rerunErr)
-	assert.Equal(t, 1, result2.migrated)
-	assert.Equal(t, 0, result2.skipped)
-	assert.Equal(t, 1, result2.missingSessions)
-	assert.NotContains(t, stdout.String(), "warning: skipping v1 session 1")
-
-	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
-	require.NoError(t, readErr)
-	require.NotNil(t, summary)
-	require.Len(t, summary.Sessions, 1)
-	assert.Equal(t, "/"+cpID.Path()+"/0/metadata.json", summary.Sessions[0].Metadata)
-
-	_, rootTreeHash, refErr := v2Store.GetRefState(plumbing.ReferenceName(paths.V2FullCurrentRefName))
-	require.NoError(t, refErr)
-	rootTree, treeErr := repo.TreeObject(rootTreeHash)
-	require.NoError(t, treeErr)
-	_, err = rootTree.File(cpID.Path() + "/1/" + paths.V2RawTranscriptHashFileName)
-	require.Error(t, err, "force migration should remove stale full transcript data for skipped sessions")
-}
-
-func TestMigrateCheckpointsV2_ForcePruneRemovesEmptyShardWhenAllSessionsSkipped(t *testing.T) {
-	t.Parallel()
-	repo := initMigrateTestRepo(t)
-	v1Store, v2Store := newMigrateStores(repo)
-
-	cpID := id.MustCheckpointID("8899aabbccdd")
-	writeV1Checkpoint(t, v1Store, cpID, "session-stale-only",
-		[]byte("{\"type\":\"assistant\",\"message\":\"stale only\"}\n"),
-		[]string{"stale prompt"},
-	)
-
-	var initialRun bytes.Buffer
-	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &initialRun, false)
-	require.NoError(t, err)
-	assert.Equal(t, 1, result1.migrated)
-
-	err = v1Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "session-stale-only",
-		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted(nil),
-		Prompts:      []string{"metadata-only stale prompt"},
-		AuthorName:   "Test",
-		AuthorEmail:  "test@test.com",
-	})
-	require.NoError(t, err)
-
-	var stdout bytes.Buffer
-	result2, _, rerunErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, true)
-	require.NoError(t, rerunErr)
-	assert.Equal(t, 0, result2.migrated)
-	assert.Equal(t, 1, result2.skipped)
-	assert.Equal(t, 1, result2.missingSessions)
-	assert.NotContains(t, stdout.String(), "no migratable v1 sessions")
-
-	summary, readErr := v2Store.ReadCommitted(context.Background(), cpID)
-	require.NoError(t, readErr)
-	assert.Nil(t, summary)
-
-	assertNoV2ShardPrefix(t, repo, v2Store, plumbing.ReferenceName(paths.V2MainRefName), cpID)
-	assertNoV2ShardPrefix(t, repo, v2Store, plumbing.ReferenceName(paths.V2FullCurrentRefName), cpID)
-}
-
-func assertNoV2ShardPrefix(t *testing.T, repo *git.Repository, v2Store *checkpoint.V2GitStore, refName plumbing.ReferenceName, cpID id.CheckpointID) {
-	t.Helper()
-
-	_, rootTreeHash, err := v2Store.GetRefState(refName)
-	require.NoError(t, err)
-
-	rootTree, err := repo.TreeObject(rootTreeHash)
-	require.NoError(t, err)
-
-	_, err = rootTree.Tree(string(cpID[:2]))
-	require.Error(t, err, "force prune should remove an empty shard prefix from %s", refName)
 }
 
 func appendMissingV1SessionReference(t *testing.T, repo *git.Repository, v1Store *checkpoint.GitStore, cpID id.CheckpointID) {
@@ -1376,7 +1106,7 @@ func TestMigrateCheckpointsV2_NoV1Branch(t *testing.T) {
 	var stdout bytes.Buffer
 
 	// No v1 data written — ListCommitted returns empty
-	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.migrated)
 	assert.Empty(t, stdout.String())
@@ -1473,7 +1203,7 @@ func TestMigrateCheckpointsV2_CompactionSkipped(t *testing.T) {
 
 	var stdout bytes.Buffer
 
-	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated)
 	assert.Equal(t, 1, result.compactTranscriptSkipped)
@@ -1501,7 +1231,7 @@ func TestMigrateCheckpointsV2_TaskCheckpoint(t *testing.T) {
 
 	var stdout bytes.Buffer
 
-	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result, _, migrateErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated)
 
@@ -1532,7 +1262,7 @@ func TestMigrateCheckpointsV2_RerunPicksUpNewV1Checkpoints(t *testing.T) {
 	)
 
 	var firstRun bytes.Buffer
-	r1, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &firstRun, false)
+	r1, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &firstRun)
 	require.NoError(t, err)
 	require.Equal(t, 1, r1.migrated)
 
@@ -1545,7 +1275,7 @@ func TestMigrateCheckpointsV2_RerunPicksUpNewV1Checkpoints(t *testing.T) {
 
 	// Rerun: existing must be skipped, new one must be migrated.
 	var rerun bytes.Buffer
-	r2, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &rerun, false)
+	r2, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &rerun)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r2.migrated, "new v1 checkpoint should be migrated on rerun")
 	assert.Equal(t, 1, r2.skipped, "already-migrated v1 checkpoint should be skipped")
@@ -1576,13 +1306,13 @@ func TestMigrateCheckpointsV2_AllSkippedOnRerun(t *testing.T) {
 
 	// First run: migrates both
 	var discard bytes.Buffer
-	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &discard, false)
+	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &discard)
 	require.NoError(t, err)
 	assert.Equal(t, 2, result1.migrated)
 
 	// Second run: skips both
 	var stdout bytes.Buffer
-	result2, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout, false)
+	result2, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result2.migrated)
 	assert.Equal(t, 2, result2.skipped)
@@ -1633,7 +1363,7 @@ func TestMigrateCheckpointsV2_BackfillsCompactTranscriptWhenFullArtifactsExist(t
 	require.True(t, hasFull, "precondition: raw /full artifacts should already exist")
 
 	var stdout bytes.Buffer
-	result, _, migrateErr := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	result, _, migrateErr := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated, "compact backfill should count as migration work")
 	assert.Equal(t, 0, result.skipped)
@@ -1687,7 +1417,7 @@ func TestMigrateCheckpointsV2_UsesComputedCompactTranscriptStart(t *testing.T) {
 	require.Positive(t, expectedOffset, "expected non-zero compact transcript start")
 
 	var stdout bytes.Buffer
-	result, _, migrateErr := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	result, _, migrateErr := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout)
 	require.NoError(t, migrateErr)
 	assert.Equal(t, 1, result.migrated)
 
@@ -1730,7 +1460,7 @@ func TestMigrateCheckpointsV2_SkipsRepairWhenArchivedFullExists(t *testing.T) {
 
 	// Initial migration to seed v2.
 	var initialRun bytes.Buffer
-	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &initialRun, false)
+	result1, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &initialRun)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result1.migrated)
 
@@ -1743,7 +1473,7 @@ func TestMigrateCheckpointsV2_SkipsRepairWhenArchivedFullExists(t *testing.T) {
 	// Re-run migration: archived /full/* artifacts are sufficient, so it should
 	// not rehydrate old raw transcripts into /full/current.
 	var rerun bytes.Buffer
-	result2, _, rerunErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &rerun, false)
+	result2, _, rerunErr := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &rerun)
 	require.NoError(t, rerunErr)
 	assert.Equal(t, 0, result2.migrated)
 	assert.Equal(t, 1, result2.skipped)
@@ -1933,7 +1663,7 @@ func TestMigrateCheckpointsV2_PreservesPromptAttributions(t *testing.T) {
 
 	// Migrate
 	var stdout bytes.Buffer
-	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.migrated)
 
@@ -1997,7 +1727,7 @@ func TestMigrateCheckpointsV2_PreservesCombinedAttribution(t *testing.T) {
 
 	// Migrate
 	var stdout bytes.Buffer
-	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout, false)
+	result, _, err := migrateCheckpointsV2(ctx, repo, v1Store, v2Store, &stdout)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.migrated)
 
@@ -2128,7 +1858,7 @@ func TestDryRunCheckpointsV2_AllAlreadyMigrated(t *testing.T) {
 
 	// Migrate once so v2 has the entry, then dry-run should report nothing pending.
 	var migrateOut bytes.Buffer
-	_, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &migrateOut, false)
+	_, _, err := migrateCheckpointsV2(context.Background(), repo, v1Store, v2Store, &migrateOut)
 	require.NoError(t, err)
 
 	var out bytes.Buffer

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -172,7 +172,6 @@ func printCheckpointsV2MigrationHint(ctx context.Context) {
 			return
 		}
 		fmt.Fprintln(os.Stderr, "[entire] Note: .entire/settings.json sets checkpoints_version: 2. Run 'entire migrate --checkpoints v2' to migrate existing checkpoints to v2.")
-		fmt.Fprintln(os.Stderr, "[entire] Use 'entire migrate --checkpoints v2 --force' to rewrite all checkpoints in v2.")
 	})
 }
 

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -1343,7 +1343,6 @@ func TestPrintCheckpointsV2MigrationHint(t *testing.T) {
 		output := restore()
 
 		assert.Contains(t, output, "entire migrate --checkpoints v2")
-		assert.Contains(t, output, "entire migrate --checkpoints v2 --force")
 	})
 
 	t.Run("prints only once per process", func(t *testing.T) {
@@ -1357,10 +1356,8 @@ func TestPrintCheckpointsV2MigrationHint(t *testing.T) {
 		printCheckpointsV2MigrationHint(context.Background())
 		output := restore()
 
-		// --force appears in exactly one line, so its count equals the number of
-		// invocations that actually emitted output.
-		forceCount := strings.Count(output, "--force")
-		assert.Equal(t, 1, forceCount, "hint should print exactly once per process")
+		hintCount := strings.Count(output, "Run 'entire migrate --checkpoints v2'")
+		assert.Equal(t, 1, hintCount, "hint should print exactly once per process")
 	})
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/366
<!-- entire-trail-link-end -->

The flag was hidden and only used internally during early versions of the migration checkpoints command during testing and iteration. Its per-checkpoint prune was O(N × G) over archived generations (each checkpoint triggered tree rebuilds + commits on /main, /full/current, and every /full/<n>), turning real-world reruns into hour-long jobs vs. minutes for non-force.

Non-force semantics — skip v1 checkpoints already in v2, copy over the rest — already match the desired behavior, and the resume path still backfills missing /full/* artifacts and compact transcripts. If a future bug ships bad v2 data, recourse is a targeted repair, not a wholesale re-migration. Reintroducing force later remains an option.

Drops the flag, the force plumbing through runMigrateCheckpointsV2 / migrateCheckpointsV2 / migrateOneCheckpoint, and the prune helpers (pruneV2CheckpointForForce, pruneV2CheckpointRef,
pruneV2ArchivedCheckpointRef, addRecomputedGenerationJSON, pruneCheckpointFromRoot). Updates the post-push migration hint to stop suggesting --force.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes checkpoint migration behavior by removing the ability to forcibly re-migrate/overwrite existing v2 data, which could affect operational recovery workflows (though the command is hidden and rerun/resume behavior remains).
> 
> **Overview**
> `entire migrate --checkpoints v2` no longer supports `--force`; the flag, its plumbing, and the expensive per-checkpoint v2 prune/rewrite helpers have been removed.
> 
> Migration now always treats existing v2 checkpoints as *already migrated*, only performing **resume repairs** (pack missing `/full/*` artifacts and backfill missing compact transcripts) and skipping otherwise; tests and the post-push migration hint were updated accordingly to stop referencing `--force`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c07c4705ece3b92066b6e656d0df1014f648bc7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->