### PR TITLE
Remove force output from checkpoints v2 push help messaging

### DIFF
--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -171,8 +171,8 @@ func printCheckpointsV2MigrationHint(ctx context.Context) {
 		if !hasUnmigratedV1Checkpoints(ctx) {
 			return
 		}
-		fmt.Fprintln(os.Stderr, "[entire] Note: .entire/settings.json sets checkpoints_version: 2. Run 'entire migrate --checkpoints v2' to migrate existing checkpoints to v2.")
-		fmt.Fprintln(os.Stderr, "[entire] Use 'entire migrate --checkpoints v2 --force' to rewrite all checkpoints in v2.")
+		fmt.Fprintln(os.Stderr, "[entire] Note: .entire/settings.json sets checkpoints_version: 2, but there are some v1 checkpoints that have not been migrated to v2.")
+		fmt.Fprintln(os.Stderr, "[entire] Run 'entire migrate --checkpoints v2' to migrate missing checkpoints to v2.")
 	})
 }
 

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -1343,7 +1343,6 @@ func TestPrintCheckpointsV2MigrationHint(t *testing.T) {
 		output := restore()
 
 		assert.Contains(t, output, "entire migrate --checkpoints v2")
-		assert.Contains(t, output, "entire migrate --checkpoints v2 --force")
 	})
 
 	t.Run("prints only once per process", func(t *testing.T) {
@@ -1357,10 +1356,8 @@ func TestPrintCheckpointsV2MigrationHint(t *testing.T) {
 		printCheckpointsV2MigrationHint(context.Background())
 		output := restore()
 
-		// --force appears in exactly one line, so its count equals the number of
-		// invocations that actually emitted output.
-		forceCount := strings.Count(output, "--force")
-		assert.Equal(t, 1, forceCount, "hint should print exactly once per process")
+		outputCount := strings.Count(output, "entire migrate --checkpoints v2")
+		assert.Equal(t, 1, outputCount, "hint should print exactly once per process")
 	})
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/367
<!-- entire-trail-link-end -->

Removes the `--force` migration flag from the checkpoints v2 push help messaging. That flag was introduced early on while we were first wiring up the checkpoints migration tooling. For missing v1 checkpoints in v2, the regular migration command should do the trick without force, which takes a long time to run and isn't beneficial in this case anyway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts user-facing stderr messaging and tightens related assertions, without changing migration or push behavior.
> 
> **Overview**
> Updates the checkpoints v2 migration hint printed during push to **remove the `--force` recommendation** and reword the output to explicitly state that v1 checkpoints remain unmigrated.
> 
> Adjusts tests to match the new messaging and to verify the hint prints only once by counting the standard `entire migrate --checkpoints v2` line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4257a5aa9f747843d464c3776c343d240b4c42e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->