### PR TITLE
Track attach reason on checkpoints

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -336,6 +336,14 @@ type WriteCommittedOptions struct {
 	// session.Kind.IsReview) because checkpoint can't import session
 	// — the session package imports checkpoint, creating a cycle.
 	HasReview bool
+
+	// AttachReason names which decision branch in PostCommit caused this
+	// session to be attached to the checkpoint (e.g. "active_recent_interaction",
+	// "file_overlap"). Empty for callers that don't track this (e.g. doctor
+	// backfills) or for legacy writers. Stored as a plain string here because
+	// the checkpoint package cannot import session (cycle); the typed enum
+	// lives in session.AttachReason.
+	AttachReason string
 }
 
 // UpdateCommittedOptions contains options for updating an existing committed checkpoint.
@@ -517,6 +525,14 @@ type CommittedMetadata struct {
 	// for spawn, first user prompt for attach). Only set when Kind is a
 	// review kind.
 	ReviewPrompt string `json:"review_prompt,omitempty"`
+
+	// AttachReason names which PostCommit decision branch caused this session
+	// to be attached to the checkpoint — e.g. "active_recent_interaction"
+	// or "file_overlap". Useful for diagnosing why a particular session
+	// shows up under a checkpoint, especially when multiple sessions share
+	// one. Empty for checkpoints written by older CLI versions or by code
+	// paths that don't track this (e.g. doctor-driven backfill).
+	AttachReason string `json:"attach_reason,omitempty"`
 }
 
 // GetTranscriptStart returns the transcript line offset at which this checkpoint's data begins.

--- a/cmd/entire/cli/checkpoint/checkpoint_test.go
+++ b/cmd/entire/cli/checkpoint/checkpoint_test.go
@@ -4331,6 +4331,77 @@ func TestCommittedMetadata_ReviewFields(t *testing.T) {
 	}
 }
 
+// TestWriteCommitted_PersistsAttachReason verifies that the AttachReason
+// passed via WriteCommittedOptions actually lands on the persisted
+// metadata.json and reads back through ReadSessionContent — the diagnostic
+// is only useful if it survives the full Write → Read path.
+func TestWriteCommitted_PersistsAttachReason(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo)
+	checkpointID := id.MustCheckpointID("aa11bb22cc33")
+
+	err := store.WriteCommitted(context.Background(), WriteCommittedOptions{
+		CheckpointID:     checkpointID,
+		SessionID:        "session-attach",
+		Strategy:         "manual-commit",
+		Transcript:       redact.AlreadyRedacted([]byte(`{"message": "attached"}`)),
+		FilesTouched:     []string{"a.go"},
+		CheckpointsCount: 1,
+		AuthorName:       "Test Author",
+		AuthorEmail:      "test@example.com",
+		AttachReason:     "file_overlap",
+	})
+	if err != nil {
+		t.Fatalf("WriteCommitted() error = %v", err)
+	}
+
+	content, err := store.ReadSessionContent(context.Background(), checkpointID, 0)
+	if err != nil {
+		t.Fatalf("ReadSessionContent() error = %v", err)
+	}
+	if content.Metadata.AttachReason != "file_overlap" {
+		t.Errorf("AttachReason = %q, want %q", content.Metadata.AttachReason, "file_overlap")
+	}
+}
+
+// TestCommittedMetadata_AttachReason pins the JSON wire format for the
+// AttachReason field on CommittedMetadata. The whole point of persisting
+// the field is that consumers can read it back from metadata.json, so a
+// silent rename of the struct field or its JSON tag would break the
+// diagnostic — even a self-consistent round-trip wouldn't catch that.
+// Also asserts omitempty: older checkpoints without the field must not
+// gain a misleading "attach_reason":"" key.
+func TestCommittedMetadata_AttachReason(t *testing.T) {
+	t.Parallel()
+
+	// Populated case: key marshals as "attach_reason":"manual_attach".
+	bSet, err := json.Marshal(CommittedMetadata{AttachReason: "manual_attach"})
+	if err != nil {
+		t.Fatalf("marshal set: %v", err)
+	}
+	var rawSet map[string]any
+	if err := json.Unmarshal(bSet, &rawSet); err != nil {
+		t.Fatalf("unmarshal set: %v", err)
+	}
+	if got, ok := rawSet["attach_reason"].(string); !ok || got != "manual_attach" {
+		t.Errorf(`expected "attach_reason":"manual_attach", got %v (raw: %s)`, rawSet["attach_reason"], string(bSet))
+	}
+
+	// Empty case: omitempty must drop the key for legacy/zero-value metadata.
+	bZero, err := json.Marshal(CommittedMetadata{})
+	if err != nil {
+		t.Fatalf("marshal zero: %v", err)
+	}
+	var rawZero map[string]any
+	if err := json.Unmarshal(bZero, &rawZero); err != nil {
+		t.Fatalf("unmarshal zero: %v", err)
+	}
+	if _, present := rawZero["attach_reason"]; present {
+		t.Errorf(`expected "attach_reason" to be omitted when empty, got %v (raw: %s)`, rawZero["attach_reason"], string(bZero))
+	}
+}
+
 // TestCheckpointSummary_HasReview pins the JSON wire format for the HasReview
 // umbrella flag on CheckpointSummary. Callers such as the re-run guard in
 // `entire review` and `entire status` depend on the on-disk shape, so we

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -458,6 +458,7 @@ func (s *GitStore) writeSessionToSubdirectory(ctx context.Context, opts WriteCom
 		Kind:                        opts.Kind,
 		ReviewSkills:                opts.ReviewSkills,
 		ReviewPrompt:                opts.ReviewPrompt,
+		AttachReason:                opts.AttachReason,
 	}
 
 	metadataJSON, err := jsonutil.MarshalIndentWithNewline(sessionMetadata, "", "  ")

--- a/cmd/entire/cli/checkpoint/v2_committed.go
+++ b/cmd/entire/cli/checkpoint/v2_committed.go
@@ -960,6 +960,7 @@ func (s *V2GitStore) writeMainSessionToSubdirectory(opts WriteCommittedOptions, 
 		Kind:                        opts.Kind,
 		ReviewSkills:                opts.ReviewSkills,
 		ReviewPrompt:                opts.ReviewPrompt,
+		AttachReason:                opts.AttachReason,
 	}
 
 	metadataJSON, err := jsonutil.MarshalIndentWithNewline(sessionMetadata, "", "  ")

--- a/cmd/entire/cli/session/attach_reason.go
+++ b/cmd/entire/cli/session/attach_reason.go
@@ -22,6 +22,12 @@ const (
 	// match the shadow branch (heuristic match).
 	AttachReasonFileOverlap AttachReason = "file_overlap"
 
+	// AttachReasonManual: session was imported via `entire attach` (or
+	// `entire review attach`) and is therefore associated with the worktree
+	// by explicit user intent. Bypasses the file-overlap and read-only-active
+	// heuristics; only the "has new content" gate still applies.
+	AttachReasonManual AttachReason = "manual_attach"
+
 	// AttachSkipNoNewContent: no new transcript or files since the last
 	// condensation. Log-only.
 	AttachSkipNoNewContent AttachReason = "skip_no_new_content"
@@ -52,7 +58,7 @@ const (
 // exhaustive linter will flag forgotten additions.
 func (r AttachReason) IsAttach() bool {
 	switch r {
-	case AttachReasonActiveRecentInteraction, AttachReasonFileOverlap:
+	case AttachReasonActiveRecentInteraction, AttachReasonFileOverlap, AttachReasonManual:
 		return true
 	case AttachSkipNoNewContent,
 		AttachSkipReadOnlyActive,

--- a/cmd/entire/cli/session/attach_reason.go
+++ b/cmd/entire/cli/session/attach_reason.go
@@ -1,61 +1,39 @@
 package session
 
 // AttachReason describes why a session was (or was not) attached to a
-// checkpoint during PostCommit condensation. It is logged at decision time
-// and — for attach reasons only — persisted on CommittedMetadata so
-// `entire checkpoint explain` and other tooling can answer "why is this
-// session here?" without rerunning with debug logs.
-//
-// Reasons starting with "skip_" are log-only and never persisted; they
-// describe the absence of an attachment.
+// checkpoint during PostCommit condensation. Attach reasons are persisted
+// on CommittedMetadata; skip reasons are log-only.
 type AttachReason string
 
 const (
-	// AttachReasonActiveRecentInteraction: session is ACTIVE and had a recent
-	// agent interaction (within activeSessionInteractionThreshold). The
-	// PrepareCommitMsg gate already established commit relatedness, so no
-	// file overlap check is required.
+	// AttachReasonActiveRecentInteraction: ACTIVE session within the
+	// activeSessionInteractionThreshold. PrepareCommitMsg already established
+	// commit relatedness via the trailer, so no overlap check is required.
 	AttachReasonActiveRecentInteraction AttachReason = "active_recent_interaction"
 
-	// AttachReasonFileOverlap: session is stale ACTIVE or IDLE/ENDED, but its
-	// tracked files overlap with the committed file set AND the file contents
-	// match the shadow branch (heuristic match).
+	// AttachReasonFileOverlap: stale ACTIVE or IDLE/ENDED, attached because
+	// tracked files overlap the committed file set and contents match the
+	// shadow branch.
 	AttachReasonFileOverlap AttachReason = "file_overlap"
 
 	// AttachReasonManual: session was imported via `entire attach` (or
-	// `entire review attach`) and is therefore associated with the worktree
-	// by explicit user intent. Bypasses the file-overlap and read-only-active
-	// heuristics; only the "has new content" gate still applies.
+	// `entire review attach`). Bypasses heuristic gates — user intent wins.
 	AttachReasonManual AttachReason = "manual_attach"
 
-	// AttachSkipNoNewContent: no new transcript or files since the last
-	// condensation. Log-only.
 	AttachSkipNoNewContent AttachReason = "skip_no_new_content"
 
-	// AttachSkipReadOnlyActive: ACTIVE session with no tracked files of its
-	// own, and another session already claims the committed files. Avoids
-	// attaching read-only agents (e.g. summarize) to unrelated commits.
-	// Log-only.
+	// AttachSkipReadOnlyActive: avoids attaching read-only agents (e.g. a
+	// summarize tool) to commits owned by a different session.
 	AttachSkipReadOnlyActive AttachReason = "skip_read_only_active"
 
-	// AttachSkipNoTrackedFiles: stale ACTIVE or IDLE/ENDED session with no
-	// tracked files — no overlap evidence available. Log-only.
-	AttachSkipNoTrackedFiles AttachReason = "skip_no_tracked_files"
-
-	// AttachSkipNoCommittedOverlap: tracked files exist but none were touched
-	// by the commit. Log-only.
+	AttachSkipNoTrackedFiles     AttachReason = "skip_no_tracked_files"
 	AttachSkipNoCommittedOverlap AttachReason = "skip_no_committed_overlap"
-
-	// AttachSkipContentMismatch: files overlap by path but shadow-branch
-	// content does not match the committed content. Log-only.
-	AttachSkipContentMismatch AttachReason = "skip_content_mismatch"
+	AttachSkipContentMismatch    AttachReason = "skip_content_mismatch"
 )
 
 // IsAttach reports whether this reason resulted in the session being
-// attached to the checkpoint. Skip reasons return false.
-//
-// New AttachReason values must be added to one of the cases below — the
-// exhaustive linter will flag forgotten additions.
+// attached to the checkpoint. New AttachReason values must be added to one
+// of the cases below — the exhaustive linter will flag forgotten additions.
 func (r AttachReason) IsAttach() bool {
 	switch r {
 	case AttachReasonActiveRecentInteraction, AttachReasonFileOverlap, AttachReasonManual:

--- a/cmd/entire/cli/session/attach_reason.go
+++ b/cmd/entire/cli/session/attach_reason.go
@@ -1,0 +1,65 @@
+package session
+
+// AttachReason describes why a session was (or was not) attached to a
+// checkpoint during PostCommit condensation. It is logged at decision time
+// and — for attach reasons only — persisted on CommittedMetadata so
+// `entire checkpoint explain` and other tooling can answer "why is this
+// session here?" without rerunning with debug logs.
+//
+// Reasons starting with "skip_" are log-only and never persisted; they
+// describe the absence of an attachment.
+type AttachReason string
+
+const (
+	// AttachReasonActiveRecentInteraction: session is ACTIVE and had a recent
+	// agent interaction (within activeSessionInteractionThreshold). The
+	// PrepareCommitMsg gate already established commit relatedness, so no
+	// file overlap check is required.
+	AttachReasonActiveRecentInteraction AttachReason = "active_recent_interaction"
+
+	// AttachReasonFileOverlap: session is stale ACTIVE or IDLE/ENDED, but its
+	// tracked files overlap with the committed file set AND the file contents
+	// match the shadow branch (heuristic match).
+	AttachReasonFileOverlap AttachReason = "file_overlap"
+
+	// AttachSkipNoNewContent: no new transcript or files since the last
+	// condensation. Log-only.
+	AttachSkipNoNewContent AttachReason = "skip_no_new_content"
+
+	// AttachSkipReadOnlyActive: ACTIVE session with no tracked files of its
+	// own, and another session already claims the committed files. Avoids
+	// attaching read-only agents (e.g. summarize) to unrelated commits.
+	// Log-only.
+	AttachSkipReadOnlyActive AttachReason = "skip_read_only_active"
+
+	// AttachSkipNoTrackedFiles: stale ACTIVE or IDLE/ENDED session with no
+	// tracked files — no overlap evidence available. Log-only.
+	AttachSkipNoTrackedFiles AttachReason = "skip_no_tracked_files"
+
+	// AttachSkipNoCommittedOverlap: tracked files exist but none were touched
+	// by the commit. Log-only.
+	AttachSkipNoCommittedOverlap AttachReason = "skip_no_committed_overlap"
+
+	// AttachSkipContentMismatch: files overlap by path but shadow-branch
+	// content does not match the committed content. Log-only.
+	AttachSkipContentMismatch AttachReason = "skip_content_mismatch"
+)
+
+// IsAttach reports whether this reason resulted in the session being
+// attached to the checkpoint. Skip reasons return false.
+//
+// New AttachReason values must be added to one of the cases below — the
+// exhaustive linter will flag forgotten additions.
+func (r AttachReason) IsAttach() bool {
+	switch r {
+	case AttachReasonActiveRecentInteraction, AttachReasonFileOverlap:
+		return true
+	case AttachSkipNoNewContent,
+		AttachSkipReadOnlyActive,
+		AttachSkipNoTrackedFiles,
+		AttachSkipNoCommittedOverlap,
+		AttachSkipContentMismatch:
+		return false
+	}
+	return false
+}

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -102,13 +102,14 @@ func (s *ManualCommitStrategy) getCheckpointLog(ctx context.Context, checkpointI
 
 // condenseOpts provides pre-resolved git objects to avoid redundant reads.
 type condenseOpts struct {
-	shadowRef        *plumbing.Reference // Pre-resolved shadow branch ref (nil = resolve from repo)
-	headTree         *object.Tree        // Pre-resolved HEAD tree (passed through to calculateSessionAttributions)
-	parentTree       *object.Tree        // Pre-resolved parent tree (nil for initial commits, for consistent non-agent line counting)
-	repoDir          string              // Repository worktree path for git CLI commands
-	parentCommitHash string              // HEAD's first parent hash for per-commit non-agent file detection
-	headCommitHash   string              // HEAD commit hash (passed through for attribution)
-	allAgentFiles    map[string]struct{} // Union of all sessions' FilesTouched for cross-session exclusion (nil = single-session)
+	shadowRef        *plumbing.Reference  // Pre-resolved shadow branch ref (nil = resolve from repo)
+	headTree         *object.Tree         // Pre-resolved HEAD tree (passed through to calculateSessionAttributions)
+	parentTree       *object.Tree         // Pre-resolved parent tree (nil for initial commits, for consistent non-agent line counting)
+	repoDir          string               // Repository worktree path for git CLI commands
+	parentCommitHash string               // HEAD's first parent hash for per-commit non-agent file detection
+	headCommitHash   string               // HEAD commit hash (passed through for attribution)
+	allAgentFiles    map[string]struct{}  // Union of all sessions' FilesTouched for cross-session exclusion (nil = single-session)
+	attachReason     session.AttachReason // Why this session was attached to the checkpoint (persisted on CommittedMetadata; empty = not set)
 }
 
 var redactSessionJSONLBytes = redact.JSONLBytes
@@ -250,6 +251,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		ReviewSkills:                state.ReviewSkills,
 		ReviewPrompt:                state.ReviewPrompt,
 		HasReview:                   state.Kind.IsReview(),
+		AttachReason:                string(o.attachReason),
 	}
 
 	compactResult := buildExternalCompactTranscript(ctx, ag, state)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -689,7 +689,7 @@ func (h *postCommitActionHandler) parentCommitHash() string {
 }
 
 func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
-	shouldCondense, reason := h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime, state.AttachedManually)
+	shouldCondense, reason := h.shouldCondenseWithOverlapCheck(state)
 	h.logAttachDecision(state, "HandleCondense", shouldCondense, reason, 0)
 
 	if shouldCondense {
@@ -710,20 +710,16 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 }
 
 func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.State) error {
-	// HandleCondenseIfFilesTouched normally gates on files_touched > 0 before
-	// consulting the overlap check; reflect that gate in the attach_reason so
-	// the log distinguishes "no files at all" from "no overlap evidence".
-	// Manually-attached sessions skip the gate — review attach in particular
-	// may legitimately have no files touched, and the user's import is the
-	// explicit signal we honor in place of file evidence.
+	// Manually-attached sessions skip the files-touched gate — review attach
+	// in particular may legitimately have no files touched, and the user's
+	// import is the explicit signal we honor in place of file evidence.
 	var (
 		shouldCondense bool
 		reason         session.AttachReason
 	)
-	switch {
-	case state.AttachedManually || len(state.FilesTouched) > 0:
-		shouldCondense, reason = h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime, state.AttachedManually)
-	default:
+	if state.AttachedManually || len(state.FilesTouched) > 0 {
+		shouldCondense, reason = h.shouldCondenseWithOverlapCheck(state)
+	} else {
 		reason = session.AttachSkipNoTrackedFiles
 	}
 	h.logAttachDecision(state, "HandleCondenseIfFilesTouched", shouldCondense, reason, len(state.FilesTouched))
@@ -745,11 +741,6 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 	return nil
 }
 
-// logAttachDecision emits the single consistent log line for "should this
-// session be attached to the current checkpoint?". One greppable shape
-// (component=checkpoint, msg="post-commit: attach decision") with the
-// trigger (Handle* method that ran), attach_reason, and attached fields,
-// so multi-session checkpoints can be traced from one log query.
 func (h *postCommitActionHandler) logAttachDecision(state *session.State, trigger string, attached bool, reason session.AttachReason, filesTouched int) {
 	logCtx := logging.WithComponent(h.ctx, "checkpoint")
 	logging.Debug(logCtx, "post-commit: attach decision",
@@ -766,22 +757,13 @@ func (h *postCommitActionHandler) logAttachDecision(state *session.State, trigge
 
 // shouldCondenseWithOverlapCheck returns whether the session should be
 // condensed into this commit, along with the AttachReason that named the
-// decision. Active sessions with recent interaction condense unless they
-// have no tracked files and another session claims the committed files
-// (read-only gate). Stale ACTIVE and IDLE/ENDED sessions require file
-// overlap evidence between tracked files and committed files. Manually
-// attached sessions (imported via `entire attach` / `entire review attach`)
-// bypass the heuristic branches entirely — they reflect explicit user
-// intent, which we trust over file-content heuristics.
-//
-// Attach reasons (true): active_recent_interaction, file_overlap, manual_attach.
-// Skip reasons (false): skip_no_new_content, skip_read_only_active,
-// skip_no_tracked_files, skip_no_committed_overlap, skip_content_mismatch.
-func (h *postCommitActionHandler) shouldCondenseWithOverlapCheck(isActive bool, lastInteraction *time.Time, attachedManually bool) (bool, session.AttachReason) {
+// decision. Manually attached sessions bypass the heuristic branches —
+// the user's import is a stronger signal than file-content evidence.
+func (h *postCommitActionHandler) shouldCondenseWithOverlapCheck(state *session.State) (bool, session.AttachReason) {
 	if !h.hasNew {
 		return false, session.AttachSkipNoNewContent
 	}
-	if attachedManually {
+	if state.AttachedManually {
 		return true, session.AttachReasonManual
 	}
 	// ACTIVE sessions with recent interaction: skip the overlap check.
@@ -799,7 +781,7 @@ func (h *postCommitActionHandler) shouldCondenseWithOverlapCheck(isActive bool, 
 	// We check LastInteractionTime to avoid condensing stale ACTIVE sessions
 	// (agent killed without Stop hook) into every subsequent commit. A stale
 	// session has no recent interaction and falls through to the overlap check.
-	if isActive && isRecentInteraction(lastInteraction) {
+	if state.Phase.IsActive() && isRecentInteraction(state.LastInteractionTime) {
 		if h.sessionsWithCommittedFiles > 0 && len(h.filesTouchedBefore) == 0 {
 			return false, session.AttachSkipReadOnlyActive
 		}
@@ -1425,17 +1407,12 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 	state.LastCheckpointID = checkpointID
 	state.LastCheckpointCommitHash = newHead
 
-	var attachReason session.AttachReason
-	if len(opts) > 0 {
-		attachReason = opts[0].attachReason
-	}
 	logging.Info(logCtx, "session condensed",
 		slog.String("strategy", "manual-commit"),
 		slog.String("session_id", state.SessionID),
 		slog.String("checkpoint_id", result.CheckpointID.String()),
 		slog.Int("checkpoints_condensed", result.CheckpointsCount),
 		slog.Int("transcript_lines", result.TotalTranscriptLines),
-		slog.String("attach_reason", string(attachReason)),
 	)
 
 	return true

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -689,16 +689,8 @@ func (h *postCommitActionHandler) parentCommitHash() string {
 }
 
 func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
-	logCtx := logging.WithComponent(h.ctx, "checkpoint")
-	shouldCondense := h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime)
-
-	logging.Debug(logCtx, "post-commit: HandleCondense decision",
-		slog.String("session_id", state.SessionID),
-		slog.String("phase", string(state.Phase)),
-		slog.Bool("has_new", h.hasNew),
-		slog.Bool("should_condense", shouldCondense),
-		slog.String("shadow_branch", h.shadowBranchName),
-	)
+	shouldCondense, reason := h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime)
+	h.logAttachDecision(state, "HandleCondense", shouldCondense, reason, 0)
 
 	if shouldCondense {
 		h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
@@ -709,6 +701,7 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 			parentCommitHash: h.parentCommitHash(),
 			headCommitHash:   h.newHead,
 			allAgentFiles:    h.allAgentFiles,
+			attachReason:     reason,
 		})
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
@@ -717,17 +710,19 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 }
 
 func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.State) error {
-	logCtx := logging.WithComponent(h.ctx, "checkpoint")
-	shouldCondense := len(state.FilesTouched) > 0 && h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime)
-
-	logging.Debug(logCtx, "post-commit: HandleCondenseIfFilesTouched decision",
-		slog.String("session_id", state.SessionID),
-		slog.String("phase", string(state.Phase)),
-		slog.Bool("has_new", h.hasNew),
-		slog.Int("files_touched", len(state.FilesTouched)),
-		slog.Bool("should_condense", shouldCondense),
-		slog.String("shadow_branch", h.shadowBranchName),
+	// HandleCondenseIfFilesTouched gates on files_touched > 0 before consulting
+	// the overlap check; reflect that gate in the attach_reason so the log
+	// distinguishes "no files at all" from "no overlap evidence".
+	var (
+		shouldCondense bool
+		reason         session.AttachReason
 	)
+	if len(state.FilesTouched) > 0 {
+		shouldCondense, reason = h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime)
+	} else {
+		reason = session.AttachSkipNoTrackedFiles
+	}
+	h.logAttachDecision(state, "HandleCondenseIfFilesTouched", shouldCondense, reason, len(state.FilesTouched))
 
 	if shouldCondense {
 		h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
@@ -738,6 +733,7 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 			parentCommitHash: h.parentCommitHash(),
 			headCommitHash:   h.newHead,
 			allAgentFiles:    h.allAgentFiles,
+			attachReason:     reason,
 		})
 	} else {
 		h.s.updateBaseCommitIfChanged(h.ctx, state, h.newHead)
@@ -745,14 +741,38 @@ func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.St
 	return nil
 }
 
-// shouldCondenseWithOverlapCheck returns true if the session should be condensed
-// into this commit. Active sessions with recent interaction condense unless they
-// have no tracked files and another session claims the committed files (read-only
-// gate). Stale ACTIVE and IDLE/ENDED sessions require file overlap evidence
-// between tracked files and committed files.
-func (h *postCommitActionHandler) shouldCondenseWithOverlapCheck(isActive bool, lastInteraction *time.Time) bool {
+// logAttachDecision emits the single consistent log line for "should this
+// session be attached to the current checkpoint?". One greppable shape
+// (component=checkpoint, msg="post-commit: attach decision") with the
+// trigger (Handle* method that ran), attach_reason, and attached fields,
+// so multi-session checkpoints can be traced from one log query.
+func (h *postCommitActionHandler) logAttachDecision(state *session.State, trigger string, attached bool, reason session.AttachReason, filesTouched int) {
+	logCtx := logging.WithComponent(h.ctx, "checkpoint")
+	logging.Debug(logCtx, "post-commit: attach decision",
+		slog.String("session_id", state.SessionID),
+		slog.String("phase", string(state.Phase)),
+		slog.String("trigger", trigger),
+		slog.Bool("attached", attached),
+		slog.String("attach_reason", string(reason)),
+		slog.Bool("has_new", h.hasNew),
+		slog.Int("files_touched", filesTouched),
+		slog.String("shadow_branch", h.shadowBranchName),
+	)
+}
+
+// shouldCondenseWithOverlapCheck returns whether the session should be
+// condensed into this commit, along with the AttachReason that named the
+// decision. Active sessions with recent interaction condense unless they
+// have no tracked files and another session claims the committed files
+// (read-only gate). Stale ACTIVE and IDLE/ENDED sessions require file
+// overlap evidence between tracked files and committed files.
+//
+// Attach reasons (true): active_recent_interaction, file_overlap.
+// Skip reasons (false): skip_no_new_content, skip_read_only_active,
+// skip_no_tracked_files, skip_no_committed_overlap, skip_content_mismatch.
+func (h *postCommitActionHandler) shouldCondenseWithOverlapCheck(isActive bool, lastInteraction *time.Time) (bool, session.AttachReason) {
 	if !h.hasNew {
-		return false
+		return false, session.AttachSkipNoNewContent
 	}
 	// ACTIVE sessions with recent interaction: skip the overlap check.
 	// PrepareCommitMsg already validated this commit is session-related
@@ -771,15 +791,12 @@ func (h *postCommitActionHandler) shouldCondenseWithOverlapCheck(isActive bool, 
 	// session has no recent interaction and falls through to the overlap check.
 	if isActive && isRecentInteraction(lastInteraction) {
 		if h.sessionsWithCommittedFiles > 0 && len(h.filesTouchedBefore) == 0 {
-			logging.Debug(h.ctx, "post-commit: skipping read-only ACTIVE session (no tracked files, other sessions claim committed files)",
-				slog.Int("sessions_with_committed_files", h.sessionsWithCommittedFiles),
-			)
-			return false
+			return false, session.AttachSkipReadOnlyActive
 		}
-		return true
+		return true, session.AttachReasonActiveRecentInteraction
 	}
 	if len(h.filesTouchedBefore) == 0 {
-		return false // No files tracked = no overlap evidence
+		return false, session.AttachSkipNoTrackedFiles
 	}
 	// Only check files that were actually changed in this commit.
 	// Without this, files that exist in the tree but weren't changed
@@ -793,14 +810,17 @@ func (h *postCommitActionHandler) shouldCondenseWithOverlapCheck(isActive bool, 
 		}
 	}
 	if len(committedTouchedFiles) == 0 {
-		return false
+		return false, session.AttachSkipNoCommittedOverlap
 	}
-	return filesOverlapWithContent(h.ctx, h.repo, h.shadowBranchName, h.commit, committedTouchedFiles, overlapOpts{
+	if filesOverlapWithContent(h.ctx, h.repo, h.shadowBranchName, h.commit, committedTouchedFiles, overlapOpts{
 		headTree:      h.headTree,
 		shadowTree:    h.shadowTree,
 		parentTree:    h.parentTree,
 		hasParentTree: true,
-	})
+	}) {
+		return true, session.AttachReasonFileOverlap
+	}
+	return false, session.AttachSkipContentMismatch
 }
 
 const (
@@ -1395,12 +1415,17 @@ func (s *ManualCommitStrategy) condenseAndUpdateState(
 	state.LastCheckpointID = checkpointID
 	state.LastCheckpointCommitHash = newHead
 
+	var attachReason session.AttachReason
+	if len(opts) > 0 {
+		attachReason = opts[0].attachReason
+	}
 	logging.Info(logCtx, "session condensed",
 		slog.String("strategy", "manual-commit"),
 		slog.String("session_id", state.SessionID),
 		slog.String("checkpoint_id", result.CheckpointID.String()),
 		slog.Int("checkpoints_condensed", result.CheckpointsCount),
 		slog.Int("transcript_lines", result.TotalTranscriptLines),
+		slog.String("attach_reason", string(attachReason)),
 	)
 
 	return true

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -689,7 +689,7 @@ func (h *postCommitActionHandler) parentCommitHash() string {
 }
 
 func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
-	shouldCondense, reason := h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime)
+	shouldCondense, reason := h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime, state.AttachedManually)
 	h.logAttachDecision(state, "HandleCondense", shouldCondense, reason, 0)
 
 	if shouldCondense {
@@ -710,16 +710,20 @@ func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 }
 
 func (h *postCommitActionHandler) HandleCondenseIfFilesTouched(state *session.State) error {
-	// HandleCondenseIfFilesTouched gates on files_touched > 0 before consulting
-	// the overlap check; reflect that gate in the attach_reason so the log
-	// distinguishes "no files at all" from "no overlap evidence".
+	// HandleCondenseIfFilesTouched normally gates on files_touched > 0 before
+	// consulting the overlap check; reflect that gate in the attach_reason so
+	// the log distinguishes "no files at all" from "no overlap evidence".
+	// Manually-attached sessions skip the gate — review attach in particular
+	// may legitimately have no files touched, and the user's import is the
+	// explicit signal we honor in place of file evidence.
 	var (
 		shouldCondense bool
 		reason         session.AttachReason
 	)
-	if len(state.FilesTouched) > 0 {
-		shouldCondense, reason = h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime)
-	} else {
+	switch {
+	case state.AttachedManually || len(state.FilesTouched) > 0:
+		shouldCondense, reason = h.shouldCondenseWithOverlapCheck(state.Phase.IsActive(), state.LastInteractionTime, state.AttachedManually)
+	default:
 		reason = session.AttachSkipNoTrackedFiles
 	}
 	h.logAttachDecision(state, "HandleCondenseIfFilesTouched", shouldCondense, reason, len(state.FilesTouched))
@@ -765,14 +769,20 @@ func (h *postCommitActionHandler) logAttachDecision(state *session.State, trigge
 // decision. Active sessions with recent interaction condense unless they
 // have no tracked files and another session claims the committed files
 // (read-only gate). Stale ACTIVE and IDLE/ENDED sessions require file
-// overlap evidence between tracked files and committed files.
+// overlap evidence between tracked files and committed files. Manually
+// attached sessions (imported via `entire attach` / `entire review attach`)
+// bypass the heuristic branches entirely — they reflect explicit user
+// intent, which we trust over file-content heuristics.
 //
-// Attach reasons (true): active_recent_interaction, file_overlap.
+// Attach reasons (true): active_recent_interaction, file_overlap, manual_attach.
 // Skip reasons (false): skip_no_new_content, skip_read_only_active,
 // skip_no_tracked_files, skip_no_committed_overlap, skip_content_mismatch.
-func (h *postCommitActionHandler) shouldCondenseWithOverlapCheck(isActive bool, lastInteraction *time.Time) (bool, session.AttachReason) {
+func (h *postCommitActionHandler) shouldCondenseWithOverlapCheck(isActive bool, lastInteraction *time.Time, attachedManually bool) (bool, session.AttachReason) {
 	if !h.hasNew {
 		return false, session.AttachSkipNoNewContent
+	}
+	if attachedManually {
+		return true, session.AttachReasonManual
 	}
 	// ACTIVE sessions with recent interaction: skip the overlap check.
 	// PrepareCommitMsg already validated this commit is session-related

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -690,7 +690,7 @@ func (h *postCommitActionHandler) parentCommitHash() string {
 
 func (h *postCommitActionHandler) HandleCondense(state *session.State) error {
 	shouldCondense, reason := h.shouldCondenseWithOverlapCheck(state)
-	h.logAttachDecision(state, "HandleCondense", shouldCondense, reason, 0)
+	h.logAttachDecision(state, "HandleCondense", shouldCondense, reason, len(state.FilesTouched))
 
 	if shouldCondense {
 		h.condensed = h.s.condenseAndUpdateState(h.ctx, h.repo, h.checkpointID, state, h.head, h.shadowBranchName, h.shadowBranchesToDelete, h.committedFileSet, condenseOpts{
@@ -1237,7 +1237,11 @@ func (s *ManualCommitStrategy) postCommitProcessSessionLocked(
 			)
 		}
 	}
-	transitionCtx.HasFilesTouched = len(state.FilesTouched) > 0
+	// Manually attached sessions are routed through the condense action even
+	// without tracked files: the user's `entire attach` import is the signal
+	// we honor in place of file overlap. shouldCondenseWithOverlapCheck then
+	// short-circuits to AttachReasonManual once it sees AttachedManually.
+	transitionCtx.HasFilesTouched = len(state.FilesTouched) > 0 || state.AttachedManually
 
 	// Save FilesTouched BEFORE TransitionAndLog — the handler's condensation
 	// clears it, but we need the original list for carry-forward computation.

--- a/cmd/entire/cli/strategy/phase_postcommit_test.go
+++ b/cmd/entire/cli/strategy/phase_postcommit_test.go
@@ -116,6 +116,50 @@ func TestPostCommit_IdleSession_Condenses(t *testing.T) {
 		"shadow branch should be deleted after condensation for IDLE session")
 }
 
+// TestPostCommit_ManualAttach_BypassesFilesTouchedGate verifies that a
+// session marked AttachedManually=true is condensed even when its
+// FilesTouched list is empty, and that the persisted CommittedMetadata
+// records the "manual_attach" reason. `entire attach` / `entire review
+// attach` import sessions whose transcript is the load-bearing artifact;
+// file evidence may be missing, so the heuristic gates must be bypassed.
+func TestPostCommit_ManualAttach_BypassesFilesTouchedGate(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	s := &ManualCommitStrategy{}
+	sessionID := "test-postcommit-manual-attach"
+
+	setupSessionWithCheckpoint(t, s, repo, dir, sessionID)
+
+	state, err := s.loadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	state.Phase = session.PhaseEnded
+	state.FilesTouched = nil
+	state.AttachedManually = true
+	now := time.Now()
+	state.LastInteractionTime = &now
+	require.NoError(t, s.saveSessionState(context.Background(), state))
+
+	const cpIDStr = "ee99dd88cc77"
+	commitWithCheckpointTrailer(t, repo, dir, cpIDStr)
+
+	err = s.PostCommit(context.Background())
+	require.NoError(t, err)
+
+	_, err = repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err,
+		"entire/checkpoints/v1 should exist — manual_attach bypasses the no-tracked-files gate")
+
+	store := checkpoint.NewGitStore(repo)
+	content, err := store.ReadSessionContent(context.Background(), id.MustCheckpointID(cpIDStr), 0)
+	require.NoError(t, err)
+	assert.Equal(t, "manual_attach", content.Metadata.AttachReason,
+		"manually-attached session should record manual_attach on CommittedMetadata")
+}
+
 // TestPostCommit_RebaseDuringActive_SkipsTransition verifies that PostCommit
 // is a no-op during rebase operations, leaving the session phase unchanged.
 func TestPostCommit_RebaseDuringActive_SkipsTransition(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/368
<!-- entire-trail-link-end -->

**Track attach reason on checkpoints**

PostCommit decides per session whether to condense it into the current commit's checkpoint, with several decision branches (active-recent-interaction, file overlap, read-only-active skip, etc.). The decision logged only true/false, making it hard to trace why multiple sessions ended up under one checkpoint.

This PR makes the decision a first-class signal:

- **`session.AttachReason`** typed string names each branch (`active_recent_interaction`, `file_overlap`, `manual_attach`, plus skip variants)
- **One greppable debug log** (`"post-commit: attach decision"`) replaces two divergent decision logs, carrying `trigger` (which `Handle*` ran), `attach_reason`, `attached`, and surrounding signals
- **Persisted on `CommittedMetadata.AttachReason`** (`metadata.json`) so `entire checkpoint explain` and downstream tooling can answer "why is this session here?" without rerunning with debug logs
- **`manual_attach`** is a first-class reason: `entire attach` / `entire review attach` imports were previously subject to heuristic gates that could reject them despite explicit user intent. Manually-attached sessions now bypass the file-overlap, read-only-active, content-match, and files-touched gates; only the `hasNew` gate still applies.

Skip reasons stay log-only; only attach reasons are persisted.

**Commits**
- `7514af3df` Track attach reason on checkpoint metadata and logs
- `65018f258` Track manual_attach as an attach reason
- `dfb60a8ec` Simplify attach-reason plumbing per review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PostCommit condensation behavior by allowing manually-attached sessions to bypass several heuristic gates, which could affect which sessions are recorded under a checkpoint. Also adds a new persisted metadata field, so downstream consumers must tolerate the new `attach_reason` value.
> 
> **Overview**
> **PostCommit condensation now records *why* a session was (or wasn’t) attached.** It introduces `session.AttachReason` (attach + skip reasons), replaces prior boolean decision logs with a single greppable debug log including `attach_reason` and `trigger`, and threads the reason through condensation.
> 
> **Checkpoint session metadata now persists this decision.** `CommittedMetadata`/`WriteCommittedOptions` gain `AttachReason` and both v1 (`committed.go`) and v2 (`v2_committed.go`) writers store it as `attach_reason` in per-session `metadata.json`.
> 
> **Manual imports are treated as first-class attaches.** Sessions marked `AttachedManually` bypass the `files_touched` gate and other heuristic checks (overlap/content-match/read-only-active), attaching with reason `manual_attach` as long as there’s new content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb60a8ec0f913bcc7eafa0ae6a891adc6c8834d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->