### PR TITLE
Skip 'remote not reachable' hint when v2 partial push succeeded

### DIFF
--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -898,7 +898,14 @@ func printV2PartialPushResult(w io.Writer, successfulRefs []plumbing.ReferenceNa
 
 func printV2PushFailures(ctx context.Context, target string, successfulRefs []plumbing.ReferenceName, failures []error, pushedContent bool) {
 	printV2PartialPushResult(os.Stderr, successfulRefs, failures)
-	printCheckpointRemoteHint(target)
+	// Skip the "remote could not be reached" hint when some refs already
+	// pushed — that's proof the remote is reachable, and the remaining
+	// failures are per-ref (e.g. /full/current's archive history doesn't
+	// match remote), not connectivity. Without this guard the hint
+	// contradicts the "Successfully pushed …" line printed just above.
+	if len(successfulRefs) == 0 {
+		printCheckpointRemoteHint(target)
+	}
 	if pushedContent {
 		printSettingsCommitHint(ctx, target)
 	}

--- a/cmd/entire/cli/strategy/push_v2_test.go
+++ b/cmd/entire/cli/strategy/push_v2_test.go
@@ -808,6 +808,53 @@ func TestPrintV2PartialPushResult(t *testing.T) {
 	assert.NotContains(t, output.String(), "[entire] All v2 checkpoints pushed")
 }
 
+// Regression: when v2/main pushes successfully but v2/full/current fails for
+// a per-ref logical reason (e.g. "no remote archive shares history"), the
+// summary used to print "checkpoint remote ... could not be reached" right
+// after "Successfully pushed v2/main", contradicting itself. The connectivity
+// hint must be suppressed whenever any ref pushed successfully.
+//
+// Not parallel: printCheckpointRemoteHint writes to os.Stderr directly.
+func TestPrintV2PushFailures_SkipsUnreachableHintWhenAnyRefPushed(t *testing.T) {
+	urlTarget := "https://example.com/checkpoints.git"
+
+	restore := captureStderr(t)
+	printV2PushFailures(
+		context.Background(),
+		urlTarget,
+		[]plumbing.ReferenceName{plumbing.ReferenceName(paths.V2MainRefName)},
+		[]error{errors.New("couldn't sync v2/full/current: failed to find related archived generation: no remote archive shares history with local /full/current")},
+		true,
+	)
+	output := restore()
+
+	assert.Contains(t, output, "Successfully pushed v2/main")
+	assert.Contains(t, output, "no remote archive shares history")
+	assert.NotContains(t, output, "could not be reached",
+		"successful pushes prove reachability — the unreachable hint must be suppressed")
+}
+
+// When zero refs pushed, the connectivity hint is still the most useful
+// guidance and must remain. Pinned so the previous fix doesn't over-suppress.
+//
+// Not parallel: printCheckpointRemoteHint writes to os.Stderr directly.
+func TestPrintV2PushFailures_PrintsUnreachableHintWhenNoRefsPushed(t *testing.T) {
+	urlTarget := "https://example.com/checkpoints.git"
+
+	restore := captureStderr(t)
+	printV2PushFailures(
+		context.Background(),
+		urlTarget,
+		nil,
+		[]error{errors.New("failed to push v2/main: dial tcp: lookup example.com: no such host")},
+		false,
+	)
+	output := restore()
+
+	assert.Contains(t, output, "could not be reached",
+		"with no successful refs the connectivity hint is still useful")
+}
+
 func TestParsePushRefResults_MultiRefPorcelain(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/369
<!-- entire-trail-link-end -->

When v2/main pushed successfully but v2/full/current failed with a per-ref logical mismatch (e.g. "no remote archive shares history with local /full/current"), printV2PushFailures still printed the connectivity hint right under "Successfully pushed v2/main". The two lines contradicted each other and pointed users at the wrong problem. Suppress the hint whenever any ref pushed; reserve it for the truly-no-contact case.

Entire-Checkpoint: 99517359536f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only CLI failure messaging and adds regression tests; no checkpoint data handling or push logic is modified.
> 
> **Overview**
> Avoids misleading v2 push guidance by **only printing the “checkpoint remote … could not be reached” hint when *no* refs were pushed successfully**.
> 
> Adds regression coverage ensuring the hint is suppressed on partial success (e.g. `v2/main` pushed but `v2/full/current` failed for a logical mismatch) and still shown when all refs fail due to connectivity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bf69a9700151dabdee90140d68fc411991a1184. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->