### PR TITLE
Rename `codex_hooks` → `hooks` in docs and internal naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Local settings override project settings field-by-field. When you run `entire st
 
 ### Agent-Specific Steps & Limitations
 
-- When enabling Entire for Codex, the command will also create or update `.codex/config.toml` with `codex_hooks = true` to enable Codex hooks. If you configure Codex manually, make sure this flag is set in your `.codex/config.toml`. Or select Codex from the interactive agent picker when running `entire enable`.
+- When enabling Entire for Codex, the command will also create or update `.codex/config.toml` with `hooks = true` under `[features]` to enable Codex hooks. If you configure Codex manually, make sure this flag is set in your `.codex/config.toml`. (The older `codex_hooks` key still works as a deprecated alias but emits a startup warning; Entire migrates it to `hooks` automatically.) Or select Codex from the interactive agent picker when running `entire enable`.
 - Entire supports Cursor IDE and Cursor Agent CLI tool, but `entire rewind` is not available at this time. Other commands (`doctor`, `status` etc.) work the same as all other agents.
 - Entire supports Copilot CLI, but not Copilot in VS Code, in other IDEs, or on github.com.
 

--- a/cmd/entire/cli/agent/codex/AGENT.md
+++ b/cmd/entire/cli/agent/codex/AGENT.md
@@ -193,7 +193,7 @@ The `systemMessage` field can be used to display messages to the user via the ag
 
 ## Gaps & Limitations
 
-- **Hooks require feature flag:** The `codex_hooks` feature is `default_enabled: false` (stage: UnderDevelopment). It must be enabled via `--enable codex_hooks` CLI flag, or `features.codex_hooks = true` in `config.toml`, or `-c features.codex_hooks=true`. Without this, hooks.json is ignored entirely.
+- **Hooks feature flag:** The `hooks` feature is `default_enabled: true` (stage: Stable) on current Codex. Older Codex builds (and any project that disabled it) need it enabled explicitly via `--enable hooks` on the CLI, `features.hooks = true` in `config.toml`, or `-c features.hooks=true`. The legacy key `codex_hooks` is still accepted as a deprecated alias but emits a startup warning every run; Entire migrates legacy lines to the new form automatically. Without the feature enabled, hooks.json is ignored entirely.
 - **No SessionEnd hook:** Codex does not fire a hook when a session is completely terminated. The `Stop` hook fires at end-of-turn, not end-of-session. This is similar to some other agents — the framework handles this gracefully.
 - **PreToolUse is shell-only:** Currently only fires for `Bash` tool (direct shell execution). MCP tools, stdin streaming, and other tool types are not yet hooked. PostToolUse is in review.
 - **Transcript may be null:** In `--ephemeral` mode, `transcript_path` is null. The integration should handle this gracefully.

--- a/cmd/entire/cli/agent/codex/hooks.go
+++ b/cmd/entire/cli/agent/codex/hooks.go
@@ -118,7 +118,7 @@ func (c *CodexAgent) InstallHooks(ctx context.Context, localDev bool, force bool
 		// Still ensure the feature flag is configured even if hooks
 		// were already present (e.g., manually installed).
 		if err := ensureProjectFeatureEnabled(repoRoot); err != nil {
-			return 0, fmt.Errorf("failed to enable codex_hooks feature: %w", err)
+			return 0, fmt.Errorf("failed to enable hooks feature: %w", err)
 		}
 		return 0, nil
 	}
@@ -155,10 +155,10 @@ func (c *CodexAgent) InstallHooks(ctx context.Context, localDev bool, force bool
 		return 0, fmt.Errorf("failed to write hooks.json: %w", err)
 	}
 
-	// Enable the codex_hooks feature in the project-level .codex/config.toml.
+	// Enable the hooks feature in the project-level .codex/config.toml.
 	// This keeps the feature flag per-repo rather than global.
 	if err := ensureProjectFeatureEnabled(repoRoot); err != nil {
-		return count, fmt.Errorf("failed to enable codex_hooks feature: %w", err)
+		return count, fmt.Errorf("failed to enable hooks feature: %w", err)
 	}
 
 	return count, nil


### PR DESCRIPTION
Fixes #1205.

## Summary

Codex renamed the `codex_hooks` feature flag to `hooks`, made it `default_enabled: true`, and moved it to stage `Stable`. The legacy key is still accepted but emits a deprecation warning on every Codex startup.

The CLI already writes `hooks = true` and migrates legacy `codex_hooks = true` lines in place (see `ensureProjectFeatureEnabled` and `TestInstallHooks_RewritesLegacyFeatureLine`). What was still stale:

- `README.md:435` — told users to set `codex_hooks = true` if configuring manually.
- `cmd/entire/cli/agent/codex/AGENT.md:196` — described the feature as `default_enabled: false` (stage `UnderDevelopment`), and the examples used legacy syntax.
- `cmd/entire/cli/agent/codex/hooks.go` — error messages (lines 121, 161) and a comment (line 158) mentioned `codex_hooks`.

This PR renames in those three surfaces only. No behaviour change.

## Why keep writing `hooks = true` (and not just drop it)

`default_enabled: true` means current Codex doesn't strictly need the line, but:

- Users on older Codex builds where the default was still `false` would silently lose hooks.
- `ensureProjectFeatureEnabled` is idempotent (returns early when the new line is present), so writing it costs nothing on current Codex.
- Explicit is better — `.codex/config.toml` documents which features Entire expects.

Rename, don't remove.

## What stays

- The `legacyFeatureLine = "codex_hooks = true"` constant and surrounding migration logic in `hooks.go` are unchanged — they're how the CLI rewrites the deprecated form when it encounters a legacy config.
- `TestInstallHooks_RewritesLegacyFeatureLine` continues to lock in that behaviour.
- README and AGENT.md now mention `codex_hooks` only as the deprecated alias that is migrated automatically.

## Evidence from upstream (Codex `main`, latest 0.130.0)

`codex-rs/features/src/lib.rs`:

```rust
FeatureSpec {
    id: Feature::CodexHooks,
    key: "hooks",
    stage: Stage::Stable,
    default_enabled: true,
},
```

`codex-rs/features/src/legacy.rs` keeps `codex_hooks` as a legacy alias.

## Test plan

- [x] `mise run fmt && mise run lint` — 0 issues
- [x] `mise run test:ci` — all unit, integration, and canary E2E tests pass
- [x] `go test ./cmd/entire/cli/agent/codex/... -run TestInstallHooks` — including legacy-rewrite regression