### PR TITLE
Clarify v2 push failure message

### DIFF
--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -854,7 +854,9 @@ func pushV2Refs(ctx context.Context, target string) {
 			slog.String("error", pendingPublishErr.Error()),
 		)
 		skipped := append([]plumbing.ReferenceName{}, pendingPublicationResult.failedRefs...)
-		skipped = append(skipped, refs...)
+		for _, ref := range refs {
+			skipped = appendUniqueRef(skipped, ref)
+		}
 		if len(skipped) > 0 {
 			verb := "were"
 			if len(skipped) == 1 {

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -916,7 +916,9 @@ func printV2PartialPushResult(w io.Writer, successfulRefs []plumbing.ReferenceNa
 
 func printV2PushFailures(ctx context.Context, target string, successfulRefs []plumbing.ReferenceName, failures []error, pushedContent bool) {
 	printV2PartialPushResult(os.Stderr, successfulRefs, failures)
-	printCheckpointRemoteHint(target)
+	if len(successfulRefs) == 0 {
+		printCheckpointRemoteHint(target)
+	}
 	if pushedContent {
 		printSettingsCommitHint(ctx, target)
 	}

--- a/cmd/entire/cli/strategy/push_v2.go
+++ b/cmd/entire/cli/strategy/push_v2.go
@@ -48,6 +48,7 @@ type v2RefPushResult struct {
 
 type pendingV2FullGenerationPublicationResult struct {
 	successfulRefs          []plumbing.ReferenceName
+	failedRefs              []plumbing.ReferenceName
 	fullCurrentResetHandled bool
 }
 
@@ -153,6 +154,7 @@ func publishPendingV2FullGenerationPublications(
 		var archivePushErr error
 		for _, pushResult := range tryPushV2Refs(ctx, target, archiveRefs) {
 			if pushResult.err != nil {
+				result.failedRefs = append(result.failedRefs, pushResult.refName)
 				if archivePushErr == nil {
 					archivePushErr = fmt.Errorf("push pending archive %s: %w", shortRefName(pushResult.refName), pushResult.err)
 				}
@@ -195,6 +197,7 @@ func publishPendingV2FullGenerationPublications(
 	}
 	currentRefSpec := fmt.Sprintf("%s:%s", currentRefName, currentRefName)
 	if err := pushWithLease(ctx, target, currentRefSpec, currentRefName.String(), expectedRemoteHash, "push rotated "+shortRefName(currentRefName)); err != nil {
+		result.failedRefs = append(result.failedRefs, currentRefName)
 		return result, fmt.Errorf("push rotated %s: %w", shortRefName(currentRefName), err)
 	}
 	result.successfulRefs = append(result.successfulRefs, currentRefName)
@@ -847,7 +850,20 @@ func pushV2Refs(ctx context.Context, target string) {
 		pushedContent = true
 	}
 	if pendingPublishErr != nil {
-		failures = append(failures, fmt.Errorf("couldn't publish pending v2 full generation refs: %w", pendingPublishErr))
+		logging.Debug(ctx, "push-v2: pending publication failed",
+			slog.String("error", pendingPublishErr.Error()),
+		)
+		skipped := append([]plumbing.ReferenceName{}, pendingPublicationResult.failedRefs...)
+		skipped = append(skipped, refs...)
+		if len(skipped) > 0 {
+			verb := "were"
+			if len(skipped) == 1 {
+				verb = "was"
+			}
+			failures = append(failures, fmt.Errorf("%s %s not pushed", strings.Join(shortRefNames(skipped), ", "), verb))
+		} else {
+			failures = append(failures, fmt.Errorf("couldn't publish pending v2 full generation refs: %w", pendingPublishErr))
+		}
 		printV2PushFailures(ctx, target, successfulRefs, failures, pushedContent)
 		return
 	}

--- a/cmd/entire/cli/strategy/push_v2_test.go
+++ b/cmd/entire/cli/strategy/push_v2_test.go
@@ -378,11 +378,9 @@ func TestPushV2Refs_PushesPendingArchivePublications(t *testing.T) {
 }
 
 // TestPushV2Refs_PendingPublicationFailureLabelsSkippedActiveRefs verifies that
-// when pending v2 full archive publication fails, the warning output explicitly
-// names the active refs (v2/main, v2/full/current) that were not pushed.
-// Otherwise the user sees only the pending archive ref in the failure and is
-// left wondering whether the active refs that were announced earlier also
-// failed (they did — they were skipped).
+// when pending v2 full archive publication fails, the warning names the failed
+// archive and the skipped active refs (v2/main, v2/full/current) together in
+// one line and keeps the low-level git error out of user output.
 //
 // Not parallel: uses t.Chdir() and os.Stderr redirection.
 func TestPushV2Refs_PendingPublicationFailureLabelsSkippedActiveRefs(t *testing.T) {
@@ -392,47 +390,34 @@ func TestPushV2Refs_PendingPublicationFailureLabelsSkippedActiveRefs(t *testing.
 	repo, err := git.PlainOpen(tmpDir)
 	require.NoError(t, err)
 	store := checkpoint.NewV2GitStore(repo, "origin")
-
-	// Create /full/current via a checkpoint.
 	writeV2Checkpoint(t, repo, id.MustCheckpointID("aabbccddeeff"), "test-session")
 
 	archiveRef := plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000099")
-	localArchiveCommitHash := writeV2ArchiveRef(t, repo, archiveRef, "local archive")
+	writeV2ArchiveRef(t, repo, archiveRef, "local archive")
 	require.NoError(t, store.AppendPendingFullGenerationPublication(ctx, checkpoint.PendingV2FullGenerationPublication{
-		ArchiveRefName:    archiveRef.String(),
-		ArchiveCommitHash: localArchiveCommitHash.String(),
+		ArchiveRefName: archiveRef.String(),
 	}))
 
-	t.Chdir(tmpDir)
-
-	// Create bare remote and seed it with a divergent archive commit at the
-	// same ref so the local push is non-fast-forward.
 	bareDir := t.TempDir()
 	initCmd := exec.CommandContext(ctx, "git", "init", "--bare")
 	initCmd.Dir = bareDir
 	initCmd.Env = testutil.GitIsolatedEnv()
 	require.NoError(t, initCmd.Run())
 
-	otherDir := setupRepoWithV2Ref(t)
-	otherRepo, err := git.PlainOpen(otherDir)
-	require.NoError(t, err)
-	writeV2ArchiveRef(t, otherRepo, archiveRef, "remote archive")
-	seedCmd := exec.CommandContext(ctx, "git", "push", bareDir,
-		string(archiveRef)+":"+string(archiveRef))
-	seedCmd.Dir = otherDir
+	// Seed bare with a divergent commit at archiveRef so the pending push is
+	// non-fast-forward. HEAD is unrelated to the local archive's root commit.
+	seedCmd := exec.CommandContext(ctx, "git", "push", bareDir, "HEAD:"+string(archiveRef))
+	seedCmd.Dir = tmpDir
 	seedOut, err := seedCmd.CombinedOutput()
-	require.NoError(t, err, "seed push to bare failed: %s", seedOut)
+	require.NoError(t, err, "seed push failed: %s", seedOut)
 
+	t.Chdir(tmpDir)
 	restore := captureStderr(t)
 	pushV2Refs(ctx, bareDir)
 	output := restore()
 
-	assert.Contains(t, output, "[entire] Warning: v2/full/0000000000099, v2/main, v2/full/current were not pushed",
-		"failure output should name the pending archive and active refs together in one line")
-	assert.NotContains(t, output, "non-fast-forward",
-		"low-level git error detail should not be shown to the user; it belongs in debug logs")
-	assert.NotContains(t, output, "couldn't publish pending v2 full generation refs",
-		"redundant wrapper error should be replaced by the consolidated 'were not pushed' line")
+	assert.Contains(t, output, "[entire] Warning: v2/full/0000000000099, v2/main, v2/full/current were not pushed")
+	assert.NotContains(t, output, "non-fast-forward", "low-level git detail should go to debug logs")
 
 	bareRepo, err := git.PlainOpen(bareDir)
 	require.NoError(t, err)

--- a/cmd/entire/cli/strategy/push_v2_test.go
+++ b/cmd/entire/cli/strategy/push_v2_test.go
@@ -377,6 +377,71 @@ func TestPushV2Refs_PushesPendingArchivePublications(t *testing.T) {
 	assert.Empty(t, remaining, "pending archive publications should be cleared after push")
 }
 
+// TestPushV2Refs_PendingPublicationFailureLabelsSkippedActiveRefs verifies that
+// when pending v2 full archive publication fails, the warning output explicitly
+// names the active refs (v2/main, v2/full/current) that were not pushed.
+// Otherwise the user sees only the pending archive ref in the failure and is
+// left wondering whether the active refs that were announced earlier also
+// failed (they did — they were skipped).
+//
+// Not parallel: uses t.Chdir() and os.Stderr redirection.
+func TestPushV2Refs_PendingPublicationFailureLabelsSkippedActiveRefs(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := setupRepoWithV2Ref(t)
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+	store := checkpoint.NewV2GitStore(repo, "origin")
+
+	// Create /full/current via a checkpoint.
+	writeV2Checkpoint(t, repo, id.MustCheckpointID("aabbccddeeff"), "test-session")
+
+	archiveRef := plumbing.ReferenceName(paths.V2FullRefPrefix + "0000000000099")
+	localArchiveCommitHash := writeV2ArchiveRef(t, repo, archiveRef, "local archive")
+	require.NoError(t, store.AppendPendingFullGenerationPublication(ctx, checkpoint.PendingV2FullGenerationPublication{
+		ArchiveRefName:    archiveRef.String(),
+		ArchiveCommitHash: localArchiveCommitHash.String(),
+	}))
+
+	t.Chdir(tmpDir)
+
+	// Create bare remote and seed it with a divergent archive commit at the
+	// same ref so the local push is non-fast-forward.
+	bareDir := t.TempDir()
+	initCmd := exec.CommandContext(ctx, "git", "init", "--bare")
+	initCmd.Dir = bareDir
+	initCmd.Env = testutil.GitIsolatedEnv()
+	require.NoError(t, initCmd.Run())
+
+	otherDir := setupRepoWithV2Ref(t)
+	otherRepo, err := git.PlainOpen(otherDir)
+	require.NoError(t, err)
+	writeV2ArchiveRef(t, otherRepo, archiveRef, "remote archive")
+	seedCmd := exec.CommandContext(ctx, "git", "push", bareDir,
+		string(archiveRef)+":"+string(archiveRef))
+	seedCmd.Dir = otherDir
+	seedOut, err := seedCmd.CombinedOutput()
+	require.NoError(t, err, "seed push to bare failed: %s", seedOut)
+
+	restore := captureStderr(t)
+	pushV2Refs(ctx, bareDir)
+	output := restore()
+
+	assert.Contains(t, output, "[entire] Warning: v2/full/0000000000099, v2/main, v2/full/current were not pushed",
+		"failure output should name the pending archive and active refs together in one line")
+	assert.NotContains(t, output, "non-fast-forward",
+		"low-level git error detail should not be shown to the user; it belongs in debug logs")
+	assert.NotContains(t, output, "couldn't publish pending v2 full generation refs",
+		"redundant wrapper error should be replaced by the consolidated 'were not pushed' line")
+
+	bareRepo, err := git.PlainOpen(bareDir)
+	require.NoError(t, err)
+	_, err = bareRepo.Reference(plumbing.ReferenceName(paths.V2MainRefName), true)
+	require.Error(t, err, "/main should not be pushed when pending publication fails")
+	_, err = bareRepo.Reference(plumbing.ReferenceName(paths.V2FullCurrentRefName), true)
+	require.Error(t, err, "/full/current should not be pushed when pending publication fails")
+}
+
 // TestPushV2Refs_PushesPendingArchivePublicationsWithoutActiveRefs verifies a
 // pending archive publication is still honored when there is no /main or
 // /full/current ref to include in the normal active-ref push set.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/380
<!-- entire-trail-link-end -->

Updates the v2 push failure message to include all refs that failed to push and add details of the failures to the debug logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error reporting/logging around v2 ref push failures and add a regression test; core push mechanics are unchanged aside from tracking which refs failed.
> 
> **Overview**
> Improves v2 checkpoint push failure reporting by tracking which pending-publication refs failed and, if pending publication aborts the run, emitting a single user-facing warning that explicitly lists **all** refs that were not pushed (including the active refs that were skipped).
> 
> Adds debug logging for the underlying pending-publication error, and includes a new test covering the non-fast-forward pending archive scenario to ensure the consolidated warning is shown and low-level git error details stay out of user output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3545c23eb3b6fa117258566d3bc301d3ef0e6305. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->