### PR TITLE
test: avoid external agent type collision in rewind test

### DIFF
--- a/cmd/entire/cli/strategy/rewind_test.go
+++ b/cmd/entire/cli/strategy/rewind_test.go
@@ -250,8 +250,8 @@ func TestResolveAgentForRewind(t *testing.T) {
 		t.Parallel()
 
 		// Simulate what external.DiscoverAndRegister does: register an agent at runtime.
-		testName := types.AgentName("test-external-kiro")
-		testType := types.AgentType("Kiro")
+		testName := types.AgentName("test-external-rewind-agent")
+		testType := types.AgentType("Entire Test External Rewind Agent")
 		agent.Register(testName, func() agent.Agent {
 			return &fakeExternalAgent{name: testName, agentType: testType}
 		})


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/381
<!-- entire-trail-link-end -->

The dynamic ResolveAgentForRewind test used a fake agent with type "Kiro" to simulate external agent registration. On machines that have a real entire-agent-kiro on PATH, earlier external discovery tests can register that real agent into the process-global registry with the same type. Because GetByAgentType scans a map, the rewind test could resolve the host agent instead of the test fixture and fail depending on package test ordering and map iteration.

Rename the test fixture to a synthetic Entire-specific name and type so it still exercises runtime external-agent registration without colliding with installed local plugins.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only rename to avoid collisions with real installed external agents; no production logic changes.
> 
> **Overview**
> Makes the `ResolveAgentForRewind` dynamic-registration test deterministic by changing the fake external agent’s `name`/`type` from a potentially real value (e.g. `Kiro`) to a unique synthetic identifier, avoiding collisions with any externally discovered/installed agents in the global registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ace97f74b4cec7f83508ff9edee0ebc6173055a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->