### PR TITLE
Test-only speedup: Shave 2 mins off test runtime

### DIFF
--- a/cmd/entire/cli/checkpoint/v2_read_test.go
+++ b/cmd/entire/cli/checkpoint/v2_read_test.go
@@ -250,7 +250,6 @@ func TestV2ReadSessionMetadata_FetchesMissingMetadataBlob(t *testing.T) {
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
 	repoRoot := wt.Filesystem().Root()
-	// No t.Parallel: this verifies a git CLI fallback that resolves from cwd.
 	t.Chdir(repoRoot)
 
 	mainTree := v2MainTree(t, repo)

--- a/cmd/entire/cli/checkpoint/v2_read_test.go
+++ b/cmd/entire/cli/checkpoint/v2_read_test.go
@@ -232,7 +232,6 @@ func TestV2ReadSessionMetadata_ReturnsMetadata(t *testing.T) {
 }
 
 func TestV2ReadSessionMetadata_FetchesMissingMetadataBlob(t *testing.T) {
-	t.Parallel()
 	repo := initTestRepo(t)
 	store := NewV2GitStore(repo, "origin")
 	cpID := id.MustCheckpointID("f1f2f3f4f5fb")
@@ -251,6 +250,9 @@ func TestV2ReadSessionMetadata_FetchesMissingMetadataBlob(t *testing.T) {
 	wt, err := repo.Worktree()
 	require.NoError(t, err)
 	repoRoot := wt.Filesystem().Root()
+	// No t.Parallel: this verifies a git CLI fallback that resolves from cwd.
+	t.Chdir(repoRoot)
+
 	mainTree := v2MainTree(t, repo)
 	sessionTree, err := mainTree.Tree(cpID.Path() + "/0")
 	require.NoError(t, err)

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -476,7 +476,6 @@ func TestCheckV2CheckpointCounts_SkipsWhenRefsMissing(t *testing.T) {
 
 func TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef(t *testing.T) {
 	dir := setupGitRepoForPhaseTest(t)
-	// No t.Parallel: this verifies a git CLI fallback that resolves from cwd.
 	t.Chdir(dir)
 
 	repo, err := git.PlainOpen(dir)

--- a/cmd/entire/cli/doctor_test.go
+++ b/cmd/entire/cli/doctor_test.go
@@ -475,8 +475,10 @@ func TestCheckV2CheckpointCounts_SkipsWhenRefsMissing(t *testing.T) {
 }
 
 func TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef(t *testing.T) {
-	t.Parallel()
 	dir := setupGitRepoForPhaseTest(t)
+	// No t.Parallel: this verifies a git CLI fallback that resolves from cwd.
+	t.Chdir(dir)
+
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/382
<!-- entire-trail-link-end -->

Removes `t.Parallel()` in two slow tests in favor of `t.Chdir(...)`.

For these two tests specifically, the working directory mattered because the code under test shells out to git without -C <repo>. The tests create temp repos, but without `t.Chdir(tempRepo)`, those fallback git calls run from the real project checkout, hit its partial-clone promisor remotes, and burned about a minute.

Before:
```
➜  cli git:(main) ✗ go test -run '^TestV2ReadSessionMetadata_FetchesMissingMetadataBlob$' -v -count=1 ./cmd/entire/cli/checkpoint
=== RUN   TestV2ReadSessionMetadata_FetchesMissingMetadataBlob
=== PAUSE TestV2ReadSessionMetadata_FetchesMissingMetadataBlob
=== CONT  TestV2ReadSessionMetadata_FetchesMissingMetadataBlob
2026/05/14 15:54:01 WARN FetchingTree.readFileViaGit: cat-file failed path=metadata.json hash=7fbc2440559c error="exit status 128"
--- PASS: TestV2ReadSessionMetadata_FetchesMissingMetadataBlob (58.68s)
PASS
ok  	github.com/entireio/cli/cmd/entire/cli/checkpoint	59.071s
```

After:
```
➜  cli git:(test-speedups) ✗ go test -run '^TestV2ReadSessionMetadata_FetchesMissingMetadataBlob$' -v -count=1 ./cmd/entire/cli/checkpoint
=== RUN   TestV2ReadSessionMetadata_FetchesMissingMetadataBlob
2026/05/14 15:52:33 WARN FetchingTree.readFileViaGit: cat-file failed path=metadata.json hash=28e8b85d8618 error="exit status 128"
--- PASS: TestV2ReadSessionMetadata_FetchesMissingMetadataBlob (0.15s)
PASS
ok  	github.com/entireio/cli/cmd/entire/cli/checkpoint	0.554s
```

Before:
```
➜  cli git:(main) ✗ go test -run '^TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef$' -v -count=1 ./cmd/entire/cli
=== RUN   TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef
=== PAUSE TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef
=== CONT  TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef
--- PASS: TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef (62.24s)
PASS
ok  	github.com/entireio/cli/cmd/entire/cli	62.754s
```

After:
```
➜  cli git:(test-speedups) ✗ go test -run '^TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef$' -v -count=1 ./cmd/entire/cli
=== RUN   TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef
--- PASS: TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef (0.05s)
PASS
ok  	github.com/entireio/cli/cmd/entire/cli	0.520s
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust working-directory and parallelism; low functional risk but could slightly reduce overall test concurrency.
> 
> **Overview**
> Speeds up two previously slow tests by removing `t.Parallel()` and explicitly `t.Chdir(...)` into the temp repo root so any shell-outs to `git` run against the intended fixture repo.
> 
> This avoids accidental interaction with the developer checkout (e.g., partial-clone promisor remotes) and keeps the tests focused on corrupt/missing-object scenarios (`TestV2ReadSessionMetadata_FetchesMissingMetadataBlob` and `TestCheckV2CheckpointCounts_ReturnsErrorForCorruptRef`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b684de518e3d3a13782fabcbcc0189e5b2e664. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->