### PR TITLE
Avoid hardcoding date in TestReviewSummaryTokenEnricher_LoadsCurrentSessionState

### DIFF
--- a/cmd/entire/cli/review/manifest_test.go
+++ b/cmd/entire/cli/review/manifest_test.go
@@ -23,7 +23,7 @@ const manifestTokenTestAgentType agenttypes.AgentType = "Review Token Test"
 
 func TestHydrateReviewSummaryTokensFromStates_PopulatesTokensFromSessionState(t *testing.T) {
 	t.Parallel()
-	started := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	started := time.Now().UTC().Truncate(time.Second)
 	summary := reviewtypes.RunSummary{
 		StartedAt: started,
 		AgentRuns: []reviewtypes.AgentRun{
@@ -67,7 +67,7 @@ func TestHydrateReviewSummaryTokensFromStates_FallsBackToTranscript(t *testing.T
 		return manifestTokenTestAgent{}, nil
 	}
 
-	started := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	started := time.Now().UTC().Truncate(time.Second)
 	tmp := t.TempDir()
 	transcriptPath := filepath.Join(tmp, "review.jsonl")
 	transcript := "review transcript\n"
@@ -112,7 +112,7 @@ func TestReviewSummaryTokenEnricher_LoadsCurrentSessionState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStateStore: %v", err)
 	}
-	started := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	started := time.Now().UTC().Truncate(time.Second)
 	if err := store.Save(ctx, &session.State{
 		SessionID:    "codex-session-token",
 		Kind:         session.KindAgentReview,


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/387
<!-- entire-trail-link-end -->

This test started failing because we hit 7 days on the `IsStale` threshold today and the date was hard coded to May 8th.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that removes a brittle, time-dependent fixture; low risk aside from potential flakiness if any logic assumes specific wall-clock dates.
> 
> **Overview**
> Stops hardcoding a fixed `StartedAt` timestamp in `manifest_test.go` and instead uses `time.Now().UTC().Truncate(time.Second)` in the token hydration/enricher tests.
> 
> This prevents the suite from failing as the run becomes *stale* relative to the current date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1ea22c2c335e5a65656d6458e44123e08cb74b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->