### PR TITLE
Improve trail list filters and output

### DIFF
--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -125,7 +125,6 @@ func printTrailDetails(w io.Writer, m *trail.Metadata) {
 func newTrailListCmd() *cobra.Command {
 	var authorFilter string
 	var statusFilter string
-	var mine bool
 	var jsonOutput bool
 	var limit int
 
@@ -133,19 +132,12 @@ func newTrailListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List recent trails",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if mine {
-				if cmd.Flags().Changed("author") {
-					return errors.New("--mine cannot be used with --author")
-				}
-				authorFilter = trailListAuthorMe
-			}
 			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), authorFilter, statusFilter, jsonOutput, limit, trailInsecureHTTP(cmd))
 		},
 	}
 
 	cmd.Flags().StringVar(&authorFilter, "author", defaultTrailListAuthor, "Filter by author login; use "+trailListAuthorMe+" for yourself; omit value for any author")
 	cmd.Flags().StringVar(&statusFilter, "status", defaultTrailListStatus, "Filter by comma-separated status(es): "+formatValidStatuses()+"; omit value for any status")
-	cmd.Flags().BoolVar(&mine, "mine", false, "Alias for --author me")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	cmd.Flags().IntVar(&limit, "limit", defaultTrailListLimit, "Maximum number of trails to show")
 	cmd.Flags().Lookup("author").NoOptDefVal = ""

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -15,13 +15,19 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
-	"github.com/entireio/cli/cmd/entire/cli/stringutil"
 	"github.com/entireio/cli/cmd/entire/cli/trail"
 
 	"charm.land/huh/v2"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/spf13/cobra"
+)
+
+const (
+	defaultTrailListLimit  = 10
+	defaultTrailListAuthor = "me"
+	defaultTrailListStatus = string(trail.StatusInProgress)
+	trailAuthorColumnWidth = 15
 )
 
 func newTrailCmd() *cobra.Command {
@@ -35,7 +41,7 @@ func newTrailCmd() *cobra.Command {
 "why" and "what" of your work, while checkpoints capture the "how" and "when".
 
 Running 'entire trail' without a subcommand shows the trail for the current
-branch, or lists all trails if no trail exists for the current branch.`,
+branch, or lists recent trails if no trail exists for the current branch.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), insecureHTTPAuth)
 		},
@@ -65,7 +71,7 @@ func trailInsecureHTTP(cmd *cobra.Command) bool {
 func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
 	branch, err := GetCurrentBranch(ctx)
 	if err != nil {
-		return runTrailListAll(ctx, w, "", false, false, insecureHTTP)
+		return runTrailListAll(ctx, w, defaultTrailListAuthor, defaultTrailListStatus, false, defaultTrailListLimit, insecureHTTP)
 	}
 
 	client, err := NewAuthenticatedAPIClient(insecureHTTP)
@@ -83,7 +89,7 @@ func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
 		return err
 	}
 	if found == nil {
-		return runTrailListAll(ctx, w, "", false, false, insecureHTTP)
+		return runTrailListAll(ctx, w, defaultTrailListAuthor, defaultTrailListStatus, false, defaultTrailListLimit, insecureHTTP)
 	}
 
 	printTrailDetails(w, found.ToMetadata())
@@ -116,26 +122,39 @@ func printTrailDetails(w io.Writer, m *trail.Metadata) {
 }
 
 func newTrailListCmd() *cobra.Command {
+	var authorFilter string
 	var statusFilter string
 	var jsonOutput bool
-	var showAll bool
+	var limit int
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all trails",
+		Short: "List recent trails",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), statusFilter, jsonOutput, showAll, trailInsecureHTTP(cmd))
+			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), authorFilter, statusFilter, jsonOutput, limit, trailInsecureHTTP(cmd))
 		},
 	}
 
-	cmd.Flags().StringVar(&statusFilter, "status", "", "Filter by status (draft, open, in_progress, in_review, merged, closed)")
+	cmd.Flags().StringVar(&authorFilter, "author", defaultTrailListAuthor, "Filter by author login; omit value for any author")
+	cmd.Flags().StringVar(&statusFilter, "status", defaultTrailListStatus, "Filter by status; omit value for any status")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
-	cmd.Flags().BoolVarP(&showAll, "all", "a", false, "Include merged and closed trails")
+	cmd.Flags().IntVar(&limit, "limit", defaultTrailListLimit, "Maximum number of trails to show")
+	cmd.Flags().Lookup("author").NoOptDefVal = ""
+	cmd.Flags().Lookup("status").NoOptDefVal = ""
 
 	return cmd
 }
 
-func runTrailListAll(ctx context.Context, w io.Writer, statusFilter string, jsonOutput, showAll, insecureHTTP bool) error {
+func runTrailListAll(ctx context.Context, w io.Writer, authorFilter, statusFilter string, jsonOutput bool, limit int, insecureHTTP bool) error {
+	if limit <= 0 {
+		return errors.New("limit must be greater than 0")
+	}
+	if statusFilter != "" {
+		status := trail.Status(statusFilter)
+		if !status.IsValid() {
+			return fmt.Errorf("invalid status %q: valid values are %s", statusFilter, formatValidStatuses())
+		}
+	}
 	client, err := NewAuthenticatedAPIClient(insecureHTTP)
 	if err != nil {
 		return fmt.Errorf("authentication required: %w", err)
@@ -166,36 +185,29 @@ func runTrailListAll(ctx context.Context, w io.Writer, statusFilter string, json
 		trails = append(trails, listResp.Trails[i].ToMetadata())
 	}
 
-	totalCount := len(trails)
-
-	// Apply status filter
-	if statusFilter != "" {
-		status := trail.Status(statusFilter)
-		if !status.IsValid() {
-			return fmt.Errorf("invalid status %q: valid values are %s", statusFilter, formatValidStatuses())
+	currentUserLogin := ""
+	if authorFilter == defaultTrailListAuthor {
+		login, err := fetchCurrentUserLogin(ctx, client)
+		if err != nil {
+			return err
 		}
-		var filtered []*trail.Metadata
-		for _, t := range trails {
-			if t.Status == status {
-				filtered = append(filtered, t)
-			}
-		}
-		trails = filtered
-	} else if !showAll {
-		// By default, hide merged and closed trails
-		var filtered []*trail.Metadata
-		for _, t := range trails {
-			if t.Status != trail.StatusMerged && t.Status != trail.StatusClosed {
-				filtered = append(filtered, t)
-			}
-		}
-		trails = filtered
+		currentUserLogin = login
+		authorFilter = login
 	}
 
-	// Sort by updated_at descending
+	if authorFilter != "" {
+		trails = filterTrailsByAuthor(trails, authorFilter)
+	}
+
+	if statusFilter != "" {
+		trails = filterTrailsByStatus(trails, trail.Status(statusFilter))
+	}
+
+	// Sort by updated_at descending, then keep only the most recent rows.
 	sort.Slice(trails, func(i, j int) bool {
 		return trails[i].UpdatedAt.After(trails[j].UpdatedAt)
 	})
+	trails = limitTrails(trails, limit)
 
 	if jsonOutput {
 		enc := json.NewEncoder(w)
@@ -207,30 +219,176 @@ func runTrailListAll(ctx context.Context, w io.Writer, statusFilter string, json
 	}
 
 	if len(trails) == 0 {
-		hiddenCount := totalCount - len(trails)
-		if hiddenCount > 0 {
-			fmt.Fprintf(w, "No active trails found. %d merged/closed trail(s) hidden — use --all to show.\n", hiddenCount)
-		} else {
-			fmt.Fprintln(w, "No trails found.")
-			fmt.Fprintln(w)
-			fmt.Fprintln(w, "Commands:")
-			fmt.Fprintln(w, "  entire trail create   Create a trail for the current branch")
-			fmt.Fprintln(w, "  entire trail list     List all trails")
-			fmt.Fprintln(w, "  entire trail update   Update trail metadata")
-		}
+		fmt.Fprintln(w, "No trails found.")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Commands:")
+		fmt.Fprintln(w, "  entire trail create   Create a trail for the current branch")
+		fmt.Fprintln(w, "  entire trail list     List recent trails")
+		fmt.Fprintln(w, "  entire trail update   Update trail metadata")
 		return nil
 	}
 
-	// Table output
-	fmt.Fprintf(w, "%-30s %-40s %-13s %-15s %s\n", "BRANCH", "TITLE", "STATUS", "AUTHOR", "UPDATED")
-	for _, t := range trails {
-		branch := stringutil.TruncateRunes(t.Branch, 30, "...")
-		title := stringutil.TruncateRunes(t.Title, 40, "...")
-		fmt.Fprintf(w, "%-30s %-40s %-13s %-15s %s\n",
-			branch, title, t.Status, stringutil.TruncateRunes(t.AuthorLogin(), 15, "..."), timeAgo(t.UpdatedAt))
-	}
+	printTrailList(w, trails, trailListDisplayOptions{
+		RequestedAuthor: authorFilter,
+		CurrentUser:     currentUserLogin,
+		StatusFilter:    statusFilter,
+	})
 
 	return nil
+}
+
+func limitTrails(trails []*trail.Metadata, limit int) []*trail.Metadata {
+	if len(trails) <= limit {
+		return trails
+	}
+	return trails[:limit]
+}
+
+func filterTrailsByAuthor(trails []*trail.Metadata, login string) []*trail.Metadata {
+	var filtered []*trail.Metadata
+	for _, t := range trails {
+		if t.AuthorLogin() == login {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
+func filterTrailsByStatus(trails []*trail.Metadata, status trail.Status) []*trail.Metadata {
+	var filtered []*trail.Metadata
+	for _, t := range trails {
+		if t.Status == status {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
+type currentUserResponse struct {
+	Login string `json:"login"`
+}
+
+func fetchCurrentUserLogin(ctx context.Context, client *api.Client) (string, error) {
+	resp, err := client.Get(ctx, "/api/v1/me")
+	if err != nil {
+		return "", fmt.Errorf("failed to get current user: %w", err)
+	}
+	defer resp.Body.Close()
+	if err := checkTrailResponse(resp); err != nil {
+		return "", err
+	}
+
+	var out currentUserResponse
+	if err := api.DecodeJSON(resp, &out); err != nil {
+		return "", fmt.Errorf("failed to decode current user: %w", err)
+	}
+	login := out.Login
+	if login == "" {
+		return "", errors.New("current user response did not include a login")
+	}
+	return login, nil
+}
+
+type trailListDisplayOptions struct {
+	RequestedAuthor string
+	CurrentUser     string
+	StatusFilter    string
+}
+
+func printTrailList(w io.Writer, trails []*trail.Metadata, opts trailListDisplayOptions) {
+	showAuthor := opts.RequestedAuthor == ""
+	if opts.StatusFilter == "" {
+		printTrailListHeader(w, opts, len(trails))
+		fmt.Fprintln(w)
+		for _, status := range trailListStatusOrder() {
+			group := filterTrailsByStatus(trails, status)
+			if len(group) == 0 {
+				continue
+			}
+			fmt.Fprintf(w, "  %s · %d\n", trailStatusTitle(status), len(group))
+			fmt.Fprintln(w)
+			printTrailRows(w, group, showAuthor)
+			fmt.Fprintln(w)
+		}
+		return
+	}
+
+	printTrailListHeader(w, opts, len(trails))
+	fmt.Fprintln(w)
+	printTrailRows(w, trails, showAuthor)
+}
+
+func printTrailListHeader(w io.Writer, opts trailListDisplayOptions, count int) {
+	status := trail.Status(opts.StatusFilter)
+	if opts.RequestedAuthor == "" {
+		if opts.StatusFilter == "" {
+			fmt.Fprintf(w, "  Recent trails · %d\n", count)
+			return
+		}
+		fmt.Fprintf(w, "  %s · %d %s\n", trailStatusTitle(status), count, pluralize("trail", count))
+		return
+	}
+
+	label := opts.RequestedAuthor
+	if opts.CurrentUser != "" && opts.RequestedAuthor == opts.CurrentUser {
+		label = "Your trails"
+	}
+	if opts.StatusFilter == "" {
+		fmt.Fprintf(w, "  %s · %d\n", label, count)
+		return
+	}
+	fmt.Fprintf(w, "  %s · %d %s\n", label, count, trailStatusDisplay(status))
+}
+
+func printTrailRows(w io.Writer, trails []*trail.Metadata, showAuthor bool) {
+	branchWidth := maxTrailBranchWidth(trails)
+	for _, t := range trails {
+		if showAuthor {
+			fmt.Fprintf(w, "  %-*s  %-*s  %s\n", branchWidth, t.Branch, trailAuthorColumnWidth, t.AuthorLogin(), timeAgo(t.UpdatedAt))
+			continue
+		}
+		fmt.Fprintf(w, "  %-*s  %s\n", branchWidth, t.Branch, timeAgo(t.UpdatedAt))
+	}
+}
+
+func maxTrailBranchWidth(trails []*trail.Metadata) int {
+	width := 0
+	for _, t := range trails {
+		if branchWidth := len([]rune(t.Branch)); branchWidth > width {
+			width = branchWidth
+		}
+	}
+	return width
+}
+
+func trailListStatusOrder() []trail.Status {
+	return []trail.Status{
+		trail.StatusInProgress,
+		trail.StatusOpen,
+		trail.StatusInReview,
+		trail.StatusDraft,
+		trail.StatusMerged,
+		trail.StatusClosed,
+	}
+}
+
+func trailStatusDisplay(status trail.Status) string {
+	return strings.ReplaceAll(string(status), "_", " ")
+}
+
+func trailStatusTitle(status trail.Status) string {
+	display := trailStatusDisplay(status)
+	if display == "" {
+		return ""
+	}
+	return strings.ToUpper(display[:1]) + display[1:]
+}
+
+func pluralize(s string, count int) string {
+	if count == 1 {
+		return s
+	}
+	return s + "s"
 }
 
 func newTrailCreateCmd() *cobra.Command {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -186,7 +186,7 @@ func runTrailListAll(ctx context.Context, w io.Writer, authorFilter, statusFilte
 
 	currentUserLogin := ""
 	if authorFilter == trailListAuthorMe {
-		login, err := fetchCurrentUserLogin(ctx, client)
+		login, err := fetchCurrentUserLogin(ctx)
 		if err != nil {
 			return err
 		}
@@ -304,27 +304,13 @@ func parseTrailStatusFilter(filter string) ([]trail.Status, error) {
 	return statuses, nil
 }
 
-type currentUserResponse struct {
-	Login string `json:"login"`
-}
-
-func fetchCurrentUserLogin(ctx context.Context, client *api.Client) (string, error) {
-	resp, err := client.Get(ctx, "/api/v1/me")
+func fetchCurrentUserLogin(ctx context.Context) (string, error) {
+	login, err := ghCurrentUser(ctx, execRunner{})
 	if err != nil {
-		return "", fmt.Errorf("failed to get current user: %w", err)
+		return "", fmt.Errorf("resolve --author %s: %w (pass --author <login> explicitly if GitHub CLI is unavailable)", trailListAuthorMe, err)
 	}
-	defer resp.Body.Close()
-	if err := checkTrailResponse(resp); err != nil {
-		return "", err
-	}
-
-	var out currentUserResponse
-	if err := api.DecodeJSON(resp, &out); err != nil {
-		return "", fmt.Errorf("failed to decode current user: %w", err)
-	}
-	login := out.Login
 	if login == "" {
-		return "", errors.New("current user response did not include a login")
+		return "", errors.New("resolve --author me: GitHub CLI returned an empty login")
 	}
 	return login, nil
 }

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -25,10 +26,10 @@ import (
 
 const (
 	defaultTrailListLimit  = 10
-	defaultTrailListAuthor = ""
 	trailListAuthorMe      = "me"
 	defaultTrailListStatus = string(trail.StatusInProgress)
-	trailAuthorColumnWidth = 15
+	// trailListStatusAny disables the status filter; user-facing value for --status.
+	trailListStatusAny = "any"
 )
 
 func newTrailCmd() *cobra.Command {
@@ -68,11 +69,29 @@ func trailInsecureHTTP(cmd *cobra.Command) bool {
 	return v
 }
 
+// trailListOptions are the inputs to runTrailListAll. Keeping them on a
+// struct avoids a long positional argument list at the two call sites.
+type trailListOptions struct {
+	Author       string
+	Status       string
+	JSON         bool
+	Limit        int
+	InsecureHTTP bool
+}
+
+func defaultTrailListOptions(insecureHTTP bool) trailListOptions {
+	return trailListOptions{
+		Status:       defaultTrailListStatus,
+		Limit:        defaultTrailListLimit,
+		InsecureHTTP: insecureHTTP,
+	}
+}
+
 // runTrailShow shows the trail for the current branch, or falls through to list.
 func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
 	branch, err := GetCurrentBranch(ctx)
 	if err != nil {
-		return runTrailListAll(ctx, w, defaultTrailListAuthor, defaultTrailListStatus, false, defaultTrailListLimit, insecureHTTP)
+		return runTrailListAll(ctx, w, defaultTrailListOptions(insecureHTTP))
 	}
 
 	client, err := NewAuthenticatedAPIClient(insecureHTTP)
@@ -90,7 +109,7 @@ func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
 		return err
 	}
 	if found == nil {
-		return runTrailListAll(ctx, w, defaultTrailListAuthor, defaultTrailListStatus, false, defaultTrailListLimit, insecureHTTP)
+		return runTrailListAll(ctx, w, defaultTrailListOptions(insecureHTTP))
 	}
 
 	printTrailDetails(w, found.ToMetadata())
@@ -123,38 +142,36 @@ func printTrailDetails(w io.Writer, m *trail.Metadata) {
 }
 
 func newTrailListCmd() *cobra.Command {
-	var authorFilter string
-	var statusFilter string
-	var jsonOutput bool
-	var limit int
+	var opts trailListOptions
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List recent trails",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), authorFilter, statusFilter, jsonOutput, limit, trailInsecureHTTP(cmd))
+			opts.InsecureHTTP = trailInsecureHTTP(cmd)
+			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), opts)
 		},
 	}
 
-	cmd.Flags().StringVar(&authorFilter, "author", defaultTrailListAuthor, "Filter by author login; use "+trailListAuthorMe+" for yourself; omit value for any author")
-	cmd.Flags().StringVar(&statusFilter, "status", defaultTrailListStatus, "Filter by comma-separated status(es): "+formatValidStatuses()+"; omit value for any status")
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
-	cmd.Flags().IntVar(&limit, "limit", defaultTrailListLimit, "Maximum number of trails to show")
-	cmd.Flags().Lookup("author").NoOptDefVal = ""
-	cmd.Flags().Lookup("status").NoOptDefVal = ""
+	cmd.Flags().StringVar(&opts.Author, "author", "",
+		"Filter by author login (case-insensitive); use '"+trailListAuthorMe+"' for yourself (requires gh CLI); omit for any author")
+	cmd.Flags().StringVar(&opts.Status, "status", defaultTrailListStatus,
+		"Filter by comma-separated status(es): "+formatValidStatuses()+"; use '"+trailListStatusAny+"' for all statuses")
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output as JSON (respects --status filter)")
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "n", defaultTrailListLimit, "Maximum number of trails to show")
 
 	return cmd
 }
 
-func runTrailListAll(ctx context.Context, w io.Writer, authorFilter, statusFilter string, jsonOutput bool, limit int, insecureHTTP bool) error {
-	if limit <= 0 {
+func runTrailListAll(ctx context.Context, w io.Writer, opts trailListOptions) error {
+	if opts.Limit <= 0 {
 		return errors.New("limit must be greater than 0")
 	}
-	statusFilters, err := parseTrailStatusFilter(statusFilter)
+	statusFilters, err := parseTrailStatusFilter(opts.Status)
 	if err != nil {
 		return err
 	}
-	client, err := NewAuthenticatedAPIClient(insecureHTTP)
+	client, err := NewAuthenticatedAPIClient(opts.InsecureHTTP)
 	if err != nil {
 		return fmt.Errorf("authentication required: %w", err)
 	}
@@ -184,9 +201,10 @@ func runTrailListAll(ctx context.Context, w io.Writer, authorFilter, statusFilte
 		trails = append(trails, listResp.Trails[i].ToMetadata())
 	}
 
+	authorFilter := opts.Author
 	currentUserLogin := ""
 	if authorFilter == trailListAuthorMe {
-		login, err := fetchCurrentUserLogin(ctx)
+		login, err := fetchCurrentUserLogin(ctx, execRunner{})
 		if err != nil {
 			return err
 		}
@@ -206,9 +224,9 @@ func runTrailListAll(ctx context.Context, w io.Writer, authorFilter, statusFilte
 	sort.Slice(trails, func(i, j int) bool {
 		return trails[i].UpdatedAt.After(trails[j].UpdatedAt)
 	})
-	trails = limitTrails(trails, limit)
+	trails = limitTrails(trails, opts.Limit)
 
-	if jsonOutput {
+	if opts.JSON {
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(trails); err != nil {
@@ -243,10 +261,12 @@ func limitTrails(trails []*trail.Metadata, limit int) []*trail.Metadata {
 	return trails[:limit]
 }
 
+// filterTrailsByAuthor matches case-insensitively because GitHub logins are
+// case-insensitive (e.g. "Alice" and "alice" identify the same user).
 func filterTrailsByAuthor(trails []*trail.Metadata, login string) []*trail.Metadata {
 	var filtered []*trail.Metadata
 	for _, t := range trails {
-		if t.AuthorLogin() == login {
+		if strings.EqualFold(t.AuthorLogin(), login) {
 			filtered = append(filtered, t)
 		}
 	}
@@ -279,7 +299,7 @@ func filterTrailsByStatuses(trails []*trail.Metadata, statuses []trail.Status) [
 }
 
 func parseTrailStatusFilter(filter string) ([]trail.Status, error) {
-	if filter == "" {
+	if filter == "" || filter == trailListStatusAny {
 		return nil, nil
 	}
 
@@ -304,13 +324,16 @@ func parseTrailStatusFilter(filter string) ([]trail.Status, error) {
 	return statuses, nil
 }
 
-func fetchCurrentUserLogin(ctx context.Context) (string, error) {
-	login, err := ghCurrentUser(ctx, execRunner{})
+// fetchCurrentUserLogin resolves --author me to a GitHub login via the local
+// gh CLI. The runner is injectable so tests can stub gh without touching the
+// process environment.
+func fetchCurrentUserLogin(ctx context.Context, runner bootstrapRunner) (string, error) {
+	login, err := ghCurrentUser(ctx, runner)
 	if err != nil {
-		return "", fmt.Errorf("resolve --author %s: %w (pass --author <login> explicitly if GitHub CLI is unavailable)", trailListAuthorMe, err)
+		return "", fmt.Errorf("resolve --author %s via gh CLI: %w\nhint: pass --author <login> explicitly if gh is unavailable", trailListAuthorMe, err)
 	}
 	if login == "" {
-		return "", errors.New("resolve --author me: GitHub CLI returned an empty login")
+		return "", errors.New("resolve --author me: gh returned an empty login")
 	}
 	return login, nil
 }
@@ -323,6 +346,8 @@ type trailListDisplayOptions struct {
 
 func printTrailList(w io.Writer, trails []*trail.Metadata, opts trailListDisplayOptions) {
 	showAuthor := opts.RequestedAuthor == ""
+	// Group by status when the user filtered for 0 or 2+ statuses. A single
+	// status is already named in the header, so flat rows read more cleanly.
 	grouped := len(opts.StatusFilters) != 1
 	printTrailListHeader(w, opts, len(trails))
 	fmt.Fprintln(w)
@@ -331,22 +356,44 @@ func printTrailList(w io.Writer, trails []*trail.Metadata, opts trailListDisplay
 		return
 	}
 
+	rendered := make(map[*trail.Metadata]bool, len(trails))
 	for _, status := range trailListStatusOrder(opts.StatusFilters) {
 		group := filterTrailsByStatus(trails, status)
 		if len(group) == 0 {
 			continue
+		}
+		for _, t := range group {
+			rendered[t] = true
 		}
 		fmt.Fprintf(w, "  %s · %d\n", trailStatusTitle(status), len(group))
 		fmt.Fprintln(w)
 		printTrailRows(w, group, showAuthor)
 		fmt.Fprintln(w)
 	}
+
+	// When no explicit status filter is set, surface trails with unknown
+	// statuses in an "Other" bucket so they don't silently disappear if the
+	// server adds a status the CLI hasn't learned about yet.
+	if len(opts.StatusFilters) == 0 {
+		var other []*trail.Metadata
+		for _, t := range trails {
+			if !rendered[t] {
+				other = append(other, t)
+			}
+		}
+		if len(other) > 0 {
+			fmt.Fprintf(w, "  Other · %d\n", len(other))
+			fmt.Fprintln(w)
+			printTrailRows(w, other, showAuthor)
+			fmt.Fprintln(w)
+		}
+	}
 }
 
 func printTrailListHeader(w io.Writer, opts trailListDisplayOptions, count int) {
 	if opts.RequestedAuthor == "" {
 		if len(opts.StatusFilters) == 0 {
-			fmt.Fprintf(w, "  Recent trails · %d\n", count)
+			fmt.Fprintf(w, "  Recent %s · %d\n", pluralize("trail", count), count)
 			return
 		}
 		fmt.Fprintf(w, "  %s · %d %s\n", trailStatusListTitle(opts.StatusFilters), count, pluralize("trail", count))
@@ -354,8 +401,11 @@ func printTrailListHeader(w io.Writer, opts trailListDisplayOptions, count int) 
 	}
 
 	label := opts.RequestedAuthor
-	if opts.CurrentUser != "" && opts.RequestedAuthor == opts.CurrentUser {
-		label = "Your trails"
+	// When --author me resolves to the same login the server already returned
+	// for the trail, render "Your trails (login)" so identity drift between
+	// gh and Entire is visible at a glance.
+	if opts.CurrentUser != "" && strings.EqualFold(opts.RequestedAuthor, opts.CurrentUser) {
+		label = fmt.Sprintf("Your trails (%s)", opts.CurrentUser)
 	}
 	if len(opts.StatusFilters) == 0 {
 		fmt.Fprintf(w, "  %s · %d\n", label, count)
@@ -365,24 +415,17 @@ func printTrailListHeader(w io.Writer, opts trailListDisplayOptions, count int) 
 }
 
 func printTrailRows(w io.Writer, trails []*trail.Metadata, showAuthor bool) {
-	branchWidth := maxTrailBranchWidth(trails)
+	// tabwriter aligns by display columns instead of bytes, so multi-byte
+	// branch names or logins don't throw off the table.
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	for _, t := range trails {
 		if showAuthor {
-			fmt.Fprintf(w, "  %-*s  %-*s  %s\n", branchWidth, t.Branch, trailAuthorColumnWidth, t.AuthorLogin(), timeAgo(t.UpdatedAt))
+			fmt.Fprintf(tw, "  %s\t%s\t%s\n", t.Branch, t.AuthorLogin(), timeAgo(t.UpdatedAt))
 			continue
 		}
-		fmt.Fprintf(w, "  %-*s  %s\n", branchWidth, t.Branch, timeAgo(t.UpdatedAt))
+		fmt.Fprintf(tw, "  %s\t%s\n", t.Branch, timeAgo(t.UpdatedAt))
 	}
-}
-
-func maxTrailBranchWidth(trails []*trail.Metadata) int {
-	width := 0
-	for _, t := range trails {
-		if branchWidth := len([]rune(t.Branch)); branchWidth > width {
-			width = branchWidth
-		}
-	}
-	return width
+	_ = tw.Flush()
 }
 
 func trailListStatusOrder(filter []trail.Status) []trail.Status {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -25,7 +25,8 @@ import (
 
 const (
 	defaultTrailListLimit  = 10
-	defaultTrailListAuthor = "me"
+	defaultTrailListAuthor = ""
+	trailListAuthorMe      = "me"
 	defaultTrailListStatus = string(trail.StatusInProgress)
 	trailAuthorColumnWidth = 15
 )
@@ -124,6 +125,7 @@ func printTrailDetails(w io.Writer, m *trail.Metadata) {
 func newTrailListCmd() *cobra.Command {
 	var authorFilter string
 	var statusFilter string
+	var mine bool
 	var jsonOutput bool
 	var limit int
 
@@ -131,12 +133,19 @@ func newTrailListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List recent trails",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if mine {
+				if cmd.Flags().Changed("author") {
+					return errors.New("--mine cannot be used with --author")
+				}
+				authorFilter = trailListAuthorMe
+			}
 			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), authorFilter, statusFilter, jsonOutput, limit, trailInsecureHTTP(cmd))
 		},
 	}
 
-	cmd.Flags().StringVar(&authorFilter, "author", defaultTrailListAuthor, "Filter by author login; omit value for any author")
-	cmd.Flags().StringVar(&statusFilter, "status", defaultTrailListStatus, "Filter by status; omit value for any status")
+	cmd.Flags().StringVar(&authorFilter, "author", defaultTrailListAuthor, "Filter by author login; use "+trailListAuthorMe+" for yourself; omit value for any author")
+	cmd.Flags().StringVar(&statusFilter, "status", defaultTrailListStatus, "Filter by comma-separated status(es): "+formatValidStatuses()+"; omit value for any status")
+	cmd.Flags().BoolVar(&mine, "mine", false, "Alias for --author me")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 	cmd.Flags().IntVar(&limit, "limit", defaultTrailListLimit, "Maximum number of trails to show")
 	cmd.Flags().Lookup("author").NoOptDefVal = ""
@@ -149,11 +158,9 @@ func runTrailListAll(ctx context.Context, w io.Writer, authorFilter, statusFilte
 	if limit <= 0 {
 		return errors.New("limit must be greater than 0")
 	}
-	if statusFilter != "" {
-		status := trail.Status(statusFilter)
-		if !status.IsValid() {
-			return fmt.Errorf("invalid status %q: valid values are %s", statusFilter, formatValidStatuses())
-		}
+	statusFilters, err := parseTrailStatusFilter(statusFilter)
+	if err != nil {
+		return err
 	}
 	client, err := NewAuthenticatedAPIClient(insecureHTTP)
 	if err != nil {
@@ -186,7 +193,7 @@ func runTrailListAll(ctx context.Context, w io.Writer, authorFilter, statusFilte
 	}
 
 	currentUserLogin := ""
-	if authorFilter == defaultTrailListAuthor {
+	if authorFilter == trailListAuthorMe {
 		login, err := fetchCurrentUserLogin(ctx, client)
 		if err != nil {
 			return err
@@ -199,8 +206,8 @@ func runTrailListAll(ctx context.Context, w io.Writer, authorFilter, statusFilte
 		trails = filterTrailsByAuthor(trails, authorFilter)
 	}
 
-	if statusFilter != "" {
-		trails = filterTrailsByStatus(trails, trail.Status(statusFilter))
+	if len(statusFilters) > 0 {
+		trails = filterTrailsByStatuses(trails, statusFilters)
 	}
 
 	// Sort by updated_at descending, then keep only the most recent rows.
@@ -231,7 +238,7 @@ func runTrailListAll(ctx context.Context, w io.Writer, authorFilter, statusFilte
 	printTrailList(w, trails, trailListDisplayOptions{
 		RequestedAuthor: authorFilter,
 		CurrentUser:     currentUserLogin,
-		StatusFilter:    statusFilter,
+		StatusFilters:   statusFilters,
 	})
 
 	return nil
@@ -264,6 +271,47 @@ func filterTrailsByStatus(trails []*trail.Metadata, status trail.Status) []*trai
 	return filtered
 }
 
+func filterTrailsByStatuses(trails []*trail.Metadata, statuses []trail.Status) []*trail.Metadata {
+	statusSet := make(map[trail.Status]bool, len(statuses))
+	for _, status := range statuses {
+		statusSet[status] = true
+	}
+
+	var filtered []*trail.Metadata
+	for _, t := range trails {
+		if statusSet[t.Status] {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
+func parseTrailStatusFilter(filter string) ([]trail.Status, error) {
+	if filter == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(filter, ",")
+	statuses := make([]trail.Status, 0, len(parts))
+	seen := make(map[trail.Status]bool, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, fmt.Errorf("invalid status filter %q: empty status", filter)
+		}
+		status := trail.Status(name)
+		if !status.IsValid() {
+			return nil, fmt.Errorf("invalid status %q: valid values are %s", name, formatValidStatuses())
+		}
+		if seen[status] {
+			continue
+		}
+		seen[status] = true
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
+}
+
 type currentUserResponse struct {
 	Login string `json:"login"`
 }
@@ -292,40 +340,38 @@ func fetchCurrentUserLogin(ctx context.Context, client *api.Client) (string, err
 type trailListDisplayOptions struct {
 	RequestedAuthor string
 	CurrentUser     string
-	StatusFilter    string
+	StatusFilters   []trail.Status
 }
 
 func printTrailList(w io.Writer, trails []*trail.Metadata, opts trailListDisplayOptions) {
 	showAuthor := opts.RequestedAuthor == ""
-	if opts.StatusFilter == "" {
-		printTrailListHeader(w, opts, len(trails))
-		fmt.Fprintln(w)
-		for _, status := range trailListStatusOrder() {
-			group := filterTrailsByStatus(trails, status)
-			if len(group) == 0 {
-				continue
-			}
-			fmt.Fprintf(w, "  %s · %d\n", trailStatusTitle(status), len(group))
-			fmt.Fprintln(w)
-			printTrailRows(w, group, showAuthor)
-			fmt.Fprintln(w)
-		}
+	grouped := len(opts.StatusFilters) != 1
+	printTrailListHeader(w, opts, len(trails))
+	fmt.Fprintln(w)
+	if !grouped {
+		printTrailRows(w, trails, showAuthor)
 		return
 	}
 
-	printTrailListHeader(w, opts, len(trails))
-	fmt.Fprintln(w)
-	printTrailRows(w, trails, showAuthor)
+	for _, status := range trailListStatusOrder(opts.StatusFilters) {
+		group := filterTrailsByStatus(trails, status)
+		if len(group) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "  %s · %d\n", trailStatusTitle(status), len(group))
+		fmt.Fprintln(w)
+		printTrailRows(w, group, showAuthor)
+		fmt.Fprintln(w)
+	}
 }
 
 func printTrailListHeader(w io.Writer, opts trailListDisplayOptions, count int) {
-	status := trail.Status(opts.StatusFilter)
 	if opts.RequestedAuthor == "" {
-		if opts.StatusFilter == "" {
+		if len(opts.StatusFilters) == 0 {
 			fmt.Fprintf(w, "  Recent trails · %d\n", count)
 			return
 		}
-		fmt.Fprintf(w, "  %s · %d %s\n", trailStatusTitle(status), count, pluralize("trail", count))
+		fmt.Fprintf(w, "  %s · %d %s\n", trailStatusListTitle(opts.StatusFilters), count, pluralize("trail", count))
 		return
 	}
 
@@ -333,11 +379,11 @@ func printTrailListHeader(w io.Writer, opts trailListDisplayOptions, count int) 
 	if opts.CurrentUser != "" && opts.RequestedAuthor == opts.CurrentUser {
 		label = "Your trails"
 	}
-	if opts.StatusFilter == "" {
+	if len(opts.StatusFilters) == 0 {
 		fmt.Fprintf(w, "  %s · %d\n", label, count)
 		return
 	}
-	fmt.Fprintf(w, "  %s · %d %s\n", label, count, trailStatusDisplay(status))
+	fmt.Fprintf(w, "  %s · %d %s\n", label, count, trailStatusListDisplay(opts.StatusFilters))
 }
 
 func printTrailRows(w io.Writer, trails []*trail.Metadata, showAuthor bool) {
@@ -361,8 +407,8 @@ func maxTrailBranchWidth(trails []*trail.Metadata) int {
 	return width
 }
 
-func trailListStatusOrder() []trail.Status {
-	return []trail.Status{
+func trailListStatusOrder(filter []trail.Status) []trail.Status {
+	order := []trail.Status{
 		trail.StatusInProgress,
 		trail.StatusOpen,
 		trail.StatusInReview,
@@ -370,6 +416,37 @@ func trailListStatusOrder() []trail.Status {
 		trail.StatusMerged,
 		trail.StatusClosed,
 	}
+	if len(filter) == 0 {
+		return order
+	}
+
+	allowed := make(map[trail.Status]bool, len(filter))
+	for _, status := range filter {
+		allowed[status] = true
+	}
+	var filtered []trail.Status
+	for _, status := range order {
+		if allowed[status] {
+			filtered = append(filtered, status)
+		}
+	}
+	return filtered
+}
+
+func trailStatusListDisplay(statuses []trail.Status) string {
+	parts := make([]string, len(statuses))
+	for i, status := range statuses {
+		parts[i] = trailStatusDisplay(status)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func trailStatusListTitle(statuses []trail.Status) string {
+	display := trailStatusListDisplay(statuses)
+	if display == "" {
+		return ""
+	}
+	return strings.ToUpper(display[:1]) + display[1:]
 }
 
 func trailStatusDisplay(status trail.Status) string {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +17,7 @@ const (
 )
 
 func TestLimitTrailsKeepsMostRecentPrefix(t *testing.T) {
+	t.Parallel()
 	trails := []*trail.Metadata{
 		{Branch: "newest"},
 		{Branch: "middle"},
@@ -35,6 +38,7 @@ func TestLimitTrailsKeepsMostRecentPrefix(t *testing.T) {
 }
 
 func TestFilterTrailsByAuthor(t *testing.T) {
+	t.Parallel()
 	alice := trailListTestAuthorAlice
 	bob := trailListTestAuthorBob
 	trails := []*trail.Metadata{
@@ -53,7 +57,21 @@ func TestFilterTrailsByAuthor(t *testing.T) {
 	}
 }
 
+func TestFilterTrailsByAuthorIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	mixed := "Alice"
+	trails := []*trail.Metadata{
+		{Branch: "mine", Author: &trail.Author{Login: &mixed}},
+	}
+
+	got := filterTrailsByAuthor(trails, "alice")
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (case-insensitive)", len(got))
+	}
+}
+
 func TestParseTrailStatusFilterAcceptsCommaSeparatedStatuses(t *testing.T) {
+	t.Parallel()
 	got, err := parseTrailStatusFilter("in_progress, open,closed")
 	if err != nil {
 		t.Fatalf("parseTrailStatusFilter: %v", err)
@@ -70,12 +88,25 @@ func TestParseTrailStatusFilterAcceptsCommaSeparatedStatuses(t *testing.T) {
 }
 
 func TestParseTrailStatusFilterRejectsInvalidStatus(t *testing.T) {
+	t.Parallel()
 	if _, err := parseTrailStatusFilter("in_progress,nope"); err == nil {
 		t.Fatal("expected invalid status error")
 	}
 }
 
+func TestParseTrailStatusFilterAnySentinelMeansNoFilter(t *testing.T) {
+	t.Parallel()
+	got, err := parseTrailStatusFilter(trailListStatusAny)
+	if err != nil {
+		t.Fatalf("parseTrailStatusFilter(%q): %v", trailListStatusAny, err)
+	}
+	if got != nil {
+		t.Fatalf("got %v, want nil (any disables the filter)", got)
+	}
+}
+
 func TestPrintTrailListDefaultRepoShapeShowsAuthor(t *testing.T) {
+	t.Parallel()
 	alice := trailListTestAuthorAlice
 	var out bytes.Buffer
 	printTrailList(&out, []*trail.Metadata{
@@ -99,6 +130,7 @@ func TestPrintTrailListDefaultRepoShapeShowsAuthor(t *testing.T) {
 }
 
 func TestPrintTrailListAuthorFilteredShapeHidesAuthor(t *testing.T) {
+	t.Parallel()
 	longBranch := "feature/very-long-branch-name-that-must-remain-visible"
 	alice := trailListTestAuthorAlice
 
@@ -127,7 +159,31 @@ func TestPrintTrailListAuthorFilteredShapeHidesAuthor(t *testing.T) {
 	}
 }
 
+func TestPrintTrailListYourTrailsRelabelsAndSurfacesGhLogin(t *testing.T) {
+	t.Parallel()
+	mixedCase := "Alice" // gh returned a different case than the filter
+	var out bytes.Buffer
+	printTrailList(&out, []*trail.Metadata{
+		{
+			Branch:    "feat/x",
+			Status:    trail.StatusInProgress,
+			Author:    &trail.Author{Login: &mixedCase},
+			UpdatedAt: time.Now(),
+		},
+	}, trailListDisplayOptions{
+		RequestedAuthor: "alice",
+		CurrentUser:     "alice",
+		StatusFilters:   []trail.Status{trail.StatusInProgress},
+	})
+
+	text := out.String()
+	if !strings.Contains(text, "Your trails (alice) · 1 in progress") {
+		t.Fatalf("expected 'Your trails (alice)' header, got:\n%s", text)
+	}
+}
+
 func TestPrintTrailListAnyAuthorAnyStatusGroupsByStatus(t *testing.T) {
+	t.Parallel()
 	alice := trailListTestAuthorAlice
 	bob := trailListTestAuthorBob
 	var out bytes.Buffer
@@ -147,5 +203,85 @@ func TestPrintTrailListAnyAuthorAnyStatusGroupsByStatus(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Fatalf("output missing %q, got:\n%s", want, text)
 		}
+	}
+}
+
+func TestPrintTrailListSingularRecentTrailWhenOne(t *testing.T) {
+	t.Parallel()
+	alice := trailListTestAuthorAlice
+	var out bytes.Buffer
+	printTrailList(&out, []*trail.Metadata{
+		{Branch: "feat/a", Status: trail.StatusInProgress, Author: &trail.Author{Login: &alice}, UpdatedAt: time.Now()},
+	}, trailListDisplayOptions{
+		RequestedAuthor: "",
+		StatusFilters:   nil,
+	})
+
+	text := out.String()
+	if !strings.Contains(text, "Recent trail · 1") {
+		t.Fatalf("expected singular 'Recent trail · 1', got:\n%s", text)
+	}
+	if strings.Contains(text, "Recent trails · 1") {
+		t.Fatalf("did not expect plural 'trails' for count 1, got:\n%s", text)
+	}
+}
+
+func TestPrintTrailListUnknownStatusGroupedInOtherBucket(t *testing.T) {
+	t.Parallel()
+	alice := trailListTestAuthorAlice
+	unknownStatus := trail.Status("experimental_review")
+	var out bytes.Buffer
+	printTrailList(&out, []*trail.Metadata{
+		{Branch: "feat/known", Status: trail.StatusInProgress, Author: &trail.Author{Login: &alice}, UpdatedAt: time.Now()},
+		{Branch: "feat/odd", Status: unknownStatus, Author: &trail.Author{Login: &alice}, UpdatedAt: time.Now()},
+	}, trailListDisplayOptions{
+		RequestedAuthor: "",
+		StatusFilters:   nil,
+	})
+
+	text := out.String()
+	for _, want := range []string{"Recent trails · 2", "In progress · 1", "Other · 1", "feat/odd"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q, got:\n%s", want, text)
+		}
+	}
+}
+
+func TestFetchCurrentUserLoginReturnsLogin(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "octocat\n", nil)
+
+	got, err := fetchCurrentUserLogin(context.Background(), r)
+	if err != nil {
+		t.Fatalf("fetchCurrentUserLogin: %v", err)
+	}
+	if got != "octocat" {
+		t.Fatalf("got %q, want octocat", got)
+	}
+}
+
+func TestFetchCurrentUserLoginRejectsEmptyLogin(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "\n", nil)
+
+	if _, err := fetchCurrentUserLogin(context.Background(), r); err == nil {
+		t.Fatal("expected error for empty login")
+	}
+}
+
+func TestFetchCurrentUserLoginWrapsGhError(t *testing.T) {
+	t.Parallel()
+	r := newFakeRunner()
+	r.set("gh", []string{"api", "user", "--jq", ".login"}, "", errors.New("gh: not authenticated"))
+
+	_, err := fetchCurrentUserLogin(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Surface the hint about the --author <login> fallback.
+	if !strings.Contains(err.Error(), "--author <login>") {
+		t.Fatalf("error should mention the --author fallback hint, got: %v", err)
 	}
 }

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/trail"
+)
+
+const (
+	trailListTestAuthorAlice = "alice"
+	trailListTestAuthorBob   = "bob"
+)
+
+func TestLimitTrailsKeepsMostRecentPrefix(t *testing.T) {
+	trails := []*trail.Metadata{
+		{Branch: "newest"},
+		{Branch: "middle"},
+		{Branch: "oldest"},
+	}
+
+	got := limitTrails(trails, 2)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Branch != "newest" || got[1].Branch != "middle" {
+		t.Fatalf("got branches %q, %q; want newest, middle", got[0].Branch, got[1].Branch)
+	}
+
+	if all := limitTrails(trails, 3); len(all) != len(trails) {
+		t.Fatalf("limit 3 len = %d, want %d", len(all), len(trails))
+	}
+}
+
+func TestFilterTrailsByAuthor(t *testing.T) {
+	alice := trailListTestAuthorAlice
+	bob := trailListTestAuthorBob
+	trails := []*trail.Metadata{
+		{Branch: "mine-1", Author: &trail.Author{Login: &alice}},
+		{Branch: "theirs", Author: &trail.Author{Login: &bob}},
+		{Branch: "unknown"},
+		{Branch: "mine-2", Author: &trail.Author{Login: &alice}},
+	}
+
+	got := filterTrailsByAuthor(trails, trailListTestAuthorAlice)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Branch != "mine-1" || got[1].Branch != "mine-2" {
+		t.Fatalf("got branches %q, %q; want mine-1, mine-2", got[0].Branch, got[1].Branch)
+	}
+}
+
+func TestPrintTrailListDefaultShapeHidesAuthor(t *testing.T) {
+	longBranch := "feature/very-long-branch-name-that-must-remain-visible"
+	alice := trailListTestAuthorAlice
+
+	var out bytes.Buffer
+	printTrailList(&out, []*trail.Metadata{
+		{
+			Branch:    longBranch,
+			Status:    trail.StatusInProgress,
+			Author:    &trail.Author{Login: &alice},
+			UpdatedAt: time.Now().Add(-24 * time.Hour),
+		},
+	}, trailListDisplayOptions{
+		RequestedAuthor: "alice",
+		StatusFilter:    string(trail.StatusInProgress),
+	})
+
+	text := out.String()
+	if !strings.Contains(text, "alice · 1 in progress") {
+		t.Fatalf("output should contain author/status header, got:\n%s", text)
+	}
+	if !strings.Contains(text, longBranch) {
+		t.Fatalf("output should contain full branch %q, got:\n%s", longBranch, text)
+	}
+	if strings.Count(text, "alice") != 1 {
+		t.Fatalf("filtered author output should not repeat author in rows, got:\n%s", text)
+	}
+}
+
+func TestPrintTrailListAnyAuthorAnyStatusGroupsByStatus(t *testing.T) {
+	alice := trailListTestAuthorAlice
+	bob := trailListTestAuthorBob
+	var out bytes.Buffer
+	printTrailList(&out, []*trail.Metadata{
+		{Branch: "feat/a", Status: trail.StatusInProgress, Author: &trail.Author{Login: &alice}, UpdatedAt: time.Now()},
+		{Branch: "fix/b", Status: trail.StatusOpen, Author: &trail.Author{Login: &bob}, UpdatedAt: time.Now()},
+	}, trailListDisplayOptions{
+		RequestedAuthor: "",
+		StatusFilter:    "",
+	})
+
+	text := out.String()
+	if strings.Index(text, "In progress · 1") > strings.Index(text, "Open · 1") {
+		t.Fatalf("expected in-progress group before open group, got:\n%s", text)
+	}
+	for _, want := range []string{"Recent trails · 2", "In progress · 1", "Open · 1", "feat/a", trailListTestAuthorAlice, "fix/b", trailListTestAuthorBob} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q, got:\n%s", want, text)
+		}
+	}
+}

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -53,7 +53,52 @@ func TestFilterTrailsByAuthor(t *testing.T) {
 	}
 }
 
-func TestPrintTrailListDefaultShapeHidesAuthor(t *testing.T) {
+func TestParseTrailStatusFilterAcceptsCommaSeparatedStatuses(t *testing.T) {
+	got, err := parseTrailStatusFilter("in_progress, open,closed")
+	if err != nil {
+		t.Fatalf("parseTrailStatusFilter: %v", err)
+	}
+	want := []trail.Status{trail.StatusInProgress, trail.StatusOpen, trail.StatusClosed}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("status[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseTrailStatusFilterRejectsInvalidStatus(t *testing.T) {
+	if _, err := parseTrailStatusFilter("in_progress,nope"); err == nil {
+		t.Fatal("expected invalid status error")
+	}
+}
+
+func TestPrintTrailListDefaultRepoShapeShowsAuthor(t *testing.T) {
+	alice := trailListTestAuthorAlice
+	var out bytes.Buffer
+	printTrailList(&out, []*trail.Metadata{
+		{
+			Branch:    "feat/repo-wide",
+			Status:    trail.StatusInProgress,
+			Author:    &trail.Author{Login: &alice},
+			UpdatedAt: time.Now(),
+		},
+	}, trailListDisplayOptions{
+		RequestedAuthor: "",
+		StatusFilters:   []trail.Status{trail.StatusInProgress},
+	})
+
+	text := out.String()
+	for _, want := range []string{"In progress · 1 trail", "feat/repo-wide", trailListTestAuthorAlice} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q, got:\n%s", want, text)
+		}
+	}
+}
+
+func TestPrintTrailListAuthorFilteredShapeHidesAuthor(t *testing.T) {
 	longBranch := "feature/very-long-branch-name-that-must-remain-visible"
 	alice := trailListTestAuthorAlice
 
@@ -66,8 +111,8 @@ func TestPrintTrailListDefaultShapeHidesAuthor(t *testing.T) {
 			UpdatedAt: time.Now().Add(-24 * time.Hour),
 		},
 	}, trailListDisplayOptions{
-		RequestedAuthor: "alice",
-		StatusFilter:    string(trail.StatusInProgress),
+		RequestedAuthor: trailListTestAuthorAlice,
+		StatusFilters:   []trail.Status{trail.StatusInProgress},
 	})
 
 	text := out.String()
@@ -91,7 +136,7 @@ func TestPrintTrailListAnyAuthorAnyStatusGroupsByStatus(t *testing.T) {
 		{Branch: "fix/b", Status: trail.StatusOpen, Author: &trail.Author{Login: &bob}, UpdatedAt: time.Now()},
 	}, trailListDisplayOptions{
 		RequestedAuthor: "",
-		StatusFilter:    "",
+		StatusFilters:   nil,
 	})
 
 	text := out.String()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/390
<!-- entire-trail-link-end -->

## Summary

- Change `entire trail list` from an unbounded/all-trails table to a recent-trails view capped by `--limit` (default: 10).
- Make the default view repository-wide in-progress trails:
  - author filter defaults to any author
  - status filter defaults to `in_progress`
- Add composable filters:
  - `--author <login>` filters by author
  - `--author me` treats `me` as an alias for the authenticated user's username
  - `--author` with no value disables author filtering explicitly
  - `--status <status[,status...]>` filters by one or more comma-separated trail statuses
  - `--status` with no value disables status filtering
- Remove the previous `--all` behavior in favor of explicit filter composition.
- Keep branches untruncated and render a compact branch/author/age list instead of the old title/status/author table.

## New output design

Default: recent in-progress trails for the repo.

```console
$ entire trail list
  In progress · 10 trails

  feat/explain-fetch-progress                    peyton-alt      1d ago
  dependabot/…/codeql-action-4.35.5              dependabot      1d ago
  feat/explain-streaming-diagnostic              peyton-alt      1d ago
  fix/checkpoints-v2-full-transcript-fallback    pfleidi         1d ago
  feat/openai-privacy-filter-v1-backup           peyton-alt      2d ago
  soph/better-migration-email                    Soph            2d ago
  feat/openai-privacy-filter                     peyton-alt      2d ago
  fix-slow-v2-pushes                             computermode    3d ago
  slow-codex-in-review                           peyton-alt      3d ago
  redact-2                                       peyton-alt      3d ago
```

Your trails via `--author me`:

```console
$ entire trail list --author me
  Your trails · 6 in progress

  feat/explain-fetch-progress               1d ago
  feat/explain-streaming-diagnostic         1d ago
  feat/openai-privacy-filter-v1-backup      2d ago
  feat/openai-privacy-filter                2d ago
  slow-codex-in-review                      3d ago
  redact-2                                  3d ago
```

Specific author, default status (`in_progress`):

```console
$ entire trail list --author alice
  alice · 4 in progress

  feat/cohort-analysis                      2d ago
  feat/billing-webhooks                     3d ago
  fix/timezone-edge-cases                   5d ago
  chore/upgrade-postgres-driver             1w ago
```

Comma-separated statuses:

```console
$ entire trail list --status open,closed
  Open, closed · 10 trails

  Open · 8

  redact-2                                  peyton-alt      1d ago
  slow-codex-in-review                      peyton-alt      3d ago
  feat/throttle-runner-spawn                peyton-alt      4d ago
  feat/new-experiment                       Soph            5d ago
  fix/runner-timeout-handling               computermode    6d ago
  chore/bump-deps                           dependabot      1w ago
  feat/checkpoint-pagination                alice           1w ago
  fix/sse-keepalive                         Kai             2w ago

  Closed · 2

  feat/checkpoint-search                    pfleidi         2h ago
  fix/sse-reconnect                         Kai             5h ago
```

Any author, any status groups the limited recent results by existing trail statuses:

```console
$ entire trail list --status
  Recent trails · 10

  In progress · 5

  feat/explain-fetch-progress         peyton-alt      1d ago
  feat/explain-streaming-diagnostic   peyton-alt      1d ago
  soph/better-migration-email         Soph            2d ago
  feat/openai-privacy-filter          peyton-alt      2d ago
  slow-codex-in-review                peyton-alt      3d ago

  Open · 3

  redact-2                            peyton-alt      1d ago
  feat/cohort-analysis                alice           1d ago
  feat/throttle-runner-spawn          peyton-alt      4d ago

  Closed · 2

  feat/checkpoint-search              pfleidi         2h ago
  fix/sse-reconnect                   Kai             5h ago
```

## Testing

```console
mise exec -- go test ./cmd/entire/cli
mise run lint:go
```

