### PR TITLE
Raise API response body cap from 1 MiB to 16 MiB

### DIFF
--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	maxResponseBytes = 1 << 20
+	maxResponseBytes = 16 << 20
 	userAgent        = "entire-cli"
 )
 

--- a/cmd/entire/cli/api/client_test.go
+++ b/cmd/entire/cli/api/client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -298,5 +299,58 @@ func TestDecodeJSONResponse(t *testing.T) {
 	}
 	if result.Status != "ok" {
 		t.Errorf("Status = %q, want %q", result.Status, "ok")
+	}
+}
+
+// TestDecodeJSONResponse_LargeBodyOverOldCap exercises a JSON body whose size
+// exceeds the previous 1 MiB read cap. `entire activity` requests up to a
+// month of commits, which routinely produces 1.5+ MiB responses; under the
+// old cap, io.LimitReader truncated the body mid-JSON and json.Unmarshal
+// surfaced "unexpected end of JSON input", masking the real cause.
+func TestDecodeJSONResponse_LargeBodyOverOldCap(t *testing.T) {
+	t.Parallel()
+
+	const itemCount = 4000 // ~2 MiB at ~500 bytes per item
+	type item struct {
+		ID      string `json:"id"`
+		Message string `json:"message"`
+	}
+	payload := struct {
+		Items []item `json:"items"`
+	}{Items: make([]item, itemCount)}
+	for i := range payload.Items {
+		payload.Items[i] = item{
+			ID:      "0123456789abcdef0123456789abcdef0123456789abcdef",
+			Message: strings.Repeat("x", 400),
+		}
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) <= 1<<20 {
+		t.Fatalf("test payload %d bytes is not over the old 1 MiB cap", len(encoded))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(encoded) //nolint:errcheck // test handler
+	}))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL) //nolint:noctx // test helper
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var got struct {
+		Items []item `json:"items"`
+	}
+	if err := DecodeJSON(resp, &got); err != nil {
+		t.Fatalf("DecodeJSON(%d-byte body) = %v, want nil", len(encoded), err)
+	}
+	if len(got.Items) != itemCount {
+		t.Errorf("decoded %d items, want %d", len(got.Items), itemCount)
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/394
<!-- entire-trail-link-end -->

## Summary

`entire activity` fails for any active user with:

```
Failed to load activity: fetch activity: decode commits: decode JSON response: unexpected end of JSON input
```

Root cause: `/api/v1/me/commits?timeframe=last-month&limit=1000` returns ~1.5 MB of valid JSON for an active account, but `api.DecodeJSON` caps reads at `maxResponseBytes = 1 << 20` (1 MiB) via `io.LimitReader`. The body is silently truncated mid-JSON, and `json.Unmarshal` then surfaces "unexpected end of JSON input" — which looks like a server bug but is self-inflicted.

Reproduction against production:

```console
$ curl -sS -o /tmp/commits.json -w "bytes: %{size_download}\n" \
    -H "Authorization: Bearer $TOKEN" \
    "https://entire.io/api/v1/me/commits?timeframe=last-month&limit=1000"
bytes: 1463800
```

1.46 MB > 1 MiB cap → truncated → invalid JSON → error.

## Fix

Raise the global cap from 1 MiB to 16 MiB (`cmd/entire/cli/api/client.go:15`). Still a defensive cap against unbounded reads, but gives the activity endpoint real headroom for active users.

## Test

New regression test `TestDecodeJSONResponse_LargeBodyOverOldCap` (`cmd/entire/cli/api/client_test.go`):

- Builds a ~1.9 MiB JSON payload (4000 items × ~500 bytes)
- Serves it from an `httptest.Server`
- Asserts `DecodeJSON` decodes the full structure

Verified the test catches the regression: reverting `maxResponseBytes` to `1 << 20` makes the test fail with the exact user-facing error:

```
DecodeJSON(1884011-byte body) = decode JSON response: unexpected end of JSON input, want nil
```

## Verification

- [x] `mise run check` (fmt + lint + unit + integration + E2E canary) — all green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only increases a defensive read limit for API responses, with a regression test to catch truncation; main impact is higher potential memory use when decoding very large responses.
> 
> **Overview**
> Fixes CLI failures when API endpoints return JSON bodies larger than 1 MiB by increasing the shared `maxResponseBytes` cap to **16 MiB** for both `DecodeJSON` and `CheckResponse` reads.
> 
> Adds a regression test that serves and successfully decodes a ~2 MiB JSON payload to ensure large-but-valid responses no longer get truncated mid-JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9fa0a64a816d1ee57f1a38b0f47d251c5f3d24. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->