### PR TITLE
feat(attach): add --target-repo and --dry-run flags for skill orchestration

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -56,6 +58,20 @@ type attachOptions struct {
 	// transcript's first user prompt. Used by `entire review attach` when a
 	// pending-review marker has the exact prompt the user was asked to run.
 	ReviewPromptOverride string
+	// TargetRepo, when non-empty, makes attach operate on this repo instead
+	// of the current working directory. The skill/orchestrator uses this to
+	// fan an agent session out to multiple repos without cd'ing per call.
+	// All downstream cwd-coupled lookups (git rev-parse, session state store
+	// path) resolve against this path for the duration of the attach.
+	TargetRepo string
+	// DryRun, when true, computes the plan (which checkpoint id would be
+	// written, whether HEAD already has a trailer, transcript size) and
+	// returns without amending the commit, writing checkpoint metadata, or
+	// saving session state. Combined with JSON for machine-readable output.
+	DryRun bool
+	// JSON, when true, emits the dry-run plan as JSON on the writer. Only
+	// meaningful with DryRun=true; ignored otherwise.
+	JSON bool
 }
 
 func newAttachCmd() *cobra.Command {
@@ -64,6 +80,9 @@ func newAttachCmd() *cobra.Command {
 		agentFlag  string
 		reviewFlag bool
 		skillsFlag []string
+		targetRepo string
+		dryRun     bool
+		jsonOut    bool
 	)
 	cmd := &cobra.Command{
 		Use:   "attach <session-id>",
@@ -88,6 +107,16 @@ external_agents in settings. Run 'entire agent list' to see the full list.`,
 			if len(args) != 1 {
 				return cmd.Help()
 			}
+			if jsonOut && !dryRun {
+				return errors.New("--json is only valid with --dry-run")
+			}
+			if targetRepo != "" {
+				restore, err := chdirToTargetRepo(targetRepo)
+				if err != nil {
+					return err
+				}
+				defer restore()
+			}
 			if checkDisabledGuard(cmd.Context(), cmd.OutOrStdout()) {
 				return nil
 			}
@@ -99,6 +128,9 @@ external_agents in settings. Run 'entire agent list' to see the full list.`,
 				Force:                force,
 				Review:               reviewFlag,
 				ReviewSkillsOverride: skillsFlag,
+				TargetRepo:           targetRepo,
+				DryRun:               dryRun,
+				JSON:                 jsonOut,
 			}
 			return runAttachSurfaceReviewErrors(cmd, args[0], agentName, opts)
 		},
@@ -107,6 +139,9 @@ external_agents in settings. Run 'entire agent list' to see the full list.`,
 	cmd.Flags().StringVarP(&agentFlag, "agent", "a", string(agent.DefaultAgentName), "Agent that created the session (see 'entire agent list' for registered agents, including external)")
 	cmd.Flags().BoolVar(&reviewFlag, "review", false, "Tag the attached session as an agent review")
 	cmd.Flags().StringSliceVar(&skillsFlag, "skills", nil, "Optional: declare which review skills were run in this session. Only used with --review")
+	cmd.Flags().StringVar(&targetRepo, "target-repo", "", "Operate on this repo instead of the current working directory (skill orchestration)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print what would happen without amending the commit or writing checkpoint/session state")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit dry-run plan as JSON (only valid with --dry-run)")
 	return cmd
 }
 
@@ -141,16 +176,19 @@ func runAttachSurfaceReviewErrors(cmd *cobra.Command, sessionID string, agentNam
 }
 
 func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName types.AgentName, opts attachOptions) error {
-	// Initialize structured logger so logging.Warn/Info write to .entire/logs/ not stderr.
-	if err := logging.Init(ctx, sessionID); err != nil {
-		// Init failed — logging will use stderr fallback, non-fatal.
-		_ = err
+	// Skip log file creation on dry-run: a multi-repo orchestrator preview
+	// shouldn't leave a trail of empty .entire/logs/<id>.log files.
+	if !opts.DryRun {
+		if err := logging.Init(ctx, sessionID); err != nil {
+			// Init failed — logging will use stderr fallback, non-fatal.
+			_ = err
+		}
+		// Flush the 8KB buffered log writer on exit. Without this, any
+		// Warn/Info calls during attach (including the overwrite tripwire)
+		// get silently dropped when the process exits, matching the pattern
+		// already used by resume/clean/reset/rewind/migrate/explain.
+		defer logging.Close()
 	}
-	// Flush the 8KB buffered log writer on exit. Without this, any
-	// Warn/Info calls during attach (including the overwrite tripwire)
-	// get silently dropped when the process exits, matching the pattern
-	// already used by resume/clean/reset/rewind/migrate/explain.
-	defer logging.Close()
 
 	logCtx := logging.WithComponent(ctx, "attach")
 
@@ -184,6 +222,21 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 			)
 		}
 		cpID := existingState.LastCheckpointID.String()
+		if opts.DryRun {
+			_, isExistingCheckpoint := resolveCheckpointID(headCommit)
+			var existingTrailer string
+			if isExistingCheckpoint {
+				existingTrailer = cpID
+			}
+			return emitDryRunResult(w, opts, dryRunResult{
+				SessionID:           sessionID,
+				TargetRepo:          targetRepoPath(ctx),
+				HeadCommit:          headCommit.Hash.String(),
+				ExistingTrailer:     existingTrailer,
+				Action:              actionWouldSkipExistingInState,
+				CheckpointIDPlanned: cpID,
+			})
+		}
 		fmt.Fprintf(w, "Session %s already has checkpoint %s\n", sessionID, cpID)
 		if err := promptAmendCommit(logCtx, w, headCommit, cpID, opts.Force); err != nil {
 			logging.Warn(logCtx, "failed to amend commit", "error", err)
@@ -196,6 +249,30 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	ag, transcriptPath, err := resolveAgentAndTranscript(logCtx, w, sessionID, agentName, existingState)
 	if err != nil {
 		return err
+	}
+
+	if opts.DryRun {
+		// Determine checkpoint ID without reading the transcript so multi-repo
+		// previews stay fast (transcripts can be MBs).
+		plannedCheckpoint, isExistingCheckpoint := resolveCheckpointID(headCommit)
+		action := actionWouldAddTrailer
+		if isExistingCheckpoint {
+			action = actionWouldLinkExistingInHead
+		}
+		var existingTrailer string
+		if isExistingCheckpoint {
+			existingTrailer = plannedCheckpoint.String()
+		}
+		return emitDryRunResult(w, opts, dryRunResult{
+			SessionID:           sessionID,
+			TargetRepo:          targetRepoPath(ctx),
+			HeadCommit:          headCommit.Hash.String(),
+			ExistingTrailer:     existingTrailer,
+			Action:              action,
+			CheckpointIDPlanned: plannedCheckpoint.String(),
+			TranscriptBytes:     transcriptFileBytes(transcriptPath),
+			Agent:               string(ag.Type()),
+		})
 	}
 
 	var reviewSkills []string
@@ -736,4 +813,105 @@ func promptAmendCommit(ctx context.Context, w io.Writer, headCommit *object.Comm
 
 	fmt.Fprintf(w, "Amended commit %s with Entire-Checkpoint: %s\n", shortHash, checkpointIDStr)
 	return nil
+}
+
+// chdirToTargetRepo validates the path is a directory and chdirs into it.
+// Returns a restore function the caller must defer. The chdir is process-global
+// for the duration of the attach; safe because the CLI is one-shot.
+func chdirToTargetRepo(target string) (func(), error) {
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return nil, fmt.Errorf("--target-repo: resolve path: %w", err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("--target-repo %s: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("--target-repo %s: not a directory", abs)
+	}
+	prev, err := os.Getwd() //nolint:forbidigo // CLI scope; restored on defer
+	if err != nil {
+		return nil, fmt.Errorf("--target-repo: getwd: %w", err)
+	}
+	if err := os.Chdir(abs); err != nil {
+		return nil, fmt.Errorf("--target-repo: chdir %s: %w", abs, err)
+	}
+	return func() {
+		// Best-effort restore — the CLI is exiting shortly after.
+		_ = os.Chdir(prev) //nolint:errcheck // best-effort restore on CLI exit
+	}, nil
+}
+
+// dryRunAction names the planned action surfaced by --dry-run. Keep in sync
+// with the JSON values consumed by the scope skill orchestrator.
+type dryRunAction string
+
+const (
+	actionWouldAddTrailer          dryRunAction = "would_add_trailer"
+	actionWouldLinkExistingInHead  dryRunAction = "would_link_existing_in_head"
+	actionWouldSkipExistingInState dryRunAction = "would_skip_existing_in_state"
+)
+
+// dryRunResult is the structured plan emitted when --dry-run is set.
+// Field ordering matches the human-readable output for predictable JSON diffs.
+type dryRunResult struct {
+	SessionID           string       `json:"session_id"`
+	TargetRepo          string       `json:"target_repo"`
+	HeadCommit          string       `json:"head_commit"`
+	ExistingTrailer     string       `json:"existing_trailer,omitempty"`
+	Action              dryRunAction `json:"action"`
+	CheckpointIDPlanned string       `json:"checkpoint_id_planned,omitempty"`
+	TranscriptBytes     int64        `json:"transcript_bytes,omitempty"`
+	Agent               string       `json:"agent,omitempty"`
+}
+
+func emitDryRunResult(w io.Writer, opts attachOptions, result dryRunResult) error {
+	if opts.JSON {
+		b, err := jsonutil.MarshalIndentWithNewline(result, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal dry-run result: %w", err)
+		}
+		if _, err := w.Write(b); err != nil {
+			return fmt.Errorf("write dry-run result: %w", err)
+		}
+		return nil
+	}
+	fmt.Fprintf(w, "dry-run: %s for session %s\n", result.Action, result.SessionID)
+	fmt.Fprintf(w, "  target repo:      %s\n", result.TargetRepo)
+	fmt.Fprintf(w, "  HEAD commit:      %s\n", result.HeadCommit)
+	if result.ExistingTrailer != "" {
+		fmt.Fprintf(w, "  existing trailer: %s\n", result.ExistingTrailer)
+	}
+	if result.CheckpointIDPlanned != "" {
+		fmt.Fprintf(w, "  checkpoint id:    %s\n", result.CheckpointIDPlanned)
+	}
+	if result.TranscriptBytes > 0 {
+		fmt.Fprintf(w, "  transcript bytes: %d\n", result.TranscriptBytes)
+	}
+	if result.Agent != "" {
+		fmt.Fprintf(w, "  agent:            %s\n", result.Agent)
+	}
+	return nil
+}
+
+// targetRepoPath returns the worktree root of the repo attach is operating on.
+// Used in dry-run output so the caller sees the canonical repo path (it matches
+// --target-repo when set, cwd's worktree root otherwise).
+func targetRepoPath(ctx context.Context) string {
+	root, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return ""
+	}
+	return root
+}
+
+// transcriptFileBytes returns the on-disk size of the transcript without
+// reading it into memory. Used by --dry-run to keep multi-repo previews fast.
+func transcriptFileBytes(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
 }

--- a/cmd/entire/cli/integration_test/attach_test.go
+++ b/cmd/entire/cli/integration_test/attach_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -361,5 +362,160 @@ func TestAttach_InvalidSessionID(t *testing.T) {
 	_, err := env.RunCLIWithError("session", "attach", "../path-traversal", "-a", "claude-code")
 	if err == nil {
 		t.Error("expected error for invalid session ID")
+	}
+}
+
+// TestAttach_TargetRepo_AmendsTargetNotCwd verifies that --target-repo makes
+// attach operate on the target repo's HEAD even when cwd is somewhere else.
+// This is the skill-orchestration scenario: agent runs in a higher-level
+// folder (or in a different repo) and fans the session out to each
+// affected child/sibling repo via --target-repo.
+func TestAttach_TargetRepo_AmendsTargetNotCwd(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+
+	sessionID := "attach-target-repo-001"
+	tb := NewTranscriptBuilder()
+	tb.AddUserMessage("explain the auth module")
+	tb.AddAssistantMessage("The auth module handles user authentication.")
+	transcriptPath := filepath.Join(env.ClaudeProjectDir, sessionID+".jsonl")
+	if err := tb.WriteToFile(transcriptPath); err != nil {
+		t.Fatalf("failed to write transcript: %v", err)
+	}
+
+	// Run CLI from a different cwd, pointing at env.RepoDir via --target-repo.
+	otherDir := t.TempDir()
+	cmd := exec.Command(getTestBinary(), "session", "attach", sessionID,
+		"-a", "claude-code", "-f",
+		"--target-repo", env.RepoDir,
+	)
+	cmd.Dir = otherDir
+	cmd.Env = env.cliEnv()
+	outBytes, err := cmd.CombinedOutput()
+	output := string(outBytes)
+	if err != nil {
+		t.Fatalf("attach with --target-repo failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Attached session") {
+		t.Errorf("expected 'Attached session' in output, got:\n%s", output)
+	}
+
+	// The target repo's HEAD must have the trailer.
+	cpID := env.GetCheckpointIDFromCommitMessage(env.GetHeadHash())
+	if cpID == "" {
+		t.Errorf("expected Entire-Checkpoint trailer on target repo HEAD\nOutput: %s", output)
+	}
+
+	// Session state must live in the target repo, not in otherDir.
+	stateFile := filepath.Join(env.RepoDir, ".git", "entire-sessions", sessionID+".json")
+	if _, statErr := os.Stat(stateFile); statErr != nil {
+		t.Errorf("expected session state at %s: %v", stateFile, statErr)
+	}
+	strayState := filepath.Join(otherDir, ".git", "entire-sessions", sessionID+".json")
+	if _, statErr := os.Stat(strayState); statErr == nil {
+		t.Errorf("session state unexpectedly written under cwd: %s", strayState)
+	}
+}
+
+// TestAttach_DryRunJSON_NoMutation verifies that --dry-run --json prints the
+// plan and makes no commit, checkpoint, or session-state mutations.
+func TestAttach_DryRunJSON_NoMutation(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+
+	sessionID := "attach-dry-run-001"
+	tb := NewTranscriptBuilder()
+	tb.AddUserMessage("explain the auth module")
+	tb.AddAssistantMessage("The auth module handles user authentication.")
+	transcriptPath := filepath.Join(env.ClaudeProjectDir, sessionID+".jsonl")
+	if err := tb.WriteToFile(transcriptPath); err != nil {
+		t.Fatalf("failed to write transcript: %v", err)
+	}
+
+	headBefore := env.GetHeadHash()
+	msgBefore := env.GetCommitMessage(headBefore)
+
+	// Capture stdout only so the JSON isn't interleaved with agent flush
+	// warnings on stderr — pipe consumers see only the structured plan.
+	cmd := exec.Command(getTestBinary(), "session", "attach", sessionID,
+		"-a", "claude-code", "--dry-run", "--json",
+	)
+	cmd.Dir = env.RepoDir
+	cmd.Env = env.cliEnv()
+	stdoutBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("dry-run failed: %v", err)
+	}
+	output := string(stdoutBytes)
+
+	var result struct {
+		SessionID           string `json:"session_id"`
+		TargetRepo          string `json:"target_repo"`
+		HeadCommit          string `json:"head_commit"`
+		ExistingTrailer     string `json:"existing_trailer"`
+		Action              string `json:"action"`
+		CheckpointIDPlanned string `json:"checkpoint_id_planned"`
+		TranscriptBytes     int64  `json:"transcript_bytes"`
+		Agent               string `json:"agent"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("dry-run output is not valid JSON: %v\nOutput: %s", err, output)
+	}
+
+	if result.SessionID != sessionID {
+		t.Errorf("session_id mismatch: want %q, got %q", sessionID, result.SessionID)
+	}
+	if result.Action != "would_add_trailer" {
+		t.Errorf("action: want would_add_trailer, got %q", result.Action)
+	}
+	if result.TargetRepo != env.RepoDir {
+		t.Errorf("target_repo: want %q, got %q", env.RepoDir, result.TargetRepo)
+	}
+	if result.HeadCommit != headBefore {
+		t.Errorf("head_commit: want %q, got %q", headBefore, result.HeadCommit)
+	}
+	if result.ExistingTrailer != "" {
+		t.Errorf("existing_trailer: want empty, got %q", result.ExistingTrailer)
+	}
+	if result.CheckpointIDPlanned == "" {
+		t.Error("checkpoint_id_planned should be set for would_add_trailer")
+	}
+	if result.TranscriptBytes <= 0 {
+		t.Errorf("transcript_bytes should be positive, got %d", result.TranscriptBytes)
+	}
+	if result.Agent == "" {
+		t.Error("agent should be set in dry-run output")
+	}
+
+	// No mutation: HEAD hash and message unchanged.
+	if got := env.GetHeadHash(); got != headBefore {
+		t.Errorf("HEAD hash changed: was %q, now %q", headBefore, got)
+	}
+	if got := env.GetCommitMessage(env.GetHeadHash()); got != msgBefore {
+		t.Errorf("HEAD message changed:\nbefore:\n%s\nafter:\n%s", msgBefore, got)
+	}
+
+	stateFile := filepath.Join(env.RepoDir, ".git", "entire-sessions", sessionID+".json")
+	if _, statErr := os.Stat(stateFile); statErr == nil {
+		t.Errorf("dry-run unexpectedly wrote session state: %s", stateFile)
+	}
+}
+
+// TestAttach_DryRun_JSONRejectedWithoutDryRun verifies that --json without
+// --dry-run is rejected. We don't want machine-readable output on the real
+// (state-mutating) path because it complicates UX.
+func TestAttach_DryRun_JSONRejectedWithoutDryRun(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+
+	output, err := env.RunCLIWithError("session", "attach", "some-session-id",
+		"-a", "claude-code", "--json",
+	)
+	if err == nil {
+		t.Errorf("expected error for --json without --dry-run, got output:\n%s", output)
+	}
+	if !strings.Contains(output, "--json is only valid with --dry-run") {
+		t.Errorf("expected explanatory error, got:\n%s", output)
 	}
 }

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -178,6 +178,12 @@ Examples:
   entire session attach <session-id>       Attach an external session
   entire session resume <branch>           Resume from a branch`,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Subcommands that take --target-repo do their own repo validation
+			// against that target inside their RunE, so skip the cwd-based
+			// worktree-root check here when the flag is set.
+			if f := cmd.Flags().Lookup("target-repo"); f != nil && f.Value.String() != "" {
+				return nil
+			}
 			if _, err := paths.WorktreeRoot(cmd.Context()); err != nil {
 				return errors.New("not a git repository")
 			}


### PR DESCRIPTION
## Summary

Adds two flags to `entire session attach` to enable agent sessions running outside an Entire-enabled repo (or across multiple repos) to be linked into the affected Entire-enabled repos without `cd`'ing or guessing what will be amended.

- `--target-repo <path>`: makes attach operate on the given repo instead of cwd. All downstream cwd-coupled lookups (`openRepository`, `git rev-parse --git-common-dir`, session state store path) resolve against the target. The session group's `PersistentPreRunE` skips its cwd-based worktree-root check when this flag is set; the chdir + restore happens inside attach's `RunE` via a deferred restore.
- `--dry-run [--json]`: emits the planned action, checkpoint id, transcript size, target repo, and agent without writing checkpoint metadata, saving session state, or amending HEAD. The short-circuit fires **before** the transcript is read into memory (uses `os.Stat` for size) and **before** `logging.Init` opens a log file — so a multi-repo orchestrator preview stays fast and side-effect-free. JSON goes to stdout for clean piping; warnings stay on stderr.

## What this solves

Today the user runs an agent from a higher-level folder (e.g. `~/Projects/devenv`) and the agent makes changes across multiple child repos. None of the child repos' commits get linked to that agent session, because Entire is repo-scoped and the parent-level launch leaves no session state in the children.

The skill consuming these flags is in entireio/skills#26 (`session-crosslink`) — it does the discovery and orchestration: find the running agent's session id and transcript, infer affected child repos from `files_touched` plus optional explicit input, call `attach --dry-run --json` per repo to render a preview, then on confirmation re-run without `--dry-run` to amend each child repo's HEAD with the checkpoint trailer.

Investigation that motivated this: from a non-Entire-enabled parent, `entire session list --json` returns `[]` because session state is stored under each repo's git common dir; the parent has no store. Once a child repo has the session id, `attach` already works — it resolves the transcript via the agent runtime's filesystem layout, not via any prior session store entry. The missing piece was a way to call attach against a specific repo (not cwd) and to preview before amending.

## Action values

`--dry-run --json` emits one of:

- `would_add_trailer` — HEAD has no checkpoint trailer; a new checkpoint will be created and the commit amended.
- `would_link_existing_in_head` — HEAD already has an `Entire-Checkpoint:` trailer; the session is added to that existing checkpoint.
- `would_skip_existing_in_state` — the session is already linked to a checkpoint in this repo's session store; no-op.

## Test plan

- [x] New integration test: `--target-repo` amends the target repo's HEAD when CLI is run from an unrelated cwd, and session state lands in the target (not cwd).
- [x] New integration test: `--dry-run --json` returns valid JSON on stdout, leaves HEAD hash + message unchanged, and writes no session state file.
- [x] New integration test: `--json` without `--dry-run` returns an explanatory error.
- [x] Existing `TestAttach_*`, `TestSession_*`, `TestReview_*` integration suites pass.
- [x] `cmd/entire/cli` unit tests pass.
- [x] `golangci-lint run --new-from-rev=main` reports 0 issues.

## Out of scope

- A separate `entire transcript locate` command — the skill currently hardcodes per-runtime transcript paths.
- Linking *all* commits in a child repo to the same session — attach links to HEAD (or `--commit`, which is a fast-follow if needed).
- Cross-store session id lookup (`--source-repo`) — not needed; attach already resolves transcripts via the agent runtime's filesystem, not via any source repo's session store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)