### PR TITLE
feat(agent): stream-driven summaries with provider-aware errors

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -255,12 +255,25 @@ const (
 // GenerationProgress reports a snapshot of streaming text generation progress.
 // Fields not relevant to the current Phase may be zero-valued.
 type GenerationProgress struct {
+	// StreamingMode reports an execution-mode transition independently of
+	// provider stream events. This lets callers distinguish a stream that
+	// stalls before its first event from a non-streaming compatibility fallback.
+	StreamingMode     *bool
 	Phase             ProgressPhase
 	OutputTokens      int // running estimate during PhaseGenerating; final at PhaseDone
 	InputTokens       int // populated at PhaseFirstToken
 	CachedInputTokens int // populated at PhaseFirstToken
 	TTFTms            int // time-to-first-token, populated at PhaseFirstToken
 	DurationMs        int // populated at PhaseDone (final result event)
+}
+
+// ReportStreamingMode notifies progress observers which generation path is
+// executing. It is intentionally separate from ProgressPhase because a
+// provider may never emit a stream event at all.
+func ReportStreamingMode(progress ProgressFn, streaming bool) {
+	if progress != nil {
+		progress(GenerationProgress{StreamingMode: &streaming})
+	}
 }
 
 // ProgressFn receives streaming progress updates. It must not block — invoke it

--- a/cmd/entire/cli/agent/claudecode/generate_streaming.go
+++ b/cmd/entire/cli/agent/claudecode/generate_streaming.go
@@ -119,7 +119,9 @@ func (c *ClaudeCodeAgent) GenerateTextStreaming(
 		stderrStr := stderr.String()
 		if looksLikeUnrecognizedFlag(stderrStr) {
 			logging.Warn(ctx, "claude CLI rejected stream-json flags; falling back to non-streaming (no progress output)",
-				slog.String("stderr", strings.TrimSpace(stderrStr)))
+				slog.String("agent", "claude-code"),
+				slog.Int("stderr_bytes", len(strings.TrimSpace(stderrStr))))
+			agent.ReportStreamingMode(progress, false)
 			return c.GenerateText(ctx, prompt, model)
 		}
 		if stderrStr != "" {

--- a/cmd/entire/cli/agent/codex/generate.go
+++ b/cmd/entire/cli/agent/codex/generate.go
@@ -15,13 +15,9 @@ func (c *CodexAgent) GenerateText(ctx context.Context, prompt string, model stri
 	}
 	args = append(args, "-")
 
-	result, capturedStderr, stdoutBytes, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, "codex", "codex", args, prompt)
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, agent.AgentNameCodex, args, prompt)
 	if err != nil {
-		return "", &agent.TextGenerationError{
-			Err:         fmt.Errorf("codex text generation failed: %w", err),
-			Stderr:      capturedStderr,
-			StdoutBytes: stdoutBytes,
-		}
+		return "", fmt.Errorf("codex text generation failed: %w", err)
 	}
 	return result, nil
 }

--- a/cmd/entire/cli/agent/codex/generate_streaming.go
+++ b/cmd/entire/cli/agent/codex/generate_streaming.go
@@ -28,6 +28,7 @@ func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, erro
 		usage           *codexStreamUsage
 		turnStartedAt   time.Time
 		turnDuration    time.Duration
+		malformed       int
 	)
 
 	dispatch := func(p agent.GenerationProgress) {
@@ -43,6 +44,11 @@ func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, erro
 		}
 		var ev codexStreamEvent
 		if err := json.Unmarshal(line, &ev); err != nil {
+			// Codex may emit transient noise (blank lines, partial flushes); a
+			// schema-incompatible line is recoverable per-event but tracked so
+			// protocol regressions surface in the "no agent_message" error
+			// instead of disappearing silently.
+			malformed++
 			continue
 		}
 
@@ -69,9 +75,23 @@ func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, erro
 			}
 
 		case "turn.failed", "error":
-			detail := "unspecified error"
-			if len(line) > 0 {
-				detail = string(line)
+			var details struct {
+				Message string `json:"message"`
+				Error   struct {
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			// Partial decode tolerated: if the schema changes we fall through
+			// to "unspecified error" rather than leaking the raw line (which
+			// may carry echoed user content or model-message fragments) into
+			// logs, telemetry, and *TextGenerationError.Stderr.
+			_ = json.Unmarshal(line, &details) //nolint:errcheck // see comment above
+			detail := details.Message
+			if detail == "" {
+				detail = details.Error.Message
+			}
+			if detail == "" {
+				detail = "unspecified error"
 			}
 			return "", fmt.Errorf("codex turn failed: %s", detail)
 		}
@@ -83,6 +103,9 @@ func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, erro
 		return "", errors.New("codex stream ended without a turn.completed event")
 	}
 	if resultText == "" {
+		if malformed > 0 {
+			return "", fmt.Errorf("codex stream produced no agent_message (%d malformed lines skipped)", malformed)
+		}
 		return "", errors.New("codex stream produced no agent_message")
 	}
 	if progress != nil {

--- a/cmd/entire/cli/agent/codex/generate_streaming.go
+++ b/cmd/entire/cli/agent/codex/generate_streaming.go
@@ -119,10 +119,9 @@ func (c *CodexAgent) GenerateTextStreaming(
 	progress agent.ProgressFn,
 ) (string, error) {
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:   "codex",
-		DisplayName: "codex",
-		BuildCmd:    c.buildStreamCmd,
-		Parser:      parseCodexStream,
+		AgentName: "codex",
+		BuildCmd:  c.buildStreamCmd,
+		Parser:    parseCodexStream,
 		LooksLikeUnrecognizedFlag: func(stderr string) bool {
 			return agent.LooksLikeUnrecognizedFlag(stderr, "json")
 		},

--- a/cmd/entire/cli/agent/codex/generate_streaming.go
+++ b/cmd/entire/cli/agent/codex/generate_streaming.go
@@ -75,25 +75,7 @@ func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, erro
 			}
 
 		case "turn.failed", "error":
-			var details struct {
-				Message string `json:"message"`
-				Error   struct {
-					Message string `json:"message"`
-				} `json:"error"`
-			}
-			// Partial decode tolerated: if the schema changes we fall through
-			// to "unspecified error" rather than leaking the raw line (which
-			// may carry echoed user content or model-message fragments) into
-			// logs, telemetry, and *TextGenerationError.Stderr.
-			_ = json.Unmarshal(line, &details) //nolint:errcheck // see comment above
-			detail := details.Message
-			if detail == "" {
-				detail = details.Error.Message
-			}
-			if detail == "" {
-				detail = "unspecified error"
-			}
-			return "", fmt.Errorf("codex turn failed: %s", detail)
+			return "", fmt.Errorf("codex turn failed: %s", agent.SafeErrorMessage(line))
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/cmd/entire/cli/agent/codex/generate_streaming.go
+++ b/cmd/entire/cli/agent/codex/generate_streaming.go
@@ -1,0 +1,159 @@
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+const streamBufferMax = 4 * 1024 * 1024 // 4 MiB
+
+// parseCodexStream consumes `codex exec --json` NDJSON output, dispatches
+// progress callbacks, and returns the final agent_message text.
+func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, error) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 64*1024), streamBufferMax)
+
+	var (
+		resultText      string
+		sawTurnComplete bool
+		usage           *codexStreamUsage
+		turnStartedAt   time.Time
+		turnDuration    time.Duration
+	)
+
+	dispatch := func(p agent.GenerationProgress) {
+		if progress != nil {
+			progress(p)
+		}
+	}
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev codexStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+
+		switch ev.Type {
+		case "turn.started":
+			turnStartedAt = time.Now()
+			dispatch(agent.GenerationProgress{Phase: agent.PhaseConnecting})
+
+		case "item.completed":
+			// Codex emits the full agent_message in one item; we capture
+			// the text but defer PhaseFirstToken until turn.completed so
+			// the cached_input_tokens usage clause can be attached. The
+			// CLI buffers and emits items in one chunk per turn, so there
+			// is no incremental "first token" signal to surface anyway.
+			if ev.Item != nil && ev.Item.Type == "agent_message" {
+				resultText = ev.Item.Text
+			}
+
+		case "turn.completed":
+			sawTurnComplete = true
+			usage = ev.Usage
+			if !turnStartedAt.IsZero() {
+				turnDuration = time.Since(turnStartedAt)
+			}
+
+		case "turn.failed", "error":
+			detail := "unspecified error"
+			if len(line) > 0 {
+				detail = string(line)
+			}
+			return "", fmt.Errorf("codex turn failed: %s", detail)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading codex stream: %w", err)
+	}
+	if !sawTurnComplete {
+		return "", errors.New("codex stream ended without a turn.completed event")
+	}
+	if resultText == "" {
+		return "", errors.New("codex stream produced no agent_message")
+	}
+	if progress != nil {
+		firstToken := agent.GenerationProgress{Phase: agent.PhaseFirstToken}
+		if usage != nil {
+			firstToken.InputTokens = usage.InputTokens
+			firstToken.CachedInputTokens = usage.CachedInputTokens
+		}
+		dispatch(firstToken)
+
+		done := agent.GenerationProgress{Phase: agent.PhaseDone}
+		if usage != nil {
+			done.OutputTokens = usage.OutputTokens
+			done.InputTokens = usage.InputTokens
+			done.CachedInputTokens = usage.CachedInputTokens
+		}
+		if turnDuration > 0 {
+			done.DurationMs = int(turnDuration.Milliseconds())
+		}
+		dispatch(done)
+	}
+	return resultText, nil
+}
+
+// GenerateTextStreaming implements agent.StreamingTextGenerator.
+func (c *CodexAgent) GenerateTextStreaming(
+	ctx context.Context,
+	prompt, model string,
+	progress agent.ProgressFn,
+) (string, error) {
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName:                 "codex",
+		DisplayName:               "codex",
+		BuildCmd:                  c.buildStreamCmd,
+		Parser:                    parseCodexStream,
+		LooksLikeUnrecognizedFlag: looksLikeCodexUnrecognizedFlag,
+	}
+
+	result, err := tmpl.Generate(ctx, prompt, model, progress)
+	if err != nil {
+		if errors.Is(err, agent.ErrUnrecognizedStreamingFlag) {
+			return c.GenerateText(ctx, prompt, model)
+		}
+		return "", fmt.Errorf("codex streaming generate: %w", err)
+	}
+	return result, nil
+}
+
+func (c *CodexAgent) buildStreamCmd(ctx context.Context, prompt, model string) *exec.Cmd {
+	commandRunner := c.CommandRunner
+	if commandRunner == nil {
+		commandRunner = exec.CommandContext
+	}
+	args := []string{"exec", "--skip-git-repo-check", "--json"}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	args = append(args, "-")
+	cmd := commandRunner(ctx, "codex", args...)
+	cmd.Stdin = strings.NewReader(prompt)
+	return cmd
+}
+
+func looksLikeCodexUnrecognizedFlag(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	hasRejectPhrase := strings.Contains(lower, "unrecognized option") ||
+		strings.Contains(lower, "unknown flag") ||
+		strings.Contains(lower, "unknown option") ||
+		strings.Contains(lower, "invalid option")
+	if !hasRejectPhrase {
+		return false
+	}
+	return strings.Contains(lower, "json") || strings.Contains(lower, "exec")
+}

--- a/cmd/entire/cli/agent/codex/generate_streaming.go
+++ b/cmd/entire/cli/agent/codex/generate_streaming.go
@@ -137,11 +137,13 @@ func (c *CodexAgent) GenerateTextStreaming(
 	progress agent.ProgressFn,
 ) (string, error) {
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:                 "codex",
-		DisplayName:               "codex",
-		BuildCmd:                  c.buildStreamCmd,
-		Parser:                    parseCodexStream,
-		LooksLikeUnrecognizedFlag: looksLikeCodexUnrecognizedFlag,
+		AgentName:   "codex",
+		DisplayName: "codex",
+		BuildCmd:    c.buildStreamCmd,
+		Parser:      parseCodexStream,
+		LooksLikeUnrecognizedFlag: func(stderr string) bool {
+			return agent.LooksLikeUnrecognizedFlag(stderr, "json")
+		},
 	}
 
 	result, err := tmpl.Generate(ctx, prompt, model, progress)
@@ -167,16 +169,4 @@ func (c *CodexAgent) buildStreamCmd(ctx context.Context, prompt, model string) *
 	cmd := commandRunner(ctx, "codex", args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	return cmd
-}
-
-func looksLikeCodexUnrecognizedFlag(stderr string) bool {
-	lower := strings.ToLower(stderr)
-	hasRejectPhrase := strings.Contains(lower, "unrecognized option") ||
-		strings.Contains(lower, "unknown flag") ||
-		strings.Contains(lower, "unknown option") ||
-		strings.Contains(lower, "invalid option")
-	if !hasRejectPhrase {
-		return false
-	}
-	return strings.Contains(lower, "json") || strings.Contains(lower, "exec")
 }

--- a/cmd/entire/cli/agent/codex/generate_streaming.go
+++ b/cmd/entire/cli/agent/codex/generate_streaming.go
@@ -26,6 +26,7 @@ func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, erro
 		resultText      string
 		sawTurnComplete bool
 		usage           *codexStreamUsage
+		firstTokenFired bool
 		turnStartedAt   time.Time
 		turnDuration    time.Duration
 		malformed       int
@@ -58,13 +59,12 @@ func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, erro
 			dispatch(agent.GenerationProgress{Phase: agent.PhaseConnecting})
 
 		case "item.completed":
-			// Codex emits the full agent_message in one item; we capture
-			// the text but defer PhaseFirstToken until turn.completed so
-			// the cached_input_tokens usage clause can be attached. The
-			// CLI buffers and emits items in one chunk per turn, so there
-			// is no incremental "first token" signal to surface anyway.
 			if ev.Item != nil && ev.Item.Type == "agent_message" {
 				resultText = ev.Item.Text
+				if !firstTokenFired {
+					firstTokenFired = true
+					dispatch(agent.GenerationProgress{Phase: agent.PhaseFirstToken})
+				}
 			}
 
 		case "turn.completed":
@@ -75,7 +75,9 @@ func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, erro
 			}
 
 		case "turn.failed", "error":
-			return "", fmt.Errorf("codex turn failed: %s", agent.SafeErrorMessage(line))
+			return "", agent.MarkProviderStreamError( //nolint:wrapcheck // private transport marker preserves the decoded provider error chain
+				fmt.Errorf("codex turn failed: %s", agent.SafeErrorMessage(line)),
+			)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -91,13 +93,6 @@ func parseCodexStream(stdout io.Reader, progress agent.ProgressFn) (string, erro
 		return "", errors.New("codex stream produced no agent_message")
 	}
 	if progress != nil {
-		firstToken := agent.GenerationProgress{Phase: agent.PhaseFirstToken}
-		if usage != nil {
-			firstToken.InputTokens = usage.InputTokens
-			firstToken.CachedInputTokens = usage.CachedInputTokens
-		}
-		dispatch(firstToken)
-
 		done := agent.GenerationProgress{Phase: agent.PhaseDone}
 		if usage != nil {
 			done.OutputTokens = usage.OutputTokens
@@ -130,6 +125,7 @@ func (c *CodexAgent) GenerateTextStreaming(
 	result, err := tmpl.Generate(ctx, prompt, model, progress)
 	if err != nil {
 		if errors.Is(err, agent.ErrUnrecognizedStreamingFlag) {
+			agent.ReportStreamingMode(progress, false)
 			return c.GenerateText(ctx, prompt, model)
 		}
 		return "", fmt.Errorf("codex streaming generate: %w", err)

--- a/cmd/entire/cli/agent/codex/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/codex/generate_streaming_test.go
@@ -1,0 +1,132 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/testutil"
+)
+
+func TestParseCodexStream_Success(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "stream_success.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var phases []agent.ProgressPhase
+	result, err := parseCodexStream(bytes.NewReader(data), func(p agent.GenerationProgress) {
+		phases = append(phases, p.Phase)
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if result != "Hello, world." {
+		t.Errorf("result = %q, want %q", result, "Hello, world.")
+	}
+
+	counts := map[agent.ProgressPhase]int{}
+	for _, p := range phases {
+		counts[p]++
+	}
+	if counts[agent.PhaseConnecting] != 1 {
+		t.Errorf("PhaseConnecting count = %d, want 1", counts[agent.PhaseConnecting])
+	}
+	if counts[agent.PhaseFirstToken] != 1 {
+		t.Errorf("PhaseFirstToken count = %d, want 1", counts[agent.PhaseFirstToken])
+	}
+	if counts[agent.PhaseDone] != 1 {
+		t.Errorf("PhaseDone count = %d, want 1", counts[agent.PhaseDone])
+	}
+}
+
+func TestParseCodexStream_ErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "stream_error.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	_, err = parseCodexStream(bytes.NewReader(data), nil)
+	if err == nil {
+		t.Fatal("expected error from error envelope")
+	}
+	if !strings.Contains(err.Error(), "model not found") {
+		t.Errorf("error %q should mention 'model not found'", err)
+	}
+}
+
+func TestParseCodexStream_MissingTurnCompleted(t *testing.T) {
+	t.Parallel()
+
+	stream := `{"type":"thread.started","thread_id":"t"}
+{"type":"item.completed","item":{"id":"i","type":"agent_message","text":"partial"}}
+`
+	_, err := parseCodexStream(strings.NewReader(stream), nil)
+	if err == nil {
+		t.Fatal("expected error when stream lacks turn.completed")
+	}
+}
+
+func TestCodexGenerateTextStreaming_Success(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := os.ReadFile(filepath.Join("testdata", "stream_success.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	c := &CodexAgent{
+		CommandRunner: testutil.FakeStreamCmd(string(fixture), "", 0),
+	}
+
+	var phases []agent.ProgressPhase
+	result, err := c.GenerateTextStreaming(context.Background(), "test prompt", "haiku", func(p agent.GenerationProgress) {
+		phases = append(phases, p.Phase)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "Hello, world." {
+		t.Errorf("result = %q, want %q", result, "Hello, world.")
+	}
+	if len(phases) != 3 {
+		t.Errorf("phases = %v (count %d), want 3 (Connecting, FirstToken, Done)", phases, len(phases))
+	}
+}
+
+func TestCodexGenerateTextStreaming_FallbackOnUnrecognizedFlag(t *testing.T) {
+	t.Parallel()
+
+	streamCall := testutil.FakeStreamCmd("", "error: unknown flag: --json", 1)
+	nonStreamCall := testutil.FakeStreamCmd("fallback response", "", 0)
+	calls := 0
+	c := &CodexAgent{
+		CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			calls++
+			if calls == 1 {
+				return streamCall(ctx, name, args...)
+			}
+			return nonStreamCall(ctx, name, args...)
+		},
+	}
+
+	result, err := c.GenerateTextStreaming(context.Background(), "test", "haiku", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "fallback") {
+		t.Errorf("result = %q, want substring 'fallback'", result)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2 (streaming + fallback)", calls)
+	}
+}

--- a/cmd/entire/cli/agent/codex/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/codex/generate_streaming_test.go
@@ -147,9 +147,15 @@ func TestCodexGenerateTextStreaming_Success(t *testing.T) {
 		t.Fatalf("read fixture: %v", err)
 	}
 
-	c := &CodexAgent{
-		CommandRunner: testutil.FakeStreamCmd(string(fixture), "", 0),
-	}
+	fake := testutil.FakeStreamCmd(string(fixture), "", 0)
+	var commandName string
+	var commandArgs []string
+	var command *exec.Cmd
+	c := &CodexAgent{CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		commandName, commandArgs = name, append([]string(nil), args...)
+		command = fake(ctx, name, args...)
+		return command
+	}}
 
 	var phases []agent.ProgressPhase
 	result, err := c.GenerateTextStreaming(context.Background(), "test prompt", "haiku", func(p agent.GenerationProgress) {
@@ -163,6 +169,13 @@ func TestCodexGenerateTextStreaming_Success(t *testing.T) {
 	}
 	if len(phases) != 3 {
 		t.Errorf("phases = %v (count %d), want 3 (Connecting, FirstToken, Done)", phases, len(phases))
+	}
+	if commandName != "codex" || strings.Join(commandArgs, " ") != "exec --skip-git-repo-check --json --model haiku -" {
+		t.Errorf("command = %q %v, want codex streaming argv", commandName, commandArgs)
+	}
+	stdin, stdinErr := testutil.ReadCommandStdin(command)
+	if stdinErr != nil || stdin != "test prompt" {
+		t.Errorf("stdin = %q, err = %v; want exact prompt", stdin, stdinErr)
 	}
 }
 

--- a/cmd/entire/cli/agent/codex/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/codex/generate_streaming_test.go
@@ -76,6 +76,69 @@ func TestParseCodexStream_MissingTurnCompleted(t *testing.T) {
 	}
 }
 
+func TestParseCodexStream_TruncatedAfterAgentMessageEmitsFirstTokenOnly(t *testing.T) {
+	t.Parallel()
+
+	stream := `{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"i","type":"agent_message","text":"partial"}}
+`
+	var events []agent.GenerationProgress
+	_, err := parseCodexStream(strings.NewReader(stream), func(progress agent.GenerationProgress) {
+		events = append(events, progress)
+	})
+	if err == nil {
+		t.Fatal("expected error when stream lacks turn.completed")
+	}
+
+	var firstToken, done int
+	for _, event := range events {
+		switch event.Phase {
+		case agent.PhaseFirstToken:
+			firstToken++
+		case agent.PhaseDone:
+			done++
+		case agent.PhaseConnecting, agent.PhaseGenerating:
+			// Other progress phases do not affect the first-token/terminal contract.
+		}
+	}
+	if firstToken != 1 {
+		t.Fatalf("PhaseFirstToken count = %d, want 1 when agent_message arrives", firstToken)
+	}
+	if done != 0 {
+		t.Fatalf("PhaseDone count = %d, want 0 without turn.completed", done)
+	}
+}
+
+func TestParseCodexStream_TerminalUsageIsAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "stream_success.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var firstToken, done agent.GenerationProgress
+	_, err = parseCodexStream(bytes.NewReader(data), func(progress agent.GenerationProgress) {
+		switch progress.Phase {
+		case agent.PhaseFirstToken:
+			firstToken = progress
+		case agent.PhaseDone:
+			done = progress
+		case agent.PhaseConnecting, agent.PhaseGenerating:
+			// Other progress phases carry no authoritative terminal usage.
+		}
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if firstToken.InputTokens != 0 || firstToken.CachedInputTokens != 0 || firstToken.OutputTokens != 0 {
+		t.Fatalf("first token must not predict terminal usage: %+v", firstToken)
+	}
+	if done.InputTokens != 9 || done.CachedInputTokens != 1234 || done.OutputTokens != 3 {
+		t.Fatalf("done usage = %+v, want authoritative terminal usage", done)
+	}
+}
+
 func TestCodexGenerateTextStreaming_Success(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/codex/stream_response.go
+++ b/cmd/entire/cli/agent/codex/stream_response.go
@@ -1,0 +1,27 @@
+package codex
+
+// codexStreamEvent is one decoded line of `codex exec --json` output.
+// Fields are populated based on the event Type/Item.Type.
+type codexStreamEvent struct {
+	Type     string            `json:"type"`
+	ThreadID string            `json:"thread_id,omitempty"`
+	Item     *codexStreamItem  `json:"item,omitempty"`
+	Usage    *codexStreamUsage `json:"usage,omitempty"`
+}
+
+// codexStreamItem appears inside type=item.completed events. For summary
+// generation we care only about Type="agent_message" items, which carry
+// the model's response in Text.
+type codexStreamItem struct {
+	ID   string `json:"id"`
+	Type string `json:"type"` // "agent_message" | "command_execution" | ...
+	Text string `json:"text"` // populated for agent_message
+}
+
+// codexStreamUsage appears inside the terminal type=turn.completed event.
+type codexStreamUsage struct {
+	InputTokens           int `json:"input_tokens,omitempty"`
+	CachedInputTokens     int `json:"cached_input_tokens,omitempty"`
+	OutputTokens          int `json:"output_tokens,omitempty"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens,omitempty"`
+}

--- a/cmd/entire/cli/agent/codex/testdata/stream_error.jsonl
+++ b/cmd/entire/cli/agent/codex/testdata/stream_error.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"test-thread"}
+{"type":"turn.started"}
+{"type":"error","message":"invalid_request_error: model not found"}
+{"type":"turn.failed","error":{"message":"model not found"}}

--- a/cmd/entire/cli/agent/codex/testdata/stream_success.jsonl
+++ b/cmd/entire/cli/agent/codex/testdata/stream_success.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"test-thread"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"Hello, world."}}
+{"type":"turn.completed","usage":{"input_tokens":9,"cached_input_tokens":1234,"output_tokens":3,"reasoning_output_tokens":0}}

--- a/cmd/entire/cli/agent/copilotcli/generate.go
+++ b/cmd/entire/cli/agent/copilotcli/generate.go
@@ -19,13 +19,9 @@ func (c *CopilotCLIAgent) GenerateText(ctx context.Context, prompt string, model
 		args = append(args, "--model", model)
 	}
 
-	result, capturedStderr, stdoutBytes, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, "copilot", "copilot", args, prompt)
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, agent.AgentNameCopilotCLI, args, prompt)
 	if err != nil {
-		return "", &agent.TextGenerationError{
-			Err:         fmt.Errorf("copilot text generation failed: %w", err),
-			Stderr:      capturedStderr,
-			StdoutBytes: stdoutBytes,
-		}
+		return "", fmt.Errorf("copilot text generation failed: %w", err)
 	}
 	return result, nil
 }

--- a/cmd/entire/cli/agent/copilotcli/generate_streaming.go
+++ b/cmd/entire/cli/agent/copilotcli/generate_streaming.go
@@ -189,11 +189,13 @@ func (c *CopilotCLIAgent) GenerateTextStreaming(
 	progress agent.ProgressFn,
 ) (string, error) {
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:                 "copilot-cli",
-		DisplayName:               "copilot",
-		BuildCmd:                  c.buildStreamCmd,
-		Parser:                    parseCopilotStream,
-		LooksLikeUnrecognizedFlag: looksLikeCopilotUnrecognizedFlag,
+		AgentName:   "copilot-cli",
+		DisplayName: "copilot",
+		BuildCmd:    c.buildStreamCmd,
+		Parser:      parseCopilotStream,
+		LooksLikeUnrecognizedFlag: func(stderr string) bool {
+			return agent.LooksLikeUnrecognizedFlag(stderr, "stream", "output-format")
+		},
 	}
 
 	result, err := tmpl.Generate(ctx, prompt, model, progress)
@@ -218,22 +220,4 @@ func (c *CopilotCLIAgent) buildStreamCmd(ctx context.Context, prompt, model stri
 	cmd := commandRunner(ctx, "copilot", args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	return cmd
-}
-
-// looksLikeCopilotUnrecognizedFlag is the 3rd of 4 per-agent flag-rejection
-// heuristics. Consolidation deferred to a post-chunk-5 cleanup commit. Phrase
-// set matches Codex's (strict — "unknown flag" rather than bare "unknown") to
-// avoid the over-broad matches a Chunk-3 code review flagged on Gemini.
-//
-//nolint:dupl // 3rd of 4 per-agent flag-rejection heuristics; consolidation deferred to a post-chunk-5 cleanup commit
-func looksLikeCopilotUnrecognizedFlag(stderr string) bool {
-	lower := strings.ToLower(stderr)
-	hasRejectPhrase := strings.Contains(lower, "unknown flag") ||
-		strings.Contains(lower, "unrecognized option") ||
-		strings.Contains(lower, "unknown option") ||
-		strings.Contains(lower, "invalid option")
-	if !hasRejectPhrase {
-		return false
-	}
-	return strings.Contains(lower, "stream") || strings.Contains(lower, "output-format")
 }

--- a/cmd/entire/cli/agent/copilotcli/generate_streaming.go
+++ b/cmd/entire/cli/agent/copilotcli/generate_streaming.go
@@ -48,6 +48,7 @@ func parseCopilotStream(stdout io.Reader, progress agent.ProgressFn) (string, er
 		sawTerminal     bool
 		usage           *copilotStreamUsage
 		outputTokens    int
+		streamedChars   int
 		malformed       int
 		start           = time.Now()
 	)
@@ -95,7 +96,13 @@ func parseCopilotStream(stdout io.Reader, progress agent.ProgressFn) (string, er
 				// without parens.
 				dispatch(agent.GenerationProgress{Phase: agent.PhaseFirstToken})
 			} else {
-				dispatch(agent.GenerationProgress{Phase: agent.PhaseGenerating})
+				// Estimate running output tokens from accumulated character
+				// count so the writer's "Writing summary... (~Nk tokens)"
+				// counter ticks during streaming (matches Claude's pattern
+				// from PR #964). Authoritative output_tokens still arrives
+				// later via assistant.message events and overrides on Done.
+				streamedChars += len(ev.Data.DeltaContent)
+				dispatch(agent.GenerationProgress{Phase: agent.PhaseGenerating, OutputTokens: streamedChars / 4})
 			}
 			result.WriteString(ev.Data.DeltaContent)
 

--- a/cmd/entire/cli/agent/copilotcli/generate_streaming.go
+++ b/cmd/entire/cli/agent/copilotcli/generate_streaming.go
@@ -165,10 +165,9 @@ func (c *CopilotCLIAgent) GenerateTextStreaming(
 	progress agent.ProgressFn,
 ) (string, error) {
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:   "copilot-cli",
-		DisplayName: "copilot",
-		BuildCmd:    c.buildStreamCmd,
-		Parser:      parseCopilotStream,
+		AgentName: "copilot-cli",
+		BuildCmd:  c.buildStreamCmd,
+		Parser:    parseCopilotStream,
 		LooksLikeUnrecognizedFlag: func(stderr string) bool {
 			return agent.LooksLikeUnrecognizedFlag(stderr, "stream", "output-format")
 		},

--- a/cmd/entire/cli/agent/copilotcli/generate_streaming.go
+++ b/cmd/entire/cli/agent/copilotcli/generate_streaming.go
@@ -1,0 +1,232 @@
+package copilotcli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+const streamBufferMax = 4 * 1024 * 1024 // 4 MiB
+
+// parseCopilotStream consumes `copilot --output-format json --stream on` NDJSON
+// output, dispatches progress callbacks, and returns the concatenated assistant
+// content.
+//
+// Real-CLI shape (GitHub Copilot CLI 1.0.48):
+//   - session.* / user.message                           → ignored (bootstrap + echo)
+//   - assistant.turn_start                               → PhaseConnecting
+//   - assistant.message_start                            → ignored (ephemeral marker)
+//   - assistant.message_delta (deltaContent)             → PhaseFirstToken (1st) /
+//     PhaseGenerating (subsequent),
+//     content concatenated
+//   - assistant.message (non-ephemeral, outputTokens)    → captures token count
+//   - assistant.turn_end                                 → turn marker, no-op
+//   - result (exitCode, usage.totalApiDurationMs)        → PhaseDone (terminal);
+//     non-zero exitCode is
+//     treated as a stream error
+//
+// The "error" event shape is defensive: Copilot's current public stream
+// typically reports failures via non-zero result.exitCode plus a stderr
+// message, not an in-stream JSON envelope. The error-event handler is kept
+// for forward-compat with potential future CLI versions that adopt one.
+func parseCopilotStream(stdout io.Reader, progress agent.ProgressFn) (string, error) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 64*1024), streamBufferMax)
+
+	var (
+		result          strings.Builder
+		connectingFired bool
+		firstTokenFired bool
+		sawTerminal     bool
+		usage           *copilotStreamUsage
+		outputTokens    int
+		malformed       int
+		start           = time.Now()
+	)
+
+	dispatch := func(p agent.GenerationProgress) {
+		if progress != nil {
+			progress(p)
+		}
+	}
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev copilotStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			// Copilot may emit transient noise (blank lines, partial flushes); a
+			// schema-incompatible line is recoverable per-event but tracked so
+			// protocol regressions surface in the no-content error instead of
+			// disappearing silently.
+			malformed++
+			continue
+		}
+
+		switch ev.Type {
+		case "assistant.turn_start":
+			// Copilot emits one assistant.turn_start per tool-using turn. The
+			// progress UI expects PhaseConnecting once per generation, so we
+			// fire only on the first turn.
+			if !connectingFired {
+				connectingFired = true
+				dispatch(agent.GenerationProgress{Phase: agent.PhaseConnecting})
+			}
+
+		case "assistant.message_delta":
+			if ev.Data == nil || ev.Data.DeltaContent == "" {
+				continue
+			}
+			if !firstTokenFired {
+				firstTokenFired = true
+				// Copilot's delta events carry no TTFT, input-token, or
+				// cached-token data; the progress writer's graceful
+				// degradation will render "Provider responded -- generating..."
+				// without parens.
+				dispatch(agent.GenerationProgress{Phase: agent.PhaseFirstToken})
+			} else {
+				dispatch(agent.GenerationProgress{Phase: agent.PhaseGenerating})
+			}
+			result.WriteString(ev.Data.DeltaContent)
+
+		case "assistant.message":
+			// Each non-ephemeral assistant.message carries the outputTokens for
+			// one turn. Multi-turn generations (tool-using runs) emit several;
+			// sum them so PhaseDone reports the total output tokens for the
+			// whole generation.
+			if ev.Data != nil && ev.Data.OutputTokens > 0 {
+				outputTokens += ev.Data.OutputTokens
+			}
+
+		case "result":
+			sawTerminal = true
+			usage = ev.Usage
+			if ev.ExitCode != 0 {
+				// Partial decode tolerated: schema drift falls through to
+				// "unspecified error" rather than leaking the raw line (which
+				// may carry echoed user content or model fragments) into logs
+				// and *TextGenerationError.Stderr.
+				return "", fmt.Errorf("copilot stream error: non-zero exit code %d", ev.ExitCode)
+			}
+
+		case "error":
+			var details struct {
+				Message string `json:"message"`
+				Error   struct {
+					Message string `json:"message"`
+				} `json:"error"`
+				Data struct {
+					Message string `json:"message"`
+				} `json:"data"`
+			}
+			// Partial decode tolerated: schema drift falls through to
+			// "unspecified error" rather than leaking the raw line (which
+			// may carry echoed user content or model fragments) into logs
+			// and *TextGenerationError.Stderr.
+			_ = json.Unmarshal(line, &details) //nolint:errcheck // see comment above
+			detail := details.Message
+			if detail == "" {
+				detail = details.Error.Message
+			}
+			if detail == "" {
+				detail = details.Data.Message
+			}
+			if detail == "" {
+				detail = "unspecified error"
+			}
+			return "", fmt.Errorf("copilot stream error: %s", detail)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading copilot stream: %w", err)
+	}
+	if !firstTokenFired {
+		if malformed > 0 {
+			return "", fmt.Errorf("copilot stream produced no assistant content (%d malformed lines skipped)", malformed)
+		}
+		return "", errors.New("copilot stream produced no assistant content")
+	}
+	if progress != nil {
+		done := agent.GenerationProgress{Phase: agent.PhaseDone}
+		if outputTokens > 0 {
+			done.OutputTokens = outputTokens
+		}
+		if usage != nil && usage.TotalAPIDurationMs > 0 {
+			done.DurationMs = usage.TotalAPIDurationMs
+		}
+		if done.DurationMs == 0 {
+			// EOF / no-terminal fallback: compute locally so the progress
+			// writer always has a duration to render.
+			done.DurationMs = int(time.Since(start).Milliseconds())
+		}
+		dispatch(done)
+	}
+	_ = sawTerminal // kept for diagnostic clarity; absence is acceptable (EOF fallback)
+	return result.String(), nil
+}
+
+// GenerateTextStreaming implements agent.StreamingTextGenerator.
+func (c *CopilotCLIAgent) GenerateTextStreaming(
+	ctx context.Context,
+	prompt, model string,
+	progress agent.ProgressFn,
+) (string, error) {
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName:                 "copilot-cli",
+		DisplayName:               "copilot",
+		BuildCmd:                  c.buildStreamCmd,
+		Parser:                    parseCopilotStream,
+		LooksLikeUnrecognizedFlag: looksLikeCopilotUnrecognizedFlag,
+	}
+
+	result, err := tmpl.Generate(ctx, prompt, model, progress)
+	if err != nil {
+		if errors.Is(err, agent.ErrUnrecognizedStreamingFlag) {
+			return c.GenerateText(ctx, prompt, model)
+		}
+		return "", fmt.Errorf("copilot streaming generate: %w", err)
+	}
+	return result, nil
+}
+
+func (c *CopilotCLIAgent) buildStreamCmd(ctx context.Context, prompt, model string) *exec.Cmd {
+	commandRunner := c.CommandRunner
+	if commandRunner == nil {
+		commandRunner = exec.CommandContext
+	}
+	args := []string{"--output-format", "json", "--stream", "on", "--allow-all-tools", "--disable-builtin-mcps"}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	cmd := commandRunner(ctx, "copilot", args...)
+	cmd.Stdin = strings.NewReader(prompt)
+	return cmd
+}
+
+// looksLikeCopilotUnrecognizedFlag is the 3rd of 4 per-agent flag-rejection
+// heuristics. Consolidation deferred to a post-chunk-5 cleanup commit. Phrase
+// set matches Codex's (strict — "unknown flag" rather than bare "unknown") to
+// avoid the over-broad matches a Chunk-3 code review flagged on Gemini.
+//
+//nolint:dupl // 3rd of 4 per-agent flag-rejection heuristics; consolidation deferred to a post-chunk-5 cleanup commit
+func looksLikeCopilotUnrecognizedFlag(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	hasRejectPhrase := strings.Contains(lower, "unknown flag") ||
+		strings.Contains(lower, "unrecognized option") ||
+		strings.Contains(lower, "unknown option") ||
+		strings.Contains(lower, "invalid option")
+	if !hasRejectPhrase {
+		return false
+	}
+	return strings.Contains(lower, "stream") || strings.Contains(lower, "output-format")
+}

--- a/cmd/entire/cli/agent/copilotcli/generate_streaming.go
+++ b/cmd/entire/cli/agent/copilotcli/generate_streaming.go
@@ -127,31 +127,7 @@ func parseCopilotStream(stdout io.Reader, progress agent.ProgressFn) (string, er
 			}
 
 		case "error":
-			var details struct {
-				Message string `json:"message"`
-				Error   struct {
-					Message string `json:"message"`
-				} `json:"error"`
-				Data struct {
-					Message string `json:"message"`
-				} `json:"data"`
-			}
-			// Partial decode tolerated: schema drift falls through to
-			// "unspecified error" rather than leaking the raw line (which
-			// may carry echoed user content or model fragments) into logs
-			// and *TextGenerationError.Stderr.
-			_ = json.Unmarshal(line, &details) //nolint:errcheck // see comment above
-			detail := details.Message
-			if detail == "" {
-				detail = details.Error.Message
-			}
-			if detail == "" {
-				detail = details.Data.Message
-			}
-			if detail == "" {
-				detail = "unspecified error"
-			}
-			return "", fmt.Errorf("copilot stream error: %s", detail)
+			return "", fmt.Errorf("copilot stream error: %s", agent.SafeErrorMessage(line))
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/cmd/entire/cli/agent/copilotcli/generate_streaming.go
+++ b/cmd/entire/cli/agent/copilotcli/generate_streaming.go
@@ -88,6 +88,7 @@ func parseCopilotStream(stdout io.Reader, progress agent.ProgressFn) (string, er
 			if ev.Data == nil || ev.Data.DeltaContent == "" {
 				continue
 			}
+			streamedChars += len(ev.Data.DeltaContent)
 			if !firstTokenFired {
 				firstTokenFired = true
 				// Copilot's delta events carry no TTFT, input-token, or
@@ -101,7 +102,6 @@ func parseCopilotStream(stdout io.Reader, progress agent.ProgressFn) (string, er
 				// counter ticks during streaming (matches Claude's pattern
 				// from PR #964). Authoritative output_tokens still arrives
 				// later via assistant.message events and overrides on Done.
-				streamedChars += len(ev.Data.DeltaContent)
 				dispatch(agent.GenerationProgress{Phase: agent.PhaseGenerating, OutputTokens: streamedChars / 4})
 			}
 			result.WriteString(ev.Data.DeltaContent)
@@ -123,11 +123,15 @@ func parseCopilotStream(stdout io.Reader, progress agent.ProgressFn) (string, er
 				// "unspecified error" rather than leaking the raw line (which
 				// may carry echoed user content or model fragments) into logs
 				// and *TextGenerationError.Stderr.
-				return "", fmt.Errorf("copilot stream error: non-zero exit code %d", ev.ExitCode)
+				return "", agent.MarkProviderStreamError( //nolint:wrapcheck // private transport marker preserves the decoded provider error chain
+					fmt.Errorf("copilot stream error: non-zero exit code %d", ev.ExitCode),
+				)
 			}
 
 		case "error":
-			return "", fmt.Errorf("copilot stream error: %s", agent.SafeErrorMessage(line))
+			return "", agent.MarkProviderStreamError( //nolint:wrapcheck // private transport marker preserves the decoded provider error chain
+				fmt.Errorf("copilot stream error: %s", agent.SafeErrorMessage(line)),
+			)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -176,6 +180,7 @@ func (c *CopilotCLIAgent) GenerateTextStreaming(
 	result, err := tmpl.Generate(ctx, prompt, model, progress)
 	if err != nil {
 		if errors.Is(err, agent.ErrUnrecognizedStreamingFlag) {
+			agent.ReportStreamingMode(progress, false)
 			return c.GenerateText(ctx, prompt, model)
 		}
 		return "", fmt.Errorf("copilot streaming generate: %w", err)

--- a/cmd/entire/cli/agent/copilotcli/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/copilotcli/generate_streaming_test.go
@@ -1,0 +1,148 @@
+package copilotcli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/testutil"
+)
+
+func TestParseCopilotStream_Success(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "stream_success.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var phases []agent.ProgressPhase
+	var doneEvent agent.GenerationProgress
+	result, err := parseCopilotStream(bytes.NewReader(data), func(p agent.GenerationProgress) {
+		phases = append(phases, p.Phase)
+		if p.Phase == agent.PhaseDone {
+			doneEvent = p
+		}
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !strings.Contains(result, "Hello") || !strings.Contains(result, "world") {
+		t.Errorf("result = %q, want concatenated assistant content", result)
+	}
+
+	counts := map[agent.ProgressPhase]int{}
+	for _, p := range phases {
+		counts[p]++
+	}
+	if counts[agent.PhaseConnecting] != 1 {
+		t.Errorf("PhaseConnecting count = %d, want 1", counts[agent.PhaseConnecting])
+	}
+	if counts[agent.PhaseFirstToken] != 1 {
+		t.Errorf("PhaseFirstToken count = %d, want 1", counts[agent.PhaseFirstToken])
+	}
+	if counts[agent.PhaseGenerating] < 1 {
+		t.Errorf("PhaseGenerating count = %d, want at least 1", counts[agent.PhaseGenerating])
+	}
+	if counts[agent.PhaseDone] != 1 {
+		t.Errorf("PhaseDone count = %d, want 1 (emitted at terminal result event)", counts[agent.PhaseDone])
+	}
+
+	// Verify that token + duration data from the real CLI's terminal events is
+	// carried into the PhaseDone progress event (assistant.message.outputTokens
+	// and result.usage.totalApiDurationMs).
+	if doneEvent.OutputTokens != 7 {
+		t.Errorf("Done.OutputTokens = %d, want 7 (from assistant.message)", doneEvent.OutputTokens)
+	}
+	if doneEvent.DurationMs != 2546 {
+		t.Errorf("Done.DurationMs = %d, want 2546 (from result.usage.totalApiDurationMs)", doneEvent.DurationMs)
+	}
+}
+
+func TestParseCopilotStream_ErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "stream_error.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	_, err = parseCopilotStream(bytes.NewReader(data), nil)
+	if err == nil {
+		t.Fatal("expected error from error envelope")
+	}
+	// Fix A: the error must surface the operational message, not the raw JSON line.
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error %q should mention 'rate limited' from the operational message field", err)
+	}
+}
+
+func TestParseCopilotStream_EmptyStream(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseCopilotStream(strings.NewReader(""), nil)
+	if err == nil {
+		t.Fatal("expected error from empty stream (no assistant content)")
+	}
+}
+
+func TestCopilotCLIGenerateTextStreaming_Success(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := os.ReadFile(filepath.Join("testdata", "stream_success.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	c := &CopilotCLIAgent{
+		CommandRunner: testutil.FakeStreamCmd(string(fixture), "", 0),
+	}
+
+	var phases []agent.ProgressPhase
+	result, err := c.GenerateTextStreaming(context.Background(), "test prompt", "haiku", func(p agent.GenerationProgress) {
+		phases = append(phases, p.Phase)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Hello") || !strings.Contains(result, "world") {
+		t.Errorf("result = %q, want concatenated assistant content", result)
+	}
+	// Expect Connecting, FirstToken, Generating (>=1), Done.
+	if len(phases) < 4 {
+		t.Errorf("phases = %v (count %d), want >= 4 (Connecting, FirstToken, Generating+, Done)", phases, len(phases))
+	}
+}
+
+func TestCopilotCLIGenerateTextStreaming_FallbackOnUnrecognizedFlag(t *testing.T) {
+	t.Parallel()
+
+	streamCall := testutil.FakeStreamCmd("", "error: unknown flag: --stream", 1)
+	nonStreamCall := testutil.FakeStreamCmd("fallback response", "", 0)
+	calls := 0
+	c := &CopilotCLIAgent{
+		CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			calls++
+			if calls == 1 {
+				return streamCall(ctx, name, args...)
+			}
+			return nonStreamCall(ctx, name, args...)
+		},
+	}
+
+	result, err := c.GenerateTextStreaming(context.Background(), "test", "haiku", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "fallback") {
+		t.Errorf("result = %q, want substring 'fallback'", result)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2 (streaming + fallback)", calls)
+	}
+}

--- a/cmd/entire/cli/agent/copilotcli/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/copilotcli/generate_streaming_test.go
@@ -82,6 +82,18 @@ func TestParseCopilotStream_ErrorEnvelope(t *testing.T) {
 	}
 }
 
+func TestParseCopilotStream_NonZeroResult(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseCopilotStream(strings.NewReader(`{"type":"result","exitCode":17}`+"\n"), nil)
+	if err == nil {
+		t.Fatal("expected error from non-zero result event")
+	}
+	if !strings.Contains(err.Error(), "non-zero exit code 17") {
+		t.Errorf("error = %q, want decoded result exit code", err)
+	}
+}
+
 func TestParseCopilotStream_EmptyStream(t *testing.T) {
 	t.Parallel()
 
@@ -121,9 +133,15 @@ func TestCopilotCLIGenerateTextStreaming_Success(t *testing.T) {
 		t.Fatalf("read fixture: %v", err)
 	}
 
-	c := &CopilotCLIAgent{
-		CommandRunner: testutil.FakeStreamCmd(string(fixture), "", 0),
-	}
+	fake := testutil.FakeStreamCmd(string(fixture), "", 0)
+	var commandName string
+	var commandArgs []string
+	var command *exec.Cmd
+	c := &CopilotCLIAgent{CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		commandName, commandArgs = name, append([]string(nil), args...)
+		command = fake(ctx, name, args...)
+		return command
+	}}
 
 	var phases []agent.ProgressPhase
 	result, err := c.GenerateTextStreaming(context.Background(), "test prompt", "haiku", func(p agent.GenerationProgress) {
@@ -138,6 +156,13 @@ func TestCopilotCLIGenerateTextStreaming_Success(t *testing.T) {
 	// Expect Connecting, FirstToken, Generating (>=1), Done.
 	if len(phases) < 4 {
 		t.Errorf("phases = %v (count %d), want >= 4 (Connecting, FirstToken, Generating+, Done)", phases, len(phases))
+	}
+	if commandName != "copilot" || strings.Join(commandArgs, " ") != "--output-format json --stream on --allow-all-tools --disable-builtin-mcps --model haiku" {
+		t.Errorf("command = %q %v, want Copilot streaming argv", commandName, commandArgs)
+	}
+	stdin, stdinErr := testutil.ReadCommandStdin(command)
+	if stdinErr != nil || stdin != "test prompt" {
+		t.Errorf("stdin = %q, err = %v; want exact prompt", stdin, stdinErr)
 	}
 }
 

--- a/cmd/entire/cli/agent/copilotcli/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/copilotcli/generate_streaming_test.go
@@ -91,6 +91,28 @@ func TestParseCopilotStream_EmptyStream(t *testing.T) {
 	}
 }
 
+func TestParseCopilotStream_RunningEstimateIncludesFirstDelta(t *testing.T) {
+	t.Parallel()
+
+	stream := `{"type":"assistant.turn_start"}
+{"type":"assistant.message_delta","data":{"deltaContent":"1234"}}
+{"type":"assistant.message_delta","data":{"deltaContent":"5678"}}
+{"type":"result","exitCode":0}
+`
+	var generating agent.GenerationProgress
+	_, err := parseCopilotStream(strings.NewReader(stream), func(progress agent.GenerationProgress) {
+		if progress.Phase == agent.PhaseGenerating {
+			generating = progress
+		}
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if generating.OutputTokens != 2 {
+		t.Fatalf("running estimate = %d, want 2 from all 8 streamed characters", generating.OutputTokens)
+	}
+}
+
 func TestCopilotCLIGenerateTextStreaming_Success(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/copilotcli/stream_response.go
+++ b/cmd/entire/cli/agent/copilotcli/stream_response.go
@@ -1,0 +1,58 @@
+package copilotcli
+
+import "time"
+
+// copilotStreamEvent is one decoded line of `copilot --output-format json
+// --stream on` NDJSON output. Fields are populated based on Type.
+//
+// Real-CLI shape (GitHub Copilot CLI 1.0.48):
+//   - session.mcp_servers_loaded / session.skills_loaded / session.tools_updated
+//     → session bootstrap, ignored
+//   - user.message                                       → echoed input, ignored
+//   - assistant.turn_start                               → turn begins
+//   - assistant.message_start (ephemeral)                → announces messageId
+//   - assistant.message_delta (ephemeral, deltaContent)  → incremental tokens
+//   - assistant.message (non-ephemeral, outputTokens)    → consolidated message
+//     with final outputTokens count
+//   - assistant.turn_end                                 → turn marker
+//   - result (terminal, usage.totalApiDurationMs etc.)   → exitCode + duration
+type copilotStreamEvent struct {
+	Type      string             `json:"type"`
+	Timestamp time.Time          `json:"timestamp,omitempty"`
+	Data      *copilotStreamData `json:"data,omitempty"`
+	ID        string             `json:"id,omitempty"`
+	ParentID  string             `json:"parentId,omitempty"`
+	Ephemeral bool               `json:"ephemeral,omitempty"`
+
+	// SessionID is populated on the terminal type=result event.
+	SessionID string `json:"sessionId,omitempty"`
+
+	// ExitCode is populated on the terminal type=result event. 0=success.
+	ExitCode int `json:"exitCode,omitempty"`
+
+	// Usage is populated on the terminal type=result event.
+	Usage *copilotStreamUsage `json:"usage,omitempty"`
+}
+
+// copilotStreamData is the per-event payload. Fields are sparsely populated
+// based on the parent event's Type.
+type copilotStreamData struct {
+	MessageID    string `json:"messageId,omitempty"`
+	TurnID       string `json:"turnId,omitempty"`
+	DeltaContent string `json:"deltaContent,omitempty"`
+	Model        string `json:"model,omitempty"`
+	Content      string `json:"content,omitempty"`
+
+	// OutputTokens appears on the consolidated assistant.message event.
+	// Copilot does not expose input/cached tokens in its public stream.
+	OutputTokens int `json:"outputTokens,omitempty"`
+}
+
+// copilotStreamUsage appears inside the terminal type=result event. Copilot
+// reports timing data and "premium request" counts but does not surface input
+// or cached-input token counts in its public stream.
+type copilotStreamUsage struct {
+	PremiumRequests    int `json:"premiumRequests,omitempty"`
+	TotalAPIDurationMs int `json:"totalApiDurationMs,omitempty"`
+	SessionDurationMs  int `json:"sessionDurationMs,omitempty"`
+}

--- a/cmd/entire/cli/agent/copilotcli/testdata/stream_error.jsonl
+++ b/cmd/entire/cli/agent/copilotcli/testdata/stream_error.jsonl
@@ -1,0 +1,5 @@
+{"type":"session.tools_updated","data":{"model":"claude-sonnet-4.6"},"id":"c","timestamp":"2026-05-15T21:35:30.958Z","ephemeral":true}
+{"type":"user.message","data":{"content":"hi","interactionId":"i0"},"id":"u0","timestamp":"2026-05-15T21:35:30.959Z"}
+{"type":"assistant.turn_start","data":{"turnId":"0","interactionId":"i0"},"id":"t0","timestamp":"2026-05-15T21:35:31.071Z"}
+{"type":"error","data":{},"message":"rate limited: too many requests","timestamp":"2026-05-15T21:35:31.100Z"}
+{"type":"result","timestamp":"2026-05-15T21:35:31.110Z","sessionId":"sess-1","exitCode":2,"usage":{"premiumRequests":0,"totalApiDurationMs":0,"sessionDurationMs":42}}

--- a/cmd/entire/cli/agent/copilotcli/testdata/stream_success.jsonl
+++ b/cmd/entire/cli/agent/copilotcli/testdata/stream_success.jsonl
@@ -1,0 +1,11 @@
+{"type":"session.mcp_servers_loaded","data":{"servers":[]},"id":"a","timestamp":"2026-05-15T21:35:30.934Z","ephemeral":true}
+{"type":"session.skills_loaded","data":{"skills":[]},"id":"b","timestamp":"2026-05-15T21:35:30.934Z","ephemeral":true}
+{"type":"session.tools_updated","data":{"model":"claude-sonnet-4.6"},"id":"c","timestamp":"2026-05-15T21:35:30.958Z","ephemeral":true}
+{"type":"user.message","data":{"content":"say hi","interactionId":"i0"},"id":"u0","timestamp":"2026-05-15T21:35:30.959Z"}
+{"type":"assistant.turn_start","data":{"turnId":"0","interactionId":"i0"},"id":"t0","timestamp":"2026-05-15T21:35:31.071Z"}
+{"type":"assistant.message_start","data":{"messageId":"m0"},"id":"ms0","timestamp":"2026-05-15T21:35:33.283Z","ephemeral":true}
+{"type":"assistant.message_delta","data":{"messageId":"m0","deltaContent":"Hello"},"id":"d1","timestamp":"2026-05-15T21:35:33.283Z","ephemeral":true}
+{"type":"assistant.message_delta","data":{"messageId":"m0","deltaContent":", world."},"id":"d2","timestamp":"2026-05-15T21:35:33.317Z","ephemeral":true}
+{"type":"assistant.message","data":{"messageId":"m0","model":"claude-sonnet-4.6","content":"Hello, world.","outputTokens":7,"turnId":"0","interactionId":"i0"},"id":"am0","timestamp":"2026-05-15T21:35:33.668Z"}
+{"type":"assistant.turn_end","data":{"turnId":"0"},"id":"te0","timestamp":"2026-05-15T21:35:33.669Z"}
+{"type":"result","timestamp":"2026-05-15T21:35:33.679Z","sessionId":"sess-1","exitCode":0,"usage":{"premiumRequests":1,"totalApiDurationMs":2546,"sessionDurationMs":4443}}

--- a/cmd/entire/cli/agent/cursor/generate.go
+++ b/cmd/entire/cli/agent/cursor/generate.go
@@ -19,13 +19,9 @@ func (c *CursorAgent) GenerateText(ctx context.Context, prompt string, model str
 		args = append(args, "--model", model)
 	}
 
-	result, capturedStderr, stdoutBytes, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, "agent", "cursor", args, prompt)
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, c.CommandRunner, agent.AgentNameCursor, args, prompt)
 	if err != nil {
-		return "", &agent.TextGenerationError{
-			Err:         fmt.Errorf("cursor text generation failed: %w", err),
-			Stderr:      capturedStderr,
-			StdoutBytes: stdoutBytes,
-		}
+		return "", fmt.Errorf("cursor text generation failed: %w", err)
 	}
 	return result, nil
 }

--- a/cmd/entire/cli/agent/cursor/generate_streaming.go
+++ b/cmd/entire/cli/agent/cursor/generate_streaming.go
@@ -160,11 +160,13 @@ func (c *CursorAgent) GenerateTextStreaming(
 	progress agent.ProgressFn,
 ) (string, error) {
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:                 "cursor",
-		DisplayName:               "agent",
-		BuildCmd:                  c.buildStreamCmd,
-		Parser:                    parseCursorStream,
-		LooksLikeUnrecognizedFlag: looksLikeCursorUnrecognizedFlag,
+		AgentName:   "cursor",
+		DisplayName: "agent",
+		BuildCmd:    c.buildStreamCmd,
+		Parser:      parseCursorStream,
+		LooksLikeUnrecognizedFlag: func(stderr string) bool {
+			return agent.LooksLikeUnrecognizedFlag(stderr, "stream-json", "stream-partial-output", "output-format")
+		},
 	}
 
 	result, err := tmpl.Generate(ctx, prompt, model, progress)
@@ -196,25 +198,4 @@ func (c *CursorAgent) buildStreamCmd(ctx context.Context, prompt, model string) 
 	cmd := commandRunner(ctx, "agent", args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	return cmd
-}
-
-// looksLikeCursorUnrecognizedFlag is the 4th of 4 per-agent flag-rejection
-// heuristics. Consolidation deferred to a post-chunk-5 cleanup commit. Phrase
-// set matches Codex/Copilot's (strict — "unknown flag" rather than bare
-// "unknown") to avoid the over-broad matches a Chunk-3 code review flagged on
-// Gemini.
-//
-//nolint:dupl // 4th of 4 per-agent flag-rejection heuristics; consolidation deferred to a post-chunk-5 cleanup commit
-func looksLikeCursorUnrecognizedFlag(stderr string) bool {
-	lower := strings.ToLower(stderr)
-	hasRejectPhrase := strings.Contains(lower, "unknown flag") ||
-		strings.Contains(lower, "unrecognized option") ||
-		strings.Contains(lower, "unknown option") ||
-		strings.Contains(lower, "invalid option")
-	if !hasRejectPhrase {
-		return false
-	}
-	return strings.Contains(lower, "stream-json") ||
-		strings.Contains(lower, "stream-partial-output") ||
-		strings.Contains(lower, "output-format")
 }

--- a/cmd/entire/cli/agent/cursor/generate_streaming.go
+++ b/cmd/entire/cli/agent/cursor/generate_streaming.go
@@ -141,6 +141,9 @@ func parseCursorStream(stdout io.Reader, progress agent.ProgressFn) (string, err
 		}
 		return "", errors.New("cursor stream ended without a result event")
 	}
+	if resultText == "" {
+		return "", errors.New("cursor stream produced no result text")
+	}
 	if progress != nil {
 		done := agent.GenerationProgress{Phase: agent.PhaseDone, DurationMs: durationMs}
 		if usage != nil {
@@ -160,10 +163,9 @@ func (c *CursorAgent) GenerateTextStreaming(
 	progress agent.ProgressFn,
 ) (string, error) {
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:   "cursor",
-		DisplayName: "agent",
-		BuildCmd:    c.buildStreamCmd,
-		Parser:      parseCursorStream,
+		AgentName: "cursor",
+		BuildCmd:  c.buildStreamCmd,
+		Parser:    parseCursorStream,
 		LooksLikeUnrecognizedFlag: func(stderr string) bool {
 			return agent.LooksLikeUnrecognizedFlag(stderr, "stream-json", "stream-partial-output", "output-format")
 		},

--- a/cmd/entire/cli/agent/cursor/generate_streaming.go
+++ b/cmd/entire/cli/agent/cursor/generate_streaming.go
@@ -1,0 +1,220 @@
+package cursor
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+const streamBufferMax = 4 * 1024 * 1024 // 4 MiB
+
+// parseCursorStream consumes `agent --print --output-format stream-json
+// --stream-partial-output` NDJSON output, dispatches progress callbacks, and
+// returns the canonical result text (from the terminal result event, not
+// from concatenated assistant deltas — see note on aggregated final message
+// below).
+//
+// Real-CLI shape (Cursor agent, Composer 2.5 Fast):
+//   - system,subtype:init                          → PhaseConnecting (once)
+//   - user.message                                 → ignored (echoed input)
+//   - thinking,subtype:delta / completed           → ignored (internal
+//     reasoning; PhaseConnecting persists during this window so users see
+//     "Sending request to provider..." for longer on reasoning-heavy turns)
+//   - assistant w/ timestamp_ms (1st)              → PhaseFirstToken (no parens —
+//     cacheReadTokens isn't known until result event)
+//   - assistant w/ timestamp_ms (subsequent)       → PhaseGenerating (running
+//     token estimate from streamed character length)
+//   - assistant w/o timestamp_ms                   → ignored (aggregated final
+//     message; result.result is canonical)
+//   - result,subtype:success                       → PhaseDone (real
+//     OutputTokens / CachedInputTokens / DurationMs from result.usage and
+//     result.duration_ms)
+//   - result,is_error:true                         → typed error (privacy
+//     decode: surfaces result.result only, never the raw line)
+func parseCursorStream(stdout io.Reader, progress agent.ProgressFn) (string, error) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 64*1024), streamBufferMax)
+
+	var (
+		connectingFired bool
+		firstTokenFired bool
+		sawResult       bool
+		resultText      string
+		streamedChars   int
+		malformed       int
+		usage           *cursorStreamUsage
+		durationMs      int
+	)
+
+	dispatch := func(p agent.GenerationProgress) {
+		if progress != nil {
+			progress(p)
+		}
+	}
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev cursorStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			// Cursor may emit transient noise (blank lines, partial flushes);
+			// a schema-incompatible line is recoverable per-event but tracked
+			// so protocol regressions surface in the missing-result error
+			// instead of disappearing silently.
+			malformed++
+			continue
+		}
+
+		switch ev.Type {
+		case "system":
+			if ev.Subtype == "init" && !connectingFired {
+				connectingFired = true
+				dispatch(agent.GenerationProgress{Phase: agent.PhaseConnecting})
+			}
+
+		case "assistant":
+			// Skip the aggregated final assistant message (no timestamp_ms);
+			// only delta events (with timestamp_ms) drive PhaseGenerating.
+			if ev.TimestampMs == 0 {
+				continue
+			}
+			var textBuilder strings.Builder
+			if ev.Message != nil {
+				for _, c := range ev.Message.Content {
+					if c.Type == "text" {
+						textBuilder.WriteString(c.Text)
+					}
+				}
+			}
+			text := textBuilder.String()
+			if text == "" {
+				continue
+			}
+			if !firstTokenFired {
+				firstTokenFired = true
+				// CacheReadTokens isn't known until the result event arrives;
+				// FirstToken renders without parens here, and Done will
+				// expose cached/output/duration from result.usage.
+				dispatch(agent.GenerationProgress{Phase: agent.PhaseFirstToken})
+			} else {
+				streamedChars += len(text)
+				dispatch(agent.GenerationProgress{Phase: agent.PhaseGenerating, OutputTokens: streamedChars / 4})
+			}
+
+		case "result":
+			sawResult = true
+			if ev.IsError {
+				// Privacy decode: surface only result text (CLI-authored,
+				// user-safe), never the raw line. Cursor's error envelope
+				// has not been observed in the wild beyond synthesized
+				// fixtures, so fall through to a generic message rather
+				// than leaking anything we haven't audited.
+				detail := ev.Result
+				if detail == "" {
+					detail = "unspecified error"
+				}
+				return "", fmt.Errorf("cursor stream error: %s", detail)
+			}
+			resultText = ev.Result
+			usage = ev.Usage
+			durationMs = ev.DurationMs
+
+			// "thinking" and "user" events are intentionally ignored.
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading cursor stream: %w", err)
+	}
+	if !sawResult {
+		if malformed > 0 {
+			return "", fmt.Errorf("cursor stream ended without a result event (%d malformed lines skipped)", malformed)
+		}
+		return "", errors.New("cursor stream ended without a result event")
+	}
+	if progress != nil {
+		done := agent.GenerationProgress{Phase: agent.PhaseDone, DurationMs: durationMs}
+		if usage != nil {
+			done.OutputTokens = usage.OutputTokens
+			done.InputTokens = usage.InputTokens
+			done.CachedInputTokens = usage.CacheReadTokens
+		}
+		dispatch(done)
+	}
+	return resultText, nil
+}
+
+// GenerateTextStreaming implements agent.StreamingTextGenerator for *CursorAgent.
+func (c *CursorAgent) GenerateTextStreaming(
+	ctx context.Context,
+	prompt, model string,
+	progress agent.ProgressFn,
+) (string, error) {
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName:                 "cursor",
+		DisplayName:               "agent",
+		BuildCmd:                  c.buildStreamCmd,
+		Parser:                    parseCursorStream,
+		LooksLikeUnrecognizedFlag: looksLikeCursorUnrecognizedFlag,
+	}
+
+	result, err := tmpl.Generate(ctx, prompt, model, progress)
+	if err != nil {
+		if errors.Is(err, agent.ErrUnrecognizedStreamingFlag) {
+			return c.GenerateText(ctx, prompt, model)
+		}
+		return "", fmt.Errorf("cursor streaming generate: %w", err)
+	}
+	return result, nil
+}
+
+func (c *CursorAgent) buildStreamCmd(ctx context.Context, prompt, model string) *exec.Cmd {
+	commandRunner := c.CommandRunner
+	if commandRunner == nil {
+		commandRunner = exec.CommandContext
+	}
+	args := []string{
+		"--print",
+		"--force",
+		"--trust",
+		"--workspace", os.TempDir(),
+		"--output-format", "stream-json",
+		"--stream-partial-output",
+	}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	cmd := commandRunner(ctx, "agent", args...)
+	cmd.Stdin = strings.NewReader(prompt)
+	return cmd
+}
+
+// looksLikeCursorUnrecognizedFlag is the 4th of 4 per-agent flag-rejection
+// heuristics. Consolidation deferred to a post-chunk-5 cleanup commit. Phrase
+// set matches Codex/Copilot's (strict — "unknown flag" rather than bare
+// "unknown") to avoid the over-broad matches a Chunk-3 code review flagged on
+// Gemini.
+//
+//nolint:dupl // 4th of 4 per-agent flag-rejection heuristics; consolidation deferred to a post-chunk-5 cleanup commit
+func looksLikeCursorUnrecognizedFlag(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	hasRejectPhrase := strings.Contains(lower, "unknown flag") ||
+		strings.Contains(lower, "unrecognized option") ||
+		strings.Contains(lower, "unknown option") ||
+		strings.Contains(lower, "invalid option")
+	if !hasRejectPhrase {
+		return false
+	}
+	return strings.Contains(lower, "stream-json") ||
+		strings.Contains(lower, "stream-partial-output") ||
+		strings.Contains(lower, "output-format")
+}

--- a/cmd/entire/cli/agent/cursor/generate_streaming.go
+++ b/cmd/entire/cli/agent/cursor/generate_streaming.go
@@ -100,6 +100,7 @@ func parseCursorStream(stdout io.Reader, progress agent.ProgressFn) (string, err
 			if text == "" {
 				continue
 			}
+			streamedChars += len(text)
 			if !firstTokenFired {
 				firstTokenFired = true
 				// CacheReadTokens isn't known until the result event arrives;
@@ -107,7 +108,6 @@ func parseCursorStream(stdout io.Reader, progress agent.ProgressFn) (string, err
 				// expose cached/output/duration from result.usage.
 				dispatch(agent.GenerationProgress{Phase: agent.PhaseFirstToken})
 			} else {
-				streamedChars += len(text)
 				dispatch(agent.GenerationProgress{Phase: agent.PhaseGenerating, OutputTokens: streamedChars / 4})
 			}
 
@@ -123,7 +123,9 @@ func parseCursorStream(stdout io.Reader, progress agent.ProgressFn) (string, err
 				if detail == "" {
 					detail = "unspecified error"
 				}
-				return "", fmt.Errorf("cursor stream error: %s", detail)
+				return "", agent.MarkProviderStreamError( //nolint:wrapcheck // private transport marker preserves the decoded provider error chain
+					fmt.Errorf("cursor stream error: %s", detail),
+				)
 			}
 			resultText = ev.Result
 			usage = ev.Usage
@@ -174,6 +176,7 @@ func (c *CursorAgent) GenerateTextStreaming(
 	result, err := tmpl.Generate(ctx, prompt, model, progress)
 	if err != nil {
 		if errors.Is(err, agent.ErrUnrecognizedStreamingFlag) {
+			agent.ReportStreamingMode(progress, false)
 			return c.GenerateText(ctx, prompt, model)
 		}
 		return "", fmt.Errorf("cursor streaming generate: %w", err)

--- a/cmd/entire/cli/agent/cursor/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/cursor/generate_streaming_test.go
@@ -1,0 +1,149 @@
+package cursor
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/testutil"
+)
+
+func TestParseCursorStream_Success(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "stream_success.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var phases []agent.ProgressPhase
+	var doneProgress agent.GenerationProgress
+	result, err := parseCursorStream(bytes.NewReader(data), func(p agent.GenerationProgress) {
+		phases = append(phases, p.Phase)
+		if p.Phase == agent.PhaseDone {
+			doneProgress = p
+		}
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if result != "Hello, world." {
+		t.Errorf("result = %q, want %q (from result.result, not delta concat)", result, "Hello, world.")
+	}
+
+	counts := map[agent.ProgressPhase]int{}
+	for _, p := range phases {
+		counts[p]++
+	}
+	if counts[agent.PhaseConnecting] != 1 {
+		t.Errorf("PhaseConnecting count = %d, want 1", counts[agent.PhaseConnecting])
+	}
+	if counts[agent.PhaseFirstToken] != 1 {
+		t.Errorf("PhaseFirstToken count = %d, want 1", counts[agent.PhaseFirstToken])
+	}
+	if counts[agent.PhaseGenerating] < 1 {
+		t.Errorf("PhaseGenerating count = %d, want >= 1", counts[agent.PhaseGenerating])
+	}
+	if counts[agent.PhaseDone] != 1 {
+		t.Errorf("PhaseDone count = %d, want 1", counts[agent.PhaseDone])
+	}
+	if doneProgress.OutputTokens != 268 {
+		t.Errorf("Done.OutputTokens = %d, want 268 (from result.usage.outputTokens)", doneProgress.OutputTokens)
+	}
+	if doneProgress.CachedInputTokens != 4608 {
+		t.Errorf("Done.CachedInputTokens = %d, want 4608 (from result.usage.cacheReadTokens)", doneProgress.CachedInputTokens)
+	}
+	if doneProgress.DurationMs != 3372 {
+		t.Errorf("Done.DurationMs = %d, want 3372 (from result.duration_ms)", doneProgress.DurationMs)
+	}
+}
+
+func TestParseCursorStream_ErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "stream_error.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	_, err = parseCursorStream(bytes.NewReader(data), nil)
+	if err == nil {
+		t.Fatal("expected error from result envelope with is_error=true")
+	}
+	if !strings.Contains(err.Error(), "Max turns") {
+		t.Errorf("error %q should mention 'Max turns'", err)
+	}
+}
+
+func TestParseCursorStream_MissingResult(t *testing.T) {
+	t.Parallel()
+
+	stream := `{"type":"system","subtype":"init","session_id":"t"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"partial"}]},"session_id":"t","timestamp_ms":1}
+`
+	_, err := parseCursorStream(strings.NewReader(stream), nil)
+	if err == nil {
+		t.Fatal("expected error when stream lacks result event")
+	}
+}
+
+func TestCursorGenerateTextStreaming_Success(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := os.ReadFile(filepath.Join("testdata", "stream_success.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	c := &CursorAgent{
+		CommandRunner: testutil.FakeStreamCmd(string(fixture), "", 0),
+	}
+
+	var phases []agent.ProgressPhase
+	result, err := c.GenerateTextStreaming(context.Background(), "test prompt", "", func(p agent.GenerationProgress) {
+		phases = append(phases, p.Phase)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "Hello, world." {
+		t.Errorf("result = %q, want %q (canonical from result.result)", result, "Hello, world.")
+	}
+	// Expect Connecting, FirstToken, Generating (>=1), Done.
+	if len(phases) < 4 {
+		t.Errorf("phases = %v (count %d), want >= 4 (Connecting, FirstToken, Generating+, Done)", phases, len(phases))
+	}
+}
+
+func TestCursorGenerateTextStreaming_FallbackOnUnrecognizedFlag(t *testing.T) {
+	t.Parallel()
+
+	streamCall := testutil.FakeStreamCmd("", "error: unknown flag: --stream-json", 1)
+	nonStreamCall := testutil.FakeStreamCmd("fallback response", "", 0)
+	calls := 0
+	c := &CursorAgent{
+		CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			calls++
+			if calls == 1 {
+				return streamCall(ctx, name, args...)
+			}
+			return nonStreamCall(ctx, name, args...)
+		},
+	}
+
+	result, err := c.GenerateTextStreaming(context.Background(), "test", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "fallback") {
+		t.Errorf("result = %q, want substring 'fallback'", result)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2 (streaming + fallback)", calls)
+	}
+}

--- a/cmd/entire/cli/agent/cursor/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/cursor/generate_streaming_test.go
@@ -92,6 +92,25 @@ func TestParseCursorStream_MissingResult(t *testing.T) {
 	}
 }
 
+func TestParseCursorStream_EmptyResultText(t *testing.T) {
+	t.Parallel()
+
+	// A successful (is_error:false) result event with an empty `result`
+	// field must error rather than returning ("", nil) — mirrors the
+	// guarantee Codex's parser makes and that RunIsolatedTextGeneratorCLI
+	// makes on the non-streaming path.
+	stream := `{"type":"system","subtype":"init","session_id":"t"}
+{"type":"result","subtype":"success","duration_ms":1,"is_error":false,"result":"","session_id":"t"}
+`
+	_, err := parseCursorStream(strings.NewReader(stream), nil)
+	if err == nil {
+		t.Fatal("expected error when result event carries empty result text")
+	}
+	if !strings.Contains(err.Error(), "no result text") {
+		t.Errorf("error %q should mention 'no result text'", err)
+	}
+}
+
 func TestCursorGenerateTextStreaming_Success(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/cursor/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/cursor/generate_streaming_test.go
@@ -141,12 +141,18 @@ func TestCursorGenerateTextStreaming_Success(t *testing.T) {
 		t.Fatalf("read fixture: %v", err)
 	}
 
-	c := &CursorAgent{
-		CommandRunner: testutil.FakeStreamCmd(string(fixture), "", 0),
-	}
+	fake := testutil.FakeStreamCmd(string(fixture), "", 0)
+	var commandName string
+	var commandArgs []string
+	var command *exec.Cmd
+	c := &CursorAgent{CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		commandName, commandArgs = name, append([]string(nil), args...)
+		command = fake(ctx, name, args...)
+		return command
+	}}
 
 	var phases []agent.ProgressPhase
-	result, err := c.GenerateTextStreaming(context.Background(), "test prompt", "", func(p agent.GenerationProgress) {
+	result, err := c.GenerateTextStreaming(context.Background(), "test prompt", "test-model", func(p agent.GenerationProgress) {
 		phases = append(phases, p.Phase)
 	})
 	if err != nil {
@@ -158,6 +164,15 @@ func TestCursorGenerateTextStreaming_Success(t *testing.T) {
 	// Expect Connecting, FirstToken, Generating (>=1), Done.
 	if len(phases) < 4 {
 		t.Errorf("phases = %v (count %d), want >= 4 (Connecting, FirstToken, Generating+, Done)", phases, len(phases))
+	}
+	joinedArgs := strings.Join(commandArgs, " ")
+	wantArgs := "--print --force --trust --workspace " + os.TempDir() + " --output-format stream-json --stream-partial-output --model test-model"
+	if commandName != "agent" || joinedArgs != wantArgs {
+		t.Errorf("command = %q %v, want Cursor isolated streaming argv", commandName, commandArgs)
+	}
+	stdin, stdinErr := testutil.ReadCommandStdin(command)
+	if stdinErr != nil || stdin != "test prompt" {
+		t.Errorf("stdin = %q, err = %v; want exact prompt", stdin, stdinErr)
 	}
 }
 

--- a/cmd/entire/cli/agent/cursor/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/cursor/generate_streaming_test.go
@@ -111,6 +111,28 @@ func TestParseCursorStream_EmptyResultText(t *testing.T) {
 	}
 }
 
+func TestParseCursorStream_RunningEstimateIncludesFirstDelta(t *testing.T) {
+	t.Parallel()
+
+	stream := `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"1234"}]},"timestamp_ms":1}
+{"type":"assistant","message":{"content":[{"type":"text","text":"5678"}]},"timestamp_ms":2}
+{"type":"result","subtype":"success","result":"12345678"}
+`
+	var generating agent.GenerationProgress
+	_, err := parseCursorStream(strings.NewReader(stream), func(progress agent.GenerationProgress) {
+		if progress.Phase == agent.PhaseGenerating {
+			generating = progress
+		}
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if generating.OutputTokens != 2 {
+		t.Fatalf("running estimate = %d, want 2 from all 8 streamed characters", generating.OutputTokens)
+	}
+}
+
 func TestCursorGenerateTextStreaming_Success(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/agent/cursor/stream_response.go
+++ b/cmd/entire/cli/agent/cursor/stream_response.go
@@ -1,0 +1,46 @@
+package cursor
+
+// cursorStreamEvent is one decoded line of `agent --print --output-format
+// stream-json --stream-partial-output` NDJSON output. Fields are populated
+// based on Type.
+//
+// Real-CLI shape (Cursor agent, Composer 2.5 Fast):
+//   - system,subtype:init                          → session bootstrap (model, cwd)
+//   - user.message                                 → echoed input, ignored
+//   - thinking,subtype:delta / completed           → internal reasoning, ignored
+//   - assistant (with timestamp_ms) delta          → incremental text token
+//   - assistant (no timestamp_ms) aggregated       → final consolidated message,
+//     ignored (use result.result)
+//   - result,subtype:success                       → terminal: usage + duration
+//   - result,is_error:true                         → terminal error envelope
+type cursorStreamEvent struct {
+	Type        string               `json:"type"`
+	Subtype     string               `json:"subtype,omitempty"`
+	IsError     bool                 `json:"is_error,omitempty"`
+	Result      string               `json:"result,omitempty"`
+	DurationMs  int                  `json:"duration_ms,omitempty"`
+	TimestampMs int64                `json:"timestamp_ms,omitempty"`
+	Message     *cursorStreamMessage `json:"message,omitempty"`
+	Usage       *cursorStreamUsage   `json:"usage,omitempty"`
+}
+
+// cursorStreamMessage is the assistant/user message payload.
+type cursorStreamMessage struct {
+	Role    string                       `json:"role,omitempty"`
+	Content []cursorStreamMessageContent `json:"content,omitempty"`
+}
+
+// cursorStreamMessageContent is one content block within a message.
+type cursorStreamMessageContent struct {
+	Type string `json:"type,omitempty"`
+	Text string `json:"text,omitempty"`
+}
+
+// cursorStreamUsage appears inside the terminal type=result event. Cursor
+// reports input, output, and cache-read token counts.
+type cursorStreamUsage struct {
+	InputTokens      int `json:"inputTokens,omitempty"`
+	OutputTokens     int `json:"outputTokens,omitempty"`
+	CacheReadTokens  int `json:"cacheReadTokens,omitempty"`
+	CacheWriteTokens int `json:"cacheWriteTokens,omitempty"`
+}

--- a/cmd/entire/cli/agent/cursor/testdata/stream_error.jsonl
+++ b/cmd/entire/cli/agent/cursor/testdata/stream_error.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/private/tmp","session_id":"test","model":"Composer 2.5 Fast","permissionMode":"default"}
+{"type":"result","subtype":"error_max_turns","duration_ms":100,"is_error":true,"result":"Max turns exceeded","session_id":"test"}

--- a/cmd/entire/cli/agent/cursor/testdata/stream_success.jsonl
+++ b/cmd/entire/cli/agent/cursor/testdata/stream_success.jsonl
@@ -1,0 +1,8 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/private/tmp","session_id":"test","model":"Composer 2.5 Fast","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"say hi"}]},"session_id":"test"}
+{"type":"thinking","subtype":"delta","text":"Hi","session_id":"test","timestamp_ms":1}
+{"type":"thinking","subtype":"completed","session_id":"test","timestamp_ms":2}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}]},"session_id":"test","timestamp_ms":3}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":", world."}]},"session_id":"test","timestamp_ms":4}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hello, world."}]},"session_id":"test"}
+{"type":"result","subtype":"success","duration_ms":3372,"is_error":false,"result":"Hello, world.","session_id":"test","usage":{"inputTokens":9141,"outputTokens":268,"cacheReadTokens":4608,"cacheWriteTokens":0}}

--- a/cmd/entire/cli/agent/geminicli/generate.go
+++ b/cmd/entire/cli/agent/geminicli/generate.go
@@ -19,13 +19,9 @@ func (g *GeminiCLIAgent) GenerateText(ctx context.Context, prompt string, model 
 		args = append(args, "--model", model)
 	}
 
-	result, capturedStderr, stdoutBytes, err := agent.RunIsolatedTextGeneratorCLI(ctx, g.CommandRunner, "gemini", "gemini", args, prompt)
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, g.CommandRunner, agent.AgentNameGemini, args, prompt)
 	if err != nil {
-		return "", &agent.TextGenerationError{
-			Err:         fmt.Errorf("gemini text generation failed: %w", err),
-			Stderr:      capturedStderr,
-			StdoutBytes: stdoutBytes,
-		}
+		return "", fmt.Errorf("gemini text generation failed: %w", err)
 	}
 	return result, nil
 }

--- a/cmd/entire/cli/agent/geminicli/generate_streaming.go
+++ b/cmd/entire/cli/agent/geminicli/generate_streaming.go
@@ -149,11 +149,13 @@ func (g *GeminiCLIAgent) GenerateTextStreaming(
 	progress agent.ProgressFn,
 ) (string, error) {
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:                 "gemini",
-		DisplayName:               "gemini",
-		BuildCmd:                  g.buildStreamCmd,
-		Parser:                    parseGeminiStream,
-		LooksLikeUnrecognizedFlag: looksLikeGeminiUnrecognizedFlag,
+		AgentName:   "gemini",
+		DisplayName: "gemini",
+		BuildCmd:    g.buildStreamCmd,
+		Parser:      parseGeminiStream,
+		LooksLikeUnrecognizedFlag: func(stderr string) bool {
+			return agent.LooksLikeUnrecognizedFlag(stderr, "output-format", "stream-json")
+		},
 	}
 
 	result, err := tmpl.Generate(ctx, prompt, model, progress)
@@ -178,17 +180,4 @@ func (g *GeminiCLIAgent) buildStreamCmd(ctx context.Context, prompt, model strin
 	cmd := commandRunner(ctx, "gemini", args...)
 	cmd.Stdin = strings.NewReader(prompt)
 	return cmd
-}
-
-// looksLikeGeminiUnrecognizedFlag is the second of 4 per-agent flag-rejection
-// heuristics. The controller will consolidate the 4 instances after Chunk 5.
-func looksLikeGeminiUnrecognizedFlag(stderr string) bool {
-	lower := strings.ToLower(stderr)
-	hasRejectPhrase := strings.Contains(lower, "unknown") ||
-		strings.Contains(lower, "unrecognized") ||
-		strings.Contains(lower, "invalid")
-	if !hasRejectPhrase {
-		return false
-	}
-	return strings.Contains(lower, "output-format") || strings.Contains(lower, "stream-json")
 }

--- a/cmd/entire/cli/agent/geminicli/generate_streaming.go
+++ b/cmd/entire/cli/agent/geminicli/generate_streaming.go
@@ -1,0 +1,194 @@
+package geminicli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+const streamBufferMax = 4 * 1024 * 1024 // 4 MiB
+
+// parseGeminiStream consumes `gemini --output-format stream-json` NDJSON
+// output, dispatches progress callbacks, and returns the concatenated
+// assistant content.
+//
+// Real-CLI shape (gemini-cli 0.38.2):
+//   - init                                              -> PhaseConnecting
+//   - message(role=user)                                -> ignored (echo)
+//   - message(role=assistant, delta=true)               -> PhaseFirstToken (1st)
+//     / PhaseGenerating (subsequent)
+//     content concatenated into result
+//   - result(status=success, stats={...})               -> PhaseDone (terminal)
+//   - result(status=error, error={type,message}, stats) -> returns error
+//
+// Note: Gemini typically emits ONE assistant message per turn rather than
+// chunking deltas, so PhaseGenerating may not fire on real captures even
+// though it works for multi-message fixtures.
+func parseGeminiStream(stdout io.Reader, progress agent.ProgressFn) (string, error) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 64*1024), streamBufferMax)
+
+	var (
+		result          strings.Builder
+		sawInit         bool
+		firstTokenFired bool
+		stats           *geminiStreamStats
+		malformed       int
+		start           = time.Now()
+		totalChars      int
+	)
+
+	dispatch := func(p agent.GenerationProgress) {
+		if progress != nil {
+			progress(p)
+		}
+	}
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev geminiStreamEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			// Gemini may emit transient noise (blank lines, partial flushes);
+			// a schema-incompatible line is recoverable per-event but tracked
+			// so protocol regressions surface in the no-content error instead
+			// of disappearing silently.
+			malformed++
+			continue
+		}
+
+		switch ev.Type {
+		case "init":
+			sawInit = true
+			dispatch(agent.GenerationProgress{Phase: agent.PhaseConnecting})
+
+		case "message":
+			if ev.Role != "assistant" {
+				continue
+			}
+			result.WriteString(ev.Content)
+			totalChars += len(ev.Content)
+			if !firstTokenFired {
+				firstTokenFired = true
+				// Gemini's init/message events carry no TTFT, input-token,
+				// or cached-token data; usage is deferred to the terminal
+				// result event. PhaseFirstToken is dispatched without those
+				// fields so the progress writer's graceful degradation
+				// renders "Provider responded -- generating..." without
+				// parens.
+				dispatch(agent.GenerationProgress{Phase: agent.PhaseFirstToken})
+			} else {
+				dispatch(agent.GenerationProgress{
+					Phase:        agent.PhaseGenerating,
+					OutputTokens: totalChars / 4,
+				})
+			}
+
+		case "result":
+			stats = ev.Stats
+			if ev.Status == "error" {
+				detail := ""
+				if ev.Error != nil {
+					detail = ev.Error.Message
+				}
+				if detail == "" {
+					// Partial decode tolerated: schema drift falls through to
+					// "unspecified error" rather than leaking raw lines (which
+					// may carry echoed user content or model fragments) into
+					// logs and *TextGenerationError.Stderr.
+					detail = "unspecified error"
+				}
+				return "", fmt.Errorf("gemini stream error: %s", detail)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading gemini stream: %w", err)
+	}
+	if !sawInit {
+		return "", errors.New("gemini stream ended without an init event")
+	}
+	if !firstTokenFired {
+		if malformed > 0 {
+			return "", fmt.Errorf("gemini stream produced no assistant content (%d malformed lines skipped)", malformed)
+		}
+		return "", errors.New("gemini stream produced no assistant content")
+	}
+	if progress != nil {
+		done := agent.GenerationProgress{Phase: agent.PhaseDone}
+		if stats != nil {
+			done.OutputTokens = stats.OutputTokens
+			done.InputTokens = stats.InputTokens
+			done.CachedInputTokens = stats.Cached
+			if stats.DurationMs > 0 {
+				done.DurationMs = stats.DurationMs
+			}
+		}
+		if done.DurationMs == 0 {
+			done.DurationMs = int(time.Since(start).Milliseconds())
+		}
+		dispatch(done)
+	}
+	return result.String(), nil
+}
+
+// GenerateTextStreaming implements agent.StreamingTextGenerator.
+func (g *GeminiCLIAgent) GenerateTextStreaming(
+	ctx context.Context,
+	prompt, model string,
+	progress agent.ProgressFn,
+) (string, error) {
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName:                 "gemini",
+		DisplayName:               "gemini",
+		BuildCmd:                  g.buildStreamCmd,
+		Parser:                    parseGeminiStream,
+		LooksLikeUnrecognizedFlag: looksLikeGeminiUnrecognizedFlag,
+	}
+
+	result, err := tmpl.Generate(ctx, prompt, model, progress)
+	if err != nil {
+		if errors.Is(err, agent.ErrUnrecognizedStreamingFlag) {
+			return g.GenerateText(ctx, prompt, model)
+		}
+		return "", fmt.Errorf("gemini streaming generate: %w", err)
+	}
+	return result, nil
+}
+
+func (g *GeminiCLIAgent) buildStreamCmd(ctx context.Context, prompt, model string) *exec.Cmd {
+	commandRunner := g.CommandRunner
+	if commandRunner == nil {
+		commandRunner = exec.CommandContext
+	}
+	args := []string{"--output-format", "stream-json", "-p", " "}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	cmd := commandRunner(ctx, "gemini", args...)
+	cmd.Stdin = strings.NewReader(prompt)
+	return cmd
+}
+
+// looksLikeGeminiUnrecognizedFlag is the second of 4 per-agent flag-rejection
+// heuristics. The controller will consolidate the 4 instances after Chunk 5.
+func looksLikeGeminiUnrecognizedFlag(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	hasRejectPhrase := strings.Contains(lower, "unknown") ||
+		strings.Contains(lower, "unrecognized") ||
+		strings.Contains(lower, "invalid")
+	if !hasRejectPhrase {
+		return false
+	}
+	return strings.Contains(lower, "output-format") || strings.Contains(lower, "stream-json")
+}

--- a/cmd/entire/cli/agent/geminicli/generate_streaming.go
+++ b/cmd/entire/cli/agent/geminicli/generate_streaming.go
@@ -138,10 +138,9 @@ func (g *GeminiCLIAgent) GenerateTextStreaming(
 	progress agent.ProgressFn,
 ) (string, error) {
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:   "gemini",
-		DisplayName: "gemini",
-		BuildCmd:    g.buildStreamCmd,
-		Parser:      parseGeminiStream,
+		AgentName: "gemini",
+		BuildCmd:  g.buildStreamCmd,
+		Parser:    parseGeminiStream,
 		LooksLikeUnrecognizedFlag: func(stderr string) bool {
 			return agent.LooksLikeUnrecognizedFlag(stderr, "output-format", "stream-json")
 		},

--- a/cmd/entire/cli/agent/geminicli/generate_streaming.go
+++ b/cmd/entire/cli/agent/geminicli/generate_streaming.go
@@ -97,18 +97,7 @@ func parseGeminiStream(stdout io.Reader, progress agent.ProgressFn) (string, err
 		case "result":
 			stats = ev.Stats
 			if ev.Status == "error" {
-				detail := ""
-				if ev.Error != nil {
-					detail = ev.Error.Message
-				}
-				if detail == "" {
-					// Partial decode tolerated: schema drift falls through to
-					// "unspecified error" rather than leaking raw lines (which
-					// may carry echoed user content or model fragments) into
-					// logs and *TextGenerationError.Stderr.
-					detail = "unspecified error"
-				}
-				return "", fmt.Errorf("gemini stream error: %s", detail)
+				return "", fmt.Errorf("gemini stream error: %s", agent.SafeErrorMessage(line))
 			}
 		}
 	}

--- a/cmd/entire/cli/agent/geminicli/generate_streaming.go
+++ b/cmd/entire/cli/agent/geminicli/generate_streaming.go
@@ -97,7 +97,9 @@ func parseGeminiStream(stdout io.Reader, progress agent.ProgressFn) (string, err
 		case "result":
 			stats = ev.Stats
 			if ev.Status == "error" {
-				return "", fmt.Errorf("gemini stream error: %s", agent.SafeErrorMessage(line))
+				return "", agent.MarkProviderStreamError( //nolint:wrapcheck // private transport marker preserves the decoded provider error chain
+					fmt.Errorf("gemini stream error: %s", agent.SafeErrorMessage(line)),
+				)
 			}
 		}
 	}
@@ -149,6 +151,7 @@ func (g *GeminiCLIAgent) GenerateTextStreaming(
 	result, err := tmpl.Generate(ctx, prompt, model, progress)
 	if err != nil {
 		if errors.Is(err, agent.ErrUnrecognizedStreamingFlag) {
+			agent.ReportStreamingMode(progress, false)
 			return g.GenerateText(ctx, prompt, model)
 		}
 		return "", fmt.Errorf("gemini streaming generate: %w", err)

--- a/cmd/entire/cli/agent/geminicli/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/geminicli/generate_streaming_test.go
@@ -1,0 +1,133 @@
+package geminicli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/testutil"
+)
+
+func TestParseGeminiStream_Success(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "stream_success.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	var phases []agent.ProgressPhase
+	result, err := parseGeminiStream(bytes.NewReader(data), func(p agent.GenerationProgress) {
+		phases = append(phases, p.Phase)
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !strings.Contains(result, "Hello") || !strings.Contains(result, "world") {
+		t.Errorf("result = %q, want concatenated assistant content", result)
+	}
+
+	counts := map[agent.ProgressPhase]int{}
+	for _, p := range phases {
+		counts[p]++
+	}
+	if counts[agent.PhaseConnecting] != 1 {
+		t.Errorf("PhaseConnecting count = %d, want 1", counts[agent.PhaseConnecting])
+	}
+	if counts[agent.PhaseFirstToken] != 1 {
+		t.Errorf("PhaseFirstToken count = %d, want 1", counts[agent.PhaseFirstToken])
+	}
+	if counts[agent.PhaseGenerating] < 1 {
+		t.Errorf("PhaseGenerating count = %d, want at least 1", counts[agent.PhaseGenerating])
+	}
+	if counts[agent.PhaseDone] != 1 {
+		t.Errorf("PhaseDone count = %d, want 1 (emitted at result event)", counts[agent.PhaseDone])
+	}
+}
+
+func TestParseGeminiStream_ErrorEnvelope(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("testdata", "stream_error.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	_, err = parseGeminiStream(bytes.NewReader(data), nil)
+	if err == nil {
+		t.Fatal("expected error from error envelope")
+	}
+	if !strings.Contains(err.Error(), "invalid request") {
+		t.Errorf("error %q should mention 'invalid request' from error.message", err)
+	}
+}
+
+func TestParseGeminiStream_EmptyStream(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseGeminiStream(strings.NewReader(""), nil)
+	if err == nil {
+		t.Fatal("expected error from empty stream (no init, no assistant content)")
+	}
+}
+
+func TestGeminiCLIGenerateTextStreaming_Success(t *testing.T) {
+	t.Parallel()
+
+	fixture, err := os.ReadFile(filepath.Join("testdata", "stream_success.jsonl"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	g := &GeminiCLIAgent{
+		CommandRunner: testutil.FakeStreamCmd(string(fixture), "", 0),
+	}
+
+	var phases []agent.ProgressPhase
+	result, err := g.GenerateTextStreaming(context.Background(), "test prompt", "haiku", func(p agent.GenerationProgress) {
+		phases = append(phases, p.Phase)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "Hello") || !strings.Contains(result, "world") {
+		t.Errorf("result = %q, want concatenated assistant content", result)
+	}
+	// Expect Connecting, FirstToken, Generating (at least once), Done.
+	if len(phases) < 4 {
+		t.Errorf("phases = %v (count %d), want >= 4 (Connecting, FirstToken, Generating+, Done)", phases, len(phases))
+	}
+}
+
+func TestGeminiCLIGenerateTextStreaming_FallbackOnUnrecognizedFlag(t *testing.T) {
+	t.Parallel()
+
+	streamCall := testutil.FakeStreamCmd("", "error: unknown flag: --output-format", 1)
+	nonStreamCall := testutil.FakeStreamCmd("fallback response", "", 0)
+	calls := 0
+	g := &GeminiCLIAgent{
+		CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			calls++
+			if calls == 1 {
+				return streamCall(ctx, name, args...)
+			}
+			return nonStreamCall(ctx, name, args...)
+		},
+	}
+
+	result, err := g.GenerateTextStreaming(context.Background(), "test", "haiku", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "fallback") {
+		t.Errorf("result = %q, want substring 'fallback'", result)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2 (streaming + fallback)", calls)
+	}
+}

--- a/cmd/entire/cli/agent/geminicli/generate_streaming_test.go
+++ b/cmd/entire/cli/agent/geminicli/generate_streaming_test.go
@@ -84,9 +84,15 @@ func TestGeminiCLIGenerateTextStreaming_Success(t *testing.T) {
 		t.Fatalf("read fixture: %v", err)
 	}
 
-	g := &GeminiCLIAgent{
-		CommandRunner: testutil.FakeStreamCmd(string(fixture), "", 0),
-	}
+	fake := testutil.FakeStreamCmd(string(fixture), "", 0)
+	var commandName string
+	var commandArgs []string
+	var command *exec.Cmd
+	g := &GeminiCLIAgent{CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		commandName, commandArgs = name, append([]string(nil), args...)
+		command = fake(ctx, name, args...)
+		return command
+	}}
 
 	var phases []agent.ProgressPhase
 	result, err := g.GenerateTextStreaming(context.Background(), "test prompt", "haiku", func(p agent.GenerationProgress) {
@@ -101,6 +107,13 @@ func TestGeminiCLIGenerateTextStreaming_Success(t *testing.T) {
 	// Expect Connecting, FirstToken, Generating (at least once), Done.
 	if len(phases) < 4 {
 		t.Errorf("phases = %v (count %d), want >= 4 (Connecting, FirstToken, Generating+, Done)", phases, len(phases))
+	}
+	if commandName != string(agent.AgentNameGemini) || strings.Join(commandArgs, " ") != "--output-format stream-json -p   --model haiku" {
+		t.Errorf("command = %q %v, want Gemini streaming argv", commandName, commandArgs)
+	}
+	stdin, stdinErr := testutil.ReadCommandStdin(command)
+	if stdinErr != nil || stdin != "test prompt" {
+		t.Errorf("stdin = %q, err = %v; want exact prompt", stdin, stdinErr)
 	}
 }
 

--- a/cmd/entire/cli/agent/geminicli/stream_response.go
+++ b/cmd/entire/cli/agent/geminicli/stream_response.go
@@ -1,0 +1,38 @@
+package geminicli
+
+import "time"
+
+// geminiStreamEvent is one decoded line of `gemini --output-format stream-json`
+// NDJSON output. Fields are populated based on Type:
+//
+//   - "init":    SessionID, Model
+//   - "message": Role ("user" or "assistant"), Content, Delta (true on incremental)
+//   - "result":  Status ("success" | "error"), Error (when status=error), Stats
+type geminiStreamEvent struct {
+	Type      string             `json:"type"`
+	Timestamp time.Time          `json:"timestamp,omitempty"`
+	SessionID string             `json:"session_id,omitempty"`
+	Model     string             `json:"model,omitempty"`
+	Role      string             `json:"role,omitempty"`
+	Content   string             `json:"content,omitempty"`
+	Delta     bool               `json:"delta,omitempty"`
+	Status    string             `json:"status,omitempty"`
+	Error     *geminiStreamError `json:"error,omitempty"`
+	Stats     *geminiStreamStats `json:"stats,omitempty"`
+}
+
+// geminiStreamError is the body of a result event with status="error".
+type geminiStreamError struct {
+	Type    string `json:"type,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// geminiStreamStats appears inside the terminal type=result event.
+// Token field names mirror gemini-cli's stats schema.
+type geminiStreamStats struct {
+	TotalTokens  int `json:"total_tokens,omitempty"`
+	InputTokens  int `json:"input_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
+	Cached       int `json:"cached,omitempty"`
+	DurationMs   int `json:"duration_ms,omitempty"`
+}

--- a/cmd/entire/cli/agent/geminicli/testdata/stream_error.jsonl
+++ b/cmd/entire/cli/agent/geminicli/testdata/stream_error.jsonl
@@ -1,0 +1,3 @@
+{"type":"init","timestamp":"2026-05-15T16:00:46.999Z","session_id":"test-session","model":"nonexistent-model"}
+{"type":"message","timestamp":"2026-05-15T16:00:47.000Z","role":"user","content":"hi"}
+{"type":"result","timestamp":"2026-05-15T16:00:47.100Z","status":"error","error":{"type":"unknown","message":"invalid request"},"stats":{"total_tokens":0,"input_tokens":0,"output_tokens":0,"cached":0,"duration_ms":0}}

--- a/cmd/entire/cli/agent/geminicli/testdata/stream_success.jsonl
+++ b/cmd/entire/cli/agent/geminicli/testdata/stream_success.jsonl
@@ -1,0 +1,5 @@
+{"type":"init","timestamp":"2026-05-15T16:00:46.999Z","session_id":"test-session","model":"gemini-3-flash-preview"}
+{"type":"message","timestamp":"2026-05-15T16:00:46.999Z","role":"user","content":"say hi"}
+{"type":"message","timestamp":"2026-05-15T16:00:48.211Z","role":"assistant","content":"Hello","delta":true}
+{"type":"message","timestamp":"2026-05-15T16:00:48.311Z","role":"assistant","content":", world.","delta":true}
+{"type":"result","timestamp":"2026-05-15T16:00:48.500Z","status":"success","stats":{"total_tokens":42,"input_tokens":35,"output_tokens":7,"cached":0,"duration_ms":1501}}

--- a/cmd/entire/cli/agent/hook_command_test.go
+++ b/cmd/entire/cli/agent/hook_command_test.go
@@ -20,9 +20,9 @@ func TestUseWindowsProductionHooks(t *testing.T) {
 		want     bool
 	}{
 		{"non-windows never uses windows wrappers", "linux", false, shBroken, false},
-		{"localDev never uses windows wrappers", windowsOS, true, shBroken, false},
-		{"windows with working sh keeps sh wrappers", windowsOS, false, shWorks, false},
-		{"windows without working sh uses windows wrappers", windowsOS, false, shBroken, true},
+		{"localDev never uses windows wrappers", hookWrapperOSWindows, true, shBroken, false},
+		{"windows with working sh keeps sh wrappers", hookWrapperOSWindows, false, shWorks, false},
+		{"windows without working sh uses windows wrappers", hookWrapperOSWindows, false, shBroken, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/entire/cli/agent/hook_command_windows_exec_test.go
+++ b/cmd/entire/cli/agent/hook_command_windows_exec_test.go
@@ -60,7 +60,7 @@ func runWindowsWrapper(t *testing.T, wrapper string, entirePresent bool) (string
 // (and propagates its exit code) when entire is present, and is skipped with a
 // 0 exit when entire is absent, for both the silent and JSON-warning forms.
 func TestWindowsWrappers_Execution(t *testing.T) {
-	if runtime.GOOS != windowsOS {
+	if runtime.GOOS != hookWrapperOSWindows {
 		t.Skip("cmd.exe wrapper execution test runs only on Windows")
 	}
 	// No t.Parallel(): t.Setenv("PATH") forbids it.

--- a/cmd/entire/cli/agent/pi/generate.go
+++ b/cmd/entire/cli/agent/pi/generate.go
@@ -17,7 +17,7 @@ func (a *PiAgent) GenerateText(ctx context.Context, prompt string, model string)
 	}
 	args = append(args, prompt)
 
-	result, _, _, err := agent.RunIsolatedTextGeneratorCLI(ctx, nil, "pi", "pi", args, "")
+	result, err := agent.RunIsolatedTextGeneratorCLI(ctx, a.CommandRunner, agent.AgentNamePi, args, "")
 	if err != nil {
 		return "", fmt.Errorf("pi text generation failed: %w", err)
 	}

--- a/cmd/entire/cli/agent/pi/generate_test.go
+++ b/cmd/entire/cli/agent/pi/generate_test.go
@@ -1,0 +1,120 @@
+package pi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+const piGenerateHelperTest = "TestPiGenerateTextHelperProcess"
+const piGenerateHelperMarker = "__entire_pi_generate_helper__"
+
+// TestPiGenerateTextHelperProcess is a subprocess entrypoint. It cannot call
+// t.Parallel because its helper modes call os.Exit.
+func TestPiGenerateTextHelperProcess(_ *testing.T) {
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 {
+		return
+	}
+
+	args := os.Args[separator+1:]
+	if len(args) == 0 || args[0] != piGenerateHelperMarker {
+		return
+	}
+	args = args[1:]
+	if len(args) == 0 {
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "auth":
+		_, _ = fmt.Fprint(os.Stderr, "HTTP 401 Unauthorized")
+		os.Exit(17)
+	case "empty":
+		_, _ = fmt.Fprint(os.Stderr, "diagnostic detail")
+		os.Exit(0)
+	default:
+		os.Exit(2)
+	}
+}
+
+func piHelperRunner(mode string) agent.TextCommandRunner {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, os.Args[0], "-test.run=^"+piGenerateHelperTest+"$", "--", piGenerateHelperMarker, mode)
+	}
+}
+
+func TestPiAgentGenerateText_ClassifiesFallbackFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		runner agent.TextCommandRunner
+		kind   agent.TextGenerationErrorKind
+	}{
+		{
+			name: "missing CLI",
+			runner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "definitely-not-installed-pi-binary")
+			},
+			kind: agent.TextGenerationErrorCLIMissing,
+		},
+		{name: "auth stderr", runner: piHelperRunner("auth"), kind: agent.TextGenerationErrorAuth},
+		{name: "empty stdout with stderr", runner: piHelperRunner("empty"), kind: agent.TextGenerationErrorUnknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			piAgent := &PiAgent{CommandRunner: test.runner}
+			_, err := piAgent.GenerateText(context.Background(), "prompt", "")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			var failure *agent.TextGenerationError
+			if !errors.As(err, &failure) {
+				t.Fatalf("err = %T %v, want *TextGenerationError", err, err)
+			}
+			if failure.Kind != test.kind {
+				t.Errorf("Kind = %v, want %v", failure.Kind, test.kind)
+			}
+			if failure.Provider != agent.AgentNamePi {
+				t.Errorf("Provider = %q, want %q", failure.Provider, agent.AgentNamePi)
+			}
+			if test.name == "empty stdout with stderr" {
+				if failure.Stderr != "diagnostic detail" {
+					t.Errorf("Stderr = %q, want retained diagnostic", failure.Stderr)
+				}
+				if !strings.Contains(failure.Message, "diagnostic detail") {
+					t.Errorf("Message = %q, want retained diagnostic", failure.Message)
+				}
+			}
+			if count := countPiTextGenerationErrors(err); count != 1 {
+				t.Errorf("TextGenerationError count = %d, want 1 (chain: %v)", count, err)
+			}
+		})
+	}
+}
+
+func countPiTextGenerationErrors(err error) int {
+	count := 0
+	for err != nil {
+		textGenerationError := &agent.TextGenerationError{}
+		if errors.As(err, &textGenerationError) {
+			count++
+		}
+		err = errors.Unwrap(err)
+	}
+	return count
+}

--- a/cmd/entire/cli/agent/pi/generate_test.go
+++ b/cmd/entire/cli/agent/pi/generate_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -109,9 +110,9 @@ func TestPiAgentGenerateText_ClassifiesFallbackFailures(t *testing.T) {
 
 func countPiTextGenerationErrors(err error) int {
 	count := 0
+	targetType := reflect.TypeFor[*agent.TextGenerationError]()
 	for err != nil {
-		textGenerationError := &agent.TextGenerationError{}
-		if errors.As(err, &textGenerationError) {
+		if reflect.TypeOf(err) == targetType {
 			count++
 		}
 		err = errors.Unwrap(err)

--- a/cmd/entire/cli/agent/pi/models.go
+++ b/cmd/entire/cli/agent/pi/models.go
@@ -16,7 +16,7 @@ var _ agent.ModelLister = (*PiAgent)(nil)
 // Pi has a real enumeration command spanning every configured provider, so the
 // result reflects what this machine/account can actually use.
 func (a *PiAgent) ListModels(ctx context.Context) ([]agent.ModelInfo, error) {
-	out, _, _, err := agent.RunIsolatedTextGeneratorCLI(ctx, nil, "pi", "pi", []string{"--list-models"}, "")
+	out, err := agent.RunIsolatedTextGeneratorCLI(ctx, nil, agent.AgentNamePi, []string{"--list-models"}, "")
 	if err != nil {
 		return nil, fmt.Errorf("pi --list-models: %w", err)
 	}

--- a/cmd/entire/cli/agent/pi/pi.go
+++ b/cmd/entire/cli/agent/pi/pi.go
@@ -43,7 +43,9 @@ func init() {
 // PiAgent implements agent.Agent for the pi coding agent.
 //
 //nolint:revive // PiAgent is clearer than Agent in this context
-type PiAgent struct{}
+type PiAgent struct {
+	CommandRunner agent.TextCommandRunner
+}
 
 // NewPiAgent returns a new Pi agent instance.
 func NewPiAgent() agent.Agent {

--- a/cmd/entire/cli/agent/streaming_safe_error.go
+++ b/cmd/entire/cli/agent/streaming_safe_error.go
@@ -1,0 +1,39 @@
+package agent
+
+import "encoding/json"
+
+// SafeErrorMessage decodes operational error text from a raw NDJSON line
+// without leaking the raw line itself.
+//
+// Stream parsers MUST NOT propagate raw protocol lines into error messages:
+// CLI stderr/stdout can carry echoed user content or model-message
+// fragments, which would then surface in logs, telemetry, and user-facing
+// error output. This helper partially decodes the line against the three
+// commonly-observed message paths (`message`, `error.message`,
+// `data.message`) and falls back to "unspecified error" if none match.
+//
+// Callers pass the raw scanner line. Decode errors are tolerated: if the
+// line is malformed or has none of these paths, the result is the safe
+// sentinel rather than the raw bytes.
+func SafeErrorMessage(line []byte) string {
+	var details struct {
+		Message string `json:"message"`
+		Error   struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		Data struct {
+			Message string `json:"message"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(line, &details) //nolint:errcheck // partial decode tolerated; raw line MUST NOT leak
+	switch {
+	case details.Message != "":
+		return details.Message
+	case details.Error.Message != "":
+		return details.Error.Message
+	case details.Data.Message != "":
+		return details.Data.Message
+	default:
+		return "unspecified error"
+	}
+}

--- a/cmd/entire/cli/agent/streaming_safe_error_test.go
+++ b/cmd/entire/cli/agent/streaming_safe_error_test.go
@@ -1,0 +1,37 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+func TestSafeErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"top_level_message", `{"type":"error","message":"model not found"}`, "model not found"},
+		{"nested_error_message", `{"type":"turn.failed","error":{"message":"timed out"}}`, "timed out"},
+		{"nested_data_message", `{"type":"error","data":{"message":"rate limited"}}`, "rate limited"},
+		{"prefers_top_level_over_nested", `{"message":"top","error":{"message":"nested"}}`, "top"},
+		{"prefers_error_over_data", `{"error":{"message":"e"},"data":{"message":"d"}}`, "e"},
+		{"empty_strings_fall_through", `{"message":"","error":{"message":""},"data":{"message":""}}`, "unspecified error"},
+		{"no_message_paths", `{"type":"thread.started","thread_id":"t"}`, "unspecified error"},
+		{"malformed_json", `{not json at all`, "unspecified error"},
+		{"empty_line", ``, "unspecified error"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := agent.SafeErrorMessage([]byte(tc.line))
+			if got != tc.want {
+				t.Errorf("SafeErrorMessage(%q) = %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/agent/streaming_template.go
+++ b/cmd/entire/cli/agent/streaming_template.go
@@ -24,14 +24,9 @@ import (
 // Fields must be non-nil before Generate is called; nil values cause
 // Generate to return ErrTemplateMisconfigured.
 type StreamingGeneratorTemplate struct {
-	// AgentName is an identifier used in log entries (e.g., "codex").
+	// AgentName is an identifier used in log entries and the error-message
+	// prefix wrapped into *TextGenerationError (e.g., "codex").
 	AgentName string
-
-	// DisplayName is the user-facing CLI binary name used in *TextGenerationError
-	// wrapping (e.g., "codex"). Often the same as AgentName but kept separate
-	// for cases where they differ (e.g., Cursor's agent is named "cursor"
-	// but its binary is "agent").
-	DisplayName string
 
 	// BuildCmd constructs the *exec.Cmd for one streaming call. Implementations
 	// MUST set cmd.Stdin to the prompt and cmd.Args to the agent's
@@ -61,8 +56,18 @@ var ErrTemplateMisconfigured = errors.New("streaming template misconfigured")
 var ErrUnrecognizedStreamingFlag = errors.New("CLI rejected streaming flag")
 
 // Generate runs one streaming generation and returns the final result text.
-// On error, returns *TextGenerationError carrying captured stderr and the
-// stdout byte count, matching RunIsolatedTextGeneratorCLI's error shape.
+//
+// Error shapes by failure point:
+//   - Pre-subprocess (StdoutPipe failure): plain wrapped error, since no
+//     stderr/stdout exists yet to diagnose with.
+//   - cmd.Start failure: wrapped error, or *TextGenerationError when ctx is
+//     already cancelled at that point.
+//   - Anything after Start (parse error, non-zero exit, ctx cancellation):
+//     *TextGenerationError carrying captured stderr and the stdout byte
+//     count from countingReader, matching RunIsolatedTextGeneratorCLI's
+//     error shape so the explain layer's diagnostic path can read both.
+//   - LooksLikeUnrecognizedFlag predicate match: ErrUnrecognizedStreamingFlag
+//     sentinel so the caller can fall back to non-streaming.
 func (t *StreamingGeneratorTemplate) Generate(
 	ctx context.Context,
 	prompt, model string,
@@ -97,7 +102,10 @@ func (t *StreamingGeneratorTemplate) Generate(
 	counter := &countingReader{r: stdout}
 	result, parseErr := t.Parser(counter, progress)
 
-	if _, drainErr := io.Copy(io.Discard, stdout); drainErr != nil {
+	// Drain through the counter so StdoutBytes reflects the full subprocess
+	// output even when the parser exited early (e.g. on a recognized
+	// in-stream error). Reading from stdout directly would bypass counter.n.
+	if _, drainErr := io.Copy(io.Discard, counter); drainErr != nil {
 		logging.Debug(ctx, "draining stream stdout",
 			slog.String("agent", t.AgentName),
 			slog.String("error", drainErr.Error()))

--- a/cmd/entire/cli/agent/streaming_template.go
+++ b/cmd/entire/cli/agent/streaming_template.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+)
+
+// StreamingGeneratorTemplate is the shared subprocess-lifecycle wrapper for
+// streaming text generators. Per-agent code provides BuildCmd (argv) and
+// Parser (stdout → progress events); the template handles Start, drain,
+// Wait, stderr capture, and error wrapping.
+//
+// Parallels review/types/template.ReviewerTemplate (established in PR #1192).
+//
+// Fields must be non-nil before Generate is called; nil values cause
+// Generate to return ErrTemplateMisconfigured.
+type StreamingGeneratorTemplate struct {
+	// AgentName is an identifier used in log entries (e.g., "codex").
+	AgentName string
+
+	// DisplayName is the user-facing CLI binary name used in *TextGenerationError
+	// wrapping (e.g., "codex"). Often the same as AgentName but kept separate
+	// for cases where they differ (e.g., Cursor's agent is named "cursor"
+	// but its binary is "agent").
+	DisplayName string
+
+	// BuildCmd constructs the *exec.Cmd for one streaming call. Implementations
+	// MUST set cmd.Stdin to the prompt and cmd.Args to the agent's
+	// streaming-mode invocation. The template will set cmd.Dir = os.TempDir()
+	// and cmd.Env = StripGitEnv(os.Environ()) before Start.
+	BuildCmd func(ctx context.Context, prompt, model string) *exec.Cmd
+
+	// Parser consumes the agent's stdout stream and dispatches progress
+	// callbacks. Returns the final result text on success. Must read until
+	// stdout EOF before returning so the template can call Wait cleanly.
+	// progress may be nil; Parser must handle that.
+	Parser func(stdout io.Reader, progress ProgressFn) (result string, err error)
+
+	// LooksLikeUnrecognizedFlag is optional. When non-nil and the subprocess
+	// fails with stderr matching the predicate, the caller can fall back to
+	// the agent's non-streaming GenerateText path. The template surfaces
+	// this signal via ErrUnrecognizedStreamingFlag so the caller decides.
+	LooksLikeUnrecognizedFlag func(stderr string) bool
+}
+
+// ErrTemplateMisconfigured is returned when required template fields are nil.
+var ErrTemplateMisconfigured = errors.New("streaming template misconfigured")
+
+// ErrUnrecognizedStreamingFlag is returned when LooksLikeUnrecognizedFlag
+// indicates the CLI rejected a streaming-specific flag. Callers that
+// implement a fallback should errors.Is this to detect.
+var ErrUnrecognizedStreamingFlag = errors.New("CLI rejected streaming flag")
+
+// Generate runs one streaming generation and returns the final result text.
+// On error, returns *TextGenerationError carrying captured stderr and the
+// stdout byte count, matching RunIsolatedTextGeneratorCLI's error shape.
+func (t *StreamingGeneratorTemplate) Generate(
+	ctx context.Context,
+	prompt, model string,
+	progress ProgressFn,
+) (string, error) {
+	if t.BuildCmd == nil || t.Parser == nil {
+		return "", ErrTemplateMisconfigured
+	}
+
+	cmd := t.BuildCmd(ctx, prompt, model)
+	cmd.Dir = os.TempDir()
+	cmd.Env = StripGitEnv(os.Environ())
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("%s stream stdout pipe: %w", t.AgentName, err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		if ctx.Err() != nil {
+			return "", &TextGenerationError{
+				Err:         ctx.Err(),
+				Stderr:      strings.TrimSpace(stderr.String()),
+				StdoutBytes: 0,
+			}
+		}
+		return "", fmt.Errorf("%s stream start: %w", t.AgentName, err)
+	}
+
+	counter := &countingReader{r: stdout}
+	result, parseErr := t.Parser(counter, progress)
+
+	if _, drainErr := io.Copy(io.Discard, stdout); drainErr != nil {
+		logging.Debug(ctx, "draining stream stdout",
+			slog.String("agent", t.AgentName),
+			slog.String("error", drainErr.Error()))
+	}
+	waitErr := cmd.Wait()
+
+	if ctx.Err() != nil {
+		stderrStr := strings.TrimSpace(stderr.String())
+		return "", &TextGenerationError{
+			Err:         ctx.Err(),
+			Stderr:      stderrStr,
+			StdoutBytes: counter.n,
+		}
+	}
+
+	if parseErr == nil && waitErr == nil {
+		return result, nil
+	}
+
+	stderrStr := strings.TrimSpace(stderr.String())
+	if waitErr != nil && t.LooksLikeUnrecognizedFlag != nil && t.LooksLikeUnrecognizedFlag(stderrStr) {
+		logging.Warn(ctx, "CLI rejected streaming flags; caller should fall back to non-streaming",
+			slog.String("agent", t.AgentName),
+			slog.String("stderr", stderrStr))
+		return "", ErrUnrecognizedStreamingFlag
+	}
+
+	wrappedErr := waitErr
+	if wrappedErr == nil {
+		wrappedErr = parseErr
+	}
+	return "", &TextGenerationError{
+		Err:         fmt.Errorf("%s stream failed: %w", t.AgentName, wrappedErr),
+		Stderr:      stderrStr,
+		StdoutBytes: counter.n,
+	}
+}
+
+// countingReader passes bytes through and counts them. Used by the template
+// so the diagnostic path can ask "did the subprocess produce any output?".
+type countingReader struct {
+	r io.Reader
+	n int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += n
+	return n, err //nolint:wrapcheck // io.Reader contract requires passthrough (including io.EOF) without wrapping
+}

--- a/cmd/entire/cli/agent/streaming_template.go
+++ b/cmd/entire/cli/agent/streaming_template.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
 
@@ -66,9 +67,10 @@ func (e *providerStreamError) Error() string { return e.err.Error() }
 func (e *providerStreamError) Unwrap() error { return e.err }
 
 // MarkProviderStreamError marks an error decoded from an explicit provider
-// stream event. It lets the subprocess template preserve that error when the
-// context completes concurrently, without mistaking EOF/parser failures
-// caused by killing the subprocess for provider failures.
+// stream event. It lets the subprocess template distinguish decoded provider
+// failures from EOF/parser failures caused by killing the subprocess. A
+// semantically specific provider failure can then outrank a concurrent context
+// error while an unclassified provider failure preserves both causes.
 func MarkProviderStreamError(err error) error {
 	if err == nil {
 		return nil
@@ -86,8 +88,8 @@ func isProviderStreamError(err error) bool {
 // Error shapes by failure point:
 //   - Pre-subprocess (StdoutPipe failure): plain wrapped error, since no
 //     stderr/stdout exists yet to diagnose with.
-//   - cmd.Start failure: wrapped error, or *TextGenerationError when ctx is
-//     already cancelled at that point.
+//   - cmd.Start failure: *TextGenerationError with provider metadata, including
+//     CLIMissing classification when the executable cannot be found.
 //   - Anything after Start (parse error, non-zero exit, ctx cancellation):
 //     *TextGenerationError carrying captured stderr and the stdout byte
 //     count from countingReader, matching RunIsolatedTextGeneratorCLI's
@@ -115,14 +117,20 @@ func (t *StreamingGeneratorTemplate) Generate(
 	cmd.Stderr = &stderr
 
 	if err := cmd.Start(); err != nil {
-		if ctx.Err() != nil {
-			return "", &TextGenerationError{
-				Err:         ctx.Err(),
-				Stderr:      strings.TrimSpace(stderr.String()),
-				StdoutBytes: 0,
-			}
+		provider := types.AgentName(t.AgentName)
+		capturedStderr := strings.TrimSpace(stderr.String())
+		kind := TextGenerationErrorUnknown
+		message := fmt.Sprintf("%s stream start: %v", t.AgentName, err)
+		var execErr *exec.Error
+		if errors.As(err, &execErr) {
+			kind = TextGenerationErrorCLIMissing
+			message = fmt.Sprintf("%s not found: %v", streamingProviderLabel(provider, t.AgentName), err)
 		}
-		return "", fmt.Errorf("%s stream start: %w", t.AgentName, err)
+		cause := err
+		if kind == TextGenerationErrorUnknown && ctx.Err() != nil {
+			cause = errors.Join(err, ctx.Err())
+		}
+		return "", newTextGenerationError(provider, kind, message, cause, capturedStderr, 0, -1)
 	}
 
 	counter := &countingReader{r: stdout}
@@ -150,32 +158,7 @@ func (t *StreamingGeneratorTemplate) Generate(
 	}
 	waitErr := cmd.Wait()
 	stderrStr := strings.TrimSpace(stderr.String())
-
-	// An explicit provider error decoded from stdout is authoritative even if
-	// the context completes concurrently. Unmarked parser failures can be a
-	// consequence of killing the subprocess, so context still wins for those.
-	if isProviderStreamError(parseErr) {
-		return "", &TextGenerationError{
-			Err:         fmt.Errorf("%s stream failed: %w", t.AgentName, parseErr),
-			Stderr:      stderrStr,
-			StdoutBytes: counter.n,
-		}
-	}
-
-	if ctx.Err() != nil {
-		return "", &TextGenerationError{
-			Err:         ctx.Err(),
-			Stderr:      stderrStr,
-			StdoutBytes: counter.n,
-		}
-	}
-
-	if parseErr == nil && waitErr == nil {
-		if doneProgress != nil {
-			progress(*doneProgress)
-		}
-		return result, nil
-	}
+	provider := types.AgentName(t.AgentName)
 
 	if waitErr != nil && t.LooksLikeUnrecognizedFlag != nil && t.LooksLikeUnrecognizedFlag(stderrStr) {
 		attrs := streamingFallbackLogAttrs(t.AgentName, stderrStr)
@@ -184,15 +167,88 @@ func (t *StreamingGeneratorTemplate) Generate(
 		return "", ErrUnrecognizedStreamingFlag
 	}
 
-	wrappedErr := waitErr
-	if wrappedErr == nil {
-		wrappedErr = parseErr
+	if parseErr == nil && waitErr == nil {
+		if doneProgress != nil {
+			progress(*doneProgress)
+		}
+		return result, nil
 	}
-	return "", &TextGenerationError{
-		Err:         fmt.Errorf("%s stream failed: %w", t.AgentName, wrappedErr),
-		Stderr:      stderrStr,
-		StdoutBytes: counter.n,
+	cause := streamingFailureCause(parseErr, waitErr)
+
+	// A semantically specific provider error decoded from stdout is authoritative
+	// even if the context completes concurrently. Unknown provider/parser errors
+	// can be consequences of a killed subprocess, so context remains discoverable.
+	if isProviderStreamError(parseErr) {
+		kind := classifyStreamingFailure(provider, stderrStr, parseErr)
+		if kind != TextGenerationErrorUnknown || ctx.Err() == nil {
+			message := parseErr.Error()
+			return "", newTextGenerationError(
+				provider, kind, message, fmt.Errorf("%s stream failed: %w", t.AgentName, cause),
+				stderrStr, counter.n, streamingExitCode(waitErr),
+			)
+		}
 	}
+
+	kind := classifyStreamingFailure(provider, stderrStr, cause)
+	if kind == TextGenerationErrorUnknown && ctx.Err() != nil {
+		cause = errors.Join(cause, ctx.Err())
+	}
+	message := streamingFailureMessage(provider, t.AgentName, stderrStr, cause)
+	return "", newTextGenerationError(
+		provider, kind, message, fmt.Errorf("%s stream failed: %w", t.AgentName, cause),
+		stderrStr, counter.n, streamingExitCode(waitErr),
+	)
+}
+
+func streamingFailureMessage(
+	provider types.AgentName,
+	fallback string,
+	stderr string,
+	cause error,
+) string {
+	if stderr != "" {
+		return stderr
+	}
+	return fmt.Sprintf("%s stream failed: %v", streamingProviderLabel(provider, fallback), cause)
+}
+
+func streamingFailureCause(parseErr, waitErr error) error {
+	if parseErr == nil {
+		return waitErr
+	}
+	if waitErr == nil {
+		return parseErr
+	}
+	return errors.Join(parseErr, waitErr)
+}
+
+func classifyStreamingFailure(provider types.AgentName, stderr string, cause error) TextGenerationErrorKind {
+	detail := stderr
+	if cause != nil {
+		if detail != "" {
+			detail += "\n"
+		}
+		detail += cause.Error()
+	}
+	return classifyTextGenerationFailure(provider, detail)
+}
+
+func streamingExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func streamingProviderLabel(provider types.AgentName, fallback string) string {
+	if label := SummaryProviderErrorLabel(provider); label != "" {
+		return label
+	}
+	return fallback
 }
 
 func streamingFallbackLogAttrs(agentName, stderr string) []slog.Attr {

--- a/cmd/entire/cli/agent/streaming_template.go
+++ b/cmd/entire/cli/agent/streaming_template.go
@@ -55,6 +55,32 @@ var ErrTemplateMisconfigured = errors.New("streaming template misconfigured")
 // implement a fallback should errors.Is this to detect.
 var ErrUnrecognizedStreamingFlag = errors.New("CLI rejected streaming flag")
 
+// providerStreamError marks a parser error decoded from an explicit provider
+// error event. The private wrapper is only transport metadata: callers still
+// observe and match the original error through Unwrap.
+type providerStreamError struct {
+	err error
+}
+
+func (e *providerStreamError) Error() string { return e.err.Error() }
+func (e *providerStreamError) Unwrap() error { return e.err }
+
+// MarkProviderStreamError marks an error decoded from an explicit provider
+// stream event. It lets the subprocess template preserve that error when the
+// context completes concurrently, without mistaking EOF/parser failures
+// caused by killing the subprocess for provider failures.
+func MarkProviderStreamError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &providerStreamError{err: err}
+}
+
+func isProviderStreamError(err error) bool {
+	var marked *providerStreamError
+	return errors.As(err, &marked)
+}
+
 // Generate runs one streaming generation and returns the final result text.
 //
 // Error shapes by failure point:
@@ -111,9 +137,20 @@ func (t *StreamingGeneratorTemplate) Generate(
 			slog.String("error", drainErr.Error()))
 	}
 	waitErr := cmd.Wait()
+	stderrStr := strings.TrimSpace(stderr.String())
+
+	// An explicit provider error decoded from stdout is authoritative even if
+	// the context completes concurrently. Unmarked parser failures can be a
+	// consequence of killing the subprocess, so context still wins for those.
+	if isProviderStreamError(parseErr) {
+		return "", &TextGenerationError{
+			Err:         fmt.Errorf("%s stream failed: %w", t.AgentName, parseErr),
+			Stderr:      stderrStr,
+			StdoutBytes: counter.n,
+		}
+	}
 
 	if ctx.Err() != nil {
-		stderrStr := strings.TrimSpace(stderr.String())
 		return "", &TextGenerationError{
 			Err:         ctx.Err(),
 			Stderr:      stderrStr,
@@ -125,11 +162,10 @@ func (t *StreamingGeneratorTemplate) Generate(
 		return result, nil
 	}
 
-	stderrStr := strings.TrimSpace(stderr.String())
 	if waitErr != nil && t.LooksLikeUnrecognizedFlag != nil && t.LooksLikeUnrecognizedFlag(stderrStr) {
+		attrs := streamingFallbackLogAttrs(t.AgentName, stderrStr)
 		logging.Warn(ctx, "CLI rejected streaming flags; caller should fall back to non-streaming",
-			slog.String("agent", t.AgentName),
-			slog.String("stderr", stderrStr))
+			attrs[0], attrs[1])
 		return "", ErrUnrecognizedStreamingFlag
 	}
 
@@ -141,6 +177,13 @@ func (t *StreamingGeneratorTemplate) Generate(
 		Err:         fmt.Errorf("%s stream failed: %w", t.AgentName, wrappedErr),
 		Stderr:      stderrStr,
 		StdoutBytes: counter.n,
+	}
+}
+
+func streamingFallbackLogAttrs(agentName, stderr string) []slog.Attr {
+	return []slog.Attr{
+		slog.String("agent", agentName),
+		slog.Int("stderr_bytes", len(stderr)),
 	}
 }
 

--- a/cmd/entire/cli/agent/streaming_template.go
+++ b/cmd/entire/cli/agent/streaming_template.go
@@ -126,7 +126,19 @@ func (t *StreamingGeneratorTemplate) Generate(
 	}
 
 	counter := &countingReader{r: stdout}
-	result, parseErr := t.Parser(counter, progress)
+	var doneProgress *GenerationProgress
+	parserProgress := progress
+	if progress != nil {
+		parserProgress = func(event GenerationProgress) {
+			if event.Phase == PhaseDone {
+				done := event
+				doneProgress = &done
+				return
+			}
+			progress(event)
+		}
+	}
+	result, parseErr := t.Parser(counter, parserProgress)
 
 	// Drain through the counter so StdoutBytes reflects the full subprocess
 	// output even when the parser exited early (e.g. on a recognized
@@ -159,6 +171,9 @@ func (t *StreamingGeneratorTemplate) Generate(
 	}
 
 	if parseErr == nil && waitErr == nil {
+		if doneProgress != nil {
+			progress(*doneProgress)
+		}
 		return result, nil
 	}
 

--- a/cmd/entire/cli/agent/streaming_template_privacy_test.go
+++ b/cmd/entire/cli/agent/streaming_template_privacy_test.go
@@ -1,0 +1,25 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestStreamingFallbackLogAttrs_DoNotContainRawStderr(t *testing.T) {
+	t.Parallel()
+
+	const secret = "prompt-content-secret"
+	attrs := streamingFallbackLogAttrs("fake", "unknown flag: --stream "+secret)
+
+	var rendered strings.Builder
+	for _, attr := range attrs {
+		fmt.Fprintf(&rendered, "%s=%v ", attr.Key, attr.Value.Any())
+	}
+	if strings.Contains(rendered.String(), secret) {
+		t.Fatalf("fallback log attrs leaked raw stderr: %s", rendered.String())
+	}
+	if !strings.Contains(rendered.String(), "stderr_bytes=") {
+		t.Fatalf("fallback log attrs should retain safe stderr size metadata: %s", rendered.String())
+	}
+}

--- a/cmd/entire/cli/agent/streaming_template_test.go
+++ b/cmd/entire/cli/agent/streaming_template_test.go
@@ -17,8 +17,7 @@ func TestStreamingGeneratorTemplate_Generate_Success(t *testing.T) {
 
 	parsed := false
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:   "fake",
-		DisplayName: "fake",
+		AgentName: "fake",
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
 			return testutil.FakeStreamCmd("hello\nworld\n", "", 0)(ctx, "fake", []string{}...)
 		},
@@ -58,8 +57,7 @@ func TestStreamingGeneratorTemplate_Generate_UnrecognizedFlagFallback(t *testing
 	t.Parallel()
 
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:   "fake",
-		DisplayName: "fake",
+		AgentName: "fake",
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
 			return testutil.FakeStreamCmd("", "error: unknown flag: --stream-json", 1)(ctx, "fake", []string{}...)
 		},
@@ -82,8 +80,7 @@ func TestStreamingGeneratorTemplate_Generate_NonZeroExitWrapsError(t *testing.T)
 	t.Parallel()
 
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:   "fake",
-		DisplayName: "fake",
+		AgentName: "fake",
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
 			return testutil.FakeStreamCmd("partial\n", "boom\n", 1)(ctx, "fake", []string{}...)
 		},
@@ -113,8 +110,7 @@ func TestStreamingGeneratorTemplate_Generate_ContextCancelled(t *testing.T) {
 	cancel()
 
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName:   "fake",
-		DisplayName: "fake",
+		AgentName: "fake",
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
 			return testutil.FakeStreamCmd("ok\n", "", 0)(ctx, "fake", []string{}...)
 		},

--- a/cmd/entire/cli/agent/streaming_template_test.go
+++ b/cmd/entire/cli/agent/streaming_template_test.go
@@ -1,0 +1,135 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/testutil"
+)
+
+func TestStreamingGeneratorTemplate_Generate_Success(t *testing.T) {
+	t.Parallel()
+
+	parsed := false
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName:   "fake",
+		DisplayName: "fake",
+		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
+			return testutil.FakeStreamCmd("hello\nworld\n", "", 0)(ctx, "fake", []string{}...)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			b, err := io.ReadAll(stdout)
+			if err != nil {
+				return "", err
+			}
+			parsed = true
+			return strings.TrimSpace(string(b)), nil
+		},
+	}
+
+	result, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "hello\nworld" {
+		t.Errorf("result = %q, want %q", result, "hello\nworld")
+	}
+	if !parsed {
+		t.Error("expected parser to have been called")
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_NilFieldsReturnError(t *testing.T) {
+	t.Parallel()
+
+	tmpl := &agent.StreamingGeneratorTemplate{}
+	_, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+	if !errors.Is(err, agent.ErrTemplateMisconfigured) {
+		t.Errorf("err = %v, want ErrTemplateMisconfigured", err)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_UnrecognizedFlagFallback(t *testing.T) {
+	t.Parallel()
+
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName:   "fake",
+		DisplayName: "fake",
+		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
+			return testutil.FakeStreamCmd("", "error: unknown flag: --stream-json", 1)(ctx, "fake", []string{}...)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // best-effort drain in test fake; failure here is irrelevant
+			return "", nil
+		},
+		LooksLikeUnrecognizedFlag: func(stderr string) bool {
+			return strings.Contains(stderr, "unknown flag") && strings.Contains(stderr, "stream-json")
+		},
+	}
+
+	_, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+	if !errors.Is(err, agent.ErrUnrecognizedStreamingFlag) {
+		t.Errorf("err = %v, want ErrUnrecognizedStreamingFlag", err)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_NonZeroExitWrapsError(t *testing.T) {
+	t.Parallel()
+
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName:   "fake",
+		DisplayName: "fake",
+		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
+			return testutil.FakeStreamCmd("partial\n", "boom\n", 1)(ctx, "fake", []string{}...)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // best-effort drain in test fake; failure here is irrelevant
+			return "", nil
+		},
+	}
+
+	_, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+	var failure *agent.TextGenerationError
+	if !errors.As(err, &failure) {
+		t.Fatalf("err = %v, want *TextGenerationError", err)
+	}
+	if !strings.Contains(failure.Stderr, "boom") {
+		t.Errorf("stderr captured = %q, want substring 'boom'", failure.Stderr)
+	}
+	if failure.StdoutBytes == 0 {
+		t.Errorf("stdoutBytes = 0, want > 0 (subprocess emitted 'partial\\n')")
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName:   "fake",
+		DisplayName: "fake",
+		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
+			return testutil.FakeStreamCmd("ok\n", "", 0)(ctx, "fake", []string{}...)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // best-effort drain in test fake; failure here is irrelevant
+			return "", nil
+		},
+	}
+
+	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	var failure *agent.TextGenerationError
+	if !errors.As(err, &failure) {
+		t.Fatalf("err = %v, want *TextGenerationError wrapping context error", err)
+	}
+	if !errors.Is(failure.Err, context.Canceled) {
+		t.Errorf("inner err = %v, want context.Canceled", failure.Err)
+	}
+}

--- a/cmd/entire/cli/agent/streaming_template_test.go
+++ b/cmd/entire/cli/agent/streaming_template_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/testutil"
@@ -127,5 +128,54 @@ func TestStreamingGeneratorTemplate_Generate_ContextCancelled(t *testing.T) {
 	}
 	if !errors.Is(failure.Err, context.Canceled) {
 		t.Errorf("inner err = %v, want context.Canceled", failure.Err)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_ProviderErrorOutranksConcurrentCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	providerErr := errors.New("provider rejected the request")
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: "fake",
+		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
+			return testutil.FakeStreamCmd("provider error event\n", "", 0)(ctx, "fake", []string{}...)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // parser result is the behavior under test
+			cancel()
+			return "", agent.MarkProviderStreamError(providerErr)
+		},
+	}
+
+	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	if !errors.Is(err, providerErr) {
+		t.Fatalf("err = %v, want provider error", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, provider error must outrank concurrent cancellation", err)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_KillInducedParserFailureUsesContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: "fake",
+		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
+			return exec.CommandContext(ctx, "sh", "-c", "sleep 10")
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // cancellation closes the subprocess pipe
+			return "", errors.New("stream ended without terminal event")
+		},
+	}
+
+	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context deadline sentinel", err)
 	}
 }

--- a/cmd/entire/cli/agent/streaming_template_test.go
+++ b/cmd/entire/cli/agent/streaming_template_test.go
@@ -3,25 +3,82 @@ package agent_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
-	"github.com/entireio/cli/cmd/entire/cli/agent/testutil"
 )
+
+const streamingTemplateHelperMarker = "__entire_streaming_template_helper__"
+
+// TestStreamingGeneratorTemplateHelperProcess is the subprocess entrypoint
+// used by this file. It must not call t.Parallel because it calls os.Exit.
+func TestStreamingGeneratorTemplateHelperProcess(_ *testing.T) {
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 {
+		return
+	}
+
+	args := os.Args[separator+1:]
+	if len(args) < 2 || args[0] != streamingTemplateHelperMarker {
+		return
+	}
+
+	switch args[1] {
+	case "output":
+		_, _ = fmt.Fprint(os.Stdout, streamingTemplateHelperArg(args, 2))
+		_, _ = fmt.Fprint(os.Stderr, streamingTemplateHelperArg(args, 3))
+		exitCode, err := strconv.Atoi(streamingTemplateHelperArg(args, 4))
+		if err != nil {
+			os.Exit(2)
+		}
+		os.Exit(exitCode)
+	case "blocking":
+		time.Sleep(time.Hour)
+	default:
+		os.Exit(2)
+	}
+}
+
+func streamingTemplateHelperArg(args []string, index int) string {
+	if index >= len(args) {
+		return ""
+	}
+	return args[index]
+}
+
+func streamingTemplateCmd(ctx context.Context, stdout, stderr string, exitCode int) *exec.Cmd {
+	return exec.CommandContext(ctx, os.Args[0],
+		"-test.run=^TestStreamingGeneratorTemplateHelperProcess$", "--",
+		streamingTemplateHelperMarker, "output", stdout, stderr, strconv.Itoa(exitCode))
+}
+
+func detachedStreamingTemplateCmd(stdout, stderr string, exitCode int) *exec.Cmd {
+	return streamingTemplateCmd(context.Background(), stdout, stderr, exitCode)
+}
 
 func TestStreamingGeneratorTemplate_Generate_Success(t *testing.T) {
 	t.Parallel()
 
 	parsed := false
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("hello\nworld\n", "", 0)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "hello\nworld\n", "", 0)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			b, err := io.ReadAll(stdout)
@@ -59,9 +116,9 @@ func TestStreamingGeneratorTemplate_Generate_UnrecognizedFlagFallback(t *testing
 	t.Parallel()
 
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("", "error: unknown flag: --stream-json", 1)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "", "error: unknown flag: --stream-json", 1)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // best-effort drain in test fake; failure here is irrelevant
@@ -82,9 +139,9 @@ func TestStreamingGeneratorTemplate_Generate_NonZeroExitWrapsError(t *testing.T)
 	t.Parallel()
 
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("partial\n", "boom\n", 1)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "partial\n", "boom\n", 1)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // best-effort drain in test fake; failure here is irrelevant
@@ -122,7 +179,7 @@ func TestStreamingGeneratorTemplate_Generate_DoneRequiresSuccessfulProcessExit(t
 			tmpl := &agent.StreamingGeneratorTemplate{
 				AgentName: string(agent.AgentNameCodex),
 				BuildCmd: func(context.Context, string, string) *exec.Cmd {
-					return testutil.FakeStreamCmd("complete", "", test.exitCode)(context.Background(), "fake")
+					return detachedStreamingTemplateCmd("complete", "", test.exitCode)
 				},
 				Parser: func(stdout io.Reader, progress agent.ProgressFn) (string, error) {
 					result, err := io.ReadAll(stdout)
@@ -154,9 +211,9 @@ func TestStreamingGeneratorTemplate_Generate_ContextCancelled(t *testing.T) {
 	cancel()
 
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("ok\n", "", 0)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "ok\n", "", 0)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // best-effort drain in test fake; failure here is irrelevant
@@ -174,16 +231,42 @@ func TestStreamingGeneratorTemplate_Generate_ContextCancelled(t *testing.T) {
 	}
 }
 
-func TestStreamingGeneratorTemplate_Generate_ProviderErrorOutranksConcurrentCancellation(t *testing.T) {
+func TestStreamingGeneratorTemplate_Generate_SuccessOutranksLateCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(context.Context, string, string) *exec.Cmd {
+			return detachedStreamingTemplateCmd("complete", "", 0)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			result, err := io.ReadAll(stdout)
+			cancel()
+			return string(result), err
+		},
+	}
+
+	result, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	if err != nil {
+		t.Fatalf("Generate() error = %v, want success", err)
+	}
+	if result != "complete" {
+		t.Errorf("result = %q, want complete", result)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_UnknownProviderErrorPreservesConcurrentCancellation(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	providerErr := errors.New("provider rejected the request")
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.FakeStreamCmd("provider error event\n", "", 0)(ctx, "fake", []string{}...)
+			return streamingTemplateCmd(ctx, "provider error event\n", "", 0)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // parser result is the behavior under test
@@ -193,11 +276,15 @@ func TestStreamingGeneratorTemplate_Generate_ProviderErrorOutranksConcurrentCanc
 	}
 
 	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	failure := requireStreamingTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorUnknown {
+		t.Errorf("Kind = %v, want Unknown", failure.Kind)
+	}
 	if !errors.Is(err, providerErr) {
 		t.Fatalf("err = %v, want provider error", err)
 	}
-	if errors.Is(err, context.Canceled) {
-		t.Fatalf("err = %v, provider error must outrank concurrent cancellation", err)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want concurrent cancellation preserved", err)
 	}
 }
 
@@ -207,9 +294,11 @@ func TestStreamingGeneratorTemplate_Generate_KillInducedParserFailureUsesContext
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 	tmpl := &agent.StreamingGeneratorTemplate{
-		AgentName: "fake",
+		AgentName: string(agent.AgentNameCodex),
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return testutil.BlockingCmd(ctx)
+			return exec.CommandContext(ctx, os.Args[0],
+				"-test.run=^TestStreamingGeneratorTemplateHelperProcess$", "--",
+				streamingTemplateHelperMarker, "blocking")
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // cancellation closes the subprocess pipe
@@ -220,5 +309,188 @@ func TestStreamingGeneratorTemplate_Generate_KillInducedParserFailureUsesContext
 	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err = %v, want context deadline sentinel", err)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_MissingCLIIsClassified(t *testing.T) {
+	t.Parallel()
+
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
+			return exec.CommandContext(ctx, "definitely-not-installed-streaming-summary-cli")
+		},
+		Parser: drainStreamingTemplateOutput,
+	}
+
+	_, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+	failure := requireStreamingTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorCLIMissing {
+		t.Errorf("Kind = %v, want CLIMissing", failure.Kind)
+	}
+	if failure.Provider != agent.AgentNameCodex {
+		t.Errorf("Provider = %q, want %q", failure.Provider, agent.AgentNameCodex)
+	}
+	assertOneStreamingTextGenerationError(t, err)
+}
+
+func TestStreamingGeneratorTemplate_Generate_ClassifiesExitStderr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		stderr string
+		kind   agent.TextGenerationErrorKind
+	}{
+		{name: "auth", stderr: "unexpected status 401", kind: agent.TextGenerationErrorAuth},
+		{name: "bare worker number", stderr: "worker 404 failed to start", kind: agent.TextGenerationErrorUnknown},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpl := &agent.StreamingGeneratorTemplate{
+				AgentName: string(agent.AgentNameCodex),
+				BuildCmd: func(context.Context, string, string) *exec.Cmd {
+					return detachedStreamingTemplateCmd("partial", test.stderr, 23)
+				},
+				Parser: drainStreamingTemplateOutput,
+			}
+
+			_, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+			failure := requireStreamingTextGenerationError(t, err)
+			if failure.Kind != test.kind {
+				t.Errorf("Kind = %v, want %v", failure.Kind, test.kind)
+			}
+			if failure.Stderr != test.stderr {
+				t.Errorf("Stderr = %q, want %q", failure.Stderr, test.stderr)
+			}
+			if failure.Message != test.stderr {
+				t.Errorf("Message = %q, want provider detail %q", failure.Message, test.stderr)
+			}
+			if failure.ExitCode != 23 {
+				t.Errorf("ExitCode = %d, want 23", failure.ExitCode)
+			}
+			assertOneStreamingTextGenerationError(t, err)
+		})
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_UnknownFailurePreservesDeadlineAndCause(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	t.Cleanup(cancel)
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(context.Context, string, string) *exec.Cmd {
+			return detachedStreamingTemplateCmd("", "provider exploded", 23)
+		},
+		Parser: drainStreamingTemplateOutput,
+	}
+
+	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	failure := requireStreamingTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorUnknown {
+		t.Errorf("Kind = %v, want Unknown", failure.Kind)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context.DeadlineExceeded in chain", err)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("err = %v, want subprocess cause preserved", err)
+	}
+	assertOneStreamingTextGenerationError(t, err)
+}
+
+func TestStreamingGeneratorTemplate_Generate_PreservesParserAndProcessFailures(t *testing.T) {
+	t.Parallel()
+
+	parserErr := errors.New("parser rejected terminal event")
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(context.Context, string, string) *exec.Cmd {
+			return detachedStreamingTemplateCmd("partial", "transport closed", 23)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // parser error is the behavior under test
+			return "", parserErr
+		},
+	}
+
+	_, err := tmpl.Generate(context.Background(), "prompt", "model", nil)
+	if !errors.Is(err, parserErr) {
+		t.Errorf("err = %v, want parser cause", err)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("err = %v, want process cause", err)
+	}
+}
+
+func TestStreamingGeneratorTemplate_Generate_SpecificProviderErrorOutranksDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	t.Cleanup(cancel)
+	providerErr := errors.New("unexpected status 401")
+	tmpl := &agent.StreamingGeneratorTemplate{
+		AgentName: string(agent.AgentNameCodex),
+		BuildCmd: func(context.Context, string, string) *exec.Cmd {
+			return detachedStreamingTemplateCmd("provider error event", "transport closed", 23)
+		},
+		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // parser result is the behavior under test
+			return "", agent.MarkProviderStreamError(providerErr)
+		},
+	}
+
+	_, err := tmpl.Generate(ctx, "prompt", "model", nil)
+	failure := requireStreamingTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorAuth {
+		t.Errorf("Kind = %v, want Auth", failure.Kind)
+	}
+	if failure.Message != providerErr.Error() {
+		t.Errorf("Message = %q, want decoded provider detail %q", failure.Message, providerErr)
+	}
+	if !errors.Is(err, providerErr) {
+		t.Errorf("err = %v, want provider error in chain", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("specific provider error should outrank deadline: %v", err)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("err = %v, want process cause preserved", err)
+	}
+	assertOneStreamingTextGenerationError(t, err)
+}
+
+func drainStreamingTemplateOutput(stdout io.Reader, _ agent.ProgressFn) (string, error) {
+	_, err := io.Copy(io.Discard, stdout)
+	return "", err
+}
+
+func requireStreamingTextGenerationError(t *testing.T, err error) *agent.TextGenerationError {
+	t.Helper()
+	var failure *agent.TextGenerationError
+	if !errors.As(err, &failure) {
+		t.Fatalf("err = %v, want *TextGenerationError", err)
+	}
+	return failure
+}
+
+func assertOneStreamingTextGenerationError(t *testing.T, err error) {
+	t.Helper()
+	count := 0
+	targetType := reflect.TypeFor[*agent.TextGenerationError]()
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		if reflect.TypeOf(current) == targetType {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("TextGenerationError count = %d, want 1 (chain: %v)", count, err)
 	}
 }

--- a/cmd/entire/cli/agent/streaming_template_test.go
+++ b/cmd/entire/cli/agent/streaming_template_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os/exec"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -104,6 +105,48 @@ func TestStreamingGeneratorTemplate_Generate_NonZeroExitWrapsError(t *testing.T)
 	}
 }
 
+func TestStreamingGeneratorTemplate_Generate_DoneRequiresSuccessfulProcessExit(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		exitCode int
+		wantDone bool
+	}{
+		{name: "success", exitCode: 0, wantDone: true},
+		{name: "non-zero exit", exitCode: 23, wantDone: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var phases []agent.ProgressPhase
+			tmpl := &agent.StreamingGeneratorTemplate{
+				AgentName: string(agent.AgentNameCodex),
+				BuildCmd: func(context.Context, string, string) *exec.Cmd {
+					return testutil.FakeStreamCmd("complete", "", test.exitCode)(context.Background(), "fake")
+				},
+				Parser: func(stdout io.Reader, progress agent.ProgressFn) (string, error) {
+					result, err := io.ReadAll(stdout)
+					progress(agent.GenerationProgress{Phase: agent.PhaseDone})
+					return string(result), err
+				},
+			}
+
+			_, err := tmpl.Generate(context.Background(), "prompt", "model", func(p agent.GenerationProgress) {
+				phases = append(phases, p.Phase)
+			})
+			if test.exitCode == 0 && err != nil {
+				t.Fatalf("Generate() error = %v, want success", err)
+			}
+			if test.exitCode != 0 && err == nil {
+				t.Fatal("Generate() error = nil, want process failure")
+			}
+			if gotDone := slices.Contains(phases, agent.PhaseDone); gotDone != test.wantDone {
+				t.Errorf("PhaseDone observed = %v, want %v (phases: %v)", gotDone, test.wantDone, phases)
+			}
+		})
+	}
+}
+
 func TestStreamingGeneratorTemplate_Generate_ContextCancelled(t *testing.T) {
 	t.Parallel()
 
@@ -166,7 +209,7 @@ func TestStreamingGeneratorTemplate_Generate_KillInducedParserFailureUsesContext
 	tmpl := &agent.StreamingGeneratorTemplate{
 		AgentName: "fake",
 		BuildCmd: func(ctx context.Context, _, _ string) *exec.Cmd {
-			return exec.CommandContext(ctx, "sh", "-c", "sleep 10")
+			return testutil.BlockingCmd(ctx)
 		},
 		Parser: func(stdout io.Reader, _ agent.ProgressFn) (string, error) {
 			_, _ = io.Copy(io.Discard, stdout) //nolint:errcheck // cancellation closes the subprocess pipe

--- a/cmd/entire/cli/agent/streaming_unrecognized_flag.go
+++ b/cmd/entire/cli/agent/streaming_unrecognized_flag.go
@@ -1,0 +1,33 @@
+package agent
+
+import "strings"
+
+// LooksLikeUnrecognizedFlag reports whether stderr matches the canonical
+// CLI-rejected-a-flag pattern: a rejection phrase ("unknown flag",
+// "unrecognized option", etc.) combined with at least one of the
+// caller-specified flag-name keywords.
+//
+// Used by streaming text generators to detect when an older CLI version
+// rejects a streaming-mode argv so the caller can fall back to a
+// non-streaming path. Returns false if no rejection phrase is present or
+// no keyword matches.
+//
+// Keyword matching is case-insensitive and substring-based; pass the
+// distinguishing words from your streaming flags (e.g. "stream-json",
+// "output-format") rather than the leading "--".
+func LooksLikeUnrecognizedFlag(stderr string, flagKeywords ...string) bool {
+	lower := strings.ToLower(stderr)
+	rejection := strings.Contains(lower, "unknown flag") ||
+		strings.Contains(lower, "unrecognized option") ||
+		strings.Contains(lower, "unknown option") ||
+		strings.Contains(lower, "invalid option")
+	if !rejection {
+		return false
+	}
+	for _, kw := range flagKeywords {
+		if strings.Contains(lower, strings.ToLower(kw)) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/agent/streaming_unrecognized_flag_test.go
+++ b/cmd/entire/cli/agent/streaming_unrecognized_flag_test.go
@@ -1,0 +1,44 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+func TestLooksLikeUnrecognizedFlag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		stderr   string
+		keywords []string
+		want     bool
+	}{
+		{"unknown_flag_with_matching_keyword", "error: unknown flag: --stream-json", []string{"stream-json"}, true},
+		{"unrecognized_option_with_matching_keyword", "unrecognized option '--json'", []string{"json"}, true},
+		{"invalid_option_with_matching_keyword", "invalid option: --output-format", []string{"output-format"}, true},
+		{"unknown_option_with_matching_keyword", "unknown option: --stream", []string{"stream"}, true},
+
+		{"case_insensitive_stderr", "ERROR: UNKNOWN FLAG: --JSON", []string{"json"}, true},
+		{"case_insensitive_keyword", "unknown flag: --json", []string{"JSON"}, true},
+
+		{"rejection_present_but_no_matching_keyword", "unknown flag: --foo", []string{"json", "stream"}, false},
+		{"matching_keyword_but_no_rejection", "json: parse error", []string{"json"}, false},
+
+		{"empty_stderr", "", []string{"json"}, false},
+		{"empty_keywords", "unknown flag: --json", nil, false},
+
+		{"weak_rejection_words_alone_dont_match", "command unknown", []string{"unknown"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := agent.LooksLikeUnrecognizedFlag(tc.stderr, tc.keywords...)
+			if got != tc.want {
+				t.Errorf("LooksLikeUnrecognizedFlag(%q, %v) = %v, want %v", tc.stderr, tc.keywords, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/agent/testutil/streaming.go
+++ b/cmd/entire/cli/agent/testutil/streaming.go
@@ -5,16 +5,26 @@ package testutil
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
+	"time"
 )
 
-const fakeStreamMarkerArg = "__entire_test_fake_stream_process__"
+const (
+	fakeStreamMarkerArg     = "__entire_test_fake_stream_process__"
+	blockingStreamMarkerArg = "__entire_test_blocking_stream_process__"
+)
 
 func init() { //nolint:gochecknoinits // child test binaries must intercept before testing.Main runs
 	args := os.Args
+	if len(args) > 0 && args[len(args)-1] == blockingStreamMarkerArg {
+		time.Sleep(time.Hour)
+		os.Exit(0)
+	}
 	if len(args) < 5 || args[len(args)-4] != fakeStreamMarkerArg {
 		return
 	}
@@ -26,6 +36,32 @@ func init() { //nolint:gochecknoinits // child test binaries must intercept befo
 		os.Exit(125)
 	}
 	os.Exit(exitCode)
+}
+
+// BlockingCmd returns a portable current-test-binary subprocess that remains
+// alive until its context is canceled.
+func BlockingCmd(ctx context.Context) *exec.Cmd {
+	return exec.CommandContext(ctx, os.Args[0], "-test.run=^$", "--", blockingStreamMarkerArg)
+}
+
+// ReadCommandStdin rewinds and reads a command's seekable stdin after a fake
+// subprocess run so tests can pin the exact prompt transport contract.
+func ReadCommandStdin(cmd *exec.Cmd) (string, error) {
+	if cmd == nil || cmd.Stdin == nil {
+		return "", errors.New("command stdin is nil")
+	}
+	seeker, ok := cmd.Stdin.(io.ReadSeeker)
+	if !ok {
+		return "", fmt.Errorf("command stdin %T is not seekable", cmd.Stdin)
+	}
+	if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+		return "", fmt.Errorf("rewind command stdin: %w", err)
+	}
+	data, err := io.ReadAll(seeker)
+	if err != nil {
+		return "", fmt.Errorf("read command stdin: %w", err)
+	}
+	return string(data), nil
 }
 
 func writeDecodedFixture(output *os.File, encoded string) {

--- a/cmd/entire/cli/agent/text_generator_cli.go
+++ b/cmd/entire/cli/agent/text_generator_cli.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
@@ -21,10 +22,42 @@ type TextGenerationError struct {
 	Err         error
 	Stderr      string
 	StdoutBytes int
+	Provider    types.AgentName
+	Kind        TextGenerationErrorKind
+	Message     string
+	ExitCode    int
 }
 
-func (e *TextGenerationError) Error() string { return e.Err.Error() }
-func (e *TextGenerationError) Unwrap() error { return e.Err }
+func (e *TextGenerationError) Error() string {
+	if e == nil {
+		return "text generation failed"
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "text generation failed"
+}
+
+func (e *TextGenerationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// TextGenerationErrorKind identifies actionable summary-provider failures.
+type TextGenerationErrorKind int
+
+const (
+	TextGenerationErrorUnknown TextGenerationErrorKind = iota
+	TextGenerationErrorAuth
+	TextGenerationErrorRateLimit
+	TextGenerationErrorConfig
+	TextGenerationErrorCLIMissing
+)
 
 // TextCommandRunner matches exec.CommandContext and allows tests to inject a runner.
 type TextCommandRunner func(ctx context.Context, name string, args ...string) *exec.Cmd
@@ -32,14 +65,18 @@ type TextCommandRunner func(ctx context.Context, name string, args ...string) *e
 // RunIsolatedTextGeneratorCLI executes a text-generation CLI in an isolated temp
 // directory with all GIT_* environment variables removed. This avoids recursive
 // hook triggers and repo side effects while preserving provider-specific flags.
-//
-// Returns (result, capturedStderr, stdoutByteCount, err). capturedStderr and
-// stdoutByteCount are populated even on error so callers can wrap them into a
-// *agent.TextGenerationError for timeout diagnostics.
-func RunIsolatedTextGeneratorCLI(ctx context.Context, runner TextCommandRunner, binary, displayName string, args []string, stdin string) (string, string, int, error) { //nolint:unparam // capturedStderr (result 1) is used by sub-package callers (codex, geminicli, etc.) even though intra-package tests blank it
+func RunIsolatedTextGeneratorCLI(
+	ctx context.Context,
+	runner TextCommandRunner,
+	provider types.AgentName,
+	args []string,
+	stdin string,
+) (string, error) {
 	if runner == nil {
 		runner = exec.CommandContext
 	}
+	binary := SummaryCLIBinaryName(provider)
+	displayName := SummaryProviderErrorLabel(provider)
 
 	cmd := runner(ctx, binary, args...)
 	cmd.Dir = os.TempDir()
@@ -55,38 +92,97 @@ func RunIsolatedTextGeneratorCLI(ctx context.Context, runner TextCommandRunner, 
 	if err := cmd.Run(); err != nil {
 		capturedStderr := strings.TrimSpace(stderr.String())
 		stdoutBytes := stdout.Len()
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return "", capturedStderr, stdoutBytes, context.DeadlineExceeded
-		}
-		if errors.Is(ctx.Err(), context.Canceled) {
-			return "", capturedStderr, stdoutBytes, context.Canceled
-		}
 		var execErr *exec.Error
 		if errors.As(err, &execErr) {
-			return "", capturedStderr, stdoutBytes, fmt.Errorf("%s CLI not found: %w", displayName, err)
+			message := fmt.Sprintf("%s not found: %v", displayName, err)
+			return "", newTextGenerationError(provider, TextGenerationErrorCLIMissing, message, err, capturedStderr, stdoutBytes, -1)
 		}
+
+		detail := capturedStderr
+		if detail == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
+		kind := classifyTextGenerationFailure(provider, detail)
+		underlying := err
+		if kind == TextGenerationErrorUnknown && ctx.Err() != nil {
+			underlying = errors.Join(err, ctx.Err())
+		}
+
+		exitCode := -1
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			detail := capturedStderr
-			if detail == "" {
-				detail = strings.TrimSpace(stdout.String())
-			}
+			exitCode = exitErr.ExitCode()
 			if detail == "" {
 				detail = err.Error()
 			}
-			return "", capturedStderr, stdoutBytes, fmt.Errorf("%s CLI failed (exit %d): %s: %w", displayName, exitErr.ExitCode(), detail, err)
+			message := fmt.Sprintf("%s failed (exit %d): %s", displayName, exitCode, detail)
+			return "", newTextGenerationError(provider, kind, message, underlying, capturedStderr, stdoutBytes, exitCode)
 		}
-		return "", capturedStderr, stdoutBytes, fmt.Errorf("failed to run %s CLI: %w", displayName, err)
+
+		message := fmt.Sprintf("failed to run %s: %v", displayName, err)
+		return "", newTextGenerationError(provider, kind, message, underlying, capturedStderr, stdoutBytes, exitCode)
 	}
 
 	result := strings.TrimSpace(stdout.String())
 	if result == "" {
-		return "", "", 0, fmt.Errorf("%s CLI returned empty output", displayName)
+		capturedStderr := strings.TrimSpace(stderr.String())
+		kind := classifyTextGenerationFailure(provider, capturedStderr)
+		message := displayName + " returned empty output"
+		if capturedStderr != "" {
+			message += ": " + capturedStderr
+		}
+		underlying := errors.New(message)
+		if kind == TextGenerationErrorUnknown && ctx.Err() != nil {
+			underlying = errors.Join(underlying, ctx.Err())
+		}
+		return "", newTextGenerationError(provider, kind, message, underlying, capturedStderr, stdout.Len(), 0)
 	}
-	return result, "", stdout.Len(), nil
+	return result, nil
 }
 
-// summaryProviderBinaries maps agent names to the CLI binary that
+func newTextGenerationError(
+	provider types.AgentName,
+	kind TextGenerationErrorKind,
+	message string,
+	err error,
+	stderr string,
+	stdoutBytes int,
+	exitCode int,
+) *TextGenerationError {
+	if err == nil {
+		err = errors.New(message)
+	}
+	return &TextGenerationError{
+		Err: err, Stderr: stderr, StdoutBytes: stdoutBytes,
+		Provider: provider, Kind: kind, Message: message, ExitCode: exitCode,
+	}
+}
+
+var contextualHTTPStatus = regexp.MustCompile(
+	`(?i)\b(?:http(?:\s+status(?:\s+code)?|\s+response\s+status)?|(?:api|provider)\s+response\s+status|unexpected\s+status|status\s+code)\s*:?\s*(400|401|403|404|429)\b`,
+)
+
+func classifyTextGenerationFailure(provider types.AgentName, message string) TextGenerationErrorKind {
+	if provider == AgentNameGemini && strings.Contains(strings.ToLower(message), "please set an auth method") {
+		return TextGenerationErrorAuth
+	}
+	match := contextualHTTPStatus.FindStringSubmatch(message)
+	if len(match) != 2 {
+		return TextGenerationErrorUnknown
+	}
+	switch match[1] {
+	case "401", "403":
+		return TextGenerationErrorAuth
+	case "429":
+		return TextGenerationErrorRateLimit
+	case "400", "404":
+		return TextGenerationErrorConfig
+	default:
+		return TextGenerationErrorUnknown
+	}
+}
+
+// summaryProviders maps agent names to summary CLI metadata. The binary is what
 // RunIsolatedTextGeneratorCLI will exec. Used by IsSummaryCLIAvailable to
 // check PATH instead of repo-level DetectPresence, because a repo can use
 // one agent for development while a different agent generates summaries.
@@ -95,13 +191,18 @@ func RunIsolatedTextGeneratorCLI(ctx context.Context, runner TextCommandRunner, 
 // Callers outside this package that need the binary name (e.g., the explain
 // diagnostic's "run `claude` directly" suggestion) should use
 // SummaryCLIBinaryName rather than duplicating the mapping.
-var summaryProviderBinaries = map[types.AgentName]string{
-	AgentNameClaudeCode: "claude",
-	AgentNameCodex:      "codex",
-	AgentNameCopilotCLI: "copilot",
-	AgentNameCursor:     "agent",
-	AgentNameGemini:     "gemini",
-	AgentNamePi:         "pi",
+type summaryProviderMetadata struct {
+	binary string
+	label  string
+}
+
+var summaryProviders = map[types.AgentName]summaryProviderMetadata{
+	AgentNameClaudeCode: {binary: "claude", label: "Claude"},
+	AgentNameCodex:      {binary: "codex", label: "Codex"},
+	AgentNameCopilotCLI: {binary: "copilot", label: "Copilot CLI"},
+	AgentNameCursor:     {binary: "agent", label: "Cursor"},
+	AgentNameGemini:     {binary: "gemini", label: "Gemini"},
+	AgentNamePi:         {binary: "pi", label: "Pi"},
 }
 
 // SummaryCLIBinaryName returns the CLI binary name for a summary-capable
@@ -109,7 +210,12 @@ var summaryProviderBinaries = map[types.AgentName]string{
 // agents that are not summary-capable; callers should treat that as "we
 // don't know" rather than guessing.
 func SummaryCLIBinaryName(name types.AgentName) string {
-	return summaryProviderBinaries[name]
+	return summaryProviders[name].binary
+}
+
+// SummaryProviderErrorLabel returns a user-facing provider name.
+func SummaryProviderErrorLabel(name types.AgentName) string {
+	return summaryProviders[name].label
 }
 
 // IsSummaryCLIAvailable reports whether the CLI binary for a summary-capable

--- a/cmd/entire/cli/agent/text_generator_cli_test.go
+++ b/cmd/entire/cli/agent/text_generator_cli_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -475,9 +476,9 @@ func requireTextGenerationError(t *testing.T, err error) *agent.TextGenerationEr
 
 func countConcreteTextGenerationErrors(err error) int {
 	count := 0
+	targetType := reflect.TypeFor[*agent.TextGenerationError]()
 	for err != nil {
-		textGenerationError := &agent.TextGenerationError{}
-		if errors.As(err, &textGenerationError) {
+		if reflect.TypeOf(err) == targetType {
 			count++
 		}
 		err = errors.Unwrap(err)

--- a/cmd/entire/cli/agent/text_generator_cli_test.go
+++ b/cmd/entire/cli/agent/text_generator_cli_test.go
@@ -1,120 +1,507 @@
-package agent
+package agent_test
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
+	"github.com/entireio/cli/cmd/entire/cli/agent/copilotcli"
+	"github.com/entireio/cli/cmd/entire/cli/agent/cursor"
+	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 )
 
-const windowsOS = "windows"
+const textGeneratorHelperTest = "TestTextGeneratorCLIHelperProcess"
+const textGeneratorHelperMarker = "__entire_text_generator_helper__"
 
-func TestRunIsolatedTextGeneratorCLI_EmptyOutput(t *testing.T) {
-	t.Parallel()
-
-	runner := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "echo", "-n", "")
-	}
-	// On some systems echo -n "" still prints a newline; use printf for reliable empty output
-	if runtime.GOOS != windowsOS {
-		runner = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			return exec.CommandContext(ctx, "printf", "")
+// TestTextGeneratorCLIHelperProcess is the subprocess entrypoint used by this
+// file's tests. It must not call t.Parallel because helper modes call os.Exit.
+func TestTextGeneratorCLIHelperProcess(_ *testing.T) {
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
 		}
 	}
-	_, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), runner, "test", "test-agent", nil, "")
-	if err == nil {
-		t.Fatal("expected error for empty output")
+	if separator == -1 {
+		return
 	}
-	if !strings.Contains(err.Error(), "test-agent CLI returned empty output") {
-		t.Fatalf("error = %q, want it to contain %q", err.Error(), "test-agent CLI returned empty output")
+
+	args := os.Args[separator+1:]
+	if len(args) == 0 || args[0] != textGeneratorHelperMarker {
+		return
+	}
+	args = args[1:]
+	if len(args) == 0 {
+		os.Exit(2)
+	}
+
+	switch args[0] {
+	case "success":
+		if _, err := io.Copy(os.Stdout, os.Stdin); err != nil {
+			os.Exit(3)
+		}
+		os.Exit(0)
+	case "empty-stderr":
+		_, _ = fmt.Fprint(os.Stderr, helperArg(args, 1))
+		os.Exit(0)
+	case "stderr-failure":
+		_, _ = fmt.Fprint(os.Stderr, helperArg(args, 1))
+		os.Exit(23)
+	case "stdout-failure":
+		_, _ = fmt.Fprint(os.Stdout, helperArg(args, 1))
+		os.Exit(23)
+	case "blocking":
+		time.Sleep(time.Hour)
+	default:
+		os.Exit(2)
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_NonZeroExit(t *testing.T) {
-	t.Parallel()
+func helperArg(args []string, index int) string {
+	if index >= len(args) {
+		return ""
+	}
+	return args[index]
+}
 
-	runner := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "sh", "-c", "echo 'some error' >&2; exit 1")
-	}
-	_, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), runner, "test", "myagent", nil, "")
-	if err == nil {
-		t.Fatal("expected error for non-zero exit")
-	}
-	errMsg := err.Error()
-	if !strings.Contains(errMsg, "myagent CLI failed (exit 1)") {
-		t.Fatalf("error = %q, want it to contain exit code info", errMsg)
-	}
-	if !strings.Contains(errMsg, "some error") {
-		t.Fatalf("error = %q, want it to contain stderr detail", errMsg)
+func helperRunner(mode string, details ...string) agent.TextCommandRunner {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		args := []string{"-test.run=^" + textGeneratorHelperTest + "$", "--", textGeneratorHelperMarker, mode}
+		args = append(args, details...)
+		return exec.CommandContext(ctx, os.Args[0], args...)
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_NonZeroExitFallsBackToStdout(t *testing.T) {
-	t.Parallel()
-
-	runner := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "sh", "-c", "echo 'stdout detail'; exit 1")
-	}
-	_, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), runner, "test", "myagent", nil, "")
-	if err == nil {
-		t.Fatal("expected error for non-zero exit")
-	}
-	if !strings.Contains(err.Error(), "stdout detail") {
-		t.Fatalf("error = %q, want it to contain stdout as fallback detail", err.Error())
+func detachedHelperRunner(mode string, details ...string) agent.TextCommandRunner {
+	return func(context.Context, string, ...string) *exec.Cmd {
+		args := []string{"-test.run=^" + textGeneratorHelperTest + "$", "--", textGeneratorHelperMarker, mode}
+		args = append(args, details...)
+		return exec.CommandContext(context.Background(), os.Args[0], args...)
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_BinaryNotFound(t *testing.T) {
+func TestSummaryProviderMetadata(t *testing.T) {
 	t.Parallel()
 
-	_, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), nil, "nonexistent-binary-12345", "myagent", nil, "")
-	if err == nil {
-		t.Fatal("expected error for missing binary")
+	tests := []struct {
+		provider types.AgentName
+		binary   string
+		label    string
+	}{
+		{provider: agent.AgentNameClaudeCode, binary: "claude", label: "Claude"},
+		{provider: agent.AgentNameCodex, binary: "codex", label: "Codex"},
+		{provider: agent.AgentNameCopilotCLI, binary: "copilot", label: "Copilot CLI"},
+		{provider: agent.AgentNameCursor, binary: "agent", label: "Cursor"},
+		{provider: agent.AgentNameGemini, binary: "gemini", label: "Gemini"},
+		{provider: agent.AgentNamePi, binary: "pi", label: "Pi"},
 	}
-	if !strings.Contains(err.Error(), "myagent CLI not found") {
-		t.Fatalf("error = %q, want it to contain 'not found'", err.Error())
+
+	for _, test := range tests {
+		t.Run(string(test.provider), func(t *testing.T) {
+			t.Parallel()
+			if got := agent.SummaryCLIBinaryName(test.provider); got != test.binary {
+				t.Errorf("SummaryCLIBinaryName(%q) = %q, want %q", test.provider, got, test.binary)
+			}
+			if got := agent.SummaryProviderErrorLabel(test.provider); got != test.label {
+				t.Errorf("SummaryProviderErrorLabel(%q) = %q, want %q", test.provider, got, test.label)
+			}
+		})
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_NilRunnerDefaultsToExec(t *testing.T) {
+func TestRunIsolatedTextGeneratorCLI_ClassifiesContextualHTTPStatus(t *testing.T) {
 	t.Parallel()
 
-	// With nil runner, it defaults to exec.CommandContext, so "echo" should work
-	result, _, _, err := RunIsolatedTextGeneratorCLI(context.Background(), nil, "echo", "echo", []string{"hello"}, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		message string
+		kind    agent.TextGenerationErrorKind
+	}{
+		{message: "HTTP 401 Unauthorized", kind: agent.TextGenerationErrorAuth},
+		{message: "HTTP status 403", kind: agent.TextGenerationErrorAuth},
+		{message: "HTTP status code 429", kind: agent.TextGenerationErrorRateLimit},
+		{message: "status code 400", kind: agent.TextGenerationErrorConfig},
+		{message: "unexpected status 401 Unauthorized", kind: agent.TextGenerationErrorAuth},
+		{message: "provider response status 404", kind: agent.TextGenerationErrorConfig},
+		{message: "API response status: 429", kind: agent.TextGenerationErrorRateLimit},
 	}
-	if result != "hello" {
-		t.Fatalf("result = %q, want %q", result, "hello")
+
+	for _, test := range tests {
+		t.Run(test.message, func(t *testing.T) {
+			t.Parallel()
+			_, err := agent.RunIsolatedTextGeneratorCLI(
+				context.Background(), helperRunner("stderr-failure", test.message), agent.AgentNameCodex, nil, "",
+			)
+			failure := requireTextGenerationError(t, err)
+			if failure.Kind != test.kind {
+				t.Errorf("Kind = %v, want %v (error: %v)", failure.Kind, test.kind, err)
+			}
+		})
 	}
 }
 
-func TestRunIsolatedTextGeneratorCLI_CanceledContextPreservesSentinel(t *testing.T) {
+func TestRunIsolatedTextGeneratorCLI_DoesNotClassifyBareNumbers(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS == windowsOS {
-		t.Skip("uses POSIX shell command")
+	tests := []string{
+		"bare 404",
+		"worker 404 failed to start",
+		"exit status 404",
+		"port 14010",
+		"took 429ms",
+		"request-id=abc-401-def",
 	}
 
-	runner := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, "sh", "-c", "sleep 10")
+	for _, message := range tests {
+		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+			_, err := agent.RunIsolatedTextGeneratorCLI(
+				context.Background(), helperRunner("stderr-failure", message), agent.AgentNameCodex, nil, "",
+			)
+			failure := requireTextGenerationError(t, err)
+			if failure.Kind != agent.TextGenerationErrorUnknown {
+				t.Errorf("Kind = %v, want Unknown (error: %v)", failure.Kind, err)
+			}
+		})
+	}
+}
+
+func TestRunIsolatedTextGeneratorCLI_FallbackContract(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing binary", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "definitely-not-installed-summary-cli")
+			}, agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorCLIMissing {
+			t.Errorf("Kind = %v, want CLIMissing", failure.Kind)
+		}
+		if failure.Provider != agent.AgentNameCodex {
+			t.Errorf("Provider = %q, want %q", failure.Provider, agent.AgentNameCodex)
+		}
+	})
+
+	t.Run("provider label is not duplicated", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "definitely-not-installed-summary-cli")
+			}, agent.AgentNameCopilotCLI, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if strings.Contains(failure.Message, "CLI CLI") {
+			t.Errorf("Message = %q, contains duplicated CLI label", failure.Message)
+		}
+	})
+
+	t.Run("auth stderr", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("stderr-failure", "HTTP 401 Unauthorized"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorAuth {
+			t.Errorf("Kind = %v, want Auth", failure.Kind)
+		}
+		if failure.ExitCode != 23 {
+			t.Errorf("ExitCode = %d, want 23", failure.ExitCode)
+		}
+		if failure.Stderr != "HTTP 401 Unauthorized" {
+			t.Errorf("Stderr = %q, want captured auth stderr", failure.Stderr)
+		}
+	})
+
+	t.Run("generic nonzero", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("stderr-failure", "provider exploded"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorUnknown {
+			t.Errorf("Kind = %v, want Unknown", failure.Kind)
+		}
+		if !strings.Contains(failure.Message, "provider exploded") {
+			t.Errorf("Message = %q, want stderr detail", failure.Message)
+		}
+	})
+
+	t.Run("stdout fallback", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("stdout-failure", "stdout detail"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.StdoutBytes != len("stdout detail") {
+			t.Errorf("StdoutBytes = %d, want %d", failure.StdoutBytes, len("stdout detail"))
+		}
+		if !strings.Contains(failure.Message, "stdout detail") {
+			t.Errorf("Message = %q, want stdout fallback detail", failure.Message)
+		}
+	})
+
+	t.Run("cancellation", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+		}()
+		_, err := agent.RunIsolatedTextGeneratorCLI(ctx, helperRunner("blocking"), agent.AgentNameCodex, nil, "")
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorUnknown {
+			t.Errorf("Kind = %v, want Unknown", failure.Kind)
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled in chain", err)
+		}
+	})
+
+	t.Run("deadline", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		t.Cleanup(cancel)
+		_, err := agent.RunIsolatedTextGeneratorCLI(ctx, helperRunner("blocking"), agent.AgentNameCodex, nil, "")
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorUnknown {
+			t.Errorf("Kind = %v, want Unknown", failure.Kind)
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("err = %v, want context.DeadlineExceeded in chain", err)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		result, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("success"), agent.AgentNameCodex, nil, "generated summary\n",
+		)
+		if err != nil {
+			t.Fatalf("RunIsolatedTextGeneratorCLI() error = %v", err)
+		}
+		if result != "generated summary" {
+			t.Errorf("result = %q, want %q", result, "generated summary")
+		}
+	})
+
+	t.Run("empty stdout with recognized auth stderr", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("empty-stderr", "HTTP status 401"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorAuth {
+			t.Errorf("Kind = %v, want Auth", failure.Kind)
+		}
+		if failure.Stderr != "HTTP status 401" {
+			t.Errorf("Stderr = %q, want retained stderr", failure.Stderr)
+		}
+	})
+
+	t.Run("empty stdout with generic stderr", func(t *testing.T) {
+		t.Parallel()
+		_, err := agent.RunIsolatedTextGeneratorCLI(
+			context.Background(), helperRunner("empty-stderr", "diagnostic detail"), agent.AgentNameCodex, nil, "",
+		)
+		failure := requireTextGenerationError(t, err)
+		if failure.Kind != agent.TextGenerationErrorUnknown {
+			t.Errorf("Kind = %v, want Unknown", failure.Kind)
+		}
+		if failure.Stderr != "diagnostic detail" {
+			t.Errorf("Stderr = %q, want retained stderr", failure.Stderr)
+		}
+		if !strings.Contains(failure.Message, "diagnostic detail") {
+			t.Errorf("Message = %q, want retained stderr detail", failure.Message)
+		}
+	})
+}
+
+func TestRunIsolatedTextGeneratorCLI_SpecificProviderSignalOutranksContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		newCtx   func(t *testing.T) context.Context
+		sentinel error
+	}{
+		{
+			name: "cancellation",
+			newCtx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
+				cancel()
+				return ctx
+			},
+			sentinel: context.Canceled,
+		},
+		{
+			name: "deadline",
+			newCtx: func(t *testing.T) context.Context {
+				t.Helper()
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+				t.Cleanup(cancel)
+				return ctx
+			},
+			sentinel: context.DeadlineExceeded,
+		},
 	}
 
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := test.newCtx(t)
+			_, err := agent.RunIsolatedTextGeneratorCLI(
+				ctx, detachedHelperRunner("stderr-failure", "HTTP 401 Unauthorized"), agent.AgentNameCodex, nil, "",
+			)
+			failure := requireTextGenerationError(t, err)
+			if failure.Kind != agent.TextGenerationErrorAuth {
+				t.Errorf("Kind = %v, want Auth (error: %v)", failure.Kind, err)
+			}
+			if errors.Is(err, test.sentinel) {
+				t.Errorf("specific provider error should outrank %v: %v", test.sentinel, err)
+			}
+		})
+	}
+}
+
+func TestRunIsolatedTextGeneratorCLI_UnknownFailurePreservesCompletedContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		sentinel error
+	}{
+		{name: "cancellation", ctx: canceledContext(), sentinel: context.Canceled},
+		{name: "deadline", ctx: expiredContext(), sentinel: context.DeadlineExceeded},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := agent.RunIsolatedTextGeneratorCLI(
+				test.ctx, detachedHelperRunner("stderr-failure", "provider exploded"), agent.AgentNameCodex, nil, "",
+			)
+			failure := requireTextGenerationError(t, err)
+			if failure.Kind != agent.TextGenerationErrorUnknown {
+				t.Errorf("Kind = %v, want Unknown", failure.Kind)
+			}
+			if !errors.Is(err, test.sentinel) {
+				t.Errorf("err = %v, want %v in chain", err, test.sentinel)
+			}
+			var exitErr *exec.ExitError
+			if !errors.As(err, &exitErr) {
+				t.Errorf("err = %v, want subprocess cause preserved", err)
+			}
+		})
+	}
+}
+
+func canceledContext() context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		cancel()
-	}()
+	cancel()
+	return ctx
+}
 
-	_, _, _, err := RunIsolatedTextGeneratorCLI(ctx, runner, "test", "test", nil, "")
-	if err == nil {
-		t.Fatal("expected cancellation error")
+func expiredContext() context.Context {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	cancel()
+	return ctx
+}
+
+func TestRunIsolatedTextGeneratorCLI_GeminiAuthPhrase(t *testing.T) {
+	t.Parallel()
+
+	_, err := agent.RunIsolatedTextGeneratorCLI(
+		context.Background(), helperRunner("stderr-failure", "Please set an Auth method"), agent.AgentNameGemini, nil, "",
+	)
+	failure := requireTextGenerationError(t, err)
+	if failure.Kind != agent.TextGenerationErrorAuth {
+		t.Errorf("Kind = %v, want Auth", failure.Kind)
 	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context.Canceled, got %v", err)
+}
+
+func TestFallbackGeneratorsContainExactlyOneTextGenerationError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		generator agent.TextGenerator
+	}{
+		{name: "codex", generator: &codex.CodexAgent{CommandRunner: helperRunner("stderr-failure", "HTTP 401 Unauthorized")}},
+		{name: "copilot", generator: &copilotcli.CopilotCLIAgent{CommandRunner: helperRunner("stderr-failure", "HTTP 401 Unauthorized")}},
+		{name: "cursor", generator: &cursor.CursorAgent{CommandRunner: helperRunner("stderr-failure", "HTTP 401 Unauthorized")}},
+		{name: "gemini", generator: &geminicli.GeminiCLIAgent{CommandRunner: helperRunner("stderr-failure", "HTTP 401 Unauthorized")}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := test.generator.GenerateText(context.Background(), "prompt", "")
+			if count := countConcreteTextGenerationErrors(err); count != 1 {
+				t.Fatalf("TextGenerationError count = %d, want 1 (chain: %v)", count, err)
+			}
+		})
+	}
+}
+
+func requireTextGenerationError(t *testing.T, err error) *agent.TextGenerationError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var failure *agent.TextGenerationError
+	if !errors.As(err, &failure) {
+		t.Fatalf("err = %T %v, want *TextGenerationError", err, err)
+	}
+	if failure.Err == nil {
+		t.Fatal("TextGenerationError.Err must be non-nil")
+	}
+	return failure
+}
+
+func countConcreteTextGenerationErrors(err error) int {
+	count := 0
+	for err != nil {
+		textGenerationError := &agent.TextGenerationError{}
+		if errors.As(err, &textGenerationError) {
+			count++
+		}
+		err = errors.Unwrap(err)
+	}
+	return count
+}
+
+func TestTextGenerationError_DefensiveNilReceiverAndErr(t *testing.T) {
+	t.Parallel()
+
+	var nilFailure *agent.TextGenerationError
+	if got := nilFailure.Error(); got == "" {
+		t.Error("nil receiver Error() returned an empty message")
+	}
+	if err := nilFailure.Unwrap(); err != nil {
+		t.Errorf("nil receiver Unwrap() = %v, want nil", err)
+	}
+
+	failure := &agent.TextGenerationError{Message: "fallback message"}
+	if got := failure.Error(); got != "fallback message" {
+		t.Errorf("Error() = %q, want %q", got, "fallback message")
+	}
+	if err := failure.Unwrap(); err != nil {
+		t.Errorf("Unwrap() = %v, want nil", err)
 	}
 }
 
@@ -128,11 +515,11 @@ func TestStripGitEnv(t *testing.T) {
 		"GIT_WORK_TREE=/some/tree",
 		"EDITOR=vim",
 	}
-	filtered := StripGitEnv(env)
+	filtered := agent.StripGitEnv(env)
 
-	for _, e := range filtered {
-		if strings.HasPrefix(e, "GIT_") {
-			t.Fatalf("GIT_ variable not stripped: %s", e)
+	for _, entry := range filtered {
+		if strings.HasPrefix(entry, "GIT_") {
+			t.Fatalf("GIT_ variable not stripped: %s", entry)
 		}
 	}
 	if len(filtered) != 3 {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1161,13 +1161,13 @@ func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, [
 		return formatProviderSummaryError(providerErr, attempt)
 	case errors.Is(err, context.DeadlineExceeded):
 		label, rows := timeoutDiagnostic(err, attempt)
-		structured := errors.New("summary generation timed out")
+		message := "summary generation timed out"
 		if attempt.deadline > 0 {
-			structured = fmt.Errorf("summary generation did not return within the %s safety deadline", formatSummaryTimeout(attempt.deadline))
+			message = fmt.Sprintf("summary generation did not return within the %s safety deadline", formatSummaryTimeout(attempt.deadline))
 		}
-		return label, rows, structured
+		return label, rows, newFormattedProviderError(message, err)
 	case errors.Is(err, context.Canceled):
-		return "Summary generation canceled", nil, errors.New("summary generation canceled")
+		return "Summary generation canceled", nil, newFormattedProviderError("summary generation canceled", err)
 	case providerErr != nil:
 		return formatProviderSummaryError(providerErr, attempt)
 	default:

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1057,6 +1057,9 @@ func generateCheckpointAISummary(ctx context.Context, scopedTranscript []byte, f
 	if timeout > 0 {
 		runCtx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
+		if deadline, ok := runCtx.Deadline(); ok {
+			attempt.deadline = time.Until(deadline)
+		}
 	}
 
 	// scopedTranscript is either read from checkpoint storage (redacted on
@@ -1088,7 +1091,7 @@ func generateCheckpointAISummary(ctx context.Context, scopedTranscript []byte, f
 		// timeout was actually the cause.
 		if errors.Is(err, context.DeadlineExceeded) {
 			if timeout > 0 {
-				return nil, fmt.Errorf("summary generation timed out after %s: %w", formatSummaryTimeout(timeout), context.DeadlineExceeded)
+				return nil, fmt.Errorf("summary generation timed out after %s: %w", formatSummaryTimeout(attempt.deadline), context.DeadlineExceeded)
 			}
 			return nil, fmt.Errorf("summary generation timed out (parent context deadline): %w", context.DeadlineExceeded)
 		}
@@ -1405,8 +1408,12 @@ func (s *summaryProgressWriter) shouldEmitGenerating(p agent.GenerationProgress)
 
 func (s *summaryProgressWriter) handle(p agent.GenerationProgress) {
 	if s.attempt != nil {
-		s.attempt.streaming = true
-		s.attempt.phasesReached[p.Phase] = true
+		if p.StreamingMode != nil {
+			s.attempt.streaming = *p.StreamingMode
+		}
+		if p.Phase != "" {
+			s.attempt.phasesReached[p.Phase] = true
+		}
 	}
 
 	switch p.Phase {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1110,7 +1110,7 @@ func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, [
 	var claudeErr *claudecode.ClaudeError
 	switch {
 	case errors.As(err, &claudeErr):
-		switch claudeErr.Kind { //nolint:exhaustive // ClaudeErrorUnknown handled by default
+		switch claudeErr.Kind {
 		case claudecode.ClaudeErrorAuth:
 			label := "Claude authentication failed"
 			rows := []explainRow{
@@ -1435,9 +1435,16 @@ func (s *summaryProgressWriter) handle(p agent.GenerationProgress) {
 			"%s Writing summary... (~%s tokens)",
 			s.arrow, formatTokenCount(p.OutputTokens)))
 	case agent.PhaseDone:
+		clauses := []string{
+			formatMs(p.DurationMs),
+			formatTokenCount(p.OutputTokens) + " output tokens",
+		}
+		if p.CachedInputTokens > 0 {
+			clauses = append(clauses, formatTokenCount(p.CachedInputTokens)+" cached input tokens")
+		}
 		s.printLine(fmt.Sprintf(
-			"%s Summary generated (%s, %s output tokens)",
-			s.check, formatMs(p.DurationMs), formatTokenCount(p.OutputTokens)))
+			"%s Summary generated (%s)",
+			s.check, strings.Join(clauses, ", ")))
 	}
 }
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1110,7 +1110,7 @@ func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, [
 	var claudeErr *claudecode.ClaudeError
 	switch {
 	case errors.As(err, &claudeErr):
-		switch claudeErr.Kind {
+		switch claudeErr.Kind { //nolint:exhaustive // ClaudeErrorUnknown handled by default
 		case claudecode.ClaudeErrorAuth:
 			label := "Claude authentication failed"
 			rows := []explainRow{

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -919,6 +919,12 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store che
 	}
 	provider, err := resolveCheckpointSummaryProvider(ctx, w)
 	if err != nil {
+		var providerFailure *agent.TextGenerationError
+		if errors.As(err, &providerFailure) {
+			attempt := newSummaryAttempt(providerFailure.Provider, 0)
+			label, rows, structured := formatCheckpointSummaryError(err, attempt)
+			return renderExplainFailure(errW, label, rows, structured)
+		}
 		return fmt.Errorf("failed to resolve summary provider: %w", err)
 	}
 	scopedTranscript = maybeCompactExternalTranscript(ctx, scopedTranscript, content.Metadata.Agent)
@@ -944,9 +950,7 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store che
 	if err != nil {
 		progressWriter.Flush()
 		label, rows, structured := formatCheckpointSummaryError(err, attempt)
-		styles := newStatusStyles(errW)
-		fmt.Fprint(errW, styles.renderFailure(label, rows))
-		return NewSilentError(structured)
+		return renderExplainFailure(errW, label, rows, structured)
 	}
 	elapsed := time.Since(start)
 
@@ -1111,6 +1115,7 @@ func generateCheckpointAISummary(ctx context.Context, scopedTranscript []byte, f
 // letting the caller still return a *SilentError for main.go's exit handling.
 func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, []explainRow, error) {
 	var claudeErr *claudecode.ClaudeError
+	var providerErr *agent.TextGenerationError
 	switch {
 	case errors.As(err, &claudeErr):
 		switch claudeErr.Kind { //nolint:exhaustive // ClaudeErrorUnknown handled by default
@@ -1152,6 +1157,8 @@ func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, [
 			}
 			return label, rows, fmt.Errorf("Claude failed to generate the summary%s", suffix) //nolint:staticcheck // ST1005
 		}
+	case errors.As(err, &providerErr) && providerErr.Kind != agent.TextGenerationErrorUnknown:
+		return formatProviderSummaryError(providerErr, attempt)
 	case errors.Is(err, context.DeadlineExceeded):
 		label, rows := timeoutDiagnostic(err, attempt)
 		structured := errors.New("summary generation timed out")
@@ -1161,8 +1168,87 @@ func formatCheckpointSummaryError(err error, attempt *summaryAttempt) (string, [
 		return label, rows, structured
 	case errors.Is(err, context.Canceled):
 		return "Summary generation canceled", nil, errors.New("summary generation canceled")
+	case providerErr != nil:
+		return formatProviderSummaryError(providerErr, attempt)
 	default:
 		return "Failed to generate summary", []explainRow{{Label: "detail", Value: err.Error()}}, fmt.Errorf("failed to generate summary: %w", err)
+	}
+}
+
+func formatProviderSummaryError(failure *agent.TextGenerationError, attempt *summaryAttempt) (string, []explainRow, error) {
+	displayName := summaryProviderErrorLabel(failure.Provider, attempt)
+	if failure.Kind == agent.TextGenerationErrorCLIMissing {
+		label := displayName + " CLI is not installed or not on PATH"
+		if strings.HasSuffix(displayName, " CLI") {
+			label = displayName + " is not installed or not on PATH"
+		}
+		return label, nil, newFormattedProviderError(label, failure)
+	}
+
+	label := displayName + " failed to generate the summary"
+	switch failure.Kind { //nolint:exhaustive // Unknown and future kinds use the generic provider label.
+	case agent.TextGenerationErrorAuth:
+		label = displayName + " authentication failed"
+	case agent.TextGenerationErrorRateLimit:
+		label = displayName + " rejected the summary request due to rate limits or quota"
+	case agent.TextGenerationErrorConfig:
+		label = displayName + " rejected the summary request"
+	}
+
+	if failure.Kind != agent.TextGenerationErrorUnknown {
+		if failure.Message == "" {
+			return label, nil, newFormattedProviderError(label, failure)
+		}
+		return label,
+			[]explainRow{{Label: "message", Value: failure.Message}},
+			newFormattedProviderError(fmt.Sprintf("%s: %s", label, failure.Message), failure)
+	}
+
+	detail := providerFailureDetail(failure, displayName)
+	return label,
+		[]explainRow{{Label: "detail", Value: detail}},
+		newFormattedProviderError(fmt.Sprintf("%s: %s", label, detail), failure)
+}
+
+type formattedProviderError struct {
+	message string
+	cause   error
+}
+
+func (e *formattedProviderError) Error() string { return e.message }
+func (e *formattedProviderError) Unwrap() error { return e.cause }
+
+func newFormattedProviderError(message string, cause error) error {
+	return &formattedProviderError{message: message, cause: cause}
+}
+
+func summaryProviderErrorLabel(provider types.AgentName, attempt *summaryAttempt) string {
+	if provider == "" && attempt != nil {
+		provider = attempt.provider
+	}
+	if label := agent.SummaryProviderErrorLabel(provider); label != "" {
+		return label
+	}
+	if provider != "" {
+		return string(provider)
+	}
+	return "Provider"
+}
+
+func providerFailureDetail(failure *agent.TextGenerationError, displayName string) string {
+	switch {
+	case failure.Message != "":
+		return failure.Message
+	case strings.TrimSpace(failure.Stderr) != "":
+		return strings.TrimSpace(failure.Stderr)
+	case failure.Err != nil:
+		return failure.Err.Error()
+	case failure.ExitCode > 0:
+		return fmt.Sprintf("%s CLI exited with code %d", displayName, failure.ExitCode)
+	case failure.ExitCode < 0:
+		return displayName + " CLI terminated abnormally — no exit code captured"
+	default:
+		return "no diagnostic detail available from " + displayName + " CLI"
 	}
 }
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1413,9 +1413,20 @@ func (s *summaryProgressWriter) handle(p agent.GenerationProgress) {
 	case agent.PhaseConnecting:
 		s.printLine(s.arrow + " Sending request to provider...")
 	case agent.PhaseFirstToken:
+		var clauses []string
+		if p.TTFTms > 0 {
+			clauses = append(clauses, "TTFT "+formatMs(p.TTFTms))
+		}
+		if p.CachedInputTokens > 0 {
+			clauses = append(clauses, formatTokenCount(p.CachedInputTokens)+" cached input tokens")
+		}
+		detail := ""
+		if len(clauses) > 0 {
+			detail = " (" + strings.Join(clauses, ", ") + ")"
+		}
 		s.printLine(fmt.Sprintf(
-			"%s Provider responded (TTFT %s, %s cached input tokens) -- generating...",
-			s.arrow, formatMs(p.TTFTms), formatTokenCount(p.CachedInputTokens)))
+			"%s Provider responded%s -- generating...",
+			s.arrow, detail))
 	case agent.PhaseGenerating:
 		if !s.shouldEmitGenerating(p) {
 			return

--- a/cmd/entire/cli/explain_summary_provider.go
+++ b/cmd/entire/cli/explain_summary_provider.go
@@ -204,7 +204,13 @@ func ensureSummaryProviderPresent(_ context.Context, name types.AgentName) error
 		return fmt.Errorf("agent %s does not support summary generation", name)
 	}
 	if !isSummaryProviderAvailable(name, ag) {
-		return fmt.Errorf("summary provider %q is configured but its CLI binary is not on PATH; install it or update summary_generation.provider in settings", name)
+		cause := fmt.Errorf("summary provider %q is configured but its CLI binary is not on PATH", name)
+		return &agent.TextGenerationError{
+			Err:      cause,
+			Provider: name,
+			Kind:     agent.TextGenerationErrorCLIMissing,
+			Message:  cause.Error(),
+		}
 	}
 	return nil
 }

--- a/cmd/entire/cli/explain_summary_provider_test.go
+++ b/cmd/entire/cli/explain_summary_provider_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/summarize"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 func rowsContain(rows []explainRow, label, value string) bool {
@@ -303,6 +304,31 @@ func TestResolveCheckpointSummaryProvider_ConfiguredProviderNotInstalledReturnsE
 	if !strings.Contains(err.Error(), "not on PATH") {
 		t.Fatalf("unexpected error text: %v", err)
 	}
+}
+
+func TestEnsureSummaryProviderPresent_MissingCLIIsTyped(t *testing.T) {
+	// Cannot use t.Parallel() because package-level lookup functions are stubbed.
+	originalGet := getSummaryAgent
+	originalCLI := isSummaryCLIAvailable
+	t.Cleanup(func() {
+		getSummaryAgent = originalGet
+		isSummaryCLIAvailable = originalCLI
+	})
+
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		return &stubTextAgent{name: name, kind: agent.AgentTypeCodex}, nil
+	}
+	isSummaryCLIAvailable = func(types.AgentName) bool { return false }
+
+	err := ensureSummaryProviderPresent(context.Background(), agent.AgentNameCodex)
+	var failure *agent.TextGenerationError
+	require.ErrorAs(t, err, &failure)
+	require.Equal(t, agent.AgentNameCodex, failure.Provider)
+	require.Equal(t, agent.TextGenerationErrorCLIMissing, failure.Kind)
+	require.Error(t, failure.Err)
+	require.Empty(t, failure.Stderr)
+	require.Zero(t, failure.StdoutBytes)
+	require.Zero(t, failure.ExitCode)
 }
 
 func TestResolveCheckpointSummaryProvider_ConfiguredExternalProvider(t *testing.T) {

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -943,7 +943,7 @@ func TestGenerateCheckpointAISummary_StreamingTimeoutBeforeFirstEvent(t *testing
 
 	streamer := &codex.CodexAgent{
 		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
-			return exec.CommandContext(ctx, "sh", "-c", "sleep 10")
+			return agenttestutil.BlockingCmd(ctx)
 		},
 	}
 	generator := &summarize.TextGeneratorAdapter{TextGenerator: streamer}
@@ -977,7 +977,7 @@ func TestGenerateCheckpointAISummary_FallbackTimeoutUsesNonStreamingDiagnostic(t
 			if calls == 1 {
 				return streamCall(ctx, name, args...)
 			}
-			return exec.CommandContext(ctx, "sh", "-c", "sleep 10")
+			return agenttestutil.BlockingCmd(ctx)
 		},
 	}
 	generator := &summarize.TextGeneratorAdapter{TextGenerator: streamer}

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -5903,6 +5903,52 @@ func TestSummaryProgressWriter_FirstTokenWithOnlyCachedTokens(t *testing.T) {
 	}
 }
 
+func TestSummaryProgressWriter_DoneWithCachedTokens(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	attempt := newSummaryAttempt("cursor", 0)
+	pw := newSummaryProgressWriter(&buf, attempt)
+
+	pw.handle(agent.GenerationProgress{
+		Phase:             agent.PhaseDone,
+		DurationMs:        10700,
+		OutputTokens:      1600,
+		CachedInputTokens: 4608,
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "1.6k output tokens") {
+		t.Errorf("output = %q, want '1.6k output tokens' clause", out)
+	}
+	if !strings.Contains(out, "4.6k cached input tokens") {
+		t.Errorf("output = %q, want '4.6k cached input tokens' clause when CachedInputTokens > 0", out)
+	}
+}
+
+func TestSummaryProgressWriter_DoneWithoutCachedTokens(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	attempt := newSummaryAttempt("gemini", 0)
+	pw := newSummaryProgressWriter(&buf, attempt)
+
+	pw.handle(agent.GenerationProgress{
+		Phase:        agent.PhaseDone,
+		DurationMs:   10700,
+		OutputTokens: 1600,
+		// CachedInputTokens: 0 — omitted
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "1.6k output tokens") {
+		t.Errorf("output = %q, want '1.6k output tokens' clause", out)
+	}
+	if strings.Contains(out, "cached input tokens") {
+		t.Errorf("output = %q, should not include cached tokens clause when CachedInputTokens == 0", out)
+	}
+}
+
 func TestSummaryProgressWriter_Accessible(t *testing.T) {
 	// Cannot use t.Parallel() — t.Setenv mutates process-global state.
 	// (Strictly, t.Setenv IS compatible with t.Parallel() in Go 1.17+ when

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -5867,6 +5867,42 @@ func TestSummaryProgressWriter_NonTTYGenerateThrottle(t *testing.T) {
 	}
 }
 
+func TestSummaryProgressWriter_FirstTokenWithoutOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	attempt := newSummaryAttempt("gemini-cli", 0)
+	pw := newSummaryProgressWriter(&buf, attempt)
+
+	pw.handle(agent.GenerationProgress{Phase: agent.PhaseFirstToken})
+
+	out := buf.String()
+	if !strings.Contains(out, "Provider responded -- generating...") {
+		t.Errorf("output = %q, want 'Provider responded -- generating...' (no parens)", out)
+	}
+	if strings.Contains(out, "(") {
+		t.Errorf("output = %q, should not contain '(' when both fields are zero", out)
+	}
+}
+
+func TestSummaryProgressWriter_FirstTokenWithOnlyCachedTokens(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	attempt := newSummaryAttempt("codex", 0)
+	pw := newSummaryProgressWriter(&buf, attempt)
+
+	pw.handle(agent.GenerationProgress{Phase: agent.PhaseFirstToken, CachedInputTokens: 23808})
+
+	out := buf.String()
+	if !strings.Contains(out, "Provider responded (23.8k cached input tokens) -- generating...") {
+		t.Errorf("output = %q, want '(23.8k cached input tokens)' clause", out)
+	}
+	if strings.Contains(out, "TTFT") {
+		t.Errorf("output = %q, should not mention TTFT when TTFTms == 0", out)
+	}
+}
+
 func TestSummaryProgressWriter_Accessible(t *testing.T) {
 	// Cannot use t.Parallel() — t.Setenv mutates process-global state.
 	// (Strictly, t.Setenv IS compatible with t.Parallel() in Go 1.17+ when

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -18,6 +18,8 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
+	agenttestutil "github.com/entireio/cli/cmd/entire/cli/agent/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
@@ -932,6 +934,68 @@ func TestGenerateCheckpointAISummary_NoTimeoutInheritsParent(t *testing.T) {
 	}
 }
 
+// Cannot use t.Parallel() — mutates package-level generateTranscriptSummary.
+func TestGenerateCheckpointAISummary_StreamingTimeoutBeforeFirstEvent(t *testing.T) {
+	tmpGenerator := generateTranscriptSummary
+	t.Cleanup(func() { generateTranscriptSummary = tmpGenerator })
+
+	generateTranscriptSummary = summarize.GenerateFromTranscript
+
+	streamer := &codex.CodexAgent{
+		CommandRunner: func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "sh", "-c", "sleep 10")
+		},
+	}
+	generator := &summarize.TextGeneratorAdapter{TextGenerator: streamer}
+	attempt := newSummaryAttempt("codex", 50*time.Millisecond)
+	progress := newSummaryProgressWriter(io.Discard, attempt)
+
+	_, err := generateCheckpointAISummary(
+		context.Background(), []byte(`{"type":"user","message":{"role":"user","content":"summarize"}}`+"\n"), nil, agent.AgentTypeClaudeCode,
+		generator, 50*time.Millisecond, progress.handle, attempt,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.True(t, attempt.streaming, "streaming mode must be known before the first provider event")
+	require.Empty(t, attempt.phasesReached)
+
+	label, _ := timeoutDiagnostic(err, attempt)
+	require.Contains(t, label, "never sent its request")
+}
+
+// Cannot use t.Parallel() — mutates package-level generateTranscriptSummary.
+func TestGenerateCheckpointAISummary_FallbackTimeoutUsesNonStreamingDiagnostic(t *testing.T) {
+	tmpGenerator := generateTranscriptSummary
+	t.Cleanup(func() { generateTranscriptSummary = tmpGenerator })
+
+	generateTranscriptSummary = summarize.GenerateFromTranscript
+
+	streamCall := agenttestutil.FakeStreamCmd("", "error: unknown flag: --json", 1)
+	calls := 0
+	streamer := &codex.CodexAgent{
+		CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			calls++
+			if calls == 1 {
+				return streamCall(ctx, name, args...)
+			}
+			return exec.CommandContext(ctx, "sh", "-c", "sleep 10")
+		},
+	}
+	generator := &summarize.TextGeneratorAdapter{TextGenerator: streamer}
+	attempt := newSummaryAttempt("codex", 100*time.Millisecond)
+	progress := newSummaryProgressWriter(io.Discard, attempt)
+
+	_, err := generateCheckpointAISummary(
+		context.Background(), []byte(`{"type":"user","message":{"role":"user","content":"summarize"}}`+"\n"), nil, agent.AgentTypeClaudeCode,
+		generator, 100*time.Millisecond, progress.handle, attempt,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.False(t, attempt.streaming, "non-streaming fallback must replace the attempted streaming mode")
+	require.Equal(t, 2, calls)
+
+	label, _ := timeoutDiagnostic(err, attempt)
+	require.Contains(t, label, "produced no output")
+}
+
 // TestGenerateCheckpointAISummary_PreservesClaudeErrorWhenCtxIsDone guards
 // against the race where the underlying summarizer returns a typed
 // *ClaudeError AND the context happens to be done. Prior code checked
@@ -1157,6 +1221,67 @@ func TestGenerateCheckpointAISummary_ExplicitTimeoutNarrowsLongParent(t *testing
 	if remaining := gotDeadline.Sub(start); remaining < 30*time.Millisecond || remaining > 200*time.Millisecond {
 		t.Fatalf("deadline offset = %s, want around %s", remaining, explicitTimeout)
 	}
+}
+
+// Cannot use t.Parallel() — mutates package-level generateTranscriptSummary.
+func TestGenerateCheckpointAISummary_ExplicitTimeoutUsesShorterParentDeadline(t *testing.T) {
+	tmpGenerator := generateTranscriptSummary
+	t.Cleanup(func() { generateTranscriptSummary = tmpGenerator })
+
+	generateTranscriptSummary = func(
+		ctx context.Context,
+		_ redact.RedactedBytes,
+		_ []string,
+		_ types.AgentType,
+		_ summarize.Generator,
+		_ agent.ProgressFn,
+	) (*checkpoint.Summary, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 75*time.Millisecond)
+	defer cancel()
+	attempt := newSummaryAttempt("codex", time.Minute)
+
+	_, err := generateCheckpointAISummary(
+		parentCtx, []byte("transcript"), nil, agent.AgentTypeClaudeCode,
+		nil, time.Minute, nil, attempt,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Greater(t, attempt.deadline, time.Duration(0))
+	require.Less(t, attempt.deadline, time.Second, "diagnostic must record the effective parent deadline")
+	require.Contains(t, err.Error(), formatSummaryTimeout(attempt.deadline))
+}
+
+// Cannot use t.Parallel() — mutates package-level generateTranscriptSummary.
+func TestGenerateCheckpointAISummary_ParentOnlyDeadlineStaysGeneric(t *testing.T) {
+	tmpGenerator := generateTranscriptSummary
+	t.Cleanup(func() { generateTranscriptSummary = tmpGenerator })
+
+	generateTranscriptSummary = func(
+		ctx context.Context,
+		_ redact.RedactedBytes,
+		_ []string,
+		_ types.AgentType,
+		_ summarize.Generator,
+		_ agent.ProgressFn,
+	) (*checkpoint.Summary, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	attempt := newSummaryAttempt("codex", 0)
+
+	_, err := generateCheckpointAISummary(
+		parentCtx, []byte("transcript"), nil, agent.AgentTypeClaudeCode,
+		nil, 0, nil, attempt,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Zero(t, attempt.deadline)
+	require.NotContains(t, err.Error(), "after")
 }
 
 // Cannot use t.Parallel() — mutates package-level generateTranscriptSummary.
@@ -5978,10 +6103,14 @@ func TestSummaryProgressWriter_PopulatesAttempt(t *testing.T) {
 	attempt := newSummaryAttempt("claude-code", 30*time.Second)
 	pw := newSummaryProgressWriter(&bytes.Buffer{}, attempt)
 	pw.handle(agent.GenerationProgress{Phase: agent.PhaseConnecting})
+	if attempt.streaming {
+		t.Error("phase events must not infer the execution mode")
+	}
+	agent.ReportStreamingMode(pw.handle, true)
 	pw.handle(agent.GenerationProgress{Phase: agent.PhaseFirstToken})
 
 	if !attempt.streaming {
-		t.Error("expected attempt.streaming=true after any progress event")
+		t.Error("expected attempt.streaming=true after the streaming mode marker")
 	}
 	if !attempt.phasesReached[agent.PhaseConnecting] {
 		t.Error("expected PhaseConnecting recorded in attempt")

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -267,9 +267,14 @@ func TestFormatCheckpointSummaryError_TextGenerationErrorPrecedence(t *testing.T
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			label, _, err := formatCheckpointSummaryError(test.failure, newSummaryAttempt(agent.AgentNameCodex, 5*time.Minute))
+			label, rows, structured := formatCheckpointSummaryError(test.failure, newSummaryAttempt(agent.AgentNameCodex, 5*time.Minute))
 			require.Equal(t, test.wantLabel, label)
-			require.Error(t, err)
+			var output bytes.Buffer
+			err := renderExplainFailure(&output, label, rows, structured)
+			require.ErrorIs(t, err, test.failure.Err)
+			var got *agent.TextGenerationError
+			require.ErrorAs(t, err, &got)
+			require.Same(t, test.failure, got)
 		})
 	}
 }
@@ -1182,7 +1187,7 @@ func TestGenerateCheckpointAISummary_FallbackTimeoutUsesNonStreamingDiagnostic(t
 		CommandRunner: func(ctx context.Context, name string, args ...string) *exec.Cmd {
 			calls++
 			if calls == 1 {
-				return streamCall(ctx, name, args...)
+				return streamCall(context.Background(), name, args...)
 			}
 			return agenttestutil.BlockingCmd(ctx)
 		},

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -140,6 +140,213 @@ func TestFormatCheckpointSummaryError_CLIMissing(t *testing.T) {
 	}
 }
 
+func TestFormatCheckpointSummaryError_NonClaudeProviderMatrix(t *testing.T) {
+	t.Parallel()
+
+	providers := []struct {
+		name  types.AgentName
+		label string
+	}{
+		{name: agent.AgentNameCodex, label: "Codex"},
+		{name: agent.AgentNameGemini, label: "Gemini"},
+		{name: agent.AgentNameCursor, label: "Cursor"},
+		{name: agent.AgentNameCopilotCLI, label: "Copilot CLI"},
+		{name: agent.AgentNamePi, label: "Pi"},
+	}
+	kinds := []struct {
+		name      string
+		kind      agent.TextGenerationErrorKind
+		label     string
+		rows      []explainRow
+		errSuffix string
+	}{
+		{
+			name:      "auth",
+			kind:      agent.TextGenerationErrorAuth,
+			label:     " authentication failed",
+			rows:      []explainRow{{Label: "message", Value: "provider detail"}},
+			errSuffix: " authentication failed: provider detail",
+		},
+		{
+			name:      "rate limit",
+			kind:      agent.TextGenerationErrorRateLimit,
+			label:     " rejected the summary request due to rate limits or quota",
+			rows:      []explainRow{{Label: "message", Value: "provider detail"}},
+			errSuffix: " rejected the summary request due to rate limits or quota: provider detail",
+		},
+		{
+			name:      "config",
+			kind:      agent.TextGenerationErrorConfig,
+			label:     " rejected the summary request",
+			rows:      []explainRow{{Label: "message", Value: "provider detail"}},
+			errSuffix: " rejected the summary request: provider detail",
+		},
+		{
+			name:      "CLI missing",
+			kind:      agent.TextGenerationErrorCLIMissing,
+			label:     " CLI is not installed or not on PATH",
+			errSuffix: " CLI is not installed or not on PATH",
+		},
+		{
+			name:      "unknown",
+			kind:      agent.TextGenerationErrorUnknown,
+			label:     " failed to generate the summary",
+			rows:      []explainRow{{Label: "detail", Value: "provider detail"}},
+			errSuffix: " failed to generate the summary: provider detail",
+		},
+	}
+
+	for _, provider := range providers {
+		for _, kind := range kinds {
+			t.Run(string(provider.name)+"/"+kind.name, func(t *testing.T) {
+				t.Parallel()
+
+				message := "provider detail"
+				if kind.kind == agent.TextGenerationErrorCLIMissing {
+					message = ""
+				}
+				failure := &agent.TextGenerationError{
+					Err:      errors.New("provider cause"),
+					Provider: provider.name,
+					Kind:     kind.kind,
+					Message:  message,
+				}
+				wantLabel := provider.label + kind.label
+				wantErr := provider.label + kind.errSuffix
+				if kind.kind == agent.TextGenerationErrorCLIMissing && strings.HasSuffix(provider.label, " CLI") {
+					wantLabel = provider.label + " is not installed or not on PATH"
+					wantErr = wantLabel
+				}
+				label, rows, err := formatCheckpointSummaryError(failure, newSummaryAttempt(provider.name, 0))
+				require.Equal(t, wantLabel, label)
+				require.Equal(t, kind.rows, rows)
+				require.EqualError(t, err, wantErr)
+			})
+		}
+	}
+}
+
+func TestFormatCheckpointSummaryError_TextGenerationErrorPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		failure   *agent.TextGenerationError
+		wantLabel string
+	}{
+		{
+			name: "specific auth outranks wrapped deadline",
+			failure: &agent.TextGenerationError{
+				Err:      context.DeadlineExceeded,
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorAuth,
+				Message:  "HTTP 401 Unauthorized",
+			},
+			wantLabel: "Codex authentication failed",
+		},
+		{
+			name: "unknown wrapped deadline uses timeout",
+			failure: &agent.TextGenerationError{
+				Err:      context.DeadlineExceeded,
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorUnknown,
+			},
+			wantLabel: "Timed out after 5m0s: provider produced no output",
+		},
+		{
+			name: "unknown wrapped cancellation uses cancellation",
+			failure: &agent.TextGenerationError{
+				Err:      context.Canceled,
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorUnknown,
+			},
+			wantLabel: "Summary generation canceled",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			label, _, err := formatCheckpointSummaryError(test.failure, newSummaryAttempt(agent.AgentNameCodex, 5*time.Minute))
+			require.Equal(t, test.wantLabel, label)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestFormatCheckpointSummaryError_PreservesProviderCause(t *testing.T) {
+	t.Parallel()
+
+	failure := &agent.TextGenerationError{
+		Err:      context.DeadlineExceeded,
+		Provider: agent.AgentNameCodex,
+		Kind:     agent.TextGenerationErrorAuth,
+		Message:  "HTTP 401 Unauthorized",
+	}
+	_, _, err := formatCheckpointSummaryError(failure, newSummaryAttempt(agent.AgentNameCodex, 0))
+
+	var got *agent.TextGenerationError
+	require.ErrorAs(t, err, &got)
+	require.Same(t, failure, got)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestFormatCheckpointSummaryError_UnknownProviderDetails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		failure  *agent.TextGenerationError
+		attempt  *summaryAttempt
+		wantRows []explainRow
+		wantErr  string
+	}{
+		{
+			name: "exit code only",
+			failure: &agent.TextGenerationError{
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorUnknown,
+				ExitCode: 17,
+			},
+			attempt:  newSummaryAttempt(agent.AgentNameCodex, 0),
+			wantRows: []explainRow{{Label: "detail", Value: "Codex CLI exited with code 17"}},
+			wantErr:  "Codex failed to generate the summary: Codex CLI exited with code 17",
+		},
+		{
+			name: "original cause only",
+			failure: &agent.TextGenerationError{
+				Err:      errors.New("transport exploded"),
+				Provider: agent.AgentNameCodex,
+				Kind:     agent.TextGenerationErrorUnknown,
+			},
+			attempt:  newSummaryAttempt(agent.AgentNameCodex, 0),
+			wantRows: []explainRow{{Label: "detail", Value: "transport exploded"}},
+			wantErr:  "Codex failed to generate the summary: transport exploded",
+		},
+		{
+			name: "legacy empty provider falls back to attempt",
+			failure: &agent.TextGenerationError{
+				Err:     errors.New("legacy failure"),
+				Kind:    agent.TextGenerationErrorUnknown,
+				Message: "legacy failure",
+			},
+			attempt:  newSummaryAttempt(agent.AgentNamePi, 0),
+			wantRows: []explainRow{{Label: "detail", Value: "legacy failure"}},
+			wantErr:  "Pi failed to generate the summary: legacy failure",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			label, rows, err := formatCheckpointSummaryError(test.failure, test.attempt)
+			require.Equal(t, strings.Split(test.wantErr, ":")[0], label)
+			require.Equal(t, test.wantRows, rows)
+			require.EqualError(t, err, test.wantErr)
+		})
+	}
+}
+
 // TestFormatCheckpointSummaryError_TypedBranchesHandleEmptyMessage guards against
 // the null-result-envelope regression: Claude can emit is_error:true with a real
 // HTTP status (401/429/4xx) but result:null, producing a ClaudeError with Message="".
@@ -1141,6 +1348,52 @@ func TestGenerateCheckpointSummary_AdvancesV1Metadata(t *testing.T) {
 	v1After, err := fixture.repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.NoError(t, err)
 	require.NotEqual(t, fixture.v1Hash, v1After.Hash(), "v1 metadata branch must advance after UpdateSummary")
+}
+
+func TestGenerateCheckpointSummary_MissingConfiguredProvider(t *testing.T) {
+	fixture := setupGenerateSummaryFixture(t)
+
+	originalLoad := loadSummarySettings
+	originalGet := getSummaryAgent
+	originalCLI := isSummaryCLIAvailable
+	t.Cleanup(func() {
+		loadSummarySettings = originalLoad
+		getSummaryAgent = originalGet
+		isSummaryCLIAvailable = originalCLI
+	})
+	loadSummarySettings = func(context.Context) (*settings.EntireSettings, error) {
+		return &settings.EntireSettings{
+			Enabled: true,
+			SummaryGeneration: &settings.SummaryGenerationSettings{
+				Provider: string(agent.AgentNameCodex),
+			},
+		}, nil
+	}
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		return &stubTextAgent{name: name, kind: agent.AgentTypeCodex}, nil
+	}
+	isSummaryCLIAvailable = func(types.AgentName) bool { return false }
+
+	var stdout, stderr bytes.Buffer
+	err := generateCheckpointSummary(
+		fixture.ctx,
+		&stdout,
+		&stderr,
+		fixture.store,
+		fixture.cpID,
+		fixture.cpSummary,
+		fixture.content,
+		false,
+		0,
+	)
+	var silentErr *SilentError
+	require.ErrorAs(t, err, &silentErr)
+	var providerFailure *agent.TextGenerationError
+	require.ErrorAs(t, err, &providerFailure)
+	require.Equal(t, agent.AgentNameCodex, providerFailure.Provider)
+	require.Equal(t, agent.TextGenerationErrorCLIMissing, providerFailure.Kind)
+	require.Contains(t, stderr.String(), "Codex CLI is not installed or not on PATH")
+	require.NotContains(t, stderr.String(), "failed to resolve summary provider:")
 }
 
 func TestRunExplainGenerateBlocksWhenPolicyWriteUnsupported(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -625,14 +625,45 @@ func generateSummary(ctx context.Context, redactedTranscript redact.RedactedByte
 	// scopedTranscript is sliced from redactedTranscript, which was redacted earlier in CondenseSession.
 	summary, err := summarize.GenerateFromTranscript(summarizeCtx, redact.AlreadyRedacted(scopedTranscript), filesTouched, state.AgentType, generator, nil) // no progress in the auto-summary hot path
 	if err != nil {
-		logging.Warn(summarizeCtx, "summary generation failed",
-			slog.String("session_id", state.SessionID),
-			slog.String("error", err.Error()))
+		attrs := []any{slog.String("session_id", state.SessionID)}
+		attrs = append(attrs, summaryGenerationFailureLogAttrs(err)...)
+		logging.Warn(summarizeCtx, "summary generation failed", attrs...)
 		return nil
 	}
 	logging.Info(summarizeCtx, "summary generated",
 		slog.String("session_id", state.SessionID))
 	return summary
+}
+
+func summaryGenerationFailureLogAttrs(err error) []any {
+	var failure *agent.TextGenerationError
+	if errors.As(err, &failure) {
+		kind := "unknown"
+		switch failure.Kind { //nolint:exhaustive // Unknown is the safe default.
+		case agent.TextGenerationErrorAuth:
+			kind = "auth"
+		case agent.TextGenerationErrorRateLimit:
+			kind = "rate_limit"
+		case agent.TextGenerationErrorConfig:
+			kind = "config"
+		case agent.TextGenerationErrorCLIMissing:
+			kind = "cli_missing"
+		}
+		return []any{
+			slog.String("failure_kind", kind),
+			slog.String("provider", string(failure.Provider)),
+			slog.Int("exit_code", failure.ExitCode),
+			slog.Int("stdout_bytes", failure.StdoutBytes),
+			slog.Int("stderr_bytes", len(failure.Stderr)),
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return []any{slog.String("failure_kind", "deadline")}
+	}
+	if errors.Is(err, context.Canceled) {
+		return []any{slog.String("failure_kind", "canceled")}
+	}
+	return []any{slog.String("failure_kind", "other")}
 }
 
 // buildSummaryGenerator returns a Generator based on the configured summary provider.

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -3,6 +3,8 @@ package strategy
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,6 +30,26 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/pi"
 )
+
+func TestSummaryGenerationFailureLogAttrsExcludeProviderContent(t *testing.T) {
+	t.Parallel()
+
+	const secret = "user prompt must not enter persistent logs"
+	failure := &agent.TextGenerationError{
+		Err:         errors.New(secret),
+		Stderr:      secret,
+		StdoutBytes: 42,
+		Provider:    agent.AgentNameCodex,
+		Kind:        agent.TextGenerationErrorAuth,
+		Message:     secret,
+		ExitCode:    7,
+	}
+
+	attrs := fmt.Sprint(summaryGenerationFailureLogAttrs(failure))
+	require.NotContains(t, attrs, secret)
+	require.Contains(t, attrs, "codex")
+	require.Contains(t, attrs, "auth")
+}
 
 // calculateTokenUsage is a test helper that looks up an agent by type and
 // calculates token usage from pre-loaded transcript bytes.

--- a/cmd/entire/cli/summarize/summarize.go
+++ b/cmd/entire/cli/summarize/summarize.go
@@ -70,9 +70,13 @@ func GenerateFromTranscript(
 	// progress field — type-assert each shape and set it.
 	switch g := generator.(type) {
 	case *ClaudeGenerator:
-		g.progress = progress
+		callGenerator := *g
+		callGenerator.progress = progress
+		generator = &callGenerator
 	case *TextGeneratorAdapter:
-		g.progress = progress
+		callGenerator := *g
+		callGenerator.progress = progress
+		generator = &callGenerator
 	}
 
 	summary, err := generator.Generate(ctx, input)

--- a/cmd/entire/cli/summarize/text_generator.go
+++ b/cmd/entire/cli/summarize/text_generator.go
@@ -40,6 +40,7 @@ func (g *TextGeneratorAdapter) Generate(ctx context.Context, input Input) (*chec
 	// Prefer streaming when the underlying agent supports it. TextGenerator
 	// embeds Agent, so AsStreamingTextGenerator accepts it directly.
 	if streamer, ok := agent.AsStreamingTextGenerator(g.TextGenerator); ok {
+		agent.ReportStreamingMode(g.progress, true)
 		result, err := streamer.GenerateTextStreaming(ctx, prompt, g.Model, g.progress)
 		if err != nil {
 			return nil, err //nolint:wrapcheck // preserve *agent.TextGenerationError / *claudecode.ClaudeError for errors.As

--- a/cmd/entire/cli/summarize/text_generator_test.go
+++ b/cmd/entire/cli/summarize/text_generator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/redact"
 )
 
 type mockTextGenerator struct {
@@ -45,6 +46,23 @@ type errorTextGenerator struct {
 	mockTextGenerator
 
 	err error
+}
+
+type streamingMockTextGenerator struct {
+	mockTextGenerator
+
+	err error
+}
+
+func (m *streamingMockTextGenerator) GenerateTextStreaming(
+	_ context.Context,
+	prompt, model string,
+	progress agent.ProgressFn,
+) (string, error) {
+	m.prompt = prompt
+	m.model = model
+	progress(agent.GenerationProgress{Phase: agent.PhaseDone})
+	return m.result, m.err
 }
 
 func (e *errorTextGenerator) GenerateText(context.Context, string, string) (string, error) {
@@ -127,5 +145,32 @@ func TestTextGeneratorAdapter_Generate(t *testing.T) {
 	}
 	if !strings.Contains(mock.prompt, "Fix the bug") {
 		t.Fatalf("prompt did not include condensed transcript: %q", mock.prompt)
+	}
+}
+
+func TestGenerateFromTranscript_DoesNotStoreCallScopedProgress(t *testing.T) {
+	t.Parallel()
+
+	mock := &streamingMockTextGenerator{mockTextGenerator: mockTextGenerator{
+		result: `{"intent":"Intent","outcome":"Outcome","learnings":{"repo":[],"code":[],"workflow":[]},"friction":[],"open_items":[]}`,
+	}}
+	adapter := &TextGeneratorAdapter{TextGenerator: mock}
+	transcript := redact.AlreadyRedacted([]byte(
+		`{"type":"user","message":{"content":"call-scoped progress"}}` + "\n" +
+			`{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}`,
+	))
+	progressCalled := false
+
+	_, err := GenerateFromTranscript(context.Background(), transcript, nil, "", adapter, func(agent.GenerationProgress) {
+		progressCalled = true
+	})
+	if err != nil {
+		t.Fatalf("GenerateFromTranscript() error = %v", err)
+	}
+	if !progressCalled {
+		t.Fatal("progress callback was not invoked")
+	}
+	if adapter.progress != nil {
+		t.Fatal("GenerateFromTranscript stored call-scoped progress on reusable adapter")
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/398
<!-- entire-trail-link-end -->

## Summary

Extends PR #964's streaming summary UI from Claude to the other four built-in summary providers — **Codex**, **Gemini**, **Cursor**, and **Copilot**. Each agent now implements `agent.StreamingTextGenerator`, sharing a new `agent.StreamingGeneratorTemplate` that owns subprocess lifecycle (mirrors the `review/types/template.ReviewerTemplate` pattern from PR #1192).

**Base branch:** `feat/explain-stream-progress` (PR #964). When that merges to `main`, this rebases cleanly.

## Architecture

- `agent.StreamingGeneratorTemplate` — shared spawn → pipe → parse → drain → wait. Per-agent code provides only `BuildCmd` (argv) and `Parser` (stdout → events). 5 unit tests cover the template; agents use it via composition.
- `agent.testutil.FakeStreamCmd` — extracted from `claudecode/generate_streaming_test.go` so all 5 streaming agents share one subprocess fake.
- `summaryProgressWriter.handle` — `PhaseFirstToken` rendering now gracefully degrades when `TTFTms`/`CachedInputTokens` are zero (Gemini, Cursor, Copilot have neither; Codex has cached but no TTFT).
- `claudecode` keeps its own `generate_streaming.go` — no migration. Per user decision: don't refactor the established Claude path.

## Per-agent observations

Each agent's stream protocol is different. The unified UX hides this:

| Agent | TTFT | Cached tokens | Tokens during stream | Final duration |
|---|---|---|---|---|
| **Codex** | no | yes (`turn.completed.usage`) | no — single chunk arrival | locally measured (`time.Since(turn.started)`) |
| **Gemini** | no | no | yes — per assistant delta | real (`result.stats.duration_ms`) |
| **Cursor** | no | captured but not yet shown on Done line | yes — per assistant w/ timestamp_ms | real (`result.duration_ms`) |
| **Copilot** | no | no | yes — per `assistant.message_delta` (estimated from char length) | real (sum of per-turn `assistant.message.outputTokens`) |

Cursor's stream includes `thinking` events (internal reasoning) which are intentionally ignored — Connecting phase persists during the thinking window.

## Test approach

- **Per-agent unit tests** — parser + integration tests using synthetic NDJSON fixtures (`testdata/stream_{success,error}.jsonl`) that mirror the real CLI shape captured during implementation.
- **Real-CLI smoke tests** — every agent was end-to-end verified against checkpoint \`d86ffe2e995d\` (734k-token transcript). UI sequence verified for each: phase ordering, parens-with-cached-tokens for Codex, no-parens for the others, running token counter ticking, real numbers in the final line.
- **Two-stage review** — every chunk got both spec-compliance and code-quality review subagents. All ✅ APPROVED with deferred nits.

## Commits

\`\`\`
f0caf4962 feat(cursor):     implement StreamingTextGenerator
2960d6236 fix(copilotcli):  tick output-token counter during streaming
74dc1470f feat(copilotcli): implement StreamingTextGenerator
1e0e93f18 feat(geminicli):  implement StreamingTextGenerator
47583e9c2 fix(codex):       redact raw error envelopes + surface skipped malformed lines
3d0a38c01 feat(codex):      implement StreamingTextGenerator
00b841b0d feat(agent):      add StreamingGeneratorTemplate + progress-writer field degradation
\`\`\`

Both fix commits are responses to bugbot/code-quality review on the immediately-preceding chunk. Each chunk + fix is independently buildable and testable.

## Known gaps / follow-ups

- **`looksLikeUnrecognizedFlag` helper duplication** (4 near-identical predicates across codex/geminicli/copilotcli/cursor). Each has a `//nolint:dupl` annotation pointing at a planned post-merge consolidation. `dupl` never actually fired at threshold 75 — the annotations are prophylactic.
- **Privacy-decode pattern duplication** (3× across codex/geminicli/copilotcli error branches; cursor's is simpler since its error envelope only carries `result.result`). A shared \`agent.SafeErrorMessage\` helper was flagged but deferred to keep the surface clean while patterns settle.
- **Cursor's `cacheReadTokens`** is parsed into `done.CachedInputTokens` but the progress writer's PhaseDone line doesn't currently display cached tokens. Future-proofing — UI can pick it up later without a parser change.
- **Cursor authentication required.** The `agent` CLI exits with `Authentication required` without an interactive `agent login` or `CURSOR_API_KEY`. The streaming path inherits this — without auth, the template surfaces a generic `TextGenerationError` (same as the non-streaming path always has).

## Test plan

- [x] Unit tests pass: \`mise run test:ci\` (58 unit + 4 canary E2E)
- [x] Lint clean: \`mise run lint\` (0 issues)
- [x] Real-CLI smoke: Codex, Gemini, Cursor, Copilot — all verified UI sequence end-to-end on \`d86ffe2e995d\`
- [x] Timeout diagnostic: \`--summary-timeout-seconds 3\` exercised on each agent — phase-attribution diagnostic from PR #964 carries through the new template

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new subprocess-driven streaming generation paths for multiple providers plus a shared lifecycle wrapper; failures could surface as incorrect progress reporting or fallback/error handling regressions.
> 
> **Overview**
> Adds streaming summary support for **Codex**, **Gemini CLI**, **Cursor agent**, and **Copilot CLI** by introducing a shared `agent.StreamingGeneratorTemplate` that owns subprocess setup, stdout parsing/draining, stderr capture, and a standardized fallback signal (`ErrUnrecognizedStreamingFlag`).
> 
> Each agent now has a streaming parser for its NDJSON protocol that emits `PhaseConnecting`/`PhaseFirstToken`/`PhaseGenerating`/`PhaseDone` (including token/duration data when available) and falls back to non-streaming `GenerateText` when the CLI rejects streaming flags.
> 
> Test infrastructure is expanded with a shared `agent/testutil.FakeStreamCmd` (replacing an inline Claude helper), new per-agent NDJSON fixtures + unit tests, and the summary UI is tweaked so `PhaseFirstToken` renders optional TTFT/cached-token clauses only when present (no empty parens).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0caf496203750cf17ebaf085059c69e3a6d2722. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->