### PR TITLE
Fix garbled repo picker in dispatch wizard

### DIFF
--- a/cmd/entire/cli/dispatch_wizard.go
+++ b/cmd/entire/cli/dispatch_wizard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -246,6 +247,11 @@ func runDispatchWizard(cmd *cobra.Command) (dispatchpkg.Options, error) {
 	// (the form computes group height before the async load resolves), so the
 	// row prefixes scrolled out of sync with the option text.
 	slugs, listErr := listDispatchWizardRepos(ctx)
+	if api.IsHTTPErrorStatus(listErr, http.StatusUnauthorized) {
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), "Your auth token has expired — run 'entire login' to refresh.")
+		return dispatchpkg.Options{}, NewSilentError(listErr)
+	}
 	if listErr != nil || len(slugs) == 0 {
 		slugs = discoverLocalRepoSlugs(ctx, currentRepo)
 	}
@@ -493,7 +499,10 @@ func resolveGitTopLevel(ctx context.Context, path string) (string, error) {
 func discoverAuthenticatedDispatchWizardRepos(ctx context.Context) ([]string, error) {
 	repos, err := listDispatchWizardRepoResources(ctx)
 	if err != nil {
-		logging.Warn(ctx, "dispatch wizard repo list failed", "error", err)
+		// Debug-level: the wizard falls back to local discovery, and 401s are
+		// surfaced explicitly by the caller. Routing this to Warn caused noise
+		// on stderr because the dispatch command does not call logging.Init.
+		logging.Debug(ctx, "dispatch wizard repo list failed", "error", err)
 		return nil, err
 	}
 

--- a/cmd/entire/cli/dispatch_wizard.go
+++ b/cmd/entire/cli/dispatch_wizard.go
@@ -241,13 +241,15 @@ func runDispatchWizard(cmd *cobra.Command) (dispatchpkg.Options, error) {
 		return dispatchpkg.Options{}, fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	loadRepos := newLazyOptions(func() []huh.Option[string] {
-		slugs, listErr := listDispatchWizardRepos(ctx)
-		if listErr != nil || len(slugs) == 0 {
-			slugs = discoverLocalRepoSlugs(ctx, currentRepo)
-		}
-		return buildDispatchRepoOptions(slugs)
-	})
+	// Pre-load repos so the multi-select renders with options at construction
+	// time. Using OptionsFunc here triggered huh v2 viewport-sizing artifacts
+	// (the form computes group height before the async load resolves), so the
+	// row prefixes scrolled out of sync with the option text.
+	slugs, listErr := listDispatchWizardRepos(ctx)
+	if listErr != nil || len(slugs) == 0 {
+		slugs = discoverLocalRepoSlugs(ctx, currentRepo)
+	}
+	repoOptions := buildDispatchRepoOptions(slugs)
 
 	state := newDispatchWizardState()
 	state.currentBranch, state.currentBranchErr = getDispatchWizardCurrentBranch(ctx)
@@ -266,7 +268,7 @@ func runDispatchWizard(cmd *cobra.Command) (dispatchpkg.Options, error) {
 				Title("Repos").
 				Description(fmt.Sprintf("Press / to filter. Up to %d repos.", dispatchpkg.CloudRepoLimit)).
 				Filterable(true).
-				OptionsFunc(loadRepos, nil).
+				Options(repoOptions...).
 				Value(&state.selectedRepos).
 				Validate(func(value []string) error {
 					selected := normalizeDispatchWizardSelections(value)
@@ -364,21 +366,6 @@ func runDispatchWizard(cmd *cobra.Command) (dispatchpkg.Options, error) {
 	}
 
 	return state.resolve()
-}
-
-// newLazyOptions returns a func that runs loader once (under sync.Once) and
-// returns the cached result on subsequent calls. Safe for concurrent use.
-func newLazyOptions(loader func() []huh.Option[string]) func() []huh.Option[string] {
-	var (
-		once    sync.Once
-		options []huh.Option[string]
-	)
-	return func() []huh.Option[string] {
-		once.Do(func() {
-			options = loader()
-		})
-		return options
-	}
 }
 
 // buildDispatchRepoOptions dedupes but preserves the caller's order so each

--- a/cmd/entire/cli/dispatch_wizard_test.go
+++ b/cmd/entire/cli/dispatch_wizard_test.go
@@ -382,6 +382,51 @@ func TestRunDispatchWizard_ProceedsWhenCurrentBranchCannotBeResolved(t *testing.
 	}
 }
 
+func TestRunDispatchWizard_AbortsWithLoginHintOnExpiredToken(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	t.Chdir(dir)
+
+	oldListRepos := listDispatchWizardRepos
+	listDispatchWizardRepos = func(context.Context) ([]string, error) {
+		return nil, &api.HTTPError{StatusCode: 401, Message: "Token expired"}
+	}
+	t.Cleanup(func() {
+		listDispatchWizardRepos = oldListRepos
+	})
+
+	oldRunForm := runDispatchWizardForm
+	formCalled := false
+	runDispatchWizardForm = func(*huh.Form) error {
+		formCalled = true
+		return nil
+	}
+	t.Cleanup(func() {
+		runDispatchWizardForm = oldRunForm
+	})
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stderr strings.Builder
+	cmd.SetErr(&stderr)
+	cmd.SetOut(&strings.Builder{})
+
+	_, err := runDispatchWizard(cmd)
+	if err == nil {
+		t.Fatal("expected error on expired token")
+	}
+	var silent *SilentError
+	if !errors.As(err, &silent) {
+		t.Fatalf("expected SilentError so main.go does not double-print, got %T", err)
+	}
+	if formCalled {
+		t.Fatal("form should not run when token is expired")
+	}
+	if !strings.Contains(stderr.String(), "entire login") {
+		t.Fatalf("expected stderr hint to mention 'entire login', got %q", stderr.String())
+	}
+}
+
 func TestDispatchWizardState_CloudIgnoresCurrentBranchResolutionError(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/dispatch_wizard_test.go
+++ b/cmd/entire/cli/dispatch_wizard_test.go
@@ -352,6 +352,15 @@ func TestRunDispatchWizard_ProceedsWhenCurrentBranchCannotBeResolved(t *testing.
 		getDispatchWizardCurrentBranch = oldGetCurrentBranch
 	})
 
+	// Stub the eager repo lookup so the test does not hit the keychain or API.
+	oldListRepos := listDispatchWizardRepos
+	listDispatchWizardRepos = func(context.Context) ([]string, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		listDispatchWizardRepos = oldListRepos
+	})
+
 	// Stub form execution so the test does not block on a TTY when run from a
 	// terminal. The "run dispatch wizard" error wrapper only exists after the
 	// wizard proceeds past branch resolution, so the assertion below is


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/399
<!-- entire-trail-link-end -->

## Summary
- `entire dispatch`'s repo multi-select used `huh.OptionsFunc` (async option loading). huh v2 sizes the group viewport off the initial `WindowSizeMsg`, which fires before the loader resolves — so the viewport got sized for the loading-spinner row and the actual options overflowed it, producing the mangled `[ ]` prefixes when scrolling.
- Switched to eager `Options(...)` — the pattern every other multi-select in the CLI already uses — and pre-loaded the repo list at the top of `runDispatchWizard`. Removed the now-unused `newLazyOptions` helper.
- Wizard test now stubs `listDispatchWizardRepos` so eager loading doesn't hit the keychain in CI.

## Test plan
- [ ] `mise run fmt && mise run lint` (already clean locally)
- [ ] `mise run test:ci`
- [ ] `entire dispatch` → select Cloud → confirm `[ ]` prefixes stay aligned while scrolling through the repo list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because repo options are now fetched eagerly on wizard start (even before the repo picker is shown), which could change latency/side effects (API/keychain access) compared to the prior lazy loading.
> 
> **Overview**
> Fixes the `entire dispatch` wizard cloud repo picker rendering issues by replacing async `huh.OptionsFunc` loading with eager `Options(...)` after preloading repo slugs at the start of `runDispatchWizard`.
> 
> Removes the unused `newLazyOptions` helper and updates the wizard test to stub `listDispatchWizardRepos` so CI doesn’t hit the keychain/API during eager repo loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4015e1f4d52adea94528a01ac580dc06f31e013. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->