### PR TITLE
Harden opencode session dir, copyFile streaming, FetchBlobs argv batching

### DIFF
--- a/cmd/entire/cli/agent/opencode/lifecycle.go
+++ b/cmd/entire/cli/agent/opencode/lifecycle.go
@@ -58,7 +58,7 @@ func (a *OpenCodeAgent) ParseHookEvent(ctx context.Context, hookName string, std
 		if err != nil {
 			return nil, err
 		}
-		transcriptPath, err := sessionTranscriptPath(ctx, raw.SessionID)
+		transcriptPath, err := a.sessionTranscriptPath(ctx, raw.SessionID)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +77,7 @@ func (a *OpenCodeAgent) ParseHookEvent(ctx context.Context, hookName string, std
 			return nil, err
 		}
 		// Export is deferred to PrepareTranscript; we just compute the path here.
-		transcriptPath, err := sessionTranscriptPath(ctx, raw.SessionID)
+		transcriptPath, err := a.sessionTranscriptPath(ctx, raw.SessionID)
 		if err != nil {
 			return nil, err
 		}
@@ -145,10 +145,12 @@ func (a *OpenCodeAgent) PrepareTranscript(ctx context.Context, sessionRef string
 	return err
 }
 
-// sessionTranscriptPath validates the session ID and returns the expected transcript path.
-// Matches GetSessionDir(repoRoot)/ResolveSessionFile(...) so the live export and the
-// path that AgentForTranscriptPath / rewind agree on are exactly the same location.
-func sessionTranscriptPath(ctx context.Context, sessionID string) (string, error) {
+// sessionTranscriptPath validates the session ID and returns the expected
+// transcript path. Composes GetSessionDir + ResolveSessionFile so the live
+// export, the path agent.AgentForTranscriptPath resolves, and the path rewind
+// reads from are guaranteed to be the same location — and so the
+// ENTIRE_TEST_OPENCODE_PROJECT_DIR test override applies uniformly.
+func (a *OpenCodeAgent) sessionTranscriptPath(ctx context.Context, sessionID string) (string, error) {
 	if err := validation.ValidateSessionID(sessionID); err != nil {
 		return "", fmt.Errorf("invalid session ID for transcript path: %w", err)
 	}
@@ -156,7 +158,11 @@ func sessionTranscriptPath(ctx context.Context, sessionID string) (string, error
 	if err != nil {
 		repoRoot = "."
 	}
-	return filepath.Join(repoRoot, paths.EntireTmpDir, OpenCodeSessionSubdir, sessionID+".json"), nil
+	dir, err := a.GetSessionDir(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve opencode session dir: %w", err)
+	}
+	return a.ResolveSessionFile(dir, sessionID), nil
 }
 
 // fetchAndCacheExport calls `opencode export <sessionID>` and writes the result
@@ -177,8 +183,11 @@ func (a *OpenCodeAgent) fetchAndCacheExport(ctx context.Context, sessionID strin
 		repoRoot = "."
 	}
 
-	tmpDir := filepath.Join(repoRoot, paths.EntireTmpDir, OpenCodeSessionSubdir)
-	tmpFile := filepath.Join(tmpDir, sessionID+".json")
+	tmpDir, err := a.GetSessionDir(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve opencode session dir: %w", err)
+	}
+	tmpFile := a.ResolveSessionFile(tmpDir, sessionID)
 
 	// Integration test mode: use pre-written mock file without calling opencode export
 	if os.Getenv("ENTIRE_TEST_OPENCODE_MOCK_EXPORT") != "" {

--- a/cmd/entire/cli/agent/opencode/lifecycle.go
+++ b/cmd/entire/cli/agent/opencode/lifecycle.go
@@ -146,6 +146,8 @@ func (a *OpenCodeAgent) PrepareTranscript(ctx context.Context, sessionRef string
 }
 
 // sessionTranscriptPath validates the session ID and returns the expected transcript path.
+// Matches GetSessionDir(repoRoot)/ResolveSessionFile(...) so the live export and the
+// path that AgentForTranscriptPath / rewind agree on are exactly the same location.
 func sessionTranscriptPath(ctx context.Context, sessionID string) (string, error) {
 	if err := validation.ValidateSessionID(sessionID); err != nil {
 		return "", fmt.Errorf("invalid session ID for transcript path: %w", err)
@@ -154,7 +156,7 @@ func sessionTranscriptPath(ctx context.Context, sessionID string) (string, error
 	if err != nil {
 		repoRoot = "."
 	}
-	return filepath.Join(repoRoot, paths.EntireTmpDir, sessionID+".json"), nil
+	return filepath.Join(repoRoot, paths.EntireTmpDir, OpenCodeSessionSubdir, sessionID+".json"), nil
 }
 
 // fetchAndCacheExport calls `opencode export <sessionID>` and writes the result
@@ -162,7 +164,7 @@ func sessionTranscriptPath(ctx context.Context, sessionID string) (string, error
 //
 // Integration testing: Set ENTIRE_TEST_OPENCODE_MOCK_EXPORT=1 to skip the
 // `opencode export` call and use pre-written mock data instead. Tests must
-// pre-write the transcript file to .entire/tmp/<sessionID>.json before
+// pre-write the transcript file to .entire/tmp/opencode/<sessionID>.json before
 // triggering the hook. See integration_test/hooks.go:SimulateOpenCodeTurnEnd.
 func (a *OpenCodeAgent) fetchAndCacheExport(ctx context.Context, sessionID string) (string, error) {
 	if err := validation.ValidateSessionID(sessionID); err != nil {
@@ -175,7 +177,7 @@ func (a *OpenCodeAgent) fetchAndCacheExport(ctx context.Context, sessionID strin
 		repoRoot = "."
 	}
 
-	tmpDir := filepath.Join(repoRoot, paths.EntireTmpDir)
+	tmpDir := filepath.Join(repoRoot, paths.EntireTmpDir, OpenCodeSessionSubdir)
 	tmpFile := filepath.Join(tmpDir, sessionID+".json")
 
 	// Integration test mode: use pre-written mock file without calling opencode export

--- a/cmd/entire/cli/agent/opencode/lifecycle_test.go
+++ b/cmd/entire/cli/agent/opencode/lifecycle_test.go
@@ -362,6 +362,62 @@ func TestParseHookEvent_TurnEnd_InvalidSessionID(t *testing.T) {
 	}
 }
 
+// Note: GetSessionDir tests cannot use t.Parallel() because t.Setenv()
+// modifies process-global state.
+
+func TestGetSessionDir_UnderRepoEntireTmpOpencode(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_OPENCODE_PROJECT_DIR", "")
+	ag := &OpenCodeAgent{}
+
+	repo := t.TempDir()
+	got, err := ag.GetSessionDir(repo)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(repo, paths.EntireTmpDir, OpenCodeSessionSubdir), got)
+}
+
+func TestGetSessionDir_UniquePrefixFromBareEntireTmp(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_OPENCODE_PROJECT_DIR", "")
+	ag := &OpenCodeAgent{}
+
+	repo := t.TempDir()
+	dir, err := ag.GetSessionDir(repo)
+	require.NoError(t, err)
+
+	// A bare .entire/tmp/<id>.jsonl file (e.g. another agent's scratch file)
+	// must NOT prefix-match opencode's session dir; otherwise
+	// agent.AgentForTranscriptPath would misroute it.
+	bare := filepath.Join(repo, paths.EntireTmpDir, "some-other-agent.jsonl")
+	require.False(t, strings.HasPrefix(bare, dir+string(filepath.Separator)),
+		"bare .entire/tmp file %q must not appear under opencode session dir %q", bare, dir)
+}
+
+func TestGetSessionDir_TestOverrideTakesPrecedence(t *testing.T) {
+	override := t.TempDir()
+	t.Setenv("ENTIRE_TEST_OPENCODE_PROJECT_DIR", override)
+
+	ag := &OpenCodeAgent{}
+	got, err := ag.GetSessionDir(t.TempDir())
+	require.NoError(t, err)
+	require.Equal(t, override, got)
+}
+
+func TestGetSessionDir_PerWorktreeIsolation(t *testing.T) {
+	t.Setenv("ENTIRE_TEST_OPENCODE_PROJECT_DIR", "")
+	ag := &OpenCodeAgent{}
+
+	worktreeA := t.TempDir()
+	worktreeB := t.TempDir()
+
+	dirA, err := ag.GetSessionDir(worktreeA)
+	require.NoError(t, err)
+	dirB, err := ag.GetSessionDir(worktreeB)
+	require.NoError(t, err)
+
+	require.NotEqual(t, dirA, dirB, "different worktrees must map to different session dirs")
+	require.True(t, strings.HasPrefix(dirA, worktreeA), "session dir A must live inside worktree A")
+	require.True(t, strings.HasPrefix(dirB, worktreeB), "session dir B must live inside worktree B")
+}
+
 func TestFetchAndCacheExport_WritesAndValidatesExportFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)

--- a/cmd/entire/cli/agent/opencode/lifecycle_test.go
+++ b/cmd/entire/cli/agent/opencode/lifecycle_test.go
@@ -372,7 +372,7 @@ func TestGetSessionDir_UnderRepoEntireTmpOpencode(t *testing.T) {
 	repo := t.TempDir()
 	got, err := ag.GetSessionDir(repo)
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(repo, paths.EntireTmpDir, OpenCodeSessionSubdir), got)
+	require.Equal(t, filepath.Join(repo, paths.EntireTmpDir, openCodeSessionSubdir), got)
 }
 
 func TestGetSessionDir_UniquePrefixFromBareEntireTmp(t *testing.T) {

--- a/cmd/entire/cli/agent/opencode/opencode.go
+++ b/cmd/entire/cli/agent/opencode/opencode.go
@@ -164,13 +164,11 @@ func (a *OpenCodeAgent) GetSessionID(input *agent.HookInput) string {
 	return input.SessionID
 }
 
-// OpenCodeSessionSubdir is the per-agent subdirectory under .entire/tmp/
-// that holds OpenCode session transcripts. The subdir prevents
-// agent.AgentForTranscriptPath from misattributing other agents' files that
-// happen to land in .entire/tmp/ (notably in integration tests) to OpenCode
-// purely on a prefix match. lifecycle.go composes this with paths.EntireTmpDir
-// when writing the live transcript so the two paths stay in lockstep.
-const OpenCodeSessionSubdir = "opencode"
+// openCodeSessionSubdir keeps the OpenCode session dir under a unique
+// prefix inside .entire/tmp/. Without it, sibling agents (or integration
+// tests) that scribble into .entire/tmp/ would prefix-match
+// agent.AgentForTranscriptPath onto OpenCode.
+const openCodeSessionSubdir = "opencode"
 
 // GetSessionDir returns the directory where Entire stores OpenCode session transcripts.
 // Transcripts are ephemeral handoff files between the TS plugin and the Go hook handler.
@@ -187,7 +185,7 @@ func (a *OpenCodeAgent) GetSessionDir(repoPath string) (string, error) {
 		return override, nil
 	}
 
-	return filepath.Join(repoPath, paths.EntireTmpDir, OpenCodeSessionSubdir), nil
+	return filepath.Join(repoPath, paths.EntireTmpDir, openCodeSessionSubdir), nil
 }
 
 func (a *OpenCodeAgent) ResolveSessionFile(sessionDir, agentSessionID string) string {

--- a/cmd/entire/cli/agent/opencode/opencode.go
+++ b/cmd/entire/cli/agent/opencode/opencode.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -165,19 +164,30 @@ func (a *OpenCodeAgent) GetSessionID(input *agent.HookInput) string {
 	return input.SessionID
 }
 
+// OpenCodeSessionSubdir is the per-agent subdirectory under .entire/tmp/
+// that holds OpenCode session transcripts. The subdir prevents
+// agent.AgentForTranscriptPath from misattributing other agents' files that
+// happen to land in .entire/tmp/ (notably in integration tests) to OpenCode
+// purely on a prefix match. lifecycle.go composes this with paths.EntireTmpDir
+// when writing the live transcript so the two paths stay in lockstep.
+const OpenCodeSessionSubdir = "opencode"
+
 // GetSessionDir returns the directory where Entire stores OpenCode session transcripts.
 // Transcripts are ephemeral handoff files between the TS plugin and the Go hook handler.
 // Once checkpointed, the data lives on git refs and the file is disposable.
-// Stored in os.TempDir()/entire-opencode/<sanitized-path>/ to avoid squatting on
-// OpenCode's own directories (~/.opencode/ is project-level, not home-level).
+// Stored under <repoPath>/.entire/tmp/opencode/ to keep handoff files inside the
+// repo (worktree-safe, gitignored via .entire/.gitignore) and out of a shared
+// os.TempDir() location where other local users could read restored transcripts.
+// The opencode/ subdir gives the directory a unique prefix so agent routing
+// based on GetSessionDir can't confuse OpenCode with siblings that share
+// .entire/tmp/ as a scratch space.
 func (a *OpenCodeAgent) GetSessionDir(repoPath string) (string, error) {
 	// Check for test environment override
 	if override := os.Getenv("ENTIRE_TEST_OPENCODE_PROJECT_DIR"); override != "" {
 		return override, nil
 	}
 
-	projectDir := SanitizePathForOpenCode(repoPath)
-	return filepath.Join(os.TempDir(), "entire-opencode", projectDir), nil
+	return filepath.Join(repoPath, paths.EntireTmpDir, OpenCodeSessionSubdir), nil
 }
 
 func (a *OpenCodeAgent) ResolveSessionFile(sessionDir, agentSessionID string) string {
@@ -267,13 +277,4 @@ func (a *OpenCodeAgent) FormatResumeCommand(sessionID string) string {
 		return "opencode"
 	}
 	return "opencode -s " + sessionID
-}
-
-// nonAlphanumericRegex matches any non-alphanumeric character.
-var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9]`)
-
-// SanitizePathForOpenCode converts a path to a safe directory name.
-// Replaces any non-alphanumeric character with a dash (same approach as Claude/Gemini).
-func SanitizePathForOpenCode(path string) string {
-	return nonAlphanumericRegex.ReplaceAllString(path, "-")
 }

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -72,6 +72,13 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	return out, nil
 }
 
+// fetchBlobsBatchSize caps how many hashes are passed to a single
+// `git fetch-pack` invocation. Each hash adds 41 bytes (40 hex chars + a
+// separator) to the argv; with a typical Linux ARG_MAX of ~2 MiB we'd run
+// out of room around 50 k hashes. 500 keeps us comfortably below that
+// while still amortizing the per-call git startup cost.
+const fetchBlobsBatchSize = 500
+
 // FetchBlobs fetches specific objects (typically blobs) by hash from a remote.
 // Uses `git fetch-pack` rather than `git fetch` because the high-level
 // porcelain enforces partial-clone integrity checks that reject blob-only
@@ -80,9 +87,35 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 // and exits — which is exactly what we want when grabbing individual blobs
 // by SHA. Works against GitHub for any reachable object, including blobs.
 //
+// Hashes are submitted in batches (see fetchBlobsBatchSize) so that very
+// large fetches don't exceed the OS argv length limit. A failure on any
+// batch aborts the fetch and returns the error; callers handle fallback
+// (e.g. a full metadata branch fetch) at a higher layer.
+//
 // The remote should be a URL (not a remote name) to avoid persisting promisor
 // settings onto the named remote. Use FetchURL to obtain the URL.
 func FetchBlobs(ctx context.Context, remote string, hashes []string) error {
+	if len(hashes) == 0 {
+		return nil
+	}
+
+	for i := 0; i < len(hashes); i += fetchBlobsBatchSize {
+		end := i + fetchBlobsBatchSize
+		if end > len(hashes) {
+			end = len(hashes)
+		}
+		if err := fetchBlobsBatchFn(ctx, remote, hashes[i:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// fetchBlobsBatchFn is swappable for tests so the batching loop can be
+// exercised without running real git fetch-pack commands.
+var fetchBlobsBatchFn = fetchBlobsBatch //nolint:gochecknoglobals // intentional test seam
+
+func fetchBlobsBatch(ctx context.Context, remote string, hashes []string) error {
 	args := []string{"fetch-pack", remote}
 	args = append(args, hashes...)
 

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -648,6 +648,79 @@ func TestIsLocalPath(t *testing.T) {
 	}
 }
 
+func TestFetchBlobs_EmptyHashesNoOp(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	restore := withFetchBlobsBatchStub(t, func(_ context.Context, _ string, _ []string) error {
+		called = true
+		return nil
+	})
+	defer restore()
+
+	require.NoError(t, FetchBlobs(context.Background(), "https://example.com/repo.git", nil))
+	assert.False(t, called, "FetchBlobs with no hashes must not invoke git")
+}
+
+func TestFetchBlobs_BatchesLargeHashLists(t *testing.T) {
+	// Note: cannot t.Parallel() — overrides a package-level var.
+	const total = fetchBlobsBatchSize*2 + 3 // 1003 → expect 3 batches: 500, 500, 3
+
+	hashes := make([]string, total)
+	for i := range hashes {
+		hashes[i] = fmt.Sprintf("%040x", i)
+	}
+
+	var batches [][]string
+	restore := withFetchBlobsBatchStub(t, func(_ context.Context, _ string, h []string) error {
+		// Copy: the slice header points at a sub-slice of the caller's hashes.
+		got := make([]string, len(h))
+		copy(got, h)
+		batches = append(batches, got)
+		return nil
+	})
+	defer restore()
+
+	require.NoError(t, FetchBlobs(context.Background(), "https://example.com/repo.git", hashes))
+
+	require.Len(t, batches, 3, "1003 hashes at batchSize=500 must produce 3 batches")
+	assert.Len(t, batches[0], fetchBlobsBatchSize)
+	assert.Len(t, batches[1], fetchBlobsBatchSize)
+	assert.Len(t, batches[2], 3)
+	assert.Equal(t, hashes[0], batches[0][0])
+	assert.Equal(t, hashes[fetchBlobsBatchSize], batches[1][0])
+	assert.Equal(t, hashes[total-1], batches[2][len(batches[2])-1])
+}
+
+func TestFetchBlobs_AbortsOnBatchFailure(t *testing.T) {
+	// Note: cannot t.Parallel() — overrides a package-level var.
+	hashes := make([]string, fetchBlobsBatchSize+10)
+	for i := range hashes {
+		hashes[i] = fmt.Sprintf("%040x", i)
+	}
+
+	calls := 0
+	wantErr := errors.New("fetch-pack failed")
+	restore := withFetchBlobsBatchStub(t, func(_ context.Context, _ string, _ []string) error {
+		calls++
+		return wantErr
+	})
+	defer restore()
+
+	err := FetchBlobs(context.Background(), "https://example.com/repo.git", hashes)
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, calls, "FetchBlobs must abort after the first failing batch")
+}
+
+func withFetchBlobsBatchStub(t *testing.T, stub func(context.Context, string, []string) error) func() {
+	t.Helper()
+	original := fetchBlobsBatchFn
+	fetchBlobsBatchFn = stub
+	return func() {
+		fetchBlobsBatchFn = original
+	}
+}
+
 // envToMap converts an env slice to a map for easy assertions.
 // For duplicate keys, the last value wins.
 func envToMap(env []string) map[string]string {

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -652,11 +652,10 @@ func TestFetchBlobs_EmptyHashesNoOp(t *testing.T) {
 	t.Parallel()
 
 	called := false
-	restore := withFetchBlobsBatchStub(t, func(_ context.Context, _ string, _ []string) error {
+	withFetchBlobsBatchStub(t, func(_ context.Context, _ string, _ []string) error {
 		called = true
 		return nil
 	})
-	defer restore()
 
 	require.NoError(t, FetchBlobs(context.Background(), "https://example.com/repo.git", nil))
 	assert.False(t, called, "FetchBlobs with no hashes must not invoke git")
@@ -672,14 +671,13 @@ func TestFetchBlobs_BatchesLargeHashLists(t *testing.T) {
 	}
 
 	var batches [][]string
-	restore := withFetchBlobsBatchStub(t, func(_ context.Context, _ string, h []string) error {
+	withFetchBlobsBatchStub(t, func(_ context.Context, _ string, h []string) error {
 		// Copy: the slice header points at a sub-slice of the caller's hashes.
 		got := make([]string, len(h))
 		copy(got, h)
 		batches = append(batches, got)
 		return nil
 	})
-	defer restore()
 
 	require.NoError(t, FetchBlobs(context.Background(), "https://example.com/repo.git", hashes))
 
@@ -701,24 +699,21 @@ func TestFetchBlobs_AbortsOnBatchFailure(t *testing.T) {
 
 	calls := 0
 	wantErr := errors.New("fetch-pack failed")
-	restore := withFetchBlobsBatchStub(t, func(_ context.Context, _ string, _ []string) error {
+	withFetchBlobsBatchStub(t, func(_ context.Context, _ string, _ []string) error {
 		calls++
 		return wantErr
 	})
-	defer restore()
 
 	err := FetchBlobs(context.Background(), "https://example.com/repo.git", hashes)
 	require.ErrorIs(t, err, wantErr)
 	assert.Equal(t, 1, calls, "FetchBlobs must abort after the first failing batch")
 }
 
-func withFetchBlobsBatchStub(t *testing.T, stub func(context.Context, string, []string) error) func() {
+func withFetchBlobsBatchStub(t *testing.T, stub func(context.Context, string, []string) error) {
 	t.Helper()
 	original := fetchBlobsBatchFn
 	fetchBlobsBatchFn = stub
-	return func() {
-		fetchBlobsBatchFn = original
-	}
+	t.Cleanup(func() { fetchBlobsBatchFn = original })
 }
 
 // envToMap converts an env slice to a map for easy assertions.

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/entireio/cli/cmd/entire/cli/agent/opencode"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
@@ -1382,13 +1383,13 @@ func (r *OpenCodeHookRunner) SimulateOpenCodeTurnEnd(sessionID, transcriptPath s
 	r.T.Helper()
 
 	// For integration tests, write the mock transcript to the location where the
-	// lifecycle handler expects it (.entire/tmp/<session_id>.json)
+	// lifecycle handler expects it (.entire/tmp/opencode/<session_id>.json)
 	if transcriptPath != "" {
 		srcData, err := os.ReadFile(transcriptPath)
 		if err != nil {
 			r.T.Fatalf("SimulateOpenCodeTurnEnd: failed to read transcript from %q: %v", transcriptPath, err)
 		}
-		destDir := filepath.Join(r.RepoDir, ".entire", "tmp")
+		destDir := filepath.Join(r.RepoDir, ".entire", "tmp", opencode.OpenCodeSessionSubdir)
 		if err := os.MkdirAll(destDir, 0o755); err != nil {
 			r.T.Fatalf("SimulateOpenCodeTurnEnd: failed to create directory %q: %v", destDir, err)
 		}
@@ -1556,10 +1557,11 @@ func (env *TestEnv) SimulateOpenCodeSessionEnd(sessionID, transcriptPath string)
 	return runner.SimulateOpenCodeSessionEnd(sessionID, transcriptPath)
 }
 
-// CopyTranscriptToEntireTmp copies an OpenCode transcript to .entire/tmp/<sessionID>.json.
-// This simulates what `opencode export` does in production. Required for mid-turn commits
-// where PrepareTranscript calls fetchAndCacheExport, which in mock mode expects the file
-// to already exist at .entire/tmp/<sessionID>.json.
+// CopyTranscriptToEntireTmp copies an OpenCode transcript to
+// .entire/tmp/opencode/<sessionID>.json. This simulates what `opencode export`
+// does in production. Required for mid-turn commits where PrepareTranscript
+// calls fetchAndCacheExport, which in mock mode expects the file to already
+// exist at that path.
 func (env *TestEnv) CopyTranscriptToEntireTmp(sessionID, transcriptPath string) {
 	env.T.Helper()
 
@@ -1567,7 +1569,7 @@ func (env *TestEnv) CopyTranscriptToEntireTmp(sessionID, transcriptPath string) 
 	if err != nil {
 		env.T.Fatalf("CopyTranscriptToEntireTmp: failed to read transcript from %q: %v", transcriptPath, err)
 	}
-	destDir := filepath.Join(env.RepoDir, ".entire", "tmp")
+	destDir := filepath.Join(env.RepoDir, ".entire", "tmp", opencode.OpenCodeSessionSubdir)
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		env.T.Fatalf("CopyTranscriptToEntireTmp: failed to create directory %q: %v", destDir, err)
 	}

--- a/cmd/entire/cli/integration_test/hooks.go
+++ b/cmd/entire/cli/integration_test/hooks.go
@@ -1382,21 +1382,8 @@ func (r *OpenCodeHookRunner) SimulateOpenCodeTurnStart(sessionID, _, prompt stri
 func (r *OpenCodeHookRunner) SimulateOpenCodeTurnEnd(sessionID, transcriptPath string) error {
 	r.T.Helper()
 
-	// For integration tests, write the mock transcript to the location where the
-	// lifecycle handler expects it (.entire/tmp/opencode/<session_id>.json)
 	if transcriptPath != "" {
-		srcData, err := os.ReadFile(transcriptPath)
-		if err != nil {
-			r.T.Fatalf("SimulateOpenCodeTurnEnd: failed to read transcript from %q: %v", transcriptPath, err)
-		}
-		destDir := filepath.Join(r.RepoDir, ".entire", "tmp", opencode.OpenCodeSessionSubdir)
-		if err := os.MkdirAll(destDir, 0o755); err != nil {
-			r.T.Fatalf("SimulateOpenCodeTurnEnd: failed to create directory %q: %v", destDir, err)
-		}
-		destPath := filepath.Join(destDir, sessionID+".json")
-		if err := os.WriteFile(destPath, srcData, 0o644); err != nil {
-			r.T.Fatalf("SimulateOpenCodeTurnEnd: failed to write transcript to %q: %v", destPath, err)
-		}
+		writeOpenCodeMockTranscript(r.T, r.RepoDir, sessionID, transcriptPath, "SimulateOpenCodeTurnEnd")
 	}
 
 	input := map[string]string{
@@ -1557,24 +1544,42 @@ func (env *TestEnv) SimulateOpenCodeSessionEnd(sessionID, transcriptPath string)
 	return runner.SimulateOpenCodeSessionEnd(sessionID, transcriptPath)
 }
 
-// CopyTranscriptToEntireTmp copies an OpenCode transcript to
-// .entire/tmp/opencode/<sessionID>.json. This simulates what `opencode export`
-// does in production. Required for mid-turn commits where PrepareTranscript
-// calls fetchAndCacheExport, which in mock mode expects the file to already
-// exist at that path.
+// CopyTranscriptToEntireTmp copies an OpenCode transcript to the location where
+// the OpenCode agent (via fetchAndCacheExport in mock mode) expects to find it.
+// Used for mid-turn commits where PrepareTranscript is invoked before turn-end.
 func (env *TestEnv) CopyTranscriptToEntireTmp(sessionID, transcriptPath string) {
 	env.T.Helper()
+	writeOpenCodeMockTranscript(env.T, env.RepoDir, sessionID, transcriptPath, "CopyTranscriptToEntireTmp")
+}
+
+// writeOpenCodeMockTranscript copies an OpenCode transcript into the path the
+// OpenCode agent reads in ENTIRE_TEST_OPENCODE_MOCK_EXPORT mode. The destination
+// is derived from the OpenCode agent itself so the test never hard-codes the
+// .entire/tmp/opencode layout.
+func writeOpenCodeMockTranscript(t fatalfHelper, repoDir, sessionID, transcriptPath, caller string) {
+	t.Helper()
 
 	srcData, err := os.ReadFile(transcriptPath)
 	if err != nil {
-		env.T.Fatalf("CopyTranscriptToEntireTmp: failed to read transcript from %q: %v", transcriptPath, err)
+		t.Fatalf("%s: failed to read transcript from %q: %v", caller, transcriptPath, err)
 	}
-	destDir := filepath.Join(env.RepoDir, ".entire", "tmp", opencode.OpenCodeSessionSubdir)
+	ag := &opencode.OpenCodeAgent{}
+	destDir, err := ag.GetSessionDir(repoDir)
+	if err != nil {
+		t.Fatalf("%s: failed to resolve opencode session dir: %v", caller, err)
+	}
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
-		env.T.Fatalf("CopyTranscriptToEntireTmp: failed to create directory %q: %v", destDir, err)
+		t.Fatalf("%s: failed to create directory %q: %v", caller, destDir, err)
 	}
-	destPath := filepath.Join(destDir, sessionID+".json")
+	destPath := ag.ResolveSessionFile(destDir, sessionID)
 	if err := os.WriteFile(destPath, srcData, 0o644); err != nil {
-		env.T.Fatalf("CopyTranscriptToEntireTmp: failed to write transcript to %q: %v", destPath, err)
+		t.Fatalf("%s: failed to write transcript to %q: %v", caller, destPath, err)
 	}
+}
+
+// fatalfHelper is the minimal *testing.T surface used by writeOpenCodeMockTranscript.
+// Both TestEnv.T and OpenCodeHookRunner.T satisfy it.
+type fatalfHelper interface {
+	Helper()
+	Fatalf(format string, args ...interface{})
 }

--- a/cmd/entire/cli/osroot/osroot.go
+++ b/cmd/entire/cli/osroot/osroot.go
@@ -54,6 +54,27 @@ func WriteFile(root *os.Root, name string, data []byte, perm os.FileMode) (retEr
 	return nil
 }
 
+// WriteFileFromReader streams data from src to the named file relative to
+// root using os.Root for traversal-resistant access. Creates the file if it
+// doesn't exist, truncates it if it does. Unlike WriteFile, the source is
+// not buffered in memory — use this for files that could be large.
+func WriteFileFromReader(root *os.Root, name string, src io.Reader, perm os.FileMode) (retErr error) {
+	f, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err //nolint:wrapcheck // preserve original error for os.IsNotExist checks
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && retErr == nil {
+			retErr = closeErr
+		}
+	}()
+
+	if _, err := io.Copy(f, src); err != nil {
+		return err //nolint:wrapcheck // preserve original error
+	}
+	return nil
+}
+
 // Remove removes the named file relative to root using os.Root for
 // traversal-resistant access. Returns nil if the file doesn't exist.
 func Remove(root *os.Root, name string) error {

--- a/cmd/entire/cli/osroot/osroot_test.go
+++ b/cmd/entire/cli/osroot/osroot_test.go
@@ -3,6 +3,7 @@ package osroot_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
@@ -95,6 +96,53 @@ func TestWriteFile_TraversalBlocked(t *testing.T) {
 	defer root.Close()
 
 	err = osroot.WriteFile(root, "../escape.txt", []byte("bad"), 0o600)
+	assert.Error(t, err)
+}
+
+func TestWriteFileFromReader(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	src := strings.NewReader("streamed payload")
+	err = osroot.WriteFileFromReader(root, "stream.txt", src, 0o600)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "stream.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "streamed payload", string(data))
+}
+
+func TestWriteFileFromReader_Overwrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("old"), 0o644))
+
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	err = osroot.WriteFileFromReader(root, "existing.txt", strings.NewReader("new"), 0o600)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(dir, "existing.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(data))
+}
+
+func TestWriteFileFromReader_TraversalBlocked(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	err = osroot.WriteFileFromReader(root, "../escape.txt", strings.NewReader("bad"), 0o600)
 	assert.Error(t, err)
 }
 

--- a/cmd/entire/cli/utils.go
+++ b/cmd/entire/cli/utils.go
@@ -87,10 +87,11 @@ func copyFile(src, dst string) error {
 		return fmt.Errorf("copyFile: dst must be absolute, got %q", dst)
 	}
 
-	input, err := os.ReadFile(src)
+	srcFile, err := os.Open(src)
 	if err != nil {
 		return err //nolint:wrapcheck // already present in codebase
 	}
+	defer srcFile.Close()
 
 	root, relPath, err := openAllowedRoot(dst)
 	if err != nil {
@@ -98,7 +99,7 @@ func copyFile(src, dst string) error {
 	}
 	defer root.Close()
 
-	if err := osroot.WriteFile(root, relPath, input, 0o600); err != nil {
+	if err := osroot.WriteFileFromReader(root, relPath, srcFile, 0o600); err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}
 	return nil

--- a/cmd/entire/cli/utils_test.go
+++ b/cmd/entire/cli/utils_test.go
@@ -110,6 +110,29 @@ func TestCopyFile_OutsideAllowedDirs(t *testing.T) {
 	assert.Contains(t, err.Error(), "outside allowed directories")
 }
 
+func TestCopyFile_LargePayloadStreams(t *testing.T) {
+	t.Parallel()
+
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// 8 MiB exercises the streaming path well past any sane read buffer
+	// without making the test slow.
+	const size = 8 * 1024 * 1024
+	payload := bytes.Repeat([]byte{0xAB}, size)
+
+	srcFile := filepath.Join(srcDir, "big.bin")
+	require.NoError(t, os.WriteFile(srcFile, payload, 0o644))
+
+	dstFile := filepath.Join(dstDir, "big.bin")
+	require.NoError(t, copyFile(srcFile, dstFile))
+
+	got, err := os.ReadFile(dstFile)
+	require.NoError(t, err)
+	require.Len(t, got, size, "copied length must match source")
+	assert.True(t, bytes.Equal(payload, got), "copied bytes must match source")
+}
+
 func TestCopyFile_OverwritesExisting(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/400
<!-- entire-trail-link-end -->

## Summary

Three independent hardening fixes carried forward from the analysis of #799, each narrowed to what's actually reachable on current code, with tests.

- **opencode session dir** — move from `/tmp/entire-opencode/<sanitized-path>/` to `<repoPath>/.entire/tmp/opencode/`. Closes a cross-user transcript exfil window on shared Linux machines (other local users can pre-create the predictable `/tmp` path and read whatever `entire rewind`/`entire resume` stashes there — `os.Root` already blocks symlink-redirected *writes* but not *reads* once the dir is owned by them). The new location is gitignored, per-user, and per-worktree by construction. The `opencode/` subdir gives `GetSessionDir` a unique prefix so `agent.AgentForTranscriptPath` can't confuse OpenCode with siblings that also touch `.entire/tmp/`. `sessionTranscriptPath` and `fetchAndCacheExport` follow suit so the live export and the path agent routing/rewind agree on are identical.
- **copyFile streaming** — replace `os.ReadFile + osroot.WriteFile` with `os.Open + osroot.WriteFileFromReader` (a new streaming counterpart to `WriteFile` that preserves the `os.Root` traversal-resistance guarantees). Practical effect is small (the API body cap is 16 MiB), but streaming is the right default and the new helper keeps the policy inside the `osroot` package.
- **FetchBlobs argv batching** — `git fetch-pack` takes every hash on argv at ~41 bytes/hash; a Linux `ARG_MAX` of 2 MiB caps a single call around 50k hashes. Split into batches of 500 and abort on the first failure so the existing `FetchBlobsByHash` fallback path still kicks in at the caller.

### Skipped from #799 (with reasoning)
- **PII deep-copy on read** — wrong layer; the maps aren't mutated after `ConfigurePII`. If we want to defend against a caller mutating their passed map, deep-copy in `ConfigurePII` once, not on every reader.
- **Post-rename `Lstat` in `session/state.go`** — can't fire. `os.Rename` of a regular file always produces a regular file, and session IDs are already validated.
- **`geminicli`/`opencode` "single oversized message" error** — would break the existing `TestChunkTranscript_SingleOversizedMessage` contract which explicitly asserts a single oversized message returns one oversized chunk with no error.
- **Fixed-buffer rewrite of the Claude transcript reader** — would silently truncate ≤16 MiB legitimate lines (we just raised the API body cap to 16 MiB) and shipped without tests. Needs a redesign + tests before adopting.

### Why a unique `opencode/` subdir, not bare `.entire/tmp/`
First pass put OpenCode at `<repoPath>/.entire/tmp/` to align with the existing `fetchAndCacheExport` location. That broke `TestShadowStrategy_MidSessionCommit_FilesTouchedFallback`: the integration test writes Claude transcripts to `.entire/tmp/<id>.jsonl`, and `agent.AgentForTranscriptPath` walked every agent's `GetSessionDir` and prefix-matched Claude's transcript to OpenCode. The `opencode/` subdir restores the unambiguous routing.

## Test plan

- [x] `mise run check` (fmt + lint + test:ci)
- [x] New unit tests: `TestWriteFileFromReader` × 3, `TestCopyFile_LargePayloadStreams`, `TestGetSessionDir_*` × 3 (including a per-worktree-isolation check and a prefix-collision check), `TestFetchBlobs_*` × 3
- [x] Integration test that previously failed (`TestShadowStrategy_MidSessionCommit_FilesTouchedFallback`) now passes
- [x] Full integration suite passes
- [x] E2E canary (Vogon) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transcript storage paths and low-level file/git plumbing; regressions could break resume/rewind or remote blob fetching, but changes are localized and well-covered by tests.
> 
> **Overview**
> **Hardens OpenCode transcript handling** by moving session exports from a shared `os.TempDir()` location into per-worktree `.entire/tmp/opencode/`, and aligning `sessionTranscriptPath`/`fetchAndCacheExport`/integration helpers to use the same path to avoid agent misrouting and reduce cross-user exposure.
> 
> **Switches `copyFile` to streaming I/O** by adding `osroot.WriteFileFromReader` and using it instead of `os.ReadFile`+buffered writes, keeping `os.Root` traversal-resistance while avoiding loading large payloads into memory.
> 
> **Adds argv-safe batching to `remote.FetchBlobs`** by splitting large hash lists into fixed-size `git fetch-pack` batches (with early abort on failure) and introducing a test seam plus unit tests for empty, batched, and failing cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddbc4cffbdf89f2a422bd4f794c8cf3483ac56b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->