### PR TITLE
Bump Go to 1.26.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,9 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 'stable'
+          # Track go.mod so future Go bumps don't need a parallel workflow
+          # edit; release.yml uses the same pattern.
+          go-version-file: go.mod
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/entireio/cli
 
-go 1.26.2
+go 1.26.3
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Please also keep the version aligned in the go.mod file
-go = { version = '1.26.2', postinstall = "go install github.com/go-delve/delve/cmd/dlv@latest && go install gotest.tools/gotestsum@latest" }
+go = { version = '1.26.3', postinstall = "go install github.com/go-delve/delve/cmd/dlv@latest && go install gotest.tools/gotestsum@latest" }
 golangci-lint = '2.11.3'
 shellcheck = 'latest'
 tmux = 'latest'


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/407
<!-- entire-trail-link-end -->

## Summary

- `mise.toml`: bump the mise-managed Go from 1.26.2 to 1.26.3.
- `.github/workflows/lint.yml`: switch `setup-go` from `go-version: 'stable'` to `go-version-file: go.mod` so the lint job auto-tracks `go.mod` going forward (matches `release.yml`).

## Test plan

- [x] `mise run lint` clean locally.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to developer tooling and CI configuration, though CI may break if the `go.mod` Go version isn’t kept in sync with the intended bump.
> 
> **Overview**
> Bumps the `mise`-managed Go toolchain from **1.26.2 → 1.26.3**.
> 
> Updates the `lint` GitHub Actions workflow to use `actions/setup-go` with `go-version-file: go.mod` (instead of `stable`) so CI automatically tracks the repo’s pinned Go version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 244430112e7009bb81c8e839a492e81c5d336211. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->