### PR TITLE
Update trail watch review event endpoint

### DIFF
--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -16,8 +16,8 @@ type TrailListResponse struct {
 
 // TrailResource represents a single trail from the API.
 type TrailResource struct {
+	ID              string           `json:"id,omitempty"`
 	Number          int              `json:"number,omitempty"`
-	TrailID         string           `json:"trail_id"`
 	Branch          string           `json:"branch"`
 	Base            string           `json:"base"`
 	Title           string           `json:"title"`
@@ -42,7 +42,7 @@ type TrailResource struct {
 func (r *TrailResource) ToMetadata() *trail.Metadata {
 	m := &trail.Metadata{
 		Number:    r.Number,
-		TrailID:   trail.ID(r.TrailID),
+		TrailID:   trail.ID(r.ID),
 		Branch:    r.Branch,
 		Base:      r.Base,
 		Title:     r.Title,

--- a/cmd/entire/cli/api/trail_types_test.go
+++ b/cmd/entire/cli/api/trail_types_test.go
@@ -1,0 +1,12 @@
+package api
+
+import "testing"
+
+func TestTrailResourceToMetadataUsesID(t *testing.T) {
+	t.Parallel()
+
+	metadata := (&TrailResource{ID: "trail-db-id", Branch: "feature/x"}).ToMetadata()
+	if got := metadata.TrailID.String(); got != "trail-db-id" {
+		t.Fatalf("metadata TrailID = %q, want stable API id", got)
+	}
+}

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -611,7 +611,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		return fmt.Errorf("failed to decode create response: %w", err)
 	}
 
-	fmt.Fprintf(w, "Created trail %q for branch %s (ID: %s)\n", createResp.Trail.Title, createResp.Trail.Branch, createResp.Trail.TrailID)
+	fmt.Fprintf(w, "Created trail %q for branch %s (ID: %s)\n", createResp.Trail.Title, createResp.Trail.Branch, createResp.Trail.ID)
 
 	// --- Phase 3: Post-creation local operations ---
 
@@ -743,7 +743,7 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, s
 	// Build update request with only changed fields
 	updateReq := buildTrailUpdateRequest(found, statusStr, title, body, labelAdd, labelRemove)
 
-	resp, err := client.Patch(ctx, trailsBasePath(host, owner, repoName)+"/"+found.TrailID, updateReq)
+	resp, err := client.Patch(ctx, trailsBasePath(host, owner, repoName)+"/"+found.ID, updateReq)
 	if err != nil {
 		return fmt.Errorf("failed to update trail: %w", err)
 	}

--- a/cmd/entire/cli/trail_watch_cmd.go
+++ b/cmd/entire/cli/trail_watch_cmd.go
@@ -56,7 +56,7 @@ connection (~50s) and on transient network errors.
 If <number> is omitted, the trail for the current branch is used.
 
 This command resolves the trail's id internally and streams
-GET /api/v1/review-events?trail_id=<id>&stream=1.
+GET /api/v1/trails/<id>/reviews/events with Accept: text/event-stream.
 
 Events emitted by the server:
   ready              initial frame, includes trail and cursor
@@ -188,10 +188,10 @@ func resolveTrailWatchTarget(ctx context.Context, client *api.Client, number int
 	if found == nil {
 		return "", "", fmt.Errorf("no trail found for branch %q (pass an explicit trail number)", branch)
 	}
-	if found.TrailID == "" {
+	if found.ID == "" {
 		return "", "", fmt.Errorf("trail for branch %q has no id yet", branch)
 	}
-	return found.TrailID, trailWatchDescription(host, owner, repo, found.Number, found.TrailID), nil
+	return found.ID, trailWatchDescription(host, owner, repo, found.Number, found.ID), nil
 }
 
 func resolveTrailWatchNumber(ctx context.Context, client *api.Client, number int) (trailID, description string, err error) {
@@ -206,10 +206,10 @@ func resolveTrailWatchNumber(ctx context.Context, client *api.Client, number int
 	if found == nil {
 		return "", "", fmt.Errorf("no trail #%d found in %s/%s/%s", number, host, owner, repo)
 	}
-	if found.TrailID == "" {
+	if found.ID == "" {
 		return "", "", fmt.Errorf("trail #%d has no id yet", number)
 	}
-	return found.TrailID, trailWatchDescription(host, owner, repo, found.Number, found.TrailID), nil
+	return found.ID, trailWatchDescription(host, owner, repo, found.Number, found.ID), nil
 }
 
 func trailWatchDescription(host, owner, repo string, number int, trailID string) string {
@@ -220,10 +220,7 @@ func trailWatchDescription(host, owner, repo string, number int, trailID string)
 }
 
 func reviewEventsPath(trailID string) string {
-	query := url.Values{}
-	query.Set("trail_id", trailID)
-	query.Set("stream", "1")
-	return "/api/v1/review-events?" + query.Encode()
+	return "/api/v1/trails/" + url.PathEscape(trailID) + "/reviews/events"
 }
 
 type streamCloseReason int

--- a/cmd/entire/cli/trail_watch_cmd_test.go
+++ b/cmd/entire/cli/trail_watch_cmd_test.go
@@ -40,7 +40,7 @@ func fakeSSEServer(t *testing.T, frames []string) (*httptest.Server, *string) {
 
 func TestReviewEventsPath(t *testing.T) {
 	got := reviewEventsPath("trail id/with slash")
-	want := "/api/v1/review-events?stream=1&trail_id=trail+id%2Fwith+slash"
+	want := "/api/v1/trails/trail%20id%2Fwith%20slash/reviews/events"
 	if got != want {
 		t.Fatalf("reviewEventsPath = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary
- point `entire trail watch` at `GET /api/v1/trails/:trail_id/reviews/events`
- keep `Accept: text/event-stream` SSE negotiation through the existing stream client
- use the stable `trail.id` field from trail list responses before constructing the stream URL
- update endpoint/id coverage

## Tests
- `mise exec -- go test ./cmd/entire/cli ./cmd/entire/cli/api`
- `mise exec -- golangci-lint run ./cmd/entire/cli ./cmd/entire/cli/api`