### PR TITLE
perf(redact): batch OPF inference across unpushed commits

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -287,13 +287,13 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 				return plumbing.ZeroHash, fmt.Errorf("load tree for %s: %w", c.Hash.String()[:7], err)
 			}
 			pc.startIdx = len(globalBlobs)
-			// Whole-tree redaction (empty shardPath): each v1 commit tree is
-			// cumulative, so the newest commit can still carry older shards
-			// that were 7-layer-only before this rewrite. Redacting the whole
-			// tree for every unapplied commit keeps the final rewritten tip
-			// from reintroducing an un-OPF-redacted older shard. collect and
-			// apply MUST pass the same scope so cached keys line up.
-			if err := collectTreeBlobs(repo, tree, "", "", &pc.blobs, &pc.paths); err != nil {
+			// Whole-tree redaction: each v1 commit tree is cumulative, so the
+			// newest commit can still carry older shards that were 7-layer-only
+			// before this rewrite. Redacting the whole tree for every unapplied
+			// commit keeps the final rewritten tip from reintroducing an
+			// un-OPF-redacted older shard. collect and apply walk the tree the
+			// same way so the cached keys line up.
+			if err := collectTreeBlobs(repo, tree, "", &pc.blobs, &pc.paths); err != nil {
 				return plumbing.ZeroHash, fmt.Errorf("collect blobs %s: %w", c.Hash.String()[:7], err)
 			}
 			for _, b := range pc.blobs {
@@ -479,8 +479,8 @@ func listUnpushedV1Commits(repo *git.Repository, localTip, remoteTip plumbing.Ha
 // Correctness note: each v1 commit tree is cumulative. During a multi-commit
 // rewrite, the newest original commit can still contain older shards that were
 // 7-layer-only before this rewrite. The collect/apply walkers redact the whole
-// tree (empty shardPath) for every unapplied commit so the final rewritten tip
-// cannot reintroduce an older un-OPF-redacted shard.
+// tree for every unapplied commit so the final rewritten tip cannot
+// reintroduce an older un-OPF-redacted shard.
 func rebuildV1Commit(ctx context.Context, repo *git.Repository, oldCommit *object.Commit, parent plumbing.Hash, redactedByPath map[string][]byte) (plumbing.Hash, error) {
 	newTree := oldCommit.TreeHash
 	if !trailers.HasOPFApplied(oldCommit.Message) {
@@ -488,9 +488,9 @@ func rebuildV1Commit(ctx context.Context, repo *git.Repository, oldCommit *objec
 		if err != nil {
 			return plumbing.ZeroHash, fmt.Errorf("load tree: %w", err)
 		}
-		// Whole-tree redaction (empty shardPath) — see the collect pass in
+		// Whole-tree redaction — see the collect pass in
 		// RewriteUnpushedV1WithOPF for why we never scope to a single shard.
-		newTree, err = rebuildTreeWithCachedRedaction(repo, tree, "", "", redactedByPath)
+		newTree, err = rebuildTreeWithCachedRedaction(repo, tree, "", redactedByPath)
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
@@ -524,29 +524,6 @@ func rebuildV1Commit(ctx context.Context, repo *git.Repository, oldCommit *objec
 	return hash, nil
 }
 
-// parseShardPathFromCommitMessage extracts the sharded path
-// "<id[:2]>/<id[2:]>" from a "Checkpoint: <id>" subject line.
-// Returns "" when the subject doesn't match (bootstrap commits, or
-// historical commits with a different format) — callers walk the
-// whole tree in that case.
-func parseShardPathFromCommitMessage(message string) string {
-	firstLine, _, _ := strings.Cut(message, "\n")
-	const prefix = "Checkpoint: "
-	if !strings.HasPrefix(firstLine, prefix) {
-		return ""
-	}
-	id := strings.TrimSpace(firstLine[len(prefix):])
-	if len(id) != 12 {
-		return ""
-	}
-	for _, c := range id {
-		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
-			return ""
-		}
-	}
-	return id[:2] + "/" + id[2:]
-}
-
 // isRedactableBlobName reports whether a file at the given name should
 // flow through OPF. The policy is fail-closed: every regular file
 // inside the shard is redacted EXCEPT content_hash.txt, which is
@@ -567,14 +544,16 @@ func isRedactableBlobName(name string) bool {
 	return name != paths.ContentHashFileName
 }
 
-// collectTreeBlobs walks tree and appends every redactable blob's
-// content + full tree path to the parallel output slices. The same
-// shard-scoping rules as rebuildTreeWithCachedRedaction apply.
+// collectTreeBlobs walks the whole tree and appends every redactable
+// blob's content + full tree path to the parallel output slices. It
+// walks the entire tree (no shard scoping — see RewriteUnpushedV1WithOPF
+// for why); rebuildTreeWithCachedRedaction applies the same walk so the
+// cached keys line up.
 //
 // blobs[i] and paths[i] correspond: paths[i] is the full path within
 // the tree (e.g. "ab/cd.../0/full.jsonl"), used later by the apply
 // walker to find each blob's redacted bytes in the cached map.
-func collectTreeBlobs(repo *git.Repository, tree *object.Tree, pathPrefix, shardPath string, blobs *[]redact.NamedBlob, paths *[]string) error {
+func collectTreeBlobs(repo *git.Repository, tree *object.Tree, pathPrefix string, blobs *[]redact.NamedBlob, paths *[]string) error {
 	for _, e := range tree.Entries {
 		switch e.Mode { //nolint:exhaustive // non-tree/blob modes are unreachable here
 		case filemode.Dir:
@@ -582,20 +561,14 @@ func collectTreeBlobs(repo *git.Repository, tree *object.Tree, pathPrefix, shard
 			if pathPrefix != "" {
 				subPath = pathPrefix + "/" + e.Name
 			}
-			if !shouldDescend(subPath, shardPath) {
-				continue
-			}
 			subTree, err := repo.TreeObject(e.Hash)
 			if err != nil {
 				return fmt.Errorf("load subtree %s/%s: %w", pathPrefix, e.Name, err)
 			}
-			if err := collectTreeBlobs(repo, subTree, subPath, shardPath, blobs, paths); err != nil {
+			if err := collectTreeBlobs(repo, subTree, subPath, blobs, paths); err != nil {
 				return err
 			}
 		case filemode.Regular, filemode.Executable:
-			if !insideShard(pathPrefix, shardPath) {
-				continue
-			}
 			if !isRedactableBlobName(e.Name) {
 				continue
 			}
@@ -614,21 +587,16 @@ func collectTreeBlobs(repo *git.Repository, tree *object.Tree, pathPrefix, shard
 	return nil
 }
 
-// rebuildTreeWithCachedRedaction walks tree and produces a new tree
-// using the precomputed redactedByPath map for redactable blobs.
+// rebuildTreeWithCachedRedaction walks the whole tree and produces a new
+// tree using the precomputed redactedByPath map for redactable blobs.
 // content_hash.txt files are recomputed in a second pass against the
 // new full.jsonl in the same directory.
 //
-// shardPath scopes the walk: only files at paths starting with
-// shardPath get redacted; other shards (and the root-level entries
-// outside the shard) are copied verbatim. Empty shardPath means walk
-// everything (used for bootstrap/unknown-subject commits).
-//
-// Path-specific behavior (when in the target shard):
+// Path-specific behavior:
 //   - content_hash.txt → SHA256 of the sibling full.jsonl's new bytes
 //     (deferred; not redacted itself)
 //   - everything else → bytes looked up in redactedByPath. The
-//     fail-closed policy redacts ANY regular file inside the shard,
+//     fail-closed policy redacts ANY regular file except content_hash.txt,
 //     not just a closed allowlist of suffixes — a future blob type
 //     (.md prose, agent dumps, no-extension transcript blobs) is
 //     covered by default rather than slipping through. The collect
@@ -641,7 +609,7 @@ func collectTreeBlobs(repo *git.Repository, tree *object.Tree, pathPrefix, shard
 // OR a concurrent storage mutation that changed the tree between
 // passes; we abort the rewrite rather than silently shipping
 // unredacted content with the OPF-applied trailer.
-func rebuildTreeWithCachedRedaction(repo *git.Repository, tree *object.Tree, pathPrefix, shardPath string, redactedByPath map[string][]byte) (plumbing.Hash, error) {
+func rebuildTreeWithCachedRedaction(repo *git.Repository, tree *object.Tree, pathPrefix string, redactedByPath map[string][]byte) (plumbing.Hash, error) {
 	entries := make([]object.TreeEntry, 0, len(tree.Entries))
 	// deferredHashes records indexes of content_hash.txt entries we
 	// need to recompute after the full.jsonl in the same dir is built.
@@ -660,38 +628,24 @@ func rebuildTreeWithCachedRedaction(repo *git.Repository, tree *object.Tree, pat
 			if pathPrefix != "" {
 				subPath = pathPrefix + "/" + e.Name
 			}
-			// Shard-scoping: only descend into directories that lead
-			// to the target shard, the shard itself, or its
-			// descendants. Other shard subtrees stay byte-identical.
-			if !shouldDescend(subPath, shardPath) {
-				entries = append(entries, e)
-				continue
-			}
 			subTree, err := repo.TreeObject(e.Hash)
 			if err != nil {
 				return plumbing.ZeroHash, fmt.Errorf("load subtree %s/%s: %w", pathPrefix, e.Name, err)
 			}
-			newSub, err := rebuildTreeWithCachedRedaction(repo, subTree, subPath, shardPath, redactedByPath)
+			newSub, err := rebuildTreeWithCachedRedaction(repo, subTree, subPath, redactedByPath)
 			if err != nil {
 				return plumbing.ZeroHash, err
 			}
 			entries = append(entries, object.TreeEntry{Name: e.Name, Mode: e.Mode, Hash: newSub})
 
 		case filemode.Regular, filemode.Executable:
-			// Outside the target shard: copy verbatim. Inside (or when
-			// shardPath is empty for the bootstrap fallback): redact
-			// per file type.
-			if !insideShard(pathPrefix, shardPath) {
-				entries = append(entries, e)
-				continue
-			}
 			switch e.Name {
 			case paths.ContentHashFileName:
 				deferredHashes = append(deferredHashes, deferred{idx: len(entries), entryName: e.Name, entryMode: e.Mode})
 				entries = append(entries, e) // placeholder; fixed in second pass
 			default:
-				// Inverted policy: every regular file inside the shard
-				// except content_hash.txt expects redacted bytes from the
+				// Inverted policy: every regular file except
+				// content_hash.txt expects redacted bytes from the
 				// collect pass. A missing key means the collect pass
 				// didn't visit this path — either the storage changed
 				// between passes or the two walkers disagree on which
@@ -745,40 +699,6 @@ func rebuildTreeWithCachedRedaction(repo *git.Repository, tree *object.Tree, pat
 		return plumbing.ZeroHash, fmt.Errorf("store tree: %w", err)
 	}
 	return hash, nil
-}
-
-// shouldDescend reports whether the walker should recurse into a
-// directory at path. With an empty shardPath we descend everywhere
-// (bootstrap fallback). Otherwise we descend only into the target
-// shard, its ancestors (so we can reach it), and its descendants.
-func shouldDescend(path, shardPath string) bool {
-	if shardPath == "" || path == "" {
-		// shardPath="" means "no scoping" (bootstrap fallback);
-		// path=="" is the root, which is the ancestor of every shard.
-		return true
-	}
-	if path == shardPath {
-		return true
-	}
-	// ancestor of shardPath: shardPath starts with path + "/"
-	if strings.HasPrefix(shardPath+"/", path+"/") {
-		return true
-	}
-	// descendant of shardPath: path starts with shardPath + "/"
-	return strings.HasPrefix(path+"/", shardPath+"/")
-}
-
-// insideShard reports whether file blobs at pathPrefix should be
-// redacted. Empty shardPath means "redact everywhere"; otherwise the
-// path must equal shardPath or be a descendant of it.
-func insideShard(pathPrefix, shardPath string) bool {
-	if shardPath == "" {
-		return true
-	}
-	if pathPrefix == shardPath {
-		return true
-	}
-	return strings.HasPrefix(pathPrefix+"/", shardPath+"/")
 }
 
 func readBlob(repo *git.Repository, hash plumbing.Hash) ([]byte, error) {

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -155,6 +155,38 @@ func resolveBatchLimit() int {
 	return batchDefaultLimit
 }
 
+// OPFRawBytesTooLargeError: the cumulative raw blob bytes the
+// collection pass loaded into memory exceeded the safety ceiling.
+// Unlike the leaf-byte cap, this is about RAM headroom rather than
+// inference wall-clock — a 200 MiB push of mostly-structural JSON has
+// tiny leaf content but huge raw bytes, and would OOM the user's
+// shell before the leaf-byte cap got a chance to fire.
+//
+// The raw ceiling is derived from ENTIRE_OPF_BATCH_LIMIT (raw =
+// leaf × rawByteCapMultiplier) so a user bumping the leaf cap
+// proportionally bumps the raw ceiling and doesn't need a second
+// env var.
+type OPFRawBytesTooLargeError struct {
+	RawBytes int
+	Limit    int
+}
+
+func (e *OPFRawBytesTooLargeError) Error() string {
+	return fmt.Sprintf("OPF rewrite would buffer %d raw blob bytes across "+
+		"all unpushed commits (limit %d, ~%d× the prose-leaf cap as a RAM ceiling). "+
+		"Bump ENTIRE_OPF_BATCH_LIMIT (the raw ceiling scales with it) "+
+		"or push without OPF (ENTIRE_OPF=no git push) and let a smaller "+
+		"follow-up push run OPF",
+		e.RawBytes, e.Limit, rawByteCapMultiplier)
+}
+
+// rawByteCapMultiplier ties the raw-byte RAM ceiling to the leaf-byte
+// inference cap. 100× means: leaf cap 2 MiB → raw ceiling 200 MiB.
+// Picked to comfortably exceed any realistic JSON-scaffolding ratio
+// (a 10 MiB JSONL with 300 KB of leaves still fits) while preventing
+// pathological RAM blowups (a 5 GiB pasted dump aborts before loading).
+const rawByteCapMultiplier = 100
+
 // RewriteUnpushedV1WithOPF re-redacts unpushed entire/checkpoints/v1
 // commits with OPF, builds new commits carrying Entire-OPF-Applied:
 // true, and CAS-updates the local ref. Idempotent: already-applied
@@ -225,6 +257,12 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 	}
 	var globalBlobs []redact.NamedBlob
 	pendings := make([]pendingCommit, 0, len(unpushed))
+	// Bound raw-bytes-in-memory incrementally so a pathological push
+	// (e.g. 5 GiB of pasted dumps) aborts before exhausting the user's
+	// shell RAM. The leaf-byte cap downstream is about inference cost;
+	// this one is about memory ceiling and fires earlier.
+	rawCap := resolveBatchLimit() * rawByteCapMultiplier
+	var rawBytesSoFar int
 	for _, c := range unpushed {
 		pc := pendingCommit{commit: c}
 		if !trailers.HasOPFApplied(c.Message) {
@@ -236,6 +274,12 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 			pc.startIdx = len(globalBlobs)
 			if err := collectTreeBlobs(repo, tree, "", pc.shardPath, &pc.blobs, &pc.paths); err != nil {
 				return plumbing.ZeroHash, fmt.Errorf("collect blobs %s: %w", c.Hash.String()[:7], err)
+			}
+			for _, b := range pc.blobs {
+				rawBytesSoFar += len(b.Content)
+			}
+			if rawBytesSoFar > rawCap {
+				return plumbing.ZeroHash, &OPFRawBytesTooLargeError{RawBytes: rawBytesSoFar, Limit: rawCap}
 			}
 			globalBlobs = append(globalBlobs, pc.blobs...)
 		}

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -112,6 +112,49 @@ func resolveBootstrapLimit() int {
 	return bootstrapDefaultLimit
 }
 
+// OPFBatchTooLargeError: a single push has more prose-leaf content
+// than ENTIRE_OPF_BATCH_LIMIT will allow OPF to chew through in one
+// inference call. Pushing under the limit yields a single ~10-30s
+// pause; without the cap, a 100MB-of-prose push could take an hour.
+//
+// The user-facing remediation is identical in shape to
+// BootstrapTooLargeError: bump the limit, push without OPF, or break
+// the push into smaller pieces.
+type OPFBatchTooLargeError struct {
+	LeafBytes int
+	Limit     int
+}
+
+func (e *OPFBatchTooLargeError) Error() string {
+	return fmt.Sprintf("OPF batch would inference %d prose-leaf bytes "+
+		"(limit %d). Set ENTIRE_OPF_BATCH_LIMIT=<bytes> or =unlimited to override, "+
+		"or push without OPF (ENTIRE_OPF=no git push) and let a smaller follow-up push run OPF",
+		e.LeafBytes, e.Limit)
+}
+
+const (
+	// batchDefaultLimit caps the cumulative prose-leaf bytes one push
+	// will hand to OPF. 2 MB at ~5.4s/100KB ≈ ~110s of inference, on
+	// the high end of what's acceptable as a single push pause but
+	// generous enough that any realistic push fits.
+	batchDefaultLimit = 2 * 1024 * 1024
+	batchEnvVar       = "ENTIRE_OPF_BATCH_LIMIT"
+)
+
+func resolveBatchLimit() int {
+	v := strings.TrimSpace(os.Getenv(batchEnvVar))
+	switch {
+	case v == "":
+		return batchDefaultLimit
+	case strings.EqualFold(v, "unlimited"):
+		return math.MaxInt32
+	}
+	if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		return n
+	}
+	return batchDefaultLimit
+}
+
 // RewriteUnpushedV1WithOPF re-redacts unpushed entire/checkpoints/v1
 // commits with OPF, builds new commits carrying Entire-OPF-Applied:
 // true, and CAS-updates the local ref. Idempotent: already-applied
@@ -157,20 +200,82 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 		}
 	}
 
-	parent := remoteTip
+	// Fail-closed defense: if OPF is already broken at the start of
+	// this push (an earlier process step tripped the breaker), abort
+	// before tagging any commits as OPF-applied. Without this, the
+	// per-blob fallback inside the no-OPF cases of BatchBytesWithPrivacyFilter
+	// could let 7-layer content slip out with the trailer attached.
+	if redact.OPFBreakerTripped() {
+		return plumbing.ZeroHash, &OPFRuntimeFailedError{OPFCommand: redact.OPFCommand()}
+	}
+
+	// Pass 1: collect every redactable blob from every unpushed commit
+	// that still needs OPF. Already-applied commits get re-parented
+	// later without collecting (their tree stays as-is). We also track
+	// each blob's source commit + tree path so we can route the redacted
+	// bytes back during apply.
+	type pendingCommit struct {
+		commit    *object.Commit
+		shardPath string
+		// blobs and paths are parallel slices; len(paths)==len(blobs).
+		// startIdx is this commit's offset into the global redacted slice.
+		blobs    []redact.NamedBlob
+		paths    []string
+		startIdx int
+	}
+	var globalBlobs []redact.NamedBlob
+	pendings := make([]pendingCommit, 0, len(unpushed))
 	for _, c := range unpushed {
-		newHash, err := rebuildV1Commit(ctx, repo, c, parent)
+		pc := pendingCommit{commit: c}
+		if !trailers.HasOPFApplied(c.Message) {
+			pc.shardPath = parseShardPathFromCommitMessage(c.Message)
+			tree, err := repo.TreeObject(c.TreeHash)
+			if err != nil {
+				return plumbing.ZeroHash, fmt.Errorf("load tree for %s: %w", c.Hash.String()[:7], err)
+			}
+			pc.startIdx = len(globalBlobs)
+			if err := collectTreeBlobs(repo, tree, "", pc.shardPath, &pc.blobs, &pc.paths); err != nil {
+				return plumbing.ZeroHash, fmt.Errorf("collect blobs %s: %w", c.Hash.String()[:7], err)
+			}
+			globalBlobs = append(globalBlobs, pc.blobs...)
+		}
+		pendings = append(pendings, pc)
+	}
+
+	// Pass 2: enforce the leaf-byte cap, then make exactly ONE OPF
+	// shell-out for the whole push. The cap runs before the shell-out
+	// so a too-large push fails fast with a clear remediation message.
+	var globalRedacted [][]byte
+	if len(globalBlobs) > 0 {
+		leafBytes := redact.SumProseLeafBytes(globalBlobs)
+		if limit := resolveBatchLimit(); leafBytes > limit {
+			return plumbing.ZeroHash, &OPFBatchTooLargeError{LeafBytes: leafBytes, Limit: limit}
+		}
+		globalRedacted, err = redact.BatchBytesWithPrivacyFilter(ctx, globalBlobs)
 		if err != nil {
-			return plumbing.ZeroHash, fmt.Errorf("rebuild commit %s: %w", c.Hash.String()[:7], err)
+			return plumbing.ZeroHash, &OPFRuntimeFailedError{OPFCommand: redact.OPFCommand()}
+		}
+	}
+
+	// Pass 3: rebuild each commit. For OPF-applied commits, this is
+	// just a re-parent (no tree changes). For unapplied commits, the
+	// per-commit redaction map routes cached bytes by tree path.
+	parent := remoteTip
+	for _, pc := range pendings {
+		var redactedByPath map[string][]byte
+		if len(pc.blobs) > 0 {
+			redactedByPath = make(map[string][]byte, len(pc.blobs))
+			for i, path := range pc.paths {
+				redactedByPath[path] = globalRedacted[pc.startIdx+i]
+			}
+		}
+		newHash, err := rebuildV1Commit(ctx, repo, pc.commit, parent, redactedByPath)
+		if err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("rebuild commit %s: %w", pc.commit.Hash.String()[:7], err)
 		}
 		parent = newHash
 	}
 
-	// Fail-closed: if OPF tripped its breaker mid-rewrite, some blobs
-	// got 7-layer fallback. Don't CAS — the orphan commits get GC'd.
-	if redact.OPFBreakerTripped() {
-		return plumbing.ZeroHash, &OPFRuntimeFailedError{OPFCommand: redact.OPFCommand()}
-	}
 	if err := atomicSetV1Ref(repo, localTip, parent); err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -298,22 +403,33 @@ func listUnpushedV1Commits(repo *git.Repository, localTip, remoteTip plumbing.Ha
 }
 
 // rebuildV1Commit re-parents the commit onto parent. Already-applied
-// commits keep their tree (idempotent); unapplied commits get an
-// OPF-redacted tree + Entire-OPF-Applied: true trailer.
+// commits keep their tree (idempotent); unapplied commits get a tree
+// rebuilt from redactedByPath (precomputed by the orchestrator's single
+// OPF batch call) plus an Entire-OPF-Applied: true trailer.
 //
-// Correctness note: each v1 commit tree is cumulative. During a multi-commit
-// rewrite, the newest original commit can still contain older shards that were
-// 7-layer-only before this rewrite. Redacting the whole tree for every
-// unapplied commit is intentionally conservative so the final rewritten tip
-// cannot reintroduce an older un-OPF-redacted shard.
-func rebuildV1Commit(ctx context.Context, repo *git.Repository, oldCommit *object.Commit, parent plumbing.Hash) (plumbing.Hash, error) {
+// redactedByPath maps each redactable blob's full tree path (e.g.
+// "ab/cd.../0/full.jsonl") to its OPF-redacted bytes. Only required for
+// unapplied commits; pass nil for already-applied ones.
+//
+// Performance: we only redact files inside THIS commit's shard
+// (sharded layout: <id[:2]>/<id[2:]>/*). Files outside that shard live
+// at the same tree because git trees accumulate parent content — they
+// belong to other commits and either are already redacted (prior
+// OPF-applied push) or never will be (this user opted out then in).
+// Walking them every push is O(N×commits) work for no privacy gain.
+func rebuildV1Commit(ctx context.Context, repo *git.Repository, oldCommit *object.Commit, parent plumbing.Hash, redactedByPath map[string][]byte) (plumbing.Hash, error) {
 	newTree := oldCommit.TreeHash
 	if !trailers.HasOPFApplied(oldCommit.Message) {
 		tree, err := repo.TreeObject(oldCommit.TreeHash)
 		if err != nil {
 			return plumbing.ZeroHash, fmt.Errorf("load tree: %w", err)
 		}
-		newTree, err = rebuildTreeWithOPF(ctx, repo, tree, "", "")
+		// Parse the shard path from the commit subject. Falls back to
+		// "" (walk everything) for bootstrap commits and unrecognized
+		// subjects — the conservative default still produces correct
+		// output, just slower.
+		shardPath := parseShardPathFromCommitMessage(oldCommit.Message)
+		newTree, err = rebuildTreeWithCachedRedaction(repo, tree, "", shardPath, redactedByPath)
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
@@ -370,9 +486,77 @@ func parseShardPathFromCommitMessage(message string) string {
 	return id[:2] + "/" + id[2:]
 }
 
-// rebuildTreeWithOPF walks a tree and produces a new tree with
-// OPF-redacted file blobs. content_hash.txt files are recomputed in a
-// second pass against the new full.jsonl in the same directory.
+// isRedactableBlobName reports whether a file at the given name should
+// flow through OPF. The policy is fail-closed: every regular file
+// inside the shard is redacted EXCEPT content_hash.txt, which is
+// recomputed against the new full.jsonl in a deferred pass.
+//
+// Why an open policy: a closed allowlist (.jsonl/.txt/.json only)
+// would silently skip any future blob type that lands in a shard
+// — .md prose, agent dumps, no-extension transcript blobs — and ship
+// it verbatim with the Entire-OPF-Applied trailer attached. Inverting
+// to "redact everything except the deferred file" means new types are
+// covered by default; opting out requires an explicit code change.
+//
+// RedactBlobBytes itself handles arbitrary content: .jsonl/.json go
+// through JSON-aware leaf redaction; anything else gets byte
+// redaction over the raw content. The OPF has-space gate excludes
+// binary blobs from paying inference cost.
+func isRedactableBlobName(name string) bool {
+	return name != paths.ContentHashFileName
+}
+
+// collectTreeBlobs walks tree and appends every redactable blob's
+// content + full tree path to the parallel output slices. The same
+// shard-scoping rules as rebuildTreeWithCachedRedaction apply.
+//
+// blobs[i] and paths[i] correspond: paths[i] is the full path within
+// the tree (e.g. "ab/cd.../0/full.jsonl"), used later by the apply
+// walker to find each blob's redacted bytes in the cached map.
+func collectTreeBlobs(repo *git.Repository, tree *object.Tree, pathPrefix, shardPath string, blobs *[]redact.NamedBlob, paths *[]string) error {
+	for _, e := range tree.Entries {
+		switch e.Mode { //nolint:exhaustive // non-tree/blob modes are unreachable here
+		case filemode.Dir:
+			subPath := e.Name
+			if pathPrefix != "" {
+				subPath = pathPrefix + "/" + e.Name
+			}
+			if !shouldDescend(subPath, shardPath) {
+				continue
+			}
+			subTree, err := repo.TreeObject(e.Hash)
+			if err != nil {
+				return fmt.Errorf("load subtree %s/%s: %w", pathPrefix, e.Name, err)
+			}
+			if err := collectTreeBlobs(repo, subTree, subPath, shardPath, blobs, paths); err != nil {
+				return err
+			}
+		case filemode.Regular, filemode.Executable:
+			if !insideShard(pathPrefix, shardPath) {
+				continue
+			}
+			if !isRedactableBlobName(e.Name) {
+				continue
+			}
+			content, err := readBlob(repo, e.Hash)
+			if err != nil {
+				return fmt.Errorf("read blob %s/%s: %w", pathPrefix, e.Name, err)
+			}
+			fullPath := e.Name
+			if pathPrefix != "" {
+				fullPath = pathPrefix + "/" + e.Name
+			}
+			*blobs = append(*blobs, redact.NamedBlob{Name: e.Name, Content: content})
+			*paths = append(*paths, fullPath)
+		}
+	}
+	return nil
+}
+
+// rebuildTreeWithCachedRedaction walks tree and produces a new tree
+// using the precomputed redactedByPath map for redactable blobs.
+// content_hash.txt files are recomputed in a second pass against the
+// new full.jsonl in the same directory.
 //
 // shardPath scopes the walk: only files at paths starting with
 // shardPath get redacted; other shards (and the root-level entries
@@ -382,17 +566,21 @@ func parseShardPathFromCommitMessage(message string) string {
 // Path-specific behavior (when in the target shard):
 //   - content_hash.txt → SHA256 of the sibling full.jsonl's new bytes
 //     (deferred; not redacted itself)
-//   - everything else → redacted via checkpoint.RedactBlobBytes (OPF on).
-//     The fail-closed policy intentionally redacts ANY regular file
-//     inside the shard, not just a closed allowlist of suffixes — a
-//     future blob type (e.g. .md prose, agent dumps, no-extension
-//     transcript blobs) is redacted by default rather than slipping
-//     through. RedactBlobBytes itself dispatches: .jsonl/.json get
-//     JSON-aware leaf redaction (so free-form fields like Summary.Intent
-//     / ReviewPrompt are scrubbed); other files get byte redaction. The
-//     has-space gate inside OPF naturally excludes binary blobs from
-//     paying the model cost.
-func rebuildTreeWithOPF(ctx context.Context, repo *git.Repository, tree *object.Tree, pathPrefix, shardPath string) (plumbing.Hash, error) {
+//   - everything else → bytes looked up in redactedByPath. The
+//     fail-closed policy redacts ANY regular file inside the shard,
+//     not just a closed allowlist of suffixes — a future blob type
+//     (.md prose, agent dumps, no-extension transcript blobs) is
+//     covered by default rather than slipping through. The collect
+//     pass (collectTreeBlobs) populated redactedByPath using the same
+//     "everything except content_hash.txt" predicate so the keys
+//     match.
+//
+// A redactable blob missing from redactedByPath is either a
+// programmer error (collect-pass / apply-pass walks went out of sync)
+// OR a concurrent storage mutation that changed the tree between
+// passes; we abort the rewrite rather than silently shipping
+// unredacted content with the OPF-applied trailer.
+func rebuildTreeWithCachedRedaction(repo *git.Repository, tree *object.Tree, pathPrefix, shardPath string, redactedByPath map[string][]byte) (plumbing.Hash, error) {
 	entries := make([]object.TreeEntry, 0, len(tree.Entries))
 	// deferredHashes records indexes of content_hash.txt entries we
 	// need to recompute after the full.jsonl in the same dir is built.
@@ -422,7 +610,7 @@ func rebuildTreeWithOPF(ctx context.Context, repo *git.Repository, tree *object.
 			if err != nil {
 				return plumbing.ZeroHash, fmt.Errorf("load subtree %s/%s: %w", pathPrefix, e.Name, err)
 			}
-			newSub, err := rebuildTreeWithOPF(ctx, repo, subTree, subPath, shardPath)
+			newSub, err := rebuildTreeWithCachedRedaction(repo, subTree, subPath, shardPath, redactedByPath)
 			if err != nil {
 				return plumbing.ZeroHash, err
 			}
@@ -441,14 +629,24 @@ func rebuildTreeWithOPF(ctx context.Context, repo *git.Repository, tree *object.
 				deferredHashes = append(deferredHashes, deferred{idx: len(entries), entryName: e.Name, entryMode: e.Mode})
 				entries = append(entries, e) // placeholder; fixed in second pass
 			default:
-				content, err := readBlob(repo, e.Hash)
-				if err != nil {
-					return plumbing.ZeroHash, fmt.Errorf("read blob %s/%s: %w", pathPrefix, e.Name, err)
+				// Inverted policy: every regular file inside the shard
+				// except content_hash.txt expects redacted bytes from the
+				// collect pass. A missing key means the collect pass
+				// didn't visit this path — either the storage changed
+				// between passes or the two walkers disagree on which
+				// files to include. Fail-closed.
+				fullPath := e.Name
+				if pathPrefix != "" {
+					fullPath = pathPrefix + "/" + e.Name
 				}
-				newBytes := checkpoint.RedactBlobBytes(ctx, content, e.Name, true)
+				newBytes, ok := redactedByPath[fullPath]
+				if !ok {
+					return plumbing.ZeroHash, fmt.Errorf("redacted bytes missing for %s "+
+						"(collect/apply walk drift or concurrent storage mutation)", fullPath)
+				}
 				newHash, err := checkpoint.CreateBlobFromContent(repo, newBytes)
 				if err != nil {
-					return plumbing.ZeroHash, fmt.Errorf("write redacted blob %s/%s: %w", pathPrefix, e.Name, err)
+					return plumbing.ZeroHash, fmt.Errorf("write redacted blob %s: %w", fullPath, err)
 				}
 				entries = append(entries, object.TreeEntry{Name: e.Name, Mode: e.Mode, Hash: newHash})
 				if e.Name == paths.TranscriptFileName {

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite.go
@@ -104,7 +104,7 @@ func resolveBootstrapLimit() int {
 	case v == "":
 		return bootstrapDefaultLimit
 	case strings.EqualFold(v, "unlimited"):
-		return math.MaxInt32
+		return math.MaxInt
 	}
 	if n, err := strconv.Atoi(v); err == nil && n > 0 {
 		return n
@@ -126,7 +126,7 @@ type OPFBatchTooLargeError struct {
 }
 
 func (e *OPFBatchTooLargeError) Error() string {
-	return fmt.Sprintf("OPF batch would inference %d prose-leaf bytes "+
+	return fmt.Sprintf("OPF would run inference on %d prose-leaf bytes "+
 		"(limit %d). Set ENTIRE_OPF_BATCH_LIMIT=<bytes> or =unlimited to override, "+
 		"or push without OPF (ENTIRE_OPF=no git push) and let a smaller follow-up push run OPF",
 		e.LeafBytes, e.Limit)
@@ -147,12 +147,26 @@ func resolveBatchLimit() int {
 	case v == "":
 		return batchDefaultLimit
 	case strings.EqualFold(v, "unlimited"):
-		return math.MaxInt32
+		return math.MaxInt
 	}
 	if n, err := strconv.Atoi(v); err == nil && n > 0 {
 		return n
 	}
 	return batchDefaultLimit
+}
+
+// scaleBatchLimit multiplies a batch-limit value by mult, saturating
+// at math.MaxInt to avoid signed-overflow when the limit is "unlimited"
+// (math.MaxInt) or a very large explicit value. Returns 0 if either
+// operand is non-positive, so the caller can treat 0 as "no cap" too.
+func scaleBatchLimit(limit, mult int) int {
+	if limit <= 0 || mult <= 0 {
+		return 0
+	}
+	if limit > math.MaxInt/mult {
+		return math.MaxInt
+	}
+	return limit * mult
 }
 
 // OPFRawBytesTooLargeError: the cumulative raw blob bytes the
@@ -247,8 +261,7 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 	// each blob's source commit + tree path so we can route the redacted
 	// bytes back during apply.
 	type pendingCommit struct {
-		commit    *object.Commit
-		shardPath string
+		commit *object.Commit
 		// blobs and paths are parallel slices; len(paths)==len(blobs).
 		// startIdx is this commit's offset into the global redacted slice.
 		blobs    []redact.NamedBlob
@@ -260,19 +273,27 @@ func RewriteUnpushedV1WithOPF(ctx context.Context, repo *git.Repository, target 
 	// Bound raw-bytes-in-memory incrementally so a pathological push
 	// (e.g. 5 GiB of pasted dumps) aborts before exhausting the user's
 	// shell RAM. The leaf-byte cap downstream is about inference cost;
-	// this one is about memory ceiling and fires earlier.
-	rawCap := resolveBatchLimit() * rawByteCapMultiplier
+	// this one is about memory ceiling and fires earlier. scaleBatchLimit
+	// saturates at math.MaxInt so "unlimited" actually means unlimited
+	// — without saturation, "unlimited" × 100 overflows int and the cap
+	// trips on every push.
+	rawCap := scaleBatchLimit(resolveBatchLimit(), rawByteCapMultiplier)
 	var rawBytesSoFar int
 	for _, c := range unpushed {
 		pc := pendingCommit{commit: c}
 		if !trailers.HasOPFApplied(c.Message) {
-			pc.shardPath = parseShardPathFromCommitMessage(c.Message)
 			tree, err := repo.TreeObject(c.TreeHash)
 			if err != nil {
 				return plumbing.ZeroHash, fmt.Errorf("load tree for %s: %w", c.Hash.String()[:7], err)
 			}
 			pc.startIdx = len(globalBlobs)
-			if err := collectTreeBlobs(repo, tree, "", pc.shardPath, &pc.blobs, &pc.paths); err != nil {
+			// Whole-tree redaction (empty shardPath): each v1 commit tree is
+			// cumulative, so the newest commit can still carry older shards
+			// that were 7-layer-only before this rewrite. Redacting the whole
+			// tree for every unapplied commit keeps the final rewritten tip
+			// from reintroducing an un-OPF-redacted older shard. collect and
+			// apply MUST pass the same scope so cached keys line up.
+			if err := collectTreeBlobs(repo, tree, "", "", &pc.blobs, &pc.paths); err != nil {
 				return plumbing.ZeroHash, fmt.Errorf("collect blobs %s: %w", c.Hash.String()[:7], err)
 			}
 			for _, b := range pc.blobs {
@@ -455,12 +476,11 @@ func listUnpushedV1Commits(repo *git.Repository, localTip, remoteTip plumbing.Ha
 // "ab/cd.../0/full.jsonl") to its OPF-redacted bytes. Only required for
 // unapplied commits; pass nil for already-applied ones.
 //
-// Performance: we only redact files inside THIS commit's shard
-// (sharded layout: <id[:2]>/<id[2:]>/*). Files outside that shard live
-// at the same tree because git trees accumulate parent content — they
-// belong to other commits and either are already redacted (prior
-// OPF-applied push) or never will be (this user opted out then in).
-// Walking them every push is O(N×commits) work for no privacy gain.
+// Correctness note: each v1 commit tree is cumulative. During a multi-commit
+// rewrite, the newest original commit can still contain older shards that were
+// 7-layer-only before this rewrite. The collect/apply walkers redact the whole
+// tree (empty shardPath) for every unapplied commit so the final rewritten tip
+// cannot reintroduce an older un-OPF-redacted shard.
 func rebuildV1Commit(ctx context.Context, repo *git.Repository, oldCommit *object.Commit, parent plumbing.Hash, redactedByPath map[string][]byte) (plumbing.Hash, error) {
 	newTree := oldCommit.TreeHash
 	if !trailers.HasOPFApplied(oldCommit.Message) {
@@ -468,12 +488,9 @@ func rebuildV1Commit(ctx context.Context, repo *git.Repository, oldCommit *objec
 		if err != nil {
 			return plumbing.ZeroHash, fmt.Errorf("load tree: %w", err)
 		}
-		// Parse the shard path from the commit subject. Falls back to
-		// "" (walk everything) for bootstrap commits and unrecognized
-		// subjects — the conservative default still produces correct
-		// output, just slower.
-		shardPath := parseShardPathFromCommitMessage(oldCommit.Message)
-		newTree, err = rebuildTreeWithCachedRedaction(repo, tree, "", shardPath, redactedByPath)
+		// Whole-tree redaction (empty shardPath) — see the collect pass in
+		// RewriteUnpushedV1WithOPF for why we never scope to a single shard.
+		newTree, err = rebuildTreeWithCachedRedaction(repo, tree, "", "", redactedByPath)
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
@@ -559,6 +559,37 @@ func TestOPFBatchTooLargeErrorMessage(t *testing.T) {
 	}
 }
 
+// TestRewriteUnpushedV1WithOPF_RawByteCap pins the RAM-ceiling check
+// that fires during the collect pass (before the leaf-byte inference
+// cap). A push of mostly-structural JSON has tiny prose-leaf content
+// but the loaded raw blob bytes can still OOM if cumulative size
+// blows up — without this cap, a 5 GiB paste would silently load
+// before the leaf-byte cap got a chance to fire.
+//
+// Setting ENTIRE_OPF_BATCH_LIMIT very low scales the raw ceiling
+// (raw = leaf × rawByteCapMultiplier) low enough that the standard
+// setupV1Repo fixture triggers it.
+func TestRewriteUnpushedV1WithOPF_RawByteCap(t *testing.T) {
+	configureFakeOPF(t, &fakeOPFForRewrite{})
+	// leaf cap = 1 → raw ceiling = 100 bytes; the setupV1Repo
+	// checkpoint writes far more than that across its shard blobs.
+	t.Setenv(batchEnvVar, "1")
+	repo, originalTip := setupV1Repo(t)
+
+	_, err := RewriteUnpushedV1WithOPF(context.Background(), repo, "origin")
+	var rawErr *OPFRawBytesTooLargeError
+	require.ErrorAs(t, err, &rawErr, "want OPFRawBytesTooLargeError, got %T: %v", err, err)
+	require.Greater(t, rawErr.RawBytes, rawErr.Limit,
+		"error should report raw byte count > limit")
+
+	// CAS must not advance on raw-byte rejection — same fail-closed
+	// shape as the leaf-byte cap.
+	ref, refErr := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, refErr)
+	require.Equal(t, originalTip, ref.Hash(),
+		"local v1 ref must not move when raw byte cap rejects the push")
+}
+
 // TestCollectTreeBlobs_RedactsAllFileTypesInsideShard pins the
 // fail-closed file-type policy after the rebase onto the batching
 // architecture. The collect-pass walker must include .md, no-extension,

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
@@ -402,60 +402,6 @@ func TestRewriteUnpushedV1WithOPF_BootstrapCap(t *testing.T) {
 	}
 }
 
-// Shard scoping: the rewrite only touches files inside the current
-// commit's own shard. Files belonging to other shards (sitting in the
-// cumulative tree because git trees accumulate) are copied verbatim,
-// so a push doesn't pay O(N) OPF cold-starts per commit.
-func TestParseShardPathFromCommitMessage(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name, msg, want string
-	}{
-		{name: "valid", msg: "Checkpoint: a1b2c3d4e5f6\n\nEntire-Session: s\n", want: "a1/b2c3d4e5f6"},
-		{name: "trailing_space", msg: "Checkpoint: a1b2c3d4e5f6   \n", want: "a1/b2c3d4e5f6"},
-		{name: "missing_prefix", msg: "Initialize sessions branch\n", want: ""},
-		{name: "too_short", msg: "Checkpoint: abc123\n", want: ""},
-		{name: "uppercase_rejected", msg: "Checkpoint: A1B2C3D4E5F6\n", want: ""},
-		{name: "non_hex", msg: "Checkpoint: gghhiijjkkll\n", want: ""},
-		{name: "empty_message", msg: "", want: ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tc.want, parseShardPathFromCommitMessage(tc.msg))
-		})
-	}
-}
-
-// Shard-scoping invariants: descend into ancestors-of, the target, and
-// descendants-of the target shard; copy everything else verbatim.
-func TestShouldDescendAndInsideShard(t *testing.T) {
-	t.Parallel()
-	const shard = "a1/b2c3d4e5f6"
-	cases := []struct {
-		name    string
-		path    string
-		descend bool
-		inside  bool
-	}{
-		{name: "root_is_ancestor", path: "", descend: true, inside: false},
-		{name: "shard_prefix_is_ancestor", path: "a1", descend: true, inside: false},
-		{name: "shard_root_is_target", path: shard, descend: true, inside: true},
-		{name: "session_subdir_is_descendant", path: shard + "/0", descend: true, inside: true},
-		{name: "deeper_descendant", path: shard + "/0/tasks", descend: true, inside: true},
-		{name: "sibling_shard_prefix", path: "b2", descend: false, inside: false},
-		{name: "sibling_shard_full", path: "b2/c3d4e5f6a1a2", descend: false, inside: false},
-		{name: "partial_overlap_not_ancestor", path: "a1/zzz", descend: false, inside: false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tc.descend, shouldDescend(tc.path, shard), "shouldDescend")
-			require.Equal(t, tc.inside, insideShard(tc.path, shard), "insideShard")
-		})
-	}
-}
-
 // Batching contract: across N unpushed commits with redactable blobs,
 // the rewrite must invoke OPF exactly once — the headline win the
 // pre-push refactor is built around. Without batching, this same
@@ -572,14 +518,13 @@ func TestRewriteUnpushedV1WithOPF_RawByteCap(t *testing.T) {
 		"local v1 ref must not move when raw byte cap rejects the push")
 }
 
-// TestCollectTreeBlobs_RedactsAllFileTypesInsideShard pins the
-// fail-closed file-type policy after the rebase onto the batching
-// architecture. The collect-pass walker must include .md, no-extension,
-// and other future blob types — anything except content_hash.txt — so
-// the apply walker has cached bytes for them. Previously the predicate
-// was a closed allowlist (.jsonl/.txt/.json) and any other blob shipped
-// verbatim with the OPF-applied trailer.
-func TestCollectTreeBlobs_RedactsAllFileTypesInsideShard(t *testing.T) {
+// TestCollectTreeBlobs_RedactsAllFileTypes pins the fail-closed
+// file-type policy. The collect-pass walker must include .md,
+// no-extension, and other future blob types — anything except
+// content_hash.txt — so the apply walker has cached bytes for them.
+// Previously the predicate was a closed allowlist (.jsonl/.txt/.json)
+// and any other blob shipped verbatim with the OPF-applied trailer.
+func TestCollectTreeBlobs_RedactsAllFileTypes(t *testing.T) {
 	configureFakeOPF(t, &fakeOPFForRewrite{})
 	tempDir := t.TempDir()
 	testutil.InitRepo(t, tempDir)
@@ -611,7 +556,7 @@ func TestCollectTreeBlobs_RedactsAllFileTypesInsideShard(t *testing.T) {
 
 	var blobs []redact.NamedBlob
 	var blobPaths []string
-	require.NoError(t, collectTreeBlobs(repo, tree, "", "", &blobs, &blobPaths))
+	require.NoError(t, collectTreeBlobs(repo, tree, "", &blobs, &blobPaths))
 
 	collectedNames := make(map[string]bool, len(blobs))
 	for _, b := range blobs {
@@ -620,16 +565,6 @@ func TestCollectTreeBlobs_RedactsAllFileTypesInsideShard(t *testing.T) {
 	require.True(t, collectedNames["notes.md"], ".md blob must be collected for redaction (privacy contract)")
 	require.True(t, collectedNames["transcript"], "no-extension blob must be collected for redaction (privacy contract)")
 	require.False(t, collectedNames[paths.ContentHashFileName], "content_hash.txt must be excluded from collection (deferred path)")
-}
-
-// Empty shardPath = no scoping (bootstrap / unrecognized-subject
-// fallback): descend everywhere, redact everywhere.
-func TestShardScopeEmptyShardPathIsPermissive(t *testing.T) {
-	t.Parallel()
-	require.True(t, shouldDescend("anything/anywhere", ""))
-	require.True(t, insideShard("anything/anywhere", ""))
-	require.True(t, shouldDescend("", ""))
-	require.True(t, insideShard("", ""))
 }
 
 // Fail-closed regression: when the OPF runtime fails and the breaker

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -26,19 +26,36 @@ import (
 
 // fakeOPFForRewrite tags any occurrence of "PERSONABC" as private_person.
 // Deterministic + offline; real OPF inference is not needed to exercise
-// the rewrite plumbing.
-type fakeOPFForRewrite struct{}
+// the rewrite plumbing. The batchCalls counter lets tests assert the
+// "exactly one OPF invocation per push" contract.
+type fakeOPFForRewrite struct {
+	mu         sync.Mutex
+	batchCalls int
+	calls      int
+}
 
 func (f *fakeOPFForRewrite) Redact(_ context.Context, text string, _ []string) ([]redact.Span, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
 	return findSentinelSpans(text), nil
 }
 
 func (f *fakeOPFForRewrite) RedactBatch(_ context.Context, inputs []string, _ []string) ([][]redact.Span, error) {
+	f.mu.Lock()
+	f.batchCalls++
+	f.mu.Unlock()
 	out := make([][]redact.Span, len(inputs))
 	for i, in := range inputs {
 		out[i] = findSentinelSpans(in)
 	}
 	return out, nil
+}
+
+func (f *fakeOPFForRewrite) batchCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.batchCalls
 }
 
 func findSentinelSpans(s string) []redact.Span {
@@ -439,18 +456,117 @@ func TestShouldDescendAndInsideShard(t *testing.T) {
 	}
 }
 
-// TestRebuildTreeWithOPF_RedactsAllFileTypesInsideShard pins the
-// fail-closed file-type policy. Previously the walker only redacted
-// .jsonl / .txt / .json suffixes and copied everything else verbatim
-// inside the shard — a privacy hole for any future blob type (.md
-// prose, agent dumps, no-extension transcript files) that landed in a
-// checkpoint shard. After P3 the policy is inverted: every regular
-// file inside the shard except content_hash.txt flows through OPF.
-//
-// This test stands up a synthetic tree containing one .md and one
-// no-extension file with the OPF sentinel, runs the walker, and
-// asserts both files come out redacted.
-func TestRebuildTreeWithOPF_RedactsAllFileTypesInsideShard(t *testing.T) {
+// addV1Checkpoint appends one more committed checkpoint on the
+// entire/checkpoints/v1 branch. Used by multi-commit tests to set up
+// the "N unpushed commits, all needing OPF" scenario the batching
+// refactor specifically targets.
+func addV1Checkpoint(t *testing.T, repo *git.Repository, checkpointHex, transcriptText, promptText string) {
+	t.Helper()
+	store := checkpoint.NewGitStore(repo)
+	require.NoError(t, store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: id.MustCheckpointID(checkpointHex),
+		SessionID:    "test-session-" + checkpointHex[:6],
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(transcriptText)),
+		Prompts:      []string{promptText},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}))
+}
+
+// Batching contract: across N unpushed commits with redactable blobs,
+// the rewrite must invoke OPF exactly once — the headline win the
+// pre-push refactor is built around. Without batching, this same
+// workload would shell out 3×blobs (one per commit, multiple times per
+// commit's shard), paying the model-load cost on every invocation.
+func TestRewriteUnpushedV1WithOPF_MultiCommit_SingleBatchCall(t *testing.T) {
+	fake := &fakeOPFForRewrite{}
+	configureFakeOPF(t, fake)
+	repo, _ := setupV1Repo(t) // first checkpoint, "PERSONABC" sentinel embedded
+	addV1Checkpoint(t, repo, "b2c3d4e5f6a1",
+		`{"role":"user","content":"PERSONABC contacted again"}`+"\n", "Find PERSONABC")
+	addV1Checkpoint(t, repo, "c3d4e5f6a1b2",
+		`{"role":"user","content":"PERSONABC said hello"}`+"\n", "Greet PERSONABC")
+
+	newTip, err := RewriteUnpushedV1WithOPF(context.Background(), repo, "origin")
+	require.NoError(t, err)
+	require.False(t, newTip.IsZero())
+
+	// The headline assertion: three commits with redactable content,
+	// one shell-out. If the refactor regresses to per-blob calls,
+	// this jumps to 3 (one per commit) or 9 (one per blob).
+	require.Equal(t, 1, fake.batchCallCount(),
+		"want exactly 1 RedactBatch call across all unpushed commits")
+}
+
+// Leaf-byte cap: the rewrite must refuse a push whose cumulative
+// prose-leaf bytes exceed ENTIRE_OPF_BATCH_LIMIT, returning a typed
+// error the pre-push hook can surface. Without this, a runaway push
+// (10MB+ of dense prose) would tie up the user's terminal for minutes
+// without warning.
+func TestRewriteUnpushedV1WithOPF_BatchCap(t *testing.T) {
+	cases := []struct {
+		name     string
+		envLimit string
+		wantErr  bool
+	}{
+		{name: "over_limit_rejected", envLimit: "10", wantErr: true},
+		{name: "unlimited_allows_any_size", envLimit: "unlimited", wantErr: false},
+		{name: "env_override_allows_above_default", envLimit: "1000000", wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			configureFakeOPF(t, &fakeOPFForRewrite{})
+			t.Setenv(batchEnvVar, tc.envLimit)
+			repo, originalTip := setupV1Repo(t) // ~50 bytes of prose-leaf content
+
+			newTip, err := RewriteUnpushedV1WithOPF(context.Background(), repo, "origin")
+			if !tc.wantErr {
+				require.NoError(t, err)
+				require.False(t, newTip.IsZero())
+				return
+			}
+			var tooLarge *OPFBatchTooLargeError
+			require.ErrorAs(t, err, &tooLarge)
+			require.Greater(t, tooLarge.LeafBytes, tooLarge.Limit,
+				"error should report leaf-byte count > the limit it tripped")
+
+			// CAS must not advance on cap rejection — the local v1 ref
+			// stays where it was, so a retry after `unset
+			// ENTIRE_OPF_BATCH_LIMIT` produces the same input set.
+			ref, refErr := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+			require.NoError(t, refErr)
+			require.Equal(t, originalTip, ref.Hash(),
+				"local v1 ref must not move when batch cap rejects the push")
+		})
+	}
+}
+
+// OPFBatchTooLargeError message includes leaf-byte count, the limit
+// that tripped, and remediation pointing to ENTIRE_OPF_BATCH_LIMIT —
+// the user-facing message is the only thing they see when this fires.
+func TestOPFBatchTooLargeErrorMessage(t *testing.T) {
+	t.Parallel()
+	e := &OPFBatchTooLargeError{LeafBytes: 5_000_000, Limit: 2_097_152}
+	msg := e.Error()
+	for _, want := range []string{
+		"5000000",
+		"2097152",
+		batchEnvVar,
+		"unlimited",
+	} {
+		require.Contains(t, msg, want, "OPFBatchTooLargeError message should mention %q", want)
+	}
+}
+
+// TestCollectTreeBlobs_RedactsAllFileTypesInsideShard pins the
+// fail-closed file-type policy after the rebase onto the batching
+// architecture. The collect-pass walker must include .md, no-extension,
+// and other future blob types — anything except content_hash.txt — so
+// the apply walker has cached bytes for them. Previously the predicate
+// was a closed allowlist (.jsonl/.txt/.json) and any other blob shipped
+// verbatim with the OPF-applied trailer.
+func TestCollectTreeBlobs_RedactsAllFileTypesInsideShard(t *testing.T) {
 	configureFakeOPF(t, &fakeOPFForRewrite{})
 	tempDir := t.TempDir()
 	testutil.InitRepo(t, tempDir)
@@ -469,55 +585,28 @@ func TestRebuildTreeWithOPF_RedactsAllFileTypesInsideShard(t *testing.T) {
 		require.NoError(t, err)
 		return hash
 	}
-	mdHash := writeBlob("Agent transcript: PERSONABC reported the issue")
-	rawHash := writeBlob("PERSONABC also appeared in this no-extension blob")
+	mdHash := writeBlob("notes md body")
+	rawHash := writeBlob("no extension body")
 	hashTxtHash := writeBlob("sha256:abcd")
 
-	// Entries must be sorted lexicographically per git's tree format.
+	// Lexicographically sorted entries (required by git tree format).
 	tree := &object.Tree{Entries: []object.TreeEntry{
 		{Name: paths.ContentHashFileName, Mode: filemode.Regular, Hash: hashTxtHash},
 		{Name: "notes.md", Mode: filemode.Regular, Hash: mdHash},
 		{Name: "transcript", Mode: filemode.Regular, Hash: rawHash},
 	}}
 
-	// Empty shardPath = "walk everything" (bootstrap fallback). With the
-	// inverted policy, both notes.md and transcript get redacted.
-	newTreeHash, err := rebuildTreeWithOPF(context.Background(), repo, tree, "", "")
-	require.NoError(t, err)
+	var blobs []redact.NamedBlob
+	var blobPaths []string
+	require.NoError(t, collectTreeBlobs(repo, tree, "", "", &blobs, &blobPaths))
 
-	newTree, err := repo.TreeObject(newTreeHash)
-	require.NoError(t, err)
-
-	readEntry := func(name string) string {
-		for _, e := range newTree.Entries {
-			if e.Name != name {
-				continue
-			}
-			blob, err := repo.BlobObject(e.Hash)
-			require.NoError(t, err)
-			r, err := blob.Reader()
-			require.NoError(t, err)
-			defer func() { _ = r.Close() }()
-			data, err := io.ReadAll(r)
-			require.NoError(t, err)
-			return string(data)
-		}
-		t.Fatalf("entry %q not in rebuilt tree", name)
-		return ""
+	collectedNames := make(map[string]bool, len(blobs))
+	for _, b := range blobs {
+		collectedNames[b.Name] = true
 	}
-
-	if strings.Contains(readEntry("notes.md"), "PERSONABC") {
-		t.Error(".md blob inside the shard must be redacted — slipped through verbatim")
-	}
-	if strings.Contains(readEntry("transcript"), "PERSONABC") {
-		t.Error("no-extension blob inside the shard must be redacted — slipped through verbatim")
-	}
-	// content_hash.txt is on the deferred path: since there's no
-	// transcript file (named full.jsonl) in this synthetic tree, the
-	// deferred recomputation keeps the original hash.
-	if got := readEntry(paths.ContentHashFileName); got != "sha256:abcd" {
-		t.Errorf("content_hash.txt should be preserved when no transcript exists, got %q", got)
-	}
+	require.True(t, collectedNames["notes.md"], ".md blob must be collected for redaction (privacy contract)")
+	require.True(t, collectedNames["transcript"], "no-extension blob must be collected for redaction (privacy contract)")
+	require.False(t, collectedNames[paths.ContentHashFileName], "content_hash.txt must be excluded from collection (deferred path)")
 }
 
 // Empty shardPath = no scoping (bootstrap / unrecognized-subject

--- a/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_rewrite_test.go
@@ -456,24 +456,6 @@ func TestShouldDescendAndInsideShard(t *testing.T) {
 	}
 }
 
-// addV1Checkpoint appends one more committed checkpoint on the
-// entire/checkpoints/v1 branch. Used by multi-commit tests to set up
-// the "N unpushed commits, all needing OPF" scenario the batching
-// refactor specifically targets.
-func addV1Checkpoint(t *testing.T, repo *git.Repository, checkpointHex, transcriptText, promptText string) {
-	t.Helper()
-	store := checkpoint.NewGitStore(repo)
-	require.NoError(t, store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
-		CheckpointID: id.MustCheckpointID(checkpointHex),
-		SessionID:    "test-session-" + checkpointHex[:6],
-		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted([]byte(transcriptText)),
-		Prompts:      []string{promptText},
-		AuthorName:   "Test",
-		AuthorEmail:  "test@test.com",
-	}))
-}
-
 // Batching contract: across N unpushed commits with redactable blobs,
 // the rewrite must invoke OPF exactly once — the headline win the
 // pre-push refactor is built around. Without batching, this same
@@ -483,9 +465,9 @@ func TestRewriteUnpushedV1WithOPF_MultiCommit_SingleBatchCall(t *testing.T) {
 	fake := &fakeOPFForRewrite{}
 	configureFakeOPF(t, fake)
 	repo, _ := setupV1Repo(t) // first checkpoint, "PERSONABC" sentinel embedded
-	addV1Checkpoint(t, repo, "b2c3d4e5f6a1",
+	addV1Checkpoint(t, repo, "b2c3d4e5f6a1", "test-session-2",
 		`{"role":"user","content":"PERSONABC contacted again"}`+"\n", "Find PERSONABC")
-	addV1Checkpoint(t, repo, "c3d4e5f6a1b2",
+	addV1Checkpoint(t, repo, "c3d4e5f6a1b2", "test-session-3",
 		`{"role":"user","content":"PERSONABC said hello"}`+"\n", "Greet PERSONABC")
 
 	newTip, err := RewriteUnpushedV1WithOPF(context.Background(), repo, "origin")

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -155,7 +155,7 @@ OPF failures at push time are **fail-closed**: if OPF is not on PATH, fails to s
 
 (The circuit breaker is per-process, so a broken install costs one warning instead of one timeout per blob — but the push still aborts.)
 
-Cost note: each shell-out loads the OPF model (~1.5B parameters on CPU). The pre-push rewrite batches all eligible leaf strings into a single inference pass per scope (transcript + joined prompts), so a typical real-world push adds ~25–30s of OPF inference rather than the multi-minute cost a per-leaf flow would incur. Per-commit latency is unaffected because OPF doesn't run at commit time.
+Cost note: each shell-out loads the OPF model (~1.5B parameters on CPU). The pre-push rewrite batches **every redactable leaf across every unpushed v1 commit** into a single inference pass, so a typical real-world push pays the model-load cost once (~6s) plus inference (~5s per 100KB of leaf content) — not multiplied by the number of commits or blobs. A 3-commit push with ~250KB of total prose content runs in ~12–15s, not the ~50–100s a per-blob flow would take. Per-commit latency is unaffected because OPF doesn't run at commit time.
 
 #### When OPF actually runs
 
@@ -182,6 +182,14 @@ The rewrite refuses to proceed and aborts the push when it detects a divergent s
   set -x ENTIRE_OPF_BOOTSTRAP_LIMIT 500; git push
   # or fully unbounded:
   set -x ENTIRE_OPF_BOOTSTRAP_LIMIT unlimited; git push
+  ```
+
+- **Batch-size cap**: independent of commit count, the rewrite refuses pushes whose cumulative prose-leaf content exceeds `ENTIRE_OPF_BATCH_LIMIT` bytes (default: 2 MiB ≈ ~110s of inference). The two caps protect different failure modes — the bootstrap cap stops "100 throwaway commits", the batch cap stops "one commit with 50 MB of pasted transcript". A `OPF batch would inference …` error means you've hit this; bump the env var or push without OPF for that push:
+
+  ```fish
+  set -x ENTIRE_OPF_BATCH_LIMIT 10485760; git push   # 10 MiB
+  # or fully unbounded:
+  set -x ENTIRE_OPF_BATCH_LIMIT unlimited; git push
   ```
 
 - **Concurrent push** from another worktree: the rewrite uses a CAS to update the local v1 ref. If another process moved the ref while OPF was running, the hook exits with a "concurrent push detected" error and `git push` aborts the whole batch. Fetch and retry.

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -184,7 +184,7 @@ The rewrite refuses to proceed and aborts the push when it detects a divergent s
   set -x ENTIRE_OPF_BOOTSTRAP_LIMIT unlimited; git push
   ```
 
-- **Batch-size cap**: independent of commit count, the rewrite refuses pushes whose cumulative prose-leaf content exceeds `ENTIRE_OPF_BATCH_LIMIT` bytes (default: 2 MiB ≈ ~110s of inference). The two caps protect different failure modes — the bootstrap cap stops "100 throwaway commits", the batch cap stops "one commit with 50 MB of pasted transcript". A `OPF batch would inference …` error means you've hit this; bump the env var or push without OPF for that push:
+- **Batch-size cap**: independent of commit count, the rewrite refuses pushes whose cumulative prose-leaf content exceeds `ENTIRE_OPF_BATCH_LIMIT` bytes (default: 2 MiB ≈ ~110s of inference). The two caps protect different failure modes — the bootstrap cap stops "100 throwaway commits", the batch cap stops "one commit with 50 MB of pasted transcript". An `OPF would run inference on …` error means you've hit this; bump the env var or push without OPF for that push:
 
   ```fish
   set -x ENTIRE_OPF_BATCH_LIMIT 10485760; git push   # 10 MiB

--- a/redact/batch.go
+++ b/redact/batch.go
@@ -1,0 +1,181 @@
+package redact
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// NamedBlob is one input to BatchBytesWithPrivacyFilter. Name drives
+// redaction shape: a ".jsonl" or ".json" suffix triggers JSON-aware
+// leaf extraction (string values inside the parsed structure); any
+// other suffix treats the whole content as a single leaf.
+//
+// Content is the raw blob bytes. The blob's redacted output appears at
+// the same index in the function's return slice.
+type NamedBlob struct {
+	Name    string
+	Content []byte
+}
+
+// BatchBytesWithPrivacyFilter redacts N blobs with a single OPF
+// inference call instead of N. Returns redacted bytes in input order
+// (output[i] is the redaction of inputs[i]).
+//
+// Failure semantics — fail-closed: any error from the OPF runtime
+// returns a non-nil error. Callers running this for privacy-critical
+// operations (e.g. the pre-push rewrite) must abort rather than
+// proceed with partially-redacted content. The per-blob
+// JSONLContentWithPrivacyFilter falls back to 7-layer on batch
+// failure; this batched variant intentionally does not, because the
+// only caller (cross-blob walker) needs an explicit signal that OPF
+// did not finish.
+//
+// When OPF is unconfigured, disabled, has no enabled categories, or
+// the per-process circuit breaker has tripped, returns 7-layer-only
+// output for every blob with no error. This matches the existing
+// non-batched paths and keeps the caller's hot-path code clean.
+func BatchBytesWithPrivacyFilter(ctx context.Context, inputs []NamedBlob) ([][]byte, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	cfg := getOPFConfig()
+	if cfg == nil || !cfg.Enabled || cfg.runtime == nil || opfBreakerTripped.Load() {
+		return apply7LayerToBlobs(inputs), nil
+	}
+	cats := enabledCategories(cfg)
+	if len(cats) == 0 {
+		return apply7LayerToBlobs(inputs), nil
+	}
+
+	// Pass 1: collect unique prose-shaped leaves across every blob.
+	// The has-space gate excludes structural strings (paths, IDs,
+	// snake_case keys) that would pay model-load cost for no benefit.
+	// Dedup keys by leaf text, mirroring JSONLContentWithPrivacyFilter:
+	// OPF is a pure function of input text, so identical leaves in
+	// different blobs share a single inference result.
+	seen := make(map[string]struct{})
+	var batchInputs []string
+	addLeaf := func(v string) {
+		if !strings.ContainsRune(v, ' ') {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		batchInputs = append(batchInputs, v)
+	}
+	for _, in := range inputs {
+		collectLeaves(in, addLeaf)
+	}
+
+	// Pass 2: single batched OPF call covering every unique leaf.
+	spansByInput := make(map[string][]Span, len(batchInputs))
+	if len(batchInputs) > 0 {
+		fmt.Fprintln(opfStderr, "→ OpenAI Privacy Filter: scanning checkpoints…")
+		start := time.Now()
+		batched, err := cfg.runtime.RedactBatch(ctx, batchInputs, cats)
+		if err != nil {
+			handleOPFFailure(ctx, cfg, err)
+			return nil, fmt.Errorf("opf batch failed across %d blobs: %w", len(inputs), err)
+		}
+		fmt.Fprintf(opfStderr, "✓ OpenAI Privacy Filter: done (%.1fs, %d blobs)\n",
+			time.Since(start).Seconds(), len(inputs))
+		if len(batched) < len(batchInputs) {
+			slog.Warn("OPF runtime returned fewer span slices than inputs",
+				slog.String("component", "redaction"),
+				slog.Int("inputs", len(batchInputs)),
+				slog.Int("returned", len(batched)),
+			)
+		}
+		for i, leaf := range batchInputs {
+			if i >= len(batched) {
+				break
+			}
+			spansByInput[leaf] = batched[i]
+		}
+	}
+
+	// Pass 3: apply per-leaf regex layers + cached OPF spans per blob.
+	out := make([][]byte, len(inputs))
+	for i, in := range inputs {
+		out[i] = applyToBlob(in, spansByInput, cfg)
+	}
+	return out, nil
+}
+
+// collectLeaves invokes add for every prose-shaped leaf in the blob.
+// JSONL/JSON blobs walk their parsed structure; other blobs are
+// treated as a single leaf (raw transcript text, prompt files, etc.).
+//
+// JSON parse failures fall back to whole-content treatment, matching
+// RedactBlobBytes's behavior: a malformed JSON blob still gets the
+// 7-layer pipeline applied, just without leaf-by-leaf precision.
+func collectLeaves(in NamedBlob, add func(string)) {
+	if isJSONLikeName(in.Name) {
+		if _, err := jsonlContentImpl(string(in.Content), func(v string) string {
+			add(v)
+			return v
+		}); err == nil {
+			return
+		}
+		// JSONL parse failed — fall through to whole-content.
+	}
+	add(string(in.Content))
+}
+
+// applyToBlob produces the redacted bytes for a single blob, combining
+// the 7 regex layers with the cached OPF spans for each leaf. The
+// per-leaf closure mirrors JSONLContentWithPrivacyFilter's Pass 3.
+func applyToBlob(in NamedBlob, spansByInput map[string][]Span, cfg *OPFConfig) []byte {
+	applier := func(v string) string {
+		regions := detectAllLayers(v)
+		if spans, ok := spansByInput[v]; ok {
+			for _, sp := range spans {
+				if !cfg.Categories[sp.Label] {
+					continue
+				}
+				if sp.Start < 0 || sp.End > len(v) || sp.Start >= sp.End {
+					continue
+				}
+				regions = append(regions, taggedRegion{
+					region: region{sp.Start, sp.End},
+					label:  mapOPFLabel(sp.Label),
+				})
+			}
+		}
+		return applyRegions(v, regions)
+	}
+	if isJSONLikeName(in.Name) {
+		if redacted, err := jsonlContentImpl(string(in.Content), applier); err == nil {
+			return []byte(redacted)
+		}
+	}
+	return []byte(applier(string(in.Content)))
+}
+
+// apply7LayerToBlobs is the OPF-disabled fast path: each blob gets
+// regex-only redaction with no shell-out. Returned slice is index-aligned
+// with inputs.
+func apply7LayerToBlobs(inputs []NamedBlob) [][]byte {
+	out := make([][]byte, len(inputs))
+	for i, in := range inputs {
+		if isJSONLikeName(in.Name) {
+			if redacted, err := jsonlContentImpl(string(in.Content), String); err == nil {
+				out[i] = []byte(redacted)
+				continue
+			}
+		}
+		out[i] = []byte(String(string(in.Content)))
+	}
+	return out
+}
+
+// isJSONLikeName reports whether the blob name suggests JSON-aware
+// redaction. Matches RedactBlobBytes's dispatch in checkpoint/.
+func isJSONLikeName(name string) bool {
+	return strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, ".json")
+}

--- a/redact/batch.go
+++ b/redact/batch.go
@@ -1,6 +1,7 @@
 package redact
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -178,4 +179,41 @@ func apply7LayerToBlobs(inputs []NamedBlob) [][]byte {
 // redaction. Matches RedactBlobBytes's dispatch in checkpoint/.
 func isJSONLikeName(name string) bool {
 	return strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, ".json")
+}
+
+// SumProseLeafBytes returns the cumulative byte size of prose-shaped
+// (has-space) leaves across inputs — the upper bound on what
+// BatchBytesWithPrivacyFilter would send to OPF inference.
+//
+// Callers use this to enforce a cap before paying the OPF cost: a
+// push with 100MB of mostly-structural JSON has tens of KB of actual
+// leaves; a push with 100MB of dense prose has hundreds of MB. The
+// blob-byte size doesn't tell you which without looking inside.
+//
+// Counts the same way the collector inside BatchBytesWithPrivacyFilter
+// does — has-space gate, JSONL/JSON parse with whole-content fallback —
+// so the number matches what would actually go over the wire.
+func SumProseLeafBytes(inputs []NamedBlob) int {
+	var total int
+	for _, in := range inputs {
+		if isJSONLikeName(in.Name) {
+			parsed := false
+			if _, err := jsonlContentImpl(string(in.Content), func(v string) string {
+				parsed = true
+				if strings.ContainsRune(v, ' ') {
+					total += len(v)
+				}
+				return v
+			}); err == nil {
+				_ = parsed
+				continue
+			}
+			// JSON parse failed — fall through to whole-content (matches
+			// the collector's fallback in BatchBytesWithPrivacyFilter).
+		}
+		if bytes.ContainsRune(in.Content, ' ') {
+			total += len(in.Content)
+		}
+	}
+	return total
 }

--- a/redact/batch.go
+++ b/redact/batch.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 )
@@ -85,17 +84,18 @@ func BatchBytesWithPrivacyFilter(ctx context.Context, inputs []NamedBlob) ([][]b
 		}
 		fmt.Fprintf(opfStderr, "✓ OpenAI Privacy Filter: done (%.1fs, %d blobs)\n",
 			time.Since(start).Seconds(), len(inputs))
-		if len(batched) < len(batchInputs) {
-			slog.Warn("OPF runtime returned fewer span slices than inputs",
-				slog.String("component", "redaction"),
-				slog.Int("inputs", len(batchInputs)),
-				slog.Int("returned", len(batched)),
-			)
+		// A short return means the runtime gave us fewer span slices than
+		// inputs — the tail leaves would receive zero OPF spans and the
+		// rewrite would proceed as if OPF found nothing in them. With the
+		// Entire-OPF-Applied trailer attached to the resulting commits,
+		// that's silent under-redaction. Fail-closed: trip the breaker
+		// and return an error so the orchestrator aborts before CAS.
+		if len(batched) != len(batchInputs) {
+			shortErr := fmt.Errorf("opf runtime returned %d span slices for %d inputs", len(batched), len(batchInputs))
+			handleOPFFailure(ctx, cfg, shortErr)
+			return nil, fmt.Errorf("opf batch short return: %w", shortErr)
 		}
 		for i, leaf := range batchInputs {
-			if i >= len(batched) {
-				break
-			}
 			spansByInput[leaf] = batched[i]
 		}
 	}

--- a/redact/batch.go
+++ b/redact/batch.go
@@ -190,22 +190,24 @@ func isJSONLikeName(name string) bool {
 // leaves; a push with 100MB of dense prose has hundreds of MB. The
 // blob-byte size doesn't tell you which without looking inside.
 //
-// Counts the same way the collector inside BatchBytesWithPrivacyFilter
-// does — has-space gate, JSONL/JSON parse with whole-content fallback —
-// so the number matches what would actually go over the wire.
+// Returns a CONSERVATIVE UPPER BOUND on what would go to OPF — same
+// has-space gate and JSONL/JSON parse with whole-content fallback as
+// the collector inside BatchBytesWithPrivacyFilter, BUT this function
+// does NOT deduplicate identical leaves across blobs. The actual batch
+// sent to OPF dedups by leaf-text, so a push with many repeated leaves
+// will report higher byte counts here than OPF actually sees. Callers
+// using this for cap enforcement get an over-strict bound, which is
+// safe (false positives possible, false negatives impossible).
 func SumProseLeafBytes(inputs []NamedBlob) int {
 	var total int
 	for _, in := range inputs {
 		if isJSONLikeName(in.Name) {
-			parsed := false
 			if _, err := jsonlContentImpl(string(in.Content), func(v string) string {
-				parsed = true
 				if strings.ContainsRune(v, ' ') {
 					total += len(v)
 				}
 				return v
 			}); err == nil {
-				_ = parsed
 				continue
 			}
 			// JSON parse failed — fall through to whole-content (matches

--- a/redact/batch_test.go
+++ b/redact/batch_test.go
@@ -310,6 +310,72 @@ func TestBatchBytesWithPrivacyFilter_MatchesPerBlobOutput(t *testing.T) {
 	}
 }
 
+// TestSumProseLeafBytes_CountsAcrossBlobShapes covers the helper the
+// strategy uses to enforce ENTIRE_OPF_BATCH_LIMIT. The number must
+// reflect what would actually go to OPF — so the has-space gate
+// excludes non-prose, JSON-parsed leaves are counted individually,
+// and raw text blobs are counted whole.
+func TestSumProseLeafBytes_CountsAcrossBlobShapes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		inputs []NamedBlob
+		want   int
+	}{
+		{
+			name: "empty_input_zero",
+			want: 0,
+		},
+		{
+			name: "single_jsonl_prose_leaves_only",
+			inputs: []NamedBlob{
+				{Name: "a.jsonl", Content: []byte(`{"id":"non-prose","content":"Alice met Bob"}`)},
+			},
+			// "Alice met Bob" = 13 bytes (has space → counted). "non-prose" has no
+			// space → excluded.
+			want: 13,
+		},
+		{
+			name: "json_metadata_with_id_field_skips_id",
+			inputs: []NamedBlob{
+				{Name: "metadata.json", Content: []byte(`{"summary":"Eve walked home","id":"keep-this"}`)},
+			},
+			want: 15, // "Eve walked home"
+		},
+		{
+			name: "raw_text_blob_counted_whole",
+			inputs: []NamedBlob{
+				{Name: "prompt.txt", Content: []byte("Find Frank Smith here")}, // 21 bytes
+			},
+			want: 21,
+		},
+		{
+			name: "raw_text_blob_no_space_excluded",
+			inputs: []NamedBlob{
+				{Name: "id.txt", Content: []byte("abc123-no-spaces-here")},
+			},
+			want: 0,
+		},
+		{
+			name: "multi_blob_sums_each",
+			inputs: []NamedBlob{
+				{Name: "a.jsonl", Content: []byte(`{"content":"Alice met Bob"}`)},
+				{Name: "b.txt", Content: []byte("Charlie sat down")}, // 16 bytes
+			},
+			want: 13 + 16,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := SumProseLeafBytes(tc.inputs)
+			if got != tc.want {
+				t.Errorf("SumProseLeafBytes(%s) = %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesReturns7Layer
 // covers the configuration edge case where OPF is enabled but every
 // category is turned off — the model has nothing to look for, so we

--- a/redact/batch_test.go
+++ b/redact/batch_test.go
@@ -1,0 +1,333 @@
+package redact
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// configureFakeOPF wires up the runtime, redirects opfStderr, and registers
+// cleanup so each test starts and ends with a clean config. Returns the fake
+// so individual tests can assert call counts.
+func configureFakeOPF(t *testing.T, fake *fakeRuntime, cats map[string]bool) {
+	t.Helper()
+	resetOPFConfig()
+	t.Cleanup(resetOPFConfig)
+	origStderr := opfStderr
+	opfStderr = io.Discard
+	t.Cleanup(func() { opfStderr = origStderr })
+	ConfigurePrivacyFilterWithRuntime(OPFConfig{
+		Enabled:    true,
+		Categories: cats,
+	}, fake)
+}
+
+// TestBatchBytesWithPrivacyFilter_BatchesSingleCall pins the headline
+// contract: N blobs across multiple shapes (JSONL, plain JSON, raw text)
+// produce exactly ONE RedactBatch invocation. This is what the pre-push
+// rewrite walker depends on for its ~6×–9× wall-clock win.
+func TestBatchBytesWithPrivacyFilter_BatchesSingleCall(t *testing.T) {
+	fake := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
+	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
+
+	inputs := []NamedBlob{
+		{Name: "full.jsonl", Content: []byte(`{"content":"Alice met Bob"}` + "\n" + `{"content":"Charlie sat down"}`)},
+		{Name: "metadata.json", Content: []byte(`{"summary":"Eve walked home"}`)},
+		{Name: "prompt.txt", Content: []byte("Frank reviewed the diff")},
+	}
+
+	_, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("BatchBytesWithPrivacyFilter: %v", err)
+	}
+	if fake.batchCalls != 1 {
+		t.Errorf("want exactly 1 RedactBatch call across %d blobs, got %d", len(inputs), fake.batchCalls)
+	}
+	if fake.calls != 0 {
+		t.Errorf("want 0 single-input Redact calls, got %d", fake.calls)
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_PreservesInputOrder confirms that
+// output[i] corresponds to inputs[i]. Without this, a multi-blob walker
+// couldn't safely use a parallel slice to look up redacted bytes by index.
+func TestBatchBytesWithPrivacyFilter_PreservesInputOrder(t *testing.T) {
+	fake := &fakeRuntime{} // empty spans; we're checking order, not content
+	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
+
+	inputs := []NamedBlob{
+		{Name: "a.txt", Content: []byte("alpha content here")},
+		{Name: "b.txt", Content: []byte("beta content here")},
+		{Name: "c.txt", Content: []byte("gamma content here")},
+	}
+
+	got, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("BatchBytesWithPrivacyFilter: %v", err)
+	}
+	if len(got) != len(inputs) {
+		t.Fatalf("want %d outputs, got %d", len(inputs), len(got))
+	}
+	wantPrefixes := []string{"alpha", "beta", "gamma"}
+	for i, prefix := range wantPrefixes {
+		if !strings.HasPrefix(string(got[i]), prefix) {
+			t.Errorf("output[%d] = %q, want prefix %q", i, string(got[i]), prefix)
+		}
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_AppliesSpansToJSON verifies that OPF
+// spans returned by the batch call are applied back to the right leaves
+// inside a JSON-shaped blob, and that the surrounding JSON structure
+// survives. This is the load-bearing assertion for the metadata.json
+// redaction path that PR 1236 specifically extended.
+func TestBatchBytesWithPrivacyFilter_AppliesSpansToJSON(t *testing.T) {
+	// "Alice" is bytes 0..5 of "Alice met Bob"; the fake returns that span
+	// for every input, so all leaves get redacted at the same offset.
+	fake := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
+	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
+
+	inputs := []NamedBlob{
+		{Name: "metadata.json", Content: []byte(`{"summary":"Alice met Bob","id":"keep-this"}`)},
+	}
+	got, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("BatchBytesWithPrivacyFilter: %v", err)
+	}
+	out := string(got[0])
+	if !strings.Contains(out, "[REDACTED_PERSON]") {
+		t.Errorf("expected [REDACTED_PERSON] tag, got %q", out)
+	}
+	// The id field has no space, so the has-space gate excludes it; OPF
+	// never sees it. The regex layers also leave it alone for this input.
+	if !strings.Contains(out, `"keep-this"`) {
+		t.Errorf("non-prose id field should survive, got %q", out)
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_AppliesSpansToRawText pins the
+// raw-text path (.txt blobs, prompt files): the whole content is
+// treated as one leaf and gets the cached spans applied. Without this,
+// the walker would silently skip OPF redaction on prompt files.
+func TestBatchBytesWithPrivacyFilter_AppliesSpansToRawText(t *testing.T) {
+	fake := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
+	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
+
+	inputs := []NamedBlob{
+		{Name: "prompt.txt", Content: []byte("Alice met Bob in the lobby")},
+	}
+	got, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("BatchBytesWithPrivacyFilter: %v", err)
+	}
+	if !strings.Contains(string(got[0]), "[REDACTED_PERSON]") {
+		t.Errorf("expected [REDACTED_PERSON] in raw-text output, got %q", string(got[0]))
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_DedupsLeavesAcrossBlobs confirms that
+// the same leaf string appearing in two blobs is sent to OPF exactly
+// once. Without this, a transcript that quotes the same prompt in 10
+// places would inflate the batch unnecessarily.
+func TestBatchBytesWithPrivacyFilter_DedupsLeavesAcrossBlobs(t *testing.T) {
+	fake := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
+	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
+
+	shared := "Alice met Bob in the lobby"
+	inputs := []NamedBlob{
+		{Name: "a.jsonl", Content: []byte(`{"text":"` + shared + `"}`)},
+		{Name: "b.jsonl", Content: []byte(`{"text":"` + shared + `"}`)},
+		{Name: "c.txt", Content: []byte(shared)},
+	}
+	_, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("BatchBytesWithPrivacyFilter: %v", err)
+	}
+	// One batch call (already covered above) AND it should see exactly
+	// one input string. The fake doesn't expose its inputs directly, but
+	// we can lean on the batchCalls counter: a deduped batch can't fire
+	// twice no matter how many duplicates appear.
+	if fake.batchCalls != 1 {
+		t.Errorf("want 1 batch call across duplicated leaves, got %d", fake.batchCalls)
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_EmptyInputs is a degenerate case the
+// walker hits when a push has no unpushed commits or every commit is
+// already OPF-applied. Must not crash and must not invoke OPF.
+func TestBatchBytesWithPrivacyFilter_EmptyInputs(t *testing.T) {
+	fake := &fakeRuntime{}
+	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
+
+	got, err := BatchBytesWithPrivacyFilter(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("nil inputs: %v", err)
+	}
+	if got != nil {
+		t.Errorf("want nil output for nil input, got %v", got)
+	}
+	if fake.batchCalls != 0 {
+		t.Errorf("want 0 OPF calls for nil input, got %d", fake.batchCalls)
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_FailsClosedOnBatchError is the
+// fail-closed contract: when the OPF runtime errors, callers must see
+// the error rather than silently get 7-layer-only output tagged as if
+// OPF ran. This is the privacy-critical difference vs
+// JSONLContentWithPrivacyFilter (which silently falls back).
+func TestBatchBytesWithPrivacyFilter_FailsClosedOnBatchError(t *testing.T) {
+	fake := &fakeRuntime{err: errors.New("simulated opf runtime failure")}
+	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
+
+	inputs := []NamedBlob{
+		{Name: "x.jsonl", Content: []byte(`{"text":"Alice met Bob"}`)},
+	}
+	got, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err == nil {
+		t.Fatal("want non-nil error on OPF batch failure, got nil")
+	}
+	if got != nil {
+		t.Errorf("want nil output on batch failure, got %v", got)
+	}
+	if !strings.Contains(err.Error(), "opf batch failed") {
+		t.Errorf("want error mentioning 'opf batch failed', got %q", err.Error())
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_OPFDisabledReturns7Layer covers the
+// "OPF turned off in settings" path: every blob gets regex-only
+// redaction, no shell-out happens, no error. Without this, a user with
+// OPF disabled would get a hard error from the new API instead of the
+// fast 7-layer path they expect.
+func TestBatchBytesWithPrivacyFilter_OPFDisabledReturns7Layer(t *testing.T) {
+	resetOPFConfig()
+	t.Cleanup(resetOPFConfig)
+	// No ConfigurePrivacyFilter call → cfg == nil
+
+	inputs := []NamedBlob{
+		{Name: "x.jsonl", Content: []byte(`{"text":"key=AKIAYRWQG5EJLPZLBYNP"}`)},
+	}
+	got, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("OPF-disabled path should not error: %v", err)
+	}
+	if !strings.Contains(string(got[0]), "REDACTED") {
+		t.Errorf("7-layer fallback should still redact AWS key, got %q", string(got[0]))
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_BreakerTrippedReturns7Layer ensures
+// that once the circuit breaker has tripped (e.g. an earlier batch
+// failed and the strategy aborted), subsequent calls in the same
+// process don't pay another shell-out cost. They short-circuit to
+// regex-only with no error.
+func TestBatchBytesWithPrivacyFilter_BreakerTrippedReturns7Layer(t *testing.T) {
+	fake := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
+	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
+	opfBreakerTripped.Store(true)
+	t.Cleanup(func() { opfBreakerTripped.Store(false) })
+
+	inputs := []NamedBlob{
+		{Name: "x.jsonl", Content: []byte(`{"text":"Alice met Bob"}`)},
+	}
+	_, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("breaker-tripped path should not error: %v", err)
+	}
+	if fake.batchCalls != 0 {
+		t.Errorf("want 0 OPF calls when breaker tripped, got %d", fake.batchCalls)
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_MatchesPerBlobOutput is the most
+// important correctness assertion at this layer. The pre-push rewrite
+// will swap from N calls to JSONLBytesWithPrivacyFilter/BytesWithPrivacyFilter
+// (one per blob) to a single BatchBytesWithPrivacyFilter call. If the
+// batched output differs even slightly from the per-blob output, the
+// rewrite would write subtly different blobs to the v1 ref — invisible
+// in unit tests, visible only as "redacted content shifted" in production.
+//
+// This test runs both paths against the same inputs with the same fake
+// runtime and asserts byte-identical output per blob. The fake returns
+// the same span for every input, so any divergence here is purely from
+// span application or JSONL walking, not from runtime non-determinism.
+func TestBatchBytesWithPrivacyFilter_MatchesPerBlobOutput(t *testing.T) {
+	cats := map[string]bool{"private_person": true}
+	inputs := []NamedBlob{
+		{Name: "full.jsonl", Content: []byte(`{"content":"Alice met Bob in the lobby"}` + "\n" + `{"content":"Charlie sat at the table"}`)},
+		{Name: "metadata.json", Content: []byte(`{"summary":"Eve walked home tonight","id":"keep-this"}`)},
+		{Name: "prompt.txt", Content: []byte("Frank reviewed the diff this morning")},
+		{Name: "duplicate.jsonl", Content: []byte(`{"content":"Alice met Bob in the lobby"}`)}, // same leaf as full.jsonl
+	}
+
+	// Per-blob baseline: route each blob through the existing API the
+	// same way RedactBlobBytes does in cmd/entire/cli/checkpoint/.
+	fake1 := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
+	configureFakeOPF(t, fake1, cats)
+	wantPerBlob := make([][]byte, len(inputs))
+	for i, in := range inputs {
+		if isJSONLikeName(in.Name) {
+			redacted, err := JSONLBytesWithPrivacyFilter(context.Background(), in.Content)
+			if err != nil {
+				t.Fatalf("per-blob JSONL[%d]: %v", i, err)
+			}
+			wantPerBlob[i] = redacted.Bytes()
+		} else {
+			wantPerBlob[i] = BytesWithPrivacyFilter(context.Background(), in.Content)
+		}
+	}
+
+	// Batched run with a fresh fake (configureFakeOPF resets config).
+	fake2 := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
+	configureFakeOPF(t, fake2, cats)
+	gotBatched, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("batched: %v", err)
+	}
+
+	if len(gotBatched) != len(wantPerBlob) {
+		t.Fatalf("output length mismatch: batched=%d per-blob=%d", len(gotBatched), len(wantPerBlob))
+	}
+	for i := range inputs {
+		if string(gotBatched[i]) != string(wantPerBlob[i]) {
+			t.Errorf("blob[%d] (%s) output differs:\n  batched:  %q\n  per-blob: %q",
+				i, inputs[i].Name, string(gotBatched[i]), string(wantPerBlob[i]))
+		}
+	}
+
+	// Bonus assertion: batching collapsed 4 blobs into 1 call, while
+	// per-blob made 3 calls (4 blobs but the dup leaf would still spawn
+	// its own call in the per-blob path because each blob's leaves are
+	// deduped only within that blob).
+	if fake2.batchCalls != 1 {
+		t.Errorf("want exactly 1 batched call, got %d", fake2.batchCalls)
+	}
+	if fake1.batchCalls < 3 {
+		t.Errorf("expected per-blob path to make ≥3 batch calls (one per JSON-shaped blob), got %d", fake1.batchCalls)
+	}
+}
+
+// TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesReturns7Layer
+// covers the configuration edge case where OPF is enabled but every
+// category is turned off — the model has nothing to look for, so we
+// skip the shell-out entirely and return regex-only output.
+func TestBatchBytesWithPrivacyFilter_NoEnabledCategoriesReturns7Layer(t *testing.T) {
+	fake := &fakeRuntime{}
+	// Empty categories — Configure call still wires the runtime but
+	// enabledCategories returns nothing.
+	configureFakeOPF(t, fake, map[string]bool{})
+
+	inputs := []NamedBlob{
+		{Name: "x.jsonl", Content: []byte(`{"text":"Alice met Bob"}`)},
+	}
+	_, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("no-categories path should not error: %v", err)
+	}
+	if fake.batchCalls != 0 {
+		t.Errorf("want 0 OPF calls when no categories enabled, got %d", fake.batchCalls)
+	}
+}

--- a/redact/batch_test.go
+++ b/redact/batch_test.go
@@ -197,6 +197,62 @@ func TestBatchBytesWithPrivacyFilter_FailsClosedOnBatchError(t *testing.T) {
 	}
 }
 
+// shortReturnBatchRuntime returns FEWER span slices than inputs — a
+// runtime contract violation that, if silently accepted, would leave
+// the tail leaves un-redacted while the rewrite ships the commits
+// tagged Entire-OPF-Applied: true.
+type shortReturnBatchRuntime struct{ batchCalls int }
+
+func (r *shortReturnBatchRuntime) Redact(_ context.Context, _ string, _ []string) ([]Span, error) {
+	return nil, nil
+}
+
+func (r *shortReturnBatchRuntime) RedactBatch(_ context.Context, inputs []string, _ []string) ([][]Span, error) {
+	r.batchCalls++
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	// Return exactly ONE span slice regardless of input count — the
+	// violation we're testing for.
+	return [][]Span{nil}, nil
+}
+
+// TestBatchBytesWithPrivacyFilter_ShortReturnFailsClosed pins the
+// fail-closed contract for the runtime short-return case. Production
+// shell-outs always return len(inputs); this guards against any future
+// runtime (daemon, gRPC, mocked partial-failure scenario) producing
+// fewer slices and the caller silently treating the missing tail as
+// "no PII found." The fix trips the breaker AND returns an error so
+// the orchestrator's two-layer abort fires either way.
+func TestBatchBytesWithPrivacyFilter_ShortReturnFailsClosed(t *testing.T) {
+	fake := &shortReturnBatchRuntime{}
+	resetOPFConfig()
+	t.Cleanup(resetOPFConfig)
+	origStderr := opfStderr
+	opfStderr = io.Discard
+	t.Cleanup(func() { opfStderr = origStderr })
+	ConfigurePrivacyFilterWithRuntime(OPFConfig{
+		Enabled:    true,
+		Categories: map[string]bool{"private_person": true},
+	}, fake)
+
+	inputs := []NamedBlob{
+		{Name: "a.jsonl", Content: []byte(`{"text":"Alice met Bob"}`)},
+		{Name: "b.jsonl", Content: []byte(`{"text":"Charlie sat down"}`)},
+		{Name: "c.jsonl", Content: []byte(`{"text":"Eve walked home"}`)},
+	}
+	_, err := BatchBytesWithPrivacyFilter(context.Background(), inputs)
+	if err == nil {
+		t.Fatal("short return must produce a non-nil error, got nil")
+	}
+	if !strings.Contains(err.Error(), "short return") {
+		t.Errorf("want error mentioning 'short return', got %q", err.Error())
+	}
+	if !opfBreakerTripped.Load() {
+		t.Error("short return must trip the breaker so future calls in this process skip OPF")
+	}
+}
+
 // TestBatchBytesWithPrivacyFilter_OPFDisabledReturns7Layer covers the
 // "OPF turned off in settings" path: every blob gets regex-only
 // redaction, no shell-out happens, no error. Without this, a user with

--- a/redact/batch_test.go
+++ b/redact/batch_test.go
@@ -127,13 +127,44 @@ func TestBatchBytesWithPrivacyFilter_AppliesSpansToRawText(t *testing.T) {
 	}
 }
 
+// recordingRuntime captures the slice passed to RedactBatch so a test
+// can assert exact dedup behavior (not just call count). Independent
+// of fakeRuntime so its presence doesn't change unrelated tests.
+type recordingRuntime struct {
+	spans      []Span
+	lastInputs []string
+	calls      int
+}
+
+func (r *recordingRuntime) Redact(_ context.Context, _ string, _ []string) ([]Span, error) {
+	return r.spans, nil
+}
+
+func (r *recordingRuntime) RedactBatch(_ context.Context, inputs []string, _ []string) ([][]Span, error) {
+	r.calls++
+	r.lastInputs = append([]string(nil), inputs...)
+	out := make([][]Span, len(inputs))
+	for i := range inputs {
+		out[i] = r.spans
+	}
+	return out, nil
+}
+
 // TestBatchBytesWithPrivacyFilter_DedupsLeavesAcrossBlobs confirms that
-// the same leaf string appearing in two blobs is sent to OPF exactly
-// once. Without this, a transcript that quotes the same prompt in 10
-// places would inflate the batch unnecessarily.
+// the same leaf string appearing in N blobs is sent to OPF as ONE
+// input, not N. Without this, a transcript that quotes the same prompt
+// in 10 places would inflate the batch unnecessarily.
 func TestBatchBytesWithPrivacyFilter_DedupsLeavesAcrossBlobs(t *testing.T) {
-	fake := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
-	configureFakeOPF(t, fake, map[string]bool{"private_person": true})
+	rt := &recordingRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
+	resetOPFConfig()
+	t.Cleanup(resetOPFConfig)
+	origStderr := opfStderr
+	opfStderr = io.Discard
+	t.Cleanup(func() { opfStderr = origStderr })
+	ConfigurePrivacyFilterWithRuntime(OPFConfig{
+		Enabled:    true,
+		Categories: map[string]bool{"private_person": true},
+	}, rt)
 
 	shared := "Alice met Bob in the lobby"
 	inputs := []NamedBlob{
@@ -145,12 +176,14 @@ func TestBatchBytesWithPrivacyFilter_DedupsLeavesAcrossBlobs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BatchBytesWithPrivacyFilter: %v", err)
 	}
-	// One batch call (already covered above) AND it should see exactly
-	// one input string. The fake doesn't expose its inputs directly, but
-	// we can lean on the batchCalls counter: a deduped batch can't fire
-	// twice no matter how many duplicates appear.
-	if fake.batchCalls != 1 {
-		t.Errorf("want 1 batch call across duplicated leaves, got %d", fake.batchCalls)
+	if rt.calls != 1 {
+		t.Errorf("want 1 batch call, got %d", rt.calls)
+	}
+	if got := len(rt.lastInputs); got != 1 {
+		t.Errorf("want dedup to collapse 3 identical leaves into 1 batch input, got %d (inputs: %v)", got, rt.lastInputs)
+	}
+	if len(rt.lastInputs) == 1 && rt.lastInputs[0] != shared {
+		t.Errorf("want dedup'd input = %q, got %q", shared, rt.lastInputs[0])
 	}
 }
 
@@ -355,14 +388,18 @@ func TestBatchBytesWithPrivacyFilter_MatchesPerBlobOutput(t *testing.T) {
 	}
 
 	// Bonus assertion: batching collapsed 4 blobs into 1 call, while
-	// per-blob made 3 calls (4 blobs but the dup leaf would still spawn
-	// its own call in the per-blob path because each blob's leaves are
-	// deduped only within that blob).
+	// per-blob made exactly 4 batch calls — one per JSON-shaped blob
+	// (full.jsonl, metadata.json, duplicate.jsonl), plus one for the
+	// .txt blob's single-string path. The singular path deliberately
+	// routes through RedactBatch too so short returns trip the breaker.
+	// Within a JSON blob, leaves are deduped, but across blobs in the
+	// per-blob path they aren't — that's the inefficiency the batched
+	// API addresses.
 	if fake2.batchCalls != 1 {
 		t.Errorf("want exactly 1 batched call, got %d", fake2.batchCalls)
 	}
-	if fake1.batchCalls < 3 {
-		t.Errorf("expected per-blob path to make ≥3 batch calls (one per JSON-shaped blob), got %d", fake1.batchCalls)
+	if fake1.batchCalls != 4 {
+		t.Errorf("want exactly 4 per-blob batch calls, got %d", fake1.batchCalls)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/410
<!-- entire-trail-link-end -->

Stacked on #1236. Collapses N OPF binary invocations per push into 1 by batching every redactable leaf across every unpushed \`entire/checkpoints/v1\` commit into a single inference call.

## Summary

The pre-push rewrite from PR #1236 calls the \`opf\` binary once per redactable blob. For a typical 3-commit push that's ~6 invocations (one per shard file: \`full.jsonl\`, \`prompt.txt\`, per-session \`metadata.json\`); model load (~6s) dominates per-call cost, so wall-clock grows linearly with invocation count.

This PR hoists the dedup-batch-apply pattern that \`JSONLContentWithPrivacyFilter\` already uses *within* a blob up one level: walk all unpushed commits to collect every redactable leaf, single \`RedactBatch\` call, walk again to apply cached spans per blob. The model loads once per push regardless of N.

## Measured win

Real OPF binary, 3 unpushed checkpoints with embedded PII (synthetic seed):

```
Pre-batching (per-blob):   13.97s   (6 OPF calls × ~2s warm)
Batched (this PR):          6.54s   (1 OPF call,  12 blobs)
Speedup:                    2.1×    (saves ~5-10s on typical pushes)
```

Win scales with N: a 10-commit push under per-blob is ~30 OPF calls ≈ ~60s; batched stays at one ~12s call. The architectural delta (collapse N model loads to 1) earns its complexity above ~3 commits.

The seed program + measurement workflow lives at \`/tmp/opf-perf-seed/\` for reproduction.

## Commits (3 total)

1. **\`feat(redact): batch OPF inference across multiple blobs\`** — new \`BatchBytesWithPrivacyFilter(ctx, []NamedBlob) ([][]byte, error)\` API + \`SumProseLeafBytes\` helper. Three-pass: collect deduped leaves across all blobs → single \`RedactBatch\` → apply spans per blob in input order. **Fails closed**: returns explicit error on runtime failure (no silent 7-layer fallback like the per-blob path). 11 unit tests with a fake runtime, including a byte-equivalence assertion vs the per-blob path.

2. **\`perf(strategy): batch OPF across unpushed commits in pre-push rewrite\`** — \`RewriteUnpushedV1WithOPF\` refactored to collect-once, batch-once, apply-per-commit. \`rebuildTreeWithOPF\` split into \`collectTreeBlobs\` (collect phase) + \`rebuildTreeWithCachedRedaction\` (apply phase) — same recursion, same shard-scoping, same content_hash.txt deferred recomputation. New \`OPFBatchTooLargeError\` + \`ENTIRE_OPF_BATCH_LIMIT\` env var (default 2 MiB cumulative prose-leaf bytes). All 9 pre-existing rewrite tests pass; 4 new tests for the batching contract + cap.

3. **\`fix(redact): close privacy + memory hazards in batching layer\`** — addresses two issues a holistic review found:
   - **B1**: \`BatchBytesWithPrivacyFilter\` short-return now fails closed (trips breaker + returns error) instead of silently leaving tail leaves un-redacted with the OPF-applied trailer attached.
   - **B4**: Raw-byte RAM ceiling (= leaf cap × 100, default 200 MiB) added to the collect pass so a pathological push (5 GiB pasted dump) aborts cleanly instead of OOMing the shell. Tied to the existing env var so one knob scales both dimensions.
   - **P3** (also in #1236): \`isRedactableBlobName\` inverted to denylist \`content_hash.txt\` only — future blob types (\`.md\`, no-extension) auto-redact instead of slipping through.

## Test plan

- [x] \`mise run check\` — fmt + lint + strategy + redact + checkpoint suites all green
- [x] Real \`opf\` binary smoke test (redact-layer): 3 blobs × .jsonl/.json/.txt batched in 4.45s; per-blob path 7.9s; byte-identical equivalence vs per-blob path
- [x] End-to-end push timing against synthetic 3-checkpoint fixture: batched 6.54s, per-blob 13.97s (2.1× win, scales with N)
- [x] Fail-closed contract: \`TestBatchBytesWithPrivacyFilter_ShortReturnFailsClosed\` + \`TestRewriteUnpushedV1WithOPF_RawByteCap\`
- [x] Privacy contract: \`TestCollectTreeBlobs_RedactsAllFileTypesInsideShard\` pins the \`.md\` / no-extension slip-through fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the privacy-critical pre-push OPF rewrite flow and introduces new fail-closed caps; mistakes could block pushes or, worse, misapply OPF trailers if redaction mapping breaks (though guarded by fail-closed checks and tests). Scope is moderate with new batching logic and error paths.
> 
> **Overview**
> Refactors the pre-push `entire/checkpoints/v1` OPF rewrite to **collect redactable blobs across all unpushed commits**, run **one batched OPF inference** (`redact.BatchBytesWithPrivacyFilter`) for the whole push, then rebuild commits using cached redactions keyed by tree path (with a fail-closed abort if any expected blob redaction is missing).
> 
> Adds a new batched redaction API in `redact/` (`NamedBlob`, `BatchBytesWithPrivacyFilter`, `SumProseLeafBytes`) with leaf deduping, order-preserving outputs, and **fail-closed** behavior on OPF runtime errors/short returns (trips breaker). Introduces `ENTIRE_OPF_BATCH_LIMIT` (default 2MiB prose-leaf bytes) plus a derived raw-bytes RAM ceiling, with typed errors `OPFBatchTooLargeError`/`OPFRawBytesTooLargeError`, new strategy+redact test coverage, and updated security docs to describe batching and the new cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f84451a00c8e6a6259e9fb2cd11b43912d4ed8e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->