### PR TITLE
git: open repositories with alternates-aware storage

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -158,6 +158,7 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	if err != nil {
 		return err
 	}
+	defer repo.Close()
 
 	existingState, err := validateAttachPreconditions(ctx, repo, sessionID)
 	if err != nil {

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -158,7 +158,11 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	if err != nil {
 		return err
 	}
-	defer repo.Close()
+	defer func() {
+		if closeErr := repo.Close(); closeErr != nil {
+			logging.Warn(logCtx, "failed to close repository", slog.String("error", closeErr.Error()))
+		}
+	}()
 
 	existingState, err := validateAttachPreconditions(ctx, repo, sessionID)
 	if err != nil {
@@ -226,7 +230,15 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 	// If HEAD references an existing checkpoint, make sure we have it locally
 	// before writing — otherwise we'd create a fresh session 0 under the same
 	// ID and overwrite the original on push.
-	repo, err = ensureCheckpointAvailable(ctx, logCtx, repo, checkpointID, isExistingCheckpoint)
+	refreshedRepo, err := ensureCheckpointAvailable(ctx, logCtx, repo, checkpointID, isExistingCheckpoint)
+	if refreshedRepo != nil && refreshedRepo != repo {
+		oldRepo := repo
+		repo = refreshedRepo
+		if closeErr := oldRepo.Close(); closeErr != nil {
+			logging.Warn(logCtx, "failed to close stale repository handle after checkpoint refresh",
+				slog.String("error", closeErr.Error()))
+		}
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/entire/cli/benchutil/benchutil.go
+++ b/cmd/entire/cli/benchutil/benchutil.go
@@ -109,6 +109,7 @@ func NewBenchRepo(b *testing.B, opts RepoOpts) *BenchRepo {
 	if err != nil {
 		b.Fatalf("git init: %v", err)
 	}
+	b.Cleanup(func() { _ = repo.Close() })
 
 	// Create .gitignore and .entire settings
 	writeFile(b, dir, ".gitignore", ".entire/\n")

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -20,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -1324,10 +1325,11 @@ func (s *GitStore) GetSessionLog(ctx context.Context, cpID id.CheckpointID) ([]b
 // Returns ErrCheckpointNotFound if the checkpoint doesn't exist.
 // Returns ErrNoTranscript if the checkpoint exists but has no transcript.
 func LookupSessionLog(ctx context.Context, cpID id.CheckpointID) ([]byte, string, error) {
-	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+	repo, err := gitrepo.OpenCurrent(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 	store := NewGitStore(repo)
 	return store.GetSessionLog(ctx, cpID)
 }

--- a/cmd/entire/cli/checkpoint/v2_resolve.go
+++ b/cmd/entire/cli/checkpoint/v2_resolve.go
@@ -43,6 +43,7 @@ func GetV2MetadataTree(ctx context.Context, treelessFetchFn, fullFetchFn FetchRe
 		}
 		tree, treeErr := getV2RefTree(freshRepo, refName)
 		if treeErr != nil {
+			_ = freshRepo.Close()
 			return nil, nil, false
 		}
 		return tree, freshRepo, true
@@ -56,6 +57,7 @@ func GetV2MetadataTree(ctx context.Context, treelessFetchFn, fullFetchFn FetchRe
 				if treeErr == nil {
 					return tree, freshRepo, nil
 				}
+				_ = freshRepo.Close()
 			}
 		}
 		if tree, repo, ok := tryFullFetch(); ok {
@@ -69,6 +71,7 @@ func GetV2MetadataTree(ctx context.Context, treelessFetchFn, fullFetchFn FetchRe
 		if err == nil {
 			return tree, localRepo, nil
 		}
+		_ = localRepo.Close()
 	}
 
 	if tree, repo, ok := tryFullFetch(); ok {

--- a/cmd/entire/cli/clean.go
+++ b/cmd/entire/cli/clean.go
@@ -157,6 +157,7 @@ func previewCurrentHead(ctx context.Context, w io.Writer) error {
 	if err != nil {
 		return err
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -494,6 +495,7 @@ func activeSessionsOnCurrentHead(ctx context.Context) ([]*session.State, error) 
 	if err != nil {
 		return nil, err
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {

--- a/cmd/entire/cli/dispatch/mode_cloud.go
+++ b/cmd/entire/cli/dispatch/mode_cloud.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
-	"github.com/go-git/go-git/v6"
 )
 
 // requireSecureDispatchURL is the secure-base-URL guard used before the cloud
@@ -68,10 +68,12 @@ func runServer(ctx context.Context, opts Options) (*Dispatch, error) {
 		if err != nil {
 			return nil, fmt.Errorf("not in a git repository: %w", err)
 		}
-		repo, err := git.PlainOpenWithOptions(repoRoot, &git.PlainOpenOptions{DetectDotGit: true})
+		repo, err := gitrepo.OpenPath(repoRoot)
 		if err != nil {
 			return nil, fmt.Errorf("open repository: %w", err)
 		}
+		defer repo.Close()
+
 		repoFullName, err := resolveRepoFullName(ctx, repo)
 		if err != nil {
 			return nil, err

--- a/cmd/entire/cli/dispatch/mode_local.go
+++ b/cmd/entire/cli/dispatch/mode_local.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/search"
@@ -130,10 +131,11 @@ func resolveRepoRoots(ctx context.Context, repoPaths []string) ([]string, error)
 }
 
 func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options, since, until time.Time) ([]candidate, error) {
-	repo, err := git.PlainOpenWithOptions(repoRoot, &git.PlainOpenOptions{DetectDotGit: true})
+	repo, err := gitrepo.OpenPath(repoRoot)
 	if err != nil {
 		return nil, fmt.Errorf("open repository %s: %w", repoRoot, err)
 	}
+	defer repo.Close()
 
 	repoFullName, err := resolveRepoFullName(ctx, repo)
 	if err != nil {

--- a/cmd/entire/cli/dispatch_wizard.go
+++ b/cmd/entire/cli/dispatch_wizard.go
@@ -14,10 +14,10 @@ import (
 	"charm.land/huh/v2"
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	dispatchpkg "github.com/entireio/cli/cmd/entire/cli/dispatch"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	searchpkg "github.com/entireio/cli/cmd/entire/cli/search"
-	"github.com/go-git/go-git/v6"
 	"github.com/spf13/cobra"
 )
 
@@ -525,10 +525,12 @@ func discoverAuthenticatedDispatchWizardRepos(ctx context.Context) ([]string, er
 }
 
 func discoverRepoSlug(repoRoot string) string {
-	repo, err := git.PlainOpenWithOptions(repoRoot, &git.PlainOpenOptions{DetectDotGit: true})
+	repo, err := gitrepo.OpenPath(repoRoot)
 	if err != nil {
 		return ""
 	}
+	defer repo.Close()
+
 	remote, err := repo.Remote("origin")
 	if err != nil || len(remote.Config().URLs) == 0 {
 		return ""

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -117,6 +117,7 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Identify stuck sessions
 	now := time.Now()
@@ -332,6 +333,7 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	ctx := cmd.Context()
 	remoteRefName := plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName)

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -93,6 +93,16 @@ type explainCheckpointLookup struct {
 	committed []checkpoint.CommittedInfo
 }
 
+func (l *explainCheckpointLookup) Close() error {
+	if l == nil || l.repo == nil {
+		return nil
+	}
+	if err := l.repo.Close(); err != nil {
+		return fmt.Errorf("close repository: %w", err)
+	}
+	return nil
+}
+
 // generateOrRawLabel returns the user-facing verb for the action the user
 // requested, used in error messages when a commit target has no trailer.
 func generateOrRawLabel(generate bool) string {
@@ -472,6 +482,9 @@ func runExplainAuto(ctx context.Context, w, errW io.Writer, target string, noPag
 	stop := startSpinner(errW, "Loading checkpoints")
 	lookup, lookupErr := newExplainCheckpointLookup(ctx)
 	stop(false)
+	if lookup != nil {
+		defer lookup.Close()
+	}
 	if generate {
 		if err := runExplainAutoAmbiguityGuard(ctx, target, lookup, lookupErr); err != nil {
 			return err
@@ -586,15 +599,26 @@ func runExplainCheckpoint(ctx context.Context, w, errW io.Writer, checkpointIDPr
 }
 
 func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, checkpointIDPrefix string, noPager, verbose, full, rawTranscript, generate, force, searchAll bool, lookup *explainCheckpointLookup, lookupErr error, summaryTimeoutSeconds int) error {
+	ownLookup := false
 	if lookup == nil {
 		var err error
 		lookup, err = newExplainCheckpointLookup(ctx)
 		if err != nil {
 			return err
 		}
+		ownLookup = true
 	} else if lookupErr != nil {
 		return lookupErr
 	}
+	initialLookup := lookup
+	defer func() {
+		if ownLookup && initialLookup != nil {
+			_ = initialLookup.Close()
+		}
+		if lookup != nil && lookup != initialLookup {
+			_ = lookup.Close()
+		}
+	}()
 
 	// Match the prefix locally; on miss, fetch from remote and retry once.
 	matches, lookup := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, checkpointIDPrefix)
@@ -834,6 +858,12 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 	if err != nil {
 		return nil, fmt.Errorf("not a git repository: %w", err)
 	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = repo.Close()
+		}
+	}()
 
 	// FetchBlobsByHash uses `git fetch-pack` for blob SHAs (porcelain
 	// `git fetch` fails against partial-clone repos with "did not send all
@@ -856,6 +886,7 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 		return nil, fmt.Errorf("failed to list checkpoints: %w", err)
 	}
 	lookup.committed = committed
+	closeOnError = false
 	return lookup, nil
 }
 
@@ -2303,6 +2334,7 @@ func runExplainBranchWithFilter(ctx context.Context, w io.Writer, noPager bool, 
 	if err != nil {
 		return fmt.Errorf("not a git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Get current branch name
 	branchName := strategy.GetCurrentBranchName(repo)
@@ -2363,6 +2395,7 @@ func runExplainCommit(ctx context.Context, w, errW io.Writer, commitRef string, 
 	if err != nil {
 		return fmt.Errorf("not a git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Resolve the commit reference, erroring on hex-prefix ambiguity
 	// instead of silently picking the first matching commit.

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -114,7 +114,11 @@ func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explai
 		return id.CheckpointID(""), nil, lookupErr
 	}
 
-	matches, lookup := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, prefix)
+	matches, resolvedLookup := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, prefix)
+	if resolvedLookup != lookup {
+		_ = lookup.Close()
+		lookup = resolvedLookup
+	}
 	switch len(matches) {
 	case 1:
 		return matches[0], lookup, nil
@@ -125,6 +129,7 @@ func resolveExplainCheckpointID(ctx context.Context, errW io.Writer, opts explai
 		if opts.target != "" && opts.checkpointFlag == "" {
 			cpID, freshLookup, commitErr := resolveCheckpointFromCommitRef(ctx, errW, opts.target)
 			if commitErr == nil {
+				_ = lookup.Close()
 				return cpID, freshLookup, nil
 			}
 		}
@@ -145,6 +150,7 @@ func resolveCheckpointFromCommitRef(ctx context.Context, errW io.Writer, commitR
 	if err != nil {
 		return id.CheckpointID(""), nil, fmt.Errorf("not a git repository: %w", err)
 	}
+	defer repo.Close()
 	hash, _, err := resolveCommitUnambiguous(repo, commitRef)
 	if err != nil {
 		return id.CheckpointID(""), nil, fmt.Errorf("commit not found: %s: %w", commitRef, err)
@@ -167,6 +173,9 @@ func resolveCheckpointFromCommitRef(ctx context.Context, errW io.Writer, commitR
 	// metadata reads would fail with an immediate "not found".
 	if !lookupHasCheckpoint(lookup, cpID) {
 		if matches, fresh := matchCheckpointPrefixWithRemoteFallback(ctx, errW, lookup, cpID.String()); len(matches) == 1 {
+			if fresh != lookup {
+				_ = lookup.Close()
+			}
 			lookup = fresh
 		}
 	}
@@ -195,10 +204,16 @@ func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer
 	}
 
 	stop := startSpinner(errW, "Fetching checkpoint metadata from remote")
-	_, _, v1Err := getMetadataTree(ctx)
+	_, v1Repo, v1Err := getMetadataTree(ctx)
+	if v1Repo != nil {
+		_ = v1Repo.Close()
+	}
 	v2OK := false
 	if shouldFetchV2Metadata(ctx, lookup) {
-		if _, _, v2Err := getV2MetadataTree(ctx); v2Err == nil {
+		if _, v2Repo, v2Err := getV2MetadataTree(ctx); v2Err == nil {
+			if v2Repo != nil {
+				_ = v2Repo.Close()
+			}
 			v2OK = true
 		}
 	}
@@ -272,8 +287,12 @@ func resolveSessionIndex(summary *checkpoint.CheckpointSummary, requested int) (
 func runExplainStreamTranscript(ctx context.Context, w, errW io.Writer, opts explainExportOptions) error {
 	cpID, lookup, err := resolveExplainCheckpointID(ctx, errW, opts)
 	if err != nil {
+		if lookup != nil {
+			_ = lookup.Close()
+		}
 		return err
 	}
+	defer lookup.Close()
 
 	store := lookup.store
 	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, store, cpID)
@@ -388,8 +407,12 @@ type checkpointSessionSummary struct {
 func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts explainExportOptions) error {
 	cpID, lookup, err := resolveExplainCheckpointID(ctx, errW, opts)
 	if err != nil {
+		if lookup != nil {
+			_ = lookup.Close()
+		}
 		return err
 	}
+	defer lookup.Close()
 
 	store := lookup.store
 	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, store, cpID)
@@ -545,6 +568,7 @@ func runExplainListJSON(ctx context.Context, w, errW io.Writer, sessionFilter st
 	if err != nil {
 		return fmt.Errorf("not a git repository: %w", err)
 	}
+	defer repo.Close()
 
 	limit := listLimit
 	if limit <= 0 {

--- a/cmd/entire/cli/fetch_no_config_pollution_test.go
+++ b/cmd/entire/cli/fetch_no_config_pollution_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -124,7 +123,7 @@ func TestFetchV2MainTreeOnly_DoesNotCreateShallowRepository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open producer repo: %v", err)
 	}
-	writeV2CheckpointForExport(t, producerRepo, id.MustCheckpointID("121212121212"), checkpoint.WriteCommittedOptions{
+	writeV2CheckpointForExport(t, producerRepo, id.MustCheckpointID("121212121212"), v2CheckpointFixtureOptions{
 		SessionID:  "fetch-v2-shallow-guard",
 		Transcript: redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}` + "\n")),
 	})

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -64,6 +64,7 @@ func GetGitAuthor(ctx context.Context) (*GitAuthor, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	name, email := strategy.GetGitAuthorFromRepo(repo)
 
@@ -108,6 +109,7 @@ func IsOnDefaultBranch(ctx context.Context) (bool, string, error) {
 	if err != nil {
 		return false, "", fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Get current branch
 	head, err := repo.Head()
@@ -181,6 +183,7 @@ func GetCurrentBranch(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -201,6 +204,7 @@ func GetMergeBase(ctx context.Context, branch1, branch2 string) (*plumbing.Hash,
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Resolve branch references
 	ref1, err := repo.Reference(plumbing.NewBranchReferenceName(branch1), true)
@@ -278,6 +282,7 @@ func BranchExistsOnRemote(ctx context.Context, branchName string) (bool, error) 
 	if err != nil {
 		return false, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Check for remote reference: refs/remotes/origin/<branchName>
 	_, err = repo.Reference(plumbing.NewRemoteReferenceName("origin", branchName), true)
@@ -308,6 +313,7 @@ func BranchExistsLocally(ctx context.Context, branchName string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
 	if err != nil {
@@ -379,6 +385,7 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Get the remote branch reference
 	remoteRef, err := repo.Reference(plumbing.NewRemoteReferenceName("origin", branchName), true)
@@ -452,6 +459,7 @@ func fetchMetadataFromOrigin(ctx context.Context, fopts fetchMetadataOpts) error
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	remoteRef, err := repo.Reference(plumbing.NewRemoteReferenceName("origin", branchName), true)
 	if err != nil {

--- a/cmd/entire/cli/gitrepo/alternates_fs.go
+++ b/cmd/entire/cli/gitrepo/alternates_fs.go
@@ -1,0 +1,103 @@
+//nolint:ireturn,wrapcheck // billy.Filesystem requires interface-returning passthrough methods; preserve osfs errors exactly.
+package gitrepo
+
+import (
+	gofs "io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/osfs"
+)
+
+type alternatesFilesystem struct {
+	root billy.Filesystem
+	base string
+}
+
+func newAlternatesFilesystem() billy.Filesystem {
+	return &alternatesFilesystem{
+		root: osfs.New(string(os.PathSeparator), osfs.WithBoundOS()),
+		base: string(os.PathSeparator),
+	}
+}
+
+func (fs *alternatesFilesystem) Create(filename string) (billy.File, error) {
+	return fs.root.Create(fs.resolve(filename))
+}
+
+func (fs *alternatesFilesystem) Open(filename string) (billy.File, error) {
+	return fs.root.Open(fs.resolve(filename))
+}
+
+func (fs *alternatesFilesystem) OpenFile(filename string, flag int, perm gofs.FileMode) (billy.File, error) {
+	return fs.root.OpenFile(fs.resolve(filename), flag, perm)
+}
+
+func (fs *alternatesFilesystem) Stat(filename string) (gofs.FileInfo, error) {
+	return fs.root.Stat(fs.resolve(filename))
+}
+
+func (fs *alternatesFilesystem) Rename(oldpath, newpath string) error {
+	return fs.root.Rename(fs.resolve(oldpath), fs.resolve(newpath))
+}
+
+func (fs *alternatesFilesystem) Remove(filename string) error {
+	return fs.root.Remove(fs.resolve(filename))
+}
+
+func (fs *alternatesFilesystem) Join(elem ...string) string {
+	return filepath.Join(elem...)
+}
+
+func (fs *alternatesFilesystem) TempFile(dir, prefix string) (billy.File, error) {
+	return fs.root.TempFile(fs.resolve(dir), prefix)
+}
+
+func (fs *alternatesFilesystem) ReadDir(path string) ([]gofs.DirEntry, error) {
+	return fs.root.ReadDir(fs.resolve(path))
+}
+
+func (fs *alternatesFilesystem) MkdirAll(filename string, perm gofs.FileMode) error {
+	return fs.root.MkdirAll(fs.resolve(filename), perm)
+}
+
+func (fs *alternatesFilesystem) Lstat(filename string) (gofs.FileInfo, error) {
+	return fs.root.Lstat(fs.resolve(filename))
+}
+
+func (fs *alternatesFilesystem) Symlink(target, link string) error {
+	return fs.root.Symlink(target, fs.resolve(link))
+}
+
+func (fs *alternatesFilesystem) Readlink(link string) (string, error) {
+	return fs.root.Readlink(fs.resolve(link))
+}
+
+func (fs *alternatesFilesystem) Chroot(path string) (billy.Filesystem, error) {
+	return &alternatesFilesystem{
+		root: fs.root,
+		base: fs.resolve(path),
+	}, nil
+}
+
+func (fs *alternatesFilesystem) Root() string {
+	return fs.base
+}
+
+func (fs *alternatesFilesystem) Capabilities() billy.Capability {
+	if capable, ok := fs.root.(billy.Capable); ok {
+		return capable.Capabilities()
+	}
+	return billy.DefaultCapabilities
+}
+
+func (fs *alternatesFilesystem) resolve(name string) string {
+	if name == "" {
+		return fs.base
+	}
+	if filepath.IsAbs(name) || filepath.VolumeName(name) != "" {
+		return filepath.Clean(name)
+	}
+	return filepath.Clean(filepath.Join(fs.base, name))
+}

--- a/cmd/entire/cli/gitrepo/repository.go
+++ b/cmd/entire/cli/gitrepo/repository.go
@@ -1,0 +1,135 @@
+package gitrepo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	gitfilesystem "github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
+)
+
+const gitDir = ".git"
+
+// OpenCurrent opens the current git worktree with object alternates enabled.
+// The caller owns the returned repository and must close it.
+func OpenCurrent(ctx context.Context) (*git.Repository, error) {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		// Fallback to current directory if git command fails
+		// (e.g., if git is not installed or we're not in a repo).
+		repoRoot = "."
+	}
+	return OpenPath(repoRoot)
+}
+
+// OpenPath opens a git repository with object alternates enabled.
+// The caller owns the returned repository and must close it.
+func OpenPath(repoRoot string) (*git.Repository, error) {
+	repo, err := openPathWithAlternates(repoRoot)
+	if err != nil {
+		// Intentional PlainOpen fallback: keep go-git's native support for unusual
+		// layouts that the custom alternate-aware opener cannot resolve yet.
+		if fallbackRepo, fallbackErr := git.PlainOpen(repoRoot); fallbackErr == nil {
+			return fallbackRepo, nil
+		}
+		return nil, fmt.Errorf("failed to open repository: %w", err)
+	}
+	return repo, nil
+}
+
+func openPathWithAlternates(repoRoot string) (*git.Repository, error) {
+	repoRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repository root: %w", err)
+	}
+
+	dotGitPath, err := resolveDotGitPath(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	commonGitPath, err := resolveCommonGitPath(dotGitPath)
+	if err != nil {
+		return nil, err
+	}
+
+	dotGitFS := osfs.New(dotGitPath, osfs.WithBoundOS())
+	var commonGitFS billy.Filesystem
+	if commonGitPath != "" {
+		commonGitFS = osfs.New(commonGitPath, osfs.WithBoundOS())
+	}
+
+	repositoryFS := dotgit.NewRepositoryFilesystem(dotGitFS, commonGitFS)
+	// Shared clones write absolute object directories to objects/info/alternates;
+	// an OS-rooted filesystem lets go-git follow those paths outside .git.
+	storage := gitfilesystem.NewStorageWithOptions(
+		repositoryFS,
+		cache.NewObjectLRUDefault(),
+		gitfilesystem.Options{
+			AlternatesFS: newAlternatesFilesystem(),
+		},
+	)
+	repo, err := git.Open(storage, osfs.New(repoRoot, osfs.WithBoundOS()))
+	if err != nil {
+		_ = storage.Close()
+		return nil, fmt.Errorf("open repository storage: %w", err)
+	}
+	return repo, nil
+}
+
+func resolveDotGitPath(repoRoot string) (string, error) {
+	gitPath := filepath.Join(repoRoot, gitDir)
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", fmt.Errorf("stat .git path: %w", err)
+	}
+	if info.IsDir() {
+		return gitPath, nil
+	}
+
+	content, err := os.ReadFile(gitPath) //nolint:gosec // gitPath is resolved from the git worktree root.
+	if err != nil {
+		return "", fmt.Errorf("read .git file: %w", err)
+	}
+
+	line, _, _ := strings.Cut(string(content), "\n")
+	gitdir, ok := strings.CutPrefix(strings.TrimSpace(line), "gitdir:")
+	if !ok {
+		return "", errors.New(".git file has no gitdir prefix")
+	}
+
+	gitdir = strings.TrimSpace(gitdir)
+	if filepath.IsAbs(gitdir) {
+		return filepath.Clean(gitdir), nil
+	}
+	return filepath.Clean(filepath.Join(repoRoot, gitdir)), nil
+}
+
+func resolveCommonGitPath(dotGitPath string) (string, error) {
+	content, err := os.ReadFile(filepath.Join(dotGitPath, "commondir")) //nolint:gosec // dotGitPath is resolved from the git worktree root.
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read commondir file: %w", err)
+	}
+
+	commonPath := strings.TrimSpace(string(content))
+	if commonPath == "" {
+		return "", nil
+	}
+	if filepath.IsAbs(commonPath) {
+		return filepath.Clean(commonPath), nil
+	}
+	return filepath.Clean(filepath.Join(dotGitPath, commonPath)), nil
+}

--- a/cmd/entire/cli/gitrepo/repository.go
+++ b/cmd/entire/cli/gitrepo/repository.go
@@ -37,14 +37,49 @@ func OpenCurrent(ctx context.Context) (*git.Repository, error) {
 func OpenPath(repoRoot string) (*git.Repository, error) {
 	repo, err := openPathWithAlternates(repoRoot)
 	if err != nil {
-		// Intentional PlainOpen fallback: keep go-git's native support for unusual
-		// layouts that the custom alternate-aware opener cannot resolve yet.
+		if hasAlternates, altErr := hasObjectAlternates(repoRoot); altErr == nil && hasAlternates {
+			return nil, fmt.Errorf("failed to open repository with alternates support: %w", err)
+		}
+
+		// Intentional PlainOpen fallback for unusual layouts that do not use
+		// alternates. Repositories with alternates must not silently downgrade
+		// because PlainOpen cannot read absolute alternate object directories.
 		if fallbackRepo, fallbackErr := git.PlainOpen(repoRoot); fallbackErr == nil {
 			return fallbackRepo, nil
 		}
 		return nil, fmt.Errorf("failed to open repository: %w", err)
 	}
 	return repo, nil
+}
+
+func hasObjectAlternates(repoRoot string) (bool, error) {
+	repoRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return false, fmt.Errorf("resolve repository root: %w", err)
+	}
+
+	dotGitPath, err := resolveDotGitPath(repoRoot)
+	if err != nil {
+		return false, fmt.Errorf("resolve .git path: %w", err)
+	}
+
+	commonGitPath, err := resolveCommonGitPath(dotGitPath)
+	if err != nil {
+		return false, fmt.Errorf("resolve common git path: %w", err)
+	}
+
+	candidates := []string{filepath.Join(dotGitPath, "objects", "info", "alternates")}
+	if commonGitPath != "" {
+		candidates = append(candidates, filepath.Join(commonGitPath, "objects", "info", "alternates"))
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Errorf("stat alternates file: %w", err)
+		}
+	}
+	return false, nil
 }
 
 func openPathWithAlternates(repoRoot string) (*git.Repository, error) {

--- a/cmd/entire/cli/gitrepo/repository_test.go
+++ b/cmd/entire/cli/gitrepo/repository_test.go
@@ -1,0 +1,91 @@
+package gitrepo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenPath_MultipleAlternates(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	altADir := t.TempDir()
+	altBDir := t.TempDir()
+	altIntermediateDir := t.TempDir()
+	altNestedDir := t.TempDir()
+
+	rootHash := initRepoWithFile(t, rootDir, "root.txt", "root\n")
+	altAHash := initRepoWithFile(t, altADir, "a.txt", "a\n")
+	altBHash := initRepoWithFile(t, altBDir, "b.txt", "b\n")
+	_ = initRepoWithFile(t, altIntermediateDir, "intermediate.txt", "intermediate\n")
+	altNestedHash := initRepoWithFile(t, altNestedDir, "nested.txt", "nested\n")
+
+	writeAlternates(t, altIntermediateDir, []string{
+		filepath.Join(altNestedDir, gitDir, "objects"),
+	})
+	writeAlternates(t, rootDir, []string{
+		filepath.Join(altADir, gitDir, "objects"),
+		filepath.Join(altBDir, gitDir, "objects"),
+		filepath.Join(altIntermediateDir, gitDir, "objects"),
+	})
+
+	repo, err := OpenPath(rootDir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	for _, hash := range []string{rootHash, altAHash, altBHash, altNestedHash} {
+		commit, err := repo.CommitObject(plumbing.NewHash(hash))
+		require.NoError(t, err, "commit %s should be readable", hash)
+		_, err = commit.Tree()
+		require.NoError(t, err, "tree for commit %s should be readable", hash)
+	}
+}
+
+func initRepoWithFile(t *testing.T, repoDir, name, content string) string {
+	t.Helper()
+	repo, err := git.PlainInit(repoDir, false)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	cfg, err := repo.Config()
+	require.NoError(t, err)
+	cfg.User.Name = "Test User"
+	cfg.User.Email = "test@example.com"
+	if cfg.Raw == nil {
+		cfg.Raw = config.New()
+	}
+	cfg.Raw.Section("commit").SetOption("gpgsign", "false")
+	require.NoError(t, repo.SetConfig(cfg))
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, name), []byte(content), 0o644))
+
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add(name)
+	require.NoError(t, err)
+	hash, err := worktree.Commit("add "+name, &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+	return hash.String()
+}
+
+func writeAlternates(t *testing.T, repoDir string, alternates []string) {
+	t.Helper()
+	infoDir := filepath.Join(repoDir, gitDir, "objects", "info")
+	require.NoError(t, os.MkdirAll(infoDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(infoDir, "alternates"), []byte(strings.Join(alternates, "\n")+"\n"), 0o644))
+}

--- a/cmd/entire/cli/gitrepo/repository_test.go
+++ b/cmd/entire/cli/gitrepo/repository_test.go
@@ -50,6 +50,51 @@ func TestOpenPath_MultipleAlternates(t *testing.T) {
 	}
 }
 
+func TestHasObjectAlternates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("main repository", func(t *testing.T) {
+		t.Parallel()
+
+		repoDir := t.TempDir()
+		_ = initRepoWithFile(t, repoDir, "root.txt", "root\n")
+
+		hasAlternates, err := hasObjectAlternates(repoDir)
+		require.NoError(t, err)
+		require.False(t, hasAlternates)
+
+		alternateDir := t.TempDir()
+		writeAlternates(t, repoDir, []string{filepath.Join(alternateDir, gitDir, "objects")})
+
+		hasAlternates, err = hasObjectAlternates(repoDir)
+		require.NoError(t, err)
+		require.True(t, hasAlternates)
+	})
+
+	t.Run("linked worktree common dir", func(t *testing.T) {
+		t.Parallel()
+
+		rootDir := t.TempDir()
+		worktreeDir := filepath.Join(rootDir, "worktree")
+		mainGitDir := filepath.Join(rootDir, "main.git")
+		worktreeGitDir := filepath.Join(mainGitDir, "worktrees", "worktree")
+		alternateDir := filepath.Join(rootDir, "alternate.git", "objects")
+
+		require.NoError(t, os.MkdirAll(worktreeDir, 0o755))
+		require.NoError(t, os.MkdirAll(worktreeGitDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, gitDir), []byte("gitdir: "+worktreeGitDir+"\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(worktreeGitDir, "commondir"), []byte("../..\n"), 0o644))
+
+		infoDir := filepath.Join(mainGitDir, "objects", "info")
+		require.NoError(t, os.MkdirAll(infoDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(infoDir, "alternates"), []byte(alternateDir+"\n"), 0o644))
+
+		hasAlternates, err := hasObjectAlternates(worktreeDir)
+		require.NoError(t, err)
+		require.True(t, hasAlternates)
+	})
+}
+
 func initRepoWithFile(t *testing.T, repoDir, name, content string) string {
 	t.Helper()
 	repo, err := git.PlainInit(repoDir, false)

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -22,6 +22,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/execx"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -214,6 +215,7 @@ func (env *TestEnv) InitRepo() {
 	if err != nil {
 		env.T.Fatalf("failed to init git repo: %v", err)
 	}
+	defer repo.Close()
 
 	// Configure git user for commits
 	cfg, err := repo.Config()
@@ -440,10 +442,11 @@ func (env *TestEnv) FileExists(path string) bool {
 func (env *TestEnv) GitAdd(paths ...string) {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -461,10 +464,11 @@ func (env *TestEnv) GitAdd(paths ...string) {
 func (env *TestEnv) GitCommit(message string) {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -491,10 +495,11 @@ func (env *TestEnv) GitCommitWithMetadata(message, metadataDir string) {
 	// Format message with metadata trailer
 	fullMessage := message + "\n\nEntire-Metadata: " + metadataDir + "\n"
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -521,10 +526,11 @@ func (env *TestEnv) GitCommitWithCheckpointID(message, checkpointID string) {
 	// Format message with checkpoint trailer
 	fullMessage := message + "\n\nEntire-Checkpoint: " + checkpointID + "\n"
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -556,10 +562,11 @@ func (env *TestEnv) GitCommitWithMultipleSessions(message string, sessionIDs []s
 	}
 	fullMessage += fullMessageSb404.String()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -592,10 +599,11 @@ func (env *TestEnv) GitCommitWithMultipleCheckpoints(message string, checkpointI
 		sb.WriteString("Entire-Checkpoint: " + cpID + "\n")
 	}
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -651,10 +659,11 @@ func composeReviewPromptForTest(skills []string) string {
 func (env *TestEnv) GetHeadHash() string {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -693,10 +702,11 @@ func (env *TestEnv) GetShadowBranchNameForCommit(commitHash string) string {
 func (env *TestEnv) GetGitLog() []string {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -738,10 +748,11 @@ func (env *TestEnv) GitCheckoutNewBranch(branchName string) {
 func (env *TestEnv) GetCurrentBranch() string {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -875,10 +886,11 @@ func (env *TestEnv) RewindReset(commitID string) error {
 func (env *TestEnv) BranchExists(branchName string) bool {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	_, err = repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
 	return err == nil
@@ -888,10 +900,11 @@ func (env *TestEnv) BranchExists(branchName string) bool {
 func (env *TestEnv) GetCommitMessage(hash string) string {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	commitHash := plumbing.NewHash(hash)
 	commit, err := repo.CommitObject(commitHash)
@@ -906,10 +919,11 @@ func (env *TestEnv) GetCommitMessage(hash string) string {
 func (env *TestEnv) FileExistsInBranch(branchName, filePath string) bool {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	// Get the branch reference
 	ref, err := repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
@@ -943,10 +957,11 @@ func (env *TestEnv) FileExistsInBranch(branchName, filePath string) bool {
 func (env *TestEnv) ReadFileFromBranch(branchName, filePath string) (string, bool) {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	// Get the branch reference
 	ref, err := repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
@@ -992,10 +1007,11 @@ func (env *TestEnv) ReadFileFromBranch(branchName, filePath string) (string, boo
 func (env *TestEnv) ReadFileFromRef(refName, filePath string) (string, bool) {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	ref, err := repo.Reference(plumbing.ReferenceName(refName), true)
 	if err != nil {
@@ -1070,10 +1086,11 @@ func (env *TestEnv) sessionMetadataMatchesID(metadataPath, sessionID string) boo
 func (env *TestEnv) RefExists(refName string) bool {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	_, err = repo.Reference(plumbing.ReferenceName(refName), true)
 	return err == nil
@@ -1083,10 +1100,11 @@ func (env *TestEnv) RefExists(refName string) bool {
 func (env *TestEnv) GetLatestCommitMessageOnBranch(branchName string) string {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	// Get the branch reference
 	ref, err := repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
@@ -1167,10 +1185,11 @@ func (env *TestEnv) gitCommitWithShadowHooks(message string, simulateTTY bool, f
 	}
 
 	// Create the commit using go-git with the modified message
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -1240,10 +1259,11 @@ func (env *TestEnv) GitCommitAmendWithShadowHooks(message string, files ...strin
 	}
 
 	// Amend the commit using go-git
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -1345,10 +1365,11 @@ func (env *TestEnv) GitCommitWithTrailerRemoved(message string, files ...string)
 	cleanedMsg := strings.TrimRight(strings.Join(cleanedLines, "\n"), "\n") + "\n"
 
 	// Create the commit using go-git with the cleaned message (no trailer)
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -1419,10 +1440,11 @@ func (env *TestEnv) gitCommitStagedWithShadowHooks(message string, simulateTTY b
 	}
 
 	// Create the commit using go-git with the modified message
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -1453,10 +1475,11 @@ func (env *TestEnv) gitCommitStagedWithShadowHooks(message string, simulateTTY b
 func (env *TestEnv) ListBranchesWithPrefix(prefix string) []string {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	refs, err := repo.References()
 	if err != nil {
@@ -1482,10 +1505,11 @@ func (env *TestEnv) ListBranchesWithPrefix(prefix string) []string {
 func (env *TestEnv) GetLatestCheckpointID() string {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	// Get the entire/checkpoints/v1 branch
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
@@ -1519,10 +1543,11 @@ func (env *TestEnv) GetLatestCheckpointID() string {
 func (env *TestEnv) TryGetLatestCheckpointID() string {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		return ""
 	}
+	defer repo.Close()
 
 	// Get the entire/checkpoints/v1 branch
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
@@ -1573,10 +1598,11 @@ func (env *TestEnv) GetCheckpointIDFromCommitMessage(commitSHA string) string {
 func (env *TestEnv) GetLatestCheckpointIDFromHistory() string {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -2096,10 +2122,11 @@ func (env *TestEnv) FetchMetadataBranch(remoteURL string) {
 func (env *TestEnv) GetBranchTipParentCount(branchName string) int {
 	env.T.Helper()
 
-	repo, err := git.PlainOpen(env.RepoDir)
+	repo, err := gitrepo.OpenPath(env.RepoDir)
 	if err != nil {
 		env.T.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	ref, err := repo.Reference(plumbing.NewBranchReferenceName(branchName), true)
 	if err != nil {

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -124,8 +124,11 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 	// Build informational message — warn early if repo has no commits yet,
 	// since checkpoints require at least one commit to work.
 	message := sessionStartMessage(ag.Name(), false)
-	if repo, err := strategy.OpenRepository(ctx); err == nil && strategy.IsEmptyRepository(repo) {
-		message = sessionStartMessage(ag.Name(), true)
+	if repo, err := strategy.OpenRepository(ctx); err == nil {
+		defer repo.Close()
+		if strategy.IsEmptyRepository(repo) {
+			message = sessionStartMessage(ag.Name(), true)
+		}
 	}
 
 	// Check for concurrent sessions and append count if any
@@ -485,10 +488,13 @@ func handleLifecycleTurnEnd(ctx context.Context, ag agent.Agent, event *agent.Ev
 	// Early check: bail out quickly if the repo has no commits yet.
 	// Return nil (not an error) so the hook exits 0 — agents treat non-zero
 	// exit codes as hook failures. The user was already warned at session start.
-	if repo, err := strategy.OpenRepository(ctx); err == nil && strategy.IsEmptyRepository(repo) {
-		prepareSpan.End()
-		logging.Info(logCtx, "skipping checkpoint - will activate after first commit")
-		return nil
+	if repo, err := strategy.OpenRepository(ctx); err == nil {
+		defer repo.Close()
+		if strategy.IsEmptyRepository(repo) {
+			prepareSpan.End()
+			logging.Info(logCtx, "skipping checkpoint - will activate after first commit")
+			return nil
+		}
 	}
 	prepareSpan.End()
 

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -149,6 +149,7 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 	if err != nil {
 		return fmt.Errorf("not a git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Find a commit with an Entire-Checkpoint trailer, looking at branch-only commits
 	result, err := findBranchCheckpoints(repo, branchName)
@@ -449,6 +450,7 @@ func getMetadataTree(ctx context.Context) (*object.Tree, *git.Repository, error)
 			logging.Debug(logCtx, "checkpoint remote fetch succeeded but tree read failed",
 				slog.String("error", treeErr.Error()),
 			)
+			_ = freshRepo.Close()
 		}
 	} else {
 		logging.Debug(logCtx, "checkpoint remote fetch skipped or failed",
@@ -472,6 +474,7 @@ func getMetadataTree(ctx context.Context) (*object.Tree, *git.Repository, error)
 			logging.Debug(logCtx, "treeless fetch succeeded but tree read failed",
 				slog.String("error", treeErr.Error()),
 			)
+			_ = freshRepo.Close()
 		}
 	} else {
 		logging.Debug(logCtx, "treeless fetch failed, trying local",
@@ -493,6 +496,7 @@ func getMetadataTree(ctx context.Context) (*object.Tree, *git.Repository, error)
 		logging.Debug(logCtx, "local metadata branch not available",
 			slog.String("error", err.Error()),
 		)
+		_ = localRepo.Close()
 	}
 
 	// Fallback: full fetch from origin
@@ -510,6 +514,7 @@ func getMetadataTree(ctx context.Context) (*object.Tree, *git.Repository, error)
 			logging.Debug(logCtx, "full fetch succeeded but tree read failed",
 				slog.String("error", treeErr.Error()),
 			)
+			_ = freshRepo.Close()
 		}
 	} else {
 		logging.Debug(logCtx, "full fetch failed",
@@ -531,6 +536,7 @@ func getMetadataTree(ctx context.Context) (*object.Tree, *git.Repository, error)
 	logging.Debug(logCtx, "remote metadata tree also not available",
 		slog.String("error", remoteErr.Error()),
 	)
+	_ = remoteRepo.Close()
 
 	return nil, nil, fmt.Errorf("metadata branch not available: %w", remoteErr)
 }
@@ -724,6 +730,7 @@ func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id
 	if settings.IsCheckpointsV2Enabled(ctx) {
 		v2Tree, v2Repo, v2Err := getV2MetadataTree(ctx)
 		if v2Err == nil {
+			defer v2Repo.Close()
 			cpSubtree, cpErr := v2Tree.Tree(checkpointID.Path())
 			if cpErr == nil {
 				ft := checkpoint.NewFetchingTree(ctx, cpSubtree, v2Repo.Storer, FetchBlobsByHash)
@@ -754,6 +761,7 @@ func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id
 		fmt.Fprintf(errW, "Checkpoint '%s' found in commit but session metadata not available\n", checkpointID)
 		return nil
 	}
+	defer repo.Close()
 
 	// Resolve checkpoint remote URL once; reuse for both fetch and error message.
 	hasCheckpointRemote := remote.Configured(ctx)
@@ -770,17 +778,20 @@ func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id
 					logging.Debug(logCtx, "checkpoint remote: open repository failed after fetch",
 						slog.String("error", freshErr.Error()),
 					)
-				} else if metadataTree, treeErr := strategy.GetMetadataBranchTree(freshRepo); treeErr != nil {
-					logging.Debug(logCtx, "checkpoint remote: fetch succeeded but tree read failed",
-						slog.String("error", treeErr.Error()),
-					)
-				} else if metadata, err := tryReadCheckpointFromTree(ctx, metadataTree, freshRepo, checkpointID); err != nil {
-					logging.Debug(logCtx, "checkpoint remote: tree read succeeded but checkpoint metadata read failed",
-						slog.String("checkpoint_id", checkpointID.String()),
-						slog.String("error", err.Error()),
-					)
 				} else {
-					return resumeSession(ctx, w, errW, metadata, false)
+					defer freshRepo.Close()
+					if metadataTree, treeErr := strategy.GetMetadataBranchTree(freshRepo); treeErr != nil {
+						logging.Debug(logCtx, "checkpoint remote: fetch succeeded but tree read failed",
+							slog.String("error", treeErr.Error()),
+						)
+					} else if metadata, err := tryReadCheckpointFromTree(ctx, metadataTree, freshRepo, checkpointID); err != nil {
+						logging.Debug(logCtx, "checkpoint remote: tree read succeeded but checkpoint metadata read failed",
+							slog.String("checkpoint_id", checkpointID.String()),
+							slog.String("error", err.Error()),
+						)
+					} else {
+						return resumeSession(ctx, w, errW, metadata, false)
+					}
 				}
 			} else {
 				logging.Debug(logCtx, "checkpoint remote fetch failed",
@@ -812,17 +823,20 @@ func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id
 			logging.Debug(logCtx, "origin metadata fetch succeeded but repository reopen failed",
 				slog.String("error", freshErr.Error()),
 			)
-		} else if metadataTree, treeErr := strategy.GetMetadataBranchTree(freshRepo); treeErr != nil {
-			logging.Debug(logCtx, "origin metadata fetch succeeded but local branch read failed",
-				slog.String("error", treeErr.Error()),
-			)
-		} else if metadata, err := tryReadCheckpointFromTree(ctx, metadataTree, freshRepo, checkpointID); err != nil {
-			logging.Debug(logCtx, "origin metadata fetch succeeded but checkpoint metadata read failed",
-				slog.String("checkpoint_id", checkpointID.String()),
-				slog.String("error", err.Error()),
-			)
 		} else {
-			return resumeSession(ctx, w, errW, metadata, false)
+			defer freshRepo.Close()
+			if metadataTree, treeErr := strategy.GetMetadataBranchTree(freshRepo); treeErr != nil {
+				logging.Debug(logCtx, "origin metadata fetch succeeded but local branch read failed",
+					slog.String("error", treeErr.Error()),
+				)
+			} else if metadata, err := tryReadCheckpointFromTree(ctx, metadataTree, freshRepo, checkpointID); err != nil {
+				logging.Debug(logCtx, "origin metadata fetch succeeded but checkpoint metadata read failed",
+					slog.String("checkpoint_id", checkpointID.String()),
+					slog.String("error", err.Error()),
+				)
+			} else {
+				return resumeSession(ctx, w, errW, metadata, false)
+			}
 		}
 	} else {
 		logging.Debug(logCtx, "origin metadata fetch failed",
@@ -998,6 +1012,7 @@ func resumeSingleSession(ctx context.Context, w, errW io.Writer, ag agent.Agent,
 	if repoErr != nil {
 		logContent, _, err = checkpoint.LookupSessionLog(ctx, checkpointID)
 	} else {
+		defer repo.Close()
 		store, storeErr := checkpoint.NewCommittedReader(ctx, repo, checkpoint.CommittedReaderOptions{})
 		if storeErr != nil {
 			err = storeErr

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -17,12 +17,12 @@ import (
 	"strings"
 
 	"charm.land/huh/v2"
-	git "github.com/go-git/go-git/v6"
 	"github.com/spf13/cobra"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -453,7 +453,7 @@ func runSingleAgentPath(
 // Otherwise (auto-detection failed): returns "" and the caller proceeds in
 // degraded mode without a scope banner.
 func detectScope(ctx context.Context, worktreeRoot, baseOverride string, out io.Writer) (string, error) {
-	repo, openErr := git.PlainOpen(worktreeRoot)
+	repo, openErr := gitrepo.OpenPath(worktreeRoot)
 	if openErr != nil {
 		logging.Debug(ctx, "review repo open failed", slog.String("error", openErr.Error()))
 		// Fail-loud when the user explicitly asked for a base. Without this
@@ -465,6 +465,7 @@ func detectScope(ctx context.Context, worktreeRoot, baseOverride string, out io.
 		}
 		return "", nil
 	}
+	defer repo.Close()
 	stats, statsErr := ComputeScopeStats(ctx, repo, baseOverride)
 	if statsErr != nil {
 		// With an override, the user explicitly asked for a specific base.

--- a/cmd/entire/cli/review_context.go
+++ b/cmd/entire/cli/review_context.go
@@ -11,10 +11,9 @@ import (
 	"strconv"
 	"strings"
 
-	git "github.com/go-git/go-git/v6"
-
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	checkpointid "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -62,11 +61,12 @@ func joinReviewContextSections(sections ...string) string {
 // in-progress session context is surfaced even when there are no committed
 // checkpoints in scope (the common case: branch with only uncommitted work).
 func reviewSessionContextForCurrentHead(ctx context.Context, worktreeRoot string) string {
-	repo, err := git.PlainOpen(worktreeRoot)
+	repo, err := gitrepo.OpenPath(worktreeRoot)
 	if err != nil {
 		logging.Debug(ctx, "review session context: open repo", slog.String("error", err.Error()))
 		return ""
 	}
+	defer repo.Close()
 	head, err := repo.Head()
 	if err != nil {
 		logging.Debug(ctx, "review session context: resolve HEAD", slog.String("error", err.Error()))
@@ -92,11 +92,12 @@ func reviewCommittedCheckpointContext(ctx context.Context, worktreeRoot string, 
 		return ""
 	}
 
-	repo, err := git.PlainOpen(worktreeRoot)
+	repo, err := gitrepo.OpenPath(worktreeRoot)
 	if err != nil {
 		logging.Debug(ctx, "review checkpoint context: open repo", slog.String("error", err.Error()))
 		return ""
 	}
+	defer repo.Close()
 	store, storeErr := checkpoint.NewCommittedReader(ctx, repo, checkpoint.CommittedReaderOptions{})
 	if storeErr != nil {
 		logging.Debug(ctx, "review checkpoint context: checkpoint store unavailable", slog.String("error", storeErr.Error()))

--- a/cmd/entire/cli/review_helpers.go
+++ b/cmd/entire/cli/review_helpers.go
@@ -18,13 +18,13 @@ import (
 	"log/slog"
 	"os/exec"
 
-	git "github.com/go-git/go-git/v6"
 	"github.com/spf13/cobra"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	cliReview "github.com/entireio/cli/cmd/entire/cli/review"
@@ -52,11 +52,12 @@ func headHasReviewCheckpoint(ctx context.Context) (bool, string) {
 		logging.Debug(ctx, "head review check: no Entire-Checkpoint trailer on HEAD")
 		return false, ""
 	}
-	repo, err := git.PlainOpen(repoRoot)
+	repo, err := gitrepo.OpenPath(repoRoot)
 	if err != nil {
 		logging.Debug(ctx, "head review check: open repository", slog.String("error", err.Error()))
 		return false, ""
 	}
+	defer repo.Close()
 	store, storeErr := checkpoint.NewCommittedReader(ctx, repo, checkpoint.CommittedReaderOptions{})
 	if storeErr != nil {
 		logging.Debug(ctx, "head review check: checkpoint store unavailable", slog.String("error", storeErr.Error()))

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -18,6 +18,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -690,6 +691,7 @@ func restoreSessionTranscriptFromStrategy(ctx context.Context, cpID id.Checkpoin
 	if err != nil {
 		return "", fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	store, err := checkpoint.NewCommittedReader(ctx, repo, checkpoint.CommittedReaderOptions{})
 	if err != nil {
@@ -729,10 +731,11 @@ func restoreSessionTranscriptFromStrategy(ctx context.Context, cpID id.Checkpoin
 // This is used for uncommitted checkpoints where the transcript is stored in the shadow branch tree.
 func restoreSessionTranscriptFromShadow(ctx context.Context, commitHash, metadataDir, sessionID string, agent agentpkg.Agent) (string, error) {
 	// Open repository
-	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+	repo, err := gitrepo.OpenCurrent(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Parse commit hash
 	hash := plumbing.NewHash(commitHash)
@@ -1069,6 +1072,7 @@ func getCurrentHeadHash(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -1088,6 +1092,7 @@ func checkResetSafety(ctx context.Context, targetCommitHash string, uncommittedC
 	if err != nil {
 		return nil, err
 	}
+	defer repo.Close()
 
 	// Check for uncommitted changes
 	if uncommittedChangesWarning != "" {

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -85,6 +85,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 				fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Run this command from within a git repository.")
 				return NewSilentError(err)
 			}
+			defer repo.Close()
 
 			remote, err := repo.Remote("origin")
 			if err != nil {

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -1079,10 +1079,13 @@ func runEnableInteractive(ctx context.Context, w io.Writer, agents []agent.Agent
 	fmt.Fprintln(w, "\nReady.")
 
 	// Note about empty repos at the end, after setup is complete
-	if repo, err := strategy.OpenRepository(ctx); err == nil && strategy.IsEmptyRepository(repo) {
-		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Note: Session checkpoints require at least one commit. To get started,")
-		fmt.Fprintln(w, "commit the configuration files (e.g. .entire/, .claude/).")
+	if repo, err := strategy.OpenRepository(ctx); err == nil {
+		defer repo.Close()
+		if strategy.IsEmptyRepository(repo) {
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "Note: Session checkpoints require at least one commit. To get started,")
+			fmt.Fprintln(w, "commit the configuration files (e.g. .entire/, .claude/).")
+		}
 	}
 
 	return nil
@@ -1559,10 +1562,13 @@ func setupAgentHooksNonInteractive(ctx context.Context, w io.Writer, ag agent.Ag
 
 	fmt.Fprintln(w, "\nReady.")
 
-	if repo, err := strategy.OpenRepository(ctx); err == nil && strategy.IsEmptyRepository(repo) {
-		fmt.Fprintln(w)
-		fmt.Fprintln(w, "Note: Session checkpoints require at least one commit. To get started,")
-		fmt.Fprintln(w, "commit the configuration files (e.g. .entire/, .claude/).")
+	if repo, err := strategy.OpenRepository(ctx); err == nil {
+		defer repo.Close()
+		if strategy.IsEmptyRepository(repo) {
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "Note: Session checkpoints require at least one commit. To get started,")
+			fmt.Fprintln(w, "commit the configuration files (e.g. .entire/, .claude/).")
+		}
 	}
 
 	return nil

--- a/cmd/entire/cli/state.go
+++ b/cmd/entire/cli/state.go
@@ -264,6 +264,7 @@ func DetectFileChanges(ctx context.Context, previouslyUntracked []string) (*File
 	if err != nil {
 		return nil, fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -324,6 +325,7 @@ func filterToUncommittedFiles(ctx context.Context, files []string, repoRoot stri
 	if err != nil {
 		return files // fail open
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -431,6 +433,7 @@ func getUntrackedFilesForState(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -21,7 +22,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 
-	"github.com/go-git/go-git/v6"
 	"github.com/spf13/cobra"
 )
 
@@ -470,10 +470,11 @@ func currentHeadLinkage(ctx context.Context) (string, headLinkage, error) {
 		return "", headLinkage{}, fmt.Errorf("resolve worktree root: %w", err)
 	}
 
-	repo, err := git.PlainOpen(repoRoot)
+	repo, err := gitrepo.OpenPath(repoRoot)
 	if err != nil {
 		return "", headLinkage{}, fmt.Errorf("open repo: %w", err)
 	}
+	defer repo.Close()
 
 	headRef, err := repo.Head()
 	if err != nil {

--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -167,6 +167,7 @@ func fetchMetadataBranchIfMissing(ctx context.Context, remoteURL string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Check if branch already exists locally - if so, nothing to do
 	branchRef := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
@@ -177,7 +178,7 @@ func fetchMetadataBranchIfMissing(ctx context.Context, remoteURL string) error {
 	// Branch doesn't exist locally - try to fetch it from the URL.
 	// Fetch failures are not fatal: push will create it on the remote when it succeeds.
 	if err := FetchMetadataBranch(ctx, remoteURL); err != nil {
-		return nil //nolint:nilerr // Fetch failure is expected when remote is unreachable or branch doesn't exist yet
+		return nil
 	}
 
 	logging.Info(ctx, "checkpoint-remote: fetched metadata branch from URL")

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -80,6 +80,7 @@ func ListShadowBranches(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	refs, err := repo.References()
 	if err != nil {
@@ -150,6 +151,7 @@ func ListOrphanedSessionStates(ctx context.Context) ([]CleanupItem, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Get all session states
 	store, err := session.NewStateStore(ctx)
@@ -248,6 +250,7 @@ func DeleteOrphanedCheckpoints(ctx context.Context, checkpointIDs []string) (del
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Get sessions branch
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -19,6 +19,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -72,6 +73,7 @@ func EnsureSetup(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 	if err := vercelconfig.InitSettings(ctx); err != nil {
 		return fmt.Errorf("failed to initialize vercel settings: %w", err)
 	}
@@ -116,6 +118,7 @@ func PromoteTmpRefSafely(ctx context.Context, tmpRefName, destRefName plumbing.R
 	if err != nil {
 		return fmt.Errorf("failed to open repository for %s promote: %w", label, err)
 	}
+	defer repo.Close()
 	defer func() { _ = repo.Storer.RemoveReference(tmpRefName) }() //nolint:errcheck // cleanup is best-effort
 
 	tmpRef, err := repo.Reference(tmpRefName, true)
@@ -305,6 +308,7 @@ func ListCheckpoints(ctx context.Context) ([]CheckpointInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Warn (once per process) if metadata branches are disconnected
 	WarnIfMetadataDisconnected()
@@ -1018,14 +1022,7 @@ func GetRemoteMetadataBranchTree(repo *git.Repository) (*object.Tree, error) {
 // It uses 'git rev-parse --show-toplevel' to find the repository root,
 // which works correctly even when called from a subdirectory or a linked worktree.
 func OpenRepository(ctx context.Context) (*git.Repository, error) {
-	repoRoot, err := paths.WorktreeRoot(ctx)
-	if err != nil {
-		// Fallback to current directory if git command fails
-		// (e.g., if git is not installed or we're not in a repo)
-		repoRoot = "."
-	}
-
-	repo, err := git.PlainOpen(repoRoot)
+	repo, err := gitrepo.OpenCurrent(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open repository: %w", err)
 	}
@@ -1173,17 +1170,18 @@ func checkCanRewindWithWarning(ctx context.Context) (bool, string, error) {
 	repo, err := OpenRepository(ctx)
 	if err != nil {
 		// Can't open repo - still allow rewind but without stats
-		return true, "", nil //nolint:nilerr // Rewind allowed even if repo can't be opened
+		return true, "", nil
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
-		return true, "", nil //nolint:nilerr // Rewind allowed even if worktree can't be accessed
+		return true, "", nil
 	}
 
 	status, err := worktree.Status()
 	if err != nil {
-		return true, "", nil //nolint:nilerr // Rewind allowed even if status can't be retrieved
+		return true, "", nil
 	}
 
 	if status.IsClean() {
@@ -1193,17 +1191,17 @@ func checkCanRewindWithWarning(ctx context.Context) (bool, string, error) {
 	// Get HEAD commit tree for comparison - if we can't get it, just return without stats
 	head, err := repo.Head()
 	if err != nil {
-		return true, "", nil //nolint:nilerr // Rewind allowed even without HEAD (e.g., empty repo)
+		return true, "", nil
 	}
 
 	headCommit, err := repo.CommitObject(head.Hash())
 	if err != nil {
-		return true, "", nil //nolint:nilerr // Rewind allowed even if commit lookup fails
+		return true, "", nil
 	}
 
 	headTree, err := headCommit.Tree()
 	if err != nil {
-		return true, "", nil //nolint:nilerr // Rewind allowed even if tree lookup fails
+		return true, "", nil
 	}
 
 	type fileChange struct {
@@ -1217,7 +1215,7 @@ func checkCanRewindWithWarning(ctx context.Context) (bool, string, error) {
 	// Use repo root, not cwd - git status returns paths relative to repo root
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
-		return true, "", nil //nolint:nilerr // Rewind allowed even if worktree root lookup fails
+		return true, "", nil
 	}
 
 	for file, st := range status {
@@ -1392,6 +1390,7 @@ func getTaskCheckpointFromTree(ctx context.Context, point RewindPoint) (*TaskChe
 	if err != nil {
 		return nil, fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	commitHash := plumbing.NewHash(point.ID)
 	commit, err := repo.CommitObject(commitHash)
@@ -1435,6 +1434,7 @@ func getTaskTranscriptFromTree(ctx context.Context, point RewindPoint) ([]byte, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	commitHash := plumbing.NewHash(point.ID)
 	commit, err := repo.CommitObject(commitHash)

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/go-git/go-git/v6"
 )
 
 // ManualCommitStrategy implements the manual-commit strategy for session management.
@@ -19,13 +20,6 @@ type ManualCommitStrategy struct {
 	stateStoreOnce sync.Once
 	// stateStoreErr captures any error during initialization
 	stateStoreErr error
-
-	// checkpointStore manages checkpoint data in git
-	checkpointStore *checkpoint.GitStore
-	// checkpointStoreOnce ensures thread-safe lazy initialization
-	checkpointStoreOnce sync.Once
-	// checkpointStoreErr captures any error during initialization
-	checkpointStoreErr error
 
 	// blobFetcher, when set, is passed to the checkpoint store to enable
 	// on-demand blob fetching after treeless fetches. Set via SetBlobFetcher.
@@ -46,31 +40,15 @@ func (s *ManualCommitStrategy) getStateStore(_ context.Context) (*session.StateS
 	return s.stateStore, s.stateStoreErr
 }
 
-// getCheckpointStore returns the checkpoint store, initializing it lazily if needed.
-// Thread-safe via sync.Once.
-func (s *ManualCommitStrategy) getCheckpointStore() (*checkpoint.GitStore, error) {
-	s.checkpointStoreOnce.Do(func() {
-		repo, err := OpenRepository(context.Background())
-		if err != nil {
-			s.checkpointStoreErr = fmt.Errorf("failed to open repository: %w", err)
-			return
-		}
-		WarnIfMetadataDisconnected()
-		store := checkpoint.NewGitStore(repo)
-		if s.blobFetcher != nil {
-			store.SetBlobFetcher(s.blobFetcher)
-		}
-		s.checkpointStore = store
-	})
-	return s.checkpointStore, s.checkpointStoreErr
+func (s *ManualCommitStrategy) getCheckpointStore(repo *git.Repository) *checkpoint.GitStore {
+	store := checkpoint.NewGitStore(repo)
+	if s.blobFetcher != nil {
+		store.SetBlobFetcher(s.blobFetcher)
+	}
+	return store
 }
 
-func (s *ManualCommitStrategy) committedCheckpointStore(ctx context.Context) (checkpoint.CommittedListReader, error) { //nolint:ireturn // Strategy callers need the selected v1 or dual store implementation.
-	repo, err := OpenRepository(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+func (s *ManualCommitStrategy) committedCheckpointStore(ctx context.Context, repo *git.Repository) (checkpoint.CommittedListReader, error) { //nolint:ireturn // Strategy callers need the selected committed checkpoint reader implementation.
 	WarnIfMetadataDisconnected()
 	store, err := checkpoint.NewCommittedReader(ctx, repo, checkpoint.CommittedReaderOptions{
 		BlobFetcher: s.blobFetcher,
@@ -104,6 +82,7 @@ func (s *ManualCommitStrategy) ValidateRepository() error {
 	if err != nil {
 		return fmt.Errorf("not a git repository: %w", err)
 	}
+	defer repo.Close()
 
 	_, err = repo.Worktree()
 	if err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -42,7 +42,13 @@ var (
 
 // listCheckpoints returns all checkpoints from committed checkpoint storage.
 func (s *ManualCommitStrategy) listCheckpoints(ctx context.Context) ([]CheckpointInfo, error) {
-	store, err := s.committedCheckpointStore(ctx)
+	repo, err := OpenRepository(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open git repository: %w", err)
+	}
+	defer repo.Close()
+
+	store, err := s.committedCheckpointStore(ctx, repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get checkpoint store: %w", err)
 	}
@@ -57,7 +63,13 @@ func (s *ManualCommitStrategy) listCheckpoints(ctx context.Context) ([]Checkpoin
 
 // getCheckpointLog returns the transcript for a specific checkpoint ID.
 func (s *ManualCommitStrategy) getCheckpointLog(ctx context.Context, checkpointID id.CheckpointID) ([]byte, error) {
-	store, err := s.committedCheckpointStore(ctx)
+	repo, err := OpenRepository(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open git repository: %w", err)
+	}
+	defer repo.Close()
+
+	store, err := s.committedCheckpointStore(ctx, repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get checkpoint store: %w", err)
 	}
@@ -166,11 +178,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		return skipped, nil
 	}
 
-	// Get checkpoint store
-	store, err := s.getCheckpointStore()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get checkpoint store: %w", err)
-	}
+	store := s.getCheckpointStore(repo)
 
 	// Get author info
 	authorName, authorEmail := GetGitAuthorFromRepo(repo)
@@ -1099,6 +1107,7 @@ func (s *ManualCommitStrategy) CondenseSessionByID(ctx context.Context, sessionI
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	checkpointID, err := id.Generate()
 	if err != nil {
@@ -1197,6 +1206,7 @@ func (s *ManualCommitStrategy) CondenseAndMarkFullyCondensed(ctx context.Context
 		)
 		return nil // fail-open
 	}
+	defer repo.Close()
 
 	checkpointID, err := id.Generate()
 	if err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_git.go
+++ b/cmd/entire/cli/strategy/manual_commit_git.go
@@ -30,6 +30,7 @@ func (s *ManualCommitStrategy) SaveStep(ctx context.Context, step StepContext) e
 		openRepoSpan.End()
 		return fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 	openRepoSpan.End()
 
 	sessionID := filepath.Base(step.MetadataDir)
@@ -51,10 +52,7 @@ func (s *ManualCommitStrategy) SaveStep(ctx context.Context, step StepContext) e
 		}
 		migrateSpan.End()
 
-		store, err := s.getCheckpointStore()
-		if err != nil {
-			return fmt.Errorf("failed to get checkpoint store: %w", err)
-		}
+		store := s.getCheckpointStore(repo)
 
 		shadowBranchName := checkpoint.ShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
 		branchExisted := store.ShadowBranchExists(state.BaseCommit, state.WorktreeID)
@@ -173,6 +171,7 @@ func (s *ManualCommitStrategy) SaveTaskStep(ctx context.Context, step TaskStepCo
 	if err != nil {
 		return fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	if err := s.ensureSessionInitialized(ctx, repo, step.SessionID, step.AgentType); err != nil {
 		return err
@@ -183,10 +182,7 @@ func (s *ManualCommitStrategy) SaveTaskStep(ctx context.Context, step TaskStepCo
 			return fmt.Errorf("failed to check/migrate shadow branch: %w", err)
 		}
 
-		store, err := s.getCheckpointStore()
-		if err != nil {
-			return fmt.Errorf("failed to get checkpoint store: %w", err)
-		}
+		store := s.getCheckpointStore(repo)
 
 		shadowBranchName := checkpoint.ShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
 		branchExisted := store.ShadowBranchExists(state.BaseCommit, state.WorktreeID)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -204,18 +204,19 @@ func (s *ManualCommitStrategy) PostRewrite(ctx context.Context, rewriteType stri
 
 	worktreePath, err := paths.WorktreeRoot(ctx)
 	if err != nil {
-		return nil //nolint:nilerr // Hook must be resilient
+		return nil
 	}
 
 	sessions, err := s.findSessionsForWorktree(ctx, worktreePath)
 	if err != nil || len(sessions) == 0 {
-		return nil //nolint:nilerr // Hook must be resilient
+		return nil
 	}
 
 	repo, err := OpenRepository(ctx)
 	if err != nil {
-		return nil //nolint:nilerr // Hook must be resilient
+		return nil
 	}
+	defer repo.Close()
 
 	for _, sess := range sessions {
 		sessionID := sess.SessionID
@@ -387,6 +388,7 @@ func (s *ManualCommitStrategy) PrepareCommitMsg(ctx context.Context, commitMsgFi
 		openRepoSpan.End()
 		return nil
 	}
+	defer repo.Close()
 	openRepoSpan.End()
 
 	_, findSessionsSpan := perf.Start(ctx, "find_sessions_for_worktree")
@@ -558,7 +560,7 @@ func (s *ManualCommitStrategy) handleAmendCommitMsg(ctx context.Context, commitM
 	// Read current commit message
 	content, err := os.ReadFile(commitMsgFile) //nolint:gosec // commitMsgFile is provided by git hook
 	if err != nil {
-		return nil //nolint:nilerr // Hook must be silent on failure
+		return nil
 	}
 
 	message := string(content)
@@ -575,12 +577,12 @@ func (s *ManualCommitStrategy) handleAmendCommitMsg(ctx context.Context, commitM
 	// No trailer in message — check if any session has LastCheckpointID to restore
 	worktreePath, err := paths.WorktreeRoot(ctx)
 	if err != nil {
-		return nil //nolint:nilerr // Hook must be silent on failure
+		return nil
 	}
 
 	sessions, err := s.findSessionsForWorktree(ctx, worktreePath)
 	if err != nil || len(sessions) == 0 {
-		return nil //nolint:nilerr // No sessions - nothing to restore
+		return nil
 	}
 
 	// For amend, HEAD^ is the commit being amended, and HEAD is where we are now.
@@ -589,11 +591,12 @@ func (s *ManualCommitStrategy) handleAmendCommitMsg(ctx context.Context, commitM
 	// unrelated checkpoint IDs.
 	repo, repoErr := OpenRepository(ctx)
 	if repoErr != nil {
-		return nil //nolint:nilerr // Hook must be silent on failure
+		return nil
 	}
+	defer repo.Close()
 	head, headErr := repo.Head()
 	if headErr != nil {
-		return nil //nolint:nilerr // Hook must be silent on failure
+		return nil
 	}
 	currentHead := head.Hash().String()
 
@@ -612,7 +615,7 @@ func (s *ManualCommitStrategy) handleAmendCommitMsg(ctx context.Context, commitM
 		// Restore the trailer
 		message = addCheckpointTrailer(message, cpID)
 		if writeErr := os.WriteFile(commitMsgFile, []byte(message), 0o600); writeErr != nil { //nolint:gosec // path from git hook arg
-			return nil //nolint:nilerr // Hook must be silent on failure
+			return nil
 		}
 
 		logging.Info(logCtx, "prepare-commit-msg: restored trailer on amend",
@@ -871,7 +874,7 @@ func (h *postCommitActionHandler) HandleWarnStaleSession(_ *session.State) error
 // During rebase/cherry-pick/revert operations, phase transitions are skipped entirely.
 //
 
-func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:unparam // error return is part of the hook contract; callers check it
+func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 
 	_, openRepoSpan := perf.Start(ctx, "open_repository_and_head")
@@ -881,6 +884,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:
 		openRepoSpan.End()
 		return nil
 	}
+	defer repo.Close()
 
 	// Get HEAD commit to check for trailer
 	head, err := repo.Head()
@@ -926,7 +930,7 @@ func (s *ManualCommitStrategy) PostCommit(ctx context.Context) error { //nolint:
 			slog.String("strategy", "manual-commit"),
 			slog.String("checkpoint_id", checkpointID.String()),
 		)
-		return nil //nolint:nilerr // Intentional: hooks must be silent on failure
+		return nil
 	}
 
 	// Build transition context
@@ -2233,6 +2237,7 @@ func (s *ManualCommitStrategy) InitializeSession(ctx context.Context, sessionID 
 	if err != nil {
 		return fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Resolve which agent actually owns this session. The hook firing isn't
 	// authoritative when multiple agents' hooks fire for the same session ID
@@ -2728,6 +2733,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 		state.TurnCheckpointIDs = nil
 		return 1 // Count as error - all checkpoints will be skipped
 	}
+	defer repo.Close()
 
 	prompts := readPromptsFromShadowBranch(ctx, repo, state)
 	if len(prompts) == 0 {

--- a/cmd/entire/cli/strategy/manual_commit_logs.go
+++ b/cmd/entire/cli/strategy/manual_commit_logs.go
@@ -27,6 +27,7 @@ func (s *ManualCommitStrategy) GetSessionInfo(ctx context.Context) (*SessionInfo
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Check if we're on a shadow branch
 	head, err := repo.Head()
@@ -80,6 +81,7 @@ func (s *ManualCommitStrategy) GetSessionMetadataRef(ctx context.Context, _ stri
 	if err != nil {
 		return ""
 	}
+	defer repo.Close()
 
 	// Get the sessions branch
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
@@ -141,6 +143,7 @@ func (s *ManualCommitStrategy) getDescriptionFromShadowBranch(ctx context.Contex
 	if err != nil {
 		return ""
 	}
+	defer repo.Close()
 
 	shadowBranchName := getShadowBranchNameForCommit(baseCommit, worktreeID)
 	refName := plumbing.NewBranchReferenceName(shadowBranchName)

--- a/cmd/entire/cli/strategy/manual_commit_reset.go
+++ b/cmd/entire/cli/strategy/manual_commit_reset.go
@@ -24,6 +24,7 @@ func (s *ManualCommitStrategy) Reset(ctx context.Context, w, errW io.Writer) err
 	if err != nil {
 		return fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Get current HEAD
 	head, err := repo.Head()
@@ -115,6 +116,7 @@ func (s *ManualCommitStrategy) ResetSession(ctx context.Context, w, errW io.Writ
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Clean up shadow branch if no other sessions need it
 	if err := s.cleanupShadowBranchIfUnused(ctx, repo, shadowBranchName, sessionID); err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -34,12 +34,9 @@ func (s *ManualCommitStrategy) GetRewindPoints(ctx context.Context, limit int) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
-	// Get checkpoint store
-	store, err := s.getCheckpointStore()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get checkpoint store: %w", err)
-	}
+	store := s.getCheckpointStore(repo)
 
 	// Get current HEAD to find matching shadow branch
 	head, err := repo.Head()
@@ -141,12 +138,13 @@ func (s *ManualCommitStrategy) GetLogsOnlyRewindPoints(ctx context.Context, limi
 	if err != nil {
 		return nil, err
 	}
+	defer repo.Close()
 
 	// Get all checkpoints from entire/checkpoints/v1 branch
 	checkpoints, err := s.listCheckpoints(ctx)
 	if err != nil {
 		// No checkpoints yet is fine
-		return nil, nil //nolint:nilerr // Expected when no checkpoints exist
+		return nil, nil
 	}
 
 	if len(checkpoints) == 0 {
@@ -282,6 +280,7 @@ func (s *ManualCommitStrategy) Rewind(ctx context.Context, w, errW io.Writer, po
 	if err != nil {
 		return fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Get the checkpoint commit
 	commitHash := plumbing.NewHash(point.ID)
@@ -505,6 +504,7 @@ func (s *ManualCommitStrategy) PreviewRewind(ctx context.Context, point RewindPo
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Get the checkpoint commit
 	commitHash := plumbing.NewHash(point.ID)
@@ -622,7 +622,13 @@ func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.W
 		return nil, errors.New("missing checkpoint ID")
 	}
 
-	store, err := s.committedCheckpointStore(ctx)
+	repo, err := OpenRepository(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open git repository: %w", err)
+	}
+	defer repo.Close()
+
+	store, err := s.committedCheckpointStore(ctx, repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare checkpoint store: %w", err)
 	}

--- a/cmd/entire/cli/strategy/manual_commit_session.go
+++ b/cmd/entire/cli/strategy/manual_commit_session.go
@@ -77,6 +77,7 @@ func (s *ManualCommitStrategy) listAllSessionStates(ctx context.Context) ([]*Ses
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	var states []*SessionState
 	for _, sessionState := range sessionStates {
@@ -247,6 +248,7 @@ func (s *ManualCommitStrategy) CountOtherActiveSessionsWithCheckpoints(ctx conte
 	if err != nil {
 		return 0, err
 	}
+	defer repo.Close()
 	head, err := repo.Head()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get HEAD: %w", err)

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -52,6 +52,7 @@ func TestManualCommitStrategy_ListCheckpointsUsesLocalV2WhenSettingsDisabled(t *
 
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
+	defer repo.Close()
 
 	cpID := id.MustCheckpointID("dd11ee22ff33")
 	writeV2CheckpointFixture(t, repo, v2CheckpointFixtureOptions{
@@ -4206,8 +4207,7 @@ func TestCondenseSession_RedactionFailure_DropsTranscriptButWritesMetadata(t *te
 	require.NoError(t, err, "redaction failure should not abort condensation")
 	require.NotNil(t, result)
 
-	store, err := s.getCheckpointStore()
-	require.NoError(t, err)
+	store := s.getCheckpointStore(repo)
 
 	committed, err := store.ListCommitted(context.Background())
 	require.NoError(t, err)

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -76,6 +76,7 @@ func WarnIfMetadataDisconnected() {
 				slog.String("error", err.Error()))
 			return
 		}
+		defer repo.Close()
 		disconnected, err := IsMetadataDisconnected(ctx, repo, plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName))
 		if err != nil {
 			logging.Debug(ctx, "metadata disconnection check failed",

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -29,15 +29,16 @@ import (
 func pushBranchIfNeeded(ctx context.Context, target, branchName string) error {
 	repo, err := OpenRepository(ctx)
 	if err != nil {
-		return nil //nolint:nilerr // Hook must be silent on failure
+		return nil
 	}
+	defer repo.Close()
 
 	// Check if branch exists locally
 	branchRef := plumbing.NewBranchReferenceName(branchName)
 	localRef, err := repo.Reference(branchRef, true)
 	if err != nil {
 		// No branch, nothing to push
-		return nil //nolint:nilerr // Expected when no sessions exist yet
+		return nil
 	}
 
 	// Only check remote tracking refs when target is a remote name (not a URL).
@@ -74,7 +75,7 @@ func displayPushTarget(target string) string {
 
 // doPushBranch pushes the given branch to the target with fetch+merge recovery.
 // The target can be a remote name or a URL.
-func doPushBranch(ctx context.Context, target, branchName string) error {
+func doPushBranch(ctx context.Context, target, branchName string) error { //nolint:unparam // callers treat push failures as non-fatal but keep an error-shaped boundary.
 	displayTarget := displayPushTarget(target)
 
 	fmt.Fprintf(os.Stderr, "[entire] Pushing %s to %s...", branchName, displayTarget)
@@ -345,6 +346,7 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	if err != nil {
 		return fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Reconcile disconnected metadata branches before rebasing.
 	// The fetch above updated the remote-tracking ref, so reconciliation

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -336,6 +336,86 @@ func TestFetchAndRebase_DivergedBranches(t *testing.T) {
 	assert.Contains(t, entries, "cc/cccccccccc/metadata.json", "remote checkpoint should be preserved")
 }
 
+// TestFetchAndRebase_SharedCloneLocalCommitInAlternate verifies that the
+// metadata branch replay path can read local-only commits that are present via
+// .git/objects/info/alternates. Git CLI can see these objects, but go-git may
+// return object not found without the CLI fallback.
+//
+// Not parallel: uses t.Chdir() (required for OpenRepository).
+func TestFetchAndRebase_SharedCloneLocalCommitInAlternate(t *testing.T) {
+	ctx := context.Background()
+	branchName := paths.MetadataBranchName
+
+	bareDir := t.TempDir()
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	remoteWorkDir := filepath.Join(t.TempDir(), "remote-work")
+	cloneDir := filepath.Join(t.TempDir(), "shared-clone")
+	gitRun := func(dir string, args ...string) string {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = dir
+		cmd.Env = testutil.GitIsolatedEnv()
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v in %s failed: %s", args, dir, out)
+		return string(out)
+	}
+	writeCheckpoint := func(dir, shard, rest, checkpointID string) {
+		t.Helper()
+		cpDir := filepath.Join(dir, shard, rest)
+		require.NoError(t, os.MkdirAll(cpDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(cpDir, "metadata.json"),
+			[]byte(`{"checkpoint_id":"`+checkpointID+`"}`), 0o644))
+	}
+	configUser := func(dir, email string) {
+		t.Helper()
+		gitRun(dir, "config", "user.email", email)
+		gitRun(dir, "config", "user.name", "Test User")
+		gitRun(dir, "config", "commit.gpgsign", "false")
+	}
+
+	gitRun(bareDir, "init", "--bare", "-b", "main")
+	gitRun(filepath.Dir(sourceDir), "clone", bareDir, filepath.Base(sourceDir))
+	configUser(sourceDir, "source@test.com")
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "README.md"), []byte("# Test"), 0o644))
+	gitRun(sourceDir, "add", ".")
+	gitRun(sourceDir, "commit", "-m", "init")
+	gitRun(sourceDir, "push", "origin", "main")
+
+	gitRun(sourceDir, "checkout", "--orphan", branchName)
+	gitRun(sourceDir, "rm", "-rf", ".")
+	writeCheckpoint(sourceDir, "aa", "aaaaaaaaaa", "aaaaaaaaaaaa")
+	gitRun(sourceDir, "add", ".")
+	gitRun(sourceDir, "commit", "-m", "Checkpoint: aaaaaaaaaaaa")
+	gitRun(sourceDir, "push", "origin", branchName)
+
+	writeCheckpoint(sourceDir, "bb", "bbbbbbbbbb", "bbbbbbbbbbbb")
+	gitRun(sourceDir, "add", ".")
+	gitRun(sourceDir, "commit", "-m", "Checkpoint: bbbbbbbbbbbb")
+	localOnlyHash := strings.TrimSpace(gitRun(sourceDir, "rev-parse", "HEAD"))
+	gitRun(sourceDir, "checkout", "main")
+
+	gitRun(filepath.Dir(cloneDir), "clone", "--shared", sourceDir, filepath.Base(cloneDir))
+	gitRun(cloneDir, "branch", branchName, "origin/"+branchName)
+	require.Equal(t, "commit\n", gitRun(cloneDir, "cat-file", "-t", localOnlyHash))
+	gitRun(cloneDir, "remote", "set-url", "origin", bareDir)
+
+	gitRun(filepath.Dir(remoteWorkDir), "clone", bareDir, filepath.Base(remoteWorkDir))
+	configUser(remoteWorkDir, "remote@test.com")
+	gitRun(remoteWorkDir, "checkout", "-b", branchName, "origin/"+branchName)
+	writeCheckpoint(remoteWorkDir, "cc", "cccccccccc", "cccccccccccc")
+	gitRun(remoteWorkDir, "add", ".")
+	gitRun(remoteWorkDir, "commit", "-m", "Checkpoint: cccccccccccc")
+	gitRun(remoteWorkDir, "push", "origin", branchName)
+
+	t.Chdir(cloneDir)
+	err := fetchAndRebaseSessionsCommon(ctx, "origin", branchName)
+	require.NoError(t, err)
+
+	treePaths := gitRun(cloneDir, "ls-tree", "-r", "--name-only", branchName)
+	assert.Contains(t, treePaths, "aa/aaaaaaaaaa/metadata.json", "base checkpoint should be preserved")
+	assert.Contains(t, treePaths, "bb/bbbbbbbbbb/metadata.json", "alternate local checkpoint should be preserved")
+	assert.Contains(t, treePaths, "cc/cccccccccc/metadata.json", "remote checkpoint should be preserved")
+}
+
 // TestFetchAndRebase_LocalBehind verifies that when local is an ancestor of remote,
 // fetchAndRebaseSessionsCommon fast-forwards.
 //

--- a/cmd/entire/cli/strategy/session.go
+++ b/cmd/entire/cli/strategy/session.go
@@ -69,6 +69,7 @@ func ListSessions(ctx context.Context) ([]Session, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Get checkpoints from the entire/checkpoints/v1 branch
 	checkpoints, err := ListCheckpoints(ctx)

--- a/cmd/entire/cli/testutil/testutil.go
+++ b/cmd/entire/cli/testutil/testutil.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/config"
@@ -38,6 +39,7 @@ func InitRepo(t *testing.T, repoDir string) {
 	if err != nil {
 		t.Fatalf("failed to init git repo: %v", err)
 	}
+	defer repo.Close()
 
 	// Configure git user for commits
 	cfg, err := repo.Config()
@@ -116,10 +118,11 @@ func FileExists(repoDir, path string) bool {
 func GitAdd(t *testing.T, repoDir string, paths ...string) {
 	t.Helper()
 
-	repo, err := git.PlainOpen(repoDir)
+	repo, err := gitrepo.OpenPath(repoDir)
 	if err != nil {
 		t.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -137,10 +140,11 @@ func GitAdd(t *testing.T, repoDir string, paths ...string) {
 func GitCommit(t *testing.T, repoDir, message string) {
 	t.Helper()
 
-	repo, err := git.PlainOpen(repoDir)
+	repo, err := gitrepo.OpenPath(repoDir)
 	if err != nil {
 		t.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	worktree, err := repo.Worktree()
 	if err != nil {
@@ -176,10 +180,11 @@ func GitCheckoutNewBranch(t *testing.T, repoDir, branchName string) {
 func GetHeadHash(t *testing.T, repoDir string) string {
 	t.Helper()
 
-	repo, err := git.PlainOpen(repoDir)
+	repo, err := gitrepo.OpenPath(repoDir)
 	if err != nil {
 		t.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -215,10 +220,11 @@ func GitReset(t *testing.T, dir string, ref string) {
 func BranchExists(t *testing.T, repoDir, branchName string) bool {
 	t.Helper()
 
-	repo, err := git.PlainOpen(repoDir)
+	repo, err := gitrepo.OpenPath(repoDir)
 	if err != nil {
 		t.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	refs, err := repo.References()
 	if err != nil {
@@ -241,10 +247,11 @@ func BranchExists(t *testing.T, repoDir, branchName string) bool {
 func GetCommitMessage(t *testing.T, repoDir, hash string) string {
 	t.Helper()
 
-	repo, err := git.PlainOpen(repoDir)
+	repo, err := gitrepo.OpenPath(repoDir)
 	if err != nil {
 		t.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	commitHash := plumbing.NewHash(hash)
 	commit, err := repo.CommitObject(commitHash)
@@ -261,10 +268,11 @@ func GetCommitMessage(t *testing.T, repoDir, hash string) string {
 func GetLatestCheckpointIDFromHistory(t *testing.T, repoDir string) (string, error) {
 	t.Helper()
 
-	repo, err := git.PlainOpen(repoDir)
+	repo, err := gitrepo.OpenPath(repoDir)
 	if err != nil {
 		t.Fatalf("failed to open git repo: %v", err)
 	}
+	defer repo.Close()
 
 	head, err := repo.Head()
 	if err != nil {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -523,6 +523,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
+	defer repo.Close()
 
 	// Determine base branch
 	if base == "" {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/426
<!-- entire-trail-link-end -->

Shared clones can store required objects only through .git/objects/info/alternates. Several checkpoint paths opened repositories with plain go-git storage, so local-only checkpoint commits reachable through alternates could look missing. That made metadata rebase and push paths silently skip checkpoint data and leave remote checkpoint branches incomplete.

Add a gitrepo package that centralizes repository opening, resolves linked worktree .git/commondir layouts, and wires go-git's AlternatesFS so multiple and nested alternates are readable. Route repository openings across the CLI and shared test harnesses through that package so go-git sees the same object graph everywhere.

Also close repository handles after use. Upstream go-git requires callers to close repositories to release filesystem storage resources, so the shared opener documents ownership and call sites now defer Close or register test cleanup.

Depends on #1251.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint metadata fetch/rebase/push and many command paths; wrong alternates or handle lifecycle could still drop local checkpoint data or leak resources, but behavior is covered by new alternates and shared-clone tests.
> 
> **Overview**
> Introduces **`gitrepo`** (`OpenCurrent` / `OpenPath`) so go-git opens repos with **object alternates** support (linked worktrees, `commondir`, OS-rooted `AlternatesFS`), and refuses a silent `PlainOpen` fallback when alternates are configured. **`strategy.OpenRepository`** and most CLI, dispatch, review, and test paths now use this opener instead of ad hoc `PlainOpen` / `PlainOpenWithOptions`.
> 
> Call sites **own and close** repository handles (`defer repo.Close()`, test cleanups, and extra closes when metadata fetch returns a fresher repo or explain swaps lookups). **Manual-commit** drops the cached checkpoint store and builds `GitStore` / committed readers from an already-open repo per operation.
> 
> Adds tests for multi-alternate reads and a **shared-clone** metadata rebase scenario where local-only commits live only via alternates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc52893ceef65d2c4546f45630f10c4378d6d49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->