### PR TITLE
Fall back to `PATH` binary when local-dev build is broken

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,7 @@
           },
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-start"
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/entire-dev hooks claude-code session-start"
           }
         ]
       }
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-end"
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/entire-dev hooks claude-code session-end"
           }
         ]
       }
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code user-prompt-submit"
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/entire-dev hooks claude-code user-prompt-submit"
           }
         ]
       }
@@ -55,7 +55,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code stop"
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/entire-dev hooks claude-code stop"
           }
         ]
       }
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code pre-task"
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/entire-dev hooks claude-code pre-task"
           }
         ]
       }
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code post-task"
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/entire-dev hooks claude-code post-task"
           }
         ]
       },
@@ -86,7 +86,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code post-todo"
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/entire-dev hooks claude-code post-todo"
           }
         ]
       }

--- a/cmd/entire/cli/agent/claudecode/hooks.go
+++ b/cmd/entire/cli/agent/claudecode/hooks.go
@@ -34,10 +34,26 @@ const ClaudeSettingsFileName = "settings.json"
 // metadataDenyRule blocks Claude from reading Entire session metadata
 const metadataDenyRule = "Read(./.entire/metadata/**)"
 
-// entireHookPrefixes are command prefixes that identify Entire hooks (both old and new formats)
+// localDevHookCmdPrefix is the command prefix used for hooks in local-dev mode.
+// It points at scripts/entire-dev, which compiles the CLI on demand and falls
+// back to the entire binary on PATH when the tree does not build (e.g. mid
+// merge-conflict-fix). ${CLAUDE_PROJECT_DIR} is set by Claude Code to the
+// repository root when it runs hooks.
+const localDevHookCmdPrefix = "${CLAUDE_PROJECT_DIR}/scripts/entire-dev "
+
+// entireHookPrefixes are command prefixes that identify Entire hooks. The
+// "go run" prefix is retained so hooks installed by older versions are still
+// recognized for removal/upgrade.
 var entireHookPrefixes = []string{
 	"entire ",
+	localDevHookCmdPrefix,
 	"go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go ",
+}
+
+// localDevHookCommand builds a local-dev hook command for the given hook name,
+// delegating to scripts/entire-dev for the build-probe-and-fallback logic.
+func localDevHookCommand(hookName string) string {
+	return fmt.Sprintf("%shooks claude-code %s", localDevHookCmdPrefix, hookName)
 }
 
 // InstallHooks installs Claude Code hooks in .claude/settings.json.
@@ -114,13 +130,13 @@ func (c *ClaudeCodeAgent) InstallHooks(ctx context.Context, localDev bool, force
 	// Define hook commands
 	var sessionStartCmd, sessionEndCmd, stopCmd, userPromptSubmitCmd, preTaskCmd, postTaskCmd, postTodoCmd string
 	if localDev {
-		sessionStartCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-start"
-		sessionEndCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code session-end"
-		stopCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code stop"
-		userPromptSubmitCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code user-prompt-submit"
-		preTaskCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code pre-task"
-		postTaskCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code post-task"
-		postTodoCmd = "go run ${CLAUDE_PROJECT_DIR}/cmd/entire/main.go hooks claude-code post-todo"
+		sessionStartCmd = localDevHookCommand(HookNameSessionStart)
+		sessionEndCmd = localDevHookCommand(HookNameSessionEnd)
+		stopCmd = localDevHookCommand(HookNameStop)
+		userPromptSubmitCmd = localDevHookCommand(HookNameUserPromptSubmit)
+		preTaskCmd = localDevHookCommand(HookNamePreTask)
+		postTaskCmd = localDevHookCommand(HookNamePostTask)
+		postTodoCmd = localDevHookCommand(HookNamePostTodo)
 	} else {
 		sessionStartCmd = agent.WrapProductionJSONWarningHookCommand("entire hooks claude-code session-start", agent.WarningFormatMultiLine)
 		sessionEndCmd = agent.WrapProductionSilentHookCommand("entire hooks claude-code session-end")

--- a/cmd/entire/cli/agent/claudecode/hooks_test.go
+++ b/cmd/entire/cli/agent/claudecode/hooks_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	agentpkg "github.com/entireio/cli/cmd/entire/cli/agent"
@@ -416,6 +417,52 @@ func TestUninstallHooks_PreservesUserDenyRules(t *testing.T) {
 	// Verify entire deny rule is removed
 	if containsRule(perms.Deny, metadataDenyRuleTest) {
 		t.Errorf("entire deny rule should be removed, got: %v", perms.Deny)
+	}
+}
+
+func TestInstallHooks_LocalDevFallsBackToPath(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	agent := &ClaudeCodeAgent{}
+	if _, err := agent.InstallHooks(context.Background(), true, false); err != nil {
+		t.Fatalf("InstallHooks(localDev=true) error = %v", err)
+	}
+
+	settings := readClaudeSettings(t, tempDir)
+	if len(settings.Hooks.Stop) == 0 || len(settings.Hooks.Stop[0].Hooks) == 0 {
+		t.Fatal("expected a Stop hook to be installed")
+	}
+	cmd := settings.Hooks.Stop[0].Hooks[0].Command
+
+	want := "${CLAUDE_PROJECT_DIR}/scripts/entire-dev hooks claude-code stop"
+	if cmd != want {
+		t.Errorf("local-dev Stop hook should delegate to the script:\ngot:  %s\nwant: %s", cmd, want)
+	}
+	if strings.Contains(cmd, "go build") || strings.Contains(cmd, "sh -c") {
+		t.Errorf("build-probe/fallback logic must live in the script, not the hook command: %s", cmd)
+	}
+	if !isEntireHook(cmd) {
+		t.Errorf("local-dev Stop hook should be recognized as an Entire hook, got:\n%s", cmd)
+	}
+}
+
+func TestUninstallHooks_RemovesLocalDevHooks(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	agent := &ClaudeCodeAgent{}
+	if _, err := agent.InstallHooks(context.Background(), true, false); err != nil {
+		t.Fatalf("InstallHooks(localDev=true) error = %v", err)
+	}
+	if !agent.AreHooksInstalled(context.Background()) {
+		t.Fatal("local-dev hooks should be detected as installed")
+	}
+	if err := agent.UninstallHooks(context.Background()); err != nil {
+		t.Fatalf("UninstallHooks() error = %v", err)
+	}
+	if agent.AreHooksInstalled(context.Background()) {
+		t.Fatal("local-dev hooks should be removed after uninstall")
 	}
 }
 

--- a/cmd/entire/cli/agent/codex/hooks.go
+++ b/cmd/entire/cli/agent/codex/hooks.go
@@ -16,9 +16,11 @@ import (
 // HooksFileName is the hooks config file used by Codex.
 const HooksFileName = "hooks.json"
 
-// entireHookPrefixes identifies Entire hook commands.
+// entireHookPrefixes identifies Entire hook commands. The "go run" prefix is
+// retained so hooks installed by older versions are still recognized.
 var entireHookPrefixes = []string{
 	"entire ",
+	agent.LocalDevHookScript + " ",
 	`go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go `,
 }
 
@@ -78,7 +80,7 @@ func (c *CodexAgent) InstallHooks(ctx context.Context, localDev bool, force bool
 	// Build hook commands
 	var cmdPrefix string
 	if localDev {
-		cmdPrefix = `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks codex `
+		cmdPrefix = agent.LocalDevHookScript + " hooks codex "
 	} else {
 		cmdPrefix = "entire hooks codex "
 	}

--- a/cmd/entire/cli/agent/codex/hooks_test.go
+++ b/cmd/entire/cli/agent/codex/hooks_test.go
@@ -77,8 +77,8 @@ func TestInstallHooks_LocalDev(t *testing.T) {
 	hooksPath := filepath.Join(tempDir, ".codex", HooksFileName)
 	data, err := os.ReadFile(hooksPath)
 	require.NoError(t, err)
-	require.Contains(t, string(data), `go run \"$(git rev-parse --show-toplevel)\"/cmd/entire/main.go hooks codex session-start`)
-	require.Contains(t, string(data), `go run \"$(git rev-parse --show-toplevel)\"/cmd/entire/main.go hooks codex post-tool-use`)
+	require.Contains(t, string(data), `\"$(git rev-parse --show-toplevel)\"/scripts/entire-dev hooks codex session-start`)
+	require.Contains(t, string(data), `\"$(git rev-parse --show-toplevel)\"/scripts/entire-dev hooks codex post-tool-use`)
 }
 
 func TestInstallHooks_Force(t *testing.T) {

--- a/cmd/entire/cli/agent/copilotcli/hooks.go
+++ b/cmd/entire/cli/agent/copilotcli/hooks.go
@@ -20,9 +20,12 @@ const HooksFileName = "entire.json"
 // hooksDir is the directory within the repo where Copilot CLI looks for hook configs.
 const hooksDir = ".github/hooks"
 
-// entireHookPrefixes are command prefixes that identify Entire hooks in the bash field.
+// entireHookPrefixes are command prefixes that identify Entire hooks in the
+// bash field. The "go run" prefix is retained so hooks installed by older
+// versions are still recognized.
 var entireHookPrefixes = []string{
 	"entire ",
+	agent.LocalDevHookScript + " ",
 	`go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go `,
 }
 
@@ -101,7 +104,7 @@ func (c *CopilotCLIAgent) InstallHooks(ctx context.Context, localDev bool, force
 	// Define command prefix
 	var cmdPrefix string
 	if localDev {
-		cmdPrefix = `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks copilot-cli `
+		cmdPrefix = agent.LocalDevHookScript + " hooks copilot-cli "
 	} else {
 		cmdPrefix = "entire hooks copilot-cli "
 	}

--- a/cmd/entire/cli/agent/copilotcli/hooks_test.go
+++ b/cmd/entire/cli/agent/copilotcli/hooks_test.go
@@ -241,7 +241,7 @@ func TestInstallHooks_LocalDev(t *testing.T) {
 	}
 
 	hooksFile := readHooksFile(t, tempDir)
-	assertEntryBash(t, hooksFile.Hooks.AgentStop, `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks copilot-cli agent-stop`)
+	assertEntryBash(t, hooksFile.Hooks.AgentStop, `"$(git rev-parse --show-toplevel)"/scripts/entire-dev hooks copilot-cli agent-stop`)
 }
 
 func TestInstallHooks_PreservesUnknownFields(t *testing.T) {

--- a/cmd/entire/cli/agent/cursor/hooks.go
+++ b/cmd/entire/cli/agent/cursor/hooks.go
@@ -31,9 +31,12 @@ const (
 // HooksFileName is the hooks file used by Cursor.
 const HooksFileName = "hooks.json"
 
-// entireHookPrefixes are command prefixes that identify Entire hooks
+// entireHookPrefixes are command prefixes that identify Entire hooks. The
+// "go run" prefix is retained so hooks installed by older versions are still
+// recognized.
 var entireHookPrefixes = []string{
 	"entire ",
+	agent.LocalDevHookScript + " ",
 	`go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go `,
 }
 
@@ -114,7 +117,7 @@ func (c *CursorAgent) InstallHooks(ctx context.Context, localDev bool, force boo
 	// Define hook commands
 	var cmdPrefix string
 	if localDev {
-		cmdPrefix = `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks cursor `
+		cmdPrefix = agent.LocalDevHookScript + " hooks cursor "
 	} else {
 		cmdPrefix = "entire hooks cursor "
 	}

--- a/cmd/entire/cli/agent/cursor/hooks_test.go
+++ b/cmd/entire/cli/agent/cursor/hooks_test.go
@@ -238,7 +238,7 @@ func TestInstallHooks_LocalDev(t *testing.T) {
 	}
 
 	hooksFile := readHooksFile(t, tempDir)
-	assertEntryCommand(t, hooksFile.Hooks.Stop, `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks cursor stop`)
+	assertEntryCommand(t, hooksFile.Hooks.Stop, `"$(git rev-parse --show-toplevel)"/scripts/entire-dev hooks cursor stop`)
 }
 
 func TestInstallHooks_PreservesUnknownFields(t *testing.T) {

--- a/cmd/entire/cli/agent/factoryaidroid/hooks.go
+++ b/cmd/entire/cli/agent/factoryaidroid/hooks.go
@@ -36,9 +36,12 @@ const FactorySettingsFileName = "settings.json"
 // metadataDenyRule blocks Factory Droid from reading Entire session metadata
 const metadataDenyRule = "Read(./.entire/metadata/**)"
 
-// entireHookPrefixes are command prefixes that identify Entire hooks
+// entireHookPrefixes are command prefixes that identify Entire hooks. The
+// "go run" prefix is retained so hooks installed by older versions are still
+// recognized.
 var entireHookPrefixes = []string{
 	"entire ",
+	agent.LocalDevHookScript + " ",
 	`go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go `,
 }
 
@@ -119,7 +122,7 @@ func (f *FactoryAIDroidAgent) InstallHooks(ctx context.Context, localDev bool, f
 
 	// Define hook commands
 	var sessionStartCmd, sessionEndCmd, stopCmd, userPromptSubmitCmd, preTaskCmd, postTaskCmd, preCompactCmd string
-	localDevPrefix := `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks factoryai-droid `
+	localDevPrefix := agent.LocalDevHookScript + " hooks factoryai-droid "
 	if localDev {
 		sessionStartCmd = localDevPrefix + "session-start"
 		sessionEndCmd = localDevPrefix + "session-end"

--- a/cmd/entire/cli/agent/factoryaidroid/hooks_test.go
+++ b/cmd/entire/cli/agent/factoryaidroid/hooks_test.go
@@ -115,8 +115,9 @@ func TestInstallHooks_LocalDev(t *testing.T) {
 
 	settings := readFactorySettings(t, tempDir)
 
-	// Verify local dev commands use git rev-parse for runtime repo root resolution
-	prefix := `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks factoryai-droid `
+	// Verify local dev commands delegate to the entire-dev launcher, resolving
+	// the repo root at runtime via git.
+	prefix := `"$(git rev-parse --show-toplevel)"/scripts/entire-dev hooks factoryai-droid `
 	assertFactoryHookExists(t, settings.Hooks.SessionStart, "",
 		prefix+"session-start", "SessionStart localDev")
 	assertFactoryHookExists(t, settings.Hooks.SessionStart, "",

--- a/cmd/entire/cli/agent/geminicli/hooks.go
+++ b/cmd/entire/cli/agent/geminicli/hooks.go
@@ -36,9 +36,12 @@ const (
 // GeminiSettingsFileName is the settings file used by Gemini CLI.
 const GeminiSettingsFileName = "settings.json"
 
-// entireHookPrefixes are command prefixes that identify Entire hooks
+// entireHookPrefixes are command prefixes that identify Entire hooks. The
+// "go run" prefix is retained so hooks installed by older versions are still
+// recognized.
 var entireHookPrefixes = []string{
 	"entire ",
+	agent.LocalDevHookScript + " ",
 	`go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go `,
 }
 
@@ -102,7 +105,7 @@ func (g *GeminiCLIAgent) InstallHooks(ctx context.Context, localDev bool, force 
 	// Define hook commands based on localDev mode
 	var cmdPrefix string
 	if localDev {
-		cmdPrefix = `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks gemini `
+		cmdPrefix = agent.LocalDevHookScript + " hooks gemini "
 	} else {
 		cmdPrefix = "entire hooks gemini "
 	}

--- a/cmd/entire/cli/agent/geminicli/hooks_test.go
+++ b/cmd/entire/cli/agent/geminicli/hooks_test.go
@@ -102,8 +102,9 @@ func TestInstallHooks_LocalDev(t *testing.T) {
 
 	settings := readGeminiSettings(t, tempDir)
 
-	// Verify local dev commands use git rev-parse for runtime repo root resolution
-	prefix := `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks gemini `
+	// Verify local dev commands delegate to the entire-dev launcher, resolving
+	// the repo root at runtime via git.
+	prefix := `"$(git rev-parse --show-toplevel)"/scripts/entire-dev hooks gemini `
 	verifyHookCommand(t, settings.Hooks.SessionStart, "", prefix+"session-start")
 	verifyHookCommand(t, settings.Hooks.SessionEnd, "exit", prefix+"session-end")
 	verifyHookCommand(t, settings.Hooks.SessionEnd, "logout", prefix+"session-end")

--- a/cmd/entire/cli/agent/hook_command.go
+++ b/cmd/entire/cli/agent/hook_command.go
@@ -25,6 +25,14 @@ func MissingEntireWarning(format WarningFormat) string {
 	}
 }
 
+// LocalDevHookScript is the local-development hook launcher, with the repo root
+// resolved at hook runtime via git. It points at scripts/entire-dev, which
+// compiles the CLI on demand and falls back to the entire binary on PATH when
+// the tree does not build (e.g. mid merge-conflict-fix). Agents that locate the
+// repo root with `git rev-parse` build their local-dev command prefix from
+// this; claude-code uses ${CLAUDE_PROJECT_DIR} and defines its own prefix.
+const LocalDevHookScript = `"$(git rev-parse --show-toplevel)"/scripts/entire-dev`
+
 // WrapProductionSilentHookCommand exits successfully without output when the
 // Entire CLI is missing from PATH.
 func WrapProductionSilentHookCommand(command string) string {

--- a/cmd/entire/cli/agent/opencode/hooks.go
+++ b/cmd/entire/cli/agent/opencode/hooks.go
@@ -51,7 +51,7 @@ func (a *OpenCodeAgent) InstallHooks(ctx context.Context, localDev bool, force b
 	// Build the command prefix
 	var cmdPrefix string
 	if localDev {
-		cmdPrefix = `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go`
+		cmdPrefix = agent.LocalDevHookScript
 	} else {
 		cmdPrefix = "entire"
 	}

--- a/cmd/entire/cli/agent/opencode/hooks_test.go
+++ b/cmd/entire/cli/agent/opencode/hooks_test.go
@@ -96,8 +96,8 @@ func TestInstallHooks_LocalDev(t *testing.T) {
 	}
 
 	content := string(data)
-	if !strings.Contains(content, `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go`) {
-		t.Error("local dev mode: plugin file should use git rev-parse for go run path")
+	if !strings.Contains(content, `"$(git rev-parse --show-toplevel)"/scripts/entire-dev`) {
+		t.Error("local dev mode: plugin file should delegate to the entire-dev launcher via git rev-parse")
 	}
 }
 
@@ -252,8 +252,8 @@ func TestInstallHooks_RewritesWhenContentDiffers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read plugin file: %v", err)
 	}
-	if !strings.Contains(string(before), "go run") {
-		t.Fatal("expected localDev content with 'go run'")
+	if !strings.Contains(string(before), "scripts/entire-dev") {
+		t.Fatal("expected localDev content to delegate to scripts/entire-dev")
 	}
 
 	// Reinstall with localDev=false (content differs) — should rewrite
@@ -269,8 +269,8 @@ func TestInstallHooks_RewritesWhenContentDiffers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read plugin file after rewrite: %v", err)
 	}
-	if strings.Contains(string(after), "go run") {
-		t.Error("expected production content after rewrite, but still contains 'go run'")
+	if strings.Contains(string(after), "scripts/entire-dev") {
+		t.Error("expected production content after rewrite, but still references scripts/entire-dev")
 	}
 	if !strings.Contains(string(after), `const ENTIRE_CMD = 'entire'`) {
 		t.Error("expected production command constant after rewrite")

--- a/cmd/entire/cli/agent/pi/hooks.go
+++ b/cmd/entire/cli/agent/pi/hooks.go
@@ -52,7 +52,7 @@ func extensionPath(ctx context.Context) (string, error) {
 func renderExtension(localDev bool) string {
 	var cmd string
 	if localDev {
-		cmd = `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go`
+		cmd = agent.LocalDevHookScript
 	} else {
 		cmd = "entire"
 	}

--- a/cmd/entire/cli/agent/pi/hooks_test.go
+++ b/cmd/entire/cli/agent/pi/hooks_test.go
@@ -53,8 +53,8 @@ func TestInstallHooks_LocalDev(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go`) {
-		t.Error("local-dev extension should reference git rev-parse path")
+	if !strings.Contains(string(data), `"$(git rev-parse --show-toplevel)"/scripts/entire-dev`) {
+		t.Error("local-dev extension should delegate to the entire-dev launcher via git rev-parse")
 	}
 }
 

--- a/cmd/entire/cli/integration_test/agent_test.go
+++ b/cmd/entire/cli/integration_test/agent_test.go
@@ -178,7 +178,7 @@ func TestAgentHookInstallation(t *testing.T) {
 		}
 	})
 
-	t.Run("localDev mode uses go run", func(t *testing.T) {
+	t.Run("localDev mode delegates to entire-dev script", func(t *testing.T) {
 		// Not parallel - uses os.Chdir
 		env := NewTestEnv(t)
 		env.InitRepo()
@@ -197,7 +197,8 @@ func TestAgentHookInstallation(t *testing.T) {
 			t.Fatalf("InstallHooks(localDev=true) error = %v", err)
 		}
 
-		// Read settings and verify commands use "go run"
+		// Read settings and verify commands delegate to scripts/entire-dev,
+		// which handles compile-on-demand with a PATH-binary fallback.
 		settingsPath := filepath.Join(env.RepoDir, ".claude", claudecode.ClaudeSettingsFileName)
 		data, err := os.ReadFile(settingsPath)
 		if err != nil {
@@ -205,8 +206,8 @@ func TestAgentHookInstallation(t *testing.T) {
 		}
 
 		content := string(data)
-		if !strings.Contains(content, "go run") {
-			t.Error("localDev hooks should use 'go run', but settings.json doesn't contain it")
+		if !strings.Contains(content, "scripts/entire-dev") {
+			t.Error("localDev hooks should delegate to scripts/entire-dev, but settings.json doesn't contain it")
 		}
 	})
 }
@@ -572,7 +573,7 @@ func TestGeminiCLIHookInstallation(t *testing.T) {
 		}
 	})
 
-	t.Run("localDev mode uses go run", func(t *testing.T) {
+	t.Run("localDev mode delegates to entire-dev script", func(t *testing.T) {
 		// Not parallel - uses os.Chdir
 		env := NewTestEnv(t)
 		env.InitRepo()
@@ -591,7 +592,7 @@ func TestGeminiCLIHookInstallation(t *testing.T) {
 			t.Fatalf("InstallHooks(localDev=true) error = %v", err)
 		}
 
-		// Read settings and verify commands use "go run"
+		// Read settings and verify commands delegate to scripts/entire-dev
 		settingsPath := filepath.Join(env.RepoDir, ".gemini", geminicli.GeminiSettingsFileName)
 		data, err := os.ReadFile(settingsPath)
 		if err != nil {
@@ -599,8 +600,8 @@ func TestGeminiCLIHookInstallation(t *testing.T) {
 		}
 
 		content := string(data)
-		if !strings.Contains(content, "go run") {
-			t.Error("localDev hooks should use 'go run', but settings.json doesn't contain it")
+		if !strings.Contains(content, "scripts/entire-dev") {
+			t.Error("localDev hooks should delegate to scripts/entire-dev, but settings.json doesn't contain it")
 		}
 		if !strings.Contains(content, "$(git rev-parse --show-toplevel)") {
 			t.Error("localDev hooks should use '$(git rev-parse --show-toplevel)', but settings.json doesn't contain it")
@@ -967,7 +968,7 @@ func TestFactoryAIDroidHookInstallation(t *testing.T) {
 		}
 	})
 
-	t.Run("localDev mode uses go run", func(t *testing.T) {
+	t.Run("localDev mode delegates to entire-dev script", func(t *testing.T) {
 		// Not parallel - uses os.Chdir
 		env := NewTestEnv(t)
 		env.InitRepo()
@@ -987,7 +988,7 @@ func TestFactoryAIDroidHookInstallation(t *testing.T) {
 			t.Fatalf("InstallHooks(localDev=true) error = %v", err)
 		}
 
-		// Read settings and verify commands use "go run"
+		// Read settings and verify commands delegate to scripts/entire-dev
 		settingsPath := filepath.Join(env.RepoDir, ".factory", factoryaidroid.FactorySettingsFileName)
 		data, err := os.ReadFile(settingsPath)
 		if err != nil {
@@ -995,8 +996,8 @@ func TestFactoryAIDroidHookInstallation(t *testing.T) {
 		}
 
 		content := string(data)
-		if !strings.Contains(content, "go run") {
-			t.Error("localDev hooks should use 'go run', but settings.json doesn't contain it")
+		if !strings.Contains(content, "scripts/entire-dev") {
+			t.Error("localDev hooks should delegate to scripts/entire-dev, but settings.json doesn't contain it")
 		}
 		if !strings.Contains(content, "$(git rev-parse --show-toplevel)") {
 			t.Error("localDev hooks should use '$(git rev-parse --show-toplevel)', but settings.json doesn't contain it")

--- a/cmd/entire/cli/strategy/hook_managers.go
+++ b/cmd/entire/cli/strategy/hook_managers.go
@@ -63,7 +63,7 @@ func detectHookManagers(repoRoot string) []hookManager {
 }
 
 // hookManagerWarning builds a warning string for detected hook managers.
-// cmdPrefix is the CLI command prefix (e.g., "entire" or "go run ./cmd/entire/main.go").
+// cmdPrefix is the CLI command prefix (e.g., "entire" or "./scripts/entire-dev").
 func hookManagerWarning(managers []hookManager, cmdPrefix string) string {
 	if len(managers) == 0 {
 		return ""

--- a/cmd/entire/cli/strategy/hook_managers_test.go
+++ b/cmd/entire/cli/strategy/hook_managers_test.go
@@ -392,10 +392,10 @@ func TestHookManagerWarning_LocalDev(t *testing.T) {
 		{Name: "Husky", ConfigPath: ".husky/", OverwritesHooks: true},
 	}
 
-	warning := hookManagerWarning(managers, "go run ./cmd/entire/main.go")
+	warning := hookManagerWarning(managers, localDevHookCmdPrefix)
 
 	// Should use the local dev prefix in command lines
-	if !strings.Contains(warning, "go run ./cmd/entire/main.go hooks git") {
+	if !strings.Contains(warning, localDevHookCmdPrefix+" hooks git") {
 		t.Error("warning should use local dev command prefix")
 	}
 }

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -20,6 +20,13 @@ const backupSuffix = ".pre-entire"
 const chainComment = "# Chain: run pre-existing hook"
 const missingEntireGitHookWarning = "[entire] Entire CLI is enabled but not installed or not on PATH. Skipping Entire Git hook; continuing. Installation guide: https://docs.entire.io/cli/installation#installation-methods"
 
+// localDevHookCmdPrefix is the command prefix used for git hooks in local
+// development mode. It points at scripts/entire-dev, which compiles the CLI on
+// demand and falls back to the entire binary on PATH when the tree does not
+// build. The path is relative to the repository root, which is git's working
+// directory when it runs hooks.
+const localDevHookCmdPrefix = "./scripts/entire-dev"
+
 // gitHookNames are the git hooks managed by Entire CLI
 var gitHookNames = []string{"prepare-commit-msg", "commit-msg", "post-commit", "post-rewrite", "pre-push"}
 
@@ -423,13 +430,13 @@ fi
 }
 
 // hookCmdPrefix returns the command prefix for hook scripts and warning messages.
-// Returns "go run ./cmd/entire/main.go" when local_dev is enabled.
+// Returns the scripts/entire-dev launcher when local_dev is enabled.
 // When absolutePath is true, resolves the full binary path via os.Executable()
 // and returns an error if resolution fails. This is needed for GUI git clients
 // (Xcode, Tower, etc.) that don't source shell profiles.
 func hookCmdPrefix(localDev, absolutePath bool) (string, error) {
 	if localDev {
-		return "go run ./cmd/entire/main.go", nil
+		return localDevHookCmdPrefix, nil
 	}
 	if absolutePath {
 		exe, err := os.Executable()

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -5,12 +5,40 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
+
+// readEntireDevScript returns the contents of the committed scripts/entire-dev
+// launcher, located relative to this test file's position in the source tree.
+func readEntireDevScript(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// cmd/entire/cli/strategy/hooks_test.go -> repo root is four levels up.
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+	data, err := os.ReadFile(filepath.Join(repoRoot, "scripts", "entire-dev"))
+	if err != nil {
+		t.Fatalf("failed to read scripts/entire-dev: %v", err)
+	}
+	return string(data)
+}
+
+// goBinDir returns the directory containing the go binary.
+func goBinDir(t *testing.T) string {
+	t.Helper()
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go not available")
+	}
+	return filepath.Dir(goPath)
+}
 
 // clearGlobalHooksPath overrides any global core.hooksPath setting so that
 // test repos use their default .git/hooks directory. Setting the local value
@@ -608,8 +636,8 @@ func TestInstallGitHook_LocalDevCommandPrefix(t *testing.T) {
 			t.Fatalf("hook %s should exist: %v", hook, err)
 		}
 		content := string(data)
-		if !strings.Contains(content, "go run ./cmd/entire/main.go") {
-			t.Errorf("hook %s should use 'go run' prefix when localDev=true, got:\n%s", hook, content)
+		if !strings.Contains(content, localDevHookCmdPrefix+" hooks git") {
+			t.Errorf("hook %s should delegate to %s when localDev=true, got:\n%s", hook, localDevHookCmdPrefix, content)
 		}
 		if strings.Contains(content, "\nentire ") {
 			t.Errorf("hook %s should not use bare 'entire' prefix when localDev=true", hook)
@@ -631,12 +659,93 @@ func TestInstallGitHook_LocalDevCommandPrefix(t *testing.T) {
 			t.Fatalf("hook %s should exist: %v", hook, err)
 		}
 		content := string(data)
-		if strings.Contains(content, "go run") {
-			t.Errorf("hook %s should not use 'go run' prefix when localDev=false, got:\n%s", hook, content)
+		if strings.Contains(content, "scripts/entire-dev") {
+			t.Errorf("hook %s should not reference the local-dev script when localDev=false, got:\n%s", hook, content)
 		}
 		if !strings.Contains(content, "entire hooks git") {
 			t.Errorf("hook %s should use bare 'entire' prefix when localDev=false", hook)
 		}
+	}
+}
+
+func TestGitHookCommand_LocalDevDelegatesToScript(t *testing.T) {
+	t.Parallel()
+
+	command := gitHookCommand(localDevHookCmdPrefix, `prepare-commit-msg "$1" "$2" 2>/dev/null || true`, false)
+
+	want := localDevHookCmdPrefix + ` hooks git prepare-commit-msg "$1" "$2" 2>/dev/null || true`
+	if command != want {
+		t.Fatalf("local-dev git hook should delegate to the script verbatim:\ngot:  %s\nwant: %s", command, want)
+	}
+	if strings.Contains(command, "go build") || strings.Contains(command, "elif") {
+		t.Fatalf("build-probe/fallback logic must live in the script, not the hook command: %s", command)
+	}
+}
+
+func TestEntireDevScript_FallsBackToBinaryWhenBuildFails(t *testing.T) {
+	t.Parallel()
+
+	shPath := requireShell(t)
+
+	// A repo layout where cmd/entire/main.go is absent, so the script's build
+	// probe fails and it must fall back to the entire binary on PATH.
+	root := t.TempDir()
+	scriptPath := filepath.Join(root, "scripts", "entire-dev")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatalf("failed to create scripts dir: %v", err)
+	}
+	if err := os.WriteFile(scriptPath, []byte(readEntireDevScript(t)), 0o755); err != nil {
+		t.Fatalf("failed to write script: %v", err)
+	}
+
+	binDir := t.TempDir()
+	markerFile := filepath.Join(root, "entire-ran")
+	fakeEntire := "#!/bin/sh\nprintf '%s\\n' \"$*\" > " + shellQuote(markerFile) + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "entire"), []byte(fakeEntire), 0o755); err != nil {
+		t.Fatalf("failed to write fake entire: %v", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), shPath, scriptPath, "hooks", "git", "post-commit")
+	cmd.Env = envWithPath(binDir + string(os.PathListSeparator) + goBinDir(t))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script should exit 0 when the build is broken: %v\n%s", err, output)
+	}
+
+	got, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("expected fallback to the entire binary on PATH, marker missing: %v\noutput:\n%s", err, output)
+	}
+	if strings.TrimSpace(string(got)) != "hooks git post-commit" {
+		t.Fatalf("fallback should forward args verbatim, got %q", got)
+	}
+	if !strings.Contains(string(output), "falling back to the entire binary on PATH") {
+		t.Fatalf("script should log the fallback to stderr, got:\n%s", output)
+	}
+}
+
+func TestEntireDevScript_ExitsZeroWhenNothingAvailable(t *testing.T) {
+	t.Parallel()
+
+	shPath := requireShell(t)
+
+	root := t.TempDir() // no cmd/entire/main.go, no entire on PATH
+	scriptPath := filepath.Join(root, "scripts", "entire-dev")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatalf("failed to create scripts dir: %v", err)
+	}
+	if err := os.WriteFile(scriptPath, []byte(readEntireDevScript(t)), 0o755); err != nil {
+		t.Fatalf("failed to write script: %v", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), shPath, scriptPath, "hooks", "git", "post-commit")
+	cmd.Env = envWithPath(t.TempDir()) // empty PATH: no go, no entire
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script should exit 0 when neither a buildable tree nor entire is available: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "no entire binary on PATH") {
+		t.Fatalf("script should log that it is skipping, got:\n%s", output)
 	}
 }
 

--- a/docs/architecture/agent-guide.md
+++ b/docs/architecture/agent-guide.md
@@ -384,14 +384,17 @@ func (a *YourAgent) InstallHooks(localDev bool, force bool) (int, error) {
     // ... read and parse ...
 
     // 3. Build hook commands
-    // localDev mode uses $(git rev-parse --show-toplevel) to resolve the repo
-    // root at runtime via shell command substitution. This works regardless of
-    // where the repo is checked out on disk.
-    // Note: Only Claude Code provides a PROJECT_DIR env var (CLAUDE_PROJECT_DIR).
-    // Other agents should use the git rev-parse approach instead.
+    // localDev mode delegates to scripts/entire-dev (agent.LocalDevHookScript),
+    // which compiles the CLI on demand and falls back to the entire binary on
+    // PATH when the tree does not build. It uses $(git rev-parse --show-toplevel)
+    // to resolve the repo root at runtime, so it works regardless of where the
+    // repo is checked out on disk.
+    // Note: Only Claude Code provides a PROJECT_DIR env var (CLAUDE_PROJECT_DIR);
+    // its prefix uses ${CLAUDE_PROJECT_DIR}/scripts/entire-dev instead. Other
+    // agents should use agent.LocalDevHookScript as shown here.
     var cmdPrefix string
     if localDev {
-        cmdPrefix = `go run "$(git rev-parse --show-toplevel)"/cmd/entire/main.go hooks your-agent `
+        cmdPrefix = agent.LocalDevHookScript + " hooks your-agent "
     } else {
         cmdPrefix = "entire hooks your-agent "
     }

--- a/scripts/entire-dev
+++ b/scripts/entire-dev
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Entire CLI local-development hook launcher.
+#
+# In local-dev mode, Entire hooks invoke the CLI straight from source via
+# "go run", which recompiles on demand. When the tree does not compile (for
+# example while an agent is resolving a merge conflict) "go run" fails and the
+# hook would silently do nothing. This launcher first checks that the tree
+# builds; if it does it runs the freshly compiled CLI, otherwise it falls back
+# to an "entire" binary on PATH. If neither is available it exits 0 so it never
+# blocks the surrounding git or agent operation.
+#
+# Usage: scripts/entire-dev <entire args...>
+#
+# All local-dev hooks delegate here so the build-probe-and-fallback logic lives
+# in one place rather than being duplicated across generated hook commands.
+
+set -eu
+
+# Informational messages go to stderr so they never pollute hook stdout (some
+# hooks emit JSON there).
+log() {
+	printf '[entire-dev] %s\n' "$1" >&2
+}
+
+# Resolve the repository root from this script's own location so it works
+# regardless of the caller's working directory. Parameter expansion avoids
+# depending on external tools like dirname, which may not be on PATH when this
+# runs from a minimal hook environment.
+case "$0" in
+	*/*) script_dir=${0%/*} ;;
+	*) script_dir=. ;;
+esac
+root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+main="$root/cmd/entire/main.go"
+
+# Run freshly compiled code when the tree builds. The build probe populates the
+# build cache, so the subsequent "go run" does not recompile from scratch.
+if command -v go >/dev/null 2>&1 && go build -o /dev/null "$main" >/dev/null 2>&1; then
+	exec go run "$main" "$@"
+fi
+
+# The tree does not build (or Go is unavailable): fall back to the installed
+# binary so hooks keep working while the source is broken.
+if command -v entire >/dev/null 2>&1; then
+	log "project isn't compiling; falling back to the entire binary on PATH"
+	exec entire "$@"
+fi
+
+# Nothing to run: do not block the surrounding operation.
+log "project isn't compiling and no entire binary on PATH; skipping hook"
+exit 0


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/433
<!-- entire-trail-link-end -->

In local-dev mode every Entire hook runs the CLI straight from source via `go run .../cmd/entire/main.go`, recompiling on demand. That coupling makes hooks only as reliable as the current tree: the moment the project stops compiling — most commonly while an agent is resolving a merge conflict — the `go run` build fails and the hook silently does nothing. The session is not checkpointed, the commit trailer is not added, and there is no signal that anything went wrong. The one situation where checkpointing matters most is the one where it quietly stops working.

The fallback cannot live in main.go: when the tree is broken, main.go never compiles, so it never runs. The decision "run fresh code vs. run the installed binary" has to be made by something outside that build.

Introduce `scripts/entire-dev`, a single committed launcher that all local-dev hooks delegate to. It probes the build with `go build`; on success it execs `go run` (fresh code, warmed by the probe's build cache), and on failure it falls back to an `entire` binary on PATH, logging the reason to stderr. When neither is available it exits 0 so it never blocks the surrounding git or agent operation. Centralising the logic in one script keeps shell branching out of the generated hook commands (it was previously a sprawl of `sh -c 'if ... elif ... fi'` strings), gives one place to test, and logs clearly which path it took.

Wiring, every `local-dev` hook path now routes through the launcher:
- git hooks (strategy): local-dev prefix points at ./scripts/entire-dev
- all eight agents: claude-code via ${CLAUDE_PROJECT_DIR}/scripts/entire-dev, the git-rev-parse agents (codex, cursor, gemini-cli, copilot-cli, factoryai-droid, opencode, pi) via the shared agent.LocalDevHookScript const
- this repo's own `.claude/settings.json` dev hooks, so the fix applies here

Each agent keeps the old `go run .../cmd/entire/main.go` prefix in its detection list so hooks installed by older versions are still recognised for clean upgrade and uninstall.

Tests run the real script against a non-building tree (build probe fails) and assert it falls back to a fake `entire` on PATH, logs the fallback, forwards args verbatim, and exits 0 when nothing is available; agent and integration suites assert hooks delegate to scripts/entire-dev rather than embedding go run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every local-dev git and agent hook invokes the CLI; mitigated by PATH fallback, exit-0 when unavailable, and broad test coverage, but still touches critical checkpoint/commit hook paths.
> 
> **Overview**
> Local-dev Entire hooks no longer invoke **`go run …/cmd/entire/main.go`** directly. They now call a committed **`scripts/entire-dev`** launcher that probes whether the tree builds, runs fresh code via **`go run`** when it does, and otherwise falls back to an **`entire`** binary on **`PATH`** (logging to stderr). If neither works, it **exits 0** so git/agent workflows are not blocked—addressing silent hook failures when the repo does not compile (e.g. during merge conflicts).
> 
> **Wiring:** git hooks use **`./scripts/entire-dev`**; Claude Code uses **`${CLAUDE_PROJECT_DIR}/scripts/entire-dev`**; other agents share **`agent.LocalDevHookScript`** (`git rev-parse` + **`scripts/entire-dev`**). This repo’s **`.claude/settings.json`** is updated accordingly. Older **`go run`** hook prefixes remain in detection lists for clean upgrade/uninstall.
> 
> Tests and **`docs/architecture/agent-guide.md`** assert delegation to the script (no embedded build/fallback shell in generated hook commands) and exercise the launcher’s fallback and no-op paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef509dbac29950e46bf422c553b87b9e4f7154c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->