### PR TITLE
Fix gemini-cli and opencode E2E harness defects

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,6 +104,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.4-mini' || '' }}
+          E2E_GEMINI_MODEL: ${{ matrix.agent == 'gemini-cli' && 'gemini-2.5-pro' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,7 +104,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.4-mini' || '' }}
-          E2E_GEMINI_MODEL: ${{ matrix.agent == 'gemini-cli' && 'gemini-2.5-pro' || '' }}
+          E2E_GEMINI_MODEL: ${{ matrix.agent == 'gemini-cli' && 'gemini-3.1-flash-lite' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ github.token }}

--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -23,6 +23,27 @@ const geminiDefaultModel = "gemini-2.5-flash"
 const geminiTrustWorkspaceEnvKey = "GEMINI_CLI_TRUST_WORKSPACE"
 const geminiTrustWorkspaceEnv = geminiTrustWorkspaceEnvKey + "=true"
 
+// geminiAbortSignatures are stderr markers for a server-side turn abort
+// (empty/malformed model response). gemini-cli prints these to stderr but
+// still exits 0 with empty stdout, so RunPrompt must surface them as an error
+// for the transient-retry path (RepoState.RunPrompt -> IsTransientError) to
+// fire. Without this, the turn never completes, the after-agent lifecycle hook
+// never runs, no checkpoint is created, and tests fail with a misleading
+// "checkpoint ref did not advance" instead of retrying.
+var geminiAbortSignatures = []string{
+	"Invalid stream",
+	"empty response or malformed tool call",
+}
+
+func geminiAbortedTurn(stderr string) bool {
+	for _, sig := range geminiAbortSignatures {
+		if strings.Contains(stderr, sig) {
+			return true
+		}
+	}
+	return false
+}
+
 type Gemini struct{}
 
 func (g *Gemini) Name() string               { return "gemini-cli" }
@@ -33,6 +54,9 @@ func (g *Gemini) TimeoutMultiplier() float64 { return 2.5 }
 
 func (g *Gemini) IsTransientError(out Output, err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if geminiAbortedTurn(out.Stderr) {
 		return true
 	}
 	transientPatterns := []string{
@@ -99,6 +123,15 @@ func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts 
 		if promptCtx.Err() == context.DeadlineExceeded {
 			err = fmt.Errorf("%w: %w", err, context.DeadlineExceeded)
 		}
+	}
+
+	// gemini-cli can abort a turn server-side (empty/malformed model response)
+	// yet still exit 0 with empty stdout. Surface it as an error so the
+	// transient-retry path restarts the scenario instead of proceeding to fail
+	// on a missing checkpoint. The real abort marker stays in stderr, which
+	// IsTransientError matches via geminiAbortSignatures.
+	if err == nil && geminiAbortedTurn(stderr.String()) {
+		err = errors.New("gemini aborted turn: empty or malformed model response")
 	}
 
 	return Output{

--- a/e2e/agents/gemini.go
+++ b/e2e/agents/gemini.go
@@ -44,6 +44,17 @@ func geminiAbortedTurn(stderr string) bool {
 	return false
 }
 
+// geminiModel returns the model to use for e2e runs. E2E_GEMINI_MODEL overrides
+// the default so CI can pin a more reliable model than the cheap local default
+// (gemini-2.5-flash, which frequently aborts turns with "Invalid stream") without
+// a code change. Mirrors E2E_CODEX_MODEL / E2E_OPENCODE_MODEL.
+func geminiModel() string {
+	if m := os.Getenv("E2E_GEMINI_MODEL"); m != "" {
+		return m
+	}
+	return geminiDefaultModel
+}
+
 type Gemini struct{}
 
 func (g *Gemini) Name() string               { return "gemini-cli" }
@@ -82,7 +93,7 @@ func (g *Gemini) Bootstrap() error {
 }
 
 func (g *Gemini) RunPrompt(ctx context.Context, dir string, prompt string, opts ...Option) (Output, error) {
-	cfg := &runConfig{Model: geminiDefaultModel}
+	cfg := &runConfig{Model: geminiModel()}
 	for _, o := range opts {
 		o(cfg)
 	}
@@ -155,7 +166,7 @@ func (g *Gemini) StartSession(_ context.Context, dir string) (Session, error) {
 	// Unset CI and GITHUB_ACTIONS so gemini doesn't force headless mode —
 	// it checks both in isHeadlessMode() and skips interactive TUI entirely.
 	args := append([]string{"env"}, envArgs...)
-	args = append(args, g.Binary(), "--model", geminiDefaultModel, "-y")
+	args = append(args, g.Binary(), "--model", geminiModel(), "-y")
 	s, err := NewTmuxSession(name, dir, []string{"CI", "GITHUB_ACTIONS", "ENTIRE_TEST_TTY", "HOME"}, args[0], args[1:]...)
 	if err != nil {
 		return nil, err

--- a/e2e/agents/gemini_test.go
+++ b/e2e/agents/gemini_test.go
@@ -33,3 +33,38 @@ func envValue(env []string, key string) (string, bool) {
 	}
 	return "", false
 }
+
+func TestGeminiIsTransientError_RecognizesAbortedTurn(t *testing.T) {
+	t.Parallel()
+	g := &Gemini{}
+	cases := []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		{"invalid stream", "[ERROR] Invalid stream: The model returned an empty response or malformed tool call.", true},
+		{"malformed tool call phrase", "something empty response or malformed tool call happened", true},
+		{"existing transient pattern still matched", "Error: RESOURCE_EXHAUSTED", true},
+		{"unrelated error", "fatal: not a git repository", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := g.IsTransientError(Output{Stderr: tc.stderr}, nil)
+			if got != tc.want {
+				t.Fatalf("IsTransientError(stderr=%q) = %v, want %v", tc.stderr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGeminiAbortedTurn(t *testing.T) {
+	t.Parallel()
+	if !geminiAbortedTurn("[ERROR] Invalid stream: ...") {
+		t.Fatal("expected Invalid stream to be detected as aborted turn")
+	}
+	if geminiAbortedTurn("clean run, no errors") {
+		t.Fatal("did not expect a clean run to be detected as aborted turn")
+	}
+}

--- a/e2e/agents/gemini_test.go
+++ b/e2e/agents/gemini_test.go
@@ -68,3 +68,18 @@ func TestGeminiAbortedTurn(t *testing.T) {
 		t.Fatal("did not expect a clean run to be detected as aborted turn")
 	}
 }
+
+func TestGeminiModel(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		t.Setenv("E2E_GEMINI_MODEL", "")
+		if got := geminiModel(); got != geminiDefaultModel {
+			t.Fatalf("geminiModel() = %q, want default %q", got, geminiDefaultModel)
+		}
+	})
+	t.Run("honors override", func(t *testing.T) {
+		t.Setenv("E2E_GEMINI_MODEL", "gemini-2.5-pro")
+		if got := geminiModel(); got != "gemini-2.5-pro" {
+			t.Fatalf("geminiModel() = %q, want override gemini-2.5-pro", got)
+		}
+	})
+}

--- a/e2e/agents/opencode.go
+++ b/e2e/agents/opencode.go
@@ -110,7 +110,7 @@ func (a *openCodeAgent) RunPrompt(ctx context.Context, dir string, prompt string
 
 	cmd := exec.CommandContext(ctx, a.Binary(), args...)
 	cmd.Dir = dir
-	cmd.Env = filterEnv(os.Environ(), "ENTIRE_TEST_TTY")
+	cmd.Env = openCodePromptEnv(os.Environ(), dir)
 
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
@@ -134,6 +134,17 @@ func (a *openCodeAgent) RunPrompt(ctx context.Context, dir string, prompt string
 	}
 
 	return out, nil
+}
+
+// openCodePromptEnv builds the child environment for a headless `opencode run`.
+// cmd.Dir chdirs the child but does NOT update the inherited PWD env var, which
+// still points at the `go test` package dir. opencode (Node) resolves its
+// project/worktree root from process.env.PWD, so without forcing PWD to match
+// cmd.Dir all file operations land in the wrong repo and the per-repo entire
+// plugin never loads. The tmux/interactive path is unaffected because
+// `tmux new-session -c dir` already sets PWD correctly.
+func openCodePromptEnv(base []string, dir string) []string {
+	return append(filterEnv(base, "ENTIRE_TEST_TTY", "PWD"), "PWD="+dir)
 }
 
 func (a *openCodeAgent) StartSession(ctx context.Context, dir string) (Session, error) {

--- a/e2e/agents/opencode_test.go
+++ b/e2e/agents/opencode_test.go
@@ -1,0 +1,52 @@
+package agents
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOpenCodePromptEnv_OverridesPWD verifies the env handed to the opencode
+// child process points PWD at the run directory and contains exactly one PWD
+// entry. opencode (Node) resolves its project/worktree root from
+// process.env.PWD, and Go's cmd.Dir chdirs without updating PWD — so without
+// this override, file operations land in the go-test package dir instead of the
+// test repo.
+func TestOpenCodePromptEnv_OverridesPWD(t *testing.T) {
+	t.Parallel()
+	base := []string{
+		"PWD=/some/stale/go-test/dir",
+		"ENTIRE_TEST_TTY=1",
+		"HOME=/home/runner",
+	}
+
+	env := openCodePromptEnv(base, "/tmp/e2e-repo-123")
+
+	got, ok := envValue(env, "PWD")
+	if !ok {
+		t.Fatal("PWD not present in child env")
+	}
+	if got != "/tmp/e2e-repo-123" {
+		t.Fatalf("PWD = %q, want %q", got, "/tmp/e2e-repo-123")
+	}
+
+	// The stale PWD must not survive: filterEnv strips it before we re-add.
+	count := 0
+	for _, e := range env {
+		if strings.HasPrefix(e, "PWD=") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one PWD entry, got %d", count)
+	}
+
+	// ENTIRE_TEST_TTY is still stripped so the agent exercises real TTY detection.
+	if got, ok := envValue(env, "ENTIRE_TEST_TTY"); ok {
+		t.Fatalf("ENTIRE_TEST_TTY = %q, want stripped", got)
+	}
+
+	// Unrelated env is preserved.
+	if got, _ := envValue(env, "HOME"); got != "/home/runner" {
+		t.Fatalf("HOME = %q, want preserved", got)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/431
<!-- entire-trail-link-end -->

## Summary

Triage of the persistent E2E failures on `main` (run [26496760848](https://github.com/entireio/cli/actions/runs/26496760848)) found that ~75 of the failures came from two agents — **opencode (43)** and **gemini-cli (32)** — and **neither is caused by CLI product code**. Both are defects in the `e2e/` agent runners. This PR fixes both. No `cmd/entire/cli/` changes.

### opencode (43 failures) — wrong working directory
`RunPrompt` set `cmd.Dir` but not `PWD`. Go's `cmd.Dir` chdirs the child without updating the inherited `PWD` env var, and opencode (Node) resolves its project/worktree root from `process.env.PWD`. So opencode's file writes landed in the `go test` package dir instead of the `/tmp/e2e-repo-*` test repo, the per-repo `.opencode/plugins/entire.ts` never loaded, and no checkpoint was created — surfacing as `checkpoint ref entire/checkpoints/v1 did not advance within 30s` and `git add <path>: exit status 128` (file never existed in the repo).

Fix: extract `openCodePromptEnv()`, which strips any stale `PWD` and forces it to match `cmd.Dir`. The tmux/interactive path was already correct (`tmux new-session -c dir` sets `PWD`), which is why the 5 interactive tests passed.

### gemini-cli (32 failures) — aborted turn exits 0
gemini-cli intermittently aborts a turn server-side with `Invalid stream: The model returned an empty response or malformed tool call` on stderr while **exiting 0** with empty stdout. The turn never completes → the `after-agent` lifecycle hook never fires → no checkpoint. Because the process exits 0, the harness's transient-retry path (`err != nil && IsTransientError`) was never reached, so a retryable glitch was scored as a hard "checkpoint did not advance" failure.

Fix: `RunPrompt` now synthesizes an error when it detects the abort signature in stderr, and `IsTransientError` recognizes it (`geminiAbortSignatures`), so the scenario restarts (up to 3 attempts) instead of failing on a missing checkpoint.

## Tests
- `e2e/agents/opencode_test.go` (new): `TestOpenCodePromptEnv_OverridesPWD`
- `e2e/agents/gemini_test.go`: `TestGeminiIsTransientError_RecognizesAbortedTurn`, `TestGeminiAbortedTurn`

These run in the **standard** `mise run test` suite — `e2e/agents` is not behind the `e2e` build tag — so they gate merges without needing a paid E2E run.

## Verification
- `mise run lint` — clean
- `go test ./e2e/agents/` — pass
- `gofmt` / `dup:staged` — clean
- Real E2E validation to be run remotely on this branch.

## Notes / caveats
- gemini's failures were 100% correlated with `Invalid stream`, which is high for pure flakiness. The retry will salvage genuinely transient cases; if gemini-2.5-flash is *systematically* choking, retries will exhaust and it'll still fail (correctly) — at which point it's a model/version question, not a harness one.
- Out of scope (separate clusters from the same triage): cursor-cli (account out of usage quota) and factory/copilot interactive PTY (`FACTORY_API_KEY` device-auth + Copilot trust-dialog sentinel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only changes in e2e/agents with unit tests; no production CLI or auth paths touched.
> 
> **Overview**
> Fixes two **E2E agent runner** bugs in `e2e/agents` (no CLI product changes).
> 
> **opencode:** Headless `RunPrompt` now sets child env via `openCodePromptEnv()` so **`PWD` matches `cmd.Dir`**. Without that, opencode (Node) used a stale `PWD` from `go test`, wrote files outside the temp repo, and checkpoints never advanced.
> 
> **gemini-cli:** When stderr shows a server-side abort (`Invalid stream` / empty or malformed tool call) but the process **exits 0**, `RunPrompt` now returns an error and **`IsTransientError`** treats it as retryable so scenarios restart instead of failing on missing checkpoints.
> 
> Unit tests cover env override and abort/transient detection; they run in the normal `go test ./e2e/agents/` suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee928618d6756907c84361491582a132f98aaa2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->