### PR TITLE
Read global git config behind symlinked dirs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -120,6 +120,7 @@ linters:
         - github.com/go-git/go-git/v6/storage.Storer
         - github.com/go-git/go-git/v6/plumbing/storer.EncodedObjectIter
         - github.com/entireio/cli/e2e/agents.Session
+        - github.com/go-git/go-billy/v6.File
         - github.com/go-git/go-billy/v6.Filesystem
         - golang.org/x/crypto/ssh/agent.Agent
     nolintlint:
@@ -160,6 +161,12 @@ linters:
       - path: ^cmd/entire/cli/review/tui_model\.go$
         linters:
           - ireturn
+      # configloader.go is a thin os-backed billy.Basic adapter. It must return
+      # raw os errors unwrapped so go-git's os.IsNotExist() fall-through (for
+      # absent config files) keeps working; wrapping would break it.
+      - path: ^cmd/entire/cli/checkpoint/configloader\.go$
+        linters:
+          - wrapcheck
       - text: "`strat` is a misspelling"
         linters:
           - misspell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,6 +469,7 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 - `store.go` - `GitStore` struct wrapping git repository
 - `temporary.go` - Shadow branch operations (`WriteTemporary`, `ReadTemporary`, `ListTemporary`)
 - `committed.go` - Metadata branch operations (`WriteCommitted`, `ReadCommitted`, `ListCommitted`)
+- `configloader.go` - Overrides go-git's default global/system config loader with a symlink-following `billy.Basic` (`osSymlinkFS`). go-git's default reads config via `os.Root`, which rejects absolute symlinks in any path component (e.g. a `~/.config` managed by a dotfile tool) with "path escapes from parent" — silently dropping global config so commit author identity fell back to "Unknown", signing was skipped, and the push hook spammed a warning per commit.
 
 #### Session Package (`cmd/entire/cli/session/`)
 

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -1900,8 +1900,9 @@ func createRedactedBlobFromFile(repo *git.Repository, filePath, treePath string)
 // checking both the repository-local config and the global ~/.gitconfig.
 func GetGitAuthorFromRepo(repo *git.Repository) (name, email string) {
 	// ConfigScoped merges local + global (local wins), matching git's own resolution.
-	// Requires a ConfigLoader plugin to be registered; cmd/entire/main.go blank-imports
-	// go-git/v6/x/plugin to register the default Auto loader.
+	// Uses the ConfigLoader plugin registered in configloader.go (a symlink-following
+	// Auto loader; importing go-git/v6/x/plugin registers go-git's default, which we
+	// override there so global config behind a symlinked ~/.config is still read).
 	if cfg, err := repo.ConfigScoped(config.GlobalScope); err == nil {
 		name = cfg.User.Name
 		email = cfg.User.Email

--- a/cmd/entire/cli/checkpoint/configloader.go
+++ b/cmd/entire/cli/checkpoint/configloader.go
@@ -1,0 +1,83 @@
+package checkpoint
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-git/v6/x/plugin"
+	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
+)
+
+// osSymlinkFS is a minimal billy.Basic backed directly by the os package so
+// that global/system git-config reads follow symlinks the same way git does.
+//
+// go-git's default config loader (xconfig.NewAuto backed by osfs.Default)
+// reads config files through Go's os.Root, which rejects an absolute symlink
+// in any path component — even when it resolves back inside the root — with
+// "path escapes from parent". Users whose global config lives behind a
+// symlinked directory (e.g. ~/.config managed by a dotfile tool such as
+// chezmoi, GNU Stow, or yadm) therefore had their global config silently
+// dropped: checkpoint-commit author identity fell back to "Unknown", commit
+// signing was skipped, and the lifecycle hook printed a "failed to load
+// global git config: path escapes from parent" warning for every commit it
+// created while pushing (once per cherry-picked commit during a sync/rebase).
+//
+// The auto loader only ever calls Open and Stat; the remaining billy.Basic
+// methods exist to satisfy the interface and are not expected to be exercised
+// for config resolution.
+type osSymlinkFS struct{}
+
+//nolint:gochecknoinits // Override go-git's default config loader so global git config behind symlinks is read (see osSymlinkFS).
+func init() {
+	// plugin.Register replaces the factory go-git registered during its own
+	// package init. This runs afterwards because this package imports x/plugin,
+	// and before any plugin.Get call (which only happens at command runtime).
+	//nolint:errcheck,gosec // Best-effort: Register only fails after a plugin.Get, which cannot precede init; go-git's default loader remains as fallback.
+	registerSymlinkConfigLoader()
+}
+
+// registerSymlinkConfigLoader registers the symlink-following config loader as
+// the ConfigLoader plugin. Exposed for tests that reset the registry.
+func registerSymlinkConfigLoader() error {
+	return plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
+		return xconfig.NewAuto(xconfig.WithFilesystem(osSymlinkFS{}))
+	})
+}
+
+func (osSymlinkFS) Open(name string) (billy.File, error) {
+	f, err := os.Open(name) //nolint:gosec // G304: name comes from git's own config-path resolution, not user input.
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (osSymlinkFS) Stat(name string) (fs.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (osSymlinkFS) OpenFile(name string, flag int, perm fs.FileMode) (billy.File, error) {
+	f, err := os.OpenFile(name, flag, perm) //nolint:gosec // G304: name comes from git's own config-path resolution, not user input.
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (fs osSymlinkFS) Create(name string) (billy.File, error) {
+	return fs.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o666)
+}
+
+func (osSymlinkFS) Rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
+func (osSymlinkFS) Remove(name string) error {
+	return os.Remove(name)
+}
+
+func (osSymlinkFS) Join(elem ...string) string {
+	return filepath.Join(elem...)
+}

--- a/cmd/entire/cli/checkpoint/configloader.go
+++ b/cmd/entire/cli/checkpoint/configloader.go
@@ -66,8 +66,8 @@ func (osSymlinkFS) OpenFile(name string, flag int, perm fs.FileMode) (billy.File
 	return f, nil
 }
 
-func (fs osSymlinkFS) Create(name string) (billy.File, error) {
-	return fs.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o666)
+func (o osSymlinkFS) Create(name string) (billy.File, error) {
+	return o.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o666)
 }
 
 func (osSymlinkFS) Rename(oldpath, newpath string) error {

--- a/cmd/entire/cli/checkpoint/configloader_test.go
+++ b/cmd/entire/cli/checkpoint/configloader_test.go
@@ -1,0 +1,146 @@
+package checkpoint
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/x/plugin"
+	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
+)
+
+// writeSymlinkedGlobalConfig builds a fake $HOME whose XDG config directory
+// (~/.config) is an *absolute* symlink to a directory elsewhere — exactly what
+// dotfile managers like chezmoi, GNU Stow, or yadm produce. The global git
+// config lives at ~/.config/git/config (reached only when ~/.gitconfig is
+// absent). It returns the fake home directory. It skips on platforms where
+// symlink creation is unprivileged/unsupported.
+func writeSymlinkedGlobalConfig(t *testing.T, contents string) (home string) {
+	t.Helper()
+
+	base := t.TempDir()
+	home = filepath.Join(base, "home")
+	realConfig := filepath.Join(base, "dotfiles", "config")
+
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(realConfig, "git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realConfig, "git", "config"), []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// ~/.config -> absolute path. os.Root rejects this even though it resolves
+	// back inside the host root, which is the root cause of the bug.
+	if err := os.Symlink(realConfig, filepath.Join(home, ".config")); err != nil {
+		t.Skipf("cannot create symlink on this platform: %v", err)
+	}
+
+	return home
+}
+
+// pointHomeAt isolates global git config resolution onto home: it sets HOME,
+// disables system config, and forces XDG resolution onto ~/.config by clearing
+// XDG_CONFIG_HOME and GIT_CONFIG_GLOBAL (the latter is unset, not emptied,
+// since an empty value disables global config entirely).
+func pointHomeAt(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_GLOBAL", "")
+	os.Unsetenv("GIT_CONFIG_GLOBAL")
+}
+
+// TestOSSymlinkFS_ReadsGlobalConfigBehindSymlink reproduces the customer's
+// "path escapes from parent" failure and verifies osSymlinkFS fixes it.
+//
+// The default loader (osfs.Default, backed by os.Root) must fail; the
+// symlink-following loader must read the config.
+func TestOSSymlinkFS_ReadsGlobalConfigBehindSymlink(t *testing.T) {
+	// Cannot t.Parallel(): mutates HOME/XDG/GIT_CONFIG_* via t.Setenv.
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG default path and symlink semantics differ on Windows")
+	}
+
+	const cfg = "[user]\n\tname = Jag\n\temail = jag@example.com\n"
+	home := writeSymlinkedGlobalConfig(t, cfg)
+	pointHomeAt(t, home)
+
+	// Default loader (os.Root): must reject the symlinked path, matching the
+	// customer's report. This locks in the regression.
+	if _, err := xconfig.NewAuto().Load(config.GlobalScope); err == nil {
+		t.Fatal("default osfs loader unexpectedly succeeded on symlinked XDG config; regression no longer reproduces")
+	} else if !strings.Contains(err.Error(), "path escapes from parent") {
+		t.Fatalf("default loader error = %v, want it to contain %q", err, "path escapes from parent")
+	}
+
+	// Symlink-following loader: must read through the symlink like git does.
+	storer, err := xconfig.NewAuto(xconfig.WithFilesystem(osSymlinkFS{})).Load(config.GlobalScope)
+	if err != nil {
+		t.Fatalf("osSymlinkFS loader failed to load global config: %v", err)
+	}
+	loaded, err := storer.Config()
+	if err != nil {
+		t.Fatalf("storer.Config() error = %v", err)
+	}
+	if loaded.User.Name != "Jag" {
+		t.Errorf("user.name = %q, want %q", loaded.User.Name, "Jag")
+	}
+	if loaded.User.Email != "jag@example.com" {
+		t.Errorf("user.email = %q, want %q", loaded.User.Email, "jag@example.com")
+	}
+}
+
+// TestGetGitAuthorFromRepo_GlobalConfigBehindSymlink verifies the user-facing
+// impact is fixed: with the symlink-following loader registered, checkpoint
+// commit authorship resolves from a global config behind a symlinked ~/.config
+// instead of falling back to "Unknown".
+func TestGetGitAuthorFromRepo_GlobalConfigBehindSymlink(t *testing.T) {
+	// Cannot t.Parallel(): mutates HOME/XDG/GIT_CONFIG_* and the plugin registry.
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG default path and symlink semantics differ on Windows")
+	}
+
+	useSymlinkConfigLoader(t)
+
+	home := writeSymlinkedGlobalConfig(t, "[user]\n\tname = Jag\n\temail = jag@example.com\n")
+	pointHomeAt(t, home)
+
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	name, email := GetGitAuthorFromRepo(repo)
+	if name != "Jag" {
+		t.Errorf("name = %q, want %q", name, "Jag")
+	}
+	if email != "jag@example.com" {
+		t.Errorf("email = %q, want %q", email, "jag@example.com")
+	}
+}
+
+// useSymlinkConfigLoader registers the production symlink-following config
+// loader (osSymlinkFS) for the duration of t, restoring NewEmpty afterwards so
+// other tests stay isolated from the host environment.
+func useSymlinkConfigLoader(t *testing.T) {
+	t.Helper()
+	resetPluginEntry(configLoaderKey)
+	if err := registerSymlinkConfigLoader(); err != nil {
+		t.Fatalf("failed to register symlink config loader: %v", err)
+	}
+	t.Cleanup(func() {
+		resetPluginEntry(configLoaderKey)
+		if err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource { return xconfig.NewEmpty() }); err != nil {
+			t.Fatalf("failed to restore NewEmpty config loader: %v", err)
+		}
+	})
+}

--- a/cmd/entire/cli/checkpoint/configloader_test.go
+++ b/cmd/entire/cli/checkpoint/configloader_test.go
@@ -1,15 +1,15 @@
 package checkpoint
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
+	"github.com/go-git/go-billy/v6/osfs"
 	git "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
-	"github.com/go-git/go-git/v6/x/plugin"
 	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
 )
 
@@ -77,8 +77,8 @@ func TestOSSymlinkFS_ReadsGlobalConfigBehindSymlink(t *testing.T) {
 	// customer's report. This locks in the regression.
 	if _, err := xconfig.NewAuto().Load(config.GlobalScope); err == nil {
 		t.Fatal("default osfs loader unexpectedly succeeded on symlinked XDG config; regression no longer reproduces")
-	} else if !strings.Contains(err.Error(), "path escapes from parent") {
-		t.Fatalf("default loader error = %v, want it to contain %q", err, "path escapes from parent")
+	} else if !errors.Is(err, osfs.ErrPathEscapesParent) {
+		t.Fatalf("default loader error = %v, want errors.Is(..., osfs.ErrPathEscapesParent)", err)
 	}
 
 	// Symlink-following loader: must read through the symlink like git does.
@@ -133,14 +133,5 @@ func TestGetGitAuthorFromRepo_GlobalConfigBehindSymlink(t *testing.T) {
 // other tests stay isolated from the host environment.
 func useSymlinkConfigLoader(t *testing.T) {
 	t.Helper()
-	resetPluginEntry(configLoaderKey)
-	if err := registerSymlinkConfigLoader(); err != nil {
-		t.Fatalf("failed to register symlink config loader: %v", err)
-	}
-	t.Cleanup(func() {
-		resetPluginEntry(configLoaderKey)
-		if err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource { return xconfig.NewEmpty() }); err != nil {
-			t.Fatalf("failed to restore NewEmpty config loader: %v", err)
-		}
-	})
+	registerConfigLoaderForTest(t, registerSymlinkConfigLoader)
 }

--- a/cmd/entire/cli/checkpoint/configloader_test.go
+++ b/cmd/entire/cli/checkpoint/configloader_test.go
@@ -54,8 +54,12 @@ func pointHomeAt(t *testing.T, home string) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	// t.Setenv registers restoration of the original value; unset it for the
+	// test so go-git falls back to XDG (an empty value disables global config).
 	t.Setenv("GIT_CONFIG_GLOBAL", "")
-	os.Unsetenv("GIT_CONFIG_GLOBAL")
+	if err := os.Unsetenv("GIT_CONFIG_GLOBAL"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestOSSymlinkFS_ReadsGlobalConfigBehindSymlink reproduces the customer's

--- a/cmd/entire/cli/checkpoint/global_test.go
+++ b/cmd/entire/cli/checkpoint/global_test.go
@@ -37,9 +37,19 @@ const configLoaderKey plugin.Name = "config-loader"
 func useAutoConfigLoader(t *testing.T) {
 	t.Helper()
 	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	registerConfigLoaderForTest(t, func() error {
+		return plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource { return config.NewAuto() })
+	})
+}
+
+// registerConfigLoaderForTest resets the ConfigLoader plugin entry, runs register
+// to install a test loader, and restores NewEmpty on cleanup. The reset is required
+// because a prior plugin.Get may have frozen the entry.
+func registerConfigLoaderForTest(t *testing.T, register func() error) {
+	t.Helper()
 	resetPluginEntry(configLoaderKey)
-	if err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource { return config.NewAuto() }); err != nil {
-		t.Fatalf("failed to register NewAuto config loader: %v", err)
+	if err := register(); err != nil {
+		t.Fatalf("failed to register config loader: %v", err)
 	}
 	t.Cleanup(func() {
 		resetPluginEntry(configLoaderKey)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/434
<!-- entire-trail-link-end -->

## Problem

A customer reported a flood of warnings during checkpoint push:

```
[entire] Syncing entire/checkpoints/v1 with remote......
warning: failed to load global git config: path escapes from parent: "Users/jag/.config/git/config"
warning: failed to load global git config: path escapes from parent: "Users/jag/.config/git/config"
... (repeated per cherry-picked commit)
```

## Root cause

The customer has `~/.config` (or another intermediate path component) as an **absolute symlink** — standard behavior for dotfile managers (chezmoi, GNU Stow, yadm, …). With no `~/.gitconfig`, go-git falls back to the XDG path `~/.config/git/config`.

go-git's default config loader (`xconfig.NewAuto` on `osfs.Default`) reads config files through Go's `os.Root`, which **rejects an absolute symlink in any path component — even one that resolves back inside the root** — returning `path escapes from parent`. Plain `os.Open`/`os.ReadFile` follow the symlink fine; only `os.Root` chokes. (Reproduced verbatim, missing leading slash and all.)

This wasn't just noise. The global config was silently dropped, so:
1. **Author identity fell back to `Unknown`/`unknown@local`** for checkpoint commits (`GetGitAuthorFromRepo` → `repo.ConfigScoped`).
2. **Commit signing was skipped** (`commit.gpgsign` never read).
3. **The warning printed once per commit** during the push/rebase loop — the flood.

## Fix

`cmd/entire/cli/checkpoint/configloader.go` registers a `ConfigLoader` plugin backed by `osSymlinkFS`, a minimal `billy.Basic` using plain `os` calls so config reads follow symlinks the way git itself does. `plugin.Register` replaces go-git's default factory during package init (before any `plugin.Get`).

The adapter returns **raw `os` errors unwrapped** because go-git's auto loader uses `os.IsNotExist(err)` (the legacy non-unwrapping check) to fall through absent config files — wrapping would break that. Hence the per-file `wrapcheck` exclusion, with the reason documented in `.golangci.yaml`.

## Tests

- `TestOSSymlinkFS_ReadsGlobalConfigBehindSymlink` — reproduces the exact `path escapes from parent` failure with the default loader and confirms `osSymlinkFS` reads through the symlink.
- `TestGetGitAuthorFromRepo_GlobalConfigBehindSymlink` — end-to-end: author identity now resolves from a global config behind a symlinked `~/.config` instead of falling back to `Unknown`. (Verified it fails with `name = "Unknown"` when reverted to the default loader.)

Full suite green (5210 tests), lint clean.

## Upstream

This is fundamentally a go-git/go-billy limitation (the `auto` loader reading trusted host config through `os.Root`, diverging from git's symlink-following behavior). A separate upstream conversation/PR will pursue the durable fix; this workaround is forward-compatible and can be dropped once upstream lands.

## Draft notes / open questions

- Left the deprecated `config.LoadConfig(GlobalScope)` fallback at `committed.go:1913` (still uses `osfs.Default`) untouched, since it's only reached when `ConfigScoped` returns empty — which the fix now prevents. Could harden it too.
- The `init()`-based registry override is slightly implicit; open to moving it to an explicit call in root setup if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized checkpoint package init and filesystem adapter for config reads; behavior change only affects environments where global config was previously unreadable.
> 
> **Overview**
> **Fixes global git config not loading** when `~/.config` (or similar) is an absolute symlink—common with dotfile managers. go-git’s default loader used `os.Root` and failed with `path escapes from parent`, so `repo.ConfigScoped` dropped global settings: checkpoint commits used **Unknown** author, **GPG signing was skipped**, and push/sync logged the same warning **once per cherry-picked commit**.
> 
> Adds **`configloader.go`**: at package `init`, registers a go-git `ConfigLoader` backed by **`osSymlinkFS`** (`billy.Basic` over plain `os.Open`/`os.Stat`) so config paths follow symlinks like git. **`GetGitAuthorFromRepo`** comments point at this loader. Lint: allow `billy.File` in `ireturn`, **`wrapcheck` off** for `configloader.go` (raw `os` errors required for `os.IsNotExist` fall-through). **Tests** reproduce the default-loader failure and assert author resolution end-to-end (non-Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b31870ab7199879d15bac921361f22f65df3aa1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->