### PR TITLE
Add per-phase perf spans to checkpoint pre-push

### DIFF
--- a/cmd/entire/cli/gitrepo/alternates_fs.go
+++ b/cmd/entire/cli/gitrepo/alternates_fs.go
@@ -1,4 +1,4 @@
-//nolint:ireturn,wrapcheck // billy.Filesystem requires interface-returning passthrough methods; preserve osfs errors exactly.
+//nolint:wrapcheck // Preserve osfs errors exactly for billy.Filesystem passthrough methods.
 package gitrepo
 
 import (

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -19,8 +19,13 @@ import (
 //   - push_sessions: false to disable automatic pushing of checkpoints
 //   - checkpoint_remote: {"provider": "github", "repo": "org/repo"} to push to a separate repo
 func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error {
-	// Load settings once for remote resolution and push_sessions check
-	ps := resolvePushSettings(ctx, remote)
+	// Load settings once for remote resolution and push_sessions check.
+	// Spanned because checkpoint-remote resolution can perform a one-time
+	// network fetch of the metadata branch (fetchMetadataBranchIfMissing),
+	// which is otherwise invisible in the pre-push trace.
+	resolveCtx, resolveSpan := perf.Start(ctx, "resolve_push_settings")
+	ps := resolvePushSettings(resolveCtx, remote)
+	resolveSpan.End()
 
 	if ps.pushDisabled {
 		return nil
@@ -28,12 +33,11 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 
 	settings.WarnIfCheckpointsV2Disallowed(ctx)
 
-	var err error
-	_, pushCheckpointsSpan := perf.Start(ctx, "push_checkpoints_branch")
-	err = pushBranchIfNeeded(ctx, ps.pushTarget(), paths.MetadataBranchName)
-	if err != nil {
-		pushCheckpointsSpan.RecordError(err)
-	}
+	// Thread the span's context into the push so the network push and any
+	// fetch+rebase recovery nest beneath it as child steps in the perf trace.
+	pushCtx, pushCheckpointsSpan := perf.Start(ctx, "push_checkpoints_branch")
+	err := pushBranchIfNeeded(pushCtx, ps.pushTarget(), paths.MetadataBranchName)
+	pushCheckpointsSpan.RecordError(err)
 	pushCheckpointsSpan.End()
 
 	return err

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -15,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/perf"
 
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -97,12 +98,18 @@ func doPushBranch(ctx context.Context, target, branchName string) error { //noli
 	}
 
 	// Push failed - likely non-fast-forward. Try to fetch and rebase.
+	// Spanned (with the network fetch as a child) so the trace distinguishes
+	// "the raw push is slow" from "we keep hitting contention and re-syncing".
 	fmt.Fprintf(os.Stderr, "[entire] Syncing %s with remote...", branchName)
 	stop = startProgressDots(os.Stderr)
 
-	if err := fetchAndRebaseSessionsCommon(ctx, target, branchName); err != nil {
+	frCtx, fetchRebaseSpan := perf.Start(ctx, "fetch_and_rebase")
+	syncErr := fetchAndRebaseSessionsCommon(frCtx, target, branchName)
+	fetchRebaseSpan.RecordError(syncErr)
+	fetchRebaseSpan.End()
+	if syncErr != nil {
 		stop("")
-		fmt.Fprintf(os.Stderr, "[entire] Warning: couldn't sync %s: %v\n", branchName, err)
+		fmt.Fprintf(os.Stderr, "[entire] Warning: couldn't sync %s: %v\n", branchName, syncErr)
 		printCheckpointRemoteHint(target)
 		return nil // Don't fail the main push
 	}
@@ -212,7 +219,16 @@ func tryPushSessionsCommon(ctx context.Context, remoteName, branchName string) (
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
+	// Span the actual `git push` subprocess: on a slow remote (e.g. a custom
+	// git transport) this is typically where pre-push time is spent. Called once
+	// per push attempt, so a retry after fetch+rebase shows up as a second
+	// git_push step (git_push~1) in the trace. A rejected first push records an
+	// error flag, which signals the recovery path was taken.
+	_, pushSpan := perf.Start(ctx, "git_push")
 	result, err := remote.Push(ctx, remoteName, branchName)
+	pushSpan.RecordError(err)
+	pushSpan.End()
+
 	outputStr := result.Output
 	if err != nil {
 		return pushResult{}, classifyPushFailure(ctx, outputStr, err)
@@ -334,12 +350,18 @@ func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string
 	// The downstream reconcile/rebase paths walk only commits visible past
 	// .git/shallow (collectCommitChain / collectCommitsSince), so the
 	// missing pre-shallow history isn't needed to produce a correct rebase.
-	if output, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
+	// Span the fetch separately so a slow sync can be attributed to the network
+	// fetch versus the local reconcile/rebase that follows it.
+	_, fetchSpan := perf.Start(ctx, "git_fetch")
+	fetchOutput, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
 		Remote:   fetchTarget,
 		RefSpecs: []string{refSpec},
 		NoTags:   true,
-	}); fetchErr != nil {
-		return fmt.Errorf("fetch failed: %s", output)
+	})
+	fetchSpan.RecordError(fetchErr)
+	fetchSpan.End()
+	if fetchErr != nil {
+		return fmt.Errorf("fetch failed: %s", fetchOutput)
 	}
 
 	repo, err := OpenRepository(ctx)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/439
<!-- entire-trail-link-end -->

Break the single `push_checkpoints_branch` span into nested child spans so `entire doctor trace --hook pre-push` shows where time goes during a slow checkpoint push instead of one total:

- resolve_push_settings: settings load + the one-time metadata-branch fetch (fetchMetadataBranchIfMissing), otherwise invisible.
- push_checkpoints_branch > git_push (+ git_push~1 for the retry): the actual `git push` subprocess, where time goes on a slow transport. Records an error flag on non-fast-forward rejection, which signals the recovery path was taken.
- push_checkpoints_branch > fetch_and_rebase > git_fetch: the sync recovery path, splitting the network fetch from the local rebase.

Threads the push span's context through pushBranchIfNeeded so the child steps nest correctly. Instrumentation only; no behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes to pre-push; no push, fetch, or rebase logic altered.
> 
> **Overview**
> Adds **nested `perf` spans** around checkpoint pre-push so traces (e.g. `entire doctor trace --hook pre-push`) show *where* time is spent instead of one opaque `push_checkpoints_branch` block.
> 
> **`PrePush`** now spans `resolve_push_settings` (including one-time metadata-branch fetch during remote resolution) and passes span context into `pushBranchIfNeeded` so children nest under `push_checkpoints_branch`.
> 
> **`push_common.go`** adds `git_push` around each push attempt (retries appear as a second span), `fetch_and_rebase` around sync recovery, and `git_fetch` inside fetch+rebase. Errors are recorded on spans where relevant. **No functional change**—instrumentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d555f9b64b465bd2852b6afd12cc4c772b61597. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->