### PR TITLE
Bound checkpoint git subprocesses to their context deadline

### DIFF
--- a/cmd/entire/cli/checkpoint/committed_reader_resolve.go
+++ b/cmd/entire/cli/checkpoint/committed_reader_resolve.go
@@ -54,7 +54,7 @@ type CommittedReaderOptions struct {
 	BlobFetcher BlobFetchFunc
 }
 
-func NewCommittedReader(ctx context.Context, repo *git.Repository, opts CommittedReaderOptions) (CommittedStore, error) { //nolint:ireturn // Factory selects between v1 and dual reader implementations.
+func NewCommittedReader(ctx context.Context, repo *git.Repository, opts CommittedReaderOptions) (CommittedStore, error) {
 	if repo == nil {
 		return nil, errors.New("git repository is required")
 	}

--- a/cmd/entire/cli/checkpoint/committed_reader_resolve.go
+++ b/cmd/entire/cli/checkpoint/committed_reader_resolve.go
@@ -54,7 +54,7 @@ type CommittedReaderOptions struct {
 	BlobFetcher BlobFetchFunc
 }
 
-func NewCommittedReader(ctx context.Context, repo *git.Repository, opts CommittedReaderOptions) (CommittedStore, error) {
+func NewCommittedReader(ctx context.Context, repo *git.Repository, opts CommittedReaderOptions) (CommittedStore, error) { //nolint:ireturn // Factory selects between v1 and dual reader implementations.
 	if repo == nil {
 		return nil, errors.New("git repository is required")
 	}

--- a/cmd/entire/cli/checkpoint/remote/command_cancel.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel.go
@@ -1,0 +1,26 @@
+package remote
+
+import (
+	"os/exec"
+	"time"
+)
+
+// killWaitDelay bounds how long Wait blocks for a killed git subprocess (and any
+// descendants) to release the stdout/stderr pipes before Go forcibly closes them
+// and returns. Without it, a `git push`/`git fetch` over a custom transport can
+// hang the caller far past its context deadline: the deadline SIGKILLs `git`, but
+// a spawned remote-helper grandchild (e.g. git-remote-entire) keeps the output
+// pipe open, so cmd.CombinedOutput() blocks until that helper finally exits —
+// observed at ~58 minutes for a stuck checkpoint push.
+const killWaitDelay = 10 * time.Second
+
+// terminateOnCancel makes a git subprocess terminate promptly when its context is
+// cancelled, even if it spawned long-lived transport helpers. It always sets a
+// WaitDelay backstop; on platforms that support it, killProcessGroupOnCancel
+// additionally runs the child in its own process group and SIGKILLs the whole
+// group on cancellation so remote-helper descendants are terminated rather than
+// orphaned.
+func terminateOnCancel(cmd *exec.Cmd) {
+	cmd.WaitDelay = killWaitDelay
+	killProcessGroupOnCancel(cmd)
+}

--- a/cmd/entire/cli/checkpoint/remote/command_cancel.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel.go
@@ -5,21 +5,13 @@ import (
 	"time"
 )
 
-// killWaitDelay bounds how long Wait blocks for a killed git subprocess (and any
-// descendants) to release the stdout/stderr pipes before Go forcibly closes them
-// and returns. Without it, a `git push`/`git fetch` over a custom transport can
-// hang the caller far past its context deadline: the deadline SIGKILLs `git`, but
-// a spawned remote-helper grandchild (e.g. git-remote-entire) keeps the output
-// pipe open, so cmd.CombinedOutput() blocks until that helper finally exits —
-// observed at ~58 minutes for a stuck checkpoint push.
+// killWaitDelay bounds the wait after ctx-cancel: a transport-helper grandchild
+// (e.g. git-remote-entire) can keep the output pipe open after `git` is SIGKILLed,
+// otherwise blocking CombinedOutput indefinitely.
 const killWaitDelay = 10 * time.Second
 
-// terminateOnCancel makes a git subprocess terminate promptly when its context is
-// cancelled, even if it spawned long-lived transport helpers. It always sets a
-// WaitDelay backstop; on platforms that support it, killProcessGroupOnCancel
-// additionally runs the child in its own process group and SIGKILLs the whole
-// group on cancellation so remote-helper descendants are terminated rather than
-// orphaned.
+// terminateOnCancel ensures the subprocess and any transport-helper descendants
+// die when ctx is cancelled.
 func terminateOnCancel(cmd *exec.Cmd) {
 	cmd.WaitDelay = killWaitDelay
 	killProcessGroupOnCancel(cmd)

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_test.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_test.go
@@ -1,0 +1,34 @@
+package remote
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// newCommand must make every git subprocess it builds terminate on cancellation
+// so a hung transport can't block past the caller's context deadline.
+func TestNewCommand_TerminatesOnCancel(t *testing.T) {
+	t.Parallel()
+
+	cmd := newCommand(context.Background(), "push", "origin", "main")
+
+	if cmd.WaitDelay != killWaitDelay {
+		t.Errorf("WaitDelay = %v; want %v", cmd.WaitDelay, killWaitDelay)
+	}
+	if cmd.Cancel == nil {
+		t.Error("Cancel = nil; want a cancellation handler that terminates the process")
+	}
+}
+
+// terminateOnCancel sets the WaitDelay backstop on all platforms.
+func TestTerminateOnCancel_SetsWaitDelay(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.CommandContext(context.Background(), "git", "status")
+	terminateOnCancel(cmd)
+
+	if cmd.WaitDelay != killWaitDelay {
+		t.Errorf("WaitDelay = %v; want %v", cmd.WaitDelay, killWaitDelay)
+	}
+}

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_test.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_test.go
@@ -8,8 +8,12 @@ import (
 
 // newCommand must make every git subprocess it builds terminate on cancellation
 // so a hung transport can't block past the caller's context deadline.
+//
+// Not parallel: uses t.Setenv. Clearing ENTIRE_CHECKPOINT_TOKEN keeps the test
+// hermetic — with a token set, newCommand would resolve "origin" via GetRemoteURL
+// and spawn a git subprocess against the ambient repo.
 func TestNewCommand_TerminatesOnCancel(t *testing.T) {
-	t.Parallel()
+	t.Setenv(CheckpointTokenEnvVar, "")
 
 	cmd := newCommand(context.Background(), "push", "origin", "main")
 

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_test.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_test.go
@@ -6,12 +6,8 @@ import (
 	"testing"
 )
 
-// newCommand must make every git subprocess it builds terminate on cancellation
-// so a hung transport can't block past the caller's context deadline.
-//
 // Not parallel: uses t.Setenv. Clearing ENTIRE_CHECKPOINT_TOKEN keeps the test
-// hermetic — with a token set, newCommand would resolve "origin" via GetRemoteURL
-// and spawn a git subprocess against the ambient repo.
+// hermetic — otherwise newCommand spawns git against the ambient repo.
 func TestNewCommand_TerminatesOnCancel(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "")
 
@@ -25,7 +21,6 @@ func TestNewCommand_TerminatesOnCancel(t *testing.T) {
 	}
 }
 
-// terminateOnCancel sets the WaitDelay backstop on all platforms.
 func TestTerminateOnCancel_SetsWaitDelay(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_unix.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_unix.go
@@ -1,0 +1,33 @@
+//go:build unix
+
+package remote
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// killProcessGroupOnCancel puts the child in its own process group and replaces
+// the context-cancellation handler so the entire group is SIGKILLed. exec.Cmd's
+// default Cancel only kills the direct `git` process, which leaves a spawned
+// remote-helper grandchild (e.g. git-remote-entire) running and holding the
+// output pipe open — defeating the caller's timeout.
+func killProcessGroupOnCancel(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		// Negative PID targets the whole process group (the leader's PID == pgid),
+		// so the remote helper and any other descendants are killed too. ESRCH
+		// means the group already exited, which is not an error for our purposes.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+			return fmt.Errorf("kill process group: %w", err)
+		}
+		return nil
+	}
+}

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_unix.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_unix.go
@@ -8,11 +8,9 @@ import (
 	"syscall"
 )
 
-// killProcessGroupOnCancel puts the child in its own process group and replaces
-// the context-cancellation handler so the entire group is SIGKILLed. exec.Cmd's
-// default Cancel only kills the direct `git` process, which leaves a spawned
-// remote-helper grandchild (e.g. git-remote-entire) running and holding the
-// output pipe open — defeating the caller's timeout.
+// killProcessGroupOnCancel SIGKILLs the whole process group on ctx-cancel.
+// exec.Cmd's default Cancel only kills `git` itself, leaving any transport-helper
+// grandchild alive and holding the output pipe open.
 func killProcessGroupOnCancel(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
@@ -22,9 +20,7 @@ func killProcessGroupOnCancel(cmd *exec.Cmd) {
 		if cmd.Process == nil {
 			return nil
 		}
-		// Negative PID targets the whole process group (the leader's PID == pgid),
-		// so the remote helper and any other descendants are killed too. ESRCH
-		// means the group already exited, which is not an error for our purposes.
+		// Negative PID = whole group (leader pid == pgid). ESRCH = already exited.
 		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
 			return fmt.Errorf("kill process group: %w", err)
 		}

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_unix_test.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_unix_test.go
@@ -1,0 +1,79 @@
+//go:build unix
+
+package remote
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestKillProcessGroupOnCancel_SetsSetpgidAndCancel(t *testing.T) {
+	t.Parallel()
+
+	cmd := newCommand(context.Background(), "push", "origin", "main")
+
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Error("Setpgid = false; want true so the whole process group can be killed")
+	}
+	if cmd.Cancel == nil {
+		t.Fatal("Cancel = nil; want a group-kill handler")
+	}
+}
+
+// TestTerminateOnCancel_KillsProcessGroup proves the fix end-to-end: a child that
+// backgrounds a grandchild which inherits (and holds open) the output pipe must
+// still be terminated when the context is cancelled. Without group-kill, the
+// backgrounded `sleep` keeps the pipe open and CombinedOutput blocks for the full
+// 60s; with it, the whole group dies and CombinedOutput returns promptly.
+func TestTerminateOnCancel_KillsProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	// `sleep 60 &` backgrounds a grandchild that inherits and holds stdout; `wait`
+	// keeps the shell (the group leader) alive so only a group-wide kill ends both.
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 60 & wait")
+	terminateOnCancel(cmd)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := cmd.CombinedOutput()
+		done <- err
+	}()
+
+	// Group-kill closes the inherited pipe on cancellation, so CombinedOutput
+	// returns well under the 60s sleep. Without it, the backgrounded grandchild
+	// keeps the pipe open and this would block for the full minute.
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CombinedOutput did not return after cancellation; the pipe-holding grandchild outlived the group-kill")
+	}
+}
+
+// The Cancel handler must return cleanly and actually terminate the process
+// group leader (the running shell), not just succeed silently.
+func TestKillProcessGroupOnCancel_TerminatesLeader(t *testing.T) {
+	t.Parallel()
+
+	// exec requires CommandContext when Cancel is non-nil; the context stays
+	// open and we invoke Cancel directly to exercise the group-kill handler.
+	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", "sleep 60 & wait")
+	killProcessGroupOnCancel(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	if err := cmd.Cancel(); err != nil {
+		t.Fatalf("Cancel returned %v; want nil", err)
+	}
+
+	// The leader was SIGKILLed, so Wait reports a non-nil (signal: killed) error
+	// rather than blocking on the 60s sleep.
+	if err := cmd.Wait(); err == nil {
+		t.Error("Wait returned nil; the killed shell should report a termination error")
+	}
+}

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_unix_test.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_unix_test.go
@@ -3,14 +3,20 @@
 package remote
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 )
 
+// Not parallel: uses t.Setenv. Clearing ENTIRE_CHECKPOINT_TOKEN keeps the test
+// hermetic — with a token set, newCommand would resolve "origin" via GetRemoteURL
+// and spawn a git subprocess against the ambient repo.
 func TestKillProcessGroupOnCancel_SetsSetpgidAndCancel(t *testing.T) {
-	t.Parallel()
+	t.Setenv(CheckpointTokenEnvVar, "")
 
 	cmd := newCommand(context.Background(), "push", "origin", "main")
 
@@ -25,28 +31,48 @@ func TestKillProcessGroupOnCancel_SetsSetpgidAndCancel(t *testing.T) {
 // TestTerminateOnCancel_KillsProcessGroup proves the fix end-to-end: a child that
 // backgrounds a grandchild which inherits (and holds open) the output pipe must
 // still be terminated when the context is cancelled. Without group-kill, the
-// backgrounded `sleep` keeps the pipe open and CombinedOutput blocks for the full
-// 60s; with it, the whole group dies and CombinedOutput returns promptly.
+// backgrounded `sleep` keeps the pipe open and the read blocks for the full 60s;
+// with it, the whole group dies and the read returns promptly.
 func TestTerminateOnCancel_KillsProcessGroup(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// `sleep 60 &` backgrounds a grandchild that inherits and holds stdout; `wait`
+	// `sleep 60 &` backgrounds a grandchild that inherits and holds stdout; the
+	// "ready" marker is printed only after it is backgrounded, so we can cancel
+	// strictly after the pipe-holding grandchild exists. A fixed timeout deadline
+	// could instead fire before the shell even spawns the grandchild (e.g. slow
+	// process start under load), silently turning this into a no-op pass. `wait`
 	// keeps the shell (the group leader) alive so only a group-wide kill ends both.
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 60 & wait")
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 60 & echo ready; wait")
 	terminateOnCancel(cmd)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Block until the grandchild is alive and holding the pipe open.
+	br := bufio.NewReader(stdout)
+	if line, err := br.ReadString('\n'); err != nil || strings.TrimSpace(line) != "ready" {
+		t.Fatalf("did not observe ready marker: line=%q err=%v", line, err)
+	}
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := cmd.CombinedOutput()
-		done <- err
+		_, _ = io.Copy(io.Discard, br) //nolint:errcheck // draining to block until the pipe closes; copy errors are irrelevant
+		done <- cmd.Wait()
 	}()
 
-	// Group-kill closes the inherited pipe on cancellation, so CombinedOutput
-	// returns well under the 60s sleep. Without it, the backgrounded grandchild
-	// keeps the pipe open and this would block for the full minute.
+	cancel()
+
+	// Group-kill closes the inherited pipe on cancellation, so the read returns well
+	// under the 60s sleep. Without it, the backgrounded grandchild keeps the pipe
+	// open and this would block for the full minute.
 	//
 	// The deadline must stay strictly below killWaitDelay: that WaitDelay backstop
 	// would itself force the pipe closed once it elapses, so a deadline >=
@@ -55,7 +81,7 @@ func TestTerminateOnCancel_KillsProcessGroup(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(killWaitDelay / 2):
-		t.Fatal("CombinedOutput did not return after cancellation; the pipe-holding grandchild outlived the group-kill")
+		t.Fatal("read did not return after cancellation; the pipe-holding grandchild outlived the group-kill")
 	}
 }
 
@@ -77,8 +103,19 @@ func TestKillProcessGroupOnCancel_TerminatesLeader(t *testing.T) {
 	}
 
 	// The leader was SIGKILLed, so Wait reports a non-nil (signal: killed) error
-	// rather than blocking on the 60s sleep.
-	if err := cmd.Wait(); err == nil {
-		t.Error("Wait returned nil; the killed shell should report a termination error")
+	// rather than blocking on the 60s sleep. killProcessGroupOnCancel sets no
+	// WaitDelay backstop, so bound the wait ourselves: if the group-kill path ever
+	// regresses to a no-op, the shell would block on `sleep 60` and hang the suite
+	// for a full minute instead of failing fast.
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("Wait returned nil; the killed shell should report a termination error")
+		}
+	case <-time.After(killWaitDelay):
+		t.Fatal("Wait did not return after Cancel; the group-kill handler may have regressed")
 	}
 }

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_unix_test.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_unix_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 // Not parallel: uses t.Setenv. Clearing ENTIRE_CHECKPOINT_TOKEN keeps the test
-// hermetic — with a token set, newCommand would resolve "origin" via GetRemoteURL
-// and spawn a git subprocess against the ambient repo.
+// hermetic — otherwise newCommand spawns git against the ambient repo.
 func TestKillProcessGroupOnCancel_SetsSetpgidAndCancel(t *testing.T) {
 	t.Setenv(CheckpointTokenEnvVar, "")
 
@@ -28,23 +27,17 @@ func TestKillProcessGroupOnCancel_SetsSetpgidAndCancel(t *testing.T) {
 	}
 }
 
-// TestTerminateOnCancel_KillsProcessGroup proves the fix end-to-end: a child that
-// backgrounds a grandchild which inherits (and holds open) the output pipe must
-// still be terminated when the context is cancelled. Without group-kill, the
-// backgrounded `sleep` keeps the pipe open and the read blocks for the full 60s;
-// with it, the whole group dies and the read returns promptly.
+// End-to-end: a backgrounded grandchild inherits stdout, so cancelling the parent
+// must kill the whole group — otherwise the read blocks for the full sleep.
 func TestTerminateOnCancel_KillsProcessGroup(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// `sleep 60 &` backgrounds a grandchild that inherits and holds stdout; the
-	// "ready" marker is printed only after it is backgrounded, so we can cancel
-	// strictly after the pipe-holding grandchild exists. A fixed timeout deadline
-	// could instead fire before the shell even spawns the grandchild (e.g. slow
-	// process start under load), silently turning this into a no-op pass. `wait`
-	// keeps the shell (the group leader) alive so only a group-wide kill ends both.
+	// `sleep 60 &` backgrounds a grandchild that holds stdout; "ready" prints after
+	// it backgrounds so we cancel strictly after it exists (no race). `wait` keeps
+	// the shell alive as group leader so only a group-wide kill ends both.
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 60 & echo ready; wait")
 	terminateOnCancel(cmd)
 
@@ -56,7 +49,7 @@ func TestTerminateOnCancel_KillsProcessGroup(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 
-	// Block until the grandchild is alive and holding the pipe open.
+	// Wait for "ready" so the grandchild is up and holding the pipe.
 	br := bufio.NewReader(stdout)
 	if line, err := br.ReadString('\n'); err != nil || strings.TrimSpace(line) != "ready" {
 		t.Fatalf("did not observe ready marker: line=%q err=%v", line, err)
@@ -70,14 +63,8 @@ func TestTerminateOnCancel_KillsProcessGroup(t *testing.T) {
 
 	cancel()
 
-	// Group-kill closes the inherited pipe on cancellation, so the read returns well
-	// under the 60s sleep. Without it, the backgrounded grandchild keeps the pipe
-	// open and this would block for the full minute.
-	//
-	// The deadline must stay strictly below killWaitDelay: that WaitDelay backstop
-	// would itself force the pipe closed once it elapses, so a deadline >=
-	// killWaitDelay would let this test pass even with group-kill removed, silently
-	// turning it into a no-op. Halving keeps it comfortably inside that window.
+	// Deadline must stay strictly below killWaitDelay: that backstop would force
+	// the pipe closed on its own, letting this test pass even if group-kill regressed.
 	select {
 	case <-done:
 	case <-time.After(killWaitDelay / 2):
@@ -85,13 +72,11 @@ func TestTerminateOnCancel_KillsProcessGroup(t *testing.T) {
 	}
 }
 
-// The Cancel handler must return cleanly and actually terminate the process
-// group leader (the running shell), not just succeed silently.
+// Cancel must return cleanly *and* actually terminate the leader.
 func TestKillProcessGroupOnCancel_TerminatesLeader(t *testing.T) {
 	t.Parallel()
 
-	// exec requires CommandContext when Cancel is non-nil; the context stays
-	// open and we invoke Cancel directly to exercise the group-kill handler.
+	// exec requires CommandContext when Cancel is non-nil; we invoke Cancel directly.
 	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", "sleep 60 & wait")
 	killProcessGroupOnCancel(cmd)
 	if err := cmd.Start(); err != nil {
@@ -102,11 +87,8 @@ func TestKillProcessGroupOnCancel_TerminatesLeader(t *testing.T) {
 		t.Fatalf("Cancel returned %v; want nil", err)
 	}
 
-	// The leader was SIGKILLed, so Wait reports a non-nil (signal: killed) error
-	// rather than blocking on the 60s sleep. killProcessGroupOnCancel sets no
-	// WaitDelay backstop, so bound the wait ourselves: if the group-kill path ever
-	// regresses to a no-op, the shell would block on `sleep 60` and hang the suite
-	// for a full minute instead of failing fast.
+	// Bound the wait ourselves — no WaitDelay is set here, so a group-kill
+	// regression would block on the full 60s sleep instead of failing fast.
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_unix_test.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_unix_test.go
@@ -47,9 +47,14 @@ func TestTerminateOnCancel_KillsProcessGroup(t *testing.T) {
 	// Group-kill closes the inherited pipe on cancellation, so CombinedOutput
 	// returns well under the 60s sleep. Without it, the backgrounded grandchild
 	// keeps the pipe open and this would block for the full minute.
+	//
+	// The deadline must stay strictly below killWaitDelay: that WaitDelay backstop
+	// would itself force the pipe closed once it elapses, so a deadline >=
+	// killWaitDelay would let this test pass even with group-kill removed, silently
+	// turning it into a no-op. Halving keeps it comfortably inside that window.
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+	case <-time.After(killWaitDelay / 2):
 		t.Fatal("CombinedOutput did not return after cancellation; the pipe-holding grandchild outlived the group-kill")
 	}
 }

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_windows.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package remote
+
+import "os/exec"
+
+// killProcessGroupOnCancel is a no-op on Windows. Reliable termination of a
+// process tree there requires a Job Object, which is out of scope here. The
+// cross-platform WaitDelay backstop still bounds how long we block on a hung
+// subprocess, and exec.Cmd's default context-cancellation handler still kills
+// the direct git process.
+func killProcessGroupOnCancel(_ *exec.Cmd) {}

--- a/cmd/entire/cli/checkpoint/remote/command_cancel_windows.go
+++ b/cmd/entire/cli/checkpoint/remote/command_cancel_windows.go
@@ -4,9 +4,6 @@ package remote
 
 import "os/exec"
 
-// killProcessGroupOnCancel is a no-op on Windows. Reliable termination of a
-// process tree there requires a Job Object, which is out of scope here. The
-// cross-platform WaitDelay backstop still bounds how long we block on a hung
-// subprocess, and exec.Cmd's default context-cancellation handler still kills
-// the direct git process.
+// killProcessGroupOnCancel is a no-op on Windows: reliable tree-kill needs a Job
+// Object. The WaitDelay backstop still bounds the wait on a hung subprocess.
 func killProcessGroupOnCancel(_ *exec.Cmd) {}

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -358,6 +358,10 @@ func newCommand(ctx context.Context, args ...string) *exec.Cmd {
 	mkCmd := func(finalArgs []string) *exec.Cmd {
 		c := exec.CommandContext(ctx, "git", finalArgs...)
 		c.Stdin = nil // Disconnect stdin to prevent hanging in hook context
+		// Kill the process group on ctx-cancel and force pipes closed after
+		// WaitDelay, so a stuck transport helper can't outlive the caller's
+		// timeout (see terminateOnCancel).
+		terminateOnCancel(c)
 		return c
 	}
 

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -358,9 +358,6 @@ func newCommand(ctx context.Context, args ...string) *exec.Cmd {
 	mkCmd := func(finalArgs []string) *exec.Cmd {
 		c := exec.CommandContext(ctx, "git", finalArgs...)
 		c.Stdin = nil // Disconnect stdin to prevent hanging in hook context
-		// Kill the process group on ctx-cancel and force pipes closed after
-		// WaitDelay, so a stuck transport helper can't outlive the caller's
-		// timeout (see terminateOnCancel).
 		terminateOnCancel(c)
 		return c
 	}

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -77,9 +77,9 @@ func displayPushTarget(target string) string {
 // checkpointPushBudget is one shared deadline for a whole checkpoint push: the
 // initial push, the fetch+rebase recovery, and the retry all draw from it. A
 // per-attempt timeout instead let a stuck transport be re-charged a fresh timeout
-// per attempt, blocking the user's `git push` for ~2x the timeout. A var so tests
-// can shrink it.
-var checkpointPushBudget = 60 * time.Second
+// per attempt, blocking the user's `git push` for ~3x the timeout. Sized to
+// tolerate a slow network across all three phases. A var so tests can shrink it.
+var checkpointPushBudget = 2 * time.Minute
 
 // doPushBranch pushes the given branch to the target with fetch+merge recovery.
 // The target can be a remote name or a URL.

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -74,17 +74,14 @@ func displayPushTarget(target string) string {
 	return target
 }
 
-// checkpointPushBudget is one shared deadline for a whole checkpoint push: the
-// initial push, the fetch+rebase recovery, and the retry all draw from it. A
-// per-attempt timeout instead let a stuck transport be re-charged a fresh timeout
-// per attempt, blocking the user's `git push` for ~3x the timeout. Sized to
-// tolerate a slow network across all three phases. A var so tests can shrink it.
+// checkpointPushBudget is one shared deadline across the initial push,
+// fetch+rebase, and retry — per-attempt timeouts can stack to ~3x. var so tests
+// can shrink it.
 var checkpointPushBudget = 2 * time.Minute
 
 // doPushBranch pushes the given branch to the target with fetch+merge recovery.
 // The target can be a remote name or a URL.
 func doPushBranch(ctx context.Context, target, branchName string) error {
-	// One shared deadline for the whole push; see checkpointPushBudget.
 	ctx, cancel := context.WithTimeout(ctx, checkpointPushBudget)
 	defer cancel()
 
@@ -225,8 +222,8 @@ func finishPush(ctx context.Context, stop func(string), result pushResult, targe
 	}
 }
 
-// tryPushSessionsCommon attempts to push the sessions branch. It sets no timeout of
-// its own — it runs under doPushBranch's shared push budget (see checkpointPushBudget).
+// tryPushSessionsCommon attempts to push the sessions branch. No timeout of its
+// own — runs under doPushBranch's shared budget.
 func tryPushSessionsCommon(ctx context.Context, remoteName, branchName string) (pushResult, error) {
 	// Span the actual `git push` subprocess: on a slow remote (e.g. a custom
 	// git transport) this is typically where pre-push time is spent. Called once
@@ -329,7 +326,7 @@ func printProtectedRefBlock(w io.Writer, ref, target string) {
 // always apply cleanly.
 // The target can be a remote name or a URL.
 func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string) error {
-	// No timeout here: runs under doPushBranch's shared push budget (see checkpointPushBudget).
+	// No timeout: runs under doPushBranch's shared budget.
 	fetchTarget, err := remote.ResolveFetchTarget(ctx, target)
 	if err != nil {
 		return fmt.Errorf("resolve fetch target: %w", err)

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -74,9 +74,20 @@ func displayPushTarget(target string) string {
 	return target
 }
 
+// checkpointPushBudget is one shared deadline for a whole checkpoint push: the
+// initial push, the fetch+rebase recovery, and the retry all draw from it. A
+// per-attempt timeout instead let a stuck transport be re-charged a fresh timeout
+// per attempt, blocking the user's `git push` for ~2x the timeout. A var so tests
+// can shrink it.
+var checkpointPushBudget = 60 * time.Second
+
 // doPushBranch pushes the given branch to the target with fetch+merge recovery.
 // The target can be a remote name or a URL.
-func doPushBranch(ctx context.Context, target, branchName string) error { //nolint:unparam // callers treat push failures as non-fatal but keep an error-shaped boundary.
+func doPushBranch(ctx context.Context, target, branchName string) error {
+	// One shared deadline for the whole push; see checkpointPushBudget.
+	ctx, cancel := context.WithTimeout(ctx, checkpointPushBudget)
+	defer cancel()
+
 	displayTarget := displayPushTarget(target)
 
 	fmt.Fprintf(os.Stderr, "[entire] Pushing %s to %s...", branchName, displayTarget)
@@ -214,11 +225,9 @@ func finishPush(ctx context.Context, stop func(string), result pushResult, targe
 	}
 }
 
-// tryPushSessionsCommon attempts to push the sessions branch.
+// tryPushSessionsCommon attempts to push the sessions branch. It sets no timeout of
+// its own — it runs under doPushBranch's shared push budget (see checkpointPushBudget).
 func tryPushSessionsCommon(ctx context.Context, remoteName, branchName string) (pushResult, error) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cancel()
-
 	// Span the actual `git push` subprocess: on a slow remote (e.g. a custom
 	// git transport) this is typically where pre-push time is spent. Called once
 	// per push attempt, so a retry after fetch+rebase shows up as a second
@@ -320,9 +329,7 @@ func printProtectedRefBlock(w io.Writer, ref, target string) {
 // always apply cleanly.
 // The target can be a remote name or a URL.
 func fetchAndRebaseSessionsCommon(ctx context.Context, target, branchName string) error {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cancel()
-
+	// No timeout here: runs under doPushBranch's shared push budget (see checkpointPushBudget).
 	fetchTarget, err := remote.ResolveFetchTarget(ctx, target)
 	if err != nil {
 		return fmt.Errorf("resolve fetch target: %w", err)

--- a/cmd/entire/cli/strategy/push_common_budget_unix_test.go
+++ b/cmd/entire/cli/strategy/push_common_budget_unix_test.go
@@ -24,7 +24,7 @@ import (
 //
 // Not parallel: uses t.Setenv and overrides checkpointPushBudget.
 func TestDoPushBranch_SharedBudget_BoundsTotalWallClock(t *testing.T) {
-	// Shrink the production 60s budget so the test runs in seconds.
+	// Shrink the production budget so the test runs in seconds.
 	const budget = 2 * time.Second
 	restoreBudget := checkpointPushBudget
 	checkpointPushBudget = budget

--- a/cmd/entire/cli/strategy/push_common_budget_unix_test.go
+++ b/cmd/entire/cli/strategy/push_common_budget_unix_test.go
@@ -14,23 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDoPushBranch_SharedBudget_BoundsTotalWallClock proves the whole checkpoint
-// push shares one deadline: a per-attempt timeout regression would let the initial
-// push, fetch+rebase, and retry each spend a full timeout (~2x the bound).
-//
-// A hanging GIT_SSH_COMMAND makes `git push` to an ssh:// URL block until the budget
-// SIGKILLs the process group; the script sleeps past the asserted bound so a
-// regression blows past it, and self-exits as a backstop.
+// A per-attempt timeout regression would let push/fetch/retry each spend a full
+// budget (~2x). A hanging GIT_SSH_COMMAND blocks until the shared budget cuts it off.
 //
 // Not parallel: uses t.Setenv and overrides checkpointPushBudget.
 func TestDoPushBranch_SharedBudget_BoundsTotalWallClock(t *testing.T) {
-	// Shrink the production budget so the test runs in seconds.
 	const budget = 2 * time.Second
 	restoreBudget := checkpointPushBudget
 	checkpointPushBudget = budget
 	t.Cleanup(func() { checkpointPushBudget = restoreBudget })
 
-	// Hangs past the asserted bound; git runs it for the ssh:// URL via GIT_SSH_COMMAND.
+	// Invoked by git for the ssh:// URL via GIT_SSH_COMMAND; outlives the bound below.
 	hangScript := filepath.Join(t.TempDir(), "hang.sh")
 	require.NoError(t, os.WriteFile(hangScript, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755))
 	t.Setenv("GIT_SSH_COMMAND", hangScript)
@@ -40,11 +34,10 @@ func TestDoPushBranch_SharedBudget_BoundsTotalWallClock(t *testing.T) {
 	tmpDir := setupRepoWithCheckpointBranch(t)
 	t.Chdir(tmpDir)
 
-	// Suppress the progress dots / warnings doPushBranch writes to os.Stderr.
 	restoreStderr := captureStderr(t)
 	defer restoreStderr()
 
-	// ssh:// URL so git invokes GIT_SSH_COMMAND (our hang) for the transport.
+	// ssh:// so git invokes GIT_SSH_COMMAND for the transport.
 	const target = "ssh://git@localhost/checkpoints.git"
 
 	start := time.Now()
@@ -53,12 +46,11 @@ func TestDoPushBranch_SharedBudget_BoundsTotalWallClock(t *testing.T) {
 
 	require.NoError(t, err, "doPushBranch degrades gracefully on a stuck transport")
 
-	// Upper bound: one shared budget. A per-attempt regression would land at ~2x; the
-	// hang script outlives this bound, so any failure to enforce the budget exceeds it.
+	// Upper bound: one shared budget; per-attempt regression would land at ~2x.
 	require.Less(t, elapsed, 5*time.Second,
 		"doPushBranch should return at ~budget, not stack multiple full timeouts; took %s", elapsed)
-	// Lower bound: confirm the push actually hung and was cut off by the budget, not
-	// failing instantly (which would make the upper bound meaningless).
+	// Lower bound: confirm the push hung and was cut off by the budget, not failing
+	// instantly (which would make the upper bound meaningless).
 	require.GreaterOrEqual(t, elapsed, budget/2,
 		"push should have run until the budget deadline; took %s", elapsed)
 }

--- a/cmd/entire/cli/strategy/push_common_budget_unix_test.go
+++ b/cmd/entire/cli/strategy/push_common_budget_unix_test.go
@@ -1,0 +1,64 @@
+//go:build unix
+
+package strategy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDoPushBranch_SharedBudget_BoundsTotalWallClock proves the whole checkpoint
+// push shares one deadline: a per-attempt timeout regression would let the initial
+// push, fetch+rebase, and retry each spend a full timeout (~2x the bound).
+//
+// A hanging GIT_SSH_COMMAND makes `git push` to an ssh:// URL block until the budget
+// SIGKILLs the process group; the script sleeps past the asserted bound so a
+// regression blows past it, and self-exits as a backstop.
+//
+// Not parallel: uses t.Setenv and overrides checkpointPushBudget.
+func TestDoPushBranch_SharedBudget_BoundsTotalWallClock(t *testing.T) {
+	// Shrink the production 60s budget so the test runs in seconds.
+	const budget = 2 * time.Second
+	restoreBudget := checkpointPushBudget
+	checkpointPushBudget = budget
+	t.Cleanup(func() { checkpointPushBudget = restoreBudget })
+
+	// Hangs past the asserted bound; git runs it for the ssh:// URL via GIT_SSH_COMMAND.
+	hangScript := filepath.Join(t.TempDir(), "hang.sh")
+	require.NoError(t, os.WriteFile(hangScript, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755))
+	t.Setenv("GIT_SSH_COMMAND", hangScript)
+	// With a token set, newCommand rewrites ssh:// to https:// and the hang never runs.
+	t.Setenv("ENTIRE_CHECKPOINT_TOKEN", "")
+
+	tmpDir := setupRepoWithCheckpointBranch(t)
+	t.Chdir(tmpDir)
+
+	// Suppress the progress dots / warnings doPushBranch writes to os.Stderr.
+	restoreStderr := captureStderr(t)
+	defer restoreStderr()
+
+	// ssh:// URL so git invokes GIT_SSH_COMMAND (our hang) for the transport.
+	const target = "ssh://git@localhost/checkpoints.git"
+
+	start := time.Now()
+	err := doPushBranch(context.Background(), target, paths.MetadataBranchName)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "doPushBranch degrades gracefully on a stuck transport")
+
+	// Upper bound: one shared budget. A per-attempt regression would land at ~2x; the
+	// hang script outlives this bound, so any failure to enforce the budget exceeds it.
+	require.Less(t, elapsed, 5*time.Second,
+		"doPushBranch should return at ~budget, not stack multiple full timeouts; took %s", elapsed)
+	// Lower bound: confirm the push actually hung and was cut off by the budget, not
+	// failing instantly (which would make the upper bound meaningless).
+	require.GreaterOrEqual(t, elapsed, budget/2,
+		"push should have run until the budget deadline; took %s", elapsed)
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/440
<!-- entire-trail-link-end -->

## Problem

A `git push`/`git fetch` over a custom transport (e.g. `entire://`) can hang the pre-push hook for ~an hour despite a 2-minute timeout. A `doctor trace` of a stuck checkpoint push:

```
push_checkpoints_branch        3,502,176ms
  ├─ fetch_and_rebase             13,695ms
  │  └─ git_fetch                 12,612ms
  ├─ git_push                      1,163ms  x
  └─ git_push~1                3,487,316ms  x   ← ~58 min
```

The context deadline SIGKILLs the `git` process, but the spawned remote-helper grandchild (e.g. `git-remote-entire`) keeps the output pipe open, so `cmd.CombinedOutput()` blocks until that helper finally exits.

## Fix

Harden every git subprocess built by `newCommand` (push / fetch / fetch-pack / ls-remote / cat-file):

- **WaitDelay backstop (all platforms):** after the process is killed, Go force-closes the pipes instead of waiting on a pipe-holding descendant.
- **Process-group kill (unix):** the child runs in its own process group and the whole group is SIGKILLed on cancellation, so the remote helper is terminated too rather than orphaned. Windows relies on the WaitDelay backstop (reliable process-tree kill there needs a Job Object, out of scope).

Turns "stuck forever" into a bounded failure: checkpoints stay saved locally and the user's own push proceeds.

## Testing

- Unit tests assert `newCommand` sets `WaitDelay` + a group-kill `Cancel` (unix `Setpgid`).
- A behavioral test reproduces the failure shape — a backgrounded grandchild holding the pipe — and confirms the group-kill terminates it promptly.
- Existing remote, strategy push/fetch/rebase, and integration remote tests pass.

## Notes

- The transport itself still hangs on the retry upload — that's the entiredb / `git-remote-entire` side; this PR just stops it from hanging the hook.
- The per-phase perf spans that produced the trace above are in a separate branch (`hooks-slow-push-db-mirror`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all checkpoint remote git invocations terminate on timeout/cancel; incorrect group kill could affect child processes, though scope is limited to the checkpoint remote package and is well-tested on Unix.
> 
> **Overview**
> Checkpoint git subprocesses built by `newCommand` (push, fetch, fetch-pack, ls-remote, cat-file) are **hardened** so context timeouts are not defeated by orphaned transport helpers.
> 
> Every such command gets a **10s `WaitDelay`** so `CombinedOutput`/`Wait` cannot block indefinitely on pipe-holding descendants after the parent is killed. On **Unix**, children run in their own process group with a custom **`Cancel` that SIGKILLs the whole group**, so helpers like `git-remote-entire` are torn down instead of keeping stdout open for tens of minutes. **Windows** only gets the `WaitDelay` backstop (process-tree kill deferred).
> 
> Unit and behavioral tests cover `WaitDelay`, group kill on Unix, and the pipe-holding grandchild scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36085bbad9891c192db2d14da6cffe6e4185cba1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->