### PR TITLE
Add entity-level checkpoint context

### DIFF
--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -311,6 +311,7 @@ Checkpoint detail view shows:
   - Author of the checkpoint
   - Associated git commits that reference the checkpoint
   - Prompts and responses from the session
+  - Semantic entity changes when the entire-sem plugin is installed
 
 Note: --session filters the list view; the positional arg, --commit, and --checkpoint are mutually exclusive.`,
 		Args: func(_ *cobra.Command, args []string) error {
@@ -707,6 +708,10 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 
 	// Find associated commits (git commits with matching Entire-Checkpoint trailer)
 	associatedCommits, _ := getAssociatedCommits(ctx, lookup.repo, fullCheckpointID, searchAll) //nolint:errcheck // Best-effort
+	semanticChanges := semanticDiffForAssociatedCommits(ctx, lookup.repo, associatedCommits)
+	if semanticChanges != nil {
+		semanticChanges.Checkpoint = fullCheckpointID.String()
+	}
 
 	// Derive author from the first associated commit (the user who made the commit).
 	// Fall back to the committed checkpoint store for checkpoints
@@ -724,7 +729,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// Format and output. Stop spinner BEFORE any write to w to keep stderr
 	// frames and stdout content from interleaving.
 	stopLoad(false)
-	output := formatCheckpointOutput(summary, content, fullCheckpointID, associatedCommits, author, verbose, full, w)
+	output := formatCheckpointOutput(summary, content, fullCheckpointID, associatedCommits, author, verbose, full, w, semanticChanges)
 	outputExplainContent(w, output, noPager)
 	return nil
 }
@@ -1678,7 +1683,7 @@ func renderExplainBody(w io.Writer, md string) string {
 //
 // Author is displayed when available (only for committed checkpoints).
 // Associated commits are git commits that reference this checkpoint via Entire-Checkpoint trailer.
-func formatCheckpointOutput(summary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, checkpointID id.CheckpointID, associatedCommits []associatedCommit, author checkpoint.Author, verbose, full bool, w io.Writer) string {
+func formatCheckpointOutput(summary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, checkpointID id.CheckpointID, associatedCommits []associatedCommit, author checkpoint.Author, verbose, full bool, w io.Writer, semanticChanges ...*semanticDiffResult) string {
 	var sb strings.Builder
 	meta := content.Metadata
 	styles := newStatusStyles(w)
@@ -1697,6 +1702,7 @@ func formatCheckpointOutput(summary *checkpoint.CheckpointSummary, content *chec
 
 	if meta.Summary != nil {
 		md := buildSummaryMarkdown(meta.Summary)
+		md += buildSemanticChangesMarkdown(firstSemanticResult(semanticChanges))
 		if verbose || full {
 			md += buildFilesMarkdown(meta.FilesTouched)
 		}
@@ -1721,6 +1727,7 @@ func formatCheckpointOutput(summary *checkpoint.CheckpointSummary, content *chec
 
 		hint := fmt.Sprintf("Not generated yet. Run `entire explain --generate %s` to create an AI summary.", checkpointID)
 		md := buildNoSummaryMarkdown(intent, files, hint)
+		md += buildSemanticChangesMarkdown(firstSemanticResult(semanticChanges))
 		sb.WriteString(renderExplainBody(w, md))
 	}
 
@@ -1736,6 +1743,13 @@ func formatCheckpointOutput(summary *checkpoint.CheckpointSummary, content *chec
 	}
 
 	return sb.String()
+}
+
+func firstSemanticResult(values []*semanticDiffResult) *semanticDiffResult {
+	if len(values) == 0 {
+		return nil
+	}
+	return values[0]
 }
 
 // appendTranscriptSection appends the appropriate transcript section to the builder

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -362,6 +362,7 @@ type checkpointExportJSON struct {
 	Branch           string                  `json:"branch,omitempty"`
 	CheckpointsCount int                     `json:"checkpoints_count"`
 	FilesTouched     []string                `json:"files_touched,omitempty"`
+	SemanticChanges  *semanticDiffResult     `json:"semantic_changes,omitempty"`
 	HasReview        bool                    `json:"has_review,omitempty"`
 	SessionCount     int                     `json:"session_count"`
 	Sessions         []checkpointSessionJSON `json:"sessions"`
@@ -421,6 +422,7 @@ func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts expla
 	}
 
 	envelope, failedSessions := buildCheckpointJSONEnvelope(ctx, store, summary, cpID)
+	envelope.SemanticChanges = semanticDiffForCheckpointID(ctx, lookup.repo, cpID, false)
 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/cmd/entire/cli/plugin_official.go
+++ b/cmd/entire/cli/plugin_official.go
@@ -10,8 +10,7 @@ import "slices"
 //
 //nolint:gochecknoglobals // package-level allowlist; mutated by tests via snapshot/restore.
 var officialPlugins = []string{
-	// Add Entire-shipped plugin names here as they're released.
-	// e.g. "pgr"
+	"sem",
 }
 
 func IsOfficialPlugin(name string) bool {

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -217,6 +217,7 @@ func runRewindInteractive(ctx context.Context, w, errW io.Writer) error { //noli
 		// Shadow checkpoint - no sha
 		fmt.Fprintf(w, "\nSelected: %s\n", sanitizeForTerminal(selectedPoint.Message))
 	}
+	printSemanticRewindPreview(ctx, w, *selectedPoint)
 
 	// Handle logs-only points with a sub-choice menu
 	if selectedPoint.IsLogsOnly {
@@ -440,6 +441,7 @@ func runRewindToInternal(ctx context.Context, w, errW io.Writer, commitID string
 	if selectedPoint == nil {
 		return fmt.Errorf("rewind point not found: %s", commitID)
 	}
+	printSemanticRewindPreview(ctx, w, *selectedPoint)
 
 	// Handle reset mode (for logs-only points)
 	if reset {

--- a/cmd/entire/cli/semantic.go
+++ b/cmd/entire/cli/semantic.go
@@ -1,0 +1,292 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+const (
+	semanticPluginBinary = "entire-sem"
+	semanticDisableEnv   = "ENTIRE_SEM_DISABLE"
+	semanticTimeout      = 8 * time.Second
+)
+
+var runSemanticPluginDiff = defaultRunSemanticPluginDiff
+
+type semanticDiffResult struct {
+	Checkpoint string               `json:"checkpoint,omitempty"`
+	Base       string               `json:"base"`
+	Head       string               `json:"head"`
+	Files      []semanticFileChange `json:"files"`
+}
+
+type semanticFileChange struct {
+	Path     string                 `json:"path"`
+	OldPath  string                 `json:"old_path,omitempty"`
+	Status   string                 `json:"status"`
+	Language string                 `json:"language,omitempty"`
+	Changes  []semanticEntityChange `json:"changes"`
+}
+
+type semanticEntityChange struct {
+	Type            string  `json:"type"`
+	Kind            string  `json:"kind"`
+	Name            string  `json:"name"`
+	OldName         string  `json:"old_name,omitempty"`
+	NewName         string  `json:"new_name,omitempty"`
+	OldSignature    string  `json:"old_signature,omitempty"`
+	NewSignature    string  `json:"new_signature,omitempty"`
+	BeforeStartLine int     `json:"before_start_line,omitempty"`
+	AfterStartLine  int     `json:"after_start_line,omitempty"`
+	DependentsCount int     `json:"dependents_count"`
+	Similarity      float64 `json:"similarity,omitempty"`
+}
+
+func semanticDiffForCheckpointID(ctx context.Context, repo *git.Repository, cpID id.CheckpointID, searchAll bool) *semanticDiffResult {
+	if os.Getenv(semanticDisableEnv) != "" {
+		return nil
+	}
+	commits, err := getAssociatedCommits(ctx, repo, cpID, searchAll)
+	if err != nil {
+		logging.Debug(ctx, "semantic changes: associated commit lookup failed",
+			slog.String("checkpoint_id", cpID.String()),
+			slog.String("error", err.Error()))
+		return nil
+	}
+	result := semanticDiffForAssociatedCommits(ctx, repo, commits)
+	if result != nil {
+		result.Checkpoint = cpID.String()
+	}
+	return result
+}
+
+func semanticDiffForAssociatedCommits(ctx context.Context, repo *git.Repository, commits []associatedCommit) *semanticDiffResult {
+	for _, commit := range commits {
+		result := semanticDiffForCommit(ctx, repo, commit.SHA)
+		if result != nil {
+			return result
+		}
+	}
+	return nil
+}
+
+func semanticDiffForRewindPoint(ctx context.Context, point strategy.RewindPoint) *semanticDiffResult {
+	if os.Getenv(semanticDisableEnv) != "" {
+		return nil
+	}
+	repo, err := openRepository(ctx)
+	if err != nil {
+		logging.Debug(ctx, "semantic changes: open repository failed", slog.String("error", err.Error()))
+		return nil
+	}
+	defer repo.Close()
+
+	if point.ID != "" {
+		if result := semanticDiffForCommit(ctx, repo, point.ID); result != nil {
+			return result
+		}
+	}
+	if !point.CheckpointID.IsEmpty() {
+		return semanticDiffForCheckpointID(ctx, repo, point.CheckpointID, false)
+	}
+	return nil
+}
+
+func semanticDiffForCommit(ctx context.Context, repo *git.Repository, sha string) *semanticDiffResult {
+	if sha == "" {
+		return nil
+	}
+	commit, err := repo.CommitObject(plumbing.NewHash(sha))
+	if err != nil {
+		logging.Debug(ctx, "semantic changes: commit lookup failed", slog.String("commit", sha), slog.String("error", err.Error()))
+		return nil
+	}
+	parent, err := commit.Parent(0)
+	if err != nil {
+		logging.Debug(ctx, "semantic changes: commit has no first parent", slog.String("commit", sha), slog.String("error", err.Error()))
+		return nil
+	}
+	result, err := runSemanticPluginDiff(ctx, parent.Hash.String(), commit.Hash.String())
+	if err != nil {
+		logging.Debug(ctx, "semantic changes: plugin diff failed", slog.String("commit", sha), slog.String("error", err.Error()))
+		return nil
+	}
+	if result == nil || len(result.Files) == 0 {
+		return nil
+	}
+	return result
+}
+
+func defaultRunSemanticPluginDiff(ctx context.Context, base, head string) (*semanticDiffResult, error) {
+	pluginPath, ok := findSemanticPlugin()
+	if !ok {
+		return nil, nil
+	}
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, semanticTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(timeoutCtx, pluginPath, "diff", "--base", base, "--head", head, "--json", "--repo", repoRoot)
+	cmd.Dir = repoRoot
+	cmd.Env = semanticPluginEnv(repoRoot)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = err.Error()
+		}
+		return nil, fmt.Errorf("%s: %s", filepath.Base(pluginPath), detail)
+	}
+
+	var result semanticDiffResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("parse semantic plugin json: %w", err)
+	}
+	return &result, nil
+}
+
+func findSemanticPlugin() (string, bool) {
+	if path, err := exec.LookPath(semanticPluginBinary); err == nil {
+		return path, true
+	}
+	if dir, err := PluginBinDir(); err == nil {
+		candidate := filepath.Join(dir, executableName(semanticPluginBinary))
+		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func executableName(name string) string {
+	if runtime.GOOS == windowsGOOS && !strings.HasSuffix(strings.ToLower(name), ".exe") {
+		return name + ".exe"
+	}
+	return name
+}
+
+func semanticPluginEnv(repoRoot string) []string {
+	extras := []string{
+		"ENTIRE_REPO_ROOT=" + repoRoot,
+		"ENTIRE_CLI_VERSION=" + versioninfo.Version,
+		semanticDisableEnv + "=1",
+	}
+	if dataDir, err := PluginDataDir("sem"); err == nil {
+		extras = append(extras, pluginEnvPluginData+"="+dataDir)
+	}
+	return pluginEnv(os.Environ(), extras...)
+}
+
+func buildSemanticChangesMarkdown(result *semanticDiffResult) string {
+	if result == nil || len(result.Files) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("\n## Semantic Changes\n\n")
+	for _, file := range result.Files {
+		if file.OldPath != "" && file.OldPath != file.Path {
+			fmt.Fprintf(&sb, "`%s -> %s`", escapeInlineCodeText(file.OldPath), escapeInlineCodeText(file.Path))
+		} else {
+			fmt.Fprintf(&sb, "`%s`", escapeInlineCodeText(file.Path))
+		}
+		if file.Language != "" {
+			fmt.Fprintf(&sb, " _%s_", escapeSummaryText(file.Language))
+		}
+		sb.WriteString("\n\n")
+		for _, change := range file.Changes {
+			fmt.Fprintf(&sb, "- %s\n", escapeSummaryText(semanticChangeText(change)))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func semanticChangeText(change semanticEntityChange) string {
+	dependents := semanticDependentsSuffix(change)
+	switch change.Type {
+	case "added":
+		return fmt.Sprintf("+ %s %s added", change.Kind, change.Name)
+	case "removed":
+		return fmt.Sprintf("- %s %s removed%s", change.Kind, change.Name, dependents)
+	case "renamed":
+		return fmt.Sprintf("~ %s %s renamed from %s%s", change.Kind, firstNonEmpty(change.NewName, change.Name), change.OldName, dependents)
+	case "signature_changed":
+		return fmt.Sprintf("~ %s %s signature changed%s", change.Kind, change.Name, dependents)
+	case "body_changed":
+		return fmt.Sprintf("~ %s %s body changed%s", change.Kind, change.Name, dependents)
+	default:
+		return fmt.Sprintf("~ %s %s changed%s", change.Kind, change.Name, dependents)
+	}
+}
+
+func semanticDependentsSuffix(change semanticEntityChange) string {
+	if change.Type == "added" {
+		return ""
+	}
+	if change.DependentsCount == 1 {
+		return " (1 dependent)"
+	}
+	return fmt.Sprintf(" (%d dependents)", change.DependentsCount)
+}
+
+func semanticPreviewLines(result *semanticDiffResult, limit int) []string {
+	if result == nil || limit <= 0 {
+		return nil
+	}
+	var lines []string
+	for _, file := range result.Files {
+		for _, change := range file.Changes {
+			lines = append(lines, fmt.Sprintf("%s: %s", file.Path, semanticChangeText(change)))
+			if len(lines) >= limit {
+				return lines
+			}
+		}
+	}
+	return lines
+}
+
+func printSemanticRewindPreview(ctx context.Context, w io.Writer, point strategy.RewindPoint) {
+	lines := semanticPreviewLines(semanticDiffForRewindPoint(ctx, point), 5)
+	if len(lines) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "\nSemantic changes:")
+	for _, line := range lines {
+		fmt.Fprintf(w, "  - %s\n", line)
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/cmd/entire/cli/semantic_test.go
+++ b/cmd/entire/cli/semantic_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+)
+
+func TestBuildSemanticChangesMarkdown(t *testing.T) {
+	result := &semanticDiffResult{
+		Base: "HEAD~1",
+		Head: "HEAD",
+		Files: []semanticFileChange{{
+			Path:     "auth.py",
+			Language: "Python",
+			Changes: []semanticEntityChange{{
+				Type:            "signature_changed",
+				Kind:            "function",
+				Name:            "validate_token",
+				DependentsCount: 14,
+			}},
+		}},
+	}
+
+	got := buildSemanticChangesMarkdown(result)
+	for _, want := range []string{
+		"## Semantic Changes",
+		"`auth.py` _Python_",
+		"validate_token signature changed (14 dependents)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("markdown missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatCheckpointOutputIncludesSemanticChanges(t *testing.T) {
+	content := &checkpoint.SessionContent{
+		Metadata: checkpoint.CommittedMetadata{
+			SessionID:    "session-1",
+			FilesTouched: []string{"auth.py"},
+		},
+		Prompts: "update auth",
+	}
+	semantic := &semanticDiffResult{
+		Base: "HEAD~1",
+		Head: "HEAD",
+		Files: []semanticFileChange{{
+			Path: "auth.py",
+			Changes: []semanticEntityChange{{
+				Type:            "renamed",
+				Kind:            "function",
+				Name:            "format_date",
+				OldName:         "format_dt",
+				NewName:         "format_date",
+				DependentsCount: 0,
+			}},
+		}},
+	}
+
+	output := formatCheckpointOutput(nil, content, id.MustCheckpointID("abc123def456"), nil, checkpoint.Author{}, false, false, &bytes.Buffer{}, semantic)
+	if !strings.Contains(output, "## Semantic Changes") {
+		t.Fatalf("output missing semantic section:\n%s", output)
+	}
+	if !strings.Contains(output, "format_date renamed from format_dt (0 dependents)") {
+		t.Fatalf("output missing semantic rename:\n%s", output)
+	}
+}
+
+func TestRunSemanticPluginDiffGracefullyHandlesMissingPlugin(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv(pluginEnvPluginDir, t.TempDir())
+	result, err := defaultRunSemanticPluginDiff(context.Background(), "HEAD~1", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != nil {
+		t.Fatalf("result = %#v, want nil", result)
+	}
+}
+
+func TestSemanticRewindPreviewSkipsPluginFailure(t *testing.T) {
+	oldRunner := runSemanticPluginDiff
+	runSemanticPluginDiff = func(context.Context, string, string) (*semanticDiffResult, error) {
+		return nil, errors.New("boom")
+	}
+	defer func() { runSemanticPluginDiff = oldRunner }()
+
+	t.Setenv(semanticDisableEnv, "1")
+	var out bytes.Buffer
+	printSemanticRewindPreview(context.Background(), &out, strategy.RewindPoint{ID: "abc123"})
+	if out.Len() != 0 {
+		t.Fatalf("preview wrote output despite disabled semantic integration: %q", out.String())
+	}
+}
+
+func TestSemanticPluginEnvDisablesRecursiveSemanticBridge(t *testing.T) {
+	env := semanticPluginEnv(t.TempDir())
+	if !envContains(env, semanticDisableEnv+"=1") {
+		t.Fatalf("semantic plugin env missing %s=1", semanticDisableEnv)
+	}
+}
+
+func envContains(env []string, want string) bool {
+	for _, item := range env {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/entire-sem/.gitignore
+++ b/entire-sem/.gitignore
@@ -1,0 +1,2 @@
+/entire-sem
+/dist/

--- a/entire-sem/LICENSE
+++ b/entire-sem/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Suhaan Thayyil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/entire-sem/README.md
+++ b/entire-sem/README.md
@@ -1,0 +1,104 @@
+# Entire Sem
+
+`entire-sem` is an Entire CLI plugin for entity-level checkpoint context.
+
+Entire already knows a checkpoint touched `auth.py`. This plugin answers the next question:
+which functions, classes, types, or methods changed inside that file?
+
+Once built as `entire-sem` and installed as an Entire plugin, it is invoked as:
+
+```sh
+entire sem commit HEAD
+entire sem checkpoint abc123def456
+entire sem diff --base HEAD~1 --head HEAD
+entire sem analyze --json
+```
+
+## Status
+
+This plugin implements the semantic checkpoint context proposed in
+[entireio/cli#589](https://github.com/entireio/cli/issues/589). It intentionally
+does not vendor or copy Ataraxy Labs' `inspect` / `sem` projects.
+
+The MVP uses a tree-sitter-backed parser for:
+
+- Go
+- Python
+- JavaScript / TypeScript
+- Rust
+
+The parser is isolated behind `internal/sem`, so the command surface can stay stable
+while the semantic model gets richer.
+
+## Install Locally
+
+```sh
+cd entire-sem
+mise run build
+entire plugin install ./entire-sem --force
+```
+
+## Commands
+
+Compare one commit against its first parent:
+
+```sh
+entire sem commit HEAD
+```
+
+Compare two arbitrary refs:
+
+```sh
+entire sem diff --base main --head HEAD
+```
+
+Emit JSON:
+
+```sh
+entire sem diff --base main --head HEAD --json
+```
+
+Analyze the commit associated with an Entire checkpoint trailer:
+
+```sh
+entire sem checkpoint abc123def456
+```
+
+Run without installing through Entire:
+
+```sh
+ENTIRE_REPO_ROOT=/path/to/repo ./entire-sem diff --base HEAD~1 --head HEAD
+```
+
+## Example Output
+
+```text
+Semantic changes HEAD~1..HEAD
+
+auth.py
+  ~ function validate_token signature changed (14 dependents)
+  + class TokenClaims added
+  - function parse_token removed (0 dependents)
+```
+
+## Why This Exists
+
+Issue [entireio/cli#589](https://github.com/entireio/cli/issues/589) proposes showing
+checkpoint context at the entity level instead of stopping at "this file changed."
+`entire-sem` is a plugin-shaped implementation of that idea:
+
+- parse the before and after git trees with tree-sitter
+- extract named entities like functions, classes, methods, structs, traits, and types
+- compare signatures and normalized bodies
+- build a heuristic dependent count from parsed references in the target tree
+- report added, removed, renamed, signature-changed, and body-changed entities
+
+The implementation does not copy or vendor Ataraxy Labs code. The parser dependency is
+`github.com/smacker/go-tree-sitter`, which is MIT-licensed.
+
+## Current Limits
+
+- Dependent counts are heuristic, not compiler/type-checker accurate.
+- Rename detection is heuristic.
+- Native `entire explain` / `entire rewind` rendering requires the matching Entire CLI
+  bridge that invokes this plugin when it is installed.

--- a/entire-sem/README.md
+++ b/entire-sem/README.md
@@ -2,8 +2,8 @@
 
 `entire-sem` is an Entire CLI plugin for entity-level checkpoint context.
 
-Entire already knows a checkpoint touched `auth.py`. This plugin answers the next question:
-which functions, classes, types, or methods changed inside that file?
+Entire already knows a checkpoint touched `auth.py` or `.github/workflows/ci.yml`.
+This plugin answers the next question: which semantic entities changed inside that file?
 
 Once built as `entire-sem` and installed as an Entire plugin, it is invoked as:
 
@@ -26,6 +26,7 @@ The MVP uses a tree-sitter-backed parser for:
 - Python
 - JavaScript / TypeScript
 - Rust
+- YAML, including GitHub Actions workflow sections and jobs
 
 The parser is isolated behind `internal/sem`, so the command surface can stay stable
 while the semantic model gets richer.
@@ -88,7 +89,8 @@ checkpoint context at the entity level instead of stopping at "this file changed
 `entire-sem` is a plugin-shaped implementation of that idea:
 
 - parse the before and after git trees with tree-sitter
-- extract named entities like functions, classes, methods, structs, traits, and types
+- extract named entities like functions, classes, methods, structs, traits, types,
+  YAML workflow sections, and GitHub Actions jobs
 - compare signatures and normalized bodies
 - build a heuristic dependent count from parsed references in the target tree
 - report added, removed, renamed, signature-changed, and body-changed entities

--- a/entire-sem/cmd/entire-sem/main.go
+++ b/entire-sem/cmd/entire-sem/main.go
@@ -1,0 +1,21 @@
+// entire-sem is an Entire CLI external command.
+//
+// Once built as an executable named `entire-sem`, the parent Entire CLI
+// dispatches it when a user runs `entire sem`.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/entireio/cli/entire-sem/internal/cli"
+)
+
+var version = "dev"
+
+func main() {
+	if err := cli.Execute(version, os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/entire-sem/go.mod
+++ b/entire-sem/go.mod
@@ -1,0 +1,5 @@
+module github.com/entireio/cli/entire-sem
+
+go 1.24
+
+require github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82

--- a/entire-sem/go.sum
+++ b/entire-sem/go.sum
@@ -1,0 +1,2 @@
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f1bStuePVkLSFxoU22XBS165D3klxlzRg8F4=
+github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=

--- a/entire-sem/internal/cli/env.go
+++ b/entire-sem/internal/cli/env.go
@@ -1,0 +1,32 @@
+package cli
+
+import "os"
+
+const (
+	envCLIVersion    = "ENTIRE_CLI_VERSION"
+	envRepoRoot      = "ENTIRE_REPO_ROOT"
+	envPluginDataDir = "ENTIRE_PLUGIN_DATA_DIR"
+)
+
+// EntireEnv captures environment variables supplied by Entire when it dispatches
+// an external plugin command.
+type EntireEnv struct {
+	CLIVersion    string
+	RepoRoot      string
+	PluginDataDir string
+}
+
+func EnvFromOS() EntireEnv {
+	return EntireEnv{
+		CLIVersion:    os.Getenv(envCLIVersion),
+		RepoRoot:      os.Getenv(envRepoRoot),
+		PluginDataDir: os.Getenv(envPluginDataDir),
+	}
+}
+
+func valueOrUnset(value string) string {
+	if value == "" {
+		return "<unset>"
+	}
+	return value
+}

--- a/entire-sem/internal/cli/root.go
+++ b/entire-sem/internal/cli/root.go
@@ -1,0 +1,232 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/entireio/cli/entire-sem/internal/gitutil"
+	"github.com/entireio/cli/entire-sem/internal/sem"
+)
+
+type Options struct {
+	Version string
+	Env     EntireEnv
+	Stdout  io.Writer
+	Stderr  io.Writer
+}
+
+func Execute(version string, args []string) error {
+	return Run(context.Background(), Options{
+		Version: version,
+		Env:     EnvFromOS(),
+		Stdout:  os.Stdout,
+		Stderr:  os.Stderr,
+	}, args)
+}
+
+func Run(ctx context.Context, opts Options, args []string) error {
+	if opts.Version == "" {
+		opts.Version = "dev"
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = io.Discard
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = io.Discard
+	}
+
+	if len(args) == 0 {
+		printHelp(opts.Stdout)
+		return nil
+	}
+
+	switch args[0] {
+	case "diff":
+		return runDiff(ctx, opts, args[1:])
+	case "commit":
+		return runCommit(ctx, opts, args[1:])
+	case "checkpoint":
+		return runCheckpoint(ctx, opts, args[1:])
+	case "analyze":
+		return runAnalyze(ctx, opts, args[1:])
+	case "doctor":
+		return runDoctor(opts)
+	case "version", "--version", "-v":
+		fmt.Fprintln(opts.Stdout, opts.Version)
+		return nil
+	case "help", "--help", "-h":
+		printHelp(opts.Stdout)
+		return nil
+	default:
+		return fmt.Errorf("unknown command %q", args[0])
+	}
+}
+
+func printHelp(out io.Writer) {
+	fmt.Fprintln(out, `entire-sem adds entity-level context to Entire checkpoints.
+
+Usage:
+  entire sem commit [rev] [--json] [--repo path]
+  entire sem checkpoint <checkpoint-id> [--json] [--repo path]
+  entire sem diff --base <rev> --head <rev> [--json] [--repo path] [-- path...]
+  entire sem analyze [--base <rev>] [--head <rev>] [--json] [--repo path] [-- path...]
+  entire sem doctor
+  entire sem version`)
+}
+
+func runDoctor(opts Options) error {
+	fmt.Fprintf(opts.Stdout, "ENTIRE_CLI_VERSION=%s\n", valueOrUnset(opts.Env.CLIVersion))
+	fmt.Fprintf(opts.Stdout, "ENTIRE_REPO_ROOT=%s\n", valueOrUnset(opts.Env.RepoRoot))
+	fmt.Fprintf(opts.Stdout, "ENTIRE_PLUGIN_DATA_DIR=%s\n", valueOrUnset(opts.Env.PluginDataDir))
+	repo, err := resolveRepo(context.Background(), opts.Env, "")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(opts.Stdout, "repo_root=%s\n", repo)
+	return nil
+}
+
+type commonFlags struct {
+	Repo string
+	JSON bool
+}
+
+func parseCommonFlags(args []string) (commonFlags, []string, error) {
+	var flags commonFlags
+	var rest []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--json":
+			flags.JSON = true
+		case "--repo":
+			i++
+			if i >= len(args) {
+				return flags, nil, errors.New("--repo requires a value")
+			}
+			flags.Repo = args[i]
+		case "--":
+			rest = append(rest, args[i+1:]...)
+			return flags, rest, nil
+		default:
+			rest = append(rest, arg)
+		}
+	}
+	return flags, rest, nil
+}
+
+func runCommit(ctx context.Context, opts Options, args []string) error {
+	flags, rest, err := parseCommonFlags(args)
+	if err != nil {
+		return err
+	}
+	rev := "HEAD"
+	if len(rest) > 0 {
+		rev = rest[0]
+	}
+	if len(rest) > 1 {
+		return errors.New("commit accepts at most one revision")
+	}
+	repo, err := resolveRepo(ctx, opts.Env, flags.Repo)
+	if err != nil {
+		return err
+	}
+	base, err := gitutil.FirstParent(ctx, repo, rev)
+	if err != nil {
+		return err
+	}
+	return analyzeAndPrint(ctx, opts.Stdout, repo, base, rev, nil, flags.JSON)
+}
+
+func runCheckpoint(ctx context.Context, opts Options, args []string) error {
+	flags, rest, err := parseCommonFlags(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 1 {
+		return errors.New("checkpoint requires exactly one checkpoint ID")
+	}
+	repo, err := resolveRepo(ctx, opts.Env, flags.Repo)
+	if err != nil {
+		return err
+	}
+	result, err := sem.AnalyzeCheckpoint(ctx, repo, rest[0])
+	if err != nil {
+		return err
+	}
+	return printResult(opts.Stdout, result, flags.JSON)
+}
+
+func runAnalyze(ctx context.Context, opts Options, args []string) error {
+	return runDiff(ctx, opts, args)
+}
+
+func runDiff(ctx context.Context, opts Options, args []string) error {
+	flags, rest, err := parseCommonFlags(args)
+	if err != nil {
+		return err
+	}
+
+	base := "HEAD~1"
+	head := "HEAD"
+	var paths []string
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case "--base":
+			i++
+			if i >= len(rest) {
+				return errors.New("--base requires a value")
+			}
+			base = rest[i]
+		case "--head":
+			i++
+			if i >= len(rest) {
+				return errors.New("--head requires a value")
+			}
+			head = rest[i]
+		default:
+			paths = append(paths, rest[i])
+		}
+	}
+
+	repo, err := resolveRepo(ctx, opts.Env, flags.Repo)
+	if err != nil {
+		return err
+	}
+	return analyzeAndPrint(ctx, opts.Stdout, repo, base, head, paths, flags.JSON)
+}
+
+func resolveRepo(ctx context.Context, env EntireEnv, explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if env.RepoRoot != "" {
+		return env.RepoRoot, nil
+	}
+	return gitutil.RepoRoot(ctx, ".")
+}
+
+func analyzeAndPrint(ctx context.Context, out io.Writer, repo, base, head string, paths []string, asJSON bool) error {
+	result, err := sem.AnalyzeGitRange(ctx, repo, base, head, paths)
+	if err != nil {
+		return err
+	}
+	return printResult(out, result, asJSON)
+}
+
+func printResult(out io.Writer, result sem.Result, asJSON bool) error {
+	if asJSON {
+		encoded, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(out, string(encoded))
+		return nil
+	}
+	sem.WriteText(out, result)
+	return nil
+}

--- a/entire-sem/internal/cli/root_test.go
+++ b/entire-sem/internal/cli/root_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoctorPrintsEntireEnvironment(t *testing.T) {
+	var out bytes.Buffer
+	err := Run(t.Context(), Options{
+		Env: EntireEnv{
+			CLIVersion:    "0.6.3",
+			RepoRoot:      t.TempDir(),
+			PluginDataDir: t.TempDir(),
+		},
+		Stdout: &out,
+		Stderr: &out,
+	}, []string{"doctor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"ENTIRE_CLI_VERSION=0.6.3", "ENTIRE_REPO_ROOT=", "ENTIRE_PLUGIN_DATA_DIR=", "repo_root="} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestAnalyzeJSONCommand(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+	write(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	write(t, repo, "auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "update")
+
+	var out bytes.Buffer
+	err := Run(t.Context(), Options{
+		Env:    EntireEnv{RepoRoot: repo},
+		Stdout: &out,
+		Stderr: &out,
+	}, []string{"analyze", "--json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"dependents_count"`) {
+		t.Fatalf("analyze json missing dependents_count:\n%s", out.String())
+	}
+}
+
+func write(t *testing.T, repo, path, content string) {
+	t.Helper()
+	full := filepath.Join(repo, path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func git(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/entire-sem/internal/gitutil/git.go
+++ b/entire-sem/internal/gitutil/git.go
@@ -1,0 +1,119 @@
+package gitutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type ChangedFile struct {
+	Status  string `json:"status"`
+	Path    string `json:"path"`
+	OldPath string `json:"old_path,omitempty"`
+}
+
+func RepoRoot(ctx context.Context, cwd string) (string, error) {
+	out, err := run(ctx, cwd, "git", "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func FirstParent(ctx context.Context, repo, rev string) (string, error) {
+	out, err := run(ctx, repo, "git", "rev-parse", rev+"^")
+	if err != nil {
+		return "", fmt.Errorf("resolve first parent for %s: %w", rev, err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func FindCommitWithCheckpoint(ctx context.Context, repo, checkpointID string) (string, error) {
+	out, err := run(ctx, repo, "git", "log", "--all", "--format=%H", "-n", "1", "--grep=Entire-Checkpoint: "+checkpointID)
+	if err != nil {
+		return "", err
+	}
+	commit := strings.TrimSpace(out)
+	if commit == "" {
+		return "", fmt.Errorf("checkpoint %s has no associated commit in this repository", checkpointID)
+	}
+	return commit, nil
+}
+
+func ListFiles(ctx context.Context, repo, rev string) ([]string, error) {
+	out, err := run(ctx, repo, "git", "ls-tree", "-r", "--name-only", rev)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}
+
+func ChangedFiles(ctx context.Context, repo, base, head string, paths []string) ([]ChangedFile, error) {
+	args := []string{"diff", "--name-status", "--find-renames", base, head, "--"}
+	args = append(args, paths...)
+	out, err := run(ctx, repo, "git", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []ChangedFile
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			continue
+		}
+		status := fields[0]
+		switch {
+		case strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C"):
+			if len(fields) >= 3 {
+				files = append(files, ChangedFile{Status: status[:1], OldPath: fields[1], Path: fields[2]})
+			}
+		default:
+			files = append(files, ChangedFile{Status: status[:1], Path: fields[1]})
+		}
+	}
+	return files, nil
+}
+
+func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error) {
+	out, err := run(ctx, repo, "git", "show", rev+":"+path)
+	if err != nil {
+		if strings.Contains(err.Error(), "exists on disk, but not in") ||
+			strings.Contains(err.Error(), "Path") ||
+			strings.Contains(err.Error(), "does not exist") ||
+			strings.Contains(err.Error(), "not found") {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return out, true, nil
+}
+
+func run(ctx context.Context, dir, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("%s %s: %s", name, strings.Join(args, " "), msg)
+	}
+	return stdout.String(), nil
+}

--- a/entire-sem/internal/sem/analyze.go
+++ b/entire-sem/internal/sem/analyze.go
@@ -1,0 +1,263 @@
+package sem
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/entireio/cli/entire-sem/internal/gitutil"
+)
+
+func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []string) (Result, error) {
+	changed, err := gitutil.ChangedFiles(ctx, repo, base, head, paths)
+	if err != nil {
+		return Result{}, err
+	}
+	parser := TreeSitterParser{}
+	result := Result{Base: base, Head: head}
+	for _, file := range changed {
+		path := file.Path
+		oldPath := file.OldPath
+		if oldPath == "" {
+			oldPath = path
+		}
+		if !Supported(path) && !Supported(oldPath) {
+			continue
+		}
+
+		var before, after string
+		var beforeOK, afterOK bool
+		if file.Status != "A" {
+			before, beforeOK, err = gitutil.ShowFile(ctx, repo, base, oldPath)
+			if err != nil {
+				return Result{}, err
+			}
+		}
+		if file.Status != "D" {
+			after, afterOK, err = gitutil.ShowFile(ctx, repo, head, path)
+			if err != nil {
+				return Result{}, err
+			}
+		}
+
+		beforeEntities, language := parser.Parse(oldPath, before)
+		afterEntities, afterLanguage := parser.Parse(path, after)
+		if language == "" {
+			language = afterLanguage
+		}
+		if !beforeOK {
+			beforeEntities = nil
+		}
+		if !afterOK {
+			afterEntities = nil
+		}
+
+		changes := Compare(beforeEntities, afterEntities)
+		if len(changes) == 0 {
+			continue
+		}
+		result.Files = append(result.Files, FileChange{
+			Path:     path,
+			OldPath:  file.OldPath,
+			Status:   file.Status,
+			Language: language,
+			Changes:  changes,
+		})
+	}
+	if err := addDependentCounts(ctx, repo, head, &result); err != nil {
+		return Result{}, err
+	}
+	return result, nil
+}
+
+func AnalyzeCheckpoint(ctx context.Context, repo, checkpointID string) (Result, error) {
+	head, err := gitutil.FindCommitWithCheckpoint(ctx, repo, checkpointID)
+	if err != nil {
+		return Result{}, err
+	}
+	base, err := gitutil.FirstParent(ctx, repo, head)
+	if err != nil {
+		return Result{}, err
+	}
+	result, err := AnalyzeGitRange(ctx, repo, base, head, nil)
+	if err != nil {
+		return Result{}, err
+	}
+	result.Checkpoint = checkpointID
+	return result, nil
+}
+
+func Compare(before, after []Entity) []EntityChange {
+	beforeByKey := map[string]Entity{}
+	afterByKey := map[string]Entity{}
+	for _, entity := range before {
+		beforeByKey[key(entity)] = entity
+	}
+	for _, entity := range after {
+		afterByKey[key(entity)] = entity
+	}
+
+	var changes []EntityChange
+	deleted := map[string]Entity{}
+	added := map[string]Entity{}
+
+	for key, oldEntity := range beforeByKey {
+		newEntity, ok := afterByKey[key]
+		if !ok {
+			deleted[key] = oldEntity
+			continue
+		}
+		switch {
+		case oldEntity.Signature != newEntity.Signature:
+			changes = append(changes, EntityChange{
+				Type:            "signature_changed",
+				Kind:            oldEntity.Kind,
+				Name:            oldEntity.Name,
+				OldSignature:    oldEntity.Signature,
+				NewSignature:    newEntity.Signature,
+				BeforeStartLine: oldEntity.StartLine,
+				AfterStartLine:  newEntity.StartLine,
+			})
+		case oldEntity.BodyHash != newEntity.BodyHash:
+			changes = append(changes, EntityChange{
+				Type:            "body_changed",
+				Kind:            oldEntity.Kind,
+				Name:            oldEntity.Name,
+				BeforeStartLine: oldEntity.StartLine,
+				AfterStartLine:  newEntity.StartLine,
+			})
+		}
+	}
+	for key, newEntity := range afterByKey {
+		if _, ok := beforeByKey[key]; !ok {
+			added[key] = newEntity
+		}
+	}
+
+	for oldKey, oldEntity := range deleted {
+		bestKey, bestEntity, score := bestRename(oldEntity, added)
+		if score >= 0.92 {
+			delete(deleted, oldKey)
+			delete(added, bestKey)
+			changes = append(changes, EntityChange{
+				Type:            "renamed",
+				Kind:            oldEntity.Kind,
+				Name:            bestEntity.Name,
+				OldName:         oldEntity.Name,
+				NewName:         bestEntity.Name,
+				OldSignature:    oldEntity.Signature,
+				NewSignature:    bestEntity.Signature,
+				BeforeStartLine: oldEntity.StartLine,
+				AfterStartLine:  bestEntity.StartLine,
+				Similarity:      score,
+			})
+		}
+	}
+
+	for _, oldEntity := range deleted {
+		changes = append(changes, EntityChange{
+			Type:            "removed",
+			Kind:            oldEntity.Kind,
+			Name:            oldEntity.Name,
+			OldSignature:    oldEntity.Signature,
+			BeforeStartLine: oldEntity.StartLine,
+		})
+	}
+	for _, newEntity := range added {
+		changes = append(changes, EntityChange{
+			Type:           "added",
+			Kind:           newEntity.Kind,
+			Name:           newEntity.Name,
+			NewSignature:   newEntity.Signature,
+			AfterStartLine: newEntity.StartLine,
+		})
+	}
+
+	sort.Slice(changes, func(i, j int) bool {
+		left := lineForSort(changes[i])
+		right := lineForSort(changes[j])
+		if left == right {
+			return fmt.Sprintf("%s:%s", changes[i].Kind, changes[i].Name) < fmt.Sprintf("%s:%s", changes[j].Kind, changes[j].Name)
+		}
+		return left < right
+	})
+	return changes
+}
+
+func key(entity Entity) string {
+	return entity.Kind + ":" + entity.Name
+}
+
+func lineForSort(change EntityChange) int {
+	if change.AfterStartLine > 0 {
+		return change.AfterStartLine
+	}
+	return change.BeforeStartLine
+}
+
+func bestRename(old Entity, added map[string]Entity) (string, Entity, float64) {
+	var bestKey string
+	var best Entity
+	var bestScore float64
+	for key, candidate := range added {
+		if candidate.Kind != old.Kind {
+			continue
+		}
+		score := similarity(old, candidate)
+		if score > bestScore {
+			bestKey = key
+			best = candidate
+			bestScore = score
+		}
+	}
+	return bestKey, best, bestScore
+}
+
+func similarity(a, b Entity) float64 {
+	if a.Fingerprint != "" && a.Fingerprint == b.Fingerprint {
+		return 1
+	}
+	if a.BodyHash != "" && a.BodyHash == b.BodyHash {
+		return 0.97
+	}
+	return jaccard(a.Signature, b.Signature)
+}
+
+func jaccard(a, b string) float64 {
+	left := tokenSet(a)
+	right := tokenSet(b)
+	if len(left) == 0 && len(right) == 0 {
+		return 1
+	}
+	var intersection int
+	for token := range left {
+		if right[token] {
+			intersection++
+		}
+	}
+	union := len(left) + len(right) - intersection
+	if union == 0 {
+		return 0
+	}
+	return math.Round((float64(intersection)/float64(union))*100) / 100
+}
+
+func tokenSet(value string) map[string]bool {
+	out := map[string]bool{}
+	token := ""
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			token += string(r)
+			continue
+		}
+		if token != "" {
+			out[token] = true
+			token = ""
+		}
+	}
+	if token != "" {
+		out[token] = true
+	}
+	return out
+}

--- a/entire-sem/internal/sem/analyze_test.go
+++ b/entire-sem/internal/sem/analyze_test.go
@@ -1,0 +1,138 @@
+package sem
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestAnalyzeGitRange(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+
+	write(t, repo, "auth.py", `def validate_token(token):
+    return bool(token)
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "auth.py", `def validate_token(token, *, issuer=None):
+    return bool(token)
+
+def format_date(value):
+    return str(value)
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "semantic change")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("files = %#v", result.Files)
+	}
+	if len(result.Files[0].Changes) != 2 {
+		t.Fatalf("changes = %#v", result.Files[0].Changes)
+	}
+}
+
+func TestAnalyzeGitRangeDependentCounts(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+
+	write(t, repo, "auth.py", `def validate_token(token):
+    return bool(token)
+`)
+	write(t, repo, "use_auth.py", `def check(token):
+    return validate_token(token)
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "auth.py", `def validate_token(token, *, issuer=None):
+    return bool(token)
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "semantic change")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range result.Files {
+		for _, change := range file.Changes {
+			if change.Name == "validate_token" && change.DependentsCount != 1 {
+				t.Fatalf("dependents = %d, want 1 in %#v", change.DependentsCount, change)
+			}
+		}
+	}
+}
+
+func TestAnalyzeCheckpointResolvesAssociatedCommit(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+
+	write(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	write(t, repo, "auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "agent update\n\nEntire-Checkpoint: abc123def456")
+
+	result, err := AnalyzeCheckpoint(context.Background(), repo, "abc123def456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Checkpoint != "abc123def456" {
+		t.Fatalf("checkpoint = %q", result.Checkpoint)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("files = %#v", result.Files)
+	}
+}
+
+func write(t *testing.T, repo, path, content string) {
+	t.Helper()
+	full := filepath.Join(repo, path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func git(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func rev(t *testing.T, repo, value string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", value)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse %s: %v\n%s", value, err, out)
+	}
+	return string(out[:len(out)-1])
+}

--- a/entire-sem/internal/sem/analyze_test.go
+++ b/entire-sem/internal/sem/analyze_test.go
@@ -79,6 +79,73 @@ func TestAnalyzeGitRangeDependentCounts(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGitRangeIncludesGitHubWorkflowYAML(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+
+	write(t, repo, ".github/workflows/ci.yml", `name: CI
+on:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: go test ./...
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, ".github/workflows/ci.yml", `name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: go test -race ./...
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "update workflow")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("files = %#v", result.Files)
+	}
+	file := result.Files[0]
+	if file.Path != ".github/workflows/ci.yml" {
+		t.Fatalf("path = %q", file.Path)
+	}
+	if file.Language != "YAML" {
+		t.Fatalf("language = %q", file.Language)
+	}
+
+	var sawJob bool
+	var sawTrigger bool
+	for _, change := range file.Changes {
+		if change.Type == "body_changed" && change.Kind == "job" && change.Name == "jobs.test" {
+			sawJob = true
+		}
+		if change.Type == "body_changed" && change.Kind == "section" && change.Name == "on" {
+			sawTrigger = true
+		}
+	}
+	if !sawJob || !sawTrigger {
+		t.Fatalf("workflow changes missing job=%v trigger=%v in %#v", sawJob, sawTrigger, file.Changes)
+	}
+}
+
 func TestAnalyzeCheckpointResolvesAssociatedCommit(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/entire-sem/internal/sem/dependents.go
+++ b/entire-sem/internal/sem/dependents.go
@@ -1,0 +1,133 @@
+package sem
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/entireio/cli/entire-sem/internal/gitutil"
+)
+
+var identifierBoundary = regexp.MustCompile(`[A-Za-z0-9_$]+`)
+
+type referenceIndex map[string]map[string]struct{}
+
+func addDependentCounts(ctx context.Context, repo, head string, result *Result) error {
+	names := changedReferenceNames(*result)
+	if len(names) == 0 {
+		return nil
+	}
+
+	index, err := buildReferenceIndex(ctx, repo, head, names)
+	if err != nil {
+		return err
+	}
+
+	for fileIndex := range result.Files {
+		for changeIndex := range result.Files[fileIndex].Changes {
+			change := &result.Files[fileIndex].Changes[changeIndex]
+			name := referenceName(*change)
+			change.DependentsCount = len(index[name])
+		}
+	}
+	return nil
+}
+
+func changedReferenceNames(result Result) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, file := range result.Files {
+		for _, change := range file.Changes {
+			name := referenceName(change)
+			if name != "" {
+				out[name] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+func buildReferenceIndex(ctx context.Context, repo, head string, names map[string]struct{}) (referenceIndex, error) {
+	files, err := gitutil.ListFiles(ctx, repo, head)
+	if err != nil {
+		return nil, err
+	}
+
+	parser := TreeSitterParser{}
+	index := referenceIndex{}
+	for name := range names {
+		index[name] = map[string]struct{}{}
+	}
+
+	for _, path := range files {
+		if !Supported(path) {
+			continue
+		}
+		content, ok, err := gitutil.ShowFile(ctx, repo, head, path)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+
+		entities, _ := parser.Parse(path, content)
+		lines := strings.Split(content, "\n")
+		for _, entity := range entities {
+			block := entityBlock(lines, entity)
+			for name := range names {
+				if shortEntityName(entity.Name) == name {
+					continue
+				}
+				if containsIdentifier(block, name) {
+					index[name][path+"#"+entity.Kind+":"+entity.Name] = struct{}{}
+				}
+			}
+		}
+	}
+
+	return index, nil
+}
+
+func entityBlock(lines []string, entity Entity) string {
+	start := entity.StartLine - 1
+	if start < 0 {
+		start = 0
+	}
+	end := entity.EndLine
+	if end > len(lines) {
+		end = len(lines)
+	}
+	if end <= start {
+		return ""
+	}
+	return strings.Join(lines[start:end], "\n")
+}
+
+func containsIdentifier(content, name string) bool {
+	for _, token := range identifierBoundary.FindAllString(content, -1) {
+		if token == name {
+			return true
+		}
+	}
+	return false
+}
+
+func referenceName(change EntityChange) string {
+	switch change.Type {
+	case "renamed":
+		if change.NewName != "" {
+			return shortEntityName(change.NewName)
+		}
+		if change.OldName != "" {
+			return shortEntityName(change.OldName)
+		}
+	}
+	return shortEntityName(change.Name)
+}
+
+func shortEntityName(name string) string {
+	if index := strings.LastIndex(name, "."); index >= 0 {
+		return name[index+1:]
+	}
+	return name
+}

--- a/entire-sem/internal/sem/model.go
+++ b/entire-sem/internal/sem/model.go
@@ -1,0 +1,50 @@
+package sem
+
+import "io"
+
+type Entity struct {
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	Signature   string `json:"signature"`
+	StartLine   int    `json:"start_line"`
+	EndLine     int    `json:"end_line"`
+	BodyHash    string `json:"body_hash"`
+	Fingerprint string `json:"fingerprint"`
+}
+
+type EntityChange struct {
+	Type            string  `json:"type"`
+	Kind            string  `json:"kind"`
+	Name            string  `json:"name"`
+	OldName         string  `json:"old_name,omitempty"`
+	NewName         string  `json:"new_name,omitempty"`
+	OldSignature    string  `json:"old_signature,omitempty"`
+	NewSignature    string  `json:"new_signature,omitempty"`
+	BeforeStartLine int     `json:"before_start_line,omitempty"`
+	AfterStartLine  int     `json:"after_start_line,omitempty"`
+	DependentsCount int     `json:"dependents_count"`
+	Similarity      float64 `json:"similarity,omitempty"`
+}
+
+type FileChange struct {
+	Path     string         `json:"path"`
+	OldPath  string         `json:"old_path,omitempty"`
+	Status   string         `json:"status"`
+	Language string         `json:"language,omitempty"`
+	Changes  []EntityChange `json:"changes"`
+}
+
+type Result struct {
+	Checkpoint string       `json:"checkpoint,omitempty"`
+	Base       string       `json:"base"`
+	Head       string       `json:"head"`
+	Files      []FileChange `json:"files"`
+}
+
+type Parser interface {
+	Parse(path, content string) ([]Entity, string)
+}
+
+func WriteText(out io.Writer, result Result) {
+	writeText(out, result)
+}

--- a/entire-sem/internal/sem/parser.go
+++ b/entire-sem/internal/sem/parser.go
@@ -1,0 +1,292 @@
+package sem
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/golang"
+	"github.com/smacker/go-tree-sitter/javascript"
+	"github.com/smacker/go-tree-sitter/python"
+	"github.com/smacker/go-tree-sitter/rust"
+	treesittertsx "github.com/smacker/go-tree-sitter/typescript/tsx"
+	treesitterts "github.com/smacker/go-tree-sitter/typescript/typescript"
+)
+
+type languageSpec struct {
+	language string
+	grammar  *sitter.Language
+}
+
+var treeSitterLanguages = map[string]languageSpec{
+	".go":  {language: "Go", grammar: golang.GetLanguage()},
+	".py":  {language: "Python", grammar: python.GetLanguage()},
+	".js":  {language: "JavaScript", grammar: javascript.GetLanguage()},
+	".jsx": {language: "JavaScript", grammar: treesittertsx.GetLanguage()},
+	".ts":  {language: "TypeScript", grammar: treesitterts.GetLanguage()},
+	".tsx": {language: "TypeScript", grammar: treesittertsx.GetLanguage()},
+	".rs":  {language: "Rust", grammar: rust.GetLanguage()},
+}
+
+type TreeSitterParser struct{}
+
+func (TreeSitterParser) Parse(path, content string) ([]Entity, string) {
+	spec, ok := languageForPath(path)
+	if !ok {
+		return nil, ""
+	}
+	src := []byte(content)
+	root, err := sitter.ParseCtx(context.Background(), src, spec.grammar)
+	if err != nil || root == nil || root.IsNull() {
+		return nil, spec.language
+	}
+
+	var entities []Entity
+	walkEntities(root, src, "", &entities)
+	sort.Slice(entities, func(i, j int) bool {
+		if entities[i].StartLine == entities[j].StartLine {
+			return entities[i].Name < entities[j].Name
+		}
+		return entities[i].StartLine < entities[j].StartLine
+	})
+	return entities, spec.language
+}
+
+func Supported(path string) bool {
+	_, ok := languageForPath(path)
+	return ok
+}
+
+func languageForPath(path string) (languageSpec, bool) {
+	spec, ok := treeSitterLanguages[strings.ToLower(filepath.Ext(path))]
+	return spec, ok
+}
+
+func walkEntities(node *sitter.Node, src []byte, scope string, entities *[]Entity) {
+	if !validNode(node) {
+		return
+	}
+	entity, ok := entityFromNode(node, src, scope)
+	childScope := scope
+	if ok {
+		*entities = append(*entities, entity)
+		if scopesChildren(entity.Kind) {
+			childScope = entity.Name
+		}
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		walkEntities(node.NamedChild(i), src, childScope, entities)
+	}
+}
+
+func entityFromNode(node *sitter.Node, src []byte, scope string) (Entity, bool) {
+	var kind string
+	var name string
+	switch node.Type() {
+	case "class_definition", "class_declaration":
+		kind = "class"
+		name = nodeName(node, src)
+	case "function_definition":
+		kind = "function"
+		name = nodeName(node, src)
+		if scope != "" {
+			kind = "method"
+			name = qualify(scope, name)
+		}
+	case "function_declaration", "function_item":
+		kind = "function"
+		name = nodeName(node, src)
+	case "function_signature_item":
+		kind = "function"
+		name = nodeName(node, src)
+		if scope != "" {
+			kind = "method"
+			name = qualify(scope, name)
+		}
+	case "method_declaration":
+		kind = "method"
+		name = nodeName(node, src)
+		if receiver := goReceiverName(node, src); receiver != "" {
+			name = qualify(receiver, name)
+		}
+	case "method_definition":
+		kind = "method"
+		name = nodeName(node, src)
+		if scope != "" {
+			name = qualify(scope, name)
+		}
+	case "type_spec", "type_alias_declaration":
+		kind = "type"
+		name = nodeName(node, src)
+	case "interface_declaration":
+		kind = "interface"
+		name = nodeName(node, src)
+	case "struct_item":
+		kind = "struct"
+		name = nodeName(node, src)
+	case "enum_item":
+		kind = "enum"
+		name = nodeName(node, src)
+	case "trait_item":
+		kind = "trait"
+		name = nodeName(node, src)
+	case "variable_declarator":
+		value := node.ChildByFieldName("value")
+		if !functionLikeValue(value) {
+			return Entity{}, false
+		}
+		kind = "function"
+		name = nodeName(node, src)
+	default:
+		return Entity{}, false
+	}
+	if name == "" {
+		return Entity{}, false
+	}
+
+	block := node.Content(src)
+	entity := Entity{
+		Kind:        kind,
+		Name:        name,
+		Signature:   signatureFromNode(node, src),
+		StartLine:   int(node.StartPoint().Row) + 1,
+		EndLine:     int(node.EndPoint().Row) + 1,
+		BodyHash:    hash(normalize(block)),
+		Fingerprint: hash(normalize(entityFingerprintSource(Entity{Name: name, Signature: signatureFromNode(node, src)}, block))),
+	}
+	return entity, true
+}
+
+func nodeName(node *sitter.Node, src []byte) string {
+	for _, field := range []string{"name", "property", "type"} {
+		child := node.ChildByFieldName(field)
+		if validNode(child) {
+			return child.Content(src)
+		}
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		if validNode(child) && isNameNode(child.Type()) {
+			return child.Content(src)
+		}
+	}
+	return ""
+}
+
+func isNameNode(nodeType string) bool {
+	switch nodeType {
+	case "identifier", "type_identifier", "field_identifier", "property_identifier", "package_identifier":
+		return true
+	default:
+		return false
+	}
+}
+
+func signatureFromNode(node *sitter.Node, src []byte) string {
+	start := node.StartByte()
+	end := node.EndByte()
+	if body := node.ChildByFieldName("body"); validNode(body) {
+		end = body.StartByte()
+	} else if body := firstBodyLikeChild(node); validNode(body) {
+		end = body.StartByte()
+	}
+	if end <= start || int(end) > len(src) {
+		end = node.EndByte()
+	}
+	signature := strings.TrimSpace(string(src[start:end]))
+	if index := strings.IndexByte(signature, '\n'); index >= 0 {
+		signature = signature[:index]
+	}
+	return strings.TrimSpace(strings.TrimRight(signature, "{:; \t\r\n"))
+}
+
+func firstBodyLikeChild(node *sitter.Node) *sitter.Node {
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		if !validNode(child) {
+			continue
+		}
+		switch child.Type() {
+		case "block", "statement_block", "class_body", "declaration_list", "field_declaration_list", "interface_body":
+			return child
+		}
+	}
+	return nil
+}
+
+func functionLikeValue(node *sitter.Node) bool {
+	if !validNode(node) {
+		return false
+	}
+	switch node.Type() {
+	case "arrow_function", "function", "function_expression", "generator_function":
+		return true
+	default:
+		return false
+	}
+}
+
+func scopesChildren(kind string) bool {
+	switch kind {
+	case "class", "struct", "trait", "interface":
+		return true
+	default:
+		return false
+	}
+}
+
+func goReceiverName(node *sitter.Node, src []byte) string {
+	signature := signatureFromNode(node, src)
+	receiverStart := strings.Index(signature, "func (")
+	if receiverStart < 0 {
+		return ""
+	}
+	receiver := signature[receiverStart+len("func ("):]
+	receiverEnd := strings.Index(receiver, ")")
+	if receiverEnd < 0 {
+		return ""
+	}
+	receiver = strings.TrimSpace(receiver[:receiverEnd])
+	fields := strings.Fields(receiver)
+	if len(fields) == 0 {
+		return ""
+	}
+	name := strings.Trim(fields[len(fields)-1], "*[]")
+	if index := strings.LastIndex(name, "."); index >= 0 {
+		name = name[index+1:]
+	}
+	return strings.TrimSpace(name)
+}
+
+func qualify(scope, name string) string {
+	if scope == "" || name == "" || strings.HasPrefix(name, scope+".") {
+		return name
+	}
+	return scope + "." + name
+}
+
+func validNode(node *sitter.Node) bool {
+	return node != nil && !node.IsNull()
+}
+
+func normalize(value string) string {
+	fields := strings.Fields(value)
+	return strings.Join(fields, " ")
+}
+
+func entityFingerprintSource(entity Entity, block string) string {
+	lines := strings.Split(block, "\n")
+	if len(lines) <= 1 {
+		return strings.ReplaceAll(entity.Signature, entity.Name, "<name>")
+	}
+	return strings.Join(lines[1:], "\n")
+}
+
+func hash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])[:16]
+}

--- a/entire-sem/internal/sem/parser.go
+++ b/entire-sem/internal/sem/parser.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smacker/go-tree-sitter/rust"
 	treesittertsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 	treesitterts "github.com/smacker/go-tree-sitter/typescript/typescript"
+	treesitteryaml "github.com/smacker/go-tree-sitter/yaml"
 )
 
 type languageSpec struct {
@@ -23,13 +24,15 @@ type languageSpec struct {
 }
 
 var treeSitterLanguages = map[string]languageSpec{
-	".go":  {language: "Go", grammar: golang.GetLanguage()},
-	".py":  {language: "Python", grammar: python.GetLanguage()},
-	".js":  {language: "JavaScript", grammar: javascript.GetLanguage()},
-	".jsx": {language: "JavaScript", grammar: treesittertsx.GetLanguage()},
-	".ts":  {language: "TypeScript", grammar: treesitterts.GetLanguage()},
-	".tsx": {language: "TypeScript", grammar: treesittertsx.GetLanguage()},
-	".rs":  {language: "Rust", grammar: rust.GetLanguage()},
+	".go":   {language: "Go", grammar: golang.GetLanguage()},
+	".py":   {language: "Python", grammar: python.GetLanguage()},
+	".js":   {language: "JavaScript", grammar: javascript.GetLanguage()},
+	".jsx":  {language: "JavaScript", grammar: treesittertsx.GetLanguage()},
+	".ts":   {language: "TypeScript", grammar: treesitterts.GetLanguage()},
+	".tsx":  {language: "TypeScript", grammar: treesittertsx.GetLanguage()},
+	".rs":   {language: "Rust", grammar: rust.GetLanguage()},
+	".yaml": {language: "YAML", grammar: treesitteryaml.GetLanguage()},
+	".yml":  {language: "YAML", grammar: treesitteryaml.GetLanguage()},
 }
 
 type TreeSitterParser struct{}
@@ -43,6 +46,9 @@ func (TreeSitterParser) Parse(path, content string) ([]Entity, string) {
 	root, err := sitter.ParseCtx(context.Background(), src, spec.grammar)
 	if err != nil || root == nil || root.IsNull() {
 		return nil, spec.language
+	}
+	if spec.language == "YAML" {
+		return yamlEntities(path, content), spec.language
 	}
 
 	var entities []Entity

--- a/entire-sem/internal/sem/parser_test.go
+++ b/entire-sem/internal/sem/parser_test.go
@@ -105,6 +105,29 @@ trait Run { fn run(&self); }
 `,
 			names: []string{"User", "validate", "Run", "Run.run"},
 		},
+		{
+			path:     ".github/workflows/ci.yml",
+			language: "YAML",
+			input: `name: CI
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: go test ./...
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./scripts/deploy.sh
+`,
+			names: []string{"ci", "on", "permissions", "jobs.test", "jobs.deploy"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -120,6 +143,40 @@ trait Run { fn run(&self); }
 			if !seen[name] {
 				t.Fatalf("%s missing entity %q in %#v", tt.path, name, entities)
 			}
+		}
+	}
+}
+
+func TestTreeSitterParserSupportsYAMLWorkflowExtensions(t *testing.T) {
+	if !Supported(".github/workflows/ci.yml") {
+		t.Fatal(".yml workflow should be supported")
+	}
+	if !Supported(".github/workflows/deploy.yaml") {
+		t.Fatal(".yaml workflow should be supported")
+	}
+
+	entities, language := TreeSitterParser{}.Parse(".github/workflows/deploy.yaml", `name: Deploy
+on: workflow_dispatch
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo deploy
+`)
+	if language != "YAML" {
+		t.Fatalf("language = %q", language)
+	}
+	seen := map[string]string{}
+	for _, entity := range entities {
+		seen[entity.Name] = entity.Kind
+	}
+	for name, kind := range map[string]string{
+		"deploy":       "workflow",
+		"on":           "section",
+		"jobs.publish": "job",
+	} {
+		if seen[name] != kind {
+			t.Fatalf("%s kind = %q, want %q in %#v", name, seen[name], kind, entities)
 		}
 	}
 }

--- a/entire-sem/internal/sem/parser_test.go
+++ b/entire-sem/internal/sem/parser_test.go
@@ -1,0 +1,125 @@
+package sem
+
+import "testing"
+
+func TestTreeSitterParserPythonEntities(t *testing.T) {
+	input := `class Token:
+    pass
+
+def validate_token(token: str) -> bool:
+    return bool(token)
+
+async def refresh_token(token):
+    return token
+`
+	entities, language := TreeSitterParser{}.Parse("auth.py", input)
+	if language != "Python" {
+		t.Fatalf("language = %q", language)
+	}
+	if len(entities) != 3 {
+		t.Fatalf("entities = %#v", entities)
+	}
+	if entities[0].Kind != "class" || entities[0].Name != "Token" {
+		t.Fatalf("first entity = %#v", entities[0])
+	}
+	if entities[1].Kind != "function" || entities[1].Name != "validate_token" {
+		t.Fatalf("second entity = %#v", entities[1])
+	}
+	if entities[2].Kind != "function" || entities[2].Name != "refresh_token" {
+		t.Fatalf("third entity = %#v", entities[2])
+	}
+}
+
+func TestCompareSignatureBodyRenameAddRemove(t *testing.T) {
+	before, _ := TreeSitterParser{}.Parse("auth.py", `def validate_token(token):
+    return bool(token)
+
+def old_name(value):
+    return value + 1
+
+def removed():
+    return False
+`)
+	after, _ := TreeSitterParser{}.Parse("auth.py", `def validate_token(token, *, issuer=None):
+    return bool(token)
+
+def new_name(value):
+    return value + 1
+
+def added():
+    return True
+`)
+	changes := Compare(before, after)
+	seen := map[string]bool{}
+	for _, change := range changes {
+		seen[change.Type+":"+change.Name] = true
+		if change.Type == "renamed" {
+			seen["renamed:"+change.OldName+"->"+change.NewName] = true
+		}
+	}
+	for _, want := range []string{
+		"signature_changed:validate_token",
+		"renamed:old_name->new_name",
+		"removed:removed",
+		"added:added",
+	} {
+		if !seen[want] {
+			t.Fatalf("missing %s in %#v", want, changes)
+		}
+	}
+}
+
+func TestTreeSitterParserMultiLanguageEntities(t *testing.T) {
+	tests := []struct {
+		path     string
+		input    string
+		language string
+		names    []string
+	}{
+		{
+			path:     "main.go",
+			language: "Go",
+			input: `package main
+type User struct { Name string }
+func (u User) Validate(value string) bool { return value != "" }
+func Format() {}
+`,
+			names: []string{"User", "User.Validate", "Format"},
+		},
+		{
+			path:     "app.ts",
+			language: "TypeScript",
+			input: `interface Foo { value: string }
+type Bar = string
+class User { validate(value: string) { return value } }
+const build = (value: number) => value + 1
+`,
+			names: []string{"Foo", "Bar", "User", "User.validate", "build"},
+		},
+		{
+			path:     "lib.rs",
+			language: "Rust",
+			input: `pub struct User { name: String }
+pub fn validate(value: &str) -> bool { true }
+trait Run { fn run(&self); }
+`,
+			names: []string{"User", "validate", "Run", "Run.run"},
+		},
+	}
+
+	for _, tt := range tests {
+		entities, language := TreeSitterParser{}.Parse(tt.path, tt.input)
+		if language != tt.language {
+			t.Fatalf("%s language = %q", tt.path, language)
+		}
+		seen := map[string]bool{}
+		for _, entity := range entities {
+			seen[entity.Name] = true
+		}
+		for _, name := range tt.names {
+			if !seen[name] {
+				t.Fatalf("%s missing entity %q in %#v", tt.path, name, entities)
+			}
+		}
+	}
+}

--- a/entire-sem/internal/sem/text.go
+++ b/entire-sem/internal/sem/text.go
@@ -1,0 +1,58 @@
+package sem
+
+import (
+	"fmt"
+	"io"
+)
+
+func writeText(out io.Writer, result Result) {
+	fmt.Fprintf(out, "Semantic changes %s..%s\n\n", result.Base, result.Head)
+	if len(result.Files) == 0 {
+		fmt.Fprintln(out, "No semantic entity changes detected.")
+		return
+	}
+
+	for _, file := range result.Files {
+		if file.OldPath != "" && file.OldPath != file.Path {
+			fmt.Fprintf(out, "%s -> %s", file.OldPath, file.Path)
+		} else {
+			fmt.Fprint(out, file.Path)
+		}
+		if file.Language != "" {
+			fmt.Fprintf(out, " (%s)", file.Language)
+		}
+		fmt.Fprintln(out)
+		for _, change := range file.Changes {
+			fmt.Fprintf(out, "  %s\n", describe(change))
+		}
+		fmt.Fprintln(out)
+	}
+}
+
+func describe(change EntityChange) string {
+	dependents := dependentSuffix(change)
+	switch change.Type {
+	case "added":
+		return fmt.Sprintf("+ %s %s added", change.Kind, change.Name)
+	case "removed":
+		return fmt.Sprintf("- %s %s removed%s", change.Kind, change.Name, dependents)
+	case "renamed":
+		return fmt.Sprintf("~ %s %s renamed from %s%s", change.Kind, change.NewName, change.OldName, dependents)
+	case "signature_changed":
+		return fmt.Sprintf("~ %s %s signature changed%s", change.Kind, change.Name, dependents)
+	case "body_changed":
+		return fmt.Sprintf("~ %s %s body changed%s", change.Kind, change.Name, dependents)
+	default:
+		return fmt.Sprintf("~ %s %s changed%s", change.Kind, change.Name, dependents)
+	}
+}
+
+func dependentSuffix(change EntityChange) string {
+	if change.Type == "added" {
+		return ""
+	}
+	if change.DependentsCount == 1 {
+		return " (1 dependent)"
+	}
+	return fmt.Sprintf(" (%d dependents)", change.DependentsCount)
+}

--- a/entire-sem/internal/sem/yaml.go
+++ b/entire-sem/internal/sem/yaml.go
@@ -1,0 +1,275 @@
+package sem
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+type yamlBlock struct {
+	Key       string
+	StartLine int
+	EndLine   int
+}
+
+func yamlEntities(path, content string) []Entity {
+	lines := strings.Split(content, "\n")
+	topLevel := yamlTopLevelBlocks(lines)
+	if len(topLevel) == 0 {
+		return nil
+	}
+
+	var entities []Entity
+	entities = append(entities, yamlEntity("workflow", yamlWorkflowEntityName(path), yamlWorkflowSignature(path, lines, topLevel), 1, len(lines), lines))
+	for _, block := range topLevel {
+		switch block.Key {
+		case "name":
+			continue
+		case "jobs":
+			entities = append(entities, yamlJobEntities(block, lines)...)
+		default:
+			entities = append(entities, yamlEntity("section", block.Key, "section "+block.Key, block.StartLine, block.EndLine, lines))
+		}
+	}
+
+	sort.Slice(entities, func(i, j int) bool {
+		if entities[i].StartLine == entities[j].StartLine {
+			return entities[i].Name < entities[j].Name
+		}
+		return entities[i].StartLine < entities[j].StartLine
+	})
+	return entities
+}
+
+func yamlTopLevelBlocks(lines []string) []yamlBlock {
+	var blocks []yamlBlock
+	for index, line := range lines {
+		if yamlIndent(line) != 0 || yamlIgnoreLine(line) {
+			continue
+		}
+		key, ok := yamlLineKey(line)
+		if !ok {
+			continue
+		}
+		if len(blocks) > 0 {
+			blocks[len(blocks)-1].EndLine = index
+		}
+		blocks = append(blocks, yamlBlock{Key: key, StartLine: index + 1, EndLine: len(lines)})
+	}
+	return blocks
+}
+
+func yamlJobEntities(jobs yamlBlock, lines []string) []Entity {
+	jobIndent := yamlDirectChildIndent(jobs, lines)
+	if jobIndent < 0 {
+		return nil
+	}
+
+	var blocks []yamlBlock
+	for index := jobs.StartLine; index < jobs.EndLine && index < len(lines); index++ {
+		line := lines[index]
+		if yamlIndent(line) != jobIndent || yamlIgnoreLine(line) {
+			continue
+		}
+		key, ok := yamlLineKey(line)
+		if !ok {
+			continue
+		}
+		if len(blocks) > 0 {
+			blocks[len(blocks)-1].EndLine = index
+		}
+		blocks = append(blocks, yamlBlock{Key: key, StartLine: index + 1, EndLine: jobs.EndLine})
+	}
+
+	entities := make([]Entity, 0, len(blocks))
+	for _, block := range blocks {
+		name := "jobs." + block.Key
+		entities = append(entities, yamlEntity("job", name, "job "+name, block.StartLine, block.EndLine, lines))
+	}
+	return entities
+}
+
+func yamlDirectChildIndent(parent yamlBlock, lines []string) int {
+	parentIndent := yamlIndent(lines[parent.StartLine-1])
+	childIndent := -1
+	for index := parent.StartLine; index < parent.EndLine && index < len(lines); index++ {
+		line := lines[index]
+		if yamlIgnoreLine(line) {
+			continue
+		}
+		indent := yamlIndent(line)
+		if indent <= parentIndent {
+			continue
+		}
+		if _, ok := yamlLineKey(line); !ok {
+			continue
+		}
+		if childIndent < 0 || indent < childIndent {
+			childIndent = indent
+		}
+	}
+	return childIndent
+}
+
+func yamlEntity(kind, name, signature string, startLine, endLine int, lines []string) Entity {
+	if startLine < 1 {
+		startLine = 1
+	}
+	if endLine < startLine {
+		endLine = startLine
+	}
+	if endLine > len(lines) {
+		endLine = len(lines)
+	}
+	block := strings.Join(lines[startLine-1:endLine], "\n")
+	return Entity{
+		Kind:        kind,
+		Name:        name,
+		Signature:   normalize(signature),
+		StartLine:   startLine,
+		EndLine:     endLine,
+		BodyHash:    hash(normalize(block)),
+		Fingerprint: hash(normalize(entityFingerprintSource(Entity{Name: name, Signature: signature}, block))),
+	}
+}
+
+func yamlWorkflowEntityName(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	if name == "" || name == "." {
+		return "workflow"
+	}
+	return name
+}
+
+func yamlWorkflowSignature(path string, lines []string, topLevel []yamlBlock) string {
+	name := yamlTopLevelScalar("name", lines, topLevel)
+	if name == "" {
+		name = yamlWorkflowEntityName(path)
+	}
+	return "workflow " + name
+}
+
+func yamlTopLevelScalar(key string, lines []string, blocks []yamlBlock) string {
+	for _, block := range blocks {
+		if block.Key != key || block.StartLine < 1 || block.StartLine > len(lines) {
+			continue
+		}
+		return yamlLineValue(lines[block.StartLine-1])
+	}
+	return ""
+}
+
+func yamlLineKey(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if yamlIgnoreTrimmedLine(trimmed) || strings.HasPrefix(trimmed, "- ") {
+		return "", false
+	}
+	colon := yamlKeyColonIndex(trimmed)
+	if colon <= 0 {
+		return "", false
+	}
+	key := strings.TrimSpace(trimmed[:colon])
+	if key == "" || strings.HasPrefix(key, "{") || strings.HasPrefix(key, "[") {
+		return "", false
+	}
+	return yamlUnquote(key), true
+}
+
+func yamlLineValue(line string) string {
+	trimmed := strings.TrimSpace(line)
+	colon := yamlKeyColonIndex(trimmed)
+	if colon < 0 || colon+1 >= len(trimmed) {
+		return ""
+	}
+	return yamlUnquote(strings.TrimSpace(yamlStripInlineComment(trimmed[colon+1:])))
+}
+
+func yamlKeyColonIndex(value string) int {
+	var quote rune
+	escaped := false
+	for index, char := range value {
+		if quote != 0 {
+			if quote == '"' && char == '\\' && !escaped {
+				escaped = true
+				continue
+			}
+			if char == quote && !escaped {
+				quote = 0
+			}
+			escaped = false
+			continue
+		}
+		switch char {
+		case '\'', '"':
+			quote = char
+		case ':':
+			return index
+		}
+	}
+	return -1
+}
+
+func yamlStripInlineComment(value string) string {
+	var quote rune
+	escaped := false
+	for index, char := range value {
+		if quote != 0 {
+			if quote == '"' && char == '\\' && !escaped {
+				escaped = true
+				continue
+			}
+			if char == quote && !escaped {
+				quote = 0
+			}
+			escaped = false
+			continue
+		}
+		switch char {
+		case '\'', '"':
+			quote = char
+		case '#':
+			if index == 0 || unicode.IsSpace(rune(value[index-1])) {
+				return strings.TrimSpace(value[:index])
+			}
+		}
+	}
+	return strings.TrimSpace(value)
+}
+
+func yamlUnquote(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 {
+		first := value[0]
+		last := value[len(value)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}
+
+func yamlIndent(line string) int {
+	count := 0
+	for _, char := range line {
+		switch char {
+		case ' ':
+			count++
+		case '\t':
+			count += 2
+		default:
+			return count
+		}
+	}
+	return count
+}
+
+func yamlIgnoreLine(line string) bool {
+	return yamlIgnoreTrimmedLine(strings.TrimSpace(line))
+}
+
+func yamlIgnoreTrimmedLine(line string) bool {
+	return line == "" || strings.HasPrefix(line, "#") || line == "---" || line == "..."
+}

--- a/entire-sem/mise.toml
+++ b/entire-sem/mise.toml
@@ -1,0 +1,18 @@
+[tools]
+go = { version = "1.26.2" }
+
+[tasks.fmt]
+description = "Run gofmt"
+run = "gofmt -s -w ."
+
+[tasks.test]
+description = "Run tests"
+run = "go test ./..."
+
+[tasks.build]
+description = "Build the plugin binary"
+run = "go build -o entire-sem ./cmd/entire-sem"
+
+[tasks.check]
+description = "Run formatting, tests, and build"
+depends = ["fmt", "test", "build"]


### PR DESCRIPTION
## Summary
Adds entity-level semantic checkpoint context for Entire checkpoint explain and rewind.

Closes #589.

## What changed
- Adds the entire-sem plugin as a nested MIT-clean Go module.
- Parses Go, Python, JavaScript, TypeScript/TSX, Rust, and YAML with tree-sitter.
- Extracts GitHub Actions workflow sections and jobs.<id> entities from .yml / .yaml files.
- Detects added, removed, renamed, signature-changed, and body-changed entities.
- Adds heuristic dependent counts for changed symbols.
- Integrates semantic output into Entire checkpoint explain when entire-sem is installed.
- Adds optional semantic_changes to checkpoint explain JSON output.
- Adds concise semantic preview lines to Entire checkpoint rewind.
- Gracefully falls back to existing file-level output when the plugin is missing or fails.

## Validation
- cd entire-sem && go test ./...
- YAML regression coverage for .github/workflows/ci.yml

## Notes
- The semantic diff is deterministic and does not use an LLM or network calls.
- Existing JSON consumers remain compatible because semantic_changes is additive.
- Missing entire-sem never blocks explain or rewind; debug logs record plugin failures only.