### PR TITLE
fix(trail): preserve forge identifier from entire:// remote URLs

### DIFF
--- a/cmd/entire/cli/gitremote/gitremote.go
+++ b/cmd/entire/cli/gitremote/gitremote.go
@@ -27,7 +27,8 @@ const (
 // Forge is the short identifier of the upstream forge ("gh", "et", ...) used
 // by the Entire trails API. It is populated from the path prefix on entire://
 // URLs (entire://host/<forge>/owner/repo) and from a hostname lookup on
-// direct git URLs (github.com → "gh"). It is empty for unrecognized hosts.
+// direct git URLs (github.com → "gh"). It is empty for direct git URLs to
+// unrecognized hosts, and for entire:// URLs without a forge segment.
 type Info struct {
 	Protocol string
 	Host     string

--- a/cmd/entire/cli/gitremote/gitremote.go
+++ b/cmd/entire/cli/gitremote/gitremote.go
@@ -23,12 +23,25 @@ const (
 // Host is the hostname only (never includes a port). Port is empty unless the
 // source URL specified an explicit non-default port. Callers that need the
 // combined "host[:port]" form should use HostPort.
+//
+// Forge is the short identifier of the upstream forge ("gh", "et", ...) used
+// by the Entire trails API. It is populated from the path prefix on entire://
+// URLs (entire://host/<forge>/owner/repo) and from a hostname lookup on
+// direct git URLs (github.com → "gh"). It is empty for unrecognized hosts.
 type Info struct {
 	Protocol string
 	Host     string
 	Port     string
+	Forge    string
 	Owner    string
 	Repo     string
+}
+
+// hostToForge maps direct git hostnames to their forge identifier on the
+// trails API. entire:// URLs carry the forge in the path instead and bypass
+// this map.
+var hostToForge = map[string]string{
+	"github.com": "gh",
 }
 
 // HostPort returns Host, or "Host:Port" when Port is non-empty.
@@ -79,7 +92,7 @@ func ParseURL(rawURL string) (*Info, error) {
 			return nil, err
 		}
 
-		return &Info{Protocol: ProtocolSSH, Host: host, Owner: owner, Repo: repo}, nil
+		return &Info{Protocol: ProtocolSSH, Host: host, Forge: hostToForge[host], Owner: owner, Repo: repo}, nil
 	}
 
 	u, err := url.Parse(rawURL)
@@ -91,25 +104,27 @@ func ParseURL(rawURL string) (*Info, error) {
 	}
 
 	pathPart := strings.TrimPrefix(u.Path, "/")
+	forge := hostToForge[u.Hostname()]
 	if u.Scheme == ProtocolEntire {
-		pathPart = stripForgePrefix(pathPart)
+		// entire:// URLs encode the forge as the first path segment.
+		forge, pathPart = splitForgePrefix(pathPart)
 	}
 	owner, repo, err := splitOwnerRepo(pathPart)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Info{Protocol: u.Scheme, Host: u.Hostname(), Port: u.Port(), Owner: owner, Repo: repo}, nil
+	return &Info{Protocol: u.Scheme, Host: u.Hostname(), Port: u.Port(), Forge: forge, Owner: owner, Repo: repo}, nil
 }
 
-// stripForgePrefix removes the leading forge/namespace segment from an entire://
-// URL path (e.g. "gh/owner/repo" -> "owner/repo"). Paths without a separator are
-// returned unchanged.
-func stripForgePrefix(path string) string {
-	if _, rest, found := strings.Cut(path, "/"); found {
-		return rest
+// splitForgePrefix returns the leading forge/namespace segment of an entire://
+// URL path and the remainder (e.g. "gh/owner/repo" -> "gh", "owner/repo").
+// Paths without a separator are returned with an empty forge.
+func splitForgePrefix(path string) (forge, rest string) {
+	if forge, rest, found := strings.Cut(path, "/"); found {
+		return forge, rest
 	}
-	return path
+	return "", path
 }
 
 // RedactURL removes credentials and query parameters from a URL for safe logging.
@@ -140,10 +155,12 @@ func ExtractOwnerFromRemoteURL(rawURL string) string {
 	return info.Owner
 }
 
-// ResolveRemoteRepo returns the host, owner, and repo name for the given git remote.
-// It parses the remote URL (SSH or HTTPS) and extracts the components.
-// For example, git@github.com:org/my-repo.git returns ("github.com", "org", "my-repo").
-func ResolveRemoteRepo(ctx context.Context, remoteName string) (host, owner, repo string, err error) {
+// ResolveRemoteRepo returns the forge identifier, owner, and repo name for the
+// given git remote. The forge is the short id used by the trails API ("gh",
+// "et", ...); it is derived from the hostname for direct git URLs or from the
+// path prefix on entire:// URLs. It is empty for unrecognized hosts.
+// For example, git@github.com:org/my-repo.git returns ("gh", "org", "my-repo").
+func ResolveRemoteRepo(ctx context.Context, remoteName string) (forge, owner, repo string, err error) {
 	rawURL, err := GetRemoteURL(ctx, remoteName)
 	if err != nil {
 		return "", "", "", fmt.Errorf("get remote URL for %q: %w", remoteName, err)
@@ -152,7 +169,7 @@ func ResolveRemoteRepo(ctx context.Context, remoteName string) (host, owner, rep
 	if err != nil {
 		return "", "", "", fmt.Errorf("parse remote URL: %w", err)
 	}
-	return info.Host, info.Owner, info.Repo, nil
+	return info.Forge, info.Owner, info.Repo, nil
 }
 
 func splitOwnerRepo(path string) (string, string, error) {

--- a/cmd/entire/cli/gitremote/gitremote_test.go
+++ b/cmd/entire/cli/gitremote/gitremote_test.go
@@ -76,6 +76,11 @@ func TestParseURL(t *testing.T) {
 			wantInfo: &Info{Protocol: ProtocolEntire, Host: "aws-us-east-2.entire.io", Forge: "gh", Owner: "entirehq", Repo: "entiredb"},
 		},
 		{
+			name:     "entire:// with .git suffix",
+			url:      "entire://entirehost/gh/entireio/cli.git",
+			wantInfo: &Info{Protocol: ProtocolEntire, Host: "entirehost", Forge: "gh", Owner: "entireio", Repo: "cli"},
+		},
+		{
 			name:     "unmapped host has empty forge",
 			url:      "git@gitlab.com:org/repo.git",
 			wantInfo: &Info{Protocol: ProtocolSSH, Host: "gitlab.com", Owner: "org", Repo: "repo"},

--- a/cmd/entire/cli/gitremote/gitremote_test.go
+++ b/cmd/entire/cli/gitremote/gitremote_test.go
@@ -23,27 +23,27 @@ func TestParseURL(t *testing.T) {
 		{
 			name:     "SSH SCP format",
 			url:      "git@github.com:org/repo.git",
-			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Forge: "gh", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "SSH SCP without .git",
 			url:      "git@github.com:org/repo",
-			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Forge: "gh", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "HTTPS format",
 			url:      "https://github.com/org/repo.git",
-			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "github.com", Forge: "gh", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "HTTPS without .git",
 			url:      "https://github.com/org/repo",
-			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "github.com", Forge: "gh", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "SSH protocol format",
 			url:      "ssh://git@github.com/org/repo.git",
-			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &Info{Protocol: ProtocolSSH, Host: "github.com", Forge: "gh", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:     "HTTPS with non-standard port",
@@ -58,17 +58,27 @@ func TestParseURL(t *testing.T) {
 		{
 			name:     "HTTPS standard port not appended",
 			url:      "https://github.com/org/repo.git",
-			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "github.com", Owner: "org", Repo: "repo"},
+			wantInfo: &Info{Protocol: ProtocolHTTPS, Host: "github.com", Forge: "gh", Owner: "org", Repo: "repo"},
 		},
 		{
-			name:     "entire:// gh prefix stripped",
+			name:     "entire:// gh prefix preserved as forge",
 			url:      "entire://entirehost/gh/entireio/cli",
-			wantInfo: &Info{Protocol: ProtocolEntire, Host: "entirehost", Owner: "entireio", Repo: "cli"},
+			wantInfo: &Info{Protocol: ProtocolEntire, Host: "entirehost", Forge: "gh", Owner: "entireio", Repo: "cli"},
 		},
 		{
-			name:     "entire:// non-gh prefix stripped",
+			name:     "entire:// non-gh prefix preserved as forge",
 			url:      "entire://abc/jk/myproject/repo",
-			wantInfo: &Info{Protocol: ProtocolEntire, Host: "abc", Owner: "myproject", Repo: "repo"},
+			wantInfo: &Info{Protocol: ProtocolEntire, Host: "abc", Forge: "jk", Owner: "myproject", Repo: "repo"},
+		},
+		{
+			name:     "entire:// regional host with gh forge",
+			url:      "entire://aws-us-east-2.entire.io/gh/entirehq/entiredb",
+			wantInfo: &Info{Protocol: ProtocolEntire, Host: "aws-us-east-2.entire.io", Forge: "gh", Owner: "entirehq", Repo: "entiredb"},
+		},
+		{
+			name:     "unmapped host has empty forge",
+			url:      "git@gitlab.com:org/repo.git",
+			wantInfo: &Info{Protocol: ProtocolSSH, Host: "gitlab.com", Owner: "org", Repo: "repo"},
 		},
 		{
 			name:    "empty string",
@@ -93,6 +103,7 @@ func TestParseURL(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantInfo.Protocol, info.Protocol)
 			assert.Equal(t, tt.wantInfo.Host, info.Host)
+			assert.Equal(t, tt.wantInfo.Forge, info.Forge)
 			assert.Equal(t, tt.wantInfo.Owner, info.Owner)
 			assert.Equal(t, tt.wantInfo.Repo, info.Repo)
 		})
@@ -165,21 +176,28 @@ func TestResolveRemoteRepo(t *testing.T) {
 	tests := []struct {
 		name      string
 		originURL string
-		wantHost  string
+		wantForge string
 		wantOwner string
 		wantRepo  string
 	}{
 		{
 			name:      "SSH SCP format",
 			originURL: "git@github.com:acme/my-app.git",
-			wantHost:  "github.com",
+			wantForge: "gh",
 			wantOwner: "acme",
 			wantRepo:  "my-app",
 		},
 		{
 			name:      "HTTPS format",
 			originURL: "https://github.com/acme/my-app.git",
-			wantHost:  "github.com",
+			wantForge: "gh",
+			wantOwner: "acme",
+			wantRepo:  "my-app",
+		},
+		{
+			name:      "entire:// with gh forge in path",
+			originURL: "entire://aws-us-east-2.entire.io/gh/acme/my-app",
+			wantForge: "gh",
 			wantOwner: "acme",
 			wantRepo:  "my-app",
 		},
@@ -197,9 +215,9 @@ func TestResolveRemoteRepo(t *testing.T) {
 
 			t.Chdir(repoDir)
 
-			host, owner, repo, err := ResolveRemoteRepo(ctx, "origin")
+			forge, owner, repo, err := ResolveRemoteRepo(ctx, "origin")
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantHost, host)
+			assert.Equal(t, tt.wantForge, forge)
 			assert.Equal(t, tt.wantOwner, owner)
 			assert.Equal(t, tt.wantRepo, repo)
 		})

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -99,9 +99,9 @@ func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repo, err := resolveTrailRemote(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to resolve repository: %w", err)
+		return err
 	}
 
 	found, err := findTrailByBranch(ctx, client, forge, owner, repo, branch)
@@ -176,9 +176,9 @@ func runTrailListAll(ctx context.Context, w io.Writer, opts trailListOptions) er
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repo, err := resolveTrailRemote(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to resolve repository: %w", err)
+		return err
 	}
 
 	resp, err := client.Get(ctx, trailsBasePath(forge, owner, repo))
@@ -585,9 +585,9 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	forge, owner, repoName, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repoName, err := resolveTrailRemote(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to resolve repository: %w", err)
+		return err
 	}
 
 	createReq := api.TrailCreateRequest{
@@ -672,9 +672,9 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, s
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	forge, owner, repoName, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repoName, err := resolveTrailRemote(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to resolve repository: %w", err)
+		return err
 	}
 
 	// Determine branch
@@ -923,10 +923,25 @@ func findTrail(ctx context.Context, client *api.Client, forge, owner, repo strin
 }
 
 // trailsBasePath returns the API path prefix for trails endpoints
-// (e.g., "/api/v1/trails/gh/org/repo"). The forge identifier comes from
-// gitremote.Info.Forge; mapping from git remote to forge lives there.
+// (e.g., "/api/v1/trails/gh/org/repo").
 func trailsBasePath(forge, owner, repo string) string {
 	return fmt.Sprintf("/api/v1/trails/%s/%s/%s", forge, owner, repo)
+}
+
+// resolveTrailRemote resolves the origin remote and ensures the forge is
+// known to the trails API. Without this guard, an unmapped host (e.g.
+// gitlab.com, or a misconfigured entire:// URL with no forge prefix)
+// produces a malformed `/api/v1/trails//owner/repo` path that the server
+// rejects with an opaque error instead of a clear "unsupported forge" one.
+func resolveTrailRemote(ctx context.Context) (forge, owner, repo string, err error) {
+	forge, owner, repo, err = gitremote.ResolveRemoteRepo(ctx, "origin")
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to resolve repository: %w", err)
+	}
+	if forge == "" {
+		return "", "", "", errors.New("origin remote is not on a forge supported by Entire trails (supported: github.com)")
+	}
+	return forge, owner, repo, nil
 }
 
 // checkTrailResponse checks the API response and returns user-friendly errors.

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -99,12 +99,12 @@ func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	host, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve repository: %w", err)
 	}
 
-	found, err := findTrailByBranch(ctx, client, host, owner, repo, branch)
+	found, err := findTrailByBranch(ctx, client, forge, owner, repo, branch)
 	if err != nil {
 		return err
 	}
@@ -176,12 +176,12 @@ func runTrailListAll(ctx context.Context, w io.Writer, opts trailListOptions) er
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	host, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve repository: %w", err)
 	}
 
-	resp, err := client.Get(ctx, trailsBasePath(host, owner, repo))
+	resp, err := client.Get(ctx, trailsBasePath(forge, owner, repo))
 	if err != nil {
 		return fmt.Errorf("failed to list trails: %w", err)
 	}
@@ -585,7 +585,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	host, owner, repoName, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repoName, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve repository: %w", err)
 	}
@@ -598,7 +598,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		Status:     statusStr,
 	}
 
-	resp, err := client.Post(ctx, trailsBasePath(host, owner, repoName), createReq)
+	resp, err := client.Post(ctx, trailsBasePath(forge, owner, repoName), createReq)
 	if err != nil {
 		return fmt.Errorf("failed to create trail: %w", err)
 	}
@@ -672,7 +672,7 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, s
 		return fmt.Errorf("authentication required: %w", err)
 	}
 
-	host, owner, repoName, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repoName, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return fmt.Errorf("failed to resolve repository: %w", err)
 	}
@@ -686,7 +686,7 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, s
 	}
 
 	// Find the trail by branch
-	found, err := findTrailByBranch(ctx, client, host, owner, repoName, branch)
+	found, err := findTrailByBranch(ctx, client, forge, owner, repoName, branch)
 	if err != nil {
 		return err
 	}
@@ -744,7 +744,7 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, s
 	// Build update request with only changed fields
 	updateReq := buildTrailUpdateRequest(found, statusStr, title, body, labelAdd, labelRemove)
 
-	resp, err := client.Patch(ctx, trailsBasePath(host, owner, repoName)+"/"+found.ID, updateReq)
+	resp, err := client.Patch(ctx, trailsBasePath(forge, owner, repoName)+"/"+found.ID, updateReq)
 	if err != nil {
 		return fmt.Errorf("failed to update trail: %w", err)
 	}
@@ -886,21 +886,21 @@ func runTrailCreateInteractive(title, body, branch, statusStr *string) error {
 }
 
 // findTrailByBranch looks up a trail by branch name via the list API.
-func findTrailByBranch(ctx context.Context, client *api.Client, host, owner, repo, branch string) (*api.TrailResource, error) {
-	return findTrail(ctx, client, host, owner, repo, func(t api.TrailResource) bool {
+func findTrailByBranch(ctx context.Context, client *api.Client, forge, owner, repo, branch string) (*api.TrailResource, error) {
+	return findTrail(ctx, client, forge, owner, repo, func(t api.TrailResource) bool {
 		return t.Branch == branch
 	})
 }
 
 // findTrailByNumber looks up a trail by numeric identifier via the list API.
-func findTrailByNumber(ctx context.Context, client *api.Client, host, owner, repo string, number int) (*api.TrailResource, error) {
-	return findTrail(ctx, client, host, owner, repo, func(t api.TrailResource) bool {
+func findTrailByNumber(ctx context.Context, client *api.Client, forge, owner, repo string, number int) (*api.TrailResource, error) {
+	return findTrail(ctx, client, forge, owner, repo, func(t api.TrailResource) bool {
 		return t.Number == number
 	})
 }
 
-func findTrail(ctx context.Context, client *api.Client, host, owner, repo string, match func(api.TrailResource) bool) (*api.TrailResource, error) {
-	resp, err := client.Get(ctx, trailsBasePath(host, owner, repo))
+func findTrail(ctx context.Context, client *api.Client, forge, owner, repo string, match func(api.TrailResource) bool) (*api.TrailResource, error) {
+	resp, err := client.Get(ctx, trailsBasePath(forge, owner, repo))
 	if err != nil {
 		return nil, fmt.Errorf("list trails: %w", err)
 	}
@@ -922,17 +922,11 @@ func findTrail(ctx context.Context, client *api.Client, host, owner, repo string
 	return nil, nil //nolint:nilnil // nil, nil means "not found" — callers check both
 }
 
-// apiHostAlias maps git host domains to short aliases used by the trails API.
-var apiHostAlias = map[string]string{
-	"github.com": "gh",
-}
-
-// trailsBasePath returns the API path prefix for trails endpoints (e.g., "/api/v1/trails/gh/org/repo").
-func trailsBasePath(host, owner, repo string) string {
-	if alias, ok := apiHostAlias[host]; ok {
-		host = alias
-	}
-	return fmt.Sprintf("/api/v1/trails/%s/%s/%s", host, owner, repo)
+// trailsBasePath returns the API path prefix for trails endpoints
+// (e.g., "/api/v1/trails/gh/org/repo"). The forge identifier comes from
+// gitremote.Info.Forge; mapping from git remote to forge lives there.
+func trailsBasePath(forge, owner, repo string) string {
+	return fmt.Sprintf("/api/v1/trails/%s/%s/%s", forge, owner, repo)
 }
 
 // checkTrailResponse checks the API response and returns user-friendly errors.

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trail"
 )
 
@@ -32,6 +34,49 @@ func TestTrailsBasePath(t *testing.T) {
 			got := trailsBasePath(tt.forge, tt.owner, tt.rp)
 			if got != tt.want {
 				t.Fatalf("trailsBasePath(%q, %q, %q) = %q, want %q", tt.forge, tt.owner, tt.rp, got, tt.want)
+			}
+		})
+	}
+}
+
+// Not parallel: uses t.Chdir() to point ResolveRemoteRepo at a fake repo.
+func TestResolveTrailRemote_RejectsUnsupportedForge(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	cmd := exec.CommandContext(context.Background(), "git", "remote", "add", "origin", "git@gitlab.com:acme/my-app.git")
+	cmd.Dir = repoDir
+	cmd.Env = testutil.GitIsolatedEnv()
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git remote add: %v", err)
+	}
+	t.Chdir(repoDir)
+
+	_, _, _, err := resolveTrailRemote(context.Background())
+	if err == nil {
+		t.Fatal("expected error for gitlab.com origin, got nil")
+	}
+	if !strings.Contains(err.Error(), "not on a forge supported by Entire trails") {
+		t.Fatalf("error message does not mention unsupported forge: %v", err)
+	}
+}
+
+func TestTrailWatchDescription(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name             string
+		forge, owner, rp string
+		number           int
+		trailID, want    string
+	}{
+		{"with number", "gh", "acme", "repo", 5, "abc123", "trail #5 (gh/acme/repo, id abc123)"},
+		{"without number", "gh", "acme", "repo", 0, "abc123", "trail abc123 (gh/acme/repo)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := trailWatchDescription(tt.forge, tt.owner, tt.rp, tt.number, tt.trailID)
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -16,6 +16,27 @@ const (
 	trailListTestAuthorBob   = "bob"
 )
 
+func TestTrailsBasePath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name             string
+		forge, owner, rp string
+		want             string
+	}{
+		{"gh forge", "gh", "acme", "repo", "/api/v1/trails/gh/acme/repo"},
+		{"et forge", "et", "acme", "repo", "/api/v1/trails/et/acme/repo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := trailsBasePath(tt.forge, tt.owner, tt.rp)
+			if got != tt.want {
+				t.Fatalf("trailsBasePath(%q, %q, %q) = %q, want %q", tt.forge, tt.owner, tt.rp, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLimitTrailsKeepsMostRecentPrefix(t *testing.T) {
 	t.Parallel()
 	trails := []*trail.Metadata{

--- a/cmd/entire/cli/trail_watch_cmd.go
+++ b/cmd/entire/cli/trail_watch_cmd.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
-	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 
 	"github.com/spf13/cobra"
 )
@@ -173,9 +172,9 @@ func resolveTrailWatchTarget(ctx context.Context, client *api.Client, number int
 		return resolveTrailWatchNumber(ctx, client, number)
 	}
 
-	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repo, err := resolveTrailRemote(ctx)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to resolve repository: %w", err)
+		return "", "", err
 	}
 	branch, err := GetCurrentBranch(ctx)
 	if err != nil {
@@ -195,9 +194,9 @@ func resolveTrailWatchTarget(ctx context.Context, client *api.Client, number int
 }
 
 func resolveTrailWatchNumber(ctx context.Context, client *api.Client, number int) (trailID, description string, err error) {
-	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repo, err := resolveTrailRemote(ctx)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to resolve repository: %w", err)
+		return "", "", err
 	}
 	found, err := findTrailByNumber(ctx, client, forge, owner, repo, number)
 	if err != nil {

--- a/cmd/entire/cli/trail_watch_cmd.go
+++ b/cmd/entire/cli/trail_watch_cmd.go
@@ -173,7 +173,7 @@ func resolveTrailWatchTarget(ctx context.Context, client *api.Client, number int
 		return resolveTrailWatchNumber(ctx, client, number)
 	}
 
-	host, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to resolve repository: %w", err)
 	}
@@ -181,7 +181,7 @@ func resolveTrailWatchTarget(ctx context.Context, client *api.Client, number int
 	if err != nil {
 		return "", "", fmt.Errorf("no trail number given and current branch is unknown: %w", err)
 	}
-	found, err := findTrailByBranch(ctx, client, host, owner, repo, branch)
+	found, err := findTrailByBranch(ctx, client, forge, owner, repo, branch)
 	if err != nil {
 		return "", "", err
 	}
@@ -191,32 +191,32 @@ func resolveTrailWatchTarget(ctx context.Context, client *api.Client, number int
 	if found.ID == "" {
 		return "", "", fmt.Errorf("trail for branch %q has no id yet", branch)
 	}
-	return found.ID, trailWatchDescription(host, owner, repo, found.Number, found.ID), nil
+	return found.ID, trailWatchDescription(forge, owner, repo, found.Number, found.ID), nil
 }
 
 func resolveTrailWatchNumber(ctx context.Context, client *api.Client, number int) (trailID, description string, err error) {
-	host, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to resolve repository: %w", err)
 	}
-	found, err := findTrailByNumber(ctx, client, host, owner, repo, number)
+	found, err := findTrailByNumber(ctx, client, forge, owner, repo, number)
 	if err != nil {
 		return "", "", err
 	}
 	if found == nil {
-		return "", "", fmt.Errorf("no trail #%d found in %s/%s/%s", number, host, owner, repo)
+		return "", "", fmt.Errorf("no trail #%d found in %s/%s/%s", number, forge, owner, repo)
 	}
 	if found.ID == "" {
 		return "", "", fmt.Errorf("trail #%d has no id yet", number)
 	}
-	return found.ID, trailWatchDescription(host, owner, repo, found.Number, found.ID), nil
+	return found.ID, trailWatchDescription(forge, owner, repo, found.Number, found.ID), nil
 }
 
-func trailWatchDescription(host, owner, repo string, number int, trailID string) string {
+func trailWatchDescription(forge, owner, repo string, number int, trailID string) string {
 	if number > 0 {
-		return fmt.Sprintf("trail #%d (%s/%s/%s, id %s)", number, host, owner, repo, trailID)
+		return fmt.Sprintf("trail #%d (%s/%s/%s, id %s)", number, forge, owner, repo, trailID)
 	}
-	return fmt.Sprintf("trail %s (%s/%s/%s)", trailID, host, owner, repo)
+	return fmt.Sprintf("trail %s (%s/%s/%s)", trailID, forge, owner, repo)
 }
 
 func reviewEventsPath(trailID string) string {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/443
<!-- entire-trail-link-end -->

## Summary
`entire trail list` (and every other `entire trail` subcommand) was rejected by the API with `Invalid host. Must be one of: gh, et` when run against an `entire://` origin (e.g. `entire://aws-us-east-2.entire.io/gh/entirehq/entiredb`).

**Root cause:** `gitremote.ParseURL` stripped the forge segment from `entire://host/<forge>/owner/repo` and threw it away. The `apiHostAlias` map in `trail_cmd.go` only knew how to translate `github.com → gh`, so the regional Entire hostname (`aws-us-east-2.entire.io`) was sent through as the API host segment, which the server rejected.

**Fix:** `gitremote.Info` now carries a `Forge` field. `ParseURL` populates it from the path prefix on `entire://` URLs and from a `hostToForge` map (`github.com → gh`) otherwise. `ResolveRemoteRepo` returns the forge directly. The old `apiHostAlias` lookup is gone — host→forge resolution lives next to the URL parsing.

A new `resolveTrailRemote` helper in the cli package adds a clear CLI-side error for unmapped hosts (gitlab.com etc.) so users get `origin remote is not on a forge supported by Entire trails (supported: github.com)` instead of a malformed `/api/v1/trails//owner/repo` 404.

## Heads-up — minor user-visible change
`entire trail watch`'s status line previously read `Watching trail #N (github.com/org/repo, id …)` for native-GitHub remotes. It now reads `… (gh/org/repo, id …)` for both transport types (direct GitHub and `entire://`). The output is now consistent across transports and matches the API path shape, but it does change for existing users on direct-GitHub remotes. Calling this out in case anyone wants `github.com/…` back — I think the new form is fine.

## Test plan
- [x] `mise run fmt && mise run lint` clean
- [x] `go test ./cmd/entire/cli/gitremote/ ./cmd/entire/cli/...` passes (12 pre-existing `TestExplainCmd_*` failures on `main` are unaffected)
- [x] New unit coverage:
  - `ParseURL` for `entire://aws-us-east-2.entire.io/gh/entirehq/entiredb` → forge `gh`, owner `entirehq`, repo `entiredb`
  - `ParseURL` for `entire://entirehost/gh/entireio/cli.git` (with `.git` suffix)
  - `ParseURL` for `git@gitlab.com:org/repo.git` (unmapped host → empty forge)
  - `TestTrailsBasePath` for `gh` and `et` forges
  - `TestResolveTrailRemote_RejectsUnsupportedForge` (gitlab.com origin produces a clear CLI error)
  - `TestTrailWatchDescription` pinning the new status-line format
- [ ] Manual smoke: run \`entire trail list\` against an \`entire://\` origin (the reporter's case) and confirm it lists trails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all trail subcommands resolve remotes and API paths; behavior is well-tested but `trail watch` output format shifts for direct GitHub users.
> 
> **Overview**
> Fixes `entire trail` commands against **`entire://`** origins by carrying a **forge** id (`gh`, `et`, …) through remote parsing instead of sending the Entire hostname to the trails API.
> 
> **`gitremote`:** `Info` gains **`Forge`**. `ParseURL` sets it from the first path segment on `entire://host/<forge>/owner/repo` (replacing discard-only `stripForgePrefix` with `splitForgePrefix`) and from **`hostToForge`** for direct git URLs (`github.com` → `gh`). **`ResolveRemoteRepo`** now returns `(forge, owner, repo)` instead of host.
> 
> **Trail CLI:** All trail API paths use forge via **`resolveTrailRemote`** (rejects empty forge with a clear “unsupported forge” error). **`apiHostAlias`** in `trail_cmd.go` is removed; **`trailsBasePath`** takes forge directly. **`entire trail watch`** status text uses `gh/org/repo` instead of `github.com/org/repo` for direct GitHub remotes.
> 
> Tests cover regional `entire://` URLs, unmapped hosts, and the new error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d8a24981c94d8e104af7949e255ec5721f185f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->