### PR TITLE
Rewrite relative alternates so go-git can follow shared clones

### DIFF
--- a/cmd/entire/cli/gitrepo/alternates_fs.go
+++ b/cmd/entire/cli/gitrepo/alternates_fs.go
@@ -27,7 +27,34 @@ func (fs *alternatesFilesystem) Create(filename string) (billy.File, error) {
 }
 
 func (fs *alternatesFilesystem) Open(filename string) (billy.File, error) {
-	return fs.root.Open(fs.resolve(filename))
+	resolved := fs.resolve(filename)
+	if isAlternatesObjectsPath(resolved) {
+		if content, ok := fs.rewrittenNestedAlternates(resolved); ok {
+			return inMemoryFile(content)
+		}
+	}
+	return fs.root.Open(resolved)
+}
+
+// rewrittenNestedAlternates reads an alternates file from an alternate
+// repository (located at <objects-dir>/info/alternates) and returns a copy
+// of its contents with relative entries resolved against that objects
+// directory. Returns ok=false when the file is unreadable or no entry
+// needed rewriting, in which case the caller should serve the original
+// file.
+func (fs *alternatesFilesystem) rewrittenNestedAlternates(resolved string) (string, bool) {
+	f, err := fs.root.Open(resolved)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = f.Close() }()
+
+	lines, ok := readAlternatesLines(f)
+	if !ok {
+		return "", false
+	}
+	objectsBase := filepath.Dir(filepath.Dir(resolved))
+	return rewriteRelativeAlternates(lines, objectsBase)
 }
 
 func (fs *alternatesFilesystem) OpenFile(filename string, flag int, perm gofs.FileMode) (billy.File, error) {

--- a/cmd/entire/cli/gitrepo/alternates_fs.go
+++ b/cmd/entire/cli/gitrepo/alternates_fs.go
@@ -49,12 +49,12 @@ func (fs *alternatesFilesystem) rewrittenNestedAlternates(resolved string) (stri
 	}
 	defer func() { _ = f.Close() }()
 
-	lines, ok := readAlternatesLines(f)
+	content, ok := readAlternatesContent(f)
 	if !ok {
 		return "", false
 	}
 	objectsBase := filepath.Dir(filepath.Dir(resolved))
-	return rewriteRelativeAlternates(lines, objectsBase)
+	return rewriteRelativeAlternates(content, objectsBase)
 }
 
 func (fs *alternatesFilesystem) OpenFile(filename string, flag int, perm gofs.FileMode) (billy.File, error) {

--- a/cmd/entire/cli/gitrepo/alternates_rewrite.go
+++ b/cmd/entire/cli/gitrepo/alternates_rewrite.go
@@ -1,4 +1,3 @@
-//nolint:ireturn // billy.Filesystem/File passthrough requires interface returns.
 package gitrepo
 
 import (
@@ -63,8 +62,12 @@ func isAlternatesFile(filename string) bool {
 // maxAlternatesReadBytes) and returns a copy of its contents with every
 // relative entry resolved against <root>/objects. Absolute entries, blank
 // lines, and comment lines (those starting with '#') are preserved
-// unchanged. ok is false when the file is missing/unreadable or no entry
-// needed rewriting, in which case the caller serves the original file.
+// unchanged. ok is false when the file is missing/unreadable or it fit
+// within the cap and needed no rewriting; in those cases the caller serves
+// the original file. When the file exceeded the cap, ok is true even if no
+// entry needed rewriting so the caller never falls back to the uncapped
+// original — which could contain a relative entry past the cap that go-git
+// would mangle.
 func (fs *alternatesRewriteFS) absolutizedAlternates() (string, bool) {
 	f, err := fs.Filesystem.Open(filepath.FromSlash(alternatesFilePath))
 	if err != nil {
@@ -72,23 +75,33 @@ func (fs *alternatesRewriteFS) absolutizedAlternates() (string, bool) {
 	}
 	defer func() { _ = f.Close() }()
 
-	lines, ok := readAlternatesLines(f)
+	content, ok := readAlternatesContent(f)
 	if !ok {
 		return "", false
 	}
-	return rewriteRelativeAlternates(lines, filepath.Join(fs.Root(), "objects"))
+	return rewriteRelativeAlternates(content, filepath.Join(fs.Root(), "objects"))
 }
 
-// readAlternatesLines reads up to maxAlternatesReadBytes from r and splits
+// alternatesContent holds the visible portion of an alternates file along
+// with a flag indicating whether the underlying file had more data than the
+// read cap allowed. Callers must not fall back to the original file when
+// truncated is true.
+type alternatesContent struct {
+	lines     []string
+	truncated bool
+}
+
+// readAlternatesContent reads up to maxAlternatesReadBytes from r and splits
 // the content on '\n'. When the file exceeds the cap, a trailing line that
 // has no closing newline is discarded so we never hand a truncated path to
-// the rewrite logic.
-func readAlternatesLines(r io.Reader) ([]string, bool) {
+// the rewrite logic, and truncated is set so the caller knows past-cap
+// content exists.
+func readAlternatesContent(r io.Reader) (alternatesContent, bool) {
 	// Read one byte past the cap so we can tell whether the underlying file
 	// has more data than fits in the budget.
 	data, err := io.ReadAll(io.LimitReader(r, maxAlternatesReadBytes+1))
 	if err != nil {
-		return nil, false
+		return alternatesContent{}, false
 	}
 	truncated := false
 	if len(data) > maxAlternatesReadBytes {
@@ -100,17 +113,20 @@ func readAlternatesLines(r io.Reader) ([]string, bool) {
 	if truncated && !strings.HasSuffix(text, "\n") && len(lines) > 0 {
 		lines = lines[:len(lines)-1]
 	}
-	return lines, true
+	return alternatesContent{lines: lines, truncated: truncated}, true
 }
 
-// rewriteRelativeAlternates rewrites every relative entry in lines against
-// objectsBase. Blank lines, comments ('#'-prefixed), and already-absolute
-// entries are left untouched. Returns (joined-content, true) when at least
-// one relative entry was rewritten; otherwise ok=false so the caller serves
-// the original file unchanged.
-func rewriteRelativeAlternates(lines []string, objectsBase string) (string, bool) {
+// rewriteRelativeAlternates rewrites every relative entry in content.lines
+// against objectsBase. Blank lines, comments ('#'-prefixed), and
+// already-absolute entries are left untouched. Returns (joined-content,
+// true) when at least one relative entry was rewritten OR when the file was
+// truncated (so the caller serves our capped view instead of the uncapped
+// original). Returns ok=false only when nothing was rewritten and the file
+// fit within the cap, in which case the caller can safely serve the
+// original file unchanged.
+func rewriteRelativeAlternates(content alternatesContent, objectsBase string) (string, bool) {
 	changed := false
-	for i, line := range lines {
+	for i, line := range content.lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
@@ -118,13 +134,13 @@ func rewriteRelativeAlternates(lines []string, objectsBase string) (string, bool
 		if filepath.IsAbs(trimmed) || filepath.VolumeName(trimmed) != "" {
 			continue
 		}
-		lines[i] = filepath.Clean(filepath.Join(objectsBase, filepath.FromSlash(trimmed)))
+		content.lines[i] = filepath.Clean(filepath.Join(objectsBase, filepath.FromSlash(trimmed)))
 		changed = true
 	}
-	if !changed {
+	if !changed && !content.truncated {
 		return "", false
 	}
-	return strings.Join(lines, "\n"), true
+	return strings.Join(content.lines, "\n"), true
 }
 
 // isAlternatesObjectsPath reports whether absPath looks like an alternates

--- a/cmd/entire/cli/gitrepo/alternates_rewrite.go
+++ b/cmd/entire/cli/gitrepo/alternates_rewrite.go
@@ -1,0 +1,153 @@
+//nolint:ireturn // billy.Filesystem/File passthrough requires interface returns.
+package gitrepo
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+)
+
+// alternatesFilePath is the repository-relative path of the alternates file,
+// in slash form, as go-git opens it.
+const alternatesFilePath = "objects/info/alternates"
+
+// maxAlternatesReadBytes caps how much of the alternates file we read. Real
+// alternates files hold a handful of short paths; the limit is purely
+// defensive against an oversized or malformed file. Content past the cap is
+// dropped, and a trailing line truncated by the cap is discarded rather
+// than fed to the rewrite logic as a bogus path.
+const maxAlternatesReadBytes = 4096
+
+// alternatesRewriteFS wraps a git-directory filesystem and rewrites the
+// objects/info/alternates file on read so that relative alternate object
+// directories are presented to go-git as absolute paths.
+//
+// go-git cannot follow relative alternates: its dotgit.Alternates() strips any
+// leading "../" and anchors the remainder at the filesystem root (see the
+// upstream comment in storage/filesystem/dotgit/dotgit.go), which mangles a
+// relative entry such as "../../entirehq/entiredb/.git/objects" into a
+// non-existent absolute path. Git itself resolves relative alternates against
+// $GIT_DIR/objects, so we resolve them the same way and hand go-git an absolute
+// path, which it follows correctly via the OS-rooted AlternatesFS.
+//
+// Absolute entries are passed through untouched; if no entry needs rewriting
+// the original file is served unchanged.
+type alternatesRewriteFS struct {
+	billy.Filesystem // wrapped git-dir FS; promotes the full billy interface
+}
+
+// wrapAlternatesRewrite wraps fs so reads of objects/info/alternates resolve
+// relative entries to absolute paths. fs must be rooted at a git directory
+// (its Root() joined with "objects" is the base for relative alternates).
+func wrapAlternatesRewrite(fs billy.Filesystem) billy.Filesystem {
+	return &alternatesRewriteFS{Filesystem: fs}
+}
+
+func (fs *alternatesRewriteFS) Open(filename string) (billy.File, error) {
+	if isAlternatesFile(filename) {
+		if content, ok := fs.absolutizedAlternates(); ok {
+			return inMemoryFile(content)
+		}
+	}
+	return fs.Filesystem.Open(filename) //nolint:wrapcheck // preserve underlying FS errors
+}
+
+func isAlternatesFile(filename string) bool {
+	return filepath.ToSlash(filepath.Clean(filename)) == alternatesFilePath
+}
+
+// absolutizedAlternates reads the wrapped alternates file (capped at
+// maxAlternatesReadBytes) and returns a copy of its contents with every
+// relative entry resolved against <root>/objects. Absolute entries, blank
+// lines, and comment lines (those starting with '#') are preserved
+// unchanged. ok is false when the file is missing/unreadable or no entry
+// needed rewriting, in which case the caller serves the original file.
+func (fs *alternatesRewriteFS) absolutizedAlternates() (string, bool) {
+	f, err := fs.Filesystem.Open(filepath.FromSlash(alternatesFilePath))
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = f.Close() }()
+
+	lines, ok := readAlternatesLines(f)
+	if !ok {
+		return "", false
+	}
+	return rewriteRelativeAlternates(lines, filepath.Join(fs.Root(), "objects"))
+}
+
+// readAlternatesLines reads up to maxAlternatesReadBytes from r and splits
+// the content on '\n'. When the file exceeds the cap, a trailing line that
+// has no closing newline is discarded so we never hand a truncated path to
+// the rewrite logic.
+func readAlternatesLines(r io.Reader) ([]string, bool) {
+	// Read one byte past the cap so we can tell whether the underlying file
+	// has more data than fits in the budget.
+	data, err := io.ReadAll(io.LimitReader(r, maxAlternatesReadBytes+1))
+	if err != nil {
+		return nil, false
+	}
+	truncated := false
+	if len(data) > maxAlternatesReadBytes {
+		data = data[:maxAlternatesReadBytes]
+		truncated = true
+	}
+	text := string(data)
+	lines := strings.Split(text, "\n")
+	if truncated && !strings.HasSuffix(text, "\n") && len(lines) > 0 {
+		lines = lines[:len(lines)-1]
+	}
+	return lines, true
+}
+
+// rewriteRelativeAlternates rewrites every relative entry in lines against
+// objectsBase. Blank lines, comments ('#'-prefixed), and already-absolute
+// entries are left untouched. Returns (joined-content, true) when at least
+// one relative entry was rewritten; otherwise ok=false so the caller serves
+// the original file unchanged.
+func rewriteRelativeAlternates(lines []string, objectsBase string) (string, bool) {
+	changed := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if filepath.IsAbs(trimmed) || filepath.VolumeName(trimmed) != "" {
+			continue
+		}
+		lines[i] = filepath.Clean(filepath.Join(objectsBase, filepath.FromSlash(trimmed)))
+		changed = true
+	}
+	if !changed {
+		return "", false
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+// isAlternatesObjectsPath reports whether absPath looks like an alternates
+// file located at <objects-dir>/info/alternates. Used by the OS-rooted
+// alternates filesystem to detect nested alternates files.
+func isAlternatesObjectsPath(absPath string) bool {
+	clean := filepath.Clean(absPath)
+	return filepath.Base(clean) == "alternates" &&
+		filepath.Base(filepath.Dir(clean)) == "info"
+}
+
+func inMemoryFile(content string) (billy.File, error) {
+	mem := memfs.New()
+	f, err := mem.Create(alternatesFilePath)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // memfs errors are descriptive enough
+	}
+	if _, err := f.Write([]byte(content)); err != nil {
+		_ = f.Close()
+		return nil, err //nolint:wrapcheck // memfs errors are descriptive enough
+	}
+	if err := f.Close(); err != nil {
+		return nil, err //nolint:wrapcheck // memfs errors are descriptive enough
+	}
+	return mem.Open(alternatesFilePath) //nolint:wrapcheck // memfs errors are descriptive enough
+}

--- a/cmd/entire/cli/gitrepo/alternates_rewrite_test.go
+++ b/cmd/entire/cli/gitrepo/alternates_rewrite_test.go
@@ -77,6 +77,11 @@ func TestAbsolutizedAlternates(t *testing.T) {
 			wantOk:  false,
 		},
 		{
+			name:    "file containing only blank lines returns not ok",
+			content: "\n\n\n",
+			wantOk:  false,
+		},
+		{
 			name:    "two relative alternates are both rewritten",
 			content: relPathA + "\n" + relPathB + "\n",
 			want:    rewrittenA + "\n" + rewrittenB + "\n",
@@ -98,6 +103,12 @@ func TestAbsolutizedAlternates(t *testing.T) {
 			name:    "comment between alternates is preserved",
 			content: relPathA + "\n#note\n" + relPathB + "\n",
 			want:    rewrittenA + "\n#note\n" + rewrittenB + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "blank lines between alternates are preserved",
+			content: relPathA + "\n\n\n" + relPathB + "\n",
+			want:    rewrittenA + "\n\n\n" + rewrittenB + "\n",
 			wantOk:  true,
 		},
 		{

--- a/cmd/entire/cli/gitrepo/alternates_rewrite_test.go
+++ b/cmd/entire/cli/gitrepo/alternates_rewrite_test.go
@@ -106,11 +106,26 @@ func TestAbsolutizedAlternates(t *testing.T) {
 			wantOk:  false,
 		},
 		{
-			name: "data beyond maxAlternatesReadBytes is ignored",
+			name: "truncation past the cap forces capped content, not fall-through",
 			// A 4096-byte comment fills the entire read budget; the relative
-			// path that follows sits past the limit and must not be reached.
+			// path that follows sits past the limit. We must serve our capped
+			// view (empty, because the visible portion was a truncated comment
+			// we dropped) rather than fall back to the uncapped original —
+			// which would expose the past-cap relative entry to go-git.
 			content: strings.Repeat("#", maxAlternatesReadBytes) + "\n" + relPath + "\n",
-			wantOk:  false,
+			want:    "",
+			wantOk:  true,
+		},
+		{
+			name: "truncation past the cap with absolute prelude preserves prelude only",
+			// Absolute entries fit inside the cap; a relative entry sits past
+			// the cap behind a giant comment whose terminating newline lives
+			// past the cap too. We serve only the absolute prelude (the
+			// truncated comment line is dropped) so the past-cap relative
+			// entry can never reach go-git unrepaired.
+			content: "/abs/one\n/abs/two\n" + strings.Repeat("#", maxAlternatesReadBytes) + "\n" + relPath + "\n",
+			want:    "/abs/one\n/abs/two",
+			wantOk:  true,
 		},
 		{
 			name: "trailing partial line past the cap is discarded",

--- a/cmd/entire/cli/gitrepo/alternates_rewrite_test.go
+++ b/cmd/entire/cli/gitrepo/alternates_rewrite_test.go
@@ -1,0 +1,149 @@
+package gitrepo
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAbsolutizedAlternates(t *testing.T) {
+	t.Parallel()
+
+	const relPath = "alt/objects"
+	const relPathA = "altA/objects"
+	const relPathB = "altB/objects"
+	rewritten := filepath.Clean(filepath.Join("/objects", relPath))
+	rewrittenA := filepath.Clean(filepath.Join("/objects", relPathA))
+	rewrittenB := filepath.Clean(filepath.Join("/objects", relPathB))
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		wantOk  bool
+	}{
+		{
+			name:    "relative path is absolutized",
+			content: relPath + "\n",
+			want:    rewritten + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "relative path without trailing newline",
+			content: relPath,
+			want:    rewritten,
+			wantOk:  true,
+		},
+		{
+			name:    "absolute path returns not ok",
+			content: "/already/absolute/objects\n",
+			wantOk:  false,
+		},
+		{
+			name:    "empty file returns not ok",
+			content: "",
+			wantOk:  false,
+		},
+		{
+			name:    "comment line is preserved, relative path rewritten",
+			content: "#comment\n" + relPath + "\n",
+			want:    "#comment\n" + rewritten + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "multiple comments preserved before relative path",
+			content: "#one\n#two\n#three\n" + relPath + "\n",
+			want:    "#one\n#two\n#three\n" + rewritten + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "leading whitespace before # still treated as comment",
+			content: "   #comment\n" + relPath + "\n",
+			want:    "   #comment\n" + rewritten + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "blank lines preserved around relative path",
+			content: "\n\n" + relPath + "\n",
+			want:    "\n\n" + rewritten + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "file containing only comments returns not ok",
+			content: "#one\n#two\n#three\n",
+			wantOk:  false,
+		},
+		{
+			name:    "two relative alternates are both rewritten",
+			content: relPathA + "\n" + relPathB + "\n",
+			want:    rewrittenA + "\n" + rewrittenB + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "mix of relative and absolute preserves order",
+			content: relPathA + "\n/already/absolute/objects\n" + relPathB + "\n",
+			want:    rewrittenA + "\n/already/absolute/objects\n" + rewrittenB + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "absolute first then relative",
+			content: "/already/absolute/objects\n" + relPath + "\n",
+			want:    "/already/absolute/objects\n" + rewritten + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "comment between alternates is preserved",
+			content: relPathA + "\n#note\n" + relPathB + "\n",
+			want:    rewrittenA + "\n#note\n" + rewrittenB + "\n",
+			wantOk:  true,
+		},
+		{
+			name:    "all absolute alternates return not ok",
+			content: "/abs/one\n/abs/two\n/abs/three\n",
+			wantOk:  false,
+		},
+		{
+			name: "data beyond maxAlternatesReadBytes is ignored",
+			// A 4096-byte comment fills the entire read budget; the relative
+			// path that follows sits past the limit and must not be reached.
+			content: strings.Repeat("#", maxAlternatesReadBytes) + "\n" + relPath + "\n",
+			wantOk:  false,
+		},
+		{
+			name: "trailing partial line past the cap is discarded",
+			// The usable path sits at offset 0 and a giant unterminated tail
+			// follows; the tail is truncated by the cap and must not be
+			// treated as a second relative entry.
+			content: relPath + "\n" + strings.Repeat("x", maxAlternatesReadBytes*4),
+			want:    rewritten,
+			wantOk:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := newAlternatesFS(t, tc.content)
+			got, ok := fs.absolutizedAlternates()
+			require.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func newAlternatesFS(t *testing.T, content string) *alternatesRewriteFS {
+	t.Helper()
+	mfs := memfs.New()
+	f, err := mfs.Create(alternatesFilePath)
+	require.NoError(t, err)
+	_, err = f.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return &alternatesRewriteFS{Filesystem: mfs}
+}

--- a/cmd/entire/cli/gitrepo/repository.go
+++ b/cmd/entire/cli/gitrepo/repository.go
@@ -98,10 +98,14 @@ func openPathWithAlternates(repoRoot string) (*git.Repository, error) {
 		return nil, err
 	}
 
-	dotGitFS := osfs.New(dotGitPath, osfs.WithBoundOS())
+	// Wrap the git-dir filesystems so relative alternate object directories are
+	// rewritten to absolute paths on read; go-git cannot follow relative
+	// alternates on its own. The alternates file lives under the common git dir
+	// for linked worktrees, so wrap both.
+	dotGitFS := wrapAlternatesRewrite(osfs.New(dotGitPath, osfs.WithBoundOS()))
 	var commonGitFS billy.Filesystem
 	if commonGitPath != "" {
-		commonGitFS = osfs.New(commonGitPath, osfs.WithBoundOS())
+		commonGitFS = wrapAlternatesRewrite(osfs.New(commonGitPath, osfs.WithBoundOS()))
 	}
 
 	repositoryFS := dotgit.NewRepositoryFilesystem(dotGitFS, commonGitFS)

--- a/cmd/entire/cli/gitrepo/repository_test.go
+++ b/cmd/entire/cli/gitrepo/repository_test.go
@@ -50,6 +50,170 @@ func TestOpenPath_MultipleAlternates(t *testing.T) {
 	}
 }
 
+// TestOpenPath_RelativeAlternate covers a shared clone whose
+// objects/info/alternates entry is a relative path (e.g. created with
+// `git clone --reference`). go-git cannot follow relative alternates on its own;
+// OpenPath must rewrite them to absolute so objects in the alternate resolve.
+func TestOpenPath_RelativeAlternate(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	altDir := t.TempDir()
+
+	rootHash := initRepoWithFile(t, rootDir, "root.txt", "root\n")
+	altHash := initRepoWithFile(t, altDir, "alt.txt", "alt\n")
+
+	// Write the alternate as a path relative to rootDir/.git/objects, matching
+	// what git records for a relative/shared clone.
+	rootObjects := filepath.Join(rootDir, gitDir, "objects")
+	altObjects := filepath.Join(altDir, gitDir, "objects")
+	relAlt, err := filepath.Rel(rootObjects, altObjects)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(relAlt, ".."), "expected a relative alternate, got %q", relAlt)
+	writeAlternates(t, rootDir, []string{relAlt})
+
+	repo, err := OpenPath(rootDir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	for _, hash := range []string{rootHash, altHash} {
+		_, err := repo.CommitObject(plumbing.NewHash(hash))
+		require.NoError(t, err, "commit %s should be readable via relative alternate", hash)
+	}
+}
+
+// TestOpenPath_MultipleRelativeAlternates covers a repository whose
+// alternates file lists several relative entries. Each entry must be
+// rewritten in place and the file's overall structure preserved so go-git
+// can enumerate every alternate object directory.
+func TestOpenPath_MultipleRelativeAlternates(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	altADir := t.TempDir()
+	altBDir := t.TempDir()
+	altCDir := t.TempDir()
+
+	rootHash := initRepoWithFile(t, rootDir, "root.txt", "root\n")
+	altAHash := initRepoWithFile(t, altADir, "a.txt", "a\n")
+	altBHash := initRepoWithFile(t, altBDir, "b.txt", "b\n")
+	altCHash := initRepoWithFile(t, altCDir, "c.txt", "c\n")
+
+	rootObjects := filepath.Join(rootDir, gitDir, "objects")
+	relA, err := filepath.Rel(rootObjects, filepath.Join(altADir, gitDir, "objects"))
+	require.NoError(t, err)
+	relB, err := filepath.Rel(rootObjects, filepath.Join(altBDir, gitDir, "objects"))
+	require.NoError(t, err)
+	relC, err := filepath.Rel(rootObjects, filepath.Join(altCDir, gitDir, "objects"))
+	require.NoError(t, err)
+	for _, rel := range []string{relA, relB, relC} {
+		require.True(t, strings.HasPrefix(rel, ".."), "expected relative alternate, got %q", rel)
+	}
+	writeAlternates(t, rootDir, []string{relA, relB, relC})
+
+	repo, err := OpenPath(rootDir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	for _, hash := range []string{rootHash, altAHash, altBHash, altCHash} {
+		commit, err := repo.CommitObject(plumbing.NewHash(hash))
+		require.NoError(t, err, "commit %s should be readable through one of the relative alternates", hash)
+		_, err = commit.Tree()
+		require.NoError(t, err, "tree for commit %s should be readable", hash)
+	}
+}
+
+// TestOpenPath_NestedRelativeAlternates covers an alternate chain where every
+// link is relative: root → alt1 → alt2. The rewrite on the root's alternates
+// file lets go-git enter alt1, but alt1's own alternates file is read via
+// go-git's AlternatesFS (not our wrapper) so the alt1 → alt2 hop must also
+// resolve correctly for objects in alt2 to be reachable.
+func TestOpenPath_NestedRelativeAlternates(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	alt1Dir := t.TempDir()
+	alt2Dir := t.TempDir()
+
+	rootHash := initRepoWithFile(t, rootDir, "root.txt", "root\n")
+	alt1Hash := initRepoWithFile(t, alt1Dir, "alt1.txt", "alt1\n")
+	alt2Hash := initRepoWithFile(t, alt2Dir, "alt2.txt", "alt2\n")
+
+	rootObjects := filepath.Join(rootDir, gitDir, "objects")
+	alt1Objects := filepath.Join(alt1Dir, gitDir, "objects")
+	alt2Objects := filepath.Join(alt2Dir, gitDir, "objects")
+
+	relRootToAlt1, err := filepath.Rel(rootObjects, alt1Objects)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(relRootToAlt1, ".."), "expected a relative alternate, got %q", relRootToAlt1)
+	writeAlternates(t, rootDir, []string{relRootToAlt1})
+
+	relAlt1ToAlt2, err := filepath.Rel(alt1Objects, alt2Objects)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(relAlt1ToAlt2, ".."), "expected a relative nested alternate, got %q", relAlt1ToAlt2)
+	writeAlternates(t, alt1Dir, []string{relAlt1ToAlt2})
+
+	repo, err := OpenPath(rootDir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	for _, hash := range []string{rootHash, alt1Hash, alt2Hash} {
+		commit, err := repo.CommitObject(plumbing.NewHash(hash))
+		require.NoError(t, err, "commit %s should be readable through nested relative alternates", hash)
+		_, err = commit.Tree()
+		require.NoError(t, err, "tree for commit %s should be readable", hash)
+	}
+}
+
+// TestOpenPath_LinkedWorktreeRelativeAlternate covers a linked worktree
+// whose common git directory holds a relative alternates entry. The alternates
+// file lives under the common git dir (not the worktree's own gitdir), so the
+// rewrite must apply to the common-dir filesystem and resolve relative entries
+// against <common-dir>/objects rather than the worktree gitdir.
+func TestOpenPath_LinkedWorktreeRelativeAlternate(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	mainDir := filepath.Join(rootDir, "main")
+	altDir := filepath.Join(rootDir, "alt")
+	worktreeDir := filepath.Join(rootDir, "wt")
+	require.NoError(t, os.MkdirAll(mainDir, 0o755))
+	require.NoError(t, os.MkdirAll(altDir, 0o755))
+	require.NoError(t, os.MkdirAll(worktreeDir, 0o755))
+
+	mainHash := initRepoWithFile(t, mainDir, "main.txt", "main\n")
+	altHash := initRepoWithFile(t, altDir, "alt.txt", "alt\n")
+
+	mainGitDir := filepath.Join(mainDir, gitDir)
+	mainObjects := filepath.Join(mainGitDir, "objects")
+	altObjects := filepath.Join(altDir, gitDir, "objects")
+
+	relAlt, err := filepath.Rel(mainObjects, altObjects)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(relAlt, ".."), "expected a relative alternate, got %q", relAlt)
+	writeAlternates(t, mainDir, []string{relAlt})
+
+	worktreeGitDir := filepath.Join(mainGitDir, "worktrees", "wt")
+	require.NoError(t, os.MkdirAll(worktreeGitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeDir, gitDir), []byte("gitdir: "+worktreeGitDir+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeGitDir, "commondir"), []byte("../..\n"), 0o644))
+
+	mainHEAD, err := os.ReadFile(filepath.Join(mainGitDir, "HEAD"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeGitDir, "HEAD"), mainHEAD, 0o644))
+
+	repo, err := OpenPath(worktreeDir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	for _, hash := range []string{mainHash, altHash} {
+		commit, err := repo.CommitObject(plumbing.NewHash(hash))
+		require.NoError(t, err, "commit %s should be readable through linked worktree relative alternate", hash)
+		_, err = commit.Tree()
+		require.NoError(t, err, "tree for commit %s should be readable", hash)
+	}
+}
+
 func TestHasObjectAlternates(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/strategy/push_common_test.go
+++ b/cmd/entire/cli/strategy/push_common_test.go
@@ -218,6 +218,7 @@ func TestPushBranchIfNeeded_LocalBareRepo_PushesSuccessfully(t *testing.T) {
 // Not parallel: uses t.Chdir() (required for OpenRepository).
 func TestFetchAndRebase_DivergedBranches(t *testing.T) {
 	ctx := context.Background()
+	testutil.IsolateGitConfigEnv(t)
 	branchName := paths.MetadataBranchName
 
 	// 1. Create bare origin with a metadata branch containing a base checkpoint
@@ -344,6 +345,7 @@ func TestFetchAndRebase_DivergedBranches(t *testing.T) {
 // Not parallel: uses t.Chdir() (required for OpenRepository).
 func TestFetchAndRebase_SharedCloneLocalCommitInAlternate(t *testing.T) {
 	ctx := context.Background()
+	testutil.IsolateGitConfigEnv(t)
 	branchName := paths.MetadataBranchName
 
 	bareDir := t.TempDir()
@@ -422,6 +424,7 @@ func TestFetchAndRebase_SharedCloneLocalCommitInAlternate(t *testing.T) {
 // Not parallel: uses t.Chdir() (required for OpenRepository).
 func TestFetchAndRebase_LocalBehind(t *testing.T) {
 	ctx := context.Background()
+	testutil.IsolateGitConfigEnv(t)
 	branchName := paths.MetadataBranchName
 
 	bareDir := t.TempDir()
@@ -502,6 +505,7 @@ func TestFetchAndRebase_LocalBehind(t *testing.T) {
 // Not parallel: uses t.Chdir() (required for OpenRepository).
 func TestFetchAndRebase_MergeBaseOnSecondParent_DoesNotReplayAncestors(t *testing.T) {
 	ctx := context.Background()
+	testutil.IsolateGitConfigEnv(t)
 	branchName := paths.MetadataBranchName
 
 	bareDir := t.TempDir()
@@ -633,6 +637,7 @@ func TestFetchAndRebase_MergeBaseOnSecondParent_DoesNotReplayAncestors(t *testin
 // Not parallel: uses t.Chdir() (required for OpenRepository).
 func TestFetchAndRebase_DoesNotResurrectRemoteOnlyCheckpointFromMerge(t *testing.T) {
 	ctx := context.Background()
+	testutil.IsolateGitConfigEnv(t)
 	branchName := paths.MetadataBranchName
 
 	bareDir := t.TempDir()
@@ -748,6 +753,7 @@ func TestFetchAndRebase_DoesNotResurrectRemoteOnlyCheckpointFromMerge(t *testing
 // Not parallel: uses t.Chdir() (required for OpenRepository).
 func TestFetchAndRebase_NonOriginRemote_ReconcilesFetchedRef(t *testing.T) {
 	ctx := context.Background()
+	testutil.IsolateGitConfigEnv(t)
 	branchName := paths.MetadataBranchName
 
 	bareDir := t.TempDir()
@@ -848,6 +854,7 @@ func TestFetchAndRebase_NonOriginRemote_ReconcilesFetchedRef(t *testing.T) {
 // Not parallel: uses t.Chdir() (required for OpenRepository).
 func TestFetchAndRebase_URLTarget_ReconcilesFetchedTempRef(t *testing.T) {
 	ctx := context.Background()
+	testutil.IsolateGitConfigEnv(t)
 	branchName := paths.MetadataBranchName
 
 	bareDir := t.TempDir()
@@ -945,6 +952,7 @@ func TestFetchAndRebase_URLTarget_ReconcilesFetchedTempRef(t *testing.T) {
 // Not parallel: uses t.Chdir() (required for OpenRepository).
 func TestFetchAndRebase_FlaggedOriginTarget_UsesTempRef(t *testing.T) {
 	ctx := context.Background()
+	testutil.IsolateGitConfigEnv(t)
 	branchName := paths.MetadataBranchName
 
 	bareDir := t.TempDir()

--- a/cmd/entire/cli/testutil/testutil.go
+++ b/cmd/entire/cli/testutil/testutil.go
@@ -339,13 +339,13 @@ func gitEmptyConfigPath() string {
 //
 // See https://git-scm.com/docs/git#Documentation/git.txt-GITCONFIGGLOBAL
 //
-// Existing GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM entries are filtered out before
-// appending overrides to ensure they take effect regardless of parent env.
+// Existing GIT_CONFIG_* entries are filtered out before appending overrides to
+// ensure they take effect regardless of parent env.
 func GitIsolatedEnv() []string {
 	env := os.Environ()
 	filtered := make([]string, 0, len(env)+2)
 	for _, e := range env {
-		if strings.HasPrefix(e, "GIT_CONFIG_GLOBAL=") || strings.HasPrefix(e, "GIT_CONFIG_SYSTEM=") {
+		if isGitConfigEnv(e) {
 			continue
 		}
 		filtered = append(filtered, e)
@@ -354,4 +354,35 @@ func GitIsolatedEnv() []string {
 		"GIT_CONFIG_GLOBAL="+gitEmptyConfigPath(), // Isolate from user's global git config (e.g. global gitignore)
 		"GIT_CONFIG_SYSTEM="+gitEmptyConfigPath(), // Isolate from system git config
 	)
+}
+
+// IsolateGitConfigEnv applies the same git config isolation to the current
+// process. Use this in tests that exercise production code paths which invoke
+// git with os.Environ().
+func IsolateGitConfigEnv(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("GIT_CONFIG_GLOBAL", gitEmptyConfigPath())
+	t.Setenv("GIT_CONFIG_SYSTEM", gitEmptyConfigPath())
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_COUNT", "0")
+
+	for _, e := range os.Environ() {
+		key, _, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") {
+			t.Setenv(key, "")
+		}
+	}
+}
+
+func isGitConfigEnv(e string) bool {
+	return strings.HasPrefix(e, "GIT_CONFIG_GLOBAL=") ||
+		strings.HasPrefix(e, "GIT_CONFIG_SYSTEM=") ||
+		strings.HasPrefix(e, "GIT_CONFIG_NOSYSTEM=") ||
+		strings.HasPrefix(e, "GIT_CONFIG_COUNT=") ||
+		strings.HasPrefix(e, "GIT_CONFIG_KEY_") ||
+		strings.HasPrefix(e, "GIT_CONFIG_VALUE_")
 }

--- a/cmd/entire/cli/testutil/testutil.go
+++ b/cmd/entire/cli/testutil/testutil.go
@@ -339,8 +339,10 @@ func gitEmptyConfigPath() string {
 //
 // See https://git-scm.com/docs/git#Documentation/git.txt-GITCONFIGGLOBAL
 //
-// Existing GIT_CONFIG_* entries are filtered out before appending overrides to
-// ensure they take effect regardless of parent env.
+// Every inherited GIT_CONFIG_* entry is filtered out — including
+// GIT_CONFIG_PARAMETERS and the indexed KEY_/VALUE_ pairs that can inject
+// `git -c` overrides — so our explicit isolation overrides take effect
+// regardless of parent env.
 func GitIsolatedEnv() []string {
 	env := os.Environ()
 	filtered := make([]string, 0, len(env)+2)
@@ -358,31 +360,29 @@ func GitIsolatedEnv() []string {
 
 // IsolateGitConfigEnv applies the same git config isolation to the current
 // process. Use this in tests that exercise production code paths which invoke
-// git with os.Environ().
+// git with os.Environ(). All inherited GIT_CONFIG_* variables are cleared
+// before the isolation overrides are set, so values such as
+// GIT_CONFIG_PARAMETERS or indexed KEY_/VALUE_ overrides cannot leak into
+// child git invocations.
 func IsolateGitConfigEnv(t *testing.T) {
 	t.Helper()
-
-	t.Setenv("GIT_CONFIG_GLOBAL", gitEmptyConfigPath())
-	t.Setenv("GIT_CONFIG_SYSTEM", gitEmptyConfigPath())
-	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
-	t.Setenv("GIT_CONFIG_COUNT", "0")
 
 	for _, e := range os.Environ() {
 		key, _, ok := strings.Cut(e, "=")
 		if !ok {
 			continue
 		}
-		if strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") {
+		if strings.HasPrefix(key, "GIT_CONFIG_") {
 			t.Setenv(key, "")
 		}
 	}
+
+	t.Setenv("GIT_CONFIG_GLOBAL", gitEmptyConfigPath())
+	t.Setenv("GIT_CONFIG_SYSTEM", gitEmptyConfigPath())
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("GIT_CONFIG_COUNT", "0")
 }
 
 func isGitConfigEnv(e string) bool {
-	return strings.HasPrefix(e, "GIT_CONFIG_GLOBAL=") ||
-		strings.HasPrefix(e, "GIT_CONFIG_SYSTEM=") ||
-		strings.HasPrefix(e, "GIT_CONFIG_NOSYSTEM=") ||
-		strings.HasPrefix(e, "GIT_CONFIG_COUNT=") ||
-		strings.HasPrefix(e, "GIT_CONFIG_KEY_") ||
-		strings.HasPrefix(e, "GIT_CONFIG_VALUE_")
+	return strings.HasPrefix(e, "GIT_CONFIG_")
 }

--- a/e2e/tests/alternates_test.go
+++ b/e2e/tests/alternates_test.go
@@ -102,7 +102,7 @@ func TestAlternates_RelativeObjectAlternate_CheckpointSync(t *testing.T) {
 	// path that reads the alternate-resident checkpoint commits via go-git.
 	cmd := exec.Command(entire.BinPath(), "hooks", "git", "pre-push", "origin")
 	cmd.Dir = work
-	cmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0", "GIT_TERMINAL_PROMPT=0")
+	cmd.Env = upsertEnv(os.Environ(), "ENTIRE_TEST_TTY", "0", "GIT_TERMINAL_PROMPT", "0")
 	combined, runErr := cmd.CombinedOutput()
 	output := string(combined)
 	t.Logf("entire pre-push output:\n%s", output)
@@ -127,4 +127,33 @@ func writeRepoFile(t *testing.T, dir, name, content string) {
 	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", name, err)
 	}
+}
+
+// upsertEnv returns env with each key=value pair set, replacing the first
+// occurrence of an existing entry for that key. Avoids the silent shadowing
+// that happens when a key is simply appended to os.Environ() but already
+// present in the inherited environment.
+func upsertEnv(env []string, pairs ...string) []string {
+	if len(pairs)%2 != 0 {
+		panic("upsertEnv requires an even number of key/value arguments")
+	}
+	out := make([]string, len(env))
+	copy(out, env)
+	for i := 0; i < len(pairs); i += 2 {
+		key, value := pairs[i], pairs[i+1]
+		prefix := key + "="
+		entry := prefix + value
+		replaced := false
+		for j, e := range out {
+			if strings.HasPrefix(e, prefix) {
+				out[j] = entry
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			out = append(out, entry)
+		}
+	}
+	return out
 }

--- a/e2e/tests/alternates_test.go
+++ b/e2e/tests/alternates_test.go
@@ -1,0 +1,130 @@
+//go:build e2e
+
+package tests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/e2e/entire"
+	"github.com/entireio/cli/e2e/testutil"
+)
+
+// TestAlternates_RelativeObjectAlternate_CheckpointSync exercises the checkpoint
+// push/sync path in a repository whose objects are resolved through a RELATIVE
+// objects/info/alternates entry — the layout produced by a shared clone
+// (`git clone --shared` / `--reference`).
+//
+// go-git cannot follow relative alternates on its own (it strips "../" and
+// anchors at the filesystem root), so gitrepo.OpenPath rewrites them to absolute
+// before go-git reads them. Without that, the pre-push sync's
+// collectCommitsSince() fails with "object not found" on alternate-resident
+// checkpoint commits, even though git itself resolves them.
+func TestAlternates_RelativeObjectAlternate_CheckpointSync(t *testing.T) {
+	// Siblings under one parent so the relative alternate path is short and
+	// mirrors a real shared-clone layout.
+	parent := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(parent); err == nil {
+		parent = resolved
+	}
+	shared := filepath.Join(parent, "shared")
+	work := filepath.Join(parent, "work")
+	originBare := filepath.Join(parent, "origin.git")
+
+	// Build the shared object store. Its objects become the alternate; the work
+	// repo will hold none of these locally.
+	testutil.Git(t, parent, "init", "shared")
+	testutil.Git(t, shared, "config", "user.name", "Alt Test")
+	testutil.Git(t, shared, "config", "user.email", "alt@test.local")
+	writeRepoFile(t, shared, "base.txt", "base\n")
+	testutil.Git(t, shared, "add", ".")
+	testutil.Git(t, shared, "commit", "-m", "B0")
+	base := testutil.GitOutput(t, shared, "rev-parse", "HEAD")
+
+	// Checkpoint-branch commits K1<-K2, created in the shared store so they are
+	// only reachable from the work repo via the alternate.
+	testutil.Git(t, shared, "checkout", "-b", "cp")
+	writeRepoFile(t, shared, "k1.txt", "k1\n")
+	testutil.Git(t, shared, "add", ".")
+	testutil.Git(t, shared, "commit", "-m", "K1")
+	writeRepoFile(t, shared, "k2.txt", "k2\n")
+	testutil.Git(t, shared, "add", ".")
+	testutil.Git(t, shared, "commit", "-m", "K2")
+	k2 := testutil.GitOutput(t, shared, "rev-parse", "HEAD")
+
+	// A divergent commit R1 (sibling of the cp chain off B0) for the remote side,
+	// so the push is non-fast-forward and triggers the rebase/sync path.
+	testutil.Git(t, shared, "checkout", "-b", "remoteside", base)
+	writeRepoFile(t, shared, "r1.txt", "r1\n")
+	testutil.Git(t, shared, "add", ".")
+	testutil.Git(t, shared, "commit", "-m", "R1")
+	r1 := testutil.GitOutput(t, shared, "rev-parse", "HEAD")
+	testutil.Git(t, shared, "checkout", "cp")
+
+	// Bare remote seeded with R1 as the checkpoint branch tip.
+	testutil.Git(t, parent, "init", "--bare", "origin.git")
+	testutil.Git(t, shared, "push", originBare, "remoteside:refs/heads/entire/checkpoints/v1")
+
+	// Shared clone: --shared makes work resolve objects from shared via an
+	// alternate and copies no objects locally.
+	testutil.Git(t, parent, "clone", "--shared", "-o", "base", "shared", "work")
+	testutil.Git(t, work, "config", "user.name", "Alt Test")
+	testutil.Git(t, work, "config", "user.email", "alt@test.local")
+
+	// Rewrite the alternate to a RELATIVE path (git clone writes it absolute);
+	// this is the layout go-git mishandles and the fix repairs.
+	rel, err := filepath.Rel(
+		filepath.Join(work, ".git", "objects"),
+		filepath.Join(shared, ".git", "objects"),
+	)
+	if err != nil {
+		t.Fatalf("compute relative alternate: %v", err)
+	}
+	if !strings.HasPrefix(rel, "..") {
+		t.Fatalf("expected a relative alternate, got %q", rel)
+	}
+	altFile := filepath.Join(work, ".git", "objects", "info", "alternates")
+	if err := os.WriteFile(altFile, []byte(rel+"\n"), 0o644); err != nil {
+		t.Fatalf("write relative alternates: %v", err)
+	}
+
+	entire.Enable(t, work, "claude-code")
+
+	// Point the local checkpoint branch at K2 (object lives only in the
+	// alternate) and aim the checkpoint push at the bare remote.
+	testutil.Git(t, work, "update-ref", "refs/heads/entire/checkpoints/v1", k2)
+	testutil.Git(t, work, "remote", "add", "origin", originBare)
+
+	// Drive the real pre-push hook: non-ff vs the remote forces the sync/rebase
+	// path that reads the alternate-resident checkpoint commits via go-git.
+	cmd := exec.Command(entire.BinPath(), "hooks", "git", "pre-push", "origin")
+	cmd.Dir = work
+	cmd.Env = append(os.Environ(), "ENTIRE_TEST_TTY=0", "GIT_TERMINAL_PROMPT=0")
+	combined, runErr := cmd.CombinedOutput()
+	output := string(combined)
+	t.Logf("entire pre-push output:\n%s", output)
+	if runErr != nil {
+		t.Fatalf("pre-push hook exited non-zero: %v\n%s", runErr, output)
+	}
+
+	if strings.Contains(output, "object not found") || strings.Contains(output, "couldn't sync") {
+		t.Fatalf("checkpoint sync could not resolve alternate-resident objects (relative alternate not followed):\n%s", output)
+	}
+
+	// The rebase should have cherry-picked K1,K2 onto R1 and pushed, advancing
+	// the remote checkpoint branch past R1.
+	got := testutil.GitOutput(t, originBare, "rev-parse", "refs/heads/entire/checkpoints/v1")
+	if got == r1 {
+		t.Fatalf("origin checkpoint branch did not advance past R1 (%s); sync/push did not complete:\n%s", r1, output)
+	}
+}
+
+func writeRepoFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/445
<!-- entire-trail-link-end -->

go-git's dotgit.Alternates() strips leading "../" and anchors entries at the filesystem root, so relative objects/info/alternates entries — the shape produced by `git clone --shared`/`--reference` — point at non-existent paths. The pre-push checkpoint sync then fails to resolve alternate-resident commits even though git itself reads them.

Wrap both the dotgit and common-git filesystems with an alternates rewriter that resolves relative entries against <root>/objects on read. The rewriter preserves file structure (comments, blanks, absolute entries pass through untouched), caps reads at 4096 bytes, and applies to nested alternate chains via the os-rooted AlternatesFS. Linked worktrees are covered because the wrap applies to the common dir where the alternates file actually lives.

Adds unit tests for the rewriter, integration tests for OpenPath across multiple/nested/linked-worktree relative-alternate layouts, and an e2e test reproducing the shared-clone checkpoint sync failure. Tests that shell out to git get GIT_CONFIG_* isolation so they don't pick up host config.

Support for Windows confirmed via [E2E tests](https://github.com/entireio/cli/actions/runs/26567317369/job/78265217563):
```
✓ TestAlternates_RelativeObjectAlternate_CheckpointSync (5.2s)
− TestAttachSessionAddsToExistingCheckpoint
− TestAttachSessionCreatesCheckpoint
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how repositories with alternates are opened for all go-git paths (checkpoint sync, tests using OpenPath); behavior is well-tested but incorrect rewriting could break object resolution for shared or worktree layouts.
> 
> **Overview**
> **go-git can’t resolve relative `objects/info/alternates` entries** (shared/`--reference` clones). This PR rewrites those paths on read so checkpoint sync and `OpenPath` can load objects from alternate stores.
> 
> On open, **dot-git and common-git billy filesystems** are wrapped so `objects/info/alternates` serves in-memory content with relative lines resolved against `<git-dir>/objects`, matching Git. Comments, blanks, and absolute paths are unchanged; reads are capped at 4KB. The **OS-rooted alternates FS** applies the same rewrite for **nested** `…/objects/info/alternates` files in alternate chains.
> 
> **Tests:** unit coverage for the rewriter; `OpenPath` integration for single/multiple/nested relative alternates and linked worktrees; e2e pre-push checkpoint sync with a forced relative alternate. **`IsolateGitConfigEnv`** and broader `GIT_CONFIG_*` filtering stabilize tests that call git via `os.Environ()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f14f107978ba0dca3c2df503a33598a2aaafd26. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->