### PR TITLE
fix(install): point Windows users at Scoop instead of failing

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,14 @@ detect_os() {
         linux)
             echo "linux"
             ;;
+        mingw*|msys*|cygwin*)
+            error "install.sh does not support Windows, you can install the Entire CLI using scoop:
+
+    scoop install entire/cli
+
+  Or download the Windows zip from:
+    https://github.com/entireio/cli/releases/latest"
+            ;;
         *)
             error "Unsupported operating system: $os"
             ;;


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/446
<!-- entire-trail-link-end -->

## Summary
- Git Bash / MSYS / Cygwin shells return `mingw*`/`msys*`/`cygwin*` from `uname -s` and fell into the generic "Unsupported operating system" branch in `install.sh`.
- The Entire CLI does ship a Windows build (via goreleaser + the Scoop bucket); `install.sh` just doesn't know how to fetch it.
- Detect those shells and exit with a message pointing at `scoop install entire/cli` and the release zip download.

## Test plan
- [ ] Run `bash scripts/install.sh` from Git Bash on Windows and verify the new Scoop-pointer message is shown instead of "Unsupported operating system: mingw64_nt-...".
- [ ] Confirm macOS/Linux installs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Install-script UX only; no change to download, verify, or install logic on supported platforms.
> 
> **Overview**
> **`scripts/install.sh`** now treats Git Bash, MSYS, and Cygwin as Windows when `uname -s` matches `mingw*`, `msys*`, or `cygwin*`. Instead of the generic unsupported-OS error, the script exits with guidance to install via **`scoop install entire/cli`** or download the latest Windows release zip from GitHub.
> 
> macOS and Linux detection paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d78252f30ceaf7024237952f3a245e34f7bfdc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->