### PR TITLE
Auto-pick v2 auth when split-host is configured

### DIFF
--- a/cmd/entire/cli/api/base_url.go
+++ b/cmd/entire/cli/api/base_url.go
@@ -60,6 +60,14 @@ func AuthBaseURL() string {
 	return NormalizeOriginURL(raw)
 }
 
+// IsSplitHost reports whether the CLI is configured for split-host —
+// i.e. ENTIRE_AUTH_BASE_URL points at a different origin than the data
+// API. Compared on canonicalised values, so a redundant override
+// (trailing slash, case differences) doesn't register as split.
+func IsSplitHost() bool {
+	return AuthBaseURL() != BaseURL()
+}
+
 // ResolveURL joins an API-relative path against the effective base URL.
 func ResolveURL(path string) (string, error) {
 	return ResolveURLFromBase(BaseURL(), path)

--- a/cmd/entire/cli/api/base_url.go
+++ b/cmd/entire/cli/api/base_url.go
@@ -62,10 +62,13 @@ func AuthBaseURL() string {
 
 // IsSplitHost reports whether the CLI is configured for split-host —
 // i.e. ENTIRE_AUTH_BASE_URL points at a different origin than the data
-// API. Compared on canonicalised values, so a redundant override
-// (trailing slash, case differences) doesn't register as split.
+// API. Both sides are canonicalised via NormalizeOriginURL before
+// comparison: AuthBaseURL already does this internally, but BaseURL
+// only trims whitespace and a trailing slash, so a cosmetically-
+// different ENTIRE_API_BASE_URL (uppercase host, explicit :443, path
+// suffix) would otherwise look split when it isn't.
 func IsSplitHost() bool {
-	return AuthBaseURL() != BaseURL()
+	return AuthBaseURL() != NormalizeOriginURL(BaseURL())
 }
 
 // ResolveURL joins an API-relative path against the effective base URL.

--- a/cmd/entire/cli/api/base_url_test.go
+++ b/cmd/entire/cli/api/base_url_test.go
@@ -82,6 +82,29 @@ func TestAuthBaseURL_CanonicalisesScheme_HostCase_DefaultPort(t *testing.T) {
 	}
 }
 
+func TestIsSplitHost(t *testing.T) {
+	cases := map[string]struct {
+		base, auth string
+		want       bool
+	}{
+		"both unset":          {"", "", false},
+		"auth unset":          {"https://entire.io", "", false},
+		"auth same as base":   {"https://api.example.com", "https://api.example.com", false},
+		"auth cosmetic match": {"https://api.example.com", "https://api.example.com/", false},
+		"different origins":   {"https://api.example.com", "https://auth.example.com", true},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(BaseURLEnvVar, tc.base)
+			t.Setenv(AuthBaseURLEnvVar, tc.auth)
+			if got := IsSplitHost(); got != tc.want {
+				t.Errorf("IsSplitHost() = %v, want %v (base=%q auth=%q)", got, tc.want, tc.base, tc.auth)
+			}
+		})
+	}
+}
+
 func TestNormalizeOriginURL(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/api/base_url_test.go
+++ b/cmd/entire/cli/api/base_url_test.go
@@ -92,6 +92,14 @@ func TestIsSplitHost(t *testing.T) {
 		"auth same as base":   {"https://api.example.com", "https://api.example.com", false},
 		"auth cosmetic match": {"https://api.example.com", "https://api.example.com/", false},
 		"different origins":   {"https://api.example.com", "https://auth.example.com", true},
+		// Regressions for asymmetric-normalisation bug: BaseURL only
+		// trims whitespace/trailing slash, AuthBaseURL canonicalises,
+		// so cosmetic differences in ENTIRE_API_BASE_URL would falsely
+		// register as split-host if both sides aren't normalised.
+		"base uppercase host, auth unset": {"HTTPS://API.EXAMPLE.COM", "", false},
+		"base default port, auth unset":   {"https://api.example.com:443", "", false},
+		"base path suffix, auth unset":    {"https://api.example.com/v1", "", false},
+		"base trailing slash, auth unset": {"https://api.example.com/", "", false},
 	}
 
 	for name, tc := range cases {

--- a/cmd/entire/cli/auth/client.go
+++ b/cmd/entire/cli/auth/client.go
@@ -36,8 +36,9 @@ type DeviceAuthPoll struct {
 }
 
 // Client wraps a deviceflow.Client preconfigured for whichever provider
-// version is selected via ENTIRE_AUTH_PROVIDER_VERSION (defaulting to
-// v1).
+// version is active. See CurrentProvider for the resolution rules
+// (ENTIRE_AUTH_PROVIDER_VERSION wins, then split-host auto-detect,
+// then v1 fallback).
 type Client struct {
 	inner *deviceflow.Client
 }

--- a/cmd/entire/cli/auth/provider.go
+++ b/cmd/entire/cli/auth/provider.go
@@ -8,25 +8,9 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 )
 
-// ProviderVersionEnvVar explicitly selects which OAuth surface this CLI
-// talks to.
-//
-// Recognised values:
-//
-//   - "v1"  — legacy single-host device-flow surface
-//   - "v2"  — OIDC-standard surface (with RFC 8693 STS for split-host)
-//
-// Unset (or unrecognised): the version is inferred from the deployment
-// shape — see effectiveProviderVersion. A user-set ENTIRE_AUTH_BASE_URL
-// that differs from the data API origin signals split-host, which only
-// the v2 surface can talk to, so v2 is picked automatically. The env
-// var is only needed to override that inference (e.g. force v2 against
-// a v2-capable single-host server, or force v1 to suppress the
-// auto-upgrade).
-//
-// Read once at process startup via CurrentProvider; later flips within
-// the same process are intentionally ignored. Tests inject via
-// SetProviderForTest rather than mutating the env mid-run.
+// ProviderVersionEnvVar overrides the auto-detected provider version.
+// Set to "v1" or "v2"; see effectiveProviderVersion for resolution.
+// Read once at process startup via CurrentProvider.
 const ProviderVersionEnvVar = "ENTIRE_AUTH_PROVIDER_VERSION"
 
 // Provider captures the per-surface bits of OAuth wiring.
@@ -88,31 +72,18 @@ func resolveProvider(version string) Provider {
 	}
 }
 
-// effectiveProviderVersion picks the version string fed into
-// resolveProvider for this process. Resolution order:
+// effectiveProviderVersion resolves the version string fed into
+// resolveProvider. Order: explicit env var > split-host auto-detect > v1.
 //
-//  1. ENTIRE_AUTH_PROVIDER_VERSION explicit value wins. "v1"/"v2" route
-//     directly; anything unrecognised falls through resolveProvider's
-//     default (v1), so a typo doesn't silently auto-upgrade.
-//  2. Split-host detected (AuthBaseURL != BaseURL) → "v2". An explicit
-//     ENTIRE_AUTH_BASE_URL pointing at a different origin than the data
-//     API is the operator's signal that the auth surface lives
-//     elsewhere; only v2's OIDC-standard paths know how to talk to a
-//     dedicated auth host. The data host's defaults (entire.io as of
-//     2026-05) don't serve the v2 surface, so picking v2 when no split
-//     is configured would break login.
-//  3. Otherwise → "v1". Single-host deployments stay on the surface
-//     their backend currently exposes; users on a v2-capable single-
-//     host server can opt in via the env var.
-//
-// Mixing env var + split-host: the env var always wins, so a user who
-// wants v1 even with a split-host config (e.g. mid-migration testing)
-// can set ENTIRE_AUTH_PROVIDER_VERSION=v1 explicitly.
+// The split-host auto-detect can't extend to a default flip: as of
+// 2026-05 entire.io (the unset-env default data host) does not serve
+// the v2 OIDC surface, so picking v2 without an explicit split-host
+// signal would break login for every existing user.
 func effectiveProviderVersion() string {
 	if v := strings.TrimSpace(os.Getenv(ProviderVersionEnvVar)); v != "" {
 		return v
 	}
-	if api.AuthBaseURL() != api.BaseURL() {
+	if api.IsSplitHost() {
 		return "v2"
 	}
 	return "v1"
@@ -132,14 +103,8 @@ var (
 )
 
 // CurrentProvider returns the active Provider for this process.
-//
-// Resolution: call effectiveProviderVersion exactly once on first
-// invocation, freeze the result, and return the same Provider on every
-// subsequent call. The function reads ENTIRE_AUTH_PROVIDER_VERSION,
-// ENTIRE_AUTH_BASE_URL, and ENTIRE_API_BASE_URL — all three must be
-// set before the first CurrentProvider call. Tests that need a
-// different provider use SetProviderForTest, which bypasses the
-// singleton entirely.
+// Resolution freezes on the first call (env vars must be set before
+// then). Tests bypass the singleton via SetProviderForTest.
 func CurrentProvider() Provider {
 	providerTestMu.Lock()
 	override := providerForTest

--- a/cmd/entire/cli/auth/provider.go
+++ b/cmd/entire/cli/auth/provider.go
@@ -4,14 +4,25 @@ import (
 	"os"
 	"strings"
 	"sync"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
 )
 
-// ProviderVersionEnvVar selects which OAuth surface this CLI talks to.
+// ProviderVersionEnvVar explicitly selects which OAuth surface this CLI
+// talks to.
 //
 // Recognised values:
 //
-//   - "v1" (or unset / unrecognised) — current device-flow surface
-//   - "v2"                            — next-generation device-flow surface
+//   - "v1"  — legacy single-host device-flow surface
+//   - "v2"  — OIDC-standard surface (with RFC 8693 STS for split-host)
+//
+// Unset (or unrecognised): the version is inferred from the deployment
+// shape — see effectiveProviderVersion. A user-set ENTIRE_AUTH_BASE_URL
+// that differs from the data API origin signals split-host, which only
+// the v2 surface can talk to, so v2 is picked automatically. The env
+// var is only needed to override that inference (e.g. force v2 against
+// a v2-capable single-host server, or force v1 to suppress the
+// auto-upgrade).
 //
 // Read once at process startup via CurrentProvider; later flips within
 // the same process are intentionally ignored. Tests inject via
@@ -77,6 +88,36 @@ func resolveProvider(version string) Provider {
 	}
 }
 
+// effectiveProviderVersion picks the version string fed into
+// resolveProvider for this process. Resolution order:
+//
+//  1. ENTIRE_AUTH_PROVIDER_VERSION explicit value wins. "v1"/"v2" route
+//     directly; anything unrecognised falls through resolveProvider's
+//     default (v1), so a typo doesn't silently auto-upgrade.
+//  2. Split-host detected (AuthBaseURL != BaseURL) → "v2". An explicit
+//     ENTIRE_AUTH_BASE_URL pointing at a different origin than the data
+//     API is the operator's signal that the auth surface lives
+//     elsewhere; only v2's OIDC-standard paths know how to talk to a
+//     dedicated auth host. The data host's defaults (entire.io as of
+//     2026-05) don't serve the v2 surface, so picking v2 when no split
+//     is configured would break login.
+//  3. Otherwise → "v1". Single-host deployments stay on the surface
+//     their backend currently exposes; users on a v2-capable single-
+//     host server can opt in via the env var.
+//
+// Mixing env var + split-host: the env var always wins, so a user who
+// wants v1 even with a split-host config (e.g. mid-migration testing)
+// can set ENTIRE_AUTH_PROVIDER_VERSION=v1 explicitly.
+func effectiveProviderVersion() string {
+	if v := strings.TrimSpace(os.Getenv(ProviderVersionEnvVar)); v != "" {
+		return v
+	}
+	if api.AuthBaseURL() != api.BaseURL() {
+		return "v2"
+	}
+	return "v1"
+}
+
 var (
 	providerOnce     sync.Once
 	resolvedProvider Provider
@@ -92,10 +133,13 @@ var (
 
 // CurrentProvider returns the active Provider for this process.
 //
-// Resolution: read ENTIRE_AUTH_PROVIDER_VERSION exactly once on first
-// call, freeze the result, and return the same Provider on every
-// subsequent call. Tests that need a different provider must use
-// SetProviderForTest before any auth call constructs the singleton.
+// Resolution: call effectiveProviderVersion exactly once on first
+// invocation, freeze the result, and return the same Provider on every
+// subsequent call. The function reads ENTIRE_AUTH_PROVIDER_VERSION,
+// ENTIRE_AUTH_BASE_URL, and ENTIRE_API_BASE_URL — all three must be
+// set before the first CurrentProvider call. Tests that need a
+// different provider use SetProviderForTest, which bypasses the
+// singleton entirely.
 func CurrentProvider() Provider {
 	providerTestMu.Lock()
 	override := providerForTest
@@ -104,7 +148,7 @@ func CurrentProvider() Provider {
 		return *override
 	}
 	providerOnce.Do(func() {
-		resolvedProvider = resolveProvider(os.Getenv(ProviderVersionEnvVar))
+		resolvedProvider = resolveProvider(effectiveProviderVersion())
 	})
 	return resolvedProvider
 }

--- a/cmd/entire/cli/auth/provider_test.go
+++ b/cmd/entire/cli/auth/provider_test.go
@@ -41,19 +41,10 @@ func TestResolveProvider_V2(t *testing.T) {
 	}
 }
 
-// --- effectiveProviderVersion ----------------------------------------------
-//
-// These tests use t.Setenv and therefore cannot be t.Parallel — Go's
-// testing harness panics if either is paired with the other. The
-// trade-off is fine because effectiveProviderVersion is a tiny pure
-// function over env state; the bodies are short.
+// effectiveProviderVersion tests cannot be t.Parallel (they use t.Setenv).
 
-// TestEffectiveProviderVersion_ExplicitEnvWins pins the highest-
-// priority rule: ENTIRE_AUTH_PROVIDER_VERSION overrides everything
-// else, including a split-host configuration that would otherwise
-// auto-pick v2.
 func TestEffectiveProviderVersion_ExplicitEnvWins(t *testing.T) {
-	// Split-host config — would auto-pick v2 if env var were unset.
+	// Split-host configured: would auto-pick v2 if env were unset.
 	t.Setenv(api.BaseURLEnvVar, "https://api.example.com")
 	t.Setenv(api.AuthBaseURLEnvVar, "https://auth.example.com")
 
@@ -67,20 +58,15 @@ func TestEffectiveProviderVersion_ExplicitEnvWins(t *testing.T) {
 		t.Errorf("explicit v2 override = %q, want v2", got)
 	}
 
-	// Unrecognised value falls through to resolveProvider's default
-	// (v1) — the version string is returned verbatim here, and the
-	// routing table catches unknowns. We don't want an unrecognised
-	// value to suddenly invoke the auto-detect path, because that
-	// would hide typos behind a silent upgrade.
+	// Unrecognised values pass through verbatim rather than triggering
+	// auto-detect — a typo must not silently auto-upgrade. resolveProvider
+	// downstream defaults unknowns to v1.
 	t.Setenv(ProviderVersionEnvVar, "v3")
 	if got := effectiveProviderVersion(); got != "v3" {
 		t.Errorf("unrecognised value = %q, want passthrough %q", got, "v3")
 	}
 }
 
-// TestEffectiveProviderVersion_SplitHostPicksV2 is the actual user-
-// facing change: setting ENTIRE_AUTH_BASE_URL to an origin different
-// from the data API origin opts into v2 without an extra env var.
 func TestEffectiveProviderVersion_SplitHostPicksV2(t *testing.T) {
 	t.Setenv(ProviderVersionEnvVar, "")
 	t.Setenv(api.BaseURLEnvVar, "https://api.example.com")
@@ -91,13 +77,9 @@ func TestEffectiveProviderVersion_SplitHostPicksV2(t *testing.T) {
 	}
 }
 
-// TestEffectiveProviderVersion_SameHostPicksV1 covers a user who set
-// ENTIRE_AUTH_BASE_URL redundantly to the same value as the data API
-// — that's not actually a split-host configuration, so the auto-
-// detect should stay on v1 rather than picking v2 against a single-
-// host server that may not serve OIDC endpoints. The canonicalisation
-// inside AuthBaseURL/BaseURL handles cosmetic differences (trailing
-// slash, case) so this rule isn't fooled by formatting.
+// Redundant ENTIRE_AUTH_BASE_URL (same origin as data API, just
+// cosmetically different) must not register as split — relies on
+// AuthBaseURL/BaseURL canonicalisation.
 func TestEffectiveProviderVersion_SameHostPicksV1(t *testing.T) {
 	t.Setenv(ProviderVersionEnvVar, "")
 	t.Setenv(api.BaseURLEnvVar, "https://api.example.com")
@@ -108,10 +90,7 @@ func TestEffectiveProviderVersion_SameHostPicksV1(t *testing.T) {
 	}
 }
 
-// TestEffectiveProviderVersion_UnsetDefaultsToV1 covers the entire.io
-// default: nothing set, AuthBaseURL falls back to BaseURL, no split
-// signal, stay on v1. This is the path most existing users hit and
-// the one that must not silently break.
+// Entire.io default path — must not regress; most users hit this.
 func TestEffectiveProviderVersion_UnsetDefaultsToV1(t *testing.T) {
 	t.Setenv(ProviderVersionEnvVar, "")
 	t.Setenv(api.BaseURLEnvVar, "")

--- a/cmd/entire/cli/auth/provider_test.go
+++ b/cmd/entire/cli/auth/provider_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
 )
 
 func TestResolveProvider_DefaultsToV1(t *testing.T) {
@@ -36,6 +38,87 @@ func TestResolveProvider_V2(t *testing.T) {
 	}
 	if got.AuthTokensPath != "/api/v1/auth/tokens" {
 		t.Errorf("v2 AuthTokensPath = %q", got.AuthTokensPath)
+	}
+}
+
+// --- effectiveProviderVersion ----------------------------------------------
+//
+// These tests use t.Setenv and therefore cannot be t.Parallel — Go's
+// testing harness panics if either is paired with the other. The
+// trade-off is fine because effectiveProviderVersion is a tiny pure
+// function over env state; the bodies are short.
+
+// TestEffectiveProviderVersion_ExplicitEnvWins pins the highest-
+// priority rule: ENTIRE_AUTH_PROVIDER_VERSION overrides everything
+// else, including a split-host configuration that would otherwise
+// auto-pick v2.
+func TestEffectiveProviderVersion_ExplicitEnvWins(t *testing.T) {
+	// Split-host config — would auto-pick v2 if env var were unset.
+	t.Setenv(api.BaseURLEnvVar, "https://api.example.com")
+	t.Setenv(api.AuthBaseURLEnvVar, "https://auth.example.com")
+
+	t.Setenv(ProviderVersionEnvVar, "v1")
+	if got := effectiveProviderVersion(); got != "v1" {
+		t.Errorf("explicit v1 override = %q, want v1", got)
+	}
+
+	t.Setenv(ProviderVersionEnvVar, "v2")
+	if got := effectiveProviderVersion(); got != "v2" {
+		t.Errorf("explicit v2 override = %q, want v2", got)
+	}
+
+	// Unrecognised value falls through to resolveProvider's default
+	// (v1) — the version string is returned verbatim here, and the
+	// routing table catches unknowns. We don't want an unrecognised
+	// value to suddenly invoke the auto-detect path, because that
+	// would hide typos behind a silent upgrade.
+	t.Setenv(ProviderVersionEnvVar, "v3")
+	if got := effectiveProviderVersion(); got != "v3" {
+		t.Errorf("unrecognised value = %q, want passthrough %q", got, "v3")
+	}
+}
+
+// TestEffectiveProviderVersion_SplitHostPicksV2 is the actual user-
+// facing change: setting ENTIRE_AUTH_BASE_URL to an origin different
+// from the data API origin opts into v2 without an extra env var.
+func TestEffectiveProviderVersion_SplitHostPicksV2(t *testing.T) {
+	t.Setenv(ProviderVersionEnvVar, "")
+	t.Setenv(api.BaseURLEnvVar, "https://api.example.com")
+	t.Setenv(api.AuthBaseURLEnvVar, "https://auth.example.com")
+
+	if got := effectiveProviderVersion(); got != "v2" {
+		t.Errorf("split-host auto-detect = %q, want v2", got)
+	}
+}
+
+// TestEffectiveProviderVersion_SameHostPicksV1 covers a user who set
+// ENTIRE_AUTH_BASE_URL redundantly to the same value as the data API
+// — that's not actually a split-host configuration, so the auto-
+// detect should stay on v1 rather than picking v2 against a single-
+// host server that may not serve OIDC endpoints. The canonicalisation
+// inside AuthBaseURL/BaseURL handles cosmetic differences (trailing
+// slash, case) so this rule isn't fooled by formatting.
+func TestEffectiveProviderVersion_SameHostPicksV1(t *testing.T) {
+	t.Setenv(ProviderVersionEnvVar, "")
+	t.Setenv(api.BaseURLEnvVar, "https://api.example.com")
+	t.Setenv(api.AuthBaseURLEnvVar, "https://api.example.com/")
+
+	if got := effectiveProviderVersion(); got != "v1" {
+		t.Errorf("same-host auto-detect = %q, want v1 (no split-host signal)", got)
+	}
+}
+
+// TestEffectiveProviderVersion_UnsetDefaultsToV1 covers the entire.io
+// default: nothing set, AuthBaseURL falls back to BaseURL, no split
+// signal, stay on v1. This is the path most existing users hit and
+// the one that must not silently break.
+func TestEffectiveProviderVersion_UnsetDefaultsToV1(t *testing.T) {
+	t.Setenv(ProviderVersionEnvVar, "")
+	t.Setenv(api.BaseURLEnvVar, "")
+	t.Setenv(api.AuthBaseURLEnvVar, "")
+
+	if got := effectiveProviderVersion(); got != "v1" {
+		t.Errorf("unset env = %q, want v1 (entire.io default)", got)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/447
<!-- entire-trail-link-end -->

## Summary

Follow-up to #1258. Removes the need to set both `ENTIRE_AUTH_BASE_URL` *and* `ENTIRE_AUTH_PROVIDER_VERSION=v2` when targeting a split-host deployment (e.g. partial.to + us.auth.partial.to). When `ENTIRE_AUTH_BASE_URL` is set to a different origin than the data API, the CLI auto-picks v2.

## Why not flip the default outright

Probed entire.io directly before deciding:

```
POST https://entire.io/device_authorization       → HTTP 405 Method Not Allowed
GET  https://entire.io/.well-known/openid-configuration → HTTP 200 returning the SPA HTML (no discovery doc)
POST https://entire.io/oauth/device/code          → HTTP 200, valid device code (v1 works)
```

So v2 isn't live on entire.io yet. An unconditional default flip would break login for every existing CLI user. The auto-detect approach makes "split-host config = v2" the actual UX (without requiring a second env var) while leaving the entire.io path on v1 until the backend ships the v2 OIDC surface.

## Resolution order

1. `ENTIRE_AUTH_PROVIDER_VERSION` explicit value wins (`v1` / `v2` / passthrough to `resolveProvider`'s default for unrecognised values — typos don't silently auto-upgrade).
2. `AuthBaseURL() != BaseURL()` → `v2`. Canonicalisation in those helpers means a redundant `ENTIRE_AUTH_BASE_URL=https://entire.io/` (trailing slash, same host) doesn't trigger v2.
3. Otherwise → `v1`.

Users on a v2-capable single-host server can still opt in with `ENTIRE_AUTH_PROVIDER_VERSION=v2`. Users mid-migration who want to suppress the auto-upgrade can force `v1` the same way.

## Test plan

- [x] `TestEffectiveProviderVersion_ExplicitEnvWins` — env var beats auto-detect for v1, v2, and unrecognised values
- [x] `TestEffectiveProviderVersion_SplitHostPicksV2` — the user-facing change
- [x] `TestEffectiveProviderVersion_SameHostPicksV1` — redundant env value doesn't trigger v2
- [x] `TestEffectiveProviderVersion_UnsetDefaultsToV1` — entire.io path (most existing users) doesn't regress
- [x] `mise run fmt && mise run lint && go test ./...` clean

## Follow-up (out of scope)

- Bring v2 OIDC surface to entire.io, then a tiny PR can flip the default outright and the env-var dance disappears.
- Optionally add OIDC discovery (`/.well-known/openid-configuration`) so split-host can be discovered from the data API alone, eliminating `ENTIRE_AUTH_BASE_URL` as a manual config step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes login routing for auth provider selection; mitigated by defaulting unchanged single-host users to v1 and letting the env var override auto-detect.
> 
> **Overview**
> When `ENTIRE_AUTH_PROVIDER_VERSION` is unset, the CLI now infers the OAuth provider version from deployment shape instead of defaulting only via that env var.
> 
> **Split-host** setups—`ENTIRE_AUTH_BASE_URL` on a different origin than the data API (`api.AuthBaseURL() != api.BaseURL()`)—automatically select **v2**, so operators no longer need both split-host URLs and `ENTIRE_AUTH_PROVIDER_VERSION=v2`. Same-origin configs (including redundant auth URL with trailing slash) still resolve to **v1**, preserving existing **entire.io** single-host behavior where v2 is not live yet.
> 
> **Explicit** `ENTIRE_AUTH_PROVIDER_VERSION` still wins (including forcing v1 during migration). Unrecognized env values are passed through to `resolveProvider` without triggering auto-detect, so typos do not silently upgrade.
> 
> Docs on `Client` / `CurrentProvider` and new unit tests document and lock in this resolution order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7789d1735c4de823253d7d9781920e031b58beb4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->