### PR TITLE
Trim down the CLAUDE.md file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ This runs unit tests, integration tests, and the E2E canary (Vogon agent) in seq
 
 ### Running E2E Canary Tests (Vogon Agent)
 
-The Vogon agent is a deterministic fake agent that exercises the full E2E test suite without making any API calls. Named after the Vogons from The Hitchhiker's Guide to the Galaxy — bureaucratic, procedural, and deterministic to a fault.
+The Vogon agent is a deterministic fake agent that exercises the full E2E test suite without making any API calls.
 
 ```bash
 mise run test:e2e:canary           # Run all E2E tests with the Vogon agent
@@ -109,13 +109,7 @@ mise run test:e2e:canary TestFoo   # Run a specific test
 
 ```bash
 mise run test:e2e [filter]                          # All agents, filtered
-mise run test:e2e --agent claude-code [filter]       # Claude Code only
-mise run test:e2e --agent gemini-cli [filter]        # Gemini CLI only
-mise run test:e2e --agent opencode [filter]          # OpenCode only
-mise run test:e2e --agent cursor [filter]            # Cursor only
-mise run test:e2e --agent factoryai-droid [filter]   # Factory AI Droid only
-mise run test:e2e --agent copilot-cli [filter]       # Copilot CLI only
-mise run test:e2e --agent pi [filter]                # Pi only
+mise run test:e2e --agent claude-code [filter]       # Claude Code only as an example here, replace `claude-code` with other agents to run tests for those agents
 ```
 
 E2E tests:
@@ -289,7 +283,7 @@ if _, err := paths.WorktreeRoot(); err != nil {
 ```
 
 **When NOT to use `SilentError`:**
-For normal errors where the default error message is sufficient, just return the error directly. main.go will print it:
+For normal errors where the default error message is sufficient, return the error directly. main.go will print it:
 
 ```go
 // Normal error - main.go will print "unknown strategy: foo"
@@ -343,7 +337,7 @@ if settings.IsSummarizeEnabled() {
 ### Logging vs User Output
 
 - **Internal/debug logging**: Use `logging.Debug/Info/Warn/Error(ctx, msg, attrs...)` from `cmd/entire/cli/logging/`. Writes to `.entire/logs/`.
-- **Enabling debug/perf logs locally**: Prefer adding `"log_level": "DEBUG"` to `.entire/settings.local.json` when you need detailed hook/perf logs. This file is gitignored, so it is a low-risk local-only change. `ENTIRE_LOG_LEVEL=debug` also works and takes precedence.
+- **Enabling debug/perf logs locally**: Prefer adding `"log_level": "DEBUG"` to `.entire/settings.local.json` when you need detailed hook/perf logs. This file is gitignored. `ENTIRE_LOG_LEVEL=debug` also works and takes precedence.
 - **User-facing output**: Use `fmt.Fprint*(cmd.OutOrStdout(), ...)` or `cmd.ErrOrStderr()`.
 
 Don't use `fmt.Print*` for operational messages (checkpoint saves, hook invocations, strategy decisions) - those should use the `logging` package.
@@ -448,336 +442,33 @@ The manual-commit strategy (`manual_commit*.go`) does not modify the active bran
 
 - `strategy.go` - Interface definition and context structs (`StepContext`, `TaskStepContext`, `RewindPoint`, etc.)
 - `common.go` - Helpers for metadata extraction, tree building, rewind validation, `ListCheckpoints()`
-- `session.go` - Session/checkpoint data structures
-- `push_common.go` - PrePush logic for pushing `entire/checkpoints/v1` branch
-- `manual_commit.go` - Manual-commit strategy main implementation
-- `manual_commit_types.go` - Type definitions: `SessionState`, `CheckpointInfo`, `CondenseResult`
-- `manual_commit_session.go` - Session state management (load/save/list session states)
-- `manual_commit_condensation.go` - Condense logic for copying logs to `entire/checkpoints/v1`
-- `manual_commit_rewind.go` - Rewind implementation: file restoration from checkpoint trees
-- `manual_commit_git.go` - Git operations: checkpoint commits, tree building
-- `manual_commit_logs.go` - Session log retrieval and session listing
-- `manual_commit_hooks.go` - Git hook handlers (prepare-commit-msg, post-commit, post-rewrite, pre-push)
-- `manual_commit_reset.go` - Shadow branch reset/cleanup functionality
+- `manual_commit*.go` - Manual-commit strategy: main impl, types, session state, condensation, rewind, git ops, logs, hook handlers (prepare-commit-msg, post-commit, post-rewrite, pre-push), reset
 - `cleanup.go` - Cleanup discovery/deletion for shadow branches, session states, and checkpoint metadata
-- `session_state.go` - Package-level session state functions (`LoadSessionState`, `SaveSessionState`, `ListSessionStates`, `FindMostRecentSession`)
+- `session_state.go` - Package-level session state functions
 - `hooks.go` - Git hook installation
 
-#### Checkpoint Package (`cmd/entire/cli/checkpoint/`)
+Note: `checkpoint/configloader.go` overrides go-git's default config loader with a symlink-following `billy.Basic` (`osSymlinkFS`) — go-git's default reads config via `os.Root`, which rejects absolute symlinks in any path component (e.g. a `~/.config` managed by a dotfile tool), silently dropping global config so author identity fell back to "Unknown" and signing was skipped.
 
-- `checkpoint.go` - Data types (`Checkpoint`, `TemporaryCheckpoint`, `CommittedCheckpoint`)
-- `store.go` - `GitStore` struct wrapping git repository
-- `temporary.go` - Shadow branch operations (`WriteTemporary`, `ReadTemporary`, `ListTemporary`)
-- `committed.go` - Metadata branch operations (`WriteCommitted`, `ReadCommitted`, `ListCommitted`)
-- `configloader.go` - Overrides go-git's default global/system config loader with a symlink-following `billy.Basic` (`osSymlinkFS`). go-git's default reads config via `os.Root`, which rejects absolute symlinks in any path component (e.g. a `~/.config` managed by a dotfile tool) with "path escapes from parent" — silently dropping global config so commit author identity fell back to "Unknown", signing was skipped, and the push hook spammed a warning per commit.
+#### Deep-Dive Reference
 
-#### Session Package (`cmd/entire/cli/session/`)
+The phase state machine, metadata directory layout, sharded checkpoint format, multi-session metadata, checkpoint ID linking, commit trailers, and concurrent-session / shadow-branch-migration behavior are documented in:
 
-- `session.go` - Session data types and interfaces
-- `state.go` - `StateStore` for managing `.git/entire-sessions/` files
-- `phase.go` - Session phase state machine (phases, events, transitions, actions)
-
-#### Session Phase State Machine
-
-Sessions track their lifecycle through phases managed by a state machine in `session/phase.go`:
-
-**Phases:** `ACTIVE`, `IDLE`, `ENDED`
-
-**Events:**
-
-- `TurnStart` - Agent begins a turn (UserPromptSubmit hook)
-- `TurnEnd` - Agent finishes a turn (Stop hook)
-- `GitCommit` - A git commit was made (PostCommit hook)
-- `SessionStart` - New session started
-- `SessionStop` - Session explicitly stopped
-
-**Key transitions:**
-
-- `IDLE + TurnStart → ACTIVE` - Agent starts working
-- `ACTIVE + TurnEnd → IDLE` - Agent finishes turn
-- `ACTIVE + GitCommit → ACTIVE` - User commits while agent is working (condense immediately)
-- `IDLE + GitCommit → IDLE` - User commits between turns (condense immediately)
-- `ENDED + GitCommit → ENDED` - Post-session commit (condense if files touched)
-
-The state machine emits **actions** (e.g., `ActionCondense`, `ActionUpdateLastInteraction`) that hook handlers dispatch to strategy-specific implementations.
-
-#### Metadata Structure
-
-**Shadow branches** (`entire/<commit-hash[:7]>-<worktreeHash[:6]>`):
-
-```
-.entire/metadata/<session-id>/
-├── full.jsonl               # Session transcript
-├── prompt.txt               # Checkpoint-scoped user prompts
-└── tasks/<tool-use-id>/     # Task checkpoints
-    ├── checkpoint.json      # UUID mapping for rewind
-    └── agent-<id>.jsonl     # Subagent transcript
-```
-
-**Metadata branch** (`entire/checkpoints/v1`) - sharded checkpoint format:
-
-```
-<checkpoint-id[:2]>/<checkpoint-id[2:]>/
-├── metadata.json            # CheckpointSummary (aggregated stats)
-├── 0/                       # First session (0-based indexing)
-│   ├── metadata.json        # Session-specific metadata
-│   ├── full.jsonl           # Session transcript
-│   ├── prompt.txt           # Checkpoint-scoped user prompts
-│   ├── content_hash.txt     # SHA256 of transcript
-│   └── tasks/<tool-use-id>/ # Task checkpoints (if applicable)
-│       ├── checkpoint.json  # UUID mapping
-│       └── agent-<id>.jsonl # Subagent transcript
-├── 1/                       # Second session (if multiple sessions)
-│   ├── metadata.json
-│   ├── full.jsonl
-│   └── ...
-└── ...
-```
-
-**Multi-session metadata.json format:**
-
-```json
-{
-  "checkpoint_id": "abc123def456",
-  "session_id": "2026-01-13-uuid", // Current/latest session
-  "session_ids": ["2026-01-13-uuid1", "2026-01-13-uuid2"], // All sessions
-  "session_count": 2, // Number of sessions in this checkpoint
-  "strategy": "manual-commit",
-  "created_at": "2026-01-13T12:00:00Z",
-  "files_touched": ["file1.txt", "file2.txt"] // Merged from all sessions
-}
-```
-
-When multiple sessions are condensed to the same checkpoint (same base commit):
-
-- Sessions are stored in numbered subfolders using 0-based indexing (`0/`, `1/`, `2/`, etc.)
-- Latest session is always in the highest-numbered folder
-- `session_ids` array tracks all sessions, `session_count` increments
-
-**Session State** (filesystem, `.git/entire-sessions/`):
-
-```
-<session-id>.json            # Active session state (base_commit, checkpoint_count, etc.)
-```
-
-#### Checkpoint ID Linking
-
-The strategy uses a **12-hex-char random checkpoint ID** (e.g., `a3b2c4d5e6f7`) as the stable identifier linking user commits to metadata.
-
-**How checkpoint IDs work:**
-
-1. **Generated once per checkpoint**: When condensing session metadata to the metadata branch
-
-2. **Added to user commits** via `Entire-Checkpoint` trailer:
-   - **Manual-commit**: Added via `prepare-commit-msg` hook (user can remove it before committing)
-
-3. **Used for directory sharding** on `entire/checkpoints/v1` branch:
-   - Path format: `<id[:2]>/<id[2:]>/`
-   - Example: `a3b2c4d5e6f7` → `a3/b2c4d5e6f7/`
-   - Creates 256 shards to avoid directory bloat
-
-4. **Appears in commit subject** on `entire/checkpoints/v1` commits:
-   - Format: `Checkpoint: a3b2c4d5e6f7`
-   - Makes `git log entire/checkpoints/v1` readable and searchable
-
-**Bidirectional linking:**
-
-```
-User commit → Metadata:
-  Extract "Entire-Checkpoint: a3b2c4d5e6f7" trailer
-  → Read a3/b2c4d5e6f7/ directory from entire/checkpoints/v1 tree at HEAD
-
-Metadata → User commits:
-  Given checkpoint ID a3b2c4d5e6f7
-  → Search user branch history for commits with "Entire-Checkpoint: a3b2c4d5e6f7" trailer
-```
-
-Note: Commit subjects on `entire/checkpoints/v1` (e.g., `Checkpoint: a3b2c4d5e6f7`) are
-for human readability in `git log` only. The CLI always reads from the tree at HEAD.
-
-**Example:**
-
-```
-User's commit (on main branch):
-  "Implement login feature
-
-  Entire-Checkpoint: a3b2c4d5e6f7"
-       ↓ ↑
-       Linked via checkpoint ID
-       ↓ ↑
-entire/checkpoints/v1 commit:
-  Subject: "Checkpoint: a3b2c4d5e6f7"
-
-  Tree: a3/b2c4d5e6f7/
-    ├── metadata.json (checkpoint_id: "a3b2c4d5e6f7")
-    ├── full.jsonl (session transcript)
-    └── prompt.txt
-```
-
-#### Commit Trailers
-
-**On user's active branch commits:**
-
-- `Entire-Checkpoint: <checkpoint-id>` - 12-hex-char ID linking to metadata on `entire/checkpoints/v1`
-  - Added via `prepare-commit-msg` hook; user can remove it before committing to skip linking
-
-**On shadow branch commits (`entire/<commit-hash[:7]>-<worktreeHash[:6]>`):**
-
-- `Entire-Session: <session-id>` - Session identifier
-- `Entire-Metadata: <path>` - Path to metadata directory within the tree
-- `Entire-Task-Metadata: <path>` - Path to task metadata directory (for task checkpoints)
-- `Entire-Strategy: manual-commit` - Strategy that created the commit
-
-**On metadata branch commits (`entire/checkpoints/v1`):**
-
-Commit subject: `Checkpoint: <checkpoint-id>` (or custom subject for task checkpoints)
-
-Trailers:
-
-- `Entire-Session: <session-id>` - Session identifier
-- `Entire-Strategy: <strategy>` - Strategy name (manual-commit)
-- `Entire-Agent: <agent-name>` - Agent name (optional, e.g., "Claude Code")
-- `Ephemeral-branch: <branch>` - Shadow branch name (optional)
-- `Entire-Metadata-Task: <path>` - Task metadata path (optional, for task checkpoints)
-
-**Note:** The strategy keeps active branch history clean - the only addition to user commits is the single `Entire-Checkpoint` trailer. It never creates commits on the active branch (the user creates them manually). All detailed session data (transcripts, prompts, context) is stored on the `entire/checkpoints/v1` orphan branch or shadow branches.
-
-#### Multi-Session Behavior
-
-**Concurrent Sessions:**
-
-- When a second session starts in the same directory while another has uncommitted checkpoints, a warning is shown
-- Both sessions can proceed - their checkpoints interleave on the same shadow branch
-- Each session's `RewindPoint` includes `SessionID` and `SessionPrompt` to help identify which checkpoint belongs to which session
-- On commit, all sessions are condensed together with archived sessions in numbered subfolders
-- Note: Different git worktrees have separate shadow branches (worktree-specific naming), so concurrent sessions in different worktrees do not conflict
-
-**Orphaned Shadow Branches:**
-
-- A shadow branch is "orphaned" if it exists but has no corresponding session state file
-- This can happen if the state file is manually deleted or lost
-- When a new session starts with an orphaned branch, the branch is automatically reset
-- If the existing session DOES have a state file (concurrent session in same directory), a `SessionIDConflictError` is returned
-
-**Shadow Branch Migration (Pull/Rebase):**
-
-- If user does stash → pull → apply (or rebase), HEAD changes but work isn't committed
-- The shadow branch would be orphaned at the old commit
-- Detection: base commit changed AND old shadow branch still exists (would be deleted if user committed)
-- Action: shadow branch is renamed from `entire/<old-hash>-<worktreeHash>` to `entire/<new-hash>-<worktreeHash>`
-- Session continues seamlessly with checkpoints preserved
+- [Sessions and Checkpoints](docs/architecture/sessions-and-checkpoints.md) - domain model, storage layout, checkpoint ID linking, commit trailers, package structure
+- [Checkpoint Scenarios](docs/architecture/checkpoint-scenarios.md) - phase state machine and worked condensation scenarios
 
 #### When Modifying the Strategy
 
 - The strategy must implement the full `Strategy` interface
 - Test with `mise run test` - strategy tests are in `*_test.go` files
-- **Update both CLAUDE.md and AGENTS.md** when modifying the strategy to keep documentation current
+- Keep this file and `docs/architecture/sessions-and-checkpoints.md` current when changing strategy behavior (`AGENTS.md` is a symlink to this file)
 
 ### `entire review` Command
 
 `entire review` runs a set of configured review skills inside an agent session. The review session is an immutable fact attached to a checkpoint — no verdict, no status tracking, no empty commits. On the next `git commit`, the review session is condensed into the checkpoint metadata alongside normal sessions, permanently recording that the code was reviewed and which skills were run.
 
-#### Command Surface
+Configured per-agent in `.entire/settings.json` (`EntireSettings.Review`); launchable agents (claude-code, codex, gemini-cli) receive `ENTIRE_REVIEW_*` env vars that the `UserPromptSubmit` hook reads to tag the session as `Kind = "agent_review"`. Multi-agent runs use a TUI dashboard + opt-in cross-agent synthesis.
 
-```
-entire review                          # Normal run: load config, run configured agent(s)
-entire review --edit                   # Re-open the skills picker before running
-entire review --agent <name>           # Force a specific configured agent (skips multi-picker)
-entire review attach <session-id>      # Tag an existing agent session as a review (post-hoc)
-entire review attach --force           # Skip confirmation
-entire review attach --agent <name>    # Agent that created the session
-entire review attach --skills <s,...>  # Declare which skills were run
-```
-
-When two or more launchable agents are configured and `--agent` is not set, a multi-select picker appears with an optional per-run prompt field (e.g. "focus on security"). Selecting one agent or passing `--agent` runs the single-agent path; selecting two or more runs the N-agent path.
-
-#### Settings Schema
-
-Review skills are configured per-agent in `.entire/settings.json`:
-
-```json
-{
-  "review": {
-    "claude-code": {"skills": ["/pr-review-toolkit:review-pr"], "prompt": "Be thorough."},
-    "codex": {"skills": ["/codex:adversarial-review"]}
-  }
-}
-```
-
-The key is the agent name. The value is a `ReviewConfig` with `skills` (skill invocations passed verbatim to the agent) and optional `prompt` (an always-prompt appended to the composed prompt). Settings field: `EntireSettings.Review` in `cmd/entire/cli/settings/settings.go`.
-
-#### How It Works (env-var handshake)
-
-1. `entire review` selects the configured agent (override → alphabetically first → prompt if multiple), composes the review prompt via `review.ComposeReviewPrompt`, and computes scope (mainline base ref via `review.ComputeScopeStats`, overridable with `--base`).
-2. **For launchable agents** (claude-code, codex, gemini-cli): the spawned agent process is given env vars `ENTIRE_REVIEW_{SESSION,AGENT,SKILLS,PROMPT,STARTING_SHA}` that the agent's `UserPromptSubmit` lifecycle hook reads to tag the session as `Kind = "agent_review"` with the configured skills/prompt. Each spawned process has its own env, so multiple worktrees and multi-agent runs are correct by construction (no shared marker file, no race).
-3. **For non-launchable agents** (cursor, opencode, factoryai-droid): `RunMarkerFallback` writes a `PendingReviewMarker` file and prints guidance — the user opens the agent themselves and runs the skills. Single shared file (`review/marker_fallback.go`); adding new non-launchable agents is a registry entry, not a new file.
-4. The agent runs the review skills; the session ends naturally.
-5. On the next `git commit`, the PostCommit hook condenses the review session into the checkpoint on `entire/checkpoints/v1`, with `Kind` and `ReviewSkills` recorded in `CommittedMetadata`.
-6. The `CheckpointSummary` sets `HasReview = true` for O(1) lookup. `HasReview` is an umbrella "any review happened" flag — future review kinds (e.g. manual review) should also set it.
-7. `entire status` and the re-run guard read `HasReview` from the checkpoint metadata (no commit history walking).
-
-#### Checkpoint Metadata
-
-Review metadata is stored at two levels on `entire/checkpoints/v1`:
-
-- **`CommittedMetadata` (per-session)**: `kind: "agent_review"`, `review_skills: ["/skill1", "/skill2"]`, `review_prompt: "..."`
-- **`CheckpointSummary` (per-checkpoint)**: `has_review: true` (umbrella; set when any session in the checkpoint has a review-kind `Kind`)
-
-#### Architecture
-
-- **`AgentReviewer` interface** (`cmd/entire/cli/review/types/reviewer.go`): per-agent contract with `Name() string` and `Start(ctx, RunConfig) (Process, error)`. Each launchable agent implements this in its own package.
-- **`ReviewerTemplate`** (`cmd/entire/cli/review/types/template.go`): shared scaffolding (Spawn → pipe stdout → run parser → forward events → close). Each agent supplies only its `BuildCmd` (argv/env) and `Parser` (stdout-to-Event stream).
-- **`Sink` interface**: consumers of the event stream. Production sinks: `DumpSink` (post-run per-agent narrative), `TUISink` (Bubble Tea live dashboard with Ctrl+O drill-in), `SynthesisSink` (opt-in y/N cross-agent verdict). Sinks are composed by `composeMultiAgentSinks` based on TTY detection.
-- **`Run(ctx, reviewer, cfg, sinks)`** (`cmd/entire/cli/review/run.go`): single-agent orchestrator. Forwards events to all sinks via `AgentEvent`, calls `RunFinished` once at end with a populated `RunSummary`. Sink dispatch is serialized; sinks need not internally synchronize.
-- **`RunMulti(ctx, reviewers, cfg, sinks)`** (`cmd/entire/cli/review/run_multi.go`): N-agent orchestrator. Each agent runs concurrently in its own goroutine; events fan into a single dispatch loop so the serial-dispatch contract is preserved. Per-agent skills/prompts are injected via `perAgentConfiguredReviewer` adapter (each reviewer sees its own `RunConfig` despite the shared API surface).
-- **Env-var contract** (`cmd/entire/cli/review/env.go`): single source of truth for `ENTIRE_REVIEW_*` constants used by spawn-side and lifecycle adoption.
-- **Scope detection** (`cmd/entire/cli/review/scope.go`): `detectScopeBaseRef` returns the first existing ref from the fallback chain `origin/HEAD → origin/main → origin/master → main → master`. Overridable per-invocation via `--base <ref>` (validated through go-git's `ResolveRevision`). Banner output: "Reviewing feat/X vs main: 3 commits, 7 files changed, 2 uncommitted".
-
-#### Multi-Agent UI
-
-When `RunMulti` is dispatched in a TTY, the sink slice is `[TUISink, DumpSink, SynthesisSink?]`:
-
-- **`TUISink` / `reviewTUIModel`** (`cmd/entire/cli/review/tui_sink.go`, `tui_model.go`, `tui_detail.go`): live dashboard with one row per agent (name, status, tokens, last assistant preview, duration). `Ctrl+O` enters drill-in mode on the alt screen showing the full event buffer for the selected agent; `Esc` returns to the dashboard. `Ctrl+C` cancels the run via the shared `CancelFunc`. The model uses `tea.WithoutSignalHandler` so the cobra root retains SIGINT routing. After all agents finish, the user dismisses with any key — `RunFinished` blocks on dismissal so `DumpSink` renders below the TUI rather than overlapping it.
-- **`SynthesisSink`** (`cmd/entire/cli/review/synthesis_sink.go`): opt-in y/N prompt offered after the dump. On "y", composes a synthesis prompt covering all agent narratives + per-run user prompt, calls the configured summary provider, and prints the unified verdict. Skipped silently when stdin can't prompt, the run was cancelled, or fewer than 2 agents produced usable output. Provider failures degrade gracefully ("synthesis unavailable: <err>") so the user can still commit.
-- **Sink composition** (`composeMultiAgentSinks` in `cmd/entire/cli/review/cmd.go`): pure helper taking explicit `isTTY`/`canPrompt` so tests don't depend on real TTY detection. `findTUISink` picks the TUI out of the slice for `Start`/`Wait` lifecycle hooks.
-
-#### Skill Discovery (Claude Code)
-
-`DiscoverReviewSkills` (`cmd/entire/cli/agent/claudecode/discovery.go`) walks three roots: plugin cache (`~/.claude/plugins/cache/<market>/<plugin>/<version>/{skills,commands,agents}`), user skills (`~/.claude/skills`), user commands/agents (`~/.claude/commands`, `~/.claude/agents`).
-
-For the plugin cache, `pickLatestVersion` picks ONE version directory per plugin: highest valid semver wins; if no entries parse as semver, the lexicographic max is picked (handles the `unknown` sentinel some plugins ship). Without this, multiple installed versions of a plugin produced duplicate skill entries in the picker and prompt.
-
-#### Anti-Features (do NOT recreate)
-
-The redesign eliminated several constructs from the prior implementation. None should be reintroduced without explicit design:
-
-- `PendingReviewMarker` for launchable agents (env-var handshake makes it unnecessary)
-- `WorktreePath` field + worktree-scoping logic (env per process eliminates the multi-tenant problem)
-- `AgentEntries` map on the marker (each agent has its own env)
-- Marker overwrite tripwire / refuse-attach guard (the bug classes they defended against don't exist)
-- `--track-only` flag (intentionally removed by #1009)
-- `--postreview` / `--finalize` / empty review commits / `/entire-review:finish` skill installer
-- `Launcher` + `HeadlessLauncher` as separate interfaces (single `AgentReviewer`)
-- Codex chrome-line filtering or any agent-specific stdout post-processing in shared multi-agent code (per-agent parsers own their format; shared code only sees `Event` variants)
-- `sync.Once`-guarded onCancel + parallel `signal.Notify` goroutine (single cancel from start)
-
-#### Key Files
-
-- `cmd/entire/cli/review/cmd.go` — `NewCommand()`, `runReview` dispatch fork, `composeMultiAgentSinks`
-- `cmd/entire/cli/review/picker.go` / `multipicker.go` — config-edit picker, first-run setup, single- and multi-agent selection
-- `cmd/entire/cli/review/attach.go` + `cli/review_helpers.go:newReviewAttachCmd` — `entire review attach` subcommand
-- `cmd/entire/cli/review/marker_fallback.go` — non-launchable agent flow (single shared file)
-- `cmd/entire/cli/review/prompt.go` / `scope.go` / `run.go` / `dump.go` / `run_multi.go` — core machinery (single-agent + N-agent fan-in)
-- `cmd/entire/cli/review/tui_sink.go` / `tui_model.go` / `tui_detail.go` — Bubble Tea TUI sink
-- `cmd/entire/cli/review/synthesis_sink.go` / `synthesis_prompt.go` — opt-in cross-agent verdict
-- `cmd/entire/cli/review/types/{reviewer,sink,template}.go` — interface contracts (CU2 + CU4 + CU5b)
-- `cmd/entire/cli/review/env.go` — `ENTIRE_REVIEW_*` constants + `EncodeSkills`/`DecodeSkills` + `AppendReviewEnv`
-- `cmd/entire/cli/agent/{claudecode,codex,geminicli}/reviewer.go` — per-agent `AgentReviewer` implementations (claude-code, codex, gemini-cli)
-- `cmd/entire/cli/agent/claudecode/discovery.go` — skill discovery + `pickLatestVersion` plugin-cache dedupe
-- `cmd/entire/cli/lifecycle.go` — `adoptReviewEnv` reads `ENTIRE_REVIEW_*` from process env; replaces marker-file adoption
-- `cmd/entire/cli/review_bridge.go` / `review_helpers.go` — bridge code in `cli` package for cycle-bound functions (`headHasReviewCheckpoint`, `launchableReviewerFor`, `newReviewAttachCmd`, `lazySynthesisProvider`)
-- `cmd/entire/cli/checkpoint/checkpoint.go` — `Kind`, `ReviewSkills`, `ReviewPrompt` on `CommittedMetadata`; `HasReview` on `CheckpointSummary`
-- `cmd/entire/cli/settings/settings.go` — `EntireSettings.Review` field
+See [Review Command](docs/architecture/review-command.md) for the full command surface, settings schema, env-var handshake, multi-agent UI, anti-features (do NOT recreate), and key-file map.
 
 # Important Notes
 

--- a/docs/architecture/review-command.md
+++ b/docs/architecture/review-command.md
@@ -1,0 +1,105 @@
+# `entire review` Command
+
+`entire review` runs a set of configured review skills inside an agent session. The review session is an immutable fact attached to a checkpoint — no verdict, no status tracking, no empty commits. On the next `git commit`, the review session is condensed into the checkpoint metadata alongside normal sessions, permanently recording that the code was reviewed and which skills were run.
+
+## Command Surface
+
+```
+entire review                          # Normal run: load config, run configured agent(s)
+entire review --edit                   # Re-open the skills picker before running
+entire review --agent <name>           # Force a specific configured agent (skips multi-picker)
+entire review attach <session-id>      # Tag an existing agent session as a review (post-hoc)
+entire review attach --force           # Skip confirmation
+entire review attach --agent <name>    # Agent that created the session
+entire review attach --skills <s,...>  # Declare which skills were run
+```
+
+When two or more launchable agents are configured and `--agent` is not set, a multi-select picker appears with an optional per-run prompt field (e.g. "focus on security"). Selecting one agent or passing `--agent` runs the single-agent path; selecting two or more runs the N-agent path.
+
+## Settings Schema
+
+Review skills are configured per-agent in `.entire/settings.json`:
+
+```json
+{
+  "review": {
+    "claude-code": {"skills": ["/pr-review-toolkit:review-pr"], "prompt": "Be thorough."},
+    "codex": {"skills": ["/codex:adversarial-review"]}
+  }
+}
+```
+
+The key is the agent name. The value is a `ReviewConfig` with `skills` (skill invocations passed verbatim to the agent) and optional `prompt` (an always-prompt appended to the composed prompt). Settings field: `EntireSettings.Review` in `cmd/entire/cli/settings/settings.go`.
+
+## How It Works (env-var handshake)
+
+1. `entire review` selects the configured agent (override → alphabetically first → prompt if multiple), composes the review prompt via `review.ComposeReviewPrompt`, and computes scope (mainline base ref via `review.ComputeScopeStats`, overridable with `--base`).
+2. **For launchable agents** (claude-code, codex, gemini-cli): the spawned agent process is given env vars `ENTIRE_REVIEW_{SESSION,AGENT,SKILLS,PROMPT,STARTING_SHA}` that the agent's `UserPromptSubmit` lifecycle hook reads to tag the session as `Kind = "agent_review"` with the configured skills/prompt. Each spawned process has its own env, so multiple worktrees and multi-agent runs are correct by construction (no shared marker file, no race).
+3. **For non-launchable agents** (cursor, opencode, factoryai-droid): `RunMarkerFallback` writes a `PendingReviewMarker` file and prints guidance — the user opens the agent themselves and runs the skills. Single shared file (`review/marker_fallback.go`); adding new non-launchable agents is a registry entry, not a new file.
+4. The agent runs the review skills; the session ends naturally.
+5. On the next `git commit`, the PostCommit hook condenses the review session into the checkpoint on `entire/checkpoints/v1`, with `Kind` and `ReviewSkills` recorded in `CommittedMetadata`.
+6. The `CheckpointSummary` sets `HasReview = true` for O(1) lookup. `HasReview` is an umbrella "any review happened" flag — future review kinds (e.g. manual review) should also set it.
+7. `entire status` and the re-run guard read `HasReview` from the checkpoint metadata (no commit history walking).
+
+## Checkpoint Metadata
+
+Review metadata is stored at two levels on `entire/checkpoints/v1`:
+
+- **`CommittedMetadata` (per-session)**: `kind: "agent_review"`, `review_skills: ["/skill1", "/skill2"]`, `review_prompt: "..."`
+- **`CheckpointSummary` (per-checkpoint)**: `has_review: true` (umbrella; set when any session in the checkpoint has a review-kind `Kind`)
+
+## Architecture
+
+- **`AgentReviewer` interface** (`cmd/entire/cli/review/types/reviewer.go`): per-agent contract with `Name() string` and `Start(ctx, RunConfig) (Process, error)`. Each launchable agent implements this in its own package.
+- **`ReviewerTemplate`** (`cmd/entire/cli/review/types/template.go`): shared scaffolding (Spawn → pipe stdout → run parser → forward events → close). Each agent supplies only its `BuildCmd` (argv/env) and `Parser` (stdout-to-Event stream).
+- **`Sink` interface**: consumers of the event stream. Production sinks: `DumpSink` (post-run per-agent narrative), `TUISink` (Bubble Tea live dashboard with Ctrl+O drill-in), `SynthesisSink` (opt-in y/N cross-agent verdict). Sinks are composed by `composeMultiAgentSinks` based on TTY detection.
+- **`Run(ctx, reviewer, cfg, sinks)`** (`cmd/entire/cli/review/run.go`): single-agent orchestrator. Forwards events to all sinks via `AgentEvent`, calls `RunFinished` once at end with a populated `RunSummary`. Sink dispatch is serialized; sinks need not internally synchronize.
+- **`RunMulti(ctx, reviewers, cfg, sinks)`** (`cmd/entire/cli/review/run_multi.go`): N-agent orchestrator. Each agent runs concurrently in its own goroutine; events fan into a single dispatch loop so the serial-dispatch contract is preserved. Per-agent skills/prompts are injected via `perAgentConfiguredReviewer` adapter (each reviewer sees its own `RunConfig` despite the shared API surface).
+- **Env-var contract** (`cmd/entire/cli/review/env.go`): single source of truth for `ENTIRE_REVIEW_*` constants used by spawn-side and lifecycle adoption.
+- **Scope detection** (`cmd/entire/cli/review/scope.go`): `detectScopeBaseRef` returns the first existing ref from the fallback chain `origin/HEAD → origin/main → origin/master → main → master`. Overridable per-invocation via `--base <ref>` (validated through go-git's `ResolveRevision`). Banner output: "Reviewing feat/X vs main: 3 commits, 7 files changed, 2 uncommitted".
+
+## Multi-Agent UI
+
+When `RunMulti` is dispatched in a TTY, the sink slice is `[TUISink, DumpSink, SynthesisSink?]`:
+
+- **`TUISink` / `reviewTUIModel`** (`cmd/entire/cli/review/tui_sink.go`, `tui_model.go`, `tui_detail.go`): live dashboard with one row per agent (name, status, tokens, last assistant preview, duration). `Ctrl+O` enters drill-in mode on the alt screen showing the full event buffer for the selected agent; `Esc` returns to the dashboard. `Ctrl+C` cancels the run via the shared `CancelFunc`. The model uses `tea.WithoutSignalHandler` so the cobra root retains SIGINT routing. After all agents finish, the user dismisses with any key — `RunFinished` blocks on dismissal so `DumpSink` renders below the TUI rather than overlapping it.
+- **`SynthesisSink`** (`cmd/entire/cli/review/synthesis_sink.go`): opt-in y/N prompt offered after the dump. On "y", composes a synthesis prompt covering all agent narratives + per-run user prompt, calls the configured summary provider, and prints the unified verdict. Skipped silently when stdin can't prompt, the run was cancelled, or fewer than 2 agents produced usable output. Provider failures degrade gracefully ("synthesis unavailable: <err>") so the user can still commit.
+- **Sink composition** (`composeMultiAgentSinks` in `cmd/entire/cli/review/cmd.go`): pure helper taking explicit `isTTY`/`canPrompt` so tests don't depend on real TTY detection. `findTUISink` picks the TUI out of the slice for `Start`/`Wait` lifecycle hooks.
+
+## Skill Discovery (Claude Code)
+
+`DiscoverReviewSkills` (`cmd/entire/cli/agent/claudecode/discovery.go`) walks three roots: plugin cache (`~/.claude/plugins/cache/<market>/<plugin>/<version>/{skills,commands,agents}`), user skills (`~/.claude/skills`), user commands/agents (`~/.claude/commands`, `~/.claude/agents`).
+
+For the plugin cache, `pickLatestVersion` picks ONE version directory per plugin: highest valid semver wins; if no entries parse as semver, the lexicographic max is picked (handles the `unknown` sentinel some plugins ship). Without this, multiple installed versions of a plugin produced duplicate skill entries in the picker and prompt.
+
+## Anti-Features (do NOT recreate)
+
+The redesign eliminated several constructs from the prior implementation. None should be reintroduced without explicit design:
+
+- `PendingReviewMarker` for launchable agents (env-var handshake makes it unnecessary)
+- `WorktreePath` field + worktree-scoping logic (env per process eliminates the multi-tenant problem)
+- `AgentEntries` map on the marker (each agent has its own env)
+- Marker overwrite tripwire / refuse-attach guard (the bug classes they defended against don't exist)
+- `--track-only` flag (intentionally removed by #1009)
+- `--postreview` / `--finalize` / empty review commits / `/entire-review:finish` skill installer
+- `Launcher` + `HeadlessLauncher` as separate interfaces (single `AgentReviewer`)
+- Codex chrome-line filtering or any agent-specific stdout post-processing in shared multi-agent code (per-agent parsers own their format; shared code only sees `Event` variants)
+- `sync.Once`-guarded onCancel + parallel `signal.Notify` goroutine (single cancel from start)
+
+## Key Files
+
+- `cmd/entire/cli/review/cmd.go` — `NewCommand()`, `runReview` dispatch fork, `composeMultiAgentSinks`
+- `cmd/entire/cli/review/picker.go` / `multipicker.go` — config-edit picker, first-run setup, single- and multi-agent selection
+- `cmd/entire/cli/review/attach.go` + `cli/review_helpers.go:newReviewAttachCmd` — `entire review attach` subcommand
+- `cmd/entire/cli/review/marker_fallback.go` — non-launchable agent flow (single shared file)
+- `cmd/entire/cli/review/prompt.go` / `scope.go` / `run.go` / `dump.go` / `run_multi.go` — core machinery (single-agent + N-agent fan-in)
+- `cmd/entire/cli/review/tui_sink.go` / `tui_model.go` / `tui_detail.go` — Bubble Tea TUI sink
+- `cmd/entire/cli/review/synthesis_sink.go` / `synthesis_prompt.go` — opt-in cross-agent verdict
+- `cmd/entire/cli/review/types/{reviewer,sink,template}.go` — interface contracts (CU2 + CU4 + CU5b)
+- `cmd/entire/cli/review/env.go` — `ENTIRE_REVIEW_*` constants + `EncodeSkills`/`DecodeSkills` + `AppendReviewEnv`
+- `cmd/entire/cli/agent/{claudecode,codex,geminicli}/reviewer.go` — per-agent `AgentReviewer` implementations (claude-code, codex, gemini-cli)
+- `cmd/entire/cli/agent/claudecode/discovery.go` — skill discovery + `pickLatestVersion` plugin-cache dedupe
+- `cmd/entire/cli/lifecycle.go` — `adoptReviewEnv` reads `ENTIRE_REVIEW_*` from process env; replaces marker-file adoption
+- `cmd/entire/cli/review_bridge.go` / `review_helpers.go` — bridge code in `cli` package for cycle-bound functions (`headHasReviewCheckpoint`, `launchableReviewerFor`, `newReviewAttachCmd`, `lazySynthesisProvider`)
+- `cmd/entire/cli/checkpoint/checkpoint.go` — `Kind`, `ReviewSkills`, `ReviewPrompt` on `CommittedMetadata`; `HasReview` on `CheckpointSummary`
+- `cmd/entire/cli/settings/settings.go` — `EntireSettings.Review` field


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/452
<!-- entire-trail-link-end -->

Any time I've opened up Claude for this repo lately, I've been seeing this warning loaded at the top:
```
 ⚠ Large CLAUDE.md will impact performance (44.4k chars > 40.0k)
 ```

Claude has also been much slower to run in general lately and I think it's partly due to that warning.

This PR trims down the CLAUDE.md file by extracting the `entire review` section of the file to its own separate doc file (same as other `docs/architecture/*` concepts). Docs are read on-demand only as Claude needs them so it won't load how `entire review` works every time we open Claude for other unrelated commands, as an example. Similar to that command, this also removes other topics discussed in other docs/* files since Claude can read how they work in those locations instead.

We could also extract these to skills as [covered in this Medium article](https://medium.com/@cem.karaca/my-claude-md-was-eating-42-000-tokens-per-conversation-heres-how-i-fixed-it-85ffba809bd4) but that's a larger change than the existing setup we have and seems it might require some changes to how we work with Claude internally (using targeted skills for specific topics). This should help us with our token usage now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only reshuffle with no runtime or CLI behavior changes.
> 
> **Overview**
> Shrinks **`CLAUDE.md`** so it stays under the ~40k character guidance that was hurting agent performance, by moving long reference material into **`docs/architecture/`** instead of loading it on every session.
> 
> The **`entire review`** section (~200 lines: command surface, settings, env handshake, multi-agent UI, anti-features, key files) is moved verbatim into new **`docs/architecture/review-command.md`**, with **`CLAUDE.md`** keeping a short overview and a link. Large **manual-commit / checkpoint / session** blocks (phase machine, metadata layouts, checkpoint ID linking, trailers, multi-session behavior, per-package file lists) are removed from **`CLAUDE.md`** in favor of pointers to **`sessions-and-checkpoints.md`** and **`checkpoint-scenarios.md`**, plus a one-line note on **`checkpoint/configloader.go`**.
> 
> Minor edits: shorter Vogon/E2E agent examples, tiny wording fixes, and strategy maintenance now says to keep **`sessions-and-checkpoints.md`** in sync (not duplicate **AGENTS.md**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e81f49337f46933334f820664cb7a07aa37cb06. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->