### PR TITLE
Pin AuthBaseURL default to https://us.auth.entire.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,13 @@ If you're working on the CLI device auth flow against a local `entire.io` checko
 cd ../entire.io-1
 mise run dev
 
-# In this repo, point the CLI at the local API
+# In this repo, point the CLI at the local API. Both env vars are
+# required: ENTIRE_AUTH_BASE_URL no longer inherits from
+# ENTIRE_API_BASE_URL — without it, the login flow reaches for the
+# production us.auth.entire.io.
 cd ../cli
 export ENTIRE_API_BASE_URL=http://localhost:8787
+export ENTIRE_AUTH_BASE_URL=http://localhost:8787
 
 # Run the smoke test
 ./scripts/local-device-auth-smoke.sh

--- a/cmd/entire/cli/api/base_url.go
+++ b/cmd/entire/cli/api/base_url.go
@@ -15,14 +15,18 @@ const (
 	// DefaultBaseURL is the production Entire API origin.
 	DefaultBaseURL = "https://entire.io"
 
+	// DefaultAuthBaseURL is the production Entire auth origin (device flow,
+	// auth-token management, keyring key). The CLI is split-host by default:
+	// auth on us.auth.entire.io, data on entire.io.
+	DefaultAuthBaseURL = "https://us.auth.entire.io"
+
 	// BaseURLEnvVar overrides the Entire API origin for local development.
 	BaseURLEnvVar = "ENTIRE_API_BASE_URL"
 
 	// AuthBaseURLEnvVar overrides only the auth/login origin (device flow,
-	// auth-tokens management, keyring key). Falls back to BaseURLEnvVar when
-	// unset, which is the right behavior for single-host deployments. Split
-	// hosts (e.g. auth on us.console.partial.to, data on partial.to) set
-	// both.
+	// auth-tokens management, keyring key). Falls back to DefaultAuthBaseURL
+	// when unset; local-dev and single-host deployments must set this
+	// alongside ENTIRE_API_BASE_URL.
 	AuthBaseURLEnvVar = "ENTIRE_AUTH_BASE_URL"
 
 	schemeHTTP  = "http"
@@ -42,7 +46,7 @@ func BaseURL() string {
 // AuthBaseURL returns the origin used for the device-flow login, auth-token
 // management endpoints, and the keyring key under which the bearer token is
 // stored. ENTIRE_AUTH_BASE_URL takes precedence; otherwise it falls back to
-// BaseURL() so single-host deployments keep working unchanged.
+// DefaultAuthBaseURL (split-host by default).
 //
 // The result is canonicalised — lowercased scheme/host, default port stripped,
 // path/query/fragment dropped, trailing slash collapsed — so the value that
@@ -55,7 +59,7 @@ func BaseURL() string {
 func AuthBaseURL() string {
 	raw := strings.TrimSpace(os.Getenv(AuthBaseURLEnvVar))
 	if raw == "" {
-		raw = BaseURL()
+		raw = DefaultAuthBaseURL
 	}
 	return NormalizeOriginURL(raw)
 }

--- a/cmd/entire/cli/api/base_url_test.go
+++ b/cmd/entire/cli/api/base_url_test.go
@@ -53,12 +53,15 @@ func TestRequireSecureURL_RejectsHTTP(t *testing.T) {
 	}
 }
 
-func TestAuthBaseURL_FallsBackToBaseURL(t *testing.T) {
+func TestAuthBaseURL_FallsBackToDefault(t *testing.T) {
+	// Default is split-host: an unset ENTIRE_AUTH_BASE_URL must NOT inherit
+	// from ENTIRE_API_BASE_URL — local-dev that only sets the data host
+	// would otherwise silently point auth at a host that can't mint tokens.
 	t.Setenv(BaseURLEnvVar, "https://example.test")
 	t.Setenv(AuthBaseURLEnvVar, "")
 
-	if got := AuthBaseURL(); got != "https://example.test" {
-		t.Fatalf("AuthBaseURL() = %q, want fallback to BaseURL", got)
+	if got := AuthBaseURL(); got != DefaultAuthBaseURL {
+		t.Fatalf("AuthBaseURL() = %q, want %q", got, DefaultAuthBaseURL)
 	}
 }
 
@@ -87,19 +90,19 @@ func TestIsSplitHost(t *testing.T) {
 		base, auth string
 		want       bool
 	}{
-		"both unset":          {"", "", false},
-		"auth unset":          {"https://entire.io", "", false},
+		// Defaults are split: data on entire.io, auth on us.auth.entire.io.
+		"both unset":          {"", "", true},
+		"auth unset":          {"https://entire.io", "", true},
 		"auth same as base":   {"https://api.example.com", "https://api.example.com", false},
 		"auth cosmetic match": {"https://api.example.com", "https://api.example.com/", false},
 		"different origins":   {"https://api.example.com", "https://auth.example.com", true},
-		// Regressions for asymmetric-normalisation bug: BaseURL only
-		// trims whitespace/trailing slash, AuthBaseURL canonicalises,
-		// so cosmetic differences in ENTIRE_API_BASE_URL would falsely
-		// register as split-host if both sides aren't normalised.
-		"base uppercase host, auth unset": {"HTTPS://API.EXAMPLE.COM", "", false},
-		"base default port, auth unset":   {"https://api.example.com:443", "", false},
-		"base path suffix, auth unset":    {"https://api.example.com/v1", "", false},
-		"base trailing slash, auth unset": {"https://api.example.com/", "", false},
+		// Asymmetric-normalisation regressions: BaseURL only trims, AuthBaseURL
+		// canonicalises. IsSplitHost must normalise both before comparing, else
+		// cosmetic noise in ENTIRE_API_BASE_URL falsely registers as split.
+		"base uppercase, auth lowercase": {"HTTPS://API.EXAMPLE.COM", "https://api.example.com", false},
+		"base default port, auth bare":   {"https://api.example.com:443", "https://api.example.com", false},
+		"base path suffix, auth bare":    {"https://api.example.com/v1", "https://api.example.com", false},
+		"base trailing slash, auth bare": {"https://api.example.com/", "https://api.example.com", false},
 	}
 
 	for name, tc := range cases {

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -43,8 +43,9 @@ const (
 //
 // Both the auth and data API origins are checked: the bearer travels to the
 // auth host for login + auth-token management, and to the data host for
-// search/activity/dispatch/etc. Single-host deployments (ENTIRE_AUTH_BASE_URL
-// unset) skip the redundant second parse.
+// search/activity/dispatch/etc. When both origins resolve to the same host
+// (e.g. an explicitly collapsed single-host deployment) the redundant second
+// parse is skipped.
 //
 // When the opt-in flag is set, the tokenmanager's matching HTTP guard is
 // also relaxed via auth.EnableInsecureHTTP — otherwise an STS exchange

--- a/cmd/entire/cli/auth/provider.go
+++ b/cmd/entire/cli/auth/provider.go
@@ -75,10 +75,10 @@ func resolveProvider(version string) Provider {
 // effectiveProviderVersion resolves the version string fed into
 // resolveProvider. Order: explicit env var > split-host auto-detect > v1.
 //
-// The split-host auto-detect can't extend to a default flip: as of
-// 2026-05 entire.io (the unset-env default data host) does not serve
-// the v2 OIDC surface, so picking v2 without an explicit split-host
-// signal would break login for every existing user.
+// The CLI is split-host by default (us.auth.entire.io for auth, entire.io
+// for data), so unset env vars take the auto-detect branch and resolve to
+// v2 — the OIDC surface us.auth.entire.io serves. v1 only kicks in when a
+// caller explicitly collapses both origins onto a single non-OIDC host.
 func effectiveProviderVersion() string {
 	if v := strings.TrimSpace(os.Getenv(ProviderVersionEnvVar)); v != "" {
 		return v

--- a/cmd/entire/cli/auth/provider_test.go
+++ b/cmd/entire/cli/auth/provider_test.go
@@ -90,14 +90,15 @@ func TestEffectiveProviderVersion_SameHostPicksV1(t *testing.T) {
 	}
 }
 
-// Entire.io default path — must not regress; most users hit this.
-func TestEffectiveProviderVersion_UnsetDefaultsToV1(t *testing.T) {
+// Default production path — split-host (entire.io + us.auth.entire.io)
+// resolves to v2 without any env vars set. Most users hit this.
+func TestEffectiveProviderVersion_UnsetDefaultsToV2(t *testing.T) {
 	t.Setenv(ProviderVersionEnvVar, "")
 	t.Setenv(api.BaseURLEnvVar, "")
 	t.Setenv(api.AuthBaseURLEnvVar, "")
 
-	if got := effectiveProviderVersion(); got != "v1" {
-		t.Errorf("unset env = %q, want v1 (entire.io default)", got)
+	if got := effectiveProviderVersion(); got != "v2" {
+		t.Errorf("unset env = %q, want v2 (split-host default)", got)
 	}
 }
 

--- a/cmd/entire/cli/auth/store.go
+++ b/cmd/entire/cli/auth/store.go
@@ -151,8 +151,9 @@ func (s *Store) DeleteTokens(profile string) error {
 
 // LookupCurrentToken retrieves the token for the current auth base URL.
 // Tokens are keyed by the auth issuer (api.AuthBaseURL()) since that's the
-// host that minted them; in single-host deployments AuthBaseURL falls back
-// to BaseURL so behaviour is unchanged.
+// host that minted them; AuthBaseURL defaults to DefaultAuthBaseURL when
+// the env override is unset, so a fresh install reads the production
+// us.auth.entire.io entry.
 func LookupCurrentToken() (string, error) {
 	return NewStore().GetToken(api.AuthBaseURL())
 }

--- a/cmd/entire/cli/auth/store_test.go
+++ b/cmd/entire/cli/auth/store_test.go
@@ -133,7 +133,11 @@ func TestStoreDeleteToken_NotFoundIsNoop(t *testing.T) {
 }
 
 func TestLookupCurrentToken(t *testing.T) {
+	// Pin both URLs: tokens are keyed by AuthBaseURL, which defaults to the
+	// production auth host when the env override is unset. Setting only
+	// BaseURL would write to a key the lookup doesn't read.
 	t.Setenv(api.BaseURLEnvVar, "http://localhost:8787")
+	t.Setenv(api.AuthBaseURLEnvVar, "http://localhost:8787")
 
 	store := NewStore()
 	if err := store.SaveToken("http://localhost:8787", "local-token"); err != nil {

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -203,6 +203,10 @@ func runLoginProcess(t *testing.T, apiBaseURL string) *loginProcess {
 		"ENTIRE_TEST_GEMINI_PROJECT_DIR="+env.GeminiProjectDir,
 		"ENTIRE_TEST_OPENCODE_PROJECT_DIR="+env.OpenCodeProjectDir,
 		"ENTIRE_API_BASE_URL="+apiBaseURL,
+		// AuthBaseURL no longer inherits from BaseURL; pin both at the test
+		// server so the device flow stays in-process instead of reaching
+		// out to the production us.auth.entire.io default.
+		"ENTIRE_AUTH_BASE_URL="+apiBaseURL,
 		"ENTIRE_TEST_AUTH_STORE_FILE="+filepath.Join(env.RepoDir, ".entire-test-auth-store.json"),
 	)
 

--- a/scripts/local-device-auth-smoke.sh
+++ b/scripts/local-device-auth-smoke.sh
@@ -6,6 +6,9 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
 : "${ENTIRE_API_BASE_URL:=http://localhost:8787}"
+# Pin auth at the same host: AuthBaseURL defaults to the production
+# us.auth.entire.io and no longer inherits from ENTIRE_API_BASE_URL.
+: "${ENTIRE_AUTH_BASE_URL:=${ENTIRE_API_BASE_URL}}"
 
 LOG_FILE="$(mktemp -t entire-device-auth-smoke.XXXXXX.log)"
 cleanup() {
@@ -18,7 +21,7 @@ trap cleanup EXIT
 cd "${REPO_ROOT}"
 
 echo "Starting device auth login against ${ENTIRE_API_BASE_URL}"
-ENTIRE_TEST_TTY=0 ENTIRE_API_BASE_URL="${ENTIRE_API_BASE_URL}" go run ./cmd/entire login --insecure-http-auth >"${LOG_FILE}" 2>&1 &
+ENTIRE_TEST_TTY=0 ENTIRE_API_BASE_URL="${ENTIRE_API_BASE_URL}" ENTIRE_AUTH_BASE_URL="${ENTIRE_AUTH_BASE_URL}" go run ./cmd/entire login --insecure-http-auth >"${LOG_FILE}" 2>&1 &
 LOGIN_PID=$!
 
 for _ in {1..100}; do


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/453
<!-- entire-trail-link-end -->

Closes [ENT-733](https://linear.app/entirehq/issue/ENT-733/entire-cli-pin-to-httpsusauthentireio).

## Summary
- `AuthBaseURL()` now defaults to `https://us.auth.entire.io` when `ENTIRE_AUTH_BASE_URL` is unset, instead of inheriting from `BaseURL()`.
- This implicitly flips `effectiveProviderVersion()` to `v2` for fresh installs — the OIDC surface `us.auth.entire.io` serves and the existing split-host auto-detect already maps to.
- Inheriting from `BaseURL()` was only meaningful in the v1 world where a single host served both data and auth. With v1 going away, the fallback would have pointed auth at a URL that doesn't speak OAuth.

## Behaviour change
| Setup | Before | After |
| --- | --- | --- |
| No env vars | Single-host on `entire.io` (v1) | Split-host: data `entire.io`, auth `us.auth.entire.io` (v2) |
| `ENTIRE_API_BASE_URL=http://localhost:8787` only | Single-host on localhost | Split-host: data localhost, auth `us.auth.entire.io` ⚠️ |
| Both env vars set | Works | Works |

Local-dev and explicit single-host deployments must now set both `ENTIRE_API_BASE_URL` and `ENTIRE_AUTH_BASE_URL`.

## Test plan
- [x] `go test ./...` passes
- [x] `mise run lint` passes
- [x] Verify a fresh `entire login` against production talks to `us.auth.entire.io`
- [x] Verify local-dev with both env vars set still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default login/OAuth endpoints and provider version for all installs without env overrides; local-dev setups that only set ENTIRE_API_BASE_URL will point auth at production until both vars are set.
> 
> **Overview**
> **Default auth host** is now `https://us.auth.entire.io` when `ENTIRE_AUTH_BASE_URL` is unset, instead of reusing the data API base from `BaseURL()`. Production defaults are **split-host**: data on `entire.io`, auth on `us.auth.entire.io`.
> 
> That makes unset-env installs **split-host** (`IsSplitHost()` true) and **`effectiveProviderVersion()` → v2** (OIDC paths on the auth host). **v1** remains only when both origins are explicitly the same host. Local dev or single-host setups must set **both** `ENTIRE_API_BASE_URL` and `ENTIRE_AUTH_BASE_URL` (setting only the data URL no longer collapses auth onto that host).
> 
> Tests and comments were updated for the new fallback, split-host defaults, and keyring lookup keyed by `AuthBaseURL()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54d7515c1c66ae3ea6ff688732a3234644c41790. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->