### PR TITLE
Backfill Pi model into checkpoint metadata from transcript

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -188,6 +188,20 @@ type TokenCalculator interface {
 	CalculateTokenUsage(transcriptData []byte, fromOffset int) (*TokenUsage, error)
 }
 
+// ModelExtractor extracts the LLM model identifier from a transcript for agents
+// that do not report the model through lifecycle hooks. Pi, for example, records
+// the model on every assistant message (message.model) but its hook events carry
+// no model field, so the transcript is the only source. The framework calls this
+// during condensation to backfill session state when the model is otherwise
+// unknown.
+type ModelExtractor interface {
+	Agent
+
+	// ExtractModel returns the model identifier from the transcript (e.g.
+	// "gpt-5.5"), or "" if none can be determined.
+	ExtractModel(transcriptData []byte) (string, error)
+}
+
 // TextGenerator is an optional interface for agents whose CLI supports
 // non-interactive text generation (e.g., claude --print).
 // Used for AI-powered metadata generation (trail titles, summaries).

--- a/cmd/entire/cli/agent/capabilities.go
+++ b/cmd/entire/cli/agent/capabilities.go
@@ -15,6 +15,11 @@ type CapabilityDeclarer interface {
 // DeclaredCaps enumerates the optional interfaces an agent claims to support.
 // JSON tags match the external agent protocol schema so external.InfoResponse
 // can deserialize directly into this type.
+//
+// Not every optional interface appears here: built-in-only capabilities that
+// have no external-protocol equivalent (SessionBaseDirProvider, ModelExtractor)
+// are intentionally excluded — their As* helpers resolve by type assertion
+// alone, with no DeclaredCaps gate.
 type DeclaredCaps struct {
 	Hooks                  bool `json:"hooks"`
 	TranscriptAnalyzer     bool `json:"transcript_analyzer"`
@@ -169,6 +174,21 @@ func AsSessionBaseDirProvider(ag Agent) (SessionBaseDirProvider, bool) {
 		return nil, false
 	}
 	return sbp, true
+}
+
+// AsModelExtractor returns the agent as ModelExtractor if it implements the
+// interface. No capability declaration is needed: transcript-based model
+// extraction is a built-in-only fallback for agents whose hooks omit the model
+// (e.g., Pi). External agents report the model through their own hook protocol.
+func AsModelExtractor(ag Agent) (ModelExtractor, bool) {
+	if ag == nil {
+		return nil, false
+	}
+	me, ok := ag.(ModelExtractor)
+	if !ok {
+		return nil, false
+	}
+	return me, true
 }
 
 // AsSubagentAwareExtractor returns the agent as SubagentAwareExtractor if it both

--- a/cmd/entire/cli/agent/capabilities_test.go
+++ b/cmd/entire/cli/agent/capabilities_test.go
@@ -78,6 +78,9 @@ func (m *mockFullAgent) PrepareTranscript(context.Context, string) error { retur
 // TokenCalculator
 func (m *mockFullAgent) CalculateTokenUsage([]byte, int) (*TokenUsage, error) { return nil, nil } //nolint:nilnil // test mock
 
+// ModelExtractor
+func (m *mockFullAgent) ExtractModel([]byte) (string, error) { return "mock-model", nil }
+
 // TextGenerator
 func (m *mockFullAgent) GenerateText(context.Context, string, string) (string, error) {
 	return "", nil
@@ -234,6 +237,36 @@ func TestAsTokenCalculator(t *testing.T) {
 		t.Parallel()
 		ag := &mockFullAgent{caps: DeclaredCaps{TokenCalculator: false}}
 		_, ok := AsTokenCalculator(ag)
+		if ok {
+			t.Error("expected false")
+		}
+	})
+}
+
+func TestAsModelExtractor(t *testing.T) {
+	t.Parallel()
+
+	// AsModelExtractor is an ungated, built-in-only helper (no DeclaredCaps
+	// field): implementing the interface is sufficient.
+	t.Run("not implemented", func(t *testing.T) {
+		t.Parallel()
+		_, ok := AsModelExtractor(&mockBaseAgent{})
+		if ok {
+			t.Error("expected false")
+		}
+	})
+
+	t.Run("implemented", func(t *testing.T) {
+		t.Parallel()
+		me, ok := AsModelExtractor(&mockFullAgent{})
+		if !ok || me == nil {
+			t.Error("expected true")
+		}
+	})
+
+	t.Run("nil agent", func(t *testing.T) {
+		t.Parallel()
+		_, ok := AsModelExtractor(nil)
 		if ok {
 			t.Error("expected false")
 		}

--- a/cmd/entire/cli/agent/pi/pijsonl/pijsonl.go
+++ b/cmd/entire/cli/agent/pi/pijsonl/pijsonl.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 )
 
 // EntryTypeMessage is the JSONL `type` value for conversational entries.
@@ -81,6 +82,7 @@ type Message struct {
 	Role       string          `json:"role"`
 	Content    json.RawMessage `json:"content"`
 	Usage      *Usage          `json:"usage,omitempty"`
+	Model      string          `json:"model,omitempty"`
 	StopReason string          `json:"stopReason,omitempty"`
 	ToolCallID string          `json:"toolCallId,omitempty"`
 	ToolName   string          `json:"toolName,omitempty"`
@@ -102,6 +104,42 @@ type ContentItem struct {
 	Name      string          `json:"name,omitempty"`
 	ID        string          `json:"id,omitempty"`
 	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// ForEachActiveMessage invokes fn for every message entry on the active
+// conversation branch, starting at line fromOffset.
+//
+// It owns the parsing skeleton shared by all Pi transcript analysis: active-
+// branch resolution runs on the FULL data (so parentId chains stay intact) while
+// iteration starts at fromOffset, lines that fail to unmarshal or are off the
+// active branch are skipped, and only entries with type=="message" reach fn.
+// Callers apply their own role filter inside fn. Empty data is a no-op.
+func ForEachActiveMessage(data []byte, fromOffset int, fn func(Entry)) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	active := ResolveActiveBranch(data)
+	content := SkipLines(data, fromOffset)
+
+	scanner := NewScanner(content)
+	for scanner.Scan() {
+		var entry Entry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry.Type != EntryTypeMessage {
+			continue
+		}
+		if active != nil && !active[entry.ID] {
+			continue
+		}
+		fn(entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan transcript: %w", err)
+	}
+	return nil
 }
 
 // ResolveActiveBranch walks a Pi transcript tree and returns the set of entry

--- a/cmd/entire/cli/agent/pi/pijsonl/pijsonl_test.go
+++ b/cmd/entire/cli/agent/pi/pijsonl/pijsonl_test.go
@@ -59,6 +59,57 @@ func TestResolveActiveBranch_CycleProtection(t *testing.T) {
 	}
 }
 
+func TestForEachActiveMessage(t *testing.T) {
+	t.Parallel()
+	data := []byte(`{"type":"session","id":"s1"}
+{"type":"message","id":"m1","parentId":null,"message":{"role":"user"}}
+{"type":"message","id":"m2","parentId":"m1","message":{"role":"assistant"}}
+`)
+	var got []string
+	if err := ForEachActiveMessage(data, 0, func(e Entry) {
+		got = append(got, e.ID+":"+e.Message.Role)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// The session header (type != "message") is filtered out.
+	want := []string{"m1:user", "m2:assistant"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestForEachActiveMessage_SkipsAbandonedBranchAndHonoursOffset(t *testing.T) {
+	t.Parallel()
+	// Two branches off m1: m2 (abandoned) and m3 (active, last). Offset 1 skips
+	// the session header line; active-branch resolution still runs on full data.
+	data := []byte(`{"type":"session","id":"s1"}
+{"type":"message","id":"m1","parentId":null,"message":{"role":"user"}}
+{"type":"message","id":"m2","parentId":"m1","message":{"role":"assistant"}}
+{"type":"message","id":"m3","parentId":"m1","message":{"role":"assistant"}}
+`)
+	var got []string
+	if err := ForEachActiveMessage(data, 1, func(e Entry) {
+		got = append(got, e.ID)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"m1", "m3"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v, want %v (m2 abandoned, header skipped by offset)", got, want)
+	}
+}
+
+func TestForEachActiveMessage_EmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+	called := false
+	if err := ForEachActiveMessage(nil, 0, func(Entry) { called = true }); err != nil {
+		t.Fatal(err)
+	}
+	if called {
+		t.Error("fn should not be called for empty data")
+	}
+}
+
 func TestSkipLines(t *testing.T) {
 	t.Parallel()
 	data := []byte("a\nb\nc\nd\n")

--- a/cmd/entire/cli/agent/pi/transcript.go
+++ b/cmd/entire/cli/agent/pi/transcript.go
@@ -14,6 +14,7 @@ var (
 	_ agent.TokenCalculator    = (*PiAgent)(nil)
 	_ agent.TranscriptAnalyzer = (*PiAgent)(nil)
 	_ agent.PromptExtractor    = (*PiAgent)(nil)
+	_ agent.ModelExtractor     = (*PiAgent)(nil)
 )
 
 // CalculateTokenUsage sums per-assistant-message token usage from a Pi JSONL
@@ -22,37 +23,39 @@ var (
 // pijsonl.ResolveActiveBranch for the rationale.
 func (a *PiAgent) CalculateTokenUsage(transcriptData []byte, fromOffset int) (*agent.TokenUsage, error) {
 	usage := &agent.TokenUsage{}
-	if len(transcriptData) == 0 {
-		return usage, nil
-	}
-
-	// IMPORTANT: resolve active branch on FULL data before slicing — a
-	// truncated buffer breaks parentId chains and leaks abandoned branches in.
-	active := pijsonl.ResolveActiveBranch(transcriptData)
-	content := pijsonl.SkipLines(transcriptData, fromOffset)
-
-	scanner := pijsonl.NewScanner(content)
-	for scanner.Scan() {
-		var entry pijsonl.Entry
-		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
-			continue
-		}
-		if entry.Type != pijsonl.EntryTypeMessage || entry.Message.Role != pijsonl.RoleAssistant || entry.Message.Usage == nil {
-			continue
-		}
-		if active != nil && !active[entry.ID] {
-			continue
+	err := pijsonl.ForEachActiveMessage(transcriptData, fromOffset, func(entry pijsonl.Entry) {
+		if entry.Message.Role != pijsonl.RoleAssistant || entry.Message.Usage == nil {
+			return
 		}
 		usage.InputTokens += entry.Message.Usage.Input
 		usage.OutputTokens += entry.Message.Usage.Output
 		usage.CacheReadTokens += entry.Message.Usage.CacheRead
 		usage.CacheCreationTokens += entry.Message.Usage.CacheWrite
 		usage.APICallCount++
-	}
-	if err := scanner.Err(); err != nil {
-		return usage, fmt.Errorf("pi transcript scanner: %w", err)
+	})
+	if err != nil {
+		return usage, fmt.Errorf("calculate token usage: %w", err)
 	}
 	return usage, nil
+}
+
+// ExtractModel returns the model identifier from the most recent assistant
+// message on the active conversation branch. Pi records the model on every
+// assistant message (message.model, e.g. "gpt-5.5") but never reports it through
+// hooks, so the transcript is the only source. Using the most recent message
+// reflects mid-session model changes. Returns "" when no active-branch assistant
+// message carries a model.
+func (a *PiAgent) ExtractModel(transcriptData []byte) (string, error) {
+	model := ""
+	err := pijsonl.ForEachActiveMessage(transcriptData, 0, func(entry pijsonl.Entry) {
+		if entry.Message.Role == pijsonl.RoleAssistant && entry.Message.Model != "" {
+			model = entry.Message.Model
+		}
+	})
+	if err != nil {
+		return model, fmt.Errorf("extract model: %w", err)
+	}
+	return model, nil
 }
 
 // GetTranscriptPosition returns the JSONL line count of the file at path.
@@ -88,27 +91,16 @@ func (a *PiAgent) ExtractModifiedFilesFromOffset(path string, startOffset int) (
 	}
 
 	totalLines := pijsonl.CountLines(data)
-	active := pijsonl.ResolveActiveBranch(data)
-	content := pijsonl.SkipLines(data, startOffset)
-
 	seen := make(map[string]bool)
 	var files []string
 
-	scanner := pijsonl.NewScanner(content)
-	for scanner.Scan() {
-		var entry pijsonl.Entry
-		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
-			continue
-		}
-		if entry.Type != pijsonl.EntryTypeMessage || entry.Message.Role != pijsonl.RoleAssistant {
-			continue
-		}
-		if active != nil && !active[entry.ID] {
-			continue
+	err = pijsonl.ForEachActiveMessage(data, startOffset, func(entry pijsonl.Entry) {
+		if entry.Message.Role != pijsonl.RoleAssistant {
+			return
 		}
 		var items []pijsonl.ContentItem
 		if err := json.Unmarshal(entry.Message.Content, &items); err != nil {
-			continue
+			return
 		}
 		for _, item := range items {
 			if item.Type != "toolCall" {
@@ -128,9 +120,9 @@ func (a *PiAgent) ExtractModifiedFilesFromOffset(path string, startOffset int) (
 				files = append(files, args.Path)
 			}
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return files, totalLines, fmt.Errorf("pi transcript scanner: %w", err)
+	})
+	if err != nil {
+		return files, totalLines, fmt.Errorf("extract modified files: %w", err)
 	}
 	return files, totalLines, nil
 }
@@ -147,39 +139,28 @@ func (a *PiAgent) ExtractPrompts(sessionRef string, fromOffset int) ([]string, e
 		return nil, fmt.Errorf("read pi transcript: %w", err)
 	}
 
-	active := pijsonl.ResolveActiveBranch(data)
-	content := pijsonl.SkipLines(data, fromOffset)
-
 	var prompts []string
-	scanner := pijsonl.NewScanner(content)
-	for scanner.Scan() {
-		var entry pijsonl.Entry
-		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
-			continue
-		}
-		if entry.Type != pijsonl.EntryTypeMessage || entry.Message.Role != pijsonl.RoleUser {
-			continue
-		}
-		if active != nil && !active[entry.ID] {
-			continue
+	err = pijsonl.ForEachActiveMessage(data, fromOffset, func(entry pijsonl.Entry) {
+		if entry.Message.Role != pijsonl.RoleUser {
+			return
 		}
 		// User content can be either a plain string or an array of typed blocks.
 		if text := pijsonl.DecodeStringContent(entry.Message.Content); text != "" {
 			prompts = append(prompts, text)
-			continue
+			return
 		}
 		var items []pijsonl.ContentItem
 		if err := json.Unmarshal(entry.Message.Content, &items); err != nil {
-			continue
+			return
 		}
 		for _, item := range items {
 			if item.Type == pijsonl.ContentTypeText && item.Text != "" {
 				prompts = append(prompts, item.Text)
 			}
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return prompts, fmt.Errorf("pi transcript scanner: %w", err)
+	})
+	if err != nil {
+		return prompts, fmt.Errorf("extract prompts: %w", err)
 	}
 	return prompts, nil
 }

--- a/cmd/entire/cli/agent/pi/transcript_test.go
+++ b/cmd/entire/cli/agent/pi/transcript_test.go
@@ -17,6 +17,7 @@ var (
 	_ agent.TokenCalculator    = (*PiAgent)(nil)
 	_ agent.TranscriptAnalyzer = (*PiAgent)(nil)
 	_ agent.PromptExtractor    = (*PiAgent)(nil)
+	_ agent.ModelExtractor     = (*PiAgent)(nil)
 )
 
 // testSessionJSONL — linear session: header + model_change + 4 messages.
@@ -44,6 +45,30 @@ const testBranchingSessionJSONL = `{"type":"session","version":3,"id":"test-bran
 const testFlatSessionJSONL = `{"type":"session","id":"flat-123"}
 {"type":"message","id":"m1","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}
 {"type":"message","id":"m2","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input":10,"output":5,"cacheRead":0,"cacheWrite":0}}}
+`
+
+// testModelSessionJSONL — assistant messages carry message.model (the real Pi
+// shape: every assistant message records the model that produced it).
+const testModelSessionJSONL = `{"type":"session","version":3,"id":"model-uuid","timestamp":"2026-05-22T21:00:00.000Z","cwd":"/tmp/test"}
+{"type":"message","id":"m1","parentId":null,"timestamp":"2026-05-22T21:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"Hi"}]}}
+{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-05-22T21:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}],"model":"gpt-5.5","provider":"openai-codex","usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0}}}
+{"type":"message","id":"m3","parentId":"m2","timestamp":"2026-05-22T21:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Done"}],"model":"gpt-5.5","provider":"openai-codex","usage":{"input":120,"output":40,"cacheRead":0,"cacheWrite":0}}}
+`
+
+// testModelChangeSessionJSONL — model switches mid-session; the most recent
+// active-branch assistant message wins.
+const testModelChangeSessionJSONL = `{"type":"session","version":3,"id":"model-change-uuid","timestamp":"2026-05-22T22:00:00.000Z","cwd":"/tmp/test"}
+{"type":"message","id":"m1","parentId":null,"timestamp":"2026-05-22T22:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"Hi"}]}}
+{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-05-22T22:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}],"model":"gpt-5.5","provider":"openai-codex","usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0}}}
+{"type":"message","id":"m3","parentId":"m2","timestamp":"2026-05-22T22:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Switched"}],"model":"claude-sonnet-4-6","provider":"anthropic","usage":{"input":120,"output":40,"cacheRead":0,"cacheWrite":0}}}
+`
+
+// testModelBranchingJSONL — abandoned branch (m4) uses a different model than
+// the active branch (m5); only the active-branch model should be returned.
+const testModelBranchingJSONL = `{"type":"session","version":3,"id":"model-branch-uuid","timestamp":"2026-05-22T23:00:00.000Z","cwd":"/tmp/test"}
+{"type":"message","id":"m1","parentId":null,"timestamp":"2026-05-22T23:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"Hi"}]}}
+{"type":"message","id":"m4","parentId":"m1","timestamp":"2026-05-22T23:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"abandoned"}],"model":"claude-opus-4-8","provider":"anthropic","usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0}}}
+{"type":"message","id":"m5","parentId":"m1","timestamp":"2026-05-22T23:00:03.000Z","message":{"role":"assistant","content":[{"type":"text","text":"active"}],"model":"gpt-5.5","provider":"openai-codex","usage":{"input":120,"output":40,"cacheRead":0,"cacheWrite":0}}}
 `
 
 func writeJSONL(t *testing.T, name, content string) string {
@@ -228,6 +253,65 @@ func TestCalculateTokenUsage_FlatTranscript(t *testing.T) {
 // itself; the in-tree tests here verify the agent surface (CalculateTokenUsage,
 // ExtractModifiedFilesFromOffset, ExtractPrompts) honours active-branch
 // filtering end-to-end.
+
+// --- ExtractModel ---
+
+func TestExtractModel(t *testing.T) {
+	t.Parallel()
+	model, err := (&PiAgent{}).ExtractModel([]byte(testModelSessionJSONL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "gpt-5.5" {
+		t.Errorf("model = %q, want gpt-5.5", model)
+	}
+}
+
+func TestExtractModel_MostRecentWinsOnModelChange(t *testing.T) {
+	t.Parallel()
+	model, err := (&PiAgent{}).ExtractModel([]byte(testModelChangeSessionJSONL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "claude-sonnet-4-6" {
+		t.Errorf("model = %q, want claude-sonnet-4-6 (most recent)", model)
+	}
+}
+
+func TestExtractModel_Branching(t *testing.T) {
+	t.Parallel()
+	model, err := (&PiAgent{}).ExtractModel([]byte(testModelBranchingJSONL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "gpt-5.5" {
+		t.Errorf("model = %q, want gpt-5.5 (active branch only)", model)
+	}
+}
+
+func TestExtractModel_Empty(t *testing.T) {
+	t.Parallel()
+	model, err := (&PiAgent{}).ExtractModel(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "" {
+		t.Errorf("model = %q, want empty", model)
+	}
+}
+
+func TestExtractModel_NoModelField(t *testing.T) {
+	t.Parallel()
+	// testSessionJSONL records the model only on the model_change entry, not on
+	// message.model, so ExtractModel finds nothing.
+	model, err := (&PiAgent{}).ExtractModel([]byte(testSessionJSONL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model != "" {
+		t.Errorf("model = %q, want empty (no message.model present)", model)
+	}
+}
 
 // --- ReadSession / WriteSession ---
 

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -152,6 +152,16 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		state.TokenUsage = backfillUsage
 	}
 
+	// Backfill the model from the transcript for agents that don't report it via
+	// hooks (e.g., Pi records message.model but its hook events carry no model
+	// field). Only fills when the model is otherwise unknown — hook-reported
+	// models take precedence.
+	if state.ModelName == "" {
+		if model := sessionStateBackfillModel(ctx, ag, sessionData.Transcript); model != "" {
+			state.ModelName = model
+		}
+	}
+
 	// Skip gate: if there is no transcript AND no files touched, there is nothing
 	// meaningful to condense. Return early to avoid writing metadata-only stubs.
 	//
@@ -596,6 +606,24 @@ func sessionStateBackfillTokenUsage(ctx context.Context, ag agent.Agent, agentTy
 	}
 
 	return nil
+}
+
+// sessionStateBackfillModel extracts the LLM model from the transcript for
+// agents that don't report it through hooks (e.g., Pi). Returns "" when the
+// agent doesn't support model extraction, the transcript is empty, or no model
+// can be determined. Errors are debug-logged because callers treat "" as "no
+// model available".
+func sessionStateBackfillModel(ctx context.Context, ag agent.Agent, transcript []byte) string {
+	me, ok := agent.AsModelExtractor(ag)
+	if !ok {
+		return ""
+	}
+	model, err := me.ExtractModel(transcript)
+	if err != nil {
+		logging.Debug(ctx, "model backfill from transcript failed", slog.String("error", err.Error()))
+		return ""
+	}
+	return model
 }
 
 // attributionOpts provides pre-resolved git objects to avoid redundant reads.

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/copilotcli"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/cursor"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid"
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/pi"
 )
 
 // calculateTokenUsage is a test helper that looks up an agent by type and
@@ -317,6 +318,44 @@ func TestSessionStateBackfillTokenUsage_CopilotUsesZeroInputSessionAggregate(t *
 	require.Equal(t, 20, backfillUsage.CacheReadTokens)
 	require.Equal(t, 10, backfillUsage.CacheCreationTokens)
 	require.Equal(t, 3, backfillUsage.APICallCount)
+}
+
+func TestSessionStateBackfillModel_PiReadsModelFromTranscript(t *testing.T) {
+	t.Parallel()
+
+	// Pi records the model on message.model but never reports it through hooks,
+	// so the model is backfilled from the transcript at condensation time.
+	transcript := []byte(strings.Join([]string{
+		`{"type":"session","version":3,"id":"pi-uuid","cwd":"/tmp"}`,
+		`{"type":"message","id":"m1","parentId":null,"message":{"role":"user","content":[{"type":"text","text":"Hi"}]}}`,
+		`{"type":"message","id":"m2","parentId":"m1","message":{"role":"assistant","content":[{"type":"text","text":"Hello"}],"model":"gpt-5.5","provider":"openai-codex","usage":{"input":100,"output":50,"cacheRead":0,"cacheWrite":0}}}`,
+	}, "\n") + "\n")
+
+	ag, err := agent.GetByAgentType(agent.AgentTypePi)
+	require.NoError(t, err)
+
+	model := sessionStateBackfillModel(context.Background(), ag, transcript)
+	require.Equal(t, "gpt-5.5", model)
+}
+
+func TestSessionStateBackfillModel_EmptyTranscript(t *testing.T) {
+	t.Parallel()
+
+	ag, err := agent.GetByAgentType(agent.AgentTypePi)
+	require.NoError(t, err)
+
+	require.Empty(t, sessionStateBackfillModel(context.Background(), ag, nil))
+}
+
+func TestSessionStateBackfillModel_AgentWithoutSupport(t *testing.T) {
+	t.Parallel()
+
+	// Cursor doesn't implement ModelExtractor, so backfill is a no-op even with
+	// transcript data present.
+	ag, err := agent.GetByAgentType(agent.AgentTypeCursor)
+	require.NoError(t, err)
+
+	require.Empty(t, sessionStateBackfillModel(context.Background(), ag, []byte("{}\n")))
 }
 
 // droidMessage builds a Droid JSONL "message" line with the given id, role, and optional usage.

--- a/docs/architecture/agent-guide.md
+++ b/docs/architecture/agent-guide.md
@@ -580,9 +580,11 @@ Pi uses JSONL (one JSON object per line) with a tree-shaped entry model. Every e
 {"type":"message","id":"def456","parentId":"abc123","timestamp":"...","message":{"role":"assistant","content":[...],"usage":{"input":100,"output":200,"cacheRead":0,"cacheWrite":50}}}
 ```
 
-User `content` can be a plain string or an array of content blocks (text, toolCall, toolResult). `usage` carries `input`, `output`, `cacheRead`, and `cacheWrite` token counts on assistant messages.
+User `content` can be a plain string or an array of content blocks (text, toolCall, toolResult). `usage` carries `input`, `output`, `cacheRead`, and `cacheWrite` token counts on assistant messages. Assistant messages also carry `model` (e.g. `"gpt-5.5"`) and `provider` (e.g. `"openai-codex"`).
 
-**Active branch resolution**: Because Pi sessions form a tree, the transcript accumulates entries from both active and abandoned branches. Entire's `pijsonl.ResolveActiveBranch()` walks the `parentId` chain from the last message to the root. Only entries on the active branch contribute to token counts, file lists, and extracted prompts.
+**Model backfill**: Pi's hook events (`session_start`, `before_agent_start`, `agent_end`) carry no model field, so the model never reaches `Event.Model` and `state.ModelName` would otherwise stay empty. Pi instead implements the optional `agent.ModelExtractor` interface (`ExtractModel`), which reads `message.model` from the most recent active-branch assistant message. Condensation calls `sessionStateBackfillModel` to fill `state.ModelName` when it's empty, so checkpoint metadata records the model just like token usage is backfilled from the transcript.
+
+**Active branch resolution**: Because Pi sessions form a tree, the transcript accumulates entries from both active and abandoned branches. Entire's `pijsonl.ResolveActiveBranch()` walks the `parentId` chain from the last message to the root. Only entries on the active branch contribute to token counts, file lists, extracted prompts, and the extracted model.
 
 **Chunking:** Use `agent.ChunkJSONL(content, maxSize)` — splits at newline boundaries.
 **Reassembly:** Use `agent.ReassembleJSONL(chunks)` — concatenates with newlines.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/454
<!-- entire-trail-link-end -->

## Problem

Pi checkpoint metadata records an empty model:

```json
"agent": "Pi",
"model": "",
```

Pi's hook events (`session_start`, `before_agent_start`, `agent_end`) carry no model field, so `Event.Model` is never set and `state.ModelName` stays empty — unlike Claude Code (reports model on `SessionStart`) or Gemini (`BeforeModel`). But every Pi assistant message in the JSONL records `message.model` (e.g. `gpt-5.5`) and `message.provider` (e.g. `openai-codex`), sitting right next to the `usage` we already parse.

## Fix

Backfill the model from the transcript, mirroring the existing token-usage backfill:

- New optional `agent.ModelExtractor` interface, resolved via an ungated `AsModelExtractor` helper (modeled on `AsSessionBaseDirProvider`, since external agents report model through their own hook protocol).
- Pi implements `ExtractModel`, reading `message.model` from the **most recent active-branch** assistant message so mid-session model changes are reflected.
- `CondenseSession` calls `sessionStateBackfillModel` to fill `state.ModelName` **only when empty** — hook-reported models always win.

## Refactor (from `/simplify`)

`ExtractModel` would have been the 4th hand-rolled copy of the "resolve active branch → skip lines → scan → unmarshal → filter" loop. Extracted `pijsonl.ForEachActiveMessage`, routing `CalculateTokenUsage`, `ExtractModifiedFilesFromOffset`, `ExtractPrompts`, and `ExtractModel` through it (net reduction in `transcript.go` despite the new method). Also removed a dead `Provider` struct field and a redundant empty-transcript guard.

## Scope note

Fills the model on **new** condensations going forward; already-condensed metadata is not retroactively rewritten (same behavior as the token-usage backfill).

## Tests

- `ExtractModel`: linear, mid-session model change (most recent wins), branching (active branch only), empty, no-`message.model`.
- `ForEachActiveMessage`: message filtering, abandoned-branch + offset handling, empty no-op.
- `AsModelExtractor`: implemented / not-implemented / nil.
- `sessionStateBackfillModel`: Pi reads model, empty transcript, unsupported agent (Cursor) no-op.

`mise run fmt` + `mise run lint` clean; agent, strategy, and transcript/compact suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only enrichment with hook precedence preserved; scoped to Pi transcript parsing and condensation backfill, covered by unit tests.
> 
> **Overview**
> Pi checkpoint metadata could record an empty **model** because Pi hooks never set `Event.Model`, even though assistant lines in the JSONL include `message.model`.
> 
> This PR adds a built-in-only **`ModelExtractor`** path (ungated `AsModelExtractor`, like `SessionBaseDirProvider`) and **`sessionStateBackfillModel`** during **`CondenseSession`**, which sets `state.ModelName` from the transcript only when it is still empty so hook-reported models win. Pi’s **`ExtractModel`** uses the latest active-branch assistant `message.model` (branching and mid-session model switches included).
> 
> Pi transcript parsing is refactored through shared **`pijsonl.ForEachActiveMessage`** (full-data active-branch resolution, offset-aware scan), replacing duplicated loops in token usage, file extraction, prompts, and the new model path; **`Message.Model`** is parsed on the shared struct. Tests and the agent guide document the backfill behavior; **new** condensations get the model—existing metadata is not rewritten.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bbe4147586cdda9d4be5df6254c8e730c8ac7da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->