### PR TITLE
Phase 1: mirror committed checkpoints to v1 custom ref (opt-in, local-only)

### DIFF
--- a/cmd/entire/cli/paths/paths.go
+++ b/cmd/entire/cli/paths/paths.go
@@ -42,6 +42,13 @@ const (
 // MetadataBranchName is the orphan branch used by manual-commit strategy to store metadata
 const MetadataBranchName = "entire/checkpoints/v1"
 
+// MetadataRefName is the v1 custom ref that committed metadata is mirrored to
+// when checkpoints_version is "1.1". It lives under refs/entire/ (not
+// refs/heads/) so it stays invisible to `git branch -a` and is not pulled by a
+// default `git clone`. v1 remains the source of truth; this ref is a local-only
+// mirror — nothing reads it and it is never pushed.
+const MetadataRefName = "refs/entire/checkpoints/v1.1"
+
 // Legacy v2 ref names use custom refs under refs/entire/ (not refs/heads/).
 // They are retained for read fallback while checkpoints v2 is rolled back.
 const (

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -1212,15 +1212,11 @@ func warnCheckpointsV2Disallowed(val any) {
 }
 
 // isV1CustomRefValue reports whether a checkpoints_version value selects the v1
-// custom ref. Accepts the JSON string "1.1" and the number 1.1 (float64).
+// custom ref. Only the JSON string "1.1" opts in; the numeric form falls back
+// to v1 (and logs as unsupported, like any other unrecognized value).
 func isV1CustomRefValue(val any) bool {
-	switch v := val.(type) {
-	case string:
-		return v == "1.1"
-	case float64:
-		return v == 1.1
-	}
-	return false
+	s, ok := val.(string)
+	return ok && s == "1.1"
 }
 
 func parseCheckpointsVersion(val any) (int, bool) {

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -1040,6 +1040,16 @@ func WarnIfCheckpointsV2Disallowed(ctx context.Context) {
 	s.WarnIfCheckpointsV2Disallowed()
 }
 
+// MirrorsToV1CustomRef reports whether the v1 custom-ref mirror is opted in.
+// Returns false if settings cannot be loaded.
+func MirrorsToV1CustomRef(ctx context.Context) bool {
+	s, err := Load(ctx)
+	if err != nil {
+		return false
+	}
+	return s.MirrorsToV1CustomRef()
+}
+
 // IsFilteredFetchesEnabled checks if filtered fetches should be used.
 // When enabled, filtered fetches always resolve remote names to URLs first so
 // git does not persist promisor settings onto named remotes in local config.
@@ -1157,6 +1167,17 @@ func (s *EntireSettings) CheckpointsVersion() int {
 	return 1
 }
 
+// MirrorsToV1CustomRef reports whether checkpoints_version opts into mirroring
+// committed metadata to the v1 custom ref (refs/entire/checkpoints/v1.1). v1
+// remains the source of truth; the v1 custom ref is a local-only mirror.
+// Returns false when unset or set to any other value.
+func (s *EntireSettings) MirrorsToV1CustomRef() bool {
+	if s.StrategyOptions == nil {
+		return false
+	}
+	return isV1CustomRefValue(s.StrategyOptions["checkpoints_version"])
+}
+
 // WarnIfCheckpointsV2Disallowed emits the v2 fallback warning when any legacy
 // settings key requests v2 writes or pushes.
 func (s *EntireSettings) WarnIfCheckpointsV2Disallowed() {
@@ -1190,7 +1211,24 @@ func warnCheckpointsV2Disallowed(val any) {
 	)
 }
 
+// isV1CustomRefValue reports whether a checkpoints_version value selects the v1
+// custom ref. Accepts the JSON string "1.1" and the number 1.1 (float64).
+func isV1CustomRefValue(val any) bool {
+	switch v := val.(type) {
+	case string:
+		return v == "1.1"
+	case float64:
+		return v == 1.1
+	}
+	return false
+}
+
 func parseCheckpointsVersion(val any) (int, bool) {
+	// "1.1" selects the v1 custom ref. It uses the v1 data format (major
+	// version 1), so map it to 1 and treat it as recognized, not unsupported.
+	if isV1CustomRefValue(val) {
+		return 1, true
+	}
 	v, ok := val.(int)
 	if ok && (v == 1 || v == 2) {
 		return v, true

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -867,7 +867,7 @@ func TestMirrorsToV1CustomRef(t *testing.T) {
 		{"unset", nil, false},
 		{"empty options", map[string]any{}, false},
 		{"string 1.1 opts in", map[string]any{"checkpoints_version": "1.1"}, true},
-		{"float 1.1 opts in", map[string]any{"checkpoints_version": 1.1}, true},
+		{"float 1.1 does not opt in (string only)", map[string]any{"checkpoints_version": 1.1}, false},
 		{"integer 1 does not mirror", map[string]any{"checkpoints_version": 1}, false},
 		{"string 1 does not mirror", map[string]any{"checkpoints_version": "1"}, false},
 		{"integer 2 does not mirror", map[string]any{"checkpoints_version": 2}, false},
@@ -886,14 +886,16 @@ func TestMirrorsToV1CustomRef(t *testing.T) {
 	}
 }
 
-// TestV1CustomRefValueIsRecognized verifies the v1 custom-ref opt-in is not
-// treated as an unsupported checkpoints_version (which would trip the warning).
+// TestV1CustomRefValueIsRecognized verifies the string "1.1" opt-in is treated
+// as a recognized checkpoints_version (so it does not trip the unsupported
+// warning), while the numeric form is not an opt-in and falls back to v1.
 func TestV1CustomRefValueIsRecognized(t *testing.T) {
 	t.Parallel()
-	for _, val := range []any{"1.1", 1.1} {
-		if _, supported := parseCheckpointsVersion(val); !supported {
-			t.Errorf("parseCheckpointsVersion(%v) reported unsupported, want recognized", val)
-		}
+	if _, supported := parseCheckpointsVersion("1.1"); !supported {
+		t.Errorf(`parseCheckpointsVersion("1.1") reported unsupported, want recognized`)
+	}
+	if _, supported := parseCheckpointsVersion(1.1); supported {
+		t.Errorf("parseCheckpointsVersion(1.1 float) reported recognized, want unsupported (string-only opt-in)")
 	}
 }
 

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -856,6 +856,47 @@ func TestCheckpointsVersion(t *testing.T) {
 	}
 }
 
+func TestMirrorsToV1CustomRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts map[string]any
+		want bool
+	}{
+		{"unset", nil, false},
+		{"empty options", map[string]any{}, false},
+		{"string 1.1 opts in", map[string]any{"checkpoints_version": "1.1"}, true},
+		{"float 1.1 opts in", map[string]any{"checkpoints_version": 1.1}, true},
+		{"integer 1 does not mirror", map[string]any{"checkpoints_version": 1}, false},
+		{"string 1 does not mirror", map[string]any{"checkpoints_version": "1"}, false},
+		{"integer 2 does not mirror", map[string]any{"checkpoints_version": 2}, false},
+		{"unrelated string does not mirror", map[string]any{"checkpoints_version": "abc"}, false},
+		{"bool does not mirror", map[string]any{"checkpoints_version": true}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &EntireSettings{StrategyOptions: tt.opts}
+			if got := s.MirrorsToV1CustomRef(); got != tt.want {
+				t.Errorf("MirrorsToV1CustomRef() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestV1CustomRefValueIsRecognized verifies the v1 custom-ref opt-in is not
+// treated as an unsupported checkpoints_version (which would trip the warning).
+func TestV1CustomRefValueIsRecognized(t *testing.T) {
+	t.Parallel()
+	for _, val := range []any{"1.1", 1.1} {
+		if _, supported := parseCheckpointsVersion(val); !supported {
+			t.Errorf("parseCheckpointsVersion(%v) reported unsupported, want recognized", val)
+		}
+	}
+}
+
 func TestWarnIfCheckpointsV2Disallowed(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -252,6 +252,10 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 	writeCommittedSpan.End()
 	writeV1Duration := time.Since(writeV1Start)
 
+	// Mirror the committed write to the v1 custom ref when opted in
+	// (local-only, never pushed; failures are logged, not fatal).
+	mirrorMetadataToV1CustomRef(ctx, repo)
+
 	logging.Debug(logCtx, "condense timings",
 		slog.String("session_id", state.SessionID),
 		slog.String("checkpoint_id", checkpointID.String()),

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1155,6 +1155,10 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 		return fmt.Errorf("persisting combined attribution: %w", err)
 	}
 
+	// Combined attribution is a committed write in the post-commit hook, so the
+	// v1 custom ref must track it too when opted in (local-only, never pushed).
+	mirrorMetadataToV1CustomRef(ctx, repo)
+
 	return nil
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -2804,6 +2804,11 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 		)
 	}
 
+	// Mirror the finalized v1 metadata to the v1 custom ref when opted in
+	// (local-only, never pushed; failures are logged, not fatal). Once after the
+	// loop is enough — it tracks v1's final commit.
+	mirrorMetadataToV1CustomRef(ctx, repo)
+
 	// Clear turn checkpoint IDs. Do NOT update CheckpointTranscriptStart here — it was
 	// already set correctly by PostCommit: condenseAndUpdateState sets it to the total
 	// transcript lines when condensing, and carryForwardToNewShadowBranch resets it to 0

--- a/cmd/entire/cli/strategy/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/strategy/v1_custom_ref_mirror.go
@@ -1,0 +1,51 @@
+package strategy
+
+import (
+	"context"
+	"log/slog"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// mirrorMetadataToV1CustomRef advances the v1 custom ref
+// (refs/entire/checkpoints/v1.1) to the v1 metadata branch's current commit
+// when checkpoints_version "1.1" is opted in.
+//
+// v1 stays the source of truth; the v1 custom ref is a local-only mirror
+// sharing v1's exact commit — nothing reads it and it is never pushed. Call
+// only after a successful v1 committed write; a mirror failure must not affect
+// that write, so problems are logged, not returned.
+func mirrorMetadataToV1CustomRef(ctx context.Context, repo *git.Repository) {
+	if !settings.MirrorsToV1CustomRef(ctx) {
+		return
+	}
+
+	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	if err != nil {
+		// No v1 metadata branch yet — nothing to mirror. Expected on first use.
+		logging.Debug(ctx, "v1 custom-ref mirror skipped: v1 metadata branch unavailable",
+			slog.String("error", err.Error()))
+		return
+	}
+
+	v1CustomRef := plumbing.ReferenceName(paths.MetadataRefName)
+	if existing, err := repo.Reference(v1CustomRef, true); err == nil && existing.Hash() == v1Ref.Hash() {
+		return // already in sync
+	}
+
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(v1CustomRef, v1Ref.Hash())); err != nil {
+		logging.Warn(ctx, "v1 custom-ref mirror failed",
+			slog.String("ref", paths.MetadataRefName),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	logging.Debug(ctx, "v1 custom-ref mirror updated",
+		slog.String("ref", paths.MetadataRefName),
+		slog.String("hash", v1Ref.Hash().String()))
+}

--- a/cmd/entire/cli/strategy/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/strategy/v1_custom_ref_mirror.go
@@ -34,11 +34,7 @@ func mirrorMetadataToV1CustomRef(ctx context.Context, repo *git.Repository) {
 	}
 
 	v1CustomRef := plumbing.ReferenceName(paths.MetadataRefName)
-	if existing, err := repo.Reference(v1CustomRef, true); err == nil && existing.Hash() == v1Ref.Hash() {
-		return // already in sync
-	}
-
-	if err := repo.Storer.SetReference(plumbing.NewHashReference(v1CustomRef, v1Ref.Hash())); err != nil {
+	if err := SafelyAdvanceLocalRef(ctx, repo, v1CustomRef, v1Ref.Hash()); err != nil {
 		logging.Warn(ctx, "v1 custom-ref mirror failed",
 			slog.String("ref", paths.MetadataRefName),
 			slog.String("error", err.Error()))

--- a/cmd/entire/cli/strategy/v1_custom_ref_mirror_test.go
+++ b/cmd/entire/cli/strategy/v1_custom_ref_mirror_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	git "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -205,6 +206,45 @@ func TestMirrorMetadataToV1CustomRef_V1MissingNoOp(t *testing.T) {
 
 	_, ok := v1CustomRefHash(t, repo)
 	assert.False(t, ok, "v1 custom ref must not be created when v1 metadata branch is absent")
+}
+
+// Not parallel: uses t.Chdir().
+func TestUpdateCombinedAttribution_MirrorsV1CustomRefWhenEnabled(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+	enableV1CustomRefMirror(t, dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	s := &ManualCommitStrategy{}
+	// Two sessions overlapping the same commit make the checkpoint hold >1
+	// session, which triggers combined-attribution persistence — a second v1
+	// write that lands after per-session condensation has already mirrored.
+	sessions := []struct{ id, file string }{
+		{"combined-a", "a.txt"},
+		{"combined-b", "b.txt"},
+	}
+	files := make([]string, 0, len(sessions))
+	for _, sess := range sessions {
+		setupSessionWithCheckpointAndFile(t, s, dir, sess.id, sess.file)
+		state, loadErr := s.loadSessionState(t.Context(), sess.id)
+		require.NoError(t, loadErr)
+		now := time.Now()
+		state.Phase = session.PhaseEnded
+		state.EndedAt = &now
+		state.FilesTouched = []string{sess.file}
+		require.NoError(t, s.saveSessionState(t.Context(), state))
+		files = append(files, sess.file)
+	}
+
+	commitFilesWithTrailer(t, repo, dir, "ccddee112233", files...)
+	require.NoError(t, s.PostCommit(t.Context()))
+
+	v1Hash := v1MetadataBranchHash(t, repo)
+	got, ok := v1CustomRefHash(t, repo)
+	require.True(t, ok, "expected %s to exist", paths.MetadataRefName)
+	assert.Equal(t, v1Hash, got, "custom ref must track v1 after combined-attribution write")
 }
 
 // TestPrePush_DoesNotPushV1CustomRef proves the phase-1 invariant: even with the

--- a/cmd/entire/cli/strategy/v1_custom_ref_mirror_test.go
+++ b/cmd/entire/cli/strategy/v1_custom_ref_mirror_test.go
@@ -1,0 +1,234 @@
+package strategy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// setupV1CustomRefRepo creates an isolated repo with one commit, writes settings
+// with the given checkpoints_version (empty string omits the option), chdirs
+// in, and returns the open repo.
+func setupV1CustomRefRepo(t *testing.T, version string) *git.Repository {
+	t.Helper()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+
+	body := `{"enabled": true}`
+	if version != "" {
+		body = `{"enabled": true, "strategy_options": {"checkpoints_version": ` + version + `}}`
+	}
+	entireDir := filepath.Join(tmpDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(body), 0o644))
+
+	t.Chdir(tmpDir)
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+	return repo
+}
+
+// setV1MetadataBranch points the v1 metadata branch at HEAD and returns the hash.
+func setV1MetadataBranch(t *testing.T, repo *git.Repository) plumbing.Hash {
+	t.Helper()
+	head, err := repo.Head()
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), head.Hash())))
+	return head.Hash()
+}
+
+func v1CustomRefHash(t *testing.T, repo *git.Repository) (plumbing.Hash, bool) {
+	t.Helper()
+	ref, err := repo.Reference(plumbing.ReferenceName(paths.MetadataRefName), true)
+	if err != nil {
+		return plumbing.ZeroHash, false
+	}
+	return ref.Hash(), true
+}
+
+func v1MetadataBranchHash(t *testing.T, repo *git.Repository) plumbing.Hash {
+	t.Helper()
+	ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+	return ref.Hash()
+}
+
+func enableV1CustomRefMirror(t *testing.T, dir string) {
+	t.Helper()
+	entireDir := filepath.Join(dir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(entireDir, paths.SettingsFileName),
+		[]byte(`{"enabled": true, "strategy_options": {"checkpoints_version": "1.1"}}`),
+		0o644,
+	))
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorMetadataToV1CustomRef_CreatesRefWhenEnabled(t *testing.T) {
+	repo := setupV1CustomRefRepo(t, `"1.1"`)
+	v1Hash := setV1MetadataBranch(t, repo)
+
+	mirrorMetadataToV1CustomRef(t.Context(), repo)
+
+	got, ok := v1CustomRefHash(t, repo)
+	require.True(t, ok, "expected %s to exist", paths.MetadataRefName)
+	assert.Equal(t, v1Hash, got)
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorMetadataToV1CustomRef_DisabledNoOp(t *testing.T) {
+	repo := setupV1CustomRefRepo(t, "") // v1 only
+	setV1MetadataBranch(t, repo)
+
+	mirrorMetadataToV1CustomRef(t.Context(), repo)
+
+	_, ok := v1CustomRefHash(t, repo)
+	assert.False(t, ok, "v1 custom ref must not be created when not opted in")
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorMetadataToV1CustomRef_AdvancesExistingRef(t *testing.T) {
+	repo := setupV1CustomRefRepo(t, `"1.1"`)
+	oldHash := setV1MetadataBranch(t, repo)
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), oldHash)))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	testutil.WriteFile(t, cwd, "f2.txt", "more")
+	testutil.GitAdd(t, cwd, "f2.txt")
+	testutil.GitCommit(t, cwd, "second")
+	newHash := setV1MetadataBranch(t, repo)
+	require.NotEqual(t, oldHash, newHash)
+
+	mirrorMetadataToV1CustomRef(t.Context(), repo)
+
+	got, ok := v1CustomRefHash(t, repo)
+	require.True(t, ok)
+	assert.Equal(t, newHash, got)
+}
+
+// Not parallel: uses t.Chdir().
+func TestCondenseSession_MirrorsV1CustomRefWhenEnabled(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+	enableV1CustomRefMirror(t, dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	s := &ManualCommitStrategy{}
+	sessionID := "test-condense-v1-custom-ref"
+	setupSessionWithCheckpoint(t, s, repo, dir, sessionID)
+
+	state, err := s.loadSessionState(t.Context(), sessionID)
+	require.NoError(t, err)
+
+	checkpointID := id.MustCheckpointID("aabbccdd1122")
+	result, err := s.CondenseSession(t.Context(), repo, checkpointID, state, nil)
+	require.NoError(t, err)
+	require.False(t, result.Skipped)
+
+	v1Hash := v1MetadataBranchHash(t, repo)
+	got, ok := v1CustomRefHash(t, repo)
+	require.True(t, ok, "expected %s to exist", paths.MetadataRefName)
+	assert.Equal(t, v1Hash, got)
+}
+
+// Not parallel: uses t.Chdir().
+func TestFinalizeAllTurnCheckpoints_MirrorsV1CustomRefWhenEnabled(t *testing.T) {
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+	enableV1CustomRefMirror(t, dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	s := &ManualCommitStrategy{}
+	sessionID := "test-finalize-v1-custom-ref"
+	setupSessionWithCheckpoint(t, s, repo, dir, sessionID)
+
+	state, err := s.loadSessionState(t.Context(), sessionID)
+	require.NoError(t, err)
+	state.Phase = session.PhaseActive
+	state.TurnCheckpointIDs = nil
+	require.NoError(t, s.saveSessionState(t.Context(), state))
+
+	commitWithCheckpointTrailer(t, repo, dir, "bbccdd112233")
+	require.NoError(t, s.PostCommit(t.Context()))
+
+	state, err = s.loadSessionState(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"bbccdd112233"}, state.TurnCheckpointIDs)
+
+	beforeV1Hash := v1MetadataBranchHash(t, repo)
+	beforeCustomHash, ok := v1CustomRefHash(t, repo)
+	require.True(t, ok, "expected %s to exist after condensation", paths.MetadataRefName)
+	require.Equal(t, beforeV1Hash, beforeCustomHash)
+
+	fullTranscript := testTranscriptPromptResponse + `{"type":"human","message":{"content":"now test it"}}
+{"type":"assistant","message":{"content":"tests pass"}}
+`
+	transcriptPath := filepath.Join(dir, ".entire", "metadata", sessionID, paths.TranscriptFileName)
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(fullTranscript), 0o644))
+	state.TranscriptPath = transcriptPath
+
+	require.NoError(t, s.HandleTurnEnd(t.Context(), state))
+
+	afterV1Hash := v1MetadataBranchHash(t, repo)
+	require.NotEqual(t, beforeV1Hash, afterV1Hash, "finalization should advance v1 metadata")
+	afterCustomHash, ok := v1CustomRefHash(t, repo)
+	require.True(t, ok, "expected %s to exist after finalization", paths.MetadataRefName)
+	assert.Equal(t, afterV1Hash, afterCustomHash)
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorMetadataToV1CustomRef_V1MissingNoOp(t *testing.T) {
+	repo := setupV1CustomRefRepo(t, `"1.1"`) // no v1 metadata branch created
+
+	mirrorMetadataToV1CustomRef(t.Context(), repo)
+
+	_, ok := v1CustomRefHash(t, repo)
+	assert.False(t, ok, "v1 custom ref must not be created when v1 metadata branch is absent")
+}
+
+// TestPrePush_DoesNotPushV1CustomRef proves the phase-1 invariant: even with the
+// mirror opted in and both refs present locally, pre-push pushes only the v1
+// branch and never the v1 custom ref.
+//
+// Not parallel: uses t.Chdir().
+func TestPrePush_DoesNotPushV1CustomRef(t *testing.T) {
+	ctx := t.Context()
+	repo := setupV1CustomRefRepo(t, `"1.1"`)
+	head := setV1MetadataBranch(t, repo)
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), head)))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	bareDir := t.TempDir()
+	runCheckpointRemoteGit(ctx, t, bareDir, "init", "--bare")
+	runCheckpointRemoteGit(ctx, t, cwd, "remote", "add", "origin", bareDir)
+
+	require.NoError(t, (&ManualCommitStrategy{}).PrePush(ctx, "origin"))
+
+	assert.True(t, refExists(ctx, t, bareDir, "refs/heads/"+paths.MetadataBranchName),
+		"v1 metadata branch should be pushed")
+	assert.False(t, refExists(ctx, t, bareDir, paths.MetadataRefName),
+		"v1 custom ref must never be pushed")
+}


### PR DESCRIPTION
## Summary

Phase 1 of the v1.1 checkpoints rollout. Adds **opt-in, local-only mirroring** of committed checkpoint metadata to a new v1 custom ref `refs/entire/checkpoints/v1.1`, gated on `strategy_options.checkpoints_version: "1.1"` (string only).

- v1 (`refs/heads/entire/checkpoints/v1`) **remains the source of truth**.
- The custom ref is **never read, pushed, or fetched** in this PR — it is only populated, so later phases can verify it and eventually flip reads/writes over to it.
- Staged rollout this is step 1 of: **mirror → verify reads → flip reads (v1 fallback) → push/fetch → replace**.

## What changed

- **`paths`** new const `MetadataRefName = "refs/entire/checkpoints/v1.1"`. Lives under `refs/entire/` so it stays invisible to `git branch -a` / GitHub's branch UI and is not pulled by a default `git clone`.
- **`settings`** the string `checkpoints_version: "1.1"` is now a *recognized* value mapping to data-format major version 1 (so it no longer trips the "unsupported version, falling back" warning). New gate `MirrorsToV1CustomRef`. Only the string `"1.1"` opts in; the numeric form `1.1` falls back to v1 and logs as unsupported.
- **`strategy`** new `mirrorMetadataToV1CustomRef(ctx, repo)` helper that, when opted in, advances the custom ref to the v1 branch's current commit using `SafelyAdvanceLocalRef` (the established ancestry-safe advancement for `refs/entire/` metadata refs). Wired into all post-commit-hook committed writes: condensation, finalize, and combined-attribution (`UpdateCheckpointSummary`). A mirror failure is **logged, never propagated**, so it can't affect the v1 write that preceded it.
- **Tests** settings gate; mirror-helper unit tests (create / disabled no-op / advance / v1-missing no-op); integration tests that run the real `CondenseSession` and finalize (`PostCommit` + `HandleTurnEnd`) paths and assert the custom ref equals v1's actual checkpoint commit; and a pre-push test proving the custom ref is never pushed while the v1 branch is.

## Divergences from the handoff plan (`plan.md`) and why

Follows the plan's **scope and intent** but not its **mechanism** (a `MirroringCommittedStore` wrapper on a reworked `GitStore`):

1. **No `MirroringCommittedStore`, no `GitStore` rework, no signature change** (plan §GitStore, §Write Return Values, §MirroringCommittedStore). Replaced by a post-write ref-sync helper — same outcome, much smaller blast radius, zero churn to the working v1 write path.
2. **No seed behavior / `vercel.json` init** (plan §Seed Behavior). N/A under mirroring: the custom ref only ever points at v1's existing commit; it is never independently initialized.
3. **Dev docs (plan Task 6) intentionally omitted** for this PR.

(Earlier divergences now closed: the opt-in is string-only per the plan; and the custom ref now advances ancestry-safely via `SafelyAdvanceLocalRef` rather than a raw `SetReference`.)

## Known limitation — comprehensive mirroring deferred (follow-up)

Mirroring covers the post-commit-hook write paths (condensation, finalize, combined-attribution). Two non-hook paths also advance the v1 ref and do **not** mirror yet:
- `UpdateSummary` (`explain --generate`)
- `attach` (`WriteCommitted`)

After either of those, the custom ref lags v1 until the next hook write re-syncs it. **Benign for phase 1** (nothing reads the custom ref), but must be addressed before reads flip in phase 2. Deferred per PR review.

Note for the follow-up: every committed write — including `explain`'s, which goes through `NewCommittedReader`/`DualCheckpointReader` rather than a raw `*GitStore` — ultimately funnels through `GitStore`'s four committed-write methods. So a single mirror point inside `GitStore` (gated + cached) is the clean way to cover all paths and any future writer, rather than wiring each construction site.

## Out of scope (per plan)

Reads (`list`/`explain`/`rewind` stay v1-only for reading), push/fetch/reconcile/cleanup/doctor for the custom ref, and any new CLI surface — all untouched.

## Testing

- `mise run lint` clean (0 issues).
- Full unit suite passes; strategy + settings packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

