### PR TITLE
test(strategy): combine and remove redundant tests

### DIFF
--- a/cmd/entire/cli/strategy/common_test.go
+++ b/cmd/entire/cli/strategy/common_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -1642,120 +1643,41 @@ func openRepoHeadTree(t *testing.T, dir string) *object.Tree {
 	return tree
 }
 
-func TestReadAgentTypeFromTree_OnlyClaude(t *testing.T) {
+func TestReadAgentTypeFromTree(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	testutil.WriteFile(t, dir, ".claude/settings.json", `{}`)
-	testutil.GitAdd(t, dir, ".claude/settings.json")
-	testutil.GitCommit(t, dir, "init")
+	tests := []struct {
+		name  string
+		files []string // committed before resolution
+		want  types.AgentType
+	}{
+		{"only claude", []string{".claude/settings.json"}, agent.AgentTypeClaudeCode},
+		{"only gemini", []string{".gemini/settings.json"}, agent.AgentTypeGemini},
+		{"only codex", []string{".codex/config.json"}, agent.AgentTypeCodex},
+		{"only cursor", []string{".cursor/settings.json"}, agent.AgentTypeCursor},
+		{"only factory", []string{".factory/settings.json"}, agent.AgentTypeFactoryAIDroid},
+		{"claude and codex is ambiguous", []string{".claude/settings.json", ".codex/config.json"}, agent.AgentTypeUnknown},
+		{"claude and gemini is ambiguous", []string{".claude/settings.json", ".gemini/settings.json"}, agent.AgentTypeUnknown},
+		{"no agent dirs", []string{"f.txt"}, agent.AgentTypeUnknown},
+	}
 
-	tree := openRepoHeadTree(t, dir)
-	result := ReadAgentTypeFromTree(tree, "nonexistent-path")
-	assert.Equal(t, agent.AgentTypeClaudeCode, result)
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-func TestReadAgentTypeFromTree_OnlyGemini(t *testing.T) {
-	t.Parallel()
+			dir := t.TempDir()
+			testutil.InitRepo(t, dir)
+			for _, f := range tt.files {
+				testutil.WriteFile(t, dir, f, `{}`)
+				testutil.GitAdd(t, dir, f)
+			}
+			testutil.GitCommit(t, dir, "init")
 
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	testutil.WriteFile(t, dir, ".gemini/settings.json", `{}`)
-	testutil.GitAdd(t, dir, ".gemini/settings.json")
-	testutil.GitCommit(t, dir, "init")
-
-	tree := openRepoHeadTree(t, dir)
-	result := ReadAgentTypeFromTree(tree, "nonexistent-path")
-	assert.Equal(t, agent.AgentTypeGemini, result)
-}
-
-func TestReadAgentTypeFromTree_OnlyCodex(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	testutil.WriteFile(t, dir, ".codex/config.json", `{}`)
-	testutil.GitAdd(t, dir, ".codex/config.json")
-	testutil.GitCommit(t, dir, "init")
-
-	tree := openRepoHeadTree(t, dir)
-	result := ReadAgentTypeFromTree(tree, "nonexistent-path")
-	assert.Equal(t, agent.AgentTypeCodex, result)
-}
-
-func TestReadAgentTypeFromTree_OnlyCursor(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	testutil.WriteFile(t, dir, ".cursor/settings.json", `{}`)
-	testutil.GitAdd(t, dir, ".cursor/settings.json")
-	testutil.GitCommit(t, dir, "init")
-
-	tree := openRepoHeadTree(t, dir)
-	result := ReadAgentTypeFromTree(tree, "nonexistent-path")
-	assert.Equal(t, agent.AgentTypeCursor, result)
-}
-
-func TestReadAgentTypeFromTree_OnlyFactory(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	testutil.WriteFile(t, dir, ".factory/settings.json", `{}`)
-	testutil.GitAdd(t, dir, ".factory/settings.json")
-	testutil.GitCommit(t, dir, "init")
-
-	tree := openRepoHeadTree(t, dir)
-	result := ReadAgentTypeFromTree(tree, "nonexistent-path")
-	assert.Equal(t, agent.AgentTypeFactoryAIDroid, result)
-}
-
-func TestReadAgentTypeFromTree_ClaudeAndCodex_ReturnsUnknown(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	testutil.WriteFile(t, dir, ".claude/settings.json", `{}`)
-	testutil.GitAdd(t, dir, ".claude/settings.json")
-	testutil.WriteFile(t, dir, ".codex/config.json", `{}`)
-	testutil.GitAdd(t, dir, ".codex/config.json")
-	testutil.GitCommit(t, dir, "init")
-
-	tree := openRepoHeadTree(t, dir)
-	result := ReadAgentTypeFromTree(tree, "nonexistent-path")
-	assert.Equal(t, agent.AgentTypeUnknown, result)
-}
-
-func TestReadAgentTypeFromTree_ClaudeAndGemini_ReturnsUnknown(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	testutil.WriteFile(t, dir, ".claude/settings.json", `{}`)
-	testutil.GitAdd(t, dir, ".claude/settings.json")
-	testutil.WriteFile(t, dir, ".gemini/settings.json", `{}`)
-	testutil.GitAdd(t, dir, ".gemini/settings.json")
-	testutil.GitCommit(t, dir, "init")
-
-	tree := openRepoHeadTree(t, dir)
-	result := ReadAgentTypeFromTree(tree, "nonexistent-path")
-	assert.Equal(t, agent.AgentTypeUnknown, result)
-}
-
-func TestReadAgentTypeFromTree_NoAgentDirs_ReturnsUnknown(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	testutil.WriteFile(t, dir, "f.txt", "init")
-	testutil.GitAdd(t, dir, "f.txt")
-	testutil.GitCommit(t, dir, "init")
-
-	tree := openRepoHeadTree(t, dir)
-	result := ReadAgentTypeFromTree(tree, "nonexistent-path")
-	assert.Equal(t, agent.AgentTypeUnknown, result)
+			tree := openRepoHeadTree(t, dir)
+			result := ReadAgentTypeFromTree(tree, "nonexistent-path")
+			assert.Equal(t, tt.want, result)
+		})
+	}
 }
 
 func TestReadAgentTypeFromTree_MetadataJSON_OverridesDir(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_condensation_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation_test.go
@@ -64,20 +64,35 @@ esac
 	}
 }
 
-func TestCalculateTokenUsage_CursorReturnsNil(t *testing.T) {
+func TestCalculateTokenUsage_CursorAlwaysNil(t *testing.T) {
 	t.Parallel()
 
 	// Cursor transcripts don't contain token usage data, so CalculateTokenUsage
-	// should return nil (not an empty struct) to signal "no data available".
-	transcript := []byte(`{"role":"user","message":{"content":[{"type":"text","text":"hello"}]}}`)
-
-	ag, err := agent.GetByAgentType(agent.AgentTypeCursor)
-	if err != nil {
-		t.Fatalf("GetByAgentType(Cursor) error: %v", err)
+	// should always return nil (not an empty struct) to signal "no data
+	// available" — regardless of transcript shape or offset.
+	tests := []struct {
+		name       string
+		transcript []byte
+		offset     int
+	}{
+		{"single-line transcript", []byte(`{"role":"user","message":{"content":[{"type":"text","text":"hello"}]}}`), 0},
+		{"multi-line real transcript", []byte(cursorSampleTranscript), 0},
+		{"real transcript with offset", []byte(cursorSampleTranscript), 3},
 	}
-	result := agent.CalculateTokenUsage(context.Background(), ag, transcript, 0, "")
-	if result != nil {
-		t.Errorf("CalculateTokenUsage(Cursor) = %+v, want nil", result)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ag, err := agent.GetByAgentType(agent.AgentTypeCursor)
+			if err != nil {
+				t.Fatalf("GetByAgentType(Cursor) error: %v", err)
+			}
+			result := agent.CalculateTokenUsage(context.Background(), ag, tt.transcript, tt.offset, "")
+			if result != nil {
+				t.Errorf("CalculateTokenUsage(Cursor) = %+v, want nil", result)
+			}
+		})
 	}
 }
 
@@ -263,34 +278,6 @@ func TestExtractUserPrompts_CursorEmpty(t *testing.T) {
 	prompts := extractUserPrompts(agent.AgentTypeCursor, "")
 	if len(prompts) != 0 {
 		t.Errorf("extractUserPrompts(Cursor, empty) = %v, want empty", prompts)
-	}
-}
-
-func TestCalculateTokenUsage_CursorRealTranscript(t *testing.T) {
-	t.Parallel()
-
-	// Even with a multi-line real transcript, Cursor should return nil
-	ag, err := agent.GetByAgentType(agent.AgentTypeCursor)
-	if err != nil {
-		t.Fatalf("GetByAgentType(Cursor) error: %v", err)
-	}
-	result := agent.CalculateTokenUsage(context.Background(), ag, []byte(cursorSampleTranscript), 0, "")
-	if result != nil {
-		t.Errorf("CalculateTokenUsage(Cursor, real transcript) = %+v, want nil", result)
-	}
-}
-
-func TestCalculateTokenUsage_CursorWithOffset(t *testing.T) {
-	t.Parallel()
-
-	// Offset should not matter — Cursor always returns nil
-	ag, err := agent.GetByAgentType(agent.AgentTypeCursor)
-	if err != nil {
-		t.Fatalf("GetByAgentType(Cursor) error: %v", err)
-	}
-	result := agent.CalculateTokenUsage(context.Background(), ag, []byte(cursorSampleTranscript), 3, "")
-	if result != nil {
-		t.Errorf("CalculateTokenUsage(Cursor, offset=3) = %+v, want nil", result)
 	}
 }
 

--- a/cmd/entire/cli/strategy/manual_commit_migration_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_migration_test.go
@@ -274,37 +274,3 @@ func TestMigrateShadowBranch_MultiTrailerHEAD(t *testing.T) {
 	assert.Equal(t, headHash, state.BaseCommit, "BaseCommit should advance to HEAD")
 	assert.Equal(t, headHash, state.AttributionBaseCommit, "AttributionBaseCommit should advance (reconcile path)")
 }
-
-// TestMigrateShadowBranch_CommitObjectFailure verifies that when HEAD has no
-// trailers but the session has a LastCheckpointID set, the code falls through
-// to the migrate path without panicking.
-func TestMigrateShadowBranch_CommitObjectFailure(t *testing.T) {
-	dir, initHash := setupMigrationRepo(t)
-	t.Chdir(dir)
-
-	cpID := checkpointID.MustCheckpointID("abc123def456")
-
-	// Create a commit without any trailers.
-	testutil.WriteFile(t, dir, "file.txt", "content")
-	testutil.GitAdd(t, dir, "file.txt")
-	testutil.GitCommit(t, dir, "plain commit without trailers")
-	headHash := testutil.GetHeadHash(t, dir)
-
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-
-	state := &SessionState{
-		SessionID:             "test-session",
-		BaseCommit:            initHash,
-		AttributionBaseCommit: initHash,
-		LastCheckpointID:      cpID,
-	}
-
-	s := &ManualCommitStrategy{}
-	migrated, _, err := s.migrateShadowBranchIfNeeded(context.Background(), repo, state)
-	require.NoError(t, err)
-
-	assert.True(t, migrated, "should fall through to migrate path")
-	assert.Equal(t, headHash, state.BaseCommit, "BaseCommit should advance")
-	assert.Equal(t, initHash, state.AttributionBaseCommit, "AttributionBaseCommit should stay pinned (migrate path)")
-}

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -4255,81 +4255,77 @@ func TestCommittedFilesExcludingMetadata(t *testing.T) {
 	require.NotContains(t, resultSet, ".cursor/hooks.json", ".cursor/ should be excluded (cursor ProtectedDirs)")
 	require.NotContains(t, resultSet, "opencode.json", "opencode.json should be excluded (opencode ProtectedFiles)")
 	require.Len(t, result, 2)
-}
 
-func TestMarshalPromptAttributionsIncludingPending_IncludesPending(t *testing.T) {
-	t.Parallel()
-
-	state := &SessionState{
-		PromptAttributions: []PromptAttribution{
-			{CheckpointNumber: 1, UserLinesAdded: 3},
-		},
-		PendingPromptAttribution: &PromptAttribution{
-			CheckpointNumber: 2, UserLinesAdded: 5,
-		},
-	}
-
-	raw := marshalPromptAttributionsIncludingPending(state)
-	require.NotNil(t, raw)
-
-	var result []PromptAttribution
-	require.NoError(t, json.Unmarshal(raw, &result))
-	require.Len(t, result, 2, "should include both committed and pending attributions")
-	require.Equal(t, 1, result[0].CheckpointNumber)
-	require.Equal(t, 3, result[0].UserLinesAdded)
-	require.Equal(t, 2, result[1].CheckpointNumber)
-	require.Equal(t, 5, result[1].UserLinesAdded)
-}
-
-func TestMarshalPromptAttributionsIncludingPending_NoPending(t *testing.T) {
-	t.Parallel()
-
-	state := &SessionState{
-		PromptAttributions: []PromptAttribution{
-			{CheckpointNumber: 1, UserLinesAdded: 3},
-		},
-	}
-
-	raw := marshalPromptAttributionsIncludingPending(state)
-	require.NotNil(t, raw)
-
-	var result []PromptAttribution
-	require.NoError(t, json.Unmarshal(raw, &result))
-	require.Len(t, result, 1)
-}
-
-func TestMarshalPromptAttributionsIncludingPending_Empty(t *testing.T) {
-	t.Parallel()
-
-	state := &SessionState{}
-	raw := marshalPromptAttributionsIncludingPending(state)
-	require.Nil(t, raw, "empty state should return nil")
-}
-
-func TestMarshalPromptAttributionsIncludingPending_OnlyPending(t *testing.T) {
-	t.Parallel()
-
-	state := &SessionState{
-		PendingPromptAttribution: &PromptAttribution{
-			CheckpointNumber: 1, UserLinesAdded: 7,
-		},
-	}
-
-	raw := marshalPromptAttributionsIncludingPending(state)
-	require.NotNil(t, raw, "pending-only should still produce output")
-
-	var result []PromptAttribution
-	require.NoError(t, json.Unmarshal(raw, &result))
-	require.Len(t, result, 1)
-	require.Equal(t, 7, result[0].UserLinesAdded)
-}
-
-func TestCommittedFilesExcludingMetadata_AllMetadata(t *testing.T) {
-	t.Parallel()
-
-	result := committedFilesExcludingMetadata(map[string]struct{}{
+	// All-metadata input excludes everything, yielding an empty result.
+	allMetadata := committedFilesExcludingMetadata(map[string]struct{}{
 		".entire/settings.json": {},
 		".entire/.gitignore":    {},
 	})
-	require.Empty(t, result, "all metadata files should be excluded")
+	require.Empty(t, allMetadata, "all metadata files should be excluded")
+}
+
+func TestMarshalPromptAttributionsIncludingPending(t *testing.T) {
+	t.Parallel()
+
+	committed := []PromptAttribution{{CheckpointNumber: 1, UserLinesAdded: 3}}
+	pending := &PromptAttribution{CheckpointNumber: 2, UserLinesAdded: 5}
+
+	tests := []struct {
+		name      string
+		state     *SessionState
+		wantNil   bool
+		wantCount int
+		// verify is an optional extra check on the unmarshalled attributions.
+		verify func(t *testing.T, result []PromptAttribution)
+	}{
+		{
+			name:      "includes both committed and pending",
+			state:     &SessionState{PromptAttributions: committed, PendingPromptAttribution: pending},
+			wantCount: 2,
+			verify: func(t *testing.T, result []PromptAttribution) {
+				require.Equal(t, 1, result[0].CheckpointNumber)
+				require.Equal(t, 3, result[0].UserLinesAdded)
+				require.Equal(t, 2, result[1].CheckpointNumber)
+				require.Equal(t, 5, result[1].UserLinesAdded)
+			},
+		},
+		{
+			name:      "committed only, no pending",
+			state:     &SessionState{PromptAttributions: committed},
+			wantCount: 1,
+		},
+		{
+			name:    "empty state returns nil",
+			state:   &SessionState{},
+			wantNil: true,
+		},
+		{
+			name:      "pending only still produces output",
+			state:     &SessionState{PendingPromptAttribution: &PromptAttribution{CheckpointNumber: 1, UserLinesAdded: 7}},
+			wantCount: 1,
+			verify: func(t *testing.T, result []PromptAttribution) {
+				require.Equal(t, 7, result[0].UserLinesAdded)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := marshalPromptAttributionsIncludingPending(tt.state)
+			if tt.wantNil {
+				require.Nil(t, raw)
+				return
+			}
+			require.NotNil(t, raw)
+
+			var result []PromptAttribution
+			require.NoError(t, json.Unmarshal(raw, &result))
+			require.Len(t, result, tt.wantCount)
+			if tt.verify != nil {
+				tt.verify(t, result)
+			}
+		})
+	}
 }

--- a/cmd/entire/cli/strategy/phase_postcommit_test.go
+++ b/cmd/entire/cli/strategy/phase_postcommit_test.go
@@ -1928,117 +1928,85 @@ func TestPostCommit_IdleSession_NoTranscriptFallbackForCarryForward(t *testing.T
 		"IDLE session should NOT be condensed via transcript fallback — only ACTIVE sessions get transcript extraction for carry-forward")
 }
 
-// TestPostCommit_IdleSession_SkipsSentinelWait is a regression test verifying that
-// PostCommit for an IDLE session with AgentType=ClaudeCode and a TranscriptPath
-// completes quickly without hitting the 3s sentinel timeout in PrepareTranscript.
+// TestPostCommit_NonActiveSession_SkipsSentinelWait is a regression test verifying
+// that PostCommit for an IDLE or ENDED session with AgentType=ClaudeCode and a
+// TranscriptPath completes quickly without hitting the 3s sentinel timeout in
+// PrepareTranscript. Both IDLE and ENDED sessions should skip the sentinel wait
+// since their transcripts are already fully flushed.
 //
-// Before the fix, the transcript extraction functions called PrepareTranscript unconditionally,
-// which triggered waitForTranscriptFlush (3s timeout) even for idle/ended sessions
-// where the transcript was already fully flushed.
+// Before the fix, the transcript extraction functions called PrepareTranscript
+// unconditionally, which triggered waitForTranscriptFlush (3s timeout) even for
+// idle/ended sessions where the transcript was already fully flushed.
 //
 // After the fix, PrepareTranscript is only called when state.Phase.IsActive().
-func TestPostCommit_IdleSession_SkipsSentinelWait(t *testing.T) {
-	dir := setupGitRepo(t)
-	t.Chdir(dir)
+func TestPostCommit_NonActiveSession_SkipsSentinelWait(t *testing.T) {
+	tests := []struct {
+		name         string
+		phase        session.Phase
+		setEndedAt   bool
+		sessionID    string
+		commitTrlSHA string
+	}{
+		{"idle", session.PhaseIdle, false, "test-idle-skip-sentinel", "a1a2a3a4a5a6"},
+		{"ended", session.PhaseEnded, true, "test-ended-skip-sentinel", "e1e2e3e4e5e6"},
+	}
 
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := setupGitRepo(t)
+			t.Chdir(dir)
 
-	s := &ManualCommitStrategy{}
-	sessionID := "test-idle-skip-sentinel"
+			repo, err := git.PlainOpen(dir)
+			require.NoError(t, err)
 
-	// Initialize session and save a checkpoint
-	setupSessionWithCheckpoint(t, s, repo, dir, sessionID)
+			s := &ManualCommitStrategy{}
 
-	// Set phase to IDLE, set AgentType to Claude Code, and set TranscriptPath
-	// Without TranscriptPath, the PrepareTranscript code path is never reached.
-	// Without AgentType=ClaudeCode, the sentinel wait is not triggered.
-	state, err := s.loadSessionState(context.Background(), sessionID)
-	require.NoError(t, err)
-	state.Phase = session.PhaseIdle
-	state.LastInteractionTime = nil
-	state.FilesTouched = []string{"test.txt"}
-	state.AgentType = agent.AgentTypeClaudeCode
+			// Initialize session and save a checkpoint
+			setupSessionWithCheckpoint(t, s, repo, dir, tt.sessionID)
 
-	// Create a transcript file so PrepareTranscript would be triggered if not guarded
-	transcriptFile := filepath.Join(dir, ".entire", "transcript-"+sessionID+".jsonl")
-	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptFile), 0o755))
-	require.NoError(t, os.WriteFile(transcriptFile, []byte(`{"type":"human"}`+"\n"), 0o644))
-	state.TranscriptPath = transcriptFile
+			// Set phase, AgentType=ClaudeCode, and TranscriptPath. Without
+			// TranscriptPath the PrepareTranscript code path is never reached;
+			// without AgentType=ClaudeCode the sentinel wait is not triggered.
+			state, err := s.loadSessionState(context.Background(), tt.sessionID)
+			require.NoError(t, err)
+			state.Phase = tt.phase
+			if tt.setEndedAt {
+				now := time.Now()
+				state.EndedAt = &now
+			} else {
+				state.LastInteractionTime = nil
+			}
+			state.FilesTouched = []string{"test.txt"}
+			state.AgentType = agent.AgentTypeClaudeCode
 
-	require.NoError(t, s.saveSessionState(context.Background(), state))
+			// Create a transcript file so PrepareTranscript would be triggered if not guarded
+			transcriptFile := filepath.Join(dir, ".entire", "transcript-"+tt.sessionID+".jsonl")
+			require.NoError(t, os.MkdirAll(filepath.Dir(transcriptFile), 0o755))
+			require.NoError(t, os.WriteFile(transcriptFile, []byte(`{"type":"human"}`+"\n"), 0o644))
+			state.TranscriptPath = transcriptFile
 
-	// Create a commit WITH the Entire-Checkpoint trailer
-	commitWithCheckpointTrailer(t, repo, dir, "a1a2a3a4a5a6")
+			require.NoError(t, s.saveSessionState(context.Background(), state))
 
-	// Time PostCommit — before the fix this would take ~3s+ due to sentinel timeout
-	start := time.Now()
-	err = s.PostCommit(context.Background())
-	elapsed := time.Since(start)
-	require.NoError(t, err)
+			// Create a commit WITH the Entire-Checkpoint trailer
+			commitWithCheckpointTrailer(t, repo, dir, tt.commitTrlSHA)
 
-	// Assert it completes well under the 3s sentinel timeout.
-	// Normal PostCommit for these tests runs in <500ms (git operations only).
-	assert.Less(t, elapsed, 2*time.Second,
-		"IDLE session PostCommit should skip sentinel wait and complete in <2s, took %v", elapsed)
+			// Time PostCommit — before the fix this would take ~3s+ due to sentinel timeout.
+			// Normal PostCommit for these tests runs in <500ms (git operations only).
+			start := time.Now()
+			err = s.PostCommit(context.Background())
+			elapsed := time.Since(start)
+			require.NoError(t, err)
 
-	// Verify condensation still happened correctly
-	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
-	require.NoError(t, err, "entire/checkpoints/v1 branch should exist after condensation")
-	assert.NotNil(t, sessionsRef)
-}
+			// Assert it completes well under the 3s sentinel timeout.
+			assert.Less(t, elapsed, 2*time.Second,
+				"%s session PostCommit should skip sentinel wait and complete in <2s, took %v", tt.name, elapsed)
 
-// TestPostCommit_EndedSession_SkipsSentinelWait is the same regression test as
-// TestPostCommit_IdleSession_SkipsSentinelWait but for ENDED phase sessions.
-// Both IDLE and ENDED sessions should skip the sentinel wait since their
-// transcripts are already fully flushed.
-func TestPostCommit_EndedSession_SkipsSentinelWait(t *testing.T) {
-	dir := setupGitRepo(t)
-	t.Chdir(dir)
-
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-
-	s := &ManualCommitStrategy{}
-	sessionID := "test-ended-skip-sentinel"
-
-	// Initialize session and save a checkpoint
-	setupSessionWithCheckpoint(t, s, repo, dir, sessionID)
-
-	// Set phase to ENDED, set AgentType to Claude Code, and set TranscriptPath
-	state, err := s.loadSessionState(context.Background(), sessionID)
-	require.NoError(t, err)
-	now := time.Now()
-	state.Phase = session.PhaseEnded
-	state.EndedAt = &now
-	state.FilesTouched = []string{"test.txt"}
-	state.AgentType = agent.AgentTypeClaudeCode
-
-	// Create a transcript file so PrepareTranscript would be triggered if not guarded
-	transcriptFile := filepath.Join(dir, ".entire", "transcript-"+sessionID+".jsonl")
-	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptFile), 0o755))
-	require.NoError(t, os.WriteFile(transcriptFile, []byte(`{"type":"human"}`+"\n"), 0o644))
-	state.TranscriptPath = transcriptFile
-
-	require.NoError(t, s.saveSessionState(context.Background(), state))
-
-	// Create a commit WITH the Entire-Checkpoint trailer
-	commitWithCheckpointTrailer(t, repo, dir, "e1e2e3e4e5e6")
-
-	// Time PostCommit — before the fix this would take ~3s+ due to sentinel timeout
-	start := time.Now()
-	err = s.PostCommit(context.Background())
-	elapsed := time.Since(start)
-	require.NoError(t, err)
-
-	// Assert it completes well under the 3s sentinel timeout
-	assert.Less(t, elapsed, 2*time.Second,
-		"ENDED session PostCommit should skip sentinel wait and complete in <2s, took %v", elapsed)
-
-	// Verify condensation still happened correctly
-	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
-	require.NoError(t, err, "entire/checkpoints/v1 branch should exist after condensation")
-	assert.NotNil(t, sessionsRef)
+			// Verify condensation still happened correctly
+			sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+			require.NoError(t, err, "entire/checkpoints/v1 branch should exist after condensation")
+			assert.NotNil(t, sessionsRef)
+		})
+	}
 }
 
 // TestPostCommit_EndedSession_SetsFullyCondensed verifies that an ENDED session

--- a/cmd/entire/cli/strategy/session_state_test.go
+++ b/cmd/entire/cli/strategy/session_state_test.go
@@ -75,132 +75,85 @@ func verifySessionState(t *testing.T, loaded, expected *SessionState) {
 }
 
 // TestLoadSessionState_WithEndedAt tests that EndedAt serializes/deserializes correctly.
-func TestLoadSessionState_WithEndedAt(t *testing.T) {
-	dir := t.TempDir()
-	_, err := git.PlainInit(dir, false)
-	if err != nil {
-		t.Fatalf("failed to init git repo: %v", err)
+// TestLoadSessionState_OptionalTimeFields verifies that the optional *time.Time
+// fields on SessionState (EndedAt, LastInteractionTime) round-trip correctly
+// through save/load — both when set (preserved and Equal) and when nil (stays nil).
+func TestLoadSessionState_OptionalTimeFields(t *testing.T) {
+	tests := []struct {
+		name string
+		// set assigns the field on a state and returns the value assigned.
+		set func(s *SessionState, ts time.Time)
+		// get reads the field back from a loaded state.
+		get func(s *SessionState) *time.Time
+	}{
+		{
+			name: "EndedAt",
+			set:  func(s *SessionState, ts time.Time) { s.EndedAt = &ts },
+			get:  func(s *SessionState) *time.Time { return s.EndedAt },
+		},
+		{
+			name: "LastInteractionTime",
+			set:  func(s *SessionState, ts time.Time) { s.LastInteractionTime = &ts },
+			get:  func(s *SessionState) *time.Time { return s.LastInteractionTime },
+		},
 	}
 
-	t.Chdir(dir)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_, err := git.PlainInit(dir, false)
+			if err != nil {
+				t.Fatalf("failed to init git repo: %v", err)
+			}
+			t.Chdir(dir)
 
-	// Test with EndedAt set
-	endedAt := time.Now().Add(-time.Hour) // 1 hour ago
-	state := &SessionState{
-		SessionID:  "test-session-ended",
-		BaseCommit: "abc123def456",
-		StartedAt:  time.Now().Add(-2 * time.Hour),
-		EndedAt:    &endedAt,
-		StepCount:  5,
-	}
+			// Field set: it should be preserved and Equal after load.
+			ts := time.Now().Add(-time.Hour)
+			state := &SessionState{
+				SessionID:  "test-session-set",
+				BaseCommit: "abc123def456",
+				StartedAt:  time.Now().Add(-2 * time.Hour),
+				StepCount:  5,
+			}
+			tt.set(state, ts)
 
-	err = SaveSessionState(context.Background(), state)
-	if err != nil {
-		t.Fatalf("SaveSessionState() error = %v", err)
-	}
+			if err := SaveSessionState(context.Background(), state); err != nil {
+				t.Fatalf("SaveSessionState() error = %v", err)
+			}
+			loaded, err := LoadSessionState(context.Background(), "test-session-set")
+			if err != nil {
+				t.Fatalf("LoadSessionState() error = %v", err)
+			}
+			require.NotNil(t, loaded, "LoadSessionState() returned nil")
 
-	loaded, err := LoadSessionState(context.Background(), "test-session-ended")
-	if err != nil {
-		t.Fatalf("LoadSessionState() error = %v", err)
-	}
-	require.NotNil(t, loaded, "LoadSessionState() returned nil")
+			got := tt.get(loaded)
+			if got == nil {
+				t.Fatalf("%s was nil after load, expected non-nil", tt.name)
+			}
+			if !got.Equal(ts) {
+				t.Errorf("%s = %v, want %v", tt.name, *got, ts)
+			}
 
-	// Verify EndedAt was preserved
-	if loaded.EndedAt == nil {
-		t.Fatal("EndedAt was nil after load, expected non-nil")
-	}
-	if !loaded.EndedAt.Equal(endedAt) {
-		t.Errorf("EndedAt = %v, want %v", *loaded.EndedAt, endedAt)
-	}
+			// Field nil: it should remain nil after load.
+			stateNil := &SessionState{
+				SessionID:  "test-session-nil",
+				BaseCommit: "xyz789",
+				StartedAt:  time.Now(),
+				StepCount:  1,
+			}
+			if err := SaveSessionState(context.Background(), stateNil); err != nil {
+				t.Fatalf("SaveSessionState() error = %v", err)
+			}
+			loadedNil, err := LoadSessionState(context.Background(), "test-session-nil")
+			if err != nil {
+				t.Fatalf("LoadSessionState() error = %v", err)
+			}
+			require.NotNil(t, loadedNil, "LoadSessionState() returned nil")
 
-	// Test with EndedAt nil (active session)
-	stateActive := &SessionState{
-		SessionID:  "test-session-active",
-		BaseCommit: "xyz789",
-		StartedAt:  time.Now(),
-		EndedAt:    nil,
-		StepCount:  1,
-	}
-
-	err = SaveSessionState(context.Background(), stateActive)
-	if err != nil {
-		t.Fatalf("SaveSessionState() error = %v", err)
-	}
-
-	loadedActive, err := LoadSessionState(context.Background(), "test-session-active")
-	if err != nil {
-		t.Fatalf("LoadSessionState() error = %v", err)
-	}
-	require.NotNil(t, loadedActive, "LoadSessionState() returned nil")
-
-	// Verify EndedAt remains nil
-	if loadedActive.EndedAt != nil {
-		t.Errorf("EndedAt = %v, want nil for active session", *loadedActive.EndedAt)
-	}
-}
-
-// TestLoadSessionState_WithLastInteractionTime tests that LastInteractionTime serializes/deserializes correctly.
-func TestLoadSessionState_WithLastInteractionTime(t *testing.T) {
-	dir := t.TempDir()
-	_, err := git.PlainInit(dir, false)
-	if err != nil {
-		t.Fatalf("failed to init git repo: %v", err)
-	}
-
-	t.Chdir(dir)
-
-	// Test with LastInteractionTime set
-	lastInteraction := time.Now().Add(-5 * time.Minute)
-	state := &SessionState{
-		SessionID:           "test-session-interaction",
-		BaseCommit:          "abc123def456",
-		StartedAt:           time.Now().Add(-2 * time.Hour),
-		LastInteractionTime: &lastInteraction,
-		StepCount:           3,
-	}
-
-	err = SaveSessionState(context.Background(), state)
-	if err != nil {
-		t.Fatalf("SaveSessionState() error = %v", err)
-	}
-
-	loaded, err := LoadSessionState(context.Background(), "test-session-interaction")
-	if err != nil {
-		t.Fatalf("LoadSessionState() error = %v", err)
-	}
-	require.NotNil(t, loaded, "LoadSessionState() returned nil")
-
-	// Verify LastInteractionTime was preserved
-	if loaded.LastInteractionTime == nil {
-		t.Fatal("LastInteractionTime was nil after load, expected non-nil")
-	}
-	if !loaded.LastInteractionTime.Equal(lastInteraction) {
-		t.Errorf("LastInteractionTime = %v, want %v", *loaded.LastInteractionTime, lastInteraction)
-	}
-
-	// Test with LastInteractionTime nil (old session without this field)
-	stateOld := &SessionState{
-		SessionID:           "test-session-no-interaction",
-		BaseCommit:          "xyz789",
-		StartedAt:           time.Now(),
-		LastInteractionTime: nil,
-		StepCount:           1,
-	}
-
-	err = SaveSessionState(context.Background(), stateOld)
-	if err != nil {
-		t.Fatalf("SaveSessionState() error = %v", err)
-	}
-
-	loadedOld, err := LoadSessionState(context.Background(), "test-session-no-interaction")
-	if err != nil {
-		t.Fatalf("LoadSessionState() error = %v", err)
-	}
-	require.NotNil(t, loadedOld, "LoadSessionState() returned nil")
-
-	// Verify LastInteractionTime remains nil
-	if loadedOld.LastInteractionTime != nil {
-		t.Errorf("LastInteractionTime = %v, want nil for old session", *loadedOld.LastInteractionTime)
+			if gotNil := tt.get(loadedNil); gotNil != nil {
+				t.Errorf("%s = %v, want nil", tt.name, *gotNil)
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/strategy/session_test.go
+++ b/cmd/entire/cli/strategy/session_test.go
@@ -123,46 +123,6 @@ func TestCheckpointStruct(t *testing.T) {
 	}
 }
 
-func TestSessionCheckpointCount(t *testing.T) {
-	session := Session{
-		ID:          "test-session",
-		Description: "Test",
-		Checkpoints: []Checkpoint{
-			{CheckpointID: "a"},
-			{CheckpointID: "b"},
-			{CheckpointID: "c"},
-		},
-	}
-
-	if session.ID != "test-session" {
-		t.Errorf("expected ID to match, got %s", session.ID)
-	}
-	if session.Description != "Test" {
-		t.Errorf("expected Description to match, got %s", session.Description)
-	}
-	if len(session.Checkpoints) != 3 {
-		t.Errorf("expected 3 checkpoints, got %d", len(session.Checkpoints))
-	}
-	// Verify checkpoint IDs are accessible
-	if session.Checkpoints[0].CheckpointID != "a" {
-		t.Errorf("expected first checkpoint ID to be 'a', got %s", session.Checkpoints[0].CheckpointID)
-	}
-}
-
-func TestEmptySession(t *testing.T) {
-	session := Session{}
-
-	if session.ID != "" {
-		t.Error("expected empty session to have empty ID")
-	}
-	if session.Description != "" {
-		t.Error("expected empty session to have empty Description")
-	}
-	if session.Checkpoints != nil {
-		t.Error("expected empty session to have nil Checkpoints")
-	}
-}
-
 // TestManualCommitStrategyGetAdditionalSessions verifies that GetAdditionalSessions is callable
 func TestManualCommitStrategyGetAdditionalSessions(t *testing.T) {
 	strat := NewManualCommitStrategy()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/457
<!-- entire-trail-link-end -->

## What

Found and consolidated redundant tests in `cmd/entire/cli/strategy` — tests that exercised the **exact same functionality** were either combined into table-driven tests or removed when fully subsumed by another test.

Candidate redundancies were identified by analyzing all 37 test files in the package, then each was verified by reading the actual code before any change. Only HIGH-confidence cases (genuinely identical behavior) were acted on.

**Net: 18 redundant test functions collapsed into 7 — 510 deletions, 262 insertions. No loss of coverage; every distinct case survives as a named subtest row.**

## Changes

| File | Before → After | Action & why |
|------|----------------|--------------|
| `common_test.go` | 8 `TestReadAgentTypeFromTree_*` → 1 | Identical bodies differing only in which agent dir(s) were written and the expected `AgentType`. Merged into a table-driven test. Kept `_MetadataJSON_OverridesDir` separate (distinct metadata-override branch). |
| `manual_commit_test.go` | 4 `TestMarshalPromptAttributionsIncludingPending_*` → 1 | Same function, same assertion shape, varying only by input state (committed/pending/empty/pending-only). Merged into a table. |
| `manual_commit_test.go` | `TestCommittedFilesExcludingMetadata_AllMetadata` removed | All-metadata case is a strict subset of `TestCommittedFilesExcludingMetadata`; folded its assertion into the base test. |
| `manual_commit_condensation_test.go` | 3 `TestCalculateTokenUsage_Cursor*` → 1 | All asserted "Cursor always returns nil token usage", varying only by transcript shape and offset. Merged into `_CursorAlwaysNil`. |
| `phase_postcommit_test.go` | `_IdleSession_SkipsSentinelWait` + `_EndedSession_SkipsSentinelWait` → 1 | Bodies were byte-identical except the session phase. Merged into `_NonActiveSession_SkipsSentinelWait` (subtest per phase). |
| `manual_commit_migration_test.go` | `TestMigrateShadowBranch_CommitObjectFailure` removed | Identical inputs (no-trailer commit, session with `LastCheckpointID`) and identical assertions to `_MigratePathPinsAttribution`. |
| `session_test.go` | `TestSessionCheckpointCount`, `TestEmptySession` removed | Trivial struct round-trips that are strict subsets of `TestSessionStruct`. |
| `session_state_test.go` | `_WithEndedAt` + `_WithLastInteractionTime` → 1 | Structurally identical save/load round-trips differing only in which `*time.Time` field is set. Merged into `_OptionalTimeFields`. |

## Deliberately left alone

Several structurally-similar tests were verified to cover **genuinely different** behavior and were **not** touched:

- Push/remote layered tests (`SafelyAdvanceLocalRef` → `FetchMetadataBranch` → `FetchV2MainFromURL`) — same invariant, different production functions with distinct historical bugs.
- Diverged-vs-orphan replay pairs — different code paths (merge-base found vs. fallback).
- `condense_skip` entry-point pair and `StoreAgentTypeHint`/`ClaimSessionStartBanner` — different functions/contracts.

Helper-level duplication (inline `gitRun` closures, repeated repo bootstrap) was flagged by analysis but is out of scope here — it's helper de-duplication, not redundant *tests*.

## Verification

- `go test ./cmd/entire/cli/strategy/` → `ok` (38s)
- `mise run lint` → `0 issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors in the strategy package; behavior is validated by existing and merged subtests, with no runtime code changes.
> 
> **Overview**
> This PR **refactors tests only** in `cmd/entire/cli/strategy`: redundant cases are folded into **table-driven** tests or dropped when another test already covers the same behavior. **Production code is unchanged.**
> 
> Eight `ReadAgentTypeFromTree_*` tests become one table (single vs ambiguous agent dirs, no dirs). Four `marshalPromptAttributionsIncludingPending` variants merge into one table; the all-metadata `committedFilesExcludingMetadata` assertion moves into the main test. Three Cursor `CalculateTokenUsage` nil checks merge into `TestCalculateTokenUsage_CursorAlwaysNil`. Idle and ended **PostCommit** sentinel-wait regressions share `TestPostCommit_NonActiveSession_SkipsSentinelWait`. `TestMigrateShadowBranch_CommitObjectFailure` is removed as duplicate of the migrate-path pin test. Trivial `Session` struct tests and separate `EndedAt` / `LastInteractionTime` round-trips consolidate into `TestLoadSessionState_OptionalTimeFields`.
> 
> Net effect: fewer test functions, same named subtest coverage; PR description cites ~510 lines removed and ~262 added with `go test ./cmd/entire/cli/strategy/` passing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bda6bd78b77fcae7686779737a89507585e1f18. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->