### PR TITLE
refactor(review): dedupe redundant tests and remove dead code

### DIFF
--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -1259,8 +1259,10 @@ func TestAttachCmd_ReviewDoesNotInferSkillsFromConfig(t *testing.T) {
 `)
 
 	// Seed review config — the spawn-path default. Attach must ignore this.
-	if err := cliReview.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
-		"claude-code": {Skills: []string{"/pr-review-toolkit:review-pr"}},
+	if err := settings.SaveClonePreferences(context.Background(), &settings.ClonePreferences{
+		Review: map[string]settings.ReviewConfig{
+			"claude-code": {Skills: []string{"/pr-review-toolkit:review-pr"}},
+		},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/entire/cli/investigate/cmd_test.go
+++ b/cmd/entire/cli/investigate/cmd_test.go
@@ -725,7 +725,7 @@ func TestNewCommand_ContinueWithMissingState(t *testing.T) {
 // --- helpers ---------------------------------------------------------------
 
 // saveInvestigateSettings writes an InvestigateConfig into the CWD's
-// .entire/settings.json. Mirrors review.SaveReviewConfig.
+// .entire/settings.json.
 func saveInvestigateSettings(cfg *settings.InvestigateConfig) error {
 	ctx := context.Background()
 	s, err := settings.Load(ctx)

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -227,7 +227,7 @@ func runReview(ctx context.Context, cmd *cobra.Command, agentOverride, baseOverr
 	// 2. Load config. A load error means the settings file exists but is
 	// malformed (Load returns a default-filled object when the file is
 	// missing). Surface the error instead of silently opening the picker,
-	// which would cause SaveReviewConfig to write over the user's other
+	// which would cause the config writer to write over the user's other
 	// settings with an empty EntireSettings{}.
 	s, err := settings.Load(ctx)
 	if err != nil {

--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -81,45 +81,39 @@ func TestNewReviewCmd_NoHiddenFlags(t *testing.T) {
 	}
 }
 
-func TestReviewFindings_NotGitRepoReturnsSilentError(t *testing.T) {
-	t.Chdir(t.TempDir())
-
-	rootCmd := cli.NewRootCmd()
-	errBuf := &bytes.Buffer{}
-	rootCmd.SetErr(errBuf)
-	rootCmd.SetArgs([]string{"review", "--findings"})
-
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error outside a git repo")
+// TestReview_NotGitRepoReturnsSilentError verifies the not-a-git-repo guard
+// (which fires before any flag-specific logic) returns a SilentError and prints
+// "Not a git repository" exactly once, regardless of which review mode flag is used.
+func TestReview_NotGitRepoReturnsSilentError(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"findings", []string{"review", "--findings"}},
+		{"fix", []string{"review", "--fix", "review-session"}},
 	}
-	var silentErr *cli.SilentError
-	if !errors.As(err, &silentErr) {
-		t.Fatalf("expected SilentError, got %T: %v", err, err)
-	}
-	if got := strings.Count(errBuf.String(), "Not a git repository"); got != 1 {
-		t.Fatalf("not-git message count = %d, want 1; stderr:\n%s", got, errBuf.String())
-	}
-}
 
-func TestReviewFix_NotGitRepoReturnsSilentError(t *testing.T) {
-	t.Chdir(t.TempDir())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
 
-	rootCmd := cli.NewRootCmd()
-	errBuf := &bytes.Buffer{}
-	rootCmd.SetErr(errBuf)
-	rootCmd.SetArgs([]string{"review", "--fix", "review-session"})
+			rootCmd := cli.NewRootCmd()
+			errBuf := &bytes.Buffer{}
+			rootCmd.SetErr(errBuf)
+			rootCmd.SetArgs(tt.args)
 
-	err := rootCmd.Execute()
-	if err == nil {
-		t.Fatal("expected error outside a git repo")
-	}
-	var silentErr *cli.SilentError
-	if !errors.As(err, &silentErr) {
-		t.Fatalf("expected SilentError, got %T: %v", err, err)
-	}
-	if got := strings.Count(errBuf.String(), "Not a git repository"); got != 1 {
-		t.Fatalf("not-git message count = %d, want 1; stderr:\n%s", got, errBuf.String())
+			err := rootCmd.Execute()
+			if err == nil {
+				t.Fatal("expected error outside a git repo")
+			}
+			var silentErr *cli.SilentError
+			if !errors.As(err, &silentErr) {
+				t.Fatalf("expected SilentError, got %T: %v", err, err)
+			}
+			if got := strings.Count(errBuf.String(), "Not a git repository"); got != 1 {
+				t.Fatalf("not-git message count = %d, want 1; stderr:\n%s", got, errBuf.String())
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -43,6 +43,22 @@ func installHooksForCmdTest(t *testing.T, agentName types.AgentName) {
 	}
 }
 
+// seedReviewConfig persists a review config map into clone-local preferences for
+// test setup, preserving any other existing preferences. It replaces the former
+// review.SaveReviewConfig, which had no production caller (the picker writes via
+// the combined config+fix-agent writer instead).
+func seedReviewConfig(ctx context.Context, cfg map[string]settings.ReviewConfig) error {
+	prefs, err := settings.LoadClonePreferences(ctx)
+	if err != nil {
+		return err
+	}
+	if prefs == nil {
+		prefs = &settings.ClonePreferences{}
+	}
+	prefs.Review = cfg
+	return settings.SaveClonePreferences(ctx, prefs)
+}
+
 // TestReviewCmd_Help verifies `entire review --help` contains the expected
 // flags and subcommands without panicking.
 func TestReviewCmd_Help(t *testing.T) {
@@ -122,7 +138,7 @@ func TestRunReview_MissingHooksAborts(t *testing.T) {
 	setupCmdTestRepo(t)
 
 	// Save config but don't install hooks.
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"claude-code": {Skills: []string{testReviewSkill}},
 	}); err != nil {
 		t.Fatal(err)
@@ -166,7 +182,7 @@ func TestRunReview_NonLaunchableAgentPreservesMarker(t *testing.T) {
 
 	// Use prompt-only config: cursor has no curated built-ins, so a Skills
 	// value would trip the installed-skill guard before reaching this path.
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		nonLaunchableAgent: {Prompt: "review the diff"},
 	}); err != nil {
 		t.Fatal(err)
@@ -203,7 +219,7 @@ func TestRunReview_MissingConfiguredSkillAbortsBeforeMarker(t *testing.T) {
 	setupCmdTestRepo(t)
 	installHooksForCmdTest(t, "claude-code")
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"claude-code": {Skills: []string{"/bogus:skill-does-not-exist"}},
 	}); err != nil {
 		t.Fatal(err)
@@ -235,7 +251,7 @@ func TestRunReview_PromptOnlyConfigSkipsVerification(t *testing.T) {
 	setupCmdTestRepo(t)
 	installHooksForCmdTest(t, "cursor")
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"cursor": {Prompt: "review the diff"},
 	}); err != nil {
 		t.Fatal(err)
@@ -264,7 +280,7 @@ func TestRunReview_FlagOverrideSkipsPicker(t *testing.T) {
 	installHooksForCmdTest(t, "cursor")
 	installHooksForCmdTest(t, "opencode")
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"cursor":   {Prompt: "review the diff"},
 		"opencode": {Prompt: "review the diff"},
 	}); err != nil {
@@ -295,7 +311,7 @@ func TestRunReview_FlagOverrideMustBeEligibleAgent(t *testing.T) {
 	installHooksForCmdTest(t, "cursor")
 	// opencode has no hooks installed
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"cursor":   {Prompt: "review the diff"},
 		"opencode": {Prompt: "review the diff"},
 	}); err != nil {
@@ -398,7 +414,7 @@ func (r *captureRunConfigReviewer) Start(_ context.Context, cfg reviewtypes.RunC
 func TestRunReview_ConfigPromptAugmentsSelectedSkills(t *testing.T) {
 	setupCmdTestRepo(t)
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"claude-code": {
 			Skills: []string{"/review"},
 			Prompt: "Focus on auth regressions.",
@@ -453,7 +469,7 @@ func TestRunReview_ConfigPromptAugmentsSelectedSkills(t *testing.T) {
 func TestDispatchFork_TwoLaunchableNoOverride(t *testing.T) {
 	setupCmdTestRepo(t)
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"agent-a": {Prompt: "review"},
 		"agent-b": {Prompt: "review"},
 	}); err != nil {
@@ -490,7 +506,7 @@ func TestDispatchFork_TwoLaunchableNoOverride(t *testing.T) {
 func TestDispatchFork_MultiAgentPassesPerAgentConfigs(t *testing.T) {
 	setupCmdTestRepo(t)
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"claude-code": {
 			Skills: []string{"/review"},
 			Prompt: "Claude saved prompt.",
@@ -576,7 +592,7 @@ func TestDispatchFork_OneLaunchableOneNonLaunchableNoOverride(t *testing.T) {
 	setupCmdTestRepo(t)
 	installHooksForCmdTest(t, "cursor")
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"cursor":  {Prompt: "review"},
 		"agent-a": {Prompt: "review"},
 	}); err != nil {
@@ -620,7 +636,7 @@ func TestDispatchFork_TwoLaunchableWithAgentOverride(t *testing.T) {
 	setupCmdTestRepo(t)
 	installHooksForCmdTest(t, "cursor") // cursor needs real hooks
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"cursor":  {Prompt: "review"},
 		"agent-a": {Prompt: "review"},
 	}); err != nil {
@@ -663,7 +679,7 @@ func TestDispatchFork_TwoLaunchableWithAgentOverride(t *testing.T) {
 func TestDispatchFork_MultiPickerCancellationExitsCleanly(t *testing.T) {
 	setupCmdTestRepo(t)
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"agent-a": {Prompt: "review"},
 		"agent-b": {Prompt: "review"},
 	}); err != nil {
@@ -694,7 +710,7 @@ func TestDispatchFork_MultiPickerCancellationExitsCleanly(t *testing.T) {
 func TestDispatchFork_MultiPickerNoSelectionSurfacesError(t *testing.T) {
 	setupCmdTestRepo(t)
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"agent-a": {Prompt: "review"},
 		"agent-b": {Prompt: "review"},
 	}); err != nil {
@@ -971,7 +987,7 @@ func TestFindTUISink_NoTUIInSlice(t *testing.T) {
 func TestDispatchFork_SynthesisSinkNilProviderNoComposition(t *testing.T) {
 	setupCmdTestRepo(t)
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"agent-a": {Prompt: "review"},
 		"agent-b": {Prompt: "review"},
 	}); err != nil {
@@ -1013,7 +1029,7 @@ func TestDispatchFork_SingleAgentNoSynthesis(t *testing.T) {
 	setupCmdTestRepo(t)
 	installHooksForCmdTest(t, "cursor")
 
-	if err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
+	if err := seedReviewConfig(context.Background(), map[string]settings.ReviewConfig{
 		"cursor": {Prompt: "review"},
 	}); err != nil {
 		t.Fatal(err)

--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -81,9 +81,8 @@ func TestNewReviewCmd_NoHiddenFlags(t *testing.T) {
 	}
 }
 
-// TestReview_NotGitRepoReturnsSilentError verifies the not-a-git-repo guard
-// (which fires before any flag-specific logic) returns a SilentError and prints
-// "Not a git repository" exactly once, regardless of which review mode flag is used.
+// TestReview_NotGitRepoReturnsSilentError checks that review outside a git repo
+// returns a SilentError and prints the message once, for any mode flag.
 func TestReview_NotGitRepoReturnsSilentError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/entire/cli/review/env.go
+++ b/cmd/entire/cli/review/env.go
@@ -89,10 +89,3 @@ func AppendReviewEnv(base []string, agentName string, cfg reviewtypes.RunConfig,
 		EnvStartingSHA+"="+cfg.StartingSHA,
 	)
 }
-
-// IsReviewEnvEntry reports whether kv is a "KEY=VALUE" entry whose key is
-// one of the ENTIRE_REVIEW_* contract variables. Exported for symmetry
-// with investigate.IsInvestigateEnvEntry.
-func IsReviewEnvEntry(kv string) bool {
-	return provenance.IsReviewEntry(kv)
-}

--- a/cmd/entire/cli/review/picker.go
+++ b/cmd/entire/cli/review/picker.go
@@ -255,26 +255,6 @@ func MergePickerResults(existing map[string]settings.ReviewConfig, offered map[s
 	return merged
 }
 
-// SaveReviewConfig persists the review map into clone-local preferences while
-// preserving other review preferences. A load error means the preferences file
-// exists but is malformed — we must NOT silently overwrite it with an empty
-// struct, or every unrelated review preference would be wiped. Return the
-// error so the caller can surface it instead.
-func SaveReviewConfig(ctx context.Context, review map[string]settings.ReviewConfig) error {
-	prefs, err := settings.LoadClonePreferences(ctx)
-	if err != nil {
-		return fmt.Errorf("load review preferences before save: %w", err)
-	}
-	if prefs == nil {
-		prefs = &settings.ClonePreferences{}
-	}
-	prefs.Review = review
-	if err := settings.SaveClonePreferences(ctx, prefs); err != nil {
-		return fmt.Errorf("save review preferences: %w", err)
-	}
-	return nil
-}
-
 func SaveReviewFixAgent(ctx context.Context, agentName string) error {
 	prefs, err := settings.LoadClonePreferences(ctx)
 	if err != nil {

--- a/cmd/entire/cli/review/picker_test.go
+++ b/cmd/entire/cli/review/picker_test.go
@@ -2,8 +2,6 @@ package review_test
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -289,63 +287,6 @@ func TestBuildReviewPickerFields_SingleBuiltinDefaultsSelectedAndRenders(t *test
 	}
 }
 
-// TestSaveReviewConfig_PersistsSettings verifies SaveReviewConfig writes
-// clone-local preferences and the settings can be read back.
-func TestSaveReviewConfig_PersistsSettings(t *testing.T) {
-	tmp := t.TempDir()
-	testutil.InitRepo(t, tmp)
-	t.Chdir(tmp)
-
-	err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
-		testAgentName: {Skills: []string{testReviewSkill, "/test-auditor"}},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	prefs, err := settings.LoadClonePreferences(context.Background())
-	if err != nil {
-		t.Fatalf("load preferences: %v", err)
-	}
-	cfg := prefs.Review[testAgentName]
-	if len(cfg.Skills) != 2 {
-		t.Fatalf("expected 2 skills saved, got %v", cfg.Skills)
-	}
-	if cfg.Skills[0] != testReviewSkill {
-		t.Errorf("first skill = %q", cfg.Skills[0])
-	}
-}
-
-func TestSaveReviewConfig_PreservesReviewFixAgent(t *testing.T) {
-	tmp := t.TempDir()
-	testutil.InitRepo(t, tmp)
-	t.Chdir(tmp)
-
-	if err := settings.SaveClonePreferences(context.Background(), &settings.ClonePreferences{
-		ReviewFixAgent: testCodexAgent,
-	}); err != nil {
-		t.Fatalf("seed preferences: %v", err)
-	}
-
-	err := review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
-		testAgentName: {Skills: []string{testReviewSkill}},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	prefs, err := settings.LoadClonePreferences(context.Background())
-	if err != nil {
-		t.Fatalf("load preferences: %v", err)
-	}
-	if prefs.ReviewFixAgent != testCodexAgent {
-		t.Fatalf("ReviewFixAgent = %q, want %s", prefs.ReviewFixAgent, testCodexAgent)
-	}
-	if _, ok := prefs.Review[testAgentName]; !ok {
-		t.Fatalf("review preferences missing %s: %+v", testAgentName, prefs.Review)
-	}
-}
-
 func TestSaveReviewFixAgent_PersistsSettings(t *testing.T) {
 	tmp := t.TempDir()
 	testutil.InitRepo(t, tmp)
@@ -361,44 +302,5 @@ func TestSaveReviewFixAgent_PersistsSettings(t *testing.T) {
 	}
 	if prefs.ReviewFixAgent != testCodexAgent {
 		t.Fatalf("ReviewFixAgent = %q, want %s", prefs.ReviewFixAgent, testCodexAgent)
-	}
-}
-
-// TestSaveReviewConfig_ReturnsErrorOnMalformedSettings ensures SaveReviewConfig
-// does not overwrite existing preferences when preferences.json is malformed.
-func TestSaveReviewConfig_ReturnsErrorOnMalformedSettings(t *testing.T) {
-	tmp := t.TempDir()
-	testutil.InitRepo(t, tmp)
-	t.Chdir(tmp)
-
-	preferencesPath, err := settings.ClonePreferencesPath(context.Background())
-	if err != nil {
-		t.Fatalf("preferences path: %v", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(preferencesPath), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	malformed := []byte(`{"review": {`)
-	if err := os.WriteFile(preferencesPath, malformed, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	before, err := os.ReadFile(preferencesPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = review.SaveReviewConfig(context.Background(), map[string]settings.ReviewConfig{
-		testAgentName: {Skills: []string{testReviewSkill}},
-	})
-	if err == nil {
-		t.Fatal("expected SaveReviewConfig to error on malformed preferences")
-	}
-
-	after, err := os.ReadFile(preferencesPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(before) != string(after) {
-		t.Errorf("preferences.json was overwritten on load error:\nbefore=%q\nafter=%q", before, after)
 	}
 }

--- a/cmd/entire/cli/review/tui_model_test.go
+++ b/cmd/entire/cli/review/tui_model_test.go
@@ -361,55 +361,51 @@ func TestTUIModel_InitializesDetailViewport(t *testing.T) {
 // mode caused the Program to receive mouse events, but the Update switch
 // only routed tea.KeyPressMsg — mouse events fell through unhandled and the
 // viewport never got a chance to scroll.
-func TestTUIModel_DelegatesMouseWheelToViewport(t *testing.T) {
+// TestTUIModel_DelegatesScrollInputToViewport pins that scroll input in detail
+// mode reaches the viewport and advances YOffset rather than being swallowed by
+// the model's Update switch. It covers both dispatch arms:
+//   - mouse-wheel: regression against setting View.MouseMode = MouseModeCellMotion
+//     on entry to detail mode causing mouse events to fall through unhandled
+//     because the switch only routed tea.KeyPressMsg.
+//   - pager keys (PgDn): reach the viewport's internal keymap.
+func TestTUIModel_DelegatesScrollInputToViewport(t *testing.T) {
 	t.Parallel()
-	m := newTestModel([]string{"agent-a"}, func() {})
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
-	m = mustModel(t, updated)
-	long := strings.Repeat("paragraph of text ", 20)
-	for range 5 {
-		updated, _ = m.Update(agentEventMsg{agent: "agent-a", ev: reviewtypes.AssistantText{Text: long}})
-		m = mustModel(t, updated)
-	}
-	updated, _ = m.Update(testCtrlKey('o'))
-	m = mustModel(t, updated)
-	m.detail.GotoTop()
-	startOffset := m.detail.YOffset()
 
-	updated, _ = m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
-	m = mustModel(t, updated)
-	if m.detail.YOffset() <= startOffset {
-		t.Errorf("expected mouse-wheel-down to advance viewport YOffset beyond %d; got %d", startOffset, m.detail.YOffset())
+	tests := []struct {
+		name  string
+		input tea.Msg
+	}{
+		{"mouse-wheel-down", tea.MouseWheelMsg{Button: tea.MouseWheelDown}},
+		{"pgdn", tea.KeyPressMsg{Code: tea.KeyPgDown}},
 	}
-}
 
-// TestTUIModel_DelegatesScrollKeysToViewport pins that pager keys (PgDn) in
-// detail mode reach the viewport's internal keymap and advance YOffset rather
-// than being swallowed by the model's switch.
-func TestTUIModel_DelegatesScrollKeysToViewport(t *testing.T) {
-	t.Parallel()
-	m := newTestModel([]string{"agent-a"}, func() {})
-	// Size the window so the viewport has a sensible height.
-	updated, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
-	m = mustModel(t, updated)
-	// Populate enough content to scroll. AssistantText with long text wraps
-	// to many viewport lines.
-	long := strings.Repeat("paragraph of text ", 20)
-	for range 5 {
-		updated, _ = m.Update(agentEventMsg{agent: "agent-a", ev: reviewtypes.AssistantText{Text: long}})
-		m = mustModel(t, updated)
-	}
-	// Enter detail mode (auto-tails to bottom).
-	updated, _ = m.Update(testCtrlKey('o'))
-	m = mustModel(t, updated)
-	// Jump to top so PgDn has somewhere to scroll into.
-	m.detail.GotoTop()
-	startOffset := m.detail.YOffset()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := newTestModel([]string{"agent-a"}, func() {})
+			// Size the window so the viewport has a sensible height.
+			updated, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+			m = mustModel(t, updated)
+			// Populate enough content to scroll. AssistantText with long text
+			// wraps to many viewport lines.
+			long := strings.Repeat("paragraph of text ", 20)
+			for range 5 {
+				updated, _ = m.Update(agentEventMsg{agent: "agent-a", ev: reviewtypes.AssistantText{Text: long}})
+				m = mustModel(t, updated)
+			}
+			// Enter detail mode (auto-tails to bottom), then jump to top so the
+			// scroll input has somewhere to advance into.
+			updated, _ = m.Update(testCtrlKey('o'))
+			m = mustModel(t, updated)
+			m.detail.GotoTop()
+			startOffset := m.detail.YOffset()
 
-	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
-	m = mustModel(t, updated)
-	if m.detail.YOffset() <= startOffset {
-		t.Errorf("expected PgDn to advance viewport YOffset beyond %d; got %d", startOffset, m.detail.YOffset())
+			updated, _ = m.Update(tt.input)
+			m = mustModel(t, updated)
+			if m.detail.YOffset() <= startOffset {
+				t.Errorf("expected %s to advance viewport YOffset beyond %d; got %d", tt.name, startOffset, m.detail.YOffset())
+			}
+		})
 	}
 }
 

--- a/cmd/entire/cli/review/tui_model_test.go
+++ b/cmd/entire/cli/review/tui_model_test.go
@@ -355,19 +355,9 @@ func TestTUIModel_InitializesDetailViewport(t *testing.T) {
 	}
 }
 
-// TestTUIModel_DelegatesMouseWheelToViewport pins that mouse-wheel events in
-// detail mode reach the viewport's MouseWheelMsg handler. The bug this guards
-// against: setting View.MouseMode = MouseModeCellMotion on entry to detail
-// mode caused the Program to receive mouse events, but the Update switch
-// only routed tea.KeyPressMsg — mouse events fell through unhandled and the
-// viewport never got a chance to scroll.
-// TestTUIModel_DelegatesScrollInputToViewport pins that scroll input in detail
-// mode reaches the viewport and advances YOffset rather than being swallowed by
-// the model's Update switch. It covers both dispatch arms:
-//   - mouse-wheel: regression against setting View.MouseMode = MouseModeCellMotion
-//     on entry to detail mode causing mouse events to fall through unhandled
-//     because the switch only routed tea.KeyPressMsg.
-//   - pager keys (PgDn): reach the viewport's internal keymap.
+// TestTUIModel_DelegatesScrollInputToViewport pins that scroll input (mouse
+// wheel and PgDn) in detail mode reaches the viewport and advances YOffset
+// instead of being swallowed by the model's Update switch.
 func TestTUIModel_DelegatesScrollInputToViewport(t *testing.T) {
 	t.Parallel()
 
@@ -383,18 +373,15 @@ func TestTUIModel_DelegatesScrollInputToViewport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			m := newTestModel([]string{"agent-a"}, func() {})
-			// Size the window so the viewport has a sensible height.
 			updated, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
 			m = mustModel(t, updated)
-			// Populate enough content to scroll. AssistantText with long text
-			// wraps to many viewport lines.
+			// Fill the viewport with enough wrapped lines to scroll.
 			long := strings.Repeat("paragraph of text ", 20)
 			for range 5 {
 				updated, _ = m.Update(agentEventMsg{agent: "agent-a", ev: reviewtypes.AssistantText{Text: long}})
 				m = mustModel(t, updated)
 			}
-			// Enter detail mode (auto-tails to bottom), then jump to top so the
-			// scroll input has somewhere to advance into.
+			// Enter detail mode, then jump to top so the input can scroll down.
 			updated, _ = m.Update(testCtrlKey('o'))
 			m = mustModel(t, updated)
 			m.detail.GotoTop()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/458
<!-- entire-trail-link-end -->

## What

Applied the same redundant-test sweep to `cmd/entire/cli/review` (and `review/types`) as [#1301](https://github.com/entireio/cli/pull/1301) did for `strategy`. All 24 test files were analyzed; each candidate was verified against the actual code before any change. Only "exact same functionality" cases were acted on.

This branch also removes two pieces of dead production code found while investigating.

## Test consolidations

| File | Before → After | Action & why |
|------|----------------|--------------|
| `cmd_test.go` | `TestReviewFindings_NotGitRepoReturnsSilentError` + `TestReviewFix_NotGitRepoReturnsSilentError` → `TestReview_NotGitRepoReturnsSilentError` | Identical code path and assertions. The not-a-git-repo guard fires before any flag-specific logic, so `--findings` and `--fix` exercise the same branch. Merged into a table over the two arg sets. |
| `tui_model_test.go` | `TestTUIModel_DelegatesMouseWheelToViewport` + `TestTUIModel_DelegatesScrollKeysToViewport` → `TestTUIModel_DelegatesScrollInputToViewport` | Byte-identical setup (window size, 5× long `AssistantText`, Ctrl+O, `GotoTop`) and identical `YOffset > startOffset` assertion, differing only in the input message. Both kept as distinct rows (they guard separate mouse-vs-key dispatch arms), but the duplicated boilerplate is gone. |

## Dead code removal

Both confirmed unreachable from `main` via `golang.org/x/tools/cmd/deadcode`.

| Symbol | Why removed |
|--------|-------------|
| `IsReviewEnvEntry` (`env.go`) | Referenced nowhere — no production caller and no test. A thin wrapper over `provenance.IsReviewEntry` kept "for symmetry with investigate.IsInvestigateEnvEntry" that nothing ever called. |
| `SaveReviewConfig` (`picker.go`) | No production caller — the picker persists via the combined writer `saveReviewConfigAndFixAgent`. It survived only as a test fixture + 3 dedicated tests. Removed the function; deleted the 3 `TestSaveReviewConfig_*` tests (they tested dead code); migrated the ~16 setup-helper usages to a test-local `seedReviewConfig` helper that writes clone preferences directly (same load-merge-save behavior). `TestSaveReviewFixAgent_PersistsSettings` stays — it covers a live function. |

## Deliberately left alone

Structurally-similar tests that cover **genuinely different** behavior were **not** touched:

- `Run` vs `RunMulti` pairs (token tracking, enrich-summary-before-finished, cancellation, sink fan-out) — same behavior contract but distinct exported functions with separate accumulation loops.
- `explainEmptyManifest` family — each asserts a different reason string / filter branch.
- `Run_FailedRun` / `TornStreamCleanExit` / `FinishedFailureCleanExit` — three distinct failure causes classified as `Failed`.
- ANSI-stripping across dashboard vs detail render surfaces — different surfaces; the primitive is already unit-tested in `tui_text_test.go`.
- Zero-value / compile-time interface checks — deliberate per-type mirrors.

## Verification

- `go test ./cmd/entire/cli/review/... ./cmd/entire/cli/ ./cmd/entire/cli/investigate/` → `ok`
- `go build ./cmd/entire/...` → clean
- `deadcode ./cmd/entire/` → no dead review symbols remain
- `mise run lint` → `0 issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)