### PR TITLE
git-remote-entire: ship the remote helper in the CLI, on a shared contexts.json login

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,8 @@ before:
     - mise run completions
 
 builds:
-  - main: ./cmd/entire
+  - id: entire
+    main: ./cmd/entire
     binary: entire
     env:
       - CGO_ENABLED=0
@@ -25,6 +26,27 @@ builds:
       - -X github.com/entireio/cli/cmd/entire/cli/versioninfo.Commit={{.ShortCommit}}
       - -X github.com/entireio/cli/cmd/entire/cli/telemetry.PostHogAPIKey={{.Env.POSTHOG_API_KEY}}
       - -X github.com/entireio/cli/cmd/entire/cli/telemetry.PostHogEndpoint={{.Env.POSTHOG_ENDPOINT}}
+
+  # git-remote-entire is the git remote helper for entire:// URLs (see
+  # cmd/git-remote-entire). A small, dedicated binary shipped alongside
+  # entire so `git clone entire://…` resolves it on PATH — no telemetry,
+  # only the versioninfo stamp it needs for its git agent string.
+  - id: git-remote-entire
+    main: ./cmd/git-remote-entire
+    binary: git-remote-entire
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/entireio/cli/cmd/entire/cli/versioninfo.Version={{.Version}}
+      - -X github.com/entireio/cli/cmd/entire/cli/versioninfo.Commit={{.ShortCommit}}
 
 notarize:
   macos:
@@ -90,6 +112,7 @@ homebrew_casks:
     description: "CLI for Entire"
     binaries:
       - entire
+      - git-remote-entire
     generate_completions_from_executable:
       executable: entire
       shell_parameter_format: cobra
@@ -111,6 +134,7 @@ homebrew_casks:
     description: "CLI for Entire (nightly build)"
     binaries:
       - entire
+      - git-remote-entire
     generate_completions_from_executable:
       executable: entire
       shell_parameter_format: cobra

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -497,8 +497,8 @@ func newAuthRevokeCmd() *cobra.Command {
 				return err
 			}
 			return runAuthRevoke(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				auth.NewStore(), defaultListTokens, defaultRevokeTokenByID, defaultRevokeCurrentToken,
-				api.AuthBaseURL(), id, revokeCurrent)
+				auth.NewContextStore(), defaultListTokens, defaultRevokeTokenByID, defaultRevokeCurrentToken,
+				auth.RemoveCurrentContext, api.AuthBaseURL(), id, revokeCurrent)
 		},
 	}
 	cmd.Flags().BoolVar(&revokeCurrent, "current", false, "Revoke the token used by this CLI and remove the local copy")
@@ -521,6 +521,7 @@ func runAuthRevoke(
 	list authTokenLister,
 	revokeByID authTokenRevoker,
 	revokeCurrent revokeCurrentFunc,
+	clearContext clearContextFunc,
 	baseURL, id string,
 	current bool,
 ) error {
@@ -535,7 +536,7 @@ func runAuthRevoke(
 	if current {
 		// Revoking our own token is just logout — reuse that path so behavior
 		// stays identical (best-effort revoke + local delete + context clear).
-		return runLogout(ctx, outW, errW, store, revokeCurrent, auth.RemoveCurrentContext, baseURL)
+		return runLogout(ctx, outW, errW, store, revokeCurrent, clearContext, baseURL)
 	}
 
 	if err := revokeByID(ctx, id); err != nil {
@@ -543,11 +544,15 @@ func runAuthRevoke(
 	}
 
 	// The list endpoint requires bearer auth, so a 401 here means the id we
-	// just revoked was the same one this CLI is using — the keychain entry is
-	// now stale and would otherwise produce confusing 401s on every command.
+	// just revoked was the same one this CLI is using — the local copy is now
+	// stale and would otherwise produce confusing 401s on every command, so
+	// remove both the legacy keyring entry and the active context.
 	if _, listErr := list(ctx); listErr != nil && api.IsHTTPErrorStatus(listErr, http.StatusUnauthorized) {
 		if delErr := store.DeleteToken(baseURL); delErr != nil {
 			return fmt.Errorf("revoked token %s but failed to remove local copy: %w", id, delErr)
+		}
+		if ctxErr := clearContext(); ctxErr != nil {
+			fmt.Fprintf(errW, "Warning: revoked token %s but failed to clear current context: %v\n", id, ctxErr)
 		}
 		fmt.Fprintf(outW, "Revoked token %s (this was your local token; removed from keychain).\n", id)
 		return nil

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -152,6 +152,8 @@ func newAuthCmd() *cobra.Command {
 	cmd.AddCommand(newAuthStatusCmd())
 	cmd.AddCommand(newAuthListCmd())
 	cmd.AddCommand(newAuthRevokeCmd())
+	cmd.AddCommand(newAuthContextsCmd())
+	cmd.AddCommand(newAuthUseCmd())
 	return cmd
 }
 
@@ -167,7 +169,7 @@ func newAuthStatusCmd() *cobra.Command {
 				return err
 			}
 			return runAuthStatus(cmd.Context(), cmd.OutOrStdout(),
-				auth.NewStore(), defaultListTokens, api.AuthBaseURL())
+				auth.NewContextStore(), defaultListTokens, api.AuthBaseURL())
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
@@ -222,7 +224,7 @@ func newAuthListCmd() *cobra.Command {
 				return err
 			}
 			return runAuthList(cmd.Context(), cmd.OutOrStdout(),
-				auth.NewStore(), defaultListTokens, api.AuthBaseURL(), jsonOut)
+				auth.NewContextStore(), defaultListTokens, api.AuthBaseURL(), jsonOut)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Print tokens as JSON")
@@ -532,8 +534,8 @@ func runAuthRevoke(
 
 	if current {
 		// Revoking our own token is just logout — reuse that path so behavior
-		// stays identical (best-effort revoke + local delete).
-		return runLogout(ctx, outW, errW, store, revokeCurrent, baseURL)
+		// stays identical (best-effort revoke + local delete + context clear).
+		return runLogout(ctx, outW, errW, store, revokeCurrent, auth.RemoveCurrentContext, baseURL)
 	}
 
 	if err := revokeByID(ctx, id); err != nil {

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -1,0 +1,126 @@
+package auth
+
+import (
+	"fmt"
+
+	"github.com/entireio/auth-go/tokens"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+// CurrentContextToken returns the login JWT for the active context in
+// contexts.json, or ("", false) when there is no current context or it
+// has no stored token. This is the contexts.json half of the CLI's
+// credential resolution; callers fall back to the legacy keyring entry so
+// pre-contexts logins keep working until migrated.
+func CurrentContextToken() (string, bool) {
+	f, err := contexts.Load(contexts.DefaultConfigDir())
+	if err != nil {
+		return "", false
+	}
+	c := f.Find(f.CurrentContext)
+	if c == nil {
+		return "", false
+	}
+	tok, err := LoginTokenForContext(c)
+	if err != nil || tok == "" {
+		return "", false
+	}
+	return tok, true
+}
+
+// RemoveCurrentContext deletes the active context from contexts.json and
+// its keyring token, advancing current_context to whatever remains. It is
+// a no-op (returns nil) when there is no current context. Used by logout.
+func RemoveCurrentContext() error {
+	cfgDir := contexts.DefaultConfigDir()
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		return fmt.Errorf("load contexts: %w", err)
+	}
+	current := f.Find(f.CurrentContext)
+	if current == nil {
+		return nil
+	}
+	if current.KeychainService != "" && current.Handle != "" {
+		// Best-effort: a missing keyring entry is fine; the contexts.json
+		// removal below is what makes us "logged out".
+		_ = tokenstore.Delete(current.KeychainService, current.Handle) //nolint:errcheck // best-effort; contexts.json removal is the source of truth for logout
+	}
+	if err := contexts.Modify(cfgDir, func(f *contexts.File) (bool, error) {
+		if f.Find(current.Name) == nil {
+			return false, nil
+		}
+		f.Delete(current.Name)
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("remove context %q: %w", current.Name, err)
+	}
+	return nil
+}
+
+// SetCurrentContext makes name the active context. Returns an error when
+// no context with that name exists (a stale current pointer is a foot-gun).
+func SetCurrentContext(name string) error {
+	if err := contexts.Modify(contexts.DefaultConfigDir(), func(f *contexts.File) (bool, error) {
+		if f.Find(name) == nil {
+			return false, fmt.Errorf("no login context named %q (run `entire auth contexts` to list)", name)
+		}
+		if f.CurrentContext == name {
+			return false, nil
+		}
+		f.CurrentContext = name
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("set current context: %w", err)
+	}
+	return nil
+}
+
+// Contexts returns all stored login contexts and the current context name,
+// for listing/switching. Order matches on-disk order.
+func Contexts() (all []*contexts.Context, current string, err error) {
+	f, loadErr := contexts.Load(contexts.DefaultConfigDir())
+	if loadErr != nil {
+		return nil, "", fmt.Errorf("load contexts: %w", loadErr)
+	}
+	return f.Contexts, f.CurrentContext, nil
+}
+
+// ContextStore wraps the legacy keyring Store so token *reads* prefer the
+// active contexts.json context, falling back to the legacy
+// entire-cli/<authBaseURL> entry. Writes are inherited from Store
+// unchanged — login dual-writes the context via RecordLoginContext, so the
+// write side needs no override here.
+//
+// This is the single seam that lets the control-plane readers (the
+// tokenmanager, LookupCurrentToken, and `auth status`/`list`) honor a
+// contexts.json login — including one created by entiredb's CLIs that
+// share this file. *ContextStore satisfies both the cli package's
+// tokenStore interface and auth-go's tokenstore.Store.
+type ContextStore struct {
+	*Store
+}
+
+// NewContextStore returns a context-preferring view over the legacy store.
+func NewContextStore() *ContextStore {
+	return &ContextStore{Store: NewStore()}
+}
+
+// GetToken prefers the active context's token, falling back to the legacy
+// entry keyed by baseURL.
+func (s *ContextStore) GetToken(baseURL string) (string, error) {
+	if tok, ok := CurrentContextToken(); ok {
+		return tok, nil
+	}
+	return s.Store.GetToken(baseURL)
+}
+
+// LoadTokens (the tokenstore.Store method the tokenmanager calls) prefers
+// the active context's token, falling back to the legacy profile entry.
+func (s *ContextStore) LoadTokens(profile string) (tokens.TokenSet, error) {
+	if tok, ok := CurrentContextToken(); ok {
+		return tokens.TokenSet{AccessToken: tok}, nil
+	}
+	return s.Store.LoadTokens(profile)
+}

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -61,6 +61,33 @@ func RemoveCurrentContext() error {
 	return nil
 }
 
+// RemoveAllContexts deletes every stored context, its keyring token, and all
+// cluster bindings — a full local logout. Returns the number of contexts
+// removed. Best-effort on the keyring deletes; the contexts.json clear is
+// what makes the CLI fully logged out (no surviving binding can authenticate
+// a clone afterward).
+func RemoveAllContexts() (int, error) {
+	var removed int
+	if err := contexts.Modify(contexts.DefaultConfigDir(), func(f *contexts.File) (bool, error) {
+		if len(f.Contexts) == 0 && f.CurrentContext == "" && len(f.ClusterContexts) == 0 {
+			return false, nil
+		}
+		for _, c := range f.Contexts {
+			if c.KeychainService != "" && c.Handle != "" {
+				_ = tokenstore.Delete(c.KeychainService, c.Handle) //nolint:errcheck // best-effort; the contexts.json clear below is authoritative
+			}
+			removed++
+		}
+		f.Contexts = nil
+		f.CurrentContext = ""
+		f.ClusterContexts = nil
+		return true, nil
+	}); err != nil {
+		return 0, fmt.Errorf("remove all contexts: %w", err)
+	}
+	return removed, nil
+}
+
 // SetCurrentContext makes name the active context. Returns an error when
 // no context with that name exists (a stale current pointer is a foot-gun).
 func SetCurrentContext(name string) error {

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -33,28 +33,26 @@ func CurrentContextToken() (string, bool) {
 // its keyring token, advancing current_context to whatever remains. It is
 // a no-op (returns nil) when there is no current context. Used by logout.
 func RemoveCurrentContext() error {
-	cfgDir := contexts.DefaultConfigDir()
-	f, err := contexts.Load(cfgDir)
-	if err != nil {
-		return fmt.Errorf("load contexts: %w", err)
-	}
-	current := f.Find(f.CurrentContext)
-	if current == nil {
-		return nil
-	}
-	if current.KeychainService != "" && current.Handle != "" {
-		// Best-effort: a missing keyring entry is fine; the contexts.json
-		// removal below is what makes us "logged out".
-		_ = tokenstore.Delete(current.KeychainService, current.Handle) //nolint:errcheck // best-effort; contexts.json removal is the source of truth for logout
-	}
-	if err := contexts.Modify(cfgDir, func(f *contexts.File) (bool, error) {
-		if f.Find(current.Name) == nil {
+	// Read-modify-write in a single locked Modify so the context we delete
+	// is exactly the one we capture the keychain slot from (separate Load +
+	// Modify would race a concurrent `auth use`).
+	var svc, handle string
+	if err := contexts.Modify(contexts.DefaultConfigDir(), func(f *contexts.File) (bool, error) {
+		current := f.Find(f.CurrentContext)
+		if current == nil {
 			return false, nil
 		}
+		svc, handle = current.KeychainService, current.Handle
 		f.Delete(current.Name)
 		return true, nil
 	}); err != nil {
-		return fmt.Errorf("remove context %q: %w", current.Name, err)
+		return fmt.Errorf("remove current context: %w", err)
+	}
+	// Best-effort keychain cleanup, sequenced off the context just removed.
+	// A missing entry is fine — the contexts.json removal above is what makes
+	// us "logged out".
+	if svc != "" && handle != "" {
+		_ = tokenstore.Delete(svc, handle) //nolint:errcheck // best-effort; contexts.json removal is the source of truth for logout
 	}
 	return nil
 }
@@ -79,10 +77,10 @@ func SetCurrentContext(name string) error {
 
 // Contexts returns all stored login contexts and the current context name,
 // for listing/switching. Order matches on-disk order.
-func Contexts() (all []*contexts.Context, current string, err error) {
-	f, loadErr := contexts.Load(contexts.DefaultConfigDir())
-	if loadErr != nil {
-		return nil, "", fmt.Errorf("load contexts: %w", loadErr)
+func Contexts() ([]*contexts.Context, string, error) {
+	f, err := contexts.Load(contexts.DefaultConfigDir())
+	if err != nil {
+		return nil, "", fmt.Errorf("load contexts: %w", err)
 	}
 	return f.Contexts, f.CurrentContext, nil
 }

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -44,6 +44,10 @@ func RemoveCurrentContext() error {
 		}
 		svc, handle = current.KeychainService, current.Handle
 		f.Delete(current.Name)
+		// Delete advances current_context to a surviving context; for logout
+		// that would silently re-authenticate as another account. Leave no
+		// active context — logged out means logged out.
+		f.CurrentContext = ""
 		return true, nil
 	}); err != nil {
 		return fmt.Errorf("remove current context: %w", err)

--- a/cmd/entire/cli/auth/contexts.go
+++ b/cmd/entire/cli/auth/contexts.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/entireio/auth-go/tokens"
@@ -23,7 +24,17 @@ const defaultContextTokenTTL = time.Hour
 // shared contexts.json credential model: it derives the issuer (core
 // URL), handle, and expiry from the token's own claims, stores the token
 // in the OS keyring under the entire-core:<issuer> service scheme entiredb
-// uses, and writes (or updates) the matching context — making it current.
+// uses, and writes (or updates) the matching context.
+//
+// Contexts are keyed by identity (core URL + handle): re-logging into the
+// same identity updates its context in place, while a second identity on
+// the same core gets its own context (named handle@host) instead of
+// clobbering the first.
+//
+// activate controls current_context: login passes true (the just-completed
+// login becomes active, kubectl use-context style); read-time migration
+// passes false so it never silently switches the user's active account —
+// it still sets current_context when none exists yet.
 //
 // This is the contexts.json half of login's dual-write: the legacy
 // entire-cli/<authBaseURL> keyring entry is still written by the caller so
@@ -33,7 +44,7 @@ const defaultContextTokenTTL = time.Hour
 //
 // Returns the context name on success. Errors are returned (not swallowed)
 // so the caller can warn; login still succeeds on the legacy entry.
-func RecordLoginContext(rawToken string) (string, error) {
+func RecordLoginContext(rawToken string, activate bool) (string, error) {
 	claims, err := tokens.ParseClaims(rawToken)
 	if err != nil {
 		return "", fmt.Errorf("parse login token claims: %w", err)
@@ -64,25 +75,59 @@ func RecordLoginContext(rawToken string) (string, error) {
 		return "", fmt.Errorf("store login token in keyring: %w", err)
 	}
 
-	name := contextNameForCoreURL(coreURL)
+	var name string
 	cfgDir := contexts.DefaultConfigDir()
 	if modErr := contexts.Modify(cfgDir, func(f *contexts.File) (bool, error) {
+		name = pickContextName(f, coreURL, handle)
 		f.Upsert(&contexts.Context{
 			Name:            name,
 			CoreURL:         coreURL,
 			Handle:          handle,
 			KeychainService: keychainService,
 		})
-		// The just-completed login becomes the active context (kubectl
-		// use-context semantics). Upsert only sets current when empty, so
-		// set it explicitly to cover re-login into an existing context.
-		f.CurrentContext = name
+		if activate || f.CurrentContext == "" {
+			f.CurrentContext = name
+		}
 		return true, nil
 	}); modErr != nil {
-		return "", fmt.Errorf("write context %q: %w", name, modErr)
+		return "", fmt.Errorf("write context: %w", modErr)
 	}
 
 	return name, nil
+}
+
+// pickContextName chooses the contexts.json name for an (coreURL, handle)
+// identity within f. An existing context for the same identity keeps its
+// name (re-login updates in place). A fresh identity prefers the bare core
+// host; if a *different* identity already holds that name, it's qualified
+// with the handle (handle@host) so the two don't collide — and, in the
+// pathological case that's taken too, a numeric suffix guarantees
+// uniqueness.
+func pickContextName(f *contexts.File, coreURL, handle string) string {
+	for _, c := range f.Contexts {
+		if sameIssuer(c.CoreURL, coreURL) && c.Handle == handle {
+			return c.Name
+		}
+	}
+	host := contextNameForCoreURL(coreURL)
+	if f.Find(host) == nil {
+		return host
+	}
+	qualified := handle + "@" + host
+	if f.Find(qualified) == nil {
+		return qualified
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", qualified, i)
+		if f.Find(candidate) == nil {
+			return candidate
+		}
+	}
+}
+
+// sameIssuer compares two core URLs ignoring a trailing slash.
+func sameIssuer(a, b string) bool {
+	return strings.TrimRight(a, "/") == strings.TrimRight(b, "/")
 }
 
 // MigrateLegacyLoginContext bridges users who logged in before the
@@ -115,7 +160,10 @@ func MigrateLegacyLoginContext() (migrated bool, err error) {
 	if len(f.ContextsForIssuer(claims.Issuer)) > 0 {
 		return false, nil // already represented
 	}
-	if _, err := RecordLoginContext(legacy); err != nil {
+	// activate=false: migrating an old login (e.g. on first `git clone`) must
+	// not silently switch the user's active context. RecordLoginContext still
+	// sets current_context when none exists yet.
+	if _, err := RecordLoginContext(legacy, false); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/cmd/entire/cli/auth/contexts.go
+++ b/cmd/entire/cli/auth/contexts.go
@@ -1,0 +1,156 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/entireio/auth-go/tokens"
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+// defaultContextTokenTTL is the encoded keychain expiry used when a login
+// token carries no usable exp claim (e.g. an opaque, non-JWT bearer). The
+// server is the real authority on validity; this only governs when local
+// readers consider the token stale, and we hold no refresh token to act on
+// it, so a conservative non-zero value is enough to keep the entry usable.
+const defaultContextTokenTTL = time.Hour
+
+// RecordLoginContext records a freshly obtained login token in the
+// shared contexts.json credential model: it derives the issuer (core
+// URL), handle, and expiry from the token's own claims, stores the token
+// in the OS keyring under the entire-core:<issuer> service scheme entiredb
+// uses, and writes (or updates) the matching context — making it current.
+//
+// This is the contexts.json half of login's dual-write: the legacy
+// entire-cli/<authBaseURL> keyring entry is still written by the caller so
+// the control-plane readers keep working untouched during the transition.
+// A login recorded here is visible to entiredb's CLIs (and the in-CLI git
+// remote helper) because they share this file and keychain layout.
+//
+// Returns the context name on success. Errors are returned (not swallowed)
+// so the caller can warn; login still succeeds on the legacy entry.
+func RecordLoginContext(rawToken string) (string, error) {
+	claims, err := tokens.ParseClaims(rawToken)
+	if err != nil {
+		return "", fmt.Errorf("parse login token claims: %w", err)
+	}
+	coreURL := claims.Issuer
+	if coreURL == "" {
+		return "", errors.New("login token has no iss claim; cannot derive core URL for a context")
+	}
+	handle := claims.Handle
+	if handle == "" {
+		handle = claims.Subject
+	}
+	if handle == "" {
+		return "", errors.New("login token has no handle/sub claim; cannot key the keychain slot")
+	}
+
+	keychainService := tokenstore.CoreKeyringService(coreURL)
+
+	expiresIn := int64(defaultContextTokenTTL.Seconds())
+	if !claims.ExpiresAt.IsZero() {
+		if secs := int64(time.Until(claims.ExpiresAt).Seconds()); secs > 0 {
+			expiresIn = secs
+		}
+	}
+
+	encoded := tokenstore.EncodeTokenWithExpiration(rawToken, expiresIn)
+	if err := tokenstore.Set(keychainService, handle, encoded); err != nil {
+		return "", fmt.Errorf("store login token in keyring: %w", err)
+	}
+
+	name := contextNameForCoreURL(coreURL)
+	cfgDir := contexts.DefaultConfigDir()
+	if modErr := contexts.Modify(cfgDir, func(f *contexts.File) (bool, error) {
+		f.Upsert(&contexts.Context{
+			Name:            name,
+			CoreURL:         coreURL,
+			Handle:          handle,
+			KeychainService: keychainService,
+		})
+		// The just-completed login becomes the active context (kubectl
+		// use-context semantics). Upsert only sets current when empty, so
+		// set it explicitly to cover re-login into an existing context.
+		f.CurrentContext = name
+		return true, nil
+	}); modErr != nil {
+		return "", fmt.Errorf("write context %q: %w", name, modErr)
+	}
+
+	return name, nil
+}
+
+// MigrateLegacyLoginContext bridges users who logged in before the
+// contexts.json dual-write existed: if the legacy entire-cli/<authBaseURL>
+// keyring entry holds a usable JWT and no context yet covers its issuer,
+// it records an equivalent context (and keychain entry under the shared
+// scheme) so the git remote helper can authenticate without a re-login.
+//
+// Returns (true, nil) when it created a context. No-ops — returning
+// (false, nil) — when there's no legacy token, the token is opaque
+// (no derivable issuer), or a context for that issuer already exists.
+// Idempotent: safe to call on every helper invocation.
+func MigrateLegacyLoginContext() (migrated bool, err error) {
+	legacy, err := NewStore().GetToken(api.AuthBaseURL())
+	if err != nil {
+		return false, fmt.Errorf("read legacy login token: %w", err)
+	}
+	if legacy == "" {
+		return false, nil
+	}
+	claims, parseErr := tokens.ParseClaims(legacy)
+	if parseErr != nil || claims.Issuer == "" {
+		// Opaque/unsigned legacy token — can't derive a context from it.
+		return false, nil //nolint:nilerr // absence of a JWT issuer is not an error here
+	}
+	f, err := contexts.Load(contexts.DefaultConfigDir())
+	if err != nil {
+		return false, fmt.Errorf("load contexts: %w", err)
+	}
+	if len(f.ContextsForIssuer(claims.Issuer)) > 0 {
+		return false, nil // already represented
+	}
+	if _, err := RecordLoginContext(legacy); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// LoginTokenForContext returns the login JWT stored for c, read from the
+// OS keyring slot the context points at. The encoded expiry is stripped;
+// the server is the authority on validity and the device-flow login holds
+// no refresh token, so an expired token surfaces as a 401 the caller can
+// translate into a re-login hint.
+func LoginTokenForContext(c *contexts.Context) (string, error) {
+	if c == nil {
+		return "", errors.New("nil context")
+	}
+	if c.KeychainService == "" || c.Handle == "" {
+		return "", fmt.Errorf("context %q has no keychain slot", c.Name)
+	}
+	encoded, err := tokenstore.Get(c.KeychainService, c.Handle)
+	if err != nil {
+		return "", fmt.Errorf("read token for context %q: %w", c.Name, err)
+	}
+	if encoded == "" {
+		return "", fmt.Errorf("no token stored for context %q (run `entire login`)", c.Name)
+	}
+	token, _ := tokenstore.DecodeTokenWithExpiration(encoded)
+	return token, nil
+}
+
+// contextNameForCoreURL derives a stable, human-readable context name
+// from the issuer URL — its host, matching entiredb's default of naming a
+// context after the core it authenticates against. Falls back to the raw
+// URL when it can't be parsed.
+func contextNameForCoreURL(coreURL string) string {
+	if u, err := url.Parse(coreURL); err == nil && u.Host != "" {
+		return u.Host
+	}
+	return coreURL
+}

--- a/cmd/entire/cli/auth/contexts.go
+++ b/cmd/entire/cli/auth/contexts.go
@@ -153,12 +153,21 @@ func MigrateLegacyLoginContext() (migrated bool, err error) {
 		// Opaque/unsigned legacy token — can't derive a context from it.
 		return false, nil //nolint:nilerr // absence of a JWT issuer is not an error here
 	}
+	handle := claims.Handle
+	if handle == "" {
+		handle = claims.Subject
+	}
 	f, err := contexts.Load(contexts.DefaultConfigDir())
 	if err != nil {
 		return false, fmt.Errorf("load contexts: %w", err)
 	}
-	if len(f.ContextsForIssuer(claims.Issuer)) > 0 {
-		return false, nil // already represented
+	// Skip only when this exact identity is already represented. Keying on
+	// issuer alone would skip a legacy bob@core just because alice@core (e.g.
+	// from another CLI) already exists, leaving Bob without a context.
+	for _, c := range f.Contexts {
+		if sameIssuer(c.CoreURL, claims.Issuer) && c.Handle == handle {
+			return false, nil
+		}
 	}
 	// activate=false: migrating an old login (e.g. on first `git clone`) must
 	// not silently switch the user's active context. RecordLoginContext still

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -37,7 +37,7 @@ func TestRecordLoginContext_WritesContextAndToken(t *testing.T) {
 	exp := time.Now().Add(2 * time.Hour).Unix()
 	token := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":%q,"exp":%d}`, coreURL, handle, exp))
 
-	name, err := RecordLoginContext(token)
+	name, err := RecordLoginContext(token, true)
 	if err != nil {
 		t.Fatalf("RecordLoginContext: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestContextStore_PrefersCurrentContextThenLegacy(t *testing.T) {
 	// Record a context: its token now wins over the legacy entry.
 	exp := time.Now().Add(time.Hour).Unix()
 	ctxToken := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
-	if _, err := RecordLoginContext(ctxToken); err != nil {
+	if _, err := RecordLoginContext(ctxToken, true); err != nil {
 		t.Fatalf("RecordLoginContext: %v", err)
 	}
 	got, err := store.GetToken(api.AuthBaseURL())
@@ -196,7 +196,7 @@ func TestRemoveCurrentContext(t *testing.T) {
 
 	exp := time.Now().Add(time.Hour).Unix()
 	token := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
-	if _, err := RecordLoginContext(token); err != nil {
+	if _, err := RecordLoginContext(token, true); err != nil {
 		t.Fatalf("RecordLoginContext: %v", err)
 	}
 	if _, ok := CurrentContextToken(); !ok {
@@ -224,10 +224,10 @@ func TestSetCurrentContext(t *testing.T) {
 
 	// Two contexts from two cores; the second becomes current on login.
 	exp := time.Now().Add(time.Hour).Unix()
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp))); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
 		t.Fatalf("record a: %v", err)
 	}
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"alice","exp":%d}`, exp))); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
 		t.Fatalf("record b: %v", err)
 	}
 
@@ -260,12 +260,109 @@ func TestSetCurrentContext(t *testing.T) {
 	}
 }
 
+func TestRecordLoginContext_SameCoreDifferentHandlesCoexist(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	const coreURL = "https://core.example.com"
+	exp := time.Now().Add(time.Hour).Unix()
+
+	aliceName, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, exp)), true)
+	if err != nil {
+		t.Fatalf("record alice: %v", err)
+	}
+	bobName, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"bob","exp":%d}`, coreURL, exp)), true)
+	if err != nil {
+		t.Fatalf("record bob: %v", err)
+	}
+
+	// Two distinct contexts for the same core — bob must not clobber alice.
+	if aliceName == bobName {
+		t.Fatalf("both logins got the same context name %q", aliceName)
+	}
+	if aliceName != "core.example.com" {
+		t.Fatalf("first login name = %q, want bare host core.example.com", aliceName)
+	}
+	if bobName != "bob@core.example.com" {
+		t.Fatalf("second login name = %q, want bob@core.example.com", bobName)
+	}
+
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := f.ContextsForIssuer(coreURL); len(got) != 2 {
+		t.Fatalf("contexts for issuer = %d, want 2", len(got))
+	}
+	if a := f.Find(aliceName); a == nil || a.Handle != "alice" {
+		t.Fatalf("alice context lost or wrong handle: %+v", a)
+	}
+
+	// Re-login as alice updates her context in place (no third entry).
+	again, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, exp)), true)
+	if err != nil {
+		t.Fatalf("re-login alice: %v", err)
+	}
+	if again != aliceName {
+		t.Fatalf("re-login produced new name %q, want %q", again, aliceName)
+	}
+	reloaded, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(reloaded.Contexts) != 2 {
+		t.Fatalf("re-login created a duplicate; want 2 contexts")
+	}
+}
+
+func TestMigrateLegacyLoginContext_PreservesCurrentContext(t *testing.T) {
+	keyring.MockInit()
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+
+	// An existing, active context for one core.
+	active, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://active.example.com","handle":"alice","exp":%d}`, exp)), true)
+	if err != nil {
+		t.Fatalf("seed active context: %v", err)
+	}
+
+	// A legacy keyring login for a *different* core, not yet migrated.
+	legacy := makeJWT(t, fmt.Sprintf(`{"iss":"https://legacy.example.com","handle":"alice","exp":%d}`, exp))
+	if err := NewStore().SaveToken(api.AuthBaseURL(), legacy); err != nil {
+		t.Fatalf("seed legacy token: %v", err)
+	}
+
+	migrated, err := MigrateLegacyLoginContext()
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration to run")
+	}
+
+	// Migration recorded the legacy context but must NOT have switched away
+	// from the already-active one.
+	_, current, err := Contexts()
+	if err != nil {
+		t.Fatalf("Contexts: %v", err)
+	}
+	if current != active {
+		t.Fatalf("current_context = %q, want unchanged %q after migration", current, active)
+	}
+}
+
 func TestRecordLoginContext_RejectsTokenWithoutIssuer(t *testing.T) {
 	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
 	t.Cleanup(restore)
 
 	token := makeJWT(t, `{"handle":"alice"}`)
-	if _, err := RecordLoginContext(token); err == nil {
+	if _, err := RecordLoginContext(token, true); err == nil {
 		t.Fatal("expected error for token without iss claim, got nil")
 	}
 }

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -216,6 +216,49 @@ func TestRemoveCurrentContext(t *testing.T) {
 	}
 }
 
+func TestRemoveAllContexts(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+	a, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), true)
+	if err != nil {
+		t.Fatalf("record a: %v", err)
+	}
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"bob","exp":%d}`, exp)), true); err != nil {
+		t.Fatalf("record b: %v", err)
+	}
+	if err := contexts.BindCluster(cfgDir, "cluster.example.com", a); err != nil {
+		t.Fatalf("bind cluster: %v", err)
+	}
+
+	n, err := RemoveAllContexts()
+	if err != nil {
+		t.Fatalf("RemoveAllContexts: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("removed %d, want 2", n)
+	}
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(f.Contexts) != 0 || f.CurrentContext != "" || len(f.ClusterContexts) != 0 {
+		t.Fatalf("expected fully cleared, got contexts=%d current=%q bindings=%d", len(f.Contexts), f.CurrentContext, len(f.ClusterContexts))
+	}
+
+	// Idempotent.
+	n2, err := RemoveAllContexts()
+	if err != nil {
+		t.Fatalf("second RemoveAllContexts: %v", err)
+	}
+	if n2 != 0 {
+		t.Fatalf("second call removed %d, want 0", n2)
+	}
+}
+
 func TestRemoveCurrentContext_DoesNotSwitchToAnother(t *testing.T) {
 	cfgDir := t.TempDir()
 	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -152,6 +152,114 @@ func TestLoginTokenForContext(t *testing.T) {
 	}
 }
 
+func TestContextStore_PrefersCurrentContextThenLegacy(t *testing.T) {
+	keyring.MockInit()
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	store := NewContextStore()
+
+	// No context yet: falls back to the legacy entry.
+	if err := store.SaveToken(api.AuthBaseURL(), "legacy-token"); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+	legacyGot, err := store.GetToken(api.AuthBaseURL())
+	if err != nil {
+		t.Fatalf("GetToken (legacy): %v", err)
+	}
+	if legacyGot != "legacy-token" {
+		t.Fatalf("with no context, GetToken = %q, want legacy-token", legacyGot)
+	}
+
+	// Record a context: its token now wins over the legacy entry.
+	exp := time.Now().Add(time.Hour).Unix()
+	ctxToken := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
+	if _, err := RecordLoginContext(ctxToken); err != nil {
+		t.Fatalf("RecordLoginContext: %v", err)
+	}
+	got, err := store.GetToken(api.AuthBaseURL())
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if got != ctxToken {
+		t.Fatal("with a current context, GetToken should return the context token")
+	}
+}
+
+func TestRemoveCurrentContext(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+	token := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
+	if _, err := RecordLoginContext(token); err != nil {
+		t.Fatalf("RecordLoginContext: %v", err)
+	}
+	if _, ok := CurrentContextToken(); !ok {
+		t.Fatal("precondition: expected a current context token")
+	}
+
+	if err := RemoveCurrentContext(); err != nil {
+		t.Fatalf("RemoveCurrentContext: %v", err)
+	}
+	if _, ok := CurrentContextToken(); ok {
+		t.Fatal("after RemoveCurrentContext, expected no current context token")
+	}
+
+	// Idempotent: a second call with nothing current is a no-op.
+	if err := RemoveCurrentContext(); err != nil {
+		t.Fatalf("second RemoveCurrentContext: %v", err)
+	}
+}
+
+func TestSetCurrentContext(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	// Two contexts from two cores; the second becomes current on login.
+	exp := time.Now().Add(time.Hour).Unix()
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp))); err != nil {
+		t.Fatalf("record a: %v", err)
+	}
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"alice","exp":%d}`, exp))); err != nil {
+		t.Fatalf("record b: %v", err)
+	}
+
+	all, current, err := Contexts()
+	if err != nil {
+		t.Fatalf("Contexts: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("got %d contexts, want 2", len(all))
+	}
+	if current != "b.example.com" {
+		t.Fatalf("current = %q, want b.example.com (most recent login)", current)
+	}
+
+	// Switch back to the first.
+	if err := SetCurrentContext("a.example.com"); err != nil {
+		t.Fatalf("SetCurrentContext: %v", err)
+	}
+	_, current, err = Contexts()
+	if err != nil {
+		t.Fatalf("Contexts after switch: %v", err)
+	}
+	if current != "a.example.com" {
+		t.Fatalf("after switch, current = %q, want a.example.com", current)
+	}
+
+	// Unknown context errors.
+	if err := SetCurrentContext("nope"); err == nil {
+		t.Fatal("expected error switching to unknown context")
+	}
+}
+
 func TestRecordLoginContext_RejectsTokenWithoutIssuer(t *testing.T) {
 	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
 	t.Cleanup(restore)

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -216,6 +216,41 @@ func TestRemoveCurrentContext(t *testing.T) {
 	}
 }
 
+func TestRemoveCurrentContext_DoesNotSwitchToAnother(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
+		t.Fatalf("record a: %v", err)
+	}
+	active, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"alice","exp":%d}`, exp)), true)
+	if err != nil {
+		t.Fatalf("record b: %v", err)
+	}
+
+	// Logging out of the active context must NOT silently switch to the
+	// surviving one — current_context is cleared.
+	if err := RemoveCurrentContext(); err != nil {
+		t.Fatalf("RemoveCurrentContext: %v", err)
+	}
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if f.CurrentContext != "" {
+		t.Fatalf("current_context = %q after logout, want empty (not switched)", f.CurrentContext)
+	}
+	if f.Find(active) != nil {
+		t.Fatalf("active context %q should have been removed", active)
+	}
+	if len(f.Contexts) != 1 {
+		t.Fatalf("want the other context to survive; got %d contexts", len(f.Contexts))
+	}
+}
+
 func TestSetCurrentContext(t *testing.T) {
 	cfgDir := t.TempDir()
 	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -357,6 +357,45 @@ func TestMigrateLegacyLoginContext_PreservesCurrentContext(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacyLoginContext_DifferentHandleSameCore(t *testing.T) {
+	keyring.MockInit()
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	const coreURL = "https://core.example.com"
+	exp := time.Now().Add(time.Hour).Unix()
+
+	// contexts.json already has alice@core (e.g. from another CLI).
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, exp)), true); err != nil {
+		t.Fatalf("seed alice: %v", err)
+	}
+
+	// The legacy keyring token is bob on the *same* core — migration must
+	// still run (issuer-only dedup would wrongly skip it).
+	bob := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"bob","exp":%d}`, coreURL, exp))
+	if err := NewStore().SaveToken(api.AuthBaseURL(), bob); err != nil {
+		t.Fatalf("seed legacy bob: %v", err)
+	}
+
+	migrated, err := MigrateLegacyLoginContext()
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected bob to be migrated despite alice@core existing")
+	}
+
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := f.ContextsForIssuer(coreURL); len(got) != 2 {
+		t.Fatalf("contexts for issuer = %d, want 2 (alice + bob)", len(got))
+	}
+}
+
 func TestRecordLoginContext_RejectsTokenWithoutIssuer(t *testing.T) {
 	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
 	t.Cleanup(restore)

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -1,0 +1,163 @@
+package auth
+
+import (
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+	"github.com/zalando/go-keyring"
+)
+
+// makeJWT builds a three-segment JWT-shaped string with a non-"none" alg
+// (so ParseClaims accepts it) and the given payload. The signature segment
+// is arbitrary — claims are parsed unverified.
+func makeJWT(t *testing.T, payloadJSON string) string {
+	t.Helper()
+	enc := base64.RawURLEncoding
+	header := enc.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := enc.EncodeToString([]byte(payloadJSON))
+	return header + "." + payload + "." + enc.EncodeToString([]byte("sig"))
+}
+
+func TestRecordLoginContext_WritesContextAndToken(t *testing.T) {
+	// Sets ENTIRE_CONFIG_DIR and swaps the keyring backend — process-global
+	// state, so this test cannot run in parallel.
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	const coreURL = "https://core.example.com"
+	const handle = "alice"
+	exp := time.Now().Add(2 * time.Hour).Unix()
+	token := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":%q,"exp":%d}`, coreURL, handle, exp))
+
+	name, err := RecordLoginContext(token)
+	if err != nil {
+		t.Fatalf("RecordLoginContext: %v", err)
+	}
+	if name != "core.example.com" {
+		t.Fatalf("context name = %q, want core.example.com", name)
+	}
+
+	// Context recorded and made current.
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load contexts: %v", err)
+	}
+	if f.CurrentContext != name {
+		t.Fatalf("current_context = %q, want %q", f.CurrentContext, name)
+	}
+	c := f.Find(name)
+	if c == nil {
+		t.Fatalf("context %q not found", name)
+	}
+	if c.CoreURL != coreURL || c.Handle != handle {
+		t.Fatalf("context = {CoreURL:%q Handle:%q}, want {%q %q}", c.CoreURL, c.Handle, coreURL, handle)
+	}
+	wantService := tokenstore.CoreKeyringService(coreURL)
+	if c.KeychainService != wantService {
+		t.Fatalf("KeychainService = %q, want %q", c.KeychainService, wantService)
+	}
+
+	// Token stored at the context's keychain slot, decodable with a
+	// future expiry.
+	encoded, err := tokenstore.Get(wantService, handle)
+	if err != nil {
+		t.Fatalf("get token: %v", err)
+	}
+	gotToken, expiresAt := tokenstore.DecodeTokenWithExpiration(encoded)
+	if gotToken != token {
+		t.Fatalf("stored token mismatch")
+	}
+	if !expiresAt.After(time.Now()) {
+		t.Fatalf("stored expiry %s is not in the future", expiresAt)
+	}
+}
+
+func TestMigrateLegacyLoginContext_SynthesizesContext(t *testing.T) {
+	// Mocks the legacy keyring + swaps the new tokenstore + sets the config
+	// dir — all process-global, so not parallel.
+	keyring.MockInit()
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	const coreURL = "https://legacy-core.example.com"
+	const handle = "bob"
+	exp := time.Now().Add(time.Hour).Unix()
+	legacy := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":%q,"exp":%d}`, coreURL, handle, exp))
+
+	// Seed only the legacy single-host keyring entry.
+	if err := NewStore().SaveToken(api.AuthBaseURL(), legacy); err != nil {
+		t.Fatalf("seed legacy token: %v", err)
+	}
+
+	migrated, err := MigrateLegacyLoginContext()
+	if err != nil {
+		t.Fatalf("MigrateLegacyLoginContext: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migration to synthesize a context")
+	}
+
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("load contexts: %v", err)
+	}
+	if got := f.ContextsForIssuer(coreURL); len(got) != 1 {
+		t.Fatalf("contexts for issuer = %d, want 1", len(got))
+	}
+
+	// Idempotent: a second call is a no-op now that a context exists.
+	migratedAgain, err := MigrateLegacyLoginContext()
+	if err != nil {
+		t.Fatalf("second MigrateLegacyLoginContext: %v", err)
+	}
+	if migratedAgain {
+		t.Fatal("second migration should be a no-op")
+	}
+}
+
+func TestLoginTokenForContext(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	c := &contexts.Context{
+		Name:            "core.example.com",
+		CoreURL:         "https://core.example.com",
+		Handle:          "carol",
+		KeychainService: tokenstore.CoreKeyringService("https://core.example.com"),
+	}
+	if err := tokenstore.Set(c.KeychainService, c.Handle, tokenstore.EncodeTokenWithExpiration("the-jwt", 3600)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	got, err := LoginTokenForContext(c)
+	if err != nil {
+		t.Fatalf("LoginTokenForContext: %v", err)
+	}
+	if got != "the-jwt" {
+		t.Fatalf("token = %q, want the-jwt", got)
+	}
+
+	if _, err := LoginTokenForContext(nil); err == nil {
+		t.Fatal("expected error for nil context")
+	}
+}
+
+func TestRecordLoginContext_RejectsTokenWithoutIssuer(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	token := makeJWT(t, `{"handle":"alice"}`)
+	if _, err := RecordLoginContext(token); err == nil {
+		t.Fatal("expected error for token without iss claim, got nil")
+	}
+}

--- a/cmd/entire/cli/auth/exchange.go
+++ b/cmd/entire/cli/auth/exchange.go
@@ -86,10 +86,13 @@ func defaultManager() (*tokenmanager.Manager, error) {
 		provider := CurrentProvider()
 		issuer := api.AuthBaseURL()
 		m, err := tokenmanager.New(tokenmanager.Config{
-			Issuer:    issuer,
-			ClientID:  provider.ClientID,
-			STSPath:   provider.STSPath,
-			Store:     NewStore(),
+			Issuer:   issuer,
+			ClientID: provider.ClientID,
+			STSPath:  provider.STSPath,
+			// Context-preferring store: the manager reads the active
+			// contexts.json login (falling back to the legacy entry) so a
+			// single login authenticates every control-plane command.
+			Store:     NewContextStore(),
 			UserAgent: provider.ClientID,
 			Scope:     "cli",
 			// Auto-permit loopback http:// for local development. The

--- a/cmd/entire/cli/auth/store.go
+++ b/cmd/entire/cli/auth/store.go
@@ -149,13 +149,12 @@ func (s *Store) DeleteTokens(profile string) error {
 	return s.backend.delete(s.service, profile)
 }
 
-// LookupCurrentToken retrieves the token for the current auth base URL.
-// Tokens are keyed by the auth issuer (api.AuthBaseURL()) since that's the
-// host that minted them; AuthBaseURL defaults to DefaultAuthBaseURL when
-// the env override is unset, so a fresh install reads the production
-// us.auth.entire.io entry.
+// LookupCurrentToken retrieves the active login token. It prefers the
+// current contexts.json context (so a login from this or entiredb's CLIs
+// authenticates control-plane commands), falling back to the legacy entry
+// keyed by the auth issuer (api.AuthBaseURL()) for pre-contexts logins.
 func LookupCurrentToken() (string, error) {
-	return NewStore().GetToken(api.AuthBaseURL())
+	return NewContextStore().GetToken(api.AuthBaseURL())
 }
 
 type keyringBackend struct{}

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/spf13/cobra"
+)
+
+// newAuthUseCmd switches the active login context — the one the
+// control-plane commands authenticate as. Clones resolve their context
+// per cluster, so this primarily affects org/project/repo operations.
+func newAuthUseCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <context>",
+		Short: "Switch the active login context",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := auth.SetCurrentContext(args[0]); err != nil {
+				return err //nolint:wrapcheck // already a user-facing message
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Now using context %q.\n", args[0])
+			return nil
+		},
+	}
+}
+
+// newAuthContextsCmd lists the stored login contexts and marks the active
+// one. Purely local — it reads contexts.json, no network.
+func newAuthContextsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "contexts",
+		Short: "List stored login contexts",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAuthContexts(cmd.OutOrStdout())
+		},
+	}
+}
+
+func runAuthContexts(w io.Writer) error {
+	all, current, err := auth.Contexts()
+	if err != nil {
+		return err //nolint:wrapcheck // already a user-facing message
+	}
+	if len(all) == 0 {
+		fmt.Fprintln(w, "No login contexts. Run 'entire login' to authenticate.")
+		return nil
+	}
+	for _, c := range all {
+		marker := " "
+		if c.Name == current {
+			marker = "*"
+		}
+		fmt.Fprintf(w, "%s %s\t%s\t%s\n", marker, c.Name, c.Handle, c.CoreURL)
+	}
+	return nil
+}

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -11,12 +11,14 @@ import (
 
 // newAuthUseCmd switches the active login context.
 //
-// The active context determines which login `git clone entire://…` prefers
-// when a cluster has several. Control-plane commands (auth status/list/
-// revoke, org/project/repo/grant) currently target the configured auth host
-// (ENTIRE_AUTH_BASE_URL / the default) regardless of the active context's
-// core, so switching to a context on a *different* core does not yet
-// retarget them — auth use warns when that's the case.
+// For `git clone entire://…` the active context is only a fallback: a
+// cluster already bound to a context (cluster_contexts) keeps using that
+// binding, and the active context is consulted only the first time a
+// not-yet-bound cluster is resolved. Control-plane commands (auth status/
+// list/revoke, org/project/repo/grant) currently target the configured auth
+// host (ENTIRE_AUTH_BASE_URL / the default) regardless of the active
+// context's core, so switching to a context on a *different* core does not
+// yet retarget them — auth use warns when that's the case.
 func newAuthUseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "use <context>",
@@ -53,8 +55,8 @@ func warnIfCrossCoreContext(errW io.Writer, name string) {
 			return
 		}
 		fmt.Fprintf(errW,
-			"Note: %q authenticates against %s, but control-plane commands still target %s.\n"+
-				"Cross-core control-plane switching isn't supported yet; `git clone entire://…` uses this context regardless.\n",
+			"Note: %q authenticates against %s, but control-plane commands still target %s — cross-core control-plane switching isn't supported yet.\n"+
+				"For `git clone entire://…`, a cluster already bound to another context keeps using it; the active context applies only to clusters not yet bound.\n",
 			name, c.CoreURL, authHost)
 		return
 	}

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -23,7 +23,14 @@ func newAuthUseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "use <context>",
 		Short: "Switch the active login context",
-		Args:  cobra.ExactArgs(1),
+		Long: "Switch the active login context.\n\n" +
+			"For `git clone entire://…` the active context is only a fallback: a cluster\n" +
+			"already bound to a context keeps using that binding, so switching here affects\n" +
+			"only clusters not yet bound (and same-core tie-breaking on first resolve).\n\n" +
+			"Control-plane commands (auth status/list/revoke, org/project/repo/grant) still\n" +
+			"target the configured auth host (ENTIRE_AUTH_BASE_URL / the default), so\n" +
+			"switching to a context on a different core does not retarget them yet.",
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := auth.SetCurrentContext(args[0]); err != nil {
 				return err //nolint:wrapcheck // already a user-facing message

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -4,13 +4,19 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/spf13/cobra"
 )
 
-// newAuthUseCmd switches the active login context — the one the
-// control-plane commands authenticate as. Clones resolve their context
-// per cluster, so this primarily affects org/project/repo operations.
+// newAuthUseCmd switches the active login context.
+//
+// The active context determines which login `git clone entire://…` prefers
+// when a cluster has several. Control-plane commands (auth status/list/
+// revoke, org/project/repo/grant) currently target the configured auth host
+// (ENTIRE_AUTH_BASE_URL / the default) regardless of the active context's
+// core, so switching to a context on a *different* core does not yet
+// retarget them — auth use warns when that's the case.
 func newAuthUseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "use <context>",
@@ -21,8 +27,36 @@ func newAuthUseCmd() *cobra.Command {
 				return err //nolint:wrapcheck // already a user-facing message
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Now using context %q.\n", args[0])
+			warnIfCrossCoreContext(cmd.ErrOrStderr(), args[0])
 			return nil
 		},
+	}
+}
+
+// warnIfCrossCoreContext warns when the now-active context authenticates
+// against a different core than the control plane targets. Clone resolves
+// per-cluster and is unaffected, but auth status/list/revoke and the
+// org/project/repo/grant commands still hit the configured auth host —
+// switching cores there isn't wired up yet, so flag it rather than
+// silently authenticate against the wrong host.
+func warnIfCrossCoreContext(errW io.Writer, name string) {
+	all, _, err := auth.Contexts()
+	if err != nil {
+		return
+	}
+	authHost := api.AuthBaseURL()
+	for _, c := range all {
+		if c.Name != name {
+			continue
+		}
+		if c.CoreURL == "" || api.OriginOnly(c.CoreURL) == api.OriginOnly(authHost) {
+			return
+		}
+		fmt.Fprintf(errW,
+			"Note: %q authenticates against %s, but control-plane commands still target %s.\n"+
+				"Cross-core control-plane switching isn't supported yet; `git clone entire://…` uses this context regardless.\n",
+			name, c.CoreURL, authHost)
+		return
 	}
 }
 

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -38,7 +38,7 @@ func TestRunAuthContexts(t *testing.T) {
 
 	exp := time.Now().Add(time.Hour).Unix()
 	token := makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
-	if _, err := auth.RecordLoginContext(token); err != nil {
+	if _, err := auth.RecordLoginContext(token, true); err != nil {
 		t.Fatalf("RecordLoginContext: %v", err)
 	}
 

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -86,3 +86,28 @@ func TestWarnIfCrossCoreContext(t *testing.T) {
 		t.Fatalf("cross-core context should warn, got: %q", diff.String())
 	}
 }
+
+func TestNoteRemainingLogins(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	// No contexts: silent.
+	var empty bytes.Buffer
+	noteRemainingLogins(&empty)
+	if empty.Len() != 0 {
+		t.Fatalf("no remaining contexts should be silent, got %q", empty.String())
+	}
+
+	// A surviving context: names it and points at --all.
+	exp := time.Now().Add(time.Hour).Unix()
+	if _, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	var buf bytes.Buffer
+	noteRemainingLogins(&buf)
+	if !strings.Contains(buf.String(), "core.example.com") || !strings.Contains(buf.String(), "--all") {
+		t.Fatalf("expected note naming the context and --all, got %q", buf.String())
+	}
+}

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+// makeContextJWT builds a JWT-shaped token (non-"none" alg) carrying the
+// given claims, which is all RecordLoginContext needs.
+func makeContextJWT(t *testing.T, payloadJSON string) string {
+	t.Helper()
+	enc := base64.RawURLEncoding
+	header := enc.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	return header + "." + enc.EncodeToString([]byte(payloadJSON)) + "." + enc.EncodeToString([]byte("sig"))
+}
+
+func TestRunAuthContexts(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	var empty bytes.Buffer
+	if err := runAuthContexts(&empty); err != nil {
+		t.Fatalf("runAuthContexts (empty): %v", err)
+	}
+	if !strings.Contains(empty.String(), "No login contexts") {
+		t.Fatalf("empty listing = %q, want a 'No login contexts' hint", empty.String())
+	}
+
+	exp := time.Now().Add(time.Hour).Unix()
+	token := makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
+	if _, err := auth.RecordLoginContext(token); err != nil {
+		t.Fatalf("RecordLoginContext: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runAuthContexts(&out); err != nil {
+		t.Fatalf("runAuthContexts: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "* core.example.com") {
+		t.Fatalf("listing = %q, want current-marked core.example.com", got)
+	}
+	if !strings.Contains(got, "alice") {
+		t.Fatalf("listing = %q, want handle alice", got)
+	}
+}

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -54,3 +54,35 @@ func TestRunAuthContexts(t *testing.T) {
 		t.Fatalf("listing = %q, want handle alice", got)
 	}
 }
+
+func TestWarnIfCrossCoreContext(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	t.Setenv("ENTIRE_AUTH_BASE_URL", "https://auth.example.com")
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+
+	// Same core as the configured auth host: no warning.
+	sameName, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://auth.example.com","handle":"alice","exp":%d}`, exp)), true)
+	if err != nil {
+		t.Fatalf("record same-core: %v", err)
+	}
+	var same bytes.Buffer
+	warnIfCrossCoreContext(&same, sameName)
+	if same.Len() != 0 {
+		t.Fatalf("same-core context should not warn, got: %q", same.String())
+	}
+
+	// Different core: warns that the control plane won't follow.
+	otherName, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://other.example.com","handle":"alice","exp":%d}`, exp)), true)
+	if err != nil {
+		t.Fatalf("record cross-core: %v", err)
+	}
+	var diff bytes.Buffer
+	warnIfCrossCoreContext(&diff, otherName)
+	if !strings.Contains(diff.String(), "other.example.com") || !strings.Contains(diff.String(), "control-plane") {
+		t.Fatalf("cross-core context should warn, got: %q", diff.String())
+	}
+}

--- a/cmd/entire/cli/auth_test.go
+++ b/cmd/entire/cli/auth_test.go
@@ -400,7 +400,7 @@ func TestRunAuthRevoke_ByIDCallsRevoker(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	err := runAuthRevoke(context.Background(), &out, &errOut, store,
-		list, revokeByID, revokeCurrent, testBaseURL, testTokenID, false)
+		list, revokeByID, revokeCurrent, func() error { return nil }, testBaseURL, testTokenID, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -438,7 +438,7 @@ func TestRunAuthRevoke_ByIDSelfRevokeCleansLocal(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	err := runAuthRevoke(context.Background(), &out, &errOut, store,
-		list, revokeByID, revokeCurrent, testBaseURL, testTokenID, false)
+		list, revokeByID, revokeCurrent, func() error { return nil }, testBaseURL, testTokenID, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -473,7 +473,7 @@ func TestRunAuthRevoke_CurrentDelegatesToLogout(t *testing.T) {
 
 	var out, errOut bytes.Buffer
 	err := runAuthRevoke(context.Background(), &out, &errOut, store,
-		list, revokeByID, revokeCurrent, testBaseURL, "", true)
+		list, revokeByID, revokeCurrent, func() error { return nil }, testBaseURL, "", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -502,6 +502,7 @@ func TestRunAuthRevoke_NotLoggedInErrors(t *testing.T) {
 		func(context.Context) ([]api.Token, error) { return nil, nil },
 		func(context.Context, string) error { return nil },
 		func(context.Context) error { return nil },
+		func() error { return nil },
 		testBaseURL, "some-id", false)
 	if err == nil {
 		t.Fatal("expected error when not logged in")

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -123,7 +123,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	// entitled cluster from this login. Best-effort: the legacy entry
 	// above remains the control-plane source of truth, so a failure here
 	// must not fail the login — warn and continue.
-	if _, err := auth.RecordLoginContext(token); err != nil {
+	if _, err := auth.RecordLoginContext(token, true); err != nil {
 		fmt.Fprintf(errW, "Warning: logged in, but could not record a shareable context (clone via entire:// may need a re-login): %v\n", err)
 	}
 

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -118,6 +118,15 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		return fmt.Errorf("save auth token: %w", err)
 	}
 
+	// Dual-write the shared contexts.json credential model so the git
+	// remote helper (and entiredb's CLIs) can authenticate against any
+	// entitled cluster from this login. Best-effort: the legacy entry
+	// above remains the control-plane source of truth, so a failure here
+	// must not fail the login — warn and continue.
+	if _, err := auth.RecordLoginContext(token); err != nil {
+		fmt.Fprintf(errW, "Warning: logged in, but could not record a shareable context (clone via entire:// may need a re-login): %v\n", err)
+	}
+
 	fmt.Fprintln(outW, "Login complete.")
 	return nil
 }

--- a/cmd/entire/cli/logout.go
+++ b/cmd/entire/cli/logout.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
@@ -33,19 +34,54 @@ type clearContextFunc func() error
 
 func newLogoutCmd() *cobra.Command {
 	var insecureHTTPAuth bool
+	var all bool
 	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Log out of Entire",
+		Long: "Log out of Entire.\n\n" +
+			"By default this removes the active login only. Other saved logins (contexts)\n" +
+			"remain and can still authenticate `git clone entire://…` against clusters they\n" +
+			"are bound to. Use --all to remove every saved login and its cluster bindings.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := requireSecureBaseURL(insecureHTTPAuth); err != nil {
 				return err
 			}
-			return runLogout(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				auth.NewContextStore(), defaultRevokeCurrentToken, auth.RemoveCurrentContext, api.AuthBaseURL())
+			outW, errW := cmd.OutOrStdout(), cmd.ErrOrStderr()
+			clearFn := auth.RemoveCurrentContext
+			if all {
+				clearFn = func() error { _, err := auth.RemoveAllContexts(); return err } //nolint:wrapcheck // RemoveAllContexts already returns a contextual error
+			}
+			if err := runLogout(cmd.Context(), outW, errW,
+				auth.NewContextStore(), defaultRevokeCurrentToken, clearFn, api.AuthBaseURL()); err != nil {
+				return err
+			}
+			if !all {
+				noteRemainingLogins(errW)
+			}
+			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&all, "all", false, "Remove all saved logins (contexts) and their cluster bindings, not just the active one")
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
 	return cmd
+}
+
+// noteRemainingLogins warns when other saved contexts survive a default
+// logout — they can still authenticate clone/push against clusters bound to
+// them, so "Logged out." alone would overstate the result.
+func noteRemainingLogins(errW io.Writer) {
+	all, _, err := auth.Contexts()
+	if err != nil || len(all) == 0 {
+		return
+	}
+	names := make([]string, 0, len(all))
+	for _, c := range all {
+		names = append(names, c.Name)
+	}
+	fmt.Fprintf(errW,
+		"Note: %d other saved login(s) remain and can still authenticate clones: %s\n"+
+			"Run `entire logout --all` to remove them, or `entire auth use <context>` to switch.\n",
+		len(all), strings.Join(names, ", "))
 }
 
 func defaultRevokeCurrentToken(ctx context.Context) error {

--- a/cmd/entire/cli/logout.go
+++ b/cmd/entire/cli/logout.go
@@ -25,6 +25,12 @@ type tokenStore interface {
 // entry through.
 type revokeCurrentFunc func(ctx context.Context) error
 
+// clearContextFunc removes the active contexts.json context (and its
+// keyring token) so logout actually logs out under the contexts model.
+// Injected so logout stays unit-testable without touching the real
+// config dir.
+type clearContextFunc func() error
+
 func newLogoutCmd() *cobra.Command {
 	var insecureHTTPAuth bool
 	cmd := &cobra.Command{
@@ -35,7 +41,7 @@ func newLogoutCmd() *cobra.Command {
 				return err
 			}
 			return runLogout(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				auth.NewStore(), defaultRevokeCurrentToken, api.AuthBaseURL())
+				auth.NewContextStore(), defaultRevokeCurrentToken, auth.RemoveCurrentContext, api.AuthBaseURL())
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
@@ -50,7 +56,7 @@ func defaultRevokeCurrentToken(ctx context.Context) error {
 	return newAPITokensClient(token).RevokeCurrentToken(ctx) //nolint:wrapcheck // RevokeCurrentToken already wraps with action context
 }
 
-func runLogout(ctx context.Context, outW, errW io.Writer, store tokenStore, revoke revokeCurrentFunc, baseURL string) error {
+func runLogout(ctx context.Context, outW, errW io.Writer, store tokenStore, revoke revokeCurrentFunc, clearContext clearContextFunc, baseURL string) error {
 	token, err := store.GetToken(baseURL)
 	if err != nil {
 		// Fall through to the local delete: we still want the keyring entry
@@ -68,6 +74,12 @@ func runLogout(ctx context.Context, outW, errW io.Writer, store tokenStore, revo
 
 	if err := store.DeleteToken(baseURL); err != nil {
 		return fmt.Errorf("remove auth token: %w", err)
+	}
+
+	// Remove the active context so the context-preferring readers no longer
+	// report a login. Best-effort: the legacy entry is already gone above.
+	if err := clearContext(); err != nil {
+		fmt.Fprintf(errW, "Warning: failed to clear current context: %v\n", err)
 	}
 
 	fmt.Fprintln(outW, "Logged out.")

--- a/cmd/entire/cli/logout_test.go
+++ b/cmd/entire/cli/logout_test.go
@@ -59,7 +59,7 @@ func TestRunLogout_RevokesServerSideThenDeletesLocally(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, "https://entire.io")
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestRunLogout_NoTokenSkipsRevoke(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, "https://entire.io")
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestRunLogout_RevokeFailureWarnsButSucceeds(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, "https://entire.io")
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestRunLogout_RevokeUnauthorizedIsSilent(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, "https://entire.io")
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestRunLogout_GetTokenErrorWarnsAndFallsThrough(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, "https://entire.io")
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestRunLogout_ReturnsErrorOnDeleteFailure(t *testing.T) {
 	revoke := func(context.Context) error { return nil }
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, "https://entire.io")
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -16,15 +16,6 @@ import (
 )
 
 func main() {
-	// Dispatch on argv[0] before anything else: when launched as
-	// git-remote-entire (via the shipped symlink), behave as a git remote
-	// helper and never touch the cobra/plugin machinery — git parses our
-	// stdout as a strict pkt-line stream, so no banner or log may precede
-	// it. runRemoteHelper handles its own version load and exit code.
-	if invokedAsRemoteHelper(os.Args[0]) {
-		os.Exit(runRemoteHelper(os.Args))
-	}
-
 	// Resolve version/commit from build info before anything reads them.
 	versioninfo.Load()
 

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -16,6 +16,15 @@ import (
 )
 
 func main() {
+	// Dispatch on argv[0] before anything else: when launched as
+	// git-remote-entire (via the shipped symlink), behave as a git remote
+	// helper and never touch the cobra/plugin machinery — git parses our
+	// stdout as a strict pkt-line stream, so no banner or log may precede
+	// it. runRemoteHelper handles its own version load and exit code.
+	if invokedAsRemoteHelper(os.Args[0]) {
+		os.Exit(runRemoteHelper(os.Args))
+	}
+
 	// Resolve version/commit from build info before anything reads them.
 	versioninfo.Load()
 

--- a/cmd/entire/remotehelper.go
+++ b/cmd/entire/remotehelper.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+	"github.com/entireio/cli/internal/remotehelper/githelper"
+	"github.com/entireio/cli/internal/remotehelper/replicas"
+	"github.com/entireio/cli/internal/remotehelper/transport"
+)
+
+// remoteHelperName is the git remote-helper binary name. Git resolves
+// `entire://` URLs by exec'ing a binary called git-remote-entire found on
+// PATH; we ship that as a symlink to the entire CLI and dispatch on
+// argv[0] so a single binary serves both roles (busybox/git style).
+const remoteHelperName = "git-remote-entire"
+
+// invokedAsRemoteHelper reports whether this process was launched under
+// the git-remote-entire name (via the shipped symlink). Detection is by
+// argv[0] basename, with a Windows .exe suffix tolerated.
+func invokedAsRemoteHelper(arg0 string) bool {
+	base := strings.TrimSuffix(filepath.Base(arg0), ".exe")
+	return base == remoteHelperName
+}
+
+// runRemoteHelper implements the git remote-helper protocol for
+// `entire://` URLs. Git invokes us as `git-remote-entire <remote> <url>`,
+// hands us the helper protocol on stdin, and expects responses on stdout.
+//
+// IMPORTANT: nothing on this path may write to stdout except the helper
+// protocol itself — git parses stdout as a strict pkt-line stream, so a
+// stray banner or log line corrupts the transfer. Diagnostics go to
+// stderr (and the ENTIRE_DEBUG-gated debuglog).
+//
+// Stage 1 wires authentication to the CLI's existing single-context
+// repo-scoped token exchange (auth.RepoScopedToken). Full multi-context
+// resolution (contexts.json + cluster discovery) lands in a later stage.
+func runRemoteHelper(args []string) int {
+	if len(args) < 3 {
+		fmt.Fprintln(os.Stderr, "usage: git-remote-entire <remote-name> <url>")
+		return 128
+	}
+
+	// Build info drives the agent string the helper advertises upstream.
+	versioninfo.Load()
+	githelper.Agent = remoteHelperName + "/" + versioninfo.Commit
+
+	rawURL := args[2]
+	parsedURL, err := url.Parse(rawURL)
+	switch {
+	case err != nil:
+		fmt.Fprintf(os.Stderr, "fatal: invalid URL %q: %v\n", rawURL, err)
+		return 128
+	case parsedURL.Scheme != "entire":
+		fmt.Fprintf(os.Stderr, "fatal: unsupported URL scheme %q (expected 'entire')\n", parsedURL.Scheme)
+		return 128
+	case parsedURL.Host == "":
+		fmt.Fprintf(os.Stderr, "fatal: missing host in URL %q\n", rawURL)
+		return 128
+	}
+
+	ctx, stop := installRemoteHelperSignals()
+	defer stop()
+
+	nodeCfg := replicas.Resolve(parsedURL)
+	// The repo-scoped token's audience is <clusterBaseURL><repoSlug>. The
+	// audience pins to the cluster entry URL (not a replica node), matching
+	// what the server validates the exchanged token against.
+	clusterBaseURL := nodeCfg.EntryURL
+	repoSlug := parsedURL.Path
+
+	setAuth := func(req *http.Request) error {
+		action := gitActionFromRequest(req)
+		if action == "" {
+			return fmt.Errorf("cannot classify git op for %s %s; scoped-token exchange requires a recognised smart-HTTP endpoint", req.Method, req.URL.Path)
+		}
+		token, err := auth.RepoScopedToken(req.Context(), clusterBaseURL, repoSlug, action)
+		if err != nil {
+			return fmt.Errorf("repo-scoped token exchange: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+
+	var onNodeFailed func(string)
+	if nodeCfg.Caching() {
+		onNodeFailed = func(string) { replicas.Invalidate(nodeCfg.ClusterHost, nodeCfg.RepoPath) }
+	}
+
+	proxy := transport.New(transport.Config{
+		Nodes:        nodeCfg,
+		Path:         parsedURL.Path,
+		SkipTLS:      os.Getenv("ENTIRE_TLS_SKIP_VERIFY") == "true",
+		SetAuth:      setAuth,
+		OnNodeFailed: onNodeFailed,
+	})
+
+	mode := githelper.ModeConnect
+	if os.Getenv("ENTIRE_STATELESS") == "true" {
+		mode = githelper.ModeStateless
+	}
+
+	if err := githelper.Run(ctx, proxy, mode, os.Stdin, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		return 128
+	}
+	return 0
+}
+
+// gitActionFromRequest classifies a smart-HTTP request as "pull" or
+// "push" so the right repo-scoped token can be minted. Returns "" when
+// the endpoint isn't a recognised git smart-HTTP route.
+func gitActionFromRequest(req *http.Request) string {
+	path := req.URL.Path
+	switch req.Method {
+	case http.MethodPost:
+		switch {
+		case strings.HasSuffix(path, "/git-receive-pack"):
+			return "push"
+		case strings.HasSuffix(path, "/git-upload-pack"):
+			return "pull"
+		}
+	case http.MethodGet:
+		if strings.HasSuffix(path, "/info/refs") {
+			switch req.URL.Query().Get("service") {
+			case "git-receive-pack":
+				return "push"
+			case "git-upload-pack":
+				return "pull"
+			}
+		}
+	}
+	return ""
+}
+
+// installRemoteHelperSignals ties HTTP request lifetimes to the parent
+// git process. Ctrl-C delivers SIGINT to the whole foreground process
+// group (us included); cancelling ctx aborts in-flight transfers instead
+// of waiting out the read timeout. After the first signal we unhook so a
+// second Ctrl-C hits the runtime default and hard-exits.
+func installRemoteHelperSignals() (context.Context, context.CancelFunc) {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-ctx.Done()
+		stop()
+		time.Sleep(2 * time.Second)
+		fmt.Fprintln(os.Stderr, "git-remote-entire: shutdown taking longer than expected; press Ctrl-C again to force-quit")
+	}()
+	return ctx, stop
+}

--- a/cmd/entire/remotehelper.go
+++ b/cmd/entire/remotehelper.go
@@ -14,6 +14,11 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/httpclient"
+	"github.com/entireio/cli/internal/entireclient/repocreds"
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
 	"github.com/entireio/cli/internal/remotehelper/githelper"
 	"github.com/entireio/cli/internal/remotehelper/replicas"
 	"github.com/entireio/cli/internal/remotehelper/transport"
@@ -42,9 +47,11 @@ func invokedAsRemoteHelper(arg0 string) bool {
 // stray banner or log line corrupts the transfer. Diagnostics go to
 // stderr (and the ENTIRE_DEBUG-gated debuglog).
 //
-// Stage 1 wires authentication to the CLI's existing single-context
-// repo-scoped token exchange (auth.RepoScopedToken). Full multi-context
-// resolution (contexts.json + cluster discovery) lands in a later stage.
+// Authentication resolves the login context for the target cluster from
+// the shared contexts.json (honoring an explicit cluster binding, else
+// /.well-known discovery), then mints repo-scoped tokens by exchanging
+// that context's login JWT. A pre-contexts.json login is migrated in
+// read-time so existing users don't have to re-authenticate.
 func runRemoteHelper(args []string) int {
 	if len(args) < 3 {
 		fmt.Fprintln(os.Stderr, "usage: git-remote-entire <remote-name> <url>")
@@ -72,6 +79,8 @@ func runRemoteHelper(args []string) int {
 	ctx, stop := installRemoteHelperSignals()
 	defer stop()
 
+	skipTLS := os.Getenv("ENTIRE_TLS_SKIP_VERIFY") == "true"
+
 	nodeCfg := replicas.Resolve(parsedURL)
 	// The repo-scoped token's audience is <clusterBaseURL><repoSlug>. The
 	// audience pins to the cluster entry URL (not a replica node), matching
@@ -79,12 +88,38 @@ func runRemoteHelper(args []string) int {
 	clusterBaseURL := nodeCfg.EntryURL
 	repoSlug := parsedURL.Path
 
+	httpClient := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: httpclient.NewTransport(skipTLS),
+	}
+
+	// Bridge any pre-contexts.json login so the resolver can find it.
+	if _, err := auth.MigrateLegacyLoginContext(); err != nil {
+		debuglog.Printf("legacy login migration: %v", err)
+	}
+
+	// Resolve which login context authenticates this cluster: an explicit
+	// cluster_contexts binding wins, otherwise the cluster's
+	// /.well-known/entire-cluster.json is matched against local contexts.
+	cfgDir := contexts.DefaultConfigDir()
+	clusterCtx, err := clusterdiscovery.ResolveContextForCluster(ctx, cfgDir, parsedURL.Host, httpClient, debuglog.Printf)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		return 128
+	}
+
+	// Mint repo-scoped tokens by exchanging the context's login JWT at its
+	// core's /oauth/token, cached per (repo, action) for this invocation.
+	creds := repocreds.New(clusterCtx.CoreURL, clusterBaseURL, func(context.Context) (string, error) {
+		return auth.LoginTokenForContext(clusterCtx)
+	}, httpClient)
+
 	setAuth := func(req *http.Request) error {
 		action := gitActionFromRequest(req)
 		if action == "" {
 			return fmt.Errorf("cannot classify git op for %s %s; scoped-token exchange requires a recognised smart-HTTP endpoint", req.Method, req.URL.Path)
 		}
-		token, err := auth.RepoScopedToken(req.Context(), clusterBaseURL, repoSlug, action)
+		token, err := creds.Token(req.Context(), repoSlug, action)
 		if err != nil {
 			return fmt.Errorf("repo-scoped token exchange: %w", err)
 		}
@@ -100,7 +135,7 @@ func runRemoteHelper(args []string) int {
 	proxy := transport.New(transport.Config{
 		Nodes:        nodeCfg,
 		Path:         parsedURL.Path,
-		SkipTLS:      os.Getenv("ENTIRE_TLS_SKIP_VERIFY") == "true",
+		SkipTLS:      skipTLS,
 		SetAuth:      setAuth,
 		OnNodeFailed: onNodeFailed,
 	})

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -1,3 +1,22 @@
+// Command git-remote-entire is the git remote helper for entire:// URLs.
+//
+// Git resolves `git clone entire://host/project/repo` by exec'ing a binary
+// named git-remote-entire on PATH, handing it the remote-helper protocol on
+// stdin and reading responses from stdout. This is a small, dedicated
+// binary (no cobra command tree) that shares the protocol, transport, and
+// auth packages with the main entire CLI.
+//
+// IMPORTANT: nothing here may write to stdout except the helper protocol
+// itself — git parses stdout as a strict pkt-line stream, so a stray banner
+// or log line corrupts the transfer. Diagnostics go to stderr (and the
+// ENTIRE_DEBUG-gated debuglog).
+//
+// Authentication resolves the login context for the target cluster from the
+// shared contexts.json (an explicit cluster binding, else
+// /.well-known discovery matched against local contexts), then mints
+// repo-scoped tokens by exchanging that context's login JWT. A
+// pre-contexts.json login is migrated at read-time so existing users don't
+// have to re-authenticate.
 package main
 
 import (
@@ -7,7 +26,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -18,49 +36,26 @@ import (
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/httpclient"
 	"github.com/entireio/cli/internal/entireclient/repocreds"
+	"github.com/entireio/cli/internal/remotehelper"
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 	"github.com/entireio/cli/internal/remotehelper/githelper"
 	"github.com/entireio/cli/internal/remotehelper/replicas"
 	"github.com/entireio/cli/internal/remotehelper/transport"
 )
 
-// remoteHelperName is the git remote-helper binary name. Git resolves
-// `entire://` URLs by exec'ing a binary called git-remote-entire found on
-// PATH; we ship that as a symlink to the entire CLI and dispatch on
-// argv[0] so a single binary serves both roles (busybox/git style).
-const remoteHelperName = "git-remote-entire"
-
-// invokedAsRemoteHelper reports whether this process was launched under
-// the git-remote-entire name (via the shipped symlink). Detection is by
-// argv[0] basename, with a Windows .exe suffix tolerated.
-func invokedAsRemoteHelper(arg0 string) bool {
-	base := strings.TrimSuffix(filepath.Base(arg0), ".exe")
-	return base == remoteHelperName
+func main() {
+	os.Exit(run(os.Args))
 }
 
-// runRemoteHelper implements the git remote-helper protocol for
-// `entire://` URLs. Git invokes us as `git-remote-entire <remote> <url>`,
-// hands us the helper protocol on stdin, and expects responses on stdout.
-//
-// IMPORTANT: nothing on this path may write to stdout except the helper
-// protocol itself — git parses stdout as a strict pkt-line stream, so a
-// stray banner or log line corrupts the transfer. Diagnostics go to
-// stderr (and the ENTIRE_DEBUG-gated debuglog).
-//
-// Authentication resolves the login context for the target cluster from
-// the shared contexts.json (honoring an explicit cluster binding, else
-// /.well-known discovery), then mints repo-scoped tokens by exchanging
-// that context's login JWT. A pre-contexts.json login is migrated in
-// read-time so existing users don't have to re-authenticate.
-func runRemoteHelper(args []string) int {
+func run(args []string) int {
 	if len(args) < 3 {
-		fmt.Fprintln(os.Stderr, "usage: git-remote-entire <remote-name> <url>")
+		fmt.Fprintf(os.Stderr, "usage: %s <remote-name> <url>\n", remotehelper.BinaryName)
 		return 128
 	}
 
 	// Build info drives the agent string the helper advertises upstream.
 	versioninfo.Load()
-	githelper.Agent = remoteHelperName + "/" + versioninfo.Commit
+	githelper.Agent = remotehelper.BinaryName + "/" + versioninfo.Commit
 
 	rawURL := args[2]
 	parsedURL, err := url.Parse(rawURL)
@@ -76,7 +71,7 @@ func runRemoteHelper(args []string) int {
 		return 128
 	}
 
-	ctx, stop := installRemoteHelperSignals()
+	ctx, stop := installSignals()
 	defer stop()
 
 	skipTLS := os.Getenv("ENTIRE_TLS_SKIP_VERIFY") == "true"
@@ -152,9 +147,9 @@ func runRemoteHelper(args []string) int {
 	return 0
 }
 
-// gitActionFromRequest classifies a smart-HTTP request as "pull" or
-// "push" so the right repo-scoped token can be minted. Returns "" when
-// the endpoint isn't a recognised git smart-HTTP route.
+// gitActionFromRequest classifies a smart-HTTP request as "pull" or "push"
+// so the right repo-scoped token can be minted. Returns "" when the
+// endpoint isn't a recognised git smart-HTTP route.
 func gitActionFromRequest(req *http.Request) string {
 	path := req.URL.Path
 	switch req.Method {
@@ -178,12 +173,12 @@ func gitActionFromRequest(req *http.Request) string {
 	return ""
 }
 
-// installRemoteHelperSignals ties HTTP request lifetimes to the parent
-// git process. Ctrl-C delivers SIGINT to the whole foreground process
-// group (us included); cancelling ctx aborts in-flight transfers instead
-// of waiting out the read timeout. After the first signal we unhook so a
-// second Ctrl-C hits the runtime default and hard-exits.
-func installRemoteHelperSignals() (context.Context, context.CancelFunc) {
+// installSignals ties HTTP request lifetimes to the parent git process.
+// Ctrl-C delivers SIGINT to the whole foreground process group (us
+// included); cancelling ctx aborts in-flight transfers instead of waiting
+// out the read timeout. After the first signal we unhook so a second
+// Ctrl-C hits the runtime default and hard-exits.
+func installSignals() (context.Context, context.CancelFunc) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-ctx.Done()

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGitActionFromRequest(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		query  string
+		want   string
+	}{
+		{"upload-pack RPC", http.MethodPost, "/et/p/r/git-upload-pack", "", "pull"},
+		{"receive-pack RPC", http.MethodPost, "/et/p/r/git-receive-pack", "", "push"},
+		{"info/refs pull", http.MethodGet, "/et/p/r/info/refs", "service=git-upload-pack", "pull"},
+		{"info/refs push", http.MethodGet, "/et/p/r/info/refs", "service=git-receive-pack", "push"},
+		{"info/refs no service", http.MethodGet, "/et/p/r/info/refs", "", ""},
+		{"unrelated GET", http.MethodGet, "/et/p/r/objects/info/packs", "", ""},
+		{"unrelated POST", http.MethodPost, "/et/p/r/whatever", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequestWithContext(context.Background(), tc.method, "https://host"+tc.path+"?"+tc.query, nil)
+			if got := gitActionFromRequest(req); got != tc.want {
+				t.Fatalf("gitActionFromRequest(%s %s?%s) = %q, want %q", tc.method, tc.path, tc.query, got, tc.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-git/go-git/v6 v6.0.0-alpha.4.0.20260521161150-3af8745c291b
 	github.com/go-git/x/plugin/objectsigner/auto v0.1.0
 	github.com/go-git/x/plugin/objectsigner/program v0.0.0-20260506121155-e7fc238fcab6
+	github.com/gofrs/flock v0.13.0
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-isatty v0.0.22
 	github.com/muesli/termenv v0.16.0
@@ -145,7 +146,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
 github.com/google/cel-go v0.27.0/go.mod h1:tTJ11FWqnhw5KKpnWpvW9CJC3Y9GK4EIS0WXnBbebzw=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -193,7 +195,6 @@ github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -1,0 +1,112 @@
+// Package clusterdiscovery resolves the trusted entire-core URLs that a
+// given entire-server cluster will accept JWTs from, by hitting the
+// cluster's /.well-known/entire-cluster.json endpoint. Used on the
+// cold-boot path where contexts.json doesn't yet bind a cluster to a
+// context, so we can tell the user *which* core(s) to log into instead
+// of leaving them to guess --base-url.
+package clusterdiscovery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Path mirrors server/cluster_discovery.go: the cluster advertises which
+// entire-core URLs it accepts as JWT issuers.
+const Path = "/.well-known/entire-cluster.json"
+
+// DebugFunc is the shape of the optional debug-log callback callers pass
+// in. It mirrors fmt.Printf-style formatting so each caller can plug in
+// its own env-var-gated logger (e.g. the [git-remote-entire] /
+// [entiredb] prefixed debugfs gated by ENTIRE_DEBUG). Pass nil to
+// suppress debug output.
+type DebugFunc func(format string, args ...any)
+
+// Response is the parsed shape of /.well-known/entire-cluster.json. New
+// fields may be added by the server; unknown ones are ignored.
+type Response struct {
+	CoreURLs []string `json:"core_urls"`
+}
+
+// Sentinel errors returned by Discover so callers can branch on the
+// failure mode (and surface different operator messages) without
+// stringly-typing the diagnosis.
+var (
+	// ErrUnreachable wraps any transport-level failure dialing the
+	// cluster (DNS, connection refused, TLS handshake, timeout). The
+	// host might be a typo or a real-but-down cluster — the client
+	// can't tell, and operators get the same nudge for both.
+	ErrUnreachable = errors.New("cluster unreachable")
+	// ErrNoIssuers means the cluster responded HTTP 503 — up but with
+	// an empty trusted-issuers configuration. Operator misconfig,
+	// not a client problem.
+	ErrNoIssuers = errors.New("cluster does not advertise any trusted login servers")
+	// ErrNoCoreURLs means the cluster responded HTTP 200 but the JSON
+	// carried an empty (or absent) core_urls list. Distinct from
+	// ErrNoIssuers because the operator fix is different — the
+	// response shape is wrong, rather than the 503 surface being
+	// served.
+	ErrNoCoreURLs = errors.New("cluster advertises no trusted core URLs")
+)
+
+// Discover fetches and parses the cluster's
+// /.well-known/entire-cluster.json. On success returns the parsed body
+// with a non-empty CoreURLs list. On failure returns one of the
+// sentinel errors above (wrapped with context) or a wrapped decode
+// error for malformed JSON. Network failures are wrapped under
+// ErrUnreachable so the caller can render the "looks unreachable"
+// nudge without string-matching.
+//
+// debugf is optional; nil suppresses debug output.
+func Discover(ctx context.Context, clusterHost string, c *http.Client, debugf DebugFunc) (*Response, error) {
+	if debugf == nil {
+		debugf = func(string, ...any) {}
+	}
+	url := "https://" + clusterHost + Path
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build discovery request: %w", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		debugf("cluster discovery: %v", err)
+		return nil, fmt.Errorf("%w: %w", ErrUnreachable, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, ErrNoIssuers
+	}
+	if resp.StatusCode != http.StatusOK {
+		debugf("cluster discovery: HTTP %d from %s", resp.StatusCode, url)
+		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+	var body Response
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		debugf("cluster discovery: decode: %v", err)
+		return nil, fmt.Errorf("decode %s: %w", url, err)
+	}
+	if len(body.CoreURLs) == 0 {
+		debugf("cluster discovery: no core_urls in response from %s", url)
+		return nil, ErrNoCoreURLs
+	}
+	return &body, nil
+}
+
+// RenderLoginHint formats a fatal-ready message describing which
+// entire-core URLs an operator can log into to gain credentials for
+// clusterHost. The output is stable (one indented URL per line) so
+// callers can pattern-match in tests.
+func RenderLoginHint(clusterHost string, coreURLs []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "no auth context for cluster %s. This cluster accepts logins from:\n", clusterHost)
+	for _, u := range coreURLs {
+		fmt.Fprintf(&b, "  %s\n", u)
+	}
+	fmt.Fprint(&b, "\nRun `entire-core auth login --base-url <url>` against one, then re-run your command.")
+	return b.String()
+}

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -107,6 +107,6 @@ func RenderLoginHint(clusterHost string, coreURLs []string) string {
 	for _, u := range coreURLs {
 		fmt.Fprintf(&b, "  %s\n", u)
 	}
-	fmt.Fprint(&b, "\nRun `entire-core auth login --base-url <url>` against one, then re-run your command.")
+	fmt.Fprint(&b, "\nRun `entire login` to authenticate (or `entire auth use <context>` to switch to an existing login), then re-run your command.")
 	return b.String()
 }

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -107,6 +107,8 @@ func RenderLoginHint(clusterHost string, coreURLs []string) string {
 	for _, u := range coreURLs {
 		fmt.Fprintf(&b, "  %s\n", u)
 	}
-	fmt.Fprint(&b, "\nRun `entire login` to authenticate (or `entire auth use <context>` to switch to an existing login), then re-run your command.")
+	fmt.Fprint(&b, "\nAuthenticate against one of those cores and re-run your command:\n"+
+		"  ENTIRE_AUTH_BASE_URL=<url> entire login\n"+
+		"or, if you already have a login there, switch to it with `entire auth use <context>`.")
 	return b.String()
 }

--- a/internal/entireclient/clusterdiscovery/discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/discovery_test.go
@@ -131,5 +131,5 @@ func TestRenderLoginHint(t *testing.T) {
 	assert.Contains(t, hint, "no auth context for cluster rc.partial.to")
 	assert.Contains(t, hint, "\n  https://a.example\n", "missing indented URL line: %q", hint)
 	assert.Contains(t, hint, "\n  https://b.example\n", "missing indented URL line: %q", hint)
-	assert.Contains(t, hint, "entire-core auth login --base-url")
+	assert.Contains(t, hint, "entire login")
 }

--- a/internal/entireclient/clusterdiscovery/discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/discovery_test.go
@@ -1,0 +1,135 @@
+package clusterdiscovery
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hostPinningClient returns an http.Client that rewrites every request
+// to hit srv. Lets the discovery helper assemble its
+// "https://<clusterHost>/..." URL while we still serve responses from
+// an httptest server on localhost.
+func hostPinningClient(t *testing.T, srv *httptest.Server) *http.Client {
+	t.Helper()
+	srvURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	return &http.Client{
+		Transport: rewritingTransport{base: http.DefaultTransport, scheme: srvURL.Scheme, host: srvURL.Host},
+	}
+}
+
+type rewritingTransport struct {
+	base   http.RoundTripper
+	scheme string
+	host   string
+}
+
+func (r rewritingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = r.scheme
+	req.URL.Host = r.host
+
+	return r.base.RoundTrip(req)
+}
+
+func TestDiscover(t *testing.T) {
+	t.Run("returns parsed core_urls on 200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, Path, r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"core_urls":["https://eu.auth.partial.to","https://us.auth.partial.to"]}`)) //nolint:errcheck // test handler
+		}))
+		defer srv.Close()
+
+		body, err := Discover(t.Context(), "royalcanin.partial.to", hostPinningClient(t, srv), t.Logf)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"https://eu.auth.partial.to", "https://us.auth.partial.to"}, body.CoreURLs)
+	})
+
+	t.Run("HTTP 503 → ErrNoIssuers", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "cluster discovery not configured", http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		_, err := Discover(t.Context(), "rc.partial.to", hostPinningClient(t, srv), t.Logf)
+		assert.ErrorIs(t, err, ErrNoIssuers)
+	})
+
+	t.Run("empty core_urls → ErrNoCoreURLs", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"core_urls":[]}`)) //nolint:errcheck // test handler
+		}))
+		defer srv.Close()
+
+		_, err := Discover(t.Context(), "rc.partial.to", hostPinningClient(t, srv), t.Logf)
+		assert.ErrorIs(t, err, ErrNoCoreURLs)
+	})
+
+	t.Run("non-200 non-503 surfaces as generic error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "nope", http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		_, err := Discover(t.Context(), "rc.partial.to", hostPinningClient(t, srv), t.Logf)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrUnreachable)
+		require.NotErrorIs(t, err, ErrNoIssuers)
+		require.NotErrorIs(t, err, ErrNoCoreURLs)
+	})
+
+	t.Run("transport error → ErrUnreachable", func(t *testing.T) {
+		// Closed server: connection refused. From the caller's POV this
+		// is indistinguishable from a typo'd host like "foo.invalid";
+		// both deserve the same actionable nudge.
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		client := hostPinningClient(t, srv)
+		srv.Close()
+
+		_, err := Discover(t.Context(), "rc.partial.to", client, t.Logf)
+		assert.ErrorIs(t, err, ErrUnreachable)
+	})
+
+	t.Run("malformed JSON surfaces as decode error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{not json`)) //nolint:errcheck // test handler
+		}))
+		defer srv.Close()
+
+		_, err := Discover(t.Context(), "rc.partial.to", hostPinningClient(t, srv), t.Logf)
+		require.Error(t, err)
+		// Not a sentinel — caller falls through to the generic
+		// "cluster discovery for <host>" wrapper.
+		assert.False(t, errors.Is(err, ErrUnreachable) || errors.Is(err, ErrNoIssuers) || errors.Is(err, ErrNoCoreURLs),
+			"decode error should not match any sentinel: %v", err)
+	})
+
+	t.Run("nil debugf is allowed", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "nope", http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		_, err := Discover(t.Context(), "rc.partial.to", hostPinningClient(t, srv), nil)
+		assert.Error(t, err)
+	})
+}
+
+func TestRenderLoginHint(t *testing.T) {
+	hint := RenderLoginHint("rc.partial.to", []string{"https://a.example", "https://b.example"})
+
+	// Each URL is on its own indented line — the "bog-simple stdout
+	// list" requirement.
+	assert.Contains(t, hint, "no auth context for cluster rc.partial.to")
+	assert.Contains(t, hint, "\n  https://a.example\n", "missing indented URL line: %q", hint)
+	assert.Contains(t, hint, "\n  https://b.example\n", "missing indented URL line: %q", hint)
+	assert.Contains(t, hint, "entire-core auth login --base-url")
+}

--- a/internal/entireclient/clusterdiscovery/discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/discovery_test.go
@@ -132,4 +132,5 @@ func TestRenderLoginHint(t *testing.T) {
 	assert.Contains(t, hint, "\n  https://a.example\n", "missing indented URL line: %q", hint)
 	assert.Contains(t, hint, "\n  https://b.example\n", "missing indented URL line: %q", hint)
 	assert.Contains(t, hint, "entire login")
+	assert.Contains(t, hint, "ENTIRE_AUTH_BASE_URL")
 }

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -50,12 +50,26 @@ func ResolveContextForCluster(ctx context.Context, configDir, clusterHost string
 	if err != nil {
 		return nil, formatDiscoveryError(clusterHost, err)
 	}
+	current := f.Find(f.CurrentContext)
 	for _, coreURL := range body.CoreURLs {
 		matches := f.ContextsForIssuer(coreURL)
 		if len(matches) == 0 {
 			continue
 		}
+		// Prefer the active context when it's one of the eligible matches —
+		// otherwise a core with several accounts (alice@core, bob@core) would
+		// auto-bind whichever was saved first, silently authenticating as the
+		// wrong user. Fall back to the first match when the current context
+		// isn't eligible for this cluster.
 		c := matches[0]
+		if current != nil {
+			for _, m := range matches {
+				if m.Name == current.Name {
+					c = current
+					break
+				}
+			}
+		}
 		if bindErr := contexts.BindCluster(configDir, clusterHost, c.Name); bindErr != nil {
 			// Non-fatal: we still resolved a usable context. Next
 			// invocation will pay the discovery round-trip again.

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -1,0 +1,88 @@
+package clusterdiscovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
+)
+
+// ResolveContextForCluster picks the auth context for clusterHost.
+// Resolution order:
+//
+//  1. Explicit `cluster_contexts[clusterHost]` binding in contexts.json
+//     pointing at an existing context — used as-is.
+//  2. Discovery via /.well-known/entire-cluster.json on the cluster
+//     itself, matched against existing local contexts by the
+//     advertised core_urls. The first advertised URL with a local
+//     context wins, and the cluster→context binding is written so the
+//     next call skips discovery.
+//  3. No local context matches any advertised URL — return a
+//     fatal-ready error with the login hint listing the cluster's
+//     advertised issuers.
+//
+// We deliberately do NOT fall back to current_context for an unknown
+// cluster host. The old fallback would silently use a staging
+// context against a prod (entire.io) cluster — which
+// then 400s as "unknown cluster_host" because the cluster's own
+// registry doesn't know the host. The cluster's /.well-known is the
+// authoritative answer to "which env am I in", so we ask it.
+//
+// debugf is optional; nil suppresses debug output.
+func ResolveContextForCluster(ctx context.Context, configDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*contexts.Context, error) {
+	if debugf == nil {
+		debugf = func(string, ...any) {}
+	}
+	f, err := contexts.Load(configDir)
+	if err != nil {
+		return nil, fmt.Errorf("load contexts: %w", err)
+	}
+	if name, ok := f.ClusterContexts[clusterHost]; ok && name != "" {
+		if c := f.Find(name); c != nil {
+			debugf("contexts.json binding %s -> %s", clusterHost, c.Name)
+			return c, nil
+		}
+		debugf("stale binding %s -> %q (context no longer exists); falling through to discovery", clusterHost, name)
+	}
+	body, err := Discover(ctx, clusterHost, httpClient, debugf)
+	if err != nil {
+		return nil, formatDiscoveryError(clusterHost, err)
+	}
+	for _, coreURL := range body.CoreURLs {
+		matches := f.ContextsForIssuer(coreURL)
+		if len(matches) == 0 {
+			continue
+		}
+		c := matches[0]
+		if bindErr := contexts.BindCluster(configDir, clusterHost, c.Name); bindErr != nil {
+			// Non-fatal: we still resolved a usable context. Next
+			// invocation will pay the discovery round-trip again.
+			debugf("auto-bind %s -> %s failed: %v", clusterHost, c.Name, bindErr)
+		} else {
+			debugf("auto-bound %s -> %s after discovery match on %s", clusterHost, c.Name, coreURL)
+		}
+		return c, nil
+	}
+	return nil, errors.New(RenderLoginHint(clusterHost, body.CoreURLs))
+}
+
+// formatDiscoveryError turns a Discover error into the message
+// operators have always seen at this layer. Kept here (not on the
+// sentinels themselves) so the package's errors stay machine-readable
+// while the caller-facing strings remain centralised.
+func formatDiscoveryError(clusterHost string, err error) error {
+	switch {
+	case errors.Is(err, ErrUnreachable):
+		return fmt.Errorf("%s doesn't look like a cluster, or it is unreachable: %w", clusterHost, err)
+	case errors.Is(err, ErrNoIssuers):
+		return fmt.Errorf("cluster %s does not advertise any trusted login servers (HTTP 503 from %s); contact the cluster administrator",
+			clusterHost, Path)
+	case errors.Is(err, ErrNoCoreURLs):
+		return fmt.Errorf("cluster %s advertises no trusted core URLs (empty list at %s); contact the cluster administrator",
+			clusterHost, Path)
+	default:
+		return fmt.Errorf("cluster discovery for %s: %w", clusterHost, err)
+	}
+}

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -1,0 +1,184 @@
+package clusterdiscovery
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
+)
+
+// TestResolveContextForClusterBindingShortCircuits: an explicit
+// cluster_contexts binding is used directly — no /.well-known hit.
+func TestResolveContextForClusterBindingShortCircuits(t *testing.T) {
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "current",
+		ClusterContexts: map[string]string{
+			"bound.example.com": "us",
+		},
+		Contexts: []*contexts.Context{
+			{Name: "current", CoreURL: "https://current.example", Handle: "alice", KeychainService: "kc:current"},
+			{Name: "us", CoreURL: "https://us.auth.entire.io", Handle: "bob", KeychainService: "kc:us"},
+		},
+	}))
+
+	// Fail-loud HTTP client: any actual request is a bug.
+	failClient := &http.Client{Transport: failTransport(t)}
+
+	c, err := ResolveContextForCluster(t.Context(), configDir, "bound.example.com", failClient, t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "us", c.Name)
+}
+
+// TestResolveContextForClusterDiscoversAndAutoBinds: no binding, no
+// fallback to current_context — instead we hit /.well-known, match
+// the first advertised core URL against a local context, and persist
+// the binding for next time.
+func TestResolveContextForClusterDiscoversAndAutoBinds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		assert.Equal(t, Path, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"core_urls":["https://eu.auth.entire.io","https://us.auth.entire.io"]}`)) //nolint:errcheck // test
+	}))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		// current_context points at a STAGING login — the bug we're
+		// fixing is that this used to silently get reused against a
+		// prod cluster host. The PROD login below should be the one
+		// discovery picks via the well-known match.
+		CurrentContext: "staging-eu",
+		Contexts: []*contexts.Context{
+			{Name: "staging-eu", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:staging"},
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod-eu"},
+		},
+	}))
+
+	c, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name, "should pick the prod context, NOT current_context")
+
+	// Auto-bound: the second call doesn't hit /.well-known.
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "first call hits discovery once")
+	c2, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c2.Name)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "auto-bind should skip discovery on the second call")
+}
+
+// TestResolveContextForClusterNoMatchReturnsLoginHint: discovery
+// succeeds but the user has no context for any of the advertised core
+// URLs. Error message tells them which login URL to use — that's the
+// whole point of having /.well-known.
+func TestResolveContextForClusterNoMatchReturnsLoginHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"core_urls":["https://eu.auth.entire.io"]}`)) //nolint:errcheck // test
+	}))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "staging",
+		Contexts: []*contexts.Context{
+			{Name: "staging", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:staging"},
+		},
+	}))
+
+	_, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no auth context for cluster aws-eu-central-1.entire.io")
+	assert.Contains(t, err.Error(), "https://eu.auth.entire.io")
+	assert.Contains(t, err.Error(), "entire-core auth login --base-url")
+}
+
+// TestResolveContextForClusterStaleBindingFallsThrough: a binding that
+// names a non-existent context is treated as if no binding exists —
+// we discover, match, and rebind to a real context.
+func TestResolveContextForClusterStaleBindingFallsThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"core_urls":["https://eu.auth.entire.io"]}`)) //nolint:errcheck // test
+	}))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "current",
+		ClusterContexts: map[string]string{
+			"aws-eu-central-1.entire.io": "deleted",
+		},
+		Contexts: []*contexts.Context{
+			{Name: "current", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:current"},
+		},
+	}))
+
+	c, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "current", c.Name)
+}
+
+// TestResolveContextForClusterUnreachable: transport failure surfaces
+// the "doesn't look like a cluster" message — the user can't tell a
+// typo from a real-but-down cluster, and either way the next step is
+// the same.
+func TestResolveContextForClusterUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	client := hostPinningClient(t, srv)
+	srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "current",
+		Contexts: []*contexts.Context{
+			{Name: "current", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:current"},
+		},
+	}))
+
+	_, err := ResolveContextForCluster(t.Context(), configDir, "missing.example.com", client, t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing.example.com doesn't look like a cluster, or it is unreachable")
+}
+
+// TestResolveContextForCluster503: HTTP 503 from /.well-known is a
+// distinct operator surface — the cluster is up but has no trusted
+// issuers configured. The error must point at the admin, not the user.
+func TestResolveContextForCluster503(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no issuers", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		Contexts: []*contexts.Context{{Name: "x", CoreURL: "https://x.example", Handle: "x", KeychainService: "kc:x"}},
+	}))
+
+	_, err := ResolveContextForCluster(t.Context(), configDir, "rc.partial.to", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not advertise any trusted login servers")
+	assert.Contains(t, err.Error(), "cluster administrator")
+}
+
+// failTransport returns a RoundTripper that fails the test if invoked —
+// used by the binding-short-circuit test to prove we never hit the
+// network.
+func failTransport(t *testing.T) http.RoundTripper {
+	t.Helper()
+	return roundTripFunc(func(*http.Request) (*http.Response, error) {
+		t.Fatal("unexpected HTTP call: binding should have short-circuited discovery")
+		return nil, nil
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -74,6 +74,31 @@ func TestResolveContextForClusterDiscoversAndAutoBinds(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "auto-bind should skip discovery on the second call")
 }
 
+// TestResolveContextForClusterPrefersCurrentAmongSameCoreMatches: when a
+// core has several accounts (alice@core, bob@core) and bob is the active
+// context, discovery must auto-bind to bob, not to whichever was saved
+// first — otherwise a clone silently authenticates as the wrong user.
+func TestResolveContextForClusterPrefersCurrentAmongSameCoreMatches(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"core_urls":["https://eu.auth.entire.io"]}`)) //nolint:errcheck // test
+	}))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "bob@eu",
+		Contexts: []*contexts.Context{
+			{Name: "alice@eu", CoreURL: "https://eu.auth.entire.io", Handle: "alice", KeychainService: "kc:alice"},
+			{Name: "bob@eu", CoreURL: "https://eu.auth.entire.io", Handle: "bob", KeychainService: "kc:bob"},
+		},
+	}))
+
+	c, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "bob@eu", c.Name, "should prefer the active context among same-core matches")
+}
+
 // TestResolveContextForClusterNoMatchReturnsLoginHint: discovery
 // succeeds but the user has no context for any of the advertised core
 // URLs. Error message tells them which login URL to use — that's the
@@ -97,7 +122,7 @@ func TestResolveContextForClusterNoMatchReturnsLoginHint(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no auth context for cluster aws-eu-central-1.entire.io")
 	assert.Contains(t, err.Error(), "https://eu.auth.entire.io")
-	assert.Contains(t, err.Error(), "entire-core auth login --base-url")
+	assert.Contains(t, err.Error(), "entire login")
 }
 
 // TestResolveContextForClusterStaleBindingFallsThrough: a binding that

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -123,6 +123,7 @@ func TestResolveContextForClusterNoMatchReturnsLoginHint(t *testing.T) {
 	assert.Contains(t, err.Error(), "no auth context for cluster aws-eu-central-1.entire.io")
 	assert.Contains(t, err.Error(), "https://eu.auth.entire.io")
 	assert.Contains(t, err.Error(), "entire login")
+	assert.Contains(t, err.Error(), "ENTIRE_AUTH_BASE_URL")
 }
 
 // TestResolveContextForClusterStaleBindingFallsThrough: a binding that

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -1,0 +1,345 @@
+// Package contexts is the kubectl-style context store for the Entire CLIs.
+//
+// One on-disk file at $ENTIRE_CONFIG_DIR/contexts.json (default
+// ~/.config/entire/contexts.json) holds:
+//
+//   - a list of named contexts, each pairing a core URL, principal handle,
+//     and OS-keychain slot where the access + refresh tokens live;
+//   - cluster_contexts, a map from entire-server cluster host to the
+//     context name that should authenticate ops against that cluster;
+//   - current_context, the fallback for clusters with no binding and the
+//     default for direct CLI commands not tied to a cluster.
+//
+// File invariants: 0600, atomic temp+rename, exclusive flock under load.
+// Both CLIs share the same file so a login from either is visible to the
+// other.
+package contexts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+// Context is a single kubectl-style entry: which core to talk to, as
+// whom, and where the credentials are stored.
+type Context struct {
+	// Name is the user-facing identifier. Defaults to the issuer host on
+	// auto-creation; overridable via login --name.
+	Name string `json:"name"`
+	// CoreURL is the JWT issuer URL — what STS exchanges hit. Set from
+	// the access token's signed iss claim, not the typed login URL.
+	CoreURL string `json:"core_url"`
+	// Handle is the principal handle returned from /api/auth/token.
+	Handle string `json:"handle"`
+	// KeychainService is the OS-keyring slot where the access token is
+	// filed; the refresh token lives at KeychainService+":refresh".
+	KeychainService string `json:"keychain_service"`
+}
+
+// File is the on-disk shape of contexts.json.
+type File struct {
+	// CurrentContext is the fallback for unbound clusters and the default
+	// for direct CLI commands. Empty until the first login.
+	CurrentContext string `json:"current_context,omitempty"`
+	// ClusterContexts maps entire-server cluster host → context name.
+	// Populated lazily after a successful op against the cluster, or
+	// explicitly via `entire-core context bind HOST NAME`.
+	ClusterContexts map[string]string `json:"cluster_contexts,omitempty"`
+	// Contexts is the list of stored credentials. Order is preserved on
+	// disk so list output stays stable across saves.
+	Contexts []*Context `json:"contexts,omitempty"`
+}
+
+// FilePath returns $configDir/contexts.json after ensuring the directory
+// exists with 0700 perms.
+func FilePath(configDir string) (string, error) {
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		return "", fmt.Errorf("create config dir: %w", err)
+	}
+	return filepath.Join(configDir, "contexts.json"), nil
+}
+
+// DefaultConfigDir is $ENTIRE_CONFIG_DIR if set, else ~/.config/entire.
+func DefaultConfigDir() string {
+	if dir := os.Getenv("ENTIRE_CONFIG_DIR"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	return filepath.Join(home, ".config", "entire")
+}
+
+// Load reads contexts.json under configDir, returning an empty *File
+// when the file doesn't exist yet (a fresh user). Holds an exclusive
+// flock for the duration of the read.
+func Load(configDir string) (*File, error) {
+	path, err := FilePath(configDir)
+	if err != nil {
+		return nil, err
+	}
+	unlock, err := lockFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+	return readNoLock(path)
+}
+
+// Save writes f to contexts.json atomically (temp+rename) under an
+// exclusive flock.
+func Save(configDir string, f *File) error {
+	path, err := FilePath(configDir)
+	if err != nil {
+		return err
+	}
+	unlock, err := lockFile(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return writeNoLock(path, f)
+}
+
+// ContextsForIssuer returns every context whose CoreURL matches issuer
+// after trimming. Used by CLI flows that prompt the operator when
+// multiple sessions are stored against the same core (logout, entiredb's
+// admin/repo prompts). Order matches the on-disk order so prompt
+// numbering is stable across saves.
+func (f *File) ContextsForIssuer(issuer string) []*Context {
+	if f == nil {
+		return nil
+	}
+	want := trimURL(issuer)
+	var out []*Context
+	for _, c := range f.Contexts {
+		if trimURL(c.CoreURL) == want {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func trimURL(u string) string {
+	for len(u) > 0 && u[len(u)-1] == '/' {
+		u = u[:len(u)-1]
+	}
+	return u
+}
+
+// Find returns the context with the given name, or nil.
+func (f *File) Find(name string) *Context {
+	if f == nil || name == "" {
+		return nil
+	}
+	for _, c := range f.Contexts {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// Resolve picks the context to use for an entire-server cluster. The
+// binding wins when present and points at an existing context;
+// otherwise we fall back to the current context. Returns nil when
+// neither resolves.
+func (f *File) Resolve(clusterHost string) *Context {
+	if f == nil {
+		return nil
+	}
+	if name, ok := f.ClusterContexts[clusterHost]; ok && name != "" {
+		if c := f.Find(name); c != nil {
+			return c
+		}
+		// Stale binding (context deleted out from under it). Treat as
+		// no binding rather than erroring — the current_context fallback
+		// is the safer behaviour.
+	}
+	return f.Find(f.CurrentContext)
+}
+
+// Upsert replaces the context with matching Name, or appends. Sets the
+// current context when there isn't one already (first login).
+func (f *File) Upsert(c *Context) {
+	if c == nil || c.Name == "" {
+		return
+	}
+	for i, existing := range f.Contexts {
+		if existing.Name == c.Name {
+			f.Contexts[i] = c
+			if f.CurrentContext == "" {
+				f.CurrentContext = c.Name
+			}
+			return
+		}
+	}
+	f.Contexts = append(f.Contexts, c)
+	if f.CurrentContext == "" {
+		f.CurrentContext = c.Name
+	}
+}
+
+// Delete drops the context with the given name, plus any cluster
+// bindings that pointed at it. If the deleted context was current, the
+// current pointer advances to whatever remains (or empty).
+func (f *File) Delete(name string) {
+	if f == nil || name == "" {
+		return
+	}
+	idx := slices.IndexFunc(f.Contexts, func(c *Context) bool { return c.Name == name })
+	if idx >= 0 {
+		f.Contexts = slices.Delete(f.Contexts, idx, idx+1)
+	}
+	for host, target := range f.ClusterContexts {
+		if target == name {
+			delete(f.ClusterContexts, host)
+		}
+	}
+	if f.CurrentContext == name {
+		f.CurrentContext = ""
+		if len(f.Contexts) > 0 {
+			f.CurrentContext = f.Contexts[0].Name
+		}
+	}
+}
+
+// Modify atomically applies fn to contexts.json under a single
+// exclusive flock — load, mutate, write all happen with the lock held.
+// Use this for any read-modify-write sequence; calling Load and Save
+// separately releases the lock between them and races concurrent
+// writers (e.g. a parallel git push triggering BindCluster).
+//
+// fn returns (changed, err). When changed is false the file isn't
+// rewritten — useful for idempotent operations that often have
+// nothing to do. When err is non-nil the change is discarded.
+func Modify(configDir string, fn func(*File) (changed bool, err error)) error {
+	path, err := FilePath(configDir)
+	if err != nil {
+		return err
+	}
+	unlock, err := lockFile(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	f, err := readNoLock(path)
+	if err != nil {
+		return err
+	}
+	changed, err := fn(f)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	return writeNoLock(path, f)
+}
+
+// BindCluster sets cluster_contexts[host] = name atomically. Errors
+// when the named context doesn't exist (a stale binding is a foot-gun).
+// Idempotent.
+func BindCluster(configDir, host, name string) error {
+	if host == "" || name == "" {
+		return errors.New("BindCluster requires non-empty host and context name")
+	}
+	return Modify(configDir, func(f *File) (bool, error) {
+		if f.Find(name) == nil {
+			return false, fmt.Errorf("no context named %q", name)
+		}
+		if f.ClusterContexts == nil {
+			f.ClusterContexts = map[string]string{}
+		}
+		if f.ClusterContexts[host] == name {
+			return false, nil
+		}
+		f.ClusterContexts[host] = name
+		return true, nil
+	})
+}
+
+func lockFile(path string) (func(), error) {
+	lockPath := path + ".lock"
+	fl := flock.New(lockPath)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	locked, err := fl.TryLockContext(ctx, 100*time.Millisecond)
+	if err != nil {
+		return nil, fmt.Errorf("acquire contexts lock: %w", err)
+	}
+	if !locked {
+		return nil, errors.New("timeout acquiring lock on contexts file")
+	}
+	return func() {
+		if unlockErr := fl.Unlock(); unlockErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to unlock contexts file: %v\n", unlockErr)
+		}
+	}, nil
+}
+
+func readNoLock(path string) (*File, error) {
+	// #nosec G304 -- path comes from ENTIRE_CONFIG_DIR or the user's home,
+	// the same trust boundary credentials.go runs under.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &File{}, nil
+		}
+		return nil, fmt.Errorf("read contexts file: %w", err)
+	}
+	if len(data) == 0 {
+		return &File{}, nil
+	}
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse contexts file: %w", err)
+	}
+	return &f, nil
+}
+
+func writeNoLock(path string, f *File) error {
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal contexts: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".contexts.json.tmp.*")
+	if err != nil {
+		return fmt.Errorf("create temp contexts file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		if tmp != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}
+	defer cleanup()
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("write temp contexts file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("sync temp contexts file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp contexts file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		return fmt.Errorf("chmod temp contexts file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename temp contexts file: %w", err)
+	}
+	tmp = nil
+	return nil
+}

--- a/internal/entireclient/contexts/contexts_test.go
+++ b/internal/entireclient/contexts/contexts_test.go
@@ -1,0 +1,394 @@
+package contexts_test
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
+)
+
+func TestLoad_MissingFileReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	f, err := contexts.Load(dir)
+	if err != nil {
+		t.Fatalf("Load on missing file: %v", err)
+	}
+	if f == nil {
+		t.Fatal("Load returned nil File")
+	}
+	if f.CurrentContext != "" || len(f.Contexts) != 0 || len(f.ClusterContexts) != 0 {
+		t.Errorf("expected zero-valued File, got %+v", f)
+	}
+}
+
+func TestSaveLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := &contexts.File{
+		CurrentContext: "eu-paul",
+		ClusterContexts: map[string]string{
+			"royalcanin.partial.to": "us-superadmin",
+		},
+		Contexts: []*contexts.Context{
+			{Name: "eu-paul", CoreURL: "https://eu.example", Handle: "paul", KeychainService: "entire-core:eu-paul"},
+			{Name: "us-superadmin", CoreURL: "https://us.example", Handle: "superadmin", KeychainService: "entire-core:us-superadmin"},
+		},
+	}
+	if err := contexts.Save(dir, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := contexts.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal got: %v", err)
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal want: %v", err)
+	}
+	if string(gotJSON) != string(wantJSON) {
+		t.Errorf("round-trip mismatch\n got: %s\nwant: %s", gotJSON, wantJSON)
+	}
+}
+
+func TestSave_WritesAtomically_AndChmod600(t *testing.T) {
+	dir := t.TempDir()
+	if err := contexts.Save(dir, &contexts.File{CurrentContext: "x"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path := filepath.Join(dir, "contexts.json")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("file perm = %#o, want 0600", perm)
+	}
+
+	// No temp file left behind on success.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() == "contexts.json" || e.Name() == "contexts.json.lock" {
+			continue
+		}
+		t.Errorf("leftover file in config dir: %s", e.Name())
+	}
+}
+
+func TestUpsert_FirstAddBecomesCurrent(t *testing.T) {
+	f := &contexts.File{}
+	c := &contexts.Context{Name: "first", CoreURL: "https://a.example", Handle: "alice"}
+	f.Upsert(c)
+	if f.CurrentContext != "first" {
+		t.Errorf("CurrentContext = %q, want %q", f.CurrentContext, "first")
+	}
+	if len(f.Contexts) != 1 || f.Contexts[0] != c {
+		t.Errorf("Contexts = %v, want one entry", f.Contexts)
+	}
+}
+
+func TestUpsert_SecondAddDoesNotChangeCurrent(t *testing.T) {
+	f := &contexts.File{}
+	f.Upsert(&contexts.Context{Name: "first"})
+	f.Upsert(&contexts.Context{Name: "second"})
+	if f.CurrentContext != "first" {
+		t.Errorf("CurrentContext = %q, want %q (a later upsert must not steal current)", f.CurrentContext, "first")
+	}
+	if len(f.Contexts) != 2 {
+		t.Errorf("len(Contexts) = %d, want 2", len(f.Contexts))
+	}
+}
+
+func TestUpsert_ReplacesByName(t *testing.T) {
+	f := &contexts.File{}
+	f.Upsert(&contexts.Context{Name: "x", Handle: "old"})
+	f.Upsert(&contexts.Context{Name: "x", Handle: "new"})
+	if len(f.Contexts) != 1 {
+		t.Errorf("len(Contexts) = %d, want 1 (upsert must replace, not append)", len(f.Contexts))
+	}
+	if f.Contexts[0].Handle != "new" {
+		t.Errorf("Handle = %q, want %q", f.Contexts[0].Handle, "new")
+	}
+}
+
+func TestResolve_ClusterBindingWins(t *testing.T) {
+	f := &contexts.File{
+		CurrentContext: "default",
+		ClusterContexts: map[string]string{
+			"royalcanin.partial.to": "special",
+		},
+		Contexts: []*contexts.Context{
+			{Name: "default"},
+			{Name: "special"},
+		},
+	}
+	got := f.Resolve("royalcanin.partial.to")
+	if got == nil || got.Name != "special" {
+		t.Errorf("Resolve = %v, want context %q", got, "special")
+	}
+}
+
+func TestResolve_FallsBackToCurrent(t *testing.T) {
+	f := &contexts.File{
+		CurrentContext: "default",
+		Contexts:       []*contexts.Context{{Name: "default"}},
+	}
+	got := f.Resolve("unbound.example")
+	if got == nil || got.Name != "default" {
+		t.Errorf("Resolve = %v, want fallback to %q", got, "default")
+	}
+}
+
+func TestResolve_StaleBindingFallsBack(t *testing.T) {
+	// Binding points at a deleted context — Resolve must not return nil
+	// just because someone forgot to clean up; fall back to current.
+	f := &contexts.File{
+		CurrentContext: "default",
+		ClusterContexts: map[string]string{
+			"royalcanin.partial.to": "deleted-name",
+		},
+		Contexts: []*contexts.Context{{Name: "default"}},
+	}
+	got := f.Resolve("royalcanin.partial.to")
+	if got == nil || got.Name != "default" {
+		t.Errorf("stale binding: Resolve = %v, want fallback to %q", got, "default")
+	}
+}
+
+func TestResolve_NoCurrentNoBindingReturnsNil(t *testing.T) {
+	f := &contexts.File{}
+	if got := f.Resolve("anything.example"); got != nil {
+		t.Errorf("Resolve on empty file = %v, want nil", got)
+	}
+}
+
+func TestDelete_DropsContextAndBindings(t *testing.T) {
+	f := &contexts.File{
+		CurrentContext: "stays",
+		ClusterContexts: map[string]string{
+			"a.example": "doomed",
+			"b.example": "stays",
+		},
+		Contexts: []*contexts.Context{
+			{Name: "stays"},
+			{Name: "doomed"},
+		},
+	}
+	f.Delete("doomed")
+	if f.Find("doomed") != nil {
+		t.Error("Delete left context behind")
+	}
+	if _, exists := f.ClusterContexts["a.example"]; exists {
+		t.Error("Delete left dangling cluster binding")
+	}
+	if f.ClusterContexts["b.example"] != "stays" {
+		t.Error("Delete clobbered unrelated cluster binding")
+	}
+	if f.CurrentContext != "stays" {
+		t.Errorf("CurrentContext = %q, want %q (untouched)", f.CurrentContext, "stays")
+	}
+}
+
+func TestDelete_OfCurrentAdvancesPointer(t *testing.T) {
+	f := &contexts.File{
+		CurrentContext: "first",
+		Contexts: []*contexts.Context{
+			{Name: "first"},
+			{Name: "second"},
+		},
+	}
+	f.Delete("first")
+	if f.CurrentContext != "second" {
+		t.Errorf("after deleting current, CurrentContext = %q, want next remaining (%q)", f.CurrentContext, "second")
+	}
+}
+
+func TestDelete_OfLastClearsCurrent(t *testing.T) {
+	f := &contexts.File{
+		CurrentContext: "only",
+		Contexts:       []*contexts.Context{{Name: "only"}},
+	}
+	f.Delete("only")
+	if f.CurrentContext != "" {
+		t.Errorf("CurrentContext = %q, want empty after deleting the last context", f.CurrentContext)
+	}
+	if len(f.Contexts) != 0 {
+		t.Errorf("len(Contexts) = %d, want 0", len(f.Contexts))
+	}
+}
+
+func TestBindCluster_PersistsAndRequiresExistingContext(t *testing.T) {
+	dir := t.TempDir()
+	if err := contexts.Save(dir, &contexts.File{
+		CurrentContext: "eu-paul",
+		Contexts:       []*contexts.Context{{Name: "eu-paul"}},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Binding to a non-existent context is rejected — stale bindings are
+	// a foot-gun.
+	if err := contexts.BindCluster(dir, "host.example", "no-such-context"); err == nil {
+		t.Error("BindCluster to missing context: want error, got nil")
+	}
+
+	if err := contexts.BindCluster(dir, "host.example", "eu-paul"); err != nil {
+		t.Fatalf("BindCluster: %v", err)
+	}
+
+	got, err := contexts.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.ClusterContexts["host.example"] != "eu-paul" {
+		t.Errorf("ClusterContexts[host.example] = %q, want %q", got.ClusterContexts["host.example"], "eu-paul")
+	}
+
+	// Idempotent: same binding twice is fine.
+	if err := contexts.BindCluster(dir, "host.example", "eu-paul"); err != nil {
+		t.Fatalf("idempotent BindCluster: %v", err)
+	}
+}
+
+func TestModify_AppliesAndPersists(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := contexts.Modify(dir, func(f *contexts.File) (bool, error) {
+		f.Upsert(&contexts.Context{Name: "alice"})
+		f.CurrentContext = "alice"
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Modify: %v", err)
+	}
+
+	got, err := contexts.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.CurrentContext != "alice" || got.Find("alice") == nil {
+		t.Errorf("Modify did not persist: %+v", got)
+	}
+}
+
+func TestModify_NoChangeSkipsWrite(t *testing.T) {
+	dir := t.TempDir()
+	// Seed a baseline file.
+	if err := contexts.Save(dir, &contexts.File{CurrentContext: "x"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path := filepath.Join(dir, "contexts.json")
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	// Sleep enough for mtime to tick on filesystems with coarse resolution.
+	time.Sleep(10 * time.Millisecond)
+
+	if err := contexts.Modify(dir, func(_ *contexts.File) (bool, error) {
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Modify: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("Modify rewrote file despite changed=false (mtime before=%v after=%v)", before.ModTime(), after.ModTime())
+	}
+}
+
+func TestModify_ErrorDiscardsChange(t *testing.T) {
+	dir := t.TempDir()
+	// Seed: a baseline current_context the test will try to mutate-and-fail.
+	if err := contexts.Save(dir, &contexts.File{CurrentContext: "original"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	wantErr := errors.New("nope")
+	err := contexts.Modify(dir, func(f *contexts.File) (bool, error) {
+		f.CurrentContext = "mutated"
+		return true, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Modify error = %v, want %v", err, wantErr)
+	}
+
+	got, err := contexts.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.CurrentContext != "original" {
+		t.Errorf("CurrentContext = %q, want %q (error must roll back)", got.CurrentContext, "original")
+	}
+}
+
+func TestModify_HoldsLockAcrossLoadAndSave(t *testing.T) {
+	// Concurrent Modify calls each increment a counter into a custom field
+	// (here: stash count in CurrentContext as a string). With proper
+	// locking the final value equals the number of Modify calls.
+	// Without locking, lost updates leave it lower.
+	const n = 25
+	dir := t.TempDir()
+	if err := contexts.Save(dir, &contexts.File{CurrentContext: "0"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			if err := contexts.Modify(dir, func(f *contexts.File) (bool, error) {
+				cur, err := strconv.Atoi(f.CurrentContext)
+				if err != nil {
+					return false, err
+				}
+				f.CurrentContext = strconv.Itoa(cur + 1)
+				return true, nil
+			}); err != nil {
+				t.Errorf("Modify: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := contexts.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.CurrentContext != strconv.Itoa(n) {
+		t.Errorf("CurrentContext = %q, want %q (lost updates indicate non-atomic RMW)", got.CurrentContext, strconv.Itoa(n))
+	}
+}
+
+func TestBindCluster_RejectsEmptyArgs(t *testing.T) {
+	dir := t.TempDir()
+	if err := contexts.BindCluster(dir, "", "name"); err == nil {
+		t.Error("empty host: want error")
+	}
+	if err := contexts.BindCluster(dir, "host", ""); err == nil {
+		t.Error("empty name: want error")
+	}
+}
+
+func TestDefaultConfigDir_HonorsEnv(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", "/tmp/explicit/path")
+	if got := contexts.DefaultConfigDir(); got != "/tmp/explicit/path" {
+		t.Errorf("DefaultConfigDir = %q, want /tmp/explicit/path", got)
+	}
+}

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -1,0 +1,168 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+const (
+	cacheFileName = "nodes.json"
+	lockTimeout   = 5 * time.Second
+	lockRetry     = 100 * time.Millisecond
+
+	// DefaultTTL is the cache TTL for replica sets discovered via info/refs.
+	DefaultTTL = 24 * time.Hour
+)
+
+// ClusterCache is the top-level cache structure, keyed by cluster host.
+type ClusterCache map[string]*ClusterEntry
+
+// ClusterEntry holds cached data for a single cluster.
+type ClusterEntry struct {
+	Nodes          []string              `json:"nodes"`
+	NodesExpiresAt time.Time             `json:"nodes_expires_at"`
+	Repos          map[string]*RepoEntry `json:"repos,omitempty"`
+}
+
+// RepoEntry caches the hosting nodes for a single repository.
+type RepoEntry struct {
+	Nodes     []string  `json:"nodes"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// DefaultCacheDir returns ~/.cache/entire, respecting XDG_CACHE_HOME.
+func DefaultCacheDir() string {
+	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "entire")
+	}
+	home, _ := os.UserHomeDir() //nolint:errcheck // best-effort default
+	return filepath.Join(home, ".cache", "entire")
+}
+
+// LoadCache reads the node cache from disk. Returns an empty cache if the file
+// does not exist.
+func LoadCache(cacheDir string) (ClusterCache, error) {
+	path := filepath.Join(cacheDir, cacheFileName)
+
+	data, err := os.ReadFile(path) // #nosec G304
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(ClusterCache), nil
+		}
+		return nil, fmt.Errorf("read cache: %w", err)
+	}
+
+	var cache ClusterCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		// Corrupted cache — start fresh.
+		return make(ClusterCache), nil //nolint:nilerr // intentional: treat corrupt cache as empty
+	}
+	return cache, nil
+}
+
+// SaveCache writes the cache to disk atomically.
+func SaveCache(cacheDir string, cache ClusterCache) error {
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return fmt.Errorf("create cache dir: %w", err)
+	}
+
+	path := filepath.Join(cacheDir, cacheFileName)
+
+	fl := flock.New(path + ".lock")
+	ctx, cancel := context.WithTimeout(context.Background(), lockTimeout)
+	defer cancel()
+
+	locked, err := fl.TryLockContext(ctx, lockRetry)
+	if err != nil {
+		return fmt.Errorf("acquire cache lock: %w", err)
+	}
+	if !locked {
+		return errors.New("timeout acquiring cache lock")
+	}
+	defer fl.Unlock() //nolint:errcheck // unlock failure is non-fatal
+
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal cache: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("write cache tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp) //nolint:gosec // cleanup best-effort
+		return fmt.Errorf("rename cache: %w", err)
+	}
+	return nil
+}
+
+// GetClusterNodes returns the cached cluster nodes. The second return value
+// indicates whether the cache entry is fresh (not expired).
+func (c ClusterCache) GetClusterNodes(cluster string) ([]string, bool) {
+	entry := c[cluster]
+	if entry == nil || len(entry.Nodes) == 0 {
+		return nil, false
+	}
+	return entry.Nodes, time.Now().Before(entry.NodesExpiresAt)
+}
+
+// SetClusterNodes stores cluster nodes with the given TTL.
+func (c ClusterCache) SetClusterNodes(cluster string, nodes []string, ttl time.Duration) {
+	entry := c[cluster]
+	if entry == nil {
+		entry = &ClusterEntry{}
+		c[cluster] = entry
+	}
+	entry.Nodes = nodes
+	entry.NodesExpiresAt = time.Now().Add(ttl)
+}
+
+// GetRepoNodes returns cached hosting nodes for a repo. The second return
+// value indicates freshness.
+func (c ClusterCache) GetRepoNodes(cluster, repoPath string) ([]string, bool) {
+	entry := c[cluster]
+	if entry == nil || entry.Repos == nil {
+		return nil, false
+	}
+	repo := entry.Repos[repoPath]
+	if repo == nil || len(repo.Nodes) == 0 {
+		return nil, false
+	}
+	return repo.Nodes, time.Now().Before(repo.ExpiresAt)
+}
+
+// SetRepoNodes caches hosting nodes for a specific repo.
+func (c ClusterCache) SetRepoNodes(cluster, repoPath string, nodes []string, ttl time.Duration) {
+	entry := c[cluster]
+	if entry == nil {
+		entry = &ClusterEntry{}
+		c[cluster] = entry
+	}
+	if entry.Repos == nil {
+		entry.Repos = make(map[string]*RepoEntry)
+	}
+	entry.Repos[repoPath] = &RepoEntry{
+		Nodes:     nodes,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+}
+
+// InvalidateRepo removes the cached repo entry.
+func (c ClusterCache) InvalidateRepo(cluster, repoPath string) {
+	if entry := c[cluster]; entry != nil && entry.Repos != nil {
+		delete(entry.Repos, repoPath)
+	}
+}
+
+// InvalidateCluster removes all cached data for a cluster.
+func (c ClusterCache) InvalidateCluster(cluster string) {
+	delete(c, cluster)
+}

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -47,10 +47,69 @@ func DefaultCacheDir() string {
 }
 
 // LoadCache reads the node cache from disk. Returns an empty cache if the file
-// does not exist.
+// does not exist. This is an unlocked read — fine for read-only callers; use
+// ModifyCache for read-modify-write sequences.
 func LoadCache(cacheDir string) (ClusterCache, error) {
-	path := filepath.Join(cacheDir, cacheFileName)
+	return readCacheNoLock(filepath.Join(cacheDir, cacheFileName))
+}
 
+// SaveCache writes the cache to disk atomically under an exclusive flock.
+func SaveCache(cacheDir string, cache ClusterCache) error {
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return fmt.Errorf("create cache dir: %w", err)
+	}
+	path := filepath.Join(cacheDir, cacheFileName)
+	unlock, err := lockCache(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	return writeCacheNoLock(path, cache)
+}
+
+// ModifyCache atomically applies fn to the node cache under a single
+// exclusive flock — load, mutate, and write all happen with the lock held.
+// Use this for any read-modify-write sequence; LoadCache followed by
+// SaveCache releases the lock between them and races concurrent writers
+// (e.g. two parallel clone/fetch/push processes updating nodes.json), losing
+// each other's entries.
+func ModifyCache(cacheDir string, fn func(ClusterCache) error) error {
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return fmt.Errorf("create cache dir: %w", err)
+	}
+	path := filepath.Join(cacheDir, cacheFileName)
+	unlock, err := lockCache(path)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	cache, err := readCacheNoLock(path)
+	if err != nil {
+		return err
+	}
+	if err := fn(cache); err != nil {
+		return err
+	}
+	return writeCacheNoLock(path, cache)
+}
+
+func lockCache(path string) (func(), error) {
+	fl := flock.New(path + ".lock")
+	ctx, cancel := context.WithTimeout(context.Background(), lockTimeout)
+	defer cancel()
+
+	locked, err := fl.TryLockContext(ctx, lockRetry)
+	if err != nil {
+		return nil, fmt.Errorf("acquire cache lock: %w", err)
+	}
+	if !locked {
+		return nil, errors.New("timeout acquiring cache lock")
+	}
+	return func() { _ = fl.Unlock() }, nil //nolint:errcheck // unlock failure is non-fatal
+}
+
+func readCacheNoLock(path string) (ClusterCache, error) {
 	data, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -58,7 +117,6 @@ func LoadCache(cacheDir string) (ClusterCache, error) {
 		}
 		return nil, fmt.Errorf("read cache: %w", err)
 	}
-
 	var cache ClusterCache
 	if err := json.Unmarshal(data, &cache); err != nil {
 		// Corrupted cache — start fresh.
@@ -67,32 +125,11 @@ func LoadCache(cacheDir string) (ClusterCache, error) {
 	return cache, nil
 }
 
-// SaveCache writes the cache to disk atomically.
-func SaveCache(cacheDir string, cache ClusterCache) error {
-	if err := os.MkdirAll(cacheDir, 0700); err != nil {
-		return fmt.Errorf("create cache dir: %w", err)
-	}
-
-	path := filepath.Join(cacheDir, cacheFileName)
-
-	fl := flock.New(path + ".lock")
-	ctx, cancel := context.WithTimeout(context.Background(), lockTimeout)
-	defer cancel()
-
-	locked, err := fl.TryLockContext(ctx, lockRetry)
-	if err != nil {
-		return fmt.Errorf("acquire cache lock: %w", err)
-	}
-	if !locked {
-		return errors.New("timeout acquiring cache lock")
-	}
-	defer fl.Unlock() //nolint:errcheck // unlock failure is non-fatal
-
+func writeCacheNoLock(path string, cache ClusterCache) error {
 	data, err := json.MarshalIndent(cache, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal cache: %w", err)
 	}
-
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0600); err != nil {
 		return fmt.Errorf("write cache tmp: %w", err)

--- a/internal/entireclient/discovery/cache_test.go
+++ b/internal/entireclient/discovery/cache_test.go
@@ -1,0 +1,128 @@
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCacheRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	cache := make(ClusterCache)
+	cache.SetClusterNodes("rc.partial.to", []string{
+		"https://node1.rc.partial.to",
+		"https://node2.rc.partial.to",
+	}, 24*time.Hour)
+	cache.SetRepoNodes("rc.partial.to", "alice/repo", []string{
+		"https://node1.rc.partial.to",
+	}, 24*time.Hour)
+
+	if err := SaveCache(dir, cache); err != nil {
+		t.Fatalf("SaveCache: %v", err)
+	}
+
+	loaded, err := LoadCache(dir)
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+
+	nodes, fresh := loaded.GetClusterNodes("rc.partial.to")
+	if !fresh {
+		t.Fatal("expected cluster nodes to be fresh")
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("got %d cluster nodes, want 2", len(nodes))
+	}
+
+	repoNodes, fresh := loaded.GetRepoNodes("rc.partial.to", "alice/repo")
+	if !fresh {
+		t.Fatal("expected repo nodes to be fresh")
+	}
+	if len(repoNodes) != 1 || repoNodes[0] != "https://node1.rc.partial.to" {
+		t.Fatalf("unexpected repo nodes: %v", repoNodes)
+	}
+}
+
+func TestCacheExpiry(t *testing.T) {
+	cache := make(ClusterCache)
+	cache.SetClusterNodes("x.com", []string{"https://n1.x.com"}, -1*time.Second)
+	cache.SetRepoNodes("x.com", "a/b", []string{"https://n1.x.com"}, -1*time.Second)
+
+	_, fresh := cache.GetClusterNodes("x.com")
+	if fresh {
+		t.Error("expected expired cluster nodes")
+	}
+
+	_, fresh = cache.GetRepoNodes("x.com", "a/b")
+	if fresh {
+		t.Error("expected expired repo nodes")
+	}
+}
+
+func TestCacheMiss(t *testing.T) {
+	cache := make(ClusterCache)
+
+	nodes, fresh := cache.GetClusterNodes("nope.com")
+	if fresh || nodes != nil {
+		t.Error("expected miss for unknown cluster")
+	}
+
+	nodes, fresh = cache.GetRepoNodes("nope.com", "a/b")
+	if fresh || nodes != nil {
+		t.Error("expected miss for unknown repo")
+	}
+}
+
+func TestCacheInvalidation(t *testing.T) {
+	cache := make(ClusterCache)
+	cache.SetClusterNodes("x.com", []string{"https://n1.x.com"}, 24*time.Hour)
+	cache.SetRepoNodes("x.com", "a/b", []string{"https://n1.x.com"}, 24*time.Hour)
+
+	cache.InvalidateRepo("x.com", "a/b")
+	_, fresh := cache.GetRepoNodes("x.com", "a/b")
+	if fresh {
+		t.Error("repo should be invalidated")
+	}
+
+	_, fresh = cache.GetClusterNodes("x.com")
+	if !fresh {
+		t.Error("cluster nodes should still be fresh")
+	}
+
+	cache.InvalidateCluster("x.com")
+	_, fresh = cache.GetClusterNodes("x.com")
+	if fresh {
+		t.Error("cluster should be invalidated")
+	}
+}
+
+func TestLoadCacheMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := LoadCache(filepath.Join(dir, "nonexistent"))
+	if err != nil {
+		t.Fatalf("LoadCache on missing dir: %v", err)
+	}
+	if len(cache) != 0 {
+		t.Fatalf("expected empty cache, got %d entries", len(cache))
+	}
+}
+
+func TestLoadCacheCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveCache(dir, make(ClusterCache)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, cacheFileName), []byte("not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := LoadCache(dir)
+	if err != nil {
+		t.Fatalf("expected graceful handling of corrupt cache, got: %v", err)
+	}
+	if len(cache) != 0 {
+		t.Fatal("expected empty cache from corrupt file")
+	}
+}

--- a/internal/entireclient/discovery/cache_test.go
+++ b/internal/entireclient/discovery/cache_test.go
@@ -1,11 +1,58 @@
 package discovery
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestModifyCache_AtomicReadModifyWrite(t *testing.T) {
+	dir := t.TempDir()
+
+	// First mutation persists.
+	if err := ModifyCache(dir, func(c ClusterCache) error {
+		c.SetRepoNodes("host", "/r1", []string{"n1"}, time.Hour)
+		return nil
+	}); err != nil {
+		t.Fatalf("ModifyCache r1: %v", err)
+	}
+	// Second mutation sees the first's write (read-modify-write under one
+	// lock) and adds to it rather than clobbering.
+	if err := ModifyCache(dir, func(c ClusterCache) error {
+		c.SetRepoNodes("host", "/r2", []string{"n2"}, time.Hour)
+		return nil
+	}); err != nil {
+		t.Fatalf("ModifyCache r2: %v", err)
+	}
+
+	cache, err := LoadCache(dir)
+	if err != nil {
+		t.Fatalf("LoadCache: %v", err)
+	}
+	if n, ok := cache.GetRepoNodes("host", "/r1"); !ok || len(n) != 1 || n[0] != "n1" {
+		t.Fatalf("r1 entry lost: %v ok=%v", n, ok)
+	}
+	if n, ok := cache.GetRepoNodes("host", "/r2"); !ok || len(n) != 1 || n[0] != "n2" {
+		t.Fatalf("r2 entry missing: %v ok=%v", n, ok)
+	}
+
+	// A fn error aborts the write — the mutation must not persist.
+	if err := ModifyCache(dir, func(c ClusterCache) error {
+		c.SetRepoNodes("host", "/r3", []string{"n3"}, time.Hour)
+		return errors.New("boom")
+	}); err == nil {
+		t.Fatal("expected ModifyCache to return the fn error")
+	}
+	cache, err = LoadCache(dir)
+	if err != nil {
+		t.Fatalf("LoadCache after abort: %v", err)
+	}
+	if _, ok := cache.GetRepoNodes("host", "/r3"); ok {
+		t.Fatal("aborted mutation must not have persisted")
+	}
+}
 
 func TestCacheRoundTrip(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/entireclient/discovery/parse_replicas.go
+++ b/internal/entireclient/discovery/parse_replicas.go
@@ -1,0 +1,50 @@
+package discovery
+
+import (
+	"net"
+	"strings"
+)
+
+// ParseReplicas parses the X-Entire-Replicas header value into a list of
+// replica URIs. The header is a comma-separated list of URIs; surrounding
+// whitespace on each entry is trimmed and empty entries are skipped. An empty
+// or missing header yields a nil slice.
+func ParseReplicas(header string) []string {
+	if header == "" {
+		return nil
+	}
+	parts := strings.Split(header, ",")
+	uris := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			uris = append(uris, p)
+		}
+	}
+	if len(uris) == 0 {
+		return nil
+	}
+	return uris
+}
+
+// HostInCluster reports whether host equals the cluster's entry domain or
+// is a subdomain of it. Both values are compared by hostname only — any
+// port is stripped from either side before comparison. Used to scope
+// sensitive-header preservation across redirects: an in-cluster hop is
+// safe to carry Authorization, anything else must be treated as a new
+// trust boundary.
+func HostInCluster(host, cluster string) bool {
+	h := stripPort(strings.ToLower(host))
+	c := stripPort(strings.ToLower(cluster))
+	return h == c || strings.HasSuffix(h, "."+c)
+}
+
+// stripPort returns s with any trailing :port removed. If s does not parse as
+// host:port (e.g. bare hostname, IPv6 without brackets), it's returned
+// unchanged.
+func stripPort(s string) string {
+	if h, _, err := net.SplitHostPort(s); err == nil {
+		return h
+	}
+	return s
+}

--- a/internal/entireclient/discovery/parse_replicas_test.go
+++ b/internal/entireclient/discovery/parse_replicas_test.go
@@ -1,0 +1,72 @@
+package discovery
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseReplicas(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   []string
+	}{
+		{"empty", "", nil},
+		{"whitespace only", "   ", nil},
+		{"empty entries", ",,,", nil},
+		{"single", "https://n1.c.to", []string{"https://n1.c.to"}},
+		{"multiple", "https://n1.c.to,https://n2.c.to,https://n3.c.to", []string{
+			"https://n1.c.to", "https://n2.c.to", "https://n3.c.to",
+		}},
+		{"whitespace around entries", " https://n1.c.to ,\thttps://n2.c.to\n", []string{
+			"https://n1.c.to", "https://n2.c.to",
+		}},
+		{"skip empty entries", "https://n1.c.to,,https://n2.c.to,", []string{
+			"https://n1.c.to", "https://n2.c.to",
+		}},
+		{"non-default port", "https://n1.c.to:8443,https://n2.c.to", []string{
+			"https://n1.c.to:8443", "https://n2.c.to",
+		}},
+		{"http scheme (sim)", "http://127.0.0.1:10001,http://127.0.0.1:10002", []string{
+			"http://127.0.0.1:10001", "http://127.0.0.1:10002",
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseReplicas(tt.header)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("ParseReplicas(%q) = %v, want %v", tt.header, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostInCluster(t *testing.T) {
+	tests := []struct {
+		host, cluster string
+		want          bool
+	}{
+		{"n1.eu.partial.to", "eu.partial.to", true},
+		{"eu.partial.to", "eu.partial.to", true},
+		{"EU.PARTIAL.TO", "eu.partial.to", true},
+		{"n1.eu.partial.to", "EU.PARTIAL.TO", true},
+		{"evil.com", "eu.partial.to", false},
+		{"evileu.partial.to", "eu.partial.to", false}, // suffix but not subdomain
+		{"partial.to", "eu.partial.to", false},        // parent domain, not a subdomain
+		{"127.0.0.1", "127.0.0.1:9999", true},
+		{"other.com", "127.0.0.1:9999", false},
+		// Port on the host side too — caller may pass a raw Host header
+		// rather than a pre-stripped url.URL.Hostname().
+		{"node1.eu.partial.to:8443", "eu.partial.to", true},
+		{"node1.eu.partial.to:8443", "eu.partial.to:443", true},
+		{"eu.partial.to:8443", "eu.partial.to", true},
+		{"evil.com:443", "eu.partial.to:443", false},
+	}
+	for _, tt := range tests {
+		got := HostInCluster(tt.host, tt.cluster)
+		if got != tt.want {
+			t.Errorf("HostInCluster(%q, %q) = %v, want %v", tt.host, tt.cluster, got, tt.want)
+		}
+	}
+}

--- a/internal/entireclient/httpclient/transport.go
+++ b/internal/entireclient/httpclient/transport.go
@@ -1,0 +1,53 @@
+// Package httpclient builds *http.Transport instances shared by Entire's
+// client binaries (git-remote-entire, entiredb, entire-deploy). Centralizing
+// transport construction means one place to honor cross-cutting knobs like
+// ENTIRE_CONNECT_TIMEOUT_SECONDS — without forcing callers through a single
+// *http.Client constructor, since they legitimately differ in CheckRedirect,
+// per-client Timeout, and request-level wrapping.
+package httpclient
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+// DefaultDialTimeout is the per-host TCP connect timeout. Short by default
+// so failover paths skip dead nodes quickly; override via
+// ENTIRE_CONNECT_TIMEOUT_SECONDS on slow links where the dial trips before
+// the node can answer.
+const DefaultDialTimeout = 500 * time.Millisecond
+
+// DialTimeout returns the configured dial timeout, honoring
+// ENTIRE_CONNECT_TIMEOUT_SECONDS. Invalid values fall back to
+// DefaultDialTimeout with a warning to stderr.
+func DialTimeout() time.Duration {
+	v := os.Getenv("ENTIRE_CONNECT_TIMEOUT_SECONDS")
+	if v == "" {
+		return DefaultDialTimeout
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs <= 0 {
+		fmt.Fprintf(os.Stderr, "httpclient: ignoring invalid ENTIRE_CONNECT_TIMEOUT_SECONDS=%q, using default %s\n", v, DefaultDialTimeout)
+		return DefaultDialTimeout
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// NewTransport builds an *http.Transport with the configured dial timeout
+// and a baseline TLS config. Callers wrap the returned transport with their
+// own RoundTripper as needed (e.g. debug logging) and assemble their own
+// *http.Client around it.
+func NewTransport(skipTLSVerify bool) *http.Transport {
+	return &http.Transport{
+		DialContext: (&net.Dialer{Timeout: DialTimeout()}).DialContext,
+		TLSClientConfig: &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: skipTLSVerify, //nolint:gosec // intentional for local development
+		},
+	}
+}

--- a/internal/entireclient/httpclient/transport_test.go
+++ b/internal/entireclient/httpclient/transport_test.go
@@ -1,0 +1,30 @@
+package httpclient
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDialTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset uses default", "", DefaultDialTimeout},
+		{"valid seconds", "10", 10 * time.Second},
+		{"single second", "1", 1 * time.Second},
+		{"non-integer falls back", "abc", DefaultDialTimeout},
+		{"zero falls back", "0", DefaultDialTimeout},
+		{"negative falls back", "-5", DefaultDialTimeout},
+		{"empty string falls back", "", DefaultDialTimeout},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ENTIRE_CONNECT_TIMEOUT_SECONDS", tc.env)
+			if got := DialTimeout(); got != tc.want {
+				t.Fatalf("DialTimeout()=%s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/entireclient/httputil/oauth.go
+++ b/internal/entireclient/httputil/oauth.go
@@ -1,0 +1,131 @@
+package httputil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// RFC 8693 grant + token-type URNs. Re-export the literals so callers
+// composing /oauth/token forms don't keep parallel copies. Lifted out
+// of core/repoadmin and core/api during COR-337 cleanup.
+const (
+	GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // G101: an OAuth grant_type URN, not a credential
+	TokenTypeAccessToken   = "urn:ietf:params:oauth:token-type:access_token"   //nolint:gosec // G101: an RFC 8693 token-type URN, not a credential
+)
+
+// BufferRequestBody reads the request body once so a fallback retry
+// can replay it. http.NoBody (and nil) short-circuits — both signal
+// "no body" but only the latter is a runtime nil, so the explicit
+// identity check keeps the cloned request's Content-Length correct on
+// the wire. Returns (nil, nil) for no-body requests; the caller can
+// safely forward without replay state.
+func BufferRequestBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil, nil
+	}
+	b, err := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("buffer request body: %w", err)
+	}
+	return b, nil
+}
+
+// BodyReader wraps a buffered request body so http.Request.Body /
+// GetBody can replay it across a retry. Pair with BufferRequestBody.
+func BodyReader(body []byte) io.ReadCloser {
+	return io.NopCloser(bytes.NewReader(body))
+}
+
+// cloneValuesWithoutClient returns a shallow copy of v with the
+// client_id and client_secret keys removed. Used so we can lift them
+// into Basic auth without mutating the caller's form.
+func cloneValuesWithoutClient(v url.Values) url.Values {
+	out := make(url.Values, len(v))
+	for k, vs := range v {
+		if k == "client_id" || k == "client_secret" {
+			continue
+		}
+		out[k] = vs
+	}
+	return out
+}
+
+// OAuthError is returned by PostOAuthToken when the OAuth endpoint
+// responds with a non-2xx status. Callers can errors.As it to surface
+// status-specific UX (e.g. a friendly 403 message).
+type OAuthError struct {
+	Status int
+	Body   string
+}
+
+func (e *OAuthError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.Status, e.Body)
+}
+
+// PostOAuthToken posts a form-encoded request to coreURL+"/oauth/token"
+// and parses the standard {access_token, expires_in} response. Callers
+// build the form (grant_type, subject_token, audience, etc.) so the
+// helper stays neutral about which OAuth grant is being exercised.
+//
+// If the form carries client_id (and optionally client_secret), the
+// helper lifts both into an HTTP Basic Authorization header and drops
+// them from the form body. zitadel/oidc's token endpoint reads client
+// credentials only from Basic auth, so form-only client_id produces
+// invalid_client even when the form is otherwise well-formed. Both values
+// are url.QueryEscaped per RFC 6749 §2.3.1 because pkg/op QueryUnescapes
+// them on the other side — a raw '+'/'%xx' would round-trip to a different
+// value and fail invalid_client (matches core/api/token_endpoint.go).
+//
+// coreURL must already be trimmed of any trailing slash. A non-2xx
+// response is surfaced as *OAuthError; transport and decode failures
+// are wrapped plain errors.
+func PostOAuthToken(ctx context.Context, httpClient *http.Client, coreURL string, form url.Values) (accessToken string, expiresIn int, err error) {
+	clientID := form.Get("client_id")
+	clientSecret := form.Get("client_secret")
+	if clientID != "" {
+		form = cloneValuesWithoutClient(form)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		coreURL+"/oauth/token", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", 0, fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if clientID != "" {
+		// RFC 6749 §2.3.1: percent-encode before Basic so pkg/op's
+		// QueryUnescape recovers the original (matches token_endpoint.go).
+		req.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024)) //nolint:errcheck // best-effort body read for error message
+		return "", 0, &OAuthError{Status: resp.StatusCode, Body: strings.TrimSpace(string(msg))}
+	}
+
+	var out struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", 0, fmt.Errorf("decode token response: %w", err)
+	}
+	if out.AccessToken == "" {
+		return "", 0, errors.New("token response missing access_token")
+	}
+	return out.AccessToken, out.ExpiresIn, nil
+}

--- a/internal/entireclient/httputil/oauth_test.go
+++ b/internal/entireclient/httputil/oauth_test.go
@@ -1,0 +1,52 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostOAuthToken_LiftsAndPercentEncodesClientCreds pins that a form
+// client_id/secret is lifted into Basic, dropped from the body, and
+// url.QueryEscaped per RFC 6749 §2.3.1 — so pkg/op's QueryUnescape on the
+// other side recovers the original. A raw '+'/'%xx' would otherwise round-trip
+// to a different value and fail invalid_client. Matches token_endpoint.go.
+func TestPostOAuthToken_LiftsAndPercentEncodesClientCreds(t *testing.T) {
+	var gotUser, gotPass string
+	var gotForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotPass, _ = r.BasicAuth()
+		_ = r.ParseForm() //nolint:errcheck // test stub
+		gotForm = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok","expires_in":900}`)) //nolint:errcheck // test stub
+	}))
+	defer srv.Close()
+
+	form := url.Values{}
+	form.Set("grant_type", GrantTypeTokenExchange)
+	form.Set("client_id", "cli+id")
+	form.Set("client_secret", "se+cr%et")
+
+	tok, exp, err := PostOAuthToken(context.Background(), srv.Client(), srv.URL, form)
+	require.NoError(t, err)
+	assert.Equal(t, "tok", tok)
+	assert.Equal(t, 900, exp)
+
+	// r.BasicAuth base64-decodes but does not unescape; QueryUnescape mirrors
+	// what pkg/op does next and must recover the originals.
+	gotID, err := url.QueryUnescape(gotUser)
+	require.NoError(t, err)
+	gotSecret, err := url.QueryUnescape(gotPass)
+	require.NoError(t, err)
+	assert.Equal(t, "cli+id", gotID, "client_id must round-trip through QueryEscape→base64→QueryUnescape")
+	assert.Equal(t, "se+cr%et", gotSecret, "client_secret must round-trip too")
+
+	assert.Empty(t, gotForm.Get("client_id"), "client_id must be dropped from the body once lifted into Basic")
+	assert.Empty(t, gotForm.Get("client_secret"), "client_secret must be dropped from the body")
+}

--- a/internal/entireclient/repocreds/repocreds.go
+++ b/internal/entireclient/repocreds/repocreds.go
@@ -1,0 +1,187 @@
+// Package repocreds exchanges a logged-in user's login JWT for short-lived
+// repo-scoped JWTs (TokenScopedJWT) and caches them per (audience, action).
+//
+// Used by client/client.go to authenticate per-repo /api/v1/repos/... calls
+// against entire-server, and by cmd/git-remote-entire to authenticate git
+// smart-HTTP push/pull. Both surfaces share the same RFC 8693 token-exchange
+// endpoint (POST /oauth/token on entire-core) but pass different audience
+// shapes — by-ULID (/git/repo/<ULID>) for client.go, by-slug
+// (/et/<owner>/<repo>) for git-remote-entire — so the Cache is neutral on
+// the audience format: callers compute audienceSuffix themselves and the
+// cache keys on it.
+package repocreds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/entireio/cli/internal/entireclient/httputil"
+)
+
+// SafetyMargin is subtracted from the server's expires_in so callers rotate
+// before actual expiry. One minute covers clock skew and gives slow downstream
+// RPCs a fresh token. Matches admincreds.safetyMargin so the two cred caches
+// don't diverge on freshness semantics.
+const SafetyMargin = time.Minute
+
+// oauthClientID is the public OAuth client_id the CLI identifies as on
+// /oauth/token. Lifted into Basic auth by httputil.PostOAuthToken.
+const oauthClientID = "entire-cli"
+
+// LoginJWTProvider returns the current login JWT. Callers wire this to their
+// own refresh logic (e.g. proactive refresh, 401 retry) so the Cache always
+// exchanges with the live parent token, never a captured-then-stale copy.
+type LoginJWTProvider func(ctx context.Context) (string, error)
+
+// Cache holds repo-scoped JWTs minted by exchanging a login JWT at entire-core's
+// /oauth/token endpoint. Keyed by (audienceSuffix, action) so a single Cache
+// can hold tokens for many repos and both pull/push at once.
+//
+// The map mutex (mu) is held only long enough to find-or-create a per-key
+// entry; the network exchange runs under the entry's own mutex. This lets
+// exchanges for different keys proceed concurrently while still de-duplicating
+// concurrent fetches for the same key.
+type Cache struct {
+	coreURL          string // trimmed, no trailing slash
+	clusterURL       string // trimmed, no trailing slash
+	loginJWTProvider LoginJWTProvider
+	httpClient       *http.Client
+
+	mu      sync.Mutex
+	entries map[key]*entry
+}
+
+type key struct {
+	audienceSuffix string
+	action         string
+}
+
+type entry struct {
+	mu        sync.Mutex // serializes exchange for this key
+	token     string
+	expiresAt time.Time
+}
+
+// New constructs a Cache. coreURL is the issuer URL of the login JWT;
+// clusterURL is the entiredb cluster the resulting JWT will target (audience
+// = clusterURL + audienceSuffix). Trailing slashes are trimmed.
+func New(coreURL, clusterURL string, loginJWTProvider LoginJWTProvider, httpClient *http.Client) *Cache {
+	return &Cache{
+		coreURL:          strings.TrimRight(coreURL, "/"),
+		clusterURL:       strings.TrimRight(clusterURL, "/"),
+		loginJWTProvider: loginJWTProvider,
+		httpClient:       httpClient,
+		entries:          make(map[key]*entry),
+	}
+}
+
+// Token returns a valid repo-scoped JWT for the (audienceSuffix, action)
+// pair, exchanging against /oauth/token if no cached entry exists or the
+// cached one has crossed the safety margin. Concurrent callers serialize on
+// the mutex; a single fetch satisfies all waiters.
+//
+// audienceSuffix is the path portion of the audience claim — e.g.
+// "/git/repo/<ULID>" or "/et/<owner>/<repo>". action is "pull" or "push".
+func (c *Cache) Token(ctx context.Context, audienceSuffix, action string) (string, error) {
+	if audienceSuffix == "" {
+		return "", errors.New("repocreds: empty audienceSuffix")
+	}
+	if action == "" {
+		return "", errors.New("repocreds: empty action")
+	}
+	if c.coreURL == "" {
+		return "", errors.New("repocreds: no entire-core URL configured for STS exchange")
+	}
+
+	e := c.entryFor(audienceSuffix, action)
+
+	// Per-key lock: serializes concurrent fetches for the same key while
+	// leaving other keys free to exchange in parallel. A slow exchange for
+	// repo A no longer blocks a cache hit for repo B.
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.token != "" && time.Now().Before(e.expiresAt) {
+		return e.token, nil
+	}
+
+	token, ttl, err := c.exchange(ctx, audienceSuffix, action)
+	if err != nil {
+		return "", err
+	}
+	if ttl <= 0 {
+		// Already expired on arrival — hand it out once, cache nothing.
+		e.token = ""
+		e.expiresAt = time.Time{}
+		return token, nil
+	}
+	// Rotate before expiry by SafetyMargin, but never reserve more than half
+	// the lifetime: a short-lived token (TTL ≤ SafetyMargin) still gets cached
+	// for the remaining half instead of being re-exchanged on every call.
+	margin := min(SafetyMargin, ttl/2)
+	e.token = token
+	e.expiresAt = time.Now().Add(ttl - margin)
+	return token, nil
+}
+
+// entryFor returns the per-key entry, creating it under the map mutex if
+// absent. The map mutex is held only for this lookup, never across the
+// network exchange.
+func (c *Cache) entryFor(audienceSuffix, action string) *entry {
+	k := key{audienceSuffix: audienceSuffix, action: action}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[k]
+	if !ok {
+		e = &entry{}
+		c.entries[k] = e
+	}
+	return e
+}
+
+// Invalidate drops any cached token for (audienceSuffix, action). Callers
+// invoke this on 401 from the data plane so the next Token call re-mints
+// instead of replaying the rejected one.
+func (c *Cache) Invalidate(audienceSuffix, action string) {
+	c.mu.Lock()
+	e, ok := c.entries[key{audienceSuffix: audienceSuffix, action: action}]
+	c.mu.Unlock()
+	if !ok {
+		return
+	}
+	e.mu.Lock()
+	e.token = ""
+	e.expiresAt = time.Time{}
+	e.mu.Unlock()
+}
+
+// exchange runs a single RFC 8693 token-exchange against /oauth/token. The
+// issued JWT's aud claim is clusterURL+audienceSuffix; the receiver compares
+// against the resolved repo, so this string IS the resource check.
+func (c *Cache) exchange(ctx context.Context, audienceSuffix, action string) (string, time.Duration, error) {
+	loginJWT, err := c.loginJWTProvider(ctx)
+	if err != nil {
+		return "", 0, err
+	}
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	form.Set("subject_token", loginJWT)
+	form.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	form.Set("audience", c.clusterURL+audienceSuffix)
+	form.Set("scope", "repo:"+action)
+	form.Set("client_id", oauthClientID)
+
+	token, expiresIn, err := httputil.PostOAuthToken(ctx, c.httpClient, c.coreURL, form)
+	if err != nil {
+		// %w preserves *httputil.OAuthError so callers can errors.As it.
+		return "", 0, fmt.Errorf("oauth token exchange: %w", err)
+	}
+	return token, time.Duration(expiresIn) * time.Second, nil
+}

--- a/internal/entireclient/repocreds/repocreds_test.go
+++ b/internal/entireclient/repocreds/repocreds_test.go
@@ -1,0 +1,247 @@
+package repocreds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubCore counts exchange calls and returns a fresh access_token per call so
+// tests can tell cache hits from upstream fetches by inspecting the value the
+// Cache hands back. Handler-side validations write to t.Errorf rather than
+// require.* so a failed assertion doesn't FailNow the wrong goroutine.
+type stubCore struct {
+	t         *testing.T
+	calls     atomic.Int64
+	expiresIn time.Duration
+}
+
+func (s *stubCore) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			s.t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/oauth/token" {
+			s.t.Errorf("path = %s, want /oauth/token", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			s.t.Errorf("ParseForm: %v", err)
+		}
+		if got := r.PostForm.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:token-exchange" {
+			s.t.Errorf("grant_type = %s", got)
+		}
+		if r.PostForm.Get("subject_token") == "" {
+			s.t.Errorf("subject_token empty")
+		}
+		if r.PostForm.Get("audience") == "" {
+			s.t.Errorf("audience empty")
+		}
+
+		n := s.calls.Add(1)
+		expires := s.expiresIn
+		if expires == 0 {
+			expires = 10 * time.Minute
+		}
+		body, err := json.Marshal(map[string]any{
+			"access_token": fmt.Sprintf("scoped-token-%d", n),
+			"expires_in":   int(expires.Seconds()),
+			"token_type":   "Bearer",
+		})
+		if err != nil {
+			s.t.Errorf("marshal: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body) //nolint:errcheck // best-effort in test stub
+	})
+}
+
+func newTestCache(t *testing.T, core *stubCore) *Cache {
+	t.Helper()
+	core.t = t
+	srv := httptest.NewServer(core.handler())
+	t.Cleanup(srv.Close)
+	provider := func(context.Context) (string, error) { return "login-jwt", nil }
+	return New(srv.URL, "https://cluster.example.com", provider, srv.Client())
+}
+
+func TestCache_MintsOnce_Reuses(t *testing.T) {
+	core := &stubCore{}
+	cache := newTestCache(t, core)
+
+	t1, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+	assert.Equal(t, "scoped-token-1", t1)
+
+	t2, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+	assert.Equal(t, "scoped-token-1", t2)
+
+	assert.EqualValues(t, 1, core.calls.Load())
+}
+
+func TestCache_DistinctKeys(t *testing.T) {
+	core := &stubCore{}
+	cache := newTestCache(t, core)
+
+	pullTok, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+	pushTok, err := cache.Token(t.Context(), "/git/repo/ulid1", "push")
+	require.NoError(t, err)
+	otherRepoTok, err := cache.Token(t.Context(), "/git/repo/ulid2", "pull")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, pullTok, pushTok)
+	assert.NotEqual(t, pullTok, otherRepoTok)
+	assert.NotEqual(t, pushTok, otherRepoTok)
+	assert.EqualValues(t, 3, core.calls.Load())
+}
+
+func TestCache_RefreshesAfterExpiry(t *testing.T) {
+	// 90s TTL minus 60s safety margin = 30s real cache lifetime. We force
+	// expiry by reaching into the entry and rewinding expiresAt.
+	core := &stubCore{expiresIn: 90 * time.Second}
+	cache := newTestCache(t, core)
+
+	first, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+	assert.Equal(t, "scoped-token-1", first)
+
+	cache.mu.Lock()
+	for _, e := range cache.entries {
+		e.mu.Lock()
+		e.expiresAt = time.Now().Add(-time.Second)
+		e.mu.Unlock()
+	}
+	cache.mu.Unlock()
+
+	second, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+	assert.Equal(t, "scoped-token-2", second)
+	assert.EqualValues(t, 2, core.calls.Load())
+}
+
+func TestCache_ShortTTL_StillCachedForHalfLife(t *testing.T) {
+	// TTL equal to the safety margin: the margin caps at ttl/2 so the token
+	// is still cached for the remaining half rather than re-exchanged on
+	// every call. Back-to-back calls should hit the cache.
+	core := &stubCore{expiresIn: SafetyMargin}
+	cache := newTestCache(t, core)
+
+	_, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+	_, err = cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, core.calls.Load())
+}
+
+func TestCache_NonPositiveTTL_NotCached(t *testing.T) {
+	// A token that arrives already expired (expires_in <= 0) is handed out
+	// once but never cached, so the next call re-exchanges.
+	core := &stubCore{expiresIn: -time.Second}
+	cache := newTestCache(t, core)
+
+	_, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+	_, err = cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 2, core.calls.Load())
+}
+
+func TestCache_Invalidate(t *testing.T) {
+	core := &stubCore{}
+	cache := newTestCache(t, core)
+
+	_, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+	cache.Invalidate("/git/repo/ulid1", "pull")
+	_, err = cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 2, core.calls.Load())
+}
+
+func TestCache_SerializesConcurrent(t *testing.T) {
+	core := &stubCore{}
+	cache := newTestCache(t, core)
+
+	const N = 20
+	var wg sync.WaitGroup
+	wg.Add(N)
+	tokens := make([]string, N)
+	errs := make([]error, N)
+	for i := range N {
+		go func() {
+			defer wg.Done()
+			tokens[i], errs[i] = cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+		}()
+	}
+	wg.Wait()
+
+	// All N callers see the same token; only one upstream exchange happened.
+	for i := range N {
+		require.NoErrorf(t, errs[i], "goroutine %d", i)
+		assert.Equalf(t, "scoped-token-1", tokens[i], "goroutine %d", i)
+	}
+	assert.EqualValues(t, 1, core.calls.Load())
+}
+
+func TestCache_PropagatesLoginProviderError(t *testing.T) {
+	core := &stubCore{t: t}
+	srv := httptest.NewServer(core.handler())
+	t.Cleanup(srv.Close)
+
+	boom := func(context.Context) (string, error) { return "", assert.AnError }
+	cache := New(srv.URL, "https://cluster.example.com", boom, srv.Client())
+
+	_, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.ErrorIs(t, err, assert.AnError)
+	assert.EqualValues(t, 0, core.calls.Load())
+}
+
+func TestCache_RejectsEmptyArgs(t *testing.T) {
+	core := &stubCore{}
+	cache := newTestCache(t, core)
+
+	_, err := cache.Token(t.Context(), "", "pull")
+	require.Error(t, err)
+	_, err = cache.Token(t.Context(), "/git/repo/ulid1", "")
+	require.Error(t, err)
+}
+
+// Defensive smoke test that the audience the cache sends to core is
+// clusterURL+audienceSuffix verbatim, since the audience is the resource
+// check at the receiver.
+func TestCache_BuildsAudience(t *testing.T) {
+	got := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("ParseForm: %v", err)
+		}
+		got <- r.PostForm.Get("audience")
+		_, _ = w.Write([]byte(`{"access_token":"t","expires_in":600}`)) //nolint:errcheck // best-effort in test stub
+	}))
+	t.Cleanup(srv.Close)
+
+	cache := New(srv.URL, "https://cluster.example.com",
+		func(context.Context) (string, error) { return "login-jwt", nil },
+		srv.Client())
+	_, err := cache.Token(t.Context(), "/git/repo/ulid1", "pull")
+	require.NoError(t, err)
+	select {
+	case aud := <-got:
+		assert.Equal(t, "https://cluster.example.com/git/repo/ulid1", aud)
+	case <-time.After(time.Second):
+		t.Fatal("audience not captured")
+	}
+}

--- a/internal/entireclient/tokenstore/expiry.go
+++ b/internal/entireclient/tokenstore/expiry.go
@@ -1,0 +1,50 @@
+package tokenstore
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// TokenExpirationSeparator separates the token from its expiration timestamp.
+// Format: "token|expires_at_unix"
+const TokenExpirationSeparator = "|"
+
+// TokenExpirationBuffer is how long before expiration we should refresh.
+const TokenExpirationBuffer = 5 * time.Minute
+
+// EncodeTokenWithExpiration encodes a token with its expiration time as a
+// "token|expires_at_unix" suffix. Callers must pass a positive expiresIn —
+// the encoded suffix is the contract that tells future readers when to
+// refresh, and a zero/negative TTL would record an immediately-expired
+// token.
+func EncodeTokenWithExpiration(token string, expiresIn int64) string {
+	expiresAt := time.Now().Unix() + expiresIn
+	return fmt.Sprintf("%s%s%d", token, TokenExpirationSeparator, expiresAt)
+}
+
+// DecodeTokenWithExpiration decodes a token that may have an expiration timestamp.
+// Returns the token and expiration time. If no expiration is encoded, returns
+// the token as-is and a zero time.
+func DecodeTokenWithExpiration(encoded string) (token string, expiresAt time.Time) {
+	idx := strings.LastIndex(encoded, TokenExpirationSeparator)
+	if idx == -1 {
+		return encoded, time.Time{}
+	}
+
+	token = encoded[:idx]
+	var expiresAtUnix int64
+	if _, err := fmt.Sscanf(encoded[idx+1:], "%d", &expiresAtUnix); err != nil {
+		return encoded, time.Time{}
+	}
+	return token, time.Unix(expiresAtUnix, 0)
+}
+
+// IsTokenExpiredOrExpiring checks if a token is expired or will expire soon.
+// A zero expiresAt is treated as "unknown, assume expired".
+func IsTokenExpiredOrExpiring(expiresAt time.Time) bool {
+	if expiresAt.IsZero() {
+		return true
+	}
+	return time.Now().Add(TokenExpirationBuffer).After(expiresAt)
+}

--- a/internal/entireclient/tokenstore/expiry_test.go
+++ b/internal/entireclient/tokenstore/expiry_test.go
@@ -1,0 +1,130 @@
+package tokenstore
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEncodeDecodeTokenWithExpiration(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     string
+		expiresIn int64
+	}{
+		{
+			name:      "normal token",
+			token:     "entr_abc123xyz",
+			expiresIn: 3600, // 1 hour
+		},
+		{
+			name:      "token with special characters",
+			token:     "entr_abc+123/xyz==",
+			expiresIn: 7200,
+		},
+		{
+			name:      "short expiration",
+			token:     "entr_test",
+			expiresIn: 60,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := time.Now().Truncate(time.Second)
+			encoded := EncodeTokenWithExpiration(tt.token, tt.expiresIn)
+			after := time.Now().Truncate(time.Second).Add(time.Second)
+
+			decodedToken, expiresAt := DecodeTokenWithExpiration(encoded)
+
+			if decodedToken != tt.token {
+				t.Errorf("token mismatch: got %q, want %q", decodedToken, tt.token)
+			}
+
+			expectedMin := before.Add(time.Duration(tt.expiresIn) * time.Second)
+			expectedMax := after.Add(time.Duration(tt.expiresIn) * time.Second)
+
+			if expiresAt.Before(expectedMin) || expiresAt.After(expectedMax) {
+				t.Errorf("expiresAt %v not in expected range [%v, %v]", expiresAt, expectedMin, expectedMax)
+			}
+		})
+	}
+}
+
+func TestDecodeTokenWithExpiration_LegacyFormat(t *testing.T) {
+	// A token written before the |expiration suffix was introduced — no
+	// pipe, no Unix timestamp. Decoder must round-trip it unchanged with
+	// a zero expiresAt so the refresh layer treats it as already-expired.
+	legacyToken := "entr_token_without_expiration"
+
+	token, expiresAt := DecodeTokenWithExpiration(legacyToken)
+
+	if token != legacyToken {
+		t.Errorf("token mismatch: got %q, want %q", token, legacyToken)
+	}
+
+	if !expiresAt.IsZero() {
+		t.Errorf("expiresAt should be zero for legacy tokens, got %v", expiresAt)
+	}
+}
+
+func TestDecodeTokenWithExpiration_InvalidFormat(t *testing.T) {
+	invalidToken := "entr_token|not_a_number"
+
+	token, expiresAt := DecodeTokenWithExpiration(invalidToken)
+
+	if token != invalidToken {
+		t.Errorf("token mismatch: got %q, want %q", token, invalidToken)
+	}
+
+	if !expiresAt.IsZero() {
+		t.Errorf("expiresAt should be zero for invalid format, got %v", expiresAt)
+	}
+}
+
+func TestIsTokenExpiredOrExpiring(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      bool
+	}{
+		{
+			name:      "zero time (legacy token)",
+			expiresAt: time.Time{},
+			want:      true,
+		},
+		{
+			name:      "already expired",
+			expiresAt: time.Now().Add(-1 * time.Hour),
+			want:      true,
+		},
+		{
+			name:      "expiring within buffer (4 minutes left)",
+			expiresAt: time.Now().Add(4 * time.Minute),
+			want:      true,
+		},
+		{
+			name:      "expiring at buffer edge (5 minutes left)",
+			expiresAt: time.Now().Add(5 * time.Minute),
+			want:      true,
+		},
+		{
+			name:      "not expiring soon (6 minutes left)",
+			expiresAt: time.Now().Add(6 * time.Minute),
+			want:      false,
+		},
+		{
+			name:      "plenty of time (1 hour left)",
+			expiresAt: time.Now().Add(1 * time.Hour),
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsTokenExpiredOrExpiring(tt.expiresAt)
+			if got != tt.want {
+				t.Errorf("IsTokenExpiredOrExpiring(%v) = %v, want %v", tt.expiresAt, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/entireclient/tokenstore/file.go
+++ b/internal/entireclient/tokenstore/file.go
@@ -1,0 +1,171 @@
+package tokenstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+// fileStore persists credentials as a JSON file on disk.
+// The file format is: { "service": { "user": "password" } }
+type fileStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+// withFileLock runs fn while holding an exclusive flock on f.path + ".lock".
+// The lock coordinates across processes; the in-process mu handles goroutines.
+func (f *fileStore) withFileLock(fn func() error) error {
+	if err := os.MkdirAll(filepath.Dir(f.path), 0700); err != nil {
+		return fmt.Errorf("creating token store directory: %w", err)
+	}
+
+	fl := flock.New(f.path + ".lock")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	locked, err := fl.TryLockContext(ctx, 50*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("acquiring token store lock: %w", err)
+	}
+	if !locked {
+		return errors.New("timeout acquiring token store lock")
+	}
+	defer func() {
+		// Unlock errors are logged but don't fail the operation.
+		if unlockErr := fl.Unlock(); unlockErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to unlock token store: %v\n", unlockErr)
+		}
+	}()
+
+	return fn()
+}
+
+func (f *fileStore) load() (map[string]map[string]string, error) {
+	data, err := os.ReadFile(f.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]map[string]string), nil
+		}
+		return nil, fmt.Errorf("reading token store: %w", err)
+	}
+	var store map[string]map[string]string
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, fmt.Errorf("parsing token store: %w", err)
+	}
+	return store, nil
+}
+
+// save writes the store atomically via temp file + rename so a concurrent
+// reader never sees a partial JSON document.
+func (f *fileStore) save(store map[string]map[string]string) error {
+	data, err := json.Marshal(store)
+	if err != nil {
+		return fmt.Errorf("marshaling token store: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(f.path), ".tokens-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp token store: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Clean up the temp file on any error path.
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing temp token store: %w", err)
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp token store: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp token store: %w", err)
+	}
+	if err := os.Rename(tmpName, f.path); err != nil {
+		return fmt.Errorf("renaming token store: %w", err)
+	}
+	return nil
+}
+
+func (f *fileStore) Get(service, user string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var result string
+	var resultErr error
+	err := f.withFileLock(func() error {
+		store, err := f.load()
+		if err != nil {
+			return err
+		}
+		if users, ok := store[service]; ok {
+			if pass, ok := users[user]; ok {
+				result = pass
+				return nil
+			}
+		}
+		resultErr = ErrNotFound
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return result, resultErr
+}
+
+func (f *fileStore) Set(service, user, password string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.withFileLock(func() error {
+		store, err := f.load()
+		if err != nil {
+			return err
+		}
+		if store[service] == nil {
+			store[service] = make(map[string]string)
+		}
+		store[service][user] = password
+		return f.save(store)
+	})
+}
+
+func (f *fileStore) Delete(service, user string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var notFound bool
+	err := f.withFileLock(func() error {
+		store, err := f.load()
+		if err != nil {
+			return err
+		}
+		users, ok := store[service]
+		if !ok {
+			notFound = true
+			return nil
+		}
+		if _, ok := users[user]; !ok {
+			notFound = true
+			return nil
+		}
+		delete(users, user)
+		if len(users) == 0 {
+			delete(store, service)
+		}
+		return f.save(store)
+	})
+	if err != nil {
+		return err
+	}
+	if notFound {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/entireclient/tokenstore/file_test.go
+++ b/internal/entireclient/tokenstore/file_test.go
@@ -1,0 +1,239 @@
+package tokenstore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestStore(t *testing.T) *fileStore {
+	t.Helper()
+	return &fileStore{path: filepath.Join(t.TempDir(), "tokens.json")}
+}
+
+func TestFileStore_GetMissingFile(t *testing.T) {
+	s := newTestStore(t)
+	_, err := s.Get("svc", "user")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFileStore_SetAndGet(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get("svc", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "secret" {
+		t.Fatalf("got %q, want %q", got, "secret")
+	}
+}
+
+func TestFileStore_GetWrongService(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := s.Get("other", "alice")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFileStore_GetWrongUser(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := s.Get("svc", "bob")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFileStore_Overwrite(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc", "alice", "old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set("svc", "alice", "new"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get("svc", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "new" {
+		t.Fatalf("got %q, want %q", got, "new")
+	}
+}
+
+func TestFileStore_MultipleServices(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc1", "alice", "pw1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set("svc2", "bob", "pw2"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get("svc1", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "pw1" {
+		t.Fatalf("got %q, want %q", got, "pw1")
+	}
+
+	got, err = s.Get("svc2", "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "pw2" {
+		t.Fatalf("got %q, want %q", got, "pw2")
+	}
+}
+
+func TestFileStore_Delete(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("svc", "alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := s.Get("svc", "alice")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFileStore_DeleteCleansEmptyService(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("svc", "alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-read the file to confirm the service key is gone entirely.
+	store, err := s.load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store["svc"]; ok {
+		t.Fatal("expected service key to be removed when last user is deleted")
+	}
+}
+
+func TestFileStore_DeletePreservesOtherUsers(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc", "alice", "pw1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set("svc", "bob", "pw2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete("svc", "alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get("svc", "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "pw2" {
+		t.Fatalf("got %q, want %q", got, "pw2")
+	}
+}
+
+func TestFileStore_DeleteNotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	err := s.Delete("svc", "alice")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFileStore_DeleteNotFoundUser(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := s.Delete("svc", "bob")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestFileStore_LoadCorruptFile(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s.path, []byte("not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := s.Get("svc", "user")
+	if err == nil {
+		t.Fatal("expected error for corrupt file")
+	}
+}
+
+func TestFileStore_CreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	s := &fileStore{path: filepath.Join(dir, "tokens.json")}
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get("svc", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "secret" {
+		t.Fatalf("got %q, want %q", got, "secret")
+	}
+}
+
+func TestFileStore_FilePermissions(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.Set("svc", "alice", "secret"); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(s.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0600 {
+		t.Fatalf("file permissions = %o, want 0600", perm)
+	}
+}

--- a/internal/entireclient/tokenstore/testing.go
+++ b/internal/entireclient/tokenstore/testing.go
@@ -1,0 +1,26 @@
+package tokenstore
+
+// UseFileBackendForTesting points the package-level token store at a
+// per-test JSON file and returns a cleanup function that restores the
+// previous backend (re-resolving on next use). It serializes against
+// concurrent Get/Set/Delete calls via the same mutex they use, so it is
+// safe to call from any test even if other goroutines are mid-call.
+//
+// Each call replaces the active backend; tests that invoke this from
+// parallel subtests will trample each other and should arrange their own
+// per-subtest paths if they actually need isolation.
+func UseFileBackendForTesting(path string) func() {
+	backendMu.Lock()
+	prevBackend := backend
+	prevResolved := resolved
+	backend = &fileStore{path: path}
+	resolved = true
+	backendMu.Unlock()
+
+	return func() {
+		backendMu.Lock()
+		backend = prevBackend
+		resolved = prevResolved
+		backendMu.Unlock()
+	}
+}

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -1,0 +1,139 @@
+// Package tokenstore provides a pluggable credential store shared by the
+// entiredb and entire-core CLIs.
+//
+// By default it delegates to the OS keyring (macOS Keychain, Linux Secret
+// Service, etc.). Set ENTIRE_TOKEN_STORE=file to use a JSON file instead,
+// which is useful in CI environments that lack a keyring daemon.
+//
+// When using the file backend the tokens are stored in
+// $ENTIRE_TOKEN_STORE_PATH (default: ~/.config/entire/tokens.json).
+//
+// Service-name conventions:
+//   - "entire:<cluster-host>"        — entiredb cluster login tokens
+//   - "entire-core:<core-base-url>"  — entire-core control-plane tokens
+//   - "<service>:refresh"            — refresh-token entry paired with the
+//     corresponding access-token service
+package tokenstore
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/zalando/go-keyring"
+)
+
+// ErrNotFound is returned when a credential is not present in the store.
+var ErrNotFound = keyring.ErrNotFound
+
+// Keyring service-name prefixes. Tokens are filed under whichever issuer
+// vouched for them, so a JWT obtained via an entire-core login flow lives
+// at "entire-core:<base-url>" regardless of which CLI wrote it. Two CLIs
+// sharing this prefix on the same machine read each other's writes.
+const (
+	ClusterKeyringPrefix = "entire:"      // entiredb cluster-issued tokens
+	CoreKeyringPrefix    = "entire-core:" // entire-core control-plane tokens
+)
+
+// ClusterKeyringService returns the service name for tokens issued by an
+// entiredb cluster. host is typically the cluster's entry domain.
+func ClusterKeyringService(host string) string {
+	return ClusterKeyringPrefix + host
+}
+
+// CoreKeyringService returns the service name for tokens issued by
+// entire-core. coreURL is the base URL of the issuer; trailing slashes
+// are normalized away so callers don't have to.
+func CoreKeyringService(coreURL string) string {
+	return CoreKeyringPrefix + strings.TrimRight(coreURL, "/")
+}
+
+// KeyringServiceForIssuerKey infers the right service prefix from a
+// raw issuer key (entire-core URL or entiredb cluster host). URL-shaped
+// keys (anything beginning with a scheme) are treated as entire-core
+// issuers; bare hostnames as cluster issuers. Used by callers that
+// derive a service name without already having a *contexts.Context in
+// hand (tests, entiredb's pre-resolution code paths).
+func KeyringServiceForIssuerKey(key string) string {
+	if strings.HasPrefix(key, "http://") || strings.HasPrefix(key, "https://") {
+		return CoreKeyringService(key)
+	}
+	return ClusterKeyringService(key)
+}
+
+// backendMu guards `resolved` and `backend`. It serializes the production
+// resolve() against the test-only override path (UseFileBackendForTesting),
+// so the package-level state stays well-defined even when tests reset it.
+var (
+	backendMu sync.Mutex
+	resolved  bool
+	backend   store
+)
+
+type store interface {
+	Get(service, user string) (string, error)
+	Set(service, user, password string) error
+	Delete(service, user string) error
+}
+
+func currentBackend() store { //nolint:ireturn // pluggable keyring backend; the interface return is the seam for the file-backed test store
+	backendMu.Lock()
+	defer backendMu.Unlock()
+	if !resolved {
+		backend = resolveBackendLocked()
+		resolved = true
+	}
+	return backend
+}
+
+func resolveBackendLocked() store { //nolint:ireturn // see currentBackend: the interface return is the test-store seam
+	if os.Getenv("ENTIRE_TOKEN_STORE") == "file" {
+		path := os.Getenv("ENTIRE_TOKEN_STORE_PATH")
+		if path == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				panic(fmt.Sprintf("tokenstore: cannot determine home directory: %v", err))
+			}
+			path = home + "/.config/entire/tokens.json"
+		}
+		return &fileStore{path: path}
+	}
+	return keyringStore{}
+}
+
+// Get retrieves a credential.
+func Get(service, user string) (string, error) {
+	//nolint:wrapcheck // thin wrapper, callers handle errors
+	return currentBackend().Get(service, user)
+}
+
+// Set stores a credential.
+func Set(service, user, password string) error {
+	//nolint:wrapcheck // thin wrapper, callers handle errors
+	return currentBackend().Set(service, user, password)
+}
+
+// Delete removes a credential.
+func Delete(service, user string) error {
+	//nolint:wrapcheck // thin wrapper, callers handle errors
+	return currentBackend().Delete(service, user)
+}
+
+// keyringStore delegates to the OS keyring.
+type keyringStore struct{}
+
+func (keyringStore) Get(service, user string) (string, error) {
+	//nolint:wrapcheck // thin wrapper, callers handle errors
+	return keyring.Get(service, user)
+}
+
+func (keyringStore) Set(service, user, password string) error {
+	//nolint:wrapcheck // thin wrapper, callers handle errors
+	return keyring.Set(service, user, password)
+}
+
+func (keyringStore) Delete(service, user string) error {
+	//nolint:wrapcheck // thin wrapper, callers handle errors
+	return keyring.Delete(service, user)
+}

--- a/internal/remotehelper/debuglog/debuglog.go
+++ b/internal/remotehelper/debuglog/debuglog.go
@@ -1,0 +1,61 @@
+// Package debuglog is the git-remote-entire helper's shared debug logger.
+//
+// Output is gated on ENTIRE_DEBUG: when unset, Printf is a no-op (and
+// Enabled returns false so callers can skip work that only matters for a
+// debug trace, e.g. dumping HTTP request bodies).
+//
+// The prefix is fixed because the binary that uses these internals is also
+// fixed — the package lives under internal/, so its callers are known.
+package debuglog
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+const (
+	envVar = "ENTIRE_DEBUG"
+	prefix = "[git-remote-entire]"
+)
+
+// outMu protects out. A mutex (over atomic.Value) is fine here because
+// debug logging is gated by ENTIRE_DEBUG — production performance never
+// touches it, and tests serialize their own SetOutput swaps.
+var (
+	outMu sync.RWMutex
+	out   io.Writer = os.Stderr
+)
+
+// Enabled reports whether debug output is on. Callers should gate any
+// expensive preparation (request dumps, body buffering) behind this.
+func Enabled() bool { return os.Getenv(envVar) != "" }
+
+// Printf writes a line to stderr (or the configured sink) when Enabled,
+// prefixed with [git-remote-entire]. A trailing newline is appended.
+func Printf(format string, args ...any) {
+	if !Enabled() {
+		return
+	}
+	outMu.RLock()
+	w := out
+	outMu.RUnlock()
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, prefix+" "+format+"\n", args...)
+}
+
+// SetOutput redirects debug output. Returns the previous writer so tests
+// can restore it. Pass nil to discard.
+func SetOutput(w io.Writer) io.Writer {
+	if w == nil {
+		w = io.Discard
+	}
+	outMu.Lock()
+	prev := out
+	out = w
+	outMu.Unlock()
+	return prev
+}

--- a/internal/remotehelper/debuglog/debuglog_test.go
+++ b/internal/remotehelper/debuglog/debuglog_test.go
@@ -1,0 +1,39 @@
+package debuglog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestPrintfRespectsEnvVar(t *testing.T) {
+	var buf bytes.Buffer
+	prev := SetOutput(&buf)
+	t.Cleanup(func() { SetOutput(prev) })
+
+	t.Setenv(envVar, "")
+	Printf("hidden %s", "msg")
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output when %s unset, got %q", envVar, buf.String())
+	}
+
+	t.Setenv(envVar, "1")
+	Printf("visible %s", "msg")
+	if !strings.Contains(buf.String(), "visible msg") {
+		t.Fatalf("expected message in output, got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), prefix) {
+		t.Fatalf("expected prefix %q in output, got %q", prefix, buf.String())
+	}
+}
+
+func TestEnabledTracksEnv(t *testing.T) {
+	t.Setenv(envVar, "")
+	if Enabled() {
+		t.Fatalf("Enabled() = true with %s unset", envVar)
+	}
+	t.Setenv(envVar, "true")
+	if !Enabled() {
+		t.Fatalf("Enabled() = false with %s set", envVar)
+	}
+}

--- a/internal/remotehelper/githelper/agent.go
+++ b/internal/remotehelper/githelper/agent.go
@@ -1,0 +1,8 @@
+package githelper
+
+// Agent is the git agent identifier the helper appends to upload-pack,
+// receive-pack, and v2 requests so the server can attribute traffic to
+// the remote helper. The CLI entrypoint overwrites it at startup with a
+// build-stamped value (see cmd/entire); the default keeps tests and
+// standalone use working without that wiring.
+var Agent = "git-remote-entire/dev"

--- a/internal/remotehelper/githelper/connect.go
+++ b/internal/remotehelper/githelper/connect.go
@@ -91,10 +91,20 @@ func handleConnect(ctx context.Context, t Transport, service string, stdin io.Re
 // terminates on the first common ancestor instead of walking the
 // entire rev queue. When git sends done, a final POST with the
 // accumulated wants + haves + done streams the pack response.
+//
+// Shallow fetches add a probe round: if the wants section contains a
+// `deepen…` line, canonical git parks waiting for the server's
+// shallow/unshallow update before writing any haves. We fire an extra
+// POST on the wants-flush carrying only the buffered wants, stream the
+// shallow-update response to git, then resume the normal have/done
+// flow. The wants buffer is preserved (every subsequent stateless-RPC
+// round must repeat the wants block including the deepen lines, or the
+// server treats the request as non-shallow).
 func handleFetch(ctx context.Context, t Transport, stdin io.Reader, stdout io.Writer) error {
 	var wantsBuf, havesBuf bytes.Buffer
 	lenBuf := make([]byte, pktline.LenSize)
 	pastWants := false
+	deepenSeen := false
 	roundNumber := 0
 
 	for {
@@ -122,12 +132,17 @@ func handleFetch(ctx context.Context, t Transport, stdin io.Reader, stdout io.Wr
 				wantsBuf.Write(lenBuf)
 				pastWants = true
 				debuglog.Printf("end of wants (%d bytes)", wantsBuf.Len())
+				if deepenSeen {
+					if err := postShallowProbe(ctx, t, stdout, &wantsBuf); err != nil {
+						return err
+					}
+				}
 				continue
 			}
 			// End of a have batch. POST wants + cumulative haves +
 			// terminating flush so the server can compute ACKs.
 			roundNumber++
-			if err := postRound(ctx, t, stdout, &wantsBuf, &havesBuf, false, roundNumber); err != nil {
+			if err := postRound(ctx, t, stdout, &wantsBuf, &havesBuf, false, deepenSeen, roundNumber); err != nil {
 				return err
 			}
 			continue
@@ -150,6 +165,16 @@ func handleFetch(ctx context.Context, t Transport, stdin io.Reader, stdout io.Wr
 			return fmt.Errorf("reading pkt-line content: %w", err)
 		}
 
+		// `deepen`, `deepen-since`, `deepen-not` in the wants section
+		// arm the probe POST on the upcoming wants-flush. `shallow X`
+		// from the client is purely informational (client telling the
+		// server about its existing shallow boundary) and does NOT
+		// trigger a server shallow-update unless paired with deepen,
+		// so it doesn't need a probe round.
+		if !pastWants && bytes.HasPrefix(content, []byte("deepen")) {
+			deepenSeen = true
+		}
+
 		dest := &wantsBuf
 		if pastWants {
 			dest = &havesBuf
@@ -161,9 +186,35 @@ func handleFetch(ctx context.Context, t Transport, stdin io.Reader, stdout io.Wr
 			// Final round: server returns ACK/NAK + pack data.
 			roundNumber++
 			debuglog.Printf("done line received, sending final request (round %d)", roundNumber)
-			return postRound(ctx, t, stdout, &wantsBuf, &havesBuf, true, roundNumber)
+			return postRound(ctx, t, stdout, &wantsBuf, &havesBuf, true, deepenSeen, roundNumber)
 		}
 	}
+}
+
+// postShallowProbe issues the shallow-update probe POST that canonical
+// git in connect mode is waiting for after writing `wants + deepen +
+// flush`. The body is exactly the buffered wants (already terminated
+// by the wants-flush); the server response is `shallow…/unshallow…
+// + flush` and is streamed verbatim to git's stdout. No synthetic NAK
+// is appended — unlike intermediate have-batch rounds, the probe
+// response IS the round terminator (its trailing flush) that git is
+// waiting for, and appending NAK would confuse the client into
+// thinking negotiation has already happened.
+func postShallowProbe(ctx context.Context, t Transport, stdout io.Writer, wantsBuf *bytes.Buffer) error {
+	body, err := gitproto.AppendAgentToUploadPackRequest(append([]byte(nil), wantsBuf.Bytes()...), Agent)
+	if err != nil {
+		return fmt.Errorf("amending upload-pack agent: %w", err)
+	}
+	debuglog.Printf("posting shallow-update probe: %d bytes", len(body))
+	resp, err := t.ServiceRPC(ctx, serviceUploadPack, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("shallow-update probe POST: %w", err)
+	}
+	defer resp.Close()
+	if _, err := io.Copy(stdout, resp); err != nil {
+		return fmt.Errorf("streaming shallow-update response: %w", err)
+	}
+	return nil
 }
 
 // postRound assembles one stateless-RPC request body from the
@@ -172,7 +223,16 @@ func handleFetch(ctx context.Context, t Transport, stdin io.Reader, stdout io.Wr
 // synthesize a trailing NAK pktline so canonical git in connect
 // (stateful) mode doesn't hang waiting for the round-end marker that
 // the HTTP wire drops implicitly.
-func postRound(ctx context.Context, t Transport, stdout io.Writer, wantsBuf, havesBuf *bytes.Buffer, final bool, roundNumber int) error {
+//
+// When stripShallow is true, the helper consumes the duplicate
+// shallow/unshallow + flush prefix the server emits on every round
+// that carries deepen in its body (HTTP stateless-RPC processes each
+// POST independently — every response begins with the boundary
+// section). Canonical git in connect mode only consumes the FIRST
+// shallow response (fetch-pack.c:453-481); subsequent rounds enter
+// the ACK/NAK loop directly, where a leftover "shallow X" pktline
+// kills get_ack (fetch-pack.c:253: `expected ACK/NAK, got '%s'`).
+func postRound(ctx context.Context, t Transport, stdout io.Writer, wantsBuf, havesBuf *bytes.Buffer, final, stripShallow bool, roundNumber int) error {
 	body := make([]byte, 0, wantsBuf.Len()+havesBuf.Len()+pktline.LenSize)
 	body = append(body, wantsBuf.Bytes()...)
 	body = append(body, havesBuf.Bytes()...)
@@ -191,7 +251,15 @@ func postRound(ctx context.Context, t Transport, stdout io.Writer, wantsBuf, hav
 	}
 	defer resp.Close()
 
-	if _, err := io.Copy(stdout, resp); err != nil {
+	var src io.Reader = resp
+	if stripShallow {
+		src, err = drainShallowUpdate(resp)
+		if err != nil {
+			return fmt.Errorf("draining shallow-update prefix on round %d: %w", roundNumber, err)
+		}
+	}
+
+	if _, err := io.Copy(stdout, src); err != nil {
 		return fmt.Errorf("streaming round %d response: %w", roundNumber, err)
 	}
 	if !final {
@@ -200,4 +268,41 @@ func postRound(ctx context.Context, t Transport, stdout io.Writer, wantsBuf, hav
 		}
 	}
 	return nil
+}
+
+// drainShallowUpdate consumes a leading shallow/unshallow pktline run
+// + the terminating flush from r and returns the trimmed reader. It is
+// the stream-mirror of fetch-pack.c:205-223 `consume_shallow_list`,
+// applied to intermediate AND final rounds in our connect-mode bridge
+// because each have-round POST repeats `deepen` and the server
+// dutifully re-emits the boundary section.
+//
+// If the first pktline isn't shallow/unshallow, returns r untouched —
+// safe to call defensively on every shallow round even when the
+// server (e.g. a probe-only response) happens to have no
+// shallow-update prefix.
+func drainShallowUpdate(r io.Reader) (io.Reader, error) {
+	br := bufio.NewReader(r)
+	for {
+		l, payload, err := pktline.PeekLine(br)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return br, nil
+			}
+			return nil, fmt.Errorf("peeking shallow-update pktline: %w", err)
+		}
+		if l == pktline.Flush {
+			if _, err := br.Discard(pktline.LenSize); err != nil {
+				return nil, fmt.Errorf("discarding shallow-update flush: %w", err)
+			}
+			return br, nil
+		}
+		if !bytes.HasPrefix(payload, []byte("shallow ")) &&
+			!bytes.HasPrefix(payload, []byte("unshallow ")) {
+			return br, nil
+		}
+		if _, err := br.Discard(l); err != nil {
+			return nil, fmt.Errorf("discarding shallow pktline: %w", err)
+		}
+	}
 }

--- a/internal/remotehelper/githelper/connect.go
+++ b/internal/remotehelper/githelper/connect.go
@@ -37,9 +37,9 @@ func handleConnect(ctx context.Context, t Transport, service string, stdin io.Re
 	}
 
 	switch service {
-	case "git-upload-pack":
+	case serviceUploadPack:
 		return handleFetch(ctx, t, stdin, stdout)
-	case "git-receive-pack":
+	case serviceReceivePack:
 		// fall through
 	default:
 		return fmt.Errorf("unsupported service: %s", service)
@@ -185,7 +185,7 @@ func postRound(ctx context.Context, t Transport, stdout io.Writer, wantsBuf, hav
 		return fmt.Errorf("amending upload-pack agent: %w", err)
 	}
 
-	resp, err := t.ServiceRPC(ctx, "git-upload-pack", bytes.NewReader(body))
+	resp, err := t.ServiceRPC(ctx, serviceUploadPack, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("connect fetch round %d POST: %w", roundNumber, err)
 	}

--- a/internal/remotehelper/githelper/connect.go
+++ b/internal/remotehelper/githelper/connect.go
@@ -1,0 +1,203 @@
+package githelper
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+	"github.com/entireio/cli/internal/remotehelper/gitproto"
+)
+
+// handleConnect handles a connect session for the given service.
+func handleConnect(ctx context.Context, t Transport, service string, stdin io.Reader, stdout io.Writer) error {
+	refs, err := t.InfoRefs(ctx, service)
+	if err != nil {
+		return fmt.Errorf("connect %s info/refs: %w", service, err)
+	}
+	defer refs.Close()
+
+	refReader := bufio.NewReader(refs)
+	var reply packp.SmartReply
+	if err := reply.Decode(refReader); err != nil {
+		return fmt.Errorf("parsing info/refs: %w", err)
+	}
+
+	if _, err := io.Copy(stdout, refReader); err != nil {
+		return fmt.Errorf("streaming refs: %w", err)
+	}
+
+	switch service {
+	case "git-upload-pack":
+		return handleFetch(ctx, t, stdin, stdout)
+	case "git-receive-pack":
+		// fall through
+	default:
+		return fmt.Errorf("unsupported service: %s", service)
+	}
+
+	reqBody, err := gitproto.ReadReceivePackRequest(stdin)
+	if err != nil {
+		return fmt.Errorf("reading git request: %w", err)
+	}
+	reqBody, err = gitproto.AppendAgentToReceivePackRequest(reqBody, Agent)
+	if err != nil {
+		return fmt.Errorf("amending receive-pack agent: %w", err)
+	}
+	debuglog.Printf("git request: %d bytes", len(reqBody))
+
+	if len(reqBody) == 0 {
+		return nil
+	}
+
+	resp, err := t.ServiceRPC(ctx, service, bytes.NewReader(reqBody), func(req *http.Request) {
+		req.Header.Set("X-Entire-Push-Size", strconv.Itoa(len(reqBody)))
+	})
+	if err != nil {
+		return fmt.Errorf("connect %s POST: %w", service, err)
+	}
+	defer resp.Close()
+
+	if _, err := io.Copy(stdout, resp); err != nil {
+		return fmt.Errorf("streaming response: %w", err)
+	}
+
+	return nil
+}
+
+// handleFetch handles upload-pack negotiation for connect mode by
+// translating canonical git's stateful conversation into HTTP
+// stateless-RPC requests against entire-server.
+//
+// Canonical git in connect mode acts as if it has a bidirectional
+// pipe to git-upload-pack: wants + flush, then alternating have
+// batches and server ACKs, terminated by done. HTTP smart-git is
+// stateless: each POST to /git-upload-pack is independent and must
+// carry the full wants list plus every have the client wants the
+// server to consider.
+//
+// We bridge by buffering wants permanently, accumulating haves across
+// rounds, and issuing one POST per have-batch flush. The server's
+// real ACK/NAK response streams back to git, so git's MAX_IN_VAIN
+// terminates on the first common ancestor instead of walking the
+// entire rev queue. When git sends done, a final POST with the
+// accumulated wants + haves + done streams the pack response.
+func handleFetch(ctx context.Context, t Transport, stdin io.Reader, stdout io.Writer) error {
+	var wantsBuf, havesBuf bytes.Buffer
+	lenBuf := make([]byte, pktline.LenSize)
+	pastWants := false
+	roundNumber := 0
+
+	for {
+		_, err := io.ReadFull(stdin, lenBuf)
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				// Git closed stdin before done. Either it aborted or
+				// (more commonly) decided no fetch was needed before
+				// ever sending wants. Either way, exit cleanly.
+				return nil
+			}
+			return fmt.Errorf("reading pkt-line length: %w", err)
+		}
+
+		pktLen, err := pktline.ParseLength(lenBuf)
+		if err != nil {
+			return fmt.Errorf("connect fetch: %w", err)
+		}
+
+		if pktLen == pktline.Flush {
+			if !pastWants {
+				// End of wants section. Include the flush in the wants
+				// buffer (every request body needs it as the wants
+				// terminator) and switch to accumulating haves.
+				wantsBuf.Write(lenBuf)
+				pastWants = true
+				debuglog.Printf("end of wants (%d bytes)", wantsBuf.Len())
+				continue
+			}
+			// End of a have batch. POST wants + cumulative haves +
+			// terminating flush so the server can compute ACKs.
+			roundNumber++
+			if err := postRound(ctx, t, stdout, &wantsBuf, &havesBuf, false, roundNumber); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if pktLen < pktline.LenSize {
+			// Special pktlines (0001 delim, 0002 response-end) — not
+			// expected in v0/v1 client→server stream, but tolerate by
+			// pass-through to the appropriate buffer.
+			dest := &wantsBuf
+			if pastWants {
+				dest = &havesBuf
+			}
+			dest.Write(lenBuf)
+			continue
+		}
+
+		content := make([]byte, pktLen-pktline.LenSize)
+		if _, err := io.ReadFull(stdin, content); err != nil {
+			return fmt.Errorf("reading pkt-line content: %w", err)
+		}
+
+		dest := &wantsBuf
+		if pastWants {
+			dest = &havesBuf
+		}
+		dest.Write(lenBuf)
+		dest.Write(content)
+
+		if strings.TrimSpace(string(content)) == "done" {
+			// Final round: server returns ACK/NAK + pack data.
+			roundNumber++
+			debuglog.Printf("done line received, sending final request (round %d)", roundNumber)
+			return postRound(ctx, t, stdout, &wantsBuf, &havesBuf, true, roundNumber)
+		}
+	}
+}
+
+// postRound assembles one stateless-RPC request body from the
+// buffered wants and cumulative haves, posts it to /git-upload-pack,
+// and streams the response back to git on stdout. Non-final rounds
+// synthesize a trailing NAK pktline so canonical git in connect
+// (stateful) mode doesn't hang waiting for the round-end marker that
+// the HTTP wire drops implicitly.
+func postRound(ctx context.Context, t Transport, stdout io.Writer, wantsBuf, havesBuf *bytes.Buffer, final bool, roundNumber int) error {
+	body := make([]byte, 0, wantsBuf.Len()+havesBuf.Len()+pktline.LenSize)
+	body = append(body, wantsBuf.Bytes()...)
+	body = append(body, havesBuf.Bytes()...)
+	if !final {
+		body = append(body, "0000"...)
+	}
+	debuglog.Printf("posting round %d: %d bytes (final=%v)", roundNumber, len(body), final)
+	body, err := gitproto.AppendAgentToUploadPackRequest(body, Agent)
+	if err != nil {
+		return fmt.Errorf("amending upload-pack agent: %w", err)
+	}
+
+	resp, err := t.ServiceRPC(ctx, "git-upload-pack", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("connect fetch round %d POST: %w", roundNumber, err)
+	}
+	defer resp.Close()
+
+	if _, err := io.Copy(stdout, resp); err != nil {
+		return fmt.Errorf("streaming round %d response: %w", roundNumber, err)
+	}
+	if !final {
+		if _, err := stdout.Write([]byte("0008NAK\n")); err != nil {
+			return fmt.Errorf("writing NAK terminator for round %d: %w", roundNumber, err)
+		}
+	}
+	return nil
+}

--- a/internal/remotehelper/githelper/connect_test.go
+++ b/internal/remotehelper/githelper/connect_test.go
@@ -14,9 +14,9 @@ import (
 
 func TestHandleConnect_DeleteBranch(t *testing.T) {
 	t.Parallel()
-	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oldSHA := testHeadSHA
 	zeroSHA := "0000000000000000000000000000000000000000"
-	ref := "refs/heads/feature-branch"
+	ref := testRefFeatureBranch
 
 	var receivedBody []byte
 
@@ -31,7 +31,7 @@ func TestHandleConnect_DeleteBranch(t *testing.T) {
 			fmt.Fprintf(w, "%04x%s", len(refLine)+4, refLine)
 			fmt.Fprint(w, "0000")
 
-		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-receive-pack"):
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, serviceReceivePack):
 			receivedBody, _ = io.ReadAll(r.Body) //nolint:errcheck // test
 			w.Header().Set("Content-Type", "application/x-git-receive-pack-result")
 			fmt.Fprint(w, pktLine("unpack ok\n"))
@@ -51,7 +51,7 @@ func TestHandleConnect_DeleteBranch(t *testing.T) {
 	stdin.WriteString("0000")
 
 	var stdout bytes.Buffer
-	err := handleConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &stdout)
+	err := handleConnect(context.Background(), testTransport(server), serviceReceivePack, &stdin, &stdout)
 	if err != nil {
 		t.Fatalf("handleConnect failed: %v", err)
 	}
@@ -89,7 +89,7 @@ func receivePackServer(t *testing.T, refLine, ref string) (*httptest.Server, *st
 			fmt.Fprintf(w, "%04x%s", len(refLine)+4, refLine)
 			fmt.Fprint(w, "0000")
 
-		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-receive-pack"):
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, serviceReceivePack):
 			receivedPushSize = r.Header.Get("X-Entire-Push-Size")
 			_, _ = io.ReadAll(r.Body) //nolint:errcheck // test
 			w.Header().Set("Content-Type", "application/x-git-receive-pack-result")
@@ -107,9 +107,9 @@ func receivePackServer(t *testing.T, refLine, ref string) (*httptest.Server, *st
 
 func TestHandleConnect_PushSizeHeader(t *testing.T) {
 	t.Parallel()
-	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oldSHA := testHeadSHA
 	newSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	ref := "refs/heads/main"
+	ref := testRefMain
 	packData := "PACK fake pack data here"
 
 	refLine := oldSHA + " " + ref + "\x00 report-status\n"
@@ -125,7 +125,7 @@ func TestHandleConnect_PushSizeHeader(t *testing.T) {
 	expectedSize := len(pktLine(cmd)) + 4 + len(packData)
 
 	var stdout bytes.Buffer
-	err := handleConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &stdout)
+	err := handleConnect(context.Background(), testTransport(server), serviceReceivePack, &stdin, &stdout)
 	if err != nil {
 		t.Fatalf("handleConnect failed: %v", err)
 	}
@@ -141,9 +141,9 @@ func TestHandleConnect_PushSizeHeader(t *testing.T) {
 
 func TestHandleConnect_DeletePushSizeHeader(t *testing.T) {
 	t.Parallel()
-	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oldSHA := testHeadSHA
 	zeroSHA := "0000000000000000000000000000000000000000"
-	ref := "refs/heads/feature-branch"
+	ref := testRefFeatureBranch
 
 	refLine := oldSHA + " " + ref + "\x00 report-status delete-refs\n"
 	server, receivedPushSize := receivePackServer(t, refLine, ref)
@@ -157,7 +157,7 @@ func TestHandleConnect_DeletePushSizeHeader(t *testing.T) {
 	expectedSize := strconv.Itoa(len(pktLine(cmd)) + 4)
 
 	var stdout bytes.Buffer
-	err := handleConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &stdout)
+	err := handleConnect(context.Background(), testTransport(server), serviceReceivePack, &stdin, &stdout)
 	if err != nil {
 		t.Fatalf("handleConnect failed: %v", err)
 	}

--- a/internal/remotehelper/githelper/connect_test.go
+++ b/internal/remotehelper/githelper/connect_test.go
@@ -1,0 +1,168 @@
+package githelper
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestHandleConnect_DeleteBranch(t *testing.T) {
+	t.Parallel()
+	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	zeroSHA := "0000000000000000000000000000000000000000"
+	ref := "refs/heads/feature-branch"
+
+	var receivedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
+			w.Header().Set("Content-Type", "application/x-git-receive-pack-advertisement")
+			announcement := "# service=git-receive-pack\n"
+			fmt.Fprintf(w, "%04x%s", len(announcement)+4, announcement)
+			fmt.Fprint(w, "0000")
+			refLine := oldSHA + " " + ref + "\x00 report-status delete-refs\n"
+			fmt.Fprintf(w, "%04x%s", len(refLine)+4, refLine)
+			fmt.Fprint(w, "0000")
+
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-receive-pack"):
+			receivedBody, _ = io.ReadAll(r.Body) //nolint:errcheck // test
+			w.Header().Set("Content-Type", "application/x-git-receive-pack-result")
+			fmt.Fprint(w, pktLine("unpack ok\n"))
+			fmt.Fprint(w, pktLine("ok "+ref+"\n"))
+			fmt.Fprint(w, "0000")
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	var stdin bytes.Buffer
+	cmd := oldSHA + " " + zeroSHA + " " + ref + "\x00 report-status delete-refs\n"
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+
+	var stdout bytes.Buffer
+	err := handleConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &stdout)
+	if err != nil {
+		t.Fatalf("handleConnect failed: %v", err)
+	}
+
+	body := string(receivedBody)
+	if !strings.Contains(body, oldSHA) {
+		t.Errorf("server body missing old SHA")
+	}
+	if !strings.Contains(body, zeroSHA) {
+		t.Errorf("server body missing zero SHA")
+	}
+	if !strings.Contains(body, ref) {
+		t.Errorf("server body missing ref name")
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "unpack ok") {
+		t.Errorf("expected 'unpack ok' in output, got %q", output)
+	}
+}
+
+// receivePackServer returns an httptest.Server that handles info/refs
+// and git-receive-pack. It captures the X-Entire-Push-Size header
+// from the POST request into the returned pointer.
+func receivePackServer(t *testing.T, refLine, ref string) (*httptest.Server, *string) {
+	t.Helper()
+	var receivedPushSize string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
+			w.Header().Set("Content-Type", "application/x-git-receive-pack-advertisement")
+			announcement := "# service=git-receive-pack\n"
+			fmt.Fprintf(w, "%04x%s", len(announcement)+4, announcement)
+			fmt.Fprint(w, "0000")
+			fmt.Fprintf(w, "%04x%s", len(refLine)+4, refLine)
+			fmt.Fprint(w, "0000")
+
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-receive-pack"):
+			receivedPushSize = r.Header.Get("X-Entire-Push-Size")
+			_, _ = io.ReadAll(r.Body) //nolint:errcheck // test
+			w.Header().Set("Content-Type", "application/x-git-receive-pack-result")
+			fmt.Fprint(w, pktLine("unpack ok\n"))
+			fmt.Fprint(w, pktLine("ok "+ref+"\n"))
+			fmt.Fprint(w, "0000")
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return server, &receivedPushSize
+}
+
+func TestHandleConnect_PushSizeHeader(t *testing.T) {
+	t.Parallel()
+	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	ref := "refs/heads/main"
+	packData := "PACK fake pack data here"
+
+	refLine := oldSHA + " " + ref + "\x00 report-status\n"
+	server, receivedPushSize := receivePackServer(t, refLine, ref)
+	defer server.Close()
+
+	var stdin bytes.Buffer
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+	stdin.WriteString(packData)
+
+	expectedSize := len(pktLine(cmd)) + 4 + len(packData)
+
+	var stdout bytes.Buffer
+	err := handleConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &stdout)
+	if err != nil {
+		t.Fatalf("handleConnect failed: %v", err)
+	}
+
+	if *receivedPushSize == "" {
+		t.Fatal("X-Entire-Push-Size header not sent")
+	}
+	want := strconv.Itoa(expectedSize)
+	if *receivedPushSize != want {
+		t.Errorf("X-Entire-Push-Size = %s, want %s", *receivedPushSize, want)
+	}
+}
+
+func TestHandleConnect_DeletePushSizeHeader(t *testing.T) {
+	t.Parallel()
+	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	zeroSHA := "0000000000000000000000000000000000000000"
+	ref := "refs/heads/feature-branch"
+
+	refLine := oldSHA + " " + ref + "\x00 report-status delete-refs\n"
+	server, receivedPushSize := receivePackServer(t, refLine, ref)
+	defer server.Close()
+
+	var stdin bytes.Buffer
+	cmd := oldSHA + " " + zeroSHA + " " + ref + "\x00 report-status delete-refs\n"
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+
+	expectedSize := strconv.Itoa(len(pktLine(cmd)) + 4)
+
+	var stdout bytes.Buffer
+	err := handleConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &stdout)
+	if err != nil {
+		t.Fatalf("handleConnect failed: %v", err)
+	}
+
+	if *receivedPushSize != expectedSize {
+		t.Errorf("X-Entire-Push-Size = %s, want %s", *receivedPushSize, expectedSize)
+	}
+}

--- a/internal/remotehelper/githelper/consts.go
+++ b/internal/remotehelper/githelper/consts.go
@@ -1,0 +1,13 @@
+package githelper
+
+// Git smart-HTTP service names exchanged over the remote-helper
+// protocol. Extracted to constants so the repeated literals across the
+// connect/stateless/push paths (and their tests) satisfy goconst.
+const (
+	serviceUploadPack  = "git-upload-pack"
+	serviceReceivePack = "git-receive-pack"
+)
+
+// optionValueTrue is git's literal boolean "true" as sent on the
+// `option <name> true` helper-protocol line (transport-helper.c).
+const optionValueTrue = "true"

--- a/internal/remotehelper/githelper/consts_test.go
+++ b/internal/remotehelper/githelper/consts_test.go
@@ -1,0 +1,9 @@
+package githelper
+
+// Shared test fixtures. Extracted to package-level constants so repeated
+// literals across the test files satisfy goconst.
+const (
+	testRefMain          = "refs/heads/main"
+	testRefFeatureBranch = "refs/heads/feature-branch"
+	testHeadSHA          = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)

--- a/internal/remotehelper/githelper/faultinject_test.go
+++ b/internal/remotehelper/githelper/faultinject_test.go
@@ -95,7 +95,7 @@ func TestHandleStatelessConnect_FallbackOnNonV2(t *testing.T) {
 		},
 	}
 	var out bytes.Buffer
-	if err := handleStatelessConnect(context.Background(), ft, "git-upload-pack", strings.NewReader(""), &out); err != nil {
+	if err := handleStatelessConnect(context.Background(), ft, serviceUploadPack, strings.NewReader(""), &out); err != nil {
 		t.Fatalf("handleStatelessConnect: %v", err)
 	}
 	if out.String() != "fallback\n" {
@@ -118,7 +118,7 @@ func TestHandleStatelessConnect_InfoRefsErrorSurfacesNoOutput(t *testing.T) {
 		},
 	}
 	var out bytes.Buffer
-	err := handleStatelessConnect(context.Background(), ft, "git-upload-pack", strings.NewReader(""), &out)
+	err := handleStatelessConnect(context.Background(), ft, serviceUploadPack, strings.NewReader(""), &out)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -137,11 +137,11 @@ func TestHandleConnect_TruncatedReceivePackRequestErrors(t *testing.T) {
 	t.Parallel()
 	oldSHA := strings.Repeat("a", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	ft := &fakeTransport{
 		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement("git-receive-pack",
+			return stringRC(serviceAnnouncement(serviceReceivePack,
 				oldSHA+" "+ref+"\x00 report-status\n")), nil
 		},
 	}
@@ -150,7 +150,7 @@ func TestHandleConnect_TruncatedReceivePackRequestErrors(t *testing.T) {
 	stdin := strings.NewReader(pktLine(cmd))
 
 	var out bytes.Buffer
-	err := handleConnect(context.Background(), ft, "git-receive-pack", stdin, &out)
+	err := handleConnect(context.Background(), ft, serviceReceivePack, stdin, &out)
 	if err == nil {
 		t.Fatal("expected error on truncated request")
 	}
@@ -167,16 +167,16 @@ func TestHandleConnect_TruncatedReceivePackRequestErrors(t *testing.T) {
 func TestHandleConnect_EmptyReceivePackRequestNoPOST(t *testing.T) {
 	t.Parallel()
 	oldSHA := strings.Repeat("a", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	ft := &fakeTransport{
 		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement("git-receive-pack",
+			return stringRC(serviceAnnouncement(serviceReceivePack,
 				oldSHA+" "+ref+"\x00 report-status\n")), nil
 		},
 	}
 	var out bytes.Buffer
-	if err := handleConnect(context.Background(), ft, "git-receive-pack", strings.NewReader(""), &out); err != nil {
+	if err := handleConnect(context.Background(), ft, serviceReceivePack, strings.NewReader(""), &out); err != nil {
 		t.Fatalf("handleConnect: %v", err)
 	}
 	if len(ft.rpcCalls) != 0 {
@@ -193,11 +193,11 @@ func TestHandleConnect_ServiceRPCFailurePropagates(t *testing.T) {
 	t.Parallel()
 	oldSHA := strings.Repeat("a", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	ft := &fakeTransport{
 		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement("git-receive-pack",
+			return stringRC(serviceAnnouncement(serviceReceivePack,
 				oldSHA+" "+ref+"\x00 report-status\n")), nil
 		},
 		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
@@ -211,7 +211,7 @@ func TestHandleConnect_ServiceRPCFailurePropagates(t *testing.T) {
 	stdin.WriteString("PACK fake")
 
 	var out bytes.Buffer
-	err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out)
+	err := handleConnect(context.Background(), ft, serviceReceivePack, &stdin, &out)
 	if err == nil {
 		t.Fatal("expected error to propagate to caller")
 	}
@@ -252,11 +252,11 @@ func TestHandleConnect_TruncatedResponseSurfacesError(t *testing.T) {
 	t.Parallel()
 	oldSHA := strings.Repeat("a", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	ft := &fakeTransport{
 		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement("git-receive-pack",
+			return stringRC(serviceAnnouncement(serviceReceivePack,
 				oldSHA+" "+ref+"\x00 report-status\n")), nil
 		},
 		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
@@ -271,7 +271,7 @@ func TestHandleConnect_TruncatedResponseSurfacesError(t *testing.T) {
 	stdin.WriteString("PACK fake")
 
 	var out bytes.Buffer
-	err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out)
+	err := handleConnect(context.Background(), ft, serviceReceivePack, &stdin, &out)
 	if err == nil {
 		t.Fatal("expected error on truncated response")
 	}
@@ -286,15 +286,15 @@ func TestHandleConnect_Real5xxNoSpuriousAck(t *testing.T) {
 	t.Parallel()
 	oldSHA := strings.Repeat("a", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
 			w.Header().Set("Content-Type", "application/x-git-receive-pack-advertisement")
-			_, _ = w.Write([]byte(serviceAnnouncement("git-receive-pack", //nolint:errcheck // test
+			_, _ = w.Write([]byte(serviceAnnouncement(serviceReceivePack, //nolint:errcheck // test
 				oldSHA+" "+ref+"\x00 report-status\n")))
-		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-receive-pack"):
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, serviceReceivePack):
 			w.WriteHeader(http.StatusBadGateway)
 			fmt.Fprint(w, "upstream dead")
 		default:
@@ -311,7 +311,7 @@ func TestHandleConnect_Real5xxNoSpuriousAck(t *testing.T) {
 	stdin.WriteString("PACK fake")
 
 	var out bytes.Buffer
-	err := handleConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &out)
+	err := handleConnect(context.Background(), testTransport(server), serviceReceivePack, &stdin, &out)
 	if err == nil {
 		t.Fatal("expected error on 502")
 	}
@@ -336,7 +336,7 @@ func TestHandleConnect_ServerHangsTimesOutViaCtx(t *testing.T) {
 	t.Parallel()
 	oldSHA := strings.Repeat("a", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	hold := make(chan struct{})
 
@@ -344,7 +344,7 @@ func TestHandleConnect_ServerHangsTimesOutViaCtx(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
 			w.Header().Set("Content-Type", "application/x-git-receive-pack-advertisement")
-			_, _ = w.Write([]byte(serviceAnnouncement("git-receive-pack", //nolint:errcheck // test
+			_, _ = w.Write([]byte(serviceAnnouncement(serviceReceivePack, //nolint:errcheck // test
 				oldSHA+" "+ref+"\x00 report-status\n")))
 		default:
 			select {
@@ -368,7 +368,7 @@ func TestHandleConnect_ServerHangsTimesOutViaCtx(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- handleConnect(ctx, testTransport(server), "git-receive-pack", &stdin, &out)
+		done <- handleConnect(ctx, testTransport(server), serviceReceivePack, &stdin, &out)
 	}()
 	select {
 	case err := <-done:

--- a/internal/remotehelper/githelper/faultinject_test.go
+++ b/internal/remotehelper/githelper/faultinject_test.go
@@ -1,0 +1,381 @@
+package githelper
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---- fake transports for fault injection ----------------------------------
+
+// fakeTransport is a Transport stub that returns user-supplied bodies
+// and errors for each method. It captures every ServiceRPC body so
+// tests can verify "what reached the wire" — the invariant we care
+// about for push acknowledgement.
+type fakeTransport struct {
+	infoRefsResp   func() (io.ReadCloser, error)
+	infoRefsV2Resp func() (io.ReadCloser, error)
+	serviceRPCResp func(service string, body []byte) (io.ReadCloser, error)
+
+	rpcCalls []rpcCall
+}
+
+type rpcCall struct {
+	Service string
+	Body    []byte
+}
+
+func (f *fakeTransport) InfoRefs(_ context.Context, _ string) (io.ReadCloser, error) {
+	if f.infoRefsResp == nil {
+		return nil, errors.New("fakeTransport: no info/refs handler")
+	}
+	return f.infoRefsResp()
+}
+
+func (f *fakeTransport) InfoRefsV2(_ context.Context) (io.ReadCloser, error) {
+	if f.infoRefsV2Resp == nil {
+		return nil, errors.New("fakeTransport: no v2 info/refs handler")
+	}
+	return f.infoRefsV2Resp()
+}
+
+func (f *fakeTransport) ServiceRPC(_ context.Context, service string, body io.ReadSeeker, _ ...func(*http.Request)) (io.ReadCloser, error) {
+	var buf []byte
+	if body != nil {
+		_, _ = body.Seek(0, io.SeekStart) //nolint:errcheck // test
+		buf, _ = io.ReadAll(body)         //nolint:errcheck // test
+	}
+	f.rpcCalls = append(f.rpcCalls, rpcCall{Service: service, Body: buf})
+	if f.serviceRPCResp == nil {
+		return nil, errors.New("fakeTransport: no service-RPC handler")
+	}
+	return f.serviceRPCResp(service, buf)
+}
+
+func (f *fakeTransport) ErrorBaseURL() string { return "https://test.invalid/repo" }
+
+// stringRC wraps a string as a ReadCloser.
+func stringRC(s string) io.ReadCloser { return io.NopCloser(strings.NewReader(s)) }
+
+// ---- helpers --------------------------------------------------------------
+
+// serviceAnnouncement returns the smart-HTTP info/refs body for the
+// given service: announcement pkt-line, flush, then refLines, then
+// trailing flush.
+func serviceAnnouncement(service string, refLines ...string) string {
+	var b strings.Builder
+	b.WriteString(pktLine("# service=" + service + "\n"))
+	b.WriteString("0000")
+	for _, r := range refLines {
+		b.WriteString(pktLine(r))
+	}
+	b.WriteString("0000")
+	return b.String()
+}
+
+// ---- fault-injection tests -----------------------------------------------
+
+// TestHandleStatelessConnect_FallbackOnNonV2: a non-v2
+// advertisement (e.g. plain HTTP error masked as 200 with garbage)
+// must end in "fallback\n" without issuing any POST. The remote
+// helper contract is that we explicitly say "fallback" instead of
+// claiming we can speak the version.
+func TestHandleStatelessConnect_FallbackOnNonV2(t *testing.T) {
+	t.Parallel()
+	ft := &fakeTransport{
+		infoRefsV2Resp: func() (io.ReadCloser, error) {
+			return stringRC(pktLine("version 1\n") + "0000"), nil
+		},
+	}
+	var out bytes.Buffer
+	if err := handleStatelessConnect(context.Background(), ft, "git-upload-pack", strings.NewReader(""), &out); err != nil {
+		t.Fatalf("handleStatelessConnect: %v", err)
+	}
+	if out.String() != "fallback\n" {
+		t.Errorf("output = %q, want fallback\\n", out.String())
+	}
+	if len(ft.rpcCalls) != 0 {
+		t.Errorf("ServiceRPC called %d times on fallback; must be zero", len(ft.rpcCalls))
+	}
+}
+
+// TestHandleStatelessConnect_InfoRefsErrorSurfacesNoOutput: a failure
+// at the info/refs probe must error without writing anything to
+// stdout — there is no half-advertisement state that git can
+// proceed from.
+func TestHandleStatelessConnect_InfoRefsErrorSurfacesNoOutput(t *testing.T) {
+	t.Parallel()
+	ft := &fakeTransport{
+		infoRefsV2Resp: func() (io.ReadCloser, error) {
+			return nil, errors.New("simulated server failure")
+		},
+	}
+	var out bytes.Buffer
+	err := handleStatelessConnect(context.Background(), ft, "git-upload-pack", strings.NewReader(""), &out)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected empty stdout on error, got %q", out.String())
+	}
+}
+
+// TestHandleConnect_TruncatedReceivePackRequestErrors: a
+// receive-pack POST body that has command pkt-lines but no
+// terminating flush must NOT be forwarded as-is. ReadReceivePackRequest
+// surfaces the truncation, handleConnect refuses to POST a partial
+// request — otherwise the server would either reject or, worse,
+// accept it as a valid empty-update batch.
+func TestHandleConnect_TruncatedReceivePackRequestErrors(t *testing.T) {
+	t.Parallel()
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement("git-receive-pack",
+				oldSHA+" "+ref+"\x00 report-status\n")), nil
+		},
+	}
+	// Command pkt-line, then EOF — no flush.
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	stdin := strings.NewReader(pktLine(cmd))
+
+	var out bytes.Buffer
+	err := handleConnect(context.Background(), ft, "git-receive-pack", stdin, &out)
+	if err == nil {
+		t.Fatal("expected error on truncated request")
+	}
+	if len(ft.rpcCalls) != 0 {
+		t.Errorf("ServiceRPC called %d times despite truncation — must be zero", len(ft.rpcCalls))
+	}
+}
+
+// TestHandleConnect_EmptyReceivePackRequestNoPOST: when git closes
+// stdin before sending any command, we must NOT issue a POST. An
+// empty receive-pack POST is technically valid and would be
+// acknowledged by some servers as "nothing changed" — but git's
+// transport layer expects no network traffic at all in that case.
+func TestHandleConnect_EmptyReceivePackRequestNoPOST(t *testing.T) {
+	t.Parallel()
+	oldSHA := strings.Repeat("a", 40)
+	ref := "refs/heads/main"
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement("git-receive-pack",
+				oldSHA+" "+ref+"\x00 report-status\n")), nil
+		},
+	}
+	var out bytes.Buffer
+	if err := handleConnect(context.Background(), ft, "git-receive-pack", strings.NewReader(""), &out); err != nil {
+		t.Fatalf("handleConnect: %v", err)
+	}
+	if len(ft.rpcCalls) != 0 {
+		t.Errorf("ServiceRPC called %d times for empty stdin — must be zero", len(ft.rpcCalls))
+	}
+}
+
+// TestHandleConnect_ServiceRPCFailurePropagates: an HTTP failure on
+// the receive-pack POST must surface a non-nil error to the caller.
+// The helper must NOT swallow the error and emit a fake "ok" line —
+// that would tell git the push succeeded when in fact nothing
+// reached the server.
+func TestHandleConnect_ServiceRPCFailurePropagates(t *testing.T) {
+	t.Parallel()
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement("git-receive-pack",
+				oldSHA+" "+ref+"\x00 report-status\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			return nil, errors.New("502 Bad Gateway")
+		},
+	}
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	var stdin bytes.Buffer
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+	stdin.WriteString("PACK fake")
+
+	var out bytes.Buffer
+	err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out)
+	if err == nil {
+		t.Fatal("expected error to propagate to caller")
+	}
+	if strings.Contains(out.String(), "ok ") {
+		t.Errorf("output contains spurious 'ok': %q", out.String())
+	}
+}
+
+// flakyBody wraps an io.Reader and returns ErrUnexpectedEOF after
+// allowing some bytes through. Used to simulate a server closing the
+// HTTP response stream mid-pack.
+type flakyBody struct {
+	src    io.Reader
+	limit  int
+	served int
+}
+
+func (f *flakyBody) Read(p []byte) (int, error) {
+	if f.served >= f.limit {
+		return 0, io.ErrUnexpectedEOF
+	}
+	remaining := f.limit - f.served
+	if remaining < len(p) {
+		p = p[:remaining]
+	}
+	n, err := f.src.Read(p)
+	f.served += n
+	return n, err
+}
+
+func (f *flakyBody) Close() error { return nil }
+
+// TestHandleConnect_TruncatedResponseSurfacesError: when the server's
+// response stream is cut short mid-stream, the io.Copy to stdout
+// errors and handleConnect must return that error. Otherwise git
+// would see a partial pack response and could mis-report success.
+func TestHandleConnect_TruncatedResponseSurfacesError(t *testing.T) {
+	t.Parallel()
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement("git-receive-pack",
+				oldSHA+" "+ref+"\x00 report-status\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			// 1KB available, ten bytes of garbage, then ErrUnexpectedEOF.
+			return &flakyBody{src: strings.NewReader(strings.Repeat("x", 1024)), limit: 10}, nil
+		},
+	}
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	var stdin bytes.Buffer
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+	stdin.WriteString("PACK fake")
+
+	var out bytes.Buffer
+	err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out)
+	if err == nil {
+		t.Fatal("expected error on truncated response")
+	}
+}
+
+// ---- HTTP-level fault injection ------------------------------------------
+
+// TestHandleConnect_Real5xxNoSpuriousAck: against a real HTTP server
+// that 502s on every POST, the helper must surface the failure and
+// emit no successful-push markers.
+func TestHandleConnect_Real5xxNoSpuriousAck(t *testing.T) {
+	t.Parallel()
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
+			w.Header().Set("Content-Type", "application/x-git-receive-pack-advertisement")
+			_, _ = w.Write([]byte(serviceAnnouncement("git-receive-pack", //nolint:errcheck // test
+				oldSHA+" "+ref+"\x00 report-status\n")))
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-receive-pack"):
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprint(w, "upstream dead")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	var stdin bytes.Buffer
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+	stdin.WriteString("PACK fake")
+
+	var out bytes.Buffer
+	err := handleConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &out)
+	if err == nil {
+		t.Fatal("expected error on 502")
+	}
+	for _, marker := range []string{"unpack ok", "\nok ", "ok refs/"} {
+		if strings.Contains(out.String(), marker) {
+			t.Errorf("stdout contains spurious success marker %q: %s", marker, out.String())
+		}
+	}
+}
+
+// TestHandleConnect_ServerHangsTimesOutViaCtx: a server that holds
+// the response open forever must NOT leave the helper blocked once
+// the context cancels. The Transport interface promises to surface
+// ctx cancellation, so handleConnect just has to thread it through.
+//
+// Cleanup order matters here: the hanging handler can't return until
+// `hold` closes, and httptest.Server.Close blocks on all in-flight
+// requests. We therefore close `hold` first via the early defer
+// (LIFO: registered last, runs first) so server.Close has a chance
+// to return.
+func TestHandleConnect_ServerHangsTimesOutViaCtx(t *testing.T) {
+	t.Parallel()
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+
+	hold := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
+			w.Header().Set("Content-Type", "application/x-git-receive-pack-advertisement")
+			_, _ = w.Write([]byte(serviceAnnouncement("git-receive-pack", //nolint:errcheck // test
+				oldSHA+" "+ref+"\x00 report-status\n")))
+		default:
+			select {
+			case <-hold:
+			case <-r.Context().Done():
+			}
+		}
+	}))
+	defer server.Close()
+	defer close(hold) // runs before server.Close — unblocks the handler
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	var stdin bytes.Buffer
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+	stdin.WriteString("PACK fake")
+
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- handleConnect(ctx, testTransport(server), "git-receive-pack", &stdin, &out)
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected error on ctx cancel")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("helper did not return after ctx timeout")
+	}
+}

--- a/internal/remotehelper/githelper/invariants_test.go
+++ b/internal/remotehelper/githelper/invariants_test.go
@@ -32,11 +32,11 @@ func TestInvariant_NoSpuriousAckOnTransportError(t *testing.T) {
 	t.Parallel()
 	oldSHA := strings.Repeat("a", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	ft := &fakeTransport{
 		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement("git-receive-pack",
+			return stringRC(serviceAnnouncement(serviceReceivePack,
 				oldSHA+" "+ref+"\x00 report-status\n")), nil
 		},
 		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
@@ -51,7 +51,7 @@ func TestInvariant_NoSpuriousAckOnTransportError(t *testing.T) {
 	stdin.WriteString("PACK fakepackdata")
 
 	var out bytes.Buffer
-	err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out)
+	err := handleConnect(context.Background(), ft, serviceReceivePack, &stdin, &out)
 	if err == nil {
 		t.Fatal("expected error on transport failure")
 	}
@@ -70,7 +70,7 @@ func TestInvariant_RequestBodyContainsOnlyClientRefspecs(t *testing.T) {
 	t.Parallel()
 	oldSHA := strings.Repeat("a", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	ft := &fakeTransport{
 		infoRefsResp: func() (io.ReadCloser, error) {
@@ -78,7 +78,7 @@ func TestInvariant_RequestBodyContainsOnlyClientRefspecs(t *testing.T) {
 			// its push batch. If the helper synthesised a refspec
 			// from the advertisement, refs/heads/other would appear
 			// in the captured POST body.
-			return stringRC(serviceAnnouncement("git-receive-pack",
+			return stringRC(serviceAnnouncement(serviceReceivePack,
 				oldSHA+" "+ref+"\x00 report-status\n",
 				strings.Repeat("c", 40)+" refs/heads/other\n")), nil
 		},
@@ -94,7 +94,7 @@ func TestInvariant_RequestBodyContainsOnlyClientRefspecs(t *testing.T) {
 	stdin.WriteString("PACK")
 
 	var out bytes.Buffer
-	if err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out); err != nil {
+	if err := handleConnect(context.Background(), ft, serviceReceivePack, &stdin, &out); err != nil {
 		t.Fatalf("handleConnect: %v", err)
 	}
 	if len(ft.rpcCalls) != 1 {
@@ -133,11 +133,11 @@ func assertDeleteOnlyPushOmitsPackData(t *testing.T, oidLen int, extraCapabiliti
 
 	oldSHA := strings.Repeat("a", oidLen)
 	zeroSHA := strings.Repeat("0", oidLen)
-	ref := "refs/heads/feature-branch"
+	ref := testRefFeatureBranch
 
 	ft := &fakeTransport{
 		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement("git-receive-pack",
+			return stringRC(serviceAnnouncement(serviceReceivePack,
 				oldSHA+" "+ref+"\x00 report-status delete-refs"+extraCapabilities+"\n")), nil
 		},
 		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
@@ -152,7 +152,7 @@ func assertDeleteOnlyPushOmitsPackData(t *testing.T, oidLen int, extraCapabiliti
 	// No PACK bytes — delete-only push.
 
 	var out bytes.Buffer
-	if err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out); err != nil {
+	if err := handleConnect(context.Background(), ft, serviceReceivePack, &stdin, &out); err != nil {
 		t.Fatalf("handleConnect: %v", err)
 	}
 	if len(ft.rpcCalls) != 1 {
@@ -180,11 +180,11 @@ func TestInvariant_AckOnlyAfterFullResponse(t *testing.T) {
 	t.Parallel()
 	oldSHA := strings.Repeat("a", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	ft := &fakeTransport{
 		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement("git-receive-pack",
+			return stringRC(serviceAnnouncement(serviceReceivePack,
 				oldSHA+" "+ref+"\x00 report-status\n")), nil
 		},
 		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
@@ -202,7 +202,7 @@ func TestInvariant_AckOnlyAfterFullResponse(t *testing.T) {
 	stdin.WriteString("PACK fakepackdata")
 
 	var out bytes.Buffer
-	if err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out); err != nil {
+	if err := handleConnect(context.Background(), ft, serviceReceivePack, &stdin, &out); err != nil {
 		t.Fatalf("handleConnect: %v", err)
 	}
 	if strings.Contains(out.String(), "ok ") {
@@ -221,12 +221,12 @@ func TestInvariant_PartialRefBatchAllOrNothing(t *testing.T) {
 	newA := strings.Repeat("b", 40)
 	oldB := strings.Repeat("c", 40)
 	newB := strings.Repeat("d", 40)
-	refA := "refs/heads/main"
+	refA := testRefMain
 	refB := "refs/heads/feature"
 
 	ft := &fakeTransport{
 		infoRefsResp: func() (io.ReadCloser, error) {
-			return stringRC(serviceAnnouncement("git-receive-pack",
+			return stringRC(serviceAnnouncement(serviceReceivePack,
 				oldA+" "+refA+"\x00 report-status\n",
 				oldB+" "+refB+"\n")), nil
 		},
@@ -246,7 +246,7 @@ func TestInvariant_PartialRefBatchAllOrNothing(t *testing.T) {
 	stdin.WriteString("PACK fakepackdata")
 
 	var out bytes.Buffer
-	if err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out); err != nil {
+	if err := handleConnect(context.Background(), ft, serviceReceivePack, &stdin, &out); err != nil {
 		t.Fatalf("handleConnect: %v", err)
 	}
 

--- a/internal/remotehelper/githelper/invariants_test.go
+++ b/internal/remotehelper/githelper/invariants_test.go
@@ -1,0 +1,263 @@
+package githelper
+
+// Push-acknowledgement invariants. These tests pin the behaviours a
+// git remote helper MUST honour to avoid silent data loss:
+//
+//   1. Never partially acknowledge a push — every refspec the client
+//      provided either reaches the server or surfaces an error to git.
+//   2. Never claim success before durable persistence — until the
+//      server's report-status arrives in full, we don't write an "ok"
+//      line for any ref.
+//   3. Never mutate refs unexpectedly — only refspecs the client
+//      explicitly pushed appear in the receive-pack request body.
+//
+// The tests below probe each invariant through handleConnect
+// (connect-mode push, which is the default path) using a fake
+// Transport that lets us inspect every byte that reached the wire
+// and every byte that reached stdout.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestInvariant_NoSpuriousAckOnTransportError: the server's POST
+// fails before any response body is written. Helper output MUST
+// contain no "ok " lines and the error MUST propagate.
+func TestInvariant_NoSpuriousAckOnTransportError(t *testing.T) {
+	t.Parallel()
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement("git-receive-pack",
+				oldSHA+" "+ref+"\x00 report-status\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			return nil, errors.New("connection reset by peer")
+		},
+	}
+
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	var stdin bytes.Buffer
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+	stdin.WriteString("PACK fakepackdata")
+
+	var out bytes.Buffer
+	err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out)
+	if err == nil {
+		t.Fatal("expected error on transport failure")
+	}
+	for _, marker := range []string{"\nok ", "ok " + ref, "unpack ok"} {
+		if strings.Contains(out.String(), marker) {
+			t.Errorf("spurious success marker %q in output: %s", marker, out.String())
+		}
+	}
+}
+
+// TestInvariant_RequestBodyContainsOnlyClientRefspecs: the bytes
+// posted to git-receive-pack MUST contain only the refspecs the
+// client supplied — no synthetic creates, deletes, or "for safety"
+// updates the helper invents on its own.
+func TestInvariant_RequestBodyContainsOnlyClientRefspecs(t *testing.T) {
+	t.Parallel()
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			// Advertise an extra ref the client did NOT include in
+			// its push batch. If the helper synthesised a refspec
+			// from the advertisement, refs/heads/other would appear
+			// in the captured POST body.
+			return stringRC(serviceAnnouncement("git-receive-pack",
+				oldSHA+" "+ref+"\x00 report-status\n",
+				strings.Repeat("c", 40)+" refs/heads/other\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			return stringRC(pktLine("unpack ok\n") + pktLine("ok "+ref+"\n") + "0000"), nil
+		},
+	}
+
+	clientRef := strings.Repeat("d", 40) + " " + newSHA + " " + ref + "\x00 report-status\n"
+	var stdin bytes.Buffer
+	stdin.WriteString(pktLine(clientRef))
+	stdin.WriteString("0000")
+	stdin.WriteString("PACK")
+
+	var out bytes.Buffer
+	if err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out); err != nil {
+		t.Fatalf("handleConnect: %v", err)
+	}
+	if len(ft.rpcCalls) != 1 {
+		t.Fatalf("expected exactly 1 ServiceRPC call, got %d", len(ft.rpcCalls))
+	}
+	if strings.Contains(string(ft.rpcCalls[0].Body), "refs/heads/other") {
+		t.Errorf("POST body mutated refs/heads/other (not in client batch): %q", ft.rpcCalls[0].Body)
+	}
+	if !strings.Contains(string(ft.rpcCalls[0].Body), ref) {
+		t.Errorf("POST body missing client refspec %q: %q", ref, ft.rpcCalls[0].Body)
+	}
+}
+
+// TestInvariant_DeleteOnlyPushOmitsPackData: a delete-only refspec
+// (new OID = zeros) must not be followed by PACK data on the wire.
+// receive-pack rejects pack data on delete-only batches with
+// "fatal: unable to read header" — and even if the server tolerated
+// it, sending pack bytes here would tell the server we pushed
+// objects we didn't.
+func TestInvariant_DeleteOnlyPushOmitsPackData(t *testing.T) {
+	t.Parallel()
+	assertDeleteOnlyPushOmitsPackData(t, 40, "")
+}
+
+// TestInvariant_DeleteOnlyPushOmitsPackData_SHA256: same as the SHA-1
+// case but with 64-hex object IDs — the old fixed-offset detector
+// mis-read bytes inside the old OID as the new OID and pulled PACK
+// data after a delete-only flush.
+func TestInvariant_DeleteOnlyPushOmitsPackData_SHA256(t *testing.T) {
+	t.Parallel()
+	assertDeleteOnlyPushOmitsPackData(t, 64, " object-format=sha256")
+}
+
+func assertDeleteOnlyPushOmitsPackData(t *testing.T, oidLen int, extraCapabilities string) {
+	t.Helper()
+
+	oldSHA := strings.Repeat("a", oidLen)
+	zeroSHA := strings.Repeat("0", oidLen)
+	ref := "refs/heads/feature-branch"
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement("git-receive-pack",
+				oldSHA+" "+ref+"\x00 report-status delete-refs"+extraCapabilities+"\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			return stringRC(pktLine("unpack ok\n") + pktLine("ok "+ref+"\n") + "0000"), nil
+		},
+	}
+
+	cmd := oldSHA + " " + zeroSHA + " " + ref + "\x00 report-status delete-refs\n"
+	var stdin bytes.Buffer
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+	// No PACK bytes — delete-only push.
+
+	var out bytes.Buffer
+	if err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out); err != nil {
+		t.Fatalf("handleConnect: %v", err)
+	}
+	if len(ft.rpcCalls) != 1 {
+		t.Fatalf("expected 1 ServiceRPC call, got %d", len(ft.rpcCalls))
+	}
+	if bytes.Contains(ft.rpcCalls[0].Body, []byte("PACK")) {
+		t.Errorf("delete-only push body unexpectedly contains PACK: %q", ft.rpcCalls[0].Body)
+	}
+}
+
+// TestInvariant_AckOnlyAfterFullResponse: the server's
+// report-status arrives in chunks and the helper streams it to
+// stdout. The contract is that the bytes appear AFTER the POST has
+// returned successfully — i.e. we never write an "ok" line before
+// the server has emitted one. The helper's loop is:
+//
+//  1. read full request from stdin
+//  2. POST it, get response
+//  3. stream response to stdout
+//
+// Steps 2 and 3 are sequential: any "ok" the helper writes to
+// stdout came from the server. We verify by checking that no "ok"
+// appears in stdout when the server returns an empty body.
+func TestInvariant_AckOnlyAfterFullResponse(t *testing.T) {
+	t.Parallel()
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement("git-receive-pack",
+				oldSHA+" "+ref+"\x00 report-status\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			// Empty response body — server processed the push but
+			// returned no report-status. Helper must surface this
+			// as "no acknowledgement" rather than synthesise one.
+			return stringRC(""), nil
+		},
+	}
+
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	var stdin bytes.Buffer
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+	stdin.WriteString("PACK fakepackdata")
+
+	var out bytes.Buffer
+	if err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out); err != nil {
+		t.Fatalf("handleConnect: %v", err)
+	}
+	if strings.Contains(out.String(), "ok ") {
+		t.Errorf("stdout contains 'ok' despite empty server response: %q", out.String())
+	}
+}
+
+// TestInvariant_PartialRefBatchAllOrNothing: the client pushes two
+// refs. When the helper reads the receive-pack request body, both
+// commands must reach the server in a single POST. Partial batches
+// (only one of the two) would let the server commit half the push
+// and the client never learn about the other half.
+func TestInvariant_PartialRefBatchAllOrNothing(t *testing.T) {
+	t.Parallel()
+	oldA := strings.Repeat("a", 40)
+	newA := strings.Repeat("b", 40)
+	oldB := strings.Repeat("c", 40)
+	newB := strings.Repeat("d", 40)
+	refA := "refs/heads/main"
+	refB := "refs/heads/feature"
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement("git-receive-pack",
+				oldA+" "+refA+"\x00 report-status\n",
+				oldB+" "+refB+"\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			return stringRC(pktLine("unpack ok\n") +
+				pktLine("ok "+refA+"\n") +
+				pktLine("ok "+refB+"\n") + "0000"), nil
+		},
+	}
+
+	cmdA := oldA + " " + newA + " " + refA + "\x00 report-status\n"
+	cmdB := oldB + " " + newB + " " + refB + "\n"
+	var stdin bytes.Buffer
+	stdin.WriteString(pktLine(cmdA))
+	stdin.WriteString(pktLine(cmdB))
+	stdin.WriteString("0000")
+	stdin.WriteString("PACK fakepackdata")
+
+	var out bytes.Buffer
+	if err := handleConnect(context.Background(), ft, "git-receive-pack", &stdin, &out); err != nil {
+		t.Fatalf("handleConnect: %v", err)
+	}
+
+	if len(ft.rpcCalls) != 1 {
+		t.Fatalf("expected exactly 1 POST (atomic batch), got %d", len(ft.rpcCalls))
+	}
+	body := string(ft.rpcCalls[0].Body)
+	if !strings.Contains(body, refA) {
+		t.Errorf("POST body missing %q", refA)
+	}
+	if !strings.Contains(body, refB) {
+		t.Errorf("POST body missing %q", refB)
+	}
+}

--- a/internal/remotehelper/githelper/list.go
+++ b/internal/remotehelper/githelper/list.go
@@ -19,9 +19,9 @@ import (
 // terminator. HEAD is emitted as "@<target> HEAD" when the symref
 // capability resolves; detached HEAD falls back to "<sha> HEAD".
 func handleList(ctx context.Context, t Transport, forPush bool, stdout io.Writer) error {
-	service := "git-upload-pack"
+	service := serviceUploadPack
 	if forPush {
-		service = "git-receive-pack"
+		service = serviceReceivePack
 	}
 	refs, err := t.InfoRefs(ctx, service)
 	if err != nil {

--- a/internal/remotehelper/githelper/list.go
+++ b/internal/remotehelper/githelper/list.go
@@ -1,0 +1,137 @@
+package githelper
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+)
+
+// handleList implements the git-remote-helpers "list" / "list for-push"
+// command. It fetches the v0 info/refs advertisement, extracts each
+// ref and HEAD's symref target from the embedded capabilities, and
+// writes one "<value> <name>" line per ref followed by a blank-line
+// terminator. HEAD is emitted as "@<target> HEAD" when the symref
+// capability resolves; detached HEAD falls back to "<sha> HEAD".
+func handleList(ctx context.Context, t Transport, forPush bool, stdout io.Writer) error {
+	service := "git-upload-pack"
+	if forPush {
+		service = "git-receive-pack"
+	}
+	refs, err := t.InfoRefs(ctx, service)
+	if err != nil {
+		return fmt.Errorf("list %s info/refs: %w", service, err)
+	}
+	defer refs.Close()
+
+	r := bufio.NewReader(refs)
+	var reply packp.SmartReply
+	if err := reply.Decode(r); err != nil {
+		return fmt.Errorf("parsing info/refs: %w", err)
+	}
+
+	type entry struct{ value, name string }
+	var (
+		lines        []entry
+		headValue    string
+		objectFormat string
+		symrefs      = map[string]string{}
+		first        = true
+	)
+	for {
+		_, content, err := pktline.ReadLine(r)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("reading ref pkt-line: %w", err)
+		}
+		if len(content) == 0 {
+			// Flush, delim, or response-end. For the v0 ref
+			// advertisement only flush is meaningful — it ends
+			// the list.
+			break
+		}
+		line := strings.TrimRight(string(content), "\n")
+
+		// The first advertised ref carries the capability list after a
+		// NUL separator: "<sha> <ref>\0<cap1> <cap2> ...". Subsequent
+		// refs are bare. We pluck every symref=src:dst pair and
+		// object-format=<hash> out of those caps; the rest is for the
+		// smart-transport client only.
+		if first {
+			first = false
+			var caps string
+			if i := strings.IndexByte(line, 0); i >= 0 {
+				caps = line[i+1:]
+				line = line[:i]
+			}
+			for c := range strings.FieldsSeq(caps) {
+				switch {
+				case strings.HasPrefix(c, "object-format="):
+					objectFormat = strings.TrimPrefix(c, "object-format=")
+				case strings.HasPrefix(c, "symref="):
+					if src, dst, ok := strings.Cut(strings.TrimPrefix(c, "symref="), ":"); ok {
+						symrefs[src] = dst
+					}
+				}
+			}
+		}
+
+		value, name, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		// Empty repos are advertised with a single dummy ref
+		// "<null-oid> capabilities^{}" so the server still gets a
+		// chance to send its capability list. Skip it — it's not a
+		// real ref and transport-helper would reject the name.
+		if name == "capabilities^{}" {
+			continue
+		}
+		if name == "HEAD" {
+			headValue = value
+			continue
+		}
+		lines = append(lines, entry{value, name})
+	}
+
+	if objectFormat != "" {
+		if _, err := fmt.Fprintf(stdout, ":object-format %s\n", objectFormat); err != nil {
+			return fmt.Errorf("writing object-format: %w", err)
+		}
+	}
+	for _, l := range lines {
+		value := l.value
+		if target, ok := symrefs[l.name]; ok {
+			value = "@" + target
+		}
+		if _, err := fmt.Fprintf(stdout, "%s %s\n", value, l.name); err != nil {
+			return fmt.Errorf("writing ref: %w", err)
+		}
+	}
+	// Emit HEAD whenever we know something about it: either a SHA
+	// (normal or detached HEAD) or a symref target (unborn HEAD on an
+	// empty repo where the server advertises
+	// symref=HEAD:refs/heads/main but no SHA). transport-helper.c:1276
+	// accepts "@<target> HEAD" without a SHA and resolves the OID via
+	// resolve_remote_symref.
+	if target, ok := symrefs["HEAD"]; ok {
+		if _, err := fmt.Fprintf(stdout, "@%s HEAD\n", target); err != nil {
+			return fmt.Errorf("writing HEAD symref: %w", err)
+		}
+	} else if headValue != "" {
+		if _, err := fmt.Fprintf(stdout, "%s HEAD\n", headValue); err != nil {
+			return fmt.Errorf("writing HEAD: %w", err)
+		}
+	}
+	if _, err := fmt.Fprintln(stdout); err != nil {
+		return fmt.Errorf("writing terminator: %w", err)
+	}
+	return nil
+}

--- a/internal/remotehelper/githelper/list_test.go
+++ b/internal/remotehelper/githelper/list_test.go
@@ -12,8 +12,8 @@ func TestHandleList(t *testing.T) {
 	t.Parallel()
 
 	const (
-		headSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		mainSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		headSHA = testHeadSHA
+		mainSHA = testHeadSHA
 		fooSHA  = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	)
 
@@ -27,7 +27,7 @@ func TestHandleList(t *testing.T) {
 	}{
 		{
 			name:     "list with HEAD symref",
-			service:  "git-upload-pack",
+			service:  serviceUploadPack,
 			firstRef: headSHA + " HEAD\x00multi_ack symref=HEAD:refs/heads/main object-format=sha1\n",
 			more: []string{
 				mainSHA + " refs/heads/main\n",
@@ -41,7 +41,7 @@ func TestHandleList(t *testing.T) {
 		{
 			name:     "list for-push hits receive-pack",
 			forPush:  true,
-			service:  "git-receive-pack",
+			service:  serviceReceivePack,
 			firstRef: mainSHA + " refs/heads/main\x00report-status delete-refs object-format=sha1\n",
 			more: []string{
 				fooSHA + " refs/heads/foo\n",
@@ -52,7 +52,7 @@ func TestHandleList(t *testing.T) {
 		},
 		{
 			name:     "detached HEAD",
-			service:  "git-upload-pack",
+			service:  serviceUploadPack,
 			firstRef: headSHA + " HEAD\x00multi_ack object-format=sha1\n",
 			more: []string{
 				mainSHA + " refs/heads/main\n",
@@ -63,7 +63,7 @@ func TestHandleList(t *testing.T) {
 		},
 		{
 			name:     "multiple symrefs",
-			service:  "git-upload-pack",
+			service:  serviceUploadPack,
 			firstRef: headSHA + " HEAD\x00multi_ack symref=HEAD:refs/heads/main symref=refs/remotes/origin/HEAD:refs/remotes/origin/main object-format=sha1\n",
 			more: []string{
 				mainSHA + " refs/heads/main\n",
@@ -78,7 +78,7 @@ func TestHandleList(t *testing.T) {
 		},
 		{
 			name:     "empty repo with unborn HEAD",
-			service:  "git-upload-pack",
+			service:  serviceUploadPack,
 			firstRef: "0000000000000000000000000000000000000000 capabilities^{}\x00symref=HEAD:refs/heads/main object-format=sha1 multi_ack\n",
 			more:     nil,
 			want: ":object-format sha1\n" +

--- a/internal/remotehelper/githelper/list_test.go
+++ b/internal/remotehelper/githelper/list_test.go
@@ -1,0 +1,118 @@
+package githelper
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleList(t *testing.T) {
+	t.Parallel()
+
+	const (
+		headSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		mainSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		fooSHA  = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	tests := []struct {
+		name     string
+		forPush  bool
+		service  string
+		firstRef string
+		more     []string
+		want     string
+	}{
+		{
+			name:     "list with HEAD symref",
+			service:  "git-upload-pack",
+			firstRef: headSHA + " HEAD\x00multi_ack symref=HEAD:refs/heads/main object-format=sha1\n",
+			more: []string{
+				mainSHA + " refs/heads/main\n",
+				fooSHA + " refs/heads/foo\n",
+			},
+			want: ":object-format sha1\n" +
+				mainSHA + " refs/heads/main\n" +
+				fooSHA + " refs/heads/foo\n" +
+				"@refs/heads/main HEAD\n\n",
+		},
+		{
+			name:     "list for-push hits receive-pack",
+			forPush:  true,
+			service:  "git-receive-pack",
+			firstRef: mainSHA + " refs/heads/main\x00report-status delete-refs object-format=sha1\n",
+			more: []string{
+				fooSHA + " refs/heads/foo\n",
+			},
+			want: ":object-format sha1\n" +
+				mainSHA + " refs/heads/main\n" +
+				fooSHA + " refs/heads/foo\n\n",
+		},
+		{
+			name:     "detached HEAD",
+			service:  "git-upload-pack",
+			firstRef: headSHA + " HEAD\x00multi_ack object-format=sha1\n",
+			more: []string{
+				mainSHA + " refs/heads/main\n",
+			},
+			want: ":object-format sha1\n" +
+				mainSHA + " refs/heads/main\n" +
+				headSHA + " HEAD\n\n",
+		},
+		{
+			name:     "multiple symrefs",
+			service:  "git-upload-pack",
+			firstRef: headSHA + " HEAD\x00multi_ack symref=HEAD:refs/heads/main symref=refs/remotes/origin/HEAD:refs/remotes/origin/main object-format=sha1\n",
+			more: []string{
+				mainSHA + " refs/heads/main\n",
+				fooSHA + " refs/remotes/origin/HEAD\n",
+				fooSHA + " refs/remotes/origin/main\n",
+			},
+			want: ":object-format sha1\n" +
+				mainSHA + " refs/heads/main\n" +
+				"@refs/remotes/origin/main refs/remotes/origin/HEAD\n" +
+				fooSHA + " refs/remotes/origin/main\n" +
+				"@refs/heads/main HEAD\n\n",
+		},
+		{
+			name:     "empty repo with unborn HEAD",
+			service:  "git-upload-pack",
+			firstRef: "0000000000000000000000000000000000000000 capabilities^{}\x00symref=HEAD:refs/heads/main object-format=sha1 multi_ack\n",
+			more:     nil,
+			want: ":object-format sha1\n" +
+				"@refs/heads/main HEAD\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.Query().Get("service"); got != tt.service {
+					t.Errorf("service = %s, want %s", got, tt.service)
+				}
+				var b bytes.Buffer
+				b.WriteString(pktLine("# service=" + tt.service + "\n"))
+				b.WriteString("0000")
+				b.WriteString(pktLine(tt.firstRef))
+				for _, ref := range tt.more {
+					b.WriteString(pktLine(ref))
+				}
+				b.WriteString("0000")
+				w.Header().Set("Content-Type", "application/x-"+tt.service+"-advertisement")
+				_, _ = w.Write(b.Bytes()) //nolint:errcheck // test
+			}))
+			defer server.Close()
+
+			var out bytes.Buffer
+			if err := handleList(context.Background(), testTransport(server), tt.forPush, &out); err != nil {
+				t.Fatalf("handleList: %v", err)
+			}
+			if out.String() != tt.want {
+				t.Errorf("got %q, want %q", out.String(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/remotehelper/githelper/options.go
+++ b/internal/remotehelper/githelper/options.go
@@ -25,13 +25,13 @@ type Options struct {
 func (o *Options) Set(name, value string) string {
 	switch name {
 	case "dry-run":
-		o.dryRun = value == "true"
+		o.dryRun = value == optionValueTrue
 	case "atomic":
-		o.atomic = value == "true"
+		o.atomic = value == optionValueTrue
 	case "push-cert":
 		o.pushCert = value
 	case "force-if-includes":
-		o.forceIfIncludes = value == "true"
+		o.forceIfIncludes = value == optionValueTrue
 	case "push-option":
 		o.pushOptions = append(o.pushOptions, value)
 	case "cas":
@@ -58,7 +58,7 @@ func (o *Options) SendPackArgs() []string {
 		args = append(args, "--atomic")
 	}
 	switch o.pushCert {
-	case "true":
+	case optionValueTrue:
 		args = append(args, "--signed=true")
 	case "if-asked":
 		args = append(args, "--signed=if-asked")

--- a/internal/remotehelper/githelper/options.go
+++ b/internal/remotehelper/githelper/options.go
@@ -1,0 +1,76 @@
+package githelper
+
+// Options accumulates `option <name> <value>` commands from git and
+// translates the ones we can act on into `git send-pack` flags. The
+// fields mirror what upstream's transport-helper.c:set_common_push_options
+// forwards before a push: dry-run, atomic, signed (push-cert),
+// force-with-lease (cas), force-if-includes, push-option, plus the
+// per-list object-format option. Unknown options are answered with
+// "unsupported", which transport-helper treats as "ignore me".
+type Options struct {
+	dryRun          bool
+	atomic          bool
+	pushCert        string // "true" / "if-asked" / ""
+	forceIfIncludes bool
+	pushOptions     []string
+	cas             []string // --force-with-lease=<spec>
+}
+
+// Set applies one option and returns the helper-protocol reply line.
+// The value is taken verbatim — booleans use the literal "true"/"false"
+// upstream emits (transport-helper.c:357-361); string options use
+// quote_c_style output, which our consumers (send-pack) accept on
+// input in the same form. We intentionally do not attempt to unquote,
+// so values containing spaces or backslashes round-trip correctly.
+func (o *Options) Set(name, value string) string {
+	switch name {
+	case "dry-run":
+		o.dryRun = value == "true"
+	case "atomic":
+		o.atomic = value == "true"
+	case "push-cert":
+		o.pushCert = value
+	case "force-if-includes":
+		o.forceIfIncludes = value == "true"
+	case "push-option":
+		o.pushOptions = append(o.pushOptions, value)
+	case "cas":
+		o.cas = append(o.cas, value)
+	case "object-format":
+		// Accepted so transport-helper can negotiate object-format
+		// support. send-pack learns the actual format from the ref
+		// advertisement.
+	default:
+		return "unsupported"
+	}
+	return "ok"
+}
+
+// SendPackArgs returns the `git send-pack` flag set corresponding to
+// the accumulated options. Returned slice is fresh; callers can mutate
+// it.
+func (o *Options) SendPackArgs() []string {
+	var args []string
+	if o.dryRun {
+		args = append(args, "--dry-run")
+	}
+	if o.atomic {
+		args = append(args, "--atomic")
+	}
+	switch o.pushCert {
+	case "true":
+		args = append(args, "--signed=true")
+	case "if-asked":
+		args = append(args, "--signed=if-asked")
+	}
+	if o.forceIfIncludes {
+		args = append(args, "--force-if-includes")
+	}
+	for _, po := range o.pushOptions {
+		args = append(args, "--push-option="+po)
+	}
+	for _, cas := range o.cas {
+		args = append(args, "--force-with-lease="+cas)
+	}
+	return args
+}

--- a/internal/remotehelper/githelper/options_test.go
+++ b/internal/remotehelper/githelper/options_test.go
@@ -1,0 +1,75 @@
+package githelper
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestOptions_SetAndSendPackArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		commands  [][2]string
+		wantReply []string
+		wantArgs  []string
+	}{
+		{
+			name:      "no options accepted",
+			commands:  [][2]string{{"object-format", "sha1"}},
+			wantReply: []string{"ok"},
+			wantArgs:  nil,
+		},
+		{
+			name:      "dry-run on",
+			commands:  [][2]string{{"dry-run", "true"}},
+			wantReply: []string{"ok"},
+			wantArgs:  []string{"--dry-run"},
+		},
+		{
+			name:      "atomic + force-if-includes",
+			commands:  [][2]string{{"atomic", "true"}, {"force-if-includes", "true"}},
+			wantReply: []string{"ok", "ok"},
+			wantArgs:  []string{"--atomic", "--force-if-includes"},
+		},
+		{
+			name:      "push-cert true → signed=true",
+			commands:  [][2]string{{"push-cert", "true"}},
+			wantReply: []string{"ok"},
+			wantArgs:  []string{"--signed=true"},
+		},
+		{
+			name:      "push-cert if-asked",
+			commands:  [][2]string{{"push-cert", "if-asked"}},
+			wantReply: []string{"ok"},
+			wantArgs:  []string{"--signed=if-asked"},
+		},
+		{
+			name:      "push-option and cas accumulate",
+			commands:  [][2]string{{"push-option", "ci.skip"}, {"push-option", "ref-prefix=refs/heads/"}, {"cas", "refs/heads/main:deadbeef"}},
+			wantReply: []string{"ok", "ok", "ok"},
+			wantArgs:  []string{"--push-option=ci.skip", "--push-option=ref-prefix=refs/heads/", "--force-with-lease=refs/heads/main:deadbeef"},
+		},
+		{
+			name:      "unknown option → unsupported",
+			commands:  [][2]string{{"weird-option", "value"}},
+			wantReply: []string{"unsupported"},
+			wantArgs:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opts := &Options{}
+			for i, cmd := range tt.commands {
+				if reply := opts.Set(cmd[0], cmd[1]); reply != tt.wantReply[i] {
+					t.Errorf("Set(%q, %q) = %q, want %q", cmd[0], cmd[1], reply, tt.wantReply[i])
+				}
+			}
+			if got := opts.SendPackArgs(); !slices.Equal(got, tt.wantArgs) {
+				t.Errorf("SendPackArgs = %v, want %v", got, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/internal/remotehelper/githelper/push.go
+++ b/internal/remotehelper/githelper/push.go
@@ -48,7 +48,7 @@ func handlePush(ctx context.Context, t Transport, firstLine string, opts *Option
 		return err
 	}
 
-	refsResp, err := t.InfoRefs(ctx, "git-receive-pack")
+	refsResp, err := t.InfoRefs(ctx, serviceReceivePack)
 	if err != nil {
 		return fmt.Errorf("fetching receive-pack info/refs: %w", err)
 	}
@@ -67,7 +67,7 @@ func handlePush(ctx context.Context, t Transport, firstLine string, opts *Option
 	args := append([]string{"send-pack", "--stateless-rpc", "--helper-status", "--stdin"},
 		opts.SendPackArgs()...)
 	args = append(args, t.ErrorBaseURL())
-	sp := exec.CommandContext(ctx, "git", args...) //nolint:gosec // fixed executable; args are constrained git send-pack flags/refspecs from Git's helper protocol.
+	sp := exec.CommandContext(ctx, "git", args...)
 	sp.Stderr = os.Stderr
 	spIn, err := sp.StdinPipe()
 	if err != nil {
@@ -119,7 +119,7 @@ func handlePush(ctx context.Context, t Transport, firstLine string, opts *Option
 		return fmt.Errorf("amending receive-pack agent: %w", err)
 	}
 
-	resp, err := t.ServiceRPC(ctx, "git-receive-pack", bytes.NewReader(amendedBody))
+	resp, err := t.ServiceRPC(ctx, serviceReceivePack, bytes.NewReader(amendedBody))
 	if err != nil {
 		close(respCh)
 		killAndWaitSendPack(sp, "after posting receive-pack failed")

--- a/internal/remotehelper/githelper/push.go
+++ b/internal/remotehelper/githelper/push.go
@@ -1,0 +1,212 @@
+package githelper
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+	"github.com/entireio/cli/internal/remotehelper/gitproto"
+)
+
+// handlePush implements the git-remote-helpers "push" / "push for-push"
+// command sequence. Git sends a batch of "push <src>:<dst>" lines
+// terminated by a blank line; we shell out to
+//
+//	git send-pack --stateless-rpc --helper-status --stdin <url>
+//
+// to do all the heavy lifting (computing reachable objects, building
+// the pack, parsing the v0 ref advertisement, framing the
+// receive-pack request, parsing report-status). Send-pack's
+// stdin/stdout are the "connection" in stateless-rpc mode, so we
+// bridge that to a single HTTP POST against /git-receive-pack — this
+// preserves our scoped-token auth and replica-failover path.
+//
+// Protocol flow (mirroring remote-curl.c:push_git + rpc_service):
+//  1. Read remaining "push <src>:<dst>" lines from git until blank
+//     line.
+//  2. Fetch v0 info/refs?service=git-receive-pack (the ref
+//     advertisement send-pack would normally read from the network).
+//  3. Feed refspecs (as pktlines + flush) + advertisement to
+//     send-pack stdin.
+//  4. Read send-pack stdout as a receive-pack request body (refs +
+//     capabilities + flush, then PACK data for non-delete updates).
+//  5. POST it to /git-receive-pack, stream response back into
+//     send-pack stdin.
+//  6. Send-pack writes a trailing flush + helper-status lines to
+//     stdout; we discard the flush and relay helper-status to git,
+//     then append the blank line that terminates the status batch.
+func handlePush(ctx context.Context, t Transport, firstLine string, opts *Options, stdin *bufio.Reader, stdout io.Writer) error {
+	refspecs, err := readPushBatch(firstLine, stdin)
+	if err != nil {
+		return err
+	}
+
+	refsResp, err := t.InfoRefs(ctx, "git-receive-pack")
+	if err != nil {
+		return fmt.Errorf("fetching receive-pack info/refs: %w", err)
+	}
+	advertisement, err := gitproto.ReadPostServiceAdvertisement(refsResp)
+	_ = refsResp.Close()
+	if err != nil {
+		return fmt.Errorf("reading receive-pack info/refs: %w", err)
+	}
+
+	var preamble bytes.Buffer
+	for _, spec := range refspecs {
+		fmt.Fprintf(&preamble, "%04x%s\n", len(spec)+5, spec)
+	}
+	preamble.WriteString("0000")
+
+	args := append([]string{"send-pack", "--stateless-rpc", "--helper-status", "--stdin"},
+		opts.SendPackArgs()...)
+	args = append(args, t.ErrorBaseURL())
+	sp := exec.CommandContext(ctx, "git", args...) //nolint:gosec // fixed executable; args are constrained git send-pack flags/refspecs from Git's helper protocol.
+	sp.Stderr = os.Stderr
+	spIn, err := sp.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("send-pack stdin pipe: %w", err)
+	}
+	spOut, err := sp.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("send-pack stdout pipe: %w", err)
+	}
+	if err := sp.Start(); err != nil {
+		return fmt.Errorf("starting send-pack: %w", err)
+	}
+
+	respCh := make(chan io.Reader, 1)
+	feedErr := make(chan error, 1)
+	go func() {
+		defer spIn.Close()
+		if _, err := spIn.Write(preamble.Bytes()); err != nil {
+			feedErr <- fmt.Errorf("writing refspecs to send-pack: %w", err)
+			return
+		}
+		if _, err := spIn.Write(advertisement); err != nil {
+			feedErr <- fmt.Errorf("writing advertisement to send-pack: %w", err)
+			return
+		}
+		resp, ok := <-respCh
+		if !ok {
+			feedErr <- nil
+			return
+		}
+		if _, err := io.Copy(spIn, resp); err != nil {
+			feedErr <- fmt.Errorf("piping receive-pack response to send-pack: %w", err)
+			return
+		}
+		feedErr <- nil
+	}()
+
+	spOutReader := bufio.NewReader(spOut)
+	var requestBody bytes.Buffer
+	if err := gitproto.ReadSendPackRequest(spOutReader, &requestBody); err != nil {
+		close(respCh)
+		killAndWaitSendPack(sp, "after reading send-pack request failed")
+		return fmt.Errorf("reading send-pack request: %w", err)
+	}
+	amendedBody, err := gitproto.AppendAgentToReceivePackRequest(requestBody.Bytes(), Agent)
+	if err != nil {
+		close(respCh)
+		killAndWaitSendPack(sp, "after amending receive-pack agent failed")
+		return fmt.Errorf("amending receive-pack agent: %w", err)
+	}
+
+	resp, err := t.ServiceRPC(ctx, "git-receive-pack", bytes.NewReader(amendedBody))
+	if err != nil {
+		close(respCh)
+		killAndWaitSendPack(sp, "after posting receive-pack failed")
+		return fmt.Errorf("posting receive-pack: %w", err)
+	}
+	respCh <- resp
+	close(respCh)
+
+	// Send-pack's stdout sequence after we write the response:
+	//   <0000>                       <- packet_flush(out) at send-pack.c:759
+	//   ok refs/heads/...            <- print_helper_status (plain text)
+	//   error refs/...
+	// Drain the trailing flush so git sees only the newline-delimited
+	// status lines that transport-helper.c:push_update_refs_status
+	// expects.
+	flushBuf := make([]byte, 4)
+	if _, err := io.ReadFull(spOutReader, flushBuf); err != nil {
+		_ = resp.Close()
+		return fmt.Errorf("reading send-pack trailing flush: %w", err)
+	}
+	if string(flushBuf) != "0000" {
+		_ = resp.Close()
+		return fmt.Errorf("expected trailing flush from send-pack, got %q", flushBuf)
+	}
+
+	helperStatus, err := io.ReadAll(spOutReader)
+	_ = resp.Close()
+	if err != nil {
+		return fmt.Errorf("reading helper-status: %w", err)
+	}
+
+	if err := <-feedErr; err != nil {
+		if waitErr := sp.Wait(); waitErr != nil {
+			return errors.Join(err, fmt.Errorf("send-pack exited after feeder error: %w", waitErr))
+		}
+		return err
+	}
+	if err := sp.Wait(); err != nil {
+		return fmt.Errorf("send-pack exited with error: %w", err)
+	}
+
+	if _, err := stdout.Write(helperStatus); err != nil {
+		return fmt.Errorf("writing helper-status: %w", err)
+	}
+	if _, err := fmt.Fprintln(stdout); err != nil {
+		return fmt.Errorf("writing push terminator: %w", err)
+	}
+	return nil
+}
+
+// readPushBatch collects the "push <src>:<dst>" lines that follow the
+// initial firstLine (already consumed by the dispatcher), stopping at
+// the blank line that terminates the batch.
+func readPushBatch(firstLine string, stdin *bufio.Reader) ([]string, error) {
+	spec, ok := strings.CutPrefix(firstLine, "push ")
+	if !ok {
+		return nil, fmt.Errorf("expected 'push <src>:<dst>', got %q", firstLine)
+	}
+	refspecs := []string{spec}
+	for {
+		line, err := stdin.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return nil, fmt.Errorf("reading push batch: %w", err)
+		}
+		line = strings.TrimRight(line, "\n\r")
+		if line == "" {
+			return refspecs, nil
+		}
+		spec, ok := strings.CutPrefix(line, "push ")
+		if !ok {
+			return nil, fmt.Errorf("expected 'push <src>:<dst>', got %q", line)
+		}
+		refspecs = append(refspecs, spec)
+		if err == io.EOF {
+			return refspecs, nil
+		}
+	}
+}
+
+func killAndWaitSendPack(sp *exec.Cmd, reason string) {
+	if sp == nil || sp.Process == nil {
+		return
+	}
+	if err := sp.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		debuglog.Printf("send-pack cleanup %s: kill: %v", reason, err)
+	}
+	if err := sp.Wait(); err != nil {
+		debuglog.Printf("send-pack cleanup %s: wait: %v", reason, err)
+	}
+}

--- a/internal/remotehelper/githelper/run.go
+++ b/internal/remotehelper/githelper/run.go
@@ -80,7 +80,7 @@ func Run(ctx context.Context, t Transport, mode Mode, stdin io.Reader, stdout io
 
 		case strings.HasPrefix(line, "connect "):
 			service := strings.TrimPrefix(line, "connect ")
-			if service != "git-upload-pack" && service != "git-receive-pack" {
+			if service != serviceUploadPack && service != serviceReceivePack {
 				return fmt.Errorf("unsupported service: %s", service)
 			}
 			fmt.Fprintln(stdout)

--- a/internal/remotehelper/githelper/run.go
+++ b/internal/remotehelper/githelper/run.go
@@ -1,0 +1,107 @@
+package githelper
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+)
+
+// Mode selects the helper's capability advertisement.
+type Mode int
+
+const (
+	// ModeConnect (the default) advertises `connect`: git speaks the
+	// raw smart-HTTP protocol and the helper relays request/response
+	// bodies. Works against any receive-pack endpoint without
+	// depending on send-pack's stateless-rpc behaviour.
+	ModeConnect Mode = iota
+	// ModeStateless advertises `stateless-connect` + `push`: v2 fetch
+	// over framed HTTP RPC, push via send-pack subprocess.
+	ModeStateless
+)
+
+// Run drives the git-remote-helper protocol loop against the given
+// Transport. It reads commands from stdin one line at a time and
+// writes responses to stdout until git closes the pipe or sends an
+// unsupported command (which terminates the loop with an error).
+//
+// The Transport interface decouples this loop from any specific HTTP
+// implementation — see the entire/transport package for the
+// production wiring.
+func Run(ctx context.Context, t Transport, mode Mode, stdin io.Reader, stdout io.Writer) error {
+	commandReader := bufio.NewReader(stdin)
+	opts := &Options{}
+
+	for {
+		line, err := commandReader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) && line == "" {
+				return nil
+			}
+			if !errors.Is(err, io.EOF) {
+				return fmt.Errorf("reading protocol input: %w", err)
+			}
+		}
+		line = strings.TrimSuffix(line, "\n")
+		line = strings.TrimSuffix(line, "\r")
+		debuglog.Printf("command: %q", line)
+
+		switch {
+		case line == "capabilities":
+			if mode == ModeStateless {
+				fmt.Fprintln(stdout, "stateless-connect")
+				fmt.Fprintln(stdout, "push")
+			} else {
+				fmt.Fprintln(stdout, "connect")
+			}
+			fmt.Fprintln(stdout, "option")
+			fmt.Fprintln(stdout)
+
+		case line == "list" || line == "list for-push":
+			if err := handleList(ctx, t, line == "list for-push", stdout); err != nil {
+				return err
+			}
+
+		case strings.HasPrefix(line, "option "):
+			name, value, _ := strings.Cut(strings.TrimPrefix(line, "option "), " ")
+			fmt.Fprintln(stdout, opts.Set(name, value))
+
+		case strings.HasPrefix(line, "stateless-connect "):
+			service := strings.TrimPrefix(line, "stateless-connect ")
+			if err := handleStatelessConnect(ctx, t, service, commandReader, stdout); err != nil {
+				return err
+			}
+			return nil
+
+		case strings.HasPrefix(line, "connect "):
+			service := strings.TrimPrefix(line, "connect ")
+			if service != "git-upload-pack" && service != "git-receive-pack" {
+				return fmt.Errorf("unsupported service: %s", service)
+			}
+			fmt.Fprintln(stdout)
+			if err := handleConnect(ctx, t, service, commandReader, stdout); err != nil {
+				return err
+			}
+			return nil
+
+		case strings.HasPrefix(line, "push "):
+			if err := handlePush(ctx, t, line, opts, commandReader, stdout); err != nil {
+				return err
+			}
+
+		case line == "":
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			continue
+
+		default:
+			return fmt.Errorf("unsupported command: %s", line)
+		}
+	}
+}

--- a/internal/remotehelper/githelper/run_test.go
+++ b/internal/remotehelper/githelper/run_test.go
@@ -104,12 +104,12 @@ func TestRun_ConnectUploadPackUsesV0(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
-			if r.URL.Query().Get("service") != "git-upload-pack" {
+			if r.URL.Query().Get("service") != serviceUploadPack {
 				t.Errorf("service = %s", r.URL.Query().Get("service"))
 			}
 			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
 			fmt.Fprint(w, pktLine("# service=git-upload-pack\n")+"0000"+refsAdvertisement)
-		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-upload-pack"):
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, serviceUploadPack):
 			body, _ := io.ReadAll(r.Body) //nolint:errcheck // test
 			posts = append(posts, body)
 			w.Header().Set("Content-Type", "application/x-git-upload-pack-result")

--- a/internal/remotehelper/githelper/run_test.go
+++ b/internal/remotehelper/githelper/run_test.go
@@ -1,0 +1,144 @@
+package githelper
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/internal/remotehelper/replicas"
+	"github.com/entireio/cli/internal/remotehelper/transport"
+)
+
+// testTransport builds a transport.Proxy pointed at a single test
+// server for /et/owner/repo.
+func testTransport(server *httptest.Server) *transport.Proxy {
+	return transport.New(transport.Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{server.URL},
+			EntryURL:     server.URL,
+			ClusterHost:  hostOf(server.URL),
+			RepoPath:     "owner/repo",
+		},
+		Path: "/et/owner/repo",
+	})
+}
+
+func hostOf(u string) string {
+	// Strip scheme.
+	if i := strings.Index(u, "://"); i >= 0 {
+		u = u[i+3:]
+	}
+	if i := strings.IndexByte(u, ':'); i >= 0 {
+		u = u[:i]
+	}
+	return u
+}
+
+// pktLine encodes a string as a git pkt-line.
+func pktLine(s string) string {
+	return fmt.Sprintf("%04x%s", len(s)+4, s)
+}
+
+func TestRun_Capabilities(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		mode Mode
+		want string
+	}{
+		{"default", ModeConnect, "connect\noption\n\n"},
+		{"stateless", ModeStateless, "stateless-connect\npush\noption\n\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			defer server.Close()
+			stdin := strings.NewReader("capabilities\n\n")
+			var stdout bytes.Buffer
+			if err := Run(context.Background(), testTransport(server), tt.mode, stdin, &stdout); err != nil {
+				t.Fatalf("Run failed: %v", err)
+			}
+			if stdout.String() != tt.want {
+				t.Errorf("output = %q, want %q", stdout.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestRun_OptionCommandReplies(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer server.Close()
+
+	stdin := strings.NewReader("option dry-run true\noption weird true\n\n")
+	var stdout bytes.Buffer
+	if err := Run(context.Background(), testTransport(server), ModeConnect, stdin, &stdout); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "ok\n") {
+		t.Errorf("missing ok reply: %q", got)
+	}
+	if !strings.Contains(got, "unsupported\n") {
+		t.Errorf("missing unsupported reply: %q", got)
+	}
+}
+
+// TestRun_ConnectUploadPackUsesV0: in connect mode, git sends `connect
+// git-upload-pack` and expects a v0/v1 bidirectional dialogue: refs
+// advertisement, then wants + flush, then alternating have/ACK rounds
+// terminated by `done`.
+func TestRun_ConnectUploadPackUsesV0(t *testing.T) {
+	t.Parallel()
+	refsAdvertisement := pktLine("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main\x00multi_ack agent=test\n") + "0000"
+	packResponse := "0008NAK\nPACK..."
+
+	var posts [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
+			if r.URL.Query().Get("service") != "git-upload-pack" {
+				t.Errorf("service = %s", r.URL.Query().Get("service"))
+			}
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			fmt.Fprint(w, pktLine("# service=git-upload-pack\n")+"0000"+refsAdvertisement)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-upload-pack"):
+			body, _ := io.ReadAll(r.Body) //nolint:errcheck // test
+			posts = append(posts, body)
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+			fmt.Fprint(w, packResponse)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	wantPkt := pktLine("want aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa multi_ack\n")
+	donePkt := pktLine("done\n")
+	stdin := strings.NewReader("connect git-upload-pack\n" + wantPkt + "0000" + donePkt)
+	var stdout bytes.Buffer
+
+	if err := Run(context.Background(), testTransport(server), ModeConnect, stdin, &stdout); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	wantOut := "\n" + refsAdvertisement + packResponse
+	if stdout.String() != wantOut {
+		t.Errorf("stdout = %q, want %q", stdout.String(), wantOut)
+	}
+	if len(posts) != 1 {
+		t.Fatalf("expected 1 POST (final round with done), got %d", len(posts))
+	}
+	wantBody := wantPkt + "0000" + donePkt
+	if string(posts[0]) != wantBody {
+		t.Errorf("POST body = %q, want %q", posts[0], wantBody)
+	}
+}

--- a/internal/remotehelper/githelper/signal_test.go
+++ b/internal/remotehelper/githelper/signal_test.go
@@ -64,7 +64,7 @@ func TestRun_CtxCancelDuringFetchSurfacesError(t *testing.T) {
 		switch r.Method {
 		case http.MethodGet:
 			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
-			_, _ = w.Write([]byte(serviceAnnouncement("git-upload-pack", //nolint:errcheck // test
+			_, _ = w.Write([]byte(serviceAnnouncement(serviceUploadPack, //nolint:errcheck // test
 				strings.Repeat("a", 40)+" refs/heads/main\x00multi_ack\n")))
 		default:
 			select {

--- a/internal/remotehelper/githelper/signal_test.go
+++ b/internal/remotehelper/githelper/signal_test.go
@@ -1,0 +1,162 @@
+package githelper
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestRun_StdinCloseExitsCleanly: when git closes the helper's
+// stdin without sending a command, Run must return nil (not error).
+// This is the normal shutdown path — git ends the session by
+// closing the pipe.
+func TestRun_StdinCloseExitsCleanly(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer server.Close()
+
+	var out bytes.Buffer
+	if err := Run(context.Background(), testTransport(server), ModeConnect, strings.NewReader(""), &out); err != nil {
+		t.Fatalf("Run on empty stdin: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output on empty stdin, got %q", out.String())
+	}
+}
+
+// TestRun_PartialCommandLineErrors: when stdin terminates mid-line
+// (no trailing newline), the partial token reaches the dispatcher
+// and is rejected as an unknown command. This matches upstream
+// transport-helper.c, which dies on unknown helper-protocol
+// commands rather than silently ignoring them — a typo'd command
+// would otherwise look like a no-op.
+func TestRun_PartialCommandLineErrors(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	var out bytes.Buffer
+	err := Run(context.Background(), testTransport(server), ModeConnect, strings.NewReader("capab"), &out)
+	if err == nil {
+		t.Fatal("expected error on partial / unknown command")
+	}
+	if !strings.Contains(err.Error(), "unsupported command") {
+		t.Errorf("error = %v, want unsupported-command shape", err)
+	}
+}
+
+// TestRun_CtxCancelDuringFetchSurfacesError: a context cancellation
+// during a hanging git-upload-pack POST must surface as an error
+// from Run — not a silent return that would leave git thinking the
+// fetch completed cleanly.
+func TestRun_CtxCancelDuringFetchSurfacesError(t *testing.T) {
+	t.Parallel()
+	hold := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			_, _ = w.Write([]byte(serviceAnnouncement("git-upload-pack", //nolint:errcheck // test
+				strings.Repeat("a", 40)+" refs/heads/main\x00multi_ack\n")))
+		default:
+			select {
+			case <-hold:
+			case <-r.Context().Done():
+			}
+		}
+	}))
+	defer server.Close()
+	defer close(hold)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	// Connect-mode upload-pack: refs read, then wants + flush + done
+	// triggers a POST.
+	wantPkt := pktLine("want " + strings.Repeat("a", 40) + " multi_ack\n")
+	donePkt := pktLine("done\n")
+	stdin := strings.NewReader("connect git-upload-pack\n" + wantPkt + "0000" + donePkt)
+
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, testTransport(server), ModeConnect, stdin, &out)
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected error on ctx cancellation")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after ctx timeout")
+	}
+}
+
+// blockingReader returns 0,nil forever until unblock is closed, then
+// returns 0,io.EOF. Simulates an SSH/HTTP stdin that's open but
+// silent — the same shape git presents while the user thinks before
+// the next command.
+type blockingReader struct {
+	unblock chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingReader) Read(_ []byte) (int, error) {
+	<-b.unblock
+	return 0, io.EOF
+}
+
+// TestRun_ParentContextCancelStopsBlockedRead: when stdin is a slow
+// reader and the parent context cancels, Run currently cannot abort
+// stdin reads (they're not ctx-aware), but it must not panic and
+// must not write spurious output before exiting. This pins current
+// behaviour: ctx cancellation stops new HTTP work, but stdin reads
+// only finish when git closes its end. Documenting this so a future
+// change that introduces ctx-aware stdin reads has a checkpoint.
+func TestRun_ParentContextCancelStopsBlockedRead(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	br := &blockingReader{unblock: make(chan struct{})}
+	t.Cleanup(func() { br.once.Do(func() { close(br.unblock) }) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, testTransport(server), ModeConnect, br, &out)
+	}()
+
+	// Give Run time to enter the read; then cancel. Run won't return
+	// until the read unblocks (stdin isn't ctx-aware), but it must
+	// not have written spurious output.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	if out.Len() != 0 {
+		t.Errorf("Run wrote output before stdin returned: %q", out.String())
+	}
+
+	// Unblock so the test exits.
+	br.once.Do(func() { close(br.unblock) })
+	select {
+	case err := <-done:
+		// EOF on stdin → clean return (nil) is the documented shape.
+		if err != nil && !errors.Is(err, io.EOF) {
+			t.Errorf("Run after unblock: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after stdin EOF")
+	}
+}

--- a/internal/remotehelper/githelper/stateless.go
+++ b/internal/remotehelper/githelper/stateless.go
@@ -19,8 +19,8 @@ import (
 // independent POST.
 func handleStatelessConnect(ctx context.Context, t Transport, service string, stdin io.Reader, stdout io.Writer) error {
 	switch service {
-	case "git-upload-pack":
-	case "git-receive-pack":
+	case serviceUploadPack:
+	case serviceReceivePack:
 		fmt.Fprintln(stdout)
 		return handleConnect(ctx, t, service, stdin, stdout)
 	default:

--- a/internal/remotehelper/githelper/stateless.go
+++ b/internal/remotehelper/githelper/stateless.go
@@ -1,0 +1,114 @@
+package githelper
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+	"github.com/entireio/cli/internal/remotehelper/gitproto"
+)
+
+// handleStatelessConnect proxies Git protocol v2 upload-pack. The
+// remote helper contract is the same shape as git-remote-curl: first
+// prove the server speaks v2 by fetching info/refs with
+// Git-Protocol: version=2, then write the server's capability
+// advertisement and relay each flush-terminated request body as an
+// independent POST.
+func handleStatelessConnect(ctx context.Context, t Transport, service string, stdin io.Reader, stdout io.Writer) error {
+	switch service {
+	case "git-upload-pack":
+	case "git-receive-pack":
+		fmt.Fprintln(stdout)
+		return handleConnect(ctx, t, service, stdin, stdout)
+	default:
+		fmt.Fprintln(stdout, "fallback")
+		return nil
+	}
+
+	refs, err := t.InfoRefsV2(ctx)
+	if err != nil {
+		return fmt.Errorf("stateless-connect v2 info/refs: %w", err)
+	}
+	defer refs.Close()
+
+	advertisement, err := io.ReadAll(refs)
+	if err != nil {
+		return fmt.Errorf("reading v2 info/refs: %w", err)
+	}
+	if !gitproto.IsV2Advertisement(advertisement) {
+		fmt.Fprintln(stdout, "fallback")
+		return nil
+	}
+
+	// bundle-uri is left for native git to drive — we don't intercept
+	// the catalogue or inject auth here. If the server advertises
+	// bundle-uri and the user opted in via transfer.bundleURI=true,
+	// they're responsible for configuring credentials for the bundle
+	// host (e.g. via credential.helper / netrc /
+	// http.<url>.extraHeader). Previously we generated a temp config
+	// with a Bearer token in plain text on disk to make this Just
+	// Work; the security trade-off wasn't worth the convenience.
+
+	fmt.Fprintln(stdout)
+	if _, err := stdout.Write(advertisement); err != nil {
+		return fmt.Errorf("streaming v2 capabilities: %w", err)
+	}
+
+	for {
+		reqBody, ok, err := gitproto.ReadFlushTerminatedMessage(stdin)
+		if err != nil {
+			return fmt.Errorf("stateless-connect: read request: %w", err)
+		}
+		if !ok {
+			return nil
+		}
+		reqBody, err = gitproto.AppendAgentToV2Request(reqBody, Agent)
+		if err != nil {
+			return fmt.Errorf("stateless-connect: amend agent: %w", err)
+		}
+		command := gitproto.V2Command(reqBody)
+		if command != "" {
+			debuglog.Printf("v2 command: %s", command)
+		}
+
+		resp, err := t.ServiceRPC(ctx, service, bytes.NewReader(reqBody), func(req *http.Request) {
+			req.Header.Set("Git-Protocol", "version=2")
+		})
+		if err != nil {
+			return fmt.Errorf("stateless-connect: POST: %w", err)
+		}
+
+		if command == "bundle-uri" {
+			respBody, readErr := io.ReadAll(resp)
+			if readErr != nil {
+				_ = resp.Close()
+				return fmt.Errorf("reading bundle-uri response: %w", readErr)
+			}
+			if err := resp.Close(); err != nil {
+				return fmt.Errorf("closing bundle-uri response: %w", err)
+			}
+			if len(respBody) == 0 {
+				debuglog.Printf("bundle-uri response was empty; synthesizing flush packet")
+				respBody = []byte("0000")
+			}
+			if _, err := stdout.Write(respBody); err != nil {
+				return fmt.Errorf("streaming bundle-uri response: %w", err)
+			}
+		} else {
+			if _, err := io.Copy(stdout, resp); err != nil {
+				_ = resp.Close()
+				return fmt.Errorf("streaming stateless response: %w", err)
+			}
+			if err := resp.Close(); err != nil {
+				return fmt.Errorf("closing stateless response: %w", err)
+			}
+		}
+
+		if _, err := stdout.Write([]byte("0002")); err != nil {
+			return fmt.Errorf("writing response-end packet: %w", err)
+		}
+	}
+}

--- a/internal/remotehelper/githelper/stateless_test.go
+++ b/internal/remotehelper/githelper/stateless_test.go
@@ -21,7 +21,7 @@ func TestHandleStatelessConnect_UploadPack(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
-			if r.URL.Query().Get("service") != "git-upload-pack" {
+			if r.URL.Query().Get("service") != serviceUploadPack {
 				t.Errorf("service = %q", r.URL.Query().Get("service"))
 			}
 			if r.Header.Get("Git-Protocol") != "version=2" {
@@ -30,7 +30,7 @@ func TestHandleStatelessConnect_UploadPack(t *testing.T) {
 			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
 			fmt.Fprint(w, advertisement)
 
-		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-upload-pack"):
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, serviceUploadPack):
 			if r.Header.Get("Git-Protocol") != "version=2" {
 				t.Errorf("Git-Protocol = %q", r.Header.Get("Git-Protocol"))
 			}
@@ -49,7 +49,7 @@ func TestHandleStatelessConnect_UploadPack(t *testing.T) {
 	input := strings.NewReader(requestBody)
 
 	var stdout bytes.Buffer
-	if err := handleStatelessConnect(context.Background(), testTransport(server), "git-upload-pack", input, &stdout); err != nil {
+	if err := handleStatelessConnect(context.Background(), testTransport(server), serviceUploadPack, input, &stdout); err != nil {
 		t.Fatalf("handleStatelessConnect failed: %v", err)
 	}
 
@@ -80,7 +80,7 @@ func TestHandleStatelessConnect_AmendsClientAgent(t *testing.T) {
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
 			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
 			fmt.Fprint(w, advertisement)
-		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-upload-pack"):
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, serviceUploadPack):
 			post, _ = io.ReadAll(r.Body) //nolint:errcheck // test
 			w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
 			fmt.Fprint(w, "0000")
@@ -92,7 +92,7 @@ func TestHandleStatelessConnect_AmendsClientAgent(t *testing.T) {
 	defer server.Close()
 
 	var stdout bytes.Buffer
-	if err := handleStatelessConnect(context.Background(), testTransport(server), "git-upload-pack", strings.NewReader(requestBody), &stdout); err != nil {
+	if err := handleStatelessConnect(context.Background(), testTransport(server), serviceUploadPack, strings.NewReader(requestBody), &stdout); err != nil {
 		t.Fatalf("handleStatelessConnect failed: %v", err)
 	}
 	if string(post) != wantBody {
@@ -110,7 +110,7 @@ func TestHandleStatelessConnect_EmptyBundleURIResponseSynthesizesFlush(t *testin
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
 			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
 			fmt.Fprint(w, advertisement)
-		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-upload-pack"):
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, serviceUploadPack):
 			body, _ := io.ReadAll(r.Body) //nolint:errcheck // test
 			if string(body) != requestBody {
 				t.Errorf("POST body = %q, want %q", body, requestBody)
@@ -125,7 +125,7 @@ func TestHandleStatelessConnect_EmptyBundleURIResponseSynthesizesFlush(t *testin
 	defer server.Close()
 
 	var stdout bytes.Buffer
-	if err := handleStatelessConnect(context.Background(), testTransport(server), "git-upload-pack", strings.NewReader(requestBody), &stdout); err != nil {
+	if err := handleStatelessConnect(context.Background(), testTransport(server), serviceUploadPack, strings.NewReader(requestBody), &stdout); err != nil {
 		t.Fatalf("handleStatelessConnect failed: %v", err)
 	}
 
@@ -148,9 +148,9 @@ func TestHandleStatelessConnect_FallbackForUnsupportedService(t *testing.T) {
 
 func TestHandleStatelessConnect_ReceivePack(t *testing.T) {
 	t.Parallel()
-	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oldSHA := testHeadSHA
 	newSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	ref := "refs/heads/main"
+	ref := testRefMain
 	packData := "PACK fake pack data here"
 
 	refLine := oldSHA + " " + ref + "\x00 report-status\n"
@@ -164,7 +164,7 @@ func TestHandleStatelessConnect_ReceivePack(t *testing.T) {
 	stdin.WriteString(packData)
 
 	var stdout bytes.Buffer
-	if err := handleStatelessConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &stdout); err != nil {
+	if err := handleStatelessConnect(context.Background(), testTransport(server), serviceReceivePack, &stdin, &stdout); err != nil {
 		t.Fatalf("handleStatelessConnect failed: %v", err)
 	}
 

--- a/internal/remotehelper/githelper/stateless_test.go
+++ b/internal/remotehelper/githelper/stateless_test.go
@@ -1,0 +1,180 @@
+package githelper
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleStatelessConnect_UploadPack(t *testing.T) {
+	t.Parallel()
+	advertisement := pktLine("version 2\n") + pktLine("agent=test\n") + pktLine("ls-refs=unborn\n") + "0000"
+	requestBody := pktLine("command=ls-refs\n") + "0000"
+	responseBody := pktLine("refs/heads/main HEAD\n") + "0000"
+
+	var posts [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
+			if r.URL.Query().Get("service") != "git-upload-pack" {
+				t.Errorf("service = %q", r.URL.Query().Get("service"))
+			}
+			if r.Header.Get("Git-Protocol") != "version=2" {
+				t.Errorf("Git-Protocol = %q", r.Header.Get("Git-Protocol"))
+			}
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			fmt.Fprint(w, advertisement)
+
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-upload-pack"):
+			if r.Header.Get("Git-Protocol") != "version=2" {
+				t.Errorf("Git-Protocol = %q", r.Header.Get("Git-Protocol"))
+			}
+			body, _ := io.ReadAll(r.Body) //nolint:errcheck // test
+			posts = append(posts, body)
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+			fmt.Fprint(w, responseBody)
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	input := strings.NewReader(requestBody)
+
+	var stdout bytes.Buffer
+	if err := handleStatelessConnect(context.Background(), testTransport(server), "git-upload-pack", input, &stdout); err != nil {
+		t.Fatalf("handleStatelessConnect failed: %v", err)
+	}
+
+	if len(posts) != 1 {
+		t.Fatalf("POST count = %d, want 1", len(posts))
+	}
+	if string(posts[0]) != requestBody {
+		t.Errorf("POST body = %q, want %q", posts[0], requestBody)
+	}
+
+	want := "\n" + advertisement + responseBody + "0002"
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestHandleStatelessConnect_AmendsClientAgent(t *testing.T) {
+	t.Parallel()
+	advertisement := pktLine("version 2\n") + pktLine("agent=test\n") + pktLine("ls-refs=unborn\n") + "0000"
+	requestBody := pktLine("command=ls-refs\n") + pktLine("agent=git/2.54.0\n") + "0000"
+	wantBody := pktLine("command=ls-refs\n") +
+		pktLine("agent=git/2.54.0 "+Agent+"\n") +
+		"0000"
+
+	var post []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			fmt.Fprint(w, advertisement)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-upload-pack"):
+			post, _ = io.ReadAll(r.Body) //nolint:errcheck // test
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+			fmt.Fprint(w, "0000")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	if err := handleStatelessConnect(context.Background(), testTransport(server), "git-upload-pack", strings.NewReader(requestBody), &stdout); err != nil {
+		t.Fatalf("handleStatelessConnect failed: %v", err)
+	}
+	if string(post) != wantBody {
+		t.Errorf("POST body = %q, want %q", post, wantBody)
+	}
+}
+
+func TestHandleStatelessConnect_EmptyBundleURIResponseSynthesizesFlush(t *testing.T) {
+	t.Parallel()
+	advertisement := pktLine("version 2\n") + pktLine("agent=test\n") + pktLine("bundle-uri\n") + "0000"
+	requestBody := pktLine("command=bundle-uri\n") + "0000"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "info/refs"):
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			fmt.Fprint(w, advertisement)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "git-upload-pack"):
+			body, _ := io.ReadAll(r.Body) //nolint:errcheck // test
+			if string(body) != requestBody {
+				t.Errorf("POST body = %q, want %q", body, requestBody)
+			}
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	if err := handleStatelessConnect(context.Background(), testTransport(server), "git-upload-pack", strings.NewReader(requestBody), &stdout); err != nil {
+		t.Fatalf("handleStatelessConnect failed: %v", err)
+	}
+
+	want := "\n" + advertisement + "00000002"
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
+}
+
+func TestHandleStatelessConnect_FallbackForUnsupportedService(t *testing.T) {
+	t.Parallel()
+	var stdout bytes.Buffer
+	if err := handleStatelessConnect(context.Background(), nil, "git-archive", strings.NewReader(""), &stdout); err != nil {
+		t.Fatalf("handleStatelessConnect failed: %v", err)
+	}
+	if stdout.String() != "fallback\n" {
+		t.Errorf("stdout = %q, want fallback", stdout.String())
+	}
+}
+
+func TestHandleStatelessConnect_ReceivePack(t *testing.T) {
+	t.Parallel()
+	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	ref := "refs/heads/main"
+	packData := "PACK fake pack data here"
+
+	refLine := oldSHA + " " + ref + "\x00 report-status\n"
+	server, receivedPushSize := receivePackServer(t, refLine, ref)
+	defer server.Close()
+
+	var stdin bytes.Buffer
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	stdin.WriteString(pktLine(cmd))
+	stdin.WriteString("0000")
+	stdin.WriteString(packData)
+
+	var stdout bytes.Buffer
+	if err := handleStatelessConnect(context.Background(), testTransport(server), "git-receive-pack", &stdin, &stdout); err != nil {
+		t.Fatalf("handleStatelessConnect failed: %v", err)
+	}
+
+	if !strings.HasPrefix(stdout.String(), "\n") {
+		t.Errorf("stdout should start with stateless-connect success line, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "unpack ok") {
+		t.Errorf("expected receive-pack response in stdout, got %q", stdout.String())
+	}
+	if *receivedPushSize == "" {
+		t.Fatal("X-Entire-Push-Size header not sent")
+	}
+}

--- a/internal/remotehelper/githelper/transport.go
+++ b/internal/remotehelper/githelper/transport.go
@@ -1,0 +1,31 @@
+// Package githelper implements the git-remote-helper protocol: the
+// "capabilities / list / option / connect / stateless-connect / push"
+// command loop that canonical Git speaks to any helper binary on
+// stdin/stdout, plus the bodies of those commands (ref listing,
+// fetch negotiation, push relay).
+//
+// The protocol layer is decoupled from the wire layer via the
+// Transport interface so callers can plug a different backend in
+// without dragging Entire-specific concerns into this package.
+package githelper
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+// Transport is the wire layer the helper protocol speaks against. In
+// production it's *entire/transport.Proxy; tests can supply a fake.
+type Transport interface {
+	// InfoRefs fetches the v0/v1 ref advertisement.
+	InfoRefs(ctx context.Context, service string) (io.ReadCloser, error)
+	// InfoRefsV2 fetches the v2 capability advertisement.
+	InfoRefsV2(ctx context.Context) (io.ReadCloser, error)
+	// ServiceRPC sends a request to /<service> and returns the
+	// response. extraHeaders runs on each request before send.
+	ServiceRPC(ctx context.Context, service string, body io.ReadSeeker, extraHeaders ...func(*http.Request)) (io.ReadCloser, error)
+	// ErrorBaseURL is embedded into helper-status error messages and
+	// passed to send-pack as the remote URL.
+	ErrorBaseURL() string
+}

--- a/internal/remotehelper/gitproto/agent.go
+++ b/internal/remotehelper/gitproto/agent.go
@@ -1,0 +1,221 @@
+package gitproto
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+// AppendAgentToV2Request appends helperAgent to an existing v2
+// client-side agent line. It leaves requests without agent= unchanged.
+func AppendAgentToV2Request(message []byte, helperAgent string) ([]byte, error) {
+	if helperAgent == "" {
+		return message, nil
+	}
+
+	for off := 0; off < len(message); {
+		line, err := parseRawPktLine(message, off)
+		if err != nil {
+			return nil, err
+		}
+		if line.special() {
+			off = line.next
+			continue
+		}
+		if !bytes.HasPrefix(line.payload, []byte("agent=")) {
+			off = line.next
+			continue
+		}
+
+		amendedPayload := appendAgentPayload(line.payload, helperAgent, " ")
+		if bytes.Equal(amendedPayload, line.payload) {
+			return message, nil
+		}
+		return replacePktLine(message, line, amendedPayload)
+	}
+
+	return message, nil
+}
+
+// AppendAgentToUploadPackRequest appends helperAgent to the agent
+// capability in a v0/v1 upload-pack request. It leaves requests
+// without agent= unchanged.
+func AppendAgentToUploadPackRequest(message []byte, helperAgent string) ([]byte, error) {
+	if helperAgent == "" || len(message) == 0 {
+		return message, nil
+	}
+
+	line, err := parseRawPktLine(message, 0)
+	if err != nil {
+		return nil, err
+	}
+	if line.special() || !bytes.HasPrefix(line.payload, []byte("want ")) {
+		return message, nil
+	}
+
+	payload, eol := splitTrailingLF(line.payload)
+	fields := bytes.SplitN(payload, []byte{' '}, 3)
+	if len(fields) < 3 {
+		return message, nil
+	}
+
+	caps, changed := appendAgentCapability(fields[2], helperAgent)
+	if !changed {
+		return message, nil
+	}
+
+	amendedPayload := make([]byte, 0, len(payload)+len(helperAgent)+1+len(eol))
+	amendedPayload = append(amendedPayload, fields[0]...)
+	amendedPayload = append(amendedPayload, ' ')
+	amendedPayload = append(amendedPayload, fields[1]...)
+	amendedPayload = append(amendedPayload, ' ')
+	amendedPayload = append(amendedPayload, caps...)
+	amendedPayload = append(amendedPayload, eol...)
+	return replacePktLine(message, line, amendedPayload)
+}
+
+// AppendAgentToReceivePackRequest appends helperAgent to the agent
+// capability on the first receive-pack command line. It leaves
+// requests without agent= unchanged.
+func AppendAgentToReceivePackRequest(message []byte, helperAgent string) ([]byte, error) {
+	if helperAgent == "" {
+		return message, nil
+	}
+
+	for off := 0; off < len(message); {
+		line, err := parseRawPktLine(message, off)
+		if err != nil {
+			return nil, err
+		}
+		if line.special() {
+			return message, nil
+		}
+
+		command, capsPayload, ok := bytes.Cut(line.payload, []byte{0})
+		if !ok {
+			off = line.next
+			continue
+		}
+
+		capsPayload, eol := splitTrailingLF(capsPayload)
+		caps, changed := appendAgentCapability(capsPayload, helperAgent)
+		if !changed {
+			return message, nil
+		}
+
+		amendedPayload := make([]byte, 0, len(line.payload)+len(helperAgent)+1)
+		amendedPayload = append(amendedPayload, command...)
+		amendedPayload = append(amendedPayload, 0)
+		amendedPayload = append(amendedPayload, caps...)
+		amendedPayload = append(amendedPayload, eol...)
+		return replacePktLine(message, line, amendedPayload)
+	}
+
+	return message, nil
+}
+
+type rawPktLine struct {
+	start   int
+	next    int
+	length  int
+	payload []byte
+}
+
+func (l rawPktLine) special() bool {
+	return l.length == pktline.Flush ||
+		l.length == pktline.Delim ||
+		l.length == pktline.ResponseEnd
+}
+
+func parseRawPktLine(message []byte, off int) (rawPktLine, error) {
+	if len(message)-off < pktline.LenSize {
+		return rawPktLine{}, fmt.Errorf("pkt-line length at offset %d: %w", off, io.ErrUnexpectedEOF)
+	}
+	pktLen, err := pktline.ParseLength(message[off : off+pktline.LenSize])
+	if err != nil {
+		return rawPktLine{}, fmt.Errorf("parsing pkt-line length at offset %d: %w", off, err)
+	}
+	switch pktLen {
+	case pktline.Flush, pktline.Delim, pktline.ResponseEnd:
+		return rawPktLine{start: off, next: off + pktline.LenSize, length: pktLen}, nil
+	}
+	if pktLen < pktline.LenSize {
+		return rawPktLine{}, fmt.Errorf("invalid pkt-line length %d at offset %d", pktLen, off)
+	}
+	next := off + pktLen
+	if next > len(message) {
+		return rawPktLine{}, fmt.Errorf("pkt-line length %d at offset %d exceeds message length", pktLen, off)
+	}
+	return rawPktLine{
+		start:   off,
+		next:    next,
+		length:  pktLen,
+		payload: message[off+pktline.LenSize : next],
+	}, nil
+}
+
+func replacePktLine(message []byte, line rawPktLine, payload []byte) ([]byte, error) {
+	if len(payload)+pktline.LenSize > 0xffff {
+		return nil, fmt.Errorf("amended pkt-line too long: %d bytes", len(payload)+pktline.LenSize)
+	}
+	var out bytes.Buffer
+	out.Grow(len(message) + len(payload) - len(line.payload))
+	out.Write(message[:line.start])
+	if _, err := fmt.Fprintf(&out, "%04x", len(payload)+pktline.LenSize); err != nil {
+		return nil, fmt.Errorf("writing pkt-line length: %w", err)
+	}
+	out.Write(payload)
+	out.Write(message[line.next:])
+	return out.Bytes(), nil
+}
+
+func appendAgentPayload(payload []byte, helperAgent, separator string) []byte {
+	body, eol := splitTrailingLF(payload)
+	value := strings.TrimPrefix(string(body), "agent=")
+	amendedValue, changed := appendAgentValue(value, helperAgent, separator)
+	if !changed {
+		return payload
+	}
+	amended := make([]byte, 0, len("agent=")+len(amendedValue)+len(eol))
+	amended = append(amended, "agent="...)
+	amended = append(amended, amendedValue...)
+	amended = append(amended, eol...)
+	return amended
+}
+
+func appendAgentCapability(caps []byte, helperAgent string) ([]byte, bool) {
+	parts := bytes.Split(caps, []byte{' '})
+	for i, part := range parts {
+		value, ok := bytes.CutPrefix(part, []byte("agent="))
+		if !ok {
+			continue
+		}
+		amendedValue, changed := appendAgentValue(string(value), helperAgent, "+")
+		if !changed {
+			return caps, false
+		}
+		parts[i] = []byte("agent=" + amendedValue)
+		return bytes.Join(parts, []byte{' '}), true
+	}
+	return caps, false
+}
+
+func appendAgentValue(value, helperAgent, separator string) (string, bool) {
+	if value == "" {
+		return helperAgent, true
+	}
+	if strings.Contains(value, helperAgent) {
+		return value, false
+	}
+	return value + separator + helperAgent, true
+}
+
+func splitTrailingLF(b []byte) ([]byte, []byte) {
+	if len(b) > 0 && b[len(b)-1] == '\n' {
+		return b[:len(b)-1], b[len(b)-1:]
+	}
+	return b, nil
+}

--- a/internal/remotehelper/gitproto/consts_test.go
+++ b/internal/remotehelper/gitproto/consts_test.go
@@ -1,0 +1,10 @@
+package gitproto
+
+// Shared test fixtures. Extracted to package-level constants so repeated
+// literals across the test files satisfy goconst.
+const (
+	testRefMain          = "refs/heads/main"
+	testRefFeatureBranch = "refs/heads/feature-branch"
+	testHeadSHA          = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testFakePackData     = "PACK fake pack data here"
+)

--- a/internal/remotehelper/gitproto/fuzz_test.go
+++ b/internal/remotehelper/gitproto/fuzz_test.go
@@ -1,0 +1,116 @@
+package gitproto
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// FuzzIsV2Advertisement exercises the v2-advertisement detector
+// against arbitrary byte sequences. The function returns a boolean
+// with no error channel, so the only thing we check is that we never
+// panic and never read beyond the input.
+func FuzzIsV2Advertisement(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("000a"))
+	f.Add([]byte("000eversion 2\n"))
+	f.Add([]byte("000eversion 1\n"))
+	f.Add([]byte("ffff"))
+	f.Add([]byte("zzzz"))
+
+	f.Fuzz(func(_ *testing.T, in []byte) {
+		// Don't validate the result — just that it returns without
+		// panicking and doesn't take ages on pathological lengths.
+		_ = IsV2Advertisement(in)
+	})
+}
+
+// FuzzV2Command exercises the v2 command extractor. The function
+// returns "" on any malformed input rather than erroring, so we only
+// pin "never panic".
+func FuzzV2Command(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("0014command=ls-refs\n0000"))
+	f.Add([]byte("0000"))
+	f.Add([]byte("0001"))
+	f.Add([]byte("0002"))
+	f.Add([]byte("ffffXXXX"))
+	f.Add([]byte("003eaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main\n0000"))
+
+	f.Fuzz(func(_ *testing.T, in []byte) {
+		_ = V2Command(in)
+	})
+}
+
+// FuzzReadReceivePackRequest fuzzes the receive-pack request reader.
+// Contract: never panic; if no error, the returned bytes mirror the
+// consumed input shape (length-prefix correctness is the caller's
+// problem).
+func FuzzReadReceivePackRequest(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("0000"))
+	f.Add([]byte("000aabcdef\n0000"))
+	f.Add([]byte("000aabcdef\n0000PACK fakepackdata"))
+	// Receive-pack-shaped command (delete) plus flush.
+	deleteCmd := strings.Repeat("a", 40) + " " + strings.Repeat("0", 40) +
+		" refs/heads/x\x00 report-status delete-refs\n"
+	f.Add([]byte("009f" + deleteCmd + "0000"))
+	f.Add([]byte("0003"))
+
+	f.Fuzz(func(_ *testing.T, in []byte) {
+		_, _ = ReadReceivePackRequest(bytes.NewReader(in)) //nolint:errcheck // fuzz: panics matter, errors don't
+	})
+}
+
+// FuzzReadSendPackRequest fuzzes the outer send-pack stateless-rpc
+// framing parser. Contract: never panic. send-pack stdout has a
+// stricter shape than receive-pack input — the parser should reject
+// truncations rather than read past EOF.
+func FuzzReadSendPackRequest(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("0000"))
+	f.Add([]byte("000a8 byte0000"))
+	f.Add([]byte("000a8 byte000a8 byte0000"))
+	f.Add([]byte("00ff"))
+	f.Add([]byte("0003"))
+
+	f.Fuzz(func(_ *testing.T, in []byte) {
+		var out bytes.Buffer
+		_ = ReadSendPackRequest(bufio.NewReader(bytes.NewReader(in)), &out) //nolint:errcheck // fuzz
+	})
+}
+
+// FuzzReadPostServiceAdvertisement fuzzes the smart-HTTP info/refs
+// preamble stripper. The fuzz contract is only that arbitrary input
+// does not panic or exhaust memory; malformed input may return any
+// ordinary error.
+func FuzzReadPostServiceAdvertisement(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("001f# service=git-upload-pack\n0000"))
+	f.Add([]byte("001f# service=git-receive-pack\n0000refs"))
+	f.Add([]byte("0000refs"))
+	f.Add([]byte("ffff"))
+
+	f.Fuzz(func(_ *testing.T, in []byte) {
+		_, _ = ReadPostServiceAdvertisement(bytes.NewReader(in)) //nolint:errcheck // fuzz: panics and OOMs matter, errors don't
+	})
+}
+
+// FuzzReadFlushTerminatedMessage exercises the v2 flush-terminated
+// message reader. The fuzz contract is only that arbitrary input does
+// not panic or exhaust memory; semantic invariants live in unit tests.
+func FuzzReadFlushTerminatedMessage(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("0000"))
+	f.Add([]byte("0001000a 0000"))
+	f.Add([]byte("0010some content padded0000"))
+	f.Add([]byte("000ahello\n0000"))
+	f.Add([]byte("0003"))         // sub-minimum length
+	f.Add([]byte("ffff"))         // largest length, no payload follows
+	f.Add([]byte("ffffaaaaaaaa")) // length larger than payload
+
+	f.Fuzz(func(_ *testing.T, in []byte) {
+		_, _, _ = ReadFlushTerminatedMessage(bytes.NewReader(in)) //nolint:errcheck // fuzz: panics and OOMs matter, errors don't
+	})
+}

--- a/internal/remotehelper/gitproto/gitproto.go
+++ b/internal/remotehelper/gitproto/gitproto.go
@@ -1,0 +1,274 @@
+// Package gitproto implements higher-level Git smart-HTTP / stateless-RPC
+// wire helpers built on top of the pkt-line layer in
+// github.com/go-git/go-git/v6/plumbing/format/pktline:
+//
+//   - v2 capability-advertisement detection (IsV2Advertisement)
+//   - v2-request command extraction (V2Command)
+//   - reading a flush-terminated v2 message verbatim
+//     (ReadFlushTerminatedMessage)
+//   - stripping the smart-HTTP service announcement
+//     (ReadPostServiceAdvertisement, backed by packp.SmartReply)
+//   - reading the receive-pack request body the helper relays
+//   - reading the send-pack stateless-rpc outer framing
+//
+// Everything here is pure Git protocol — no Entire-specific knowledge.
+package gitproto
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+)
+
+// IsV2Advertisement reports whether p begins with the v2 service
+// capability line ("version 2\n"). The peek is conservative: if the
+// length prefix is malformed or claims more bytes than p contains,
+// we return false rather than panic.
+func IsV2Advertisement(p []byte) bool {
+	if len(p) < pktline.LenSize {
+		return false
+	}
+	n, err := pktline.ParseLength(p[:pktline.LenSize])
+	if err != nil || n < pktline.LenSize || len(p) < n {
+		return false
+	}
+	return string(p[pktline.LenSize:n]) == "version 2\n"
+}
+
+// V2Command extracts the "command=" value from a v2 fetch / ls-refs /
+// bundle-uri request message. The message is the bytes between two
+// flushes (callers typically pass the buffer returned by
+// ReadFlushTerminatedMessage). Returns "" when the message is
+// malformed, truncated, or carries no command pktline.
+func V2Command(message []byte) string {
+	for len(message) > 0 {
+		if len(message) < pktline.LenSize {
+			return ""
+		}
+		pktLen, err := pktline.ParseLength(message[:pktline.LenSize])
+		if err != nil {
+			return ""
+		}
+		switch pktLen {
+		case pktline.Flush:
+			return ""
+		case pktline.Delim, pktline.ResponseEnd:
+			message = message[pktline.LenSize:]
+			continue
+		}
+		if pktLen < pktline.LenSize || len(message) < pktLen {
+			return ""
+		}
+		line := string(message[pktline.LenSize:pktLen])
+		if after, ok := strings.CutPrefix(line, "command="); ok {
+			return strings.TrimSuffix(after, "\n")
+		}
+		message = message[pktLen:]
+	}
+	return ""
+}
+
+// ReadFlushTerminatedMessage reads pkt-lines from r until a flush
+// (0000), returning the concatenated raw bytes including every length
+// prefix and the trailing flush. The boolean is false (with nil
+// error) when r is at EOF before any byte has been read — the
+// natural signal that the stream closed cleanly between messages.
+//
+// Special lengths 0001 (delim) and 0002 (response-end) are passed
+// through verbatim — they're part of v2 framing.
+//
+// We reach for the raw bytes instead of pktline.Scanner because the
+// helper proxies messages over HTTP unchanged; reconstructing the
+// length prefixes from Scanner's payload-only output would re-encode
+// and risk drift.
+func ReadFlushTerminatedMessage(r io.Reader) ([]byte, bool, error) {
+	var buf bytes.Buffer
+	lenBuf := make([]byte, pktline.LenSize)
+	for {
+		n, err := io.ReadFull(r, lenBuf)
+		if err != nil {
+			if errors.Is(err, io.EOF) && n == 0 && buf.Len() == 0 {
+				return nil, false, nil
+			}
+			if errors.Is(err, io.ErrUnexpectedEOF) || (errors.Is(err, io.EOF) && n > 0) {
+				return nil, false, fmt.Errorf("reading pkt-line length: %w", io.ErrUnexpectedEOF)
+			}
+			return nil, false, fmt.Errorf("reading pkt-line length: %w", err)
+		}
+		buf.Write(lenBuf)
+
+		pktLen, err := pktline.ParseLength(lenBuf)
+		if err != nil {
+			return nil, false, err //nolint:wrapcheck // pktline.ParseLength already returns a typed error
+		}
+		switch pktLen {
+		case pktline.Flush:
+			return buf.Bytes(), true, nil
+		case pktline.Delim, pktline.ResponseEnd:
+			continue
+		}
+		if pktLen < pktline.LenSize {
+			return nil, false, fmt.Errorf("invalid pkt-line length %d", pktLen)
+		}
+
+		payload := make([]byte, pktLen-pktline.LenSize)
+		if _, err := io.ReadFull(r, payload); err != nil {
+			return nil, false, fmt.Errorf("reading pkt-line content: %w", err)
+		}
+		buf.Write(payload)
+	}
+}
+
+// ReadPostServiceAdvertisement reads a v0/v1 smart-HTTP info/refs body
+// and returns the bytes that follow the service announcement plus
+// its terminating flush — i.e. just the ref advertisement.
+//
+// `git send-pack --stateless-rpc` runs the input through
+// discover_version + get_remote_heads, which die with "protocol
+// error: unexpected '# service=...'" if the announcement preamble is
+// left in. Strip it once, here, so callers can feed the result
+// straight into send-pack.
+func ReadPostServiceAdvertisement(r io.Reader) ([]byte, error) {
+	br := bufio.NewReader(r)
+	var reply packp.SmartReply
+	if err := reply.Decode(br); err != nil {
+		return nil, fmt.Errorf("decoding smart-HTTP service announcement: %w", err)
+	}
+	body, err := io.ReadAll(br)
+	if err != nil {
+		return nil, fmt.Errorf("reading ref advertisement: %w", err)
+	}
+	return body, nil
+}
+
+// ReadReceivePackRequest reads a v0/v1 git-receive-pack request body
+// from r: a sequence of command pkt-lines terminated by a flush,
+// optionally followed by a raw PACK stream when at least one command
+// is not a delete (i.e. the new OID isn't all zeros).
+//
+// The returned bytes are exactly what was on the wire — caller
+// streams them to the remote without further framing. EOF before the
+// flush is reported (treating it as a clean close would let a
+// truncated request look like a clean delete-only push).
+func ReadReceivePackRequest(r io.Reader) ([]byte, error) {
+	var buf bytes.Buffer
+	lenBuf := make([]byte, pktline.LenSize)
+	needPackData := false
+
+	for {
+		n, err := io.ReadFull(r, lenBuf)
+		if err != nil {
+			if errors.Is(err, io.EOF) && n == 0 && buf.Len() == 0 {
+				return buf.Bytes(), nil
+			}
+			if errors.Is(err, io.ErrUnexpectedEOF) || (errors.Is(err, io.EOF) && n > 0) {
+				return nil, fmt.Errorf("reading pkt-line length: %w", io.ErrUnexpectedEOF)
+			}
+			return nil, fmt.Errorf("reading pkt-line length: %w", err)
+		}
+
+		pktLen, err := pktline.ParseLength(lenBuf)
+		if err != nil {
+			return nil, fmt.Errorf("receive-pack request: %w", err)
+		}
+		buf.Write(lenBuf)
+
+		if pktLen == pktline.Flush {
+			if needPackData {
+				if _, err := io.Copy(&buf, r); err != nil {
+					return nil, fmt.Errorf("reading pack data: %w", err)
+				}
+			}
+			return buf.Bytes(), nil
+		}
+		if pktLen < pktline.LenSize {
+			continue
+		}
+
+		content := make([]byte, pktLen-pktline.LenSize)
+		if _, err := io.ReadFull(r, content); err != nil {
+			return nil, fmt.Errorf("reading pkt-line content: %w", err)
+		}
+		buf.Write(content)
+
+		if !needPackData && receivePackCommandNeedsPack(content) {
+			needPackData = true
+		}
+	}
+}
+
+// receivePackCommandNeedsPack reports whether a receive-pack command
+// pkt-line describes a non-delete update (new OID not all zeros).
+// Wire shape: "<old-id> <new-id> <ref>[\0<capabilities>]\n". Works
+// for both SHA-1 (40-hex) and SHA-256 (64-hex) object IDs.
+func receivePackCommandNeedsPack(content []byte) bool {
+	line := content
+	if i := bytes.IndexByte(line, 0); i >= 0 {
+		line = line[:i]
+	} else {
+		line = bytes.TrimSuffix(line, []byte("\n"))
+	}
+	_, rest, ok := bytes.Cut(line, []byte{' '})
+	if !ok {
+		return false
+	}
+	newOID, _, ok := bytes.Cut(rest, []byte{' '})
+	if !ok || len(newOID) == 0 {
+		return false
+	}
+	for _, b := range newOID {
+		if b != '0' {
+			return true
+		}
+	}
+	return false
+}
+
+// ReadSendPackRequest reads one request emitted by
+// `git send-pack --stateless-rpc` and writes the unwrapped payload to
+// dst. Send-pack wraps the receive-pack request in an outer pkt-line
+// stream so it can mark request boundaries without closing stdout;
+// the HTTP body is the concatenated payload of those outer packets.
+//
+// Returns when the outer flush is seen. Special lengths 1/2 are
+// tolerated and skipped (current send-pack doesn't emit them, but
+// the shape is permissive). EOF before the flush is wrapped as
+// io.ErrUnexpectedEOF — a truncated send-pack stdout is never a
+// clean end.
+func ReadSendPackRequest(r *bufio.Reader, dst *bytes.Buffer) error {
+	for {
+		lenBuf := make([]byte, pktline.LenSize)
+		n, err := io.ReadFull(r, lenBuf)
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				_ = n
+				return fmt.Errorf("reading send-pack packet length: %w", io.ErrUnexpectedEOF)
+			}
+			return fmt.Errorf("reading send-pack packet length: %w", err)
+		}
+		pktLen, err := pktline.ParseLength(lenBuf)
+		if err != nil {
+			return fmt.Errorf("parsing send-pack packet length: %w", err)
+		}
+		if pktLen == pktline.Flush {
+			return nil
+		}
+		if pktLen < pktline.LenSize {
+			continue
+		}
+
+		payload := make([]byte, pktLen-pktline.LenSize)
+		if _, err := io.ReadFull(r, payload); err != nil {
+			return fmt.Errorf("reading send-pack packet payload: %w", err)
+		}
+		if _, err := dst.Write(payload); err != nil {
+			return fmt.Errorf("buffering send-pack packet payload: %w", err)
+		}
+	}
+}

--- a/internal/remotehelper/gitproto/gitproto_test.go
+++ b/internal/remotehelper/gitproto/gitproto_test.go
@@ -203,7 +203,7 @@ func TestAppendAgentToReceivePackRequest(t *testing.T) {
 
 	oldSHA := strings.Repeat("a", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status agent=git/2.54.0\n"
 	in := pktLine(cmd) + "0000PACK"
 
@@ -222,9 +222,9 @@ func TestAppendAgentToReceivePackRequest(t *testing.T) {
 func TestReadReceivePackRequest_DeleteOnly(t *testing.T) {
 	t.Parallel()
 
-	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oldSHA := testHeadSHA
 	zeroSHA := "0000000000000000000000000000000000000000"
-	ref := "refs/heads/feature-branch"
+	ref := testRefFeatureBranch
 
 	var input bytes.Buffer
 	cmd := oldSHA + " " + zeroSHA + " " + ref + "\x00 report-status delete-refs\n"
@@ -257,7 +257,7 @@ func TestReceivePackCommandNeedsPack(t *testing.T) {
 	sha256Old := strings.Repeat("a", 64)
 	sha256New := strings.Repeat("b", 64)
 	sha256Zero := strings.Repeat("0", 64)
-	ref := "refs/heads/main"
+	ref := testRefMain
 
 	tests := []struct {
 		name string
@@ -286,7 +286,7 @@ func TestReadReceivePackRequest_DeleteOnlySHA256(t *testing.T) {
 
 	oldSHA := strings.Repeat("a", 64)
 	zeroSHA := strings.Repeat("0", 64)
-	ref := "refs/heads/feature-branch"
+	ref := testRefFeatureBranch
 	packData := "PACK must not be consumed on delete-only push"
 
 	var input bytes.Buffer
@@ -313,8 +313,8 @@ func TestReadReceivePackRequest_WithPackDataSHA256(t *testing.T) {
 
 	oldSHA := strings.Repeat("a", 64)
 	newSHA := strings.Repeat("b", 64)
-	ref := "refs/heads/main"
-	packData := "PACK fake pack data here"
+	ref := testRefMain
+	packData := testFakePackData
 
 	var input bytes.Buffer
 	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
@@ -335,10 +335,10 @@ func TestReadReceivePackRequest_WithPackDataSHA256(t *testing.T) {
 func TestReadReceivePackRequest_WithPackData(t *testing.T) {
 	t.Parallel()
 
-	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oldSHA := testHeadSHA
 	newSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	ref := "refs/heads/main"
-	packData := "PACK fake pack data here"
+	ref := testRefMain
+	packData := testFakePackData
 
 	var input bytes.Buffer
 	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
@@ -367,7 +367,7 @@ func TestReadReceivePackRequest_TruncatedFails(t *testing.T) {
 	// of the expected flush packet — must not be treated as a clean end
 	// (otherwise a network truncation could look like a successful no-op
 	// to the caller).
-	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	oldSHA := testHeadSHA
 	newSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	cmd := oldSHA + " " + newSHA + " refs/heads/main\x00 report-status\n"
 	body := pktLine(cmd) // no trailing flush
@@ -383,11 +383,11 @@ func TestReadSendPackRequest_IncludesPackData(t *testing.T) {
 
 	oldSHA := strings.Repeat("0", 40)
 	newSHA := strings.Repeat("b", 40)
-	ref := "refs/heads/main"
+	ref := testRefMain
 	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status push-options\n"
 	commandSection := pktLine(cmd) + "0000"
 	pushOptions := pktLine("ci.skip") + "0000"
-	packData := "PACK fake pack data here"
+	packData := testFakePackData
 	trailingStatus := "0000ok " + ref + "\n"
 
 	var input bytes.Buffer
@@ -420,7 +420,7 @@ func TestReadSendPackRequest_DeleteOnly(t *testing.T) {
 
 	oldSHA := strings.Repeat("a", 40)
 	zeroSHA := strings.Repeat("0", 40)
-	ref := "refs/heads/feature-branch"
+	ref := testRefFeatureBranch
 	cmd := oldSHA + " " + zeroSHA + " " + ref + "\x00 report-status delete-refs\n"
 	commandSection := pktLine(cmd) + "0000"
 	trailingStatus := "0000ok " + ref + "\n"

--- a/internal/remotehelper/gitproto/gitproto_test.go
+++ b/internal/remotehelper/gitproto/gitproto_test.go
@@ -1,0 +1,480 @@
+package gitproto
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// pktLine encodes a string as a git pkt-line.
+func pktLine(s string) string {
+	return fmt.Sprintf("%04x%s", len(s)+4, s)
+}
+
+func TestReadFlushTerminatedMessage_HappyPath(t *testing.T) {
+	t.Parallel()
+	body := "000ahello\n" + "000aworld\n" + "0000"
+	got, ok, err := ReadFlushTerminatedMessage(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !ok {
+		t.Fatal("ok = false")
+	}
+	if string(got) != body {
+		t.Errorf("got %q, want %q", got, body)
+	}
+}
+
+func TestReadFlushTerminatedMessage_EOFBeforeFirstByte(t *testing.T) {
+	t.Parallel()
+	got, ok, err := ReadFlushTerminatedMessage(strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if ok {
+		t.Errorf("ok = true, want false on clean EOF")
+	}
+	if got != nil {
+		t.Errorf("got = %q, want nil", got)
+	}
+}
+
+func TestReadFlushTerminatedMessage_TruncatedLength(t *testing.T) {
+	t.Parallel()
+	_, _, err := ReadFlushTerminatedMessage(strings.NewReader("00"))
+	if err == nil {
+		t.Fatal("expected error on truncated length")
+	}
+}
+
+func TestReadFlushTerminatedMessage_TolerateSpecialLengths(t *testing.T) {
+	t.Parallel()
+	// 0001 delim and 0002 response-end carry no payload; pass through.
+	body := "000ahello\n0001000b world\n00020000"
+	got, ok, err := ReadFlushTerminatedMessage(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !ok {
+		t.Fatal("ok = false")
+	}
+	if string(got) != body {
+		t.Errorf("got %q, want %q", got, body)
+	}
+}
+
+func TestReadPostServiceAdvertisementStripsPreamble(t *testing.T) {
+	t.Parallel()
+
+	// A realistic v0/v1 receive-pack info/refs body: service
+	// announcement pktline, flush, then refs+caps + final flush. The
+	// advertisement we hand to send-pack must NOT include the
+	// "# service=..." line — connect.c:get_remote_heads dies on it
+	// with "protocol error: unexpected '# service=git-receive-pack'".
+	refsAndCaps := "003eaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/heads/main\n0000"
+	body := "001f# service=git-receive-pack\n0000" + refsAndCaps
+
+	got, err := ReadPostServiceAdvertisement(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("ReadPostServiceAdvertisement: %v", err)
+	}
+	if string(got) != refsAndCaps {
+		t.Errorf("got %q, want %q", got, refsAndCaps)
+	}
+}
+
+func TestIsV2Advertisement(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy", func(t *testing.T) {
+		t.Parallel()
+		if !IsV2Advertisement([]byte(pktLine("version 2\n"))) {
+			t.Error("expected true for valid v2 advertisement")
+		}
+	})
+	t.Run("v1 looks-like", func(t *testing.T) {
+		t.Parallel()
+		if IsV2Advertisement([]byte(pktLine("version 1\n"))) {
+			t.Error("expected false for v1 advertisement")
+		}
+	})
+	t.Run("too short", func(t *testing.T) {
+		t.Parallel()
+		if IsV2Advertisement([]byte("00")) {
+			t.Error("expected false for buffer shorter than length prefix")
+		}
+	})
+	t.Run("length larger than buffer", func(t *testing.T) {
+		t.Parallel()
+		if IsV2Advertisement([]byte("ffff")) {
+			t.Error("expected false when length exceeds buffer")
+		}
+	})
+	t.Run("non-hex length", func(t *testing.T) {
+		t.Parallel()
+		if IsV2Advertisement([]byte("zzzz")) {
+			t.Error("expected false on non-hex length")
+		}
+	})
+}
+
+func TestV2Command(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy", func(t *testing.T) {
+		t.Parallel()
+		message := pktLine("agent=test\n") + pktLine("command=bundle-uri\n") + "00010000"
+		if got, want := V2Command([]byte(message)), "bundle-uri"; got != want {
+			t.Errorf("V2Command = %q, want %q", got, want)
+		}
+	})
+	t.Run("missing command", func(t *testing.T) {
+		t.Parallel()
+		message := pktLine("agent=test\n") + "0000"
+		if got := V2Command([]byte(message)); got != "" {
+			t.Errorf("V2Command = %q, want empty", got)
+		}
+	})
+	t.Run("truncated", func(t *testing.T) {
+		t.Parallel()
+		// length says 100 bytes but only 8 supplied.
+		if got := V2Command([]byte("0064command=ls-refs")); got != "" {
+			t.Errorf("V2Command on truncated = %q, want empty", got)
+		}
+	})
+	t.Run("garbage length", func(t *testing.T) {
+		t.Parallel()
+		if got := V2Command([]byte("zzzzcommand=ls-refs\n")); got != "" {
+			t.Errorf("V2Command on bad length = %q, want empty", got)
+		}
+	})
+}
+
+func TestAppendAgentToV2Request(t *testing.T) {
+	t.Parallel()
+
+	in := pktLine("command=ls-refs\n") + pktLine("agent=git/2.54.0\n") + "0000"
+	got, err := AppendAgentToV2Request([]byte(in), "git-remote-entire/dev")
+	if err != nil {
+		t.Fatalf("AppendAgentToV2Request: %v", err)
+	}
+	want := pktLine("command=ls-refs\n") +
+		pktLine("agent=git/2.54.0 git-remote-entire/dev\n") +
+		"0000"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestAppendAgentToV2RequestWithoutAgentUnchanged(t *testing.T) {
+	t.Parallel()
+
+	in := pktLine("command=ls-refs\n") + "0000"
+	got, err := AppendAgentToV2Request([]byte(in), "git-remote-entire/dev")
+	if err != nil {
+		t.Fatalf("AppendAgentToV2Request: %v", err)
+	}
+	if string(got) != in {
+		t.Errorf("got %q, want unchanged %q", got, in)
+	}
+}
+
+func TestAppendAgentToUploadPackRequest(t *testing.T) {
+	t.Parallel()
+
+	oid := strings.Repeat("a", 40)
+	in := pktLine("want "+oid+" multi_ack agent=git/2.54.0 object-format=sha1\n") + "0000"
+	got, err := AppendAgentToUploadPackRequest([]byte(in), "git-remote-entire/dev")
+	if err != nil {
+		t.Fatalf("AppendAgentToUploadPackRequest: %v", err)
+	}
+	want := pktLine("want "+oid+" multi_ack agent=git/2.54.0+git-remote-entire/dev object-format=sha1\n") + "0000"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestAppendAgentToReceivePackRequest(t *testing.T) {
+	t.Parallel()
+
+	oldSHA := strings.Repeat("a", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status agent=git/2.54.0\n"
+	in := pktLine(cmd) + "0000PACK"
+
+	got, err := AppendAgentToReceivePackRequest([]byte(in), "git-remote-entire/dev")
+	if err != nil {
+		t.Fatalf("AppendAgentToReceivePackRequest: %v", err)
+	}
+	wantCmd := oldSHA + " " + newSHA + " " + ref +
+		"\x00 report-status agent=git/2.54.0+git-remote-entire/dev\n"
+	want := pktLine(wantCmd) + "0000PACK"
+	if string(got) != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadReceivePackRequest_DeleteOnly(t *testing.T) {
+	t.Parallel()
+
+	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	zeroSHA := "0000000000000000000000000000000000000000"
+	ref := "refs/heads/feature-branch"
+
+	var input bytes.Buffer
+	cmd := oldSHA + " " + zeroSHA + " " + ref + "\x00 report-status delete-refs\n"
+	input.WriteString(pktLine(cmd))
+	input.WriteString("0000")
+
+	result, err := ReadReceivePackRequest(&input)
+	if err != nil {
+		t.Fatalf("ReadReceivePackRequest failed: %v", err)
+	}
+
+	got := string(result)
+	if !strings.Contains(got, oldSHA) {
+		t.Errorf("result missing old SHA")
+	}
+	if !strings.Contains(got, ref) {
+		t.Errorf("result missing ref name")
+	}
+	if !strings.HasSuffix(got, "0000") {
+		t.Errorf("result should end with flush packet, got suffix %q", got[len(got)-4:])
+	}
+}
+
+func TestReceivePackCommandNeedsPack(t *testing.T) {
+	t.Parallel()
+
+	sha1Old := strings.Repeat("a", 40)
+	sha1New := strings.Repeat("b", 40)
+	sha1Zero := strings.Repeat("0", 40)
+	sha256Old := strings.Repeat("a", 64)
+	sha256New := strings.Repeat("b", 64)
+	sha256Zero := strings.Repeat("0", 64)
+	ref := "refs/heads/main"
+
+	tests := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{"sha1 update", sha1Old + " " + sha1New + " " + ref, true},
+		{"sha1 delete", sha1Old + " " + sha1Zero + " " + ref, false},
+		{"sha256 update", sha256Old + " " + sha256New + " " + ref, true},
+		{"sha256 delete", sha256Old + " " + sha256Zero + " " + ref, false},
+		{"sha256 delete with caps", sha256Old + " " + sha256Zero + " " + ref + "\x00 report-status delete-refs", false},
+		{"malformed", "not-a-command", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := receivePackCommandNeedsPack([]byte(tc.cmd)); got != tc.want {
+				t.Errorf("receivePackCommandNeedsPack(%q) = %v, want %v", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadReceivePackRequest_DeleteOnlySHA256(t *testing.T) {
+	t.Parallel()
+
+	oldSHA := strings.Repeat("a", 64)
+	zeroSHA := strings.Repeat("0", 64)
+	ref := "refs/heads/feature-branch"
+	packData := "PACK must not be consumed on delete-only push"
+
+	var input bytes.Buffer
+	cmd := oldSHA + " " + zeroSHA + " " + ref + "\x00 report-status delete-refs\n"
+	input.WriteString(pktLine(cmd))
+	input.WriteString("0000")
+	input.WriteString(packData)
+
+	result, err := ReadReceivePackRequest(&input)
+	if err != nil {
+		t.Fatalf("ReadReceivePackRequest failed: %v", err)
+	}
+	got := string(result)
+	if strings.Contains(got, "PACK") {
+		t.Errorf("delete-only SHA-256 push must not read pack data, got %q", got)
+	}
+	if !strings.HasSuffix(got, "0000") {
+		t.Errorf("result should end with flush packet, got suffix %q", got[len(got)-4:])
+	}
+}
+
+func TestReadReceivePackRequest_WithPackDataSHA256(t *testing.T) {
+	t.Parallel()
+
+	oldSHA := strings.Repeat("a", 64)
+	newSHA := strings.Repeat("b", 64)
+	ref := "refs/heads/main"
+	packData := "PACK fake pack data here"
+
+	var input bytes.Buffer
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	input.WriteString(pktLine(cmd))
+	input.WriteString("0000")
+	input.WriteString(packData)
+
+	result, err := ReadReceivePackRequest(&input)
+	if err != nil {
+		t.Fatalf("ReadReceivePackRequest failed: %v", err)
+	}
+	got := string(result)
+	if !strings.Contains(got, packData) {
+		t.Errorf("result missing pack data, got: %q", got)
+	}
+}
+
+func TestReadReceivePackRequest_WithPackData(t *testing.T) {
+	t.Parallel()
+
+	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	ref := "refs/heads/main"
+	packData := "PACK fake pack data here"
+
+	var input bytes.Buffer
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status\n"
+	input.WriteString(pktLine(cmd))
+	input.WriteString("0000")
+	input.WriteString(packData)
+
+	result, err := ReadReceivePackRequest(&input)
+	if err != nil {
+		t.Fatalf("ReadReceivePackRequest failed: %v", err)
+	}
+
+	got := string(result)
+	if !strings.Contains(got, newSHA) {
+		t.Errorf("result missing new SHA")
+	}
+	if !strings.Contains(got, packData) {
+		t.Errorf("result missing pack data, got: %q", got)
+	}
+}
+
+func TestReadReceivePackRequest_TruncatedFails(t *testing.T) {
+	t.Parallel()
+
+	// Command pkt-line announces an update but is followed by EOF instead
+	// of the expected flush packet — must not be treated as a clean end
+	// (otherwise a network truncation could look like a successful no-op
+	// to the caller).
+	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	cmd := oldSHA + " " + newSHA + " refs/heads/main\x00 report-status\n"
+	body := pktLine(cmd) // no trailing flush
+
+	_, err := ReadReceivePackRequest(strings.NewReader(body))
+	if err == nil {
+		t.Fatal("expected error on truncated request without flush")
+	}
+}
+
+func TestReadSendPackRequest_IncludesPackData(t *testing.T) {
+	t.Parallel()
+
+	oldSHA := strings.Repeat("0", 40)
+	newSHA := strings.Repeat("b", 40)
+	ref := "refs/heads/main"
+	cmd := oldSHA + " " + newSHA + " " + ref + "\x00 report-status push-options\n"
+	commandSection := pktLine(cmd) + "0000"
+	pushOptions := pktLine("ci.skip") + "0000"
+	packData := "PACK fake pack data here"
+	trailingStatus := "0000ok " + ref + "\n"
+
+	var input bytes.Buffer
+	input.WriteString(pktLine(commandSection + pushOptions))
+	input.WriteString(pktLine(packData))
+	input.WriteString("0000")
+	input.WriteString(trailingStatus)
+
+	reader := bufio.NewReader(&input)
+	var got bytes.Buffer
+	if err := ReadSendPackRequest(reader, &got); err != nil {
+		t.Fatalf("ReadSendPackRequest failed: %v", err)
+	}
+
+	want := commandSection + pushOptions + packData
+	if got.String() != want {
+		t.Fatalf("request body = %q, want %q", got.String(), want)
+	}
+	remaining, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading remaining status: %v", err)
+	}
+	if string(remaining) != trailingStatus {
+		t.Fatalf("remaining status = %q, want %q", remaining, trailingStatus)
+	}
+}
+
+func TestReadSendPackRequest_DeleteOnly(t *testing.T) {
+	t.Parallel()
+
+	oldSHA := strings.Repeat("a", 40)
+	zeroSHA := strings.Repeat("0", 40)
+	ref := "refs/heads/feature-branch"
+	cmd := oldSHA + " " + zeroSHA + " " + ref + "\x00 report-status delete-refs\n"
+	commandSection := pktLine(cmd) + "0000"
+	trailingStatus := "0000ok " + ref + "\n"
+
+	var input bytes.Buffer
+	input.WriteString(pktLine(commandSection))
+	input.WriteString("0000")
+	input.WriteString(trailingStatus)
+
+	reader := bufio.NewReader(&input)
+	var got bytes.Buffer
+	if err := ReadSendPackRequest(reader, &got); err != nil {
+		t.Fatalf("ReadSendPackRequest failed: %v", err)
+	}
+
+	if got.String() != commandSection {
+		t.Fatalf("request body = %q, want %q", got.String(), commandSection)
+	}
+	remaining, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("reading remaining status: %v", err)
+	}
+	if string(remaining) != trailingStatus {
+		t.Fatalf("remaining status = %q, want %q", remaining, trailingStatus)
+	}
+}
+
+func TestReadSendPackRequest_TruncatedFails(t *testing.T) {
+	t.Parallel()
+
+	t.Run("truncated length prefix", func(t *testing.T) {
+		t.Parallel()
+		r := bufio.NewReader(strings.NewReader("00"))
+		if err := ReadSendPackRequest(r, &bytes.Buffer{}); err == nil {
+			t.Fatal("expected error on truncated length")
+		}
+	})
+
+	t.Run("missing trailing flush", func(t *testing.T) {
+		t.Parallel()
+		// One inner payload followed by EOF instead of the outer flush.
+		body := pktLine("0000ok refs/heads/main\n")
+		r := bufio.NewReader(strings.NewReader(body))
+		if err := ReadSendPackRequest(r, &bytes.Buffer{}); err == nil {
+			t.Fatal("expected error on missing trailing flush")
+		}
+	})
+
+	t.Run("payload shorter than declared length", func(t *testing.T) {
+		t.Parallel()
+		// Length claims 100 bytes of payload but only 10 follow.
+		r := bufio.NewReader(strings.NewReader("0064short"))
+		if err := ReadSendPackRequest(r, &bytes.Buffer{}); err == nil {
+			t.Fatal("expected error on short payload")
+		}
+	})
+}

--- a/internal/remotehelper/httpdebug/redact.go
+++ b/internal/remotehelper/httpdebug/redact.go
@@ -1,0 +1,113 @@
+// Package httpdebug logs HTTP request / response traffic for
+// developer-facing debugging while redacting credentials.
+//
+// Three redaction layers run independently:
+//
+//   - sensitive headers (Authorization, Proxy-Authorization) collapse to
+//     a placeholder before any header dump is written;
+//   - URL userinfo (user@ or user:pass@) is stripped from any text run
+//     through RedactURLCredentials, covering Location headers and HTML
+//     redirect bodies;
+//   - JSON token fields (access_token, id_token, refresh_token,
+//     subject_token) — the shapes the STS / OAuth endpoints return —
+//     collapse to the placeholder.
+//
+// The redactors run in that order in BodyPreview. Truncation comes last:
+// if a long JWT or URL password extends past the preview boundary,
+// truncating first would leave the regex's terminator outside the slice
+// and silently leak the secret. Tests in this package pin the order.
+package httpdebug
+
+import (
+	"bytes"
+	"net/http"
+	"regexp"
+	"slices"
+)
+
+// Placeholder replaces any redacted value in dumps.
+const Placeholder = "***REDACTED***"
+
+// SensitiveHeaders carries credentials we never want to log verbatim.
+// Stored by canonical key so RedactHeaders can do a single map lookup
+// per header.
+var SensitiveHeaders = map[string]struct{}{
+	"Authorization":       {},
+	"Proxy-Authorization": {},
+}
+
+// RedactHeaders returns a copy of h with values for SensitiveHeaders
+// replaced by Placeholder. The input is not mutated — callers still
+// need the real headers on the live request/response.
+func RedactHeaders(h http.Header) http.Header {
+	out := make(http.Header, len(h))
+	for k, vals := range h {
+		ck := http.CanonicalHeaderKey(k)
+		if _, sensitive := SensitiveHeaders[ck]; sensitive {
+			redacted := make([]string, len(vals))
+			for i := range vals {
+				redacted[i] = Placeholder
+			}
+			out[ck] = redacted
+			continue
+		}
+		out[ck] = slices.Clone(vals)
+	}
+	return out
+}
+
+// jsonTokenRedactor matches JSON token fields the STS/OAuth endpoints
+// return (access_token, id_token, refresh_token, subject_token) and
+// captures the surrounding key + quote so the replacement keeps the
+// JSON shape intact.
+var jsonTokenRedactor = regexp.MustCompile(`"(access_token|id_token|refresh_token|subject_token)"\s*:\s*"[^"]*"`)
+
+// urlUserinfoRedactor matches the userinfo of an http/https URL —
+// everything between `://` and the next `@` that doesn't cross a
+// path/query/fragment boundary or whitespace. Covers `user@`,
+// `user:pass@`, and `x-token:<pw>@` shapes that appear in Location
+// headers and HTML redirect bodies.
+var urlUserinfoRedactor = regexp.MustCompile(`(https?://)[^@/?#\s"'<>]+@`)
+
+// RedactURLCredentials replaces the userinfo of any http/https URL in
+// s with Placeholder. Safe to run over arbitrary text — header dumps,
+// HTML bodies, log lines.
+func RedactURLCredentials(s []byte) []byte {
+	return urlUserinfoRedactor.ReplaceAll(s, []byte(`${1}`+Placeholder+`@`))
+}
+
+// RedactJSONTokens replaces JWT values inside a JSON body with
+// Placeholder. Bodies that aren't JSON (or don't carry token fields)
+// pass through unchanged.
+func RedactJSONTokens(body []byte) []byte {
+	return jsonTokenRedactor.ReplaceAll(body, []byte(`"$1":"`+Placeholder+`"`))
+}
+
+// PreviewBytes is the upper bound on the size of a body preview written
+// to the log. Anything beyond is truncated.
+const PreviewBytes = 512
+
+// packMagic marks the start of a packfile inside a smart-HTTP response.
+// Everything past it is binary pack data, unreadable in debug logs.
+var packMagic = []byte("PACK")
+
+// BodyPreview returns the first PreviewBytes of body after URL +
+// JSON-token redaction. Redaction MUST happen before truncation: a long
+// JWT or URL password can extend past PreviewBytes, leaving its
+// terminator (closing quote or `@`) outside the preview slice and out of
+// reach of the regexes — truncate-first silently leaks the secret.
+//
+// When the body contains a packfile, the preview ends just after the
+// PACK signature so the rest of the binary stream doesn't flood the log.
+func BodyPreview(body []byte) []byte {
+	redacted := RedactJSONTokens(body)
+	redacted = RedactURLCredentials(redacted)
+	if idx := bytes.Index(redacted, packMagic); idx >= 0 {
+		head := redacted[:min(idx+len(packMagic), PreviewBytes)]
+		return append(append([]byte(nil), head...), []byte(" [PACK_DATA]")...)
+	}
+	if len(redacted) > PreviewBytes {
+		return redacted[:PreviewBytes]
+	}
+	return redacted
+}

--- a/internal/remotehelper/httpdebug/redact_test.go
+++ b/internal/remotehelper/httpdebug/redact_test.go
@@ -1,0 +1,299 @@
+package httpdebug
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRedactHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   http.Header
+		want http.Header
+	}{
+		{name: "nil header", in: nil, want: http.Header{}},
+		{
+			name: "no sensitive headers",
+			in: http.Header{
+				"Content-Type": []string{"application/json"},
+				"User-Agent":   []string{"git-remote-entire/test"},
+			},
+			want: http.Header{
+				"Content-Type": []string{"application/json"},
+				"User-Agent":   []string{"git-remote-entire/test"},
+			},
+		},
+		{
+			name: "Authorization redacted",
+			in: http.Header{
+				"Authorization": []string{"Bearer eyJhbGciOi.secret.payload"},
+				"Content-Type":  []string{"application/json"},
+			},
+			want: http.Header{
+				"Authorization": []string{Placeholder},
+				"Content-Type":  []string{"application/json"},
+			},
+		},
+		{
+			name: "Proxy-Authorization redacted",
+			in:   http.Header{"Proxy-Authorization": []string{"Bearer leaky-token"}},
+			want: http.Header{"Proxy-Authorization": []string{Placeholder}},
+		},
+		{
+			name: "Cookie left alone (out of scope)",
+			in:   http.Header{"Cookie": []string{"session=abc123"}},
+			want: http.Header{"Cookie": []string{"session=abc123"}},
+		},
+		{
+			name: "case-insensitive match via canonical key",
+			in:   http.Header{"authorization": []string{"Bearer leaky"}},
+			want: http.Header{"Authorization": []string{Placeholder}},
+		},
+		{
+			name: "multi-value Authorization redacted per value",
+			in:   http.Header{"Authorization": []string{"Bearer first", "Bearer second"}},
+			want: http.Header{"Authorization": []string{Placeholder, Placeholder}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := RedactHeaders(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (got=%v want=%v)", len(got), len(tt.want), got, tt.want)
+			}
+			for k, wantVals := range tt.want {
+				gotVals := got.Values(k)
+				if len(gotVals) != len(wantVals) {
+					t.Errorf("%q: len = %d, want %d", k, len(gotVals), len(wantVals))
+					continue
+				}
+				for i := range wantVals {
+					if gotVals[i] != wantVals[i] {
+						t.Errorf("%q[%d] = %q, want %q", k, i, gotVals[i], wantVals[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRedactHeadersDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	in := http.Header{
+		"Authorization": []string{"Bearer real-token"},
+		"Content-Type":  []string{"application/json"},
+	}
+
+	_ = RedactHeaders(in)
+
+	if got := in.Get("Authorization"); got != "Bearer real-token" {
+		t.Errorf("input mutated: Authorization = %q, want unchanged", got)
+	}
+}
+
+func TestRedactURLCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		in         string
+		mustNotHas []string
+		mustHas    []string
+	}{
+		{
+			name:       "Location header userinfo",
+			in:         "Location: https://x-token:secret@host.example/path/repo\r\n",
+			mustNotHas: []string{"secret", "x-token"},
+			mustHas:    []string{"https://" + Placeholder + "@host.example/path/repo"},
+		},
+		{
+			name:       "HTML anchor userinfo",
+			in:         `<a href="https://x-token:abc123@host.example/path">redirect</a>`,
+			mustNotHas: []string{"abc123", "x-token"},
+			mustHas:    []string{"https://" + Placeholder + "@host.example/path"},
+		},
+		{
+			name:       "username only (no password)",
+			in:         "Location: http://user@host.example/path",
+			mustNotHas: []string{"user@host"},
+			mustHas:    []string{"http://" + Placeholder + "@host.example/path"},
+		},
+		{
+			name:       "URL with no userinfo unchanged",
+			in:         "Location: https://host.example/path?u=alice@example.com",
+			mustNotHas: []string{Placeholder},
+			mustHas:    []string{"https://host.example/path?u=alice@example.com"},
+		},
+		{
+			name:       "plain text with @ but no scheme unchanged",
+			in:         "contact alice@example.com for access",
+			mustNotHas: []string{Placeholder},
+			mustHas:    []string{"alice@example.com"},
+		},
+		{
+			name:       "multiple URLs on same line",
+			in:         "https://u1:p1@a.example/x https://u2:p2@b.example/y",
+			mustNotHas: []string{"u1:p1", "u2:p2"},
+			mustHas:    []string{"https://" + Placeholder + "@a.example/x", "https://" + Placeholder + "@b.example/y"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := string(RedactURLCredentials([]byte(tt.in)))
+			for _, s := range tt.mustNotHas {
+				if strings.Contains(got, s) {
+					t.Errorf("output should not contain %q\ngot: %s", s, got)
+				}
+			}
+			for _, s := range tt.mustHas {
+				if !strings.Contains(got, s) {
+					t.Errorf("output should contain %q\ngot: %s", s, got)
+				}
+			}
+		})
+	}
+}
+
+func TestBodyPreviewRedactsURLCredentials(t *testing.T) {
+	t.Parallel()
+
+	longPass := strings.Repeat("S", 600)
+	body := []byte(`<a href="https://x-token:` + longPass + `@host.example/path">go</a>`)
+
+	preview := BodyPreview(body)
+
+	if strings.Contains(string(preview), longPass) {
+		t.Fatalf("password leaked in preview:\n%s", preview)
+	}
+	if !strings.Contains(string(preview), "https://"+Placeholder+"@host.example/path") {
+		t.Errorf("expected redacted URL in preview:\n%s", preview)
+	}
+}
+
+func TestBodyPreviewTruncatesAfterRedaction(t *testing.T) {
+	t.Parallel()
+
+	// Long JWT whose closing quote falls past the preview boundary. If
+	// we truncate first and redact second, the regex never sees the
+	// closing quote and the token leaks. This test pins the
+	// redact-then-truncate order.
+	longJWT := strings.Repeat("A", 600)
+	body := []byte(`{"access_token":"` + longJWT + `","token_type":"Bearer","expires_in":900}`)
+
+	preview := BodyPreview(body)
+
+	if strings.Contains(string(preview), longJWT) {
+		t.Fatalf("token leaked in preview:\n%s", preview)
+	}
+	if !strings.Contains(string(preview), `"access_token":"`+Placeholder+`"`) {
+		t.Errorf("expected redacted access_token in preview:\n%s", preview)
+	}
+}
+
+func TestBodyPreviewBelowMaxUnchanged(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"name":"alice"}`)
+	preview := BodyPreview(body)
+	if string(preview) != `{"name":"alice"}` {
+		t.Errorf("preview = %q, want unchanged", preview)
+	}
+}
+
+func TestBodyPreviewCutsAtPackMagic(t *testing.T) {
+	t.Parallel()
+
+	// Smart-HTTP pack response: pktline header, then PACK signature,
+	// then binary pack stream. Without the PACK cut, ~512 bytes of
+	// binary garbage land in the debug log.
+	binary := bytes.Repeat([]byte{0xff, 0x00, 0x42, 0x13}, 200)
+	body := append([]byte("0008NAK\n0011PACK"), binary...)
+
+	preview := BodyPreview(body)
+
+	want := "0008NAK\n0011PACK [PACK_DATA]"
+	if string(preview) != want {
+		t.Errorf("preview = %q, want %q", preview, want)
+	}
+}
+
+func TestRedactJSONTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		in         string
+		mustNotHas []string
+		mustHas    []string
+	}{
+		{
+			name:       "STS access_token response",
+			in:         `{"access_token":"eyJhbGciOi.secret.payload","token_type":"Bearer","expires_in":900}`,
+			mustNotHas: []string{"eyJhbGciOi.secret.payload"},
+			mustHas:    []string{`"access_token":"` + Placeholder + `"`, `"token_type":"Bearer"`, `"expires_in":900`},
+		},
+		{
+			name:       "id_token, refresh_token, subject_token all redacted",
+			in:         `{"id_token":"id.leak","refresh_token":"refresh.leak","subject_token":"subject.leak"}`,
+			mustNotHas: []string{"id.leak", "refresh.leak", "subject.leak"},
+			mustHas:    []string{`"id_token":"` + Placeholder + `"`, `"refresh_token":"` + Placeholder + `"`, `"subject_token":"` + Placeholder + `"`},
+		},
+		{
+			name:       "whitespace around colon",
+			in:         `{"access_token" : "spaced.leak"}`,
+			mustNotHas: []string{"spaced.leak"},
+			mustHas:    []string{`"` + Placeholder + `"`},
+		},
+		{
+			name:       "non-token JSON unchanged",
+			in:         `{"name":"alice","role":"admin"}`,
+			mustNotHas: []string{Placeholder},
+			mustHas:    []string{`"name":"alice"`, `"role":"admin"`},
+		},
+		{
+			name:       "nested token field",
+			in:         `{"data":{"access_token":"nested.leak","other":"keep"}}`,
+			mustNotHas: []string{"nested.leak"},
+			mustHas:    []string{`"access_token":"` + Placeholder + `"`, `"other":"keep"`},
+		},
+		{
+			name:       "non-JSON body unchanged",
+			in:         "not json at all",
+			mustNotHas: []string{Placeholder},
+			mustHas:    []string{"not json at all"},
+		},
+		{
+			name:       "lookalike key not redacted",
+			in:         `{"my_token":"keep","token":"keep2"}`,
+			mustNotHas: []string{Placeholder},
+			mustHas:    []string{`"my_token":"keep"`, `"token":"keep2"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := string(RedactJSONTokens([]byte(tt.in)))
+			for _, s := range tt.mustNotHas {
+				if strings.Contains(got, s) {
+					t.Errorf("output should not contain %q\ngot: %s", s, got)
+				}
+			}
+			for _, s := range tt.mustHas {
+				if !strings.Contains(got, s) {
+					t.Errorf("output should contain %q\ngot: %s", s, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/remotehelper/httpdebug/roundtripper.go
+++ b/internal/remotehelper/httpdebug/roundtripper.go
@@ -1,0 +1,70 @@
+package httpdebug
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+)
+
+// RoundTripper wraps another http.RoundTripper and logs each
+// request/response when debuglog.Enabled returns true. Bodies and
+// sensitive headers are redacted before logging.
+//
+// When debugging is off, the wrapper is a thin pass-through: no
+// allocations, no body buffering.
+type RoundTripper struct {
+	Next http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper. Response bodies are read in
+// full (so the preview can render correctly) and re-wrapped before
+// returning — the caller sees an io.ReadCloser as before. This is a
+// debug-only cost; non-debug mode skips the read entirely.
+func (d *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !debuglog.Enabled() {
+		//nolint:wrapcheck // passthrough - wrapping would change error semantics
+		return d.Next.RoundTrip(req)
+	}
+
+	reqForDump := req.Clone(req.Context())
+	reqForDump.Header = RedactHeaders(req.Header)
+	reqDump, err := httputil.DumpRequestOut(reqForDump, false)
+	if err != nil {
+		debuglog.Printf("failed to dump request: %v", err)
+	} else {
+		debuglog.Printf(">>> REQUEST >>>\n%s", RedactURLCredentials(reqDump))
+	}
+
+	resp, err := d.Next.RoundTrip(req)
+	if err != nil {
+		debuglog.Printf("<<< ERROR <<< %v", err)
+		//nolint:wrapcheck // passthrough
+		return nil, err
+	}
+
+	respForDump := *resp
+	respForDump.Header = RedactHeaders(resp.Header)
+	respDump, err := httputil.DumpResponse(&respForDump, false)
+	if err != nil {
+		debuglog.Printf("failed to dump response: %v", err)
+	} else {
+		debuglog.Printf("<<< RESPONSE <<<\n%s", RedactURLCredentials(respDump))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		debuglog.Printf("failed to read response body: %v", err)
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	preview := BodyPreview(body)
+	debuglog.Printf("<<< BODY (%d bytes, showing %d) >>>\n%s", len(body), len(preview), preview)
+
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return resp, nil
+}

--- a/internal/remotehelper/name.go
+++ b/internal/remotehelper/name.go
@@ -1,0 +1,11 @@
+// Package remotehelper holds constants shared between the entire CLI's
+// argv[0] dispatch (cmd/entire) and the installer that places the
+// git-remote-entire launcher (cmd/entire/cli). The remote-helper protocol
+// implementation lives in the subpackages (githelper, transport, …).
+package remotehelper
+
+// BinaryName is the git remote-helper executable name. Git resolves
+// `entire://` URLs by exec'ing a binary called this on PATH; the entire
+// CLI is installed under this name (a symlink to, or copy of, the entire
+// binary) and dispatches on argv[0].
+const BinaryName = "git-remote-entire"

--- a/internal/remotehelper/name.go
+++ b/internal/remotehelper/name.go
@@ -1,11 +1,10 @@
-// Package remotehelper holds constants shared between the entire CLI's
-// argv[0] dispatch (cmd/entire) and the installer that places the
-// git-remote-entire launcher (cmd/entire/cli). The remote-helper protocol
-// implementation lives in the subpackages (githelper, transport, …).
+// Package remotehelper holds the shared name of the git remote-helper
+// binary; the protocol implementation lives in the subpackages (githelper,
+// transport, …) and the binary itself in cmd/git-remote-entire.
 package remotehelper
 
 // BinaryName is the git remote-helper executable name. Git resolves
-// `entire://` URLs by exec'ing a binary called this on PATH; the entire
-// CLI is installed under this name (a symlink to, or copy of, the entire
-// binary) and dispatches on argv[0].
+// `entire://` URLs by exec'ing a binary called this on PATH; cmd/git-remote-entire
+// is built and shipped under this name and uses it for its usage text and
+// git agent string.
 const BinaryName = "git-remote-entire"

--- a/internal/remotehelper/replicas/replicas.go
+++ b/internal/remotehelper/replicas/replicas.go
@@ -86,31 +86,32 @@ func LoadFresh(host, repoPath string) []string {
 }
 
 // Persist stores the given replica set in the on-disk cache. Best
-// effort: cache write failures are logged but never fatal.
+// effort: cache write failures are logged but never fatal. The
+// load-mutate-save runs under ModifyCache's single lock so concurrent
+// clone/fetch/push processes don't clobber each other's entries.
 func Persist(host, repoPath string, nodes []string) {
 	if host == "" || repoPath == "" || len(nodes) == 0 {
 		return
 	}
-	cache, err := discovery.LoadCache(discovery.DefaultCacheDir())
-	if err != nil || cache == nil {
-		cache = make(discovery.ClusterCache)
-	}
-	cache.SetRepoNodes(host, repoPath, nodes, discovery.DefaultTTL)
-	if err := discovery.SaveCache(discovery.DefaultCacheDir(), cache); err != nil {
+	if err := discovery.ModifyCache(discovery.DefaultCacheDir(), func(cache discovery.ClusterCache) error {
+		cache.SetRepoNodes(host, repoPath, nodes, discovery.DefaultTTL)
+		return nil
+	}); err != nil {
 		debuglog.Printf("cache save failed for %s: %v", repoPath, err)
 	}
 }
 
 // Invalidate removes the cached entry for (host, repoPath). Best
-// effort: missing/unreadable caches are ignored.
+// effort: failures are logged but never fatal. Runs under ModifyCache's
+// lock so it doesn't race a concurrent Persist.
 func Invalidate(host, repoPath string) {
 	if host == "" || repoPath == "" {
 		return
 	}
-	cache, err := discovery.LoadCache(discovery.DefaultCacheDir())
-	if err != nil || cache == nil {
-		return
+	if err := discovery.ModifyCache(discovery.DefaultCacheDir(), func(cache discovery.ClusterCache) error {
+		cache.InvalidateRepo(host, repoPath)
+		return nil
+	}); err != nil {
+		debuglog.Printf("cache invalidate failed for %s: %v", repoPath, err)
 	}
-	cache.InvalidateRepo(host, repoPath)
-	_ = discovery.SaveCache(discovery.DefaultCacheDir(), cache) //nolint:errcheck // best-effort invalidation
 }

--- a/internal/remotehelper/replicas/replicas.go
+++ b/internal/remotehelper/replicas/replicas.go
@@ -1,0 +1,116 @@
+// Package replicas manages the on-disk cache of Entire data-plane
+// replicas and the per-invocation NodeConfig that drives the transport's
+// warm/cold paths.
+//
+// A NodeConfig is built up front from the remote URL: the entry URL is
+// derived from the cluster host, and the initial node list is whatever
+// the local cache contains for (cluster, repo) — possibly empty on a
+// cold invocation, in which case the transport's cold path probes the
+// entry domain and populates the set from the first X-Entire-Replicas
+// header it sees.
+package replicas
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/entireio/cli/internal/entireclient/discovery"
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+)
+
+// NodeConfig is the discovery-time state the transport needs: an
+// entry-domain URL to use when the cached replica set is empty or
+// exhausted, whatever replicas are currently cached, the cluster host
+// for same-cluster redirect checks, and the repo path used as the
+// cache key (empty when the URL has no path, in which case caching is
+// disabled).
+type NodeConfig struct {
+	InitialNodes []string
+	EntryURL     string
+	ClusterHost  string
+	RepoPath     string
+}
+
+// Caching reports whether this config participates in the persistent
+// replica cache. False when the URL had no recognisable repo path to
+// key on.
+func (n NodeConfig) Caching() bool { return n.RepoPath != "" }
+
+// Resolve builds the NodeConfig for this invocation. No network
+// operations: the entry URL is derived from the cluster host in the
+// remote URL and the initial node list is whatever the local replica
+// cache contains.
+func Resolve(parsedURL *url.URL) NodeConfig {
+	clusterHost := parsedURL.Host
+	repoPath := ExtractRepoPath(parsedURL.Path)
+	entryURL := "https://" + clusterHost
+	cached := LoadFresh(clusterHost, repoPath)
+	if len(cached) > 0 {
+		debuglog.Printf("loaded %d cached replicas for %s: %v", len(cached), repoPath, cached)
+	} else {
+		debuglog.Printf("no fresh replica cache for %s; will use entry URL on first request", repoPath)
+	}
+	return NodeConfig{
+		InitialNodes: cached,
+		EntryURL:     entryURL,
+		ClusterHost:  clusterHost,
+		RepoPath:     repoPath,
+	}
+}
+
+// ExtractRepoPath builds the per-repo cache key from a remote URL's
+// path. The path is used verbatim (minus leading/trailing slashes), so
+// /et/<project>/<repo> (or legacy /git/<owner>/<repo>) and
+// /gh/<owner>/<repo> live in distinct keyspaces — they're separate
+// repos with potentially-different replica sets, even when the
+// segments after the prefix match.
+//
+// entire://host/et/project/repo -> "et/project/repo"
+// entire://host/gh/owner/repo   -> "gh/owner/repo"
+func ExtractRepoPath(urlPath string) string {
+	return strings.Trim(urlPath, "/")
+}
+
+// LoadFresh returns the cached replica set for (host, repoPath) if one
+// exists and is fresh, otherwise nil.
+func LoadFresh(host, repoPath string) []string {
+	cache, err := discovery.LoadCache(discovery.DefaultCacheDir())
+	if err != nil || cache == nil {
+		return nil
+	}
+	nodes, fresh := cache.GetRepoNodes(host, repoPath)
+	if !fresh {
+		return nil
+	}
+	return nodes
+}
+
+// Persist stores the given replica set in the on-disk cache. Best
+// effort: cache write failures are logged but never fatal.
+func Persist(host, repoPath string, nodes []string) {
+	if host == "" || repoPath == "" || len(nodes) == 0 {
+		return
+	}
+	cache, err := discovery.LoadCache(discovery.DefaultCacheDir())
+	if err != nil || cache == nil {
+		cache = make(discovery.ClusterCache)
+	}
+	cache.SetRepoNodes(host, repoPath, nodes, discovery.DefaultTTL)
+	if err := discovery.SaveCache(discovery.DefaultCacheDir(), cache); err != nil {
+		debuglog.Printf("cache save failed for %s: %v", repoPath, err)
+	}
+}
+
+// Invalidate removes the cached entry for (host, repoPath). Best
+// effort: missing/unreadable caches are ignored.
+func Invalidate(host, repoPath string) {
+	if host == "" || repoPath == "" {
+		return
+	}
+	cache, err := discovery.LoadCache(discovery.DefaultCacheDir())
+	if err != nil || cache == nil {
+		return
+	}
+	cache.InvalidateRepo(host, repoPath)
+	_ = discovery.SaveCache(discovery.DefaultCacheDir(), cache) //nolint:errcheck // best-effort invalidation
+}

--- a/internal/remotehelper/replicas/replicas_test.go
+++ b/internal/remotehelper/replicas/replicas_test.go
@@ -1,0 +1,79 @@
+package replicas
+
+import (
+	"net/url"
+	"slices"
+	"testing"
+)
+
+func TestExtractRepoPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		urlPath string
+		want    string
+	}{
+		{"/et/alice/repo", "et/alice/repo"},
+		{"/et/alice/repo/", "et/alice/repo"},
+		{"/et/a/b", "et/a/b"},
+		{"/et/deeply/nested/path/repo", "et/deeply/nested/path/repo"},
+		{"", ""},
+		{"/et/", "et"},
+		{"/et/repo", "et/repo"},
+		// /gh/<owner>/<repo> is the mirror prefix; the prefix stays in
+		// the cache key so a native /et/foo/bar and a same-coord mirror
+		// /gh/foo/bar on the same cluster don't collide.
+		{"/gh/alice/repo", "gh/alice/repo"},
+		{"/gh/alice/repo/", "gh/alice/repo"},
+	}
+	for _, tt := range tests {
+		got := ExtractRepoPath(tt.urlPath)
+		if got != tt.want {
+			t.Errorf("ExtractRepoPath(%q) = %q, want %q", tt.urlPath, got, tt.want)
+		}
+	}
+}
+
+func TestResolveDerivesFromURL(t *testing.T) {
+	// Isolate from the user's real cache dir by pointing XDG_CACHE_HOME
+	// at an empty tempdir.
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	parsed, _ := url.Parse("entire://eu.cluster.example/et/alice/repo") //nolint:errcheck // test URL is static
+	cfg := Resolve(parsed)
+	if cfg.EntryURL != "https://eu.cluster.example" {
+		t.Errorf("EntryURL = %q, want https://eu.cluster.example", cfg.EntryURL)
+	}
+	if cfg.ClusterHost != "eu.cluster.example" {
+		t.Errorf("ClusterHost = %q, want eu.cluster.example", cfg.ClusterHost)
+	}
+	if cfg.RepoPath != "et/alice/repo" {
+		t.Errorf("RepoPath = %q, want et/alice/repo", cfg.RepoPath)
+	}
+	if len(cfg.InitialNodes) != 0 {
+		t.Errorf("InitialNodes = %v, want empty on cold start", cfg.InitialNodes)
+	}
+	if !cfg.Caching() {
+		t.Error("expected Caching to be enabled when repo path is parseable")
+	}
+}
+
+func TestPersistAndLoadFresh(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+
+	const cluster = "eu.cluster.example"
+	const repo = "alice/repo"
+	want := []string{"https://n1.eu.cluster.example", "https://n2.eu.cluster.example"}
+
+	Persist(cluster, repo, want)
+
+	got := LoadFresh(cluster, repo)
+	if !slices.Equal(got, want) {
+		t.Errorf("LoadFresh = %v, want %v", got, want)
+	}
+
+	Invalidate(cluster, repo)
+	if got := LoadFresh(cluster, repo); len(got) != 0 {
+		t.Errorf("after Invalidate, LoadFresh = %v, want empty", got)
+	}
+}

--- a/internal/remotehelper/transport/fault_test.go
+++ b/internal/remotehelper/transport/fault_test.go
@@ -1,0 +1,168 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestServiceRPC_TruncatedResponseBodyError: when the server hangs
+// up mid-response, the streaming caller must see an error. We
+// don't read the body inside ServiceRPC (the caller does), but the
+// returned ReadCloser must surface the truncation via io.ReadAll.
+func TestServiceRPC_TruncatedResponseBodyError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("ResponseWriter not Hijacker")
+		}
+		conn, bufw, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack: %v", err)
+		}
+		// Write a 200 with a Content-Length larger than what we'll
+		// actually send, then drop the connection.
+		fmt.Fprint(bufw, "HTTP/1.1 200 OK\r\n")
+		fmt.Fprint(bufw, "Content-Length: 1000\r\n\r\n")
+		fmt.Fprint(bufw, "partial")
+		_ = bufw.Flush()
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	resp, err := testProxy(server).ServiceRPC(context.Background(), "git-upload-pack", strings.NewReader("body"))
+	if err != nil {
+		// Failure surfacing at this layer is also acceptable.
+		return
+	}
+	defer resp.Close()
+	_, err = io.ReadAll(resp)
+	if err == nil {
+		t.Fatal("expected truncation error from body read")
+	}
+}
+
+// TestInfoRefs_CtxCancelDuringHang: a server that hangs the
+// info/refs response must surrender the request when the caller's
+// context cancels.
+func TestInfoRefs_CtxCancelDuringHang(t *testing.T) {
+	t.Parallel()
+	hold := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-hold:
+		case <-r.Context().Done():
+		}
+	}))
+	defer server.Close()
+	defer close(hold)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	p := testProxy(server)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := p.InfoRefs(ctx, "git-upload-pack")
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected error on ctx cancel")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("InfoRefs did not return after ctx timeout")
+	}
+}
+
+// TestDoWithFailover_RetriesAfterConnectionReset: a server that
+// resets the connection mid-request (RST shape: TCP close while the
+// client is still writing) must be marked failed, and a second
+// healthy server must answer the request via failover.
+func TestDoWithFailover_RetriesAfterConnectionReset(t *testing.T) {
+	t.Parallel()
+	resetter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		// Force TCP RST by setting linger to 0 and closing.
+		if tcp, ok := conn.(*net.TCPConn); ok {
+			_ = tcp.SetLinger(0) //nolint:errcheck // test
+		}
+		_ = conn.Close()
+	}))
+	defer resetter.Close()
+
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "from good")
+	}))
+	defer good.Close()
+
+	p := proxyWithClient([]string{resetter.URL, good.URL}, "/et/alice/repo", "", "", &http.Client{})
+
+	resp, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err != nil {
+		t.Fatalf("failover should succeed despite reset, got: %v", err)
+	}
+	defer resp.Close()
+	body, _ := io.ReadAll(resp) //nolint:errcheck // test
+	if string(body) != "from good" {
+		t.Errorf("body = %q, want %q", body, "from good")
+	}
+}
+
+// TestServiceRPC_ResetMidResponseSurfacesError: a connection that's
+// closed while the response body streams must produce an error at
+// io.ReadAll time. Critical for push acknowledgement: a truncated
+// receive-pack response could otherwise be mistaken for "ok".
+func TestServiceRPC_ResetMidResponseSurfacesError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		hj, _ := w.(http.Hijacker) //nolint:errcheck // not asserting ok intentionally
+		w.Header().Set("Content-Type", "application/x-git-receive-pack-result")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "0014unpack ok\n0014ok refs/heads") // truncated mid-line
+		flusher.Flush()
+		if hj != nil {
+			conn, _, err := hj.Hijack()
+			if err == nil {
+				if tcp, ok := conn.(*net.TCPConn); ok {
+					_ = tcp.SetLinger(0) //nolint:errcheck // test
+				}
+				_ = conn.Close()
+			}
+		}
+	}))
+	defer server.Close()
+
+	p := testProxy(server)
+	resp, err := p.ServiceRPC(context.Background(), "git-receive-pack", strings.NewReader("PACK fake"))
+	if err != nil {
+		return // surfacing here is fine
+	}
+	defer resp.Close()
+	body, err := io.ReadAll(resp)
+	if err == nil && len(body) == 0 {
+		t.Error("expected truncation error or partial body, got clean empty read")
+	}
+}

--- a/internal/remotehelper/transport/inforefs.go
+++ b/internal/remotehelper/transport/inforefs.go
@@ -119,7 +119,7 @@ func (p *Proxy) coldInfoRefs(ctx context.Context, suffix string, setHeaders func
 		return p.handleInfoRefsResponse(resp)
 	}
 
-	rs := discovery.ParseReplicas(resp.Header.Get("X-Entire-Replicas"))
+	rs := p.filterReplicas(discovery.ParseReplicas(resp.Header.Get("X-Entire-Replicas")))
 	location := resp.Header.Get("Location")
 	_ = resp.Body.Close()
 
@@ -141,6 +141,13 @@ func (p *Proxy) coldInfoRefs(ctx context.Context, suffix string, setHeaders func
 	}
 
 	if location == "" {
+		return nil, fmt.Errorf("fetching info/refs after entry-domain redirect: %w", err)
+	}
+	// The Location target is server-controlled. Salvaging the request means
+	// dialing it with the token attached, so it must be in-cluster — an
+	// off-cluster Location is an exfiltration target, not a fallback node.
+	if !p.replicaInCluster(location) {
+		debuglog.Printf("all advertised replicas failed and redirect Location %s is out-of-cluster; refusing credentialed fallback", location)
 		return nil, fmt.Errorf("fetching info/refs after entry-domain redirect: %w", err)
 	}
 	debuglog.Printf("all advertised replicas failed; trying redirect Location %s as last-ditch fallback: %v", location, err)

--- a/internal/remotehelper/transport/inforefs.go
+++ b/internal/remotehelper/transport/inforefs.go
@@ -216,7 +216,7 @@ func HTTPErrorMessage(statusCode int, serverMsg, baseURL string) error {
 		if serverMsg != "" {
 			return fmt.Errorf("authentication failed: %s", serverMsg)
 		}
-		return errors.New("authentication failed - please run 'entire-core auth login'")
+		return errors.New("authentication failed - please run 'entire login'")
 	case http.StatusNotFound:
 		if serverMsg != "" {
 			return errors.New(serverMsg)

--- a/internal/remotehelper/transport/inforefs.go
+++ b/internal/remotehelper/transport/inforefs.go
@@ -1,0 +1,231 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/entireio/cli/internal/entireclient/discovery"
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+)
+
+// InfoRefs fetches the ref advertisement from the server. This is
+// also the discovery entry point: the response's X-Entire-Replicas
+// header refreshes the proxy's cached replica set, and every
+// subsequent request in this invocation hits one of those replicas
+// directly.
+//
+// Warm path: when the cache has replicas, they're tried with failover.
+// If every cached replica fails we fall back to the cold path rather
+// than surfacing the error — the cached set may be entirely stale
+// (cluster resized, replicas moved) and the entry domain's LB will
+// still route us to a live node.
+//
+// Cold path: probe the entry domain without auto-following 3xx. If it
+// returns 307 + X-Entire-Replicas we adopt those replicas as the
+// working set and run the warm-path failover instead of letting Go's
+// HTTP client dial the redirect target — that matters when the
+// redirect target's DNS or TCP is broken: failover rolls to the next
+// replica instead of returning the dial error. When the redirect
+// carries no replica header we fall back to following the redirect
+// once. A direct 2xx is handled in place.
+func (p *Proxy) InfoRefs(ctx context.Context, service string) (io.ReadCloser, error) {
+	suffix := "/info/refs?service=" + service
+
+	var warmErr error
+	switch {
+	case len(p.nodes) > 0:
+		debuglog.Printf("info/refs warm path: trying %d cached replicas %v", len(p.nodes), p.nodes)
+		resp, err := p.doWithFailover(ctx, suffix, http.MethodGet, nil, nil)
+		if err == nil {
+			return p.handleInfoRefsResponse(resp)
+		}
+		if p.entryURL == "" {
+			return nil, fmt.Errorf("fetching info/refs: %w", err)
+		}
+		warmErr = err
+		debuglog.Printf("all cached replicas failed for info/refs, falling back to entry URL %s: %v", p.entryURL, err)
+	case p.entryURL == "":
+		return nil, errors.New("no replicas available and no entry URL configured")
+	default:
+		debuglog.Printf("info/refs cold path: hitting entry URL %s (LB will route or 307 to a hosting replica)", p.entryURL)
+	}
+
+	body, err := p.coldInfoRefs(ctx, suffix, nil)
+	if err != nil && warmErr != nil {
+		return nil, errors.Join(fmt.Errorf("cached replicas: %w", warmErr), err)
+	}
+	return body, err
+}
+
+// InfoRefsV2 is InfoRefs with Git-Protocol: version=2 added — same
+// replica-failover / cold-path / discovery logic, but the server's v2
+// capability advertisement is what gets returned instead of the v0/v1
+// ref list.
+func (p *Proxy) InfoRefsV2(ctx context.Context) (io.ReadCloser, error) {
+	suffix := "/info/refs?service=git-upload-pack"
+	setHeaders := func(req *http.Request) {
+		req.Header.Set("Git-Protocol", "version=2")
+	}
+
+	var warmErr error
+	switch {
+	case len(p.nodes) > 0:
+		debuglog.Printf("v2 info/refs warm path: trying %d cached replicas %v", len(p.nodes), p.nodes)
+		resp, err := p.doWithFailover(ctx, suffix, http.MethodGet, nil, setHeaders)
+		if err == nil {
+			return p.handleInfoRefsResponse(resp)
+		}
+		if p.entryURL == "" {
+			return nil, fmt.Errorf("fetching v2 info/refs: %w", err)
+		}
+		warmErr = err
+		debuglog.Printf("all cached replicas failed for v2 info/refs, falling back to entry URL %s: %v", p.entryURL, err)
+	case p.entryURL == "":
+		return nil, errors.New("no replicas available and no entry URL configured")
+	default:
+		debuglog.Printf("v2 info/refs cold path: hitting entry URL %s (LB will route or 307 to a hosting replica)", p.entryURL)
+	}
+
+	body, err := p.coldInfoRefs(ctx, suffix, setHeaders)
+	if err != nil && warmErr != nil {
+		return nil, errors.Join(fmt.Errorf("cached replicas: %w", warmErr), err)
+	}
+	return body, err
+}
+
+// coldInfoRefs fetches info/refs via the entry domain without
+// following redirects automatically. See InfoRefs for the rationale.
+//
+// Order of attempts when the entry domain returns 307 + X-Entire-Replicas:
+//  1. doWithFailover across the advertised replicas.
+//  2. If every advertised replica fails, follow the original Location
+//     target once. This salvages the request when the header was stale
+//     but the LB-picked node is still healthy.
+//
+// Persisting the replica set is gated on a successful response so a
+// stale header can't pin a bad set in the on-disk cache.
+func (p *Proxy) coldInfoRefs(ctx context.Context, suffix string, setHeaders func(*http.Request)) (io.ReadCloser, error) {
+	entryURL := strings.TrimSuffix(p.entryURL, "/") + p.path + suffix
+	resp, err := p.doGet(ctx, entryURL, p.noRedirectClient(), setHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("fetching info/refs from entry domain: %w", err)
+	}
+
+	if !isRedirect(resp.StatusCode) {
+		return p.handleInfoRefsResponse(resp)
+	}
+
+	rs := discovery.ParseReplicas(resp.Header.Get("X-Entire-Replicas"))
+	location := resp.Header.Get("Location")
+	_ = resp.Body.Close()
+
+	if len(rs) == 0 {
+		debuglog.Printf("entry domain redirect missing X-Entire-Replicas; falling back to redirect-following")
+		followed, err := p.doGet(ctx, entryURL, p.client, setHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("fetching info/refs from entry domain: %w", err)
+		}
+		return p.handleInfoRefsResponse(followed)
+	}
+
+	debuglog.Printf("entry domain redirected with %d replicas %v; failing over instead of following", len(rs), rs)
+	p.nodes = rs
+
+	viaReplicas, err := p.doWithFailover(ctx, suffix, http.MethodGet, nil, setHeaders)
+	if err == nil {
+		return p.handleInfoRefsResponse(viaReplicas)
+	}
+
+	if location == "" {
+		return nil, fmt.Errorf("fetching info/refs after entry-domain redirect: %w", err)
+	}
+	debuglog.Printf("all advertised replicas failed; trying redirect Location %s as last-ditch fallback: %v", location, err)
+	locResp, locErr := p.doGet(ctx, location, p.client, setHeaders)
+	if locErr != nil {
+		return nil, fmt.Errorf("fetching info/refs after entry-domain redirect: %w", errors.Join(err, locErr))
+	}
+	return p.handleInfoRefsResponse(locResp)
+}
+
+// handleInfoRefsResponse refreshes the replica cache from the response
+// and returns the body (or a typed HTTP error). The caller is
+// responsible for closing the returned ReadCloser on success.
+func (p *Proxy) handleInfoRefsResponse(resp *http.Response) (io.ReadCloser, error) {
+	p.refreshReplicas(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		var msg string
+		if readErr == nil {
+			msg = strings.TrimSpace(string(body))
+		}
+		if strings.HasPrefix(msg, "<") {
+			msg = ""
+		}
+		return nil, HTTPErrorMessage(resp.StatusCode, msg, p.ErrorBaseURL())
+	}
+	return resp.Body, nil
+}
+
+// ServiceRPC sends data to a Git service endpoint and returns the
+// response. The extraHeaders callbacks are invoked on each request to
+// set additional headers (e.g. Git-Protocol, X-Entire-Push-Size).
+func (p *Proxy) ServiceRPC(ctx context.Context, service string, body io.ReadSeeker, extraHeaders ...func(*http.Request)) (io.ReadCloser, error) {
+	suffix := "/" + service
+
+	setHeaders := func(req *http.Request) {
+		req.Header.Set("Content-Type", fmt.Sprintf("application/x-%s-request", service))
+		req.Header.Set("Accept", fmt.Sprintf("application/x-%s-result", service))
+		for _, fn := range extraHeaders {
+			fn(req)
+		}
+	}
+
+	resp, err := p.doWithFailover(ctx, suffix, http.MethodPost, body, setHeaders)
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", service, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		var msg string
+		if readErr == nil {
+			msg = strings.TrimSpace(string(respBody))
+		}
+		if strings.HasPrefix(msg, "<") {
+			msg = ""
+		}
+		return nil, HTTPErrorMessage(resp.StatusCode, msg, p.ErrorBaseURL())
+	}
+
+	return resp.Body, nil
+}
+
+// HTTPErrorMessage returns a user-friendly error for non-200 HTTP
+// responses. Exposed so handlers outside the transport package can
+// produce the same shape.
+func HTTPErrorMessage(statusCode int, serverMsg, baseURL string) error {
+	switch statusCode {
+	case http.StatusUnauthorized:
+		if serverMsg != "" {
+			return fmt.Errorf("authentication failed: %s", serverMsg)
+		}
+		return errors.New("authentication failed - please run 'entire-core auth login'")
+	case http.StatusNotFound:
+		if serverMsg != "" {
+			return errors.New(serverMsg)
+		}
+		return fmt.Errorf("repository not found: %s", baseURL)
+	default:
+		if serverMsg != "" {
+			return fmt.Errorf("server error (HTTP %d): %s", statusCode, serverMsg)
+		}
+		return fmt.Errorf("server error (HTTP %d)", statusCode)
+	}
+}

--- a/internal/remotehelper/transport/proxy.go
+++ b/internal/remotehelper/transport/proxy.go
@@ -1,0 +1,349 @@
+// Package transport implements the HTTP layer the helper protocol
+// speaks against: a Proxy that talks to one or more Entire data-plane
+// replicas, applies failover on connection errors and 5xx responses,
+// and bridges the warm/cold paths driven by X-Entire-Replicas.
+//
+// The Proxy is decoupled from authentication via a SetAuthFunc — the
+// caller (cmd/entire's runRemoteHelper) wires the scoped-token mint in
+// there. checkRedirect enforces the same-cluster Authorization carry
+// rule so credentials never leak across hosts.
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/entireio/cli/internal/entireclient/discovery"
+	"github.com/entireio/cli/internal/entireclient/httpclient"
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+	"github.com/entireio/cli/internal/remotehelper/httpdebug"
+	"github.com/entireio/cli/internal/remotehelper/replicas"
+)
+
+// SetAuthFunc attaches authentication headers to an outbound request.
+// Errors are surfaced verbatim — they short-circuit failover because
+// they originate at the auth provider, not the data-plane node.
+type SetAuthFunc func(*http.Request) error
+
+// Config bundles the inputs needed to build a Proxy. Path is the URL
+// path on each node (e.g. "/et/project/repo") and is appended to the
+// node base for every request.
+type Config struct {
+	Nodes        replicas.NodeConfig
+	Path         string
+	SkipTLS      bool
+	SetAuth      SetAuthFunc
+	OnNodeFailed func(failedNode string)
+}
+
+// Proxy is the HTTP transport the helper protocol uses to talk to the
+// data plane. Methods are not safe for concurrent use — Git's helper
+// protocol is strictly serial.
+type Proxy struct {
+	// nodes is the current replica set. Populated from
+	// X-Entire-Replicas headers and the on-disk cache; empty on a
+	// cold invocation, in which case InfoRefs uses entryURL instead.
+	nodes []string
+	// entryURL is the cluster entry domain (e.g.
+	// https://aws-us-east-2.entire.io). Used by InfoRefs when the
+	// cached replica set is empty or exhausted.
+	entryURL string
+	// clusterHost is the cluster's entry hostname (no scheme, port
+	// allowed). Used to decide which redirects are safe to carry
+	// Authorization across — same-cluster only.
+	clusterHost string
+	// cacheHost is the key used when persisting replica sets. Empty
+	// disables cache writes.
+	cacheHost string
+	// repoPath mirrors cacheHost — empty disables cache writes.
+	repoPath string
+	// path is the URL path on each node.
+	path string
+
+	client       *http.Client
+	setAuth      SetAuthFunc
+	onNodeFailed func(failedNode string)
+
+	// stickyNode is the URL (matching one of nodes) of the replica
+	// that served the most recent successful request, post-redirects.
+	// Used as the starting offset for the next doWithFailover so
+	// subsequent requests in the same fetch session reuse Go's
+	// transport-pool TCP + TLS connection instead of paying a fresh
+	// handshake per round.
+	stickyNode string
+}
+
+// New builds a Proxy from the given configuration. The HTTP client is
+// constructed here so that its CheckRedirect can reference the proxy
+// (otherwise the cross-host Authorization-stripping policy would need
+// duplicate state).
+func New(cfg Config) *Proxy {
+	debuglog.Printf("nodes=%v entry=%s path=%s skipTLS=%v", cfg.Nodes.InitialNodes, cfg.Nodes.EntryURL, cfg.Path, cfg.SkipTLS)
+
+	p := &Proxy{
+		nodes:        cfg.Nodes.InitialNodes,
+		entryURL:     cfg.Nodes.EntryURL,
+		clusterHost:  cfg.Nodes.ClusterHost,
+		path:         cfg.Path,
+		setAuth:      cfg.SetAuth,
+		onNodeFailed: cfg.OnNodeFailed,
+	}
+	if cfg.Nodes.Caching() {
+		p.cacheHost = cfg.Nodes.ClusterHost
+		p.repoPath = cfg.Nodes.RepoPath
+	}
+
+	transport := httpclient.NewTransport(cfg.SkipTLS)
+	p.client = &http.Client{
+		Transport:     &httpdebug.RoundTripper{Next: transport},
+		CheckRedirect: p.checkRedirect,
+	}
+	return p
+}
+
+// ErrorBaseURL returns a URL string suitable for embedding in error
+// messages, guarding against empty node lists.
+func (p *Proxy) ErrorBaseURL() string {
+	if len(p.nodes) > 0 {
+		return p.nodes[0] + p.path
+	}
+	return p.path
+}
+
+// checkRedirect is the http.Client CheckRedirect hook. It caps
+// redirect chains and enforces an explicit same-cluster policy for the
+// Authorization header: in-cluster hops re-carry it (Go's default
+// strips on cross-host redirect, which would otherwise drop the
+// credential when info/refs 307s from the entry domain to a hosting
+// replica), out-of-cluster hops strip it.
+//
+// The explicit strip matters: Go's default shouldCopyHeaderOnRedirect
+// keys on hostname only, so same-host-different-port hops (common with
+// local test servers, and possible with a misconfigured LB) would
+// otherwise carry Authorization through. We'd rather drop the header
+// than leak it.
+func (p *Proxy) checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	if len(via) == 0 {
+		return nil
+	}
+	if p.clusterHost != "" && !discovery.HostInCluster(req.URL.Hostname(), p.clusterHost) {
+		debuglog.Printf("redirect to %s is out-of-cluster (cluster=%s); stripping Authorization", req.URL.Host, p.clusterHost)
+		req.Header.Del("Authorization")
+		return nil
+	}
+	if auth := via[0].Header.Get("Authorization"); auth != "" {
+		debuglog.Printf("redirect to %s is in-cluster (cluster=%s); preserving Authorization", req.URL.Host, p.clusterHost)
+		req.Header.Set("Authorization", auth) //nolint:gosec // intentional: preserve auth for in-cluster hops (out-of-cluster is stripped above)
+	}
+	return nil
+}
+
+func (p *Proxy) nodeURL(nodeBase, suffix string) string {
+	return strings.TrimSuffix(nodeBase, "/") + p.path + suffix
+}
+
+// shouldFailover returns true for HTTP status codes that indicate a
+// node health issue (5xx). Client errors (4xx) are not retried since
+// they would produce the same result on any node.
+func shouldFailover(statusCode int) bool { return statusCode >= 500 }
+
+// markNodeFailed removes a node from the in-memory list and notifies
+// the OnNodeFailed callback. Subsequent calls (in this invocation)
+// skip the removed node.
+func (p *Proxy) markNodeFailed(node string) {
+	filtered := make([]string, 0, len(p.nodes))
+	for _, n := range p.nodes {
+		if n != node {
+			filtered = append(filtered, n)
+		}
+	}
+	p.nodes = filtered
+
+	if p.onNodeFailed != nil {
+		p.onNodeFailed(node)
+	}
+}
+
+// setAuthOrError applies the configured SetAuthFunc (if any) to the
+// request. Errors come from the auth provider (core), not the data
+// plane, so they short-circuit failover.
+func (p *Proxy) setAuthOrError(req *http.Request) error {
+	if p.setAuth == nil {
+		return nil
+	}
+	return p.setAuth(req)
+}
+
+// doGet issues an authed GET to a fully qualified URL using the given
+// client. Used for one-shot cold-path fetches that don't carry a
+// request body — the cold-path probe (no-redirect client), the
+// missing-replicas fallback, and the Location salvage all share this
+// shape.
+func (p *Proxy) doGet(ctx context.Context, urlStr string, client *http.Client, setHeaders func(*http.Request)) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	if err := p.setAuthOrError(req); err != nil {
+		return nil, err
+	}
+	if setHeaders != nil {
+		setHeaders(req)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("doing request: %w", err)
+	}
+	return resp, nil
+}
+
+// doWithFailover tries an HTTP request against each node, starting
+// from a random offset (or the stickyNode if one is set and still in
+// the replica list). Connection errors and 5xx responses trigger
+// failover to the next node. The failed node is removed from the list
+// and OnNodeFailed is called.
+func (p *Proxy) doWithFailover(ctx context.Context, makeSuffix string, method string, body io.ReadSeeker, setHeaders func(*http.Request)) (*http.Response, error) {
+	nodes := slices.Clone(p.nodes)
+	if len(nodes) == 0 {
+		return nil, errors.New("no healthy nodes available")
+	}
+	start := rand.IntN(len(nodes)) //nolint:gosec // load-spreading, not security
+	if p.stickyNode != "" {
+		if idx := slices.Index(nodes, p.stickyNode); idx >= 0 {
+			start = idx
+		}
+	}
+	var lastErr error
+
+	for i := range nodes {
+		node := nodes[(start+i)%len(nodes)]
+		reqURL := p.nodeURL(node, makeSuffix)
+
+		var bodyReader io.Reader
+		if body != nil {
+			if _, err := body.Seek(0, io.SeekStart); err != nil {
+				return nil, fmt.Errorf("resetting request body: %w", err)
+			}
+			bodyReader = body
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, bodyReader)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		if err := p.setAuthOrError(req); err != nil {
+			return nil, err
+		}
+		if setHeaders != nil {
+			setHeaders(req)
+		}
+
+		resp, err := p.client.Do(req)
+		if err != nil {
+			debuglog.Printf("node %s unreachable: %v", node, err)
+			lastErr = err
+			p.markNodeFailed(node)
+			continue
+		}
+
+		if shouldFailover(resp.StatusCode) {
+			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024)) //nolint:errcheck // best-effort body read for error message
+			_ = resp.Body.Close()
+			msg := strings.TrimSpace(string(respBody))
+			debuglog.Printf("node %s returned HTTP %d: %s", node, resp.StatusCode, msg)
+			lastErr = fmt.Errorf("node %s: HTTP %d: %s", node, resp.StatusCode, msg)
+			p.markNodeFailed(node)
+			continue
+		}
+
+		// Record the actual responder for connection reuse on the next
+		// request. Use the post-redirect URL so a 307 to a different
+		// replica makes us stick to the redirect target, not the
+		// bouncer.
+		if resp.Request != nil && resp.Request.URL != nil {
+			resolved := resp.Request.URL.Scheme + "://" + resp.Request.URL.Host
+			if slices.Contains(nodes, resolved) {
+				p.stickyNode = resolved
+			}
+		}
+		return resp, nil
+	}
+
+	return nil, fmt.Errorf("all %d nodes failed, last error: %w", len(nodes), lastErr)
+}
+
+// noRedirectClient returns a one-shot client that shares this proxy's
+// transport (so connection pooling still applies) but never follows
+// redirects, surfacing 3xx responses to the caller.
+func (p *Proxy) noRedirectClient() *http.Client {
+	var transport http.RoundTripper
+	if p.client != nil {
+		transport = p.client.Transport
+	}
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func isRedirect(statusCode int) bool { return statusCode >= 300 && statusCode < 400 }
+
+// responseHost returns the host of the URL that ultimately answered
+// the request (after redirects), for log messages. Empty for a
+// malformed response.
+func responseHost(resp *http.Response) string {
+	if resp == nil || resp.Request == nil || resp.Request.URL == nil {
+		return ""
+	}
+	return resp.Request.URL.Host
+}
+
+// refreshReplicas updates p.nodes from the X-Entire-Replicas header on
+// an info/refs response.
+//
+// When the header is present we treat it as the authoritative current
+// replica set: in-memory state and on-disk cache are both updated.
+// When it's absent we deliberately do *not* persist, because doing so
+// would mask a server running without the discovery middleware — every
+// op would shrink the cache to a single entry. Behaviour in that case:
+//
+//   - If a cached set already populated p.nodes, keep it untouched and
+//     skip the cache write. Subsequent ops retry the cached set; if
+//     those entries go bad the warm-path failover and entry-domain
+//     fallback in InfoRefs take over.
+//   - Otherwise (cold start with no header), use the URL that answered
+//     as a single in-memory entry so the subsequent POST has somewhere
+//     to go, but still don't persist — the next invocation retries
+//     cold so the fix (server side) eventually shows up.
+func (p *Proxy) refreshReplicas(resp *http.Response) {
+	if rs := discovery.ParseReplicas(resp.Header.Get("X-Entire-Replicas")); len(rs) > 0 {
+		debuglog.Printf("X-Entire-Replicas from %s: refreshed replica set to %d nodes %v", responseHost(resp), len(rs), rs)
+		p.nodes = rs
+		if p.cacheHost != "" && p.repoPath != "" {
+			replicas.Persist(p.cacheHost, p.repoPath, rs)
+		}
+		return
+	}
+
+	debuglog.Printf("info/refs response from %s missing X-Entire-Replicas; not refreshing cache", responseHost(resp))
+
+	if len(p.nodes) > 0 {
+		return
+	}
+	if resp.Request != nil && resp.Request.URL != nil {
+		u := &url.URL{Scheme: resp.Request.URL.Scheme, Host: resp.Request.URL.Host}
+		p.nodes = []string{u.String()}
+	}
+}

--- a/internal/remotehelper/transport/proxy.go
+++ b/internal/remotehelper/transport/proxy.go
@@ -88,13 +88,16 @@ func New(cfg Config) *Proxy {
 	debuglog.Printf("nodes=%v entry=%s path=%s skipTLS=%v", cfg.Nodes.InitialNodes, cfg.Nodes.EntryURL, cfg.Path, cfg.SkipTLS)
 
 	p := &Proxy{
-		nodes:        cfg.Nodes.InitialNodes,
 		entryURL:     cfg.Nodes.EntryURL,
 		clusterHost:  cfg.Nodes.ClusterHost,
 		path:         cfg.Path,
 		setAuth:      cfg.SetAuth,
 		onNodeFailed: cfg.OnNodeFailed,
 	}
+	// The cached node set (nodes.json) is attacker-influenceable: anything
+	// running as the user can amend it. Scope it to the cluster trust domain
+	// before any of these become credential-bearing dial targets.
+	p.nodes = p.filterReplicas(cfg.Nodes.InitialNodes)
 	if cfg.Nodes.Caching() {
 		p.cacheHost = cfg.Nodes.ClusterHost
 		p.repoPath = cfg.Nodes.RepoPath
@@ -148,6 +151,51 @@ func (p *Proxy) checkRedirect(req *http.Request, via []*http.Request) error {
 	return nil
 }
 
+// hostInCluster reports whether host is the cluster's entry domain or a
+// subdomain of it. With no clusterHost configured (un-pinned callers and
+// some tests) it returns true — there is no trust domain to enforce, which
+// matches checkRedirect's behaviour.
+func (p *Proxy) hostInCluster(host string) bool {
+	if p.clusterHost == "" {
+		return true
+	}
+	return discovery.HostInCluster(host, p.clusterHost)
+}
+
+// replicaInCluster reports whether a replica base URL is safe to dial with
+// the repo-scoped token attached: it must parse and resolve to a host
+// inside the cluster trust domain. Replica sets arrive from
+// attacker-influenceable sources — the X-Entire-Replicas response header, a
+// redirect Location, and the on-disk node cache — so a malicious or poisoned
+// entry pointing off-cluster would otherwise receive a core-minted bearer
+// token. Dropping it here keeps credentials scoped to the cluster the user
+// actually addressed.
+func (p *Proxy) replicaInCluster(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return p.hostInCluster(u.Hostname())
+}
+
+// filterReplicas drops replica URLs that fall outside the cluster trust
+// domain, logging each rejection. A no-op when clusterHost is unset. See
+// replicaInCluster.
+func (p *Proxy) filterReplicas(urls []string) []string {
+	if p.clusterHost == "" {
+		return urls
+	}
+	kept := make([]string, 0, len(urls))
+	for _, u := range urls {
+		if p.replicaInCluster(u) {
+			kept = append(kept, u)
+			continue
+		}
+		debuglog.Printf("dropping out-of-cluster replica %q (cluster=%s): refusing to carry credentials off-cluster", u, p.clusterHost)
+	}
+	return kept
+}
+
 func (p *Proxy) nodeURL(nodeBase, suffix string) string {
 	return strings.TrimSuffix(nodeBase, "/") + p.path + suffix
 }
@@ -180,6 +228,12 @@ func (p *Proxy) markNodeFailed(node string) {
 func (p *Proxy) setAuthOrError(req *http.Request) error {
 	if p.setAuth == nil {
 		return nil
+	}
+	// Hard chokepoint: every credential-bearing request flows through here.
+	// Even if a node URL slipped past the ingress filters, refuse to stamp a
+	// token onto a request bound for a host outside the cluster trust domain.
+	if !p.hostInCluster(req.URL.Hostname()) {
+		return fmt.Errorf("refusing to send credentials to out-of-cluster host %q (cluster %q)", req.URL.Hostname(), p.clusterHost)
 	}
 	return p.setAuth(req)
 }
@@ -328,7 +382,7 @@ func responseHost(resp *http.Response) string {
 //     to go, but still don't persist — the next invocation retries
 //     cold so the fix (server side) eventually shows up.
 func (p *Proxy) refreshReplicas(resp *http.Response) {
-	if rs := discovery.ParseReplicas(resp.Header.Get("X-Entire-Replicas")); len(rs) > 0 {
+	if rs := p.filterReplicas(discovery.ParseReplicas(resp.Header.Get("X-Entire-Replicas"))); len(rs) > 0 {
 		debuglog.Printf("X-Entire-Replicas from %s: refreshed replica set to %d nodes %v", responseHost(resp), len(rs), rs)
 		p.nodes = rs
 		if p.cacheHost != "" && p.repoPath != "" {
@@ -342,7 +396,11 @@ func (p *Proxy) refreshReplicas(resp *http.Response) {
 	if len(p.nodes) > 0 {
 		return
 	}
-	if resp.Request != nil && resp.Request.URL != nil {
+	// Cold start with no header: adopt the host that answered as a single
+	// in-memory entry so the subsequent POST has a target — but only if it's
+	// in-cluster, so a stripped-auth redirect to an off-cluster host can't
+	// pin an attacker URL as the node set.
+	if resp.Request != nil && resp.Request.URL != nil && p.hostInCluster(resp.Request.URL.Hostname()) {
 		u := &url.URL{Scheme: resp.Request.URL.Scheme, Host: resp.Request.URL.Host}
 		p.nodes = []string{u.String()}
 	}

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -1207,3 +1207,142 @@ func TestInfoRefsWarmAndColdBothFailSurfacesBoth(t *testing.T) {
 	assert.Contains(t, msg, "all 2 nodes failed")
 	assert.Contains(t, msg, "entry domain")
 }
+
+// --- Off-cluster credential-leak protection -------------------------------
+//
+// These tests cover the trust boundary that keeps the repo-scoped bearer
+// token from reaching hosts outside the cluster the user addressed. The
+// attack: a malicious entry domain (or a poisoned nodes.json) advertises
+// replica/Location URLs on attacker-controlled hosts; without scoping, the
+// helper would POST git-upload-pack to them with the core-minted JWT
+// attached. httptest servers all bind 127.0.0.1, so off-cluster hosts are
+// fabricated URL strings — the point is precisely that they are never
+// dialed.
+
+const offClusterReplica = "https://attacker-log-collector.example.com"
+
+func TestSetAuthOrErrorRefusesOutOfClusterHost(t *testing.T) {
+	t.Parallel()
+	var attached int
+	p := &Proxy{
+		clusterHost: "cluster.example",
+		setAuth: func(req *http.Request) error {
+			attached++
+			req.Header.Set("Authorization", "Bearer scoped-token")
+			return nil
+		},
+	}
+
+	off, err := http.NewRequestWithContext(t.Context(), http.MethodGet, offClusterReplica+"/et/alice/repo/info/refs", nil)
+	require.NoError(t, err)
+	require.Error(t, p.setAuthOrError(off), "must refuse to stamp a token onto an off-cluster request")
+	assert.Empty(t, off.Header.Get("Authorization"))
+	assert.Zero(t, attached, "SetAuth must not even be invoked for an off-cluster host")
+
+	in, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://n1.cluster.example/et/alice/repo/info/refs", nil)
+	require.NoError(t, err)
+	require.NoError(t, p.setAuthOrError(in))
+	assert.Equal(t, "Bearer scoped-token", in.Header.Get("Authorization"))
+}
+
+func TestNewFiltersOutOfClusterCachedNodes(t *testing.T) {
+	t.Parallel()
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{"https://n1.cluster.example", offClusterReplica, "https://n2.cluster.example"},
+			EntryURL:     "https://cluster.example",
+			ClusterHost:  "cluster.example",
+			RepoPath:     "alice/repo",
+		},
+		Path: "/et/alice/repo",
+	})
+	assert.Equal(t, []string{"https://n1.cluster.example", "https://n2.cluster.example"}, p.nodes,
+		"poisoned cache entry pointing off-cluster must be dropped on load")
+}
+
+func TestRefreshReplicasDropsOutOfClusterReplicas(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+
+	const cluster = "cluster.example"
+	const repo = "alice/repo"
+
+	u, err := url.Parse("https://n1.cluster.example/et/alice/repo/info/refs?service=git-upload-pack")
+	require.NoError(t, err)
+	resp := &http.Response{
+		Request: &http.Request{URL: u},
+		Header: http.Header{
+			"X-Entire-Replicas": {buildReplicasHeader("https://n1.cluster.example", offClusterReplica, "https://canarytokens.com/foo")},
+		},
+	}
+	p := &Proxy{clusterHost: cluster, cacheHost: cluster, repoPath: repo}
+	p.refreshReplicas(resp)
+
+	assert.Equal(t, []string{"https://n1.cluster.example"}, p.nodes,
+		"off-cluster entries from X-Entire-Replicas must be dropped")
+	assert.Equal(t, []string{"https://n1.cluster.example"}, replicas.LoadFresh(cluster, repo),
+		"only in-cluster replicas may be persisted to disk")
+}
+
+func TestRefreshReplicasResponseURLFallbackIgnoresOutOfClusterHost(t *testing.T) {
+	t.Parallel()
+	// Cold start, no header, but the request landed on an off-cluster host
+	// (e.g. an auth-stripped redirect). It must not become the node set.
+	u, err := url.Parse(offClusterReplica + "/et/alice/repo/info/refs")
+	require.NoError(t, err)
+	resp := &http.Response{Request: &http.Request{URL: u}, Header: http.Header{}}
+	p := &Proxy{clusterHost: "cluster.example"}
+	p.refreshReplicas(resp)
+	assert.Empty(t, p.nodes, "off-cluster responder must not be adopted as the node set")
+}
+
+func TestColdPathDropsOutOfClusterReplicasFromHeader(t *testing.T) {
+	t.Parallel()
+	var aliveURL string
+	alive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(aliveURL))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "refs from in-cluster replica")
+	}))
+	defer alive.Close()
+	aliveURL = alive.URL
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Advertise a legit in-cluster replica next to an attacker host.
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(aliveURL, offClusterReplica))
+		http.Redirect(w, r, aliveURL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	// clusterHost = 127.0.0.1 makes the httptest hosts in-cluster while the
+	// fabricated attacker host stays out.
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", entry.Client())
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err)
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	_ = body.Close()
+
+	assert.Equal(t, "refs from in-cluster replica", string(got))
+	assert.NotContains(t, p.nodes, offClusterReplica, "attacker replica must never enter the node set")
+}
+
+func TestColdPathRefusesOutOfClusterLocationSalvage(t *testing.T) {
+	t.Parallel()
+	deadReplica := closedServerURL() // in-cluster (127.0.0.1) but unreachable
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The only replica is dead, forcing the salvage path; Location points
+		// off-cluster, which the salvage path must refuse rather than dial
+		// with the token attached.
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(deadReplica))
+		http.Redirect(w, r, offClusterReplica+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", entry.Client())
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.Error(t, err, "must not salvage to an off-cluster Location")
+}

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -1,0 +1,1209 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/entireclient/discovery"
+	"github.com/entireio/cli/internal/remotehelper/replicas"
+)
+
+// testProxy creates a Proxy pointed at a single test server for
+// /et/owner/repo. token is left empty so SetAuth no-ops — these tests
+// exercise the plumbing (HTTP method, path, body), not the auth flow.
+func testProxy(server *httptest.Server) *Proxy {
+	return New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{server.URL},
+			EntryURL:     server.URL,
+			ClusterHost:  mustHost(nil, server.URL),
+			RepoPath:     "owner/repo",
+		},
+		Path: "/et/owner/repo",
+	})
+}
+
+func proxyWithClient(nodes []string, path, entryURL, clusterHost string, client *http.Client) *Proxy {
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: nodes,
+			EntryURL:     entryURL,
+			ClusterHost:  clusterHost,
+			RepoPath:     "owner/repo",
+		},
+		Path: path,
+	})
+	if client != nil {
+		// Swap in the test-provided client (e.g. one we want to
+		// inspect or one with a custom CheckRedirect).
+		p.client = client
+	}
+	return p
+}
+
+// mustHost returns the hostname portion of a URL, stripping the port.
+func mustHost(t *testing.T, raw string) string {
+	if t != nil {
+		t.Helper()
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		if t != nil {
+			t.Fatalf("parse %q: %v", raw, err)
+		}
+		return ""
+	}
+	return u.Hostname()
+}
+
+func TestNewProxy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		nodes    []string
+		path     string
+		wantPath string
+	}{
+		{
+			name:     "basic",
+			nodes:    []string{"https://host.com"},
+			path:     "/et/owner/repo",
+			wantPath: "/et/owner/repo",
+		},
+		{
+			name:     "multiple nodes",
+			nodes:    []string{"https://n1.host.com", "https://n2.host.com"},
+			path:     "/et/owner/repo",
+			wantPath: "/et/owner/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := New(Config{
+				Nodes: replicas.NodeConfig{
+					InitialNodes: tt.nodes,
+					EntryURL:     tt.nodes[0],
+					ClusterHost:  "host.com",
+					RepoPath:     "owner/repo",
+				},
+				Path: tt.path,
+			})
+			if p.path != tt.wantPath {
+				t.Errorf("path = %q, want %q", p.path, tt.wantPath)
+			}
+			if len(p.nodes) != len(tt.nodes) {
+				t.Errorf("nodes = %d, want %d", len(p.nodes), len(tt.nodes))
+			}
+		})
+	}
+}
+
+const serviceParam = "git-upload-pack"
+
+func TestInfoRefs(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if !strings.HasPrefix(r.URL.Path, "/et/owner/repo/info/refs") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("service") != serviceParam {
+			t.Errorf("service = %s", r.URL.Query().Get("service"))
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "mock refs response")
+	}))
+	defer server.Close()
+
+	resp, err := testProxy(server).InfoRefs(context.Background(), serviceParam)
+	if err != nil {
+		t.Fatalf("InfoRefs failed: %v", err)
+	}
+	defer resp.Close()
+
+	body, err := io.ReadAll(resp)
+	if err != nil {
+		t.Fatalf("ReadAll failed: %v", err)
+	}
+	if string(body) != "mock refs response" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestServiceRPC(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/et/owner/repo/git-upload-pack" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/x-git-upload-pack-request" {
+			t.Errorf("content-type = %s", r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body) //nolint:errcheck // test
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body) //nolint:errcheck // test
+	}))
+	defer server.Close()
+
+	resp, err := testProxy(server).ServiceRPC(context.Background(), serviceParam, strings.NewReader("body"))
+	if err != nil {
+		t.Fatalf("ServiceRPC: %v", err)
+	}
+	defer resp.Close()
+	got, _ := io.ReadAll(resp) //nolint:errcheck // test
+	if string(got) != "body" {
+		t.Errorf("body = %q", got)
+	}
+}
+
+func TestInfoRefs_ErrorIncludesStatusCode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantSubstr string
+	}{
+		{"5xx with body", http.StatusBadGateway, "upstream connect error", "HTTP 502"},
+		{"HTML body shows status", http.StatusBadGateway, "<html>Bad Gateway</html>", "HTTP 502"},
+		{"empty body shows status", http.StatusInternalServerError, "", "HTTP 500"},
+		{"4xx", http.StatusBadRequest, "bad request body", "server error (HTTP 400): bad request body"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				fmt.Fprint(w, tt.body)
+			}))
+			defer server.Close()
+
+			_, err := testProxy(server).InfoRefs(context.Background(), "git-upload-pack")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestServiceRPC_ErrorIncludesStatusCode(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(w, "upstream timeout")
+	}))
+	defer server.Close()
+
+	_, err := testProxy(server).ServiceRPC(context.Background(), "git-upload-pack", strings.NewReader("body"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 502") {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+func TestUnauthorized(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, err := testProxy(server).InfoRefs(context.Background(), "git-upload-pack")
+	if err == nil {
+		t.Fatal("expected error for unauthorized request")
+	}
+	if !strings.Contains(err.Error(), "authentication failed") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func TestFailover(t *testing.T) {
+	t.Parallel()
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	down.Close()
+
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok from up node")
+	}))
+	defer up.Close()
+
+	p := proxyWithClient([]string{down.URL, up.URL}, "/et/alice/repo", "", "", &http.Client{})
+
+	resp, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err != nil {
+		t.Fatalf("expected failover to succeed, got: %v", err)
+	}
+	defer resp.Close()
+	body, _ := io.ReadAll(resp) //nolint:errcheck // test
+	if string(body) != "ok from up node" {
+		t.Errorf("unexpected body: %q", body)
+	}
+}
+
+func TestFailover5xx(t *testing.T) {
+	t.Parallel()
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(w, "bad gateway")
+	}))
+	defer bad.Close()
+
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok")
+	}))
+	defer good.Close()
+
+	p := proxyWithClient([]string{bad.URL, good.URL}, "/et/alice/repo", "", "", &http.Client{})
+
+	resp, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err != nil {
+		t.Fatalf("expected failover to succeed, got: %v", err)
+	}
+	defer resp.Close()
+	body, _ := io.ReadAll(resp) //nolint:errcheck // test
+	if string(body) != "ok" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestOnNodeFailedCalledOnConnectionError(t *testing.T) {
+	t.Parallel()
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	down.Close()
+
+	var failed []string
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{down.URL},
+			ClusterHost:  mustHost(t, down.URL),
+		},
+		Path:         "/et/alice/repo",
+		OnNodeFailed: func(node string) { failed = append(failed, node) },
+	})
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err == nil {
+		t.Fatal("expected error with single unreachable node")
+	}
+	if len(failed) != 1 || failed[0] != down.URL {
+		t.Errorf("onNodeFailed = %v, want [%s]", failed, down.URL)
+	}
+}
+
+func TestOnNodeFailedCalledOn5xx(t *testing.T) {
+	t.Parallel()
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer bad.Close()
+
+	var failed []string
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{bad.URL},
+			ClusterHost:  mustHost(t, bad.URL),
+		},
+		Path:         "/et/alice/repo",
+		OnNodeFailed: func(node string) { failed = append(failed, node) },
+	})
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err == nil {
+		t.Fatal("expected error with single 502 node")
+	}
+	if len(failed) != 1 || failed[0] != bad.URL {
+		t.Errorf("onNodeFailed = %v, want [%s]", failed, bad.URL)
+	}
+}
+
+func TestNodeRemovedAfterFailure(t *testing.T) {
+	t.Parallel()
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+
+	p := proxyWithClient([]string{bad.URL}, "/et/alice/repo", "", "", &http.Client{})
+
+	resp, _ := p.doWithFailover(context.Background(), "/info/refs?service=git-upload-pack", http.MethodGet, nil, nil) //nolint:errcheck // we expect failure
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if len(p.nodes) != 0 {
+		t.Errorf("expected 0 nodes after failure, got %d: %v", len(p.nodes), p.nodes)
+	}
+}
+
+func TestFailoverAll5xx(t *testing.T) {
+	t.Parallel()
+	s1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer s1.Close()
+	s2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer s2.Close()
+
+	p := proxyWithClient([]string{s1.URL, s2.URL}, "/et/alice/repo", "", "", &http.Client{})
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err == nil {
+		t.Fatal("expected error when all nodes return 5xx")
+	}
+	if !strings.Contains(err.Error(), "all 2 nodes failed") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func TestNoFailoverOn401(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, "unauthorized")
+	}))
+	defer server.Close()
+
+	var failedCalled bool
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{server.URL},
+			ClusterHost:  mustHost(t, server.URL),
+		},
+		Path:         "/et/alice/repo",
+		OnNodeFailed: func(string) { failedCalled = true },
+	})
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !strings.Contains(err.Error(), "authentication failed") {
+		t.Errorf("error = %v", err)
+	}
+	if failedCalled {
+		t.Error("onNodeFailed should not be called on 401")
+	}
+}
+
+func TestNoFailoverOn404(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "not found")
+	}))
+	defer server.Close()
+
+	var failedCalled bool
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{server.URL},
+			ClusterHost:  mustHost(t, server.URL),
+		},
+		Path:         "/et/alice/repo",
+		OnNodeFailed: func(string) { failedCalled = true },
+	})
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if failedCalled {
+		t.Error("onNodeFailed should not be called on 404")
+	}
+}
+
+// TestSticky_AcrossRounds verifies that multiple POSTs from the same
+// fetch session land on the same replica so Go's transport pool can
+// reuse its TCP+TLS connection.
+func TestSticky_AcrossRounds(t *testing.T) {
+	t.Parallel()
+	var s1Hits, s2Hits, s3Hits int
+	mkServer := func(counter *int) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			*counter++
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+	s1 := mkServer(&s1Hits)
+	s2 := mkServer(&s2Hits)
+	s3 := mkServer(&s3Hits)
+	defer s1.Close()
+	defer s2.Close()
+	defer s3.Close()
+
+	p := proxyWithClient([]string{s1.URL, s2.URL, s3.URL}, "/et/owner/repo", "", "", s1.Client())
+
+	ctx := context.Background()
+	const rounds = 10
+	for range rounds {
+		resp, err := p.ServiceRPC(ctx, "git-upload-pack", strings.NewReader("body"))
+		if err != nil {
+			t.Fatalf("ServiceRPC: %v", err)
+		}
+		_ = resp.Close()
+	}
+
+	hits := []int{s1Hits, s2Hits, s3Hits}
+	var nonZero, total int
+	for _, h := range hits {
+		total += h
+		if h > 0 {
+			nonZero++
+		}
+	}
+	if total != rounds {
+		t.Fatalf("total hits = %d, want %d", total, rounds)
+	}
+	if nonZero != 1 {
+		t.Errorf("expected sticky to one node, got hits distributed across %d nodes: %v", nonZero, hits)
+	}
+}
+
+func TestSticky_FollowsRedirect(t *testing.T) {
+	t.Parallel()
+	var bouncerHits, targetHits int
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+	bouncer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bouncerHits++
+		http.Redirect(w, r, target.URL+r.URL.Path, http.StatusTemporaryRedirect)
+	}))
+	defer bouncer.Close()
+
+	p := proxyWithClient([]string{bouncer.URL, target.URL}, "/et/owner/repo", "", "", target.Client())
+	p.stickyNode = bouncer.URL
+
+	resp, err := p.ServiceRPC(context.Background(), "git-upload-pack", strings.NewReader("body"))
+	if err != nil {
+		t.Fatalf("ServiceRPC: %v", err)
+	}
+	_ = resp.Close()
+
+	if bouncerHits != 1 {
+		t.Errorf("bouncer hits = %d, want 1", bouncerHits)
+	}
+	if targetHits != 1 {
+		t.Errorf("target hits = %d, want 1", targetHits)
+	}
+	if p.stickyNode != target.URL {
+		t.Errorf("StickyNode = %q after redirect, want %q", p.stickyNode, target.URL)
+	}
+
+	bouncerHits, targetHits = 0, 0
+	resp, err = p.ServiceRPC(context.Background(), "git-upload-pack", strings.NewReader("body"))
+	if err != nil {
+		t.Fatalf("ServiceRPC 2: %v", err)
+	}
+	_ = resp.Close()
+	if bouncerHits != 0 {
+		t.Errorf("after sticky moved to target, bouncer should not be hit; got %d", bouncerHits)
+	}
+	if targetHits != 1 {
+		t.Errorf("target hits on round 2 = %d, want 1", targetHits)
+	}
+}
+
+func TestSticky_ResetsOnReplicaRefresh(t *testing.T) {
+	t.Parallel()
+	var hits int
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s.Close()
+
+	p := proxyWithClient([]string{s.URL}, "/et/owner/repo", "", "", s.Client())
+	p.stickyNode = "https://stale-replica.example.com:443"
+
+	resp, err := p.ServiceRPC(context.Background(), "git-upload-pack", strings.NewReader("body"))
+	if err != nil {
+		t.Fatalf("ServiceRPC: %v", err)
+	}
+	_ = resp.Close()
+
+	if hits != 1 {
+		t.Errorf("hits = %d, want 1 (stale stickyNode shouldn't poison selection)", hits)
+	}
+	if p.stickyNode != s.URL {
+		t.Errorf("StickyNode = %q after request, want %q", p.stickyNode, s.URL)
+	}
+}
+
+// buildReplicasHeader joins server URLs the way the server middleware does.
+func buildReplicasHeader(urls ...string) string { return strings.Join(urls, ",") }
+
+func TestInfoRefsColdPathUsesEntryURL(t *testing.T) {
+	t.Parallel()
+	replica := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Errorf("cold-path test should not hit the replica directly")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer replica.Close()
+
+	var entryHits atomic.Int32
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		entryHits.Add(1)
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(replica.URL))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "refs")
+	}))
+	defer entry.Close()
+
+	entryHost := mustHost(t, entry.URL)
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, entryHost, entry.Client())
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err != nil {
+		t.Fatalf("InfoRefs: %v", err)
+	}
+	_ = body.Close()
+
+	if got := entryHits.Load(); got != 1 {
+		t.Errorf("entry hits = %d, want 1", got)
+	}
+	if !slices.Equal(p.nodes, []string{replica.URL}) {
+		t.Errorf("nodes after cold path = %v, want %v", p.nodes, []string{replica.URL})
+	}
+}
+
+func TestInfoRefsWarmPathRefreshesCache(t *testing.T) {
+	t.Parallel()
+	var newReplica string
+	old := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(newReplica))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "refs")
+	}))
+	defer old.Close()
+
+	brandNew := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer brandNew.Close()
+	newReplica = brandNew.URL
+
+	entryHost := mustHost(t, old.URL)
+	p := proxyWithClient([]string{old.URL}, "/et/alice/repo", "http://unused.example", entryHost, old.Client())
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err != nil {
+		t.Fatalf("InfoRefs: %v", err)
+	}
+	_ = body.Close()
+
+	if !slices.Equal(p.nodes, []string{newReplica}) {
+		t.Errorf("nodes after warm path = %v, want %v", p.nodes, []string{newReplica})
+	}
+}
+
+func TestInfoRefsFollowsRedirectFromEntryDomain(t *testing.T) {
+	t.Parallel()
+	var replicaURL string
+	replica := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/info/refs") {
+			t.Errorf("replica got unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(replicaURL))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "refs")
+	}))
+	defer replica.Close()
+	replicaURL = replica.URL
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(replicaURL))
+		http.Redirect(w, r, replicaURL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", nil)
+	p.client = &http.Client{CheckRedirect: p.checkRedirect}
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	if err != nil {
+		t.Fatalf("InfoRefs: %v", err)
+	}
+	_ = body.Close()
+
+	if !slices.Equal(p.nodes, []string{replicaURL}) {
+		t.Errorf("nodes after 307 = %v, want %v", p.nodes, []string{replicaURL})
+	}
+}
+
+func TestInfoRefsV2FollowsRedirectFromEntryDomain(t *testing.T) {
+	t.Parallel()
+	var replicaURL string
+	var sawV2OnEntry, sawV2OnReplica atomic.Bool
+	replica := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Git-Protocol") == "version=2" {
+			sawV2OnReplica.Store(true)
+		}
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(replicaURL))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "v2 refs")
+	}))
+	defer replica.Close()
+	replicaURL = replica.URL
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Git-Protocol") == "version=2" {
+			sawV2OnEntry.Store(true)
+		}
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(replicaURL))
+		http.Redirect(w, r, replicaURL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", entry.Client())
+
+	body, err := p.InfoRefsV2(context.Background())
+	require.NoError(t, err)
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, "v2 refs", string(got))
+	assert.True(t, sawV2OnEntry.Load(), "entry-domain v2 probe must carry Git-Protocol")
+	assert.True(t, sawV2OnReplica.Load(), "replica v2 fetch must carry Git-Protocol")
+}
+
+func TestCheckRedirectPreservesAuthSameCluster(t *testing.T) {
+	t.Parallel()
+	p := &Proxy{clusterHost: "cluster.example"}
+
+	via, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://entry.cluster.example/et/alice/repo", nil)
+	require.NoError(t, err)
+	via.Header.Set("Authorization", "Bearer scoped-token")
+
+	next, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://n1.cluster.example/et/alice/repo", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, p.checkRedirect(next, []*http.Request{via}))
+	assert.Equal(t, "Bearer scoped-token", next.Header.Get("Authorization"))
+}
+
+func TestCheckRedirectDropsAuthOutOfCluster(t *testing.T) {
+	t.Parallel()
+	p := &Proxy{clusterHost: "cluster.example"}
+
+	via, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://entry.cluster.example/et/alice/repo", nil)
+	require.NoError(t, err)
+	via.Header.Set("Authorization", "Bearer scoped-token")
+
+	next, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://foreign.example/some/path", nil)
+	require.NoError(t, err)
+	next.Header.Set("Authorization", "Bearer scoped-token") // simulate same-host carry
+
+	require.NoError(t, p.checkRedirect(next, []*http.Request{via}))
+	assert.Empty(t, next.Header.Get("Authorization"))
+}
+
+func TestRefreshReplicasFallsBackToResponseURL(t *testing.T) {
+	t.Parallel()
+	u, _ := url.Parse("https://node7.cluster.example:8443/et/owner/repo/info/refs?service=git-upload-pack") //nolint:errcheck // static
+	resp := &http.Response{Request: &http.Request{URL: u}, Header: http.Header{}}
+	p := &Proxy{}
+	p.refreshReplicas(resp)
+	want := []string{"https://node7.cluster.example:8443"}
+	if !slices.Equal(p.nodes, want) {
+		t.Errorf("nodes = %v, want %v", p.nodes, want)
+	}
+}
+
+func TestRefreshReplicasMissingHeaderPreservesCachedSet(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+
+	const cluster = "eu.cluster.example"
+	const repo = "alice/repo"
+	cached := []string{"https://n1", "https://n2", "https://n3"}
+	replicas.Persist(cluster, repo, cached)
+
+	u, _ := url.Parse("https://n1/et/alice/repo/info/refs?service=git-upload-pack") //nolint:errcheck // static
+	resp := &http.Response{Request: &http.Request{URL: u}, Header: http.Header{}}
+	p := &Proxy{nodes: slices.Clone(cached), cacheHost: cluster, repoPath: repo}
+	p.refreshReplicas(resp)
+
+	if !slices.Equal(p.nodes, cached) {
+		t.Errorf("p.nodes = %v, want %v", p.nodes, cached)
+	}
+	onDisk := replicas.LoadFresh(cluster, repo)
+	if !slices.Equal(onDisk, cached) {
+		t.Errorf("on-disk cache = %v, want %v", onDisk, cached)
+	}
+}
+
+func TestRefreshReplicasMissingHeaderDoesNotPersist(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", dir)
+
+	const cluster = "eu.cluster.example"
+	const repo = "alice/repo"
+
+	u, _ := url.Parse("https://n1.eu.cluster.example/et/alice/repo/info/refs?service=git-upload-pack") //nolint:errcheck // static
+	resp := &http.Response{Request: &http.Request{URL: u}, Header: http.Header{}}
+	p := &Proxy{cacheHost: cluster, repoPath: repo}
+	p.refreshReplicas(resp)
+
+	if len(p.nodes) != 1 {
+		t.Fatalf("p.nodes = %v, want one in-memory fallback entry", p.nodes)
+	}
+	if got := replicas.LoadFresh(cluster, repo); len(got) != 0 {
+		t.Errorf("on-disk cache = %v, want empty (cold-start fallback must not persist)", got)
+	}
+}
+
+func TestProxyConsumesServerHeaderFormat(t *testing.T) {
+	t.Parallel()
+	header := "https://n1.eu.cluster.example,https://n2.eu.cluster.example:8443"
+	got := discovery.ParseReplicas(header)
+	want := []string{"https://n1.eu.cluster.example", "https://n2.eu.cluster.example:8443"}
+	if !slices.Equal(got, want) {
+		t.Errorf("ParseReplicas = %v, want %v", got, want)
+	}
+	if got := discovery.ParseReplicas(""); got != nil {
+		t.Errorf("ParseReplicas(\"\") = %v, want nil", got)
+	}
+}
+
+// closedServerURL returns the URL of an httptest.Server that has been
+// closed — a guaranteed-dead 127.0.0.1:port a request will fail to dial.
+func closedServerURL() string {
+	s := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := s.URL
+	s.Close()
+	return url
+}
+
+func TestColdPathFailoverWhenRedirectTargetUnreachable(t *testing.T) {
+	dead := closedServerURL()
+
+	var aliveURL string
+	alive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/info/refs") {
+			t.Errorf("alive replica got unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(aliveURL))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "refs from alive")
+	}))
+	defer alive.Close()
+	aliveURL = alive.URL
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(dead, aliveURL))
+		http.Redirect(w, r, dead+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	const iterations = 8
+	deadFailoverObserved := false
+
+	for i := range iterations {
+		var failed []string
+		p := New(Config{
+			Nodes: replicas.NodeConfig{
+				EntryURL:    entry.URL,
+				ClusterHost: "127.0.0.1",
+			},
+			Path:         "/et/alice/repo",
+			OnNodeFailed: func(node string) { failed = append(failed, node) },
+		})
+
+		body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+		require.NoErrorf(t, err, "iteration %d: failover must succeed", i)
+
+		got, err := io.ReadAll(body)
+		require.NoError(t, err)
+		_ = body.Close()
+		assert.Equal(t, "refs from alive", string(got), "iteration %d: response must come from alive replica", i)
+
+		if !slices.Equal(p.nodes, []string{aliveURL}) {
+			t.Errorf("iteration %d: nodes after failover = %v, want [%s]", i, p.nodes, aliveURL)
+		}
+		if slices.Contains(failed, dead) {
+			deadFailoverObserved = true
+		}
+	}
+
+	if !deadFailoverObserved {
+		t.Errorf("dead replica never marked failed across %d iterations — failover path may not be exercised", iterations)
+	}
+}
+
+func TestColdPathDoesNotFollowRedirectAuto(t *testing.T) {
+	t.Parallel()
+	forbidden := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("redirect target was dialled — auto-follow regression")
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer forbidden.Close()
+
+	replica := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Entire-Replicas", "")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "from replica")
+	}))
+	defer replica.Close()
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(replica.URL))
+		http.Redirect(w, r, forbidden.URL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", entry.Client())
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err)
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, "from replica", string(got))
+}
+
+func TestColdPathRedirectAllReplicasFail(t *testing.T) {
+	t.Parallel()
+	dead1 := closedServerURL()
+	dead2 := closedServerURL()
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(dead1, dead2))
+		http.Redirect(w, r, dead1+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", entry.Client())
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all 2 nodes failed")
+	assert.Contains(t, err.Error(), "after entry-domain redirect")
+}
+
+func TestColdPathRedirectMissingHeaderFollows(t *testing.T) {
+	t.Parallel()
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "from final")
+	}))
+	defer final.Close()
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, final.URL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", nil)
+	p.client = &http.Client{CheckRedirect: p.checkRedirect}
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err)
+	defer body.Close()
+	got, _ := io.ReadAll(body) //nolint:errcheck // test
+	assert.Equal(t, "from final", string(got))
+}
+
+func TestColdPathRedirectFailureDoesNotPoisonCache(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	dead1 := closedServerURL()
+	dead2 := closedServerURL()
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(dead1, dead2))
+		http.Redirect(w, r, dead1+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	const cluster = "eu.cluster.example"
+	const repo = "alice/repo"
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			EntryURL:    entry.URL,
+			ClusterHost: "127.0.0.1",
+			RepoPath:    repo,
+		},
+		Path: "/et/alice/repo",
+	})
+	p.cacheHost, p.repoPath = cluster, repo
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.Error(t, err)
+	if got := replicas.LoadFresh(cluster, repo); len(got) != 0 {
+		t.Errorf("on-disk cache = %v, want empty", got)
+	}
+}
+
+func TestColdPathRedirectStaleHeaderFallsBackToLocation(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	dead1 := closedServerURL()
+	dead2 := closedServerURL()
+
+	var aliveURL string
+	alive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(aliveURL))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "served by alive")
+	}))
+	defer alive.Close()
+	aliveURL = alive.URL
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(dead1, dead2))
+		http.Redirect(w, r, aliveURL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	const cluster = "eu.cluster.example"
+	const repo = "alice/repo"
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", &http.Client{})
+	p.cacheHost, p.repoPath = cluster, repo
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err)
+	defer body.Close()
+	got, _ := io.ReadAll(body) //nolint:errcheck // test
+	assert.Equal(t, "served by alive", string(got))
+
+	if cached := replicas.LoadFresh(cluster, repo); !slices.Equal(cached, []string{aliveURL}) {
+		t.Errorf("on-disk cache = %v, want [%s]", cached, aliveURL)
+	}
+}
+
+func TestColdPathRedirectSuccessPersistsReplicas(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+
+	var aliveURL string
+	alive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(aliveURL))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok")
+	}))
+	defer alive.Close()
+	aliveURL = alive.URL
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(aliveURL))
+		http.Redirect(w, r, aliveURL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	const cluster = "eu.cluster.example"
+	const repo = "alice/repo"
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", entry.Client())
+	p.cacheHost, p.repoPath = cluster, repo
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err)
+	_ = body.Close()
+
+	if cached := replicas.LoadFresh(cluster, repo); !slices.Equal(cached, []string{aliveURL}) {
+		t.Errorf("on-disk cache = %v, want [%s]", cached, aliveURL)
+	}
+}
+
+// TestColdPathRedirectForwardsBearer: the Bearer header set by SetAuth
+// must reach both the entry probe AND the replica fetch across a
+// cold-path 307. The SetAuth callback stamps Authorization per
+// request, and checkRedirect re-carries it for same-cluster hops.
+func TestColdPathRedirectForwardsBearer(t *testing.T) {
+	t.Parallel()
+	const bearer = "Bearer scoped"
+
+	var replicaURL string
+	var sawBearerOnReplica atomic.Bool
+	replica := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == bearer {
+			sawBearerOnReplica.Store(true)
+		}
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(replicaURL))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok")
+	}))
+	defer replica.Close()
+	replicaURL = replica.URL
+
+	var sawBearerOnEntry atomic.Bool
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == bearer {
+			sawBearerOnEntry.Store(true)
+		}
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(replicaURL))
+		http.Redirect(w, r, replicaURL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			EntryURL:    entry.URL,
+			ClusterHost: "127.0.0.1",
+		},
+		Path: "/et/alice/repo",
+		SetAuth: func(req *http.Request) error {
+			req.Header.Set("Authorization", bearer)
+			return nil
+		},
+	})
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err)
+	_ = body.Close()
+
+	assert.True(t, sawBearerOnEntry.Load(), "entry-domain probe must carry Authorization: Bearer")
+	assert.True(t, sawBearerOnReplica.Load(), "warm-path replica fetch must carry Authorization: Bearer")
+}
+
+func TestColdPathDirect2xxIsHandledInPlace(t *testing.T) {
+	t.Parallel()
+	var replicaURL string
+	replica := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("replica must not be dialled when entry serves 200 directly")
+	}))
+	defer replica.Close()
+	replicaURL = replica.URL
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Entire-Replicas", buildReplicasHeader(replicaURL))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "from entry")
+	}))
+	defer entry.Close()
+
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", entry.Client())
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err)
+	defer body.Close()
+	got, _ := io.ReadAll(body) //nolint:errcheck // test
+	assert.Equal(t, "from entry", string(got))
+	if !slices.Equal(p.nodes, []string{replicaURL}) {
+		t.Errorf("nodes = %v, want [%s]", p.nodes, replicaURL)
+	}
+}
+
+func TestColdPathEntryDomain4xxNotTreatedAsRedirect(t *testing.T) {
+	t.Parallel()
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer entry.Close()
+
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", entry.Client())
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+	assert.NotContains(t, err.Error(), "after entry-domain redirect")
+}
+
+func TestColdPathRedirectEmptyReplicaHeaderFollows(t *testing.T) {
+	t.Parallel()
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "fallback served")
+	}))
+	defer final.Close()
+
+	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Entire-Replicas", "  , ,")
+		http.Redirect(w, r, final.URL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer entry.Close()
+
+	p := proxyWithClient(nil, "/et/alice/repo", entry.URL, "127.0.0.1", nil)
+	p.client = &http.Client{CheckRedirect: p.checkRedirect}
+
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err)
+	defer body.Close()
+	got, _ := io.ReadAll(body) //nolint:errcheck // test
+	assert.Equal(t, "fallback served", string(got))
+}
+
+func TestIsRedirect(t *testing.T) {
+	t.Parallel()
+	for _, c := range []int{300, 301, 302, 303, 307, 308, 399} {
+		if !isRedirect(c) {
+			t.Errorf("isRedirect(%d) = false, want true", c)
+		}
+	}
+	for _, c := range []int{200, 299, 400, 401, 500, 502} {
+		if isRedirect(c) {
+			t.Errorf("isRedirect(%d) = true, want false", c)
+		}
+	}
+}
+
+// fakeTransport is a no-op http.RoundTripper used to verify pointer
+// identity in TestNoRedirectClientShareTransport without leaning on
+// http.DefaultTransport.
+type fakeTransport struct{}
+
+func (fakeTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	panic("fakeTransport must not be exercised")
+}
+
+func TestNoRedirectClientShareTransport(t *testing.T) {
+	t.Parallel()
+	transport := fakeTransport{}
+	p := &Proxy{client: &http.Client{Transport: transport}}
+	got := p.noRedirectClient()
+	if got.Transport != transport {
+		t.Errorf("NoRedirectClient transport = %v, want %v", got.Transport, transport)
+	}
+	if got.CheckRedirect == nil {
+		t.Fatal("NoRedirectClient must set CheckRedirect")
+	}
+	if err := got.CheckRedirect(nil, nil); !errors.Is(err, http.ErrUseLastResponse) {
+		t.Errorf("CheckRedirect returned %v, want http.ErrUseLastResponse", err)
+	}
+}
+
+func TestInfoRefsWarmAndColdBothFailSurfacesBoth(t *testing.T) {
+	t.Parallel()
+	deadReplica1 := closedServerURL()
+	deadReplica2 := closedServerURL()
+	deadEntry := closedServerURL()
+
+	p := proxyWithClient([]string{deadReplica1, deadReplica2}, "/et/alice/repo", deadEntry, "127.0.0.1", &http.Client{})
+
+	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "cached replicas")
+	assert.Contains(t, msg, "all 2 nodes failed")
+	assert.Contains(t, msg, "entry domain")
+}

--- a/scripts/entire-dev
+++ b/scripts/entire-dev
@@ -31,12 +31,16 @@ case "$0" in
 	*) script_dir=. ;;
 esac
 root=$(CDPATH= cd -- "$script_dir/.." && pwd)
-main="$root/cmd/entire/main.go"
+# Build/run the whole cmd/entire package, not just main.go: package main is
+# split across multiple files (e.g. the git-remote-entire dispatch in
+# remotehelper.go), and naming a single file would leave the others out and
+# fail to compile.
+pkg="$root/cmd/entire"
 
 # Run freshly compiled code when the tree builds. The build probe populates the
 # build cache, so the subsequent "go run" does not recompile from scratch.
-if command -v go >/dev/null 2>&1 && go build -o /dev/null "$main" >/dev/null 2>&1; then
-	exec go run "$main" "$@"
+if command -v go >/dev/null 2>&1 && go build -o /dev/null "$pkg" >/dev/null 2>&1; then
+	exec go run "$pkg" "$@"
 fi
 
 # The tree does not build (or Go is unavailable): fall back to the installed

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -252,6 +252,16 @@ main() {
     fi
     mv "$binary_path" "$install_path"
 
+    # Install the git remote helper binary alongside entire so
+    # `git clone entire://…` resolves it on PATH. It ships in the same
+    # archive as a separate binary.
+    if [[ -f "${tmp_dir}/git-remote-entire" ]]; then
+        chmod +x "${tmp_dir}/git-remote-entire"
+        mv "${tmp_dir}/git-remote-entire" "${install_dir}/git-remote-entire"
+    else
+        warn "git-remote-entire not found in archive; entire:// clones won't work until the next release includes it."
+    fi
+
     # Verify installation
     if "$install_path" version &> /dev/null; then
         success "Entire CLI installed to ${install_path}"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/460
<!-- entire-trail-link-end -->

Stacked on #1299 — review/merge that first; this PR's base is `soph/entire-control-plane-client`, so the diff here is only the helper + multi-context auth work.

## What this does

Makes `git clone entire://…` work from the CLI by folding entiredb's `git-remote-entire` into this repo, and re-platforms the CLI's auth onto the shared kubectl-style `contexts.json` credential model so a single login authenticates both control-plane commands and clones — across any entitled cluster.

## Shape of the change

**1. Vendor the remote-helper protocol** (`internal/remotehelper/*` + `internal/entireclient/{discovery,httpclient}`) — copied from entiredb with import rewrites; antithesis assertion dropped, `version.GitRemoteHelperAgent` swapped for a local stamp. Kept verbatim so the planned auth-go extraction stays a clean move.

**2. Shared credential model** (`internal/entireclient/{tokenstore,contexts,clusterdiscovery,repocreds,httputil}`) — adopts entiredb's keychain layout (`entire-core:<issuer>/handle`, `token|expiry` encoding) so a login in either CLI is visible to the other.

**3. Multi-context auth**
- `entire login` dual-writes a `contexts.json` context (derived from the token's own claims) alongside the legacy entry.
- A context-preferring `ContextStore` wires the control-plane readers (tokenmanager, `LookupCurrentToken`, `auth status/list`) at `contexts.json`, with legacy fallback + read-time migration so existing users aren't logged out.
- `entire auth contexts` / `entire auth use <ctx>` to list/switch; `logout` clears the active context.

**4. Dedicated `git-remote-entire` binary** (`cmd/git-remote-entire`) — a lean main (~28 MB stripped vs the CLI's ~45 MB) that runs the helper loop directly. A real binary on PATH means no argv[0]/symlink/shim fragility, so Windows + Homebrew + scoop all work. Shipped via goreleaser (second build + cask `binaries`) and `install.sh`.

## Notes / follow-ups (not in this PR)
- **auth-go extraction**: the `internal/entireclient/*` packages are vendored copies of entiredb's; the intent is to promote them into `auth-go` and have both CLIs consume from there.
- **Retire entiredb's `cmd/git-remote-entire`** once this ships.
- **goreleaser**: the cask/scoop changes are standard fields but couldn't be validated offline (pro + license key) — worth a `goreleaser check` / snapshot before the next release.

## Verification
Full unit (5884), integration, and e2e canary green; `golangci-lint` clean on the changed packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, credential storage, logout/revoke paths, and a new git transport surface; cluster discovery changes which login applies per host, so mis-binding or migration bugs could cause wrong-cluster auth or failed clones.
> 
> **Overview**
> This PR makes **`entire://` remotes work from the Entire CLI** by shipping a dedicated **`git-remote-entire`** binary (Goreleaser + Homebrew casks) and moving login onto a **shared `contexts.json` + keychain model** aligned with entiredb.
> 
> **Auth:** Login **dual-writes** a named context from JWT claims while keeping the legacy keyring entry. A **`ContextStore`** prefers the active context for token reads, STS, and `auth status`/`list`; **logout/revoke-current** also clear the active context. **`entire auth contexts`** and **`entire auth use`** list and switch contexts. **Legacy logins** can be migrated at read time for the helper.
> 
> **Git remote:** The helper resolves cluster auth via **explicit bindings** or **`/.well-known/entire-cluster.json`** (no silent reuse of `current_context` against the wrong cluster), exchanges login JWTs for **repo-scoped pull/push tokens**, and runs the **smart-HTTP remote-helper protocol** (connect/stateless fetch bridge, list, push options, replica discovery/cache).
> 
> **Shared client libraries** under `internal/entireclient/` (contexts file locking, tokenstore, repocreds, cluster discovery, HTTP transport) and **`internal/remotehelper/`** support the helper and future auth-go consolidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1476f902814e0da50ca1f37aeddf9bab951a7f9e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->