### PR TITLE
auth: keyring deadline + post-review polish for control-plane client

### DIFF
--- a/cmd/entire/cli/auth/keyring_timeout.go
+++ b/cmd/entire/cli/auth/keyring_timeout.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// defaultKeyringTimeout caps how long every OS keyring call may take.
+// On Linux the keyring talks D-Bus to the Secret Service; in headless
+// environments (SSH without a graphical session, containers, WSL) no
+// provider is running and the call blocks indefinitely, freezing the
+// CLI. 5s is comfortably longer than any healthy round-trip while still
+// surfacing the hang to the user quickly.
+const defaultKeyringTimeout = 5 * time.Second
+
+// keyringTimeoutEnvVar overrides defaultKeyringTimeout. Accepts any
+// time.ParseDuration string; invalid or non-positive values fall back
+// to the default. Useful on slow keyrings or to extend the wait on a
+// system where the secret service is just sluggish.
+const keyringTimeoutEnvVar = "ENTIRE_KEYRING_TIMEOUT"
+
+func keyringTimeout() time.Duration {
+	v := os.Getenv(keyringTimeoutEnvVar)
+	if v == "" {
+		return defaultKeyringTimeout
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return defaultKeyringTimeout
+	}
+	return d
+}
+
+// newKeyringContext returns a context that cancels after the configured
+// keyring timeout. Callers must invoke the returned cancel to release
+// the timer regardless of which select branch wins.
+func newKeyringContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), keyringTimeout())
+}
+
+// callKeyringWithContext runs fn in a goroutine and returns its result,
+// or a descriptive error if ctx is cancelled (e.g. its deadline
+// elapses) first. The goroutine continues running — a blocked D-Bus
+// syscall can't be cancelled from Go — and its eventual result is
+// discarded. The buffered result channel keeps the goroutine from
+// leaking forever waiting to publish into a receiver that's already
+// gone.
+func callKeyringWithContext(ctx context.Context, op string, fn func() (string, error)) (string, error) {
+	type result struct {
+		val string
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		v, err := fn()
+		ch <- result{val: v, err: err}
+	}()
+	select {
+	case r := <-ch:
+		return r.val, r.err
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf(
+				"%s timed out: OS keyring (Secret Service) appears unavailable; set %s to a longer duration to wait further: %w",
+				op, keyringTimeoutEnvVar, ctx.Err(),
+			)
+		}
+		return "", fmt.Errorf("%s cancelled: %w", op, ctx.Err())
+	}
+}

--- a/cmd/entire/cli/auth/keyring_timeout.go
+++ b/cmd/entire/cli/auth/keyring_timeout.go
@@ -5,15 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 )
 
 // defaultKeyringTimeout caps how long every OS keyring call may take.
-// On Linux the keyring talks D-Bus to the Secret Service; in headless
-// environments (SSH without a graphical session, containers, WSL) no
-// provider is running and the call blocks indefinitely, freezing the
-// CLI. 5s is comfortably longer than any healthy round-trip while still
-// surfacing the hang to the user quickly.
+// The underlying keyring API (Secret Service on Linux, Keychain on
+// macOS, Credential Manager on Windows) can block indefinitely when no
+// provider is reachable — a headless SSH/container/WSL session, a
+// suppressed Keychain prompt, a stuck Credential Manager — and that
+// freezes the CLI. 5s is comfortably longer than any healthy
+// round-trip while still surfacing the hang to the user quickly.
 const defaultKeyringTimeout = 5 * time.Second
 
 // keyringTimeoutEnvVar overrides defaultKeyringTimeout. Accepts any
@@ -64,10 +66,28 @@ func callKeyringWithContext(ctx context.Context, op string, fn func() (string, e
 	case <-ctx.Done():
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return "", fmt.Errorf(
-				"%s timed out: OS keyring (Secret Service) appears unavailable; set %s to a longer duration to wait further: %w",
-				op, keyringTimeoutEnvVar, ctx.Err(),
+				"%s timed out: OS keyring (%s) appears unavailable; set %s to a longer duration to wait further: %w",
+				op, keyringProviderName(), keyringTimeoutEnvVar, ctx.Err(),
 			)
 		}
 		return "", fmt.Errorf("%s cancelled: %w", op, ctx.Err())
+	}
+}
+
+// keyringProviderName returns the human name of the OS keyring backend
+// for the current platform, so the timeout error can point the user at
+// the specific service that's likely stuck (Keychain on macOS,
+// Credential Manager on Windows, Secret Service on Linux/BSD). The
+// fallback for unrecognised GOOS is the generic "OS keyring".
+func keyringProviderName() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "macOS Keychain"
+	case "windows":
+		return "Windows Credential Manager"
+	case "linux", "freebsd", "openbsd", "netbsd", "dragonfly":
+		return "Secret Service (D-Bus)"
+	default:
+		return "OS keyring"
 	}
 }

--- a/cmd/entire/cli/auth/keyring_timeout_test.go
+++ b/cmd/entire/cli/auth/keyring_timeout_test.go
@@ -1,0 +1,137 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCallKeyringWithContext_ReturnsValueWhenFast(t *testing.T) {
+	t.Parallel()
+
+	got, err := callKeyringWithContext(context.Background(), "get", func() (string, error) {
+		return "token", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "token" {
+		t.Fatalf("got = %q, want %q", got, "token")
+	}
+}
+
+func TestCallKeyringWithContext_PropagatesInnerError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("backend exploded")
+	_, err := callKeyringWithContext(context.Background(), "get", func() (string, error) {
+		return "", sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("got %v, want %v wrapped", err, sentinel)
+	}
+}
+
+func TestCallKeyringWithContext_DeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := callKeyringWithContext(ctx, "get", func() (string, error) {
+		time.Sleep(5 * time.Second)
+		return "should not be returned", nil
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want DeadlineExceeded wrapped, got %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("call did not return promptly after timeout: elapsed=%s", elapsed)
+	}
+
+	msg := err.Error()
+	for _, want := range []string{"get", "OS keyring", keyringTimeoutEnvVar} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("timeout error %q missing %q", msg, want)
+		}
+	}
+}
+
+func TestCallKeyringWithContext_ExternalCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := callKeyringWithContext(ctx, "get", func() (string, error) {
+		time.Sleep(5 * time.Second)
+		return "should not be returned", nil
+	})
+	if err == nil {
+		t.Fatal("expected cancellation error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled wrapped, got %v", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("plain cancel should not surface as DeadlineExceeded: %v", err)
+	}
+}
+
+func TestKeyringTimeout_DefaultWhenUnset(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "")
+
+	if got := keyringTimeout(); got != defaultKeyringTimeout {
+		t.Fatalf("got %v, want default %v", got, defaultKeyringTimeout)
+	}
+}
+
+func TestKeyringTimeout_HonoursEnvOverride(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "150ms")
+
+	if got := keyringTimeout(); got != 150*time.Millisecond {
+		t.Fatalf("got %v, want 150ms", got)
+	}
+}
+
+func TestKeyringTimeout_IgnoresInvalidEnvValue(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "not-a-duration")
+
+	if got := keyringTimeout(); got != defaultKeyringTimeout {
+		t.Fatalf("got %v, want default %v", got, defaultKeyringTimeout)
+	}
+}
+
+func TestKeyringTimeout_IgnoresNonPositiveValue(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "0s")
+
+	if got := keyringTimeout(); got != defaultKeyringTimeout {
+		t.Fatalf("got %v, want default %v", got, defaultKeyringTimeout)
+	}
+}
+
+func TestNewKeyringContext_HasDeadline(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "250ms")
+
+	ctx, cancel := newKeyringContext()
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected context with deadline, got none")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > 250*time.Millisecond {
+		t.Fatalf("deadline out of expected window: remaining=%s", remaining)
+	}
+}

--- a/cmd/entire/cli/auth/store.go
+++ b/cmd/entire/cli/auth/store.go
@@ -157,20 +157,34 @@ func LookupCurrentToken() (string, error) {
 	return NewContextStore().GetToken(api.AuthBaseURL())
 }
 
+// keyringBackend persists tokens in the OS keyring. Every operation is
+// wrapped in callKeyringWithTimeout because the underlying D-Bus /
+// Secret Service call can block indefinitely on headless Linux hosts
+// where no provider (gnome-keyring, kwalletd, KeePassXC, …) is running.
 type keyringBackend struct{}
 
 func (keyringBackend) save(service, key, value string) error {
-	if err := keyring.Set(service, key, value); err != nil {
+	ctx, cancel := newKeyringContext()
+	defer cancel()
+	_, err := callKeyringWithContext(ctx, "save", func() (string, error) {
+		return "", keyring.Set(service, key, value)
+	})
+	if err != nil {
 		return fmt.Errorf("save token to keyring: %w", err)
 	}
 	return nil
 }
 
 func (keyringBackend) get(service, key string) (string, error) {
-	token, err := keyring.Get(service, key)
-	if errors.Is(err, keyring.ErrNotFound) {
-		return "", nil
-	}
+	ctx, cancel := newKeyringContext()
+	defer cancel()
+	token, err := callKeyringWithContext(ctx, "get", func() (string, error) {
+		v, err := keyring.Get(service, key)
+		if errors.Is(err, keyring.ErrNotFound) {
+			return "", nil
+		}
+		return v, err
+	})
 	if err != nil {
 		return "", fmt.Errorf("get token from keyring: %w", err)
 	}
@@ -178,10 +192,14 @@ func (keyringBackend) get(service, key string) (string, error) {
 }
 
 func (keyringBackend) delete(service, key string) error {
-	err := keyring.Delete(service, key)
-	if errors.Is(err, keyring.ErrNotFound) {
-		return nil
-	}
+	ctx, cancel := newKeyringContext()
+	defer cancel()
+	_, err := callKeyringWithContext(ctx, "delete", func() (string, error) {
+		if err := keyring.Delete(service, key); err != nil && !errors.Is(err, keyring.ErrNotFound) {
+			return "", err
+		}
+		return "", nil
+	})
 	if err != nil {
 		return fmt.Errorf("delete token from keyring: %w", err)
 	}

--- a/cmd/entire/cli/auth/store.go
+++ b/cmd/entire/cli/auth/store.go
@@ -186,7 +186,10 @@ func (keyringBackend) get(service, key string) (string, error) {
 		if errors.Is(err, keyring.ErrNotFound) {
 			return "", nil
 		}
-		return v, err
+		if err != nil {
+			return "", fmt.Errorf("keyring.Get: %w", err)
+		}
+		return v, nil
 	})
 	if err != nil {
 		return "", fmt.Errorf("get token from keyring: %w", err)
@@ -199,7 +202,7 @@ func (keyringBackend) delete(service, key string) error {
 	defer cancel()
 	_, err := callKeyringWithContext(ctx, "delete", func() (string, error) {
 		if err := keyring.Delete(service, key); err != nil && !errors.Is(err, keyring.ErrNotFound) {
-			return "", err
+			return "", fmt.Errorf("keyring.Delete: %w", err)
 		}
 		return "", nil
 	})

--- a/cmd/entire/cli/auth/store.go
+++ b/cmd/entire/cli/auth/store.go
@@ -158,9 +158,12 @@ func LookupCurrentToken() (string, error) {
 }
 
 // keyringBackend persists tokens in the OS keyring. Every operation is
-// wrapped in callKeyringWithTimeout because the underlying D-Bus /
-// Secret Service call can block indefinitely on headless Linux hosts
-// where no provider (gnome-keyring, kwalletd, KeePassXC, …) is running.
+// wrapped in callKeyringWithContext because the underlying keyring call
+// can block indefinitely when no provider is reachable — most commonly
+// a headless Linux host with no Secret Service running (gnome-keyring,
+// kwalletd, KeePassXC), but the same hang shape exists on macOS when
+// the Keychain prompt is suppressed or on Windows when Credential
+// Manager misbehaves.
 type keyringBackend struct{}
 
 func (keyringBackend) save(service, key, value string) error {

--- a/cmd/entire/cli/grant.go
+++ b/cmd/entire/cli/grant.go
@@ -2,11 +2,31 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/entireio/cli/internal/coreapi"
 )
+
+// parseOrgRole maps the --role flag for `entire grant org add` to the
+// generated enum, rejecting unknown values at the CLI boundary so the
+// user gets a clear message instead of a server 422. Mirrors
+// parseProjectOwnerType. The empty string means "use the server default
+// (member)" and is the caller's signal to omit the field entirely; it is
+// not handled here.
+func parseOrgRole(s string) (coreapi.AddOrgMemberInputBodyRole, error) {
+	switch s {
+	case "owner":
+		return coreapi.AddOrgMemberInputBodyRoleOwner, nil
+	case "admin":
+		return coreapi.AddOrgMemberInputBodyRoleAdmin, nil
+	case "member":
+		return coreapi.AddOrgMemberInputBodyRoleMember, nil
+	default:
+		return "", fmt.Errorf("invalid --role %q: must be \"owner\", \"admin\", or \"member\"", s)
+	}
+}
 
 // newGrantCmd is the hidden `entire grant` command group: manage access
 // grants and org membership on the Entire control plane. Surface follows
@@ -65,14 +85,19 @@ func newGrantOrgAddCmd() *cobra.Command {
 		Short: "Add a member to an org",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			body := &coreapi.AddOrgMemberInputBody{
+				Provider:       provider,
+				ProviderUserId: providerUserID,
+			}
+			if role != "" {
+				r, err := parseOrgRole(role)
+				if err != nil {
+					cmd.SilenceUsage = true
+					return err
+				}
+				body.Role = coreapi.NewOptAddOrgMemberInputBodyRole(r)
+			}
 			return runCoreJSON(cmd, func(ctx context.Context, c *coreapi.Client) (any, error) {
-				body := &coreapi.AddOrgMemberInputBody{
-					Provider:       provider,
-					ProviderUserId: providerUserID,
-				}
-				if role != "" {
-					body.Role = coreapi.NewOptAddOrgMemberInputBodyRole(coreapi.AddOrgMemberInputBodyRole(role))
-				}
 				return c.AddOrgMember(ctx, body, coreapi.AddOrgMemberParams{OrgId: args[0]})
 			})
 		},

--- a/cmd/entire/cli/grant_test.go
+++ b/cmd/entire/cli/grant_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+func TestParseOrgRole(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in      string
+		want    coreapi.AddOrgMemberInputBodyRole
+		wantErr bool
+	}{
+		{in: "owner", want: coreapi.AddOrgMemberInputBodyRoleOwner},
+		{in: "admin", want: coreapi.AddOrgMemberInputBodyRoleAdmin},
+		{in: "member", want: coreapi.AddOrgMemberInputBodyRoleMember},
+		{in: "", wantErr: true},
+		{in: "viewer", wantErr: true},
+		{in: "Owner", wantErr: true}, // case-sensitive: server enum is lowercase
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseOrgRole(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseOrgRole(%q) expected error, got %q", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseOrgRole(%q): %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseOrgRole(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -67,8 +67,13 @@ func parseGitHubURL(rawURL string) (owner, repo string, err error) {
 }
 
 // probeInterval is the cadence between info/refs probes during the
-// clone wait.
-const probeInterval = 2 * time.Second
+// clone wait. minReauthInterval floors how often we'll re-mint a
+// repo-scoped token after a 401: STS rate-limits or auth flapping
+// during a long wait shouldn't be amplified by the 2s probe cadence.
+const (
+	probeInterval     = 2 * time.Second
+	minReauthInterval = 30 * time.Second
+)
 
 // maxProbeBytes bounds the smart-HTTP info/refs body read so a
 // pathological or misbehaving server can't make us allocate without
@@ -110,7 +115,9 @@ var probeClient = &http.Client{
 // Repo-scoped pull tokens are short-lived (minutes) while the default wait
 // is 30m, so a single token can't cover the whole wait. The loop re-mints
 // from the (long-lived) login token whenever a probe comes back 401,
-// rather than minting once up front.
+// rather than minting once up front. Re-mints are floored at
+// minReauthInterval so a flapping STS can't be amplified into a re-mint
+// every probeInterval ticks.
 func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, repo string, timeout time.Duration) error {
 	repoSlug := "/gh/" + owner + "/" + repo
 	checkURL := fmt.Sprintf("https://%s%s/info/refs?service=git-upload-pack", clusterHost, repoSlug)
@@ -122,6 +129,7 @@ func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, 
 	if err != nil {
 		return fmt.Errorf("authorize clone probe: %w", err)
 	}
+	lastMint := time.Now()
 
 	if timeout > 0 {
 		var cancel context.CancelFunc
@@ -145,14 +153,22 @@ func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, 
 			return nil
 		case status == http.StatusUnauthorized:
 			// The repo-scoped token expired mid-wait; mint a fresh one from
-			// the login token and re-probe after the usual interval (no dot,
-			// since this is a token refresh, not clone progress).
-			if token, err = mintToken(); err != nil {
+			// the login token (no dot, since this is a token refresh, not
+			// clone progress). Skip the re-mint if we just refreshed —
+			// otherwise an STS hiccup that 401s every probe would mint on
+			// every probeInterval tick.
+			if since := time.Since(lastMint); since < minReauthInterval {
+				break
+			}
+			newToken, mintErr := mintToken()
+			if mintErr != nil {
 				if cloning {
 					fmt.Fprintln(out)
 				}
-				return fmt.Errorf("re-authorize clone probe: %w", err)
+				return fmt.Errorf("re-authorize clone probe: %w", mintErr)
 			}
+			token = newToken
+			lastMint = time.Now()
 		default:
 			if !cloning {
 				fmt.Fprint(out, "  cloning")

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -66,6 +66,41 @@ func parseGitHubURL(rawURL string) (owner, repo string, err error) {
 	return "", "", fmt.Errorf("not a recognized GitHub URL: %s", rawURL)
 }
 
+// probeInterval is the cadence between info/refs probes during the
+// clone wait.
+const probeInterval = 2 * time.Second
+
+// maxProbeBytes bounds the smart-HTTP info/refs body read so a
+// pathological or misbehaving server can't make us allocate without
+// limit. Real ref advertisements for the largest repos sit well under
+// this; the cap is sized for headroom, not snugness.
+const maxProbeBytes = 8 << 20 // 8 MiB
+
+// probeClient is the HTTP client used for the clone-readiness loop. It is
+// purpose-built (own Transport, explicit timeouts, no redirect surprises)
+// instead of http.DefaultClient: DefaultClient is process-global and can
+// be poisoned by other code, and its zero-Timeout default would let a
+// stuck connection consume one ticker slot indefinitely. Each probe is
+// already context-bound by the loop's deadline, but Timeout is a belt to
+// the context's braces for the connection/TLS phase.
+var probeClient = &http.Client{
+	Timeout: 15 * time.Second,
+	Transport: &http.Transport{
+		// One mirror, repeated probes — a tiny idle pool is enough to
+		// reuse the TLS session between ticks without leaking conns.
+		MaxIdleConns:        2,
+		MaxIdleConnsPerHost: 2,
+		IdleConnTimeout:     90 * time.Second,
+		TLSHandshakeTimeout: 10 * time.Second,
+	},
+	// info/refs is a single GET; a redirect would indicate misconfiguration
+	// (e.g. cluster host fronted by something that 30x's to a login page).
+	// Surface it as an error rather than silently following.
+	CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
 // waitForMirrorClone blocks until the mirror at /gh/<owner>/<repo> on
 // clusterHost advertises a resolvable HEAD (the initial GitHub→EntireDB
 // clone has landed) or the deadline expires. It probes the data plane's
@@ -94,7 +129,7 @@ func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, 
 		defer cancel()
 	}
 
-	ticker := time.NewTicker(2 * time.Second)
+	ticker := time.NewTicker(probeInterval)
 	defer ticker.Stop()
 
 	cloning := false
@@ -153,7 +188,7 @@ func mirrorAdvertisesHead(ctx context.Context, checkURL, token string) (ready bo
 		return false, 0
 	}
 	req.SetBasicAuth("entire-cli", token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := probeClient.Do(req)
 	if err != nil {
 		return false, 0
 	}
@@ -161,15 +196,17 @@ func mirrorAdvertisesHead(ctx context.Context, checkURL, token string) (ready bo
 	if resp.StatusCode != http.StatusOK {
 		return false, resp.StatusCode
 	}
-	// Smart-HTTP wraps the advertisement in a "# service=..." pkt-line
-	// header + flush; AdvRefs.Decode expects to start at the first ref
-	// line, so strip the wrapper first.
+	// Cap the body to prevent unbounded reads; ogen's api/client.go does
+	// the same for JSON. Smart-HTTP wraps the advertisement in a "#
+	// service=..." pkt-line header + flush; AdvRefs.Decode expects to
+	// start at the first ref line, so strip the wrapper first.
+	body := io.LimitReader(resp.Body, maxProbeBytes)
 	var sr packp.SmartReply
-	if err := sr.Decode(resp.Body); err != nil {
+	if err := sr.Decode(body); err != nil {
 		return false, 0
 	}
 	var adv packp.AdvRefs
-	if err := adv.Decode(resp.Body); err != nil {
+	if err := adv.Decode(body); err != nil {
 		return false, 0
 	}
 	if _, err := adv.ResolvedHead(); err != nil {

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -42,13 +42,26 @@ var (
 	gitHubHTTPSRe = regexp.MustCompile(`^https?://github\.com/` + gitHubOwnerPat + `/` + gitHubRepoPat + `(?:\.git)?$`)
 	gitHubSSHRe   = regexp.MustCompile(`^git@github\.com:` + gitHubOwnerPat + `/` + gitHubRepoPat + `(?:\.git)?$`)
 	gitHubBareRe  = regexp.MustCompile(`^(?:github\.com/)?` + gitHubOwnerPat + `/` + gitHubRepoPat + `(?:\.git)?$`)
+
+	// gitHubDotOnlyRe matches repo segments that are entirely dots
+	// (".", "..", ...). The tightened owner charset already excludes
+	// dots, but gitHubRepoPat allows ".", and a dot-only repo name would
+	// embed a literal ".." in both /gh/<owner>/<repo> and the
+	// token-exchange audience. Reject at the boundary.
+	gitHubDotOnlyRe = regexp.MustCompile(`^\.+$`)
 )
 
 func parseGitHubURL(rawURL string) (owner, repo string, err error) {
 	for _, re := range []*regexp.Regexp{gitHubHTTPSRe, gitHubSSHRe, gitHubBareRe} {
-		if m := re.FindStringSubmatch(rawURL); m != nil {
-			return strings.ToLower(m[1]), strings.ToLower(m[2]), nil
+		m := re.FindStringSubmatch(rawURL)
+		if m == nil {
+			continue
 		}
+		owner, repo = strings.ToLower(m[1]), strings.ToLower(m[2])
+		if gitHubDotOnlyRe.MatchString(repo) {
+			return "", "", fmt.Errorf("invalid GitHub URL: repo cannot be dot-only: %s", rawURL)
+		}
+		return owner, repo, nil
 	}
 	return "", "", fmt.Errorf("not a recognized GitHub URL: %s", rawURL)
 }

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -124,6 +124,10 @@ func TestValidateClusterHost(t *testing.T) {
 		{name: "host with port", host: "localhost:8080"},
 		{name: "ipv4", host: "10.0.0.1"},
 		{name: "ipv4 with port", host: "10.0.0.1:8080"},
+		// IPv6 takes a different path through validateClusterHost: the
+		// host must be bracketed for url.Parse to round-trip, and
+		// u.Hostname() strips the brackets before net.ParseIP sees it.
+		{name: "ipv6 with port", host: "[::1]:8080"},
 		// The token-leak primitive: userinfo demotes the real cluster so the
 		// request (and basic-auth token) targets evil.com.
 		{name: "userinfo smuggle", host: "aws-us-east-2.entire.io@evil.com", wantErr: true},

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -41,6 +41,11 @@ func TestParseGitHubURL(t *testing.T) {
 		{name: "repo with encoded slash", url: "octocat/repo%2fevil", wantErr: true},
 		{name: "owner with dot-dot", url: "../repo", wantErr: true},
 		{name: "owner with underscore (not a GitHub login)", url: "oct_cat/repo", wantErr: true},
+		// Dot-only repo names pass the gitHubRepoPat charset (which allows
+		// dots) but would embed a literal "." or ".." in the audience and
+		// probe URL — reject at the boundary.
+		{name: "dot-only repo", url: "github.com/owner/..", wantErr: true},
+		{name: "single-dot repo", url: "github.com/owner/.", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ogen-go/ogen/ogenerrors"
+
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 )
@@ -44,8 +46,11 @@ func New() (*Client, error) {
 // bearerSource implements the generated SecuritySource, supplying the
 // logged-in user's bearer token for every request. The control plane
 // only uses bearerAuth from the CLI; the sessionAuth (browser cookie)
-// scheme is satisfied with an empty value so ogen's two-scheme security
-// requirement is met without sending a cookie.
+// scheme is reported as ErrSkipClientSecurity so ogen's middleware
+// satisfies the "bearerAuth OR sessionAuth" requirement via the bearer
+// alone — without adding a stray `Cookie: entire_session=` header.
+// (Returning an empty SessionAuth would not skip the cookie: the
+// generated securitySessionAuth unconditionally calls req.AddCookie.)
 type bearerSource struct {
 	resourceBaseURL string
 }
@@ -66,9 +71,10 @@ func (b *bearerSource) BearerAuth(ctx context.Context, _ OperationName) (BearerA
 
 func (b *bearerSource) SessionAuth(context.Context, OperationName) (SessionAuth, error) {
 	// The CLI authenticates with a bearer token, never the browser
-	// session cookie. Returning an empty value lets ogen satisfy the
-	// "bearerAuth OR sessionAuth" requirement via the bearer alone.
-	return SessionAuth{}, nil
+	// session cookie. ErrSkipClientSecurity tells ogen to drop this
+	// scheme entirely for the request (no Cookie header added); the
+	// bearerAuth path alone satisfies the OR-requirement.
+	return SessionAuth{}, ogenerrors.ErrSkipClientSecurity
 }
 
 // APIError reports the title/detail/status of a control-plane RFC 7807

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -1,9 +1,14 @@
 package coreapi
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/ogen-go/ogen/ogenerrors"
 )
 
 func TestAPIError(t *testing.T) {
@@ -64,5 +69,57 @@ func TestAPIError(t *testing.T) {
 				t.Errorf("APIError() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// bearerOnlySource mirrors the CLI's bearerSource contract: a fixed
+// bearer token, and ErrSkipClientSecurity for sessionAuth so the
+// generated middleware does NOT add a `Cookie: entire_session=` header.
+// Used by TestBearerOnlySource_NoCookieOnTheWire to nail down the
+// "bearer-only, no cookie" contract at the HTTP layer.
+type bearerOnlySource struct{}
+
+func (bearerOnlySource) BearerAuth(context.Context, OperationName) (BearerAuth, error) {
+	return BearerAuth{Token: "test-bearer"}, nil
+}
+
+func (bearerOnlySource) SessionAuth(context.Context, OperationName) (SessionAuth, error) {
+	return SessionAuth{}, ogenerrors.ErrSkipClientSecurity
+}
+
+// TestBearerOnlySource_NoCookieOnTheWire documents the SessionAuth
+// empty-value contract by checking the wire: any operation issued by a
+// Client built with a SessionAuth-skipping source must NOT carry a
+// Cookie header. (ogen's securitySessionAuth unconditionally calls
+// req.AddCookie, so returning SessionAuth{} with a nil error would send
+// an empty `entire_session=` cookie; only ErrSkipClientSecurity prevents
+// the cookie from being added.)
+func TestBearerOnlySource_NoCookieOnTheWire(t *testing.T) {
+	t.Parallel()
+
+	var cookieHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookieHeader = r.Header.Get("Cookie")
+		w.Header().Set("Content-Type", "application/json")
+		// Minimal valid ListOrgMembersOutputBody payload so the response
+		// decoder doesn't blow up; we only care about the inbound headers.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"members":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(srv.URL, bearerOnlySource{})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	// ListOrgMembers is a simple GET that exercises the security
+	// middleware; the result itself is irrelevant to this test.
+	if _, err := c.ListOrgMembers(context.Background(), ListOrgMembersParams{OrgId: "01H000000000000000000000A1"}); err != nil {
+		t.Fatalf("ListOrgMembers: %v", err)
+	}
+
+	if cookieHeader != "" {
+		t.Errorf("outbound Cookie header = %q, want empty (bearer-only contract)", cookieHeader)
 	}
 }

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -97,14 +97,20 @@ func (bearerOnlySource) SessionAuth(context.Context, OperationName) (SessionAuth
 func TestBearerOnlySource_NoCookieOnTheWire(t *testing.T) {
 	t.Parallel()
 
-	var cookieHeader string
+	// The handler runs on httptest's goroutine and the assertion runs
+	// on the test goroutine; HTTP completion isn't a happens-before
+	// edge the race detector recognises. Pass the captured header
+	// across through a buffered channel so -race stays happy.
+	cookieCh := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		cookieHeader = r.Header.Get("Cookie")
+		cookieCh <- r.Header.Get("Cookie")
 		w.Header().Set("Content-Type", "application/json")
 		// Minimal valid ListOrgMembersOutputBody payload so the response
 		// decoder doesn't blow up; we only care about the inbound headers.
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"members":[]}`))
+		if _, err := w.Write([]byte(`{"members":[]}`)); err != nil {
+			t.Errorf("writing test response: %v", err)
+		}
 	}))
 	t.Cleanup(srv.Close)
 
@@ -119,6 +125,7 @@ func TestBearerOnlySource_NoCookieOnTheWire(t *testing.T) {
 		t.Fatalf("ListOrgMembers: %v", err)
 	}
 
+	cookieHeader := <-cookieCh
 	if cookieHeader != "" {
 		t.Errorf("outbound Cookie header = %q, want empty (bearer-only contract)", cookieHeader)
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/461
<!-- entire-trail-link-end -->

## Summary

Bundles the OS-keyring deadline with a small set of review-pass fixes
for the freshly-merged control-plane client (#1299):

- **auth: cap OS-keyring calls with a context deadline.** A hung
  keychain helper (locked Keychain, paused libsecret prompt) would
  block `entire login`/`logout` indefinitely; wrap every keyring read
  and write with a 3s deadline and surface the timeout as a clear
  error rather than a frozen process.
- **coreapi: skip sessionAuth so requests carry no stray `Cookie`
  header.** `bearerSource.SessionAuth` previously returned an empty
  `SessionAuth{}` and the generated `securitySessionAuth` would
  unconditionally add `Cookie: entire_session=` to every outbound
  request. Return `ogenerrors.ErrSkipClientSecurity` instead; the
  bearer alone satisfies the OR-requirement and no cookie is sent.
  Locked in with a wire-level unit test.
- **grant org add: validate `--role` at the CLI boundary.** Mirrors
  `parseProjectOwnerType` with a `parseOrgRole` mapping
  owner/admin/member onto the generated enum, so typos fail fast
  with a clear local message instead of an opaque server 422.
  Project and repo `--role` stay free-form because the spec for those
  doesn't enumerate values.
- **mirror create/remove: reject dot-only owner/repo segments.** The
  tightened owner charset (from #1299) already excludes dots, but
  `gitHubRepoPat` admits `.` and `..` — both would embed a literal
  `..` in the `/gh/<owner>/<repo>` slug and the token-exchange
  audience. Reject at the boundary; two negative tests cover `.` and
  `..`.
- **mirror clone probe: drop `http.DefaultClient`, cap the body
  read.** `DefaultClient` is process-global, has no `Timeout`, and is
  poisonable; replace with a purpose-built `probeClient` (own
  Transport, 15s timeout, 10s TLS handshake, no redirect-follow), and
  wrap the body in `io.LimitReader(8 MiB)` to match the JSON path in
  `api/client.go`.
- **mirror clone probe: floor token re-mints so STS hiccups don't
  amplify.** Re-mint on 401 was unconditional, so a flapping STS
  during the 30-minute wait could mint ~900 tokens at the 2s probe
  cadence. Track `lastMint` and skip re-mint inside a 30s window;
  probes keep firing, auth load is bounded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch credential storage timeouts, control-plane HTTP auth headers, STS token re-mint behavior, and URL validation used for token audiences—mostly defensive but in security-sensitive paths.
> 
> **Overview**
> Adds **bounded OS keyring I/O** so login/logout cannot hang forever: every keyring save/get/delete runs through a **5s** deadline (overridable via `ENTIRE_KEYRING_TIMEOUT`) with platform-specific timeout errors.
> 
> Hardens **control-plane and mirror paths**: the Core API client skips `sessionAuth` via `ogenerrors.ErrSkipClientSecurity` so outbound requests do not send an empty `entire_session` cookie; `entire grant org add` validates `--role` locally; GitHub URL parsing rejects **dot-only** repo segments; the mirror clone probe uses a dedicated HTTP client (timeouts, no redirects), caps `info/refs` reads at **8 MiB**, and **rate-limits** repo-scoped token re-mints after 401s.
> 
> Pins **go-licenses** to **v2.0.1** in the license lint task for reproducible CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614d8450ccd8e94c7250fbbe3ce35ad70c854a1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->