### PR TITLE
install git-remote-entire helper when doing mise run dev:publish

### DIFF
--- a/mise-tasks/dev/publish
+++ b/mise-tasks/dev/publish
@@ -6,4 +6,4 @@ set -eu
 export GOBIN=${GOPATH:-$HOME/go}/bin
 echo "NOTE: we're overriding \$GOBIN: $GOBIN" 1>&2
 
-go install ./cmd/entire
+go install ./cmd/entire ./cmd/git-remote-entire


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/462
<!-- entire-trail-link-end -->

make sure we also install `git-remote-entire` when running `mise run dev:publish`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the dev mise publish script; no runtime or auth logic.
> 
> **Overview**
> **`mise run dev:publish`** now installs **`git-remote-entire`** into **`$GOBIN`** alongside **`entire`**, by adding **`./cmd/git-remote-entire`** to the existing **`go install`** line in **`mise-tasks/dev/publish`**.
> 
> Local dev publish flows match release packaging (Homebrew already ships both binaries), so **`entire://`** git remote helper behavior works after a dev install without a separate build step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc7e43ecd6f15b24ac80ae2b078409bc42c1270. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->