### PR TITLE
Harden cluster trust: ephemeral binding + HostInCluster specificity floor

### DIFF
--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -154,6 +154,7 @@ func newAuthCmd() *cobra.Command {
 	cmd.AddCommand(newAuthRevokeCmd())
 	cmd.AddCommand(newAuthContextsCmd())
 	cmd.AddCommand(newAuthUseCmd())
+	cmd.AddCommand(newAuthUnbindCmd())
 	return cmd
 }
 

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -116,6 +116,36 @@ func Contexts() ([]*contexts.Context, string, error) {
 	return f.Contexts, f.CurrentContext, nil
 }
 
+// ClusterBindings returns the cluster_host → context_name map from
+// contexts.json. Surfaced by `entire auth contexts` so users can audit
+// which cluster hosts auto-authenticate git operations with a stored
+// context — and spot any they don't recognise.
+func ClusterBindings() (map[string]string, error) {
+	f, err := contexts.Load(contexts.DefaultConfigDir())
+	if err != nil {
+		return nil, fmt.Errorf("load contexts: %w", err)
+	}
+	return f.ClusterContexts, nil
+}
+
+// UnbindCluster removes the cluster→context binding for host, reporting
+// whether one existed. Used by `entire auth unbind` to revoke a binding
+// without touching the underlying login context.
+func UnbindCluster(host string) (bool, error) {
+	var existed bool
+	if err := contexts.Modify(contexts.DefaultConfigDir(), func(f *contexts.File) (bool, error) {
+		if _, ok := f.ClusterContexts[host]; !ok {
+			return false, nil
+		}
+		delete(f.ClusterContexts, host)
+		existed = true
+		return true, nil
+	}); err != nil {
+		return false, fmt.Errorf("unbind cluster: %w", err)
+	}
+	return existed, nil
+}
+
 // ContextStore wraps the legacy keyring Store so token *reads* prefer the
 // active contexts.json context, falling back to the legacy
 // entire-cli/<authBaseURL> entry. Writes are inherited from Store

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -88,16 +88,20 @@ func runAuthContexts(w io.Writer) error {
 	if err != nil {
 		return err //nolint:wrapcheck // already a user-facing message
 	}
+	// Print login contexts (or the empty-state hint), then always fall
+	// through to cluster bindings — a binding can outlive every context
+	// (manual edits, partial cleanup, a deleted context), and that orphan
+	// is exactly the kind of thing the audit path must surface.
 	if len(all) == 0 {
 		fmt.Fprintln(w, "No login contexts. Run 'entire login' to authenticate.")
-		return nil
-	}
-	for _, c := range all {
-		marker := " "
-		if c.Name == current {
-			marker = "*"
+	} else {
+		for _, c := range all {
+			marker := " "
+			if c.Name == current {
+				marker = "*"
+			}
+			fmt.Fprintf(w, "%s %s\t%s\t%s\n", marker, c.Name, c.Handle, c.CoreURL)
 		}
-		fmt.Fprintf(w, "%s %s\t%s\t%s\n", marker, c.Name, c.Handle, c.CoreURL)
 	}
 	return printClusterBindings(w)
 }

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
@@ -74,7 +75,7 @@ func warnIfCrossCoreContext(errW io.Writer, name string) {
 func newAuthContextsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "contexts",
-		Short: "List stored login contexts",
+		Short: "List stored login contexts and cluster bindings",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAuthContexts(cmd.OutOrStdout())
@@ -98,5 +99,55 @@ func runAuthContexts(w io.Writer) error {
 		}
 		fmt.Fprintf(w, "%s %s\t%s\t%s\n", marker, c.Name, c.Handle, c.CoreURL)
 	}
+	return printClusterBindings(w)
+}
+
+// printClusterBindings lists any cluster_contexts bindings so users can
+// audit which hosts auto-authenticate git operations with a stored
+// context. A binding means future ops against that host mint
+// identity-bearing JWTs without re-checking the host's /.well-known, so an
+// unrecognised entry is worth revoking with `entire auth unbind`.
+func printClusterBindings(w io.Writer) error {
+	bindings, err := auth.ClusterBindings()
+	if err != nil {
+		return err //nolint:wrapcheck // already a user-facing message
+	}
+	if len(bindings) == 0 {
+		return nil
+	}
+	hosts := make([]string, 0, len(bindings))
+	for h := range bindings {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+	fmt.Fprintln(w, "\nCluster bindings (these hosts auto-authenticate with a stored context):")
+	for _, h := range hosts {
+		fmt.Fprintf(w, "  %s\t-> %s\n", h, bindings[h])
+	}
+	fmt.Fprintln(w, "\nRevoke a binding you don't recognise with 'entire auth unbind <host>'.")
 	return nil
+}
+
+// newAuthUnbindCmd removes a cluster→context binding. Purely local.
+func newAuthUnbindCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unbind <cluster-host>",
+		Short: "Remove a cluster→context binding",
+		Long: "Remove the stored binding that makes git operations against a cluster host\n" +
+			"auto-authenticate with a saved context. The login context itself is left\n" +
+			"intact. List current bindings with 'entire auth contexts'.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			existed, err := auth.UnbindCluster(args[0])
+			if err != nil {
+				return err //nolint:wrapcheck // already a user-facing message
+			}
+			if !existed {
+				fmt.Fprintf(cmd.OutOrStdout(), "No cluster binding for %q.\n", args[0])
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Removed cluster binding for %q.\n", args[0])
+			return nil
+		},
+	}
 }

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -87,6 +87,36 @@ func TestRunAuthContextsSurfacesClusterBindings(t *testing.T) {
 	}
 }
 
+// TestRunAuthContextsSurfacesOrphanedBinding: a binding can outlive every
+// login context (manual edit, deleted context). The audit path must still
+// list it even though there are no contexts to print.
+func TestRunAuthContextsSurfacesOrphanedBinding(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	// Written directly: BindCluster refuses a binding to a missing context,
+	// so an orphan only arises via manual edits or partial cleanup.
+	if err := contexts.Save(cfgDir, &contexts.File{
+		ClusterContexts: map[string]string{"evil.example.com": "deleted-ctx"},
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runAuthContexts(&out); err != nil {
+		t.Fatalf("runAuthContexts: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "No login contexts") {
+		t.Fatalf("listing = %q, want the empty-state hint", got)
+	}
+	if !strings.Contains(got, "Cluster bindings") || !strings.Contains(got, "evil.example.com") {
+		t.Fatalf("listing = %q, want the orphaned binding surfaced", got)
+	}
+}
+
 // TestUnbindCluster: removing a binding leaves the underlying context
 // intact and is idempotent.
 func TestUnbindCluster(t *testing.T) {

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
 
@@ -52,6 +53,83 @@ func TestRunAuthContexts(t *testing.T) {
 	}
 	if !strings.Contains(got, "alice") {
 		t.Fatalf("listing = %q, want handle alice", got)
+	}
+}
+
+// TestRunAuthContextsSurfacesClusterBindings: cluster_contexts entries are
+// listed so a user can audit (and then revoke) any host that
+// auto-authenticates with a stored context.
+func TestRunAuthContextsSurfacesClusterBindings(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+	token := makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
+	if _, err := auth.RecordLoginContext(token, true); err != nil {
+		t.Fatalf("RecordLoginContext: %v", err)
+	}
+	if err := contexts.BindCluster(cfgDir, "evil.example.com", "core.example.com"); err != nil {
+		t.Fatalf("BindCluster: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runAuthContexts(&out); err != nil {
+		t.Fatalf("runAuthContexts: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Cluster bindings") {
+		t.Fatalf("listing = %q, want a 'Cluster bindings' section", got)
+	}
+	if !strings.Contains(got, "evil.example.com") || !strings.Contains(got, "auth unbind") {
+		t.Fatalf("listing = %q, want the bound host and an unbind hint", got)
+	}
+}
+
+// TestUnbindCluster: removing a binding leaves the underlying context
+// intact and is idempotent.
+func TestUnbindCluster(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+	if _, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
+		t.Fatalf("RecordLoginContext: %v", err)
+	}
+	if err := contexts.BindCluster(cfgDir, "evil.example.com", "core.example.com"); err != nil {
+		t.Fatalf("BindCluster: %v", err)
+	}
+
+	existed, err := auth.UnbindCluster("evil.example.com")
+	if err != nil {
+		t.Fatalf("UnbindCluster: %v", err)
+	}
+	if !existed {
+		t.Fatal("UnbindCluster reported no binding, want existed=true")
+	}
+
+	// Binding gone, context preserved.
+	f, err := contexts.Load(cfgDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := f.ClusterContexts["evil.example.com"]; ok {
+		t.Fatal("binding still present after unbind")
+	}
+	if f.Find("core.example.com") == nil {
+		t.Fatal("login context must survive unbind")
+	}
+
+	// Idempotent: second unbind reports no binding.
+	existed, err = auth.UnbindCluster("evil.example.com")
+	if err != nil {
+		t.Fatalf("UnbindCluster (second): %v", err)
+	}
+	if existed {
+		t.Fatal("second unbind reported existed=true, want false")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.52.0
 	golang.org/x/mod v0.36.0
+	golang.org/x/net v0.54.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
@@ -141,7 +142,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org v0.0.0-20260112195520-a5071408f32f // indirect
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
-	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b // indirect

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -13,12 +13,20 @@ import (
 // Resolution order:
 //
 //  1. Explicit `cluster_contexts[clusterHost]` binding in contexts.json
-//     pointing at an existing context — used as-is.
+//     pointing at an existing context — used as-is. Bindings are only
+//     created by deliberate action (`entire-core context bind`, or a
+//     teammate's tooling); this CLI never writes one implicitly.
 //  2. Discovery via /.well-known/entire-cluster.json on the cluster
 //     itself, matched against existing local contexts by the
 //     advertised core_urls. The first advertised URL with a local
-//     context wins, and the cluster→context binding is written so the
-//     next call skips discovery.
+//     context wins. This match is used for the current invocation only
+//     — we deliberately do NOT persist a cluster→context binding.
+//     Persisting it would let a single drive-by clone of an
+//     attacker-controlled host (e.g. via a malicious submodule whose
+//     /.well-known names the victim's real core) establish a durable,
+//     silent channel that re-mints identity-bearing JWTs on every
+//     future fetch. Re-evaluating the live /.well-known each time keeps
+//     the trust decision fresh and revocable.
 //  3. No local context matches any advertised URL — return a
 //     fatal-ready error with the login hint listing the cluster's
 //     advertised issuers.
@@ -58,9 +66,11 @@ func ResolveContextForCluster(ctx context.Context, configDir, clusterHost string
 		}
 		// Prefer the active context when it's one of the eligible matches —
 		// otherwise a core with several accounts (alice@core, bob@core) would
-		// auto-bind whichever was saved first, silently authenticating as the
+		// resolve to whichever was saved first, silently authenticating as the
 		// wrong user. Fall back to the first match when the current context
-		// isn't eligible for this cluster.
+		// isn't eligible for this cluster. Because we re-resolve every
+		// invocation (no persisted binding), `entire auth use` takes effect
+		// immediately for unbound clusters.
 		c := matches[0]
 		if current != nil {
 			for _, m := range matches {
@@ -70,13 +80,7 @@ func ResolveContextForCluster(ctx context.Context, configDir, clusterHost string
 				}
 			}
 		}
-		if bindErr := contexts.BindCluster(configDir, clusterHost, c.Name); bindErr != nil {
-			// Non-fatal: we still resolved a usable context. Next
-			// invocation will pay the discovery round-trip again.
-			debugf("auto-bind %s -> %s failed: %v", clusterHost, c.Name, bindErr)
-		} else {
-			debugf("auto-bound %s -> %s after discovery match on %s", clusterHost, c.Name, coreURL)
-		}
+		debugf("resolved %s -> %s via discovery match on %s (ephemeral; binding not persisted)", clusterHost, c.Name, coreURL)
 		return c, nil
 	}
 	return nil, errors.New(RenderLoginHint(clusterHost, body.CoreURLs))

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -35,11 +35,13 @@ func TestResolveContextForClusterBindingShortCircuits(t *testing.T) {
 	assert.Equal(t, "us", c.Name)
 }
 
-// TestResolveContextForClusterDiscoversAndAutoBinds: no binding, no
-// fallback to current_context — instead we hit /.well-known, match
-// the first advertised core URL against a local context, and persist
-// the binding for next time.
-func TestResolveContextForClusterDiscoversAndAutoBinds(t *testing.T) {
+// TestResolveContextForClusterDiscoversEphemerally: no binding, no
+// fallback to current_context — instead we hit /.well-known, match the
+// first advertised core URL against a local context, and resolve it for
+// this invocation only. We deliberately do NOT persist a binding: a
+// drive-by clone of an attacker host must not establish a durable,
+// silent auth channel, so every call re-evaluates the live /.well-known.
+func TestResolveContextForClusterDiscoversEphemerally(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&calls, 1)
@@ -65,18 +67,24 @@ func TestResolveContextForClusterDiscoversAndAutoBinds(t *testing.T) {
 	c, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.NoError(t, err)
 	assert.Equal(t, "prod-eu", c.Name, "should pick the prod context, NOT current_context")
-
-	// Auto-bound: the second call doesn't hit /.well-known.
 	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "first call hits discovery once")
+
+	// No binding was persisted — the resolution is ephemeral.
+	f, err := contexts.Load(configDir)
+	require.NoError(t, err)
+	assert.Empty(t, f.ClusterContexts, "discovery must not persist a cluster binding")
+
+	// Second call re-discovers (no short-circuit), keeping the trust
+	// decision fresh and revocable.
 	c2, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.NoError(t, err)
 	assert.Equal(t, "prod-eu", c2.Name)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "auto-bind should skip discovery on the second call")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "ephemeral resolution re-hits discovery each call")
 }
 
 // TestResolveContextForClusterPrefersCurrentAmongSameCoreMatches: when a
 // core has several accounts (alice@core, bob@core) and bob is the active
-// context, discovery must auto-bind to bob, not to whichever was saved
+// context, discovery must resolve to bob, not to whichever was saved
 // first — otherwise a clone silently authenticates as the wrong user.
 func TestResolveContextForClusterPrefersCurrentAmongSameCoreMatches(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -128,7 +136,8 @@ func TestResolveContextForClusterNoMatchReturnsLoginHint(t *testing.T) {
 
 // TestResolveContextForClusterStaleBindingFallsThrough: a binding that
 // names a non-existent context is treated as if no binding exists —
-// we discover, match, and rebind to a real context.
+// we discover and match a real context for this invocation (without
+// rewriting the binding).
 func TestResolveContextForClusterStaleBindingFallsThrough(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/entireclient/discovery/parse_replicas.go
+++ b/internal/entireclient/discovery/parse_replicas.go
@@ -3,6 +3,8 @@ package discovery
 import (
 	"net"
 	"strings"
+
+	"golang.org/x/net/publicsuffix"
 )
 
 // ParseReplicas parses the X-Entire-Replicas header value into a list of
@@ -30,13 +32,52 @@ func ParseReplicas(header string) []string {
 // HostInCluster reports whether host equals the cluster's entry domain or
 // is a subdomain of it. Both values are compared by hostname only — any
 // port is stripped from either side before comparison. Used to scope
-// sensitive-header preservation across redirects: an in-cluster hop is
-// safe to carry Authorization, anything else must be treated as a new
-// trust boundary.
+// sensitive-header preservation across redirects and the replica trust
+// boundary: an in-cluster hop is safe to carry Authorization, anything
+// else must be treated as a new trust boundary.
+//
+// The subdomain (wildcard) match is only honored when the cluster host is
+// strictly more specific than its own public suffix — see
+// clusterAllowsSubdomains. Without that floor a cluster host of "io" or
+// "co.uk" (a bare eTLD) would make every subdomain of an entire TLD
+// "in cluster", so a relinquished or misconfigured subdomain anywhere
+// under that suffix could inherit credential-carry trust.
 func HostInCluster(host, cluster string) bool {
 	h := stripPort(strings.ToLower(host))
 	c := stripPort(strings.ToLower(cluster))
-	return h == c || strings.HasSuffix(h, "."+c)
+	if c == "" {
+		return false
+	}
+	if h == c {
+		return true
+	}
+	if !clusterAllowsSubdomains(c) {
+		return false
+	}
+	return strings.HasSuffix(h, "."+c)
+}
+
+// clusterAllowsSubdomains reports whether cluster is specific enough that
+// treating its subdomains as same-cluster is safe: it must be strictly
+// more specific than its own public suffix (a registrable domain or
+// deeper), never a bare public suffix like "io"/"com"/"co.uk". IP
+// literals are allowed — they have no subdomain semantics and are matched
+// exactly in practice. cluster is expected to already be lowercased and
+// port-stripped.
+func clusterAllowsSubdomains(cluster string) bool {
+	if net.ParseIP(cluster) != nil {
+		return true
+	}
+	if !strings.Contains(cluster, ".") {
+		return false
+	}
+	// PublicSuffix returns the eTLD ("io" for "entire.io", "co.uk" for
+	// "x.co.uk"). For domains absent from the list the prevailing rule is
+	// "*", yielding the rightmost label — so a bare made-up TLD is also
+	// rejected as too broad. The cluster is registrable (safe) only when
+	// it extends beyond that suffix.
+	suffix, _ := publicsuffix.PublicSuffix(cluster)
+	return cluster != suffix
 }
 
 // stripPort returns s with any trailing :port removed. If s does not parse as

--- a/internal/entireclient/discovery/parse_replicas.go
+++ b/internal/entireclient/discovery/parse_replicas.go
@@ -60,13 +60,19 @@ func HostInCluster(host, cluster string) bool {
 // clusterAllowsSubdomains reports whether cluster is specific enough that
 // treating its subdomains as same-cluster is safe: it must be strictly
 // more specific than its own public suffix (a registrable domain or
-// deeper), never a bare public suffix like "io"/"com"/"co.uk". IP
-// literals are allowed — they have no subdomain semantics and are matched
-// exactly in practice. cluster is expected to already be lowercased and
-// port-stripped.
+// deeper), never a bare public suffix like "io"/"com"/"co.uk" and never a
+// single-label name (which is its own public suffix).
+//
+// IP literals are rejected outright: an IP has no subdomain semantics, so
+// only the exact-host match in HostInCluster applies. Allowing the
+// wildcard for an IP cluster would let a replica URL like
+// https://evil.127.0.0.1 string-suffix-match the cluster IP and wrongly
+// inherit credential-carry trust.
+//
+// cluster is expected to already be lowercased and port-stripped.
 func clusterAllowsSubdomains(cluster string) bool {
 	if net.ParseIP(cluster) != nil {
-		return true
+		return false
 	}
 	if !strings.Contains(cluster, ".") {
 		return false

--- a/internal/entireclient/discovery/parse_replicas_test.go
+++ b/internal/entireclient/discovery/parse_replicas_test.go
@@ -70,6 +70,10 @@ func TestHostInCluster(t *testing.T) {
 		{"acquired.entire.io", "entire.io", true}, // registrable domain — wildcard OK
 		{"entire.io", "entire.io", true},          // exact
 		{"a.b.entire.io", "entire.io", true},      // deeper subdomain
+		// IP clusters: exact match only, never wildcard — a host that
+		// merely ends with the IP string must not be treated as in-cluster.
+		{"evil.127.0.0.1", "127.0.0.1", false},
+		{"127.0.0.1", "127.0.0.1", true}, // exact still in-cluster
 	}
 	for _, tt := range tests {
 		got := HostInCluster(tt.host, tt.cluster)

--- a/internal/entireclient/discovery/parse_replicas_test.go
+++ b/internal/entireclient/discovery/parse_replicas_test.go
@@ -62,6 +62,14 @@ func TestHostInCluster(t *testing.T) {
 		{"node1.eu.partial.to:8443", "eu.partial.to:443", true},
 		{"eu.partial.to:8443", "eu.partial.to", true},
 		{"evil.com:443", "eu.partial.to:443", false},
+		// Specificity floor: a bare public suffix as the cluster host must
+		// not wildcard-match all of its subdomains.
+		{"anything.io", "io", false},              // *.io is a public suffix — too broad
+		{"io", "io", true},                        // exact match is still fine (degenerate)
+		{"victim.co.uk", "co.uk", false},          // multi-label public suffix
+		{"acquired.entire.io", "entire.io", true}, // registrable domain — wildcard OK
+		{"entire.io", "entire.io", true},          // exact
+		{"a.b.entire.io", "entire.io", true},      // deeper subdomain
 	}
 	for _, tt := range tests {
 		got := HostInCluster(tt.host, tt.cluster)


### PR DESCRIPTION
Follow-up security hardening to the remote-helper credential-scoping work (merged via #1306). Two independent fixes to the `entire://` clone trust model.

## 1. Stop silent persistent cluster auto-binding (`clusterdiscovery`)

A successful `/.well-known/entire-cluster.json` discovery match used to persist `cluster_contexts[host] = <context>` to `contexts.json`. That binding is **durable and silent**: after a single drive-by clone of an attacker URL (e.g. a malicious submodule whose `.well-known` names the victim's real core), every future op against that host skipped discovery and minted identity-bearing JWTs against the bound context — a persistent identity-leak channel with no UX to notice or revoke it.

- `ResolveContextForCluster` no longer persists a binding. It resolves the match **for the current invocation only** and re-evaluates the live `.well-known` each time, so the trust decision stays fresh and a one-off clone leaves no durable state. The sole caller (the non-interactive git-remote-entire helper) can't prompt, so ephemeral resolution is the right scoping. Explicit bindings (`entire-core context bind`, teammate tooling) are still honored.
- Bindings are now **auditable and revocable**: `entire auth contexts` lists any `cluster_contexts` entries with an unbind hint, and new `entire auth unbind <host>` revokes one without touching the underlying login context.

## 2. Floor `HostInCluster` wildcard at a registrable domain (`discovery`)

`HostInCluster` treated any `*.cluster` host as same-cluster via a bare suffix match. With a broad cluster host that makes an entire public suffix in-cluster (cluster `io` → every `*.io` inherits the Authorization-carry / replica-trust boundary), so a relinquished or misconfigured subdomain anywhere under that suffix becomes a credential receiver.

- The subdomain (wildcard) match is now gated on the cluster host being strictly more specific than its own public suffix (via `x/net/publicsuffix`). `*.entire.io` still matches `entire.io`; `*.io` and `*.co.uk` no longer wildcard-match. Exact matches and IP literals are unaffected.

## Scope note

With #1 in place an attacker can no longer durably pin `*.example.com` trust via a one-off clone. The `example.com` (eTLD+1, attacker-registrable) case still passes the public-suffix floor — fully closing that needs a signed/endorsed cluster manifest, which is intentionally out of scope here.

## Testing

- New tests: ephemeral resolution (no binding persisted, re-discovers each call), `HostInCluster` specificity-floor cases, binding surfacing in `auth contexts`, and `auth unbind` (idempotent, preserves the context).
- `mise run fmt && mise run lint` clean; `go test -tags=integration,authfilestore -race ./...` and the e2e canary pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication trust boundaries for entire:// git operations and redirect/replica credential scoping; mistakes could break clones or leak tokens.
> 
> **Overview**
> Hardens the `entire://` clone trust model in two ways.
> 
> **Cluster auth resolution** no longer persists `cluster_contexts` after a successful `/.well-known` discovery match—each git operation re-reads discovery so a one-off malicious clone cannot leave a silent, durable auto-auth channel. Explicit bindings (e.g. deliberate `context bind`) still apply. **`entire auth contexts`** now lists those bindings with an unbind hint, and **`entire auth unbind <host>`** removes a binding without deleting the login context.
> 
> **`HostInCluster`** subdomain matching now requires the cluster host to be a registrable domain (via `golang.org/x/net/publicsuffix`), so bare suffixes like `io` or `co.uk` cannot treat an entire TLD as in-cluster for credential-carrying redirects/replicas.
> 
> Tests cover ephemeral discovery, binding audit/unbind, and the hostname specificity floor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8bc4b94e925ae24bc84e7377d14c0ee069b59ba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->