### PR TITLE
Capture generic slash skill prompts

### DIFF
--- a/cmd/entire/cli/agent/skill_events.go
+++ b/cmd/entire/cli/agent/skill_events.go
@@ -9,6 +9,7 @@ const (
 // Skill event source signals.
 const (
 	SkillSignalPiInputSlashCommand = "input_slash_command"
+	SkillSignalPromptSlashCommand  = "prompt_slash_command"
 	SkillSignalClaudeSkillToolUse  = "skill_tool_use"
 )
 

--- a/cmd/entire/cli/agent/skill_events_prompt.go
+++ b/cmd/entire/cli/agent/skill_events_prompt.go
@@ -10,9 +10,31 @@ import (
 var skillSlashCommandPattern = regexp.MustCompile(`^/skill:([A-Za-z0-9][A-Za-z0-9._-]{0,63})(?:\s|$)`)
 
 // SkillEventFromPromptSlashCommand returns a normalized skill event when prompt
-// begins with an explicit /skill:<name> command. It intentionally records only
-// the slash command token (not the rest of the prompt) so metadata does not copy
-// arbitrary user text outside the redacted transcript/prompt files.
+// begins with an explicit "/skill:<name>" command.
+//
+// Scope: this captures USER-INVOKED prompt skills only. Tool-call skills (e.g.
+// Claude Code's "Skill" tool) are handled separately by agent-specific
+// SkillEventExtractor implementations and produce "tool_invocation" events.
+//
+// Slash-command format validation (2026-06, against installed agent binaries):
+//   - Pi: uses "/skill:<name>". Already captured natively from Pi's pre-expansion
+//     "input" event (see agent/pi), so by the time the framework TurnStart fires,
+//     event.Prompt is the EXPANDED "<skill ...>" text — this generic parser does
+//     not re-match it, and the native event wins regardless.
+//   - Claude Code: user skills are invoked as "/<skill-name>" (the skill name is
+//     the command) and by the model via the "Skill" tool. Neither is "/skill:".
+//   - Codex, OpenCode, Gemini CLI, Cursor, Factory Droid, Copilot CLI: no
+//     "/skill:<name>" user-prompt syntax.
+//
+// So among shipped agents the "/skill:<name>" form is Pi-only and already covered
+// natively. This parser is therefore a forward-looking, low-risk fallback for any
+// agent whose turn-start hook surfaces a raw "/skill:<name>" prompt; it is
+// intentionally strict (only "/skill:", never every "/<word>") to avoid
+// misclassifying ordinary slash commands as skills.
+//
+// It intentionally records only the slash command token (not the rest of the
+// prompt) so metadata does not copy arbitrary user text outside the redacted
+// transcript/prompt files.
 func SkillEventFromPromptSlashCommand(agentName, prompt string, timestamp time.Time) (SkillEvent, bool) {
 	trimmed := strings.TrimLeft(prompt, " \t\r\n")
 	match := skillSlashCommandPattern.FindStringSubmatch(trimmed)

--- a/cmd/entire/cli/agent/skill_events_prompt.go
+++ b/cmd/entire/cli/agent/skill_events_prompt.go
@@ -1,0 +1,97 @@
+package agent
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var skillSlashCommandPattern = regexp.MustCompile(`^/skill:([A-Za-z0-9][A-Za-z0-9._-]{0,63})(?:\s|$)`)
+
+// SkillEventFromPromptSlashCommand returns a normalized skill event when prompt
+// begins with an explicit /skill:<name> command. It intentionally records only
+// the slash command token (not the rest of the prompt) so metadata does not copy
+// arbitrary user text outside the redacted transcript/prompt files.
+func SkillEventFromPromptSlashCommand(agentName, prompt string, timestamp time.Time) (SkillEvent, bool) {
+	trimmed := strings.TrimLeft(prompt, " \t\r\n")
+	match := skillSlashCommandPattern.FindStringSubmatch(trimmed)
+	if match == nil {
+		return SkillEvent{}, false
+	}
+
+	skillName := strings.TrimSpace(match[1])
+	if skillName == "" {
+		return SkillEvent{}, false
+	}
+
+	command := "/skill:" + skillName
+	event := SkillEvent{
+		ID:        promptSkillEventID(agentName, skillName, timestamp),
+		EventType: SkillEventTypePromptInvocation,
+		Skill: SkillEventSkill{
+			Name: skillName,
+		},
+		Source: SkillEventSource{
+			Agent:      agentName,
+			Signal:     SkillSignalPromptSlashCommand,
+			Confidence: SkillConfidenceExplicit,
+		},
+		Native: map[string]string{
+			"command": command,
+		},
+		Collapse: SkillEventCollapse{
+			Target:           SkillCollapseTargetUserMessage,
+			Label:            command,
+			DefaultCollapsed: true,
+		},
+	}
+	if !timestamp.IsZero() {
+		event.Timestamp = timestamp.UTC().Format(time.RFC3339Nano)
+	}
+	return event, true
+}
+
+// AppendPromptSlashCommandSkillEvent adds a generic prompt-invocation skill
+// event for explicit /skill:<name> prompts. If an agent adapter already surfaced
+// an equivalent prompt skill event (for example Pi's pre-expansion input event),
+// the adapter event wins and no generic duplicate is appended.
+func AppendPromptSlashCommandSkillEvent(events []SkillEvent, agentName, prompt string, timestamp time.Time) []SkillEvent {
+	event, ok := SkillEventFromPromptSlashCommand(agentName, prompt, timestamp)
+	if !ok {
+		return events
+	}
+	if hasEquivalentPromptSkillEvent(events, event) {
+		return events
+	}
+	return append(events, event)
+}
+
+func promptSkillEventID(agentName, skillName string, timestamp time.Time) string {
+	if timestamp.IsZero() {
+		return ""
+	}
+	return fmt.Sprintf("prompt-skill-%s-%s-%s", agentName, skillName, timestamp.UTC().Format(time.RFC3339Nano))
+}
+
+func hasEquivalentPromptSkillEvent(events []SkillEvent, candidate SkillEvent) bool {
+	candidateCommand := ""
+	if candidate.Native != nil {
+		candidateCommand = candidate.Native["command"]
+	}
+	for _, existing := range events {
+		if existing.EventType != SkillEventTypePromptInvocation || existing.Skill.Name != candidate.Skill.Name {
+			continue
+		}
+		if existing.ID != "" && candidate.ID != "" && existing.ID == candidate.ID {
+			return true
+		}
+		if candidateCommand != "" && existing.Native != nil && existing.Native["command"] == candidateCommand {
+			return true
+		}
+		if existing.Source.Signal == SkillSignalPiInputSlashCommand || existing.Source.Signal == SkillSignalPromptSlashCommand {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/agent/skill_events_prompt_test.go
+++ b/cmd/entire/cli/agent/skill_events_prompt_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSkillEventFromPromptSlashCommand(t *testing.T) {
+	t.Parallel()
+
+	timestamp := time.Date(2026, 5, 25, 12, 34, 56, 0, time.UTC)
+	event, ok := SkillEventFromPromptSlashCommand("codex", "  /skill:trigger-analysis inspect the diff", timestamp)
+	if !ok {
+		t.Fatal("SkillEventFromPromptSlashCommand() ok = false, want true")
+	}
+	if event.EventType != SkillEventTypePromptInvocation {
+		t.Fatalf("EventType = %q, want %q", event.EventType, SkillEventTypePromptInvocation)
+	}
+	if event.Skill.Name != "trigger-analysis" {
+		t.Fatalf("Skill.Name = %q, want trigger-analysis", event.Skill.Name)
+	}
+	if event.Source.Agent != "codex" || event.Source.Signal != SkillSignalPromptSlashCommand || event.Source.Confidence != SkillConfidenceExplicit {
+		t.Fatalf("Source = %+v", event.Source)
+	}
+	if event.Timestamp != "2026-05-25T12:34:56Z" {
+		t.Fatalf("Timestamp = %q", event.Timestamp)
+	}
+	if event.Native["command"] != "/skill:trigger-analysis" {
+		t.Fatalf("Native command = %q", event.Native["command"])
+	}
+	if event.Collapse.Target != SkillCollapseTargetUserMessage || !event.Collapse.DefaultCollapsed {
+		t.Fatalf("Collapse = %+v", event.Collapse)
+	}
+	if event.Collapse.Label != "/skill:trigger-analysis" {
+		t.Fatalf("Collapse label = %q", event.Collapse.Label)
+	}
+}
+
+func TestSkillEventFromPromptSlashCommand_NonSkillPrompt(t *testing.T) {
+	t.Parallel()
+
+	for _, prompt := range []string{"/review", "/skills", "please use /skill:foo", "/skill:", "/skillset:foo"} {
+		if event, ok := SkillEventFromPromptSlashCommand("codex", prompt, time.Now()); ok {
+			t.Fatalf("SkillEventFromPromptSlashCommand(%q) = %+v, true; want false", prompt, event)
+		}
+	}
+}
+
+func TestAppendPromptSlashCommandSkillEvent_KeepsNativeAdapterEvent(t *testing.T) {
+	t.Parallel()
+
+	existing := []SkillEvent{
+		{
+			ID:        "pi-skill-trigger-analysis-1",
+			EventType: SkillEventTypePromptInvocation,
+			Skill:     SkillEventSkill{Name: "trigger-analysis"},
+			Source: SkillEventSource{
+				Agent:      "pi",
+				Signal:     SkillSignalPiInputSlashCommand,
+				Confidence: SkillConfidenceExplicit,
+			},
+			Native: map[string]string{"command": "/skill:trigger-analysis"},
+		},
+	}
+
+	got := AppendPromptSlashCommandSkillEvent(existing, "pi", "/skill:trigger-analysis inspect", time.Now())
+	if len(got) != 1 {
+		t.Fatalf("AppendPromptSlashCommandSkillEvent len = %d, want 1", len(got))
+	}
+	if got[0].ID != existing[0].ID {
+		t.Fatalf("AppendPromptSlashCommandSkillEvent replaced native event: %+v", got[0])
+	}
+}

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -367,6 +367,10 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 		}
 	}
 
+	// Generic explicit skill signal for agents whose turn-start hook exposes the raw prompt.
+	// Agent adapters can still provide stronger/native events; those win over this fallback.
+	event.SkillEvents = agent.AppendPromptSlashCommandSkillEvent(event.SkillEvents, string(ag.Name()), event.Prompt, event.Timestamp)
+
 	// Capture pre-prompt state (including transcript position via TranscriptAnalyzer)
 	_, captureSpan := perf.Start(ctx, "capture_pre_prompt_state")
 	if err := CapturePrePromptState(ctx, ag, sessionID, event.SessionRef); err != nil {

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -432,7 +432,10 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 		adoptInvestigateEnv(logCtx, state, string(ag.Name()))
 
 		skillEventSource := *event
-		// Generic explicit skill signal for agents whose turn-start hook exposes the raw prompt.
+		// Generic explicit skill signal for USER-INVOKED "/skill:<name>" prompts on
+		// agents whose turn-start hook exposes the raw prompt. Tool-call skills are
+		// handled by agent-specific SkillEventExtractors, not here. See
+		// agent.SkillEventFromPromptSlashCommand for the per-agent format validation.
 		// TurnStart bypasses the dispatcher-level owner filter so InitializeSession can repair
 		// agent ownership. Only add the generic event after ownership is known; native
 		// adapter-provided events remain unchanged.

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -367,10 +367,6 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 		}
 	}
 
-	// Generic explicit skill signal for agents whose turn-start hook exposes the raw prompt.
-	// Agent adapters can still provide stronger/native events; those win over this fallback.
-	event.SkillEvents = agent.AppendPromptSlashCommandSkillEvent(event.SkillEvents, string(ag.Name()), event.Prompt, event.Timestamp)
-
 	// Capture pre-prompt state (including transcript position via TranscriptAnalyzer)
 	_, captureSpan := perf.Start(ctx, "capture_pre_prompt_state")
 	if err := CapturePrePromptState(ctx, ag, sessionID, event.SessionRef); err != nil {
@@ -434,7 +430,21 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 		before.ReviewSkills = slices.Clone(state.ReviewSkills)
 		adoptReviewEnv(logCtx, state, string(ag.Name()))
 		adoptInvestigateEnv(logCtx, state, string(ag.Name()))
-		skillEventsChanged := appendEventSkillEventsToState(event, state)
+
+		skillEventSource := *event
+		// Generic explicit skill signal for agents whose turn-start hook exposes the raw prompt.
+		// TurnStart bypasses the dispatcher-level owner filter so InitializeSession can repair
+		// agent ownership. Only add the generic event after ownership is known; native
+		// adapter-provided events remain unchanged.
+		if state.AgentType == "" || state.AgentType == ag.Type() {
+			skillEventSource.SkillEvents = agent.AppendPromptSlashCommandSkillEvent(
+				skillEventSource.SkillEvents,
+				string(ag.Name()),
+				event.Prompt,
+				event.Timestamp,
+			)
+		}
+		skillEventsChanged := appendEventSkillEventsToState(&skillEventSource, state)
 		if state.Kind == before.Kind &&
 			state.ReviewPrompt == before.ReviewPrompt &&
 			slices.Equal(state.ReviewSkills, before.ReviewSkills) &&

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -1099,6 +1099,45 @@ func TestHandleLifecycleTurnStart_WritesPromptContent(t *testing.T) {
 	}
 }
 
+func TestHandleLifecycleTurnStart_RecordsGenericSkillSlashEvent(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "init.txt", "init")
+	testutil.GitAdd(t, tmpDir, "init.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+	paths.ClearWorktreeRootCache()
+
+	ag := newMockAgent()
+	sessionID := "test-generic-skill-slash"
+	event := &agent.Event{
+		Type:      agent.TurnStart,
+		SessionID: sessionID,
+		Prompt:    "/skill:trigger-analysis inspect the implementation",
+		Timestamp: time.Date(2026, 5, 25, 12, 34, 56, 0, time.UTC),
+	}
+
+	require.NoError(t, handleLifecycleTurnStart(context.Background(), ag, event))
+
+	state, err := strategy.LoadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Len(t, state.SkillEvents, 1)
+
+	skillEvent := state.SkillEvents[0]
+	require.Equal(t, agent.SkillEventTypePromptInvocation, skillEvent.EventType)
+	require.Equal(t, "trigger-analysis", skillEvent.Skill.Name)
+	require.Equal(t, string(ag.Name()), skillEvent.Source.Agent)
+	require.Equal(t, agent.SkillSignalPromptSlashCommand, skillEvent.Source.Signal)
+	require.Equal(t, agent.SkillConfidenceExplicit, skillEvent.Source.Confidence)
+	require.Equal(t, state.TurnID, skillEvent.TurnID)
+	require.Equal(t, "2026-05-25T12:34:56Z", skillEvent.Timestamp)
+	require.Equal(t, "/skill:trigger-analysis", skillEvent.Native["command"])
+	require.Equal(t, agent.SkillCollapseTargetUserMessage, skillEvent.Collapse.Target)
+	require.True(t, skillEvent.Collapse.DefaultCollapsed)
+}
+
 func TestHandleLifecycleTurnEnd_BackfillsPromptFromTranscript(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir()
 	tmpDir := t.TempDir()

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -1138,6 +1138,46 @@ func TestHandleLifecycleTurnStart_RecordsGenericSkillSlashEvent(t *testing.T) {
 	require.True(t, skillEvent.Collapse.DefaultCollapsed)
 }
 
+func TestHandleLifecycleTurnStart_DoesNotDuplicateGenericSkillSlashEventFromForwardedHook(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "init.txt", "init")
+	testutil.GitAdd(t, tmpDir, "init.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+	paths.ClearWorktreeRootCache()
+
+	sessionID := "test-generic-skill-forwarded"
+	ownerAgent := newMockAgent()
+	forwardedAgent := &mockLifecycleAgent{
+		name:           "forwarded-agent",
+		agentType:      "Forwarded Agent",
+		transcriptData: []byte(`{"type":"user","message":"test"}`),
+	}
+	prompt := "/skill:trigger-analysis inspect the implementation"
+
+	require.NoError(t, handleLifecycleTurnStart(context.Background(), ownerAgent, &agent.Event{
+		Type:      agent.TurnStart,
+		SessionID: sessionID,
+		Prompt:    prompt,
+		Timestamp: time.Date(2026, 5, 25, 12, 34, 56, 0, time.UTC),
+	}))
+	require.NoError(t, handleLifecycleTurnStart(context.Background(), forwardedAgent, &agent.Event{
+		Type:      agent.TurnStart,
+		SessionID: sessionID,
+		Prompt:    prompt,
+		Timestamp: time.Date(2026, 5, 25, 12, 34, 57, 0, time.UTC),
+	}))
+
+	state, err := strategy.LoadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, ownerAgent.Type(), state.AgentType)
+	require.Len(t, state.SkillEvents, 1)
+	require.Equal(t, string(ownerAgent.Name()), state.SkillEvents[0].Source.Agent)
+}
+
 func TestHandleLifecycleTurnEnd_BackfillsPromptFromTranscript(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary
- add a generic `/skill:<name>` prompt parser for agents whose turn-start hook exposes the raw prompt
- append prompt skill events in the lifecycle dispatcher while letting native adapter events win
- persist generic events with explicit provenance, command-only native metadata, and user-message collapse hints

## Scope: user-invoked prompt skills only

This change captures **user-invoked** skill calls of the form `/skill:<name>` typed
into the prompt. It does **not** add generic detection of skill **tool calls**.

| Event | event_type | source.signal | collapse.target | Where it is produced |
| --- | --- | --- | --- | --- |
| User prompt `/skill:<name>` | `prompt_invocation` | `prompt_slash_command` | `user_message` | generic, this PR (lifecycle TurnStart) |
| Pi `/skill:<name>` (pre-expansion) | `prompt_invocation` | `input_slash_command` | `user_message` | Pi extension (native) |
| Claude `Skill` tool use | `tool_invocation` | `skill_tool_use` | `tool_pair` | Claude transcript extractor (native) |

Tool-call skill detection stays **agent-specific** (currently Claude Code's `Skill`
tool) because tool formats and skill semantics vary per agent and generic tool-call
heuristics would be unreliable.

## Slash-command format validation

Validated against installed agent binaries (Claude Code 2.1.x, Codex, OpenCode, Pi):

| Agent | User skill prompt syntax | Uses `/skill:<name>`? | Covered |
| --- | --- | --- | --- |
| Pi | `/skill:<name>` | yes | natively, pre-expansion (Pi `input` event). At framework TurnStart Pi's prompt is already the expanded `<skill ...>` block, so the generic parser does not re-match it; the native event wins. |
| Claude Code | `/<skill-name>` + `Skill` tool | no | tool calls → `tool_invocation`; `/<skill-name>` is the skill's own name, not `/skill:` |
| Codex | none (skills injected/tool) | no | n/a |
| OpenCode | none | no | n/a |
| Gemini CLI | none | no | n/a |
| Cursor | none | no | n/a |
| Factory Droid | none | no | n/a |
| Copilot CLI | none | no | n/a |

**Conclusion:** among shipped agents the literal `/skill:<name>` syntax is **Pi-only**,
and Pi is already covered natively before expansion. The generic TurnStart parser is a
forward-looking, low-risk fallback for any agent whose turn-start hook surfaces a raw
`/skill:<name>` prompt. It is intentionally strict (only `/skill:`, never every
`/<word>`) to avoid misclassifying ordinary slash commands as skills, and it only
fires when the firing TurnStart agent matches the owning agent so forwarded hooks
(e.g. Cursor IDE → Claude) do not duplicate events.

## Testing
- `mise exec -- go test ./cmd/entire/cli/agent ./cmd/entire/cli`
- `mise exec -- go test ./cmd/entire/cli/agent ./cmd/entire/cli/agent/pi ./cmd/entire/cli/agent/claudecode ./cmd/entire/cli/checkpoint ./cmd/entire/cli/strategy ./cmd/entire/cli`
- `env -u GIT_TERMINAL_PROMPT -u PI_CODING_AGENT mise exec -- go test ./...`
- Manual E2E: simulated Codex `user-prompt-submit` with `/skill:trigger-analysis`, committed with trailer, and verified `skill_events` in checkpoint metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds optional checkpoint metadata parsing and lifecycle append logic with deduplication; no auth, payments, or core commit path changes.
> 
> **Overview**
> Adds a **generic fallback** so turn-start hooks that expose the raw user prompt can record explicit **`/skill:<name>`** invocations in checkpoint metadata, even when the agent has no native skill adapter.
> 
> A new parser recognizes a leading slash command (after whitespace), emits a **`prompt_invocation`** skill event with signal **`prompt_slash_command`**, and stores only the command in **`native`** (not the rest of the prompt). **`handleLifecycleTurnStart`** appends these events before session init; **native adapter events** (e.g. Pi’s pre-expansion input event) **win** and duplicates are skipped.
> 
> Collapse hints target the user message and default to collapsed, matching other explicit skill signals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc75f0f28ef5e320b5860d6b7b9a01d088c77d6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
