### PR TITLE
Add checkpoints v1.1 support to entire explain

### DIFF
--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -1781,13 +1781,18 @@ func (s *GitStore) getFetchingTree(ctx context.Context) (*FetchingTree, error) {
 	return NewFetchingTree(ctx, tree, s.repo.Storer, s.blobFetcher), nil
 }
 
-// getSessionsBranchTree returns the tree object for the entire/checkpoints/v1 branch.
-// Falls back to origin/entire/checkpoints/v1 if the local branch doesn't exist.
+// getSessionsBranchTree returns the tree object for the configured committed
+// ref (the v1 branch by default, or the v1.1 custom ref for v1.1 read stores).
+// For the default v1 branch it falls back to origin/entire/checkpoints/v1 when
+// the local branch is missing; the v1.1 custom ref is local-only, so no remote
+// fallback applies there.
 func (s *GitStore) getSessionsBranchTree() (*object.Tree, error) {
-	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
-	ref, err := s.repo.Reference(refName, true)
+	ref, err := s.repo.Reference(s.committedReadRef, true)
 	if err != nil {
-		// Local branch doesn't exist, try remote-tracking branch
+		if s.committedReadRef != defaultCommittedReadRef() {
+			return nil, fmt.Errorf("sessions ref %s not found: %w", s.committedReadRef, err)
+		}
+		// Local v1 branch doesn't exist, try remote-tracking branch
 		remoteRefName := plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName)
 		ref, err = s.repo.Reference(remoteRefName, true)
 		if err != nil {
@@ -2193,11 +2198,12 @@ type Author struct {
 	Email string
 }
 
-// GetCheckpointAuthor retrieves the author of a checkpoint from the entire/checkpoints/v1 commit history.
+// GetCheckpointAuthor retrieves the author of a checkpoint from the configured
+// committed-read ref history.
 // Finds the commit whose subject matches "Checkpoint: <id>" and returns its author.
 // Returns empty Author if the checkpoint is not found or the sessions branch doesn't exist.
 func (s *GitStore) GetCheckpointAuthor(ctx context.Context, checkpointID id.CheckpointID) (Author, error) {
-	return getCheckpointAuthorFromRef(ctx, s.repo, plumbing.NewBranchReferenceName(paths.MetadataBranchName), checkpointID)
+	return getCheckpointAuthorFromRef(ctx, s.repo, s.committedReadRef, checkpointID)
 }
 
 func getCheckpointAuthorFromRef(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, checkpointID id.CheckpointID) (Author, error) {

--- a/cmd/entire/cli/checkpoint/committed_read_store.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store.go
@@ -15,11 +15,13 @@ import (
 // NewCommittedReadStore returns a GitStore for reading committed checkpoints,
 // honoring the checkpoints_version setting.
 //
-// When v1.1 is enabled it first brings the local-only v1.1 custom ref up to the
-// v1 branch tip (sync-then-read). If the custom ref cannot be synced, or if it
-// has diverged from v1, reads fall back to the default v1 store so v1 remains
-// the source of truth and the existing remote-tracking fallback still applies.
-// When v1.1 is not enabled, this is the default v1 read store.
+// When v1.1 is enabled, committed reads resolve against the local-only v1.1
+// custom ref and NEVER fall back to v1: the store always binds to the v1.1 ref.
+// Before returning, it best-effort syncs that ref up to the v1 tip
+// (sync-then-read) so v1.1 carries v1's full history. v1 stays the source of
+// truth via the write-time mirror; reads stay on v1.1 so the v1.1 path is
+// genuinely exercised rather than masked by a v1 fallback. When v1.1 is not
+// enabled, this is the default v1 read store.
 //
 // Currently only the `entire explain` command reads through this factory. Other
 // read-only commands stay on NewGitStore (v1) for now and will be migrated in
@@ -29,36 +31,39 @@ func NewCommittedReadStore(ctx context.Context, repo *git.Repository) *GitStore 
 	if !settings.MirrorsToV1CustomRef(ctx) {
 		return NewGitStore(repo)
 	}
-	if syncV1CustomRefForRead(ctx, repo) {
-		return NewGitStoreWithRef(repo, plumbing.ReferenceName(paths.MetadataRefName))
-	}
-	return NewGitStore(repo)
+	syncV1CustomRefForRead(ctx, repo)
+	return NewGitStoreWithRef(repo, plumbing.ReferenceName(paths.MetadataRefName))
 }
 
-// syncV1CustomRefForRead advances the local-only v1.1 custom ref to the v1
-// branch tip before a read so v1.1 reflects v1's current history. It mirrors the
-// write-time mirror's safety rules: seed when missing, advance when the custom
-// ref is an ancestor of v1, and no-op when equal. A diverged custom ref is left
-// untouched, but is not used for reads. All failures are logged and reported as
-// false so callers can fall back to the v1 store.
-func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) bool {
-	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
-	if err != nil {
-		// No v1 branch yet — nothing to mirror. Expected on a fresh repo.
-		logging.Debug(ctx, "v1.1 read sync skipped: v1 branch unavailable",
-			slog.String("error", err.Error()))
-		return false
+// syncV1CustomRefForRead best-effort advances the local-only v1.1 custom ref to
+// the v1 tip before a read so v1.1 reflects v1's current history. The v1 tip is
+// taken from the local v1 branch, or from origin/entire/checkpoints/v1 when the
+// local branch is absent (e.g. a fresh clone), so v1.1 can be seeded without a
+// local write.
+//
+// It applies the write-time mirror's safety rules: seed when missing, advance
+// when the custom ref is an ancestor of v1, and no-op when equal. A diverged
+// custom ref is left untouched. All failures are logged, never returned: reads
+// proceed against the v1.1 ref regardless (there is no v1 fallback), so a sync
+// problem surfaces as missing/stale v1.1 data rather than being papered over.
+func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) {
+	v1Hash, ok := resolveV1Tip(repo)
+	if !ok {
+		// No v1 branch locally or on origin — nothing to seed from.
+		logging.Debug(ctx, "v1.1 read sync skipped: no v1 tip available")
+		return
 	}
 
 	customRefName := plumbing.ReferenceName(paths.MetadataRefName)
 	customRef, err := repo.Reference(customRefName, false)
 	if err != nil {
 		// Custom ref missing — seed it at the v1 tip.
-		return setCustomRef(ctx, repo, customRefName, v1Ref.Hash())
+		setCustomRef(ctx, repo, customRefName, v1Hash)
+		return
 	}
 
-	if customRef.Hash() == v1Ref.Hash() {
-		return true // already current
+	if customRef.Hash() == v1Hash {
+		return // already current
 	}
 
 	customCommit, err := repo.CommitObject(customRef.Hash())
@@ -66,45 +71,57 @@ func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) bool {
 		logging.Warn(ctx, "v1.1 read sync skipped: custom ref commit unreadable",
 			slog.String("ref", paths.MetadataRefName),
 			slog.String("error", err.Error()))
-		return false
+		return
 	}
-	v1Commit, err := repo.CommitObject(v1Ref.Hash())
+	v1Commit, err := repo.CommitObject(v1Hash)
 	if err != nil {
 		logging.Warn(ctx, "v1.1 read sync skipped: v1 commit unreadable",
 			slog.String("error", err.Error()))
-		return false
+		return
 	}
 
 	isAncestor, err := customCommit.IsAncestor(v1Commit)
 	if err != nil {
 		logging.Warn(ctx, "v1.1 read sync skipped: ancestry check failed",
 			slog.String("error", err.Error()))
-		return false
+		return
 	}
 	if !isAncestor {
 		// Diverged from v1: leave the custom ref untouched rather than clobber
-		// local-only history. Fall back to v1 so v1 remains the source of truth.
-		logging.Warn(ctx, "v1.1 custom ref diverged from v1; falling back to v1 reads",
+		// local-only history. Reads still use the v1.1 ref as-is.
+		logging.Warn(ctx, "v1.1 custom ref diverged from v1; reading custom ref as-is",
 			slog.String("ref", paths.MetadataRefName),
 			slog.String("custom_hash", customRef.Hash().String()),
-			slog.String("v1_hash", v1Ref.Hash().String()))
-		return false
+			slog.String("v1_hash", v1Hash.String()))
+		return
 	}
 
-	return setCustomRef(ctx, repo, customRefName, v1Ref.Hash())
+	setCustomRef(ctx, repo, customRefName, v1Hash)
+}
+
+// resolveV1Tip returns the v1 metadata tip, preferring the local v1 branch and
+// falling back to the origin remote-tracking branch (so v1.1 can be seeded on a
+// fresh clone that has not yet written locally).
+func resolveV1Tip(repo *git.Repository) (plumbing.Hash, bool) {
+	if ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true); err == nil {
+		return ref.Hash(), true
+	}
+	if ref, err := repo.Reference(plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName), true); err == nil {
+		return ref.Hash(), true
+	}
+	return plumbing.ZeroHash, false
 }
 
 // setCustomRef points refName at hash, logging success at debug and failure at
-// warning. The return value reports whether the ref now points at hash.
-func setCustomRef(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, hash plumbing.Hash) bool {
+// warning. Failures are swallowed so the read can proceed against the ref as-is.
+func setCustomRef(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, hash plumbing.Hash) {
 	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, hash)); err != nil {
 		logging.Warn(ctx, "v1.1 read sync failed to advance custom ref",
 			slog.String("ref", refName.String()),
 			slog.String("error", err.Error()))
-		return false
+		return
 	}
 	logging.Debug(ctx, "v1.1 custom ref synced for read",
 		slog.String("ref", refName.String()),
 		slog.String("hash", hash.String()))
-	return true
 }

--- a/cmd/entire/cli/checkpoint/committed_read_store.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store.go
@@ -1,0 +1,110 @@
+package checkpoint
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// NewCommittedReadStore returns a GitStore for reading committed checkpoints,
+// honoring the checkpoints_version setting.
+//
+// When v1.1 is enabled it first brings the local-only v1.1 custom ref up to the
+// v1 branch tip (sync-then-read). If the custom ref cannot be synced, or if it
+// has diverged from v1, reads fall back to the default v1 store so v1 remains
+// the source of truth and the existing remote-tracking fallback still applies.
+// When v1.1 is not enabled, this is the default v1 read store.
+//
+// Currently only the `entire explain` command reads through this factory. Other
+// read-only commands stay on NewGitStore (v1) for now and will be migrated in
+// follow-up work. Write and read-modify-write paths always use NewGitStore (v1)
+// plus the existing write-time mirror.
+func NewCommittedReadStore(ctx context.Context, repo *git.Repository) *GitStore {
+	if !settings.MirrorsToV1CustomRef(ctx) {
+		return NewGitStore(repo)
+	}
+	if syncV1CustomRefForRead(ctx, repo) {
+		return NewGitStoreWithRef(repo, plumbing.ReferenceName(paths.MetadataRefName))
+	}
+	return NewGitStore(repo)
+}
+
+// syncV1CustomRefForRead advances the local-only v1.1 custom ref to the v1
+// branch tip before a read so v1.1 reflects v1's current history. It mirrors the
+// write-time mirror's safety rules: seed when missing, advance when the custom
+// ref is an ancestor of v1, and no-op when equal. A diverged custom ref is left
+// untouched, but is not used for reads. All failures are logged and reported as
+// false so callers can fall back to the v1 store.
+func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) bool {
+	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	if err != nil {
+		// No v1 branch yet — nothing to mirror. Expected on a fresh repo.
+		logging.Debug(ctx, "v1.1 read sync skipped: v1 branch unavailable",
+			slog.String("error", err.Error()))
+		return false
+	}
+
+	customRefName := plumbing.ReferenceName(paths.MetadataRefName)
+	customRef, err := repo.Reference(customRefName, false)
+	if err != nil {
+		// Custom ref missing — seed it at the v1 tip.
+		return setCustomRef(ctx, repo, customRefName, v1Ref.Hash())
+	}
+
+	if customRef.Hash() == v1Ref.Hash() {
+		return true // already current
+	}
+
+	customCommit, err := repo.CommitObject(customRef.Hash())
+	if err != nil {
+		logging.Warn(ctx, "v1.1 read sync skipped: custom ref commit unreadable",
+			slog.String("ref", paths.MetadataRefName),
+			slog.String("error", err.Error()))
+		return false
+	}
+	v1Commit, err := repo.CommitObject(v1Ref.Hash())
+	if err != nil {
+		logging.Warn(ctx, "v1.1 read sync skipped: v1 commit unreadable",
+			slog.String("error", err.Error()))
+		return false
+	}
+
+	isAncestor, err := customCommit.IsAncestor(v1Commit)
+	if err != nil {
+		logging.Warn(ctx, "v1.1 read sync skipped: ancestry check failed",
+			slog.String("error", err.Error()))
+		return false
+	}
+	if !isAncestor {
+		// Diverged from v1: leave the custom ref untouched rather than clobber
+		// local-only history. Fall back to v1 so v1 remains the source of truth.
+		logging.Warn(ctx, "v1.1 custom ref diverged from v1; falling back to v1 reads",
+			slog.String("ref", paths.MetadataRefName),
+			slog.String("custom_hash", customRef.Hash().String()),
+			slog.String("v1_hash", v1Ref.Hash().String()))
+		return false
+	}
+
+	return setCustomRef(ctx, repo, customRefName, v1Ref.Hash())
+}
+
+// setCustomRef points refName at hash, logging success at debug and failure at
+// warning. The return value reports whether the ref now points at hash.
+func setCustomRef(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, hash plumbing.Hash) bool {
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, hash)); err != nil {
+		logging.Warn(ctx, "v1.1 read sync failed to advance custom ref",
+			slog.String("ref", refName.String()),
+			slog.String("error", err.Error()))
+		return false
+	}
+	logging.Debug(ctx, "v1.1 custom ref synced for read",
+		slog.String("ref", refName.String()),
+		slog.String("hash", hash.String()))
+	return true
+}

--- a/cmd/entire/cli/checkpoint/committed_read_store.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store.go
@@ -13,20 +13,11 @@ import (
 )
 
 // NewCommittedReadStore returns a GitStore for reading committed checkpoints,
-// honoring the checkpoints_version setting.
-//
-// When v1.1 is enabled, committed reads resolve against the local-only v1.1
-// custom ref and NEVER fall back to v1: the store always binds to the v1.1 ref.
-// Before returning, it best-effort syncs that ref up to the v1 tip
-// (sync-then-read) so v1.1 carries v1's full history. v1 stays the source of
-// truth via the write-time mirror; reads stay on v1.1 so the v1.1 path is
-// genuinely exercised rather than masked by a v1 fallback. When v1.1 is not
-// enabled, this is the default v1 read store.
-//
-// Currently only the `entire explain` command reads through this factory. Other
-// read-only commands stay on NewGitStore (v1) for now and will be migrated in
-// follow-up work. Write and read-modify-write paths always use NewGitStore (v1)
-// plus the existing write-time mirror.
+// honoring checkpoints_version. With v1.1 enabled, reads bind to the local-only
+// v1.1 custom ref and never fall back to v1: it best-effort sync-then-reads,
+// advancing the ref to the v1 tip first so v1.1 carries v1's history. v1 stays
+// the source of truth via the write-time mirror. Only `entire explain` reads
+// through this today; other read paths, and all writes, use NewGitStore (v1).
 func NewCommittedReadStore(ctx context.Context, repo *git.Repository) *GitStore {
 	if !settings.MirrorsToV1CustomRef(ctx) {
 		return NewGitStore(repo)
@@ -35,21 +26,14 @@ func NewCommittedReadStore(ctx context.Context, repo *git.Repository) *GitStore 
 	return NewGitStoreWithRef(repo, plumbing.ReferenceName(paths.MetadataRefName))
 }
 
-// syncV1CustomRefForRead best-effort advances the local-only v1.1 custom ref to
-// the v1 tip before a read so v1.1 reflects v1's current history. The v1 tip is
-// taken from the local v1 branch, or from origin/entire/checkpoints/v1 when the
-// local branch is absent (e.g. a fresh clone), so v1.1 can be seeded without a
-// local write.
-//
-// It applies the write-time mirror's safety rules: seed when missing, advance
-// when the custom ref is an ancestor of v1, and no-op when equal. A diverged
-// custom ref is left untouched. All failures are logged, never returned: reads
-// proceed against the v1.1 ref regardless (there is no v1 fallback), so a sync
-// problem surfaces as missing/stale v1.1 data rather than being papered over.
+// syncV1CustomRefForRead best-effort advances the v1.1 custom ref to the v1 tip
+// (the local v1 branch, or origin/entire/checkpoints/v1 on a fresh clone) so a
+// read sees v1's current history: seed when missing, advance when an ancestor,
+// no-op when equal, leave a diverged ref untouched. Failures are logged, not
+// returned; reads proceed against the ref regardless (there is no v1 fallback).
 func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) {
 	v1Hash, ok := resolveV1Tip(repo)
 	if !ok {
-		// No v1 branch locally or on origin — nothing to seed from.
 		logging.Debug(ctx, "v1.1 read sync skipped: no v1 tip available")
 		return
 	}
@@ -57,8 +41,7 @@ func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) {
 	customRefName := plumbing.ReferenceName(paths.MetadataRefName)
 	customRef, err := repo.Reference(customRefName, false)
 	if err != nil {
-		// Custom ref missing — seed it at the v1 tip.
-		setCustomRef(ctx, repo, customRefName, v1Hash)
+		setCustomRef(ctx, repo, customRefName, v1Hash) // missing — seed at v1 tip
 		return
 	}
 
@@ -87,8 +70,7 @@ func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) {
 		return
 	}
 	if !isAncestor {
-		// Diverged from v1: leave the custom ref untouched rather than clobber
-		// local-only history. Reads still use the v1.1 ref as-is.
+		// Diverged from v1: leave the ref untouched and read it as-is.
 		logging.Warn(ctx, "v1.1 custom ref diverged from v1; reading custom ref as-is",
 			slog.String("ref", paths.MetadataRefName),
 			slog.String("custom_hash", customRef.Hash().String()),
@@ -100,8 +82,8 @@ func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) {
 }
 
 // resolveV1Tip returns the v1 metadata tip, preferring the local v1 branch and
-// falling back to the origin remote-tracking branch (so v1.1 can be seeded on a
-// fresh clone that has not yet written locally).
+// falling back to origin's remote-tracking branch (so v1.1 can seed on a fresh
+// clone).
 func resolveV1Tip(repo *git.Repository) (plumbing.Hash, bool) {
 	if ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true); err == nil {
 		return ref.Hash(), true
@@ -112,8 +94,8 @@ func resolveV1Tip(repo *git.Repository) (plumbing.Hash, bool) {
 	return plumbing.ZeroHash, false
 }
 
-// setCustomRef points refName at hash, logging success at debug and failure at
-// warning. Failures are swallowed so the read can proceed against the ref as-is.
+// setCustomRef points refName at hash; failures are logged and swallowed so the
+// read can proceed against the ref as-is.
 func setCustomRef(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, hash plumbing.Hash) {
 	if err := repo.Storer.SetReference(plumbing.NewHashReference(refName, hash)); err != nil {
 		logging.Warn(ctx, "v1.1 read sync failed to advance custom ref",

--- a/cmd/entire/cli/checkpoint/committed_read_store.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store.go
@@ -13,22 +13,30 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
-// NewCommittedReadStore returns a GitStore for reading committed checkpoints.
-// With checkpoints_version 1.1 it binds reads to the local-only v1.1 custom ref
-// (never falling back to v1) after best-effort syncing it to the v1 tip. Writes
-// still use NewGitStore (v1); only `entire explain` reads through this today.
+// NewCommittedReadStore returns a GitStore for reading committed checkpoints:
+// the local-only v1.1 custom ref when checkpoints_version 1.1 is enabled (no v1
+// fallback), else the v1 branch. Pure — callers run SyncCommittedReadRef first
+// to bring the v1.1 ref up to date.
 func NewCommittedReadStore(ctx context.Context, repo *git.Repository) *GitStore {
 	if !settings.MirrorsToV1CustomRef(ctx) {
 		return NewGitStore(repo)
 	}
-	syncV1CustomRefForRead(ctx, repo)
 	return NewGitStoreWithRef(repo, plumbing.ReferenceName(paths.MetadataRefName))
 }
 
-// syncV1CustomRefForRead best-effort advances the v1.1 custom ref to the v1 tip
-// (local v1 branch, or origin's on a fresh clone): seed when missing, advance
-// when an ancestor, no-op when equal, leave a diverged ref as-is. Failures are
-// logged, not returned — reads proceed against the ref regardless.
+// SyncCommittedReadRef advances the v1.1 custom ref to the v1 tip before a read,
+// a no-op unless checkpoints_version 1.1 is enabled. The ref is local-only, so a
+// git pull updates v1 but not v1.1; this keeps it current. Best-effort.
+func SyncCommittedReadRef(ctx context.Context, repo *git.Repository) {
+	if !settings.MirrorsToV1CustomRef(ctx) {
+		return
+	}
+	syncV1CustomRefForRead(ctx, repo)
+}
+
+// syncV1CustomRefForRead advances the v1.1 custom ref to the v1 tip (local v1
+// branch, or origin's on a fresh clone): seed when missing, advance when an
+// ancestor, no-op when equal, leave a diverged ref as-is. Failures are logged.
 func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) {
 	v1Hash, ok := resolveV1Tip(repo)
 	if !ok {

--- a/cmd/entire/cli/checkpoint/committed_read_store.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store.go
@@ -15,8 +15,7 @@ import (
 
 // NewCommittedReadStore returns a GitStore for reading committed checkpoints:
 // the local-only v1.1 custom ref when checkpoints_version 1.1 is enabled (no v1
-// fallback), else the v1 branch. Pure — callers run SyncCommittedReadRef first
-// to bring the v1.1 ref up to date.
+// fallback), else the v1 branch.
 func NewCommittedReadStore(ctx context.Context, repo *git.Repository) *GitStore {
 	if !settings.MirrorsToV1CustomRef(ctx) {
 		return NewGitStore(repo)

--- a/cmd/entire/cli/checkpoint/committed_read_store.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/go-git/go-git/v6"
@@ -40,8 +41,15 @@ func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) {
 
 	customRefName := plumbing.ReferenceName(paths.MetadataRefName)
 	customRef, err := repo.Reference(customRefName, false)
-	if err != nil {
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
 		setCustomRef(ctx, repo, customRefName, v1Hash) // missing — seed at v1 tip
+		return
+	}
+	if err != nil {
+		// Unexpected read error — don't overwrite the ref; read it as-is.
+		logging.Warn(ctx, "v1.1 read sync skipped: custom ref unreadable",
+			slog.String("ref", paths.MetadataRefName),
+			slog.String("error", err.Error()))
 		return
 	}
 

--- a/cmd/entire/cli/checkpoint/committed_read_store.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store.go
@@ -13,12 +13,10 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
-// NewCommittedReadStore returns a GitStore for reading committed checkpoints,
-// honoring checkpoints_version. With v1.1 enabled, reads bind to the local-only
-// v1.1 custom ref and never fall back to v1: it best-effort sync-then-reads,
-// advancing the ref to the v1 tip first so v1.1 carries v1's history. v1 stays
-// the source of truth via the write-time mirror. Only `entire explain` reads
-// through this today; other read paths, and all writes, use NewGitStore (v1).
+// NewCommittedReadStore returns a GitStore for reading committed checkpoints.
+// With checkpoints_version 1.1 it binds reads to the local-only v1.1 custom ref
+// (never falling back to v1) after best-effort syncing it to the v1 tip. Writes
+// still use NewGitStore (v1); only `entire explain` reads through this today.
 func NewCommittedReadStore(ctx context.Context, repo *git.Repository) *GitStore {
 	if !settings.MirrorsToV1CustomRef(ctx) {
 		return NewGitStore(repo)
@@ -28,10 +26,9 @@ func NewCommittedReadStore(ctx context.Context, repo *git.Repository) *GitStore 
 }
 
 // syncV1CustomRefForRead best-effort advances the v1.1 custom ref to the v1 tip
-// (the local v1 branch, or origin/entire/checkpoints/v1 on a fresh clone) so a
-// read sees v1's current history: seed when missing, advance when an ancestor,
-// no-op when equal, leave a diverged ref untouched. Failures are logged, not
-// returned; reads proceed against the ref regardless (there is no v1 fallback).
+// (local v1 branch, or origin's on a fresh clone): seed when missing, advance
+// when an ancestor, no-op when equal, leave a diverged ref as-is. Failures are
+// logged, not returned — reads proceed against the ref regardless.
 func syncV1CustomRefForRead(ctx context.Context, repo *git.Repository) {
 	v1Hash, ok := resolveV1Tip(repo)
 	if !ok {

--- a/cmd/entire/cli/checkpoint/committed_read_store_test.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store_test.go
@@ -1,0 +1,340 @@
+package checkpoint
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/redact"
+)
+
+// commitFile adds path with content to the worktree and commits it, returning
+// the new commit hash. Successive calls build a linear ancestry chain.
+func commitFile(t *testing.T, repo *git.Repository, dir, path, content, msg string) plumbing.Hash {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, path), []byte(content), 0o644))
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add(path)
+	require.NoError(t, err)
+	h, err := wt.Commit(msg, &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@test.com"},
+	})
+	require.NoError(t, err)
+	return h
+}
+
+func setV1Branch(t *testing.T, repo *git.Repository, hash plumbing.Hash) {
+	t.Helper()
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), hash)))
+}
+
+func setCustomRefHash(t *testing.T, repo *git.Repository, hash plumbing.Hash) {
+	t.Helper()
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), hash)))
+}
+
+func customRefHash(t *testing.T, repo *git.Repository) (plumbing.Hash, bool) {
+	t.Helper()
+	ref, err := repo.Reference(plumbing.ReferenceName(paths.MetadataRefName), true)
+	if err != nil {
+		return plumbing.ZeroHash, false
+	}
+	return ref.Hash(), true
+}
+
+func TestNewGitStore_DefaultsToV1Branch(t *testing.T) {
+	t.Parallel()
+	store := NewGitStore(nil)
+	assert.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), store.CommittedReadRef())
+}
+
+func TestNewGitStoreWithRef(t *testing.T) {
+	t.Parallel()
+	custom := plumbing.ReferenceName(paths.MetadataRefName)
+	assert.Equal(t, custom, NewGitStoreWithRef(nil, custom).CommittedReadRef())
+}
+
+func TestSyncV1CustomRefForRead_SeedsWhenMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
+	setV1Branch(t, repo, h)
+
+	synced := syncV1CustomRefForRead(context.Background(), repo)
+
+	require.True(t, synced, "custom ref sync should succeed")
+	got, ok := customRefHash(t, repo)
+	require.True(t, ok, "custom ref should be seeded from v1")
+	assert.Equal(t, h, got)
+}
+
+func TestSyncV1CustomRefForRead_NoopWhenEqual(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
+	setV1Branch(t, repo, h)
+	setCustomRefHash(t, repo, h)
+
+	synced := syncV1CustomRefForRead(context.Background(), repo)
+
+	require.True(t, synced, "equal refs should be usable for reads")
+	got, _ := customRefHash(t, repo)
+	assert.Equal(t, h, got)
+}
+
+func TestSyncV1CustomRefForRead_AdvancesWhenAncestor(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	old := commitFile(t, repo, dir, "f.txt", "v1", "init")
+	setCustomRefHash(t, repo, old)
+	newHash := commitFile(t, repo, dir, "f2.txt", "more", "second")
+	setV1Branch(t, repo, newHash)
+	require.NotEqual(t, old, newHash)
+
+	synced := syncV1CustomRefForRead(context.Background(), repo)
+
+	require.True(t, synced, "ancestor custom ref should advance for reads")
+	got, _ := customRefHash(t, repo)
+	assert.Equal(t, newHash, got, "custom ref should advance to the v1 tip")
+}
+
+func TestSyncV1CustomRefForRead_LeavesNonAncestorRef(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	first := commitFile(t, repo, dir, "f.txt", "v1", "init")
+	second := commitFile(t, repo, dir, "f2.txt", "more", "second")
+	// v1 points at the parent while the custom ref is ahead at the child: the
+	// custom ref is not an ancestor of v1, so it must be left untouched.
+	setV1Branch(t, repo, first)
+	setCustomRefHash(t, repo, second)
+
+	synced := syncV1CustomRefForRead(context.Background(), repo)
+
+	require.False(t, synced, "non-ancestor custom ref should not be used for reads")
+	got, _ := customRefHash(t, repo)
+	assert.Equal(t, second, got, "non-ancestor custom ref must not be rewound")
+}
+
+func TestSyncV1CustomRefForRead_V1MissingNoOp(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	commitFile(t, repo, dir, "f.txt", "v1", "init")
+	// No v1 metadata branch set.
+
+	synced := syncV1CustomRefForRead(context.Background(), repo)
+
+	require.False(t, synced, "missing v1 branch should fall back to the v1 store")
+	_, ok := customRefHash(t, repo)
+	assert.False(t, ok, "custom ref must not be created when the v1 branch is absent")
+}
+
+func TestSyncV1CustomRefForRead_WriteFailureReturnsFalse(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
+	setV1Branch(t, repo, h)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "refs", "entire"), []byte("blocked"), 0o644))
+
+	synced := syncV1CustomRefForRead(context.Background(), repo)
+	require.False(t, synced, "blocked custom-ref write should force v1 fallback")
+}
+
+// writeSettings writes .entire/settings.json with the given checkpoints_version
+// (empty string omits the option) into dir.
+func writeSettings(t *testing.T, dir, version string) {
+	t.Helper()
+	body := `{"enabled": true}`
+	if version != "" {
+		body = `{"enabled": true, "strategy_options": {"checkpoints_version": ` + version + `}}`
+	}
+	entireDir := filepath.Join(dir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, paths.SettingsFileName), []byte(body), 0o644))
+}
+
+// Not parallel: uses t.Chdir() so settings.Load resolves the test repo.
+func TestNewCommittedReadStore_SelectsRefByVersion(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
+	setV1Branch(t, repo, h)
+	t.Chdir(dir)
+
+	writeSettings(t, dir, "") // v1 only
+	v1Store := NewCommittedReadStore(context.Background(), repo)
+	assert.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), v1Store.CommittedReadRef())
+
+	writeSettings(t, dir, `"1.1"`)
+	v11Store := NewCommittedReadStore(context.Background(), repo)
+	assert.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), v11Store.CommittedReadRef())
+}
+
+// Not parallel: uses t.Chdir().
+func TestNewCommittedReadStore_ReadsMirroredData(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	commitFile(t, repo, dir, "README.md", "# Test", "init")
+	t.Chdir(dir)
+	writeSettings(t, dir, `"1.1"`)
+
+	// Write a committed checkpoint via the default v1 store.
+	cpID := id.MustCheckpointID("a1b2c3d4e5f6")
+	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("transcript line 1\n")),
+		Prompts:      []string{"initial prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}))
+
+	// The v1.1 read store sync-then-reads the same checkpoint without any
+	// separate mirror step, and the custom ref ends at the v1 tip.
+	readStore := NewCommittedReadStore(context.Background(), repo)
+	require.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), readStore.CommittedReadRef())
+
+	// The successful read-equivalence below already proves the factory
+	// sync-then-read populated the v1.1 ref from v1; the ref-position itself is
+	// covered by the TestSyncV1CustomRefForRead_* cases.
+	v1Summary, err := NewGitStore(repo).ReadCommitted(context.Background(), cpID)
+	require.NoError(t, err)
+	v11Summary, err := readStore.ReadCommitted(context.Background(), cpID)
+	require.NoError(t, err)
+	assert.Equal(t, v1Summary, v11Summary)
+}
+
+// Not parallel: uses t.Chdir().
+func TestNewCommittedReadStore_FallsBackToV1ForRemoteOnlyMetadata(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	commitFile(t, repo, dir, "README.md", "# Test", "init")
+	t.Chdir(dir)
+	writeSettings(t, dir, `"1.1"`)
+
+	cpID := id.MustCheckpointID("b1b2c3d4e5f6")
+	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-remote",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("remote transcript\n")),
+		Prompts:      []string{"remote prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}))
+
+	v1RefName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+	v1Ref, err := repo.Reference(v1RefName, true)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName), v1Ref.Hash())))
+	require.NoError(t, repo.Storer.RemoveReference(v1RefName))
+
+	readStore := NewCommittedReadStore(context.Background(), repo)
+	require.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), readStore.CommittedReadRef())
+
+	summary, err := readStore.ReadCommitted(context.Background(), cpID)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, cpID, summary.CheckpointID)
+}
+
+// Not parallel: uses t.Chdir().
+func TestNewCommittedReadStore_FallsBackToV1WhenCustomRefWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	commitFile(t, repo, dir, "README.md", "# Test", "init")
+	t.Chdir(dir)
+	writeSettings(t, dir, `"1.1"`)
+
+	cpID := id.MustCheckpointID("c1c2c3d4e5f6")
+	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-write-fails",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("transcript\n")),
+		Prompts:      []string{"prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "refs", "entire"), []byte("blocked"), 0o644))
+
+	readStore := NewCommittedReadStore(context.Background(), repo)
+	require.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), readStore.CommittedReadRef())
+
+	summary, err := readStore.ReadCommitted(context.Background(), cpID)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, cpID, summary.CheckpointID)
+}
+
+// Not parallel: uses t.Chdir().
+func TestNewCommittedReadStore_FallsBackToV1WhenCustomRefDiverges(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	divergedHash := commitFile(t, repo, dir, "README.md", "# Diverged", "worktree commit")
+	t.Chdir(dir)
+	writeSettings(t, dir, `"1.1"`)
+
+	cpID := id.MustCheckpointID("d1d2c3d4e5f6")
+	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-diverged",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("transcript\n")),
+		Prompts:      []string{"prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}))
+	setCustomRefHash(t, repo, divergedHash)
+
+	readStore := NewCommittedReadStore(context.Background(), repo)
+	require.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), readStore.CommittedReadRef())
+
+	summary, err := readStore.ReadCommitted(context.Background(), cpID)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, cpID, summary.CheckpointID)
+}

--- a/cmd/entire/cli/checkpoint/committed_read_store_test.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store_test.go
@@ -76,11 +76,28 @@ func TestSyncV1CustomRefForRead_SeedsWhenMissing(t *testing.T) {
 	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
 	setV1Branch(t, repo, h)
 
-	synced := syncV1CustomRefForRead(context.Background(), repo)
+	syncV1CustomRefForRead(context.Background(), repo)
 
-	require.True(t, synced, "custom ref sync should succeed")
 	got, ok := customRefHash(t, repo)
 	require.True(t, ok, "custom ref should be seeded from v1")
+	assert.Equal(t, h, got)
+}
+
+func TestSyncV1CustomRefForRead_SeedsFromOriginWhenLocalV1Missing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
+	// Only the origin remote-tracking branch exists (fresh clone), no local v1.
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName), h)))
+
+	syncV1CustomRefForRead(context.Background(), repo)
+
+	got, ok := customRefHash(t, repo)
+	require.True(t, ok, "custom ref should be seeded from origin v1 when local v1 is missing")
 	assert.Equal(t, h, got)
 }
 
@@ -94,9 +111,8 @@ func TestSyncV1CustomRefForRead_NoopWhenEqual(t *testing.T) {
 	setV1Branch(t, repo, h)
 	setCustomRefHash(t, repo, h)
 
-	synced := syncV1CustomRefForRead(context.Background(), repo)
+	syncV1CustomRefForRead(context.Background(), repo)
 
-	require.True(t, synced, "equal refs should be usable for reads")
 	got, _ := customRefHash(t, repo)
 	assert.Equal(t, h, got)
 }
@@ -113,9 +129,8 @@ func TestSyncV1CustomRefForRead_AdvancesWhenAncestor(t *testing.T) {
 	setV1Branch(t, repo, newHash)
 	require.NotEqual(t, old, newHash)
 
-	synced := syncV1CustomRefForRead(context.Background(), repo)
+	syncV1CustomRefForRead(context.Background(), repo)
 
-	require.True(t, synced, "ancestor custom ref should advance for reads")
 	got, _ := customRefHash(t, repo)
 	assert.Equal(t, newHash, got, "custom ref should advance to the v1 tip")
 }
@@ -133,30 +148,28 @@ func TestSyncV1CustomRefForRead_LeavesNonAncestorRef(t *testing.T) {
 	setV1Branch(t, repo, first)
 	setCustomRefHash(t, repo, second)
 
-	synced := syncV1CustomRefForRead(context.Background(), repo)
+	syncV1CustomRefForRead(context.Background(), repo)
 
-	require.False(t, synced, "non-ancestor custom ref should not be used for reads")
 	got, _ := customRefHash(t, repo)
 	assert.Equal(t, second, got, "non-ancestor custom ref must not be rewound")
 }
 
-func TestSyncV1CustomRefForRead_V1MissingNoOp(t *testing.T) {
+func TestSyncV1CustomRefForRead_NoV1TipNoOp(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
 	commitFile(t, repo, dir, "f.txt", "v1", "init")
-	// No v1 metadata branch set.
+	// No local or origin v1 metadata branch set.
 
-	synced := syncV1CustomRefForRead(context.Background(), repo)
+	syncV1CustomRefForRead(context.Background(), repo)
 
-	require.False(t, synced, "missing v1 branch should fall back to the v1 store")
 	_, ok := customRefHash(t, repo)
-	assert.False(t, ok, "custom ref must not be created when the v1 branch is absent")
+	assert.False(t, ok, "custom ref must not be created when no v1 tip is available")
 }
 
-func TestSyncV1CustomRefForRead_WriteFailureReturnsFalse(t *testing.T) {
+func TestSyncV1CustomRefForRead_WriteFailureLeavesRefUnset(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
@@ -165,10 +178,14 @@ func TestSyncV1CustomRefForRead_WriteFailureReturnsFalse(t *testing.T) {
 	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
 	setV1Branch(t, repo, h)
 
+	// Block creation of refs/entire/* by occupying the path with a file.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "refs", "entire"), []byte("blocked"), 0o644))
 
-	synced := syncV1CustomRefForRead(context.Background(), repo)
-	require.False(t, synced, "blocked custom-ref write should force v1 fallback")
+	// Must not panic; the custom ref simply stays unset.
+	syncV1CustomRefForRead(context.Background(), repo)
+
+	_, ok := customRefHash(t, repo)
+	assert.False(t, ok, "custom ref must not exist when the write was blocked")
 }
 
 // writeSettings writes .entire/settings.json with the given checkpoints_version
@@ -240,8 +257,13 @@ func TestNewCommittedReadStore_ReadsMirroredData(t *testing.T) {
 	assert.Equal(t, v1Summary, v11Summary)
 }
 
+// TestNewCommittedReadStore_ReadsV11ForRemoteOnlyMetadata verifies that on a
+// repo whose v1 metadata exists only as origin/entire/checkpoints/v1 (no local
+// v1 branch), v1.1 mode seeds the custom ref from the remote-tracking tip and
+// reads through the v1.1 ref — without falling back to a v1 store.
+//
 // Not parallel: uses t.Chdir().
-func TestNewCommittedReadStore_FallsBackToV1ForRemoteOnlyMetadata(t *testing.T) {
+func TestNewCommittedReadStore_ReadsV11ForRemoteOnlyMetadata(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	repo, err := git.PlainOpen(dir)
@@ -261,6 +283,8 @@ func TestNewCommittedReadStore_FallsBackToV1ForRemoteOnlyMetadata(t *testing.T) 
 		AuthorEmail:  "test@test.com",
 	}))
 
+	// Move the v1 metadata to origin-only: copy the local branch to the remote
+	// tracking ref, then remove the local branch.
 	v1RefName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 	v1Ref, err := repo.Reference(v1RefName, true)
 	require.NoError(t, err)
@@ -269,7 +293,8 @@ func TestNewCommittedReadStore_FallsBackToV1ForRemoteOnlyMetadata(t *testing.T) 
 	require.NoError(t, repo.Storer.RemoveReference(v1RefName))
 
 	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), readStore.CommittedReadRef())
+	require.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), readStore.CommittedReadRef(),
+		"v1.1 mode must read through the custom ref, not fall back to v1")
 
 	summary, err := readStore.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, err)
@@ -277,8 +302,12 @@ func TestNewCommittedReadStore_FallsBackToV1ForRemoteOnlyMetadata(t *testing.T) 
 	assert.Equal(t, cpID, summary.CheckpointID)
 }
 
+// TestNewCommittedReadStore_BindsV11WhenSyncFails verifies that when the v1.1
+// custom ref cannot be written (sync failure), v1.1 mode still binds reads to
+// the custom ref rather than falling back to v1.
+//
 // Not parallel: uses t.Chdir().
-func TestNewCommittedReadStore_FallsBackToV1WhenCustomRefWriteFails(t *testing.T) {
+func TestNewCommittedReadStore_BindsV11WhenSyncFails(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	repo, err := git.PlainOpen(dir)
@@ -297,19 +326,25 @@ func TestNewCommittedReadStore_FallsBackToV1WhenCustomRefWriteFails(t *testing.T
 		AuthorName:   "Test",
 		AuthorEmail:  "test@test.com",
 	}))
+	// Block creation of the v1.1 custom ref so the sync cannot seed it.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "refs", "entire"), []byte("blocked"), 0o644))
 
 	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), readStore.CommittedReadRef())
+	require.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), readStore.CommittedReadRef(),
+		"v1.1 mode must not fall back to v1 even when the custom ref cannot be synced")
 
+	// With no v1.1 ref available and no v1 fallback, the read finds nothing
+	// rather than silently returning the v1 checkpoint.
 	summary, err := readStore.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, err)
-	require.NotNil(t, summary)
-	assert.Equal(t, cpID, summary.CheckpointID)
+	assert.Nil(t, summary, "read must not fall back to v1 when the custom ref is unavailable")
 }
 
+// TestNewCommittedReadStore_BindsV11WhenCustomRefDiverges verifies that a
+// diverged custom ref is read as-is (bound to v1.1), never falling back to v1.
+//
 // Not parallel: uses t.Chdir().
-func TestNewCommittedReadStore_FallsBackToV1WhenCustomRefDiverges(t *testing.T) {
+func TestNewCommittedReadStore_BindsV11WhenCustomRefDiverges(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	repo, err := git.PlainOpen(dir)
@@ -328,13 +363,16 @@ func TestNewCommittedReadStore_FallsBackToV1WhenCustomRefDiverges(t *testing.T) 
 		AuthorName:   "Test",
 		AuthorEmail:  "test@test.com",
 	}))
+	// Point the custom ref at an unrelated commit that is not an ancestor of v1.
 	setCustomRefHash(t, repo, divergedHash)
 
 	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), readStore.CommittedReadRef())
+	require.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), readStore.CommittedReadRef(),
+		"v1.1 mode must read the diverged custom ref, not fall back to v1")
 
+	// The checkpoint lives on v1, not on the diverged custom ref, so the v1.1
+	// read does not find it (no v1 fallback).
 	summary, err := readStore.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, err)
-	require.NotNil(t, summary)
-	assert.Equal(t, cpID, summary.CheckpointID)
+	assert.Nil(t, summary, "diverged custom ref read must not fall back to v1")
 }

--- a/cmd/entire/cli/checkpoint/committed_read_store_test.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store_test.go
@@ -18,6 +18,17 @@ import (
 	"github.com/entireio/cli/redact"
 )
 
+// newTestRepo creates an isolated repo with a single "init" commit and returns
+// its directory, an open handle, and the commit hash.
+func newTestRepo(t *testing.T) (string, *git.Repository, plumbing.Hash) {
+	t.Helper()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	return dir, repo, commitFile(t, repo, dir, "f.txt", "init", "init")
+}
+
 // commitFile adds path with content to the worktree and commits it, returning
 // the new commit hash. Successive calls build a linear ancestry chain.
 func commitFile(t *testing.T, repo *git.Repository, dir, path, content, msg string) plumbing.Hash {
@@ -34,158 +45,48 @@ func commitFile(t *testing.T, repo *git.Repository, dir, path, content, msg stri
 	return h
 }
 
-func setV1Branch(t *testing.T, repo *git.Repository, hash plumbing.Hash) {
+func setRef(t *testing.T, repo *git.Repository, name plumbing.ReferenceName, hash plumbing.Hash) {
 	t.Helper()
-	require.NoError(t, repo.Storer.SetReference(
-		plumbing.NewHashReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), hash)))
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(name, hash)))
 }
 
-func setCustomRefHash(t *testing.T, repo *git.Repository, hash plumbing.Hash) {
-	t.Helper()
-	require.NoError(t, repo.Storer.SetReference(
-		plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), hash)))
+func v1BranchRef() plumbing.ReferenceName {
+	return plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+}
+func customRef() plumbing.ReferenceName { return plumbing.ReferenceName(paths.MetadataRefName) }
+func originV1Ref() plumbing.ReferenceName {
+	return plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName)
 }
 
 func customRefHash(t *testing.T, repo *git.Repository) (plumbing.Hash, bool) {
 	t.Helper()
-	ref, err := repo.Reference(plumbing.ReferenceName(paths.MetadataRefName), true)
+	ref, err := repo.Reference(customRef(), true)
 	if err != nil {
 		return plumbing.ZeroHash, false
 	}
 	return ref.Hash(), true
 }
 
-func TestNewGitStore_DefaultsToV1Branch(t *testing.T) {
-	t.Parallel()
-	store := NewGitStore(nil)
-	assert.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), store.CommittedReadRef())
+// writeV1Checkpoint writes a committed checkpoint to the v1 branch via the
+// default store.
+func writeV1Checkpoint(t *testing.T, repo *git.Repository, cpID id.CheckpointID, sessionID string) {
+	t.Helper()
+	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    sessionID,
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("transcript\n")),
+		Prompts:      []string{"prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}))
 }
 
-func TestNewGitStoreWithRef(t *testing.T) {
-	t.Parallel()
-	custom := plumbing.ReferenceName(paths.MetadataRefName)
-	assert.Equal(t, custom, NewGitStoreWithRef(nil, custom).CommittedReadRef())
-}
-
-func TestSyncV1CustomRefForRead_SeedsWhenMissing(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
-	setV1Branch(t, repo, h)
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, ok := customRefHash(t, repo)
-	require.True(t, ok, "custom ref should be seeded from v1")
-	assert.Equal(t, h, got)
-}
-
-func TestSyncV1CustomRefForRead_SeedsFromOriginWhenLocalV1Missing(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
-	// Only the origin remote-tracking branch exists (fresh clone), no local v1.
-	require.NoError(t, repo.Storer.SetReference(
-		plumbing.NewHashReference(plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName), h)))
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, ok := customRefHash(t, repo)
-	require.True(t, ok, "custom ref should be seeded from origin v1 when local v1 is missing")
-	assert.Equal(t, h, got)
-}
-
-func TestSyncV1CustomRefForRead_NoopWhenEqual(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
-	setV1Branch(t, repo, h)
-	setCustomRefHash(t, repo, h)
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, _ := customRefHash(t, repo)
-	assert.Equal(t, h, got)
-}
-
-func TestSyncV1CustomRefForRead_AdvancesWhenAncestor(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	old := commitFile(t, repo, dir, "f.txt", "v1", "init")
-	setCustomRefHash(t, repo, old)
-	newHash := commitFile(t, repo, dir, "f2.txt", "more", "second")
-	setV1Branch(t, repo, newHash)
-	require.NotEqual(t, old, newHash)
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, _ := customRefHash(t, repo)
-	assert.Equal(t, newHash, got, "custom ref should advance to the v1 tip")
-}
-
-func TestSyncV1CustomRefForRead_LeavesNonAncestorRef(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	first := commitFile(t, repo, dir, "f.txt", "v1", "init")
-	second := commitFile(t, repo, dir, "f2.txt", "more", "second")
-	// v1 points at the parent while the custom ref is ahead at the child: the
-	// custom ref is not an ancestor of v1, so it must be left untouched.
-	setV1Branch(t, repo, first)
-	setCustomRefHash(t, repo, second)
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, _ := customRefHash(t, repo)
-	assert.Equal(t, second, got, "non-ancestor custom ref must not be rewound")
-}
-
-func TestSyncV1CustomRefForRead_NoV1TipNoOp(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	commitFile(t, repo, dir, "f.txt", "v1", "init")
-	// No local or origin v1 metadata branch set.
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	_, ok := customRefHash(t, repo)
-	assert.False(t, ok, "custom ref must not be created when no v1 tip is available")
-}
-
-func TestSyncV1CustomRefForRead_WriteFailureLeavesRefUnset(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
-	setV1Branch(t, repo, h)
-
-	// Block creation of refs/entire/* by occupying the path with a file.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "refs", "entire"), []byte("blocked"), 0o644))
-
-	// Must not panic; the custom ref simply stays unset.
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	_, ok := customRefHash(t, repo)
-	assert.False(t, ok, "custom ref must not exist when the write was blocked")
+// enableV11 chdirs into dir and writes settings opting into checkpoints v1.1.
+func enableV11(t *testing.T, dir string) {
+	t.Helper()
+	t.Chdir(dir)
+	writeSettings(t, dir, `"1.1"`)
 }
 
 // writeSettings writes .entire/settings.json with the given checkpoints_version
@@ -201,55 +102,134 @@ func writeSettings(t *testing.T, dir, version string) {
 	require.NoError(t, os.WriteFile(filepath.Join(entireDir, paths.SettingsFileName), []byte(body), 0o644))
 }
 
+func TestNewGitStore_DefaultsToV1Branch(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, v1BranchRef(), NewGitStore(nil).CommittedReadRef())
+}
+
+func TestNewGitStoreWithRef(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, customRef(), NewGitStoreWithRef(nil, customRef()).CommittedReadRef())
+}
+
+func TestSyncV1CustomRefForRead_SeedsWhenMissing(t *testing.T) {
+	t.Parallel()
+	_, repo, h := newTestRepo(t)
+	setRef(t, repo, v1BranchRef(), h)
+
+	syncV1CustomRefForRead(context.Background(), repo)
+
+	got, ok := customRefHash(t, repo)
+	require.True(t, ok, "custom ref should be seeded from v1")
+	assert.Equal(t, h, got)
+}
+
+func TestSyncV1CustomRefForRead_SeedsFromOriginWhenLocalV1Missing(t *testing.T) {
+	t.Parallel()
+	_, repo, h := newTestRepo(t)
+	setRef(t, repo, originV1Ref(), h) // only the remote-tracking branch exists
+
+	syncV1CustomRefForRead(context.Background(), repo)
+
+	got, ok := customRefHash(t, repo)
+	require.True(t, ok, "custom ref should be seeded from origin v1")
+	assert.Equal(t, h, got)
+}
+
+func TestSyncV1CustomRefForRead_NoopWhenEqual(t *testing.T) {
+	t.Parallel()
+	_, repo, h := newTestRepo(t)
+	setRef(t, repo, v1BranchRef(), h)
+	setRef(t, repo, customRef(), h)
+
+	syncV1CustomRefForRead(context.Background(), repo)
+
+	got, _ := customRefHash(t, repo)
+	assert.Equal(t, h, got)
+}
+
+func TestSyncV1CustomRefForRead_AdvancesWhenAncestor(t *testing.T) {
+	t.Parallel()
+	dir, repo, old := newTestRepo(t)
+	setRef(t, repo, customRef(), old)
+	newHash := commitFile(t, repo, dir, "f2.txt", "more", "second")
+	setRef(t, repo, v1BranchRef(), newHash)
+
+	syncV1CustomRefForRead(context.Background(), repo)
+
+	got, _ := customRefHash(t, repo)
+	assert.Equal(t, newHash, got, "custom ref should advance to the v1 tip")
+}
+
+func TestSyncV1CustomRefForRead_LeavesNonAncestorRef(t *testing.T) {
+	t.Parallel()
+	dir, repo, first := newTestRepo(t)
+	second := commitFile(t, repo, dir, "f2.txt", "more", "second")
+	// v1 at the parent, custom ref ahead at the child: not an ancestor of v1.
+	setRef(t, repo, v1BranchRef(), first)
+	setRef(t, repo, customRef(), second)
+
+	syncV1CustomRefForRead(context.Background(), repo)
+
+	got, _ := customRefHash(t, repo)
+	assert.Equal(t, second, got, "non-ancestor custom ref must not be rewound")
+}
+
+func TestSyncV1CustomRefForRead_NoV1TipNoOp(t *testing.T) {
+	t.Parallel()
+	_, repo, _ := newTestRepo(t) // no v1 branch, local or origin
+
+	syncV1CustomRefForRead(context.Background(), repo)
+
+	_, ok := customRefHash(t, repo)
+	assert.False(t, ok, "custom ref must not be created without a v1 tip")
+}
+
+func TestSyncV1CustomRefForRead_WriteFailureLeavesRefUnset(t *testing.T) {
+	t.Parallel()
+	dir, repo, h := newTestRepo(t)
+	setRef(t, repo, v1BranchRef(), h)
+	blockCustomRefWrite(t, dir)
+
+	syncV1CustomRefForRead(context.Background(), repo) // must not panic
+
+	_, ok := customRefHash(t, repo)
+	assert.False(t, ok, "custom ref must not exist when the write was blocked")
+}
+
+// blockCustomRefWrite occupies refs/entire with a file so refs/entire/* cannot
+// be created.
+func blockCustomRefWrite(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "refs", "entire"), []byte("blocked"), 0o644))
+}
+
 // Not parallel: uses t.Chdir() so settings.Load resolves the test repo.
 func TestNewCommittedReadStore_SelectsRefByVersion(t *testing.T) {
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	h := commitFile(t, repo, dir, "f.txt", "v1", "init")
-	setV1Branch(t, repo, h)
+	dir, repo, h := newTestRepo(t)
+	setRef(t, repo, v1BranchRef(), h)
 	t.Chdir(dir)
 
 	writeSettings(t, dir, "") // v1 only
-	v1Store := NewCommittedReadStore(context.Background(), repo)
-	assert.Equal(t, plumbing.NewBranchReferenceName(paths.MetadataBranchName), v1Store.CommittedReadRef())
+	assert.Equal(t, v1BranchRef(), NewCommittedReadStore(context.Background(), repo).CommittedReadRef())
 
 	writeSettings(t, dir, `"1.1"`)
-	v11Store := NewCommittedReadStore(context.Background(), repo)
-	assert.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), v11Store.CommittedReadRef())
+	assert.Equal(t, customRef(), NewCommittedReadStore(context.Background(), repo).CommittedReadRef())
 }
 
 // Not parallel: uses t.Chdir().
 func TestNewCommittedReadStore_ReadsMirroredData(t *testing.T) {
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	commitFile(t, repo, dir, "README.md", "# Test", "init")
-	t.Chdir(dir)
-	writeSettings(t, dir, `"1.1"`)
+	dir, repo, _ := newTestRepo(t)
+	enableV11(t, dir)
 
-	// Write a committed checkpoint via the default v1 store.
 	cpID := id.MustCheckpointID("a1b2c3d4e5f6")
-	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "session-001",
-		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted([]byte("transcript line 1\n")),
-		Prompts:      []string{"initial prompt"},
-		AuthorName:   "Test",
-		AuthorEmail:  "test@test.com",
-	}))
+	writeV1Checkpoint(t, repo, cpID, "session-001")
 
-	// The v1.1 read store sync-then-reads the same checkpoint without any
-	// separate mirror step, and the custom ref ends at the v1 tip.
+	// The v1.1 read store sync-then-reads the same checkpoint; equivalence below
+	// proves the custom ref was populated from v1.
 	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), readStore.CommittedReadRef())
+	require.Equal(t, customRef(), readStore.CommittedReadRef())
 
-	// The successful read-equivalence below already proves the factory
-	// sync-then-read populated the v1.1 ref from v1; the ref-position itself is
-	// covered by the TestSyncV1CustomRefForRead_* cases.
 	v1Summary, err := NewGitStore(repo).ReadCommitted(context.Background(), cpID)
 	require.NoError(t, err)
 	v11Summary, err := readStore.ReadCommitted(context.Background(), cpID)
@@ -257,44 +237,25 @@ func TestNewCommittedReadStore_ReadsMirroredData(t *testing.T) {
 	assert.Equal(t, v1Summary, v11Summary)
 }
 
-// TestNewCommittedReadStore_ReadsV11ForRemoteOnlyMetadata verifies that on a
-// repo whose v1 metadata exists only as origin/entire/checkpoints/v1 (no local
-// v1 branch), v1.1 mode seeds the custom ref from the remote-tracking tip and
-// reads through the v1.1 ref — without falling back to a v1 store.
+// v1 metadata exists only as origin/entire/checkpoints/v1: v1.1 mode seeds the
+// custom ref from the remote tip and reads through it, never falling back to v1.
 //
 // Not parallel: uses t.Chdir().
 func TestNewCommittedReadStore_ReadsV11ForRemoteOnlyMetadata(t *testing.T) {
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	commitFile(t, repo, dir, "README.md", "# Test", "init")
-	t.Chdir(dir)
-	writeSettings(t, dir, `"1.1"`)
+	dir, repo, _ := newTestRepo(t)
+	enableV11(t, dir)
 
 	cpID := id.MustCheckpointID("b1b2c3d4e5f6")
-	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "session-remote",
-		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted([]byte("remote transcript\n")),
-		Prompts:      []string{"remote prompt"},
-		AuthorName:   "Test",
-		AuthorEmail:  "test@test.com",
-	}))
+	writeV1Checkpoint(t, repo, cpID, "session-remote")
 
-	// Move the v1 metadata to origin-only: copy the local branch to the remote
-	// tracking ref, then remove the local branch.
-	v1RefName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
-	v1Ref, err := repo.Reference(v1RefName, true)
+	// Make v1 metadata origin-only: mirror the branch to the remote ref, drop it.
+	v1Ref, err := repo.Reference(v1BranchRef(), true)
 	require.NoError(t, err)
-	require.NoError(t, repo.Storer.SetReference(
-		plumbing.NewHashReference(plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName), v1Ref.Hash())))
-	require.NoError(t, repo.Storer.RemoveReference(v1RefName))
+	setRef(t, repo, originV1Ref(), v1Ref.Hash())
+	require.NoError(t, repo.Storer.RemoveReference(v1BranchRef()))
 
 	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), readStore.CommittedReadRef(),
-		"v1.1 mode must read through the custom ref, not fall back to v1")
+	require.Equal(t, customRef(), readStore.CommittedReadRef(), "must read the custom ref, not fall back to v1")
 
 	summary, err := readStore.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, err)
@@ -302,76 +263,41 @@ func TestNewCommittedReadStore_ReadsV11ForRemoteOnlyMetadata(t *testing.T) {
 	assert.Equal(t, cpID, summary.CheckpointID)
 }
 
-// TestNewCommittedReadStore_BindsV11WhenSyncFails verifies that when the v1.1
-// custom ref cannot be written (sync failure), v1.1 mode still binds reads to
-// the custom ref rather than falling back to v1.
+// When the custom ref cannot be written, v1.1 mode still binds reads to it (no
+// v1 fallback), so a v1-only checkpoint is not found.
 //
 // Not parallel: uses t.Chdir().
 func TestNewCommittedReadStore_BindsV11WhenSyncFails(t *testing.T) {
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	commitFile(t, repo, dir, "README.md", "# Test", "init")
-	t.Chdir(dir)
-	writeSettings(t, dir, `"1.1"`)
+	dir, repo, _ := newTestRepo(t)
+	enableV11(t, dir)
 
 	cpID := id.MustCheckpointID("c1c2c3d4e5f6")
-	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "session-write-fails",
-		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted([]byte("transcript\n")),
-		Prompts:      []string{"prompt"},
-		AuthorName:   "Test",
-		AuthorEmail:  "test@test.com",
-	}))
-	// Block creation of the v1.1 custom ref so the sync cannot seed it.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "refs", "entire"), []byte("blocked"), 0o644))
+	writeV1Checkpoint(t, repo, cpID, "session-write-fails")
+	blockCustomRefWrite(t, dir)
 
 	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), readStore.CommittedReadRef(),
-		"v1.1 mode must not fall back to v1 even when the custom ref cannot be synced")
+	require.Equal(t, customRef(), readStore.CommittedReadRef(), "must not fall back to v1 when sync fails")
 
-	// With no v1.1 ref available and no v1 fallback, the read finds nothing
-	// rather than silently returning the v1 checkpoint.
 	summary, err := readStore.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, err)
-	assert.Nil(t, summary, "read must not fall back to v1 when the custom ref is unavailable")
+	assert.Nil(t, summary, "must not fall back to v1 when the custom ref is unavailable")
 }
 
-// TestNewCommittedReadStore_BindsV11WhenCustomRefDiverges verifies that a
-// diverged custom ref is read as-is (bound to v1.1), never falling back to v1.
+// A diverged custom ref is read as-is; the v1-only checkpoint is not found.
 //
 // Not parallel: uses t.Chdir().
 func TestNewCommittedReadStore_BindsV11WhenCustomRefDiverges(t *testing.T) {
-	dir := t.TempDir()
-	testutil.InitRepo(t, dir)
-	repo, err := git.PlainOpen(dir)
-	require.NoError(t, err)
-	divergedHash := commitFile(t, repo, dir, "README.md", "# Diverged", "worktree commit")
-	t.Chdir(dir)
-	writeSettings(t, dir, `"1.1"`)
+	dir, repo, _ := newTestRepo(t)
+	divergedHash := commitFile(t, repo, dir, "other.txt", "diverged", "worktree commit")
+	enableV11(t, dir)
 
 	cpID := id.MustCheckpointID("d1d2c3d4e5f6")
-	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
-		CheckpointID: cpID,
-		SessionID:    "session-diverged",
-		Strategy:     "manual-commit",
-		Transcript:   redact.AlreadyRedacted([]byte("transcript\n")),
-		Prompts:      []string{"prompt"},
-		AuthorName:   "Test",
-		AuthorEmail:  "test@test.com",
-	}))
-	// Point the custom ref at an unrelated commit that is not an ancestor of v1.
-	setCustomRefHash(t, repo, divergedHash)
+	writeV1Checkpoint(t, repo, cpID, "session-diverged")
+	setRef(t, repo, customRef(), divergedHash) // not an ancestor of v1
 
 	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, plumbing.ReferenceName(paths.MetadataRefName), readStore.CommittedReadRef(),
-		"v1.1 mode must read the diverged custom ref, not fall back to v1")
+	require.Equal(t, customRef(), readStore.CommittedReadRef(), "must read the diverged custom ref, not fall back to v1")
 
-	// The checkpoint lives on v1, not on the diverged custom ref, so the v1.1
-	// read does not find it (no v1 fallback).
 	summary, err := readStore.ReadCommitted(context.Background(), cpID)
 	require.NoError(t, err)
 	assert.Nil(t, summary, "diverged custom ref read must not fall back to v1")

--- a/cmd/entire/cli/checkpoint/committed_read_store_test.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store_test.go
@@ -29,8 +29,7 @@ func newTestRepo(t *testing.T) (string, *git.Repository, plumbing.Hash) {
 	return dir, repo, commitFile(t, repo, dir, "f.txt", "init", "init")
 }
 
-// commitFile adds path with content to the worktree and commits it, returning
-// the new commit hash. Successive calls build a linear ancestry chain.
+// commitFile commits content to path; successive calls build a linear chain.
 func commitFile(t *testing.T, repo *git.Repository, dir, path, content, msg string) plumbing.Hash {
 	t.Helper()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, path), []byte(content), 0o644))
@@ -38,9 +37,7 @@ func commitFile(t *testing.T, repo *git.Repository, dir, path, content, msg stri
 	require.NoError(t, err)
 	_, err = wt.Add(path)
 	require.NoError(t, err)
-	h, err := wt.Commit(msg, &git.CommitOptions{
-		Author: &object.Signature{Name: "Test", Email: "test@test.com"},
-	})
+	h, err := wt.Commit(msg, &git.CommitOptions{Author: &object.Signature{Name: "Test", Email: "test@test.com"}})
 	require.NoError(t, err)
 	return h
 }
@@ -67,13 +64,12 @@ func customRefHash(t *testing.T, repo *git.Repository) (plumbing.Hash, bool) {
 	return ref.Hash(), true
 }
 
-// writeV1Checkpoint writes a committed checkpoint to the v1 branch via the
-// default store.
-func writeV1Checkpoint(t *testing.T, repo *git.Repository, cpID id.CheckpointID, sessionID string) {
+// writeV1Checkpoint writes a committed checkpoint to the v1 branch.
+func writeV1Checkpoint(t *testing.T, repo *git.Repository, cpID id.CheckpointID) {
 	t.Helper()
 	require.NoError(t, NewGitStore(repo).WriteCommitted(context.Background(), WriteCommittedOptions{
 		CheckpointID: cpID,
-		SessionID:    sessionID,
+		SessionID:    "session",
 		Strategy:     "manual-commit",
 		Transcript:   redact.AlreadyRedacted([]byte("transcript\n")),
 		Prompts:      []string{"prompt"},
@@ -82,126 +78,91 @@ func writeV1Checkpoint(t *testing.T, repo *git.Repository, cpID id.CheckpointID,
 	}))
 }
 
-// enableV11 chdirs into dir and writes settings opting into checkpoints v1.1.
+// enableV11 chdirs into dir and opts into checkpoints v1.1.
 func enableV11(t *testing.T, dir string) {
 	t.Helper()
 	t.Chdir(dir)
 	writeSettings(t, dir, `"1.1"`)
 }
 
-// writeSettings writes .entire/settings.json with the given checkpoints_version
-// (empty string omits the option) into dir.
+// writeSettings writes .entire/settings.json (empty version omits the option).
 func writeSettings(t *testing.T, dir, version string) {
 	t.Helper()
 	body := `{"enabled": true}`
 	if version != "" {
 		body = `{"enabled": true, "strategy_options": {"checkpoints_version": ` + version + `}}`
 	}
-	entireDir := filepath.Join(dir, ".entire")
-	require.NoError(t, os.MkdirAll(entireDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(entireDir, paths.SettingsFileName), []byte(body), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".entire", paths.SettingsFileName), []byte(body), 0o644))
 }
 
-func TestNewGitStore_DefaultsToV1Branch(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, v1BranchRef(), NewGitStore(nil).CommittedReadRef())
-}
-
-func TestNewGitStoreWithRef(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, customRef(), NewGitStoreWithRef(nil, customRef()).CommittedReadRef())
-}
-
-func TestSyncV1CustomRefForRead_SeedsWhenMissing(t *testing.T) {
-	t.Parallel()
-	_, repo, h := newTestRepo(t)
-	setRef(t, repo, v1BranchRef(), h)
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, ok := customRefHash(t, repo)
-	require.True(t, ok, "custom ref should be seeded from v1")
-	assert.Equal(t, h, got)
-}
-
-func TestSyncV1CustomRefForRead_SeedsFromOriginWhenLocalV1Missing(t *testing.T) {
-	t.Parallel()
-	_, repo, h := newTestRepo(t)
-	setRef(t, repo, originV1Ref(), h) // only the remote-tracking branch exists
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, ok := customRefHash(t, repo)
-	require.True(t, ok, "custom ref should be seeded from origin v1")
-	assert.Equal(t, h, got)
-}
-
-func TestSyncV1CustomRefForRead_NoopWhenEqual(t *testing.T) {
-	t.Parallel()
-	_, repo, h := newTestRepo(t)
-	setRef(t, repo, v1BranchRef(), h)
-	setRef(t, repo, customRef(), h)
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, _ := customRefHash(t, repo)
-	assert.Equal(t, h, got)
-}
-
-func TestSyncV1CustomRefForRead_AdvancesWhenAncestor(t *testing.T) {
-	t.Parallel()
-	dir, repo, old := newTestRepo(t)
-	setRef(t, repo, customRef(), old)
-	newHash := commitFile(t, repo, dir, "f2.txt", "more", "second")
-	setRef(t, repo, v1BranchRef(), newHash)
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, _ := customRefHash(t, repo)
-	assert.Equal(t, newHash, got, "custom ref should advance to the v1 tip")
-}
-
-func TestSyncV1CustomRefForRead_LeavesNonAncestorRef(t *testing.T) {
-	t.Parallel()
-	dir, repo, first := newTestRepo(t)
-	second := commitFile(t, repo, dir, "f2.txt", "more", "second")
-	// v1 at the parent, custom ref ahead at the child: not an ancestor of v1.
-	setRef(t, repo, v1BranchRef(), first)
-	setRef(t, repo, customRef(), second)
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	got, _ := customRefHash(t, repo)
-	assert.Equal(t, second, got, "non-ancestor custom ref must not be rewound")
-}
-
-func TestSyncV1CustomRefForRead_NoV1TipNoOp(t *testing.T) {
-	t.Parallel()
-	_, repo, _ := newTestRepo(t) // no v1 branch, local or origin
-
-	syncV1CustomRefForRead(context.Background(), repo)
-
-	_, ok := customRefHash(t, repo)
-	assert.False(t, ok, "custom ref must not be created without a v1 tip")
-}
-
-func TestSyncV1CustomRefForRead_WriteFailureLeavesRefUnset(t *testing.T) {
-	t.Parallel()
-	dir, repo, h := newTestRepo(t)
-	setRef(t, repo, v1BranchRef(), h)
-	blockCustomRefWrite(t, dir)
-
-	syncV1CustomRefForRead(context.Background(), repo) // must not panic
-
-	_, ok := customRefHash(t, repo)
-	assert.False(t, ok, "custom ref must not exist when the write was blocked")
-}
-
-// blockCustomRefWrite occupies refs/entire with a file so refs/entire/* cannot
-// be created.
+// blockCustomRefWrite occupies refs/entire with a file so refs/entire/* writes fail.
 func blockCustomRefWrite(t *testing.T, dir string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "refs", "entire"), []byte("blocked"), 0o644))
+}
+
+func TestGitStore_CommittedReadRef(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, v1BranchRef(), NewGitStore(nil).CommittedReadRef())
+	assert.Equal(t, customRef(), NewGitStoreWithRef(nil, customRef()).CommittedReadRef())
+}
+
+func TestSyncV1CustomRefForRead(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, dir string, repo *git.Repository, init plumbing.Hash) (want plumbing.Hash, exists bool)
+	}{
+		{"seeds from local v1 when missing", func(t *testing.T, _ string, repo *git.Repository, init plumbing.Hash) (plumbing.Hash, bool) {
+			setRef(t, repo, v1BranchRef(), init)
+			return init, true
+		}},
+		{"seeds from origin when local v1 missing", func(t *testing.T, _ string, repo *git.Repository, init plumbing.Hash) (plumbing.Hash, bool) {
+			setRef(t, repo, originV1Ref(), init)
+			return init, true
+		}},
+		{"no-op when equal", func(t *testing.T, _ string, repo *git.Repository, init plumbing.Hash) (plumbing.Hash, bool) {
+			setRef(t, repo, v1BranchRef(), init)
+			setRef(t, repo, customRef(), init)
+			return init, true
+		}},
+		{"advances when ancestor", func(t *testing.T, dir string, repo *git.Repository, init plumbing.Hash) (plumbing.Hash, bool) {
+			setRef(t, repo, customRef(), init)
+			newHash := commitFile(t, repo, dir, "f2.txt", "more", "second")
+			setRef(t, repo, v1BranchRef(), newHash)
+			return newHash, true
+		}},
+		{"leaves non-ancestor ref", func(t *testing.T, dir string, repo *git.Repository, init plumbing.Hash) (plumbing.Hash, bool) {
+			ahead := commitFile(t, repo, dir, "f2.txt", "more", "second")
+			setRef(t, repo, v1BranchRef(), init) // parent
+			setRef(t, repo, customRef(), ahead)  // child, not an ancestor of v1
+			return ahead, true
+		}},
+		{"no v1 tip", func(_ *testing.T, _ string, _ *git.Repository, _ plumbing.Hash) (plumbing.Hash, bool) {
+			return plumbing.ZeroHash, false
+		}},
+		{"write failure leaves ref unset", func(t *testing.T, dir string, repo *git.Repository, init plumbing.Hash) (plumbing.Hash, bool) {
+			setRef(t, repo, v1BranchRef(), init)
+			blockCustomRefWrite(t, dir)
+			return plumbing.ZeroHash, false
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir, repo, init := newTestRepo(t)
+			want, exists := tt.setup(t, dir, repo, init)
+
+			syncV1CustomRefForRead(context.Background(), repo)
+
+			got, ok := customRefHash(t, repo)
+			require.Equal(t, exists, ok)
+			if exists {
+				assert.Equal(t, want, got)
+			}
+		})
+	}
 }
 
 // Not parallel: uses t.Chdir() so settings.Load resolves the test repo.
@@ -217,88 +178,50 @@ func TestNewCommittedReadStore_SelectsRefByVersion(t *testing.T) {
 	assert.Equal(t, customRef(), NewCommittedReadStore(context.Background(), repo).CommittedReadRef())
 }
 
-// Not parallel: uses t.Chdir().
-func TestNewCommittedReadStore_ReadsMirroredData(t *testing.T) {
-	dir, repo, _ := newTestRepo(t)
-	enableV11(t, dir)
-
-	cpID := id.MustCheckpointID("a1b2c3d4e5f6")
-	writeV1Checkpoint(t, repo, cpID, "session-001")
-
-	// The v1.1 read store sync-then-reads the same checkpoint; equivalence below
-	// proves the custom ref was populated from v1.
-	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, customRef(), readStore.CommittedReadRef())
-
-	v1Summary, err := NewGitStore(repo).ReadCommitted(context.Background(), cpID)
-	require.NoError(t, err)
-	v11Summary, err := readStore.ReadCommitted(context.Background(), cpID)
-	require.NoError(t, err)
-	assert.Equal(t, v1Summary, v11Summary)
-}
-
-// v1 metadata exists only as origin/entire/checkpoints/v1: v1.1 mode seeds the
-// custom ref from the remote tip and reads through it, never falling back to v1.
+// TestNewCommittedReadStore_V11Reads checks that v1.1 mode always reads through
+// the custom ref (never falling back to v1): it finds a checkpoint when the ref
+// can be synced to v1, and finds nothing when it cannot.
 //
-// Not parallel: uses t.Chdir().
-func TestNewCommittedReadStore_ReadsV11ForRemoteOnlyMetadata(t *testing.T) {
-	dir, repo, _ := newTestRepo(t)
-	enableV11(t, dir)
+// Not parallel: subtests use t.Chdir().
+func TestNewCommittedReadStore_V11Reads(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(t *testing.T, dir string, repo *git.Repository)
+		wantFound bool
+	}{
+		{"reads v1 data via custom ref", func(_ *testing.T, _ string, _ *git.Repository) {}, true},
+		{"reads remote-only metadata", func(t *testing.T, _ string, repo *git.Repository) {
+			ref, err := repo.Reference(v1BranchRef(), true)
+			require.NoError(t, err)
+			setRef(t, repo, originV1Ref(), ref.Hash())
+			require.NoError(t, repo.Storer.RemoveReference(v1BranchRef()))
+		}, true},
+		{"sync write fails", func(t *testing.T, dir string, _ *git.Repository) {
+			blockCustomRefWrite(t, dir)
+		}, false},
+		{"custom ref diverges", func(t *testing.T, dir string, repo *git.Repository) {
+			setRef(t, repo, customRef(), commitFile(t, repo, dir, "other.txt", "diverged", "diverged"))
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, repo, _ := newTestRepo(t)
+			enableV11(t, dir)
+			cpID := id.MustCheckpointID("a1b2c3d4e5f6")
+			writeV1Checkpoint(t, repo, cpID)
+			tt.mutate(t, dir, repo)
 
-	cpID := id.MustCheckpointID("b1b2c3d4e5f6")
-	writeV1Checkpoint(t, repo, cpID, "session-remote")
+			store := NewCommittedReadStore(context.Background(), repo)
+			require.Equal(t, customRef(), store.CommittedReadRef(), "must read the custom ref, not fall back to v1")
 
-	// Make v1 metadata origin-only: mirror the branch to the remote ref, drop it.
-	v1Ref, err := repo.Reference(v1BranchRef(), true)
-	require.NoError(t, err)
-	setRef(t, repo, originV1Ref(), v1Ref.Hash())
-	require.NoError(t, repo.Storer.RemoveReference(v1BranchRef()))
-
-	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, customRef(), readStore.CommittedReadRef(), "must read the custom ref, not fall back to v1")
-
-	summary, err := readStore.ReadCommitted(context.Background(), cpID)
-	require.NoError(t, err)
-	require.NotNil(t, summary)
-	assert.Equal(t, cpID, summary.CheckpointID)
-}
-
-// When the custom ref cannot be written, v1.1 mode still binds reads to it (no
-// v1 fallback), so a v1-only checkpoint is not found.
-//
-// Not parallel: uses t.Chdir().
-func TestNewCommittedReadStore_BindsV11WhenSyncFails(t *testing.T) {
-	dir, repo, _ := newTestRepo(t)
-	enableV11(t, dir)
-
-	cpID := id.MustCheckpointID("c1c2c3d4e5f6")
-	writeV1Checkpoint(t, repo, cpID, "session-write-fails")
-	blockCustomRefWrite(t, dir)
-
-	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, customRef(), readStore.CommittedReadRef(), "must not fall back to v1 when sync fails")
-
-	summary, err := readStore.ReadCommitted(context.Background(), cpID)
-	require.NoError(t, err)
-	assert.Nil(t, summary, "must not fall back to v1 when the custom ref is unavailable")
-}
-
-// A diverged custom ref is read as-is; the v1-only checkpoint is not found.
-//
-// Not parallel: uses t.Chdir().
-func TestNewCommittedReadStore_BindsV11WhenCustomRefDiverges(t *testing.T) {
-	dir, repo, _ := newTestRepo(t)
-	divergedHash := commitFile(t, repo, dir, "other.txt", "diverged", "worktree commit")
-	enableV11(t, dir)
-
-	cpID := id.MustCheckpointID("d1d2c3d4e5f6")
-	writeV1Checkpoint(t, repo, cpID, "session-diverged")
-	setRef(t, repo, customRef(), divergedHash) // not an ancestor of v1
-
-	readStore := NewCommittedReadStore(context.Background(), repo)
-	require.Equal(t, customRef(), readStore.CommittedReadRef(), "must read the diverged custom ref, not fall back to v1")
-
-	summary, err := readStore.ReadCommitted(context.Background(), cpID)
-	require.NoError(t, err)
-	assert.Nil(t, summary, "diverged custom ref read must not fall back to v1")
+			summary, err := store.ReadCommitted(context.Background(), cpID)
+			require.NoError(t, err)
+			if tt.wantFound {
+				require.NotNil(t, summary)
+				assert.Equal(t, cpID, summary.CheckpointID)
+			} else {
+				assert.Nil(t, summary, "must not fall back to v1")
+			}
+		})
+	}
 }

--- a/cmd/entire/cli/checkpoint/committed_read_store_test.go
+++ b/cmd/entire/cli/checkpoint/committed_read_store_test.go
@@ -178,10 +178,8 @@ func TestNewCommittedReadStore_SelectsRefByVersion(t *testing.T) {
 	assert.Equal(t, customRef(), NewCommittedReadStore(context.Background(), repo).CommittedReadRef())
 }
 
-// TestNewCommittedReadStore_V11Reads checks that v1.1 mode always reads through
-// the custom ref (never falling back to v1): it finds a checkpoint when the ref
-// can be synced to v1, and finds nothing when it cannot.
-//
+// v1.1 reads always go through the custom ref (no v1 fallback): a checkpoint is
+// found when the ref can be synced to v1, and not found when it can't.
 // Not parallel: subtests use t.Chdir().
 func TestNewCommittedReadStore_V11Reads(t *testing.T) {
 	tests := []struct {
@@ -211,6 +209,7 @@ func TestNewCommittedReadStore_V11Reads(t *testing.T) {
 			writeV1Checkpoint(t, repo, cpID)
 			tt.mutate(t, dir, repo)
 
+			SyncCommittedReadRef(context.Background(), repo)
 			store := NewCommittedReadStore(context.Background(), repo)
 			require.Equal(t, customRef(), store.CommittedReadRef(), "must read the custom ref, not fall back to v1")
 

--- a/cmd/entire/cli/checkpoint/store.go
+++ b/cmd/entire/cli/checkpoint/store.go
@@ -2,6 +2,9 @@ package checkpoint
 
 import (
 	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
 // Compile-time check that GitStore implements the Store interface.
@@ -12,11 +15,33 @@ var _ Store = (*GitStore)(nil)
 type GitStore struct {
 	repo        *git.Repository
 	blobFetcher BlobFetchFunc
+	// committedReadRef is the ref that committed-checkpoint *reads* resolve
+	// against. Defaults to the v1 branch; v1.1 read stores bind it to the
+	// local-only custom ref (paths.MetadataRefName).
+	//
+	// Writes intentionally do NOT use this ref: committed writes always target
+	// the v1 branch (the durable source of truth) and are mirrored to the v1.1
+	// custom ref separately by the strategy's write-time mirror. Pointing writes
+	// here would let a v1.1 read store write ahead of v1 and diverge from it.
+	committedReadRef plumbing.ReferenceName
+}
+
+// defaultCommittedReadRef is the v1 metadata branch ref reads resolve against by
+// default.
+func defaultCommittedReadRef() plumbing.ReferenceName {
+	return plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 }
 
 // NewGitStore creates a new checkpoint store backed by the given git repository.
+// Committed reads resolve against the default v1 metadata branch.
 func NewGitStore(repo *git.Repository) *GitStore {
-	return &GitStore{repo: repo}
+	return &GitStore{repo: repo, committedReadRef: defaultCommittedReadRef()}
+}
+
+// NewGitStoreWithRef creates a checkpoint store whose committed reads resolve
+// against committedReadRef (writes still target the v1 branch; see GitStore).
+func NewGitStoreWithRef(repo *git.Repository, committedReadRef plumbing.ReferenceName) *GitStore {
+	return &GitStore{repo: repo, committedReadRef: committedReadRef}
 }
 
 // SetBlobFetcher configures the store to automatically fetch missing blobs
@@ -30,4 +55,9 @@ func (s *GitStore) SetBlobFetcher(f BlobFetchFunc) {
 // This is useful for strategies that need direct repository access.
 func (s *GitStore) Repository() *git.Repository {
 	return s.repo
+}
+
+// CommittedReadRef returns the ref that committed-checkpoint reads resolve against.
+func (s *GitStore) CommittedReadRef() plumbing.ReferenceName {
+	return s.committedReadRef
 }

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -678,11 +678,14 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// Handle summary generation — uses raw transcript.
 	if generate {
 		stopLoad(false) // generation prints its own progress to w/errW
-		if err := generateCheckpointSummary(ctx, w, errW, lookup.store, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
+		writeStore := checkpoint.NewGitStore(lookup.repo)
+		if err := generateCheckpointSummary(ctx, w, errW, writeStore, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
 			return err
 		}
 		// Reload to get the updated summary.
 		stopLoad = startSpinner(errW, fmt.Sprintf("Reloading checkpoint %s", fullCheckpointID))
+		lookup.store = checkpoint.NewCommittedReadStore(ctx, lookup.repo)
+		lookup.store.SetBlobFetcher(FetchBlobsByHash)
 		content, err = checkpoint.ReadLatestSessionContent(ctx, lookup.store, fullCheckpointID, summary)
 		if err != nil {
 			stopLoad(false)
@@ -845,7 +848,7 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 	// `git fetch` fails against partial-clone repos with "did not send all
 	// necessary objects"). Falls back to a full metadata-branch fetch if
 	// fetch-pack also can't reach the blobs.
-	store := checkpoint.NewGitStore(repo)
+	store := checkpoint.NewCommittedReadStore(ctx, repo)
 	store.SetBlobFetcher(FetchBlobsByHash)
 
 	lookup := &explainCheckpointLookup{
@@ -1993,7 +1996,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	// Warn (once per process) if metadata branches are disconnected
 	strategy.WarnIfMetadataDisconnected()
 
-	store := checkpoint.NewGitStore(repo)
+	store := checkpoint.NewCommittedReadStore(ctx, repo)
 
 	// Get all committed checkpoints for lookup.
 	committedInfos, err := store.ListCommitted(ctx)

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -684,6 +684,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		}
 		// Reload to get the updated summary.
 		stopLoad = startSpinner(errW, fmt.Sprintf("Reloading checkpoint %s", fullCheckpointID))
+		checkpoint.SyncCommittedReadRef(ctx, lookup.repo)
 		lookup.store = checkpoint.NewCommittedReadStore(ctx, lookup.repo)
 		lookup.store.SetBlobFetcher(FetchBlobsByHash)
 		content, err = checkpoint.ReadLatestSessionContent(ctx, lookup.store, fullCheckpointID, summary)
@@ -848,6 +849,7 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 	// `git fetch` fails against partial-clone repos with "did not send all
 	// necessary objects"). Falls back to a full metadata-branch fetch if
 	// fetch-pack also can't reach the blobs.
+	checkpoint.SyncCommittedReadRef(ctx, repo)
 	store := checkpoint.NewCommittedReadStore(ctx, repo)
 	store.SetBlobFetcher(FetchBlobsByHash)
 
@@ -1996,6 +1998,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	// Warn (once per process) if metadata branches are disconnected
 	strategy.WarnIfMetadataDisconnected()
 
+	checkpoint.SyncCommittedReadRef(ctx, repo)
 	store := checkpoint.NewCommittedReadStore(ctx, repo)
 
 	// Get all committed checkpoints for lookup.

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -2165,6 +2165,90 @@ func TestRunExplainCheckpoint_GenerateWritesV1Store(t *testing.T) {
 	require.Equal(t, "selected v1 intent", v1Metadata.Summary.Intent)
 }
 
+func TestRunExplainCheckpoint_GenerateV11ReloadsAfterV1Write(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	testutil.InitRepo(t, tmpDir)
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("test"), 0o644))
+	_, err = wt.Add("test.txt")
+	require.NoError(t, err)
+	_, err = wt.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tmpDir, ".entire", "settings.json"),
+		[]byte(`{"enabled": true, "strategy_options": {"checkpoints_version": "1.1"}, "summary_generation": {"provider": "claude-code"}}`),
+		0o644,
+	))
+
+	originalGet := getSummaryAgent
+	originalCLI := isSummaryCLIAvailable
+	originalDiscover := discoverSummaryProviders
+	originalGenerate := generateTranscriptSummary
+	t.Cleanup(func() {
+		getSummaryAgent = originalGet
+		isSummaryCLIAvailable = originalCLI
+		discoverSummaryProviders = originalDiscover
+		generateTranscriptSummary = originalGenerate
+	})
+
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		return &stubTextAgent{name: name, kind: agent.AgentTypeClaudeCode}, nil
+	}
+	isSummaryCLIAvailable = func(types.AgentName) bool { return true }
+	discoverSummaryProviders = func(context.Context) {}
+	generateTranscriptSummary = func(
+		_ context.Context,
+		_ redact.RedactedBytes,
+		_ []string,
+		_ types.AgentType,
+		_ summarize.Generator,
+	) (*checkpoint.Summary, error) {
+		return &checkpoint.Summary{Intent: "generated v1.1 intent", Outcome: "generated v1.1 outcome"}, nil
+	}
+
+	v1Store := checkpoint.NewGitStore(repo)
+	cpID := id.MustCheckpointID("bbccddee1122")
+	ctx := context.Background()
+
+	transcript := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"generate v1.1 test"}]}}` + "\n" +
+		`{"type":"assistant","message":{"content":"done"}}` + "\n")
+
+	require.NoError(t, v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-v11",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted(transcript),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	}))
+
+	var buf, errBuf bytes.Buffer
+	err = runExplainCheckpoint(ctx, &buf, &errBuf, "bbccdd", false, false, false, false, true, true, false, 0)
+	require.NoError(t, err)
+	require.Contains(t, buf.String(), "generated v1.1 intent")
+
+	v1Metadata, err := v1Store.ReadSessionMetadata(ctx, cpID, 0)
+	require.NoError(t, err)
+	require.NotNil(t, v1Metadata.Summary)
+	require.Equal(t, "generated v1.1 intent", v1Metadata.Summary.Intent)
+
+	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+	customRef, err := repo.Reference(plumbing.ReferenceName(paths.MetadataRefName), true)
+	require.NoError(t, err)
+	require.Equal(t, v1Ref.Hash(), customRef.Hash(), "reload should resync v1.1 to the v1 write")
+}
+
 func TestRunExplainCheckpoint_DefaultViewUsesV1Transcript(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)

--- a/cmd/entire/cli/paths/paths.go
+++ b/cmd/entire/cli/paths/paths.go
@@ -42,7 +42,9 @@ const MetadataBranchName = "entire/checkpoints/v1"
 // when checkpoints_version is "1.1". It lives under refs/entire/ (not
 // refs/heads/) so it stays invisible to `git branch -a` and is not pulled by a
 // default `git clone`. v1 remains the source of truth; this ref is a local-only
-// mirror — nothing reads it and it is never pushed.
+// mirror. When v1.1 is enabled, the `entire explain` command resolves committed
+// reads against this ref after syncing it from v1, falling back to v1 when sync
+// cannot establish a trustworthy mirror; it is never pushed.
 const MetadataRefName = "refs/entire/checkpoints/v1.1"
 
 // TrailsBranchName is the orphan branch used to store trail metadata.

--- a/cmd/entire/cli/strategy/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/strategy/v1_custom_ref_mirror.go
@@ -17,9 +17,11 @@ import (
 // when checkpoints_version "1.1" is opted in.
 //
 // v1 stays the source of truth; the v1 custom ref is a local-only mirror
-// sharing v1's exact commit — nothing reads it and it is never pushed. Call
-// only after a successful v1 committed write; a mirror failure must not affect
-// that write, so problems are logged, not returned.
+// sharing v1's exact commit. When v1.1 is enabled, the `entire explain` command
+// reads from this ref after re-syncing it from v1, and falls back to v1 if sync
+// cannot establish a trustworthy mirror; it is never pushed. Call only after a
+// successful v1 committed write; a mirror failure must not affect that write, so
+// problems are logged, not returned.
 func mirrorMetadataToV1CustomRef(ctx context.Context, repo *git.Repository) {
 	if !settings.MirrorsToV1CustomRef(ctx) {
 		return

--- a/cmd/entire/cli/strategy/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/strategy/v1_custom_ref_mirror.go
@@ -16,12 +16,9 @@ import (
 // (refs/entire/checkpoints/v1.1) to the v1 metadata branch's current commit
 // when checkpoints_version "1.1" is opted in.
 //
-// v1 stays the source of truth; the v1 custom ref is a local-only mirror
-// sharing v1's exact commit. When v1.1 is enabled, the `entire explain` command
-// reads from this ref after re-syncing it from v1, and falls back to v1 if sync
-// cannot establish a trustworthy mirror; it is never pushed. Call only after a
-// successful v1 committed write; a mirror failure must not affect that write, so
-// problems are logged, not returned.
+// sharing v1's exact commit — it is never pushed. Call
+// only after a successful v1 committed write; a mirror failure must not affect
+// that write, so problems are logged, not returned.
 func mirrorMetadataToV1CustomRef(ctx context.Context, repo *git.Repository) {
 	if !settings.MirrorsToV1CustomRef(ctx) {
 		return


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/465
<!-- entire-trail-link-end -->

## Summary

Adds a v1.1 committed-checkpoint read path so `entire explain` reads from `refs/entire/checkpoints/v1.1` when `checkpoints_version` is `1.1`. When v1.1 is enabled, reads bind to the v1.1 custom ref and **never fall back to v1** — the v1.1 path is genuinely exercised rather than masked by a v1 fallback.

## Details

- `GitStore` gains a configurable `committedReadRef` for **reads only**. Writes and read-modify-write paths always target the v1 branch (the durable source of truth) and are mirrored to v1.1 separately by the write-time mirror.
- `NewCommittedReadStore` always binds reads to the v1.1 ref when v1.1 is enabled. Before returning, it best-effort **sync-then-reads**: advances the local-only v1.1 ref up to the v1 tip (seed when missing, advance when an ancestor, no-op when equal, leave a diverged ref as-is). Sync failures are logged, never gating the store choice — there is no v1 store fallback.
- The v1 tip for the sync is taken from the local v1 branch, or from `origin/entire/checkpoints/v1` when no local branch exists, so `entire explain` still works on a fresh clone whose v1 metadata is remote-only — without reading through a v1 store.
- `entire explain --generate` writes summaries through the v1 store (source of truth), then rebuilds the read store so v1.1 mode reloads the newly written summary after the next sync.
- The v1.1 custom ref keeps its local-only invariant: it is never pushed or fetched.

## Validation

- `go test ./cmd/entire/cli/checkpoint`
- `go test ./cmd/entire/cli -run Explain`
- `mise run lint`

Regression coverage: sync rules (seed, seed-from-origin, advance, equal, diverged, write-failure, no-v1-tip) and read-store behavior (ref selection, read equivalence with v1, remote-only metadata, and no-v1-fallback when the custom ref is unavailable or diverged).