### PR TITLE
Mirror v1.1 checkpoint writes

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -306,6 +306,10 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		return fmt.Errorf("failed to write checkpoint: %w", err)
 	}
 
+	if err := mirrorToV1CustomRef(ctx, repo); err != nil {
+		return fmt.Errorf("checkpoint was written to %s, but failed to mirror to %s: %w", paths.MetadataBranchName, paths.MetadataRefName, err)
+	}
+
 	// Create or update session state.
 	if err := saveAttachSessionState(logCtx, repo, existingState, sessionID, ag.Type(), transcriptPath, checkpointID, meta, tokenUsage, opts, reviewSkills); err != nil {
 		logging.Warn(logCtx, "failed to save session state", "error", err)

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -22,6 +22,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
@@ -55,6 +56,15 @@ type attachOptions struct {
 	// transcript's first user prompt. Used by `entire review attach` when a
 	// pending-review marker has the exact prompt the user was asked to run.
 	ReviewPromptOverride string
+	// entireSettings, when non-nil, supplies already-resolved settings.
+	entireSettings *settings.EntireSettings
+}
+
+func (opts attachOptions) mirrorsToV1CustomRef(ctx context.Context) bool {
+	if opts.entireSettings != nil {
+		return opts.entireSettings.MirrorsToV1CustomRef()
+	}
+	return settings.MirrorsToV1CustomRef(ctx)
 }
 
 func newAttachCmd() *cobra.Command {
@@ -306,8 +316,10 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		return fmt.Errorf("failed to write checkpoint: %w", err)
 	}
 
-	if err := mirrorToV1CustomRef(ctx, repo); err != nil {
-		return fmt.Errorf("checkpoint was written to %s, but failed to mirror to %s: %w", paths.MetadataBranchName, paths.MetadataRefName, err)
+	if opts.mirrorsToV1CustomRef(ctx) {
+		if err := mirrorToV1CustomRef(repo); err != nil {
+			return fmt.Errorf("checkpoint was written to %s, but failed to mirror to %s: %w", paths.MetadataBranchName, paths.MetadataRefName, err)
+		}
 	}
 
 	// Create or update session state.

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -540,6 +540,42 @@ func TestAttach_SetsSessionTurnCount(t *testing.T) {
 	}
 }
 
+func TestAttach_MirrorsToV1CustomRefWhenOptedIn(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	repoRoot := mustGetwd(t)
+	settingsPath := filepath.Join(repoRoot, ".entire", paths.SettingsFileName)
+	if err := os.WriteFile(settingsPath, []byte(`{"enabled":true,"strategy_options":{"checkpoints_version":"1.1"}}`), 0o600); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	sessionID := "test-attach-v1-1-mirror"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"hello"},"uuid":"u1"}
+{"type":"assistant","message":{"role":"assistant","content":"hi"},"uuid":"a1"}
+`)
+
+	var out bytes.Buffer
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
+		t.Fatalf("runAttach failed: %v", err)
+	}
+
+	repo, err := git.PlainOpen(repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	if err != nil {
+		t.Fatalf("v1 metadata branch missing: %v", err)
+	}
+	customRef, err := repo.Reference(plumbing.ReferenceName(paths.MetadataRefName), true)
+	if err != nil {
+		t.Fatalf("v1.1 custom ref missing: %v", err)
+	}
+	if v1Ref.Hash() != customRef.Hash() {
+		t.Errorf("v1.1 custom ref = %s, want %s (v1 tip)", customRef.Hash(), v1Ref.Hash())
+	}
+}
+
 func TestCountUserTurns(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -544,18 +544,19 @@ func TestAttach_MirrorsToV1CustomRefWhenOptedIn(t *testing.T) {
 	setupAttachTestRepo(t)
 
 	repoRoot := mustGetwd(t)
-	settingsPath := filepath.Join(repoRoot, ".entire", paths.SettingsFileName)
-	if err := os.WriteFile(settingsPath, []byte(`{"enabled":true,"strategy_options":{"checkpoints_version":"1.1"}}`), 0o600); err != nil {
-		t.Fatalf("write settings: %v", err)
-	}
-
 	sessionID := "test-attach-v1-1-mirror"
 	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"hello"},"uuid":"u1"}
 {"type":"assistant","message":{"role":"assistant","content":"hi"},"uuid":"a1"}
 `)
 
 	var out bytes.Buffer
-	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true}); err != nil {
+	opts := attachOptions{
+		Force: true,
+		entireSettings: &settings.EntireSettings{
+			StrategyOptions: map[string]any{"checkpoints_version": "1.1"},
+		},
+	}
+	if err := runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, opts); err != nil {
 		t.Fatalf("runAttach failed: %v", err)
 	}
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -678,7 +678,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// Handle summary generation — uses raw transcript.
 	if generate {
 		stopLoad(false) // generation prints its own progress to w/errW
-		if err := generateCheckpointSummary(ctx, w, errW, lookup.store, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
+		if err := generateCheckpointSummary(ctx, w, errW, lookup.repo, lookup.store, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
 			return err
 		}
 		// Reload to get the updated summary.
@@ -869,7 +869,7 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 // summaryTimeoutSeconds is the per-invocation --summary-timeout-seconds flag
 // value (0 = unset). Effective precedence for the deadline: flag > settings >
 // package default. See resolveSummaryTimeout for the resolution.
-func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store *checkpoint.GitStore, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
+func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, repo *git.Repository, store *checkpoint.GitStore, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
 	// Check if summary already exists
 	if content.Metadata.Summary != nil && !force {
 		return renderExplainFailure(errW, "Summary already exists", []explainRow{
@@ -918,6 +918,10 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store *ch
 
 	if err := store.UpdateSummary(ctx, checkpointID, summary); err != nil {
 		return fmt.Errorf("failed to save summary: %w", err)
+	}
+
+	if err := mirrorToV1CustomRef(ctx, repo); err != nil {
+		return fmt.Errorf("summary was written to %s, but failed to mirror to %s: %w", paths.MetadataBranchName, paths.MetadataRefName, err)
 	}
 
 	styles := newStatusStyles(w)

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -678,7 +678,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// Handle summary generation — uses raw transcript.
 	if generate {
 		stopLoad(false) // generation prints its own progress to w/errW
-		if err := generateCheckpointSummary(ctx, w, errW, lookup.repo, lookup.store, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
+		if err := generateCheckpointSummary(ctx, w, errW, lookup.store, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
 			return err
 		}
 		// Reload to get the updated summary.
@@ -869,7 +869,7 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 // summaryTimeoutSeconds is the per-invocation --summary-timeout-seconds flag
 // value (0 = unset). Effective precedence for the deadline: flag > settings >
 // package default. See resolveSummaryTimeout for the resolution.
-func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, repo *git.Repository, store *checkpoint.GitStore, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
+func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store *checkpoint.GitStore, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
 	// Check if summary already exists
 	if content.Metadata.Summary != nil && !force {
 		return renderExplainFailure(errW, "Summary already exists", []explainRow{
@@ -920,7 +920,7 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, repo *git
 		return fmt.Errorf("failed to save summary: %w", err)
 	}
 
-	if err := mirrorToV1CustomRef(ctx, repo); err != nil {
+	if err := mirrorToV1CustomRef(ctx, store.Repository()); err != nil {
 		return fmt.Errorf("summary was written to %s, but failed to mirror to %s: %w", paths.MetadataBranchName, paths.MetadataRefName, err)
 	}
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -920,8 +920,10 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store *ch
 		return fmt.Errorf("failed to save summary: %w", err)
 	}
 
-	if err := mirrorToV1CustomRef(ctx, store.Repository()); err != nil {
-		return fmt.Errorf("summary was written to %s, but failed to mirror to %s: %w", paths.MetadataBranchName, paths.MetadataRefName, err)
+	if settings.MirrorsToV1CustomRef(ctx) {
+		if err := mirrorToV1CustomRef(store.Repository()); err != nil {
+			return fmt.Errorf("summary was written to %s, but failed to mirror to %s: %w", paths.MetadataBranchName, paths.MetadataRefName, err)
+		}
 	}
 
 	styles := newStatusStyles(w)

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/summarize"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -990,6 +991,84 @@ func TestGenerateCheckpointAISummary_PreservesClaudeErrorWhenCtxIsDone(t *testin
 	if ce.Kind != claudecode.ClaudeErrorAuth {
 		t.Errorf("Kind = %v; want auth", ce.Kind)
 	}
+}
+
+// Not parallel: uses t.Chdir() and package-level var stubs.
+func TestGenerateCheckpointSummary_MirrorsToV1CustomRefWhenOptedIn(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "init.txt", "init")
+	testutil.GitAdd(t, tmpDir, "init.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+
+	entireDir := filepath.Join(tmpDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(entireDir, paths.SettingsFileName),
+		[]byte(`{"enabled":true,"strategy_options":{"checkpoints_version":"1.1"}}`),
+		0o644,
+	))
+
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+	store := checkpoint.NewGitStore(repo)
+	cpID := id.MustCheckpointID("a1b2c3d4e5f6")
+	require.NoError(t, store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("transcript line\n")),
+		Prompts:      []string{"hello"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+		Agent:        agent.AgentTypeClaudeCode,
+	}))
+	cpSummary, err := checkpoint.ReadCommittedCheckpoint(ctx, store, cpID)
+	require.NoError(t, err)
+	content, err := checkpoint.ReadLatestSessionContent(ctx, store, cpID, cpSummary)
+	require.NoError(t, err)
+
+	v1Before, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+
+	origLoad := loadSummarySettings
+	origGet := getSummaryAgent
+	origCLI := isSummaryCLIAvailable
+	origGen := generateTranscriptSummary
+	t.Cleanup(func() {
+		loadSummarySettings = origLoad
+		getSummaryAgent = origGet
+		isSummaryCLIAvailable = origCLI
+		generateTranscriptSummary = origGen
+	})
+	loadSummarySettings = func(context.Context) (*settings.EntireSettings, error) {
+		return &settings.EntireSettings{
+			Enabled: true,
+			SummaryGeneration: &settings.SummaryGenerationSettings{
+				Provider: string(agent.AgentNameClaudeCode),
+			},
+		}, nil
+	}
+	getSummaryAgent = func(name types.AgentName) (agent.Agent, error) {
+		return &stubTextAgent{name: name, kind: agent.AgentTypeClaudeCode}, nil
+	}
+	isSummaryCLIAvailable = func(types.AgentName) bool { return true }
+	generateTranscriptSummary = func(context.Context, redact.RedactedBytes, []string, types.AgentType, summarize.Generator) (*checkpoint.Summary, error) {
+		return &checkpoint.Summary{Intent: "i", Outcome: "o"}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	require.NoError(t, generateCheckpointSummary(ctx, &stdout, &stderr, repo, store, cpID, cpSummary, content, false, 0))
+
+	v1After, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+	require.NotEqual(t, v1Before.Hash(), v1After.Hash(), "v1 metadata branch must advance after UpdateSummary")
+
+	customRef, err := repo.Reference(plumbing.ReferenceName(paths.MetadataRefName), true)
+	require.NoError(t, err)
+	require.Equal(t, v1After.Hash(), customRef.Hash())
 }
 
 func TestGenerateCheckpointAISummary_ClampsLongParentDeadlineToDefaultTimeout(t *testing.T) {

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1060,7 +1060,7 @@ func TestGenerateCheckpointSummary_MirrorsToV1CustomRefWhenOptedIn(t *testing.T)
 	}
 
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, generateCheckpointSummary(ctx, &stdout, &stderr, repo, store, cpID, cpSummary, content, false, 0))
+	require.NoError(t, generateCheckpointSummary(ctx, &stdout, &stderr, store, cpID, cpSummary, content, false, 0))
 
 	v1After, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.NoError(t, err)

--- a/cmd/entire/cli/integration_test/attach_test.go
+++ b/cmd/entire/cli/integration_test/attach_test.go
@@ -363,3 +363,43 @@ func TestAttach_InvalidSessionID(t *testing.T) {
 		t.Error("expected error for invalid session ID")
 	}
 }
+
+// TestAttach_MirrorsToV1CustomRefWhenOptedIn verifies that running attach
+// through the real entire binary with checkpoints_version "1.1" leaves
+// refs/entire/checkpoints/v1.1 at the same hash as entire/checkpoints/v1.
+func TestAttach_MirrorsToV1CustomRefWhenOptedIn(t *testing.T) {
+	t.Parallel()
+	env := NewFeatureBranchEnv(t)
+
+	env.PatchSettings(map[string]any{
+		"strategy_options": map[string]any{"checkpoints_version": "1.1"},
+	})
+
+	sessionID := "attach-v1-1-mirror"
+	tb := NewTranscriptBuilder()
+	tb.AddUserMessage("hello")
+	tb.AddAssistantMessage("hi")
+	transcriptPath := filepath.Join(env.ClaudeProjectDir, sessionID+".jsonl")
+	if err := tb.WriteToFile(transcriptPath); err != nil {
+		t.Fatalf("failed to write transcript: %v", err)
+	}
+
+	env.RunCLI("session", "attach", sessionID, "-a", "claude-code", "-f")
+
+	v1 := revParse(t, env.RepoDir, "entire/checkpoints/v1")
+	custom := revParse(t, env.RepoDir, "refs/entire/checkpoints/v1.1")
+	if v1 != custom {
+		t.Errorf("refs/entire/checkpoints/v1.1 = %s, want %s (entire/checkpoints/v1)", custom, v1)
+	}
+}
+
+func revParse(t *testing.T, dir, ref string) string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "--verify", ref)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse %s in %s failed: %v\n%s", ref, dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cmd/entire/cli/integration_test/attach_test.go
+++ b/cmd/entire/cli/integration_test/attach_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -397,9 +398,11 @@ func revParse(t *testing.T, dir, ref string) string {
 	t.Helper()
 	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "--verify", ref)
 	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("git rev-parse %s in %s failed: %v\n%s", ref, dir, err, out)
+		t.Fatalf("git rev-parse %s in %s failed: %v\n%s", ref, dir, err, stderr.String())
 	}
 	return strings.TrimSpace(string(out))
 }

--- a/cmd/entire/cli/integration_test/attach_test.go
+++ b/cmd/entire/cli/integration_test/attach_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 )
 
@@ -398,6 +399,7 @@ func revParse(t *testing.T, dir, ref string) string {
 	t.Helper()
 	cmd := exec.CommandContext(t.Context(), "git", "rev-parse", "--verify", ref)
 	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()

--- a/cmd/entire/cli/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror.go
@@ -12,9 +12,12 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
-// mirrorToV1CustomRef advances refs/entire/checkpoints/v1.1 to the v1 metadata
-// branch tip when opted in, returning errors so callers can surface them.
-// The hook-side equivalent (strategy.mirrorMetadataToV1CustomRef) logs instead.
+// mirrorToV1CustomRef sets refs/entire/checkpoints/v1.1 to the v1 metadata
+// branch tip when opted in, returning errors so callers can surface them. v1
+// is the source of truth; the v1.1 ref is a strict local mirror, so this
+// force-overwrites rather than safely advancing. The hook-side equivalent
+// (strategy.mirrorMetadataToV1CustomRef) logs errors instead of returning
+// them.
 func mirrorToV1CustomRef(ctx context.Context, repo *git.Repository) error {
 	if !settings.MirrorsToV1CustomRef(ctx) {
 		return nil

--- a/cmd/entire/cli/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror.go
@@ -31,7 +31,7 @@ func mirrorToV1CustomRef(ctx context.Context, repo *git.Repository) error {
 	}
 	customRef := plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), v1Ref.Hash())
 	if err := repo.Storer.SetReference(customRef); err != nil {
-		return fmt.Errorf("advance v1 custom ref %s: %w", paths.MetadataRefName, err)
+		return fmt.Errorf("set ref: %w", err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
-	"github.com/entireio/cli/cmd/entire/cli/strategy"
 )
 
 // mirrorToV1CustomRef advances refs/entire/checkpoints/v1.1 to the v1 metadata
@@ -27,7 +26,8 @@ func mirrorToV1CustomRef(ctx context.Context, repo *git.Repository) error {
 		}
 		return fmt.Errorf("read v1 metadata branch %s: %w", paths.MetadataBranchName, err)
 	}
-	if err := strategy.SafelyAdvanceLocalRef(ctx, repo, plumbing.ReferenceName(paths.MetadataRefName), v1Ref.Hash()); err != nil {
+	customRef := plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), v1Ref.Hash())
+	if err := repo.Storer.SetReference(customRef); err != nil {
 		return fmt.Errorf("advance v1 custom ref %s: %w", paths.MetadataRefName, err)
 	}
 	return nil

--- a/cmd/entire/cli/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -9,19 +8,14 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
-	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
 // mirrorToV1CustomRef sets refs/entire/checkpoints/v1.1 to the v1 metadata
-// branch tip when opted in, returning errors so callers can surface them. v1
-// is the source of truth; the v1.1 ref is a strict local mirror, so this
-// force-overwrites rather than safely advancing. The hook-side equivalent
-// (strategy.mirrorMetadataToV1CustomRef) logs errors instead of returning
-// them.
-func mirrorToV1CustomRef(ctx context.Context, repo *git.Repository) error {
-	if !settings.MirrorsToV1CustomRef(ctx) {
-		return nil
-	}
+// branch tip, returning errors so callers can surface them. v1 is the source
+// of truth; the v1.1 ref is a strict local mirror, so this force-overwrites
+// rather than safely advancing. The hook-side equivalent
+// (strategy.mirrorMetadataToV1CustomRef) logs errors instead of returning them.
+func mirrorToV1CustomRef(repo *git.Repository) error {
 	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {

--- a/cmd/entire/cli/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror.go
@@ -25,7 +25,7 @@ func mirrorToV1CustomRef(repo *git.Repository) error {
 	}
 	customRef := plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), v1Ref.Hash())
 	if err := repo.Storer.SetReference(customRef); err != nil {
-		return fmt.Errorf("set ref: %w", err)
+		return fmt.Errorf("set ref %s to %s: %w", paths.MetadataRefName, v1Ref.Hash(), err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/v1_custom_ref_mirror.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+)
+
+// mirrorToV1CustomRef advances refs/entire/checkpoints/v1.1 to the v1 metadata
+// branch tip when opted in, returning errors so callers can surface them.
+// The hook-side equivalent (strategy.mirrorMetadataToV1CustomRef) logs instead.
+func mirrorToV1CustomRef(ctx context.Context, repo *git.Repository) error {
+	if !settings.MirrorsToV1CustomRef(ctx) {
+		return nil
+	}
+	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	if err != nil {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return fmt.Errorf("v1 metadata branch %s missing after v1 write", paths.MetadataBranchName)
+		}
+		return fmt.Errorf("read v1 metadata branch %s: %w", paths.MetadataBranchName, err)
+	}
+	if err := strategy.SafelyAdvanceLocalRef(ctx, repo, plumbing.ReferenceName(paths.MetadataRefName), v1Ref.Hash()); err != nil {
+		return fmt.Errorf("advance v1 custom ref %s: %w", paths.MetadataRefName, err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/v1_custom_ref_mirror_test.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror_test.go
@@ -1,17 +1,29 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"testing"
 
 	git "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
+
+type setReferenceErrorStorer struct {
+	storage.Storer
+
+	err error
+}
+
+func (s setReferenceErrorStorer) SetReference(*plumbing.Reference) error {
+	return s.err
+}
 
 func setupCustomRefRepo(t *testing.T) *git.Repository {
 	t.Helper()
@@ -112,4 +124,17 @@ func TestMirrorToV1CustomRef_V1MissingErrors(t *testing.T) {
 
 	_, ok := readCustomRefHash(t, repo)
 	assert.False(t, ok, "v1 custom ref must not be created when v1 metadata branch is absent")
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorToV1CustomRef_SetReferenceErrorNamesTarget(t *testing.T) {
+	repo := setupCustomRefRepo(t)
+	v1Hash := pointV1MetadataBranchAtHead(t, repo)
+	storerErr := errors.New("set failed")
+	repo.Storer = setReferenceErrorStorer{Storer: repo.Storer, err: storerErr}
+
+	err := mirrorToV1CustomRef(repo)
+	require.ErrorIs(t, err, storerErr)
+	assert.Contains(t, err.Error(), paths.MetadataRefName)
+	assert.Contains(t, err.Error(), v1Hash.String())
 }

--- a/cmd/entire/cli/v1_custom_ref_mirror_test.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	git "github.com/go-git/go-git/v6"
@@ -14,21 +13,13 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
-func setupCustomRefRepo(t *testing.T, version string) *git.Repository {
+func setupCustomRefRepo(t *testing.T) *git.Repository {
 	t.Helper()
 	tmpDir := t.TempDir()
 	testutil.InitRepo(t, tmpDir)
 	testutil.WriteFile(t, tmpDir, "f.txt", "init")
 	testutil.GitAdd(t, tmpDir, "f.txt")
 	testutil.GitCommit(t, tmpDir, "init")
-
-	body := `{"enabled": true}`
-	if version != "" {
-		body = `{"enabled": true, "strategy_options": {"checkpoints_version": ` + version + `}}`
-	}
-	entireDir := filepath.Join(tmpDir, ".entire")
-	require.NoError(t, os.MkdirAll(entireDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(entireDir, paths.SettingsFileName), []byte(body), 0o644))
 
 	t.Chdir(tmpDir)
 	repo, err := git.PlainOpen(tmpDir)
@@ -55,11 +46,11 @@ func readCustomRefHash(t *testing.T, repo *git.Repository) (plumbing.Hash, bool)
 }
 
 // Not parallel: uses t.Chdir().
-func TestMirrorToV1CustomRef_CreatesRefWhenEnabled(t *testing.T) {
-	repo := setupCustomRefRepo(t, `"1.1"`)
+func TestMirrorToV1CustomRef_CreatesRef(t *testing.T) {
+	repo := setupCustomRefRepo(t)
 	v1Hash := pointV1MetadataBranchAtHead(t, repo)
 
-	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
+	require.NoError(t, mirrorToV1CustomRef(repo))
 
 	got, ok := readCustomRefHash(t, repo)
 	require.True(t, ok, "expected %s to exist", paths.MetadataRefName)
@@ -67,19 +58,8 @@ func TestMirrorToV1CustomRef_CreatesRefWhenEnabled(t *testing.T) {
 }
 
 // Not parallel: uses t.Chdir().
-func TestMirrorToV1CustomRef_DisabledNoOp(t *testing.T) {
-	repo := setupCustomRefRepo(t, "") // v1 only
-	pointV1MetadataBranchAtHead(t, repo)
-
-	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
-
-	_, ok := readCustomRefHash(t, repo)
-	assert.False(t, ok, "v1 custom ref must not be created when not opted in")
-}
-
-// Not parallel: uses t.Chdir().
 func TestMirrorToV1CustomRef_AdvancesExistingRef(t *testing.T) {
-	repo := setupCustomRefRepo(t, `"1.1"`)
+	repo := setupCustomRefRepo(t)
 	oldHash := pointV1MetadataBranchAtHead(t, repo)
 	require.NoError(t, repo.Storer.SetReference(
 		plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), oldHash)))
@@ -92,7 +72,7 @@ func TestMirrorToV1CustomRef_AdvancesExistingRef(t *testing.T) {
 	newHash := pointV1MetadataBranchAtHead(t, repo)
 	require.NotEqual(t, oldHash, newHash)
 
-	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
+	require.NoError(t, mirrorToV1CustomRef(repo))
 
 	got, ok := readCustomRefHash(t, repo)
 	require.True(t, ok)
@@ -101,7 +81,7 @@ func TestMirrorToV1CustomRef_AdvancesExistingRef(t *testing.T) {
 
 // Not parallel: uses t.Chdir().
 func TestMirrorToV1CustomRef_ReplacesLocallyAheadRef(t *testing.T) {
-	repo := setupCustomRefRepo(t, `"1.1"`)
+	repo := setupCustomRefRepo(t)
 	v1Hash := pointV1MetadataBranchAtHead(t, repo)
 
 	cwd, err := os.Getwd()
@@ -115,7 +95,7 @@ func TestMirrorToV1CustomRef_ReplacesLocallyAheadRef(t *testing.T) {
 	require.NoError(t, repo.Storer.SetReference(
 		plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), head.Hash())))
 
-	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
+	require.NoError(t, mirrorToV1CustomRef(repo))
 
 	got, ok := readCustomRefHash(t, repo)
 	require.True(t, ok)
@@ -124,22 +104,12 @@ func TestMirrorToV1CustomRef_ReplacesLocallyAheadRef(t *testing.T) {
 
 // Not parallel: uses t.Chdir().
 func TestMirrorToV1CustomRef_V1MissingErrors(t *testing.T) {
-	repo := setupCustomRefRepo(t, `"1.1"`) // no v1 metadata branch created
+	repo := setupCustomRefRepo(t) // no v1 metadata branch created
 
-	err := mirrorToV1CustomRef(t.Context(), repo)
+	err := mirrorToV1CustomRef(repo)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), paths.MetadataBranchName)
 
 	_, ok := readCustomRefHash(t, repo)
 	assert.False(t, ok, "v1 custom ref must not be created when v1 metadata branch is absent")
-}
-
-// Not parallel: uses t.Chdir().
-func TestMirrorToV1CustomRef_DisabledTakesPrecedenceOverV1Missing(t *testing.T) {
-	repo := setupCustomRefRepo(t, "")
-
-	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
-
-	_, ok := readCustomRefHash(t, repo)
-	assert.False(t, ok)
 }

--- a/cmd/entire/cli/v1_custom_ref_mirror_test.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror_test.go
@@ -100,6 +100,29 @@ func TestMirrorToV1CustomRef_AdvancesExistingRef(t *testing.T) {
 }
 
 // Not parallel: uses t.Chdir().
+func TestMirrorToV1CustomRef_ReplacesLocallyAheadRef(t *testing.T) {
+	repo := setupCustomRefRepo(t, `"1.1"`)
+	v1Hash := pointV1MetadataBranchAtHead(t, repo)
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	testutil.WriteFile(t, cwd, "f2.txt", "more")
+	testutil.GitAdd(t, cwd, "f2.txt")
+	testutil.GitCommit(t, cwd, "second")
+	head, err := repo.Head()
+	require.NoError(t, err)
+	require.NotEqual(t, v1Hash, head.Hash())
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), head.Hash())))
+
+	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
+
+	got, ok := readCustomRefHash(t, repo)
+	require.True(t, ok)
+	assert.Equal(t, v1Hash, got)
+}
+
+// Not parallel: uses t.Chdir().
 func TestMirrorToV1CustomRef_V1MissingErrors(t *testing.T) {
 	repo := setupCustomRefRepo(t, `"1.1"`) // no v1 metadata branch created
 

--- a/cmd/entire/cli/v1_custom_ref_mirror_test.go
+++ b/cmd/entire/cli/v1_custom_ref_mirror_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+func setupCustomRefRepo(t *testing.T, version string) *git.Repository {
+	t.Helper()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+
+	body := `{"enabled": true}`
+	if version != "" {
+		body = `{"enabled": true, "strategy_options": {"checkpoints_version": ` + version + `}}`
+	}
+	entireDir := filepath.Join(tmpDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, paths.SettingsFileName), []byte(body), 0o644))
+
+	t.Chdir(tmpDir)
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+	return repo
+}
+
+func pointV1MetadataBranchAtHead(t *testing.T, repo *git.Repository) plumbing.Hash {
+	t.Helper()
+	head, err := repo.Head()
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), head.Hash())))
+	return head.Hash()
+}
+
+func readCustomRefHash(t *testing.T, repo *git.Repository) (plumbing.Hash, bool) {
+	t.Helper()
+	ref, err := repo.Reference(plumbing.ReferenceName(paths.MetadataRefName), true)
+	if err != nil {
+		return plumbing.ZeroHash, false
+	}
+	return ref.Hash(), true
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorToV1CustomRef_CreatesRefWhenEnabled(t *testing.T) {
+	repo := setupCustomRefRepo(t, `"1.1"`)
+	v1Hash := pointV1MetadataBranchAtHead(t, repo)
+
+	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
+
+	got, ok := readCustomRefHash(t, repo)
+	require.True(t, ok, "expected %s to exist", paths.MetadataRefName)
+	assert.Equal(t, v1Hash, got)
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorToV1CustomRef_DisabledNoOp(t *testing.T) {
+	repo := setupCustomRefRepo(t, "") // v1 only
+	pointV1MetadataBranchAtHead(t, repo)
+
+	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
+
+	_, ok := readCustomRefHash(t, repo)
+	assert.False(t, ok, "v1 custom ref must not be created when not opted in")
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorToV1CustomRef_AdvancesExistingRef(t *testing.T) {
+	repo := setupCustomRefRepo(t, `"1.1"`)
+	oldHash := pointV1MetadataBranchAtHead(t, repo)
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), oldHash)))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	testutil.WriteFile(t, cwd, "f2.txt", "more")
+	testutil.GitAdd(t, cwd, "f2.txt")
+	testutil.GitCommit(t, cwd, "second")
+	newHash := pointV1MetadataBranchAtHead(t, repo)
+	require.NotEqual(t, oldHash, newHash)
+
+	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
+
+	got, ok := readCustomRefHash(t, repo)
+	require.True(t, ok)
+	assert.Equal(t, newHash, got)
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorToV1CustomRef_V1MissingErrors(t *testing.T) {
+	repo := setupCustomRefRepo(t, `"1.1"`) // no v1 metadata branch created
+
+	err := mirrorToV1CustomRef(t.Context(), repo)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), paths.MetadataBranchName)
+
+	_, ok := readCustomRefHash(t, repo)
+	assert.False(t, ok, "v1 custom ref must not be created when v1 metadata branch is absent")
+}
+
+// Not parallel: uses t.Chdir().
+func TestMirrorToV1CustomRef_DisabledTakesPrecedenceOverV1Missing(t *testing.T) {
+	repo := setupCustomRefRepo(t, "")
+
+	require.NoError(t, mirrorToV1CustomRef(t.Context(), repo))
+
+	_, ok := readCustomRefHash(t, repo)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/469
<!-- entire-trail-link-end -->

## Goal

Make the deferred user-facing checkpoint write paths compatible with `strategy_options.checkpoints_version: "1.1"` without generalizing the checkpoint writer yet.

When the option is exactly the JSON string `"1.1"`, `session attach` and `checkpoint explain --generate` continue writing existing v1 metadata first, then mirror the resulting `entire/checkpoints/v1` tip to `refs/entire/checkpoints/v1.1`.

## Scope and decisions

- Keeps the change narrowly scoped to `session attach` and `checkpoint explain --generate`.
- Leaves `checkpoint.GitStore` as-is; mirroring is not moved into the generic writer in this step.
- Uses the existing settings semantics: only exact string `"1.1"` enables the v1.1 mirror.
- Treats foreground command paths differently from hooks: mirror failures return an error instead of being log-only.
- Leaves successful v1 writes in place when v1.1 mirroring fails, with wrapped errors that name both refs.
- Runs the strict mirror before later success-side effects: before attach session-state save / commit amendment, and before the explain success block.

## Implementation

- Adds a CLI strict mirror helper gated by `settings.MirrorsToV1CustomRef(ctx)`.
- Reads the current `paths.MetadataBranchName` tip and sets `paths.MetadataRefName` to that exact hash.
- Calls the helper immediately after `store.WriteCommitted(...)` in attach and after `store.UpdateSummary(...)` in explain summary generation.
- Keeps hook-side mirroring behavior separate, preserving its log-only failure policy.

## Tests

- Covers opt-in mirroring, disabled no-op behavior, missing v1 metadata branch handling, advancing an existing custom ref, and replacing a locally-ahead custom ref with the exact v1 tip.
- Covers `session attach` mirroring through unit coverage and the real integration-test CLI path.
- Covers `checkpoint explain --generate` mirroring with a deterministic summary-provider stub.

## Verification

- `mise run build`
- `mise run lint`
- `mise run test:ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how checkpoint metadata refs are updated on user-facing attach and summary-generation paths; failures can abort the command after a successful v1 write.
> 
> **Overview**
> When `strategy_options.checkpoints_version` is exactly **`"1.1"`**, deferred CLI writes still land on **`entire/checkpoints/v1`**, then a new strict helper **`mirrorToV1CustomRef`** points **`refs/entire/checkpoints/v1.1`** at that branch tip (force-overwrite local mirror; v1 stays canonical).
> 
> **`session attach`** calls the mirror right after **`WriteCommitted`**; **`entire explain --generate`** calls it after **`UpdateSummary`**. Mirror failures **return an error** (unlike hook-side mirroring, which only logs), run **before** later success steps (attach session state / commit amend, explain success output), and leave the v1 write in place with a message naming both refs.
> 
> Unit, attach/explain, and integration tests cover opt-in mirroring, disabled no-op, missing v1 branch, advancing the custom ref, and resetting a locally-ahead custom ref to the v1 tip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e3b5d8245899bc1947b894d9fa4a0932ecd94f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->