### PR TITLE
Vastly simplify auth contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ docs/superpowers
 tmp/
 .tmp/
 .superpowers/
+/git-remote-entire

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -154,7 +154,6 @@ func newAuthCmd() *cobra.Command {
 	cmd.AddCommand(newAuthRevokeCmd())
 	cmd.AddCommand(newAuthContextsCmd())
 	cmd.AddCommand(newAuthUseCmd())
-	cmd.AddCommand(newAuthUnbindCmd())
 	return cmd
 }
 

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -116,36 +116,6 @@ func Contexts() ([]*contexts.Context, string, error) {
 	return f.Contexts, f.CurrentContext, nil
 }
 
-// ClusterBindings returns the cluster_host → context_name map from
-// contexts.json. Surfaced by `entire auth contexts` so users can audit
-// which cluster hosts auto-authenticate git operations with a stored
-// context — and spot any they don't recognise.
-func ClusterBindings() (map[string]string, error) {
-	f, err := contexts.Load(contexts.DefaultConfigDir())
-	if err != nil {
-		return nil, fmt.Errorf("load contexts: %w", err)
-	}
-	return f.ClusterContexts, nil
-}
-
-// UnbindCluster removes the cluster→context binding for host, reporting
-// whether one existed. Used by `entire auth unbind` to revoke a binding
-// without touching the underlying login context.
-func UnbindCluster(host string) (bool, error) {
-	var existed bool
-	if err := contexts.Modify(contexts.DefaultConfigDir(), func(f *contexts.File) (bool, error) {
-		if _, ok := f.ClusterContexts[host]; !ok {
-			return false, nil
-		}
-		delete(f.ClusterContexts, host)
-		existed = true
-		return true, nil
-	}); err != nil {
-		return false, fmt.Errorf("unbind cluster: %w", err)
-	}
-	return existed, nil
-}
-
 // ContextStore wraps the legacy keyring Store so token *reads* prefer the
 // active contexts.json context, falling back to the legacy
 // entire-cli/<authBaseURL> entry. Writes are inherited from Store

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -30,8 +30,8 @@ func CurrentContextToken() (string, bool) {
 }
 
 // RemoveCurrentContext deletes the active context from contexts.json and
-// its keyring token, advancing current_context to whatever remains. It is
-// a no-op (returns nil) when there is no current context. Used by logout.
+// its keyring token, clearing current_context. It is a no-op (returns nil)
+// when there is no current context. Used by logout.
 func RemoveCurrentContext() error {
 	// Read-modify-write in a single locked Modify so the context we delete
 	// is exactly the one we capture the keychain slot from (separate Load +
@@ -43,11 +43,9 @@ func RemoveCurrentContext() error {
 			return false, nil
 		}
 		svc, handle = current.KeychainService, current.Handle
+		// Delete clears current_context because we're deleting the active
+		// one — logged out means logged out, no switch to another identity.
 		f.Delete(current.Name)
-		// Delete advances current_context to a surviving context; for logout
-		// that would silently re-authenticate as another account. Leave no
-		// active context — logged out means logged out.
-		f.CurrentContext = ""
 		return true, nil
 	}); err != nil {
 		return fmt.Errorf("remove current context: %w", err)

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -61,15 +61,14 @@ func RemoveCurrentContext() error {
 	return nil
 }
 
-// RemoveAllContexts deletes every stored context, its keyring token, and all
-// cluster bindings — a full local logout. Returns the number of contexts
-// removed. Best-effort on the keyring deletes; the contexts.json clear is
-// what makes the CLI fully logged out (no surviving binding can authenticate
-// a clone afterward).
+// RemoveAllContexts deletes every stored context and its keyring token — a
+// full local logout. Returns the number of contexts removed. Best-effort on
+// the keyring deletes; the contexts.json clear is what makes the CLI fully
+// logged out.
 func RemoveAllContexts() (int, error) {
 	var removed int
 	if err := contexts.Modify(contexts.DefaultConfigDir(), func(f *contexts.File) (bool, error) {
-		if len(f.Contexts) == 0 && f.CurrentContext == "" && len(f.ClusterContexts) == 0 {
+		if len(f.Contexts) == 0 && f.CurrentContext == "" {
 			return false, nil
 		}
 		for _, c := range f.Contexts {
@@ -80,7 +79,6 @@ func RemoveAllContexts() (int, error) {
 		}
 		f.Contexts = nil
 		f.CurrentContext = ""
-		f.ClusterContexts = nil
 		return true, nil
 	}); err != nil {
 		return 0, fmt.Errorf("remove all contexts: %w", err)

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -230,8 +230,13 @@ func TestRemoveAllContexts(t *testing.T) {
 	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"bob","exp":%d}`, exp)), true); err != nil {
 		t.Fatalf("record b: %v", err)
 	}
-	if err := contexts.BindCluster(cfgDir, "cluster.example.com", a); err != nil {
-		t.Fatalf("bind cluster: %v", err)
+	// Seed a legacy cluster_contexts entry directly to prove RemoveAllContexts
+	// still clears the inert field on a full logout.
+	if err := contexts.Modify(cfgDir, func(f *contexts.File) (bool, error) {
+		f.ClusterContexts = map[string]string{"cluster.example.com": a}
+		return true, nil
+	}); err != nil {
+		t.Fatalf("seed legacy binding: %v", err)
 	}
 
 	n, err := RemoveAllContexts()

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -223,22 +223,12 @@ func TestRemoveAllContexts(t *testing.T) {
 	t.Cleanup(restore)
 
 	exp := time.Now().Add(time.Hour).Unix()
-	a, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), true)
-	if err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
 		t.Fatalf("record a: %v", err)
 	}
 	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"bob","exp":%d}`, exp)), true); err != nil {
 		t.Fatalf("record b: %v", err)
 	}
-	// Seed a legacy cluster_contexts entry directly to prove RemoveAllContexts
-	// still clears the inert field on a full logout.
-	if err := contexts.Modify(cfgDir, func(f *contexts.File) (bool, error) {
-		f.ClusterContexts = map[string]string{"cluster.example.com": a}
-		return true, nil
-	}); err != nil {
-		t.Fatalf("seed legacy binding: %v", err)
-	}
-
 	n, err := RemoveAllContexts()
 	if err != nil {
 		t.Fatalf("RemoveAllContexts: %v", err)
@@ -250,8 +240,8 @@ func TestRemoveAllContexts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if len(f.Contexts) != 0 || f.CurrentContext != "" || len(f.ClusterContexts) != 0 {
-		t.Fatalf("expected fully cleared, got contexts=%d current=%q bindings=%d", len(f.Contexts), f.CurrentContext, len(f.ClusterContexts))
+	if len(f.Contexts) != 0 || f.CurrentContext != "" {
+		t.Fatalf("expected fully cleared, got contexts=%d current=%q", len(f.Contexts), f.CurrentContext)
 	}
 
 	// Idempotent.

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"io"
-	"sort"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
@@ -75,7 +74,7 @@ func warnIfCrossCoreContext(errW io.Writer, name string) {
 func newAuthContextsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "contexts",
-		Short: "List stored login contexts and cluster bindings",
+		Short: "List stored login contexts",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAuthContexts(cmd.OutOrStdout())
@@ -88,72 +87,16 @@ func runAuthContexts(w io.Writer) error {
 	if err != nil {
 		return err //nolint:wrapcheck // already a user-facing message
 	}
-	// Print login contexts (or the empty-state hint), then always fall
-	// through to cluster bindings — a binding can outlive every context
-	// (manual edits, partial cleanup, a deleted context), and that orphan
-	// is exactly the kind of thing the audit path must surface.
 	if len(all) == 0 {
 		fmt.Fprintln(w, "No login contexts. Run 'entire login' to authenticate.")
-	} else {
-		for _, c := range all {
-			marker := " "
-			if c.Name == current {
-				marker = "*"
-			}
-			fmt.Fprintf(w, "%s %s\t%s\t%s\n", marker, c.Name, c.Handle, c.CoreURL)
-		}
-	}
-	return printClusterBindings(w)
-}
-
-// printClusterBindings lists any cluster_contexts bindings so users can
-// audit which hosts skip /.well-known discovery and resolve straight to a
-// stored context. A binding does not hand that host your login JWT — that
-// only ever goes to the bound context's core, and the host receives a
-// repo-scoped, audience-pinned token (see repocreds). What a binding pins
-// is which core authenticates that host, so an entry you don't recognise
-// is still worth revoking with `entire auth unbind`.
-func printClusterBindings(w io.Writer) error {
-	bindings, err := auth.ClusterBindings()
-	if err != nil {
-		return err //nolint:wrapcheck // already a user-facing message
-	}
-	if len(bindings) == 0 {
 		return nil
 	}
-	hosts := make([]string, 0, len(bindings))
-	for h := range bindings {
-		hosts = append(hosts, h)
+	for _, c := range all {
+		marker := " "
+		if c.Name == current {
+			marker = "*"
+		}
+		fmt.Fprintf(w, "%s %s\t%s\t%s\n", marker, c.Name, c.Handle, c.CoreURL)
 	}
-	sort.Strings(hosts)
-	fmt.Fprintln(w, "\nCluster bindings (these hosts auto-authenticate with a stored context):")
-	for _, h := range hosts {
-		fmt.Fprintf(w, "  %s\t-> %s\n", h, bindings[h])
-	}
-	fmt.Fprintln(w, "\nRevoke a binding you don't recognise with 'entire auth unbind <host>'.")
 	return nil
-}
-
-// newAuthUnbindCmd removes a cluster→context binding. Purely local.
-func newAuthUnbindCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "unbind <cluster-host>",
-		Short: "Remove a cluster→context binding",
-		Long: "Remove the stored binding that makes git operations against a cluster host\n" +
-			"auto-authenticate with a saved context. The login context itself is left\n" +
-			"intact. List current bindings with 'entire auth contexts'.",
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			existed, err := auth.UnbindCluster(args[0])
-			if err != nil {
-				return err //nolint:wrapcheck // already a user-facing message
-			}
-			if !existed {
-				fmt.Fprintf(cmd.OutOrStdout(), "No cluster binding for %q.\n", args[0])
-				return nil
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Removed cluster binding for %q.\n", args[0])
-			return nil
-		},
-	}
 }

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -11,25 +11,25 @@ import (
 
 // newAuthUseCmd switches the active login context.
 //
-// For `git clone entire://…` the active context is only a fallback: a
-// cluster already bound to a context (cluster_contexts) keeps using that
-// binding, and the active context is consulted only the first time a
-// not-yet-bound cluster is resolved. Control-plane commands (auth status/
-// list/revoke, org/project/repo/grant) currently target the configured auth
-// host (ENTIRE_AUTH_BASE_URL / the default) regardless of the active
-// context's core, so switching to a context on a *different* core does not
-// yet retarget them — auth use warns when that's the case.
+// For `git clone entire://…` the active context is the preferred identity:
+// it authenticates any cluster fronted by its login server, and switching
+// here takes effect on the next operation (resolution recomputes the account
+// every time). Control-plane commands (auth status/list/revoke, org/project/
+// repo/grant) currently target the configured auth host (ENTIRE_AUTH_BASE_URL
+// / the default) regardless of the active context's login server, so
+// switching to a context on a *different* login server does not yet retarget
+// them — auth use warns when that's the case.
 func newAuthUseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "use <context>",
 		Short: "Switch the active login context",
 		Long: "Switch the active login context.\n\n" +
-			"For `git clone entire://…` the active context is only a fallback: a cluster\n" +
-			"already bound to a context keeps using that binding, so switching here affects\n" +
-			"only clusters not yet bound (and same-core tie-breaking on first resolve).\n\n" +
+			"For `git clone entire://…` the active context is the preferred identity: it\n" +
+			"authenticates any cluster fronted by its login server, and the switch takes\n" +
+			"effect on the next operation.\n\n" +
 			"Control-plane commands (auth status/list/revoke, org/project/repo/grant) still\n" +
 			"target the configured auth host (ENTIRE_AUTH_BASE_URL / the default), so\n" +
-			"switching to a context on a different core does not retarget them yet.",
+			"switching to a context on a different login server does not retarget them yet.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := auth.SetCurrentContext(args[0]); err != nil {
@@ -62,9 +62,9 @@ func warnIfCrossCoreContext(errW io.Writer, name string) {
 			return
 		}
 		fmt.Fprintf(errW,
-			"Note: %q authenticates against %s, but control-plane commands still target %s — cross-core control-plane switching isn't supported yet.\n"+
-				"For `git clone entire://…`, a cluster already bound to another context keeps using it; the active context applies only to clusters not yet bound.\n",
-			name, c.CoreURL, authHost)
+			"Note: %q authenticates against %s, but control-plane commands still target %s — switching the active context doesn't retarget control-plane commands yet.\n"+
+				"For `git clone entire://…`, this context now authenticates any cluster fronted by %s.\n",
+			name, c.CoreURL, authHost, c.CoreURL)
 		return
 	}
 }

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
-	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
 
@@ -53,113 +52,6 @@ func TestRunAuthContexts(t *testing.T) {
 	}
 	if !strings.Contains(got, "alice") {
 		t.Fatalf("listing = %q, want handle alice", got)
-	}
-}
-
-// TestRunAuthContextsSurfacesClusterBindings: cluster_contexts entries are
-// listed so a user can audit (and then revoke) any host that
-// auto-authenticates with a stored context.
-func TestRunAuthContextsSurfacesClusterBindings(t *testing.T) {
-	cfgDir := t.TempDir()
-	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
-	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
-	t.Cleanup(restore)
-
-	exp := time.Now().Add(time.Hour).Unix()
-	token := makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
-	if _, err := auth.RecordLoginContext(token, true); err != nil {
-		t.Fatalf("RecordLoginContext: %v", err)
-	}
-	if err := contexts.BindCluster(cfgDir, "evil.example.com", "core.example.com"); err != nil {
-		t.Fatalf("BindCluster: %v", err)
-	}
-
-	var out bytes.Buffer
-	if err := runAuthContexts(&out); err != nil {
-		t.Fatalf("runAuthContexts: %v", err)
-	}
-	got := out.String()
-	if !strings.Contains(got, "Cluster bindings") {
-		t.Fatalf("listing = %q, want a 'Cluster bindings' section", got)
-	}
-	if !strings.Contains(got, "evil.example.com") || !strings.Contains(got, "auth unbind") {
-		t.Fatalf("listing = %q, want the bound host and an unbind hint", got)
-	}
-}
-
-// TestRunAuthContextsSurfacesOrphanedBinding: a binding can outlive every
-// login context (manual edit, deleted context). The audit path must still
-// list it even though there are no contexts to print.
-func TestRunAuthContextsSurfacesOrphanedBinding(t *testing.T) {
-	cfgDir := t.TempDir()
-	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
-	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
-	t.Cleanup(restore)
-
-	// Written directly: BindCluster refuses a binding to a missing context,
-	// so an orphan only arises via manual edits or partial cleanup.
-	if err := contexts.Save(cfgDir, &contexts.File{
-		ClusterContexts: map[string]string{"evil.example.com": "deleted-ctx"},
-	}); err != nil {
-		t.Fatalf("Save: %v", err)
-	}
-
-	var out bytes.Buffer
-	if err := runAuthContexts(&out); err != nil {
-		t.Fatalf("runAuthContexts: %v", err)
-	}
-	got := out.String()
-	if !strings.Contains(got, "No login contexts") {
-		t.Fatalf("listing = %q, want the empty-state hint", got)
-	}
-	if !strings.Contains(got, "Cluster bindings") || !strings.Contains(got, "evil.example.com") {
-		t.Fatalf("listing = %q, want the orphaned binding surfaced", got)
-	}
-}
-
-// TestUnbindCluster: removing a binding leaves the underlying context
-// intact and is idempotent.
-func TestUnbindCluster(t *testing.T) {
-	cfgDir := t.TempDir()
-	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
-	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
-	t.Cleanup(restore)
-
-	exp := time.Now().Add(time.Hour).Unix()
-	if _, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
-		t.Fatalf("RecordLoginContext: %v", err)
-	}
-	if err := contexts.BindCluster(cfgDir, "evil.example.com", "core.example.com"); err != nil {
-		t.Fatalf("BindCluster: %v", err)
-	}
-
-	existed, err := auth.UnbindCluster("evil.example.com")
-	if err != nil {
-		t.Fatalf("UnbindCluster: %v", err)
-	}
-	if !existed {
-		t.Fatal("UnbindCluster reported no binding, want existed=true")
-	}
-
-	// Binding gone, context preserved.
-	f, err := contexts.Load(cfgDir)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if _, ok := f.ClusterContexts["evil.example.com"]; ok {
-		t.Fatal("binding still present after unbind")
-	}
-	if f.Find("core.example.com") == nil {
-		t.Fatal("login context must survive unbind")
-	}
-
-	// Idempotent: second unbind reports no binding.
-	existed, err = auth.UnbindCluster("evil.example.com")
-	if err != nil {
-		t.Fatalf("UnbindCluster (second): %v", err)
-	}
-	if existed {
-		t.Fatal("second unbind reported existed=true, want false")
 	}
 }
 

--- a/cmd/entire/cli/logout.go
+++ b/cmd/entire/cli/logout.go
@@ -40,8 +40,8 @@ func newLogoutCmd() *cobra.Command {
 		Short: "Log out of Entire",
 		Long: "Log out of Entire.\n\n" +
 			"By default this removes the active login only. Other saved logins (contexts)\n" +
-			"remain and can still authenticate `git clone entire://…` against clusters they\n" +
-			"are bound to. Use --all to remove every saved login and its cluster bindings.",
+			"remain and can still authenticate `git clone entire://…` against any cluster\n" +
+			"fronted by their login server. Use --all to remove every saved login.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := requireSecureBaseURL(insecureHTTPAuth); err != nil {
 				return err
@@ -61,7 +61,7 @@ func newLogoutCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&all, "all", false, "Remove all saved logins (contexts) and their cluster bindings, not just the active one")
+	cmd.Flags().BoolVar(&all, "all", false, "Remove all saved logins (contexts), not just the active one")
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
 	return cmd
 }

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -12,11 +12,11 @@
 // ENTIRE_DEBUG-gated debuglog).
 //
 // Authentication resolves the login context for the target cluster from the
-// shared contexts.json (an explicit cluster binding, else
-// /.well-known discovery matched against local contexts), then mints
-// repo-scoped tokens by exchanging that context's login JWT. A
-// pre-contexts.json login is migrated at read-time so existing users don't
-// have to re-authenticate.
+// shared contexts.json: the cluster's cores come from the cluster_cores.json
+// cache (or a live /.well-known fetch on miss), then the account is selected
+// from local contexts. It then mints repo-scoped tokens by exchanging that
+// context's login JWT. A pre-contexts.json login is migrated at read-time so
+// existing users don't have to re-authenticate.
 package main
 
 import (

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -35,6 +34,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/discovery"
 	"github.com/entireio/cli/internal/entireclient/httpclient"
 	"github.com/entireio/cli/internal/entireclient/repocreds"
 	"github.com/entireio/cli/internal/remotehelper"
@@ -94,11 +94,13 @@ func run(args []string) int {
 		debuglog.Printf("legacy login migration: %v", err)
 	}
 
-	// Resolve which login context authenticates this cluster: an explicit
-	// cluster_contexts binding wins, otherwise the cluster's
-	// /.well-known/entire-cluster.json is matched against local contexts.
+	// Resolve which login context authenticates this cluster: the cluster's
+	// cores are taken from the cluster_cores.json cache (or a live
+	// /.well-known fetch on miss/expiry), then the account is selected from
+	// local contexts — active context if eligible, else the sole eligible
+	// one, else an explicit-choice error.
 	cfgDir := contexts.DefaultConfigDir()
-	clusterCtx, err := clusterdiscovery.ResolveContextForCluster(ctx, cfgDir, parsedURL.Host, httpClient, debuglog.Printf)
+	clusterCtx, err := clusterdiscovery.ResolveContextForCluster(ctx, cfgDir, discovery.DefaultCacheDir(), parsedURL.Host, httpClient, debuglog.Printf)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		return 128
@@ -110,14 +112,6 @@ func run(args []string) int {
 		return auth.LoginTokenForContext(clusterCtx)
 	}, httpClient)
 
-	// Persist the cluster→context binding the first time a scoped-token
-	// exchange succeeds, so the next invocation skips /.well-known
-	// discovery. Firing post-success (not on the discovery match in
-	// ResolveContextForCluster) means a host whose /.well-known matches a
-	// local context but then can't actually authenticate leaves no stale
-	// binding behind.
-	onScopedSuccess := makeBindHook(cfgDir, parsedURL.Host, clusterCtx.Name)
-
 	setAuth := func(req *http.Request) error {
 		action := gitActionFromRequest(req)
 		if action == "" {
@@ -126,9 +120,6 @@ func run(args []string) int {
 		token, err := creds.Token(req.Context(), repoSlug, action)
 		if err != nil {
 			return fmt.Errorf("repo-scoped token exchange: %w", err)
-		}
-		if onScopedSuccess != nil {
-			onScopedSuccess()
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 		return nil
@@ -157,36 +148,6 @@ func run(args []string) int {
 		return 128
 	}
 	return 0
-}
-
-// makeBindHook returns a func that, on its first call, persists the
-// clusterHost→contextName binding to contexts.json (and is a no-op
-// thereafter). It is meant to fire after the first successful scoped-token
-// exchange: at that point the context has provably authenticated against
-// the cluster, so the binding is safe to cache. A bind failure is logged,
-// not fatal — the token exchange already succeeded, and the next
-// invocation just pays the discovery round-trip again.
-//
-// Returns nil when contextName is empty (e.g. a future env-token flow with
-// no named context to bind), so callers can skip the hook entirely.
-//
-// Relies on creds being a freshly-constructed (empty) cache per process:
-// the first scoped-token call is therefore always a real exchange, never a
-// cache hit, so "first call" == "first proven auth".
-func makeBindHook(cfgDir, clusterHost, contextName string) func() {
-	if contextName == "" {
-		return nil
-	}
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			if err := contexts.BindCluster(cfgDir, clusterHost, contextName); err != nil {
-				debuglog.Printf("auto-bind %s -> %s failed: %v", clusterHost, contextName, err)
-				return
-			}
-			debuglog.Printf("auto-bound %s -> %s after first successful exchange", clusterHost, contextName)
-		})
-	}
 }
 
 // gitActionFromRequest classifies a smart-HTTP request as "pull" or "push"

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -109,6 +110,14 @@ func run(args []string) int {
 		return auth.LoginTokenForContext(clusterCtx)
 	}, httpClient)
 
+	// Persist the cluster→context binding the first time a scoped-token
+	// exchange succeeds, so the next invocation skips /.well-known
+	// discovery. Firing post-success (not on the discovery match in
+	// ResolveContextForCluster) means a host whose /.well-known matches a
+	// local context but then can't actually authenticate leaves no stale
+	// binding behind.
+	onScopedSuccess := makeBindHook(cfgDir, parsedURL.Host, clusterCtx.Name)
+
 	setAuth := func(req *http.Request) error {
 		action := gitActionFromRequest(req)
 		if action == "" {
@@ -117,6 +126,9 @@ func run(args []string) int {
 		token, err := creds.Token(req.Context(), repoSlug, action)
 		if err != nil {
 			return fmt.Errorf("repo-scoped token exchange: %w", err)
+		}
+		if onScopedSuccess != nil {
+			onScopedSuccess()
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 		return nil
@@ -145,6 +157,36 @@ func run(args []string) int {
 		return 128
 	}
 	return 0
+}
+
+// makeBindHook returns a func that, on its first call, persists the
+// clusterHost→contextName binding to contexts.json (and is a no-op
+// thereafter). It is meant to fire after the first successful scoped-token
+// exchange: at that point the context has provably authenticated against
+// the cluster, so the binding is safe to cache. A bind failure is logged,
+// not fatal — the token exchange already succeeded, and the next
+// invocation just pays the discovery round-trip again.
+//
+// Returns nil when contextName is empty (e.g. a future env-token flow with
+// no named context to bind), so callers can skip the hook entirely.
+//
+// Relies on creds being a freshly-constructed (empty) cache per process:
+// the first scoped-token call is therefore always a real exchange, never a
+// cache hit, so "first call" == "first proven auth".
+func makeBindHook(cfgDir, clusterHost, contextName string) func() {
+	if contextName == "" {
+		return nil
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			if err := contexts.BindCluster(cfgDir, clusterHost, contextName); err != nil {
+				debuglog.Printf("auto-bind %s -> %s failed: %v", clusterHost, contextName, err)
+				return
+			}
+			debuglog.Printf("auto-bound %s -> %s after first successful exchange", clusterHost, contextName)
+		})
+	}
 }
 
 // gitActionFromRequest classifies a smart-HTTP request as "pull" or "push"

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/entireio/cli/internal/entireclient/contexts"
 )
 
 func TestGitActionFromRequest(t *testing.T) {
@@ -35,63 +33,4 @@ func TestGitActionFromRequest(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestMakeBindHook(t *testing.T) {
-	t.Parallel()
-
-	t.Run("nil when no context name", func(t *testing.T) {
-		t.Parallel()
-		if makeBindHook(t.TempDir(), "host.example", "") != nil {
-			t.Fatal("expected nil hook for empty context name")
-		}
-	})
-
-	t.Run("binds cluster after first call", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		// BindCluster only writes a binding for a context that exists.
-		if err := contexts.Modify(dir, func(f *contexts.File) (bool, error) {
-			f.Upsert(&contexts.Context{
-				Name:            "ctx",
-				CoreURL:         "https://core.example",
-				Handle:          "h",
-				KeychainService: "svc",
-			})
-			return true, nil
-		}); err != nil {
-			t.Fatalf("seed context: %v", err)
-		}
-
-		hook := makeBindHook(dir, "cluster.example", "ctx")
-		if hook == nil {
-			t.Fatal("expected non-nil hook")
-		}
-		hook()
-		hook() // second call is a no-op (sync.Once); must not error or change state
-
-		f, err := contexts.Load(dir)
-		if err != nil {
-			t.Fatalf("load contexts: %v", err)
-		}
-		if got := f.ClusterContexts["cluster.example"]; got != "ctx" {
-			t.Fatalf("binding for cluster.example = %q, want %q", got, "ctx")
-		}
-	})
-
-	t.Run("no binding when context is missing", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		// No context named "ghost" exists, so BindCluster fails and the hook
-		// logs without persisting anything.
-		makeBindHook(dir, "cluster.example", "ghost")()
-
-		f, err := contexts.Load(dir)
-		if err != nil {
-			t.Fatalf("load contexts: %v", err)
-		}
-		if _, ok := f.ClusterContexts["cluster.example"]; ok {
-			t.Fatal("expected no binding to be written for a missing context")
-		}
-	})
 }

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
 )
 
 func TestGitActionFromRequest(t *testing.T) {
@@ -33,4 +35,63 @@ func TestGitActionFromRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMakeBindHook(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil when no context name", func(t *testing.T) {
+		t.Parallel()
+		if makeBindHook(t.TempDir(), "host.example", "") != nil {
+			t.Fatal("expected nil hook for empty context name")
+		}
+	})
+
+	t.Run("binds cluster after first call", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		// BindCluster only writes a binding for a context that exists.
+		if err := contexts.Modify(dir, func(f *contexts.File) (bool, error) {
+			f.Upsert(&contexts.Context{
+				Name:            "ctx",
+				CoreURL:         "https://core.example",
+				Handle:          "h",
+				KeychainService: "svc",
+			})
+			return true, nil
+		}); err != nil {
+			t.Fatalf("seed context: %v", err)
+		}
+
+		hook := makeBindHook(dir, "cluster.example", "ctx")
+		if hook == nil {
+			t.Fatal("expected non-nil hook")
+		}
+		hook()
+		hook() // second call is a no-op (sync.Once); must not error or change state
+
+		f, err := contexts.Load(dir)
+		if err != nil {
+			t.Fatalf("load contexts: %v", err)
+		}
+		if got := f.ClusterContexts["cluster.example"]; got != "ctx" {
+			t.Fatalf("binding for cluster.example = %q, want %q", got, "ctx")
+		}
+	})
+
+	t.Run("no binding when context is missing", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		// No context named "ghost" exists, so BindCluster fails and the hook
+		// logs without persisting anything.
+		makeBindHook(dir, "cluster.example", "ghost")()
+
+		f, err := contexts.Load(dir)
+		if err != nil {
+			t.Fatalf("load contexts: %v", err)
+		}
+		if _, ok := f.ClusterContexts["cluster.example"]; ok {
+			t.Fatal("expected no binding to be written for a missing context")
+		}
+	})
 }

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -107,7 +107,7 @@ func RenderLoginHint(clusterHost string, coreURLs []string) string {
 	for _, u := range coreURLs {
 		fmt.Fprintf(&b, "  %s\n", u)
 	}
-	fmt.Fprint(&b, "\nAuthenticate against one of those cores and re-run your command:\n"+
+	fmt.Fprint(&b, "\nAuthenticate against one of those login servers and re-run your command:\n"+
 		"  ENTIRE_AUTH_BASE_URL=<url> entire login\n"+
 		"or, if you already have a login there, switch to it with `entire auth use <context>`.")
 	return b.String()

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -5,45 +5,51 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 
 	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/discovery"
 )
 
-// ResolveContextForCluster picks the auth context for clusterHost.
-// Resolution order:
+// ResolveContextForCluster picks the local login context to authenticate
+// git operations against clusterHost.
 //
-//  1. Explicit `cluster_contexts[clusterHost]` binding in contexts.json
-//     pointing at an existing context — used as-is. Bindings are
-//     created only by deliberate action; this helper never writes one.
+// It separates two concerns that used to be conflated in a single
+// cluster→context binding:
 //
-//  2. Discovery via /.well-known/entire-cluster.json on the cluster
-//     itself, matched against existing local contexts by the
-//     advertised core_urls. The first advertised URL with a local
-//     context wins.
+//   - Which control plane(s) front the cluster — an objective infra fact.
+//     Discovered from the cluster's /.well-known/entire-cluster.json and
+//     cached in cluster_cores.json (see discovery.ClusterCoresCache) with
+//     a long TTL, since a cluster's home core is near-static. On a cache
+//     miss or expiry we re-fetch; if the re-fetch fails we fall back to
+//     the stale cached cores rather than break the op.
 //
-//     A discovery match is NOT persisted here. The caller binds the
-//     clusterHost→context mapping into contexts.json only after the
-//     first scoped-token exchange against the cluster succeeds (see
-//     makeBindHook in cmd/git-remote-entire). Binding post-success
-//     rather than on the bare /.well-known match means a host that
-//     advertises a core we hold a context for, but then can't actually
-//     authenticate us, never leaves a stale binding behind. Once bound,
-//     subsequent invocations short-circuit at step 1 and skip discovery.
+//   - Which of the user's accounts to use — recomputed every call from the
+//     live contexts, never persisted. So a user with several accounts is
+//     never silently pinned to one identity.
 //
-//  3. No local context matches any advertised URL — return a
-//     fatal-ready error with the login hint listing the cluster's
-//     advertised issuers.
+// Account selection (selectContext):
 //
-// We deliberately do NOT fall back to current_context for an unknown
-// cluster host. current_context can point at a different environment
-// than clusterHost (e.g. a staging context against a prod cluster); the
-// cluster then rejects the exchanged token with "unknown cluster_host"
-// because its own registry doesn't know that core. The cluster's
-// /.well-known is the authoritative answer to "which env am I in", so we
-// ask it rather than guessing from the active context.
+//  1. If the active context (current_context) is issued by one of the
+//     cluster's cores, use it. This is the explicit lever: `entire auth
+//     use <name>` chooses the identity for every cluster that context's
+//     core fronts.
+//  2. Otherwise gather every local context eligible for the cluster (its
+//     CoreURL is among the advertised cores):
+//     - exactly one  → use it (the common single-account case);
+//     - none         → error with the login hint listing the cluster's cores;
+//     - more than one → error asking the user to pick with `entire auth use`,
+//     rather than silently guessing an account.
+//
+// We never fall back to an active context whose core does NOT front the
+// cluster: the cluster would reject the exchanged token as "unknown
+// cluster_host", and silently authenticating a staging identity against a
+// prod cluster (or vice versa) is exactly the confusion the /.well-known
+// lookup exists to prevent.
 //
 // debugf is optional; nil suppresses debug output.
-func ResolveContextForCluster(ctx context.Context, configDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*contexts.Context, error) {
+func ResolveContextForCluster(ctx context.Context, configDir, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*contexts.Context, error) {
 	if debugf == nil {
 		debugf = func(string, ...any) {}
 	}
@@ -51,45 +57,114 @@ func ResolveContextForCluster(ctx context.Context, configDir, clusterHost string
 	if err != nil {
 		return nil, fmt.Errorf("load contexts: %w", err)
 	}
-	if name, ok := f.ClusterContexts[clusterHost]; ok && name != "" {
-		if c := f.Find(name); c != nil {
-			debugf("contexts.json binding %s -> %s", clusterHost, c.Name)
-			return c, nil
-		}
-		debugf("stale binding %s -> %q (context no longer exists); falling through to discovery", clusterHost, name)
+
+	coreURLs, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
+	if err != nil {
+		return nil, err
 	}
+
+	return selectContext(f, clusterHost, coreURLs, debugf)
+}
+
+// resolveClusterCores returns the control-plane core URLs that front
+// clusterHost, from cluster_cores.json when fresh, otherwise via a live
+// /.well-known fetch (which is then cached). A stale-but-present cache
+// entry is used as a fallback when the live fetch fails, so a brief
+// cluster outage doesn't break an operation whose cores we already knew.
+func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) ([]string, error) {
+	cache, err := discovery.LoadClusterCores(cacheDir)
+	if err != nil {
+		// A cache read problem must not block resolution — discover live.
+		debugf("cluster-cores cache load failed: %v; discovering live", err)
+		cache = nil
+	}
+
+	var stale []string
+	if cache != nil {
+		if urls, fresh, ok := cache.Get(clusterHost); ok {
+			if fresh {
+				debugf("cluster %s cores from cache: %v", clusterHost, urls)
+				return urls, nil
+			}
+			stale = urls
+			debugf("cluster %s cores cache expired; re-fetching /.well-known", clusterHost)
+		}
+	}
+
 	body, err := Discover(ctx, clusterHost, httpClient, debugf)
 	if err != nil {
+		if stale != nil {
+			debugf("discovery for %s failed (%v); falling back to stale cached cores %v", clusterHost, err, stale)
+			return stale, nil
+		}
 		return nil, formatDiscoveryError(clusterHost, err)
 	}
-	current := f.Find(f.CurrentContext)
-	for _, coreURL := range body.CoreURLs {
-		matches := f.ContextsForIssuer(coreURL)
-		if len(matches) == 0 {
-			continue
-		}
-		// Prefer the active context when it's one of the eligible matches —
-		// otherwise a core with several accounts (alice@core, bob@core) would
-		// resolve to whichever was saved first, silently authenticating as the
-		// wrong user. Fall back to the first match when the current context
-		// isn't eligible for this cluster. This tie-break only applies until
-		// the caller binds the cluster (after the first successful exchange);
-		// from then on step 1 returns the bound context directly. `entire auth
-		// use` therefore affects only not-yet-bound clusters — matching the
-		// `auth use`/`auth unbind` contract.
-		c := matches[0]
-		if current != nil {
-			for _, m := range matches {
-				if m.Name == current.Name {
-					c = current
-					break
-				}
+
+	if mErr := discovery.ModifyClusterCores(cacheDir, func(c discovery.ClusterCoresCache) error {
+		c.Set(clusterHost, body.CoreURLs)
+		return nil
+	}); mErr != nil {
+		// Non-fatal: we resolved the cores, the next call just re-fetches.
+		debugf("cluster-cores cache write for %s failed: %v", clusterHost, mErr)
+	}
+	return body.CoreURLs, nil
+}
+
+// selectContext applies the account-selection rules over the cluster's
+// advertised cores. See ResolveContextForCluster for the rationale.
+func selectContext(f *contexts.File, clusterHost string, coreURLs []string, debugf DebugFunc) (*contexts.Context, error) {
+	eligible := eligibleContexts(f, coreURLs)
+
+	// 1. Active context wins when it's eligible for this cluster.
+	if current := f.Find(f.CurrentContext); current != nil {
+		for _, c := range eligible {
+			if c.Name == current.Name {
+				debugf("cluster %s -> active context %s", clusterHost, current.Name)
+				return current, nil
 			}
 		}
-		debugf("resolved %s -> %s via discovery match on %s (caller binds on first successful exchange)", clusterHost, c.Name, coreURL)
-		return c, nil
 	}
-	return nil, errors.New(RenderLoginHint(clusterHost, body.CoreURLs))
+
+	// 2. Otherwise the eligible set decides.
+	switch len(eligible) {
+	case 0:
+		return nil, errors.New(RenderLoginHint(clusterHost, coreURLs))
+	case 1:
+		debugf("cluster %s -> sole eligible context %s", clusterHost, eligible[0].Name)
+		return eligible[0], nil
+	default:
+		return nil, ambiguousContextError(clusterHost, eligible)
+	}
+}
+
+// eligibleContexts returns the local contexts whose core is among coreURLs,
+// de-duplicated by name. Order is unspecified — callers either use the sole
+// element or report the whole set, never index [0] as a silent winner.
+func eligibleContexts(f *contexts.File, coreURLs []string) []*contexts.Context {
+	seen := make(map[string]bool)
+	var out []*contexts.Context
+	for _, coreURL := range coreURLs {
+		for _, c := range f.ContextsForIssuer(coreURL) {
+			if !seen[c.Name] {
+				seen[c.Name] = true
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
+// ambiguousContextError is returned when more than one local context could
+// authenticate against the cluster and none is active. We refuse to guess —
+// the user picks explicitly. Names are sorted so the message is stable.
+func ambiguousContextError(clusterHost string, eligible []*contexts.Context) error {
+	names := make([]string, len(eligible))
+	for i, c := range eligible {
+		names[i] = c.Name
+	}
+	sort.Strings(names)
+	return fmt.Errorf("multiple login contexts can authenticate against cluster %s (%s); choose one with `entire auth use <context>` and re-run",
+		clusterHost, strings.Join(names, ", "))
 }
 
 // formatDiscoveryError turns a Discover error into the message

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -19,21 +19,16 @@ import (
 //  2. Discovery via /.well-known/entire-cluster.json on the cluster
 //     itself, matched against existing local contexts by the
 //     advertised core_urls. The first advertised URL with a local
-//     context wins. This match applies to the current invocation only:
-//     this helper does not persist a cluster→context binding.
+//     context wins.
 //
-//     Resolving fresh on each call is a correctness choice, not a
-//     credential-safety one. The login JWT is only ever sent to the
-//     resolved context's CoreURL — a core the user already holds a local
-//     context for — never to clusterHost; the token clusterHost receives
-//     is repo-scoped and audience-pinned to clusterHost itself (see
-//     repocreds.exchange). A hostile clusterHost can at most steer us
-//     toward a core we already trust; it cannot introduce a new core or
-//     capture an identity-bearing token. What resolving fresh buys is
-//     immediacy: `entire auth use` and context deletion take effect on
-//     the next fetch with no stale binding to unbind, and no
-//     host→core mapping derived from a host-controlled /.well-known
-//     lingers in contexts.json.
+//     A discovery match is NOT persisted here. The caller binds the
+//     clusterHost→context mapping into contexts.json only after the
+//     first scoped-token exchange against the cluster succeeds (see
+//     makeBindHook in cmd/git-remote-entire). Binding post-success
+//     rather than on the bare /.well-known match means a host that
+//     advertises a core we hold a context for, but then can't actually
+//     authenticate us, never leaves a stale binding behind. Once bound,
+//     subsequent invocations short-circuit at step 1 and skip discovery.
 //
 //  3. No local context matches any advertised URL — return a
 //     fatal-ready error with the login hint listing the cluster's
@@ -77,9 +72,11 @@ func ResolveContextForCluster(ctx context.Context, configDir, clusterHost string
 		// otherwise a core with several accounts (alice@core, bob@core) would
 		// resolve to whichever was saved first, silently authenticating as the
 		// wrong user. Fall back to the first match when the current context
-		// isn't eligible for this cluster. Because we re-resolve every
-		// invocation (no persisted binding), `entire auth use` takes effect
-		// immediately for unbound clusters.
+		// isn't eligible for this cluster. This tie-break only applies until
+		// the caller binds the cluster (after the first successful exchange);
+		// from then on step 1 returns the bound context directly. `entire auth
+		// use` therefore affects only not-yet-bound clusters — matching the
+		// `auth use`/`auth unbind` contract.
 		c := matches[0]
 		if current != nil {
 			for _, m := range matches {
@@ -89,7 +86,7 @@ func ResolveContextForCluster(ctx context.Context, configDir, clusterHost string
 				}
 			}
 		}
-		debugf("resolved %s -> %s via discovery match on %s (ephemeral; binding not persisted)", clusterHost, c.Name, coreURL)
+		debugf("resolved %s -> %s via discovery match on %s (caller binds on first successful exchange)", clusterHost, c.Name, coreURL)
 		return c, nil
 	}
 	return nil, errors.New(RenderLoginHint(clusterHost, body.CoreURLs))

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -1,96 +1,42 @@
 package clusterdiscovery
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/discovery"
 )
 
-// TestResolveContextForClusterBindingShortCircuits: an explicit
-// cluster_contexts binding is used directly — no /.well-known hit.
-func TestResolveContextForClusterBindingShortCircuits(t *testing.T) {
-	configDir := t.TempDir()
-	require.NoError(t, contexts.Save(configDir, &contexts.File{
-		CurrentContext: "current",
-		ClusterContexts: map[string]string{
-			"bound.example.com": "us",
-		},
-		Contexts: []*contexts.Context{
-			{Name: "current", CoreURL: "https://current.example", Handle: "alice", KeychainService: "kc:current"},
-			{Name: "us", CoreURL: "https://us.auth.entire.io", Handle: "bob", KeychainService: "kc:us"},
-		},
-	}))
-
-	// Fail-loud HTTP client: any actual request is a bug.
-	failClient := &http.Client{Transport: failTransport(t)}
-
-	c, err := ResolveContextForCluster(t.Context(), configDir, "bound.example.com", failClient, t.Logf)
+// coresHandler serves a fixed core_urls list and counts how many times
+// /.well-known was hit, so tests can assert cache hits vs live fetches.
+func coresHandler(t *testing.T, calls *int32, coreURLs ...string) http.HandlerFunc {
+	t.Helper()
+	body, err := json.Marshal(Response{CoreURLs: coreURLs})
 	require.NoError(t, err)
-	assert.Equal(t, "us", c.Name)
-}
-
-// TestResolveContextForClusterDiscoversEphemerally: no binding, no
-// fallback to current_context — instead we hit /.well-known, match the
-// first advertised core URL against a local context, and resolve it for
-// this invocation only. We deliberately do NOT persist a binding: a
-// drive-by clone of an attacker host must not establish a durable,
-// silent auth channel, so every call re-evaluates the live /.well-known.
-func TestResolveContextForClusterDiscoversEphemerally(t *testing.T) {
-	var calls int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if calls != nil {
+			atomic.AddInt32(calls, 1)
+		}
 		assert.Equal(t, Path, r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"core_urls":["https://eu.auth.entire.io","https://us.auth.entire.io"]}`)) //nolint:errcheck // test
-	}))
-	defer srv.Close()
-
-	configDir := t.TempDir()
-	require.NoError(t, contexts.Save(configDir, &contexts.File{
-		// current_context points at a STAGING login — the bug we're
-		// fixing is that this used to silently get reused against a
-		// prod cluster host. The PROD login below should be the one
-		// discovery picks via the well-known match.
-		CurrentContext: "staging-eu",
-		Contexts: []*contexts.Context{
-			{Name: "staging-eu", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:staging"},
-			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod-eu"},
-		},
-	}))
-
-	c, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
-	require.NoError(t, err)
-	assert.Equal(t, "prod-eu", c.Name, "should pick the prod context, NOT current_context")
-	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "first call hits discovery once")
-
-	// No binding was persisted — the resolution is ephemeral.
-	f, err := contexts.Load(configDir)
-	require.NoError(t, err)
-	assert.Empty(t, f.ClusterContexts, "discovery must not persist a cluster binding")
-
-	// Second call re-discovers (no short-circuit), keeping the trust
-	// decision fresh and revocable.
-	c2, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
-	require.NoError(t, err)
-	assert.Equal(t, "prod-eu", c2.Name)
-	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "ephemeral resolution re-hits discovery each call")
+		_, _ = w.Write(body) //nolint:errcheck // test
+	}
 }
 
-// TestResolveContextForClusterPrefersCurrentAmongSameCoreMatches: when a
-// core has several accounts (alice@core, bob@core) and bob is the active
-// context, discovery must resolve to bob, not to whichever was saved
-// first — otherwise a clone silently authenticates as the wrong user.
-func TestResolveContextForClusterPrefersCurrentAmongSameCoreMatches(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"core_urls":["https://eu.auth.entire.io"]}`)) //nolint:errcheck // test
-	}))
+// TestResolve_ActiveContextWinsWhenEligible: the active context is issued
+// by one of the cluster's cores, so it is used even though another eligible
+// context exists for the same core.
+func TestResolve_ActiveContextWinsWhenEligible(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
 	defer srv.Close()
 
 	configDir := t.TempDir()
@@ -102,20 +48,64 @@ func TestResolveContextForClusterPrefersCurrentAmongSameCoreMatches(t *testing.T
 		},
 	}))
 
-	c, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.NoError(t, err)
-	assert.Equal(t, "bob@eu", c.Name, "should prefer the active context among same-core matches")
+	assert.Equal(t, "bob@eu", c.Name, "active eligible context must win over other same-core accounts")
 }
 
-// TestResolveContextForClusterNoMatchReturnsLoginHint: discovery
-// succeeds but the user has no context for any of the advertised core
-// URLs. Error message tells them which login URL to use — that's the
-// whole point of having /.well-known.
-func TestResolveContextForClusterNoMatchReturnsLoginHint(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"core_urls":["https://eu.auth.entire.io"]}`)) //nolint:errcheck // test
+// TestResolve_SoleEligibleContextUsedDespiteUnrelatedActive: the active
+// context is on an unrelated core, but the user has exactly one context
+// eligible for the cluster — use it (the 99% single-account case).
+func TestResolve_SoleEligibleContextUsedDespiteUnrelatedActive(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "paul@unrelated",
+		Contexts: []*contexts.Context{
+			{Name: "paul@unrelated", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:unrelated"},
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
 	}))
+
+	c, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name)
+}
+
+// TestResolve_AmbiguousMultipleEligibleErrors: two same-core accounts are
+// eligible and neither is active — refuse to guess, list both, and tell the
+// user to pick. This is the footgun this redesign closes.
+func TestResolve_AmbiguousMultipleEligibleErrors(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(coresHandler(t, nil, "https://core-us.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "paul@unrelated",
+		Contexts: []*contexts.Context{
+			{Name: "alice@core-us", CoreURL: "https://core-us.entire.io", Handle: "alice", KeychainService: "kc:alice"},
+			{Name: "admin@core-us", CoreURL: "https://core-us.entire.io", Handle: "admin", KeychainService: "kc:admin"},
+			{Name: "paul@unrelated", CoreURL: "https://eu.auth.partial.to", Handle: "paul", KeychainService: "kc:unrelated"},
+		},
+	}))
+
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "cluster1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple login contexts")
+	assert.Contains(t, err.Error(), "admin@core-us")
+	assert.Contains(t, err.Error(), "alice@core-us")
+	assert.Contains(t, err.Error(), "entire auth use")
+}
+
+// TestResolve_NoEligibleContextReturnsLoginHint: discovery succeeds but the
+// user has no context for any advertised core.
+func TestResolve_NoEligibleContextReturnsLoginHint(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(coresHandler(t, nil, "https://eu.auth.entire.io"))
 	defer srv.Close()
 
 	configDir := t.TempDir()
@@ -126,7 +116,7 @@ func TestResolveContextForClusterNoMatchReturnsLoginHint(t *testing.T) {
 		},
 	}))
 
-	_, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no auth context for cluster aws-eu-central-1.entire.io")
 	assert.Contains(t, err.Error(), "https://eu.auth.entire.io")
@@ -134,38 +124,79 @@ func TestResolveContextForClusterNoMatchReturnsLoginHint(t *testing.T) {
 	assert.Contains(t, err.Error(), "ENTIRE_AUTH_BASE_URL")
 }
 
-// TestResolveContextForClusterStaleBindingFallsThrough: a binding that
-// names a non-existent context is treated as if no binding exists —
-// we discover and match a real context for this invocation (without
-// rewriting the binding).
-func TestResolveContextForClusterStaleBindingFallsThrough(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"core_urls":["https://eu.auth.entire.io"]}`)) //nolint:errcheck // test
-	}))
+// TestResolve_CoresCachedAcrossCalls: the first call hits /.well-known and
+// caches the cores; the second is served from cluster_cores.json with no
+// network hit.
+func TestResolve_CoresCachedAcrossCalls(t *testing.T) {
+	t.Parallel()
+	var calls int32
+	srv := httptest.NewServer(coresHandler(t, &calls, "https://eu.auth.entire.io"))
 	defer srv.Close()
 
 	configDir := t.TempDir()
+	cacheDir := t.TempDir()
 	require.NoError(t, contexts.Save(configDir, &contexts.File{
-		CurrentContext: "current",
-		ClusterContexts: map[string]string{
-			"aws-eu-central-1.entire.io": "deleted",
-		},
+		CurrentContext: "prod-eu",
 		Contexts: []*contexts.Context{
-			{Name: "current", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:current"},
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
 		},
 	}))
 
-	c, err := ResolveContextForCluster(t.Context(), configDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	c, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
 	require.NoError(t, err)
-	assert.Equal(t, "current", c.Name)
+	assert.Equal(t, "prod-eu", c.Name)
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls), "first call fetches /.well-known")
+
+	c2, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c2.Name)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "second call is served from the cores cache")
+
+	// The cores fact is persisted; the account choice is not.
+	cache, err := discovery.LoadClusterCores(cacheDir)
+	require.NoError(t, err)
+	urls, fresh, ok := cache.Get("aws-eu-central-1.entire.io")
+	require.True(t, ok)
+	assert.True(t, fresh)
+	assert.Equal(t, []string{"https://eu.auth.entire.io"}, urls)
 }
 
-// TestResolveContextForClusterUnreachable: transport failure surfaces
-// the "doesn't look like a cluster" message — the user can't tell a
-// typo from a real-but-down cluster, and either way the next step is
-// the same.
-func TestResolveContextForClusterUnreachable(t *testing.T) {
+// TestResolve_StaleCacheFallbackOnDiscoveryFailure: an expired cache entry
+// is used when the live re-fetch fails, so a brief cluster outage doesn't
+// break an operation whose cores we already knew.
+func TestResolve_StaleCacheFallbackOnDiscoveryFailure(t *testing.T) {
+	t.Parallel()
+	// Server is closed immediately so any discovery attempt fails.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	client := hostPinningClient(t, srv)
+	srv.Close()
+
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod-eu",
+		Contexts: []*contexts.Context{
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}))
+	// Seed an EXPIRED cores entry.
+	require.NoError(t, discovery.ModifyClusterCores(cacheDir, func(c discovery.ClusterCoresCache) error {
+		c["aws-eu-central-1.entire.io"] = &discovery.CoresEntry{
+			CoreURLs:  []string{"https://eu.auth.entire.io"},
+			FetchedAt: time.Now().Add(-discovery.ClusterCoresTTL - time.Hour),
+		}
+		return nil
+	}))
+
+	c, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", client, t.Logf)
+	require.NoError(t, err, "should fall back to stale cores when re-fetch fails")
+	assert.Equal(t, "prod-eu", c.Name)
+}
+
+// TestResolve_Unreachable: transport failure with no cached cores surfaces
+// the "doesn't look like a cluster" message.
+func TestResolve_Unreachable(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	client := hostPinningClient(t, srv)
 	srv.Close()
@@ -178,15 +209,15 @@ func TestResolveContextForClusterUnreachable(t *testing.T) {
 		},
 	}))
 
-	_, err := ResolveContextForCluster(t.Context(), configDir, "missing.example.com", client, t.Logf)
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "missing.example.com", client, t.Logf)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing.example.com doesn't look like a cluster, or it is unreachable")
 }
 
-// TestResolveContextForCluster503: HTTP 503 from /.well-known is a
-// distinct operator surface — the cluster is up but has no trusted
-// issuers configured. The error must point at the admin, not the user.
-func TestResolveContextForCluster503(t *testing.T) {
+// TestResolve_503: HTTP 503 from /.well-known points at the admin, not the
+// user.
+func TestResolve_503(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "no issuers", http.StatusServiceUnavailable)
 	}))
@@ -197,23 +228,8 @@ func TestResolveContextForCluster503(t *testing.T) {
 		Contexts: []*contexts.Context{{Name: "x", CoreURL: "https://x.example", Handle: "x", KeychainService: "kc:x"}},
 	}))
 
-	_, err := ResolveContextForCluster(t.Context(), configDir, "rc.partial.to", hostPinningClient(t, srv), t.Logf)
+	_, err := ResolveContextForCluster(t.Context(), configDir, t.TempDir(), "rc.partial.to", hostPinningClient(t, srv), t.Logf)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not advertise any trusted login servers")
 	assert.Contains(t, err.Error(), "cluster administrator")
 }
-
-// failTransport returns a RoundTripper that fails the test if invoked —
-// used by the binding-short-circuit test to prove we never hit the
-// network.
-func failTransport(t *testing.T) http.RoundTripper {
-	t.Helper()
-	return roundTripFunc(func(*http.Request) (*http.Response, error) {
-		t.Fatal("unexpected HTTP call: binding should have short-circuited discovery")
-		return nil, nil
-	})
-}
-
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -5,10 +5,9 @@
 //
 //   - a list of named contexts, each pairing a core URL, principal handle,
 //     and OS-keychain slot where the access + refresh tokens live;
-//   - cluster_contexts, a map from entire-server cluster host to the
-//     context name that should authenticate ops against that cluster;
-//   - current_context, the fallback for clusters with no binding and the
-//     default for direct CLI commands not tied to a cluster.
+//   - current_context, the active login: the preferred identity for cluster
+//     operations and the default for direct CLI commands not tied to a
+//     cluster.
 //
 // File invariants: 0600, atomic temp+rename, exclusive flock under load.
 // Both CLIs share the same file so a login from either is visible to the

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -46,12 +46,15 @@ type Context struct {
 
 // File is the on-disk shape of contexts.json.
 type File struct {
-	// CurrentContext is the fallback for unbound clusters and the default
-	// for direct CLI commands. Empty until the first login.
+	// CurrentContext is the active login; the default identity for cluster
+	// operations and direct CLI commands. Empty until the first login.
 	CurrentContext string `json:"current_context,omitempty"`
-	// ClusterContexts maps entire-server cluster host → context name.
-	// Populated lazily after a successful op against the cluster, or
-	// explicitly via `entire-core context bind HOST NAME`.
+	// ClusterContexts is a legacy cluster host → context name binding map.
+	// No longer read or written: the cluster's cores are cached separately
+	// (discovery.ClusterCoresCache) and the account is chosen fresh per
+	// operation. The field is retained only so an existing contexts.json
+	// round-trips without losing data; Delete still prunes entries and a
+	// full logout clears it. Safe to drop once no deployed tool writes it.
 	ClusterContexts map[string]string `json:"cluster_contexts,omitempty"`
 	// Contexts is the list of stored credentials. Order is preserved on
 	// disk so list output stays stable across saves.
@@ -149,25 +152,6 @@ func (f *File) Find(name string) *Context {
 	return nil
 }
 
-// Resolve picks the context to use for an entire-server cluster. The
-// binding wins when present and points at an existing context;
-// otherwise we fall back to the current context. Returns nil when
-// neither resolves.
-func (f *File) Resolve(clusterHost string) *Context {
-	if f == nil {
-		return nil
-	}
-	if name, ok := f.ClusterContexts[clusterHost]; ok && name != "" {
-		if c := f.Find(name); c != nil {
-			return c
-		}
-		// Stale binding (context deleted out from under it). Treat as
-		// no binding rather than erroring — the current_context fallback
-		// is the safer behaviour.
-	}
-	return f.Find(f.CurrentContext)
-}
-
 // Upsert replaces the context with matching Name, or appends. Sets the
 // current context when there isn't one already (first login).
 func (f *File) Upsert(c *Context) {
@@ -245,28 +229,6 @@ func Modify(configDir string, fn func(*File) (changed bool, err error)) error {
 		return nil
 	}
 	return writeNoLock(path, f)
-}
-
-// BindCluster sets cluster_contexts[host] = name atomically. Errors
-// when the named context doesn't exist (a stale binding is a foot-gun).
-// Idempotent.
-func BindCluster(configDir, host, name string) error {
-	if host == "" || name == "" {
-		return errors.New("BindCluster requires non-empty host and context name")
-	}
-	return Modify(configDir, func(f *File) (bool, error) {
-		if f.Find(name) == nil {
-			return false, fmt.Errorf("no context named %q", name)
-		}
-		if f.ClusterContexts == nil {
-			f.ClusterContexts = map[string]string{}
-		}
-		if f.ClusterContexts[host] == name {
-			return false, nil
-		}
-		f.ClusterContexts[host] = name
-		return true, nil
-	})
 }
 
 func lockFile(path string) (func(), error) {

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -52,12 +52,6 @@ type File struct {
 	// Contexts is the list of stored credentials. Order is preserved on
 	// disk so list output stays stable across saves.
 	Contexts []*Context `json:"contexts,omitempty"`
-
-	// NOTE: a legacy "cluster_contexts" map used to live here, binding a
-	// cluster host to one context name. It's gone — cluster cores are cached
-	// in discovery.ClusterCoresCache and the account is chosen fresh per
-	// operation. json.Unmarshal ignores the obsolete key, so an old file
-	// loads cleanly; the key drops out on the next write.
 }
 
 // FilePath returns $configDir/contexts.json after ensuring the directory
@@ -172,8 +166,10 @@ func (f *File) Upsert(c *Context) {
 	}
 }
 
-// Delete drops the context with the given name. If the deleted context
-// was current, the current pointer advances to whatever remains (or empty).
+// Delete drops the context with the given name. If it was the current
+// context, current_context is cleared — never reassigned to another
+// context, so deleting your active login never silently switches you to a
+// different identity.
 func (f *File) Delete(name string) {
 	if f == nil || name == "" {
 		return
@@ -184,9 +180,6 @@ func (f *File) Delete(name string) {
 	}
 	if f.CurrentContext == name {
 		f.CurrentContext = ""
-		if len(f.Contexts) > 0 {
-			f.CurrentContext = f.Contexts[0].Name
-		}
 	}
 }
 

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -46,8 +46,9 @@ type Context struct {
 
 // File is the on-disk shape of contexts.json.
 type File struct {
-	// CurrentContext is the active login; the default identity for cluster
-	// operations and direct CLI commands. Empty until the first login.
+	// CurrentContext is the active login; preferred identity for cluster
+	// operations (used when its CoreURL is eligible for the target cluster)
+	// and the default for direct CLI commands. Empty until the first login.
 	CurrentContext string `json:"current_context,omitempty"`
 	// Contexts is the list of stored credentials. Order is preserved on
 	// disk so list output stays stable across saves.

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -49,16 +49,15 @@ type File struct {
 	// CurrentContext is the active login; the default identity for cluster
 	// operations and direct CLI commands. Empty until the first login.
 	CurrentContext string `json:"current_context,omitempty"`
-	// ClusterContexts is a legacy cluster host → context name binding map.
-	// No longer read or written: the cluster's cores are cached separately
-	// (discovery.ClusterCoresCache) and the account is chosen fresh per
-	// operation. The field is retained only so an existing contexts.json
-	// round-trips without losing data; Delete still prunes entries and a
-	// full logout clears it. Safe to drop once no deployed tool writes it.
-	ClusterContexts map[string]string `json:"cluster_contexts,omitempty"`
 	// Contexts is the list of stored credentials. Order is preserved on
 	// disk so list output stays stable across saves.
 	Contexts []*Context `json:"contexts,omitempty"`
+
+	// NOTE: a legacy "cluster_contexts" map used to live here, binding a
+	// cluster host to one context name. It's gone — cluster cores are cached
+	// in discovery.ClusterCoresCache and the account is chosen fresh per
+	// operation. json.Unmarshal ignores the obsolete key, so an old file
+	// loads cleanly; the key drops out on the next write.
 }
 
 // FilePath returns $configDir/contexts.json after ensuring the directory
@@ -173,9 +172,8 @@ func (f *File) Upsert(c *Context) {
 	}
 }
 
-// Delete drops the context with the given name, plus any cluster
-// bindings that pointed at it. If the deleted context was current, the
-// current pointer advances to whatever remains (or empty).
+// Delete drops the context with the given name. If the deleted context
+// was current, the current pointer advances to whatever remains (or empty).
 func (f *File) Delete(name string) {
 	if f == nil || name == "" {
 		return
@@ -183,11 +181,6 @@ func (f *File) Delete(name string) {
 	idx := slices.IndexFunc(f.Contexts, func(c *Context) bool { return c.Name == name })
 	if idx >= 0 {
 		f.Contexts = slices.Delete(f.Contexts, idx, idx+1)
-	}
-	for host, target := range f.ClusterContexts {
-		if target == name {
-			delete(f.ClusterContexts, host)
-		}
 	}
 	if f.CurrentContext == name {
 		f.CurrentContext = ""
@@ -201,7 +194,7 @@ func (f *File) Delete(name string) {
 // exclusive flock — load, mutate, write all happen with the lock held.
 // Use this for any read-modify-write sequence; calling Load and Save
 // separately releases the lock between them and races concurrent
-// writers (e.g. a parallel git push triggering BindCluster).
+// writers (e.g. a parallel login recording a context).
 //
 // fn returns (changed, err). When changed is false the file isn't
 // rewritten — useful for idempotent operations that often have

--- a/internal/entireclient/contexts/contexts_test.go
+++ b/internal/entireclient/contexts/contexts_test.go
@@ -123,57 +123,6 @@ func TestUpsert_ReplacesByName(t *testing.T) {
 	}
 }
 
-func TestResolve_ClusterBindingWins(t *testing.T) {
-	f := &contexts.File{
-		CurrentContext: "default",
-		ClusterContexts: map[string]string{
-			"royalcanin.partial.to": "special",
-		},
-		Contexts: []*contexts.Context{
-			{Name: "default"},
-			{Name: "special"},
-		},
-	}
-	got := f.Resolve("royalcanin.partial.to")
-	if got == nil || got.Name != "special" {
-		t.Errorf("Resolve = %v, want context %q", got, "special")
-	}
-}
-
-func TestResolve_FallsBackToCurrent(t *testing.T) {
-	f := &contexts.File{
-		CurrentContext: "default",
-		Contexts:       []*contexts.Context{{Name: "default"}},
-	}
-	got := f.Resolve("unbound.example")
-	if got == nil || got.Name != "default" {
-		t.Errorf("Resolve = %v, want fallback to %q", got, "default")
-	}
-}
-
-func TestResolve_StaleBindingFallsBack(t *testing.T) {
-	// Binding points at a deleted context — Resolve must not return nil
-	// just because someone forgot to clean up; fall back to current.
-	f := &contexts.File{
-		CurrentContext: "default",
-		ClusterContexts: map[string]string{
-			"royalcanin.partial.to": "deleted-name",
-		},
-		Contexts: []*contexts.Context{{Name: "default"}},
-	}
-	got := f.Resolve("royalcanin.partial.to")
-	if got == nil || got.Name != "default" {
-		t.Errorf("stale binding: Resolve = %v, want fallback to %q", got, "default")
-	}
-}
-
-func TestResolve_NoCurrentNoBindingReturnsNil(t *testing.T) {
-	f := &contexts.File{}
-	if got := f.Resolve("anything.example"); got != nil {
-		t.Errorf("Resolve on empty file = %v, want nil", got)
-	}
-}
-
 func TestDelete_DropsContextAndBindings(t *testing.T) {
 	f := &contexts.File{
 		CurrentContext: "stays",
@@ -226,39 +175,6 @@ func TestDelete_OfLastClearsCurrent(t *testing.T) {
 	}
 	if len(f.Contexts) != 0 {
 		t.Errorf("len(Contexts) = %d, want 0", len(f.Contexts))
-	}
-}
-
-func TestBindCluster_PersistsAndRequiresExistingContext(t *testing.T) {
-	dir := t.TempDir()
-	if err := contexts.Save(dir, &contexts.File{
-		CurrentContext: "eu-paul",
-		Contexts:       []*contexts.Context{{Name: "eu-paul"}},
-	}); err != nil {
-		t.Fatalf("Save: %v", err)
-	}
-
-	// Binding to a non-existent context is rejected — stale bindings are
-	// a foot-gun.
-	if err := contexts.BindCluster(dir, "host.example", "no-such-context"); err == nil {
-		t.Error("BindCluster to missing context: want error, got nil")
-	}
-
-	if err := contexts.BindCluster(dir, "host.example", "eu-paul"); err != nil {
-		t.Fatalf("BindCluster: %v", err)
-	}
-
-	got, err := contexts.Load(dir)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if got.ClusterContexts["host.example"] != "eu-paul" {
-		t.Errorf("ClusterContexts[host.example] = %q, want %q", got.ClusterContexts["host.example"], "eu-paul")
-	}
-
-	// Idempotent: same binding twice is fine.
-	if err := contexts.BindCluster(dir, "host.example", "eu-paul"); err != nil {
-		t.Fatalf("idempotent BindCluster: %v", err)
 	}
 }
 
@@ -373,16 +289,6 @@ func TestModify_HoldsLockAcrossLoadAndSave(t *testing.T) {
 	}
 	if got.CurrentContext != strconv.Itoa(n) {
 		t.Errorf("CurrentContext = %q, want %q (lost updates indicate non-atomic RMW)", got.CurrentContext, strconv.Itoa(n))
-	}
-}
-
-func TestBindCluster_RejectsEmptyArgs(t *testing.T) {
-	dir := t.TempDir()
-	if err := contexts.BindCluster(dir, "", "name"); err == nil {
-		t.Error("empty host: want error")
-	}
-	if err := contexts.BindCluster(dir, "host", ""); err == nil {
-		t.Error("empty name: want error")
 	}
 }
 

--- a/internal/entireclient/contexts/contexts_test.go
+++ b/internal/entireclient/contexts/contexts_test.go
@@ -140,7 +140,7 @@ func TestDelete_DropsContext(t *testing.T) {
 	}
 }
 
-func TestDelete_OfCurrentAdvancesPointer(t *testing.T) {
+func TestDelete_OfCurrentClearsCurrent(t *testing.T) {
 	f := &contexts.File{
 		CurrentContext: "first",
 		Contexts: []*contexts.Context{
@@ -149,8 +149,11 @@ func TestDelete_OfCurrentAdvancesPointer(t *testing.T) {
 		},
 	}
 	f.Delete("first")
-	if f.CurrentContext != "second" {
-		t.Errorf("after deleting current, CurrentContext = %q, want next remaining (%q)", f.CurrentContext, "second")
+	if f.CurrentContext != "" {
+		t.Errorf("after deleting current, CurrentContext = %q, want empty (no fallback to another identity)", f.CurrentContext)
+	}
+	if f.Find("second") == nil {
+		t.Error("Delete dropped the unrelated remaining context")
 	}
 }
 

--- a/internal/entireclient/contexts/contexts_test.go
+++ b/internal/entireclient/contexts/contexts_test.go
@@ -22,7 +22,7 @@ func TestLoad_MissingFileReturnsEmpty(t *testing.T) {
 	if f == nil {
 		t.Fatal("Load returned nil File")
 	}
-	if f.CurrentContext != "" || len(f.Contexts) != 0 || len(f.ClusterContexts) != 0 {
+	if f.CurrentContext != "" || len(f.Contexts) != 0 {
 		t.Errorf("expected zero-valued File, got %+v", f)
 	}
 }
@@ -31,9 +31,6 @@ func TestSaveLoad_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	want := &contexts.File{
 		CurrentContext: "eu-paul",
-		ClusterContexts: map[string]string{
-			"royalcanin.partial.to": "us-superadmin",
-		},
 		Contexts: []*contexts.Context{
 			{Name: "eu-paul", CoreURL: "https://eu.example", Handle: "paul", KeychainService: "entire-core:eu-paul"},
 			{Name: "us-superadmin", CoreURL: "https://us.example", Handle: "superadmin", KeychainService: "entire-core:us-superadmin"},
@@ -123,13 +120,9 @@ func TestUpsert_ReplacesByName(t *testing.T) {
 	}
 }
 
-func TestDelete_DropsContextAndBindings(t *testing.T) {
+func TestDelete_DropsContext(t *testing.T) {
 	f := &contexts.File{
 		CurrentContext: "stays",
-		ClusterContexts: map[string]string{
-			"a.example": "doomed",
-			"b.example": "stays",
-		},
 		Contexts: []*contexts.Context{
 			{Name: "stays"},
 			{Name: "doomed"},
@@ -139,11 +132,8 @@ func TestDelete_DropsContextAndBindings(t *testing.T) {
 	if f.Find("doomed") != nil {
 		t.Error("Delete left context behind")
 	}
-	if _, exists := f.ClusterContexts["a.example"]; exists {
-		t.Error("Delete left dangling cluster binding")
-	}
-	if f.ClusterContexts["b.example"] != "stays" {
-		t.Error("Delete clobbered unrelated cluster binding")
+	if f.Find("stays") == nil {
+		t.Error("Delete dropped an unrelated context")
 	}
 	if f.CurrentContext != "stays" {
 		t.Errorf("CurrentContext = %q, want %q (untouched)", f.CurrentContext, "stays")

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -130,7 +130,7 @@ func lockCache(path string) (func(), error) {
 // readCacheFile reads and unmarshals a JSON cache file. A missing file or a
 // corrupt one both yield a fresh empty value (newEmpty), so a damaged cache
 // self-heals on the next write instead of wedging callers.
-func readCacheFile[T any](path string, newEmpty func() T) (T, error) { //nolint:ireturn // generic helper returns the caller's concrete cache type, not an abstract interface
+func readCacheFile[T any](path string, newEmpty func() T) (T, error) {
 	data, exists, err := readCacheBytes(path)
 	if err != nil {
 		var zero T

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -71,7 +71,9 @@ func ModifyCache(cacheDir string, fn func(ClusterCache) error) error {
 }
 
 func readCacheNoLock(path string) (ClusterCache, error) {
-	return readCacheFile(path, func() ClusterCache { return make(ClusterCache) })
+	cache := make(ClusterCache)
+	err := loadCacheFile(path, &cache, func() ClusterCache { return make(ClusterCache) })
+	return cache, err
 }
 
 func writeCacheNoLock(path string, cache ClusterCache) error {
@@ -127,23 +129,24 @@ func lockCache(path string) (func(), error) {
 	return func() { _ = fl.Unlock() }, nil //nolint:errcheck // unlock failure is non-fatal
 }
 
-// readCacheFile reads and unmarshals a JSON cache file. A missing file or a
-// corrupt one both yield a fresh empty value (newEmpty), so a damaged cache
-// self-heals on the next write instead of wedging callers.
-func readCacheFile[T any](path string, newEmpty func() T) (T, error) {
+// loadCacheFile reads path and unmarshals it into dst. A missing file leaves
+// dst at its caller-initialized (empty) value; a corrupt file resets dst via
+// newEmpty so a damaged cache self-heals on the next write instead of wedging
+// callers. Returns an error only on a genuine read failure. Returning error
+// (rather than the cache value itself) keeps this generic helper off the
+// ireturn linter while still sharing the read/unmarshal logic across caches.
+func loadCacheFile[T any](path string, dst *T, newEmpty func() T) error {
 	data, exists, err := readCacheBytes(path)
 	if err != nil {
-		var zero T
-		return zero, err
+		return err
 	}
-	c := newEmpty()
 	if !exists {
-		return c, nil
+		return nil
 	}
-	if err := json.Unmarshal(data, &c); err != nil {
-		return newEmpty(), nil //nolint:nilerr // intentional: treat corrupt cache as empty
+	if json.Unmarshal(data, dst) != nil {
+		*dst = newEmpty() // corrupt → start fresh
 	}
-	return c, nil
+	return nil
 }
 
 // writeCacheFile marshals v and writes it atomically (tmp + rename).

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -55,16 +55,9 @@ func LoadCache(cacheDir string) (ClusterCache, error) {
 
 // SaveCache writes the cache to disk atomically under an exclusive flock.
 func SaveCache(cacheDir string, cache ClusterCache) error {
-	if err := os.MkdirAll(cacheDir, 0700); err != nil {
-		return fmt.Errorf("create cache dir: %w", err)
-	}
-	path := filepath.Join(cacheDir, cacheFileName)
-	unlock, err := lockCache(path)
-	if err != nil {
-		return err
-	}
-	defer unlock()
-	return writeCacheNoLock(path, cache)
+	return withCacheFileLock(cacheDir, cacheFileName, func(path string) error {
+		return writeCacheNoLock(path, cache)
+	})
 }
 
 // ModifyCache atomically applies fn to the node cache under a single
@@ -74,24 +67,49 @@ func SaveCache(cacheDir string, cache ClusterCache) error {
 // (e.g. two parallel clone/fetch/push processes updating nodes.json), losing
 // each other's entries.
 func ModifyCache(cacheDir string, fn func(ClusterCache) error) error {
+	return modifyCacheFile(cacheDir, cacheFileName, readCacheNoLock, writeCacheNoLock, fn)
+}
+
+func readCacheNoLock(path string) (ClusterCache, error) {
+	return readCacheFile(path, func() ClusterCache { return make(ClusterCache) })
+}
+
+func writeCacheNoLock(path string, cache ClusterCache) error {
+	return writeCacheFile(path, cache)
+}
+
+// --- shared cache-file primitives (used by every cache file in this
+// package: nodes.json, cluster_cores.json) ---
+
+// withCacheFileLock ensures cacheDir exists, takes the exclusive flock for
+// the named cache file, and runs fn with the file's path.
+func withCacheFileLock(cacheDir, fileName string, fn func(path string) error) error {
 	if err := os.MkdirAll(cacheDir, 0700); err != nil {
 		return fmt.Errorf("create cache dir: %w", err)
 	}
-	path := filepath.Join(cacheDir, cacheFileName)
+	path := filepath.Join(cacheDir, fileName)
 	unlock, err := lockCache(path)
 	if err != nil {
 		return err
 	}
 	defer unlock()
+	return fn(path)
+}
 
-	cache, err := readCacheNoLock(path)
-	if err != nil {
-		return err
-	}
-	if err := fn(cache); err != nil {
-		return err
-	}
-	return writeCacheNoLock(path, cache)
+// modifyCacheFile runs a load → mutate → write cycle for one cache file with
+// the file's flock held throughout, so concurrent processes filling the same
+// entry don't clobber each other.
+func modifyCacheFile[T any](cacheDir, fileName string, read func(string) (T, error), write func(string, T) error, fn func(T) error) error {
+	return withCacheFileLock(cacheDir, fileName, func(path string) error {
+		c, err := read(path)
+		if err != nil {
+			return err
+		}
+		if err := fn(c); err != nil {
+			return err
+		}
+		return write(path, c)
+	})
 }
 
 func lockCache(path string) (func(), error) {
@@ -109,27 +127,50 @@ func lockCache(path string) (func(), error) {
 	return func() { _ = fl.Unlock() }, nil //nolint:errcheck // unlock failure is non-fatal
 }
 
-func readCacheNoLock(path string) (ClusterCache, error) {
-	data, err := os.ReadFile(path) // #nosec G304
+// readCacheFile reads and unmarshals a JSON cache file. A missing file or a
+// corrupt one both yield a fresh empty value (newEmpty), so a damaged cache
+// self-heals on the next write instead of wedging callers.
+func readCacheFile[T any](path string, newEmpty func() T) (T, error) { //nolint:ireturn // generic helper returns the caller's concrete cache type, not an abstract interface
+	data, exists, err := readCacheBytes(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return make(ClusterCache), nil
-		}
-		return nil, fmt.Errorf("read cache: %w", err)
+		var zero T
+		return zero, err
 	}
-	var cache ClusterCache
-	if err := json.Unmarshal(data, &cache); err != nil {
-		// Corrupted cache — start fresh.
-		return make(ClusterCache), nil //nolint:nilerr // intentional: treat corrupt cache as empty
+	c := newEmpty()
+	if !exists {
+		return c, nil
 	}
-	return cache, nil
+	if err := json.Unmarshal(data, &c); err != nil {
+		return newEmpty(), nil //nolint:nilerr // intentional: treat corrupt cache as empty
+	}
+	return c, nil
 }
 
-func writeCacheNoLock(path string, cache ClusterCache) error {
-	data, err := json.MarshalIndent(cache, "", "  ")
+// writeCacheFile marshals v and writes it atomically (tmp + rename).
+func writeCacheFile[T any](path string, v T) error {
+	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal cache: %w", err)
 	}
+	return writeCacheBytesAtomic(path, data)
+}
+
+// readCacheBytes returns the file contents and whether the file exists. A
+// missing file is (nil, false, nil); other read errors propagate.
+func readCacheBytes(path string) ([]byte, bool, error) {
+	data, err := os.ReadFile(path) // #nosec G304
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("read cache: %w", err)
+	}
+	return data, true, nil
+}
+
+// writeCacheBytesAtomic writes data via a tmp file + rename so a reader never
+// observes a half-written cache.
+func writeCacheBytesAtomic(path string, data []byte) error {
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0600); err != nil {
 		return fmt.Errorf("write cache tmp: %w", err)

--- a/internal/entireclient/discovery/cluster_cores.go
+++ b/internal/entireclient/discovery/cluster_cores.go
@@ -13,7 +13,7 @@ const (
 	// near-static infra — once a cluster is homed to a core it stays — so a
 	// long TTL is fine. On expiry we re-fetch /.well-known and only fall back
 	// to the stale entry if that fetch fails.
-	ClusterCoresTTL = 7 * 24 * time.Hour
+	ClusterCoresTTL = 24 * time.Hour
 )
 
 // ClusterCoresCache maps a cluster host to the control-plane core URLs that

--- a/internal/entireclient/discovery/cluster_cores.go
+++ b/internal/entireclient/discovery/cluster_cores.go
@@ -49,7 +49,9 @@ func ModifyClusterCores(cacheDir string, fn func(ClusterCoresCache) error) error
 }
 
 func readClusterCoresNoLock(path string) (ClusterCoresCache, error) {
-	return readCacheFile(path, func() ClusterCoresCache { return make(ClusterCoresCache) })
+	cache := make(ClusterCoresCache)
+	err := loadCacheFile(path, &cache, func() ClusterCoresCache { return make(ClusterCoresCache) })
+	return cache, err
 }
 
 func writeClusterCoresNoLock(path string, cache ClusterCoresCache) error {

--- a/internal/entireclient/discovery/cluster_cores.go
+++ b/internal/entireclient/discovery/cluster_cores.go
@@ -1,0 +1,78 @@
+package discovery
+
+import (
+	"path/filepath"
+	"time"
+)
+
+const (
+	clusterCoresFileName = "cluster_cores.json"
+
+	// ClusterCoresTTL bounds how long a cached cluster→core_urls mapping is
+	// treated as fresh. Which control plane(s) front a data-plane cluster is
+	// near-static infra — once a cluster is homed to a core it stays — so a
+	// long TTL is fine. On expiry we re-fetch /.well-known and only fall back
+	// to the stale entry if that fetch fails.
+	ClusterCoresTTL = 7 * 24 * time.Hour
+)
+
+// ClusterCoresCache maps a cluster host to the control-plane core URLs that
+// front it, memoizing /.well-known/entire-cluster.json so routine git ops
+// don't re-fetch it every time. It stores only the objective cluster→core
+// fact — never which local account to authenticate as. The account is chosen
+// fresh on every operation from the user's contexts, so a multi-account user
+// is never silently pinned to one identity.
+//
+// Cache file: cluster_cores.json in the cache dir (alongside nodes.json).
+// Safe to delete by hand to force re-discovery.
+type ClusterCoresCache map[string]*CoresEntry
+
+// CoresEntry is one cluster's cached core URLs plus when they were fetched.
+// Freshness is fetched_at + ClusterCoresTTL, computed at read time so a TTL
+// change re-interprets existing entries without a migration.
+type CoresEntry struct {
+	CoreURLs  []string  `json:"core_urls"`
+	FetchedAt time.Time `json:"fetched_at"`
+}
+
+// LoadClusterCores reads the cluster→cores cache. A missing or corrupt file
+// yields an empty cache. Unlocked read; use ModifyClusterCores for a
+// read-modify-write sequence.
+func LoadClusterCores(cacheDir string) (ClusterCoresCache, error) {
+	return readClusterCoresNoLock(filepath.Join(cacheDir, clusterCoresFileName))
+}
+
+// ModifyClusterCores atomically applies fn to the cluster→cores cache under a
+// single exclusive flock.
+func ModifyClusterCores(cacheDir string, fn func(ClusterCoresCache) error) error {
+	return modifyCacheFile(cacheDir, clusterCoresFileName, readClusterCoresNoLock, writeClusterCoresNoLock, fn)
+}
+
+func readClusterCoresNoLock(path string) (ClusterCoresCache, error) {
+	return readCacheFile(path, func() ClusterCoresCache { return make(ClusterCoresCache) })
+}
+
+func writeClusterCoresNoLock(path string, cache ClusterCoresCache) error {
+	return writeCacheFile(path, cache)
+}
+
+// Get returns a cluster's cached core URLs, whether the entry is still fresh,
+// and whether it exists at all. A present-but-stale entry returns
+// (urls, false, true) so callers can attempt a re-fetch yet fall back to the
+// stale URLs if that fetch fails.
+func (c ClusterCoresCache) Get(cluster string) (urls []string, fresh, ok bool) {
+	entry := c[cluster]
+	if entry == nil || len(entry.CoreURLs) == 0 {
+		return nil, false, false
+	}
+	return entry.CoreURLs, time.Now().Before(entry.FetchedAt.Add(ClusterCoresTTL)), true
+}
+
+// Set records a cluster's core URLs, stamping the fetch time to now. The
+// slice is copied so later mutation by the caller can't corrupt the cache.
+func (c ClusterCoresCache) Set(cluster string, urls []string) {
+	c[cluster] = &CoresEntry{
+		CoreURLs:  append([]string(nil), urls...),
+		FetchedAt: time.Now(),
+	}
+}

--- a/internal/entireclient/discovery/cluster_cores_test.go
+++ b/internal/entireclient/discovery/cluster_cores_test.go
@@ -1,0 +1,122 @@
+package discovery
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClusterCores_RoundTripFresh(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	if err := ModifyClusterCores(dir, func(c ClusterCoresCache) error {
+		c.Set("aws-us-east-2.entire.io", []string{"https://us.auth.entire.io", "https://eu.auth.entire.io"})
+		return nil
+	}); err != nil {
+		t.Fatalf("ModifyClusterCores: %v", err)
+	}
+
+	cache, err := LoadClusterCores(dir)
+	if err != nil {
+		t.Fatalf("LoadClusterCores: %v", err)
+	}
+	urls, fresh, ok := cache.Get("aws-us-east-2.entire.io")
+	if !ok {
+		t.Fatal("expected entry to exist")
+	}
+	if !fresh {
+		t.Fatal("expected freshly-set entry to be fresh")
+	}
+	if len(urls) != 2 || urls[0] != "https://us.auth.entire.io" || urls[1] != "https://eu.auth.entire.io" {
+		t.Fatalf("unexpected core URLs: %v", urls)
+	}
+}
+
+func TestClusterCores_Miss(t *testing.T) {
+	t.Parallel()
+	cache, err := LoadClusterCores(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadClusterCores: %v", err)
+	}
+	if _, _, ok := cache.Get("unknown.example"); ok {
+		t.Fatal("expected miss for unknown cluster")
+	}
+}
+
+func TestClusterCores_StaleEntryStillReturned(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Write an entry whose fetch time is older than the TTL.
+	if err := ModifyClusterCores(dir, func(c ClusterCoresCache) error {
+		c["old.example"] = &CoresEntry{
+			CoreURLs:  []string{"https://core.example"},
+			FetchedAt: time.Now().Add(-ClusterCoresTTL - time.Hour),
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("ModifyClusterCores: %v", err)
+	}
+
+	cache, err := LoadClusterCores(dir)
+	if err != nil {
+		t.Fatalf("LoadClusterCores: %v", err)
+	}
+	urls, fresh, ok := cache.Get("old.example")
+	if !ok {
+		t.Fatal("stale entry should still report ok=true so callers can fall back to it")
+	}
+	if fresh {
+		t.Fatal("entry older than the TTL should report fresh=false")
+	}
+	if len(urls) != 1 || urls[0] != "https://core.example" {
+		t.Fatalf("unexpected stale core URLs: %v", urls)
+	}
+}
+
+func TestClusterCores_ModifyAccumulates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	if err := ModifyClusterCores(dir, func(c ClusterCoresCache) error {
+		c.Set("a.example", []string{"https://core-a.example"})
+		return nil
+	}); err != nil {
+		t.Fatalf("ModifyClusterCores a: %v", err)
+	}
+	// Second modify must see the first's write (single locked RMW) rather
+	// than clobbering it.
+	if err := ModifyClusterCores(dir, func(c ClusterCoresCache) error {
+		c.Set("b.example", []string{"https://core-b.example"})
+		return nil
+	}); err != nil {
+		t.Fatalf("ModifyClusterCores b: %v", err)
+	}
+
+	cache, err := LoadClusterCores(dir)
+	if err != nil {
+		t.Fatalf("LoadClusterCores: %v", err)
+	}
+	if _, _, ok := cache.Get("a.example"); !ok {
+		t.Fatal("first entry lost after second modify")
+	}
+	if _, _, ok := cache.Get("b.example"); !ok {
+		t.Fatal("second entry missing")
+	}
+}
+
+func TestClusterCores_SetCopiesSlice(t *testing.T) {
+	t.Parallel()
+	cache := make(ClusterCoresCache)
+	urls := []string{"https://core.example"}
+	cache.Set("c.example", urls)
+	urls[0] = "https://evil.example" // mutate caller's slice after Set
+
+	got, _, ok := cache.Get("c.example")
+	if !ok {
+		t.Fatal("expected entry")
+	}
+	if got[0] != "https://core.example" {
+		t.Fatalf("Set did not copy the slice; cache corrupted to %v", got)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/471
<!-- entire-trail-link-end -->

TLDR: Cache entiredb-cluster→entire-core mappings

#  Problem

  Resolving which login context to use for an `entire://` cluster mixed two concerns: which control plane fronts a cluster (stable infra) and which of your accounts to use (per-user). When several contexts were eligible and none was active, it picked one by last-save order and persisted that guess as a binding — so the choice was somewhat arbitrary, and the stored state ended up asymmetric and confusing.

#  99% happy path: unchanged

  - One account → exactly one eligible context → used automatically. No prompt, no extra step.
  - No added latency — `/.well-known` is cached; first op per cluster fetches once, as before.
  - No migration / re-login — existing `contexts.json` loads as-is; the obsolete `cluster_contexts` key is ignored and removed.
  - A new error fires only on genuine ambiguity (2+ accounts on the same core, none active) — previously a silent guess (e.g., `admin@core`, `paul@core` both match), now a clear "pick one."

#  Change

  - Cache only the objective `cluster → [core_urls]` fact (in `cluster_cores.json`, 24h TTL, stale-fallback). The matching account is recomputed locally every op, never persisted.
  - Selection: active context if eligible → else the sole eligible one → else (2+ eligible, none active) a one-line error listing them and pointing at `entire auth use`, instead of guessing.
  - Drops the now-defunct bind/unbind surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how every `entire://` operation picks credentials (auth path); wrong selection or stale core cache could block git or use the wrong account until the user runs `entire auth use` or clears cache.
> 
> **Overview**
> This PR **splits cluster auth into infra vs identity**: only **which cores front a cluster** is cached (`cluster_cores.json`, 24h TTL, stale fallback on discovery failure); **which login context to use** is recomputed every git op and never written to disk.
> 
> **`entire://` resolution** loads cores from cache or `/.well-known`, then picks a context: active context if its core is eligible → else the only eligible context → else an error listing candidates and pointing at `entire auth use` (no silent multi-account guess).
> 
> **Removed** persisted `cluster_contexts`, `BindCluster` / `File.Resolve`, and **`entire auth unbind`** plus cluster-binding output from **`entire auth contexts`**. **Logout / delete** no longer auto-advance `current_context` to another stored identity.
> 
> Shared discovery cache I/O is refactored for the new cores file; **`git-remote-entire`** passes the discovery cache dir into resolution. **`.gitignore`** adds `/git-remote-entire`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb6bdb6c2fe049402eb47c983c71e5f217f28ac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->