### PR TITLE
Auth contexts: finish binding-removal cleanup, use "login server" wording

### DIFF
--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -11,25 +11,25 @@ import (
 
 // newAuthUseCmd switches the active login context.
 //
-// For `git clone entire://…` the active context is only a fallback: a
-// cluster already bound to a context (cluster_contexts) keeps using that
-// binding, and the active context is consulted only the first time a
-// not-yet-bound cluster is resolved. Control-plane commands (auth status/
-// list/revoke, org/project/repo/grant) currently target the configured auth
-// host (ENTIRE_AUTH_BASE_URL / the default) regardless of the active
-// context's core, so switching to a context on a *different* core does not
-// yet retarget them — auth use warns when that's the case.
+// For `git clone entire://…` the active context is the preferred identity:
+// it authenticates any cluster fronted by its login server, and switching
+// here takes effect on the next operation (resolution recomputes the account
+// every time). Control-plane commands (auth status/list/revoke, org/project/
+// repo/grant) currently target the configured auth host (ENTIRE_AUTH_BASE_URL
+// / the default) regardless of the active context's login server, so
+// switching to a context on a *different* login server does not yet retarget
+// them — auth use warns when that's the case.
 func newAuthUseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "use <context>",
 		Short: "Switch the active login context",
 		Long: "Switch the active login context.\n\n" +
-			"For `git clone entire://…` the active context is only a fallback: a cluster\n" +
-			"already bound to a context keeps using that binding, so switching here affects\n" +
-			"only clusters not yet bound (and same-core tie-breaking on first resolve).\n\n" +
+			"For `git clone entire://…` the active context is the preferred identity: it\n" +
+			"authenticates any cluster fronted by its login server, and the switch takes\n" +
+			"effect on the next operation.\n\n" +
 			"Control-plane commands (auth status/list/revoke, org/project/repo/grant) still\n" +
 			"target the configured auth host (ENTIRE_AUTH_BASE_URL / the default), so\n" +
-			"switching to a context on a different core does not retarget them yet.",
+			"switching to a context on a different login server does not retarget them yet.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := auth.SetCurrentContext(args[0]); err != nil {
@@ -62,9 +62,9 @@ func warnIfCrossCoreContext(errW io.Writer, name string) {
 			return
 		}
 		fmt.Fprintf(errW,
-			"Note: %q authenticates against %s, but control-plane commands still target %s — cross-core control-plane switching isn't supported yet.\n"+
-				"For `git clone entire://…`, a cluster already bound to another context keeps using it; the active context applies only to clusters not yet bound.\n",
-			name, c.CoreURL, authHost)
+			"Note: %q authenticates against %s, but control-plane commands still target %s — switching the active context doesn't retarget control-plane commands yet.\n"+
+				"For `git clone entire://…`, this context now authenticates any cluster fronted by %s.\n",
+			name, c.CoreURL, authHost, c.CoreURL)
 		return
 	}
 }

--- a/cmd/entire/cli/logout.go
+++ b/cmd/entire/cli/logout.go
@@ -40,8 +40,8 @@ func newLogoutCmd() *cobra.Command {
 		Short: "Log out of Entire",
 		Long: "Log out of Entire.\n\n" +
 			"By default this removes the active login only. Other saved logins (contexts)\n" +
-			"remain and can still authenticate `git clone entire://…` against clusters they\n" +
-			"are bound to. Use --all to remove every saved login and its cluster bindings.",
+			"remain and can still authenticate `git clone entire://…` against any cluster\n" +
+			"fronted by their login server. Use --all to remove every saved login.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := requireSecureBaseURL(insecureHTTPAuth); err != nil {
 				return err
@@ -61,7 +61,7 @@ func newLogoutCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&all, "all", false, "Remove all saved logins (contexts) and their cluster bindings, not just the active one")
+	cmd.Flags().BoolVar(&all, "all", false, "Remove all saved logins (contexts), not just the active one")
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
 	return cmd
 }

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -12,11 +12,11 @@
 // ENTIRE_DEBUG-gated debuglog).
 //
 // Authentication resolves the login context for the target cluster from the
-// shared contexts.json (an explicit cluster binding, else
-// /.well-known discovery matched against local contexts), then mints
-// repo-scoped tokens by exchanging that context's login JWT. A
-// pre-contexts.json login is migrated at read-time so existing users don't
-// have to re-authenticate.
+// shared contexts.json: the cluster's cores come from the cluster_cores.json
+// cache (or a live /.well-known fetch on miss), then the account is selected
+// from local contexts. It then mints repo-scoped tokens by exchanging that
+// context's login JWT. A pre-contexts.json login is migrated at read-time so
+// existing users don't have to re-authenticate.
 package main
 
 import (

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -107,7 +107,7 @@ func RenderLoginHint(clusterHost string, coreURLs []string) string {
 	for _, u := range coreURLs {
 		fmt.Fprintf(&b, "  %s\n", u)
 	}
-	fmt.Fprint(&b, "\nAuthenticate against one of those cores and re-run your command:\n"+
+	fmt.Fprint(&b, "\nAuthenticate against one of those login servers and re-run your command:\n"+
 		"  ENTIRE_AUTH_BASE_URL=<url> entire login\n"+
 		"or, if you already have a login there, switch to it with `entire auth use <context>`.")
 	return b.String()

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -5,10 +5,9 @@
 //
 //   - a list of named contexts, each pairing a core URL, principal handle,
 //     and OS-keychain slot where the access + refresh tokens live;
-//   - cluster_contexts, a map from entire-server cluster host to the
-//     context name that should authenticate ops against that cluster;
-//   - current_context, the fallback for clusters with no binding and the
-//     default for direct CLI commands not tied to a cluster.
+//   - current_context, the active login: the preferred identity for cluster
+//     operations and the default for direct CLI commands not tied to a
+//     cluster.
 //
 // File invariants: 0600, atomic temp+rename, exclusive flock under load.
 // Both CLIs share the same file so a login from either is visible to the


### PR DESCRIPTION
Stacked on top of #1318 (`20260602-auth-contexts`).

#1318 removes the cluster→context binding model, but a few user-facing strings and package docs still describe bindings that no longer exist, and the user-facing copy used the internal term **core** for the JWT issuer. This cleans that up.

## Changes (docs/help text only — no logic)

- **`logout --help` / `--all` flag** — no longer claims to remove "cluster bindings" (logout removes logins; there are no bindings anymore).
- **`auth use` — doc comment, `--help` `Long`, and the cross-core runtime warning** — reframed: the active context is the preferred identity that authenticates any cluster its **login server** fronts, and the switch takes effect on the next operation. Drops the obsolete "bound / not yet bound" narrative.
- **`git-remote-entire` package doc** — describes cores-cache-or-`/.well-known` resolution instead of "an explicit cluster binding, else discovery".
- **`contexts` package doc** — drops the removed `cluster_contexts` field; reframes `current_context`.
- **`RenderLoginHint` + warning copy** — "core(s)" → "login server(s)" so user-facing text doesn't leak the internal issuer term.

## Verification

- `go build ./...` clean
- `mise run fmt` applied
- affected `cli` + `clusterdiscovery` tests pass
- `golangci-lint` 0 issues on all changed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)