### PR TITLE
mirror: drain probe body before close so the idle pool works

### DIFF
--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -208,7 +208,16 @@ func mirrorAdvertisesHead(ctx context.Context, checkURL, token string) (ready bo
 	if err != nil {
 		return false, 0
 	}
-	defer func() { _ = resp.Body.Close() }()
+	// Drain before close so the transport can return the connection to the
+	// idle pool and reuse the TLS session on the next tick. Go only recycles
+	// a conn whose body was read to EOF before Close; the Decode error
+	// returns below leave the body partially read, so without this drain the
+	// pool is defeated and every probe pays a fresh TLS handshake. Bound the
+	// drain by maxProbeBytes to match the read cap above.
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxProbeBytes)) //nolint:errcheck // best-effort drain to enable conn reuse; copy errors are irrelevant
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusOK {
 		return false, resp.StatusCode
 	}

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -210,12 +210,14 @@ func mirrorAdvertisesHead(ctx context.Context, checkURL, token string) (ready bo
 	}
 	// Drain before close so the transport can return the connection to the
 	// idle pool and reuse the TLS session on the next tick. Go only recycles
-	// a conn whose body was read to EOF before Close; the Decode error
-	// returns below leave the body partially read, so without this drain the
-	// pool is defeated and every probe pays a fresh TLS handshake. Bound the
-	// drain by maxProbeBytes to match the read cap above.
+	// a conn whose body was read to EOF before Close, and the Decode error
+	// returns below leave the body partially read. Drain to EOF, uncapped:
+	// the maxProbeBytes cap on the read below bounds the Decode *allocation*,
+	// but draining to io.Discard is O(1) memory, and a LimitReader cap
+	// shorter than the body would stop before EOF and silently defeat reuse.
+	// The client Timeout still bounds how long the drain can run.
 	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxProbeBytes)) //nolint:errcheck // best-effort drain to enable conn reuse; copy errors are irrelevant
+		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck // best-effort drain to enable conn reuse; copy errors are irrelevant
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != http.StatusOK {

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -142,7 +142,7 @@ func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, 
 
 	cloning := false
 	for {
-		ready, status := mirrorAdvertisesHead(ctx, checkURL, token)
+		ready, status := mirrorAdvertisesHead(ctx, probeClient, checkURL, token)
 		switch {
 		case ready:
 			if cloning {
@@ -198,13 +198,13 @@ func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, 
 // 0 for transport/build/decode failures, treated as "not ready, keep
 // waiting". Auth is the repo-scoped token as HTTP basic-auth password, the
 // same shape git presents over the entire:// transport.
-func mirrorAdvertisesHead(ctx context.Context, checkURL, token string) (ready bool, status int) {
+func mirrorAdvertisesHead(ctx context.Context, client *http.Client, checkURL, token string) (ready bool, status int) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checkURL, nil)
 	if err != nil {
 		return false, 0
 	}
 	req.SetBasicAuth("entire-cli", token)
-	resp, err := probeClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return false, 0
 	}

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -1,7 +1,16 @@
 package cli
 
 import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/internal/coreapi"
 )
@@ -152,4 +161,60 @@ func TestValidateClusterHost(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMirrorAdvertisesHead_ReusesConnection is the regression test for the
+// body drain in mirrorAdvertisesHead. The probe runs every 2s for up to 30m,
+// and probeClient keeps a small idle pool specifically to reuse the TLS
+// session across ticks — but Go only returns a connection to that pool when
+// the response body is read to EOF before Close. If the drain is removed (or
+// re-capped shorter than the body), the body is left partially read and the
+// transport closes the connection instead, so every probe pays a fresh
+// handshake.
+//
+// We serve a non-200 with a non-empty body: mirrorAdvertisesHead returns at
+// the status check without reading the body itself, so the deferred drain is
+// the *only* thing that consumes it. Counting StateNew transitions then
+// distinguishes "drained → one reused connection" from "not drained → a new
+// connection per call".
+func TestMirrorAdvertisesHead_ReusesConnection(t *testing.T) {
+	t.Parallel()
+
+	// Larger than any plausible "small cap" someone might reintroduce, so a
+	// capped drain would stop before EOF and fail this test too.
+	body := strings.Repeat("x", 64<<10)
+
+	var newConns atomic.Int64
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// 503 = mirror reachable but not ready; the function returns at the
+		// status check below http.StatusOK without touching the body.
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(body)) //nolint:errcheck // test server write; failure surfaces as a client error
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	srv.Start()
+	defer srv.Close()
+
+	// Isolated client (not the package-global probeClient) so the idle pool
+	// is private to this test and the assertion stays deterministic under
+	// t.Parallel(). Keep-alives and idle pooling are on by default.
+	client := &http.Client{
+		Timeout:   15 * time.Second,
+		Transport: &http.Transport{MaxIdleConns: 2, MaxIdleConnsPerHost: 2, IdleConnTimeout: 90 * time.Second},
+	}
+
+	const probes = 5
+	for range probes {
+		ready, status := mirrorAdvertisesHead(context.Background(), client, srv.URL, "tok")
+		require.False(t, ready)
+		require.Equal(t, http.StatusServiceUnavailable, status)
+	}
+
+	require.Equal(t, int64(1), newConns.Load(),
+		"expected the drained body to let all %d probes share one connection; got %d new connections (body not drained to EOF?)",
+		probes, newConns.Load())
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/474
<!-- entire-trail-link-end -->

## Summary

`probeClient` (used by the mirror clone-readiness loop in `repo_mirror_probe.go`) is deliberately built with a small idle pool (`MaxIdleConns: 2`) and a 90s `IdleConnTimeout`, specifically to reuse the TLS session across the 2s probes. But Go's transport only returns a connection to the idle pool when the response body is read to EOF **before** `Close()`.

`mirrorAdvertisesHead` closed the body without draining it, and the `sr.Decode`/`adv.Decode` error returns leave the body partially read. So the connection was closed instead of pooled — every 2s probe paid a fresh TLS handshake, defeating the pool's stated purpose. Over a 30-minute wait (~900 probes) that's 900 handshakes instead of one reused connection.

## Change

Drain the body (bounded by `maxProbeBytes` to match the existing read cap) before closing, so the transport can recycle the connection.

## Testing

- `mise run fmt` + `mise run lint` — clean
- `go build ./cmd/entire/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized HTTP client lifecycle fix in the mirror readiness probe; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes mirror clone-readiness probes so **`probeClient`** can actually reuse idle connections and TLS sessions between ~2s ticks.
> 
> In **`mirrorAdvertisesHead`**, the response body is now **drained** (capped at **`maxProbeBytes`**, same as the decode path) before **`Close()`**, because partial reads from decode/error paths prevented Go’s transport from returning connections to the pool—long waits could repeat a full TLS handshake on every probe instead of one reused connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aed46f181e8afc9e807655a41347cba4a9cbeb6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->