### PR TITLE
Simplify login: drop clipboard copy and code-entry prompt

### DIFF
--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/atotto/clipboard"
 	"github.com/entireio/auth-go/tokens"
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
@@ -41,9 +40,6 @@ func chooseApprovalURL(start *auth.DeviceAuthStart) string {
 	return start.VerificationURI
 }
 
-// clipboardWriteFunc is the signature for copying text to the user's clipboard.
-type clipboardWriteFunc func(text string) error
-
 // deviceAuthClient abstracts the auth client so runLogin and waitForApproval can be unit-tested.
 type deviceAuthClient interface {
 	StartDeviceAuth(ctx context.Context) (*auth.DeviceAuthStart, error)
@@ -60,14 +56,14 @@ func newLoginCmd() *cobra.Command {
 			if err := requireSecureBaseURL(insecureHTTPAuth); err != nil {
 				return err
 			}
-			return runLogin(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), auth.NewClient(nil, insecureHTTPAuth), openBrowser, copyToClipboard)
+			return runLogin(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), auth.NewClient(nil, insecureHTTPAuth), openBrowser)
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
 	return cmd
 }
 
-func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc, writeClipboard clipboardWriteFunc) error {
+func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc) error {
 	start, err := client.StartDeviceAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("start login: %w", err)
@@ -78,7 +74,11 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	approvalURL := chooseApprovalURL(start)
 
 	if interactive.CanPromptInteractively() {
-		fmt.Fprintf(outW, "Press Enter to copy the code to your clipboard, open %s in your browser, and enter the generated device code...", approvalURL)
+		// chooseApprovalURL prefers the code-embedded verification_uri_complete,
+		// so opening the URL is usually all the user needs to do. The device
+		// code is printed above regardless, so it's still available to confirm
+		// against the page (RFC 8628 §3.3.1) or to enter on the bare-URI fallback.
+		fmt.Fprintf(outW, "Press Enter to open %s in your browser to approve this login...", approvalURL)
 
 		// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
 		if err := waitForEnter(ctx); err != nil {
@@ -86,13 +86,9 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		}
 
 		fmt.Fprintln(outW)
-		if copied := copyDeviceCodeToClipboard(errW, start.UserCode, writeClipboard); copied {
-			fmt.Fprintln(outW, "Device code copied to clipboard.")
-		}
-
 		if err := openURL(ctx, approvalURL); err != nil {
 			fmt.Fprintf(errW, "Warning: failed to open browser: %v\n", err)
-			fmt.Fprintf(outW, "Open the approval URL in your browser to continue and enter the generated device code: %s\n", approvalURL)
+			fmt.Fprintf(outW, "Open this URL in your browser to approve this login: %s\n", approvalURL)
 		}
 	} else {
 		fmt.Fprintf(outW, "Approval URL: %s\n", approvalURL)
@@ -183,24 +179,6 @@ func issMatches(claimed, expected string) error {
 	normExpected := api.OriginOnly(expected)
 	if normClaimed != normExpected {
 		return fmt.Errorf("iss mismatch: token claims %q, expected %q", normClaimed, normExpected)
-	}
-	return nil
-}
-
-func copyDeviceCodeToClipboard(errW io.Writer, userCode string, writeClipboard clipboardWriteFunc) bool {
-	if writeClipboard == nil {
-		return false
-	}
-	if err := writeClipboard(userCode); err != nil {
-		fmt.Fprintf(errW, "Warning: failed to copy device code to clipboard: %v\n", err)
-		return false
-	}
-	return true
-}
-
-func copyToClipboard(text string) error {
-	if err := clipboard.WriteAll(text); err != nil {
-		return fmt.Errorf("write clipboard: %w", err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -37,43 +36,6 @@ func (m *mockClient) PollDeviceAuth(_ context.Context, _ string) (*auth.DeviceAu
 	r := m.responses[m.calls]
 	m.calls++
 	return r.result, r.err
-}
-
-func TestCopyDeviceCodeToClipboard_Success(t *testing.T) {
-	t.Parallel()
-
-	var errBuf bytes.Buffer
-	var copied string
-	ok := copyDeviceCodeToClipboard(&errBuf, "ABCD-1234", func(text string) error {
-		copied = text
-		return nil
-	})
-
-	if !ok {
-		t.Fatal("copyDeviceCodeToClipboard() = false, want true")
-	}
-	if copied != "ABCD-1234" {
-		t.Fatalf("copied = %q, want device code", copied)
-	}
-	if errBuf.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty", errBuf.String())
-	}
-}
-
-func TestCopyDeviceCodeToClipboard_Failure(t *testing.T) {
-	t.Parallel()
-
-	var errBuf bytes.Buffer
-	ok := copyDeviceCodeToClipboard(&errBuf, "ABCD-1234", func(_ string) error {
-		return errors.New("clipboard unavailable")
-	})
-
-	if ok {
-		t.Fatal("copyDeviceCodeToClipboard() = true, want false")
-	}
-	if !strings.Contains(errBuf.String(), "failed to copy device code to clipboard") {
-		t.Fatalf("stderr = %q, want clipboard warning", errBuf.String())
-	}
 }
 
 func TestWaitForApproval_ImmediateSuccess(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	charm.land/glamour/v2 v2.0.0
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.3
-	github.com/atotto/clipboard v0.1.4
 	github.com/betterleaks/betterleaks v1.3.1
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
@@ -51,6 +50,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/476
<!-- entire-trail-link-end -->

## What

The device-auth approval URL already embeds the `user_code`
(`verification_uri_complete`, RFC 8628 §3.3.1), so opening it is all the
user needs to do. The old flow copied the code to the clipboard and told
the user to type it into the browser — both now redundant.

This PR:
- Rewords the interactive prompt to `Press Enter to open <url> in your browser to approve this login...`
- Removes the clipboard write and the "Device code copied to clipboard." line
- Removes the "enter the generated device code" instruction (incl. the browser-open-failure fallback message)
- Deletes the `copyToClipboard` / `copyDeviceCodeToClipboard` helpers and their unit tests
- Drops the `github.com/atotto/clipboard` direct dependency (now indirect via `go mod tidy`)

The **Press Enter** gate is kept by design, and the device code is still
printed above the prompt so the user can confirm it against the page.

## Fallback behavior

The device code remains visible regardless, so the bare-URI fallback (when
an AS omits `verification_uri_complete`) still works — the user can read the
code from the terminal. In practice the Entire auth server always returns
the complete form, so the fallback is a spec-conformance safety net only.

## Testing

- `mise run fmt && mise run lint` clean (gomod tidy committed)
- `mise run test:ci` green (unit + integration + Vogon E2E canary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and dependency cleanup in the login command only; device auth, polling, and token validation are unchanged.
> 
> **Overview**
> Streamlines the interactive **`entire login`** device-auth flow now that **`chooseApprovalURL`** prefers **`verification_uri_complete`** (user code in the URL).
> 
> **Press Enter** still gates opening the browser, but the prompt no longer mentions copying the code or typing it on the page—only opening the approval URL. Clipboard helpers and their injectable dependency are removed from **`runLogin`**, along with the related unit tests. **`github.com/atotto/clipboard`** is no longer a direct **`go.mod`** dependency (tidy leaves it indirect).
> 
> The device code line above the prompt is unchanged for confirmation or bare-URI fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9b6b3961f6928ad10178dc6a357fc9457a32f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->