### PR TITLE
Fix macOS notarization skipped after adding second binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,17 @@ jobs:
             git log --oneline "${BASE_TAG}..HEAD" --no-merges >> "$RUNNER_TEMP/release_notes.md"
           fi
 
+      - name: Detect macOS signing availability
+        id: signing
+        env:
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+        run: |
+          if [ -n "$MACOS_SIGN_P12" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
@@ -102,6 +113,34 @@ jobs:
           POSTHOG_ENDPOINT: ${{ vars.POSTHOG_ENDPOINT }}
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+
+      # Guard against the notarize pipe silently skipping (e.g. notarize.macos.ids
+      # not matching the build ids). GoReleaser only warns and exits 0 in that
+      # case, so the job stays green while shipping ad-hoc-signed binaries that
+      # Gatekeeper kills on launch. We can't run codesign/spctl on Linux, but a
+      # Developer ID signed Mach-O embeds the signing certificate, whose subject
+      # ("Developer ID Application: … (TEAMID)") is greppable; an ad-hoc binary
+      # embeds no certificate. Fail closed if any darwin binary is unsigned or if
+      # none are found at all.
+      - name: Verify macOS binaries are Developer ID signed
+        if: steps.signing.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          mapfile -t bins < <(jq -r '.[] | select(.type=="Binary" and .goos=="darwin") | .path' dist/artifacts.json)
+          if [ "${#bins[@]}" -eq 0 ]; then
+            echo "::error::No darwin binaries found in dist/artifacts.json — cannot verify signing. Did the build matrix change?"
+            exit 1
+          fi
+          fail=0
+          for bin in "${bins[@]}"; do
+            if grep -aq "Developer ID Application" "$bin"; then
+              echo "ok: $bin is Developer ID signed"
+            else
+              echo "::error::$bin is NOT Developer ID signed (ad-hoc only) — the notarize pipe was skipped. Check that notarize.macos.ids in .goreleaser.yaml matches the build ids."
+              fail=1
+            fi
+          done
+          exit $fail
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,7 +52,7 @@ notarize:
   macos:
     # Must list every darwin build id explicitly. When omitted, goreleaser
     # defaults the id filter to the project name ("cli"), which matched the
-    # old single unnamed build but matches neither named build below — the
+    # old single unnamed build but matches neither named build above — the
     # notarize pipe then silently skips and ships ad-hoc-signed binaries that
     # Gatekeeper kills on launch.
     - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,15 @@ builds:
 
 notarize:
   macos:
+    # Must list every darwin build id explicitly. When omitted, goreleaser
+    # defaults the id filter to the project name ("cli"), which matched the
+    # old single unnamed build but matches neither named build below — the
+    # notarize pipe then silently skips and ships ad-hoc-signed binaries that
+    # Gatekeeper kills on launch.
     - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids:
+        - entire
+        - git-remote-entire
       sign:
         certificate: "{{.Env.MACOS_SIGN_P12}}"
         password: "{{.Env.MACOS_SIGN_PASSWORD}}"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/478
<!-- entire-trail-link-end -->

## Problem

v0.7.0 shipped macOS binaries that Gatekeeper kills on launch. Users hit it as Homebrew completion-generation failures:

```
Warning: Failed to generate bash completions ... was terminated by uncaught signal KILL.
```

The published `entire` and `git-remote-entire` binaries are only **ad-hoc/linker-signed** (`Signature=adhoc`, `TeamIdentifier=not set`); `spctl` assessment → rejected. They were never Developer-ID signed or notarized.

## Root cause

Adding `git-remote-entire` (#1306) gave the GoReleaser builds explicit ids (`entire`, `git-remote-entire`). The `notarize.macos` block has no `ids:` field, so GoReleaser defaults it to `[project_name]` = `[cli]` (from the module `github.com/entireio/cli`).

Previously the single build had **no explicit id**, so it *also* defaulted to `cli` — they matched by accident. Once the builds were named, nothing matched `cli` and the notarize pipe skipped silently while the job stayed green:

```
• sign & notarize macOS binaries
  • pipe skipped or partially skipped   reason=no darwin binaries found with ids cli
```

## Fix

- **`.goreleaser.yaml`** — pin `notarize.macos.ids` to both darwin builds (`entire`, `git-remote-entire`), with a comment documenting the footgun.
- **`.github/workflows/release.yml`** — add a fail-closed guard after GoReleaser: it inspects every darwin binary in `dist/` and fails the release if any lacks a Developer ID signature, or if none are found. We can't run `codesign`/`spctl` on the Linux runner, so it greps the Mach-O for the embedded signing certificate subject (`Developer ID Application`), which is absent from ad-hoc binaries. Gated on a signing-availability check so forks without the cert secret aren't failed.

## Notes

- Config-only — **0.7.0 itself can't be repaired**; a new tagged release (0.7.1) is needed for users to get notarized binaries.
- Nightlies have shipped ad-hoc binaries since #1306 merged too; this fixes all future builds.

## Verification

- Confirmed against the published `entire_darwin_arm64.tar.gz`: both binaries ad-hoc only, `spctl` rejected.
- Traced the skip to the release run log (`no darwin binaries found with ids cli`).
- Diffed the v0.7.0-tagged config vs v0.6.3 to confirm the build-id rename is the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release pipeline and GoReleaser config only; no runtime app logic, and the new check is gated on signing secrets so forks without certs are unaffected.
> 
> **Overview**
> **Restores macOS Developer ID signing and notarization** for both darwin artifacts (`entire`, `git-remote-entire`) after a second named build caused GoReleaser’s notarize step to silently skip (default `ids` no longer matched).
> 
> In **`.goreleaser.yaml`**, `notarize.macos.ids` is set explicitly to `entire` and `git-remote-entire`, with a comment explaining the default-id footgun.
> 
> In **`.github/workflows/release.yml`**, a signing-availability step gates a **fail-closed post-release check**: when `MACOS_SIGN_P12` is present, every darwin binary in `dist/artifacts.json` must contain an embedded `Developer ID Application` certificate string (grep on Linux), or the job fails with actionable errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73584a09a9323e8dd47629ffe26acad8a87dd5e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->