### PR TITLE
Add 0.7.2 changelog entry (macOS signing fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.2] - 2026-06-02
+
+### Fixed
+
+- macOS release binaries are Developer ID signed and notarized again. Adding the `git-remote-entire` binary in 0.7.0 gave the release builds explicit ids that no longer matched the notarization step's default filter, so 0.7.0 shipped ad-hoc-signed binaries that macOS Gatekeeper refused to run — surfacing as Homebrew shell-completion errors and `killed` on launch ([#1324](https://github.com/entireio/cli/pull/1324))
+
+### Housekeeping
+
+- The release workflow now fails closed when any macOS binary is not Developer ID signed, so an un-notarized build can no longer ship silently ([#1324](https://github.com/entireio/cli/pull/1324))
+
 ## [0.7.0] - 2026-06-02
 
 ### Added


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/479
<!-- entire-trail-link-end -->

Patch release shipping the macOS notarization fix + release guard from #1324.

0.7.0 shipped ad-hoc-signed macOS binaries that Gatekeeper kills on launch (the notarize pipe silently skipped after the build ids changed). #1324 fixed the config and added a fail-closed guard; this entry lets the Release workflow extract notes for the 0.7.2 tag.

Once merged, tag `v0.7.2` on `main` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md with no runtime or CI logic modified in this diff.
> 
> **Overview**
> Adds a **0.7.2** section to `CHANGELOG.md` so release automation can publish patch notes for the upcoming tag.
> 
> **Fixed** documents that macOS artifacts are Developer ID signed and notarized again after 0.7.0 shipped ad-hoc binaries (notarization filter mismatch when `git-remote-entire` changed build ids), which broke Gatekeeper and showed up as Homebrew completion errors and processes **killed** on launch ([#1324](https://github.com/entireio/cli/pull/1324)).
> 
> **Housekeeping** notes the release workflow now fails if any macOS binary is not properly signed, preventing another silent bad release ([#1324](https://github.com/entireio/cli/pull/1324)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b21894e5f068c3d1942a461fb214002dfb60dd1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->