### PR TITLE
remotehelper: Use Git Protocol v2 by default

### DIFF
--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -22,11 +22,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -151,25 +151,30 @@ func run(args []string) int {
 
 // resolveProtocolVersion reads the effective protocol.version from
 // the GIT_PROTOCOL environment variable. The value is a colon-
-// separated list of key=value pairs (e.g. "version=2"); we extract
-// the version key. Defaults to 2 — matching upstream Git's default
-// since 2.26 — when GIT_PROTOCOL is unset or malformed.
+// separated list of key=value pairs (e.g. "version=2"). We accept
+// 0, 1, or 2; any other value emits a stderr warning and falls
+// back to 2 — upstream Git's default since 2.26.
 func resolveProtocolVersion() int {
+	return parseProtocolVersion(os.Getenv("GIT_PROTOCOL"), os.Stderr)
+}
+
+func parseProtocolVersion(raw string, warn io.Writer) int {
 	const defaultVersion = 2
-	raw := os.Getenv("GIT_PROTOCOL")
-	if raw == "" {
-		return defaultVersion
-	}
 	for kv := range strings.SplitSeq(raw, ":") {
 		k, v, ok := strings.Cut(kv, "=")
 		if !ok || k != "version" {
 			continue
 		}
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			return defaultVersion
+		switch v {
+		case "0":
+			return 0
+		case "1":
+			return 1
+		case "2":
+			return 2
 		}
-		return n
+		fmt.Fprintf(warn, "git-remote-entire: ignoring unrecognised protocol.version=%q; defaulting to %d\n", v, defaultVersion)
+		return defaultVersion
 	}
 	return defaultVersion
 }

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -138,16 +139,39 @@ func run(args []string) int {
 		OnNodeFailed: onNodeFailed,
 	})
 
-	mode := githelper.ModeConnect
-	if os.Getenv("ENTIRE_STATELESS") == "true" {
-		mode = githelper.ModeStateless
-	}
+	protocolVersion := resolveProtocolVersion()
+	debuglog.Printf("git protocol.version=%d (v2 advertises stateless-connect + push; v0/v1 advertises connect)", protocolVersion)
 
-	if err := githelper.Run(ctx, proxy, mode, os.Stdin, os.Stdout); err != nil {
+	if err := githelper.Run(ctx, proxy, protocolVersion, os.Stdin, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		return 128
 	}
 	return 0
+}
+
+// resolveProtocolVersion reads the effective protocol.version from
+// the GIT_PROTOCOL environment variable. The value is a colon-
+// separated list of key=value pairs (e.g. "version=2"); we extract
+// the version key. Defaults to 2 — matching upstream Git's default
+// since 2.26 — when GIT_PROTOCOL is unset or malformed.
+func resolveProtocolVersion() int {
+	const defaultVersion = 2
+	raw := os.Getenv("GIT_PROTOCOL")
+	if raw == "" {
+		return defaultVersion
+	}
+	for kv := range strings.SplitSeq(raw, ":") {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k != "version" {
+			continue
+		}
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return defaultVersion
+		}
+		return n
+	}
+	return defaultVersion
 }
 
 // gitActionFromRequest classifies a smart-HTTP request as "pull" or "push"

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -1,11 +1,50 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+func TestParseProtocolVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		env      string
+		want     int
+		wantWarn string
+	}{
+		{"unset", "", 2, ""},
+		{"version_0", "version=0", 0, ""},
+		{"version_1", "version=1", 1, ""},
+		{"version_2", "version=2", 2, ""},
+		{"unknown_version_warns", "version=3", 2, "ignoring unrecognised protocol.version"},
+		{"malformed_value_warns", "version=abc", 2, "ignoring unrecognised protocol.version"},
+		{"empty_value_warns", "version=", 2, "ignoring unrecognised protocol.version"},
+		{"no_version_key", "foo=bar", 2, ""},
+		{"version_after_other_key", "foo=bar:version=1", 1, ""},
+		{"version_before_other_key", "version=2:foo=bar", 2, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			got := parseProtocolVersion(tc.env, &buf)
+			if got != tc.want {
+				t.Errorf("parseProtocolVersion(%q) = %d, want %d", tc.env, got, tc.want)
+			}
+			switch {
+			case tc.wantWarn == "" && buf.Len() != 0:
+				t.Errorf("expected no warning, got %q", buf.String())
+			case tc.wantWarn != "" && !strings.Contains(buf.String(), tc.wantWarn):
+				t.Errorf("expected warning containing %q, got %q", tc.wantWarn, buf.String())
+			}
+		})
+	}
+}
 
 func TestGitActionFromRequest(t *testing.T) {
 	t.Parallel()

--- a/internal/remotehelper/githelper/run.go
+++ b/internal/remotehelper/githelper/run.go
@@ -11,29 +11,24 @@ import (
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 )
 
-// Mode selects the helper's capability advertisement.
-type Mode int
-
-const (
-	// ModeConnect (the default) advertises `connect`: git speaks the
-	// raw smart-HTTP protocol and the helper relays request/response
-	// bodies. Works against any receive-pack endpoint without
-	// depending on send-pack's stateless-rpc behaviour.
-	ModeConnect Mode = iota
-	// ModeStateless advertises `stateless-connect` + `push`: v2 fetch
-	// over framed HTTP RPC, push via send-pack subprocess.
-	ModeStateless
-)
-
 // Run drives the git-remote-helper protocol loop against the given
 // Transport. It reads commands from stdin one line at a time and
 // writes responses to stdout until git closes the pipe or sends an
 // unsupported command (which terminates the loop with an error).
 //
+// protocolVersion selects which capability set to advertise. v2 (the
+// upstream default since Git 2.26) advertises `stateless-connect` +
+// `push` so Git negotiates wire-protocol v2 over framed HTTP RPC.
+// v0/v1 advertises `connect`, giving Git a raw pipe to speak the
+// legacy smart-HTTP protocol through. Upstream Git's
+// transport-helper.c always prefers `connect` over `stateless-connect`
+// when both are present, so the advertised set has to match the
+// resolved protocol.version rather than offering both.
+//
 // The Transport interface decouples this loop from any specific HTTP
 // implementation — see the entire/transport package for the
 // production wiring.
-func Run(ctx context.Context, t Transport, mode Mode, stdin io.Reader, stdout io.Writer) error {
+func Run(ctx context.Context, t Transport, protocolVersion int, stdin io.Reader, stdout io.Writer) error {
 	commandReader := bufio.NewReader(stdin)
 	opts := &Options{}
 
@@ -53,7 +48,7 @@ func Run(ctx context.Context, t Transport, mode Mode, stdin io.Reader, stdout io
 
 		switch {
 		case line == "capabilities":
-			if mode == ModeStateless {
+			if protocolVersion >= 2 {
 				fmt.Fprintln(stdout, "stateless-connect")
 				fmt.Fprintln(stdout, "push")
 			} else {

--- a/internal/remotehelper/githelper/run_test.go
+++ b/internal/remotehelper/githelper/run_test.go
@@ -47,12 +47,13 @@ func pktLine(s string) string {
 func TestRun_Capabilities(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name string
-		mode Mode
-		want string
+		name            string
+		protocolVersion int
+		want            string
 	}{
-		{"default", ModeConnect, "connect\noption\n\n"},
-		{"stateless", ModeStateless, "stateless-connect\npush\noption\n\n"},
+		{"v0_advertises_connect", 0, "connect\noption\n\n"},
+		{"v1_advertises_connect", 1, "connect\noption\n\n"},
+		{"v2_advertises_stateless_connect", 2, "stateless-connect\npush\noption\n\n"},
 	}
 
 	for _, tt := range tests {
@@ -62,7 +63,7 @@ func TestRun_Capabilities(t *testing.T) {
 			defer server.Close()
 			stdin := strings.NewReader("capabilities\n\n")
 			var stdout bytes.Buffer
-			if err := Run(context.Background(), testTransport(server), tt.mode, stdin, &stdout); err != nil {
+			if err := Run(context.Background(), testTransport(server), tt.protocolVersion, stdin, &stdout); err != nil {
 				t.Fatalf("Run failed: %v", err)
 			}
 			if stdout.String() != tt.want {
@@ -79,7 +80,7 @@ func TestRun_OptionCommandReplies(t *testing.T) {
 
 	stdin := strings.NewReader("option dry-run true\noption weird true\n\n")
 	var stdout bytes.Buffer
-	if err := Run(context.Background(), testTransport(server), ModeConnect, stdin, &stdout); err != nil {
+	if err := Run(context.Background(), testTransport(server), 1, stdin, &stdout); err != nil {
 		t.Fatalf("Run failed: %v", err)
 	}
 	got := stdout.String()
@@ -126,7 +127,7 @@ func TestRun_ConnectUploadPackUsesV0(t *testing.T) {
 	stdin := strings.NewReader("connect git-upload-pack\n" + wantPkt + "0000" + donePkt)
 	var stdout bytes.Buffer
 
-	if err := Run(context.Background(), testTransport(server), ModeConnect, stdin, &stdout); err != nil {
+	if err := Run(context.Background(), testTransport(server), 1, stdin, &stdout); err != nil {
 		t.Fatalf("Run failed: %v", err)
 	}
 

--- a/internal/remotehelper/githelper/signal_test.go
+++ b/internal/remotehelper/githelper/signal_test.go
@@ -23,7 +23,7 @@ func TestRun_StdinCloseExitsCleanly(t *testing.T) {
 	defer server.Close()
 
 	var out bytes.Buffer
-	if err := Run(context.Background(), testTransport(server), ModeConnect, strings.NewReader(""), &out); err != nil {
+	if err := Run(context.Background(), testTransport(server), 1, strings.NewReader(""), &out); err != nil {
 		t.Fatalf("Run on empty stdin: %v", err)
 	}
 	if out.Len() != 0 {
@@ -43,7 +43,7 @@ func TestRun_PartialCommandLineErrors(t *testing.T) {
 	defer server.Close()
 
 	var out bytes.Buffer
-	err := Run(context.Background(), testTransport(server), ModeConnect, strings.NewReader("capab"), &out)
+	err := Run(context.Background(), testTransport(server), 1, strings.NewReader("capab"), &out)
 	if err == nil {
 		t.Fatal("expected error on partial / unknown command")
 	}
@@ -88,7 +88,7 @@ func TestRun_CtxCancelDuringFetchSurfacesError(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- Run(ctx, testTransport(server), ModeConnect, stdin, &out)
+		done <- Run(ctx, testTransport(server), 1, stdin, &out)
 	}()
 	select {
 	case err := <-done:
@@ -134,7 +134,7 @@ func TestRun_ParentContextCancelStopsBlockedRead(t *testing.T) {
 	var out bytes.Buffer
 	done := make(chan error, 1)
 	go func() {
-		done <- Run(ctx, testTransport(server), ModeConnect, br, &out)
+		done <- Run(ctx, testTransport(server), 1, br, &out)
 	}()
 
 	// Give Run time to enter the read; then cancel. Run won't return


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/480
<!-- entire-trail-link-end -->

Replace the `ENTIRE_STATELESS` env-var toggle with protocol.version resolution from GIT_PROTOCOL. v2 (Git's default since 2.26) advertises stateless-connect + push so partial clone works end-to-end; v0/v1 advertises connect. transport-helper.c prefers connect when both are present, so the helper has to commit to one set rather than offer both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Git wire path (connect vs stateless-connect) clients use for fetch/push; mis-parsed GIT_PROTOCOL could fall back to v2 and alter behavior for legacy Git setups.
> 
> **Overview**
> **Replaces** the `ENTIRE_STATELESS` env toggle with **protocol version** derived from Git’s `GIT_PROTOCOL` (default **2** when unset or invalid).
> 
> `git-remote-entire` parses `version=N` from the colon-separated `GIT_PROTOCOL` string and passes that int into `githelper.Run`. The helper **drops** the `Mode` enum: **v0/v1** still advertise `connect`; **v2+** advertise `stateless-connect` and `push`, aligned with upstream Git preferring `connect` when both are offered. Capability tests now cover v0, v1, and v2 explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65172cf257237ccb57993fc79749b9a7f6fbbcb4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->