### PR TITLE
mirror create: follow node 307 in the clone probe

### DIFF
--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/entireclient/discovery"
 )
 
 // gitHubHTTPSRe / gitHubSSHRe / gitHubBareRe parse the GitHub URL shapes
@@ -98,12 +99,35 @@ var probeClient = &http.Client{
 		IdleConnTimeout:     90 * time.Second,
 		TLSHandshakeTimeout: 10 * time.Second,
 	},
-	// info/refs is a single GET; a redirect would indicate misconfiguration
-	// (e.g. cluster host fronted by something that 30x's to a login page).
-	// Surface it as an error rather than silently following.
-	CheckRedirect: func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	},
+	// The cluster front door 307-redirects info/refs to the node holding the
+	// mirror (e.g. bishop.<cluster-host>); git follows these to clone, so the
+	// probe must too. Refusing them (the old http.ErrUseLastResponse) made
+	// mirrorAdvertisesHead read the 307 as "not 200, not ready" and spin the
+	// cloning-dots forever even after the clone had landed.
+	CheckRedirect: checkProbeRedirect,
+}
+
+// maxProbeRedirects bounds redirect-following during the clone probe.
+// One front-door→node hop is expected; the cap is headroom against a
+// misconfigured loop, not snugness.
+const maxProbeRedirects = 5
+
+// checkProbeRedirect confines the clone probe's redirect-following to the
+// cluster trust domain, over https. The 307 the front door issues carries the
+// pull token in the Location userinfo; following it out of the cluster would
+// hand that token to whoever the redirect named. discovery.HostInCluster is
+// the same boundary the entire:// transport enforces on its own redirects.
+func checkProbeRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxProbeRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxProbeRedirects)
+	}
+	if req.URL.Scheme != "https" {
+		return fmt.Errorf("refusing non-https redirect to %s", req.URL.Redacted())
+	}
+	if !discovery.HostInCluster(req.URL.Hostname(), via[0].URL.Hostname()) {
+		return fmt.Errorf("refusing cross-host redirect to %s", req.URL.Redacted())
+	}
+	return nil
 }
 
 // waitForMirrorClone blocks until the mirror at /gh/<owner>/<repo> on

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -217,4 +219,92 @@ func TestMirrorAdvertisesHead_ReusesConnection(t *testing.T) {
 	require.Equal(t, int64(1), newConns.Load(),
 		"expected the drained body to let all %d probes share one connection; got %d new connections (body not drained to EOF?)",
 		probes, newConns.Load())
+}
+
+// pktLine encodes s as a git pkt-line (4-hex length prefix including the
+// prefix itself), mirroring what a smart-HTTP server writes.
+func pktLine(s string) string { return fmt.Sprintf("%04x%s", len(s)+4, s) }
+
+// uploadPackAdvertisement returns a minimal but valid git-upload-pack
+// info/refs body: the "# service" banner, a flush, a HEAD line carrying the
+// symref capability, a refs/heads/main line, and a trailing flush. It decodes
+// to an AdvRefs whose HEAD resolves to refs/heads/main.
+func uploadPackAdvertisement() string {
+	const sha = "d9a69831082341eab799c062e10ad28b3204c08a"
+	return pktLine("# service=git-upload-pack\n") +
+		"0000" +
+		pktLine(sha+" HEAD\x00symref=HEAD:refs/heads/main\n") +
+		pktLine(sha+" refs/heads/main\n") +
+		"0000"
+}
+
+// TestMirrorAdvertisesHead_FollowsNodeRedirect is the regression test for the
+// infinite cloning-dots bug. The cluster front door 307-redirects info/refs to
+// the node holding the mirror; git follows that to clone. The probe used to
+// refuse all redirects (http.ErrUseLastResponse), so it saw the 307 as "not
+// 200, not ready" and printed cloning-dots forever even after the clone had
+// landed. With checkProbeRedirect the probe follows same-host redirects and
+// reaches the advertisement, so it reports ready.
+func TestMirrorAdvertisesHead_FollowsNodeRedirect(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/node/info/refs" {
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			_, _ = w.Write([]byte(uploadPackAdvertisement())) //nolint:errcheck // test server write
+			return
+		}
+		// Front door: route to the backing node on the same host, the way the
+		// real cluster front door 307s to bishop.<cluster-host>.
+		http.Redirect(w, r, "/node/info/refs", http.StatusTemporaryRedirect)
+	}))
+	defer srv.Close()
+
+	// srv.Client() trusts the test cert; layer on the production redirect
+	// policy so we exercise the real follow path.
+	client := srv.Client()
+	client.CheckRedirect = checkProbeRedirect
+
+	ready, status := mirrorAdvertisesHead(context.Background(), client, srv.URL+"/info/refs", "tok")
+	require.True(t, ready, "probe should follow the node redirect and see HEAD")
+	require.Equal(t, http.StatusOK, status)
+}
+
+func TestCheckProbeRedirect(t *testing.T) {
+	t.Parallel()
+
+	orig := mustReq(t, "https://aws-us-east-2.entire.io/gh/o/r/info/refs")
+	tests := []struct {
+		name    string
+		target  string
+		via     int
+		wantErr bool
+	}{
+		{name: "same host", target: "https://aws-us-east-2.entire.io/node/info/refs", via: 1},
+		{name: "subdomain node", target: "https://bishop.aws-us-east-2.entire.io/gh/o/r/info/refs", via: 1},
+		{name: "cross host leaks token", target: "https://evil.example.com/info/refs", via: 1, wantErr: true},
+		{name: "sibling suffix trick", target: "https://aws-us-east-2.entire.io.evil.com/x", via: 1, wantErr: true},
+		{name: "non-https", target: "http://bishop.aws-us-east-2.entire.io/x", via: 1, wantErr: true},
+		{name: "too many hops", target: "https://bishop.aws-us-east-2.entire.io/x", via: maxProbeRedirects, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			via := make([]*http.Request, tt.via)
+			via[0] = orig
+			err := checkProbeRedirect(mustReq(t, tt.target), via)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func mustReq(t *testing.T, rawURL string) *http.Request {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return &http.Request{URL: u}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/481
<!-- entire-trail-link-end -->

## Problem

`entire repo mirror create <repo>` registers the mirror, then waits for the initial GitHub→EntireDB clone to land by polling the cluster's smart-HTTP `info/refs` endpoint, printing `cloning...` dots until `HEAD` resolves. Users reported the dots **never stop** even though the mirror is fully set up and `git clone` works.

## Root cause

The cluster front door (`aws-us-east-2.entire.io`) doesn't serve `info/refs` directly — it returns an **HTTP 307** redirect to the node actually holding the mirror (`bishop.<cluster-host>`), with a pull token embedded in the redirect URL's userinfo. `git clone` follows that redirect (standard smart-HTTP behavior), which is why cloning works.

But the probe's HTTP client was configured to refuse all redirects:

```go
CheckRedirect: func(*http.Request, []*http.Request) error {
    return http.ErrUseLastResponse
},
```

So every probe saw the 307, `mirrorAdvertisesHead` treated anything ≠ 200 as "not ready," and `waitForMirrorClone` fell into its dot-printing `default` branch on every tick — forever, regardless of clone state. Confirmed by instrumenting the real loop: it logged `status=307` on every tick, while a redirect-following client fetched the advertisement and resolved `HEAD` in one shot.

## Fix

Follow redirects in the probe, confined to the cluster trust domain over HTTPS via `discovery.HostInCluster` — the **same boundary the `entire://` transport already enforces** on its own redirects (`internal/remotehelper/transport/proxy.go`). Host confinement matters because the redirect carries the pull token in its userinfo; following it off-cluster would leak the token. A stray redirect to a login page still can't cause a false "ready," since readiness is gated on the body decoding as a git advertisement with a resolvable `HEAD`.

Verified against the live mirror: now prints `ready to use` immediately instead of spinning dots.

## Tests

- `TestMirrorAdvertisesHead_FollowsNodeRedirect` — TLS server 307s `info/refs` to a node path serving a real advertisement; asserts the probe follows it and reports ready (direct regression for the infinite-dots bug).
- `TestCheckProbeRedirect` — table test: same-host, subdomain node, cross-host token-leak refusal, the `…entire.io.evil.com` suffix trick, non-HTTPS, and the hop cap.

`mise run check` passes (fmt, lint, unit + integration + e2e canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes redirect handling for an authenticated clone probe; mistakes could leak repo-scoped tokens via redirects or falsely report readiness, though policy mirrors existing transport boundaries and is table-tested.
> 
> **Overview**
> Fixes **`entire repo mirror create`** waiting forever on **`cloning...`** dots after the mirror is actually ready.
> 
> The clone-readiness probe used to **reject all HTTP redirects** on `info/refs`, so it treated the cluster front door’s **307 to the backing node** as “not ready” even though **`git clone`** follows that hop. **`probeClient`** now follows redirects via **`checkProbeRedirect`**: **HTTPS only**, up to **5 hops**, and only to hosts **`discovery.HostInCluster`** accepts (same rule as the **`entire://`** transport), so pull tokens in redirect URLs are not followed off-cluster.
> 
> Adds regression coverage: **`TestMirrorAdvertisesHead_FollowsNodeRedirect`** (307 → valid advertisement → ready) and **`TestCheckProbeRedirect`** (same-host, node subdomain, cross-host, suffix trick, non-HTTPS, hop cap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e26e6b6694f1ff59ab11a23b43564809828aa7ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->