### PR TITLE
Add 0.7.3 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.3] - 2026-06-02
+
+### Fixed
+
+- Fixed a bug where internal API calls didn't follow a redirect properly ([#1327](https://github.com/entireio/cli/pull/1327))
+
 ## [0.7.2] - 2026-06-02
 
 ### Fixed


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/482
<!-- entire-trail-link-end -->

Adds the 0.7.3 changelog entry for the mirror clone-probe redirect fix shipped in #1327.

```
## [0.7.3] - 2026-06-02

### Fixed

- Fixed a bug where internal API calls didn't follow a redirect properly (#1327)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md with no runtime or code impact.
> 
> **Overview**
> Documents **release 0.7.3** (2026-06-02) at the top of `CHANGELOG.md` under **Fixed**, noting that internal API calls now follow redirects correctly ([#1327](https://github.com/entireio/cli/pull/1327)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b9eea665b101f9ccbabc5db5bb019629452fcf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->