### PR TITLE
Read session resume checkpoints from v1.1 ref

### DIFF
--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -187,14 +187,16 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 	checkpointID := result.checkpointIDs[0]
 	var metadata *strategy.CheckpointInfo
 
-	promoteRemoteTrackingMetadataBranch(ctx, repo)
-
-	store := checkpoint.NewGitStore(repo)
+	store := checkpoint.NewCommittedReadStore(ctx, repo)
 	store.SetBlobFetcher(FetchBlobsByHash)
+
+	if store.CommittedReadRef() == plumbing.NewBranchReferenceName(paths.MetadataBranchName) {
+		promoteRemoteTrackingMetadataBranch(ctx, repo)
+	}
 
 	// Multiple checkpoints (squash merge): resolve latest by CreatedAt timestamp.
 	if len(result.checkpointIDs) > 1 {
-		latestMetadata, err := resolveLatestCheckpoint(ctx, repo, store, result.checkpointIDs)
+		latestMetadata, err := resolveLatestCheckpoint(ctx, store, result.checkpointIDs)
 		if err != nil {
 			// No metadata available — nothing to resume from
 			logging.Warn(logCtx, "resolveLatestCheckpoint failed",
@@ -203,7 +205,7 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 			)
 			fmt.Fprintf(w, "Found %d checkpoints for commit %s but metadata is not available\n",
 				len(result.checkpointIDs), result.commitHash[:7])
-			return checkRemoteMetadata(ctx, w, errW, result.checkpointIDs[0])
+			return checkRemoteMetadata(ctx, w, errW, result.checkpointIDs[0], store.CommittedReadRef())
 		}
 		skipped := len(result.checkpointIDs) - 1
 		fmt.Fprintf(w, "Found %d checkpoints for commit %s, resuming from the latest (%d older checkpoints skipped)\n",
@@ -217,21 +219,15 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 		if storeErr == nil {
 			metadata = storeInfo
 		} else {
-			logging.Debug(ctx, "checkpoint store metadata read failed, trying metadata branch",
+			logging.Debug(ctx, "checkpoint store metadata read failed",
 				slog.String("checkpoint_id", checkpointID.String()),
 				slog.String("error", storeErr.Error()),
 			)
-			localInfo, localErr := readCheckpointInfoFromMetadataBranch(ctx, repo, checkpointID)
-			if localErr == nil {
-				metadata = localInfo
-			} else {
-				metadataErr := errors.Join(storeErr, localErr)
-				logging.Warn(logCtx, "checkpoint metadata read failed, checking remote",
-					slog.String("checkpoint_id", checkpointID.String()),
-					slog.String("error", metadataErr.Error()),
-				)
-				return checkRemoteMetadata(ctx, w, errW, checkpointID)
-			}
+			logging.Warn(logCtx, "checkpoint metadata read failed, checking remote",
+				slog.String("checkpoint_id", checkpointID.String()),
+				slog.String("error", storeErr.Error()),
+			)
+			return checkRemoteMetadata(ctx, w, errW, checkpointID, store.CommittedReadRef())
 		}
 	}
 
@@ -246,16 +242,15 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 
 // resolveLatestCheckpoint reads metadata for each checkpoint ID and returns
 // the checkpoint with the latest CreatedAt.
-func resolveLatestCheckpoint(ctx context.Context, repo *git.Repository, store checkpoint.CommittedListReader, checkpointIDs []id.CheckpointID) (*strategy.CheckpointInfo, error) {
+func resolveLatestCheckpoint(ctx context.Context, store *checkpoint.GitStore, checkpointIDs []id.CheckpointID) (*strategy.CheckpointInfo, error) {
 	infoMap := make(map[id.CheckpointID]strategy.CheckpointInfo, len(checkpointIDs))
 	for _, cpID := range checkpointIDs {
 		metadata, readErr := readCheckpointInfoFromStore(ctx, store, cpID)
 		if readErr != nil {
-			logging.Debug(ctx, "checkpoint store metadata read failed, trying metadata branch",
+			logging.Debug(ctx, "checkpoint store metadata read failed",
 				slog.String("checkpoint_id", cpID.String()),
 				slog.String("error", readErr.Error()),
 			)
-			metadata, readErr = readCheckpointInfoFromMetadataBranch(ctx, repo, cpID)
 		}
 		if readErr != nil {
 			logging.Debug(ctx, "resolveLatestCheckpoint: checkpoint metadata read failed",
@@ -309,78 +304,15 @@ func readCheckpointInfoFromStore(ctx context.Context, store checkpoint.Committed
 	return info, nil
 }
 
-func readCheckpointInfoFromMetadataBranch(ctx context.Context, repo *git.Repository, checkpointID id.CheckpointID) (*strategy.CheckpointInfo, error) {
-	v1Tree, err := strategy.GetMetadataBranchTree(repo)
-	if err == nil {
-		info, infoErr := readCheckpointInfoFromMetadataTree(ctx, repo, checkpointID, v1Tree)
-		if infoErr == nil {
-			return info, nil
-		}
-		err = infoErr
-	}
-	logging.Debug(ctx, "metadata branch tree not available",
-		slog.String("checkpoint_id", checkpointID.String()),
-		slog.String("error", err.Error()),
-	)
-	return nil, checkpoint.ErrCheckpointNotFound
-}
-
-func readCheckpointInfoFromMetadataTree(
+func readCheckpointInfoFromRef(
 	ctx context.Context,
 	repo *git.Repository,
+	committedReadRef plumbing.ReferenceName,
 	checkpointID id.CheckpointID,
-	metadataTree *object.Tree,
 ) (*strategy.CheckpointInfo, error) {
-	logging.Debug(ctx, "metadata tree obtained",
-		slog.String("checkpoint_id", checkpointID.String()),
-		slog.String("checkpoint_path", checkpointID.Path()),
-		slog.String("tree_hash", metadataTree.Hash.String()),
-	)
-
-	cpSubtree, err := metadataTree.Tree(checkpointID.Path())
-	if err != nil {
-		logging.Debug(ctx, "checkpoint subtree not found in metadata tree",
-			slog.String("checkpoint_id", checkpointID.String()),
-			slog.String("checkpoint_path", checkpointID.Path()),
-			slog.String("tree_hash", metadataTree.Hash.String()),
-			slog.String("error", err.Error()),
-		)
-		return nil, fmt.Errorf("find checkpoint subtree: %w", err)
-	}
-
-	subtreeEntryNames := make([]string, 0, len(cpSubtree.Entries))
-	for _, e := range cpSubtree.Entries {
-		subtreeEntryNames = append(subtreeEntryNames, fmt.Sprintf("%s(%s:%s)", e.Name, e.Mode, e.Hash.String()[:7]))
-	}
-	logging.Debug(ctx, "checkpoint subtree found",
-		slog.String("checkpoint_id", checkpointID.String()),
-		slog.String("subtree_hash", cpSubtree.Hash.String()),
-		slog.Int("entry_count", len(cpSubtree.Entries)),
-		slog.Any("entries", subtreeEntryNames),
-	)
-
-	ft := checkpoint.NewFetchingTree(ctx, cpSubtree, repo.Storer, FetchBlobsByHash)
-	if prefetched, pfErr := ft.PreFetch(); pfErr != nil {
-		logging.Debug(ctx, "read checkpoint metadata: PreFetch failed",
-			slog.String("checkpoint_id", checkpointID.String()),
-			slog.String("error", pfErr.Error()),
-		)
-	} else if prefetched > 0 {
-		logging.Debug(ctx, "PreFetch completed",
-			slog.String("checkpoint_id", checkpointID.String()),
-			slog.Int("blobs_fetched", prefetched),
-		)
-	}
-	info, err := strategy.ReadCheckpointMetadataFromSubtree(ft, checkpointID.Path())
-	if err != nil {
-		logging.Debug(ctx, "ReadCheckpointMetadataFromSubtree failed",
-			slog.String("checkpoint_id", checkpointID.String()),
-			slog.String("subtree_hash", cpSubtree.Hash.String()),
-			slog.String("error", err.Error()),
-		)
-		return nil, fmt.Errorf("read checkpoint metadata: %w", err)
-	}
-	return info, nil
+	store := checkpoint.NewGitStoreWithRef(repo, committedReadRef)
+	store.SetBlobFetcher(FetchBlobsByHash)
+	return readCheckpointInfoFromStore(ctx, store, checkpointID)
 }
 
 // getMetadataTree returns the metadata branch tree and a fresh repo handle.
@@ -670,8 +602,18 @@ func promptResumeFromOlderCheckpoint() (bool, error) {
 // checkRemoteMetadata checks if checkpoint metadata exists on the remote and
 // automatically fetches it if available. When a checkpoint_remote is configured,
 // fetches from there. Otherwise falls back to origin.
-func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id.CheckpointID) error {
+func checkRemoteMetadata(
+	ctx context.Context,
+	w, errW io.Writer,
+	checkpointID id.CheckpointID,
+	committedReadRef plumbing.ReferenceName,
+) error {
 	logCtx := logging.WithComponent(ctx, "resume.checkRemoteMetadata")
+
+	if committedReadRef != plumbing.NewBranchReferenceName(paths.MetadataBranchName) {
+		fmt.Fprintf(errW, "Checkpoint '%s' found in commit but metadata is not available in %s.\n", checkpointID, committedReadRef)
+		return nil
+	}
 
 	// Open a fresh repo to avoid stale packfile index issues
 	repo, repoErr := openRepository(ctx)
@@ -701,12 +643,9 @@ func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id
 					)
 				} else {
 					defer freshRepo.Close()
-					if metadataTree, treeErr := strategy.GetMetadataBranchTree(freshRepo); treeErr != nil {
-						logging.Debug(logCtx, "checkpoint remote: fetch succeeded but tree read failed",
-							slog.String("error", treeErr.Error()),
-						)
-					} else if metadata, err := tryReadCheckpointFromTree(ctx, metadataTree, freshRepo, checkpointID); err != nil {
-						logging.Debug(logCtx, "checkpoint remote: tree read succeeded but checkpoint metadata read failed",
+					metadata, err := readCheckpointInfoFromRef(ctx, freshRepo, committedReadRef, checkpointID)
+					if err != nil {
+						logging.Debug(logCtx, "checkpoint remote: fetch succeeded but checkpoint metadata read failed",
 							slog.String("checkpoint_id", checkpointID.String()),
 							slog.String("error", err.Error()),
 						)
@@ -723,20 +662,15 @@ func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id
 	}
 
 	// Fall back to origin's remote-tracking branch
-	if remoteTree, treeErr := strategy.GetRemoteMetadataBranchTree(repo); treeErr == nil {
-		metadata, err := tryReadCheckpointFromTree(ctx, remoteTree, repo, checkpointID)
-		if err == nil {
-			return resumeSession(ctx, w, errW, metadata, false)
-		}
-		logging.Debug(logCtx, "remote-tracking metadata tree read failed",
-			slog.String("checkpoint_id", checkpointID.String()),
-			slog.String("error", err.Error()),
-		)
-	} else {
-		logging.Debug(logCtx, "remote-tracking metadata branch not available",
-			slog.String("error", treeErr.Error()),
-		)
+	promoteRemoteTrackingMetadataBranch(ctx, repo)
+	metadata, metadataErr := readCheckpointInfoFromRef(ctx, repo, committedReadRef, checkpointID)
+	if metadataErr == nil {
+		return resumeSession(ctx, w, errW, metadata, false)
 	}
+	logging.Debug(logCtx, "remote-tracking metadata read failed",
+		slog.String("checkpoint_id", checkpointID.String()),
+		slog.String("error", metadataErr.Error()),
+	)
 
 	if fetchErr := FetchMetadataBranch(ctx); fetchErr == nil {
 		freshRepo, freshErr := openRepository(ctx)
@@ -746,11 +680,8 @@ func checkRemoteMetadata(ctx context.Context, w, errW io.Writer, checkpointID id
 			)
 		} else {
 			defer freshRepo.Close()
-			if metadataTree, treeErr := strategy.GetMetadataBranchTree(freshRepo); treeErr != nil {
-				logging.Debug(logCtx, "origin metadata fetch succeeded but local branch read failed",
-					slog.String("error", treeErr.Error()),
-				)
-			} else if metadata, err := tryReadCheckpointFromTree(ctx, metadataTree, freshRepo, checkpointID); err != nil {
+			metadata, err := readCheckpointInfoFromRef(ctx, freshRepo, committedReadRef, checkpointID)
+			if err != nil {
 				logging.Debug(logCtx, "origin metadata fetch succeeded but checkpoint metadata read failed",
 					slog.String("checkpoint_id", checkpointID.String()),
 					slog.String("error", err.Error()),
@@ -798,26 +729,6 @@ func promoteRemoteTrackingMetadataBranch(ctx context.Context, repo *git.Reposito
 			slog.String("error", err.Error()),
 		)
 	}
-}
-
-// tryReadCheckpointFromTree attempts to read checkpoint metadata from a metadata tree.
-func tryReadCheckpointFromTree(ctx context.Context, tree *object.Tree, repo *git.Repository, checkpointID id.CheckpointID) (*strategy.CheckpointInfo, error) {
-	cpSubtree, cpErr := tree.Tree(checkpointID.Path())
-	if cpErr != nil {
-		return nil, fmt.Errorf("checkpoint subtree not found: %w", cpErr)
-	}
-	ft := checkpoint.NewFetchingTree(ctx, cpSubtree, repo.Storer, FetchBlobsByHash)
-	if _, pfErr := ft.PreFetch(); pfErr != nil {
-		logging.Debug(ctx, "tryReadCheckpointFromTree: PreFetch failed",
-			slog.String("checkpoint_id", checkpointID.String()),
-			slog.String("error", pfErr.Error()),
-		)
-	}
-	metadata, err := strategy.ReadCheckpointMetadataFromSubtree(ft, checkpointID.Path())
-	if err != nil {
-		return nil, fmt.Errorf("failed to read checkpoint metadata: %w", err)
-	}
-	return metadata, nil
 }
 
 // resumeSession restores and displays the resume command for a specific session.

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -845,7 +845,8 @@ func resumeSingleSession(ctx context.Context, w, errW io.Writer, ag agent.Agent,
 		logContent, _, err = checkpoint.LookupSessionLog(ctx, checkpointID)
 	} else {
 		defer repo.Close()
-		store := checkpoint.NewGitStore(repo)
+		store := checkpoint.NewCommittedReadStore(ctx, repo)
+		store.SetBlobFetcher(FetchBlobsByHash)
 		logContent, _, err = checkpoint.ReadRawSessionLogForCheckpoint(ctx, store, checkpointID)
 	}
 	if err != nil {

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -247,12 +247,6 @@ func resolveLatestCheckpoint(ctx context.Context, store *checkpoint.GitStore, ch
 	for _, cpID := range checkpointIDs {
 		metadata, readErr := readCheckpointInfoFromStore(ctx, store, cpID)
 		if readErr != nil {
-			logging.Debug(ctx, "checkpoint store metadata read failed",
-				slog.String("checkpoint_id", cpID.String()),
-				slog.String("error", readErr.Error()),
-			)
-		}
-		if readErr != nil {
 			logging.Debug(ctx, "resolveLatestCheckpoint: checkpoint metadata read failed",
 				slog.String("checkpoint_id", cpID.String()),
 				slog.String("error", readErr.Error()),
@@ -599,9 +593,8 @@ func promptResumeFromOlderCheckpoint() (bool, error) {
 	return confirmed, nil
 }
 
-// checkRemoteMetadata checks if checkpoint metadata exists on the remote and
-// automatically fetches it if available. When a checkpoint_remote is configured,
-// fetches from there. Otherwise falls back to origin.
+// checkRemoteMetadata checks if v1 checkpoint metadata exists on the remote and
+// fetches it if available. Custom committed read refs are local-only.
 func checkRemoteMetadata(
 	ctx context.Context,
 	w, errW io.Writer,

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -832,16 +832,14 @@ func resumeSingleSession(ctx context.Context, w, errW io.Writer, ag agent.Agent,
 		return nil
 	}
 
-	var logContent []byte
 	repo, repoErr := openRepository(ctx)
 	if repoErr != nil {
-		logContent, _, err = checkpoint.LookupSessionLog(ctx, checkpointID)
-	} else {
-		defer repo.Close()
-		store := checkpoint.NewCommittedReadStore(ctx, repo)
-		store.SetBlobFetcher(FetchBlobsByHash)
-		logContent, _, err = checkpoint.ReadRawSessionLogForCheckpoint(ctx, store, checkpointID)
+		return fmt.Errorf("failed to open repository: %w", repoErr)
 	}
+	defer repo.Close()
+	store := checkpoint.NewCommittedReadStore(ctx, repo)
+	store.SetBlobFetcher(FetchBlobsByHash)
+	logContent, _, err := checkpoint.ReadRawSessionLogForCheckpoint(ctx, store, checkpointID)
 	if err != nil {
 		if errors.Is(err, checkpoint.ErrCheckpointNotFound) || errors.Is(err, checkpoint.ErrNoTranscript) {
 			logging.Debug(ctx, "resume session completed (no metadata)",

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -605,6 +605,7 @@ func checkRemoteMetadata(
 
 	if committedReadRef != plumbing.NewBranchReferenceName(paths.MetadataBranchName) {
 		fmt.Fprintf(errW, "Checkpoint '%s' found in commit but metadata is not available in %s.\n", checkpointID, committedReadRef)
+		fmt.Fprintf(errW, "This ref is local-only. Try: entire explain %s\n", checkpointID)
 		return nil
 	}
 

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -496,6 +496,79 @@ func createCheckpointOnMetadataBranchFull(t *testing.T, repo *git.Repository, se
 	return checkpointID
 }
 
+func writeCommittedResumeCheckpoint(t *testing.T, repo *git.Repository, checkpointID id.CheckpointID, sessionID string, createdAt time.Time) {
+	t.Helper()
+
+	writeCommittedResumeCheckpointWithAgent(t, repo, checkpointID, sessionID, createdAt, agent.AgentTypeClaudeCode)
+}
+
+func writeCommittedResumeCheckpointWithAgent(
+	t *testing.T,
+	repo *git.Repository,
+	checkpointID id.CheckpointID,
+	sessionID string,
+	createdAt time.Time,
+	agentType types.AgentType,
+) {
+	t.Helper()
+
+	rawTranscript := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"resume"}]}}` + "\n")
+	if err := checkpoint.NewGitStore(repo).WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID: checkpointID,
+		SessionID:    sessionID,
+		CreatedAt:    createdAt,
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted(rawTranscript),
+		Prompts:      []string{"resume prompt"},
+		Agent:        agentType,
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	}); err != nil {
+		t.Fatalf("WriteCommitted(%s): %v", sessionID, err)
+	}
+}
+
+func mirrorMetadataBranchToV11Ref(t *testing.T, repo *git.Repository) {
+	t.Helper()
+
+	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	if err != nil {
+		t.Fatalf("read v1 metadata branch: %v", err)
+	}
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), v1Ref.Hash())); err != nil {
+		t.Fatalf("set v1.1 metadata ref: %v", err)
+	}
+}
+
+func enableResumeV11(t *testing.T, repoRoot string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".entire"), 0o755); err != nil {
+		t.Fatalf("create settings dir: %v", err)
+	}
+	settingsPath := filepath.Join(repoRoot, ".entire", paths.SettingsFileName)
+	settingsJSON := []byte(`{"enabled": true, "strategy_options": {"checkpoints_version": "1.1"}}`)
+	if err := os.WriteFile(settingsPath, settingsJSON, 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+}
+
+func commitResumeTrailer(t *testing.T, worktree *git.Worktree, repoRoot, fileName, commitMessage string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(repoRoot, fileName), []byte("feature content"), 0o644); err != nil {
+		t.Fatalf("write feature file: %v", err)
+	}
+	if _, err := worktree.Add(fileName); err != nil {
+		t.Fatalf("add feature file: %v", err)
+	}
+	if _, err := worktree.Commit(commitMessage, &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com"},
+	}); err != nil {
+		t.Fatalf("commit trailer: %v", err)
+	}
+}
+
 // TestResolveLatestCheckpoint verifies that resolveLatestCheckpoint returns the
 // checkpoint with the newest CreatedAt, regardless of trailer order.
 func TestResolveLatestCheckpoint(t *testing.T) {
@@ -510,15 +583,18 @@ func TestResolveLatestCheckpoint(t *testing.T) {
 	t2 := time.Date(2025, 1, 1, 11, 0, 0, 0, time.UTC)
 	t3 := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC) // newest
 
-	cpID1 := createCheckpointOnMetadataBranchFull(t, repo, "session-oldest", id.MustCheckpointID("aaa111bbb222"), t1)
-	cpID2 := createCheckpointOnMetadataBranchFull(t, repo, "session-middle", id.MustCheckpointID("ccc333ddd444"), t2)
-	cpID3 := createCheckpointOnMetadataBranchFull(t, repo, "session-newest", id.MustCheckpointID("eee555fff666"), t3)
+	cpID1 := id.MustCheckpointID("aaa111bbb222")
+	cpID2 := id.MustCheckpointID("ccc333ddd444")
+	cpID3 := id.MustCheckpointID("eee555fff666")
+	writeCommittedResumeCheckpoint(t, repo, cpID1, "session-oldest", t1)
+	writeCommittedResumeCheckpoint(t, repo, cpID2, "session-middle", t2)
+	writeCommittedResumeCheckpoint(t, repo, cpID3, "session-newest", t3)
 
 	// Pass checkpoint IDs in reverse chronological order (newest first),
 	// simulating git CLI squash merge trailer order.
 	reverseOrderIDs := []id.CheckpointID{cpID3, cpID2, cpID1}
 	reader := checkpoint.NewGitStore(repo)
-	latest, err := resolveLatestCheckpoint(context.Background(), repo, reader, reverseOrderIDs)
+	latest, err := resolveLatestCheckpoint(context.Background(), reader, reverseOrderIDs)
 	if err != nil {
 		t.Fatalf("resolveLatestCheckpoint() error = %v", err)
 	}
@@ -530,7 +606,7 @@ func TestResolveLatestCheckpoint(t *testing.T) {
 
 	// Also verify with chronological order
 	chronologicalIDs := []id.CheckpointID{cpID1, cpID2, cpID3}
-	latest2, err := resolveLatestCheckpoint(context.Background(), repo, reader, chronologicalIDs)
+	latest2, err := resolveLatestCheckpoint(context.Background(), reader, chronologicalIDs)
 	if err != nil {
 		t.Fatalf("resolveLatestCheckpoint() error = %v", err)
 	}
@@ -606,22 +682,150 @@ func TestResolveLatestCheckpointUsesV1Checkpoint(t *testing.T) {
 
 	repo, _, _ := setupResumeTestRepo(t, tmpDir, false)
 
-	targetID := createCheckpointOnMetadataBranchFull(
-		t,
-		repo,
-		"session-v1-target",
-		id.MustCheckpointID("aa11bb22cc33"),
-		time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC),
-	)
+	targetID := id.MustCheckpointID("aa11bb22cc33")
+	writeCommittedResumeCheckpoint(t, repo, targetID, "session-v1-target", time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC))
 
 	store := checkpoint.NewGitStore(repo)
 
-	latest, err := resolveLatestCheckpoint(context.Background(), repo, store, []id.CheckpointID{targetID})
+	latest, err := resolveLatestCheckpoint(context.Background(), store, []id.CheckpointID{targetID})
 	if err != nil {
 		t.Fatalf("resolveLatestCheckpoint() error = %v", err)
 	}
 	if latest.CheckpointID != targetID {
 		t.Errorf("resolveLatestCheckpoint() = %s, want %s", latest.CheckpointID, targetID)
+	}
+}
+
+func TestResumeFromCurrentBranch_UsesV11MetadataOnly(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("ENTIRE_TEST_CLAUDE_PROJECT_DIR", filepath.Join(tmpDir, "claude-projects"))
+
+	repo, worktree, _ := setupResumeTestRepo(t, tmpDir, false)
+	enableResumeV11(t, tmpDir)
+
+	cpID := id.MustCheckpointID("b1b2b3b4b5b6")
+	sessionID := "session-v11-only"
+	writeCommittedResumeCheckpoint(t, repo, cpID, sessionID, time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC))
+	mirrorMetadataBranchToV11Ref(t, repo)
+
+	if err := repo.Storer.RemoveReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName)); err != nil {
+		t.Fatalf("remove v1 metadata branch: %v", err)
+	}
+
+	commitResumeTrailer(t, worktree, tmpDir, "feature-v11-only.txt", "Add feature\n\nEntire-Checkpoint: "+cpID.String())
+
+	var stdout, stderr bytes.Buffer
+	if err := resumeFromCurrentBranch(context.Background(), &stdout, &stderr, "master", true); err != nil {
+		t.Fatalf("resumeFromCurrentBranch error: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	combined := stdout.String() + stderr.String()
+	if !strings.Contains(combined, sessionID) {
+		t.Fatalf("resume did not read v1.1 metadata for session %q:\n%s", sessionID, combined)
+	}
+	if strings.Contains(combined, "found in commit but the entire/checkpoints/v1 branch is not available") {
+		t.Fatalf("resume fell through to missing-v1 metadata message despite v1.1 metadata:\n%s", combined)
+	}
+}
+
+func TestResolveLatestCheckpoint_V11DoesNotFallbackToStaleV1(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	repo, _, _ := setupResumeTestRepo(t, tmpDir, false)
+	enableResumeV11(t, tmpDir)
+
+	baseHash := readMetadataBranchHash(t, repo)
+	customOnlyID := id.MustCheckpointID("c1c2c3c4c5c6")
+	writeCommittedResumeCheckpoint(t, repo, customOnlyID, "session-custom-only", time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC))
+	mirrorMetadataBranchToV11Ref(t, repo)
+
+	v1RefName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(v1RefName, baseHash)); err != nil {
+		t.Fatalf("reset v1 metadata branch: %v", err)
+	}
+
+	staleV1ID := id.MustCheckpointID("d1d2d3d4d5d6")
+	writeCommittedResumeCheckpoint(t, repo, staleV1ID, "session-stale-v1", time.Date(2025, 1, 3, 10, 0, 0, 0, time.UTC))
+
+	store := checkpoint.NewCommittedReadStore(context.Background(), repo)
+	store.SetBlobFetcher(FetchBlobsByHash)
+
+	_, err := resolveLatestCheckpoint(context.Background(), store, []id.CheckpointID{staleV1ID})
+	if err == nil {
+		t.Fatal("resolveLatestCheckpoint found checkpoint from stale v1 even though v1.1 custom ref differs")
+	}
+}
+
+func TestResumeFromCurrentBranch_V11DoesNotSeedFromV1(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("ENTIRE_TEST_CLAUDE_PROJECT_DIR", filepath.Join(tmpDir, "claude-projects"))
+
+	repo, worktree, _ := setupResumeTestRepo(t, tmpDir, false)
+	enableResumeV11(t, tmpDir)
+
+	cpID := id.MustCheckpointID("1122aabbccdd")
+	sessionID := "session-v1-only"
+	writeCommittedResumeCheckpoint(t, repo, cpID, sessionID, time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC))
+
+	commitResumeTrailer(t, worktree, tmpDir, "feature-v1-only.txt", "Add feature\n\nEntire-Checkpoint: "+cpID.String())
+
+	var stdout, stderr bytes.Buffer
+	if err := resumeFromCurrentBranch(context.Background(), &stdout, &stderr, "master", true); err != nil {
+		t.Fatalf("resumeFromCurrentBranch error: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	combined := stdout.String() + stderr.String()
+	if strings.Contains(combined, sessionID) {
+		t.Fatalf("resume used v1 metadata for session %q in v1.1 mode:\n%s", sessionID, combined)
+	}
+	if !strings.Contains(stderr.String(), paths.MetadataRefName) {
+		t.Fatalf("resume did not report missing v1.1 metadata ref:\nstdout: %s\nstderr: %s", stdout.String(), stderr.String())
+	}
+	if strings.Contains(combined, "git fetch origin entire/checkpoints/v1") {
+		t.Fatalf("resume suggested v1 fetch in v1.1 mode:\n%s", combined)
+	}
+}
+
+func TestResumeFromCurrentBranch_V11SquashUsesLatestMetadataTimestamp(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("ENTIRE_TEST_CLAUDE_PROJECT_DIR", filepath.Join(tmpDir, "claude-projects"))
+
+	repo, worktree, _ := setupResumeTestRepo(t, tmpDir, false)
+	enableResumeV11(t, tmpDir)
+
+	olderID := id.MustCheckpointID("e1e2e3e4e5e6")
+	newerID := id.MustCheckpointID("f1f2f3f4f5f6")
+	olderSession := "session-v11-older"
+	newerSession := "session-v11-newer"
+	writeCommittedResumeCheckpoint(t, repo, olderID, olderSession, time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC))
+	writeCommittedResumeCheckpoint(t, repo, newerID, newerSession, time.Date(2025, 1, 2, 11, 0, 0, 0, time.UTC))
+	mirrorMetadataBranchToV11Ref(t, repo)
+
+	if err := repo.Storer.RemoveReference(plumbing.NewBranchReferenceName(paths.MetadataBranchName)); err != nil {
+		t.Fatalf("remove v1 metadata branch: %v", err)
+	}
+
+	squashMsg := fmt.Sprintf("Squash feature\n\nEntire-Checkpoint: %s\n\nEntire-Checkpoint: %s\n", olderID, newerID)
+	commitResumeTrailer(t, worktree, tmpDir, "feature-v11-squash.txt", squashMsg)
+
+	var stdout, stderr bytes.Buffer
+	if err := resumeFromCurrentBranch(context.Background(), &stdout, &stderr, "master", true); err != nil {
+		t.Fatalf("resumeFromCurrentBranch error: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	combined := stdout.String() + stderr.String()
+	if !strings.Contains(combined, "resuming from the latest") {
+		t.Fatalf("resume did not report latest-checkpoint selection:\n%s", combined)
+	}
+	if !strings.Contains(combined, newerSession) {
+		t.Fatalf("resume did not use newest v1.1 metadata session %q:\n%s", newerSession, combined)
+	}
+	if strings.Contains(combined, olderSession) {
+		t.Fatalf("resume used older v1.1 metadata session %q:\n%s", olderSession, combined)
 	}
 }
 
@@ -785,7 +989,15 @@ func TestCheckRemoteMetadata_MetadataExistsOnRemote(t *testing.T) {
 
 	// Create checkpoint metadata on local entire/checkpoints/v1 branch
 	sessionID := "2025-01-01-test-session"
-	checkpointID := createCheckpointOnMetadataBranch(t, repo, sessionID)
+	checkpointID := id.MustCheckpointID("abc123def456")
+	writeCommittedResumeCheckpointWithAgent(
+		t,
+		repo,
+		checkpointID,
+		sessionID,
+		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		"",
+	)
 
 	// Copy the local entire/checkpoints/v1 to origin/entire/checkpoints/v1 (simulate remote)
 	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
@@ -807,7 +1019,7 @@ func TestCheckRemoteMetadata_MetadataExistsOnRemote(t *testing.T) {
 
 	// Call checkRemoteMetadata - should find metadata on the remote tree and
 	// attempt to resume, but fail because the test checkpoint has no agent field.
-	err = checkRemoteMetadata(context.Background(), os.Stdout, os.Stderr, checkpointID)
+	err = checkRemoteMetadata(context.Background(), os.Stdout, os.Stderr, checkpointID, plumbing.NewBranchReferenceName(paths.MetadataBranchName))
 	if err == nil {
 		t.Error("checkRemoteMetadata() should return error when agent is missing from metadata")
 	} else if !strings.Contains(err.Error(), "failed to resolve agent") {
@@ -829,7 +1041,13 @@ func TestCheckRemoteMetadata_NoRemoteMetadataBranch(t *testing.T) {
 	// Don't create any remote ref - simulating no remote entire/checkpoints/v1
 
 	// Call checkRemoteMetadata - should handle gracefully (no remote branch)
-	err := checkRemoteMetadata(context.Background(), os.Stdout, os.Stderr, id.MustCheckpointID("aaa111bbb222"))
+	err := checkRemoteMetadata(
+		context.Background(),
+		os.Stdout,
+		os.Stderr,
+		id.MustCheckpointID("aaa111bbb222"),
+		plumbing.NewBranchReferenceName(paths.MetadataBranchName),
+	)
 	if err != nil {
 		t.Errorf("checkRemoteMetadata() returned error when no remote branch: %v", err)
 	}
@@ -843,7 +1061,13 @@ func TestCheckRemoteMetadata_CheckpointNotOnRemote(t *testing.T) {
 
 	// Create checkpoint metadata on local entire/checkpoints/v1 branch
 	sessionID := "2025-01-01-test-session"
-	_ = createCheckpointOnMetadataBranch(t, repo, sessionID)
+	writeCommittedResumeCheckpoint(
+		t,
+		repo,
+		id.MustCheckpointID("abc123def456"),
+		sessionID,
+		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	)
 
 	// Copy the local entire/checkpoints/v1 to origin/entire/checkpoints/v1 (simulate remote)
 	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
@@ -864,7 +1088,13 @@ func TestCheckRemoteMetadata_CheckpointNotOnRemote(t *testing.T) {
 	}
 
 	// Call checkRemoteMetadata with a DIFFERENT checkpoint ID (not on remote)
-	err = checkRemoteMetadata(context.Background(), os.Stdout, os.Stderr, id.MustCheckpointID("abcd12345678"))
+	err = checkRemoteMetadata(
+		context.Background(),
+		os.Stdout,
+		os.Stderr,
+		id.MustCheckpointID("abcd12345678"),
+		plumbing.NewBranchReferenceName(paths.MetadataBranchName),
+	)
 	if err != nil {
 		t.Errorf("checkRemoteMetadata() returned error for missing checkpoint: %v", err)
 	}

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const resumeTestStrategy = "manual-commit"
+
 type recordingResumeAgent struct {
 	sessionDir     string
 	writtenSession *agent.AgentSession
@@ -531,7 +533,7 @@ func writeCommittedResumeCheckpointWithTranscript(
 		CheckpointID: checkpointID,
 		SessionID:    sessionID,
 		CreatedAt:    createdAt,
-		Strategy:     "manual-commit",
+		Strategy:     resumeTestStrategy,
 		Transcript:   redact.AlreadyRedacted(rawTranscript),
 		Prompts:      []string{"resume prompt"},
 		Agent:        agentType,

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -513,6 +513,20 @@ func writeCommittedResumeCheckpointWithAgent(
 	t.Helper()
 
 	rawTranscript := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"resume"}]}}` + "\n")
+	writeCommittedResumeCheckpointWithTranscript(t, repo, checkpointID, sessionID, createdAt, agentType, rawTranscript)
+}
+
+func writeCommittedResumeCheckpointWithTranscript(
+	t *testing.T,
+	repo *git.Repository,
+	checkpointID id.CheckpointID,
+	sessionID string,
+	createdAt time.Time,
+	agentType types.AgentType,
+	rawTranscript []byte,
+) {
+	t.Helper()
+
 	if err := checkpoint.NewGitStore(repo).WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
 		CheckpointID: checkpointID,
 		SessionID:    sessionID,
@@ -978,6 +992,53 @@ func TestResumeSingleSession_UsesV1Transcript(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "session log not available") {
 		t.Fatalf("resumeSingleSession() reported missing log: %q", stdout.String())
+	}
+}
+
+func TestResumeSingleSession_UsesV11Transcript(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	repo, _, _ := setupResumeTestRepo(t, tmpDir, false)
+	enableResumeV11(t, tmpDir)
+
+	ctx := context.Background()
+	cpID := id.MustCheckpointID("bca123bca123")
+	sessionID := "resume-v11-session"
+	v11Raw := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"resume from v11"}]}}` + "\n")
+	staleV1Raw := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"stale v1"}]}}` + "\n")
+
+	writeCommittedResumeCheckpointWithTranscript(
+		t,
+		repo,
+		cpID,
+		sessionID,
+		time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC),
+		agent.AgentTypeClaudeCode,
+		v11Raw,
+	)
+	mirrorMetadataBranchToV11Ref(t, repo)
+	writeCommittedResumeCheckpointWithTranscript(
+		t,
+		repo,
+		cpID,
+		sessionID,
+		time.Date(2025, 1, 3, 10, 0, 0, 0, time.UTC),
+		agent.AgentTypeClaudeCode,
+		staleV1Raw,
+	)
+
+	ag := &recordingResumeAgent{sessionDir: filepath.Join(tmpDir, "sessions")}
+	var stdout, stderr bytes.Buffer
+	if err := resumeSingleSession(ctx, &stdout, &stderr, ag, sessionID, cpID, tmpDir, true); err != nil {
+		t.Fatalf("resumeSingleSession() error = %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+
+	if ag.writtenSession == nil {
+		t.Fatal("resumeSingleSession() did not restore a session")
+	}
+	if string(ag.writtenSession.NativeData) != string(v11Raw) {
+		t.Fatalf("restored transcript = %q, want v1.1 transcript %q", string(ag.writtenSession.NativeData), string(v11Raw))
 	}
 }
 

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -559,6 +559,8 @@ func mirrorMetadataBranchToV11Ref(t *testing.T, repo *git.Repository) {
 func enableResumeV11(t *testing.T, repoRoot string) {
 	t.Helper()
 
+	t.Setenv("ENTIRE_TEST_CLAUDE_PROJECT_DIR", filepath.Join(repoRoot, "claude-projects"))
+
 	if err := os.MkdirAll(filepath.Join(repoRoot, ".entire"), 0o755); err != nil {
 		t.Fatalf("create settings dir: %v", err)
 	}
@@ -715,7 +717,6 @@ func TestResolveLatestCheckpointUsesV1Checkpoint(t *testing.T) {
 func TestResumeFromCurrentBranch_UsesV11MetadataOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	t.Setenv("ENTIRE_TEST_CLAUDE_PROJECT_DIR", filepath.Join(tmpDir, "claude-projects"))
 
 	repo, worktree, _ := setupResumeTestRepo(t, tmpDir, false)
 	enableResumeV11(t, tmpDir)
@@ -777,7 +778,6 @@ func TestResolveLatestCheckpoint_V11DoesNotFallbackToStaleV1(t *testing.T) {
 func TestResumeFromCurrentBranch_V11DoesNotSeedFromV1(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	t.Setenv("ENTIRE_TEST_CLAUDE_PROJECT_DIR", filepath.Join(tmpDir, "claude-projects"))
 
 	repo, worktree, _ := setupResumeTestRepo(t, tmpDir, false)
 	enableResumeV11(t, tmpDir)
@@ -811,7 +811,6 @@ func TestResumeFromCurrentBranch_V11DoesNotSeedFromV1(t *testing.T) {
 func TestResumeFromCurrentBranch_V11SquashUsesLatestMetadataTimestamp(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)
-	t.Setenv("ENTIRE_TEST_CLAUDE_PROJECT_DIR", filepath.Join(tmpDir, "claude-projects"))
 
 	repo, worktree, _ := setupResumeTestRepo(t, tmpDir, false)
 	enableResumeV11(t, tmpDir)

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -803,6 +803,9 @@ func TestResumeFromCurrentBranch_V11DoesNotSeedFromV1(t *testing.T) {
 	if strings.Contains(combined, "git fetch origin entire/checkpoints/v1") {
 		t.Fatalf("resume suggested v1 fetch in v1.1 mode:\n%s", combined)
 	}
+	if !strings.Contains(stderr.String(), "entire explain "+cpID.String()) {
+		t.Fatalf("resume did not suggest 'entire explain' to sync the v1.1 ref:\nstderr: %s", stderr.String())
+	}
 }
 
 func TestResumeFromCurrentBranch_V11SquashUsesLatestMetadataTimestamp(t *testing.T) {

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -629,7 +629,10 @@ func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.W
 	defer repo.Close()
 
 	WarnIfMetadataDisconnected()
-	store := s.getCheckpointStore(repo)
+	store := cpkg.NewCommittedReadStore(ctx, repo)
+	if s.blobFetcher != nil {
+		store.SetBlobFetcher(s.blobFetcher)
+	}
 	summary, err := cpkg.ReadCommittedCheckpoint(ctx, store, point.CheckpointID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read checkpoint: %w", err)

--- a/cmd/entire/cli/strategy/rewind_test.go
+++ b/cmd/entire/cli/strategy/rewind_test.go
@@ -14,10 +14,14 @@ import (
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode" // Register agent for ResolveAgentForRewind tests
 	_ "github.com/entireio/cli/cmd/entire/cli/agent/geminicli"  // Register agent for ResolveAgentForRewind tests
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/redact"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
@@ -203,6 +207,49 @@ func TestShadowStrategy_PreviewRewind_LogsOnly(t *testing.T) {
 	if len(preview.FilesToRestore) > 0 {
 		t.Errorf("Logs-only preview should have no files to restore, got: %v", preview.FilesToRestore)
 	}
+}
+
+func TestRestoreLogsOnly_UsesV11Transcript(t *testing.T) {
+	repo := setupV1CustomRefRepo(t, `"1.1"`)
+	repoRoot, err := os.Getwd()
+	require.NoError(t, err)
+
+	agentName := types.AgentName("restore-logs-v11-agent")
+	agentType := types.AgentType("Restore Logs V11 Agent")
+	sessionDir := filepath.Join(repoRoot, "restored-sessions")
+	agent.Register(agentName, func() agent.Agent {
+		return &restoreLogsOnlyAgent{
+			name:       agentName,
+			agentType:  agentType,
+			sessionDir: sessionDir,
+		}
+	})
+
+	ctx := context.Background()
+	cpID := id.MustCheckpointID("abc987abc987")
+	sessionID := "restore-v11-session"
+	v11Transcript := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"restore from v11"}]}}` + "\n")
+	staleV1Transcript := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"stale v1"}]}}` + "\n")
+
+	writeCommittedRewindCheckpoint(t, repo, cpID, sessionID, agentType, v11Transcript, time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC))
+	v1Ref, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), v1Ref.Hash())))
+
+	writeCommittedRewindCheckpoint(t, repo, cpID, sessionID, agentType, staleV1Transcript, time.Date(2025, 1, 3, 10, 0, 0, 0, time.UTC))
+
+	var stdout, stderr bytes.Buffer
+	restored, err := NewManualCommitStrategy().RestoreLogsOnly(ctx, &stdout, &stderr, RewindPoint{
+		IsLogsOnly:   true,
+		CheckpointID: cpID,
+	}, true)
+	require.NoError(t, err, "stderr: %s", stderr.String())
+	require.Len(t, restored, 1, "stdout: %s\nstderr: %s", stdout.String(), stderr.String())
+
+	restoredPath := filepath.Join(sessionDir, sessionID+".jsonl")
+	got, err := os.ReadFile(restoredPath)
+	require.NoError(t, err)
+	require.Equal(t, string(v11Transcript), string(got))
 }
 
 func TestResolveAgentForRewind(t *testing.T) {
@@ -544,6 +591,74 @@ func TestShadowStrategy_Rewind_FromRepoRoot(t *testing.T) {
 	if string(content) != "# Test\n" {
 		t.Errorf("README.md content = %q, want %q", string(content), "# Test\n")
 	}
+}
+
+func writeCommittedRewindCheckpoint(
+	t *testing.T,
+	repo *git.Repository,
+	checkpointID id.CheckpointID,
+	sessionID string,
+	agentType types.AgentType,
+	transcript []byte,
+	createdAt time.Time,
+) {
+	t.Helper()
+
+	err := cpkg.NewGitStore(repo).WriteCommitted(context.Background(), cpkg.WriteCommittedOptions{
+		CheckpointID: checkpointID,
+		SessionID:    sessionID,
+		CreatedAt:    createdAt,
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted(transcript),
+		Prompts:      []string{"restore prompt"},
+		Agent:        agentType,
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	})
+	require.NoError(t, err)
+}
+
+type restoreLogsOnlyAgent struct {
+	name       types.AgentName
+	agentType  types.AgentType
+	sessionDir string
+}
+
+var _ agent.Agent = (*restoreLogsOnlyAgent)(nil)
+
+func (a *restoreLogsOnlyAgent) Name() types.AgentName                          { return a.name }
+func (a *restoreLogsOnlyAgent) Type() types.AgentType                          { return a.agentType }
+func (a *restoreLogsOnlyAgent) Description() string                            { return "restore logs test agent" }
+func (a *restoreLogsOnlyAgent) IsPreview() bool                                { return false }
+func (a *restoreLogsOnlyAgent) DetectPresence(_ context.Context) (bool, error) { return true, nil }
+func (a *restoreLogsOnlyAgent) ProtectedDirs() []string                        { return nil }
+func (a *restoreLogsOnlyAgent) ReadTranscript(string) ([]byte, error)          { return nil, nil }
+func (a *restoreLogsOnlyAgent) ChunkTranscript(_ context.Context, content []byte, _ int) ([][]byte, error) {
+	return [][]byte{content}, nil
+}
+func (a *restoreLogsOnlyAgent) ReassembleTranscript(chunks [][]byte) ([]byte, error) {
+	var out []byte
+	for _, chunk := range chunks {
+		out = append(out, chunk...)
+	}
+	return out, nil
+}
+func (a *restoreLogsOnlyAgent) GetSessionID(*agent.HookInput) string { return "" }
+func (a *restoreLogsOnlyAgent) GetSessionDir(string) (string, error) { return a.sessionDir, nil }
+func (a *restoreLogsOnlyAgent) ResolveSessionFile(sessionDir, sessionID string) string {
+	return filepath.Join(sessionDir, sessionID+".jsonl")
+}
+func (a *restoreLogsOnlyAgent) ReadSession(*agent.HookInput) (*agent.AgentSession, error) {
+	return nil, nil //nolint:nilnil // Not used by this test agent.
+}
+func (a *restoreLogsOnlyAgent) WriteSession(_ context.Context, session *agent.AgentSession) error {
+	if err := os.MkdirAll(filepath.Dir(session.SessionRef), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(session.SessionRef, session.NativeData, 0o600)
+}
+func (a *restoreLogsOnlyAgent) FormatResumeCommand(sessionID string) string {
+	return "restore-logs " + sessionID
 }
 
 // fakeExternalAgent is a minimal Agent implementation for testing dynamic registration.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/483
<!-- entire-trail-link-end -->

## What

Port `entire session resume <branch>` to read committed checkpoint metadata and transcripts from the configured committed checkpoint read store. When checkpoints v1.1 is enabled, resume now reads from the local custom ref instead of the v1 metadata branch.

## How

- Use `checkpoint.NewCommittedReadStore(ctx, repo)` in the resume metadata and transcript paths.
- Keep v1 remote metadata fetch behavior limited to v1 reads; v1.1 missing metadata is reported against the custom ref instead of falling back to v1.
- Update logs-only transcript restoration through `ManualCommitStrategy.RestoreLogsOnly` to use the same committed read store.
- Add focused v1 and v1.1 resume tests for metadata selection, squash/latest resolution, missing v1.1 metadata, and transcript restoration.

## Verification

- [x] `mise run fmt`
- [x] `mise run lint`
- [x] `mise run build`
- [x] `mise run test`

## Reviewer Notes

This PR intentionally avoids migrating general `checkpoint rewind` listing/interactive behavior. The shared `RestoreLogsOnly` path is updated because `session resume` uses it for transcript restoration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how resume resolves metadata and transcripts across v1 vs v1.1 refs; wrong ref selection could block resume or restore stale logs, though behavior is covered by new tests.
> 
> **Overview**
> **`entire session resume`** now loads committed checkpoint metadata and transcripts through **`checkpoint.NewCommittedReadStore`**, so checkpoints **v1.1** read from the configured local custom ref instead of falling back to **`entire/checkpoints/v1`**.
> 
> The resume path drops direct metadata-branch tree reads and routes remote recovery through the same store/ref. **v1** remote fetch/promotion stays on the v1 branch only; when the active read ref is the v1.1 custom ref, missing metadata is reported as local-only (e.g. **`entire explain`**) rather than seeding from stale v1. Squash commits still pick the latest checkpoint by metadata timestamp. **`ManualCommitStrategy.RestoreLogsOnly`** uses the same committed read store for transcript restore (used by resume).
> 
> Tests cover v1.1-only reads, no stale v1 fallback, squash latest selection, and v1.1 transcript restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d37d3dfa447b8c52bbedb91236f9614f05ecd18. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->