### PR TITLE
checkpoint activity: v1.1 committed-read support

### DIFF
--- a/cmd/entire/cli/dispatch/mode_local.go
+++ b/cmd/entire/cli/dispatch/mode_local.go
@@ -171,7 +171,8 @@ func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options,
 		return nil, err
 	}
 
-	store := checkpoint.NewGitStore(repo)
+	checkpoint.SyncCommittedReadRef(ctx, repo)
+	store := checkpoint.NewCommittedReadStore(ctx, repo)
 	infos, err := store.ListCommitted(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list committed checkpoints: %w", err)

--- a/cmd/entire/cli/dispatch/mode_local.go
+++ b/cmd/entire/cli/dispatch/mode_local.go
@@ -16,6 +16,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/search"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -171,8 +172,14 @@ func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options,
 		return nil, err
 	}
 
-	checkpoint.SyncCommittedReadRef(ctx, repo)
-	store := checkpoint.NewCommittedReadStore(ctx, repo)
+	// The committed-read topology (and thus the v1.1 mirror opt-in) is resolved
+	// from settings relative to the context's worktree root, which defaults to
+	// the process cwd. repoRoot may be a different repo (--repo/RepoPaths) or
+	// the cwd may not be a repo at all, so scope settings resolution to this
+	// repo before consulting the topology.
+	repoCtx := settings.WithWorktreeRoot(ctx, repoRoot)
+	checkpoint.SyncCommittedReadRef(repoCtx, repo)
+	store := checkpoint.NewCommittedReadStore(repoCtx, repo)
 	infos, err := store.ListCommitted(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list committed checkpoints: %w", err)

--- a/cmd/entire/cli/dispatch/mode_local_test.go
+++ b/cmd/entire/cli/dispatch/mode_local_test.go
@@ -2,7 +2,6 @@ package dispatch
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,7 +13,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	checkpointid "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
-	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/entireio/cli/redact"
@@ -111,7 +109,7 @@ func TestLocalMode_ReadsV1CustomRefWhenEnabled(t *testing.T) {
 	}
 
 	// Mirror enabled: reads resolve against the custom ref.
-	enableV1CustomRefMirror(t)
+	writeV1CustomRefMirrorSettings(t, dir)
 	got, err = Run(context.Background(), opts)
 	if err != nil {
 		t.Fatal(err)
@@ -981,34 +979,13 @@ func moveCheckpointsToCustomRefOnly(t *testing.T, repoDir string) {
 	}
 }
 
-// mirrorEnabledSettings returns settings opted into the v1 custom-ref mirror.
+// writeV1CustomRefMirrorSettings opts repoDir into the v1 custom-ref mirror.
 // "1.1" is the on-disk checkpoints_version encoding read by
 // settings.MirrorsToV1CustomRef.
-func mirrorEnabledSettings() *settings.EntireSettings {
-	return &settings.EntireSettings{
-		Enabled:         true,
-		StrategyOptions: map[string]any{"checkpoints_version": "1.1"},
-	}
-}
-
-// enableV1CustomRefMirror opts the current repo into the v1 custom-ref mirror.
-func enableV1CustomRefMirror(t *testing.T) {
-	t.Helper()
-	if err := settings.Save(context.Background(), mirrorEnabledSettings()); err != nil {
-		t.Fatal(err)
-	}
-}
-
-// writeV1CustomRefMirrorSettings opts repoDir into the v1 custom-ref mirror by
-// writing its .entire/settings.json directly (settings.Save resolves relative
-// to cwd, not an arbitrary repo).
 func writeV1CustomRefMirrorSettings(t *testing.T, repoDir string) {
 	t.Helper()
-	data, err := json.MarshalIndent(mirrorEnabledSettings(), "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	testutil.WriteFile(t, repoDir, ".entire/settings.json", string(data))
+	testutil.WriteFile(t, repoDir, ".entire/settings.json",
+		`{"enabled": true, "strategy_options": {"checkpoints_version": "1.1"}}`)
 }
 
 func addOriginRemote(t *testing.T, repoDir string) {

--- a/cmd/entire/cli/dispatch/mode_local_test.go
+++ b/cmd/entire/cli/dispatch/mode_local_test.go
@@ -12,11 +12,14 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	checkpointid "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 	"github.com/entireio/cli/redact"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
@@ -68,6 +71,52 @@ func TestLocalMode_EnumeratesCheckpoints(t *testing.T) {
 	}
 	if len(got.CoveredRepos) != 1 || got.CoveredRepos[0] != testRepoFullName {
 		t.Fatalf("unexpected covered repos: %v", got.CoveredRepos)
+	}
+}
+
+func TestLocalMode_ReadsV1CustomRefWhenEnabled(t *testing.T) {
+	dir := t.TempDir()
+	stubGeneratedLocalDispatch(t)
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "a.txt", "x")
+	testutil.GitAdd(t, dir, "a.txt")
+	testutil.GitCommit(t, dir, "initial")
+	addOriginRemote(t, dir)
+
+	createdAt := time.Now().UTC()
+	seedCommittedCheckpoint(t, dir, seededCheckpoint{
+		id:           testCheckpointID,
+		branch:       "main",
+		createdAt:    createdAt,
+		filesTouched: []string{"a.txt"},
+		outcome:      testLocalFallbackText,
+	})
+	moveCheckpointsToCustomRefOnly(t, dir)
+
+	oldNow := nowUTC
+	nowUTC = func() time.Time { return createdAt.Add(2 * time.Hour) }
+	t.Cleanup(func() { nowUTC = oldNow })
+
+	t.Chdir(dir)
+	opts := Options{Mode: ModeLocal, Since: "7d", Branches: []string{"main"}}
+
+	// Mirror disabled: the checkpoint lives only on the custom ref, so the v1 read finds nothing.
+	got, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Repos) != 0 {
+		t.Fatalf("expected no checkpoints with mirror disabled, got %+v", got.Repos)
+	}
+
+	// Mirror enabled: reads resolve against the custom ref.
+	enableV1CustomRefMirror(t)
+	got, err = Run(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Repos) != 1 || got.Repos[0].Sections[0].Bullets[0].Text != testLocalFallbackText {
+		t.Fatalf("expected checkpoint via custom ref, got %+v", got.Repos)
 	}
 }
 
@@ -851,6 +900,38 @@ func seedCommittedCheckpoint(t *testing.T, repoDir string, cp seededCheckpoint) 
 		AuthorEmail: "test@example.com",
 	})
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// moveCheckpointsToCustomRefOnly points the v1 custom ref at the v1 branch tip
+// and removes the v1 branch, so committed checkpoints are reachable only via the
+// custom ref.
+func moveCheckpointsToCustomRefOnly(t *testing.T, repoDir string) {
+	t.Helper()
+	repo, err := git.PlainOpenWithOptions(repoDir, &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v1Branch := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+	v1Ref, err := repo.Reference(v1Branch, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(paths.MetadataRefName), v1Ref.Hash())); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Storer.RemoveReference(v1Branch); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// enableV1CustomRefMirror opts the current repo into the v1 custom-ref mirror.
+func enableV1CustomRefMirror(t *testing.T) {
+	t.Helper()
+	s := &settings.EntireSettings{Enabled: true}
+	s.EnableV1CustomRefMirror()
+	if err := settings.Save(context.Background(), s); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/entire/cli/dispatch/mode_local_test.go
+++ b/cmd/entire/cli/dispatch/mode_local_test.go
@@ -190,16 +190,7 @@ func TestLocalMode_ExplicitRepoResolvesMirrorOptInFromTargetRepo(t *testing.T) {
 
 	// cwd repo: mirror explicitly disabled.
 	testutil.InitRepo(t, cwdDir)
-	if err := os.MkdirAll(filepath.Join(cwdDir, ".entire"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(
-		filepath.Join(cwdDir, ".entire", "settings.json"),
-		[]byte(`{"enabled": true}`),
-		0o600,
-	); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFile(t, cwdDir, ".entire/settings.json", `{"enabled": true}`)
 
 	testutil.InitRepo(t, targetDir)
 	testutil.WriteFile(t, targetDir, "a.txt", "x")
@@ -1017,12 +1008,7 @@ func writeV1CustomRefMirrorSettings(t *testing.T, repoDir string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(repoDir, ".entire"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(repoDir, ".entire", "settings.json"), data, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFile(t, repoDir, ".entire/settings.json", string(data))
 }
 
 func addOriginRemote(t *testing.T, repoDir string) {

--- a/cmd/entire/cli/dispatch/mode_local_test.go
+++ b/cmd/entire/cli/dispatch/mode_local_test.go
@@ -990,25 +990,30 @@ func moveCheckpointsToCustomRefOnly(t *testing.T, repoDir string) {
 	}
 }
 
+// mirrorEnabledSettings returns settings opted into the v1 custom-ref mirror.
+// "1.1" is the on-disk checkpoints_version encoding read by
+// settings.MirrorsToV1CustomRef.
+func mirrorEnabledSettings() *settings.EntireSettings {
+	return &settings.EntireSettings{
+		Enabled:         true,
+		StrategyOptions: map[string]any{"checkpoints_version": "1.1"},
+	}
+}
+
 // enableV1CustomRefMirror opts the current repo into the v1 custom-ref mirror.
 func enableV1CustomRefMirror(t *testing.T) {
 	t.Helper()
-	s := &settings.EntireSettings{Enabled: true}
-	s.EnableV1CustomRefMirror()
-	if err := settings.Save(context.Background(), s); err != nil {
+	if err := settings.Save(context.Background(), mirrorEnabledSettings()); err != nil {
 		t.Fatal(err)
 	}
 }
 
 // writeV1CustomRefMirrorSettings opts repoDir into the v1 custom-ref mirror by
 // writing its .entire/settings.json directly (settings.Save resolves relative
-// to cwd, not an arbitrary repo). Uses the EnableV1CustomRefMirror setter so the
-// test does not hardcode the checkpoints_version encoding.
+// to cwd, not an arbitrary repo).
 func writeV1CustomRefMirrorSettings(t *testing.T, repoDir string) {
 	t.Helper()
-	s := &settings.EntireSettings{Enabled: true}
-	s.EnableV1CustomRefMirror()
-	data, err := json.MarshalIndent(s, "", "  ")
+	data, err := json.MarshalIndent(mirrorEnabledSettings(), "", "  ")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/entire/cli/dispatch/mode_local_test.go
+++ b/cmd/entire/cli/dispatch/mode_local_test.go
@@ -2,6 +2,7 @@ package dispatch
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -174,6 +175,69 @@ func TestLocalMode_ExplicitRepoUsesTargetRepoCheckpointSettings(t *testing.T) {
 	}
 	if got.Repos[0].Sections[0].Bullets[0].Text != testLocalFallbackText {
 		t.Fatalf("unexpected bullet: %+v", got.Repos[0].Sections[0].Bullets[0])
+	}
+}
+
+// TestLocalMode_ExplicitRepoResolvesMirrorOptInFromTargetRepo guards against
+// resolving the committed-read topology from the process cwd instead of the
+// enumerated repo. The target repo opts into the v1.1 mirror and keeps its
+// checkpoint only on the custom ref; cwd is a separate repo with the mirror
+// off. If the opt-in were read from cwd, the checkpoint would be invisible.
+func TestLocalMode_ExplicitRepoResolvesMirrorOptInFromTargetRepo(t *testing.T) {
+	cwdDir := t.TempDir()
+	targetDir := t.TempDir()
+	stubGeneratedLocalDispatch(t)
+
+	// cwd repo: mirror explicitly disabled.
+	testutil.InitRepo(t, cwdDir)
+	if err := os.MkdirAll(filepath.Join(cwdDir, ".entire"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(cwdDir, ".entire", "settings.json"),
+		[]byte(`{"enabled": true}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	testutil.InitRepo(t, targetDir)
+	testutil.WriteFile(t, targetDir, "a.txt", "x")
+	testutil.GitAdd(t, targetDir, "a.txt")
+	testutil.GitCommit(t, targetDir, "initial")
+	addOriginRemote(t, targetDir)
+
+	createdAt := time.Now().UTC()
+	seedCommittedCheckpoint(t, targetDir, seededCheckpoint{
+		id:           testCheckpointID,
+		branch:       "main",
+		createdAt:    createdAt,
+		filesTouched: []string{"a.txt"},
+		outcome:      testLocalFallbackText,
+	})
+	// Reachable only via the custom ref, and the target repo opts into the mirror.
+	moveCheckpointsToCustomRefOnly(t, targetDir)
+	writeV1CustomRefMirrorSettings(t, targetDir)
+
+	oldNow := nowUTC
+	nowUTC = func() time.Time { return createdAt.Add(2 * time.Hour) }
+	t.Cleanup(func() {
+		nowUTC = oldNow
+	})
+
+	t.Chdir(cwdDir)
+
+	got, err := Run(context.Background(), Options{
+		Mode:      ModeLocal,
+		RepoPaths: []string{targetDir},
+		Since:     "7d",
+		Branches:  []string{"main"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Repos) != 1 || got.Repos[0].Sections[0].Bullets[0].Text != testLocalFallbackText {
+		t.Fatalf("expected target repo's v1.1 custom-ref checkpoint, got %+v", got.Repos)
 	}
 }
 
@@ -932,6 +996,26 @@ func enableV1CustomRefMirror(t *testing.T) {
 	s := &settings.EntireSettings{Enabled: true}
 	s.EnableV1CustomRefMirror()
 	if err := settings.Save(context.Background(), s); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeV1CustomRefMirrorSettings opts repoDir into the v1 custom-ref mirror by
+// writing its .entire/settings.json directly (settings.Save resolves relative
+// to cwd, not an arbitrary repo). Uses the EnableV1CustomRefMirror setter so the
+// test does not hardcode the checkpoints_version encoding.
+func writeV1CustomRefMirrorSettings(t *testing.T, repoDir string) {
+	t.Helper()
+	s := &settings.EntireSettings{Enabled: true}
+	s.EnableV1CustomRefMirror()
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, ".entire"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, ".entire", "settings.json"), data, 0o600); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -1081,10 +1081,6 @@ func (s *EntireSettings) GetCheckpointRemote() *CheckpointRemoteConfig {
 	return &CheckpointRemoteConfig{Provider: provider, Repo: repo}
 }
 
-// checkpointsVersionV1CustomRef is the checkpoints_version value that opts into
-// mirroring committed metadata to the v1 custom ref.
-const checkpointsVersionV1CustomRef = "1.1"
-
 // MirrorsToV1CustomRef reports whether checkpoints_version opts into mirroring
 // committed metadata to the v1 custom ref (refs/entire/checkpoints/v1.1). v1
 // remains the source of truth; the v1 custom ref is a local-only mirror.
@@ -1096,21 +1092,11 @@ func (s *EntireSettings) MirrorsToV1CustomRef() bool {
 	return isV1CustomRefValue(s.StrategyOptions["checkpoints_version"])
 }
 
-// EnableV1CustomRefMirror opts the settings into the v1 custom-ref mirror. The
-// inverse of MirrorsToV1CustomRef; lets callers enable the mirror without
-// knowing the underlying checkpoints_version encoding.
-func (s *EntireSettings) EnableV1CustomRefMirror() {
-	if s.StrategyOptions == nil {
-		s.StrategyOptions = map[string]any{}
-	}
-	s.StrategyOptions["checkpoints_version"] = checkpointsVersionV1CustomRef
-}
-
 // isV1CustomRefValue reports whether a checkpoints_version value selects the v1
 // custom ref. Only the JSON string "1.1" opts in; numeric values remain plain v1.
 func isV1CustomRefValue(val any) bool {
 	s, ok := val.(string)
-	return ok && s == checkpointsVersionV1CustomRef
+	return ok && s == "1.1"
 }
 
 // IsFilteredFetchesEnabled checks if fetches should use --filter=blob:none.

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -1081,6 +1081,10 @@ func (s *EntireSettings) GetCheckpointRemote() *CheckpointRemoteConfig {
 	return &CheckpointRemoteConfig{Provider: provider, Repo: repo}
 }
 
+// checkpointsVersionV1CustomRef is the checkpoints_version value that opts into
+// mirroring committed metadata to the v1 custom ref.
+const checkpointsVersionV1CustomRef = "1.1"
+
 // MirrorsToV1CustomRef reports whether checkpoints_version opts into mirroring
 // committed metadata to the v1 custom ref (refs/entire/checkpoints/v1.1). v1
 // remains the source of truth; the v1 custom ref is a local-only mirror.
@@ -1092,11 +1096,21 @@ func (s *EntireSettings) MirrorsToV1CustomRef() bool {
 	return isV1CustomRefValue(s.StrategyOptions["checkpoints_version"])
 }
 
+// EnableV1CustomRefMirror opts the settings into the v1 custom-ref mirror. The
+// inverse of MirrorsToV1CustomRef; lets callers enable the mirror without
+// knowing the underlying checkpoints_version encoding.
+func (s *EntireSettings) EnableV1CustomRefMirror() {
+	if s.StrategyOptions == nil {
+		s.StrategyOptions = map[string]any{}
+	}
+	s.StrategyOptions["checkpoints_version"] = checkpointsVersionV1CustomRef
+}
+
 // isV1CustomRefValue reports whether a checkpoints_version value selects the v1
 // custom ref. Only the JSON string "1.1" opts in; numeric values remain plain v1.
 func isV1CustomRefValue(val any) bool {
 	s, ok := val.(string)
-	return ok && s == "1.1"
+	return ok && s == checkpointsVersionV1CustomRef
 }
 
 // IsFilteredFetchesEnabled checks if fetches should use --filter=blob:none.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/486
<!-- entire-trail-link-end -->

## Summary

Adds checkpoints v1.1 read support to `entire activity` / `dispatch` (local mode), built on the committed-ref topology seam.

Routes local-mode checkpoint enumeration through `checkpoint.ResolveCommittedRefs`, so it resolves the local-only v1 custom ref when the mirror is opted in, else the v1 branch.

## What changed

- **`enumerateRepoCandidates`** (`dispatch/mode_local.go`) now calls `SyncCommittedReadRef` (advances the local read mirror so a prior `git pull` is reflected) and binds its store via `NewCommittedReadStore` instead of `NewGitStore`. It scopes topology resolution to the enumerated repo via `settings.WithWorktreeRoot(ctx, repoRoot)`, so the mirror opt-in is read from that repo rather than the process cwd (matters under `--repo`/`RepoPaths` or when cwd is not a repo).

## Tests

`mode_local_test.go`:
- `TestLocalMode_ReadsV1CustomRefWhenEnabled` — seeds a checkpoint reachable **only** via the custom ref; asserts it is invisible with the mirror disabled and surfaced when enabled. The existing suite already covers the v1 path, so this adds only the toggle.
- `TestLocalMode_ExplicitRepoResolvesMirrorOptInFromTargetRepo` — with `--repo` pointing at a repo whose checkpoint lives only on the custom ref, asserts the mirror opt-in is resolved from the target repo (mirror on) rather than cwd (mirror off).

## Validation

- `mise run fmt && mise run lint` — clean
- `go test ./cmd/entire/cli/dispatch/ ./cmd/entire/cli/settings/` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path change for local dispatch only, gated by existing checkpoints_version mirror opt-in; behavior unchanged for default v1 branch reads.
> 
> **Overview**
> **Local activity/dispatch** now lists committed checkpoints through the committed-read topology: it syncs the read mirror before listing, then uses `NewCommittedReadStore` instead of always reading the v1 metadata branch.
> 
> **Settings** gain `EnableV1CustomRefMirror()` (symmetric to `MirrorsToV1CustomRef`) and a shared `checkpoints_version` `"1.1"` constant so tests and callers can opt into the local custom ref without hardcoding strategy options.
> 
> **Tests** add `TestLocalMode_ReadsV1CustomRefWhenEnabled`, which moves metadata to the custom ref only and checks dispatch finds nothing until the mirror is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89fcdb7a2fa7b354c2dbd333bc21861b24eeb484. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
