### PR TITLE
Capture generic slash-command skill invocations

### DIFF
--- a/cmd/entire/cli/agent/skill_events.go
+++ b/cmd/entire/cli/agent/skill_events.go
@@ -9,6 +9,7 @@ const (
 // Skill event source signals.
 const (
 	SkillSignalPiInputSlashCommand = "input_slash_command"
+	SkillSignalPromptSlashCommand  = "prompt_slash_command"
 	SkillSignalClaudeSkillToolUse  = "skill_tool_use"
 )
 

--- a/cmd/entire/cli/agent/skill_events_prompt.go
+++ b/cmd/entire/cli/agent/skill_events_prompt.go
@@ -1,0 +1,140 @@
+package agent
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// skillSlashCommandPattern matches a leading "/<command>" token up to the first
+// whitespace, so command arguments are never captured.
+var skillSlashCommandPattern = regexp.MustCompile(`^/([A-Za-z0-9][A-Za-z0-9._:/-]*)`)
+
+// filesystemRoots reject pasted absolute paths ("/Users/x", "/tmp/y") that would
+// otherwise look like commands. Only matched when the root is followed by another
+// path segment, so a bare "/dev" stays a command (see isFilesystemPath).
+var filesystemRoots = map[string]struct{}{
+	"users": {}, "home": {}, "tmp": {}, "usr": {}, "var": {}, "etc": {},
+	"opt": {}, "mnt": {}, "private": {}, "volumes": {}, "library": {},
+	"applications": {}, "system": {}, "bin": {}, "sbin": {}, "dev": {},
+	"proc": {}, "sys": {}, "root": {}, "srv": {}, "run": {}, "boot": {},
+	"lib": {}, "media": {}, "network": {}, "cores": {},
+}
+
+// SkillEventFromPromptSlashCommand returns a skill event for a prompt beginning
+// with a "/<command>" slash command. A recorded prompt only contains a slash
+// command that was submitted as a turn, so runtime/UI-only commands (/mcp,
+// /model, ...) are naturally absent; pasted filesystem paths are rejected.
+//
+// Only the command token is stored, never the prompt body. Tool-call skills
+// (e.g. Claude Code's Skill tool) are captured separately by SkillEventExtractors
+// as "tool_invocation" events.
+func SkillEventFromPromptSlashCommand(agentName, prompt string, timestamp time.Time) (SkillEvent, bool) {
+	trimmed := strings.TrimLeft(prompt, " \t\r\n")
+	match := skillSlashCommandPattern.FindStringSubmatch(trimmed)
+	if match == nil {
+		return SkillEvent{}, false
+	}
+
+	token := strings.Trim(match[1], "/")
+	if token == "" || isFilesystemPath(match[1]) {
+		return SkillEvent{}, false
+	}
+
+	// Normalize Pi's "/skill:<name>" form to the bare skill name so the generic
+	// event dedupes against Pi's native input_slash_command event, which records
+	// the name without the "skill:" namespace.
+	name := token
+	if rest, ok := strings.CutPrefix(token, "skill:"); ok {
+		if rest == "" {
+			return SkillEvent{}, false
+		}
+		name = rest
+	}
+
+	command := "/" + token
+	event := SkillEvent{
+		ID:        promptSkillEventID(agentName, name, timestamp),
+		EventType: SkillEventTypePromptInvocation,
+		Skill: SkillEventSkill{
+			Name: name,
+		},
+		Source: SkillEventSource{
+			Agent:      agentName,
+			Signal:     SkillSignalPromptSlashCommand,
+			Confidence: SkillConfidenceExplicit,
+		},
+		Native: map[string]string{
+			"command": command,
+		},
+		Collapse: SkillEventCollapse{
+			Target:           SkillCollapseTargetUserMessage,
+			Label:            command,
+			DefaultCollapsed: true,
+		},
+	}
+	if !timestamp.IsZero() {
+		event.Timestamp = timestamp.UTC().Format(time.RFC3339Nano)
+	}
+	return event, true
+}
+
+// isFilesystemPath reports whether raw (the captured command token, e.g.
+// "Users/alice/x", "dev", "parent/child") is a pasted absolute filesystem path
+// rather than a slash command. It matches only when a well-known root segment is
+// FOLLOWED by a further path segment, so bare single-token commands that happen
+// to collide with a root name (e.g. "/dev", "/run", "/lib") are still treated as
+// commands — only "/dev/null", "/Users/alice/...", etc. are rejected.
+func isFilesystemPath(raw string) bool {
+	first, rest, found := strings.Cut(raw, "/")
+	if !found || rest == "" {
+		return false
+	}
+	_, ok := filesystemRoots[strings.ToLower(first)]
+	return ok
+}
+
+// AppendPromptSlashCommandSkillEvent adds a generic prompt-invocation skill
+// event for a "/<command>" prompt. If an agent adapter already surfaced an
+// equivalent prompt skill event (for example Pi's pre-expansion input event),
+// the adapter event wins and no generic duplicate is appended.
+func AppendPromptSlashCommandSkillEvent(events []SkillEvent, agentName, prompt string, timestamp time.Time) []SkillEvent {
+	event, ok := SkillEventFromPromptSlashCommand(agentName, prompt, timestamp)
+	if !ok {
+		return events
+	}
+	if hasEquivalentPromptSkillEvent(events, event) {
+		return events
+	}
+	return append(events, event)
+}
+
+func promptSkillEventID(agentName, skillName string, timestamp time.Time) string {
+	if timestamp.IsZero() {
+		return ""
+	}
+	return fmt.Sprintf("prompt-skill-%s-%s-%s", agentName, skillName, timestamp.UTC().Format(time.RFC3339Nano))
+}
+
+func hasEquivalentPromptSkillEvent(events []SkillEvent, candidate SkillEvent) bool {
+	candidateCommand := ""
+	if candidate.Native != nil {
+		candidateCommand = candidate.Native["command"]
+	}
+	for _, existing := range events {
+		if existing.EventType != SkillEventTypePromptInvocation || existing.Skill.Name != candidate.Skill.Name {
+			continue
+		}
+		if existing.ID != "" && candidate.ID != "" && existing.ID == candidate.ID {
+			return true
+		}
+		if candidateCommand != "" && existing.Native != nil && existing.Native["command"] == candidateCommand {
+			return true
+		}
+		if existing.Source.Signal == SkillSignalPiInputSlashCommand || existing.Source.Signal == SkillSignalPromptSlashCommand {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/entire/cli/agent/skill_events_prompt_test.go
+++ b/cmd/entire/cli/agent/skill_events_prompt_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSkillEventFromPromptSlashCommand(t *testing.T) {
+	t.Parallel()
+
+	timestamp := time.Date(2026, 5, 25, 12, 34, 56, 0, time.UTC)
+	event, ok := SkillEventFromPromptSlashCommand("codex", "  /goal Complete ENG-623: ship it", timestamp)
+	if !ok {
+		t.Fatal("SkillEventFromPromptSlashCommand() ok = false, want true")
+	}
+	if event.EventType != SkillEventTypePromptInvocation {
+		t.Fatalf("EventType = %q, want %q", event.EventType, SkillEventTypePromptInvocation)
+	}
+	if event.Skill.Name != "goal" {
+		t.Fatalf("Skill.Name = %q, want goal", event.Skill.Name)
+	}
+	if event.Source.Agent != "codex" || event.Source.Signal != SkillSignalPromptSlashCommand || event.Source.Confidence != SkillConfidenceExplicit {
+		t.Fatalf("Source = %+v", event.Source)
+	}
+	if event.Timestamp != "2026-05-25T12:34:56Z" {
+		t.Fatalf("Timestamp = %q", event.Timestamp)
+	}
+	if event.Native["command"] != "/goal" {
+		t.Fatalf("Native command = %q", event.Native["command"])
+	}
+	if event.Collapse.Target != SkillCollapseTargetUserMessage || !event.Collapse.DefaultCollapsed {
+		t.Fatalf("Collapse = %+v", event.Collapse)
+	}
+	if event.Collapse.Label != "/goal" {
+		t.Fatalf("Collapse label = %q", event.Collapse.Label)
+	}
+}
+
+func TestSkillEventFromPromptSlashCommand_Variants(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		prompt   string
+		wantName string // "" means: expect no match
+	}{
+		{"/review", "review"}, // built-in prompt command — still a skill/prompt
+		{"/build-feature implement the thing", "build-feature"},     // custom command with args
+		{"/superpowers:brainstorming", "superpowers:brainstorming"}, // plugin-namespaced
+		{"/git:commit", "git:commit"},                               // gemini colon namespace
+		{"/parent/child do x", "parent/child"},                      // opencode path namespace
+		{"/start-ticket https://x/y", "start-ticket"},               // url arg ignored
+		{"\t/skill:trigger-analysis inspect", "trigger-analysis"},   // pi form → bare name
+		{"/dev", "dev"},                       // bare command colliding with a root name — still a command
+		{"/dev implement the feature", "dev"}, // ditto, with args
+		{"/Users/alice/notes.md", ""},         // pasted absolute path
+		{"/dev/null 2>&1", ""},                // root followed by a path segment
+		{"/tmp/output.log read this", ""},     // pasted path with args
+		{"please run /review", ""},            // not leading
+		{"/ spaced", ""},                      // no command token
+		{"/", ""},                             // bare slash
+		{"/skill:", ""},                       // empty skill name
+		{"do the thing", ""},                  // no slash
+	}
+	for _, tc := range cases {
+		event, ok := SkillEventFromPromptSlashCommand("codex", tc.prompt, time.Time{})
+		if tc.wantName == "" {
+			if ok {
+				t.Errorf("SkillEventFromPromptSlashCommand(%q) = %+v, true; want false", tc.prompt, event)
+			}
+			continue
+		}
+		if !ok {
+			t.Errorf("SkillEventFromPromptSlashCommand(%q) ok = false, want true", tc.prompt)
+			continue
+		}
+		if event.Skill.Name != tc.wantName {
+			t.Errorf("SkillEventFromPromptSlashCommand(%q) name = %q, want %q", tc.prompt, event.Skill.Name, tc.wantName)
+		}
+	}
+}
+
+func TestAppendPromptSlashCommandSkillEvent_KeepsNativeAdapterEvent(t *testing.T) {
+	t.Parallel()
+
+	existing := []SkillEvent{
+		{
+			ID:        "pi-skill-trigger-analysis-1",
+			EventType: SkillEventTypePromptInvocation,
+			Skill:     SkillEventSkill{Name: "trigger-analysis"},
+			Source: SkillEventSource{
+				Agent:      "pi",
+				Signal:     SkillSignalPiInputSlashCommand,
+				Confidence: SkillConfidenceExplicit,
+			},
+			Native: map[string]string{"command": "/skill:trigger-analysis"},
+		},
+	}
+
+	got := AppendPromptSlashCommandSkillEvent(existing, "pi", "/skill:trigger-analysis inspect", time.Now())
+	if len(got) != 1 {
+		t.Fatalf("AppendPromptSlashCommandSkillEvent len = %d, want 1", len(got))
+	}
+	if got[0].ID != existing[0].ID {
+		t.Fatalf("AppendPromptSlashCommandSkillEvent replaced native event: %+v", got[0])
+	}
+}

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -430,7 +430,20 @@ func handleLifecycleTurnStart(ctx context.Context, ag agent.Agent, event *agent.
 		before.ReviewSkills = slices.Clone(state.ReviewSkills)
 		adoptReviewEnv(logCtx, state, string(ag.Name()))
 		adoptInvestigateEnv(logCtx, state, string(ag.Name()))
-		skillEventsChanged := appendEventSkillEventsToState(event, state)
+
+		skillEventSource := *event
+		// Record a skill event for a leading "/<command>" in the raw prompt. Only
+		// once ownership is known — TurnStart bypasses the owner filter so
+		// InitializeSession can repair it — and never overriding native adapter events.
+		if state.AgentType == "" || state.AgentType == ag.Type() {
+			skillEventSource.SkillEvents = agent.AppendPromptSlashCommandSkillEvent(
+				skillEventSource.SkillEvents,
+				string(ag.Name()),
+				event.Prompt,
+				event.Timestamp,
+			)
+		}
+		skillEventsChanged := appendEventSkillEventsToState(&skillEventSource, state)
 		if state.Kind == before.Kind &&
 			state.ReviewPrompt == before.ReviewPrompt &&
 			slices.Equal(state.ReviewSkills, before.ReviewSkills) &&

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -1099,6 +1099,85 @@ func TestHandleLifecycleTurnStart_WritesPromptContent(t *testing.T) {
 	}
 }
 
+func TestHandleLifecycleTurnStart_RecordsGenericSkillSlashEvent(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "init.txt", "init")
+	testutil.GitAdd(t, tmpDir, "init.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+	paths.ClearWorktreeRootCache()
+
+	ag := newMockAgent()
+	sessionID := "test-generic-skill-slash"
+	event := &agent.Event{
+		Type:      agent.TurnStart,
+		SessionID: sessionID,
+		Prompt:    "/skill:trigger-analysis inspect the implementation",
+		Timestamp: time.Date(2026, 5, 25, 12, 34, 56, 0, time.UTC),
+	}
+
+	require.NoError(t, handleLifecycleTurnStart(context.Background(), ag, event))
+
+	state, err := strategy.LoadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Len(t, state.SkillEvents, 1)
+
+	skillEvent := state.SkillEvents[0]
+	require.Equal(t, agent.SkillEventTypePromptInvocation, skillEvent.EventType)
+	require.Equal(t, "trigger-analysis", skillEvent.Skill.Name)
+	require.Equal(t, string(ag.Name()), skillEvent.Source.Agent)
+	require.Equal(t, agent.SkillSignalPromptSlashCommand, skillEvent.Source.Signal)
+	require.Equal(t, agent.SkillConfidenceExplicit, skillEvent.Source.Confidence)
+	require.Equal(t, state.TurnID, skillEvent.TurnID)
+	require.Equal(t, "2026-05-25T12:34:56Z", skillEvent.Timestamp)
+	require.Equal(t, "/skill:trigger-analysis", skillEvent.Native["command"])
+	require.Equal(t, agent.SkillCollapseTargetUserMessage, skillEvent.Collapse.Target)
+	require.True(t, skillEvent.Collapse.DefaultCollapsed)
+}
+
+func TestHandleLifecycleTurnStart_DoesNotDuplicateGenericSkillSlashEventFromForwardedHook(t *testing.T) {
+	// Cannot use t.Parallel() because we use t.Chdir()
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "init.txt", "init")
+	testutil.GitAdd(t, tmpDir, "init.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	t.Chdir(tmpDir)
+	paths.ClearWorktreeRootCache()
+
+	sessionID := "test-generic-skill-forwarded"
+	ownerAgent := newMockAgent()
+	forwardedAgent := &mockLifecycleAgent{
+		name:           "forwarded-agent",
+		agentType:      "Forwarded Agent",
+		transcriptData: []byte(`{"type":"user","message":"test"}`),
+	}
+	prompt := "/skill:trigger-analysis inspect the implementation"
+
+	require.NoError(t, handleLifecycleTurnStart(context.Background(), ownerAgent, &agent.Event{
+		Type:      agent.TurnStart,
+		SessionID: sessionID,
+		Prompt:    prompt,
+		Timestamp: time.Date(2026, 5, 25, 12, 34, 56, 0, time.UTC),
+	}))
+	require.NoError(t, handleLifecycleTurnStart(context.Background(), forwardedAgent, &agent.Event{
+		Type:      agent.TurnStart,
+		SessionID: sessionID,
+		Prompt:    prompt,
+		Timestamp: time.Date(2026, 5, 25, 12, 34, 57, 0, time.UTC),
+	}))
+
+	state, err := strategy.LoadSessionState(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	require.Equal(t, ownerAgent.Type(), state.AgentType)
+	require.Len(t, state.SkillEvents, 1)
+	require.Equal(t, string(ownerAgent.Name()), state.SkillEvents[0].Source.Agent)
+}
+
 func TestHandleLifecycleTurnEnd_BackfillsPromptFromTranscript(t *testing.T) {
 	// Cannot use t.Parallel() because we use t.Chdir()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Problem

Prompt-based skill/prompt invocations were only captured for one fixed slash-command shape. Agents that invoke skills via ordinary slash commands (Codex, Cursor, OpenCode, Gemini, Factory) recorded **no** skill events, even though a leading `/<command>` is exactly such an invocation.

## Solution

Record a `prompt_invocation` skill event for **any** leading `/<command>` in a submitted prompt.

This is safe because a slash command only reaches a recorded prompt if it submitted a model turn:
- **Runtime/UI-only commands** (`/mcp`, `/model`, `/help`, `/clear`, …) are handled in the agent REPL, never submit a turn, and never fire the turn-start hook — so they're excluded for free, no denylist needed.
- **Pasted filesystem paths** (`/Users/...`, `/tmp/...`) are the only non-command class and are rejected via a filesystem-root denylist. A bare root-name command (`/dev`) stays a command; only a root followed by a path segment (`/dev/null`) is rejected.

Details:
- Only the command **token** is stored — never prompt arguments (privacy).
- Pi's `/skill:<name>` is normalized to the bare name so it dedupes against Pi's native event.
- Built-in vs custom is just a label; both are injected prompts and recorded.
- Wiring is unchanged — `handleLifecycleTurnStart` already appends for every agent that exposes `event.Prompt`.

**Behavior note:** Claude Code sessions now also get `prompt_invocation` events for slash commands, alongside `tool_invocation` events from its native Skill tool (different event types, not deduped).

## Testing
- `go test ./cmd/entire/cli/agent ./cmd/entire/cli`; `mise run fmt` + `golangci-lint` clean.
- Table tests cover built-ins, custom commands, `:`/path namespacing, arg-stripping, the Pi form, bare root-name commands, and path/non-command rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)