### PR TITLE
Add Entire Replay Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin
 | `entire disable` | Remove Entire hooks from repository                                                               |
 | `entire doctor`  | Fix or clean up stuck sessions                                                                    |
 | `entire enable`  | Enable Entire in your repository                                                                  |
+| `entire replay`  | Replay checkpoint tasks in isolated worktrees                                                     |
+| `entire eval`    | Run private agent evals from Entire checkpoints                                                   |
 | `entire checkpoint`        | List, explain, rewind, and search checkpoints                                           |
 | `entire checkpoint explain` | Explain a session, commit, or checkpoint                                               |
 | `entire checkpoint rewind` | Rewind to a previous checkpoint                                                         |
@@ -252,6 +254,14 @@ go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin
 | `entire status`  | Show current session info                                                                         |
 | `entire doctor trace` | Show hook performance traces                                                                 |
 | `entire version` | Show Entire CLI version                                                                           |
+
+`entire replay checkpoint <id>` turns a real checkpoint into a private
+agent-eval task. Entire checks out the checkpoint's parent commit in an
+isolated temp worktree, runs the original prompt with the selected launchable
+agent, then compares the result to the original commit by changed files,
+optional tests, risk signals, and optional `entire-sem` semantic similarity.
+Use `entire eval run --from-checkpoints --agent claude-code,codex` to compare
+agents across recent checkpoint tasks.
 
 ### `entire enable` Flags
 

--- a/cmd/entire/cli/replay.go
+++ b/cmd/entire/cli/replay.go
@@ -1,0 +1,1157 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	checkpointid "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/stringutil"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+	"github.com/spf13/cobra"
+)
+
+type replayCheckpointOptions struct {
+	Agent        string
+	Model        string
+	TestCommand  string
+	KeepWorktree bool
+	JSON         bool
+}
+
+type replayEvalOptions struct {
+	Checkpoints     []string
+	FromCheckpoints bool
+	Limit           int
+	Agents          []string
+	Model           string
+	TestCommand     string
+	KeepWorktrees   bool
+	JSON            bool
+}
+
+type replayReportOptions struct {
+	JSON bool
+}
+
+type ReplaySpec struct {
+	CheckpointID  string            `json:"checkpoint_id"`
+	SessionID     string            `json:"session_id,omitempty"`
+	Prompt        string            `json:"prompt"`
+	TargetCommit  string            `json:"target_commit"`
+	BaseCommit    string            `json:"base_commit"`
+	FilesTouched  []string          `json:"files_touched"`
+	OriginalAgent string            `json:"original_agent,omitempty"`
+	OriginalModel string            `json:"original_model,omitempty"`
+	TokenUsage    *agent.TokenUsage `json:"token_usage,omitempty"`
+}
+
+type ReplayRun struct {
+	ID           string        `json:"id"`
+	Spec         ReplaySpec    `json:"spec"`
+	Agent        string        `json:"agent"`
+	Model        string        `json:"model,omitempty"`
+	Status       string        `json:"status"`
+	StartedAt    time.Time     `json:"started_at"`
+	FinishedAt   time.Time     `json:"finished_at"`
+	DurationMS   int64         `json:"duration_ms"`
+	WorktreePath string        `json:"worktree_path,omitempty"`
+	ChangedFiles []string      `json:"changed_files"`
+	Diff         string        `json:"diff,omitempty"`
+	Test         ReplayTestRun `json:"test"`
+	Metrics      ReplayMetrics `json:"metrics"`
+	Warnings     []string      `json:"warnings,omitempty"`
+	Error        string        `json:"error,omitempty"`
+	Output       string        `json:"output,omitempty"`
+	ResultPath   string        `json:"result_path,omitempty"`
+}
+
+type ReplayTestRun struct {
+	Status     string `json:"status"`
+	Command    string `json:"command,omitempty"`
+	ExitCode   int    `json:"exit_code,omitempty"`
+	Output     string `json:"output,omitempty"`
+	DurationMS int64  `json:"duration_ms,omitempty"`
+}
+
+type ReplayMetrics struct {
+	FilePrecision      int      `json:"file_precision"`
+	FileRecall         int      `json:"file_recall"`
+	FileOverlap        int      `json:"file_overlap"`
+	MissingFiles       []string `json:"missing_files,omitempty"`
+	ExtraFiles         []string `json:"extra_files,omitempty"`
+	RiskyFiles         []string `json:"risky_files,omitempty"`
+	RiskScore          int      `json:"risk_score"`
+	SemanticAvailable  bool     `json:"semantic_available"`
+	SemanticSimilarity int      `json:"semantic_similarity,omitempty"`
+}
+
+type ReplayEvalRun struct {
+	ID         string      `json:"id"`
+	StartedAt  time.Time   `json:"started_at"`
+	FinishedAt time.Time   `json:"finished_at"`
+	Agents     []string    `json:"agents"`
+	Runs       []ReplayRun `json:"runs"`
+	ResultPath string      `json:"result_path,omitempty"`
+}
+
+type ReplayRunnerRequest struct {
+	Spec         ReplaySpec
+	Agent        string
+	Model        string
+	Prompt       string
+	WorktreePath string
+}
+
+type ReplayRunnerResult struct {
+	Output   string
+	Warnings []string
+}
+
+type ReplayRunner interface {
+	Name() string
+	Run(ctx context.Context, req ReplayRunnerRequest) (ReplayRunnerResult, error)
+}
+
+type replayRunnerFunc struct {
+	name string
+	fn   func(context.Context, ReplayRunnerRequest) (ReplayRunnerResult, error)
+}
+
+func (f replayRunnerFunc) Name() string { return f.name }
+
+func (f replayRunnerFunc) Run(ctx context.Context, req ReplayRunnerRequest) (ReplayRunnerResult, error) {
+	return f.fn(ctx, req)
+}
+
+var replayRunnerFor = defaultReplayRunnerFor
+
+const (
+	replayAgentGeminiCLI    = "gemini-cli"
+	replayResultOutputLimit = 64 * 1024
+	replayStatusFailed      = "failed"
+	replayStatusPassed      = "passed"
+	replayStatusRunning     = "running"
+	replayStatusSkipped     = "skipped"
+	replayTestStatusSkipped = replayStatusSkipped
+)
+
+func newReplayCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "replay",
+		Short: "Replay checkpoint tasks in isolated worktrees",
+		Long:  "Replay historical Entire checkpoints against coding agents and compare their output to the original commit.",
+	}
+	cmd.AddCommand(newReplayCheckpointCmd())
+	return cmd
+}
+
+func newReplayCheckpointCmd() *cobra.Command {
+	opts := replayCheckpointOptions{Agent: string(agent.AgentNameClaudeCode)}
+	cmd := &cobra.Command{
+		Use:   "checkpoint <checkpoint-id>",
+		Short: "Replay one checkpoint with one agent",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			run, err := runReplayCheckpoint(cmd.Context(), args[0], opts)
+			if err != nil {
+				return err
+			}
+			if opts.JSON {
+				return writeReplayJSON(cmd.OutOrStdout(), run)
+			}
+			renderReplayRun(cmd.OutOrStdout(), run)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.Agent, "agent", opts.Agent, "Agent to replay with: claude-code, codex, or gemini")
+	cmd.Flags().StringVar(&opts.Model, "model", "", "Model override passed to the agent when supported")
+	cmd.Flags().StringVar(&opts.TestCommand, "test-cmd", "", "Optional test command to run after replay")
+	cmd.Flags().BoolVar(&opts.KeepWorktree, "keep-worktree", false, "Keep the replay worktree for inspection")
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output replay result as JSON")
+	return cmd
+}
+
+func newEvalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "eval",
+		Short: "Run private agent evals from Entire checkpoints",
+		Long:  "Run checkpoint replay tasks across one or more agents and rank the results.",
+	}
+	cmd.AddCommand(newEvalRunCmd())
+	cmd.AddCommand(newEvalReportCmd())
+	return cmd
+}
+
+func newEvalRunCmd() *cobra.Command {
+	opts := replayEvalOptions{Limit: 10, Agents: []string{string(agent.AgentNameClaudeCode)}}
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run a replay eval",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			run, err := runReplayEval(cmd.Context(), opts)
+			if err != nil {
+				return err
+			}
+			if opts.JSON {
+				return writeReplayJSON(cmd.OutOrStdout(), run)
+			}
+			renderReplayEval(cmd.OutOrStdout(), run)
+			return nil
+		},
+	}
+	cmd.Flags().StringArrayVar(&opts.Checkpoints, "checkpoint", nil, "Checkpoint ID to include (repeatable)")
+	cmd.Flags().BoolVar(&opts.FromCheckpoints, "from-checkpoints", false, "Use recent committed checkpoints")
+	cmd.Flags().IntVar(&opts.Limit, "limit", opts.Limit, "Maximum checkpoints when using --from-checkpoints")
+	cmd.Flags().StringSliceVar(&opts.Agents, "agent", opts.Agents, "Agents to run, comma-separated or repeated")
+	cmd.Flags().StringVar(&opts.Model, "model", "", "Model override passed to each agent when supported")
+	cmd.Flags().StringVar(&opts.TestCommand, "test-cmd", "", "Optional test command to run after each replay")
+	cmd.Flags().BoolVar(&opts.KeepWorktrees, "keep-worktree", false, "Keep replay worktrees for inspection")
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output eval result as JSON")
+	return cmd
+}
+
+func newEvalReportCmd() *cobra.Command {
+	var opts replayReportOptions
+	cmd := &cobra.Command{
+		Use:   "report <run-id>",
+		Short: "Show a saved replay eval report",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			run, err := readReplayEval(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			if opts.JSON {
+				return writeReplayJSON(cmd.OutOrStdout(), run)
+			}
+			renderReplayEval(cmd.OutOrStdout(), run)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output eval report as JSON")
+	return cmd
+}
+
+func runReplayCheckpoint(ctx context.Context, checkpointRef string, opts replayCheckpointOptions) (*ReplayRun, error) {
+	spec, err := buildReplaySpec(ctx, checkpointRef)
+	if err != nil {
+		return nil, err
+	}
+	return executeReplay(ctx, spec, opts)
+}
+
+func runReplayEval(ctx context.Context, opts replayEvalOptions) (*ReplayEvalRun, error) {
+	checkpoints := append([]string(nil), opts.Checkpoints...)
+	if opts.FromCheckpoints {
+		recent, err := recentReplayCheckpoints(ctx, opts.Limit)
+		if err != nil {
+			return nil, err
+		}
+		checkpoints = append(checkpoints, recent...)
+	}
+	checkpoints = uniqueNonEmpty(checkpoints)
+	if len(checkpoints) == 0 {
+		return nil, errors.New("no checkpoints selected; pass --checkpoint or --from-checkpoints")
+	}
+	agents := uniqueNonEmpty(opts.Agents)
+	if len(agents) == 0 {
+		return nil, errors.New("no agents selected")
+	}
+
+	eval := &ReplayEvalRun{
+		ID:        newReplayID(),
+		StartedAt: time.Now().UTC(),
+		Agents:    agents,
+	}
+	for _, cp := range checkpoints {
+		spec, err := buildReplaySpec(ctx, cp)
+		if err != nil {
+			eval.Runs = append(eval.Runs, ReplayRun{
+				ID:     newReplayID(),
+				Status: replayStatusFailed,
+				Error:  err.Error(),
+				Spec:   ReplaySpec{CheckpointID: cp},
+			})
+			continue
+		}
+		for _, agentName := range agents {
+			run, err := executeReplay(ctx, spec, replayCheckpointOptions{
+				Agent:        agentName,
+				Model:        opts.Model,
+				TestCommand:  opts.TestCommand,
+				KeepWorktree: opts.KeepWorktrees,
+				JSON:         opts.JSON,
+			})
+			if err != nil {
+				run = &ReplayRun{
+					ID:     newReplayID(),
+					Spec:   spec,
+					Agent:  agentName,
+					Model:  opts.Model,
+					Status: replayStatusFailed,
+					Error:  err.Error(),
+				}
+			}
+			eval.Runs = append(eval.Runs, *run)
+		}
+	}
+	sortReplayRuns(eval.Runs)
+	eval.FinishedAt = time.Now().UTC()
+	path, err := saveReplayEval(ctx, eval)
+	if err != nil {
+		return nil, err
+	}
+	eval.ResultPath = path
+	return eval, nil
+}
+
+func buildReplaySpec(ctx context.Context, checkpointRef string) (ReplaySpec, error) {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return ReplaySpec{}, errors.New("not a git repository")
+	}
+	fullID, targetCommit, err := resolveReplayCheckpointCommit(ctx, repoRoot, checkpointRef)
+	if err != nil {
+		return ReplaySpec{}, err
+	}
+	baseCommit, err := replayCommitParent(ctx, repoRoot, targetCommit)
+	if err != nil {
+		return ReplaySpec{}, err
+	}
+
+	repo, err := openRepository(ctx)
+	if err != nil {
+		return ReplaySpec{}, fmt.Errorf("open repository: %w", err)
+	}
+	defer repo.Close()
+	store := checkpoint.NewGitStore(repo)
+	store.SetBlobFetcher(FetchBlobsByHash)
+
+	cpID, err := checkpointid.NewCheckpointID(fullID)
+	if err != nil {
+		return ReplaySpec{}, fmt.Errorf("parse checkpoint id %s: %w", fullID, err)
+	}
+	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, store, cpID)
+	if err != nil {
+		return ReplaySpec{}, fmt.Errorf("read checkpoint %s: %w", fullID, err)
+	}
+	content, err := checkpoint.ReadLatestSessionContent(ctx, store, cpID, summary)
+	if err != nil {
+		return ReplaySpec{}, fmt.Errorf("read checkpoint prompt %s: %w", fullID, err)
+	}
+	prompt := strings.TrimSpace(content.Prompts)
+	if prompt == "" && content.Metadata.ReviewPrompt != "" {
+		prompt = strings.TrimSpace(content.Metadata.ReviewPrompt)
+	}
+	if prompt == "" && content.Metadata.Summary != nil {
+		prompt = strings.TrimSpace(content.Metadata.Summary.Intent)
+	}
+	if prompt == "" {
+		return ReplaySpec{}, fmt.Errorf("checkpoint %s has no replayable prompt", fullID)
+	}
+
+	files := normalizeReplayPaths(summary.FilesTouched)
+	if len(files) == 0 {
+		files = normalizeReplayPaths(content.Metadata.FilesTouched)
+	}
+	return ReplaySpec{
+		CheckpointID:  fullID,
+		SessionID:     content.Metadata.SessionID,
+		Prompt:        prompt,
+		TargetCommit:  targetCommit,
+		BaseCommit:    baseCommit,
+		FilesTouched:  files,
+		OriginalAgent: string(content.Metadata.Agent),
+		OriginalModel: content.Metadata.Model,
+		TokenUsage:    content.Metadata.TokenUsage,
+	}, nil
+}
+
+func executeReplay(ctx context.Context, spec ReplaySpec, opts replayCheckpointOptions) (*ReplayRun, error) {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return nil, errors.New("not a git repository")
+	}
+	runner := replayRunnerFor(opts.Agent)
+	if runner == nil {
+		return nil, fmt.Errorf("agent %q is not launchable for replay yet", opts.Agent)
+	}
+
+	run := &ReplayRun{
+		ID:        newReplayID(),
+		Spec:      spec,
+		Agent:     runner.Name(),
+		Model:     opts.Model,
+		Status:    replayStatusRunning,
+		StartedAt: time.Now().UTC(),
+		Test:      ReplayTestRun{Status: replayTestStatusSkipped},
+	}
+
+	worktree, err := createReplayWorktree(ctx, repoRoot, spec.BaseCommit)
+	if err != nil {
+		return nil, err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			if err := removeReplayWorktree(context.Background(), repoRoot, worktree); err != nil {
+				run.Warnings = append(run.Warnings, fmt.Sprintf("failed to remove replay worktree: %v", err))
+			}
+		}
+	}()
+
+	result, runnerErr := runner.Run(ctx, ReplayRunnerRequest{
+		Spec:         spec,
+		Agent:        runner.Name(),
+		Model:        opts.Model,
+		Prompt:       replayPrompt(spec),
+		WorktreePath: worktree,
+	})
+	run.Output = truncateReplayOutput(result.Output)
+	run.Warnings = append(run.Warnings, result.Warnings...)
+	if runnerErr != nil {
+		run.Status = replayStatusFailed
+		run.Error = runnerErr.Error()
+	} else {
+		run.Status = replayStatusPassed
+	}
+
+	if opts.TestCommand != "" {
+		run.Test = runReplayTestCommand(ctx, worktree, opts.TestCommand)
+		if run.Test.Status == replayStatusFailed && run.Status == replayStatusPassed {
+			run.Status = replayStatusFailed
+		}
+	}
+	files, diff, diffErr := replayChangedFilesAndDiff(ctx, worktree, spec.BaseCommit)
+	if diffErr != nil {
+		run.Warnings = append(run.Warnings, fmt.Sprintf("failed to read replay diff: %v", diffErr))
+	} else {
+		run.ChangedFiles = files
+		run.Diff = diff
+	}
+	run.Metrics = replayMetrics(ctx, repoRoot, worktree, spec, run.ChangedFiles)
+
+	run.FinishedAt = time.Now().UTC()
+	run.DurationMS = run.FinishedAt.Sub(run.StartedAt).Milliseconds()
+	if opts.KeepWorktree {
+		run.WorktreePath = worktree
+		cleanup = false
+	}
+	path, err := saveReplayRun(ctx, run)
+	if err != nil {
+		return nil, err
+	}
+	run.ResultPath = path
+	return run, nil
+}
+
+func defaultReplayRunnerFor(agentName string) *replayRunnerFunc {
+	switch agentName {
+	case string(agent.AgentNameClaudeCode):
+		return &replayRunnerFunc{name: agentName, fn: runClaudeReplay}
+	case string(agent.AgentNameCodex):
+		return &replayRunnerFunc{name: agentName, fn: runCodexReplay}
+	case string(agent.AgentNameGemini), replayAgentGeminiCLI:
+		return &replayRunnerFunc{name: string(agent.AgentNameGemini), fn: runGeminiReplay}
+	default:
+		return nil
+	}
+}
+
+func runClaudeReplay(ctx context.Context, req ReplayRunnerRequest) (ReplayRunnerResult, error) {
+	args := []string{"-p", req.Prompt, "--output-format", "stream-json", "--verbose", "--permission-mode", "acceptEdits"}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
+	}
+	return runReplayProcess(ctx, req.WorktreePath, "claude", args, nil)
+}
+
+func runCodexReplay(ctx context.Context, req ReplayRunnerRequest) (ReplayRunnerResult, error) {
+	args := []string{"exec", "--skip-git-repo-check", "--json", "--sandbox", "workspace-write"}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
+	}
+	args = append(args, "-")
+	return runReplayProcess(ctx, req.WorktreePath, "codex", args, strings.NewReader(req.Prompt))
+}
+
+func runGeminiReplay(ctx context.Context, req ReplayRunnerRequest) (ReplayRunnerResult, error) {
+	args := []string{"-p", " "}
+	if req.Model != "" {
+		args = append(args, "--model", req.Model)
+	}
+	return runReplayProcess(ctx, req.WorktreePath, "gemini", args, strings.NewReader(req.Prompt))
+}
+
+func runReplayProcess(ctx context.Context, dir, name string, args []string, stdin io.Reader) (ReplayRunnerResult, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Env = replayAgentEnv(os.Environ())
+	cmd.Stdin = stdin
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	output := strings.TrimSpace(stdout.String())
+	if stderr.Len() > 0 {
+		if output != "" {
+			output += "\n"
+		}
+		output += strings.TrimSpace(stderr.String())
+	}
+	if err != nil {
+		return ReplayRunnerResult{Output: output}, fmt.Errorf("%s replay failed: %w", name, err)
+	}
+	return ReplayRunnerResult{Output: output}, nil
+}
+
+func replayAgentEnv(env []string) []string {
+	filtered := agent.StripGitEnv(env)
+	out := filtered[:0]
+	for _, item := range filtered {
+		switch {
+		case item == "GIT_CONFIG_COUNT" || strings.HasPrefix(item, "GIT_CONFIG_COUNT="):
+			continue
+		case strings.HasPrefix(item, "GIT_CONFIG_KEY_"):
+			continue
+		case strings.HasPrefix(item, "GIT_CONFIG_VALUE_"):
+			continue
+		}
+		out = append(out, item)
+	}
+	return append(out,
+		"ENTIRE_REPLAY=1",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=core.hooksPath",
+		"GIT_CONFIG_VALUE_0=/dev/null",
+	)
+}
+
+func replayPrompt(spec ReplaySpec) string {
+	return strings.TrimSpace(fmt.Sprintf(`You are replaying a historical coding task in an isolated git worktree.
+
+Original user prompt:
+%s
+
+Complete the task normally in this worktree. Do not inspect Entire checkpoint metadata, git history, or the original target commit to find the previous answer. Make the necessary code changes and stop when done. Do not commit unless the original prompt explicitly asks for a commit.`, spec.Prompt))
+}
+
+func resolveReplayCheckpointCommit(ctx context.Context, repoRoot, checkpointRef string) (string, string, error) {
+	out, err := replayGit(ctx, repoRoot, "rev-list", "--all")
+	if err != nil {
+		return "", "", fmt.Errorf("list commits: %w", err)
+	}
+	type match struct {
+		cpID string
+		sha  string
+	}
+	var matches []match
+	seen := map[string]struct{}{}
+	for _, sha := range strings.Fields(out) {
+		msg, msgErr := replayGit(ctx, repoRoot, "show", "-s", "--format=%B", sha)
+		if msgErr != nil {
+			continue
+		}
+		for _, cpID := range trailers.ParseAllCheckpoints(msg) {
+			if strings.HasPrefix(cpID.String(), checkpointRef) {
+				key := cpID.String() + ":" + sha
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				matches = append(matches, match{cpID: cpID.String(), sha: sha})
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return "", "", fmt.Errorf("checkpoint %s was not found in commit trailers", checkpointRef)
+	}
+	if len(matches) > 1 {
+		var labels []string
+		for _, m := range matches {
+			labels = append(labels, m.cpID+"@"+shortReplaySHA(m.sha))
+		}
+		sort.Strings(labels)
+		return "", "", fmt.Errorf("checkpoint %s is ambiguous: %s", checkpointRef, strings.Join(labels, ", "))
+	}
+	return matches[0].cpID, matches[0].sha, nil
+}
+
+func replayCommitParent(ctx context.Context, repoRoot, targetCommit string) (string, error) {
+	parent, err := replayGit(ctx, repoRoot, "rev-parse", "--verify", targetCommit+"^")
+	if err != nil {
+		return "", fmt.Errorf("checkpoint target commit %s has no parent; replay needs a committed base", shortReplaySHA(targetCommit))
+	}
+	return parent, nil
+}
+
+func createReplayWorktree(ctx context.Context, repoRoot, baseCommit string) (string, error) {
+	dir, err := os.MkdirTemp("", "entire-replay-*")
+	if err != nil {
+		return "", fmt.Errorf("create replay temp dir: %w", err)
+	}
+	if err := os.Remove(dir); err != nil {
+		return "", fmt.Errorf("prepare replay temp dir: %w", err)
+	}
+	if _, err := replayGit(ctx, repoRoot, "worktree", "add", "--detach", dir, baseCommit); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", fmt.Errorf("create replay worktree: %w", err)
+	}
+	return dir, nil
+}
+
+func removeReplayWorktree(ctx context.Context, repoRoot, worktree string) error {
+	if _, err := replayGit(ctx, repoRoot, "worktree", "remove", "--force", worktree); err != nil {
+		_ = os.RemoveAll(worktree)
+		return err
+	}
+	return nil
+}
+
+func replayChangedFilesAndDiff(ctx context.Context, worktree, baseCommit string) ([]string, string, error) {
+	if _, err := replayGit(ctx, worktree, "add", "-N", "."); err != nil {
+		return nil, "", fmt.Errorf("index replay untracked files: %w", err)
+	}
+	modified, err := replayGit(ctx, worktree, "diff", "--name-only", baseCommit)
+	if err != nil {
+		return nil, "", err
+	}
+	files := normalizeReplayPaths(strings.Fields(modified))
+	diff, err := replayGit(ctx, worktree, "diff", "--binary", baseCommit)
+	if err != nil {
+		return files, "", err
+	}
+	return files, diff, nil
+}
+
+func runReplayTestCommand(ctx context.Context, worktree, command string) ReplayTestRun {
+	start := time.Now()
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command)
+	cmd.Dir = worktree
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	err := cmd.Run()
+	result := ReplayTestRun{
+		Status:     replayStatusPassed,
+		Command:    command,
+		Output:     truncateReplayOutput(output.String()),
+		DurationMS: time.Since(start).Milliseconds(),
+	}
+	if err != nil {
+		result.Status = replayStatusFailed
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			result.ExitCode = exitErr.ExitCode()
+		} else {
+			result.ExitCode = -1
+		}
+	}
+	return result
+}
+
+func replayMetrics(ctx context.Context, repoRoot, worktree string, spec ReplaySpec, changedFiles []string) ReplayMetrics {
+	original := normalizeReplayPaths(spec.FilesTouched)
+	produced := normalizeReplayPaths(changedFiles)
+	overlap, missing, extra := replayFileSets(original, produced)
+	metrics := ReplayMetrics{
+		FileOverlap:   len(overlap),
+		MissingFiles:  missing,
+		ExtraFiles:    extra,
+		RiskyFiles:    riskyReplayFiles(produced),
+		FilePrecision: percent(len(overlap), len(produced)),
+		FileRecall:    percent(len(overlap), len(original)),
+	}
+	metrics.RiskScore = len(metrics.ExtraFiles) + len(metrics.RiskyFiles)
+	if sourceChangedWithoutTests(produced) {
+		metrics.RiskScore++
+	}
+	if score, ok := replaySemanticSimilarity(ctx, repoRoot, worktree, spec); ok {
+		metrics.SemanticAvailable = true
+		metrics.SemanticSimilarity = score
+	}
+	return metrics
+}
+
+func replaySemanticSimilarity(ctx context.Context, repoRoot, worktree string, spec ReplaySpec) (int, bool) {
+	if _, err := exec.LookPath("entire-sem"); err != nil {
+		return 0, false
+	}
+	gold, err := replaySemanticKeys(ctx, repoRoot, spec.BaseCommit, spec.TargetCommit)
+	if err != nil {
+		return 0, false
+	}
+	replayHead, err := commitReplayResultForSemantic(ctx, worktree)
+	if err != nil {
+		return 0, false
+	}
+	replayed, err := replaySemanticKeys(ctx, worktree, spec.BaseCommit, replayHead)
+	if err != nil {
+		return 0, false
+	}
+	return jaccardPercent(gold, replayed), true
+}
+
+func commitReplayResultForSemantic(ctx context.Context, worktree string) (string, error) {
+	if _, err := replayGit(ctx, worktree, "diff", "--quiet"); err == nil {
+		head, headErr := replayGit(ctx, worktree, "rev-parse", "HEAD")
+		return head, headErr
+	}
+	if _, err := replayGit(ctx, worktree, "add", "-A"); err != nil {
+		return "", err
+	}
+	if _, err := replayGit(ctx, worktree,
+		"-c", "user.name=Entire Replay",
+		"-c", "user.email=replay@entire.local",
+		"commit", "--no-gpg-sign", "-m", "entire replay result",
+	); err != nil {
+		return "", err
+	}
+	return replayGit(ctx, worktree, "rev-parse", "HEAD")
+}
+
+func replaySemanticKeys(ctx context.Context, dir, base, head string) (map[string]struct{}, error) {
+	cmd := exec.CommandContext(ctx, "entire-sem", "diff", "--base", base, "--head", head, "--json")
+	cmd.Dir = dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return nil, fmt.Errorf("entire-sem: %s", msg)
+		}
+		return nil, fmt.Errorf("run entire-sem: %w", err)
+	}
+	var raw any
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse entire-sem json: %w", err)
+	}
+	keys := map[string]struct{}{}
+	collectReplaySemanticKeys(raw, keys)
+	return keys, nil
+}
+
+func collectReplaySemanticKeys(value any, keys map[string]struct{}) {
+	switch v := value.(type) {
+	case []any:
+		for _, item := range v {
+			collectReplaySemanticKeys(item, keys)
+		}
+	case map[string]any:
+		name := replayStringField(v, "name", "symbol", "new_name")
+		kind := replayStringField(v, "kind", "entity_kind", "node_kind")
+		change := replayStringField(v, "change_type", "change", "type", "status")
+		if name != "" || change != "" {
+			keys[strings.Join([]string{kind, name, change}, ":")] = struct{}{}
+		}
+		for _, child := range v {
+			collectReplaySemanticKeys(child, keys)
+		}
+	}
+}
+
+func replayStringField(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := m[key].(string); ok {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func saveReplayRun(ctx context.Context, run *ReplayRun) (string, error) {
+	dir, err := replayRunsDir(ctx)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, run.ID+".json")
+	run.ResultPath = path
+	return path, writeReplayFile(path, run)
+}
+
+func saveReplayEval(ctx context.Context, run *ReplayEvalRun) (string, error) {
+	dir, err := replayEvalsDir(ctx)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, run.ID+".json")
+	run.ResultPath = path
+	return path, writeReplayFile(path, run)
+}
+
+func readReplayEval(ctx context.Context, runID string) (*ReplayEvalRun, error) {
+	dir, err := replayEvalsDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+	name := strings.TrimSuffix(filepath.Base(runID), ".json")
+	path := filepath.Join(dir, name+".json")
+	data, err := os.ReadFile(path) //nolint:gosec // runID is filepath.Base'd above
+	if err != nil {
+		return nil, fmt.Errorf("read eval report: %w", err)
+	}
+	var run ReplayEvalRun
+	if err := json.Unmarshal(data, &run); err != nil {
+		return nil, fmt.Errorf("parse eval report: %w", err)
+	}
+	run.ResultPath = path
+	return &run, nil
+}
+
+func replayRunsDir(ctx context.Context) (string, error) {
+	commonDir, err := session.GetGitCommonDir(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve git common dir: %w", err)
+	}
+	return filepath.Join(commonDir, "entire-replay", "runs"), nil
+}
+
+func replayEvalsDir(ctx context.Context) (string, error) {
+	commonDir, err := session.GetGitCommonDir(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolve git common dir: %w", err)
+	}
+	return filepath.Join(commonDir, "entire-replay", "evals"), nil
+}
+
+func writeReplayFile(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create replay result dir: %w", err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal replay result: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write replay result: %w", err)
+	}
+	return nil
+}
+
+func recentReplayCheckpoints(ctx context.Context, limit int) ([]string, error) {
+	repo, err := openRepository(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer repo.Close()
+	infos, err := checkpoint.NewGitStore(repo).ListCommitted(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list committed checkpoints: %w", err)
+	}
+	if limit <= 0 || limit > len(infos) {
+		limit = len(infos)
+	}
+	out := make([]string, 0, limit)
+	for i := range limit {
+		out = append(out, infos[i].CheckpointID.String())
+	}
+	return out, nil
+}
+
+func replayFileSets(original, produced []string) (overlap, missing, extra []string) {
+	origSet := make(map[string]struct{}, len(original))
+	prodSet := make(map[string]struct{}, len(produced))
+	for _, file := range original {
+		origSet[file] = struct{}{}
+	}
+	for _, file := range produced {
+		prodSet[file] = struct{}{}
+		if _, ok := origSet[file]; ok {
+			overlap = append(overlap, file)
+		} else {
+			extra = append(extra, file)
+		}
+	}
+	for _, file := range original {
+		if _, ok := prodSet[file]; !ok {
+			missing = append(missing, file)
+		}
+	}
+	sort.Strings(overlap)
+	sort.Strings(missing)
+	sort.Strings(extra)
+	return overlap, missing, extra
+}
+
+func riskyReplayFiles(files []string) []string {
+	var risky []string
+	for _, file := range files {
+		lower := strings.ToLower(file)
+		if strings.Contains(lower, "auth") ||
+			strings.Contains(lower, "token") ||
+			strings.Contains(lower, "secret") ||
+			strings.Contains(lower, "payment") ||
+			strings.Contains(lower, "billing") ||
+			strings.Contains(lower, "database") ||
+			strings.Contains(lower, "migration") ||
+			strings.Contains(lower, "config") {
+			risky = append(risky, file)
+		}
+	}
+	sort.Strings(risky)
+	return risky
+}
+
+func sourceChangedWithoutTests(files []string) bool {
+	hasSource := false
+	hasTest := false
+	for _, file := range files {
+		lower := strings.ToLower(file)
+		if strings.Contains(lower, "test") || strings.Contains(lower, "spec") {
+			hasTest = true
+			continue
+		}
+		switch {
+		case strings.HasSuffix(lower, ".go"),
+			strings.HasSuffix(lower, ".py"),
+			strings.HasSuffix(lower, ".js"),
+			strings.HasSuffix(lower, ".ts"),
+			strings.HasSuffix(lower, ".tsx"),
+			strings.HasSuffix(lower, ".rs"):
+			hasSource = true
+		}
+	}
+	return hasSource && !hasTest
+}
+
+func sortReplayRuns(runs []ReplayRun) {
+	sort.SliceStable(runs, func(i, j int) bool {
+		a, b := runs[i], runs[j]
+		if a.Status != b.Status {
+			return a.Status == replayStatusPassed
+		}
+		if a.Test.Status != b.Test.Status {
+			return a.Test.Status == replayStatusPassed
+		}
+		if a.Metrics.FileRecall != b.Metrics.FileRecall {
+			return a.Metrics.FileRecall > b.Metrics.FileRecall
+		}
+		if a.Metrics.FilePrecision != b.Metrics.FilePrecision {
+			return a.Metrics.FilePrecision > b.Metrics.FilePrecision
+		}
+		if a.Metrics.RiskScore != b.Metrics.RiskScore {
+			return a.Metrics.RiskScore < b.Metrics.RiskScore
+		}
+		return a.DurationMS < b.DurationMS
+	})
+}
+
+func renderReplayRun(w io.Writer, run *ReplayRun) {
+	sty := newStatusStyles(w)
+	fmt.Fprintf(w, "\n  %s %s\n", sty.render(sty.bold, "Replay"), sty.render(sty.cyan, run.ID))
+	fmt.Fprintf(w, "  checkpoint %s %s agent %s %s status %s\n\n",
+		sty.render(sty.cyan, run.Spec.CheckpointID),
+		sty.render(sty.dim, "·"),
+		run.Agent,
+		sty.render(sty.dim, "·"),
+		renderReplayStatus(sty, run.Status),
+	)
+	fmt.Fprintf(w, "  %s %s..%s\n", sty.render(sty.bold, "Range:"), shortReplaySHA(run.Spec.BaseCommit), shortReplaySHA(run.Spec.TargetCommit))
+	fmt.Fprintf(w, "  %s %s\n", sty.render(sty.bold, "Files:"), replayFileMetricText(run.Metrics))
+	if run.Test.Status != "skipped" {
+		fmt.Fprintf(w, "  %s %s", sty.render(sty.bold, "Tests:"), renderReplayStatus(sty, run.Test.Status))
+		if run.Test.Command != "" {
+			fmt.Fprintf(w, " %s %s", sty.render(sty.dim, "·"), run.Test.Command)
+		}
+		fmt.Fprintln(w)
+	}
+	if run.Metrics.SemanticAvailable {
+		fmt.Fprintf(w, "  %s %d%% semantic match\n", sty.render(sty.bold, "Semantic:"), run.Metrics.SemanticSimilarity)
+	}
+	if len(run.Metrics.RiskyFiles) > 0 || len(run.Metrics.ExtraFiles) > 0 {
+		fmt.Fprintf(w, "  %s risk score %d\n", sty.render(sty.bold, "Risk:"), run.Metrics.RiskScore)
+	}
+	if run.WorktreePath != "" {
+		fmt.Fprintf(w, "  %s %s\n", sty.render(sty.bold, "Worktree:"), run.WorktreePath)
+	}
+	if run.ResultPath != "" {
+		fmt.Fprintf(w, "  %s %s\n", sty.render(sty.dim, "Saved:"), run.ResultPath)
+	}
+	if run.Error != "" {
+		fmt.Fprintf(w, "\n  %s %s\n", sty.render(sty.red, "Error:"), run.Error)
+	}
+	if len(run.Warnings) > 0 {
+		fmt.Fprintf(w, "\n  %s\n", sty.render(sty.dim, "Warnings:"))
+		for _, warning := range run.Warnings {
+			fmt.Fprintf(w, "  - %s\n", sty.render(sty.dim, warning))
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+func renderReplayEval(w io.Writer, eval *ReplayEvalRun) {
+	sty := newStatusStyles(w)
+	fmt.Fprintf(w, "\n  %s %s\n\n", sty.render(sty.bold, "Replay Eval"), sty.render(sty.cyan, eval.ID))
+	if len(eval.Runs) == 0 {
+		fmt.Fprintf(w, "  %s\n\n", sty.render(sty.dim, "No runs recorded."))
+		return
+	}
+	fmt.Fprintf(w, "  %-12s  %-12s  %-8s  %-7s  %-7s  %-5s  %s\n", "Checkpoint", "Agent", "Status", "Recall", "Prec.", "Risk", "Tests")
+	fmt.Fprintf(w, "  %s\n", sty.render(sty.dim, strings.Repeat("─", 76)))
+	for _, run := range eval.Runs {
+		fmt.Fprintf(w, "  %-12s  %-12s  %-8s  %6d%%  %6d%%  %5d  %s\n",
+			run.Spec.CheckpointID,
+			stringutil.TruncateRunes(run.Agent, 12, ""),
+			run.Status,
+			run.Metrics.FileRecall,
+			run.Metrics.FilePrecision,
+			run.Metrics.RiskScore,
+			run.Test.Status,
+		)
+	}
+	if eval.ResultPath != "" {
+		fmt.Fprintf(w, "\n  %s %s\n", sty.render(sty.dim, "Saved:"), eval.ResultPath)
+	}
+	fmt.Fprintln(w)
+}
+
+func renderReplayStatus(sty statusStyles, status string) string {
+	switch status {
+	case replayStatusPassed:
+		return sty.render(sty.green, status)
+	case replayStatusFailed:
+		return sty.render(sty.red, status)
+	case replayStatusSkipped:
+		return sty.render(sty.dim, status)
+	default:
+		return sty.render(sty.yellow, status)
+	}
+}
+
+func replayFileMetricText(metrics ReplayMetrics) string {
+	return fmt.Sprintf("%d%% recall, %d%% precision (%d overlap, %d missing, %d extra)",
+		metrics.FileRecall,
+		metrics.FilePrecision,
+		metrics.FileOverlap,
+		len(metrics.MissingFiles),
+		len(metrics.ExtraFiles),
+	)
+}
+
+func replayGit(ctx context.Context, repoRoot string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoRoot}, args...)...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return "", fmt.Errorf("git %s: %w (stderr: %s)", strings.Join(args, " "), err, msg)
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func normalizeReplayPaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	seen := make(map[string]struct{}, len(paths))
+	for _, p := range paths {
+		normalized := filepath.ToSlash(strings.Trim(strings.TrimSpace(p), "/"))
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func uniqueNonEmpty(values []string) []string {
+	var out []string
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func percent(numerator, denominator int) int {
+	if denominator == 0 {
+		if numerator == 0 {
+			return 100
+		}
+		return 0
+	}
+	return numerator * 100 / denominator
+}
+
+func jaccardPercent(a, b map[string]struct{}) int {
+	if len(a) == 0 && len(b) == 0 {
+		return 100
+	}
+	intersection := 0
+	union := make(map[string]struct{}, len(a)+len(b))
+	for key := range a {
+		union[key] = struct{}{}
+		if _, ok := b[key]; ok {
+			intersection++
+		}
+	}
+	for key := range b {
+		union[key] = struct{}{}
+	}
+	return percent(intersection, len(union))
+}
+
+func truncateReplayOutput(output string) string {
+	output = strings.TrimSpace(output)
+	if len(output) <= replayResultOutputLimit {
+		return output
+	}
+	return output[:replayResultOutputLimit] + "\n...[truncated]"
+}
+
+func shortReplaySHA(sha string) string {
+	if len(sha) <= 8 {
+		return sha
+	}
+	return sha[:8]
+}
+
+func newReplayID() string {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%012x", time.Now().UnixNano()&0xffffffffffff)
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func writeReplayJSON(w io.Writer, value any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("encode json: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/replay_test.go
+++ b/cmd/entire/cli/replay_test.go
@@ -1,0 +1,350 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	agentpkg "github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	checkpointid "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/trailers"
+	"github.com/entireio/cli/redact"
+	git "github.com/go-git/go-git/v6"
+)
+
+const (
+	fakeReplayAgent     = "fake-agent"
+	replayTargetContent = "def greet():\n    return 'hello'\n\n\ndef replay_helper():\n    return 'ok'\n"
+)
+
+func TestBuildReplaySpecFromCheckpoint(t *testing.T) {
+	repoRoot, cpID, base, target := newReplayRepo(t)
+
+	spec, err := buildReplaySpec(context.Background(), cpID)
+	if err != nil {
+		t.Fatalf("buildReplaySpec() error = %v", err)
+	}
+
+	if spec.CheckpointID != cpID {
+		t.Fatalf("CheckpointID = %q, want %q", spec.CheckpointID, cpID)
+	}
+	if spec.BaseCommit != base {
+		t.Fatalf("BaseCommit = %q, want %q", spec.BaseCommit, base)
+	}
+	if spec.TargetCommit != target {
+		t.Fatalf("TargetCommit = %q, want %q", spec.TargetCommit, target)
+	}
+	if spec.Prompt != "Add the replay helper." {
+		t.Fatalf("Prompt = %q", spec.Prompt)
+	}
+	if got := strings.Join(spec.FilesTouched, ","); got != "app.py" {
+		t.Fatalf("FilesTouched = %q", got)
+	}
+	if spec.OriginalAgent != string(agentpkg.AgentTypeClaudeCode) {
+		t.Fatalf("OriginalAgent = %q", spec.OriginalAgent)
+	}
+
+	if content, err := os.ReadFile(filepath.Join(repoRoot, "app.py")); err != nil || !strings.Contains(string(content), "replay_helper") {
+		t.Fatalf("fixture target file not written: %v", err)
+	}
+}
+
+func TestReplayCheckpointUsesIsolatedWorktreeAndSavesResult(t *testing.T) {
+	repoRoot, cpID, _, _ := newReplayRepo(t)
+	restore := stubReplayRunner(func(_ context.Context, req ReplayRunnerRequest) (ReplayRunnerResult, error) {
+		if err := os.WriteFile(filepath.Join(req.WorktreePath, "app.py"), []byte(replayTargetContent), 0o644); err != nil {
+			return ReplayRunnerResult{}, err
+		}
+		return ReplayRunnerResult{Output: "fake replay completed"}, nil
+	})
+	defer restore()
+
+	run, err := runReplayCheckpoint(context.Background(), cpID, replayCheckpointOptions{
+		Agent:       fakeReplayAgent,
+		TestCommand: "python3 -m py_compile app.py",
+	})
+	if err != nil {
+		t.Fatalf("runReplayCheckpoint() error = %v", err)
+	}
+
+	if run.Status != replayStatusPassed {
+		t.Fatalf("Status = %q, error = %s", run.Status, run.Error)
+	}
+	if run.WorktreePath != "" {
+		t.Fatalf("WorktreePath should be empty when keep-worktree=false, got %q", run.WorktreePath)
+	}
+	if run.Metrics.FileRecall != 100 || run.Metrics.FilePrecision != 100 {
+		t.Fatalf("metrics = %+v", run.Metrics)
+	}
+	if run.Test.Status != replayStatusPassed {
+		t.Fatalf("test status = %q output=%s", run.Test.Status, run.Test.Output)
+	}
+	if run.ResultPath == "" {
+		t.Fatal("ResultPath is empty")
+	}
+	if _, err := os.Stat(run.ResultPath); err != nil {
+		t.Fatalf("saved result missing: %v", err)
+	}
+
+	mainContent, err := os.ReadFile(filepath.Join(repoRoot, "app.py"))
+	if err != nil {
+		t.Fatalf("read main worktree: %v", err)
+	}
+	if !strings.Contains(string(mainContent), "replay_helper") {
+		t.Fatalf("main worktree should remain at target commit content, got:\n%s", mainContent)
+	}
+}
+
+func TestReplayCheckpointKeepWorktreePreservesPath(t *testing.T) {
+	repoRoot, cpID, _, _ := newReplayRepo(t)
+	restore := stubReplayRunner(func(_ context.Context, _ ReplayRunnerRequest) (ReplayRunnerResult, error) {
+		return ReplayRunnerResult{Output: "no changes"}, nil
+	})
+	defer restore()
+
+	run, err := runReplayCheckpoint(context.Background(), cpID, replayCheckpointOptions{
+		Agent:        fakeReplayAgent,
+		KeepWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("runReplayCheckpoint() error = %v", err)
+	}
+	if run.WorktreePath == "" {
+		t.Fatal("WorktreePath is empty")
+	}
+	if _, err := os.Stat(run.WorktreePath); err != nil {
+		t.Fatalf("kept worktree missing: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := removeReplayWorktree(context.Background(), repoRoot, run.WorktreePath); err != nil {
+			t.Errorf("remove replay worktree: %v", err)
+		}
+	})
+}
+
+func TestReplayCheckpointCapturesCommittedAgentResult(t *testing.T) {
+	_, cpID, _, _ := newReplayRepo(t)
+	restore := stubReplayRunner(func(ctx context.Context, req ReplayRunnerRequest) (ReplayRunnerResult, error) {
+		if err := os.WriteFile(filepath.Join(req.WorktreePath, "app.py"), []byte(replayTargetContent), 0o644); err != nil {
+			return ReplayRunnerResult{}, err
+		}
+		if _, err := replayGit(ctx, req.WorktreePath, "add", "app.py"); err != nil {
+			return ReplayRunnerResult{}, err
+		}
+		if _, err := replayGit(ctx, req.WorktreePath,
+			"-c", "user.name=Replay Agent",
+			"-c", "user.email=replay@example.com",
+			"commit", "--no-gpg-sign", "-m", "agent replay result",
+		); err != nil {
+			return ReplayRunnerResult{}, err
+		}
+		return ReplayRunnerResult{Output: "committed replay completed"}, nil
+	})
+	defer restore()
+
+	run, err := runReplayCheckpoint(context.Background(), cpID, replayCheckpointOptions{Agent: fakeReplayAgent})
+	if err != nil {
+		t.Fatalf("runReplayCheckpoint() error = %v", err)
+	}
+	if got := strings.Join(run.ChangedFiles, ","); got != "app.py" {
+		t.Fatalf("ChangedFiles = %q", got)
+	}
+	if !strings.Contains(run.Diff, "replay_helper") {
+		t.Fatalf("Diff does not include committed replay result:\n%s", run.Diff)
+	}
+	if run.Metrics.FileRecall != 100 || run.Metrics.FilePrecision != 100 {
+		t.Fatalf("metrics = %+v", run.Metrics)
+	}
+}
+
+func TestReplayEvalRunRanksAndPersistsResults(t *testing.T) {
+	_, cpID, _, _ := newReplayRepo(t)
+	restore := stubReplayRunner(func(_ context.Context, req ReplayRunnerRequest) (ReplayRunnerResult, error) {
+		if err := os.WriteFile(filepath.Join(req.WorktreePath, "app.py"), []byte(replayTargetContent), 0o644); err != nil {
+			return ReplayRunnerResult{}, err
+		}
+		return ReplayRunnerResult{Output: "fake replay completed"}, nil
+	})
+	defer restore()
+
+	eval, err := runReplayEval(context.Background(), replayEvalOptions{
+		Checkpoints: []string{cpID},
+		Agents:      []string{fakeReplayAgent},
+	})
+	if err != nil {
+		t.Fatalf("runReplayEval() error = %v", err)
+	}
+	if len(eval.Runs) != 1 {
+		t.Fatalf("runs = %d, want 1", len(eval.Runs))
+	}
+	if eval.Runs[0].Status != replayStatusPassed {
+		t.Fatalf("run status = %q", eval.Runs[0].Status)
+	}
+	if eval.ResultPath == "" {
+		t.Fatal("ResultPath is empty")
+	}
+
+	loaded, err := readReplayEval(context.Background(), eval.ID)
+	if err != nil {
+		t.Fatalf("readReplayEval() error = %v", err)
+	}
+	if loaded.ID != eval.ID || len(loaded.Runs) != 1 {
+		t.Fatalf("loaded eval = %+v", loaded)
+	}
+}
+
+func TestReplayMetricsFlagsExtraAndRiskyFiles(t *testing.T) {
+	metrics := replayMetrics(context.Background(), "", "", ReplaySpec{FilesTouched: []string{"app.py"}}, []string{"app.py", "auth/config.yaml"})
+
+	if metrics.FileRecall != 100 {
+		t.Fatalf("FileRecall = %d", metrics.FileRecall)
+	}
+	if metrics.FilePrecision != 50 {
+		t.Fatalf("FilePrecision = %d", metrics.FilePrecision)
+	}
+	if got := strings.Join(metrics.ExtraFiles, ","); got != "auth/config.yaml" {
+		t.Fatalf("ExtraFiles = %q", got)
+	}
+	if got := strings.Join(metrics.RiskyFiles, ","); got != "auth/config.yaml" {
+		t.Fatalf("RiskyFiles = %q", got)
+	}
+	if metrics.RiskScore == 0 {
+		t.Fatal("RiskScore should be non-zero")
+	}
+}
+
+func TestReplayJSONIsStable(t *testing.T) {
+	run := ReplayRun{
+		ID:     "abc123def456",
+		Status: replayStatusPassed,
+		Spec: ReplaySpec{
+			CheckpointID: "a1b2c3d4e5f6",
+			Prompt:       "Do work",
+			BaseCommit:   "base",
+			TargetCommit: "target",
+		},
+		Metrics: ReplayMetrics{FileRecall: 100, FilePrecision: 100},
+	}
+	var out bytes.Buffer
+	if err := writeReplayJSON(&out, run); err != nil {
+		t.Fatalf("writeReplayJSON() error = %v", err)
+	}
+	var decoded ReplayRun
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+	if decoded.ID != run.ID || decoded.Spec.CheckpointID != run.Spec.CheckpointID {
+		t.Fatalf("decoded = %+v", decoded)
+	}
+}
+
+func TestReplayAgentEnvDisablesGitHooks(t *testing.T) {
+	env := replayAgentEnv([]string{
+		"PATH=/usr/bin",
+		"GIT_DIR=/tmp/git",
+		"GIT_CONFIG_COUNT=99",
+		"GIT_CONFIG_KEY_0=user.name",
+		"GIT_CONFIG_VALUE_0=Bad",
+	})
+	joined := "\n" + strings.Join(env, "\n") + "\n"
+	for _, absent := range []string{"\nGIT_DIR=", "\nGIT_CONFIG_COUNT=99", "\nGIT_CONFIG_KEY_0=user.name", "\nGIT_CONFIG_VALUE_0=Bad"} {
+		if strings.Contains(joined, absent) {
+			t.Fatalf("env still contains %q:\n%s", absent, joined)
+		}
+	}
+	for _, present := range []string{"ENTIRE_REPLAY=1", "GIT_CONFIG_COUNT=1", "GIT_CONFIG_KEY_0=core.hooksPath", "GIT_CONFIG_VALUE_0=/dev/null"} {
+		if !strings.Contains(joined, "\n"+present+"\n") {
+			t.Fatalf("env missing %q:\n%s", present, joined)
+		}
+	}
+}
+
+func TestRootCommandHasReplayAndEval(t *testing.T) {
+	root := NewRootCmd()
+	replayCmd, _, err := root.Find([]string{"replay", "checkpoint"})
+	if err != nil {
+		t.Fatalf("find replay checkpoint: %v", err)
+	}
+	if replayCmd.Name() != "checkpoint" {
+		t.Fatalf("replay command = %q", replayCmd.Name())
+	}
+	evalCmd, _, err := root.Find([]string{"eval", "run"})
+	if err != nil {
+		t.Fatalf("find eval run: %v", err)
+	}
+	if evalCmd.Name() != "run" {
+		t.Fatalf("eval command = %q", evalCmd.Name())
+	}
+}
+
+func newReplayRepo(t *testing.T) (repoRoot, cpID, base, target string) {
+	t.Helper()
+	repoRoot = t.TempDir()
+	testutil.InitRepo(t, repoRoot)
+	t.Chdir(repoRoot)
+	paths.ClearWorktreeRootCache()
+	session.ClearGitCommonDirCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+	t.Cleanup(session.ClearGitCommonDirCache)
+
+	testutil.WriteFile(t, repoRoot, ".gitignore", "__pycache__/\n")
+	testutil.WriteFile(t, repoRoot, "app.py", "def greet():\n    return 'hello'\n")
+	testutil.GitAdd(t, repoRoot, ".gitignore", "app.py")
+	testutil.GitCommit(t, repoRoot, "initial app")
+	base = replayGitForTest(t, repoRoot, "rev-parse", "HEAD")
+
+	cpID = "a1b2c3d4e5f6"
+	testutil.WriteFile(t, repoRoot, "app.py", "def greet():\n    return 'hello'\n\n\ndef replay_helper():\n    return 'ok'\n")
+	testutil.GitAdd(t, repoRoot, "app.py")
+	testutil.GitCommit(t, repoRoot, trailers.FormatCheckpoint("add replay helper", checkpointid.MustCheckpointID(cpID)))
+	target = replayGitForTest(t, repoRoot, "rev-parse", "HEAD")
+
+	repo, err := git.PlainOpen(repoRoot)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+	if err := checkpoint.NewGitStore(repo).WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		CheckpointID:     checkpointid.MustCheckpointID(cpID),
+		SessionID:        "session-replay-12345678",
+		Strategy:         "manual-commit",
+		Branch:           "master",
+		Transcript:       redact.AlreadyRedacted([]byte(`{"type":"user"}` + "\n")),
+		Prompts:          []string{"Add the replay helper."},
+		FilesTouched:     []string{"app.py"},
+		CheckpointsCount: 1,
+		Agent:            agentpkg.AgentTypeClaudeCode,
+		Model:            "claude-test-model",
+	}); err != nil {
+		t.Fatalf("write checkpoint: %v", err)
+	}
+	return repoRoot, cpID, base, target
+}
+
+func replayGitForTest(t *testing.T, repoRoot string, args ...string) string {
+	t.Helper()
+	out, err := replayGit(context.Background(), repoRoot, args...)
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return out
+}
+
+func stubReplayRunner(fn func(context.Context, ReplayRunnerRequest) (ReplayRunnerResult, error)) func() {
+	previous := replayRunnerFor
+	replayRunnerFor = func(agentName string) *replayRunnerFunc {
+		if agentName == fakeReplayAgent {
+			return &replayRunnerFunc{name: fakeReplayAgent, fn: fn}
+		}
+		return nil
+	}
+	return func() { replayRunnerFor = previous }
+}

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -102,6 +102,8 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newEnableCmd())
 	cmd.AddCommand(newDisableCmd())
 	cmd.AddCommand(newStatusCmd())
+	cmd.AddCommand(newReplayCmd())
+	cmd.AddCommand(newEvalCmd())
 	cmd.AddCommand(newLoginCmd())
 	cmd.AddCommand(newLogoutCmd())
 	cmd.AddCommand(newVersionCmd())


### PR DESCRIPTION
## Summary
Adds Entire Replay Lab: private checkpoint replay and eval commands built from existing Entire checkpoint metadata.

## What changed
- Adds `entire replay checkpoint <checkpoint-id>` for replaying one checkpoint in an isolated temp git worktree.
- Adds `entire eval run` for running checkpoint replay tasks across one or more launchable agents.
- Adds `entire eval report <run-id>` for reading saved eval results.
- Builds `ReplaySpec` from `Entire-Checkpoint` trailers plus committed checkpoint/session metadata.
- Compares replay output to the original commit by changed files, optional test command, risk signals, and optional `entire-sem` semantic similarity.
- Saves replay/eval JSON locally under the git common dir, outside tracked repo files.
- Disables git hooks inside replay agent subprocesses so replay commits do not create new checkpoint noise.
- Captures both uncommitted and agent-committed replay results by diffing back to the checkpoint base commit.

## Validation
- `go test ./cmd/entire/cli -run 'TestReplay|TestRootCommandHasReplayAndEval' -count=1`\n- `go test ./cmd/entire/cli -count=1`\n- `go vet ./cmd/entire/cli`\n- `go build -o /tmp/entire-replay-lab ./cmd/entire`\n- `mise run lint`\n- `go test ./...`\n- Built CLI help smoke for `entire replay checkpoint --help` and `entire eval run --help`\n\n## Notes\nThis is CLI-first and local/private by default. Live model execution requires the selected agent CLI and auth to be configured locally; tests use a fake replay runner to validate the real worktree, diff, metrics, persistence, and cleanup paths without spending model tokens.