### PR TITLE
auth: silent login-token refresh for git-remote-entire

### DIFF
--- a/cmd/entire/cli/auth/client.go
+++ b/cmd/entire/cli/auth/client.go
@@ -28,6 +28,7 @@ type DeviceAuthStart = deviceflow.DeviceCode
 // callers a more actionable message than the bare error code.
 type DeviceAuthPoll struct {
 	AccessToken      string
+	RefreshToken     string
 	TokenType        string
 	ExpiresIn        int
 	Scope            string
@@ -61,10 +62,14 @@ func NewClient(httpClient *http.Client, allowInsecureHTTP bool) *Client {
 		transport = httpClient.Transport
 	}
 	return &Client{inner: &deviceflow.Client{
-		Transport:         transport,
-		BaseURL:           issuer,
-		ClientID:          p.ClientID,
-		Scope:             "cli",
+		Transport: transport,
+		BaseURL:   issuer,
+		ClientID:  p.ClientID,
+		// offline_access asks the authorization server for a refresh token.
+		// The server only mints one when it's requested (it's client-gated),
+		// so without this the device login is access-token-only and silent
+		// refresh is impossible.
+		Scope:             "cli offline_access",
 		UserAgent:         p.ClientID,
 		DeviceCodePath:    p.DeviceCodePath,
 		TokenPath:         p.TokenPath,
@@ -101,10 +106,11 @@ func (c *Client) PollDeviceAuth(ctx context.Context, deviceCode string) (*Device
 	}
 
 	return &DeviceAuthPoll{
-		AccessToken: t.AccessToken,
-		TokenType:   t.TokenType,
-		ExpiresIn:   secondsUntil(t),
-		Scope:       t.Scope,
+		AccessToken:  t.AccessToken,
+		RefreshToken: t.RefreshToken,
+		TokenType:    t.TokenType,
+		ExpiresIn:    secondsUntil(t),
+		Scope:        t.Scope,
 	}, nil
 }
 

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -52,9 +52,12 @@ func RemoveCurrentContext() error {
 	}
 	// Best-effort keychain cleanup, sequenced off the context just removed.
 	// A missing entry is fine — the contexts.json removal above is what makes
-	// us "logged out".
+	// us "logged out". Both the access slot and its paired refresh slot must
+	// go: leaving the long-lived refresh token behind would let any later
+	// keyring-capable process mint fresh access tokens after logout.
 	if svc != "" && handle != "" {
-		_ = tokenstore.Delete(svc, handle) //nolint:errcheck // best-effort; contexts.json removal is the source of truth for logout
+		_ = tokenstore.Delete(svc, handle)                            //nolint:errcheck // best-effort; contexts.json removal is the source of truth for logout
+		_ = tokenstore.Delete(tokenstore.RefreshService(svc), handle) //nolint:errcheck // best-effort; absent refresh slot is fine
 	}
 	return nil
 }
@@ -71,7 +74,11 @@ func RemoveAllContexts() (int, error) {
 		}
 		for _, c := range f.Contexts {
 			if c.KeychainService != "" && c.Handle != "" {
-				_ = tokenstore.Delete(c.KeychainService, c.Handle) //nolint:errcheck // best-effort; the contexts.json clear below is authoritative
+				// Delete both slots: the access token and its paired refresh
+				// token. Dropping the refresh slot is what actually scrubs the
+				// machine — otherwise a leftover refresh token outlives logout.
+				_ = tokenstore.Delete(c.KeychainService, c.Handle)                            //nolint:errcheck // best-effort; the contexts.json clear below is authoritative
+				_ = tokenstore.Delete(tokenstore.RefreshService(c.KeychainService), c.Handle) //nolint:errcheck // best-effort; absent refresh slot is fine
 			}
 			removed++
 		}

--- a/cmd/entire/cli/auth/contexts.go
+++ b/cmd/entire/cli/auth/contexts.go
@@ -79,7 +79,7 @@ func RecordLoginContext(rawToken, refreshToken string, activate bool) (string, e
 	// no expiry suffix). Clear any prior one when this login carries none,
 	// so a stale token from an earlier session can't later be replayed
 	// against the server's single-use rotation and revoke the family.
-	refreshSlot := keychainService + ":refresh"
+	refreshSlot := tokenstore.RefreshService(keychainService)
 	if refreshToken != "" {
 		if err := tokenstore.Set(refreshSlot, handle, refreshToken); err != nil {
 			return "", fmt.Errorf("store refresh token in keyring: %w", err)

--- a/cmd/entire/cli/auth/contexts.go
+++ b/cmd/entire/cli/auth/contexts.go
@@ -70,15 +70,17 @@ func RecordLoginContext(rawToken, refreshToken string, activate bool) (string, e
 		}
 	}
 
-	encoded := tokenstore.EncodeTokenWithExpiration(rawToken, expiresIn)
-	if err := tokenstore.Set(keychainService, handle, encoded); err != nil {
-		return "", fmt.Errorf("store login token in keyring: %w", err)
-	}
-
 	// The refresh token lives in the paired "<service>:refresh" slot (raw,
 	// no expiry suffix). Clear any prior one when this login carries none,
 	// so a stale token from an earlier session can't later be replayed
 	// against the server's single-use rotation and revoke the family.
+	//
+	// Write the refresh slot BEFORE the access token, matching
+	// contextTokenStore.SaveTokens: a partial write must never leave a fresh
+	// access token paired with a stale refresh token left over from an
+	// earlier login. Refresh-first means a failed refresh write aborts before
+	// the access token is touched (old pair preserved), rather than committing
+	// a new access JWT against a dead refresh token.
 	refreshSlot := tokenstore.RefreshService(keychainService)
 	if refreshToken != "" {
 		if err := tokenstore.Set(refreshSlot, handle, refreshToken); err != nil {
@@ -86,6 +88,11 @@ func RecordLoginContext(rawToken, refreshToken string, activate bool) (string, e
 		}
 	} else {
 		_ = tokenstore.Delete(refreshSlot, handle) //nolint:errcheck // best-effort cleanup of a stale refresh token
+	}
+
+	encoded := tokenstore.EncodeTokenWithExpiration(rawToken, expiresIn)
+	if err := tokenstore.Set(keychainService, handle, encoded); err != nil {
+		return "", fmt.Errorf("store login token in keyring: %w", err)
 	}
 
 	var name string

--- a/cmd/entire/cli/auth/contexts.go
+++ b/cmd/entire/cli/auth/contexts.go
@@ -44,7 +44,7 @@ const defaultContextTokenTTL = time.Hour
 //
 // Returns the context name on success. Errors are returned (not swallowed)
 // so the caller can warn; login still succeeds on the legacy entry.
-func RecordLoginContext(rawToken string, activate bool) (string, error) {
+func RecordLoginContext(rawToken, refreshToken string, activate bool) (string, error) {
 	claims, err := tokens.ParseClaims(rawToken)
 	if err != nil {
 		return "", fmt.Errorf("parse login token claims: %w", err)
@@ -73,6 +73,19 @@ func RecordLoginContext(rawToken string, activate bool) (string, error) {
 	encoded := tokenstore.EncodeTokenWithExpiration(rawToken, expiresIn)
 	if err := tokenstore.Set(keychainService, handle, encoded); err != nil {
 		return "", fmt.Errorf("store login token in keyring: %w", err)
+	}
+
+	// The refresh token lives in the paired "<service>:refresh" slot (raw,
+	// no expiry suffix). Clear any prior one when this login carries none,
+	// so a stale token from an earlier session can't later be replayed
+	// against the server's single-use rotation and revoke the family.
+	refreshSlot := keychainService + ":refresh"
+	if refreshToken != "" {
+		if err := tokenstore.Set(refreshSlot, handle, refreshToken); err != nil {
+			return "", fmt.Errorf("store refresh token in keyring: %w", err)
+		}
+	} else {
+		_ = tokenstore.Delete(refreshSlot, handle) //nolint:errcheck // best-effort cleanup of a stale refresh token
 	}
 
 	var name string
@@ -172,7 +185,8 @@ func MigrateLegacyLoginContext() (migrated bool, err error) {
 	// activate=false: migrating an old login (e.g. on first `git clone`) must
 	// not silently switch the user's active context. RecordLoginContext still
 	// sets current_context when none exists yet.
-	if _, err := RecordLoginContext(legacy, false); err != nil {
+	// No refresh token: the legacy entry is access-token-only.
+	if _, err := RecordLoginContext(legacy, "", false); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -25,6 +25,45 @@ func makeJWT(t *testing.T, payloadJSON string) string {
 	return header + "." + payload + "." + enc.EncodeToString([]byte("sig"))
 }
 
+// RecordLoginContext must persist the refresh token before the access token,
+// so a failed access write never commits a fresh access JWT against a stale
+// refresh token left over from an earlier login.
+func TestRecordLoginContext_RefreshFirstOrdering(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+
+	const coreURL = "https://core.example.com"
+	const handle = "alice"
+	svc := tokenstore.CoreKeyringService(coreURL)
+	path := filepath.Join(t.TempDir(), "tokens.json")
+
+	// A prior login left a stale refresh token in the slot.
+	seedRestore := tokenstore.UseFileBackendForTesting(path)
+	if err := tokenstore.Set(tokenstore.RefreshService(svc), handle, "entr_stale"); err != nil {
+		t.Fatalf("seed stale refresh: %v", err)
+	}
+	seedRestore()
+
+	// Fail the access-token write only.
+	failAccess := func(service, _ string) bool { return service == svc }
+	restore := tokenstore.UseFailingBackendForTesting(path, failAccess)
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(2 * time.Hour).Unix()
+	token := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":%q,"exp":%d}`, coreURL, handle, exp))
+	if _, err := RecordLoginContext(token, "entr_login_new", true); err == nil {
+		t.Fatal("RecordLoginContext: want error when access write fails")
+	}
+	// The refresh token must already be the new one (written first), and no
+	// access token may sit alongside the stale refresh token.
+	if r, _ := tokenstore.Get(tokenstore.RefreshService(svc), handle); r != "entr_login_new" { //nolint:errcheck // read-back
+		t.Fatalf("refresh slot = %q, want entr_login_new persisted before the access write", r)
+	}
+	if v, err := tokenstore.Get(svc, handle); !errors.Is(err, tokenstore.ErrNotFound) {
+		t.Fatalf("access slot = %q (err=%v); a fresh access token must not be committed when its write failed", v, err)
+	}
+}
+
 func TestRecordLoginContext_WritesContextAndToken(t *testing.T) {
 	// Sets ENTIRE_CONFIG_DIR and swaps the keyring backend — process-global
 	// state, so this test cannot run in parallel.

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -196,11 +197,15 @@ func TestRemoveCurrentContext(t *testing.T) {
 
 	exp := time.Now().Add(time.Hour).Unix()
 	token := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
-	if _, err := RecordLoginContext(token, "", true); err != nil {
+	if _, err := RecordLoginContext(token, "entr_refresh", true); err != nil {
 		t.Fatalf("RecordLoginContext: %v", err)
 	}
 	if _, ok := CurrentContextToken(); !ok {
 		t.Fatal("precondition: expected a current context token")
+	}
+	svc := tokenstore.CoreKeyringService("https://core.example.com")
+	if r, _ := tokenstore.Get(tokenstore.RefreshService(svc), "alice"); r != "entr_refresh" { //nolint:errcheck // read-back; only the value matters
+		t.Fatalf("precondition: expected refresh slot seeded, got %q", r)
 	}
 
 	if err := RemoveCurrentContext(); err != nil {
@@ -208,6 +213,15 @@ func TestRemoveCurrentContext(t *testing.T) {
 	}
 	if _, ok := CurrentContextToken(); ok {
 		t.Fatal("after RemoveCurrentContext, expected no current context token")
+	}
+	// Logout must scrub both slots: the access token and the long-lived
+	// refresh token. A leftover refresh token would let any keyring-capable
+	// process mint fresh access tokens after logout.
+	if v, err := tokenstore.Get(svc, "alice"); !errors.Is(err, tokenstore.ErrNotFound) {
+		t.Fatalf("access slot survived logout: value=%q err=%v", v, err)
+	}
+	if v, err := tokenstore.Get(tokenstore.RefreshService(svc), "alice"); !errors.Is(err, tokenstore.ErrNotFound) {
+		t.Fatalf("refresh slot survived logout: value=%q err=%v", v, err)
 	}
 
 	// Idempotent: a second call with nothing current is a no-op.
@@ -223,10 +237,10 @@ func TestRemoveAllContexts(t *testing.T) {
 	t.Cleanup(restore)
 
 	exp := time.Now().Add(time.Hour).Unix()
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), "", true); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), "entr_a", true); err != nil {
 		t.Fatalf("record a: %v", err)
 	}
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"bob","exp":%d}`, exp)), "", true); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"bob","exp":%d}`, exp)), "entr_b", true); err != nil {
 		t.Fatalf("record b: %v", err)
 	}
 	n, err := RemoveAllContexts()
@@ -242,6 +256,19 @@ func TestRemoveAllContexts(t *testing.T) {
 	}
 	if len(f.Contexts) != 0 || f.CurrentContext != "" {
 		t.Fatalf("expected fully cleared, got contexts=%d current=%q", len(f.Contexts), f.CurrentContext)
+	}
+	// Every refresh slot must be gone too, for both removed contexts.
+	for _, tc := range []struct{ iss, handle string }{
+		{"https://a.example.com", "alice"},
+		{"https://b.example.com", "bob"},
+	} {
+		svc := tokenstore.CoreKeyringService(tc.iss)
+		if v, err := tokenstore.Get(svc, tc.handle); !errors.Is(err, tokenstore.ErrNotFound) {
+			t.Fatalf("access slot for %s survived: value=%q err=%v", tc.handle, v, err)
+		}
+		if v, err := tokenstore.Get(tokenstore.RefreshService(svc), tc.handle); !errors.Is(err, tokenstore.ErrNotFound) {
+			t.Fatalf("refresh slot for %s survived: value=%q err=%v", tc.handle, v, err)
+		}
 	}
 
 	// Idempotent.

--- a/cmd/entire/cli/auth/contexts_test.go
+++ b/cmd/entire/cli/auth/contexts_test.go
@@ -37,7 +37,7 @@ func TestRecordLoginContext_WritesContextAndToken(t *testing.T) {
 	exp := time.Now().Add(2 * time.Hour).Unix()
 	token := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":%q,"exp":%d}`, coreURL, handle, exp))
 
-	name, err := RecordLoginContext(token, true)
+	name, err := RecordLoginContext(token, "", true)
 	if err != nil {
 		t.Fatalf("RecordLoginContext: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestContextStore_PrefersCurrentContextThenLegacy(t *testing.T) {
 	// Record a context: its token now wins over the legacy entry.
 	exp := time.Now().Add(time.Hour).Unix()
 	ctxToken := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
-	if _, err := RecordLoginContext(ctxToken, true); err != nil {
+	if _, err := RecordLoginContext(ctxToken, "", true); err != nil {
 		t.Fatalf("RecordLoginContext: %v", err)
 	}
 	got, err := store.GetToken(api.AuthBaseURL())
@@ -196,7 +196,7 @@ func TestRemoveCurrentContext(t *testing.T) {
 
 	exp := time.Now().Add(time.Hour).Unix()
 	token := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
-	if _, err := RecordLoginContext(token, true); err != nil {
+	if _, err := RecordLoginContext(token, "", true); err != nil {
 		t.Fatalf("RecordLoginContext: %v", err)
 	}
 	if _, ok := CurrentContextToken(); !ok {
@@ -223,10 +223,10 @@ func TestRemoveAllContexts(t *testing.T) {
 	t.Cleanup(restore)
 
 	exp := time.Now().Add(time.Hour).Unix()
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), "", true); err != nil {
 		t.Fatalf("record a: %v", err)
 	}
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"bob","exp":%d}`, exp)), true); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"bob","exp":%d}`, exp)), "", true); err != nil {
 		t.Fatalf("record b: %v", err)
 	}
 	n, err := RemoveAllContexts()
@@ -261,10 +261,10 @@ func TestRemoveCurrentContext_DoesNotSwitchToAnother(t *testing.T) {
 	t.Cleanup(restore)
 
 	exp := time.Now().Add(time.Hour).Unix()
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), "", true); err != nil {
 		t.Fatalf("record a: %v", err)
 	}
-	active, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"alice","exp":%d}`, exp)), true)
+	active, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"alice","exp":%d}`, exp)), "", true)
 	if err != nil {
 		t.Fatalf("record b: %v", err)
 	}
@@ -297,10 +297,10 @@ func TestSetCurrentContext(t *testing.T) {
 
 	// Two contexts from two cores; the second becomes current on login.
 	exp := time.Now().Add(time.Hour).Unix()
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://a.example.com","handle":"alice","exp":%d}`, exp)), "", true); err != nil {
 		t.Fatalf("record a: %v", err)
 	}
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://b.example.com","handle":"alice","exp":%d}`, exp)), "", true); err != nil {
 		t.Fatalf("record b: %v", err)
 	}
 
@@ -342,11 +342,11 @@ func TestRecordLoginContext_SameCoreDifferentHandlesCoexist(t *testing.T) {
 	const coreURL = "https://core.example.com"
 	exp := time.Now().Add(time.Hour).Unix()
 
-	aliceName, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, exp)), true)
+	aliceName, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, exp)), "", true)
 	if err != nil {
 		t.Fatalf("record alice: %v", err)
 	}
-	bobName, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"bob","exp":%d}`, coreURL, exp)), true)
+	bobName, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"bob","exp":%d}`, coreURL, exp)), "", true)
 	if err != nil {
 		t.Fatalf("record bob: %v", err)
 	}
@@ -374,7 +374,7 @@ func TestRecordLoginContext_SameCoreDifferentHandlesCoexist(t *testing.T) {
 	}
 
 	// Re-login as alice updates her context in place (no third entry).
-	again, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, exp)), true)
+	again, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, exp)), "", true)
 	if err != nil {
 		t.Fatalf("re-login alice: %v", err)
 	}
@@ -400,7 +400,7 @@ func TestMigrateLegacyLoginContext_PreservesCurrentContext(t *testing.T) {
 	exp := time.Now().Add(time.Hour).Unix()
 
 	// An existing, active context for one core.
-	active, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://active.example.com","handle":"alice","exp":%d}`, exp)), true)
+	active, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":"https://active.example.com","handle":"alice","exp":%d}`, exp)), "", true)
 	if err != nil {
 		t.Fatalf("seed active context: %v", err)
 	}
@@ -441,7 +441,7 @@ func TestMigrateLegacyLoginContext_DifferentHandleSameCore(t *testing.T) {
 	exp := time.Now().Add(time.Hour).Unix()
 
 	// contexts.json already has alice@core (e.g. from another CLI).
-	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, exp)), true); err != nil {
+	if _, err := RecordLoginContext(makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, exp)), "", true); err != nil {
 		t.Fatalf("seed alice: %v", err)
 	}
 
@@ -474,7 +474,7 @@ func TestRecordLoginContext_RejectsTokenWithoutIssuer(t *testing.T) {
 	t.Cleanup(restore)
 
 	token := makeJWT(t, `{"handle":"alice"}`)
-	if _, err := RecordLoginContext(token, true); err == nil {
+	if _, err := RecordLoginContext(token, "", true); err == nil {
 		t.Fatal("expected error for token without iss claim, got nil")
 	}
 }

--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -134,7 +134,7 @@ func NewRefreshingLoginProvider(c *contexts.Context, transport http.RoundTripper
 	mgr, err := tokenmanager.New(tokenmanager.Config{
 		Issuer:            strings.TrimRight(c.CoreURL, "/"),
 		ClientID:          CurrentProvider().ClientID,
-		RefreshPath:       refreshGrantPath,
+		RefreshPath:       CurrentProvider().TokenPath,
 		Store:             contextTokenStore{service: c.KeychainService, handle: c.Handle},
 		Transport:         transport,
 		AllowInsecureHTTP: allowInsecureHTTP,

--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -132,13 +132,17 @@ func NewRefreshingLoginProvider(c *contexts.Context, transport http.RoundTripper
 		return nil, fmt.Errorf("init token manager for context %q: %w", c.Name, err)
 	}
 	name := c.Name
+	coreURL := strings.TrimRight(c.CoreURL, "/")
+	// Name the core in the re-login hint so a multi-core user logs back
+	// into the right one; matches clusterdiscovery.RenderLoginHint's idiom.
+	relogin := fmt.Sprintf("ENTIRE_AUTH_BASE_URL=%s entire login", coreURL)
 	return func(ctx context.Context) (string, error) {
 		tok, err := mgr.Refresh(ctx)
 		switch {
 		case errors.Is(err, tokenmanager.ErrReauthRequired):
-			return "", fmt.Errorf("login session for %q expired; run `entire login` to re-authenticate", name)
+			return "", fmt.Errorf("login session for %q (%s) expired; run `%s` to re-authenticate", name, coreURL, relogin)
 		case errors.Is(err, tokenmanager.ErrNotLoggedIn):
-			return "", fmt.Errorf("no usable login for %q; run `entire login`", name)
+			return "", fmt.Errorf("no usable login for %q (%s); run `%s`", name, coreURL, relogin)
 		case err != nil:
 			return "", fmt.Errorf("refresh login token: %w", err)
 		}

--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -1,0 +1,147 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/entireio/auth-go/tokenmanager"
+	"github.com/entireio/auth-go/tokens"
+	authtokenstore "github.com/entireio/auth-go/tokenstore"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+// refreshGrantPath is the token endpoint path where grant_type=refresh_token
+// is POSTed. Both provider versions multiplex grants at /oauth/token (the
+// same endpoint repocreds exchanges against), so it's stable across them.
+const refreshGrantPath = "/oauth/token"
+
+// defaultSavedTokenTTL is the encoded keychain expiry used when a refreshed
+// token carries no usable ExpiresAt. The server is the real authority; this
+// only governs when local readers consider the cached token stale.
+const defaultSavedTokenTTL = time.Hour
+
+// contextTokenStore adapts one login context's keyring slots to auth-go's
+// tokenstore.Store, so tokenmanager can load, refresh, and persist that
+// context's credentials. It is bound to a specific (service, handle) at
+// construction and ignores the profile argument: the cluster resolver has
+// already chosen exactly one context, so there is no per-issuer account
+// ambiguity to resolve here.
+//
+// Access token lives at `service`/`handle` (with the "|<expiry>" encoding
+// the rest of the CLI reads); the refresh token lives raw at
+// `service:refresh`/`handle`.
+type contextTokenStore struct {
+	service string
+	handle  string
+}
+
+func (s contextTokenStore) LoadTokens(string) (tokens.TokenSet, error) {
+	enc, err := tokenstore.Get(s.service, s.handle)
+	// Map "no credential stored" to auth-go's sentinel so tokenmanager
+	// reports "not logged in" rather than a hard store failure.
+	if errors.Is(err, tokenstore.ErrNotFound) || (err == nil && enc == "") {
+		return tokens.TokenSet{}, authtokenstore.ErrNotFound
+	}
+	if err != nil {
+		return tokens.TokenSet{}, fmt.Errorf("read access token: %w", err)
+	}
+	access, expiresAt := tokenstore.DecodeTokenWithExpiration(enc)
+	refresh, _ := tokenstore.Get(s.service+":refresh", s.handle) //nolint:errcheck // an absent refresh token is fine — treated as no-refresh
+	return tokens.TokenSet{
+		AccessToken:  access,
+		RefreshToken: refresh,
+		ExpiresAt:    expiresAt,
+	}, nil
+}
+
+func (s contextTokenStore) SaveTokens(_ string, t tokens.TokenSet) error {
+	if t.AccessToken == "" {
+		return errors.New("save tokens: empty access token")
+	}
+	expiresIn := int64(defaultSavedTokenTTL.Seconds())
+	if !t.ExpiresAt.IsZero() {
+		if secs := int64(time.Until(t.ExpiresAt).Seconds()); secs > 0 {
+			expiresIn = secs
+		}
+	}
+	if err := tokenstore.Set(s.service, s.handle, tokenstore.EncodeTokenWithExpiration(t.AccessToken, expiresIn)); err != nil {
+		return fmt.Errorf("store access token: %w", err)
+	}
+	// persistRefreshed carries a still-valid refresh token forward when the
+	// server doesn't rotate, so an empty value here means "leave as-is",
+	// never "clear".
+	if t.RefreshToken != "" {
+		if err := tokenstore.Set(s.service+":refresh", s.handle, t.RefreshToken); err != nil {
+			return fmt.Errorf("store refresh token: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s contextTokenStore) DeleteTokens(string) error {
+	_ = tokenstore.Delete(s.service+":refresh", s.handle) //nolint:errcheck // best-effort; the access-token delete below is what matters
+	if err := tokenstore.Delete(s.service, s.handle); err != nil {
+		return fmt.Errorf("delete access token: %w", err)
+	}
+	return nil
+}
+
+// NewRefreshingLoginProvider returns a login-JWT provider (the shape
+// repocreds wants) for context c that transparently re-mints an expired
+// login JWT from the stored refresh token.
+//
+// It is backed by auth-go's tokenmanager, which is what makes this safe
+// against the server's single-use refresh-token rotation: refreshes are
+// serialised across processes (an advisory file lock) and goroutines, the
+// store is re-read after locking so a late waiter reuses a peer's freshly
+// minted token, and the rotated refresh token is persisted. Without that,
+// two concurrent git-remote-entire processes (e.g. a recursive submodule
+// fetch) could replay the same single-use token and trip the server's
+// reuse detection, revoking the whole family.
+//
+// Behaviour is a strict superset of the old read-only provider: a still
+// valid token is returned with no network call; a context with no refresh
+// token (e.g. a login predating offline_access) behaves exactly as before
+// — valid token used, expired token surfaces a re-login error.
+//
+// transport carries the caller's TLS configuration; allowInsecureHTTP
+// permits an http:// core for loopback/dev.
+func NewRefreshingLoginProvider(c *contexts.Context, transport http.RoundTripper, allowInsecureHTTP bool) (func(context.Context) (string, error), error) {
+	if c == nil {
+		return nil, errors.New("nil context")
+	}
+	if c.KeychainService == "" || c.Handle == "" {
+		return nil, fmt.Errorf("context %q has no keychain slot", c.Name)
+	}
+	mgr, err := tokenmanager.New(tokenmanager.Config{
+		Issuer:            strings.TrimRight(c.CoreURL, "/"),
+		ClientID:          CurrentProvider().ClientID,
+		RefreshPath:       refreshGrantPath,
+		Store:             contextTokenStore{service: c.KeychainService, handle: c.Handle},
+		Transport:         transport,
+		AllowInsecureHTTP: allowInsecureHTTP,
+		UserAgent:         CurrentProvider().ClientID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("init token manager for context %q: %w", c.Name, err)
+	}
+	name := c.Name
+	return func(ctx context.Context) (string, error) {
+		tok, err := mgr.Refresh(ctx)
+		switch {
+		case errors.Is(err, tokenmanager.ErrReauthRequired):
+			return "", fmt.Errorf("login session for %q expired; run `entire login` to re-authenticate", name)
+		case errors.Is(err, tokenmanager.ErrNotLoggedIn):
+			return "", fmt.Errorf("no usable login for %q; run `entire login`", name)
+		case err != nil:
+			return "", fmt.Errorf("refresh login token: %w", err)
+		}
+		return tok, nil
+	}, nil
+}

--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -16,11 +16,6 @@ import (
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
 
-// refreshGrantPath is the token endpoint path where grant_type=refresh_token
-// is POSTed. Both provider versions multiplex grants at /oauth/token (the
-// same endpoint repocreds exchanges against), so it's stable across them.
-const refreshGrantPath = "/oauth/token"
-
 // defaultSavedTokenTTL is the encoded keychain expiry used when a refreshed
 // token carries no usable ExpiresAt. The server is the real authority; this
 // only governs when local readers consider the cached token stale.

--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -52,7 +52,14 @@ func (s contextTokenStore) LoadTokens(string) (tokens.TokenSet, error) {
 		return tokens.TokenSet{}, fmt.Errorf("read access token: %w", err)
 	}
 	access, expiresAt := tokenstore.DecodeTokenWithExpiration(enc)
-	refresh, _ := tokenstore.Get(tokenstore.RefreshService(s.service), s.handle) //nolint:errcheck // an absent refresh token is fine — treated as no-refresh
+	// A missing refresh slot is fine (login predating offline_access) — treat
+	// it as no-refresh. Any other store error must surface, not be swallowed:
+	// dropping it would silently discard a valid refresh token and force a
+	// re-login on what was really a transient keyring/file-store failure.
+	refresh, err := tokenstore.Get(tokenstore.RefreshService(s.service), s.handle)
+	if err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
+		return tokens.TokenSet{}, fmt.Errorf("read refresh token: %w", err)
+	}
 	return tokens.TokenSet{
 		AccessToken:  access,
 		RefreshToken: refresh,

--- a/cmd/entire/cli/auth/refresh.go
+++ b/cmd/entire/cli/auth/refresh.go
@@ -52,7 +52,7 @@ func (s contextTokenStore) LoadTokens(string) (tokens.TokenSet, error) {
 		return tokens.TokenSet{}, fmt.Errorf("read access token: %w", err)
 	}
 	access, expiresAt := tokenstore.DecodeTokenWithExpiration(enc)
-	refresh, _ := tokenstore.Get(s.service+":refresh", s.handle) //nolint:errcheck // an absent refresh token is fine — treated as no-refresh
+	refresh, _ := tokenstore.Get(tokenstore.RefreshService(s.service), s.handle) //nolint:errcheck // an absent refresh token is fine — treated as no-refresh
 	return tokens.TokenSet{
 		AccessToken:  access,
 		RefreshToken: refresh,
@@ -70,22 +70,32 @@ func (s contextTokenStore) SaveTokens(_ string, t tokens.TokenSet) error {
 			expiresIn = secs
 		}
 	}
-	if err := tokenstore.Set(s.service, s.handle, tokenstore.EncodeTokenWithExpiration(t.AccessToken, expiresIn)); err != nil {
-		return fmt.Errorf("store access token: %w", err)
-	}
+	// Persist the rotated refresh token BEFORE the access token. The server
+	// single-use-rotates refresh tokens, so a partial write must never leave
+	// a fresh access token paired with a stale refresh token: that pairing
+	// looks healthy until the access token expires, then the dead refresh
+	// token trips invalid_grant/family revocation and forces a re-login.
+	// Refresh-first inverts the failure modes: a failed refresh write aborts
+	// before touching the access slot (old pair preserved), and a failed
+	// access write after a good refresh write self-heals on the next load
+	// (the new refresh token re-mints an access token).
+	//
 	// persistRefreshed carries a still-valid refresh token forward when the
 	// server doesn't rotate, so an empty value here means "leave as-is",
 	// never "clear".
 	if t.RefreshToken != "" {
-		if err := tokenstore.Set(s.service+":refresh", s.handle, t.RefreshToken); err != nil {
+		if err := tokenstore.Set(tokenstore.RefreshService(s.service), s.handle, t.RefreshToken); err != nil {
 			return fmt.Errorf("store refresh token: %w", err)
 		}
+	}
+	if err := tokenstore.Set(s.service, s.handle, tokenstore.EncodeTokenWithExpiration(t.AccessToken, expiresIn)); err != nil {
+		return fmt.Errorf("store access token: %w", err)
 	}
 	return nil
 }
 
 func (s contextTokenStore) DeleteTokens(string) error {
-	_ = tokenstore.Delete(s.service+":refresh", s.handle) //nolint:errcheck // best-effort; the access-token delete below is what matters
+	_ = tokenstore.Delete(tokenstore.RefreshService(s.service), s.handle) //nolint:errcheck // best-effort; the access-token delete below is what matters
 	if err := tokenstore.Delete(s.service, s.handle); err != nil {
 		return fmt.Errorf("delete access token: %w", err)
 	}

--- a/cmd/entire/cli/auth/refresh_test.go
+++ b/cmd/entire/cli/auth/refresh_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,8 +112,13 @@ func TestNewRefreshingLoginProvider_ExpiredNoRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRefreshingLoginProvider: %v", err)
 	}
-	if _, err := provider(context.Background()); err == nil {
+	_, err = provider(context.Background())
+	if err == nil {
 		t.Fatal("expired token with no refresh: want a re-login error")
+	}
+	// The hint must name the core so a multi-core user re-logs into the right one.
+	if got := err.Error(); !strings.Contains(got, "https://core.example") || !strings.Contains(got, "entire login") {
+		t.Fatalf("re-login error = %q, want it to name the core and the login command", got)
 	}
 }
 

--- a/cmd/entire/cli/auth/refresh_test.go
+++ b/cmd/entire/cli/auth/refresh_test.go
@@ -151,7 +151,7 @@ func TestNewRefreshingLoginProvider_RefreshesAndRotates(t *testing.T) {
 
 	svc := tokenstore.CoreKeyringService(srv.URL)
 	expired := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, srv.URL, time.Now().Add(-time.Hour).Unix()))
-	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(expired, -3600)); err != nil {
+	if err := tokenstore.Set(svc, "alice", expired+tokenstore.TokenExpirationSeparator+"0"); err != nil {
 		t.Fatalf("seed access token: %v", err)
 	}
 	if err := tokenstore.Set(tokenstore.RefreshService(svc), "alice", "entr_old"); err != nil {

--- a/cmd/entire/cli/auth/refresh_test.go
+++ b/cmd/entire/cli/auth/refresh_test.go
@@ -103,7 +103,7 @@ func TestNewRefreshingLoginProvider_ExpiredNoRefresh(t *testing.T) {
 
 	svc := tokenstore.CoreKeyringService("https://core.example")
 	expired := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(-time.Hour).Unix()))
-	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(expired, -3600)); err != nil {
+	if err := tokenstore.Set(svc, "alice", expired+tokenstore.TokenExpirationSeparator+"0"); err != nil {
 		t.Fatalf("seed token: %v", err)
 	}
 

--- a/cmd/entire/cli/auth/refresh_test.go
+++ b/cmd/entire/cli/auth/refresh_test.go
@@ -1,0 +1,190 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/auth-go/tokens"
+	authtokenstore "github.com/entireio/auth-go/tokenstore"
+
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+func TestContextTokenStore_RoundTrip(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	st := contextTokenStore{service: "entire-core:https://core.example", handle: "alice"}
+
+	// Missing → ErrNotFound.
+	if _, err := st.LoadTokens(""); !errors.Is(err, authtokenstore.ErrNotFound) {
+		t.Fatalf("LoadTokens on empty store: got %v, want ErrNotFound", err)
+	}
+
+	jwt := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(time.Hour).Unix()))
+	if err := st.SaveTokens("", tokens.TokenSet{
+		AccessToken:  jwt,
+		RefreshToken: "entr_refresh",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveTokens: %v", err)
+	}
+
+	got, err := st.LoadTokens("")
+	if err != nil {
+		t.Fatalf("LoadTokens: %v", err)
+	}
+	if got.AccessToken != jwt {
+		t.Fatalf("access token = %q, want the stored JWT", got.AccessToken)
+	}
+	if got.RefreshToken != "entr_refresh" {
+		t.Fatalf("refresh token = %q, want %q", got.RefreshToken, "entr_refresh")
+	}
+
+	if err := st.DeleteTokens(""); err != nil {
+		t.Fatalf("DeleteTokens: %v", err)
+	}
+	if _, err := st.LoadTokens(""); !errors.Is(err, authtokenstore.ErrNotFound) {
+		t.Fatal("LoadTokens after delete: want ErrNotFound")
+	}
+	if r, _ := tokenstore.Get(st.service+":refresh", st.handle); r != "" { //nolint:errcheck // read-back; only the value matters here
+		t.Fatalf("refresh slot survived delete: %q", r)
+	}
+}
+
+func TestNewRefreshingLoginProvider_Validation(t *testing.T) {
+	if _, err := NewRefreshingLoginProvider(nil, nil, false); err == nil {
+		t.Error("nil context: want error")
+	}
+	if _, err := NewRefreshingLoginProvider(&contexts.Context{Name: "x"}, nil, false); err == nil {
+		t.Error("context without keychain slot: want error")
+	}
+}
+
+// A still-valid login JWT is returned with no network call — proven by a
+// transport that fails the test if invoked.
+func TestNewRefreshingLoginProvider_FreshTokenNoNetwork(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	svc := tokenstore.CoreKeyringService("https://core.example")
+	jwt := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(jwt, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	c := &contexts.Context{Name: "alice@core", CoreURL: "https://core.example", Handle: "alice", KeychainService: svc}
+	provider, err := NewRefreshingLoginProvider(c, failRoundTripper(t), false)
+	if err != nil {
+		t.Fatalf("NewRefreshingLoginProvider: %v", err)
+	}
+	got, err := provider(context.Background())
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	if got != jwt {
+		t.Fatalf("provider returned %q, want the stored valid JWT", got)
+	}
+}
+
+// Expired token with no refresh token behaves like the old read-only path:
+// a clear re-login error, not a crash.
+func TestNewRefreshingLoginProvider_ExpiredNoRefresh(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	svc := tokenstore.CoreKeyringService("https://core.example")
+	expired := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(-time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(expired, -3600)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	c := &contexts.Context{Name: "alice@core", CoreURL: "https://core.example", Handle: "alice", KeychainService: svc}
+	provider, err := NewRefreshingLoginProvider(c, failRoundTripper(t), false)
+	if err != nil {
+		t.Fatalf("NewRefreshingLoginProvider: %v", err)
+	}
+	if _, err := provider(context.Background()); err == nil {
+		t.Fatal("expired token with no refresh: want a re-login error")
+	}
+}
+
+// The full path: an expired access token is silently re-minted from the
+// stored refresh token, and the rotated refresh token is persisted.
+func TestNewRefreshingLoginProvider_RefreshesAndRotates(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	newJWT := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(time.Hour).Unix()))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+		}
+		if got := r.FormValue("grant_type"); got != "refresh_token" {
+			t.Errorf("grant_type = %q, want refresh_token", got)
+		}
+		if got := r.FormValue("refresh_token"); got != "entr_old" {
+			t.Errorf("refresh_token = %q, want entr_old", got)
+		}
+		if r.FormValue("client_id") == "" {
+			t.Error("missing client_id")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"access_token":%q,"refresh_token":"entr_new","token_type":"Bearer","expires_in":3600}`, newJWT)
+	}))
+	defer srv.Close()
+
+	svc := tokenstore.CoreKeyringService(srv.URL)
+	expired := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, srv.URL, time.Now().Add(-time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(expired, -3600)); err != nil {
+		t.Fatalf("seed access token: %v", err)
+	}
+	if err := tokenstore.Set(svc+":refresh", "alice", "entr_old"); err != nil {
+		t.Fatalf("seed refresh token: %v", err)
+	}
+
+	c := &contexts.Context{Name: "alice@core", CoreURL: srv.URL, Handle: "alice", KeychainService: svc}
+	// allowInsecureHTTP: the httptest server is http://127.0.0.1.
+	provider, err := NewRefreshingLoginProvider(c, srv.Client().Transport, true)
+	if err != nil {
+		t.Fatalf("NewRefreshingLoginProvider: %v", err)
+	}
+
+	got, err := provider(context.Background())
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	if got != newJWT {
+		t.Fatalf("provider returned the old token, want the refreshed one")
+	}
+
+	// Rotated refresh token persisted, and the new access token cached.
+	if r, _ := tokenstore.Get(svc+":refresh", "alice"); r != "entr_new" { //nolint:errcheck // read-back
+		t.Fatalf("rotated refresh token = %q, want entr_new", r)
+	}
+	enc, _ := tokenstore.Get(svc, "alice") //nolint:errcheck // read-back
+	if access, _ := tokenstore.DecodeTokenWithExpiration(enc); access != newJWT {
+		t.Fatalf("persisted access token not updated to the refreshed JWT")
+	}
+}
+
+func failRoundTripper(t *testing.T) http.RoundTripper {
+	t.Helper()
+	return roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Errorf("unexpected HTTP call to %s — a fresh token must not hit the network", r.URL)
+		return nil, errors.New("unexpected network call")
+	})
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/cmd/entire/cli/auth/refresh_test.go
+++ b/cmd/entire/cli/auth/refresh_test.go
@@ -18,11 +18,15 @@ import (
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
 
+// testCoreService is the keychain access-token service used across the
+// contextTokenStore tests (paired refresh slot is RefreshService(it)).
+const testCoreService = "entire-core:https://core.example"
+
 func TestContextTokenStore_RoundTrip(t *testing.T) {
 	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
 	t.Cleanup(restore)
 
-	st := contextTokenStore{service: "entire-core:https://core.example", handle: "alice"}
+	st := contextTokenStore{service: testCoreService, handle: "alice"}
 
 	// Missing → ErrNotFound.
 	if _, err := st.LoadTokens(""); !errors.Is(err, authtokenstore.ErrNotFound) {
@@ -57,6 +61,32 @@ func TestContextTokenStore_RoundTrip(t *testing.T) {
 	}
 	if r, _ := tokenstore.Get(tokenstore.RefreshService(st.service), st.handle); r != "" { //nolint:errcheck // read-back; only the value matters here
 		t.Fatalf("refresh slot survived delete: %q", r)
+	}
+}
+
+// A non-NotFound failure reading the refresh slot must surface, not be
+// swallowed — swallowing would discard a valid refresh token and force a
+// re-login on a transient keyring/file-store hiccup.
+func TestContextTokenStore_LoadTokens_RefreshReadErrorSurfaces(t *testing.T) {
+	svc := testCoreService
+
+	// Seed a valid access token through a clean backend.
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	seedRestore := tokenstore.UseFileBackendForTesting(path)
+	access := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(access, 3600)); err != nil {
+		t.Fatalf("seed access: %v", err)
+	}
+	seedRestore()
+
+	// Fail only the refresh-slot read; the access read still succeeds.
+	failRefreshGet := func(service, _ string) bool { return service == tokenstore.RefreshService(svc) }
+	restore := tokenstore.UseFailingGetBackendForTesting(path, failRefreshGet)
+	t.Cleanup(restore)
+
+	st := contextTokenStore{service: svc, handle: "alice"}
+	if _, err := st.LoadTokens(""); err == nil {
+		t.Fatal("LoadTokens: want error when the refresh-slot read fails, got nil")
 	}
 }
 
@@ -189,7 +219,7 @@ func TestNewRefreshingLoginProvider_RefreshesAndRotates(t *testing.T) {
 // re-login. The store persists refresh-first to invert both failure modes.
 func TestContextTokenStore_SaveTokens_RefreshFirstOrdering(t *testing.T) {
 	t.Run("refresh write fails: access slot untouched", func(t *testing.T) {
-		svc := "entire-core:https://core.example"
+		svc := testCoreService
 		path := filepath.Join(t.TempDir(), "tokens.json")
 
 		// Seed an existing good pair through a clean backend first — the fault
@@ -224,7 +254,7 @@ func TestContextTokenStore_SaveTokens_RefreshFirstOrdering(t *testing.T) {
 	})
 
 	t.Run("access write fails: refresh slot already advanced (self-heals)", func(t *testing.T) {
-		svc := "entire-core:https://core.example"
+		svc := testCoreService
 		failAccess := func(service, _ string) bool { return service == svc }
 		restore := tokenstore.UseFailingBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"), failAccess)
 		t.Cleanup(restore)

--- a/cmd/entire/cli/auth/refresh_test.go
+++ b/cmd/entire/cli/auth/refresh_test.go
@@ -55,7 +55,7 @@ func TestContextTokenStore_RoundTrip(t *testing.T) {
 	if _, err := st.LoadTokens(""); !errors.Is(err, authtokenstore.ErrNotFound) {
 		t.Fatal("LoadTokens after delete: want ErrNotFound")
 	}
-	if r, _ := tokenstore.Get(st.service+":refresh", st.handle); r != "" { //nolint:errcheck // read-back; only the value matters here
+	if r, _ := tokenstore.Get(tokenstore.RefreshService(st.service), st.handle); r != "" { //nolint:errcheck // read-back; only the value matters here
 		t.Fatalf("refresh slot survived delete: %q", r)
 	}
 }
@@ -154,7 +154,7 @@ func TestNewRefreshingLoginProvider_RefreshesAndRotates(t *testing.T) {
 	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(expired, -3600)); err != nil {
 		t.Fatalf("seed access token: %v", err)
 	}
-	if err := tokenstore.Set(svc+":refresh", "alice", "entr_old"); err != nil {
+	if err := tokenstore.Set(tokenstore.RefreshService(svc), "alice", "entr_old"); err != nil {
 		t.Fatalf("seed refresh token: %v", err)
 	}
 
@@ -174,13 +174,74 @@ func TestNewRefreshingLoginProvider_RefreshesAndRotates(t *testing.T) {
 	}
 
 	// Rotated refresh token persisted, and the new access token cached.
-	if r, _ := tokenstore.Get(svc+":refresh", "alice"); r != "entr_new" { //nolint:errcheck // read-back
+	if r, _ := tokenstore.Get(tokenstore.RefreshService(svc), "alice"); r != "entr_new" { //nolint:errcheck // read-back
 		t.Fatalf("rotated refresh token = %q, want entr_new", r)
 	}
 	enc, _ := tokenstore.Get(svc, "alice") //nolint:errcheck // read-back
 	if access, _ := tokenstore.DecodeTokenWithExpiration(enc); access != newJWT {
 		t.Fatalf("persisted access token not updated to the refreshed JWT")
 	}
+}
+
+// SaveTokens must never leave a fresh access token paired with a stale
+// refresh token: the server single-use-rotates, so that pairing looks healthy
+// until the access token expires, then the dead refresh token forces a
+// re-login. The store persists refresh-first to invert both failure modes.
+func TestContextTokenStore_SaveTokens_RefreshFirstOrdering(t *testing.T) {
+	t.Run("refresh write fails: access slot untouched", func(t *testing.T) {
+		svc := "entire-core:https://core.example"
+		path := filepath.Join(t.TempDir(), "tokens.json")
+
+		// Seed an existing good pair through a clean backend first — the fault
+		// backend installed below would reject the refresh-slot seed too.
+		oldAccess := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(time.Hour).Unix()))
+		seedRestore := tokenstore.UseFileBackendForTesting(path)
+		if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(oldAccess, 3600)); err != nil {
+			t.Fatalf("seed access: %v", err)
+		}
+		if err := tokenstore.Set(tokenstore.RefreshService(svc), "alice", "entr_old"); err != nil {
+			t.Fatalf("seed refresh: %v", err)
+		}
+		seedRestore()
+
+		// Now point at the SAME file but fail any refresh-slot write.
+		failRefresh := func(service, _ string) bool { return service == tokenstore.RefreshService(svc) }
+		restore := tokenstore.UseFailingBackendForTesting(path, failRefresh)
+		t.Cleanup(restore)
+
+		st := contextTokenStore{service: svc, handle: "alice"}
+		newAccess := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(2*time.Hour).Unix()))
+		err := st.SaveTokens("", tokens.TokenSet{AccessToken: newAccess, RefreshToken: "entr_new", ExpiresAt: time.Now().Add(2 * time.Hour)})
+		if err == nil {
+			t.Fatal("SaveTokens: want error when refresh write fails")
+		}
+		// The access slot must NOT have advanced — aborting before the access
+		// write preserves the old (still-mintable) pair.
+		enc, _ := tokenstore.Get(svc, "alice") //nolint:errcheck // read-back
+		if access, _ := tokenstore.DecodeTokenWithExpiration(enc); access != oldAccess {
+			t.Fatalf("access slot advanced despite refresh-write failure: a fresh access token is now paired with a stale refresh token")
+		}
+	})
+
+	t.Run("access write fails: refresh slot already advanced (self-heals)", func(t *testing.T) {
+		svc := "entire-core:https://core.example"
+		failAccess := func(service, _ string) bool { return service == svc }
+		restore := tokenstore.UseFailingBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"), failAccess)
+		t.Cleanup(restore)
+
+		st := contextTokenStore{service: svc, handle: "alice"}
+		newAccess := makeJWT(t, fmt.Sprintf(`{"iss":"https://core.example","handle":"alice","exp":%d}`, time.Now().Add(2*time.Hour).Unix()))
+		err := st.SaveTokens("", tokens.TokenSet{AccessToken: newAccess, RefreshToken: "entr_new", ExpiresAt: time.Now().Add(2 * time.Hour)})
+		if err == nil {
+			t.Fatal("SaveTokens: want error when access write fails")
+		}
+		// Refresh-first means the rotated refresh token is already persisted, so
+		// the next load re-mints a fresh access token rather than replaying a
+		// dead refresh token.
+		if r, _ := tokenstore.Get(tokenstore.RefreshService(svc), "alice"); r != "entr_new" { //nolint:errcheck // read-back
+			t.Fatalf("refresh slot = %q, want entr_new persisted before the access write", r)
+		}
+	})
 }
 
 func failRoundTripper(t *testing.T) http.RoundTripper {

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -38,7 +38,7 @@ func TestRunAuthContexts(t *testing.T) {
 
 	exp := time.Now().Add(time.Hour).Unix()
 	token := makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp))
-	if _, err := auth.RecordLoginContext(token, true); err != nil {
+	if _, err := auth.RecordLoginContext(token, "", true); err != nil {
 		t.Fatalf("RecordLoginContext: %v", err)
 	}
 
@@ -65,7 +65,7 @@ func TestWarnIfCrossCoreContext(t *testing.T) {
 	exp := time.Now().Add(time.Hour).Unix()
 
 	// Same core as the configured auth host: no warning.
-	sameName, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://auth.example.com","handle":"alice","exp":%d}`, exp)), true)
+	sameName, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://auth.example.com","handle":"alice","exp":%d}`, exp)), "", true)
 	if err != nil {
 		t.Fatalf("record same-core: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestWarnIfCrossCoreContext(t *testing.T) {
 	}
 
 	// Different core: warns that the control plane won't follow.
-	otherName, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://other.example.com","handle":"alice","exp":%d}`, exp)), true)
+	otherName, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://other.example.com","handle":"alice","exp":%d}`, exp)), "", true)
 	if err != nil {
 		t.Fatalf("record cross-core: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestNoteRemainingLogins(t *testing.T) {
 
 	// A surviving context: names it and points at --all.
 	exp := time.Now().Add(time.Hour).Unix()
-	if _, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp)), true); err != nil {
+	if _, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core.example.com","handle":"alice","exp":%d}`, exp)), "", true); err != nil {
 		t.Fatalf("record: %v", err)
 	}
 	var buf bytes.Buffer

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -96,7 +96,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 
 	fmt.Fprintln(outW, "Waiting for approval...")
 
-	token, err := waitForApproval(ctx, client, start.DeviceCode, start.ExpiresIn, time.Duration(start.Interval)*time.Second, defaultSlowDownBackoff)
+	token, refreshToken, err := waitForApproval(ctx, client, start.DeviceCode, start.ExpiresIn, time.Duration(start.Interval)*time.Second, defaultSlowDownBackoff)
 	if err != nil {
 		return fmt.Errorf("complete login: %w", err)
 	}
@@ -119,7 +119,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	// entitled cluster from this login. Best-effort: the legacy entry
 	// above remains the control-plane source of truth, so a failure here
 	// must not fail the login — warn and continue.
-	if _, err := auth.RecordLoginContext(token, true); err != nil {
+	if _, err := auth.RecordLoginContext(token, refreshToken, true); err != nil {
 		fmt.Fprintf(errW, "Warning: logged in, but could not record a shareable context (clone via entire:// may need a re-login): %v\n", err)
 	}
 
@@ -183,7 +183,7 @@ func issMatches(claimed, expected string) error {
 	return nil
 }
 
-func waitForApproval(ctx context.Context, poller deviceAuthClient, deviceCode string, expiresIn int, interval, slowDownBackoff time.Duration) (string, error) {
+func waitForApproval(ctx context.Context, poller deviceAuthClient, deviceCode string, expiresIn int, interval, slowDownBackoff time.Duration) (accessToken, refreshToken string, err error) {
 	expiry := time.Duration(expiresIn) * time.Second
 	if expiry <= 0 || expiry > maxExpiresIn {
 		expiry = maxExpiresIn
@@ -198,19 +198,19 @@ func waitForApproval(ctx context.Context, poller deviceAuthClient, deviceCode st
 
 	for {
 		if time.Now().After(deadline) {
-			return "", errors.New("device authorization expired")
+			return "", "", errors.New("device authorization expired")
 		}
 
 		result, err := poller.PollDeviceAuth(ctx, deviceCode)
 		if err != nil {
 			consecutiveErrors++
 			if consecutiveErrors >= maxTransientErrors {
-				return "", fmt.Errorf("poll approval status (after %d consecutive failures): %w", consecutiveErrors, err)
+				return "", "", fmt.Errorf("poll approval status (after %d consecutive failures): %w", consecutiveErrors, err)
 			}
 			// Transient error — wait and retry.
 			select {
 			case <-ctx.Done():
-				return "", fmt.Errorf("wait for approval: %w", ctx.Err())
+				return "", "", fmt.Errorf("wait for approval: %w", ctx.Err())
 			case <-time.After(pollInterval):
 			}
 			continue
@@ -220,9 +220,9 @@ func waitForApproval(ctx context.Context, poller deviceAuthClient, deviceCode st
 		switch result.Error {
 		case "":
 			if result.AccessToken == "" {
-				return "", errors.New("device authorization completed without a token")
+				return "", "", errors.New("device authorization completed without a token")
 			}
-			return result.AccessToken, nil
+			return result.AccessToken, result.RefreshToken, nil
 		case "authorization_pending":
 			// no-op, will sleep and retry below
 		case "slow_down":
@@ -231,19 +231,19 @@ func waitForApproval(ctx context.Context, poller deviceAuthClient, deviceCode st
 				pollInterval = maxPollInterval
 			}
 		case "access_denied":
-			return "", errors.New("device authorization denied")
+			return "", "", errors.New("device authorization denied")
 		case "expired_token":
-			return "", errors.New("device authorization expired")
+			return "", "", errors.New("device authorization expired")
 		default:
 			if result.ErrorDescription != "" {
-				return "", fmt.Errorf("device authorization failed: %s: %s", result.Error, result.ErrorDescription)
+				return "", "", fmt.Errorf("device authorization failed: %s: %s", result.Error, result.ErrorDescription)
 			}
-			return "", fmt.Errorf("device authorization failed: %s", result.Error)
+			return "", "", fmt.Errorf("device authorization failed: %s", result.Error)
 		}
 
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("wait for approval: %w", ctx.Err())
+			return "", "", fmt.Errorf("wait for approval: %w", ctx.Err())
 		case <-time.After(pollInterval):
 		}
 	}

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -45,7 +45,7 @@ func TestWaitForApproval_ImmediateSuccess(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{AccessToken: "tok-123"}},
 	}}
 
-	token, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	token, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestWaitForApproval_PendingThenSuccess(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{AccessToken: "tok-456"}},
 	}}
 
-	token, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	token, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestWaitForApproval_AccessDenied(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{Error: "access_denied"}},
 	}}
 
-	_, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	_, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "device authorization denied") {
 		t.Fatalf("err = %v, want 'device authorization denied'", err)
 	}
@@ -98,7 +98,7 @@ func TestWaitForApproval_ExpiredToken(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{Error: "expired_token"}},
 	}}
 
-	_, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	_, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "device authorization expired") {
 		t.Fatalf("err = %v, want 'device authorization expired'", err)
 	}
@@ -111,7 +111,7 @@ func TestWaitForApproval_UnknownError(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{Error: "server_error"}},
 	}}
 
-	_, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	_, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "server_error") {
 		t.Fatalf("err = %v, want to contain 'server_error'", err)
 	}
@@ -124,7 +124,7 @@ func TestWaitForApproval_EmptyTokenOnSuccess(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{AccessToken: ""}},
 	}}
 
-	_, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	_, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "completed without a token") {
 		t.Fatalf("err = %v, want 'completed without a token'", err)
 	}
@@ -138,7 +138,7 @@ func TestWaitForApproval_SlowDown(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{AccessToken: "tok-slow"}},
 	}}
 
-	token, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	token, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestWaitForApproval_ExpiresInClamped(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{AccessToken: "tok-clamp"}},
 	}}
 
-	token, err := waitForApproval(context.Background(), poller, "device-1", 0, time.Millisecond, time.Millisecond)
+	token, _, err := waitForApproval(context.Background(), poller, "device-1", 0, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestWaitForApproval_NegativeExpiresInClamped(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{AccessToken: "tok-neg"}},
 	}}
 
-	token, err := waitForApproval(context.Background(), poller, "device-1", -1, time.Millisecond, time.Millisecond)
+	token, _, err := waitForApproval(context.Background(), poller, "device-1", -1, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestWaitForApproval_TransientErrorRetry(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{AccessToken: "tok-retry"}},
 	}}
 
-	token, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	token, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestWaitForApproval_TransientErrorExhausted(t *testing.T) {
 	}
 	poller := &mockClient{responses: responses}
 
-	_, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	_, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "consecutive failures") {
 		t.Fatalf("err = %v, want 'consecutive failures'", err)
 	}
@@ -235,7 +235,7 @@ func TestWaitForApproval_TransientErrorCounterResets(t *testing.T) {
 	responses = append(responses, pollResponse{result: &auth.DeviceAuthPoll{AccessToken: "tok-reset"}})
 	poller := &mockClient{responses: responses}
 
-	token, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	token, _, err := waitForApproval(context.Background(), poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -295,7 +295,7 @@ func TestWaitForApproval_ContextCancelled(t *testing.T) {
 		{result: &auth.DeviceAuthPoll{Error: "authorization_pending"}},
 	}}
 
-	_, err := waitForApproval(ctx, poller, "device-1", 60, time.Millisecond, time.Millisecond)
+	_, _, err := waitForApproval(ctx, poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "context canceled") {
 		t.Fatalf("err = %v, want context canceled", err)
 	}

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -90,7 +90,7 @@ func run(args []string) int {
 		Transport: httpclient.NewTransport(skipTLS),
 	}
 
-	creds, err := resolveCreds(ctx, parsedURL, clusterBaseURL, httpClient)
+	creds, err := resolveCreds(ctx, parsedURL, clusterBaseURL, skipTLS, httpClient)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		return 128
@@ -171,7 +171,7 @@ func parseProtocolVersion(raw string, warn io.Writer) int {
 //   - otherwise: resolve the login context for this cluster from contexts.json
 //     (migrating any pre-contexts.json login first) and exchange its stored
 //     login JWT.
-func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string, httpClient *http.Client) (*repocreds.Cache, error) {
+func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string, skipTLS bool, httpClient *http.Client) (*repocreds.Cache, error) {
 	// Presence of ENTIRE_TOKEN is the signal: if it's set at all (LookupEnv,
 	// not Getenv, so we can tell set-empty from unset), we commit to the
 	// env-token path and any failure to use it is fatal — never a silent
@@ -204,11 +204,17 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 		return nil, err //nolint:wrapcheck // ResolveContextForCluster already returns a user-facing error; preserved verbatim for the "fatal: <msg>" surface
 	}
 
+	// The login-JWT provider transparently refreshes an expired login JWT
+	// from the stored refresh token (serialised across processes, rotated
+	// tokens persisted) before repocreds exchanges it for repo-scoped tokens.
+	loginProvider, err := auth.NewRefreshingLoginProvider(clusterCtx, httpClient.Transport, skipTLS)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // NewRefreshingLoginProvider already returns a user-facing error
+	}
+
 	// Mint repo-scoped tokens by exchanging the context's login JWT at its
 	// login server's /oauth/token, cached per (repo, action) for this invocation.
-	return repocreds.New(clusterCtx.CoreURL, clusterBaseURL, func(context.Context) (string, error) {
-		return auth.LoginTokenForContext(clusterCtx)
-	}, httpClient), nil
+	return repocreds.New(clusterCtx.CoreURL, clusterBaseURL, loginProvider, httpClient), nil
 }
 
 // resolveEnvTokenCreds builds the repo-cred cache for the ENTIRE_TOKEN path.

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -167,7 +167,7 @@ func TestResolveCreds_BlankEnvTokenFailsClosed(t *testing.T) {
 	dummyURL := &url.URL{Scheme: "entire", Host: "cluster.example.com"}
 	for _, blank := range []string{"", " ", "\t", "\n", " \t\n "} {
 		t.Setenv(auth.EnvTokenVar, blank)
-		creds, err := resolveCreds(t.Context(), dummyURL, "https://cluster.example.com", nil)
+		creds, err := resolveCreds(t.Context(), dummyURL, "https://cluster.example.com", false, nil)
 		if err == nil {
 			t.Fatalf("blank ENTIRE_TOKEN %q should fail closed", blank)
 		}

--- a/internal/entireclient/tokenstore/testing.go
+++ b/internal/entireclient/tokenstore/testing.go
@@ -33,10 +33,21 @@ func UseFileBackendForTesting(path string) func() {
 // paths (e.g. the refresh-then-access ordering in contextTokenStore) without
 // exposing the unexported store interface. Returns a cleanup function.
 func UseFailingBackendForTesting(path string, failSet func(service, user string) bool) func() {
+	return installFaultStore(faultStore{inner: &fileStore{path: path}, failSet: failSet})
+}
+
+// UseFailingGetBackendForTesting is the read-side analogue: Get returns an
+// error for any (service, user) pair where failGet reports true. Used to test
+// that callers surface a real store failure rather than swallowing it.
+func UseFailingGetBackendForTesting(path string, failGet func(service, user string) bool) func() {
+	return installFaultStore(faultStore{inner: &fileStore{path: path}, failGet: failGet})
+}
+
+func installFaultStore(fs faultStore) func() {
 	backendMu.Lock()
 	prevBackend := backend
 	prevResolved := resolved
-	backend = faultStore{inner: &fileStore{path: path}, failSet: failSet}
+	backend = fs
 	resolved = true
 	backendMu.Unlock()
 
@@ -51,9 +62,13 @@ func UseFailingBackendForTesting(path string, failSet func(service, user string)
 type faultStore struct {
 	inner   store
 	failSet func(service, user string) bool
+	failGet func(service, user string) bool
 }
 
 func (f faultStore) Get(service, user string) (string, error) {
+	if f.failGet != nil && f.failGet(service, user) {
+		return "", fmt.Errorf("injected Get failure for %s/%s", service, user)
+	}
 	//nolint:wrapcheck // thin test wrapper; callers handle errors
 	return f.inner.Get(service, user)
 }

--- a/internal/entireclient/tokenstore/testing.go
+++ b/internal/entireclient/tokenstore/testing.go
@@ -1,5 +1,7 @@
 package tokenstore
 
+import "fmt"
+
 // UseFileBackendForTesting points the package-level token store at a
 // per-test JSON file and returns a cleanup function that restores the
 // previous backend (re-resolving on next use). It serializes against
@@ -23,4 +25,48 @@ func UseFileBackendForTesting(path string) func() {
 		resolved = prevResolved
 		backendMu.Unlock()
 	}
+}
+
+// UseFailingBackendForTesting wraps a file backend so Set returns an error
+// for any (service, user) pair where failSet reports true; all other
+// operations behave normally. It lets tests exercise partial-write failure
+// paths (e.g. the refresh-then-access ordering in contextTokenStore) without
+// exposing the unexported store interface. Returns a cleanup function.
+func UseFailingBackendForTesting(path string, failSet func(service, user string) bool) func() {
+	backendMu.Lock()
+	prevBackend := backend
+	prevResolved := resolved
+	backend = faultStore{inner: &fileStore{path: path}, failSet: failSet}
+	resolved = true
+	backendMu.Unlock()
+
+	return func() {
+		backendMu.Lock()
+		backend = prevBackend
+		resolved = prevResolved
+		backendMu.Unlock()
+	}
+}
+
+type faultStore struct {
+	inner   store
+	failSet func(service, user string) bool
+}
+
+func (f faultStore) Get(service, user string) (string, error) {
+	//nolint:wrapcheck // thin test wrapper; callers handle errors
+	return f.inner.Get(service, user)
+}
+
+func (f faultStore) Set(service, user, password string) error {
+	if f.failSet != nil && f.failSet(service, user) {
+		return fmt.Errorf("injected Set failure for %s/%s", service, user)
+	}
+	//nolint:wrapcheck // thin test wrapper; callers handle errors
+	return f.inner.Set(service, user, password)
+}
+
+func (f faultStore) Delete(service, user string) error {
+	//nolint:wrapcheck // thin test wrapper; callers handle errors
+	return f.inner.Delete(service, user)
 }

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -49,6 +49,15 @@ func CoreKeyringService(coreURL string) string {
 	return CoreKeyringPrefix + strings.TrimRight(coreURL, "/")
 }
 
+// RefreshService returns the paired refresh-token service name for an
+// access-token service, following the "<service>:refresh" convention
+// documented in this package's service-name conventions. Callers store the
+// raw refresh token under (RefreshService(service), user) alongside the
+// access token at (service, user).
+func RefreshService(service string) string {
+	return service + ":refresh"
+}
+
 // KeyringServiceForIssuerKey infers the right service prefix from a
 // raw issuer key (entire-core URL or entiredb cluster host). URL-shaped
 // keys (anything beginning with a scheme) are treated as entire-core


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/491
<!-- entire-trail-link-end -->

Expired login tokens are now silently re-minted from a stored refresh token instead of forcing a re-login, with rotation serialized across processes/goroutines so concurrent `git-remote-entire` invocations (e.g. recursive submodule fetch) don't replay a single-use refresh token and trip family revocation.

Includes fixes for two review findings:
- **logout now scrubs all bearer material** — `entire logout`/`--all` delete both the access slot and the paired `<service>:refresh` slot; previously the long-lived refresh token survived logout.
- **crash-safe rotation** — the rotated refresh token is persisted before the access token, so a partial keyring write can never leave a fresh access token paired with a now-dead refresh token (which would force a re-login after a transient failure).

Verification: `go build ./...`, `mise run lint:go` (0 issues), `mise run test` (6011 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication token lifecycle, keyring layout, refresh rotation, and logout behavior—mistakes could leave stale credentials, break concurrent git fetches, or fail to revoke sessions on logout.
> 
> **Overview**
> This PR adds **silent login JWT refresh** for `git-remote-entire` (and the shared contexts keyring model) so expired login tokens can be re-minted without forcing `entire login` when a refresh token is present.
> 
> **Device login** now requests `offline_access`, surfaces `RefreshToken` from device-flow polling, and passes it into `RecordLoginContext` alongside the access JWT. Refresh credentials live in a paired keyring slot via `tokenstore.RefreshService` (`<service>:refresh`).
> 
> **`NewRefreshingLoginProvider`** wraps auth-go `tokenmanager` (cross-process lock, re-read after lock) and a `contextTokenStore` adapter so repo-scoped token exchange gets a login JWT that refreshes when needed. Valid tokens still avoid network I/O; sessions without a refresh token behave like the old read-only path.
> 
> **Persistence and logout:** login and refresh both write **refresh before access** so a partial keyring update cannot pair a new access token with a stale or missing refresh token (important for single-use refresh rotation). Logout (`RemoveCurrentContext` / `RemoveAllContexts`) deletes **both** access and refresh slots so long-lived refresh tokens do not survive logout.
> 
> **`git-remote-entire`** switches from `LoginTokenForContext` to the refreshing provider before `repocreds`. Tests add `UseFailingBackendForTesting` and coverage for refresh-first ordering, full refresh/rotate, and logout scrubbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f030f35e908399d8040003f36dc3a68af4e6b3b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->