### PR TITLE
Tiny adjustments to output

### DIFF
--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -78,7 +78,8 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		// so opening the URL is usually all the user needs to do. The device
 		// code is printed above regardless, so it's still available to confirm
 		// against the page (RFC 8628 §3.3.1) or to enter on the bare-URI fallback.
-		fmt.Fprintf(outW, "Press Enter to open %s in your browser to approve this login...", approvalURL)
+		fmt.Fprintf(outW, "Login URL:   %s\n\n", approvalURL)
+		fmt.Fprintf(outW, "Press Enter to open in browser...")
 
 		// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
 		if err := waitForEnter(ctx); err != nil {
@@ -91,10 +92,10 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 			fmt.Fprintf(outW, "Open this URL in your browser to approve this login: %s\n", approvalURL)
 		}
 	} else {
-		fmt.Fprintf(outW, "Approval URL: %s\n", approvalURL)
+		fmt.Fprintf(outW, "Login URL:   %s\n\n", approvalURL)
 	}
 
-	fmt.Fprintln(outW, "Waiting for approval...")
+	fmt.Fprintln(outW, "Waiting for approval... ")
 
 	token, refreshToken, err := waitForApproval(ctx, client, start.DeviceCode, start.ExpiresIn, time.Duration(start.Interval)*time.Second, defaultSlowDownBackoff)
 	if err != nil {
@@ -123,7 +124,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		fmt.Fprintf(errW, "Warning: logged in, but could not record a shareable context (clone via entire:// may need a re-login): %v\n", err)
 	}
 
-	fmt.Fprintln(outW, "Login complete.")
+	fmt.Fprint(outW, "    ✅ login complete.")
 	return nil
 }
 

--- a/mise-tasks/dev/publish
+++ b/mise-tasks/dev/publish
@@ -6,4 +6,12 @@ set -eu
 export GOBIN=${GOPATH:-$HOME/go}/bin
 echo "NOTE: we're overriding \$GOBIN: $GOBIN" 1>&2
 
-go install ./cmd/entire ./cmd/git-remote-entire
+commands=(
+  entire
+  git-remote-entire
+)
+
+for c in "${commands[@]}"; do
+  go install "./cmd/$c"
+  echo "Installed: '$c'" 1>&2
+done


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/496
<!-- entire-trail-link-end -->

# Description

Very small prettification of things that were bothering me:

* `mise run dev:publish` - i use it all the time and i like it when it tells me what it's installed
* The login flow - i found i always had to read twice, because the URL and the "press Enter" prompt blurred together a bit.  Now i think it's very readable:


```shellsession
$ entire login
Device code: 5XXS-2XXB
Login URL:   https://us.auth.entire.io/cli/auth?user_code=5XXS-2XXB

Press Enter to open in browser...

Waiting for approval... ✅ login complete.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and dev-task script changes only; no auth, token, or install logic changes.
> 
> **Overview**
> Polishes **`entire login`** terminal output so the device code, labeled **Login URL**, and Enter prompt are on separate lines (interactive and non-interactive paths share the same URL label). The approval wait line stays on one line so a checkmark can appear inline, and success is shown as **`✅ login complete.`** on that line instead of a separate sentence.
> 
> **`mise run dev:publish`** now installs `entire` and `git-remote-entire` in a loop and prints an **Installed:** line per binary to stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bebe4957d2de61f1bbb0bdf3216623a7dc4ddf22. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->