### PR TITLE
Slight cosmetic tweaks to output

### DIFF
--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -96,7 +96,7 @@ func TestLogin_SavesTokenAfterApproval(t *testing.T) {
 		t.Fatalf("output missing wait message:\n%s", output)
 	}
 
-	if !strings.Contains(output, "login complete.") {
+	if !strings.Contains(output, "Login complete.") {
 		t.Fatalf("output missing login complete message (token save likely failed):\n%s", output)
 	}
 
@@ -142,7 +142,7 @@ func TestLogin_ExpiredFlow(t *testing.T) {
 		t.Fatalf("expected expired message, got:\n%s", output)
 	}
 
-	if strings.Contains(output, "login complete.") {
+	if strings.Contains(output, "Login complete.") {
 		t.Fatal("output should NOT contain login complete for expired flow")
 	}
 }
@@ -181,7 +181,7 @@ func TestLogin_DeniedFlow(t *testing.T) {
 		t.Fatalf("expected denied message, got:\n%s", output)
 	}
 
-	if strings.Contains(output, "login complete.") {
+	if strings.Contains(output, "Login complete.") {
 		t.Fatal("output should NOT contain login complete for denied flow")
 	}
 }

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -96,7 +96,7 @@ func TestLogin_SavesTokenAfterApproval(t *testing.T) {
 		t.Fatalf("output missing wait message:\n%s", output)
 	}
 
-	if !strings.Contains(output, "Login complete.") {
+	if !strings.Contains(output, "login complete.") {
 		t.Fatalf("output missing login complete message (token save likely failed):\n%s", output)
 	}
 
@@ -142,7 +142,7 @@ func TestLogin_ExpiredFlow(t *testing.T) {
 		t.Fatalf("expected expired message, got:\n%s", output)
 	}
 
-	if strings.Contains(output, "Login complete.") {
+	if strings.Contains(output, "login complete.") {
 		t.Fatal("output should NOT contain login complete for expired flow")
 	}
 }
@@ -181,7 +181,7 @@ func TestLogin_DeniedFlow(t *testing.T) {
 		t.Fatalf("expected denied message, got:\n%s", output)
 	}
 
-	if strings.Contains(output, "Login complete.") {
+	if strings.Contains(output, "login complete.") {
 		t.Fatal("output should NOT contain login complete for denied flow")
 	}
 }
@@ -255,8 +255,8 @@ func waitForLoginPrompt(t *testing.T, stdout *bufio.Reader) (string, string) {
 		switch {
 		case strings.HasPrefix(line, "Device code: "):
 			deviceCode = strings.TrimPrefix(line, "Device code: ")
-		case strings.HasPrefix(line, "Approval URL: "):
-			approvalURL = strings.TrimPrefix(line, "Approval URL: ")
+		case strings.HasPrefix(line, "Login URL:"):
+			approvalURL = strings.TrimSpace(strings.TrimPrefix(line, "Login URL:"))
 		}
 
 		if approvalURL != "" && deviceCode != "" {

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -78,7 +78,8 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		// so opening the URL is usually all the user needs to do. The device
 		// code is printed above regardless, so it's still available to confirm
 		// against the page (RFC 8628 §3.3.1) or to enter on the bare-URI fallback.
-		fmt.Fprintf(outW, "Press Enter to open %s in your browser to approve this login...", approvalURL)
+		fmt.Fprintf(outW, "Login URL:   %s\n\n", approvalURL)
+		fmt.Fprintf(outW, "Press Enter to open in browser...")
 
 		// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
 		if err := waitForEnter(ctx); err != nil {
@@ -91,10 +92,10 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 			fmt.Fprintf(outW, "Open this URL in your browser to approve this login: %s\n", approvalURL)
 		}
 	} else {
-		fmt.Fprintf(outW, "Approval URL: %s\n", approvalURL)
+		fmt.Fprintf(outW, "Login URL:   %s\n\n", approvalURL)
 	}
 
-	fmt.Fprintln(outW, "Waiting for approval...")
+	fmt.Fprint(outW, "Waiting for approval... ")
 
 	token, refreshToken, err := waitForApproval(ctx, client, start.DeviceCode, start.ExpiresIn, time.Duration(start.Interval)*time.Second, defaultSlowDownBackoff)
 	if err != nil {
@@ -123,7 +124,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		fmt.Fprintf(errW, "Warning: logged in, but could not record a shareable context (clone via entire:// may need a re-login): %v\n", err)
 	}
 
-	fmt.Fprintln(outW, "Login complete.")
+	fmt.Fprintln(outW, "✅ login complete.")
 	return nil
 }
 

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -124,7 +124,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		fmt.Fprintf(errW, "Warning: logged in, but could not record a shareable context (clone via entire:// may need a re-login): %v\n", err)
 	}
 
-	fmt.Fprintln(outW, "✅ login complete.")
+	fmt.Fprintln(outW, "✓ Login complete.")
 	return nil
 }
 

--- a/mise-tasks/dev/publish
+++ b/mise-tasks/dev/publish
@@ -6,4 +6,12 @@ set -eu
 export GOBIN=${GOPATH:-$HOME/go}/bin
 echo "NOTE: we're overriding \$GOBIN: $GOBIN" 1>&2
 
-go install ./cmd/entire ./cmd/git-remote-entire
+commands=(
+  entire
+  git-remote-entire
+)
+
+for c in "${commands[@]}"; do
+  go install "./cmd/$c"
+  echo "Installed: '$c'" 1>&2
+done


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/496
<!-- entire-trail-link-end -->

# Description

Very small prettification of things that were bothering me:

* `mise run dev:publish` - i use it all the time and i like it when it tells me what it's installed
* The login flow - i found i always had to read twice, because the URL and the "press Enter" prompt blurred together a bit.  Now i think it's very readable:


```shellsession
$ entire login
Device code: 5XXS-2XXB
Login URL:   https://us.auth.entire.io/cli/auth?user_code=5XXS-2XXB

Press Enter to open in browser...

Waiting for approval... ✓ Login complete.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and test assertions only; no auth, token, or polling logic changes.
> 
> **Overview**
> Polishes **`entire login`** CLI output so the device code, login URL, and Enter prompt are easier to scan: renames **Approval URL** to a labeled **`Login URL:`** line (with spacing), shortens the interactive **Press Enter** text, prints **Waiting for approval...** on the same line as the success marker, and ends with **`✅ login complete.`** (lowercase). Integration tests now assert the new strings and parse **`Login URL:`** instead of **`Approval URL:`**.
> 
> **`mise run dev:publish`** installs `entire` and `git-remote-entire` in a loop and prints an **Installed:** line per binary to stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fdfa6befd663090f0bfc69fceaf3f4043ecf3ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->