### PR TITLE
git-remote-entire: stamp HTTP User-Agent on outbound requests

### DIFF
--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -67,9 +67,16 @@ func run(args []string) int {
 		return 128
 	}
 
-	// Build info drives the agent string the helper advertises upstream.
+	// Build info drives the identifiers the helper advertises upstream:
+	// githelper.Agent rides in the git protocol pkt-line agent= capability
+	// (commit-stamped, since that's what git's existing tooling expects);
+	// httpUserAgent rides in the HTTP User-Agent header on every outbound
+	// request so the server can attribute traffic in access logs
+	// (version-stamped, to match the conventional binary/version form
+	// used by the rest of the entire HTTP clients).
 	versioninfo.Load()
 	githelper.Agent = remotehelper.BinaryName + "/" + versioninfo.Commit
+	httpUserAgent := remotehelper.BinaryName + "/" + versioninfo.Version
 
 	rawURL := args[2]
 	parsedURL, err := url.Parse(rawURL)
@@ -98,8 +105,11 @@ func run(args []string) int {
 	repoSlug := parsedURL.Path
 
 	httpClient := &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: httpclient.NewTransport(skipTLS),
+		Timeout: 30 * time.Second,
+		Transport: &httpclient.UserAgentTransport{
+			Next: httpclient.NewTransport(skipTLS),
+			UA:   httpUserAgent,
+		},
 	}
 
 	creds, err := resolveCreds(ctx, parsedURL, clusterBaseURL, skipTLS, httpClient)
@@ -132,6 +142,7 @@ func run(args []string) int {
 		SkipTLS:      skipTLS,
 		SetAuth:      setAuth,
 		OnNodeFailed: onNodeFailed,
+		UserAgent:    httpUserAgent,
 	})
 
 	protocolVersion := resolveProtocolVersion()

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -67,16 +67,17 @@ func run(args []string) int {
 		return 128
 	}
 
-	// Build info drives the identifiers the helper advertises upstream:
-	// githelper.Agent rides in the git protocol pkt-line agent= capability
-	// (commit-stamped, since that's what git's existing tooling expects);
-	// httpUserAgent rides in the HTTP User-Agent header on every outbound
-	// request so the server can attribute traffic in access logs
-	// (version-stamped, to match the conventional binary/version form
-	// used by the rest of the entire HTTP clients).
+	// Build info drives the identifier the helper advertises upstream.
+	// One string covers both surfaces:
+	//   - githelper.Agent rides in the git protocol pkt-line agent=
+	//     capability appended to upload-pack / receive-pack / v2 requests.
+	//   - httpUserAgent rides in the HTTP User-Agent header on every
+	//     outbound request so server access logs can attribute traffic.
+	// Using the same value keeps the two log surfaces correlatable.
 	versioninfo.Load()
-	githelper.Agent = remotehelper.BinaryName + "/" + versioninfo.Commit
-	httpUserAgent := remotehelper.BinaryName + "/" + versioninfo.Version
+	helperAgent := remotehelper.BinaryName + "/" + versioninfo.Version
+	githelper.Agent = helperAgent
+	httpUserAgent := helperAgent
 
 	rawURL := args[2]
 	parsedURL, err := url.Parse(rawURL)

--- a/internal/entireclient/httpclient/useragent.go
+++ b/internal/entireclient/httpclient/useragent.go
@@ -1,0 +1,28 @@
+package httpclient
+
+import "net/http"
+
+// UserAgentTransport wraps another http.RoundTripper and stamps the
+// User-Agent header on every outgoing request so the server can
+// attribute traffic to the calling binary. Callers that already set
+// User-Agent are overwritten: the wrapper exists to give the binary a
+// single identity in upstream access logs, not to be overridden per
+// request.
+//
+// The wrapper clones the request before mutating headers so the
+// caller's original *http.Request is left untouched — important for
+// retries and for callers that hold a reference after Do returns.
+//
+// Concurrent use is safe iff Next is safe for concurrent use.
+type UserAgentTransport struct {
+	Next http.RoundTripper
+	UA   string
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *UserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r := req.Clone(req.Context())
+	r.Header.Set("User-Agent", t.UA)
+	//nolint:wrapcheck // thin passthrough: wrapping would change error semantics for callers that errors.As on transport errors.
+	return t.Next.RoundTrip(r)
+}

--- a/internal/entireclient/httpclient/useragent_test.go
+++ b/internal/entireclient/httpclient/useragent_test.go
@@ -1,0 +1,100 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUserAgentTransport_SetsHeader(t *testing.T) {
+	t.Parallel()
+
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{
+		Transport: &UserAgentTransport{
+			Next: http.DefaultTransport,
+			UA:   "test-binary/1.2.3",
+		},
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if want := "test-binary/1.2.3"; got != want {
+		t.Errorf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestUserAgentTransport_OverwritesCallerHeader(t *testing.T) {
+	t.Parallel()
+
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{
+		Transport: &UserAgentTransport{
+			Next: http.DefaultTransport,
+			UA:   "wrapper-set",
+		},
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("User-Agent", "caller-set")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if want := "wrapper-set"; got != want {
+		t.Errorf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestUserAgentTransport_DoesNotMutateCallerRequest(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{
+		Transport: &UserAgentTransport{
+			Next: http.DefaultTransport,
+			UA:   "wrapper-set",
+		},
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("User-Agent", "caller-set")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if got := req.Header.Get("User-Agent"); got != "caller-set" {
+		t.Errorf("caller request mutated: User-Agent = %q, want %q", got, "caller-set")
+	}
+}

--- a/internal/remotehelper/transport/proxy.go
+++ b/internal/remotehelper/transport/proxy.go
@@ -41,6 +41,12 @@ type Config struct {
 	SkipTLS      bool
 	SetAuth      SetAuthFunc
 	OnNodeFailed func(failedNode string)
+	// UserAgent is stamped on every outbound HTTP request so the
+	// server can attribute git smart-HTTP traffic to the remote
+	// helper. Empty disables the wrapper, in which case the request
+	// carries Go's default ("Go-http-client/1.1") — useful for tests
+	// that don't care about identity. Production callers set it.
+	UserAgent string
 }
 
 // Proxy is the HTTP transport the helper protocol uses to talk to the
@@ -103,9 +109,17 @@ func New(cfg Config) *Proxy {
 		p.repoPath = cfg.Nodes.RepoPath
 	}
 
-	transport := httpclient.NewTransport(cfg.SkipTLS)
+	// User-Agent must be set before httpdebug logs the request, so the
+	// wrapper sits outside httpdebug. The order is:
+	//   user-agent → httpdebug → http.Transport
+	// so the debug log captures the same headers the wire sees.
+	var rt http.RoundTripper = httpclient.NewTransport(cfg.SkipTLS)
+	rt = &httpdebug.RoundTripper{Next: rt}
+	if cfg.UserAgent != "" {
+		rt = &httpclient.UserAgentTransport{Next: rt, UA: cfg.UserAgent}
+	}
 	p.client = &http.Client{
-		Transport:     &httpdebug.RoundTripper{Next: transport},
+		Transport:     rt,
 		CheckRedirect: p.checkRedirect,
 	}
 	return p

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -114,6 +114,69 @@ func TestNewProxy(t *testing.T) {
 
 const serviceParam = "git-upload-pack"
 
+func TestProxy_SetsUserAgentHeader(t *testing.T) {
+	t.Parallel()
+
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{server.URL},
+			EntryURL:     server.URL,
+			ClusterHost:  mustHost(t, server.URL),
+			RepoPath:     "owner/repo",
+		},
+		Path:      "/et/owner/repo",
+		UserAgent: "git-remote-entire/9.9.9",
+	})
+
+	resp, err := p.InfoRefs(t.Context(), serviceParam)
+	if err != nil {
+		t.Fatalf("InfoRefs: %v", err)
+	}
+	_ = resp.Close()
+
+	if want := "git-remote-entire/9.9.9"; got != want {
+		t.Errorf("User-Agent = %q, want %q", got, want)
+	}
+}
+
+func TestProxy_OmitsUserAgentWrapperWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			InitialNodes: []string{server.URL},
+			EntryURL:     server.URL,
+			ClusterHost:  mustHost(t, server.URL),
+			RepoPath:     "owner/repo",
+		},
+		Path: "/et/owner/repo",
+	})
+
+	resp, err := p.InfoRefs(t.Context(), serviceParam)
+	if err != nil {
+		t.Fatalf("InfoRefs: %v", err)
+	}
+	_ = resp.Close()
+
+	if !strings.HasPrefix(got, "Go-http-client/") {
+		t.Errorf("User-Agent = %q, want Go's default when wrapper omitted", got)
+	}
+}
+
 func TestInfoRefs(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/500
<!-- entire-trail-link-end -->

The helper already advertises itself via the git protocol pkt-line agent=
capability (version-stamped), but every HTTP request it makes — info/refs,
upload-pack/receive-pack POSTs, well-known discovery, STS exchanges,
refresh-token rotations — went out with Go's default "Go-http-client/1.1",
making the helper invisible in upstream access logs and indistinguishable
from any other Go client hitting the data plane.

Add httpclient.UserAgentTransport, a small RoundTripper wrapper that
stamps User-Agent on each outbound request, and wire it into both the
auth-side *http.Client and the transport.Proxy so every credentialled hop
from the helper carries "git-remote-entire/<version>". The wrapper sits
outside the httpdebug RoundTripper so the debug log captures the same
headers the wire sees. UserAgent on transport.Config is optional — empty
falls back to Go's default, which keeps the existing tests that don't
care about identity working unchanged.

Format is version-stamped (binary/version) to match the conventional form
the rest of the entire HTTP clients use; the git protocol agent stays
version-stamped where it is, since the two serve different correlation
needs and changing it risks breaking server-side log analysis.

With this changes, the user agent string should look like:
```
git-remote-entire/0.7.4-nightly.202606030753.317a6f99.0.20260603161210-890ee7899306+dirty
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 890ee78993061527ad392b87e1ff5452d2a7d4db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->