### PR TITLE
git-remote-entire: add --version and --help flags

### DIFF
--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -50,6 +51,16 @@ func main() {
 }
 
 func run(args []string) int {
+	// --version / --help only activate as the sole argument. Git always invokes
+	// the helper as `git-remote-entire <remote-name> <url>` (two args), so these
+	// can never collide with a real remote-helper invocation.
+	if len(args) == 2 {
+		if text, ok := infoFlagText(args[1], loadedVersion()); ok {
+			fmt.Fprint(os.Stdout, text)
+			return 0
+		}
+	}
+
 	if len(args) < 3 {
 		fmt.Fprintf(os.Stderr, "usage: %s <remote-name> <url>\n", remotehelper.BinaryName)
 		return 128
@@ -130,6 +141,29 @@ func run(args []string) int {
 		return 128
 	}
 	return 0
+}
+
+// loadedVersion populates the build info and returns the resolved version.
+func loadedVersion() string {
+	versioninfo.Load()
+	return versioninfo.Version
+}
+
+// infoFlagText renders the output for the standalone --version / --help flags,
+// returning false for anything else. Kept pure (version passed in, no globals)
+// so it's unit-testable.
+func infoFlagText(flag, version string) (string, bool) {
+	switch flag {
+	case "--version":
+		return fmt.Sprintf("%s %s\nGo version: %s\nOS/Arch: %s/%s\n",
+			remotehelper.BinaryName, version, runtime.Version(), runtime.GOOS, runtime.GOARCH), true
+	case "--help":
+		return fmt.Sprintf("%s %s\n\n"+
+			"This is a helper which Git calls when encountering entire://... URLs.  "+
+			"For more information see https://github.com/entireio/cli.\n",
+			remotehelper.BinaryName, version), true
+	}
+	return "", false
 }
 
 // resolveProtocolVersion reads the effective protocol.version from

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -51,9 +51,10 @@ func main() {
 }
 
 func run(args []string) int {
-	// --version / --help only activate as the sole argument. Git always invokes
-	// the helper as `git-remote-entire <remote-name> <url>` (two args), so these
-	// can never collide with a real remote-helper invocation.
+	// --version / --help only activate as the sole argument (so os.Args has
+	// length 2). Git always invokes the helper as
+	// `git-remote-entire <remote-name> <url>` (os.Args length 3), so these can
+	// never collide with a real remote-helper invocation.
 	if len(args) == 2 {
 		if text, ok := infoFlagText(args[1], loadedVersion()); ok {
 			fmt.Fprint(os.Stdout, text)

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -15,6 +15,42 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 )
 
+func TestInfoFlagText(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		flag     string
+		want     bool
+		contains []string
+	}{
+		{"version", "--version", true, []string{"git-remote-entire 1.2.3", "Go version:", "OS/Arch:"}},
+		{"help", "--help", true, []string{"git-remote-entire 1.2.3", "entire://", "https://github.com/entireio/cli"}},
+		{"unknown flag", "--nope", false, nil},
+		{"empty", "", false, nil},
+		{"url-like arg", "entire://host/p/r", false, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			text, ok := infoFlagText(tc.flag, "1.2.3")
+			if ok != tc.want {
+				t.Fatalf("infoFlagText(%q) ok = %v, want %v", tc.flag, ok, tc.want)
+			}
+			if !ok {
+				if text != "" {
+					t.Fatalf("expected empty text when not handled, got %q", text)
+				}
+				return
+			}
+			for _, sub := range tc.contains {
+				if !strings.Contains(text, sub) {
+					t.Errorf("infoFlagText(%q) = %q, missing %q", tc.flag, text, sub)
+				}
+			}
+		})
+	}
+}
+
 func TestParseProtocolVersion(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/mise-tasks/build
+++ b/mise-tasks/build
@@ -2,3 +2,4 @@
 #MISE description="Build the CLI"
 
 go build ./cmd/entire
+go build ./cmd/git-remote-entire


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/505
<!-- entire-trail-link-end -->

Adds standalone `--version` and `--help` to the `git-remote-entire` helper. Both only activate as the sole argument — git invokes the helper as `git-remote-entire <remote> <url>`, so no collision.

```
git-remote-entire --version   # version + Go/OS-arch
git-remote-entire --help      # brief description + docs link
```

No cobra; a plain `len(args)==2` guard.

# Why

Slightly more user-friendly if someone wonders "what's this binary they're installing".  Also will help with https://github.com/entireio/entire-upgrade/pull/3 to auto-upgrade `git-remote-entire` alongside `entire`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Informational early-exit paths only; the remote-helper protocol, auth, and transport paths are unchanged when Git invokes the helper normally.
> 
> **Overview**
> Adds standalone **`--version`** and **`--help`** handling to `git-remote-entire` when invoked with exactly one argument after the program name (`len(args) == 2`), so operators can inspect build metadata without starting the remote-helper protocol.
> 
> **`--version`** prints the binary name, build version (via `versioninfo`), Go runtime version, and OS/arch. **`--help`** prints a short description of the `entire://` helper and a link to the CLI repo. Real Git invocations always pass `<remote-name> <url>` (three or more args), so these flags cannot intercept normal helper traffic.
> 
> Rendering lives in a pure **`infoFlagText`** helper (version injected for tests), with new table-driven tests including negative cases (unknown flags, URL-like args). The **`mise-tasks/build`** script now also builds `./cmd/git-remote-entire` alongside the main CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090a1cf1fb978dbfd90c7448d7220b7914e755e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->