### PR TITLE
auth: tab-complete context names for `auth use`

### DIFF
--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -30,7 +30,8 @@ func newAuthUseCmd() *cobra.Command {
 			"Control-plane commands (auth status/list/revoke, org/project/repo/grant) still\n" +
 			"target the configured auth host (ENTIRE_AUTH_BASE_URL / the default), so\n" +
 			"switching to a context on a different login server does not retarget them yet.",
-		Args: cobra.ExactArgs(1),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completeContextNames,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := auth.SetCurrentContext(args[0]); err != nil {
 				return err //nolint:wrapcheck // already a user-facing message
@@ -40,6 +41,34 @@ func newAuthUseCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// completeContextNames is the ValidArgsFunction for commands taking a single
+// <context> positional. It offers the stored context names, each annotated
+// (shell-completion descriptions, after a tab) with handle, core URL, and an
+// "(active)" marker for the current context. Errors are swallowed because
+// completion runs on every TAB press; a failed read just yields no suggestions.
+func completeContextNames(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		// <context> is a single positional; nothing to complete past it.
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	all, current, err := auth.Contexts()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	out := make([]string, 0, len(all))
+	for _, c := range all {
+		desc := c.Handle
+		if c.CoreURL != "" {
+			desc += " " + c.CoreURL
+		}
+		if c.Name == current {
+			desc += " (active)"
+		}
+		out = append(out, c.Name+"\t"+desc)
+	}
+	return out, cobra.ShellCompDirectiveNoFileComp
 }
 
 // warnIfCrossCoreContext warns when the now-active context authenticates

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
+	"github.com/spf13/cobra"
 )
 
 // makeContextJWT builds a JWT-shaped token (non-"none" alg) carrying the
@@ -52,6 +53,74 @@ func TestRunAuthContexts(t *testing.T) {
 	}
 	if !strings.Contains(got, "alice") {
 		t.Fatalf("listing = %q, want handle alice", got)
+	}
+}
+
+func TestCompleteContextNames(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	exp := time.Now().Add(time.Hour).Unix()
+
+	// Two contexts; the second one recorded with activate=true is current.
+	if _, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core-a.example.com","handle":"alice","exp":%d}`, exp)), "", false); err != nil {
+		t.Fatalf("record core-a: %v", err)
+	}
+	currentName, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://core-b.example.com","handle":"bob","exp":%d}`, exp)), "", true)
+	if err != nil {
+		t.Fatalf("record core-b: %v", err)
+	}
+
+	got, directive := completeContextNames(nil, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v, want NoFileComp", directive)
+	}
+	if len(got) != 2 {
+		t.Fatalf("completions = %v, want 2 entries", got)
+	}
+
+	// Each entry is "name\tdescription" carrying handle and core URL; the
+	// active context is annotated "(active)" and no other entry is.
+	var activeCount int
+	for _, entry := range got {
+		name, desc, found := strings.Cut(entry, "\t")
+		if !found {
+			t.Fatalf("entry %q missing tab-separated description", entry)
+		}
+		if name == currentName {
+			if !strings.Contains(desc, "(active)") {
+				t.Fatalf("active entry %q missing (active) marker", entry)
+			}
+			if !strings.Contains(desc, "bob") || !strings.Contains(desc, "core-b.example.com") {
+				t.Fatalf("active entry %q missing handle/core URL", entry)
+			}
+			activeCount++
+		} else if strings.Contains(desc, "(active)") {
+			t.Fatalf("non-active entry %q wrongly marked (active)", entry)
+		}
+	}
+	if activeCount != 1 {
+		t.Fatalf("want exactly one (active) entry, got %d", activeCount)
+	}
+
+	// Past the single positional: nothing to complete.
+	got, directive = completeContextNames(nil, []string{"already"}, "")
+	if got != nil || directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("with an arg present, want (nil, NoFileComp), got (%v, %v)", got, directive)
+	}
+}
+
+func TestCompleteContextNames_NoContexts(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	got, directive := completeContextNames(nil, nil, "")
+	if len(got) != 0 || directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("no contexts: want (empty, NoFileComp), got (%v, %v)", got, directive)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/509
<!-- entire-trail-link-end -->

Tab-completion of stored context names for `entire auth use <context>` — type and press TAB.

Each completion is annotated (zsh/fish) with handle, core URL, and `(active)` for the current context. No behavior change beyond completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only shell completion on local context listing; no change to auth switching or network behavior.
> 
> **Overview**
> Adds **shell tab completion** for `entire auth use <context>` so users can pick a stored login context instead of typing the name manually.
> 
> The `use` command now registers **`completeContextNames`** as its `ValidArgsFunction`. Completion lists context names from local `auth.Contexts()`, disables file completion, and stops once the positional is filled. Each suggestion uses Cobra’s `name\tdescription` form so zsh/fish can show **handle**, **core URL**, and **`(active)`** for the current context; read errors are ignored so a bad TAB doesn’t surface CLI errors.
> 
> **Runtime behavior** of `auth use` is unchanged aside from completion UX.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69fe06fcea251bcaca35a0f65ccbb7b1681b3c56. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->