### PR TITLE
auth: review follow-ups + keyring-safe cli TestMain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ at the canonical group form.
 - `configure`: bare prints help and a hint pointing at `entire agent`; flags
   manage non-agent settings (telemetry, git-hook installation mode, strategy
   options, summary provider). Agent CRUD lives under `entire agent`.
-- `auth`: `login`, `logout`, `status`, `list`, `revoke`
+- `auth`: `login`, `logout`, `status`, `contexts`, `use`. `logout` takes
+  `--everywhere` (revoke every session on the active core, not just the
+  current one) and `--all-contexts` (log out of every saved login)
 - `doctor`: bare runs the scan-and-fix flow, plus `trace`, `logs`, `bundle`
 
 Top-level lifecycle and standalone commands: `enable`, `disable`, `status`,

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -268,7 +268,7 @@ func defaultFetchProfile(ctx context.Context, coreURL, token string) (*authProfi
 
 // defaultListAuthSessions lists the user's active login sessions on coreURL.
 func defaultListAuthSessions(ctx context.Context, coreURL, token string) ([]api.AuthSession, error) {
-	return newAuthSessionsClient(coreURL, token).ListAuthSessions(ctx) //nolint:wrapcheck // ListSessions already wraps with action context
+	return newAuthSessionsClient(coreURL, token).ListAuthSessions(ctx) //nolint:wrapcheck // ListAuthSessions already wraps with action context
 }
 
 // runAuthStatus reports auth state against the target core: GET /me validates

--- a/cmd/entire/cli/global_test.go
+++ b/cmd/entire/cli/global_test.go
@@ -7,9 +7,18 @@ import (
 
 	"github.com/go-git/go-git/v6/x/plugin"
 	"github.com/go-git/go-git/v6/x/plugin/config"
+	"github.com/zalando/go-keyring"
 )
 
 func TestMain(m *testing.M) {
+	// Route the OS keyring to an in-memory mock for the whole package. The
+	// default tokenstore backend is the real OS keychain, so any test that
+	// reaches a credential path without UseFileBackendForTesting — or in the
+	// window after such a test restores the backend — would otherwise read the
+	// developer's real keychain and trigger a macOS unlock prompt. Mirrors the
+	// auth subpackage's TestMain.
+	keyring.MockInit()
+
 	// Register a default ConfigSource so tests that call ConfigScoped
 	// (directly or indirectly via Commit/CreateTag) don't fail with
 	// "no config loader registered".

--- a/cmd/entire/cli/logout.go
+++ b/cmd/entire/cli/logout.go
@@ -20,11 +20,12 @@ type tokenStore interface {
 	DeleteToken(baseURL string) error
 }
 
-// revokeCurrentFunc revokes the CLI's current login session server-side.
-// The caller resolves the active context's core URL + bearer up-front and
-// binds them into the closure, so the revocation hits the same core that
-// `auth status` lists.
-type revokeCurrentFunc func(ctx context.Context) error
+// boundRevokeFunc revokes login session(s) server-side — either just the
+// current session or every session on the core, depending on which the caller
+// selected (--everywhere). The caller resolves the active context's core URL +
+// bearer up-front and binds them into the closure, so the revocation hits the
+// same core that `auth status` lists.
+type boundRevokeFunc func(ctx context.Context) error
 
 // clearContextFunc removes the active contexts.json context (and its
 // keyring token) so logout actually logs out under the contexts model.
@@ -147,7 +148,7 @@ func revokeAllAuthSessions(ctx context.Context, coreURL, token string) error {
 // when --everywhere is set. Either way the local keyring entry and active
 // context are removed, so the CLI reports logged-out even if the server call
 // fails.
-func runLogout(ctx context.Context, outW, errW io.Writer, store tokenStore, revoke revokeCurrentFunc, clearContext clearContextFunc, baseURL string) error {
+func runLogout(ctx context.Context, outW, errW io.Writer, store tokenStore, revoke boundRevokeFunc, clearContext clearContextFunc, baseURL string) error {
 	token, err := store.GetToken(baseURL)
 	if err != nil {
 		// Fall through to the local delete: we still want the keyring entry

--- a/cmd/entire/cli/logout.go
+++ b/cmd/entire/cli/logout.go
@@ -79,15 +79,12 @@ func newLogoutCmd() *cobra.Command {
 					return fmt.Errorf("context login server URL check: %w", err)
 				}
 			}
-			revokeCurrent := func(ctx context.Context) error {
-				return revokeCurrentAuthSession(ctx, target.coreURL, target.token)
-			}
-			revokeAll := func(ctx context.Context) error {
-				return revokeAllAuthSessions(ctx, target.coreURL, target.token)
+			revoke := func(ctx context.Context) error {
+				return revokeForTarget(ctx, target.coreURL, target.token)
 			}
 			if err := runLogout(cmd.Context(), outW, errW,
-				auth.NewContextStore(), revokeCurrent, revokeAll,
-				auth.RemoveCurrentContext, api.AuthBaseURL(), everywhere); err != nil {
+				auth.NewContextStore(), revoke,
+				auth.RemoveCurrentContext, api.AuthBaseURL()); err != nil {
 				return err
 			}
 			promoteNextLogin(outW, errW)
@@ -121,7 +118,7 @@ func promoteNextLogin(outW, errW io.Writer) {
 // revokeCurrentAuthSession revokes the active session on coreURL (the family the
 // bearer belongs to) — the default `entire logout`.
 func revokeCurrentAuthSession(ctx context.Context, coreURL, token string) error {
-	return newAuthSessionsClient(coreURL, token).RevokeCurrentAuthSession(ctx) //nolint:wrapcheck // RevokeCurrentSession already wraps with action context
+	return newAuthSessionsClient(coreURL, token).RevokeCurrentAuthSession(ctx) //nolint:wrapcheck // RevokeCurrentAuthSession already wraps with action context
 }
 
 // revokeAllAuthSessions revokes every active login session on coreURL (the
@@ -130,11 +127,11 @@ func revokeCurrentAuthSession(ctx context.Context, coreURL, token string) error 
 // failure, so one stuck session doesn't strand the rest.
 func revokeAllAuthSessions(ctx context.Context, coreURL, token string) error {
 	client := newAuthSessionsClient(coreURL, token)
-	// ListSessions and RevokeSession already wrap with their own action
+	// ListAuthSessions and RevokeAuthSession already wrap with their own action
 	// context (incl. the session id), so return their errors verbatim.
 	sessions, err := client.ListAuthSessions(ctx)
 	if err != nil {
-		return err //nolint:wrapcheck // ListSessions already wraps with "list sessions"
+		return err //nolint:wrapcheck // ListAuthSessions already wraps with "list sessions"
 	}
 	var firstErr error
 	for _, s := range sessions {
@@ -145,11 +142,12 @@ func revokeAllAuthSessions(ctx context.Context, coreURL, token string) error {
 	return firstErr
 }
 
-// runLogout ends the user's login. revokeCurrent revokes just the active
-// session; revokeAll (used when all is set) revokes every session on the
-// active core. Either way the local keyring entry and active context are
-// removed, so the CLI reports logged-out even if the server call fails.
-func runLogout(ctx context.Context, outW, errW io.Writer, store tokenStore, revokeCurrent, revokeAll revokeCurrentFunc, clearContext clearContextFunc, baseURL string, all bool) error {
+// runLogout ends the user's login. revoke is the caller-selected server-side
+// revocation — just the active session, or every session on the active core
+// when --everywhere is set. Either way the local keyring entry and active
+// context are removed, so the CLI reports logged-out even if the server call
+// fails.
+func runLogout(ctx context.Context, outW, errW io.Writer, store tokenStore, revoke revokeCurrentFunc, clearContext clearContextFunc, baseURL string) error {
 	token, err := store.GetToken(baseURL)
 	if err != nil {
 		// Fall through to the local delete: we still want the keyring entry
@@ -157,10 +155,6 @@ func runLogout(ctx context.Context, outW, errW io.Writer, store tokenStore, revo
 		fmt.Fprintf(errW, "Warning: failed to read token before revocation: %v\n", err)
 	}
 	if token != "" {
-		revoke := revokeCurrent
-		if all {
-			revoke = revokeAll
-		}
 		if err := revoke(ctx); err != nil && !api.IsHTTPErrorStatus(err, http.StatusUnauthorized) {
 			// Best-effort: a transient network error shouldn't block local
 			// logout. A 401 means the token is already invalid server-side,

--- a/cmd/entire/cli/logout_test.go
+++ b/cmd/entire/cli/logout_test.go
@@ -67,7 +67,7 @@ func TestRunLogout_RevokesServerSideThenDeletesLocally(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, func(context.Context) error { return nil }, func() error { return nil }, "https://entire.io", false)
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestRunLogout_NoTokenSkipsRevoke(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, func(context.Context) error { return nil }, func() error { return nil }, "https://entire.io", false)
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestRunLogout_RevokeFailureWarnsButSucceeds(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, func(context.Context) error { return nil }, func() error { return nil }, "https://entire.io", false)
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestRunLogout_RevokeUnauthorizedIsSilent(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, func(context.Context) error { return nil }, func() error { return nil }, "https://entire.io", false)
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestRunLogout_GetTokenErrorWarnsAndFallsThrough(t *testing.T) {
 	}
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, func(context.Context) error { return nil }, func() error { return nil }, "https://entire.io", false)
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestRunLogout_ReturnsErrorOnDeleteFailure(t *testing.T) {
 	revoke := func(context.Context) error { return nil }
 
 	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store, revoke, func(context.Context) error { return nil }, func() error { return nil }, "https://entire.io", false)
+	err := runLogout(context.Background(), &out, &errOut, store, revoke, func() error { return nil }, "https://entire.io")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -219,37 +219,6 @@ func TestRunLogout_ReturnsErrorOnDeleteFailure(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "Logged out.") {
 		t.Fatal("should not print success message when local delete fails")
-	}
-}
-
-func TestRunLogout_AllRevokesAllSessions(t *testing.T) {
-	t.Parallel()
-
-	store := newMockTokenStore()
-	store.tokens["https://entire.io"] = testLogoutToken
-
-	currentCalled, allCalled := false, false
-	revokeCurrent := func(context.Context) error { currentCalled = true; return nil }
-	revokeAll := func(context.Context) error { allCalled = true; return nil }
-
-	var out, errOut bytes.Buffer
-	err := runLogout(context.Background(), &out, &errOut, store,
-		revokeCurrent, revokeAll, func() error { return nil }, "https://entire.io", true)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if currentCalled {
-		t.Error("--everywhere should not call the current-session revoke")
-	}
-	if !allCalled {
-		t.Error("--everywhere should call the revoke-all path")
-	}
-	if !store.deleted["https://entire.io"] {
-		t.Fatal("local token should still be deleted under --everywhere")
-	}
-	if !strings.Contains(out.String(), "Logged out.") {
-		t.Fatalf("stdout = %q, want to contain %q", out.String(), "Logged out.")
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/511
<!-- entire-trail-link-end -->

Follow-ups from review of the (now-merged) auth-context-consolidation work, plus a test-isolation fix.

## Changes

**`auth: review follow-ups` (3eeb08cb6)**
- **CLAUDE.md**: correct the `auth` command surface — `login`/`logout`/`status`/`contexts`/`use` (drop the removed `list`/`revoke`) and document `logout`'s `--everywhere` / `--all-contexts` flags.
- **logout**: `runLogout` now takes a single caller-selected revoke func instead of both `revokeCurrent`+`revokeAll` plus an `all` bool — the command already knows `--everywhere`. Dropped the now-obsolete `TestRunLogout_AllRevokesAllSessions` (selection is covered end-to-end by `TestLogoutCommand_FlagMatrix`) and updated the simple callers.
- Fixed stale method names in `//nolint:wrapcheck` comments left over from the `Session` → `AuthSession` rename.

**`test: mock the OS keyring in the cli package TestMain` (1ea54e2db)**
- The `cli` package's `TestMain` never routed go-keyring to its in-memory mock (unlike the `auth` subpackage). The default tokenstore backend is the real OS keychain, so a `cli` test reaching a credential path without `UseFileBackendForTesting` — or running in the window after such a test restores the global backend — could read the developer's real keychain and trigger a macOS unlock prompt during `mise run test:ci`.
- Calls `keyring.MockInit()` once in `TestMain`, mirroring `cmd/entire/cli/auth`'s `TestMain`, so no `cli` test can touch the real keychain. This closes a latent, pre-existing gap (not introduced by the auth branch).

## Testing
- `go build ./...`, targeted `cli` tests pass
- `mise run fmt` + `mise run lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local CLI auth/logout and test isolation only; behavior for `--everywhere` is unchanged and still covered by the flag-matrix e2e test.
> 
> **Overview**
> **Docs:** `CLAUDE.md` now documents the consolidated `auth` surface (`contexts`, `use`; no `list`/`revoke`) and `logout`’s `--everywhere` / `--all-contexts` flags.
> 
> **Logout refactor:** `runLogout` takes one caller-chosen `revoke` func instead of `revokeCurrent` + `revokeAll` and an `all` bool—the Cobra handler already selects current vs all sessions via `--everywhere`. Unit tests were updated; `TestRunLogout_AllRevokesAllSessions` was removed in favor of `TestLogoutCommand_FlagMatrix`.
> 
> **Tests:** `cli` package `TestMain` calls `keyring.MockInit()` so tests never touch the real OS keychain (avoids macOS unlock prompts). Stale `//nolint:wrapcheck` comments were aligned with `AuthSession` naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea54e2dba178f1ceea3d7c8670668a5ab934325. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->