### PR TITLE
test: make GitTerminalPromptOnIsNotAgent hermetic

### DIFF
--- a/cmd/entire/cli/interactive/interactive_test.go
+++ b/cmd/entire/cli/interactive/interactive_test.go
@@ -62,6 +62,11 @@ func TestIsAgentSubprocessEnv(t *testing.T) {
 // GIT_TERMINAL_PROMPT only counts when explicitly set to "0". Other values
 // (or absence) shouldn't trigger the guard.
 func TestIsAgentSubprocessEnv_GitTerminalPromptOnIsNotAgent(t *testing.T) {
+	// Clear sibling agent-detection vars so the test is hermetic regardless of
+	// parent environment (e.g. running inside pi, gemini-cli, copilot-cli).
+	t.Setenv("GEMINI_CLI", "")
+	t.Setenv("COPILOT_CLI", "")
+	t.Setenv("PI_CODING_AGENT", "")
 	t.Setenv("GIT_TERMINAL_PROMPT", "1")
 	if isAgentSubprocessEnv() {
 		t.Error("isAgentSubprocessEnv() = true; want false when GIT_TERMINAL_PROMPT=1")


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/513
<!-- entire-trail-link-end -->

## Summary
`TestIsAgentSubprocessEnv_GitTerminalPromptOnIsNotAgent` was failing when any of `GEMINI_CLI`, `COPILOT_CLI`, or `PI_CODING_AGENT` were set in the parent environment (common when running tests inside those agent CLIs, including this `pi` harness).

The test only overrode `GIT_TERMINAL_PROMPT` but did not clear the sibling detection variables, so `isAgentSubprocessEnv()` still returned true.

## Fix
Explicitly set the three other agent-detection env vars to empty strings using `t.Setenv` so the test is hermetic regardless of inherited environment.

This is a pure test robustness improvement; no production code changed.

## Testing
- `mise run test -- cmd/entire/cli/interactive` now passes even when `PI_CODING_AGENT=true`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no runtime behavior or security surface affected.
> 
> **Overview**
> Makes `TestIsAgentSubprocessEnv_GitTerminalPromptOnIsNotAgent` **hermetic** by clearing `GEMINI_CLI`, `COPILOT_CLI`, and `PI_CODING_AGENT` with `t.Setenv` before asserting that `GIT_TERMINAL_PROMPT=1` does **not** count as an agent subprocess.
> 
> Without that, inherited agent env vars from the parent shell (e.g. running `go test` inside pi, Gemini, or Copilot) could still make `isAgentSubprocessEnv()` return true and flake the test. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a26779e8838bec634361a8fa986815c1bf2915b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->