### PR TITLE
git-remote-entire: relay helper-status before send-pack exit check

### DIFF
--- a/internal/remotehelper/githelper/invariants_test.go
+++ b/internal/remotehelper/githelper/invariants_test.go
@@ -17,10 +17,14 @@ package githelper
 // and every byte that reached stdout.
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -259,5 +263,72 @@ func TestInvariant_PartialRefBatchAllOrNothing(t *testing.T) {
 	}
 	if !strings.Contains(body, refB) {
 		t.Errorf("POST body missing %q", refB)
+	}
+}
+
+// TestInvariant_HelperStatusSurfacedOnSendPackError: when `git send-pack`
+// exits non-zero on a per-ref rejection (e.g. branch protection, D/F
+// conflict, server hook decline), its buffered `error <ref> <reason>`
+// helper-status lines are what `transport-helper.c` reads to render
+// `! [remote rejected] <ref> (<reason>)`. handlePush must therefore
+// relay helper-status to stdout BEFORE returning the send-pack exit
+// error — relaying only on the success path strips the rejection
+// reason and leaves the user with bare "send-pack exited with error".
+//
+// A shell stub on PATH plays the role of `git send-pack`: it emits the
+// minimal wire shape handlePush expects (empty wrapped request, then
+// trailing flush + helper-status), and exits 1.
+func TestInvariant_HelperStatusSurfacedOnSendPackError(t *testing.T) {
+	// No t.Parallel(): t.Setenv("PATH", ...) mutates process-global state.
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script PATH stub is POSIX-only")
+	}
+
+	ref := testRefMain
+	helperStatusLine := "error " + ref + " remote rejected: branch protection violation\n"
+
+	// Stub git: emits the outer flush that terminates an empty
+	// send-pack request, drains stdin (refspecs + advertisement +
+	// receive-pack response), then emits the trailing flush +
+	// helper-status line, then exits 1. The exit code mirrors
+	// send-pack's behaviour on per-ref rejection.
+	stubDir := t.TempDir()
+	stubPath := filepath.Join(stubDir, "git")
+	stub := "#!/bin/sh\n" +
+		"printf '0000'\n" +
+		"cat > /dev/null\n" +
+		"printf '0000" + helperStatusLine + "'\n" +
+		"exit 1\n"
+	if err := os.WriteFile(stubPath, []byte(stub), 0o755); err != nil {
+		t.Fatalf("writing stub git: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	oldSHA := strings.Repeat("a", 40)
+
+	ft := &fakeTransport{
+		infoRefsResp: func() (io.ReadCloser, error) {
+			return stringRC(serviceAnnouncement(serviceReceivePack,
+				oldSHA+" "+ref+"\x00 report-status\n")), nil
+		},
+		serviceRPCResp: func(string, []byte) (io.ReadCloser, error) {
+			return stringRC(""), nil
+		},
+	}
+
+	// handlePush takes the first "push" line plus a bufio.Reader for
+	// the rest of the batch; readPushBatch terminates on the blank
+	// line.
+	firstLine := "push " + oldSHA + ":" + ref
+	stdin := bufio.NewReader(strings.NewReader("\n"))
+
+	var stdout bytes.Buffer
+	err := handlePush(context.Background(), ft, firstLine, &Options{}, stdin, &stdout)
+	if err == nil {
+		t.Fatal("expected error from send-pack exit 1")
+	}
+	if !strings.Contains(stdout.String(), helperStatusLine) {
+		t.Errorf("stdout missing helper-status line; got %q, want substring %q",
+			stdout.String(), helperStatusLine)
 	}
 }

--- a/internal/remotehelper/githelper/push.go
+++ b/internal/remotehelper/githelper/push.go
@@ -151,6 +151,20 @@ func handlePush(ctx context.Context, t Transport, firstLine string, opts *Option
 		return fmt.Errorf("reading helper-status: %w", err)
 	}
 
+	// Relay helper-status before checking exit codes. send-pack exits
+	// non-zero on per-ref rejections (D/F conflict, protected branch,
+	// hook decline); the buffered `error refs/X <reason>` lines are
+	// what git's transport-helper.c reads to print `! [remote rejected]
+	// refs/X (<reason>)`. Returning early on Wait/feed errors swallowed
+	// them, leaving users with only `send-pack exited with error: exit
+	// status 1`.
+	if _, err := stdout.Write(helperStatus); err != nil {
+		return fmt.Errorf("writing helper-status: %w", err)
+	}
+	if _, err := fmt.Fprintln(stdout); err != nil {
+		return fmt.Errorf("writing push terminator: %w", err)
+	}
+
 	if err := <-feedErr; err != nil {
 		if waitErr := sp.Wait(); waitErr != nil {
 			return errors.Join(err, fmt.Errorf("send-pack exited after feeder error: %w", waitErr))
@@ -159,13 +173,6 @@ func handlePush(ctx context.Context, t Transport, firstLine string, opts *Option
 	}
 	if err := sp.Wait(); err != nil {
 		return fmt.Errorf("send-pack exited with error: %w", err)
-	}
-
-	if _, err := stdout.Write(helperStatus); err != nil {
-		return fmt.Errorf("writing helper-status: %w", err)
-	}
-	if _, err := fmt.Fprintln(stdout); err != nil {
-		return fmt.Errorf("writing push terminator: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/515
<!-- entire-trail-link-end -->

send-pack exits non-zero on per-ref rejections (D/F conflict, protected branch, server hook decline). The buffered `error refs/X <reason>` lines are what git's transport-helper.c reads to render the user-visible `! [remote rejected]` output. Forwarding helper-status only on the happy path meant Wait/feed errors swallowed those lines, leaving users with only `send-pack exited with error: exit status 1`.

Relay helper-status before checking exit codes so the real reason reaches the user. Examples now surfaced:

###  Branch protection violation
```
! [remote rejected]     branch-test -> branch-test (upstream: push declined due to repository rule violations)
  error: failed to push some refs to 'X'
```

###  Invalid ref
```
! [remote rejected]     test-prefix -> test-prefix (ref name conflicts with an existing ref namespace)
  error: failed to push some refs to 'X'
```

###  Permissions:
```
! [remote rejected]   new-test/repo -> new-test/repo (pushing to GitHub: tracing transport: handshake: http transport: authorization failed: unexpected requesting "https://github.com/x/x/info/refs?service=git-receive-pack" status code: 403: Permission to x/x.git denied to <user>.)
  error: failed to push some refs to 'X'
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow reorder in push handling; improves error output without changing auth or pack upload behavior.
> 
> **Overview**
> **Fixes push error reporting** in the Entire git remote helper by **writing `send-pack` helper-status to git before** waiting on the feeder goroutine or `send-pack` exit code.
> 
> When the remote rejects refs (branch rules, bad ref names, auth failures), `send-pack` still emits `error refs/...` lines but exits non-zero. The old order returned on `Wait`/`feedErr` first, so those lines never reached git and users only saw a generic `send-pack exited with error: exit status 1`. Git can now show the usual `! [remote rejected]` messages with the real reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad52a591c1655fbffa2b8a8e699b2579842df43f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->