### PR TITLE
Fix checkpoint/session path-traversal: validate IDs at read/dispatch boundaries

### DIFF
--- a/cmd/entire/cli/agent/agent.go
+++ b/cmd/entire/cli/agent/agent.go
@@ -66,6 +66,15 @@ type Agent interface {
 	GetSessionDir(repoPath string) (string, error)
 
 	// ResolveSessionFile returns the path to the session transcript file.
+	//
+	// SECURITY CONTRACT: agentSessionID is used to build a filesystem path and
+	// some implementations use it as a directory component or (Codex/Pi) return
+	// it verbatim when absolute. Callers that source agentSessionID from
+	// untrusted data (e.g. checkpoint metadata on the shared
+	// entire/checkpoints/v1 branch, hook input) MUST validate it with
+	// validation.ValidateSessionID first. The resume/rewind restore paths do
+	// this at their choke points (transcript.resolveTranscriptPath and
+	// strategy.RestoreLogsOnly); do not call this with unvalidated input.
 	ResolveSessionFile(sessionDir, agentSessionID string) string
 
 	// ReadSession reads session data from agent's storage.

--- a/cmd/entire/cli/agent/claudecode/transcript.go
+++ b/cmd/entire/cli/agent/claudecode/transcript.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
+	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
 
 // TranscriptLine is an alias to the shared transcript.Line type.
@@ -254,8 +255,11 @@ func ExtractSpawnedAgentIDs(transcript []TranscriptLine) map[string]string {
 				}
 			}
 
-			// Look for agentId in the text
-			if agentID := extractAgentIDFromText(textContent); agentID != "" {
+			// Look for agentId in the text. Drop any ID that isn't path-safe:
+			// callers build agent-<id>.jsonl from it and read that file, so this
+			// is the choke point that keeps the path inside subagentsDir,
+			// independent of extractAgentIDFromText's character handling.
+			if agentID := extractAgentIDFromText(textContent); agentID != "" && validation.ValidateAgentID(agentID) == nil {
 				agentIDs[agentID] = block.ToolUseID
 			}
 		}

--- a/cmd/entire/cli/agent/codex/security_contract_test.go
+++ b/cmd/entire/cli/agent/codex/security_contract_test.go
@@ -1,0 +1,31 @@
+package codex
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/validation"
+)
+
+// TestResolveSessionFile_AbsoluteVerbatim_GuardedByValidator pins the security
+// contract for Codex's ResolveSessionFile: an absolute agentSessionID is
+// returned verbatim (a deliberate feature for agent-recorded transcript paths),
+// which makes it a path-traversal footgun if fed untrusted input. Callers that
+// source the ID from untrusted data (checkpoint metadata, hook input) must
+// reject it first via validation.ValidateSessionID.
+//
+// This test fails if either the verbatim behavior changes silently OR the shared
+// validator stops rejecting absolute IDs — i.e. it guards the resume/rewind fix
+// from regressing out from under this agent.
+func TestResolveSessionFile_AbsoluteVerbatim_GuardedByValidator(t *testing.T) {
+	t.Parallel()
+
+	ag := &CodexAgent{}
+	const abs = "/etc/evil.jsonl"
+
+	if got := ag.ResolveSessionFile("/home/u/.codex/sessions", abs); got != abs {
+		t.Fatalf("ResolveSessionFile returned %q, want verbatim %q (behavior change — re-check the validator guard)", got, abs)
+	}
+	if err := validation.ValidateSessionID(abs); err == nil {
+		t.Fatalf("ValidateSessionID(%q) = nil; the validator MUST reject absolute IDs to guard this footgun", abs)
+	}
+}

--- a/cmd/entire/cli/agent/copilotcli/security_contract_test.go
+++ b/cmd/entire/cli/agent/copilotcli/security_contract_test.go
@@ -1,0 +1,41 @@
+package copilotcli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/validation"
+)
+
+// TestResolveSessionFile_DirComponent_GuardedByValidator pins the security
+// contract for Copilot's ResolveSessionFile: it uses agentSessionID as a
+// directory component (<dir>/<id>/events.jsonl). A bare ".." therefore escapes
+// the session directory even though it contains no path separator, so the
+// shared validator must reject it. Callers sourcing the ID from untrusted data
+// must validate first.
+//
+// This test fails if the validator stops rejecting ".." (regressing the
+// resume/rewind guard) or if the layout changes such that the ID is no longer a
+// directory component without a matching guard update.
+func TestResolveSessionFile_DirComponent_GuardedByValidator(t *testing.T) {
+	t.Parallel()
+
+	ag := &CopilotCLIAgent{}
+	sessionDir := "/home/user/.copilot/session-state"
+
+	// A ".." id used as a directory component escapes sessionDir.
+	escaped := ag.ResolveSessionFile(sessionDir, "..")
+	rel, err := filepath.Rel(sessionDir, escaped)
+	if err != nil {
+		t.Fatalf("filepath.Rel(%q, %q) error: %v", sessionDir, escaped, err)
+	}
+	if !strings.HasPrefix(rel, "..") {
+		t.Fatalf("expected %q to escape %q, but it did not (rel=%q)", escaped, sessionDir, rel)
+	}
+
+	// The shared validator is the guard that prevents that id from reaching here.
+	if err := validation.ValidateSessionID(".."); err == nil {
+		t.Fatal(`ValidateSessionID("..") = nil; the validator MUST reject ".." to guard this directory-component footgun`)
+	}
+}

--- a/cmd/entire/cli/agent/factoryaidroid/transcript.go
+++ b/cmd/entire/cli/agent/factoryaidroid/transcript.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
+	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
 
 // TranscriptLine is an alias to the shared transcript.Line type.
@@ -270,8 +271,11 @@ func ExtractSpawnedAgentIDs(transcriptLines []TranscriptLine) map[string]string 
 				}
 			}
 
-			// Look for agentId in the text
-			if agentID := extractAgentIDFromText(textContent); agentID != "" {
+			// Look for agentId in the text. Drop any ID that isn't path-safe:
+			// callers build agent-<id>.jsonl from it and read that file, so this
+			// is the choke point that keeps the path inside subagentsDir,
+			// independent of extractAgentIDFromText's character handling.
+			if agentID := extractAgentIDFromText(textContent); agentID != "" && validation.ValidateAgentID(agentID) == nil {
 				agentIDs[agentID] = block.ToolUseID
 			}
 		}

--- a/cmd/entire/cli/agent/pi/lifecycle.go
+++ b/cmd/entire/cli/agent/pi/lifecycle.go
@@ -15,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
 
 // Hook names — these match Pi's native event names exactly (snake_case),
@@ -286,6 +287,15 @@ func captureTranscript(ctx context.Context, sessionID, piSessionFile string) str
 	if sessionID == "" || piSessionFile == "" {
 		return ""
 	}
+	// sessionID comes from the hook payload (or the locally cached active
+	// session) and is used to build dst below, before the lifecycle dispatcher
+	// validates it. Validate here at the choke point so an unsafe ID cannot
+	// write the transcript outside the cache directory; "" signals no capture.
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		logging.Warn(ctx, "pi: refusing to capture transcript for unsafe session ID",
+			slog.String("session_id", sessionID), slog.String("err", err.Error()))
+		return ""
+	}
 	dir := resolveSessionDir(ctx)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		logging.Warn(ctx, "pi: capture transcript mkdir failed",
@@ -300,7 +310,7 @@ func captureTranscript(ctx context.Context, sessionID, piSessionFile string) str
 			slog.String("src", piSessionFile), slog.String("err", err.Error()))
 		return ""
 	}
-	//nolint:gosec // G703: dst constructed from validated session ID inside .entire/tmp
+	//nolint:gosec // G703: dst is sessionID (validated above) under .entire/tmp/pi
 	if err := os.WriteFile(dst, data, 0o600); err != nil {
 		logging.Warn(ctx, "pi: capture transcript write failed",
 			slog.String("dst", dst), slog.String("err", err.Error()))

--- a/cmd/entire/cli/agent/pi/lifecycle_test.go
+++ b/cmd/entire/cli/agent/pi/lifecycle_test.go
@@ -211,6 +211,41 @@ func TestCaptureTranscript_MissingInputs(t *testing.T) {
 	}
 }
 
+// TestCaptureTranscript_RejectsTraversalSessionID verifies that captureTranscript
+// refuses an unsafe session ID. captureTranscript runs inside ParseHookEvent,
+// before the lifecycle dispatcher validates the ID, so it must guard the
+// transcript write itself — otherwise a "../"-laden ID escapes the cache dir.
+func TestCaptureTranscript_RejectsTraversalSessionID(t *testing.T) {
+	// Cannot use t.Parallel — t.Chdir.
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	src := filepath.Join(dir, "src.jsonl")
+	if err := os.WriteFile(src, []byte("payload\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A sentinel outside the cache dir that the traversal would target.
+	victim := filepath.Join(dir, "victim.json")
+	if err := os.WriteFile(victim, []byte("SAFE"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, bad := range []string{"../victim", "/etc/passwd", "..", "a/b"} {
+		if got := captureTranscript(context.Background(), bad, src); got != "" {
+			t.Errorf("captureTranscript(%q) = %q, want \"\" (unsafe ID must be refused)", bad, got)
+		}
+	}
+
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "SAFE" {
+		t.Errorf("sentinel was overwritten via traversal: %q", string(got))
+	}
+}
+
 func TestGetSupportedHooks(t *testing.T) {
 	t.Parallel()
 	got := (&PiAgent{}).GetSupportedHooks()

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -53,16 +53,27 @@ func DispatchLifecycleEvent(ctx context.Context, ag agent.Agent, event *agent.Ev
 		return errors.New("event cannot be nil")
 	}
 
-	// Reject path-unsafe session IDs once, here, before any handler uses the ID
-	// to build filesystem paths. Handlers historically validated individually,
+	// Reject path-unsafe identifiers once, here, before any handler uses them to
+	// build filesystem paths. Handlers historically validated individually,
 	// which is fragile — handleLifecycleTurnEnd builds .entire/metadata/<id>/
-	// via os.MkdirAll + os.WriteFile without its own check. Centralizing the
-	// guard covers every handler (and any future one) uniformly. Empty IDs pass
-	// through: handlers apply their own empty-handling (e.g. TurnEnd falls back
-	// to a safe constant).
+	// via os.MkdirAll + os.WriteFile, and handleLifecycleSubagentEnd builds a
+	// subagent transcript path from SubagentID and reads it, without their own
+	// checks. Centralizing the guard covers every handler (and any future one)
+	// uniformly. Empty IDs pass through: handlers apply their own empty-handling
+	// (e.g. TurnEnd falls back to a safe constant; SubagentEnd skips the path).
 	if event.SessionID != "" {
 		if err := validation.ValidateSessionID(event.SessionID); err != nil {
 			return fmt.Errorf("invalid session ID in %s event: %w", event.Type, err)
+		}
+	}
+	if event.ToolUseID != "" {
+		if err := validation.ValidateToolUseID(event.ToolUseID); err != nil {
+			return fmt.Errorf("invalid tool use ID in %s event: %w", event.Type, err)
+		}
+	}
+	if event.SubagentID != "" {
+		if err := validation.ValidateAgentID(event.SubagentID); err != nil {
+			return fmt.Errorf("invalid subagent ID in %s event: %w", event.Type, err)
 		}
 	}
 

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -53,6 +53,19 @@ func DispatchLifecycleEvent(ctx context.Context, ag agent.Agent, event *agent.Ev
 		return errors.New("event cannot be nil")
 	}
 
+	// Reject path-unsafe session IDs once, here, before any handler uses the ID
+	// to build filesystem paths. Handlers historically validated individually,
+	// which is fragile — handleLifecycleTurnEnd builds .entire/metadata/<id>/
+	// via os.MkdirAll + os.WriteFile without its own check. Centralizing the
+	// guard covers every handler (and any future one) uniformly. Empty IDs pass
+	// through: handlers apply their own empty-handling (e.g. TurnEnd falls back
+	// to a safe constant).
+	if event.SessionID != "" {
+		if err := validation.ValidateSessionID(event.SessionID); err != nil {
+			return fmt.Errorf("invalid session ID in %s event: %w", event.Type, err)
+		}
+	}
+
 	// Filter forwarded hooks: when Cursor IDE forwards events to both
 	// .cursor/hooks.json and .claude/settings.json, only the agent that owns
 	// the session should process them — otherwise checkpoints, metadata

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -373,6 +373,19 @@ func TestDispatchLifecycleEvent_RejectsTraversalSessionID(t *testing.T) {
 			t.Errorf("%v event: error = %q, want \"invalid session ID\"", evType, err)
 		}
 	}
+
+	// ToolUseID and SubagentID also build filesystem paths (task metadata dir,
+	// subagent transcript path) and must be rejected too.
+	if err := DispatchLifecycleEvent(context.Background(), ag, &agent.Event{
+		Type: agent.SubagentEnd, SessionID: "ok-session", ToolUseID: "../../evil", SessionRef: "/dev/null",
+	}); err == nil || !strings.Contains(err.Error(), "invalid tool use ID") {
+		t.Errorf("traversal tool use ID: error = %v, want \"invalid tool use ID\"", err)
+	}
+	if err := DispatchLifecycleEvent(context.Background(), ag, &agent.Event{
+		Type: agent.SubagentEnd, SessionID: "ok-session", SubagentID: "../../evil", SessionRef: "/dev/null",
+	}); err == nil || !strings.Contains(err.Error(), "invalid subagent ID") {
+		t.Errorf("traversal subagent ID: error = %v, want \"invalid subagent ID\"", err)
+	}
 }
 
 // --- handleLifecycleSessionStart tests ---

--- a/cmd/entire/cli/lifecycle_test.go
+++ b/cmd/entire/cli/lifecycle_test.go
@@ -347,6 +347,34 @@ func TestDispatchLifecycleEvent_UnknownEventType(t *testing.T) {
 	}
 }
 
+// TestDispatchLifecycleEvent_RejectsTraversalSessionID verifies the dispatcher
+// rejects a path-unsafe session ID for every event type, before routing to a
+// handler. This guards handlers that build filesystem paths from the ID without
+// their own check (notably handleLifecycleTurnEnd's .entire/metadata/<id>/
+// MkdirAll + WriteFile). The guard runs before any repo/FS access, so no repo
+// setup is needed.
+func TestDispatchLifecycleEvent_RejectsTraversalSessionID(t *testing.T) {
+	t.Parallel()
+
+	ag := newMockAgent()
+	for _, evType := range []agent.EventType{
+		agent.TurnEnd, agent.ModelUpdate, agent.Compaction, agent.SubagentEnd, agent.SessionEnd,
+	} {
+		err := DispatchLifecycleEvent(context.Background(), ag, &agent.Event{
+			Type:       evType,
+			SessionID:  "../../etc/evil",
+			SessionRef: "/dev/null",
+			Model:      "x",
+		})
+		if err == nil {
+			t.Fatalf("%v event with traversal session ID: got nil error, want rejection", evType)
+		}
+		if !strings.Contains(err.Error(), "invalid session ID") {
+			t.Errorf("%v event: error = %q, want \"invalid session ID\"", evType, err)
+		}
+	}
+}
+
 // --- handleLifecycleSessionStart tests ---
 
 func TestHandleLifecycleSessionStart_EmptySessionID(t *testing.T) {

--- a/cmd/entire/cli/osroot/osroot.go
+++ b/cmd/entire/cli/osroot/osroot.go
@@ -2,23 +2,17 @@
 // (Go 1.24+). These helpers ensure that file operations cannot escape a scoped
 // directory, preventing symlink attacks and TOCTOU races at the kernel level.
 //
-// os.Root supports: Open, OpenFile, Create, Stat, Lstat, Mkdir, Remove, OpenRoot.
-// os.Root does NOT support: MkdirAll, WriteFile, ReadFile, Rename, RemoveAll.
-// For unsupported operations, callers should use standard os functions with
-// lexical validation.
+// These wrappers predate Go 1.25, which added native ReadFile/WriteFile/MkdirAll
+// (etc.) on *os.Root; they remain as the codebase's stable, consistent helper
+// surface and delegate to the native methods where those now exist.
 //
 // Errors from these functions are returned unwrapped so that callers can use
 // os.IsNotExist() and errors.Is() directly without losing the original sentinel.
 package osroot
 
 import (
-	"errors"
 	"io"
-	"io/fs"
 	"os"
-	"path"
-	"path/filepath"
-	"strings"
 )
 
 // ReadFile reads the named file relative to root using os.Root for
@@ -60,29 +54,13 @@ func WriteFile(root *os.Root, name string, data []byte, perm os.FileMode) (retEr
 }
 
 // MkdirAll creates the directory named by name, along with any necessary
-// parents, relative to root. Each level is created with os.Root.Mkdir so the
-// kernel enforces containment: unlike os.MkdirAll, it cannot create directories
-// outside root. A name that escapes root (absolute, or containing ".." segments
-// that climb above root) is rejected by os.Root and returns an error. Already-
-// existing directories are tolerated. name may use either OS-native or forward
-// slashes; an empty or "." name is a no-op.
+// parents, relative to root. The kernel enforces containment: a name that
+// escapes root (absolute, or climbing above it via "..") is rejected. Already-
+// existing directories are tolerated, like os.MkdirAll. This thin wrapper keeps
+// the package's os.Root helper surface (alongside ReadFile/WriteFile/Remove)
+// consistent at call sites.
 func MkdirAll(root *os.Root, name string, perm os.FileMode) error {
-	name = strings.Trim(filepath.ToSlash(name), "/")
-	if name == "" || name == "." {
-		return nil
-	}
-
-	cur := ""
-	for _, part := range strings.Split(name, "/") {
-		if part == "" {
-			continue
-		}
-		cur = path.Join(cur, part)
-		if err := root.Mkdir(cur, perm); err != nil && !errors.Is(err, fs.ErrExist) {
-			return err //nolint:wrapcheck // preserve original error (incl. traversal rejection) for callers
-		}
-	}
-	return nil
+	return root.MkdirAll(name, perm) //nolint:wrapcheck // preserve original error for errors.Is/os.IsNotExist
 }
 
 // Remove removes the named file relative to root using os.Root for

--- a/cmd/entire/cli/osroot/osroot.go
+++ b/cmd/entire/cli/osroot/osroot.go
@@ -12,8 +12,13 @@
 package osroot
 
 import (
+	"errors"
 	"io"
+	"io/fs"
 	"os"
+	"path"
+	"path/filepath"
+	"strings"
 )
 
 // ReadFile reads the named file relative to root using os.Root for
@@ -50,6 +55,32 @@ func WriteFile(root *os.Root, name string, data []byte, perm os.FileMode) (retEr
 
 	if _, err := f.Write(data); err != nil {
 		return err //nolint:wrapcheck // preserve original error
+	}
+	return nil
+}
+
+// MkdirAll creates the directory named by name, along with any necessary
+// parents, relative to root. Each level is created with os.Root.Mkdir so the
+// kernel enforces containment: unlike os.MkdirAll, it cannot create directories
+// outside root. A name that escapes root (absolute, or containing ".." segments
+// that climb above root) is rejected by os.Root and returns an error. Already-
+// existing directories are tolerated. name may use either OS-native or forward
+// slashes; an empty or "." name is a no-op.
+func MkdirAll(root *os.Root, name string, perm os.FileMode) error {
+	name = strings.Trim(filepath.ToSlash(name), "/")
+	if name == "" || name == "." {
+		return nil
+	}
+
+	cur := ""
+	for _, part := range strings.Split(name, "/") {
+		if part == "" {
+			continue
+		}
+		cur = path.Join(cur, part)
+		if err := root.Mkdir(cur, perm); err != nil && !errors.Is(err, fs.ErrExist) {
+			return err //nolint:wrapcheck // preserve original error (incl. traversal rejection) for callers
+		}
 	}
 	return nil
 }

--- a/cmd/entire/cli/osroot/osroot_test.go
+++ b/cmd/entire/cli/osroot/osroot_test.go
@@ -80,18 +80,6 @@ func TestMkdirAll_Idempotent(t *testing.T) {
 	require.NoError(t, osroot.MkdirAll(root, "x/y", 0o755))
 }
 
-func TestMkdirAll_EmptyOrDotIsNoop(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	root, err := os.OpenRoot(dir)
-	require.NoError(t, err)
-	defer root.Close()
-
-	require.NoError(t, osroot.MkdirAll(root, "", 0o755))
-	require.NoError(t, osroot.MkdirAll(root, ".", 0o755))
-}
-
 func TestMkdirAll_TraversalBlocked(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/osroot/osroot_test.go
+++ b/cmd/entire/cli/osroot/osroot_test.go
@@ -52,6 +52,67 @@ func TestReadFile_TraversalBlocked(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestMkdirAll(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	require.NoError(t, osroot.MkdirAll(root, "a/b/c", 0o755))
+
+	info, err := os.Stat(filepath.Join(dir, "a", "b", "c"))
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestMkdirAll_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	require.NoError(t, osroot.MkdirAll(root, "x/y", 0o755))
+	// Creating an existing tree must not error.
+	require.NoError(t, osroot.MkdirAll(root, "x/y", 0o755))
+}
+
+func TestMkdirAll_EmptyOrDotIsNoop(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	require.NoError(t, osroot.MkdirAll(root, "", 0o755))
+	require.NoError(t, osroot.MkdirAll(root, ".", 0o755))
+}
+
+func TestMkdirAll_TraversalBlocked(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	for _, name := range []string{"../escape", "../../escape/deep", "a/../../escape"} {
+		err := osroot.MkdirAll(root, name, 0o755)
+		require.Error(t, err, "MkdirAll(%q) must be rejected", name)
+	}
+
+	// Nothing must have been created outside the root.
+	entries, err := os.ReadDir(outsideDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "no directories should be created outside the root")
+}
+
 func TestWriteFile(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -948,6 +948,82 @@ func TestFindBranchCheckpoint_SquashMergeMultipleCheckpoints(t *testing.T) {
 	}
 }
 
+// TestResumeSingleSession_RejectsPathTraversalSessionID is an end-to-end proof
+// that a malicious session ID cannot cause an arbitrary file write during resume.
+//
+// The checkpoint transcript is stored under a benign session ID; the attack is the
+// session ID that flows into path construction (in production this comes from the
+// remote checkpoint metadata via readCheckpointInfoFromStore). A "../"-laden ID
+// resolves to a path outside the agent's session directory. Before the fix,
+// resumeSingleSession would resolve the path, write the attacker-controlled
+// transcript there, and overwrite the sentinel — RCE if the target is e.g. a
+// shell init file. The fix must reject the ID and write nothing.
+func TestResumeSingleSession_RejectsPathTraversalSessionID(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	repo, _, _ := setupResumeTestRepo(t, tmpDir, false)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".entire"), 0o755); err != nil {
+		t.Fatalf("failed to create settings dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(tmpDir, ".entire", "settings.json"),
+		[]byte(`{"enabled": true}`),
+		0o644,
+	); err != nil {
+		t.Fatalf("failed to write settings: %v", err)
+	}
+
+	ctx := context.Background()
+	cpID := id.MustCheckpointID("dddddddddddd")
+	raw := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"payload"}]}}` + "\n")
+
+	v1Store := checkpoint.NewGitStore(repo)
+	if err := v1Store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "benign-session",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted(raw),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+	}); err != nil {
+		t.Fatalf("failed to write v1 checkpoint: %v", err)
+	}
+
+	sessionDir := filepath.Join(tmpDir, "sessions")
+	ag := &recordingResumeAgent{sessionDir: sessionDir}
+
+	// Sentinel lives outside the session directory; the traversal targets it.
+	// recordingResumeAgent.ResolveSessionFile appends ".jsonl".
+	victimDir := filepath.Join(tmpDir, "victim")
+	if err := os.MkdirAll(victimDir, 0o755); err != nil {
+		t.Fatalf("failed to create victim dir: %v", err)
+	}
+	sentinel := filepath.Join(victimDir, "secret.jsonl")
+	if err := os.WriteFile(sentinel, []byte("SAFE"), 0o600); err != nil {
+		t.Fatalf("failed to write sentinel: %v", err)
+	}
+
+	maliciousSessionID := "../victim/secret"
+
+	var stdout, stderr bytes.Buffer
+	err := resumeSingleSession(ctx, &stdout, &stderr, ag, maliciousSessionID, cpID, tmpDir, true)
+	if err == nil {
+		t.Fatalf("resumeSingleSession() with traversal session ID = nil error, want rejection\nstdout: %s", stdout.String())
+	}
+	if ag.writtenSession != nil {
+		t.Fatalf("resumeSingleSession() wrote a session despite malicious ID: ref=%s", ag.writtenSession.SessionRef)
+	}
+	got, readErr := os.ReadFile(sentinel)
+	if readErr != nil {
+		t.Fatalf("failed to read sentinel: %v", readErr)
+	}
+	if string(got) != "SAFE" {
+		t.Fatalf("sentinel was overwritten via path traversal: %q", string(got))
+	}
+}
+
 func TestResumeSingleSession_UsesV1Transcript(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -533,21 +533,43 @@ func (s *StateStore) Clear(ctx context.Context, sessionID string) error {
 		return fmt.Errorf("invalid session ID: %w", err)
 	}
 
-	// Remove all files for this session (state .json, .model hint, any future hint files).
-	// filepath.Glob finds matches; os.Root ensures traversal-resistant removal.
-	matches, _ := filepath.Glob(filepath.Join(s.stateDir, sessionID+".*")) //nolint:errcheck // pattern is always valid
+	// Remove all files for this session (state .json, .model hint, any future
+	// hint files). Match by literal prefix rather than filepath.Glob: the
+	// session ID is user-controlled, and a glob pattern would let metacharacters
+	// match and delete other sessions' files. os.Root ensures traversal-resistant
+	// removal.
+	matches := matchSessionFiles(s.stateDir, sessionID)
 	if len(matches) > 0 {
 		root, rootErr := os.OpenRoot(s.stateDir)
 		if rootErr != nil {
 			return fmt.Errorf("failed to open session state directory for cleanup: %w", rootErr)
 		}
 		defer root.Close()
-		for _, f := range matches {
-			_ = osroot.Remove(root, filepath.Base(f)) //nolint:errcheck // best-effort cleanup
+		for _, name := range matches {
+			_ = osroot.Remove(root, name) //nolint:errcheck // best-effort cleanup
 		}
 	}
 
 	return nil
+}
+
+// matchSessionFiles returns the names (not paths) of files in dir that belong to
+// the given session ID — i.e. "<sessionID>.<ext>". It uses literal prefix
+// matching, never glob patterns, so a session ID containing glob metacharacters
+// cannot match unrelated files.
+func matchSessionFiles(dir, sessionID string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil // missing/unreadable dir => nothing to clear
+	}
+	prefix := sessionID + "."
+	var matched []string
+	for _, e := range entries {
+		if name := e.Name(); strings.HasPrefix(name, prefix) {
+			matched = append(matched, name)
+		}
+	}
+	return matched
 }
 
 // RemoveAll removes the entire session state directory.

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -478,12 +478,20 @@ func (s *StateStore) Save(ctx context.Context, state *State) error {
 		return fmt.Errorf("failed to create session state directory: %w", err)
 	}
 
+	// Scope the final rename to an os.Root so the session-ID-derived destination
+	// cannot escape the state directory even if validation were ever bypassed
+	// (defense in depth; the ID is already validated above).
+	root, err := os.OpenRoot(s.stateDir)
+	if err != nil {
+		return fmt.Errorf("failed to open session state directory: %w", err)
+	}
+	defer root.Close()
+
 	data, err := jsonutil.MarshalIndentWithNewline(state, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal session state: %w", err)
 	}
 
-	stateFile := s.stateFilePath(state.SessionID)
 	fileName := state.SessionID + ".json"
 
 	// Use a unique temp file per save. Concurrent hook processes can write the
@@ -508,8 +516,8 @@ func (s *StateStore) Save(ctx context.Context, state *State) error {
 		return fmt.Errorf("failed to close session state file: %w", err)
 	}
 
-	// Atomic rename into the validated final path.
-	if err := os.Rename(tmpFileName, stateFile); err != nil {
+	// Atomic rename into the validated final path, via os.Root.
+	if err := root.Rename(filepath.Base(tmpFileName), fileName); err != nil {
 		return fmt.Errorf("failed to rename session state file: %w", err)
 	}
 	removeTmp = false
@@ -582,11 +590,6 @@ func (s *StateStore) List(ctx context.Context) ([]*State, error) {
 		states = append(states, state)
 	}
 	return states, nil
-}
-
-// stateFilePath returns the path to a session state file.
-func (s *StateStore) stateFilePath(sessionID string) string {
-	return filepath.Join(s.stateDir, sessionID+".json")
 }
 
 // gitCommonDirCache caches the git common dir to avoid repeated subprocess calls.

--- a/cmd/entire/cli/state.go
+++ b/cmd/entire/cli/state.go
@@ -638,6 +638,13 @@ func FindActivePreTaskFile(ctx context.Context) (taskToolUseID string, found boo
 // It counts existing checkpoint files in the task metadata checkpoints directory.
 // Returns 1 if no checkpoints exist yet.
 func GetNextCheckpointSequence(sessionID, taskToolUseID string) int {
+	// sessionID/taskToolUseID arrive from agent hook input and are used as path
+	// components below. Reject unsafe values so a crafted "../.." cannot redirect
+	// the os.ReadDir to an arbitrary directory; an invalid ID just starts at 1.
+	if validation.ValidateSessionID(sessionID) != nil || validation.ValidateToolUseID(taskToolUseID) != nil {
+		return 1
+	}
+
 	// Use the session ID directly as the metadata directory name
 	sessionMetadataDir := paths.SessionMetadataDirFromSessionID(sessionID)
 	taskMetadataDir := strategy.TaskMetadataDir(sessionMetadataDir, taskToolUseID)

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -420,7 +420,7 @@ func (s *ManualCommitStrategy) Rewind(ctx context.Context, w, errW io.Writer, po
 		// name (e.g. containing "..") from an untrusted checkpoint cannot create
 		// directories outside the repo. f.Name uses forward slashes (git tree).
 		dir := path.Dir(f.Name)
-		if dir != "." && dir != "" {
+		if dir != "." {
 			if err := osroot.MkdirAll(repoRootHandle, dir, 0o755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", dir, err)
 			}

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -19,6 +19,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
+	"github.com/entireio/cli/cmd/entire/cli/validation"
 
 	"charm.land/huh/v2"
 	"github.com/go-git/go-git/v6"
@@ -691,6 +692,14 @@ func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.W
 			fmt.Fprintf(errW, "  Warning: session %d has no session ID, skipping\n", i)
 			continue
 		}
+		// Checkpoint metadata comes from the shared entire/checkpoints/v1 branch
+		// and is attacker-influenceable. Reject path separators/absolute IDs before
+		// they reach ResolveSessionFile + WriteSession, which would otherwise let a
+		// crafted session ID overwrite files outside the agent session directory.
+		if err := validation.ValidateSessionID(sessionID); err != nil {
+			fmt.Fprintf(errW, "  Warning: session %d has unsafe session ID %q, skipping: %v\n", i, sessionID, err)
+			continue
+		}
 
 		// Resolve per-session agent from metadata — skip if agent is unknown
 		if content.Metadata.Agent == "" {
@@ -842,6 +851,11 @@ func (s *ManualCommitStrategy) classifySessionsForRestore(ctx context.Context, r
 
 		sessionID := content.Metadata.SessionID
 		if sessionID == "" || content.Metadata.Agent == "" {
+			continue
+		}
+		// Skip unsafe session IDs (see RestoreLogsOnly): this path stats the resolved
+		// transcript file, so a crafted ID could otherwise probe arbitrary locations.
+		if validation.ValidateSessionID(sessionID) != nil {
 			continue
 		}
 

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -415,12 +416,12 @@ func (s *ManualCommitStrategy) Rewind(ctx context.Context, w, errW io.Writer, po
 			return fmt.Errorf("failed to read file %s: %w", f.Name, err)
 		}
 
-		// Ensure directory exists (MkdirAll not available on os.Root)
-		absPath := filepath.Join(repoRoot, f.Name)
-		dir := filepath.Dir(absPath)
-		if dir != "." {
-			//nolint:gosec // G301: Need 0o755 for user directories during rewind
-			if err := os.MkdirAll(dir, 0o755); err != nil {
+		// Ensure parent directories exist via os.Root so a crafted tree entry
+		// name (e.g. containing "..") from an untrusted checkpoint cannot create
+		// directories outside the repo. f.Name uses forward slashes (git tree).
+		dir := path.Dir(f.Name)
+		if dir != "." && dir != "" {
+			if err := osroot.MkdirAll(repoRootHandle, dir, 0o755); err != nil {
 				return fmt.Errorf("failed to create directory %s: %w", dir, err)
 			}
 		}

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -640,17 +640,27 @@ func ClearSessionState(ctx context.Context, sessionID string) error {
 		return fmt.Errorf("failed to get session state directory: %w", err)
 	}
 
-	// Remove all files for this session (state .json, .model hint, any future hint files).
-	// filepath.Glob finds matches; os.Root ensures traversal-resistant removal.
-	matches, _ := filepath.Glob(filepath.Join(stateDir, sessionID+".*")) //nolint:errcheck // pattern is always valid
+	// Remove all files for this session (state .json, .model hint, any future
+	// hint files). Match by literal prefix rather than filepath.Glob: the
+	// session ID is user-controlled, and a glob pattern would let metacharacters
+	// match and delete other sessions' files. os.Root ensures traversal-resistant
+	// removal.
+	prefix := sessionID + "."
+	entries, _ := os.ReadDir(stateDir) //nolint:errcheck // best-effort cleanup; missing dir => nothing to clear
+	var matches []string
+	for _, e := range entries {
+		if name := e.Name(); strings.HasPrefix(name, prefix) {
+			matches = append(matches, name)
+		}
+	}
 	if len(matches) > 0 {
 		root, rootErr := os.OpenRoot(stateDir)
 		if rootErr != nil {
 			return fmt.Errorf("failed to open session state directory for cleanup: %w", rootErr)
 		}
 		defer root.Close()
-		for _, f := range matches {
-			_ = osroot.Remove(root, filepath.Base(f)) //nolint:errcheck // best-effort cleanup
+		for _, name := range matches {
+			_ = osroot.Remove(root, name) //nolint:errcheck // best-effort cleanup
 		}
 	}
 

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -17,6 +17,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
@@ -33,6 +34,44 @@ func getSessionStateDir(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return filepath.Join(commonDir, session.SessionStateDirName), nil
+}
+
+// openSessionStateRoot creates the session state directory if needed and returns
+// an os.Root scoped to it. Hint/marker files are named from the (already
+// validated) session ID; routing their writes through os.Root makes escaping
+// the directory impossible at the kernel level even if validation were bypassed.
+// Callers must Close the returned root.
+func openSessionStateRoot(ctx context.Context) (*os.Root, error) {
+	stateDir, err := getSessionStateDir(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session state directory: %w", err)
+	}
+	if err := os.MkdirAll(stateDir, 0o750); err != nil {
+		return nil, fmt.Errorf("failed to create session state directory: %w", err)
+	}
+	root, err := os.OpenRoot(stateDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open session state directory: %w", err)
+	}
+	return root, nil
+}
+
+// openSessionStateRootForRead returns an os.Root scoped to the session state
+// directory without creating it. Returns (nil, nil) when the directory does not
+// exist, so read paths can treat a missing directory as "no hint".
+func openSessionStateRootForRead(ctx context.Context) (*os.Root, error) {
+	stateDir, err := getSessionStateDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+	root, err := os.OpenRoot(stateDir)
+	if os.IsNotExist(err) {
+		return nil, nil //nolint:nilnil // missing dir = no hint; callers handle nil root
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to open session state directory: %w", err)
+	}
+	return root, nil
 }
 
 // sessionStateFile returns the path to a session state file.
@@ -207,16 +246,13 @@ func StoreModelHint(ctx context.Context, sessionID, model string) error {
 		return nil
 	}
 
-	stateDir, err := getSessionStateDir(ctx)
+	root, err := openSessionStateRoot(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get session state directory: %w", err)
+		return err
 	}
-	if err := os.MkdirAll(stateDir, 0o750); err != nil {
-		return fmt.Errorf("failed to create session state directory: %w", err)
-	}
+	defer root.Close()
 
-	hintFile := filepath.Join(stateDir, sessionID+".model")
-	if err := os.WriteFile(hintFile, []byte(model), 0o600); err != nil {
+	if err := osroot.WriteFile(root, sessionID+".model", []byte(model), 0o600); err != nil {
 		return fmt.Errorf("failed to write model hint file: %w", err)
 	}
 	return nil
@@ -229,20 +265,23 @@ func LoadModelHint(ctx context.Context, sessionID string) string {
 		return ""
 	}
 
-	stateDir, err := getSessionStateDir(ctx)
+	root, err := openSessionStateRootForRead(ctx)
 	if err != nil {
 		logging.Warn(logging.WithComponent(ctx, "session"), "failed to resolve state dir for model hint",
 			slog.String("session_id", sessionID),
 			slog.Any("error", err))
 		return ""
 	}
+	if root == nil {
+		return ""
+	}
+	defer root.Close()
 
-	hintPath := filepath.Join(stateDir, sessionID+".model")
-	data, err := os.ReadFile(hintPath) //nolint:gosec // sessionID is validated above
+	data, err := osroot.ReadFile(root, sessionID+".model")
 	if err != nil {
 		if !os.IsNotExist(err) {
 			logging.Warn(logging.WithComponent(ctx, "session"), "failed to read model hint file",
-				slog.String("path", hintPath),
+				slog.String("session_id", sessionID),
 				slog.Any("error", err))
 		}
 		return ""
@@ -279,16 +318,13 @@ func StoreAgentTypeHint(ctx context.Context, sessionID string, agentType types.A
 		return false, nil
 	}
 
-	stateDir, sErr := getSessionStateDir(ctx)
-	if sErr != nil {
-		return false, fmt.Errorf("failed to get session state directory: %w", sErr)
+	root, rErr := openSessionStateRoot(ctx)
+	if rErr != nil {
+		return false, rErr
 	}
-	if mErr := os.MkdirAll(stateDir, 0o750); mErr != nil {
-		return false, fmt.Errorf("failed to create session state directory: %w", mErr)
-	}
+	defer root.Close()
 
-	hintFile := filepath.Join(stateDir, sessionID+".agent")
-	f, oErr := os.OpenFile(hintFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // hintFile path is built from validated sessionID
+	f, oErr := root.OpenFile(sessionID+".agent", os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if oErr != nil {
 		if errors.Is(oErr, os.ErrExist) {
 			// First-writer-wins: another caller already claimed this session.
@@ -320,16 +356,13 @@ func ClaimSessionStartBanner(ctx context.Context, sessionID string) (claimed boo
 		return false, fmt.Errorf("invalid session ID: %w", vErr)
 	}
 
-	stateDir, sErr := getSessionStateDir(ctx)
-	if sErr != nil {
-		return false, fmt.Errorf("failed to get session state directory: %w", sErr)
+	root, rErr := openSessionStateRoot(ctx)
+	if rErr != nil {
+		return false, rErr
 	}
-	if mErr := os.MkdirAll(stateDir, 0o750); mErr != nil {
-		return false, fmt.Errorf("failed to create session state directory: %w", mErr)
-	}
+	defer root.Close()
 
-	markerFile := filepath.Join(stateDir, sessionID+".banner")
-	f, oErr := os.OpenFile(markerFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // markerFile path is built from validated sessionID
+	f, oErr := root.OpenFile(sessionID+".banner", os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if oErr != nil {
 		if errors.Is(oErr, os.ErrExist) {
 			return false, nil
@@ -348,20 +381,23 @@ func LoadAgentTypeHint(ctx context.Context, sessionID string) types.AgentType {
 		return ""
 	}
 
-	stateDir, err := getSessionStateDir(ctx)
+	root, err := openSessionStateRootForRead(ctx)
 	if err != nil {
 		logging.Warn(logging.WithComponent(ctx, "session"), "failed to resolve state dir for agent hint",
 			slog.String("session_id", sessionID),
 			slog.Any("error", err))
 		return ""
 	}
+	if root == nil {
+		return ""
+	}
+	defer root.Close()
 
-	hintPath := filepath.Join(stateDir, sessionID+".agent")
-	data, err := os.ReadFile(hintPath) //nolint:gosec // sessionID is validated above
+	data, err := osroot.ReadFile(root, sessionID+".agent")
 	if err != nil {
 		if !os.IsNotExist(err) {
 			logging.Warn(logging.WithComponent(ctx, "session"), "failed to read agent hint file",
-				slog.String("path", hintPath),
+				slog.String("session_id", sessionID),
 				slog.Any("error", err))
 		}
 		return ""
@@ -605,9 +641,17 @@ func ClearSessionState(ctx context.Context, sessionID string) error {
 	}
 
 	// Remove all files for this session (state .json, .model hint, any future hint files).
+	// filepath.Glob finds matches; os.Root ensures traversal-resistant removal.
 	matches, _ := filepath.Glob(filepath.Join(stateDir, sessionID+".*")) //nolint:errcheck // pattern is always valid
-	for _, f := range matches {
-		_ = os.Remove(f)
+	if len(matches) > 0 {
+		root, rootErr := os.OpenRoot(stateDir)
+		if rootErr != nil {
+			return fmt.Errorf("failed to open session state directory for cleanup: %w", rootErr)
+		}
+		defer root.Close()
+		for _, f := range matches {
+			_ = osroot.Remove(root, filepath.Base(f)) //nolint:errcheck // best-effort cleanup
+		}
 	}
 
 	// Intentionally do NOT remove the per-session lock file under

--- a/cmd/entire/cli/transcript.go
+++ b/cmd/entire/cli/transcript.go
@@ -14,11 +14,21 @@ import (
 	agentpkg "github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/transcript"
+	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
 
 // resolveTranscriptPath determines the correct file path for an agent's session transcript.
 // Computes the path dynamically from the current repo location for cross-machine portability.
 func resolveTranscriptPath(ctx context.Context, sessionID string, agent agentpkg.Agent) (string, error) {
+	// Session IDs reaching this restore path can originate from checkpoint
+	// metadata on the shared entire/checkpoints/v1 branch, which is attacker-
+	// influenceable. Reject path separators/absolute paths before they reach
+	// agent.ResolveSessionFile (some agents return absolute IDs verbatim),
+	// preventing transcript writes outside the agent session directory.
+	if err := validation.ValidateSessionID(sessionID); err != nil {
+		return "", fmt.Errorf("invalid session ID for transcript path: %w", err)
+	}
+
 	repoRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get worktree root: %w", err)

--- a/cmd/entire/cli/transcript_test.go
+++ b/cmd/entire/cli/transcript_test.go
@@ -1,10 +1,72 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// TestResolveTranscriptPath_RejectsTraversalSessionID verifies that session IDs
+// containing path-traversal primitives are rejected before being used to build a
+// filesystem write path.
+//
+// Session IDs reaching the resume/rewind restore paths originate from checkpoint
+// metadata stored on the shared entire/checkpoints/v1 branch, which an attacker
+// with push access can craft. Without validation, an absolute or "../"-laden
+// session ID escapes the agent session directory (and for agents like Pi/Codex
+// that return absolute paths verbatim, lands anywhere), letting attacker-controlled
+// transcript bytes overwrite arbitrary files such as ~/.bashrc.
+func TestResolveTranscriptPath_RejectsTraversalSessionID(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupResumeTestRepo(t, tmpDir, false)
+	t.Chdir(tmpDir)
+
+	ag := &recordingResumeAgent{sessionDir: filepath.Join(tmpDir, "sessions")}
+	ctx := context.Background()
+
+	cases := []struct {
+		name      string
+		sessionID string
+	}{
+		{"absolute unix path", "/tmp/entire-pwned"},
+		{"absolute path to dotfile", filepath.Join(tmpDir, "victim", ".bashrc")},
+		{"parent traversal", "../../../../../../tmp/entire-pwned"},
+		{"backslash traversal", `..\..\..\evil`},
+		{"embedded separator", "sessions/../../evil"},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveTranscriptPath(ctx, tc.sessionID, ag)
+			if err == nil {
+				t.Fatalf("resolveTranscriptPath(%q) = %q, want error (traversal must be rejected)", tc.sessionID, got)
+			}
+		})
+	}
+}
+
+// TestResolveTranscriptPath_AllowsLegitSessionID is the regression guard ensuring
+// the traversal check does not reject ordinary (UUID-style) session IDs.
+func TestResolveTranscriptPath_AllowsLegitSessionID(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupResumeTestRepo(t, tmpDir, false)
+	t.Chdir(tmpDir)
+
+	sessionDir := filepath.Join(tmpDir, "sessions")
+	ag := &recordingResumeAgent{sessionDir: sessionDir}
+	ctx := context.Background()
+
+	sessionID := "11111111-2222-3333-4444-555555555555"
+	got, err := resolveTranscriptPath(ctx, sessionID, ag)
+	if err != nil {
+		t.Fatalf("resolveTranscriptPath(%q) unexpected error: %v", sessionID, err)
+	}
+	want := filepath.Join(sessionDir, sessionID+".jsonl")
+	if got != want {
+		t.Fatalf("resolveTranscriptPath(%q) = %q, want %q", sessionID, got, want)
+	}
+}
 
 func createTempTranscript(t *testing.T, content string) string {
 	t.Helper()

--- a/cmd/entire/cli/validation/validators.go
+++ b/cmd/entire/cli/validation/validators.go
@@ -5,6 +5,7 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -22,6 +23,16 @@ func ValidateSessionID(id string) error {
 	}
 	if strings.ContainsAny(id, "/\\") {
 		return fmt.Errorf("invalid session ID %q: contains path separators", id)
+	}
+	// A bare "." or ".." is separator-free but still traverses when used as a
+	// path segment (e.g. an agent that uses the ID as a directory component).
+	if id == "." || id == ".." {
+		return fmt.Errorf("invalid session ID %q: reserved path segment", id)
+	}
+	// Defense in depth against platform-specific absolute forms (e.g. Windows
+	// drive paths) that the separator check above may not catch.
+	if filepath.IsAbs(id) {
+		return fmt.Errorf("invalid session ID %q: must not be an absolute path", id)
 	}
 	return nil
 }

--- a/cmd/entire/cli/validation/validators.go
+++ b/cmd/entire/cli/validation/validators.go
@@ -29,6 +29,19 @@ func ValidateSessionID(id string) error {
 	if id == "." || id == ".." {
 		return fmt.Errorf("invalid session ID %q: reserved path segment", id)
 	}
+	// Reject the Windows volume separator. A drive-relative path like "C:foo" is
+	// separator-free and filepath.IsAbs reports it as non-absolute, yet
+	// filepath.Join discards the base directory when the appended element
+	// carries a volume name — escaping the intended directory on Windows.
+	if strings.Contains(id, ":") {
+		return fmt.Errorf("invalid session ID %q: contains volume separator", id)
+	}
+	// Reject glob metacharacters. Session IDs are interpolated into
+	// filepath.Glob patterns in several places (agent transcript lookup,
+	// session-state cleanup); "*"/"?"/"[" could match and act on unrelated files.
+	if strings.ContainsAny(id, "*?[") {
+		return fmt.Errorf("invalid session ID %q: contains glob metacharacters", id)
+	}
 	// Defense in depth against platform-specific absolute forms (e.g. Windows
 	// drive paths) that the separator check above may not catch.
 	if filepath.IsAbs(id) {

--- a/cmd/entire/cli/validation/validators.go
+++ b/cmd/entire/cli/validation/validators.go
@@ -44,7 +44,7 @@ func ValidateSessionID(id string) error {
 	}
 	// Defense in depth against platform-specific absolute forms (e.g. Windows
 	// drive paths) that the separator check above may not catch.
-	if filepath.IsAbs(id) {
+	if filepath.IsAbs(id) || filepath.VolumeName(id) != "" {
 		return fmt.Errorf("invalid session ID %q: must not be an absolute path", id)
 	}
 	return nil

--- a/cmd/entire/cli/validation/validators_test.go
+++ b/cmd/entire/cli/validation/validators_test.go
@@ -90,6 +90,32 @@ func TestValidateSessionID(t *testing.T) {
 			sessionID: "a..b",
 			wantErr:   false,
 		},
+		// Windows drive-relative path (separator-free, not reported absolute)
+		{
+			name:      "windows drive-relative path",
+			sessionID: "C:foo",
+			wantErr:   true,
+			errMsg:    "volume separator",
+		},
+		// Glob metacharacters (would match unrelated files when used in a pattern)
+		{
+			name:      "glob star",
+			sessionID: "*",
+			wantErr:   true,
+			errMsg:    "glob metacharacters",
+		},
+		{
+			name:      "glob question mark",
+			sessionID: "sess?on",
+			wantErr:   true,
+			errMsg:    "glob metacharacters",
+		},
+		{
+			name:      "glob bracket",
+			sessionID: "a[bc]d",
+			wantErr:   true,
+			errMsg:    "glob metacharacters",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/entire/cli/validation/validators_test.go
+++ b/cmd/entire/cli/validation/validators_test.go
@@ -72,6 +72,24 @@ func TestValidateSessionID(t *testing.T) {
 			wantErr:   true,
 			errMsg:    "contains path separators",
 		},
+		// Bare path segments (separator-free but still traverse as a path component)
+		{
+			name:      "single dot",
+			sessionID: ".",
+			wantErr:   true,
+			errMsg:    "reserved path segment",
+		},
+		{
+			name:      "double dot",
+			sessionID: "..",
+			wantErr:   true,
+			errMsg:    "reserved path segment",
+		},
+		{
+			name:      "dot in the middle is allowed",
+			sessionID: "a..b",
+			wantErr:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/512
<!-- entire-trail-link-end -->

## Summary

Closes a path-traversal / arbitrary-file-write class across the checkpoint, session, and agent-lifecycle paths. The root issue: identifiers read from the shared `entire/checkpoints/v1` branch (attacker-influenceable) or from agent hook input flowed into filesystem paths without validation at the read/restore boundary.

**Original vulnerability:** `entire session resume` / `entire checkpoint rewind` used the metadata `SessionID` to build the transcript write path with no validation. A crafted absolute or `../`-laden session ID (or, for Codex/Pi, an absolute ID returned verbatim) let attacker-controlled transcript bytes overwrite arbitrary files (e.g. `~/.bashrc`) → RCE on the next resume, with no prompt.

## What changed (11 commits)

**Core fix**
- Validate session IDs at the two restore choke points (`resolveTranscriptPath`, `RestoreLogsOnly`) before any path construction.

**Validator hardening**
- `ValidateSessionID` now also rejects `.`, `..`, and absolute paths (closes the bare-`..` dir-component vector and the Windows drive edge).

**Lifecycle dispatch (right altitude)**
- Validate `SessionID`, `ToolUseID`, and `SubagentID` once in `DispatchLifecycleEvent`, before routing — so no handler (e.g. `handleLifecycleTurnEnd`'s `.entire/metadata/<id>/` write, `handleLifecycleSubagentEnd`'s subagent-transcript read) can forget.

**os.Root containment (defense in depth)**
- Rewind working-tree restore creates dirs via new `osroot.MkdirAll` (kernel-enforced containment), matching the already-rooted file write.
- `.git/entire-sessions/` writes (state Save + hint/marker files) scoped to `os.Root`.

**Other boundaries**
- Pi `captureTranscript` validates before writing.
- `GetNextCheckpointSequence` (posttodo hook) validates before the directory read.
- `ExtractSpawnedAgentIDs` (claudecode + factoryaidroid) drops non-path-safe subagent IDs, so `agent-<id>.jsonl` reads are path-safe by construction.
- Documented the `ResolveSessionFile` security contract on the `Agent` interface + Codex/Copilot contract regression tests.

## Audit results
- **All `CommittedMetadata` fields read from checkpoints** were traced: `CheckpointID` (12-hex at unmarshal) and `InvestigateRunID` (`validateRunID`) are validated at read; every other field is display/logic-only. `ToolUseID` has a write/read validation asymmetry but no live read→path sink.
- **All `os.WriteFile`/`Open`/`OpenFile`/`Rename`/`Symlink`/`Create` sinks** were swept: every attacker-influenceable path is now validated, hash-derived, or os.Root-contained.

## Testing
- New regression tests at each boundary (resume/rewind, dispatcher, Pi, osroot, validators, agent contracts).
- `mise run check` green (fmt + lint + unit + integration + Vogon canary). 388 integration tests pass; all touched packages lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-adjacent filesystem behavior (resume/rewind transcript writes, lifecycle metadata paths) using attacker-influenceable checkpoint metadata; mistakes could break legitimate sessions or leave traversal gaps.
> 
> **Overview**
> This PR closes a **path-traversal / arbitrary-file-write** class of bugs where **session, tool-use, and subagent IDs** from **checkpoint metadata** (`entire/checkpoints/v1`) or **agent hooks** were joined into filesystem paths without checks—enabling crafted IDs to overwrite files outside agent/session directories (e.g. on **resume** or **rewind**).
> 
> **Validation** is tightened at read/dispatch boundaries: `ValidateSessionID` now rejects `.`, `..`, and absolute paths; **`DispatchLifecycleEvent`** validates `SessionID`, `ToolUseID`, and `SubagentID` once before any handler; restore paths **`resolveTranscriptPath`** and **`RestoreLogsOnly`** reject unsafe IDs from metadata; Pi **`captureTranscript`**, **`GetNextCheckpointSequence`**, and subagent ID extraction (**Claude Code / Factory Droid**) add matching guards. The **`ResolveSessionFile`** security contract is documented, with **Codex/Copilot** contract tests.
> 
> **Defense in depth**: rewind working-tree restore uses **`osroot.MkdirAll`** under a repo `os.Root`; **`.git/entire-sessions/`** state save, hints, markers, and cleanup route through **`os.Root`**. Regression tests cover resume, dispatcher, Pi, osroot, and validators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98f8e37c4e75ae036f3964e0d0ac1f23da8dc053. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->