### PR TITLE
login: default to browser sign-in, add --device fallback

### DIFF
--- a/cmd/entire/cli/auth/client.go
+++ b/cmd/entire/cli/auth/client.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/entireio/auth-go/authcode"
 	"github.com/entireio/auth-go/deviceflow"
 	"github.com/entireio/auth-go/tokens"
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -41,7 +42,8 @@ type DeviceAuthPoll struct {
 // (ENTIRE_AUTH_PROVIDER_VERSION wins, then split-host auto-detect,
 // then v1 fallback).
 type Client struct {
-	inner *deviceflow.Client
+	inner   *deviceflow.Client
+	browser *authcode.Client
 }
 
 // NewClient constructs a Client targeting the active provider version.
@@ -61,20 +63,85 @@ func NewClient(httpClient *http.Client, allowInsecureHTTP bool) *Client {
 	if httpClient != nil {
 		transport = httpClient.Transport
 	}
-	return &Client{inner: &deviceflow.Client{
-		Transport: transport,
-		BaseURL:   issuer,
-		ClientID:  p.ClientID,
-		// offline_access asks the authorization server for a refresh token.
-		// The server only mints one when it's requested (it's client-gated),
-		// so without this the device login is access-token-only and silent
-		// refresh is impossible.
-		Scope:             "cli offline_access",
-		UserAgent:         p.ClientID,
-		DeviceCodePath:    p.DeviceCodePath,
-		TokenPath:         p.TokenPath,
-		AllowInsecureHTTP: allowInsecureHTTP || isLoopbackHTTP(issuer),
-	}}
+	// offline_access asks the authorization server for a refresh token.
+	// The server only mints one when it's requested (it's client-gated),
+	// so without this the login is access-token-only and silent refresh is
+	// impossible. Both flows request it identically.
+	const scope = "cli offline_access"
+	allowHTTP := allowInsecureHTTP || isLoopbackHTTP(issuer)
+	return &Client{
+		inner: &deviceflow.Client{
+			Transport:         transport,
+			BaseURL:           issuer,
+			ClientID:          p.ClientID,
+			Scope:             scope,
+			UserAgent:         p.ClientID,
+			DeviceCodePath:    p.DeviceCodePath,
+			TokenPath:         p.TokenPath,
+			AllowInsecureHTTP: allowHTTP,
+		},
+		browser: &authcode.Client{
+			Transport:         transport,
+			BaseURL:           issuer,
+			ClientID:          p.ClientID,
+			Scope:             scope,
+			UserAgent:         p.ClientID,
+			AuthorizePath:     p.AuthorizePath,
+			TokenPath:         p.TokenPath,
+			AllowInsecureHTTP: allowHTTP,
+		},
+	}
+}
+
+// BrowserAuthFlow is one in-progress loopback authorization-code login.
+// It wraps an authcode.Flow so login.go can depend on a small interface
+// (and fake it in tests) rather than the concrete library type that owns
+// a live loopback listener.
+type BrowserAuthFlow interface {
+	// AuthorizationURL is the URL to open in the user's browser.
+	AuthorizationURL() string
+	// Wait blocks until the browser is redirected to the loopback
+	// listener, returning the authorization code.
+	Wait(ctx context.Context) (code string, err error)
+	// Exchange redeems code for access + refresh tokens.
+	Exchange(ctx context.Context, code string) (accessToken, refreshToken string, err error)
+	// Close tears down the loopback listener. Safe to call after Wait.
+	Close() error
+}
+
+// browserAuthFlow adapts *authcode.Flow to BrowserAuthFlow, flattening the
+// TokenSet to the (access, refresh) pair login.go persists — mirroring how
+// PollDeviceAuth flattens the device-flow result.
+type browserAuthFlow struct {
+	inner *authcode.Flow
+}
+
+func (f *browserAuthFlow) AuthorizationURL() string { return f.inner.AuthorizationURL }
+
+func (f *browserAuthFlow) Wait(ctx context.Context) (string, error) {
+	return f.inner.Wait(ctx) //nolint:wrapcheck // shim preserves the lib's wrapped errors verbatim for errors.Is
+}
+
+func (f *browserAuthFlow) Exchange(ctx context.Context, code string) (string, string, error) {
+	ts, err := f.inner.Exchange(ctx, code)
+	if err != nil {
+		return "", "", err //nolint:wrapcheck // shim returns authcode errors verbatim so callers can errors.Is on sentinels
+	}
+	return ts.AccessToken, ts.RefreshToken, nil
+}
+
+func (f *browserAuthFlow) Close() error {
+	return f.inner.Close() //nolint:wrapcheck // shutdown error is best-effort; caller logs at most
+}
+
+// StartBrowserAuth begins the loopback authorization-code flow: it binds a
+// local listener and returns a flow carrying the browser URL to open.
+func (c *Client) StartBrowserAuth(ctx context.Context) (BrowserAuthFlow, error) {
+	f, err := c.browser.Start(ctx)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // shim returns authcode errors verbatim so callers can errors.Is on sentinels
+	}
+	return &browserAuthFlow{inner: f}, nil
 }
 
 // BaseURL returns the issuer base URL this client talks to.

--- a/cmd/entire/cli/auth/client.go
+++ b/cmd/entire/cli/auth/client.go
@@ -93,36 +93,26 @@ func NewClient(httpClient *http.Client, allowInsecureHTTP bool) *Client {
 	}
 }
 
-// BrowserAuthFlow is one in-progress loopback authorization-code login.
-// It wraps an authcode.Flow so login.go can depend on a small interface
-// (and fake it in tests) rather than the concrete library type that owns
-// a live loopback listener.
-type BrowserAuthFlow interface {
-	// AuthorizationURL is the URL to open in the user's browser.
-	AuthorizationURL() string
-	// Wait blocks until the browser is redirected to the loopback
-	// listener, returning the authorization code.
-	Wait(ctx context.Context) (code string, err error)
-	// Exchange redeems code for access + refresh tokens.
-	Exchange(ctx context.Context, code string) (accessToken, refreshToken string, err error)
-	// Close tears down the loopback listener. Safe to call after Wait.
-	Close() error
-}
-
-// browserAuthFlow adapts *authcode.Flow to BrowserAuthFlow, flattening the
-// TokenSet to the (access, refresh) pair login.go persists — mirroring how
-// PollDeviceAuth flattens the device-flow result.
-type browserAuthFlow struct {
+// BrowserAuthFlow is one in-progress loopback authorization-code login. It
+// wraps an authcode.Flow, flattening the TokenSet to the (access, refresh)
+// pair login.go persists — mirroring how PollDeviceAuth flattens the
+// device-flow result. login.go depends on a small local interface that this
+// concrete type satisfies, so it can fake the flow in tests.
+type BrowserAuthFlow struct {
 	inner *authcode.Flow
 }
 
-func (f *browserAuthFlow) AuthorizationURL() string { return f.inner.AuthorizationURL }
+// AuthorizationURL is the URL to open in the user's browser.
+func (f *BrowserAuthFlow) AuthorizationURL() string { return f.inner.AuthorizationURL }
 
-func (f *browserAuthFlow) Wait(ctx context.Context) (string, error) {
+// Wait blocks until the browser is redirected to the loopback listener,
+// returning the authorization code.
+func (f *BrowserAuthFlow) Wait(ctx context.Context) (string, error) {
 	return f.inner.Wait(ctx) //nolint:wrapcheck // shim preserves the lib's wrapped errors verbatim for errors.Is
 }
 
-func (f *browserAuthFlow) Exchange(ctx context.Context, code string) (string, string, error) {
+// Exchange redeems code for access + refresh tokens.
+func (f *BrowserAuthFlow) Exchange(ctx context.Context, code string) (accessToken, refreshToken string, err error) {
 	ts, err := f.inner.Exchange(ctx, code)
 	if err != nil {
 		return "", "", err //nolint:wrapcheck // shim returns authcode errors verbatim so callers can errors.Is on sentinels
@@ -130,20 +120,19 @@ func (f *browserAuthFlow) Exchange(ctx context.Context, code string) (string, st
 	return ts.AccessToken, ts.RefreshToken, nil
 }
 
-func (f *browserAuthFlow) Close() error {
+// Close tears down the loopback listener. Safe to call after Wait.
+func (f *BrowserAuthFlow) Close() error {
 	return f.inner.Close() //nolint:wrapcheck // shutdown error is best-effort; caller logs at most
 }
 
 // StartBrowserAuth begins the loopback authorization-code flow: it binds a
 // local listener and returns a flow carrying the browser URL to open.
-//
-//nolint:ireturn // returns the BrowserAuthFlow interface deliberately so login.go can substitute a fake in tests; the concrete impl owns a live listener and stays unexported.
-func (c *Client) StartBrowserAuth(ctx context.Context) (BrowserAuthFlow, error) {
+func (c *Client) StartBrowserAuth(ctx context.Context) (*BrowserAuthFlow, error) {
 	f, err := c.browser.Start(ctx)
 	if err != nil {
 		return nil, err //nolint:wrapcheck // shim returns authcode errors verbatim so callers can errors.Is on sentinels
 	}
-	return &browserAuthFlow{inner: f}, nil
+	return &BrowserAuthFlow{inner: f}, nil
 }
 
 // BaseURL returns the issuer base URL this client talks to.

--- a/cmd/entire/cli/auth/client.go
+++ b/cmd/entire/cli/auth/client.go
@@ -136,6 +136,8 @@ func (f *browserAuthFlow) Close() error {
 
 // StartBrowserAuth begins the loopback authorization-code flow: it binds a
 // local listener and returns a flow carrying the browser URL to open.
+//
+//nolint:ireturn // returns the BrowserAuthFlow interface deliberately so login.go can substitute a fake in tests; the concrete impl owns a live listener and stays unexported.
 func (c *Client) StartBrowserAuth(ctx context.Context) (BrowserAuthFlow, error) {
 	f, err := c.browser.Start(ctx)
 	if err != nil {

--- a/cmd/entire/cli/auth/provider.go
+++ b/cmd/entire/cli/auth/provider.go
@@ -24,6 +24,7 @@ const ProviderVersionEnvVar = "ENTIRE_AUTH_PROVIDER_VERSION"
 type Provider struct {
 	ClientID       string
 	DeviceCodePath string
+	AuthorizePath  string
 	TokenPath      string
 	STSPath        string
 }
@@ -32,6 +33,7 @@ var providers = map[string]Provider{
 	"v1": { //nolint:gosec // OAuth client_id and endpoint paths, not credentials
 		ClientID:       "entire-cli",
 		DeviceCodePath: "/oauth/device/code",
+		AuthorizePath:  "/oauth/authorize",
 		TokenPath:      "/oauth/token",
 	},
 	"v2": { //nolint:gosec // OAuth client_id and endpoint paths, not credentials
@@ -42,8 +44,11 @@ var providers = map[string]Provider{
 		// exchange at the shared /oauth/token endpoint.
 		ClientID:       "entire-cli",
 		DeviceCodePath: "/device_authorization",
-		TokenPath:      "/oauth/token",
-		STSPath:        "/oauth/token",
+		// OIDC-standard authorization_endpoint. Verified against
+		// us.auth.entire.io's /.well-known/openid-configuration.
+		AuthorizePath: "/authorize",
+		TokenPath:     "/oauth/token",
+		STSPath:       "/oauth/token",
 	},
 }
 

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -186,6 +187,62 @@ func TestLogin_DeniedFlow(t *testing.T) {
 	}
 }
 
+// TestLogin_BrowserFlow_SavesToken drives the loopback authorization-code
+// flow end to end: ENTIRE_TEST_TTY=1 forces the interactive (browser)
+// default, openBrowser is a no-op under test, and the test plays the role
+// of the browser by GETting the loopback callback with a code + the state
+// parsed out of the printed authorization URL.
+func TestLogin_BrowserFlow_SavesToken(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/oauth/token" {
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("parse token form: %v", err)
+			}
+			if got := r.PostForm.Get("grant_type"); got != "authorization_code" {
+				t.Errorf("grant_type = %q, want authorization_code", got)
+			}
+			if r.PostForm.Get("code_verifier") == "" {
+				t.Error("token request missing code_verifier")
+			}
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"access_token": "browser-token", "token_type": "Bearer", "expires_in": 3600, "scope": "cli offline_access",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	proc := startLoginProcess(t, server.URL, []string{"ENTIRE_TEST_TTY=1"}, "login", "--insecure-http-auth")
+
+	authURL := waitForBrowserPrompt(t, proc.stdout)
+	u, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse authorization URL %q: %v", authURL, err)
+	}
+	q := u.Query()
+	redirectURI, state := q.Get("redirect_uri"), q.Get("state")
+	if redirectURI == "" || state == "" {
+		t.Fatalf("authorization URL missing redirect_uri/state: %s", authURL)
+	}
+
+	cbResp, err := http.Get(redirectURI + "?" + url.Values{"code": {"auth-code-1"}, "state": {state}}.Encode()) //nolint:noctx // test
+	if err != nil {
+		t.Fatalf("GET loopback callback: %v", err)
+	}
+	_ = cbResp.Body.Close()
+
+	output, waitErr := proc.wait()
+	if waitErr != nil {
+		t.Fatalf("login command failed: %v\nOutput:\n%s", waitErr, output)
+	}
+	if !strings.Contains(output, "Login complete.") {
+		t.Fatalf("output missing login complete message:\n%s", output)
+	}
+}
+
 type loginProcess struct {
 	stdout *bufio.Reader
 	waitFn func() (string, error)
@@ -193,10 +250,17 @@ type loginProcess struct {
 
 func runLoginProcess(t *testing.T, apiBaseURL string) *loginProcess {
 	t.Helper()
+	// No ENTIRE_TEST_TTY: NonInteractive + non-interactive default routes
+	// `entire login` to the device-code flow.
+	return startLoginProcess(t, apiBaseURL, nil, "login", "--insecure-http-auth")
+}
+
+func startLoginProcess(t *testing.T, apiBaseURL string, extraEnv []string, args ...string) *loginProcess {
+	t.Helper()
 
 	env := NewTestEnv(t)
 
-	cmd := execx.NonInteractive(context.Background(), getTestBinary(), "login", "--insecure-http-auth")
+	cmd := execx.NonInteractive(context.Background(), getTestBinary(), args...)
 	cmd.Dir = env.RepoDir
 	cmd.Env = append(testutil.GitIsolatedEnv(),
 		"ENTIRE_TEST_CLAUDE_PROJECT_DIR="+env.ClaudeProjectDir,
@@ -204,11 +268,12 @@ func runLoginProcess(t *testing.T, apiBaseURL string) *loginProcess {
 		"ENTIRE_TEST_OPENCODE_PROJECT_DIR="+env.OpenCodeProjectDir,
 		"ENTIRE_API_BASE_URL="+apiBaseURL,
 		// AuthBaseURL no longer inherits from BaseURL; pin both at the test
-		// server so the device flow stays in-process instead of reaching
-		// out to the production us.auth.entire.io default.
+		// server so the flow stays in-process instead of reaching out to the
+		// production us.auth.entire.io default.
 		"ENTIRE_AUTH_BASE_URL="+apiBaseURL,
 		"ENTIRE_TEST_AUTH_STORE_FILE="+filepath.Join(env.RepoDir, ".entire-test-auth-store.json"),
 	)
+	cmd.Env = append(cmd.Env, extraEnv...)
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -266,6 +331,31 @@ func waitForLoginPrompt(t *testing.T, stdout *bufio.Reader) (string, string) {
 
 	t.Fatal("timed out waiting for login prompt output")
 	return "", ""
+}
+
+// waitForBrowserPrompt reads login stdout until it finds the
+// "Opening <url> in your browser to sign in..." line and returns the URL.
+func waitForBrowserPrompt(t *testing.T, stdout *bufio.Reader) string {
+	t.Helper()
+
+	const prefix = "Opening "
+	const suffix = " in your browser to sign in..."
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		line, err := stdout.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read login output: %v", err)
+		}
+		line = strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(line, prefix); ok {
+			if authURL, ok := strings.CutSuffix(after, suffix); ok {
+				return authURL
+			}
+		}
+	}
+
+	t.Fatal("timed out waiting for browser login prompt")
+	return ""
 }
 
 func writeJSON(t *testing.T, w http.ResponseWriter, status int, body map[string]any) {

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -333,13 +333,15 @@ func waitForLoginPrompt(t *testing.T, stdout *bufio.Reader) (string, string) {
 	return "", ""
 }
 
-// waitForBrowserPrompt reads login stdout until it finds the "Login URL:"
-// line (the browser flow mirrors the device flow's prompt) and returns the
-// URL. The browser flow has no "Device code:" line, so this scans for the
-// URL alone rather than reusing waitForLoginPrompt.
+// waitForBrowserPrompt reads login stdout until it finds the
+// "Open this URL in your browser to sign in: <url>" fallback line and
+// returns the URL. Under test openBrowser reports failure (no usable
+// browser on a headless host), so the browser flow always prints this
+// fallback — which is how the test recovers the ephemeral callback URL.
 func waitForBrowserPrompt(t *testing.T, stdout *bufio.Reader) string {
 	t.Helper()
 
+	const prefix = "Open this URL in your browser to sign in: "
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		line, err := stdout.ReadString('\n')
@@ -347,8 +349,8 @@ func waitForBrowserPrompt(t *testing.T, stdout *bufio.Reader) string {
 			t.Fatalf("read login output: %v", err)
 		}
 		line = strings.TrimSpace(line)
-		if after, ok := strings.CutPrefix(line, "Login URL:"); ok {
-			return strings.TrimSpace(after)
+		if after, ok := strings.CutPrefix(line, prefix); ok {
+			return after
 		}
 	}
 

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -333,13 +333,13 @@ func waitForLoginPrompt(t *testing.T, stdout *bufio.Reader) (string, string) {
 	return "", ""
 }
 
-// waitForBrowserPrompt reads login stdout until it finds the
-// "Opening <url> in your browser to sign in..." line and returns the URL.
+// waitForBrowserPrompt reads login stdout until it finds the "Login URL:"
+// line (the browser flow mirrors the device flow's prompt) and returns the
+// URL. The browser flow has no "Device code:" line, so this scans for the
+// URL alone rather than reusing waitForLoginPrompt.
 func waitForBrowserPrompt(t *testing.T, stdout *bufio.Reader) string {
 	t.Helper()
 
-	const prefix = "Opening "
-	const suffix = " in your browser to sign in..."
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		line, err := stdout.ReadString('\n')
@@ -347,10 +347,8 @@ func waitForBrowserPrompt(t *testing.T, stdout *bufio.Reader) string {
 			t.Fatalf("read login output: %v", err)
 		}
 		line = strings.TrimSpace(line)
-		if after, ok := strings.CutPrefix(line, prefix); ok {
-			if authURL, ok := strings.CutSuffix(after, suffix); ok {
-				return authURL
-			}
+		if after, ok := strings.CutPrefix(line, "Login URL:"); ok {
+			return strings.TrimSpace(after)
 		}
 	}
 

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -216,13 +216,7 @@ func TestLogin_BrowserFlow_SavesToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Blank the SSH_* vars too: startLoginProcess inherits os.Environ(), so a
-	// developer running tests over SSH would otherwise flip the subprocess'
-	// isSSHSession() detection and route it to the device flow.
-	proc := startLoginProcess(t, server.URL, []string{
-		"ENTIRE_TEST_TTY=1",
-		"SSH_CONNECTION=", "SSH_CLIENT=", "SSH_TTY=",
-	}, "login", "--insecure-http-auth")
+	proc := startLoginProcess(t, server.URL, []string{"ENTIRE_TEST_TTY=1"}, "login", "--insecure-http-auth")
 
 	authURL := waitForBrowserPrompt(t, proc.stdout)
 	u, err := url.Parse(authURL)
@@ -279,6 +273,12 @@ func startLoginProcess(t *testing.T, apiBaseURL string, extraEnv []string, args 
 		// production us.auth.entire.io default.
 		"ENTIRE_AUTH_BASE_URL="+apiBaseURL,
 		"ENTIRE_TEST_AUTH_STORE_FILE="+filepath.Join(env.RepoDir, ".entire-test-auth-store.json"),
+		// Blank the SSH_* vars inherited from os.Environ(): a developer
+		// running tests over SSH would otherwise flip the subprocess'
+		// isSSHSession() detection and route browser-flow tests to the
+		// device flow. extraEnv is appended after, so a test can still
+		// set them deliberately.
+		"SSH_CONNECTION=", "SSH_CLIENT=", "SSH_TTY=",
 	)
 	cmd.Env = append(cmd.Env, extraEnv...)
 

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -189,9 +189,10 @@ func TestLogin_DeniedFlow(t *testing.T) {
 
 // TestLogin_BrowserFlow_SavesToken drives the loopback authorization-code
 // flow end to end: ENTIRE_TEST_TTY=1 forces the interactive (browser)
-// default, openBrowser is a no-op under test, and the test plays the role
-// of the browser by GETting the loopback callback with a code + the state
-// parsed out of the printed authorization URL.
+// default, openBrowser reports failure under test (no usable browser on a
+// headless host) so the flow prints the fallback URL, and the test plays
+// the role of the browser by parsing that URL and GETting the loopback
+// callback with a code + the state from it.
 func TestLogin_BrowserFlow_SavesToken(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -216,7 +216,13 @@ func TestLogin_BrowserFlow_SavesToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	proc := startLoginProcess(t, server.URL, []string{"ENTIRE_TEST_TTY=1"}, "login", "--insecure-http-auth")
+	// Blank the SSH_* vars too: startLoginProcess inherits os.Environ(), so a
+	// developer running tests over SSH would otherwise flip the subprocess'
+	// isSSHSession() detection and route it to the device flow.
+	proc := startLoginProcess(t, server.URL, []string{
+		"ENTIRE_TEST_TTY=1",
+		"SSH_CONNECTION=", "SSH_CLIENT=", "SSH_TTY=",
+	}, "login", "--insecure-http-auth")
 
 	authURL := waitForBrowserPrompt(t, proc.stdout)
 	u, err := url.Parse(authURL)

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -157,21 +157,25 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, client browserAu
 	// Login complete." runBrowserLogin is only reached interactively (see
 	// shouldUseBrowserLogin), so the Enter prompt is unconditional here.
 	authURL := flow.AuthorizationURL()
-	fmt.Fprintf(outW, "Login URL:   %s\n\n", authURL)
-	fmt.Fprintf(outW, "Press Enter to open in browser...")
+	// Show the auth host, not the full authorize URL — the PKCE challenge +
+	// loopback redirect make it long and unreadable, and the browser is
+	// opened for the user anyway. The full URL is only printed below as a
+	// fallback when the browser can't be opened.
+	fmt.Fprintf(outW, "Logging in to:  %s\n\n", client.BaseURL())
+	fmt.Fprint(outW, "Press Enter to open in browser...")
 
 	// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
 	if err := waitForEnter(ctx); err != nil {
 		return fmt.Errorf("wait for input: %w", err)
 	}
-
 	fmt.Fprintln(outW)
+
 	if err := openURL(ctx, authURL); err != nil {
 		fmt.Fprintf(errW, "Warning: failed to open browser: %v\n", err)
 		fmt.Fprintf(outW, "Open this URL in your browser to sign in: %s\n", authURL)
 	}
 
-	fmt.Fprint(outW, "Waiting for sign-in... ")
+	fmt.Fprint(outW, "\nWaiting for sign-in... ")
 
 	code, err := flow.Wait(ctx)
 	if err != nil {
@@ -378,12 +382,13 @@ func openBrowser(ctx context.Context, browserURL string) error {
 		return fmt.Errorf("refusing to open non-HTTP URL: %s", browserURL)
 	}
 
-	// Tests force interactive mode (ENTIRE_TEST_TTY=1) to exercise the
-	// browser flow, but must not actually spawn a browser on the test/CI
-	// host. Report success so the "Opening..." path runs — the loopback
-	// listener is what the test drives. URL validation above still applies.
+	// Under test there's no usable browser, and we must not spawn a real one
+	// on a dev/CI host. Report failure so the caller takes the "here's the
+	// URL" fallback — exactly the path a genuinely headless machine hits, and
+	// what lets an integration test recover the loopback callback URL from
+	// stdout. URL validation above still applies.
 	if interactive.UnderTest() {
-		return nil
+		return errors.New("browser unavailable under test")
 	}
 
 	var command string

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -47,11 +47,14 @@ type deviceAuthClient interface {
 	BaseURL() string
 }
 
-// browserAuthClient abstracts the loopback authorization-code client so
-// runBrowserLogin can be unit-tested without binding a real listener.
-type browserAuthClient interface {
-	StartBrowserAuth(ctx context.Context) (auth.BrowserAuthFlow, error)
-	BaseURL() string
+// browserAuthFlow abstracts an in-progress loopback authorization-code
+// login so runBrowserLogin can be unit-tested with a fake instead of a real
+// listener. *auth.BrowserAuthFlow satisfies it.
+type browserAuthFlow interface {
+	AuthorizationURL() string
+	Wait(ctx context.Context) (code string, err error)
+	Exchange(ctx context.Context, code string) (accessToken, refreshToken string, err error)
+	Close() error
 }
 
 func newLoginCmd() *cobra.Command {
@@ -74,7 +77,11 @@ func newLoginCmd() *cobra.Command {
 			// the same both-flows-with-fallback shape gh / gcloud / aws sso
 			// ship. --device forces the device flow explicitly.
 			if shouldUseBrowserLogin(useDevice, interactive.CanPromptInteractively()) {
-				return runBrowserLogin(cmd.Context(), outW, errW, client, openBrowser)
+				flow, err := client.StartBrowserAuth(cmd.Context())
+				if err != nil {
+					return fmt.Errorf("start login: %w", err)
+				}
+				return runBrowserLogin(cmd.Context(), outW, errW, flow, client.BaseURL(), openBrowser)
 			}
 			if !useDevice {
 				fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
@@ -138,15 +145,12 @@ func shouldUseBrowserLogin(useDevice, canPrompt bool) bool {
 	return !useDevice && canPrompt
 }
 
-// runBrowserLogin runs the loopback authorization-code flow: open the
-// authorization URL in the user's browser, wait for the redirect back to
-// the local listener, then exchange the code for tokens. Shares the token
-// validation + persistence tail with runLogin via persistLogin.
-func runBrowserLogin(ctx context.Context, outW, errW io.Writer, client browserAuthClient, openURL browserOpenFunc) error {
-	flow, err := client.StartBrowserAuth(ctx)
-	if err != nil {
-		return fmt.Errorf("start login: %w", err)
-	}
+// runBrowserLogin runs the loopback authorization-code flow on an
+// already-started flow: open the authorization URL in the user's browser,
+// wait for the redirect back to the local listener, then exchange the code
+// for tokens. Shares the token validation + persistence tail with runLogin
+// via persistLogin.
+func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuthFlow, baseURL string, openURL browserOpenFunc) error {
 	// Wait tears the listener down on return, but Close is idempotent and
 	// covers the error paths before Wait runs.
 	defer func() { _ = flow.Close() }()
@@ -161,7 +165,7 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, client browserAu
 	// loopback redirect make it long and unreadable, and the browser is
 	// opened for the user anyway. The full URL is only printed below as a
 	// fallback when the browser can't be opened.
-	fmt.Fprintf(outW, "Logging in to:  %s\n\n", client.BaseURL())
+	fmt.Fprintf(outW, "Logging in to: %s\n\n", baseURL)
 	fmt.Fprint(outW, "Press Enter to open in browser...")
 
 	// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
@@ -175,7 +179,7 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, client browserAu
 		fmt.Fprintf(outW, "Open this URL in your browser to sign in: %s\n", authURL)
 	}
 
-	fmt.Fprint(outW, "\nWaiting for sign-in... ")
+	fmt.Fprint(outW, "Waiting for sign-in... ")
 
 	code, err := flow.Wait(ctx)
 	if err != nil {
@@ -187,7 +191,7 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, client browserAu
 		return fmt.Errorf("complete login: %w", err)
 	}
 
-	return persistLogin(outW, errW, client.BaseURL(), token, refreshToken)
+	return persistLogin(outW, errW, baseURL, token, refreshToken)
 }
 
 // persistLogin validates the freshly-issued access token, saves it to the

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -25,6 +25,12 @@ const maxPollInterval = 30 * time.Second
 const maxExpiresIn = 15 * time.Minute
 const maxTransientErrors = 5
 
+// browserLoginTimeout bounds how long the browser flow waits for the
+// loopback redirect. The device flow is bounded by the AS's expires_in
+// (capped at maxExpiresIn); without a bound here a closed browser tab
+// would hang `entire login` forever.
+const browserLoginTimeout = 5 * time.Minute
+
 // browserOpenFunc is the signature for opening a URL in the user's browser.
 type browserOpenFunc func(ctx context.Context, url string) error
 
@@ -81,7 +87,7 @@ func newLoginCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("start login: %w", err)
 				}
-				return runBrowserLogin(cmd.Context(), outW, errW, flow, client.BaseURL(), openBrowser)
+				return runBrowserLogin(cmd.Context(), outW, errW, flow, client.BaseURL(), openBrowser, browserLoginTimeout)
 			}
 			if !useDevice {
 				fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
@@ -147,10 +153,10 @@ func shouldUseBrowserLogin(useDevice, canPrompt bool) bool {
 
 // runBrowserLogin runs the loopback authorization-code flow on an
 // already-started flow: open the authorization URL in the user's browser,
-// wait for the redirect back to the local listener, then exchange the code
-// for tokens. Shares the token validation + persistence tail with runLogin
-// via persistLogin.
-func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuthFlow, baseURL string, openURL browserOpenFunc) error {
+// wait up to waitTimeout for the redirect back to the local listener, then
+// exchange the code for tokens. Shares the token validation + persistence
+// tail with runLogin via persistLogin.
+func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuthFlow, baseURL string, openURL browserOpenFunc, waitTimeout time.Duration) error {
 	// Wait tears the listener down on return, but Close is idempotent and
 	// covers the error paths before Wait runs.
 	defer func() { _ = flow.Close() }()
@@ -181,8 +187,16 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 
 	fmt.Fprint(outW, "Waiting for sign-in... ")
 
-	code, err := flow.Wait(ctx)
+	// The clock starts here, after the Enter prompt, so time spent reading
+	// the prompt isn't counted against the sign-in itself.
+	waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
+	defer cancel()
+
+	code, err := flow.Wait(waitCtx)
 	if err != nil {
+		if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("timed out waiting for sign-in after %v; run `entire login` again, or use `entire login --device`", waitTimeout)
+		}
 		return fmt.Errorf("complete login: %w", err)
 	}
 

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -47,8 +47,16 @@ type deviceAuthClient interface {
 	BaseURL() string
 }
 
+// browserAuthClient abstracts the loopback authorization-code client so
+// runBrowserLogin can be unit-tested without binding a real listener.
+type browserAuthClient interface {
+	StartBrowserAuth(ctx context.Context) (auth.BrowserAuthFlow, error)
+	BaseURL() string
+}
+
 func newLoginCmd() *cobra.Command {
 	var insecureHTTPAuth bool
+	var useDevice bool
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to Entire",
@@ -56,10 +64,26 @@ func newLoginCmd() *cobra.Command {
 			if err := requireSecureBaseURL(insecureHTTPAuth); err != nil {
 				return err
 			}
-			return runLogin(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), auth.NewClient(nil, insecureHTTPAuth), openBrowser)
+			client := auth.NewClient(nil, insecureHTTPAuth)
+			outW, errW := cmd.OutOrStdout(), cmd.ErrOrStderr()
+
+			// Default to the browser (loopback authorization-code) flow:
+			// no code to type, no poll latency. It needs a local browser and
+			// a reachable 127.0.0.1, so when there's no interactive terminal
+			// (CI, piped, SSH without a tty) fall back to the device flow —
+			// the same both-flows-with-fallback shape gh / gcloud / aws sso
+			// ship. --device forces the device flow explicitly.
+			if shouldUseBrowserLogin(useDevice, interactive.CanPromptInteractively()) {
+				return runBrowserLogin(cmd.Context(), outW, errW, client, openBrowser)
+			}
+			if !useDevice {
+				fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
+			}
+			return runLogin(cmd.Context(), outW, errW, client, openBrowser)
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
+	cmd.Flags().BoolVar(&useDevice, "device", false, "Use the device-code flow (enter a code in your browser) instead of the default browser redirect")
 	return cmd
 }
 
@@ -102,7 +126,59 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 		return fmt.Errorf("complete login: %w", err)
 	}
 
-	if err := validateReceivedToken(token, client.BaseURL(), time.Now()); err != nil {
+	return persistLogin(outW, errW, client.BaseURL(), token, refreshToken)
+}
+
+// runBrowserLogin runs the loopback authorization-code flow: open the
+// authorization URL in the user's browser, wait for the redirect back to
+// the local listener, then exchange the code for tokens. Shares the token
+// validation + persistence tail with runLogin via persistLogin.
+// shouldUseBrowserLogin reports whether `entire login` should use the
+// loopback authorization-code (browser) flow. The browser flow is the
+// default but needs a local browser + reachable 127.0.0.1, so it's only
+// chosen when --device wasn't passed and an interactive terminal is
+// present; otherwise the caller falls back to the device flow.
+func shouldUseBrowserLogin(useDevice, canPrompt bool) bool {
+	return !useDevice && canPrompt
+}
+
+func runBrowserLogin(ctx context.Context, outW, errW io.Writer, client browserAuthClient, openURL browserOpenFunc) error {
+	flow, err := client.StartBrowserAuth(ctx)
+	if err != nil {
+		return fmt.Errorf("start login: %w", err)
+	}
+	// Wait tears the listener down on return, but Close is idempotent and
+	// covers the error paths before Wait runs.
+	defer func() { _ = flow.Close() }()
+
+	authURL := flow.AuthorizationURL()
+	if err := openURL(ctx, authURL); err != nil {
+		fmt.Fprintf(errW, "Warning: failed to open browser: %v\n", err)
+		fmt.Fprintf(outW, "Open this URL in your browser to sign in: %s\n", authURL)
+	} else {
+		fmt.Fprintf(outW, "Opening %s in your browser to sign in...\n", authURL)
+	}
+
+	fmt.Fprintln(outW, "Waiting for sign-in to complete...")
+
+	code, err := flow.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("complete login: %w", err)
+	}
+
+	token, refreshToken, err := flow.Exchange(ctx, code)
+	if err != nil {
+		return fmt.Errorf("complete login: %w", err)
+	}
+
+	return persistLogin(outW, errW, client.BaseURL(), token, refreshToken)
+}
+
+// persistLogin validates the freshly-issued access token, saves it to the
+// keyring, and dual-writes the shared contexts.json credential model.
+// Shared by the device-code and browser flows.
+func persistLogin(outW, errW io.Writer, baseURL, token, refreshToken string) error {
+	if err := validateReceivedToken(token, baseURL, time.Now()); err != nil {
 		return fmt.Errorf("reject login token: %w", err)
 	}
 
@@ -110,8 +186,8 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 
 	// Login deliberately uses the legacy SaveToken (string, string)
 	// surface — we only have an access-token string at this point;
-	// the deviceflow client doesn't return a TokenSet here.
-	if err := store.SaveToken(client.BaseURL(), token); err != nil {
+	// neither flow's client returns a TokenSet here.
+	if err := store.SaveToken(baseURL, token); err != nil {
 		return fmt.Errorf("save auth token: %w", err)
 	}
 
@@ -281,6 +357,14 @@ func openBrowser(ctx context.Context, browserURL string) error {
 	u, err := url.Parse(browserURL)
 	if err != nil || (u.Scheme != "https" && u.Scheme != "http") {
 		return fmt.Errorf("refusing to open non-HTTP URL: %s", browserURL)
+	}
+
+	// Tests force interactive mode (ENTIRE_TEST_TTY=1) to exercise the
+	// browser flow, but must not actually spawn a browser on the test/CI
+	// host. Report success so the "Opening..." path runs — the loopback
+	// listener is what the test drives. URL validation above still applies.
+	if interactive.UnderTest() {
+		return nil
 	}
 
 	var command string

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -129,10 +129,6 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	return persistLogin(outW, errW, client.BaseURL(), token, refreshToken)
 }
 
-// runBrowserLogin runs the loopback authorization-code flow: open the
-// authorization URL in the user's browser, wait for the redirect back to
-// the local listener, then exchange the code for tokens. Shares the token
-// validation + persistence tail with runLogin via persistLogin.
 // shouldUseBrowserLogin reports whether `entire login` should use the
 // loopback authorization-code (browser) flow. The browser flow is the
 // default but needs a local browser + reachable 127.0.0.1, so it's only
@@ -142,6 +138,10 @@ func shouldUseBrowserLogin(useDevice, canPrompt bool) bool {
 	return !useDevice && canPrompt
 }
 
+// runBrowserLogin runs the loopback authorization-code flow: open the
+// authorization URL in the user's browser, wait for the redirect back to
+// the local listener, then exchange the code for tokens. Shares the token
+// validation + persistence tail with runLogin via persistLogin.
 func runBrowserLogin(ctx context.Context, outW, errW io.Writer, client browserAuthClient, openURL browserOpenFunc) error {
 	flow, err := client.StartBrowserAuth(ctx)
 	if err != nil {
@@ -151,15 +151,27 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, client browserAu
 	// covers the error paths before Wait runs.
 	defer func() { _ = flow.Close() }()
 
+	// Mirror the device flow's interactive shape: show the URL, pause on
+	// Enter before opening the browser, then wait on the same line so
+	// persistLogin's "Login complete." reads "Waiting for sign-in...
+	// Login complete." runBrowserLogin is only reached interactively (see
+	// shouldUseBrowserLogin), so the Enter prompt is unconditional here.
 	authURL := flow.AuthorizationURL()
+	fmt.Fprintf(outW, "Login URL:   %s\n\n", authURL)
+	fmt.Fprintf(outW, "Press Enter to open in browser...")
+
+	// Read from /dev/tty so we get a real keypress and don't consume piped stdin.
+	if err := waitForEnter(ctx); err != nil {
+		return fmt.Errorf("wait for input: %w", err)
+	}
+
+	fmt.Fprintln(outW)
 	if err := openURL(ctx, authURL); err != nil {
 		fmt.Fprintf(errW, "Warning: failed to open browser: %v\n", err)
 		fmt.Fprintf(outW, "Open this URL in your browser to sign in: %s\n", authURL)
-	} else {
-		fmt.Fprintf(outW, "Opening %s in your browser to sign in...\n", authURL)
 	}
 
-	fmt.Fprintln(outW, "Waiting for sign-in to complete...")
+	fmt.Fprint(outW, "Waiting for sign-in... ")
 
 	code, err := flow.Wait(ctx)
 	if err != nil {
@@ -330,6 +342,13 @@ func waitForApproval(ctx context.Context, poller deviceAuthClient, deviceCode st
 // If /dev/tty cannot be opened (e.g. on Windows), it returns immediately.
 // Returns ctx.Err() if the context is cancelled before the user presses Enter.
 func waitForEnter(ctx context.Context) error {
+	// Under test (in-process go test, or a child with ENTIRE_TEST_TTY set)
+	// don't block on a real /dev/tty read — tests that force interactive
+	// mode still need this prompt to return. Mirrors openBrowser's guard.
+	if interactive.UnderTest() {
+		return nil
+	}
+
 	tty, err := os.Open("/dev/tty")
 	if err != nil {
 		return nil //nolint:nilerr // tty unavailable (e.g. Windows) — skip prompt silently

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -78,7 +78,7 @@ func newLoginCmd() *cobra.Command {
 				flow, err := client.StartBrowserAuth(ctx)
 				if err != nil {
 					// Explicit nil so the interface value is nil, not a typed nil.
-					return nil, err //nolint:wrapcheck // runLoginAuto wraps this as "start login: %w"
+					return nil, err //nolint:wrapcheck // runLoginAuto surfaces this verbatim in its fallback warning
 				}
 				return flow, nil
 			}
@@ -138,14 +138,19 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 // device-code flows and runs the chosen one. The browser flow is the
 // default — no code to type, no poll latency — but it needs a browser that
 // can reach this machine's 127.0.0.1, so headless terminals (CI, piped
-// stdin) and SSH sessions fall back to the device flow with a one-line
-// explanation; the same both-flows-with-fallback shape gh / gcloud /
-// aws sso ship. --device forces the device flow without commentary.
+// stdin), SSH sessions, and a loopback listener that fails to start all
+// fall back to the device flow with a one-line explanation; the same
+// both-flows-with-fallback shape gh / gcloud / aws sso ship. --device
+// forces the device flow without commentary.
 func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient deviceAuthClient, startBrowser func(context.Context) (browserAuthFlow, error), openURL browserOpenFunc, useDevice, canPrompt, sshSession bool) error {
 	if shouldUseBrowserLogin(useDevice, canPrompt, sshSession) {
 		flow, err := startBrowser(ctx)
 		if err != nil {
-			return fmt.Errorf("start login: %w", err)
+			// Binding the loopback listener can fail (sandboxing, firewall,
+			// exhausted ports); that shouldn't strand the user — warn and
+			// use the device flow instead.
+			fmt.Fprintf(errW, "Warning: could not start browser sign-in (%v); falling back to the device-code flow.\n", err)
+			return runLogin(ctx, outW, errW, deviceClient, openURL)
 		}
 		return runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout)
 	}

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -74,17 +74,19 @@ func newLoginCmd() *cobra.Command {
 				return err
 			}
 			client := auth.NewClient(nil, insecureHTTPAuth)
+			// Closure adapts the concrete *auth.BrowserAuthFlow result to the
+			// browserAuthFlow interface (func types are invariant, so the
+			// method value alone won't do). On error the flow is a typed nil,
+			// which is fine — runLoginAuto checks err before touching it.
 			startBrowser := func(ctx context.Context) (browserAuthFlow, error) {
-				flow, err := client.StartBrowserAuth(ctx)
-				if err != nil {
-					// Explicit nil so the interface value is nil, not a typed nil.
-					return nil, err //nolint:wrapcheck // runLoginAuto surfaces this verbatim in its fallback warning
-				}
-				return flow, nil
+				return client.StartBrowserAuth(ctx)
 			}
 			return runLoginAuto(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				client, startBrowser, openBrowser,
-				useDevice, interactive.CanPromptInteractively(), isSSHSession())
+				client, startBrowser, openBrowser, loginFlowFacts{
+					useDevice:  useDevice,
+					canPrompt:  interactive.CanPromptInteractively(),
+					sshSession: isSSHSession(),
+				})
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
@@ -92,7 +94,7 @@ func newLoginCmd() *cobra.Command {
 	return cmd
 }
 
-func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc) error {
+func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc, canPrompt bool) error {
 	start, err := client.StartDeviceAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("start login: %w", err)
@@ -102,7 +104,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 
 	approvalURL := chooseApprovalURL(start)
 
-	if interactive.CanPromptInteractively() {
+	if canPrompt {
 		// chooseApprovalURL prefers the code-embedded verification_uri_complete,
 		// so opening the URL is usually all the user needs to do. The device
 		// code is printed above regardless, so it's still available to confirm
@@ -134,6 +136,15 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	return persistLogin(outW, errW, client.BaseURL(), token, refreshToken)
 }
 
+// loginFlowFacts carries the environment facts that pick between the
+// browser and device-code flows. Detection happens once at the command
+// entry point; the decision logic below only consumes these values.
+type loginFlowFacts struct {
+	useDevice  bool // --device flag
+	canPrompt  bool // interactive terminal present
+	sshSession bool // running inside an SSH session
+}
+
 // runLoginAuto picks between the browser (loopback authorization-code) and
 // device-code flows and runs the chosen one. The browser flow is the
 // default — no code to type, no poll latency — but it needs a browser that
@@ -142,27 +153,27 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 // fall back to the device flow with a one-line explanation; the same
 // both-flows-with-fallback shape gh / gcloud / aws sso ship. --device
 // forces the device flow without commentary.
-func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient deviceAuthClient, startBrowser func(context.Context) (browserAuthFlow, error), openURL browserOpenFunc, useDevice, canPrompt, sshSession bool) error {
-	if shouldUseBrowserLogin(useDevice, canPrompt, sshSession) {
+func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient deviceAuthClient, startBrowser func(context.Context) (browserAuthFlow, error), openURL browserOpenFunc, facts loginFlowFacts) error {
+	if shouldUseBrowserLogin(facts) {
 		flow, err := startBrowser(ctx)
 		if err != nil {
 			// Binding the loopback listener can fail (sandboxing, firewall,
 			// exhausted ports); that shouldn't strand the user — warn and
 			// use the device flow instead.
 			fmt.Fprintf(errW, "Warning: could not start browser sign-in (%v); falling back to the device-code flow.\n", err)
-			return runLogin(ctx, outW, errW, deviceClient, openURL)
+			return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt)
 		}
 		return runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout)
 	}
 	switch {
-	case useDevice:
+	case facts.useDevice:
 		// Explicitly requested; no explanation needed.
-	case !canPrompt:
+	case !facts.canPrompt:
 		fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
-	case sshSession:
+	case facts.sshSession:
 		fmt.Fprintln(errW, "SSH session detected; using device-code flow (a browser opened here couldn't reach this machine).")
 	}
-	return runLogin(ctx, outW, errW, deviceClient, openURL)
+	return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt)
 }
 
 // shouldUseBrowserLogin reports whether `entire login` should use the
@@ -172,8 +183,8 @@ func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient device
 // and we're not inside an SSH session (where the loopback listener binds
 // on the remote host, out of the user's browser's reach); otherwise the
 // caller falls back to the device flow.
-func shouldUseBrowserLogin(useDevice, canPrompt, sshSession bool) bool {
-	return !useDevice && canPrompt && !sshSession
+func shouldUseBrowserLogin(f loginFlowFacts) bool {
+	return !f.useDevice && f.canPrompt && !f.sshSession
 }
 
 // isSSHSession reports whether this process is running inside an SSH

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -74,25 +74,17 @@ func newLoginCmd() *cobra.Command {
 				return err
 			}
 			client := auth.NewClient(nil, insecureHTTPAuth)
-			outW, errW := cmd.OutOrStdout(), cmd.ErrOrStderr()
-
-			// Default to the browser (loopback authorization-code) flow:
-			// no code to type, no poll latency. It needs a local browser and
-			// a reachable 127.0.0.1, so when there's no interactive terminal
-			// (CI, piped, SSH without a tty) fall back to the device flow —
-			// the same both-flows-with-fallback shape gh / gcloud / aws sso
-			// ship. --device forces the device flow explicitly.
-			if shouldUseBrowserLogin(useDevice, interactive.CanPromptInteractively()) {
-				flow, err := client.StartBrowserAuth(cmd.Context())
+			startBrowser := func(ctx context.Context) (browserAuthFlow, error) {
+				flow, err := client.StartBrowserAuth(ctx)
 				if err != nil {
-					return fmt.Errorf("start login: %w", err)
+					// Explicit nil so the interface value is nil, not a typed nil.
+					return nil, err //nolint:wrapcheck // runLoginAuto wraps this as "start login: %w"
 				}
-				return runBrowserLogin(cmd.Context(), outW, errW, flow, client.BaseURL(), openBrowser, browserLoginTimeout)
+				return flow, nil
 			}
-			if !useDevice {
-				fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
-			}
-			return runLogin(cmd.Context(), outW, errW, client, openBrowser)
+			return runLoginAuto(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+				client, startBrowser, openBrowser,
+				useDevice, interactive.CanPromptInteractively(), isSSHSession())
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
@@ -142,13 +134,50 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	return persistLogin(outW, errW, client.BaseURL(), token, refreshToken)
 }
 
+// runLoginAuto picks between the browser (loopback authorization-code) and
+// device-code flows and runs the chosen one. The browser flow is the
+// default — no code to type, no poll latency — but it needs a browser that
+// can reach this machine's 127.0.0.1, so headless terminals (CI, piped
+// stdin) and SSH sessions fall back to the device flow with a one-line
+// explanation; the same both-flows-with-fallback shape gh / gcloud /
+// aws sso ship. --device forces the device flow without commentary.
+func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient deviceAuthClient, startBrowser func(context.Context) (browserAuthFlow, error), openURL browserOpenFunc, useDevice, canPrompt, sshSession bool) error {
+	if shouldUseBrowserLogin(useDevice, canPrompt, sshSession) {
+		flow, err := startBrowser(ctx)
+		if err != nil {
+			return fmt.Errorf("start login: %w", err)
+		}
+		return runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout)
+	}
+	switch {
+	case useDevice:
+		// Explicitly requested; no explanation needed.
+	case !canPrompt:
+		fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
+	case sshSession:
+		fmt.Fprintln(errW, "SSH session detected; using device-code flow (a browser opened here couldn't reach this machine).")
+	}
+	return runLogin(ctx, outW, errW, deviceClient, openURL)
+}
+
 // shouldUseBrowserLogin reports whether `entire login` should use the
 // loopback authorization-code (browser) flow. The browser flow is the
 // default but needs a local browser + reachable 127.0.0.1, so it's only
-// chosen when --device wasn't passed and an interactive terminal is
-// present; otherwise the caller falls back to the device flow.
-func shouldUseBrowserLogin(useDevice, canPrompt bool) bool {
-	return !useDevice && canPrompt
+// chosen when --device wasn't passed, an interactive terminal is present,
+// and we're not inside an SSH session (where the loopback listener binds
+// on the remote host, out of the user's browser's reach); otherwise the
+// caller falls back to the device flow.
+func shouldUseBrowserLogin(useDevice, canPrompt, sshSession bool) bool {
+	return !useDevice && canPrompt && !sshSession
+}
+
+// isSSHSession reports whether this process is running inside an SSH
+// session: sshd sets SSH_CONNECTION/SSH_CLIENT for every session and
+// SSH_TTY for interactive ones.
+func isSSHSession() bool {
+	return os.Getenv("SSH_CONNECTION") != "" ||
+		os.Getenv("SSH_CLIENT") != "" ||
+		os.Getenv("SSH_TTY") != ""
 }
 
 // runBrowserLogin runs the loopback authorization-code flow on an

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -302,7 +302,7 @@ func TestWaitForApproval_ContextCancelled(t *testing.T) {
 	}
 }
 
-// fakeBrowserFlow implements auth.BrowserAuthFlow for unit tests.
+// fakeBrowserFlow implements the browserAuthFlow interface for unit tests.
 type fakeBrowserFlow struct {
 	authURL     string
 	waitCode    string
@@ -329,22 +329,6 @@ func (f *fakeBrowserFlow) Close() error {
 	return nil
 }
 
-// fakeBrowserClient implements browserAuthClient for unit tests.
-type fakeBrowserClient struct {
-	flow     *fakeBrowserFlow
-	startErr error
-}
-
-//nolint:ireturn // mirrors the browserAuthClient interface, which returns the auth.BrowserAuthFlow interface by design.
-func (c *fakeBrowserClient) StartBrowserAuth(context.Context) (auth.BrowserAuthFlow, error) {
-	if c.startErr != nil {
-		return nil, c.startErr
-	}
-	return c.flow, nil
-}
-
-func (c *fakeBrowserClient) BaseURL() string { return "http://test" }
-
 func TestShouldUseBrowserLogin(t *testing.T) {
 	t.Parallel()
 
@@ -365,23 +349,10 @@ func TestShouldUseBrowserLogin(t *testing.T) {
 	}
 }
 
-func TestRunBrowserLogin_StartError(t *testing.T) {
-	t.Parallel()
-
-	client := &fakeBrowserClient{startErr: errors.New("bind failed")}
-	noopOpen := func(context.Context, string) error { return nil }
-
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, client, noopOpen)
-	if err == nil || !strings.Contains(err.Error(), "start login") {
-		t.Fatalf("err = %v, want start login error", err)
-	}
-}
-
 func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
 	t.Parallel()
 
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize?x=1", waitErr: errors.New("stop")}
-	client := &fakeBrowserClient{flow: flow}
 
 	var openedURL string
 	openURL := func(_ context.Context, u string) error {
@@ -393,7 +364,7 @@ func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
 	// The stubbed Wait returns an error, so runBrowserLogin stops before
 	// persistLogin (which would hit the real keyring); we assert on the
 	// side effects up to that point.
-	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, client, openURL); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, flow, "https://auth.test", openURL); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -420,11 +391,10 @@ func TestRunBrowserLogin_OpenBrowserFallback(t *testing.T) {
 	t.Parallel()
 
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: errors.New("stop")}
-	client := &fakeBrowserClient{flow: flow}
 	failOpen := func(context.Context, string) error { return errors.New("no browser") }
 
 	var out, errW bytes.Buffer
-	if err := runBrowserLogin(context.Background(), &out, &errW, client, failOpen); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &errW, flow, "https://auth.test", failOpen); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -441,10 +411,9 @@ func TestRunBrowserLogin_WaitError(t *testing.T) {
 
 	denied := errors.New("access_denied")
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: denied}
-	client := &fakeBrowserClient{flow: flow}
 	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, client, noopOpen)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen)
 	if !errors.Is(err, denied) {
 		t.Fatalf("err = %v, want wrapped %v", err, denied)
 	}
@@ -458,10 +427,9 @@ func TestRunBrowserLogin_ExchangeError(t *testing.T) {
 		waitCode: "the-code",
 		exchErr:  errors.New("invalid_grant"),
 	}
-	client := &fakeBrowserClient{flow: flow}
 	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, client, noopOpen)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen)
 	if err == nil || !strings.Contains(err.Error(), "complete login") {
 		t.Fatalf("err = %v, want complete login error", err)
 	}

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -298,5 +299,157 @@ func TestWaitForApproval_ContextCancelled(t *testing.T) {
 	_, _, err := waitForApproval(ctx, poller, "device-1", 60, time.Millisecond, time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "context canceled") {
 		t.Fatalf("err = %v, want context canceled", err)
+	}
+}
+
+// fakeBrowserFlow implements auth.BrowserAuthFlow for unit tests.
+type fakeBrowserFlow struct {
+	authURL     string
+	waitCode    string
+	waitErr     error
+	exchAccess  string
+	exchRefresh string
+	exchErr     error
+
+	gotExchangeCode string
+	closed          bool
+}
+
+func (f *fakeBrowserFlow) AuthorizationURL() string { return f.authURL }
+
+func (f *fakeBrowserFlow) Wait(context.Context) (string, error) { return f.waitCode, f.waitErr }
+
+func (f *fakeBrowserFlow) Exchange(_ context.Context, code string) (string, string, error) {
+	f.gotExchangeCode = code
+	return f.exchAccess, f.exchRefresh, f.exchErr
+}
+
+func (f *fakeBrowserFlow) Close() error {
+	f.closed = true
+	return nil
+}
+
+// fakeBrowserClient implements browserAuthClient for unit tests.
+type fakeBrowserClient struct {
+	flow     *fakeBrowserFlow
+	startErr error
+}
+
+func (c *fakeBrowserClient) StartBrowserAuth(context.Context) (auth.BrowserAuthFlow, error) {
+	if c.startErr != nil {
+		return nil, c.startErr
+	}
+	return c.flow, nil
+}
+
+func (c *fakeBrowserClient) BaseURL() string { return "http://test" }
+
+func TestShouldUseBrowserLogin(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		useDevice bool
+		canPrompt bool
+		want      bool
+	}{
+		{useDevice: false, canPrompt: true, want: true},   // default interactive → browser
+		{useDevice: false, canPrompt: false, want: false}, // headless → fall back to device
+		{useDevice: true, canPrompt: true, want: false},   // --device forces device
+		{useDevice: true, canPrompt: false, want: false},
+	}
+	for _, tc := range cases {
+		if got := shouldUseBrowserLogin(tc.useDevice, tc.canPrompt); got != tc.want {
+			t.Errorf("shouldUseBrowserLogin(%v, %v) = %v, want %v", tc.useDevice, tc.canPrompt, got, tc.want)
+		}
+	}
+}
+
+func TestRunBrowserLogin_StartError(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeBrowserClient{startErr: errors.New("bind failed")}
+	noopOpen := func(context.Context, string) error { return nil }
+
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, client, noopOpen)
+	if err == nil || !strings.Contains(err.Error(), "start login") {
+		t.Fatalf("err = %v, want start login error", err)
+	}
+}
+
+func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
+	t.Parallel()
+
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize?x=1", waitErr: errors.New("stop")}
+	client := &fakeBrowserClient{flow: flow}
+
+	var openedURL string
+	openURL := func(_ context.Context, u string) error {
+		openedURL = u
+		return nil
+	}
+
+	var out bytes.Buffer
+	_ = runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, client, openURL)
+
+	if openedURL != flow.authURL {
+		t.Errorf("opened URL = %q, want %q", openedURL, flow.authURL)
+	}
+	if !strings.Contains(out.String(), "Opening") {
+		t.Errorf("output missing open message:\n%s", out.String())
+	}
+	if !flow.closed {
+		t.Error("flow was not closed")
+	}
+}
+
+func TestRunBrowserLogin_OpenBrowserFallback(t *testing.T) {
+	t.Parallel()
+
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: errors.New("stop")}
+	client := &fakeBrowserClient{flow: flow}
+	failOpen := func(context.Context, string) error { return errors.New("no browser") }
+
+	var out, errW bytes.Buffer
+	_ = runBrowserLogin(context.Background(), &out, &errW, client, failOpen)
+
+	if !strings.Contains(errW.String(), "failed to open browser") {
+		t.Errorf("stderr missing warning:\n%s", errW.String())
+	}
+	if !strings.Contains(out.String(), flow.authURL) {
+		t.Errorf("stdout missing fallback URL:\n%s", out.String())
+	}
+}
+
+func TestRunBrowserLogin_WaitError(t *testing.T) {
+	t.Parallel()
+
+	denied := errors.New("access_denied")
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: denied}
+	client := &fakeBrowserClient{flow: flow}
+	noopOpen := func(context.Context, string) error { return nil }
+
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, client, noopOpen)
+	if !errors.Is(err, denied) {
+		t.Fatalf("err = %v, want wrapped %v", err, denied)
+	}
+}
+
+func TestRunBrowserLogin_ExchangeError(t *testing.T) {
+	t.Parallel()
+
+	flow := &fakeBrowserFlow{
+		authURL:  "https://auth.test/authorize",
+		waitCode: "the-code",
+		exchErr:  errors.New("invalid_grant"),
+	}
+	client := &fakeBrowserClient{flow: flow}
+	noopOpen := func(context.Context, string) error { return nil }
+
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, client, noopOpen)
+	if err == nil || !strings.Contains(err.Error(), "complete login") {
+		t.Fatalf("err = %v, want complete login error", err)
+	}
+	if flow.gotExchangeCode != "the-code" {
+		t.Errorf("Exchange got code %q, want the-code", flow.gotExchangeCode)
 	}
 }

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -304,12 +304,13 @@ func TestWaitForApproval_ContextCancelled(t *testing.T) {
 
 // fakeBrowserFlow implements the browserAuthFlow interface for unit tests.
 type fakeBrowserFlow struct {
-	authURL     string
-	waitCode    string
-	waitErr     error
-	exchAccess  string
-	exchRefresh string
-	exchErr     error
+	authURL       string
+	waitCode      string
+	waitErr       error
+	waitUntilDone bool // Wait blocks until ctx is done and returns ctx.Err()
+	exchAccess    string
+	exchRefresh   string
+	exchErr       error
 
 	gotExchangeCode string
 	closed          bool
@@ -317,7 +318,13 @@ type fakeBrowserFlow struct {
 
 func (f *fakeBrowserFlow) AuthorizationURL() string { return f.authURL }
 
-func (f *fakeBrowserFlow) Wait(context.Context) (string, error) { return f.waitCode, f.waitErr }
+func (f *fakeBrowserFlow) Wait(ctx context.Context) (string, error) {
+	if f.waitUntilDone {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	return f.waitCode, f.waitErr
+}
 
 func (f *fakeBrowserFlow) Exchange(_ context.Context, code string) (string, string, error) {
 	f.gotExchangeCode = code
@@ -364,7 +371,7 @@ func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
 	// The stubbed Wait returns an error, so runBrowserLogin stops before
 	// persistLogin (which would hit the real keyring); we assert on the
 	// side effects up to that point.
-	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, flow, "https://auth.test", openURL); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, flow, "https://auth.test", openURL, browserLoginTimeout); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -394,7 +401,7 @@ func TestRunBrowserLogin_OpenBrowserFallback(t *testing.T) {
 	failOpen := func(context.Context, string) error { return errors.New("no browser") }
 
 	var out, errW bytes.Buffer
-	if err := runBrowserLogin(context.Background(), &out, &errW, flow, "https://auth.test", failOpen); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &errW, flow, "https://auth.test", failOpen, browserLoginTimeout); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -413,7 +420,7 @@ func TestRunBrowserLogin_WaitError(t *testing.T) {
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: denied}
 	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, browserLoginTimeout)
 	if !errors.Is(err, denied) {
 		t.Fatalf("err = %v, want wrapped %v", err, denied)
 	}
@@ -429,11 +436,49 @@ func TestRunBrowserLogin_ExchangeError(t *testing.T) {
 	}
 	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, browserLoginTimeout)
 	if err == nil || !strings.Contains(err.Error(), "complete login") {
 		t.Fatalf("err = %v, want complete login error", err)
 	}
 	if flow.gotExchangeCode != "the-code" {
 		t.Errorf("Exchange got code %q, want the-code", flow.gotExchangeCode)
+	}
+}
+
+func TestRunBrowserLogin_WaitTimeout(t *testing.T) {
+	t.Parallel()
+
+	// The fake blocks until the wait context expires — the deadline must
+	// come from runBrowserLogin's own timeout, or this test would hang.
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
+	noopOpen := func(context.Context, string) error { return nil }
+
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, 50*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting for sign-in") {
+		t.Fatalf("err = %v, want sign-in timeout", err)
+	}
+	if !strings.Contains(err.Error(), "--device") {
+		t.Errorf("timeout error should point at the --device escape hatch, got: %v", err)
+	}
+	if !flow.closed {
+		t.Error("flow was not closed")
+	}
+}
+
+func TestRunBrowserLogin_ParentCancelNotReportedAsTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // user hit Ctrl-C before the redirect arrived
+
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
+	noopOpen := func(context.Context, string) error { return nil }
+
+	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, time.Minute)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want wrapped context.Canceled", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("cancellation must not be reported as a timeout: %v", err)
 	}
 }

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -394,8 +394,11 @@ func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
 	if openedURL != flow.authURL {
 		t.Errorf("opened URL = %q, want %q", openedURL, flow.authURL)
 	}
-	if !strings.Contains(out.String(), "Opening") {
-		t.Errorf("output missing open message:\n%s", out.String())
+	if !strings.Contains(out.String(), "Login URL:") || !strings.Contains(out.String(), flow.authURL) {
+		t.Errorf("output missing login URL:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Press Enter to open in browser...") {
+		t.Errorf("output missing enter-to-open prompt:\n%s", out.String())
 	}
 	if !flow.closed {
 		t.Error("flow was not closed")

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -340,22 +340,20 @@ func TestShouldUseBrowserLogin(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		useDevice  bool
-		canPrompt  bool
-		sshSession bool
-		want       bool
+		facts loginFlowFacts
+		want  bool
 	}{
-		{useDevice: false, canPrompt: true, sshSession: false, want: true},   // default interactive → browser
-		{useDevice: false, canPrompt: false, sshSession: false, want: false}, // headless → fall back to device
-		{useDevice: false, canPrompt: true, sshSession: true, want: false},   // SSH: loopback unreachable → device
-		{useDevice: false, canPrompt: false, sshSession: true, want: false},
-		{useDevice: true, canPrompt: true, sshSession: false, want: false}, // --device forces device
-		{useDevice: true, canPrompt: false, sshSession: false, want: false},
-		{useDevice: true, canPrompt: true, sshSession: true, want: false},
+		{facts: loginFlowFacts{canPrompt: true}, want: true},                    // default interactive → browser
+		{facts: loginFlowFacts{}, want: false},                                  // headless → fall back to device
+		{facts: loginFlowFacts{canPrompt: true, sshSession: true}, want: false}, // SSH: loopback unreachable → device
+		{facts: loginFlowFacts{sshSession: true}, want: false},
+		{facts: loginFlowFacts{useDevice: true, canPrompt: true}, want: false}, // --device forces device
+		{facts: loginFlowFacts{useDevice: true}, want: false},
+		{facts: loginFlowFacts{useDevice: true, canPrompt: true, sshSession: true}, want: false},
 	}
 	for _, tc := range cases {
-		if got := shouldUseBrowserLogin(tc.useDevice, tc.canPrompt, tc.sshSession); got != tc.want {
-			t.Errorf("shouldUseBrowserLogin(%v, %v, %v) = %v, want %v", tc.useDevice, tc.canPrompt, tc.sshSession, got, tc.want)
+		if got := shouldUseBrowserLogin(tc.facts); got != tc.want {
+			t.Errorf("shouldUseBrowserLogin(%+v) = %v, want %v", tc.facts, got, tc.want)
 		}
 	}
 }
@@ -375,6 +373,10 @@ func TestIsSSHSession(t *testing.T) {
 	}
 }
 
+// noopOpenURL is a browserOpenFunc for tests that don't care about the
+// browser actually opening.
+func noopOpenURL(context.Context, string) error { return nil }
+
 // startBrowserStub returns a startBrowser func that records invocations and
 // returns the given flow/error.
 func startBrowserStub(calls *int, flow browserAuthFlow, err error) func(context.Context) (browserAuthFlow, error) {
@@ -389,11 +391,10 @@ func TestRunLoginAuto_Interactive_UsesBrowserFlow(t *testing.T) {
 
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: errors.New("stop")}
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, &mockClient{},
-		startBrowserStub(&browserCalls, flow, nil), noopOpen,
-		false /* useDevice */, true /* canPrompt */, false /* ssh */)
+		startBrowserStub(&browserCalls, flow, nil), noopOpenURL,
+		loginFlowFacts{canPrompt: true})
 
 	if browserCalls != 1 {
 		t.Errorf("startBrowser calls = %d, want 1", browserCalls)
@@ -408,12 +409,11 @@ func TestRunLoginAuto_SSHSession_FallsBackToDevice(t *testing.T) {
 	t.Parallel()
 
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil, nil), noopOpen,
-		false /* useDevice */, true /* canPrompt */, true /* ssh */)
+		startBrowserStub(&browserCalls, nil, nil), noopOpenURL,
+		loginFlowFacts{canPrompt: true, sshSession: true})
 
 	if browserCalls != 0 {
 		t.Errorf("startBrowser calls = %d, want 0 (SSH must skip the browser flow)", browserCalls)
@@ -431,12 +431,11 @@ func TestRunLoginAuto_Headless_FallsBackToDevice(t *testing.T) {
 	t.Parallel()
 
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil, nil), noopOpen,
-		false /* useDevice */, false /* canPrompt */, false /* ssh */)
+		startBrowserStub(&browserCalls, nil, nil), noopOpenURL,
+		loginFlowFacts{})
 
 	if browserCalls != 0 {
 		t.Errorf("startBrowser calls = %d, want 0", browserCalls)
@@ -453,12 +452,11 @@ func TestRunLoginAuto_BrowserStartFails_FallsBackToDevice(t *testing.T) {
 	t.Parallel()
 
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil, errors.New("listen tcp 127.0.0.1:0: operation not permitted")), noopOpen,
-		false /* useDevice */, true /* canPrompt */, false /* ssh */)
+		startBrowserStub(&browserCalls, nil, errors.New("listen tcp 127.0.0.1:0: operation not permitted")), noopOpenURL,
+		loginFlowFacts{canPrompt: true})
 
 	if browserCalls != 1 {
 		t.Errorf("startBrowser calls = %d, want 1", browserCalls)
@@ -476,12 +474,11 @@ func TestRunLoginAuto_DeviceFlag_NoExplanation(t *testing.T) {
 	t.Parallel()
 
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil, nil), noopOpen,
-		true /* useDevice */, true /* canPrompt */, false /* ssh */)
+		startBrowserStub(&browserCalls, nil, nil), noopOpenURL,
+		loginFlowFacts{useDevice: true, canPrompt: true})
 
 	if browserCalls != 0 {
 		t.Errorf("startBrowser calls = %d, want 0", browserCalls)
@@ -557,9 +554,8 @@ func TestRunBrowserLogin_WaitError(t *testing.T) {
 
 	denied := errors.New("access_denied")
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: denied}
-	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, browserLoginTimeout)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout)
 	if !errors.Is(err, denied) {
 		t.Fatalf("err = %v, want wrapped %v", err, denied)
 	}
@@ -573,9 +569,8 @@ func TestRunBrowserLogin_ExchangeError(t *testing.T) {
 		waitCode: "the-code",
 		exchErr:  errors.New("invalid_grant"),
 	}
-	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, browserLoginTimeout)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout)
 	if err == nil || !strings.Contains(err.Error(), "complete login") {
 		t.Fatalf("err = %v, want complete login error", err)
 	}
@@ -590,9 +585,8 @@ func TestRunBrowserLogin_WaitTimeout(t *testing.T) {
 	// The fake blocks until the wait context expires — the deadline must
 	// come from runBrowserLogin's own timeout, or this test would hang.
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
-	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, 50*time.Millisecond)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, 50*time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "timed out waiting for sign-in") {
 		t.Fatalf("err = %v, want sign-in timeout", err)
 	}
@@ -611,9 +605,8 @@ func TestRunBrowserLogin_ParentCancelNotReportedAsTimeout(t *testing.T) {
 	cancel() // user hit Ctrl-C before the redirect arrived
 
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
-	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, time.Minute)
+	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, time.Minute)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want wrapped context.Canceled", err)
 	}

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -376,11 +376,11 @@ func TestIsSSHSession(t *testing.T) {
 }
 
 // startBrowserStub returns a startBrowser func that records invocations and
-// returns the given flow.
-func startBrowserStub(calls *int, flow browserAuthFlow) func(context.Context) (browserAuthFlow, error) {
+// returns the given flow/error.
+func startBrowserStub(calls *int, flow browserAuthFlow, err error) func(context.Context) (browserAuthFlow, error) {
 	return func(context.Context) (browserAuthFlow, error) {
 		*calls++
-		return flow, nil
+		return flow, err
 	}
 }
 
@@ -392,7 +392,7 @@ func TestRunLoginAuto_Interactive_UsesBrowserFlow(t *testing.T) {
 	noopOpen := func(context.Context, string) error { return nil }
 
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, &mockClient{},
-		startBrowserStub(&browserCalls, flow), noopOpen,
+		startBrowserStub(&browserCalls, flow, nil), noopOpen,
 		false /* useDevice */, true /* canPrompt */, false /* ssh */)
 
 	if browserCalls != 1 {
@@ -412,7 +412,7 @@ func TestRunLoginAuto_SSHSession_FallsBackToDevice(t *testing.T) {
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil), noopOpen,
+		startBrowserStub(&browserCalls, nil, nil), noopOpen,
 		false /* useDevice */, true /* canPrompt */, true /* ssh */)
 
 	if browserCalls != 0 {
@@ -435,7 +435,7 @@ func TestRunLoginAuto_Headless_FallsBackToDevice(t *testing.T) {
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil), noopOpen,
+		startBrowserStub(&browserCalls, nil, nil), noopOpen,
 		false /* useDevice */, false /* canPrompt */, false /* ssh */)
 
 	if browserCalls != 0 {
@@ -449,6 +449,29 @@ func TestRunLoginAuto_Headless_FallsBackToDevice(t *testing.T) {
 	}
 }
 
+func TestRunLoginAuto_BrowserStartFails_FallsBackToDevice(t *testing.T) {
+	t.Parallel()
+
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	var errW bytes.Buffer
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, nil, errors.New("listen tcp 127.0.0.1:0: operation not permitted")), noopOpen,
+		false /* useDevice */, true /* canPrompt */, false /* ssh */)
+
+	if browserCalls != 1 {
+		t.Errorf("startBrowser calls = %d, want 1", browserCalls)
+	}
+	if !strings.Contains(errW.String(), "could not start browser sign-in") {
+		t.Errorf("stderr missing fallback warning:\n%s", errW.String())
+	}
+	// mockClient.StartDeviceAuth errors — proof the device flow was attempted.
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+}
+
 func TestRunLoginAuto_DeviceFlag_NoExplanation(t *testing.T) {
 	t.Parallel()
 
@@ -457,7 +480,7 @@ func TestRunLoginAuto_DeviceFlag_NoExplanation(t *testing.T) {
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil), noopOpen,
+		startBrowserStub(&browserCalls, nil, nil), noopOpen,
 		true /* useDevice */, true /* canPrompt */, false /* ssh */)
 
 	if browserCalls != 0 {

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -394,8 +394,13 @@ func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
 	if openedURL != flow.authURL {
 		t.Errorf("opened URL = %q, want %q", openedURL, flow.authURL)
 	}
-	if !strings.Contains(out.String(), "Login URL:") || !strings.Contains(out.String(), flow.authURL) {
-		t.Errorf("output missing login URL:\n%s", out.String())
+	// Happy path shows the auth host, not the full authorize URL, and
+	// doesn't print the URL at all (the browser opened fine).
+	if !strings.Contains(out.String(), "Logging in to:") {
+		t.Errorf("output missing 'Logging in to:' line:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), flow.authURL) {
+		t.Errorf("happy path should not print the full authorize URL:\n%s", out.String())
 	}
 	if !strings.Contains(out.String(), "Press Enter to open in browser...") {
 		t.Errorf("output missing enter-to-open prompt:\n%s", out.String())

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -335,6 +335,7 @@ type fakeBrowserClient struct {
 	startErr error
 }
 
+//nolint:ireturn // mirrors the browserAuthClient interface, which returns the auth.BrowserAuthFlow interface by design.
 func (c *fakeBrowserClient) StartBrowserAuth(context.Context) (auth.BrowserAuthFlow, error) {
 	if c.startErr != nil {
 		return nil, c.startErr
@@ -389,7 +390,12 @@ func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	_ = runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, client, openURL)
+	// The stubbed Wait returns an error, so runBrowserLogin stops before
+	// persistLogin (which would hit the real keyring); we assert on the
+	// side effects up to that point.
+	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, client, openURL); err == nil {
+		t.Fatal("expected error from stubbed Wait")
+	}
 
 	if openedURL != flow.authURL {
 		t.Errorf("opened URL = %q, want %q", openedURL, flow.authURL)
@@ -418,7 +424,9 @@ func TestRunBrowserLogin_OpenBrowserFallback(t *testing.T) {
 	failOpen := func(context.Context, string) error { return errors.New("no browser") }
 
 	var out, errW bytes.Buffer
-	_ = runBrowserLogin(context.Background(), &out, &errW, client, failOpen)
+	if err := runBrowserLogin(context.Background(), &out, &errW, client, failOpen); err == nil {
+		t.Fatal("expected error from stubbed Wait")
+	}
 
 	if !strings.Contains(errW.String(), "failed to open browser") {
 		t.Errorf("stderr missing warning:\n%s", errW.String())

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -340,19 +340,135 @@ func TestShouldUseBrowserLogin(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		useDevice bool
-		canPrompt bool
-		want      bool
+		useDevice  bool
+		canPrompt  bool
+		sshSession bool
+		want       bool
 	}{
-		{useDevice: false, canPrompt: true, want: true},   // default interactive → browser
-		{useDevice: false, canPrompt: false, want: false}, // headless → fall back to device
-		{useDevice: true, canPrompt: true, want: false},   // --device forces device
-		{useDevice: true, canPrompt: false, want: false},
+		{useDevice: false, canPrompt: true, sshSession: false, want: true},   // default interactive → browser
+		{useDevice: false, canPrompt: false, sshSession: false, want: false}, // headless → fall back to device
+		{useDevice: false, canPrompt: true, sshSession: true, want: false},   // SSH: loopback unreachable → device
+		{useDevice: false, canPrompt: false, sshSession: true, want: false},
+		{useDevice: true, canPrompt: true, sshSession: false, want: false}, // --device forces device
+		{useDevice: true, canPrompt: false, sshSession: false, want: false},
+		{useDevice: true, canPrompt: true, sshSession: true, want: false},
 	}
 	for _, tc := range cases {
-		if got := shouldUseBrowserLogin(tc.useDevice, tc.canPrompt); got != tc.want {
-			t.Errorf("shouldUseBrowserLogin(%v, %v) = %v, want %v", tc.useDevice, tc.canPrompt, got, tc.want)
+		if got := shouldUseBrowserLogin(tc.useDevice, tc.canPrompt, tc.sshSession); got != tc.want {
+			t.Errorf("shouldUseBrowserLogin(%v, %v, %v) = %v, want %v", tc.useDevice, tc.canPrompt, tc.sshSession, got, tc.want)
 		}
+	}
+}
+
+func TestIsSSHSession(t *testing.T) {
+	// t.Setenv forbids t.Parallel.
+	for _, v := range []string{"SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"} {
+		t.Setenv(v, "")
+	}
+	if isSSHSession() {
+		t.Error("isSSHSession() = true with all SSH env vars empty")
+	}
+
+	t.Setenv("SSH_CONNECTION", "10.0.0.1 50022 10.0.0.2 22")
+	if !isSSHSession() {
+		t.Error("isSSHSession() = false with SSH_CONNECTION set")
+	}
+}
+
+// startBrowserStub returns a startBrowser func that records invocations and
+// returns the given flow.
+func startBrowserStub(calls *int, flow browserAuthFlow) func(context.Context) (browserAuthFlow, error) {
+	return func(context.Context) (browserAuthFlow, error) {
+		*calls++
+		return flow, nil
+	}
+}
+
+func TestRunLoginAuto_Interactive_UsesBrowserFlow(t *testing.T) {
+	t.Parallel()
+
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: errors.New("stop")}
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, &mockClient{},
+		startBrowserStub(&browserCalls, flow), noopOpen,
+		false /* useDevice */, true /* canPrompt */, false /* ssh */)
+
+	if browserCalls != 1 {
+		t.Errorf("startBrowser calls = %d, want 1", browserCalls)
+	}
+	// The stubbed Wait errors, so the browser flow is entered and fails there.
+	if err == nil || !strings.Contains(err.Error(), "complete login") {
+		t.Fatalf("err = %v, want browser-flow 'complete login' error", err)
+	}
+}
+
+func TestRunLoginAuto_SSHSession_FallsBackToDevice(t *testing.T) {
+	t.Parallel()
+
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	var errW bytes.Buffer
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, nil), noopOpen,
+		false /* useDevice */, true /* canPrompt */, true /* ssh */)
+
+	if browserCalls != 0 {
+		t.Errorf("startBrowser calls = %d, want 0 (SSH must skip the browser flow)", browserCalls)
+	}
+	if !strings.Contains(errW.String(), "SSH session detected") {
+		t.Errorf("stderr missing SSH explanation:\n%s", errW.String())
+	}
+	// mockClient.StartDeviceAuth errors — proof the device flow was attempted.
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+}
+
+func TestRunLoginAuto_Headless_FallsBackToDevice(t *testing.T) {
+	t.Parallel()
+
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	var errW bytes.Buffer
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, nil), noopOpen,
+		false /* useDevice */, false /* canPrompt */, false /* ssh */)
+
+	if browserCalls != 0 {
+		t.Errorf("startBrowser calls = %d, want 0", browserCalls)
+	}
+	if !strings.Contains(errW.String(), "No interactive terminal detected") {
+		t.Errorf("stderr missing headless explanation:\n%s", errW.String())
+	}
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+}
+
+func TestRunLoginAuto_DeviceFlag_NoExplanation(t *testing.T) {
+	t.Parallel()
+
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	var errW bytes.Buffer
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, nil), noopOpen,
+		true /* useDevice */, true /* canPrompt */, false /* ssh */)
+
+	if browserCalls != 0 {
+		t.Errorf("startBrowser calls = %d, want 0", browserCalls)
+	}
+	// mockClient.StartDeviceAuth errors — proof the device flow was attempted.
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+	if errW.String() != "" {
+		t.Errorf("--device should produce no fallback commentary, got:\n%s", errW.String())
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/entireio/auth-go v0.4.1-0.20260610004806-f943c0bc8826
+	github.com/entireio/auth-go v0.5.0
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/go-git/go-billy/v6 v6.0.0-alpha.1.0.20260519112248-0095b064a6c6

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/entireio/auth-go v0.4.1-0.20260604093244-dfb6f1d8eb12
+	github.com/entireio/auth-go v0.4.1-0.20260610004806-f943c0bc8826
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/go-git/go-billy/v6 v6.0.0-alpha.1.0.20260519112248-0095b064a6c6

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/entireio/auth-go v0.4.1-0.20260603125945-62cd5140d2d4
+	github.com/entireio/auth-go v0.4.1-0.20260604093244-dfb6f1d8eb12
 	github.com/go-faster/errors v0.7.1
 	github.com/go-faster/jx v1.2.0
 	github.com/go-git/go-billy/v6 v6.0.0-alpha.1.0.20260519112248-0095b064a6c6

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/entireio/auth-go v0.4.1-0.20260610004806-f943c0bc8826 h1:X0TQoeD+zjMm7mt2YZa9kx2TgYGM9SYJLZ/pj5TX9us=
-github.com/entireio/auth-go v0.4.1-0.20260610004806-f943c0bc8826/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
+github.com/entireio/auth-go v0.5.0 h1:omda1kFqyxrxxzDHtb9HH2ObgCaDUz8P2HQK+3g1QLg=
+github.com/entireio/auth-go v0.5.0/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/fatih/semgroup v1.2.0 h1:h/OLXwEM+3NNyAdZEpMiH1OzfplU09i2qXPVThGZvyg=

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,6 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/entireio/auth-go v0.4.1-0.20260603125945-62cd5140d2d4 h1:apyo1X5SUGjbvFJyzaw2WSTTq7suvtYZ5JMA83lbx7M=
-github.com/entireio/auth-go v0.4.1-0.20260603125945-62cd5140d2d4/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
 github.com/entireio/auth-go v0.4.1-0.20260604093244-dfb6f1d8eb12 h1:9xItErYdM5WKYjsdBqwCKmdCqEj+KhAgqSRXdOtWUCQ=
 github.com/entireio/auth-go v0.4.1-0.20260604093244-dfb6f1d8eb12/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/entireio/auth-go v0.4.1-0.20260604093244-dfb6f1d8eb12 h1:9xItErYdM5WKYjsdBqwCKmdCqEj+KhAgqSRXdOtWUCQ=
-github.com/entireio/auth-go v0.4.1-0.20260604093244-dfb6f1d8eb12/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
+github.com/entireio/auth-go v0.4.1-0.20260610004806-f943c0bc8826 h1:X0TQoeD+zjMm7mt2YZa9kx2TgYGM9SYJLZ/pj5TX9us=
+github.com/entireio/auth-go v0.4.1-0.20260610004806-f943c0bc8826/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/fatih/semgroup v1.2.0 h1:h/OLXwEM+3NNyAdZEpMiH1OzfplU09i2qXPVThGZvyg=

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/entireio/auth-go v0.4.1-0.20260603125945-62cd5140d2d4 h1:apyo1X5SUGjbvFJyzaw2WSTTq7suvtYZ5JMA83lbx7M=
 github.com/entireio/auth-go v0.4.1-0.20260603125945-62cd5140d2d4/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
+github.com/entireio/auth-go v0.4.1-0.20260604093244-dfb6f1d8eb12 h1:9xItErYdM5WKYjsdBqwCKmdCqEj+KhAgqSRXdOtWUCQ=
+github.com/entireio/auth-go v0.4.1-0.20260604093244-dfb6f1d8eb12/go.mod h1:eqFYgiNSBw6HXYR3j8DRW0/WTV1dX3SWxr2D6YCYNQ0=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/fatih/semgroup v1.2.0 h1:h/OLXwEM+3NNyAdZEpMiH1OzfplU09i2qXPVThGZvyg=


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/517
<!-- entire-trail-link-end -->

## What

`entire login` now opens your browser by default and finishes automatically — no code to copy.

```
entire login            # browser sign-in (default when interactive)
entire login --device   # the old device-code flow
```

```
Logging in to: https://us.auth.entire.io

Press Enter to open in browser...

Waiting for sign-in... ✓ Login complete.
```

Falls back to the device-code flow automatically when there's no interactive terminal (CI, piped, SSH without a tty), so headless logins keep working — same shape as `gh` / `gcloud` / `aws sso`.

## How

RFC 8252 loopback authorization-code flow with PKCE, via auth-go's new `authcode` package: bind a `127.0.0.1` listener, open the browser, catch the redirect, exchange the code. Shares the token-validate/save/context-record tail with the device flow.

## Verified against prod (`us.auth.entire.io`)

- Discovery doc: `authorization_endpoint=/authorize`, `code_challenge_methods_supported=["S256"]`, `authorization_code` grant, public-client (`none`) auth.
- `entire-cli` is registered with a `http://127.0.0.1/callback` loopback redirect, any-port (probed: unknown client and unregistered redirect both 400 at `/authorize`; two ephemeral ports accepted).

## Before merge (stacked) - DONE ✅

Stacked on entireio/auth-go#16 (`authcode` package). `go.mod` is pinned to that branch's pseudo-version so this builds today; once #16 merges + tags, re-pin: `go get github.com/entireio/auth-go@<tag> && go mod tidy`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the default authentication path and OAuth loopback/PKCE handling; mistakes could break login or weaken token handling across environments.
> 
> **Overview**
> **`entire login`** now defaults to a **loopback browser (PKCE authorization-code)** sign-in when an interactive terminal is available, with **`--device`** to keep the previous device-code flow. Non-interactive environments (CI, pipes, SSH without a tty) still use device-code automatically.
> 
> The auth client wires **`auth-go` `authcode`** alongside device flow, adds **`AuthorizePath`** on v1/v2 providers, and exposes **`StartBrowserAuth` / `BrowserAuthFlow`**. Login shares token validation and persistence via **`persistLogin`** for both paths. Test-only behavior skips blocking on `/dev/tty` and refuses to spawn a real browser so integration tests can drive the loopback callback from printed URLs.
> 
> **`go.mod`** pins a newer **`github.com/entireio/auth-go`** pseudo-version that includes the `authcode` package (stacked on auth-go#16).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ea776af5f3597e464400a03adb4dd364fe0de9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->