### PR TITLE
COR-389: control-plane commands follow the active auth context

### DIFF
--- a/cmd/entire/cli/api/base_url.go
+++ b/cmd/entire/cli/api/base_url.go
@@ -64,15 +64,6 @@ func AuthBaseURL() string {
 	return NormalizeOriginURL(raw)
 }
 
-// AuthBaseURLOverridden reports whether ENTIRE_AUTH_BASE_URL is explicitly
-// set (non-empty after trimming). Control-plane host resolution treats an
-// explicit override as unconditional: it pins the core to that origin and
-// skips the active-context lookup, so split-host / local-dev invocations that
-// already set this var keep their exact behaviour.
-func AuthBaseURLOverridden() bool {
-	return strings.TrimSpace(os.Getenv(AuthBaseURLEnvVar)) != ""
-}
-
 // IsSplitHost reports whether the CLI is configured for split-host —
 // i.e. ENTIRE_AUTH_BASE_URL points at a different origin than the data
 // API. Both sides are canonicalised via NormalizeOriginURL before

--- a/cmd/entire/cli/api/base_url.go
+++ b/cmd/entire/cli/api/base_url.go
@@ -64,6 +64,15 @@ func AuthBaseURL() string {
 	return NormalizeOriginURL(raw)
 }
 
+// AuthBaseURLOverridden reports whether ENTIRE_AUTH_BASE_URL is explicitly
+// set (non-empty after trimming). Control-plane host resolution treats an
+// explicit override as unconditional: it pins the core to that origin and
+// skips the active-context lookup, so split-host / local-dev invocations that
+// already set this var keep their exact behaviour.
+func AuthBaseURLOverridden() bool {
+	return strings.TrimSpace(os.Getenv(AuthBaseURLEnvVar)) != ""
+}
+
 // IsSplitHost reports whether the CLI is configured for split-host —
 // i.e. ENTIRE_AUTH_BASE_URL points at a different origin than the data
 // API. Both sides are canonicalised via NormalizeOriginURL before

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -167,7 +167,10 @@ func newAuthStatusCmd() *cobra.Command {
 			if err := requireSecureBaseURL(insecureHTTPAuth); err != nil {
 				return err
 			}
-			target := resolveStatusTarget(auth.NewContextStore(), auth.Contexts, api.AuthBaseURL())
+			target, err := resolveStatusTarget(auth.NewContextStore(), auth.Contexts, api.AuthBaseURL())
+			if err != nil {
+				return err
+			}
 			// We send the session token to target.coreURL; enforce TLS on it
 			// too (it may differ from AuthBaseURL when a context is active).
 			if !insecureHTTPAuth {
@@ -220,25 +223,31 @@ type statusTarget struct {
 // active contexts.json context wins (so `auth use` retargets status onto that
 // login server); otherwise it falls back to the legacy keyring entry keyed by
 // the configured auth host.
-func resolveStatusTarget(store tokenStore, listContexts contextsProvider, fallbackBaseURL string) statusTarget {
+//
+// A genuine contexts.json read/parse error is surfaced, not swallowed — a
+// missing file reads as "no contexts" (no error), so an error here means the
+// file is corrupt or unreadable, which the user must see. This keeps status
+// symmetric with the control-plane commands (auth.ResolveControlPlaneTarget),
+// which fail the same way rather than silently degrading to a stale identity.
+func resolveStatusTarget(store tokenStore, listContexts contextsProvider, fallbackBaseURL string) (statusTarget, error) {
 	all, current, err := listContexts()
-	total := 0
-	if err == nil {
-		total = len(all)
-		for _, c := range all {
-			if c.Name != current || c.CoreURL == "" {
-				continue
-			}
-			if tok, terr := auth.LoginTokenForContext(c); terr == nil && tok != "" {
-				return statusTarget{coreURL: c.CoreURL, token: tok, activeContext: c.Name, totalContexts: total}
-			}
+	if err != nil {
+		return statusTarget{}, fmt.Errorf("load contexts: %w", err)
+	}
+	total := len(all)
+	for _, c := range all {
+		if c.Name != current || c.CoreURL == "" {
+			continue
+		}
+		if tok, terr := auth.LoginTokenForContext(c); terr == nil && tok != "" {
+			return statusTarget{coreURL: c.CoreURL, token: tok, activeContext: c.Name, totalContexts: total}, nil
 		}
 	}
 	tok, gerr := store.GetToken(fallbackBaseURL)
 	if gerr != nil {
 		tok = "" // best-effort: a keyring read failure just reads as "no token"
 	}
-	return statusTarget{coreURL: fallbackBaseURL, token: tok, totalContexts: total}
+	return statusTarget{coreURL: fallbackBaseURL, token: tok, totalContexts: total}, nil
 }
 
 // defaultFetchProfile fetches a user's profile from coreURL's GET /me with the

--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -23,22 +23,19 @@ type ControlPlaneTarget struct {
 // ResolveControlPlaneTarget chooses which core the control-plane commands talk
 // to and how their bearer is obtained. The control-plane host *is* a core, so
 // there is no /.well-known discovery here — the active context already names
-// the core. Precedence:
+// the core. Precedence (matching `auth status`):
 //
-//  1. ENTIRE_AUTH_BASE_URL explicitly set -> that origin verbatim, bearer via
-//     the singleton manager (TokenForResource), exactly as before. The env
-//     var stays an unconditional override so split-host / local-dev
-//     invocations are untouched.
-//  2. otherwise the active contexts.json login -> its CoreURL, with a
-//     per-context refreshing bearer (silent JWT re-mint). This is what makes
+//  1. the active contexts.json login -> its CoreURL, with a per-context
+//     refreshing bearer (silent JWT re-mint). This is what makes
 //     `entire auth use <ctx>` retarget the control plane onto that core.
-//  3. no active context -> the configured default origin + TokenForResource,
-//     the pre-contexts behaviour for users who never ran `entire auth use`.
+//  2. no active context -> the configured auth origin (ENTIRE_AUTH_BASE_URL or
+//     the default) + TokenForResource, the pre-contexts fallback.
+//
+// ENTIRE_AUTH_BASE_URL is the fallback host, not an override: a token minted
+// by the active context's core can't authenticate against a different host, so
+// "use the override host but the context's identity" can't succeed. The active
+// context always wins when present.
 func ResolveControlPlaneTarget() (ControlPlaneTarget, error) {
-	if api.AuthBaseURLOverridden() {
-		return staticControlPlaneTarget(), nil
-	}
-
 	c, ok, err := activeContext()
 	if err != nil {
 		return ControlPlaneTarget{}, err
@@ -58,11 +55,10 @@ func ResolveControlPlaneTarget() (ControlPlaneTarget, error) {
 	return ControlPlaneTarget{CoreURL: strings.TrimRight(c.CoreURL, "/"), TokenSource: src}, nil
 }
 
-// staticControlPlaneTarget is the pre-contexts path: dial the configured auth
-// origin and resolve the bearer through the singleton manager, which performs
-// an RFC 8693 exchange when the stored token's audience doesn't cover the
-// core. Used for an explicit ENTIRE_AUTH_BASE_URL override and as the
-// no-active-context fallback.
+// staticControlPlaneTarget is the no-active-context fallback: dial the
+// configured auth origin (ENTIRE_AUTH_BASE_URL or the default) and resolve the
+// bearer through the singleton manager, which performs an RFC 8693 exchange
+// when the stored token's audience doesn't cover the core.
 func staticControlPlaneTarget() ControlPlaneTarget {
 	base := strings.TrimRight(api.AuthBaseURL(), "/")
 	// The exchange's resource must be the bare origin; OriginOnly strips any

--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+)
+
+// ControlPlaneTarget is the resolved login server a control-plane request
+// (org/repo/project/grant) should dial, plus the bearer source for it.
+//
+// CoreURL is an origin (no /api/v1 suffix); the caller appends the API base
+// path. TokenSource returns a bearer valid for CoreURL, re-minting silently
+// from the stored refresh token when the active context drives resolution.
+type ControlPlaneTarget struct {
+	CoreURL     string
+	TokenSource func(context.Context) (string, error)
+}
+
+// ResolveControlPlaneTarget chooses which core the control-plane commands talk
+// to and how their bearer is obtained. The control-plane host *is* a core, so
+// there is no /.well-known discovery here — the active context already names
+// the core. Precedence:
+//
+//  1. ENTIRE_AUTH_BASE_URL explicitly set -> that origin verbatim, bearer via
+//     the singleton manager (TokenForResource), exactly as before. The env
+//     var stays an unconditional override so split-host / local-dev
+//     invocations are untouched.
+//  2. otherwise the active contexts.json login -> its CoreURL, with a
+//     per-context refreshing bearer (silent JWT re-mint). This is what makes
+//     `entire auth use <ctx>` retarget the control plane onto that core.
+//  3. no active context -> the configured default origin + TokenForResource,
+//     the pre-contexts behaviour for users who never ran `entire auth use`.
+func ResolveControlPlaneTarget() (ControlPlaneTarget, error) {
+	if api.AuthBaseURLOverridden() {
+		return staticControlPlaneTarget(), nil
+	}
+
+	c, ok, err := activeContext()
+	if err != nil {
+		return ControlPlaneTarget{}, err
+	}
+	if !ok {
+		return staticControlPlaneTarget(), nil
+	}
+
+	// The refreshing provider keys its own token manager on c.CoreURL as the
+	// issuer, so its store reads and STS/refresh both target the right core —
+	// the bug the singleton manager (pinned to AuthBaseURL) has when the
+	// active context lives on a different core.
+	src, err := NewRefreshingLoginProvider(c, nil, insecureHTTPEnabled() || isLoopbackHTTP(c.CoreURL))
+	if err != nil {
+		return ControlPlaneTarget{}, fmt.Errorf("build token source for context %q: %w", c.Name, err)
+	}
+	return ControlPlaneTarget{CoreURL: strings.TrimRight(c.CoreURL, "/"), TokenSource: src}, nil
+}
+
+// staticControlPlaneTarget is the pre-contexts path: dial the configured auth
+// origin and resolve the bearer through the singleton manager, which performs
+// an RFC 8693 exchange when the stored token's audience doesn't cover the
+// core. Used for an explicit ENTIRE_AUTH_BASE_URL override and as the
+// no-active-context fallback.
+func staticControlPlaneTarget() ControlPlaneTarget {
+	base := strings.TrimRight(api.AuthBaseURL(), "/")
+	// The exchange's resource must be the bare origin; OriginOnly strips any
+	// path/query so the audience the manager keys on matches the server's.
+	resource := api.OriginOnly(base)
+	return ControlPlaneTarget{
+		CoreURL: base,
+		TokenSource: func(ctx context.Context) (string, error) {
+			return TokenForResource(ctx, resource)
+		},
+	}
+}
+
+// activeContext returns the active contexts.json login and ok=true, or
+// ok=false when there is no current context or it carries no CoreURL (an
+// unusable pointer we treat as "no active context" rather than dialing an
+// empty host).
+func activeContext() (c *contexts.Context, ok bool, err error) {
+	f, err := contexts.Load(contexts.DefaultConfigDir())
+	if err != nil {
+		return nil, false, fmt.Errorf("load contexts: %w", err)
+	}
+	c = f.Find(f.CurrentContext)
+	if c == nil || c.CoreURL == "" {
+		return nil, false, nil
+	}
+	return c, true, nil
+}

--- a/cmd/entire/cli/auth/control_plane_test.go
+++ b/cmd/entire/cli/auth/control_plane_test.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+// These tests drive process-global state (ENTIRE_AUTH_BASE_URL,
+// ENTIRE_CONFIG_DIR, the token-store backend) so they cannot run in parallel.
+
+// writeActiveContext writes a single-context contexts.json under configDir and
+// marks it current.
+func writeActiveContext(t *testing.T, configDir, name, coreURL, handle, svc string) {
+	t.Helper()
+	c := &contexts.Context{Name: name, CoreURL: coreURL, Handle: handle, KeychainService: svc}
+	if err := contexts.Save(configDir, &contexts.File{CurrentContext: name, Contexts: []*contexts.Context{c}}); err != nil {
+		t.Fatalf("write contexts.json: %v", err)
+	}
+}
+
+// An explicit ENTIRE_AUTH_BASE_URL pins the core to that origin and skips the
+// active-context lookup entirely — the override is unconditional.
+func TestResolveControlPlaneTarget_EnvOverrideWins(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+	t.Setenv(api.AuthBaseURLEnvVar, "https://override.example")
+
+	// An active context on a *different* core must be ignored under override.
+	writeActiveContext(t, configDir, "ctx", "https://other-core.example", "alice", "svc")
+
+	target, err := ResolveControlPlaneTarget()
+	if err != nil {
+		t.Fatalf("ResolveControlPlaneTarget: %v", err)
+	}
+	if want := api.AuthBaseURL(); target.CoreURL != want {
+		t.Fatalf("CoreURL = %q, want the override origin %q (not the context core)", target.CoreURL, want)
+	}
+}
+
+// With no override and an active context, the target is that context's core and
+// the bearer comes from the context's keyring slot (the refreshing provider).
+func TestResolveControlPlaneTarget_ActiveContextWins(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+	t.Setenv(api.AuthBaseURLEnvVar, "") // ensure no override leaks in from the env
+
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	const coreURL = "https://ctx-core.example"
+	svc := tokenstore.CoreKeyringService(coreURL)
+	jwt := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(jwt, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	writeActiveContext(t, configDir, "alice@core", coreURL, "alice", svc)
+
+	target, err := ResolveControlPlaneTarget()
+	if err != nil {
+		t.Fatalf("ResolveControlPlaneTarget: %v", err)
+	}
+	if target.CoreURL != coreURL {
+		t.Fatalf("CoreURL = %q, want the active context's core %q", target.CoreURL, coreURL)
+	}
+	// The fresh token is returned with no network call, proving the source is
+	// wired to the context's keyring slot.
+	got, err := target.TokenSource(context.Background())
+	if err != nil {
+		t.Fatalf("TokenSource: %v", err)
+	}
+	if got != jwt {
+		t.Fatalf("TokenSource returned %q, want the context's stored JWT", got)
+	}
+}
+
+// With no override and no active context, the target falls back to the
+// configured default auth origin (pre-contexts behaviour).
+func TestResolveControlPlaneTarget_NoContextFallsBackToDefault(t *testing.T) {
+	configDir := t.TempDir() // empty: no contexts.json
+	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+	t.Setenv(api.AuthBaseURLEnvVar, "")
+
+	target, err := ResolveControlPlaneTarget()
+	if err != nil {
+		t.Fatalf("ResolveControlPlaneTarget: %v", err)
+	}
+	if want := api.AuthBaseURL(); target.CoreURL != want {
+		t.Fatalf("CoreURL = %q, want the default auth origin %q", target.CoreURL, want)
+	}
+}

--- a/cmd/entire/cli/auth/control_plane_test.go
+++ b/cmd/entire/cli/auth/control_plane_test.go
@@ -25,22 +25,23 @@ func writeActiveContext(t *testing.T, configDir, name, coreURL, handle, svc stri
 	}
 }
 
-// An explicit ENTIRE_AUTH_BASE_URL pins the core to that origin and skips the
-// active-context lookup entirely — the override is unconditional.
-func TestResolveControlPlaneTarget_EnvOverrideWins(t *testing.T) {
+// The active context wins even when ENTIRE_AUTH_BASE_URL is set to a different
+// origin: the env var is a fallback host, not an override (a token from the
+// context's core can't authenticate against the env host anyway).
+func TestResolveControlPlaneTarget_ActiveContextBeatsEnv(t *testing.T) {
 	configDir := t.TempDir()
 	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
 	t.Setenv(api.AuthBaseURLEnvVar, "https://override.example")
 
-	// An active context on a *different* core must be ignored under override.
-	writeActiveContext(t, configDir, "ctx", "https://other-core.example", "alice", "svc")
+	const coreURL = "https://other-core.example"
+	writeActiveContext(t, configDir, "ctx", coreURL, "alice", "svc")
 
 	target, err := ResolveControlPlaneTarget()
 	if err != nil {
 		t.Fatalf("ResolveControlPlaneTarget: %v", err)
 	}
-	if want := api.AuthBaseURL(); target.CoreURL != want {
-		t.Fatalf("CoreURL = %q, want the override origin %q (not the context core)", target.CoreURL, want)
+	if target.CoreURL != coreURL {
+		t.Fatalf("CoreURL = %q, want the active context's core %q (env is only a fallback)", target.CoreURL, coreURL)
 	}
 }
 
@@ -80,18 +81,35 @@ func TestResolveControlPlaneTarget_ActiveContextWins(t *testing.T) {
 	}
 }
 
-// With no override and no active context, the target falls back to the
-// configured default auth origin (pre-contexts behaviour).
-func TestResolveControlPlaneTarget_NoContextFallsBackToDefault(t *testing.T) {
-	configDir := t.TempDir() // empty: no contexts.json
-	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
-	t.Setenv(api.AuthBaseURLEnvVar, "")
+// With no active context, the target falls back to the configured auth origin
+// — the default when ENTIRE_AUTH_BASE_URL is unset, or the env value when set
+// (the env var is the fallback host).
+func TestResolveControlPlaneTarget_NoContextFallsBackToAuthBaseURL(t *testing.T) {
+	t.Run("default when env unset", func(t *testing.T) {
+		configDir := t.TempDir() // empty: no contexts.json
+		t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+		t.Setenv(api.AuthBaseURLEnvVar, "")
 
-	target, err := ResolveControlPlaneTarget()
-	if err != nil {
-		t.Fatalf("ResolveControlPlaneTarget: %v", err)
-	}
-	if want := api.AuthBaseURL(); target.CoreURL != want {
-		t.Fatalf("CoreURL = %q, want the default auth origin %q", target.CoreURL, want)
-	}
+		target, err := ResolveControlPlaneTarget()
+		if err != nil {
+			t.Fatalf("ResolveControlPlaneTarget: %v", err)
+		}
+		if want := api.AuthBaseURL(); target.CoreURL != want {
+			t.Fatalf("CoreURL = %q, want the default auth origin %q", target.CoreURL, want)
+		}
+	})
+
+	t.Run("env value when set", func(t *testing.T) {
+		configDir := t.TempDir()
+		t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+		t.Setenv(api.AuthBaseURLEnvVar, "https://fallback.example")
+
+		target, err := ResolveControlPlaneTarget()
+		if err != nil {
+			t.Fatalf("ResolveControlPlaneTarget: %v", err)
+		}
+		if want := api.AuthBaseURL(); target.CoreURL != want {
+			t.Fatalf("CoreURL = %q, want the env fallback origin %q", target.CoreURL, want)
+		}
+	})
 }

--- a/cmd/entire/cli/auth/control_plane_test.go
+++ b/cmd/entire/cli/auth/control_plane_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -78,6 +79,20 @@ func TestResolveControlPlaneTarget_ActiveContextWins(t *testing.T) {
 	}
 	if got != jwt {
 		t.Fatalf("TokenSource returned %q, want the context's stored JWT", got)
+	}
+}
+
+// A genuine contexts.json read/parse error must fail loud — not silently fall
+// back to a stale legacy identity for a control-plane mutation.
+func TestResolveControlPlaneTarget_CorruptContextsErrors(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+	t.Setenv(api.AuthBaseURLEnvVar, "")
+	if err := os.WriteFile(filepath.Join(configDir, "contexts.json"), []byte("{ not valid json"), 0o600); err != nil {
+		t.Fatalf("write corrupt contexts.json: %v", err)
+	}
+	if _, err := ResolveControlPlaneTarget(); err == nil {
+		t.Fatal("want an error when contexts.json is corrupt, got nil")
 	}
 }
 

--- a/cmd/entire/cli/auth/exchange.go
+++ b/cmd/entire/cli/auth/exchange.go
@@ -54,6 +54,14 @@ func EnableInsecureHTTP() {
 	insecureHTTPOverride.Store(true)
 }
 
+// insecureHTTPEnabled reports whether EnableInsecureHTTP was called. The
+// per-context control-plane provider (which bypasses the singleton manager)
+// reads this so --insecure-http-auth still relaxes the HTTPS guard for a
+// non-loopback http:// core, mirroring the singleton's AllowInsecureHTTP.
+func insecureHTTPEnabled() bool {
+	return insecureHTTPOverride.Load()
+}
+
 // SetManagerForTest installs mgr as the manager returned by
 // defaultManager() and returns a cleanup function. Test-only.
 func SetManagerForTest(t interface{ Helper() }, mgr *tokenmanager.Manager) func() {

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/spf13/cobra"
@@ -12,25 +11,22 @@ import (
 
 // newAuthUseCmd switches the active login context.
 //
-// For `git clone entire://…` the active context is the preferred identity:
-// it authenticates any cluster fronted by its login server, and switching
-// here takes effect on the next operation (resolution recomputes the account
-// every time). Control-plane commands (auth status/list/revoke, org/project/
-// repo/grant) currently target the configured auth host (ENTIRE_AUTH_BASE_URL
-// / the default) regardless of the active context's login server, so
-// switching to a context on a *different* login server does not yet retarget
-// them — auth use warns when that's the case.
+// The active context is the preferred identity for both `git clone entire://…`
+// (it authenticates any cluster fronted by its login server) and the
+// control-plane commands (auth status, org/project/repo/grant), which dial the
+// context's core. Switching takes effect on the next operation; resolution
+// recomputes every time. Data-API commands (activity/search/trail/dispatch)
+// still target ENTIRE_API_BASE_URL and do not follow the active context yet.
 func newAuthUseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "use <context>",
 		Short: "Switch the active login context",
 		Long: "Switch the active login context.\n\n" +
-			"For `git clone entire://…` the active context is the preferred identity: it\n" +
-			"authenticates any cluster fronted by its login server, and the switch takes\n" +
-			"effect on the next operation.\n\n" +
-			"Control-plane commands (auth status/list/revoke, org/project/repo/grant) still\n" +
-			"target the configured auth host (ENTIRE_AUTH_BASE_URL / the default), so\n" +
-			"switching to a context on a different login server does not retarget them yet.",
+			"The active context is the preferred identity for `git clone entire://…` and\n" +
+			"the control-plane commands (auth status, org/project/repo/grant), which dial\n" +
+			"the context's core. The switch takes effect on the next operation.\n\n" +
+			"Data-API commands (activity/search/trail/dispatch) still target\n" +
+			"ENTIRE_API_BASE_URL and do not follow the active context yet.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completeContextNames,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -38,7 +34,6 @@ func newAuthUseCmd() *cobra.Command {
 				return err //nolint:wrapcheck // already a user-facing message
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Now using context %q.\n", args[0])
-			warnIfCrossCoreContext(cmd.ErrOrStderr(), args[0])
 			return nil
 		},
 	}
@@ -70,33 +65,6 @@ func completeContextNames(_ *cobra.Command, args []string, _ string) ([]string, 
 		out = append(out, c.Name+"\t"+desc)
 	}
 	return out, cobra.ShellCompDirectiveNoFileComp
-}
-
-// warnIfCrossCoreContext warns when the now-active context authenticates
-// against a different core than the control plane targets. Clone resolves
-// per-cluster and is unaffected, but auth status/list/revoke and the
-// org/project/repo/grant commands still hit the configured auth host —
-// switching cores there isn't wired up yet, so flag it rather than
-// silently authenticate against the wrong host.
-func warnIfCrossCoreContext(errW io.Writer, name string) {
-	all, _, err := auth.Contexts()
-	if err != nil {
-		return
-	}
-	authHost := api.AuthBaseURL()
-	for _, c := range all {
-		if c.Name != name {
-			continue
-		}
-		if c.CoreURL == "" || api.OriginOnly(c.CoreURL) == api.OriginOnly(authHost) {
-			return
-		}
-		fmt.Fprintf(errW,
-			"Note: %q authenticates against %s, but control-plane commands still target %s — switching the active context doesn't retarget control-plane commands yet.\n"+
-				"For `git clone entire://…`, this context now authenticates any cluster fronted by %s.\n",
-			name, c.CoreURL, authHost, c.CoreURL)
-		return
-	}
 }
 
 // newAuthContextsCmd lists the stored login contexts and marks the active

--- a/cmd/entire/cli/auth_context.go
+++ b/cmd/entire/cli/auth_context.go
@@ -24,7 +24,7 @@ func newAuthUseCmd() *cobra.Command {
 		Long: "Switch the active login context.\n\n" +
 			"The active context is the preferred identity for `git clone entire://…` and\n" +
 			"the control-plane commands (auth status, org/project/repo/grant), which dial\n" +
-			"the context's core. The switch takes effect on the next operation.\n\n" +
+			"the context's login server. The switch takes effect on the next operation.\n\n" +
 			"Data-API commands (activity/search/trail/dispatch) still target\n" +
 			"ENTIRE_API_BASE_URL and do not follow the active context yet.",
 		Args:              cobra.ExactArgs(1),

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -28,7 +29,10 @@ func TestResolveStatusTarget_PrefersActiveContext(t *testing.T) {
 		t.Fatalf("record context: %v", err)
 	}
 
-	got := resolveStatusTarget(auth.NewContextStore(), auth.Contexts, "https://fallback.example.com")
+	got, err := resolveStatusTarget(auth.NewContextStore(), auth.Contexts, "https://fallback.example.com")
+	if err != nil {
+		t.Fatalf("resolveStatusTarget: %v", err)
+	}
 	if got.coreURL != "https://eu.auth.entire.io" {
 		t.Errorf("coreURL = %q, want the active context's CoreURL", got.coreURL)
 	}
@@ -37,6 +41,23 @@ func TestResolveStatusTarget_PrefersActiveContext(t *testing.T) {
 	}
 	if got.activeContext == "" {
 		t.Error("activeContext = empty, want the active context name")
+	}
+}
+
+// A genuine contexts.json read/parse error is surfaced by resolveStatusTarget,
+// symmetric with the control-plane commands — not swallowed into the legacy
+// fallback. (A missing file reads as "no contexts" and is not an error.)
+func TestResolveStatusTarget_CorruptContextsErrors(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	if err := os.WriteFile(filepath.Join(cfgDir, "contexts.json"), []byte("{ not valid json"), 0o600); err != nil {
+		t.Fatalf("write corrupt contexts.json: %v", err)
+	}
+	if _, err := resolveStatusTarget(auth.NewContextStore(), auth.Contexts, "https://fallback.example.com"); err == nil {
+		t.Fatal("want an error when contexts.json is corrupt, got nil")
 	}
 }
 

--- a/cmd/entire/cli/auth_context_test.go
+++ b/cmd/entire/cli/auth_context_test.go
@@ -158,38 +158,6 @@ func TestCompleteContextNames_NoContexts(t *testing.T) {
 	}
 }
 
-func TestWarnIfCrossCoreContext(t *testing.T) {
-	cfgDir := t.TempDir()
-	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)
-	t.Setenv("ENTIRE_AUTH_BASE_URL", "https://auth.example.com")
-	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
-	t.Cleanup(restore)
-
-	exp := time.Now().Add(time.Hour).Unix()
-
-	// Same core as the configured auth host: no warning.
-	sameName, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://auth.example.com","handle":"alice","exp":%d}`, exp)), "", true)
-	if err != nil {
-		t.Fatalf("record same-core: %v", err)
-	}
-	var same bytes.Buffer
-	warnIfCrossCoreContext(&same, sameName)
-	if same.Len() != 0 {
-		t.Fatalf("same-core context should not warn, got: %q", same.String())
-	}
-
-	// Different core: warns that the control plane won't follow.
-	otherName, err := auth.RecordLoginContext(makeContextJWT(t, fmt.Sprintf(`{"iss":"https://other.example.com","handle":"alice","exp":%d}`, exp)), "", true)
-	if err != nil {
-		t.Fatalf("record cross-core: %v", err)
-	}
-	var diff bytes.Buffer
-	warnIfCrossCoreContext(&diff, otherName)
-	if !strings.Contains(diff.String(), "other.example.com") || !strings.Contains(diff.String(), "control-plane") {
-		t.Fatalf("cross-core context should warn, got: %q", diff.String())
-	}
-}
-
 func TestPromoteNextLogin(t *testing.T) {
 	cfgDir := t.TempDir()
 	t.Setenv("ENTIRE_CONFIG_DIR", cfgDir)

--- a/cmd/entire/cli/logout.go
+++ b/cmd/entire/cli/logout.go
@@ -74,7 +74,10 @@ func newLogoutCmd() *cobra.Command {
 
 			// Revoke against the active context's core (matching what
 			// `auth status` lists), not a static AuthBaseURL.
-			target := resolveStatusTarget(auth.NewContextStore(), auth.Contexts, api.AuthBaseURL())
+			target, err := resolveStatusTarget(auth.NewContextStore(), auth.Contexts, api.AuthBaseURL())
+			if err != nil {
+				return err
+			}
 			if !insecureHTTPAuth {
 				if err := api.RequireSecureURL(target.coreURL); err != nil {
 					return fmt.Errorf("context login server URL check: %w", err)

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -40,20 +40,23 @@ sole eligible context, else an error (zero → login hint; ambiguous → asks fo
 ### Control plane (done — this slice)
 
 The host *is* a core, so there is no discovery. `coreapi.New()` consults
-`auth.ResolveControlPlaneTarget()`:
+`auth.ResolveControlPlaneTarget()`, which mirrors `auth status`:
 
-1. **`ENTIRE_AUTH_BASE_URL` set** → that origin, verbatim; bearer via the
-   singleton token manager (`TokenForResource`). The env var is an
-   unconditional override, so split-host / local-dev invocations are
-   untouched.
-2. **else active context** → its `CoreURL`, with a **per-context refreshing**
+1. **active context** → its `CoreURL`, with a **per-context refreshing**
    bearer (`auth.NewRefreshingLoginProvider`): the token manager is keyed on
    `c.CoreURL` as issuer, so store reads and refresh/STS hit the right core,
    and an expired access token is silently re-minted from the stored refresh
    token. This is what makes `entire auth use <ctx>` actually retarget
    `org`/`repo`/`project`/`grant`.
-3. **else** (no active context) → the configured default origin +
-   `TokenForResource` — the pre-contexts behaviour.
+2. **else** (no active context) → the configured auth origin
+   (`ENTIRE_AUTH_BASE_URL` or the default) + `TokenForResource` — the
+   pre-contexts fallback.
+
+`ENTIRE_AUTH_BASE_URL` is the fallback host, **not** an override: a token
+minted by the active context's core can't authenticate against a different
+host, so the active context always wins when present. (At login time the env
+var still chooses where to authenticate, and the resulting context's `CoreURL`
+*is* that host — so local-dev / split-host setups keep working.)
 
 Key files: `cmd/entire/cli/auth/control_plane.go` (resolver),
 `cmd/entire/cli/auth/refresh.go` (per-context refreshing provider),
@@ -97,5 +100,7 @@ auto-selects the right context without also setting `ENTIRE_AUTH_BASE_URL`):
    the `activity` / `search` / `trail` / `dispatch` constructors
    (`NewAuthenticatedAPIClient`, `dispatch.NewCloudClient`, `search.Search`).
 
-`ENTIRE_AUTH_BASE_URL` / `ENTIRE_API_BASE_URL` remain explicit overrides: when
-set they short-circuit discovery; discovery only runs when they are unset.
+`ENTIRE_API_BASE_URL` names the resource host to dial (the discovery target);
+the context is then chosen from the issuers that host advertises. It does not
+need to be paired with `ENTIRE_AUTH_BASE_URL` once discovery exists — that is
+the whole point of the well-known.

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -1,0 +1,101 @@
+# Upstream Host & Auth-Context Resolution
+
+How the CLI decides *which host to dial* and *which login (auth context) to
+authenticate as* for every upstream call. The goal is one mental model:
+
+> An **auth context** is a login to one **core** (the identity provider /
+> login server). Every upstream call resolves to some host. That host either
+> **is** a core — use the active context's core directly — or it is a
+> **resource server** that advertises which cores it trusts via a
+> `/.well-known` blob, so the CLI picks the context whose core is trusted and
+> exchanges that context's token for the resource.
+
+There is no separate "auth system" per service. There is one identity model
+(`contexts.json`, keyed on `CoreURL`) and a set of resource servers that
+accept a core's JWTs.
+
+## The pieces
+
+| Role | Service (prod / staging) | Hit by | Trusted-core discovery |
+|---|---|---|---|
+| **Core** — IdP **and** control-plane API, co-located | `entire-core` (`us.auth.entire.io`) | `org` / `repo` / `project` / `grant`, `auth *`, `login` | none needed — the host *is* the core |
+| **Resource: git cluster** | `entire-server` / `entiredb` | `git-remote-entire` (clone/push) | `/.well-known/entire-cluster.json` → `core_urls` |
+| **Resource: web/data API** | `entire.io` (`partial.to`) | `activity` / `search` / `trail` / `dispatch` | **none today** — see [Deferred](#deferred) |
+
+`contexts.json` (`$ENTIRE_CONFIG_DIR/contexts.json`, shared with entiredb's
+CLIs) stores each login as `{Name, CoreURL, Handle, KeychainService}` plus a
+`CurrentContext` pointer. `CoreURL` is the JWT `iss` — the core that minted the
+token. `entire auth use <ctx>` flips `CurrentContext`.
+
+## Resolution per call type
+
+### Git cluster (done — `internal/entireclient/clusterdiscovery`)
+
+`ResolveContextForCluster(host)` fetches+caches the cluster's
+`/.well-known/entire-cluster.json`, reads `core_urls`, then selects the
+context: active-context-wins if its `CoreURL` is among the cores, else the
+sole eligible context, else an error (zero → login hint; ambiguous → asks for
+`auth use`). The token is then exchanged for the cluster.
+
+### Control plane (done — this slice)
+
+The host *is* a core, so there is no discovery. `coreapi.New()` consults
+`auth.ResolveControlPlaneTarget()`:
+
+1. **`ENTIRE_AUTH_BASE_URL` set** → that origin, verbatim; bearer via the
+   singleton token manager (`TokenForResource`). The env var is an
+   unconditional override, so split-host / local-dev invocations are
+   untouched.
+2. **else active context** → its `CoreURL`, with a **per-context refreshing**
+   bearer (`auth.NewRefreshingLoginProvider`): the token manager is keyed on
+   `c.CoreURL` as issuer, so store reads and refresh/STS hit the right core,
+   and an expired access token is silently re-minted from the stored refresh
+   token. This is what makes `entire auth use <ctx>` actually retarget
+   `org`/`repo`/`project`/`grant`.
+3. **else** (no active context) → the configured default origin +
+   `TokenForResource` — the pre-contexts behaviour.
+
+Key files: `cmd/entire/cli/auth/control_plane.go` (resolver),
+`cmd/entire/cli/auth/refresh.go` (per-context refreshing provider),
+`internal/coreapi/client.go` (`New()` + `providerSource`),
+`cmd/entire/cli/api/base_url.go` (`AuthBaseURLOverridden`).
+
+Why the per-context path and not the singleton manager: the singleton
+(`auth/exchange.go:defaultManager`) is built once with `Issuer =
+api.AuthBaseURL()`. When the active context lives on a *different* core, both
+its token-store reads and its STS/refresh endpoint are keyed on the wrong
+host. The per-context provider fixes that by keying on `c.CoreURL`.
+
+## Deferred: the web/data API (`entire.io`)
+
+`activity` / `search` / `trail` / `dispatch` dial `ENTIRE_API_BASE_URL`
+(default `entire.io`) and statically resolve their token. `entire.io` is a
+**resource server** — it validates incoming JWTs against statically-configured
+trusted issuers (`ENTIRE_CORE_BASE_URL` + `ENTIRE_CORE_TRUSTED_ISSUERS`) and a
+fixed audience (`ENTIRE_CORE_JWT_AUDIENCE`, e.g. `entire-web-api`) — but it
+does **not advertise** any of this. So the CLI can't map an `entire.io` host
+back to a core/context the way it does for a git cluster.
+
+To close the gap (so `ENTIRE_API_BASE_URL=https://partial.to entire activity`
+auto-selects the right context without also setting `ENTIRE_AUTH_BASE_URL`):
+
+1. **Server**: `entire.io` grows a `/.well-known/entire-api.json` advertising
+   its trust roots. Unlike the cluster blob (`core_urls` only), the API blob
+   must also carry the **audience** the CLI exchanges for:
+   ```json
+   {
+     "issuer": "https://us.auth.partial.to",
+     "trusted_issuers": ["https://us.auth.partial.to", "https://eu.auth.partial.to"],
+     "audience": "entire-web-api",
+     "jwks_uri": "https://us.auth.partial.to/.well-known/jwks.json"
+   }
+   ```
+2. **CLI**: generalize the cluster resolver into a shared "host → trusted
+   issuers → pick context" path whose *source* of trusted issuers is pluggable
+   (cluster.json / api.json / the core itself), then exchange the context's
+   token for the advertised audience via `auth.TokenForResource`. Wire it into
+   the `activity` / `search` / `trail` / `dispatch` constructors
+   (`NewAuthenticatedAPIClient`, `dispatch.NewCloudClient`, `search.Search`).
+
+`ENTIRE_AUTH_BASE_URL` / `ENTIRE_API_BASE_URL` remain explicit overrides: when
+set they short-circuit discovery; discovery only runs when they are unset.

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -84,14 +84,17 @@ type providerSource struct {
 func (p *providerSource) BearerAuth(ctx context.Context, _ OperationName) (BearerAuth, error) {
 	token, err := p.provide(ctx)
 	if err != nil {
-		// Only suggest login when the user genuinely isn't logged in.
-		// Other failures (STS rejection, refresh-expired, network) already
-		// carry descriptive messages and must surface verbatim rather than
-		// be masked by a login hint.
+		// The static fallback path returns a bare ErrNotLoggedIn sentinel with
+		// no helpful text, so add the standard login hint. The active-context
+		// path (NewRefreshingLoginProvider) instead returns a tailored message
+		// that already names the context, its login server, and the exact
+		// re-login command — surface that verbatim rather than burying it under
+		// a generic prefix. Other failures (STS rejection, network) are
+		// likewise self-descriptive.
 		if errors.Is(err, auth.ErrNotLoggedIn) {
 			return BearerAuth{}, fmt.Errorf("not logged in — run 'entire login': %w", err)
 		}
-		return BearerAuth{}, fmt.Errorf("resolve control-plane token: %w", err)
+		return BearerAuth{}, err
 	}
 	return BearerAuth{Token: token}, nil
 }

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ogen-go/ogen/ogenerrors"
 
-	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 )
 
@@ -20,23 +19,21 @@ const apiBasePath = "/api/v1"
 // New returns a *Client wired to talk to the Entire control plane (Core
 // API) as the currently logged-in user.
 //
-// The base URL is the auth/login host — the Core API is served at
-// <auth-host>/api/v1, and that host is exactly what `entire login`
-// authenticated against, so no extra configuration is needed. Override
-// with ENTIRE_AUTH_BASE_URL for non-default deployments (the same knob
-// `entire login` honours).
-//
-// Auth is the logged-in bearer, resolved lazily per request through
-// auth.TokenForResource so an RFC 8693 token exchange happens
-// transparently when the stored token's audience doesn't already cover
-// the control-plane host.
+// The host and bearer come from auth.ResolveControlPlaneTarget: the active
+// contexts.json login's core (so `entire auth use <ctx>` retargets the
+// control plane), or — when ENTIRE_AUTH_BASE_URL is set or no context is
+// active — the configured auth host. The Core API is served at
+// <core>/api/v1. The bearer is resolved lazily per request; for an active
+// context it re-mints silently from the stored refresh token, and for the
+// static path an RFC 8693 exchange happens transparently when the stored
+// token's audience doesn't cover the core.
 func New() (*Client, error) {
-	base := strings.TrimRight(api.AuthBaseURL(), "/")
-	// The token exchange's resource must be the bare origin; api.OriginOnly
-	// strips any path/query so the audience the manager keys on matches
-	// what the server expects.
-	src := &bearerSource{resourceBaseURL: api.OriginOnly(base)}
-	client, err := NewClient(base+apiBasePath, src)
+	target, err := auth.ResolveControlPlaneTarget()
+	if err != nil {
+		return nil, fmt.Errorf("resolve control-plane target: %w", err)
+	}
+	src := &providerSource{provide: target.TokenSource}
+	client, err := NewClient(strings.TrimRight(target.CoreURL, "/")+apiBasePath, src)
 	if err != nil {
 		return nil, fmt.Errorf("build core API client: %w", err)
 	}
@@ -69,24 +66,26 @@ func (s staticBearer) SessionAuth(context.Context, OperationName) (SessionAuth, 
 	return SessionAuth{}, ogenerrors.ErrSkipClientSecurity
 }
 
-// bearerSource implements the generated SecuritySource, supplying the
-// logged-in user's bearer token for every request. The control plane
-// only uses bearerAuth from the CLI; the sessionAuth (browser cookie)
-// scheme is reported as ErrSkipClientSecurity so ogen's middleware
-// satisfies the "bearerAuth OR sessionAuth" requirement via the bearer
-// alone — without adding a stray `Cookie: entire_session=` header.
-// (Returning an empty SessionAuth would not skip the cookie: the
-// generated securitySessionAuth unconditionally calls req.AddCookie.)
-type bearerSource struct {
-	resourceBaseURL string
+// providerSource implements the generated SecuritySource, supplying the
+// logged-in user's bearer token for every request from a token-provider
+// func (auth.ControlPlaneTarget.TokenSource). The control plane only uses
+// bearerAuth from the CLI; the sessionAuth (browser cookie) scheme is
+// reported as ErrSkipClientSecurity so ogen's middleware satisfies the
+// "bearerAuth OR sessionAuth" requirement via the bearer alone — without
+// adding a stray `Cookie: entire_session=` header. (Returning an empty
+// SessionAuth would not skip the cookie: the generated securitySessionAuth
+// unconditionally calls req.AddCookie.)
+type providerSource struct {
+	provide func(context.Context) (string, error)
 }
 
-func (b *bearerSource) BearerAuth(ctx context.Context, _ OperationName) (BearerAuth, error) {
-	token, err := auth.TokenForResource(ctx, b.resourceBaseURL)
+func (p *providerSource) BearerAuth(ctx context.Context, _ OperationName) (BearerAuth, error) {
+	token, err := p.provide(ctx)
 	if err != nil {
 		// Only suggest login when the user genuinely isn't logged in.
-		// Other failures (STS rejection, network, malformed config) must
-		// surface verbatim rather than be masked by a login hint.
+		// Other failures (STS rejection, refresh-expired, network) already
+		// carry descriptive messages and must surface verbatim rather than
+		// be masked by a login hint.
 		if errors.Is(err, auth.ErrNotLoggedIn) {
 			return BearerAuth{}, fmt.Errorf("not logged in — run 'entire login': %w", err)
 		}
@@ -95,7 +94,7 @@ func (b *bearerSource) BearerAuth(ctx context.Context, _ OperationName) (BearerA
 	return BearerAuth{Token: token}, nil
 }
 
-func (b *bearerSource) SessionAuth(context.Context, OperationName) (SessionAuth, error) {
+func (p *providerSource) SessionAuth(context.Context, OperationName) (SessionAuth, error) {
 	// The CLI authenticates with a bearer token, never the browser
 	// session cookie. ErrSkipClientSecurity tells ogen to drop this
 	// scheme entirely for the request (no Cookie header added); the

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -19,14 +19,16 @@ const apiBasePath = "/api/v1"
 // New returns a *Client wired to talk to the Entire control plane (Core
 // API) as the currently logged-in user.
 //
-// The host and bearer come from auth.ResolveControlPlaneTarget: the active
-// contexts.json login's core (so `entire auth use <ctx>` retargets the
-// control plane), or — when no context is active — the configured auth host
-// (ENTIRE_AUTH_BASE_URL or the default). The Core API is served at
-// <core>/api/v1. The bearer is resolved lazily per request; for an active
-// context it re-mints silently from the stored refresh token, and for the
-// static path an RFC 8693 exchange happens transparently when the stored
-// token's audience doesn't cover the core.
+// The host and bearer come from auth.ResolveControlPlaneTarget. Control-plane
+// commands target a login server directly — unlike `git clone` or the data
+// API, there's no resource host to match a context against — so the active
+// contexts.json login is used as-is, and `entire auth use <ctx>` retargets the
+// control plane onto that login server. ENTIRE_AUTH_BASE_URL / the default is
+// only the fallback when no context is active, not an override. The Core API
+// is served at <host>/api/v1. The bearer is resolved lazily per request; for
+// an active context it re-mints silently from the stored refresh token, and
+// for the fallback path an RFC 8693 exchange happens transparently when the
+// stored token's audience doesn't cover the host.
 func New() (*Client, error) {
 	target, err := auth.ResolveControlPlaneTarget()
 	if err != nil {
@@ -35,7 +37,7 @@ func New() (*Client, error) {
 	src := &providerSource{provide: target.TokenSource}
 	client, err := NewClient(strings.TrimRight(target.CoreURL, "/")+apiBasePath, src)
 	if err != nil {
-		return nil, fmt.Errorf("build core API client: %w", err)
+		return nil, fmt.Errorf("build Entire API client: %w", err)
 	}
 	return client, nil
 }
@@ -49,13 +51,13 @@ func NewWithBearer(coreBaseURL, token string) (*Client, error) {
 	base := strings.TrimRight(coreBaseURL, "/")
 	client, err := NewClient(base+apiBasePath, staticBearer{token: token})
 	if err != nil {
-		return nil, fmt.Errorf("build core API client: %w", err)
+		return nil, fmt.Errorf("build Entire API client: %w", err)
 	}
 	return client, nil
 }
 
 // staticBearer is a SecuritySource that returns a fixed bearer token. Same
-// sessionAuth-skipping rationale as bearerSource.
+// sessionAuth-skipping rationale as providerSource.
 type staticBearer struct{ token string }
 
 func (s staticBearer) BearerAuth(context.Context, OperationName) (BearerAuth, error) {

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -21,8 +21,8 @@ const apiBasePath = "/api/v1"
 //
 // The host and bearer come from auth.ResolveControlPlaneTarget: the active
 // contexts.json login's core (so `entire auth use <ctx>` retargets the
-// control plane), or — when ENTIRE_AUTH_BASE_URL is set or no context is
-// active — the configured auth host. The Core API is served at
+// control plane), or — when no context is active — the configured auth host
+// (ENTIRE_AUTH_BASE_URL or the default). The Core API is served at
 // <core>/api/v1. The bearer is resolved lazily per request; for an active
 // context it re-mints silently from the stored refresh token, and for the
 // static path an RFC 8693 exchange happens transparently when the stored

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ogen-go/ogen/ogenerrors"
+
+	"github.com/entireio/cli/cmd/entire/cli/auth"
 )
 
 func TestAPIError(t *testing.T) {
@@ -69,6 +72,63 @@ func TestAPIError(t *testing.T) {
 				t.Errorf("APIError() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestProviderSource_BearerAuth covers the three branches of the
+// token-provider SecuritySource New() builds: a token passes through, a
+// not-logged-in error gets the login hint, and any other error surfaces
+// under the control-plane-token wrapper rather than the login hint.
+func TestProviderSource_BearerAuth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("token passes through", func(t *testing.T) {
+		t.Parallel()
+		src := &providerSource{provide: func(context.Context) (string, error) { return "tok-123", nil }}
+		got, err := src.BearerAuth(context.Background(), "")
+		if err != nil {
+			t.Fatalf("BearerAuth: %v", err)
+		}
+		if got.Token != "tok-123" {
+			t.Fatalf("Token = %q, want tok-123", got.Token)
+		}
+	})
+
+	t.Run("not-logged-in maps to login hint", func(t *testing.T) {
+		t.Parallel()
+		src := &providerSource{provide: func(context.Context) (string, error) {
+			return "", fmt.Errorf("wrapped: %w", auth.ErrNotLoggedIn)
+		}}
+		_, err := src.BearerAuth(context.Background(), "")
+		if err == nil || !strings.Contains(err.Error(), "entire login") {
+			t.Fatalf("error = %v, want a login hint", err)
+		}
+		if !errors.Is(err, auth.ErrNotLoggedIn) {
+			t.Fatalf("error must wrap ErrNotLoggedIn, got %v", err)
+		}
+	})
+
+	t.Run("other errors surface without the login hint", func(t *testing.T) {
+		t.Parallel()
+		sentinel := errors.New("STS rejected the exchange")
+		src := &providerSource{provide: func(context.Context) (string, error) { return "", sentinel }}
+		_, err := src.BearerAuth(context.Background(), "")
+		if err == nil || !errors.Is(err, sentinel) {
+			t.Fatalf("error = %v, want it to wrap the sentinel", err)
+		}
+		if strings.Contains(err.Error(), "entire login") {
+			t.Fatalf("non-auth error must not carry a login hint: %v", err)
+		}
+	})
+}
+
+// providerSource must skip SessionAuth so no Cookie header is added — same
+// contract as bearerOnlySource below, asserted here at the unit level.
+func TestProviderSource_SkipsSessionAuth(t *testing.T) {
+	t.Parallel()
+	src := &providerSource{provide: func(context.Context) (string, error) { return "", nil }}
+	if _, err := src.SessionAuth(context.Background(), ""); !errors.Is(err, ogenerrors.ErrSkipClientSecurity) {
+		t.Fatalf("SessionAuth err = %v, want ErrSkipClientSecurity", err)
 	}
 }
 

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -108,16 +108,16 @@ func TestProviderSource_BearerAuth(t *testing.T) {
 		}
 	})
 
-	t.Run("other errors surface without the login hint", func(t *testing.T) {
+	t.Run("other errors surface verbatim", func(t *testing.T) {
 		t.Parallel()
-		sentinel := errors.New("STS rejected the exchange")
+		// The active-context provider returns an already-tailored message; it
+		// must reach the user unprefixed (no generic "resolve control-plane
+		// token" wrapper burying it) and without the login hint.
+		sentinel := errors.New(`no usable login for "ctx" (https://core.example); run ENTIRE_AUTH_BASE_URL=https://core.example entire login`)
 		src := &providerSource{provide: func(context.Context) (string, error) { return "", sentinel }}
 		_, err := src.BearerAuth(context.Background(), "")
-		if err == nil || !errors.Is(err, sentinel) {
-			t.Fatalf("error = %v, want it to wrap the sentinel", err)
-		}
-		if strings.Contains(err.Error(), "entire login") {
-			t.Fatalf("non-auth error must not carry a login hint: %v", err)
+		if err == nil || err.Error() != sentinel.Error() {
+			t.Fatalf("error = %v, want the provider message surfaced verbatim", err)
 		}
 	})
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/516
<!-- entire-trail-link-end -->

`org`/`repo`/`project`/`grant` now authenticate as the **active login context**
instead of always hitting the static default core — and refresh their token
silently.

## Why
After `entire auth use <ctx>`, control-plane commands ignored the switch: they
always dialed `ENTIRE_AUTH_BASE_URL` (or the `us.auth.entire.io` default) and
resolved their token from a manager pinned to that host. So a context on a
different core was silently unused — the bug pattern `auth status` already fixed
in #1341, now extended to the rest of the control plane.

## What changed
- `auth.ResolveControlPlaneTarget()` picks host + token from the active context,
  falling back to `ENTIRE_AUTH_BASE_URL`/default only when no context is active.
  The env var is a **fallback host, not an override** (a token from core B can't
  authenticate against core A), matching `auth status`.
- `coreapi.New()` resolves through it; the bearer comes from the per-context
  refreshing provider, so an expired token re-mints from the stored refresh
  token (the silent-refresh down payment on COR-389).
- Removed the now-stale `auth use` cross-core warning and updated its help.
- `docs/architecture/upstream-host-resolution.md`: the "one core + resource
  servers" model and the deferred data-API work.

## Effect
```
entire auth use <ctx-on-another-core>
entire org list      # now hits that context's core, with a silently-refreshed token
```

## Not in scope (next slice)
Data-API commands (`activity`/`search`/`trail`/`dispatch`) still target
`ENTIRE_API_BASE_URL` and don't follow the context yet — that needs a
`/.well-known` on `entire.io` advertising its trusted cores + audience. Designed
in the doc.

## Test
Unit tests for the affected packages (`cli`, `auth`, `api`, `coreapi`) + lint
clean. Full `mise run test:ci` (integration + canary) not yet run — leaving that
to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication host selection and token refresh for all control-plane mutations; incorrect resolution could send requests to the wrong core or use invalid tokens, though behavior is covered by new unit tests and aligns with existing `auth status` semantics.
> 
> **Overview**
> **Control-plane commands (`org`/`repo`/`project`/`grant`) now follow `entire auth use`**, dialing the active context's core and obtaining bearers through a **per-context refreshing provider** keyed on that core's issuer—fixing the case where everything still hit `ENTIRE_AUTH_BASE_URL` and a singleton token manager pinned to the wrong host.
> 
> `coreapi.New()` routes through **`auth.ResolveControlPlaneTarget()`**: active context wins over `ENTIRE_AUTH_BASE_URL` (env is fallback only when no context is active); no active context keeps the legacy `TokenForResource` path. **`--insecure-http-auth`** is wired into that per-context path via `insecureHTTPEnabled()`.
> 
> **`auth status` and `logout`** now propagate errors from **`resolveStatusTarget`** when `contexts.json` is corrupt/unreadable, matching control-plane behavior instead of silently falling back to a stale legacy identity.
> 
> Docs and UX: new **`upstream-host-resolution.md`**, updated **`auth use`** help (control plane follows context; data API still on `ENTIRE_API_BASE_URL`), and removal of the obsolete cross-core warning. **`providerSource`** surfaces tailored re-login errors from the active-context path without wrapping them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6621920f516bfcaebabaa18c7d3042693b8ff68f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->