### PR TITLE
test(e2e): keep the spawned entire binary off the real OS keychain

### DIFF
--- a/e2e/tests/main_test.go
+++ b/e2e/tests/main_test.go
@@ -25,6 +25,19 @@ func TestMain(m *testing.M) {
 	_ = os.MkdirAll(runDir, 0o755)
 	testutil.SetRunDir(runDir)
 
+	// Route every spawned entire binary (and the git hooks that invoke it) at
+	// file-backed token stores so e2e never touches the developer's real OS
+	// keychain. These env vars are inherited by child processes:
+	//   - internal/entireclient/tokenstore honors ENTIRE_TOKEN_STORE/_PATH
+	//     unconditionally (always compiled).
+	//   - the auth package's legacy keyring store honors
+	//     ENTIRE_TEST_AUTH_STORE_FILE only in -tags=authfilestore builds, which
+	//     the build:e2e task produces.
+	// In-process keyring.MockInit() cannot help here: the binary is a subprocess.
+	os.Setenv("ENTIRE_TOKEN_STORE", "file")
+	os.Setenv("ENTIRE_TOKEN_STORE_PATH", filepath.Join(runDir, "e2e-tokenstore.json"))
+	os.Setenv("ENTIRE_TEST_AUTH_STORE_FILE", filepath.Join(runDir, "e2e-auth-tokens.json"))
+
 	// Resolve the entire binary (set by mise run build via E2E_ENTIRE_BIN).
 	entireBin := entire.BinPath()
 	if err := ensureHookEntireBinary(entireBin); err != nil {

--- a/mise-tasks/test/e2e/_default
+++ b/mise-tasks/test/e2e/_default
@@ -10,7 +10,7 @@ export E2E_AGENT="${usage_agent:-}"
 
 # Build from source with version info unless a pre-built binary is provided.
 if [ -z "${E2E_ENTIRE_BIN:-}" ]; then
-  mise run build
+  mise run build:e2e
   if [ -f "$PWD/entire.exe" ]; then
     export E2E_ENTIRE_BIN="$PWD/entire.exe"
   else

--- a/mise-tasks/test/e2e/canary
+++ b/mise-tasks/test/e2e/canary
@@ -5,7 +5,7 @@
 set -eu
 
 # Build entire CLI
-mise run build
+mise run build:e2e
 export E2E_ENTIRE_BIN="$PWD/entire"
 
 # Build vogon binary

--- a/mise-tasks/test/e2e/roger-roger
+++ b/mise-tasks/test/e2e/roger-roger
@@ -7,7 +7,7 @@ set -eu
 export E2E_AGENT="roger-roger"
 
 # Build entire CLI
-mise run build
+mise run build:e2e
 export E2E_ENTIRE_BIN="$PWD/entire"
 
 # Ensure roger-roger binaries are available on PATH before running E2E tests.

--- a/mise.toml
+++ b/mise.toml
@@ -19,6 +19,13 @@ run = "gotestsum --format pkgname --format-icons text --format-hide-empty-pkg --
 description = "Run integration tests"
 run = "gotestsum --format testname --format-icons text --hide-summary skipped -- -tags=integration,authfilestore ./cmd/entire/cli/integration_test/... ./cmd/entire/cli/auth/..."
 
+[tasks."build:e2e"]
+description = "Build the CLI for e2e tests with the file-backed auth store (-tags=authfilestore), so the spawned binary and git hooks never touch the developer's OS keychain"
+run = """
+go build -tags=authfilestore ./cmd/entire
+go build ./cmd/git-remote-entire
+"""
+
 [tasks."test:ci"]
 description = "Run all tests (unit + integration + E2E canary) with race detection"
 run = """

--- a/mise.toml
+++ b/mise.toml
@@ -20,10 +20,10 @@ description = "Run integration tests"
 run = "gotestsum --format testname --format-icons text --hide-summary skipped -- -tags=integration,authfilestore ./cmd/entire/cli/integration_test/... ./cmd/entire/cli/auth/..."
 
 [tasks."build:e2e"]
-description = "Build the CLI for e2e tests with the file-backed auth store (-tags=authfilestore), so the spawned binary and git hooks never touch the developer's OS keychain"
+description = "Build the CLI for e2e tests with the file-backed auth store (-tags=authfilestore), so the spawned binary, the git-remote-entire helper, and git hooks never touch the developer's OS keychain"
 run = """
 go build -tags=authfilestore ./cmd/entire
-go build ./cmd/git-remote-entire
+go build -tags=authfilestore ./cmd/git-remote-entire
 """
 
 [tasks."test:ci"]


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/519
<!-- entire-trail-link-end -->

## Problem

`1ea54e2` added `keyring.MockInit()` to the cli package `TestMain` so in-process tests don't read the developer's keychain. But that's process-local — the **e2e suite drives the real `entire` binary as a subprocess** (via `E2E_ENTIRE_BIN`), which `MockInit` cannot touch. So `mise run test:ci` (which runs the canary) and `mise run test:e2e` still trigger a **macOS keychain unlock prompt** whenever a canary flow resolves credentials (e.g. the `pre-push` hook).

Two stores are reachable from the spawned binary:
- `internal/entireclient/tokenstore` (always compiled).
- the `auth` package's **legacy** keyring store — `auth.NewStore().GetToken()` fallback in `contexts.go`, which queries the keychain even when no token is present.

This was never a regression of `1ea54e2` (its `MockInit` is intact and only ever covered in-process tests) and is unrelated to the path-traversal work in #1365.

## Fix

Neutralize both stores in the e2e environment:

- **`build:e2e` task** builds `entire` with `-tags=authfilestore` (compiles in the auth file backend). The canary, roger-roger, and default e2e tasks now use it. Production `mise run build` stays untagged.
- **e2e `TestMain`** sets, pointing into the run's artifact dir (inherited by the binary and the git hooks it spawns):
  - `ENTIRE_TOKEN_STORE=file` + `ENTIRE_TOKEN_STORE_PATH` — covers `tokenstore` (no tag needed).
  - `ENTIRE_TEST_AUTH_STORE_FILE` — covers the auth keyring store (honored only under `authfilestore`).

With these set, `resolveBackendLocked` returns a `fileStore` and `chooseBackend` returns the file backend, so no keyring/keychain call can occur.

## Testing
- `mise run test:e2e:canary` green (vogon + roger-roger), now keychain-free by construction.
- Production build untouched; only e2e build/test paths use the tag + env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2965addc26f27892a7b23fed579bbb2f7d3b30ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->