### PR TITLE
changelog 0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.5] - 2026-06-04
+
+### Security
+
+- Closed a path-traversal / arbitrary-file-write vulnerability across the checkpoint, session, and agent-lifecycle paths: identifiers read from the shared `entire/checkpoints/v1` branch or from agent hook input flowed into filesystem paths without validation, so a crafted session ID could overwrite arbitrary files on `entire session resume` / `entire checkpoint rewind`. IDs are now validated at the read/dispatch boundaries, with `os.Root` containment as defense in depth ([#1365](https://github.com/entireio/cli/pull/1365))
+
+### Fixed
+
+- `git-remote-entire` now relays helper-status before checking the send-pack exit code, so per-ref rejections (branch protection, ref-name conflicts, permission denials) surface as `! [remote rejected]` with the real reason instead of a bare `send-pack exited with error: exit status 1` ([#1364](https://github.com/entireio/cli/pull/1364))
+
 ## [0.7.4] - 2026-06-04
 
 ### Added


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/520
<!-- entire-trail-link-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md; no runtime behavior is modified in this PR.
> 
> **Overview**
> Adds the **0.7.5** release section (dated 2026-06-04) to `CHANGELOG.md`, documenting shipped fixes rather than changing product code in this diff.
> 
> Under **Security**, it records closure of a path-traversal / arbitrary-file-write issue ([#1365]): session and checkpoint identifiers from `entire/checkpoints/v1` or agent hooks were used in filesystem paths without validation, so crafted IDs could overwrite arbitrary files during `entire session resume` or `entire checkpoint rewind`; the release notes describe validation at read/dispatch boundaries plus `os.Root` containment.
> 
> Under **Fixed**, it records that `git-remote-entire` now relays helper-status before checking the send-pack exit code ([#1364), so per-ref rejections show as `! [remote rejected]` with the real reason instead of a generic `send-pack exited with error: exit status 1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf774dbae1f00fc15b78225607386ba5e2cf983. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->