### PR TITLE
test: fix flaky TestSafelyAdvanceLocalRef temp-dir cleanup race (COR-394)

### DIFF
--- a/cmd/entire/cli/testutil/testutil.go
+++ b/cmd/entire/cli/testutil/testutil.go
@@ -232,7 +232,9 @@ func gitEmptyConfigPath() string {
 		if err != nil {
 			panic("write git isolation config: " + err.Error())
 		}
-		_ = f.Close()
+		if err := f.Close(); err != nil {
+			panic("close git isolation config: " + err.Error())
+		}
 		gitEmptyConfig = f.Name()
 	})
 	return gitEmptyConfig

--- a/cmd/entire/cli/testutil/testutil.go
+++ b/cmd/entire/cli/testutil/testutil.go
@@ -209,17 +209,28 @@ func BranchExists(t *testing.T, repoDir, branchName string) bool {
 	return found
 }
 
-// gitEmptyConfigPath returns the path to an empty file suitable for use as
-// GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM. We use an empty file instead of
+// gitEmptyConfigPath returns the path to a config file suitable for use as
+// GIT_CONFIG_GLOBAL/GIT_CONFIG_SYSTEM. We use a real file instead of
 // os.DevNull because git on Windows cannot open NUL as a config file.
+//
+// The file is not strictly empty: it pins background maintenance off so that
+// no detached `git gc`/`git maintenance` process lingers after a test holding
+// an open handle on the temp repo's .git/objects. Such a lingering process
+// races t.TempDir()'s deferred RemoveAll and fails the test with
+// "directory not empty" (see COR-394). Suppressing it centrally keeps every
+// git-shelling test that uses GitIsolatedEnv/IsolateGitConfigEnv safe.
 var gitEmptyConfig string
 var gitEmptyConfigOnce sync.Once
 
 func gitEmptyConfigPath() string {
 	gitEmptyConfigOnce.Do(func() {
-		f, err := os.CreateTemp("", "git-empty-config-*")
+		f, err := os.CreateTemp("", "git-isolation-config-*")
 		if err != nil {
-			panic("create empty git config: " + err.Error())
+			panic("create git isolation config: " + err.Error())
+		}
+		_, err = f.WriteString("[gc]\n\tauto = 0\n\tautoDetach = false\n[maintenance]\n\tauto = false\n[fetch]\n\twriteCommitGraph = false\n")
+		if err != nil {
+			panic("write git isolation config: " + err.Error())
 		}
 		_ = f.Close()
 		gitEmptyConfig = f.Name()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/528
<!-- entire-trail-link-end -->

Disables git background gc/maintenance in the isolated test env so no detached `git gc` process lingers holding `.git/objects` open, racing `t.TempDir()`'s `RemoveAll` ("directory not empty").

- `GitIsolatedEnv`/`IsolateGitConfigEnv` now point git at a config pinning `gc.auto=0`, `gc.autoDetach=false`, `maintenance.auto=false`, `fetch.writeCommitGraph=false`.
- Central fix — covers every git-shelling strategy test, not just the one flaking.
- Stress-verified: `go test -run TestSafelyAdvanceLocalRef -count=50 -p 4` green.

Closes COR-394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only isolation config in `testutil`; no production runtime or auth/data paths affected.
> 
> **Overview**
> Fixes flaky **"directory not empty"** failures when `t.TempDir()` tears down repos after git-heavy tests (COR-394).
> 
> The shared **GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM** file used by `GitIsolatedEnv` and `IsolateGitConfigEnv` is no longer empty: it now pins **`gc.auto=0`**, **`gc.autoDetach=false`**, **`maintenance.auto=false`**, and **`fetch.writeCommitGraph=false`** so detached **`git gc` / maintenance** does not keep **`.git/objects`** open and race deferred cleanup. The temp config filename and write/panic paths were updated accordingly; behavior change is **central** for every test that shells git through those helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72ac486ce8385c7a1a62709012a8c19e6327fea4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->