### PR TITLE
update CLI docs overview link

### DIFF
--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -20,7 +20,7 @@ Getting Started:
   To get started with Entire CLI, run 'entire enable' to enable
   session tracking in your repository, then 'entire agent add <name>'
   to install hooks for a specific agent. For more information, visit:
-  https://docs.entire.io/introduction
+  https://docs.entire.io/overview
 
 `
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/529
<!-- entire-trail-link-end -->

## Summary

- Update the root CLI help getting-started docs link from `/introduction` to `/overview`.
- Keep non-CLI-rendered docs references unchanged.

## Validation

- `TZ=UTC mise run check`
- `mise run lint`
