### PR TITLE
Lock Pi's live skill-capture model; guard against duplicate extractor

### DIFF
--- a/cmd/entire/cli/agent/pi/lifecycle.go
+++ b/cmd/entire/cli/agent/pi/lifecycle.go
@@ -71,20 +71,10 @@ type piSkillEventInput struct {
 }
 
 // piSkillEvents converts the Pi extension's live skill-invocation reports into
-// agent.SkillEvents. This is Pi's ONLY skill-capture path, and it is captured
-// live: the embedded extension matches "/skill:<name>" on raw input (before Pi
-// expands it into a <skill name="..."> block) and ships the result in the
-// before_agent_start hook payload. These events flow into state.SkillEvents and
-// are merged into checkpoint metadata at condensation.
-//
-// Deliberately, PiAgent does NOT implement agent.SkillEventExtractor (the
-// transcript-extraction interface that claude-code uses). The two models are
-// mutually exclusive on purpose — see TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction.
-// Adding a transcript extractor here would double-count: condensation merges
-// the extractor output with these live events via mergeSkillEvents, and the
-// keys cannot dedup cleanly (live events carry their original per-invocation
-// TurnID, while a re-extraction stamps every event with the current TurnID),
-// so earlier-turn skills would surface twice in checkpoint metadata.
+// agent.SkillEvents. This is Pi's only skill-capture path. PiAgent intentionally
+// does NOT implement agent.SkillEventExtractor: a transcript extractor would
+// double-count these live events at condensation (see
+// TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction).
 func piSkillEvents(in []piSkillEventInput) []agent.SkillEvent {
 	if len(in) == 0 {
 		return nil

--- a/cmd/entire/cli/agent/pi/lifecycle.go
+++ b/cmd/entire/cli/agent/pi/lifecycle.go
@@ -70,6 +70,21 @@ type piSkillEventInput struct {
 	Timestamp  string `json:"timestamp,omitempty"`
 }
 
+// piSkillEvents converts the Pi extension's live skill-invocation reports into
+// agent.SkillEvents. This is Pi's ONLY skill-capture path, and it is captured
+// live: the embedded extension matches "/skill:<name>" on raw input (before Pi
+// expands it into a <skill name="..."> block) and ships the result in the
+// before_agent_start hook payload. These events flow into state.SkillEvents and
+// are merged into checkpoint metadata at condensation.
+//
+// Deliberately, PiAgent does NOT implement agent.SkillEventExtractor (the
+// transcript-extraction interface that claude-code uses). The two models are
+// mutually exclusive on purpose — see TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction.
+// Adding a transcript extractor here would double-count: condensation merges
+// the extractor output with these live events via mergeSkillEvents, and the
+// keys cannot dedup cleanly (live events carry their original per-invocation
+// TurnID, while a re-extraction stamps every event with the current TurnID),
+// so earlier-turn skills would surface twice in checkpoint metadata.
 func piSkillEvents(in []piSkillEventInput) []agent.SkillEvent {
 	if len(in) == 0 {
 		return nil

--- a/cmd/entire/cli/agent/pi/lifecycle_test.go
+++ b/cmd/entire/cli/agent/pi/lifecycle_test.go
@@ -71,11 +71,8 @@ func TestParseHookEvent_BeforeAgentStart_WithSkillEvent(t *testing.T) {
 	}
 }
 
-// TestParseHookEvent_BeforeAgentStart_MultipleSkillEvents locks the live-capture
-// guarantee for more than one invocation in a single turn: every reported
-// /skill:<name> must surface as its own SkillEvent. This is the path that backs
-// invoked-skill capture for ALL live Pi sessions, including `entire review
-// --agent pi`.
+// TestParseHookEvent_BeforeAgentStart_MultipleSkillEvents locks live capture of
+// every /skill:<name> in a turn (the path backing all live Pi sessions).
 func TestParseHookEvent_BeforeAgentStart_MultipleSkillEvents(t *testing.T) {
 	t.Parallel()
 	a := &PiAgent{}
@@ -98,25 +95,14 @@ func TestParseHookEvent_BeforeAgentStart_MultipleSkillEvents(t *testing.T) {
 	}
 }
 
-// TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction is an architectural
-// guard. Pi captures invoked skills LIVE via the extension's input handler
-// (see piSkillEvents), which is mutually exclusive with the transcript-
-// extraction model claude-code uses. PiAgent must therefore NOT implement
-// agent.SkillEventExtractor: condensation merges any extractor output with the
-// live state.SkillEvents, and the keys cannot dedup cleanly across the
-// live/transcript boundary (per-invocation vs current TurnID), so adding an
-// extractor would double-count earlier-turn skills in checkpoint metadata.
-//
-// If you are here because this test failed: you likely added an ExtractSkillEvents
-// method to PiAgent. Don't — Pi already captures invoked skills live. Reconcile
-// the dedup model first (make skill-event identity stable across the boundary)
-// before reintroducing transcript extraction.
+// TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction guards Pi's
+// live-capture model: a transcript extractor would double-count at
+// condensation (see piSkillEvents).
 func TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction(t *testing.T) {
 	t.Parallel()
 	if _, ok := agent.AsSkillEventExtractor(NewPiAgent()); ok {
-		t.Fatal("PiAgent implements SkillEventExtractor: Pi uses live skill capture; " +
-			"a transcript extractor would double-count live-captured events at condensation. " +
-			"See piSkillEvents and this test's doc comment.")
+		t.Fatal("PiAgent must not implement SkillEventExtractor: Pi captures skills live; " +
+			"a transcript extractor would double-count at condensation (see piSkillEvents)")
 	}
 }
 

--- a/cmd/entire/cli/agent/pi/lifecycle_test.go
+++ b/cmd/entire/cli/agent/pi/lifecycle_test.go
@@ -71,6 +71,55 @@ func TestParseHookEvent_BeforeAgentStart_WithSkillEvent(t *testing.T) {
 	}
 }
 
+// TestParseHookEvent_BeforeAgentStart_MultipleSkillEvents locks the live-capture
+// guarantee for more than one invocation in a single turn: every reported
+// /skill:<name> must surface as its own SkillEvent. This is the path that backs
+// invoked-skill capture for ALL live Pi sessions, including `entire review
+// --agent pi`.
+func TestParseHookEvent_BeforeAgentStart_MultipleSkillEvents(t *testing.T) {
+	t.Parallel()
+	a := &PiAgent{}
+	stdin := strings.NewReader(`{"type":"before_agent_start","session_file":"/tmp/2026-05-09T12-00-00-000Z_abc-123.jsonl","prompt":"expanded","skill_events":[{"skill_name":"review-pr","invocation":"/skill:review-pr","timestamp":"2026-05-25T12:34:56Z"},{"skill_name":"test-auditor","invocation":"/skill:test-auditor","timestamp":"2026-05-25T12:35:10Z"}]}`)
+	ev, err := a.ParseHookEvent(context.Background(), HookNameBeforeAgentStart, stdin)
+	if err != nil {
+		t.Fatalf("ParseHookEvent: %v", err)
+	}
+	got := make(map[string]bool)
+	for _, se := range ev.SkillEvents {
+		got[se.Skill.Name] = true
+		if se.Source.Agent != string(agent.AgentNamePi) {
+			t.Errorf("Source.Agent = %q, want pi", se.Source.Agent)
+		}
+	}
+	for _, want := range []string{"review-pr", "test-auditor"} {
+		if !got[want] {
+			t.Errorf("missing live skill event for %q; got %v", want, got)
+		}
+	}
+}
+
+// TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction is an architectural
+// guard. Pi captures invoked skills LIVE via the extension's input handler
+// (see piSkillEvents), which is mutually exclusive with the transcript-
+// extraction model claude-code uses. PiAgent must therefore NOT implement
+// agent.SkillEventExtractor: condensation merges any extractor output with the
+// live state.SkillEvents, and the keys cannot dedup cleanly across the
+// live/transcript boundary (per-invocation vs current TurnID), so adding an
+// extractor would double-count earlier-turn skills in checkpoint metadata.
+//
+// If you are here because this test failed: you likely added an ExtractSkillEvents
+// method to PiAgent. Don't — Pi already captures invoked skills live. Reconcile
+// the dedup model first (make skill-event identity stable across the boundary)
+// before reintroducing transcript extraction.
+func TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction(t *testing.T) {
+	t.Parallel()
+	if _, ok := agent.AsSkillEventExtractor(NewPiAgent()); ok {
+		t.Fatal("PiAgent implements SkillEventExtractor: Pi uses live skill capture; " +
+			"a transcript extractor would double-count live-captured events at condensation. " +
+			"See piSkillEvents and this test's doc comment.")
+	}
+}
+
 func TestParseHookEvent_SessionShutdown_NoLifecycleEvent(t *testing.T) {
 	t.Parallel()
 	a := &PiAgent{}


### PR DESCRIPTION
## Summary

Investigated whether Pi needs transcript-based extraction of invoked skills (parallel to claude-code's `ExtractSkillEvents`). Conclusion: **it does not — Pi already captures invoked skills**, and adding a transcript extractor would be actively harmful. This PR documents and guards that decision instead.

## Background: two mutually-exclusive models

| Agent | Model | Mechanism |
|-------|-------|-----------|
| **claude-code** | transcript extraction | `ExtractSkillEvents` parses `Skill` tool-use at condensation; emits no live skill events |
| **pi** | live capture | extension `input` handler matches `/skill:<name>` (pre-expansion) → `skill_events` in the `before_agent_start` hook → `state.SkillEvents` |

Pi already captures every `/skill:<name>` invocation in all live sessions, including `entire review --agent pi`.

## Why not add a Pi transcript extractor

1. **The literal is gone from the transcript.** Pi's `_expandSkillCommand` rewrites `/skill:name` into a `<skill name="...">…</skill>` block before the user message is stored.
2. **It would double-count.** At condensation `agent.ExtractSkillEvents` is merged with the live `state.SkillEvents` via `mergeSkillEvents`. The keys cannot dedup cleanly across the live/transcript boundary: live events carry their original per-invocation `TurnID`, while a re-extraction stamps every event with the current `TurnID`, so earlier-turn skills surface twice.
3. **`attach` calls neither path** for any agent, so the attach-time gap is not Pi-specific.

## Changes

- Document `piSkillEvents`: Pi uses live capture; `PiAgent` must not implement `SkillEventExtractor`.
- `TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction`: architectural guard — fails (with guidance) if `PiAgent` becomes a `SkillEventExtractor`.
- `TestParseHookEvent_BeforeAgentStart_MultipleSkillEvents`: locks multi-invocation live capture.

No behavior change — documentation + regression tests only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and test-only changes with no production logic modifications.
> 
> **Overview**
> Documents Pi’s **live-only** skill capture path in `piSkillEvents`: `/skill:<name>` invocations arrive via the `before_agent_start` hook and must **not** be duplicated by a claude-code-style `SkillEventExtractor`, because condensation’s `mergeSkillEvents` cannot dedupe live vs transcript events (TurnID mismatch).
> 
> Adds regression coverage: **multi-invocation** live skill events in one turn, and **`TestPiAgent_UsesLiveSkillCaptureNotTranscriptExtraction`**, which fails if `PiAgent` ever implements `SkillEventExtractor`.
> 
> **No runtime behavior change** — comments and tests only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9854c62bcfc6cd948c277b646ce889eec16c68e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->