### PR TITLE
fix(strategy): fetch metadata branch from checkpoint_remote on enable

### DIFF
--- a/cmd/entire/cli/strategy/checkpoint_remote.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 
+	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
@@ -187,4 +190,167 @@ func fetchMetadataBranchIfMissing(ctx context.Context, remoteURL string) error {
 
 	logging.Info(ctx, "checkpoint-remote: fetched metadata branch from URL")
 	return nil
+}
+
+// resolveCheckpointRemoteURLFn resolves the checkpoint_remote fetch URL. It is a
+// package var so tests can point bootstrap/heal at a local repository instead of
+// the provider-derived (e.g. github.com) URL, which can't be reached offline.
+var resolveCheckpointRemoteURLFn = resolveCheckpointRemoteURL
+
+// resolveCheckpointRemoteURL returns the fetch URL for the configured
+// checkpoint_remote, or ok=false when no checkpoint_remote is configured or a
+// dedicated checkpoint URL cannot be resolved. It never returns an error: callers
+// treat a missing URL as "no checkpoint remote to adopt from" and fall back to
+// keeping the local branch / creating an orphan.
+//
+// remote.FetchURL silently falls back to the origin remote URL when it cannot
+// derive a checkpoint URL (e.g. origin uses a non-derivable protocol and the
+// provider host is unknown). Adopting from origin would contradict the rule that
+// origin is never authoritative when a checkpoint_remote is configured (issue
+// #1374), so we verify the resolved URL actually targets the configured checkpoint
+// repo and treat the origin fallback as "unresolved".
+func resolveCheckpointRemoteURL(ctx context.Context) (string, bool) {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return "", false
+	}
+	config := s.GetCheckpointRemote()
+	if config == nil {
+		return "", false
+	}
+	url, err := remote.FetchURL(ctx)
+	if err != nil {
+		logging.Debug(ctx, "checkpoint-remote: could not resolve fetch URL for metadata bootstrap",
+			slog.String("error", err.Error()))
+		return "", false
+	}
+	if !urlTargetsCheckpointRepo(url, config) {
+		logging.Debug(ctx, "checkpoint-remote: fetch URL did not resolve to the configured checkpoint repo; not adopting from origin",
+			slog.String("repo", config.Repo))
+		return "", false
+	}
+	return url, true
+}
+
+// urlTargetsCheckpointRepo reports whether url points at the configured
+// checkpoint repository (host-agnostic owner/repo match). It distinguishes a
+// derived checkpoint URL from remote.FetchURL's origin fallback, which targets the
+// origin repository instead. A same-repo checkpoint_remote (origin == checkpoint
+// repo) still matches, which is correct: adopting from that URL is adopting the
+// checkpoint repo.
+func urlTargetsCheckpointRepo(url string, config *settings.CheckpointRemoteConfig) bool {
+	info, err := remote.ParseURL(url)
+	if err != nil || info.Owner == "" || info.Repo == "" {
+		return false
+	}
+	return strings.EqualFold(info.Owner+"/"+info.Repo, config.Repo)
+}
+
+// BootstrapMetadataFromCheckpointRemote populates the local metadata branch from a
+// configured checkpoint_remote when no local or origin-tracked branch exists.
+//
+// This prevents `entire enable` on a second device from creating an empty orphan
+// branch that conflicts with the real metadata branch already stored in the
+// checkpoint remote — the orphan would otherwise leave `entire checkpoint list`
+// empty and cause a non-fast-forward rejection on the next fetch (issue #1374).
+//
+// Returns true when a non-empty branch was fetched and the local ref now points at
+// it. When no checkpoint_remote is configured or its URL can't be resolved, returns
+// (false, nil) so setup can fall back to creating an orphan.
+func BootstrapMetadataFromCheckpointRemote(ctx context.Context, repo *git.Repository) (bool, error) {
+	url, ok := resolveCheckpointRemoteURLFn(ctx)
+	if !ok {
+		return false, nil
+	}
+	return bootstrapMetadataFromURL(ctx, repo, url)
+}
+
+// bootstrapMetadataFromURL fetches the metadata branch from remoteURL into the
+// local branch. It assumes the local branch is absent, so FetchMetadataBranch's
+// SafelyAdvanceLocalRef sets the ref directly to the fetched tip (no replay, no
+// empty commit). Fetch failures and an empty fetched branch are non-fatal and
+// return (false, nil) so callers can fall back to creating an orphan.
+func bootstrapMetadataFromURL(ctx context.Context, repo *git.Repository, remoteURL string) (bool, error) {
+	if err := FetchMetadataBranch(ctx, remoteURL); err != nil {
+		logging.Debug(ctx, "checkpoint-remote: metadata bootstrap fetch failed; will create orphan",
+			slog.String("error", err.Error()))
+		return false, nil
+	}
+	ref, err := repo.Reference(checkpoint.ResolveCommittedRefs(ctx).Primary, true)
+	if err != nil {
+		// Fetch reported success but the local ref is unreadable — treat as "no
+		// usable data" and let the caller create an orphan rather than fail setup.
+		return false, nil //nolint:nilerr // intentional non-fatal fallback
+	}
+	hasData, err := metadataBranchHasData(repo, ref)
+	if err != nil || !hasData {
+		return false, nil //nolint:nilerr // unreadable or data-free tree → fall back to orphan
+	}
+	fmt.Fprintf(os.Stderr, "✓ Fetched metadata branch '%s' from checkpoint remote\n", paths.MetadataBranchName)
+	return true, nil
+}
+
+// HealEmptyOrphanMetadataFromCheckpointRemote replaces a local metadata branch that
+// holds no checkpoint data (an empty orphan, or a vercel.json-only orphan — the bug
+// behind issue #1374) with the real branch fetched from a configured
+// checkpoint_remote. This repairs second-device repos that were enabled before the
+// checkpoint_remote bootstrap existed and were left with an un-initialized orphan
+// disjoint from the remote history.
+//
+// Returns true when the branch was healed. A local branch that already has
+// checkpoints, a missing checkpoint_remote, or an unresolvable URL all return
+// (false, nil).
+func HealEmptyOrphanMetadataFromCheckpointRemote(ctx context.Context, repo *git.Repository, localRef *plumbing.Reference) (bool, error) {
+	hasData, err := metadataBranchHasData(repo, localRef)
+	if err != nil {
+		return false, fmt.Errorf("failed to check metadata branch contents: %w", err)
+	}
+	if hasData {
+		return false, nil
+	}
+	url, ok := resolveCheckpointRemoteURLFn(ctx)
+	if !ok {
+		return false, nil
+	}
+	return healEmptyOrphanFromURL(ctx, repo, url)
+}
+
+// healEmptyOrphanFromURL fetches the metadata branch from remoteURL and force-sets
+// the local ref to the fetched tip. It deliberately bypasses SafelyAdvanceLocalRef:
+// the local orphan is disconnected from the real branch, so a safe advance would
+// cherry-pick the orphan commit onto the real tip, leaving a stray empty commit.
+// Discarding the checkpoint-free orphan is always correct here. Fetch failures and
+// a checkpoint-free fetched branch are non-fatal and return (false, nil).
+func healEmptyOrphanFromURL(ctx context.Context, repo *git.Repository, remoteURL string) (bool, error) {
+	refs := checkpoint.ResolveCommittedRefs(ctx)
+	if !refs.Primary.IsBranch() {
+		return false, nil
+	}
+	tmpRef := plumbing.ReferenceName(FetchTmpRefPrefix + refs.Primary.Short())
+	defer func() { _ = repo.Storer.RemoveReference(tmpRef) }() //nolint:errcheck // cleanup is best-effort
+
+	if err := fetchURLIntoTmpRef(ctx, remoteURL, refs.Primary.String(), tmpRef.String(), "metadata branch", true); err != nil {
+		logging.Debug(ctx, "checkpoint-remote: empty-orphan heal fetch failed",
+			slog.String("error", err.Error()))
+		return false, nil
+	}
+
+	fetchedRef, err := repo.Reference(tmpRef, true)
+	if err != nil {
+		return false, nil
+	}
+	fetchedHasData, err := metadataBranchHasData(repo, fetchedRef)
+	if err != nil || !fetchedHasData {
+		return false, nil
+	}
+
+	// Force-set the primary ref to the fetched tip (and best-effort-advance the
+	// mirror). AdvanceCommittedPrimary does a plain SetReference rather than a safe
+	// advance, which is what we want: the local orphan is disconnected from the
+	// real branch and must be discarded, not replayed onto it.
+	if err := AdvanceCommittedPrimary(ctx, repo, refs, fetchedRef.Hash()); err != nil {
+		return false, fmt.Errorf("failed to replace empty orphan metadata ref: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "✓ Replaced empty metadata ref '%s' with data from checkpoint remote\n", refs.Primary.Short())
+	return true, nil
 }

--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/cmd/entire/cli/vercelconfig"
 
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,6 +86,33 @@ func TestDeriveCheckpointURL(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestURLTargetsCheckpointRepo(t *testing.T) {
+	t.Parallel()
+
+	config := &settings.CheckpointRemoteConfig{Provider: "github", Repo: "org/checkpoints"}
+
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"HTTPS checkpoint repo", "https://github.com/org/checkpoints.git", true},
+		{"SSH checkpoint repo", "git@github.com:org/checkpoints.git", true},
+		{"enterprise host, same repo path", "https://github.example.com/org/checkpoints.git", true},
+		{"case-insensitive owner/repo", "https://github.com/Org/Checkpoints.git", true},
+		{"origin fallback (different repo)", "https://github.com/org/main-repo.git", false},
+		{"different owner", "https://github.com/other/checkpoints.git", false},
+		{"unparseable url", "not a url", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, urlTargetsCheckpointRepo(tt.url, config))
 		})
 	}
 }
@@ -923,6 +953,326 @@ func TestFetchMetadataBranch_DisconnectedPreservesLocalCheckpoint(t *testing.T) 
 	files := checkpointRemoteMetadataFiles(ctx, t, localDir)
 	assert.Contains(t, files, "cc/cccccccccc/metadata.json", "rewritten remote checkpoint should be present after fetch")
 	assert.Contains(t, files, "bb/bbbbbbbbbb/metadata.json", "local-only checkpoint should be replayed when there is no common ancestor")
+}
+
+// TestBootstrapMetadataFromURL_FetchesWhenLocalMissing verifies the issue #1374
+// fix: when no local metadata branch exists, the branch is fetched from the
+// checkpoint remote and points exactly at the remote tip — no empty orphan, no
+// replayed commit on top.
+//
+// Not parallel: uses t.Chdir().
+func TestBootstrapMetadataFromURL_FetchesWhenLocalMissing(t *testing.T) {
+	ctx := context.Background()
+
+	remoteDir := t.TempDir()
+	testutil.InitRepo(t, remoteDir)
+	testutil.WriteFile(t, remoteDir, "f.txt", "init")
+	testutil.GitAdd(t, remoteDir, "f.txt")
+	testutil.GitCommit(t, remoteDir, "init")
+	remoteDefault := checkpointRemoteCurrentBranch(ctx, t, remoteDir)
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, remoteDir, "rm", "-rf", ".")
+	commitCheckpointRemoteMetadata(ctx, t, remoteDir, "abcabcabcabc", "data")
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", remoteDefault)
+	remoteTip := checkpointRemoteRevParse(ctx, t, remoteDir, paths.MetadataBranchName)
+
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+	t.Chdir(localDir)
+
+	repo, err := git.PlainOpen(localDir)
+	require.NoError(t, err)
+
+	require.False(t, testutil.BranchExists(t, localDir, paths.MetadataBranchName),
+		"test setup: local metadata branch should not exist yet")
+
+	ok, err := bootstrapMetadataFromURL(ctx, repo, remoteDir)
+	require.NoError(t, err)
+	assert.True(t, ok, "bootstrap should report success when the remote has real metadata")
+	assert.True(t, testutil.BranchExists(t, localDir, paths.MetadataBranchName))
+	assert.Equal(t, remoteTip, checkpointRemoteRevParse(ctx, t, localDir, paths.MetadataBranchName),
+		"local branch should point exactly at the remote tip, not at a fresh orphan")
+}
+
+// TestBootstrapMetadataFromURL_EmptyRemoteReturnsFalse verifies that fetching a
+// remote whose metadata branch is itself an empty orphan does not count as a
+// successful bootstrap, so the caller falls back to its normal orphan creation.
+//
+// Not parallel: uses t.Chdir().
+func TestBootstrapMetadataFromURL_EmptyRemoteReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+
+	remoteDir := t.TempDir()
+	testutil.InitRepo(t, remoteDir)
+	testutil.WriteFile(t, remoteDir, "f.txt", "init")
+	testutil.GitAdd(t, remoteDir, "f.txt")
+	testutil.GitCommit(t, remoteDir, "init")
+	createEmptyOrphanMetadataBranch(ctx, t, remoteDir)
+
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+	t.Chdir(localDir)
+
+	repo, err := git.PlainOpen(localDir)
+	require.NoError(t, err)
+
+	ok, err := bootstrapMetadataFromURL(ctx, repo, remoteDir)
+	require.NoError(t, err)
+	assert.False(t, ok, "an empty remote metadata branch should not be treated as a successful bootstrap")
+}
+
+// TestHealEmptyOrphanFromURL_ReplacesEmptyOrphanWithRemoteData verifies that an
+// existing empty-orphan metadata branch (the issue #1374 bug state) is replaced
+// wholesale with the real branch from the checkpoint remote — the local ref ends
+// up at the exact remote tip with no replayed empty commit on top.
+//
+// Not parallel: uses t.Chdir().
+func TestHealEmptyOrphanFromURL_ReplacesEmptyOrphanWithRemoteData(t *testing.T) {
+	ctx := context.Background()
+
+	remoteDir := t.TempDir()
+	testutil.InitRepo(t, remoteDir)
+	testutil.WriteFile(t, remoteDir, "f.txt", "init")
+	testutil.GitAdd(t, remoteDir, "f.txt")
+	testutil.GitCommit(t, remoteDir, "init")
+	remoteDefault := checkpointRemoteCurrentBranch(ctx, t, remoteDir)
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, remoteDir, "rm", "-rf", ".")
+	commitCheckpointRemoteMetadata(ctx, t, remoteDir, "abcabcabcabc", "data")
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", remoteDefault)
+	remoteTip := checkpointRemoteRevParse(ctx, t, remoteDir, paths.MetadataBranchName)
+
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+	createEmptyOrphanMetadataBranch(ctx, t, localDir)
+	t.Chdir(localDir)
+
+	repo, err := git.PlainOpen(localDir)
+	require.NoError(t, err)
+
+	orphanHash := checkpointRemoteRevParse(ctx, t, localDir, paths.MetadataBranchName)
+	require.NotEqual(t, remoteTip, orphanHash, "test setup: orphan must differ from remote tip")
+
+	ok, err := healEmptyOrphanFromURL(ctx, repo, remoteDir)
+	require.NoError(t, err)
+	assert.True(t, ok, "heal should report success when it replaces an empty orphan with real data")
+
+	healed := checkpointRemoteRevParse(ctx, t, localDir, paths.MetadataBranchName)
+	assert.Equal(t, remoteTip, healed,
+		"empty orphan should be replaced by the exact remote tip, not a replay with an extra empty commit")
+	assert.Contains(t, checkpointRemoteMetadataFiles(ctx, t, localDir), "ab/cabcabcabc/metadata.json",
+		"healed branch should contain the remote checkpoint data")
+	assert.False(t, testutil.BranchExists(t, localDir, "refs/entire-fetch-tmp/"+paths.MetadataBranchName),
+		"temp fetch ref should be cleaned up")
+}
+
+// TestBootstrapMetadataFromCheckpointRemote_NoConfigReturnsFalse verifies the
+// resolver wrapper is a no-op (and creates no branch) when no checkpoint_remote is
+// configured, so the caller falls through to normal orphan creation.
+//
+// Not parallel: uses t.Chdir().
+func TestBootstrapMetadataFromCheckpointRemote_NoConfigReturnsFalse(t *testing.T) {
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+
+	entireDir := filepath.Join(localDir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(entireDir, paths.SettingsFileName),
+		[]byte(`{"enabled": true}`),
+		0o644,
+	))
+	t.Chdir(localDir)
+
+	repo, err := git.PlainOpen(localDir)
+	require.NoError(t, err)
+
+	ok, err := BootstrapMetadataFromCheckpointRemote(t.Context(), repo)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.False(t, testutil.BranchExists(t, localDir, paths.MetadataBranchName),
+		"bootstrap must not create a branch when no checkpoint_remote is configured")
+}
+
+// TestHealEmptyOrphanMetadataFromCheckpointRemote_NonEmptyLocalReturnsFalse
+// verifies that a local metadata branch with real data is never healed/replaced,
+// regardless of any configured checkpoint_remote (the guard returns before any
+// network access).
+//
+// Not parallel: uses t.Chdir().
+func TestHealEmptyOrphanMetadataFromCheckpointRemote_NonEmptyLocalReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+	localDefault := checkpointRemoteCurrentBranch(ctx, t, localDir)
+	runCheckpointRemoteGit(ctx, t, localDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, localDir, "rm", "-rf", ".")
+	commitCheckpointRemoteMetadata(ctx, t, localDir, "abcabcabcabc", "real")
+	runCheckpointRemoteGit(ctx, t, localDir, "checkout", localDefault)
+	t.Chdir(localDir)
+
+	repo, err := git.PlainOpen(localDir)
+	require.NoError(t, err)
+	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+
+	ok, err := HealEmptyOrphanMetadataFromCheckpointRemote(ctx, repo, localRef)
+	require.NoError(t, err)
+	assert.False(t, ok, "a non-empty local metadata branch must not be replaced")
+}
+
+// TestHealEmptyOrphanMetadataFromCheckpointRemote_HealsVercelOnlyOrphan verifies
+// that a local metadata branch carrying only vercel.json — the orphan-init state in
+// a vercel-enabled repo (issue #1374) — is still recognized as un-initialized and
+// healed from the checkpoint remote. A literal empty-tree check would have skipped
+// it because the tree is not empty.
+//
+// Not parallel: overrides the URL resolver seam and uses t.Chdir().
+func TestHealEmptyOrphanMetadataFromCheckpointRemote_HealsVercelOnlyOrphan(t *testing.T) {
+	ctx := context.Background()
+
+	remoteDir := t.TempDir()
+	testutil.InitRepo(t, remoteDir)
+	testutil.WriteFile(t, remoteDir, "f.txt", "init")
+	testutil.GitAdd(t, remoteDir, "f.txt")
+	testutil.GitCommit(t, remoteDir, "init")
+	remoteDefault := checkpointRemoteCurrentBranch(ctx, t, remoteDir)
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, remoteDir, "rm", "-rf", ".")
+	commitCheckpointRemoteMetadata(ctx, t, remoteDir, "abcabcabcabc", "data")
+	runCheckpointRemoteGit(ctx, t, remoteDir, "checkout", remoteDefault)
+	remoteTip := checkpointRemoteRevParse(ctx, t, remoteDir, paths.MetadataBranchName)
+
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+	localDefault := checkpointRemoteCurrentBranch(ctx, t, localDir)
+	// Orphan that carries only vercel.json — the vercel-enabled bug state.
+	runCheckpointRemoteGit(ctx, t, localDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, localDir, "rm", "-rf", ".")
+	testutil.WriteFile(t, localDir, vercelconfig.FileName, `{"git":{"deploymentEnabled":{"entire/**":false}}}`)
+	runCheckpointRemoteGit(ctx, t, localDir, "add", vercelconfig.FileName)
+	runCheckpointRemoteGit(ctx, t, localDir, "commit", "-m", "Initialize metadata branch")
+	runCheckpointRemoteGit(ctx, t, localDir, "checkout", localDefault)
+	t.Chdir(localDir)
+
+	origResolve := resolveCheckpointRemoteURLFn
+	t.Cleanup(func() { resolveCheckpointRemoteURLFn = origResolve })
+	resolveCheckpointRemoteURLFn = func(context.Context) (string, bool) { return remoteDir, true }
+
+	repo, err := git.PlainOpen(localDir)
+	require.NoError(t, err)
+	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, err)
+
+	ok, err := HealEmptyOrphanMetadataFromCheckpointRemote(ctx, repo, localRef)
+	require.NoError(t, err)
+	assert.True(t, ok, "a vercel.json-only orphan should be treated as un-initialized and healed")
+	assert.Equal(t, remoteTip, checkpointRemoteRevParse(ctx, t, localDir, paths.MetadataBranchName),
+		"local branch should adopt the checkpoint remote tip")
+}
+
+// TestEnsurePrimaryRef_CheckpointRemoteTakesPrecedenceOverOrigin verifies that
+// when a checkpoint_remote is configured, EnsurePrimaryRef adopts its branch even
+// when a (stale) origin/entire/checkpoints/v1 tracking ref is present. Origin is no
+// longer the authoritative checkpoint store, so it must not be seeded from (issue
+// #1374).
+//
+// Not parallel: overrides the URL resolver seam and uses t.Chdir().
+func TestEnsurePrimaryRef_CheckpointRemoteTakesPrecedenceOverOrigin(t *testing.T) {
+	ctx := context.Background()
+
+	// Checkpoint remote holds the authoritative checkpoint.
+	checkpointRemoteDir := t.TempDir()
+	testutil.InitRepo(t, checkpointRemoteDir)
+	testutil.WriteFile(t, checkpointRemoteDir, "f.txt", "init")
+	testutil.GitAdd(t, checkpointRemoteDir, "f.txt")
+	testutil.GitCommit(t, checkpointRemoteDir, "init")
+	cpDefault := checkpointRemoteCurrentBranch(ctx, t, checkpointRemoteDir)
+	runCheckpointRemoteGit(ctx, t, checkpointRemoteDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, checkpointRemoteDir, "rm", "-rf", ".")
+	commitCheckpointRemoteMetadata(ctx, t, checkpointRemoteDir, "aaaaaaaaaaaa", "authoritative")
+	runCheckpointRemoteGit(ctx, t, checkpointRemoteDir, "checkout", cpDefault)
+	cpTip := checkpointRemoteRevParse(ctx, t, checkpointRemoteDir, paths.MetadataBranchName)
+
+	// Origin holds a different, stale checkpoint branch.
+	originDir := t.TempDir()
+	testutil.InitRepo(t, originDir)
+	testutil.WriteFile(t, originDir, "f.txt", "init")
+	testutil.GitAdd(t, originDir, "f.txt")
+	testutil.GitCommit(t, originDir, "init")
+	originDefault := checkpointRemoteCurrentBranch(ctx, t, originDir)
+	runCheckpointRemoteGit(ctx, t, originDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, originDir, "rm", "-rf", ".")
+	commitCheckpointRemoteMetadata(ctx, t, originDir, "bbbbbbbbbbbb", "stale")
+	runCheckpointRemoteGit(ctx, t, originDir, "checkout", originDefault)
+
+	// Local clone of origin: origin tracking ref present, no local metadata branch.
+	localDir := t.TempDir()
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "f.txt", "init")
+	testutil.GitAdd(t, localDir, "f.txt")
+	testutil.GitCommit(t, localDir, "init")
+	runCheckpointRemoteGit(ctx, t, localDir, "remote", "add", "origin", originDir)
+	runCheckpointRemoteGit(ctx, t, localDir, "fetch", "origin")
+	require.NoError(t, os.MkdirAll(filepath.Join(localDir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(localDir, ".entire", paths.SettingsFileName),
+		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`),
+		0o644,
+	))
+	t.Chdir(localDir)
+
+	// Point the resolver at the local checkpoint remote instead of the github URL.
+	origResolve := resolveCheckpointRemoteURLFn
+	t.Cleanup(func() { resolveCheckpointRemoteURLFn = origResolve })
+	resolveCheckpointRemoteURLFn = func(context.Context) (string, bool) { return checkpointRemoteDir, true }
+
+	repo, err := git.PlainOpen(localDir)
+	require.NoError(t, err)
+
+	// Sanity: the stale origin tracking ref exists and differs from the remote.
+	originRef, err := repo.Reference(plumbing.NewRemoteReferenceName("origin", paths.MetadataBranchName), true)
+	require.NoError(t, err)
+	require.NotEqual(t, cpTip, originRef.Hash().String(), "test setup: origin must differ from checkpoint remote")
+
+	require.NoError(t, EnsurePrimaryRef(ctx, repo))
+
+	got := checkpointRemoteRevParse(ctx, t, localDir, paths.MetadataBranchName)
+	assert.Equal(t, cpTip, got, "local branch should adopt the checkpoint remote, not the stale origin ref")
+	files := checkpointRemoteMetadataFiles(ctx, t, localDir)
+	assert.Contains(t, files, "aa/aaaaaaaaaa/metadata.json", "authoritative checkpoint-remote data should be present")
+	assert.NotContains(t, files, "bb/bbbbbbbbbb/metadata.json", "stale origin data must not be adopted")
+}
+
+// createEmptyOrphanMetadataBranch creates an empty-tree orphan entire/checkpoints/v1
+// branch in dir, reproducing the issue #1374 bug state, and leaves the default
+// branch checked out.
+func createEmptyOrphanMetadataBranch(ctx context.Context, t *testing.T, dir string) {
+	t.Helper()
+	defaultBranch := checkpointRemoteCurrentBranch(ctx, t, dir)
+	runCheckpointRemoteGit(ctx, t, dir, "checkout", "--orphan", paths.MetadataBranchName)
+	runCheckpointRemoteGit(ctx, t, dir, "rm", "-rf", ".")
+	runCheckpointRemoteGit(ctx, t, dir, "commit", "--allow-empty", "-m", "Initialize metadata branch")
+	runCheckpointRemoteGit(ctx, t, dir, "checkout", defaultBranch)
 }
 
 func runCheckpointRemoteGit(ctx context.Context, t *testing.T, dir string, args ...string) {

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -19,6 +19,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -454,10 +455,62 @@ func resolveAgentType(ctxAgentType types.AgentType, state *SessionState) types.A
 // empty, creates/updates the local ref from origin's remote-tracking ref.
 // Otherwise creates an empty orphan.
 func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
+	// Rebind settings (checkpoint_remote, committed-ref topology) lookup to the
+	// repository being modified rather than the ambient working directory, so the
+	// "is a checkpoint_remote configured" decision matches repo even when a caller
+	// or test passes a handle for a repo that is not CWD.
+	//
+	// This rebinds only settings lookup. The bootstrap/heal fetch below delegates
+	// to FetchMetadataBranch / fetchURLIntoTmpRef, which run git and resolve the
+	// destination repo from the process working directory — so adopting from a
+	// checkpoint_remote still requires CWD to be the repo root. EnsureSetup
+	// satisfies this (it opens repo from CWD); tests t.Chdir into the repo. In
+	// normal use CWD already is the repo root, so the rebinding is a no-op.
+	if root, rootErr := getRepoPath(repo); rootErr == nil {
+		ctx = settings.WithWorktreeRoot(ctx, root)
+	}
+
 	refs := checkpoint.ResolveCommittedRefs(ctx)
 	primaryName := refs.Primary.Short()
 
-	// Origin only tracks Primary when Primary is in Push.
+	localRef, localErr := repo.Reference(refs.Primary, true)
+	if localErr != nil && !errors.Is(localErr, plumbing.ErrReferenceNotFound) {
+		return fmt.Errorf("failed to check metadata ref: %w", localErr)
+	}
+	localExists := localErr == nil
+
+	// A configured checkpoint_remote is the authoritative checkpoint store and
+	// takes precedence over origin's (possibly stale) primary tracking ref. Adopt
+	// it whenever the local ref holds no real checkpoint data yet — missing, or an
+	// un-initialized orphan that only carries config such as vercel.json — so a
+	// fresh machine never seeds stale checkpoints from origin and later replays
+	// them into the checkpoint remote (issue #1374).
+	if remote.Configured(ctx) {
+		var adopted bool
+		var adoptErr error
+		if localExists {
+			adopted, adoptErr = HealEmptyOrphanMetadataFromCheckpointRemote(ctx, repo, localRef)
+		} else {
+			adopted, adoptErr = BootstrapMetadataFromCheckpointRemote(ctx, repo)
+		}
+		if adoptErr != nil {
+			return adoptErr
+		}
+		if adopted {
+			return nil
+		}
+		// The authoritative remote had no usable data, or the fetch failed. Do
+		// not seed from origin (non-authoritative): keep an existing local ref
+		// as-is, otherwise create a fresh orphan that future pushes publish to the
+		// checkpoint remote.
+		if localExists {
+			return nil
+		}
+		return createOrphanMetadataRef(ctx, repo, refs)
+	}
+
+	// No checkpoint_remote configured — origin holds the checkpoint store. Origin
+	// only tracks Primary when Primary is in Push.
 	var remoteRef *plumbing.Reference
 	if refs.PrimaryFetchableFromOrigin() {
 		var remoteErr error
@@ -467,17 +520,15 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 		}
 	}
 
-	// Check if local ref already exists
-	localRef, err := repo.Reference(refs.Primary, true)
-	if err == nil {
+	if localExists {
 		if remoteRef != nil && localRef.Hash() != remoteRef.Hash() {
 			// Local and remote exist but differ — determine relationship
-			isEmpty, checkErr := isEmptyMetadataBranch(repo, localRef)
+			hasData, checkErr := metadataBranchHasData(repo, localRef)
 			if checkErr != nil {
 				return fmt.Errorf("failed to check metadata ref contents: %w", checkErr)
 			}
-			if isEmpty {
-				// Empty orphan — just point to remote
+			if !hasData {
+				// Un-initialized orphan — just point to remote
 				if setErr := AdvanceCommittedPrimary(ctx, repo, refs, remoteRef.Hash()); setErr != nil {
 					return fmt.Errorf("failed to update metadata ref from remote: %w", setErr)
 				}
@@ -494,11 +545,8 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 		}
 		return nil
 	}
-	if !errors.Is(err, plumbing.ErrReferenceNotFound) {
-		return fmt.Errorf("failed to check metadata ref: %w", err)
-	}
 
-	// Local ref doesn't exist — create from remote if available
+	// Local ref doesn't exist — create from origin if available
 	if remoteRef != nil {
 		if err := AdvanceCommittedPrimary(ctx, repo, refs, remoteRef.Hash()); err != nil {
 			return fmt.Errorf("failed to create metadata ref from remote: %w", err)
@@ -507,7 +555,14 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 		return nil
 	}
 
-	// No local ref and nothing to bootstrap from — create empty orphan
+	// No local or origin ref — create empty orphan
+	return createOrphanMetadataRef(ctx, repo, refs)
+}
+
+// createOrphanMetadataRef creates the local primary metadata ref as a fresh empty
+// orphan commit (plus any merged vercel config). Used when no metadata ref can be
+// sourced from origin or a checkpoint_remote.
+func createOrphanMetadataRef(ctx context.Context, repo *git.Repository, refs checkpoint.CommittedRefs) error {
 	emptyTree := &object.Tree{Entries: []object.TreeEntry{}}
 	obj := repo.Storer.NewEncodedObject()
 	if err := emptyTree.Encode(obj); err != nil {
@@ -560,14 +615,28 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 		return fmt.Errorf("failed to create metadata ref: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "  ✓ Created orphan ref %s for session metadata\n", primaryName)
+	fmt.Fprintf(os.Stderr, "  ✓ Created orphan ref %s for session metadata\n", refs.Primary.Short())
 	return nil
 }
 
-// isEmptyMetadataBranch returns true if the branch ref points to a commit with an empty tree.
-// Only checks the tip commit — if a data commit sits on top of an empty orphan, this returns
-// false, which is correct: the bug this detects creates a single empty orphan as the tip.
-func isEmptyMetadataBranch(repo *git.Repository, ref *plumbing.Reference) (bool, error) {
+// metadataBranchInitFiles are the root-level files that orphan initialization may
+// write into an otherwise-empty metadata branch (currently only the Vercel
+// config). A branch containing nothing but these holds no checkpoint data.
+var metadataBranchInitFiles = map[string]bool{
+	vercelconfig.FileName: true, // "vercel.json"
+}
+
+// metadataBranchHasData reports whether the branch tip tree contains anything
+// beyond orphan-initialization artifacts. It returns false for an empty tree, or
+// a tree holding only init files such as vercel.json — the un-initialized-orphan
+// state that is safe to adopt from the authoritative remote — and true for any
+// other content (checkpoint shards or pre-existing files).
+//
+// A literal empty-tree check missed vercel.json-only orphans on vercel-enabled
+// second devices, leaving them unhealed (issue #1374). Ignoring only the known
+// init files (rather than treating "no shards" as empty) avoids clobbering a
+// branch that carries other real content. Only the tip commit is inspected.
+func metadataBranchHasData(repo *git.Repository, ref *plumbing.Reference) (bool, error) {
 	commit, err := repo.CommitObject(ref.Hash())
 	if err != nil {
 		return false, fmt.Errorf("failed to get commit: %w", err)
@@ -576,7 +645,12 @@ func isEmptyMetadataBranch(repo *git.Repository, ref *plumbing.Reference) (bool,
 	if err != nil {
 		return false, fmt.Errorf("failed to get tree: %w", err)
 	}
-	return len(tree.Entries) == 0, nil
+	for _, entry := range tree.Entries {
+		if !metadataBranchInitFiles[entry.Name] {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // sessionMetadataLite contains only the fields needed from session-level metadata.json.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/534
<!-- entire-trail-link-end -->

## Problem

Relates to #1374.

`EnsureMetadataBranch` only consulted the local branch and origin's remote-tracking ref when setting up `entire/checkpoints/v1`. When a separate `checkpoint_remote` is configured, the metadata history lives in *that* remote rather than origin, so on a second device neither source existed and `entire enable` fell straight through to creating an **empty orphan** branch. That orphan left `entire checkpoint list` empty and was rejected as non-fast-forward on the next fetch from the real remote.

## What changed

`EnsureMetadataBranch` now treats a configured `checkpoint_remote` as the authoritative store and consults it **before** origin:

- **Local branch missing** → bootstrap from the checkpoint remote (direct ref set, no replay).
- **Local branch holds no checkpoint data** → force-replace the un-initialized orphan with the real branch from the checkpoint remote (force-set rather than a safe advance, so the disjoint orphan commit is discarded instead of replayed onto the real tip).
- It **never seeds from origin** while a `checkpoint_remote` is configured, so a stale `origin/entire/checkpoints/v1` tracking ref can no longer shadow the real checkpoints or get replayed back into the checkpoint remote.

The "un-initialized" check now ignores orphan-init artifacts (`vercel.json`) rather than requiring a literal empty tree — vercel-enabled repos write `vercel.json` into the orphan, which previously made the branch look non-empty and skip healing. Ignoring only the known init files (instead of treating "no checkpoint shards" as empty) avoids clobbering a branch that carries other real content.

Settings are resolved against the repository being modified (its worktree root) rather than the ambient CWD, keeping the decision consistent with the repo handle. In normal use CWD is the repo root, so this is a no-op.

All paths are non-fatal: a missing/unreachable `checkpoint_remote` falls back to keeping the local branch or creating a fresh orphan.

## Tests

- `TestEnsureMetadataBranch_CheckpointRemoteTakesPrecedenceOverOrigin` — a stale origin ref is ignored in favor of the checkpoint remote.
- `TestHealEmptyOrphanMetadataFromCheckpointRemote_HealsVercelOnlyOrphan` — a `vercel.json`-only orphan heals.
- `TestBootstrapMetadataFromURL_*`, `TestHealEmptyOrphanFromURL_*` — bootstrap/heal mechanics against a local remote.

`mise run fmt && mise run lint` clean; full unit suite (6138) and integration suite (394) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes metadata branch creation during enable/setup and can force-reset local refs when healing empty orphans; wrong remote URL or fetch behavior could leave users with missing or incorrect checkpoint history, though failures fall back without hard errors.
> 
> **Overview**
> Fixes **#1374** by making `EnsureMetadataBranch` treat a configured **`checkpoint_remote`** as the source of truth during `entire enable` / setup, instead of only local + `origin/entire/checkpoints/v1`.
> 
> When **`checkpoint_remote` is set**, setup now **bootstraps** a missing local metadata branch from that remote (ref set to the fetched tip, no replay) or **heals** a local branch that has no real checkpoint data by **force-replacing** the orphan with the remote tip (avoids replaying a disjoint empty commit). It **does not seed from `origin`** in that mode, so stale `origin/entire/checkpoints/v1` cannot shadow the real store.
> 
> **`isEmptyMetadataBranch`** is replaced by **`metadataBranchHasData`**, which treats tips with only orphan-init files (e.g. **`vercel.json`**) as uninitialized so vercel-enabled second devices still heal. Settings resolution uses the **repo worktree root** via `settings.WithWorktreeRoot` for consistent `checkpoint_remote` detection.
> 
> New helpers in **`checkpoint_remote.go`** (`BootstrapMetadataFromCheckpointRemote`, `HealEmptyOrphanMetadataFromCheckpointRemote`, test seam `resolveCheckpointRemoteURLFn`) plus broad integration tests cover bootstrap, heal, origin precedence, and vercel-only orphans. Unreachable/missing checkpoint remote remains **non-fatal** (keep local or create orphan).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcab96d8ba07bf60e6f2223e02c4e3ef6147741c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->