### PR TITLE
Report entire enable to the backend

### DIFF
--- a/cmd/entire/cli/api/enable.go
+++ b/cmd/entire/cli/api/enable.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 )
 
-// EnableRepoRequest is the body of POST /api/v1/cli/enable. The server parses
-// the raw remote URL itself, so the CLI only needs to send what it knows.
+// EnableRepoRequest is the body of POST /api/v1/cli/enable. RemoteURL is a
+// clean, credential-free remote URL (the CLI strips any embedded credentials
+// and query params before sending — see reportRepoEnabled); the server
+// resolves it to a repo on its end.
 type EnableRepoRequest struct {
 	RemoteURL string `json:"remote_url"`
 }
@@ -14,6 +16,10 @@ type EnableRepoRequest struct {
 // EnableRepoResponse is the result of recording an `entire enable`. Connected
 // reports whether the GitHub App can currently reach the repo; when it can't,
 // InstallURL points at the App installation page.
+//
+// The CLI deliberately ignores these fields today: reporting is best-effort and
+// the "install the GitHub App" nudge is surfaced by the web onboarding, not the
+// CLI. They are decoded for the API contract and potential future use.
 type EnableRepoResponse struct {
 	Connected  bool   `json:"connected"`
 	InstallURL string `json:"install_url,omitempty"`

--- a/cmd/entire/cli/api/enable.go
+++ b/cmd/entire/cli/api/enable.go
@@ -19,7 +19,7 @@ type EnableRepoResponse struct {
 	InstallURL string `json:"install_url,omitempty"`
 	Repo       *struct {
 		FullName string `json:"full_name"`
-		GithubID int64  `json:"github_id"`
+		GitHubID int64  `json:"github_id"`
 		Private  bool   `json:"private"`
 	} `json:"repo,omitempty"`
 }

--- a/cmd/entire/cli/api/enable.go
+++ b/cmd/entire/cli/api/enable.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+	"fmt"
+)
+
+// EnableRepoRequest is the body of POST /api/v1/cli/enable. The server parses
+// the raw remote URL itself, so the CLI only needs to send what it knows.
+type EnableRepoRequest struct {
+	RemoteURL string `json:"remote_url"`
+}
+
+// EnableRepoResponse is the result of recording an `entire enable`. Connected
+// reports whether the GitHub App can currently reach the repo; when it can't,
+// InstallURL points at the App installation page.
+type EnableRepoResponse struct {
+	Connected  bool   `json:"connected"`
+	InstallURL string `json:"install_url,omitempty"`
+	Repo       *struct {
+		FullName string `json:"full_name"`
+		GithubID int64  `json:"github_id"`
+		Private  bool   `json:"private"`
+	} `json:"repo,omitempty"`
+}
+
+// ReportEnable records that the authenticated user ran `entire enable` for the
+// repo identified by remoteURL, and returns whether the App can reach it.
+func (c *Client) ReportEnable(ctx context.Context, remoteURL string) (*EnableRepoResponse, error) {
+	resp, err := c.Post(ctx, "/api/v1/cli/enable", EnableRepoRequest{RemoteURL: remoteURL})
+	if err != nil {
+		return nil, fmt.Errorf("report enable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if err := CheckResponse(resp); err != nil {
+		return nil, err
+	}
+
+	var out EnableRepoResponse
+	if err := DecodeJSON(resp, &out); err != nil {
+		return nil, fmt.Errorf("report enable: %w", err)
+	}
+	return &out, nil
+}

--- a/cmd/entire/cli/api/enable_test.go
+++ b/cmd/entire/cli/api/enable_test.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient_ReportEnable_PostsRemoteAndDecodesResponse(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotMethod, gotAuth string
+	var gotBody EnableRepoRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotAuth = r.Header.Get("Authorization")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(body, &gotBody); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"connected":true,"repo":{"full_name":"entireio/cli","github_id":42,"private":true}}`)) //nolint:errcheck // test handler
+	}))
+	defer server.Close()
+
+	c := NewClient("tok")
+	c.baseURL = server.URL
+
+	out, err := c.ReportEnable(context.Background(), "git@github.com:entireio/cli.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/v1/cli/enable" {
+		t.Errorf("path = %q, want /api/v1/cli/enable", gotPath)
+	}
+	if gotAuth != testBearerHeader {
+		t.Errorf("Authorization = %q, want %q", gotAuth, testBearerHeader)
+	}
+	if gotBody.RemoteURL != "git@github.com:entireio/cli.git" {
+		t.Errorf("remote_url = %q", gotBody.RemoteURL)
+	}
+	if !out.Connected {
+		t.Errorf("connected = false, want true")
+	}
+	if out.Repo == nil || out.Repo.FullName != "entireio/cli" {
+		t.Errorf("repo = %+v", out.Repo)
+	}
+}
+
+func TestClient_ReportEnable_ReturnsInstallURLWhenNotConnected(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"connected":false,"install_url":"https://github.com/apps/entire/installations/new"}`)) //nolint:errcheck // test handler
+	}))
+	defer server.Close()
+
+	c := NewClient("tok")
+	c.baseURL = server.URL
+
+	out, err := c.ReportEnable(context.Background(), "https://github.com/secret/private.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Connected {
+		t.Errorf("connected = true, want false")
+	}
+	if out.InstallURL != "https://github.com/apps/entire/installations/new" {
+		t.Errorf("install_url = %q", out.InstallURL)
+	}
+}
+
+func TestClient_ReportEnable_ReturnsErrorOnFailureStatus(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"Unsupported or non-GitHub remote_url"}`)) //nolint:errcheck // test handler
+	}))
+	defer server.Close()
+
+	c := NewClient("tok")
+	c.baseURL = server.URL
+
+	if _, err := c.ReportEnable(context.Background(), "git@gitlab.com:foo/bar.git"); err == nil {
+		t.Fatal("expected error for 400 response, got nil")
+	}
+}

--- a/cmd/entire/cli/gitremote/gitremote.go
+++ b/cmd/entire/cli/gitremote/gitremote.go
@@ -45,6 +45,31 @@ var hostToForge = map[string]string{
 	"github.com": "gh",
 }
 
+// forgeToHost is the reverse of hostToForge: it maps a forge identifier back to
+// its canonical public host. Used to recover the real forge host from an
+// entire:// remote, whose Host is the Entire cluster rather than the forge.
+var forgeToHost = func() map[string]string {
+	m := make(map[string]string, len(hostToForge))
+	for host, forge := range hostToForge {
+		m[forge] = host
+	}
+	return m
+}()
+
+// CanonicalHost returns the canonical public host of the upstream forge.
+//
+// For direct git URLs this is just Host. For entire:// remotes — whose Host is
+// the Entire cluster (e.g. aws-us-east-2.entire.io) rather than the forge — it
+// maps the forge prefix back to the forge's host (gh → github.com). Falls back
+// to Host when the forge is unknown (e.g. a self-hosted GitHub Enterprise),
+// preserving the only host we know for it.
+func (i *Info) CanonicalHost() string {
+	if host, ok := forgeToHost[i.Forge]; ok {
+		return host
+	}
+	return i.Host
+}
+
 // HostPort returns Host, or "Host:Port" when Port is non-empty.
 func (i *Info) HostPort() string {
 	if i.Port == "" {

--- a/cmd/entire/cli/gitremote/gitremote_test.go
+++ b/cmd/entire/cli/gitremote/gitremote_test.go
@@ -136,6 +136,30 @@ func TestExtractOwnerFromRemoteURL(t *testing.T) {
 	}
 }
 
+func TestInfo_CanonicalHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"direct https github", "https://github.com/org/repo.git", "github.com"},
+		{"direct ssh github", "git@github.com:org/repo.git", "github.com"},
+		{"entire mirror maps forge to host", "entire://aws-us-east-2.entire.io/gh/org/repo", "github.com"},
+		{"unknown forge falls back to host", "git@ghe.corp.example.com:org/repo.git", "ghe.corp.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			info, err := ParseURL(tt.url)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, info.CanonicalHost())
+		})
+	}
+}
+
 func TestRedactURL(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -952,15 +952,11 @@ func reportRepoEnabled(ctx context.Context, insecureHTTPAuth bool) {
 		return
 	}
 
-	// Never send the raw remote: it can carry embedded credentials
-	// (https://token@host/...) or query params. Parse and rebuild a clean,
-	// credential-free URL; skip entirely if it isn't parseable.
-	info, err := gitremote.ParseURL(rawURL)
+	cleanURL, err := cleanRemoteURLForReport(rawURL)
 	if err != nil {
 		logging.Debug(ctx, "skipping enable report: unparseable origin remote", "error", err)
 		return
 	}
-	cleanURL := fmt.Sprintf("https://%s/%s/%s.git", info.Host, info.Owner, info.Repo)
 
 	client, err := NewAuthenticatedAPIClient(ctx, insecureHTTPAuth)
 	if err != nil {
@@ -972,6 +968,19 @@ func reportRepoEnabled(ctx context.Context, insecureHTTPAuth bool) {
 	if _, err := client.ReportEnable(ctx, cleanURL); err != nil {
 		logging.Debug(ctx, "enable report failed", "error", err)
 	}
+}
+
+// cleanRemoteURLForReport turns a raw git remote URL into a clean,
+// credential-free HTTPS URL safe to send to the backend. The raw remote can
+// carry embedded credentials (https://token@host/...) or query params, so we
+// never forward it verbatim: parse it and rebuild from host/owner/repo alone.
+// Returns an error if the URL can't be parsed (the caller skips reporting).
+func cleanRemoteURLForReport(rawURL string) (string, error) {
+	info, err := gitremote.ParseURL(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse remote URL: %w", err)
+	}
+	return fmt.Sprintf("https://%s/%s/%s.git", info.Host, info.Owner, info.Repo), nil
 }
 
 func newDisableCmd() *cobra.Command {

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
@@ -939,6 +940,12 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 // network error, App-can't-reach-repo) is swallowed — the web onboarding
 // surfaces the "install the GitHub App" nudge, so the CLI stays quiet.
 func reportRepoEnabled(ctx context.Context, insecureHTTPAuth bool) {
+	// This runs synchronously on the enable success path, so bound it: a backend
+	// that accepts the connection but never responds must not hang the command
+	// after it has already printed success.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
 	rawURL, err := gitremote.GetRemoteURL(ctx, "origin")
 	if err != nil || strings.TrimSpace(rawURL) == "" {
 		// Local-only repo with no origin yet — nothing to report.

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -777,7 +777,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 				if runErr != nil {
 					return
 				}
-				reportRepoEnabled(ctx, cmd.OutOrStdout(), insecureHTTPAuth)
+				reportRepoEnabled(ctx, cmd.ErrOrStderr(), insecureHTTPAuth)
 			}()
 			// Check if we're in a git repository first. If not, offer to
 			// bootstrap one (git init + optional GitHub repo). If the user
@@ -936,13 +936,24 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 // reportRepoEnabled records the `entire enable` against the backend so the web
 // onboarding can reflect it. It is strictly best-effort: enabling works fully
 // offline, so any failure (no origin remote, not logged in, network error) is
-// swallowed except for the actionable "App can't reach this repo" hint.
-func reportRepoEnabled(ctx context.Context, w io.Writer, insecureHTTPAuth bool) {
-	remoteURL, err := gitremote.GetRemoteURL(ctx, "origin")
-	if err != nil || strings.TrimSpace(remoteURL) == "" {
+// swallowed except for the actionable "App can't reach this repo" hint, which
+// is written to errW (a warning, not piped output).
+func reportRepoEnabled(ctx context.Context, errW io.Writer, insecureHTTPAuth bool) {
+	rawURL, err := gitremote.GetRemoteURL(ctx, "origin")
+	if err != nil || strings.TrimSpace(rawURL) == "" {
 		// Local-only repo with no origin yet — nothing to report.
 		return
 	}
+
+	// Never send the raw remote: it can carry embedded credentials
+	// (https://token@host/...) or query params. Parse and rebuild a clean,
+	// credential-free URL; skip entirely if it isn't parseable.
+	info, err := gitremote.ParseURL(rawURL)
+	if err != nil {
+		logging.Debug(ctx, "skipping enable report: unparseable origin remote", "error", err)
+		return
+	}
+	cleanURL := fmt.Sprintf("https://%s/%s/%s.git", info.Host, info.Owner, info.Repo)
 
 	client, err := NewAuthenticatedAPIClient(ctx, insecureHTTPAuth)
 	if err != nil {
@@ -951,14 +962,14 @@ func reportRepoEnabled(ctx context.Context, w io.Writer, insecureHTTPAuth bool) 
 		return
 	}
 
-	resp, err := client.ReportEnable(ctx, remoteURL)
+	resp, err := client.ReportEnable(ctx, cleanURL)
 	if err != nil {
 		logging.Debug(ctx, "enable report failed", "error", err)
 		return
 	}
 
 	if !resp.Connected && resp.InstallURL != "" {
-		fmt.Fprintf(w, "\nEntire can't access this repository yet. Install the GitHub App so checkpoints can sync:\n  %s\n", resp.InstallURL)
+		fmt.Fprintf(errW, "\nEntire can't access this repository yet. Install the GitHub App so checkpoints can sync:\n  %s\n", resp.InstallURL)
 	}
 }
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/external"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -753,6 +754,7 @@ func newEnableCmd() *cobra.Command {
 	var ignoreUntracked bool
 	var agentName string
 	var bootstrapOpts GitHubBootstrapOptions
+	var insecureHTTPAuth bool
 
 	cmd := &cobra.Command{
 		Use:   "enable",
@@ -766,6 +768,17 @@ If the current directory is not a git repository, Entire can initialize one
 for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 		RunE: func(cmd *cobra.Command, _ []string) (runErr error) {
 			ctx := cmd.Context()
+			// Best-effort: after a successful enable, tell the backend which repo
+			// was enabled so the web onboarding reflects it (and we can warn when
+			// the GitHub App can't reach it). Registered first so it runs LAST
+			// (defers are LIFO) — after any bootstrap finalize that creates the
+			// GitHub repo and pushes, by which point an origin remote exists.
+			defer func() {
+				if runErr != nil {
+					return
+				}
+				reportRepoEnabled(ctx, cmd.OutOrStdout(), insecureHTTPAuth)
+			}()
 			// Check if we're in a git repository first. If not, offer to
 			// bootstrap one (git init + optional GitHub repo). If the user
 			// declines, fall back to the legacy prerequisite error.
@@ -892,6 +905,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	cmd.Flags().BoolVar(&opts.Telemetry, flagTelemetry, true, "Enable anonymous usage analytics")
 	cmd.Flags().BoolVar(&opts.AbsoluteGitHookPath, flagAbsoluteGitHookPath, false, "Embed full binary path in git hooks (for GUI git clients that don't source shell profiles)")
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Accept all defaults without prompting (in a non-repo directory: init git, create private GitHub repo, commit; then enable all agents and accept telemetry)")
+	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
 
 	// Bootstrap flags for non-git-repo folders.
 	cmd.Flags().BoolVar(&bootstrapOpts.InitRepo, "init-repo", false, "If not a git repo, initialize one non-interactively")
@@ -917,6 +931,35 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 	})
 
 	return cmd
+}
+
+// reportRepoEnabled records the `entire enable` against the backend so the web
+// onboarding can reflect it. It is strictly best-effort: enabling works fully
+// offline, so any failure (no origin remote, not logged in, network error) is
+// swallowed except for the actionable "App can't reach this repo" hint.
+func reportRepoEnabled(ctx context.Context, w io.Writer, insecureHTTPAuth bool) {
+	remoteURL, err := gitremote.GetRemoteURL(ctx, "origin")
+	if err != nil || strings.TrimSpace(remoteURL) == "" {
+		// Local-only repo with no origin yet — nothing to report.
+		return
+	}
+
+	client, err := NewAuthenticatedAPIClient(ctx, insecureHTTPAuth)
+	if err != nil {
+		// Not logged in / token unavailable — enable already succeeded locally.
+		logging.Debug(ctx, "skipping enable report", "error", err)
+		return
+	}
+
+	resp, err := client.ReportEnable(ctx, remoteURL)
+	if err != nil {
+		logging.Debug(ctx, "enable report failed", "error", err)
+		return
+	}
+
+	if !resp.Connected && resp.InstallURL != "" {
+		fmt.Fprintf(w, "\nEntire can't access this repository yet. Install the GitHub App so checkpoints can sync:\n  %s\n", resp.InstallURL)
+	}
 }
 
 func newDisableCmd() *cobra.Command {

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -777,7 +777,7 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 				if runErr != nil {
 					return
 				}
-				reportRepoEnabled(ctx, cmd.ErrOrStderr(), insecureHTTPAuth)
+				reportRepoEnabled(ctx, insecureHTTPAuth)
 			}()
 			// Check if we're in a git repository first. If not, offer to
 			// bootstrap one (git init + optional GitHub repo). If the user
@@ -934,11 +934,11 @@ for you and (optionally) create a matching GitHub repository via the gh CLI.`,
 }
 
 // reportRepoEnabled records the `entire enable` against the backend so the web
-// onboarding can reflect it. It is strictly best-effort: enabling works fully
-// offline, so any failure (no origin remote, not logged in, network error) is
-// swallowed except for the actionable "App can't reach this repo" hint, which
-// is written to errW (a warning, not piped output).
-func reportRepoEnabled(ctx context.Context, errW io.Writer, insecureHTTPAuth bool) {
+// onboarding can reflect it. It is strictly best-effort and fully silent:
+// enabling works offline, and every outcome (no origin remote, not logged in,
+// network error, App-can't-reach-repo) is swallowed — the web onboarding
+// surfaces the "install the GitHub App" nudge, so the CLI stays quiet.
+func reportRepoEnabled(ctx context.Context, insecureHTTPAuth bool) {
 	rawURL, err := gitremote.GetRemoteURL(ctx, "origin")
 	if err != nil || strings.TrimSpace(rawURL) == "" {
 		// Local-only repo with no origin yet — nothing to report.
@@ -962,14 +962,8 @@ func reportRepoEnabled(ctx context.Context, errW io.Writer, insecureHTTPAuth boo
 		return
 	}
 
-	resp, err := client.ReportEnable(ctx, cleanURL)
-	if err != nil {
+	if _, err := client.ReportEnable(ctx, cleanURL); err != nil {
 		logging.Debug(ctx, "enable report failed", "error", err)
-		return
-	}
-
-	if !resp.Connected && resp.InstallURL != "" {
-		fmt.Fprintf(errW, "\nEntire can't access this repository yet. Install the GitHub App so checkpoints can sync:\n  %s\n", resp.InstallURL)
 	}
 }
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -980,7 +980,10 @@ func cleanRemoteURLForReport(rawURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse remote URL: %w", err)
 	}
-	return fmt.Sprintf("https://%s/%s/%s.git", info.Host, info.Owner, info.Repo), nil
+	// Use CanonicalHost, not Host: an entire://cluster/gh/owner/repo origin (an
+	// already-mirrored repo) carries the Entire cluster as Host, so reporting
+	// Host verbatim would point the backend at the cluster instead of github.com.
+	return fmt.Sprintf("https://%s/%s/%s.git", info.CanonicalHost(), info.Owner, info.Repo), nil
 }
 
 func newDisableCmd() *cobra.Command {

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -3089,3 +3089,76 @@ func TestConfigureCmd_FreshRepo_PointsAtEnable(t *testing.T) {
 		t.Errorf("expected hint pointing at 'entire enable', got stderr: %s", stderr.String())
 	}
 }
+
+func TestCleanRemoteURLForReport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "https without credentials is normalized",
+			rawURL: "https://github.com/entireio/cli.git",
+			want:   "https://github.com/entireio/cli.git",
+		},
+		{
+			name:   "https token credentials are stripped",
+			rawURL: "https://ghp_secrettoken@github.com/entireio/cli.git",
+			want:   "https://github.com/entireio/cli.git",
+		},
+		{
+			name:   "https user:password credentials are stripped",
+			rawURL: "https://x-access-token:ghp_secret@github.com/entireio/cli.git",
+			want:   "https://github.com/entireio/cli.git",
+		},
+		{
+			name:   "query parameters are dropped",
+			rawURL: "https://github.com/entireio/cli.git?token=secret",
+			want:   "https://github.com/entireio/cli.git",
+		},
+		{
+			name:   "scp-style ssh remote is normalized to https and the user is dropped",
+			rawURL: "git@github.com:entireio/cli.git",
+			want:   "https://github.com/entireio/cli.git",
+		},
+		{
+			name:   "missing .git suffix is added",
+			rawURL: "https://github.com/entireio/cli",
+			want:   "https://github.com/entireio/cli.git",
+		},
+		{
+			name:    "unparseable single-segment path errors",
+			rawURL:  "https://github.com/onlyowner.git",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := cleanRemoteURLForReport(tt.rawURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tt.rawURL, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.rawURL, err)
+			}
+			if got != tt.want {
+				t.Errorf("cleanRemoteURLForReport(%q) = %q, want %q", tt.rawURL, got, tt.want)
+			}
+			// The cleaned URL must never carry the original credentials.
+			for _, secret := range []string{"ghp_secrettoken", "ghp_secret", "x-access-token", "token=secret"} {
+				if strings.Contains(got, secret) {
+					t.Errorf("cleaned URL %q leaked credential %q", got, secret)
+				}
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/setup_test.go
+++ b/cmd/entire/cli/setup_test.go
@@ -3130,6 +3130,16 @@ func TestCleanRemoteURLForReport(t *testing.T) {
 			want:   "https://github.com/entireio/cli.git",
 		},
 		{
+			name:   "entire:// mirror origin maps the forge back to its real host",
+			rawURL: "entire://aws-us-east-2.entire.io/gh/entireio/cli",
+			want:   "https://github.com/entireio/cli.git",
+		},
+		{
+			name:   "unknown forge host is preserved (self-hosted enterprise)",
+			rawURL: "git@ghe.corp.example.com:entireio/cli.git",
+			want:   "https://ghe.corp.example.com/entireio/cli.git",
+		},
+		{
 			name:    "unparseable single-segment path errors",
 			rawURL:  "https://github.com/onlyowner.git",
 			wantErr: true,


### PR DESCRIPTION
## Summary

After a successful `entire enable`, the CLI now tells the backend which repo was enabled so the web onboarding (`/overview` setup timeline) can reflect it. This is the CLI half of the per-user `entire enable` tracking added in entirehq/entire.io#2293 (new `POST /api/v1/cli/enable`).

## What changed

- **`api.Client.ReportEnable`** (`cmd/entire/cli/api/enable.go`) — `POST /api/v1/cli/enable` with `{ remote_url }`, decoding `{ connected, install_url?, repo? }`.
- **`reportRepoEnabled`** (`cmd/entire/cli/setup.go`) wired as a **top-of-`RunE` deferred hook** in `entire enable`, so it runs **last** (after any bootstrap finalize that creates the GitHub repo + pushes) and **only on success**. Covers every enable path (`--agent`, already-enabled, re-enable, fresh setup).
- **Credential-safe:** the raw `origin` remote is never sent — it can embed tokens (`https://token@host/...`) or query params. We parse it with `gitremote.ParseURL` and send a rebuilt, credential-free `https://<host>/<owner>/<repo>.git`; unparseable remotes are skipped.
- **Fully silent / best-effort:** enabling works offline, so every outcome — no origin remote, not logged in, network error, or "App can't reach the repo" — is swallowed (debug-logged only). No user-facing output. The web onboarding surfaces the "install the GitHub App" nudge.
- Adds the hidden `--insecure-http-auth` flag (consistent with other authed commands) for local dev.

## Testing
- `go build ./...`, `go vet`, `golangci-lint` clean.
- `enable_test.go` covers the POST path/headers/body, the not-connected + install-URL decode, and non-2xx error handling.

## Depends on
- entirehq/entire.io#2293 (the `/api/v1/cli/enable` endpoint).
