### PR TITLE
Fix: Keep Entire pre-push alive after Lefthook reinstalls hooks

### DIFF
--- a/cmd/entire/cli/strategy/hook_managers.go
+++ b/cmd/entire/cli/strategy/hook_managers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"gopkg.in/yaml.v3"
 )
 
 // hookManager describes an external hook manager detected in a repository.
@@ -29,8 +30,8 @@ func detectHookManagers(repoRoot string) []hookManager {
 		{"Overcommit", ".overcommit.yml", false},
 	}
 
-	// Lefthook supports {.,}lefthook{,-local}.{yml,yaml,json,toml}
-	for _, prefix := range []string{"", "."} {
+	// Lefthook supports {.config/,}{.,}lefthook{,-local}.{yml,yaml,json,toml}
+	for _, prefix := range []string{"", ".", ".config/"} {
 		for _, variant := range []string{"", "-local"} {
 			for _, ext := range []string{"yml", "yaml", "json", "toml"} {
 				name := prefix + "lefthook" + variant + "." + ext
@@ -74,7 +75,8 @@ func hookManagerWarning(managers []hookManager, cmdPrefix string) string {
 	specs := buildHookSpecs(cmdPrefix)
 
 	for _, m := range managers {
-		if m.OverwritesHooks {
+		switch {
+		case m.OverwritesHooks:
 			fmt.Fprintf(&b, "Warning: %s detected (%s)\n", m.Name, m.ConfigPath)
 			fmt.Fprintf(&b, "\n")
 			fmt.Fprintf(&b, "  %s may overwrite hooks installed by Entire on npm install.\n", m.Name)
@@ -94,7 +96,16 @@ func hookManagerWarning(managers []hookManager, cmdPrefix string) string {
 				fmt.Fprintf(&b, "      %s\n", cmdLine)
 				fmt.Fprintf(&b, "\n")
 			}
-		} else {
+		case m.Name == "Lefthook":
+			fmt.Fprintf(&b, "Note: %s detected (%s)\n", m.Name, m.ConfigPath)
+			fmt.Fprintf(&b, "\n")
+			if _, ok := lefthookLocalConfigPath(m.ConfigPath); ok {
+				fmt.Fprintf(&b, "  Added a local Lefthook pre-push safety net so Entire session pushes still run if Lefthook reinstalls hooks.\n")
+			} else {
+				fmt.Fprintf(&b, "  If Lefthook reinstalls hooks, run 'entire enable' to restore Entire's hooks.\n")
+			}
+			fmt.Fprintf(&b, "\n")
+		default:
 			fmt.Fprintf(&b, "Note: %s detected (%s)\n", m.Name, m.ConfigPath)
 			fmt.Fprintf(&b, "\n")
 			fmt.Fprintf(&b, "  If %s reinstalls hooks, run 'entire enable' to restore Entire's hooks.\n", m.Name)
@@ -143,4 +154,198 @@ func CheckAndWarnHookManagers(ctx context.Context, w io.Writer, localDev, absolu
 		fmt.Fprintln(w)
 		fmt.Fprint(w, warning)
 	}
+}
+
+const lefthookEntireCommandName = "entire-push-sessions"
+
+func ensureLefthookSafetyNet(ctx context.Context, cmdPrefix string) error {
+	repoRoot, localConfigPath, ok := lefthookSafetyNetConfigPath(ctx)
+	if !ok {
+		return nil
+	}
+
+	config, err := readLefthookLocalConfig(localConfigPath)
+	if err != nil {
+		return err
+	}
+
+	prePush := ensureMap(config, "pre-push")
+	commands := ensureMap(prePush, "commands")
+	commands[lefthookEntireCommandName] = map[string]any{
+		"run":      lefthookSafetyNetCommand(cmdPrefix),
+		"priority": -100,
+	}
+
+	if err := writeLefthookLocalConfig(localConfigPath, config); err != nil {
+		return err
+	}
+	return addLefthookLocalConfigToGitExclude(ctx, repoRoot, localConfigPath)
+}
+
+func removeLefthookSafetyNet(ctx context.Context) error {
+	_, localConfigPath, ok := lefthookSafetyNetConfigPath(ctx)
+	if !ok {
+		return nil
+	}
+
+	config, err := readLefthookLocalConfig(localConfigPath)
+	if err != nil {
+		return err
+	}
+
+	prePush, ok := config["pre-push"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	commands, ok := prePush["commands"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	delete(commands, lefthookEntireCommandName)
+
+	if len(commands) == 0 {
+		delete(prePush, "commands")
+	}
+	if len(prePush) == 0 {
+		delete(config, "pre-push")
+	}
+	if len(config) == 0 {
+		if err := os.Remove(localConfigPath); err != nil {
+			return fmt.Errorf("remove empty Lefthook local config %s: %w", localConfigPath, err)
+		}
+		return nil
+	}
+	return writeLefthookLocalConfig(localConfigPath, config)
+}
+
+func lefthookSafetyNetConfigPath(ctx context.Context) (repoRoot, localConfigPath string, ok bool) {
+	repoRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return "", "", false
+	}
+	for _, manager := range detectHookManagers(repoRoot) {
+		if manager.Name != "Lefthook" {
+			continue
+		}
+		localRel, ok := lefthookLocalConfigPath(manager.ConfigPath)
+		if !ok {
+			return "", "", false
+		}
+		return repoRoot, filepath.Join(repoRoot, localRel), true
+	}
+	return "", "", false
+}
+
+func lefthookLocalConfigPath(configPath string) (string, bool) {
+	ext := filepath.Ext(configPath)
+	if ext != ".yml" && ext != ".yaml" {
+		return "", false
+	}
+
+	dir := filepath.Dir(configPath)
+	base := filepath.Base(configPath)
+	if strings.Contains(base, "lefthook-local") {
+		return configPath, true
+	}
+	localBase := strings.Replace(base, "lefthook", "lefthook-local", 1)
+	if dir == "." {
+		return localBase, true
+	}
+	return filepath.Join(dir, localBase), true
+}
+
+func readLefthookLocalConfig(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from repo root + known Lefthook config name
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]any), nil
+		}
+		return nil, fmt.Errorf("read Lefthook local config %s: %w", path, err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return make(map[string]any), nil
+	}
+
+	var config map[string]any
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+	if config == nil {
+		config = make(map[string]any)
+	}
+	return config, nil
+}
+
+func writeLefthookLocalConfig(path string, config map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create Lefthook local config directory: %w", err)
+	}
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshal Lefthook local config: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil { //nolint:gosec // local config should be user-readable like normal config files
+		return fmt.Errorf("write Lefthook local config %s: %w", path, err)
+	}
+	return nil
+}
+
+func ensureMap(parent map[string]any, key string) map[string]any {
+	if child, ok := parent[key].(map[string]any); ok {
+		return child
+	}
+	child := make(map[string]any)
+	parent[key] = child
+	return child
+}
+
+func lefthookSafetyNetCommand(cmdPrefix string) string {
+	return fmt.Sprintf(`hook="$(git rev-parse --git-path hooks)/pre-push"
+if ! grep -q %s "$hook" 2>/dev/null; then
+  %s hooks git pre-push {1} || true
+fi`, shellQuote(entireHookMarker), cmdPrefix)
+}
+
+func addLefthookLocalConfigToGitExclude(ctx context.Context, repoRoot, localConfigPath string) error {
+	relPath, err := filepath.Rel(repoRoot, localConfigPath)
+	if err != nil {
+		return fmt.Errorf("make Lefthook local config path relative: %w", err)
+	}
+	relPath = filepath.ToSlash(relPath)
+
+	gitDir, err := GetGitDir(ctx)
+	if err != nil {
+		return err
+	}
+	excludePath := filepath.Join(gitDir, "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o750); err != nil {
+		return fmt.Errorf("create git info directory: %w", err)
+	}
+
+	data, err := os.ReadFile(excludePath) //nolint:gosec // path is derived from git dir
+	if err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.TrimSpace(line) == relPath {
+				return nil
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read git exclude file %s: %w", excludePath, err)
+	}
+
+	f, err := os.OpenFile(excludePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644) //nolint:gosec // git info/exclude is a regular text file
+	if err != nil {
+		return fmt.Errorf("open git exclude file %s: %w", excludePath, err)
+	}
+	defer f.Close()
+
+	if len(data) > 0 && !strings.HasSuffix(string(data), "\n") {
+		if _, err := f.WriteString("\n"); err != nil {
+			return fmt.Errorf("append newline to git exclude file %s: %w", excludePath, err)
+		}
+	}
+	if _, err := fmt.Fprintln(f, relPath); err != nil {
+		return fmt.Errorf("append Lefthook local config to git exclude file %s: %w", excludePath, err)
+	}
+	return nil
 }

--- a/cmd/entire/cli/strategy/hook_managers_test.go
+++ b/cmd/entire/cli/strategy/hook_managers_test.go
@@ -106,6 +106,30 @@ func TestDetectHookManagers_LefthookToml(t *testing.T) {
 	}
 }
 
+func TestDetectHookManagers_LefthookConfigDir(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create .config/: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "lefthook.yml"), []byte(""), 0o644); err != nil {
+		t.Fatalf("failed to create .config/lefthook.yml: %v", err)
+	}
+
+	managers := detectHookManagers(tmpDir)
+	if len(managers) != 1 {
+		t.Fatalf("expected 1 manager, got %d", len(managers))
+	}
+	if managers[0].Name != "Lefthook" {
+		t.Errorf("expected Lefthook, got %s", managers[0].Name)
+	}
+	if managers[0].ConfigPath != filepath.Join(".config", "lefthook.yml") {
+		t.Errorf("expected .config/lefthook.yml, got %s", managers[0].ConfigPath)
+	}
+}
+
 func TestDetectHookManagers_LefthookLocal(t *testing.T) {
 	t.Parallel()
 
@@ -123,6 +147,18 @@ func TestDetectHookManagers_LefthookLocal(t *testing.T) {
 	}
 	if managers[0].ConfigPath != "lefthook-local.yml" {
 		t.Errorf("expected lefthook-local.yml, got %s", managers[0].ConfigPath)
+	}
+}
+
+func TestLefthookLocalConfigPath_LocalIsAlreadyLocal(t *testing.T) {
+	t.Parallel()
+
+	got, ok := lefthookLocalConfigPath("lefthook-local.yml")
+	if !ok {
+		t.Fatal("lefthook-local.yml should be supported")
+	}
+	if got != "lefthook-local.yml" {
+		t.Fatalf("lefthookLocalConfigPath() = %q, want lefthook-local.yml", got)
 	}
 }
 
@@ -361,13 +397,32 @@ func TestHookManagerWarning_GitHooksManager(t *testing.T) {
 	if !strings.Contains(warning, "Note: Lefthook detected") {
 		t.Error("warning should contain 'Note: Lefthook detected'")
 	}
-	if !strings.Contains(warning, "run 'entire enable' to restore") {
-		t.Error("warning should mention running 'entire enable'")
+	if !strings.Contains(warning, "local Lefthook pre-push safety net") {
+		t.Error("warning should mention the local Lefthook pre-push safety net")
 	}
 
 	// Should NOT contain hook file copy-paste instructions
 	if strings.Contains(warning, "prepare-commit-msg:") {
 		t.Error("category B warning should not contain hook file instructions")
+	}
+}
+
+func TestHookManagerWarning_LefthookNonYAMLFallback(t *testing.T) {
+	t.Parallel()
+
+	managers := []hookManager{
+		{Name: "Lefthook", ConfigPath: "lefthook.toml", OverwritesHooks: false},
+	}
+
+	warning := hookManagerWarning(managers, "entire")
+	if !strings.Contains(warning, "Note: Lefthook detected") {
+		t.Error("warning should contain 'Note: Lefthook detected'")
+	}
+	if !strings.Contains(warning, "run 'entire enable' to restore") {
+		t.Error("warning should mention running 'entire enable' for unsupported local config formats")
+	}
+	if strings.Contains(warning, "local Lefthook pre-push safety net") {
+		t.Error("warning should not claim a safety net was added for non-YAML Lefthook configs")
 	}
 }
 

--- a/cmd/entire/cli/strategy/hooks.go
+++ b/cmd/entire/cli/strategy/hooks.go
@@ -320,6 +320,10 @@ func InstallGitHook(ctx context.Context, silent, localDev, absolutePath bool) (i
 		}
 	}
 
+	if err := ensureLefthookSafetyNet(ctx, cmdPrefix); err != nil {
+		return installedCount, fmt.Errorf("failed to install Lefthook safety net: %w", err)
+	}
+
 	if !silent {
 		fmt.Println("✓ Installed git hooks (prepare-commit-msg, commit-msg, post-commit, pre-push)")
 		fmt.Println("  Hooks delegate to the current strategy at runtime")
@@ -384,6 +388,10 @@ func RemoveGitHook(ctx context.Context) (int, error) {
 				}
 			}
 		}
+	}
+
+	if err := removeLefthookSafetyNet(ctx); err != nil {
+		removeErrors = append(removeErrors, fmt.Sprintf("remove Lefthook safety net: %v", err))
 	}
 
 	if len(removeErrors) > 0 {

--- a/cmd/entire/cli/strategy/hooks_test.go
+++ b/cmd/entire/cli/strategy/hooks_test.go
@@ -1424,6 +1424,160 @@ func TestInstallGitHook_MixedHooks(t *testing.T) {
 	}
 }
 
+func TestInstallGitHook_LefthookSafetyNetKeepsPrePushWrapper(t *testing.T) {
+	tmpDir, hooksDir := initHooksTestRepo(t)
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "lefthook.yml"), []byte("pre-push:\n  commands: {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to create lefthook.yml: %v", err)
+	}
+
+	_, err := InstallGitHook(context.Background(), true, false, false)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+
+	prePushData, err := os.ReadFile(filepath.Join(hooksDir, "pre-push"))
+	if err != nil {
+		t.Fatalf("pre-push hook should exist: %v", err)
+	}
+	prePush := string(prePushData)
+	if !strings.Contains(prePush, entireHookMarker) {
+		t.Fatalf("pre-push should keep the normal Entire wrapper, got:\n%s", prePush)
+	}
+	if !strings.Contains(prePush, `entire hooks git pre-push "$1" || true`) {
+		t.Fatalf("pre-push should keep the normal Entire command, got:\n%s", prePush)
+	}
+
+	config := readLefthookConfigForTest(t, filepath.Join(tmpDir, "lefthook-local.yml"))
+	if !lefthookConfigHasEntireCommand(config) {
+		t.Fatalf("lefthook-local.yml should include %s, got %#v", lefthookEntireCommandName, config)
+	}
+
+	excludeData, err := os.ReadFile(filepath.Join(tmpDir, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatalf("git info/exclude should exist: %v", err)
+	}
+	if !strings.Contains(string(excludeData), "lefthook-local.yml") {
+		t.Fatalf("git info/exclude should include lefthook-local.yml, got:\n%s", excludeData)
+	}
+}
+
+func TestInstallGitHook_LefthookSafetyNetPreservesExistingLocalCommands(t *testing.T) {
+	tmpDir, _ := initHooksTestRepo(t)
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "lefthook.yml"), []byte("pre-push:\n  commands: {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to create lefthook.yml: %v", err)
+	}
+	existing := []byte(`pre-push:
+  commands:
+    existing-check:
+      run: echo existing
+pre-commit:
+  commands:
+    lint:
+      run: echo lint
+`)
+	if err := os.WriteFile(filepath.Join(tmpDir, "lefthook-local.yml"), existing, 0o644); err != nil {
+		t.Fatalf("failed to create lefthook-local.yml: %v", err)
+	}
+
+	_, err := InstallGitHook(context.Background(), true, false, false)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+
+	config := readLefthookConfigForTest(t, filepath.Join(tmpDir, "lefthook-local.yml"))
+	if !lefthookConfigHasEntireCommand(config) {
+		t.Fatalf("lefthook-local.yml should include %s, got %#v", lefthookEntireCommandName, config)
+	}
+	prePush := mapValueForTest(t, config, "pre-push")
+	prePushCommands := mapValueForTest(t, prePush, "commands")
+	if _, ok := prePushCommands["existing-check"]; !ok {
+		t.Fatalf("existing pre-push command should be preserved, got %#v", prePushCommands)
+	}
+	preCommit := mapValueForTest(t, config, "pre-commit")
+	preCommitCommands := mapValueForTest(t, preCommit, "commands")
+	if _, ok := preCommitCommands["lint"]; !ok {
+		t.Fatalf("existing pre-commit command should be preserved, got %#v", preCommitCommands)
+	}
+}
+
+func TestLefthookSafetyNetCommandSkipsWhenEntireWrapperPresent(t *testing.T) {
+	tmpDir, hooksDir := initHooksTestRepo(t)
+	binDir := t.TempDir()
+	markerFile := filepath.Join(tmpDir, "entire-called")
+
+	if err := os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte("#!/bin/sh\n# Entire CLI hooks\n"), 0o755); err != nil {
+		t.Fatalf("failed to write pre-push hook: %v", err)
+	}
+	writeFakeEntire(t, binDir, markerFile)
+
+	command := strings.ReplaceAll(lefthookSafetyNetCommand("entire"), "{1}", "origin")
+	runSafetyNetCommand(t, tmpDir, binDir, command)
+
+	if _, err := os.Stat(markerFile); !os.IsNotExist(err) {
+		t.Fatalf("safety-net command should not call entire when wrapper is present")
+	}
+}
+
+func TestLefthookSafetyNetCommandRunsWhenEntireWrapperMissing(t *testing.T) {
+	tmpDir, hooksDir := initHooksTestRepo(t)
+	binDir := t.TempDir()
+	markerFile := filepath.Join(tmpDir, "entire-called")
+
+	if err := os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte("#!/bin/sh\n# Lefthook\n"), 0o755); err != nil {
+		t.Fatalf("failed to write pre-push hook: %v", err)
+	}
+	writeFakeEntire(t, binDir, markerFile)
+
+	command := strings.ReplaceAll(lefthookSafetyNetCommand("entire"), "{1}", "origin")
+	runSafetyNetCommand(t, tmpDir, binDir, command)
+
+	data, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("safety-net command should call entire when wrapper is missing: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "hooks git pre-push origin" {
+		t.Fatalf("fake entire args = %q, want hooks git pre-push origin", got)
+	}
+}
+
+func TestRemoveGitHook_RemovesOnlyLefthookSafetyNetCommand(t *testing.T) {
+	tmpDir, _ := initHooksTestRepo(t)
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "lefthook.yml"), []byte("pre-push:\n  commands: {}\n"), 0o644); err != nil {
+		t.Fatalf("failed to create lefthook.yml: %v", err)
+	}
+	localPath := filepath.Join(tmpDir, "lefthook-local.yml")
+	existing := []byte(`pre-push:
+  commands:
+    existing-check:
+      run: echo existing
+`)
+	if err := os.WriteFile(localPath, existing, 0o644); err != nil {
+		t.Fatalf("failed to create lefthook-local.yml: %v", err)
+	}
+
+	_, err := InstallGitHook(context.Background(), true, false, false)
+	if err != nil {
+		t.Fatalf("InstallGitHook() error = %v", err)
+	}
+	_, err = RemoveGitHook(context.Background())
+	if err != nil {
+		t.Fatalf("RemoveGitHook() error = %v", err)
+	}
+
+	config := readLefthookConfigForTest(t, localPath)
+	if lefthookConfigHasEntireCommand(config) {
+		t.Fatalf("RemoveGitHook should remove %s, got %#v", lefthookEntireCommandName, config)
+	}
+	prePush := mapValueForTest(t, config, "pre-push")
+	prePushCommands := mapValueForTest(t, prePush, "commands")
+	if _, ok := prePushCommands["existing-check"]; !ok {
+		t.Fatalf("existing Lefthook command should be preserved, got %#v", prePushCommands)
+	}
+}
+
 func TestRemoveGitHook_RestoresBackup(t *testing.T) {
 	_, hooksDir := initHooksTestRepo(t)
 
@@ -1460,6 +1614,57 @@ func TestRemoveGitHook_RestoresBackup(t *testing.T) {
 	backupPath := hookPath + backupSuffix
 	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
 		t.Error("backup should be removed after restore")
+	}
+}
+
+func readLefthookConfigForTest(t *testing.T, path string) map[string]any {
+	t.Helper()
+	config, err := readLefthookLocalConfig(path)
+	if err != nil {
+		t.Fatalf("failed to read Lefthook config %s: %v", path, err)
+	}
+	return config
+}
+
+func lefthookConfigHasEntireCommand(config map[string]any) bool {
+	prePush, ok := config["pre-push"].(map[string]any)
+	if !ok {
+		return false
+	}
+	commands, ok := prePush["commands"].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, ok = commands[lefthookEntireCommandName]
+	return ok
+}
+
+func mapValueForTest(t *testing.T, parent map[string]any, key string) map[string]any {
+	t.Helper()
+	child, ok := parent[key].(map[string]any)
+	if !ok {
+		t.Fatalf("expected %q to be a map, got %#v", key, parent[key])
+	}
+	return child
+}
+
+func writeFakeEntire(t *testing.T, binDir, markerFile string) {
+	t.Helper()
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" > " + shellQuote(markerFile) + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "entire"), []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write fake entire: %v", err)
+	}
+}
+
+func runSafetyNetCommand(t *testing.T, repoDir, binDir, command string) {
+	t.Helper()
+	shPath := requireShell(t)
+	cmd := exec.CommandContext(context.Background(), shPath, "-c", command)
+	cmd.Dir = repoDir
+	cmd.Env = envWithPath(binDir + string(os.PathListSeparator) + os.Getenv("PATH"))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("safety-net command failed: %v\n%s\ncommand:\n%s", err, output, command)
 	}
 }
 


### PR DESCRIPTION
## Summary

https://entire.io/gh/stale2000/cli/session/019ea5bb-9549-7083-b95f-7ecb498cbc24 

Closes #1349.

This keeps Entire's existing Git hook ownership behavior unchanged while adding a Lefthook-local safety net for the failure mode reported in the issue.

When a repository has a YAML Lefthook config, `entire enable` still installs the normal Entire `.git/hooks/pre-push` wrapper. It now also ensures `lefthook-local.yml` contains an `entire-push-sessions` pre-push command that only runs if Lefthook has reclaimed `.git/hooks/pre-push` and removed the `Entire CLI hooks` marker.

Normal state:
- Git runs Entire's `pre-push` wrapper.
- Entire chains to Lefthook.
- The Lefthook-local fallback sees the Entire marker and does nothing.

Recovered state:
- Lefthook has rewritten `.git/hooks/pre-push`.
- Git runs Lefthook directly.
- The Lefthook-local fallback sees the Entire marker is missing and runs `entire hooks git pre-push {1} || true`.

## Details

- Adds and updates `lefthook-local.yml`, not team-owned `lefthook.yml`.
- Adds the local Lefthook config path to `.git/info/exclude`.
- Preserves unrelated existing local Lefthook commands.
- Removes only Entire's local Lefthook command from `entire disable`.
- Keeps non-Lefthook hook behavior unchanged.
- Handles `.config/lefthook.yml` detection in addition to the existing Lefthook config names.

## Verification

Passed:
- `gofmt -w cmd/entire/cli/strategy/hook_managers.go cmd/entire/cli/strategy/hook_managers_test.go cmd/entire/cli/strategy/hooks.go cmd/entire/cli/strategy/hooks_test.go`
- `/Users/stale2000/.local/share/mise/installs/golangci-lint/2.11.3/golangci-lint-2.11.3-darwin-arm64/golangci-lint run ./cmd/entire/cli/strategy/...`
- `go test ./cmd/entire/cli/strategy`
- `go test -tags=integration ./cmd/entire/cli/integration_test -run 'Test(UserPromptSubmit_ReinstallsOverwrittenHooks|HookOverwrite_MidTurnWipe_NextPromptRecovers)'`
- `git diff --check`

Manual real-Lefthook checks:
- Verified with Lefthook `v1.13.6` that `lefthook-local.yml` is merged into `pre-push` runs.
- Verified `{1}` expands to the Git pre-push remote name (`origin`).
- Verified the generated safety-net command calls `entire hooks git pre-push origin` when `.git/hooks/pre-push` lacks the Entire marker.
- Verified the same command skips when `.git/hooks/pre-push` contains `Entire CLI hooks`.

Known verification gaps:
- `mise run check` and `mise run fmt` did not reach the repo tasks because mise/aqua hit GitHub 504s while downloading ShellCheck and tmux.
- `go test ./cmd/entire/cli` still has an unrelated date-sensitive failure in `TestRunAuthStatus_RendersSessionsTable` where the rendered local date is `2025-12-31` but the test expects `2026-01-01`.

## Entire Integration

This PR commit was attached to the active Codex transcript with Entire:

- Session: `019ea5bb-9549-7083-b95f-7ecb498cbc24`
- Checkpoint: `965634231c03`
- Commit includes `Entire-Checkpoint: 965634231c03`
- `entire session current` resolves the attached Codex session.
- `entire checkpoint list` shows checkpoint `965634231c03` on this branch.
- `git push` ran the Entire `pre-push` hook and pushed `entire/checkpoints/v1` to the fork.
