### PR TITLE
Sign checkpoints at push time

### DIFF
--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -1959,7 +1959,7 @@ func GetGitAuthorFromRepo(repo *git.Repository) (name, email string) {
 
 // CreateCommit creates a git commit object with the given tree, parent, message, and author.
 // If parentHash is ZeroHash, the commit is created without a parent (orphan commit).
-func CreateCommit(ctx context.Context, repo *git.Repository, treeHash, parentHash plumbing.Hash, message, authorName, authorEmail string) (plumbing.Hash, error) {
+func CreateCommit(_ context.Context, repo *git.Repository, treeHash, parentHash plumbing.Hash, message, authorName, authorEmail string) (plumbing.Hash, error) {
 	now := time.Now()
 	sig := object.Signature{
 		Name:  authorName,
@@ -1977,8 +1977,6 @@ func CreateCommit(ctx context.Context, repo *git.Repository, treeHash, parentHas
 	if parentHash != plumbing.ZeroHash {
 		commit.ParentHashes = []plumbing.Hash{parentHash}
 	}
-
-	SignCommitBestEffort(ctx, commit)
 
 	obj := repo.Storer.NewEncodedObject()
 	if err := commit.Encode(obj); err != nil {

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -1993,44 +1993,49 @@ func CreateCommit(ctx context.Context, repo *git.Repository, treeHash, parentHas
 	return hash, nil
 }
 
-// SignCommitBestEffort signs the commit using an on-demand object signer.
-// If signing is disabled, no signer can be created, or signing fails, the commit
-// is left unsigned and the error is logged.
-func SignCommitBestEffort(ctx context.Context, commit *object.Commit) {
+// SignCommit signs the commit using an on-demand object signer. It returns
+// ErrSigningDisabled when signing is disabled in settings or no signer is
+// available. Any signer error is returned wrapped so callers can use
+// errors.Is/As. On success the commit's Signature field is populated.
+func SignCommit(ctx context.Context, commit *object.Commit) error {
 	if !settings.IsSignCheckpointCommitsEnabled(ctx) {
-		return
+		return ErrSigningDisabled
 	}
 
 	signer, ok := objectSignerLoader(ctx)
-	if !ok {
-		return
-	}
-
-	if signer == nil {
-		return
+	if !ok || signer == nil {
+		return ErrSigningDisabled
 	}
 
 	encoded := &plumbing.MemoryObject{}
-	var err error
-	if err = commit.EncodeWithoutSignature(encoded); err != nil {
-		logging.Warn(ctx, "failed to encode commit for signing", slog.String("error", err.Error()))
-		return
+	if err := commit.EncodeWithoutSignature(encoded); err != nil {
+		return fmt.Errorf("encode commit for signing: %w", err)
 	}
 
 	r, err := encoded.Reader()
 	if err != nil {
-		logging.Warn(ctx, "failed to read encoded commit", slog.String("error", err.Error()))
-		return
+		return fmt.Errorf("read encoded commit: %w", err)
 	}
 	defer r.Close()
 
 	sig, err := signer.Sign(r)
 	if err != nil {
-		logging.Warn(ctx, "failed to sign commit", slog.String("error", err.Error()))
-		return
+		return fmt.Errorf("sign commit: %w", err)
 	}
 
 	commit.Signature = string(sig)
+	return nil
+}
+
+// SignCommitBestEffort signs the commit using an on-demand object signer.
+// If signing is disabled, no signer can be created, or signing fails, the commit
+// is left unsigned and the error is logged.
+func SignCommitBestEffort(ctx context.Context, commit *object.Commit) {
+	if err := SignCommit(ctx, commit); err != nil {
+		if !errors.Is(err, ErrSigningDisabled) {
+			logging.Warn(ctx, "failed to sign commit", slog.String("error", err.Error()))
+		}
+	}
 }
 
 // readTranscriptFromTree reads a transcript from a git tree, handling both chunked and non-chunked formats.

--- a/cmd/entire/cli/checkpoint/committed_no_eager_sign_test.go
+++ b/cmd/entire/cli/checkpoint/committed_no_eager_sign_test.go
@@ -1,0 +1,45 @@
+package checkpoint
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/x/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateCommit_DoesNotSign verifies CreateCommit produces unsigned
+// commits even when signing is enabled and a working signer is registered.
+// Signing is deferred to push time.
+func TestCreateCommit_DoesNotSign(t *testing.T) { //nolint:paralleltest // t.Chdir + setupSigningEnv conventions
+	setupSigningEnv(t, false) // signing enabled in settings
+
+	signerCalled := false
+	prev := objectSignerLoader
+	objectSignerLoader = func(context.Context) (plugin.Signer, bool) {
+		return signerFn(func(io.Reader) ([]byte, error) {
+			signerCalled = true
+			return []byte("sig"), nil
+		}), true
+	}
+	t.Cleanup(func() { objectSignerLoader = prev })
+
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	// CreateCommit accepts ZeroHash for tree and parent during init.
+	// The point of the test is solely to confirm the signer is not invoked.
+	_, err = CreateCommit(context.Background(), repo, plumbing.ZeroHash, plumbing.ZeroHash, "msg", "User", "u@e")
+	require.NoError(t, err)
+
+	assert.False(t, signerCalled, "CreateCommit must not invoke the signer")
+}
+
+type signerFn func(io.Reader) ([]byte, error)
+
+func (f signerFn) Sign(r io.Reader) ([]byte, error) { return f(r) }

--- a/cmd/entire/cli/checkpoint/objectsigner_errors.go
+++ b/cmd/entire/cli/checkpoint/objectsigner_errors.go
@@ -1,7 +1,19 @@
 package checkpoint
 
-import "errors"
+import (
+	"context"
+	"errors"
+
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
 
 // ErrSigningDisabled is returned by SignCommit when checkpoint signing is
 // disabled in settings.
 var ErrSigningDisabled = errors.New("checkpoint signing disabled")
+
+// ShouldSkipPushSigning reports whether the push-time signing loop should
+// be bypassed entirely. Returns true only when checkpoint signing is
+// disabled in settings.
+func ShouldSkipPushSigning(ctx context.Context) bool {
+	return !settings.IsSignCheckpointCommitsEnabled(ctx)
+}

--- a/cmd/entire/cli/checkpoint/objectsigner_errors.go
+++ b/cmd/entire/cli/checkpoint/objectsigner_errors.go
@@ -1,0 +1,7 @@
+package checkpoint
+
+import "errors"
+
+// ErrSigningDisabled is returned by SignCommit when checkpoint signing is
+// disabled in settings.
+var ErrSigningDisabled = errors.New("checkpoint signing disabled")

--- a/cmd/entire/cli/checkpoint/objectsigner_strict_test.go
+++ b/cmd/entire/cli/checkpoint/objectsigner_strict_test.go
@@ -1,0 +1,55 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-git/go-git/v6/x/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignCommit_DisabledReturnsErrSigningDisabled(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
+	setupSigningEnv(t, true) // signing disabled in settings
+
+	objectSignerLoader = func(context.Context) (plugin.Signer, bool) {
+		t.Fatal("signer should not be called when signing is disabled")
+		return nil, true
+	}
+
+	commit := newTestCommit()
+	err := SignCommit(context.Background(), commit)
+
+	require.ErrorIs(t, err, ErrSigningDisabled)
+	assert.Empty(t, commit.Signature)
+}
+
+func TestSignCommit_PropagatesSignerError(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
+	setupSigningEnv(t, false)
+
+	signerErr := errors.New("signing failed")
+	objectSignerLoader = func(context.Context) (plugin.Signer, bool) {
+		return &stubSigner{err: signerErr}, true
+	}
+
+	commit := newTestCommit()
+	err := SignCommit(context.Background(), commit)
+
+	require.ErrorIs(t, err, signerErr)
+	assert.Empty(t, commit.Signature)
+}
+
+func TestSignCommit_AttachesSignatureOnSuccess(t *testing.T) { //nolint:paralleltest // t.Chdir requires non-parallel
+	setupSigningEnv(t, false)
+
+	objectSignerLoader = func(context.Context) (plugin.Signer, bool) {
+		return &stubSigner{sig: []byte("FAKESIG")}, true
+	}
+
+	commit := newTestCommit()
+	err := SignCommit(context.Background(), commit)
+
+	require.NoError(t, err)
+	assert.Equal(t, "FAKESIG", commit.Signature)
+}

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -539,14 +539,6 @@ func EnsurePrimaryRef(ctx context.Context, repo *git.Repository) error {
 	}
 	// Note: No ParentHashes - this is an orphan commit
 
-	// Sign the orphan commit when signing is enabled, matching the path used
-	// for every other metadata commit (see metadata_reconcile.go and
-	// push_common.go). Without this, repos that enforce a "verified
-	// signatures" ruleset on entire/* refs reject the very first push of
-	// the metadata ref with GH013, even though every later commit on it
-	// is correctly signed.
-	checkpoint.SignCommitBestEffort(ctx, commit)
-
 	commitObj := repo.Storer.NewEncodedObject()
 	if err := commit.Encode(commitObj); err != nil {
 		return fmt.Errorf("failed to encode orphan commit: %w", err)

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"log/slog"
+	"os"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -40,6 +41,10 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 	pushCtx, pushCheckpointsSpan := perf.Start(ctx, "push_checkpoint_refs")
 	defer pushCheckpointsSpan.End()
 	for _, ref := range refs.Push {
+		if err := signLocalCommitsForPush(pushCtx, ps.pushTarget(), ref, os.Stderr); err != nil {
+			pushCheckpointsSpan.RecordError(err)
+			return err
+		}
 		if err := pushRefIfNeeded(pushCtx, ps.pushTarget(), ref); err != nil {
 			pushCheckpointsSpan.RecordError(err)
 			return err

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -408,13 +408,16 @@ func changeToTreeChange(change *object.Change) (checkpoint.TreeChange, error) {
 	}
 }
 
-// createCherryPickCommit creates a new commit on top of parent, preserving the
-// original commit's message and author.
-func createCherryPickCommit(ctx context.Context, repo *git.Repository, treeHash, parent plumbing.Hash, original *object.Commit) (plumbing.Hash, error) {
+// buildCherryPickCommit constructs a cherry-picked commit object on top of
+// parent with treeHash. The returned commit is unsigned and not persisted —
+// callers can attach a signature before calling persistCherryPickCommit.
+//
+//nolint:unparam // error return reserved for future signing errors (Task 4 push-signing loop)
+func buildCherryPickCommit(_ context.Context, repo *git.Repository, treeHash, parent plumbing.Hash, original *object.Commit) (*object.Commit, error) {
 	committerName, committerEmail := GetGitAuthorFromRepo(repo)
 	now := time.Now()
 
-	commit := &object.Commit{
+	return &object.Commit{
 		TreeHash:     treeHash,
 		ParentHashes: []plumbing.Hash{parent},
 		Author:       original.Author,
@@ -424,10 +427,11 @@ func createCherryPickCommit(ctx context.Context, repo *git.Repository, treeHash,
 			When:  now,
 		},
 		Message: original.Message,
-	}
+	}, nil
+}
 
-	checkpoint.SignCommitBestEffort(ctx, commit)
-
+// persistCherryPickCommit encodes commit and stores it in the repo.
+func persistCherryPickCommit(repo *git.Repository, commit *object.Commit) (plumbing.Hash, error) {
 	obj := repo.Storer.NewEncodedObject()
 	if err := commit.Encode(obj); err != nil {
 		return plumbing.ZeroHash, fmt.Errorf("failed to encode commit: %w", err)
@@ -439,6 +443,17 @@ func createCherryPickCommit(ctx context.Context, repo *git.Repository, treeHash,
 	}
 
 	return hash, nil
+}
+
+// createCherryPickCommit builds, best-effort signs, and persists a cherry-
+// picked commit. Used by the metadata-reconcile divergence path.
+func createCherryPickCommit(ctx context.Context, repo *git.Repository, treeHash, parent plumbing.Hash, original *object.Commit) (plumbing.Hash, error) {
+	commit, err := buildCherryPickCommit(ctx, repo, treeHash, parent, original)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	checkpoint.SignCommitBestEffort(ctx, commit)
+	return persistCherryPickCommit(repo, commit)
 }
 
 // getRepoPath returns the filesystem path for the repository's worktree.

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -417,9 +417,16 @@ func buildCherryPickCommit(_ context.Context, repo *git.Repository, treeHash, pa
 	committerName, committerEmail := GetGitAuthorFromRepo(repo)
 	now := time.Now()
 
+	// When parent is ZeroHash the new chain has no base commit to attach to;
+	// encode it as a root commit (empty ParentHashes) so git CLI can traverse it.
+	var parentHashes []plumbing.Hash
+	if parent != plumbing.ZeroHash {
+		parentHashes = []plumbing.Hash{parent}
+	}
+
 	return &object.Commit{
 		TreeHash:     treeHash,
-		ParentHashes: []plumbing.Hash{parent},
+		ParentHashes: parentHashes,
 		Author:       original.Author,
 		Committer: object.Signature{
 			Name:  committerName,

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -508,7 +508,13 @@ func collectCommitsSince(ctx context.Context, repo *git.Repository, repoPath str
 	// cherryPickOnto computes each commit's delta against its first parent, so
 	// replaying merge commits would incorrectly re-apply changes that arrived via
 	// non-first-parent history. Limit the replay set to non-merge commits.
-	cmd := exec.CommandContext(ctx, "git", "rev-list", "--reverse", "--topo-order", "--no-merges", exclude.String()+".."+tip.String())
+	var revRange string
+	if exclude == plumbing.ZeroHash {
+		revRange = tip.String()
+	} else {
+		revRange = exclude.String() + ".." + tip.String()
+	}
+	cmd := exec.CommandContext(ctx, "git", "rev-list", "--reverse", "--topo-order", "--no-merges", revRange)
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -169,10 +169,10 @@ func defaultPromptOnSigningFailure(_ context.Context, subject string, signErr er
 	}
 }
 
-// signLocalCommitsForPush fetches the remote-tracking tip for ref, finds
-// the local-only commits above it, signs and cherry-picks them onto that
-// tip, and advances the local ref to the new signed tip. The caller is then
-// expected to do a fast-forward push.
+// signLocalCommitsForPush fetches the remote tip for ref, finds the
+// local-only commits above it, signs and cherry-picks them onto that tip, and
+// advances the local ref to the new signed tip. The caller is then expected to
+// do a fast-forward push.
 //
 // When checkpoint signing is disabled in settings, this is a no-op so the
 // caller's plain push goes through unchanged.
@@ -187,19 +187,14 @@ func signLocalCommitsForPush(ctx context.Context, target string, ref plumbing.Re
 	}
 	defer repo.Close()
 
-	if fetchErr := fetchRefBestEffort(ctx, target, ref); fetchErr != nil {
-		logging.Debug(ctx, "fetch for sign-at-push failed; treating all local commits as new",
-			slog.String("ref", ref.String()),
-			slog.String("error", fetchErr.Error()))
-	}
-
 	localRef, err := repo.Reference(ref, true)
 	if err != nil {
 		// No local ref yet — nothing to sign or push.
 		return nil
 	}
 
-	remoteHash := lookupRemoteTipForSigning(ctx, repo, target, ref)
+	remoteHash, cleanup := resolveRemoteTipForSigning(ctx, repo, target, ref)
+	defer cleanup()
 
 	repoPath, err := getRepoPath(repo)
 	if err != nil {
@@ -251,46 +246,65 @@ func signLocalCommitsForPush(ctx context.Context, target string, ref plumbing.Re
 	return AdvanceLocalRef(ctx, repo, refsBundle, ref, newTip)
 }
 
-// lookupRemoteTipForSigning returns the hash of the remote-tracking ref for
-// target/ref, or ZeroHash when no tracking ref exists (first push).
-func lookupRemoteTipForSigning(ctx context.Context, repo *git.Repository, target string, ref plumbing.ReferenceName) plumbing.Hash {
+// resolveRemoteTipForSigning fetches ref from target into the appropriate
+// local-side ref and returns the fetched tip hash. URL targets get a
+// transient temp ref (refs/entire-sign-tmp/<rest>) that the returned cleanup
+// removes; named-remote targets reuse the standard remote-tracking ref and
+// the cleanup is a no-op.
+//
+// Returns ZeroHash + nil cleanup if anything fails (e.g. remote has no ref
+// yet, network failure, non-branch ref). Best-effort: failures only mean the
+// caller will treat the local chain as entirely new, which is the same
+// pre-fix behaviour for URL targets.
+func resolveRemoteTipForSigning(ctx context.Context, repo *git.Repository, target string, ref plumbing.ReferenceName) (plumbing.Hash, func()) {
+	cleanup := func() {}
 	if !ref.IsBranch() {
-		return plumbing.ZeroHash
-	}
-	rname := plumbing.NewRemoteReferenceName(target, ref.Short())
-	r, err := repo.Reference(rname, true)
-	if err != nil {
-		logging.Debug(ctx, "no remote-tracking ref; treating all local commits as new",
-			slog.String("ref", rname.String()),
-			slog.String("error", err.Error()))
-		return plumbing.ZeroHash
-	}
-	return r.Hash()
-}
-
-// fetchRefBestEffort fetches ref from target into the standard remote-tracking
-// ref (refs/remotes/<target>/<branch>) without doing any local rebase. It is
-// called before signing so that lookupRemoteTipForSigning finds a fresh tip.
-// Failures are silently ignored by the caller — this is a best-effort update.
-func fetchRefBestEffort(ctx context.Context, target string, ref plumbing.ReferenceName) error {
-	if !ref.IsBranch() || remote.IsURL(target) {
-		// Non-branch refs and URL targets don't have a standard remote-tracking
-		// ref, so there is nothing useful to fetch here.
-		return nil
+		return plumbing.ZeroHash, cleanup
 	}
 
 	fetchTarget, err := remote.ResolveFetchTarget(ctx, target)
 	if err != nil {
-		return fmt.Errorf("resolve fetch target: %w", err)
+		logging.Debug(ctx, "resolve fetch target failed; treating local chain as new",
+			slog.String("target", target),
+			slog.String("error", err.Error()))
+		return plumbing.ZeroHash, cleanup
 	}
 
-	refSpec := fmt.Sprintf("+%s:refs/remotes/%s/%s", ref.String(), target, ref.Short())
+	var fetchedRefName plumbing.ReferenceName
+	var refSpec string
+	usedTempRef := remote.IsURL(fetchTarget)
+	if usedTempRef {
+		tmp := plumbing.ReferenceName("refs/entire-sign-tmp/" + strings.TrimPrefix(ref.String(), "refs/"))
+		refSpec = fmt.Sprintf("+%s:%s", ref.String(), tmp.String())
+		fetchedRefName = tmp
+		cleanup = func() {
+			_ = repo.Storer.RemoveReference(tmp) //nolint:errcheck // best-effort cleanup
+		}
+	} else {
+		refSpec = fmt.Sprintf("+%s:refs/remotes/%s/%s", ref.String(), target, ref.Short())
+		fetchedRefName = plumbing.NewRemoteReferenceName(target, ref.Short())
+	}
+
 	if _, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
 		Remote:   fetchTarget,
 		RefSpecs: []string{refSpec},
 		NoTags:   true,
 	}); fetchErr != nil {
-		return fmt.Errorf("fetch ref %s from %s: %w", ref, target, fetchErr)
+		logging.Debug(ctx, "pre-sign fetch failed; treating local chain as new",
+			slog.String("ref", ref.String()),
+			slog.String("target", target),
+			slog.String("error", fetchErr.Error()))
+		cleanup()
+		return plumbing.ZeroHash, func() {}
 	}
-	return nil
+
+	r, err := repo.Reference(fetchedRefName, true)
+	if err != nil {
+		logging.Debug(ctx, "fetched ref not present after pre-sign fetch",
+			slog.String("ref", fetchedRefName.String()),
+			slog.String("error", err.Error()))
+		cleanup()
+		return plumbing.ZeroHash, func() {}
+	}
+	return r.Hash(), cleanup
 }

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -206,8 +206,14 @@ func commitSubject(message string) string {
 
 // defaultPromptOnSigningFailure asks the user what to do when stderr is a
 // TTY; defaults to skip silently in non-interactive contexts.
+//
+// Two gates must hold before we prompt: CanPromptInteractively (a controlling
+// terminal exists, so reading stdin won't hang) AND IsTerminalWriter(stderr)
+// (the question itself will be visible to the user). When pre-push runs as a
+// git hook with stderr piped or redirected, /dev/tty may still exist but the
+// user can't see what we'd ask them — so we skip instead of risking a hang.
 func defaultPromptOnSigningFailure(_ context.Context, subject string, signErr error, stderr io.Writer) signingAction {
-	if !interactive.CanPromptInteractively() {
+	if !interactive.CanPromptInteractively() || !interactive.IsTerminalWriter(stderr) {
 		return signingActionSkip
 	}
 	fmt.Fprintf(stderr, "Failed to sign commit: %s\nError: %v\nRetry, skip, or abort? [r/s/a]: ", subject, signErr)

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -159,15 +159,6 @@ func signLocalCommitsForPush(ctx context.Context, target string, ref plumbing.Re
 	}
 
 	remoteHash := lookupRemoteTipForSigning(ctx, repo, target, ref)
-	// When there is no remote tip (first push), fall back to HEAD so that only
-	// commits on the checkpoint branch itself are signed. Without this guard the
-	// traversal walks back through the user's working-branch history and
-	// cherry-picks a synthetic signed copy of every ancestor.
-	if remoteHash == plumbing.ZeroHash {
-		if head, headErr := repo.Head(); headErr == nil {
-			remoteHash = head.Hash()
-		}
-	}
 
 	repoPath, err := getRepoPath(repo)
 	if err != nil {

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -27,6 +27,55 @@ const (
 	signingActionAbort
 )
 
+// signingProgress renders a rolling N-line progress display on a TTY,
+// in-place, using ANSI cursor-up + clear-line escapes. On a non-TTY the
+// renderer falls back to printing each line as it arrives.
+type signingProgress struct {
+	out      io.Writer
+	capacity int
+	isTTY    bool
+	lines    []string
+	drawn    int
+}
+
+func newSigningProgress(out io.Writer, capacity int) *signingProgress {
+	return &signingProgress{
+		out:      out,
+		capacity: capacity,
+		isTTY:    interactive.IsTerminalWriter(out),
+	}
+}
+
+// Push appends line to the visible buffer. On a TTY, the previous N lines
+// (if any) are erased and the buffer redrawn in place; on a non-TTY, line
+// is appended to out without any cursor manipulation.
+func (p *signingProgress) Push(line string) {
+	p.lines = append(p.lines, line)
+	if len(p.lines) > p.capacity {
+		p.lines = p.lines[len(p.lines)-p.capacity:]
+	}
+	if !p.isTTY {
+		fmt.Fprintln(p.out, line)
+		return
+	}
+	if p.drawn > 0 {
+		// Move cursor up `drawn` lines so we can rewrite them in place.
+		fmt.Fprintf(p.out, "\033[%dA", p.drawn)
+	}
+	for _, l := range p.lines {
+		// Clear the entire line then print the buffered content.
+		fmt.Fprintf(p.out, "\033[2K%s\n", l)
+	}
+	p.drawn = len(p.lines)
+}
+
+// Detach forgets that we've drawn anything, so the next Push prints below
+// whatever currently sits on screen (e.g. after a prompt that wrote lines
+// outside our control). The currently-visible buffered lines stay in place.
+func (p *signingProgress) Detach() {
+	p.drawn = 0
+}
+
 var errSigningAborted = errors.New("checkpoint signing aborted by user")
 
 // signCommitForPush is the strict signer used at push time. Overridden in
@@ -63,6 +112,9 @@ func signAndPersistCommits(ctx context.Context, repo *git.Repository, repoPath s
 	if err != nil {
 		return plumbing.ZeroHash, fmt.Errorf("load shallow hashes: %w", err)
 	}
+
+	const progressBufferLines = 3
+	progress := newSigningProgress(stderr, progressBufferLines)
 
 	total := len(commits)
 	currentTip := base
@@ -101,10 +153,13 @@ func signAndPersistCommits(ctx context.Context, repo *git.Repository, repoPath s
 		}
 
 		subject := commitSubject(original.Message)
-		fmt.Fprintln(stderr, signingProgressMessage(i+1, total, subject))
+		progress.Push(signingProgressMessage(i+1, total, subject))
 
 		signErr := signCommitForPush(ctx, built)
 		for signErr != nil && !errors.Is(signErr, checkpoint.ErrSigningDisabled) {
+			// Detach so the prompt's output lines are not overwritten by the
+			// next Push.
+			progress.Detach()
 			action := promptOnSigningFailure(ctx, subject, signErr, stderr)
 			switch action {
 			case signingActionRetry:

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/go-git/go-git/v6"
@@ -125,4 +126,111 @@ func defaultPromptOnSigningFailure(_ context.Context, subject string, signErr er
 		}
 		fmt.Fprint(stderr, "Please answer r, s, or a: ")
 	}
+}
+
+// signLocalCommitsForPush fetches the remote-tracking tip for ref, finds
+// the local-only commits above it, signs and cherry-picks them onto that
+// tip, and advances the local ref to the new signed tip. The caller is then
+// expected to do a fast-forward push.
+//
+// When checkpoint signing is disabled in settings, this is a no-op so the
+// caller's plain push goes through unchanged.
+func signLocalCommitsForPush(ctx context.Context, target string, ref plumbing.ReferenceName, stderr io.Writer) error {
+	if checkpoint.ShouldSkipPushSigning(ctx) {
+		return nil
+	}
+
+	repo, err := OpenRepository(ctx)
+	if err != nil {
+		return fmt.Errorf("open repo: %w", err)
+	}
+	defer repo.Close()
+
+	if fetchErr := fetchRefBestEffort(ctx, target, ref); fetchErr != nil {
+		logging.Debug(ctx, "fetch for sign-at-push failed; treating all local commits as new",
+			slog.String("ref", ref.String()),
+			slog.String("error", fetchErr.Error()))
+	}
+
+	localRef, err := repo.Reference(ref, true)
+	if err != nil {
+		// No local ref yet — nothing to sign or push.
+		return nil
+	}
+
+	remoteHash := lookupRemoteTipForSigning(ctx, repo, target, ref)
+	// When there is no remote tip (first push), fall back to HEAD so that only
+	// commits on the checkpoint branch itself are signed. Without this guard the
+	// traversal walks back through the user's working-branch history and
+	// cherry-picks a synthetic signed copy of every ancestor.
+	if remoteHash == plumbing.ZeroHash {
+		if head, headErr := repo.Head(); headErr == nil {
+			remoteHash = head.Hash()
+		}
+	}
+
+	repoPath, err := getRepoPath(repo)
+	if err != nil {
+		return fmt.Errorf("repo path: %w", err)
+	}
+
+	commits, err := collectCommitsSince(ctx, repo, repoPath, localRef.Hash(), remoteHash)
+	if err != nil {
+		return fmt.Errorf("collect commits since remote tip: %w", err)
+	}
+	if len(commits) == 0 {
+		return nil
+	}
+
+	newTip, err := signAndPersistCommits(ctx, repo, remoteHash, commits, stderr)
+	if err != nil {
+		return err
+	}
+
+	refsBundle := checkpoint.ResolveCommittedRefs(ctx)
+	return AdvanceLocalRef(ctx, repo, refsBundle, ref, newTip)
+}
+
+// lookupRemoteTipForSigning returns the hash of the remote-tracking ref for
+// target/ref, or ZeroHash when no tracking ref exists (first push).
+func lookupRemoteTipForSigning(ctx context.Context, repo *git.Repository, target string, ref plumbing.ReferenceName) plumbing.Hash {
+	if !ref.IsBranch() {
+		return plumbing.ZeroHash
+	}
+	rname := plumbing.NewRemoteReferenceName(target, ref.Short())
+	r, err := repo.Reference(rname, true)
+	if err != nil {
+		logging.Debug(ctx, "no remote-tracking ref; treating all local commits as new",
+			slog.String("ref", rname.String()),
+			slog.String("error", err.Error()))
+		return plumbing.ZeroHash
+	}
+	return r.Hash()
+}
+
+// fetchRefBestEffort fetches ref from target into the standard remote-tracking
+// ref (refs/remotes/<target>/<branch>) without doing any local rebase. It is
+// called before signing so that lookupRemoteTipForSigning finds a fresh tip.
+// Failures are silently ignored by the caller — this is a best-effort update.
+func fetchRefBestEffort(ctx context.Context, target string, ref plumbing.ReferenceName) error {
+	if !ref.IsBranch() || remote.IsURL(target) {
+		// Non-branch refs and URL targets don't have a standard remote-tracking
+		// ref, so there is nothing useful to fetch here.
+		return nil
+	}
+
+	fetchTarget, err := remote.ResolveFetchTarget(ctx, target)
+	if err != nil {
+		return fmt.Errorf("resolve fetch target: %w", err)
+	}
+
+	refSpec := fmt.Sprintf("+%s:refs/remotes/%s/%s", ref.String(), target, ref.Short())
+	if _, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   fetchTarget,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+	}); fetchErr != nil {
+		return fmt.Errorf("fetch ref %s from %s: %w", ref, target, fetchErr)
+	}
+	return nil
 }

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -127,13 +127,24 @@ func signAndPersistCommits(ctx context.Context, repo *git.Repository, repoPath s
 			return plumbing.ZeroHash, fmt.Errorf("tree changes for %s: %w", original.Hash.String()[:7], err)
 		}
 
+		// A "true root" is a commit treeChangesForCherryPick treats as having no
+		// parent: it has no ParentHashes or sits on the shallow boundary. For
+		// those, len(changes) == 0 means the original tree is empty (the
+		// orphan-init case) and the cherry-picked clone must keep that empty
+		// tree as the chain anchor.
+		//
+		// For non-root no-op commits (original.Tree == parent.Tree), the diff
+		// is also empty, but reusing original.TreeHash would clobber the
+		// accumulated state on the remote tip — in cross-clone pushes, the
+		// remote tip can carry files the local parent never had. Skip those
+		// commits entirely, matching the same skip cherryPickOnto applies.
+		isRoot := len(original.ParentHashes) == 0 || shallow[original.Hash]
 		var treeHash plumbing.Hash
 		switch {
-		case len(changes) == 0:
-			// No changes relative to parent (e.g. empty-tree orphan init). Use
-			// the original tree directly; ApplyTreeChanges with no changes would
-			// return the base tree, which is wrong for root commits.
+		case len(changes) == 0 && isRoot:
 			treeHash = original.TreeHash
+		case len(changes) == 0:
+			continue
 		case currentTip == plumbing.ZeroHash:
 			treeHash, err = checkpoint.ApplyTreeChanges(ctx, repo, plumbing.ZeroHash, changes)
 			if err != nil {

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -43,18 +43,59 @@ var promptOnSigningFailure = defaultPromptOnSigningFailure
 // failure it consults promptOnSigningFailure and either retries, includes
 // the commit unsigned, or aborts (returning errSigningAborted).
 //
+// Tree construction uses a diff-based approach: each commit's delta (relative
+// to its own parent) is applied to the current chain tip's tree. This is
+// equivalent to what cherryPickOnto does, but with strict signing added.
+// Using per-commit deltas rather than the original TreeHash ensures that
+// cross-clone cherry-picks accumulate trees correctly — each replica's commits
+// only carry their own checkpoint files, so a simple tree-replace would
+// overwrite the other clone's data.
+//
 // Returns the hash of the new chain tip on success. Returns base unchanged
 // when signing is disabled in settings (caller is expected to push the
 // chain as-is in that case).
-func signAndPersistCommits(ctx context.Context, repo *git.Repository, base plumbing.Hash, commits []*object.Commit, stderr io.Writer) (plumbing.Hash, error) {
+func signAndPersistCommits(ctx context.Context, repo *git.Repository, repoPath string, base plumbing.Hash, commits []*object.Commit, stderr io.Writer) (plumbing.Hash, error) {
 	if checkpoint.ShouldSkipPushSigning(ctx) {
 		return base, nil
+	}
+
+	shallow, err := loadShallowHashes(ctx, repoPath)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("load shallow hashes: %w", err)
 	}
 
 	total := len(commits)
 	currentTip := base
 	for i, original := range commits {
-		built, err := buildCherryPickCommit(ctx, repo, original.TreeHash, currentTip, original)
+		changes, err := treeChangesForCherryPick(ctx, repo, original, shallow)
+		if err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("tree changes for %s: %w", original.Hash.String()[:7], err)
+		}
+
+		var treeHash plumbing.Hash
+		switch {
+		case len(changes) == 0:
+			// No changes relative to parent (e.g. empty-tree orphan init). Use
+			// the original tree directly; ApplyTreeChanges with no changes would
+			// return the base tree, which is wrong for root commits.
+			treeHash = original.TreeHash
+		case currentTip == plumbing.ZeroHash:
+			treeHash, err = checkpoint.ApplyTreeChanges(ctx, repo, plumbing.ZeroHash, changes)
+			if err != nil {
+				return plumbing.ZeroHash, fmt.Errorf("apply tree changes for %s: %w", original.Hash.String()[:7], err)
+			}
+		default:
+			tipCommit, tipErr := repo.CommitObject(currentTip)
+			if tipErr != nil {
+				return plumbing.ZeroHash, fmt.Errorf("get tip commit %s: %w", currentTip.String()[:7], tipErr)
+			}
+			treeHash, err = checkpoint.ApplyTreeChanges(ctx, repo, tipCommit.TreeHash, changes)
+			if err != nil {
+				return plumbing.ZeroHash, fmt.Errorf("apply tree changes for %s: %w", original.Hash.String()[:7], err)
+			}
+		}
+
+		built, err := buildCherryPickCommit(ctx, repo, treeHash, currentTip, original)
 		if err != nil {
 			return plumbing.ZeroHash, fmt.Errorf("build cherry-pick: %w", err)
 		}
@@ -173,7 +214,35 @@ func signLocalCommitsForPush(ctx context.Context, target string, ref plumbing.Re
 		return nil
 	}
 
-	newTip, err := signAndPersistCommits(ctx, repo, remoteHash, commits, stderr)
+	// In cross-clone scenarios the remote already has its own orphan-init
+	// commit. Each clone also has its own local orphan-init commit (different
+	// hash). When we cherry-pick B's local chain onto the remote tip we must
+	// skip B's orphan-init, otherwise the remote accumulates duplicate
+	// empty-tree commits. Only apply this filter when the remote already has
+	// commits (remoteHash != ZeroHash); on first-ever push the local orphan
+	// is the intended root and must be included.
+	//
+	// This mirrors the filter that metadata_reconcile.go applies in its
+	// disconnected path.
+	signingCommits := commits
+	if remoteHash != plumbing.ZeroHash {
+		dataCommits := commits[:0]
+		for _, c := range commits {
+			tree, treeErr := c.Tree()
+			if treeErr != nil {
+				return fmt.Errorf("read tree for commit %s: %w", c.Hash.String()[:7], treeErr)
+			}
+			if len(tree.Entries) > 0 {
+				dataCommits = append(dataCommits, c)
+			}
+		}
+		if len(dataCommits) == 0 {
+			return nil
+		}
+		signingCommits = dataCommits
+	}
+
+	newTip, err := signAndPersistCommits(ctx, repo, repoPath, remoteHash, signingCommits, stderr)
 	if err != nil {
 		return err
 	}

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -27,53 +27,57 @@ const (
 	signingActionAbort
 )
 
-// signingProgress renders a rolling N-line progress display on a TTY,
-// in-place, using ANSI cursor-up + clear-line escapes. On a non-TTY the
-// renderer falls back to printing each line as it arrives.
+// signingProgress renders a two-line push-signing display:
+//
+//	[entire] Signing commits:
+//	        3/10: <subject>
+//
+// The header prints once on the first Update; the status line below it is
+// rewritten in place on each subsequent Update. On a non-TTY the status line
+// is appended fresh for each commit instead of being overwritten, so CI logs
+// retain a record of every signed commit.
 type signingProgress struct {
-	out      io.Writer
-	capacity int
-	isTTY    bool
-	lines    []string
-	drawn    int
+	out         io.Writer
+	isTTY       bool
+	total       int
+	headerDrawn bool
+	statusDrawn bool
 }
 
-func newSigningProgress(out io.Writer, capacity int) *signingProgress {
+func newSigningProgress(out io.Writer, total int) *signingProgress {
 	return &signingProgress{
-		out:      out,
-		capacity: capacity,
-		isTTY:    interactive.IsTerminalWriter(out),
+		out:   out,
+		isTTY: interactive.IsTerminalWriter(out),
+		total: total,
 	}
 }
 
-// Push appends line to the visible buffer. On a TTY, the previous N lines
-// (if any) are erased and the buffer redrawn in place; on a non-TTY, line
-// is appended to out without any cursor manipulation.
-func (p *signingProgress) Push(line string) {
-	p.lines = append(p.lines, line)
-	if len(p.lines) > p.capacity {
-		p.lines = p.lines[len(p.lines)-p.capacity:]
+// Update writes the progress line for commit i (1-indexed) with the given
+// subject. The first call also prints the static "[entire] Signing commits:"
+// header.
+func (p *signingProgress) Update(i int, subject string) {
+	if !p.headerDrawn {
+		fmt.Fprintln(p.out, "[entire] Signing commits:")
+		p.headerDrawn = true
 	}
+	line := fmt.Sprintf("        %d/%d: %s", i, p.total, truncatedSubject(subject))
 	if !p.isTTY {
 		fmt.Fprintln(p.out, line)
 		return
 	}
-	if p.drawn > 0 {
-		// Move cursor up `drawn` lines so we can rewrite them in place.
-		fmt.Fprintf(p.out, "\033[%dA", p.drawn)
+	if p.statusDrawn {
+		// Move cursor up one line so we can rewrite the status line in place.
+		fmt.Fprint(p.out, "\033[1A")
 	}
-	for _, l := range p.lines {
-		// Clear the entire line then print the buffered content.
-		fmt.Fprintf(p.out, "\033[2K%s\n", l)
-	}
-	p.drawn = len(p.lines)
+	fmt.Fprintf(p.out, "\033[2K%s\n", line)
+	p.statusDrawn = true
 }
 
-// Detach forgets that we've drawn anything, so the next Push prints below
-// whatever currently sits on screen (e.g. after a prompt that wrote lines
-// outside our control). The currently-visible buffered lines stay in place.
+// Detach forgets that we've drawn a status line so the next Update prints
+// below whatever currently sits on screen (used before showing a prompt that
+// writes output we shouldn't overwrite). The header tracking is preserved.
 func (p *signingProgress) Detach() {
-	p.drawn = 0
+	p.statusDrawn = false
 }
 
 var errSigningAborted = errors.New("checkpoint signing aborted by user")
@@ -113,10 +117,9 @@ func signAndPersistCommits(ctx context.Context, repo *git.Repository, repoPath s
 		return plumbing.ZeroHash, fmt.Errorf("load shallow hashes: %w", err)
 	}
 
-	const progressBufferLines = 3
-	progress := newSigningProgress(stderr, progressBufferLines)
-
 	total := len(commits)
+	progress := newSigningProgress(stderr, total)
+
 	currentTip := base
 	for i, original := range commits {
 		changes, err := treeChangesForCherryPick(ctx, repo, original, shallow)
@@ -153,12 +156,12 @@ func signAndPersistCommits(ctx context.Context, repo *git.Repository, repoPath s
 		}
 
 		subject := commitSubject(original.Message)
-		progress.Push(signingProgressMessage(i+1, total, subject))
+		progress.Update(i+1, subject)
 
 		signErr := signCommitForPush(ctx, built)
 		for signErr != nil && !errors.Is(signErr, checkpoint.ErrSigningDisabled) {
 			// Detach so the prompt's output lines are not overwritten by the
-			// next Push.
+			// next Update.
 			progress.Detach()
 			action := promptOnSigningFailure(ctx, subject, signErr, stderr)
 			switch action {
@@ -186,13 +189,15 @@ func signAndPersistCommits(ctx context.Context, repo *git.Repository, repoPath s
 	return currentTip, nil
 }
 
-func signingProgressMessage(i, total int, subject string) string {
+// truncatedSubject returns the first line of subject, rune-truncated to 80
+// visible characters with an ellipsis suffix when shortened.
+func truncatedSubject(subject string) string {
 	subject = strings.SplitN(subject, "\n", 2)[0]
 	const maxLen = 80
 	if len([]rune(subject)) > maxLen {
 		subject = string([]rune(subject)[:maxLen-1]) + "…"
 	}
-	return fmt.Sprintf("Signing commit %d/%d: %s", i, total, subject)
+	return subject
 }
 
 func commitSubject(message string) string {
@@ -248,7 +253,7 @@ func signLocalCommitsForPush(ctx context.Context, target string, ref plumbing.Re
 		return nil
 	}
 
-	remoteHash, cleanup := resolveRemoteTipForSigning(ctx, repo, target, ref)
+	remoteHash, cleanup := resolveRemoteTipForSigning(ctx, repo, target, ref, stderr)
 	defer cleanup()
 
 	repoPath, err := getRepoPath(repo)
@@ -311,7 +316,7 @@ func signLocalCommitsForPush(ctx context.Context, target string, ref plumbing.Re
 // yet, network failure, non-branch ref). Best-effort: failures only mean the
 // caller will treat the local chain as entirely new, which is the same
 // pre-fix behaviour for URL targets.
-func resolveRemoteTipForSigning(ctx context.Context, repo *git.Repository, target string, ref plumbing.ReferenceName) (plumbing.Hash, func()) {
+func resolveRemoteTipForSigning(ctx context.Context, repo *git.Repository, target string, ref plumbing.ReferenceName, stderr io.Writer) (plumbing.Hash, func()) {
 	cleanup := func() {}
 	if !ref.IsBranch() {
 		return plumbing.ZeroHash, cleanup
@@ -339,6 +344,8 @@ func resolveRemoteTipForSigning(ctx context.Context, repo *git.Repository, targe
 		refSpec = fmt.Sprintf("+%s:refs/remotes/%s/%s", ref.String(), target, ref.Short())
 		fetchedRefName = plumbing.NewRemoteReferenceName(target, ref.Short())
 	}
+
+	fmt.Fprintln(stderr, "[entire] Fetching latest from remote...")
 
 	if _, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
 		Remote:   fetchTarget,

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -309,7 +309,15 @@ func signLocalCommitsForPush(ctx context.Context, target string, ref plumbing.Re
 			}
 		}
 		if len(dataCommits) == 0 {
-			return nil
+			// Local-only chain is just orphan-init commits with no checkpoint
+			// data. Pushing it as-is would be rejected as non-fast-forward
+			// against the populated remote. Reset the local ref to the
+			// remote tip so the subsequent push is a no-op and the local
+			// metadata branch matches what the remote already has — this
+			// mirrors the same reset in metadata_reconcile.go's
+			// disconnected path.
+			refsBundle := checkpoint.ResolveCommittedRefs(ctx)
+			return AdvanceLocalRef(ctx, repo, refsBundle, ref, remoteHash)
 		}
 		signingCommits = dataCommits
 	}

--- a/cmd/entire/cli/strategy/push_signing.go
+++ b/cmd/entire/cli/strategy/push_signing.go
@@ -1,0 +1,128 @@
+package strategy
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+type signingAction int
+
+const (
+	signingActionRetry signingAction = iota
+	signingActionSkip
+	signingActionAbort
+)
+
+var errSigningAborted = errors.New("checkpoint signing aborted by user")
+
+// signCommitForPush is the strict signer used at push time. Overridden in
+// tests.
+var signCommitForPush = checkpoint.SignCommit
+
+// promptOnSigningFailure asks the user what to do on a signing failure.
+// Overridden in tests; defaults to a stdin/stderr prompt when a TTY is
+// available and to "skip" when not.
+var promptOnSigningFailure = defaultPromptOnSigningFailure
+
+// signAndPersistCommits cherry-picks each commit in commits onto base
+// (oldest-first), signing each new commit before persisting it. On signing
+// failure it consults promptOnSigningFailure and either retries, includes
+// the commit unsigned, or aborts (returning errSigningAborted).
+//
+// Returns the hash of the new chain tip on success. Returns base unchanged
+// when signing is disabled in settings (caller is expected to push the
+// chain as-is in that case).
+func signAndPersistCommits(ctx context.Context, repo *git.Repository, base plumbing.Hash, commits []*object.Commit, stderr io.Writer) (plumbing.Hash, error) {
+	if checkpoint.ShouldSkipPushSigning(ctx) {
+		return base, nil
+	}
+
+	total := len(commits)
+	currentTip := base
+	for i, original := range commits {
+		built, err := buildCherryPickCommit(ctx, repo, original.TreeHash, currentTip, original)
+		if err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("build cherry-pick: %w", err)
+		}
+
+		subject := commitSubject(original.Message)
+		fmt.Fprintln(stderr, signingProgressMessage(i+1, total, subject))
+
+		signErr := signCommitForPush(ctx, built)
+		for signErr != nil && !errors.Is(signErr, checkpoint.ErrSigningDisabled) {
+			action := promptOnSigningFailure(ctx, subject, signErr, stderr)
+			switch action {
+			case signingActionRetry:
+				signErr = signCommitForPush(ctx, built)
+			case signingActionSkip:
+				logging.Warn(ctx, "signing skipped for commit",
+					slog.String("subject", subject),
+					slog.String("error", signErr.Error()),
+				)
+				built.Signature = ""
+				signErr = nil
+			case signingActionAbort:
+				return plumbing.ZeroHash, errSigningAborted
+			}
+		}
+
+		newHash, err := persistCherryPickCommit(repo, built)
+		if err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("persist commit: %w", err)
+		}
+		currentTip = newHash
+	}
+
+	return currentTip, nil
+}
+
+func signingProgressMessage(i, total int, subject string) string {
+	subject = strings.SplitN(subject, "\n", 2)[0]
+	const maxLen = 80
+	if len([]rune(subject)) > maxLen {
+		subject = string([]rune(subject)[:maxLen-1]) + "…"
+	}
+	return fmt.Sprintf("Signing commit %d/%d: %s", i, total, subject)
+}
+
+func commitSubject(message string) string {
+	return strings.SplitN(message, "\n", 2)[0]
+}
+
+// defaultPromptOnSigningFailure asks the user what to do when stderr is a
+// TTY; defaults to skip silently in non-interactive contexts.
+func defaultPromptOnSigningFailure(_ context.Context, subject string, signErr error, stderr io.Writer) signingAction {
+	if !interactive.CanPromptInteractively() {
+		return signingActionSkip
+	}
+	fmt.Fprintf(stderr, "Failed to sign commit: %s\nError: %v\nRetry, skip, or abort? [r/s/a]: ", subject, signErr)
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return signingActionSkip
+		}
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "r", "retry":
+			return signingActionRetry
+		case "s", "skip":
+			return signingActionSkip
+		case "a", "abort":
+			return signingActionAbort
+		}
+		fmt.Fprint(stderr, "Please answer r, s, or a: ")
+	}
+}

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -1,12 +1,20 @@
 package strategy
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
 	"testing"
 
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,4 +72,248 @@ func TestPersistCherryPickCommit_StoresAndReturnsHash(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, headCommit.Message, stored.Message)
 	assert.Equal(t, headCommit.TreeHash, stored.TreeHash)
+}
+
+// Tests for signingProgressMessage formatting.
+func TestSigningProgressMessage_FormatsSubjectAndCount(t *testing.T) {
+	t.Parallel()
+
+	got := signingProgressMessage(3, 12, "entire-checkpoint: step 4 post-tool")
+	assert.Equal(t, "Signing commit 3/12: entire-checkpoint: step 4 post-tool", got)
+}
+
+func TestSigningProgressMessage_TruncatesLongSubject(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", 200)
+	got := signingProgressMessage(1, 1, long)
+	// Subject is truncated to 80 visible chars (79 'a's + "…"). "…" is 3 bytes.
+	// Prefix is "Signing commit 1/1: " (20 chars). So byte length = 20 + 79 + 3 = 102.
+	assert.True(t, strings.HasSuffix(got, "…"))
+	assert.True(t, strings.HasPrefix(got, "Signing commit 1/1: "))
+	// Subject portion (after prefix) should be 79 'a's + "…"
+	subjectPortion := strings.TrimPrefix(got, "Signing commit 1/1: ")
+	assert.Equal(t, 79, strings.Count(subjectPortion, "a"))
+}
+
+func TestSigningProgressMessage_StripsBodyOfMessage(t *testing.T) {
+	t.Parallel()
+
+	got := signingProgressMessage(1, 1, "subject line\n\nlong body line 1\nlong body line 2\n")
+	assert.Equal(t, "Signing commit 1/1: subject line", got)
+}
+
+const testFakeSig = "fake-sig"
+
+// Tests for signAndPersistCommits behavior.
+// These tests override package-level function vars and cannot be parallelized.
+func TestSignAndPersistCommits_AllSucceed(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, base := setupChainOfUnsignedCommits(t, dir, 3)
+
+	prev := signCommitForPush
+	signCommitForPush = func(_ context.Context, c *object.Commit) error {
+		c.Signature = testFakeSig
+		return nil
+	}
+	t.Cleanup(func() { signCommitForPush = prev })
+
+	var stderr bytes.Buffer
+	commits := listLocalCommits(t, repo, base)
+	tip, err := signAndPersistCommits(context.Background(), repo, base, commits, &stderr)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, plumbing.ZeroHash, tip)
+	out := stderr.String()
+	assert.Contains(t, out, "Signing commit 1/3:")
+	assert.Contains(t, out, "Signing commit 2/3:")
+	assert.Contains(t, out, "Signing commit 3/3:")
+
+	walkAndAssertAllSigned(t, repo, tip, base)
+}
+
+func TestSignAndPersistCommits_SkipKeepsChainConnectedWithUnsignedMiddle(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, base := setupChainOfUnsignedCommits(t, dir, 3)
+
+	prevSign := signCommitForPush
+	calls := 0
+	signCommitForPush = func(_ context.Context, c *object.Commit) error {
+		calls++
+		if calls == 2 {
+			return errors.New("agent busy")
+		}
+		c.Signature = testFakeSig
+		return nil
+	}
+	t.Cleanup(func() { signCommitForPush = prevSign })
+
+	prevPrompt := promptOnSigningFailure
+	promptOnSigningFailure = func(_ context.Context, _ string, _ error, _ io.Writer) signingAction {
+		return signingActionSkip
+	}
+	t.Cleanup(func() { promptOnSigningFailure = prevPrompt })
+
+	var stderr bytes.Buffer
+	commits := listLocalCommits(t, repo, base)
+	tip, err := signAndPersistCommits(context.Background(), repo, base, commits, &stderr)
+	require.NoError(t, err)
+
+	signedCount, unsignedCount := countSignedAndUnsigned(t, repo, tip, base)
+	assert.Equal(t, 2, signedCount)
+	assert.Equal(t, 1, unsignedCount)
+}
+
+func TestSignAndPersistCommits_AbortReturnsErrorWithoutAdvancing(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, base := setupChainOfUnsignedCommits(t, dir, 3)
+
+	prevSign := signCommitForPush
+	signCommitForPush = func(_ context.Context, _ *object.Commit) error {
+		return errors.New("agent down")
+	}
+	t.Cleanup(func() { signCommitForPush = prevSign })
+
+	prevPrompt := promptOnSigningFailure
+	promptOnSigningFailure = func(_ context.Context, _ string, _ error, _ io.Writer) signingAction {
+		return signingActionAbort
+	}
+	t.Cleanup(func() { promptOnSigningFailure = prevPrompt })
+
+	var stderr bytes.Buffer
+	commits := listLocalCommits(t, repo, base)
+	_, err := signAndPersistCommits(context.Background(), repo, base, commits, &stderr)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSigningAborted)
+}
+
+func TestSignAndPersistCommits_RetrySucceedsOnSecondAttempt(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, base := setupChainOfUnsignedCommits(t, dir, 1)
+
+	prevSign := signCommitForPush
+	attempt := 0
+	signCommitForPush = func(_ context.Context, c *object.Commit) error {
+		attempt++
+		if attempt == 1 {
+			return errors.New("transient")
+		}
+		c.Signature = testFakeSig
+		return nil
+	}
+	t.Cleanup(func() { signCommitForPush = prevSign })
+
+	prevPrompt := promptOnSigningFailure
+	promptOnSigningFailure = func(_ context.Context, _ string, _ error, _ io.Writer) signingAction {
+		return signingActionRetry
+	}
+	t.Cleanup(func() { promptOnSigningFailure = prevPrompt })
+
+	var stderr bytes.Buffer
+	commits := listLocalCommits(t, repo, base)
+	tip, err := signAndPersistCommits(context.Background(), repo, base, commits, &stderr)
+	require.NoError(t, err)
+	assert.Equal(t, 2, attempt)
+	walkAndAssertAllSigned(t, repo, tip, base)
+}
+
+// setupChainOfUnsignedCommits commits a base file, then creates n unsigned
+// checkpoint commits on top using checkpoint.CreateCommit and points the
+// local entire/checkpoints/v1 ref at the chain tip. Returns the repo and
+// the base (pre-chain) hash that callers should pass as the cherry-pick
+// base.
+func setupChainOfUnsignedCommits(t *testing.T, dir string, n int) (*git.Repository, plumbing.Hash) {
+	t.Helper()
+	testutil.WriteFile(t, dir, "base.txt", "base")
+	testutil.GitAdd(t, dir, "base.txt")
+	testutil.GitCommit(t, dir, "base")
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	head, err := repo.Head()
+	require.NoError(t, err)
+	base := head.Hash()
+
+	parent := base
+	for i := range n {
+		treeHash := makeUniqueTree(t, repo, i)
+		hash, err := checkpoint.CreateCommit(context.Background(), repo, treeHash, parent, fmt.Sprintf("entire-checkpoint: step %d", i+1), "u", "u@e")
+		require.NoError(t, err)
+		parent = hash
+	}
+
+	tip := parent
+	refs := checkpoint.DefaultV1Refs()
+	require.NoError(t, AdvanceLocalRef(context.Background(), repo, refs, refs.Primary, tip))
+
+	return repo, base
+}
+
+func listLocalCommits(t *testing.T, repo *git.Repository, base plumbing.Hash) []*object.Commit {
+	t.Helper()
+	refs := checkpoint.DefaultV1Refs()
+	tipRef, err := repo.Reference(refs.Primary, true)
+	require.NoError(t, err)
+
+	var out []*object.Commit
+	for h := tipRef.Hash(); h != base; {
+		c, err := repo.CommitObject(h)
+		require.NoError(t, err)
+		out = append([]*object.Commit{c}, out...)
+		if len(c.ParentHashes) == 0 {
+			break
+		}
+		h = c.ParentHashes[0]
+	}
+	return out
+}
+
+func walkAndAssertAllSigned(t *testing.T, repo *git.Repository, tip, base plumbing.Hash) {
+	t.Helper()
+	for h := tip; h != base; {
+		c, err := repo.CommitObject(h)
+		require.NoError(t, err)
+		assert.NotEmpty(t, c.Signature, "expected commit %s signed", h)
+		if len(c.ParentHashes) == 0 {
+			break
+		}
+		h = c.ParentHashes[0]
+	}
+}
+
+func countSignedAndUnsigned(t *testing.T, repo *git.Repository, tip, base plumbing.Hash) (signed, unsigned int) {
+	t.Helper()
+	for h := tip; h != base; {
+		c, err := repo.CommitObject(h)
+		require.NoError(t, err)
+		if c.Signature != "" {
+			signed++
+		} else {
+			unsigned++
+		}
+		if len(c.ParentHashes) == 0 {
+			break
+		}
+		h = c.ParentHashes[0]
+	}
+	return signed, unsigned
+}
+
+func makeUniqueTree(t *testing.T, repo *git.Repository, salt int) plumbing.Hash {
+	t.Helper()
+	content := []byte(fmt.Sprintf("contents-%d", salt))
+	blob, err := checkpoint.CreateBlobFromContent(repo, content)
+	require.NoError(t, err)
+	tree := &object.Tree{Entries: []object.TreeEntry{
+		{Name: fmt.Sprintf("f-%d.txt", salt), Mode: filemode.Regular, Hash: blob},
+	}}
+	obj := repo.Storer.NewEncodedObject()
+	require.NoError(t, tree.Encode(obj))
+	hash, err := repo.Storer.SetEncodedObject(obj)
+	require.NoError(t, err)
+	return hash
 }

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -554,6 +554,42 @@ func extendChainOfUnsignedCommits(t *testing.T, dir string, n int) {
 	require.NoError(t, AdvanceLocalRef(context.Background(), repo, refs, refs.Primary, parent))
 }
 
+func TestSigningProgress_NonTTYPrintsEveryLine(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	p := newSigningProgress(&buf, 3)
+	p.Push("a")
+	p.Push("b")
+	p.Push("c")
+	p.Push("d")
+	p.Push("e")
+
+	assert.Equal(t, "a\nb\nc\nd\ne\n", buf.String())
+}
+
+func TestSigningProgress_TTYRollsLastN(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	// Bypass the TTY detection by direct construction.
+	p := &signingProgress{out: &buf, capacity: 3, isTTY: true}
+
+	p.Push("a")
+	p.Push("b")
+	p.Push("c")
+	p.Push("d")
+	p.Push("e")
+
+	out := buf.String()
+	// ANSI cursor-up should appear after the first draw.
+	assert.Contains(t, out, "\033[")
+	// Final buffer state should include the most recent three lines, c d e.
+	assert.Contains(t, out, "c")
+	assert.Contains(t, out, "d")
+	assert.Contains(t, out, "e")
+}
+
 // writeDisabledSigningSettings writes a settings file disabling signing into dir/.entire/settings.json.
 func writeDisabledSigningSettings(t *testing.T, dir string) {
 	t.Helper()

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -123,7 +123,7 @@ func TestSignAndPersistCommits_AllSucceed(t *testing.T) {
 
 	var stderr bytes.Buffer
 	commits := listLocalCommits(t, repo, base)
-	tip, err := signAndPersistCommits(context.Background(), repo, base, commits, &stderr)
+	tip, err := signAndPersistCommits(context.Background(), repo, dir, base, commits, &stderr)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, plumbing.ZeroHash, tip)
@@ -160,7 +160,7 @@ func TestSignAndPersistCommits_SkipKeepsChainConnectedWithUnsignedMiddle(t *test
 
 	var stderr bytes.Buffer
 	commits := listLocalCommits(t, repo, base)
-	tip, err := signAndPersistCommits(context.Background(), repo, base, commits, &stderr)
+	tip, err := signAndPersistCommits(context.Background(), repo, dir, base, commits, &stderr)
 	require.NoError(t, err)
 
 	signedCount, unsignedCount := countSignedAndUnsigned(t, repo, tip, base)
@@ -187,7 +187,7 @@ func TestSignAndPersistCommits_AbortReturnsErrorWithoutAdvancing(t *testing.T) {
 
 	var stderr bytes.Buffer
 	commits := listLocalCommits(t, repo, base)
-	_, err := signAndPersistCommits(context.Background(), repo, base, commits, &stderr)
+	_, err := signAndPersistCommits(context.Background(), repo, dir, base, commits, &stderr)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errSigningAborted)
 }
@@ -217,7 +217,7 @@ func TestSignAndPersistCommits_RetrySucceedsOnSecondAttempt(t *testing.T) {
 
 	var stderr bytes.Buffer
 	commits := listLocalCommits(t, repo, base)
-	tip, err := signAndPersistCommits(context.Background(), repo, base, commits, &stderr)
+	tip, err := signAndPersistCommits(context.Background(), repo, dir, base, commits, &stderr)
 	require.NoError(t, err)
 	assert.Equal(t, 2, attempt)
 	walkAndAssertAllSigned(t, repo, tip, base)

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -494,6 +494,73 @@ func TestPrePush_SigningAbort_LeavesLocalUnchanged(t *testing.T) { //nolint:para
 	assert.Equal(t, tipBefore.Hash(), tipAfter.Hash(), "local ref must not advance on abort")
 }
 
+// TestPrePush_OrphanOnlyLocalResetsToRemoteTip exercises the bug where, on a
+// clone that has only its own orphan-init commit locally and a populated
+// remote, the pre-sign filter dropped every commit, returned without touching
+// the ref, and the subsequent push went out as the local orphan chain —
+// which the remote rejected as non-fast-forward, masking the real fix until
+// reconciliation kicked in.
+//
+// The pre-sign path must mirror the disconnected-reconcile path's reset:
+// when the data-commit set is empty, advance the local ref to the remote
+// tip so the push that follows is a clean fast-forward (no-op).
+func TestPrePush_OrphanOnlyLocalResetsToRemoteTip(t *testing.T) { //nolint:paralleltest // t.Chdir + signCommitForPush global
+	dir := t.TempDir()
+	bareRemote := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.InitBareRepo(t, bareRemote)
+	testutil.AddRemote(t, dir, "origin", bareRemote)
+
+	// Populate the remote with a real chain via a regular push.
+	_, _ = setupChainOfUnsignedCommits(t, dir, 2)
+
+	prev := signCommitForPush
+	signCommitForPush = func(_ context.Context, c *object.Commit) error {
+		c.Signature = testFakeSig
+		return nil
+	}
+	t.Cleanup(func() { signCommitForPush = prev })
+
+	t.Chdir(dir)
+	s := &ManualCommitStrategy{}
+	require.NoError(t, s.PrePush(context.Background(), "origin"))
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	refs := checkpoint.DefaultV1Refs()
+
+	bare, err := git.PlainOpen(bareRemote)
+	require.NoError(t, err)
+	remoteRef, err := bare.Reference(refs.Primary, true)
+	require.NoError(t, err)
+	remoteTipHash := remoteRef.Hash()
+
+	// Build a fresh orphan-only local chain — an empty-tree commit with no
+	// parent — and reset local v1 to it. This is the shape of a freshly
+	// initialised entire/checkpoints/v1 on a clone that has not yet fetched.
+	emptyTree := &object.Tree{Entries: []object.TreeEntry{}}
+	emptyTreeObj := repo.Storer.NewEncodedObject()
+	require.NoError(t, emptyTree.Encode(emptyTreeObj))
+	emptyTreeHash, err := repo.Storer.SetEncodedObject(emptyTreeObj)
+	require.NoError(t, err)
+	orphanHash, err := checkpoint.CreateCommit(context.Background(), repo, emptyTreeHash, plumbing.ZeroHash, "Initialize metadata ref", "u", "u@e")
+	require.NoError(t, err)
+	require.NoError(t, AdvanceLocalRef(context.Background(), repo, refs, refs.Primary, orphanHash))
+
+	localBefore, err := repo.Reference(refs.Primary, true)
+	require.NoError(t, err)
+	require.Equal(t, orphanHash, localBefore.Hash())
+	require.NotEqual(t, remoteTipHash, localBefore.Hash())
+
+	// The push should observe an empty data-commit set and reset local to
+	// the remote tip; pushRefIfNeeded then has nothing to do.
+	require.NoError(t, s.PrePush(context.Background(), "origin"))
+
+	localAfter, err := repo.Reference(refs.Primary, true)
+	require.NoError(t, err)
+	assert.Equal(t, remoteTipHash, localAfter.Hash(), "local ref should be reset to remote tip when local-only chain is just orphan-init")
+}
+
 func TestPrePush_SignsOnceWhenRemoteIsURL(t *testing.T) { //nolint:paralleltest // t.Chdir + signCommitForPush global
 	dir := t.TempDir()
 	bareRemote := t.TempDir()

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -499,6 +499,61 @@ func TestPrePush_SigningAbort_LeavesLocalUnchanged(t *testing.T) { //nolint:para
 	assert.Equal(t, tipBefore.Hash(), tipAfter.Hash(), "local ref must not advance on abort")
 }
 
+func TestPrePush_SignsOnceWhenRemoteIsURL(t *testing.T) { //nolint:paralleltest // t.Chdir + signCommitForPush global
+	dir := t.TempDir()
+	bareRemote := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.InitBareRepo(t, bareRemote)
+	// Add the remote as a file:// URL so remote.IsURL returns true.
+	testutil.AddRemote(t, dir, "origin", "file://"+bareRemote)
+	_, _ = setupChainOfUnsignedCommits(t, dir, 3)
+
+	signCalls := 0
+	prev := signCommitForPush
+	signCommitForPush = func(_ context.Context, c *object.Commit) error {
+		signCalls++
+		c.Signature = testFakeSig
+		return nil
+	}
+	t.Cleanup(func() { signCommitForPush = prev })
+
+	t.Chdir(dir)
+	s := &ManualCommitStrategy{}
+	require.NoError(t, s.PrePush(context.Background(), "origin"))
+
+	// First push: empty remote, all 3 commits signed once.
+	assert.Equal(t, 3, signCalls, "first push should sign each commit exactly once")
+
+	// Add 2 more local commits and push again.
+	extendChainOfUnsignedCommits(t, dir, 2)
+
+	signCalls = 0
+	require.NoError(t, s.PrePush(context.Background(), "origin"))
+	assert.Equal(t, 2, signCalls, "second push should sign only the 2 new commits, NOT re-sign the 3 already-pushed commits")
+}
+
+// extendChainOfUnsignedCommits appends n more unsigned checkpoint commits onto
+// the existing entire/checkpoints/v1 chain. Used to simulate additional work
+// after an initial push.
+func extendChainOfUnsignedCommits(t *testing.T, dir string, n int) {
+	t.Helper()
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	refs := checkpoint.DefaultV1Refs()
+	tip, err := repo.Reference(refs.Primary, true)
+	require.NoError(t, err)
+	parent := tip.Hash()
+	for i := range n {
+		// Salt by a large offset so each tree is unique and doesn't collide
+		// with the trees created by setupChainOfUnsignedCommits.
+		treeHash := makeUniqueTree(t, repo, 1000+i)
+		hash, err := checkpoint.CreateCommit(context.Background(), repo, treeHash, parent, fmt.Sprintf("entire-checkpoint: appended %d", i+1), "u", "u@e")
+		require.NoError(t, err)
+		parent = hash
+	}
+	require.NoError(t, AdvanceLocalRef(context.Background(), repo, refs, refs.Primary, parent))
+}
+
 // writeDisabledSigningSettings writes a settings file disabling signing into dir/.entire/settings.json.
 func writeDisabledSigningSettings(t *testing.T, dir string) {
 	t.Helper()

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -1,0 +1,67 @@
+package strategy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCherryPickCommit_ReturnsUnsignedCommit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "f.txt", "init")
+	testutil.GitAdd(t, dir, "f.txt")
+	testutil.GitCommit(t, dir, "init")
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+	headCommit, err := repo.CommitObject(head.Hash())
+	require.NoError(t, err)
+
+	built, err := buildCherryPickCommit(context.Background(), repo, headCommit.TreeHash, head.Hash(), headCommit)
+	require.NoError(t, err)
+	assert.Equal(t, headCommit.Message, built.Message)
+	assert.Equal(t, headCommit.TreeHash, built.TreeHash)
+	assert.Empty(t, built.Signature, "build must not sign")
+	assert.Equal(t, []plumbing.Hash{head.Hash()}, built.ParentHashes)
+}
+
+func TestPersistCherryPickCommit_StoresAndReturnsHash(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "f.txt", "init")
+	testutil.GitAdd(t, dir, "f.txt")
+	testutil.GitCommit(t, dir, "init")
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+
+	head, err := repo.Head()
+	require.NoError(t, err)
+	headCommit, err := repo.CommitObject(head.Hash())
+	require.NoError(t, err)
+
+	built, err := buildCherryPickCommit(context.Background(), repo, headCommit.TreeHash, head.Hash(), headCommit)
+	require.NoError(t, err)
+
+	hash, err := persistCherryPickCommit(repo, built)
+	require.NoError(t, err)
+	assert.NotEqual(t, plumbing.ZeroHash, hash)
+
+	stored, err := repo.CommitObject(hash)
+	require.NoError(t, err)
+	assert.Equal(t, headCommit.Message, stored.Message)
+	assert.Equal(t, headCommit.TreeHash, stored.TreeHash)
+}

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -76,33 +76,27 @@ func TestPersistCherryPickCommit_StoresAndReturnsHash(t *testing.T) {
 	assert.Equal(t, headCommit.TreeHash, stored.TreeHash)
 }
 
-// Tests for signingProgressMessage formatting.
-func TestSigningProgressMessage_FormatsSubjectAndCount(t *testing.T) {
+// Tests for truncatedSubject formatting.
+func TestTruncatedSubject_ShortPassthrough(t *testing.T) {
 	t.Parallel()
 
-	got := signingProgressMessage(3, 12, "entire-checkpoint: step 4 post-tool")
-	assert.Equal(t, "Signing commit 3/12: entire-checkpoint: step 4 post-tool", got)
+	assert.Equal(t, "entire-checkpoint: step 4 post-tool", truncatedSubject("entire-checkpoint: step 4 post-tool"))
 }
 
-func TestSigningProgressMessage_TruncatesLongSubject(t *testing.T) {
+func TestTruncatedSubject_TruncatesLong(t *testing.T) {
 	t.Parallel()
 
 	long := strings.Repeat("a", 200)
-	got := signingProgressMessage(1, 1, long)
-	// Subject is truncated to 80 visible chars (79 'a's + "…"). "…" is 3 bytes.
-	// Prefix is "Signing commit 1/1: " (20 chars). So byte length = 20 + 79 + 3 = 102.
+	got := truncatedSubject(long)
+	// 80 visible characters: 79 'a's + "…".
 	assert.True(t, strings.HasSuffix(got, "…"))
-	assert.True(t, strings.HasPrefix(got, "Signing commit 1/1: "))
-	// Subject portion (after prefix) should be 79 'a's + "…"
-	subjectPortion := strings.TrimPrefix(got, "Signing commit 1/1: ")
-	assert.Equal(t, 79, strings.Count(subjectPortion, "a"))
+	assert.Equal(t, 79, strings.Count(got, "a"))
 }
 
-func TestSigningProgressMessage_StripsBodyOfMessage(t *testing.T) {
+func TestTruncatedSubject_StripsBody(t *testing.T) {
 	t.Parallel()
 
-	got := signingProgressMessage(1, 1, "subject line\n\nlong body line 1\nlong body line 2\n")
-	assert.Equal(t, "Signing commit 1/1: subject line", got)
+	assert.Equal(t, "subject line", truncatedSubject("subject line\n\nlong body line 1\nlong body line 2\n"))
 }
 
 const testFakeSig = "fake-sig"
@@ -128,9 +122,10 @@ func TestSignAndPersistCommits_AllSucceed(t *testing.T) {
 
 	assert.NotEqual(t, plumbing.ZeroHash, tip)
 	out := stderr.String()
-	assert.Contains(t, out, "Signing commit 1/3:")
-	assert.Contains(t, out, "Signing commit 2/3:")
-	assert.Contains(t, out, "Signing commit 3/3:")
+	assert.Contains(t, out, "[entire] Signing commits:")
+	assert.Contains(t, out, "        1/3:")
+	assert.Contains(t, out, "        2/3:")
+	assert.Contains(t, out, "        3/3:")
 
 	walkAndAssertAllSigned(t, repo, tip, base)
 }
@@ -554,40 +549,56 @@ func extendChainOfUnsignedCommits(t *testing.T, dir string, n int) {
 	require.NoError(t, AdvanceLocalRef(context.Background(), repo, refs, refs.Primary, parent))
 }
 
-func TestSigningProgress_NonTTYPrintsEveryLine(t *testing.T) {
+func TestSigningProgress_NonTTYPrintsHeaderAndEveryLine(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	p := newSigningProgress(&buf, 3)
-	p.Push("a")
-	p.Push("b")
-	p.Push("c")
-	p.Push("d")
-	p.Push("e")
+	p := newSigningProgress(&buf, 5)
+	p.Update(1, "first")
+	p.Update(2, "second")
+	p.Update(3, "third")
 
-	assert.Equal(t, "a\nb\nc\nd\ne\n", buf.String())
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, "[entire] Signing commits:"), "header printed exactly once")
+	assert.Contains(t, out, "        1/5: first")
+	assert.Contains(t, out, "        2/5: second")
+	assert.Contains(t, out, "        3/5: third")
 }
 
-func TestSigningProgress_TTYRollsLastN(t *testing.T) {
+func TestSigningProgress_TTYRewritesStatusInPlace(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 	// Bypass the TTY detection by direct construction.
-	p := &signingProgress{out: &buf, capacity: 3, isTTY: true}
+	p := &signingProgress{out: &buf, total: 3, isTTY: true}
 
-	p.Push("a")
-	p.Push("b")
-	p.Push("c")
-	p.Push("d")
-	p.Push("e")
+	p.Update(1, "alpha")
+	p.Update(2, "beta")
+	p.Update(3, "gamma")
 
 	out := buf.String()
-	// ANSI cursor-up should appear after the first draw.
-	assert.Contains(t, out, "\033[")
-	// Final buffer state should include the most recent three lines, c d e.
-	assert.Contains(t, out, "c")
-	assert.Contains(t, out, "d")
-	assert.Contains(t, out, "e")
+	assert.Equal(t, 1, strings.Count(out, "[entire] Signing commits:"), "header printed exactly once")
+	// First update has no cursor-up; subsequent ones do.
+	assert.Equal(t, 2, strings.Count(out, "\033[1A"), "cursor-up emitted once per re-render")
+	assert.Equal(t, 3, strings.Count(out, "\033[2K"), "clear-line emitted on every status write")
+	assert.Contains(t, out, "        3/3: gamma")
+}
+
+func TestSigningProgress_DetachResumesBelowPrompt(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	p := &signingProgress{out: &buf, total: 2, isTTY: true}
+
+	p.Update(1, "first")
+	p.Detach()
+	p.Update(2, "second")
+
+	out := buf.String()
+	// After Detach, the second Update should NOT emit cursor-up (Detach resets
+	// statusDrawn to false), so the line lands fresh below whatever the prompt
+	// printed in between.
+	assert.Equal(t, 0, strings.Count(out, "\033[1A"))
 }
 
 // writeDisabledSigningSettings writes a settings file disabling signing into dir/.entire/settings.json.

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -601,6 +601,22 @@ func TestSigningProgress_DetachResumesBelowPrompt(t *testing.T) {
 	assert.Equal(t, 0, strings.Count(out, "\033[1A"))
 }
 
+// TestDefaultPromptOnSigningFailure_SkipsWhenStderrNotTTY guards against the
+// failure mode where a controlling /dev/tty exists (so
+// CanPromptInteractively returns true) but stderr has been redirected by the
+// caller (e.g. a git pre-push hook with output captured). Prompting in that
+// case writes a question the user can never see and then blocks reading
+// stdin. The defaultPromptOnSigningFailure must skip silently instead.
+func TestDefaultPromptOnSigningFailure_SkipsWhenStderrNotTTY(t *testing.T) { //nolint:paralleltest // t.Setenv mutates process env
+	t.Setenv("ENTIRE_TEST_TTY", "1") // force CanPromptInteractively true
+
+	var stderr bytes.Buffer // bytes.Buffer is not a terminal
+	got := defaultPromptOnSigningFailure(context.Background(), "subject", errors.New("boom"), &stderr)
+
+	assert.Equal(t, signingActionSkip, got, "must skip when stderr is not a terminal")
+	assert.Empty(t, stderr.String(), "must not write the prompt to a non-TTY writer")
+}
+
 // writeDisabledSigningSettings writes a settings file disabling signing into dir/.entire/settings.json.
 func writeDisabledSigningSettings(t *testing.T, dir string) {
 	t.Helper()

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -223,24 +223,30 @@ func TestSignAndPersistCommits_RetrySucceedsOnSecondAttempt(t *testing.T) {
 	walkAndAssertAllSigned(t, repo, tip, base)
 }
 
-// setupChainOfUnsignedCommits commits a base file, then creates n unsigned
-// checkpoint commits on top using checkpoint.CreateCommit and points the
-// local entire/checkpoints/v1 ref at the chain tip. Returns the repo and
-// the base (pre-chain) hash that callers should pass as the cherry-pick
-// base.
+// setupChainOfUnsignedCommits commits a base file to give the repo a valid
+// HEAD, then creates n unsigned checkpoint commits as an orphan-rooted chain
+// (matching production: entire/checkpoints/v1 is initialized as an orphan via
+// strategy/common.go orphan-init). Points the local entire/checkpoints/v1 ref
+// at the chain tip. Returns the repo and ZeroHash as the base, because the
+// checkpoint chain does NOT descend from HEAD.
 func setupChainOfUnsignedCommits(t *testing.T, dir string, n int) (*git.Repository, plumbing.Hash) {
 	t.Helper()
+
+	// Production rationale: entire/checkpoints/v1 is initialized as an orphan
+	// (see strategy/common.go orphan-init and checkpoint/temporary.go
+	// getOrCreateShadowBranch). The test must mirror that so first-push code
+	// paths exercise the real chain shape.
+	//
+	// We still need an initial user commit so the repo has a valid HEAD for
+	// OpenRepository, but the checkpoint chain does NOT descend from it.
 	testutil.WriteFile(t, dir, "base.txt", "base")
 	testutil.GitAdd(t, dir, "base.txt")
 	testutil.GitCommit(t, dir, "base")
 
 	repo, err := git.PlainOpen(dir)
 	require.NoError(t, err)
-	head, err := repo.Head()
-	require.NoError(t, err)
-	base := head.Hash()
 
-	parent := base
+	parent := plumbing.ZeroHash
 	for i := range n {
 		treeHash := makeUniqueTree(t, repo, i)
 		hash, err := checkpoint.CreateCommit(context.Background(), repo, treeHash, parent, fmt.Sprintf("entire-checkpoint: step %d", i+1), "u", "u@e")
@@ -252,7 +258,9 @@ func setupChainOfUnsignedCommits(t *testing.T, dir string, n int) (*git.Reposito
 	refs := checkpoint.DefaultV1Refs()
 	require.NoError(t, AdvanceLocalRef(context.Background(), repo, refs, refs.Primary, tip))
 
-	return repo, base
+	// base is ZeroHash because the chain is orphan-rooted — there is no
+	// anchor commit to exclude when walking.
+	return repo, plumbing.ZeroHash
 }
 
 func listLocalCommits(t *testing.T, repo *git.Repository, base plumbing.Hash) []*object.Commit {
@@ -344,8 +352,7 @@ func TestPrePush_SignsCommitsAboveRemoteTipAndAdvancesLocal(t *testing.T) { //no
 	refs := checkpoint.DefaultV1Refs()
 	tip, err := repo.Reference(refs.Primary, true)
 	require.NoError(t, err)
-	// Only the checkpoint commits above base should be signed; base itself is a
-	// regular working-branch commit and is not part of the checkpoint chain.
+	// All checkpoint commits in the orphan-rooted chain must be signed.
 	walkAndAssertAllSigned(t, repo, tip.Hash(), base)
 
 	bare, err := git.PlainOpen(bareRemote)
@@ -353,6 +360,20 @@ func TestPrePush_SignsCommitsAboveRemoteTipAndAdvancesLocal(t *testing.T) { //no
 	remoteTip, err := bare.Reference(refs.Primary, true)
 	require.NoError(t, err)
 	assert.Equal(t, tip.Hash(), remoteTip.Hash(), "remote should mirror local signed tip")
+
+	// Walk to root and confirm the chain is orphan-rooted (matches production).
+	rootHash := tip.Hash()
+	for {
+		c, err := repo.CommitObject(rootHash)
+		require.NoError(t, err)
+		if len(c.ParentHashes) == 0 {
+			break
+		}
+		rootHash = c.ParentHashes[0]
+	}
+	root, err := repo.CommitObject(rootHash)
+	require.NoError(t, err)
+	assert.Empty(t, root.ParentHashes, "signed chain root must be orphan-rooted")
 }
 
 func TestPrePush_IdempotentReRunDoesNothing(t *testing.T) { //nolint:paralleltest // t.Chdir + signCommitForPush global
@@ -400,7 +421,7 @@ func TestPrePush_SigningDisabled_PushesUnsigned(t *testing.T) { //nolint:paralle
 	tip, err := repo.Reference(refs.Primary, true)
 	require.NoError(t, err)
 
-	// Count only the checkpoint commits above base; base is a regular commit.
+	// All checkpoint commits in the orphan-rooted chain should be unsigned.
 	signed, unsigned := countSignedAndUnsigned(t, repo, tip.Hash(), base)
 	assert.Equal(t, 0, signed)
 	assert.Equal(t, 2, unsigned)
@@ -437,7 +458,7 @@ func TestPrePush_SigningFailureSkipNonTTY_KeepsChainConnected(t *testing.T) { //
 	refs := checkpoint.DefaultV1Refs()
 	tip, err := repo.Reference(refs.Primary, true)
 	require.NoError(t, err)
-	// Count only checkpoint commits above base; base is a regular working commit.
+	// Count across all checkpoint commits in the orphan-rooted chain.
 	signed, unsigned := countSignedAndUnsigned(t, repo, tip.Hash(), base)
 	assert.Equal(t, 2, signed)
 	assert.Equal(t, 1, unsigned)

--- a/cmd/entire/cli/strategy/push_signing_test.go
+++ b/cmd/entire/cli/strategy/push_signing_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -316,4 +318,170 @@ func makeUniqueTree(t *testing.T, repo *git.Repository, salt int) plumbing.Hash 
 	hash, err := repo.Storer.SetEncodedObject(obj)
 	require.NoError(t, err)
 	return hash
+}
+
+func TestPrePush_SignsCommitsAboveRemoteTipAndAdvancesLocal(t *testing.T) { //nolint:paralleltest // t.Chdir + signCommitForPush global
+	dir := t.TempDir()
+	bareRemote := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.InitBareRepo(t, bareRemote)
+	testutil.AddRemote(t, dir, "origin", bareRemote)
+	_, base := setupChainOfUnsignedCommits(t, dir, 4)
+
+	prev := signCommitForPush
+	signCommitForPush = func(_ context.Context, c *object.Commit) error {
+		c.Signature = testFakeSig
+		return nil
+	}
+	t.Cleanup(func() { signCommitForPush = prev })
+
+	t.Chdir(dir)
+	s := &ManualCommitStrategy{}
+	require.NoError(t, s.PrePush(context.Background(), "origin"))
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	refs := checkpoint.DefaultV1Refs()
+	tip, err := repo.Reference(refs.Primary, true)
+	require.NoError(t, err)
+	// Only the checkpoint commits above base should be signed; base itself is a
+	// regular working-branch commit and is not part of the checkpoint chain.
+	walkAndAssertAllSigned(t, repo, tip.Hash(), base)
+
+	bare, err := git.PlainOpen(bareRemote)
+	require.NoError(t, err)
+	remoteTip, err := bare.Reference(refs.Primary, true)
+	require.NoError(t, err)
+	assert.Equal(t, tip.Hash(), remoteTip.Hash(), "remote should mirror local signed tip")
+}
+
+func TestPrePush_IdempotentReRunDoesNothing(t *testing.T) { //nolint:paralleltest // t.Chdir + signCommitForPush global
+	dir := t.TempDir()
+	bareRemote := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.InitBareRepo(t, bareRemote)
+	testutil.AddRemote(t, dir, "origin", bareRemote)
+	_, _ = setupChainOfUnsignedCommits(t, dir, 2)
+
+	signCalls := 0
+	prev := signCommitForPush
+	signCommitForPush = func(_ context.Context, c *object.Commit) error {
+		signCalls++
+		c.Signature = testFakeSig
+		return nil
+	}
+	t.Cleanup(func() { signCommitForPush = prev })
+
+	t.Chdir(dir)
+	s := &ManualCommitStrategy{}
+	require.NoError(t, s.PrePush(context.Background(), "origin"))
+	require.NoError(t, s.PrePush(context.Background(), "origin"))
+
+	assert.Equal(t, 2, signCalls, "second push should sign nothing")
+}
+
+func TestPrePush_SigningDisabled_PushesUnsigned(t *testing.T) { //nolint:paralleltest // t.Chdir + setupSigningEnv global
+	dir := t.TempDir()
+	bareRemote := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.InitBareRepo(t, bareRemote)
+	testutil.AddRemote(t, dir, "origin", bareRemote)
+	_, base := setupChainOfUnsignedCommits(t, dir, 2)
+
+	// Write a settings file that disables signing, then chdir.
+	writeDisabledSigningSettings(t, dir)
+	t.Chdir(dir)
+	s := &ManualCommitStrategy{}
+	require.NoError(t, s.PrePush(context.Background(), "origin"))
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	refs := checkpoint.DefaultV1Refs()
+	tip, err := repo.Reference(refs.Primary, true)
+	require.NoError(t, err)
+
+	// Count only the checkpoint commits above base; base is a regular commit.
+	signed, unsigned := countSignedAndUnsigned(t, repo, tip.Hash(), base)
+	assert.Equal(t, 0, signed)
+	assert.Equal(t, 2, unsigned)
+}
+
+func TestPrePush_SigningFailureSkipNonTTY_KeepsChainConnected(t *testing.T) { //nolint:paralleltest // t.Chdir + signCommitForPush global
+	dir := t.TempDir()
+	bareRemote := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.InitBareRepo(t, bareRemote)
+	testutil.AddRemote(t, dir, "origin", bareRemote)
+	_, base := setupChainOfUnsignedCommits(t, dir, 3)
+
+	prev := signCommitForPush
+	calls := 0
+	signCommitForPush = func(_ context.Context, c *object.Commit) error {
+		calls++
+		if calls == 2 {
+			return errors.New("agent busy")
+		}
+		c.Signature = testFakeSig
+		return nil
+	}
+	t.Cleanup(func() { signCommitForPush = prev })
+
+	// Default prompt under `go test` is non-interactive, so it skips silently.
+
+	t.Chdir(dir)
+	s := &ManualCommitStrategy{}
+	require.NoError(t, s.PrePush(context.Background(), "origin"))
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	refs := checkpoint.DefaultV1Refs()
+	tip, err := repo.Reference(refs.Primary, true)
+	require.NoError(t, err)
+	// Count only checkpoint commits above base; base is a regular working commit.
+	signed, unsigned := countSignedAndUnsigned(t, repo, tip.Hash(), base)
+	assert.Equal(t, 2, signed)
+	assert.Equal(t, 1, unsigned)
+}
+
+func TestPrePush_SigningAbort_LeavesLocalUnchanged(t *testing.T) { //nolint:paralleltest // t.Chdir + signCommitForPush global
+	dir := t.TempDir()
+	bareRemote := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.InitBareRepo(t, bareRemote)
+	testutil.AddRemote(t, dir, "origin", bareRemote)
+	_, _ = setupChainOfUnsignedCommits(t, dir, 2)
+
+	prevSign := signCommitForPush
+	signCommitForPush = func(_ context.Context, _ *object.Commit) error {
+		return errors.New("agent down")
+	}
+	t.Cleanup(func() { signCommitForPush = prevSign })
+
+	prevPrompt := promptOnSigningFailure
+	promptOnSigningFailure = func(_ context.Context, _ string, _ error, _ io.Writer) signingAction {
+		return signingActionAbort
+	}
+	t.Cleanup(func() { promptOnSigningFailure = prevPrompt })
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	refs := checkpoint.DefaultV1Refs()
+	tipBefore, err := repo.Reference(refs.Primary, true)
+	require.NoError(t, err)
+
+	t.Chdir(dir)
+	s := &ManualCommitStrategy{}
+	require.Error(t, s.PrePush(context.Background(), "origin"))
+
+	tipAfter, err := repo.Reference(refs.Primary, true)
+	require.NoError(t, err)
+	assert.Equal(t, tipBefore.Hash(), tipAfter.Hash(), "local ref must not advance on abort")
+}
+
+// writeDisabledSigningSettings writes a settings file disabling signing into dir/.entire/settings.json.
+func writeDisabledSigningSettings(t *testing.T, dir string) {
+	t.Helper()
+	entireDir := filepath.Join(dir, ".entire")
+	require.NoError(t, os.MkdirAll(entireDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(entireDir, "settings.json"), []byte(`{"sign_checkpoint_commits": false}`), 0o644))
 }

--- a/cmd/entire/cli/testutil/testutil.go
+++ b/cmd/entire/cli/testutil/testutil.go
@@ -294,3 +294,26 @@ func IsolateGitConfigEnv(t *testing.T) {
 func isGitConfigEnv(e string) bool {
 	return strings.HasPrefix(e, "GIT_CONFIG_")
 }
+
+// InitBareRepo runs git init --bare in dir, suitable as a push target.
+func InitBareRepo(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init", "--bare", dir) //nolint:noctx // test helper, no context needed
+	cmd.Env = GitIsolatedEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git init --bare failed: %v\n%s", err, out)
+	}
+}
+
+// AddRemote runs git remote add <name> <url> inside dir.
+func AddRemote(t *testing.T, dir, name, url string) {
+	t.Helper()
+	cmd := exec.Command("git", "remote", "add", name, url) //nolint:noctx // test helper, no context needed
+	cmd.Dir = dir
+	cmd.Env = GitIsolatedEnv()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git remote add failed: %v\n%s", err, out)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/537
<!-- entire-trail-link-end -->

 ## Summary

  Defer GPG/SSH signing of checkpoint commits from creation time to push time. During an agent session, checkpoint commits accumulate
  unsigned on the local `entire/checkpoints/v1` ref — no GPG agent calls per step. At pre-push, every local-only commit is cherry-picked
  onto the remote tip with strict signing, with a visible per-commit progress line and an interactive retry/skip/abort prompt on failure.

  ## Why

  - **Performance:** active sessions create many checkpoint commits; the per-step `SignCommitBestEffort` round-trip to the GPG/SSH agent
  dominated commit latency.
  - **Visibility:** signing was silent — users couldn't tell when the agent was being invoked or which commit it was signing.
  - **Correctness:** local-only checkpoints don't need signatures; only what leaves the machine.

  ## What changes

  - `CreateCommit` and the orphan metadata-branch init no longer sign.
  - `createCherryPickCommit` is split into `buildCherryPickCommit` + `persistCherryPickCommit` so a new push-time loop can sign each
  cherry-picked clone between build and persist.
  - New strict `SignCommit(ctx, commit) error` alongside the existing `SignCommitBestEffort` (now a logging wrapper). `ErrSigningDisabled`
  sentinel.
  - `PrePush` fetches the remote tip into the appropriate ref (temp ref for URL targets), runs the sign-loop over local-only commits,
  advances the local ref to the new signed tip, then pushes. On any abort the local ref stays untouched.
  - Cross-clone safety: empty-tree orphans are filtered out, and tree construction uses diff-based application (mirroring `cherryPickOnto`)
   so per-clone files accumulate onto the remote tip rather than overwriting it.

  ## UX

  [entire] Fetching latest from remote...
  [entire] Signing commits:
          10/10: Finalize transcript for Checkpoint: 17d941007e3b
  [entire] Pushing entire/checkpoints/v1 to checkpoint remote... done

  - TTY: a static header and a single status line that rewrites in place — no scrollback noise.
  - Non-TTY (CI): one line per commit, preserved for the audit trail.
  - Signing failure: `Retry, skip, or abort? [r/s/a]:`. Non-TTY defaults to skip (with a `logging.Warn`).
  - Setting: `sign_checkpoint_commits` (default `true`) gates the whole loop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes when and how metadata refs are rewritten before push (cherry-pick, ref advance, cross-clone filtering); signing failures can block push or leave unsigned commits on the chain.
> 
> **Overview**
> **Checkpoint commit signing moves from per-step creation to pre-push**, so local `entire/checkpoints/v1` history stays unsigned during sessions and only commits that will leave the machine are signed.
> 
> `CreateCommit` and orphan metadata ref init **no longer call the signer**. Signing is centralized in a new strict `SignCommit` (returns `ErrSigningDisabled` and propagates signer errors); `SignCommitBestEffort` is a thin logging wrapper. Cherry-pick helpers split into **`buildCherryPickCommit` / `persistCherryPickCommit`** so push can sign between build and store.
> 
> **`PrePush`** runs **`signLocalCommitsForPush`** before each checkpoint ref push: fetch remote tip, collect local-only commits (`collectCommitsSince` now supports `exclude == ZeroHash`), optionally drop empty-tree orphan dupes on cross-clone pushes, then **`signAndPersistCommits`** (diff-based cherry-pick + per-commit signing, TTY progress, retry/skip/abort on failure). Abort leaves the local ref unchanged; signing off via `sign_checkpoint_commits` skips the loop. Metadata reconcile still uses best-effort signing on its cherry-pick path.
> 
> Tests cover unsigned `CreateCommit`, strict `SignCommit`, and end-to-end pre-push signing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d3e845e6aaaaade398400d047b9de0ba655d38. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->