### PR TITLE
Centralize huh form accessibility behavior

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_reset.go
+++ b/cmd/entire/cli/strategy/manual_commit_reset.go
@@ -4,18 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 
 	"github.com/go-git/go-git/v6/plumbing"
 )
-
-// isAccessibleMode returns true if accessibility mode should be enabled.
-// This checks the ACCESSIBLE environment variable.
-func isAccessibleMode() bool {
-	return os.Getenv("ACCESSIBLE") != ""
-}
 
 // Reset deletes the shadow branch and session state for the current HEAD.
 // This allows starting fresh without existing checkpoints.

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -20,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
+	"github.com/entireio/cli/cmd/entire/cli/uiform"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
 
 	"charm.land/huh/v2"
@@ -979,16 +980,13 @@ func PromptOverwriteNewerLogs(errW io.Writer, sessions []SessionRestoreInfo) (bo
 	fmt.Fprintf(errW, "\nOverwriting will lose the newer local entries.\n\n")
 
 	var confirmed bool
-	form := huh.NewForm(
+	form := uiform.New(
 		huh.NewGroup(
 			huh.NewConfirm().
 				Title("Overwrite local session logs with checkpoint versions?").
 				Value(&confirmed),
 		),
 	)
-	if isAccessibleMode() {
-		form = form.WithAccessible(true)
-	}
 
 	if err := form.Run(); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) {

--- a/cmd/entire/cli/uiform/uiform_test.go
+++ b/cmd/entire/cli/uiform/uiform_test.go
@@ -1,0 +1,64 @@
+package uiform
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProductionFormsUseUIFormHelper(t *testing.T) {
+	t.Parallel()
+
+	root := findRepoRoot(t)
+	cliDir := filepath.Join(root, "cmd", "entire", "cli")
+	allowed := filepath.ToSlash(filepath.Join("cmd", "entire", "cli", "uiform", "uiform.go"))
+
+	err := filepath.WalkDir(cliDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(string(data), "huh.NewForm(") {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if filepath.ToSlash(rel) != allowed {
+			t.Errorf("%s uses huh.NewForm directly; use uiform.New instead", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk CLI files: %v", err)
+	}
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find repo root from %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/cmd/entire/cli/versioncheck/autoupdate.go
+++ b/cmd/entire/cli/versioncheck/autoupdate.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/uiform"
 )
 
 // envKillSwitch disables the interactive update prompt regardless of TTY.
@@ -114,10 +115,7 @@ func realChooseUpdate(ctx context.Context, currentVersion, latestVersion, cmdStr
 			huh.NewOption("Skip until next version", autoUpdateActionSkipUntilNextVersion),
 		).
 		Value(&action)
-	form := huh.NewForm(huh.NewGroup(sel)).WithTheme(huh.ThemeFunc(huh.ThemeDracula))
-	if os.Getenv("ACCESSIBLE") != "" {
-		form = form.WithAccessible(true)
-	}
+	form := uiform.New(huh.NewGroup(sel))
 	if err := form.RunWithContext(ctx); err != nil {
 		if errors.Is(err, huh.ErrUserAborted) || errors.Is(err, huh.ErrTimeout) {
 			return autoUpdateActionSkip, nil


### PR DESCRIPTION
## Summary
- Route remaining production huh form construction through the shared uiform helper
- Remove the strategy-local accessibility helper now that uiform owns the behavior
- Keep accessibility handling consistent for future form additions

## Problem
The CLI documents ACCESSIBLE-mode support for huh prompts, but some production form construction still bypassed the shared uiform path. That creates drift risk: a new or modified prompt can accidentally miss the standard theme/accessibility behavior.

## Fix
Use uiform.New for the remaining form call sites and keep uiform.IsAccessibleMode available for non-form callers. This keeps the production path centralized without adding new abstractions.

## Verification
- go test ./cmd/entire/cli/uiform ./cmd/entire/cli/versioncheck ./cmd/entire/cli/strategy
- mise run check lint phase passed

## Known gap
Full mise run check is blocked by the existing TestRunAuthStatus_RendersSessionsTable date expectation, unrelated to this change.
