### PR TITLE
[bug]Preserve Claude subagent token totals during condensation

### DIFF
--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -462,6 +462,13 @@ func (s *ManualCommitStrategy) extractOrCreateSessionData(ctx context.Context, r
 	}
 }
 
+func subagentsDirForTranscript(transcriptPath, sessionID string) string {
+	if transcriptPath == "" || sessionID == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(transcriptPath), sessionID, "subagents")
+}
+
 // generateSummary produces an LLM-generated summary of the session transcript.
 // The transcript must be pre-redacted to avoid sending secrets to the LLM.
 // Returns nil if the scoped transcript is empty or generation fails.
@@ -898,7 +905,8 @@ func (s *ManualCommitStrategy) extractSessionData(ctx context.Context, repo *git
 	// extract them from offset 0; consumers can filter by checkpoint_transcript_start
 	// if they only render the checkpoint-scoped slice.
 	if len(data.Transcript) > 0 {
-		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, checkpointTranscriptStart, "") //TODO: why do we not use here subagents dir?
+		subagentsDir := subagentsDirForTranscript(liveTranscriptPath, sessionID)
+		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, checkpointTranscriptStart, subagentsDir)
 		data.SkillEvents = agent.ExtractSkillEvents(ctx, ag, data.Transcript, 0)
 	}
 
@@ -940,7 +948,8 @@ func (s *ManualCommitStrategy) extractSessionDataFromLiveTranscript(ctx context.
 	// extract them from offset 0; consumers can filter by checkpoint_transcript_start
 	// if they only render the checkpoint-scoped slice.
 	if len(data.Transcript) > 0 {
-		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, state.CheckpointTranscriptStart, "") //TODO: why do we not use here subagents dir?
+		subagentsDir := subagentsDirForTranscript(transcriptPath, state.SessionID)
+		data.TokenUsage = agent.CalculateTokenUsage(ctx, ag, data.Transcript, state.CheckpointTranscriptStart, subagentsDir)
 		data.SkillEvents = agent.ExtractSkillEvents(ctx, ag, data.Transcript, 0)
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/entireio/cli/cmd/entire/cli/agent/claudecode"
 )
 
 const testTrailerCheckpointID id.CheckpointID = "a1b2c3d4e5f6"
@@ -3321,6 +3323,65 @@ func TestCondenseSession_TranscriptRelocatedMidSession(t *testing.T) {
 	if state.TranscriptPath != nestedPath {
 		t.Errorf("state.TranscriptPath = %q, want %q (should be updated after re-resolution)", state.TranscriptPath, nestedPath)
 	}
+}
+
+func TestCondenseSession_ClaudeSubagentTokenUsage(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "README.md", "initial\n")
+	testutil.GitAdd(t, dir, "README.md")
+	testutil.GitCommit(t, dir, "initial")
+	t.Chdir(dir)
+
+	sessionID := "2026-06-09-claude-subagent-token"
+	transcriptDir := filepath.Join(dir, ".claude", "transcripts")
+	transcriptPath := filepath.Join(transcriptDir, "main.jsonl")
+	subagentsDir := filepath.Join(transcriptDir, sessionID, "subagents")
+	require.NoError(t, os.MkdirAll(subagentsDir, 0o755))
+
+	mainTranscript := strings.Join([]string{
+		`{"type":"assistant","uuid":"a-main","message":{"id":"msg_main","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_task1","name":"Task","input":{"description":"write helper","prompt":"write helper"}}],"usage":{"input_tokens":100,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":10}}}`,
+		`{"type":"user","uuid":"u-main","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_task1","content":"agentId: sub1"}]}}`,
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(mainTranscript), 0o644))
+
+	subagentTranscript := `{"type":"assistant","uuid":"a-sub","message":{"id":"msg_sub","type":"message","role":"assistant","content":[{"type":"text","text":"wrote helper"}],"usage":{"input_tokens":200,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":20}}}` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(subagentsDir, "agent-sub1.jsonl"), []byte(subagentTranscript), 0o644))
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	head, err := repo.Head()
+	require.NoError(t, err)
+	initialHash := head.Hash().String()
+
+	state := &SessionState{
+		SessionID:                 sessionID,
+		BaseCommit:                initialHash,
+		AttributionBaseCommit:     initialHash,
+		WorktreePath:              dir,
+		TranscriptPath:            transcriptPath,
+		FilesTouched:              []string{"helper.go"},
+		AgentType:                 agent.AgentTypeClaudeCode,
+		ModelName:                 "claude-sonnet-repro",
+		CheckpointTranscriptStart: 0,
+	}
+
+	s := &ManualCommitStrategy{}
+	checkpointID := id.MustCheckpointID("dd11cc22bb33")
+	_, err = s.CondenseSession(context.Background(), repo, checkpointID, state, nil)
+	require.NoError(t, err)
+
+	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
+	content, err := store.ReadLatestSessionContent(t.Context(), checkpointID)
+	require.NoError(t, err)
+
+	require.NotNil(t, content.Metadata.TokenUsage, "TokenUsage should be persisted")
+	assert.Equal(t, 100, content.Metadata.TokenUsage.InputTokens)
+	assert.Equal(t, 10, content.Metadata.TokenUsage.OutputTokens)
+	require.NotNil(t, content.Metadata.TokenUsage.SubagentTokens, "SubagentTokens should survive condensation")
+	assert.Equal(t, 200, content.Metadata.TokenUsage.SubagentTokens.InputTokens)
+	assert.Equal(t, 20, content.Metadata.TokenUsage.SubagentTokens.OutputTokens)
+	assert.Equal(t, 1, content.Metadata.TokenUsage.SubagentTokens.APICallCount)
 }
 
 // TestCondenseSession_GeminiTranscript verifies that CondenseSession works correctly


### PR DESCRIPTION
Entire Logs: https://entire.io/gh/stale2000/cli/session/019eaa64-5270-74c0-9f8a-e4df88c7014e
SUMMARY:
After finding and making the fix, I noticed the log saying that the "bug" might be intentional?  Or it is unknown why it is written this way?  

I did an analysis as for why it might have been written this way and got the following response that implies that its indeed a bug, and the previous implementation didn't know how to solve it.  But this PR does fix the issue.  

Explanation/response to the TODO statement:
"
So the nuanced answer is:

For live transcript condensation: bug.
For shadow-only fallback with no live path: empty dir may be unavoidable.
The TODO was probably someone noticing the bug-prone gap during cleanup but not resolving the live-vs-shadow distinction.
Our fix handles exactly that: derive the dir when a live transcript path exists, otherwise helper returns "".
"


## Summary

This fixes a metadata loss bug in checkpoint condensation for Claude Code sessions that spawn Task subagents.

Before this change, live session handling could see subagent token usage, but the later condensation step recalculated token usage without passing the session's subagent transcript directory. As a result, `SubagentTokens` were silently dropped from the committed checkpoint metadata written to `entire/checkpoints/v1`.

## Issue

Claude Code stores Task subagent transcripts separately from the main transcript:

```text
<transcriptDir>/<sessionID>/subagents/agent-<agentID>.jsonl
```

The lifecycle path already knows that convention and passes the subagent directory into token/file extraction. Condensation did not. Both condensation paths called:

```go
agent.CalculateTokenUsage(ctx, ag, data.Transcript, checkpointTranscriptStart, "")
```

For subagent-aware agents, the empty directory intentionally disables subagent transcript reads. That means the main transcript token totals survived, but spawned subagent token totals disappeared when checkpoint metadata was committed.

## How to reproduce

One reproducible shape is:

1. Enable Entire in a repo and start a Claude Code session.
2. Have Claude invoke the `Task` tool so the main transcript contains a Task `tool_use` and a corresponding `tool_result` with an `agentId`, for example `agentId: sub1`.
3. Ensure the subagent transcript exists at:

   ```text
   <main-transcript-dir>/<sessionID>/subagents/agent-sub1.jsonl
   ```

   and contains assistant usage metadata.
4. Let the normal stop hook run. At this point live session state can include subagent token usage because the lifecycle path passes the subagent directory.
5. Make a user commit so the post-commit hook condenses the session into committed checkpoint metadata.
6. Inspect the committed checkpoint metadata from `entire/checkpoints/v1`.

Before this fix, the condensed checkpoint metadata had main token usage but no `subagent_tokens` field, even though the subagent transcript was present and readable.

The added regression test builds that shape directly: a main Claude transcript with a Task result referencing `sub1`, a matching `agent-sub1.jsonl` subagent transcript, and a condensation call that verifies `SubagentTokens` survive in committed metadata.

## Impact

This affects checkpoint metadata for Claude Code sessions that use Task subagents.

Observed effects:

- `entire/checkpoints/v1` underreports total work done by spawned subagents.
- Later checkpoint consumers such as activity, explain/status views, or metadata sync consumers cannot recover those subagent token totals from the committed metadata.
- The bug is silent: checkpoint writes succeed, but the committed metadata is incomplete.

The code path is shared through the `SubagentAwareExtractor` token interface, so passing the directory also keeps condensation aligned with other subagent-aware implementations that use the same transcript layout convention.

## Fix

- Add `subagentsDirForTranscript(transcriptPath, sessionID)` in the strategy package.
- Pass the derived subagent directory into `agent.CalculateTokenUsage` from both condensation paths:
  - shadow-branch extraction with live-transcript preference
  - direct live-transcript extraction
- Add `TestCondenseSession_ClaudeSubagentTokenUsage` to lock the end-to-end condensation behavior.

## Verification

```text
go test ./cmd/entire/cli/strategy -run 'TestCondenseSession' -count=1
go test ./cmd/entire/cli/agent/claudecode -run 'TestCalculateTotalTokenUsage|TestExtractAllModifiedFiles' -count=1
mise run lint
```
