### PR TITLE
search: support all result types and align CLI with UI

### DIFF
--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -24,14 +24,28 @@ const WildcardQuery = "*"
 // AllReposFilter is the inline repo filter value that disables repo scoping.
 const AllReposFilter = "*"
 
+// Result type constants.
+const (
+	TypeCheckpoint = "checkpoint"
+	TypeCommit     = "commit"
+	TypeSession    = "session"
+)
+
 // MaxLimit is the maximum number of results the search API will return per request.
 const MaxLimit = 200
 
+// DefaultLimit is the default number of results to fetch per request, matching the UI.
+const DefaultLimit = 100
+
 // Meta contains search ranking metadata for a result.
 type Meta struct {
-	MatchType string  `json:"matchType"`
-	Score     float64 `json:"score"`
-	Snippet   string  `json:"snippet,omitempty"`
+	MatchType string   `json:"matchType"`
+	Score     float64  `json:"score"`
+	Tier      *int     `json:"tier,omitempty"`
+	Snippet   string   `json:"snippet,omitempty"`
+	Summary   string   `json:"summary,omitempty"`
+	BM25Score *float64 `json:"bm25Score,omitempty"`
+	ANNScore  *float64 `json:"annScore,omitempty"`
 }
 
 // CheckpointResult represents a checkpoint returned by the search service.
@@ -39,6 +53,7 @@ type CheckpointResult struct {
 	ID             string   `json:"id"`
 	Prompt         string   `json:"prompt"`
 	CommitMessage  *string  `json:"commitMessage"`
+	CommitSubject  *string  `json:"commitSubject"`
 	CommitSHA      *string  `json:"commitSha"`
 	Branch         string   `json:"branch"`
 	Org            string   `json:"org"`
@@ -49,19 +64,293 @@ type CheckpointResult struct {
 	FilesTouched   []string `json:"filesTouched"`
 }
 
+// CommitResult represents a commit returned by the search service.
+type CommitResult struct {
+	ID             string  `json:"id"`
+	CommitSHA      string  `json:"commitSha"`
+	CommitMessage  string  `json:"commitMessage"`
+	CommitSubject  string  `json:"commitSubject"`
+	Branch         string  `json:"branch"`
+	Org            string  `json:"org"`
+	Repo           string  `json:"repo"`
+	Author         string  `json:"author"`
+	AuthorUsername *string `json:"authorUsername"`
+	CreatedAt      string  `json:"createdAt"`
+	Additions      int     `json:"additions"`
+	Deletions      int     `json:"deletions"`
+	FilesChanged   int     `json:"filesChanged"`
+	HTMLUrl        *string `json:"htmlUrl"`
+}
+
+// SessionResult represents a session returned by the search service.
+type SessionResult struct {
+	SessionID      string  `json:"sessionId"`
+	DisplayName    string  `json:"displayName"`
+	Prompt         *string `json:"prompt"`
+	Agent          *string `json:"agent"`
+	Model          *string `json:"model"`
+	StepCount      int     `json:"stepCount"`
+	Org            string  `json:"org"`
+	Repo           string  `json:"repo"`
+	Branch         *string `json:"branch"`
+	AuthorUsername *string `json:"authorUsername"`
+	CreatedAt      string  `json:"createdAt"`
+}
+
 // Result wraps a search result with its type and ranking metadata.
+// Exactly one of Checkpoint, Commit, or Session is non-nil based on Type.
 type Result struct {
-	Type string           `json:"type"`
-	Data CheckpointResult `json:"data"`
-	Meta Meta             `json:"searchMeta"`
+	Type       string            `json:"-"`
+	Meta       Meta              `json:"-"`
+	Checkpoint *CheckpointResult `json:"-"`
+	Commit     *CommitResult     `json:"-"`
+	Session    *SessionResult    `json:"-"`
+
+	// rawData preserves the original JSON for unknown types (repo, pr)
+	rawData json.RawMessage
+}
+
+// resultJSON is the wire format for JSON marshaling/unmarshaling.
+type resultJSON struct {
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+	Meta Meta            `json:"searchMeta"`
+}
+
+// MarshalJSON implements custom JSON marshaling to produce the API wire format.
+func (r *Result) MarshalJSON() ([]byte, error) {
+	var data any
+	switch r.Type {
+	case TypeCheckpoint:
+		data = r.Checkpoint
+	case TypeCommit:
+		data = r.Commit
+	case TypeSession:
+		data = r.Session
+	default:
+		data = r.rawData
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling result data: %w", err)
+	}
+	out, err := json.Marshal(resultJSON{
+		Type: r.Type,
+		Data: raw,
+		Meta: r.Meta,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling result: %w", err)
+	}
+	return out, nil
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling to parse typed data.
+func (r *Result) UnmarshalJSON(b []byte) error {
+	var raw resultJSON
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return fmt.Errorf("unmarshaling result: %w", err)
+	}
+	r.Type = raw.Type
+	r.Meta = raw.Meta
+	r.rawData = raw.Data
+
+	switch raw.Type {
+	case TypeCheckpoint:
+		var d CheckpointResult
+		if err := json.Unmarshal(raw.Data, &d); err != nil {
+			return fmt.Errorf("unmarshaling checkpoint data: %w", err)
+		}
+		r.Checkpoint = &d
+	case TypeCommit:
+		var d CommitResult
+		if err := json.Unmarshal(raw.Data, &d); err != nil {
+			return fmt.Errorf("unmarshaling commit data: %w", err)
+		}
+		r.Commit = &d
+	case TypeSession:
+		var d SessionResult
+		if err := json.Unmarshal(raw.Data, &d); err != nil {
+			return fmt.Errorf("unmarshaling session data: %w", err)
+		}
+		r.Session = &d
+	}
+	return nil
+}
+
+// ResultOrg returns the org for any result type.
+func (r *Result) ResultOrg() string {
+	switch r.Type {
+	case TypeCheckpoint:
+		if r.Checkpoint != nil {
+			return r.Checkpoint.Org
+		}
+	case TypeCommit:
+		if r.Commit != nil {
+			return r.Commit.Org
+		}
+	case TypeSession:
+		if r.Session != nil {
+			return r.Session.Org
+		}
+	}
+	return ""
+}
+
+// ResultRepo returns the repo for any result type.
+func (r *Result) ResultRepo() string {
+	switch r.Type {
+	case TypeCheckpoint:
+		if r.Checkpoint != nil {
+			return r.Checkpoint.Repo
+		}
+	case TypeCommit:
+		if r.Commit != nil {
+			return r.Commit.Repo
+		}
+	case TypeSession:
+		if r.Session != nil {
+			return r.Session.Repo
+		}
+	}
+	return ""
+}
+
+// ResultBranch returns the branch for any result type.
+func (r *Result) ResultBranch() string {
+	switch r.Type {
+	case TypeCheckpoint:
+		if r.Checkpoint != nil {
+			return r.Checkpoint.Branch
+		}
+	case TypeCommit:
+		if r.Commit != nil {
+			return r.Commit.Branch
+		}
+	case TypeSession:
+		if r.Session != nil && r.Session.Branch != nil {
+			return *r.Session.Branch
+		}
+	}
+	return ""
+}
+
+// ResultCreatedAt returns the createdAt for any result type.
+func (r *Result) ResultCreatedAt() string {
+	switch r.Type {
+	case TypeCheckpoint:
+		if r.Checkpoint != nil {
+			return r.Checkpoint.CreatedAt
+		}
+	case TypeCommit:
+		if r.Commit != nil {
+			return r.Commit.CreatedAt
+		}
+	case TypeSession:
+		if r.Session != nil {
+			return r.Session.CreatedAt
+		}
+	}
+	return ""
+}
+
+// ResultAuthor returns the display author for any result type.
+func (r *Result) ResultAuthor() string {
+	switch r.Type {
+	case TypeCheckpoint:
+		if r.Checkpoint != nil {
+			if r.Checkpoint.AuthorUsername != nil && *r.Checkpoint.AuthorUsername != "" {
+				return *r.Checkpoint.AuthorUsername
+			}
+			return r.Checkpoint.Author
+		}
+	case TypeCommit:
+		if r.Commit != nil {
+			if r.Commit.AuthorUsername != nil && *r.Commit.AuthorUsername != "" {
+				return *r.Commit.AuthorUsername
+			}
+			return r.Commit.Author
+		}
+	case TypeSession:
+		if r.Session != nil {
+			if r.Session.AuthorUsername != nil {
+				return *r.Session.AuthorUsername
+			}
+		}
+	}
+	return ""
+}
+
+// ResultID returns the primary ID for any result type.
+func (r *Result) ResultID() string {
+	switch r.Type {
+	case TypeCheckpoint:
+		if r.Checkpoint != nil {
+			return r.Checkpoint.ID
+		}
+	case TypeCommit:
+		if r.Commit != nil {
+			return r.Commit.CommitSHA
+		}
+	case TypeSession:
+		if r.Session != nil {
+			return r.Session.SessionID
+		}
+	}
+	return ""
+}
+
+// ResultTitle returns the primary display text for any result type.
+func (r *Result) ResultTitle() string {
+	switch r.Type {
+	case TypeCheckpoint:
+		if r.Checkpoint != nil {
+			return r.Checkpoint.Prompt
+		}
+	case TypeCommit:
+		if r.Commit != nil {
+			if r.Commit.CommitSubject != "" {
+				return r.Commit.CommitSubject
+			}
+			return r.Commit.CommitMessage
+		}
+	case TypeSession:
+		if r.Session != nil {
+			return r.Session.DisplayName
+		}
+	}
+	return ""
+}
+
+// TypeCounts holds per-type result counts.
+type TypeCounts struct {
+	Repos       int `json:"repos"`
+	Checkpoints int `json:"checkpoints"`
+	Commits     int `json:"commits"`
+	PRs         int `json:"prs"`
+	Sessions    int `json:"sessions"`
+}
+
+// Timing holds search performance timing data.
+type Timing struct {
+	TotalMs            *float64 `json:"total_ms"`
+	KeywordMs          *float64 `json:"keyword_ms"`
+	EmbeddingMs        *float64 `json:"embedding_ms"`
+	VectorMs           *float64 `json:"vector_ms"`
+	RerankMs           *float64 `json:"rerank_ms"`
+	FanoutMs           *float64 `json:"fanout_ms"`
+	SessionHydrationMs *float64 `json:"session_hydration_ms"`
 }
 
 // Response is the search service response.
 type Response struct {
-	Results []Result `json:"results"`
-	Total   int      `json:"total"`
-	Page    int      `json:"page"`
-	Error   string   `json:"error,omitempty"`
+	Results  []Result    `json:"results"`
+	Total    int         `json:"total"`
+	Page     int         `json:"page"`
+	Error    string      `json:"error,omitempty"`
+	Timing   *Timing     `json:"timing,omitempty"`
+	Reranked *bool       `json:"reranked,omitempty"`
+	Counts   *TypeCounts `json:"counts,omitempty"`
 }
 
 // Config holds the configuration for a search request.
@@ -71,6 +360,7 @@ type Config struct {
 	Owner       string
 	Repo        string
 	Repos       []string
+	AllRepos    bool // When true, search all accessible repos (no repo scoping)
 	Query       string
 	Limit       int
 	Author      string // Filter by author name
@@ -244,15 +534,15 @@ func Search(ctx context.Context, cfg Config) (*Response, error) {
 	if err := ValidateRepoFilters(cfg.Repos); err != nil {
 		return nil, err
 	}
-	allRepos := len(cfg.Repos) == 1 && cfg.Repos[0] == AllReposFilter
+	allRepos := cfg.AllRepos || (len(cfg.Repos) == 1 && cfg.Repos[0] == AllReposFilter)
 	if len(cfg.Repos) > 0 && !allRepos {
 		for _, repo := range cfg.Repos {
 			q.Add("repo", repo)
 		}
-	} else if len(cfg.Repos) == 0 && cfg.Owner != "" && cfg.Repo != "" {
+	} else if !allRepos && cfg.Owner != "" && cfg.Repo != "" {
 		q.Set("repo", cfg.Owner+"/"+cfg.Repo)
 	}
-	q.Set("types", "checkpoints")
+	// Don't set types — let the API return all types (checkpoints, commits, sessions, etc.)
 	if cfg.Limit > 0 {
 		q.Set("limit", strconv.Itoa(cfg.Limit))
 	}

--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -305,6 +305,14 @@ func (r *Result) ResultTitle() string {
 	switch r.Type {
 	case TypeCheckpoint:
 		if r.Checkpoint != nil {
+			// Prefer the commit title over the prompt; fall back to the prompt
+			// for uncommitted checkpoints. The full prompt remains in the detail view.
+			if r.Checkpoint.CommitSubject != nil && *r.Checkpoint.CommitSubject != "" {
+				return *r.Checkpoint.CommitSubject
+			}
+			if r.Checkpoint.CommitMessage != nil && *r.Checkpoint.CommitMessage != "" {
+				return *r.Checkpoint.CommitMessage
+			}
 			return r.Checkpoint.Prompt
 		}
 	case TypeCommit:

--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -154,6 +154,9 @@ func (r *Result) UnmarshalJSON(b []byte) error {
 	r.Type = raw.Type
 	r.Meta = raw.Meta
 	r.rawData = raw.Data
+	// Clear any previously-decoded payloads so a reused Result keeps the
+	// "exactly one typed pointer is non-nil" invariant.
+	r.Checkpoint, r.Commit, r.Session = nil, nil, nil
 
 	switch raw.Type {
 	case TypeCheckpoint:
@@ -379,7 +382,7 @@ type Config struct {
 
 // HasFilters reports whether any filter fields are set on the config.
 func (c Config) HasFilters() bool {
-	return c.Author != "" || c.Date != "" || c.Branch != "" || len(c.Repos) > 0
+	return c.Author != "" || c.Date != "" || c.Branch != "" || len(c.Repos) > 0 || c.AllRepos
 }
 
 // ParsedInput holds the parsed query and optional filters extracted from search input.
@@ -543,11 +546,25 @@ func Search(ctx context.Context, cfg Config) (*Response, error) {
 		return nil, err
 	}
 	allRepos := cfg.AllRepos || (len(cfg.Repos) == 1 && cfg.Repos[0] == AllReposFilter)
-	if len(cfg.Repos) > 0 && !allRepos {
-		for _, repo := range cfg.Repos {
-			q.Add("repo", repo)
+	hasExplicitRepo := false
+	for _, repo := range cfg.Repos {
+		if repo != AllReposFilter {
+			hasExplicitRepo = true
+			break
 		}
-	} else if !allRepos && cfg.Owner != "" && cfg.Repo != "" {
+	}
+	switch {
+	case hasExplicitRepo:
+		// An explicit owner/name filter always scopes the search, even when
+		// --all-repos is also set (the more specific filter wins).
+		for _, repo := range cfg.Repos {
+			if repo != AllReposFilter {
+				q.Add("repo", repo)
+			}
+		}
+	case allRepos:
+		// No repo scoping — search every accessible repo.
+	case cfg.Owner != "" && cfg.Repo != "":
 		q.Set("repo", cfg.Owner+"/"+cfg.Repo)
 	}
 	// Don't set types — let the API return all types (checkpoints, commits, sessions, etc.)

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -11,6 +11,13 @@ import (
 
 const testOwner = "entirehq"
 const testRepo = "entire.io"
+const testCPID = "cp1"
+
+// writeTestJSON writes raw JSON to a response writer, ignoring write errors (test helper).
+func writeTestJSON(w http.ResponseWriter, jsonStr string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(jsonStr)) //nolint:errcheck // test helper
+}
 
 // -- ParseGitHubRemote tests --
 
@@ -133,8 +140,9 @@ func TestSearch_URLConstruction(t *testing.T) {
 	if capturedReq.URL.Query().Get("repo") != "myowner/myrepo" {
 		t.Errorf("repo = %s, want 'myowner/myrepo'", capturedReq.URL.Query().Get("repo"))
 	}
-	if capturedReq.URL.Query().Get("types") != "checkpoints" {
-		t.Errorf("types = %s, want 'checkpoints'", capturedReq.URL.Query().Get("types"))
+	// types param should NOT be set — the CLI now requests all types
+	if capturedReq.URL.Query().Has("types") {
+		t.Errorf("types param should not be set, got %q", capturedReq.URL.Query().Get("types"))
 	}
 	if capturedReq.URL.Query().Get("limit") != "10" {
 		t.Errorf("limit = %s, want '10'", capturedReq.URL.Query().Get("limit"))
@@ -301,28 +309,7 @@ func TestSearch_SuccessWithResults(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		resp := Response{
-			Results: []Result{
-				{
-					Type: "checkpoint",
-					Data: CheckpointResult{
-						ID:        "abc123def456",
-						Branch:    "main",
-						Prompt:    "add auth middleware",
-						Author:    "alice",
-						CreatedAt: "2026-01-13T12:00:00Z",
-					},
-					Meta: Meta{
-						Score:     0.042,
-						MatchType: "both",
-					},
-				},
-			},
-			Total: 1,
-			Page:  1,
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp) //nolint:errcheck // test helper response
+		writeTestJSON(w, `{"results":[{"type":"checkpoint","data":{"id":"abc123def456","branch":"main","prompt":"add auth middleware","author":"alice","createdAt":"2026-01-13T12:00:00Z","org":"","repo":"","filesTouched":[]},"searchMeta":{"score":0.042,"matchType":"both"}}],"total":1,"page":1}`)
 	}))
 	defer srv.Close()
 
@@ -339,11 +326,168 @@ func TestSearch_SuccessWithResults(t *testing.T) {
 	if len(resp.Results) != 1 {
 		t.Fatalf("got %d results, want 1", len(resp.Results))
 	}
-	if resp.Results[0].Data.ID != "abc123def456" {
-		t.Errorf("checkpoint id = %s, want abc123def456", resp.Results[0].Data.ID)
+	r := resp.Results[0]
+	if r.Type != TypeCheckpoint {
+		t.Errorf("type = %s, want checkpoint", r.Type)
 	}
-	if resp.Results[0].Meta.MatchType != "both" {
-		t.Errorf("matchType = %s, want both", resp.Results[0].Meta.MatchType)
+	if r.Checkpoint == nil {
+		t.Fatal("checkpoint data is nil")
+	}
+	if r.Checkpoint.ID != "abc123def456" {
+		t.Errorf("checkpoint id = %s, want abc123def456", r.Checkpoint.ID)
+	}
+	if r.Meta.MatchType != "both" {
+		t.Errorf("matchType = %s, want both", r.Meta.MatchType)
+	}
+}
+
+func TestSearch_SuccessWithMultipleTypes(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeTestJSON(w, `{"results":[{"type":"checkpoint","data":{"id":"cp1","prompt":"fix bug","branch":"main","org":"o","repo":"r","author":"alice","createdAt":"2026-01-13T12:00:00Z","filesTouched":[]},"searchMeta":{"matchType":"keyword","score":0.5}},{"type":"commit","data":{"id":"cm1","commitSha":"abc1234567890","commitMessage":"fix: auth bug","commitSubject":"fix: auth bug","branch":"main","org":"o","repo":"r","author":"bob","createdAt":"2026-01-14T12:00:00Z","additions":10,"deletions":5,"filesChanged":3},"searchMeta":{"matchType":"semantic","score":0.3}},{"type":"session","data":{"sessionId":"ss1","displayName":"Debug auth","org":"o","repo":"r","createdAt":"2026-01-15T12:00:00Z","stepCount":5},"searchMeta":{"matchType":"both","score":0.4}}],"total":3,"page":1,"counts":{"repos":0,"checkpoints":1,"commits":1,"prs":0,"sessions":1}}`)
+	}))
+	defer srv.Close()
+
+	resp, err := Search(context.Background(), Config{
+		ServiceURL:  srv.URL,
+		GitHubToken: "tok",
+		Owner:       "o",
+		Repo:        "r",
+		Query:       "auth",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("got %d results, want 3", len(resp.Results))
+	}
+
+	// Checkpoint
+	if resp.Results[0].Checkpoint == nil {
+		t.Fatal("result[0] checkpoint is nil")
+	}
+	if resp.Results[0].Checkpoint.ID != testCPID {
+		t.Errorf("checkpoint ID = %q", resp.Results[0].Checkpoint.ID)
+	}
+
+	// Commit
+	if resp.Results[1].Commit == nil {
+		t.Fatal("result[1] commit is nil")
+	}
+	if resp.Results[1].Commit.CommitSHA != "abc1234567890" {
+		t.Errorf("commit SHA = %q", resp.Results[1].Commit.CommitSHA)
+	}
+	if resp.Results[1].Commit.Additions != 10 {
+		t.Errorf("commit additions = %d", resp.Results[1].Commit.Additions)
+	}
+
+	// Session
+	if resp.Results[2].Session == nil {
+		t.Fatal("result[2] session is nil")
+	}
+	if resp.Results[2].Session.SessionID != "ss1" {
+		t.Errorf("session ID = %q", resp.Results[2].Session.SessionID)
+	}
+	if resp.Results[2].Session.StepCount != 5 {
+		t.Errorf("session steps = %d", resp.Results[2].Session.StepCount)
+	}
+
+	// Counts
+	if resp.Counts == nil {
+		t.Fatal("counts is nil")
+	}
+	if resp.Counts.Checkpoints != 1 || resp.Counts.Commits != 1 || resp.Counts.Sessions != 1 {
+		t.Errorf("counts = %+v", resp.Counts)
+	}
+}
+
+func TestSearch_ResultAccessors(t *testing.T) {
+	t.Parallel()
+
+	cp := Result{
+		Type:       TypeCheckpoint,
+		Checkpoint: &CheckpointResult{ID: testCPID, Org: "o", Repo: "r", Branch: "main", Author: "alice", CreatedAt: "2026-01-01T00:00:00Z", Prompt: "fix bug"},
+	}
+	if cp.ResultOrg() != "o" {
+		t.Errorf("ResultOrg = %q", cp.ResultOrg())
+	}
+	if cp.ResultTitle() != "fix bug" {
+		t.Errorf("ResultTitle = %q", cp.ResultTitle())
+	}
+	if cp.ResultID() != testCPID {
+		t.Errorf("ResultID = %q", cp.ResultID())
+	}
+
+	cm := Result{
+		Type:   TypeCommit,
+		Commit: &CommitResult{CommitSHA: "abc123", CommitSubject: "fix: bug", Org: "o", Repo: "r", Branch: "dev", Author: "bob"},
+	}
+	if cm.ResultTitle() != "fix: bug" {
+		t.Errorf("commit ResultTitle = %q", cm.ResultTitle())
+	}
+	if cm.ResultID() != "abc123" {
+		t.Errorf("commit ResultID = %q", cm.ResultID())
+	}
+
+	ss := Result{
+		Type:    TypeSession,
+		Session: &SessionResult{SessionID: "ss1", DisplayName: "Debug session", Org: "o", Repo: "r"},
+	}
+	if ss.ResultTitle() != "Debug session" {
+		t.Errorf("session ResultTitle = %q", ss.ResultTitle())
+	}
+	if ss.ResultID() != "ss1" {
+		t.Errorf("session ResultID = %q", ss.ResultID())
+	}
+}
+
+func TestSearch_ResultJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := Result{
+		Type: TypeCheckpoint,
+		Checkpoint: &CheckpointResult{
+			ID:        testCPID,
+			Prompt:    "fix bug",
+			Branch:    "main",
+			Org:       "o",
+			Repo:      "r",
+			Author:    "alice",
+			CreatedAt: "2026-01-01T00:00:00Z",
+		},
+		Meta: Meta{MatchType: "keyword", Score: 0.5},
+	}
+
+	data, err := json.Marshal(&original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify wire format has "type", "data", "searchMeta" keys
+	if !strings.Contains(string(data), `"type":"checkpoint"`) {
+		t.Errorf("JSON missing type: %s", data)
+	}
+	if !strings.Contains(string(data), `"data":{`) {
+		t.Errorf("JSON missing data: %s", data)
+	}
+	if !strings.Contains(string(data), `"searchMeta":{`) {
+		t.Errorf("JSON missing searchMeta: %s", data)
+	}
+
+	// Round-trip
+	var decoded Result
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Type != TypeCheckpoint {
+		t.Errorf("decoded type = %q", decoded.Type)
+	}
+	if decoded.Checkpoint == nil || decoded.Checkpoint.ID != testCPID {
+		t.Errorf("decoded checkpoint = %+v", decoded.Checkpoint)
+	}
+	if decoded.Meta.Score != 0.5 {
+		t.Errorf("decoded score = %f", decoded.Meta.Score)
 	}
 }
 
@@ -463,6 +607,35 @@ func TestSearch_AllReposFilterOmitsRepoParam(t *testing.T) {
 
 	if got := capturedReq.URL.Query()["repo"]; len(got) != 0 {
 		t.Errorf("repo params = %v, want omitted for all-repos search", got)
+	}
+}
+
+func TestSearch_AllReposFlagOmitsRepoParam(t *testing.T) {
+	t.Parallel()
+
+	var capturedReq *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		resp := Response{Results: []Result{}, Total: 0, Page: 1}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck // test helper response
+	}))
+	defer srv.Close()
+
+	_, err := Search(context.Background(), Config{
+		ServiceURL:  srv.URL,
+		GitHubToken: "tok",
+		Owner:       "default-owner",
+		Repo:        "default-repo",
+		Query:       "q",
+		AllRepos:    true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := capturedReq.URL.Query()["repo"]; len(got) != 0 {
+		t.Errorf("repo params = %v, want omitted for AllRepos=true", got)
 	}
 }
 

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -639,6 +639,38 @@ func TestSearch_AllReposFlagOmitsRepoParam(t *testing.T) {
 	}
 }
 
+func TestSearch_ExplicitRepoWinsOverAllRepos(t *testing.T) {
+	t.Parallel()
+
+	var capturedReq *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		resp := Response{Results: []Result{}, Total: 0, Page: 1}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck // test helper response
+	}))
+	defer srv.Close()
+
+	// --all-repos alongside an explicit owner/name filter must scope to the
+	// explicit repo (the more specific filter wins), not search all repos.
+	_, err := Search(context.Background(), Config{
+		ServiceURL:  srv.URL,
+		GitHubToken: "tok",
+		Owner:       "default-owner",
+		Repo:        "default-repo",
+		Query:       "q",
+		AllRepos:    true,
+		Repos:       []string{"owner/explicit"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := capturedReq.URL.Query()["repo"]; len(got) != 1 || got[0] != "owner/explicit" {
+		t.Errorf("repo params = %v, want [owner/explicit]", got)
+	}
+}
+
 func TestSearch_MultipleExplicitReposRejected(t *testing.T) {
 	t.Parallel()
 
@@ -762,6 +794,9 @@ func TestConfig_HasFilters(t *testing.T) {
 	}
 	if !(Config{Repos: []string{"entirehq/entire.io"}}).HasFilters() {
 		t.Error("config with Repos should have filters")
+	}
+	if !(Config{AllRepos: true}).HasFilters() {
+		t.Error("config with AllRepos should have filters")
 	}
 	if !(Config{Author: "alice", Date: testDateWeek}).HasFilters() {
 		t.Error("config with both should have filters")

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSearchCmd() *cobra.Command {
+func newSearchCmd() *cobra.Command { //nolint:maintidx // command wiring is inherently complex
 	var (
 		jsonOutput       bool
 		limitFlag        int
@@ -27,16 +27,20 @@ func newSearchCmd() *cobra.Command {
 		dateFlag         string
 		branchFlag       string
 		repoFlag         string
+		allReposFlag     bool
 		insecureHTTPAuth bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "search [query]",
-		Short: "Search checkpoints using semantic and keyword matching",
-		Long: `Search checkpoints using hybrid search (semantic + keyword),
+		Short: "Search checkpoints, commits, and sessions using semantic and keyword matching",
+		Long: `Search checkpoints, commits, and sessions using hybrid search (semantic + keyword),
 powered by the Entire search service.
 
 Requires authentication via 'entire login' (GitHub device flow).
+
+By default, results are scoped to the current repository. Use --all-repos to
+search across all accessible repos.
 
 Run without arguments to open an interactive search. Results are
 displayed in an interactive table. Use --json for machine-readable output.
@@ -67,6 +71,12 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			}
 			if err := search.ValidateRepoFilters(repos); err != nil {
 				return fmt.Errorf("validating repo filter: %w", err)
+			}
+
+			// Check for repo:* in inline filters
+			allRepos := allReposFlag
+			if len(repos) == 1 && repos[0] == search.AllReposFilter {
+				allRepos = true
 			}
 
 			w := cmd.OutOrStdout()
@@ -121,6 +131,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 				Owner:       owner,
 				Repo:        repoName,
 				Repos:       repos,
+				AllRepos:    allRepos,
 				Query:       query,
 				Limit:       limitFlag,
 				Page:        pageFlag,
@@ -136,7 +147,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 
 			// No query provided + interactive = open TUI with search bar focused
 			if query == "" && !searchCfg.HasFilters() {
-				searchCfg.Limit = search.MaxLimit
+				searchCfg.Limit = search.DefaultLimit
 				styles := newStatusStyles(w)
 				model := newSearchModel(nil, "", 0, searchCfg, styles)
 				model.mode = modeSearch
@@ -153,7 +164,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 			// the maximum and paginate client-side for all output modes.
 			requestedLimit := searchCfg.Limit
 			requestedPage := searchCfg.Page
-			searchCfg.Limit = search.MaxLimit
+			searchCfg.Limit = search.DefaultLimit
 			searchCfg.Page = 0 // let API default to page 1
 
 			resp, err := search.Search(ctx, searchCfg)
@@ -195,6 +206,7 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 	cmd.Flags().StringVar(&dateFlag, "date", "", "Filter by time period (week or month)")
 	cmd.Flags().StringVar(&branchFlag, "branch", "", "Filter by branch name")
 	cmd.Flags().StringVar(&repoFlag, "repo", "", "Filter by repository (owner/name or *)")
+	cmd.Flags().BoolVar(&allReposFlag, "all-repos", false, "Search all accessible repos instead of just the current one")
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
 
 	cmd.RegisterFlagCompletionFunc("date", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) { //nolint:errcheck,gosec // only fails if the flag isn't defined; defined directly above
@@ -280,17 +292,19 @@ func writeSearchJSON(w io.Writer, resp *search.Response, limit, page int) error 
 	}
 
 	out := struct {
-		Results    []search.Result `json:"results"`
-		Total      int             `json:"total"`
-		Page       int             `json:"page"`
-		TotalPages int             `json:"total_pages"`
-		Limit      int             `json:"limit"`
+		Results    []search.Result    `json:"results"`
+		Total      int                `json:"total"`
+		Page       int                `json:"page"`
+		TotalPages int                `json:"total_pages"`
+		Limit      int                `json:"limit"`
+		Counts     *search.TypeCounts `json:"counts,omitempty"`
 	}{
 		Results:    pageResults,
 		Total:      total,
 		Page:       page,
 		TotalPages: totalPages,
 		Limit:      limit,
+		Counts:     resp.Counts,
 	}
 	data, err := jsonutil.MarshalIndentWithNewline(out, "", "  ")
 	if err != nil {

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -81,7 +81,10 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 
 			w := cmd.OutOrStdout()
 			isTerminal := interactive.IsTerminalWriter(w)
-			hasFilters := authorFlag != "" || dateFlag != "" || branchFlag != "" || len(repos) > 0
+			// Mirror search.Config.HasFilters (incl. --all-repos) so an empty
+			// query with only filters isn't rejected here. This guard runs
+			// before git/auth, so it can't call searchCfg.HasFilters() directly.
+			hasFilters := authorFlag != "" || dateFlag != "" || branchFlag != "" || len(repos) > 0 || allRepos
 
 			// Fast-fail: no query + non-interactive mode = error (before auth/git checks)
 			if query == "" && !hasFilters && (jsonOutput || !isTerminal || IsAccessibleMode()) {

--- a/cmd/entire/cli/search_cmd.go
+++ b/cmd/entire/cli/search_cmd.go
@@ -159,9 +159,9 @@ branch:<name>, repo:<owner/name>, and repo:* to search all accessible repos.`,
 				return nil
 			}
 
-			// Fetch max results so client-side pagination works.
-			// The search API caps results at the limit, so we fetch
-			// the maximum and paginate client-side for all output modes.
+			// Fetch a full page (DefaultLimit, matching the web UI) up front and
+			// paginate client-side for all output modes; the requested --limit
+			// only controls the client-side page size.
 			requestedLimit := searchCfg.Limit
 			requestedPage := searchCfg.Page
 			searchCfg.Limit = search.DefaultLimit

--- a/cmd/entire/cli/search_cmd_test.go
+++ b/cmd/entire/cli/search_cmd_test.go
@@ -69,7 +69,7 @@ func TestWriteSearchJSON_ZeroLimitFallsBackToDefaultPageSize(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, `"limit": 25`) {
+	if !strings.Contains(output, `"limit": 10`) {
 		t.Fatalf("output missing default limit fallback:\n%s", output)
 	}
 	if !strings.Contains(output, `"total_pages": 1`) {

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,6 +34,7 @@ const (
 type searchResultsMsg struct {
 	results []search.Result
 	total   int
+	counts  *search.TypeCounts
 	err     error
 }
 
@@ -55,6 +57,8 @@ type searchStyles struct {
 	helpSep      lipgloss.Style // dim separator dots in footer
 	detailTitle  lipgloss.Style // colored title and section headers (orange, bold)
 	detailBorder lipgloss.Style // border style for detail card
+	tabActive    lipgloss.Style // active type tab
+	tabInactive  lipgloss.Style // inactive type tab
 }
 
 // Search palette mirrors activity's dark-mode CSS variables (Tailwind 400-level).
@@ -81,6 +85,8 @@ func newSearchStyles(ss statusStyles) searchStyles {
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(searchAccentPurple)).
 		Padding(1, 2)
+	s.tabActive = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(searchAccentOrange))
+	s.tabInactive = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
 	return s
 }
 
@@ -92,6 +98,16 @@ func (s searchStyles) helpItem(keyLabel, desc string) string {
 }
 
 const resultsPerPage = 25
+
+// typeFilter represents the active type tab in the TUI.
+type typeFilter string
+
+const (
+	typeFilterAll         typeFilter = ""
+	typeFilterCheckpoints typeFilter = typeFilter(search.TypeCheckpoint)
+	typeFilterCommits     typeFilter = typeFilter(search.TypeCommit)
+	typeFilterSessions    typeFilter = typeFilter(search.TypeSession)
+)
 
 // searchModel is the bubbletea model for interactive search results.
 type searchModel struct {
@@ -109,8 +125,10 @@ type searchModel struct {
 	searchCfg    search.Config
 	apiPage      int // 1-based last-fetched API page
 	styles       searchStyles
-	detailVP     viewport.Model // full-screen detail view
-	browseVP     viewport.Model // scrollable browse view
+	detailVP     viewport.Model     // full-screen detail view
+	browseVP     viewport.Model     // scrollable browse view
+	filterType   typeFilter         // active type tab filter
+	counts       *search.TypeCounts // per-type counts from API
 
 	// darkBg is captured once before bubbletea takes over the terminal so the
 	// snippet renderer never re-queries the terminal via OSC during the Update
@@ -118,25 +136,46 @@ type searchModel struct {
 	darkBg bool
 }
 
+// filteredResults returns results matching the active type filter.
+func (m searchModel) filteredResults() []search.Result {
+	if m.filterType == typeFilterAll {
+		return m.results
+	}
+	var out []search.Result
+	for _, r := range m.results {
+		if typeFilter(r.Type) == m.filterType {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 // pageResults returns the slice of results for the current page.
 func (m searchModel) pageResults() []search.Result {
+	filtered := m.filteredResults()
 	start := m.page * resultsPerPage
-	if start >= len(m.results) {
+	if start >= len(filtered) {
 		return nil
 	}
 	end := start + resultsPerPage
-	if end > len(m.results) {
-		end = len(m.results)
+	if end > len(filtered) {
+		end = len(filtered)
 	}
-	return m.results[start:end]
+	return filtered[start:end]
 }
 
-// totalPages returns the number of pages based on the API's total result count.
+// totalPages returns the number of pages based on the filtered result count.
 func (m searchModel) totalPages() int {
-	if m.total == 0 {
+	n := len(m.filteredResults())
+	// When showing all types, use the API total if it's larger than loaded results
+	// (we may not have fetched everything yet).
+	if m.filterType == typeFilterAll && m.total > n {
+		n = m.total
+	}
+	if n == 0 {
 		return 1
 	}
-	return (m.total + resultsPerPage - 1) / resultsPerPage
+	return (n + resultsPerPage - 1) / resultsPerPage
 }
 
 // selectedResult returns the currently selected result, accounting for pagination.
@@ -146,6 +185,27 @@ func (m searchModel) selectedResult() *search.Result {
 		return &pageResults[m.cursor]
 	}
 	return nil
+}
+
+// computeTypeCounts calculates per-type counts from the loaded results,
+// falling back to API-provided counts when available.
+func (m searchModel) computeTypeCounts() (checkpoints, commits, sessions int) {
+	if m.counts != nil {
+		return m.counts.Checkpoints, m.counts.Commits, m.counts.Sessions
+	}
+	for _, r := range m.results {
+		switch typeFilter(r.Type) {
+		case typeFilterCheckpoints:
+			checkpoints++
+		case typeFilterCommits:
+			commits++
+		case typeFilterSessions:
+			sessions++
+		case typeFilterAll:
+			// not a valid result type; skip
+		}
+	}
+	return
 }
 
 func newSearchModel(results []search.Result, query string, total int, cfg search.Config, ss statusStyles) searchModel {
@@ -210,6 +270,7 @@ func (m searchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop 
 		m.searchErr = ""
 		m.results = msg.results
 		m.total = msg.total
+		m.counts = msg.counts
 		m.apiPage = 1
 		m.cursor = 0
 		m.page = 0
@@ -302,6 +363,38 @@ func (m searchModel) updateSearchMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 }
 
 func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	// Type tab keys (1/2/3)
+	switch msg.String() {
+	case "1":
+		m.filterType = typeFilterCheckpoints
+		m.cursor = 0
+		m.page = 0
+		m.browseVP.GotoTop()
+		m = m.refreshBrowseContent()
+		return m, nil
+	case "2":
+		m.filterType = typeFilterSessions
+		m.cursor = 0
+		m.page = 0
+		m.browseVP.GotoTop()
+		m = m.refreshBrowseContent()
+		return m, nil
+	case "3":
+		m.filterType = typeFilterCommits
+		m.cursor = 0
+		m.page = 0
+		m.browseVP.GotoTop()
+		m = m.refreshBrowseContent()
+		return m, nil
+	case "0":
+		m.filterType = typeFilterAll
+		m.cursor = 0
+		m.page = 0
+		m.browseVP.GotoTop()
+		m = m.refreshBrowseContent()
+		return m, nil
+	}
+
 	pageLen := len(m.pageResults())
 	switch {
 	case key.Matches(msg, keys.Quit), key.Matches(msg, keys.Back), msg.String() == "h":
@@ -322,8 +415,9 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		m = m.refreshBrowseContent()
 		m.browseVP.GotoTop()
 	case key.Matches(msg, keys.End):
-		if len(m.results) > 0 {
-			lastLoaded := len(m.results) - 1
+		filtered := m.filteredResults()
+		if len(filtered) > 0 {
+			lastLoaded := len(filtered) - 1
 			m.page = min(lastLoaded/resultsPerPage, m.totalPages()-1)
 			if pageLen := len(m.pageResults()); pageLen > 0 {
 				m.cursor = pageLen - 1
@@ -338,7 +432,7 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			m.browseVP.GotoTop()
 			// Fetch next API page if we've scrolled past loaded results
 			start := m.page * resultsPerPage
-			if start >= len(m.results) && !m.fetchingMore {
+			if start >= len(m.filteredResults()) && !m.fetchingMore {
 				m.fetchingMore = true
 				m = m.refreshBrowseContent()
 				return m, fetchMoreResults(m.searchCfg, m.apiPage+1)
@@ -396,7 +490,7 @@ func performSearch(cfg search.Config) tea.Cmd {
 		if err != nil {
 			return searchResultsMsg{err: err}
 		}
-		return searchResultsMsg{results: resp.Results, total: resp.Total}
+		return searchResultsMsg{results: resp.Results, total: resp.Total, counts: resp.Counts}
 	}
 }
 
@@ -454,6 +548,29 @@ func (m searchModel) viewSearchMode() string {
 	return b.String()
 }
 
+// viewTypeTabs renders the type filter tabs with counts.
+func (m searchModel) viewTypeTabs() string {
+	cpCount, cmCount, ssCount := m.computeTypeCounts()
+	allCount := cpCount + cmCount + ssCount
+
+	renderTab := func(label string, filter typeFilter, count int, keyHint string) string {
+		text := fmt.Sprintf("[%s] %s %d", keyHint, label, count)
+		if m.filterType == filter {
+			return m.styles.render(m.styles.tabActive, text)
+		}
+		return m.styles.render(m.styles.tabInactive, text)
+	}
+
+	tabs := []string{
+		renderTab("All", typeFilterAll, allCount, "0"),
+		renderTab("Checkpoints", typeFilterCheckpoints, cpCount, "1"),
+		renderTab("Sessions", typeFilterSessions, ssCount, "2"),
+		renderTab("Commits", typeFilterCommits, cmCount, "3"),
+	}
+
+	return strings.Join(tabs, "  ")
+}
+
 // renderBrowseContent builds the scrollable content for browse mode (everything except the footer).
 func (m searchModel) renderBrowseContent() string {
 	var b strings.Builder
@@ -479,11 +596,20 @@ func (m searchModel) renderBrowseContent() string {
 		return b.String()
 	}
 
+	// Type tabs
+	b.WriteString(pad + m.viewTypeTabs())
+	b.WriteString("\n\n")
+
 	// Section: RESULTS
 	b.WriteString(pad + m.styles.render(m.styles.sectionTitle, "RESULTS"))
 	b.WriteString("\n\n")
 
 	// Table (current page only)
+	filtered := m.filteredResults()
+	if len(filtered) == 0 {
+		b.WriteString(pad + m.styles.render(m.styles.dim, "No results for this type."))
+		return b.String()
+	}
 	if m.fetchingMore && m.pageResults() == nil {
 		b.WriteString(pad + m.styles.render(m.styles.dim, "Loading more results...") + "\n")
 	} else {
@@ -513,12 +639,13 @@ func (m searchModel) viewTable() string {
 	var b strings.Builder
 
 	// Column headers
-	hdr := fmt.Sprintf("%-*s %-*s %-*s %-*s %-*s %-*s",
+	hdr := fmt.Sprintf("%-*s %-*s %-*s %-*s %-*s %-*s %-*s",
+		cols.typeCol, "Type",
 		cols.age, "Age",
 		cols.id, "ID",
 		cols.branch, "Branch",
 		cols.repo, "Repo",
-		cols.prompt, "Prompt",
+		cols.prompt, "Title",
 		cols.author, "Author",
 	)
 	b.WriteString(pad + m.styles.render(m.styles.dim, hdr) + "\n")
@@ -540,29 +667,63 @@ func (m searchModel) viewTable() string {
 	return b.String()
 }
 
-func (m searchModel) viewRow(r search.Result, cols columnLayout) string {
-	age := fmt.Sprintf("%-*s", cols.age, stringutil.TruncateRunes(formatSearchAge(r.Data.CreatedAt), cols.age, ""))
-	id := fmt.Sprintf("%-*s", cols.id, stringutil.TruncateRunes(r.Data.ID, cols.id-1, "…"))
-	branch := fmt.Sprintf("%-*s", cols.branch, stringutil.TruncateRunes(r.Data.Branch, cols.branch-1, "…"))
-	repo := fmt.Sprintf("%-*s", cols.repo, stringutil.TruncateRunes(
-		r.Data.Org+"/"+r.Data.Repo, cols.repo-1, "…",
-	))
-	prompt := fmt.Sprintf("%-*s", cols.prompt, stringutil.TruncateRunes(
-		stringutil.CollapseWhitespace(r.Data.Prompt), cols.prompt-1, "…",
-	))
-	authorName := derefStr(r.Data.AuthorUsername, r.Data.Author)
-	author := fmt.Sprintf("%-*s", cols.author, stringutil.TruncateRunes(authorName, cols.author-1, "…"))
-
-	return fmt.Sprintf("%s %s %s %s %s %s", age, id, branch, repo, prompt, author)
+// typeLabel returns a short type badge for display in the table.
+func typeLabel(resultType string) string {
+	switch resultType {
+	case search.TypeCheckpoint:
+		return "CP"
+	case search.TypeCommit:
+		return "CM"
+	case search.TypeSession:
+		return "SS"
+	default:
+		return strings.ToUpper(resultType[:min(2, len(resultType))])
+	}
 }
 
-// renderDetailContent builds the text content for a checkpoint detail (no border/card chrome).
+func (m searchModel) viewRow(r search.Result, cols columnLayout) string {
+	typeBadge := fmt.Sprintf("%-*s", cols.typeCol, typeLabel(r.Type))
+	age := fmt.Sprintf("%-*s", cols.age, stringutil.TruncateRunes(formatSearchAge(r.ResultCreatedAt()), cols.age, ""))
+	id := fmt.Sprintf("%-*s", cols.id, stringutil.TruncateRunes(formatResultID(r), cols.id-1, "…"))
+	branch := fmt.Sprintf("%-*s", cols.branch, stringutil.TruncateRunes(r.ResultBranch(), cols.branch-1, "…"))
+	repo := fmt.Sprintf("%-*s", cols.repo, stringutil.TruncateRunes(
+		r.ResultOrg()+"/"+r.ResultRepo(), cols.repo-1, "…",
+	))
+	title := fmt.Sprintf("%-*s", cols.prompt, stringutil.TruncateRunes(
+		stringutil.CollapseWhitespace(r.ResultTitle()), cols.prompt-1, "…",
+	))
+	author := fmt.Sprintf("%-*s", cols.author, stringutil.TruncateRunes(r.ResultAuthor(), cols.author-1, "…"))
+
+	return fmt.Sprintf("%s %s %s %s %s %s %s", typeBadge, age, id, branch, repo, title, author)
+}
+
+// formatResultID returns a display-friendly ID for a result.
+func formatResultID(r search.Result) string {
+	if r.Type == search.TypeCommit && r.Commit != nil && len(r.Commit.CommitSHA) > 7 {
+		return r.Commit.CommitSHA[:7]
+	}
+	return r.ResultID()
+}
+
+// renderDetailContent builds the text content for a result detail (no border/card chrome).
 func (m searchModel) renderDetailContent(r search.Result, contentWidth int, showSections bool) string {
+	switch r.Type {
+	case search.TypeCheckpoint:
+		return m.renderCheckpointDetail(r, contentWidth, showSections)
+	case search.TypeCommit:
+		return m.renderCommitDetail(r, contentWidth, showSections)
+	case search.TypeSession:
+		return m.renderSessionDetail(r, contentWidth, showSections)
+	default:
+		return m.renderCheckpointDetail(r, contentWidth, showSections)
+	}
+}
+
+func (m searchModel) renderCheckpointDetail(r search.Result, contentWidth int, showSections bool) string {
 	const labelWidth = 12
-	// Available width for field values: content width minus label minus space.
 	valueWidth := contentWidth - labelWidth - 1
 	if valueWidth < 20 {
-		valueWidth = 0 // disable wrapping on very narrow terminals
+		valueWidth = 0
 	}
 
 	var content strings.Builder
@@ -578,13 +739,12 @@ func (m searchModel) renderDetailContent(r search.Result, contentWidth int, show
 		content.WriteString(formatLabel(label) + " " + value + "\n")
 	}
 
-	// writeWrappedField word-wraps a long value, indenting continuation lines to align with the value column.
 	writeWrappedField := func(label, value string) {
 		if valueWidth == 0 || len(value) <= valueWidth {
 			writeField(label, value)
 			return
 		}
-		indent := strings.Repeat(" ", labelWidth+1) // align with value column
+		indent := strings.Repeat(" ", labelWidth+1)
 		wrapped := wrapText(value, valueWidth)
 		lines := strings.Split(wrapped, "\n")
 		content.WriteString(formatLabel(label) + " " + lines[0] + "\n")
@@ -601,10 +761,15 @@ func (m searchModel) renderDetailContent(r search.Result, contentWidth int, show
 		}
 	}
 
+	cp := r.Checkpoint
+	if cp == nil {
+		return content.String()
+	}
+
 	// ── OVERVIEW ──
 	writeSection("OVERVIEW")
-	writeField("ID", r.Data.ID)
-	writeWrappedField("Prompt", stringutil.CollapseWhitespace(r.Data.Prompt))
+	writeField("ID", cp.ID)
+	writeWrappedField("Prompt", stringutil.CollapseWhitespace(cp.Prompt))
 	matchType := r.Meta.MatchType
 	if r.Meta.Score > 0 {
 		matchType += " " + m.styles.render(m.styles.dim, fmt.Sprintf("(score: %.3f)", r.Meta.Score))
@@ -613,15 +778,15 @@ func (m searchModel) renderDetailContent(r search.Result, contentWidth int, show
 
 	// ── SOURCE ──
 	writeSection("SOURCE")
-	writeWrappedField("Commit", formatCommit(r.Data.CommitSHA, r.Data.CommitMessage))
-	writeField("Branch", r.Data.Branch)
-	writeField("Repo", r.Data.Org+"/"+r.Data.Repo)
-	authorStr := r.Data.Author
-	if r.Data.AuthorUsername != nil && *r.Data.AuthorUsername != "" {
-		authorStr = *r.Data.AuthorUsername + " " + m.styles.render(m.styles.dim, "("+r.Data.Author+")")
+	writeWrappedField("Commit", formatCommit(cp.CommitSHA, cp.CommitMessage))
+	writeField("Branch", cp.Branch)
+	writeField("Repo", cp.Org+"/"+cp.Repo)
+	authorStr := cp.Author
+	if cp.AuthorUsername != nil && *cp.AuthorUsername != "" {
+		authorStr = *cp.AuthorUsername + " " + m.styles.render(m.styles.dim, "("+cp.Author+")")
 	}
 	writeField("Author", authorStr)
-	createdStr := formatDetailCreatedAt(r.Data.CreatedAt, m.styles)
+	createdStr := formatDetailCreatedAt(cp.CreatedAt, m.styles)
 	writeField("Created", createdStr)
 
 	// ── SNIPPET ──
@@ -638,17 +803,181 @@ func (m searchModel) renderDetailContent(r search.Result, contentWidth int, show
 	}
 
 	// ── FILES ──
-	if len(r.Data.FilesTouched) > 0 {
+	if len(cp.FilesTouched) > 0 {
 		content.WriteString("\n")
 		if showSections {
 			content.WriteString(m.styles.render(m.styles.detailTitle, "FILES") + "\n")
 		} else {
 			content.WriteString(m.styles.render(m.styles.label, "Files:") + "\n")
 		}
-		for _, f := range r.Data.FilesTouched {
+		for _, f := range cp.FilesTouched {
 			content.WriteString("  " + f + "\n")
 		}
 	}
+
+	return strings.TrimRight(content.String(), "\n")
+}
+
+func (m searchModel) renderCommitDetail(r search.Result, contentWidth int, showSections bool) string {
+	const labelWidth = 12
+	valueWidth := contentWidth - labelWidth - 1
+	if valueWidth < 20 {
+		valueWidth = 0
+	}
+
+	var content strings.Builder
+
+	content.WriteString(m.styles.render(m.styles.detailTitle, "Commit Detail"))
+	content.WriteString("\n")
+
+	formatLabel := func(label string) string {
+		return m.styles.render(m.styles.label, fmt.Sprintf("%-*s", labelWidth, label+":"))
+	}
+
+	writeField := func(label, value string) {
+		content.WriteString(formatLabel(label) + " " + value + "\n")
+	}
+
+	writeWrappedField := func(label, value string) {
+		if valueWidth == 0 || len(value) <= valueWidth {
+			writeField(label, value)
+			return
+		}
+		indent := strings.Repeat(" ", labelWidth+1)
+		wrapped := wrapText(value, valueWidth)
+		lines := strings.Split(wrapped, "\n")
+		content.WriteString(formatLabel(label) + " " + lines[0] + "\n")
+		for _, line := range lines[1:] {
+			content.WriteString(indent + line + "\n")
+		}
+	}
+
+	writeSection := func(title string) {
+		if showSections {
+			content.WriteString("\n" + m.styles.render(m.styles.detailTitle, title) + "\n")
+		} else {
+			content.WriteString("\n")
+		}
+	}
+
+	cm := r.Commit
+	if cm == nil {
+		return content.String()
+	}
+
+	writeSection("OVERVIEW")
+	sha := cm.CommitSHA
+	if len(sha) > 7 {
+		sha = sha[:7]
+	}
+	writeField("SHA", sha)
+	writeWrappedField("Subject", cm.CommitSubject)
+	if cm.CommitMessage != cm.CommitSubject {
+		writeWrappedField("Message", stringutil.CollapseWhitespace(cm.CommitMessage))
+	}
+	matchType := r.Meta.MatchType
+	if r.Meta.Score > 0 {
+		matchType += " " + m.styles.render(m.styles.dim, fmt.Sprintf("(score: %.3f)", r.Meta.Score))
+	}
+	writeField("Match", matchType)
+
+	writeSection("SOURCE")
+	writeField("Branch", cm.Branch)
+	writeField("Repo", cm.Org+"/"+cm.Repo)
+	authorStr := cm.Author
+	if cm.AuthorUsername != nil && *cm.AuthorUsername != "" {
+		authorStr = *cm.AuthorUsername + " " + m.styles.render(m.styles.dim, "("+cm.Author+")")
+	}
+	writeField("Author", authorStr)
+	writeField("Created", formatDetailCreatedAt(cm.CreatedAt, m.styles))
+
+	writeSection("STATS")
+	writeField("Additions", fmt.Sprintf("+%d", cm.Additions))
+	writeField("Deletions", fmt.Sprintf("-%d", cm.Deletions))
+	writeField("Files", fmt.Sprintf("%d changed", cm.FilesChanged))
+
+	if cm.HTMLUrl != nil && *cm.HTMLUrl != "" {
+		writeField("URL", *cm.HTMLUrl)
+	}
+
+	return strings.TrimRight(content.String(), "\n")
+}
+
+func (m searchModel) renderSessionDetail(r search.Result, contentWidth int, showSections bool) string {
+	const labelWidth = 12
+	valueWidth := contentWidth - labelWidth - 1
+	if valueWidth < 20 {
+		valueWidth = 0
+	}
+
+	var content strings.Builder
+
+	content.WriteString(m.styles.render(m.styles.detailTitle, "Session Detail"))
+	content.WriteString("\n")
+
+	formatLabel := func(label string) string {
+		return m.styles.render(m.styles.label, fmt.Sprintf("%-*s", labelWidth, label+":"))
+	}
+
+	writeField := func(label, value string) {
+		content.WriteString(formatLabel(label) + " " + value + "\n")
+	}
+
+	writeWrappedField := func(label, value string) {
+		if valueWidth == 0 || len(value) <= valueWidth {
+			writeField(label, value)
+			return
+		}
+		indent := strings.Repeat(" ", labelWidth+1)
+		wrapped := wrapText(value, valueWidth)
+		lines := strings.Split(wrapped, "\n")
+		content.WriteString(formatLabel(label) + " " + lines[0] + "\n")
+		for _, line := range lines[1:] {
+			content.WriteString(indent + line + "\n")
+		}
+	}
+
+	writeSection := func(title string) {
+		if showSections {
+			content.WriteString("\n" + m.styles.render(m.styles.detailTitle, title) + "\n")
+		} else {
+			content.WriteString("\n")
+		}
+	}
+
+	ss := r.Session
+	if ss == nil {
+		return content.String()
+	}
+
+	writeSection("OVERVIEW")
+	writeField("Session ID", ss.SessionID)
+	writeWrappedField("Name", ss.DisplayName)
+	if ss.Prompt != nil && *ss.Prompt != "" {
+		writeWrappedField("Prompt", stringutil.CollapseWhitespace(*ss.Prompt))
+	}
+	if ss.Agent != nil && *ss.Agent != "" {
+		writeField("Agent", *ss.Agent)
+	}
+	if ss.Model != nil && *ss.Model != "" {
+		writeField("Model", *ss.Model)
+	}
+	writeField("Steps", strconv.Itoa(ss.StepCount))
+	matchType := r.Meta.MatchType
+	if r.Meta.Score > 0 {
+		matchType += " " + m.styles.render(m.styles.dim, fmt.Sprintf("(score: %.3f)", r.Meta.Score))
+	}
+	writeField("Match", matchType)
+
+	writeSection("SOURCE")
+	writeField("Repo", ss.Org+"/"+ss.Repo)
+	if ss.Branch != nil && *ss.Branch != "" {
+		writeField("Branch", *ss.Branch)
+	}
+	if ss.AuthorUsername != nil && *ss.AuthorUsername != "" {
+		writeField("Author", *ss.AuthorUsername)
+	}
+	writeField("Created", formatDetailCreatedAt(ss.CreatedAt, m.styles))
 
 	return strings.TrimRight(content.String(), "\n")
 }
@@ -735,11 +1064,13 @@ func (m searchModel) viewHelp() string {
 	if pages > 1 {
 		left += dot + m.styles.helpItem("n/p", "page")
 	}
-	left += dot + m.styles.helpItem(keys.Quit.Help().Key, keys.Quit.Help().Desc)
+	left += dot + m.styles.helpItem("0-3", "type") + dot +
+		m.styles.helpItem(keys.Quit.Help().Key, keys.Quit.Help().Desc)
 
-	right := fmt.Sprintf("%d results", m.total)
+	filtered := m.filteredResults()
+	right := fmt.Sprintf("%d results", len(filtered))
 	if pages > 1 {
-		right = fmt.Sprintf("page %d/%d · %d results", m.page+1, pages, m.total)
+		right = fmt.Sprintf("page %d/%d · %d results", m.page+1, pages, len(filtered))
 	}
 
 	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right) - 2
@@ -805,25 +1136,27 @@ func wrapParagraph(b *strings.Builder, text string, width int) {
 
 // columnLayout holds computed column widths for the search results table.
 type columnLayout struct {
-	age    int
-	id     int
-	branch int
-	repo   int
-	prompt int
-	author int
+	typeCol int
+	age     int
+	id      int
+	branch  int
+	repo    int
+	prompt  int
+	author  int
 }
 
 // computeColumns calculates column widths from terminal width.
 func computeColumns(width int) columnLayout {
 	const (
+		typeWidth   = 5
 		ageWidth    = 10
 		idWidth     = 12
 		repoMin     = 10
 		authorWidth = 14
-		gaps        = 5 // spaces between columns
+		gaps        = 6 // spaces between columns (one more than before for type col)
 	)
 
-	remaining := width - ageWidth - idWidth - authorWidth - gaps
+	remaining := width - typeWidth - ageWidth - idWidth - authorWidth - gaps
 	if remaining < 20 {
 		remaining = 20
 	}
@@ -838,12 +1171,13 @@ func computeColumns(width int) columnLayout {
 	}
 
 	return columnLayout{
-		age:    ageWidth,
-		id:     idWidth,
-		branch: branchWidth,
-		repo:   repoWidth,
-		prompt: promptWidth,
-		author: authorWidth,
+		typeCol: typeWidth,
+		age:     ageWidth,
+		id:      idWidth,
+		branch:  branchWidth,
+		repo:    repoWidth,
+		prompt:  promptWidth,
+		author:  authorWidth,
 	}
 }
 
@@ -972,35 +1306,38 @@ func snippetMarkdownStyles(dark bool) ansi.StyleConfig {
 
 // renderSearchStatic writes a non-interactive table for accessible mode.
 func renderSearchStatic(w io.Writer, results []search.Result, query string, total int, styles statusStyles) {
-	fmt.Fprintf(w, "Found %d checkpoints matching %q\n\n", total, query)
+	fmt.Fprintf(w, "Found %d results matching %q\n\n", total, query)
 
 	cols := computeColumns(styles.width)
 
-	fmt.Fprintf(w, "%-*s %-*s %-*s %-*s %-*s %-*s\n",
+	fmt.Fprintf(w, "%-*s %-*s %-*s %-*s %-*s %-*s %-*s\n",
+		cols.typeCol, "TYPE",
 		cols.age, "AGE",
 		cols.id, "ID",
 		cols.branch, "BRANCH",
 		cols.repo, "REPO",
-		cols.prompt, "PROMPT",
+		cols.prompt, "TITLE",
 		cols.author, "AUTHOR",
 	)
 
 	for _, r := range results {
-		age := formatSearchAge(r.Data.CreatedAt)
-		id := stringutil.TruncateRunes(r.Data.ID, cols.id, "")
-		branch := stringutil.TruncateRunes(r.Data.Branch, cols.branch, "...")
-		repo := stringutil.TruncateRunes(r.Data.Org+"/"+r.Data.Repo, cols.repo, "...")
-		prompt := stringutil.TruncateRunes(
-			stringutil.CollapseWhitespace(r.Data.Prompt), cols.prompt, "...",
+		typeBadge := typeLabel(r.Type)
+		age := formatSearchAge(r.ResultCreatedAt())
+		id := stringutil.TruncateRunes(formatResultID(r), cols.id, "")
+		branch := stringutil.TruncateRunes(r.ResultBranch(), cols.branch, "...")
+		repo := stringutil.TruncateRunes(r.ResultOrg()+"/"+r.ResultRepo(), cols.repo, "...")
+		title := stringutil.TruncateRunes(
+			stringutil.CollapseWhitespace(r.ResultTitle()), cols.prompt, "...",
 		)
-		author := stringutil.TruncateRunes(derefStr(r.Data.AuthorUsername, r.Data.Author), cols.author, "...")
+		author := stringutil.TruncateRunes(r.ResultAuthor(), cols.author, "...")
 
-		fmt.Fprintf(w, "%-*s %-*s %-*s %-*s %-*s %-*s\n",
+		fmt.Fprintf(w, "%-*s %-*s %-*s %-*s %-*s %-*s %-*s\n",
+			cols.typeCol, typeBadge,
 			cols.age, age,
 			cols.id, id,
 			cols.branch, branch,
 			cols.repo, repo,
-			cols.prompt, prompt,
+			cols.prompt, title,
 			cols.author, author,
 		)
 	}

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -931,267 +931,206 @@ func (m searchModel) renderDetailContent(r search.Result, contentWidth int, show
 	}
 }
 
-func (m searchModel) renderCheckpointDetail(r search.Result, contentWidth int, showSections bool) string {
+// detailWriter accumulates a label/value detail body. It owns the shared
+// layout (label column width, value wrap width, section spacing) so the
+// per-type renderers below differ only in which fields they emit.
+type detailWriter struct {
+	b            strings.Builder
+	styles       searchStyles
+	labelWidth   int
+	valueWidth   int
+	showSections bool
+}
+
+func (m searchModel) newDetailWriter(title string, contentWidth int, showSections bool) *detailWriter {
 	const labelWidth = 12
 	valueWidth := contentWidth - labelWidth - 1
 	if valueWidth < 20 {
 		valueWidth = 0
 	}
-
-	var content strings.Builder
-
-	content.WriteString(m.styles.render(m.styles.detailTitle, "Checkpoint Detail"))
-	content.WriteString("\n")
-
-	formatLabel := func(label string) string {
-		return m.styles.render(m.styles.label, fmt.Sprintf("%-*s", labelWidth, label+":"))
+	w := &detailWriter{
+		styles:       m.styles,
+		labelWidth:   labelWidth,
+		valueWidth:   valueWidth,
+		showSections: showSections,
 	}
+	w.b.WriteString(w.styles.render(w.styles.detailTitle, title) + "\n")
+	return w
+}
 
-	writeField := func(label, value string) {
-		content.WriteString(formatLabel(label) + " " + value + "\n")
+func (w *detailWriter) label(label string) string {
+	return w.styles.render(w.styles.label, fmt.Sprintf("%-*s", w.labelWidth, label+":"))
+}
+
+func (w *detailWriter) field(label, value string) {
+	w.b.WriteString(w.label(label) + " " + value + "\n")
+}
+
+func (w *detailWriter) wrappedField(label, value string) {
+	if w.valueWidth == 0 || len(value) <= w.valueWidth {
+		w.field(label, value)
+		return
 	}
-
-	writeWrappedField := func(label, value string) {
-		if valueWidth == 0 || len(value) <= valueWidth {
-			writeField(label, value)
-			return
-		}
-		indent := strings.Repeat(" ", labelWidth+1)
-		wrapped := wrapText(value, valueWidth)
-		lines := strings.Split(wrapped, "\n")
-		content.WriteString(formatLabel(label) + " " + lines[0] + "\n")
-		for _, line := range lines[1:] {
-			content.WriteString(indent + line + "\n")
-		}
+	indent := strings.Repeat(" ", w.labelWidth+1)
+	lines := strings.Split(wrapText(value, w.valueWidth), "\n")
+	w.b.WriteString(w.label(label) + " " + lines[0] + "\n")
+	for _, line := range lines[1:] {
+		w.b.WriteString(indent + line + "\n")
 	}
+}
 
-	writeSection := func(title string) {
-		if showSections {
-			content.WriteString("\n" + m.styles.render(m.styles.detailTitle, title) + "\n")
-		} else {
-			content.WriteString("\n")
-		}
+func (w *detailWriter) section(title string) {
+	if w.showSections {
+		w.b.WriteString("\n" + w.styles.render(w.styles.detailTitle, title) + "\n")
+	} else {
+		w.b.WriteString("\n")
 	}
+}
 
+// matchField emits the "Match" row, appending the relevance score when present.
+func (w *detailWriter) matchField(meta search.Meta) {
+	value := meta.MatchType
+	if meta.Score > 0 {
+		value += " " + w.styles.render(w.styles.dim, fmt.Sprintf("(score: %.3f)", meta.Score))
+	}
+	w.field("Match", value)
+}
+
+// authorField emits the "Author" row, preferring the username with the raw
+// author dimmed in parentheses when both are available.
+func (w *detailWriter) authorField(author string, username *string) {
+	value := author
+	if username != nil && *username != "" {
+		value = *username + " " + w.styles.render(w.styles.dim, "("+author+")")
+	}
+	w.field("Author", value)
+}
+
+func (w *detailWriter) String() string {
+	return strings.TrimRight(w.b.String(), "\n")
+}
+
+func (m searchModel) renderCheckpointDetail(r search.Result, contentWidth int, showSections bool) string {
+	w := m.newDetailWriter("Checkpoint Detail", contentWidth, showSections)
 	cp := r.Checkpoint
 	if cp == nil {
-		return content.String()
+		return w.String()
 	}
 
 	// ── OVERVIEW ──
-	writeSection("OVERVIEW")
-	writeField("ID", cp.ID)
-	writeWrappedField("Prompt", stringutil.CollapseWhitespace(cp.Prompt))
-	matchType := r.Meta.MatchType
-	if r.Meta.Score > 0 {
-		matchType += " " + m.styles.render(m.styles.dim, fmt.Sprintf("(score: %.3f)", r.Meta.Score))
-	}
-	writeField("Match", matchType)
+	w.section("OVERVIEW")
+	w.field("ID", cp.ID)
+	w.wrappedField("Prompt", stringutil.CollapseWhitespace(cp.Prompt))
+	w.matchField(r.Meta)
 
 	// ── SOURCE ──
-	writeSection("SOURCE")
-	writeWrappedField("Commit", formatCommit(cp.CommitSHA, cp.CommitMessage))
-	writeField("Branch", cp.Branch)
-	writeField("Repo", cp.Org+"/"+cp.Repo)
-	authorStr := cp.Author
-	if cp.AuthorUsername != nil && *cp.AuthorUsername != "" {
-		authorStr = *cp.AuthorUsername + " " + m.styles.render(m.styles.dim, "("+cp.Author+")")
-	}
-	writeField("Author", authorStr)
-	createdStr := formatDetailCreatedAt(cp.CreatedAt, m.styles)
-	writeField("Created", createdStr)
+	w.section("SOURCE")
+	w.wrappedField("Commit", formatCommit(cp.CommitSHA, cp.CommitMessage))
+	w.field("Branch", cp.Branch)
+	w.field("Repo", cp.Org+"/"+cp.Repo)
+	w.authorField(cp.Author, cp.AuthorUsername)
+	w.field("Created", formatDetailCreatedAt(cp.CreatedAt, m.styles))
 
 	// ── SNIPPET ──
 	if r.Meta.Snippet != "" {
-		writeSection("SNIPPET")
+		w.section("SNIPPET")
 		switch {
 		case showSections:
-			content.WriteString(renderSnippetMarkdown(r.Meta.Snippet, contentWidth, m.darkBg) + "\n")
-		case valueWidth > 0:
-			content.WriteString(wrapText(r.Meta.Snippet, contentWidth) + "\n")
+			w.b.WriteString(renderSnippetMarkdown(r.Meta.Snippet, contentWidth, m.darkBg) + "\n")
+		case w.valueWidth > 0:
+			w.b.WriteString(wrapText(r.Meta.Snippet, contentWidth) + "\n")
 		default:
-			content.WriteString(r.Meta.Snippet + "\n")
+			w.b.WriteString(r.Meta.Snippet + "\n")
 		}
 	}
 
 	// ── FILES ──
 	if len(cp.FilesTouched) > 0 {
-		content.WriteString("\n")
+		w.b.WriteString("\n")
 		if showSections {
-			content.WriteString(m.styles.render(m.styles.detailTitle, "FILES") + "\n")
+			w.b.WriteString(m.styles.render(m.styles.detailTitle, "FILES") + "\n")
 		} else {
-			content.WriteString(m.styles.render(m.styles.label, "Files:") + "\n")
+			w.b.WriteString(m.styles.render(m.styles.label, "Files:") + "\n")
 		}
 		for _, f := range cp.FilesTouched {
-			content.WriteString("  " + f + "\n")
+			w.b.WriteString("  " + f + "\n")
 		}
 	}
 
-	return strings.TrimRight(content.String(), "\n")
+	return w.String()
 }
 
 func (m searchModel) renderCommitDetail(r search.Result, contentWidth int, showSections bool) string {
-	const labelWidth = 12
-	valueWidth := contentWidth - labelWidth - 1
-	if valueWidth < 20 {
-		valueWidth = 0
-	}
-
-	var content strings.Builder
-
-	content.WriteString(m.styles.render(m.styles.detailTitle, "Commit Detail"))
-	content.WriteString("\n")
-
-	formatLabel := func(label string) string {
-		return m.styles.render(m.styles.label, fmt.Sprintf("%-*s", labelWidth, label+":"))
-	}
-
-	writeField := func(label, value string) {
-		content.WriteString(formatLabel(label) + " " + value + "\n")
-	}
-
-	writeWrappedField := func(label, value string) {
-		if valueWidth == 0 || len(value) <= valueWidth {
-			writeField(label, value)
-			return
-		}
-		indent := strings.Repeat(" ", labelWidth+1)
-		wrapped := wrapText(value, valueWidth)
-		lines := strings.Split(wrapped, "\n")
-		content.WriteString(formatLabel(label) + " " + lines[0] + "\n")
-		for _, line := range lines[1:] {
-			content.WriteString(indent + line + "\n")
-		}
-	}
-
-	writeSection := func(title string) {
-		if showSections {
-			content.WriteString("\n" + m.styles.render(m.styles.detailTitle, title) + "\n")
-		} else {
-			content.WriteString("\n")
-		}
-	}
-
+	w := m.newDetailWriter("Commit Detail", contentWidth, showSections)
 	cm := r.Commit
 	if cm == nil {
-		return content.String()
+		return w.String()
 	}
 
-	writeSection("OVERVIEW")
+	w.section("OVERVIEW")
 	sha := cm.CommitSHA
 	if len(sha) > 7 {
 		sha = sha[:7]
 	}
-	writeField("SHA", sha)
-	writeWrappedField("Subject", cm.CommitSubject)
+	w.field("SHA", sha)
+	w.wrappedField("Subject", cm.CommitSubject)
 	if cm.CommitMessage != cm.CommitSubject {
-		writeWrappedField("Message", stringutil.CollapseWhitespace(cm.CommitMessage))
+		w.wrappedField("Message", stringutil.CollapseWhitespace(cm.CommitMessage))
 	}
-	matchType := r.Meta.MatchType
-	if r.Meta.Score > 0 {
-		matchType += " " + m.styles.render(m.styles.dim, fmt.Sprintf("(score: %.3f)", r.Meta.Score))
-	}
-	writeField("Match", matchType)
+	w.matchField(r.Meta)
 
-	writeSection("SOURCE")
-	writeField("Branch", cm.Branch)
-	writeField("Repo", cm.Org+"/"+cm.Repo)
-	authorStr := cm.Author
-	if cm.AuthorUsername != nil && *cm.AuthorUsername != "" {
-		authorStr = *cm.AuthorUsername + " " + m.styles.render(m.styles.dim, "("+cm.Author+")")
-	}
-	writeField("Author", authorStr)
-	writeField("Created", formatDetailCreatedAt(cm.CreatedAt, m.styles))
+	w.section("SOURCE")
+	w.field("Branch", cm.Branch)
+	w.field("Repo", cm.Org+"/"+cm.Repo)
+	w.authorField(cm.Author, cm.AuthorUsername)
+	w.field("Created", formatDetailCreatedAt(cm.CreatedAt, m.styles))
 
-	writeSection("STATS")
-	writeField("Additions", fmt.Sprintf("+%d", cm.Additions))
-	writeField("Deletions", fmt.Sprintf("-%d", cm.Deletions))
-	writeField("Files", fmt.Sprintf("%d changed", cm.FilesChanged))
+	w.section("STATS")
+	w.field("Additions", fmt.Sprintf("+%d", cm.Additions))
+	w.field("Deletions", fmt.Sprintf("-%d", cm.Deletions))
+	w.field("Files", fmt.Sprintf("%d changed", cm.FilesChanged))
 
 	if cm.HTMLUrl != nil && *cm.HTMLUrl != "" {
-		writeField("URL", *cm.HTMLUrl)
+		w.field("URL", *cm.HTMLUrl)
 	}
 
-	return strings.TrimRight(content.String(), "\n")
+	return w.String()
 }
 
 func (m searchModel) renderSessionDetail(r search.Result, contentWidth int, showSections bool) string {
-	const labelWidth = 12
-	valueWidth := contentWidth - labelWidth - 1
-	if valueWidth < 20 {
-		valueWidth = 0
-	}
-
-	var content strings.Builder
-
-	content.WriteString(m.styles.render(m.styles.detailTitle, "Session Detail"))
-	content.WriteString("\n")
-
-	formatLabel := func(label string) string {
-		return m.styles.render(m.styles.label, fmt.Sprintf("%-*s", labelWidth, label+":"))
-	}
-
-	writeField := func(label, value string) {
-		content.WriteString(formatLabel(label) + " " + value + "\n")
-	}
-
-	writeWrappedField := func(label, value string) {
-		if valueWidth == 0 || len(value) <= valueWidth {
-			writeField(label, value)
-			return
-		}
-		indent := strings.Repeat(" ", labelWidth+1)
-		wrapped := wrapText(value, valueWidth)
-		lines := strings.Split(wrapped, "\n")
-		content.WriteString(formatLabel(label) + " " + lines[0] + "\n")
-		for _, line := range lines[1:] {
-			content.WriteString(indent + line + "\n")
-		}
-	}
-
-	writeSection := func(title string) {
-		if showSections {
-			content.WriteString("\n" + m.styles.render(m.styles.detailTitle, title) + "\n")
-		} else {
-			content.WriteString("\n")
-		}
-	}
-
+	w := m.newDetailWriter("Session Detail", contentWidth, showSections)
 	ss := r.Session
 	if ss == nil {
-		return content.String()
+		return w.String()
 	}
 
-	writeSection("OVERVIEW")
-	writeField("Session ID", ss.SessionID)
-	writeWrappedField("Name", ss.DisplayName)
+	w.section("OVERVIEW")
+	w.field("Session ID", ss.SessionID)
+	w.wrappedField("Name", ss.DisplayName)
 	if ss.Prompt != nil && *ss.Prompt != "" {
-		writeWrappedField("Prompt", stringutil.CollapseWhitespace(*ss.Prompt))
+		w.wrappedField("Prompt", stringutil.CollapseWhitespace(*ss.Prompt))
 	}
 	if ss.Agent != nil && *ss.Agent != "" {
-		writeField("Agent", *ss.Agent)
+		w.field("Agent", *ss.Agent)
 	}
 	if ss.Model != nil && *ss.Model != "" {
-		writeField("Model", *ss.Model)
+		w.field("Model", *ss.Model)
 	}
-	writeField("Steps", strconv.Itoa(ss.StepCount))
-	matchType := r.Meta.MatchType
-	if r.Meta.Score > 0 {
-		matchType += " " + m.styles.render(m.styles.dim, fmt.Sprintf("(score: %.3f)", r.Meta.Score))
-	}
-	writeField("Match", matchType)
+	w.field("Steps", strconv.Itoa(ss.StepCount))
+	w.matchField(r.Meta)
 
-	writeSection("SOURCE")
-	writeField("Repo", ss.Org+"/"+ss.Repo)
+	w.section("SOURCE")
+	w.field("Repo", ss.Org+"/"+ss.Repo)
 	if ss.Branch != nil && *ss.Branch != "" {
-		writeField("Branch", *ss.Branch)
+		w.field("Branch", *ss.Branch)
 	}
+	// Session author is the username only (no raw-author fallback to dim).
 	if ss.AuthorUsername != nil && *ss.AuthorUsername != "" {
-		writeField("Author", *ss.AuthorUsername)
+		w.field("Author", *ss.AuthorUsername)
 	}
-	writeField("Created", formatDetailCreatedAt(ss.CreatedAt, m.styles))
+	w.field("Created", formatDetailCreatedAt(ss.CreatedAt, m.styles))
 
-	return strings.TrimRight(content.String(), "\n")
+	return w.String()
 }
 
 // formatDetailCreatedAt renders date (default) + relative time (dim) for the detail view.

--- a/cmd/entire/cli/search_tui.go
+++ b/cmd/entire/cli/search_tui.go
@@ -16,6 +16,7 @@ import (
 	"charm.land/glamour/v2/ansi"
 	glamourstyles "charm.land/glamour/v2/styles"
 	"charm.land/lipgloss/v2"
+	xansi "github.com/charmbracelet/x/ansi"
 	"github.com/entireio/cli/cmd/entire/cli/search"
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
 	"github.com/muesli/termenv"
@@ -84,7 +85,7 @@ func newSearchStyles(ss statusStyles) searchStyles {
 	s.detailBorder = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(searchAccentPurple)).
-		Padding(1, 2)
+		Padding(0, 2)
 	s.tabActive = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(searchAccentOrange))
 	s.tabInactive = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
 	return s
@@ -97,12 +98,15 @@ func (s searchStyles) helpItem(keyLabel, desc string) string {
 	return s.render(s.helpKey, keyLabel) + " " + desc
 }
 
-const resultsPerPage = 25
+const resultsPerPage = 10
 
 // typeFilter represents the active type tab in the TUI.
 type typeFilter string
 
 const (
+	// typeFilterAll is no longer user-selectable in the TUI (no "All" tab), but
+	// remains the internal sentinel for "show every loaded result" used by the
+	// pagination/fetch-more math that reasons about the grand result total.
 	typeFilterAll         typeFilter = ""
 	typeFilterCheckpoints typeFilter = typeFilter(search.TypeCheckpoint)
 	typeFilterCommits     typeFilter = typeFilter(search.TypeCommit)
@@ -235,16 +239,17 @@ func newSearchModel(results []search.Result, query string, total int, cfg search
 	}
 
 	m := searchModel{
-		results:   results,
-		total:     total,
-		width:     ss.width,
-		mode:      modeBrowse,
-		input:     ti,
-		searchCfg: cfg,
-		apiPage:   apiPage,
-		styles:    styles,
-		browseVP:  viewport.New(viewport.WithWidth(ss.width), viewport.WithHeight(1)), // height set on first WindowSizeMsg
-		darkBg:    termenv.HasDarkBackground(),
+		results:    results,
+		total:      total,
+		width:      ss.width,
+		mode:       modeBrowse,
+		input:      ti,
+		searchCfg:  cfg,
+		apiPage:    apiPage,
+		styles:     styles,
+		browseVP:   viewport.New(viewport.WithWidth(ss.width), viewport.WithHeight(1)), // height set on first WindowSizeMsg
+		darkBg:     termenv.HasDarkBackground(),
+		filterType: typeFilterCheckpoints, // default the results table to checkpoints
 	}
 	m = m.refreshBrowseContent()
 	return m
@@ -386,13 +391,6 @@ func (m searchModel) updateBrowseMode(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		m.browseVP.GotoTop()
 		m = m.refreshBrowseContent()
 		return m, nil
-	case "0":
-		m.filterType = typeFilterAll
-		m.cursor = 0
-		m.page = 0
-		m.browseVP.GotoTop()
-		m = m.refreshBrowseContent()
-		return m, nil
 	}
 
 	pageLen := len(m.pageResults())
@@ -519,9 +517,71 @@ func (m searchModel) View() tea.View {
 	case modeSearch:
 		v.SetContent(m.viewSearchMode())
 	case modeBrowse:
-		v.SetContent(m.browseVP.View() + "\n" + m.viewHelp())
+		v.SetContent(m.viewBrowse())
 	}
 	return v
+}
+
+// viewBrowse composes the browse screen as a fixed master-detail layout:
+//
+//	┌ header  (search title, query, tabs, RESULTS) — pinned top
+//	│ list    (scrollable result rows in browseVP)
+//	│ detail  (bordered card for the selected row) — pinned bottom
+//	└ footer  (help line) — pinned very bottom
+//
+// Heights are budgeted from the terminal height so the detail card is always
+// fully visible and can never be clipped, regardless of how the list scrolls.
+func (m searchModel) viewBrowse() string {
+	footer := strings.TrimRight(m.viewHelp(), "\n")
+	header, showList := m.viewBrowseHeader()
+
+	var body string
+	switch {
+	case !showList:
+		// Loading / error / empty states: header is the whole body; pin the
+		// footer to the bottom of the screen.
+		body = padToHeight(header, max(m.height-1, 0)) + "\n" + footer
+	default:
+		paneH := m.detailPaneHeight(lipgloss.Height(header))
+		// browseVP height is kept in sync by refreshBrowseContent; render
+		// whatever window it currently exposes.
+		list := m.browseVP.View()
+		// The reserved row beneath the list shows the page/results count (and a
+		// scroll affordance when rows are cut off).
+		gap := m.viewListStatusRow()
+		if paneH <= 0 {
+			body = header + "\n" + list + "\n" + gap + "\n" + footer
+		} else {
+			body = header + "\n" + list + "\n" + gap + "\n" + m.viewDetailPane(paneH) + "\n" + footer
+		}
+	}
+
+	// Final safety net: on a terminal too short to fit even the pinned chrome,
+	// clamp so we never emit more rows than the screen (which would scroll the
+	// alt-screen and clip the top). Exactly-budgeted layouts are unaffected.
+	return clampToHeight(body, m.height)
+}
+
+// padToHeight pads s with blank lines so it occupies exactly n lines (or leaves
+// it unchanged when already taller). Used to push a pinned footer to the bottom.
+func padToHeight(s string, n int) string {
+	h := lipgloss.Height(s)
+	if h >= n {
+		return s
+	}
+	return s + strings.Repeat("\n", n-h)
+}
+
+// clampToHeight returns at most the first n lines of s.
+func clampToHeight(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[:n], "\n")
 }
 
 func (m searchModel) viewSearchHeader(b *strings.Builder) {
@@ -551,7 +611,6 @@ func (m searchModel) viewSearchMode() string {
 // viewTypeTabs renders the type filter tabs with counts.
 func (m searchModel) viewTypeTabs() string {
 	cpCount, cmCount, ssCount := m.computeTypeCounts()
-	allCount := cpCount + cmCount + ssCount
 
 	renderTab := func(label string, filter typeFilter, count int, keyHint string) string {
 		text := fmt.Sprintf("[%s] %s %d", keyHint, label, count)
@@ -562,7 +621,6 @@ func (m searchModel) viewTypeTabs() string {
 	}
 
 	tabs := []string{
-		renderTab("All", typeFilterAll, allCount, "0"),
 		renderTab("Checkpoints", typeFilterCheckpoints, cpCount, "1"),
 		renderTab("Sessions", typeFilterSessions, ssCount, "2"),
 		renderTab("Commits", typeFilterCommits, cmCount, "3"),
@@ -571,8 +629,11 @@ func (m searchModel) viewTypeTabs() string {
 	return strings.Join(tabs, "  ")
 }
 
-// renderBrowseContent builds the scrollable content for browse mode (everything except the footer).
-func (m searchModel) renderBrowseContent() string {
+// viewBrowseHeader builds the pinned top chrome (search title, query, type
+// tabs, RESULTS heading). The second return value reports whether the
+// scrolling list + detail regions should render; it is false for the
+// loading / error / empty states, where the returned string is the whole body.
+func (m searchModel) viewBrowseHeader() (string, bool) {
 	var b strings.Builder
 	pad := " "
 
@@ -585,15 +646,15 @@ func (m searchModel) renderBrowseContent() string {
 	// Loading / error / empty states
 	if m.loading {
 		b.WriteString(pad + m.styles.render(m.styles.dim, "Searching..."))
-		return b.String()
+		return b.String(), false
 	}
 	if m.searchErr != "" {
 		b.WriteString(pad + m.styles.render(m.styles.red, "Error: "+m.searchErr))
-		return b.String()
+		return b.String(), false
 	}
 	if len(m.results) == 0 {
 		b.WriteString(pad + m.styles.render(m.styles.dim, "No results found."))
-		return b.String()
+		return b.String(), false
 	}
 
 	// Type tabs
@@ -602,72 +663,239 @@ func (m searchModel) renderBrowseContent() string {
 
 	// Section: RESULTS
 	b.WriteString(pad + m.styles.render(m.styles.sectionTitle, "RESULTS"))
-	b.WriteString("\n\n")
-
-	// Table (current page only)
-	filtered := m.filteredResults()
-	if len(filtered) == 0 {
-		b.WriteString(pad + m.styles.render(m.styles.dim, "No results for this type."))
-		return b.String()
-	}
-	if m.fetchingMore && m.pageResults() == nil {
-		b.WriteString(pad + m.styles.render(m.styles.dim, "Loading more results...") + "\n")
-	} else {
-		b.WriteString(m.viewTable())
-	}
 	b.WriteString("\n")
 
-	// Detail card (no truncation — viewport handles overflow)
-	if r := m.selectedResult(); r != nil {
-		b.WriteString(m.viewDetailCard(*r))
+	filtered := m.filteredResults()
+	if len(filtered) == 0 {
+		b.WriteString("\n" + pad + m.styles.render(m.styles.dim, "No results for this type."))
+		return b.String(), false
+	}
+	if m.fetchingMore && m.pageResults() == nil {
+		b.WriteString("\n" + pad + m.styles.render(m.styles.dim, "Loading more results..."))
+		return b.String(), false
 	}
 
-	return strings.TrimRight(b.String(), "\n")
+	return b.String(), true
 }
 
-// refreshBrowseContent rebuilds the browse viewport content from current state.
+// refreshBrowseContent rebuilds the scrollable list viewport and re-applies the
+// master-detail layout (list height + cursor visibility) for the current state.
 func (m searchModel) refreshBrowseContent() searchModel {
-	m.browseVP.SetContent(m.renderBrowseContent())
+	// Trim the trailing newline so the viewport's line count reflects the real
+	// number of rows (a phantom blank line would keep "scroll down" lit at the
+	// bottom of the list).
+	m.browseVP.SetContent(strings.TrimRight(m.viewResultList(), "\n"))
+
+	if m.height <= 0 || m.width == 0 {
+		return m
+	}
+	header, showList := m.viewBrowseHeader()
+	if !showList {
+		return m
+	}
+	headerLines := lipgloss.Height(header)
+	paneH := m.detailPaneHeight(headerLines)
+	// Always reserve the gap/scroll-hint row and the footer row.
+	listH := max(m.height-headerLines-paneH-detailGap-1, 1)
+	m.browseVP.SetHeight(listH)
+	return m.ensureCursorVisible()
+}
+
+// detailPaneHeight returns the number of terminal rows reserved for the pinned
+// detail pane, or 0 when there is no selection or the screen is too short to
+// pin one (in which case the list takes the full area and detail is reachable
+// via the full-screen view). headerLines is the height of the pinned top chrome.
+func (m searchModel) detailPaneHeight(headerLines int) int {
+	if m.height <= 0 || m.selectedResult() == nil {
+		return 0
+	}
+	avail := m.height - 1 - headerLines - detailGap // footer + gap rows
+	if avail < minListHeight+minDetailPaneHeight {
+		return 0
+	}
+	h := m.height * 2 / 5 // ~40% of the screen
+	h = min(max(h, minDetailPaneHeight), maxDetailPaneHeight)
+	if h > avail-minListHeight {
+		h = avail - minListHeight
+	}
+	return h
+}
+
+// ensureCursorVisible scrolls the list viewport so the selected row stays
+// within the visible window as the cursor moves.
+func (m searchModel) ensureCursorVisible() searchModel {
+	listH := m.browseVP.Height()
+	if listH <= 0 {
+		return m
+	}
+	top := m.cursor * linesPerResult // first line of the selected item
+	bottom := top + 1                // each item occupies 2 lines
+	yo := m.browseVP.YOffset()
+	switch {
+	case top < yo:
+		yo = top
+	case bottom > yo+listH-1:
+		yo = bottom - listH + 1
+	}
+	m.browseVP.SetYOffset(max(yo, 0))
 	return m
 }
 
-func (m searchModel) viewTable() string {
+// viewListStatusRow renders the single reserved row directly beneath the result
+// list: a "more results" scroll affordance on the left (only when rows are
+// scrolled out of view) and the page / total-results indicator on the right.
+// It is exactly one line wide (never wraps) so the layout budget holds.
+func (m searchModel) viewListStatusRow() string {
+	contentWidth := max(m.width-2, 0)
+
+	// Left: scroll affordance when the list viewport can't show every row.
+	left := ""
+	if listH := m.browseVP.Height(); listH > 0 {
+		if total := m.browseVP.TotalLineCount(); total > listH {
+			yo := m.browseVP.YOffset()
+			switch {
+			case yo > 0 && yo+listH < total:
+				left = "↑↓ more results"
+			case yo+listH < total:
+				left = "↓ more results"
+			default:
+				left = "↑ more results"
+			}
+		}
+	}
+
+	// Right: page X/Y · N results (drops the page clause for a single page).
+	n := len(m.filteredResults())
+	right := fmt.Sprintf("%d results", n)
+	if pages := m.totalPages(); pages > 1 {
+		right = fmt.Sprintf("page %d/%d · %d results", m.page+1, pages, n)
+	}
+	if lipgloss.Width(right) > contentWidth {
+		right = stringutil.TruncateRunes(right, contentWidth, "…")
+	}
+
+	// Drop the scroll hint if both can't fit on one row.
+	if lipgloss.Width(left)+1+lipgloss.Width(right) > contentWidth {
+		left = ""
+	}
+	gap := max(contentWidth-lipgloss.Width(left)-lipgloss.Width(right), 1)
+
+	return " " + m.styles.render(m.styles.dim, left) +
+		strings.Repeat(" ", gap) + m.styles.render(m.styles.dim, right)
+}
+
+// gutterWidth is the fixed-width left rail of the result list: a selection
+// caret, the graph node glyph, and trailing space. The metadata line is
+// indented to align with the title (col gutterWidth).
+const gutterWidth = 4
+
+// Layout constants for the master-detail browse view.
+const (
+	// linesPerResult is the vertical stride of one result in the list: 2 content
+	// lines (title + meta) plus 1 separator rule between items.
+	linesPerResult = 3
+
+	minListHeight       = 4  // never shrink the list below this to fit the detail pane
+	minDetailPaneHeight = 6  // smallest worthwhile pinned detail pane (border + a few rows)
+	maxDetailPaneHeight = 24 // cap so the detail pane never dominates a tall terminal
+
+	// detailGap is the blank line between the result list and the pinned detail
+	// card, for a little breathing room.
+	detailGap = 1
+)
+
+// viewResultList renders the current page of results as a two-line list:
+// a type-colored graph node + bold title with a right-aligned relative age,
+// then a dim metadata line (type · repo · ⎇ branch · author). Items are
+// separated by a thin rule, mirroring the web activity list.
+func (m searchModel) viewResultList() string {
 	contentWidth := max(m.width-2, 0) // 1 char padding each side
-	cols := computeColumns(contentWidth)
 	pad := " "
 
 	var b strings.Builder
+	results := m.pageResults()
+	rule := pad + m.styles.render(m.styles.dim, strings.Repeat("─", contentWidth)) + "\n"
 
-	// Column headers
-	hdr := fmt.Sprintf("%-*s %-*s %-*s %-*s %-*s %-*s %-*s",
-		cols.typeCol, "Type",
-		cols.age, "Age",
-		cols.id, "ID",
-		cols.branch, "Branch",
-		cols.repo, "Repo",
-		cols.prompt, "Title",
-		cols.author, "Author",
-	)
-	b.WriteString(pad + m.styles.render(m.styles.dim, hdr) + "\n")
-
-	// Header separator
-	b.WriteString(pad + m.styles.render(m.styles.dim, strings.Repeat("─", contentWidth)) + "\n")
-
-	// Rows
-	for i, r := range m.pageResults() {
-		row := m.viewRow(r, cols)
-		if i == m.cursor && m.styles.colorEnabled {
-			b.WriteString(pad + m.styles.selected.Render(row))
-		} else {
-			b.WriteString(pad + row)
+	for i, r := range results {
+		if i > 0 {
+			b.WriteString(rule)
 		}
-		b.WriteString("\n")
+		b.WriteString(m.viewResultItem(r, i == m.cursor, contentWidth))
 	}
 
 	return b.String()
 }
 
-// typeLabel returns a short type badge for display in the table.
+// viewResultItem renders a single two-line result entry (title line + meta line)
+// with a leading 1-char pad on each line, matching the surrounding browse layout.
+func (m searchModel) viewResultItem(r search.Result, selected bool, contentWidth int) string {
+	pad := " "
+	var b strings.Builder
+
+	// ── Title line: gutter + bold title …… right-aligned age ──
+	node, caret := "◇", " "
+	if selected {
+		node, caret = "◆", "▸"
+	}
+	gutter := caret + " " + m.styles.render(resultNodeStyle(m.styles, r.Type, selected), node) + " "
+
+	age := formatSearchAge(r.ResultCreatedAt())
+	ageW := lipgloss.Width(age)
+
+	titleMax := max(contentWidth-gutterWidth-ageW-1, 8)
+	title := stringutil.TruncateRunes(stringutil.CollapseWhitespace(r.ResultTitle()), titleMax, "…")
+	titleStyle := m.styles.bold
+	if selected {
+		titleStyle = m.styles.selected
+	}
+
+	gap := max(contentWidth-gutterWidth-lipgloss.Width(title)-ageW, 1)
+	b.WriteString(pad + gutter + m.styles.render(titleStyle, title) +
+		strings.Repeat(" ", gap) + m.styles.render(m.styles.dim, age) + "\n")
+
+	// ── Meta line: type · repo · ⎇ branch · author (indented to title col) ──
+	indent := strings.Repeat(" ", gutterWidth)
+	// The search type constants ("checkpoint", "commit", "session") double as
+	// the lowercase type word shown on the metadata line.
+	typeWord := r.Type
+	typeTag := m.styles.render(resultNodeStyle(m.styles, r.Type, false), typeWord)
+
+	var meta strings.Builder
+	meta.WriteString(r.ResultOrg() + "/" + r.ResultRepo())
+	if br := r.ResultBranch(); br != "" {
+		meta.WriteString("  ⎇ " + br)
+	}
+	if author := r.ResultAuthor(); author != "" {
+		meta.WriteString("  · " + author)
+	}
+	metaMax := max(contentWidth-gutterWidth-lipgloss.Width(typeWord)-2, 8)
+	metaStr := stringutil.TruncateRunes(meta.String(), metaMax, "…")
+	b.WriteString(pad + indent + typeTag + "  " + m.styles.render(m.styles.dim, metaStr) + "\n")
+
+	return b.String()
+}
+
+// resultNodeStyle returns the accent style for a result's graph node and type
+// tag: orange for checkpoints, purple for sessions, blue for commits. The
+// selected node is always rendered in the shared selection accent.
+func resultNodeStyle(s searchStyles, resultType string, selected bool) lipgloss.Style {
+	if !s.colorEnabled {
+		return lipgloss.NewStyle()
+	}
+	if selected {
+		return s.selected
+	}
+	switch resultType {
+	case search.TypeSession:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(searchAccentPurple))
+	case search.TypeCommit:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(searchAccentBlue))
+	default: // checkpoint and unknown
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(searchAccentOrange))
+	}
+}
+
+// typeLabel returns a short type badge for display in the static table.
 func typeLabel(resultType string) string {
 	switch resultType {
 	case search.TypeCheckpoint:
@@ -679,22 +907,6 @@ func typeLabel(resultType string) string {
 	default:
 		return strings.ToUpper(resultType[:min(2, len(resultType))])
 	}
-}
-
-func (m searchModel) viewRow(r search.Result, cols columnLayout) string {
-	typeBadge := fmt.Sprintf("%-*s", cols.typeCol, typeLabel(r.Type))
-	age := fmt.Sprintf("%-*s", cols.age, stringutil.TruncateRunes(formatSearchAge(r.ResultCreatedAt()), cols.age, ""))
-	id := fmt.Sprintf("%-*s", cols.id, stringutil.TruncateRunes(formatResultID(r), cols.id-1, "…"))
-	branch := fmt.Sprintf("%-*s", cols.branch, stringutil.TruncateRunes(r.ResultBranch(), cols.branch-1, "…"))
-	repo := fmt.Sprintf("%-*s", cols.repo, stringutil.TruncateRunes(
-		r.ResultOrg()+"/"+r.ResultRepo(), cols.repo-1, "…",
-	))
-	title := fmt.Sprintf("%-*s", cols.prompt, stringutil.TruncateRunes(
-		stringutil.CollapseWhitespace(r.ResultTitle()), cols.prompt-1, "…",
-	))
-	author := fmt.Sprintf("%-*s", cols.author, stringutil.TruncateRunes(r.ResultAuthor(), cols.author-1, "…"))
-
-	return fmt.Sprintf("%s %s %s %s %s %s %s", typeBadge, age, id, branch, repo, title, author)
 }
 
 // formatResultID returns a display-friendly ID for a result.
@@ -991,40 +1203,57 @@ func formatDetailCreatedAt(createdAt string, styles searchStyles) string {
 	return t.Format("Jan 02, 2006") + " " + styles.render(styles.dim, "("+timeAgo(t)+")")
 }
 
-// maxCardContentLines is the maximum number of content lines shown in the
-// inline detail card. Longer content is truncated with a "enter for more" hint.
-// The full content is always available via the detail view (enter key).
-const maxCardContentLines = 15
+// viewDetailPane renders the pinned detail card for the selected result,
+// sized to exactly paneH terminal rows. Content taller than the pane is
+// truncated with a "▼ enter for more" hint (the full content is always
+// available via the full-screen detail view). Shorter content is padded so
+// the pane occupies its full allotment and the footer stays pinned.
+func (m searchModel) viewDetailPane(paneH int) string {
+	r := m.selectedResult()
+	if r == nil || paneH <= 0 {
+		return strings.TrimSuffix(padToHeight("", paneH), "\n")
+	}
 
-func (m searchModel) viewDetailCard(r search.Result) string {
-	var contentWidth int
-	var borderWidth int
+	var contentWidth, borderWidth, chrome int
 	if m.styles.colorEnabled {
-		// lipgloss .Width(W) includes padding but excludes border:
-		//   text wraps at W - padding(4), rendered = W + border(2), + indent(1) = W + 3
+		// lipgloss v2 .Width(W) is the outer width: it absorbs horizontal padding
+		// (2+2) and the rounded border (1+1), so the inner text area is W-6.
+		// .Height(H) yields H + vertical-padding(0) + border(2) rendered rows, so
+		// vertical chrome is 2. Wrapping content to W-6 keeps the card at its
+		// budgeted height.
 		borderWidth = max(m.width-3, 0)
-		contentWidth = max(borderWidth-4, 0)
+		contentWidth = max(borderWidth-6, 0)
+		chrome = 2
 	} else {
-		// No border/padding in NO_COLOR mode, only indent(1)
+		// NO_COLOR: a leading dim rule stands in for the top border.
 		contentWidth = max(m.width-1, 0)
+		chrome = 1
 	}
-	cardContent := m.renderDetailContent(r, contentWidth, false)
 
-	lines := strings.Split(cardContent, "\n")
-	if len(lines) > maxCardContentLines {
-		lines = lines[:maxCardContentLines]
+	contentLines := max(paneH-chrome, 1)
+	lines := strings.Split(m.renderDetailContent(*r, contentWidth, false), "\n")
+	if len(lines) > contentLines {
+		lines = lines[:contentLines]
 		hint := m.styles.render(m.styles.dim, "▼ enter for more")
-		hintWidth := lipgloss.Width(hint)
-		lines = append(lines, "", strings.Repeat(" ", max(contentWidth-hintWidth, 0))+hint)
-		cardContent = strings.Join(lines, "\n")
+		lines[contentLines-1] = strings.Repeat(" ", max(contentWidth-lipgloss.Width(hint), 0)) + hint
 	}
+	// Hard-cap each line to the inner width (ANSI-aware) so no line wraps inside
+	// the bordered box and inflates the card past its budgeted height. This keeps
+	// the pane exactly paneH rows tall regardless of detail content.
+	for i, ln := range lines {
+		if lipgloss.Width(ln) > contentWidth {
+			lines[i] = xansi.Truncate(ln, contentWidth, "…")
+		}
+	}
+	body := strings.Join(lines, "\n")
 
-	card := cardContent
 	if m.styles.colorEnabled {
-		card = m.styles.detailBorder.Width(borderWidth).Render(cardContent)
+		card := m.styles.detailBorder.Width(borderWidth).Height(contentLines).Render(body)
+		return strings.TrimSuffix(indentLines(card, " "), "\n")
 	}
 
-	return indentLines(card, " ")
+	pane := " " + m.styles.horizontalRule(contentWidth) + "\n" + strings.TrimSuffix(indentLines(body, " "), "\n")
+	return padToHeight(pane, paneH)
 }
 
 func (m searchModel) viewDetailFull() string {
@@ -1064,21 +1293,12 @@ func (m searchModel) viewHelp() string {
 	if pages > 1 {
 		left += dot + m.styles.helpItem("n/p", "page")
 	}
-	left += dot + m.styles.helpItem("0-3", "type") + dot +
+	left += dot + m.styles.helpItem("1-3", "type") + dot +
 		m.styles.helpItem(keys.Quit.Help().Key, keys.Quit.Help().Desc)
 
-	filtered := m.filteredResults()
-	right := fmt.Sprintf("%d results", len(filtered))
-	if pages > 1 {
-		right = fmt.Sprintf("page %d/%d · %d results", m.page+1, pages, len(filtered))
-	}
-
-	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right) - 2
-	if gap < 1 {
-		gap = 1
-	}
-
-	return left + strings.Repeat(" ", gap) + m.styles.render(m.styles.dim, right) + "\n"
+	// The page / results count lives on the status row beneath the list
+	// (viewListStatusRow), so the footer holds only the key hints.
+	return left + "\n"
 }
 
 // indentLines prefixes every line of text with the given prefix.

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -23,7 +23,7 @@ func testResults() []search.Result {
 	return []search.Result{
 		{
 			Type: "checkpoint",
-			Data: search.CheckpointResult{
+			Checkpoint: &search.CheckpointResult{
 				ID:             "a3b2c4d5e6f7",
 				Prompt:         "add auth middleware to protect API routes",
 				CommitSHA:      &sha1,
@@ -44,7 +44,7 @@ func testResults() []search.Result {
 		},
 		{
 			Type: "checkpoint",
-			Data: search.CheckpointResult{
+			Checkpoint: &search.CheckpointResult{
 				ID:            "d5e6f789ab01",
 				Prompt:        "fix auth token refresh",
 				CommitSHA:     &sha2,
@@ -64,10 +64,55 @@ func testResults() []search.Result {
 	}
 }
 
+func testMultiTypeResults() []search.Result {
+	results := testResults()
+	results = append(results,
+		search.Result{
+			Type: "commit",
+			Commit: &search.CommitResult{
+				ID:            "cm1",
+				CommitSHA:     "abc1234567890",
+				CommitMessage: "fix: auth token validation",
+				CommitSubject: "fix: auth token validation",
+				Branch:        "main",
+				Org:           "entirehq",
+				Repo:          "entire.io",
+				Author:        "carol",
+				CreatedAt:     "2026-03-22T09:00:00Z",
+				Additions:     15,
+				Deletions:     3,
+				FilesChanged:  2,
+			},
+			Meta: search.Meta{MatchType: "keyword", Score: 0.4},
+		},
+		search.Result{
+			Type: "session",
+			Session: &search.SessionResult{
+				SessionID:   "ss1",
+				DisplayName: "Debug auth flow",
+				Org:         "entirehq",
+				Repo:        "entire.io",
+				CreatedAt:   "2026-03-23T11:00:00Z",
+				StepCount:   8,
+			},
+			Meta: search.Meta{MatchType: "semantic", Score: 0.3},
+		},
+	)
+	return results
+}
+
 func testModel() searchModel {
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{ServiceURL: "http://test", Owner: "o", Repo: "r", Limit: 20}
 	m := newSearchModel(testResults(), "auth", 2, cfg, ss)
+	return initTestViewport(m)
+}
+
+func testMultiTypeModel() searchModel {
+	ss := statusStyles{colorEnabled: false, width: 120}
+	cfg := search.Config{ServiceURL: "http://test", Owner: "o", Repo: "r", Limit: 20}
+	results := testMultiTypeResults()
+	m := newSearchModel(results, "auth", len(results), cfg, ss)
 	return initTestViewport(m)
 }
 
@@ -139,7 +184,7 @@ func TestSearchModel_TopBottomNavigation(t *testing.T) {
 
 	results := make([]search.Result, 30)
 	for i := range results {
-		results[i] = search.Result{Data: search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 
 	tests := []struct {
@@ -312,13 +357,18 @@ func TestSearchModel_View(t *testing.T) {
 	}
 
 	// Column headers
-	for _, col := range []string{"Age", "ID", "Branch", "Repo", "Prompt", "Author"} {
+	for _, col := range []string{"Type", "Age", "ID", "Branch", "Repo", "Title", "Author"} {
 		if !strings.Contains(view, col) {
 			t.Errorf("view missing column header %q", col)
 		}
 	}
 
-	// Table data
+	// Table data - type badge
+	if !strings.Contains(view, "CP") {
+		t.Error("view missing checkpoint type badge")
+	}
+
+	// Table data - ID
 	if !strings.Contains(view, "a3b2c4d5e6f") {
 		t.Error("view missing first result ID")
 	}
@@ -352,6 +402,157 @@ func TestSearchModel_View(t *testing.T) {
 	}
 }
 
+func TestSearchModel_ViewMultiTypes(t *testing.T) {
+	t.Parallel()
+	m := testMultiTypeModel()
+	view := m.View().Content
+
+	// Type badges
+	if !strings.Contains(view, "CP") {
+		t.Error("view missing CP type badge")
+	}
+	if !strings.Contains(view, "CM") {
+		t.Error("view missing CM type badge")
+	}
+	if !strings.Contains(view, "SS") {
+		t.Error("view missing SS type badge")
+	}
+
+	// Type tabs
+	if !strings.Contains(view, "Checkpoints") {
+		t.Error("view missing Checkpoints tab")
+	}
+	if !strings.Contains(view, "Sessions") {
+		t.Error("view missing Sessions tab")
+	}
+	if !strings.Contains(view, "Commits") {
+		t.Error("view missing Commits tab")
+	}
+}
+
+func TestSearchModel_TypeFilterKeys(t *testing.T) {
+	t.Parallel()
+	m := testMultiTypeModel()
+
+	// Press 1 → filter to checkpoints
+	m = updateModel(t, m, tea.KeyPressMsg{Code: '1', Text: "1"})
+	if m.filterType != typeFilterCheckpoints {
+		t.Errorf("after 1: filterType = %q, want %q", m.filterType, typeFilterCheckpoints)
+	}
+	if len(m.filteredResults()) != 2 {
+		t.Errorf("checkpoint filter: got %d results, want 2", len(m.filteredResults()))
+	}
+
+	// Press 2 → filter to sessions
+	m = updateModel(t, m, tea.KeyPressMsg{Code: '2', Text: "2"})
+	if m.filterType != typeFilterSessions {
+		t.Errorf("after 2: filterType = %q, want %q", m.filterType, typeFilterSessions)
+	}
+	if len(m.filteredResults()) != 1 {
+		t.Errorf("session filter: got %d results, want 1", len(m.filteredResults()))
+	}
+
+	// Press 3 → filter to commits
+	m = updateModel(t, m, tea.KeyPressMsg{Code: '3', Text: "3"})
+	if m.filterType != typeFilterCommits {
+		t.Errorf("after 3: filterType = %q, want %q", m.filterType, typeFilterCommits)
+	}
+	if len(m.filteredResults()) != 1 {
+		t.Errorf("commit filter: got %d results, want 1", len(m.filteredResults()))
+	}
+
+	// Press 0 → show all
+	m = updateModel(t, m, tea.KeyPressMsg{Code: '0', Text: "0"})
+	if m.filterType != typeFilterAll {
+		t.Errorf("after 0: filterType = %q, want %q", m.filterType, typeFilterAll)
+	}
+	if len(m.filteredResults()) != 4 {
+		t.Errorf("all filter: got %d results, want 4", len(m.filteredResults()))
+	}
+}
+
+func TestSearchModel_TypeFilterResetsCursorAndPage(t *testing.T) {
+	t.Parallel()
+	m := testMultiTypeModel()
+	m.cursor = 2
+	m.page = 1
+
+	m = updateModel(t, m, tea.KeyPressMsg{Code: '1', Text: "1"})
+	if m.cursor != 0 {
+		t.Errorf("cursor should reset to 0 on type change, got %d", m.cursor)
+	}
+	if m.page != 0 {
+		t.Errorf("page should reset to 0 on type change, got %d", m.page)
+	}
+}
+
+func TestSearchModel_CommitDetail(t *testing.T) {
+	t.Parallel()
+	m := testMultiTypeModel()
+
+	// Filter to commits and check detail
+	m.filterType = typeFilterCommits
+	m.cursor = 0
+	m = m.refreshBrowseContent()
+
+	r := m.selectedResult()
+	if r == nil {
+		t.Fatal("no selected result")
+	}
+	if r.Type != "commit" {
+		t.Fatalf("selected result type = %q, want commit", r.Type)
+	}
+
+	content := m.renderDetailContent(*r, 80, true)
+	if !strings.Contains(content, "Commit Detail") {
+		t.Error("missing Commit Detail title")
+	}
+	if !strings.Contains(content, "abc1234") {
+		t.Error("missing truncated SHA")
+	}
+	if !strings.Contains(content, "fix: auth token validation") {
+		t.Error("missing commit subject")
+	}
+	if !strings.Contains(content, "+15") {
+		t.Error("missing additions")
+	}
+	if !strings.Contains(content, "-3") {
+		t.Error("missing deletions")
+	}
+}
+
+func TestSearchModel_SessionDetail(t *testing.T) {
+	t.Parallel()
+	m := testMultiTypeModel()
+
+	// Filter to sessions and check detail
+	m.filterType = typeFilterSessions
+	m.cursor = 0
+	m = m.refreshBrowseContent()
+
+	r := m.selectedResult()
+	if r == nil {
+		t.Fatal("no selected result")
+	}
+	if r.Type != "session" {
+		t.Fatalf("selected result type = %q, want session", r.Type)
+	}
+
+	content := m.renderDetailContent(*r, 80, true)
+	if !strings.Contains(content, "Session Detail") {
+		t.Error("missing Session Detail title")
+	}
+	if !strings.Contains(content, "ss1") {
+		t.Error("missing session ID")
+	}
+	if !strings.Contains(content, "Debug auth flow") {
+		t.Error("missing display name")
+	}
+	if !strings.Contains(content, "8") {
+		t.Error("missing step count")
+	}
+}
+
 func TestSearchModel_BrowseFooterHelp(t *testing.T) {
 	t.Parallel()
 	m := testModel()
@@ -361,6 +562,7 @@ func TestSearchModel_BrowseFooterHelp(t *testing.T) {
 		"/ search",
 		"↑/↓, j/k scroll",
 		"home/end, g/G top/bottom",
+		"0-3 type",
 		"q quit",
 	}
 	lastIndex := -1
@@ -390,7 +592,7 @@ func TestSearchModel_BrowseFooterHelpIncludesPagingForMultiplePages(t *testing.T
 
 	results := make([]search.Result, 30)
 	for i := range results {
-		results[i] = search.Result{Data: search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 
 	ss := statusStyles{colorEnabled: false, width: 120}
@@ -402,6 +604,7 @@ func TestSearchModel_BrowseFooterHelpIncludesPagingForMultiplePages(t *testing.T
 		"↑/↓, j/k scroll",
 		"home/end, g/G top/bottom",
 		"n/p page",
+		"0-3 type",
 		"q quit",
 	}
 	lastIndex := -1
@@ -595,7 +798,7 @@ func TestRenderDetailContent_AuthorEmptyUsername(t *testing.T) {
 
 	// Empty string username should fall back to display name
 	empty := ""
-	r.Data.AuthorUsername = &empty
+	r.Checkpoint.AuthorUsername = &empty
 	content = m.renderDetailContent(r, 80, false)
 	if !strings.Contains(content, "bob") {
 		t.Error("author should show display name when username is empty string")
@@ -606,7 +809,7 @@ func TestRenderDetailContent_PromptWrapping(t *testing.T) {
 	t.Parallel()
 	m := testModel()
 	r := testResults()[0]
-	r.Data.Prompt = "line one\nline two\nline three"
+	r.Checkpoint.Prompt = "line one\nline two\nline three"
 
 	content := m.renderDetailContent(r, 80, false)
 	// CollapseWhitespace should merge the newlines into spaces
@@ -622,24 +825,28 @@ func TestRenderSearchStatic(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	styles := statusStyles{colorEnabled: false, width: 100}
-	renderSearchStatic(&buf, testResults(), "auth", 2, styles)
+	styles := statusStyles{colorEnabled: false, width: 120}
+	results := testMultiTypeResults()
+	renderSearchStatic(&buf, results, "auth", len(results), styles)
 	output := buf.String()
 
-	if !strings.Contains(output, `Found 2 checkpoints matching "auth"`) {
-		t.Error("static output missing header")
+	if !strings.Contains(output, `Found 4 results matching "auth"`) {
+		t.Errorf("static output missing header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "TYPE") {
+		t.Error("static output missing TYPE header")
 	}
 	if !strings.Contains(output, "REPO") {
-		t.Error("static output missing repo header")
+		t.Error("static output missing REPO header")
 	}
-	if !strings.Contains(output, "entire") {
-		t.Error("static output missing repo value")
+	if !strings.Contains(output, "CP") {
+		t.Error("static output missing CP badge")
 	}
-	if !strings.Contains(output, "a3b2c4d5e6") {
-		t.Error("static output missing first result ID")
+	if !strings.Contains(output, "CM") {
+		t.Error("static output missing CM badge")
 	}
-	if !strings.Contains(output, "d5e6f789ab") {
-		t.Error("static output missing second result ID")
+	if !strings.Contains(output, "SS") {
+		t.Error("static output missing SS badge")
 	}
 }
 
@@ -678,22 +885,30 @@ func TestSearchModel_TotalPages(t *testing.T) {
 	}
 
 	// 26 loaded results, total=26 → 2 pages
-	many := newSearchModel(make([]search.Result, 26), "q", 26, cfg, ss)
+	results := make([]search.Result, 26)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	many := newSearchModel(results, "q", 26, cfg, ss)
 	if got := many.totalPages(); got != 2 {
 		t.Errorf("totalPages() with total=26 = %d, want 2", got)
 	}
 }
 
-func TestSearchModel_TotalPagesUsesAPITotal(t *testing.T) {
+func TestSearchModel_TotalPagesUsesFilteredCount(t *testing.T) {
 	t.Parallel()
 
-	// Only 20 results loaded but API reports total=100
-	ss := statusStyles{colorEnabled: false, width: 100}
-	cfg := search.Config{}
-	m := newSearchModel(make([]search.Result, 20), "q", 100, cfg, ss)
+	m := testMultiTypeModel()
 
-	if got := m.totalPages(); got != 4 {
-		t.Errorf("totalPages() with 20 loaded but total=100 = %d, want 4", got)
+	// Unfiltered: 4 results → 1 page
+	if got := m.totalPages(); got != 1 {
+		t.Errorf("unfiltered totalPages = %d, want 1", got)
+	}
+
+	// Filter to checkpoints: 2 results → 1 page
+	m.filterType = typeFilterCheckpoints
+	if got := m.totalPages(); got != 1 {
+		t.Errorf("checkpoint-filtered totalPages = %d, want 1", got)
 	}
 }
 
@@ -702,7 +917,11 @@ func TestSearchModel_AppendResults(t *testing.T) {
 
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{}
-	m := newSearchModel(make([]search.Result, 25), "q", 50, cfg, ss)
+	results := make([]search.Result, 25)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	m := newSearchModel(results, "q", 50, cfg, ss)
 
 	if m.apiPage != 1 {
 		t.Fatalf("initial apiPage = %d, want 1", m.apiPage)
@@ -710,6 +929,9 @@ func TestSearchModel_AppendResults(t *testing.T) {
 
 	// Simulate receiving more results
 	newResults := make([]search.Result, 25)
+	for i := range newResults {
+		newResults[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("new-%02d", i)}}
+	}
 	m = updateModel(t, m, searchMoreResultsMsg{results: newResults})
 
 	if len(m.results) != 50 {
@@ -729,7 +951,11 @@ func TestSearchModel_FetchMoreOnNavigate(t *testing.T) {
 	// 25 loaded results, total=50 → 2 display pages but only 1 page loaded
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{ServiceURL: "http://test", Owner: "o", Repo: "r", Limit: 25}
-	m := newSearchModel(make([]search.Result, 25), "q", 50, cfg, ss)
+	results := make([]search.Result, 25)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	m := newSearchModel(results, "q", 50, cfg, ss)
 
 	// Navigate to page 2 — should trigger fetch
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
@@ -757,7 +983,7 @@ func TestSearchModel_NoFetchWhenResultsLoaded(t *testing.T) {
 	cfg := search.Config{ServiceURL: "http://test", Owner: "o", Repo: "r", Limit: 25}
 	results := make([]search.Result, 50)
 	for i := range results {
-		results[i] = search.Result{Data: search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 	m := newSearchModel(results, "q", 50, cfg, ss)
 
@@ -806,8 +1032,8 @@ func TestSearchModel_SelectedResult(t *testing.T) {
 		t.Fatal("selectedResult() = nil, want first result")
 		return
 	}
-	if r.Data.ID != "a3b2c4d5e6f7" {
-		t.Errorf("selectedResult().Data.ID = %q, want %q", r.Data.ID, "a3b2c4d5e6f7")
+	if r.Checkpoint == nil || r.Checkpoint.ID != "a3b2c4d5e6f7" {
+		t.Errorf("selectedResult().Checkpoint.ID = %q, want %q", r.ResultID(), "a3b2c4d5e6f7")
 	}
 
 	// Move cursor to second result
@@ -817,8 +1043,8 @@ func TestSearchModel_SelectedResult(t *testing.T) {
 		t.Fatal("selectedResult() at cursor 1 = nil")
 		return
 	}
-	if r.Data.ID != "d5e6f789ab01" {
-		t.Errorf("selectedResult().Data.ID = %q, want %q", r.Data.ID, "d5e6f789ab01")
+	if r.Checkpoint == nil || r.Checkpoint.ID != "d5e6f789ab01" {
+		t.Errorf("selectedResult().Checkpoint.ID = %q, want %q", r.ResultID(), "d5e6f789ab01")
 	}
 
 	// Out-of-range cursor returns nil
@@ -836,7 +1062,7 @@ func TestSearchModel_PageNavigation(t *testing.T) {
 	cfg := search.Config{ServiceURL: "http://test", Owner: "o", Repo: "r"}
 	results := make([]search.Result, 30)
 	for i := range results {
-		results[i] = search.Result{Data: search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 	m := newSearchModel(results, "q", 30, cfg, ss)
 
@@ -924,7 +1150,11 @@ func TestSearchModel_FetchMoreError(t *testing.T) {
 
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{}
-	m := newSearchModel(make([]search.Result, 25), "q", 50, cfg, ss)
+	results := make([]search.Result, 25)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	m := newSearchModel(results, "q", 50, cfg, ss)
 	m.fetchingMore = true
 
 	m = updateModel(t, m, searchMoreResultsMsg{err: errTestSearch})
@@ -945,7 +1175,11 @@ func TestSearchModel_FetchMoreEmpty_CapsTotal(t *testing.T) {
 
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{}
-	m := newSearchModel(make([]search.Result, 25), "q", 100, cfg, ss)
+	results := make([]search.Result, 25)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	m := newSearchModel(results, "q", 100, cfg, ss)
 
 	if m.totalPages() != 4 {
 		t.Fatalf("initial totalPages = %d, want 4", m.totalPages())
@@ -968,7 +1202,11 @@ func TestSearchModel_ViewFetchingMore(t *testing.T) {
 	// Model with 25 loaded results but on page 2 (no data) while fetching
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{}
-	m := initTestViewport(newSearchModel(make([]search.Result, 25), "q", 50, cfg, ss))
+	results := make([]search.Result, 25)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
+	}
+	m := initTestViewport(newSearchModel(results, "q", 50, cfg, ss))
 	m.page = 1
 	m.fetchingMore = true
 	m = m.refreshBrowseContent()
@@ -1146,7 +1384,10 @@ func TestSearchModel_ApiPageInitialization(t *testing.T) {
 func TestComputeColumns(t *testing.T) {
 	t.Parallel()
 
-	cols := computeColumns(100)
+	cols := computeColumns(120)
+	if cols.typeCol != 5 {
+		t.Errorf("type width = %d, want 5", cols.typeCol)
+	}
 	if cols.age != 10 {
 		t.Errorf("age width = %d, want 10", cols.age)
 	}
@@ -1166,5 +1407,38 @@ func TestComputeColumns(t *testing.T) {
 	}
 	if cols.repo < 10 {
 		t.Errorf("repo width on narrow terminal = %d, want >= 10", cols.repo)
+	}
+}
+
+func TestSearchModel_ComputeTypeCounts(t *testing.T) {
+	t.Parallel()
+
+	m := testMultiTypeModel()
+	cp, cm, ss := m.computeTypeCounts()
+	if cp != 2 {
+		t.Errorf("checkpoints = %d, want 2", cp)
+	}
+	if cm != 1 {
+		t.Errorf("commits = %d, want 1", cm)
+	}
+	if ss != 1 {
+		t.Errorf("sessions = %d, want 1", ss)
+	}
+}
+
+func TestSearchModel_ComputeTypeCounts_UsesAPICounts(t *testing.T) {
+	t.Parallel()
+
+	m := testMultiTypeModel()
+	m.counts = &search.TypeCounts{Checkpoints: 10, Commits: 5, Sessions: 3}
+	cp, cm, ss := m.computeTypeCounts()
+	if cp != 10 {
+		t.Errorf("checkpoints = %d, want 10", cp)
+	}
+	if cm != 5 {
+		t.Errorf("commits = %d, want 5", cm)
+	}
+	if ss != 3 {
+		t.Errorf("sessions = %d, want 3", ss)
 	}
 }

--- a/cmd/entire/cli/search_tui_test.go
+++ b/cmd/entire/cli/search_tui_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/entireio/cli/cmd/entire/cli/search"
 )
 
@@ -216,16 +217,16 @@ func TestSearchModel_TopBottomNavigation(t *testing.T) {
 			key:         tea.KeyPressMsg{Code: tea.KeyEnd},
 			startPage:   0,
 			startCursor: 0,
-			wantPage:    1,
-			wantCursor:  4,
+			wantPage:    2,
+			wantCursor:  9,
 		},
 		{
 			name:        "G",
 			key:         tea.KeyPressMsg{Code: 'G', Text: "G"},
 			startPage:   0,
 			startCursor: 0,
-			wantPage:    1,
-			wantCursor:  4,
+			wantPage:    2,
+			wantCursor:  9,
 		},
 	}
 
@@ -338,6 +339,88 @@ func TestSearchModel_SearchModeEnterEmpty(t *testing.T) {
 	}
 }
 
+// TestSearchModel_BrowseNeverExceedsHeight guards the master-detail layout:
+// the browse view (header + scrolling list + pinned detail card + footer) must
+// never render more rows than the terminal height, or the detail card gets
+// clipped at the bottom (the bug this layout fixes).
+func TestSearchModel_BrowseNeverExceedsHeight(t *testing.T) {
+	t.Parallel()
+
+	results := make([]search.Result, 10)
+	for i := range results {
+		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{
+			ID:           fmt.Sprintf("id-%02d", i),
+			Prompt:       "a deliberately long prompt that wraps across the detail card width several times over",
+			Branch:       "feature/a-fairly-long-branch-name",
+			Org:          "entireio",
+			Repo:         "cli",
+			Author:       "toothbrush",
+			CreatedAt:    "2026-06-03T10:00:00Z",
+			FilesTouched: []string{"cmd/entire/cli/auth.go", "cmd/entire/cli/some/deeply/nested/long/path/file.go"},
+		}}
+	}
+
+	for _, color := range []bool{false, true} {
+		for _, w := range []int{40, 80, 120} {
+			for _, h := range []int{12, 20, 24, 40, 60} {
+				ss := statusStyles{colorEnabled: color, width: w}
+				m := initTestViewport(newSearchModel(results, "auth", 47, search.Config{}, ss))
+				m.width, m.height = w, h
+				m.cursor = 7 // force the list to scroll
+				m = m.refreshBrowseContent()
+
+				if got := lipgloss.Height(m.viewBrowse()); got > h {
+					t.Errorf("color=%v w=%d h=%d: rendered %d rows, exceeds height", color, w, h, got)
+				}
+			}
+		}
+	}
+}
+
+// TestSearchModel_ListScrollHint verifies the reserved gap row shows a "more
+// results" affordance when the list is cut off, and stays blank when it fits.
+func TestSearchModel_ListScrollHint(t *testing.T) {
+	t.Parallel()
+
+	mk := func(n int) []search.Result {
+		r := make([]search.Result, n)
+		for i := range r {
+			r[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{
+				ID: fmt.Sprintf("id-%02d", i), Prompt: "p", Branch: "main", Org: "o", Repo: "r",
+				Author: "a", CreatedAt: "2026-06-03T10:00:00Z",
+			}}
+		}
+		return r
+	}
+
+	// Short terminal + 25 results (multiple pages) → the page's rows can't all fit.
+	overflow := newSearchModel(mk(25), "auth", 25, search.Config{}, statusStyles{width: 80})
+	overflow.height, overflow.width = 28, 80
+	overflow = overflow.refreshBrowseContent()
+
+	overflow.cursor = 0
+	if v := overflow.viewBrowse(); !strings.Contains(v, "↓ more results") {
+		t.Error("expected a down-scroll hint at the top of an overflowing list")
+	}
+	// The page / results count renders on the same status row beneath the list.
+	if v := overflow.viewBrowse(); !strings.Contains(v, "page 1/3") || !strings.Contains(v, "25 results") {
+		t.Errorf("expected page/results count in the list status row: %q", v)
+	}
+	overflow.cursor = 9
+	overflow = overflow.refreshBrowseContent()
+	if v := overflow.viewBrowse(); !strings.Contains(v, "↑ more results") {
+		t.Error("expected an up-scroll hint at the bottom of an overflowing list")
+	}
+
+	// Tall terminal + few results → everything fits, no hint.
+	fits := newSearchModel(mk(3), "auth", 3, search.Config{}, statusStyles{width: 80})
+	fits.height, fits.width = 50, 80
+	fits = fits.refreshBrowseContent()
+	if v := fits.viewBrowse(); strings.Contains(v, "more results") {
+		t.Error("did not expect a scroll hint when the whole list fits")
+	}
+}
+
 func TestSearchModel_View(t *testing.T) {
 	t.Parallel()
 	m := testModel()
@@ -356,19 +439,12 @@ func TestSearchModel_View(t *testing.T) {
 		t.Error("view missing query in search bar")
 	}
 
-	// Column headers
-	for _, col := range []string{"Type", "Age", "ID", "Branch", "Repo", "Title", "Author"} {
-		if !strings.Contains(view, col) {
-			t.Errorf("view missing column header %q", col)
-		}
+	// List meta line shows the result's type word
+	if !strings.Contains(view, "checkpoint") {
+		t.Error("view missing checkpoint type word on meta line")
 	}
 
-	// Table data - type badge
-	if !strings.Contains(view, "CP") {
-		t.Error("view missing checkpoint type badge")
-	}
-
-	// Table data - ID
+	// Selected result's full ID is shown in the detail card
 	if !strings.Contains(view, "a3b2c4d5e6f") {
 		t.Error("view missing first result ID")
 	}
@@ -405,17 +481,20 @@ func TestSearchModel_View(t *testing.T) {
 func TestSearchModel_ViewMultiTypes(t *testing.T) {
 	t.Parallel()
 	m := testMultiTypeModel()
+	// Switch to the All tab so every result type renders in the list.
+	m.filterType = typeFilterAll
+	m = m.refreshBrowseContent()
 	view := m.View().Content
 
-	// Type badges
-	if !strings.Contains(view, "CP") {
-		t.Error("view missing CP type badge")
+	// List meta lines show each result's type word
+	if !strings.Contains(view, "checkpoint") {
+		t.Error("view missing checkpoint type word")
 	}
-	if !strings.Contains(view, "CM") {
-		t.Error("view missing CM type badge")
+	if !strings.Contains(view, "commit") {
+		t.Error("view missing commit type word")
 	}
-	if !strings.Contains(view, "SS") {
-		t.Error("view missing SS type badge")
+	if !strings.Contains(view, "session") {
+		t.Error("view missing session type word")
 	}
 
 	// Type tabs
@@ -461,13 +540,10 @@ func TestSearchModel_TypeFilterKeys(t *testing.T) {
 		t.Errorf("commit filter: got %d results, want 1", len(m.filteredResults()))
 	}
 
-	// Press 0 → show all
+	// Press 0 → no-op (the All tab was removed); filter stays on commits
 	m = updateModel(t, m, tea.KeyPressMsg{Code: '0', Text: "0"})
-	if m.filterType != typeFilterAll {
-		t.Errorf("after 0: filterType = %q, want %q", m.filterType, typeFilterAll)
-	}
-	if len(m.filteredResults()) != 4 {
-		t.Errorf("all filter: got %d results, want 4", len(m.filteredResults()))
+	if m.filterType != typeFilterCommits {
+		t.Errorf("after 0: filterType = %q, want %q (no-op)", m.filterType, typeFilterCommits)
 	}
 }
 
@@ -562,7 +638,7 @@ func TestSearchModel_BrowseFooterHelp(t *testing.T) {
 		"/ search",
 		"↑/↓, j/k scroll",
 		"home/end, g/G top/bottom",
-		"0-3 type",
+		"1-3 type",
 		"q quit",
 	}
 	lastIndex := -1
@@ -604,7 +680,7 @@ func TestSearchModel_BrowseFooterHelpIncludesPagingForMultiplePages(t *testing.T
 		"↑/↓, j/k scroll",
 		"home/end, g/G top/bottom",
 		"n/p page",
-		"0-3 type",
+		"1-3 type",
 		"q quit",
 	}
 	lastIndex := -1
@@ -890,8 +966,8 @@ func TestSearchModel_TotalPages(t *testing.T) {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 	many := newSearchModel(results, "q", 26, cfg, ss)
-	if got := many.totalPages(); got != 2 {
-		t.Errorf("totalPages() with total=26 = %d, want 2", got)
+	if got := many.totalPages(); got != 3 {
+		t.Errorf("totalPages() with total=26 = %d, want 3", got)
 	}
 }
 
@@ -948,14 +1024,15 @@ func TestSearchModel_AppendResults(t *testing.T) {
 func TestSearchModel_FetchMoreOnNavigate(t *testing.T) {
 	t.Parallel()
 
-	// 25 loaded results, total=50 → 2 display pages but only 1 page loaded
+	// 10 loaded results, total=50 → multiple display pages but only 1 page loaded
 	ss := statusStyles{colorEnabled: false, width: 100}
-	cfg := search.Config{ServiceURL: "http://test", Owner: "o", Repo: "r", Limit: 25}
-	results := make([]search.Result, 25)
+	cfg := search.Config{ServiceURL: "http://test", Owner: "o", Repo: "r", Limit: 10}
+	results := make([]search.Result, 10)
 	for i := range results {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 	m := newSearchModel(results, "q", 50, cfg, ss)
+	m.filterType = typeFilterAll // fetch-more from the API applies in the All view
 
 	// Navigate to page 2 — should trigger fetch
 	updated, cmd := m.Update(tea.KeyPressMsg{Code: 'n', Text: "n"})
@@ -1057,14 +1134,14 @@ func TestSearchModel_SelectedResult(t *testing.T) {
 func TestSearchModel_PageNavigation(t *testing.T) {
 	t.Parallel()
 
-	// Create model with 30 results (2 pages)
+	// Create model with 20 results (2 pages at 10/page)
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{ServiceURL: "http://test", Owner: "o", Repo: "r"}
-	results := make([]search.Result, 30)
+	results := make([]search.Result, 20)
 	for i := range results {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
-	m := newSearchModel(results, "q", 30, cfg, ss)
+	m := newSearchModel(results, "q", 20, cfg, ss)
 
 	if m.page != 0 {
 		t.Fatalf("initial page = %d, want 0", m.page)
@@ -1175,21 +1252,22 @@ func TestSearchModel_FetchMoreEmpty_CapsTotal(t *testing.T) {
 
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{}
-	results := make([]search.Result, 25)
+	results := make([]search.Result, 10)
 	for i := range results {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}
 	m := newSearchModel(results, "q", 100, cfg, ss)
+	m.filterType = typeFilterAll // exercise all-types pagination against m.total
 
-	if m.totalPages() != 4 {
-		t.Fatalf("initial totalPages = %d, want 4", m.totalPages())
+	if m.totalPages() != 10 {
+		t.Fatalf("initial totalPages = %d, want 10", m.totalPages())
 	}
 
 	// Simulate API returning empty results (exhausted)
 	m = updateModel(t, m, searchMoreResultsMsg{results: nil})
 
-	if m.total != 25 {
-		t.Errorf("total should be capped to loaded results (25), got %d", m.total)
+	if m.total != 10 {
+		t.Errorf("total should be capped to loaded results (10), got %d", m.total)
 	}
 	if m.totalPages() != 1 {
 		t.Errorf("totalPages should be 1 after cap, got %d", m.totalPages())
@@ -1199,10 +1277,10 @@ func TestSearchModel_FetchMoreEmpty_CapsTotal(t *testing.T) {
 func TestSearchModel_ViewFetchingMore(t *testing.T) {
 	t.Parallel()
 
-	// Model with 25 loaded results but on page 2 (no data) while fetching
+	// Model with 10 loaded results but on page 2 (no data) while fetching
 	ss := statusStyles{colorEnabled: false, width: 100}
 	cfg := search.Config{}
-	results := make([]search.Result, 25)
+	results := make([]search.Result, 10)
 	for i := range results {
 		results[i] = search.Result{Type: "checkpoint", Checkpoint: &search.CheckpointResult{ID: fmt.Sprintf("id-%02d", i)}}
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/546
<!-- entire-trail-link-end -->

## Summary

- **Remove `types=checkpoints` hardcoding** — the search API now returns all result types (checkpoints, commits, sessions) instead of only checkpoints
- **Add `CommitResult` and `SessionResult` types** with polymorphic `Result` struct using custom JSON marshal/unmarshal for wire-format compatibility
- **Add type filter tabs to TUI** — press `0-3` to filter by All/Checkpoints/Sessions/Commits, with per-type counts
- **Add `--all-repos` flag** — defaults to current repo scoping; use `--all-repos` or `repo:*` to search across all accessible repos
- **Align default limit to 100** (was 200) to match the UI
- **Add commit and session detail views** in TUI with type-specific fields (SHA, additions/deletions, agent, model, steps, etc.)

## Test plan

- [x] `mise run fmt` — clean
- [x] `mise run lint` — 0 issues
- [x] `mise run test` — 6229 tests pass
- [x] New tests for multi-type deserialization, accessor methods, JSON round-trip, type filter keys, commit/session detail views, type counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1060" height="974" alt="Screenshot 2026-06-10 at 12 45 46 PM" src="https://github.com/user-attachments/assets/e932a1e0-3989-4ad0-9b67-7c978dec50e9" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large CLI/TUI surface area and a breaking change to `search.Result` JSON shape for any external consumers of `--json`, but behavior is covered by extensive tests and search remains a hidden command.
> 
> **Overview**
> **CLI search now returns checkpoints, commits, and sessions** instead of checkpoints only: the client stops sending `types=checkpoints`, adds typed `CommitResult` / `SessionResult` payloads with custom JSON on `Result`, and shared accessors (`ResultTitle`, `ResultID`, etc.) for all output paths.
> 
> **`entire search` gains `--all-repos`** (and `repo:*` / `Config.AllRepos`), with explicit `owner/repo` winning when both are set. API fetch size moves to **`DefaultLimit` 100** (was 200); client page size is **10** (was 25).
> 
> **Interactive search TUI** gets type tabs (**1–3** for checkpoints / sessions / commits), a **master–detail** browse layout with a pinned detail pane, list styling aligned with the web UI, and **commit/session detail** panels. JSON output includes **`counts`**; static/accessible tables add a **TYPE** column and use titles instead of checkpoint-only prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ef3a5746b017472c00d570d42cf24164fe963df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->