### PR TITLE
Deprecate 'entire checkpoint rewind' ahead of removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,9 @@ shortcuts remain functional but hidden, and emit a deprecation hint pointing
 at the canonical group form.
 
 - `session` (alias: `sessions`): `list`, `info`, `stop`, `attach`, `resume`, `current`
-- `checkpoint` (aliases: `cp`, `checkpoints`): `list`, `explain`, `rewind`, `search`
+- `checkpoint` (aliases: `cp`, `checkpoints`): `list`, `explain`, `search`, plus
+  the deprecated `rewind` (functional, prints a cobra deprecation message, will
+  be removed in a future release)
 - `agent`: bare opens the interactive agent selector, plus `list`, `add`, `remove`
 - `configure`: bare prints help and a hint pointing at `entire agent`; flags
   manage non-agent settings (telemetry, git-hook installation mode, strategy
@@ -43,13 +45,14 @@ Top-level lifecycle and standalone commands: `enable`, `disable`, `status`,
 `configure`.
 
 Hidden top-level shortcuts (functional, emit a one-line deprecation hint):
-`rewind` → `checkpoint rewind`, `resume` → `session resume`, `attach` →
-`session attach`, `explain` → `checkpoint explain`, `trace` → `doctor trace`.
+`resume` → `session resume`, `attach` → `session attach`, `explain` →
+`checkpoint explain`, `trace` → `doctor trace`.
 Cobra-native aliases (no hint): `sessions` → `session`, `cp`/`checkpoints` →
 `checkpoint`. The `search` top-level remains hidden without a hint.
 
-Deprecated top-level alias (functional, prints cobra deprecation message):
-`reset` → `clean`.
+Deprecated top-level commands (functional, print a cobra deprecation message):
+`reset` → `clean`, and `rewind` (no replacement, announces removal — same
+deprecation as `checkpoint rewind`).
 
 Hidden infrastructure commands: `hooks`, `trail`,
 `curl-bash-post-install`, `__send_analytics`.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ Just use one of your AI agents as before. Entire runs in the background, trackin
 entire status  # Check current session status anytime
 ```
 
-### 3. Rewind to a Previous Checkpoint
+### 3. Rewind to a Previous Checkpoint (deprecated)
+
+> **Deprecated:** `entire checkpoint rewind` will be removed in a future release.
 
 If you want to undo some changes and go back to an earlier checkpoint:
 
@@ -242,9 +244,9 @@ go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin
 | `entire disable` | Remove Entire hooks from repository                                                               |
 | `entire doctor`  | Fix or clean up stuck sessions                                                                    |
 | `entire enable`  | Enable Entire in your repository                                                                  |
-| `entire checkpoint`        | List, explain, rewind, and search checkpoints                                           |
+| `entire checkpoint`        | List, explain, and search checkpoints                                                   |
 | `entire checkpoint explain` | Explain a session, commit, or checkpoint                                               |
-| `entire checkpoint rewind` | Rewind to a previous checkpoint                                                         |
+| `entire checkpoint rewind` | Rewind to a previous checkpoint (deprecated, will be removed in a future release)       |
 | `entire login`   | Authenticate the CLI with Entire device auth                                                      |
 | `entire session` | View and manage agent sessions tracked by Entire                                                  |
 | `entire session resume`    | Switch to a branch, restore latest checkpointed session metadata, and show command(s) |

--- a/cmd/entire/cli/checkpoint_group.go
+++ b/cmd/entire/cli/checkpoint_group.go
@@ -8,24 +8,22 @@ import (
 )
 
 // newCheckpointGroupCmd builds the `entire checkpoint` parent command and
-// registers list/explain/rewind/search as children.
+// registers list/explain/search as children, plus the deprecated rewind.
 func newCheckpointGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "checkpoint",
 		Aliases: []string{"cp", "checkpoints"},
-		Short:   "Inspect, rewind, and search checkpoints",
+		Short:   "Inspect and search checkpoints",
 		Long: `Operations on checkpoints — the persistent records of agent work tied to commits.
 
 Commands:
   list     List checkpoints on the current branch
   explain  Explain a checkpoint, commit, or session
-  rewind   Browse and rewind to a checkpoint
   search   Search checkpoints (semantic + keyword)
 
 Examples:
   entire checkpoint list
   entire checkpoint explain <id|sha>
-  entire checkpoint rewind --to <id>
   entire checkpoint search "fix login"`,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if _, err := paths.WorktreeRoot(cmd.Context()); err != nil {

--- a/cmd/entire/cli/integration_test/testenv.go
+++ b/cmd/entire/cli/integration_test/testenv.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -692,14 +693,17 @@ type RewindPoint struct {
 func (env *TestEnv) GetRewindPoints() []RewindPoint {
 	env.T.Helper()
 
-	// Run rewind --list using the shared binary
+	// Run rewind --list using the shared binary. Parse stdout only — the
+	// deprecated command prints a notice on stderr that would break the JSON.
 	cmd := exec.Command(getTestBinary(), "checkpoint", "rewind", "--list")
 	cmd.Dir = env.RepoDir
 	cmd.Env = env.cliEnv()
 
-	output, err := cmd.CombinedOutput()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
 	if err != nil {
-		env.T.Fatalf("rewind --list failed: %v\nOutput: %s", err, output)
+		env.T.Fatalf("rewind --list failed: %v\nOutput: %s\nStderr: %s", err, output, stderr.String())
 	}
 
 	// Parse JSON output

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -50,8 +50,9 @@ func newRewindCmd() *cobra.Command {
 	var resetFlag bool
 
 	cmd := &cobra.Command{
-		Use:   "rewind",
-		Short: "Browse checkpoints and rewind your session",
+		Use:        "rewind",
+		Short:      "Browse checkpoints and rewind your session",
+		Deprecated: "and will be removed in a future release",
 		Long: `Interactive command for rewinding and managing agent sessions.
 
 This command will show you an interactive list of recent checkpoints.  You'll be

--- a/cmd/entire/cli/rewind_test.go
+++ b/cmd/entire/cli/rewind_test.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewindCmd_IsDeprecated(t *testing.T) {
+	t.Parallel()
+
+	cmd := newRewindCmd()
+	if cmd.Deprecated == "" {
+		t.Error("rewind command should have Deprecated field set")
+	}
+	if !strings.Contains(cmd.Deprecated, "removed") {
+		t.Errorf("Deprecated message should announce removal, got: %s", cmd.Deprecated)
+	}
+}

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -110,15 +110,16 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newRecapCmd())
 
 	// Hidden top-level shortcuts. Functional but print a deprecation hint.
-	cmd.AddCommand(hideAsAlias(newRewindCmd(), "entire checkpoint rewind"))
 	cmd.AddCommand(hideAsAlias(newResumeCmd(), "entire session resume"))
 	cmd.AddCommand(hideAsAlias(newAttachCmd(), "entire session attach"))
 	cmd.AddCommand(hideAsAlias(newExplainCmd(), "entire checkpoint explain"))
 	cmd.AddCommand(hideAsAlias(newTraceCmd(), "entire doctor trace"))
 	cmd.AddCommand(newSearchCmd()) // 'entire search' = 'checkpoint search' (hidden, no hint)
 
-	// Deprecated top-level alias (functional; reset.go marks it Deprecated).
+	// Deprecated top-level commands (functional; the constructors mark them
+	// Deprecated, which also excludes them from help and completion).
 	cmd.AddCommand(newResetCmd())
+	cmd.AddCommand(newRewindCmd())
 
 	// Hidden infrastructure.
 	cmd.AddCommand(newHooksCmd())

--- a/e2e/entire/entire.go
+++ b/e2e/entire/entire.go
@@ -1,6 +1,7 @@
 package entire
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log"
@@ -67,7 +68,7 @@ func CleanForce(t *testing.T, dir string) string {
 // RewindList runs `entire rewind --list` and parses the JSON output.
 func RewindList(t *testing.T, dir string) []RewindPoint {
 	t.Helper()
-	out := run(t, dir, "checkpoint", "rewind", "--list")
+	out := runStdout(t, dir, "checkpoint", "rewind", "--list")
 
 	var points []RewindPoint
 	if err := json.Unmarshal([]byte(out), &points); err != nil {
@@ -99,6 +100,24 @@ func run(t *testing.T, dir string, args ...string) string {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("entire %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// runStdout executes an `entire` subcommand in dir and fails the test on
+// error, returning stdout only. Use for commands whose stdout is parsed
+// (e.g. JSON) and must not be mixed with stderr notices.
+func runStdout(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := execx.NonInteractive(context.Background(), BinPath(), args...)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("entire %s failed: %v\n%s%s", strings.Join(args, " "), err, out, stderr.String())
 	}
 	return strings.TrimSpace(string(out))
 }

--- a/e2e/entire/entire.go
+++ b/e2e/entire/entire.go
@@ -65,7 +65,7 @@ func CleanForce(t *testing.T, dir string) string {
 	return run(t, dir, "clean", "--force")
 }
 
-// RewindList runs `entire rewind --list` and parses the JSON output.
+// RewindList runs `entire checkpoint rewind --list` and parses the JSON output.
 func RewindList(t *testing.T, dir string) []RewindPoint {
 	t.Helper()
 	out := runStdout(t, dir, "checkpoint", "rewind", "--list")
@@ -117,7 +117,7 @@ func runStdout(t *testing.T, dir string, args ...string) string {
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("entire %s failed: %v\n%s%s", strings.Join(args, " "), err, out, stderr.String())
+		t.Fatalf("entire %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, out, stderr.String())
 	}
 	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/548
<!-- entire-trail-link-end -->

## What

Deprecates `entire checkpoint rewind` (no replacement — the command is slated for removal in a future release). It stays fully functional until then, but:

- prints `Command "rewind" is deprecated, and will be removed in a future release` to stderr on every invocation
- no longer appears in `entire checkpoint --help`, root help, or shell completion (cobra excludes deprecated commands automatically)

## How

- `newRewindCmd()` sets cobra's `Deprecated` field — the single constructor feeds both registration sites, matching the existing `reset` → `clean` precedent.
- The hidden top-level `rewind` shortcut previously used `hideAsAlias` with a hint pointing at `entire checkpoint rewind`; since that target is now itself deprecated, it registers plainly alongside `reset` and carries the same removal notice.
- The checkpoint group's hand-written help text and `Short` description drop rewind; CLAUDE.md and README are updated to match.
- Test helpers that parse `rewind --list` JSON (integration `TestEnv.GetRewindPoints` and the e2e `entire` package's `RewindList`) switched from `CombinedOutput` to stdout-only capture so the new stderr notice doesn't corrupt the JSON.
- New `TestRewindCmd_IsDeprecated` pins the deprecation, mirroring `TestResetCmd_IsDeprecated`.

## Reviewer notes

- The e2e helpers and rewind E2E scenarios still exercise the command — intentional while it remains functional, but they'll need removal/rework when the command is actually deleted.
- Verified locally: `mise run check` (fmt, lint, unit + integration tests) and `mise run test:e2e:canary` (all 63 Vogon/roger-roger tests) pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Cobra metadata only; rewind stays functional with no strategy or hook changes.
> 
> **Overview**
> **Deprecates `entire checkpoint rewind`** (and the top-level `entire rewind` shortcut) ahead of removal. Behavior is unchanged, but every run prints Cobra’s deprecation notice on stderr, and the command drops out of help and completion like `reset` → `clean`.
> 
> **Implementation:** `newRewindCmd()` sets `Deprecated`; the root CLI no longer registers rewind via `hideAsAlias` and instead adds the same constructor directly. Checkpoint group `Short`/`Long` help and **README** / **CLAUDE.md** no longer promote rewind as a primary workflow.
> 
> **Tests:** Integration `GetRewindPoints` and e2e `RewindList` read **stdout only** when parsing `rewind --list` JSON so stderr notices don’t break parsing; **`TestRewindCmd_IsDeprecated`** locks in the deprecation message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e9b4a70b1f6758d958d95e7f3958def206c99b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->