### PR TITLE
repo mirror: mint repo-scoped tokens via cluster discovery (COR-395)

### DIFF
--- a/cmd/entire/cli/auth/data_api.go
+++ b/cmd/entire/cli/auth/data_api.go
@@ -18,14 +18,14 @@ import (
 // resolution, so a slow or absent endpoint must not stall the command.
 const dataAPIDiscoveryTimeout = 8 * time.Second
 
-// resolveContextForAPIFunc is the shape of the discovery seam: it mirrors
-// clusterdiscovery.ResolveContextForAPI (ctx, configDir, cacheDir, apiHost,
-// httpClient, debugf).
-type resolveContextForAPIFunc func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error)
+// resolveContextFunc is the shape of a context-discovery seam: it mirrors
+// clusterdiscovery.ResolveContextForAPI / ResolveContextForCluster
+// (ctx, configDir, cacheDir, host, httpClient, debugf).
+type resolveContextFunc func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error)
 
 // resolveContextForAPI is the discovery seam, swapped in tests so they don't
 // reach the network. See SetResolveContextForAPIForTest for cross-package tests.
-var resolveContextForAPI resolveContextForAPIFunc = clusterdiscovery.ResolveContextForAPI
+var resolveContextForAPI resolveContextFunc = clusterdiscovery.ResolveContextForAPI
 
 // SetResolveContextForAPIForTest overrides the /.well-known/entire-api.json
 // discovery seam and returns a cleanup func. Tests in other packages that
@@ -34,7 +34,7 @@ var resolveContextForAPI resolveContextForAPIFunc = clusterdiscovery.ResolveCont
 // configured data host and bypasses any SetManagerForTest fallback seam. Pass
 // a func returning clusterdiscovery.ErrDiscoveryUnavailable to force the static
 // fallback path. Test-only.
-func SetResolveContextForAPIForTest(t interface{ Helper() }, fn resolveContextForAPIFunc) func() {
+func SetResolveContextForAPIForTest(t interface{ Helper() }, fn resolveContextFunc) func() {
 	t.Helper()
 	prev := resolveContextForAPI
 	resolveContextForAPI = fn

--- a/cmd/entire/cli/auth/data_api_test.go
+++ b/cmd/entire/cli/auth/data_api_test.go
@@ -25,7 +25,7 @@ import (
 
 // stubResolveContextForAPI swaps the discovery seam for the duration of the
 // test, restoring it after.
-func stubResolveContextForAPI(t *testing.T, fn resolveContextForAPIFunc) {
+func stubResolveContextForAPI(t *testing.T, fn resolveContextFunc) {
 	t.Helper()
 	prev := resolveContextForAPI
 	resolveContextForAPI = fn

--- a/cmd/entire/cli/auth/repo_token.go
+++ b/cmd/entire/cli/auth/repo_token.go
@@ -24,9 +24,9 @@ import (
 // actionable message instead of the raw OAuth error.
 var ErrRepoTargetUnknown = errors.New("cluster has no servable mirror at this audience")
 
-// repoExchangeTimeout bounds the HTTP calls behind one mint: the
-// /.well-known cluster discovery (disk-cached after the first call) and
-// the /oauth/token exchange.
+// repoExchangeTimeout bounds each HTTP call on the mint path: the
+// /.well-known cluster discovery at construction (disk-cached after the
+// first call) and each /oauth/token exchange.
 const repoExchangeTimeout = 30 * time.Second
 
 // resolveContextForCluster is the discovery seam, swapped in tests so they
@@ -46,32 +46,31 @@ func SetRepoExchangeTransportForTest(rt http.RoundTripper) func() {
 	return func() { repoExchangeTransportForTest = prev }
 }
 
-// RepoScopedToken exchanges a login JWT for a short-lived, repo-scoped
-// access token usable against a data-plane cluster's git endpoints
-// (clone / fetch / info-refs). The data plane's git gate rejects the raw
-// login bearer: it only accepts a token whose RFC 8693 audience is
+// RepoTokenSource mints short-lived, repo-scoped access tokens usable
+// against one data-plane cluster's git endpoints (clone / fetch /
+// info-refs). The data plane's git gate rejects the raw login bearer: it
+// only accepts a token whose RFC 8693 audience is
 // https://<clusterHost><repoSlug> and whose scope is "repo:<action>".
 //
-// The login context is resolved the way git-remote-entire resolves it: the
-// cluster's /.well-known/entire-cluster.json names the core(s) it trusts,
-// and the matching local context (active if eligible, else the sole
-// eligible one, else an explicit-choice error) supplies the subject token —
-// exchanged at that context's core, never at the active context's. The
-// exchange itself goes through repocreds, the same code path (and wire
-// form) git-remote-entire uses. An expired login JWT is transparently
-// re-minted from the stored refresh token.
-//
-//   - clusterHost is the data-plane cluster host (e.g. aws-us-east-2.entire.io).
-//   - repoSlug is the surface-prefixed repo path (e.g. /gh/octocat/hello or
-//     /et/<project>/<repo>), joined verbatim to https://<clusterHost> to
-//     form the audience.
-//   - action is "pull" for reads or "push" for writes.
-//
-// Each call performs a fresh exchange and does not cache — callers that
-// poll (e.g. the mirror clone wait) re-invoke on token expiry.
-func RepoScopedToken(ctx context.Context, clusterHost, repoSlug, action string) (string, error) {
+// The login context is resolved once, at construction, the way
+// git-remote-entire resolves it: the cluster's
+// /.well-known/entire-cluster.json names the core(s) it trusts, and the
+// matching local context (active if eligible, else the sole eligible one,
+// else an explicit-choice error) supplies the subject token — exchanged at
+// that context's core, never at the active context's. Token calls then only
+// exchange (through repocreds, the same code path and wire form
+// git-remote-entire uses), re-minting an expired login JWT from the stored
+// refresh token as needed — so a poller's re-mints don't depend on
+// discovery staying reachable.
+type RepoTokenSource struct {
+	creds *repocreds.Cache
+}
+
+// NewRepoTokenSource resolves clusterHost's trusted core and login context
+// and returns a source minting tokens for that cluster.
+func NewRepoTokenSource(ctx context.Context, clusterHost string) (*RepoTokenSource, error) {
 	if clusterHost == "" {
-		return "", errors.New("repo-scoped token exchange requires a target cluster host")
+		return nil, errors.New("repo-scoped token exchange requires a target cluster host")
 	}
 
 	// Bridge any pre-contexts.json login so the resolver can match it.
@@ -81,17 +80,24 @@ func RepoScopedToken(ctx context.Context, clusterHost, repoSlug, action string) 
 	httpClient := &http.Client{Timeout: repoExchangeTimeout, Transport: repoExchangeTransportForTest}
 	clusterCtx, err := resolveContextForCluster(ctx, contexts.DefaultConfigDir(), discovery.DefaultCacheDir(), clusterHost, httpClient, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	allowInsecure := insecureHTTPEnabled() || isLoopbackHTTP(clusterCtx.CoreURL)
 	loginProvider, err := NewRefreshingLoginProvider(clusterCtx, repoExchangeTransportForTest, allowInsecure)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	token, err := repocreds.New(clusterCtx.CoreURL, "https://"+clusterHost, loginProvider, httpClient).
-		Token(ctx, repoSlug, action)
+	return &RepoTokenSource{creds: repocreds.New(clusterCtx.CoreURL, "https://"+clusterHost, loginProvider, httpClient)}, nil
+}
+
+// Token returns a repo-scoped token for repoSlug (the surface-prefixed repo
+// path, e.g. /gh/octocat/hello, joined verbatim to the cluster URL to form
+// the audience) and action ("pull" or "push"). Tokens are cached per
+// (repoSlug, action) until near expiry.
+func (s *RepoTokenSource) Token(ctx context.Context, repoSlug, action string) (string, error) {
+	token, err := s.creds.Token(ctx, repoSlug, action)
 	if err != nil {
 		// invalid_target means the cluster has no servable mirror at this
 		// audience (commonly a suspended placement). Surface the sentinel for
@@ -104,4 +110,22 @@ func RepoScopedToken(ctx context.Context, clusterHost, repoSlug, action string) 
 		return "", fmt.Errorf("repo-scoped token exchange: %w", err)
 	}
 	return token, nil
+}
+
+// Invalidate drops the cached (repoSlug, action) token so the next Token
+// call re-exchanges — for when the data plane rejected it (401) ahead of
+// its recorded expiry.
+func (s *RepoTokenSource) Invalidate(repoSlug, action string) {
+	s.creds.Invalidate(repoSlug, action)
+}
+
+// RepoScopedToken is the one-shot form of RepoTokenSource: resolve, mint
+// once, discard. Callers that re-mint (e.g. a polling wait) should hold a
+// RepoTokenSource instead, so re-mints skip cluster discovery.
+func RepoScopedToken(ctx context.Context, clusterHost, repoSlug, action string) (string, error) {
+	src, err := NewRepoTokenSource(ctx, clusterHost)
+	if err != nil {
+		return "", err
+	}
+	return src.Token(ctx, repoSlug, action)
 }

--- a/cmd/entire/cli/auth/repo_token.go
+++ b/cmd/entire/cli/auth/repo_token.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
-	"strings"
+	"time"
 
-	"github.com/entireio/auth-go/sts"
-	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/discovery"
+	"github.com/entireio/cli/internal/entireclient/httputil"
+	"github.com/entireio/cli/internal/entireclient/repocreds"
 )
 
 // ErrRepoTargetUnknown reports that the cluster's STS refused the exchange
@@ -22,10 +24,26 @@ import (
 // actionable message instead of the raw OAuth error.
 var ErrRepoTargetUnknown = errors.New("cluster has no servable mirror at this audience")
 
-// repoExchangeTransportForTest, when non-nil, is used as the sts.Client
-// transport by RepoScopedToken instead of the default. Test-only seam so
-// the wire form (audience / scope / client_id) can be asserted without a
-// live core. Production leaves it nil.
+// repoExchangeTimeout bounds the HTTP calls behind one mint: the
+// /.well-known cluster discovery (disk-cached after the first call) and
+// the /oauth/token exchange.
+const repoExchangeTimeout = 30 * time.Second
+
+// resolveContextForCluster is the discovery seam, swapped in tests so they
+// don't reach the network. Mirrors clusterdiscovery.ResolveContextForCluster.
+var resolveContextForCluster resolveContextFunc = clusterdiscovery.ResolveContextForCluster
+
+// setResolveContextForClusterForTest overrides the cluster-discovery seam
+// and returns a cleanup func. Test-only.
+func setResolveContextForClusterForTest(fn resolveContextFunc) func() {
+	prev := resolveContextForCluster
+	resolveContextForCluster = fn
+	return func() { resolveContextForCluster = prev }
+}
+
+// repoExchangeTransportForTest, when non-nil, is the HTTP transport used by
+// RepoScopedToken's exchange (and login refresh), so the wire form can be
+// asserted without a live core. Production leaves it nil.
 var repoExchangeTransportForTest http.RoundTripper
 
 // SetRepoExchangeTransportForTest installs rt as the transport used by
@@ -36,97 +54,62 @@ func SetRepoExchangeTransportForTest(rt http.RoundTripper) func() {
 	return func() { repoExchangeTransportForTest = prev }
 }
 
-// RepoScopedToken exchanges the logged-in user's token for a short-lived,
-// repo-scoped access token usable against a data-plane cluster's git
-// endpoints (clone / fetch / info-refs).
+// RepoScopedToken exchanges a login JWT for a short-lived, repo-scoped
+// access token usable against a data-plane cluster's git endpoints
+// (clone / fetch / info-refs). The data plane's git gate rejects the raw
+// login bearer: it only accepts a token whose RFC 8693 audience is
+// https://<clusterHost><repoSlug> and whose scope is "repo:<action>".
 //
-// The data plane's git gate rejects the raw login bearer (HTTP 403): it
-// only accepts a token whose RFC 8693 audience is <clusterBaseURL><repoSlug>
-// and whose scope is "repo:<action>". This is the same exchange
-// git-remote-entire performs internally for the entire:// transport — the
-// CLI does it in-process when it needs to read the data plane directly
-// (e.g. probing a mirror's clone readiness).
+// The login context is resolved the way git-remote-entire resolves it: the
+// cluster's /.well-known/entire-cluster.json names the core(s) it trusts,
+// and the matching local context (active if eligible, else the sole
+// eligible one, else an explicit-choice error) supplies the subject token —
+// exchanged at that context's core, never at the active context's. The
+// exchange itself goes through repocreds, the same code path (and wire
+// form) git-remote-entire uses. An expired login JWT is transparently
+// re-minted from the stored refresh token.
 //
-//   - clusterBaseURL is the data-plane cluster origin (scheme+host, e.g.
-//     https://aws-us-east-2.entire.io); a trailing slash is trimmed.
-//   - repoSlug is the full surface-prefixed path (e.g. /gh/octocat/hello
-//     or /et/<project>/<repo>), joined to the cluster URL verbatim to form
-//     the audience.
+//   - clusterHost is the data-plane cluster host (e.g. aws-us-east-2.entire.io).
+//   - repoSlug is the surface-prefixed repo path (e.g. /gh/octocat/hello or
+//     /et/<project>/<repo>), joined verbatim to https://<clusterHost> to
+//     form the audience.
 //   - action is "pull" for reads or "push" for writes.
 //
-// The exchange targets the same core endpoint and client identity the CLI
-// logged in against (AuthBaseURL + the provider's STS path, client_id
-// entire-cli), so a successful login implies a usable exchange. Errors
-// surface verbatim from the STS endpoint (e.g. invalid_target when no
-// mirror matches the slug+cluster).
-//
-// The subject token is the stored login access token read directly, rather
-// than routed through the refresh-aware tokenmanager — so this path does NOT
-// silently re-mint an expired login JWT, even though one is now refreshable.
-// This is a known gap slated for removal: COR-395 reworks RepoScopedToken to
-// go through cluster discovery + the per-context refreshing provider (and
-// deletes the dead resolveAuthHostToken alongside it). Two reasons it stayed
-// direct until then: (1) historically `entire login` stored only a bare access
-// token, so there was nothing to refresh — no longer true now that login
-// requests `offline_access` and persists a refresh token, which is exactly why
-// this needs the COR-395 rework. (2) The manager's exchange also emits an RFC
-// 8693 `resource` parameter alongside `audience`, whereas the data-plane gate
-// keys solely on `audience`; going direct keeps the wire form byte-for-byte
-// what git-remote-entire (and the standalone entiredb CLI) already send.
 // Each call performs a fresh exchange and does not cache — callers that
 // poll (e.g. the mirror clone wait) re-invoke on token expiry.
-func RepoScopedToken(ctx context.Context, clusterBaseURL, repoSlug, action string) (string, error) {
-	provider := CurrentProvider()
-	if strings.TrimSpace(provider.STSPath) == "" {
-		return "", errors.New("repo-scoped token exchange requires a v2 auth host (set ENTIRE_AUTH_BASE_URL to a login server that exposes /oauth/token)")
+func RepoScopedToken(ctx context.Context, clusterHost, repoSlug, action string) (string, error) {
+	if clusterHost == "" {
+		return "", errors.New("repo-scoped token exchange requires a target cluster host")
 	}
 
-	loginJWT, err := LookupCurrentToken()
+	// Bridge any pre-contexts.json login so the resolver can match it.
+	// Best-effort: a migration failure must not block resolution.
+	_, _ = MigrateLegacyLoginContext() //nolint:errcheck // best-effort bridge; resolution proceeds regardless
+
+	httpClient := &http.Client{Timeout: repoExchangeTimeout, Transport: repoExchangeTransportForTest}
+	clusterCtx, err := resolveContextForCluster(ctx, contexts.DefaultConfigDir(), discovery.DefaultCacheDir(), clusterHost, httpClient, nil)
 	if err != nil {
-		return "", fmt.Errorf("read login token: %w", err)
-	}
-	if loginJWT == "" {
-		return "", ErrNotLoggedIn
+		return "", err
 	}
 
-	clusterBaseURL = strings.TrimRight(clusterBaseURL, "/")
-	if clusterBaseURL == "" {
-		return "", errors.New("repo-scoped token exchange requires a target cluster URL")
-	}
-	issuer := api.AuthBaseURL()
-
-	client := &sts.Client{
-		Transport:         repoExchangeTransportForTest,
-		BaseURL:           issuer,
-		Path:              provider.STSPath,
-		UserAgent:         provider.ClientID,
-		AllowInsecureHTTP: isLoopbackHTTP(issuer) || insecureHTTPOverride.Load(),
-	}
-	set, err := client.Exchange(ctx, sts.ExchangeRequest{
-		SubjectToken:     loginJWT,
-		SubjectTokenType: sts.SubjectTokenTypeAccessToken,
-		// sts.Client (unlike the tokenmanager) applies no default, so set
-		// requested_token_type explicitly to the access-token URI.
-		RequestedTokenType: sts.SubjectTokenTypeAccessToken,
-		// Audience-only (no Resource): the data plane's git gate keys its
-		// repo check on the audience host+slug. Sending a separate resource
-		// param risks the server validating a different value than it grants.
-		Audience: clusterBaseURL + repoSlug,
-		Scope:    "repo:" + action,
-		// Public-client identification per RFC 6749 §2.3.1, carried via
-		// Extra because the sts package is provider-agnostic.
-		Extra: url.Values{"client_id": {provider.ClientID}},
-	})
+	allowInsecure := insecureHTTPEnabled() || isLoopbackHTTP(clusterCtx.CoreURL)
+	loginProvider, err := NewRefreshingLoginProvider(clusterCtx, repoExchangeTransportForTest, allowInsecure)
 	if err != nil {
-		// A typed invalid_target means the cluster has no servable mirror at
-		// this audience (commonly a suspended placement). Surface the
-		// sentinel for callers that branch on it, preserving the verbatim STS
-		// text (second %w) for those that don't.
-		var xe *sts.ExchangeError
-		if errors.As(err, &xe) && xe.Code == "invalid_target" {
+		return "", err
+	}
+
+	token, err := repocreds.New(clusterCtx.CoreURL, "https://"+clusterHost, loginProvider, httpClient).
+		Token(ctx, repoSlug, action)
+	if err != nil {
+		// invalid_target means the cluster has no servable mirror at this
+		// audience (commonly a suspended placement). Surface the sentinel for
+		// callers that branch on it, preserving the verbatim OAuth body
+		// (second %w) for those that don't.
+		var oe *httputil.OAuthError
+		if errors.As(err, &oe) && oe.Code == "invalid_target" {
 			return "", fmt.Errorf("repo-scoped token exchange: %w: %w", ErrRepoTargetUnknown, err)
 		}
 		return "", fmt.Errorf("repo-scoped token exchange: %w", err)
 	}
-	return set.AccessToken, nil
+	return token, nil
 }

--- a/cmd/entire/cli/auth/repo_token.go
+++ b/cmd/entire/cli/auth/repo_token.go
@@ -33,14 +33,6 @@ const repoExchangeTimeout = 30 * time.Second
 // don't reach the network. Mirrors clusterdiscovery.ResolveContextForCluster.
 var resolveContextForCluster resolveContextFunc = clusterdiscovery.ResolveContextForCluster
 
-// setResolveContextForClusterForTest overrides the cluster-discovery seam
-// and returns a cleanup func. Test-only.
-func setResolveContextForClusterForTest(fn resolveContextFunc) func() {
-	prev := resolveContextForCluster
-	resolveContextForCluster = fn
-	return func() { resolveContextForCluster = prev }
-}
-
 // repoExchangeTransportForTest, when non-nil, is the HTTP transport used by
 // RepoScopedToken's exchange (and login refresh), so the wire form can be
 // asserted without a live core. Production leaves it nil.

--- a/cmd/entire/cli/auth/repo_token_test.go
+++ b/cmd/entire/cli/auth/repo_token_test.go
@@ -4,17 +4,46 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
-	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
 
+// seedRepoTokenContext wires the two seams RepoScopedToken sits on: a
+// file-backed token store holding a still-valid login JWT for a context on
+// coreURL, and a discovery stub resolving any cluster to that context. The
+// exchange transport is left to each test. Returns the seeded login JWT.
+func seedRepoTokenContext(t *testing.T, coreURL string) string {
+	t.Helper()
+	// Sandbox the legacy-login migration's contexts.json writes.
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+
+	svc := tokenstore.CoreKeyringService(coreURL)
+	jwt := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "alice", tokenstore.EncodeTokenWithExpiration(jwt, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	c := &contexts.Context{Name: "alice@core", CoreURL: coreURL, Handle: "alice", KeychainService: svc}
+	t.Cleanup(setResolveContextForClusterForTest(
+		func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+			return c, nil
+		}))
+	return jwt
+}
+
 // statusTransport returns a canned non-200 response with the given body so
-// the STS error-decoding path (sts.readAPIError) can be exercised offline.
+// the OAuth error-decoding path can be exercised offline.
 type statusTransport struct {
 	status int
 	body   string
@@ -32,22 +61,17 @@ func (s statusTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // TestRepoScopedToken_InvalidTarget asserts that a 400 invalid_target STS
 // response — what the data plane returns for a suspended (or otherwise
 // non-servable) mirror — surfaces as ErrRepoTargetUnknown while still
-// preserving the verbatim OAuth code + description for callers that don't
-// branch on the sentinel.
+// preserving the verbatim OAuth description for callers that don't branch
+// on the sentinel.
 func TestRepoScopedToken_InvalidTarget(t *testing.T) {
-	t.Setenv(api.AuthBaseURLEnvVar, "https://us.auth.entire.io")
-
-	prevBackend := chooseBackend
-	chooseBackend = func() tokenBackend { return fakeBackend{token: "login.jwt.value"} }
-	t.Cleanup(func() { chooseBackend = prevBackend })
-
+	seedRepoTokenContext(t, "https://us.auth.entire.io")
 	t.Cleanup(SetRepoExchangeTransportForTest(statusTransport{
 		status: http.StatusBadRequest,
 		body:   `{"error":"invalid_target","error_description":"no mirror at this URL"}`,
 	}))
 
 	_, err := RepoScopedToken(context.Background(),
-		"https://aws-us-east-2.entire.io", "/gh/octocat/hello", "pull")
+		"aws-us-east-2.entire.io", "/gh/octocat/hello", "pull")
 	if err == nil {
 		t.Fatal("RepoScopedToken: expected error, got nil")
 	}
@@ -60,11 +84,13 @@ func TestRepoScopedToken_InvalidTarget(t *testing.T) {
 	}
 }
 
-// captureTransport records the last request's parsed form body and
-// returns a canned RFC 8693 token-exchange success response.
+// captureTransport records the last request's parsed form body, URL, and
+// Authorization header, and returns a canned RFC 8693 token-exchange
+// success response.
 type captureTransport struct {
 	form url.Values
 	url  string
+	auth string
 }
 
 func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -78,6 +104,7 @@ func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 	c.form = form
 	c.url = req.URL.String()
+	c.auth = req.Header.Get("Authorization")
 	resp := `{"access_token":"repo-scoped.jwt","token_type":"Bearer",` +
 		`"issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":300}`
 	return &http.Response{
@@ -88,26 +115,17 @@ func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}, nil
 }
 
-// fakeBackend returns a fixed login token for any keyring lookup so the
-// exchange has a subject token without touching the OS keyring.
-type fakeBackend struct{ token string }
-
-func (f fakeBackend) save(string, string, string) error  { return nil }
-func (f fakeBackend) get(string, string) (string, error) { return f.token, nil }
-func (f fakeBackend) delete(string, string) error        { return nil }
-
+// TestRepoScopedToken_WireForm asserts the exchange targets the
+// cluster-resolved context's core (not any ambient default) and that the
+// form matches what the data plane's git gate accepts — identical to what
+// git-remote-entire sends via repocreds.
 func TestRepoScopedToken_WireForm(t *testing.T) {
-	t.Setenv(api.AuthBaseURLEnvVar, "https://us.auth.entire.io")
-
-	prevBackend := chooseBackend
-	chooseBackend = func() tokenBackend { return fakeBackend{token: "login.jwt.value"} }
-	t.Cleanup(func() { chooseBackend = prevBackend })
-
+	loginJWT := seedRepoTokenContext(t, "https://eu.auth.entire.io")
 	capture := &captureTransport{}
 	t.Cleanup(SetRepoExchangeTransportForTest(capture))
 
 	tok, err := RepoScopedToken(context.Background(),
-		"https://aws-us-east-2.entire.io/", "/gh/octocat/hello", "pull")
+		"aws-eu-west-1.entire.io", "/gh/octocat/hello", "pull")
 	if err != nil {
 		t.Fatalf("RepoScopedToken: %v", err)
 	}
@@ -115,20 +133,19 @@ func TestRepoScopedToken_WireForm(t *testing.T) {
 		t.Errorf("token = %q, want %q", tok, "repo-scoped.jwt")
 	}
 
-	// Endpoint: the configured core's STS path.
-	if !strings.HasPrefix(capture.url, "https://us.auth.entire.io/") {
-		t.Errorf("exchange URL = %q, want core host prefix", capture.url)
+	// Endpoint: the resolved context's core, not the active context's.
+	if capture.url != "https://eu.auth.entire.io/oauth/token" {
+		t.Errorf("exchange URL = %q, want resolved core's /oauth/token", capture.url)
 	}
 
 	// Wire form must match what the data plane's git gate accepts.
 	want := map[string]string{
 		"grant_type":           "urn:ietf:params:oauth:grant-type:token-exchange",
-		"subject_token":        "login.jwt.value",
+		"subject_token":        loginJWT,
 		"subject_token_type":   "urn:ietf:params:oauth:token-type:access_token",
 		"requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
-		"audience":             "https://aws-us-east-2.entire.io/gh/octocat/hello",
+		"audience":             "https://aws-eu-west-1.entire.io/gh/octocat/hello",
 		"scope":                "repo:pull",
-		"client_id":            "entire-cli",
 	}
 	for k, v := range want {
 		if got := capture.form.Get(k); got != v {
@@ -140,5 +157,32 @@ func TestRepoScopedToken_WireForm(t *testing.T) {
 	// divergent resource param risks the server validating the wrong value.
 	if capture.form.Has("resource") {
 		t.Errorf("form unexpectedly includes resource=%q", capture.form.Get("resource"))
+	}
+
+	// client_id travels as Basic auth (PostOAuthToken lifts it from the
+	// form; zitadel's token endpoint only reads it there).
+	if capture.form.Has("client_id") {
+		t.Errorf("form unexpectedly includes client_id=%q", capture.form.Get("client_id"))
+	}
+	if !strings.HasPrefix(capture.auth, "Basic ") {
+		t.Errorf("Authorization = %q, want Basic client credentials", capture.auth)
+	}
+}
+
+// TestRepoScopedToken_DiscoveryErrorSurfaces asserts a context-resolution
+// failure (no eligible login, ambiguous contexts, unreachable cluster) is
+// returned verbatim — never papered over with a wrong-core exchange.
+func TestRepoScopedToken_DiscoveryErrorSurfaces(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+	t.Cleanup(setResolveContextForClusterForTest(
+		func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+			return nil, errors.New("not logged in to a login server trusted by cluster x; run `entire login`")
+		}))
+	t.Cleanup(SetRepoExchangeTransportForTest(failRoundTripper(t)))
+
+	_, err := RepoScopedToken(context.Background(), "x.entire.io", "/gh/o/r", "pull")
+	if err == nil || !strings.Contains(err.Error(), "not logged in to a login server trusted by cluster x") {
+		t.Fatalf("err = %v, want the discovery error verbatim", err)
 	}
 }

--- a/cmd/entire/cli/auth/repo_token_test.go
+++ b/cmd/entire/cli/auth/repo_token_test.go
@@ -98,13 +98,14 @@ func TestRepoScopedToken_InvalidTarget(t *testing.T) {
 	}
 }
 
-// captureTransport records the last request's parsed form body, URL, and
-// Authorization header, and returns a canned RFC 8693 token-exchange
-// success response.
+// captureTransport counts exchanges and records the last request's parsed
+// form body, URL, and Authorization header, returning a canned RFC 8693
+// token-exchange success response.
 type captureTransport struct {
-	form url.Values
-	url  string
-	auth string
+	calls int
+	form  url.Values
+	url   string
+	auth  string
 }
 
 func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -116,6 +117,7 @@ func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	if err != nil {
 		return nil, err
 	}
+	c.calls++
 	c.form = form
 	c.url = req.URL.String()
 	c.auth = req.Header.Get("Authorization")
@@ -197,5 +199,41 @@ func TestRepoScopedToken_DiscoveryErrorSurfaces(t *testing.T) {
 	_, err := RepoScopedToken(context.Background(), "x.entire.io", "/gh/o/r", "pull")
 	if err == nil || !strings.Contains(err.Error(), "not logged in to a login server trusted by cluster x") {
 		t.Fatalf("err = %v, want the discovery error verbatim", err)
+	}
+}
+
+// TestRepoTokenSource_ReMintSkipsDiscovery asserts cluster discovery runs
+// once, at construction — re-mints after Invalidate (the clone wait's
+// 401 path) only re-exchange, so a discovery hiccup mid-wait can't abort a
+// wait that already authorized.
+func TestRepoTokenSource_ReMintSkipsDiscovery(t *testing.T) {
+	seedRepoTokenContext(t, "https://us.auth.entire.io")
+	var discoveries int
+	inner := resolveContextForCluster
+	stubResolveContextForCluster(t,
+		func(ctx context.Context, configDir, cacheDir, host string, hc *http.Client, debugf clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+			discoveries++
+			return inner(ctx, configDir, cacheDir, host, hc, debugf)
+		})
+	capture := &captureTransport{}
+	t.Cleanup(SetRepoExchangeTransportForTest(capture))
+
+	src, err := NewRepoTokenSource(context.Background(), "aws-us-east-2.entire.io")
+	if err != nil {
+		t.Fatalf("NewRepoTokenSource: %v", err)
+	}
+	if _, err := src.Token(context.Background(), "/gh/octocat/hello", "pull"); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	src.Invalidate("/gh/octocat/hello", "pull")
+	if _, err := src.Token(context.Background(), "/gh/octocat/hello", "pull"); err != nil {
+		t.Fatalf("Token after Invalidate: %v", err)
+	}
+
+	if discoveries != 1 {
+		t.Errorf("discovery ran %d times, want 1 (construction only)", discoveries)
+	}
+	if capture.calls != 2 {
+		t.Errorf("exchange ran %d times, want 2 (initial + re-mint)", capture.calls)
 	}
 }

--- a/cmd/entire/cli/auth/repo_token_test.go
+++ b/cmd/entire/cli/auth/repo_token_test.go
@@ -18,15 +18,29 @@ import (
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
 
+// sandboxRepoTokenStores redirects the token store and contexts.json (the
+// legacy-login migration's write target) to temp locations.
+func sandboxRepoTokenStores(t *testing.T) {
+	t.Helper()
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+}
+
+// stubResolveContextForCluster swaps the discovery seam for fn.
+func stubResolveContextForCluster(t *testing.T, fn resolveContextFunc) {
+	t.Helper()
+	prev := resolveContextForCluster
+	resolveContextForCluster = fn
+	t.Cleanup(func() { resolveContextForCluster = prev })
+}
+
 // seedRepoTokenContext wires the two seams RepoScopedToken sits on: a
 // file-backed token store holding a still-valid login JWT for a context on
 // coreURL, and a discovery stub resolving any cluster to that context. The
 // exchange transport is left to each test. Returns the seeded login JWT.
 func seedRepoTokenContext(t *testing.T, coreURL string) string {
 	t.Helper()
-	// Sandbox the legacy-login migration's contexts.json writes.
-	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
-	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+	sandboxRepoTokenStores(t)
 
 	svc := tokenstore.CoreKeyringService(coreURL)
 	jwt := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, coreURL, time.Now().Add(2*time.Hour).Unix()))
@@ -35,10 +49,10 @@ func seedRepoTokenContext(t *testing.T, coreURL string) string {
 	}
 
 	c := &contexts.Context{Name: "alice@core", CoreURL: coreURL, Handle: "alice", KeychainService: svc}
-	t.Cleanup(setResolveContextForClusterForTest(
+	stubResolveContextForCluster(t,
 		func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
 			return c, nil
-		}))
+		})
 	return jwt
 }
 
@@ -173,12 +187,11 @@ func TestRepoScopedToken_WireForm(t *testing.T) {
 // failure (no eligible login, ambiguous contexts, unreachable cluster) is
 // returned verbatim — never papered over with a wrong-core exchange.
 func TestRepoScopedToken_DiscoveryErrorSurfaces(t *testing.T) {
-	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
-	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
-	t.Cleanup(setResolveContextForClusterForTest(
+	sandboxRepoTokenStores(t)
+	stubResolveContextForCluster(t,
 		func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
 			return nil, errors.New("not logged in to a login server trusted by cluster x; run `entire login`")
-		}))
+		})
 	t.Cleanup(SetRepoExchangeTransportForTest(failRoundTripper(t)))
 
 	_, err := RepoScopedToken(context.Background(), "x.entire.io", "/gh/o/r", "pull")

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1077,7 +1077,7 @@ func formatCheckpointSummaryError(err error, deadline time.Duration) (string, []
 	var claudeErr *claudecode.ClaudeError
 	switch {
 	case errors.As(err, &claudeErr):
-		switch claudeErr.Kind { //nolint:exhaustive // ClaudeErrorUnknown handled by default
+		switch claudeErr.Kind {
 		case claudecode.ClaudeErrorAuth:
 			label := "Claude authentication failed"
 			rows := []explainRow{

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -1077,7 +1077,7 @@ func formatCheckpointSummaryError(err error, deadline time.Duration) (string, []
 	var claudeErr *claudecode.ClaudeError
 	switch {
 	case errors.As(err, &claudeErr):
-		switch claudeErr.Kind {
+		switch claudeErr.Kind { //nolint:exhaustive // ClaudeErrorUnknown handled by default
 		case claudecode.ClaudeErrorAuth:
 			label := "Claude authentication failed"
 			rows := []explainRow{

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -150,7 +150,7 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 				repoSlug := "/gh/" + owner + "/" + repo
 				return finishMirrorCreate(out, cmd.ErrOrStderr(), created, noWait,
 					func() error {
-						if _, terr := auth.RepoScopedToken(ctx, "https://"+clusterHost, repoSlug, "pull"); terr != nil {
+						if _, terr := auth.RepoScopedToken(ctx, clusterHost, repoSlug, "pull"); terr != nil {
 							return fmt.Errorf("probe mirror for suspension: %w", terr)
 						}
 						return nil

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -179,7 +179,7 @@ func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, 
 	checkURL := fmt.Sprintf("https://%s%s/info/refs?service=git-upload-pack", clusterHost, repoSlug)
 
 	mintToken := func() (string, error) {
-		return auth.RepoScopedToken(ctx, "https://"+clusterHost, repoSlug, "pull")
+		return auth.RepoScopedToken(ctx, clusterHost, repoSlug, "pull")
 	}
 	token, err := mintToken()
 	if err != nil {

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -162,9 +162,18 @@ func explainSuspendedMirror(w io.Writer, mirrorID string, freshCreate bool, err 
 	return true, NewSilentError(fmt.Errorf("mirror %s is suspended", mirrorID))
 }
 
-// mintRepoToken mints the repo-scoped pull token for the clone probe.
-// Package var so tests can substitute a slow or failing auth path.
-var mintRepoToken = auth.RepoScopedToken
+// repoTokenSource is the slice of auth.RepoTokenSource the clone probe
+// uses; an interface so tests can substitute a fake.
+type repoTokenSource interface {
+	Token(ctx context.Context, repoSlug, action string) (string, error)
+	Invalidate(repoSlug, action string)
+}
+
+// newRepoTokenSource builds the clone probe's token source. Package var so
+// tests can substitute a slow or failing auth path.
+var newRepoTokenSource = func(ctx context.Context, clusterHost string) (repoTokenSource, error) {
+	return auth.NewRepoTokenSource(ctx, clusterHost)
+}
 
 // waitForMirrorClone blocks until the mirror at /gh/<owner>/<repo> on
 // clusterHost advertises a resolvable HEAD (the initial GitHub→EntireDB
@@ -174,14 +183,16 @@ var mintRepoToken = auth.RepoScopedToken
 //
 // Repo-scoped pull tokens are short-lived (minutes) while the default wait
 // is 30m, so a single token can't cover the whole wait. The loop re-mints
-// from the (long-lived) login token whenever a probe comes back 401,
-// rather than minting once up front. Re-mints are floored at
-// minReauthInterval so a flapping STS can't be amplified into a re-mint
-// every probeInterval ticks.
+// from the (long-lived) login token whenever a probe comes back 401, rather
+// than minting once up front. Cluster discovery and context selection run
+// once, when the source is built — a discovery hiccup mid-wait can't abort
+// a wait that already authorized. Re-mints are floored at minReauthInterval
+// so a flapping STS can't be amplified into a re-mint every probeInterval
+// ticks.
 //
-// The deadline is applied before the first mint: minting now spans cluster
-// discovery and a possible login refresh, so the authorization phase must
-// consume the user's wait budget, not run before it.
+// The deadline is applied before the source is built: authorization spans
+// cluster discovery and a possible login refresh, so it must consume the
+// user's wait budget, not run before it.
 func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, repo string, timeout time.Duration) error {
 	if timeout > 0 {
 		var cancel context.CancelFunc
@@ -192,10 +203,11 @@ func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, 
 	repoSlug := "/gh/" + owner + "/" + repo
 	checkURL := fmt.Sprintf("https://%s%s/info/refs?service=git-upload-pack", clusterHost, repoSlug)
 
-	mintToken := func() (string, error) {
-		return mintRepoToken(ctx, clusterHost, repoSlug, "pull")
+	src, err := newRepoTokenSource(ctx, clusterHost)
+	if err != nil {
+		return fmt.Errorf("authorize clone probe: %w", err)
 	}
-	token, err := mintToken()
+	token, err := src.Token(ctx, repoSlug, "pull")
 	if err != nil {
 		return fmt.Errorf("authorize clone probe: %w", err)
 	}
@@ -224,7 +236,10 @@ func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, 
 			if since := time.Since(lastMint); since < minReauthInterval {
 				break
 			}
-			newToken, mintErr := mintToken()
+			// Drop the cached token first: the cluster rejected it ahead of
+			// its recorded expiry, so a plain Token call could replay it.
+			src.Invalidate(repoSlug, "pull")
+			newToken, mintErr := src.Token(ctx, repoSlug, "pull")
 			if mintErr != nil {
 				if cloning {
 					fmt.Fprintln(out)

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -162,6 +162,10 @@ func explainSuspendedMirror(w io.Writer, mirrorID string, freshCreate bool, err 
 	return true, NewSilentError(fmt.Errorf("mirror %s is suspended", mirrorID))
 }
 
+// mintRepoToken mints the repo-scoped pull token for the clone probe.
+// Package var so tests can substitute a slow or failing auth path.
+var mintRepoToken = auth.RepoScopedToken
+
 // waitForMirrorClone blocks until the mirror at /gh/<owner>/<repo> on
 // clusterHost advertises a resolvable HEAD (the initial GitHub→EntireDB
 // clone has landed) or the deadline expires. It probes the data plane's
@@ -174,24 +178,28 @@ func explainSuspendedMirror(w io.Writer, mirrorID string, freshCreate bool, err 
 // rather than minting once up front. Re-mints are floored at
 // minReauthInterval so a flapping STS can't be amplified into a re-mint
 // every probeInterval ticks.
+//
+// The deadline is applied before the first mint: minting now spans cluster
+// discovery and a possible login refresh, so the authorization phase must
+// consume the user's wait budget, not run before it.
 func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, repo string, timeout time.Duration) error {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	repoSlug := "/gh/" + owner + "/" + repo
 	checkURL := fmt.Sprintf("https://%s%s/info/refs?service=git-upload-pack", clusterHost, repoSlug)
 
 	mintToken := func() (string, error) {
-		return auth.RepoScopedToken(ctx, clusterHost, repoSlug, "pull")
+		return mintRepoToken(ctx, clusterHost, repoSlug, "pull")
 	}
 	token, err := mintToken()
 	if err != nil {
 		return fmt.Errorf("authorize clone probe: %w", err)
 	}
 	lastMint := time.Now()
-
-	if timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
 
 	ticker := time.NewTicker(probeInterval)
 	defer ticker.Stop()

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -162,7 +162,7 @@ func explainSuspendedMirror(w io.Writer, mirrorID string, freshCreate bool, err 
 	return true, NewSilentError(fmt.Errorf("mirror %s is suspended", mirrorID))
 }
 
-// repoTokenSource is the slice of auth.RepoTokenSource the clone probe
+// repoTokenSource is the subset of auth.RepoTokenSource the clone probe
 // uses; an interface so tests can substitute a fake.
 type repoTokenSource interface {
 	Token(ctx context.Context, repoSlug, action string) (string, error)

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -508,4 +509,24 @@ func mustReq(t *testing.T, rawURL string) *http.Request {
 	u, err := url.Parse(rawURL)
 	require.NoError(t, err)
 	return &http.Request{URL: u}
+}
+
+// TestWaitForMirrorClone_TimeoutBoundsAuthorization pins that --wait-timeout
+// covers the initial token mint, not just the probe loop: minting spans
+// cluster discovery and a possible login refresh, so a hung auth path must
+// be cut off by the user's wait budget.
+//
+// Not parallel: swaps the package-level mintRepoToken seam.
+func TestWaitForMirrorClone_TimeoutBoundsAuthorization(t *testing.T) {
+	prev := mintRepoToken
+	mintRepoToken = func(ctx context.Context, _, _, _ string) (string, error) {
+		<-ctx.Done() // hang until the wait deadline fires
+		return "", ctx.Err()
+	}
+	t.Cleanup(func() { mintRepoToken = prev })
+
+	start := time.Now()
+	err := waitForMirrorClone(context.Background(), io.Discard, "cluster.example", "o", "r", 50*time.Millisecond)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Less(t, time.Since(start), 10*time.Second, "first mint must be bounded by the wait timeout")
 }

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -512,21 +512,21 @@ func mustReq(t *testing.T, rawURL string) *http.Request {
 }
 
 // TestWaitForMirrorClone_TimeoutBoundsAuthorization pins that --wait-timeout
-// covers the initial token mint, not just the probe loop: minting spans
-// cluster discovery and a possible login refresh, so a hung auth path must
-// be cut off by the user's wait budget.
+// covers the authorization phase, not just the probe loop: building the
+// token source spans cluster discovery and a possible login refresh, so a
+// hung auth path must be cut off by the user's wait budget.
 //
-// Not parallel: swaps the package-level mintRepoToken seam.
+// Not parallel: swaps the package-level newRepoTokenSource seam.
 func TestWaitForMirrorClone_TimeoutBoundsAuthorization(t *testing.T) {
-	prev := mintRepoToken
-	mintRepoToken = func(ctx context.Context, _, _, _ string) (string, error) {
+	prev := newRepoTokenSource
+	newRepoTokenSource = func(ctx context.Context, _ string) (repoTokenSource, error) {
 		<-ctx.Done() // hang until the wait deadline fires
-		return "", ctx.Err()
+		return nil, ctx.Err()
 	}
-	t.Cleanup(func() { mintRepoToken = prev })
+	t.Cleanup(func() { newRepoTokenSource = prev })
 
 	start := time.Now()
 	err := waitForMirrorClone(context.Background(), io.Discard, "cluster.example", "o", "r", 50*time.Millisecond)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
-	require.Less(t, time.Since(start), 10*time.Second, "first mint must be bounded by the wait timeout")
+	require.Less(t, time.Since(start), 10*time.Second, "authorization must be bounded by the wait timeout")
 }

--- a/internal/entireclient/httputil/oauth.go
+++ b/internal/entireclient/httputil/oauth.go
@@ -60,9 +60,11 @@ func cloneValuesWithoutClient(v url.Values) url.Values {
 
 // OAuthError is returned by PostOAuthToken when the OAuth endpoint
 // responds with a non-2xx status. Callers can errors.As it to surface
-// status-specific UX (e.g. a friendly 403 message).
+// status-specific UX (e.g. a friendly 403 message) or branch on the
+// RFC 6749 error code.
 type OAuthError struct {
 	Status int
+	Code   string // RFC 6749 `error` code from the response body; "" when not present
 	Body   string
 }
 
@@ -114,7 +116,11 @@ func PostOAuthToken(ctx context.Context, httpClient *http.Client, coreURL string
 
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024)) //nolint:errcheck // best-effort body read for error message
-		return "", 0, &OAuthError{Status: resp.StatusCode, Body: strings.TrimSpace(string(msg))}
+		var oauthBody struct {
+			Code string `json:"error"`
+		}
+		_ = json.Unmarshal(msg, &oauthBody) //nolint:errcheck // best-effort code extraction; non-JSON bodies leave Code empty
+		return "", 0, &OAuthError{Status: resp.StatusCode, Code: oauthBody.Code, Body: strings.TrimSpace(string(msg))}
 	}
 
 	var out struct {

--- a/internal/entireclient/httputil/oauth.go
+++ b/internal/entireclient/httputil/oauth.go
@@ -59,7 +59,7 @@ func cloneValuesWithoutClient(v url.Values) url.Values {
 }
 
 // OAuthError is returned by PostOAuthToken when the OAuth endpoint
-// responds with a non-2xx status. Callers can errors.As it to surface
+// responds with a non-200 status. Callers can errors.As it to surface
 // status-specific UX (e.g. a friendly 403 message) or branch on the
 // RFC 6749 error code.
 type OAuthError struct {
@@ -86,8 +86,9 @@ func (e *OAuthError) Error() string {
 // them on the other side — a raw '+'/'%xx' would round-trip to a different
 // value and fail invalid_client (matches core/api/token_endpoint.go).
 //
-// coreURL must already be trimmed of any trailing slash. A non-2xx
-// response is surfaced as *OAuthError; transport and decode failures
+// coreURL must already be trimmed of any trailing slash. A non-200
+// response is surfaced as *OAuthError (RFC 6749 defines token-endpoint
+// success as 200 only); transport and decode failures
 // are wrapped plain errors.
 func PostOAuthToken(ctx context.Context, httpClient *http.Client, coreURL string, form url.Values) (accessToken string, expiresIn int, err error) {
 	clientID := form.Get("client_id")

--- a/internal/entireclient/httputil/oauth_test.go
+++ b/internal/entireclient/httputil/oauth_test.go
@@ -50,3 +50,32 @@ func TestPostOAuthToken_LiftsAndPercentEncodesClientCreds(t *testing.T) {
 	assert.Empty(t, gotForm.Get("client_id"), "client_id must be dropped from the body once lifted into Basic")
 	assert.Empty(t, gotForm.Get("client_secret"), "client_secret must be dropped from the body")
 }
+
+// TestPostOAuthToken_ErrorCode pins that a non-2xx response surfaces as
+// *OAuthError with the RFC 6749 `error` code parsed from the body (empty for
+// non-JSON bodies), so callers can branch on e.g. invalid_target.
+func TestPostOAuthToken_ErrorCode(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, body, wantCode string
+	}{
+		{"json error code", `{"error":"invalid_target","error_description":"no mirror"}`, "invalid_target"},
+		{"non-json body", `gateway exploded`, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(tc.body)) //nolint:errcheck // test stub
+			}))
+			defer srv.Close()
+
+			_, _, err := PostOAuthToken(context.Background(), srv.Client(), srv.URL, url.Values{})
+			var oe *OAuthError
+			require.ErrorAs(t, err, &oe)
+			assert.Equal(t, http.StatusBadRequest, oe.Status)
+			assert.Equal(t, tc.wantCode, oe.Code)
+			assert.Equal(t, tc.body, oe.Body)
+		})
+	}
+}

--- a/internal/entireclient/httputil/oauth_test.go
+++ b/internal/entireclient/httputil/oauth_test.go
@@ -51,7 +51,7 @@ func TestPostOAuthToken_LiftsAndPercentEncodesClientCreds(t *testing.T) {
 	assert.Empty(t, gotForm.Get("client_secret"), "client_secret must be dropped from the body")
 }
 
-// TestPostOAuthToken_ErrorCode pins that a non-2xx response surfaces as
+// TestPostOAuthToken_ErrorCode pins that a non-200 response surfaces as
 // *OAuthError with the RFC 6749 `error` code parsed from the body (empty for
 // non-JSON bodies), so callers can branch on e.g. invalid_target.
 func TestPostOAuthToken_ErrorCode(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/549
<!-- entire-trail-link-end -->

Closes COR-395.

`entire repo mirror create` (suspension probe + clone wait) minted repo-scoped tokens by exchanging the **active** context's login JWT at the hard-coded `api.AuthBaseURL()` core — on multi-core that ships the token to the wrong core's STS. Now it resolves the cluster's trusted core from `/.well-known/entire-cluster.json` and picks the matching login context, the same path (and wire form) `git-remote-entire` already uses.

**User impact**
- Multi-core: active context on core A, mirror on a cluster fronted by core B → B's context is used. No eligible login → actionable "log in to one of: …" error instead of a wrong-core STS failure.
- An expired login JWT is now silently refreshed from the stored refresh token mid-wait (previously a hard failure).
- `--wait-timeout` now bounds the authorization phase too, not just the probe loop.
- Long clone waits resolve discovery/context once up front; 401 re-mints only re-exchange, so a discovery hiccup mid-wait can't abort an authorized wait.

**New hard requirements** (no fallback, consistent with COR-393): minting needs cluster discovery reachable on a cold cache, and a readable `contexts.json`. The old path could fall back to exchanging the legacy keyring token at the default core — that fallback is gone here and not coming back.

**Transitional machinery left in place, to be removed in the COR-393 follow-up:**
- the `MigrateLegacyLoginContext()` best-effort bridge in `NewRepoTokenSource` (goes when the migration machinery is deleted),
- the remaining `api.AuthBaseURL()` env-read sites elsewhere in the auth package — this PR only takes `repo_token.go` off that list.

**Plumbing:** `httputil.OAuthError` gains a parsed RFC 6749 `Code` so the suspended-mirror sentinel survives the new exchange path. COR-395's second item (`resolveAuthHostToken` removal) had already landed; the last stale comment reference is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication for mirror create/wait in multi-core setups and removes the old default-core fallback; behavior is well-tested but affects token exchange and long-running clone waits.
> 
> **Overview**
> Repo-scoped tokens for **`entire repo mirror`** (suspension probe and clone wait) no longer exchange the **active** login JWT at a hard-coded default core. They follow **`git-remote-entire`**: resolve the cluster’s trusted core from **`/.well-known/entire-cluster.json`**, pick the matching local login context, and mint via **`repocreds`** with **refresh-aware** login and per-**(repo, action)** caching.
> 
> **`RepoTokenSource`** runs discovery once at construction; **`waitForMirrorClone`** holds it so 401 re-mints only re-exchange (with **`Invalidate`** on early rejection). **`--wait-timeout`** now applies before building the token source, so discovery/refresh count toward the wait budget. **`RepoScopedToken`** remains a one-shot wrapper; callers pass a bare **cluster host** (no `https://` prefix).
> 
> **`httputil.OAuthError`** gains a parsed RFC 6749 **`error`** **`Code`** so suspended-mirror handling still maps **`invalid_target`** to **`ErrRepoTargetUnknown`**. The legacy exchange-at-default-core path for repo tokens is removed (cluster discovery + **`contexts.json`** required, aligned with COR-393 direction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2098377390330f54482591f17b9061b9e08699f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->