### PR TITLE
login: harden the browser sign-in fallbacks

### DIFF
--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -216,13 +216,7 @@ func TestLogin_BrowserFlow_SavesToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Blank the SSH_* vars too: startLoginProcess inherits os.Environ(), so a
-	// developer running tests over SSH would otherwise flip the subprocess'
-	// isSSHSession() detection and route it to the device flow.
-	proc := startLoginProcess(t, server.URL, []string{
-		"ENTIRE_TEST_TTY=1",
-		"SSH_CONNECTION=", "SSH_CLIENT=", "SSH_TTY=",
-	}, "login", "--insecure-http-auth")
+	proc := startLoginProcess(t, server.URL, []string{"ENTIRE_TEST_TTY=1"}, "login", "--insecure-http-auth")
 
 	authURL := waitForBrowserPrompt(t, proc.stdout)
 	u, err := url.Parse(authURL)
@@ -279,6 +273,12 @@ func startLoginProcess(t *testing.T, apiBaseURL string, extraEnv []string, args 
 		// production us.auth.entire.io default.
 		"ENTIRE_AUTH_BASE_URL="+apiBaseURL,
 		"ENTIRE_TEST_AUTH_STORE_FILE="+filepath.Join(env.RepoDir, ".entire-test-auth-store.json"),
+		// Blank the SSH_* vars inherited from os.Environ(): a developer
+		// running tests over SSH would otherwise flip the subprocess'
+		// isSSHSession() detection and route browser-flow tests to the
+		// device flow. extraEnv is appended after, so a test can still
+		// set them deliberately.
+		"SSH_CONNECTION=", "SSH_CLIENT=", "SSH_TTY=",
 	)
 	cmd.Env = append(cmd.Env, extraEnv...)
 

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -216,7 +216,13 @@ func TestLogin_BrowserFlow_SavesToken(t *testing.T) {
 	}))
 	defer server.Close()
 
-	proc := startLoginProcess(t, server.URL, []string{"ENTIRE_TEST_TTY=1"}, "login", "--insecure-http-auth")
+	// Blank the SSH_* vars too: startLoginProcess inherits os.Environ(), so a
+	// developer running tests over SSH would otherwise flip the subprocess'
+	// isSSHSession() detection and route it to the device flow.
+	proc := startLoginProcess(t, server.URL, []string{
+		"ENTIRE_TEST_TTY=1",
+		"SSH_CONNECTION=", "SSH_CLIENT=", "SSH_TTY=",
+	}, "login", "--insecure-http-auth")
 
 	authURL := waitForBrowserPrompt(t, proc.stdout)
 	u, err := url.Parse(authURL)

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -25,6 +25,12 @@ const maxPollInterval = 30 * time.Second
 const maxExpiresIn = 15 * time.Minute
 const maxTransientErrors = 5
 
+// browserLoginTimeout bounds how long the browser flow waits for the
+// loopback redirect. The device flow is bounded by the AS's expires_in
+// (capped at maxExpiresIn); without a bound here a closed browser tab
+// would hang `entire login` forever.
+const browserLoginTimeout = 5 * time.Minute
+
 // browserOpenFunc is the signature for opening a URL in the user's browser.
 type browserOpenFunc func(ctx context.Context, url string) error
 
@@ -81,7 +87,7 @@ func newLoginCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("start login: %w", err)
 				}
-				return runBrowserLogin(cmd.Context(), outW, errW, flow, client.BaseURL(), openBrowser)
+				return runBrowserLogin(cmd.Context(), outW, errW, flow, client.BaseURL(), openBrowser, browserLoginTimeout)
 			}
 			if !useDevice {
 				fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
@@ -147,10 +153,10 @@ func shouldUseBrowserLogin(useDevice, canPrompt bool) bool {
 
 // runBrowserLogin runs the loopback authorization-code flow on an
 // already-started flow: open the authorization URL in the user's browser,
-// wait for the redirect back to the local listener, then exchange the code
-// for tokens. Shares the token validation + persistence tail with runLogin
-// via persistLogin.
-func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuthFlow, baseURL string, openURL browserOpenFunc) error {
+// wait up to waitTimeout for the redirect back to the local listener, then
+// exchange the code for tokens. Shares the token validation + persistence
+// tail with runLogin via persistLogin.
+func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuthFlow, baseURL string, openURL browserOpenFunc, waitTimeout time.Duration) error {
 	// Wait tears the listener down on return, but Close is idempotent and
 	// covers the error paths before Wait runs.
 	defer func() { _ = flow.Close() }()
@@ -181,8 +187,16 @@ func runBrowserLogin(ctx context.Context, outW, errW io.Writer, flow browserAuth
 
 	fmt.Fprint(outW, "Waiting for sign-in... ")
 
-	code, err := flow.Wait(ctx)
+	// The clock starts here, after the Enter prompt, so time spent reading
+	// the prompt isn't counted against the sign-in itself.
+	waitCtx, cancel := context.WithTimeout(ctx, waitTimeout)
+	defer cancel()
+
+	code, err := flow.Wait(waitCtx)
 	if err != nil {
+		if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("timed out waiting for sign-in after %v; run `entire login` again, or use `entire login --device`", waitTimeout)
+		}
 		return fmt.Errorf("complete login: %w", err)
 	}
 

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -78,7 +78,7 @@ func newLoginCmd() *cobra.Command {
 				flow, err := client.StartBrowserAuth(ctx)
 				if err != nil {
 					// Explicit nil so the interface value is nil, not a typed nil.
-					return nil, err //nolint:wrapcheck // runLoginAuto wraps this as "start login: %w"
+					return nil, err //nolint:wrapcheck // runLoginAuto surfaces this verbatim in its fallback warning
 				}
 				return flow, nil
 			}
@@ -138,14 +138,19 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 // device-code flows and runs the chosen one. The browser flow is the
 // default — no code to type, no poll latency — but it needs a browser that
 // can reach this machine's 127.0.0.1, so headless terminals (CI, piped
-// stdin) and SSH sessions fall back to the device flow with a one-line
-// explanation; the same both-flows-with-fallback shape gh / gcloud /
-// aws sso ship. --device forces the device flow without commentary.
+// stdin), SSH sessions, and a loopback listener that fails to start all
+// fall back to the device flow with a one-line explanation; the same
+// both-flows-with-fallback shape gh / gcloud / aws sso ship. --device
+// forces the device flow without commentary.
 func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient deviceAuthClient, startBrowser func(context.Context) (browserAuthFlow, error), openURL browserOpenFunc, useDevice, canPrompt, sshSession bool) error {
 	if shouldUseBrowserLogin(useDevice, canPrompt, sshSession) {
 		flow, err := startBrowser(ctx)
 		if err != nil {
-			return fmt.Errorf("start login: %w", err)
+			// Binding the loopback listener can fail (sandboxing, firewall,
+			// exhausted ports); that shouldn't strand the user — warn and
+			// use the device flow instead.
+			fmt.Fprintf(errW, "Warning: could not start browser sign-in (%v); falling back to the device-code flow.\n", err)
+			return runLogin(ctx, outW, errW, deviceClient, openURL)
 		}
 		return runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout)
 	}

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -74,17 +74,19 @@ func newLoginCmd() *cobra.Command {
 				return err
 			}
 			client := auth.NewClient(nil, insecureHTTPAuth)
+			// Closure adapts the concrete *auth.BrowserAuthFlow result to the
+			// browserAuthFlow interface (func types are invariant, so the
+			// method value alone won't do). On error the flow is a typed nil,
+			// which is fine — runLoginAuto checks err before touching it.
 			startBrowser := func(ctx context.Context) (browserAuthFlow, error) {
-				flow, err := client.StartBrowserAuth(ctx)
-				if err != nil {
-					// Explicit nil so the interface value is nil, not a typed nil.
-					return nil, err //nolint:wrapcheck // runLoginAuto surfaces this verbatim in its fallback warning
-				}
-				return flow, nil
+				return client.StartBrowserAuth(ctx)
 			}
 			return runLoginAuto(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				client, startBrowser, openBrowser,
-				useDevice, interactive.CanPromptInteractively(), isSSHSession())
+				client, startBrowser, openBrowser, loginFlowFacts{
+					useDevice:  useDevice,
+					canPrompt:  interactive.CanPromptInteractively(),
+					sshSession: isSSHSession(),
+				})
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
@@ -92,7 +94,7 @@ func newLoginCmd() *cobra.Command {
 	return cmd
 }
 
-func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc) error {
+func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc, canPrompt bool) error {
 	start, err := client.StartDeviceAuth(ctx)
 	if err != nil {
 		return fmt.Errorf("start login: %w", err)
@@ -102,7 +104,7 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 
 	approvalURL := chooseApprovalURL(start)
 
-	if interactive.CanPromptInteractively() {
+	if canPrompt {
 		// chooseApprovalURL prefers the code-embedded verification_uri_complete,
 		// so opening the URL is usually all the user needs to do. The device
 		// code is printed above regardless, so it's still available to confirm
@@ -134,6 +136,15 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	return persistLogin(outW, errW, client.BaseURL(), token, refreshToken)
 }
 
+// loginFlowFacts carries the environment facts that pick between the
+// browser and device-code flows. Detection happens once at the command
+// entry point; the decision logic below only consumes these values.
+type loginFlowFacts struct {
+	useDevice  bool // --device flag
+	canPrompt  bool // interactive terminal present
+	sshSession bool // running inside an SSH session
+}
+
 // runLoginAuto picks between the browser (loopback authorization-code) and
 // device-code flows and runs the chosen one. The browser flow is the
 // default — no code to type, no poll latency — but it needs a browser that
@@ -142,27 +153,27 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 // fall back to the device flow with a one-line explanation; the same
 // both-flows-with-fallback shape gh / gcloud / aws sso ship. --device
 // forces the device flow without commentary.
-func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient deviceAuthClient, startBrowser func(context.Context) (browserAuthFlow, error), openURL browserOpenFunc, useDevice, canPrompt, sshSession bool) error {
-	if shouldUseBrowserLogin(useDevice, canPrompt, sshSession) {
+func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient deviceAuthClient, startBrowser func(context.Context) (browserAuthFlow, error), openURL browserOpenFunc, facts loginFlowFacts) error {
+	if shouldUseBrowserLogin(facts) {
 		flow, err := startBrowser(ctx)
 		if err != nil {
 			// Binding the loopback listener can fail (sandboxing, firewall,
 			// exhausted ports); that shouldn't strand the user — warn and
 			// use the device flow instead.
 			fmt.Fprintf(errW, "Warning: could not start browser sign-in (%v); falling back to the device-code flow.\n", err)
-			return runLogin(ctx, outW, errW, deviceClient, openURL)
+			return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt)
 		}
 		return runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout)
 	}
 	switch {
-	case useDevice:
+	case facts.useDevice:
 		// Explicitly requested; no explanation needed.
-	case !canPrompt:
+	case !facts.canPrompt:
 		fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
-	case sshSession:
+	case facts.sshSession:
 		fmt.Fprintln(errW, "SSH session detected; using device-code flow (a browser opened here couldn't reach this machine).")
 	}
-	return runLogin(ctx, outW, errW, deviceClient, openURL)
+	return runLogin(ctx, outW, errW, deviceClient, openURL, facts.canPrompt)
 }
 
 // shouldUseBrowserLogin reports whether `entire login` should use the
@@ -172,8 +183,8 @@ func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient device
 // and we're not inside an SSH session (where the loopback listener binds
 // on the remote host, out of the user's browser's reach); otherwise the
 // caller falls back to the device flow.
-func shouldUseBrowserLogin(useDevice, canPrompt, sshSession bool) bool {
-	return !useDevice && canPrompt && !sshSession
+func shouldUseBrowserLogin(f loginFlowFacts) bool {
+	return !f.useDevice && f.canPrompt && !f.sshSession
 }
 
 // isSSHSession reports whether this process is running inside an SSH

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -74,25 +74,17 @@ func newLoginCmd() *cobra.Command {
 				return err
 			}
 			client := auth.NewClient(nil, insecureHTTPAuth)
-			outW, errW := cmd.OutOrStdout(), cmd.ErrOrStderr()
-
-			// Default to the browser (loopback authorization-code) flow:
-			// no code to type, no poll latency. It needs a local browser and
-			// a reachable 127.0.0.1, so when there's no interactive terminal
-			// (CI, piped, SSH without a tty) fall back to the device flow —
-			// the same both-flows-with-fallback shape gh / gcloud / aws sso
-			// ship. --device forces the device flow explicitly.
-			if shouldUseBrowserLogin(useDevice, interactive.CanPromptInteractively()) {
-				flow, err := client.StartBrowserAuth(cmd.Context())
+			startBrowser := func(ctx context.Context) (browserAuthFlow, error) {
+				flow, err := client.StartBrowserAuth(ctx)
 				if err != nil {
-					return fmt.Errorf("start login: %w", err)
+					// Explicit nil so the interface value is nil, not a typed nil.
+					return nil, err //nolint:wrapcheck // runLoginAuto wraps this as "start login: %w"
 				}
-				return runBrowserLogin(cmd.Context(), outW, errW, flow, client.BaseURL(), openBrowser, browserLoginTimeout)
+				return flow, nil
 			}
-			if !useDevice {
-				fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
-			}
-			return runLogin(cmd.Context(), outW, errW, client, openBrowser)
+			return runLoginAuto(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(),
+				client, startBrowser, openBrowser,
+				useDevice, interactive.CanPromptInteractively(), isSSHSession())
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
@@ -142,13 +134,50 @@ func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient
 	return persistLogin(outW, errW, client.BaseURL(), token, refreshToken)
 }
 
+// runLoginAuto picks between the browser (loopback authorization-code) and
+// device-code flows and runs the chosen one. The browser flow is the
+// default — no code to type, no poll latency — but it needs a browser that
+// can reach this machine's 127.0.0.1, so headless terminals (CI, piped
+// stdin) and SSH sessions fall back to the device flow with a one-line
+// explanation; the same both-flows-with-fallback shape gh / gcloud /
+// aws sso ship. --device forces the device flow without commentary.
+func runLoginAuto(ctx context.Context, outW, errW io.Writer, deviceClient deviceAuthClient, startBrowser func(context.Context) (browserAuthFlow, error), openURL browserOpenFunc, useDevice, canPrompt, sshSession bool) error {
+	if shouldUseBrowserLogin(useDevice, canPrompt, sshSession) {
+		flow, err := startBrowser(ctx)
+		if err != nil {
+			return fmt.Errorf("start login: %w", err)
+		}
+		return runBrowserLogin(ctx, outW, errW, flow, deviceClient.BaseURL(), openURL, browserLoginTimeout)
+	}
+	switch {
+	case useDevice:
+		// Explicitly requested; no explanation needed.
+	case !canPrompt:
+		fmt.Fprintln(errW, "No interactive terminal detected; using device-code flow.")
+	case sshSession:
+		fmt.Fprintln(errW, "SSH session detected; using device-code flow (a browser opened here couldn't reach this machine).")
+	}
+	return runLogin(ctx, outW, errW, deviceClient, openURL)
+}
+
 // shouldUseBrowserLogin reports whether `entire login` should use the
 // loopback authorization-code (browser) flow. The browser flow is the
 // default but needs a local browser + reachable 127.0.0.1, so it's only
-// chosen when --device wasn't passed and an interactive terminal is
-// present; otherwise the caller falls back to the device flow.
-func shouldUseBrowserLogin(useDevice, canPrompt bool) bool {
-	return !useDevice && canPrompt
+// chosen when --device wasn't passed, an interactive terminal is present,
+// and we're not inside an SSH session (where the loopback listener binds
+// on the remote host, out of the user's browser's reach); otherwise the
+// caller falls back to the device flow.
+func shouldUseBrowserLogin(useDevice, canPrompt, sshSession bool) bool {
+	return !useDevice && canPrompt && !sshSession
+}
+
+// isSSHSession reports whether this process is running inside an SSH
+// session: sshd sets SSH_CONNECTION/SSH_CLIENT for every session and
+// SSH_TTY for interactive ones.
+func isSSHSession() bool {
+	return os.Getenv("SSH_CONNECTION") != "" ||
+		os.Getenv("SSH_CLIENT") != "" ||
+		os.Getenv("SSH_TTY") != ""
 }
 
 // runBrowserLogin runs the loopback authorization-code flow on an

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -304,12 +304,13 @@ func TestWaitForApproval_ContextCancelled(t *testing.T) {
 
 // fakeBrowserFlow implements the browserAuthFlow interface for unit tests.
 type fakeBrowserFlow struct {
-	authURL     string
-	waitCode    string
-	waitErr     error
-	exchAccess  string
-	exchRefresh string
-	exchErr     error
+	authURL       string
+	waitCode      string
+	waitErr       error
+	waitUntilDone bool // Wait blocks until ctx is done and returns ctx.Err()
+	exchAccess    string
+	exchRefresh   string
+	exchErr       error
 
 	gotExchangeCode string
 	closed          bool
@@ -317,7 +318,13 @@ type fakeBrowserFlow struct {
 
 func (f *fakeBrowserFlow) AuthorizationURL() string { return f.authURL }
 
-func (f *fakeBrowserFlow) Wait(context.Context) (string, error) { return f.waitCode, f.waitErr }
+func (f *fakeBrowserFlow) Wait(ctx context.Context) (string, error) {
+	if f.waitUntilDone {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	return f.waitCode, f.waitErr
+}
 
 func (f *fakeBrowserFlow) Exchange(_ context.Context, code string) (string, string, error) {
 	f.gotExchangeCode = code
@@ -364,7 +371,7 @@ func TestRunBrowserLogin_OpensAuthorizationURL(t *testing.T) {
 	// The stubbed Wait returns an error, so runBrowserLogin stops before
 	// persistLogin (which would hit the real keyring); we assert on the
 	// side effects up to that point.
-	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, flow, "https://auth.test", openURL); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &bytes.Buffer{}, flow, "https://auth.test", openURL, browserLoginTimeout); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -394,7 +401,7 @@ func TestRunBrowserLogin_OpenBrowserFallback(t *testing.T) {
 	failOpen := func(context.Context, string) error { return errors.New("no browser") }
 
 	var out, errW bytes.Buffer
-	if err := runBrowserLogin(context.Background(), &out, &errW, flow, "https://auth.test", failOpen); err == nil {
+	if err := runBrowserLogin(context.Background(), &out, &errW, flow, "https://auth.test", failOpen, browserLoginTimeout); err == nil {
 		t.Fatal("expected error from stubbed Wait")
 	}
 
@@ -413,7 +420,7 @@ func TestRunBrowserLogin_WaitError(t *testing.T) {
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: denied}
 	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, browserLoginTimeout)
 	if !errors.Is(err, denied) {
 		t.Fatalf("err = %v, want wrapped %v", err, denied)
 	}
@@ -429,11 +436,49 @@ func TestRunBrowserLogin_ExchangeError(t *testing.T) {
 	}
 	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, browserLoginTimeout)
 	if err == nil || !strings.Contains(err.Error(), "complete login") {
 		t.Fatalf("err = %v, want complete login error", err)
 	}
 	if flow.gotExchangeCode != "the-code" {
 		t.Errorf("Exchange got code %q, want the-code", flow.gotExchangeCode)
+	}
+}
+
+func TestRunBrowserLogin_WaitTimeout(t *testing.T) {
+	t.Parallel()
+
+	// The fake blocks until the wait context expires — the deadline must
+	// come from runBrowserLogin's own timeout, or this test would hang.
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
+	noopOpen := func(context.Context, string) error { return nil }
+
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, 50*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting for sign-in") {
+		t.Fatalf("err = %v, want sign-in timeout", err)
+	}
+	if !strings.Contains(err.Error(), "--device") {
+		t.Errorf("timeout error should point at the --device escape hatch, got: %v", err)
+	}
+	if !flow.closed {
+		t.Error("flow was not closed")
+	}
+}
+
+func TestRunBrowserLogin_ParentCancelNotReportedAsTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // user hit Ctrl-C before the redirect arrived
+
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
+	noopOpen := func(context.Context, string) error { return nil }
+
+	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, time.Minute)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want wrapped context.Canceled", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("cancellation must not be reported as a timeout: %v", err)
 	}
 }

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -340,22 +340,20 @@ func TestShouldUseBrowserLogin(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		useDevice  bool
-		canPrompt  bool
-		sshSession bool
-		want       bool
+		facts loginFlowFacts
+		want  bool
 	}{
-		{useDevice: false, canPrompt: true, sshSession: false, want: true},   // default interactive → browser
-		{useDevice: false, canPrompt: false, sshSession: false, want: false}, // headless → fall back to device
-		{useDevice: false, canPrompt: true, sshSession: true, want: false},   // SSH: loopback unreachable → device
-		{useDevice: false, canPrompt: false, sshSession: true, want: false},
-		{useDevice: true, canPrompt: true, sshSession: false, want: false}, // --device forces device
-		{useDevice: true, canPrompt: false, sshSession: false, want: false},
-		{useDevice: true, canPrompt: true, sshSession: true, want: false},
+		{facts: loginFlowFacts{canPrompt: true}, want: true},                    // default interactive → browser
+		{facts: loginFlowFacts{}, want: false},                                  // headless → fall back to device
+		{facts: loginFlowFacts{canPrompt: true, sshSession: true}, want: false}, // SSH: loopback unreachable → device
+		{facts: loginFlowFacts{sshSession: true}, want: false},
+		{facts: loginFlowFacts{useDevice: true, canPrompt: true}, want: false}, // --device forces device
+		{facts: loginFlowFacts{useDevice: true}, want: false},
+		{facts: loginFlowFacts{useDevice: true, canPrompt: true, sshSession: true}, want: false},
 	}
 	for _, tc := range cases {
-		if got := shouldUseBrowserLogin(tc.useDevice, tc.canPrompt, tc.sshSession); got != tc.want {
-			t.Errorf("shouldUseBrowserLogin(%v, %v, %v) = %v, want %v", tc.useDevice, tc.canPrompt, tc.sshSession, got, tc.want)
+		if got := shouldUseBrowserLogin(tc.facts); got != tc.want {
+			t.Errorf("shouldUseBrowserLogin(%+v) = %v, want %v", tc.facts, got, tc.want)
 		}
 	}
 }
@@ -375,6 +373,10 @@ func TestIsSSHSession(t *testing.T) {
 	}
 }
 
+// noopOpenURL is a browserOpenFunc for tests that don't care about the
+// browser actually opening.
+func noopOpenURL(context.Context, string) error { return nil }
+
 // startBrowserStub returns a startBrowser func that records invocations and
 // returns the given flow/error.
 func startBrowserStub(calls *int, flow browserAuthFlow, err error) func(context.Context) (browserAuthFlow, error) {
@@ -389,11 +391,10 @@ func TestRunLoginAuto_Interactive_UsesBrowserFlow(t *testing.T) {
 
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: errors.New("stop")}
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, &mockClient{},
-		startBrowserStub(&browserCalls, flow, nil), noopOpen,
-		false /* useDevice */, true /* canPrompt */, false /* ssh */)
+		startBrowserStub(&browserCalls, flow, nil), noopOpenURL,
+		loginFlowFacts{canPrompt: true})
 
 	if browserCalls != 1 {
 		t.Errorf("startBrowser calls = %d, want 1", browserCalls)
@@ -408,12 +409,11 @@ func TestRunLoginAuto_SSHSession_FallsBackToDevice(t *testing.T) {
 	t.Parallel()
 
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil, nil), noopOpen,
-		false /* useDevice */, true /* canPrompt */, true /* ssh */)
+		startBrowserStub(&browserCalls, nil, nil), noopOpenURL,
+		loginFlowFacts{canPrompt: true, sshSession: true})
 
 	if browserCalls != 0 {
 		t.Errorf("startBrowser calls = %d, want 0 (SSH must skip the browser flow)", browserCalls)
@@ -431,12 +431,11 @@ func TestRunLoginAuto_Headless_FallsBackToDevice(t *testing.T) {
 	t.Parallel()
 
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil, nil), noopOpen,
-		false /* useDevice */, false /* canPrompt */, false /* ssh */)
+		startBrowserStub(&browserCalls, nil, nil), noopOpenURL,
+		loginFlowFacts{})
 
 	if browserCalls != 0 {
 		t.Errorf("startBrowser calls = %d, want 0", browserCalls)
@@ -453,12 +452,11 @@ func TestRunLoginAuto_BrowserStartFails_FallsBackToDevice(t *testing.T) {
 	t.Parallel()
 
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil, errors.New("listen tcp 127.0.0.1:0: operation not permitted")), noopOpen,
-		false /* useDevice */, true /* canPrompt */, false /* ssh */)
+		startBrowserStub(&browserCalls, nil, errors.New("listen tcp 127.0.0.1:0: operation not permitted")), noopOpenURL,
+		loginFlowFacts{canPrompt: true})
 
 	if browserCalls != 1 {
 		t.Errorf("startBrowser calls = %d, want 1", browserCalls)
@@ -476,12 +474,11 @@ func TestRunLoginAuto_DeviceFlag_NoExplanation(t *testing.T) {
 	t.Parallel()
 
 	var browserCalls int
-	noopOpen := func(context.Context, string) error { return nil }
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil, nil), noopOpen,
-		true /* useDevice */, true /* canPrompt */, false /* ssh */)
+		startBrowserStub(&browserCalls, nil, nil), noopOpenURL,
+		loginFlowFacts{useDevice: true, canPrompt: true})
 
 	if browserCalls != 0 {
 		t.Errorf("startBrowser calls = %d, want 0", browserCalls)
@@ -557,9 +554,8 @@ func TestRunBrowserLogin_WaitError(t *testing.T) {
 
 	denied := errors.New("access_denied")
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: denied}
-	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, browserLoginTimeout)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout)
 	if !errors.Is(err, denied) {
 		t.Fatalf("err = %v, want wrapped %v", err, denied)
 	}
@@ -573,9 +569,8 @@ func TestRunBrowserLogin_ExchangeError(t *testing.T) {
 		waitCode: "the-code",
 		exchErr:  errors.New("invalid_grant"),
 	}
-	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, browserLoginTimeout)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, browserLoginTimeout)
 	if err == nil || !strings.Contains(err.Error(), "complete login") {
 		t.Fatalf("err = %v, want complete login error", err)
 	}
@@ -590,9 +585,8 @@ func TestRunBrowserLogin_WaitTimeout(t *testing.T) {
 	// The fake blocks until the wait context expires — the deadline must
 	// come from runBrowserLogin's own timeout, or this test would hang.
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
-	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, 50*time.Millisecond)
+	err := runBrowserLogin(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, 50*time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "timed out waiting for sign-in") {
 		t.Fatalf("err = %v, want sign-in timeout", err)
 	}
@@ -611,9 +605,8 @@ func TestRunBrowserLogin_ParentCancelNotReportedAsTimeout(t *testing.T) {
 	cancel() // user hit Ctrl-C before the redirect arrived
 
 	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitUntilDone: true}
-	noopOpen := func(context.Context, string) error { return nil }
 
-	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpen, time.Minute)
+	err := runBrowserLogin(ctx, &bytes.Buffer{}, &bytes.Buffer{}, flow, "https://auth.test", noopOpenURL, time.Minute)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("err = %v, want wrapped context.Canceled", err)
 	}

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -376,11 +376,11 @@ func TestIsSSHSession(t *testing.T) {
 }
 
 // startBrowserStub returns a startBrowser func that records invocations and
-// returns the given flow.
-func startBrowserStub(calls *int, flow browserAuthFlow) func(context.Context) (browserAuthFlow, error) {
+// returns the given flow/error.
+func startBrowserStub(calls *int, flow browserAuthFlow, err error) func(context.Context) (browserAuthFlow, error) {
 	return func(context.Context) (browserAuthFlow, error) {
 		*calls++
-		return flow, nil
+		return flow, err
 	}
 }
 
@@ -392,7 +392,7 @@ func TestRunLoginAuto_Interactive_UsesBrowserFlow(t *testing.T) {
 	noopOpen := func(context.Context, string) error { return nil }
 
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, &mockClient{},
-		startBrowserStub(&browserCalls, flow), noopOpen,
+		startBrowserStub(&browserCalls, flow, nil), noopOpen,
 		false /* useDevice */, true /* canPrompt */, false /* ssh */)
 
 	if browserCalls != 1 {
@@ -412,7 +412,7 @@ func TestRunLoginAuto_SSHSession_FallsBackToDevice(t *testing.T) {
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil), noopOpen,
+		startBrowserStub(&browserCalls, nil, nil), noopOpen,
 		false /* useDevice */, true /* canPrompt */, true /* ssh */)
 
 	if browserCalls != 0 {
@@ -435,7 +435,7 @@ func TestRunLoginAuto_Headless_FallsBackToDevice(t *testing.T) {
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil), noopOpen,
+		startBrowserStub(&browserCalls, nil, nil), noopOpen,
 		false /* useDevice */, false /* canPrompt */, false /* ssh */)
 
 	if browserCalls != 0 {
@@ -449,6 +449,29 @@ func TestRunLoginAuto_Headless_FallsBackToDevice(t *testing.T) {
 	}
 }
 
+func TestRunLoginAuto_BrowserStartFails_FallsBackToDevice(t *testing.T) {
+	t.Parallel()
+
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	var errW bytes.Buffer
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, nil, errors.New("listen tcp 127.0.0.1:0: operation not permitted")), noopOpen,
+		false /* useDevice */, true /* canPrompt */, false /* ssh */)
+
+	if browserCalls != 1 {
+		t.Errorf("startBrowser calls = %d, want 1", browserCalls)
+	}
+	if !strings.Contains(errW.String(), "could not start browser sign-in") {
+		t.Errorf("stderr missing fallback warning:\n%s", errW.String())
+	}
+	// mockClient.StartDeviceAuth errors — proof the device flow was attempted.
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+}
+
 func TestRunLoginAuto_DeviceFlag_NoExplanation(t *testing.T) {
 	t.Parallel()
 
@@ -457,7 +480,7 @@ func TestRunLoginAuto_DeviceFlag_NoExplanation(t *testing.T) {
 
 	var errW bytes.Buffer
 	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
-		startBrowserStub(&browserCalls, nil), noopOpen,
+		startBrowserStub(&browserCalls, nil, nil), noopOpen,
 		true /* useDevice */, true /* canPrompt */, false /* ssh */)
 
 	if browserCalls != 0 {

--- a/cmd/entire/cli/login_test.go
+++ b/cmd/entire/cli/login_test.go
@@ -340,19 +340,135 @@ func TestShouldUseBrowserLogin(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		useDevice bool
-		canPrompt bool
-		want      bool
+		useDevice  bool
+		canPrompt  bool
+		sshSession bool
+		want       bool
 	}{
-		{useDevice: false, canPrompt: true, want: true},   // default interactive → browser
-		{useDevice: false, canPrompt: false, want: false}, // headless → fall back to device
-		{useDevice: true, canPrompt: true, want: false},   // --device forces device
-		{useDevice: true, canPrompt: false, want: false},
+		{useDevice: false, canPrompt: true, sshSession: false, want: true},   // default interactive → browser
+		{useDevice: false, canPrompt: false, sshSession: false, want: false}, // headless → fall back to device
+		{useDevice: false, canPrompt: true, sshSession: true, want: false},   // SSH: loopback unreachable → device
+		{useDevice: false, canPrompt: false, sshSession: true, want: false},
+		{useDevice: true, canPrompt: true, sshSession: false, want: false}, // --device forces device
+		{useDevice: true, canPrompt: false, sshSession: false, want: false},
+		{useDevice: true, canPrompt: true, sshSession: true, want: false},
 	}
 	for _, tc := range cases {
-		if got := shouldUseBrowserLogin(tc.useDevice, tc.canPrompt); got != tc.want {
-			t.Errorf("shouldUseBrowserLogin(%v, %v) = %v, want %v", tc.useDevice, tc.canPrompt, got, tc.want)
+		if got := shouldUseBrowserLogin(tc.useDevice, tc.canPrompt, tc.sshSession); got != tc.want {
+			t.Errorf("shouldUseBrowserLogin(%v, %v, %v) = %v, want %v", tc.useDevice, tc.canPrompt, tc.sshSession, got, tc.want)
 		}
+	}
+}
+
+func TestIsSSHSession(t *testing.T) {
+	// t.Setenv forbids t.Parallel.
+	for _, v := range []string{"SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"} {
+		t.Setenv(v, "")
+	}
+	if isSSHSession() {
+		t.Error("isSSHSession() = true with all SSH env vars empty")
+	}
+
+	t.Setenv("SSH_CONNECTION", "10.0.0.1 50022 10.0.0.2 22")
+	if !isSSHSession() {
+		t.Error("isSSHSession() = false with SSH_CONNECTION set")
+	}
+}
+
+// startBrowserStub returns a startBrowser func that records invocations and
+// returns the given flow.
+func startBrowserStub(calls *int, flow browserAuthFlow) func(context.Context) (browserAuthFlow, error) {
+	return func(context.Context) (browserAuthFlow, error) {
+		*calls++
+		return flow, nil
+	}
+}
+
+func TestRunLoginAuto_Interactive_UsesBrowserFlow(t *testing.T) {
+	t.Parallel()
+
+	flow := &fakeBrowserFlow{authURL: "https://auth.test/authorize", waitErr: errors.New("stop")}
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &bytes.Buffer{}, &mockClient{},
+		startBrowserStub(&browserCalls, flow), noopOpen,
+		false /* useDevice */, true /* canPrompt */, false /* ssh */)
+
+	if browserCalls != 1 {
+		t.Errorf("startBrowser calls = %d, want 1", browserCalls)
+	}
+	// The stubbed Wait errors, so the browser flow is entered and fails there.
+	if err == nil || !strings.Contains(err.Error(), "complete login") {
+		t.Fatalf("err = %v, want browser-flow 'complete login' error", err)
+	}
+}
+
+func TestRunLoginAuto_SSHSession_FallsBackToDevice(t *testing.T) {
+	t.Parallel()
+
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	var errW bytes.Buffer
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, nil), noopOpen,
+		false /* useDevice */, true /* canPrompt */, true /* ssh */)
+
+	if browserCalls != 0 {
+		t.Errorf("startBrowser calls = %d, want 0 (SSH must skip the browser flow)", browserCalls)
+	}
+	if !strings.Contains(errW.String(), "SSH session detected") {
+		t.Errorf("stderr missing SSH explanation:\n%s", errW.String())
+	}
+	// mockClient.StartDeviceAuth errors — proof the device flow was attempted.
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+}
+
+func TestRunLoginAuto_Headless_FallsBackToDevice(t *testing.T) {
+	t.Parallel()
+
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	var errW bytes.Buffer
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, nil), noopOpen,
+		false /* useDevice */, false /* canPrompt */, false /* ssh */)
+
+	if browserCalls != 0 {
+		t.Errorf("startBrowser calls = %d, want 0", browserCalls)
+	}
+	if !strings.Contains(errW.String(), "No interactive terminal detected") {
+		t.Errorf("stderr missing headless explanation:\n%s", errW.String())
+	}
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+}
+
+func TestRunLoginAuto_DeviceFlag_NoExplanation(t *testing.T) {
+	t.Parallel()
+
+	var browserCalls int
+	noopOpen := func(context.Context, string) error { return nil }
+
+	var errW bytes.Buffer
+	err := runLoginAuto(context.Background(), &bytes.Buffer{}, &errW, &mockClient{},
+		startBrowserStub(&browserCalls, nil), noopOpen,
+		true /* useDevice */, true /* canPrompt */, false /* ssh */)
+
+	if browserCalls != 0 {
+		t.Errorf("startBrowser calls = %d, want 0", browserCalls)
+	}
+	// mockClient.StartDeviceAuth errors — proof the device flow was attempted.
+	if err == nil || !strings.Contains(err.Error(), "not implemented in mock") {
+		t.Fatalf("err = %v, want device-flow start error from mock", err)
+	}
+	if errW.String() != "" {
+		t.Errorf("--device should produce no fallback commentary, got:\n%s", errW.String())
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/550
<!-- entire-trail-link-end -->

## What

Hardening follow-ups to #1366 (browser sign-in default), from its code review. Stacked on `login-loopback-browser-flow` — review/merge that first.

- **Bound the loopback wait at 5 minutes.** The device flow is bounded by the AS's `expires_in`; the browser flow waited forever if the user closed the tab. The timeout error points at `entire login --device` as the escape hatch, and Ctrl-C still reports as cancellation, not a timeout.
- **SSH sessions fall back to the device flow.** Over `ssh -t` the browser flow was chosen (a TTY is present), but the loopback listener binds 127.0.0.1 on the *remote* host where the user's browser can't reach it. Detect SSH via the `SSH_CONNECTION`/`SSH_CLIENT`/`SSH_TTY` vars sshd sets — same as `gh`/`gcloud` — and explain the fallback in one line on stderr.
- **Listener-bind failure falls back to the device flow.** If `StartBrowserAuth` can't bind (sandboxing, firewall, exhausted ports), warn and continue with the device flow instead of erroring out.

## How

The flow choice moved out of the cobra `RunE` into `runLoginAuto`, which takes a `loginFlowFacts` struct (`useDevice`/`canPrompt`/`sshSession`, detected once at entry) plus a `startBrowser` func, so the selection logic and all three fallback paths are unit-tested with fakes. `startLoginProcess` in the integration tests now blanks the inherited `SSH_*` vars centrally, so browser-flow subprocess tests stay on the browser path even when the developer runs the suite over SSH.

## Testing

- New unit tests: timeout (incl. Ctrl-C-is-not-a-timeout), SSH/headless/listener-failure fallbacks and their stderr messages, `--device` produces no commentary, `isSSHSession`.
- Existing browser-flow integration test still passes; `mise run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication flow selection and timeout behavior for `entire login`, which is security-sensitive but limited to CLI UX and fallbacks with broad unit test coverage.
> 
> **Overview**
> Hardens **`entire login`** browser sign-in with timeouts, SSH-aware routing, and automatic fallbacks to the device-code flow.
> 
> **Browser wait is capped at 5 minutes** (`browserLoginTimeout`). Loopback redirect wait uses a context timeout starting after the Enter prompt; deadline exceeded yields an error that suggests `entire login --device`, while parent cancellation still surfaces as `context.Canceled`, not a timeout.
> 
> **Flow selection moves into `runLoginAuto`** with a `loginFlowFacts` struct (`--device`, interactive TTY, SSH session). Browser flow is skipped when SSH env vars indicate a remote session (one-line stderr explanation), when headless, or when `--device` is set. If `StartBrowserAuth` fails to bind loopback, the CLI warns and falls back to device flow instead of failing outright.
> 
> Integration **`startLoginProcess`** clears inherited `SSH_*` vars so browser-flow subprocess tests stay stable when the suite runs over SSH. Unit tests cover SSH/headless/listener-failure paths, timeout vs cancel, and `--device` silence on stderr commentary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334df98857aeee8ac36d898fdf2c8136c698af53. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->