### PR TITLE
login: add --server, retire ENTIRE_AUTH_BASE_URL (COR-393, part 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,13 +210,12 @@ If you're working on the CLI device auth flow against a local `entire.io` checko
 cd ../entire.io-1
 mise run dev
 
-# In this repo, point the CLI at the local API. Both env vars are
-# required: ENTIRE_AUTH_BASE_URL no longer inherits from
-# ENTIRE_API_BASE_URL — without it, the login flow reaches for the
-# production us.auth.entire.io.
+# In this repo, point data-API commands at the local API.
+# (ENTIRE_AUTH_BASE_URL is retired — commands refuse to run while it's
+# exported. The login server is chosen at login time via --server, and
+# every other command follows the login context.)
 cd ../cli
 export ENTIRE_API_BASE_URL=http://localhost:8787
-export ENTIRE_AUTH_BASE_URL=http://localhost:8787
 
 # Run the smoke test
 ./scripts/local-device-auth-smoke.sh
@@ -226,7 +225,7 @@ Useful commands while developing:
 
 ```bash
 # Run the login flow against a local server (prompts to press Enter before opening the browser)
-go run ./cmd/entire login --insecure-http-auth
+go run ./cmd/entire login --server http://localhost:8787 --insecure-http-auth
 
 # Run the focused integration coverage for login
 go test -tags=integration ./cmd/entire/cli/integration_test -run TestLogin

--- a/cmd/entire/cli/api/base_url.go
+++ b/cmd/entire/cli/api/base_url.go
@@ -33,6 +33,18 @@ const (
 	schemeHTTPS = "https"
 )
 
+// RejectRemovedAuthEnv returns an error when ENTIRE_AUTH_BASE_URL is set
+// at all (even empty). The variable is retired in favour of
+// `entire login --server`; failing loudly beats silently ignoring an
+// override the operator believes is in effect. The remaining internal
+// AuthBaseURL() reads only ever see the default once this gate has run.
+func RejectRemovedAuthEnv() error {
+	if _, ok := os.LookupEnv(AuthBaseURLEnvVar); ok {
+		return fmt.Errorf("%s is no longer supported; unset it, and use `entire login --server <url>` to log in to a non-default login server", AuthBaseURLEnvVar)
+	}
+	return nil
+}
+
 // BaseURL returns the effective Entire API base URL.
 // ENTIRE_API_BASE_URL takes precedence over the production default.
 func BaseURL() string {

--- a/cmd/entire/cli/api/base_url_test.go
+++ b/cmd/entire/cli/api/base_url_test.go
@@ -159,7 +159,9 @@ func TestResolveURL(t *testing.T) {
 // empty — errors with the --server replacement hint; unset passes.
 func TestRejectRemovedAuthEnv(t *testing.T) {
 	t.Run("unset passes", func(t *testing.T) {
-		if os.Getenv(AuthBaseURLEnvVar) != "" {
+		// LookupEnv, not Getenv: the gate rejects a present-but-empty var
+		// too, so an empty export in the parent shell must also skip.
+		if _, ok := os.LookupEnv(AuthBaseURLEnvVar); ok {
 			t.Skipf("%s set in test environment", AuthBaseURLEnvVar)
 		}
 		if err := RejectRemovedAuthEnv(); err != nil {

--- a/cmd/entire/cli/api/base_url_test.go
+++ b/cmd/entire/cli/api/base_url_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"errors"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -151,4 +153,30 @@ func TestResolveURL(t *testing.T) {
 	if got != "http://localhost:8787/oauth/device/code" {
 		t.Fatalf("ResolveURL() = %q, want %q", got, "http://localhost:8787/oauth/device/code")
 	}
+}
+
+// TestRejectRemovedAuthEnv pins the retired-env gate: any set value — even
+// empty — errors with the --server replacement hint; unset passes.
+func TestRejectRemovedAuthEnv(t *testing.T) {
+	t.Run("unset passes", func(t *testing.T) {
+		if os.Getenv(AuthBaseURLEnvVar) != "" {
+			t.Skipf("%s set in test environment", AuthBaseURLEnvVar)
+		}
+		if err := RejectRemovedAuthEnv(); err != nil {
+			t.Fatalf("RejectRemovedAuthEnv() with unset var: %v", err)
+		}
+	})
+	t.Run("set errors", func(t *testing.T) {
+		t.Setenv(AuthBaseURLEnvVar, "https://custom.example")
+		err := RejectRemovedAuthEnv()
+		if err == nil || !strings.Contains(err.Error(), "entire login --server") {
+			t.Fatalf("err = %v, want --server hint", err)
+		}
+	})
+	t.Run("set-but-empty errors", func(t *testing.T) {
+		t.Setenv(AuthBaseURLEnvVar, "")
+		if err := RejectRemovedAuthEnv(); err == nil {
+			t.Fatal("RejectRemovedAuthEnv() with empty-but-set var: want error")
+		}
+	})
 }

--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -47,8 +47,8 @@ func NewClient(token string) *Client {
 
 // NewClientWithBaseURL creates a new authenticated API client targeting an
 // explicit base URL. Use this for endpoints that live on the auth host (e.g.
-// auth-token management) when ENTIRE_AUTH_BASE_URL splits the auth origin
-// from the data API origin.
+// auth-token management), which is split from the data API origin by
+// default.
 func NewClientWithBaseURL(token, baseURL string) *Client {
 	return &Client{
 		httpClient: &http.Client{

--- a/cmd/entire/cli/auth/client.go
+++ b/cmd/entire/cli/auth/client.go
@@ -46,19 +46,20 @@ type Client struct {
 	browser *authcode.Client
 }
 
-// NewClient constructs a Client targeting the active provider version.
-// httpClient.Transport is reused when non-nil (its TLS / proxy config
-// flows through); a nil httpClient or nil Transport falls back to the
-// deviceflow default (http.DefaultTransport).
+// NewClient constructs a Client for the device-flow login against server
+// (the login-server origin, validated by the caller — `entire login
+// --server`). httpClient.Transport is reused when non-nil (its TLS /
+// proxy config flows through); a nil httpClient or nil Transport falls
+// back to the deviceflow default (http.DefaultTransport).
 //
 // HTTPS is required by default. Loopback http:// (localhost, 127.0.0.1,
 // ::1) is always permitted — see isLoopbackHTTP. allowInsecureHTTP=true
 // additionally permits non-loopback http:// for cases like local-dev
 // auth hosts on a private network (e.g. http://devbox.internal); the
 // CLI plumbs this from the --insecure-http-auth flag.
-func NewClient(httpClient *http.Client, allowInsecureHTTP bool) *Client {
+func NewClient(server string, httpClient *http.Client, allowInsecureHTTP bool) *Client {
 	p := CurrentProvider()
-	issuer := api.AuthBaseURL()
+	issuer := api.NormalizeOriginURL(server)
 	var transport http.RoundTripper
 	if httpClient != nil {
 		transport = httpClient.Transport

--- a/cmd/entire/cli/auth/client_test.go
+++ b/cmd/entire/cli/auth/client_test.go
@@ -99,21 +99,21 @@ func TestSecondsUntil_PastExpiryClampsToZero(t *testing.T) {
 }
 
 func TestNewClient_AllowInsecureHTTPPermitsNonLoopback(t *testing.T) {
+	t.Parallel()
 	// --insecure-http-auth must reach the deviceflow client; without this,
 	// http://devbox.internal style auth hosts fail with ErrInsecureBaseURL
 	// even when the operator has explicitly opted in.
-	t.Setenv("ENTIRE_AUTH_BASE_URL", "http://devbox.internal:8787")
-	c := NewClient(nil, true)
+	c := NewClient("http://devbox.internal:8787", nil, true)
 	if !c.inner.AllowInsecureHTTP {
-		t.Fatal("NewClient(nil, true) AllowInsecureHTTP = false, want true")
+		t.Fatal("NewClient(server, nil, true) AllowInsecureHTTP = false, want true")
 	}
 }
 
 func TestNewClient_LoopbackHTTPAlwaysPermitted(t *testing.T) {
-	t.Setenv("ENTIRE_AUTH_BASE_URL", "http://127.0.0.1:8787")
-	c := NewClient(nil, false)
+	t.Parallel()
+	c := NewClient("http://127.0.0.1:8787", nil, false)
 	if !c.inner.AllowInsecureHTTP {
-		t.Fatal("NewClient(nil, false) AllowInsecureHTTP = false for loopback, want true")
+		t.Fatal("NewClient(server, nil, false) AllowInsecureHTTP = false for loopback, want true")
 	}
 }
 

--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -28,13 +28,13 @@ type ControlPlaneTarget struct {
 //  1. the active contexts.json login -> its CoreURL, with a per-context
 //     refreshing bearer (silent JWT re-mint). This is what makes
 //     `entire auth use <ctx>` retarget the control plane onto that core.
-//  2. no active context -> the configured auth origin (ENTIRE_AUTH_BASE_URL or
-//     the default) + TokenForResource, the pre-contexts fallback.
+//  2. no active context -> the default auth origin + TokenForResource,
+//     the pre-contexts fallback.
 //
-// ENTIRE_AUTH_BASE_URL is the fallback host, not an override: a token minted
-// by the active context's core can't authenticate against a different host, so
-// "use the override host but the context's identity" can't succeed. The active
-// context always wins when present.
+// The default auth origin is the fallback host, not an override: a token
+// minted by the active context's core can't authenticate against a different
+// host, so "use the fallback host but the context's identity" can't succeed.
+// The active context always wins when present.
 func ResolveControlPlaneTarget() (ControlPlaneTarget, error) {
 	c, ok, err := activeContext()
 	if err != nil {
@@ -56,7 +56,7 @@ func ResolveControlPlaneTarget() (ControlPlaneTarget, error) {
 }
 
 // staticControlPlaneTarget is the no-active-context fallback: dial the
-// configured auth origin (ENTIRE_AUTH_BASE_URL or the default) and resolve the
+// default auth origin and resolve the
 // bearer through the singleton manager, which performs an RFC 8693 exchange
 // when the stored token's audience doesn't cover the core.
 func staticControlPlaneTarget() ControlPlaneTarget {

--- a/cmd/entire/cli/auth/data_api.go
+++ b/cmd/entire/cli/auth/data_api.go
@@ -59,7 +59,7 @@ func DiscoveryUnavailableForTest(context.Context, string, string, string, *http.
 //	ENTIRE_API_BASE_URL=https://partial.to entire activity
 //
 // authenticate as the partial.to login even while the active context is a
-// prod entire.io login — without the operator also setting ENTIRE_AUTH_BASE_URL.
+// prod entire.io login — with no per-command override needed.
 //
 // When the API doesn't advertise discovery (404 / unreachable / 503 /
 // malformed — e.g. a deployment predating the well-known), it falls back to

--- a/cmd/entire/cli/auth/exchange.go
+++ b/cmd/entire/cli/auth/exchange.go
@@ -80,7 +80,7 @@ func SetManagerForTest(t interface{ Helper() }, mgr *tokenmanager.Manager) func(
 // defaultManager returns the package-level Manager built from this
 // CLI's identity (current provider, AuthBaseURL, NewStore service
 // name). Constructed lazily on first use so any env-var setup
-// (ENTIRE_AUTH_BASE_URL, ENTIRE_AUTH_PROVIDER_VERSION) lands before
+// (ENTIRE_AUTH_PROVIDER_VERSION, ENTIRE_API_BASE_URL) lands before
 // construction. sync.Once means later env-var changes within the same
 // process are ignored; tests bypass the singleton via SetManagerForTest.
 func defaultManager() (*tokenmanager.Manager, error) {

--- a/cmd/entire/cli/integration_test/login_test.go
+++ b/cmd/entire/cli/integration_test/login_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -21,6 +23,19 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/execx"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
+
+// fakeLoginJWT builds a JWT-shaped access token with a junk signature
+// (ParseClaims doesn't verify signatures) whose iss matches the test server
+// origin, so login's iss cross-check passes and the context can be recorded.
+// A bare opaque token is no longer enough for a --server login: with no iss
+// claim there is nothing to key the login context by, and login fails.
+func fakeLoginJWT(iss string) string {
+	enc := base64.RawURLEncoding
+	header := enc.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := enc.EncodeToString(fmt.Appendf(nil,
+		`{"iss":%q,"sub":"user-123","exp":%d}`, iss, time.Now().Add(time.Hour).Unix()))
+	return header + "." + payload + "." + enc.EncodeToString([]byte("sig"))
+}
 
 func TestLogin_SavesTokenAfterApproval(t *testing.T) {
 	t.Parallel()
@@ -34,7 +49,7 @@ func TestLogin_SavesTokenAfterApproval(t *testing.T) {
 	serverState := &state{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/oauth/device/code":
+		case r.Method == http.MethodPost && r.URL.Path == "/device_authorization":
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"device_code":               "device-123",
 				"user_code":                 "ABCD-EFGH",
@@ -54,7 +69,7 @@ func TestLogin_SavesTokenAfterApproval(t *testing.T) {
 				return
 			}
 
-			writeJSON(t, w, http.StatusOK, map[string]any{"access_token": "local-token", "token_type": "Bearer", "expires_in": 3600, "scope": "cli"})
+			writeJSON(t, w, http.StatusOK, map[string]any{"access_token": fakeLoginJWT("http://" + r.Host), "token_type": "Bearer", "expires_in": 3600, "scope": "cli"})
 		case r.Method == http.MethodPost && r.URL.Path == "/approve":
 			serverState.Lock()
 			serverState.approved = true
@@ -101,6 +116,18 @@ func TestLogin_SavesTokenAfterApproval(t *testing.T) {
 		t.Fatalf("output missing login complete message (token save likely failed):\n%s", output)
 	}
 
+	// A --server login is recorded as a contexts.json context (the legacy
+	// keyring entry is only written for the default login server, whose key
+	// is the only one legacy readers consult).
+	contextsPath := filepath.Join(proc.configDir, "contexts.json")
+	data, readErr := os.ReadFile(contextsPath)
+	if readErr != nil {
+		t.Fatalf("read %s after login: %v", contextsPath, readErr)
+	}
+	if !strings.Contains(string(data), server.URL) {
+		t.Fatalf("contexts.json does not reference login server %s:\n%s", server.URL, data)
+	}
+
 	serverState.Lock()
 	polls := serverState.polls
 	serverState.Unlock()
@@ -114,7 +141,7 @@ func TestLogin_ExpiredFlow(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/oauth/device/code":
+		case r.Method == http.MethodPost && r.URL.Path == "/device_authorization":
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"device_code":               "device-expired",
 				"user_code":                 "WXYZ-0000",
@@ -153,7 +180,7 @@ func TestLogin_DeniedFlow(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/oauth/device/code":
+		case r.Method == http.MethodPost && r.URL.Path == "/device_authorization":
 			writeJSON(t, w, http.StatusOK, map[string]any{
 				"device_code":               "device-denied",
 				"user_code":                 "QRST-9999",
@@ -208,7 +235,7 @@ func TestLogin_BrowserFlow_SavesToken(t *testing.T) {
 				t.Error("token request missing code_verifier")
 			}
 			writeJSON(t, w, http.StatusOK, map[string]any{
-				"access_token": "browser-token", "token_type": "Bearer", "expires_in": 3600, "scope": "cli offline_access",
+				"access_token": fakeLoginJWT("http://" + r.Host), "token_type": "Bearer", "expires_in": 3600, "scope": "cli offline_access",
 			})
 			return
 		}
@@ -246,7 +273,10 @@ func TestLogin_BrowserFlow_SavesToken(t *testing.T) {
 
 type loginProcess struct {
 	stdout *bufio.Reader
-	waitFn func() (string, error)
+	// configDir is the sandboxed ENTIRE_CONFIG_DIR the spawned binary writes
+	// contexts.json into; tests can assert on its contents after login.
+	configDir string
+	waitFn    func() (string, error)
 }
 
 func runLoginProcess(t *testing.T, apiBaseURL string) *loginProcess {
@@ -260,7 +290,12 @@ func startLoginProcess(t *testing.T, apiBaseURL string, extraEnv []string, args 
 	t.Helper()
 
 	env := NewTestEnv(t)
+	configDir := filepath.Join(env.RepoDir, ".entire-test-config")
 
+	// ENTIRE_AUTH_BASE_URL is retired (commands reject it when set at all);
+	// --server is how a login targets the test server instead of the
+	// production default.
+	args = append(args, "--server", apiBaseURL)
 	cmd := execx.NonInteractive(context.Background(), getTestBinary(), args...)
 	cmd.Dir = env.RepoDir
 	cmd.Env = append(testutil.GitIsolatedEnv(),
@@ -268,11 +303,13 @@ func startLoginProcess(t *testing.T, apiBaseURL string, extraEnv []string, args 
 		"ENTIRE_TEST_GEMINI_PROJECT_DIR="+env.GeminiProjectDir,
 		"ENTIRE_TEST_OPENCODE_PROJECT_DIR="+env.OpenCodeProjectDir,
 		"ENTIRE_API_BASE_URL="+apiBaseURL,
-		// AuthBaseURL no longer inherits from BaseURL; pin both at the test
-		// server so the flow stays in-process instead of reaching out to the
-		// production us.auth.entire.io default.
-		"ENTIRE_AUTH_BASE_URL="+apiBaseURL,
 		"ENTIRE_TEST_AUTH_STORE_FILE="+filepath.Join(env.RepoDir, ".entire-test-auth-store.json"),
+		// A --server login records its credential in contexts.json and the
+		// token store; point both at the test sandbox so the spawned binary
+		// can't touch the real ~/.config/entire or the OS keychain.
+		"ENTIRE_CONFIG_DIR="+configDir,
+		"ENTIRE_TOKEN_STORE=file",
+		"ENTIRE_TOKEN_STORE_PATH="+filepath.Join(env.RepoDir, ".entire-test-tokens.json"),
 		// Blank the SSH_* vars inherited from os.Environ(): a developer
 		// running tests over SSH would otherwise flip the subprocess'
 		// isSSHSession() detection and route browser-flow tests to the
@@ -297,7 +334,8 @@ func startLoginProcess(t *testing.T, apiBaseURL string, extraEnv []string, args 
 	reader := bufio.NewReader(stdoutPipe)
 
 	return &loginProcess{
-		stdout: reader,
+		stdout:    reader,
+		configDir: configDir,
 		waitFn: func() (string, error) {
 			stdoutBytes, readErr := io.ReadAll(reader)
 			waitErr := cmd.Wait()

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -124,17 +124,20 @@ func parseLoginServer(raw string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse server URL: %w", err)
 	}
+	// Error messages echo u.Redacted(), not raw: the URL may carry
+	// userinfo (that's one of the rejection cases), and stderr often ends
+	// up in CI logs where a password must not appear.
 	switch {
 	case u.Scheme != schemeHTTPS && u.Scheme != schemeHTTP:
-		return "", fmt.Errorf("scheme must be http or https, got %q", raw)
+		return "", fmt.Errorf("scheme must be http or https, got %q", u.Redacted())
 	case u.Host == "":
-		return "", fmt.Errorf("missing host in %q", raw)
+		return "", fmt.Errorf("missing host in %q", u.Redacted())
 	case u.User != nil:
-		return "", fmt.Errorf("userinfo not allowed in %q", raw)
+		return "", fmt.Errorf("userinfo not allowed in %q", u.Redacted())
 	case u.Path != "" && u.Path != "/":
-		return "", fmt.Errorf("path not allowed in %q (use the bare origin)", raw)
+		return "", fmt.Errorf("path not allowed in %q (use the bare origin)", u.Redacted())
 	case u.RawQuery != "" || u.Fragment != "":
-		return "", fmt.Errorf("query/fragment not allowed in %q", raw)
+		return "", fmt.Errorf("query/fragment not allowed in %q", u.Redacted())
 	}
 	return api.NormalizeOriginURL(raw), nil
 }
@@ -321,21 +324,31 @@ func persistLogin(outW, errW io.Writer, baseURL, token, refreshToken string) err
 		return fmt.Errorf("reject login token: %w", err)
 	}
 
-	store := auth.NewStore()
-
-	// Login deliberately uses the legacy SaveToken (string, string)
-	// surface — we only have an access-token string at this point;
-	// neither flow's client returns a TokenSet here.
-	if err := store.SaveToken(baseURL, token); err != nil {
-		return fmt.Errorf("save auth token: %w", err)
+	// Every legacy-keyring read in the CLI keys by api.AuthBaseURL(),
+	// which is always the default origin now that ENTIRE_AUTH_BASE_URL is
+	// retired. A legacy entry saved under any other --server origin would
+	// be unreadable forever (and undeletable by logout, which deletes the
+	// default key) — so only write it when this login targeted that origin.
+	legacyReadable := baseURL == api.AuthBaseURL()
+	if legacyReadable {
+		// Login deliberately uses the legacy SaveToken (string, string)
+		// surface — we only have an access-token string at this point;
+		// neither flow's client returns a TokenSet here.
+		if err := auth.NewStore().SaveToken(baseURL, token); err != nil {
+			return fmt.Errorf("save auth token: %w", err)
+		}
 	}
 
 	// Dual-write the shared contexts.json credential model so the git
 	// remote helper (and entiredb's CLIs) can authenticate against any
-	// entitled cluster from this login. Best-effort: the legacy entry
-	// above remains the control-plane source of truth, so a failure here
-	// must not fail the login — warn and continue.
+	// entitled cluster from this login. Best-effort only when the legacy
+	// entry above exists as the control-plane source of truth; for a
+	// non-default --server the context is the sole record of the login,
+	// so failing to write it means the login failed.
 	if _, err := auth.RecordLoginContext(token, refreshToken, true); err != nil {
+		if !legacyReadable {
+			return fmt.Errorf("record login context: %w", err)
+		}
 		fmt.Fprintf(errW, "Warning: logged in, but could not record a shareable context (clone via entire:// may need a re-login): %v\n", err)
 	}
 

--- a/cmd/entire/cli/login.go
+++ b/cmd/entire/cli/login.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/entireio/auth-go/tokens"
@@ -17,6 +18,11 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/spf13/cobra"
+)
+
+const (
+	schemeHTTP  = "http"
+	schemeHTTPS = "https"
 )
 
 const fallbackDeviceAuthPollInterval = time.Second
@@ -64,16 +70,23 @@ type browserAuthFlow interface {
 }
 
 func newLoginCmd() *cobra.Command {
-	var insecureHTTPAuth bool
-	var useDevice bool
+	var (
+		insecureHTTPAuth bool
+		useDevice        bool
+		server           string
+	)
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to Entire",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := requireSecureBaseURL(insecureHTTPAuth); err != nil {
+			loginServer, err := parseLoginServer(server)
+			if err != nil {
+				return fmt.Errorf("invalid --server: %w", err)
+			}
+			if err := requireSecureLoginServer(loginServer, insecureHTTPAuth); err != nil {
 				return err
 			}
-			client := auth.NewClient(nil, insecureHTTPAuth)
+			client := auth.NewClient(loginServer, nil, insecureHTTPAuth)
 			// Closure adapts the concrete *auth.BrowserAuthFlow result to the
 			// browserAuthFlow interface (func types are invariant, so the
 			// method value alone won't do). On error the flow is a typed nil,
@@ -89,9 +102,56 @@ func newLoginCmd() *cobra.Command {
 				})
 		},
 	}
+	cmd.Flags().StringVar(&server, "server", api.DefaultAuthBaseURL,
+		"login server to authenticate against (rarely needed; the default serves all standard accounts)")
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
 	cmd.Flags().BoolVar(&useDevice, "device", false, "Use the device-code flow (enter a code in your browser) instead of the default browser redirect")
 	return cmd
+}
+
+// parseLoginServer validates and canonicalises the --server value: an
+// http(s) origin with nothing but scheme and host. Userinfo, path, query,
+// and fragment are rejected rather than silently dropped — the value
+// becomes the OAuth issuer, the token-exchange target, and the keyring
+// key, so surprising rewrites would surface as confusing auth failures
+// much later. A lone trailing slash is tolerated (normalised away).
+func parseLoginServer(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("empty server URL")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse server URL: %w", err)
+	}
+	switch {
+	case u.Scheme != schemeHTTPS && u.Scheme != schemeHTTP:
+		return "", fmt.Errorf("scheme must be http or https, got %q", raw)
+	case u.Host == "":
+		return "", fmt.Errorf("missing host in %q", raw)
+	case u.User != nil:
+		return "", fmt.Errorf("userinfo not allowed in %q", raw)
+	case u.Path != "" && u.Path != "/":
+		return "", fmt.Errorf("path not allowed in %q (use the bare origin)", raw)
+	case u.RawQuery != "" || u.Fragment != "":
+		return "", fmt.Errorf("query/fragment not allowed in %q", raw)
+	}
+	return api.NormalizeOriginURL(raw), nil
+}
+
+// requireSecureLoginServer enforces TLS for the chosen login server.
+// Unlike requireSecureBaseURL it checks only the server being dialled —
+// login never touches the data API. --insecure-http-auth opts in to
+// http:// (and enables it process-wide for the token save path).
+func requireSecureLoginServer(server string, insecureHTTPAuth bool) error {
+	if insecureHTTPAuth {
+		auth.EnableInsecureHTTP()
+		return nil
+	}
+	if err := api.RequireSecureURL(server); err != nil {
+		return fmt.Errorf("login server check: %w", err)
+	}
+	return nil
 }
 
 func runLogin(ctx context.Context, outW, errW io.Writer, client deviceAuthClient, openURL browserOpenFunc, canPrompt bool) error {
@@ -441,7 +501,7 @@ func waitForEnter(ctx context.Context) error {
 
 func openBrowser(ctx context.Context, browserURL string) error {
 	u, err := url.Parse(browserURL)
-	if err != nil || (u.Scheme != "https" && u.Scheme != "http") {
+	if err != nil || (u.Scheme != schemeHTTPS && u.Scheme != schemeHTTP) {
 		return fmt.Errorf("refusing to open non-HTTP URL: %s", browserURL)
 	}
 

--- a/cmd/entire/cli/login_validate_test.go
+++ b/cmd/entire/cli/login_validate_test.go
@@ -108,3 +108,41 @@ func TestValidateReceivedToken_AllowsFutureExp(t *testing.T) {
 		t.Fatalf("validateReceivedToken(future exp) = %v, want nil", err)
 	}
 }
+
+func TestParseLoginServer(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, in, want string // want=="" means error expected
+	}{
+		{"default form", "https://us.auth.entire.io", "https://us.auth.entire.io"},
+		{"trailing slash normalised", "https://eu.auth.entire.io/", "https://eu.auth.entire.io"},
+		{"case and default port normalised", "HTTPS://US.AUTH.ENTIRE.IO:443", "https://us.auth.entire.io"},
+		{"loopback http kept", "http://127.0.0.1:8787", "http://127.0.0.1:8787"},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"no scheme", "us.auth.entire.io", ""},
+		{"bad scheme", "ftp://x.example", ""},
+		{"userinfo rejected", "https://tok@evil.example", ""},
+		{"path rejected", "https://x.example/oauth", ""},
+		{"query rejected", "https://x.example?a=1", ""},
+		{"fragment rejected", "https://x.example#frag", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseLoginServer(tc.in)
+			if tc.want == "" {
+				if err == nil {
+					t.Fatalf("parseLoginServer(%q) = %q, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseLoginServer(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseLoginServer(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -121,7 +121,7 @@ func checkProbeRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) >= maxProbeRedirects {
 		return fmt.Errorf("stopped after %d redirects", maxProbeRedirects)
 	}
-	if req.URL.Scheme != "https" {
+	if req.URL.Scheme != schemeHTTPS {
 		return fmt.Errorf("refusing non-https redirect to %s", req.URL.Redacted())
 	}
 	if !discovery.HostInCluster(req.URL.Hostname(), via[0].URL.Hostname()) {

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/entireio/cli/cmd/entire/cli"
+	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/spf13/cobra"
 )
@@ -52,6 +53,15 @@ func main() {
 		os.Exit(code)
 	}
 	restorePATH()
+
+	// Retired env vars fail every built-in command up front; a removed knob
+	// must never be silently ignored. Plugins (above) are exempt — what they
+	// read is their business.
+	if err := api.RejectRemovedAuthEnv(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		cancel()
+		os.Exit(1)
+	}
 
 	executed, err := rootCmd.ExecuteContextC(ctx)
 	if err != nil {

--- a/docs/architecture/upstream-host-resolution.md
+++ b/docs/architecture/upstream-host-resolution.md
@@ -48,20 +48,20 @@ The host *is* a core, so there is no discovery. `coreapi.New()` consults
    and an expired access token is silently re-minted from the stored refresh
    token. This is what makes `entire auth use <ctx>` actually retarget
    `org`/`repo`/`project`/`grant`.
-2. **else** (no active context) → the configured auth origin
-   (`ENTIRE_AUTH_BASE_URL` or the default) + `TokenForResource` — the
-   pre-contexts fallback.
+2. **else** (no active context) → the default auth origin +
+   `TokenForResource` — the pre-contexts fallback.
 
-`ENTIRE_AUTH_BASE_URL` is the fallback host, **not** an override: a token
+The default auth origin is the fallback host, **not** an override: a token
 minted by the active context's core can't authenticate against a different
-host, so the active context always wins when present. (At login time the env
-var still chooses where to authenticate, and the resulting context's `CoreURL`
-*is* that host — so local-dev / split-host setups keep working.)
+host, so the active context always wins when present. (At login time
+`entire login --server` chooses where to authenticate, and the resulting
+context's `CoreURL` *is* that host — so local-dev / split-host setups keep
+working. `ENTIRE_AUTH_BASE_URL` is retired and rejected when set.)
 
 Key files: `cmd/entire/cli/auth/control_plane.go` (resolver),
 `cmd/entire/cli/auth/refresh.go` (per-context refreshing provider),
 `internal/coreapi/client.go` (`New()` + `providerSource`),
-`cmd/entire/cli/api/base_url.go` (`AuthBaseURLOverridden`).
+`cmd/entire/cli/api/base_url.go` (`AuthBaseURL`).
 
 Why the per-context path and not the singleton manager: the singleton
 (`auth/exchange.go:defaultManager`) is built once with `Issuer =
@@ -116,7 +116,7 @@ Resolution (`auth.ResolveDataAPIToken`):
    active-context-wins-if-eligible → sole eligible → explicit-choice error.
    This is the lever that makes `ENTIRE_API_BASE_URL=https://partial.to entire
    activity` authenticate as the partial.to login even while the active context
-   is a prod entire.io login — without also setting `ENTIRE_AUTH_BASE_URL`.
+   is a prod entire.io login — with no env override needed.
 3. Exchange that context's login JWT at **its** core for the data host origin
    (`auth.NewRefreshingResourceProvider`, keyed on `c.CoreURL` like the
    control-plane provider; the token manager sets `aud` = that origin).

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -23,7 +23,7 @@ const apiBasePath = "/api/v1"
 // commands target a login server directly — unlike `git clone` or the data
 // API, there's no resource host to match a context against — so the active
 // contexts.json login is used as-is, and `entire auth use <ctx>` retargets the
-// control plane onto that login server. ENTIRE_AUTH_BASE_URL / the default is
+// control plane onto that login server. The default auth origin is
 // only the fallback when no context is active, not an override. The Core API
 // is served at <host>/api/v1. The bearer is resolved lazily per request; for
 // an active context it re-mints silently from the stored refresh token, and

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -113,7 +113,7 @@ func TestProviderSource_BearerAuth(t *testing.T) {
 		// The active-context provider returns an already-tailored message; it
 		// must reach the user unprefixed (no generic "resolve control-plane
 		// token" wrapper burying it) and without the login hint.
-		sentinel := errors.New(`no usable login for "ctx" (https://core.example); run ENTIRE_AUTH_BASE_URL=https://core.example entire login`)
+		sentinel := errors.New(`no usable login for "ctx" (https://core.example); run entire login --server https://core.example`)
 		src := &providerSource{provide: func(context.Context) (string, error) { return "", sentinel }}
 		_, err := src.BearerAuth(context.Background(), "")
 		if err == nil || err.Error() != sentinel.Error() {

--- a/internal/entireclient/clusterdiscovery/api_discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery_test.go
@@ -172,7 +172,7 @@ func TestResolveContextForAPI(t *testing.T) {
 
 	// The cross-core case the slice exists to fix: the active context is a prod
 	// login, but the only context eligible for the partial.to API is the
-	// staging one — pick it without the operator setting ENTIRE_AUTH_BASE_URL.
+	// staging one — pick it without any operator override.
 	t.Run("sole eligible context used despite unrelated active", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(apiHandler(t, "https://us.auth.partial.to", "https://eu.auth.partial.to"))

--- a/scripts/local-device-auth-smoke.sh
+++ b/scripts/local-device-auth-smoke.sh
@@ -6,9 +6,10 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
 : "${ENTIRE_API_BASE_URL:=http://localhost:8787}"
-# Pin auth at the same host: AuthBaseURL defaults to the production
-# us.auth.entire.io and no longer inherits from ENTIRE_API_BASE_URL.
-: "${ENTIRE_AUTH_BASE_URL:=${ENTIRE_API_BASE_URL}}"
+# The login server is chosen at login time via --server
+# (ENTIRE_AUTH_BASE_URL is retired); default to the same host that
+# serves the local data API.
+: "${ENTIRE_LOGIN_SERVER:=${ENTIRE_API_BASE_URL}}"
 
 LOG_FILE="$(mktemp -t entire-device-auth-smoke.XXXXXX.log)"
 cleanup() {
@@ -20,20 +21,20 @@ trap cleanup EXIT
 
 cd "${REPO_ROOT}"
 
-echo "Starting device auth login against ${ENTIRE_API_BASE_URL}"
-ENTIRE_TEST_TTY=0 ENTIRE_API_BASE_URL="${ENTIRE_API_BASE_URL}" ENTIRE_AUTH_BASE_URL="${ENTIRE_AUTH_BASE_URL}" go run ./cmd/entire login --insecure-http-auth >"${LOG_FILE}" 2>&1 &
+echo "Starting device auth login against ${ENTIRE_LOGIN_SERVER}"
+ENTIRE_TEST_TTY=0 ENTIRE_API_BASE_URL="${ENTIRE_API_BASE_URL}" go run ./cmd/entire login --server "${ENTIRE_LOGIN_SERVER}" --insecure-http-auth >"${LOG_FILE}" 2>&1 &
 LOGIN_PID=$!
 
 for _ in {1..100}; do
-  if grep -q '^Approval URL: ' "${LOG_FILE}" && grep -q '^Device code: ' "${LOG_FILE}"; then
+  if grep -q '^Login URL:' "${LOG_FILE}" && grep -q '^Device code: ' "${LOG_FILE}"; then
     break
   fi
   sleep 0.1
 done
 
-if ! grep -q '^Approval URL: ' "${LOG_FILE}"; then
+if ! grep -q '^Login URL:' "${LOG_FILE}"; then
   cat "${LOG_FILE}"
-  echo "Failed to capture approval URL from login output" >&2
+  echo "Failed to capture login URL from login output" >&2
   exit 1
 fi
 
@@ -42,8 +43,8 @@ import pathlib
 import sys
 
 for line in pathlib.Path(sys.argv[1]).read_text().splitlines():
-    if line.startswith("Approval URL: "):
-        print(line.split(": ", 1)[1])
+    if line.startswith("Login URL:"):
+        print(line.split(":", 1)[1].strip())
         break
 PY
 )"
@@ -60,7 +61,7 @@ PY
 )"
 
 echo "Device code: ${DEVICE_CODE}"
-echo "Approval URL: ${APPROVAL_URL}"
+echo "Login URL: ${APPROVAL_URL}"
 
 if command -v open >/dev/null 2>&1; then
   open "${APPROVAL_URL}"
@@ -79,25 +80,26 @@ if ! wait "${LOGIN_PID}"; then
   exit 1
 fi
 
-AUTH_FILE="${HOME}/.config/entire/auth.json"
+# A --server login is recorded as a contexts.json context (the legacy
+# keyring/auth.json entry is only written for the default login server).
+CONTEXTS_FILE="${ENTIRE_CONFIG_DIR:-${HOME}/.config/entire}/contexts.json"
 
-python3 - <<'PY' "${AUTH_FILE}" "${ENTIRE_API_BASE_URL}"
+python3 - <<'PY' "${CONTEXTS_FILE}" "${ENTIRE_LOGIN_SERVER}"
 import json
 import pathlib
 import sys
 
-auth_file = pathlib.Path(sys.argv[1])
-base_url = sys.argv[2]
+contexts_file = pathlib.Path(sys.argv[1])
+server = sys.argv[2].rstrip("/")
 
-if not auth_file.exists():
-    raise SystemExit(f"Auth file not found: {auth_file}")
+if not contexts_file.exists():
+    raise SystemExit(f"Contexts file not found: {contexts_file}")
 
-data = json.loads(auth_file.read_text())
-token = data.get("tokens", {}).get(base_url, {}).get("value", "")
-if not token:
-    raise SystemExit(f"No token saved for {base_url} in {auth_file}")
+data = json.loads(contexts_file.read_text())
+if not any(c.get("core_url", "").rstrip("/") == server for c in data.get("contexts", [])):
+    raise SystemExit(f"No login context for {server} in {contexts_file}")
 
-print(f"Verified token saved for {base_url} in {auth_file}")
+print(f"Verified login context for {server} in {contexts_file}")
 PY
 
 cat "${LOG_FILE}"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/551
<!-- entire-trail-link-end -->

Part 1 of COR-393. Stacked on #1402.

**What changes**
- `ENTIRE_AUTH_BASE_URL` is retired: if it's set (even empty), every built-in `entire` command exits immediately with an error naming the replacement.
- `entire login --server <url>` is the replacement (default `https://us.auth.entire.io`). The value must be a bare http(s) origin; userinfo/path/query are rejected, not silently dropped.

**If you have the env var exported** (dev/staging setups): unset it and run `entire login --server <that-url>` once. Every other command then follows the login context — no per-command override needed or possible.

**Why**
Auth resolution is context- and discovery-based now (COR-389, #1402): commands follow your login, not a process-global env override. Leaving the var readable-but-ignored would silently send credentials somewhere the operator doesn't expect, so it fails loudly instead. With the gate in place, the remaining internal `AuthBaseURL()` reads can only ever observe the default — which is what makes the follow-up demolition PR (static fallbacks, v1 provider, legacy-token migration) a mechanical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication entry points, credential storage rules, and fails all commands when a legacy env var is set—operators must migrate login flows before upgrading.
> 
> **Overview**
> **Retires `ENTIRE_AUTH_BASE_URL`** in favor of login-time server selection. If the variable is present (including empty), built-in `entire` commands exit immediately with a message to unset it and use `entire login --server <url>` instead. Plugins are not gated.
> 
> **Adds `entire login --server`** (default `https://us.auth.entire.io`). The flag must be a bare `http`/`https` origin; userinfo, path, query, and fragment are rejected. Device auth targets that origin via `auth.NewClient(server, …)` rather than env-driven `AuthBaseURL()`.
> 
> **Tightens login persistence:** legacy keyring/`SaveToken` runs only when `--server` matches the default auth origin; custom servers rely on `contexts.json`, and a failed `RecordLoginContext` fails the login. Integration tests and the local device-auth smoke script use `--server`, JWT-shaped tokens with matching `iss`, and assert on `contexts.json`.
> 
> Docs and architecture notes now describe `--server` and context/discovery-based resolution instead of per-command auth env overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41d01eb86decfbc33afa168c50471910a07a46b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->