### PR TITLE
tests: never touch the user's real config, cache, or keychain

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -123,6 +123,7 @@ linters:
         - github.com/entireio/cli/cmd/entire/cli/review.SynthesisProvider
         - github.com/entireio/cli/cmd/entire/cli/checkpoint.CommittedReader
         - github.com/entireio/cli/cmd/entire/cli/strategy.Strategy
+        - github.com/entireio/cli/internal/entireclient/tokenstore.store
         - github.com/go-git/go-git/v6/x/plugin.Signer
         - github.com/go-git/go-git/v6/plumbing/storer.ReferenceIter
         - github.com/go-git/go-git/v6/plumbing.EncodedObject

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,31 @@ t.Chdir(tmpDir)                                 // redirect CWD-based git resolu
 
 **Do NOT** shell out to `git init`/`git commit` directly without setting user config and `--no-gpg-sign`, and **do NOT** run lifecycle/strategy handlers from the real repo CWD in tests.
 
+### Config/Cache/Keyring Isolation in Tests
+
+Tests must never read or write the developer's real `~/.config/entire`
+(contexts.json, version_check.json), `~/.cache/entire` (nodes.json,
+cluster_cores.json, api_discovery.json), or OS keychain. The developer may be
+using `entire` for real while tests run.
+
+- **In-process safety net**: `contexts.DefaultConfigDir()`,
+  `discovery.DefaultCacheDir()`, versioncheck's config path, and the
+  `tokenstore` default backend all detect `go test` (via `internal/testdirs`)
+  and fall back to a throwaway per-process temp directory when their env
+  override is unset. The fallback is shared across tests in one process — for
+  per-test isolation still set `t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())`
+  and `tokenstore.UseFileBackendForTesting(...)`.
+- **Spawned binaries are NOT covered**: `testing.Testing()` is false in a
+  subprocess. The integration and e2e TestMains set `ENTIRE_CONFIG_DIR`,
+  `XDG_CACHE_HOME`, `ENTIRE_TOKEN_STORE=file`, `ENTIRE_TOKEN_STORE_PATH`, and
+  `ENTIRE_TEST_AUTH_STORE_FILE` process-wide so every spawned `entire` (and
+  every agent-invoked hook) inherits isolation. Any new harness that spawns
+  the real binary must do the same.
+- **Legacy auth store**: `auth.NewStore()` talks straight to the zalando
+  keyring; packages whose tests can reach it need `keyring.MockInit()` in
+  `TestMain` (see `cmd/entire/cli/global_test.go`) — the `testdirs` fallback
+  does not cover it in-process.
+
 ### Spawning subprocesses in tests (TTY detection)
 
 Tests that spawn the real `entire` or `git` binary need the child to be non-interactive so prompts don't hang on a developer terminal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,13 +179,17 @@ Tests must never read or write the developer's real `~/.config/entire`
 cluster_cores.json, api_discovery.json), or OS keychain. The developer may be
 using `entire` for real while tests run.
 
-- **In-process safety net**: `contexts.DefaultConfigDir()`,
-  `discovery.DefaultCacheDir()`, versioncheck's config path, and the
-  `tokenstore` default backend all detect `go test` (via `internal/testdirs`)
-  and fall back to a throwaway per-process temp directory when their env
-  override is unset. The fallback is shared across tests in one process — for
-  per-test isolation still set `t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())`
-  and `tokenstore.UseFileBackendForTesting(...)`.
+- **Single resolver**: `internal/entireclient/userdirs` is the only place
+  that resolves the per-user config dir (`userdirs.Config()`:
+  `$ENTIRE_CONFIG_DIR` else `~/.config/entire`) and cache dir
+  (`userdirs.Cache()`: `$XDG_CACHE_HOME/entire` else `~/.cache/entire`).
+  Never derive these paths anywhere else.
+- **In-process safety net**: `userdirs` and the `tokenstore` default backend
+  detect `go test` (via `internal/testdirs`) and fall back to a throwaway
+  per-process temp directory when their env override is unset. The fallback
+  is shared across tests in one process — for per-test isolation still set
+  `t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())` and
+  `tokenstore.UseFileBackendForTesting(...)`.
 - **Spawned binaries are NOT covered**: `testing.Testing()` is false in a
   subprocess. The integration and e2e TestMains set `ENTIRE_CONFIG_DIR`,
   `XDG_CACHE_HOME`, `ENTIRE_TOKEN_STORE=file`, `ENTIRE_TOKEN_STORE_PATH`, and

--- a/cmd/entire/cli/auth/context_store.go
+++ b/cmd/entire/cli/auth/context_store.go
@@ -6,6 +6,7 @@ import (
 	"github.com/entireio/auth-go/tokens"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
 // CurrentContextToken returns the login JWT for the active context in
@@ -14,7 +15,7 @@ import (
 // credential resolution; callers fall back to the legacy keyring entry so
 // pre-contexts logins keep working until migrated.
 func CurrentContextToken() (string, bool) {
-	f, err := contexts.Load(contexts.DefaultConfigDir())
+	f, err := contexts.Load(userdirs.Config())
 	if err != nil {
 		return "", false
 	}
@@ -37,7 +38,7 @@ func RemoveCurrentContext() error {
 	// is exactly the one we capture the keychain slot from (separate Load +
 	// Modify would race a concurrent `auth use`).
 	var svc, handle string
-	if err := contexts.Modify(contexts.DefaultConfigDir(), func(f *contexts.File) (bool, error) {
+	if err := contexts.Modify(userdirs.Config(), func(f *contexts.File) (bool, error) {
 		current := f.Find(f.CurrentContext)
 		if current == nil {
 			return false, nil
@@ -60,7 +61,7 @@ func RemoveCurrentContext() error {
 // the active one, so removing the current context this way also logs it out.
 func RemoveContext(name string) error {
 	var svc, handle string
-	if err := contexts.Modify(contexts.DefaultConfigDir(), func(f *contexts.File) (bool, error) {
+	if err := contexts.Modify(userdirs.Config(), func(f *contexts.File) (bool, error) {
 		c := f.Find(name)
 		if c == nil {
 			return false, nil
@@ -92,7 +93,7 @@ func deleteContextKeychain(svc, handle string) {
 // SetCurrentContext makes name the active context. Returns an error when
 // no context with that name exists (a stale current pointer is a foot-gun).
 func SetCurrentContext(name string) error {
-	if err := contexts.Modify(contexts.DefaultConfigDir(), func(f *contexts.File) (bool, error) {
+	if err := contexts.Modify(userdirs.Config(), func(f *contexts.File) (bool, error) {
 		if f.Find(name) == nil {
 			return false, fmt.Errorf("no login context named %q (run `entire auth contexts` to list)", name)
 		}
@@ -110,7 +111,7 @@ func SetCurrentContext(name string) error {
 // Contexts returns all stored login contexts and the current context name,
 // for listing/switching. Order matches on-disk order.
 func Contexts() ([]*contexts.Context, string, error) {
-	f, err := contexts.Load(contexts.DefaultConfigDir())
+	f, err := contexts.Load(userdirs.Config())
 	if err != nil {
 		return nil, "", fmt.Errorf("load contexts: %w", err)
 	}

--- a/cmd/entire/cli/auth/contexts.go
+++ b/cmd/entire/cli/auth/contexts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
 // defaultContextTokenTTL is the encoded keychain expiry used when a login
@@ -96,7 +97,7 @@ func RecordLoginContext(rawToken, refreshToken string, activate bool) (string, e
 	}
 
 	var name string
-	cfgDir := contexts.DefaultConfigDir()
+	cfgDir := userdirs.Config()
 	if modErr := contexts.Modify(cfgDir, func(f *contexts.File) (bool, error) {
 		name = pickContextName(f, coreURL, handle)
 		f.Upsert(&contexts.Context{
@@ -177,7 +178,7 @@ func MigrateLegacyLoginContext() (migrated bool, err error) {
 	if handle == "" {
 		handle = claims.Subject
 	}
-	f, err := contexts.Load(contexts.DefaultConfigDir())
+	f, err := contexts.Load(userdirs.Config())
 	if err != nil {
 		return false, fmt.Errorf("load contexts: %w", err)
 	}

--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
 // ControlPlaneTarget is the resolved login server a control-plane request
@@ -77,7 +78,7 @@ func staticControlPlaneTarget() ControlPlaneTarget {
 // unusable pointer we treat as "no active context" rather than dialing an
 // empty host).
 func activeContext() (c *contexts.Context, ok bool, err error) {
-	f, err := contexts.Load(contexts.DefaultConfigDir())
+	f, err := contexts.Load(userdirs.Config())
 	if err != nil {
 		return nil, false, fmt.Errorf("load contexts: %w", err)
 	}

--- a/cmd/entire/cli/auth/data_api.go
+++ b/cmd/entire/cli/auth/data_api.go
@@ -10,7 +10,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/contexts"
-	"github.com/entireio/cli/internal/entireclient/discovery"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
 // dataAPIDiscoveryTimeout bounds the one /.well-known/entire-api.json GET we
@@ -88,7 +88,7 @@ func ResolveDataAPIToken(ctx context.Context, dataBaseURL string) (string, error
 	defer cancel()
 	httpClient := &http.Client{Timeout: dataAPIDiscoveryTimeout}
 
-	selected, err := resolveContextForAPI(dctx, contexts.DefaultConfigDir(), discovery.DefaultCacheDir(), host, httpClient, nil)
+	selected, err := resolveContextForAPI(dctx, userdirs.Config(), userdirs.Cache(), host, httpClient, nil)
 	if errors.Is(err, clusterdiscovery.ErrDiscoveryUnavailable) {
 		// Old deployment / not rolled out / transient — preserve today's behaviour.
 		return TokenForResource(ctx, dataOrigin)

--- a/cmd/entire/cli/integration_test/setup_test.go
+++ b/cmd/entire/cli/integration_test/setup_test.go
@@ -21,6 +21,27 @@ func TestMain(m *testing.M) {
 
 	testBinaryPath = filepath.Join(tmpDir, "entire")
 
+	// Route every spawned CLI away from the developer's real ~/.config/entire
+	// (contexts.json, version_check.json), ~/.cache/entire (discovery caches),
+	// and OS keychain. testing.Testing() is false in the subprocess, so the
+	// internal/testdirs fallback cannot protect it — isolation must come from
+	// the environment, which children inherit because all integration env
+	// building starts from os.Environ() (testutil.GitIsolatedEnv).
+	isolation := map[string]string{
+		"ENTIRE_CONFIG_DIR":           filepath.Join(tmpDir, "entire-config"),
+		"XDG_CACHE_HOME":              filepath.Join(tmpDir, "entire-cache"),
+		"ENTIRE_TOKEN_STORE":          "file",
+		"ENTIRE_TOKEN_STORE_PATH":     filepath.Join(tmpDir, "entire-tokens.json"),
+		"ENTIRE_TEST_AUTH_STORE_FILE": filepath.Join(tmpDir, "entire-auth-tokens.json"),
+	}
+	for k, v := range isolation {
+		if err := os.Setenv(k, v); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to set %s: %v\n", k, err)
+			os.RemoveAll(tmpDir)
+			os.Exit(1)
+		}
+	}
+
 	moduleRoot := findModuleRoot()
 	// -tags=authfilestore enables the file-backed auth store backend so the
 	// subprocess can opt into ENTIRE_TEST_AUTH_STORE_FILE instead of touching

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -102,7 +102,7 @@ func CheckAndNotify(ctx context.Context, w io.Writer, currentVersion string) {
 // globalConfigDirPath returns the CLI's global config directory:
 // $ENTIRE_CONFIG_DIR if set, else ~/.config/entire. Under `go test` an
 // unset ENTIRE_CONFIG_DIR resolves to a throwaway per-process directory
-// instead of the real home (see internal/testdirs).
+// instead of the real ~/.config/entire (see internal/testdirs).
 func globalConfigDirPath() (string, error) {
 	if dir := os.Getenv("ENTIRE_CONFIG_DIR"); dir != "" {
 		return dir, nil

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+	"github.com/entireio/cli/internal/testdirs"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 )
@@ -98,8 +99,17 @@ func CheckAndNotify(ctx context.Context, w io.Writer, currentVersion string) {
 	}
 }
 
-// globalConfigDirPath returns the expanded path to the global config directory (~/.config/entire).
+// globalConfigDirPath returns the CLI's global config directory:
+// $ENTIRE_CONFIG_DIR if set, else ~/.config/entire. Under `go test` an
+// unset ENTIRE_CONFIG_DIR resolves to a throwaway per-process directory
+// instead of the real home (see internal/testdirs).
 func globalConfigDirPath() (string, error) {
+	if dir := os.Getenv("ENTIRE_CONFIG_DIR"); dir != "" {
+		return dir, nil
+	}
+	if dir, ok := testdirs.Dir("config"); ok {
+		return dir, nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("getting home directory: %w", err)

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
-	"github.com/entireio/cli/internal/testdirs"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 )
@@ -99,33 +99,17 @@ func CheckAndNotify(ctx context.Context, w io.Writer, currentVersion string) {
 	}
 }
 
-// globalConfigDirPath returns the CLI's global config directory:
-// $ENTIRE_CONFIG_DIR if set, else ~/.config/entire. Under `go test` an
-// unset ENTIRE_CONFIG_DIR resolves to a throwaway per-process directory
-// instead of the real ~/.config/entire (see internal/testdirs).
-func globalConfigDirPath() (string, error) {
-	if dir := os.Getenv("ENTIRE_CONFIG_DIR"); dir != "" {
-		return dir, nil
-	}
-	if dir, ok := testdirs.Dir("config"); ok {
-		return dir, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("getting home directory: %w", err)
-	}
-	return filepath.Join(home, globalConfigDirName), nil
+// globalConfigDirPath returns the CLI's global config directory. Resolution
+// lives in userdirs.Config — the single implementation shared by all
+// config-dir consumers (contexts.json, the file token store, this cache).
+func globalConfigDirPath() string {
+	return userdirs.Config()
 }
 
 // ensureGlobalConfigDir creates the global config directory if it doesn't exist.
 func ensureGlobalConfigDir() error {
-	configDir, err := globalConfigDirPath()
-	if err != nil {
-		return err
-	}
-
 	//nolint:gosec // ~/.config/entire is user home directory, 0o755 is appropriate
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
+	if err := os.MkdirAll(globalConfigDirPath(), 0o755); err != nil {
 		return fmt.Errorf("creating config directory: %w", err)
 	}
 
@@ -133,23 +117,14 @@ func ensureGlobalConfigDir() error {
 }
 
 // cacheFilePath returns the full path to the version check cache file.
-func cacheFilePath() (string, error) {
-	configDir, err := globalConfigDirPath()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(configDir, cacheFileName), nil
+func cacheFilePath() string {
+	return filepath.Join(globalConfigDirPath(), cacheFileName)
 }
 
 // loadCache loads the version check cache from disk.
 // Returns an error if the file doesn't exist or is corrupted.
 func loadCache() (*VersionCache, error) {
-	filePath, err := cacheFilePath()
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := os.ReadFile(filePath) //nolint:gosec // cacheFilePath is safe
+	data, err := os.ReadFile(cacheFilePath())
 	if err != nil {
 		return nil, fmt.Errorf("reading cache file: %w", err)
 	}
@@ -165,10 +140,7 @@ func loadCache() (*VersionCache, error) {
 // saveCache saves the version check cache to disk.
 // Uses atomic write semantics (write to temp file, then rename).
 func saveCache(cache *VersionCache) error {
-	filePath, err := cacheFilePath()
-	if err != nil {
-		return err
-	}
+	filePath := cacheFilePath()
 
 	// Marshal to JSON
 	data, err := json.MarshalIndent(cache, "", "  ")

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -422,13 +422,13 @@ func TestUpdateCommand(t *testing.T) {
 	}
 }
 
-// setupCheckAndNotifyTest sets HOME to a temp dir and overrides githubAPIURL.
-// Returns a cobra.Command with captured stdout and a cleanup function.
+// setupCheckAndNotifyTest points the global config dir at a per-test temp
+// dir and overrides githubAPIURL. Returns a cobra.Command with captured
+// stdout and a cleanup function.
 func setupCheckAndNotifyTest(t *testing.T, serverURL string) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
 
 	origURL := githubAPIURL
 	githubAPIURL = serverURL

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -505,10 +505,7 @@ func TestCheckAndNotify_SkipsWhenCacheIsFresh(t *testing.T) {
 	cmd, buf := setupCheckAndNotifyTest(t, server.URL)
 
 	// Pre-seed the cache with a recent check time
-	configDir, err := globalConfigDirPath()
-	if err != nil {
-		t.Fatalf("globalConfigDirPath() error = %v", err)
-	}
+	configDir := globalConfigDirPath()
 	if err := os.MkdirAll(configDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -35,10 +35,9 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
-	"github.com/entireio/cli/internal/entireclient/contexts"
-	"github.com/entireio/cli/internal/entireclient/discovery"
 	"github.com/entireio/cli/internal/entireclient/httpclient"
 	"github.com/entireio/cli/internal/entireclient/repocreds"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 	"github.com/entireio/cli/internal/remotehelper"
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 	"github.com/entireio/cli/internal/remotehelper/githelper"
@@ -232,7 +231,7 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 		if envToken == "" {
 			return nil, fmt.Errorf("%s is set but blank", auth.EnvTokenVar)
 		}
-		return resolveEnvTokenCreds(ctx, envToken, parsedURL.Host, clusterBaseURL, discovery.DefaultCacheDir(), httpClient)
+		return resolveEnvTokenCreds(ctx, envToken, parsedURL.Host, clusterBaseURL, userdirs.Cache(), httpClient)
 	}
 
 	// Bridge any pre-contexts.json login so the resolver can find it.
@@ -245,8 +244,8 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 	// /.well-known fetch on miss/expiry), then the account is selected from
 	// local contexts — active context if eligible, else the sole eligible
 	// one, else an explicit-choice error.
-	cfgDir := contexts.DefaultConfigDir()
-	clusterCtx, err := clusterdiscovery.ResolveContextForCluster(ctx, cfgDir, discovery.DefaultCacheDir(), parsedURL.Host, httpClient, debuglog.Printf)
+	cfgDir := userdirs.Config()
+	clusterCtx, err := clusterdiscovery.ResolveContextForCluster(ctx, cfgDir, userdirs.Cache(), parsedURL.Host, httpClient, debuglog.Printf)
 	if err != nil {
 		return nil, err //nolint:wrapcheck // ResolveContextForCluster already returns a user-facing error; preserved verbatim for the "fatal: <msg>" surface
 	}
@@ -266,7 +265,7 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 
 // resolveEnvTokenCreds builds the repo-cred cache for the ENTIRE_TOKEN path.
 // Split out of resolveCreds with explicit clusterHost/cacheDir params (no
-// os.Getenv / DefaultCacheDir globals) so the trust gate below is unit-testable
+// os.Getenv / userdirs.Cache globals) so the trust gate below is unit-testable
 // against a fake well-known server.
 //
 // SECURITY: coreURL is derived from the env token's *unverified* aud claim, and

--- a/e2e/tests/main_test.go
+++ b/e2e/tests/main_test.go
@@ -38,6 +38,14 @@ func TestMain(m *testing.M) {
 	os.Setenv("ENTIRE_TOKEN_STORE_PATH", filepath.Join(runDir, "e2e-tokenstore.json"))
 	os.Setenv("ENTIRE_TEST_AUTH_STORE_FILE", filepath.Join(runDir, "e2e-auth-tokens.json"))
 
+	// Same for the CLI's config and cache directories: contexts.json,
+	// version_check.json, and the discovery caches must never resolve to the
+	// developer's real ~/.config/entire or ~/.cache/entire from a spawned
+	// binary (testing.Testing() is false there, so the internal/testdirs
+	// fallback cannot protect it).
+	os.Setenv("ENTIRE_CONFIG_DIR", filepath.Join(runDir, "entire-config"))
+	os.Setenv("XDG_CACHE_HOME", filepath.Join(runDir, "entire-cache"))
+
 	// Resolve the entire binary (set by mise run build via E2E_ENTIRE_BIN).
 	entireBin := entire.BinPath()
 	if err := ensureHookEntireBinary(entireBin); err != nil {

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+
+	"github.com/entireio/cli/internal/testdirs"
 )
 
 // Context is a single kubectl-style entry: which core to talk to, as
@@ -64,8 +66,15 @@ func FilePath(configDir string) (string, error) {
 }
 
 // DefaultConfigDir is $ENTIRE_CONFIG_DIR if set, else ~/.config/entire.
+// Under `go test` an unset ENTIRE_CONFIG_DIR resolves to a throwaway
+// per-process directory instead of the real home, so a test that forgets to
+// isolate can never read or pollute the developer's real config (see
+// internal/testdirs).
 func DefaultConfigDir() string {
 	if dir := os.Getenv("ENTIRE_CONFIG_DIR"); dir != "" {
+		return dir
+	}
+	if dir, ok := testdirs.Dir("config"); ok {
 		return dir
 	}
 	home, err := os.UserHomeDir()

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -67,9 +67,9 @@ func FilePath(configDir string) (string, error) {
 
 // DefaultConfigDir is $ENTIRE_CONFIG_DIR if set, else ~/.config/entire.
 // Under `go test` an unset ENTIRE_CONFIG_DIR resolves to a throwaway
-// per-process directory instead of the real home, so a test that forgets to
-// isolate can never read or pollute the developer's real config (see
-// internal/testdirs).
+// per-process directory instead of the real ~/.config/entire, so a test that
+// forgets to isolate can never read or pollute the developer's real config
+// (see internal/testdirs).
 func DefaultConfigDir() string {
 	if dir := os.Getenv("ENTIRE_CONFIG_DIR"); dir != "" {
 		return dir

--- a/internal/entireclient/contexts/contexts.go
+++ b/internal/entireclient/contexts/contexts.go
@@ -25,8 +25,6 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
-
-	"github.com/entireio/cli/internal/testdirs"
 )
 
 // Context is a single kubectl-style entry: which core to talk to, as
@@ -63,25 +61,6 @@ func FilePath(configDir string) (string, error) {
 		return "", fmt.Errorf("create config dir: %w", err)
 	}
 	return filepath.Join(configDir, "contexts.json"), nil
-}
-
-// DefaultConfigDir is $ENTIRE_CONFIG_DIR if set, else ~/.config/entire.
-// Under `go test` an unset ENTIRE_CONFIG_DIR resolves to a throwaway
-// per-process directory instead of the real ~/.config/entire, so a test that
-// forgets to isolate can never read or pollute the developer's real config
-// (see internal/testdirs).
-func DefaultConfigDir() string {
-	if dir := os.Getenv("ENTIRE_CONFIG_DIR"); dir != "" {
-		return dir
-	}
-	if dir, ok := testdirs.Dir("config"); ok {
-		return dir
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		home = "."
-	}
-	return filepath.Join(home, ".config", "entire")
 }
 
 // Load reads contexts.json under configDir, returning an empty *File

--- a/internal/entireclient/contexts/contexts_test.go
+++ b/internal/entireclient/contexts/contexts_test.go
@@ -293,17 +293,23 @@ func TestDefaultConfigDir_HonorsEnv(t *testing.T) {
 	}
 }
 
-func TestDefaultConfigDir_TestRunsNeverResolveRealHome(t *testing.T) {
+func TestDefaultConfigDir_TestRunsNeverResolveRealConfigDir(t *testing.T) {
 	// With no explicit override, a `go test` process must fall back to a
 	// throwaway directory — never ~/.config/entire, where it could read or
-	// pollute the developer's real contexts.json.
+	// pollute the developer's real contexts.json. (The fallback lives under
+	// os.TempDir, which may itself be under $HOME via TMPDIR — that's fine;
+	// only the real config location is off-limits.)
 	t.Setenv("ENTIRE_CONFIG_DIR", "")
 	got := contexts.DefaultConfigDir()
 	if got == "" {
 		t.Fatal("DefaultConfigDir returned empty string")
 	}
 	home, err := os.UserHomeDir()
-	if err == nil && (got == home || strings.HasPrefix(got, home+string(os.PathSeparator))) {
-		t.Fatalf("DefaultConfigDir = %q resolves under the real home %q during tests", got, home)
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	realDir := filepath.Join(home, ".config", "entire")
+	if got == realDir || strings.HasPrefix(got, realDir+string(os.PathSeparator)) {
+		t.Fatalf("DefaultConfigDir = %q resolves to the real config dir %q during tests", got, realDir)
 	}
 }

--- a/internal/entireclient/contexts/contexts_test.go
+++ b/internal/entireclient/contexts/contexts_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -289,5 +290,20 @@ func TestDefaultConfigDir_HonorsEnv(t *testing.T) {
 	t.Setenv("ENTIRE_CONFIG_DIR", "/tmp/explicit/path")
 	if got := contexts.DefaultConfigDir(); got != "/tmp/explicit/path" {
 		t.Errorf("DefaultConfigDir = %q, want /tmp/explicit/path", got)
+	}
+}
+
+func TestDefaultConfigDir_TestRunsNeverResolveRealHome(t *testing.T) {
+	// With no explicit override, a `go test` process must fall back to a
+	// throwaway directory — never ~/.config/entire, where it could read or
+	// pollute the developer's real contexts.json.
+	t.Setenv("ENTIRE_CONFIG_DIR", "")
+	got := contexts.DefaultConfigDir()
+	if got == "" {
+		t.Fatal("DefaultConfigDir returned empty string")
+	}
+	home, err := os.UserHomeDir()
+	if err == nil && (got == home || strings.HasPrefix(got, home+string(os.PathSeparator))) {
+		t.Fatalf("DefaultConfigDir = %q resolves under the real home %q during tests", got, home)
 	}
 }

--- a/internal/entireclient/contexts/contexts_test.go
+++ b/internal/entireclient/contexts/contexts_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -283,33 +282,5 @@ func TestModify_HoldsLockAcrossLoadAndSave(t *testing.T) {
 	}
 	if got.CurrentContext != strconv.Itoa(n) {
 		t.Errorf("CurrentContext = %q, want %q (lost updates indicate non-atomic RMW)", got.CurrentContext, strconv.Itoa(n))
-	}
-}
-
-func TestDefaultConfigDir_HonorsEnv(t *testing.T) {
-	t.Setenv("ENTIRE_CONFIG_DIR", "/tmp/explicit/path")
-	if got := contexts.DefaultConfigDir(); got != "/tmp/explicit/path" {
-		t.Errorf("DefaultConfigDir = %q, want /tmp/explicit/path", got)
-	}
-}
-
-func TestDefaultConfigDir_TestRunsNeverResolveRealConfigDir(t *testing.T) {
-	// With no explicit override, a `go test` process must fall back to a
-	// throwaway directory — never ~/.config/entire, where it could read or
-	// pollute the developer's real contexts.json. (The fallback lives under
-	// os.TempDir, which may itself be under $HOME via TMPDIR — that's fine;
-	// only the real config location is off-limits.)
-	t.Setenv("ENTIRE_CONFIG_DIR", "")
-	got := contexts.DefaultConfigDir()
-	if got == "" {
-		t.Fatal("DefaultConfigDir returned empty string")
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skipf("no home dir: %v", err)
-	}
-	realDir := filepath.Join(home, ".config", "entire")
-	if got == realDir || strings.HasPrefix(got, realDir+string(os.PathSeparator)) {
-		t.Fatalf("DefaultConfigDir = %q resolves to the real config dir %q during tests", got, realDir)
 	}
 }

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -41,7 +41,8 @@ type RepoEntry struct {
 
 // DefaultCacheDir returns ~/.cache/entire, respecting XDG_CACHE_HOME.
 // Under `go test` an unset XDG_CACHE_HOME resolves to a throwaway
-// per-process directory instead of the real home (see internal/testdirs).
+// per-process directory instead of the real ~/.cache/entire (see
+// internal/testdirs).
 func DefaultCacheDir() string {
 	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
 		return filepath.Join(xdg, "entire")

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+
+	"github.com/entireio/cli/internal/testdirs"
 )
 
 const (
@@ -38,9 +40,14 @@ type RepoEntry struct {
 }
 
 // DefaultCacheDir returns ~/.cache/entire, respecting XDG_CACHE_HOME.
+// Under `go test` an unset XDG_CACHE_HOME resolves to a throwaway
+// per-process directory instead of the real home (see internal/testdirs).
 func DefaultCacheDir() string {
 	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
 		return filepath.Join(xdg, "entire")
+	}
+	if dir, ok := testdirs.Dir("cache"); ok {
+		return filepath.Join(dir, "entire")
 	}
 	home, _ := os.UserHomeDir() //nolint:errcheck // best-effort default
 	return filepath.Join(home, ".cache", "entire")

--- a/internal/entireclient/discovery/cache.go
+++ b/internal/entireclient/discovery/cache.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
-
-	"github.com/entireio/cli/internal/testdirs"
 )
 
 const (
@@ -37,21 +35,6 @@ type ClusterEntry struct {
 type RepoEntry struct {
 	Nodes     []string  `json:"nodes"`
 	ExpiresAt time.Time `json:"expires_at"`
-}
-
-// DefaultCacheDir returns ~/.cache/entire, respecting XDG_CACHE_HOME.
-// Under `go test` an unset XDG_CACHE_HOME resolves to a throwaway
-// per-process directory instead of the real ~/.cache/entire (see
-// internal/testdirs).
-func DefaultCacheDir() string {
-	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
-		return filepath.Join(xdg, "entire")
-	}
-	if dir, ok := testdirs.Dir("cache"); ok {
-		return filepath.Join(dir, "entire")
-	}
-	home, _ := os.UserHomeDir() //nolint:errcheck // best-effort default
-	return filepath.Join(home, ".cache", "entire")
 }
 
 // LoadCache reads the node cache from disk. Returns an empty cache if the file

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -18,10 +18,13 @@ package tokenstore
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
 	"github.com/zalando/go-keyring"
+
+	"github.com/entireio/cli/internal/testdirs"
 )
 
 // ErrNotFound is returned when a credential is not present in the store.
@@ -107,6 +110,14 @@ func resolveBackendLocked() store { //nolint:ireturn // see currentBackend: the 
 			path = home + "/.config/entire/tokens.json"
 		}
 		return &fileStore{path: path}
+	}
+	// Under `go test`, never fall through to the real OS keyring: a test
+	// that forgets tokenstore.UseFileBackendForTesting would otherwise write
+	// real keychain entries. The fallback file is per-process; tests that
+	// need isolation from each other still swap in a per-test file via
+	// UseFileBackendForTesting.
+	if dir, ok := testdirs.Dir("tokenstore"); ok {
+		return &fileStore{path: filepath.Join(dir, "tokens.json")}
 	}
 	return keyringStore{}
 }

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -6,7 +6,8 @@
 // which is useful in CI environments that lack a keyring daemon.
 //
 // When using the file backend the tokens are stored in
-// $ENTIRE_TOKEN_STORE_PATH (default: ~/.config/entire/tokens.json).
+// $ENTIRE_TOKEN_STORE_PATH (default: tokens.json in the per-user config
+// directory — see internal/entireclient/userdirs).
 //
 // Service-name conventions:
 //   - "entire:<cluster-host>"        — entiredb cluster login tokens
@@ -16,7 +17,6 @@
 package tokenstore
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +24,7 @@ import (
 
 	"github.com/zalando/go-keyring"
 
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 	"github.com/entireio/cli/internal/testdirs"
 )
 
@@ -89,7 +90,7 @@ type store interface {
 	Delete(service, user string) error
 }
 
-func currentBackend() store { //nolint:ireturn // pluggable keyring backend; the interface return is the seam for the file-backed test store
+func currentBackend() store {
 	backendMu.Lock()
 	defer backendMu.Unlock()
 	if !resolved {
@@ -99,15 +100,11 @@ func currentBackend() store { //nolint:ireturn // pluggable keyring backend; the
 	return backend
 }
 
-func resolveBackendLocked() store { //nolint:ireturn // see currentBackend: the interface return is the test-store seam
+func resolveBackendLocked() store {
 	if os.Getenv("ENTIRE_TOKEN_STORE") == "file" {
 		path := os.Getenv("ENTIRE_TOKEN_STORE_PATH")
 		if path == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				panic(fmt.Sprintf("tokenstore: cannot determine home directory: %v", err))
-			}
-			path = home + "/.config/entire/tokens.json"
+			path = filepath.Join(userdirs.Config(), "tokens.json")
 		}
 		return &fileStore{path: path}
 	}

--- a/internal/entireclient/userdirs/userdirs.go
+++ b/internal/entireclient/userdirs/userdirs.go
@@ -1,0 +1,48 @@
+// Package userdirs resolves the per-user directories where the Entire CLIs
+// keep global state. It is the single implementation of that resolution —
+// don't derive ~/.config/entire or ~/.cache/entire paths anywhere else.
+//
+//   - Config: contexts.json, version_check.json, the file-backed token
+//     store. $ENTIRE_CONFIG_DIR if set, else ~/.config/entire.
+//   - Cache: discovery caches (nodes.json, cluster_cores.json,
+//     api_discovery.json). $XDG_CACHE_HOME/entire if set, else
+//     ~/.cache/entire.
+//
+// Under `go test`, both fall back to a throwaway per-process directory when
+// their env override is unset (see internal/testdirs), so a test that
+// forgets to isolate can never read or pollute the developer's real state.
+package userdirs
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/entireio/cli/internal/testdirs"
+)
+
+// Config returns the per-user config directory.
+func Config() string {
+	if dir := os.Getenv("ENTIRE_CONFIG_DIR"); dir != "" {
+		return dir
+	}
+	if dir, ok := testdirs.Dir("config"); ok {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	return filepath.Join(home, ".config", "entire")
+}
+
+// Cache returns the per-user cache directory.
+func Cache() string {
+	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "entire")
+	}
+	if dir, ok := testdirs.Dir("cache"); ok {
+		return filepath.Join(dir, "entire")
+	}
+	home, _ := os.UserHomeDir() //nolint:errcheck // best-effort default
+	return filepath.Join(home, ".cache", "entire")
+}

--- a/internal/entireclient/userdirs/userdirs_test.go
+++ b/internal/entireclient/userdirs/userdirs_test.go
@@ -1,0 +1,52 @@
+package userdirs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/internal/entireclient/userdirs"
+)
+
+func TestConfig_HonorsEnv(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", "/tmp/explicit/path")
+	if got := userdirs.Config(); got != "/tmp/explicit/path" {
+		t.Errorf("Config = %q, want /tmp/explicit/path", got)
+	}
+}
+
+func TestCache_HonorsEnv(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", "/tmp/explicit/cache")
+	want := filepath.Join("/tmp/explicit/cache", "entire")
+	if got := userdirs.Cache(); got != want {
+		t.Errorf("Cache = %q, want %q", got, want)
+	}
+}
+
+func TestTestRunsNeverResolveRealDirs(t *testing.T) {
+	// With no explicit override, a `go test` process must fall back to a
+	// throwaway directory — never the real ~/.config/entire or
+	// ~/.cache/entire, where it could read or pollute the developer's real
+	// state. (The fallback lives under os.TempDir, which may itself be under
+	// $HOME via TMPDIR — that's fine; only the real app dirs are
+	// off-limits.)
+	t.Setenv("ENTIRE_CONFIG_DIR", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home dir: %v", err)
+	}
+	for name, tc := range map[string]struct{ got, realDir string }{
+		"config": {userdirs.Config(), filepath.Join(home, ".config", "entire")},
+		"cache":  {userdirs.Cache(), filepath.Join(home, ".cache", "entire")},
+	} {
+		if tc.got == "" {
+			t.Fatalf("%s: resolved to empty string", name)
+		}
+		if tc.got == tc.realDir || strings.HasPrefix(tc.got, tc.realDir+string(os.PathSeparator)) {
+			t.Fatalf("%s: %q resolves to the real dir %q during tests", name, tc.got, tc.realDir)
+		}
+	}
+}

--- a/internal/remotehelper/replicas/replicas.go
+++ b/internal/remotehelper/replicas/replicas.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/entireio/cli/internal/entireclient/discovery"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 )
 
@@ -74,7 +75,7 @@ func ExtractRepoPath(urlPath string) string {
 // LoadFresh returns the cached replica set for (host, repoPath) if one
 // exists and is fresh, otherwise nil.
 func LoadFresh(host, repoPath string) []string {
-	cache, err := discovery.LoadCache(discovery.DefaultCacheDir())
+	cache, err := discovery.LoadCache(userdirs.Cache())
 	if err != nil || cache == nil {
 		return nil
 	}
@@ -93,7 +94,7 @@ func Persist(host, repoPath string, nodes []string) {
 	if host == "" || repoPath == "" || len(nodes) == 0 {
 		return
 	}
-	if err := discovery.ModifyCache(discovery.DefaultCacheDir(), func(cache discovery.ClusterCache) error {
+	if err := discovery.ModifyCache(userdirs.Cache(), func(cache discovery.ClusterCache) error {
 		cache.SetRepoNodes(host, repoPath, nodes, discovery.DefaultTTL)
 		return nil
 	}); err != nil {
@@ -108,7 +109,7 @@ func Invalidate(host, repoPath string) {
 	if host == "" || repoPath == "" {
 		return
 	}
-	if err := discovery.ModifyCache(discovery.DefaultCacheDir(), func(cache discovery.ClusterCache) error {
+	if err := discovery.ModifyCache(userdirs.Cache(), func(cache discovery.ClusterCache) error {
 		cache.InvalidateRepo(host, repoPath)
 		return nil
 	}); err != nil {

--- a/internal/testdirs/testdirs.go
+++ b/internal/testdirs/testdirs.go
@@ -52,7 +52,8 @@ func Dir(surface string) (string, bool) {
 	}
 	d, err := os.MkdirTemp("", "entire-test-"+surface+"-")
 	if err != nil {
-		return "", false
+		// Never fall back to home-relative defaults under `go test`.
+		return os.TempDir(), true
 	}
 	dirs[surface] = d
 	return d, true

--- a/internal/testdirs/testdirs.go
+++ b/internal/testdirs/testdirs.go
@@ -8,7 +8,10 @@
 // ENTIRE_TOKEN_STORE, ...) would silently read and write the developer's
 // real configuration — real auth contexts have been polluted with test
 // fixtures this way. Dir gives the resolution functions a safe default under
-// test: a throwaway directory under os.TempDir instead of the real home.
+// test: a throwaway directory under os.TempDir, never the real config/cache
+// locations. (os.TempDir respects TMPDIR and may itself live under $HOME;
+// the guarantee is "not ~/.config/entire or ~/.cache/entire", not "outside
+// the home directory".)
 //
 // The fallback directory is per-process, not per-test: all tests in one test
 // binary share it. Tests that need isolation from each other must still set

--- a/internal/testdirs/testdirs.go
+++ b/internal/testdirs/testdirs.go
@@ -1,0 +1,56 @@
+// Package testdirs provides per-process fallback directories for the CLI's
+// on-disk config, cache, and credential surfaces when running inside
+// `go test`.
+//
+// Production code resolves these surfaces relative to the user's home
+// directory (~/.config/entire, ~/.cache/entire, the OS keyring). A test that
+// forgets to set the explicit override (ENTIRE_CONFIG_DIR, XDG_CACHE_HOME,
+// ENTIRE_TOKEN_STORE, ...) would silently read and write the developer's
+// real configuration — real auth contexts have been polluted with test
+// fixtures this way. Dir gives the resolution functions a safe default under
+// test: a throwaway directory under os.TempDir instead of the real home.
+//
+// The fallback directory is per-process, not per-test: all tests in one test
+// binary share it. Tests that need isolation from each other must still set
+// the explicit override (e.g. t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())) —
+// this package only guarantees that an unisolated test can never touch real
+// user state.
+//
+// testing.Testing() is false in subprocesses, so spawned `entire` binaries
+// are NOT covered by this fallback. Harnesses that spawn the real binary
+// (integration tests, e2e) must export the override env vars instead — see
+// their TestMain functions.
+package testdirs
+
+import (
+	"os"
+	"sync"
+	"testing"
+)
+
+var (
+	mu   sync.Mutex
+	dirs = map[string]string{}
+)
+
+// Dir returns a stable per-process directory for the named surface (e.g.
+// "config", "cache", "tokenstore") when running under `go test`, creating it
+// on first use. ok is false in production binaries — testing.Testing() is
+// false there — and when the directory cannot be created; callers then fall
+// back to their normal home-relative resolution.
+func Dir(surface string) (string, bool) {
+	if !testing.Testing() {
+		return "", false
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if d, exists := dirs[surface]; exists {
+		return d, true
+	}
+	d, err := os.MkdirTemp("", "entire-test-"+surface+"-")
+	if err != nil {
+		return "", false
+	}
+	dirs[surface] = d
+	return d, true
+}

--- a/internal/testdirs/testdirs_test.go
+++ b/internal/testdirs/testdirs_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestDir_StablePerSurfaceAndNeverUnderHome(t *testing.T) {
+func TestDir_StablePerSurfaceAndNeverRealConfigOrCache(t *testing.T) {
 	t.Parallel()
 
 	cfg1, ok := Dir("config")
@@ -27,13 +27,13 @@ func TestDir_StablePerSurfaceAndNeverUnderHome(t *testing.T) {
 		t.Fatalf("surfaces must not share a directory: %q", cache)
 	}
 
-	// The invariant is "never the real config/cache locations" — not "never
-	// under $HOME": os.MkdirTemp respects TMPDIR, which may itself live under
-	// the home directory on some setups.
+	// The invariant is "never the real app locations" — not "never under
+	// $HOME" or even "never under ~/.cache": os.MkdirTemp respects TMPDIR,
+	// which is commonly set to places like $HOME/.cache/tmp.
 	if home, err := os.UserHomeDir(); err == nil {
 		for _, realDir := range []string{
-			filepath.Join(home, ".config"),
-			filepath.Join(home, ".cache"),
+			filepath.Join(home, ".config", "entire"),
+			filepath.Join(home, ".cache", "entire"),
 		} {
 			for _, d := range []string{cfg1, cache} {
 				if d == realDir || strings.HasPrefix(d, realDir+string(os.PathSeparator)) {

--- a/internal/testdirs/testdirs_test.go
+++ b/internal/testdirs/testdirs_test.go
@@ -2,6 +2,7 @@ package testdirs
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -26,10 +27,18 @@ func TestDir_StablePerSurfaceAndNeverUnderHome(t *testing.T) {
 		t.Fatalf("surfaces must not share a directory: %q", cache)
 	}
 
+	// The invariant is "never the real config/cache locations" — not "never
+	// under $HOME": os.MkdirTemp respects TMPDIR, which may itself live under
+	// the home directory on some setups.
 	if home, err := os.UserHomeDir(); err == nil {
-		for _, d := range []string{cfg1, cache} {
-			if strings.HasPrefix(d, home+string(os.PathSeparator)) || d == home {
-				t.Fatalf("fallback dir %q resolves under the real home %q", d, home)
+		for _, realDir := range []string{
+			filepath.Join(home, ".config"),
+			filepath.Join(home, ".cache"),
+		} {
+			for _, d := range []string{cfg1, cache} {
+				if d == realDir || strings.HasPrefix(d, realDir+string(os.PathSeparator)) {
+					t.Fatalf("fallback dir %q resolves under the real %q", d, realDir)
+				}
 			}
 		}
 	}

--- a/internal/testdirs/testdirs_test.go
+++ b/internal/testdirs/testdirs_test.go
@@ -1,0 +1,40 @@
+package testdirs
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDir_StablePerSurfaceAndNeverUnderHome(t *testing.T) {
+	t.Parallel()
+
+	cfg1, ok := Dir("config")
+	if !ok {
+		t.Fatal("Dir(config) not available under go test")
+	}
+	cfg2, ok := Dir("config")
+	if !ok || cfg2 != cfg1 {
+		t.Fatalf("Dir(config) not stable: first %q, second %q (ok=%v)", cfg1, cfg2, ok)
+	}
+
+	cache, ok := Dir("cache")
+	if !ok {
+		t.Fatal("Dir(cache) not available under go test")
+	}
+	if cache == cfg1 {
+		t.Fatalf("surfaces must not share a directory: %q", cache)
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		for _, d := range []string{cfg1, cache} {
+			if strings.HasPrefix(d, home+string(os.PathSeparator)) || d == home {
+				t.Fatalf("fallback dir %q resolves under the real home %q", d, home)
+			}
+		}
+	}
+
+	if _, err := os.Stat(cfg1); err != nil {
+		t.Fatalf("fallback dir %q was not created: %v", cfg1, err)
+	}
+}


### PR DESCRIPTION
A test fixture (`bob@core.example.com`) showed up in a developer's **real** `~/.config/entire/contexts.json`. Tests could write to the real config dir, cache dir, and OS keychain — while the developer may be using `entire` live.

**Two layers of defense:**

- **`internal/testdirs` (new)**: under `go test`, path resolution falls back to a throwaway per-process temp dir when the env override is unset. An unisolated test now hits a sandbox, never `~/.config/entire`, `~/.cache/entire`, or the real keychain (the tokenstore previously defaulted to the OS keyring even under test). Fails closed: if the temp dir can't be created, it returns `os.TempDir()` rather than anything home-relative.
- **Spawned binaries** (`testing.Testing()` is false there): integration and e2e TestMains export `ENTIRE_CONFIG_DIR`, `XDG_CACHE_HOME`, `ENTIRE_TOKEN_STORE=file` + path, and `ENTIRE_TEST_AUTH_STORE_FILE` process-wide, so every spawned `entire` and agent-invoked hook inherits isolation. Previously both harnesses passed the developer's real environment straight through.

**Unification (`internal/entireclient/userdirs`, new)**: config/cache dir resolution was implemented four times (contexts, discovery, versioncheck, tokenstore). `userdirs.Config()` and `userdirs.Cache()` are now the only implementation; `contexts.DefaultConfigDir` and `discovery.DefaultCacheDir` are gone.

**Behavior changes worth noting:**
- versioncheck now honors `ENTIRE_CONFIG_DIR` (previously `HOME`-only), so one env var isolates every config-dir surface — `version_check.json` follows it too.
- The file token store's default path (`ENTIRE_TOKEN_STORE=file` without `ENTIRE_TOKEN_STORE_PATH`) now honors `ENTIRE_CONFIG_DIR` instead of hard-coding `~/.config/entire/tokens.json`.
- `tokenstore`'s unexported `store` interface joins the ireturn allow list: the local lint `--fix` pass strips the inline nolint directives that CI's non-fix run requires, so the inline form flaps.

Rules documented in CLAUDE.md; regression tests assert test runs never resolve the real app dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)