### PR TITLE
[bug]Use user-scoped auth for Copilot E2E

### DIFF
--- a/.github/workflows/e2e-checkpoints-v2.yml
+++ b/.github/workflows/e2e-checkpoints-v2.yml
@@ -148,12 +148,17 @@ jobs:
 
       - name: Bootstrap agent
         env:
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
-        run: go run ./e2e/bootstrap ${{ inputs.agent }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+        run: |
+          if [ -z "${COPILOT_GITHUB_TOKEN:-}" ]; then
+            echo "::error::COPILOT_GITHUB_TOKEN repository secret is required for Copilot CLI E2E tests"
+            exit 1
+          fi
+          go run ./e2e/bootstrap ${{ inputs.agent }}
 
       - name: E2E Checkpoints V2
         env:
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts
           E2E_ENTIRE_BIN: /usr/local/bin/entire
           E2E_CHECKPOINTS_MODE: ${{ inputs.checkpoints_mode }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,8 +95,13 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
-        run: go run ./e2e/bootstrap
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+        run: |
+          if [ "${{ matrix.agent }}" = "copilot-cli" ] && [ -z "${COPILOT_GITHUB_TOKEN:-}" ]; then
+            echo "::error::COPILOT_GITHUB_TOKEN repository secret is required for Copilot CLI E2E tests"
+            exit 1
+          fi
+          go run ./e2e/bootstrap
 
       - name: Run E2E Tests
         env:
@@ -107,7 +112,7 @@ jobs:
           E2E_GEMINI_MODEL: ${{ matrix.agent == 'gemini-cli' && 'gemini-3.1-flash-lite' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           E2E_CONCURRENT_TEST_LIMIT: ${{ matrix.agent == 'gemini-cli' && '6' || matrix.agent == 'factoryai-droid' && '1' || '' }}
         run: mise run test:e2e --agent ${{ matrix.agent }} ${{ matrix.agent == 'roger-roger' && 'TestExternalAgent' || '' }}
 


### PR DESCRIPTION
Entire logs: https://entire.io/gh/stale2000/cli/session/019eb4d1-91e3-7633-97e4-689edfb04769

## Summary

Fixes the Copilot CLI E2E jobs by using the repo's Copilot-specific secret for Copilot CLI authentication instead of the GitHub Actions installation token.

The failing E2E run showed Copilot CLI failing while loading models with:

```text
GitHub App Server-To-Server Tokens are not supported for this endpoint
```

That points at the token type passed to Copilot CLI, not git checkout/push auth. The workflow was setting `COPILOT_GITHUB_TOKEN` to `${{ github.token }}`, which is an Actions installation/server-to-server token. Copilot CLI model access needs a supported user-scoped token, matching the existing `E2E Isolated Test` workflow pattern that already passes `secrets.COPILOT_GITHUB_TOKEN`.

## Targeted Fix

- Change Copilot E2E workflow env from `${{ github.token }}` to `${{ secrets.COPILOT_GITHUB_TOKEN }}`.
- Apply the same change to the Copilot-specific checkpoints-v2 workflow.
- Add an early missing-secret guard so CI fails with a clear error if the repo secret is absent, without printing the token value.

This intentionally does not change unrelated `GITHUB_TOKEN`/`GH_TOKEN` usage, git remotes, checkout auth, or non-Copilot agents.

## Verification

- `git diff --check`
- `mise run lint`

Not run: real Copilot E2E tests, because they invoke an external paid agent.
