### PR TITLE
[bug]Prevent checkpoint symlink target disclosure

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint_test.go
+++ b/cmd/entire/cli/checkpoint/checkpoint_test.go
@@ -2067,6 +2067,129 @@ func TestWriteTemporary_FirstCheckpoint_CapturesUntrackedFiles(t *testing.T) {
 	}
 }
 
+// TestWriteTemporary_PreservesSymlinkWithoutReadingTarget verifies that changed
+// worktree symlinks are snapshotted as git symlinks, not as the target contents.
+func TestWriteTemporary_PreservesSymlinkWithoutReadingTarget(t *testing.T) {
+	tests := []struct {
+		name              string
+		isFirstCheckpoint bool
+	}{
+		{
+			name:              "first checkpoint untracked symlink",
+			isFirstCheckpoint: true,
+		},
+		{
+			name:              "subsequent checkpoint new symlink",
+			isFirstCheckpoint: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			externalDir := t.TempDir()
+
+			repo, err := git.PlainInit(tempDir, false)
+			if err != nil {
+				t.Fatalf("failed to init git repo: %v", err)
+			}
+
+			worktree, err := repo.Worktree()
+			if err != nil {
+				t.Fatalf("failed to get worktree: %v", err)
+			}
+
+			readmeFile := filepath.Join(tempDir, "README.md")
+			if err := os.WriteFile(readmeFile, []byte("# Test\n"), 0o644); err != nil {
+				t.Fatalf("failed to write README: %v", err)
+			}
+			if _, err := worktree.Add("README.md"); err != nil {
+				t.Fatalf("failed to add README: %v", err)
+			}
+			initialCommit, err := worktree.Commit("Initial commit", &git.CommitOptions{
+				Author: &object.Signature{Name: "Test", Email: "test@test.com"},
+			})
+			if err != nil {
+				t.Fatalf("failed to commit: %v", err)
+			}
+
+			secretContent := "SECRET DATA THAT MUST NOT ENTER CHECKPOINTS"
+			secretFile := filepath.Join(externalDir, "id_rsa")
+			if err := os.WriteFile(secretFile, []byte(secretContent), 0o600); err != nil {
+				t.Fatalf("failed to write external secret: %v", err)
+			}
+
+			linkPath := filepath.Join(tempDir, "leaked-key")
+			if err := os.Symlink(secretFile, linkPath); err != nil {
+				t.Skipf("cannot create symlink on this platform: %v", err)
+			}
+
+			t.Chdir(tempDir)
+
+			metadataDir := filepath.Join(tempDir, ".entire", "metadata", "test-session")
+			if err := os.MkdirAll(metadataDir, 0o755); err != nil {
+				t.Fatalf("failed to create metadata dir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(metadataDir, "full.jsonl"), []byte(`{"test": true}`), 0o644); err != nil {
+				t.Fatalf("failed to write transcript: %v", err)
+			}
+
+			var newFiles []string
+			if !tt.isFirstCheckpoint {
+				newFiles = []string{"leaked-key"}
+			}
+
+			store := NewGitStore(repo, DefaultV1Refs())
+			result, err := store.WriteTemporary(context.Background(), WriteTemporaryOptions{
+				SessionID:         "test-session",
+				BaseCommit:        initialCommit.String(),
+				NewFiles:          newFiles,
+				MetadataDir:       ".entire/metadata/test-session",
+				MetadataDirAbs:    metadataDir,
+				CommitMessage:     "Checkpoint symlink",
+				AuthorName:        "Test",
+				AuthorEmail:       "test@test.com",
+				IsFirstCheckpoint: tt.isFirstCheckpoint,
+			})
+			if err != nil {
+				t.Fatalf("WriteTemporary() error = %v", err)
+			}
+
+			commit, err := repo.CommitObject(result.CommitHash)
+			if err != nil {
+				t.Fatalf("failed to get commit object: %v", err)
+			}
+			tree, err := commit.Tree()
+			if err != nil {
+				t.Fatalf("failed to get tree: %v", err)
+			}
+
+			entry, err := tree.FindEntry("leaked-key")
+			if err != nil {
+				t.Fatalf("leaked-key not found in checkpoint tree: %v", err)
+			}
+			if entry.Mode != filemode.Symlink {
+				t.Fatalf("leaked-key mode = %v, want %v", entry.Mode, filemode.Symlink)
+			}
+
+			file, err := tree.File("leaked-key")
+			if err != nil {
+				t.Fatalf("failed to get leaked-key file: %v", err)
+			}
+			content, err := file.Contents()
+			if err != nil {
+				t.Fatalf("failed to read leaked-key blob: %v", err)
+			}
+			if content != secretFile {
+				t.Fatalf("symlink blob content = %q, want link target %q", content, secretFile)
+			}
+			if content == secretContent {
+				t.Fatal("checkpoint stored symlink target contents instead of link target")
+			}
+		})
+	}
+}
+
 // TestWriteTemporary_FirstCheckpoint_ExcludesGitIgnoredFiles verifies that
 // the first checkpoint does NOT capture files that are in .gitignore.
 func TestWriteTemporary_FirstCheckpoint_ExcludesGitIgnoredFiles(t *testing.T) {
@@ -4193,6 +4316,97 @@ func TestAddDirectoryToEntries_SkipsSymlinkedDirectories(t *testing.T) {
 
 	if len(entries) != 1 {
 		t.Errorf("expected 1 entry (regular.txt only), got %d: %v", len(entries), entries)
+	}
+}
+
+// TestWriteTemporaryTask_PreservesSymlinkWithoutReadingTarget verifies that task
+// checkpoints use the same symlink-safe blob path as session checkpoints.
+func TestWriteTemporaryTask_PreservesSymlinkWithoutReadingTarget(t *testing.T) {
+	tempDir := t.TempDir()
+	externalDir := t.TempDir()
+
+	repo, err := git.PlainInit(tempDir, false)
+	if err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tempDir, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatalf("failed to write README: %v", err)
+	}
+	if _, err := worktree.Add("README.md"); err != nil {
+		t.Fatalf("failed to add README: %v", err)
+	}
+	initialCommit, err := worktree.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@test.com"},
+	})
+	if err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	secretContent := "SECRET DATA THAT MUST NOT ENTER TASK CHECKPOINTS"
+	secretFile := filepath.Join(externalDir, "token")
+	if err := os.WriteFile(secretFile, []byte(secretContent), 0o600); err != nil {
+		t.Fatalf("failed to write external secret: %v", err)
+	}
+
+	linkPath := filepath.Join(tempDir, "reported-link")
+	if err := os.Symlink(secretFile, linkPath); err != nil {
+		t.Skipf("cannot create symlink on this platform: %v", err)
+	}
+
+	t.Chdir(tempDir)
+
+	store := NewGitStore(repo, DefaultV1Refs())
+	commitHash, err := store.WriteTemporaryTask(context.Background(), WriteTemporaryTaskOptions{
+		SessionID:      "test-session",
+		BaseCommit:     initialCommit.String(),
+		ToolUseID:      "toolu_symlink123",
+		AgentID:        "agent1",
+		ModifiedFiles:  []string{"reported-link"},
+		CheckpointUUID: "test-uuid",
+		CommitMessage:  "Task checkpoint",
+		AuthorName:     "Test",
+		AuthorEmail:    "test@test.com",
+	})
+	if err != nil {
+		t.Fatalf("WriteTemporaryTask() error = %v", err)
+	}
+
+	commit, err := repo.CommitObject(commitHash)
+	if err != nil {
+		t.Fatalf("failed to get commit object: %v", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		t.Fatalf("failed to get tree: %v", err)
+	}
+
+	entry, err := tree.FindEntry("reported-link")
+	if err != nil {
+		t.Fatalf("reported-link not found in task checkpoint tree: %v", err)
+	}
+	if entry.Mode != filemode.Symlink {
+		t.Fatalf("reported-link mode = %v, want %v", entry.Mode, filemode.Symlink)
+	}
+
+	file, err := tree.File("reported-link")
+	if err != nil {
+		t.Fatalf("failed to get reported-link file: %v", err)
+	}
+	content, err := file.Contents()
+	if err != nil {
+		t.Fatalf("failed to read reported-link blob: %v", err)
+	}
+	if content != secretFile {
+		t.Fatalf("symlink blob content = %q, want link target %q", content, secretFile)
+	}
+	if content == secretContent {
+		t.Fatal("task checkpoint stored symlink target contents instead of link target")
 	}
 }
 

--- a/cmd/entire/cli/checkpoint/temporary.go
+++ b/cmd/entire/cli/checkpoint/temporary.go
@@ -883,30 +883,38 @@ func FlattenTree(repo *git.Repository, tree *object.Tree, prefix string, entries
 
 // fileExists checks if a file exists at the given path.
 func fileExists(path string) bool {
-	_, err := os.Stat(path)
+	_, err := os.Lstat(path)
 	return err == nil
 }
 
 // createBlobFromFile creates a blob object from a file in the working directory.
 func createBlobFromFile(repo *git.Repository, filePath string) (plumbing.Hash, filemode.FileMode, error) {
-	info, err := os.Stat(filePath)
+	info, err := os.Lstat(filePath)
 	if err != nil {
 		return plumbing.ZeroHash, 0, fmt.Errorf("failed to stat file: %w", err)
 	}
 
 	// Determine file mode
 	mode := filemode.Regular
-	if info.Mode()&0o111 != 0 {
-		mode = filemode.Executable
-	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		mode = filemode.Symlink
+	} else if info.Mode()&0o111 != 0 {
+		mode = filemode.Executable
 	}
 
 	// Read file contents
-	content, err := os.ReadFile(filePath) //nolint:gosec // filePath comes from walking the repository
-	if err != nil {
-		return plumbing.ZeroHash, 0, fmt.Errorf("failed to read file: %w", err)
+	var content []byte
+	if mode == filemode.Symlink {
+		target, readErr := os.Readlink(filePath)
+		if readErr != nil {
+			return plumbing.ZeroHash, 0, fmt.Errorf("failed to read symlink: %w", readErr)
+		}
+		content = []byte(target)
+	} else {
+		content, err = os.ReadFile(filePath) //nolint:gosec // filePath comes from walking the repository
+		if err != nil {
+			return plumbing.ZeroHash, 0, fmt.Errorf("failed to read file: %w", err)
+		}
 	}
 
 	// Create blob object


### PR DESCRIPTION
Entire logs:  https://entire.io/gh/stale2000/cli/session/019eb504-3cfe-7a92-92ab-e996c653480d

COMMENTARY:  

This one is kinda important.  Its a security bug fix.

## Summary

Checkpoint creation currently materializes changed worktree paths with `os.Stat` followed by `os.ReadFile`. Because both calls follow symlinks, a changed symlink in the repository can be snapshotted as the contents of its target instead of as a Git symlink. For example, an attacker-controlled branch or generated workspace change could introduce `leaked-key -> ~/.ssh/id_rsa`; if Entire checkpoints that changed path, the checkpoint shadow history can persist the victim user's local private key contents.

This is important because checkpoint refs and metadata can later be pushed, bundled, or shared. The attacker does not need arbitrary code execution: they only need to get a symlink into the set of changed/touched files that Entire snapshots during a session or task checkpoint.

## Fix

- Use `os.Lstat` when checking checkpoint file paths so the checkpoint writer inspects the worktree entry itself instead of the symlink target.
- Store symlinks with `filemode.Symlink` and blob content from `os.Readlink`, matching Git's normal symlink representation.
- Keep regular file and executable handling unchanged.
- Use `Lstat` for existence checks so broken symlinks are not silently treated as deleted.

## Tests

- Added regression coverage for first session checkpoints where the symlink is discovered through `git status`.
- Added regression coverage for subsequent session checkpoints where the symlink is supplied through `NewFiles`.
- Added regression coverage for task checkpoints where the symlink is supplied through `ModifiedFiles`.
- Each test verifies the checkpoint tree stores a symlink blob containing the link target, not the external target file contents.

## Verification

- `go test ./cmd/entire/cli/checkpoint`
- `go test ./cmd/entire/cli/strategy`
- `mise run lint`