### PR TITLE
[codex] add token profile history diagnostics

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -114,6 +114,8 @@ linters:
         - empty
         - stdlib
         - charm.land/bubbletea/v2.Model
+        - charm.land/bubbletea/v2.Msg
+        - charm.land/huh/v2.Theme
         - grpc.DialOption
         - github.com/entireio/cli/cmd/entire/cli/summarize.Generator
         - github.com/entireio/cli/cmd/entire/cli/agent\..+
@@ -122,6 +124,8 @@ linters:
         - github.com/entireio/cli/cmd/entire/cli/review/types.AgentReviewer
         - github.com/entireio/cli/cmd/entire/cli/review.SynthesisProvider
         - github.com/entireio/cli/cmd/entire/cli/checkpoint.CommittedReader
+        - github.com/entireio/cli/cmd/entire/cli/checkpoint.CommittedStore
+        - github.com/entireio/cli/cmd/entire/cli/checkpoint.TemporaryStore
         - github.com/entireio/cli/cmd/entire/cli/strategy.Strategy
         - github.com/entireio/cli/internal/entireclient/tokenstore.store
         - github.com/go-git/go-git/v6/x/plugin.Signer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,18 +22,20 @@ This repo contains the CLI for Entire.
 
 ### Command Layout
 
-The CLI is organized around five noun groups plus a small set of top-level
-verbs. The groups are the canonical home for each verb; legacy top-level
-shortcuts remain functional but hidden, and emit a deprecation hint pointing
-at the canonical group form.
+The visible CLI is organized around five noun groups plus a small set of
+top-level verbs. The groups are the canonical home for each verb; legacy
+top-level shortcuts remain functional but hidden, and emit a deprecation hint
+pointing at the canonical group form. Newer experimental command families are
+discoverable through `entire labs` and may remain hidden from root help while
+their canonical paths are still runnable.
 
-- `session` (alias: `sessions`): `list`, `info`, `stop`, `attach`, `resume`, `current`.
+- `session` (alias: `sessions`): `list`, `info`, `tokens`, `stop`, `attach`, `resume`, `current`.
   `resume` with a branch arg switches to it and resumes its session; with no arg
   it opens an interactive picker of stopped sessions (across all worktrees),
   resolving each to its branch and pointing at the owning worktree when the
   branch is checked out elsewhere. Resume keeps an existing local session log
   as-is by default (`--force` overwrites it from the checkpoint).
-- `checkpoint` (aliases: `cp`, `checkpoints`): `list`, `explain`, `search`, plus
+- `checkpoint` (aliases: `cp`, `checkpoints`): `list`, `explain`, `tokens`, `search`, plus
   the deprecated `rewind` (functional, prints a cobra deprecation message, will
   be removed in a future release)
 - `agent`: bare opens the interactive agent selector, plus `list`, `add`, `remove`
@@ -44,6 +46,10 @@ at the canonical group form.
   `--everywhere` (revoke every session on the active core, not just the
   current one) and `--all-contexts` (log out of every saved login)
 - `doctor`: bare runs the scan-and-fix flow, plus `trace`, `logs`, `bundle`
+
+Experimental command families advertised through `entire labs`:
+
+- `tokens`: `profile` (hidden from root help while token diagnostics mature)
 
 Top-level lifecycle and standalone commands: `enable`, `disable`, `status`,
 `login`, `logout`, `clean`, `version`, `dispatch`, `activity`, `help`,

--- a/cmd/entire/cli/activity_tui.go
+++ b/cmd/entire/cli/activity_tui.go
@@ -70,7 +70,7 @@ func runActivityTUI(ctx context.Context, client *api.Client) error {
 	return nil
 }
 
-func (m activityModel) fetchData() tea.Msg { //nolint:ireturn // bubbletea Cmd signature requires tea.Msg return
+func (m activityModel) fetchData() tea.Msg {
 	activity, commits, err := fetchActivityData(m.ctx, m.client)
 	if err != nil {
 		return activityErrMsg{err: err}

--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -21,8 +21,12 @@ type TrailListResponse struct {
 
 // TrailResource represents a single trail from the API.
 type TrailResource struct {
-	ID              string           `json:"id,omitempty"`
-	Number          int              `json:"number,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Number int    `json:"number,omitempty"`
+	// URL is the canonical browser URL for the trail. The server provides it so
+	// clients need not reconstruct the route; it may be empty against older
+	// servers that predate the field.
+	URL             string           `json:"url,omitempty"`
 	Branch          string           `json:"branch"`
 	Base            string           `json:"base"`
 	Title           string           `json:"title"`

--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -59,6 +59,7 @@ func (r *TrailResource) ToMetadata() *trail.Metadata {
 	m := &trail.Metadata{
 		Number:    r.Number,
 		TrailID:   trail.ID(r.ID),
+		URL:       r.URL,
 		Branch:    r.Branch,
 		Base:      r.Base,
 		Title:     r.Title,

--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -21,11 +21,8 @@ type TrailListResponse struct {
 
 // TrailResource represents a single trail from the API.
 type TrailResource struct {
-	ID     string `json:"id,omitempty"`
-	Number int    `json:"number,omitempty"`
-	// URL is the canonical browser URL for the trail. The server provides it so
-	// clients need not reconstruct the route; it may be empty against older
-	// servers that predate the field.
+	ID              string           `json:"id,omitempty"`
+	Number          int              `json:"number,omitempty"`
 	URL             string           `json:"url,omitempty"`
 	Branch          string           `json:"branch"`
 	Base            string           `json:"base"`

--- a/cmd/entire/cli/api/trail_types_test.go
+++ b/cmd/entire/cli/api/trail_types_test.go
@@ -46,11 +46,16 @@ func TestTrailResourceDecodesServerURL(t *testing.T) {
 func TestTrailResourceToMetadataUsesID(t *testing.T) {
 	t.Parallel()
 
-	metadata := (&TrailResource{ID: "trail-db-id", Branch: "feature/x", Phase: "has_code"}).ToMetadata()
+	metadata := (&TrailResource{ID: "trail-db-id", URL: "https://entire.io/gh/o/r/trails/9", Branch: "feature/x", Phase: "has_code"}).ToMetadata()
 	if got := metadata.TrailID.String(); got != "trail-db-id" {
 		t.Fatalf("metadata TrailID = %q, want stable API id", got)
 	}
 	if metadata.Phase != "has_code" {
 		t.Fatalf("metadata Phase = %q, want has_code", metadata.Phase)
+	}
+	// The server-provided URL must propagate so callers relying on ToMetadata()
+	// don't silently drop it.
+	if metadata.URL != "https://entire.io/gh/o/r/trails/9" {
+		t.Fatalf("metadata URL = %q, want propagated server url", metadata.URL)
 	}
 }

--- a/cmd/entire/cli/api/trail_types_test.go
+++ b/cmd/entire/cli/api/trail_types_test.go
@@ -1,6 +1,47 @@
 package api
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestTrailResourceDecodesServerURL covers the wire-compatibility matrix for the
+// `url` field the API added:
+//   - new cli + new api: the field decodes into TrailResource.URL and is used.
+//   - old cli + new api: a client struct predating the field ignores the extra
+//     key without error (Go's json.Unmarshal drops unknown fields), so an older
+//     CLI keeps working against a newer server.
+//
+// (new cli + old api is exercised by trailDisplayURL's fallback in the cli pkg.)
+func TestTrailResourceDecodesServerURL(t *testing.T) {
+	t.Parallel()
+
+	// Shape a newer server would emit: includes `url`.
+	payload := []byte(`{"id":"t1","number":640,"url":"https://entire.io/gh/o/r/trails/640/slug","branch":"feat/x","title":"T"}`)
+
+	// new cli + new api: URL is captured and available to display.
+	var newClient TrailResource
+	if err := json.Unmarshal(payload, &newClient); err != nil {
+		t.Fatalf("new client failed to decode new payload: %v", err)
+	}
+	if newClient.URL != "https://entire.io/gh/o/r/trails/640/slug" {
+		t.Fatalf("URL = %q, want server-provided url", newClient.URL)
+	}
+
+	// old cli + new api: a struct without a URL field must not choke on the
+	// extra key, and still decodes the fields it knows about.
+	var oldClient struct {
+		ID     string `json:"id"`
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+	}
+	if err := json.Unmarshal(payload, &oldClient); err != nil {
+		t.Fatalf("old client rejected new payload with extra url field: %v", err)
+	}
+	if oldClient.Number != 640 || oldClient.Title != "T" {
+		t.Fatalf("old client decoded wrong values: %+v", oldClient)
+	}
+}
 
 func TestTrailResourceToMetadataUsesID(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -62,7 +62,7 @@ func (opts attachOptions) committedRefs(ctx context.Context) cpkg.CommittedRefs 
 
 // openAttachStore opens the committed store for the resolved topology. refs is
 // passed explicitly so attach preserves PrimaryAsRead() pinning.
-func openAttachStore(ctx context.Context, repo *git.Repository, refs cpkg.CommittedRefs) (cpkg.CommittedStore, error) { //nolint:ireturn // committed store capability preserves attach's read-ref override
+func openAttachStore(ctx context.Context, repo *git.Repository, refs cpkg.CommittedRefs) (cpkg.CommittedStore, error) {
 	stores, err := cpkg.Open(ctx, repo, cpkg.OpenOptions{Refs: &refs})
 	if err != nil {
 		return nil, fmt.Errorf("open checkpoint store: %w", err)

--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -55,7 +55,7 @@ func resolveOpenRefs(ctx context.Context, opts OpenOptions) CommittedRefs {
 }
 
 // Temporary returns the git-backed temporary shadow-branch store.
-func (s *Stores) Temporary() TemporaryStore { return s.temporary } //nolint:ireturn // temporary store capability is the abstraction boundary
+func (s *Stores) Temporary() TemporaryStore { return s.temporary }
 
 // Refs returns the resolved committed-ref topology.
 func (s *Stores) Refs() CommittedRefs { return s.refs }

--- a/cmd/entire/cli/checkpoint_tokens.go
+++ b/cmd/entire/cli/checkpoint_tokens.go
@@ -213,10 +213,7 @@ func buildCheckpointTokensReport(cpID id.CheckpointID, summary *checkpoint.Check
 		report.Branch = firstCheckpointBranch(metas)
 	}
 
-	usage := aggregateCheckpointTokenUsage(metas)
-	if summary != nil && summary.TokenUsage != nil && (usage == nil || metadataWarnings > 0) {
-		usage = summary.TokenUsage
-	}
+	usage := checkpointTokenUsage(summary, metas, metadataWarnings > 0)
 	if tokens := buildSessionTokensUsage(usage); tokens != nil {
 		report.Tokens = tokens
 		if tokens.SubagentTotal > 0 {
@@ -347,6 +344,17 @@ func aggregateCheckpointTokenUsage(metas []*checkpoint.CommittedMetadata) *agent
 		total = addCheckpointTokenUsage(total, meta.TokenUsage)
 	}
 	return total
+}
+
+func checkpointTokenUsage(summary *checkpoint.CheckpointSummary, metas []*checkpoint.CommittedMetadata, metadataReadWarning bool) *agent.TokenUsage {
+	sessionUsage := aggregateCheckpointTokenUsage(metas)
+	if !metadataReadWarning && sessionUsage != nil {
+		return sessionUsage
+	}
+	if summary != nil && summary.TokenUsage != nil {
+		return summary.TokenUsage
+	}
+	return sessionUsage
 }
 
 func addCheckpointTokenUsage(a, b *agent.TokenUsage) *agent.TokenUsage {

--- a/cmd/entire/cli/checkpoint_tokens.go
+++ b/cmd/entire/cli/checkpoint_tokens.go
@@ -117,6 +117,10 @@ func runCheckpointTokens(ctx context.Context, cmd *cobra.Command, checkpointIDPr
 		if err != nil {
 			return tokenCommandError(err)
 		}
+		if baselineReport.CheckpointID == report.CheckpointID {
+			cmd.SilenceUsage = true
+			return fmt.Errorf("cannot compare checkpoint %s to itself", report.CheckpointID)
+		}
 		report.Comparison = buildCheckpointTokensComparison(report, baselineReport)
 	}
 

--- a/cmd/entire/cli/checkpoint_tokens.go
+++ b/cmd/entire/cli/checkpoint_tokens.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -37,7 +38,10 @@ type checkpointTokensComparison struct {
 	TargetCheckpointID   string                       `json:"target_checkpoint_id"`
 	Status               string                       `json:"status"`
 	Total                *checkpointTokensMetricDelta `json:"total,omitempty"`
+	Input                *checkpointTokensMetricDelta `json:"input,omitempty"`
 	CacheRead            *checkpointTokensMetricDelta `json:"cache_read,omitempty"`
+	CacheWrite           *checkpointTokensMetricDelta `json:"cache_write,omitempty"`
+	Output               *checkpointTokensMetricDelta `json:"output,omitempty"`
 	APICalls             *checkpointTokensMetricDelta `json:"api_calls,omitempty"`
 	CacheReadCaveat      string                       `json:"cache_read_caveat,omitempty"`
 	Qualification        string                       `json:"qualification"`
@@ -66,6 +70,7 @@ const (
 func newCheckpointTokensCmd() *cobra.Command {
 	var jsonFlag bool
 	var compareFlag string
+	var agentBriefFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "tokens <checkpoint-id>",
@@ -82,16 +87,20 @@ Use --compare <checkpoint-id> to compare this checkpoint against a previous
 checkpoint and qualify observed token reduction or increase.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCheckpointTokens(cmd.Context(), cmd, args[0], jsonFlag, compareFlag)
+			if jsonFlag && agentBriefFlag {
+				return errors.New("--json and --agent-brief are mutually exclusive")
+			}
+			return runCheckpointTokens(cmd.Context(), cmd, args[0], jsonFlag, compareFlag, agentBriefFlag)
 		},
 	}
 
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON")
 	cmd.Flags().StringVar(&compareFlag, "compare", "", "Compare against a baseline checkpoint ID")
+	cmd.Flags().BoolVar(&agentBriefFlag, "agent-brief", false, "Output compact next-step guidance for agents")
 	return cmd
 }
 
-func runCheckpointTokens(ctx context.Context, cmd *cobra.Command, checkpointIDPrefix string, jsonOutput bool, comparePrefix string) error {
+func runCheckpointTokens(ctx context.Context, cmd *cobra.Command, checkpointIDPrefix string, jsonOutput bool, comparePrefix string, agentBrief bool) error {
 	report, lookup, err := loadCheckpointTokensReport(ctx, cmd, checkpointIDPrefix)
 	if lookup != nil {
 		defer lookup.Close()
@@ -113,6 +122,10 @@ func runCheckpointTokens(ctx context.Context, cmd *cobra.Command, checkpointIDPr
 
 	if jsonOutput {
 		return writeCheckpointTokensJSON(cmd.OutOrStdout(), report)
+	}
+	if agentBrief {
+		writeCheckpointTokensAgentBrief(cmd.OutOrStdout(), report)
+		return nil
 	}
 	writeCheckpointTokensText(cmd.OutOrStdout(), report)
 	return nil
@@ -394,12 +407,45 @@ func buildCheckpointTokensComparison(target, baseline checkpointTokensReport) *c
 	}
 
 	comparison.Total = buildCheckpointMetricDelta(baseline.Tokens.Total, target.Tokens.Total)
+	comparison.Input = buildCheckpointMetricDelta(baseline.Tokens.Input, target.Tokens.Input)
 	comparison.CacheRead = buildCheckpointMetricDelta(baseline.Tokens.CacheRead, target.Tokens.CacheRead)
+	comparison.CacheWrite = buildCheckpointMetricDelta(baseline.Tokens.CacheWrite, target.Tokens.CacheWrite)
+	comparison.Output = buildCheckpointMetricDelta(baseline.Tokens.Output, target.Tokens.Output)
 	comparison.APICalls = buildCheckpointMetricDelta(baseline.Tokens.APICalls, target.Tokens.APICalls)
 	comparison.CacheReadCaveat = checkpointComparisonCacheReadCaveat(comparison.CacheRead)
 	comparison.Status = checkpointComparisonStatus(comparison.Total)
 	comparison.Qualification = checkpointComparisonQualification(comparison.Status)
+	if classes := checkpointCostProxyPressureIncreased(comparison); len(classes) > 0 {
+		comparison.Qualification += fmt.Sprintf(" Cost-proxy pressure increased for %s even though total tokens decreased.", formatTokenClassList(classes))
+	}
 	return comparison
+}
+
+func checkpointCostProxyPressureIncreased(comparison *checkpointTokensComparison) []string {
+	if comparison == nil || comparison.Total == nil || comparison.Total.Change >= 0 {
+		return nil
+	}
+	var classes []string
+	if comparison.CacheWrite != nil && comparison.CacheWrite.Change > 0 {
+		classes = append(classes, "cache write")
+	}
+	if comparison.Output != nil && comparison.Output.Change > 0 {
+		classes = append(classes, "output")
+	}
+	return classes
+}
+
+func formatTokenClassList(classes []string) string {
+	switch len(classes) {
+	case 0:
+		return ""
+	case 1:
+		return classes[0]
+	case 2:
+		return classes[0] + " and " + classes[1]
+	default:
+		return strings.Join(classes[:len(classes)-1], ", ") + ", and " + classes[len(classes)-1]
+	}
 }
 
 func buildCheckpointMetricDelta(baseline, current int) *checkpointTokensMetricDelta {
@@ -534,6 +580,45 @@ func writeCheckpointTokensText(w io.Writer, report checkpointTokensReport) {
 	writeTokenLimitations(w, report.Limitations)
 }
 
+func writeCheckpointTokensAgentBrief(w io.Writer, report checkpointTokensReport) {
+	fmt.Fprintln(w, "Checkpoint token brief")
+	fmt.Fprintf(w, "Checkpoint: %s\n", report.CheckpointID)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, agentBriefUsageLine(report.Tokens))
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Next best action:")
+	fmt.Fprintln(w, checkpointAgentBriefNextAction(report))
+
+	signals := agentBriefSignals(checkpointAgentBriefSessionReport(report))
+	if len(signals) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Signals:")
+		for _, signal := range signals {
+			fmt.Fprintf(w, "- %s\n", signal)
+		}
+	}
+}
+
+func checkpointAgentBriefNextAction(report checkpointTokensReport) string {
+	sessionReport := checkpointAgentBriefSessionReport(report)
+	if hasTokenRecommendation(sessionReport, "no-token-data") {
+		return "Do not spend extra commands on token optimization for this checkpoint. Continue with the task and capture a newer checkpoint before rechecking tokens."
+	}
+	if action, ok := agentBriefOptimizationAction(sessionReport); ok {
+		return action
+	}
+	return "Continue normally; no high-signal token optimization is available from this checkpoint."
+}
+
+func checkpointAgentBriefSessionReport(report checkpointTokensReport) sessionTokensReport {
+	return sessionTokensReport{
+		Tokens:          report.Tokens,
+		Context:         report.Context,
+		Recommendations: report.Recommendations,
+		Limitations:     report.Limitations,
+	}
+}
+
 func writeCheckpointTokenComparison(w io.Writer, comparison *checkpointTokensComparison) {
 	if comparison == nil {
 		return
@@ -547,7 +632,10 @@ func writeCheckpointTokenComparison(w io.Writer, comparison *checkpointTokensCom
 	}
 	if comparison.Status != checkpointComparisonStatusUnavailable {
 		fmt.Fprintf(w, "Total tokens: %s\n", formatCheckpointMetricDelta(comparison.Total, formatTokenCount))
+		fmt.Fprintf(w, "Input: %s\n", formatCheckpointMetricDelta(comparison.Input, formatTokenCount))
 		fmt.Fprintf(w, "Cache/context replay: %s\n", formatCheckpointMetricDelta(comparison.CacheRead, formatTokenCount))
+		fmt.Fprintf(w, "Cache write: %s\n", formatCheckpointMetricDelta(comparison.CacheWrite, formatTokenCount))
+		fmt.Fprintf(w, "Output: %s\n", formatCheckpointMetricDelta(comparison.Output, formatTokenCount))
 		fmt.Fprintf(w, "API calls: %s\n", formatCheckpointMetricDelta(comparison.APICalls, formatPlainCount))
 	}
 	fmt.Fprintln(w)

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -120,6 +120,14 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 	}
 	defer repo.Close()
 
+	// Finalize any ACTIVE session whose agent process has exited (no SessionStop
+	// hook fired). A gone process is unambiguous, so these are condensed on the
+	// spot rather than left for the interactive prompt below; the sweep marks
+	// them ended in place so classifySession won't re-flag them.
+	if n := finalizeExitedSessions(ctx, states); n > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "Finalized %d exited session(s) (agent process gone).\n\n", n)
+	}
+
 	// Identify stuck sessions
 	now := time.Now()
 	var stuck []stuckSession
@@ -210,14 +218,22 @@ func classifySession(state *strategy.SessionState, repo *git.Repository, now tim
 
 	switch {
 	case state.Phase.IsActive():
-		if !state.IsStuckActive() {
-			return nil
-		}
-
 		var reason string
-		if state.LastInteractionTime != nil {
+		switch {
+		case state.OwnerExited():
+			// Detected immediately (no timeout wait): the owning agent process
+			// is gone. Normally finalized up front in runSessionsFix; this
+			// branch covers a session that couldn't be finalized there.
+			pid := 0
+			if state.Owner != nil {
+				pid = state.Owner.PID
+			}
+			reason = fmt.Sprintf("agent process %d exited (no longer running)", pid)
+		case !state.IsStuckActive():
+			return nil
+		case state.LastInteractionTime != nil:
 			reason = fmt.Sprintf("active, last interaction %s ago", now.Sub(*state.LastInteractionTime).Truncate(time.Minute))
-		} else {
+		default:
 			reason = fmt.Sprintf("active, started %s ago with no recorded interaction", now.Sub(state.StartedAt).Truncate(time.Minute))
 		}
 

--- a/cmd/entire/cli/labs.go
+++ b/cmd/entire/cli/labs.go
@@ -9,51 +9,61 @@ import (
 )
 
 type experimentalCommandInfo struct {
-	Name       string
-	Invocation string
-	Summary    string
+	CommandPath []string
+	Invocation  string
+	Summary     string
 }
 
 var experimentalCommands = []experimentalCommandInfo{
 	{
-		Name:       "review",
-		Invocation: "entire review",
-		Summary:    "Run configured review skills against the current branch",
+		CommandPath: []string{"review"},
+		Invocation:  "entire review",
+		Summary:     "Run configured review skills against the current branch",
 	},
 	{
-		Name:       "investigate",
-		Invocation: "entire investigate",
-		Summary:    "Run a multi-agent investigation against a topic, issue, or seed doc",
+		CommandPath: []string{"investigate"},
+		Invocation:  "entire investigate",
+		Summary:     "Run a multi-agent investigation against a topic, issue, or seed doc",
 	},
 	{
-		Name:       "org",
-		Invocation: "entire org",
-		Summary:    "Manage Entire organizations (create, list)",
+		CommandPath: []string{"tokens"},
+		Invocation:  "entire tokens",
+		Summary:     "Analyze experimental token usage diagnostics",
 	},
 	{
-		Name:       "project",
-		Invocation: "entire project",
-		Summary:    "Manage Entire projects (create, list)",
+		CommandPath: []string{"tokens", "profile"},
+		Invocation:  "entire tokens profile",
+		Summary:     "Aggregate token usage across committed checkpoints",
 	},
 	{
-		Name:       "repo",
-		Invocation: "entire repo",
-		Summary:    "Manage Entire repositories (create, list, get, delete)",
+		CommandPath: []string{"org"},
+		Invocation:  "entire org",
+		Summary:     "Manage Entire organizations (create, list)",
 	},
 	{
-		Name:       "grant",
-		Invocation: "entire grant",
-		Summary:    "Manage access grants and org membership (org, project, repo)",
+		CommandPath: []string{"project"},
+		Invocation:  "entire project",
+		Summary:     "Manage Entire projects (create, list)",
 	},
 	{
-		Name:       "blame",
-		Invocation: "entire blame",
-		Summary:    "Show which lines came from Entire checkpoints",
+		CommandPath: []string{"repo"},
+		Invocation:  "entire repo",
+		Summary:     "Manage Entire repositories (create, list, get, delete)",
 	},
 	{
-		Name:       "why",
-		Invocation: "entire why",
-		Summary:    "Show why a line exists (commit, checkpoint, prompt, session)",
+		CommandPath: []string{"grant"},
+		Invocation:  "entire grant",
+		Summary:     "Manage access grants and org membership (org, project, repo)",
+	},
+	{
+		CommandPath: []string{"blame"},
+		Invocation:  "entire blame",
+		Summary:     "Show which lines came from Entire checkpoints",
+	},
+	{
+		CommandPath: []string{"why"},
+		Invocation:  "entire why",
+		Summary:     "Show why a line exists (commit, checkpoint, prompt, session)",
 	},
 }
 
@@ -97,6 +107,8 @@ Available experimental commands:
 Try:
   entire review --help
   entire investigate --help
+  entire tokens --help
+  entire tokens profile --help
   entire org --help
   entire project --help
   entire repo --help

--- a/cmd/entire/cli/labs_test.go
+++ b/cmd/entire/cli/labs_test.go
@@ -26,6 +26,9 @@ func TestLabsCmd_PrintsExperimentalCommandList(t *testing.T) {
 		"Available experimental commands",
 		"entire review",
 		"entire review --help",
+		"entire tokens",
+		"entire tokens profile",
+		"entire tokens profile --help",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("entire labs output missing %q:\n%s", want, got)
@@ -93,8 +96,13 @@ func TestRootHelp_ShowsLabsButHidesReview(t *testing.T) {
 	if !strings.Contains(got, "labs") || !strings.Contains(got, "Explore experimental Entire workflows") {
 		t.Fatalf("root help should include labs command, got:\n%s", got)
 	}
-	if strings.Contains(got, "review") {
-		t.Fatalf("root help should not include review while it is listed in labs, got:\n%s", got)
+	for _, hiddenExperimentalCommand := range []string{
+		"review",
+		"tokens                 Analyze token usage across sessions and checkpoints",
+	} {
+		if strings.Contains(got, hiddenExperimentalCommand) {
+			t.Fatalf("root help should not include %q while it is listed in labs, got:\n%s", hiddenExperimentalCommand, got)
+		}
 	}
 }
 
@@ -143,12 +151,12 @@ func TestRenderExperimentalCommands_ColumnWidthAdjustsToLongest(t *testing.T) {
 	t.Parallel()
 
 	short := []experimentalCommandInfo{
-		{Name: "a", Invocation: "entire a", Summary: "first"},
-		{Name: "b", Invocation: "entire b", Summary: "second"},
+		{Invocation: "entire a", Summary: "first"},
+		{Invocation: "entire b", Summary: "second"},
 	}
 	long := []experimentalCommandInfo{
-		{Name: "a", Invocation: "entire a", Summary: "first"},
-		{Name: "verylongcommand", Invocation: "entire verylongcommand", Summary: "second"},
+		{Invocation: "entire a", Summary: "first"},
+		{Invocation: "entire verylongcommand", Summary: "second"},
 	}
 
 	shortCol := summaryColumns(t, short)[0]
@@ -173,8 +181,8 @@ func TestRenderExperimentalCommands_MultiByteInvocationAligns(t *testing.T) {
 	// padding, len("entire ▶▶") == 13 >= 12 would skip padding and misalign the
 	// row; rune-based padding correctly adds 3 spaces.
 	commands := []experimentalCommandInfo{
-		{Name: "long", Invocation: "entire aaaaa", Summary: "first"},
-		{Name: "multibyte", Invocation: "entire ▶▶", Summary: "second"},
+		{Invocation: "entire aaaaa", Summary: "first"},
+		{Invocation: "entire ▶▶", Summary: "second"},
 	}
 
 	if got := len("entire ▶▶"); got < 12 {
@@ -192,12 +200,12 @@ func TestLabsRegistryCommandsExistAtCanonicalPaths(t *testing.T) {
 
 	root := NewRootCmd()
 	for _, info := range experimentalCommands {
-		cmd, _, err := root.Find([]string{info.Name})
+		cmd, _, err := root.Find(info.CommandPath)
 		if err != nil {
-			t.Fatalf("labs command %q should exist at canonical path: %v", info.Name, err)
+			t.Fatalf("labs command %q should exist at canonical path: %v", info.Invocation, err)
 		}
 		if cmd == nil {
-			t.Fatalf("labs command %q resolved to nil command", info.Name)
+			t.Fatalf("labs command %q resolved to nil command", info.Invocation)
 		}
 	}
 }

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -933,26 +933,39 @@ func handleLifecycleSessionEnd(ctx context.Context, ag agent.Agent, event *agent
 	// the transcript to extract file changes. Cleanup is handled by
 	// `entire clean` or when the session state is fully removed.
 
-	if err := markSessionEnded(ctx, event, event.SessionID); err != nil {
+	if _, err := endSessionNow(ctx, event, event.SessionID, nil); err != nil {
 		logging.Warn(logCtx, "failed to mark session ended",
-			slog.String("error", err.Error()))
-		// Don't attempt eager condense if we couldn't even mark the session ended —
-		// the session state may be in an inconsistent state.
-		return nil
-	}
-
-	// Eagerly condense session data so PostCommit doesn't have to process it.
-	// This prevents zombie ENDED sessions from accumulating and causing O(N)
-	// overhead on every future commit (GitHub issue #591).
-	// Fail-open: if this fails, PostCommit will still process it on the next commit.
-	strat := GetStrategy(ctx)
-	if err := strat.CondenseAndMarkFullyCondensed(ctx, event.SessionID); err != nil {
-		logging.Warn(logCtx, "eager condense on session stop failed",
-			slog.String("session_id", event.SessionID),
 			slog.String("error", err.Error()))
 	}
 
 	return nil
+}
+
+// endSessionNow runs the canonical "this session is over" sequence: it marks the
+// session ended (firing the SessionStop transition → PhaseEnded + EndedAt) and
+// eagerly condenses its pending work so PostCommit need not. This prevents
+// zombie ENDED sessions from accumulating and causing O(N) overhead on every
+// future commit (GitHub issue #591). It is shared by the SessionStop hook
+// (handleLifecycleSessionEnd) and the exited-session sweep
+// (finalizeExitedSessions), so the two stay in lockstep.
+//
+// The condense is fail-open (PostCommit retries on the next commit); an error
+// marking the session ended is returned so callers can react, and skips the
+// condense since the state may be inconsistent. event may be nil when no hook
+// event drives the end (the sweep), which skips event-metadata persistence.
+// guard is forwarded to markSessionEnded (see there); when it skips the end,
+// the condense is skipped too and ended is false.
+func endSessionNow(ctx context.Context, event *agent.Event, sessionID string, guard func(*strategy.SessionState) bool) (ended bool, err error) {
+	ended, err = markSessionEnded(ctx, event, sessionID, guard)
+	if err != nil || !ended {
+		return ended, err
+	}
+	if condErr := GetStrategy(ctx).CondenseAndMarkFullyCondensed(ctx, sessionID); condErr != nil {
+		logging.Warn(logging.WithComponent(ctx, "lifecycle"), "eager condense on session end failed",
+			slog.String("session_id", sessionID),
+			slog.String("error", condErr.Error()))
+	}
+	return true, nil
 }
 
 // handleLifecycleSubagentStart handles subagent start: captures pre-task state.
@@ -1170,8 +1183,18 @@ func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agen
 
 // markSessionEnded transitions the session to ENDED phase via the state machine.
 // If event is non-nil, hook-provided metrics are persisted to state before saving.
-func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string) error {
+// markSessionEnded fires the SessionStop transition (PhaseEnded + EndedAt) under
+// the session-state lock. When guard is non-nil and returns false on the
+// freshly-loaded state, the transition is skipped — callers use it to
+// re-validate a precondition that may have changed since their snapshot (the
+// exited-session sweep re-checks OwnerExited under the lock so it never ends a
+// session a concurrent turn just revived). It reports whether the session was
+// actually ended.
+func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string, guard func(*strategy.SessionState) bool) (ended bool, err error) {
 	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+		if guard != nil && !guard(state) {
+			return strategy.ErrMutationSkip
+		}
 		if event != nil {
 			persistEventMetadataToState(event, state)
 		}
@@ -1181,15 +1204,16 @@ func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string)
 		}
 		now := time.Now()
 		state.EndedAt = &now
+		ended = true
 		return nil
 	})
-	if errors.Is(mutErr, strategy.ErrStateNotFound) {
-		return nil
+	if errors.Is(mutErr, strategy.ErrStateNotFound) || errors.Is(mutErr, strategy.ErrMutationSkip) {
+		return false, nil
 	}
 	if mutErr != nil {
-		return fmt.Errorf("failed to save session state: %w", mutErr)
+		return false, fmt.Errorf("failed to save session state: %w", mutErr)
 	}
-	return nil
+	return ended, nil
 }
 
 // logFileChanges logs the files modified, created, and deleted during a session.

--- a/cmd/entire/cli/phase_wiring_test.go
+++ b/cmd/entire/cli/phase_wiring_test.go
@@ -30,7 +30,7 @@ func TestMarkSessionEnded_SetsPhaseEnded(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call markSessionEnded
-	err = markSessionEnded(context.Background(), nil, "test-session-end-1")
+	_, err = markSessionEnded(context.Background(), nil, "test-session-end-1", nil)
 	require.NoError(t, err)
 
 	// Verify phase is ENDED
@@ -60,7 +60,7 @@ func TestMarkSessionEnded_IdleToEnded(t *testing.T) {
 	err := strategy.SaveSessionState(context.Background(), state)
 	require.NoError(t, err)
 
-	err = markSessionEnded(context.Background(), nil, "test-session-end-idle")
+	_, err = markSessionEnded(context.Background(), nil, "test-session-end-idle", nil)
 	require.NoError(t, err)
 
 	loaded, err := strategy.LoadSessionState(context.Background(), "test-session-end-idle")
@@ -85,7 +85,7 @@ func TestMarkSessionEnded_AlreadyEndedIsNoop(t *testing.T) {
 	err := strategy.SaveSessionState(context.Background(), state)
 	require.NoError(t, err)
 
-	err = markSessionEnded(context.Background(), nil, "test-session-end-noop")
+	_, err = markSessionEnded(context.Background(), nil, "test-session-end-noop", nil)
 	require.NoError(t, err)
 
 	loaded, err := strategy.LoadSessionState(context.Background(), "test-session-end-noop")
@@ -110,7 +110,7 @@ func TestMarkSessionEnded_EmptyPhaseBackwardCompat(t *testing.T) {
 	err := strategy.SaveSessionState(context.Background(), state)
 	require.NoError(t, err)
 
-	err = markSessionEnded(context.Background(), nil, "test-session-end-compat")
+	_, err = markSessionEnded(context.Background(), nil, "test-session-end-compat", nil)
 	require.NoError(t, err)
 
 	loaded, err := strategy.LoadSessionState(context.Background(), "test-session-end-compat")
@@ -125,7 +125,7 @@ func TestMarkSessionEnded_NoState(t *testing.T) {
 	dir := setupGitRepoForPhaseTest(t)
 	t.Chdir(dir)
 
-	err := markSessionEnded(context.Background(), nil, "nonexistent-session")
+	_, err := markSessionEnded(context.Background(), nil, "nonexistent-session", nil)
 	assert.NoError(t, err, "should be a no-op when no state exists")
 }
 

--- a/cmd/entire/cli/proclive/proc_darwin.go
+++ b/cmd/entire/cli/proclive/proc_darwin.go
@@ -1,0 +1,42 @@
+//go:build darwin
+
+package proclive
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// procStat looks up a process via sysctl(kern.proc.pid) and returns its parent
+// PID, executable name (comm), and start time as the fingerprint. It uses the
+// typed KinfoProc decoder from golang.org/x/sys/unix rather than hand-decoding
+// raw sysctl bytes. p_starttime is an absolute wall-clock timeval, so it is a
+// stable per-process fingerprint without needing the boot guard.
+func procStat(pid int) (ppid int, name, start string, err error) {
+	k, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		// A missing process surfaces as ESRCH or as EIO (sysctl returns a
+		// zero-length result, which the wrapper rejects). Either way it's gone.
+		if err == unix.ESRCH || err == unix.EIO || err == unix.ENOENT {
+			return 0, "", "", errProcessGone
+		}
+		return 0, "", "", fmt.Errorf("proclive: sysctl kern.proc.pid %d: %w", pid, err)
+	}
+	tv := k.Proc.P_starttime
+	return int(k.Eproc.Ppid),
+		unix.ByteSliceToString(k.Proc.P_comm[:]),
+		fmt.Sprintf("%d.%06d", tv.Sec, tv.Usec),
+		nil
+}
+
+// bootID returns no boot guard on darwin. kern.boottime is NOT stable for a
+// running machine — the kernel recomputes it whenever the wall clock is stepped
+// (e.g. an NTP correction), so using it would let a clock adjustment falsely
+// declare a still-running session dead. It is also unnecessary here: darwin's
+// P_starttime fingerprint is an absolute wall-clock timestamp fixed at process
+// creation, so it already distinguishes a reused PID across reboots without a
+// boot guard. (Linux uses ticks-since-boot, which does need the guard.)
+func bootID() (string, error) {
+	return "", nil
+}

--- a/cmd/entire/cli/proclive/proc_linux.go
+++ b/cmd/entire/cli/proclive/proc_linux.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package proclive
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// procStat reads /proc/<pid>/stat and returns the parent PID, executable name
+// (comm), and the process start time (field 22, in clock ticks since boot) used
+// as the start fingerprint. The fingerprint only needs to be stable for the
+// process lifetime and distinct across PID reuse within a boot; the boot guard
+// in Check invalidates it across reboots, so raw ticks suffice and we avoid
+// needing _SC_CLK_TCK.
+func procStat(pid int) (ppid int, name, start string, err error) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, "", "", errProcessGone
+		}
+		return 0, "", "", fmt.Errorf("proclive: read /proc/%d/stat: %w", pid, err)
+	}
+	return parseProcStat(string(data))
+}
+
+// parseProcStat parses the contents of /proc/<pid>/stat. It is separated from
+// the file read so it can be unit-tested with adversarial comm values.
+//
+// The comm (field 2) is wrapped in parentheses and may itself contain spaces
+// and ')'. Everything before the first '(' is the PID; the comm runs to the
+// LAST ')'; the remaining space-separated fields begin at 'state' (field 3).
+func parseProcStat(content string) (ppid int, name, start string, err error) {
+	openIdx := strings.IndexByte(content, '(')
+	closeIdx := strings.LastIndexByte(content, ')')
+	if openIdx < 0 || closeIdx < 0 || closeIdx < openIdx {
+		return 0, "", "", errors.New("proclive: malformed /proc stat: no comm parens")
+	}
+	name = content[openIdx+1 : closeIdx]
+
+	// Fields after the comm, 0-indexed: 0=state (field 3), 1=ppid (field 4),
+	// ... 19=starttime (field 22).
+	const ppidIdx, starttimeIdx = 1, 19
+	rest := strings.Fields(content[closeIdx+1:])
+	if len(rest) <= starttimeIdx {
+		return 0, "", "", errors.New("proclive: truncated /proc stat")
+	}
+	ppid, err = strconv.Atoi(rest[ppidIdx])
+	if err != nil {
+		return 0, "", "", fmt.Errorf("proclive: parse ppid: %w", err)
+	}
+	return ppid, name, rest[starttimeIdx], nil
+}
+
+// bootID returns the kernel boot id, which changes on every reboot. It falls
+// back to /proc/stat's btime line if boot_id is unavailable.
+func bootID() (string, error) {
+	if data, err := os.ReadFile("/proc/sys/kernel/random/boot_id"); err == nil {
+		return strings.TrimSpace(string(data)), nil
+	}
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return "", fmt.Errorf("proclive: read /proc/stat: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if rest, ok := strings.CutPrefix(line, "btime "); ok {
+			return strings.TrimSpace(rest), nil
+		}
+	}
+	return "", nil
+}

--- a/cmd/entire/cli/proclive/proc_linux_test.go
+++ b/cmd/entire/cli/proclive/proc_linux_test.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package proclive
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestParseProcStat_CommWithSpacesAndParens(t *testing.T) {
+	t.Parallel()
+
+	// comm contains both spaces and ')', which must NOT confuse field parsing.
+	const comm = "weird) proc name"
+	const wantPPID = 1000
+	const wantStart = "987654"
+
+	// Build the post-comm fields: index 0=state, 1=ppid, ..., 19=starttime.
+	rest := make([]string, 20)
+	for i := range rest {
+		rest[i] = strconv.Itoa(i) // distinct filler so a wrong index is obvious
+	}
+	rest[0] = "R"
+	rest[1] = strconv.Itoa(wantPPID)
+	rest[19] = wantStart
+
+	content := "4242 (" + comm + ") " + strings.Join(rest, " ") + "\n"
+
+	ppid, name, start, err := parseProcStat(content)
+	if err != nil {
+		t.Fatalf("parseProcStat: %v", err)
+	}
+	if name != comm {
+		t.Errorf("name = %q, want %q", name, comm)
+	}
+	if ppid != wantPPID {
+		t.Errorf("ppid = %d, want %d", ppid, wantPPID)
+	}
+	if start != wantStart {
+		t.Errorf("start = %q, want %q", start, wantStart)
+	}
+}
+
+func TestParseProcStat_Malformed(t *testing.T) {
+	t.Parallel()
+	for _, content := range []string{
+		"no parens here",
+		"123 (proc) R 1", // truncated: too few post-comm fields
+		"",
+	} {
+		if _, _, _, err := parseProcStat(content); err == nil {
+			t.Errorf("parseProcStat(%q) = nil error, want error", content)
+		}
+	}
+}

--- a/cmd/entire/cli/proclive/proc_other.go
+++ b/cmd/entire/cli/proclive/proc_other.go
@@ -1,0 +1,16 @@
+//go:build !linux && !darwin
+
+package proclive
+
+// On platforms without process introspection (e.g. Windows), the seam reports
+// "unsupported". Check then yields LivenessUnknown and ResolveOwner yields no
+// owner, so session liveness degrades cleanly to the inactivity-timeout
+// fallback instead of producing wrong answers.
+
+func procStat(pid int) (ppid int, name, start string, err error) {
+	return 0, "", "", errUnsupported
+}
+
+func bootID() (string, error) {
+	return "", errUnsupported
+}

--- a/cmd/entire/cli/proclive/proc_other_test.go
+++ b/cmd/entire/cli/proclive/proc_other_test.go
@@ -1,0 +1,21 @@
+//go:build !linux && !darwin
+
+package proclive
+
+import (
+	"os"
+	"testing"
+)
+
+// On unsupported platforms liveness must degrade to Unknown (never a wrong
+// Alive/Dead), so callers fall back to the inactivity timeout.
+func TestCheck_UnsupportedIsUnknown(t *testing.T) {
+	t.Parallel()
+	id := Identity{PID: os.Getpid(), Start: "anything"}
+	if got := Check(id); got != LivenessUnknown {
+		t.Errorf("Check on unsupported platform = %v, want unknown", got)
+	}
+	if _, ok := ResolveOwner(); ok {
+		t.Errorf("ResolveOwner on unsupported platform returned ok=true, want false")
+	}
+}

--- a/cmd/entire/cli/proclive/proclive.go
+++ b/cmd/entire/cli/proclive/proclive.go
@@ -1,0 +1,195 @@
+// Package proclive captures a process's identity (PID plus a start-time
+// fingerprint) and later reports whether that exact process is still alive.
+//
+// It exists to detect agent sessions left in an ACTIVE state when the owning
+// process went away — a clean exit, a crash, a kill, a closed terminal, or a
+// reboot — without firing a SessionStop hook. Recording the owner's identity at
+// turn start lets `entire status` / `entire doctor` notice the process is gone
+// immediately, instead of waiting out a coarse inactivity timeout.
+//
+// This package is a leaf: it imports only the standard library and
+// golang.org/x/sys/unix. It must NOT import session, strategy, agent, or cli,
+// so those packages can depend on it without an import cycle.
+package proclive
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// Liveness is the result of checking a recorded process Identity.
+type Liveness int
+
+const (
+	// LivenessUnknown means liveness could not be determined: the identity is
+	// empty, was recorded on another host, or the platform cannot introspect
+	// processes. Callers should fall back to a time-based heuristic.
+	LivenessUnknown Liveness = iota
+	// LivenessAlive means the recorded process is still running.
+	LivenessAlive
+	// LivenessDead means the recorded process is gone (exited, killed, or the
+	// machine rebooted) or its PID has been reused by a different process.
+	LivenessDead
+)
+
+func (l Liveness) String() string {
+	switch l {
+	case LivenessAlive:
+		return "alive"
+	case LivenessDead:
+		return "dead"
+	case LivenessUnknown:
+		return "unknown"
+	default:
+		return "unknown"
+	}
+}
+
+// Identity fingerprints the process that owns a session turn. It is persisted
+// in session state and later passed to Check. The zero value means "no owner
+// recorded" and always yields LivenessUnknown.
+type Identity struct {
+	// PID is the operating-system process id of the owner.
+	PID int `json:"pid"`
+	// Start is an opaque, per-platform process start-time fingerprint. It need
+	// only be stable for the process lifetime and distinct across PID reuse
+	// within a single boot; the Boot guard invalidates it across reboots.
+	Start string `json:"start"`
+	// Boot identifies the current OS boot. A mismatch at check time means the
+	// machine rebooted, so the recorded PID cannot still be the same process.
+	Boot string `json:"boot,omitempty"`
+	// Host is the hostname where the identity was recorded. PIDs are only
+	// meaningful on their own machine, so a mismatch yields Unknown.
+	Host string `json:"host,omitempty"`
+	// Name is the owning process's executable name (comm). Diagnostic only.
+	Name string `json:"name,omitempty"`
+}
+
+var (
+	// errProcessGone is returned by procStat when no process with the given PID
+	// exists. Check maps it to LivenessDead.
+	errProcessGone = errors.New("proclive: process not found")
+	// errUnsupported is returned by the per-platform seam when the OS cannot be
+	// introspected (e.g. Windows). Check maps it to LivenessUnknown.
+	errUnsupported = errors.New("proclive: unsupported platform")
+)
+
+// maxAncestorDepth bounds the ResolveOwner walk so a pathological or cyclic
+// process tree can never loop or hang.
+const maxAncestorDepth = 12
+
+// transientNames are process names that are never the long-lived session owner:
+// our own hook binary, the shells agents commonly use to exec hooks, and the Go
+// toolchain (local-dev runs hooks via `go run`, whose short-lived `go` parent
+// would otherwise be recorded as the owner and exit immediately). The walk skips
+// past these to reach the real agent process. Note that interpreter runtimes
+// (node, bun, python) are deliberately absent — for several agents the runtime
+// IS the long-lived agent, so treating it as transient would skip the real owner.
+var transientNames = map[string]bool{
+	"entire": true,
+	"sh":     true,
+	"bash":   true,
+	"zsh":    true,
+	"dash":   true,
+	"fish":   true,
+	"ash":    true,
+	"ksh":    true,
+	"env":    true,
+	"go":     true,
+}
+
+func isTransient(name string) bool {
+	return transientNames[strings.ToLower(strings.TrimSpace(name))]
+}
+
+// ResolveOwner walks up the process tree from the current process and returns
+// the Identity of the first ancestor that is not our own hook binary or a
+// shell — i.e. the long-lived agent that owns this session.
+//
+// It returns (zero, false) when no such ancestor can be determined: an
+// unsupported platform, a truncated/looping tree, or only transient ancestors.
+// In that case the caller should record no owner and let liveness degrade to
+// the time-based fallback. Resolving to nothing is always safer than recording
+// a guessed PID, which could later be (mis)read as a live or dead owner.
+func ResolveOwner() (Identity, bool) {
+	// The host guard is essential — a PID is only meaningful on the machine that
+	// recorded it — so if the hostname can't be determined, record no owner
+	// rather than an unguarded one that Check could later (mis)classify as
+	// alive/dead across machines. Boot is a best-effort secondary guard; an
+	// empty value just disables it (darwin records none — see bootID there).
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		return Identity{}, false
+	}
+	boot, err := bootID()
+	if err != nil {
+		boot = ""
+	}
+
+	// Walk up from our own process, reading each ancestor exactly once: procStat
+	// returns its parent (to continue the walk), its name (to skip shells and our
+	// own binary), and its start fingerprint (to record).
+	candidate, _, _, err := procStat(os.Getpid())
+	if err != nil {
+		return Identity{}, false
+	}
+	for range maxAncestorDepth {
+		if candidate <= 1 {
+			return Identity{}, false
+		}
+		parent, name, start, err := procStat(candidate)
+		if err != nil {
+			return Identity{}, false
+		}
+		if !isTransient(name) {
+			return Identity{PID: candidate, Start: start, Boot: boot, Host: host, Name: name}, true
+		}
+		candidate = parent
+	}
+	return Identity{}, false
+}
+
+// Check reports whether the process recorded in id is still alive.
+//
+// Precedence: an empty identity or a host mismatch is Unknown (cannot judge); a
+// boot mismatch means a reboot, so the process is Dead; a missing PID or a
+// start-fingerprint mismatch (PID reuse) is Dead; otherwise Alive. An
+// unsupported platform is always Unknown so callers fall back to a timeout.
+func Check(id Identity) Liveness {
+	if id.PID <= 0 {
+		return LivenessUnknown
+	}
+	if id.Host != "" {
+		// Can't confirm we're on the recording host → can't trust its PIDs.
+		host, err := os.Hostname()
+		if err != nil || host != id.Host {
+			return LivenessUnknown
+		}
+	}
+	if id.Boot != "" {
+		boot, err := bootID()
+		switch {
+		case err != nil || boot == "":
+			return LivenessUnknown // can't confirm the boot → can't trust the PID
+		case boot != id.Boot:
+			return LivenessDead // rebooted: the process cannot have survived
+		}
+	}
+
+	_, _, start, err := procStat(id.PID)
+	switch {
+	case errors.Is(err, errUnsupported):
+		return LivenessUnknown
+	case errors.Is(err, errProcessGone):
+		return LivenessDead
+	case err != nil:
+		// Transient/unexpected error: don't claim the process is dead.
+		return LivenessUnknown
+	}
+	if id.Start != "" && start != "" && id.Start != start {
+		// Same PID, different start time: the PID was reused by another process.
+		return LivenessDead
+	}
+	return LivenessAlive
+}

--- a/cmd/entire/cli/proclive/proclive_live_test.go
+++ b/cmd/entire/cli/proclive/proclive_live_test.go
@@ -1,0 +1,111 @@
+//go:build linux || darwin
+
+package proclive
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// startSleeper spawns a real long-lived child bound to the test context (so it
+// is killed when the test ends) and returns its PID and a captured Identity.
+func startSleeper(t *testing.T) (int, Identity) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		// The context kill (on test end) signals the process; reap it here to
+		// avoid a zombie. A non-nil "signal: killed" error is expected.
+		if err := cmd.Wait(); err != nil {
+			t.Logf("sleeper wait: %v", err)
+		}
+	})
+	pid := cmd.Process.Pid
+	_, name, start, err := procStat(pid)
+	if err != nil {
+		t.Fatalf("procStat(child %d): %v", pid, err)
+	}
+	return pid, Identity{PID: pid, Start: start, Name: name}
+}
+
+func TestCheck_LiveProcessIsAlive(t *testing.T) {
+	t.Parallel()
+	_, id := startSleeper(t)
+	if got := Check(id); got != LivenessAlive {
+		t.Errorf("Check(live) = %v, want alive", got)
+	}
+}
+
+func TestCheck_ExitedProcessIsDead(t *testing.T) {
+	t.Parallel()
+	cmd := exec.CommandContext(t.Context(), "sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	pid := cmd.Process.Pid
+	_, name, start, err := procStat(pid)
+	if err != nil {
+		t.Fatalf("procStat(child %d): %v", pid, err)
+	}
+	id := Identity{PID: pid, Start: start, Name: name}
+
+	// Kill and reap, then the recorded identity must read as dead. (A PID reused
+	// within the test window would mismatch Start and still be Dead.)
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Logf("wait after kill: %v", err) // expected: "signal: killed"
+	}
+
+	if got := Check(id); got != LivenessDead {
+		t.Errorf("Check(exited) = %v, want dead", got)
+	}
+}
+
+func TestCheck_StartMismatchIsDead(t *testing.T) {
+	t.Parallel()
+	// Our own process is alive, but a bogus start fingerprint must read as PID
+	// reuse → Dead.
+	id := Identity{PID: os.Getpid(), Start: "0.000000-not-a-real-fingerprint"}
+	if got := Check(id); got != LivenessDead {
+		t.Errorf("Check(start mismatch) = %v, want dead", got)
+	}
+}
+
+func TestProcStat_Self(t *testing.T) {
+	t.Parallel()
+	ppid, name, start, err := procStat(os.Getpid())
+	if err != nil {
+		t.Fatalf("procStat(self): %v", err)
+	}
+	if ppid <= 0 {
+		t.Errorf("ppid = %d, want > 0", ppid)
+	}
+	if name == "" {
+		t.Errorf("name is empty")
+	}
+	if start == "" {
+		t.Errorf("start is empty")
+	}
+}
+
+func TestResolveOwner_ReturnsSomething(t *testing.T) {
+	t.Parallel()
+	// Under `go test` the ancestor chain (test binary ← go ← shell ← ...) should
+	// resolve to some non-shell owner. We can't assert which, but if it resolves
+	// it must be self-consistent and currently alive.
+	id, ok := ResolveOwner()
+	if !ok {
+		t.Skip("no stable owner resolved in this environment")
+	}
+	if id.PID <= 0 {
+		t.Errorf("resolved PID = %d, want > 0", id.PID)
+	}
+	if got := Check(id); got != LivenessAlive {
+		t.Errorf("resolved owner Check = %v, want alive", got)
+	}
+}

--- a/cmd/entire/cli/proclive/proclive_test.go
+++ b/cmd/entire/cli/proclive/proclive_test.go
@@ -1,0 +1,55 @@
+package proclive
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLiveness_String(t *testing.T) {
+	t.Parallel()
+	cases := map[Liveness]string{
+		LivenessUnknown: "unknown",
+		LivenessAlive:   "alive",
+		LivenessDead:    "dead",
+		Liveness(99):    "unknown",
+	}
+	for l, want := range cases {
+		if got := l.String(); got != want {
+			t.Errorf("Liveness(%d).String() = %q, want %q", int(l), got, want)
+		}
+	}
+}
+
+func TestCheck_EmptyIdentityIsUnknown(t *testing.T) {
+	t.Parallel()
+	if got := Check(Identity{}); got != LivenessUnknown {
+		t.Errorf("Check(empty) = %v, want unknown", got)
+	}
+	if got := Check(Identity{PID: 0, Start: "x"}); got != LivenessUnknown {
+		t.Errorf("Check(pid=0) = %v, want unknown", got)
+	}
+}
+
+func TestCheck_HostMismatchIsUnknown(t *testing.T) {
+	t.Parallel()
+	// A recorded host that cannot match the current machine must yield Unknown
+	// regardless of platform, before any process introspection happens.
+	id := Identity{PID: os.Getpid(), Start: "anything", Host: "not-this-host-\x00-ever"}
+	if got := Check(id); got != LivenessUnknown {
+		t.Errorf("Check(host mismatch) = %v, want unknown", got)
+	}
+}
+
+func TestIsTransient(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"entire", "sh", "bash", "ZSH", " dash ", "Fish", "go"} {
+		if !isTransient(name) {
+			t.Errorf("isTransient(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"node", "bun", "claude", "cursor", "python3", ""} {
+		if isTransient(name) {
+			t.Errorf("isTransient(%q) = true, want false", name)
+		}
+	}
+}

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -84,6 +84,7 @@ func NewRootCmd() *cobra.Command {
 	// Noun groups (canonical homes for subcommands).
 	cmd.AddCommand(newSessionsCmd())        // 'session' (with 'sessions' as Cobra alias)
 	cmd.AddCommand(newCheckpointGroupCmd()) // 'checkpoint' / 'cp' / 'checkpoints'
+	cmd.AddCommand(newTokensGroupCmd())     // 'tokens'
 	cmd.AddCommand(newAgentGroupCmd())      // 'agent'
 	cmd.AddCommand(newAuthCmd())            // 'auth'
 	cmd.AddCommand(newDoctorCmd())          // 'doctor' (group: trace/logs/bundle)

--- a/cmd/entire/cli/session/owner_live_test.go
+++ b/cmd/entire/cli/session/owner_live_test.go
@@ -1,0 +1,37 @@
+//go:build linux || darwin
+
+package session
+
+import (
+	"os"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+)
+
+func TestOwnerExited_DeadOwnerActiveIsTrue(t *testing.T) {
+	t.Parallel()
+	// Our own PID is alive, but a mismatched start fingerprint makes proclive
+	// treat it as a reused (dead) PID — a deterministic "owner gone" signal.
+	exitedOwner := &proclive.Identity{PID: os.Getpid(), Start: "bogus-start-fingerprint"}
+	s := &State{Phase: PhaseActive, Owner: exitedOwner}
+	if s.OwnerLiveness() != proclive.LivenessDead {
+		t.Fatalf("OwnerLiveness = %v, want dead", s.OwnerLiveness())
+	}
+	if !s.OwnerExited() {
+		t.Error("OwnerExited(active, dead owner) = false, want true")
+	}
+}
+
+func TestOwnerExited_LiveOwnerActiveIsFalse(t *testing.T) {
+	t.Parallel()
+	// A faithfully-captured identity of a live process must NOT read as exited.
+	id, ok := proclive.ResolveOwner()
+	if !ok {
+		t.Skip("no stable owner resolved in this environment")
+	}
+	s := &State{Phase: PhaseActive, Owner: &id}
+	if s.OwnerExited() {
+		t.Error("OwnerExited(active, live owner) = true, want false")
+	}
+}

--- a/cmd/entire/cli/session/owner_test.go
+++ b/cmd/entire/cli/session/owner_test.go
@@ -1,0 +1,38 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+)
+
+func TestOwnerLiveness_NilOwnerIsUnknown(t *testing.T) {
+	t.Parallel()
+	s := &State{Phase: PhaseActive}
+	if got := s.OwnerLiveness(); got != proclive.LivenessUnknown {
+		t.Errorf("OwnerLiveness(nil owner) = %v, want unknown", got)
+	}
+}
+
+func TestOwnerExited_NilOwnerIsFalse(t *testing.T) {
+	t.Parallel()
+	// No owner recorded: behavior must degrade to the timeout heuristic, so
+	// OwnerExited reports false regardless of phase.
+	s := &State{Phase: PhaseActive}
+	if s.OwnerExited() {
+		t.Error("OwnerExited(nil owner) = true, want false")
+	}
+}
+
+func TestOwnerExited_NonActivePhaseIsFalse(t *testing.T) {
+	t.Parallel()
+	// Even with a dead owner, a non-ACTIVE session is not "exited" — there's no
+	// live turn to have been orphaned.
+	deadOwner := &proclive.Identity{PID: 999999999, Start: "never"}
+	for _, phase := range []Phase{PhaseIdle, PhaseEnded} {
+		s := &State{Phase: phase, Owner: deadOwner}
+		if s.OwnerExited() {
+			t.Errorf("OwnerExited(phase=%s) = true, want false", phase)
+		}
+	}
+}

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -18,6 +18,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
 
@@ -300,6 +301,15 @@ type State struct {
 	// PendingPromptAttribution holds attribution calculated at prompt start (before agent runs).
 	// This is moved to PromptAttributions when SaveStep is called.
 	PendingPromptAttribution *PromptAttribution `json:"pending_prompt_attribution,omitempty"`
+
+	// Owner fingerprints the process that owns this session's agent turn,
+	// captured at each turn start via proclive.ResolveOwner. It lets liveness
+	// checks detect an ACTIVE session whose agent has exited (clean /exit,
+	// crash, kill, terminal close, reboot) without a SessionStop hook firing —
+	// see OwnerExited. nil for legacy sessions or when the owner couldn't be
+	// resolved, in which case liveness falls back to the StuckActiveThreshold
+	// timeout. Only meaningful on Owner.Host.
+	Owner *proclive.Identity `json:"owner,omitempty"`
 }
 
 // PromptAttribution captures line-level attribution data at the start of each prompt.
@@ -408,6 +418,31 @@ func (s *State) IsStuckActive() bool {
 		ref = &s.StartedAt
 	}
 	return time.Since(*ref) > StuckActiveThreshold
+}
+
+// OwnerLiveness reports the liveness of this session's recorded owner process.
+// It returns proclive.LivenessUnknown when no owner was recorded (legacy
+// sessions, or sessions where the owner couldn't be resolved), so callers can
+// fall back to the time-based IsStuckActive heuristic.
+func (s *State) OwnerLiveness() proclive.Liveness {
+	if s.Owner == nil {
+		return proclive.LivenessUnknown
+	}
+	return proclive.Check(*s.Owner)
+}
+
+// OwnerExited reports true when this session is ACTIVE but its owning agent
+// process is gone — exited cleanly, crashed, was killed, or the machine
+// rebooted — without a SessionStop hook firing. Unlike IsStuckActive (a
+// time-based heuristic), this is detected immediately, regardless of how
+// recently the session interacted. It returns false when liveness is Unknown
+// (no owner recorded, cross-host state, or an unsupported platform) so behavior
+// degrades to the StuckActiveThreshold timeout.
+func (s *State) OwnerExited() bool {
+	if !s.Phase.IsActive() {
+		return false
+	}
+	return s.OwnerLiveness() == proclive.LivenessDead
 }
 
 func (s *State) IsStale() bool {

--- a/cmd/entire/cli/session_finalize.go
+++ b/cmd/entire/cli/session_finalize.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+)
+
+// finalizeExitedSessions finalizes every ACTIVE session in states whose owning
+// agent process has exited (clean /exit, crash, kill, terminal close, reboot)
+// without a SessionStop hook firing. Each such session is finalized exactly as a
+// clean session stop would be: the session-stop transition runs (PhaseEnded +
+// EndedAt) and pending work is eagerly condensed.
+//
+// It refreshes the matched in-memory states from disk after finalizing — so
+// callers can re-filter/re-render without their own reload — and returns the
+// number finalized. Each session is best-effort: a failure to mark one ended is
+// logged and skipped; a condense failure is logged but the session is still
+// counted (PostCommit will retry the condense later).
+func finalizeExitedSessions(ctx context.Context, states []*session.State) int {
+	logCtx := logging.WithComponent(ctx, "session")
+
+	var store *session.StateStore // lazily created on first finalize
+	finalized := 0
+	for _, st := range states {
+		if !st.OwnerExited() {
+			continue // cheap pre-filter on the (possibly stale) list snapshot
+		}
+
+		// Finalize via the same path a clean SessionStop hook would take, but
+		// re-validate OwnerExited on the freshly-loaded state under the lock:
+		// a turn may have started since the snapshot and replaced the dead
+		// owner with a live one, in which case ended is false and we leave it be.
+		ended, err := endSessionNow(ctx, nil, st.SessionID, func(s *session.State) bool {
+			return s.OwnerExited()
+		})
+		if err != nil {
+			logging.Warn(logCtx, "failed to finalize exited session",
+				slog.String("session_id", st.SessionID),
+				slog.String("error", err.Error()))
+			continue
+		}
+		if !ended {
+			continue
+		}
+
+		// Refresh the in-memory snapshot from disk so downstream filtering and
+		// doctor classification see the true post-finalize state: ended, and
+		// condensed only if the eager condense actually succeeded (it is
+		// fail-open, so StepCount/FullyCondensed must not be assumed). Fall back
+		// to a minimal ended-marking if the reload fails — enough for the
+		// caller's "active" filter to drop it.
+		if store == nil {
+			if s, serr := session.NewStateStore(ctx); serr == nil {
+				store = s
+			}
+		}
+		refreshed := false
+		if store != nil {
+			if reloaded, lerr := store.Load(ctx, st.SessionID); lerr == nil && reloaded != nil {
+				*st = *reloaded
+				refreshed = true
+			}
+		}
+		if !refreshed {
+			now := time.Now()
+			st.Phase = session.PhaseEnded
+			st.EndedAt = &now
+		}
+		finalized++
+	}
+	return finalized
+}

--- a/cmd/entire/cli/session_finalize_test.go
+++ b/cmd/entire/cli/session_finalize_test.go
@@ -1,0 +1,127 @@
+//go:build linux || darwin
+
+package cli
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+)
+
+// TestFinalizeExitedSessions finalizes an ACTIVE session whose owner process is
+// gone, and leaves an ACTIVE session without a recorded owner untouched.
+//
+// Not parallel: setupAttachTestRepo uses t.Chdir.
+func TestFinalizeExitedSessions(t *testing.T) {
+	setupAttachTestRepo(t)
+	ctx := context.Background()
+
+	store, err := session.NewStateStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Owner with a mismatched start fingerprint reads as a reused (dead) PID, a
+	// deterministic "agent exited" signal on linux/darwin.
+	exited := &session.State{
+		SessionID: "exited-session",
+		Phase:     session.PhaseActive,
+		StartedAt: time.Now(),
+		Owner:     &proclive.Identity{PID: os.Getpid(), Start: "bogus-start-fingerprint"},
+	}
+	// No owner recorded: must be left alone (liveness unknown → timeout fallback).
+	noOwner := &session.State{
+		SessionID: "no-owner-session",
+		Phase:     session.PhaseActive,
+		StartedAt: time.Now(),
+	}
+	for _, s := range []*session.State{exited, noOwner} {
+		if err := store.Save(ctx, s); err != nil {
+			t.Fatalf("save %s: %v", s.SessionID, err)
+		}
+	}
+
+	states, err := store.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if n := finalizeExitedSessions(ctx, states); n != 1 {
+		t.Fatalf("finalizeExitedSessions = %d, want 1", n)
+	}
+
+	// The exited session is now ended on disk.
+	got, err := store.Load(ctx, "exited-session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EndedAt == nil {
+		t.Error("exited session EndedAt = nil, want set")
+	}
+	if got.Phase != session.PhaseEnded {
+		t.Errorf("exited session Phase = %q, want %q", got.Phase, session.PhaseEnded)
+	}
+
+	// The owner-less session is untouched.
+	got, err = store.Load(ctx, "no-owner-session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EndedAt != nil {
+		t.Error("no-owner session EndedAt set, want nil (left active)")
+	}
+}
+
+// TestFinalizeExitedSessions_RevalidatesUnderLock guards against the
+// time-of-check/time-of-use race: the sweep must re-check OwnerExited on the
+// freshly-loaded state, not act on a stale list snapshot. Here the on-disk
+// state has a LIVE owner while the snapshot passed to the sweep carries a dead
+// one (as if a turn revived the session after the list was taken).
+//
+// Not parallel: setupAttachTestRepo uses t.Chdir.
+func TestFinalizeExitedSessions_RevalidatesUnderLock(t *testing.T) {
+	setupAttachTestRepo(t)
+	ctx := context.Background()
+
+	liveOwner, ok := proclive.ResolveOwner()
+	if !ok {
+		t.Skip("no stable process owner resolvable in this environment")
+	}
+
+	store, err := session.NewStateStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(ctx, &session.State{
+		SessionID: "revived",
+		Phase:     session.PhaseActive,
+		StartedAt: time.Now(),
+		Owner:     &liveOwner, // on disk: a live owner
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale snapshot the sweep sees: same session, but with a dead owner.
+	stale := &session.State{
+		SessionID: "revived",
+		Phase:     session.PhaseActive,
+		StartedAt: time.Now(),
+		Owner:     &proclive.Identity{PID: os.Getpid(), Start: "bogus-start-fingerprint"},
+	}
+
+	if n := finalizeExitedSessions(ctx, []*session.State{stale}); n != 0 {
+		t.Fatalf("finalizeExitedSessions = %d, want 0 (revalidation should skip the revived session)", n)
+	}
+
+	got, err := store.Load(ctx, "revived")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EndedAt != nil {
+		t.Error("revived session was ended despite a live owner on disk")
+	}
+}

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -528,7 +528,7 @@ func agentBriefOptimizationAction(report sessionTokensReport) (string, bool) {
 	case hasTokenRecommendation(report, "api-call-amplification"):
 		return agentBriefCostProxyBatchAction, true
 	case hasTokenRecommendation(report, "context-replay-hotspot"):
-		return "Use at most 2 focused reads after summarizing known findings, then answer. Avoid broad grep, broad diffs, and broad tests.", true
+		return "Use at most 2 focused reads only if a named file or test can change the answer; otherwise answer now. Avoid broad grep, broad diffs, and broad tests.", true
 	case hasTokenRecommendation(report, "subagent-heavy"):
 		return "Do not launch broad subagents. Use one narrowly scoped check with a concrete expected output.", true
 	case hasTokenRecommendation(report, "high-context-pressure"):

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -76,6 +76,8 @@ const (
 	recommendationLongSessionCheckpoints   = 5
 )
 
+const agentBriefCostProxyBatchAction = "Use at most 3 batched reads before answering. Continue only if a named file or test can change the verdict; otherwise answer now. Avoid broad grep, broad diffs, broad tests, and repeated token diagnostics; keep the answer tight."
+
 func newTokensCmd() *cobra.Command {
 	var jsonFlag bool
 	var currentFlag bool
@@ -118,8 +120,12 @@ optimize next steps."`,
 }
 
 func runSessionTokens(ctx context.Context, cmd *cobra.Command, sessionID string, current, jsonOutput, agentBrief bool) error {
-	if sessionID == "" || current {
-		sessionID = strategy.FindMostRecentSession(ctx)
+	if sessionID == "" {
+		if current {
+			sessionID = strategy.FindMostRecentSessionInCurrentWorktree(ctx)
+		} else {
+			sessionID = strategy.FindMostRecentSession(ctx)
+		}
 		if sessionID == "" {
 			fmt.Fprintln(cmd.OutOrStdout(), "No active session found in this worktree.")
 			return nil
@@ -328,6 +334,24 @@ func recommendationRules(signals tokenRecommendationSignals) []sessionTokensReco
 			Signals:  []string{"subagent_tokens"},
 		})
 	}
+	if signals.Tokens != nil && signals.Tokens.Total > 0 &&
+		tokenClassPressure(signals.Tokens.CacheWrite, signals.Tokens.Total, 5000, 10, 50_000) {
+		recs = append(recs, sessionTokensRecommendation{
+			ID:       "cache-write-pressure",
+			Severity: "medium",
+			Message:  "Cache write is elevated; avoid broad new context and narrow the next read before continuing.",
+			Signals:  []string{"cache_write_tokens"},
+		})
+	}
+	if signals.Tokens != nil && signals.Tokens.Total > 0 &&
+		tokenClassPressure(signals.Tokens.Output, signals.Tokens.Total, 3000, 2, 10_000) {
+		recs = append(recs, sessionTokensRecommendation{
+			ID:       "output-pressure",
+			Severity: "medium",
+			Message:  "Output tokens are elevated; keep the next answer tight and avoid restating evidence.",
+			Signals:  []string{"output_tokens"},
+		})
+	}
 	if signals.Context != nil && signals.Context.Percent >= recommendationHighContextPercent {
 		recs = append(recs, sessionTokensRecommendation{
 			ID:       "high-context-pressure",
@@ -361,6 +385,16 @@ func tokenShareAtLeastOneTenth(part, total int) bool {
 		return false
 	}
 	return part >= (total-1)/recommendationSubagentShareDenominator+1
+}
+
+func tokenClassPressure(value, total, minTokens int, minPercent float64, highTokens int) bool {
+	if value <= 0 || total <= 0 {
+		return false
+	}
+	if value >= highTokens {
+		return true
+	}
+	return value >= minTokens && tokenPercent(value, total) >= minPercent
 }
 
 func tokenPercent(value, total int) float64 {
@@ -469,23 +503,40 @@ func formatAPICalls(count int) string {
 }
 
 func agentBriefNextAction(report sessionTokensReport) string {
-	switch {
-	case hasTokenRecommendation(report, "context-replay-hotspot") && hasTokenRecommendation(report, "api-call-amplification"):
-		return "Summarize the useful findings, then batch the next diagnostic step. Avoid more exploratory reads until you have a narrowed hypothesis."
-	case hasTokenRecommendation(report, "api-call-amplification"):
-		return "Batch the next diagnostic step around one narrowed hypothesis before making more tool calls."
-	case hasTokenRecommendation(report, "context-replay-hotspot"):
-		return "Summarize the current useful findings before continuing, and keep the next prompt narrow."
-	case hasTokenRecommendation(report, "no-token-data"):
+	if hasTokenRecommendation(report, "no-token-data") {
 		return "Token usage is not available yet. Use this as a context check, not a spend diagnosis; continue after the next checkpoint captures usage."
+	}
+	if action, ok := agentBriefOptimizationAction(report); ok {
+		return action
+	}
+	return "Continue normally; no high-signal token optimization is available from this session yet."
+}
+
+func agentBriefOptimizationAction(report sessionTokensReport) (string, bool) {
+	switch {
+	case (hasTokenRecommendation(report, "cache-write-pressure") || hasTokenRecommendation(report, "output-pressure")) &&
+		(hasTokenRecommendation(report, "context-replay-hotspot") || hasTokenRecommendation(report, "api-call-amplification")):
+		return agentBriefCostProxyBatchAction, true
+	case hasTokenRecommendation(report, "cache-write-pressure") && hasTokenRecommendation(report, "output-pressure"):
+		return agentBriefCostProxyBatchAction, true
+	case hasTokenRecommendation(report, "cache-write-pressure"):
+		return "Use at most 3 batched reads and avoid broad new context until you have one narrowed hypothesis.", true
+	case hasTokenRecommendation(report, "output-pressure"):
+		return "Keep the next answer tight; cite only necessary evidence and avoid restating prior context.", true
+	case hasTokenRecommendation(report, "context-replay-hotspot") && hasTokenRecommendation(report, "api-call-amplification"):
+		return agentBriefCostProxyBatchAction, true
+	case hasTokenRecommendation(report, "api-call-amplification"):
+		return agentBriefCostProxyBatchAction, true
+	case hasTokenRecommendation(report, "context-replay-hotspot"):
+		return "Use at most 2 focused reads after summarizing known findings, then answer. Avoid broad grep, broad diffs, and broad tests.", true
 	case hasTokenRecommendation(report, "subagent-heavy"):
-		return "Keep the next agent or subagent task narrow with a concrete expected output; avoid broad parallel exploration."
+		return "Do not launch broad subagents. Use one narrowly scoped check with a concrete expected output.", true
 	case hasTokenRecommendation(report, "high-context-pressure"):
-		return "Preserve the useful findings and compact or restart before adding more broad context."
+		return "Preserve useful findings, then answer with at most 2 focused reads if more evidence is required.", true
 	case hasTokenRecommendation(report, "long-session"):
-		return "Compact or restart after summarizing useful findings if older context is no longer needed."
+		return "Summarize useful findings and stop unless one focused read can change the answer.", true
 	default:
-		return "Continue normally; no high-signal token optimization is available from this session yet."
+		return "", false
 	}
 }
 
@@ -496,6 +547,12 @@ func agentBriefSignals(report sessionTokensReport) []string {
 	}
 	if hasTokenRecommendation(report, "api-call-amplification") {
 		signals = append(signals, "API call count is high for one session.")
+	}
+	if hasTokenRecommendation(report, "cache-write-pressure") {
+		signals = append(signals, "Cache write/new context pressure is elevated.")
+	}
+	if hasTokenRecommendation(report, "output-pressure") {
+		signals = append(signals, "Output pressure is elevated.")
 	}
 	if hasTokenRecommendation(report, "subagent-heavy") {
 		signals = append(signals, "Subagent usage is a meaningful part of total tokens.")

--- a/cmd/entire/cli/session_tokens.go
+++ b/cmd/entire/cli/session_tokens.go
@@ -533,8 +533,12 @@ func writeTokenRecommendations(w io.Writer, recs []sessionTokensRecommendation) 
 }
 
 func writeTokenUsageSection(w io.Writer, tokens *sessionTokensUsage) {
+	writeTokenUsageSectionWithTitle(w, "Token usage", tokens)
+}
+
+func writeTokenUsageSectionWithTitle(w io.Writer, title string, tokens *sessionTokensUsage) {
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "Token usage")
+	fmt.Fprintln(w, title)
 	if tokens != nil {
 		fmt.Fprintf(w, "Total:  %s tokens\n", formatTokenCount(tokens.Total))
 		parts := []string{

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -870,7 +870,7 @@ func stopSessionAndPrint(ctx context.Context, cmd *cobra.Command, state *strateg
 	lastCheckpointID := state.LastCheckpointID
 	stepCount := state.StepCount
 
-	if err := markSessionEnded(ctx, nil, sessionID); err != nil {
+	if _, err := markSessionEnded(ctx, nil, sessionID, nil); err != nil {
 		return fmt.Errorf("failed to stop session %s: %w", sessionID, err)
 	}
 

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -1328,6 +1328,7 @@ func TestTokensCmd_AgentBriefPrioritizesNextAction(t *testing.T) {
 		"Token usage: 6213.6k total; 97.4% cache/context replay; 70 API calls.",
 		"Next best action:",
 		"Use at most 3 batched reads before answering.",
+		"Continue only if a named file or test can change the verdict; otherwise answer now.",
 		"Avoid broad grep, broad diffs, broad tests, and repeated token diagnostics; keep the answer tight.",
 		"Signals:",
 		"- Cache/context replay dominates token volume.",
@@ -1396,7 +1397,7 @@ func TestTokensCmd_AgentBriefHighCacheReplayWithoutHighAPICalls(t *testing.T) {
 	out := stdout.String()
 	checks := []string{
 		"Token usage: 637.7k total; 95.5% cache/context replay; 3 API calls.",
-		"Use at most 2 focused reads after summarizing known findings, then answer.",
+		"Use at most 2 focused reads only if a named file or test can change the answer; otherwise answer now.",
 		"Avoid broad grep, broad diffs, and broad tests.",
 		"- Cache/context replay dominates token volume.",
 	}
@@ -1516,6 +1517,7 @@ func TestSessionTokensAgentBriefClassAwareCostProxy(t *testing.T) {
 		"Session: test-cost-proxy-brief",
 		"Use at most 3 batched reads",
 		"Avoid broad grep, broad diffs, broad tests",
+		"otherwise answer now",
 		"keep the answer tight",
 		"- Cache write/new context pressure is elevated.",
 		"- Output pressure is elevated.",
@@ -1551,6 +1553,7 @@ func TestCheckpointTokensAgentBriefClassAwareCostProxy(t *testing.T) {
 		"Checkpoint: c05e500cafe0",
 		"Use at most 3 batched reads",
 		"Avoid broad grep, broad diffs, broad tests",
+		"otherwise answer now",
 		"keep the answer tight",
 		"- Cache write/new context pressure is elevated.",
 		"- Output pressure is elevated.",
@@ -1961,6 +1964,7 @@ func TestCheckpointTokensCmd_AgentBriefGivesOperationalBudget(t *testing.T) {
 		"Token usage: 6213.6k total; 97.4% cache/context replay; 70 API calls.",
 		"Next best action:",
 		"Use at most 3 batched reads before answering.",
+		"Continue only if a named file or test can change the verdict; otherwise answer now.",
 		"Avoid broad grep, broad diffs, broad tests, and repeated token diagnostics; keep the answer tight.",
 		"Signals:",
 		"- Cache/context replay dominates token volume.",

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -1815,6 +1815,47 @@ func TestTokensCmd_DefaultsToCurrentSession(t *testing.T) {
 	}
 }
 
+func TestTokensCmd_CurrentDoesNotFallbackToOtherWorktree(t *testing.T) {
+	setupStopTestRepo(t)
+
+	ctx := context.Background()
+	now := time.Now()
+	other := makeSessionState("test-tokens-other-only", session.PhaseActive)
+	other.WorktreePath = testOtherWorktreePath
+	other.LastInteractionTime = &now
+	other.TokenUsage = &agent.TokenUsage{InputTokens: 9999}
+
+	if err := strategy.SaveSessionState(ctx, other); err != nil {
+		t.Fatalf("SaveSessionState() error = %v", err)
+	}
+
+	defaultCmd := newTokensCmd()
+	var defaultStdout bytes.Buffer
+	defaultCmd.SetOut(&defaultStdout)
+	defaultCmd.SetArgs([]string{})
+	if err := defaultCmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected default command to fall back, got: %v", err)
+	}
+	if !strings.Contains(defaultStdout.String(), "Session: test-tokens-other-only") {
+		t.Fatalf("expected default command to fall back to other worktree session, got:\n%s", defaultStdout.String())
+	}
+
+	currentCmd := newTokensCmd()
+	var currentStdout bytes.Buffer
+	currentCmd.SetOut(&currentStdout)
+	currentCmd.SetArgs([]string{"--current"})
+	if err := currentCmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected --current command to avoid fallback without error, got: %v", err)
+	}
+	out := currentStdout.String()
+	if !strings.Contains(out, "No active session found in this worktree.") {
+		t.Fatalf("expected --current command to report no current worktree session, got:\n%s", out)
+	}
+	if strings.Contains(out, "test-tokens-other-only") {
+		t.Fatalf("expected --current command not to fall back to other worktree, got:\n%s", out)
+	}
+}
+
 func TestTokensCmd_CurrentAndSessionIDAreMutuallyExclusive(t *testing.T) {
 	setupStopTestRepo(t)
 

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -2384,6 +2384,35 @@ func TestCheckpointTokensCmd_TextOutputWithComparison(t *testing.T) {
 	}
 }
 
+func TestCheckpointTokensCmd_RejectsSelfComparison(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
+	cpID := id.MustCheckpointID("abc222abc222")
+
+	writeCommittedTokenCheckpoint(ctx, t, store, cpID, "checkpoint-token-self-compare", &agent.TokenUsage{
+		InputTokens:  100,
+		OutputTokens: 50,
+		APICallCount: 1,
+	})
+
+	cmd := newCheckpointGroupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"tokens", "abc222", "--compare", "abc222abc222"})
+
+	err := cmd.ExecuteContext(ctx)
+	if err == nil {
+		t.Fatal("expected self-comparison error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot compare checkpoint abc222abc222 to itself") {
+		t.Fatalf("expected self-comparison error, got: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no report output for self-comparison, got:\n%s", stdout.String())
+	}
+}
+
 func TestCheckpointTokensCmd_JSONOutputWithComparison(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()

--- a/cmd/entire/cli/sessions_test.go
+++ b/cmd/entire/cli/sessions_test.go
@@ -1239,6 +1239,61 @@ func reportHasSessionRecommendation(report sessionTokensReport, id string) bool 
 	return false
 }
 
+func TestRecommendationRules_CacheWritePressure(t *testing.T) {
+	t.Parallel()
+
+	recs := recommendationRules(tokenRecommendationSignals{
+		Tokens: &sessionTokensUsage{
+			Total:      50_000,
+			CacheWrite: 6_000,
+		},
+	})
+
+	if !recommendationsIncludeID(recs, "cache-write-pressure") {
+		t.Fatalf("expected cache-write-pressure recommendation, got %+v", recs)
+	}
+}
+
+func TestRecommendationRules_OutputPressure(t *testing.T) {
+	t.Parallel()
+
+	recs := recommendationRules(tokenRecommendationSignals{
+		Tokens: &sessionTokensUsage{
+			Total:  100_000,
+			Output: 3_500,
+		},
+	})
+
+	if !recommendationsIncludeID(recs, "output-pressure") {
+		t.Fatalf("expected output-pressure recommendation, got %+v", recs)
+	}
+}
+
+func TestRecommendationRules_OutputPressureWithLargeCacheReplay(t *testing.T) {
+	t.Parallel()
+
+	recs := recommendationRules(tokenRecommendationSignals{
+		Tokens: &sessionTokensUsage{
+			Total:     10_000_000,
+			CacheRead: 9_800_000,
+			Output:    100_000,
+		},
+	})
+
+	if !recommendationsIncludeID(recs, "output-pressure") {
+		t.Fatalf("expected output-pressure recommendation for high absolute output, got %+v", recs)
+	}
+}
+
+func recommendationsIncludeID(recs []sessionTokensRecommendation, id string) bool {
+	for _, rec := range recs {
+		if rec.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
 func TestTokensCmd_AgentBriefPrioritizesNextAction(t *testing.T) {
 	setupStopTestRepo(t)
 
@@ -1272,10 +1327,13 @@ func TestTokensCmd_AgentBriefPrioritizesNextAction(t *testing.T) {
 		"Session: test-tokens-brief",
 		"Token usage: 6213.6k total; 97.4% cache/context replay; 70 API calls.",
 		"Next best action:",
-		"Summarize the useful findings, then batch the next diagnostic step.",
+		"Use at most 3 batched reads before answering.",
+		"Avoid broad grep, broad diffs, broad tests, and repeated token diagnostics; keep the answer tight.",
 		"Signals:",
 		"- Cache/context replay dominates token volume.",
 		"- API call count is high for one session.",
+		"- Cache write/new context pressure is elevated.",
+		"- Output pressure is elevated.",
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
@@ -1338,7 +1396,8 @@ func TestTokensCmd_AgentBriefHighCacheReplayWithoutHighAPICalls(t *testing.T) {
 	out := stdout.String()
 	checks := []string{
 		"Token usage: 637.7k total; 95.5% cache/context replay; 3 API calls.",
-		"Summarize the current useful findings before continuing, and keep the next prompt narrow.",
+		"Use at most 2 focused reads after summarizing known findings, then answer.",
+		"Avoid broad grep, broad diffs, and broad tests.",
 		"- Cache/context replay dominates token volume.",
 	}
 	for _, check := range checks {
@@ -1379,7 +1438,8 @@ func TestTokensCmd_AgentBriefHighAPICallsWithoutCacheReplay(t *testing.T) {
 	out := stdout.String()
 	checks := []string{
 		"Token usage: 11k total; 25 API calls.",
-		"Batch the next diagnostic step around one narrowed hypothesis before making more tool calls.",
+		"Use at most 3 batched reads before answering.",
+		"Avoid broad grep, broad diffs, broad tests, and repeated token diagnostics; keep the answer tight.",
 		"- API call count is high for one session.",
 	}
 	for _, check := range checks {
@@ -1424,6 +1484,110 @@ func TestTokensCmd_AgentBriefNoTokenData(t *testing.T) {
 		"Signals:",
 		"- Token usage is unavailable for this session.",
 		"- Context pressure is high.",
+	}
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected %q in output, got:\n%s", check, out)
+		}
+	}
+}
+
+func TestSessionTokensAgentBriefClassAwareCostProxy(t *testing.T) {
+	t.Parallel()
+
+	tokens := &sessionTokensUsage{
+		Total:      50_000,
+		CacheWrite: 6_000,
+		Output:     3_500,
+		APICalls:   4,
+	}
+	report := sessionTokensReport{
+		SessionID:       "test-cost-proxy-brief",
+		Tokens:          tokens,
+		Recommendations: recommendationRules(tokenRecommendationSignals{Tokens: tokens}),
+	}
+
+	var stdout bytes.Buffer
+	writeSessionTokensAgentBrief(&stdout, report)
+
+	out := stdout.String()
+	checks := []string{
+		"Session token brief",
+		"Session: test-cost-proxy-brief",
+		"Use at most 3 batched reads",
+		"Avoid broad grep, broad diffs, broad tests",
+		"keep the answer tight",
+		"- Cache write/new context pressure is elevated.",
+		"- Output pressure is elevated.",
+	}
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected %q in output, got:\n%s", check, out)
+		}
+	}
+}
+
+func TestCheckpointTokensAgentBriefClassAwareCostProxy(t *testing.T) {
+	t.Parallel()
+
+	tokens := &sessionTokensUsage{
+		Total:      50_000,
+		CacheWrite: 6_000,
+		Output:     3_500,
+		APICalls:   4,
+	}
+	report := checkpointTokensReport{
+		CheckpointID:    "c05e500cafe0",
+		Tokens:          tokens,
+		Recommendations: recommendationRules(tokenRecommendationSignals{Tokens: tokens}),
+	}
+
+	var stdout bytes.Buffer
+	writeCheckpointTokensAgentBrief(&stdout, report)
+
+	out := stdout.String()
+	checks := []string{
+		"Checkpoint token brief",
+		"Checkpoint: c05e500cafe0",
+		"Use at most 3 batched reads",
+		"Avoid broad grep, broad diffs, broad tests",
+		"keep the answer tight",
+		"- Cache write/new context pressure is elevated.",
+		"- Output pressure is elevated.",
+	}
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected %q in output, got:\n%s", check, out)
+		}
+	}
+}
+
+func TestCheckpointTokensAgentBriefCombinesOutputAndReplayPressure(t *testing.T) {
+	t.Parallel()
+
+	tokens := &sessionTokensUsage{
+		Total:     10_000_000,
+		CacheRead: 9_800_000,
+		Output:    100_000,
+		APICalls:  25,
+	}
+	report := checkpointTokensReport{
+		CheckpointID:    "c05e501cafe0",
+		Tokens:          tokens,
+		Recommendations: recommendationRules(tokenRecommendationSignals{Tokens: tokens}),
+	}
+
+	var stdout bytes.Buffer
+	writeCheckpointTokensAgentBrief(&stdout, report)
+
+	out := stdout.String()
+	checks := []string{
+		"Use at most 3 batched reads",
+		"Avoid broad grep, broad diffs, broad tests",
+		"keep the answer tight",
+		"- Cache/context replay dominates token volume.",
+		"- API call count is high for one session.",
+		"- Output pressure is elevated.",
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
@@ -1521,6 +1685,21 @@ func TestTokensCmd_JSONAndAgentBriefAreMutuallyExclusive(t *testing.T) {
 
 	cmd := newTokensCmd()
 	cmd.SetArgs([]string{"test-session", "--json", "--agent-brief"})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error for --json with --agent-brief")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutually exclusive error, got: %v", err)
+	}
+}
+
+func TestCheckpointTokensCmd_JSONAndAgentBriefAreMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	cmd := newCheckpointGroupCmd()
+	cmd.SetArgs([]string{"tokens", "abc123", "--json", "--agent-brief"})
 
 	err := cmd.ExecuteContext(context.Background())
 	if err == nil {
@@ -1739,6 +1918,96 @@ func TestCheckpointTokensCmd_TextOutputWithRealCheckpointShape(t *testing.T) {
 	}
 	if tokenUsageIndex > recommendationsIndex {
 		t.Fatalf("expected token usage before recommendations, got:\n%s", out)
+	}
+}
+
+func TestCheckpointTokensCmd_AgentBriefGivesOperationalBudget(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+	cpID := id.MustCheckpointID("b1efbeefcafe")
+	if err := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs()).WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "checkpoint-token-brief",
+		Strategy:     strategy.StrategyNameManualCommit,
+		Branch:       "e2e-triage-fix",
+		Agent:        testAgentClaude,
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"why is slack failing"}]}}` + "\n")),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+		TokenUsage: &agent.TokenUsage{
+			InputTokens:         94,
+			CacheCreationTokens: 122171,
+			CacheReadTokens:     6052424,
+			OutputTokens:        38956,
+			APICallCount:        70,
+		},
+	}); err != nil {
+		t.Fatalf("WriteCommitted() error = %v", err)
+	}
+
+	cmd := newCheckpointGroupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"tokens", "b1efbeef", "--agent-brief"})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	out := stdout.String()
+	checks := []string{
+		"Checkpoint token brief",
+		"Checkpoint: b1efbeefcafe",
+		"Token usage: 6213.6k total; 97.4% cache/context replay; 70 API calls.",
+		"Next best action:",
+		"Use at most 3 batched reads before answering.",
+		"Avoid broad grep, broad diffs, broad tests, and repeated token diagnostics; keep the answer tight.",
+		"Signals:",
+		"- Cache/context replay dominates token volume.",
+		"- API call count is high for one session.",
+		"- Cache write/new context pressure is elevated.",
+		"- Output pressure is elevated.",
+	}
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected %q in output, got:\n%s", check, out)
+		}
+	}
+	for _, verboseSection := range []string{"Recommendations", "Likely contributors", "Limitations"} {
+		if strings.Contains(out, verboseSection) {
+			t.Fatalf("expected agent brief to omit %s section, got:\n%s", verboseSection, out)
+		}
+	}
+}
+
+func TestCheckpointTokensCmd_AgentBriefMissingTokenData(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
+	cpID := id.MustCheckpointID("deadcafebeef")
+	writeCommittedTokenCheckpoint(ctx, t, store, cpID, "checkpoint-token-missing-brief", nil)
+
+	cmd := newCheckpointGroupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"tokens", "deadcafe", "--agent-brief"})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	out := stdout.String()
+	checks := []string{
+		"Checkpoint token brief",
+		"Checkpoint: deadcafebeef",
+		"Token usage: unavailable.",
+		"Do not spend extra commands on token optimization for this checkpoint.",
+		"- Token usage is unavailable for this session.",
+	}
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected %q in output, got:\n%s", check, out)
+		}
 	}
 }
 
@@ -2049,6 +2318,7 @@ func TestCheckpointTokensCmd_TextOutputWithComparison(t *testing.T) {
 			InputTokens:         200_000,
 			CacheCreationTokens: 50_000,
 			CacheReadTokens:     750_000,
+			OutputTokens:        10_000,
 			APICallCount:        10,
 		},
 	}); err != nil {
@@ -2065,8 +2335,9 @@ func TestCheckpointTokensCmd_TextOutputWithComparison(t *testing.T) {
 		AuthorEmail:  "test@example.com",
 		TokenUsage: &agent.TokenUsage{
 			InputTokens:         150_000,
-			CacheCreationTokens: 50_000,
+			CacheCreationTokens: 25_000,
 			CacheReadTokens:     300_000,
+			OutputTokens:        25_000,
 			APICallCount:        4,
 		},
 	}); err != nil {
@@ -2091,12 +2362,16 @@ func TestCheckpointTokensCmd_TextOutputWithComparison(t *testing.T) {
 		"Comparison",
 		"Baseline: aaa111bbb222",
 		"Caveat: Total tokens include cache/context replay; use the cache/context replay delta below before treating total direction as work saved or added.",
-		"Total tokens: down 50% (1000k -> 500k)",
+		"Total tokens: down 50.5% (1010k -> 500k)",
+		"Input: down 25% (200k -> 150k)",
 		"Cache/context replay: down 60% (750k -> 300k)",
+		"Cache write: down 50% (50k -> 25k)",
+		"Output: up 150% (10k -> 25k)",
 		"API calls: down 60% (10 -> 4)",
 		"Qualification",
 		"Observed total token use decreased for this checkpoint comparison.",
 		"This does not prove quality was preserved",
+		"Cost-proxy pressure increased for output",
 	}
 	for _, check := range checks {
 		if !strings.Contains(out, check) {
@@ -2121,10 +2396,11 @@ func TestCheckpointTokensCmd_JSONOutputWithComparison(t *testing.T) {
 		AuthorName:   "Test",
 		AuthorEmail:  "test@example.com",
 		TokenUsage: &agent.TokenUsage{
-			InputTokens:     100,
-			CacheReadTokens: 300,
-			OutputTokens:    100,
-			APICallCount:    5,
+			InputTokens:         100,
+			CacheCreationTokens: 50,
+			CacheReadTokens:     300,
+			OutputTokens:        100,
+			APICallCount:        5,
 		},
 	}); err != nil {
 		t.Fatalf("WriteCommitted() baseline error = %v", err)
@@ -2138,10 +2414,11 @@ func TestCheckpointTokensCmd_JSONOutputWithComparison(t *testing.T) {
 		AuthorName:   "Test",
 		AuthorEmail:  "test@example.com",
 		TokenUsage: &agent.TokenUsage{
-			InputTokens:     120,
-			CacheReadTokens: 480,
-			OutputTokens:    200,
-			APICallCount:    8,
+			InputTokens:         120,
+			CacheCreationTokens: 80,
+			CacheReadTokens:     480,
+			OutputTokens:        200,
+			APICallCount:        8,
 		},
 	}); err != nil {
 		t.Fatalf("WriteCommitted() current error = %v", err)
@@ -2175,11 +2452,11 @@ func TestCheckpointTokensCmd_JSONOutputWithComparison(t *testing.T) {
 	if result.Comparison.Total == nil {
 		t.Fatalf("expected total delta, got nil")
 	}
-	if result.Comparison.Total.Baseline != 500 || result.Comparison.Total.Current != 800 {
+	if result.Comparison.Total.Baseline != 550 || result.Comparison.Total.Current != 880 {
 		t.Fatalf("unexpected total delta: %+v", result.Comparison.Total)
 	}
-	if result.Comparison.Total.Change != 300 {
-		t.Fatalf("expected total change 300, got %+v", result.Comparison.Total)
+	if result.Comparison.Total.Change != 330 {
+		t.Fatalf("expected total change 330, got %+v", result.Comparison.Total)
 	}
 	if result.Comparison.Total.Direction != checkpointDeltaDirectionUp {
 		t.Fatalf("expected total direction up, got %+v", result.Comparison.Total)
@@ -2189,6 +2466,65 @@ func TestCheckpointTokensCmd_JSONOutputWithComparison(t *testing.T) {
 	}
 	if result.Comparison.CacheReadCaveat == "" {
 		t.Fatalf("expected cache read caveat, got %+v", result.Comparison)
+	}
+	if result.Comparison.Input == nil || result.Comparison.Input.Change != 20 {
+		t.Fatalf("expected input change 20, got %+v", result.Comparison.Input)
+	}
+	if result.Comparison.CacheWrite == nil || result.Comparison.CacheWrite.Change != 30 {
+		t.Fatalf("expected cache write change 30, got %+v", result.Comparison.CacheWrite)
+	}
+	if result.Comparison.Output == nil || result.Comparison.Output.Change != 100 {
+		t.Fatalf("expected output change 100, got %+v", result.Comparison.Output)
+	}
+}
+
+func TestCheckpointTokensCmd_JSONComparisonQualifiesCostProxyPressure(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
+	baselineID := id.MustCheckpointID("c0a111c0a111")
+	currentID := id.MustCheckpointID("c0a222c0a222")
+
+	writeCommittedTokenCheckpoint(ctx, t, store, baselineID, "checkpoint-token-cost-proxy-baseline", &agent.TokenUsage{
+		InputTokens:     100_000,
+		CacheReadTokens: 100_000,
+		APICallCount:    6,
+	})
+	writeCommittedTokenCheckpoint(ctx, t, store, currentID, "checkpoint-token-cost-proxy-current", &agent.TokenUsage{
+		InputTokens:         50_000,
+		CacheCreationTokens: 30_000,
+		OutputTokens:        30_000,
+		APICallCount:        4,
+	})
+
+	cmd := newCheckpointGroupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"tokens", "c0a222", "--compare", "c0a111", "--json"})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var result checkpointTokensReport
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("expected valid JSON, got parse error: %v\noutput: %s", err, stdout.String())
+	}
+	if result.Comparison == nil {
+		t.Fatalf("expected comparison, got nil")
+	}
+	if result.Comparison.Status != checkpointComparisonStatusObservedReduction {
+		t.Fatalf("expected observed reduction, got %q", result.Comparison.Status)
+	}
+	checks := []string{
+		"Cost-proxy pressure increased",
+		"cache write",
+		"output",
+	}
+	for _, check := range checks {
+		if !strings.Contains(result.Comparison.Qualification, check) {
+			t.Fatalf("expected %q in qualification, got %q", check, result.Comparison.Qualification)
+		}
 	}
 }
 

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -271,6 +271,14 @@ func writeActiveSessions(ctx context.Context, w io.Writer, sty statusStyles) {
 		return
 	}
 
+	// Finalize any ACTIVE session whose agent process has exited without a
+	// SessionStop hook firing, so it doesn't linger as "active" until the
+	// inactivity timeout. The sweep marks them ended in place, so the filter
+	// below drops them.
+	if n := finalizeExitedSessions(ctx, states); n > 0 {
+		fmt.Fprintln(w, sty.render(sty.dim, fmt.Sprintf("Finalized %d exited session(s) (agent process gone).", n)))
+	}
+
 	// Filter to active sessions only
 	var active []*session.State
 	for _, s := range states {
@@ -379,11 +387,18 @@ func writeActiveSessions(ctx context.Context, w io.Writer, sty statusStyles) {
 			}
 
 			statsLine := strings.Join(stats, sty.render(sty.dim, " · "))
-			if st.IsStuckActive() {
+			switch {
+			case st.OwnerExited():
+				// Agent process is gone but the session couldn't be finalized
+				// above (e.g. condense/transition error); flag it explicitly.
+				fmt.Fprintf(w, "%s %s %s\n", sty.render(sty.dim, statsLine),
+					sty.render(sty.dim, "·"),
+					sty.render(sty.yellow, "exited")+" (run 'entire doctor')")
+			case st.IsStuckActive():
 				fmt.Fprintf(w, "%s %s %s\n", sty.render(sty.dim, statsLine),
 					sty.render(sty.dim, "·"),
 					sty.render(sty.yellow, "stale")+" (run 'entire doctor')")
-			} else {
+			default:
 				fmt.Fprintln(w, sty.render(sty.dim, statsLine))
 			}
 			if warning := divergenceWarnings[st.SessionID]; warning != "" {
@@ -622,6 +637,10 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 
 		if store, err := session.NewStateStore(ctx); err == nil {
 			if states, err := store.List(ctx); err == nil {
+				// Finalize sessions whose agent has exited (matches the human
+				// status path) so --json doesn't leave them orphaned ACTIVE or
+				// report them under active_sessions.
+				finalizeExitedSessions(ctx, states)
 				// Deduplicate by agent: one entry per agent, "active" wins over "idle".
 				type agentEntry struct {
 					brief    sessionBriefJSON
@@ -671,6 +690,10 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 func sessionStatusLabel(s *session.State) string {
 	if s.EndedAt != nil {
 		return "ended"
+	}
+	if s.OwnerExited() {
+		// ACTIVE on disk, but the owning agent process is gone.
+		return "exited"
 	}
 	if s.Phase != "" {
 		return string(s.Phase)

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -52,7 +52,7 @@ func (s *ManualCommitStrategy) getCheckpointStores(ctx context.Context, repo *gi
 // topology. Writes target refs.Primary; reads target refs.Read. The strategy's
 // blob fetcher is wired in so reads can fetch blobs on demand after a treeless
 // fetch.
-func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git.Repository) (checkpoint.CommittedStore, error) { //nolint:ireturn // committed store capability is the abstraction boundary
+func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git.Repository) (checkpoint.CommittedStore, error) {
 	stores, err := s.getCheckpointStores(ctx, repo)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git
 
 // getTemporaryStore returns the git-backed shadow-branch store with the
 // strategy's blob fetcher wired in.
-func (s *ManualCommitStrategy) getTemporaryStore(ctx context.Context, repo *git.Repository) (checkpoint.TemporaryStore, error) { //nolint:ireturn // temporary store capability is the abstraction boundary
+func (s *ManualCommitStrategy) getTemporaryStore(ctx context.Context, repo *git.Repository) (checkpoint.TemporaryStore, error) {
 	stores, err := s.getCheckpointStores(ctx, repo)
 	if err != nil {
 		return nil, err

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -533,7 +533,7 @@ func generateSummary(ctx context.Context, redactedTranscript redact.RedactedByte
 // The return type is the summarize.Generator interface rather than the concrete
 // adapter pointer so callers can't accidentally hold a non-nil interface that
 // wraps a nil pointer (the classic Go nil-interface footgun).
-func buildSummaryGenerator(ctx context.Context) summarize.Generator { //nolint:ireturn,nolintlint // interface return is intentional for provider abstraction and nil-safety; nolintlint flagged as "unused" under some linter versions but ireturn fires in others
+func buildSummaryGenerator(ctx context.Context) summarize.Generator {
 	s, err := settings.Load(ctx)
 	if err != nil {
 		// Warn (not Debug): this is the auto-summarize hot path on every commit.

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -25,6 +25,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
@@ -2296,6 +2297,7 @@ func (s *ManualCommitStrategy) InitializeSession(ctx context.Context, sessionID 
 			state.TranscriptPath = transcriptPath
 		}
 		captureSessionBranch(repo, state)
+		captureSessionOwner(state)
 
 		// ORDERING: attribution runs BEFORE migrate to use the pre-migration
 		// BaseCommit as the base tree (preserving correct agent-line counts
@@ -2340,6 +2342,7 @@ func (s *ManualCommitStrategy) InitializeSession(ctx context.Context, sessionID 
 		promptAttr := s.calculatePromptAttributionAtStart(ctx, repo, state)
 		state.PendingPromptAttribution = &promptAttr
 		captureSessionBranch(repo, state)
+		captureSessionOwner(state)
 		return nil
 	})
 	if mutErr != nil && !errors.Is(mutErr, ErrStateNotFound) {
@@ -2367,6 +2370,26 @@ func captureSessionBranch(repo *git.Repository, state *SessionState) {
 		// falls back to deriving the branch from checkpoint trailers instead of
 		// using a stale, now-incorrect value.
 		state.Branch = ""
+	}
+}
+
+// captureSessionOwner records the owning agent process (PID + start-time
+// fingerprint) into the session state so liveness checks can later detect an
+// ACTIVE session whose agent exited without firing a SessionStop hook. The hook
+// runs as a short-lived child of the agent, so proclive.ResolveOwner walks up
+// past our own binary and any shells to the long-lived agent process.
+//
+// It is best-effort and re-run on every turn start: if the owner can't be
+// resolved (unsupported platform, transient-only ancestry) the field is cleared
+// and liveness degrades to the inactivity timeout; re-resolving each turn keeps
+// the fingerprint current across agent restarts.
+func captureSessionOwner(state *SessionState) {
+	// Clear first: a failed resolve must never leave a stale owner from an
+	// earlier turn. Otherwise a now-live session (agent restarted with a new
+	// PID) could still carry a dead PID and be wrongly finalized as exited.
+	state.Owner = nil
+	if owner, ok := proclive.ResolveOwner(); ok {
+		state.Owner = &owner
 	}
 }
 

--- a/cmd/entire/cli/strategy/owner_wiring_test.go
+++ b/cmd/entire/cli/strategy/owner_wiring_test.go
@@ -1,0 +1,34 @@
+//go:build linux || darwin
+
+package strategy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInitializeSession_CapturesOwner verifies that a turn start records the
+// owning process identity, and that the live owner reads as not-exited.
+func TestInitializeSession_CapturesOwner(t *testing.T) {
+	if _, ok := proclive.ResolveOwner(); !ok {
+		t.Skip("no stable process owner resolvable in this environment")
+	}
+
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	s := &ManualCommitStrategy{}
+	err := s.InitializeSession(context.Background(), "test-session-owner", "Claude Code", "", "", "")
+	require.NoError(t, err)
+
+	state, err := s.loadSessionState(context.Background(), "test-session-owner")
+	require.NoError(t, err)
+	require.NotNil(t, state.Owner, "InitializeSession should capture the owning process")
+	assert.Positive(t, state.Owner.PID, "captured owner PID should be positive")
+	assert.False(t, state.OwnerExited(), "a freshly-captured live owner must not read as exited")
+}

--- a/cmd/entire/cli/strategy/session_state.go
+++ b/cmd/entire/cli/strategy/session_state.go
@@ -138,20 +138,40 @@ func FindMostRecentSession(ctx context.Context) string {
 	}
 
 	// Scope to current worktree to prevent cross-worktree pollution.
-	worktreePath, wpErr := paths.WorktreeRoot(ctx)
-	if wpErr == nil && worktreePath != "" {
-		var filtered []*SessionState
-		for _, s := range states {
-			if s.WorktreePath == worktreePath {
-				filtered = append(filtered, s)
-			}
-		}
-		if len(filtered) > 0 {
-			states = filtered
-		}
-		// If no sessions match the worktree, fall back to all sessions
+	if filtered := sessionStatesForCurrentWorktree(ctx, states); len(filtered) > 0 {
+		states = filtered
+		// If no sessions match the worktree, fall back to all sessions.
 	}
 
+	return mostRecentSessionID(states)
+}
+
+// FindMostRecentSessionInCurrentWorktree returns the most recently interacted
+// session from the current worktree only. Unlike FindMostRecentSession, it does
+// not fall back to sessions from other worktrees.
+func FindMostRecentSessionInCurrentWorktree(ctx context.Context) string {
+	states, err := ListSessionStates(ctx)
+	if err != nil || len(states) == 0 {
+		return ""
+	}
+	return mostRecentSessionID(sessionStatesForCurrentWorktree(ctx, states))
+}
+
+func sessionStatesForCurrentWorktree(ctx context.Context, states []*SessionState) []*SessionState {
+	worktreePath, err := paths.WorktreeRoot(ctx)
+	if err != nil || worktreePath == "" {
+		return nil
+	}
+	filtered := make([]*SessionState, 0, len(states))
+	for _, s := range states {
+		if s.WorktreePath == worktreePath {
+			filtered = append(filtered, s)
+		}
+	}
+	return filtered
+}
+
+func mostRecentSessionID(states []*SessionState) string {
 	var best *SessionState
 	for _, s := range states {
 		if s.LastInteractionTime == nil {

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -210,14 +210,7 @@ func tokensProfileCheckpointUsage(ctx context.Context, store *checkpoint.GitStor
 		}
 		metas = append(metas, meta)
 	}
-	sessionUsage := aggregateCheckpointTokenUsage(metas)
-	if !metadataReadWarning && sessionUsage != nil {
-		return sessionUsage, false, nil
-	}
-	if summary.TokenUsage != nil {
-		return summary.TokenUsage, metadataReadWarning, nil
-	}
-	return sessionUsage, metadataReadWarning, nil
+	return checkpointTokenUsage(summary, metas, metadataReadWarning), metadataReadWarning, nil
 }
 
 func addTokensProfileTokenSignals(signals map[string]*tokensProfileSignal, checkpointID id.CheckpointID, tokens *sessionTokensUsage, denominator int) {

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -355,10 +355,10 @@ func tokensProfileLimitations(report tokensProfileReport) []string {
 		limitations = append(limitations, "No committed checkpoints found.")
 	}
 	if report.MissingTokenData > 0 {
-		limitations = append(limitations, fmt.Sprintf("%d checkpoint%s did not include token usage.", report.MissingTokenData, pluralSuffix(report.MissingTokenData)))
+		limitations = append(limitations, fmt.Sprintf("%d checkpoint%s did not include token usage.", report.MissingTokenData, tokenPluralSuffix(report.MissingTokenData)))
 	}
 	if report.MetadataReadWarnings > 0 {
-		limitations = append(limitations, fmt.Sprintf("%d checkpoint%s had incomplete session metadata; profile used root token summaries or readable sessions where available.", report.MetadataReadWarnings, pluralSuffix(report.MetadataReadWarnings)))
+		limitations = append(limitations, fmt.Sprintf("%d checkpoint%s had incomplete session metadata; profile used root token summaries or readable sessions where available.", report.MetadataReadWarnings, tokenPluralSuffix(report.MetadataReadWarnings)))
 	}
 	if report.Tokens != nil {
 		limitations = append(limitations, "Token totals are summed from analyzed checkpoints and may include overlapping checkpoint history; treat them as checkpoint-observed volume, not guaranteed unique session spend.")
@@ -406,17 +406,10 @@ func writeTokensProfileSignals(w io.Writer, signals []tokensProfileSignal) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Repeated signals")
 	for _, signal := range signals {
-		fmt.Fprintf(w, "- %s: %d checkpoint%s", signal.Label, signal.Count, pluralSuffix(signal.Count))
+		fmt.Fprintf(w, "- %s: %d checkpoint%s", signal.Label, signal.Count, tokenPluralSuffix(signal.Count))
 		if signal.Percent > 0 {
 			fmt.Fprintf(w, " (%d%%)", signal.Percent)
 		}
 		fmt.Fprintln(w)
 	}
-}
-
-func pluralSuffix(count int) string {
-	if count == 1 {
-		return ""
-	}
-	return "s"
 }

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -51,8 +51,9 @@ const tokensProfileUsageScopeCheckpointObserved = "checkpoint_observed"
 
 func newTokensGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tokens",
-		Short: "Analyze token usage across sessions and checkpoints",
+		Use:    "tokens",
+		Short:  "Analyze token usage across sessions and checkpoints",
+		Hidden: true,
 		Long: `Analyze token usage across sessions and checkpoints.
 
 Commands:

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -109,7 +109,7 @@ func runTokensProfile(ctx context.Context, cmd *cobra.Command, jsonOutput bool, 
 	}
 	defer repo.Close()
 
-	store := checkpoint.NewCommittedReadStore(ctx, repo)
+	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
 	store.SetBlobFetcher(FetchBlobsByHash)
 	infos, err := store.ListCommitted(ctx)
 	if err != nil {

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -96,6 +96,7 @@ checkpoints; use --limit or --all to change the scope.`,
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON")
 	cmd.Flags().IntVar(&limitFlag, "limit", 50, "Maximum committed checkpoints to analyze")
 	cmd.Flags().BoolVar(&allFlag, "all", false, "Analyze all committed checkpoints")
+	cmd.MarkFlagsMutuallyExclusive("limit", "all")
 	return cmd
 }
 
@@ -109,6 +110,7 @@ func runTokensProfile(ctx context.Context, cmd *cobra.Command, jsonOutput bool, 
 	defer repo.Close()
 
 	store := checkpoint.NewCommittedReadStore(ctx, repo)
+	store.SetBlobFetcher(FetchBlobsByHash)
 	infos, err := store.ListCommitted(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list checkpoints: %w", err)

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -230,7 +230,7 @@ func addTokensProfileTokenSignals(signals map[string]*tokensProfileSignal, check
 	if tokens.APICalls >= 20 {
 		addTokensProfileSignal(signals, "api-call-amplification", checkpointID, denominator)
 	}
-	if tokens.Total > 0 && tokens.SubagentTotal*100 >= tokens.Total*10 {
+	if tokenShareAtLeastOneTenth(tokens.SubagentTotal, tokens.Total) {
 		addTokensProfileSignal(signals, "subagent-heavy", checkpointID, denominator)
 	}
 }

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -217,7 +217,8 @@ func addTokensProfileTokenSignals(signals map[string]*tokensProfileSignal, check
 	if tokens == nil {
 		return
 	}
-	if tokens.Total > 0 && tokenPercent(tokens.CacheRead, tokens.Total) >= 80 {
+	topLevelTotal := topLevelSessionTokenTotal(tokens)
+	if topLevelTotal > 0 && tokenPercent(tokens.CacheRead, topLevelTotal) >= recommendationHighCacheReadPercent {
 		addTokensProfileSignal(signals, "context-replay-hotspot", checkpointID, denominator)
 	}
 	if tokens.APICalls >= 20 {

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -1,0 +1,413 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/spf13/cobra"
+)
+
+type tokensProfileReport struct {
+	Source                   string                        `json:"source"`
+	CheckpointsAvailable     int                           `json:"checkpoints_available"`
+	CheckpointsAnalyzed      int                           `json:"checkpoints_analyzed"`
+	CheckpointsWithTokenData int                           `json:"checkpoints_with_token_data"`
+	MissingTokenData         int                           `json:"missing_token_data"`
+	MetadataReadWarnings     int                           `json:"metadata_read_warnings,omitempty"`
+	Tokens                   *sessionTokensUsage           `json:"tokens,omitempty"`
+	Signals                  []tokensProfileSignal         `json:"signals,omitempty"`
+	Recommendations          []sessionTokensRecommendation `json:"recommendations,omitempty"`
+	Limitations              []string                      `json:"limitations,omitempty"`
+}
+
+type tokensProfileSignal struct {
+	ID            string   `json:"id"`
+	Label         string   `json:"label"`
+	Count         int      `json:"count"`
+	Percent       int      `json:"percent"`
+	CheckpointIDs []string `json:"checkpoint_ids,omitempty"`
+}
+
+type tokensProfileSignalDefinition struct {
+	id    string
+	label string
+}
+
+var tokensProfileSignalDefinitions = []tokensProfileSignalDefinition{
+	{id: "context-replay-hotspot", label: "Cache/context replay hotspot"},
+	{id: "api-call-amplification", label: "API call amplification"},
+	{id: "subagent-heavy", label: "Subagent-heavy sessions"},
+	{id: "missing-token-data", label: "Missing token data"},
+}
+
+func newTokensGroupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tokens",
+		Short: "Analyze token usage across sessions and checkpoints",
+		Long: `Analyze token usage across sessions and checkpoints.
+
+Commands:
+  profile  Aggregate token usage across committed checkpoints
+
+Examples:
+  entire tokens profile
+  entire tokens profile --json`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newTokensProfileCmd())
+	return cmd
+}
+
+func newTokensProfileCmd() *cobra.Command {
+	var jsonFlag bool
+	var limitFlag int
+	var allFlag bool
+
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Aggregate token usage and recommendations across checkpoint history",
+		Long: `Aggregate token usage and recommendations across committed checkpoint history.
+
+The profile reads committed checkpoint metadata only. It does not inspect
+transcripts or source files, so it is deterministic and avoids adding token
+cost while diagnosing token usage. By default it scans the latest 50 committed
+checkpoints; use --limit or --all to change the scope.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			limit := limitFlag
+			if allFlag {
+				limit = 0
+			} else if limit <= 0 {
+				return errors.New("--limit must be positive unless --all is used")
+			}
+			return runTokensProfile(cmd.Context(), cmd, jsonFlag, limit)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output as JSON")
+	cmd.Flags().IntVar(&limitFlag, "limit", 50, "Maximum committed checkpoints to analyze")
+	cmd.Flags().BoolVar(&allFlag, "all", false, "Analyze all committed checkpoints")
+	return cmd
+}
+
+func runTokensProfile(ctx context.Context, cmd *cobra.Command, jsonOutput bool, limit int) error {
+	repo, err := openRepository(ctx)
+	if err != nil {
+		cmd.SilenceUsage = true
+		fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository.")
+		return NewSilentError(err)
+	}
+	defer repo.Close()
+
+	store := checkpoint.NewCommittedReadStore(ctx, repo)
+	infos, err := store.ListCommitted(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list checkpoints: %w", err)
+	}
+
+	report, err := buildTokensProfileReport(ctx, store, infos, limit)
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		return writeTokensProfileJSON(cmd.OutOrStdout(), report)
+	}
+	writeTokensProfileText(cmd.OutOrStdout(), report)
+	return nil
+}
+
+func buildTokensProfileReport(ctx context.Context, store *checkpoint.GitStore, infos []checkpoint.CommittedInfo, limit int) (tokensProfileReport, error) {
+	checkpointsAvailable := len(infos)
+	infos = limitTokensProfileCheckpoints(infos, limit)
+	report := tokensProfileReport{
+		Source:               "committed_checkpoints",
+		CheckpointsAvailable: checkpointsAvailable,
+		CheckpointsAnalyzed:  len(infos),
+	}
+	signals := make(map[string]*tokensProfileSignal, len(tokensProfileSignalDefinitions))
+	var aggregate *agent.TokenUsage
+
+	for _, info := range infos {
+		if err := ctx.Err(); err != nil {
+			return tokensProfileReport{}, err //nolint:wrapcheck // Propagating context cancellation.
+		}
+
+		summary, err := store.ReadCommitted(ctx, info.CheckpointID)
+		if err != nil {
+			return tokensProfileReport{}, fmt.Errorf("failed to read checkpoint %s: %w", info.CheckpointID, err)
+		}
+		if summary == nil {
+			report.MissingTokenData++
+			addTokensProfileSignal(signals, "missing-token-data", info.CheckpointID, report.CheckpointsAnalyzed)
+			continue
+		}
+
+		usage, metadataReadWarning, err := tokensProfileCheckpointUsage(ctx, store, info.CheckpointID, summary)
+		if err != nil {
+			return tokensProfileReport{}, err
+		}
+		if metadataReadWarning {
+			report.MetadataReadWarnings++
+		}
+		tokens := buildSessionTokensUsage(usage)
+		if tokens == nil {
+			report.MissingTokenData++
+			addTokensProfileSignal(signals, "missing-token-data", info.CheckpointID, report.CheckpointsAnalyzed)
+			continue
+		}
+
+		report.CheckpointsWithTokenData++
+		aggregate = addCheckpointTokenUsage(aggregate, usage)
+		addTokensProfileTokenSignals(signals, info.CheckpointID, tokens, report.CheckpointsAnalyzed)
+	}
+
+	report.Tokens = buildSessionTokensUsage(aggregate)
+	report.Signals = orderedTokensProfileSignals(signals)
+	report.Recommendations = tokensProfileRecommendations(report)
+	report.Limitations = tokensProfileLimitations(report)
+	return report, nil
+}
+
+func limitTokensProfileCheckpoints(infos []checkpoint.CommittedInfo, limit int) []checkpoint.CommittedInfo {
+	if limit <= 0 || len(infos) <= limit {
+		return infos
+	}
+	return infos[:limit]
+}
+
+func tokensProfileCheckpointUsage(ctx context.Context, store *checkpoint.GitStore, checkpointID id.CheckpointID, summary *checkpoint.CheckpointSummary) (*agent.TokenUsage, bool, error) {
+	if summary == nil {
+		return nil, false, nil
+	}
+
+	metas := make([]*checkpoint.CommittedMetadata, 0, len(summary.Sessions))
+	metadataReadWarning := false
+	for i := range len(summary.Sessions) {
+		meta, err := store.ReadSessionMetadata(ctx, checkpointID, i)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, false, ctxErr //nolint:wrapcheck // Propagating context cancellation.
+			}
+			metadataReadWarning = true
+			continue
+		}
+		metas = append(metas, meta)
+	}
+	sessionUsage := aggregateCheckpointTokenUsage(metas)
+	if !metadataReadWarning && sessionUsage != nil {
+		return sessionUsage, false, nil
+	}
+	if summary.TokenUsage != nil {
+		return summary.TokenUsage, metadataReadWarning, nil
+	}
+	return sessionUsage, metadataReadWarning, nil
+}
+
+func addTokensProfileTokenSignals(signals map[string]*tokensProfileSignal, checkpointID id.CheckpointID, tokens *sessionTokensUsage, denominator int) {
+	if tokens == nil {
+		return
+	}
+	if tokens.Total > 0 && tokenPercent(tokens.CacheRead, tokens.Total) >= 80 {
+		addTokensProfileSignal(signals, "context-replay-hotspot", checkpointID, denominator)
+	}
+	if tokens.APICalls >= 20 {
+		addTokensProfileSignal(signals, "api-call-amplification", checkpointID, denominator)
+	}
+	if tokens.Total > 0 && tokens.SubagentTotal*100 >= tokens.Total*10 {
+		addTokensProfileSignal(signals, "subagent-heavy", checkpointID, denominator)
+	}
+}
+
+func addTokensProfileSignal(signals map[string]*tokensProfileSignal, signalID string, checkpointID id.CheckpointID, denominator int) {
+	signal := signals[signalID]
+	if signal == nil {
+		definition := tokensProfileSignalDefinitionFor(signalID)
+		signal = &tokensProfileSignal{
+			ID:    definition.id,
+			Label: definition.label,
+		}
+		signals[signalID] = signal
+	}
+	signal.Count++
+	if denominator > 0 {
+		signal.Percent = roundedPercent(signal.Count, denominator)
+	}
+	if checkpointID != "" {
+		signal.CheckpointIDs = append(signal.CheckpointIDs, checkpointID.String())
+	}
+}
+
+func tokensProfileSignalDefinitionFor(signalID string) tokensProfileSignalDefinition {
+	for _, definition := range tokensProfileSignalDefinitions {
+		if definition.id == signalID {
+			return definition
+		}
+	}
+	return tokensProfileSignalDefinition{id: signalID, label: signalID}
+}
+
+func orderedTokensProfileSignals(signals map[string]*tokensProfileSignal) []tokensProfileSignal {
+	ordered := make([]tokensProfileSignal, 0, len(signals))
+	for _, definition := range tokensProfileSignalDefinitions {
+		if signal := signals[definition.id]; signal != nil {
+			ordered = append(ordered, *signal)
+		}
+	}
+	return ordered
+}
+
+func tokensProfileRecommendations(report tokensProfileReport) []sessionTokensRecommendation {
+	var recs []sessionTokensRecommendation
+
+	if report.CheckpointsAnalyzed == 0 {
+		return []sessionTokensRecommendation{{
+			ID:       "no-checkpoints",
+			Severity: "low",
+			Message:  "Create checkpoints first; token profiling needs committed checkpoint metadata to identify patterns.",
+			Signals:  []string{"empty_checkpoint_history"},
+		}}
+	}
+
+	if tokensProfileSignalCount(report.Signals, "context-replay-hotspot") > 0 ||
+		tokensProfileSignalCount(report.Signals, "api-call-amplification") > 0 {
+		recs = append(recs, sessionTokensRecommendation{
+			ID:       "search-before-reinvestigation",
+			Severity: "high",
+			Message:  "Use `entire search` for prior decisions/checkpoints before broad re-investigation.",
+			Signals:  []string{"cache_read_tokens", "api_call_count"},
+		})
+	}
+	if tokensProfileSignalCount(report.Signals, "api-call-amplification") > 0 {
+		recs = append(recs, sessionTokensRecommendation{
+			ID:       "batch-diagnostics",
+			Severity: "medium",
+			Message:  "Batch diagnostic reads around one narrowed hypothesis when API call amplification repeats.",
+			Signals:  []string{"api_call_count"},
+		})
+	}
+	if tokensProfileSignalCount(report.Signals, "context-replay-hotspot") > 0 {
+		recs = append(recs, sessionTokensRecommendation{
+			ID:       "preserve-then-compact",
+			Severity: "medium",
+			Message:  "Summarize useful findings before continuing large-context work; compact or restart only after preserving relevant context.",
+			Signals:  []string{"cache_read_tokens"},
+		})
+	}
+	if tokensProfileSignalCount(report.Signals, "subagent-heavy") > 0 {
+		recs = append(recs, sessionTokensRecommendation{
+			ID:       "scope-subagents",
+			Severity: "medium",
+			Message:  "Scope subagent tasks tightly with a narrow objective and expected output.",
+			Signals:  []string{"subagent_tokens"},
+		})
+	}
+	if report.MissingTokenData > 0 {
+		recs = append(recs, sessionTokensRecommendation{
+			ID:       "improve-token-coverage",
+			Severity: "low",
+			Message:  "Increase token coverage by using agents and checkpoints that report token usage.",
+			Signals:  []string{"missing_token_usage"},
+		})
+	}
+
+	if len(recs) == 0 {
+		recs = append(recs, sessionTokensRecommendation{
+			ID:       "no-repeated-hotspots",
+			Severity: "low",
+			Message:  "No repeated token hotspots were visible in committed checkpoint metadata.",
+			Signals:  []string{"checkpoint_token_metadata"},
+		})
+	}
+	return recs
+}
+
+func tokensProfileSignalCount(signals []tokensProfileSignal, signalID string) int {
+	for _, signal := range signals {
+		if signal.ID == signalID {
+			return signal.Count
+		}
+	}
+	return 0
+}
+
+func tokensProfileLimitations(report tokensProfileReport) []string {
+	var limitations []string
+	if report.CheckpointsAvailable > report.CheckpointsAnalyzed {
+		limitations = append(limitations, fmt.Sprintf("Limited to latest %d of %d committed checkpoints; use --limit or --all to change scope.", report.CheckpointsAnalyzed, report.CheckpointsAvailable))
+	}
+	if report.CheckpointsAnalyzed == 0 {
+		limitations = append(limitations, "No committed checkpoints found.")
+	}
+	if report.MissingTokenData > 0 {
+		limitations = append(limitations, fmt.Sprintf("%d checkpoint%s did not include token usage.", report.MissingTokenData, pluralSuffix(report.MissingTokenData)))
+	}
+	if report.MetadataReadWarnings > 0 {
+		limitations = append(limitations, fmt.Sprintf("%d checkpoint%s had incomplete session metadata; profile used root token summaries or readable sessions where available.", report.MetadataReadWarnings, pluralSuffix(report.MetadataReadWarnings)))
+	}
+	if report.CheckpointsAnalyzed > 0 {
+		limitations = append(limitations, "Tool-level search/read spend is not captured yet; this profile infers patterns from token totals, cache/context replay, API call counts, and subagent totals.")
+	}
+	return limitations
+}
+
+func writeTokensProfileJSON(w io.Writer, report tokensProfileReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(report); err != nil {
+		return fmt.Errorf("failed to encode token profile report: %w", err)
+	}
+	return nil
+}
+
+func writeTokensProfileText(w io.Writer, report tokensProfileReport) {
+	fmt.Fprintln(w, "Token profile")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Source:               %s\n", report.Source)
+	fmt.Fprintf(w, "Checkpoints available: %d\n", report.CheckpointsAvailable)
+	fmt.Fprintf(w, "Checkpoints analyzed: %d\n", report.CheckpointsAnalyzed)
+	fmt.Fprintf(w, "With token data:      %d\n", report.CheckpointsWithTokenData)
+	fmt.Fprintf(w, "Missing token data:   %d\n", report.MissingTokenData)
+	if report.MetadataReadWarnings > 0 {
+		fmt.Fprintf(w, "Metadata warnings:    %d\n", report.MetadataReadWarnings)
+	}
+
+	writeTokenUsageSection(w, report.Tokens)
+	writeTokensProfileSignals(w, report.Signals)
+	if len(report.Recommendations) > 0 {
+		writeTokenRecommendations(w, report.Recommendations)
+	}
+	writeTokenLimitations(w, report.Limitations)
+}
+
+func writeTokensProfileSignals(w io.Writer, signals []tokensProfileSignal) {
+	if len(signals) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Repeated signals")
+	for _, signal := range signals {
+		fmt.Fprintf(w, "- %s: %d checkpoint%s", signal.Label, signal.Count, pluralSuffix(signal.Count))
+		if signal.Percent > 0 {
+			fmt.Fprintf(w, " (%d%%)", signal.Percent)
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -15,6 +15,7 @@ import (
 
 type tokensProfileReport struct {
 	Source                   string                        `json:"source"`
+	UsageScope               string                        `json:"usage_scope"`
 	CheckpointsAvailable     int                           `json:"checkpoints_available"`
 	CheckpointsAnalyzed      int                           `json:"checkpoints_analyzed"`
 	CheckpointsWithTokenData int                           `json:"checkpoints_with_token_data"`
@@ -45,6 +46,8 @@ var tokensProfileSignalDefinitions = []tokensProfileSignalDefinition{
 	{id: "subagent-heavy", label: "Subagent-heavy sessions"},
 	{id: "missing-token-data", label: "Missing token data"},
 }
+
+const tokensProfileUsageScopeCheckpointObserved = "checkpoint_observed"
 
 func newTokensGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -133,6 +136,7 @@ func buildTokensProfileReport(ctx context.Context, store *checkpoint.GitStore, i
 	infos = limitTokensProfileCheckpoints(infos, limit)
 	report := tokensProfileReport{
 		Source:               "committed_checkpoints",
+		UsageScope:           tokensProfileUsageScopeCheckpointObserved,
 		CheckpointsAvailable: checkpointsAvailable,
 		CheckpointsAnalyzed:  len(infos),
 	}
@@ -356,6 +360,9 @@ func tokensProfileLimitations(report tokensProfileReport) []string {
 	if report.MetadataReadWarnings > 0 {
 		limitations = append(limitations, fmt.Sprintf("%d checkpoint%s had incomplete session metadata; profile used root token summaries or readable sessions where available.", report.MetadataReadWarnings, pluralSuffix(report.MetadataReadWarnings)))
 	}
+	if report.Tokens != nil {
+		limitations = append(limitations, "Token totals are summed from analyzed checkpoints and may include overlapping checkpoint history; treat them as checkpoint-observed volume, not guaranteed unique session spend.")
+	}
 	if report.CheckpointsAnalyzed > 0 {
 		limitations = append(limitations, "Tool-level search/read spend is not captured yet; this profile infers patterns from token totals, cache/context replay, API call counts, and subagent totals.")
 	}
@@ -383,7 +390,7 @@ func writeTokensProfileText(w io.Writer, report tokensProfileReport) {
 		fmt.Fprintf(w, "Metadata warnings:    %d\n", report.MetadataReadWarnings)
 	}
 
-	writeTokenUsageSection(w, report.Tokens)
+	writeTokenUsageSectionWithTitle(w, "Checkpoint-observed token usage", report.Tokens)
 	writeTokensProfileSignals(w, report.Signals)
 	if len(report.Recommendations) > 0 {
 		writeTokenRecommendations(w, report.Recommendations)

--- a/cmd/entire/cli/tokens_profile_test.go
+++ b/cmd/entire/cli/tokens_profile_test.go
@@ -17,7 +17,7 @@ import (
 func TestTokensProfileCmd_TextOutputAggregatesCommittedCheckpoints(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()
-	store := checkpoint.NewGitStore(repo)
+	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
 
 	writeProfileTokenCheckpoint(ctx, t, store, "100aaa000001", "profile-cache-hotspot", &agent.TokenUsage{
 		InputTokens:         100,
@@ -87,7 +87,7 @@ func TestTokensProfileCmd_TextOutputAggregatesCommittedCheckpoints(t *testing.T)
 func TestTokensProfileCmd_JSONOutput(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()
-	store := checkpoint.NewGitStore(repo)
+	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
 
 	writeProfileTokenCheckpoint(ctx, t, store, "200bbb000001", "profile-json-cache", &agent.TokenUsage{
 		InputTokens:     100,
@@ -133,10 +133,46 @@ func TestTokensProfileCmd_JSONOutput(t *testing.T) {
 	}
 }
 
+func TestTokensProfileCmd_JSONOutputReportsAPICallOnlyCheckpoints(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
+
+	writeProfileTokenCheckpoint(ctx, t, store, "250bbb000001", "profile-json-api-only", &agent.TokenUsage{
+		APICallCount: 25,
+	})
+
+	cmd := newTokensGroupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"profile", "--json"})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var result tokensProfileReport
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("expected valid JSON, got parse error: %v\noutput: %s", err, stdout.String())
+	}
+	if result.CheckpointsWithTokenData != 1 {
+		t.Fatalf("checkpoints_with_token_data = %d, want 1", result.CheckpointsWithTokenData)
+	}
+	if result.MissingTokenData != 0 {
+		t.Fatalf("missing_token_data = %d, want 0", result.MissingTokenData)
+	}
+	if result.Tokens == nil || result.Tokens.Total != 0 || result.Tokens.APICalls != 25 {
+		t.Fatalf("unexpected token usage: %+v", result.Tokens)
+	}
+	if got := signalCount(result.Signals, "api-call-amplification"); got != 1 {
+		t.Fatalf("api-call-amplification signal count = %d, want 1", got)
+	}
+}
+
 func TestTokensProfileCmd_LimitScopesAnalyzedCheckpoints(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()
-	store := checkpoint.NewGitStore(repo)
+	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
 
 	writeProfileTokenCheckpoint(ctx, t, store, "300ccc000001", "profile-limit-one", &agent.TokenUsage{
 		InputTokens:  100,

--- a/cmd/entire/cli/tokens_profile_test.go
+++ b/cmd/entire/cli/tokens_profile_test.go
@@ -177,6 +177,21 @@ func TestTokensProfileCmd_LimitScopesAnalyzedCheckpoints(t *testing.T) {
 	}
 }
 
+func TestTokensProfileCmd_LimitAndAllAreMutuallyExclusive(t *testing.T) {
+	runExplainAutoTestRepo(t)
+
+	cmd := newTokensGroupCmd()
+	cmd.SetArgs([]string{"profile", "--limit", "2", "--all"})
+
+	err := cmd.ExecuteContext(context.Background())
+	if err == nil {
+		t.Fatal("expected error for --limit with --all")
+	}
+	if !strings.Contains(err.Error(), "limit") || !strings.Contains(err.Error(), "all") {
+		t.Fatalf("expected error to mention limit and all, got: %v", err)
+	}
+}
+
 func TestTokensProfileCmd_EmptyHistory(t *testing.T) {
 	runExplainAutoTestRepo(t)
 

--- a/cmd/entire/cli/tokens_profile_test.go
+++ b/cmd/entire/cli/tokens_profile_test.go
@@ -14,6 +14,21 @@ import (
 	"github.com/entireio/cli/redact"
 )
 
+func TestAddTokensProfileTokenSignalsSubagentHeavyAvoidsOverflow(t *testing.T) {
+	t.Parallel()
+
+	maxInt := int(^uint(0) >> 1)
+	signals := map[string]*tokensProfileSignal{}
+	addTokensProfileTokenSignals(signals, id.MustCheckpointID("999aaa000001"), &sessionTokensUsage{
+		Total:         maxInt,
+		SubagentTotal: maxInt,
+	}, 1)
+
+	if signals["subagent-heavy"] == nil {
+		t.Fatalf("expected subagent-heavy signal, got %+v", signals)
+	}
+}
+
 func TestTokensProfileCmd_TextOutputAggregatesCommittedCheckpoints(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()

--- a/cmd/entire/cli/tokens_profile_test.go
+++ b/cmd/entire/cli/tokens_profile_test.go
@@ -29,6 +29,25 @@ func TestAddTokensProfileTokenSignalsSubagentHeavyAvoidsOverflow(t *testing.T) {
 	}
 }
 
+func TestAddTokensProfileTokenSignalsCacheReplayUsesTopLevelTokenTotal(t *testing.T) {
+	t.Parallel()
+
+	signals := map[string]*tokensProfileSignal{}
+	addTokensProfileTokenSignals(signals, id.MustCheckpointID("999aaa000002"), &sessionTokensUsage{
+		Total:         10000,
+		Input:         100,
+		CacheRead:     800,
+		CacheWrite:    50,
+		Output:        50,
+		APICalls:      20,
+		SubagentTotal: 9000,
+	}, 1)
+
+	if signals["context-replay-hotspot"] == nil {
+		t.Fatalf("expected context-replay-hotspot signal, got %+v", signals)
+	}
+}
+
 func TestTokensProfileCmd_TextOutputAggregatesCommittedCheckpoints(t *testing.T) {
 	repo, _ := runExplainAutoTestRepo(t)
 	ctx := context.Background()

--- a/cmd/entire/cli/tokens_profile_test.go
+++ b/cmd/entire/cli/tokens_profile_test.go
@@ -55,7 +55,7 @@ func TestTokensProfileCmd_TextOutputAggregatesCommittedCheckpoints(t *testing.T)
 		"Checkpoints analyzed: 4",
 		"With token data:      3",
 		"Missing token data:   1",
-		"Token usage",
+		"Checkpoint-observed token usage",
 		"Total:  3.5k tokens",
 		"Cache read: 800",
 		"API calls: 33",
@@ -66,6 +66,7 @@ func TestTokensProfileCmd_TextOutputAggregatesCommittedCheckpoints(t *testing.T)
 		"Missing token data: 1 checkpoint",
 		"Recommendations",
 		"Use `entire search` for prior decisions/checkpoints before broad re-investigation.",
+		"Token totals are summed from analyzed checkpoints and may include overlapping checkpoint history",
 		"Tool-level search/read spend is not captured yet",
 	}
 	for _, check := range checks {
@@ -74,7 +75,7 @@ func TestTokensProfileCmd_TextOutputAggregatesCommittedCheckpoints(t *testing.T)
 		}
 	}
 
-	tokenUsageIndex := strings.Index(out, "Token usage")
+	tokenUsageIndex := strings.Index(out, "Checkpoint-observed token usage")
 	recommendationsIndex := strings.Index(out, "Recommendations")
 	if tokenUsageIndex == -1 || recommendationsIndex == -1 {
 		t.Fatalf("expected token usage and recommendations sections, got:\n%s", out)
@@ -112,6 +113,13 @@ func TestTokensProfileCmd_JSONOutput(t *testing.T) {
 	var result tokensProfileReport
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("expected valid JSON, got parse error: %v\noutput: %s", err, stdout.String())
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		t.Fatalf("expected valid JSON object, got parse error: %v\noutput: %s", err, stdout.String())
+	}
+	if raw["usage_scope"] != "checkpoint_observed" {
+		t.Fatalf("usage_scope = %v, want checkpoint_observed", raw["usage_scope"])
 	}
 	if result.CheckpointsAnalyzed != 2 {
 		t.Fatalf("checkpoints_analyzed = %d, want 2", result.CheckpointsAnalyzed)

--- a/cmd/entire/cli/tokens_profile_test.go
+++ b/cmd/entire/cli/tokens_profile_test.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/redact"
+)
+
+func TestTokensProfileCmd_TextOutputAggregatesCommittedCheckpoints(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+	store := checkpoint.NewGitStore(repo)
+
+	writeProfileTokenCheckpoint(ctx, t, store, "100aaa000001", "profile-cache-hotspot", &agent.TokenUsage{
+		InputTokens:         100,
+		CacheCreationTokens: 100,
+		CacheReadTokens:     800,
+		APICallCount:        5,
+	})
+	writeProfileTokenCheckpoint(ctx, t, store, "100aaa000002", "profile-api-heavy", &agent.TokenUsage{
+		InputTokens:  400,
+		OutputTokens: 100,
+		APICallCount: 25,
+	})
+	writeProfileTokenCheckpoint(ctx, t, store, "100aaa000003", "profile-subagent-heavy", &agent.TokenUsage{
+		InputTokens:  500,
+		OutputTokens: 500,
+		APICallCount: 3,
+		SubagentTokens: &agent.TokenUsage{
+			InputTokens: 1_000,
+		},
+	})
+	writeProfileTokenCheckpoint(ctx, t, store, "100aaa000004", "profile-missing", nil)
+
+	cmd := newTokensGroupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"profile"})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	out := stdout.String()
+	checks := []string{
+		"Token profile",
+		"Checkpoints analyzed: 4",
+		"With token data:      3",
+		"Missing token data:   1",
+		"Token usage",
+		"Total:  3.5k tokens",
+		"Cache read: 800",
+		"API calls: 33",
+		"Repeated signals",
+		"Cache/context replay hotspot: 1 checkpoint",
+		"API call amplification: 1 checkpoint",
+		"Subagent-heavy sessions: 1 checkpoint",
+		"Missing token data: 1 checkpoint",
+		"Recommendations",
+		"Use `entire search` for prior decisions/checkpoints before broad re-investigation.",
+		"Tool-level search/read spend is not captured yet",
+	}
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected %q in output, got:\n%s", check, out)
+		}
+	}
+
+	tokenUsageIndex := strings.Index(out, "Token usage")
+	recommendationsIndex := strings.Index(out, "Recommendations")
+	if tokenUsageIndex == -1 || recommendationsIndex == -1 {
+		t.Fatalf("expected token usage and recommendations sections, got:\n%s", out)
+	}
+	if tokenUsageIndex > recommendationsIndex {
+		t.Fatalf("expected token usage before recommendations, got:\n%s", out)
+	}
+}
+
+func TestTokensProfileCmd_JSONOutput(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+	store := checkpoint.NewGitStore(repo)
+
+	writeProfileTokenCheckpoint(ctx, t, store, "200bbb000001", "profile-json-cache", &agent.TokenUsage{
+		InputTokens:     100,
+		CacheReadTokens: 900,
+		APICallCount:    2,
+	})
+	writeProfileTokenCheckpoint(ctx, t, store, "200bbb000002", "profile-json-api", &agent.TokenUsage{
+		InputTokens:  200,
+		OutputTokens: 100,
+		APICallCount: 22,
+	})
+
+	cmd := newTokensGroupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"profile", "--json"})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var result tokensProfileReport
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("expected valid JSON, got parse error: %v\noutput: %s", err, stdout.String())
+	}
+	if result.CheckpointsAnalyzed != 2 {
+		t.Fatalf("checkpoints_analyzed = %d, want 2", result.CheckpointsAnalyzed)
+	}
+	if result.CheckpointsWithTokenData != 2 {
+		t.Fatalf("checkpoints_with_token_data = %d, want 2", result.CheckpointsWithTokenData)
+	}
+	if result.Tokens == nil || result.Tokens.Total != 1300 {
+		t.Fatalf("unexpected token total: %+v", result.Tokens)
+	}
+	if got := signalCount(result.Signals, "context-replay-hotspot"); got != 1 {
+		t.Fatalf("context-replay-hotspot signal count = %d, want 1", got)
+	}
+	if got := signalCount(result.Signals, "api-call-amplification"); got != 1 {
+		t.Fatalf("api-call-amplification signal count = %d, want 1", got)
+	}
+	if len(result.Recommendations) == 0 {
+		t.Fatalf("expected recommendations, got none")
+	}
+}
+
+func TestTokensProfileCmd_LimitScopesAnalyzedCheckpoints(t *testing.T) {
+	repo, _ := runExplainAutoTestRepo(t)
+	ctx := context.Background()
+	store := checkpoint.NewGitStore(repo)
+
+	writeProfileTokenCheckpoint(ctx, t, store, "300ccc000001", "profile-limit-one", &agent.TokenUsage{
+		InputTokens:  100,
+		OutputTokens: 100,
+		APICallCount: 1,
+	})
+	writeProfileTokenCheckpoint(ctx, t, store, "300ccc000002", "profile-limit-two", &agent.TokenUsage{
+		InputTokens:  100,
+		OutputTokens: 100,
+		APICallCount: 1,
+	})
+	writeProfileTokenCheckpoint(ctx, t, store, "300ccc000003", "profile-limit-three", &agent.TokenUsage{
+		InputTokens:  100,
+		OutputTokens: 100,
+		APICallCount: 1,
+	})
+
+	cmd := newTokensGroupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"profile", "--limit", "2"})
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	out := stdout.String()
+	checks := []string{
+		"Checkpoints available: 3",
+		"Checkpoints analyzed: 2",
+		"Total:  400 tokens",
+		"Limited to latest 2 of 3 committed checkpoints",
+	}
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected %q in output, got:\n%s", check, out)
+		}
+	}
+}
+
+func TestTokensProfileCmd_EmptyHistory(t *testing.T) {
+	runExplainAutoTestRepo(t)
+
+	cmd := newTokensGroupCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"profile"})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	out := stdout.String()
+	checks := []string{
+		"Token profile",
+		"Checkpoints analyzed: 0",
+		"Token data: unavailable",
+		"No committed checkpoints found.",
+	}
+	for _, check := range checks {
+		if !strings.Contains(out, check) {
+			t.Errorf("expected %q in output, got:\n%s", check, out)
+		}
+	}
+}
+
+func signalCount(signals []tokensProfileSignal, id string) int {
+	for _, signal := range signals {
+		if signal.ID == id {
+			return signal.Count
+		}
+	}
+	return 0
+}
+
+func writeProfileTokenCheckpoint(ctx context.Context, t *testing.T, store *checkpoint.GitStore, checkpointID string, sessionID string, usage *agent.TokenUsage) {
+	t.Helper()
+
+	if err := store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+		CheckpointID: id.MustCheckpointID(checkpointID),
+		SessionID:    sessionID,
+		Strategy:     strategy.StrategyNameManualCommit,
+		Branch:       "tokens-profile",
+		Agent:        testAgentClaude,
+		Transcript:   redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"profile"}]}}` + "\n")),
+		AuthorName:   "Test",
+		AuthorEmail:  "test@example.com",
+		TokenUsage:   usage,
+	}); err != nil {
+		t.Fatalf("WriteCommitted(%s) error = %v", checkpointID, err)
+	}
+}

--- a/cmd/entire/cli/trail/trail.go
+++ b/cmd/entire/cli/trail/trail.go
@@ -153,6 +153,7 @@ type Author struct {
 type Metadata struct {
 	Number    int        `json:"number,omitempty"`
 	TrailID   ID         `json:"trail_id"`
+	URL       string     `json:"url,omitempty"`
 	Branch    string     `json:"branch"`
 	Base      string     `json:"base"`
 	Title     string     `json:"title"`

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -133,14 +133,13 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, sel
 		// the core metadata already came from the list, so a detail failure
 		// falls back to the list body with a warning rather than failing.
 		m := found.ToMetadata()
-		webURL := ""
+		webURL := trailDisplayURL(*found, forge, owner, repo)
 		// Seed the description from the list body so a failed (or skipped)
 		// detail fetch still shows something; a successful detail fetch
 		// supersedes it with the richer body_document text below.
 		bodyText := found.Body
 		descriptionLoaded := strings.TrimSpace(found.Body) != ""
 		if found.Number > 0 {
-			webURL = trailWebURL(api.BaseURL(), forge, owner, repo, found.Number)
 			if bt, derr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); derr == nil {
 				// A successful fetch means we authoritatively consulted the
 				// description, but it only supersedes the seeded list body when
@@ -241,7 +240,31 @@ func trailDescriptionForDisplay(bodyText string, loaded bool) string {
 	return ""
 }
 
-// trailWebURL builds the browser URL for a trail:
+// printCreatedTrail reports a newly created trail, including its browser URL
+// (the same URL `trail show` surfaces) when one is available.
+func printCreatedTrail(w io.Writer, t api.TrailResource, forge, owner, repo string) {
+	fmt.Fprintf(w, "Created trail %q for branch %s (ID: %s)\n", t.Title, t.Branch, t.ID)
+	if url := trailDisplayURL(t, forge, owner, repo); url != "" {
+		fmt.Fprintf(w, "  URL: %s\n", url)
+	}
+}
+
+// trailDisplayURL returns the trail's browser URL. It prefers the canonical URL
+// the server now returns, so the CLI tracks any route change without being
+// updated in lockstep, and falls back to a locally constructed URL only for
+// older servers that omit the field.
+func trailDisplayURL(t api.TrailResource, forge, owner, repo string) string {
+	if strings.TrimSpace(t.URL) != "" {
+		return t.URL
+	}
+	if t.Number > 0 {
+		return trailWebURL(api.BaseURL(), forge, owner, repo, t.Number)
+	}
+	return ""
+}
+
+// trailWebURL builds a fallback browser URL for a trail used only when the
+// server does not supply one (older servers):
 // <web-origin>/<forge>/<owner>/<repo>/trails/<number>. In production the web app
 // is served from the same origin as the data API, so the API base URL doubles
 // as the web origin. A split local-dev setup (API and frontend on different
@@ -789,7 +812,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		return fmt.Errorf("failed to decode create response: %w", err)
 	}
 
-	fmt.Fprintf(w, "Created trail %q for branch %s (ID: %s)\n", createResp.Trail.Title, createResp.Trail.Branch, createResp.Trail.ID)
+	printCreatedTrail(w, createResp.Trail, forge, owner, repoName)
 
 	if needsCreation && currentBranch != branch {
 		shouldCheckout := checkout

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -380,10 +380,13 @@ func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Cli
 		return fmt.Errorf("failed to decode trail list: %w", err)
 	}
 
-	// Convert to metadata for display
+	// Convert to metadata for display, attaching the browser URL (server-provided
+	// when present, locally constructed as a fallback for older servers).
 	trails := make([]*trail.Metadata, 0, len(listResp.Trails))
 	for i := range listResp.Trails {
-		trails = append(trails, listResp.Trails[i].ToMetadata())
+		m := listResp.Trails[i].ToMetadata()
+		m.URL = trailDisplayURL(listResp.Trails[i], forge, owner, repo)
+		trails = append(trails, m)
 	}
 
 	totalMatched := listResp.Total
@@ -572,6 +575,7 @@ func printTrailRows(w io.Writer, trails []*trail.Metadata, showAuthor, showStatu
 	// branch names or logins don't throw off the table.
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	showPhase := trailListHasPhase(trails)
+	showURL := trailListHasURL(trails)
 	columns := []string{"NUM", "BRANCH", "TITLE"}
 	if showStatus {
 		columns = append(columns, "STATUS")
@@ -583,6 +587,9 @@ func printTrailRows(w io.Writer, trails []*trail.Metadata, showAuthor, showStatu
 		columns = append(columns, "AUTHOR")
 	}
 	columns = append(columns, "UPDATED")
+	if showURL {
+		columns = append(columns, "URL")
+	}
 	fmt.Fprintln(tw, "  "+strings.Join(columns, "\t"))
 	for _, t := range trails {
 		number := "-"
@@ -604,6 +611,9 @@ func printTrailRows(w io.Writer, trails []*trail.Metadata, showAuthor, showStatu
 			fields = append(fields, t.AuthorLogin())
 		}
 		fields = append(fields, timeAgo(t.UpdatedAt))
+		if showURL {
+			fields = append(fields, t.URL)
+		}
 		fmt.Fprintln(tw, "  "+strings.Join(fields, "\t"))
 	}
 	_ = tw.Flush()
@@ -612,6 +622,15 @@ func printTrailRows(w io.Writer, trails []*trail.Metadata, showAuthor, showStatu
 func trailListHasPhase(trails []*trail.Metadata) bool {
 	for _, t := range trails {
 		if t != nil && strings.TrimSpace(t.Phase) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func trailListHasURL(trails []*trail.Metadata) bool {
+	for _, t := range trails {
+		if t != nil && strings.TrimSpace(t.URL) != "" {
 			return true
 		}
 	}

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -893,6 +893,35 @@ func TestPrintTrailListYourTrailsRelabelsAndSurfacesGhLogin(t *testing.T) {
 	}
 }
 
+func TestPrintTrailListShowsURLColumnWhenPresent(t *testing.T) {
+	t.Parallel()
+	alice := trailListTestAuthorAlice
+	var out bytes.Buffer
+	printTrailList(&out, []*trail.Metadata{
+		{Number: 5, Branch: "feat/a", Status: trail.StatusOpen, URL: "https://entire.io/gh/acme/repo/trails/5", Author: &trail.Author{Login: &alice}, UpdatedAt: time.Now()},
+	}, trailListDisplayOptions{StatusFilters: []trail.Status{trail.StatusOpen}})
+
+	text := out.String()
+	if !strings.Contains(text, "URL") || !strings.Contains(text, "https://entire.io/gh/acme/repo/trails/5") {
+		t.Fatalf("expected a URL column with the trail url, got:\n%s", text)
+	}
+}
+
+func TestPrintTrailListOmitsURLColumnWhenAbsent(t *testing.T) {
+	t.Parallel()
+	alice := trailListTestAuthorAlice
+	var out bytes.Buffer
+	printTrailList(&out, []*trail.Metadata{
+		{Number: 5, Branch: "feat/a", Status: trail.StatusOpen, Author: &trail.Author{Login: &alice}, UpdatedAt: time.Now()},
+	}, trailListDisplayOptions{StatusFilters: []trail.Status{trail.StatusOpen}})
+
+	// The column header must not appear when no trail carries a URL (e.g. an
+	// older server that omits the field and no local fallback was attached).
+	if text := out.String(); strings.Contains(text, "URL") {
+		t.Fatalf("expected URL column omitted when no trail has a url, got:\n%s", text)
+	}
+}
+
 func TestPrintTrailListAnyStatusShowsStatusColumn(t *testing.T) {
 	t.Parallel()
 	alice := trailListTestAuthorAlice

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -302,6 +302,49 @@ func TestTrailWebURL(t *testing.T) {
 	}
 }
 
+func TestPrintCreatedTrail(t *testing.T) {
+	t.Parallel()
+
+	// The server-provided URL is used verbatim.
+	var out bytes.Buffer
+	printCreatedTrail(&out, api.TrailResource{Title: "Fix it", Branch: "feat/x", ID: "abc123", Number: 575, URL: "https://entire.io/gh/acme/repo/trails/575/fix-it"}, "gh", "acme", "repo")
+	text := out.String()
+	if !strings.Contains(text, `Created trail "Fix it" for branch feat/x (ID: abc123)`) {
+		t.Fatalf("missing create summary line, got:\n%s", text)
+	}
+	if !strings.Contains(text, "URL: https://entire.io/gh/acme/repo/trails/575/fix-it") {
+		t.Fatalf("expected the server-provided URL, got:\n%s", text)
+	}
+
+	// Without a number, omit the URL line.
+	out.Reset()
+	printCreatedTrail(&out, api.TrailResource{Title: "No num", Branch: "feat/y", ID: "def456"}, "gh", "acme", "repo")
+	if text := out.String(); strings.Contains(text, "URL:") {
+		t.Fatalf("expected URL omitted when number and URL are absent, got:\n%s", text)
+	}
+}
+
+func TestTrailDisplayURL(t *testing.T) {
+	t.Parallel()
+
+	// Server URL wins, even when a number is present.
+	got := trailDisplayURL(api.TrailResource{Number: 5, URL: "https://server/url"}, "gh", "acme", "repo")
+	if got != "https://server/url" {
+		t.Fatalf("expected server URL, got %q", got)
+	}
+
+	// Falls back to a constructed URL for older servers that omit it.
+	got = trailDisplayURL(api.TrailResource{Number: 5}, "gh", "acme", "repo")
+	if !strings.HasSuffix(got, "/gh/acme/repo/trails/5") {
+		t.Fatalf("expected constructed fallback URL, got %q", got)
+	}
+
+	// Nothing to show when neither is available.
+	if got := trailDisplayURL(api.TrailResource{}, "gh", "acme", "repo"); got != "" {
+		t.Fatalf("expected empty URL, got %q", got)
+	}
+}
+
 func TestTrailDescriptionForDisplay(t *testing.T) {
 	t.Parallel()
 	if got := trailDescriptionForDisplay("the body", true); got != "the body" {

--- a/cmd/entire/cli/uiform/uiform.go
+++ b/cmd/entire/cli/uiform/uiform.go
@@ -20,8 +20,6 @@ func IsAccessibleMode() bool {
 }
 
 // Theme returns Entire's standard huh theme.
-//
-//nolint:ireturn // huh.Theme is an interface in v2
 func Theme() huh.Theme {
 	return huh.ThemeFunc(huh.ThemeDracula)
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/559
<!-- entire-trail-link-end -->

## Summary

- add top-level `entire tokens profile` for historical checkpoint token diagnostics
- default profile scans to latest 50 checkpoints, with `--limit` and `--all` for scope control
- aggregate token usage, repeated cache/API/subagent/missing-data signals, recommendations, JSON output, and public-checkpoint-safe limitations

## Verification

- `GOCACHE=/private/tmp/entire-go-cache go test ./cmd/entire/cli -run 'TestTokensProfileCmd' -count=1`
- `GOCACHE=/private/tmp/entire-go-cache go test ./cmd/entire/cli -run 'Test.*Tokens|Test.*Token' -count=1`
- `GOCACHE=/private/tmp/entire-go-cache go test ./cmd/entire/cli -count=1`
- `mise run lint`
- `mise run check`
- real checkpoint smoke over public/local checkpoint refs: `entire tokens profile --limit 5` and default `entire tokens profile` both completed successfully over 4,306 available checkpoints

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only local git checkpoint metadata analysis with no auth or data writes; main risk is slow runs when using `--all` on very large histories.
> 
> **Overview**
> Adds a top-level **`entire tokens`** command group with **`profile`**, which scans **committed checkpoint metadata only** (no transcripts) to aggregate historical token usage and surface repeated patterns.
> 
> By default it analyzes the **latest 50** checkpoints; **`--limit`** and **`--all`** control scope. Output includes aggregated totals, **repeated signals** (cache/context replay hotspots, high API call counts, subagent-heavy checkpoints, missing token data), **actionable recommendations**, explicit **limitations**, and optional **`--json`**. Token rollup reuses the same formatting/aggregation helpers as existing session/checkpoint token commands.
> 
> Tests cover text and JSON output, limit scoping, and empty checkpoint history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93eb40f6af8ea4e3868f55a7b346d031605c454c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->