### PR TITLE
fixed lint/package name issue

### DIFF
--- a/cmd/entire/cli/auth/repo_token.go
+++ b/cmd/entire/cli/auth/repo_token.go
@@ -8,10 +8,9 @@ import (
 	"time"
 
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
-	"github.com/entireio/cli/internal/entireclient/contexts"
-	"github.com/entireio/cli/internal/entireclient/discovery"
 	"github.com/entireio/cli/internal/entireclient/httputil"
 	"github.com/entireio/cli/internal/entireclient/repocreds"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
 
 // ErrRepoTargetUnknown reports that the cluster's STS refused the exchange
@@ -78,7 +77,7 @@ func NewRepoTokenSource(ctx context.Context, clusterHost string) (*RepoTokenSour
 	_, _ = MigrateLegacyLoginContext() //nolint:errcheck // best-effort bridge; resolution proceeds regardless
 
 	httpClient := &http.Client{Timeout: repoExchangeTimeout, Transport: repoExchangeTransportForTest}
-	clusterCtx, err := resolveContextForCluster(ctx, contexts.DefaultConfigDir(), discovery.DefaultCacheDir(), clusterHost, httpClient, nil)
+	clusterCtx, err := resolveContextForCluster(ctx, userdirs.Config(), userdirs.Cache(), clusterHost, httpClient, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/560
<!-- entire-trail-link-end -->

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single call-site import swap with equivalent path helpers; no auth or exchange logic changes.
> 
> **Overview**
> Consolidates how `NewRepoTokenSource` passes config and cache paths into cluster context resolution: it now uses **`userdirs.Config()`** and **`userdirs.Cache()`** instead of **`contexts.DefaultConfigDir()`** and **`discovery.DefaultCacheDir()`**, with imports updated accordingly.
> 
> This is a small wiring change in `repo_token.go` only; resolution behavior should stay the same if `userdirs` exposes the same default locations (including test/env overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e37e006c11ce78ff97bee2dd7684f5feb803ca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->