### PR TITLE
docs: Update Homebrew install for Tap Trust (Homebrew 6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Entire currently ships two release channels:
 
 How to use each channel:
 
-- Homebrew stable: `brew install --cask entire`
-- Homebrew nightly: `brew install --cask entire@nightly`
+- Homebrew stable: `brew install --cask entireio/tap/entire`
+- Homebrew nightly: `brew install --cask entireio/tap/entire@nightly`
 - `install.sh` stable: `curl -fsSL https://entire.io/install.sh | bash`
 - `install.sh` nightly: `curl -fsSL https://entire.io/install.sh | bash -s -- --channel nightly`
 - Scoop: currently supports `stable` only via `scoop install entire/cli`

--- a/README.md
+++ b/README.md
@@ -44,12 +44,10 @@ With Entire, you can:
 
 ```bash
 # Install stable via Homebrew
-brew tap entireio/tap
-brew install --cask entire
+brew install --cask entireio/tap/entire
 
 # Or install nightly via Homebrew
-brew tap entireio/tap
-brew install --cask entire@nightly
+brew install --cask entireio/tap/entire@nightly
 
 # Or install stable via install.sh
 curl -fsSL https://entire.io/install.sh | bash


### PR DESCRIPTION
Use fully qualified cask for scoped trust under Homebrew 6.0 Tap Trust.

### Description

Homebrew 6.0.0 introduced a new "Tap Trust" security model that requires explicit trust for third-party taps before their code is evaluated. The existing instructions use `brew tap` followed by `brew install`, which now triggers trust prompts when tap trust is required.

### Changes

Updated the macOS Homebrew installation snippet to use the fully-qualified cask path:

**Stable**

```bash
brew install --cask entireio/tap/entire
```

**Nightly**

```bash
brew install --cask entireio/tap/entire@nightly
```

This matches Homebrew's Tap Trust documentation, which states that installing a fully-qualified formula or cask (`user/repo/name`) trusts only that item and allows it to be installed even when tap trust is enforced.

### Why this is needed

Using the fully-qualified cask (`entireio/tap/entire`) gives scoped trust to the `entire` cask without requiring users to trust the entire tap. This avoids new Tap Trust warning prompts and keeps the install command simple for new users.