### PR TITLE
Centralize data API auth handling

### DIFF
--- a/cmd/entire/cli/activity_cmd.go
+++ b/cmd/entire/cli/activity_cmd.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -13,7 +12,6 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
-	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -58,34 +56,14 @@ func newActivityCmd() *cobra.Command {
 }
 
 func runActivity(ctx context.Context, w, errW io.Writer) error {
-	client, err := NewAuthenticatedAPIClient(ctx, false)
-	if err != nil {
-		// Ctrl+C during the keyring read or STS exchange surfaces as
-		// context.Canceled / DeadlineExceeded. Silence it to match the
-		// codebase convention (clean.go, explain.go, explain_export.go) —
-		// printing "context canceled" at a user who just hit Ctrl+C is
-		// noise, not diagnostic.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return NewSilentError(err)
+	return runAuthenticatedDataAPI(ctx, errW, false, func(ctx context.Context, client *api.Client) error {
+		// Non-interactive fallback: piped output or accessibility mode
+		if !interactive.IsTerminalWriter(w) || IsAccessibleMode() {
+			return runActivityStatic(ctx, w, client)
 		}
-		// Only the "no core token in keyring" sentinel gets the friendly
-		// login hint. Other failures (STS exchange rejected, network
-		// error, malformed env config) used to be swallowed under the
-		// same hint, which sent users on wild goose chases trying to
-		// "re-login" their way out of unrelated server-side problems.
-		if errors.Is(err, auth.ErrNotLoggedIn) {
-			fmt.Fprintln(errW, "Not logged in. Run 'entire login' to authenticate.")
-			return NewSilentError(err)
-		}
-		return err
-	}
 
-	// Non-interactive fallback: piped output or accessibility mode
-	if !interactive.IsTerminalWriter(w) || IsAccessibleMode() {
-		return runActivityStatic(ctx, w, client)
-	}
-
-	return runActivityTUI(ctx, client)
+		return runActivityTUI(ctx, client)
+	})
 }
 
 func runActivityStatic(ctx context.Context, w io.Writer, client *api.Client) error {

--- a/cmd/entire/cli/authcmd.go
+++ b/cmd/entire/cli/authcmd.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+)
+
+// runAuthenticatedDataAPI centralizes the auth gate for commands that must
+// call the Entire data API as the current user. Keep intentionally anonymous
+// flows (for example recap's server-rendered 401 path) out of this helper.
+func runAuthenticatedDataAPI(ctx context.Context, errW io.Writer, insecureHTTP bool, fn func(context.Context, *api.Client) error) error {
+	client, err := NewAuthenticatedAPIClient(ctx, insecureHTTP)
+	if err != nil {
+		return renderDataAPIAuthError(errW, err)
+	}
+	return fn(ctx, client)
+}
+
+func renderDataAPIAuthError(errW io.Writer, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return NewSilentError(err)
+	}
+	if errors.Is(err, auth.ErrNotLoggedIn) {
+		fmt.Fprintln(errW, "Not logged in. Run 'entire login' to authenticate.")
+		return NewSilentError(err)
+	}
+	return err
+}

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -50,7 +50,7 @@ func newTrailCmd() *cobra.Command {
 Running 'entire trail' without a subcommand shows the trail for the current
 branch, or lists recent trails if no trail exists for the current branch.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), insecureHTTPAuth)
+			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), insecureHTTPAuth)
 		},
 	}
 
@@ -94,32 +94,29 @@ func defaultTrailListOptions(insecureHTTP bool) trailListOptions {
 }
 
 // runTrailShow shows the trail for the current branch, or falls through to list.
-func runTrailShow(ctx context.Context, w io.Writer, insecureHTTP bool) error {
-	branch, err := GetCurrentBranch(ctx)
-	if err != nil {
-		return runTrailListAll(ctx, w, defaultTrailListOptions(insecureHTTP))
-	}
+func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool) error {
+	return runAuthenticatedDataAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
+		branch, err := GetCurrentBranch(ctx)
+		if err != nil {
+			return runTrailListAllWithClient(ctx, w, client, defaultTrailListOptions(insecureHTTP))
+		}
 
-	client, err := NewAuthenticatedAPIClient(ctx, insecureHTTP)
-	if err != nil {
-		return fmt.Errorf("authentication required: %w", err)
-	}
+		forge, owner, repo, err := resolveTrailRemote(ctx)
+		if err != nil {
+			return err
+		}
 
-	forge, owner, repo, err := resolveTrailRemote(ctx)
-	if err != nil {
-		return err
-	}
+		found, err := findTrailByBranch(ctx, client, forge, owner, repo, branch)
+		if err != nil {
+			return err
+		}
+		if found == nil {
+			return runTrailListAllWithClient(ctx, w, client, defaultTrailListOptions(insecureHTTP))
+		}
 
-	found, err := findTrailByBranch(ctx, client, forge, owner, repo, branch)
-	if err != nil {
-		return err
-	}
-	if found == nil {
-		return runTrailListAll(ctx, w, defaultTrailListOptions(insecureHTTP))
-	}
-
-	printTrailDetails(w, found.ToMetadata())
-	return nil
+		printTrailDetails(w, found.ToMetadata())
+		return nil
+	})
 }
 
 func printTrailDetails(w io.Writer, m *trail.Metadata) {
@@ -155,7 +152,7 @@ func newTrailListCmd() *cobra.Command {
 		Short: "List recent trails",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts.InsecureHTTP = trailInsecureHTTP(cmd)
-			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), opts)
+			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts)
 		},
 	}
 
@@ -169,7 +166,13 @@ func newTrailListCmd() *cobra.Command {
 	return cmd
 }
 
-func runTrailListAll(ctx context.Context, w io.Writer, opts trailListOptions) error {
+func runTrailListAll(ctx context.Context, w, errW io.Writer, opts trailListOptions) error {
+	return runAuthenticatedDataAPI(ctx, errW, opts.InsecureHTTP, func(ctx context.Context, client *api.Client) error {
+		return runTrailListAllWithClient(ctx, w, client, opts)
+	})
+}
+
+func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Client, opts trailListOptions) error {
 	if opts.Limit <= 0 {
 		return errors.New("limit must be greater than 0")
 	}
@@ -187,11 +190,6 @@ func runTrailListAll(ctx context.Context, w io.Writer, opts trailListOptions) er
 		}
 		currentUserLogin = login
 		authorFilter = login
-	}
-
-	client, err := NewAuthenticatedAPIClient(ctx, opts.InsecureHTTP)
-	if err != nil {
-		return fmt.Errorf("authentication required: %w", err)
 	}
 
 	forge, owner, repo, err := resolveTrailRemote(ctx)
@@ -558,36 +556,36 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 
 	// --- Phase 2: API operations ---
 
-	client, err := NewAuthenticatedAPIClient(ctx, trailInsecureHTTP(cmd))
-	if err != nil {
-		return fmt.Errorf("authentication required: %w", err)
-	}
-
-	forge, owner, repoName, err := resolveTrailRemote(ctx)
-	if err != nil {
-		return err
-	}
-
-	createReq := api.TrailCreateRequest{
-		Title:      title,
-		Body:       body,
-		BranchName: branch,
-		Base:       base,
-		Status:     statusStr,
-	}
-
-	resp, err := client.Post(ctx, trailsBasePath(forge, owner, repoName), createReq)
-	if err != nil {
-		return fmt.Errorf("failed to create trail: %w", err)
-	}
-	defer resp.Body.Close()
-	if err := checkTrailResponse(resp); err != nil {
-		return err
-	}
-
 	var createResp api.TrailCreateResponse
-	if err := api.DecodeJSON(resp, &createResp); err != nil {
-		return fmt.Errorf("failed to decode create response: %w", err)
+	if err := runAuthenticatedDataAPI(ctx, cmd.ErrOrStderr(), trailInsecureHTTP(cmd), func(ctx context.Context, client *api.Client) error {
+		forge, owner, repoName, err := resolveTrailRemote(ctx)
+		if err != nil {
+			return err
+		}
+
+		createReq := api.TrailCreateRequest{
+			Title:      title,
+			Body:       body,
+			BranchName: branch,
+			Base:       base,
+			Status:     statusStr,
+		}
+
+		resp, err := client.Post(ctx, trailsBasePath(forge, owner, repoName), createReq)
+		if err != nil {
+			return fmt.Errorf("failed to create trail: %w", err)
+		}
+		defer resp.Body.Close()
+		if err := checkTrailResponse(resp); err != nil {
+			return err
+		}
+
+		if err := api.DecodeJSON(resp, &createResp); err != nil {
+			return fmt.Errorf("failed to decode create response: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	fmt.Fprintf(w, "Created trail %q for branch %s (ID: %s)\n", createResp.Trail.Title, createResp.Trail.Branch, createResp.Trail.ID)
@@ -643,106 +641,101 @@ func newTrailUpdateCmd() *cobra.Command {
 }
 
 func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, statusStr, title, body, branch string, labelAdd, labelRemove []string) error {
-	_ = errW // reserved for future warnings
-
-	client, err := NewAuthenticatedAPIClient(ctx, insecureHTTP)
-	if err != nil {
-		return fmt.Errorf("authentication required: %w", err)
-	}
-
-	forge, owner, repoName, err := resolveTrailRemote(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Determine branch
-	if branch == "" {
-		branch, err = GetCurrentBranch(ctx)
+	return runAuthenticatedDataAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
+		forge, owner, repoName, err := resolveTrailRemote(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to determine current branch: %w", err)
+			return err
 		}
-	}
 
-	// Find the trail by branch
-	found, err := findTrailByBranch(ctx, client, forge, owner, repoName, branch)
-	if err != nil {
-		return err
-	}
-	if found == nil {
-		return fmt.Errorf("no trail found for branch %q", branch)
-	}
-
-	// Interactive mode when no flags are provided
-	noFlags := statusStr == "" && title == "" && body == "" && labelAdd == nil && labelRemove == nil
-	if noFlags {
-		metadata := found.ToMetadata()
-		// Build status options with current value as default.
-		var statusOptions []huh.Option[string]
-		for _, s := range trail.ValidStatuses() {
-			if (s == trail.StatusMerged || s == trail.StatusClosed) && s != metadata.Status {
-				continue
+		// Determine branch
+		if branch == "" {
+			branch, err = GetCurrentBranch(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to determine current branch: %w", err)
 			}
-			label := string(s)
-			if s == metadata.Status {
-				label += " (current)"
+		}
+
+		// Find the trail by branch
+		found, err := findTrailByBranch(ctx, client, forge, owner, repoName, branch)
+		if err != nil {
+			return err
+		}
+		if found == nil {
+			return fmt.Errorf("no trail found for branch %q", branch)
+		}
+
+		// Interactive mode when no flags are provided
+		noFlags := statusStr == "" && title == "" && body == "" && labelAdd == nil && labelRemove == nil
+		if noFlags {
+			metadata := found.ToMetadata()
+			// Build status options with current value as default.
+			var statusOptions []huh.Option[string]
+			for _, s := range trail.ValidStatuses() {
+				if (s == trail.StatusMerged || s == trail.StatusClosed) && s != metadata.Status {
+					continue
+				}
+				label := string(s)
+				if s == metadata.Status {
+					label += " (current)"
+				}
+				statusOptions = append(statusOptions, huh.NewOption(label, string(s)))
 			}
-			statusOptions = append(statusOptions, huh.NewOption(label, string(s)))
+			statusStr = string(metadata.Status)
+			title = metadata.Title
+			body = metadata.Body
+
+			form := NewAccessibleForm(
+				huh.NewGroup(
+					huh.NewSelect[string]().
+						Title("Status").
+						Options(statusOptions...).
+						Value(&statusStr),
+					huh.NewInput().
+						Title("Title").
+						Value(&title),
+					huh.NewText().
+						Title("Body").
+						Value(&body),
+				),
+			)
+			if formErr := form.Run(); formErr != nil {
+				return handleFormCancellation(w, "Trail update", formErr)
+			}
 		}
-		statusStr = string(metadata.Status)
-		title = metadata.Title
-		body = metadata.Body
 
-		form := NewAccessibleForm(
-			huh.NewGroup(
-				huh.NewSelect[string]().
-					Title("Status").
-					Options(statusOptions...).
-					Value(&statusStr),
-				huh.NewInput().
-					Title("Title").
-					Value(&title),
-				huh.NewText().
-					Title("Body").
-					Value(&body),
-			),
-		)
-		if formErr := form.Run(); formErr != nil {
-			return handleFormCancellation(w, "Trail update", formErr)
+		// Validate status if provided
+		if statusStr != "" {
+			status := trail.Status(statusStr)
+			if !status.IsValid() {
+				return fmt.Errorf("invalid status %q: valid values are %s", statusStr, formatValidStatuses())
+			}
 		}
-	}
 
-	// Validate status if provided
-	if statusStr != "" {
-		status := trail.Status(statusStr)
-		if !status.IsValid() {
-			return fmt.Errorf("invalid status %q: valid values are %s", statusStr, formatValidStatuses())
+		// Build update request with only changed fields
+		updateReq := buildTrailUpdateRequest(found, statusStr, title, body, labelAdd, labelRemove)
+
+		// The single-trail endpoint is keyed by trail number, not id; the server
+		// rejects an id here with "Invalid trail number format".
+		if found.Number <= 0 {
+			return fmt.Errorf("trail for branch %q has no number yet; cannot update", branch)
 		}
-	}
+		resp, err := client.Patch(ctx, trailsBasePath(forge, owner, repoName)+"/"+strconv.Itoa(found.Number), updateReq)
+		if err != nil {
+			return fmt.Errorf("failed to update trail: %w", err)
+		}
+		defer resp.Body.Close()
+		if err := checkTrailResponse(resp); err != nil {
+			return err
+		}
 
-	// Build update request with only changed fields
-	updateReq := buildTrailUpdateRequest(found, statusStr, title, body, labelAdd, labelRemove)
+		var updateResp api.TrailUpdateResponse
+		if err := api.DecodeJSON(resp, &updateResp); err != nil {
+			return fmt.Errorf("failed to decode update response: %w", err)
+		}
 
-	// The single-trail endpoint is keyed by trail number, not id; the server
-	// rejects an id here with "Invalid trail number format".
-	if found.Number <= 0 {
-		return fmt.Errorf("trail for branch %q has no number yet; cannot update", branch)
-	}
-	resp, err := client.Patch(ctx, trailsBasePath(forge, owner, repoName)+"/"+strconv.Itoa(found.Number), updateReq)
-	if err != nil {
-		return fmt.Errorf("failed to update trail: %w", err)
-	}
-	defer resp.Body.Close()
-	if err := checkTrailResponse(resp); err != nil {
-		return err
-	}
-
-	var updateResp api.TrailUpdateResponse
-	if err := api.DecodeJSON(resp, &updateResp); err != nil {
-		return fmt.Errorf("failed to decode update response: %w", err)
-	}
-
-	fmt.Fprintf(w, "Updated trail for branch %s\n", branch)
-	return nil
+		fmt.Fprintf(w, "Updated trail for branch %s\n", branch)
+		return nil
+	})
 }
 
 // buildTrailUpdateRequest constructs a PATCH request body from the current trail and the requested changes.

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -96,14 +96,15 @@ func defaultTrailListOptions(insecureHTTP bool) trailListOptions {
 // runTrailShow shows the trail for the current branch, or falls through to list.
 func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool) error {
 	listOpts := defaultTrailListOptions(insecureHTTP)
-	if err := validateTrailListOptions(listOpts); err != nil {
+	listStatusFilters, err := validateTrailListOptions(listOpts)
+	if err != nil {
 		return err
 	}
 
 	return runAuthenticatedDataAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
 		branch, err := GetCurrentBranch(ctx)
 		if err != nil {
-			return runTrailListAllWithClient(ctx, w, client, listOpts)
+			return runTrailListAllWithClient(ctx, w, client, listOpts, listStatusFilters)
 		}
 
 		forge, owner, repo, err := resolveTrailRemote(ctx)
@@ -116,7 +117,7 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool) err
 			return err
 		}
 		if found == nil {
-			return runTrailListAllWithClient(ctx, w, client, listOpts)
+			return runTrailListAllWithClient(ctx, w, client, listOpts, listStatusFilters)
 		}
 
 		printTrailDetails(w, found.ToMetadata())
@@ -172,32 +173,31 @@ func newTrailListCmd() *cobra.Command {
 }
 
 func runTrailListAll(ctx context.Context, w, errW io.Writer, opts trailListOptions) error {
-	if err := validateTrailListOptions(opts); err != nil {
-		return err
-	}
-	return runAuthenticatedDataAPI(ctx, errW, opts.InsecureHTTP, func(ctx context.Context, client *api.Client) error {
-		return runTrailListAllWithClient(ctx, w, client, opts)
-	})
-}
-
-func validateTrailListOptions(opts trailListOptions) error {
-	if opts.Limit <= 0 {
-		return errors.New("limit must be greater than 0")
-	}
-	_, err := parseTrailStatusFilter(opts.Status)
-	return err
-}
-
-func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Client, opts trailListOptions) error {
-	if err := validateTrailListOptions(opts); err != nil {
-		return err
-	}
-
-	statusFilters, err := parseTrailStatusFilter(opts.Status)
+	statusFilters, err := validateTrailListOptions(opts)
 	if err != nil {
 		return err
 	}
+	return runAuthenticatedDataAPI(ctx, errW, opts.InsecureHTTP, func(ctx context.Context, client *api.Client) error {
+		return runTrailListAllWithClient(ctx, w, client, opts, statusFilters)
+	})
+}
 
+func validateTrailListOptions(opts trailListOptions) ([]trail.Status, error) {
+	if opts.Limit <= 0 {
+		return nil, errors.New("limit must be greater than 0")
+	}
+	return parseTrailStatusFilter(opts.Status)
+}
+
+func runTrailListAllValidatedWithClient(ctx context.Context, w io.Writer, client *api.Client, opts trailListOptions) error {
+	statusFilters, err := validateTrailListOptions(opts)
+	if err != nil {
+		return err
+	}
+	return runTrailListAllWithClient(ctx, w, client, opts, statusFilters)
+}
+
+func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Client, opts trailListOptions, statusFilters []trail.Status) error {
 	authorFilter := opts.Author
 	currentUserLogin := ""
 	if authorFilter == trailListAuthorMe {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -95,10 +95,15 @@ func defaultTrailListOptions(insecureHTTP bool) trailListOptions {
 
 // runTrailShow shows the trail for the current branch, or falls through to list.
 func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool) error {
+	listOpts := defaultTrailListOptions(insecureHTTP)
+	if err := validateTrailListOptions(listOpts); err != nil {
+		return err
+	}
+
 	return runAuthenticatedDataAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
 		branch, err := GetCurrentBranch(ctx)
 		if err != nil {
-			return runTrailListAllWithClient(ctx, w, client, defaultTrailListOptions(insecureHTTP))
+			return runTrailListAllWithClient(ctx, w, client, listOpts)
 		}
 
 		forge, owner, repo, err := resolveTrailRemote(ctx)
@@ -111,7 +116,7 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool) err
 			return err
 		}
 		if found == nil {
-			return runTrailListAllWithClient(ctx, w, client, defaultTrailListOptions(insecureHTTP))
+			return runTrailListAllWithClient(ctx, w, client, listOpts)
 		}
 
 		printTrailDetails(w, found.ToMetadata())
@@ -184,6 +189,10 @@ func validateTrailListOptions(opts trailListOptions) error {
 }
 
 func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Client, opts trailListOptions) error {
+	if err := validateTrailListOptions(opts); err != nil {
+		return err
+	}
+
 	statusFilters, err := parseTrailStatusFilter(opts.Status)
 	if err != nil {
 		return err

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -167,15 +167,23 @@ func newTrailListCmd() *cobra.Command {
 }
 
 func runTrailListAll(ctx context.Context, w, errW io.Writer, opts trailListOptions) error {
+	if err := validateTrailListOptions(opts); err != nil {
+		return err
+	}
 	return runAuthenticatedDataAPI(ctx, errW, opts.InsecureHTTP, func(ctx context.Context, client *api.Client) error {
 		return runTrailListAllWithClient(ctx, w, client, opts)
 	})
 }
 
-func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Client, opts trailListOptions) error {
+func validateTrailListOptions(opts trailListOptions) error {
 	if opts.Limit <= 0 {
 		return errors.New("limit must be greater than 0")
 	}
+	_, err := parseTrailStatusFilter(opts.Status)
+	return err
+}
+
+func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Client, opts trailListOptions) error {
 	statusFilters, err := parseTrailStatusFilter(opts.Status)
 	if err != nil {
 		return err

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/entireio/auth-go/sts"
+	"github.com/entireio/auth-go/tokens"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trail"
 )
@@ -17,6 +20,37 @@ const (
 	trailListTestAuthorAlice = "alice"
 	trailListTestAuthorBob   = "bob"
 )
+
+func TestRunTrailListAll_PrintsLoginHintWhenNotLoggedIn(t *testing.T) {
+	// No t.Parallel: SetManagerForTest mutates package-level auth state.
+	store := newAuthMemStore()
+	mgr := newResolveTestManager(t, store, func(context.Context, sts.ExchangeRequest) (*tokens.TokenSet, error) {
+		t.Fatal("exchange should not run when no core token is stored")
+		return nil, errors.New("unreachable")
+	})
+	t.Cleanup(auth.SetManagerForTest(t, mgr))
+	t.Cleanup(auth.SetResolveContextForAPIForTest(t, auth.DiscoveryUnavailableForTest))
+
+	var out, errOut bytes.Buffer
+	err := runTrailListAll(t.Context(), &out, &errOut, defaultTrailListOptions(false))
+	if err == nil {
+		t.Fatal("expected error when not logged in")
+	}
+	if !errors.Is(err, auth.ErrNotLoggedIn) {
+		t.Errorf("error chain missing ErrNotLoggedIn: %v", err)
+	}
+	var silent *SilentError
+	if !errors.As(err, &silent) {
+		t.Errorf("error = %v, want SilentError wrap", err)
+	}
+	if strings.Contains(out.String(), "No trails found") {
+		t.Errorf("stdout = %q, must not render logged-out state as an empty trail list", out.String())
+	}
+	wantHint := "Not logged in. Run 'entire login' to authenticate."
+	if got := errOut.String(); !strings.Contains(got, wantHint) {
+		t.Errorf("errOut = %q, want hint %q", got, wantHint)
+	}
+}
 
 func TestTrailsBasePath(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -81,6 +81,22 @@ func TestRunTrailListAll_ValidatesOptionsBeforeAuth(t *testing.T) {
 	}
 }
 
+func TestRunTrailListAllWithClient_ValidatesOptionsBeforeRepoLookup(t *testing.T) {
+	t.Parallel()
+
+	opts := defaultTrailListOptions(false)
+	opts.Limit = 0
+
+	var out bytes.Buffer
+	err := runTrailListAllWithClient(t.Context(), &out, nil, opts)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if got, want := err.Error(), "limit must be greater than 0"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
 func TestTrailsBasePath(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -88,7 +88,7 @@ func TestRunTrailListAllWithClient_ValidatesOptionsBeforeRepoLookup(t *testing.T
 	opts.Limit = 0
 
 	var out bytes.Buffer
-	err := runTrailListAllWithClient(t.Context(), &out, nil, opts)
+	err := runTrailListAllValidatedWithClient(t.Context(), &out, nil, opts)
 	if err == nil {
 		t.Fatal("expected validation error")
 	}

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -52,6 +52,35 @@ func TestRunTrailListAll_PrintsLoginHintWhenNotLoggedIn(t *testing.T) {
 	}
 }
 
+func TestRunTrailListAll_ValidatesOptionsBeforeAuth(t *testing.T) {
+	// No t.Parallel: SetManagerForTest mutates package-level auth state.
+	store := newAuthMemStore()
+	mgr := newResolveTestManager(t, store, func(context.Context, sts.ExchangeRequest) (*tokens.TokenSet, error) {
+		t.Fatal("exchange should not run for invalid local options")
+		return nil, errors.New("unreachable")
+	})
+	t.Cleanup(auth.SetManagerForTest(t, mgr))
+	t.Cleanup(auth.SetResolveContextForAPIForTest(t, auth.DiscoveryUnavailableForTest))
+
+	opts := defaultTrailListOptions(false)
+	opts.Limit = 0
+
+	var out, errOut bytes.Buffer
+	err := runTrailListAll(t.Context(), &out, &errOut, opts)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if errors.Is(err, auth.ErrNotLoggedIn) {
+		t.Fatalf("got auth error %v, want local validation error", err)
+	}
+	if got, want := err.Error(), "limit must be greater than 0"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("errOut = %q, want no auth hint", errOut.String())
+	}
+}
+
 func TestTrailsBasePath(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/entire/cli/trail_review_cmd.go
+++ b/cmd/entire/cli/trail_review_cmd.go
@@ -269,7 +269,7 @@ func runTrailReviewDashboard(cmd *cobra.Command, selector string, opts trailRevi
 		if strings.TrimSpace(selector) == "" && errors.Is(err, errTrailReviewDefaultTargetNotFound) {
 			fmt.Fprintln(cmd.OutOrStdout(), "No trail found for the current branch; showing trails in this repo.")
 			fmt.Fprintln(cmd.OutOrStdout())
-			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), trailListOptions{Status: trailListStatusAny, Limit: defaultTrailListLimit, InsecureHTTP: trailInsecureHTTP(cmd)})
+			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailListOptions{Status: trailListStatusAny, Limit: defaultTrailListLimit, InsecureHTTP: trailInsecureHTTP(cmd)})
 		}
 		return err
 	}
@@ -423,15 +423,18 @@ func runTrailReviewWatchWithClient(cmd *cobra.Command, client *api.Client, targe
 }
 
 func authenticatedTrailReviewTarget(cmd *cobra.Command, selector string) (*api.Client, trailReviewTarget, error) {
-	client, err := NewAuthenticatedAPIClient(cmd.Context(), trailInsecureHTTP(cmd))
-	if err != nil {
-		return nil, trailReviewTarget{}, fmt.Errorf("authentication required: %w", err)
-	}
-	target, err := resolveTrailReviewTarget(cmd.Context(), client, selector)
+	var target trailReviewTarget
+	var resolvedClient *api.Client
+	err := runAuthenticatedDataAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), func(ctx context.Context, client *api.Client) error {
+		var err error
+		resolvedClient = client
+		target, err = resolveTrailReviewTarget(ctx, client, selector)
+		return err
+	})
 	if err != nil {
 		return nil, trailReviewTarget{}, err
 	}
-	return client, target, nil
+	return resolvedClient, target, nil
 }
 
 func resolveTrailReviewTarget(ctx context.Context, client *api.Client, selector string) (trailReviewTarget, error) {

--- a/cmd/entire/cli/trail_watch_cmd.go
+++ b/cmd/entire/cli/trail_watch_cmd.go
@@ -84,17 +84,13 @@ Events emitted by the server:
 }
 
 func runTrailWatch(cmd *cobra.Command, number int, jsonOutput, showPings, once bool) error {
-	ctx := cmd.Context()
-	client, err := NewAuthenticatedAPIClient(ctx, trailInsecureHTTP(cmd))
-	if err != nil {
-		return fmt.Errorf("authentication required: %w", err)
-	}
-
-	trailID, description, err := resolveTrailWatchTarget(ctx, client, number)
-	if err != nil {
-		return err
-	}
-	return runTrailWatchResolved(cmd, client, trailID, description, jsonOutput, showPings, once)
+	return runAuthenticatedDataAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), func(ctx context.Context, client *api.Client) error {
+		trailID, description, err := resolveTrailWatchTarget(ctx, client, number)
+		if err != nil {
+			return err
+		}
+		return runTrailWatchResolved(cmd, client, trailID, description, jsonOutput, showPings, once)
+	})
 }
 
 func runTrailWatchResolved(cmd *cobra.Command, client *api.Client, trailID, description string, jsonOutput, showPings, once bool) error {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/564
<!-- entire-trail-link-end -->

Centralizes authentication handling for data API commands so logged-out users get a clear login prompt instead of command-specific fallback output.

## Why this change?
Previously, each data API command created its own authenticated client and handled auth failures locally. Trail commands could therefore drift from other commands and risk rendering normal empty-state output, such as `No trails found`, when the real problem was missing or unusable authentication.

With this change, auth-required data API commands go through a shared auth gate before command-specific logic runs. If the user is not logged in, commands now consistently print:

```text
Not logged in. Run 'entire login' to authenticate.
```

Old behavior:
- Trail/activity-style commands owned auth setup independently.
- Trail list could reach empty-state rendering despite auth being the actual issue.
- Error messages varied across commands.

New behavior:
- Trail and activity data API paths use one shared auth wrapper.
- Command-specific output only renders after auth succeeds.
- Logged-out behavior is consistent across the migrated commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only refactor of auth/error UX with no API or credential logic changes; behavior is tightened and covered by new tests.
> 
> **Overview**
> Introduces **`runAuthenticatedDataAPI`** and **`renderDataAPIAuthError`** in `authcmd.go` so user-facing data API commands share one auth gate before any command logic runs.
> 
> **`entire activity`** and trail paths (show, list, create, update, watch, review/finding) now call the helper instead of inlining `NewAuthenticatedAPIClient` and ad hoc error handling. Logged-out users get a consistent stderr hint (`Not logged in. Run 'entire login' to authenticate.`) wrapped in **`SilentError`**; cancel/deadline stays silent; other auth failures are returned without masquerading as “not logged in.”
> 
> Trail **list** validates `--limit` and `--status` via **`validateTrailListOptions`** before auth, and list/show reuse an authenticated client through **`runTrailListAllWithClient`** so fallbacks don’t re-auth or print empty lists when auth failed. Tests cover the login hint and pre-auth validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5049009bf7456671a7006b627513f83e646b75. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->