### PR TITLE
auth: restore keyring timeout + fix stale fallback comments (COR-393 follow-up)

### DIFF
--- a/cmd/entire/cli/dispatch/mode_local.go
+++ b/cmd/entire/cli/dispatch/mode_local.go
@@ -27,8 +27,8 @@ var (
 	// lookupResourceToken returns a bearer for the given data-API base URL.
 	// Production wiring goes through auth.ResolveDataAPIToken so the dispatch
 	// host's /.well-known/entire-api.json picks the matching login context
-	// (falling back to static resolution when unadvertised). Tests swap to a
-	// fixed-token closure.
+	// (a host that doesn't advertise discovery is a surfaced error). Tests
+	// swap to a fixed-token closure.
 	lookupResourceToken = auth.ResolveDataAPIToken
 
 	nowUTC = func() time.Time { return time.Now().UTC() }

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -170,8 +170,8 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 //
 // Goes through auth.ResolveDataAPIToken (the same context-aware path as
 // activity/search/dispatch) so the data host's /.well-known/entire-api.json
-// picks the matching login context and exchanges for the advertised audience,
-// falling back to static resolution when discovery is unavailable.
+// picks the matching login context and exchanges for the advertised audience;
+// a host that doesn't advertise discovery is a surfaced error, not a fallback.
 // ErrNotLoggedIn is collapsed back into an empty token so the caller's "render
 // with no bearer, let the server respond 401" path still fires. Every other
 // resolution failure (no eligible/ambiguous context, STS exchange rejected,

--- a/internal/entireclient/clusterdiscovery/api_discovery.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery.go
@@ -32,17 +32,17 @@ type APIResponse struct {
 // ErrDiscoveryUnavailable wraps every "the API didn't give us a usable
 // trust-root document" outcome: it doesn't serve /.well-known/entire-api.json
 // (404 — old deployment), is unreachable, answers 503 (unconfigured), or
-// returns a malformed/empty body. Callers match on it to fall back to
-// static token resolution so behaviour is never worse than before
-// discovery existed. Selection failures (no eligible / ambiguous
-// context) are NOT wrapped — those are real "log in / pick one" errors
-// the user must see.
+// returns a malformed/empty body. Callers match on it to surface a clear
+// "host does not advertise its trusted login servers" error — discovery is
+// the only path, so there is no static fallback. Selection failures (no
+// eligible / ambiguous context) are NOT wrapped — those are real "log in /
+// pick one" errors the user must see.
 var ErrDiscoveryUnavailable = errors.New("api discovery unavailable")
 
 // DiscoverAPI fetches and parses an API host's /.well-known/entire-api.json,
 // returning its trusted issuers. Every failure mode (transport, non-200,
 // decode, empty trusted_issuers) is folded under ErrDiscoveryUnavailable so the
-// caller has a single sentinel to fall back on.
+// caller has a single sentinel to match on.
 //
 // debugf is optional; nil suppresses debug output.
 func DiscoverAPI(ctx context.Context, apiHost string, c *http.Client, debugf DebugFunc) (*APIResponse, error) {
@@ -66,7 +66,7 @@ func DiscoverAPI(ctx context.Context, apiHost string, c *http.Client, debugf Deb
 // Shares the cache-then-discover logic with resolveClusterCores via
 // resolveCachedCores — the data-API trusted issuers ARE core URLs, so they
 // reuse the cores cache (different file). Cold failures stay folded under
-// ErrDiscoveryUnavailable (from DiscoverAPI) for the caller's static fallback.
+// ErrDiscoveryUnavailable (from DiscoverAPI) for the caller to surface.
 func resolveAPICores(ctx context.Context, cacheDir, apiHost string, httpClient *http.Client, debugf DebugFunc) ([]string, error) {
 	return resolveCachedCores(cacheDir, apiHost, "api host",
 		discovery.LoadAPICores, discovery.ModifyAPICores,
@@ -93,9 +93,10 @@ func resolveAPICores(ctx context.Context, cacheDir, apiHost string, httpClient *
 //
 // When the API doesn't advertise discovery (404 / unreachable / 503 /
 // malformed) and no cache entry exists, the returned error wraps
-// ErrDiscoveryUnavailable so the caller falls back to static resolution. A
-// successful fetch whose context selection fails returns that selection error
-// unwrapped — the user must act on it.
+// ErrDiscoveryUnavailable; data-API callers surface it as a fatal "host does
+// not advertise its trusted login servers" error rather than guessing which
+// login servers to trust. A successful fetch whose context selection fails
+// returns that selection error unwrapped — the user must act on it.
 //
 // debugf is optional; nil suppresses debug output.
 func ResolveContextForAPI(ctx context.Context, configDir, cacheDir, apiHost string, httpClient *http.Client, debugf DebugFunc) (*contexts.Context, error) {

--- a/internal/entireclient/tokenstore/keyring_timeout.go
+++ b/internal/entireclient/tokenstore/keyring_timeout.go
@@ -1,0 +1,86 @@
+package tokenstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+)
+
+// defaultKeyringTimeout caps how long every OS keyring call may take.
+// The underlying keyring API (Secret Service on Linux, Keychain on
+// macOS, Credential Manager on Windows) can block indefinitely when no
+// provider is reachable — a headless SSH/container/WSL session, a
+// suppressed Keychain prompt, a stuck Credential Manager — and that
+// freezes the CLI. 5s is comfortably longer than any healthy
+// round-trip while still surfacing the hang to the user quickly.
+const defaultKeyringTimeout = 5 * time.Second
+
+// keyringTimeoutEnvVar overrides defaultKeyringTimeout. Accepts any
+// time.ParseDuration string; invalid or non-positive values fall back
+// to the default. Useful on slow keyrings or to extend the wait on a
+// system where the secret service is just sluggish.
+const keyringTimeoutEnvVar = "ENTIRE_KEYRING_TIMEOUT"
+
+func keyringTimeout() time.Duration {
+	v := os.Getenv(keyringTimeoutEnvVar)
+	if v == "" {
+		return defaultKeyringTimeout
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		return defaultKeyringTimeout
+	}
+	return d
+}
+
+// callKeyringWithTimeout runs fn in a goroutine and returns its result,
+// or a descriptive error if the configured keyring timeout elapses
+// first. The goroutine continues running — a blocked D-Bus syscall
+// can't be cancelled from Go — and its eventual result is discarded.
+// The buffered result channel keeps the goroutine from leaking forever
+// waiting to publish into a receiver that's already gone. fn's own
+// error (including ErrNotFound) propagates unchanged on the fast path;
+// only the timeout branch wraps.
+func callKeyringWithTimeout(op string, fn func() (string, error)) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), keyringTimeout())
+	defer cancel()
+
+	type result struct {
+		val string
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		v, err := fn()
+		ch <- result{val: v, err: err}
+	}()
+	select {
+	case r := <-ch:
+		return r.val, r.err
+	case <-ctx.Done():
+		return "", fmt.Errorf(
+			"%s timed out: OS keyring (%s) appears unavailable; set %s to a longer duration to wait further: %w",
+			op, keyringProviderName(), keyringTimeoutEnvVar, ctx.Err(),
+		)
+	}
+}
+
+// keyringProviderName returns the human name of the OS keyring backend
+// for the current platform, so the timeout error can point the user at
+// the specific service that's likely stuck (Keychain on macOS,
+// Credential Manager on Windows, Secret Service on Linux/BSD). The
+// fallback for unrecognised GOOS is the generic "OS keyring".
+func keyringProviderName() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "macOS Keychain"
+	case "windows":
+		return "Windows Credential Manager"
+	case "linux", "freebsd", "openbsd", "netbsd", "dragonfly":
+		return "Secret Service (D-Bus)"
+	default:
+		return "OS keyring"
+	}
+}

--- a/internal/entireclient/tokenstore/keyring_timeout_test.go
+++ b/internal/entireclient/tokenstore/keyring_timeout_test.go
@@ -1,0 +1,119 @@
+package tokenstore
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCallKeyringWithTimeout_ReturnsValueWhenFast(t *testing.T) {
+	t.Parallel()
+
+	got, err := callKeyringWithTimeout("get", func() (string, error) {
+		return "token", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "token" {
+		t.Fatalf("got = %q, want %q", got, "token")
+	}
+}
+
+func TestCallKeyringWithTimeout_PropagatesInnerError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("backend exploded")
+	_, err := callKeyringWithTimeout("get", func() (string, error) {
+		return "", sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("got %v, want %v wrapped", err, sentinel)
+	}
+}
+
+// A missing-credential error must reach the caller unchanged so the
+// errors.Is(err, ErrNotFound) checks scattered through the auth package
+// keep working through the timeout wrapper.
+func TestCallKeyringWithTimeout_PropagatesNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := callKeyringWithTimeout("get", func() (string, error) {
+		return "", ErrNotFound
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("got %v, want ErrNotFound", err)
+	}
+}
+
+func TestCallKeyringWithTimeout_DeadlineExceeded(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "50ms")
+
+	start := time.Now()
+	_, err := callKeyringWithTimeout("get", func() (string, error) {
+		time.Sleep(5 * time.Second)
+		return "should not be returned", nil
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want DeadlineExceeded wrapped, got %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("call did not return promptly after timeout: elapsed=%s", elapsed)
+	}
+
+	msg := err.Error()
+	for _, want := range []string{"get", "OS keyring", keyringTimeoutEnvVar} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("timeout error %q missing %q", msg, want)
+		}
+	}
+}
+
+func TestKeyringTimeout_DefaultWhenUnset(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "")
+
+	if got := keyringTimeout(); got != defaultKeyringTimeout {
+		t.Fatalf("got %v, want default %v", got, defaultKeyringTimeout)
+	}
+}
+
+func TestKeyringTimeout_HonoursEnvOverride(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "150ms")
+
+	if got := keyringTimeout(); got != 150*time.Millisecond {
+		t.Fatalf("got %v, want 150ms", got)
+	}
+}
+
+func TestKeyringTimeout_IgnoresInvalidEnvValue(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "not-a-duration")
+
+	if got := keyringTimeout(); got != defaultKeyringTimeout {
+		t.Fatalf("got %v, want default %v", got, defaultKeyringTimeout)
+	}
+}
+
+func TestKeyringTimeout_IgnoresNonPositiveValue(t *testing.T) {
+	t.Setenv(keyringTimeoutEnvVar, "0s")
+
+	if got := keyringTimeout(); got != defaultKeyringTimeout {
+		t.Fatalf("got %v, want default %v", got, defaultKeyringTimeout)
+	}
+}
+
+// keyringProviderName must always name something the timeout error can
+// point at, including on unrecognised platforms.
+func TestKeyringProviderName_NonEmpty(t *testing.T) {
+	t.Parallel()
+
+	if keyringProviderName() == "" {
+		t.Fatal("keyringProviderName returned empty string")
+	}
+}

--- a/internal/entireclient/tokenstore/tokenstore.go
+++ b/internal/entireclient/tokenstore/tokenstore.go
@@ -137,20 +137,29 @@ func Delete(service, user string) error {
 	return currentBackend().Delete(service, user)
 }
 
-// keyringStore delegates to the OS keyring.
+// keyringStore delegates to the OS keyring. Every call is bounded by
+// callKeyringWithTimeout: the underlying provider (Secret Service,
+// Keychain, Credential Manager) can block indefinitely when no daemon
+// is reachable, and an unbounded keyring call freezes the whole CLI.
 type keyringStore struct{}
 
 func (keyringStore) Get(service, user string) (string, error) {
-	//nolint:wrapcheck // thin wrapper, callers handle errors
-	return keyring.Get(service, user)
+	// keyring.ErrNotFound propagates unchanged; only a timeout wraps.
+	return callKeyringWithTimeout("get", func() (string, error) {
+		return keyring.Get(service, user)
+	})
 }
 
 func (keyringStore) Set(service, user, password string) error {
-	//nolint:wrapcheck // thin wrapper, callers handle errors
-	return keyring.Set(service, user, password)
+	_, err := callKeyringWithTimeout("set", func() (string, error) {
+		return "", keyring.Set(service, user, password)
+	})
+	return err
 }
 
 func (keyringStore) Delete(service, user string) error {
-	//nolint:wrapcheck // thin wrapper, callers handle errors
-	return keyring.Delete(service, user)
+	_, err := callKeyringWithTimeout("delete", func() (string, error) {
+		return "", keyring.Delete(service, user)
+	})
+	return err
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/566
<!-- entire-trail-link-end -->

Stacked on top of #1410. Two follow-ups from reviewing that branch.

## 1. Restore the OS keyring timeout (real regression)

The keyring-timeout shim deleted in `37de13a6d` only ever wrapped the legacy `auth.Store`. The surviving `tokenstore.keyringStore` called `keyring.Get/Set/Delete` with **no deadline** — even on `main`. What masked this was login's dual-write through the legacy store, whose 5s timeout surfaced a hung keyring. With that path gone, `login`/`logout`/`status` can now block **forever** on:

- a headless Linux box with no Secret Service daemon,
- a suppressed macOS Keychain prompt,
- a stuck Windows Credential Manager.

This moves the timeout down to where the raw keyring calls now live. Every `keyringStore` op runs in a goroutine bounded by `ENTIRE_KEYRING_TIMEOUT` (default 5s). The inner error — including `ErrNotFound` — propagates unchanged on the fast path; only the timeout branch wraps, naming the platform's keyring backend and the override env var. The file backend is untouched (it can't hang on a daemon).

## 2. Fix stale "static resolution" fallback comments (docs only)

`ResolveDataAPIToken` has been discovery-only since `10aa97eec`: a host that doesn't advertise `/.well-known/entire-api.json` is a surfaced error, not a fall-through to static resolution. Three comments still described the removed fallback — `recap.go` and `dispatch/mode_local.go` on the call side, and `api_discovery.go`'s `ErrDiscoveryUnavailable` doc on the source side (which invited a future caller to reintroduce the fallback). The no-fallback docs-alignment pass (`087f5a498`) missed these.

## Verification
- `mise run fmt` + `mise run lint` → 0 issues
- `mise run test` → 6273 tests pass (4 skipped)
- Ported the deleted shim's timeout tests into the `tokenstore` package, plus an explicit `ErrNotFound`-propagation test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential storage on every login/logout/status path; behavior change is bounded waits instead of indefinite hangs, with low risk of breaking happy-path auth if timeouts are too aggressive.
> 
> **Overview**
> **OS keyring calls are no longer unbounded.** `tokenstore.keyringStore` wraps every `Get`/`Set`/`Delete` in `callKeyringWithTimeout` (default **5s**, overridable via `ENTIRE_KEYRING_TIMEOUT`), with platform-specific timeout messages and unchanged propagation of `ErrNotFound` and other fast-path errors. The file backend is unchanged.
> 
> **Comments** in `dispatch`, `recap`, and `ResolveContextForAPI` now state that missing `/.well-known/entire-api.json` is a surfaced error for data-API token resolution, not a static-resolution fallback.
> 
> Tests for the timeout helper and env parsing live in `keyring_timeout_test.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dbf85128bfb6224b0a33628bfeb91cf2bdd080e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->