### PR TITLE
strategy: don't treat shallow merge-base miss as disconnected metadata

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -75,7 +75,10 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 		args = append(args, "--depth=1")
 	case opts.Unshallow && isShallowRepository(ctx, opts.Dir):
 		args = append(args, "--unshallow")
-	case opts.Deepen > 0:
+	case opts.Deepen > 0 && !opts.Unshallow:
+		// Honour the documented precedence: Deepen is ignored whenever
+		// Unshallow is set, even when --unshallow is a no-op because the repo
+		// isn't currently shallow.
 		args = append(args, fmt.Sprintf("--deepen=%d", opts.Deepen))
 	}
 	if !opts.NoFilter && settings.IsFilteredFetchesEnabled(ctx) {

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -44,7 +44,15 @@ type FetchOptions struct {
 	// Set this on metadata-repair / reconcile paths that need complete
 	// checkpoint ancestry. Do not set on generic branch fetches — it would
 	// silently convert a deliberately-shallow user clone into a full one.
+	// Note: --unshallow is repository-global (it removes .git/shallow), so it
+	// also deepens unrelated shallow branches. Prefer Deepen for ref-scoped
+	// extension.
 	Unshallow bool
+	// Deepen adds --deepen=N, extending the fetched ref's shallow history by N
+	// commits. Unlike Unshallow this is ref-scoped: the repository stays shallow
+	// and other shallow boundaries (e.g. a shallow source-tree clone) are left
+	// untouched. Ignored when zero, or when Shallow/Unshallow are set.
+	Deepen    int
 	Dir       string   // working directory (empty = CWD)
 	ExtraArgs []string // additional flags before remote (e.g., "--no-write-fetch-head")
 }
@@ -65,8 +73,10 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	switch {
 	case opts.Shallow:
 		args = append(args, "--depth=1")
-	case opts.Unshallow && IsShallowRepository(ctx, opts.Dir):
+	case opts.Unshallow && isShallowRepository(ctx, opts.Dir):
 		args = append(args, "--unshallow")
+	case opts.Deepen > 0:
+		args = append(args, fmt.Sprintf("--deepen=%d", opts.Deepen))
 	}
 	if !opts.NoFilter && settings.IsFilteredFetchesEnabled(ctx) {
 		args = append(args, "--filter=blob:none")
@@ -317,10 +327,10 @@ func ResolveFetchTarget(ctx context.Context, target string) (string, error) {
 	return url, nil
 }
 
-// IsShallowRepository returns true when the git repository at dir is shallow.
+// isShallowRepository returns true when the git repository at dir is shallow.
 // An empty dir inherits the parent process's working directory, matching the
 // semantics callers use when invoking Fetch with empty FetchOptions.Dir.
-func IsShallowRepository(ctx context.Context, dir string) bool {
+func isShallowRepository(ctx context.Context, dir string) bool {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--is-shallow-repository")
 	cmd.Dir = dir
 	disableTerminalPrompt(cmd)

--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -65,7 +65,7 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	switch {
 	case opts.Shallow:
 		args = append(args, "--depth=1")
-	case opts.Unshallow && isShallowRepository(ctx, opts.Dir):
+	case opts.Unshallow && IsShallowRepository(ctx, opts.Dir):
 		args = append(args, "--unshallow")
 	}
 	if !opts.NoFilter && settings.IsFilteredFetchesEnabled(ctx) {
@@ -317,10 +317,10 @@ func ResolveFetchTarget(ctx context.Context, target string) (string, error) {
 	return url, nil
 }
 
-// isShallowRepository returns true when the git repository at dir is shallow.
+// IsShallowRepository returns true when the git repository at dir is shallow.
 // An empty dir inherits the parent process's working directory, matching the
 // semantics callers use when invoking Fetch with empty FetchOptions.Dir.
-func isShallowRepository(ctx context.Context, dir string) bool {
+func IsShallowRepository(ctx context.Context, dir string) bool {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--is-shallow-repository")
 	cmd.Dir = dir
 	disableTerminalPrompt(cmd)

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -265,7 +266,7 @@ func TestFetch_Unshallow(t *testing.T) {
 		ctx := context.Background()
 
 		bareDir, cloneDir := setupShallowClone(ctx, t)
-		require.True(t, IsShallowRepository(ctx, cloneDir), "test setup should produce a shallow repo")
+		require.True(t, isShallowRepository(ctx, cloneDir), "test setup should produce a shallow repo")
 
 		out, err := Fetch(ctx, FetchOptions{
 			Remote:    "file://" + bareDir,
@@ -276,7 +277,7 @@ func TestFetch_Unshallow(t *testing.T) {
 		})
 		require.NoError(t, err, "fetch output: %s", out)
 
-		assert.False(t, IsShallowRepository(ctx, cloneDir),
+		assert.False(t, isShallowRepository(ctx, cloneDir),
 			"Unshallow=true should remove shallow state when the repo is shallow")
 	})
 
@@ -285,7 +286,7 @@ func TestFetch_Unshallow(t *testing.T) {
 		ctx := context.Background()
 
 		bareDir, cloneDir := setupShallowClone(ctx, t)
-		require.True(t, IsShallowRepository(ctx, cloneDir))
+		require.True(t, isShallowRepository(ctx, cloneDir))
 
 		out, err := Fetch(ctx, FetchOptions{
 			Remote:   "file://" + bareDir,
@@ -295,9 +296,47 @@ func TestFetch_Unshallow(t *testing.T) {
 		})
 		require.NoError(t, err, "fetch output: %s", out)
 
-		assert.True(t, IsShallowRepository(ctx, cloneDir),
+		assert.True(t, isShallowRepository(ctx, cloneDir),
 			"a fetch without Unshallow must not silently convert a shallow repo to a full one")
 	})
+}
+
+func TestFetch_Deepen(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	bareDir := filepath.Join(tmpDir, "bare.git")
+	seedDir := filepath.Join(tmpDir, "seed")
+	cloneDir := filepath.Join(tmpDir, "clone")
+
+	testutil.InitRepo(t, seedDir)
+	for _, c := range []string{"c1", "c2", "c3"} {
+		testutil.WriteFile(t, seedDir, "f.txt", c)
+		testutil.GitAdd(t, seedDir, "f.txt")
+		testutil.GitCommit(t, seedDir, c)
+	}
+	runIsolatedGit(ctx, t, "", "init", "--bare", bareDir)
+	runIsolatedGit(ctx, t, seedDir, "remote", "add", "origin", bareDir)
+	runIsolatedGit(ctx, t, seedDir, "push", "origin", "HEAD:refs/heads/main")
+	runIsolatedGit(ctx, t, "", "clone", "--depth=1", "--branch", "main", "file://"+bareDir, cloneDir)
+	require.True(t, isShallowRepository(ctx, cloneDir))
+	require.Equal(t, 1, revListCount(ctx, t, cloneDir, "refs/remotes/origin/main"),
+		"a --depth=1 clone of a 3-commit history sees exactly one commit")
+
+	out, err := Fetch(ctx, FetchOptions{
+		Remote:   "file://" + bareDir,
+		RefSpecs: []string{"+refs/heads/main:refs/remotes/origin/main"},
+		NoTags:   true,
+		Deepen:   1,
+		Dir:      cloneDir,
+	})
+	require.NoError(t, err, "fetch output: %s", out)
+
+	assert.True(t, isShallowRepository(ctx, cloneDir),
+		"Deepen must extend history ref-scoped without unshallowing the whole repo")
+	assert.Equal(t, 2, revListCount(ctx, t, cloneDir, "refs/remotes/origin/main"),
+		"Deepen=1 should add one commit of history to the fetched ref")
 }
 
 func TestFetch_Shallow(t *testing.T) {
@@ -309,7 +348,7 @@ func TestFetch_Shallow(t *testing.T) {
 	// .git/shallow appears.
 	cloneDir := t.TempDir()
 	runIsolatedGit(ctx, t, "", "clone", "--branch", "main", "file://"+bareDir, cloneDir)
-	require.False(t, IsShallowRepository(ctx, cloneDir), "fresh clone should not be shallow")
+	require.False(t, isShallowRepository(ctx, cloneDir), "fresh clone should not be shallow")
 
 	out, err := Fetch(ctx, FetchOptions{
 		Remote:   "file://" + bareDir,
@@ -320,7 +359,7 @@ func TestFetch_Shallow(t *testing.T) {
 	})
 	require.NoError(t, err, "fetch output: %s", out)
 
-	assert.True(t, IsShallowRepository(ctx, cloneDir),
+	assert.True(t, isShallowRepository(ctx, cloneDir),
 		"Shallow=true should request --depth=1 and leave the repo shallow")
 }
 
@@ -351,6 +390,18 @@ func setupShallowClone(ctx context.Context, t *testing.T) (bareDir, cloneDir str
 	runIsolatedGit(ctx, t, seedDir, "push", "origin", "HEAD:refs/heads/main")
 
 	return bareDir, cloneDir
+}
+
+func revListCount(ctx context.Context, t *testing.T, dir, ref string) int {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, "git", "rev-list", "--count", ref)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	require.NoError(t, err)
+	return n
 }
 
 func runIsolatedGit(ctx context.Context, t *testing.T, dir string, args ...string) {

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -265,7 +265,7 @@ func TestFetch_Unshallow(t *testing.T) {
 		ctx := context.Background()
 
 		bareDir, cloneDir := setupShallowClone(ctx, t)
-		require.True(t, isShallowRepository(ctx, cloneDir), "test setup should produce a shallow repo")
+		require.True(t, IsShallowRepository(ctx, cloneDir), "test setup should produce a shallow repo")
 
 		out, err := Fetch(ctx, FetchOptions{
 			Remote:    "file://" + bareDir,
@@ -276,7 +276,7 @@ func TestFetch_Unshallow(t *testing.T) {
 		})
 		require.NoError(t, err, "fetch output: %s", out)
 
-		assert.False(t, isShallowRepository(ctx, cloneDir),
+		assert.False(t, IsShallowRepository(ctx, cloneDir),
 			"Unshallow=true should remove shallow state when the repo is shallow")
 	})
 
@@ -285,7 +285,7 @@ func TestFetch_Unshallow(t *testing.T) {
 		ctx := context.Background()
 
 		bareDir, cloneDir := setupShallowClone(ctx, t)
-		require.True(t, isShallowRepository(ctx, cloneDir))
+		require.True(t, IsShallowRepository(ctx, cloneDir))
 
 		out, err := Fetch(ctx, FetchOptions{
 			Remote:   "file://" + bareDir,
@@ -295,7 +295,7 @@ func TestFetch_Unshallow(t *testing.T) {
 		})
 		require.NoError(t, err, "fetch output: %s", out)
 
-		assert.True(t, isShallowRepository(ctx, cloneDir),
+		assert.True(t, IsShallowRepository(ctx, cloneDir),
 			"a fetch without Unshallow must not silently convert a shallow repo to a full one")
 	})
 }
@@ -309,7 +309,7 @@ func TestFetch_Shallow(t *testing.T) {
 	// .git/shallow appears.
 	cloneDir := t.TempDir()
 	runIsolatedGit(ctx, t, "", "clone", "--branch", "main", "file://"+bareDir, cloneDir)
-	require.False(t, isShallowRepository(ctx, cloneDir), "fresh clone should not be shallow")
+	require.False(t, IsShallowRepository(ctx, cloneDir), "fresh clone should not be shallow")
 
 	out, err := Fetch(ctx, FetchOptions{
 		Remote:   "file://" + bareDir,
@@ -320,7 +320,7 @@ func TestFetch_Shallow(t *testing.T) {
 	})
 	require.NoError(t, err, "fetch output: %s", out)
 
-	assert.True(t, isShallowRepository(ctx, cloneDir),
+	assert.True(t, IsShallowRepository(ctx, cloneDir),
 		"Shallow=true should request --depth=1 and leave the repo shallow")
 }
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -351,7 +351,9 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to open repository: %w", err)
 	}
-	defer repo.Close()
+	// Closure (not `defer repo.Close()`) so the latest repo is closed even after
+	// the post-deepen swap below reassigns the variable.
+	defer func() { _ = repo.Close() }()
 
 	ctx := cmd.Context()
 	refs := checkpoint.ResolveCommittedRefs(ctx)
@@ -376,6 +378,16 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 		if deepenErr := DeepenMetadataBranch(ctx); deepenErr != nil {
 			logging.Warn(ctx, "could not deepen metadata branch before disconnection check",
 				slog.String("error", deepenErr.Error()))
+		} else if fresh, reopenErr := openRepository(ctx); reopenErr != nil {
+			logging.Warn(ctx, "could not reopen repository after deepening metadata branch",
+				slog.String("error", reopenErr.Error()))
+		} else {
+			// Swap to a freshly opened repo so the connectivity check and any
+			// reconcile see the objects fetched by the deepen, rather than a
+			// storer that was opened before the fetch. Matches the post-git-op
+			// reopen pattern used elsewhere (e.g. resume.go's freshRepo).
+			_ = repo.Close()
+			repo = fresh
 		}
 	}
 

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,6 +13,8 @@ import (
 	"charm.land/huh/v2"
 	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
@@ -341,7 +344,9 @@ func discardSession(ctx context.Context, ss stuckSession, _ *git.Repository, err
 }
 
 // checkDisconnectedMetadata detects and optionally repairs disconnected
-// local/remote metadata branches (the "empty-orphan bug").
+// local/remote metadata branches (the "empty-orphan bug"). On a shallow
+// checkpoint clone it first deepens the metadata branch so the check isn't
+// fooled by a merge-base miss at the shallow boundary.
 func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 	repo, err := openRepository(cmd.Context())
 	if err != nil {
@@ -356,6 +361,20 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 		fmt.Fprintf(w, "✓ Metadata branches: OK (primary ref %s is not pushed to origin)\n", refs.Primary)
 		return nil
 	}
+	// On a shallow checkpoint clone, `git merge-base` can falsely report "no
+	// common ancestor" because the real ancestor lives below the shallow
+	// boundary (see strategy.metadataDisconnected). Deepen the metadata branch
+	// first so detection — and any subsequent reconcile — operate on real
+	// ancestry. Best-effort: if the deepen fails (offline), the check below
+	// still runs and conservatively treats a shallow repo as connected.
+	if remote.IsShallowRepository(ctx, "") {
+		fmt.Fprintln(w, "  Deepening metadata branch (shallow clone) before check...")
+		if deepenErr := DeepenMetadataBranch(ctx); deepenErr != nil {
+			logging.Warn(ctx, "could not deepen metadata branch before disconnection check",
+				slog.String("error", deepenErr.Error()))
+		}
+	}
+
 	remoteRefName := plumbing.NewRemoteReferenceName("origin", refs.Primary.Short())
 	disconnected, err := strategy.IsMetadataDisconnected(ctx, repo, remoteRefName)
 	if err != nil {

--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -13,7 +13,6 @@ import (
 	"charm.land/huh/v2"
 	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
-	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -361,14 +360,19 @@ func checkDisconnectedMetadata(cmd *cobra.Command, force bool) error {
 		fmt.Fprintf(w, "✓ Metadata branches: OK (primary ref %s is not pushed to origin)\n", refs.Primary)
 		return nil
 	}
-	// On a shallow checkpoint clone, `git merge-base` can falsely report "no
-	// common ancestor" because the real ancestor lives below the shallow
-	// boundary (see strategy.metadataDisconnected). Deepen the metadata branch
-	// first so detection — and any subsequent reconcile — operate on real
-	// ancestry. Best-effort: if the deepen fails (offline), the check below
-	// still runs and conservatively treats a shallow repo as connected.
-	if remote.IsShallowRepository(ctx, "") {
-		fmt.Fprintln(w, "  Deepening metadata branch (shallow clone) before check...")
+	// When the metadata history is shallow-bounded, `git merge-base` can falsely
+	// report "no common ancestor" because the real ancestor lives below the
+	// shallow boundary (see strategy.metadataDisconnected). Deepen the metadata
+	// branch first so detection — and any subsequent reconcile — operate on real
+	// ancestry. Gated on the metadata refs specifically so an unrelated shallow
+	// boundary (e.g. a shallow source-tree clone) doesn't trigger a deepen.
+	// Best-effort: if the deepen fails (offline), the check below still runs and
+	// conservatively treats shallow-bounded metadata as connected.
+	if bounded, boundedErr := strategy.MetadataHistoryShallowBounded(ctx, repo); boundedErr != nil {
+		logging.Debug(ctx, "could not determine metadata shallow state",
+			slog.String("error", boundedErr.Error()))
+	} else if bounded {
+		fmt.Fprintln(w, "  Deepening metadata branch (shallow history) before check...")
 		if deepenErr := DeepenMetadataBranch(ctx); deepenErr != nil {
 			logging.Warn(ctx, "could not deepen metadata branch before disconnection check",
 				slog.String("error", deepenErr.Error()))

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -421,16 +421,18 @@ func FetchMetadataTreeOnly(ctx context.Context) error {
 	return fetchMetadataFromOrigin(ctx, fetchMetadataOpts{Shallow: true})
 }
 
-// DeepenMetadataBranch converts a shallow checkpoint clone to complete history
-// for the metadata branch by fetching it from origin with --unshallow. It only
-// updates the origin remote-tracking ref and the local object store; it does
-// NOT advance the local primary ref, so callers can compare local vs remote
-// afterwards on a no-longer-shallow repo.
+// DeepenMetadataBranch extends the metadata branch's shallow history by
+// strategy.MaxCommitTraversalDepth commits using a ref-scoped --deepen. It
+// only updates the origin remote-tracking ref and the local object store; it
+// does NOT advance the local primary ref, so callers can compare local vs
+// remote afterwards.
 //
 // 'entire doctor' calls this before the disconnection check so `git merge-base`
 // can see the real common ancestor instead of falsely reporting a disconnection
-// at the shallow boundary (see metadataDisconnected). On a non-shallow repo the
-// --unshallow flag is suppressed by remote.Fetch and this is a plain fetch.
+// at the shallow boundary (see metadataDisconnected). --deepen is used rather
+// than --unshallow because --unshallow is repository-global: it would also
+// deepen an unrelated shallow source-tree clone. --deepen keeps the repository
+// shallow and touches only the metadata ref's boundary.
 func DeepenMetadataBranch(ctx context.Context) error {
 	refs := checkpoint.ResolveCommittedRefs(ctx)
 	if !refs.Primary.IsBranch() {
@@ -448,10 +450,10 @@ func DeepenMetadataBranch(ctx context.Context) error {
 
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 	output, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
-		Remote:    fetchTarget,
-		RefSpecs:  []string{refSpec},
-		NoTags:    true,
-		Unshallow: true,
+		Remote:   fetchTarget,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+		Deepen:   strategy.MaxCommitTraversalDepth,
 	})
 	if fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -421,6 +421,47 @@ func FetchMetadataTreeOnly(ctx context.Context) error {
 	return fetchMetadataFromOrigin(ctx, fetchMetadataOpts{Shallow: true})
 }
 
+// DeepenMetadataBranch converts a shallow checkpoint clone to complete history
+// for the metadata branch by fetching it from origin with --unshallow. It only
+// updates the origin remote-tracking ref and the local object store; it does
+// NOT advance the local primary ref, so callers can compare local vs remote
+// afterwards on a no-longer-shallow repo.
+//
+// 'entire doctor' calls this before the disconnection check so `git merge-base`
+// can see the real common ancestor instead of falsely reporting a disconnection
+// at the shallow boundary (see metadataDisconnected). On a non-shallow repo the
+// --unshallow flag is suppressed by remote.Fetch and this is a plain fetch.
+func DeepenMetadataBranch(ctx context.Context) error {
+	refs := checkpoint.ResolveCommittedRefs(ctx)
+	if !refs.Primary.IsBranch() {
+		return fmt.Errorf("primary metadata ref %s is not a branch", refs.Primary)
+	}
+	branchName := refs.Primary.Short()
+
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	fetchTarget, err := remote.ResolveFetchTarget(ctx, "origin")
+	if err != nil {
+		return fmt.Errorf("failed to resolve fetch target: %w", err)
+	}
+
+	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
+	output, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:    fetchTarget,
+		RefSpecs:  []string{refSpec},
+		NoTags:    true,
+		Unshallow: true,
+	})
+	if fetchErr != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return errors.New("fetch timed out after 2 minutes")
+		}
+		return formatFilteredFetchError("failed to deepen "+branchName, fetchTarget, output, fetchErr)
+	}
+	return nil
+}
+
 type fetchMetadataOpts struct {
 	NoFilter  bool
 	Shallow   bool

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 
 	"github.com/go-git/go-git/v6"
@@ -55,7 +56,7 @@ func IsMetadataDisconnected(ctx context.Context, repo *git.Repository, remoteRef
 		return false, err
 	}
 
-	return isDisconnected(ctx, repoPath, localRef.Hash().String(), remoteRef.Hash().String())
+	return metadataDisconnected(ctx, repoPath, localRef.Hash().String(), remoteRef.Hash().String())
 }
 
 // WarnIfMetadataDisconnected checks (once per process) whether the metadata
@@ -94,9 +95,11 @@ func WarnIfMetadataDisconnected() {
 }
 
 // ReconcileDisconnectedMetadataRef detects and repairs disconnected local/remote
-// metadata refs. Disconnected means no common ancestor, which
-// only happens due to the empty-orphan bug. Diverged (shared ancestor) is normal
-// and handled by the push path.
+// metadata refs. Disconnected means no common ancestor — genuinely caused by the
+// empty-orphan bug. Diverged (shared ancestor) is normal and handled by the push
+// path. The disconnection check is shallow-aware (see metadataDisconnected): on a
+// shallow clone a merge-base miss is suppressed rather than trusted, so this
+// no-ops instead of attempting a doomed full-history cherry-pick.
 //
 // Repair strategy: cherry-pick local commits onto remote tip, preserving all data.
 // Checkpoint shards use unique paths (<id[:2]>/<id[2:]>/), so cherry-picks always
@@ -149,7 +152,7 @@ func ReconcileDisconnectedMetadataRef(
 		return err
 	}
 
-	disconnected, err := isDisconnected(ctx, repoPath, localHash.String(), remoteHash.String())
+	disconnected, err := metadataDisconnected(ctx, repoPath, localHash.String(), remoteHash.String())
 	if err != nil {
 		return fmt.Errorf("failed to check metadata ref ancestry: %w", err)
 	}
@@ -206,6 +209,41 @@ func ReconcileDisconnectedMetadataRef(
 
 	fmt.Fprintln(w, "[entire] Done — all local and remote checkpoints preserved")
 	return nil
+}
+
+// metadataDisconnected reports whether the local and remote metadata commits
+// share no common ancestor, accounting for shallow clones.
+//
+// A bare `git merge-base` miss is NOT sufficient evidence of disconnection on a
+// shallow repository: the real common ancestor can live below the shallow
+// boundary, where git has no objects, so merge-base reports a false "no common
+// ancestor". Checkpoint metadata branches are routinely shallow — resume/explain
+// fetch the tip with --depth=1 and nothing deepens them again (see
+// FetchMetadataTreeOnly) — so trusting that miss marks an ordinary
+// diverged-but-behind branch as disconnected and triggers a doomed
+// full-history reconcile (collectCommitChain blows MaxCommitTraversalDepth on a
+// deep team branch).
+//
+// We therefore only treat a merge-base miss as a genuine disconnection when the
+// repository is not shallow. On a shallow repo the verdict is suppressed (the
+// refs are reported connected) and 'entire doctor' is the path that deepens the
+// branch first and then re-checks authoritatively.
+func metadataDisconnected(ctx context.Context, repoPath, localHash, remoteHash string) (bool, error) {
+	disconnected, err := isDisconnected(ctx, repoPath, localHash, remoteHash)
+	if err != nil {
+		return false, err
+	}
+	if !disconnected {
+		return false, nil
+	}
+	if remote.IsShallowRepository(ctx, repoPath) {
+		logging.Debug(ctx, "merge-base reports no common ancestor but repository is shallow; "+
+			"treating metadata refs as connected (run 'entire doctor' to deepen and re-check)",
+			slog.String("local", localHash),
+			slog.String("remote", remoteHash))
+		return false, nil
+	}
+	return true, nil
 }
 
 // isDisconnected checks if two commits have no common ancestor using git merge-base.

--- a/cmd/entire/cli/strategy/metadata_reconcile.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
-	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 
 	"github.com/go-git/go-git/v6"
@@ -56,7 +55,7 @@ func IsMetadataDisconnected(ctx context.Context, repo *git.Repository, remoteRef
 		return false, err
 	}
 
-	return metadataDisconnected(ctx, repoPath, localRef.Hash().String(), remoteRef.Hash().String())
+	return metadataDisconnected(ctx, repo, repoPath, localRef.Hash().String(), remoteRef.Hash().String())
 }
 
 // WarnIfMetadataDisconnected checks (once per process) whether the metadata
@@ -152,7 +151,7 @@ func ReconcileDisconnectedMetadataRef(
 		return err
 	}
 
-	disconnected, err := metadataDisconnected(ctx, repoPath, localHash.String(), remoteHash.String())
+	disconnected, err := metadataDisconnected(ctx, repo, repoPath, localHash.String(), remoteHash.String())
 	if err != nil {
 		return fmt.Errorf("failed to check metadata ref ancestry: %w", err)
 	}
@@ -214,21 +213,24 @@ func ReconcileDisconnectedMetadataRef(
 // metadataDisconnected reports whether the local and remote metadata commits
 // share no common ancestor, accounting for shallow clones.
 //
-// A bare `git merge-base` miss is NOT sufficient evidence of disconnection on a
-// shallow repository: the real common ancestor can live below the shallow
-// boundary, where git has no objects, so merge-base reports a false "no common
-// ancestor". Checkpoint metadata branches are routinely shallow — resume/explain
-// fetch the tip with --depth=1 and nothing deepens them again (see
-// FetchMetadataTreeOnly) — so trusting that miss marks an ordinary
-// diverged-but-behind branch as disconnected and triggers a doomed
-// full-history reconcile (collectCommitChain blows MaxCommitTraversalDepth on a
-// deep team branch).
+// A bare `git merge-base` miss is NOT sufficient evidence of disconnection when
+// the metadata history is shallow: the real common ancestor can live below the
+// shallow boundary, where git has no objects, so merge-base reports a false "no
+// common ancestor". Checkpoint metadata branches are routinely shallow —
+// resume/explain fetch the tip with --depth=1 and nothing deepens them again
+// (see FetchMetadataTreeOnly) — so trusting that miss marks an ordinary
+// diverged-but-behind branch as disconnected and triggers a doomed full-history
+// reconcile (collectCommitChain blows MaxCommitTraversalDepth on a deep team
+// branch).
 //
 // We therefore only treat a merge-base miss as a genuine disconnection when the
-// repository is not shallow. On a shallow repo the verdict is suppressed (the
-// refs are reported connected) and 'entire doctor' is the path that deepens the
-// branch first and then re-checks authoritatively.
-func metadataDisconnected(ctx context.Context, repoPath, localHash, remoteHash string) (bool, error) {
+// metadata history does not reach a shallow boundary. The check is keyed on the
+// metadata commits specifically (not merely "is the repo shallow"), so a
+// genuine disconnection on a repo that is shallow only for an unrelated
+// source-tree branch is still reported. When the metadata history is
+// shallow-bounded the verdict is suppressed (refs reported connected) and
+// 'entire doctor' is the path that deepens the branch and re-checks.
+func metadataDisconnected(ctx context.Context, repo *git.Repository, repoPath, localHash, remoteHash string) (bool, error) {
 	disconnected, err := isDisconnected(ctx, repoPath, localHash, remoteHash)
 	if err != nil {
 		return false, err
@@ -236,14 +238,48 @@ func metadataDisconnected(ctx context.Context, repoPath, localHash, remoteHash s
 	if !disconnected {
 		return false, nil
 	}
-	if remote.IsShallowRepository(ctx, repoPath) {
-		logging.Debug(ctx, "merge-base reports no common ancestor but repository is shallow; "+
-			"treating metadata refs as connected (run 'entire doctor' to deepen and re-check)",
+	bounded, err := hasReachableShallowBoundary(ctx, repo, repoPath, localHash, remoteHash)
+	if err != nil {
+		return false, err
+	}
+	if bounded {
+		logging.Debug(ctx, "merge-base reports no common ancestor but metadata history reaches a "+
+			"shallow boundary; treating refs as connected (run 'entire doctor' to deepen and re-check)",
 			slog.String("local", localHash),
 			slog.String("remote", remoteHash))
 		return false, nil
 	}
 	return true, nil
+}
+
+// MetadataHistoryShallowBounded reports whether the local primary metadata ref
+// or its origin remote-tracking ref has a shallow boundary in its ancestry —
+// i.e. whether deepening the metadata branch could change a merge-base result.
+//
+// 'entire doctor' uses this to decide whether to deepen before the disconnection
+// check, so it never issues a (potentially large) deepen for a shallow boundary
+// that belongs to an unrelated branch such as a shallow source-tree clone.
+func MetadataHistoryShallowBounded(ctx context.Context, repo *git.Repository) (bool, error) {
+	repoPath, err := getRepoPath(repo)
+	if err != nil {
+		return false, err
+	}
+	refs := checkpoint.ResolveCommittedRefs(ctx)
+
+	var hashes []string
+	addRef := func(name plumbing.ReferenceName) {
+		if ref, refErr := repo.Reference(name, true); refErr == nil {
+			hashes = append(hashes, ref.Hash().String())
+		}
+	}
+	addRef(refs.Primary)
+	if refs.PrimaryFetchableFromOrigin() {
+		addRef(plumbing.NewRemoteReferenceName("origin", refs.Primary.Short()))
+	}
+	if len(hashes) == 0 {
+		return false, nil
+	}
+	return hasReachableShallowBoundary(ctx, repo, repoPath, hashes...)
 }
 
 // isDisconnected checks if two commits have no common ancestor using git merge-base.

--- a/cmd/entire/cli/strategy/metadata_reconcile_test.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile_test.go
@@ -29,6 +29,25 @@ func metadataLocalRef() plumbing.ReferenceName {
 	return plumbing.NewBranchReferenceName(paths.MetadataBranchName)
 }
 
+// gitRunnerInDir returns a helper that runs git in dir with isolated config and
+// fails the test on error, returning trimmed stdout+stderr. Pair it with
+// testutil.InitRepo (which sets repo-local user identity and disables signing)
+// so commits succeed under GitIsolatedEnv, which clears global/system config.
+func gitRunnerInDir(t *testing.T, dir string) func(args ...string) string {
+	t.Helper()
+	return func(args ...string) string {
+		t.Helper()
+		cmd := exec.CommandContext(context.Background(), "git", args...)
+		cmd.Dir = dir
+		cmd.Env = testutil.GitIsolatedEnv()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+}
+
 func TestReconcileDisconnected_NoRemote(t *testing.T) {
 	t.Parallel()
 
@@ -842,19 +861,8 @@ func TestMetadataDisconnected_ShallowSuppressesFalsePositive(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	runGit := func(args ...string) string {
-		t.Helper()
-		cmd := exec.CommandContext(context.Background(), "git", args...)
-		cmd.Dir = dir
-		cmd.Env = testutil.GitIsolatedEnv()
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v failed: %v\n%s", args, err, out)
-		}
-		return strings.TrimSpace(string(out))
-	}
-
-	runGit("init", "-b", "main")
+	testutil.InitRepo(t, dir)
+	runGit := gitRunnerInDir(t, dir)
 
 	// Shared ancestor B.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("base"), 0o644))
@@ -878,7 +886,9 @@ func TestMetadataDisconnected_ShallowSuppressesFalsePositive(t *testing.T) {
 	ctx := context.Background()
 
 	// Sanity: with full history they share ancestor B → connected.
-	disconnected, err := metadataDisconnected(ctx, dir, localTip, remoteTip)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	disconnected, err := metadataDisconnected(ctx, repo, dir, localTip, remoteTip)
 	require.NoError(t, err)
 	require.False(t, disconnected, "full-history repo shares ancestor B")
 
@@ -893,11 +903,14 @@ func TestMetadataDisconnected_ShallowSuppressesFalsePositive(t *testing.T) {
 	require.True(t, rawDisconnected,
 		"precondition: shallow boundary should hide the common ancestor from merge-base")
 
-	// The shallow-aware check must suppress the false positive.
-	disconnected, err = metadataDisconnected(ctx, dir, localTip, remoteTip)
+	// The shallow-aware check must suppress the false positive. Re-open so the
+	// storer picks up the freshly written shallow file.
+	shallowRepo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	disconnected, err = metadataDisconnected(ctx, shallowRepo, dir, localTip, remoteTip)
 	require.NoError(t, err)
 	assert.False(t, disconnected,
-		"shallow repo: a merge-base miss must not be treated as a disconnection")
+		"shallow metadata history: a merge-base miss must not be treated as a disconnection")
 }
 
 // TestMetadataDisconnected_GenuineDisconnectionOnFullRepo verifies that on a
@@ -907,19 +920,9 @@ func TestMetadataDisconnected_GenuineDisconnectionOnFullRepo(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	runGit := func(args ...string) string {
-		t.Helper()
-		cmd := exec.CommandContext(context.Background(), "git", args...)
-		cmd.Dir = dir
-		cmd.Env = testutil.GitIsolatedEnv()
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v failed: %v\n%s", args, err, out)
-		}
-		return strings.TrimSpace(string(out))
-	}
+	testutil.InitRepo(t, dir)
+	runGit := gitRunnerInDir(t, dir)
 
-	runGit("init", "-b", "main")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("a"), 0o644))
 	runGit("add", ".")
 	runGit("commit", "-m", "a")
@@ -934,7 +937,9 @@ func TestMetadataDisconnected_GenuineDisconnectionOnFullRepo(t *testing.T) {
 	tipB := runGit("rev-parse", "HEAD")
 
 	ctx := context.Background()
-	disconnected, err := metadataDisconnected(ctx, dir, tipA, tipB)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	disconnected, err := metadataDisconnected(ctx, repo, dir, tipA, tipB)
 	require.NoError(t, err)
 	assert.True(t, disconnected,
 		"non-shallow repo with unrelated roots must be reported as disconnected")

--- a/cmd/entire/cli/strategy/metadata_reconcile_test.go
+++ b/cmd/entire/cli/strategy/metadata_reconcile_test.go
@@ -830,6 +830,116 @@ func TestLoadShallowHashes(t *testing.T) {
 	})
 }
 
+// TestMetadataDisconnected_ShallowSuppressesFalsePositive verifies that a
+// merge-base miss on a SHALLOW repo is not reported as a disconnection. The
+// common ancestor may live below the shallow boundary, where git has no
+// objects, so `git merge-base` falsely reports "no common ancestor".
+// Suppressing this prevents a doomed full-history reconcile on an ordinary
+// diverged-but-behind metadata branch (the shallow-clone incident: local fell
+// behind while out of office, the clone stayed shallow, and merge-base could
+// not see the still-existing shared ancestor).
+func TestMetadataDisconnected_ShallowSuppressesFalsePositive(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	runGit := func(args ...string) string {
+		t.Helper()
+		cmd := exec.CommandContext(context.Background(), "git", args...)
+		cmd.Dir = dir
+		cmd.Env = testutil.GitIsolatedEnv()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	runGit("init", "-b", "main")
+
+	// Shared ancestor B.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("base"), 0o644))
+	runGit("add", ".")
+	runGit("commit", "-m", "base")
+	base := runGit("rev-parse", "HEAD")
+
+	// Remote tip C on top of B.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("remote"), 0o644))
+	runGit("add", ".")
+	runGit("commit", "-m", "remote")
+	remoteTip := runGit("rev-parse", "HEAD")
+
+	// Local tip D, also on top of B (diverged-but-connected).
+	runGit("checkout", "-b", "local", base)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "g.txt"), []byte("local"), 0o644))
+	runGit("add", ".")
+	runGit("commit", "-m", "local")
+	localTip := runGit("rev-parse", "HEAD")
+
+	ctx := context.Background()
+
+	// Sanity: with full history they share ancestor B → connected.
+	disconnected, err := metadataDisconnected(ctx, dir, localTip, remoteTip)
+	require.NoError(t, err)
+	require.False(t, disconnected, "full-history repo shares ancestor B")
+
+	// Make the repo shallow at both tips, cutting B out of view. The shared
+	// ancestor is now hidden and bare merge-base reports no common ancestor.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "shallow"),
+		[]byte(localTip+"\n"+remoteTip+"\n"), 0o644))
+
+	// Precondition: the bare merge-base check now misses.
+	rawDisconnected, err := isDisconnected(ctx, dir, localTip, remoteTip)
+	require.NoError(t, err)
+	require.True(t, rawDisconnected,
+		"precondition: shallow boundary should hide the common ancestor from merge-base")
+
+	// The shallow-aware check must suppress the false positive.
+	disconnected, err = metadataDisconnected(ctx, dir, localTip, remoteTip)
+	require.NoError(t, err)
+	assert.False(t, disconnected,
+		"shallow repo: a merge-base miss must not be treated as a disconnection")
+}
+
+// TestMetadataDisconnected_GenuineDisconnectionOnFullRepo verifies that on a
+// non-shallow repo a real merge-base miss (two unrelated roots) is still
+// reported as disconnected — the suppression only applies to shallow clones.
+func TestMetadataDisconnected_GenuineDisconnectionOnFullRepo(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	runGit := func(args ...string) string {
+		t.Helper()
+		cmd := exec.CommandContext(context.Background(), "git", args...)
+		cmd.Dir = dir
+		cmd.Env = testutil.GitIsolatedEnv()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	runGit("init", "-b", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("a"), 0o644))
+	runGit("add", ".")
+	runGit("commit", "-m", "a")
+	tipA := runGit("rev-parse", "HEAD")
+
+	// Unrelated orphan root — no shared ancestry with tipA.
+	runGit("checkout", "--orphan", "orphan")
+	runGit("rm", "-rf", ".")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "h.txt"), []byte("b"), 0o644))
+	runGit("add", ".")
+	runGit("commit", "-m", "b")
+	tipB := runGit("rev-parse", "HEAD")
+
+	ctx := context.Background()
+	disconnected, err := metadataDisconnected(ctx, dir, tipA, tipB)
+	require.NoError(t, err)
+	assert.True(t, disconnected,
+		"non-shallow repo with unrelated roots must be reported as disconnected")
+}
+
 // TestReconcileDisconnected_AllEmptyOrphans verifies that when all local commits
 // are empty-tree orphan commits (the exact bug artifact), reconciliation resets
 // the local branch to the remote tip without cherry-picking.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/569
<!-- entire-trail-link-end -->

On a shallow checkpoint clone, `git merge-base` reports "no common ancestor" whenever the real ancestor lives below the shallow boundary — git has no objects there. The disconnection check trusted that exit code as proof of disconnection, so an ordinary diverged-but-behind metadata branch on a shallow clone was misread as disconnected. That triggered a full-history cherry-pick reconcile, which then blew MaxCommitTraversalDepth on a deep team branch and aborted both `entire push` and `entire doctor` ("commit chain exceeded 1000 commits without reaching root"), leaving doctor looping on a fix that could never succeed.

checkpoint/v1 clones are routinely shallow (resume/explain fetch the tip with --depth=1 via FetchMetadataTreeOnly and nothing deepens them again), so this hit a normal user who fell behind while out of office.

Fix:
- New metadataDisconnected() only trusts a merge-base miss as a genuine disconnection when the repo is NOT shallow; on a shallow clone the verdict is suppressed and the refs are reported connected. Routed through IsMetadataDisconnected (warn hot path + doctor detection) and ReconcileDisconnectedMetadataRef (push + doctor fix), so the warn path stays network-free and the doomed reconcile no longer fires.
- `entire doctor` now deepens the metadata branch (--unshallow, best-effort, without advancing the local ref) before the check when the repo is shallow, so it can still detect and repair genuine disconnections on an accurate, fully-materialized history.
- Export remote.IsShallowRepository so both packages share one check.

With the false positive gone, push rebases the local-only commits onto the remote tip normally and doctor reports OK instead of erroring. Genuine empty-orphan disconnections are still caught (by doctor after deepening, and on push the rebase cap still refuses to combine unrelated histories).


Entire-Checkpoint: 175693b95a72

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes metadata disconnection detection and doctor fetch behavior on shallow repos; incorrect logic could miss real disconnections or skip needed repair, but behavior is covered by new tests and doctor still deepens before authoritative checks.
> 
> **Overview**
> Fixes false **disconnected metadata** detection on shallow checkpoint clones, where `git merge-base` can report no common ancestor even when local and remote still share history below the shallow boundary.
> 
> **`metadataDisconnected`** only trusts a merge-base miss when the repo is **not** shallow; on shallow clones it reports refs as connected so push/warn paths skip a doomed full-history cherry-pick reconcile (which could hit `MaxCommitTraversalDepth`). **`IsMetadataDisconnected`** and **`ReconcileDisconnectedMetadataRef`** route through this helper.
> 
> **`entire doctor`** best-effort calls new **`DeepenMetadataBranch`** (`--unshallow` fetch of the metadata branch without advancing the local ref) before the disconnection check when the clone is shallow, so genuine disconnections can still be found after history is materialized.
> 
> **`remote.IsShallowRepository`** is exported for shared shallow detection; tests cover shallow false-positive suppression and real disconnections on full repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7742dd751a9c08c0eaca2df09e3ea302a3f63c0e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->