### PR TITLE
fix(trail): repair test build after auth-fallback demolition

### DIFF
--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -4,16 +4,19 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net/http"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/entireio/auth-go/sts"
-	"github.com/entireio/auth-go/tokens"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/cmd/entire/cli/trail"
+	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
 
 const (
@@ -22,14 +25,17 @@ const (
 )
 
 func TestRunTrailListAll_PrintsLoginHintWhenNotLoggedIn(t *testing.T) {
-	// No t.Parallel: SetManagerForTest mutates package-level auth state.
-	store := newAuthMemStore()
-	mgr := newResolveTestManager(t, store, func(context.Context, sts.ExchangeRequest) (*tokens.TokenSet, error) {
-		t.Fatal("exchange should not run when no core token is stored")
-		return nil, errors.New("unreachable")
-	})
-	t.Cleanup(auth.SetManagerForTest(t, mgr))
-	t.Cleanup(auth.SetResolveContextForAPIForTest(t, auth.DiscoveryUnavailableForTest))
+	// No t.Parallel: SetResolveContextForAPIForTest mutates package-level
+	// auth state.
+	//
+	// Discovery selects a context whose keyring slot holds nothing, so the
+	// per-context provider reports ErrNotLoggedIn.
+	t.Cleanup(tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json")))
+	c := &contexts.Context{Name: "me@core", CoreURL: "https://core.example", Handle: "me", KeychainService: "kc:me"}
+	t.Cleanup(auth.SetResolveContextForAPIForTest(t,
+		func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+			return c, nil
+		}))
 
 	var out, errOut bytes.Buffer
 	err := runTrailListAll(t.Context(), &out, &errOut, defaultTrailListOptions(false))
@@ -53,14 +59,16 @@ func TestRunTrailListAll_PrintsLoginHintWhenNotLoggedIn(t *testing.T) {
 }
 
 func TestRunTrailListAll_ValidatesOptionsBeforeAuth(t *testing.T) {
-	// No t.Parallel: SetManagerForTest mutates package-level auth state.
-	store := newAuthMemStore()
-	mgr := newResolveTestManager(t, store, func(context.Context, sts.ExchangeRequest) (*tokens.TokenSet, error) {
-		t.Fatal("exchange should not run for invalid local options")
-		return nil, errors.New("unreachable")
-	})
-	t.Cleanup(auth.SetManagerForTest(t, mgr))
-	t.Cleanup(auth.SetResolveContextForAPIForTest(t, auth.DiscoveryUnavailableForTest))
+	// No t.Parallel: SetResolveContextForAPIForTest mutates package-level
+	// auth state.
+	//
+	// Discovery must never run for invalid local options: validation has to
+	// short-circuit before any auth resolution.
+	t.Cleanup(auth.SetResolveContextForAPIForTest(t,
+		func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+			t.Fatal("discovery should not run for invalid local options")
+			return nil, errors.New("unreachable")
+		}))
 
 	opts := defaultTrailListOptions(false)
 	opts.Limit = 0

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -25,8 +25,8 @@ const (
 )
 
 func TestRunTrailListAll_PrintsLoginHintWhenNotLoggedIn(t *testing.T) {
-	// No t.Parallel: SetResolveContextForAPIForTest mutates package-level
-	// auth state.
+	// No t.Parallel: SetResolveContextForAPIForTest and
+	// tokenstore.UseFileBackendForTesting mutate package-level state.
 	//
 	// Discovery selects a context whose keyring slot holds nothing, so the
 	// per-context provider reports ErrNotLoggedIn.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/571
<!-- entire-trail-link-end -->

## What

`mise run lint` is red on `main`: the `cli` package test binary fails to typecheck.

```
cmd/entire/cli/trail_cmd_test.go:26:11: undefined: newAuthMemStore
cmd/entire/cli/trail_cmd_test.go:27:9:  undefined: newResolveTestManager
cmd/entire/cli/trail_cmd_test.go:31:17: undefined: auth.SetManagerForTest
cmd/entire/cli/trail_cmd_test.go:32:56: undefined: auth.DiscoveryUnavailableForTest
```

This rewrites the two affected tests (`TestRunTrailListAll_PrintsLoginHintWhenNotLoggedIn`, `TestRunTrailListAll_ValidatesOptionsBeforeAuth`) to use the surviving discovery seam `auth.SetResolveContextForAPIForTest` + `tokenstore.UseFileBackendForTesting`, mirroring the pattern already used by `activity_cmd_test.go`. Asserted behaviour is unchanged.

## How this happened on main

Two PRs that were each green in isolation produced a **semantic merge conflict** — no textual overlap, so git merged them cleanly, but the result doesn't compile:

1. **#1410** (`paul/cor-393-demolish-auth-fallbacks`, commit `10aa97eec`) **deleted** the auth test helpers `SetManagerForTest`, `newResolveTestManager`, `newAuthMemStore`, and `DiscoveryUnavailableForTest` as part of moving data-API auth to discovery-only resolution.
2. The **trail-list** PR (commit `16beeac52`, "Validate trail list options before auth") **added** `trail_cmd_test.go`, which depends on exactly those helpers.

Each branch compiled against its own base. Once both landed on `main`, the test file referenced symbols that no longer exist. CI on each PR didn't catch it because neither branch contained both halves. (A `main` merge into the trail branch before landing, or a required up-to-date-with-base check, would have surfaced it.)

## Verification

- `go test ./cmd/entire/cli/ -run 'TestRunTrailListAll_...'` → ok
- `mise run fmt && mise run lint` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that mirror an existing pattern; no production auth or trail logic is modified.
> 
> **Overview**
> Restores **`cmd/entire/cli` test compilation** after auth-fallback helpers were removed from `main`. The two `TestRunTrailListAll_*` tests no longer use `SetManagerForTest`, `newResolveTestManager`, `newAuthMemStore`, or `DiscoveryUnavailableForTest`.
> 
> **Not logged in:** Uses `tokenstore.UseFileBackendForTesting` with an empty token file plus `auth.SetResolveContextForAPIForTest` returning a fixed `contexts.Context`, so discovery succeeds but the keyring slot is empty and `ErrNotLoggedIn` still drives the login hint (same assertions as before).
> 
> **Validation before auth:** Stubs discovery with a hook that `t.Fatal`s if called, so invalid options (e.g. `limit = 0`) fail locally without auth resolution.
> 
> Imports drop `auth-go` STS/token types and add `net/http`, `filepath`, and the `clusterdiscovery` / `contexts` / `tokenstore` packages—aligned with **`activity_cmd_test.go`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708725e3b1166abbe88988de015f30b477ab6ee3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->