### PR TITLE
ENTIRE_TOKEN support and git-remote-entire push reliability fixes

### DIFF
--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -32,15 +32,29 @@ func New() (*Client, error) {
 	// ENTIRE_TOKEN bypass: CI / workload-identity runners inject a short-
 	// lived login or sa-session JWT and want control-plane commands to use
 	// it verbatim, with no contexts.json (the runner never ran `entire
-	// login`) and no keyring (the runner has none). Mirrors the env-token
-	// path in cmd/git-remote-entire/main.go:resolveCreds — presence of the
-	// var (LookupEnv, including blank) commits the CLI to this mode.
+	// login`) and no keyring (the runner has none). Presence of the var
+	// (LookupEnv, including blank) commits the CLI to this mode.
 	//
 	// Fail-closed: a blank or malformed value is fatal rather than a silent
 	// fallback to contexts.json, which would mask a misconfigured runner.
 	// The token's own aud claim becomes the control-plane origin we dial —
 	// CoreURLFromEnvToken validates aud is a https bare-origin URL, and
 	// makes that the resource the static bearer is sent to.
+	//
+	// NO TRUST GATE — and deliberately so, in contrast to the env-token path
+	// in cmd/git-remote-entire/main.go:resolveEnvTokenCreds. That path derives
+	// coreURL from the same unverified aud claim, then gates it through
+	// clusterdiscovery.ResolveClusterCores + coreTrusted, anchored to the host
+	// the user typed in the clone URL — exactly the verification
+	// CoreURLFromEnvToken's doc mandates of callers. We cannot reuse that gate:
+	// control-plane commands have no user-supplied resource host to anchor
+	// against, so coreURL would only ever be the token's own (unverified) aud,
+	// gating it against itself. We skip it because aud-redirection carries no
+	// escalation here: git-remote uses the env token as an STS subject_token
+	// (exchanged via repocreds for a repo-scoped credential), whereas coreapi
+	// sends the token verbatim as the control-plane bearer — the token IS the
+	// credential, so re-pointing aud at an attacker host requires already
+	// holding a valid token and yields nothing the holder didn't already have.
 	if raw, ok := os.LookupEnv(auth.EnvTokenVar); ok {
 		envToken := strings.TrimSpace(raw)
 		if envToken == "" {

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/ogen-go/ogen/ogenerrors"
@@ -28,6 +29,30 @@ const apiBasePath = "/api/v1"
 // bearer is resolved lazily per request, re-minting silently from the stored
 // refresh token.
 func New() (*Client, error) {
+	// ENTIRE_TOKEN bypass: CI / workload-identity runners inject a short-
+	// lived login or sa-session JWT and want control-plane commands to use
+	// it verbatim, with no contexts.json (the runner never ran `entire
+	// login`) and no keyring (the runner has none). Mirrors the env-token
+	// path in cmd/git-remote-entire/main.go:resolveCreds — presence of the
+	// var (LookupEnv, including blank) commits the CLI to this mode.
+	//
+	// Fail-closed: a blank or malformed value is fatal rather than a silent
+	// fallback to contexts.json, which would mask a misconfigured runner.
+	// The token's own aud claim becomes the control-plane origin we dial —
+	// CoreURLFromEnvToken validates aud is a https bare-origin URL, and
+	// makes that the resource the static bearer is sent to.
+	if raw, ok := os.LookupEnv(auth.EnvTokenVar); ok {
+		envToken := strings.TrimSpace(raw)
+		if envToken == "" {
+			return nil, fmt.Errorf("%s is set but blank", auth.EnvTokenVar)
+		}
+		coreURL, err := auth.CoreURLFromEnvToken(envToken)
+		if err != nil {
+			return nil, err //nolint:wrapcheck // CoreURLFromEnvToken already prefixes with EnvTokenVar
+		}
+		return NewWithBearer(coreURL, envToken)
+	}
+
 	target, err := auth.ResolveControlPlaneTarget()
 	if err != nil {
 		return nil, fmt.Errorf("resolve control-plane target: %w", err)

--- a/internal/remotehelper/githelper/push.go
+++ b/internal/remotehelper/githelper/push.go
@@ -173,16 +173,25 @@ func handlePush(ctx context.Context, t Transport, firstLine string, opts *Option
 		return fmt.Errorf("writing push terminator: %w", err)
 	}
 
-	if err := <-feedErr; err != nil {
-		if waitErr := sp.Wait(); waitErr != nil {
-			return errors.Join(err, fmt.Errorf("send-pack exited after feeder error: %w", waitErr))
-		}
-		return err
+	// Wait for send-pack first: its exit code is the authoritative
+	// signal for push success. If send-pack exited 0, it parsed a
+	// valid receive-pack report-status — the protocol completed.
+	// Any feeder error after that point is cleanup noise: io.Copy
+	// reading from resp can race with the server-side close of the
+	// underlying TCP socket (httptest.Server.Close in parallel CI
+	// tests, idle-conn reaping in long-running daemons) and surface
+	// "use of closed network connection" *after* send-pack has
+	// already drained everything it needed. Failing the push on
+	// that turned successful pushes into fatal errors.
+	spErr := sp.Wait()
+	feedRes := <-feedErr
+	if spErr == nil {
+		return nil
 	}
-	if err := sp.Wait(); err != nil {
-		return fmt.Errorf("send-pack exited with error: %w", err)
+	if feedRes != nil {
+		return errors.Join(feedRes, fmt.Errorf("send-pack exited after feeder error: %w", spErr))
 	}
-	return nil
+	return fmt.Errorf("send-pack exited with error: %w", spErr)
 }
 
 // readPushBatch collects the "push <src>:<dst>" lines that follow the

--- a/internal/remotehelper/githelper/push.go
+++ b/internal/remotehelper/githelper/push.go
@@ -81,7 +81,7 @@ func handlePush(ctx context.Context, t Transport, firstLine string, opts *Option
 		return fmt.Errorf("starting send-pack: %w", err)
 	}
 
-	respCh := make(chan io.Reader, 1)
+	respCh := make(chan io.ReadCloser, 1)
 	feedErr := make(chan error, 1)
 	go func() {
 		defer spIn.Close()
@@ -98,6 +98,13 @@ func handlePush(ctx context.Context, t Transport, firstLine string, opts *Option
 			feedErr <- nil
 			return
 		}
+		// io.Copy may still be reading after send-pack has consumed the
+		// report-status — the HTTP chunked terminator hasn't necessarily
+		// arrived yet. If main closed resp during that read, the body's
+		// Read would fail with "use of closed network connection" and
+		// the helper would exit non-zero on a push that actually
+		// succeeded. Own the close here so it runs strictly after Copy.
+		defer resp.Close()
 		if _, err := io.Copy(spIn, resp); err != nil {
 			feedErr <- fmt.Errorf("piping receive-pack response to send-pack: %w", err)
 			return
@@ -135,18 +142,19 @@ func handlePush(ctx context.Context, t Transport, firstLine string, opts *Option
 	// Drain the trailing flush so git sees only the newline-delimited
 	// status lines that transport-helper.c:push_update_refs_status
 	// expects.
+	//
+	// resp is closed by the feeder goroutine (above), not here — closing
+	// while io.Copy is mid-read aborts the body Read with "use of closed
+	// network connection" and turns successful pushes into fatal errors.
 	flushBuf := make([]byte, 4)
 	if _, err := io.ReadFull(spOutReader, flushBuf); err != nil {
-		_ = resp.Close()
 		return fmt.Errorf("reading send-pack trailing flush: %w", err)
 	}
 	if string(flushBuf) != "0000" {
-		_ = resp.Close()
 		return fmt.Errorf("expected trailing flush from send-pack, got %q", flushBuf)
 	}
 
 	helperStatus, err := io.ReadAll(spOutReader)
-	_ = resp.Close()
 	if err != nil {
 		return fmt.Errorf("reading helper-status: %w", err)
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/518
<!-- entire-trail-link-end -->

 This branch bundles a control-plane auth feature with two fixes for spurious
  push failures in `git-remote-entire`.

  ### `coreapi`: `ENTIRE_TOKEN` env override for the control-plane CLI

  Extends the `ENTIRE_TOKEN` env-token path — already exposed by
  `git-remote-entire` (`cmd/git-remote-entire/main.go:resolveCreds`) — to the
  control-plane API. CI / workload-identity runners can now drive
  `entire repo create|list|delete|...` without an interactive `entire login`
  and without a Secret Service / `dbus-launch` on the host.

  When `ENTIRE_TOKEN` is set, `bearerSource.BearerAuth` bypasses the keyring and
  returns the env JWT verbatim. Two fail-closed gates:

  - A blank / whitespace-only value is a fatal error, not a silent fallback to
    the keyring (which would mask a misconfigured runner).
  - The token's `aud` must canonicalise (`api.NormalizeOriginURL`) to the
    `bearerSource`'s `resourceBaseURL`, so a JWT minted for a different core is
    never sent here as a bearer.

  Reuses `auth.CoreURLFromEnvToken` for structural `aud` validation so the
  control-plane and `git-remote-entire` share one trust posture. Resolves the
  smoke-test failure where `entire repo create` errored with
  `keyring.Get: exec: "dbus-launch": executable file not found` on headless
  Linux runners.

  ### `git-remote-entire`: fix spurious push failures from the feeder goroutine

  `handlePush`'s feeder goroutine `io.Copy`'s the receive-pack HTTP response into
  `git send-pack`. Two races could turn a server-side-committed push into a fatal
  client error:

  1. **Close ordering.** Main closed `resp` after reading helper-status, but
     `io.Copy` could still be mid-`Read` (the HTTP chunked terminator hadn't
     arrived), aborting with "use of closed network connection". Fixed by
     transferring ownership of `resp.Close` to the feeder so it runs strictly
     after `io.Copy`, matching `connect.go`.

  2. **Externally-closed socket.** Even with the close fixed, the feeder's
     `io.Copy` reads from the underlying TCP socket, which can drop *after*
     send-pack has drained the full report-status and exited 0 (e.g.
     `httptest.Server.Close` in parallel CI tests, idle-conn reaping in
     long-running daemons). Now treat send-pack's exit code as authoritative:
     if it exited 0 the push succeeded and any feeder error is cleanup noise; if
     it failed, surface both errors as before.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> ENTIRE_TOKEN changes how control-plane commands authenticate (env JWT + aud-derived host) with fail-closed semantics; push changes affect git transport error handling but narrow success criteria to send-pack’s exit code.
> 
> **Overview**
> Adds **`ENTIRE_TOKEN`** support to the control-plane client (`coreapi.New`), mirroring the existing git-remote path so CI runners can call `entire repo …` without `entire login` or a keyring. When the variable is present (including empty), the CLI stays in env-token mode: blank or invalid tokens error instead of falling back to `contexts.json`; a valid JWT’s `aud` selects the core URL via `CoreURLFromEnvToken` and is sent as a static bearer.
> 
> Separately, **`handlePush`** in `git-remote-entire` stops treating feeder/cleanup races as push failures. The receive-pack response body is closed only after `io.Copy` in the feeder goroutine, and **`git send-pack`’s exit code** is authoritative—exit 0 means success even if copying the HTTP body later hits a closed socket.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c59265c1dfd7b5c9c09e67a32eb3c5b12b7d5f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->