### PR TITLE
repo create: stamp a usable entire:// remote in the JSON output

### DIFF
--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -39,6 +42,52 @@ func repoRow(r coreapi.Repo) []string {
 	return []string{r.ID, r.Name, r.OwningProjectId, r.ClusterHost.Or("-"), state}
 }
 
+// repoRemoteURL synthesizes the entire:// clone/remote URL for a repo from
+// its resolved cluster host and path — the form `git clone` and
+// `git remote add` accept, which git-remote-entire reads back as the repo
+// slug from the URL path. Returns "" when either coordinate is missing (a
+// still-provisioning repo may not have them yet); a half-formed URL is worse
+// than none.
+func repoRemoteURL(r coreapi.Repo) string {
+	host := strings.TrimSpace(r.ClusterHost.Or(""))
+	path := strings.TrimSpace(r.Path.Or(""))
+	if host == "" || path == "" {
+		return ""
+	}
+	return "entire://" + host + "/" + strings.TrimPrefix(path, "/")
+}
+
+// repoCreateOutput renders a created repo as JSON with a synthesized `remote`
+// field merged in — the entire:// URL callers paste into `git clone` or
+// `git remote add`. The repo carries a custom marshaler plus arbitrary
+// additional properties, so it can't simply be embedded in a wrapper struct;
+// instead it's round-tripped through its own encoder and the remote is merged
+// into the resulting object. The synthesis only fills a gap: if the wire
+// object already carries a `remote` (a future first-class field, or one
+// arriving via additional properties) it's left untouched, so the
+// server-provided value always wins. The field is omitted when the clone
+// coordinates aren't resolvable yet rather than emitted half-formed.
+func repoCreateOutput(r *coreapi.Repo) (any, error) {
+	raw, err := json.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("encode repo: %w", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, fmt.Errorf("decode repo: %w", err)
+	}
+	if _, ok := obj["remote"]; !ok {
+		if remote := repoRemoteURL(*r); remote != "" {
+			encoded, err := json.Marshal(remote)
+			if err != nil {
+				return nil, fmt.Errorf("encode remote: %w", err)
+			}
+			obj["remote"] = encoded
+		}
+	}
+	return obj, nil
+}
+
 func newRepoCreateCmd() *cobra.Command {
 	var (
 		projectID   string
@@ -57,7 +106,11 @@ func newRepoCreateCmd() *cobra.Command {
 				if clusterHost != "" {
 					body.ClusterHost = coreapi.NewOptString(clusterHost)
 				}
-				return c.CreateRepo(ctx, body)
+				created, err := c.CreateRepo(ctx, body)
+				if err != nil {
+					return nil, err
+				}
+				return repoCreateOutput(created)
 			})
 		},
 	}

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -68,6 +69,9 @@ func repoRemoteURL(r coreapi.Repo) string {
 // server-provided value always wins. The field is omitted when the clone
 // coordinates aren't resolvable yet rather than emitted half-formed.
 func repoCreateOutput(r *coreapi.Repo) (any, error) {
+	if r == nil {
+		return nil, errors.New("nil repo")
+	}
 	raw, err := json.Marshal(r)
 	if err != nil {
 		return nil, fmt.Errorf("encode repo: %w", err)

--- a/cmd/entire/cli/repo_test.go
+++ b/cmd/entire/cli/repo_test.go
@@ -128,6 +128,16 @@ func TestRepoCreateOutput_PreservesServerProvidedRemote(t *testing.T) {
 	}
 }
 
+func TestRepoCreateOutput_NilRepoErrors(t *testing.T) {
+	t.Parallel()
+	// Defends the contract rather than a real path (the caller only passes a
+	// repo after a nil-error create): a nil pointer must return an error, not
+	// panic on the later dereference.
+	if _, err := repoCreateOutput(nil); err == nil {
+		t.Fatal("expected an error for a nil repo, got nil")
+	}
+}
+
 func TestRepoCreateOutput_OmitsRemoteWhenUnresolvable(t *testing.T) {
 	t.Parallel()
 	// A still-provisioning repo may lack a path; omit the field rather than

--- a/cmd/entire/cli/repo_test.go
+++ b/cmd/entire/cli/repo_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-faster/jx"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+func TestRepoRemoteURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		repo coreapi.Repo
+		want string
+	}{
+		{
+			name: "host and path produce an entire:// URL",
+			repo: coreapi.Repo{
+				ClusterHost: coreapi.NewOptString("aws-us-east-2.entire.io"),
+				Path:        coreapi.NewOptString("acme/web"),
+			},
+			want: "entire://aws-us-east-2.entire.io/acme/web",
+		},
+		{
+			name: "leading slash on path is not doubled",
+			repo: coreapi.Repo{
+				ClusterHost: coreapi.NewOptString("aws-us-east-2.entire.io"),
+				Path:        coreapi.NewOptString("/acme/web"),
+			},
+			want: "entire://aws-us-east-2.entire.io/acme/web",
+		},
+		{
+			name: "missing host yields no URL",
+			repo: coreapi.Repo{Path: coreapi.NewOptString("acme/web")},
+			want: "",
+		},
+		{
+			name: "missing path yields no URL",
+			repo: coreapi.Repo{ClusterHost: coreapi.NewOptString("aws-us-east-2.entire.io")},
+			want: "",
+		},
+		{
+			name: "blank coordinates yield no URL",
+			repo: coreapi.Repo{
+				ClusterHost: coreapi.NewOptString("  "),
+				Path:        coreapi.NewOptString(""),
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := repoRemoteURL(tt.repo); got != tt.want {
+				t.Errorf("repoRemoteURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoCreateOutput_StampsRemote(t *testing.T) {
+	t.Parallel()
+	repo := &coreapi.Repo{
+		ID:              "01KS6KFJR2XS6PZ188MVYE07AN",
+		Name:            "web",
+		OwningProjectId: "01KS6KFJR2XS6PZ188MVYE07AP",
+		ClusterHost:     coreapi.NewOptString("aws-us-east-2.entire.io"),
+		Path:            coreapi.NewOptString("acme/web"),
+	}
+	out, err := repoCreateOutput(repo)
+	if err != nil {
+		t.Fatalf("repoCreateOutput() error = %v", err)
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal output: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if want := "entire://aws-us-east-2.entire.io/acme/web"; got["remote"] != want {
+		t.Errorf("remote = %v, want %q", got["remote"], want)
+	}
+	// The original repo fields must survive the round-trip alongside the
+	// synthesized remote.
+	if got["id"] != repo.ID {
+		t.Errorf("id = %v, want %q", got["id"], repo.ID)
+	}
+	if got["name"] != repo.Name {
+		t.Errorf("name = %v, want %q", got["name"], repo.Name)
+	}
+}
+
+func TestRepoCreateOutput_PreservesServerProvidedRemote(t *testing.T) {
+	t.Parallel()
+	// A server-provided `remote` (here via additional properties, the same
+	// path a future first-class field would surface through) must win over
+	// the synthesized one — synthesis only fills a gap.
+	const serverRemote = "entire://override.entire.io/server/value"
+	repo := &coreapi.Repo{
+		ID:              "01KS6KFJR2XS6PZ188MVYE07AN",
+		Name:            "web",
+		OwningProjectId: "01KS6KFJR2XS6PZ188MVYE07AP",
+		ClusterHost:     coreapi.NewOptString("aws-us-east-2.entire.io"),
+		Path:            coreapi.NewOptString("acme/web"),
+		AdditionalProps: coreapi.RepoAdditional{
+			"remote": jx.Raw(`"` + serverRemote + `"`),
+		},
+	}
+	out, err := repoCreateOutput(repo)
+	if err != nil {
+		t.Fatalf("repoCreateOutput() error = %v", err)
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal output: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if got["remote"] != serverRemote {
+		t.Errorf("remote = %v, want server-provided %q", got["remote"], serverRemote)
+	}
+}
+
+func TestRepoCreateOutput_OmitsRemoteWhenUnresolvable(t *testing.T) {
+	t.Parallel()
+	// A still-provisioning repo may lack a path; omit the field rather than
+	// emit a half-formed URL.
+	repo := &coreapi.Repo{
+		ID:              "01KS6KFJR2XS6PZ188MVYE07AN",
+		Name:            "web",
+		OwningProjectId: "01KS6KFJR2XS6PZ188MVYE07AP",
+		ClusterHost:     coreapi.NewOptString("aws-us-east-2.entire.io"),
+	}
+	out, err := repoCreateOutput(repo)
+	if err != nil {
+		t.Fatalf("repoCreateOutput() error = %v", err)
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal output: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if _, ok := got["remote"]; ok {
+		t.Errorf("expected no remote field, got %v", got["remote"])
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/574
<!-- entire-trail-link-end -->

`entire repo create` echoed the raw Repo wire JSON, which has clusterHost and path but no ready-to-use clone/remote URL. Synthesize a `remote` field of the form entire://<clusterHost>/<path> (the form git clone and git-remote-entire accept), merged into the create output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only JSON shaping for repo create with no auth or data-path changes; behavior is additive and guarded when clone coordinates are incomplete.
> 
> **Overview**
> **`entire repo create`** no longer returns only the raw API `Repo` JSON. After create succeeds, output is passed through **`repoCreateOutput`**, which adds a **`remote`** field when **`clusterHost`** and **`path`** are both present: an **`entire://<host>/<path>`** URL (leading slashes on path are normalized) suitable for **`git clone`** / **`git remote add`**.
> 
> If either coordinate is missing or blank—e.g. a still-provisioning repo—the **`remote`** key is **omitted** rather than emitting a partial URL. Implementation uses JSON marshal/unmarshal on the repo object so existing fields and custom marshaling stay intact while **`remote`** is merged in.
> 
> Unit tests cover URL synthesis edge cases and create-output behavior (stamps **`remote`**, preserves other fields, omits when unresolvable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db50a217116d8b6cb93665c260399a5db13b8bf4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->