### PR TITLE
git_operations: stop shallow-fetching the metadata tip (root-cause fix for shallow-metadata false-disconnect)

### DIFF
--- a/cmd/entire/cli/checkpoint/remote/git.go
+++ b/cmd/entire/cli/checkpoint/remote/git.go
@@ -45,6 +45,15 @@ type FetchOptions struct {
 	// checkpoint ancestry. Do not set on generic branch fetches — it would
 	// silently convert a deliberately-shallow user clone into a full one.
 	Unshallow bool
+	// Depth adds --depth=<Depth>, fetching the refspec to this absolute depth.
+	// Unlike Unshallow (which is repo-global) this is ref-scoped: it fully
+	// fetches the named branch — healing a prior shallow boundary on it — while
+	// leaving an independently-shallow source-tree clone untouched, and it does
+	// not introduce shallowness on a full repo when the value exceeds the
+	// branch's length. Use a value above the branch's realistic length but below
+	// math.MaxInt32 (2147483647), which git special-cases as a global unshallow.
+	// Ignored when zero or when Shallow is set.
+	Depth     int
 	Dir       string   // working directory (empty = CWD)
 	ExtraArgs []string // additional flags before remote (e.g., "--no-write-fetch-head")
 }
@@ -65,6 +74,8 @@ func Fetch(ctx context.Context, opts FetchOptions) ([]byte, error) {
 	switch {
 	case opts.Shallow:
 		args = append(args, "--depth=1")
+	case opts.Depth > 0:
+		args = append(args, fmt.Sprintf("--depth=%d", opts.Depth))
 	case opts.Unshallow && isShallowRepository(ctx, opts.Dir):
 		args = append(args, "--unshallow")
 	}

--- a/cmd/entire/cli/checkpoint/remote/git_test.go
+++ b/cmd/entire/cli/checkpoint/remote/git_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -322,6 +323,72 @@ func TestFetch_Shallow(t *testing.T) {
 
 	assert.True(t, isShallowRepository(ctx, cloneDir),
 		"Shallow=true should request --depth=1 and leave the repo shallow")
+}
+
+// TestFetch_Depth verifies that Depth is ref-scoped: it fully fetches (heals)
+// the named branch while leaving an independently-shallow branch shallow —
+// unlike Unshallow, which is repo-global.
+func TestFetch_Depth(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	bareDir := filepath.Join(tmpDir, "bare.git")
+	seedDir := filepath.Join(tmpDir, "seed")
+	runIsolatedGit(ctx, t, "", "init", "--bare", bareDir)
+
+	testutil.InitRepo(t, seedDir)
+	runIsolatedGit(ctx, t, seedDir, "remote", "add", "origin", bareDir)
+	for _, c := range []string{"m1", "m2", "m3"} { // main: 3 commits
+		testutil.WriteFile(t, seedDir, "f.txt", c)
+		testutil.GitAdd(t, seedDir, "f.txt")
+		testutil.GitCommit(t, seedDir, c)
+	}
+	runIsolatedGit(ctx, t, seedDir, "push", "origin", "HEAD:refs/heads/main")
+	runIsolatedGit(ctx, t, seedDir, "checkout", "--orphan", "meta")
+	runIsolatedGit(ctx, t, seedDir, "rm", "-rf", ".")
+	for _, c := range []string{"c1", "c2"} { // meta: 2 commits
+		testutil.WriteFile(t, seedDir, "g.txt", c)
+		testutil.GitAdd(t, seedDir, "g.txt")
+		testutil.GitCommit(t, seedDir, c)
+	}
+	runIsolatedGit(ctx, t, seedDir, "push", "origin", "HEAD:refs/heads/meta")
+
+	// Shallow clone of main + shallow fetch of meta → both branches shallow.
+	cloneDir := filepath.Join(tmpDir, "clone")
+	runIsolatedGit(ctx, t, "", "clone", "--depth=1", "--single-branch", "--branch", "main", "file://"+bareDir, cloneDir)
+	runIsolatedGit(ctx, t, cloneDir, "fetch", "--depth=1", "origin", "+refs/heads/meta:refs/remotes/origin/meta")
+	require.True(t, isShallowRepository(ctx, cloneDir))
+	require.Equal(t, 1, revListCount(ctx, t, cloneDir, "refs/remotes/origin/meta"))
+	require.Equal(t, 1, revListCount(ctx, t, cloneDir, "refs/remotes/origin/main"))
+
+	out, err := Fetch(ctx, FetchOptions{
+		Remote:   "file://" + bareDir,
+		RefSpecs: []string{"+refs/heads/meta:refs/remotes/origin/meta"},
+		NoTags:   true,
+		Depth:    1_000_000_000,
+		Dir:      cloneDir,
+	})
+	require.NoError(t, err, "fetch output: %s", out)
+
+	assert.Equal(t, 2, revListCount(ctx, t, cloneDir, "refs/remotes/origin/meta"),
+		"Depth should fully fetch (heal) the named branch")
+	assert.Equal(t, 1, revListCount(ctx, t, cloneDir, "refs/remotes/origin/main"),
+		"Depth is ref-scoped: an independently-shallow branch must stay shallow")
+	assert.True(t, isShallowRepository(ctx, cloneDir),
+		"repo stays shallow because main is still bounded")
+}
+
+func revListCount(ctx context.Context, t *testing.T, dir, ref string) int {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, "git", "rev-list", "--count", ref)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	require.NoError(t, err)
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	require.NoError(t, err)
+	return n
 }
 
 // setupShallowClone creates a bare origin, a seed repo with one commit pushed

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -407,8 +407,6 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 // FetchMetadataBranch fetches the entire/checkpoints/v1 branch from origin
 // with full blob content. Used as a fallback by resume/explain when the
 // tree-only probe is insufficient (e.g. the metadata.json blob is missing).
-// Does NOT --unshallow: --unshallow is a global property of the clone, so on
-// shallow checkpoint repos it would also deepen unrelated branches.
 func FetchMetadataBranch(ctx context.Context) error {
 	return fetchMetadataFromOrigin(ctx, true /* noFilter */)
 }
@@ -427,6 +425,9 @@ func FetchMetadataBranch(ctx context.Context) error {
 // (see strategy.IsMetadataDisconnected). Fetching at full depth keeps the
 // remote-tracking ref connected; git fetches incrementally, so after the first
 // fetch only new commits/trees travel.
+//
+// It also unshallows a repo that an older CLI already shallowed, so the boundary
+// left by a prior --depth=1 fetch is removed rather than lingering forever.
 func FetchMetadataTreeOnly(ctx context.Context) error {
 	return fetchMetadataFromOrigin(ctx, false /* noFilter */)
 }
@@ -453,6 +454,13 @@ func fetchMetadataFromOrigin(ctx context.Context, noFilter bool) error {
 		RefSpecs: []string{refSpec},
 		NoTags:   true,
 		NoFilter: noFilter,
+		// Heal a repo that an older CLI already shallowed with --depth=1: the
+		// metadata tip is grafted in .git/shallow, which breaks merge-base
+		// connectivity checks for the metadata branch. remote.Fetch only adds
+		// --unshallow when the repo is actually shallow, so this is a no-op on a
+		// normally-cloned repo and only does work where a prior shallow boundary
+		// needs removing.
+		Unshallow: true,
 	})
 	if fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -413,17 +413,26 @@ func FetchMetadataBranch(ctx context.Context) error {
 	return fetchMetadataFromOrigin(ctx, fetchMetadataOpts{NoFilter: true})
 }
 
-// FetchMetadataTreeOnly fetches just the tip of the entire/checkpoints/v1
-// branch (--depth=1). Used by resume/explain to resolve the latest checkpoint
-// cheaply without pulling the entire history. May leave .git/shallow set;
-// FetchMetadataBranch will undo that when full ancestry is later needed.
+// FetchMetadataTreeOnly fetches the entire/checkpoints/v1 commit+tree graph
+// from origin to resolve the latest checkpoint, relying on --filter=blob:none
+// (when filtered fetches are enabled) to skip blob content rather than on a
+// shallow --depth=1 fetch.
+//
+// It deliberately does NOT use --depth=1. A depth-1 fetch adds the fetched tip
+// to .git/shallow, and any ref pointing at a shallow commit (the durable
+// refs/remotes/origin/<branch> that git updates opportunistically, or the local
+// primary) can no longer be walked past that boundary. A later `git merge-base`
+// against it then falsely reports "no common ancestor", which makes push and
+// `entire doctor` treat an ordinary diverged-but-behind branch as disconnected
+// (see strategy.IsMetadataDisconnected). Fetching at full depth keeps the
+// remote-tracking ref connected; git fetches incrementally, so after the first
+// fetch only new commits/trees travel.
 func FetchMetadataTreeOnly(ctx context.Context) error {
-	return fetchMetadataFromOrigin(ctx, fetchMetadataOpts{Shallow: true})
+	return fetchMetadataFromOrigin(ctx, fetchMetadataOpts{})
 }
 
 type fetchMetadataOpts struct {
 	NoFilter  bool
-	Shallow   bool
 	Unshallow bool
 }
 
@@ -449,7 +458,6 @@ func fetchMetadataFromOrigin(ctx context.Context, fopts fetchMetadataOpts) error
 		RefSpecs:  []string{refSpec},
 		NoTags:    true,
 		NoFilter:  fopts.NoFilter,
-		Shallow:   fopts.Shallow,
 		Unshallow: fopts.Unshallow,
 	})
 	if fetchErr != nil {

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -404,6 +404,13 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 	return CheckoutBranch(ctx, branchName)
 }
 
+// metadataFetchDepth is the absolute --depth used when fetching the metadata
+// branch. It is far above any realistic checkpoint-branch length, so it fully
+// fetches the branch (and heals a prior --depth=1 shallow boundary on it),
+// while staying below math.MaxInt32 (2147483647) — which git special-cases as
+// a global unshallow that would also deepen an unrelated shallow source tree.
+const metadataFetchDepth = 1_000_000_000
+
 // FetchMetadataBranch fetches the entire/checkpoints/v1 branch from origin
 // with full blob content. Used as a fallback by resume/explain when the
 // tree-only probe is insufficient (e.g. the metadata.json blob is missing).
@@ -426,8 +433,9 @@ func FetchMetadataBranch(ctx context.Context) error {
 // remote-tracking ref connected; git fetches incrementally, so after the first
 // fetch only new commits/trees travel.
 //
-// It also unshallows a repo that an older CLI already shallowed, so the boundary
-// left by a prior --depth=1 fetch is removed rather than lingering forever.
+// It also heals a repo that an older CLI already shallowed: the ref-scoped deep
+// fetch removes the boundary left by a prior --depth=1 fetch rather than letting
+// it linger forever, without deepening an independently-shallow source tree.
 func FetchMetadataTreeOnly(ctx context.Context) error {
 	return fetchMetadataFromOrigin(ctx, false /* noFilter */)
 }
@@ -456,11 +464,11 @@ func fetchMetadataFromOrigin(ctx context.Context, noFilter bool) error {
 		NoFilter: noFilter,
 		// Heal a repo that an older CLI already shallowed with --depth=1: the
 		// metadata tip is grafted in .git/shallow, which breaks merge-base
-		// connectivity checks for the metadata branch. remote.Fetch only adds
-		// --unshallow when the repo is actually shallow, so this is a no-op on a
-		// normally-cloned repo and only does work where a prior shallow boundary
-		// needs removing.
-		Unshallow: true,
+		// connectivity checks for the metadata branch. A ref-scoped deep fetch
+		// removes that boundary without deepening an independently-shallow
+		// source-tree clone (unlike --unshallow), and is a no-op on a normally
+		// cloned repo.
+		Depth: metadataFetchDepth,
 	})
 	if fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -410,7 +410,7 @@ func FetchAndCheckoutRemoteBranch(ctx context.Context, branchName string) error 
 // Does NOT --unshallow: --unshallow is a global property of the clone, so on
 // shallow checkpoint repos it would also deepen unrelated branches.
 func FetchMetadataBranch(ctx context.Context) error {
-	return fetchMetadataFromOrigin(ctx, fetchMetadataOpts{NoFilter: true})
+	return fetchMetadataFromOrigin(ctx, true /* noFilter */)
 }
 
 // FetchMetadataTreeOnly fetches the entire/checkpoints/v1 commit+tree graph
@@ -428,15 +428,10 @@ func FetchMetadataBranch(ctx context.Context) error {
 // remote-tracking ref connected; git fetches incrementally, so after the first
 // fetch only new commits/trees travel.
 func FetchMetadataTreeOnly(ctx context.Context) error {
-	return fetchMetadataFromOrigin(ctx, fetchMetadataOpts{})
+	return fetchMetadataFromOrigin(ctx, false /* noFilter */)
 }
 
-type fetchMetadataOpts struct {
-	NoFilter  bool
-	Unshallow bool
-}
-
-func fetchMetadataFromOrigin(ctx context.Context, fopts fetchMetadataOpts) error {
+func fetchMetadataFromOrigin(ctx context.Context, noFilter bool) error {
 	refs := checkpoint.ResolveCommittedRefs(ctx)
 	if !refs.Primary.IsBranch() {
 		return fmt.Errorf("primary metadata ref %s is not a branch", refs.Primary)
@@ -454,11 +449,10 @@ func fetchMetadataFromOrigin(ctx context.Context, fopts fetchMetadataOpts) error
 	refSpec := fmt.Sprintf("+refs/heads/%s:refs/remotes/origin/%s", branchName, branchName)
 
 	output, fetchErr := remote.Fetch(ctx, remote.FetchOptions{
-		Remote:    fetchTarget,
-		RefSpecs:  []string{refSpec},
-		NoTags:    true,
-		NoFilter:  fopts.NoFilter,
-		Unshallow: fopts.Unshallow,
+		Remote:   fetchTarget,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+		NoFilter: noFilter,
 	})
 	if fetchErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {

--- a/cmd/entire/cli/treeless_fetch_full_depth_test.go
+++ b/cmd/entire/cli/treeless_fetch_full_depth_test.go
@@ -51,8 +51,13 @@ func TestFetchMetadataTreeOnly_DoesNotShallowRepo(t *testing.T) {
 
 	originTip := gitOutput(t, bareDir, "rev-parse", "refs/heads/"+paths.MetadataBranchName)
 
+	// Single-branch file:// clone: fetch only main, via a real fetch-pack rather
+	// than the local hardlink optimization. This leaves the metadata branch and
+	// its history absent until FetchMetadataTreeOnly fetches them, so the
+	// assertions actually exercise the tip-read (the old --depth=1 behavior
+	// would shallow the repo here).
 	clonedDir := filepath.Join(tmpDir, "cloned")
-	runGit(t, tmpDir, "clone", bareDir, clonedDir)
+	runGit(t, tmpDir, "clone", "--single-branch", "--branch", "main", "file://"+bareDir, clonedDir)
 	runGit(t, clonedDir, "config", "user.email", "test@example.com")
 	runGit(t, clonedDir, "config", "user.name", "Test")
 

--- a/cmd/entire/cli/treeless_fetch_full_depth_test.go
+++ b/cmd/entire/cli/treeless_fetch_full_depth_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// TestFetchMetadataTreeOnly_DoesNotShallowRepo is a regression test for the
+// shallow-metadata false-disconnect.
+//
+// FetchMetadataTreeOnly resolves the latest checkpoint on resume/explain/attach.
+// It used to fetch with --depth=1, which adds the fetched tip to .git/shallow.
+// Once the metadata tip is a shallow boundary, a later `git merge-base` against
+// refs/remotes/origin/entire/checkpoints/v1 can't reach the real common
+// ancestor (it's below the boundary) and the disconnection check falsely
+// reports "no common ancestor" — aborting push and looping doctor.
+//
+// The fix drops --depth=1 and relies on blob filtering for cheapness, so the
+// fetch never creates a shallow boundary.
+func TestFetchMetadataTreeOnly_DoesNotShallowRepo(t *testing.T) {
+	// Uses t.Chdir() — cannot run in parallel.
+
+	tmpDir := t.TempDir()
+	bareDir := filepath.Join(tmpDir, "bare.git")
+	localDir := filepath.Join(tmpDir, "local")
+
+	runGit(t, tmpDir, "init", "--bare", bareDir)
+
+	// Seed: a main commit plus an orphan metadata branch with two checkpoint
+	// commits, so a --depth=1 fetch would visibly truncate to one.
+	testutil.InitRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "README.md", "hello")
+	testutil.GitAdd(t, localDir, "README.md")
+	testutil.GitCommit(t, localDir, "init")
+	runGit(t, localDir, "branch", "-M", "main")
+	runGit(t, localDir, "remote", "add", "origin", bareDir)
+	runGit(t, localDir, "checkout", "--orphan", paths.MetadataBranchName)
+	runGit(t, localDir, "rm", "-rf", ".")
+	testutil.WriteFile(t, localDir, "a/metadata.json", `{"checkpoint_id":"deadbeef0001"}`)
+	testutil.GitAdd(t, localDir, "a/metadata.json")
+	testutil.GitCommit(t, localDir, "Checkpoint: deadbeef0001")
+	testutil.WriteFile(t, localDir, "b/metadata.json", `{"checkpoint_id":"deadbeef0002"}`)
+	testutil.GitAdd(t, localDir, "b/metadata.json")
+	testutil.GitCommit(t, localDir, "Checkpoint: deadbeef0002")
+	runGit(t, localDir, "checkout", "main")
+	runGit(t, localDir, "push", "origin", "HEAD:refs/heads/main", paths.MetadataBranchName)
+	runGit(t, bareDir, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	originTip := gitRevParse(t, bareDir, "refs/heads/"+paths.MetadataBranchName)
+
+	clonedDir := filepath.Join(tmpDir, "cloned")
+	runGit(t, tmpDir, "clone", bareDir, clonedDir)
+	runGit(t, clonedDir, "config", "user.email", "test@example.com")
+	runGit(t, clonedDir, "config", "user.name", "Test")
+
+	t.Chdir(clonedDir)
+
+	if err := FetchMetadataTreeOnly(t.Context()); err != nil {
+		t.Fatalf("FetchMetadataTreeOnly: %v", err)
+	}
+
+	// The fix: the tip-read must not leave the repo shallow. Under the old
+	// --depth=1 behavior this would be "true".
+	if shallow := gitOut(t, clonedDir, "rev-parse", "--is-shallow-repository"); shallow != "false" {
+		t.Errorf("repo is shallow after tree-only fetch (--is-shallow-repository=%q); the tip-read must not create a shallow boundary", shallow)
+	}
+
+	// The full metadata history is present (two commits), not truncated to one.
+	originRef := "refs/remotes/origin/" + paths.MetadataBranchName
+	if n := gitOut(t, clonedDir, "rev-list", "--count", originRef); n != "2" {
+		t.Errorf("origin metadata history has %s commit(s), want 2 (full depth)", n)
+	}
+
+	// The local primary ref is advanced to the tip so reads work.
+	localRef := "refs/heads/" + paths.MetadataBranchName
+	if got := gitRevParse(t, clonedDir, localRef); got != originTip {
+		t.Errorf("local primary ref %s = %q, want origin tip %q", localRef, got, originTip)
+	}
+}
+
+func gitRevParse(t *testing.T, dir, rev string) string {
+	t.Helper()
+	return gitOut(t, dir, "rev-parse", rev)
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s in %s: %v", strings.Join(args, " "), dir, err)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/cmd/entire/cli/treeless_fetch_full_depth_test.go
+++ b/cmd/entire/cli/treeless_fetch_full_depth_test.go
@@ -8,29 +8,19 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
-// TestFetchMetadataTreeOnly_DoesNotShallowRepo is a regression test for the
-// shallow-metadata false-disconnect.
-//
-// FetchMetadataTreeOnly resolves the latest checkpoint on resume/explain/attach.
-// It used to fetch with --depth=1, which adds the fetched tip to .git/shallow.
-// Once the metadata tip is a shallow boundary, a later `git merge-base` against
-// refs/remotes/origin/entire/checkpoints/v1 can't reach the real common
-// ancestor (it's below the boundary) and the disconnection check falsely
-// reports "no common ancestor" — aborting push and looping doctor.
-//
-// The fix drops --depth=1 and relies on blob filtering for cheapness, so the
-// fetch never creates a shallow boundary.
-func TestFetchMetadataTreeOnly_DoesNotShallowRepo(t *testing.T) {
-	// Uses t.Chdir() — cannot run in parallel.
-
+// seedTreelessFetchRepo builds a bare origin with a `main` commit and a 2-commit
+// orphan entire/checkpoints/v1 branch, then makes a single-branch file:// clone
+// of main (a real fetch-pack, not the local hardlink optimization, so the
+// metadata branch and its history are absent until fetched). Returns the clone
+// dir and the origin metadata tip. The caller is responsible for t.Chdir.
+func seedTreelessFetchRepo(t *testing.T) (clonedDir, originTip string) {
+	t.Helper()
 	tmpDir := t.TempDir()
 	bareDir := filepath.Join(tmpDir, "bare.git")
 	localDir := filepath.Join(tmpDir, "local")
 
 	runGit(t, tmpDir, "init", "--bare", bareDir)
 
-	// Seed: a main commit plus an orphan metadata branch with two checkpoint
-	// commits, so a --depth=1 fetch would visibly truncate to one.
 	testutil.InitRepo(t, localDir)
 	testutil.WriteFile(t, localDir, "README.md", "hello")
 	testutil.GitAdd(t, localDir, "README.md")
@@ -49,18 +39,35 @@ func TestFetchMetadataTreeOnly_DoesNotShallowRepo(t *testing.T) {
 	runGit(t, localDir, "push", "origin", "HEAD:refs/heads/main", paths.MetadataBranchName)
 	runGit(t, bareDir, "symbolic-ref", "HEAD", "refs/heads/main")
 
-	originTip := gitOutput(t, bareDir, "rev-parse", "refs/heads/"+paths.MetadataBranchName)
+	originTip = gitOutput(t, bareDir, "rev-parse", "refs/heads/"+paths.MetadataBranchName)
 
-	// Single-branch file:// clone: fetch only main, via a real fetch-pack rather
-	// than the local hardlink optimization. This leaves the metadata branch and
-	// its history absent until FetchMetadataTreeOnly fetches them, so the
-	// assertions actually exercise the tip-read (the old --depth=1 behavior
-	// would shallow the repo here).
-	clonedDir := filepath.Join(tmpDir, "cloned")
+	clonedDir = filepath.Join(tmpDir, "cloned")
 	runGit(t, tmpDir, "clone", "--single-branch", "--branch", "main", "file://"+bareDir, clonedDir)
 	runGit(t, clonedDir, "config", "user.email", "test@example.com")
 	runGit(t, clonedDir, "config", "user.name", "Test")
+	return clonedDir, originTip
+}
 
+func repoIsShallow(t *testing.T, dir string) bool {
+	t.Helper()
+	return gitOutput(t, dir, "rev-parse", "--is-shallow-repository") == "true"
+}
+
+// TestFetchMetadataTreeOnly_DoesNotShallowRepo is a regression test for the
+// shallow-metadata false-disconnect.
+//
+// FetchMetadataTreeOnly resolves the latest checkpoint on resume/explain/attach.
+// It used to fetch with --depth=1, which adds the fetched tip to .git/shallow.
+// Once the metadata tip is a shallow boundary, a later `git merge-base` against
+// refs/remotes/origin/entire/checkpoints/v1 can't reach the real common
+// ancestor (it's below the boundary) and the disconnection check falsely
+// reports "no common ancestor" — aborting push and looping doctor.
+//
+// The fix drops --depth=1 and relies on blob filtering for cheapness, so the
+// fetch never creates a shallow boundary.
+func TestFetchMetadataTreeOnly_DoesNotShallowRepo(t *testing.T) {
+	// Uses t.Chdir() — cannot run in parallel.
+	clonedDir, originTip := seedTreelessFetchRepo(t)
 	t.Chdir(clonedDir)
 
 	if err := FetchMetadataTreeOnly(t.Context()); err != nil {
@@ -68,9 +75,9 @@ func TestFetchMetadataTreeOnly_DoesNotShallowRepo(t *testing.T) {
 	}
 
 	// The fix: the tip-read must not leave the repo shallow. Under the old
-	// --depth=1 behavior this would be "true".
-	if shallow := gitOutput(t, clonedDir, "rev-parse", "--is-shallow-repository"); shallow != "false" {
-		t.Errorf("repo is shallow after tree-only fetch (--is-shallow-repository=%q); the tip-read must not create a shallow boundary", shallow)
+	// --depth=1 behavior this would be shallow.
+	if repoIsShallow(t, clonedDir) {
+		t.Errorf("repo is shallow after tree-only fetch; the tip-read must not create a shallow boundary")
 	}
 
 	// The full metadata history is present (two commits), not truncated to one.
@@ -83,5 +90,35 @@ func TestFetchMetadataTreeOnly_DoesNotShallowRepo(t *testing.T) {
 	localRef := "refs/heads/" + paths.MetadataBranchName
 	if got := gitOutput(t, clonedDir, "rev-parse", localRef); got != originTip {
 		t.Errorf("local primary ref %s = %q, want origin tip %q", localRef, got, originTip)
+	}
+}
+
+// TestFetchMetadataTreeOnly_HealsPriorShallow verifies that a repo already
+// shallowed by an older CLI (a lingering --depth=1 boundary on the metadata
+// branch) is unshallowed by the tip-read, so the poison doesn't persist
+// indefinitely for users who ran the buggy version.
+func TestFetchMetadataTreeOnly_HealsPriorShallow(t *testing.T) {
+	// Uses t.Chdir() — cannot run in parallel.
+	clonedDir, _ := seedTreelessFetchRepo(t)
+
+	// Reproduce the old behavior: a --depth=1 fetch grafts the metadata tip into
+	// .git/shallow, marking the repo shallow.
+	runGit(t, clonedDir, "fetch", "--depth=1", "origin",
+		"+refs/heads/"+paths.MetadataBranchName+":refs/remotes/origin/"+paths.MetadataBranchName)
+	if !repoIsShallow(t, clonedDir) {
+		t.Fatal("precondition: expected a shallow repo after --depth=1 fetch")
+	}
+
+	t.Chdir(clonedDir)
+	if err := FetchMetadataTreeOnly(t.Context()); err != nil {
+		t.Fatalf("FetchMetadataTreeOnly: %v", err)
+	}
+
+	if repoIsShallow(t, clonedDir) {
+		t.Errorf("repo still shallow after tree-only fetch; a prior --depth=1 boundary must be healed")
+	}
+	originRef := "refs/remotes/origin/" + paths.MetadataBranchName
+	if n := gitOutput(t, clonedDir, "rev-list", "--count", originRef); n != "2" {
+		t.Errorf("metadata history = %s commit(s) after heal, want 2 (full depth)", n)
 	}
 }

--- a/cmd/entire/cli/treeless_fetch_full_depth_test.go
+++ b/cmd/entire/cli/treeless_fetch_full_depth_test.go
@@ -1,10 +1,7 @@
 package cli
 
 import (
-	"context"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -52,7 +49,7 @@ func TestFetchMetadataTreeOnly_DoesNotShallowRepo(t *testing.T) {
 	runGit(t, localDir, "push", "origin", "HEAD:refs/heads/main", paths.MetadataBranchName)
 	runGit(t, bareDir, "symbolic-ref", "HEAD", "refs/heads/main")
 
-	originTip := gitRevParse(t, bareDir, "refs/heads/"+paths.MetadataBranchName)
+	originTip := gitOutput(t, bareDir, "rev-parse", "refs/heads/"+paths.MetadataBranchName)
 
 	clonedDir := filepath.Join(tmpDir, "cloned")
 	runGit(t, tmpDir, "clone", bareDir, clonedDir)
@@ -67,36 +64,19 @@ func TestFetchMetadataTreeOnly_DoesNotShallowRepo(t *testing.T) {
 
 	// The fix: the tip-read must not leave the repo shallow. Under the old
 	// --depth=1 behavior this would be "true".
-	if shallow := gitOut(t, clonedDir, "rev-parse", "--is-shallow-repository"); shallow != "false" {
+	if shallow := gitOutput(t, clonedDir, "rev-parse", "--is-shallow-repository"); shallow != "false" {
 		t.Errorf("repo is shallow after tree-only fetch (--is-shallow-repository=%q); the tip-read must not create a shallow boundary", shallow)
 	}
 
 	// The full metadata history is present (two commits), not truncated to one.
 	originRef := "refs/remotes/origin/" + paths.MetadataBranchName
-	if n := gitOut(t, clonedDir, "rev-list", "--count", originRef); n != "2" {
+	if n := gitOutput(t, clonedDir, "rev-list", "--count", originRef); n != "2" {
 		t.Errorf("origin metadata history has %s commit(s), want 2 (full depth)", n)
 	}
 
 	// The local primary ref is advanced to the tip so reads work.
 	localRef := "refs/heads/" + paths.MetadataBranchName
-	if got := gitRevParse(t, clonedDir, localRef); got != originTip {
+	if got := gitOutput(t, clonedDir, "rev-parse", localRef); got != originTip {
 		t.Errorf("local primary ref %s = %q, want origin tip %q", localRef, got, originTip)
 	}
-}
-
-func gitRevParse(t *testing.T, dir, rev string) string {
-	t.Helper()
-	return gitOut(t, dir, "rev-parse", rev)
-}
-
-func gitOut(t *testing.T, dir string, args ...string) string {
-	t.Helper()
-	cmd := exec.CommandContext(context.Background(), "git", args...)
-	cmd.Dir = dir
-	cmd.Env = testutil.GitIsolatedEnv()
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("git %s in %s: %v", strings.Join(args, " "), dir, err)
-	}
-	return strings.TrimSpace(string(out))
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/578
<!-- entire-trail-link-end -->

## Problem

`FetchMetadataTreeOnly` resolves the latest checkpoint on `resume` / `explain` / `attach` by fetching the `entire/checkpoints/v1` tip with `--depth=1`. A depth-1 fetch adds the fetched commit to `.git/shallow`. Once the metadata tip is a shallow boundary, a later `git merge-base` against `refs/remotes/origin/entire/checkpoints/v1` can't reach the real common ancestor (it lives below the boundary), so the disconnection check falsely reports **"no common ancestor"** — aborting `git push` and looping `entire doctor`.

This is the **upstream source** of the shallow-metadata false-disconnect. It's self-inflicted by the CLI's own tip-read, which runs on essentially every `entire resume` when checkpoints live on `origin` (no `checkpoint_remote` to short-circuit it via `getMetadataTree`). The user never has to clone shallowly — the CLI shallows the branch for them.

### Why not "fetch the tip into a throwaway ref"?

The shallow boundary is **intrinsic to `--depth=1`**: it truncates the fetched *commit*, regardless of which ref it lands on, and git (2.54) opportunistically points `refs/remotes/origin/<branch>` at that commit anyway (verified against `--refmap=`, fetch-by-URL, FETCH_HEAD-only, and `-c remote.origin.fetch=`). You cannot read a tip via `--depth=1` without creating a shallow boundary on the shared object store.

## Fix

Stop shallow-fetching. `FetchMetadataTreeOnly` now fetches the metadata commit+tree graph at **full depth**, relying on `--filter=blob:none` (when filtered fetches are enabled) to skip blob content instead of on depth-limiting. No shallow boundary is ever created, so `refs/remotes/origin/<branch>` stays connected and `merge-base` works.

`git fetch` is incremental, so after the first fetch only new commits/trees travel — the cheapness now comes from blob filtering + incremental fetch rather than from truncating history.

## Test

`TestFetchMetadataTreeOnly_DoesNotShallowRepo` seeds a 2-commit metadata branch, runs the tip-read on a clone, and asserts the repo is **not** shallow afterward (`--is-shallow-repository=false`), full history is present, and the local primary ref is advanced. Under the old `--depth=1` behavior the repo would be shallow.

## Notes

- Repos with a configured `checkpoint_remote` were never affected (that path short-circuits before the shallow fetch and is already full-depth).
- Complements the detection-side hardening in #1434 (`IsMetadataDisconnected` shallow-awareness + `doctor` deepen); this PR removes the source so the boundary isn't created in the first place.
- Unit + relevant integration tests (`filtered_fetches` enabled) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default fetch behavior on a hot path (resume/explain/attach), which can increase first-fetch work on repos without blob filtering, but fixes incorrect disconnect detection tied to git shallow state.
> 
> **Overview**
> **`FetchMetadataTreeOnly`** (used on resume/explain/attach to read the latest checkpoint) no longer uses **`--depth=1`**. It fetches the metadata branch at **full commit/tree depth** and stays cheap via **`--filter=blob:none`** when filtered fetches are on, instead of truncating history.
> 
> That removes the root cause where a depth-1 fetch wrote a shallow boundary and later **`git merge-base`** / **`strategy.IsMetadataDisconnected`** falsely reported no common ancestor—blocking push and looping **`entire doctor`**.
> 
> The **`Shallow`** option is dropped from **`fetchMetadataOpts`**. **`TestFetchMetadataTreeOnly_DoesNotShallowRepo`** asserts the clone stays non-shallow, keeps two metadata commits, and advances the local primary ref to the origin tip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe73db181081df993c7cee1f826c2a7eba815f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->