### PR TITLE
fix(e2e/copilot): detect trust dialog case-insensitively (v1.0.63)

### DIFF
--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -286,6 +286,15 @@ func isAutocompleteMenu(content string) bool {
 	return false
 }
 
+// isStartupDialog reports whether the captured pane is showing a Copilot
+// startup dialog (e.g. "Confirm folder trust") rather than the interactive
+// prompt. The dialog renders its selected option with the same "❯" cursor as
+// the input prompt, so presence of "❯" alone cannot distinguish them — we must
+// key off the dialog chrome.
+func isStartupDialog(content string) bool {
+	return strings.Contains(content, "Enter to select")
+}
+
 func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, error) {
 	bin, err := exec.LookPath(c.Binary())
 	if err != nil {
@@ -322,7 +331,7 @@ func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, err
 			_ = s.Close()
 			return nil, fmt.Errorf("waiting for startup prompt: %w", err)
 		}
-		if strings.Contains(content, "❯") && !strings.Contains(content, "Enter to select") {
+		if strings.Contains(content, "❯") && !isStartupDialog(content) {
 			foundPrompt = true
 			break
 		}

--- a/e2e/agents/copilot-cli.go
+++ b/e2e/agents/copilot-cli.go
@@ -291,8 +291,18 @@ func isAutocompleteMenu(content string) bool {
 // prompt. The dialog renders its selected option with the same "❯" cursor as
 // the input prompt, so presence of "❯" alone cannot distinguish them — we must
 // key off the dialog chrome.
+//
+// Matching is case-insensitive and keyed off both the dialog title and its
+// footer: Copilot v1.0.63 lowercased the footer to "enter to select", which
+// silently broke the previous exact "Enter to select" match and caused the
+// harness to mistake the trust dialog's "❯ 1. Yes" cursor for the prompt —
+// breaking out of the dismissal loop without dismissing the dialog, so the
+// first real prompt was swallowed by the still-open dialog.
 func isStartupDialog(content string) bool {
-	return strings.Contains(content, "Enter to select")
+	lower := strings.ToLower(content)
+	return strings.Contains(lower, "confirm folder trust") ||
+		strings.Contains(lower, "do you trust") ||
+		strings.Contains(lower, "enter to select")
 }
 
 func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, error) {
@@ -326,7 +336,7 @@ func (c *CopilotCLI) StartSession(ctx context.Context, dir string) (Session, err
 	// new directories. "Yes" is pre-selected, so Enter dismisses it.
 	foundPrompt := false
 	for range 5 {
-		content, err := s.WaitFor(`(❯|Enter to select)`, 30*time.Second)
+		content, err := s.WaitFor(`(❯|(?i:enter to select))`, 30*time.Second)
 		if err != nil {
 			_ = s.Close()
 			return nil, fmt.Errorf("waiting for startup prompt: %w", err)

--- a/e2e/agents/copilot_trust_test.go
+++ b/e2e/agents/copilot_trust_test.go
@@ -1,0 +1,66 @@
+package agents
+
+import "testing"
+
+// trustDialogPane is a trimmed capture of Copilot v1.0.63's interactive
+// startup dialog. Note the footer renders the navigation hint lowercase
+// ("enter to select") and the selected option uses the same "❯" cursor as the
+// input prompt — the exact shape that broke the old exact-case detection.
+const trustDialogPane = `╭───────────────────────────────────────────────────────────╮
+│ Confirm folder trust                                        │
+│                                                             │
+│ /tmp/e2e-repo-457367550                                     │
+│                                                             │
+│ Copilot can read files in this folder and, with your        │
+│ permission, edit them or run code and shell commands.       │
+│                                                             │
+│ Do you trust the files in this folder?                      │
+│                                                             │
+│ ❯ 1. Yes                                                    │
+│   2. Yes, and remember this folder for future sessions      │
+│   3. No (Esc)                                               │
+│                                                             │
+│ ↑/↓ to navigate · enter to select · esc to cancel           │
+╰───────────────────────────────────────────────────────────╯`
+
+// interactivePromptPane is the real idle prompt: a bare "❯" with no dialog
+// chrome. This must NOT be classified as a startup dialog.
+const interactivePromptPane = ` Tip: /app
+ /tmp/e2e-repo-457367550 [master%]
+
+❯
+
+ / commands · ? help                                  Claude Haiku 4.5`
+
+// TestIsStartupDialog_DetectsLowercaseTrustFooter is the regression guard for
+// the Copilot v1.0.63 break: the trust dialog must be recognized even though
+// its footer is lowercase ("enter to select"), so the StartSession dismissal
+// loop keeps sending Enter instead of mistaking the "❯ 1. Yes" cursor for the
+// interactive prompt and swallowing the first real prompt.
+func TestIsStartupDialog_DetectsLowercaseTrustFooter(t *testing.T) {
+	t.Parallel()
+	if !isStartupDialog(trustDialogPane) {
+		t.Fatal("trust dialog with lowercase footer should be detected as a startup dialog")
+	}
+}
+
+// TestIsStartupDialog_DetectsByTitle confirms detection keys off the dialog
+// title too, so a footer-text change in a future Copilot release does not
+// silently re-break the handshake.
+func TestIsStartupDialog_DetectsByTitle(t *testing.T) {
+	t.Parallel()
+	const titleOnly = "│ Confirm folder trust │\n│ ❯ 1. Yes │"
+	if !isStartupDialog(titleOnly) {
+		t.Fatal("dialog title alone should be enough to detect a startup dialog")
+	}
+}
+
+// TestIsStartupDialog_IgnoresInteractivePrompt ensures the real prompt is not
+// classified as a dialog — otherwise StartSession would loop dismissing a
+// dialog that isn't there and never hand back a usable session.
+func TestIsStartupDialog_IgnoresInteractivePrompt(t *testing.T) {
+	t.Parallel()
+	if isStartupDialog(interactivePromptPane) {
+		t.Fatal("bare interactive prompt should not be classified as a startup dialog")
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/582
<!-- entire-trail-link-end -->

## Summary

Fixes the 5 `TestInteractive*` copilot-cli E2E failures seen in [run 27635117591](https://github.com/entireio/cli/actions/runs/27635117591/job/81720212479) (all `WaitFor("❯"): timed out`).

Copilot **v1.0.63** lowercased the trust-dialog footer from `Enter to select` to `enter to select`. `StartSession`'s dialog-dismissal loop matched that footer with an exact-case `strings.Contains`, so the trust dialog stopped being recognized:

- the loop saw the dialog's `❯ 1. Yes` selection cursor,
- mistook it for the interactive prompt (same `❯` glyph),
- and broke out **without pressing Enter to dismiss it**.

The still-open dialog then swallowed the first real prompt (the `Send`'s Enter just selected "Yes"), the agent never did the work, and every interactive test timed out.

## Fix

- Extract the prompt-vs-dialog check into a named `isStartupDialog()` helper (pure refactor commit).
- Make `isStartupDialog()` lowercase-fold the pane and match on the dialog **title** (`Confirm folder trust` / `Do you trust`) as well as the footer, so a future footer-wording change can't silently re-break it.
- Widen the `WaitFor` trigger regex to match the footer case-insensitively.
- Add `copilot_trust_test.go` with the real v1.0.63 dialog capture as a regression fixture, plus a negative case for the bare prompt.

## Verification

- `go build -tags e2e ./e2e/...` ✓
- `go vet -tags e2e ./e2e/agents/` ✓
- `go test ./e2e/agents/` ✓ (new unit tests pass; they run under `mise run test`)
- `mise run lint` → 0 issues ✓
- Real Copilot E2E **not** run locally (token cost + auth); the real proof is the next CI E2E run.

## Out of scope

The 6th failure, `TestSubagentCommitFlow` (shadow branch not cleaned), is a separate pre-existing Copilot background-subagent timing quirk already acknowledged in the `single_session_test.go:95` skip. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2e harness-only startup handshake logic with unit regression tests; no production auth or runtime behavior changes.
> 
> **Overview**
> Fixes Copilot CLI **v1.0.63** breaking interactive E2E `StartSession`: the folder-trust dialog footer became lowercase (`enter to select`), so the harness no longer treated the pane as a dialog, confused the dialog’s `❯` selection cursor with the real prompt, and exited the dismissal loop without pressing Enter.
> 
> Adds **`isStartupDialog()`** with case-insensitive checks on dialog title (`confirm folder trust`, `do you trust`) and footer text, and uses it in the startup loop instead of an exact `Enter to select` check. **`WaitFor`** now matches the footer case-insensitively via `(?i:enter to select)`.
> 
> Adds **`copilot_trust_test.go`** with a v1.0.63 dialog fixture plus tests that the trust dialog is detected (footer and title) and the bare interactive prompt is not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0677238fc7288ecaed4f9b242d4a8f8dfd83ebd2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->