### PR TITLE
test: isolate git config in attach tests to fix TempDir cleanup flake (COR-394)

### DIFF
--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -1501,6 +1501,11 @@ func setupAttachTestRepo(t *testing.T) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	testutil.InitRepo(t, tmpDir)
+	// attach runs `git commit --amend` via the git CLI, which inherits this
+	// process's env. Pin git config (gc.auto=0, gc.autoDetach=false) so git
+	// doesn't fork a detached `git gc` that keeps writing into the temp repo's
+	// .git/objects and races t.TempDir cleanup ("directory not empty", COR-394).
+	testutil.IsolateGitConfigEnv(t)
 	testutil.WriteFile(t, tmpDir, "init.txt", "init")
 	testutil.GitAdd(t, tmpDir, "init.txt")
 	testutil.GitCommit(t, tmpDir, "init")


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/590
<!-- entire-trail-link-end -->

## Problem

`TestAttachCmd_*` / `TestReviewAttach_*` intermittently fail in CI — not on an assertion, but during `t.TempDir()` cleanup:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat .../001/.git/objects: directory not empty
```

"directory not empty" during `os.RemoveAll` means a process created a new file mid-removal — a concurrent writer into the test repo's `.git/objects`.

## Root cause (COR-394)

`attach` runs `git commit --amend` via the **git CLI** (`attach.go`), which inherits this process's env and therefore the developer's real global/system git config. With default `gc.auto` / `gc.autoDetach=true`, that commit forks a **detached background `git gc`** that keeps packing/writing into `.git/objects` after `rootCmd.Execute()` returns — racing Go's deferred `t.TempDir` `os.RemoveAll`.

`setupAttachTestRepo` configured repo-local identity (`testutil.InitRepo`) but never isolated global/system git config, so the gc-disabling pins this repo already ships (in `testutil`) weren't applied to attach's git invocations.

Ruled out as writers: detached telemetry analytics (gated off — no `telemetry` key in the test settings, and the child never touches the repo) and version-check (early-returns on dev/test builds). The only async writer to the test repo's `.git` is the git-forked `gc`.

## Fix

Add `testutil.IsolateGitConfigEnv(t)` to `setupAttachTestRepo`. It points `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at the isolation config (`gc.auto=0`, `gc.autoDetach=false`, `maintenance.auto=false`, `fetch.writeCommitGraph=false`) — the central remedy `testutil` documents for exactly this race. It both removes the dependence on the developer's git config and prevents the detached gc.

`IsolateGitConfigEnv` uses `t.Setenv`, so it's non-parallel — already satisfied since the helper uses `t.Chdir`.

## Notes

- One-line change to a shared test helper; fixes every attach/review test that goes through `setupAttachTestRepo` and the `git commit --amend` path.
- `testutil.GitAdd`/`GitCommit` use go-git (not the CLI), so they never forked gc — the leak was specific to attach's CLI amend.
- Surfaced on PR #1443's CI; unrelated to that change (it failed identically with/without it). Fixed here on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 33cb6db46c6f05f6cd7d2d88e37cec7a6db6cbd9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->