### PR TITLE
Use `os.Lstat` for existence checks on Entire-owned paths

### DIFF
--- a/cmd/entire/cli/doctor_logs.go
+++ b/cmd/entire/cli/doctor_logs.go
@@ -33,7 +33,7 @@ Use --follow to stream new lines as they are written (Ctrl+C to exit).`,
 				return errors.New("not a git repository")
 			}
 			logFile := filepath.Join(repoRoot, logging.LogsDir, "entire.log")
-			if _, err := os.Stat(logFile); errors.Is(err, os.ErrNotExist) {
+			if _, err := os.Lstat(logFile); errors.Is(err, os.ErrNotExist) {
 				fmt.Fprintf(cmd.OutOrStdout(), "No log file at %s yet.\n", logFile)
 				return nil
 			}

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -669,20 +669,24 @@ func handleLogsOnlyResetNonInteractive(ctx context.Context, w, errW io.Writer, s
 // (<metadataDir>/full.log) used when checkpoint-storage and shadow-branch
 // restores are unavailable. metadataDir originates from the Entire-Metadata
 // commit trailer, which is attacker-influenceable, and the result is read via
-// copyFile -> os.ReadFile with no root containment on the source. Reject
-// absolute paths, Windows volume-relative paths, and any value that escapes its
-// base via traversal so a crafted trailer cannot redirect the read outside the
-// repository. Returns "" when the metadata dir is empty or unsafe, which makes
-// the local-file fallback fail closed.
+// copyFile -> os.ReadFile with no root containment on the source.
+//
+// Legitimate values are always Entire-owned metadata under .entire/metadata/, so
+// require the cleaned path to stay within that subtree. paths.IsSubpath also
+// rejects absolute, volume-relative, and traversing paths, so a crafted trailer
+// cannot redirect the read to arbitrary in-repo or CWD-relative locations (e.g.
+// "notes/full.log" or "."). Returns "" when the metadata dir is empty or unsafe,
+// which makes the local-file fallback fail closed. filepath.Join cleans the
+// result, avoiding surprising ".//a/../b" forms.
 func legacyFallbackTranscriptPath(metadataDir string) string {
 	if metadataDir == "" {
 		return ""
 	}
 	cleaned := filepath.Clean(metadataDir)
-	if filepath.IsAbs(cleaned) || filepath.VolumeName(cleaned) != "" || paths.IsRelativeTraversal(cleaned) {
+	if !paths.IsSubpath(paths.EntireMetadataDir, cleaned) {
 		return ""
 	}
-	return filepath.Join(metadataDir, paths.TranscriptFileNameLegacy)
+	return filepath.Join(cleaned, paths.TranscriptFileNameLegacy)
 }
 
 func restoreSessionTranscript(ctx context.Context, w io.Writer, transcriptFile, sessionID string, agent agentpkg.Agent) error {

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -320,7 +320,7 @@ func runRewindInteractive(ctx context.Context, w, errW io.Writer) error { //noli
 		if sessionID == "" {
 			sessionID = filepath.Base(selectedPoint.MetadataDir)
 		}
-		transcriptFile = filepath.Join(selectedPoint.MetadataDir, paths.TranscriptFileNameLegacy)
+		transcriptFile = legacyFallbackTranscriptPath(selectedPoint.MetadataDir)
 	}
 
 	// Try to restore transcript using the appropriate method:
@@ -344,7 +344,7 @@ func runRewindInteractive(ctx context.Context, w, errW io.Writer) error { //noli
 		}
 	}
 
-	if !restored {
+	if !restored && transcriptFile != "" {
 		// Fall back to local file
 		if err := restoreSessionTranscript(ctx, w, transcriptFile, sessionID, agent); err != nil {
 			fmt.Fprintf(errW, "Warning: failed to restore session transcript: %v\n", err)
@@ -523,7 +523,7 @@ func runRewindToInternal(ctx context.Context, w, errW io.Writer, commitID string
 		if sessionID == "" {
 			sessionID = filepath.Base(selectedPoint.MetadataDir)
 		}
-		transcriptFile = filepath.Join(selectedPoint.MetadataDir, paths.TranscriptFileNameLegacy)
+		transcriptFile = legacyFallbackTranscriptPath(selectedPoint.MetadataDir)
 	}
 
 	// Try to restore transcript using the appropriate method:
@@ -547,7 +547,7 @@ func runRewindToInternal(ctx context.Context, w, errW io.Writer, commitID string
 		}
 	}
 
-	if !restored {
+	if !restored && transcriptFile != "" {
 		// Fall back to local file
 		if err := restoreSessionTranscript(ctx, w, transcriptFile, sessionID, agent); err != nil {
 			fmt.Fprintf(errW, "Warning: failed to restore session transcript: %v\n", err)
@@ -663,6 +663,26 @@ func handleLogsOnlyResetNonInteractive(ctx context.Context, w, errW io.Writer, s
 	}
 
 	return nil
+}
+
+// legacyFallbackTranscriptPath builds the local-disk fallback transcript path
+// (<metadataDir>/full.log) used when checkpoint-storage and shadow-branch
+// restores are unavailable. metadataDir originates from the Entire-Metadata
+// commit trailer, which is attacker-influenceable, and the result is read via
+// copyFile -> os.ReadFile with no root containment on the source. Reject
+// absolute paths, Windows volume-relative paths, and any value that escapes its
+// base via traversal so a crafted trailer cannot redirect the read outside the
+// repository. Returns "" when the metadata dir is empty or unsafe, which makes
+// the local-file fallback fail closed.
+func legacyFallbackTranscriptPath(metadataDir string) string {
+	if metadataDir == "" {
+		return ""
+	}
+	cleaned := filepath.Clean(metadataDir)
+	if filepath.IsAbs(cleaned) || filepath.VolumeName(cleaned) != "" || paths.IsRelativeTraversal(cleaned) {
+		return ""
+	}
+	return filepath.Join(metadataDir, paths.TranscriptFileNameLegacy)
 }
 
 func restoreSessionTranscript(ctx context.Context, w io.Writer, transcriptFile, sessionID string, agent agentpkg.Agent) error {

--- a/cmd/entire/cli/rewind_test.go
+++ b/cmd/entire/cli/rewind_test.go
@@ -11,8 +11,9 @@ import (
 // legacyFallbackTranscriptPath reads its metadata-dir argument from the
 // attacker-influenceable Entire-Metadata commit trailer and feeds the result to
 // an unrooted os.ReadFile. A crafted trailer must not be able to redirect that
-// read outside the repository, so traversal and absolute/volume paths must fail
-// closed (return "").
+// read anywhere other than Entire-owned metadata under .entire/metadata/, so
+// anything outside that subtree (traversal, absolute/volume paths, and in-repo
+// or CWD-relative dirs like "notes" or ".") must fail closed (return "").
 func TestLegacyFallbackTranscriptPath(t *testing.T) {
 	t.Parallel()
 
@@ -57,6 +58,21 @@ func TestLegacyFallbackTranscriptPath(t *testing.T) {
 		{
 			name:        "absolute path fails closed",
 			metadataDir: "/etc/passwd",
+			want:        "",
+		},
+		{
+			name:        "in-repo dir outside .entire/metadata fails closed",
+			metadataDir: "notes",
+			want:        "",
+		},
+		{
+			name:        "current dir fails closed",
+			metadataDir: ".",
+			want:        "",
+		},
+		{
+			name:        "the metadata root itself (not a session dir) fails closed",
+			metadataDir: ".entire",
 			want:        "",
 		},
 	}

--- a/cmd/entire/cli/rewind_test.go
+++ b/cmd/entire/cli/rewind_test.go
@@ -1,9 +1,75 @@
 package cli
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
+
+// legacyFallbackTranscriptPath reads its metadata-dir argument from the
+// attacker-influenceable Entire-Metadata commit trailer and feeds the result to
+// an unrooted os.ReadFile. A crafted trailer must not be able to redirect that
+// read outside the repository, so traversal and absolute/volume paths must fail
+// closed (return "").
+func TestLegacyFallbackTranscriptPath(t *testing.T) {
+	t.Parallel()
+
+	legit := paths.EntireMetadataDir + "/sess-123"
+	legitTask := paths.EntireMetadataDir + "/sess-123/tasks/toolu_abc"
+
+	tests := []struct {
+		name        string
+		metadataDir string
+		want        string
+	}{
+		{
+			name:        "valid session metadata dir",
+			metadataDir: legit,
+			want:        filepath.Join(legit, paths.TranscriptFileNameLegacy),
+		},
+		{
+			name:        "valid task metadata dir",
+			metadataDir: legitTask,
+			want:        filepath.Join(legitTask, paths.TranscriptFileNameLegacy),
+		},
+		{
+			name:        "empty fails closed",
+			metadataDir: "",
+			want:        "",
+		},
+		{
+			name:        "leading parent traversal fails closed",
+			metadataDir: "../../../etc/passwd",
+			want:        "",
+		},
+		{
+			name:        "embedded traversal escaping the base fails closed",
+			metadataDir: paths.EntireMetadataDir + "/../../../../etc/passwd",
+			want:        "",
+		},
+		{
+			name:        "bare dot-dot fails closed",
+			metadataDir: "..",
+			want:        "",
+		},
+		{
+			name:        "absolute path fails closed",
+			metadataDir: "/etc/passwd",
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := legacyFallbackTranscriptPath(tt.metadataDir); got != tt.want {
+				t.Errorf("legacyFallbackTranscriptPath(%q) = %q, want %q", tt.metadataDir, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestRewindCmd_IsDeprecated(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -963,7 +963,7 @@ func IsSetUp(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	_, err = os.Stat(settingsFileAbs)
+	_, err = os.Lstat(settingsFileAbs)
 	return err == nil
 }
 

--- a/cmd/entire/cli/setup.go
+++ b/cmd/entire/cli/setup.go
@@ -327,13 +327,13 @@ func settingsTargetFile(ctx context.Context, useLocal, useProject bool) (string,
 	// Check project file first, then local.
 	projectAbs, err := paths.AbsPath(ctx, settings.EntireSettingsFile)
 	if err == nil {
-		if _, statErr := os.Stat(projectAbs); statErr == nil {
+		if _, statErr := os.Lstat(projectAbs); statErr == nil {
 			return settings.EntireSettingsFile, configDisplayProject
 		}
 	}
 	localAbs, err := paths.AbsPath(ctx, settings.EntireSettingsLocalFile)
 	if err == nil {
-		if _, statErr := os.Stat(localAbs); statErr == nil {
+		if _, statErr := os.Lstat(localAbs); statErr == nil {
 			return settings.EntireSettingsLocalFile, configDisplayLocal
 		}
 	}
@@ -1258,7 +1258,7 @@ func localExists(ctx context.Context) bool {
 	if abs, err := paths.AbsPath(ctx, localFile); err == nil {
 		localFile = abs
 	}
-	_, err := os.Stat(localFile)
+	_, err := os.Lstat(localFile)
 	return err == nil
 }
 
@@ -1694,7 +1694,7 @@ func determineSettingsTarget(entireDir string, useLocal, useProject bool) (bool,
 
 	// No flags specified - check if settings file exists
 	settingsPath := filepath.Join(entireDir, paths.SettingsFileName)
-	if _, err := os.Stat(settingsPath); err == nil {
+	if _, err := os.Lstat(settingsPath); err == nil {
 		// Settings file exists - auto-redirect to local with notification
 		return true, true
 	}
@@ -1714,7 +1714,7 @@ func setupEntireDirectory(ctx context.Context) (bool, error) { //nolint:unparam 
 
 	// Check if directory already exists
 	created := false
-	if _, err := os.Stat(entireDirAbs); os.IsNotExist(err) {
+	if _, err := os.Lstat(entireDirAbs); os.IsNotExist(err) {
 		created = true
 	}
 
@@ -2151,7 +2151,7 @@ func checkEntireDirExists(ctx context.Context) bool {
 	if err != nil {
 		entireDirAbs = paths.EntireDir
 	}
-	_, err = os.Stat(entireDirAbs)
+	_, err = os.Lstat(entireDirAbs)
 	return err == nil
 }
 

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -72,11 +72,11 @@ func runStatus(ctx context.Context, w io.Writer, detailed, jsonOutput bool) erro
 	}
 
 	// Check which settings files exist
-	_, projectErr := os.Stat(settingsPath)
+	_, projectErr := os.Lstat(settingsPath)
 	if projectErr != nil && !errors.Is(projectErr, fs.ErrNotExist) {
 		return fmt.Errorf("cannot access project settings file: %w", projectErr)
 	}
-	_, localErr := os.Stat(localSettingsPath)
+	_, localErr := os.Lstat(localSettingsPath)
 	if localErr != nil && !errors.Is(localErr, fs.ErrNotExist) {
 		return fmt.Errorf("cannot access local settings file: %w", localErr)
 	}
@@ -591,11 +591,11 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		localSettingsPath = EntireSettingsLocalFile
 	}
 
-	_, projectErr := os.Stat(settingsPath)
+	_, projectErr := os.Lstat(settingsPath)
 	if projectErr != nil && !errors.Is(projectErr, fs.ErrNotExist) {
 		return writeJSON(statusJSON{Error: fmt.Sprintf("cannot access project settings file: %v", projectErr)})
 	}
-	_, localErr := os.Stat(localSettingsPath)
+	_, localErr := os.Lstat(localSettingsPath)
 	if localErr != nil && !errors.Is(localErr, fs.ErrNotExist) {
 		return writeJSON(statusJSON{Error: fmt.Sprintf("cannot access local settings file: %v", localErr)})
 	}

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -320,18 +320,18 @@ func isGitSequenceOperation(ctx context.Context) bool {
 	}
 
 	// Check for rebase state directories
-	if _, err := os.Stat(filepath.Join(gitDir, "rebase-merge")); err == nil {
+	if _, err := os.Lstat(filepath.Join(gitDir, "rebase-merge")); err == nil {
 		return true
 	}
-	if _, err := os.Stat(filepath.Join(gitDir, "rebase-apply")); err == nil {
+	if _, err := os.Lstat(filepath.Join(gitDir, "rebase-apply")); err == nil {
 		return true
 	}
 
 	// Check for cherry-pick and revert state files
-	if _, err := os.Stat(filepath.Join(gitDir, "CHERRY_PICK_HEAD")); err == nil {
+	if _, err := os.Lstat(filepath.Join(gitDir, "CHERRY_PICK_HEAD")); err == nil {
 		return true
 	}
-	if _, err := os.Stat(filepath.Join(gitDir, "REVERT_HEAD")); err == nil {
+	if _, err := os.Lstat(filepath.Join(gitDir, "REVERT_HEAD")); err == nil {
 		return true
 	}
 
@@ -829,7 +829,7 @@ func warnStaleEndedSessionsTo(ctx context.Context, count int, w io.Writer) {
 	}
 	warnDir := filepath.Join(commonDir, session.SessionStateDirName)
 	warnFile := filepath.Join(warnDir, staleEndedSessionWarnFile)
-	if info, statErr := os.Stat(warnFile); statErr == nil {
+	if info, statErr := os.Lstat(warnFile); statErr == nil {
 		if time.Since(info.ModTime()) < staleEndedSessionWarnInterval {
 			return // rate-limited
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/592
<!-- entire-trail-link-end -->

 ## Summary

  `os.Stat` follows symlinks; `os.Lstat` does not. For existence checks on paths
  that Entire owns and creates, following a symlink is never needed and a
  symlinked entry there would be anomalous — so this switches those sites to stat
  the entry itself. This is symlink-hardening hygiene (a follow-up to the recent
  checkpoint symlink/traversal fixes), not a behavior change on any legitimate
  setup.

  ## What changed (17 sites)

  - `.entire/`-owned files: `settings.json` / `settings.local.json` existence
    checks (`status.go`, `settings.go`, `setup.go`), the `.entire/` dir existence
    checks (`setup.go`), and `.entire/logs/entire.log` (`doctor_logs.go`).
  - git-internal state under `.git/`: the rebase / cherry-pick / revert markers
    and the stale-ended-session warning sentinel we create (`manual_commit_hooks.go`).
  ## What was deliberately left as os.Stat

  Sites where following a symlink is required or legitimately expected:

  - `.git` directory-vs-gitfile worktree detection — must match git's own
    semantics for a symlinked `.git`.
  - The generic `fileExists` helpers — also called with agent-supplied transcript
    paths, which can legitimately be symlinks.
  - Agent presence dirs (`.claude`, `.cursor`, …) and transcript/session paths,
    PATH binaries and plugins, `~/.bash_profile`, Vercel config, and the
    deliberate symlink-following git config loader.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive rewind file reads and broad setup/status/hook existence logic; behavior should match legitimate repos but symlink edge cases and blocked malicious trailers change outcomes.
> 
> **Overview**
> Hardens symlink handling and one rewind read path.
> 
> **`os.Stat` → `os.Lstat`** on existence checks for paths Entire owns or treats as its own markers—`.entire` settings/logs, setup/status/local-settings probes, and `.git` rebase/cherry-pick/revert/stale-session sentinel files in `manual_commit_hooks.go`. The goal is to detect the symlink entry itself instead of following it; normal layouts are unchanged.
> 
> **Rewind local transcript fallback:** adds `legacyFallbackTranscriptPath` to validate `Entire-Metadata` trailer `metadataDir` (reject empty, absolute, volume-relative, and traversal via `paths.IsRelativeTraversal`) before joining `full.log`. Unsafe values return `""`, and both interactive and `--to` rewind only run the local `copyFile` fallback when that path is non-empty. Unit tests cover traversal and absolute paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 062d8bb3acd504bf54c435d4241ac3856779470b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->