### PR TITLE
cli: isolate the token store in tests so spawned binaries skip the keychain

### DIFF
--- a/cmd/entire/cli/global_test.go
+++ b/cmd/entire/cli/global_test.go
@@ -32,6 +32,9 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Errorf("failed to create test isolation dir: %w", err))
 	}
+	defer func() {
+		_ = os.RemoveAll(isolationDir)
+	}()
 	os.Setenv("ENTIRE_TOKEN_STORE", "file")
 	os.Setenv("ENTIRE_TOKEN_STORE_PATH", filepath.Join(isolationDir, "tokenstore.json"))
 	os.Setenv("ENTIRE_TEST_AUTH_STORE_FILE", filepath.Join(isolationDir, "auth-tokens.json"))

--- a/cmd/entire/cli/global_test.go
+++ b/cmd/entire/cli/global_test.go
@@ -32,9 +32,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Errorf("failed to create test isolation dir: %w", err))
 	}
-	defer func() {
-		_ = os.RemoveAll(isolationDir)
-	}()
 	os.Setenv("ENTIRE_TOKEN_STORE", "file")
 	os.Setenv("ENTIRE_TOKEN_STORE_PATH", filepath.Join(isolationDir, "tokenstore.json"))
 	os.Setenv("ENTIRE_TEST_AUTH_STORE_FILE", filepath.Join(isolationDir, "auth-tokens.json"))

--- a/cmd/entire/cli/global_test.go
+++ b/cmd/entire/cli/global_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-git/v6/x/plugin"
@@ -19,15 +20,34 @@ func TestMain(m *testing.M) {
 	// auth subpackage's TestMain.
 	keyring.MockInit()
 
+	// keyring.MockInit only covers in-process credential access. Several tests
+	// in this package spawn the real entire binary (or a git hook that invokes
+	// it), and testing.Testing() is false in that child — so the internal
+	// testdirs fallback and the in-memory keyring mock don't apply there, and
+	// the child's tokenstore default backend reaches the developer's real OS
+	// keychain. Set the file-backed token store and isolated config/cache dirs
+	// process-wide so spawned children inherit them. Mirrors the integration
+	// and e2e TestMains.
+	isolationDir, err := os.MkdirTemp("", "entire-cli-test-*")
+	if err != nil {
+		panic(fmt.Errorf("failed to create test isolation dir: %w", err))
+	}
+	os.Setenv("ENTIRE_TOKEN_STORE", "file")
+	os.Setenv("ENTIRE_TOKEN_STORE_PATH", filepath.Join(isolationDir, "tokenstore.json"))
+	os.Setenv("ENTIRE_TEST_AUTH_STORE_FILE", filepath.Join(isolationDir, "auth-tokens.json"))
+	os.Setenv("ENTIRE_CONFIG_DIR", filepath.Join(isolationDir, "config"))
+	os.Setenv("XDG_CACHE_HOME", filepath.Join(isolationDir, "cache"))
+
 	// Register a default ConfigSource so tests that call ConfigScoped
 	// (directly or indirectly via Commit/CreateTag) don't fail with
 	// "no config loader registered".
-	err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
+	if regErr := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
 		return config.NewEmpty()
-	})
-	if err != nil {
-		panic(fmt.Errorf("failed to register config storers: %w", err))
+	}); regErr != nil {
+		panic(fmt.Errorf("failed to register config storers: %w", regErr))
 	}
 
-	os.Exit(m.Run())
+	code := m.Run()
+	_ = os.RemoveAll(isolationDir)
+	os.Exit(code)
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/594
<!-- entire-trail-link-end -->

## Problem

Running `go test ./cmd/entire/cli/` triggers a macOS keychain unlock prompt.

The cli package `TestMain` mocks the in-process zalando keyring (`keyring.MockInit()`), but several tests in this package spawn the **real** `entire` binary (or a git hook that invokes it). `testing.Testing()` is false in that child process, so neither the in-memory keyring mock nor the `internal/testdirs` fallback applies there — and the child's tokenstore *default* backend reaches the developer's real OS keychain.

## Fix

Set `ENTIRE_TOKEN_STORE=file` (plus an isolated token / auth / config / cache path under a temp dir) process-wide in `TestMain` before `m.Run`, so spawned children inherit file-backed isolation. This mirrors what the integration and e2e `TestMain`s already do. The in-process `keyring.MockInit()` stays for legacy `auth.NewStore` paths.

## Verification

`go test ./cmd/entire/cli/` passes with the external token env vars explicitly unset (`env -u ENTIRE_TOKEN_STORE ...`), relying solely on the `TestMain` change — and no keychain prompt. `mise run lint`: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness changes with no production code paths; aligns cli package TestMain with existing integration/e2e isolation patterns.
> 
> **Overview**
> **Fixes macOS keychain unlock prompts** when running `go test ./cmd/entire/cli/` by extending `TestMain` so child processes spawned by tests (real `entire` binary or git hooks) no longer hit the OS keychain.
> 
> In-process `keyring.MockInit()` only applies inside the test process; spawned children still used the default token store. **`TestMain` now creates a temp isolation directory** and sets `ENTIRE_TOKEN_STORE=file` plus paths for token store, auth store, config, and cache **before `m.Run()`**, matching integration and e2e harnesses. The temp dir is removed after tests finish. Plugin registration error handling is slightly refactored to avoid shadowing the new `err` from `MkdirTemp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2ed442dd471b7217117813378a0405e90db62f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->