### PR TITLE
checkpoint: centralize store construction behind Open (Phase 0)

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -66,6 +66,17 @@ func (opts attachOptions) committedRefs(ctx context.Context) cpkg.CommittedRefs 
 	return cpkg.ResolveCommittedRefs(ctx)
 }
 
+// openAttachStore opens the committed store for the resolved topology. refs is
+// passed explicitly (not re-resolved from live settings) so attach preserves
+// any injected EntireSettings / PrimaryAsRead() pinning.
+func openAttachStore(ctx context.Context, repo *git.Repository, refs cpkg.CommittedRefs) (*cpkg.GitStore, error) {
+	stores, err := cpkg.Open(ctx, repo, cpkg.OpenOptions{Refs: &refs})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
+	}
+	return stores.Primary, nil
+}
+
 func newAttachCmd() *cobra.Command {
 	var (
 		force      bool
@@ -272,7 +283,10 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		return err
 	}
 
-	store := cpkg.NewGitStore(repo, refs)
+	store, err := openAttachStore(ctx, repo, refs)
+	if err != nil {
+		return err
+	}
 
 	// Defense-in-depth guard: the earlier existingState.LastCheckpointID
 	// check only fires when the session's state file records its
@@ -363,7 +377,10 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 // at Primary. Reads target Primary directly, not refs.Read, because this guard
 // must reflect what the next write would target.
 func checkpointHasSessionMetadata(ctx context.Context, repo *git.Repository, refs cpkg.CommittedRefs, checkpointID id.CheckpointID, sessionID string) (bool, error) {
-	store := cpkg.NewGitStore(repo, refs.PrimaryAsRead())
+	store, err := openAttachStore(ctx, repo, refs.PrimaryAsRead())
+	if err != nil {
+		return false, err
+	}
 	summary, err := store.ReadCommitted(ctx, checkpointID)
 	if err != nil {
 		return false, fmt.Errorf("read checkpoint summary: %w", err)
@@ -463,7 +480,11 @@ func checkpointPresentLocally(ctx context.Context, repo *git.Repository, refs cp
 	if _, err := repo.Reference(refs.Primary, true); err != nil {
 		return false, nil //nolint:nilerr // Missing ref is the "absent" signal, not an error.
 	}
-	summary, err := cpkg.NewGitStore(repo, refs.PrimaryAsRead()).ReadCommitted(ctx, checkpointID)
+	store, err := openAttachStore(ctx, repo, refs.PrimaryAsRead())
+	if err != nil {
+		return false, err
+	}
+	summary, err := store.ReadCommitted(ctx, checkpointID)
 	if err != nil {
 		return false, err //nolint:wrapcheck // Caller wraps with checkpoint ID context
 	}

--- a/cmd/entire/cli/attribution.go
+++ b/cmd/entire/cli/attribution.go
@@ -312,13 +312,15 @@ func newAttributionResolver(ctx context.Context, fetchOnMiss bool) (*attribution
 		return nil, fmt.Errorf("not a git repository: %w", err)
 	}
 
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
-	store.SetBlobFetcher(FetchBlobsByHash)
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
+	}
 
 	return &attributionResolver{
 		ctx:             ctx,
 		repo:            repo,
-		store:           store,
+		store:           stores.Primary,
 		fetchOnMiss:     fetchOnMiss,
 		commitCache:     make(map[string]*object.Commit),
 		checkpointCache: make(map[string]attributionCheckpointContext),

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -1335,8 +1335,11 @@ func LookupSessionLog(ctx context.Context, cpID id.CheckpointID) ([]byte, string
 		return nil, "", fmt.Errorf("failed to open git repository: %w", err)
 	}
 	defer repo.Close()
-	store := NewGitStore(repo, ResolveCommittedRefs(ctx))
-	return store.GetSessionLog(ctx, cpID)
+	stores, err := Open(ctx, repo, OpenOptions{})
+	if err != nil {
+		return nil, "", fmt.Errorf("open checkpoint store: %w", err)
+	}
+	return stores.Primary.GetSessionLog(ctx, cpID)
 }
 
 // UpdateSummary updates the summary field in the latest session's metadata.

--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -1,0 +1,90 @@
+package checkpoint
+
+import (
+	"context"
+
+	"github.com/go-git/go-git/v6"
+
+	"github.com/entireio/cli/cmd/entire/cli/settings"
+)
+
+// OpenOptions configures Open. The zero value resolves the committed-ref
+// topology from on-disk settings and attaches no blob fetcher.
+type OpenOptions struct {
+	// BlobFetcher is the CLI-level on-demand blob fetcher. The checkpoint
+	// package cannot resolve it itself, so the CLI layer injects it here and
+	// Open attaches it to the constructed store(s). nil leaves on-demand
+	// fetching off.
+	BlobFetcher BlobFetchFunc
+
+	// Settings overrides on-disk settings when resolving the committed-ref
+	// topology. nil resolves from disk via ResolveCommittedRefs. Ignored when
+	// Refs is non-nil.
+	Settings *settings.EntireSettings
+
+	// Refs overrides the resolved committed-ref topology outright. nil resolves
+	// from Settings (or disk). A non-nil value wins — e.g. attach pins reads to
+	// Primary via PrimaryAsRead().
+	Refs *CommittedRefs
+}
+
+// Stores is the facade returned by Open: the committed store plus the git-only
+// temporary capability and the resolved topology accessors callers need during
+// the transition to pluggable backends.
+//
+// Phase 0 (centralized construction) holds the concrete *GitStore in Primary,
+// and the same instance backs Temporary(). Later phases narrow Primary to a
+// pluggable committed-store interface and add independent-backend mirrors
+// without changing this call-site-facing API.
+type Stores struct {
+	// Primary is the committed store — the source of truth that serves all
+	// committed reads and writes.
+	Primary *GitStore
+
+	temporary *GitStore
+	refs      CommittedRefs
+}
+
+// Open resolves the checkpoint storage topology and constructs the backing
+// store(s). It is the single construction seam that replaces scattered
+// NewGitStore(repo, ResolveCommittedRefs(ctx)) calls, so ref resolution and
+// blob-fetcher wiring live in one place.
+//
+//nolint:unparam // The error result is part of the forward-looking facade contract: pluggable backends (Phase 2+) can fail to open. The git backend never returns one today.
+func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores, error) {
+	refs := resolveOpenRefs(ctx, opts)
+	store := NewGitStore(repo, refs)
+	if opts.BlobFetcher != nil {
+		store.SetBlobFetcher(opts.BlobFetcher)
+	}
+	return &Stores{
+		Primary:   store,
+		temporary: store,
+		refs:      refs,
+	}, nil
+}
+
+func resolveOpenRefs(ctx context.Context, opts OpenOptions) CommittedRefs {
+	switch {
+	case opts.Refs != nil:
+		return *opts.Refs
+	case opts.Settings != nil:
+		return ResolveCommittedRefsFromSettings(opts.Settings)
+	default:
+		return ResolveCommittedRefs(ctx)
+	}
+}
+
+// Temporary returns the git-backed temporary (shadow-branch) store. Temporary
+// capture is inherently git-only; a future non-git Primary would leave this
+// pointing at a dedicated git store.
+func (s *Stores) Temporary() *GitStore { return s.temporary }
+
+// Refs returns the resolved committed-ref topology. Transition accessor: this
+// ref logic moves behind sync/admin capabilities in a later phase.
+func (s *Stores) Refs() CommittedRefs { return s.refs }
+
+// Repository returns the underlying git repository. Transition accessor for
+// git-topology operations (e.g. mirror repair) that have not yet moved behind a
+// capability.
+func (s *Stores) Repository() *git.Repository { return s.Primary.Repository() }

--- a/cmd/entire/cli/dispatch/mode_local.go
+++ b/cmd/entire/cli/dispatch/mode_local.go
@@ -179,7 +179,11 @@ func enumerateRepoCandidates(ctx context.Context, repoRoot string, opts Options,
 	// the cwd may not be a repo at all, so scope settings resolution to this
 	// repo before consulting the topology.
 	repoCtx := settings.WithWorktreeRoot(ctx, repoRoot)
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(repoCtx))
+	stores, err := checkpoint.Open(repoCtx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
+	}
+	store := stores.Primary
 	infos, err := store.ListCommitted(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list committed checkpoints: %w", err)

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -638,7 +638,11 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		// layer, so rawTranscript is always false when generate is true; the
 		// direct-to-w write path inside explainTemporaryCheckpoint is not
 		// reachable here and won't leak partial output on error.
-		output, found, tempErr := explainTemporaryCheckpoint(ctx, w, errW, lookup.repo, checkpoint.NewGitStore(lookup.repo, checkpoint.ResolveCommittedRefs(ctx)), checkpointIDPrefix, verbose, full, rawTranscript)
+		tempStores, openErr := checkpoint.Open(ctx, lookup.repo, checkpoint.OpenOptions{})
+		if openErr != nil {
+			return fmt.Errorf("open checkpoint store: %w", openErr)
+		}
+		output, found, tempErr := explainTemporaryCheckpoint(ctx, w, errW, lookup.repo, tempStores.Temporary(), checkpointIDPrefix, verbose, full, rawTranscript)
 		if tempErr != nil {
 			return tempErr
 		}
@@ -678,14 +682,21 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// Handle summary generation — uses raw transcript.
 	if generate {
 		stopLoad(false) // generation prints its own progress to w/errW
-		writeStore := checkpoint.NewGitStore(lookup.repo, checkpoint.ResolveCommittedRefs(ctx))
-		if err := generateCheckpointSummary(ctx, w, errW, writeStore, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
+		writeStores, openErr := checkpoint.Open(ctx, lookup.repo, checkpoint.OpenOptions{})
+		if openErr != nil {
+			return fmt.Errorf("open checkpoint store: %w", openErr)
+		}
+		if err := generateCheckpointSummary(ctx, w, errW, writeStores, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
 			return err
 		}
 		// Reload to get the updated summary.
 		stopLoad = startSpinner(errW, fmt.Sprintf("Reloading checkpoint %s", fullCheckpointID))
-		lookup.store = checkpoint.NewGitStore(lookup.repo, checkpoint.ResolveCommittedRefs(ctx))
-		lookup.store.SetBlobFetcher(FetchBlobsByHash)
+		reopened, openErr := checkpoint.Open(ctx, lookup.repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+		if openErr != nil {
+			stopLoad(false)
+			return fmt.Errorf("open checkpoint store: %w", openErr)
+		}
+		lookup.store = reopened.Primary
 		content, err = checkpoint.ReadLatestSessionContent(ctx, lookup.store, fullCheckpointID, summary)
 		if err != nil {
 			stopLoad(false)
@@ -857,8 +868,11 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 	// `git fetch` fails against partial-clone repos with "did not send all
 	// necessary objects"). Falls back to a full metadata-branch fetch if
 	// fetch-pack also can't reach the blobs.
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
-	store.SetBlobFetcher(FetchBlobsByHash)
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
+	}
+	store := stores.Primary
 
 	lookup := &explainCheckpointLookup{
 		repo:  repo,
@@ -881,7 +895,7 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 // summaryTimeoutSeconds is the per-invocation --summary-timeout-seconds flag
 // value (0 = unset). Effective precedence for the deadline: flag > settings >
 // package default. See resolveSummaryTimeout for the resolution.
-func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store *checkpoint.GitStore, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
+func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, stores *checkpoint.Stores, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
 	// Check if summary already exists
 	if content.Metadata.Summary != nil && !force {
 		return renderExplainFailure(errW, "Summary already exists", []explainRow{
@@ -928,12 +942,12 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store *ch
 	}
 	elapsed := time.Since(start)
 
-	if err := store.UpdateSummary(ctx, checkpointID, summary); err != nil {
+	if err := stores.Primary.UpdateSummary(ctx, checkpointID, summary); err != nil {
 		return fmt.Errorf("failed to save summary: %w", err)
 	}
 
 	refs := checkpoint.ResolveCommittedRefs(ctx)
-	if err := strategy.MirrorCommittedMetadataRef(ctx, store.Repository(), refs); err != nil {
+	if err := strategy.MirrorCommittedMetadataRef(ctx, stores.Repository(), refs); err != nil {
 		return fmt.Errorf("summary was written to %s, but failed to mirror to %s: %w", refs.Primary, refs.Mirror, err)
 	}
 
@@ -2010,7 +2024,11 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	// Warn (once per process) if metadata branches are disconnected
 	strategy.WarnIfMetadataDisconnected()
 
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
+	}
+	store := stores.Primary
 
 	// Get all committed checkpoints for lookup.
 	committedInfos, err := store.ListCommitted(ctx)
@@ -2114,7 +2132,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	}
 
 	// Get temporary checkpoints from ALL shadow branches whose base commit is reachable from HEAD.
-	tempPoints := getReachableTemporaryCheckpoints(ctx, repo, store, head.Hash(), isOnDefault, limit)
+	tempPoints := getReachableTemporaryCheckpoints(ctx, repo, stores.Temporary(), head.Hash(), isOnDefault, limit)
 	points = append(points, tempPoints...)
 
 	// Sort by date, most recent first

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1013,7 +1013,10 @@ func TestGenerateCheckpointSummary_MirrorsToV1CustomRefWhenOptedIn(t *testing.T)
 
 	repo, err := git.PlainOpen(tmpDir)
 	require.NoError(t, err)
-	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
+	v1Refs := checkpoint.DefaultV1Refs()
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{Refs: &v1Refs})
+	require.NoError(t, err)
+	store := stores.Primary
 	cpID := id.MustCheckpointID("a1b2c3d4e5f6")
 	require.NoError(t, store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
 		CheckpointID: cpID,
@@ -1060,7 +1063,7 @@ func TestGenerateCheckpointSummary_MirrorsToV1CustomRefWhenOptedIn(t *testing.T)
 	}
 
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, generateCheckpointSummary(ctx, &stdout, &stderr, store, cpID, cpSummary, content, false, 0))
+	require.NoError(t, generateCheckpointSummary(ctx, &stdout, &stderr, stores, cpID, cpSummary, content, false, 0))
 
 	v1After, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.NoError(t, err)

--- a/cmd/entire/cli/head_checkpoint_flags.go
+++ b/cmd/entire/cli/head_checkpoint_flags.go
@@ -52,8 +52,12 @@ func headCheckpointFlags(ctx context.Context) (hasReview, hasInvestigation bool,
 		return false, false, ""
 	}
 	defer repo.Close()
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
-	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, store, cpID)
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		logging.Debug(ctx, "head checkpoint flags: open store", slog.String("error", err.Error()))
+		return false, false, ""
+	}
+	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, stores.Primary, cpID)
 	if err != nil || summary == nil {
 		logging.Debug(ctx, "head checkpoint flags: resolve checkpoint summary",
 			slog.String("checkpoint_id", cpID.String()),

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -267,10 +267,13 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 	checkpointID := result.checkpointIDs[0]
 	var metadata *strategy.CheckpointInfo
 
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
-	store.SetBlobFetcher(FetchBlobsByHash)
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	if err != nil {
+		return fmt.Errorf("open checkpoint store: %w", err)
+	}
+	store := stores.Primary
 
-	refs := store.Refs()
+	refs := stores.Refs()
 	if refs.ReadBootstrappableFromOrigin() {
 		promoteRemoteTrackingPrimary(ctx, repo, refs)
 	}
@@ -286,7 +289,7 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 			)
 			fmt.Fprintf(w, "Found %d checkpoints for commit %s but metadata is not available\n",
 				len(result.checkpointIDs), result.commitHash[:7])
-			return checkRemoteMetadata(ctx, w, errW, result.checkpointIDs[0], store.Refs())
+			return checkRemoteMetadata(ctx, w, errW, result.checkpointIDs[0], stores.Refs())
 		}
 		skipped := len(result.checkpointIDs) - 1
 		fmt.Fprintf(w, "Found %d checkpoints for commit %s, resuming from the latest (%d older checkpoints skipped)\n",
@@ -308,7 +311,7 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 				slog.String("checkpoint_id", checkpointID.String()),
 				slog.String("error", storeErr.Error()),
 			)
-			return checkRemoteMetadata(ctx, w, errW, checkpointID, store.Refs())
+			return checkRemoteMetadata(ctx, w, errW, checkpointID, stores.Refs())
 		}
 	}
 
@@ -385,9 +388,11 @@ func readCheckpointInfoFromRef(
 	refs checkpoint.CommittedRefs,
 	checkpointID id.CheckpointID,
 ) (*strategy.CheckpointInfo, error) {
-	store := checkpoint.NewGitStore(repo, refs)
-	store.SetBlobFetcher(FetchBlobsByHash)
-	return readCheckpointInfoFromStore(ctx, store, checkpointID)
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{Refs: &refs, BlobFetcher: FetchBlobsByHash})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
+	}
+	return readCheckpointInfoFromStore(ctx, stores.Primary, checkpointID)
 }
 
 // getMetadataTree returns the metadata branch tree and a fresh repo handle.
@@ -926,9 +931,11 @@ func resumeSingleSession(ctx context.Context, w, _ io.Writer, ag agent.Agent, se
 		return fmt.Errorf("failed to open repository: %w", repoErr)
 	}
 	defer repo.Close()
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
-	store.SetBlobFetcher(FetchBlobsByHash)
-	logContent, _, err := checkpoint.ReadRawSessionLogForCheckpoint(ctx, store, checkpointID)
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	if err != nil {
+		return fmt.Errorf("open checkpoint store: %w", err)
+	}
+	logContent, _, err := checkpoint.ReadRawSessionLogForCheckpoint(ctx, stores.Primary, checkpointID)
 	if err != nil {
 		if errors.Is(err, checkpoint.ErrCheckpointNotFound) || errors.Is(err, checkpoint.ErrNoTranscript) {
 			logging.Debug(ctx, "resume session completed (no metadata)",

--- a/cmd/entire/cli/review_context.go
+++ b/cmd/entire/cli/review_context.go
@@ -98,7 +98,12 @@ func reviewCommittedCheckpointContext(ctx context.Context, worktreeRoot string, 
 		return ""
 	}
 	defer repo.Close()
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		logging.Debug(ctx, "review checkpoint context: open store", slog.String("error", err.Error()))
+		return ""
+	}
+	store := stores.Primary
 
 	var lines []string
 	seen := map[checkpointid.CheckpointID]bool{}

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -718,8 +718,11 @@ func restoreSessionTranscriptFromStrategy(ctx context.Context, cpID id.Checkpoin
 	}
 	defer repo.Close()
 
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
-	content, returnedSessionID, err := checkpoint.ReadRawSessionLogForCheckpoint(ctx, store, cpID)
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		return "", fmt.Errorf("open checkpoint store: %w", err)
+	}
+	content, returnedSessionID, err := checkpoint.ReadRawSessionLogForCheckpoint(ctx, stores.Primary, cpID)
 	if err != nil {
 		return "", fmt.Errorf("failed to get session log: %w", err)
 	}
@@ -766,8 +769,11 @@ func restoreSessionTranscriptFromShadow(ctx context.Context, commitHash, metadat
 	}
 
 	// Get transcript from shadow branch commit tree
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
-	content, err := store.GetTranscriptFromCommit(ctx, hash, metadataDir, agent.Type())
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		return "", fmt.Errorf("open checkpoint store: %w", err)
+	}
+	content, err := stores.Temporary().GetTranscriptFromCommit(ctx, hash, metadataDir, agent.Type())
 	if err != nil {
 		return "", fmt.Errorf("failed to get transcript from shadow branch: %w", err)
 	}

--- a/cmd/entire/cli/strategy/cleanup.go
+++ b/cmd/entire/cli/strategy/cleanup.go
@@ -169,10 +169,13 @@ func ListOrphanedSessionStates(ctx context.Context) ([]CleanupItem, error) {
 	}
 
 	// Get all committed checkpoints from the configured read ref to find which sessions have checkpoints
-	cpStore := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
+	cpStores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
+	}
 
 	sessionsWithCheckpoints := make(map[string]bool)
-	checkpoints, listErr := cpStore.ListCommitted(ctx)
+	checkpoints, listErr := cpStores.Primary.ListCommitted(ctx)
 	if listErr == nil {
 		for _, cp := range checkpoints {
 			// cp.SessionID is the most-recent session in a multi-session checkpoint;

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -305,8 +305,11 @@ func ListCheckpoints(ctx context.Context) ([]CheckpointInfo, error) {
 	// Warn (once per process) if metadata branches are disconnected
 	WarnIfMetadataDisconnected()
 
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
-	committed, err := store.ListCommitted(ctx)
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
+	}
+	committed, err := stores.Primary.ListCommitted(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list committed checkpoints: %w", err)
 	}

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -40,19 +40,16 @@ func (s *ManualCommitStrategy) getStateStore(_ context.Context) (*session.StateS
 	return s.stateStore, s.stateStoreErr
 }
 
-// withBlobFetcher wires the strategy's blob fetcher into a store so it can fetch
-// blobs on demand after a treeless fetch.
-func (s *ManualCommitStrategy) withBlobFetcher(store *checkpoint.GitStore) *checkpoint.GitStore {
-	if s.blobFetcher != nil {
-		store.SetBlobFetcher(s.blobFetcher)
-	}
-	return store
-}
-
 // getCheckpointStore returns a store bound to the resolved committed-metadata
-// topology. Writes target refs.Primary; reads target refs.Read.
-func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git.Repository) *checkpoint.GitStore {
-	return s.withBlobFetcher(checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx)))
+// topology. Writes target refs.Primary; reads target refs.Read. The strategy's
+// blob fetcher is wired in so reads can fetch blobs on demand after a treeless
+// fetch.
+func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git.Repository) (*checkpoint.GitStore, error) {
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: s.blobFetcher})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
+	}
+	return stores.Primary, nil
 }
 
 // NewManualCommitStrategy creates a new manual-commit strategy instance.

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -49,7 +49,10 @@ func (s *ManualCommitStrategy) listCheckpoints(ctx context.Context) ([]Checkpoin
 	defer repo.Close()
 
 	WarnIfMetadataDisconnected()
-	store := s.getCheckpointStore(ctx, repo)
+	store, err := s.getCheckpointStore(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	committed, err := store.ListCommitted(ctx)
 	if err != nil {
@@ -68,7 +71,10 @@ func (s *ManualCommitStrategy) getCheckpointLog(ctx context.Context, checkpointI
 	defer repo.Close()
 
 	WarnIfMetadataDisconnected()
-	store := s.getCheckpointStore(ctx, repo)
+	store, err := s.getCheckpointStore(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	summary, err := cpkg.ReadCommittedCheckpoint(ctx, store, checkpointID)
 	if err != nil {
@@ -198,7 +204,10 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		return skipped, nil
 	}
 
-	store := s.getCheckpointStore(ctx, repo)
+	store, err := s.getCheckpointStore(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	// Get author info
 	authorName, authorEmail := GetGitAuthorFromRepo(repo)

--- a/cmd/entire/cli/strategy/manual_commit_git.go
+++ b/cmd/entire/cli/strategy/manual_commit_git.go
@@ -52,7 +52,10 @@ func (s *ManualCommitStrategy) SaveStep(ctx context.Context, step StepContext) e
 		}
 		migrateSpan.End()
 
-		store := s.getCheckpointStore(ctx, repo)
+		store, err := s.getCheckpointStore(ctx, repo)
+		if err != nil {
+			return err
+		}
 
 		shadowBranchName := checkpoint.ShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
 		branchExisted := store.ShadowBranchExists(state.BaseCommit, state.WorktreeID)
@@ -182,7 +185,10 @@ func (s *ManualCommitStrategy) SaveTaskStep(ctx context.Context, step TaskStepCo
 			return fmt.Errorf("failed to check/migrate shadow branch: %w", err)
 		}
 
-		store := s.getCheckpointStore(ctx, repo)
+		store, err := s.getCheckpointStore(ctx, repo)
+		if err != nil {
+			return err
+		}
 
 		shadowBranchName := checkpoint.ShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
 		branchExisted := store.ShadowBranchExists(state.BaseCommit, state.WorktreeID)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1061,7 +1061,11 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 	repoDir string,
 ) error {
 	logCtx := logging.WithComponent(ctx, "attribution")
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		return fmt.Errorf("open checkpoint store: %w", err)
+	}
+	store := stores.Primary
 
 	summary, err := store.ReadCommitted(ctx, checkpointID)
 	if err != nil {
@@ -1160,7 +1164,7 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 
 	// Combined attribution is a committed write in the post-commit hook, so the
 	// mirror must track it too when configured (best-effort).
-	mirrorCommittedMetadataRefBestEffort(ctx, repo, store.Refs())
+	mirrorCommittedMetadataRefBestEffort(ctx, repo, stores.Refs())
 
 	return nil
 }
@@ -2794,7 +2798,14 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 		prompts[i] = redact.String(p)
 	}
 
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		logging.Warn(logCtx, "finalize: failed to open checkpoint store",
+			slog.String("error", err.Error()),
+		)
+		return 1 // Count as error - all checkpoints will be skipped
+	}
+	store := stores.Primary
 
 	precomputed := precomputeTranscriptBlobsForFinalize(logCtx, repo, redactedTranscript, state)
 
@@ -2839,7 +2850,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 	// Mirror the finalized primary metadata to refs.Mirror when configured
 	// (best-effort; failures are logged, not fatal). Once after the loop is
 	// enough — it tracks Primary's final commit.
-	mirrorCommittedMetadataRefBestEffort(ctx, repo, store.Refs())
+	mirrorCommittedMetadataRefBestEffort(ctx, repo, stores.Refs())
 
 	// Clear turn checkpoint IDs. Do NOT update CheckpointTranscriptStart here — it was
 	// already set correctly by PostCommit: condenseAndUpdateState sets it to the total
@@ -2910,14 +2921,21 @@ func (s *ManualCommitStrategy) carryForwardToNewShadowBranch(
 ) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	start := time.Now()
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveCommittedRefs(ctx))
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
+	if err != nil {
+		logging.Warn(logCtx, "post-commit: carry-forward failed to open checkpoint store",
+			slog.String("session_id", state.SessionID),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
 
 	// Don't include metadata directory in carry-forward. The carry-forward branch
 	// only needs to preserve file content for comparison - not the transcript.
 	// Including the transcript would cause sessionHasNewContent to always return true
 	// because CheckpointTranscriptStart is reset to 0 for carry-forward.
 	writeCtx, carryForwardWriteSpan := perf.Start(ctx, "write_carry_forward_shadow")
-	result, err := store.WriteTemporary(writeCtx, checkpoint.WriteTemporaryOptions{
+	result, err := stores.Temporary().WriteTemporary(writeCtx, checkpoint.WriteTemporaryOptions{
 		SessionID:         state.SessionID,
 		BaseCommit:        state.BaseCommit,
 		WorktreeID:        state.WorktreeID,

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -38,7 +38,10 @@ func (s *ManualCommitStrategy) GetRewindPoints(ctx context.Context, limit int) (
 	}
 	defer repo.Close()
 
-	store := s.getCheckpointStore(ctx, repo)
+	store, err := s.getCheckpointStore(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
 
 	// Get current HEAD to find matching shadow branch
 	head, err := repo.Head()
@@ -639,10 +642,11 @@ func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.W
 	defer repo.Close()
 
 	WarnIfMetadataDisconnected()
-	store := cpkg.NewGitStore(repo, cpkg.ResolveCommittedRefs(ctx))
-	if s.blobFetcher != nil {
-		store.SetBlobFetcher(s.blobFetcher)
+	stores, err := cpkg.Open(ctx, repo, cpkg.OpenOptions{BlobFetcher: s.blobFetcher})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint store: %w", err)
 	}
+	store := stores.Primary
 	summary, err := cpkg.ReadCommittedCheckpoint(ctx, store, point.CheckpointID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read checkpoint: %w", err)

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -4252,7 +4252,8 @@ func TestCondenseSession_RedactionFailure_DropsTranscriptButWritesMetadata(t *te
 	require.NoError(t, err, "redaction failure should not abort condensation")
 	require.NotNil(t, result)
 
-	store := s.getCheckpointStore(context.Background(), repo)
+	store, err := s.getCheckpointStore(context.Background(), repo)
+	require.NoError(t, err)
 
 	committed, err := store.ListCommitted(context.Background())
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/593
<!-- entire-trail-link-end -->

Phase 0 of #1433 (pluggable checkpoint stores).

## What

Replace the scattered `NewGitStore(repo, ResolveCommittedRefs(ctx))` construction across `cli`, `strategy`, `dispatch`, and the in-package `LookupSessionLog` with a single seam:

```go
checkpoint.Open(ctx, repo, OpenOptions) (*Stores, error)
```

This lands the **final facade signature now** so call sites migrate only once. `Stores.Primary` holds the concrete `*GitStore` today and the same instance backs `Temporary()`; later phases narrow `Primary` to a pluggable committed-store interface and add independent-backend mirrors without further call-site churn. The facade exposes `Temporary()` / `Refs()` / `Repository()` so callers no longer reach for the concrete type, and `OpenOptions` carries the CLI-level `BlobFetcher` plus explicit `Settings` / `Refs` overrides (attach keeps its injected-settings / `PrimaryAsRead` topology exactly).

Pure mechanical, **no behavior change.**

## Notes / decisions

- All 26 production `NewGitStore` sites migrated; the ~131 test-file sites and `benchutil` keep using `NewGitStore`, which `Open` now wraps.
- `getCheckpointStore` returns `(*GitStore, error)` (propagated through its callers); the old `withBlobFetcher` folds into `OpenOptions.BlobFetcher`.
- `generateCheckpointSummary` takes the facade since it needs both the committed writer and `Repository()`; its mirror still resolves refs from settings (`ResolveCommittedRefs`) to preserve exact behavior.
- Type is `checkpoint.Stores` (not `CheckpointStores`) to avoid the `revive` stutter; `Open`'s always-nil error is documented as the forward-looking facade contract.

## Verification

`go build ./...` ✓ · `mise run lint` → 0 issues · `checkpoint` / `strategy` / `dispatch` / `cli` package tests ✓.

> Note: the keychain-isolation gap surfaced while testing this is fixed independently in #1450.

Refs #1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only consolidation of store construction across many files; git backend behavior is unchanged and errors are propagated consistently at new open sites.
> 
> **Overview**
> **Phase 0** introduces `checkpoint.Open(ctx, repo, OpenOptions)` and a `Stores` facade (`Primary`, `Temporary()`, `Refs()`, `Repository()`) so committed-ref resolution, optional `BlobFetcher`, and `Settings` / `Refs` overrides live in one place instead of repeated `NewGitStore(repo, ResolveCommittedRefs(ctx))` wiring.
> 
> Production call sites across **attach**, **explain**, **resume**, **rewind**, attribution, dispatch, strategy hooks, and `LookupSessionLog` now open stores through this seam. **Attach** uses `openAttachStore` with explicit `Refs` (including `PrimaryAsRead()`) so injected settings and read pinning stay intact. **Manual commit** folds `withBlobFetcher` into `OpenOptions` and makes `getCheckpointStore` return `(*GitStore, error)`; paths that need shadow-branch I/O use `Stores.Temporary()` rather than treating the committed store as the temp capability.
> 
> Intended as a **mechanical migration** with no deliberate behavior change; tests largely still construct `NewGitStore` directly where convenient.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b938d6ac78edf0c4563dd1f8a60394d3eb7701. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->