### PR TITLE
search: support Entire mirror remotes

### DIFF
--- a/cmd/entire/cli/search/github.go
+++ b/cmd/entire/cli/search/github.go
@@ -2,6 +2,7 @@
 package search
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,10 @@ import (
 // whose forge prefix maps back to github.com. Remotes resolving to any other
 // host, or whose path holds extra segments beyond owner/repo, are rejected.
 func ParseGitHubRemote(remoteURL string) (owner, repo string, err error) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return "", "", errors.New("empty remote URL")
+	}
 	info, err := gitremote.ParseURL(remoteURL)
 	if err != nil {
 		return "", "", fmt.Errorf("parsing remote URL: %w", err)

--- a/cmd/entire/cli/search/github.go
+++ b/cmd/entire/cli/search/github.go
@@ -3,6 +3,7 @@ package search
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 )
@@ -11,7 +12,7 @@ import (
 // to GitHub. It accepts direct GitHub remotes (SCP-style SSH, ssh://, and
 // https://) as well as Entire mirror remotes (entire://host/gh/owner/repo),
 // whose forge prefix maps back to github.com. Remotes resolving to any other
-// host are rejected.
+// host, or whose path holds extra segments beyond owner/repo, are rejected.
 func ParseGitHubRemote(remoteURL string) (owner, repo string, err error) {
 	info, err := gitremote.ParseURL(remoteURL)
 	if err != nil {
@@ -19,6 +20,9 @@ func ParseGitHubRemote(remoteURL string) (owner, repo string, err error) {
 	}
 	if host := info.CanonicalHost(); host != "github.com" {
 		return "", "", fmt.Errorf("remote is not a GitHub repository (host: %s)", host)
+	}
+	if strings.Contains(info.Repo, "/") {
+		return "", "", fmt.Errorf("remote path has extra segments beyond owner/repo: %s", gitremote.RedactURL(remoteURL))
 	}
 	return info.Owner, info.Repo, nil
 }

--- a/cmd/entire/cli/search/github.go
+++ b/cmd/entire/cli/search/github.go
@@ -2,56 +2,23 @@
 package search
 
 import (
-	"errors"
 	"fmt"
-	"net/url"
-	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 )
 
-// ParseGitHubRemote extracts owner and repo from a GitHub remote URL.
-// Supports SCP-style SSH (git@github.com:owner/repo.git),
-// ssh:// URLs (ssh://git@github.com/owner/repo.git),
-// and HTTPS (https://github.com/owner/repo.git).
+// ParseGitHubRemote extracts owner and repo from a git remote URL that resolves
+// to GitHub. It accepts direct GitHub remotes (SCP-style SSH, ssh://, and
+// https://) as well as Entire mirror remotes (entire://host/gh/owner/repo),
+// whose forge prefix maps back to github.com. Remotes resolving to any other
+// host are rejected.
 func ParseGitHubRemote(remoteURL string) (owner, repo string, err error) {
-	remoteURL = strings.TrimSpace(remoteURL)
-	if remoteURL == "" {
-		return "", "", errors.New("empty remote URL")
+	info, err := gitremote.ParseURL(remoteURL)
+	if err != nil {
+		return "", "", fmt.Errorf("parsing remote URL: %w", err)
 	}
-
-	var path string
-
-	// SCP-style SSH: git@github.com:owner/repo.git
-	// Distinguished from ssh:// URLs by having no scheme and a colon before the path.
-	if strings.HasPrefix(remoteURL, "git@") && !strings.Contains(remoteURL, "://") {
-		idx := strings.Index(remoteURL, ":")
-		if idx < 0 {
-			return "", "", fmt.Errorf("invalid SSH remote URL: %s", remoteURL)
-		}
-		host := remoteURL[len("git@"):idx]
-		if host != "github.com" {
-			return "", "", fmt.Errorf("remote is not a GitHub repository (host: %s)", host)
-		}
-		path = remoteURL[idx+1:]
-	} else {
-		// URL format: https://, ssh://, git://
-		u, parseErr := url.Parse(remoteURL)
-		if parseErr != nil {
-			return "", "", fmt.Errorf("parsing remote URL: %w", parseErr)
-		}
-		host := u.Hostname()
-		if host != "github.com" {
-			return "", "", fmt.Errorf("remote is not a GitHub repository (host: %s)", host)
-		}
-		path = strings.TrimPrefix(u.Path, "/")
+	if host := info.CanonicalHost(); host != "github.com" {
+		return "", "", fmt.Errorf("remote is not a GitHub repository (host: %s)", host)
 	}
-
-	// Remove .git suffix
-	path = strings.TrimSuffix(path, ".git")
-
-	parts := strings.SplitN(path, "/", 3)
-	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", fmt.Errorf("could not extract owner/repo from remote URL: %s", remoteURL)
-	}
-
-	return parts[0], parts[1], nil
+	return info.Owner, info.Repo, nil
 }

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -105,6 +105,18 @@ func TestParseGitHubRemote_NonGitHubHTTPS(t *testing.T) {
 	}
 }
 
+func TestParseGitHubRemote_RejectsExtraPathSegments(t *testing.T) {
+	t.Parallel()
+	for _, remoteURL := range []string{
+		"https://github.com/entirehq/entire.io/extra.git",
+		"entire://aws-us-east-2.entire.io/gh/entirehq/entire.io/extra",
+	} {
+		if _, _, err := ParseGitHubRemote(remoteURL); err == nil {
+			t.Errorf("expected error for malformed remote %q, got none", remoteURL)
+		}
+	}
+}
+
 func TestParseGitHubRemote_EntireMirror(t *testing.T) {
 	t.Parallel()
 	owner, repo, err := ParseGitHubRemote("entire://aws-us-east-2.entire.io/gh/entirehq/entire.io")

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -56,9 +56,9 @@ func TestParseGitHubRemote_HTTPSNoGit(t *testing.T) {
 
 func TestParseGitHubRemote_Invalid(t *testing.T) {
 	t.Parallel()
-	_, _, err := ParseGitHubRemote("")
-	if err == nil {
-		t.Error("expected error for empty URL")
+	_, _, err := ParseGitHubRemote("   ")
+	if err == nil || err.Error() != "empty remote URL" {
+		t.Errorf("expected 'empty remote URL' for blank input, got %v", err)
 	}
 
 	_, _, err = ParseGitHubRemote("not-a-url")

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -105,6 +105,17 @@ func TestParseGitHubRemote_NonGitHubHTTPS(t *testing.T) {
 	}
 }
 
+func TestParseGitHubRemote_EntireMirror(t *testing.T) {
+	t.Parallel()
+	owner, repo, err := ParseGitHubRemote("entire://aws-us-east-2.entire.io/gh/entirehq/entire.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if owner != testOwner || repo != testRepo {
+		t.Errorf("got %s/%s, want %s/%s", owner, repo, testOwner, testRepo)
+	}
+}
+
 // -- Search() tests --
 
 func TestSearch_URLConstruction(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/595
<!-- entire-trail-link-end -->

## Why

`entire search` failed for any repo whose `origin` points at the Entire git mirror rather than GitHub directly:

```
$ entire search "..."
parsing remote URL: remote is not a GitHub repository (host: aws-us-east-2.entire.io)
```

The search command derives `owner`/`repo` from the `origin` remote, but it used a GitHub-only parser (`search.ParseGitHubRemote`) that required the URL host to literally be `github.com`. Entire mirror remotes use the form `entire://<cluster-host>/gh/<owner>/<repo>`, so the parser saw the cluster host and rejected it. The same limitation also affected the two `dispatch` callers that share this helper.

## What changed

`ParseGitHubRemote` now delegates to the canonical `gitremote.ParseURL`, which understands the `entire://` scheme, and enforces the "must resolve to GitHub" policy via `Info.CanonicalHost()` (the `gh` forge prefix maps back to `github.com`). It also rejects remote paths carrying extra segments beyond `owner/repo`.

## Implementation decisions

- **Reused `gitremote.ParseURL` instead of extending the local parser.** That package is the existing single source of truth for the `entire://` scheme (forge prefix → canonical host) and is already well tested. Delegating removed ~46 lines of duplicated URL parsing and fixed the two `dispatch` callers for free, rather than teaching a second parser about mirrors.
- **Kept `ParseGitHubRemote` as a thin wrapper** rather than inlining it into its three call sites: it encodes the GitHub-only policy those callers depend on. Non-GitHub remotes (e.g. gitlab) are still rejected with the same message.
- **Extra-segment rejection lives in the wrapper, not in shared `gitremote`.** A GitHub repo path is always exactly `owner/repo`; a longer path is malformed. The shared `splitOwnerRepo` keeps everything after the owner as the repo, which previously slipped through as a bogus `repo="repo/extra"` filter sent to the search service. Failing fast in the search wrapper is local and avoids changing behavior for every other `gitremote` consumer. The error redacts the URL via `gitremote.RedactURL`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of remote parsing with added validation; behavior for standard GitHub URLs is preserved and covered by existing tests.
> 
> **Overview**
> **`entire search`** (and **dispatch** paths that resolve `origin` via the same helper) no longer fail when `origin` is an Entire git mirror instead of a direct `github.com` URL.
> 
> `ParseGitHubRemote` drops its inline URL parsing and delegates to **`gitremote.ParseURL`**, then still requires the remote to resolve to GitHub via **`CanonicalHost()`** (so `entire://…/gh/owner/repo` works). It also **rejects** paths with extra segments beyond `owner/repo`, with a redacted URL in the error—avoiding bogus `owner/repo/extra` filters sent to search.
> 
> Tests cover Entire mirror success, extra-segment rejection, and whitespace-only empty input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42175e99af319a8aee52e90dec661a3472ef1ad4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->