### PR TITLE
feat(trail): add 'entire trail delete' subcommand

### DIFF
--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -119,3 +119,10 @@ type TrailUpdateRequest struct {
 type TrailUpdateResponse struct {
 	Trail TrailResource `json:"trail"`
 }
+
+// TrailDeleteResponse is the response from DELETE /api/v1/trails/:host/:owner/:repo/:number.
+// OK is the server's explicit success signal; a destructive delete should not be
+// reported as done unless it is true.
+type TrailDeleteResponse struct {
+	OK bool `json:"ok"`
+}

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1071,6 +1071,11 @@ func confirmTrailDeletion(ctx context.Context, w io.Writer, number int, title st
 	if !canPrompt {
 		return false, fmt.Errorf("refusing to delete trail #%d without confirmation; pass --force", number)
 	}
+	// huh opens the TTY during form startup regardless of context state, so
+	// guard explicitly to honor an already-cancelled command context.
+	if ctx.Err() != nil {
+		return false, nil //nolint:nilerr // cancelled context is a clean skip, not an error
+	}
 	prompt := fmt.Sprintf("Delete trail #%d?", number)
 	if title != "" {
 		prompt = fmt.Sprintf("Delete trail #%d (%s)?", number, title)
@@ -1080,7 +1085,12 @@ func confirmTrailDeletion(ctx context.Context, w io.Writer, number int, title st
 		huh.NewGroup(huh.NewConfirm().Title(prompt).Value(&confirmed)),
 	)
 	if err := form.RunWithContext(ctx); err != nil {
-		return false, handleFormCancellation(w, "Trail deletion", err)
+		// A user abort (Esc) or context cancel (Ctrl+C) is a clean cancel, not
+		// an error — mirror confirmDoctorFix / uiform.PromptYN.
+		if errors.Is(err, huh.ErrUserAborted) || errors.Is(err, context.Canceled) {
+			return false, nil
+		}
+		return false, fmt.Errorf("trail deletion prompt: %w", err)
 	}
 	if !confirmed {
 		fmt.Fprintln(w, "Trail deletion cancelled.")

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1019,7 +1019,7 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 			title = found.Title
 		}
 
-		proceed, err := confirmTrailDeletion(w, number, title, force, interactive.CanPromptInteractively())
+		proceed, err := confirmTrailDeletion(ctx, w, number, title, force, interactive.CanPromptInteractively())
 		if err != nil {
 			return err
 		}
@@ -1058,7 +1058,7 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 // when none is available it refuses (returns an error) rather than deleting
 // unprompted; when one is, it shows a confirmation form. canPrompt is passed in
 // (rather than queried) so the decision is unit-testable without a TTY.
-func confirmTrailDeletion(w io.Writer, number int, title string, force, canPrompt bool) (bool, error) {
+func confirmTrailDeletion(ctx context.Context, w io.Writer, number int, title string, force, canPrompt bool) (bool, error) {
 	if force {
 		return true, nil
 	}
@@ -1073,7 +1073,7 @@ func confirmTrailDeletion(w io.Writer, number int, title string, force, canPromp
 	form := NewAccessibleForm(
 		huh.NewGroup(huh.NewConfirm().Title(prompt).Value(&confirmed)),
 	)
-	if err := form.Run(); err != nil {
+	if err := form.RunWithContext(ctx); err != nil {
 		return false, handleFormCancellation(w, "Trail deletion", err)
 	}
 	if !confirmed {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trail"
 
@@ -62,6 +63,7 @@ func newTrailCmd() *cobra.Command {
 	cmd.AddCommand(newTrailListCmd())
 	cmd.AddCommand(newTrailCreateCmd())
 	cmd.AddCommand(newTrailUpdateCmd())
+	cmd.AddCommand(newTrailDeleteCmd())
 	cmd.AddCommand(newTrailFindingCmd())
 	cmd.AddCommand(newTrailWatchCmd())
 
@@ -860,7 +862,7 @@ func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, i
 		if found.Number <= 0 {
 			return fmt.Errorf("trail for branch %q has no number yet; cannot update", branch)
 		}
-		resp, err := client.Patch(ctx, trailsBasePath(forge, owner, repoName)+"/"+strconv.Itoa(found.Number), updateReq)
+		resp, err := client.Patch(ctx, trailNumberPath(forge, owner, repoName, found.Number), updateReq)
 		if err != nil {
 			return fmt.Errorf("failed to update trail: %w", err)
 		}
@@ -934,6 +936,151 @@ func buildTrailUpdateRequest(current *api.TrailResource, inputs trailUpdateInput
 	}
 
 	return req
+}
+
+// parseTrailNumberArg parses an optional positional trail-number argument.
+// It returns 0 when no argument is supplied; a supplied value must be a
+// positive integer (the server keys single-trail endpoints by number).
+func parseTrailNumberArg(args []string) (int, error) {
+	if len(args) == 0 {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(args[0])
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid trail number %q", args[0])
+	}
+	return n, nil
+}
+
+func newTrailDeleteCmd() *cobra.Command {
+	var branch string
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete [<number>]",
+		Short: "Delete a trail",
+		Long: `Delete a trail by number, or the trail for a branch.
+
+If <number> is omitted, the trail for --branch (or the current branch) is used.
+Deletion is permanent; you are prompted to confirm unless --force is passed.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			number, err := parseTrailNumberArg(args)
+			if err != nil {
+				return err
+			}
+			if number > 0 && cmd.Flags().Changed("branch") {
+				return errors.New("cannot combine a trail <number> with --branch")
+			}
+			return runTrailDelete(cmd, number, branch, force)
+		},
+	}
+
+	cmd.Flags().StringVar(&branch, "branch", "", "Branch whose trail to delete (defaults to current)")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) error {
+	ctx := cmd.Context()
+	w := cmd.OutOrStdout()
+
+	return runAuthenticatedDataAPI(ctx, cmd.ErrOrStderr(), trailInsecureHTTP(cmd), func(ctx context.Context, client *api.Client) error {
+		forge, owner, repo, err := resolveTrailRemote(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Resolve the target trail. An explicit number is authoritative (a
+		// lookup is best-effort, only to label the confirmation); otherwise the
+		// branch's trail supplies the number.
+		title := ""
+		if number == 0 {
+			if branch == "" {
+				branch, err = GetCurrentBranch(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to determine current branch: %w", err)
+				}
+			}
+			found, ferr := findTrailByBranch(ctx, client, forge, owner, repo, branch)
+			if ferr != nil {
+				return ferr
+			}
+			if found == nil {
+				return fmt.Errorf("no trail found for branch %q", branch)
+			}
+			if found.Number <= 0 {
+				return fmt.Errorf("trail for branch %q has no number yet; cannot delete", branch)
+			}
+			number = found.Number
+			title = found.Title
+		} else if found, ferr := findTrailByNumber(ctx, client, forge, owner, repo, number); ferr == nil && found != nil {
+			title = found.Title
+		}
+
+		proceed, err := confirmTrailDeletion(w, number, title, force, interactive.CanPromptInteractively())
+		if err != nil {
+			return err
+		}
+		if !proceed {
+			return nil
+		}
+
+		resp, err := client.Delete(ctx, trailNumberPath(forge, owner, repo, number))
+		if err != nil {
+			return fmt.Errorf("failed to delete trail: %w", err)
+		}
+		defer resp.Body.Close()
+		if err := checkTrailResponse(resp); err != nil {
+			return err
+		}
+
+		// Verify the server's success signal. CheckResponse accepts any 2xx and
+		// the body is otherwise never read, so a destructive delete could report
+		// success on an unexpected/incomplete 2xx; decoding guards that (and
+		// drains the body for connection reuse).
+		var delResp api.TrailDeleteResponse
+		if err := api.DecodeJSON(resp, &delResp); err != nil {
+			return fmt.Errorf("failed to decode delete response: %w", err)
+		}
+		if !delResp.OK {
+			return fmt.Errorf("trail API did not confirm deletion of trail #%d", number)
+		}
+
+		fmt.Fprintf(w, "Deleted trail #%d\n", number)
+		return nil
+	})
+}
+
+// confirmTrailDeletion decides whether a trail delete should proceed. With
+// force it proceeds silently. Otherwise it requires an interactive terminal:
+// when none is available it refuses (returns an error) rather than deleting
+// unprompted; when one is, it shows a confirmation form. canPrompt is passed in
+// (rather than queried) so the decision is unit-testable without a TTY.
+func confirmTrailDeletion(w io.Writer, number int, title string, force, canPrompt bool) (bool, error) {
+	if force {
+		return true, nil
+	}
+	if !canPrompt {
+		return false, fmt.Errorf("refusing to delete trail #%d without confirmation; pass --force", number)
+	}
+	prompt := fmt.Sprintf("Delete trail #%d?", number)
+	if title != "" {
+		prompt = fmt.Sprintf("Delete trail #%d (%s)?", number, title)
+	}
+	confirmed := false
+	form := NewAccessibleForm(
+		huh.NewGroup(huh.NewConfirm().Title(prompt).Value(&confirmed)),
+	)
+	if err := form.Run(); err != nil {
+		return false, handleFormCancellation(w, "Trail deletion", err)
+	}
+	if !confirmed {
+		fmt.Fprintln(w, "Trail deletion cancelled.")
+		return false, nil
+	}
+	return true, nil
 }
 
 // defaultBaseBranch is the fallback base branch name when it cannot be determined.
@@ -1117,6 +1264,13 @@ func trailListPageSignature(trails []api.TrailResource) string {
 // (e.g., "/api/v1/trails/gh/org/repo").
 func trailsBasePath(forge, owner, repo string) string {
 	return fmt.Sprintf("/api/v1/trails/%s/%s/%s", forge, owner, repo)
+}
+
+// trailNumberPath returns the single-trail API path keyed by integer trail
+// number (e.g. "/api/v1/trails/gh/acme/repo/575"). The server validates an
+// integer here and rejects the trail UUID, so callers must pass Number, not ID.
+func trailNumberPath(forge, owner, repo string, number int) string {
+	return trailsBasePath(forge, owner, repo) + "/" + strconv.Itoa(number)
 }
 
 // resolveTrailRemote resolves the origin remote and ensures the forge is

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -947,7 +947,7 @@ func parseTrailNumberArg(args []string) (int, error) {
 	}
 	n, err := strconv.Atoi(args[0])
 	if err != nil || n <= 0 {
-		return 0, fmt.Errorf("invalid trail number %q", args[0])
+		return 0, fmt.Errorf("invalid trail number %q: expected a positive integer (see 'entire trail list')", args[0])
 	}
 	return n, nil
 }
@@ -1027,30 +1027,36 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 			return nil
 		}
 
-		resp, err := client.Delete(ctx, trailNumberPath(forge, owner, repo, number))
-		if err != nil {
-			return fmt.Errorf("failed to delete trail: %w", err)
-		}
-		defer resp.Body.Close()
-		if err := checkTrailResponse(resp); err != nil {
+		if err := deleteTrailByNumber(ctx, client, forge, owner, repo, number); err != nil {
 			return err
-		}
-
-		// Verify the server's success signal. CheckResponse accepts any 2xx and
-		// the body is otherwise never read, so a destructive delete could report
-		// success on an unexpected/incomplete 2xx; decoding guards that (and
-		// drains the body for connection reuse).
-		var delResp api.TrailDeleteResponse
-		if err := api.DecodeJSON(resp, &delResp); err != nil {
-			return fmt.Errorf("failed to decode delete response: %w", err)
-		}
-		if !delResp.OK {
-			return fmt.Errorf("trail API did not confirm deletion of trail #%d", number)
 		}
 
 		fmt.Fprintf(w, "Deleted trail #%d\n", number)
 		return nil
 	})
+}
+
+// deleteTrailByNumber deletes the trail with the given integer number and
+// verifies the server's {ok:true} signal. CheckResponse accepts any 2xx and the
+// body is otherwise unread, so a destructive delete must confirm ok before
+// reporting success (decoding also drains the body for connection reuse).
+func deleteTrailByNumber(ctx context.Context, client *api.Client, forge, owner, repo string, number int) error {
+	resp, err := client.Delete(ctx, trailNumberPath(forge, owner, repo, number))
+	if err != nil {
+		return fmt.Errorf("failed to delete trail: %w", err)
+	}
+	defer resp.Body.Close()
+	if err := checkTrailResponse(resp); err != nil {
+		return err
+	}
+	var delResp api.TrailDeleteResponse
+	if err := api.DecodeJSON(resp, &delResp); err != nil {
+		return fmt.Errorf("failed to decode delete response: %w", err)
+	}
+	if !delResp.OK {
+		return fmt.Errorf("trail API did not confirm deletion of trail #%d", number)
+	}
+	return nil
 }
 
 // confirmTrailDeletion decides whether a trail delete should proceed. With

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -204,14 +204,14 @@ func TestConfirmTrailDeletion(t *testing.T) {
 
 	// --force proceeds without prompting (no TTY needed).
 	var buf bytes.Buffer
-	proceed, err := confirmTrailDeletion(&buf, 575, "Some title", true, false)
+	proceed, err := confirmTrailDeletion(t.Context(), &buf, 575, "Some title", true, false)
 	if err != nil || !proceed {
 		t.Fatalf("force: got (proceed=%v, err=%v), want (true, nil)", proceed, err)
 	}
 
 	// Non-interactive without --force must refuse, not delete unprompted.
 	buf.Reset()
-	proceed, err = confirmTrailDeletion(&buf, 575, "Some title", false, false)
+	proceed, err = confirmTrailDeletion(t.Context(), &buf, 575, "Some title", false, false)
 	if err == nil {
 		t.Fatalf("non-interactive without --force: expected error, got nil (proceed=%v)", proceed)
 	}

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -221,6 +221,15 @@ func TestConfirmTrailDeletion(t *testing.T) {
 	if !strings.Contains(err.Error(), "--force") {
 		t.Fatalf("error should mention --force, got: %v", err)
 	}
+
+	// An already-cancelled context is a clean cancel: no prompt, no error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	buf.Reset()
+	proceed, err = confirmTrailDeletion(ctx, &buf, 575, "Some title", false, true)
+	if err != nil || proceed {
+		t.Fatalf("cancelled ctx: got (proceed=%v, err=%v), want (false, nil)", proceed, err)
+	}
 }
 
 func TestDeleteTrailByNumber(t *testing.T) {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -154,6 +154,75 @@ func TestTrailsBasePath(t *testing.T) {
 	}
 }
 
+func TestTrailNumberPath(t *testing.T) {
+	t.Parallel()
+	got := trailNumberPath("gh", "acme", "repo", 575)
+	want := "/api/v1/trails/gh/acme/repo/575"
+	if got != want {
+		t.Fatalf("trailNumberPath = %q, want %q", got, want)
+	}
+	// Regression guard: the single-trail endpoint is keyed by the integer trail
+	// number, never the UUID id — the server's parseTrailNumber rejects a UUID
+	// (it starts with a non-[1-9] char), which previously surfaced as a 400.
+	if strings.Contains(got, "-") {
+		t.Fatalf("trailNumberPath must use the integer number, got %q", got)
+	}
+}
+
+func TestParseTrailNumberArg(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		args    []string
+		want    int
+		wantErr bool
+	}{
+		{"no arg", nil, 0, false},
+		{"empty slice", []string{}, 0, false},
+		{"valid number", []string{"575"}, 575, false},
+		{"zero rejected", []string{"0"}, 0, true},
+		{"negative rejected", []string{"-3"}, 0, true},
+		{"non-numeric rejected", []string{"abc"}, 0, true},
+		{"uuid rejected", []string{"019ed3c9-7fd9-72d6-bd29-1130d2b2eec4"}, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseTrailNumberArg(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseTrailNumberArg(%v) err = %v, wantErr %v", tt.args, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("parseTrailNumberArg(%v) = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfirmTrailDeletion(t *testing.T) {
+	t.Parallel()
+
+	// --force proceeds without prompting (no TTY needed).
+	var buf bytes.Buffer
+	proceed, err := confirmTrailDeletion(&buf, 575, "Some title", true, false)
+	if err != nil || !proceed {
+		t.Fatalf("force: got (proceed=%v, err=%v), want (true, nil)", proceed, err)
+	}
+
+	// Non-interactive without --force must refuse, not delete unprompted.
+	buf.Reset()
+	proceed, err = confirmTrailDeletion(&buf, 575, "Some title", false, false)
+	if err == nil {
+		t.Fatalf("non-interactive without --force: expected error, got nil (proceed=%v)", proceed)
+	}
+	if proceed {
+		t.Fatal("non-interactive without --force: must not proceed")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("error should mention --force, got: %v", err)
+	}
+}
+
 // Not parallel: uses t.Chdir() to point ResolveRemoteRepo at a fake repo.
 func TestResolveTrailRemote_RejectsUnsupportedForge(t *testing.T) {
 	repoDir := t.TempDir()

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -223,6 +223,64 @@ func TestConfirmTrailDeletion(t *testing.T) {
 	}
 }
 
+func TestDeleteTrailByNumber(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deletes via the integer number path and accepts ok:true", func(t *testing.T) {
+		t.Parallel()
+		var gotMethod, gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod, gotPath = r.Method, r.URL.Path
+			if err := json.NewEncoder(w).Encode(api.TrailDeleteResponse{OK: true}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+		}))
+		defer srv.Close()
+
+		client := api.NewClientWithBaseURL("tok", srv.URL)
+		if err := deleteTrailByNumber(t.Context(), client, "gh", "acme", "repo", 575); err != nil {
+			t.Fatalf("deleteTrailByNumber: %v", err)
+		}
+		if gotMethod != http.MethodDelete {
+			t.Fatalf("method = %q, want DELETE", gotMethod)
+		}
+		if want := "/api/v1/trails/gh/acme/repo/575"; gotPath != want {
+			t.Fatalf("path = %q, want %q (integer number, not UUID)", gotPath, want)
+		}
+	})
+
+	t.Run("treats a 2xx without ok:true as failure", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if err := json.NewEncoder(w).Encode(api.TrailDeleteResponse{OK: false}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+		}))
+		defer srv.Close()
+
+		client := api.NewClientWithBaseURL("tok", srv.URL)
+		if err := deleteTrailByNumber(t.Context(), client, "gh", "acme", "repo", 575); err == nil {
+			t.Fatal("expected error for 2xx without ok:true, got nil")
+		}
+	})
+
+	t.Run("surfaces a non-2xx status", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Trail not found"}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+		}))
+		defer srv.Close()
+
+		client := api.NewClientWithBaseURL("tok", srv.URL)
+		if err := deleteTrailByNumber(t.Context(), client, "gh", "acme", "repo", 999); err == nil {
+			t.Fatal("expected error for 404, got nil")
+		}
+	})
+}
+
 // Not parallel: uses t.Chdir() to point ResolveRemoteRepo at a fake repo.
 func TestResolveTrailRemote_RejectsUnsupportedForge(t *testing.T) {
 	repoDir := t.TempDir()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/575
<!-- entire-trail-link-end -->

## What

Adds `entire trail delete [<number>]` (or `--branch` / current branch). Deletion prompts for confirmation unless `--force`, and **refuses to delete unprompted** in a non-interactive context. Wired to the existing API `DELETE /api/v1/trails/:host/:owner/:repo/:number` route.

## Why

There was no CLI way to remove a mistaken trail (e.g. a junk trail left by the `create` branch-resolution behaviour); cleanup required the web UI. The API already exposed a DELETE route — this surfaces it.

## Notes

- Introduces `trailNumberPath()` so the single-trail endpoint is always keyed by the **integer trail number** (never the UUID id, which the server's `parseTrailNumber` rejects — the root cause of the earlier `update` 400s). `update` now uses the same helper, with a regression test guarding against UUID-shaped paths.
- Decodes and verifies the server's `{ok: true}` so an unexpected/incomplete 2xx can't report a delete that didn't happen (also drains the body).
- Rejects combining an explicit `<number>` with `--branch`.

## Testing

- Unit tests: `parseTrailNumberArg`, `trailNumberPath`, and the `confirmTrailDeletion` gate (force proceeds; non-interactive-without-`--force` refuses).
- `gofmt` clean; `golangci-lint` 0 issues.
- Verified live against the backend: the new command deleted a real trail end-to-end.
- Reviewed via pr-review-toolkit (code quality / tests / silent-failure); findings addressed.

Tracked by Entire trail #575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Permanent destructive deletes against the live API; mitigated by confirmation, non-interactive refusal, and explicit `ok` checks.
> 
> **Overview**
> Adds **`entire trail delete [<number>]`** so trails can be removed from the CLI via the existing DELETE API. Targets a trail by number, or by **`--branch`** / the current branch when the number is omitted; explicit number and **`--branch`** cannot be combined.
> 
> Deletion is **interactive by default** (confirm prompt with optional title) and **refuses to run without a TTY** unless **`--force`**. The client decodes **`{ok: true}`** before reporting success so a bare 2xx cannot claim a delete that did not happen.
> 
> Introduces **`trailNumberPath()`** for single-trail URLs keyed by the **integer trail number** (not UUID). **`trail update`** now uses the same helper, addressing server 400s from UUID-shaped paths.
> 
> Unit tests cover path building, argument parsing, confirmation gates, and delete HTTP behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8bce4b4a9071045c92ae659469a9501e64f8303. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->