### PR TITLE
fix(trail): default create --branch to the checked-out branch

### DIFF
--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -110,7 +110,14 @@ func IsOnDefaultBranch(ctx context.Context) (bool, string, error) {
 		return false, "", fmt.Errorf("failed to open git repository: %w", err)
 	}
 	defer repo.Close()
+	return isOnDefaultBranchRepo(repo)
+}
 
+// isOnDefaultBranchRepo reports whether the repo's current branch is its default
+// branch, along with the current branch name (empty on a detached HEAD). It
+// operates on an already-open repository so callers that already hold one need
+// not reopen it.
+func isOnDefaultBranchRepo(repo *git.Repository) (bool, string, error) {
 	// Get current branch
 	head, err := repo.Head()
 	if err != nil {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -585,7 +585,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		}
 	}
 
-	onDefault, currentBranch, _ := IsOnDefaultBranch(ctx) //nolint:errcheck // best-effort detection
+	onDefault, currentBranch, _ := isOnDefaultBranchRepo(repo) //nolint:errcheck // best-effort detection; reuse the already-open repo
 	interactive := !cmd.Flags().Changed("title") && !cmd.Flags().Changed("branch")
 
 	if interactive {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -585,7 +585,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		}
 	}
 
-	onDefault, currentBranch, _ := isOnDefaultBranchRepo(repo) //nolint:errcheck // best-effort detection; reuse the already-open repo
+	_, currentBranch, _ := isOnDefaultBranchRepo(repo) //nolint:errcheck // best-effort; reuse the open repo for the current branch name
 	interactive := !cmd.Flags().Changed("title") && !cmd.Flags().Changed("branch")
 
 	if interactive {
@@ -596,8 +596,8 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 	} else {
 		// Non-interactive: derive missing values from provided flags. With
 		// --branch omitted, use the checked-out branch (a feature branch); only
-		// slug a new branch from the title when starting work on the default branch.
-		branch = resolveCreateBranch(branch, currentBranch, title, onDefault, cmd.Flags().Changed("title"))
+		// slug a new branch from the title when the checked-out branch is the base.
+		branch = resolveCreateBranch(branch, currentBranch, base, title, cmd.Flags().Changed("title"))
 		if title == "" {
 			title = trail.HumanizeBranchName(branch)
 		}
@@ -1315,15 +1315,16 @@ func checkTrailResponse(resp *http.Response) error {
 
 // resolveCreateBranch picks the branch a non-interactive `trail create` targets.
 // An explicit --branch always wins. Otherwise, on a feature branch it uses the
-// checked-out branch; on the default branch it derives a new branch from the
-// title when one was given (starting fresh work), else falls back to current.
-func resolveCreateBranch(branchFlag, currentBranch, title string, onDefaultBranch, titleProvided bool) string {
+// checked-out branch; when the checked-out branch IS the base (the trail's
+// target/default branch) — or HEAD is detached — it derives a new branch from
+// the title when one was given (starting fresh work), else falls back to current.
+// Comparing against the already-resolved base keeps this consistent with how
+// `base` itself was detected (avoids a second, divergent default-branch lookup).
+func resolveCreateBranch(branchFlag, currentBranch, base, title string, titleProvided bool) string {
 	if branchFlag != "" {
 		return branchFlag
 	}
-	// On the default branch — or a detached HEAD, where there is no usable
-	// checked-out branch — start work on a branch derived from the title.
-	if titleProvided && (onDefaultBranch || currentBranch == "") {
+	if titleProvided && (currentBranch == base || currentBranch == "") {
 		return slugifyTitle(title)
 	}
 	return currentBranch

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -585,7 +585,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		}
 	}
 
-	_, currentBranch, _ := IsOnDefaultBranch(ctx) //nolint:errcheck // best-effort detection
+	onDefault, currentBranch, _ := IsOnDefaultBranch(ctx) //nolint:errcheck // best-effort detection
 	interactive := !cmd.Flags().Changed("title") && !cmd.Flags().Changed("branch")
 
 	if interactive {
@@ -594,14 +594,10 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 			return handleFormCancellation(w, "Trail creation", err)
 		}
 	} else {
-		// Non-interactive: derive missing values from provided flags.
-		if branch == "" {
-			if cmd.Flags().Changed("title") {
-				branch = slugifyTitle(title)
-			} else {
-				branch = currentBranch
-			}
-		}
+		// Non-interactive: derive missing values from provided flags. With
+		// --branch omitted, use the checked-out branch (a feature branch); only
+		// slug a new branch from the title when starting work on the default branch.
+		branch = resolveCreateBranch(branch, currentBranch, title, onDefault, cmd.Flags().Changed("title"))
 		if title == "" {
 			title = trail.HumanizeBranchName(branch)
 		}
@@ -1315,6 +1311,22 @@ func checkTrailResponse(resp *http.Response) error {
 		return fmt.Errorf("trail API: %w", err)
 	}
 	return nil
+}
+
+// resolveCreateBranch picks the branch a non-interactive `trail create` targets.
+// An explicit --branch always wins. Otherwise, on a feature branch it uses the
+// checked-out branch; on the default branch it derives a new branch from the
+// title when one was given (starting fresh work), else falls back to current.
+func resolveCreateBranch(branchFlag, currentBranch, title string, onDefaultBranch, titleProvided bool) string {
+	if branchFlag != "" {
+		return branchFlag
+	}
+	// On the default branch — or a detached HEAD, where there is no usable
+	// checked-out branch — start work on a branch derived from the title.
+	if titleProvided && (onDefaultBranch || currentBranch == "") {
+		return slugifyTitle(title)
+	}
+	return currentBranch
 }
 
 // slugifyTitle converts a title string into a branch-friendly slug.

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -169,6 +169,38 @@ func TestTrailNumberPath(t *testing.T) {
 	}
 }
 
+func TestResolveCreateBranch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		branchFlag    string
+		currentBranch string
+		title         string
+		onDefault     bool
+		titleProvided bool
+		want          string
+	}{
+		{"explicit --branch always wins", "feat/x", "main", "My Title", true, true, "feat/x"},
+		{"feature branch uses current, not title slug", "", "alex/authz-read", "Shared authz read client", false, true, "alex/authz-read"},
+		{"default branch slugs the title (start new work)", "", "main", "Add Auth System", true, true, "add-auth-system"},
+		{"feature branch, no title, uses current", "", "alex/authz-read", "", false, false, "alex/authz-read"},
+		{"default branch, no title, falls back to current", "", "main", "", true, false, "main"},
+		{"detached HEAD with title slugs the title", "", "", "Add Auth System", false, true, "add-auth-system"},
+		{"detached HEAD, no title, returns empty (caller errors)", "", "", "", false, false, ""},
+		{"unsluggable title yields empty (caller errors)", "", "main", "!!!", true, true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveCreateBranch(tt.branchFlag, tt.currentBranch, tt.title, tt.onDefault, tt.titleProvided)
+			if got != tt.want {
+				t.Fatalf("resolveCreateBranch(%q, %q, %q, %v, %v) = %q, want %q",
+					tt.branchFlag, tt.currentBranch, tt.title, tt.onDefault, tt.titleProvided, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseTrailNumberArg(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -175,27 +175,28 @@ func TestResolveCreateBranch(t *testing.T) {
 		name          string
 		branchFlag    string
 		currentBranch string
+		base          string
 		title         string
-		onDefault     bool
 		titleProvided bool
 		want          string
 	}{
-		{"explicit --branch always wins", "feat/x", "main", "My Title", true, true, "feat/x"},
-		{"feature branch uses current, not title slug", "", "alex/authz-read", "Shared authz read client", false, true, "alex/authz-read"},
-		{"default branch slugs the title (start new work)", "", "main", "Add Auth System", true, true, "add-auth-system"},
-		{"feature branch, no title, uses current", "", "alex/authz-read", "", false, false, "alex/authz-read"},
-		{"default branch, no title, falls back to current", "", "main", "", true, false, "main"},
-		{"detached HEAD with title slugs the title", "", "", "Add Auth System", false, true, "add-auth-system"},
-		{"detached HEAD, no title, returns empty (caller errors)", "", "", "", false, false, ""},
-		{"unsluggable title yields empty (caller errors)", "", "main", "!!!", true, true, ""},
+		{"explicit --branch always wins", "feat/x", "main", "main", "My Title", true, "feat/x"},
+		{"feature branch uses current, not title slug", "", "alex/authz-read", "main", "Shared authz read client", true, "alex/authz-read"},
+		{"on base (main) slugs the title", "", "main", "main", "Add Auth System", true, "add-auth-system"},
+		{"non-standard default (develop==base) slugs the title", "", "develop", "develop", "Add Auth System", true, "add-auth-system"},
+		{"feature branch, no title, uses current", "", "alex/authz-read", "main", "", false, "alex/authz-read"},
+		{"on base, no title, falls back to current", "", "main", "main", "", false, "main"},
+		{"detached HEAD with title slugs the title", "", "", "main", "Add Auth System", true, "add-auth-system"},
+		{"detached HEAD, no title, returns empty (caller errors)", "", "", "main", "", false, ""},
+		{"unsluggable title yields empty (caller errors)", "", "main", "main", "!!!", true, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := resolveCreateBranch(tt.branchFlag, tt.currentBranch, tt.title, tt.onDefault, tt.titleProvided)
+			got := resolveCreateBranch(tt.branchFlag, tt.currentBranch, tt.base, tt.title, tt.titleProvided)
 			if got != tt.want {
-				t.Fatalf("resolveCreateBranch(%q, %q, %q, %v, %v) = %q, want %q",
-					tt.branchFlag, tt.currentBranch, tt.title, tt.onDefault, tt.titleProvided, got, tt.want)
+				t.Fatalf("resolveCreateBranch(%q, %q, %q, %q, %v) = %q, want %q",
+					tt.branchFlag, tt.currentBranch, tt.base, tt.title, tt.titleProvided, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/598
<!-- entire-trail-link-end -->

## What

Fixes `entire trail create` branch resolution (Bug 1). With `--branch` omitted, `create` previously slugified the `--title` into a new branch and pushed it, **ignoring the checked-out branch** — contradicting its own `--help` ("defaults to current branch").

## Behavior now

- **On a feature branch** → the trail targets the checked-out branch (no surprise new branch / push).
- **On the default branch** (or a detached HEAD, where there's no usable current branch) **with a title** → derive a new branch from the title (start-new-work ergonomics).
- An explicit `--branch` always wins.

Uses the `onDefault` signal from `IsOnDefaultBranch` (already computed in `runTrailCreate` but previously discarded). The decision is extracted into a pure `resolveCreateBranch` helper.

## Testing

- `TestResolveCreateBranch` table test covers the full matrix incl. the **Bug-1 regression guard** (feature branch + title → current branch, not a slug), detached HEAD, and the unsluggable-title boundary.
- `gofmt` clean; `golangci-lint` 0 issues.
- Reviewed via pr-review-toolkit (code + tests); the detached-HEAD regression it surfaced is fixed and covered.

Tracked by Entire trail #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only branch-selection fix with a pure helper and table tests; no auth, API contract, or server changes.
> 
> **Overview**
> **Fixes non-interactive `entire trail create` when `--branch` is omitted.** It no longer always slugifies `--title` into a new branch (which could push a surprise branch while on a feature branch); behavior now matches the help text that the branch defaults to the current branch.
> 
> **New `resolveCreateBranch` logic:** explicit `--branch` wins; on a feature branch (current ≠ resolved `base`) the checked-out branch is used even if `--title` is set; on the default/base branch or detached HEAD with a title, the title is slugged for “start new work”; otherwise it falls back to the current branch.
> 
> **Refactor:** `isOnDefaultBranchRepo` extracts default-branch detection onto an already-open `*git.Repository`, and `runTrailCreate` uses it instead of reopening the repo via `IsOnDefaultBranch`. **`TestResolveCreateBranch`** covers the matrix including the feature-branch + title regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9be5fe0276874e70669ef603e6522d70f658a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->