### PR TITLE
fix(coreapi): handle cross-jurisdiction routing for control-plane commands

### DIFF
--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -72,7 +72,7 @@ func New() (*Client, error) {
 		return nil, fmt.Errorf("resolve control-plane target: %w", err)
 	}
 	src := &providerSource{provide: target.TokenSource}
-	client, err := NewClient(strings.TrimRight(target.CoreURL, "/")+apiBasePath, src)
+	client, err := NewClient(strings.TrimRight(target.CoreURL, "/")+apiBasePath, src, WithClient(newCrossJurisHTTPClient()))
 	if err != nil {
 		return nil, fmt.Errorf("build Entire API client: %w", err)
 	}
@@ -86,7 +86,7 @@ func New() (*Client, error) {
 // that context's session token.
 func NewWithBearer(coreBaseURL, token string) (*Client, error) {
 	base := strings.TrimRight(coreBaseURL, "/")
-	client, err := NewClient(base+apiBasePath, staticBearer{token: token})
+	client, err := NewClient(base+apiBasePath, staticBearer{token: token}, WithClient(newCrossJurisHTTPClient()))
 	if err != nil {
 		return nil, fmt.Errorf("build Entire API client: %w", err)
 	}

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -28,6 +28,10 @@ const apiBasePath = "/api/v1"
 // with the `entire login` hint. The Core API is served at <host>/api/v1. The
 // bearer is resolved lazily per request, re-minting silently from the stored
 // refresh token.
+//
+// For a resource whose home jurisdiction is another region, the client's
+// transport follows the home core's 421 redirect and exchanges the login
+// token for one that core accepts (see newCrossJurisHTTPClient).
 func New() (*Client, error) {
 	// ENTIRE_TOKEN bypass: CI / workload-identity runners inject a short-
 	// lived login or sa-session JWT and want control-plane commands to use
@@ -80,10 +84,12 @@ func New() (*Client, error) {
 }
 
 // NewWithBearer returns a *Client targeting an explicit core origin with a
-// fixed bearer token — no per-request resolution or STS exchange. Used when a
-// command must hit a specific login server with a token already in hand:
-// e.g. `entire auth status` querying /me on the active context's core with
-// that context's session token.
+// fixed bearer token: the token is sent verbatim, not re-resolved or
+// re-minted per request. Used when a command must hit a specific login
+// server with a token already in hand: e.g. `entire auth status` querying
+// /me on the active context's core with that context's session token. A
+// cross-jurisdiction call still follows the home core's 421 and exchanges
+// this token for that core's audience (see newCrossJurisHTTPClient).
 func NewWithBearer(coreBaseURL, token string) (*Client, error) {
 	base := strings.TrimRight(coreBaseURL, "/")
 	client, err := NewClient(base+apiBasePath, staticBearer{token: token}, WithClient(newCrossJurisHTTPClient()))

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -102,6 +102,11 @@ type cachedExchangedToken struct {
 // see the same latency as a cold cache.
 const cachedTokenTTL = 4 * time.Minute
 
+// tokenExpiryBuffer is subtracted from a server-advertised expires_in so a
+// cached token is retired before it actually expires — same rationale as
+// cachedTokenTTL's margin below the 5m server-side lifetime.
+const tokenExpiryBuffer = 1 * time.Minute
+
 // crossJurisErrorBody is the wire shape entire-core's auth middleware
 // emits for the machine-readable 401.
 type crossJurisErrorBody struct {
@@ -272,12 +277,12 @@ func (t *crossJurisRoundTripper) send(req *http.Request, body []byte, originalAu
 		if !found || subjectToken == "" {
 			return resp, nil
 		}
-		exchanged, err := t.exchangeSubjectToken(req.Context(), hint, subjectToken)
+		exchanged, expiresIn, err := t.exchangeSubjectToken(req.Context(), hint, subjectToken)
 		if err != nil {
 			debugf("exchange failed: %v", err)
 			return resp, nil
 		}
-		t.storeToken(origin, exchanged)
+		t.storeToken(origin, exchanged, effectiveTokenTTL(expiresIn))
 		budget.triedExchange[origin] = true
 		_ = resp.Body.Close()
 		req.Header.Set("Authorization", "Bearer "+exchanged)
@@ -502,7 +507,7 @@ func drainAndRestoreBody(resp *http.Response, maxBytes int64) ([]byte, error) {
 // exchange and returns the issued access_token. Delegates the wire-
 // level details (form encode, lifting client_id into Basic auth,
 // response decode) to httputil.PostOAuthToken.
-func (t *crossJurisRoundTripper) exchangeSubjectToken(ctx context.Context, hint crossJurisErrorBody, subjectToken string) (string, error) {
+func (t *crossJurisRoundTripper) exchangeSubjectToken(ctx context.Context, hint crossJurisErrorBody, subjectToken string) (string, int, error) {
 	form := url.Values{}
 	form.Set("grant_type", httputil.GrantTypeTokenExchange)
 	form.Set("subject_token", subjectToken)
@@ -518,16 +523,17 @@ func (t *crossJurisRoundTripper) exchangeSubjectToken(ctx context.Context, hint 
 	form.Set("client_id", "entire-cli")
 	// PostOAuthToken expects a base core URL and appends /oauth/token
 	// itself; hint.TokenExchangeURL is already the full path (and
-	// validateExchangeURL has gated the origin), so strip the suffix.
+	// validateExchangeURL has gated both origin and path == oauthTokenPath),
+	// so stripping the suffix yields exactly the origin.
 	coreURL := strings.TrimSuffix(hint.TokenExchangeURL, oauthTokenPath)
 	// Exchange goes through the base transport so we don't re-enter our
 	// own retry logic — a non-200 here is terminal.
 	client := &http.Client{Transport: t.base}
-	token, _, err := httputil.PostOAuthToken(ctx, client, coreURL, form)
+	token, expiresIn, err := httputil.PostOAuthToken(ctx, client, coreURL, form)
 	if err != nil {
-		return "", fmt.Errorf("exchange: %w", err)
+		return "", 0, fmt.Errorf("exchange: %w", err)
 	}
-	return token, nil
+	return token, expiresIn, nil
 }
 
 func (t *crossJurisRoundTripper) lookupToken(origin string) (string, bool) {
@@ -543,14 +549,32 @@ func (t *crossJurisRoundTripper) lookupToken(origin string) (string, bool) {
 	return cached.token, true
 }
 
-func (t *crossJurisRoundTripper) storeToken(origin, token string) {
-	if origin == "" || token == "" {
+func (t *crossJurisRoundTripper) storeToken(origin, token string, ttl time.Duration) {
+	if origin == "" || token == "" || ttl <= 0 {
 		return
 	}
 	t.tokens.Store(origin, cachedExchangedToken{
 		token: token,
-		exp:   time.Now().Add(cachedTokenTTL),
+		exp:   time.Now().Add(ttl),
 	})
+}
+
+// effectiveTokenTTL picks how long an exchanged token may live in the
+// per-origin cache. It honors the exchange response's expires_in (less a
+// safety buffer so we never serve a token within seconds of expiry),
+// capped at cachedTokenTTL. A non-positive expires_in means the server
+// advertised no lifetime, so we fall back to the conservative cap; a
+// lifetime shorter than the buffer yields <=0, which storeToken declines
+// to cache (the triggering request still succeeds via the live retry).
+func effectiveTokenTTL(expiresIn int) time.Duration {
+	if expiresIn <= 0 {
+		return cachedTokenTTL
+	}
+	ttl := time.Duration(expiresIn)*time.Second - tokenExpiryBuffer
+	if ttl > cachedTokenTTL {
+		return cachedTokenTTL
+	}
+	return ttl
 }
 
 // bufferBody reads req.Body once into memory and sets GetBody so each

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -64,8 +64,9 @@ func debugf(format string, args ...any) {
 // recursion is a server bug we want to surface, not paper over.
 //
 // Per-origin token cache lives on the transport instance, scoped to one
-// CLI invocation. TTL matches the foreign-session token's lifetime (5
-// minutes).
+// CLI invocation. A cached token's TTL honors the exchange response's
+// expires_in (minus a safety buffer), capped at cachedTokenTTL so we
+// never present a token near expiry.
 //
 // # Trust anchors for server-supplied URLs
 //

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -482,12 +482,12 @@ func readCrossJurisHint(resp *http.Response) (crossJurisErrorBody, bool, error) 
 // readable. Cap is conservative — control-plane error envelopes are
 // always small.
 func drainAndRestoreBody(resp *http.Response, maxBytes int64) ([]byte, error) {
-	body, err := io.ReadAll(http.MaxBytesReader(nil, resp.Body, maxBytes))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes))
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body)) // restore even on error
 	if err != nil {
 		return nil, fmt.Errorf("drain response body: %w", err)
 	}
-	_ = resp.Body.Close()
-	resp.Body = io.NopCloser(bytes.NewReader(body))
 	return body, nil
 }
 

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -102,15 +102,15 @@ type cachedExchangedToken struct {
 // see the same latency as a cold cache.
 const cachedTokenTTL = 4 * time.Minute
 
-// crossJurisErrorBody is the wire shape the server emits for the
-// machine-readable 401. Mirrored from core/api/middleware.go.
+// crossJurisErrorBody is the wire shape entire-core's auth middleware
+// emits for the machine-readable 401.
 type crossJurisErrorBody struct {
 	Error            string `json:"error"`
 	TokenExchangeURL string `json:"token_exchange_url"`
 	Audience         string `json:"audience"`
 }
 
-// mirror421Body mirrors core/coreapi/mirrors.go's 421 envelope.
+// mirror421Body is entire-core's 421 cross-jurisdiction redirect envelope.
 type mirror421Body struct {
 	Error       string `json:"error"`
 	HomeCoreURL string `json:"home_core_url"`

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -1,0 +1,579 @@
+package coreapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/entireio/cli/internal/entireclient/httpclient"
+	"github.com/entireio/cli/internal/entireclient/httputil"
+)
+
+// newCrossJurisHTTPClient builds the *http.Client the control-plane
+// (coreapi) client dials with. Its transport follows cross-jurisdiction
+// 421 redirects and runs the RFC 8693 token exchange a foreign core
+// requires, so a home-region login JWT can operate on a resource whose
+// home jurisdiction is another region. Inert for same-jurisdiction calls.
+func newCrossJurisHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: newCrossJurisRoundTripper(httpclient.NewTransport(false)),
+	}
+}
+
+// debugf writes ENTIRE_DEBUG-gated trace lines for the transport. The
+// recovery hops (421 follow, token exchange) are otherwise invisible, so
+// a misconfigured federation / off-origin reject is hard to diagnose
+// without this.
+func debugf(format string, args ...any) {
+	if os.Getenv("ENTIRE_DEBUG") == "" {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[entire] cross-juris transport: "+format+"\n", args...)
+}
+
+// crossJurisRoundTripper handles two recoverable failure modes uniformly,
+// for every control-plane HTTP call that wraps its transport:
+//
+//   - 421 Misdirected Request: a control-plane core responded that the
+//     target resource lives in another jurisdiction and returned the
+//     home core's base URL. The transport rewrites the request URL and
+//     retries once.
+//   - 401 needing a cross-juris token exchange. Two shapes:
+//     (a) the structured hint `{"error":"cross_juris_token_required",
+//     "token_exchange_url":"...","audience":"..."}` — emitted by a core
+//     that can verify the JWT's signature but sees a sibling audience; and
+//     (b) a BARE 401 received right after following a 421 — the home core
+//     can't verify a foreign-region login JWT's signature (its API
+//     verifier trusts only local JWKS), so it never reaches the audience
+//     check and emits no hint. In both cases the transport POSTs an RFC
+//     8693 exchange at the home core's /oauth/token (subject_token = the
+//     original Authorization Bearer), caches the resulting access token
+//     keyed by origin, swaps the Authorization header, and retries once.
+//
+// Each original request gets at most one redirect and one exchange per
+// origin — a 421 followed by an exchange-retry is allowed; further
+// recursion is a server bug we want to surface, not paper over.
+//
+// Per-origin token cache lives on the transport instance, scoped to one
+// CLI invocation. TTL matches the foreign-session token's lifetime (5
+// minutes).
+//
+// # Trust anchors for server-supplied URLs
+//
+// Both recovery paths take a URL from the server response and re-target
+// the user's long-lived login JWT at it. A misconfigured or malicious
+// core could otherwise exfiltrate the JWT by pointing those URLs at an
+// attacker-controlled host. The transport applies:
+//
+//   - All server-supplied URLs must be HTTPS, except loopback hosts on
+//     http (so httptest fixtures keep working).
+//   - 401 `token_exchange_url`: must be SAME-ORIGIN with the response
+//     that emitted the 401. (The bare-401-after-421 exchange synthesizes
+//     the exchange URL from the redirect origin itself, which was already
+//     vetted against the responding core's federation manifest.)
+//   - 421 `home_core_url`: by definition off-origin, so same-origin is
+//     not applicable. Instead, the transport lazy-fetches
+//     `/.well-known/entire-federation` from the response origin and
+//     validates the redirect target appears in the returned peer list.
+type crossJurisRoundTripper struct {
+	base       http.RoundTripper
+	tokens     sync.Map // origin (scheme://host) → cachedExchangedToken
+	federation sync.Map // origin (scheme://host) → cachedFederation
+}
+
+type cachedExchangedToken struct {
+	token string
+	exp   time.Time
+}
+
+// cachedTokenTTL bounds how long an exchanged token stays in the
+// process-local cache. Slightly shorter than the server-side foreign-
+// session TTL (5m) so we never present a token within seconds of its
+// expiry — the server would 401, we'd re-exchange, and the user would
+// see the same latency as a cold cache.
+const cachedTokenTTL = 4 * time.Minute
+
+// crossJurisErrorBody is the wire shape the server emits for the
+// machine-readable 401. Mirrored from core/api/middleware.go.
+type crossJurisErrorBody struct {
+	Error            string `json:"error"`
+	TokenExchangeURL string `json:"token_exchange_url"`
+	Audience         string `json:"audience"`
+}
+
+// mirror421Body mirrors core/coreapi/mirrors.go's 421 envelope.
+type mirror421Body struct {
+	Error       string `json:"error"`
+	HomeCoreURL string `json:"home_core_url"`
+}
+
+// federationBody mirrors the GET /.well-known/entire-federation response
+// shape. Empty / missing peer_auth_hosts means no peers are trusted for
+// 421 follow from this origin.
+type federationBody struct {
+	PeerAuthHosts []string `json:"peer_auth_hosts"`
+}
+
+// cachedFederation records the result of one lazy federation-list fetch
+// so the next 421 from the same origin doesn't pay the round trip
+// again. The negative case (fetch failed / endpoint absent) is cached
+// the same way: an attacker can't bypass the check by 421-spamming and
+// hoping for a stale negative, because we still reject when hosts is nil.
+type cachedFederation struct {
+	hosts map[string]struct{}
+}
+
+// federationLookupTimeout caps the lazy federation-list fetch on the
+// critical path of a 421 follow. Kept tight: the endpoint is local to
+// the responding core and the response is small. A slow fetch shouldn't
+// stall a user-facing redirect.
+const federationLookupTimeout = 3 * time.Second
+
+// federationWellKnownPath is the URL path for the federation-trust
+// manifest. Served public, unauthenticated (the list itself is not a
+// secret — it names siblings any user can already enumerate via login).
+const federationWellKnownPath = "/.well-known/entire-federation"
+
+func newCrossJurisRoundTripper(base http.RoundTripper) *crossJurisRoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &crossJurisRoundTripper{base: base}
+}
+
+// RoundTrip implements http.RoundTripper. On the first attempt it swaps
+// the Authorization header to a cached exchanged token when one exists
+// for the request origin; otherwise the caller-supplied header is used.
+//
+// The original caller-supplied bearer is snapshotted at entry and used
+// as the subject_token on every exchange — re-using a previously-
+// exchanged token would already carry foreign_iss and the validator
+// rejects chained cross-juris exchanges.
+func (t *crossJurisRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := bufferBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("cross-juris transport: buffer body: %w", err)
+	}
+	originalAuth := req.Header.Get("Authorization")
+	return t.send(req, body, originalAuth, retryBudget{redirects: 1, triedExchange: map[string]bool{}})
+}
+
+// retryBudget caps the recursion. Redirects share one budget across the
+// whole call; exchanges are bounded per-origin via triedExchange so a
+// 421-then-401 chain doesn't starve the home core of its first attempt.
+//
+// afterRedirect records that the current hop was reached by following a
+// 421. It flips on the bare-401 recovery: a home core reached via 421
+// can't verify a foreign-region login JWT's signature (its API verifier
+// trusts only local JWKS), so it returns a bare 401 rather than the
+// cross_juris_token_required hint. On a redirected hop we treat that
+// bare 401 as an exchange trigger; on a non-redirected hop a bare 401 is
+// a genuine auth failure and passes through.
+type retryBudget struct {
+	redirects     int
+	triedExchange map[string]bool
+	afterRedirect bool
+}
+
+func (t *crossJurisRoundTripper) send(req *http.Request, body []byte, originalAuth string, budget retryBudget) (*http.Response, error) {
+	// Pick the Authorization for this hop: cached exchanged token for
+	// this origin if present (cache hit), otherwise the original caller-
+	// supplied bearer. Crucially we DON'T inherit whatever Authorization
+	// happens to be on req.Header — a previous hop may have stamped an
+	// exchanged token scoped to a different origin, and presenting that
+	// here would be wrong on its face AND would corrupt subject_token
+	// for any exchange this hop ends up doing.
+	origin := requestOrigin(req)
+	switch cached, ok := t.lookupToken(origin); {
+	case ok:
+		req.Header.Set("Authorization", "Bearer "+cached)
+	case originalAuth != "":
+		req.Header.Set("Authorization", originalAuth)
+	}
+	resetBody(req, body)
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("cross-juris transport: base round trip: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusMisdirectedRequest:
+		if budget.redirects <= 0 {
+			return resp, nil
+		}
+		newReq, err := t.followMisdirected(req, resp, origin)
+		if err != nil {
+			// Couldn't follow — surface the original response so the
+			// caller sees the server's body.
+			debugf("421 follow failed: %v", err)
+			return resp, nil
+		}
+		_ = resp.Body.Close()
+		budget.redirects--
+		budget.afterRedirect = true
+		return t.send(newReq, body, originalAuth, budget)
+	case http.StatusUnauthorized:
+		if budget.triedExchange[origin] {
+			return resp, nil
+		}
+		hint, ok, err := readCrossJurisHint(resp)
+		if err != nil {
+			debugf("read 401 body failed: %v", err)
+			return resp, nil
+		}
+		if !ok {
+			// No structured hint. On a non-redirected hop this is an
+			// ordinary auth failure — pass it through. But a home core
+			// reached by following a 421 returns a bare 401 for a
+			// foreign-region login JWT (its API verifier trusts only
+			// local JWKS, so the signature check fails before audience and
+			// no cross_juris_token_required hint is emitted). We already
+			// vetted this origin against the responding core's federation
+			// manifest when we followed the 421, so synthesize the hint
+			// from it: the core's /oauth/token is same-origin and its
+			// audience is its own base URL.
+			if !budget.afterRedirect {
+				return resp, nil
+			}
+			hint = crossJurisErrorBody{
+				Error:            "cross_juris_token_required",
+				TokenExchangeURL: origin + "/oauth/token",
+				Audience:         origin,
+			}
+		}
+		// Same-origin + safe-scheme check before re-targeting the user's
+		// login JWT: a 401 emitted by a core has no legitimate reason to
+		// point token_exchange_url at any other host. Off-origin or
+		// http:// (non-loopback) hints get the original 401 passed
+		// through unchanged so the caller sees the server's bytes and
+		// the JWT never leaves the trusted origin.
+		if err := validateExchangeURL(hint.TokenExchangeURL, req.URL); err != nil {
+			debugf("rejecting token_exchange_url: %v", err)
+			return resp, nil
+		}
+		// Exchange the ORIGINAL login JWT (not whatever exchanged token
+		// a prior hop stashed on req). An exchanged token already
+		// carries foreign_iss; the server rejects chained cross-juris hops.
+		subjectToken, found := strings.CutPrefix(originalAuth, "Bearer ")
+		if !found || subjectToken == "" {
+			return resp, nil
+		}
+		exchanged, err := t.exchangeSubjectToken(req.Context(), hint, subjectToken)
+		if err != nil {
+			debugf("exchange failed: %v", err)
+			return resp, nil
+		}
+		t.storeToken(origin, exchanged)
+		budget.triedExchange[origin] = true
+		_ = resp.Body.Close()
+		req.Header.Set("Authorization", "Bearer "+exchanged)
+		return t.send(req, body, originalAuth, budget)
+	}
+	return resp, nil
+}
+
+// followMisdirected reads the 421 envelope and constructs a fresh
+// request aimed at the home core. Method, headers, and (buffered) body
+// are preserved on the new request. On parse failure the original
+// response body is restored (the caller is about to return resp
+// unchanged) so downstream consumers still see the server's bytes.
+//
+// Trust gate: home_core_url must be HTTPS (loopback http allowed for
+// tests), and its host must appear in the federation manifest fetched
+// lazily from responseOrigin (the host that emitted the 421 — already
+// a trusted origin for the CLI). Off-federation or off-scheme targets
+// surface the original 421 unchanged.
+func (t *crossJurisRoundTripper) followMisdirected(orig *http.Request, resp *http.Response, responseOrigin string) (*http.Request, error) {
+	body, err := drainAndRestoreBody(resp, 64*1024)
+	if err != nil {
+		return nil, fmt.Errorf("read 421 body: %w", err)
+	}
+	var env mirror421Body
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, fmt.Errorf("parse 421 body: %w", err)
+	}
+	if env.HomeCoreURL == "" {
+		return nil, errors.New("421 body missing home_core_url")
+	}
+	homeCore, err := url.Parse(strings.TrimRight(env.HomeCoreURL, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("parse home_core_url: %w", err)
+	}
+	if !isSafeOrigin(homeCore) {
+		return nil, fmt.Errorf("home_core_url %q is not https (or http loopback)", env.HomeCoreURL)
+	}
+	peers := t.federationHostsFor(orig.Context(), responseOrigin)
+	if _, ok := peers[homeCore.Host]; !ok {
+		return nil, fmt.Errorf("home_core_url host %q is not in the responding core's federation manifest", homeCore.Host)
+	}
+	target := *homeCore
+	target.Path = orig.URL.Path
+	target.RawQuery = orig.URL.RawQuery
+	newReq, err := http.NewRequestWithContext(orig.Context(), orig.Method, target.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build redirected request: %w", err)
+	}
+	newReq.Header = orig.Header.Clone()
+	return newReq, nil
+}
+
+// validateExchangeURL gates the URL the transport will POST the user's
+// login JWT to for an RFC 8693 exchange. Two checks:
+//
+//   - Scheme must be https, except http://localhost for tests.
+//   - Host must equal the request URL host that emitted the 401. A
+//     core's /oauth/token always lives on the same origin as its
+//     middleware; off-origin hints have no legitimate use and would
+//     let a misconfigured / hostile core exfiltrate the user's JWT.
+func validateExchangeURL(raw string, requestURL *url.URL) error {
+	if raw == "" {
+		return errors.New("token_exchange_url missing")
+	}
+	exchange, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse token_exchange_url: %w", err)
+	}
+	if !isSafeOrigin(exchange) {
+		return fmt.Errorf("token_exchange_url %q is not https (or http loopback)", raw)
+	}
+	if requestURL == nil || requestURL.Host == "" {
+		return errors.New("cannot determine response origin for same-origin check")
+	}
+	if exchange.Host != requestURL.Host {
+		return fmt.Errorf("token_exchange_url host %q must match response host %q", exchange.Host, requestURL.Host)
+	}
+	return nil
+}
+
+// isSafeOrigin reports whether u is acceptable as a destination for the
+// user's login JWT. https is always allowed; http is allowed only for
+// loopback so httptest fixtures keep working.
+func isSafeOrigin(u *url.URL) bool {
+	switch u.Scheme {
+	case "https":
+		return u.Host != ""
+	case "http":
+		return isLoopbackHost(u.Hostname())
+	default:
+		return false
+	}
+}
+
+// isLoopbackHost reports whether host is a loopback name or IP. Used
+// only to widen isSafeOrigin for local/test fixtures — production
+// federation traffic is always https.
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
+}
+
+// federationHostsFor returns the set of hosts the core at origin
+// publishes as its federation peers (via GET /.well-known/entire-
+// federation). Cached for the life of the transport. nil result means
+// the origin advertises no peers OR the fetch failed; either way, no
+// 421 redirect from this origin will be followed.
+func (t *crossJurisRoundTripper) federationHostsFor(ctx context.Context, origin string) map[string]struct{} {
+	if origin == "" {
+		return nil
+	}
+	if v, ok := t.federation.Load(origin); ok {
+		cached, _ := v.(cachedFederation) //nolint:errcheck // type assertion, not error
+		return cached.hosts
+	}
+	hosts := t.fetchFederationHosts(ctx, origin)
+	t.federation.Store(origin, cachedFederation{hosts: hosts})
+	return hosts
+}
+
+// fetchFederationHosts performs the one-shot GET against origin's
+// well-known endpoint. Returns nil on any failure (transport error,
+// non-200, parse error, empty list) — federationHostsFor caches the
+// nil so we don't pound the endpoint per 421.
+func (t *crossJurisRoundTripper) fetchFederationHosts(ctx context.Context, origin string) map[string]struct{} {
+	ctx, cancel := context.WithTimeout(ctx, federationLookupTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+federationWellKnownPath, nil)
+	if err != nil {
+		debugf("build federation request: %v", err)
+		return nil
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		debugf("federation fetch: %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		debugf("federation fetch returned HTTP %d", resp.StatusCode)
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16*1024))
+	if err != nil {
+		debugf("read federation body: %v", err)
+		return nil
+	}
+	var env federationBody
+	if err := json.Unmarshal(body, &env); err != nil {
+		debugf("parse federation body: %v", err)
+		return nil
+	}
+	if len(env.PeerAuthHosts) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(env.PeerAuthHosts))
+	for _, raw := range env.PeerAuthHosts {
+		u, err := url.Parse(raw)
+		if err != nil || u.Host == "" {
+			continue
+		}
+		out[u.Host] = struct{}{}
+	}
+	return out
+}
+
+// readCrossJurisHint reads the structured 401 envelope. Returns ok=false
+// when the body isn't the expected shape (a plain 401 from somewhere
+// else, an HTML proxy error, etc.) so the caller passes the response
+// through unchanged. The body is restored regardless so downstream
+// consumers can re-read.
+func readCrossJurisHint(resp *http.Response) (crossJurisErrorBody, bool, error) {
+	body, err := drainAndRestoreBody(resp, 8*1024)
+	if err != nil {
+		return crossJurisErrorBody{}, false, fmt.Errorf("read 401 body: %w", err)
+	}
+	var env crossJurisErrorBody
+	// Unmarshal failure means the body isn't our envelope shape (HTML
+	// proxy error, a different JSON shape, garbage). That's the
+	// not-a-hint case, not an error condition — the caller passes the
+	// response through unchanged.
+	if err := json.Unmarshal(body, &env); err != nil {
+		return crossJurisErrorBody{}, false, nil //nolint:nilerr // unmarshal-fail = "not our envelope shape"
+	}
+	if env.Error != "cross_juris_token_required" || env.TokenExchangeURL == "" {
+		return crossJurisErrorBody{}, false, nil
+	}
+	return env, true, nil
+}
+
+// drainAndRestoreBody reads up to maxBytes from resp.Body and replaces
+// resp.Body with a fresh in-memory reader over those bytes, so the
+// caller can hand resp back to its own caller with the body still
+// readable. Cap is conservative — control-plane error envelopes are
+// always small.
+func drainAndRestoreBody(resp *http.Response, maxBytes int64) ([]byte, error) {
+	body, err := io.ReadAll(http.MaxBytesReader(nil, resp.Body, maxBytes))
+	if err != nil {
+		return nil, fmt.Errorf("drain response body: %w", err)
+	}
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return body, nil
+}
+
+// exchangeSubjectToken performs the RFC 8693 cross-juris session
+// exchange and returns the issued access_token. Delegates the wire-
+// level details (form encode, lifting client_id into Basic auth,
+// response decode) to httputil.PostOAuthToken.
+func (t *crossJurisRoundTripper) exchangeSubjectToken(ctx context.Context, hint crossJurisErrorBody, subjectToken string) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", httputil.GrantTypeTokenExchange)
+	form.Set("subject_token", subjectToken)
+	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:jwt")
+	form.Set("requested_token_type", httputil.TokenTypeAccessToken)
+	if hint.Audience != "" {
+		form.Set("audience", hint.Audience)
+	}
+	// "entire-cli" is the public client every CLI binary identifies as on
+	// /oauth/token; PostOAuthToken lifts it into Basic auth because
+	// pkg/op's token-exchange handler reads client credentials only from
+	// the Authorization header. The subject_token is the real authorizer.
+	form.Set("client_id", "entire-cli")
+	// PostOAuthToken expects a base core URL and appends /oauth/token
+	// itself; hint.TokenExchangeURL is already the full path (and
+	// validateExchangeURL has gated the origin), so strip the suffix.
+	coreURL := strings.TrimSuffix(hint.TokenExchangeURL, "/oauth/token")
+	// Exchange goes through the base transport so we don't re-enter our
+	// own retry logic — a non-200 here is terminal.
+	client := &http.Client{Transport: t.base}
+	token, _, err := httputil.PostOAuthToken(ctx, client, coreURL, form)
+	if err != nil {
+		return "", fmt.Errorf("exchange: %w", err)
+	}
+	return token, nil
+}
+
+func (t *crossJurisRoundTripper) lookupToken(origin string) (string, bool) {
+	v, ok := t.tokens.Load(origin)
+	if !ok {
+		return "", false
+	}
+	cached, _ := v.(cachedExchangedToken) //nolint:errcheck // type assertion, not error
+	if time.Now().After(cached.exp) {
+		t.tokens.Delete(origin)
+		return "", false
+	}
+	return cached.token, true
+}
+
+func (t *crossJurisRoundTripper) storeToken(origin, token string) {
+	if origin == "" || token == "" {
+		return
+	}
+	t.tokens.Store(origin, cachedExchangedToken{
+		token: token,
+		exp:   time.Now().Add(cachedTokenTTL),
+	})
+}
+
+// bufferBody reads req.Body once into memory and sets GetBody so each
+// retry produces a fresh reader. Returns nil when there's no body.
+func bufferBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil, nil
+	}
+	buf, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read request body: %w", err)
+	}
+	_ = req.Body.Close()
+	return buf, nil
+}
+
+// resetBody attaches a fresh body reader (and ContentLength) to req,
+// using the buffer captured by bufferBody. Safe to call when buf is nil.
+func resetBody(req *http.Request, buf []byte) {
+	if buf == nil {
+		req.Body = http.NoBody
+		req.ContentLength = 0
+		req.GetBody = func() (io.ReadCloser, error) { return http.NoBody, nil }
+		return
+	}
+	req.Body = io.NopCloser(bytes.NewReader(buf))
+	req.ContentLength = int64(len(buf))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(buf)), nil
+	}
+}
+
+// requestOrigin returns scheme://host of req, the cache key for
+// exchanged tokens. Empty when req.URL is malformed.
+func requestOrigin(req *http.Request) string {
+	if req.URL == nil || req.URL.Scheme == "" || req.URL.Host == "" {
+		return ""
+	}
+	return req.URL.Scheme + "://" + req.URL.Host
+}

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -143,6 +143,10 @@ const federationLookupTimeout = 3 * time.Second
 // secret — it names siblings any user can already enumerate via login).
 const federationWellKnownPath = "/.well-known/entire-federation"
 
+// oauthTokenPath is entire-core's RFC 8693 token-exchange endpoint,
+// always same-origin with the core that emitted the 401 / 421.
+const oauthTokenPath = "/oauth/token" //nolint:gosec // G101: a URL path, not a credential
+
 func newCrossJurisRoundTripper(base http.RoundTripper) *crossJurisRoundTripper {
 	if base == nil {
 		base = http.DefaultTransport
@@ -247,7 +251,7 @@ func (t *crossJurisRoundTripper) send(req *http.Request, body []byte, originalAu
 			}
 			hint = crossJurisErrorBody{
 				Error:            "cross_juris_token_required",
-				TokenExchangeURL: origin + "/oauth/token",
+				TokenExchangeURL: origin + oauthTokenPath,
 				Audience:         origin,
 			}
 		}
@@ -405,7 +409,10 @@ func (t *crossJurisRoundTripper) federationHostsFor(ctx context.Context, origin 
 func (t *crossJurisRoundTripper) fetchFederationHosts(ctx context.Context, origin string) map[string]struct{} {
 	ctx, cancel := context.WithTimeout(ctx, federationLookupTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+federationWellKnownPath, nil)
+	// origin is the scheme://host of a core the CLI is already configured to
+	// talk to (or one it just received a response from), and the path is a
+	// fixed public well-known endpoint — not attacker-controlled SSRF.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, origin+federationWellKnownPath, nil) //nolint:gosec // G704: origin is a core the CLI already dials; fixed well-known path
 	if err != nil {
 		debugf("build federation request: %v", err)
 		return nil
@@ -505,7 +512,7 @@ func (t *crossJurisRoundTripper) exchangeSubjectToken(ctx context.Context, hint 
 	// PostOAuthToken expects a base core URL and appends /oauth/token
 	// itself; hint.TokenExchangeURL is already the full path (and
 	// validateExchangeURL has gated the origin), so strip the suffix.
-	coreURL := strings.TrimSuffix(hint.TokenExchangeURL, "/oauth/token")
+	coreURL := strings.TrimSuffix(hint.TokenExchangeURL, oauthTokenPath)
 	// Exchange goes through the base transport so we don't re-enter our
 	// own retry logic — a non-200 here is terminal.
 	client := &http.Client{Transport: t.base}

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -339,6 +339,10 @@ func (t *crossJurisRoundTripper) followMisdirected(orig *http.Request, resp *htt
 //     core's /oauth/token always lives on the same origin as its
 //     middleware; off-origin hints have no legitimate use and would
 //     let a misconfigured / hostile core exfiltrate the user's JWT.
+//   - Path must be exactly oauthTokenPath. exchangeSubjectToken strips
+//     that suffix and PostOAuthToken re-appends it; validating it here
+//     keeps that round-trip honest instead of silently POSTing to a
+//     server-chosen path.
 func validateExchangeURL(raw string, requestURL *url.URL) error {
 	if raw == "" {
 		return errors.New("token_exchange_url missing")
@@ -355,6 +359,9 @@ func validateExchangeURL(raw string, requestURL *url.URL) error {
 	}
 	if exchange.Host != requestURL.Host {
 		return fmt.Errorf("token_exchange_url host %q must match response host %q", exchange.Host, requestURL.Host)
+	}
+	if exchange.Path != oauthTokenPath {
+		return fmt.Errorf("token_exchange_url path %q must be %q", exchange.Path, oauthTokenPath)
 	}
 	return nil
 }

--- a/internal/coreapi/cross_juris_transport_test.go
+++ b/internal/coreapi/cross_juris_transport_test.go
@@ -14,6 +14,12 @@ import (
 	"time"
 )
 
+// Bearer tokens the fixtures assert on, hoisted to consts so goconst is happy.
+const (
+	bearerExchanged     = "Bearer exchanged-jwt"
+	bearerHomeExchanged = "Bearer home-exchanged-jwt"
+)
+
 // authRecorder collects values captured inside an httptest handler
 // goroutine for assertion in the test goroutine. HTTP completion isn't a
 // happens-before edge the race detector recognises (see
@@ -168,7 +174,7 @@ func TestRoundTripper_421ThenBareUnauthorizedProactiveExchange(t *testing.T) {
 			return
 		}
 		homeAPIAuths.add(r.Header.Get("Authorization"))
-		if r.Header.Get("Authorization") == "Bearer home-exchanged-jwt" {
+		if r.Header.Get("Authorization") == bearerHomeExchanged {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test
 			return
@@ -203,7 +209,7 @@ func TestRoundTripper_421ThenBareUnauthorizedProactiveExchange(t *testing.T) {
 	if subs := homeExchangeSubjects.snapshot(); len(subs) != 1 || subs[0] != "original-eu-login-jwt" {
 		t.Fatalf("exchange subject_token = %v, want [original-eu-login-jwt]", subs)
 	}
-	if auths := homeAPIAuths.snapshot(); len(auths) != 2 || auths[0] != "Bearer original-eu-login-jwt" || auths[1] != "Bearer home-exchanged-jwt" {
+	if auths := homeAPIAuths.snapshot(); len(auths) != 2 || auths[0] != "Bearer original-eu-login-jwt" || auths[1] != bearerHomeExchanged {
 		t.Fatalf("home API auths = %v", auths)
 	}
 }
@@ -282,7 +288,7 @@ func TestRoundTripper_401ExchangeAndRetry(t *testing.T) {
 	if exchangeHits.Load() != 1 {
 		t.Fatalf("exchanges=%d", exchangeHits.Load())
 	}
-	if auths := apiAuths.snapshot(); len(auths) != 2 || auths[0] != "Bearer user-jwt" || auths[1] != "Bearer exchanged-jwt" {
+	if auths := apiAuths.snapshot(); len(auths) != 2 || auths[0] != "Bearer user-jwt" || auths[1] != bearerExchanged {
 		t.Fatalf("api auths = %v", auths)
 	}
 }
@@ -409,6 +415,210 @@ func TestValidateExchangeURL(t *testing.T) {
 	}
 	if err := validateExchangeURL("http://localhost:1234/oauth/token", mustParse("http://localhost:1234/api")); err != nil {
 		t.Errorf("loopback http must pass: %v", err)
+	}
+}
+
+// TestRoundTripper_TokenCacheReusesExchanged confirms the per-origin
+// cache: a second request to the same origin within TTL skips the
+// exchange and presents the cached token on the first attempt.
+func TestRoundTripper_TokenCacheReusesExchanged(t *testing.T) {
+	t.Parallel()
+	exchangeHits := atomic.Int32{}
+	apiHits := atomic.Int32{}
+	var apiAuths authRecorder
+	var apiServer *httptest.Server
+	apiServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == oauthTokenPath {
+			exchangeHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"exchanged-jwt"}`)) //nolint:errcheck // test
+			return
+		}
+		apiHits.Add(1)
+		apiAuths.add(r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") == bearerExchanged {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"cross_juris_token_required","token_exchange_url":"` + apiServer.URL + `/oauth/token","audience":"` + apiServer.URL + `"}`)) //nolint:errcheck // test
+	}))
+	t.Cleanup(apiServer.Close)
+
+	client := &http.Client{Transport: transportFor()}
+	for i := range 2 {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, apiServer.URL+"/api/v1/me", nil) //nolint:errcheck // test
+		req.Header.Set("Authorization", "Bearer user-jwt")
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("request %d: got %d", i, resp.StatusCode)
+		}
+	}
+	if exchangeHits.Load() != 1 {
+		t.Fatalf("exchange must run once across both requests, got %d", exchangeHits.Load())
+	}
+	if auths := apiAuths.snapshot(); len(auths) != 3 || auths[2] != bearerExchanged {
+		t.Fatalf("second request must present the cached token on its first attempt: %v", auths)
+	}
+}
+
+// TestRoundTripper_NoInfiniteLoopOn421Chain confirms the redirect budget
+// cap: a home core that itself 421s gets the second response passed
+// through, not followed again.
+func TestRoundTripper_NoInfiniteLoopOn421Chain(t *testing.T) {
+	t.Parallel()
+	var second *crossJurisTestServer
+	first := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		w.WriteHeader(http.StatusMisdirectedRequest)
+		w.Write([]byte(`{"home_core_url":"` + second.srv.URL + `"}`)) //nolint:errcheck // test
+	})
+	second = newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		w.WriteHeader(http.StatusMisdirectedRequest)
+		// Loopback host so the test exercises the budget cap, not the
+		// federation/scheme reject path.
+		w.Write([]byte(`{"home_core_url":"http://127.0.0.1:1"}`)) //nolint:errcheck // test
+	})
+	first.peers = []string{second.srv.URL}
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, first.srv.URL+"/api/v1/mirrors", nil) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer user-jwt")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMisdirectedRequest {
+		t.Fatalf("got %d, want the second 421 passed through after budget exhaustion", resp.StatusCode)
+	}
+	if first.hits.Load() != 1 || second.hits.Load() != 1 {
+		t.Fatalf("first=%d second=%d, want 1/1 (no third hop)", first.hits.Load(), second.hits.Load())
+	}
+}
+
+// TestRoundTripper_ExchangeFailurePropagates401: a non-200 exchange leaves
+// the original 401 (and its hint body) visible to the caller.
+func TestRoundTripper_ExchangeFailurePropagates401(t *testing.T) {
+	t.Parallel()
+	apiHits := atomic.Int32{}
+	var api *httptest.Server
+	api = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == oauthTokenPath {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"invalid_grant"}`)) //nolint:errcheck // test
+			return
+		}
+		apiHits.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"cross_juris_token_required","token_exchange_url":"` + api.URL + `/oauth/token","audience":"` + api.URL + `"}`)) //nolint:errcheck // test
+	}))
+	t.Cleanup(api.Close)
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, api.URL+"/api/v1/me", nil) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer user-jwt")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("got %d, want original 401 surfaced", resp.StatusCode)
+	}
+	if apiHits.Load() != 1 {
+		t.Fatalf("no retry when exchange fails, got %d hits", apiHits.Load())
+	}
+	body, _ := io.ReadAll(resp.Body) //nolint:errcheck // test
+	if !strings.Contains(string(body), "cross_juris_token_required") {
+		t.Errorf("original hint body must survive the failed exchange: %q", body)
+	}
+}
+
+// TestRoundTripper_ExchangeAfter401Then421UsesOriginalSubjectToken is the
+// regression for the chained-exchange case: 401-hint at the misdirected
+// core → exchange → retry → 421 to home → 401-hint at home. The home
+// exchange must reuse the ORIGINAL login JWT as subject_token, not the
+// misdirected core's foreign-session token (which already carries
+// foreign_iss; the server rejects chained cross-juris hops).
+func TestRoundTripper_ExchangeAfter401Then421UsesOriginalSubjectToken(t *testing.T) {
+	t.Parallel()
+	const originalLoginJWT = "original-eu-login-jwt"
+
+	homeExchangeHits := atomic.Int32{}
+	var homeExchangeSubjects, homeAPIAuths authRecorder
+	var homeAPI *httptest.Server
+	homeAPI = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == oauthTokenPath {
+			_ = r.ParseForm() //nolint:errcheck // test
+			homeExchangeSubjects.add(r.PostForm.Get("subject_token"))
+			homeExchangeHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"home-exchanged-jwt"}`)) //nolint:errcheck // test
+			return
+		}
+		homeAPIAuths.add(r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") == bearerHomeExchanged {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"cross_juris_token_required","token_exchange_url":"` + homeAPI.URL + `/oauth/token","audience":"` + homeAPI.URL + `"}`)) //nolint:errcheck // test
+	}))
+	t.Cleanup(homeAPI.Close)
+
+	misdirectedExchangeHits := atomic.Int32{}
+	misdirectedHits := atomic.Int32{}
+	var misdirected *httptest.Server
+	misdirected = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case federationWellKnownPath:
+			writeTestFederation(w, []string{homeAPI.URL})
+			return
+		case oauthTokenPath:
+			misdirectedExchangeHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"misdirected-exchanged-jwt"}`)) //nolint:errcheck // test
+			return
+		}
+		if misdirectedHits.Add(1) == 1 {
+			// First hop: middleware sees the EU-aud JWT, emits the hint.
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":"cross_juris_token_required","token_exchange_url":"` + misdirected.URL + `/oauth/token","audience":"` + misdirected.URL + `"}`)) //nolint:errcheck // test
+			return
+		}
+		// Retry accepted; handler finds the cluster is in another
+		// jurisdiction and 421s to home.
+		w.WriteHeader(http.StatusMisdirectedRequest)
+		w.Write([]byte(`{"home_core_url":"` + homeAPI.URL + `"}`)) //nolint:errcheck // test
+	}))
+	t.Cleanup(misdirected.Close)
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, misdirected.URL+"/api/v1/mirrors", strings.NewReader(`{}`)) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer "+originalLoginJWT)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d, want home core to accept the home-audience exchanged token", resp.StatusCode)
+	}
+	if misdirectedExchangeHits.Load() != 1 || homeExchangeHits.Load() != 1 {
+		t.Fatalf("misdirected=%d home=%d exchanges, want 1/1", misdirectedExchangeHits.Load(), homeExchangeHits.Load())
+	}
+	if subs := homeExchangeSubjects.snapshot(); len(subs) != 1 || subs[0] != originalLoginJWT {
+		t.Fatalf("REGRESSION: home exchange must reuse the ORIGINAL login JWT as subject_token, got %v", subs)
+	}
+	if auths := homeAPIAuths.snapshot(); len(auths) != 2 || auths[0] != "Bearer "+originalLoginJWT || auths[1] != bearerHomeExchanged {
+		t.Fatalf("home API auths = %v", auths)
 	}
 }
 

--- a/internal/coreapi/cross_juris_transport_test.go
+++ b/internal/coreapi/cross_juris_transport_test.go
@@ -8,10 +8,33 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// authRecorder collects values captured inside an httptest handler
+// goroutine for assertion in the test goroutine. HTTP completion isn't a
+// happens-before edge the race detector recognises (see
+// client_test.go:160-189), so the mutex makes the cross-goroutine reads
+// race-safe under `-race`.
+type authRecorder struct {
+	mu   sync.Mutex
+	vals []string
+}
+
+func (a *authRecorder) add(v string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.vals = append(a.vals, v)
+}
+
+func (a *authRecorder) snapshot() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.vals...)
+}
 
 // crossJurisTestServer scripts responses keyed by the caller-controlled
 // handler and records the Authorization header per request so tests can
@@ -19,14 +42,14 @@ import (
 // GET /.well-known/entire-federation with the hosts in `peers`.
 type crossJurisTestServer struct {
 	hits  atomic.Int32
-	auths []string
+	auths authRecorder
 	peers []string
 	srv   *httptest.Server
 }
 
 func (s *crossJurisTestServer) record(r *http.Request) {
 	s.hits.Add(1)
-	s.auths = append(s.auths, r.Header.Get("Authorization"))
+	s.auths.add(r.Header.Get("Authorization"))
 }
 
 func newCrossJurisTestServer(t *testing.T, handler func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request)) *crossJurisTestServer {
@@ -119,8 +142,8 @@ func TestRoundTripper_421FollowsToHomeCore(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("got %d", resp.StatusCode)
 	}
-	if homeCore.auths[0] != "Bearer user-jwt" {
-		t.Fatalf("home core first hop auth = %q", homeCore.auths[0])
+	if got := homeCore.auths.snapshot(); len(got) == 0 || got[0] != "Bearer user-jwt" {
+		t.Fatalf("home core first hop auth = %v", got)
 	}
 }
 
@@ -131,18 +154,17 @@ func TestRoundTripper_421FollowsToHomeCore(t *testing.T) {
 // at the home core's same-origin /oauth/token and retrying.
 func TestRoundTripper_421ThenBareUnauthorizedProactiveExchange(t *testing.T) {
 	homeExchangeHits := atomic.Int32{}
-	homeExchangeSubjects := []string{}
-	homeAPIAuths := []string{}
+	var homeExchangeSubjects, homeAPIAuths authRecorder
 	homeCore := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/oauth/token" {
+		if r.URL.Path == oauthTokenPath {
 			_ = r.ParseForm() //nolint:errcheck // test
-			homeExchangeSubjects = append(homeExchangeSubjects, r.PostForm.Get("subject_token"))
+			homeExchangeSubjects.add(r.PostForm.Get("subject_token"))
 			homeExchangeHits.Add(1)
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"access_token":"home-exchanged-jwt"}`)) //nolint:errcheck // test
 			return
 		}
-		homeAPIAuths = append(homeAPIAuths, r.Header.Get("Authorization"))
+		homeAPIAuths.add(r.Header.Get("Authorization"))
 		if r.Header.Get("Authorization") == "Bearer home-exchanged-jwt" {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test
@@ -175,11 +197,11 @@ func TestRoundTripper_421ThenBareUnauthorizedProactiveExchange(t *testing.T) {
 	if homeExchangeHits.Load() != 1 {
 		t.Fatalf("home exchange hits=%d", homeExchangeHits.Load())
 	}
-	if len(homeExchangeSubjects) != 1 || homeExchangeSubjects[0] != "original-eu-login-jwt" {
-		t.Fatalf("exchange subject_token = %v, want [original-eu-login-jwt]", homeExchangeSubjects)
+	if subs := homeExchangeSubjects.snapshot(); len(subs) != 1 || subs[0] != "original-eu-login-jwt" {
+		t.Fatalf("exchange subject_token = %v, want [original-eu-login-jwt]", subs)
 	}
-	if len(homeAPIAuths) != 2 || homeAPIAuths[0] != "Bearer original-eu-login-jwt" || homeAPIAuths[1] != "Bearer home-exchanged-jwt" {
-		t.Fatalf("home API auths = %v", homeAPIAuths)
+	if auths := homeAPIAuths.snapshot(); len(auths) != 2 || auths[0] != "Bearer original-eu-login-jwt" || auths[1] != "Bearer home-exchanged-jwt" {
+		t.Fatalf("home API auths = %v", auths)
 	}
 }
 
@@ -188,7 +210,7 @@ func TestRoundTripper_421ThenBareUnauthorizedProactiveExchange(t *testing.T) {
 func TestRoundTripper_BareUnauthorizedNoRedirectPassesThrough(t *testing.T) {
 	exchangeHits := atomic.Int32{}
 	srv := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/oauth/token" {
+		if r.URL.Path == oauthTokenPath {
 			exchangeHits.Add(1)
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"access_token":"x"}`)) //nolint:errcheck // test
@@ -220,17 +242,17 @@ func TestRoundTripper_BareUnauthorizedNoRedirectPassesThrough(t *testing.T) {
 func TestRoundTripper_401ExchangeAndRetry(t *testing.T) {
 	exchangeHits := atomic.Int32{}
 	apiHits := atomic.Int32{}
-	apiAuths := []string{}
+	var apiAuths authRecorder
 	var apiServer *httptest.Server
 	apiServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/oauth/token" {
+		if r.URL.Path == oauthTokenPath {
 			exchangeHits.Add(1)
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"access_token":"exchanged-jwt","token_type":"Bearer","expires_in":300}`)) //nolint:errcheck // test
 			return
 		}
 		n := apiHits.Add(1)
-		apiAuths = append(apiAuths, r.Header.Get("Authorization"))
+		apiAuths.add(r.Header.Get("Authorization"))
 		if n == 1 {
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte(`{"error":"cross_juris_token_required","token_exchange_url":"` + apiServer.URL + `/oauth/token","audience":"` + apiServer.URL + `"}`)) //nolint:errcheck // test
@@ -255,8 +277,8 @@ func TestRoundTripper_401ExchangeAndRetry(t *testing.T) {
 	if exchangeHits.Load() != 1 {
 		t.Fatalf("exchanges=%d", exchangeHits.Load())
 	}
-	if len(apiAuths) != 2 || apiAuths[0] != "Bearer user-jwt" || apiAuths[1] != "Bearer exchanged-jwt" {
-		t.Fatalf("api auths = %v", apiAuths)
+	if auths := apiAuths.snapshot(); len(auths) != 2 || auths[0] != "Bearer user-jwt" || auths[1] != "Bearer exchanged-jwt" {
+		t.Fatalf("api auths = %v", auths)
 	}
 }
 

--- a/internal/coreapi/cross_juris_transport_test.go
+++ b/internal/coreapi/cross_juris_transport_test.go
@@ -421,6 +421,43 @@ func TestValidateExchangeURL(t *testing.T) {
 	}
 }
 
+func TestEffectiveTokenTTL(t *testing.T) {
+	t.Parallel()
+	// No advertised lifetime → conservative cap.
+	if got := effectiveTokenTTL(0); got != cachedTokenTTL {
+		t.Errorf("expires_in=0: got %v, want %v", got, cachedTokenTTL)
+	}
+	if got := effectiveTokenTTL(-5); got != cachedTokenTTL {
+		t.Errorf("expires_in<0: got %v, want %v", got, cachedTokenTTL)
+	}
+	// Long-lived token is capped at cachedTokenTTL.
+	if got := effectiveTokenTTL(3600); got != cachedTokenTTL {
+		t.Errorf("long lifetime: got %v, want cap %v", got, cachedTokenTTL)
+	}
+	// Short-lived token honors expires_in minus the buffer.
+	if got := effectiveTokenTTL(180); got != 180*time.Second-tokenExpiryBuffer {
+		t.Errorf("short lifetime: got %v, want %v", got, 180*time.Second-tokenExpiryBuffer)
+	}
+	// Lifetime under the buffer yields <=0, which storeToken declines to cache.
+	if got := effectiveTokenTTL(30); got > 0 {
+		t.Errorf("sub-buffer lifetime: got %v, want <=0", got)
+	}
+}
+
+// TestStoreTokenDeclinesNonPositiveTTL: a <=0 TTL must not be cached.
+func TestStoreTokenDeclinesNonPositiveTTL(t *testing.T) {
+	t.Parallel()
+	rt := transportFor()
+	rt.storeToken("https://example.test", "tok", 0)
+	if _, ok := rt.lookupToken("https://example.test"); ok {
+		t.Error("zero TTL must not be cached")
+	}
+	rt.storeToken("https://example.test", "tok", -time.Second)
+	if _, ok := rt.lookupToken("https://example.test"); ok {
+		t.Error("negative TTL must not be cached")
+	}
+}
+
 // TestRoundTripper_TokenCacheReusesExchanged confirms the per-origin
 // cache: a second request to the same origin within TTL skips the
 // exchange and presents the cached token on the first attempt.
@@ -629,7 +666,7 @@ func TestRoundTripper_ExchangeAfter401Then421UsesOriginalSubjectToken(t *testing
 func TestCacheExpiresAfterTTL(t *testing.T) {
 	t.Parallel()
 	rt := transportFor()
-	rt.storeToken("https://example.test", "tok")
+	rt.storeToken("https://example.test", "tok", cachedTokenTTL)
 	if _, ok := rt.lookupToken("https://example.test"); !ok {
 		t.Fatal("fresh token must be a hit")
 	}

--- a/internal/coreapi/cross_juris_transport_test.go
+++ b/internal/coreapi/cross_juris_transport_test.go
@@ -1,0 +1,395 @@
+package coreapi
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// crossJurisTestServer scripts responses keyed by the caller-controlled
+// handler and records the Authorization header per request so tests can
+// assert which token the transport presented on each hop. It auto-serves
+// GET /.well-known/entire-federation with the hosts in `peers`.
+type crossJurisTestServer struct {
+	hits  atomic.Int32
+	auths []string
+	peers []string
+	srv   *httptest.Server
+}
+
+func (s *crossJurisTestServer) record(r *http.Request) {
+	s.hits.Add(1)
+	s.auths = append(s.auths, r.Header.Get("Authorization"))
+}
+
+func newCrossJurisTestServer(t *testing.T, handler func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request)) *crossJurisTestServer {
+	t.Helper()
+	s := &crossJurisTestServer{}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/entire-federation" {
+			writeTestFederation(w, s.peers)
+			return
+		}
+		handler(s, w, r)
+	}))
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func writeTestFederation(w http.ResponseWriter, peers []string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if len(peers) == 0 {
+		w.Write([]byte(`{"peer_auth_hosts":[]}`)) //nolint:errcheck // test
+		return
+	}
+	var b strings.Builder
+	b.WriteString(`{"peer_auth_hosts":[`)
+	for i, p := range peers {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`"`)
+		b.WriteString(p)
+		b.WriteString(`"`)
+	}
+	b.WriteString(`]}`)
+	w.Write([]byte(b.String())) //nolint:errcheck // test
+}
+
+func transportFor() *crossJurisRoundTripper {
+	return newCrossJurisRoundTripper(http.DefaultTransport)
+}
+
+// TestRoundTripper_PassThrough: a 2xx is returned unchanged.
+func TestRoundTripper_PassThrough(t *testing.T) {
+	srv := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test
+	})
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.srv.URL, nil) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer user-jwt")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d", resp.StatusCode)
+	}
+	if srv.hits.Load() != 1 {
+		t.Fatalf("hits=%d", srv.hits.Load())
+	}
+}
+
+// TestRoundTripper_421FollowsToHomeCore: 421 with home_core_url is
+// followed; the home core gets the original bearer on the first hop.
+func TestRoundTripper_421FollowsToHomeCore(t *testing.T) {
+	homeCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		w.WriteHeader(http.StatusOK)
+	})
+	wrongCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		w.WriteHeader(http.StatusMisdirectedRequest)
+		w.Write([]byte(`{"home_core_url":"` + homeCore.srv.URL + `"}`)) //nolint:errcheck // test
+	})
+	wrongCore.peers = []string{homeCore.srv.URL}
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, wrongCore.srv.URL+"/api/v1/mirrors", strings.NewReader(`{"a":1}`)) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer user-jwt")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d", resp.StatusCode)
+	}
+	if homeCore.auths[0] != "Bearer user-jwt" {
+		t.Fatalf("home core first hop auth = %q", homeCore.auths[0])
+	}
+}
+
+// TestRoundTripper_421ThenBareUnauthorizedProactiveExchange is the
+// production path: after following a 421, the home core can't verify the
+// foreign-region login JWT's signature and returns a BARE 401 (no hint).
+// The transport must still recover by exchanging the original login JWT
+// at the home core's same-origin /oauth/token and retrying.
+func TestRoundTripper_421ThenBareUnauthorizedProactiveExchange(t *testing.T) {
+	homeExchangeHits := atomic.Int32{}
+	homeExchangeSubjects := []string{}
+	homeAPIAuths := []string{}
+	homeCore := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/token" {
+			_ = r.ParseForm() //nolint:errcheck // test
+			homeExchangeSubjects = append(homeExchangeSubjects, r.PostForm.Get("subject_token"))
+			homeExchangeHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"home-exchanged-jwt"}`)) //nolint:errcheck // test
+			return
+		}
+		homeAPIAuths = append(homeAPIAuths, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") == "Bearer home-exchanged-jwt" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"invalid token"}`)) //nolint:errcheck // test
+	}))
+	t.Cleanup(homeCore.Close)
+
+	wrongCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		w.WriteHeader(http.StatusMisdirectedRequest)
+		w.Write([]byte(`{"home_core_url":"` + homeCore.URL + `"}`)) //nolint:errcheck // test
+	})
+	wrongCore.peers = []string{homeCore.URL}
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, wrongCore.srv.URL+"/api/v1/mirrors/collaborators", strings.NewReader(`{}`)) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer original-eu-login-jwt")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+	if homeExchangeHits.Load() != 1 {
+		t.Fatalf("home exchange hits=%d", homeExchangeHits.Load())
+	}
+	if len(homeExchangeSubjects) != 1 || homeExchangeSubjects[0] != "original-eu-login-jwt" {
+		t.Fatalf("exchange subject_token = %v, want [original-eu-login-jwt]", homeExchangeSubjects)
+	}
+	if len(homeAPIAuths) != 2 || homeAPIAuths[0] != "Bearer original-eu-login-jwt" || homeAPIAuths[1] != "Bearer home-exchanged-jwt" {
+		t.Fatalf("home API auths = %v", homeAPIAuths)
+	}
+}
+
+// TestRoundTripper_BareUnauthorizedNoRedirectPassesThrough: a bare 401
+// on a non-redirected request is a genuine failure — no exchange.
+func TestRoundTripper_BareUnauthorizedNoRedirectPassesThrough(t *testing.T) {
+	exchangeHits := atomic.Int32{}
+	srv := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/token" {
+			exchangeHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"x"}`)) //nolint:errcheck // test
+			return
+		}
+		s.record(r)
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"invalid token"}`)) //nolint:errcheck // test
+	})
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.srv.URL+"/api/v1/me", nil) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer user-jwt")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("got %d", resp.StatusCode)
+	}
+	if srv.hits.Load() != 1 || exchangeHits.Load() != 0 {
+		t.Fatalf("hits=%d exchanges=%d", srv.hits.Load(), exchangeHits.Load())
+	}
+}
+
+// TestRoundTripper_401ExchangeAndRetry covers the structured-hint path.
+func TestRoundTripper_401ExchangeAndRetry(t *testing.T) {
+	exchangeHits := atomic.Int32{}
+	apiHits := atomic.Int32{}
+	apiAuths := []string{}
+	var apiServer *httptest.Server
+	apiServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/token" {
+			exchangeHits.Add(1)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"exchanged-jwt","token_type":"Bearer","expires_in":300}`)) //nolint:errcheck // test
+			return
+		}
+		n := apiHits.Add(1)
+		apiAuths = append(apiAuths, r.Header.Get("Authorization"))
+		if n == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":"cross_juris_token_required","token_exchange_url":"` + apiServer.URL + `/oauth/token","audience":"` + apiServer.URL + `"}`)) //nolint:errcheck // test
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(apiServer.Close)
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, apiServer.URL+"/api/v1/mirrors", strings.NewReader(`{"a":1}`)) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer user-jwt")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d", resp.StatusCode)
+	}
+	if exchangeHits.Load() != 1 {
+		t.Fatalf("exchanges=%d", exchangeHits.Load())
+	}
+	if len(apiAuths) != 2 || apiAuths[0] != "Bearer user-jwt" || apiAuths[1] != "Bearer exchanged-jwt" {
+		t.Fatalf("api auths = %v", apiAuths)
+	}
+}
+
+// TestRoundTripper_Rejects421OffFederation: a 421 to a host not in the
+// responding core's federation manifest is not followed.
+func TestRoundTripper_Rejects421OffFederation(t *testing.T) {
+	homeHits := atomic.Int32{}
+	homeCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		homeHits.Add(1)
+		s.record(r)
+		w.WriteHeader(http.StatusOK)
+	})
+	wrongCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		w.WriteHeader(http.StatusMisdirectedRequest)
+		w.Write([]byte(`{"home_core_url":"` + homeCore.srv.URL + `"}`)) //nolint:errcheck // test
+	})
+	// wrongCore.peers stays empty.
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, wrongCore.srv.URL+"/api/v1/mirrors", nil) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer user-jwt")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMisdirectedRequest {
+		t.Fatalf("got %d, want 421 passthrough", resp.StatusCode)
+	}
+	if homeHits.Load() != 0 {
+		t.Fatalf("REGRESSION: off-federation home core received the JWT (hits=%d)", homeHits.Load())
+	}
+}
+
+// TestRoundTripper_RejectsOffOrigin401ExchangeURL: a hint pointing
+// token_exchange_url off-origin must not leak the JWT.
+func TestRoundTripper_RejectsOffOrigin401ExchangeURL(t *testing.T) {
+	attackerHits := atomic.Int32{}
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attackerHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"access_token":"attacker-issued"}`)) //nolint:errcheck // test
+	}))
+	t.Cleanup(attacker.Close)
+
+	api := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"cross_juris_token_required","token_exchange_url":"` + attacker.URL + `","audience":"https://api.test"}`)) //nolint:errcheck // test
+	})
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, api.srv.URL+"/api/v1/me", nil) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer user-jwt")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("got %d", resp.StatusCode)
+	}
+	if attackerHits.Load() != 0 {
+		t.Fatalf("REGRESSION: attacker host received the JWT (hits=%d)", attackerHits.Load())
+	}
+}
+
+// TestRoundTripper_BodyReplayedOnRetry: a retried request replays its body.
+func TestRoundTripper_BodyReplayedOnRetry(t *testing.T) {
+	const payload = `{"provider":"github","owner":"acme","repo":"widget"}`
+	homeCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		body, _ := io.ReadAll(r.Body) //nolint:errcheck // test
+		if string(body) != payload {
+			t.Errorf("home body = %q", string(body))
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	wrongCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
+		s.record(r)
+		w.WriteHeader(http.StatusMisdirectedRequest)
+		w.Write([]byte(`{"home_core_url":"` + homeCore.srv.URL + `"}`)) //nolint:errcheck // test
+	})
+	wrongCore.peers = []string{homeCore.srv.URL}
+
+	client := &http.Client{Transport: transportFor()}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, wrongCore.srv.URL+"/api/v1/mirrors", bytes.NewReader([]byte(payload))) //nolint:errcheck // test
+	req.Header.Set("Authorization", "Bearer user-jwt")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d", resp.StatusCode)
+	}
+}
+
+// TestValidateExchangeURL pins the scheme / same-origin rules.
+func TestValidateExchangeURL(t *testing.T) {
+	mustParse := func(raw string) *url.URL {
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return u
+	}
+	if err := validateExchangeURL("http://example.test/oauth/token", mustParse("http://example.test/api")); err == nil {
+		t.Error("http non-loopback must be refused")
+	}
+	if err := validateExchangeURL("https://attacker.test/oauth/token", mustParse("https://example.test/api")); err == nil {
+		t.Error("off-origin https must be refused")
+	}
+	if err := validateExchangeURL("https://example.test/oauth/token", mustParse("https://example.test/api")); err != nil {
+		t.Errorf("same-origin https must pass: %v", err)
+	}
+	if err := validateExchangeURL("http://localhost:1234/oauth/token", mustParse("http://localhost:1234/api")); err != nil {
+		t.Errorf("loopback http must pass: %v", err)
+	}
+}
+
+// TestCacheExpiresAfterTTL: expired entries are evicted on lookup.
+func TestCacheExpiresAfterTTL(t *testing.T) {
+	rt := transportFor()
+	rt.storeToken("https://example.test", "tok")
+	if _, ok := rt.lookupToken("https://example.test"); !ok {
+		t.Fatal("fresh token must be a hit")
+	}
+	rt.tokens.Store("https://example.test", cachedExchangedToken{token: "tok", exp: time.Now().Add(-time.Second)})
+	if _, ok := rt.lookupToken("https://example.test"); ok {
+		t.Fatal("expired entry must be evicted")
+	}
+}

--- a/internal/coreapi/cross_juris_transport_test.go
+++ b/internal/coreapi/cross_juris_transport_test.go
@@ -93,6 +93,7 @@ func transportFor() *crossJurisRoundTripper {
 
 // TestRoundTripper_PassThrough: a 2xx is returned unchanged.
 func TestRoundTripper_PassThrough(t *testing.T) {
+	t.Parallel()
 	srv := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
 		s.record(r)
 		w.WriteHeader(http.StatusOK)
@@ -119,6 +120,7 @@ func TestRoundTripper_PassThrough(t *testing.T) {
 // TestRoundTripper_421FollowsToHomeCore: 421 with home_core_url is
 // followed; the home core gets the original bearer on the first hop.
 func TestRoundTripper_421FollowsToHomeCore(t *testing.T) {
+	t.Parallel()
 	homeCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
 		s.record(r)
 		w.WriteHeader(http.StatusOK)
@@ -153,6 +155,7 @@ func TestRoundTripper_421FollowsToHomeCore(t *testing.T) {
 // The transport must still recover by exchanging the original login JWT
 // at the home core's same-origin /oauth/token and retrying.
 func TestRoundTripper_421ThenBareUnauthorizedProactiveExchange(t *testing.T) {
+	t.Parallel()
 	homeExchangeHits := atomic.Int32{}
 	var homeExchangeSubjects, homeAPIAuths authRecorder
 	homeCore := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -208,6 +211,7 @@ func TestRoundTripper_421ThenBareUnauthorizedProactiveExchange(t *testing.T) {
 // TestRoundTripper_BareUnauthorizedNoRedirectPassesThrough: a bare 401
 // on a non-redirected request is a genuine failure — no exchange.
 func TestRoundTripper_BareUnauthorizedNoRedirectPassesThrough(t *testing.T) {
+	t.Parallel()
 	exchangeHits := atomic.Int32{}
 	srv := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == oauthTokenPath {
@@ -240,6 +244,7 @@ func TestRoundTripper_BareUnauthorizedNoRedirectPassesThrough(t *testing.T) {
 
 // TestRoundTripper_401ExchangeAndRetry covers the structured-hint path.
 func TestRoundTripper_401ExchangeAndRetry(t *testing.T) {
+	t.Parallel()
 	exchangeHits := atomic.Int32{}
 	apiHits := atomic.Int32{}
 	var apiAuths authRecorder
@@ -285,6 +290,7 @@ func TestRoundTripper_401ExchangeAndRetry(t *testing.T) {
 // TestRoundTripper_Rejects421OffFederation: a 421 to a host not in the
 // responding core's federation manifest is not followed.
 func TestRoundTripper_Rejects421OffFederation(t *testing.T) {
+	t.Parallel()
 	homeHits := atomic.Int32{}
 	homeCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
 		homeHits.Add(1)
@@ -318,6 +324,7 @@ func TestRoundTripper_Rejects421OffFederation(t *testing.T) {
 // TestRoundTripper_RejectsOffOrigin401ExchangeURL: a hint pointing
 // token_exchange_url off-origin must not leak the JWT.
 func TestRoundTripper_RejectsOffOrigin401ExchangeURL(t *testing.T) {
+	t.Parallel()
 	attackerHits := atomic.Int32{}
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		attackerHits.Add(1)
@@ -351,6 +358,7 @@ func TestRoundTripper_RejectsOffOrigin401ExchangeURL(t *testing.T) {
 
 // TestRoundTripper_BodyReplayedOnRetry: a retried request replays its body.
 func TestRoundTripper_BodyReplayedOnRetry(t *testing.T) {
+	t.Parallel()
 	const payload = `{"provider":"github","owner":"acme","repo":"widget"}`
 	homeCore := newCrossJurisTestServer(t, func(s *crossJurisTestServer, w http.ResponseWriter, r *http.Request) {
 		s.record(r)
@@ -382,6 +390,7 @@ func TestRoundTripper_BodyReplayedOnRetry(t *testing.T) {
 
 // TestValidateExchangeURL pins the scheme / same-origin rules.
 func TestValidateExchangeURL(t *testing.T) {
+	t.Parallel()
 	mustParse := func(raw string) *url.URL {
 		u, err := url.Parse(raw)
 		if err != nil {
@@ -405,6 +414,7 @@ func TestValidateExchangeURL(t *testing.T) {
 
 // TestCacheExpiresAfterTTL: expired entries are evicted on lookup.
 func TestCacheExpiresAfterTTL(t *testing.T) {
+	t.Parallel()
 	rt := transportFor()
 	rt.storeToken("https://example.test", "tok")
 	if _, ok := rt.lookupToken("https://example.test"); !ok {

--- a/internal/coreapi/cross_juris_transport_test.go
+++ b/internal/coreapi/cross_juris_transport_test.go
@@ -416,6 +416,9 @@ func TestValidateExchangeURL(t *testing.T) {
 	if err := validateExchangeURL("http://localhost:1234/oauth/token", mustParse("http://localhost:1234/api")); err != nil {
 		t.Errorf("loopback http must pass: %v", err)
 	}
+	if err := validateExchangeURL("https://example.test/auth/x", mustParse("https://example.test/api")); err == nil {
+		t.Error("non-/oauth/token path must be refused")
+	}
 }
 
 // TestRoundTripper_TokenCacheReusesExchanged confirms the per-origin


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/599
<!-- entire-trail-link-end -->

## What

Control-plane commands (`mirror create/delete/collaborators`, `repo`, `grant`, …) didn't work cross-region. They pinned to the home core, sent the bare login JWT, and had no 421-follow or token exchange. Operating on a resource whose home jurisdiction is another region failed: the home core's 421 surfaced as a generic decode error, and even reaching the foreign core a home-region login JWT can't verify there (local-only JWKS → bare `invalid token` 401, with no `cross_juris_token_required` hint).

## Fix

Wrap the `coreapi` client's transport with a cross-juris `RoundTripper` (`WithClient`):

- Follows a 421's `home_core_url`, gated by the responding core's `/.well-known/entire-federation` manifest.
- After the redirect, a **bare 401** triggers a proactive RFC 8693 exchange at `<home>/oauth/token` — the home core can't verify a foreign-region JWT's signature so it never emits the hint, but its `/oauth/token` federates the sibling JWKS and mints a token it accepts.
- Also handles the structured `cross_juris_token_required` hint.
- Per-origin token cache; HTTPS / same-origin / federation trust gates so the login JWT never leaks off-origin.

Reuses the existing `httputil.PostOAuthToken` primitive. Inert for same-jurisdiction calls.

## Test

Run a control-plane command against a resource in another region (e.g. `entire mirror collaborators ...` for a US-jurisdiction cluster as an EU user) — it now follows the 421 and exchanges automatically instead of erroring.

Mirrors the server-side + entire-core-CLI fix in entirehq/entiredb (no server change needed; the 421 `home_core_url`, federation manifest, and sibling JWKS federation are already in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication transport for all control-plane API calls: redirects, token exchange, and federation trust directly affect whether login JWTs are sent and where; mistakes could break cross-region ops or weaken JWT exfiltration protections.
> 
> **Overview**
> Control-plane **coreapi** clients now use a cross-jurisdiction HTTP transport so mirror/repo/grant-style commands work when a resource’s home region differs from the user’s login region.
> 
> The transport **follows 421** responses using `home_core_url`, but only if the redirect host appears in the responding core’s **`/.well-known/entire-federation`** peer list. After redirect, it handles **`cross_juris_token_required` 401s** and the **bare 401** case (foreign login JWT fails local JWKS) by RFC 8693 **token exchange** at same-origin `/oauth/token`, always using the **original** login JWT as `subject_token`, caching exchanged tokens per origin (~4m TTL), and retrying with buffered request bodies.
> 
> **Trust gates** block off-origin exchange URLs and non-HTTPS targets (except loopback for tests) so server-supplied URLs cannot exfiltrate the login JWT. Same-jurisdiction traffic is unchanged. **`New()`** and **`NewWithBearer()`** both opt in via `WithClient(newCrossJurisHTTPClient())`; tests cover federation rejection, off-origin hints, 421→exchange, and body replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a23ba488acb12548bf61e1882698110d037690b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->