### PR TITLE
feat(copilot): capture Copilot sessions from VS Code agent hooks (Preview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Each agent stores its hook configuration in its own directory. When you run `ent
 | Claude Code      | `.claude/settings.json`       | JSON hooks config |
 | Codex            | `.codex/hooks.json`           | JSON hooks config |
 | Copilot CLI      | `.github/hooks/entire.json`   | JSON hooks config |
+| Copilot (VS Code)| `.github/hooks/entire-vscode.json` | JSON hooks config |
 | Cursor           | `.cursor/hooks.json`          | JSON hooks config |
 | Factory AI Droid | `.factory/settings.json`      | JSON hooks config |
 | Gemini CLI       | `.gemini/settings.json`       | JSON hooks config |
@@ -447,7 +448,7 @@ Local settings override project settings field-by-field. When you run `entire st
 
 - When enabling Entire for Codex, the command will also create or update `.codex/config.toml` with `codex_hooks = true` to enable Codex hooks. If you configure Codex manually, make sure this flag is set in your `.codex/config.toml`. Or select Codex from the interactive agent picker when running `entire enable`.
 - Entire supports Cursor IDE and Cursor Agent CLI tool, but `entire rewind` is not available at this time. Other commands (`doctor`, `status` etc.) work the same as all other agents.
-- Entire supports Copilot CLI, but not Copilot in VS Code, in other IDEs, or on github.com.
+- Entire supports GitHub Copilot in two places: the Copilot CLI (`.github/hooks/entire.json`) and Copilot in VS Code via VS Code's agent hooks (Preview), which Entire wires up in `.github/hooks/entire-vscode.json`. Both are installed together by `entire enable`. Copilot in other IDEs, or on github.com, is not supported.
 - Entire supports Pi coding agent (Preview). Pi uses a TypeScript extension instead of a JSON hook config. Subagent capture is not currently available.
 
 ## Security & Privacy

--- a/cmd/entire/cli/agent/copilotcli/AGENT.md
+++ b/cmd/entire/cli/agent/copilotcli/AGENT.md
@@ -151,6 +151,33 @@ The `TranscriptAnalyzer` interface is implemented for Copilot CLI, providing:
 - No need for read-modify-write of existing files
 - If `entire.json` already exists, read-modify-write to preserve any user additions
 
+## VS Code Agent Hooks (Preview)
+
+`InstallHooks` also writes a second dedicated file, `.github/hooks/entire-vscode.json`,
+so Copilot sessions driven from **VS Code's agent hooks (Preview)** are captured.
+See `vscode_hooks.go`.
+
+Why a separate file is required: VS Code auto-discovers `.github/hooks/*.json` and
+reads Copilot CLI configs by converting lowerCamelCase event names to PascalCase
+(`userPromptSubmitted` → `UserPromptSubmitted`, `agentStop` → `AgentStop`). Those
+converted names are **not** real VS Code events, so the capture-critical turn hooks
+never fire from `entire.json` inside VS Code. The events whose converted names *do*
+line up with a real VS Code event (`sessionStart`, `subagentStop`, `preToolUse`,
+`postToolUse`) are already delivered by VS Code from `entire.json`, so the VS Code
+file only registers the two that don't round-trip:
+
+| VS Code event      | Entire verb              | Lifecycle |
+| ------------------ | ------------------------ | --------- |
+| `UserPromptSubmit` | `user-prompt-submitted`  | TurnStart |
+| `Stop`             | `agent-stop`             | TurnEnd → checkpoint |
+
+Keeping the VS Code file minimal also avoids double-firing the already-covered
+events. VS Code uses the `command` field (not `bash`). The shared
+`entire hooks copilot-cli <verb>` handlers parse both Copilot CLI and VS Code
+payload shapes (`hookEventName`, ISO-8601 `timestamp`, `transcript_path`) — see
+`compat.go` and `parseHookEnvelope`. `entire disable` removes the Entire entries
+from both files, deleting `entire-vscode.json` when nothing user-owned remains.
+
 ## CLI Flags
 
 - Non-interactive prompt (documented): `copilot -p "prompt" --allow-all-tools`

--- a/cmd/entire/cli/agent/copilotcli/AGENT.md
+++ b/cmd/entire/cli/agent/copilotcli/AGENT.md
@@ -164,19 +164,29 @@ converted names are **not** real VS Code events, so the capture-critical turn ho
 never fire from `entire.json` inside VS Code. The events whose converted names *do*
 line up with a real VS Code event (`sessionStart`, `subagentStop`, `preToolUse`,
 `postToolUse`) are already delivered by VS Code from `entire.json`, so the VS Code
-file only registers the two that don't round-trip:
+file only registers the turn events that don't round-trip:
 
 | VS Code event      | Entire verb              | Lifecycle |
 | ------------------ | ------------------------ | --------- |
 | `UserPromptSubmit` | `user-prompt-submitted`  | TurnStart |
 | `Stop`             | `agent-stop`             | TurnEnd → checkpoint |
+| `Stop`             | `session-end`            | Terminal stop → session end |
 
-Keeping the VS Code file minimal also avoids double-firing the already-covered
-events. VS Code uses the `command` field (not `bash`). The shared
-`entire hooks copilot-cli <verb>` handlers parse both Copilot CLI and VS Code
-payload shapes (`hookEventName`, ISO-8601 `timestamp`, `transcript_path`) — see
-`compat.go` and `parseHookEnvelope`. `entire disable` removes the Entire entries
-from both files, deleting `entire-vscode.json` when nothing user-owned remains.
+VS Code uses a single `Stop` event for both end-of-turn and terminal
+session-stop, so both verbs are registered under it. `validateVSCodeEvent`
+(`compat.go`) routes each payload to the matching handler by reason and the
+non-matching handler no-ops; omitting `session-end` would drop terminal
+`SessionEnd` for VS Code-driven sessions. Keeping the file otherwise minimal
+avoids double-firing the already-covered events.
+
+VS Code uses the `command` field (not `bash`), a `timeout` field in seconds (not
+`timeoutSec`), and has no top-level `version` field — so `entire-vscode.json` is
+just `{"hooks": {...}}`. The shared `entire hooks copilot-cli <verb>` handlers
+parse both Copilot CLI and VS Code payload shapes (`hookEventName`, ISO-8601
+`timestamp`, `transcript_path`) — see `compat.go` and `parseHookEnvelope`.
+`entire disable` removes the Entire entries from both files, deleting
+`entire-vscode.json` only when no hooks and no user-added top-level fields remain
+(user hooks and top-level fields are otherwise preserved on round-trip).
 
 ## CLI Flags
 

--- a/cmd/entire/cli/agent/copilotcli/hooks.go
+++ b/cmd/entire/cli/agent/copilotcli/hooks.go
@@ -44,7 +44,7 @@ var hookConfigKey = map[string]string{
 // InstallHooks installs Copilot CLI hooks in .github/hooks/entire.json and the
 // VS Code-native hook file .github/hooks/entire-vscode.json (see vscode_hooks.go).
 // If force is true, removes existing Entire hooks before installing.
-// Returns the number of Copilot CLI hooks installed.
+// Returns the total number of hooks installed across both files.
 // Unknown top-level fields and hook types are preserved on round-trip.
 func (c *CopilotCLIAgent) InstallHooks(ctx context.Context, localDev bool, force bool) (int, error) {
 	worktreeRoot, err := paths.WorktreeRoot(ctx)
@@ -54,7 +54,10 @@ func (c *CopilotCLIAgent) InstallHooks(ctx context.Context, localDev bool, force
 
 	// Install the VS Code-native hook file alongside the Copilot CLI file so
 	// Copilot sessions run from VS Code's agent hooks (Preview) are captured.
-	if err := c.installVSCodeHooks(worktreeRoot, localDev, force); err != nil {
+	// Its additions count toward the total so a fresh VS Code-file write is
+	// reported as an install rather than "already installed".
+	vsCodeCount, err := c.installVSCodeHooks(worktreeRoot, localDev, force)
+	if err != nil {
 		return 0, err
 	}
 
@@ -137,7 +140,8 @@ func (c *CopilotCLIAgent) InstallHooks(ctx context.Context, localDev bool, force
 	}
 
 	if count == 0 {
-		return 0, nil
+		// No Copilot CLI changes, but the VS Code file may have been updated.
+		return vsCodeCount, nil
 	}
 
 	// Marshal modified hook types back into rawHooks
@@ -169,7 +173,7 @@ func (c *CopilotCLIAgent) InstallHooks(ctx context.Context, localDev bool, force
 		return 0, fmt.Errorf("failed to write %s: %w", HooksFileName, err)
 	}
 
-	return count, nil
+	return count + vsCodeCount, nil
 }
 
 // UninstallHooks removes Entire hooks from Copilot CLI's entire.json.

--- a/cmd/entire/cli/agent/copilotcli/hooks.go
+++ b/cmd/entire/cli/agent/copilotcli/hooks.go
@@ -41,14 +41,21 @@ var hookConfigKey = map[string]string{
 	HookNameErrorOccurred:       "errorOccurred",
 }
 
-// InstallHooks installs Copilot CLI hooks in .github/hooks/entire.json.
+// InstallHooks installs Copilot CLI hooks in .github/hooks/entire.json and the
+// VS Code-native hook file .github/hooks/entire-vscode.json (see vscode_hooks.go).
 // If force is true, removes existing Entire hooks before installing.
-// Returns the number of hooks installed.
+// Returns the number of Copilot CLI hooks installed.
 // Unknown top-level fields and hook types are preserved on round-trip.
 func (c *CopilotCLIAgent) InstallHooks(ctx context.Context, localDev bool, force bool) (int, error) {
 	worktreeRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		worktreeRoot = "."
+	}
+
+	// Install the VS Code-native hook file alongside the Copilot CLI file so
+	// Copilot sessions run from VS Code's agent hooks (Preview) are captured.
+	if err := c.installVSCodeHooks(worktreeRoot, localDev, force); err != nil {
+		return 0, err
 	}
 
 	hooksPath := filepath.Join(worktreeRoot, hooksDir, HooksFileName)
@@ -172,6 +179,12 @@ func (c *CopilotCLIAgent) UninstallHooks(ctx context.Context) error {
 	if err != nil {
 		worktreeRoot = "."
 	}
+
+	// Remove the VS Code-native hook file's Entire entries too.
+	if err := c.uninstallVSCodeHooks(worktreeRoot); err != nil {
+		return err
+	}
+
 	hooksPath := filepath.Join(worktreeRoot, hooksDir, HooksFileName)
 	data, err := os.ReadFile(hooksPath) //nolint:gosec // path is constructed from repo root + fixed path
 	if err != nil {
@@ -244,16 +257,18 @@ func (c *CopilotCLIAgent) AreHooksInstalled(ctx context.Context) bool {
 		if !errors.Is(err, os.ErrNotExist) {
 			logging.Warn(ctx, "copilot-cli: failed to read hooks file", "path", hooksPath, "err", err)
 		}
-		return false
+		// The Copilot CLI file may be absent while the VS Code file is present.
+		return c.areVSCodeHooksInstalled(worktreeRoot)
 	}
 
 	var hooksFile CopilotHooksFile
 	if err := json.Unmarshal(data, &hooksFile); err != nil {
 		logging.Warn(ctx, "copilot-cli: failed to parse hooks file", "path", hooksPath, "err", err)
-		return false
+		return c.areVSCodeHooksInstalled(worktreeRoot)
 	}
 
-	return hasEntireHook(hooksFile.Hooks.UserPromptSubmitted) ||
+	return c.areVSCodeHooksInstalled(worktreeRoot) ||
+		hasEntireHook(hooksFile.Hooks.UserPromptSubmitted) ||
 		hasEntireHook(hooksFile.Hooks.SessionStart) ||
 		hasEntireHook(hooksFile.Hooks.AgentStop) ||
 		hasEntireHook(hooksFile.Hooks.SessionEnd) ||

--- a/cmd/entire/cli/agent/copilotcli/hooks_test.go
+++ b/cmd/entire/cli/agent/copilotcli/hooks_test.go
@@ -22,8 +22,9 @@ func TestInstallHooks_FreshInstall(t *testing.T) {
 		t.Fatalf("InstallHooks() error = %v", err)
 	}
 
-	if count != 8 {
-		t.Errorf("InstallHooks() count = %d, want 8", count)
+	// 8 Copilot CLI hooks + 3 VS Code hooks (user-prompt-submitted, agent-stop, session-end).
+	if count != 11 {
+		t.Errorf("InstallHooks() count = %d, want 11", count)
 	}
 
 	hooksFile := readHooksFile(t, tempDir)
@@ -87,8 +88,8 @@ func TestInstallHooks_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first InstallHooks() error = %v", err)
 	}
-	if count1 != 8 {
-		t.Errorf("first InstallHooks() count = %d, want 8", count1)
+	if count1 != 11 {
+		t.Errorf("first InstallHooks() count = %d, want 11", count1)
 	}
 
 	// Second install
@@ -189,8 +190,8 @@ func TestInstallHooks_ForceReinstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("force InstallHooks() error = %v", err)
 	}
-	if count != 8 {
-		t.Errorf("force InstallHooks() count = %d, want 8", count)
+	if count != 11 {
+		t.Errorf("force InstallHooks() count = %d, want 11", count)
 	}
 
 	// Verify no duplicates
@@ -271,8 +272,8 @@ func TestInstallHooks_PreservesUnknownFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InstallHooks() error = %v", err)
 	}
-	if count != 8 {
-		t.Errorf("InstallHooks() count = %d, want 8", count)
+	if count != 11 {
+		t.Errorf("InstallHooks() count = %d, want 11", count)
 	}
 
 	// Read the raw JSON to verify unknown fields are preserved

--- a/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
+++ b/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
@@ -1,0 +1,272 @@
+package copilotcli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
+)
+
+// VSCodeHooksFileName is the VS Code-native hook file managed by Entire. It is
+// installed alongside the Copilot CLI file (HooksFileName) so Copilot sessions
+// driven from VS Code's agent hooks (Preview) are captured. See AGENT.md.
+const VSCodeHooksFileName = "entire-vscode.json"
+
+// vsCodeManagedEvents lists the VS Code events Entire registers in
+// entire-vscode.json, paired with the CLI hook verb each one invokes.
+//
+// Only the two turn hooks are registered here. VS Code reads Copilot CLI
+// configs by converting lowerCamelCase event names to PascalCase
+// (userPromptSubmitted -> UserPromptSubmitted, agentStop -> AgentStop). Those
+// converted names are not real VS Code events, so the capture-critical turn
+// hooks never fire from entire.json inside VS Code. The events whose converted
+// names line up with a real VS Code event (SessionStart, SubagentStop,
+// PreToolUse, PostToolUse) are already delivered by VS Code from entire.json,
+// so registering them here too would only double-fire them.
+var vsCodeManagedEvents = []struct {
+	Event string // VS Code hookEventName (PascalCase)
+	Verb  string // Entire CLI hook verb
+}{
+	{VSCodeEventUserPromptSubmit, HookNameUserPromptSubmitted},
+	{VSCodeEventStop, HookNameAgentStop},
+}
+
+// VSCodeHookEntry represents a single VS Code hook command. VS Code uses the
+// "command" field rather than Copilot CLI's "bash" field. Unknown top-level
+// file fields and unknown event types are preserved on round-trip via raw maps;
+// known optional per-entry fields are retained explicitly.
+type VSCodeHookEntry struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Comment string `json:"comment,omitempty"`
+}
+
+// vsCodeHookCommand builds the command string for a VS Code hook verb. In
+// production it is wrapped so a missing Entire CLI exits cleanly; the shared
+// "entire hooks copilot-cli <verb>" handlers parse VS Code payload shapes.
+func vsCodeHookCommand(verb string, localDev bool) string {
+	if localDev {
+		return agent.LocalDevHookScript + " hooks copilot-cli " + verb
+	}
+	return agent.WrapProductionSilentHookCommand("entire hooks copilot-cli " + verb)
+}
+
+// installVSCodeHooks writes/updates .github/hooks/entire-vscode.json with the
+// VS Code turn hooks. If force is true, existing Entire entries are removed
+// before installing. Unknown fields and event types are preserved on round-trip.
+func (c *CopilotCLIAgent) installVSCodeHooks(worktreeRoot string, localDev bool, force bool) error {
+	hooksPath := filepath.Join(worktreeRoot, hooksDir, VSCodeHooksFileName)
+
+	rawFile, rawHooks, err := readVSCodeHooksFile(hooksPath)
+	if err != nil {
+		return err
+	}
+	if rawFile == nil {
+		rawFile = map[string]json.RawMessage{"version": json.RawMessage(`1`)}
+	}
+	if rawHooks == nil {
+		rawHooks = make(map[string]json.RawMessage)
+	}
+
+	for _, h := range vsCodeManagedEvents {
+		var entries []VSCodeHookEntry
+		if err := parseVSCodeHookEvent(rawHooks, h.Event, &entries); err != nil {
+			return err
+		}
+		if force {
+			entries = removeEntireVSCodeHooks(entries)
+		}
+		cmd := vsCodeHookCommand(h.Verb, localDev)
+		if !vsCodeCommandExists(entries, cmd) {
+			entries = append(entries, VSCodeHookEntry{
+				Type:    "command",
+				Command: cmd,
+				Comment: "Entire CLI",
+			})
+		}
+		if err := marshalVSCodeHookEvent(rawHooks, h.Event, entries); err != nil {
+			return err
+		}
+	}
+
+	return writeVSCodeHooksFile(hooksPath, rawFile, rawHooks)
+}
+
+// uninstallVSCodeHooks removes Entire entries from entire-vscode.json. When no
+// hooks of any event type remain afterwards (nothing user-owned), the file is
+// deleted rather than left as an empty shell.
+func (c *CopilotCLIAgent) uninstallVSCodeHooks(worktreeRoot string) error {
+	hooksPath := filepath.Join(worktreeRoot, hooksDir, VSCodeHooksFileName)
+
+	rawFile, rawHooks, err := readVSCodeHooksFile(hooksPath)
+	if err != nil {
+		return err
+	}
+	if rawFile == nil {
+		return nil // No file means nothing to uninstall.
+	}
+
+	for _, h := range vsCodeManagedEvents {
+		var entries []VSCodeHookEntry
+		if err := parseVSCodeHookEvent(rawHooks, h.Event, &entries); err != nil {
+			return err
+		}
+		entries = removeEntireVSCodeHooks(entries)
+		if err := marshalVSCodeHookEvent(rawHooks, h.Event, entries); err != nil {
+			return err
+		}
+	}
+
+	// If nothing user-owned remains, remove the file entirely.
+	if len(rawHooks) == 0 {
+		if err := os.Remove(hooksPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to remove %s: %w", VSCodeHooksFileName, err)
+		}
+		return nil
+	}
+
+	return writeVSCodeHooksFile(hooksPath, rawFile, rawHooks)
+}
+
+// areVSCodeHooksInstalled reports whether any Entire hook is present in
+// entire-vscode.json.
+func (c *CopilotCLIAgent) areVSCodeHooksInstalled(worktreeRoot string) bool {
+	hooksPath := filepath.Join(worktreeRoot, hooksDir, VSCodeHooksFileName)
+	rawFile, rawHooks, err := readVSCodeHooksFile(hooksPath)
+	if err != nil || rawFile == nil {
+		return false
+	}
+	for _, h := range vsCodeManagedEvents {
+		var entries []VSCodeHookEntry
+		if err := parseVSCodeHookEvent(rawHooks, h.Event, &entries); err != nil {
+			return false
+		}
+		if hasEntireVSCodeHook(entries) {
+			return true
+		}
+	}
+	return false
+}
+
+// readVSCodeHooksFile reads and parses entire-vscode.json into raw maps,
+// preserving unknown fields. Returns (nil, nil, nil) when the file is absent so
+// callers can distinguish "missing" from "empty". A "version" field is ensured
+// when the file exists.
+func readVSCodeHooksFile(hooksPath string) (rawFile, rawHooks map[string]json.RawMessage, err error) {
+	data, readErr := os.ReadFile(hooksPath) //nolint:gosec // path is constructed from repo root + fixed path
+	switch {
+	case readErr == nil:
+		if err := json.Unmarshal(data, &rawFile); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse %s: %w", VSCodeHooksFileName, err)
+		}
+		if hooksRaw, ok := rawFile["hooks"]; ok {
+			if err := json.Unmarshal(hooksRaw, &rawHooks); err != nil {
+				return nil, nil, fmt.Errorf("failed to parse hooks in %s: %w", VSCodeHooksFileName, err)
+			}
+		}
+		if _, ok := rawFile["version"]; !ok {
+			rawFile["version"] = json.RawMessage(`1`)
+		}
+	case errors.Is(readErr, os.ErrNotExist):
+		return nil, nil, nil
+	default:
+		return nil, nil, fmt.Errorf("failed to read %s: %w", VSCodeHooksFileName, readErr)
+	}
+
+	if rawHooks == nil {
+		rawHooks = make(map[string]json.RawMessage)
+	}
+	return rawFile, rawHooks, nil
+}
+
+// writeVSCodeHooksFile marshals rawHooks back into rawFile and writes it,
+// creating the hooks directory if needed. When no hooks remain the "hooks" key
+// is dropped rather than written as an empty object.
+func writeVSCodeHooksFile(hooksPath string, rawFile, rawHooks map[string]json.RawMessage) error {
+	if rawFile == nil {
+		rawFile = map[string]json.RawMessage{"version": json.RawMessage(`1`)}
+	}
+
+	if len(rawHooks) > 0 {
+		hooksJSON, err := jsonutil.MarshalWithNoHTMLEscape(rawHooks)
+		if err != nil {
+			return fmt.Errorf("failed to marshal hooks: %w", err)
+		}
+		rawFile["hooks"] = hooksJSON
+	} else {
+		delete(rawFile, "hooks")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o750); err != nil {
+		return fmt.Errorf("failed to create %s directory: %w", hooksDir, err)
+	}
+
+	output, err := jsonutil.MarshalIndentWithNewline(rawFile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s: %w", VSCodeHooksFileName, err)
+	}
+	if err := os.WriteFile(hooksPath, output, 0o600); err != nil {
+		return fmt.Errorf("failed to write %s: %w", VSCodeHooksFileName, err)
+	}
+	return nil
+}
+
+// parseVSCodeHookEvent parses a specific event's entries from rawHooks.
+func parseVSCodeHookEvent(rawHooks map[string]json.RawMessage, event string, target *[]VSCodeHookEntry) error {
+	if data, ok := rawHooks[event]; ok {
+		if err := json.Unmarshal(data, target); err != nil {
+			return fmt.Errorf("invalid JSON for VS Code event %s: %w", event, err)
+		}
+	}
+	return nil
+}
+
+// marshalVSCodeHookEvent marshals an event's entries back into rawHooks,
+// removing the key when the slice is empty.
+func marshalVSCodeHookEvent(rawHooks map[string]json.RawMessage, event string, entries []VSCodeHookEntry) error {
+	if len(entries) == 0 {
+		delete(rawHooks, event)
+		return nil
+	}
+	data, err := jsonutil.MarshalWithNoHTMLEscape(entries)
+	if err != nil {
+		return fmt.Errorf("failed to marshal VS Code event %s: %w", event, err)
+	}
+	rawHooks[event] = data
+	return nil
+}
+
+// vsCodeCommandExists reports whether an entry with the given command already exists.
+func vsCodeCommandExists(entries []VSCodeHookEntry, command string) bool {
+	for _, entry := range entries {
+		if entry.Command == command {
+			return true
+		}
+	}
+	return false
+}
+
+// hasEntireVSCodeHook reports whether any entry is an Entire hook.
+func hasEntireVSCodeHook(entries []VSCodeHookEntry) bool {
+	for _, entry := range entries {
+		if isEntireHook(entry.Command) {
+			return true
+		}
+	}
+	return false
+}
+
+// removeEntireVSCodeHooks returns entries with all Entire hooks removed.
+func removeEntireVSCodeHooks(entries []VSCodeHookEntry) []VSCodeHookEntry {
+	result := make([]VSCodeHookEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !isEntireHook(entry.Command) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}

--- a/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
+++ b/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
@@ -19,20 +19,27 @@ const VSCodeHooksFileName = "entire-vscode.json"
 // vsCodeManagedEvents lists the VS Code events Entire registers in
 // entire-vscode.json, paired with the CLI hook verb each one invokes.
 //
-// Only the two turn hooks are registered here. VS Code reads Copilot CLI
-// configs by converting lowerCamelCase event names to PascalCase
-// (userPromptSubmitted -> UserPromptSubmitted, agentStop -> AgentStop). Those
-// converted names are not real VS Code events, so the capture-critical turn
-// hooks never fire from entire.json inside VS Code. The events whose converted
-// names line up with a real VS Code event (SessionStart, SubagentStop,
-// PreToolUse, PostToolUse) are already delivered by VS Code from entire.json,
-// so registering them here too would only double-fire them.
+// Only the turn hooks are registered here. VS Code reads Copilot CLI configs by
+// converting lowerCamelCase event names to PascalCase (userPromptSubmitted ->
+// UserPromptSubmitted, agentStop -> AgentStop). Those converted names are not
+// real VS Code events, so the capture-critical turn hooks never fire from
+// entire.json inside VS Code. The events whose converted names line up with a
+// real VS Code event (SessionStart, SubagentStop, PreToolUse, PostToolUse) are
+// already delivered by VS Code from entire.json, so registering them here too
+// would only double-fire them.
+//
+// VS Code uses a single "Stop" event for both end-of-turn and terminal
+// session-stop, where Copilot CLI distinguishes agent-stop from session-end.
+// We therefore register BOTH verbs under "Stop"; validateVSCodeEvent (compat.go)
+// routes each payload to the matching handler by reason, and the non-matching
+// handler no-ops. Omitting session-end here would drop terminal SessionEnd
+// events for VS Code-driven sessions.
 var vsCodeManagedEvents = []struct {
-	Event string // VS Code hookEventName (PascalCase)
-	Verb  string // Entire CLI hook verb
+	Event string   // VS Code hookEventName (PascalCase)
+	Verbs []string // Entire CLI hook verbs registered under that event
 }{
-	{VSCodeEventUserPromptSubmit, HookNameUserPromptSubmitted},
-	{VSCodeEventStop, HookNameAgentStop},
+	{VSCodeEventUserPromptSubmit, []string{HookNameUserPromptSubmitted}},
+	{VSCodeEventStop, []string{HookNameAgentStop, HookNameSessionEnd}},
 }
 
 // VSCodeHookEntry represents a single VS Code hook command. VS Code uses the
@@ -58,12 +65,13 @@ func vsCodeHookCommand(verb string, localDev bool) string {
 // installVSCodeHooks writes/updates .github/hooks/entire-vscode.json with the
 // VS Code turn hooks. If force is true, existing Entire entries are removed
 // before installing. Unknown fields and event types are preserved on round-trip.
-func (c *CopilotCLIAgent) installVSCodeHooks(worktreeRoot string, localDev bool, force bool) error {
+// Returns the number of hook entries newly added.
+func (c *CopilotCLIAgent) installVSCodeHooks(worktreeRoot string, localDev bool, force bool) (int, error) {
 	hooksPath := filepath.Join(worktreeRoot, hooksDir, VSCodeHooksFileName)
 
 	rawFile, rawHooks, err := readVSCodeHooksFile(hooksPath)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if rawFile == nil {
 		rawFile = map[string]json.RawMessage{"version": json.RawMessage(`1`)}
@@ -72,33 +80,45 @@ func (c *CopilotCLIAgent) installVSCodeHooks(worktreeRoot string, localDev bool,
 		rawHooks = make(map[string]json.RawMessage)
 	}
 
+	count := 0
 	for _, h := range vsCodeManagedEvents {
 		var entries []VSCodeHookEntry
 		if err := parseVSCodeHookEvent(rawHooks, h.Event, &entries); err != nil {
-			return err
+			return 0, err
 		}
 		if force {
 			entries = removeEntireVSCodeHooks(entries)
 		}
-		cmd := vsCodeHookCommand(h.Verb, localDev)
-		if !vsCodeCommandExists(entries, cmd) {
-			entries = append(entries, VSCodeHookEntry{
-				Type:    "command",
-				Command: cmd,
-				Comment: "Entire CLI",
-			})
+		// All verbs share one event, so remove-on-force happens once above; then
+		// add each missing verb. Doing the force-removal per verb would wipe a
+		// sibling verb added earlier in this same loop.
+		for _, verb := range h.Verbs {
+			cmd := vsCodeHookCommand(verb, localDev)
+			if !vsCodeCommandExists(entries, cmd) {
+				entries = append(entries, VSCodeHookEntry{
+					Type:    "command",
+					Command: cmd,
+					Comment: "Entire CLI",
+				})
+				count++
+			}
 		}
 		if err := marshalVSCodeHookEvent(rawHooks, h.Event, entries); err != nil {
-			return err
+			return 0, err
 		}
 	}
 
-	return writeVSCodeHooksFile(hooksPath, rawFile, rawHooks)
+	if err := writeVSCodeHooksFile(hooksPath, rawFile, rawHooks); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
-// uninstallVSCodeHooks removes Entire entries from entire-vscode.json. When no
-// hooks of any event type remain afterwards (nothing user-owned), the file is
-// deleted rather than left as an empty shell.
+// uninstallVSCodeHooks removes Entire entries from entire-vscode.json. When the
+// file holds nothing user-owned afterwards (no hooks of any event type and no
+// top-level fields beyond the structural version/hooks keys Entire writes), it
+// is deleted rather than left as an empty shell. If the user added their own
+// hooks or top-level fields, those are preserved and the file is rewritten.
 func (c *CopilotCLIAgent) uninstallVSCodeHooks(worktreeRoot string) error {
 	hooksPath := filepath.Join(worktreeRoot, hooksDir, VSCodeHooksFileName)
 
@@ -121,8 +141,9 @@ func (c *CopilotCLIAgent) uninstallVSCodeHooks(worktreeRoot string) error {
 		}
 	}
 
-	// If nothing user-owned remains, remove the file entirely.
-	if len(rawHooks) == 0 {
+	// Delete the file only when nothing user-owned remains: no hooks left and no
+	// top-level fields other than the structural ones Entire itself writes.
+	if len(rawHooks) == 0 && !hasUserTopLevelFields(rawFile) {
 		if err := os.Remove(hooksPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to remove %s: %w", VSCodeHooksFileName, err)
 		}
@@ -130,6 +151,18 @@ func (c *CopilotCLIAgent) uninstallVSCodeHooks(worktreeRoot string) error {
 	}
 
 	return writeVSCodeHooksFile(hooksPath, rawFile, rawHooks)
+}
+
+// hasUserTopLevelFields reports whether rawFile carries any top-level key beyond
+// the structural "version" and "hooks" keys Entire manages — i.e. fields a user
+// added that must survive uninstall.
+func hasUserTopLevelFields(rawFile map[string]json.RawMessage) bool {
+	for key := range rawFile {
+		if key != "version" && key != "hooks" {
+			return true
+		}
+	}
+	return false
 }
 
 // areVSCodeHooksInstalled reports whether any Entire hook is present in

--- a/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
+++ b/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
@@ -185,12 +185,9 @@ func readVSCodeHooksFile(hooksPath string) (rawFile, rawHooks map[string]json.Ra
 
 // writeVSCodeHooksFile marshals rawHooks back into rawFile and writes it,
 // creating the hooks directory if needed. When no hooks remain the "hooks" key
-// is dropped rather than written as an empty object.
+// is dropped rather than written as an empty object. Callers must pass a
+// non-nil rawFile (with its "version" already set).
 func writeVSCodeHooksFile(hooksPath string, rawFile, rawHooks map[string]json.RawMessage) error {
-	if rawFile == nil {
-		rawFile = map[string]json.RawMessage{"version": json.RawMessage(`1`)}
-	}
-
 	if len(rawHooks) > 0 {
 		hooksJSON, err := jsonutil.MarshalWithNoHTMLEscape(rawHooks)
 		if err != nil {

--- a/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
+++ b/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
@@ -43,13 +43,22 @@ var vsCodeManagedEvents = []struct {
 }
 
 // VSCodeHookEntry represents a single VS Code hook command. VS Code uses the
-// "command" field rather than Copilot CLI's "bash" field. Unknown top-level
-// file fields and unknown event types are preserved on round-trip via raw maps;
-// known optional per-entry fields are retained explicitly.
+// "command" field rather than Copilot CLI's "bash" field, and a "timeout" field
+// in seconds (not Copilot CLI's "timeoutSec"). Unknown top-level file fields and
+// unknown event types are preserved on round-trip via raw maps; the optional
+// per-entry fields VS Code documents are retained explicitly so user-authored
+// entries survive a rewrite. See the schema at
+// https://code.visualstudio.com/docs/copilot/customization/hooks.
 type VSCodeHookEntry struct {
-	Type    string `json:"type"`
-	Command string `json:"command"`
-	Comment string `json:"comment,omitempty"`
+	Type    string            `json:"type"`
+	Command string            `json:"command"`
+	Windows string            `json:"windows,omitempty"`
+	Linux   string            `json:"linux,omitempty"`
+	Osx     string            `json:"osx,omitempty"`
+	Cwd     string            `json:"cwd,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+	Timeout int               `json:"timeout,omitempty"`
+	Comment string            `json:"comment,omitempty"`
 }
 
 // vsCodeHookCommand builds the command string for a VS Code hook verb. In
@@ -74,7 +83,9 @@ func (c *CopilotCLIAgent) installVSCodeHooks(worktreeRoot string, localDev bool,
 		return 0, err
 	}
 	if rawFile == nil {
-		rawFile = map[string]json.RawMessage{"version": json.RawMessage(`1`)}
+		// VS Code's hook schema has no top-level "version" field (unlike the
+		// Copilot CLI's entire.json), so a fresh file is just {"hooks": {...}}.
+		rawFile = make(map[string]json.RawMessage)
 	}
 	if rawHooks == nil {
 		rawHooks = make(map[string]json.RawMessage)
@@ -154,8 +165,9 @@ func (c *CopilotCLIAgent) uninstallVSCodeHooks(worktreeRoot string) error {
 }
 
 // hasUserTopLevelFields reports whether rawFile carries any top-level key beyond
-// the structural "version" and "hooks" keys Entire manages — i.e. fields a user
-// added that must survive uninstall.
+// the structural ones — i.e. fields a user added that must survive uninstall.
+// "hooks" is structural; "version" is not part of the VS Code schema but older
+// Entire builds wrote it, so it is treated as non-user to keep cleanup working.
 func hasUserTopLevelFields(rawFile map[string]json.RawMessage) bool {
 	for key := range rawFile {
 		if key != "version" && key != "hooks" {
@@ -187,8 +199,7 @@ func (c *CopilotCLIAgent) areVSCodeHooksInstalled(worktreeRoot string) bool {
 
 // readVSCodeHooksFile reads and parses entire-vscode.json into raw maps,
 // preserving unknown fields. Returns (nil, nil, nil) when the file is absent so
-// callers can distinguish "missing" from "empty". A "version" field is ensured
-// when the file exists.
+// callers can distinguish "missing" from "empty".
 func readVSCodeHooksFile(hooksPath string) (rawFile, rawHooks map[string]json.RawMessage, err error) {
 	data, readErr := os.ReadFile(hooksPath) //nolint:gosec // path is constructed from repo root + fixed path
 	switch {
@@ -200,9 +211,6 @@ func readVSCodeHooksFile(hooksPath string) (rawFile, rawHooks map[string]json.Ra
 			if err := json.Unmarshal(hooksRaw, &rawHooks); err != nil {
 				return nil, nil, fmt.Errorf("failed to parse hooks in %s: %w", VSCodeHooksFileName, err)
 			}
-		}
-		if _, ok := rawFile["version"]; !ok {
-			rawFile["version"] = json.RawMessage(`1`)
 		}
 	case errors.Is(readErr, os.ErrNotExist):
 		return nil, nil, nil
@@ -219,7 +227,7 @@ func readVSCodeHooksFile(hooksPath string) (rawFile, rawHooks map[string]json.Ra
 // writeVSCodeHooksFile marshals rawHooks back into rawFile and writes it,
 // creating the hooks directory if needed. When no hooks remain the "hooks" key
 // is dropped rather than written as an empty object. Callers must pass a
-// non-nil rawFile (with its "version" already set).
+// non-nil rawFile.
 func writeVSCodeHooksFile(hooksPath string, rawFile, rawHooks map[string]json.RawMessage) error {
 	if len(rawHooks) > 0 {
 		hooksJSON, err := jsonutil.MarshalWithNoHTMLEscape(rawHooks)

--- a/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
+++ b/cmd/entire/cli/agent/copilotcli/vscode_hooks.go
@@ -119,6 +119,14 @@ func (c *CopilotCLIAgent) installVSCodeHooks(worktreeRoot string, localDev bool,
 		}
 	}
 
+	// Nothing was added — all managed hooks are already present — so leave the
+	// file untouched rather than rewriting identical content and churning its
+	// formatting. (Under force the canonical verbs are always re-added, so
+	// count > 0 there; count == 0 strictly means no change.)
+	if count == 0 {
+		return 0, nil
+	}
+
 	if err := writeVSCodeHooksFile(hooksPath, rawFile, rawHooks); err != nil {
 		return 0, err
 	}

--- a/cmd/entire/cli/agent/copilotcli/vscode_hooks_test.go
+++ b/cmd/entire/cli/agent/copilotcli/vscode_hooks_test.go
@@ -23,11 +23,9 @@ func readVSCodeFile(t *testing.T, tempDir string) map[string][]VSCodeHookEntry {
 	require.NoError(t, err)
 
 	var file struct {
-		Version int                          `json:"version"`
-		Hooks   map[string][]VSCodeHookEntry `json:"hooks"`
+		Hooks map[string][]VSCodeHookEntry `json:"hooks"`
 	}
 	require.NoError(t, json.Unmarshal(data, &file))
-	require.Equal(t, 1, file.Version, "version field")
 	return file.Hooks
 }
 
@@ -39,6 +37,11 @@ func TestInstallVSCodeHooks_FreshInstall(t *testing.T) {
 	count, err := ag.installVSCodeHooks(tempDir, false, false)
 	require.NoError(t, err)
 	require.Equal(t, 3, count, "user-prompt-submitted + agent-stop + session-end")
+
+	// VS Code's schema has no top-level "version" field; a fresh file is just hooks.
+	raw, err := os.ReadFile(vsCodeHooksPath(tempDir))
+	require.NoError(t, err)
+	require.NotContains(t, string(raw), `"version"`, "fresh VS Code file must not carry a version field")
 
 	hooks := readVSCodeFile(t, tempDir)
 
@@ -123,6 +126,50 @@ func TestInstallVSCodeHooks_PreservesUserHooks(t *testing.T) {
 	data, err := os.ReadFile(vsCodeHooksPath(tempDir))
 	require.NoError(t, err)
 	require.Contains(t, string(data), "keep-me")
+}
+
+func TestInstallVSCodeHooks_PreservesUserEntryFields(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	// A user Stop entry exercising every optional VS Code field.
+	seed := `{
+  "hooks": {
+    "Stop": [
+      {
+        "type": "command",
+        "command": "./scripts/notify.sh",
+        "windows": "scripts\\notify.ps1",
+        "linux": "./scripts/notify-linux.sh",
+        "osx": "./scripts/notify-mac.sh",
+        "cwd": "tools",
+        "env": {"FOO": "bar"},
+        "timeout": 20
+      }
+    ]
+  }
+}`
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, hooksDir), 0o755))
+	require.NoError(t, os.WriteFile(vsCodeHooksPath(tempDir), []byte(seed), 0o600))
+
+	ag := &CopilotCLIAgent{}
+	_, err := ag.installVSCodeHooks(tempDir, false, false)
+	require.NoError(t, err)
+
+	hooks := readVSCodeFile(t, tempDir)
+	var user VSCodeHookEntry
+	for _, e := range hooks[VSCodeEventStop] {
+		if e.Command == "./scripts/notify.sh" {
+			user = e
+		}
+	}
+	require.Equal(t, "./scripts/notify.sh", user.Command, "user entry must survive the rewrite")
+	require.Equal(t, `scripts\notify.ps1`, user.Windows)
+	require.Equal(t, "./scripts/notify-linux.sh", user.Linux)
+	require.Equal(t, "./scripts/notify-mac.sh", user.Osx)
+	require.Equal(t, "tools", user.Cwd)
+	require.Equal(t, map[string]string{"FOO": "bar"}, user.Env)
+	require.Equal(t, 20, user.Timeout)
 }
 
 func TestUninstallVSCodeHooks_DeletesWhenEmpty(t *testing.T) {

--- a/cmd/entire/cli/agent/copilotcli/vscode_hooks_test.go
+++ b/cmd/entire/cli/agent/copilotcli/vscode_hooks_test.go
@@ -36,14 +36,17 @@ func TestInstallVSCodeHooks_FreshInstall(t *testing.T) {
 	tempDir := t.TempDir()
 
 	ag := &CopilotCLIAgent{}
-	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+	count, err := ag.installVSCodeHooks(tempDir, false, false)
+	require.NoError(t, err)
+	require.Equal(t, 3, count, "user-prompt-submitted + agent-stop + session-end")
 
 	hooks := readVSCodeFile(t, tempDir)
 
 	// Only the two turn events are registered; the rest come from entire.json.
 	require.Len(t, hooks, 2, "only UserPromptSubmit and Stop should be registered")
 	require.Len(t, hooks[VSCodeEventUserPromptSubmit], 1)
-	require.Len(t, hooks[VSCodeEventStop], 1)
+	// VS Code's single Stop event carries both agent-stop and session-end.
+	require.Len(t, hooks[VSCodeEventStop], 2)
 
 	ups := hooks[VSCodeEventUserPromptSubmit][0]
 	require.Equal(t, "command", ups.Type)
@@ -53,9 +56,21 @@ func TestInstallVSCodeHooks_FreshInstall(t *testing.T) {
 		ups.Command,
 		"VS Code uses the command field, not bash")
 
-	require.Equal(t,
-		agent.WrapProductionSilentHookCommand("entire hooks copilot-cli agent-stop"),
-		hooks[VSCodeEventStop][0].Command)
+	stopCommands := commandsOf(hooks[VSCodeEventStop])
+	require.Contains(t, stopCommands,
+		agent.WrapProductionSilentHookCommand("entire hooks copilot-cli agent-stop"))
+	require.Contains(t, stopCommands,
+		agent.WrapProductionSilentHookCommand("entire hooks copilot-cli session-end"),
+		"terminal VS Code Stop must route to session-end")
+}
+
+// commandsOf extracts the command strings from a slice of hook entries.
+func commandsOf(entries []VSCodeHookEntry) []string {
+	cmds := make([]string, len(entries))
+	for i, e := range entries {
+		cmds[i] = e.Command
+	}
+	return cmds
 }
 
 func TestInstallVSCodeHooks_Idempotent(t *testing.T) {
@@ -63,12 +78,15 @@ func TestInstallVSCodeHooks_Idempotent(t *testing.T) {
 	tempDir := t.TempDir()
 
 	ag := &CopilotCLIAgent{}
-	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
-	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+	_, err := ag.installVSCodeHooks(tempDir, false, false)
+	require.NoError(t, err)
+	count, err := ag.installVSCodeHooks(tempDir, false, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, count, "reinstall adds nothing")
 
 	hooks := readVSCodeFile(t, tempDir)
 	require.Len(t, hooks[VSCodeEventUserPromptSubmit], 1, "must not duplicate on reinstall")
-	require.Len(t, hooks[VSCodeEventStop], 1)
+	require.Len(t, hooks[VSCodeEventStop], 2, "agent-stop + session-end, no duplicates")
 }
 
 func TestInstallVSCodeHooks_PreservesUserHooks(t *testing.T) {
@@ -92,12 +110,14 @@ func TestInstallVSCodeHooks_PreservesUserHooks(t *testing.T) {
 	require.NoError(t, os.WriteFile(vsCodeHooksPath(tempDir), []byte(seed), 0o600))
 
 	ag := &CopilotCLIAgent{}
-	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+	_, err := ag.installVSCodeHooks(tempDir, false, false)
+	require.NoError(t, err)
 
 	hooks := readVSCodeFile(t, tempDir)
-	require.Len(t, hooks[VSCodeEventStop], 2, "user Stop hook retained alongside Entire's")
+	require.Len(t, hooks[VSCodeEventStop], 3, "user Stop hook retained alongside Entire's agent-stop + session-end")
 	require.Len(t, hooks[VSCodeEventPreToolUse], 1, "unknown event type preserved")
 	require.Equal(t, "echo user-pretool", hooks[VSCodeEventPreToolUse][0].Command)
+	require.Contains(t, commandsOf(hooks[VSCodeEventStop]), "echo user-stop", "user Stop hook survives")
 
 	// Unknown top-level field is preserved on round-trip.
 	data, err := os.ReadFile(vsCodeHooksPath(tempDir))
@@ -110,12 +130,13 @@ func TestUninstallVSCodeHooks_DeletesWhenEmpty(t *testing.T) {
 	tempDir := t.TempDir()
 
 	ag := &CopilotCLIAgent{}
-	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+	_, err := ag.installVSCodeHooks(tempDir, false, false)
+	require.NoError(t, err)
 	require.True(t, ag.areVSCodeHooksInstalled(tempDir))
 
 	require.NoError(t, ag.uninstallVSCodeHooks(tempDir))
 
-	_, err := os.Stat(vsCodeHooksPath(tempDir))
+	_, err = os.Stat(vsCodeHooksPath(tempDir))
 	require.ErrorIs(t, err, os.ErrNotExist, "file removed when nothing user-owned remains")
 	require.False(t, ag.areVSCodeHooksInstalled(tempDir))
 }
@@ -125,7 +146,8 @@ func TestUninstallVSCodeHooks_KeepsUserHooks(t *testing.T) {
 	tempDir := t.TempDir()
 
 	ag := &CopilotCLIAgent{}
-	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+	_, err := ag.installVSCodeHooks(tempDir, false, false)
+	require.NoError(t, err)
 
 	// Add a user-owned hook to the Stop event.
 	rawFile, rawHooks, err := readVSCodeHooksFile(vsCodeHooksPath(tempDir))
@@ -158,12 +180,42 @@ func TestInstallVSCodeHooks_ForceReinstall(t *testing.T) {
 	tempDir := t.TempDir()
 
 	ag := &CopilotCLIAgent{}
-	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
-	require.NoError(t, ag.installVSCodeHooks(tempDir, false, true))
+	_, err := ag.installVSCodeHooks(tempDir, false, false)
+	require.NoError(t, err)
+	_, err = ag.installVSCodeHooks(tempDir, false, true)
+	require.NoError(t, err)
 
 	hooks := readVSCodeFile(t, tempDir)
 	require.Len(t, hooks[VSCodeEventUserPromptSubmit], 1)
-	require.Len(t, hooks[VSCodeEventStop], 1)
+	require.Len(t, hooks[VSCodeEventStop], 2, "force reinstall keeps both agent-stop + session-end")
+}
+
+func TestUninstallVSCodeHooks_PreservesUserTopLevelFields(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	// File with only Entire-managed hooks but a user-added top-level field.
+	seed := `{
+  "version": 1,
+  "customField": "keep-me",
+  "hooks": {
+    "Stop": [
+      {"type": "command", "command": "` + agent.WrapProductionSilentHookCommand("entire hooks copilot-cli agent-stop") + `"}
+    ]
+  }
+}`
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, hooksDir), 0o755))
+	require.NoError(t, os.WriteFile(vsCodeHooksPath(tempDir), []byte(seed), 0o600))
+
+	ag := &CopilotCLIAgent{}
+	require.NoError(t, ag.uninstallVSCodeHooks(tempDir))
+
+	// File must survive (custom field) but Entire's hook is gone.
+	require.FileExists(t, vsCodeHooksPath(tempDir), "file kept because customField is user-owned")
+	data, err := os.ReadFile(vsCodeHooksPath(tempDir))
+	require.NoError(t, err)
+	require.Contains(t, string(data), "keep-me")
+	require.False(t, ag.areVSCodeHooksInstalled(tempDir))
 }
 
 func TestInstallHooks_AlsoInstallsVSCodeFile(t *testing.T) {

--- a/cmd/entire/cli/agent/copilotcli/vscode_hooks_test.go
+++ b/cmd/entire/cli/agent/copilotcli/vscode_hooks_test.go
@@ -1,0 +1,194 @@
+package copilotcli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/stretchr/testify/require"
+)
+
+// vsCodeHooksPath is the path to the VS Code hook file under a temp repo root.
+func vsCodeHooksPath(tempDir string) string {
+	return filepath.Join(tempDir, ".github", "hooks", VSCodeHooksFileName)
+}
+
+// readVSCodeFile reads and parses entire-vscode.json from a temp repo root.
+func readVSCodeFile(t *testing.T, tempDir string) map[string][]VSCodeHookEntry {
+	t.Helper()
+	data, err := os.ReadFile(vsCodeHooksPath(tempDir))
+	require.NoError(t, err)
+
+	var file struct {
+		Version int                          `json:"version"`
+		Hooks   map[string][]VSCodeHookEntry `json:"hooks"`
+	}
+	require.NoError(t, json.Unmarshal(data, &file))
+	require.Equal(t, 1, file.Version, "version field")
+	return file.Hooks
+}
+
+func TestInstallVSCodeHooks_FreshInstall(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	ag := &CopilotCLIAgent{}
+	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+
+	hooks := readVSCodeFile(t, tempDir)
+
+	// Only the two turn events are registered; the rest come from entire.json.
+	require.Len(t, hooks, 2, "only UserPromptSubmit and Stop should be registered")
+	require.Len(t, hooks[VSCodeEventUserPromptSubmit], 1)
+	require.Len(t, hooks[VSCodeEventStop], 1)
+
+	ups := hooks[VSCodeEventUserPromptSubmit][0]
+	require.Equal(t, "command", ups.Type)
+	require.Equal(t, "Entire CLI", ups.Comment)
+	require.Equal(t,
+		agent.WrapProductionSilentHookCommand("entire hooks copilot-cli user-prompt-submitted"),
+		ups.Command,
+		"VS Code uses the command field, not bash")
+
+	require.Equal(t,
+		agent.WrapProductionSilentHookCommand("entire hooks copilot-cli agent-stop"),
+		hooks[VSCodeEventStop][0].Command)
+}
+
+func TestInstallVSCodeHooks_Idempotent(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	ag := &CopilotCLIAgent{}
+	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+
+	hooks := readVSCodeFile(t, tempDir)
+	require.Len(t, hooks[VSCodeEventUserPromptSubmit], 1, "must not duplicate on reinstall")
+	require.Len(t, hooks[VSCodeEventStop], 1)
+}
+
+func TestInstallVSCodeHooks_PreservesUserHooks(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	// A user-managed hook plus an unknown event type and unknown top-level field.
+	seed := `{
+  "version": 1,
+  "customField": "keep-me",
+  "hooks": {
+    "Stop": [
+      {"type": "command", "command": "echo user-stop"}
+    ],
+    "PreToolUse": [
+      {"type": "command", "command": "echo user-pretool"}
+    ]
+  }
+}`
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, hooksDir), 0o755))
+	require.NoError(t, os.WriteFile(vsCodeHooksPath(tempDir), []byte(seed), 0o600))
+
+	ag := &CopilotCLIAgent{}
+	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+
+	hooks := readVSCodeFile(t, tempDir)
+	require.Len(t, hooks[VSCodeEventStop], 2, "user Stop hook retained alongside Entire's")
+	require.Len(t, hooks[VSCodeEventPreToolUse], 1, "unknown event type preserved")
+	require.Equal(t, "echo user-pretool", hooks[VSCodeEventPreToolUse][0].Command)
+
+	// Unknown top-level field is preserved on round-trip.
+	data, err := os.ReadFile(vsCodeHooksPath(tempDir))
+	require.NoError(t, err)
+	require.Contains(t, string(data), "keep-me")
+}
+
+func TestUninstallVSCodeHooks_DeletesWhenEmpty(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	ag := &CopilotCLIAgent{}
+	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+	require.True(t, ag.areVSCodeHooksInstalled(tempDir))
+
+	require.NoError(t, ag.uninstallVSCodeHooks(tempDir))
+
+	_, err := os.Stat(vsCodeHooksPath(tempDir))
+	require.ErrorIs(t, err, os.ErrNotExist, "file removed when nothing user-owned remains")
+	require.False(t, ag.areVSCodeHooksInstalled(tempDir))
+}
+
+func TestUninstallVSCodeHooks_KeepsUserHooks(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	ag := &CopilotCLIAgent{}
+	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+
+	// Add a user-owned hook to the Stop event.
+	rawFile, rawHooks, err := readVSCodeHooksFile(vsCodeHooksPath(tempDir))
+	require.NoError(t, err)
+	var stop []VSCodeHookEntry
+	require.NoError(t, parseVSCodeHookEvent(rawHooks, VSCodeEventStop, &stop))
+	stop = append(stop, VSCodeHookEntry{Type: "command", Command: "echo user"})
+	require.NoError(t, marshalVSCodeHookEvent(rawHooks, VSCodeEventStop, stop))
+	require.NoError(t, writeVSCodeHooksFile(vsCodeHooksPath(tempDir), rawFile, rawHooks))
+
+	require.NoError(t, ag.uninstallVSCodeHooks(tempDir))
+
+	hooks := readVSCodeFile(t, tempDir)
+	require.Len(t, hooks[VSCodeEventStop], 1, "user hook survives")
+	require.Equal(t, "echo user", hooks[VSCodeEventStop][0].Command)
+	require.Empty(t, hooks[VSCodeEventUserPromptSubmit], "Entire turn hook removed")
+	require.False(t, ag.areVSCodeHooksInstalled(tempDir))
+}
+
+func TestUninstallVSCodeHooks_NoFile(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	ag := &CopilotCLIAgent{}
+	require.NoError(t, ag.uninstallVSCodeHooks(tempDir), "no file is a no-op")
+}
+
+func TestInstallVSCodeHooks_ForceReinstall(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	ag := &CopilotCLIAgent{}
+	require.NoError(t, ag.installVSCodeHooks(tempDir, false, false))
+	require.NoError(t, ag.installVSCodeHooks(tempDir, false, true))
+
+	hooks := readVSCodeFile(t, tempDir)
+	require.Len(t, hooks[VSCodeEventUserPromptSubmit], 1)
+	require.Len(t, hooks[VSCodeEventStop], 1)
+}
+
+func TestInstallHooks_AlsoInstallsVSCodeFile(t *testing.T) {
+	// No t.Parallel(): t.Chdir mutates process-global cwd.
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &CopilotCLIAgent{}
+	_, err := ag.InstallHooks(context.Background(), false, false)
+	require.NoError(t, err)
+
+	require.FileExists(t, vsCodeHooksPath(tempDir), "InstallHooks must write the VS Code file too")
+	require.True(t, ag.AreHooksInstalled(context.Background()))
+}
+
+func TestUninstallHooks_AlsoRemovesVSCodeFile(t *testing.T) {
+	// No t.Parallel(): t.Chdir mutates process-global cwd.
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	ag := &CopilotCLIAgent{}
+	_, err := ag.InstallHooks(context.Background(), false, false)
+	require.NoError(t, err)
+
+	require.NoError(t, ag.UninstallHooks(context.Background()))
+	_, err = os.Stat(vsCodeHooksPath(tempDir))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/601
<!-- entire-trail-link-end -->

## Summary

Adds capture support for GitHub Copilot sessions driven from **VS Code's agent hooks (Preview)**, on top of the existing Copilot CLI support.

## Why a separate hook file

VS Code auto-discovers `.github/hooks/*.json` and reads Copilot CLI configs by converting lowerCamelCase event names to PascalCase (`userPromptSubmitted` → `UserPromptSubmitted`, `agentStop` → `AgentStop`). Those converted names are **not** real VS Code events, so the capture-critical turn hooks never fire from `entire.json` inside VS Code.

The events whose converted names *do* line up with a real VS Code event (`sessionStart`, `subagentStop`, `preToolUse`, `postToolUse`) are already delivered from `entire.json`. So the new `.github/hooks/entire-vscode.json` registers only the two that don't round-trip:

| VS Code event      | Entire verb             | Lifecycle            |
| ------------------ | ----------------------- | -------------------- |
| `UserPromptSubmit` | `user-prompt-submitted` | TurnStart            |
| `Stop`             | `agent-stop`            | TurnEnd → checkpoint |

VS Code uses the `command` field (not `bash`); the shared `entire hooks copilot-cli <verb>` handlers already parse both payload shapes (see `compat.go`).

## Changes

- **`hooks.go`** (from gist): `InstallHooks` / `UninstallHooks` now also manage the VS Code file; `AreHooksInstalled` considers it too.
- **`vscode_hooks.go`** (new): the install/uninstall/detection implementation. Round-trips unknown fields and event types, removes only Entire-managed entries on uninstall, and deletes `entire-vscode.json` when nothing user-owned remains.
- **`vscode_hooks_test.go`** (new): fresh install, idempotency, force reinstall, user-hook preservation, file deletion when empty, and end-to-end `InstallHooks`/`UninstallHooks` coverage.
- **`README.md` / `AGENT.md`** (from gist): docs.

## Testing

- `mise run fmt && mise run lint` — clean
- `mise run test` — all 6458 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Copilot hook file management under `.github/hooks/` with tests; reuses existing copilot-cli hook handlers and payload parsing in compat.go.
> 
> **Overview**
> Adds **GitHub Copilot in VS Code** (agent hooks Preview) to the same `entire enable` / `entire disable` flow as Copilot CLI, without changing how CLI hooks in `entire.json` work.
> 
> **New hook file** `.github/hooks/entire-vscode.json` registers only **`UserPromptSubmit`** and **`Stop`** with VS Code’s `command` field (not CLI `bash`), because VS Code’s PascalCase mapping from CLI event names never fires the turn hooks from `entire.json`. Other lifecycle events still come from `entire.json` inside VS Code to avoid double-firing. Install/uninstall preserves user hooks and unknown JSON fields; uninstall deletes the file when only Entire entries remain.
> 
> **`hooks.go`** calls the new VS Code install/uninstall helpers and treats the VS Code file as part of “hooks installed” detection when the CLI file is missing or unreadable.
> 
> Docs in **README** and **AGENT.md** document the second hook location and Copilot VS Code support. **`vscode_hooks_test.go`** covers idempotency, force reinstall, user-hook preservation, and end-to-end `InstallHooks` / `UninstallHooks`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a07d35c573a62ea0daf96814088b07dfd174363. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->