### PR TITLE
entire trail create binds a trail without delivering the branch

### DIFF
--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -79,12 +79,8 @@ type TrailCreateRequest struct {
 	Title      string `json:"title"`
 	Body       string `json:"body,omitempty"`
 	BranchName string `json:"branch_name"`
-	// BranchAction tells the server how to bind BranchName. The CLI always
-	// pushes the branch to the remote before creating the trail, so it sends
-	// "link" to attach the already-delivered branch. This prevents the server
-	// from backfilling a backing branch at the base tip when the branch was
-	// never delivered (which would silently anchor the trail to empty/diverged
-	// content). Valid values: "create" (default, server-side) or "link".
+	// BranchAction is "create" (default) or "link". The CLI sends "link" to
+	// attach the already-pushed branch instead of backfilling it at base.
 	BranchAction string   `json:"branch_action,omitempty"`
 	Base         string   `json:"base,omitempty"`
 	Status       string   `json:"status,omitempty"`

--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -76,15 +76,22 @@ func (r *TrailResource) ToMetadata() *trail.Metadata {
 
 // TrailCreateRequest is the body for POST /api/v1/trails/:host/:owner/:repo.
 type TrailCreateRequest struct {
-	Title      string   `json:"title"`
-	Body       string   `json:"body,omitempty"`
-	BranchName string   `json:"branch_name"`
-	Base       string   `json:"base,omitempty"`
-	Status     string   `json:"status,omitempty"`
-	Assignees  []string `json:"assignees,omitempty"`
-	Labels     []string `json:"labels,omitempty"`
-	Priority   string   `json:"priority,omitempty"`
-	Type       string   `json:"type,omitempty"`
+	Title      string `json:"title"`
+	Body       string `json:"body,omitempty"`
+	BranchName string `json:"branch_name"`
+	// BranchAction tells the server how to bind BranchName. The CLI always
+	// pushes the branch to the remote before creating the trail, so it sends
+	// "link" to attach the already-delivered branch. This prevents the server
+	// from backfilling a backing branch at the base tip when the branch was
+	// never delivered (which would silently anchor the trail to empty/diverged
+	// content). Valid values: "create" (default, server-side) or "link".
+	BranchAction string   `json:"branch_action,omitempty"`
+	Base         string   `json:"base,omitempty"`
+	Status       string   `json:"status,omitempty"`
+	Assignees    []string `json:"assignees,omitempty"`
+	Labels       []string `json:"labels,omitempty"`
+	Priority     string   `json:"priority,omitempty"`
+	Type         string   `json:"type,omitempty"`
 }
 
 // TrailCreateResponse is the response from POST /api/v1/trails/:org/:repo.

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -352,6 +352,9 @@ func CheckoutBranch(ctx context.Context, ref string) error {
 // ValidateBranchName checks if a branch name is valid using git check-ref-format.
 // Returns an error if the name is invalid or contains unsafe characters.
 func ValidateBranchName(ctx context.Context, branchName string) error {
+	if strings.HasPrefix(branchName, "-") {
+		return fmt.Errorf("invalid branch name %q", branchName)
+	}
 	cmd := exec.CommandContext(ctx, "git", "check-ref-format", "--branch", branchName)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("invalid branch name %q", branchName)

--- a/cmd/entire/cli/git_operations_test.go
+++ b/cmd/entire/cli/git_operations_test.go
@@ -37,6 +37,12 @@ func initOpenedTestRepo(t *testing.T, dir string) *git.Repository {
 	return repo
 }
 
+func TestValidateBranchNameRejectsLeadingDash(t *testing.T) {
+	err := ValidateBranchName(context.Background(), "--all")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid branch name")
+}
+
 func TestGetCurrentBranch(t *testing.T) {
 	// Create temp directory for test repo
 	tmpDir := t.TempDir()

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -642,12 +642,21 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		fmt.Fprintf(w, "Note: trail will be created for branch %q (not the current branch)\n", branch)
 	}
 
-	if needsCreation {
-		// needsCreation is a local-only signal, so the branch may still exist on
-		// origin (e.g. a teammate pushed it and we never fetched). In that case the
-		// remote branch is not ours, and our push may merely fast-forward it; we
-		// must not delete it during cleanup. Only treat the remote branch as
-		// created-by-us when it did not already exist before our push.
+	// Delivering the branch to origin is a PRECONDITION for trail creation, not
+	// an optional follow-up. A trail binds to a *remote* branch; if the branch
+	// never reaches origin the server has nothing to anchor to and backfills it
+	// at the base tip, producing a trail whose backing branch does not reflect
+	// the user's work (local branch, remote branch, and actual work all differ).
+	// We therefore always push and hard-fail on error, regardless of whether we
+	// created the branch locally. (Previously this was gated on needsCreation,
+	// so `git checkout -b foo && entire trail create --branch foo` created the
+	// trail without ever pushing foo.)
+	{
+		// branchExistsOnOrigin tells us whether origin already has this branch
+		// (e.g. a teammate pushed it, or we pushed it on a previous run). In that
+		// case our push may merely fast-forward it and we must not delete it
+		// during cleanup. Only treat the remote branch as created-by-us when it
+		// did not already exist before our push.
 		existedOnOrigin, existErr := branchExistsOnOrigin(branch)
 		if existErr != nil {
 			// Be conservative: if we cannot tell, do not delete the remote branch.
@@ -656,7 +665,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		}
 		if err := pushBranchToOrigin(branch); err != nil {
 			cleanupCreatedTrailBranch(repo, branch, localBranchCreated, false, errW)
-			return fmt.Errorf("failed to push branch %q: %w", branch, err)
+			return fmt.Errorf("failed to push branch %q to origin: %w\nhint: the trail was not created because its branch could not be delivered to the remote.\n  - if this is an auth error, link your GitHub account and retry\n  - if this is a non-fast-forward, update your base (git fetch && git rebase) and retry", branch, err)
 		}
 		remoteBranchPushed = !existedOnOrigin
 		fmt.Fprintf(w, "Pushed branch %s to origin\n", branch)
@@ -666,8 +675,11 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		Title:      title,
 		Body:       body,
 		BranchName: branch,
-		Base:       base,
-		Status:     statusStr,
+		// We pushed the branch to origin above, so ask the server to link the
+		// already-delivered branch rather than backfill it at the base tip.
+		BranchAction: "link",
+		Base:         base,
+		Status:       statusStr,
 	}
 
 	var createResp api.TrailCreateResponse

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -673,15 +673,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		fmt.Fprintf(w, "Pushed branch %s to origin\n", branch)
 	}
 
-	createReq := api.TrailCreateRequest{
-		Title:      title,
-		Body:       body,
-		BranchName: branch,
-		// Branch already pushed above; link it instead of backfilling at base.
-		BranchAction: "link",
-		Base:         base,
-		Status:       statusStr,
-	}
+	createReq := newTrailCreateRequest(title, body, branch, base, statusStr)
 
 	var createResp api.TrailCreateResponse
 	resp, err := client.Post(ctx, trailsBasePath(forge, owner, repoName), createReq)
@@ -726,6 +718,17 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 	}
 
 	return nil
+}
+
+func newTrailCreateRequest(title, body, branch, base, statusStr string) api.TrailCreateRequest {
+	return api.TrailCreateRequest{
+		Title:        title,
+		Body:         body,
+		BranchName:   branch,
+		BranchAction: "link",
+		Base:         base,
+		Status:       statusStr,
+	}
 }
 
 func newTrailUpdateCmd() *cobra.Command {

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -642,24 +642,13 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		fmt.Fprintf(w, "Note: trail will be created for branch %q (not the current branch)\n", branch)
 	}
 
-	// Delivering the branch to origin is a PRECONDITION for trail creation, not
-	// an optional follow-up. A trail binds to a *remote* branch; if the branch
-	// never reaches origin the server has nothing to anchor to and backfills it
-	// at the base tip, producing a trail whose backing branch does not reflect
-	// the user's work (local branch, remote branch, and actual work all differ).
-	// We therefore always push and hard-fail on error, regardless of whether we
-	// created the branch locally. (Previously this was gated on needsCreation,
-	// so `git checkout -b foo && entire trail create --branch foo` created the
-	// trail without ever pushing foo.)
+	// Always push the branch first: the trail binds to a remote branch, so
+	// deliver it before creating the trail rather than letting the server
+	// backfill it at the base tip.
 	{
-		// branchExistsOnOrigin tells us whether origin already has this branch
-		// (e.g. a teammate pushed it, or we pushed it on a previous run). In that
-		// case our push may merely fast-forward it and we must not delete it
-		// during cleanup. Only treat the remote branch as created-by-us when it
-		// did not already exist before our push.
+		// Don't delete a remote branch we didn't create during cleanup.
 		existedOnOrigin, existErr := branchExistsOnOrigin(branch)
 		if existErr != nil {
-			// Be conservative: if we cannot tell, do not delete the remote branch.
 			fmt.Fprintf(errW, "Warning: could not check whether branch %s already exists on origin: %v\n", branch, existErr)
 			existedOnOrigin = true
 		}
@@ -675,8 +664,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		Title:      title,
 		Body:       body,
 		BranchName: branch,
-		// We pushed the branch to origin above, so ask the server to link the
-		// already-delivered branch rather than backfill it at the base tip.
+		// Branch already pushed above; link it instead of backfilling at base.
 		BranchAction: "link",
 		Base:         base,
 		Status:       statusStr,

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -631,7 +631,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 	}
 
 	localBranchCreated := false
-	remoteBranchPushed := false
+	var remoteBranchPushed bool
 	if needsCreation {
 		if err := createBranch(repo, branch); err != nil {
 			return fmt.Errorf("failed to create branch %q: %w", branch, err)

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -559,7 +559,7 @@ func newTrailCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&body, "body", "", "Trail body")
 	cmd.Flags().StringVar(&base, "base", "", "Base branch (defaults to detected default branch)")
 	cmd.Flags().StringVar(&branch, "branch", "", "Branch for the trail (defaults to current branch)")
-	cmd.Flags().StringVar(&status, "status", "", "Initial status (defaults to draft)")
+	cmd.Flags().StringVar(&status, "status", "", "Initial status (defaults to open)")
 	cmd.Flags().BoolVar(&checkout, "checkout", false, "Check out the branch after creating it")
 
 	return cmd
@@ -613,7 +613,7 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 		return errors.New("branch name is required")
 	}
 	if statusStr == "" {
-		statusStr = string(trail.StatusDraft)
+		statusStr = string(trail.StatusOpen)
 	}
 	if status := trail.Status(statusStr); !status.IsValid() {
 		return fmt.Errorf("invalid status %q: valid values are %s", statusStr, formatValidStatuses())
@@ -1149,7 +1149,7 @@ func runTrailCreateInteractive(title, body, branch, statusStr *string) error {
 		statusOptions = append(statusOptions, huh.NewOption(string(s), string(s)))
 	}
 	if *statusStr == "" {
-		*statusStr = string(trail.StatusDraft)
+		*statusStr = string(trail.StatusOpen)
 	}
 
 	form = NewAccessibleForm(

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -635,12 +635,28 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 
 	localBranchCreated := false
 	var remoteBranchPushed bool
+
+	// Don't delete a remote branch we didn't create during cleanup.
+	existedOnOrigin, existErr := branchExistsOnOrigin(branch)
+	if existErr != nil {
+		fmt.Fprintf(errW, "Warning: could not check whether branch %s already exists on origin: %v\n", branch, existErr)
+		existedOnOrigin = true
+	}
+
 	if needsCreation {
-		if err := createBranch(repo, branch); err != nil {
-			return fmt.Errorf("failed to create branch %q: %w", branch, err)
+		if existedOnOrigin {
+			if err := fetchBranchFromOrigin(branch); err != nil {
+				return fmt.Errorf("failed to fetch branch %q from origin: %w", branch, err)
+			}
+			localBranchCreated = true
+			fmt.Fprintf(w, "Fetched branch %s from origin\n", branch)
+		} else {
+			if err := createBranch(repo, branch); err != nil {
+				return fmt.Errorf("failed to create branch %q: %w", branch, err)
+			}
+			localBranchCreated = true
+			fmt.Fprintf(w, "Created branch %s\n", branch)
 		}
-		localBranchCreated = true
-		fmt.Fprintf(w, "Created branch %s\n", branch)
 	} else if currentBranch != branch {
 		fmt.Fprintf(w, "Note: trail will be created for branch %q (not the current branch)\n", branch)
 	}
@@ -649,15 +665,9 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 	// deliver it before creating the trail rather than letting the server
 	// backfill it at the base tip.
 	{
-		// Don't delete a remote branch we didn't create during cleanup.
-		existedOnOrigin, existErr := branchExistsOnOrigin(branch)
-		if existErr != nil {
-			fmt.Fprintf(errW, "Warning: could not check whether branch %s already exists on origin: %v\n", branch, existErr)
-			existedOnOrigin = true
-		}
 		if err := pushBranchToOrigin(branch); err != nil {
 			cleanupCreatedTrailBranch(repo, branch, localBranchCreated, false, errW)
-			return fmt.Errorf("failed to push branch %q to origin: %w\nhint: the trail was not created because its branch could not be delivered to the remote.\n  - if this is an auth error, link your GitHub account and retry\n  - if this is a non-fast-forward, update your base (git fetch && git rebase) and retry", branch, err)
+			return fmt.Errorf("failed to push branch %q to origin: %w\nhint: the trail was not created because its branch could not be delivered to the remote.\n  - if this is an auth error, link your GitHub account and retry\n  - if this is a non-fast-forward, update branch %q from origin and retry", branch, err, branch)
 		}
 		remoteBranchPushed = !existedOnOrigin
 		fmt.Fprintf(w, "Pushed branch %s to origin\n", branch)
@@ -1394,6 +1404,20 @@ func cleanupCreatedTrailBranch(repo *git.Repository, branchName string, localCre
 			fmt.Fprintf(errW, "Warning: failed to delete remote branch %s after trail creation failed: %v\n", branchName, err)
 		}
 	}
+}
+
+func fetchBranchFromOrigin(branchName string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	if err := ValidateBranchName(ctx, branchName); err != nil {
+		return err
+	}
+	refspec := fmt.Sprintf("refs/heads/%s:refs/heads/%s", branchName, branchName)
+	cmd := exec.CommandContext(ctx, "git", "fetch", "--no-tags", "origin", refspec)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(output)), err)
+	}
+	return nil
 }
 
 // pushBranchToOrigin pushes a branch to the origin remote.

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -612,6 +612,9 @@ func runTrailCreate(cmd *cobra.Command, title, body, base, branch, statusStr str
 	if branch == "" {
 		return errors.New("branch name is required")
 	}
+	if err := ValidateBranchName(ctx, branch); err != nil {
+		return err
+	}
 	if statusStr == "" {
 		statusStr = string(trail.StatusOpen)
 	}

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -23,13 +24,133 @@ import (
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
+	"github.com/go-git/go-git/v6"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 )
 
 const (
 	trailListTestAuthorAlice = "alice"
 	trailListTestAuthorBob   = "bob"
 )
+
+func TestNewTrailCreateRequestUsesLinkBranchAction(t *testing.T) {
+	req := newTrailCreateRequest("title", "body", "feature/x", "main", "open")
+
+	require.Equal(t, api.TrailCreateRequest{
+		Title:        "title",
+		Body:         "body",
+		BranchName:   "feature/x",
+		BranchAction: "link",
+		Base:         "main",
+		Status:       "open",
+	}, req)
+}
+
+func TestCleanupCreatedTrailBranch(t *testing.T) {
+	cases := []struct {
+		name             string
+		localCreated     bool
+		remotePushed     bool
+		checkoutBranch   bool
+		wantLocalBranch  bool
+		wantRemoteBranch bool
+	}{
+		{
+			name:             "removes local branch only",
+			localCreated:     true,
+			remotePushed:     false,
+			wantLocalBranch:  false,
+			wantRemoteBranch: false,
+		},
+		{
+			name:             "removes local and pushed remote branch",
+			localCreated:     true,
+			remotePushed:     true,
+			wantLocalBranch:  false,
+			wantRemoteBranch: false,
+		},
+		{
+			name:             "does not delete remote when checked out branch cannot be removed locally",
+			localCreated:     true,
+			remotePushed:     true,
+			checkoutBranch:   true,
+			wantLocalBranch:  true,
+			wantRemoteBranch: true,
+		},
+		{
+			name:             "deletes remote when local was not created by cleanup owner",
+			localCreated:     false,
+			remotePushed:     true,
+			wantLocalBranch:  true,
+			wantRemoteBranch: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			branch := "cleanup-test"
+			localDir, originDir, repo := initTrailCleanupRepo(t)
+			defer repo.Close()
+			t.Chdir(localDir)
+
+			runGitTrailTest(t, localDir, "branch", branch)
+			if tc.remotePushed {
+				runGitTrailTest(t, localDir, "push", "origin", branch)
+			}
+			if tc.checkoutBranch {
+				runGitTrailTest(t, localDir, "checkout", branch)
+			}
+
+			var errBuf bytes.Buffer
+			cleanupCreatedTrailBranch(repo, branch, tc.localCreated, tc.remotePushed, &errBuf)
+
+			require.Equal(t, tc.wantLocalBranch, gitBranchExistsTrailTest(t, localDir, branch), "local branch mismatch; stderr: %s", errBuf.String())
+			require.Equal(t, tc.wantRemoteBranch, gitBranchExistsTrailTest(t, originDir, branch), "remote branch mismatch; stderr: %s", errBuf.String())
+			if tc.checkoutBranch {
+				require.Contains(t, errBuf.String(), "not deleting remote branch")
+			}
+		})
+	}
+}
+
+func initTrailCleanupRepo(t *testing.T) (localDir, originDir string, repo *git.Repository) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	localDir = filepath.Join(tmp, "local")
+	originDir = filepath.Join(tmp, "origin.git")
+	require.NoError(t, os.MkdirAll(localDir, 0o755))
+	runGitTrailTest(t, tmp, "init", "--bare", originDir)
+	repo = initOpenedTestRepo(t, localDir)
+	testutil.WriteFile(t, localDir, "README.md", "test\n")
+	runGitTrailTest(t, localDir, "add", "README.md")
+	runGitTrailTest(t, localDir, "commit", "-m", "initial")
+	runGitTrailTest(t, localDir, "remote", "add", "origin", originDir)
+	return localDir, originDir, repo
+}
+
+func runGitTrailTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %s failed: %s", strings.Join(args, " "), strings.TrimSpace(string(output)))
+}
+
+func gitBranchExistsTrailTest(t *testing.T, repoDir, branch string) bool {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	cmd.Dir = repoDir
+	err := cmd.Run()
+	if err == nil {
+		return true
+	}
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 1, exitErr.ExitCode())
+	return false
+}
 
 func TestRunTrailListAll_PrintsLoginHintWhenNotLoggedIn(t *testing.T) {
 	// No t.Parallel: SetResolveContextForAPIForTest and


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/602
<!-- entire-trail-link-end -->

Problem: 'entire trail create' only pushed the branch to origin when the CLI itself created it locally (needsCreation). If the branch already existed locally — e.g. 'git checkout -b foo && entire trail create --branch foo' — the push was skipped entirely, yet the trail was still created and 'Created trail' printed.

The branch never reached the remote, so the server had nothing to anchor to and backfilled it at the base tip. Result: local branch, remote branch, and actual work were three different things, and a failed/absent push surfaced only as a warning while the command reported success.

Fix: always push the branch to origin as a precondition for trail creation (hard-fail on auth/non-fast-forward errors), and send branch_action=link so the server attaches the delivered branch instead of backfilling at base.

<!-- entire-shadow-pr -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the trail-create contract with the API and always runs git push before create, which can fail or affect remotes for branches that previously skipped push.
> 
> **Overview**
> **`entire trail create` now pushes the branch to origin before calling the API**, so a trail is not created unless its branch exists on the remote. The create request sets **`branch_action: link`** so the server attaches that remote branch instead of backfilling a branch at the base tip.
> 
> Default **initial status** changes from **draft** to **open** (CLI flags, non-interactive default, and interactive form). Push failures return a clearer error (trail not created) with hints for auth and non-fast-forward cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 813099712ee96fd8b7e3689a16d566d7cd404b25. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->