### PR TITLE
strategy: stop resolvePushSettings tests from fetching github.com

### DIFF
--- a/cmd/entire/cli/strategy/checkpoint_remote_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_remote_test.go
@@ -322,6 +322,12 @@ func TestResolvePushSettings_WithCheckpointRemote_HTTPS(t *testing.T) {
 		0o644,
 	))
 
+	// Seed the local v1 metadata branch so resolvePushSettings finds it and
+	// skips fetchMetadataBranchIfMissing. Without it the test fetches the
+	// resolved checkpoint URL from github.com for real — slow, flaky, and it
+	// triggers the OS keychain credential helper when GitHub returns 401.
+	runCheckpointRemoteGit(ctx, t, localDir, "branch", paths.MetadataBranchName)
+
 	t.Chdir(localDir)
 
 	ps := resolvePushSettings(ctx, "origin")
@@ -353,6 +359,12 @@ func TestResolvePushSettings_WithCheckpointRemote_SSH(t *testing.T) {
 		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`),
 		0o644,
 	))
+
+	// Seed the local v1 metadata branch so resolvePushSettings finds it and
+	// skips fetchMetadataBranchIfMissing. Without it the test fetches the
+	// resolved checkpoint URL from github.com for real — slow, flaky, and it
+	// triggers the OS keychain credential helper when GitHub returns 401.
+	runCheckpointRemoteGit(ctx, t, localDir, "branch", paths.MetadataBranchName)
 
 	t.Chdir(localDir)
 
@@ -417,6 +429,12 @@ func TestResolvePushSettings_CheckpointURLDoesNotAffectRemoteField(t *testing.T)
 		[]byte(`{"enabled": true, "strategy_options": {"checkpoint_remote": {"provider": "github", "repo": "org/checkpoints"}}}`),
 		0o644,
 	))
+
+	// Seed the local v1 metadata branch so resolvePushSettings finds it and
+	// skips fetchMetadataBranchIfMissing. Without it the test fetches the
+	// resolved checkpoint URL from github.com for real — slow, flaky, and it
+	// triggers the OS keychain credential helper when GitHub returns 401.
+	runCheckpointRemoteGit(ctx, t, localDir, "branch", paths.MetadataBranchName)
 
 	t.Chdir(localDir)
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/605
<!-- entire-trail-link-end -->

## Why

Three `TestResolvePushSettings_*` tests in `checkpoint_remote_test.go` were doing a **real network fetch against github.com**, which blocks on a macOS keychain prompt and is slow/flaky in CI.

Each test configures a `checkpoint_remote` of `{github, org/checkpoints}` and calls `resolvePushSettings`, but never creates a local `entire/checkpoints/v1` branch. `resolvePushSettings` → `fetchMetadataBranchIfMissing` then runs a live `git fetch` against the resolved checkpoint URL (`https://github.com/org/checkpoints.git` / its SSH form). GitHub returns `401 Basic realm="GitHub"`, git invokes its `osxkeychain` credential helper, and the run stalls on a keychain access prompt.

Found while reviewing #1454 — this is a **pre-existing bug on `main`**, unrelated to that PR and unrelated to the token-store isolation in #1450 (this is git's own credential helper, a different subsystem).

## What changed

Seed the local `entire/checkpoints/v1` branch in the three affected tests (via the existing `runCheckpointRemoteGit` helper) so `fetchMetadataBranchIfMissing` finds it and short-circuits before fetching. The `pushTarget()` / `hasCheckpointURL()` assertions are unaffected — `checkpointURL` is resolved before the fetch.

The two owner-mismatch tests (`ForkDetection`, `FetchURL_IgnoresOwnerMismatchCheck`) already return before the fetch, so they're left untouched.

## Verification

- Re-ran the three tests with `credential.helper` forced to a logging shim: **0 credential-helper calls** (was 2× `host=github.com`).
- Each test now runs in ~0.03s (previously multi-second network timeouts).
- `mise run fmt` + `mise run lint` clean (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only setup changes with no production code paths modified.
> 
> **Overview**
> Three `TestResolvePushSettings_*` cases in `checkpoint_remote_test.go` now create a local `entire/checkpoints/v1` branch (via `runCheckpointRemoteGit`) before calling `resolvePushSettings`.
> 
> That matches production behavior when metadata is already present and stops `fetchMetadataBranchIfMissing` from issuing a real `git fetch` to the derived `github.com` checkpoint URL—avoiding slow/flaky CI runs and macOS keychain credential prompts on 401. Assertions on `pushTarget()` and `hasCheckpointURL()` are unchanged because URL resolution happens before the fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8767fe1b21f1f1d508ef32c5dbaf34647f1ba3ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->