### PR TITLE
fix(redact): order OPF prompt defaults

### DIFF
--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -243,8 +243,8 @@ type OPFSettings struct {
 
 	// PromptDefault controls whether the pre-push hook asks the user
 	// before running OPF. "" (default) and "ask" both surface the
-	// interactive prompt; "always" runs without asking; "never" skips
-	// OPF and pushes 7-layer content. ENTIRE_OPF=yes|no on the push
+	// interactive prompt; "never" skips OPF and pushes 7-layer content;
+	// "always" runs without asking. ENTIRE_OPF=yes|no on the push
 	// invocation overrides this setting per-push.
 	PromptDefault string `json:"prompt_default,omitempty"`
 }
@@ -252,8 +252,8 @@ type OPFSettings struct {
 // Valid PromptDefault values. Empty == OPFPromptAsk.
 const (
 	OPFPromptAsk    = "ask"
-	OPFPromptAlways = "always"
 	OPFPromptNever  = "never"
+	OPFPromptAlways = "always"
 )
 
 // GetCommitLinking returns the effective commit linking mode.
@@ -993,11 +993,11 @@ func validateOPFSettings(opf *OPFSettings) error {
 		return fmt.Errorf("openai_privacy_filter.timeout_seconds must be greater than or equal to 0 (got %d)", opf.TimeoutSeconds)
 	}
 	switch opf.PromptDefault {
-	case "", OPFPromptAsk, OPFPromptAlways, OPFPromptNever:
+	case "", OPFPromptAsk, OPFPromptNever, OPFPromptAlways:
 		// ok
 	default:
 		return fmt.Errorf("openai_privacy_filter.prompt_default must be one of %q, %q, %q (got %q)",
-			OPFPromptAsk, OPFPromptAlways, OPFPromptNever, opf.PromptDefault)
+			OPFPromptAsk, OPFPromptNever, OPFPromptAlways, opf.PromptDefault)
 	}
 	return nil
 }

--- a/cmd/entire/cli/settings/settings_test.go
+++ b/cmd/entire/cli/settings/settings_test.go
@@ -955,7 +955,7 @@ func TestLoadFromBytes_OPFSettings_RejectsOnFailureField(t *testing.T) {
 
 // TestLoadFromBytes_OPFSettings_PromptDefault covers parsing + validation
 // of the prompt_default field added for the pre-push prompt UX. Empty is
-// allowed (treated as "ask"); ask/always/never are the only valid values.
+// allowed (treated as "ask"); ask/never/always are the only valid values.
 func TestLoadFromBytes_OPFSettings_PromptDefault(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -965,8 +965,8 @@ func TestLoadFromBytes_OPFSettings_PromptDefault(t *testing.T) {
 		wantVal string
 	}{
 		{name: "ask", value: `"ask"`, wantVal: "ask"},
-		{name: "always", value: `"always"`, wantVal: "always"},
 		{name: "never", value: `"never"`, wantVal: "never"},
+		{name: "always", value: `"always"`, wantVal: "always"},
 		{name: "empty_string_allowed_as_ask", value: `""`, wantVal: ""},
 		{name: "bogus_value_rejected", value: `"sometimes"`, wantErr: true},
 	}

--- a/cmd/entire/cli/strategy/global_test.go
+++ b/cmd/entire/cli/strategy/global_test.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"testing"
 
@@ -12,6 +13,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	opfPrePushProgressWriter = io.Discard
+
 	// Register a default ConfigSource so tests that call ConfigScoped
 	// (directly or indirectly via Commit/CreateTag) don't fail with
 	// "no config loader registered".

--- a/cmd/entire/cli/strategy/manual_commit_opf_prompt.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_prompt.go
@@ -41,10 +41,10 @@ func resolveOPFDecision(env, promptDefault string, hasTTY bool, prompter func() 
 		return OPFSkip, nil
 	}
 	switch strings.ToLower(strings.TrimSpace(promptDefault)) {
-	case settings.OPFPromptAlways:
-		return OPFRun, nil
 	case settings.OPFPromptNever:
 		return OPFSkip, nil
+	case settings.OPFPromptAlways:
+		return OPFRun, nil
 	}
 	if !hasTTY {
 		// Non-interactive context: run OPF (matches the user's "if

--- a/cmd/entire/cli/strategy/manual_commit_opf_prompt_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_opf_prompt_test.go
@@ -1,15 +1,18 @@
 package strategy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,8 +49,8 @@ func TestResolveOPFDecision_Precedence(t *testing.T) {
 		{name: "env_yes_case_insensitive", env: "YES", promptDefault: "", hasTTY: false, prompter: promptNever, want: OPFRun},
 		{name: "env_no_with_whitespace", env: "  no  ", promptDefault: "", hasTTY: false, prompter: promptNever, want: OPFSkip},
 		// Setting wins over prompt
-		{name: "setting_always_skips_prompt", env: "", promptDefault: settings.OPFPromptAlways, hasTTY: true, prompter: promptNever, want: OPFRun},
 		{name: "setting_never_skips_prompt", env: "", promptDefault: settings.OPFPromptNever, hasTTY: true, prompter: promptNever, want: OPFSkip},
+		{name: "setting_always_skips_prompt", env: "", promptDefault: settings.OPFPromptAlways, hasTTY: true, prompter: promptNever, want: OPFRun},
 		// Non-TTY fallback: run (matches the "if enabled, just run" semantics)
 		{name: "no_tty_auto_runs", env: "", promptDefault: "", hasTTY: false, prompter: promptNever, want: OPFRun},
 		{name: "no_tty_ignores_ask_setting", env: "", promptDefault: settings.OPFPromptAsk, hasTTY: false, prompter: promptNever, want: OPFRun},
@@ -147,4 +150,42 @@ func TestPersistOPFPromptDefaultAlways_CreatesFileFromScratch(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(got, &parsed))
 	require.Equal(t, settings.OPFPromptAlways, parsed.Redaction.OPF.PromptDefault)
+}
+
+// TestPrePush_OPFProgressUsesConfiguredWriter pins the test-noise escape hatch:
+// PrePush still emits the non-interactive OPF progress notice in production,
+// but tests can redirect it away from process stderr.
+func TestPrePush_OPFProgressUsesConfiguredWriter(t *testing.T) {
+	tmpDir := t.TempDir()
+	testutil.InitRepo(t, tmpDir)
+	testutil.WriteFile(t, tmpDir, "f.txt", "init")
+	testutil.GitAdd(t, tmpDir, "f.txt")
+	testutil.GitCommit(t, tmpDir, "init")
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, paths.EntireDir), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, paths.EntireDir, "settings.json"), []byte(`{
+  "enabled": true,
+  "redaction": {
+    "openai_privacy_filter": {
+      "enabled": true,
+      "categories": {"private_person": true}
+    }
+  }
+}`), 0o644))
+	t.Chdir(tmpDir)
+	configureFakeOPF(t, &fakeOPFForRewrite{})
+
+	var out bytes.Buffer
+	withOPFPrePushProgressWriterForTest(t, &out)
+
+	require.NoError(t, (&ManualCommitStrategy{}).PrePush(t.Context(), "origin"))
+	require.Contains(t, out.String(), "OpenAI Privacy Filter: scanning checkpoints before push")
+}
+
+func withOPFPrePushProgressWriterForTest(t testing.TB, w io.Writer) {
+	t.Helper()
+	previous := opfPrePushProgressWriter
+	opfPrePushProgressWriter = w
+	t.Cleanup(func() {
+		opfPrePushProgressWriter = previous
+	})
 }

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -3,6 +3,7 @@ package strategy
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"os"
 
@@ -17,6 +18,8 @@ import (
 // Ctrl-C) at the OPF prompt. PrePush returns it verbatim; the hook
 // command propagates the non-zero exit code so git push aborts.
 var errOPFAbortedByUser = errors.New("OPF prompt aborted by user; push cancelled")
+
+var opfPrePushProgressWriter io.Writer = os.Stderr
 
 // PrePush is called by the git pre-push hook before pushing to a remote.
 // It pushes each ref in refs.Push alongside the user's push.
@@ -53,7 +56,7 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 		if cfg != nil && cfg.Redaction != nil {
 			opfCfg = cfg.Redaction.OpenAIPrivacyFilter
 		}
-		decision, decisionErr := resolveOPFDecisionForPrePush(ctx, opfCfg, os.Stderr)
+		decision, decisionErr := resolveOPFDecisionForPrePush(ctx, opfCfg, opfPrePushProgressWriter)
 		if decisionErr != nil {
 			logging.Warn(ctx, "OPF pre-push decision failed; aborting push",
 				slog.String("error", decisionErr.Error()),

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -128,7 +128,7 @@ Full settings reference:
 
 - `command` — path or PATH-resolvable name of the `opf` binary. Defaults to `opf`.
 - `timeout_seconds` — per-invocation timeout. Defaults to `30`.
-- `prompt_default` — `"ask"` (default), `"always"`, or `"never"`. Controls whether the pre-push hook surfaces an interactive prompt before running OPF. `ENTIRE_OPF=yes` or `ENTIRE_OPF=no` on a single `git push` invocation overrides this for that push only.
+- `prompt_default` — `"ask"` (default), `"never"`, or `"always"`. Controls whether the pre-push hook surfaces an interactive prompt before running OPF. `ENTIRE_OPF=yes` or `ENTIRE_OPF=no` on a single `git push` invocation overrides this for that push only.
 
 The interactive prompt offers three options and reacts to **Ctrl-C** for cancellation:
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/606
<!-- entire-trail-link-end -->

## Summary

- Reorder OPF `prompt_default` handling and docs to `ask`, `never`, `always`.
- Keep production non-interactive OPF progress output on stderr while letting strategy tests discard it.
- Add a regression test covering the configurable OPF pre-push progress writer.

## Test plan

- `go test ./cmd/entire/cli/settings -run TestLoadFromBytes_OPFSettings_PromptDefault -count=1`
- `go test ./cmd/entire/cli/strategy ./cmd/entire/cli/settings ./redact -count=1`
- `mise run lint`
- `mise run check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic ordering plus a test-only hook around stderr progress text; production push/OPF decision behavior is unchanged.
>
> **Overview**
> Aligns **OpenAI Privacy Filter** `prompt_default` documentation and related code with a consistent **`ask` → `never` → `always`** ordering (comments, constants, validation messages, and `resolveOPFDecision` switch cases). Runtime precedence is unchanged.
>
> Introduces **`opfPrePushProgressWriter`** (defaults to **`stderr`** in production) so non-interactive pre-push OPF progress lines go through a swappable writer. Strategy **`TestMain`** discards that output by default; a new **`TestPrePush_OPFProgressUsesConfiguredWriter`** regression test asserts the message is emitted when the writer is redirected.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c559e15ee225e524ffa82507f86f657a97df2ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
