### PR TITLE
Fix trail finding stale-any API filter

### DIFF
--- a/cmd/entire/cli/trail_review_cmd.go
+++ b/cmd/entire/cli/trail_review_cmd.go
@@ -613,7 +613,9 @@ func trailReviewCommentsPath(trailID string, opts trailReviewListOptions) string
 	if opts.Severity != "" {
 		q.Set("severity", opts.Severity)
 	}
-	if opts.Stale != "" && opts.Stale != trailReviewStaleAny {
+	// Unlike status=any (which the API treats as no status filter), stale=any is
+	// semantically significant: omitting stale defaults to current-only server-side.
+	if opts.Stale != "" {
 		q.Set("stale", opts.Stale)
 	}
 	if opts.IncludeDismissed {

--- a/cmd/entire/cli/trail_review_cmd_test.go
+++ b/cmd/entire/cli/trail_review_cmd_test.go
@@ -97,7 +97,7 @@ func TestTrailReviewCommentsPath(t *testing.T) {
 		Limit:            25,
 		Offset:           50,
 	})
-	want := "/api/v1/trails/trail%20id%2Fwith%20slash/reviews/comments?include_dismissed=true&limit=25&offset=50&severity=high%2Cmedium&status=open%2Cresolved"
+	want := "/api/v1/trails/trail%20id%2Fwith%20slash/reviews/comments?include_dismissed=true&limit=25&offset=50&severity=high%2Cmedium&stale=any&status=open%2Cresolved"
 	if got != want {
 		t.Fatalf("trailReviewCommentsPath = %q, want %q", got, want)
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/610
<!-- entire-trail-link-end -->

This draft pull request was opened by [Entire](https://entire.io) after CI was requested for the linked trail. Feel free to edit the title or body — the link above is what keeps the trail and PR connected.

<!-- entire-shadow-pr -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small query-string fix in CLI API URL building with an updated unit test; no auth or server changes.
> 
> **Overview**
> **Fixes trail finding list requests when `--stale any` is used.** The CLI used to drop `stale=any` from the query (same pattern as `status=any`), but on the server an omitted `stale` defaults to **current-only**, while `stale=any` is required to include both current and stale findings.
> 
> `trailReviewCommentsPath` now adds the `stale` query param whenever it is set, including `any`. The path test expectation was updated to include `stale=any` in the encoded URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb784c63160d988c65d775411853049e9a7b6aac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->