### PR TITLE
Update Pi extension for context injection

### DIFF
--- a/.pi/extensions/entire/index.ts
+++ b/.pi/extensions/entire/index.ts
@@ -14,21 +14,43 @@ export default function (pi: ExtensionAPI) {
   const ENTIRE_CMD = "entire";
   let pendingSkillEvents: Array<{ skill_name: string; invocation: string; timestamp: string }> = [];
 
-  function fireHook(hookName: string, data: Record<string, unknown>): Promise<void> {
+  // fireHook pipes data to `entire hooks pi <hookName>` and resolves with the
+  // hook's stdout (empty string on any failure). Most hooks ignore the return;
+  // before_agent_start uses it to apply a model-context injection.
+  function fireHook(hookName: string, data: Record<string, unknown>): Promise<string> {
     return new Promise((resolve) => {
       try {
         const child = execFile(
           "sh",
           ["-c", `${ENTIRE_CMD} hooks pi ${hookName}`],
-          { timeout: 10000, windowsHide: true },
-          () => resolve(),
+          { timeout: 10000, windowsHide: true, maxBuffer: 4 * 1024 * 1024 },
+          (_err, stdout) => resolve(typeof stdout === "string" ? stdout : ""),
         );
         child.stdin?.end(JSON.stringify(data));
       } catch {
         // best effort — never block the agent on a hook failure
-        resolve();
+        resolve("");
       }
     });
+  }
+
+  // parseInjectedContext scans a hook's stdout for Entire's injection envelope
+  // ({"inject_context":"..."}) and returns the text to inject, or null.
+  function parseInjectedContext(stdout: string): string | null {
+    if (!stdout) return null;
+    for (const line of stdout.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("{")) continue;
+      try {
+        const parsed = JSON.parse(trimmed) as { inject_context?: unknown };
+        if (typeof parsed.inject_context === "string" && parsed.inject_context.length > 0) {
+          return parsed.inject_context;
+        }
+      } catch {
+        // not our envelope — ignore
+      }
+    }
+    return null;
   }
 
   function parseSkillInvocation(text: string): { skill_name: string; invocation: string } | null {
@@ -69,13 +91,26 @@ export default function (pi: ExtensionAPI) {
   pi.on("before_agent_start", async (event, ctx) => {
     const skillEvents = pendingSkillEvents;
     pendingSkillEvents = [];
-    await fireHook("before_agent_start", {
+    const stdout = await fireHook("before_agent_start", {
       type: "before_agent_start",
       cwd: ctx.cwd,
       session_file: ctx.sessionManager.getSessionFile(),
       prompt: event.prompt,
       skill_events: skillEvents,
     });
+    const injected = parseInjectedContext(stdout);
+    if (injected) {
+      // Inject a hidden, persistent message so the model learns about Entire.
+      // display:false keeps it out of the user-facing transcript while still
+      // sending it to the LLM. Entire emits this at most once per session.
+      return {
+        message: {
+          customType: "entire-context",
+          content: injected,
+          display: false,
+        },
+      };
+    }
   });
 
   pi.on("agent_end", async (_event, ctx) => {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/611
<!-- entire-trail-link-end -->

## Summary
Refresh the repo-local Pi extension via `entire agent add pi --force`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Integration-only change to the generated Pi extension; hook failures still resolve to empty stdout and only add optional hidden context to the model.
> 
> **Overview**
> The Pi Entire extension now **reads stdout** from `entire hooks pi` instead of discarding it: `fireHook` resolves with captured output (up to a 4MB buffer) and still returns an empty string on errors so the agent never blocks.
> 
> On **`before_agent_start`**, it parses hook output for a JSON line envelope `{"inject_context":"..."}` and, when present, returns a **hidden persistent message** (`customType: "entire-context"`, `display: false`) so Pi sends that text to the model without showing it in the user transcript. Other lifecycle hooks keep firing hooks as before and ignore the return value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea20713ad3c762e1ac2954fc2601c34682b34ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->