### PR TITLE
redact: route OPF progress to stderr instead of /dev/tty

### DIFF
--- a/redact/batch_test.go
+++ b/redact/batch_test.go
@@ -3,21 +3,18 @@ package redact
 import (
 	"context"
 	"errors"
-	"io"
 	"strings"
 	"testing"
 )
 
-// configureFakeOPF wires up the runtime, redirects opfStderr, and registers
-// cleanup so each test starts and ends with a clean config. Returns the fake
-// so individual tests can assert call counts.
+// configureFakeOPF wires up the runtime and registers cleanup so each
+// test starts and ends with a clean config. Returns the fake so
+// individual tests can assert call counts. (opfStderr is silenced
+// process-wide in TestMain; see global_test.go.)
 func configureFakeOPF(t *testing.T, fake *fakeRuntime, cats map[string]bool) {
 	t.Helper()
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 	ConfigurePrivacyFilterWithRuntime(OPFConfig{
 		Enabled:    true,
 		Categories: cats,
@@ -158,9 +155,6 @@ func TestBatchBytesWithPrivacyFilter_DedupsLeavesAcrossBlobs(t *testing.T) {
 	rt := &recordingRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 	ConfigurePrivacyFilterWithRuntime(OPFConfig{
 		Enabled:    true,
 		Categories: map[string]bool{"private_person": true},
@@ -261,9 +255,6 @@ func TestBatchBytesWithPrivacyFilter_ShortReturnFailsClosed(t *testing.T) {
 	fake := &shortReturnBatchRuntime{}
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 	ConfigurePrivacyFilterWithRuntime(OPFConfig{
 		Enabled:    true,
 		Categories: map[string]bool{"private_person": true},

--- a/redact/global_test.go
+++ b/redact/global_test.go
@@ -1,0 +1,18 @@
+package redact
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// OPF progress UX (→ scanning / ✓ done / × unavailable) defaults to
+	// os.Stderr in production. Silence it process-wide for tests so it
+	// neither bleeds into `go test -v` output nor needs a per-test
+	// override. No test captures opfStderr to assert on its content; the
+	// strategy package suppresses its own pre-push progress writer the
+	// same way (see strategy/global_test.go).
+	opfStderr = io.Discard
+	os.Exit(m.Run())
+}

--- a/redact/opf.go
+++ b/redact/opf.go
@@ -183,7 +183,7 @@ func enabledCategories(cfg *OPFConfig) []string {
 
 // opfStderr is where progress and failure UX is written. OPF only runs
 // in the pre-push rewrite path (strategy/manual_commit_opf_rewrite.go),
-// whose hook is installed without an `2>/dev/null` redirect, so plain
+// whose hook is installed without a `2>/dev/null` redirect, so plain
 // stderr reaches the user's terminal during `git push`. Post-commit
 // condensation never invokes OPF (it calls the 7-layer functions
 // directly via RedactBlobBytes(..., usePrivacyFilter=false)), so the

--- a/redact/opf.go
+++ b/redact/opf.go
@@ -181,19 +181,15 @@ func enabledCategories(cfg *OPFConfig) []string {
 	return out
 }
 
-// opfStderr is where progress and failure UX is written. Defaults to
-// /dev/tty so messages survive the post-commit hook's stderr redirect
-// (the hook runs `entire hooks git post-commit 2>/dev/null` to suppress
-// unrelated logging). Tests override this directly.
-var opfStderr = openTTYOrDiscard()
-
-func openTTYOrDiscard() io.Writer {
-	f, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
-	if err != nil {
-		return io.Discard
-	}
-	return f
-}
+// opfStderr is where progress and failure UX is written. OPF only runs
+// in the pre-push rewrite path (strategy/manual_commit_opf_rewrite.go),
+// whose hook is installed without an `2>/dev/null` redirect, so plain
+// stderr reaches the user's terminal during `git push`. Post-commit
+// condensation never invokes OPF (it calls the 7-layer functions
+// directly via RedactBlobBytes(..., usePrivacyFilter=false)), so the
+// historical `/dev/tty` routing that survived the post-commit hook's
+// stderr redirect is no longer needed. Tests override this directly.
+var opfStderr io.Writer = os.Stderr
 
 // detectOPF runs OPF on a single text and returns tagged regions for any
 // spans whose category is enabled in cfg. Returns nil when OPF is disabled,

--- a/redact/opf_test.go
+++ b/redact/opf_test.go
@@ -3,7 +3,6 @@ package redact
 import (
 	"context"
 	"errors"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -130,10 +129,6 @@ func TestDetectOPF_MapsLabelsCorrectly(t *testing.T) {
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
 
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
-
 	fake := &fakeRuntime{
 		spans: []Span{
 			{Start: 0, End: 5, Label: "private_person"},
@@ -163,9 +158,6 @@ func TestDetectOPF_MapsLabelsCorrectly(t *testing.T) {
 func TestDetectOPF_SkipsCategoriesNotEnabled(t *testing.T) {
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 
 	fake := &fakeRuntime{
 		spans: []Span{
@@ -218,9 +210,6 @@ func TestDetectOPF_SkipsNonProseStrings(t *testing.T) {
 func TestDetectOPF_CircuitBreaker(t *testing.T) {
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 
 	fake := &fakeRuntime{err: errors.New("simulated opf failure")}
 	ConfigurePrivacyFilterWithRuntime(OPFConfig{
@@ -272,9 +261,6 @@ func (r *emptyBatchRuntime) RedactBatch(_ context.Context, _ []string, _ []strin
 func TestDetectOPF_SingleInputShortReturnTripsBreaker(t *testing.T) {
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 
 	ConfigurePrivacyFilterWithRuntime(OPFConfig{
 		Enabled:    true,
@@ -544,9 +530,6 @@ func TestPlainEntryPointsNeverInvokeOPF(t *testing.T) {
 func TestStringWithPrivacyFilter_AugmentsRegexLayers(t *testing.T) {
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 
 	fake := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
 	ConfigurePrivacyFilterWithRuntime(OPFConfig{
@@ -563,9 +546,6 @@ func TestStringWithPrivacyFilter_AugmentsRegexLayers(t *testing.T) {
 func TestJSONLContentWithPrivacyFilter_BatchesSingleCall(t *testing.T) {
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 
 	fake := &fakeRuntime{spans: []Span{{Start: 0, End: 5, Label: "private_person"}}}
 	ConfigurePrivacyFilterWithRuntime(OPFConfig{
@@ -589,9 +569,6 @@ func TestJSONLContentWithPrivacyFilter_BatchesSingleCall(t *testing.T) {
 func TestJSONLContentWithPrivacyFilter_FallsBackOnBatchError(t *testing.T) {
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 
 	fake := &fakeRuntime{err: errors.New("simulated opf failure")}
 	ConfigurePrivacyFilterWithRuntime(OPFConfig{
@@ -638,9 +615,6 @@ func (r *shortReturnRuntime) RedactBatch(_ context.Context, inputs []string, _ [
 func TestJSONLContentWithPrivacyFilter_ShortReturnTripsBreaker(t *testing.T) {
 	resetOPFConfig()
 	t.Cleanup(resetOPFConfig)
-	origStderr := opfStderr
-	opfStderr = io.Discard
-	t.Cleanup(func() { opfStderr = origStderr })
 
 	ConfigurePrivacyFilterWithRuntime(OPFConfig{
 		Enabled:    true,


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/612
<!-- entire-trail-link-end -->

## What

OPF progress UX (`→ scanning` / `✓ done` / `× unavailable`) was written to `/dev/tty` so the messages would survive the post-commit hook's `2>/dev/null` redirect. That rationale is obsolete:

- OPF no longer runs at post-commit — it lives solely in the **pre-push rewrite path** (`strategy/manual_commit_opf_rewrite.go`), whose hook is installed **without** a stderr redirect (`pre-push "$1"`).
- Post-commit condensation calls the 7-layer functions directly via `RedactBlobBytes(..., usePrivacyFilter=false)`, so it never reaches the OPF progress writes.

So `opfStderr` now defaults to `os.Stderr`. During `git push` the messages are still visible (stderr isn't swallowed there); in tests they're captured by `go test` instead of bleeding straight to the developer's terminal — which fixes the stray `→ scanning…` lines that interleaved with `PASS`/`ok` output.

## Changes

- `redact/opf.go`: default `opfStderr` to `os.Stderr`; remove the now-dead `openTTYOrDiscard` helper; update the comment.
- `redact/global_test.go` (new): silence `opfStderr` once in `TestMain`, matching how the `strategy` package handles its own pre-push progress writer (`strategy/global_test.go`).
- `redact/{opf,batch}_test.go`: remove the 11 per-test `io.Discard` overrides — now redundant, and race-free as a single set-once (the per-test blocks mutated a global under `t.Parallel()`).

## Verification

- `mise run fmt` + `mise run lint` (0 issues)
- `go test ./redact/...` and `./cmd/entire/cli/strategy/...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing and test-only stderr handling; no change to OPF redaction or breaker behavior.
> 
> **Overview**
> **OPF progress and failure messages** (`→ scanning…`, `✓ done`, `× unavailable`) now go to **`os.Stderr`** instead of opening **`/dev/tty`**. The old TTY default existed so output would survive post-commit’s `2>/dev/null`; OPF only runs on the **pre-push rewrite** path now, where stderr is not redirected, so that workaround is removed along with **`openTTYOrDiscard`**.
> 
> **Tests** add **`redact/global_test.go`** with **`TestMain`** that sets **`opfStderr = io.Discard`** once for the package (aligned with **`strategy`**). Per-test **`io.Discard`** overrides are deleted from **`batch_test`** and **`opf_test`**, avoiding redundant setup and races when tests run in parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626a0344e5fb9fabcbbc59f7041e68b5e724c30e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->