### PR TITLE
fix(activity): truncate repo names rune-safely in repo chart

### DIFF
--- a/cmd/entire/cli/activity_render.go
+++ b/cmd/entire/cli/activity_render.go
@@ -352,11 +352,9 @@ func renderRepoChart(w io.Writer, sty activityStyles, repos []repoContribution) 
 	}
 
 	for _, r := range display {
-		name := r.Repo
-		if len(name) > maxNameLen {
-			name = name[:maxNameLen-1] + "…"
-		}
-		name = fmt.Sprintf("%-*s", maxNameLen, name)
+		// padOrTruncate is rune-aware; truncating r.Repo with a byte slice
+		// could split a multi-byte rune and emit invalid UTF-8.
+		name := padOrTruncate(r.Repo, maxNameLen)
 
 		bar := renderAgentBar(sty, r.Agents, maxCount, barWidth)
 		count := fmt.Sprintf("%*d", countWidth, r.Total)

--- a/cmd/entire/cli/activity_render_test.go
+++ b/cmd/entire/cli/activity_render_test.go
@@ -276,6 +276,31 @@ func TestRenderRepoChart_LimitsToFive(t *testing.T) {
 	}
 }
 
+func TestRenderRepoChart_UnicodeNameSafeTruncation(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	sty := activityStyles{width: 60}
+	// A repo name long enough to force truncation and full of multi-byte
+	// runes, so a byte-based slice would split a rune and emit invalid UTF-8.
+	repos := []repoContribution{
+		{
+			Repo:   strings.Repeat("é", 40),
+			Total:  3,
+			Agents: map[string]int{activityTestAgentClaude: 3},
+		},
+	}
+
+	renderRepoChart(&buf, sty, repos)
+	out := buf.String()
+
+	if !utf8.ValidString(out) {
+		t.Fatal("rendered repo chart contains invalid UTF-8")
+	}
+	if !strings.Contains(out, "…") {
+		t.Error("expected the long repo name to be truncated with an ellipsis")
+	}
+}
+
 func TestPadOrTruncate(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Overview

`renderRepoChart` (the `entire activity` repo chart) shortened long repo names
with a byte slice — `name[:maxNameLen-1] + "…"`. For repo names containing
multi-byte UTF-8 (accents, non-Latin scripts, emoji), that can split a rune
mid-byte and emit invalid UTF-8 to the terminal.

This reuses the file's existing rune-aware `padOrTruncate` helper — the same one
the commit-list path already relies on — which also removes the duplicated
truncate-and-pad logic.

## Test

Adds `TestRenderRepoChart_UnicodeNameSafeTruncation`, mirroring the existing
`TestRenderCommitList_UnicodeMessageSafeTruncation`: it renders a long,
multi-byte repo name and asserts the output is valid UTF-8 and still truncated.
The test fails on the previous byte-slicing code and passes with this change.

> **Low risk** — rendering-only change in the activity dashboard; no auth, API,
> or on-disk behavior touched.
