### PR TITLE
fix(repo mirror): route cluster-addressed commands to the cluster's core

### DIFF
--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -2,12 +2,21 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/userdirs"
 )
+
+// controlPlaneClusterDiscoveryTimeout bounds the one
+// /.well-known/entire-cluster.json GET a cluster-addressed control-plane
+// command makes to learn which core fronts the cluster. Short so an absent or
+// slow endpoint fails the command promptly.
+const controlPlaneClusterDiscoveryTimeout = 8 * time.Second
 
 // ControlPlaneTarget is the resolved login server a control-plane request
 // (org/repo/project/grant) should dial, plus the bearer source for it.
@@ -42,6 +51,41 @@ func ResolveControlPlaneTarget() (ControlPlaneTarget, error) {
 		}
 	}
 
+	src, err := NewRefreshingLoginProvider(c, nil, insecureHTTPEnabled() || isLoopbackHTTP(c.CoreURL))
+	if err != nil {
+		return ControlPlaneTarget{}, fmt.Errorf("build token source for context %q: %w", c.Name, err)
+	}
+	return ControlPlaneTarget{CoreURL: strings.TrimRight(c.CoreURL, "/"), TokenSource: src}, nil
+}
+
+// ResolveControlPlaneTargetForCluster chooses which core a *resource-provider*
+// control-plane command should dial — one whose subject is a mirror on a
+// specific cluster (mirror create/remove, mirror collaborators add/remove/list)
+// rather than the caller's own account.
+//
+// Unlike ResolveControlPlaneTarget, the core is NOT taken from the active
+// context: a cluster's mirror lives in the federation that fronts that cluster,
+// which may differ from the active login (e.g. a partial.to context acting on a
+// prod entire.io cluster). We discover the cluster's trusted cores from its
+// /.well-known/entire-cluster.json and pick the local context eligible for one
+// of them — active-wins-if-eligible, else the sole eligible context, else an
+// explicit-choice / login hint — exactly as git and data-API resolution do
+// (see RepoTokenSource, ResolveDataAPIToken). The bearer is that context's
+// refreshing login provider (silent JWT re-mint from its stored refresh token).
+//
+// With no eligible local context the discovery resolver returns its login hint
+// naming the cluster's cores, so the user logs in to the right federation
+// rather than seeing an opaque "unknown cluster_host" 400 from the active
+// context's core.
+func ResolveControlPlaneTargetForCluster(ctx context.Context, clusterHost string) (ControlPlaneTarget, error) {
+	if clusterHost == "" {
+		return ControlPlaneTarget{}, errors.New("cluster-addressed control-plane command requires a target cluster host")
+	}
+	httpClient := &http.Client{Timeout: controlPlaneClusterDiscoveryTimeout, Transport: repoExchangeTransportForTest}
+	c, err := resolveContextForCluster(ctx, userdirs.Config(), userdirs.Cache(), clusterHost, httpClient, nil)
+	if err != nil {
+		return ControlPlaneTarget{}, err
+	}
 	src, err := NewRefreshingLoginProvider(c, nil, insecureHTTPEnabled() || isLoopbackHTTP(c.CoreURL))
 	if err != nil {
 		return ControlPlaneTarget{}, fmt.Errorf("build token source for context %q: %w", c.Name, err)

--- a/cmd/entire/cli/auth/control_plane.go
+++ b/cmd/entire/cli/auth/control_plane.go
@@ -51,11 +51,7 @@ func ResolveControlPlaneTarget() (ControlPlaneTarget, error) {
 		}
 	}
 
-	src, err := NewRefreshingLoginProvider(c, nil, insecureHTTPEnabled() || isLoopbackHTTP(c.CoreURL))
-	if err != nil {
-		return ControlPlaneTarget{}, fmt.Errorf("build token source for context %q: %w", c.Name, err)
-	}
-	return ControlPlaneTarget{CoreURL: strings.TrimRight(c.CoreURL, "/"), TokenSource: src}, nil
+	return targetForContext(c)
 }
 
 // ResolveControlPlaneTargetForCluster chooses which core a *resource-provider*
@@ -86,6 +82,14 @@ func ResolveControlPlaneTargetForCluster(ctx context.Context, clusterHost string
 	if err != nil {
 		return ControlPlaneTarget{}, err
 	}
+	return targetForContext(c)
+}
+
+// targetForContext builds the ControlPlaneTarget for an already-chosen context:
+// a refreshing login provider (silent JWT re-mint from the stored refresh
+// token) bound to that context's core. Shared by the active-context and
+// cluster-addressed resolvers, which differ only in how they pick c.
+func targetForContext(c *contexts.Context) (ControlPlaneTarget, error) {
 	src, err := NewRefreshingLoginProvider(c, nil, insecureHTTPEnabled() || isLoopbackHTTP(c.CoreURL))
 	if err != nil {
 		return ControlPlaneTarget{}, fmt.Errorf("build token source for context %q: %w", c.Name, err)

--- a/cmd/entire/cli/auth/control_plane_test.go
+++ b/cmd/entire/cli/auth/control_plane_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
@@ -59,6 +61,74 @@ func TestResolveControlPlaneTarget_ActiveContextWins(t *testing.T) {
 	}
 	if got != jwt {
 		t.Fatalf("TokenSource returned %q, want the context's stored JWT", got)
+	}
+}
+
+// A cluster-addressed control-plane command dials the core that fronts the
+// cluster (discovered from /.well-known) using the matching local context —
+// NOT the active context, which may belong to a different federation. This is
+// the fix for `repo mirror collaborators list … <prod-cluster>` 400ing with
+// "unknown cluster_host" while the active context is a staging login.
+func TestResolveControlPlaneTargetForCluster_DialsClusterCoreNotActive(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	const (
+		activeCore  = "https://eu.auth.partial.to"
+		clusterCore = "https://eu.auth.entire.io"
+		clusterHost = "aws-us-east-2.entire.io"
+	)
+	// Seed a fresh token only for the cluster's core context — the one we
+	// expect to win. The active (partial) context deliberately has no token, so
+	// a regression that dialed it would fail loudly rather than pass by luck.
+	clusterSvc := tokenstore.CoreKeyringService(clusterCore)
+	jwt := makeJWT(t, fmt.Sprintf(`{"iss":%q,"handle":"alice","exp":%d}`, clusterCore, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(clusterSvc, "alice", tokenstore.EncodeTokenWithExpiration(jwt, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+
+	activeCtx := &contexts.Context{Name: "alice@partial", CoreURL: activeCore, Handle: "alice", KeychainService: tokenstore.CoreKeyringService(activeCore)}
+	clusterCtx := &contexts.Context{Name: "alice@prod", CoreURL: clusterCore, Handle: "alice", KeychainService: clusterSvc}
+	if err := contexts.Save(configDir, &contexts.File{CurrentContext: activeCtx.Name, Contexts: []*contexts.Context{activeCtx, clusterCtx}}); err != nil {
+		t.Fatalf("write contexts.json: %v", err)
+	}
+
+	// Stub cluster discovery so the test doesn't hit the network: the cluster
+	// resolves to the prod context (what /.well-known + selectContext would
+	// yield), NOT the active partial context.
+	prev := resolveContextForCluster
+	resolveContextForCluster = func(_ context.Context, _, _, host string, _ *http.Client, _ clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+		if host != clusterHost {
+			t.Fatalf("discovery host = %q, want %q", host, clusterHost)
+		}
+		return clusterCtx, nil
+	}
+	t.Cleanup(func() { resolveContextForCluster = prev })
+
+	target, err := ResolveControlPlaneTargetForCluster(context.Background(), clusterHost)
+	if err != nil {
+		t.Fatalf("ResolveControlPlaneTargetForCluster: %v", err)
+	}
+	if target.CoreURL != clusterCore {
+		t.Fatalf("CoreURL = %q, want the cluster's core %q (not the active context's %q)", target.CoreURL, clusterCore, activeCore)
+	}
+	got, err := target.TokenSource(context.Background())
+	if err != nil {
+		t.Fatalf("TokenSource: %v", err)
+	}
+	if got != jwt {
+		t.Fatalf("TokenSource returned %q, want the cluster context's stored JWT", got)
+	}
+}
+
+// An empty cluster host is a caller bug — fail fast rather than discovering
+// against "".
+func TestResolveControlPlaneTargetForCluster_EmptyHost(t *testing.T) {
+	if _, err := ResolveControlPlaneTargetForCluster(context.Background(), ""); err == nil {
+		t.Fatal("want an error for empty cluster host, got nil")
 	}
 }
 

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -51,7 +51,22 @@ func insecureHTTPRequested(cmd *cobra.Command) bool {
 // output actionable — only the columns a person acts on — while --json
 // preserves the full model for scripting.
 func runCoreList[T any](cmd *cobra.Command, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) ([]T, error)) error {
-	return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+	return runCore(cmd, renderCoreList(cmd, headers, row, fn))
+}
+
+// runCoreListForCluster is runCoreList for a resource-provider command (see
+// runCoreForCluster): identical table/JSON rendering, but dialing the core that
+// fronts clusterHost rather than the active context.
+func runCoreListForCluster[T any](cmd *cobra.Command, clusterHost string, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) ([]T, error)) error {
+	return runCoreForCluster(cmd, clusterHost, renderCoreList(cmd, headers, row, fn))
+}
+
+// renderCoreList builds the run-function shared by runCoreList and
+// runCoreListForCluster: fetch via fn, then render as a table (default) or raw
+// JSON (--json). Kept separate from the client-selection so the two list
+// variants differ only in which core they dial.
+func renderCoreList[T any](cmd *cobra.Command, headers []string, row func(T) []string, fn func(ctx context.Context, c *coreapi.Client) ([]T, error)) func(context.Context, *coreapi.Client) error {
+	return func(ctx context.Context, c *coreapi.Client) error {
 		items, err := fn(ctx, c)
 		if err != nil {
 			return err
@@ -64,7 +79,7 @@ func runCoreList[T any](cmd *cobra.Command, headers []string, row func(T) []stri
 			return nil
 		}
 		return printTable(cmd.OutOrStdout(), headers, items, row)
-	})
+	}
 }
 
 // runCoreObject fetches a single value via fn and renders it as a vertical
@@ -229,8 +244,32 @@ func runCoreJSON(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Cli
 
 // runCore is the variant for commands that don't render JSON (delete,
 // revoke, remove): it runs the same preamble — silence usage, build
-// client, map API errors — and leaves any success output to fn.
+// client, map API errors — and leaves any success output to fn. The client
+// dials the active context's core (coreapi.New); use runCoreForCluster for
+// commands addressed at a specific cluster.
 func runCore(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client) error) error {
+	return runCoreClient(cmd, func(context.Context) (*coreapi.Client, error) { return coreapi.New() }, fn)
+}
+
+// runCoreForCluster is runCore for resource-provider commands addressed at a
+// specific cluster (mirror create/remove, mirror collaborators add/remove/list):
+// it dials the core that fronts clusterHost — discovered from the cluster's
+// /.well-known/entire-cluster.json, authenticating with the matching local
+// context — instead of the active context. So the command works on a cluster in
+// a federation other than the active login, instead of failing with "unknown
+// cluster_host". See coreapi.NewForCluster.
+func runCoreForCluster(cmd *cobra.Command, clusterHost string, fn func(ctx context.Context, c *coreapi.Client) error) error {
+	return runCoreClient(cmd, func(ctx context.Context) (*coreapi.Client, error) {
+		return coreapi.NewForCluster(ctx, clusterHost)
+	}, fn)
+}
+
+// runCoreClient owns the control-plane preamble shared by the active-context
+// (runCore) and cluster-addressed (runCoreForCluster) variants: silence usage,
+// opt into plain-HTTP token exchange if requested, build the client via
+// newClient, run fn, and map API errors. The only difference between the two
+// variants is which core newClient dials.
+func runCoreClient(cmd *cobra.Command, newClient func(context.Context) (*coreapi.Client, error), fn func(ctx context.Context, c *coreapi.Client) error) error {
 	cmd.SilenceUsage = true
 	// Opt into plain-HTTP token exchange before the client (and its lazily
 	// built token manager) is constructed — the manager freezes the
@@ -238,7 +277,7 @@ func runCore(cmd *cobra.Command, fn func(ctx context.Context, c *coreapi.Client)
 	if insecureHTTPRequested(cmd) {
 		auth.EnableInsecureHTTP()
 	}
-	client, err := coreapi.New()
+	client, err := newClient(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("connect to Entire control plane: %w", err)
 	}

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -145,7 +145,7 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid [cluster-host]: %w", err)
 			}
-			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
 				created, err := c.CreateMirror(ctx, &coreapi.CreateMirrorInputBody{
 					Provider:    coreapi.CreateMirrorInputBodyProviderGithub,
 					Owner:       owner,
@@ -302,7 +302,7 @@ func newRepoMirrorRemoveCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid [cluster-host]: %w", err)
 			}
-			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
 				// Delete by upstream coords in one call. A 404 is a real
 				// error here, not idempotent success: the server only
 				// answers 204 when it actually removed a placement, so a

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -239,6 +240,17 @@ func newRepoMirrorListCmd() *cobra.Command {
 		Short: "List mirrors you can see",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// mirror list is identity-scoped: it shows the mirrors visible from
+			// the active login's federation, so name that login server. It makes
+			// a surprising empty result legible — e.g. mirrors that live in a
+			// different deployment than the active context (--cluster is a filter,
+			// not a router). Skipped for --json to keep machine output clean; on
+			// stderr so it never lands in a piped table.
+			if !jsonRequested(cmd) {
+				if server := activeLoginServer(); server != "" {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Listing mirrors on %s\n", server)
+				}
+			}
 			return runCoreList(cmd, mirrorColumns, mirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Mirror, error) {
 				var params coreapi.ListMirrorsParams
 				if cluster != "" {
@@ -262,6 +274,32 @@ func newRepoMirrorListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&provider, "provider", "", "filter by upstream provider (e.g. github)")
 	cmd.Flags().StringVar(&owner, "owner", "", "filter by upstream owner login")
 	return cmd
+}
+
+// activeLoginServer returns the control-plane login server that identity-scoped
+// commands (e.g. `mirror list`) query, for an informational header. Mirrors the
+// resolution coreapi.New uses: the ENTIRE_TOKEN audience when set, else the
+// active context's core. Best-effort — returns "" when it can't be determined,
+// so the header is simply omitted rather than failing; the command's own call
+// surfaces any real auth error.
+func activeLoginServer() string {
+	if raw, ok := os.LookupEnv(auth.EnvTokenVar); ok {
+		u, err := auth.CoreURLFromEnvToken(strings.TrimSpace(raw))
+		if err != nil {
+			return ""
+		}
+		return u
+	}
+	all, current, err := auth.Contexts()
+	if err != nil {
+		return ""
+	}
+	for _, c := range all {
+		if c.Name == current {
+			return c.CoreURL
+		}
+	}
+	return ""
 }
 
 func newRepoMirrorGetCmd() *cobra.Command {

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	"net/url"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -244,11 +243,13 @@ func newRepoMirrorListCmd() *cobra.Command {
 			// the active login's federation, so name that login server. It makes
 			// a surprising empty result legible — e.g. mirrors that live in a
 			// different deployment than the active context (--cluster is a filter,
-			// not a router). Skipped for --json to keep machine output clean; on
-			// stderr so it never lands in a piped table.
+			// not a router). Reuses the same target coreapi.New dials. Best-effort:
+			// no header rather than a hard failure if the active context can't be
+			// resolved. Skipped for --json to keep machine output clean; on stderr
+			// so it never lands in a piped table.
 			if !jsonRequested(cmd) {
-				if server := activeLoginServer(); server != "" {
-					fmt.Fprintf(cmd.ErrOrStderr(), "Listing mirrors on %s\n", server)
+				if t, err := auth.ResolveControlPlaneTarget(); err == nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Listing mirrors on %s\n", t.CoreURL)
 				}
 			}
 			return runCoreList(cmd, mirrorColumns, mirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Mirror, error) {
@@ -274,32 +275,6 @@ func newRepoMirrorListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&provider, "provider", "", "filter by upstream provider (e.g. github)")
 	cmd.Flags().StringVar(&owner, "owner", "", "filter by upstream owner login")
 	return cmd
-}
-
-// activeLoginServer returns the control-plane login server that identity-scoped
-// commands (e.g. `mirror list`) query, for an informational header. Mirrors the
-// resolution coreapi.New uses: the ENTIRE_TOKEN audience when set, else the
-// active context's core. Best-effort — returns "" when it can't be determined,
-// so the header is simply omitted rather than failing; the command's own call
-// surfaces any real auth error.
-func activeLoginServer() string {
-	if raw, ok := os.LookupEnv(auth.EnvTokenVar); ok {
-		u, err := auth.CoreURLFromEnvToken(strings.TrimSpace(raw))
-		if err != nil {
-			return ""
-		}
-		return u
-	}
-	all, current, err := auth.Contexts()
-	if err != nil {
-		return ""
-	}
-	for _, c := range all {
-		if c.Name == current {
-			return c.CoreURL
-		}
-	}
-	return ""
 }
 
 func newRepoMirrorGetCmd() *cobra.Command {

--- a/cmd/entire/cli/repo_mirror_collaborators.go
+++ b/cmd/entire/cli/repo_mirror_collaborators.go
@@ -93,7 +93,7 @@ func newRepoMirrorCollaboratorsAddCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid [cluster-host]: %w", err)
 			}
-			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
 				granted, err := c.GrantMirrorCollaborator(ctx, &coreapi.GrantMirrorCollaboratorInputBody{
 					Provider:    coreapi.GrantMirrorCollaboratorInputBodyProviderGithub,
 					Owner:       owner,
@@ -141,7 +141,7 @@ func newRepoMirrorCollaboratorsRemoveCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid [cluster-host]: %w", err)
 			}
-			return runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
 				if err := c.RevokeMirrorCollaborator(ctx, coreapi.RevokeMirrorCollaboratorParams{
 					Provider:    coreapi.RevokeMirrorCollaboratorProviderGithub,
 					Owner:       owner,
@@ -179,7 +179,7 @@ func newRepoMirrorCollaboratorsListCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid [cluster-host]: %w", err)
 			}
-			return runCoreList(cmd, mirrorCollaboratorColumns, mirrorCollaboratorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.MirrorCollaborator, error) {
+			return runCoreListForCluster(cmd, clusterHost, mirrorCollaboratorColumns, mirrorCollaboratorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.MirrorCollaborator, error) {
 				out, err := c.ListMirrorCollaborators(ctx, coreapi.ListMirrorCollaboratorsParams{
 					Provider:    coreapi.ListMirrorCollaboratorsProviderGithub,
 					Owner:       owner,

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -19,7 +20,46 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/internal/coreapi"
+	"github.com/entireio/cli/internal/entireclient/contexts"
 )
+
+// unsetEnvToken removes ENTIRE_TOKEN for the duration of a test (and restores
+// it), so the contexts-based resolution path under test isn't shadowed by an
+// env token in the ambient environment.
+func unsetEnvToken(t *testing.T) {
+	t.Helper()
+	if v, ok := os.LookupEnv(auth.EnvTokenVar); ok {
+		require.NoError(t, os.Unsetenv(auth.EnvTokenVar))
+		t.Cleanup(func() { _ = os.Setenv(auth.EnvTokenVar, v) })
+	}
+}
+
+// activeLoginServer names the active context's core, so `mirror list` can tell
+// the user which login server's view they're seeing.
+func TestActiveLoginServer_ReturnsCurrentContextCore(t *testing.T) {
+	unsetEnvToken(t)
+	configDir := t.TempDir()
+	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
+
+	const prodCore = "https://eu.auth.entire.io"
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "alice@prod",
+		Contexts: []*contexts.Context{
+			{Name: "alice@partial", CoreURL: "https://eu.auth.partial.to", Handle: "alice"},
+			{Name: "alice@prod", CoreURL: prodCore, Handle: "alice"},
+		},
+	}))
+
+	require.Equal(t, prodCore, activeLoginServer())
+}
+
+// With no contexts the header is omitted rather than failing.
+func TestActiveLoginServer_NoContextReturnsEmpty(t *testing.T) {
+	unsetEnvToken(t)
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+
+	require.Equal(t, "", activeLoginServer())
+}
 
 func TestExplainSuspendedMirror(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -20,46 +19,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/internal/coreapi"
-	"github.com/entireio/cli/internal/entireclient/contexts"
 )
-
-// unsetEnvToken removes ENTIRE_TOKEN for the duration of a test (and restores
-// it), so the contexts-based resolution path under test isn't shadowed by an
-// env token in the ambient environment.
-func unsetEnvToken(t *testing.T) {
-	t.Helper()
-	if v, ok := os.LookupEnv(auth.EnvTokenVar); ok {
-		require.NoError(t, os.Unsetenv(auth.EnvTokenVar))
-		t.Cleanup(func() { _ = os.Setenv(auth.EnvTokenVar, v) })
-	}
-}
-
-// activeLoginServer names the active context's core, so `mirror list` can tell
-// the user which login server's view they're seeing.
-func TestActiveLoginServer_ReturnsCurrentContextCore(t *testing.T) {
-	unsetEnvToken(t)
-	configDir := t.TempDir()
-	t.Setenv("ENTIRE_CONFIG_DIR", configDir)
-
-	const prodCore = "https://eu.auth.entire.io"
-	require.NoError(t, contexts.Save(configDir, &contexts.File{
-		CurrentContext: "alice@prod",
-		Contexts: []*contexts.Context{
-			{Name: "alice@partial", CoreURL: "https://eu.auth.partial.to", Handle: "alice"},
-			{Name: "alice@prod", CoreURL: prodCore, Handle: "alice"},
-		},
-	}))
-
-	require.Equal(t, prodCore, activeLoginServer())
-}
-
-// With no contexts the header is omitted rather than failing.
-func TestActiveLoginServer_NoContextReturnsEmpty(t *testing.T) {
-	unsetEnvToken(t)
-	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
-
-	require.Equal(t, "", activeLoginServer())
-}
 
 func TestExplainSuspendedMirror(t *testing.T) {
 	t.Parallel()

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -33,48 +33,93 @@ const apiBasePath = "/api/v1"
 // transport follows the home core's 421 redirect and exchanges the login
 // token for one that core accepts (see newCrossJurisHTTPClient).
 func New() (*Client, error) {
-	// ENTIRE_TOKEN bypass: CI / workload-identity runners inject a short-
-	// lived login or sa-session JWT and want control-plane commands to use
-	// it verbatim, with no contexts.json (the runner never ran `entire
-	// login`) and no keyring (the runner has none). Presence of the var
-	// (LookupEnv, including blank) commits the CLI to this mode.
-	//
-	// Fail-closed: a blank or malformed value is fatal rather than a silent
-	// fallback to contexts.json, which would mask a misconfigured runner.
-	// The token's own aud claim becomes the control-plane origin we dial —
-	// CoreURLFromEnvToken validates aud is a https bare-origin URL, and
-	// makes that the resource the static bearer is sent to.
-	//
-	// NO TRUST GATE — and deliberately so, in contrast to the env-token path
-	// in cmd/git-remote-entire/main.go:resolveEnvTokenCreds. That path derives
-	// coreURL from the same unverified aud claim, then gates it through
-	// clusterdiscovery.ResolveClusterCores + coreTrusted, anchored to the host
-	// the user typed in the clone URL — exactly the verification
-	// CoreURLFromEnvToken's doc mandates of callers. We cannot reuse that gate:
-	// control-plane commands have no user-supplied resource host to anchor
-	// against, so coreURL would only ever be the token's own (unverified) aud,
-	// gating it against itself. We skip it because aud-redirection carries no
-	// escalation here: git-remote uses the env token as an STS subject_token
-	// (exchanged via repocreds for a repo-scoped credential), whereas coreapi
-	// sends the token verbatim as the control-plane bearer — the token IS the
-	// credential, so re-pointing aud at an attacker host requires already
-	// holding a valid token and yields nothing the holder didn't already have.
-	if raw, ok := os.LookupEnv(auth.EnvTokenVar); ok {
-		envToken := strings.TrimSpace(raw)
-		if envToken == "" {
-			return nil, fmt.Errorf("%s is set but blank", auth.EnvTokenVar)
-		}
-		coreURL, err := auth.CoreURLFromEnvToken(envToken)
-		if err != nil {
-			return nil, err //nolint:wrapcheck // CoreURLFromEnvToken already prefixes with EnvTokenVar
-		}
-		return NewWithBearer(coreURL, envToken)
+	if client, ok, err := clientFromEnvToken(); ok {
+		return client, err
 	}
-
 	target, err := auth.ResolveControlPlaneTarget()
 	if err != nil {
 		return nil, fmt.Errorf("resolve control-plane target: %w", err)
 	}
+	return clientForTarget(target)
+}
+
+// NewForCluster returns a *Client for a resource-provider control-plane command
+// whose subject is a mirror on clusterHost (mirror create/remove, mirror
+// collaborators add/remove/list).
+//
+// Unlike New — which dials the active context — the core is discovered from the
+// cluster's /.well-known/entire-cluster.json and the matching local context
+// supplies the bearer (see auth.ResolveControlPlaneTargetForCluster). This is
+// what lets a command act on a cluster fronted by a federation other than the
+// active login, e.g. running `repo mirror collaborators list … aws-us-east-2.entire.io`
+// while the active context is a partial.to login: without it the active
+// context's core 400s with "unknown cluster_host" because it doesn't front the
+// cluster. ENTIRE_TOKEN is honoured identically to New.
+func NewForCluster(ctx context.Context, clusterHost string) (*Client, error) {
+	if client, ok, err := clientFromEnvToken(); ok {
+		return client, err
+	}
+	target, err := auth.ResolveControlPlaneTargetForCluster(ctx, clusterHost)
+	if err != nil {
+		return nil, fmt.Errorf("resolve control-plane target for cluster %q: %w", clusterHost, err)
+	}
+	return clientForTarget(target)
+}
+
+// clientFromEnvToken handles the ENTIRE_TOKEN bypass shared by New and
+// NewForCluster. ok=true commits the caller to this mode (the var is present);
+// ok=false means no env token, so fall through to context resolution.
+//
+// CI / workload-identity runners inject a short-lived login or sa-session JWT
+// and want control-plane commands to use it verbatim, with no contexts.json
+// (the runner never ran `entire login`) and no keyring (the runner has none).
+// Presence of the var (LookupEnv, including blank) commits the CLI to this mode.
+//
+// Fail-closed: a blank or malformed value is fatal rather than a silent
+// fallback to contexts.json, which would mask a misconfigured runner. The
+// token's own aud claim becomes the control-plane origin we dial —
+// CoreURLFromEnvToken validates aud is a https bare-origin URL, and makes that
+// the resource the static bearer is sent to.
+//
+// NO TRUST GATE — and deliberately so, in contrast to the env-token path
+// in cmd/git-remote-entire/main.go:resolveEnvTokenCreds. That path derives
+// coreURL from the same unverified aud claim, then gates it through
+// clusterdiscovery.ResolveClusterCores + coreTrusted, anchored to the host
+// the user typed in the clone URL — exactly the verification
+// CoreURLFromEnvToken's doc mandates of callers. We cannot reuse that gate:
+// control-plane commands have no user-supplied resource host to anchor
+// against, so coreURL would only ever be the token's own (unverified) aud,
+// gating it against itself. We skip it because aud-redirection carries no
+// escalation here: git-remote uses the env token as an STS subject_token
+// (exchanged via repocreds for a repo-scoped credential), whereas coreapi
+// sends the token verbatim as the control-plane bearer — the token IS the
+// credential, so re-pointing aud at an attacker host requires already
+// holding a valid token and yields nothing the holder didn't already have.
+//
+// (NewForCluster doesn't tighten this even though it has a cluster host to
+// anchor against: the same no-escalation argument holds — the env token is the
+// credential, sent verbatim, not exchanged.)
+func clientFromEnvToken() (*Client, bool, error) {
+	raw, ok := os.LookupEnv(auth.EnvTokenVar)
+	if !ok {
+		return nil, false, nil
+	}
+	envToken := strings.TrimSpace(raw)
+	if envToken == "" {
+		return nil, true, fmt.Errorf("%s is set but blank", auth.EnvTokenVar)
+	}
+	coreURL, err := auth.CoreURLFromEnvToken(envToken)
+	if err != nil {
+		return nil, true, err //nolint:wrapcheck // CoreURLFromEnvToken already prefixes with EnvTokenVar
+	}
+	client, err := NewWithBearer(coreURL, envToken)
+	return client, true, err
+}
+
+// clientForTarget builds the *Client for a resolved control-plane target: the
+// per-request bearer source plus the cross-juris transport. Shared by New and
+// NewForCluster.
+func clientForTarget(target auth.ControlPlaneTarget) (*Client, error) {
 	src := &providerSource{provide: target.TokenSource}
 	client, err := NewClient(strings.TrimRight(target.CoreURL, "/")+apiBasePath, src, WithClient(newCrossJurisHTTPClient()))
 	if err != nil {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/615
<!-- entire-trail-link-end -->

## Failure mode

`entire repo mirror collaborators list github.com/… aws-us-east-2.entire.io` (and `create`/`remove`, `collaborators add`/`remove`) 400'd with `unknown cluster_host` whenever the active context's core didn't front that cluster — e.g. addressing a prod `entire.io` cluster while logged into `partial.to`.

## Insight

The mirror verbs added in #1458 are the first **cluster-anchored** core calls: the user supplies a `<cluster-host>` and an upstream, and the owning project is the per-cell, system-managed `gh:mirrors:*` project derived server-side from the cluster. So the core to dial is a property of the cluster, not the user.

Every other core call is anchored to an **identity-owned resource** and correctly dials the active context. `repo create`, for instance, takes a required `--project`; the repo's project and its target cluster must be co-located on one core, so the *project* (which lives in your federation) is the anchor and `--cluster-host` is just an in-federation placement — routing it by cluster would be wrong.

So the mirror verbs now resolve the core from the cluster's `/.well-known/entire-cluster.json` and authenticate with the matching local context (active-wins-if-eligible → sole eligible → login hint) — the same discovery the git/data-API paths already use. Project/identity-anchored commands (`repo create/list`, `mirror list/get`) are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which core and credentials mirror mutations use in multi-federation setups; behavior is localized to cluster-scoped mirror commands with tests, but mis-discovery could still send requests to the wrong federation.
> 
> **Overview**
> Fixes **`unknown cluster_host`** on mirror verbs when the active login’s core does not front the target cluster (e.g. prod `entire.io` cluster with a `partial.to` active context).
> 
> **Cluster-scoped** mirror commands (`create`/`remove`, collaborators `add`/`remove`/`list`) now resolve the control-plane core from the cluster’s `/.well-known/entire-cluster.json` and authenticate with the matching local context (same rules as git/data-API), via `ResolveControlPlaneTargetForCluster`, `coreapi.NewForCluster`, and `runCoreForCluster` / `runCoreListForCluster`. **Identity-scoped** mirror calls (`list`/`get`) still use the active context.
> 
> `ResolveControlPlaneTarget` is refactored to share `targetForContext`; `coreapi.New` pulls `ENTIRE_TOKEN` handling into `clientFromEnvToken` / `clientForTarget`. Tests cover cluster vs active context selection and empty cluster host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c3e161525560c07d1ad15e6e69f3ef5cb4f856e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
