### PR TITLE
feat(trail): show the description and a browser URL in trail show

### DIFF
--- a/cmd/entire/cli/api/trail_types.go
+++ b/cmd/entire/cli/api/trail_types.go
@@ -42,6 +42,15 @@ type TrailResource struct {
 	UnresolvedCount int              `json:"unresolved_count,omitempty"`
 	CheckpointCount int              `json:"checkpoint_count,omitempty"`
 	CommitsAhead    int              `json:"commits_ahead,omitempty"`
+	// BodyDocument carries the trail's description (collaborative editor doc).
+	// The list endpoint omits it; the detail endpoint populates it.
+	BodyDocument *TrailBodyDocument `json:"body_document,omitempty"`
+}
+
+// TrailBodyDocument is the trail's description editor document. TextSnapshot is
+// the rendered plain text the CLI displays.
+type TrailBodyDocument struct {
+	TextSnapshot string `json:"text_snapshot"`
 }
 
 // ToMetadata converts a TrailResource to a trail.Metadata for display.

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -131,21 +131,29 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, sel
 		// rendered description (trail.body_document.text_snapshot) the list
 		// omits, and surface a browser URL. The detail fetch is best-effort:
 		// the core metadata already came from the list, so a detail failure
-		// degrades to "no description" with a warning rather than failing.
+		// falls back to the list body with a warning rather than failing.
 		m := found.ToMetadata()
 		webURL := ""
-		// The description lives only in the detail response (the list omits the
-		// body), so it's only known when the detail fetch below succeeds.
-		bodyText := ""
-		descriptionLoaded := false
+		// Seed the description from the list body so a failed (or skipped)
+		// detail fetch still shows something; a successful detail fetch
+		// supersedes it with the richer body_document text below.
+		bodyText := found.Body
+		descriptionLoaded := strings.TrimSpace(found.Body) != ""
 		if found.Number > 0 {
 			webURL = trailWebURL(api.BaseURL(), forge, owner, repo, found.Number)
 			if bt, derr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); derr == nil {
-				bodyText = bt
+				// A successful fetch means we authoritatively consulted the
+				// description, but it only supersedes the seeded list body when
+				// it actually carries text: an older/partial server that omits
+				// body_document returns "" here and must not blank out a list
+				// body that is present.
 				descriptionLoaded = true
+				if strings.TrimSpace(bt) != "" {
+					bodyText = bt
+				}
 			} else {
-				// Best-effort: warn but still render metadata + URL rather than
-				// failing the whole command.
+				// Best-effort: warn but still render metadata + URL (and the
+				// list body) rather than failing the whole command.
 				fmt.Fprintf(errW, "Warning: could not load trail description: %v\n", derr)
 			}
 		}
@@ -234,8 +242,10 @@ func trailDescriptionForDisplay(bodyText string, loaded bool) string {
 }
 
 // trailWebURL builds the browser URL for a trail:
-// <web-origin>/<forge>/<owner>/<repo>/trails/<number>. The web app is co-hosted
-// with the data API, so the API base URL is the web origin.
+// <web-origin>/<forge>/<owner>/<repo>/trails/<number>. In production the web app
+// is served from the same origin as the data API, so the API base URL doubles
+// as the web origin. A split local-dev setup (API and frontend on different
+// ports) would point this at the API port rather than the dev frontend.
 func trailWebURL(base, forge, owner, repo string, number int) string {
 	return strings.TrimRight(base, "/") + "/" + forge + "/" + owner + "/" + repo + "/trails/" + strconv.Itoa(number)
 }

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -127,7 +127,29 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, sel
 			return err
 		}
 
-		printTrailDetails(w, found.ToMetadata())
+		// Enrich the list result with the detail endpoint, which carries the
+		// rendered description (trail.body_document.text_snapshot) the list
+		// omits, and surface a browser URL. The detail fetch is best-effort:
+		// the core metadata already came from the list, so a detail failure
+		// degrades to "no description" with a warning rather than failing.
+		m := found.ToMetadata()
+		webURL := ""
+		// The description lives only in the detail response (the list omits the
+		// body), so it's only known when the detail fetch below succeeds.
+		bodyText := ""
+		descriptionLoaded := false
+		if found.Number > 0 {
+			webURL = trailWebURL(api.BaseURL(), forge, owner, repo, found.Number)
+			if bt, derr := fetchTrailDescription(ctx, client, forge, owner, repo, found.Number); derr == nil {
+				bodyText = bt
+				descriptionLoaded = true
+			} else {
+				// Best-effort: warn but still render metadata + URL rather than
+				// failing the whole command.
+				fmt.Fprintf(errW, "Warning: could not load trail description: %v\n", derr)
+			}
+		}
+		printTrailDetails(w, m, webURL, trailDescriptionForDisplay(bodyText, descriptionLoaded))
 		return nil
 	})
 }
@@ -162,7 +184,7 @@ func resolveTrailBySelector(ctx context.Context, client *api.Client, forge, owne
 	return found, nil
 }
 
-func printTrailDetails(w io.Writer, m *trail.Metadata) {
+func printTrailDetails(w io.Writer, m *trail.Metadata, webURL, bodyText string) {
 	fmt.Fprintf(w, "Trail: %s\n", m.Title)
 	if m.Number > 0 {
 		fmt.Fprintf(w, "  Number:  %d\n", m.Number)
@@ -177,8 +199,8 @@ func printTrailDetails(w io.Writer, m *trail.Metadata) {
 	if strings.TrimSpace(m.Phase) != "" {
 		fmt.Fprintf(w, "  Phase:   %s\n", trailPhaseDisplay(m.Phase))
 	}
-	if m.Body != "" {
-		fmt.Fprintf(w, "  Body:    %s\n", m.Body)
+	if webURL != "" {
+		fmt.Fprintf(w, "  URL:     %s\n", webURL)
 	}
 	if len(m.Labels) > 0 {
 		fmt.Fprintf(w, "  Labels:  %s\n", strings.Join(m.Labels, ", "))
@@ -188,6 +210,60 @@ func printTrailDetails(w io.Writer, m *trail.Metadata) {
 	}
 	fmt.Fprintf(w, "  Created: %s\n", m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
 	fmt.Fprintf(w, "  Updated: %s\n", m.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	if strings.TrimSpace(bodyText) != "" {
+		fmt.Fprintf(w, "\nDescription:\n%s\n", bodyText)
+	}
+}
+
+// noTrailDescription is shown by `trail show` when a trail's description loaded
+// successfully but is empty — distinguishing "no description yet" from a load
+// failure (which warns and renders nothing).
+const noTrailDescription = "-- no description provided --"
+
+// trailDescriptionForDisplay returns the text `trail show` renders for the
+// description: the body when present; the placeholder when it loaded but is
+// empty; or "" when it couldn't be loaded (the caller has already warned).
+func trailDescriptionForDisplay(bodyText string, loaded bool) string {
+	if strings.TrimSpace(bodyText) != "" {
+		return bodyText
+	}
+	if loaded {
+		return noTrailDescription
+	}
+	return ""
+}
+
+// trailWebURL builds the browser URL for a trail:
+// <web-origin>/<forge>/<owner>/<repo>/trails/<number>. The web app is co-hosted
+// with the data API, so the API base URL is the web origin.
+func trailWebURL(base, forge, owner, repo string, number int) string {
+	return strings.TrimRight(base, "/") + "/" + forge + "/" + owner + "/" + repo + "/trails/" + strconv.Itoa(number)
+}
+
+// fetchTrailDescription fetches a trail's rendered description text
+// (`trail.body_document.text_snapshot`), which the list endpoint omits, by
+// integer number. It returns only the description — the list result already
+// supplies the metadata — and decodes only the fields it needs, so it is
+// unaffected by the shape of sibling fields like `checkpoints`/`thread`.
+func fetchTrailDescription(ctx context.Context, client *api.Client, forge, owner, repo string, number int) (string, error) {
+	resp, err := client.Get(ctx, trailNumberPath(forge, owner, repo, number))
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch trail detail: %w", err)
+	}
+	defer resp.Body.Close()
+	if err := checkTrailResponse(resp); err != nil {
+		return "", err
+	}
+	var detail struct {
+		Trail api.TrailResource `json:"trail"`
+	}
+	if err := api.DecodeJSON(resp, &detail); err != nil {
+		return "", fmt.Errorf("failed to decode trail detail: %w", err)
+	}
+	if detail.Trail.BodyDocument == nil {
+		return "", nil
+	}
+	return strings.TrimSpace(detail.Trail.BodyDocument.TextSnapshot), nil
 }
 
 func newTrailListCmd() *cobra.Command {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -323,7 +323,7 @@ func TestTrailDescriptionForDisplay(t *testing.T) {
 	}
 }
 
-func TestFetchTrailDetail_ReadsNestedBodyDocument(t *testing.T) {
+func TestFetchTrailDescription_ReadsNestedBodyDocument(t *testing.T) {
 	t.Parallel()
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/entire/cli/trail_cmd_test.go
+++ b/cmd/entire/cli/trail_cmd_test.go
@@ -290,6 +290,65 @@ func TestTrailNumberPath(t *testing.T) {
 	}
 }
 
+func TestTrailWebURL(t *testing.T) {
+	t.Parallel()
+	want := "https://entire.io/gh/acme/repo/trails/575"
+	if got := trailWebURL("https://entire.io", "gh", "acme", "repo", 575); got != want {
+		t.Fatalf("trailWebURL = %q, want %q", got, want)
+	}
+	// A trailing slash on the base must not double up.
+	if got := trailWebURL("https://entire.io/", "gh", "acme", "repo", 575); got != want {
+		t.Fatalf("trailWebURL(trailing slash) = %q, want %q", got, want)
+	}
+}
+
+func TestTrailDescriptionForDisplay(t *testing.T) {
+	t.Parallel()
+	if got := trailDescriptionForDisplay("the body", true); got != "the body" {
+		t.Fatalf("non-empty body: got %q, want %q", got, "the body")
+	}
+	if got := trailDescriptionForDisplay("the body", false); got != "the body" {
+		t.Fatalf("non-empty body (not loaded): got %q, want %q", got, "the body")
+	}
+	// Loaded but empty/whitespace → explicit placeholder.
+	if got := trailDescriptionForDisplay("", true); got != noTrailDescription {
+		t.Fatalf("loaded+empty: got %q, want %q", got, noTrailDescription)
+	}
+	if got := trailDescriptionForDisplay("   ", true); got != noTrailDescription {
+		t.Fatalf("loaded+whitespace: got %q, want %q", got, noTrailDescription)
+	}
+	// Not loaded (fetch failed) → nothing (the caller already warned).
+	if got := trailDescriptionForDisplay("", false); got != "" {
+		t.Fatalf("not loaded+empty: got %q, want empty", got)
+	}
+}
+
+func TestFetchTrailDetail_ReadsNestedBodyDocument(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		// Regression guard: body_document is nested under `trail`, and
+		// `checkpoints` is a bare array the decode must ignore.
+		if _, err := io.WriteString(w, `{"trail":{"number":777,"branch":"feat/x","body_document":{"text_snapshot":"the intent text"}},"checkpoints":[],"has_write_permission":true}`); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	bodyText, err := fetchTrailDescription(t.Context(), client, "gh", "acme", "repo", 777)
+	if err != nil {
+		t.Fatalf("fetchTrailDescription: %v", err)
+	}
+	if want := "/api/v1/trails/gh/acme/repo/777"; gotPath != want {
+		t.Fatalf("path = %q, want %q", gotPath, want)
+	}
+	if bodyText != "the intent text" {
+		t.Fatalf("bodyText = %q, want %q", bodyText, "the intent text")
+	}
+}
+
 func TestResolveCreateBranch(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -839,10 +898,32 @@ func TestPrintTrailDetailsOmitsWhitespacePhase(t *testing.T) {
 		Base:   "main",
 		Status: trail.StatusOpen,
 		Phase:  "   ",
-	})
+	}, "", "")
 
 	if text := out.String(); strings.Contains(text, "Phase:") {
 		t.Fatalf("expected whitespace phase to be omitted, got:\n%s", text)
+	}
+}
+
+func TestPrintTrailDetailsRendersURLAndDescription(t *testing.T) {
+	t.Parallel()
+	m := &trail.Metadata{Title: "T", Branch: "feat/a", Base: "main", Status: trail.StatusOpen}
+
+	var out bytes.Buffer
+	printTrailDetails(&out, m, "https://entire.io/gh/acme/repo/trails/5", "line one\nline two")
+	text := out.String()
+	if !strings.Contains(text, "URL:") || !strings.Contains(text, "https://entire.io/gh/acme/repo/trails/5") {
+		t.Fatalf("expected a URL line, got:\n%s", text)
+	}
+	if !strings.Contains(text, "Description:") || !strings.Contains(text, "line one\nline two") {
+		t.Fatalf("expected a Description block, got:\n%s", text)
+	}
+
+	// Empty URL and whitespace-only body are omitted.
+	out.Reset()
+	printTrailDetails(&out, m, "", "   ")
+	if text := out.String(); strings.Contains(text, "URL:") || strings.Contains(text, "Description:") {
+		t.Fatalf("expected URL/Description omitted for empty values, got:\n%s", text)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/616
<!-- entire-trail-link-end -->

## What

`entire trail show` now renders the two things missing from it:
1. **The trail description / intent** — fetched from the detail endpoint (`trail.body_document.text_snapshot`), which the list endpoint omits. This is the same content the web UI shows at the top of the trail page (the collaborative body editor).
2. **A browser URL** for the trail (`BaseURL()/gh/<owner>/<repo>/trails/<number>`; the web app is co-hosted with the data API).

## Notes

- `body_document` is nested under `trail` in the detail response (not top-level); `fetchTrailDetail` decodes only `trail` + `body_document`, so it's unaffected by the `checkpoints`/`thread` shapes. A regression test pins the nested path.
- The detail fetch is **best-effort**: the core metadata already came from the list lookup, so a detail-fetch failure warns to stderr and still prints metadata + URL (degrades to "no description"; falls back to `found.Body`).
- No URL/description for number-less trails (the detail endpoint is keyed by the integer number).

## Testing

- `TestTrailWebURL` (incl. trailing-slash dedup), `TestFetchTrailDetail_ReadsNestedBodyDocument` (httptest; nested-body path + ignores the `checkpoints` array), `TestPrintTrailDetailsRendersURLAndDescription` (URL + Description render; empty/whitespace omitted).
- Verified live: `entire trail show <n>` now prints the Description + URL.
- `gofmt` clean; `golangci-lint` 0 issues.
- Reviewed via pr-review-toolkit (code / tests / silent-failure); findings addressed.

Tracked by Entire trail #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI display and an extra GET on `trail show`; metadata still comes from list lookup and detail failures degrade gracefully.
> 
> **Overview**
> **`entire trail show`** now prints a **browser URL** (from the API base + forge/owner/repo/trails/number) and the trail **description** from the detail API’s `trail.body_document.text_snapshot`, which the list response does not include.
> 
> After the usual list lookup, the command **best-effort** calls the per-number detail endpoint via new `fetchTrailDescription`; failures warn on stderr but still show metadata and the URL. Descriptions use a **Description** block instead of inline **Body**; empty loaded descriptions show `-- no description provided --`. Trails without a number skip URL and description fetch.
> 
> `TrailResource` gains optional **`BodyDocument`** / **`TrailBodyDocument`** types for JSON decoding. Tests cover URL building, display helpers, nested body decode, and output formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db9051c7ee5e4838b02d75a6a4c3e67d4d377a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->