### PR TITLE
fix: display the core a request actually dials (mirror list, auth status)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -444,6 +444,30 @@ relPath := paths.ToRelativePath("/repo/api/file.ts", repoRoot)  // returns "api/
 
 Test case in `state_test.go`: `TestFilterAndNormalizePaths_SiblingDirectories` documents this bug pattern.
 
+### Control-Plane Core Resolution (which core am I talking to?)
+
+Control-plane commands dial one of three cores: the active context's
+(`coreapi.New`), a specific cluster's (`coreapi.NewForCluster`), or — when
+`ENTIRE_TOKEN` is set — the env token's `aud` (the bypass inside `New`/
+`NewForCluster`). This precedence lives **only** inside `coreapi`; nothing else
+re-derives it.
+
+**To display which core a request uses, ask the client: `client.CoreOrigin()`.**
+It returns whatever was actually wired in, so the shown core can never diverge
+from where the request goes. **Do NOT** re-resolve with
+`auth.ResolveControlPlaneTarget()` for display — it only knows the active
+context and silently ignores both `ENTIRE_TOKEN` and the cluster case, so it can
+name a core the request never touches (this was a real bug in the `mirror list`
+banner; see `repo_mirror.go` and `coreapi.Client.CoreOrigin`).
+
+When a command resolves auth *outside* a `coreapi.Client` (e.g. `entire auth
+status`, which builds its own `/me` client), it must apply the same
+env-token-first precedence itself — see `resolveAuthStatusTarget` /
+`resolveEnvTokenStatusTarget` in `auth.go`, which branch on
+`auth.EnvTokenVar` before falling back to the active context. `logout` is the
+deliberate exception: it manages a *stored* login session, which an ephemeral
+env token has none of, so it stays on the active context.
+
 ### Session Strategy (`cmd/entire/cli/strategy/`)
 
 The CLI uses a manual-commit strategy for managing session data and checkpoints. The strategy implements the `Strategy` interface defined in `strategy.go`.

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -130,7 +131,7 @@ func newAuthStatusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "Show authentication status",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			target, err := resolveStatusTarget(cmd.Context(), auth.Contexts, auth.RefreshedLoginToken)
+			target, err := resolveAuthStatusTarget(cmd.Context(), auth.Contexts, auth.RefreshedLoginToken)
 			if err != nil {
 				return err
 			}
@@ -179,11 +180,43 @@ type loginTokenResolver func(ctx context.Context, c *contexts.Context) (string, 
 // CoreURL + its session token. Zero coreURL/token means not logged in.
 // Shared by `auth status` (profile + session list) and `logout`
 // (revocation) so both hit the same login server.
+//
+// envToken marks the target as resolved from ENTIRE_TOKEN rather than a stored
+// context: the bearer is the env token itself, sent verbatim to its own aud,
+// and there is no stored session to manage — so status renders it without the
+// context/keychain/session lines.
 type statusTarget struct {
 	coreURL       string
 	token         string
 	activeContext string
 	totalContexts int
+	envToken      bool
+}
+
+// resolveAuthStatusTarget picks the target for `entire auth status`, honouring
+// ENTIRE_TOKEN: when it is set the request dials the token's own aud (exactly
+// as coreapi.New does), so status must report that core, not a stored context
+// that the request never touches. `logout` deliberately does NOT use this —
+// logout manages a stored login session, which an ephemeral env token has none
+// of, so it stays on resolveStatusTarget (the active context).
+func resolveAuthStatusTarget(ctx context.Context, listContexts contextsProvider, resolveLogin loginTokenResolver) (statusTarget, error) {
+	if raw, ok := os.LookupEnv(auth.EnvTokenVar); ok {
+		return resolveEnvTokenStatusTarget(raw)
+	}
+	return resolveStatusTarget(ctx, listContexts, resolveLogin)
+}
+
+// resolveEnvTokenStatusTarget builds the status target from ENTIRE_TOKEN via the
+// shared auth.ParseEnvToken — the same trim/blank/aud validation coreapi.New
+// applies — so status reports exactly the core a request would dial. The token
+// is the bearer; fail-closed (a blank or malformed value errors, never falls
+// back to a stored context).
+func resolveEnvTokenStatusTarget(raw string) (statusTarget, error) {
+	coreURL, token, err := auth.ParseEnvToken(raw)
+	if err != nil {
+		return statusTarget{}, err //nolint:wrapcheck // auth.ParseEnvToken already prefixes with EnvTokenVar
+	}
+	return statusTarget{coreURL: coreURL, token: token, envToken: true}, nil
 }
 
 // resolveStatusTarget picks the core + token for `entire auth status` (and
@@ -282,6 +315,15 @@ func runAuthStatus(ctx context.Context, w io.Writer, fetchProfile profileFetcher
 
 	fmt.Fprintf(w, "Logged in to %s\n", t.coreURL)
 	writeProfileLines(w, profile)
+
+	// ENTIRE_TOKEN mode: no stored context, keychain slot, or revocable
+	// session — the bearer is the env var itself. Name that and stop, rather
+	// than printing context/keychain/session lines that don't apply.
+	if t.envToken {
+		fmt.Fprintf(w, "  %-9s %s\n", "Token:", auth.EnvTokenVar+" environment variable")
+		return nil
+	}
+
 	if t.activeContext != "" {
 		fmt.Fprintf(w, "  %-9s %s\n", "Context:", t.activeContext)
 	}

--- a/cmd/entire/cli/auth/env_token.go
+++ b/cmd/entire/cli/auth/env_token.go
@@ -15,6 +15,25 @@ import (
 // without an interactive `entire login`.
 const EnvTokenVar = "ENTIRE_TOKEN"
 
+// ParseEnvToken is the single owner of the ENTIRE_TOKEN validation sequence
+// shared by coreapi.New's bypass and `entire auth status`: it trims the raw
+// value, enforces fail-closed that it is non-blank, and derives the control-
+// plane core origin from its aud via CoreURLFromEnvToken. Callers pass the raw
+// env value (presence is the caller's LookupEnv decision) and send the returned
+// token verbatim as the bearer to coreURL. A blank or aud-less value is an
+// error, never a silent fall-back to context resolution.
+func ParseEnvToken(raw string) (coreURL, token string, err error) {
+	token = strings.TrimSpace(raw)
+	if token == "" {
+		return "", "", fmt.Errorf("%s is set but blank", EnvTokenVar)
+	}
+	coreURL, err = CoreURLFromEnvToken(token)
+	if err != nil {
+		return "", "", err
+	}
+	return coreURL, token, nil
+}
+
 // CoreURLFromEnvToken derives the home-region core URL from an ENTIRE_TOKEN
 // JWT's audience claim. Login and sa-session JWTs carry aud=<home-region URL>,
 // which is what STS routing keys on — so we read aud, not iss (iss may be a

--- a/cmd/entire/cli/auth/env_token_test.go
+++ b/cmd/entire/cli/auth/env_token_test.go
@@ -131,3 +131,34 @@ func TestCoreURLFromEnvToken_RejectsAlgNone(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), EnvTokenVar)
 }
+
+// ParseEnvToken owns the shared trim → blank-check → aud-derivation sequence.
+// Unlike CoreURLFromEnvToken it DOES trim, and it returns the (trimmed) token
+// so callers send the same bytes verbatim as the bearer.
+func TestParseEnvToken(t *testing.T) {
+	t.Parallel()
+	const core = "https://core.us.entire.io"
+	tok := makeJWT(t, `{"sub":"ci-runner","aud":"`+core+`"}`)
+
+	t.Run("trims and returns aud core + trimmed token", func(t *testing.T) {
+		t.Parallel()
+		coreURL, token, err := ParseEnvToken("  " + tok + "\n")
+		require.NoError(t, err)
+		assert.Equal(t, core, coreURL)
+		assert.Equal(t, tok, token, "token must be returned trimmed for verbatim bearer use")
+	})
+
+	t.Run("blank is fail-closed", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := ParseEnvToken("   ")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), EnvTokenVar)
+	})
+
+	t.Run("no URL aud is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := ParseEnvToken(makeJWT(t, `{"sub":"ci-runner"}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), EnvTokenVar)
+	})
+}

--- a/cmd/entire/cli/auth_test.go
+++ b/cmd/entire/cli/auth_test.go
@@ -90,6 +90,81 @@ func TestRunAuthStatus_LoggedIn(t *testing.T) {
 	}
 }
 
+// In ENTIRE_TOKEN mode there is no stored context, keychain slot, or revocable
+// session: status names the env-token core and bearer source, and renders none
+// of the context/keychain/session lines. listSessions must not be called — you
+// can't manage an env-token session.
+func TestRunAuthStatus_EnvTokenMode(t *testing.T) {
+	t.Parallel()
+
+	target := statusTarget{coreURL: testCoreURL, token: "tok", envToken: true}
+	listSessions := func(context.Context, string, string) ([]api.AuthSession, error) {
+		t.Helper()
+		t.Fatal("listSessions must not be called in ENTIRE_TOKEN mode")
+		return nil, nil
+	}
+
+	var out bytes.Buffer
+	if err := runAuthStatus(context.Background(), &out, okProfile, listSessions, target); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "Logged in to "+testCoreURL) {
+		t.Fatalf("output = %q, want 'Logged in' to the env token's core", got)
+	}
+	if !strings.Contains(got, "Alice Smith") {
+		t.Fatalf("output = %q, want the profile header", got)
+	}
+	if !strings.Contains(got, auth.EnvTokenVar+" environment variable") {
+		t.Fatalf("output = %q, want the ENTIRE_TOKEN bearer note", got)
+	}
+	for _, unwanted := range []string{"Context:", "stored in OS keychain", "Active sessions", "login contexts saved"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("output = %q, must not contain %q in ENTIRE_TOKEN mode", got, unwanted)
+		}
+	}
+}
+
+// resolveEnvTokenStatusTarget reads the core from the token's aud (the same
+// origin coreapi.New dials) and uses the token verbatim as the bearer; a blank
+// or aud-less token is a fail-closed error, never a fall-back to a context.
+func TestResolveEnvTokenStatusTarget(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid token yields aud core + verbatim bearer", func(t *testing.T) {
+		t.Parallel()
+		tok := makeJWT(t, `{"alg":"HS256","typ":"JWT"}`, `{"aud":"`+testCoreURL+`"}`)
+		got, err := resolveEnvTokenStatusTarget("  " + tok + "  ") // surrounding whitespace trimmed
+		if err != nil {
+			t.Fatalf("resolveEnvTokenStatusTarget: %v", err)
+		}
+		if got.coreURL != testCoreURL {
+			t.Fatalf("coreURL = %q, want the token's aud %q", got.coreURL, testCoreURL)
+		}
+		if got.token != tok {
+			t.Fatalf("token = %q, want the verbatim env token", got.token)
+		}
+		if !got.envToken {
+			t.Fatal("envToken = false, want true")
+		}
+	})
+
+	t.Run("blank is fail-closed", func(t *testing.T) {
+		t.Parallel()
+		if _, err := resolveEnvTokenStatusTarget("   "); err == nil {
+			t.Fatal("want an error for a blank ENTIRE_TOKEN, got nil")
+		}
+	})
+
+	t.Run("token without a URL aud is rejected", func(t *testing.T) {
+		t.Parallel()
+		tok := makeJWT(t, `{"alg":"HS256","typ":"JWT"}`, `{"sub":"ci-runner"}`)
+		if _, err := resolveEnvTokenStatusTarget(tok); err == nil {
+			t.Fatal("want an error when the token has no URL-shaped aud, got nil")
+		}
+	})
+}
+
 func TestRunAuthStatus_RendersSessionsTable(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -239,20 +239,20 @@ func newRepoMirrorListCmd() *cobra.Command {
 		Short: "List mirrors you can see",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// mirror list is identity-scoped: it shows the mirrors visible from
-			// the active login's federation, so name that login server. It makes
-			// a surprising empty result legible — e.g. mirrors that live in a
-			// different deployment than the active context (--cluster is a filter,
-			// not a router). Reuses the same target coreapi.New dials. Best-effort:
-			// no header rather than a hard failure if the active context can't be
-			// resolved. Skipped for --json to keep machine output clean; on stderr
-			// so it never lands in a piped table.
-			if !jsonRequested(cmd) {
-				if t, err := auth.ResolveControlPlaneTarget(); err == nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "Listing mirrors on %s\n", t.CoreURL)
-				}
-			}
 			return runCoreList(cmd, mirrorColumns, mirrorRow, func(ctx context.Context, c *coreapi.Client) ([]coreapi.Mirror, error) {
+				// mirror list is identity-scoped: it shows the mirrors visible
+				// from the active login's federation, so naming that login server
+				// makes a surprising empty result legible — e.g. mirrors in a
+				// different deployment than the active context (--cluster is a
+				// filter, not a router). Name the core the client actually dials
+				// (c.CoreOrigin) so the banner can never diverge from where the
+				// request goes — in particular it reflects ENTIRE_TOKEN's aud,
+				// which a separately-resolved ResolveControlPlaneTarget would miss.
+				// On stderr so it never lands in a piped table; skipped for --json
+				// to keep machine output clean.
+				if !jsonRequested(cmd) {
+					fmt.Fprintf(cmd.ErrOrStderr(), "Listing mirrors on %s\n", c.CoreOrigin())
+				}
 				var params coreapi.ListMirrorsParams
 				if cluster != "" {
 					params.Cluster = coreapi.NewOptString(cluster)

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -104,13 +104,9 @@ func clientFromEnvToken() (*Client, bool, error) {
 	if !ok {
 		return nil, false, nil
 	}
-	envToken := strings.TrimSpace(raw)
-	if envToken == "" {
-		return nil, true, fmt.Errorf("%s is set but blank", auth.EnvTokenVar)
-	}
-	coreURL, err := auth.CoreURLFromEnvToken(envToken)
+	coreURL, envToken, err := auth.ParseEnvToken(raw)
 	if err != nil {
-		return nil, true, err //nolint:wrapcheck // CoreURLFromEnvToken already prefixes with EnvTokenVar
+		return nil, true, err //nolint:wrapcheck // auth.ParseEnvToken already prefixes with EnvTokenVar
 	}
 	client, err := NewWithBearer(coreURL, envToken)
 	return client, true, err
@@ -126,6 +122,18 @@ func clientForTarget(target auth.ControlPlaneTarget) (*Client, error) {
 		return nil, fmt.Errorf("build Entire API client: %w", err)
 	}
 	return client, nil
+}
+
+// CoreOrigin reports the control-plane core origin this client dials —
+// scheme://host, the apiBasePath stripped. It is the single source of truth
+// for "which core am I talking to": whether the client came from New (active
+// context), NewForCluster (the cluster's core), or the ENTIRE_TOKEN bypass
+// (the token's aud), the origin is whatever was actually wired in. Use it for
+// user-facing "talking to <core>" output so the named core can never diverge
+// from where requests go — re-deriving it from ResolveControlPlaneTarget would
+// silently miss the ENTIRE_TOKEN and cluster cases.
+func (c *Client) CoreOrigin() string {
+	return c.serverURL.Scheme + "://" + c.serverURL.Host
 }
 
 // NewWithBearer returns a *Client targeting an explicit core origin with a

--- a/internal/coreapi/client_test.go
+++ b/internal/coreapi/client_test.go
@@ -2,6 +2,7 @@ package coreapi
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,6 +14,63 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 )
+
+// CoreOrigin reports the scheme://host the client dials, with the apiBasePath
+// (and any trailing slash) stripped — the single source of truth display sites
+// use so the named core can't diverge from where requests go.
+func TestClient_CoreOrigin(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		coreURL string
+		want    string
+	}{
+		{name: "bare origin", coreURL: "https://eu.auth.entire.io", want: "https://eu.auth.entire.io"},
+		{name: "trailing slash", coreURL: "https://eu.auth.entire.io/", want: "https://eu.auth.entire.io"},
+		{name: "with port", coreURL: "https://localhost:8443", want: "https://localhost:8443"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c, err := NewWithBearer(tt.coreURL, "tok")
+			if err != nil {
+				t.Fatalf("NewWithBearer: %v", err)
+			}
+			if got := c.CoreOrigin(); got != tt.want {
+				t.Fatalf("CoreOrigin() = %q, want %q (apiBasePath and trailing slash must be stripped)", got, tt.want)
+			}
+		})
+	}
+}
+
+// The whole point of the getter: a client built through the ENTIRE_TOKEN bypass
+// reports the token's aud, so a display site asking the client "which core?"
+// names the core the request actually dials — not a stale active context that a
+// separate ResolveControlPlaneTarget would return.
+//
+// Not parallel: sets ENTIRE_TOKEN (process-global).
+func TestNew_CoreOrigin_HonoursEnvToken(t *testing.T) {
+	const core = "https://core.us.entire.io"
+	t.Setenv(auth.EnvTokenVar, makeAudJWT(core))
+	c, err := New()
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if got := c.CoreOrigin(); got != core {
+		t.Fatalf("CoreOrigin() = %q, want the env token's aud %q", got, core)
+	}
+}
+
+// makeAudJWT builds a JWT carrying only an aud claim. CoreURLFromEnvToken reads
+// aud without verifying the signature, so the "sig" is a placeholder — but the
+// header must name a real alg (alg:none is refused), matching how login JWTs
+// look on the wire.
+func makeAudJWT(aud string) string {
+	enc := base64.RawURLEncoding
+	header := enc.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := enc.EncodeToString([]byte(`{"aud":"` + aud + `"}`))
+	return header + "." + payload + "." + enc.EncodeToString([]byte("sig"))
+}
 
 func TestAPIError(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/620
<!-- entire-trail-link-end -->

## Problem

The `entire repo mirror list` banner ("Listing mirrors on …") re-derived its core via `auth.ResolveControlPlaneTarget()`, which **ignores `ENTIRE_TOKEN`**. In env-token mode the request actually dials the token's own `aud` (via `coreapi.New` → `clientFromEnvToken`), so when both `ENTIRE_TOKEN` and a `contexts.json` were present, the banner named a core the request never talks to.

Root cause: the env-token-then-active-context precedence lives **only** inside `coreapi.New`, and the `coreapi.Client` hid its resolved core (`serverURL` is unexported, no getter). So every "talking to X" display site was forced to re-derive the core independently — and could get it wrong. `entire auth status` had the same latent bug (it reports the active context's core, ignoring `ENTIRE_TOKEN`).

## Fix

- **`coreapi.Client.CoreOrigin()`** — single source of truth for "which core am I dialing", reporting whatever was actually wired in (active context, `NewForCluster`'s cluster core, or the `ENTIRE_TOKEN` aud). Display can no longer diverge from the request.
- **`mirror list`** now renders the banner from the live client's `CoreOrigin()` — correct (not suppressed) in env-token mode.
- **`entire auth status`** applies the env-token-first precedence (it builds its own `/me` client outside `coreapi`), reporting the env token's core + bearer instead of a stale active context. **`logout` deliberately stays on the active context** — it manages a *stored* login session, which an ephemeral env token has none of.
- **`auth.ParseEnvToken`** extracted as the single owner of the `ENTIRE_TOKEN` trim/blank/aud-validation sequence (was duplicated inline in `coreapi.New`'s bypass and `auth status`).
- **CLAUDE.md** documents the convention: to show which core, ask the client (`CoreOrigin`); never re-resolve for display.

## Tests

- `coreapi`: `TestClient_CoreOrigin`, `TestNew_CoreOrigin_HonoursEnvToken`
- `auth`: `TestParseEnvToken`
- `cli`: `TestRunAuthStatus_EnvTokenMode`, `TestResolveEnvTokenStatusTarget`

`mise run fmt` + `lint` (0 issues) + full unit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing auth/status and mirror list messaging only; behavior matches existing request routing in coreapi, with added tests and no change to logout or token exchange semantics.
> 
> **Overview**
> Fixes misleading **"which core am I talking to?"** output when `ENTIRE_TOKEN` is set alongside a saved login context: banners and `entire auth status` could name the active context while requests went to the token's `aud`.
> 
> Adds **`coreapi.Client.CoreOrigin()`** as the display source of truth for wired-in clients. **`entire repo mirror list`** now prints its stderr banner from `c.CoreOrigin()` instead of `auth.ResolveControlPlaneTarget()`.
> 
> **`entire auth status`** uses **`resolveAuthStatusTarget`**, which prefers `ENTIRE_TOKEN` via shared **`auth.ParseEnvToken`** (also used by `clientFromEnvToken`); env-token mode shows the env var as the bearer and skips context/keychain/session lines. **`logout`** still uses the active context only.
> 
> **CLAUDE.md** documents the convention: use `CoreOrigin()` for display; don't re-resolve for UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fbe7bcf66dee2b15523505bf79225500616b101. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->