### PR TITLE
checkpoint: unify committed writes behind Store.Write(ctx, WriteRequest)

### DIFF
--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -337,7 +337,7 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		writeOpts.HasReview = true
 	}
 
-	if err := store.WriteCommitted(ctx, writeOpts); err != nil {
+	if err := store.Write(ctx, cpkg.WriteSession(writeOpts)); err != nil {
 		return fmt.Errorf("failed to write checkpoint: %w", err)
 	}
 

--- a/cmd/entire/cli/benchutil/benchutil.go
+++ b/cmd/entire/cli/benchutil/benchutil.go
@@ -398,7 +398,7 @@ func (br *BenchRepo) SeedMetadataBranch(b *testing.B, checkpointCount int) {
 			files = append(files, fmt.Sprintf("src/file_%03d.go", (i*5+j)%100))
 		}
 
-		err = br.Store.WriteCommitted(context.Background(), checkpoint.WriteCommittedOptions{
+		err = br.Store.Write(context.Background(), checkpoint.WriteSession{
 			CheckpointID:     cpID,
 			SessionID:        sessionID,
 			Strategy:         br.Strategy,

--- a/cmd/entire/cli/checkpoint/committed_reader_resolve.go
+++ b/cmd/entire/cli/checkpoint/committed_reader_resolve.go
@@ -21,19 +21,14 @@ type CommittedListReader interface {
 	ReadSessionPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (string, error)
 }
 
-// CommittedWriter provides write access to committed checkpoint data.
-type CommittedWriter interface {
-	WriteCommitted(ctx context.Context, opts WriteCommittedOptions) error
-	UpdateCommitted(ctx context.Context, opts UpdateCommittedOptions) error
-	UpdateSummary(ctx context.Context, checkpointID id.CheckpointID, summary *Summary) error
-	UpdateCheckpointSummary(ctx context.Context, checkpointID id.CheckpointID, combinedAttribution *InitialAttribution) error
-}
-
 // CommittedStore provides the production committed checkpoint storage surface.
+// Writes go through the unified Writer.Write(ctx, WriteRequest); the concrete
+// per-operation methods (WriteCommitted/UpdateCommitted/...) remain on GitStore
+// as the implementation Write dispatches to.
 type CommittedStore interface {
 	CommittedListReader
 	ReadSessionMetadataAndPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*SessionContent, error)
-	CommittedWriter
+	Writer
 }
 
 // AuthorReader provides optional checkpoint author lookup.

--- a/cmd/entire/cli/checkpoint/committed_write.go
+++ b/cmd/entire/cli/checkpoint/committed_write.go
@@ -7,9 +7,9 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 )
 
-// WriteRequest is a single committed-store write command. The set is closed:
-// the only implementations are the request types in this file, sealed via the
-// unexported isWriteRequest marker. A store dispatches on the concrete type;
+// WriteRequest is a single committed-store write command. The set is closed to
+// other packages: only types in package checkpoint can implement it, sealed via
+// the unexported isWriteRequest marker. A store dispatches on the concrete type;
 // a mirror/fan-out store forwards the same value to each backend's Write.
 //
 // This replaces the four separate writer methods (WriteCommitted /

--- a/cmd/entire/cli/checkpoint/committed_write.go
+++ b/cmd/entire/cli/checkpoint/committed_write.go
@@ -1,0 +1,74 @@
+package checkpoint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+)
+
+// WriteRequest is a single committed-store write command. The set is closed:
+// the only implementations are the request types in this file, sealed via the
+// unexported isWriteRequest marker. A store dispatches on the concrete type;
+// a mirror/fan-out store forwards the same value to each backend's Write.
+//
+// This replaces the four separate writer methods (WriteCommitted /
+// UpdateCommitted / UpdateSummary / UpdateCheckpointSummary) with one
+// Store.Write(ctx, req) entry point, so adding a write operation is a new
+// request type plus one dispatch case — the Store interface stays unchanged
+// and existing backends keep compiling.
+type WriteRequest interface {
+	isWriteRequest()
+}
+
+// WriteSession creates or replaces a session document within a checkpoint,
+// materializing the checkpoint on its first session. This is condensation's
+// write. (Maps to the former WriteCommitted.)
+type WriteSession WriteCommittedOptions
+
+// BackfillTranscript replaces a session's transcript, prompts, and skill
+// events at stop time without clobbering sibling fields. (Maps to the former
+// UpdateCommitted.)
+type BackfillTranscript UpdateCommittedOptions
+
+// BackfillSummary rewrites only the summary of the checkpoint's latest
+// session. (Maps to the former UpdateSummary.)
+type BackfillSummary struct {
+	CheckpointID id.CheckpointID
+	Summary      *Summary
+}
+
+// BackfillAttribution rewrites the checkpoint root's combined attribution.
+// (Maps to the former UpdateCheckpointSummary.)
+type BackfillAttribution struct {
+	CheckpointID id.CheckpointID
+	Attribution  *InitialAttribution
+}
+
+func (WriteSession) isWriteRequest()        {}
+func (BackfillTranscript) isWriteRequest()  {}
+func (BackfillSummary) isWriteRequest()     {}
+func (BackfillAttribution) isWriteRequest() {}
+
+// Writer is the committed-store write surface: a single Write that accepts any
+// WriteRequest. It is the natural type for mirror fan-out.
+type Writer interface {
+	Write(ctx context.Context, req WriteRequest) error
+}
+
+// Write dispatches a committed write request to the matching git operation.
+// Unknown request types are a programmer error, surfaced rather than ignored.
+func (s *GitStore) Write(ctx context.Context, req WriteRequest) error {
+	switch r := req.(type) {
+	case WriteSession:
+		return s.WriteCommitted(ctx, WriteCommittedOptions(r))
+	case BackfillTranscript:
+		return s.UpdateCommitted(ctx, UpdateCommittedOptions(r))
+	case BackfillSummary:
+		return s.UpdateSummary(ctx, r.CheckpointID, r.Summary)
+	case BackfillAttribution:
+		return s.UpdateCheckpointSummary(ctx, r.CheckpointID, r.Attribution)
+	default:
+		return fmt.Errorf("checkpoint: unsupported write request %T", req)
+	}
+}

--- a/cmd/entire/cli/checkpoint/committed_write_test.go
+++ b/cmd/entire/cli/checkpoint/committed_write_test.go
@@ -1,0 +1,122 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/redact"
+)
+
+// unknownWriteRequest is a WriteRequest the dispatcher does not handle. It is
+// sealed into the union via the unexported marker (only possible in-package),
+// which lets the test exercise the default branch.
+type unknownWriteRequest struct{}
+
+func (unknownWriteRequest) isWriteRequest() {}
+
+// TestWrite_DispatchesEachRequest verifies that Store.Write routes each request
+// type to the corresponding git operation, observing the effect of each.
+func TestWrite_DispatchesEachRequest(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo, DefaultV1Refs())
+	ctx := context.Background()
+	cpID := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	// WriteSession materializes the checkpoint on first session.
+	if err := store.Write(ctx, WriteSession{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("provisional\n")),
+		Prompts:      []string{"initial"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}); err != nil {
+		t.Fatalf("Write(WriteSession) error = %v", err)
+	}
+	summary, err := store.ReadCommitted(ctx, cpID)
+	if err != nil || summary == nil {
+		t.Fatalf("checkpoint not created by WriteSession: summary=%v err=%v", summary, err)
+	}
+
+	// BackfillTranscript replaces the session transcript.
+	full := []byte("full line 1\nfull line 2\n")
+	if err := store.Write(ctx, BackfillTranscript{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Transcript:   redact.AlreadyRedacted(full),
+	}); err != nil {
+		t.Fatalf("Write(BackfillTranscript) error = %v", err)
+	}
+	content, err := store.ReadSessionContent(ctx, cpID, 0)
+	if err != nil {
+		t.Fatalf("ReadSessionContent() error = %v", err)
+	}
+	if string(content.Transcript) != string(full) {
+		t.Errorf("BackfillTranscript not applied: got %q want %q", content.Transcript, full)
+	}
+
+	// BackfillSummary rewrites the latest session's summary.
+	if err := store.Write(ctx, BackfillSummary{
+		CheckpointID: cpID,
+		Summary:      &Summary{Intent: "why", Outcome: "what"},
+	}); err != nil {
+		t.Fatalf("Write(BackfillSummary) error = %v", err)
+	}
+	if meta := readLatestSessionMetadata(t, repo, cpID); meta.Summary == nil || meta.Summary.Intent != "why" {
+		t.Errorf("BackfillSummary not applied: %+v", meta.Summary)
+	}
+
+	// BackfillAttribution rewrites the checkpoint root combined attribution.
+	if err := store.Write(ctx, BackfillAttribution{
+		CheckpointID: cpID,
+		Attribution:  &InitialAttribution{AgentLines: 42},
+	}); err != nil {
+		t.Fatalf("Write(BackfillAttribution) error = %v", err)
+	}
+	rootSummary, err := store.ReadCommitted(ctx, cpID)
+	if err != nil {
+		t.Fatalf("ReadCommitted() error = %v", err)
+	}
+	if rootSummary.CombinedAttribution == nil || rootSummary.CombinedAttribution.AgentLines != 42 {
+		t.Errorf("BackfillAttribution not applied: %+v", rootSummary.CombinedAttribution)
+	}
+}
+
+// TestWrite_UnknownRequestErrors verifies the dispatcher surfaces an
+// unhandled request type rather than silently ignoring it.
+func TestWrite_UnknownRequestErrors(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo, DefaultV1Refs())
+
+	err := store.Write(context.Background(), unknownWriteRequest{})
+	if err == nil {
+		t.Fatal("Write(unknownWriteRequest) should error")
+	}
+	if !strings.Contains(err.Error(), "unsupported write request") {
+		t.Errorf("error = %v, want mention of unsupported write request", err)
+	}
+}
+
+// TestWrite_BackfillSummaryNotFound verifies error propagation through dispatch.
+func TestWrite_BackfillSummaryNotFound(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo, DefaultV1Refs())
+	if err := store.ensureSessionsBranch(context.Background()); err != nil {
+		t.Fatalf("ensureSessionsBranch() error = %v", err)
+	}
+
+	err := store.Write(context.Background(), BackfillSummary{
+		CheckpointID: id.MustCheckpointID("000000000000"),
+		Summary:      &Summary{Intent: "x"},
+	})
+	if !errors.Is(err, ErrCheckpointNotFound) {
+		t.Errorf("Write(BackfillSummary) error = %v, want ErrCheckpointNotFound", err)
+	}
+}

--- a/cmd/entire/cli/checkpoint/store.go
+++ b/cmd/entire/cli/checkpoint/store.go
@@ -56,3 +56,6 @@ func (s *GitStore) setPrimaryRef(hash plumbing.Hash) error {
 	}
 	return nil
 }
+
+// Compile-time check: GitStore satisfies the unified write surface.
+var _ Writer = (*GitStore)(nil)

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -888,10 +888,6 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 	return lookup, nil
 }
 
-type checkpointSummaryUpdater interface {
-	Write(ctx context.Context, req checkpoint.WriteRequest) error
-}
-
 // generateCheckpointSummary generates an AI summary for a checkpoint and persists it.
 // The summary is generated from the scoped transcript (only this checkpoint's portion),
 // not the entire session transcript.
@@ -899,7 +895,7 @@ type checkpointSummaryUpdater interface {
 // summaryTimeoutSeconds is the per-invocation --summary-timeout-seconds flag
 // value (0 = unset). Effective precedence for the deadline: flag > settings >
 // package default. See resolveSummaryTimeout for the resolution.
-func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store checkpointSummaryUpdater, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
+func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store checkpoint.Writer, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
 	// Check if summary already exists
 	if content.Metadata.Summary != nil && !force {
 		return renderExplainFailure(errW, "Summary already exists", []explainRow{

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -889,7 +889,7 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 }
 
 type checkpointSummaryUpdater interface {
-	UpdateSummary(ctx context.Context, checkpointID id.CheckpointID, summary *checkpoint.Summary) error
+	Write(ctx context.Context, req checkpoint.WriteRequest) error
 }
 
 // generateCheckpointSummary generates an AI summary for a checkpoint and persists it.
@@ -946,7 +946,7 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store che
 	}
 	elapsed := time.Since(start)
 
-	if err := store.UpdateSummary(ctx, checkpointID, summary); err != nil {
+	if err := store.Write(ctx, checkpoint.BackfillSummary{CheckpointID: checkpointID, Summary: summary}); err != nil {
 		return fmt.Errorf("failed to save summary: %w", err)
 	}
 

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1011,7 +1011,7 @@ func TestGenerateCheckpointSummary_AdvancesV1Metadata(t *testing.T) {
 	require.NoError(t, err)
 	store := stores.Primary
 	cpID := id.MustCheckpointID("a1b2c3d4e5f6")
-	require.NoError(t, store.WriteCommitted(ctx, checkpoint.WriteCommittedOptions{
+	require.NoError(t, store.Write(ctx, checkpoint.WriteSession{
 		CheckpointID: cpID,
 		SessionID:    "session-001",
 		Strategy:     "manual-commit",

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -290,7 +290,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 
 	writeV1Start := time.Now()
 	writeCtx, writeCommittedSpan := perf.Start(ctx, "write_committed_v1")
-	if err := store.WriteCommitted(writeCtx, writeOpts); err != nil {
+	if err := store.Write(writeCtx, cpkg.WriteSession(writeOpts)); err != nil {
 		writeCommittedSpan.RecordError(err)
 		writeCommittedSpan.End()
 		return nil, fmt.Errorf("failed to write checkpoint metadata: %w", err)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1158,7 +1158,7 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 		slog.Float64("agent_percentage", agentPercentage),
 	)
 
-	if err := store.UpdateCheckpointSummary(ctx, checkpointID, combined); err != nil {
+	if err := store.Write(ctx, checkpoint.BackfillAttribution{CheckpointID: checkpointID, Attribution: combined}); err != nil {
 		return fmt.Errorf("persisting combined attribution: %w", err)
 	}
 
@@ -2830,7 +2830,7 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 			PrecomputedBlobs: precomputed,
 		}
 
-		updateErr := store.UpdateCommitted(ctx, updateOpts)
+		updateErr := store.Write(ctx, checkpoint.BackfillTranscript(updateOpts))
 		if updateErr != nil {
 			logging.Warn(logCtx, "finalize: failed to update checkpoint",
 				slog.String("checkpoint_id", cpIDStr),


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/623
<!-- entire-trail-link-end -->

> **Stacked on #1480** (the foundation slice). Review/merge that first; this PR's diff is against that branch.

## What

The writer redesign discussed on #1433: collapse the four committed-writer methods into a single unqualified `Store.Write(ctx, WriteRequest)` — the `checkpoint.Store.Write(ctx, in)` shape we want for a pluggable backend.

```go
type WriteRequest interface{ isWriteRequest() } // sealed: only the 4 types below

type WriteSession        WriteCommittedOptions   // defined type — flat call sites, no nesting
type BackfillTranscript  UpdateCommittedOptions
type BackfillSummary     struct { CheckpointID id.CheckpointID; Summary *Summary }
type BackfillAttribution struct { CheckpointID id.CheckpointID; Attribution *InitialAttribution }
```

| Former method | Request |
|---|---|
| `WriteCommitted` | `WriteSession` |
| `UpdateCommitted` | `BackfillTranscript` |
| `UpdateSummary` | `BackfillSummary` |
| `UpdateCheckpointSummary` | `BackfillAttribution` |

`CommittedStore` now embeds `Writer` (just `Write`); the per-operation methods stay on `GitStore` as the implementation `Write` dispatches to.

## Why this shape

- **One method → trivial mirror fan-out.** A multi-backend store's `Write` just forwards the request value to each backend. Matches #1433's "mirror/push is per-store implementation detail."
- **Adding a write op = new request type + one dispatch case.** The `Store` interface is unchanged, so existing/new backends keep compiling — the "cheap to add a backend" goal.
- **No shared option bag.** Each request carries exactly its own fields, so the silent-no-op footgun from the original review (an attribution option ignored on a session write) is impossible by construction.
- **Defined types over the option structs** mean zero payload churn (`WriteCommittedOptions(r)` round-trips) and flat call sites: `store.Write(ctx, checkpoint.WriteSession{...})`.

The one honest tradeoff: Go has no exhaustive unions, so dispatch is a runtime type switch with an explicit `default → unsupported write request %T` (surfaced, never silent).

## Scope

Production call sites migrated (6). The hundreds of `WriteCommitted`/`UpdateCommitted` calls in **tests** intentionally keep using the concrete `*GitStore` methods directly — they exercise the git implementation, not the interface — so this PR's diff stays about the interface change rather than a package-wide test sweep. `committed_write_test.go` covers every dispatch case plus the unsupported-request and not-found paths.

## Next in the stack

PR3 (stacked on this): detangle `agent`/`session`/`review`/TUI deps from the contract and relocate it to `github.com/entireio/cli/api/checkpoint`.

## Verification

`go build ./...`, all tests compile, `mise run fmt` (clean), `mise run lint` (0 issues), and full suites for `checkpoint/...`, `cmd/entire/cli`, `strategy`, `dispatch`, `benchutil` all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the committed-store write contract and all main persistence paths; behavior stays delegated to the same GitStore methods, but mistakes in dispatch or call-site migration could corrupt checkpoint metadata.
> 
> **Overview**
> **Committed checkpoint writes** now go through a single `Writer.Write(ctx, req)` entry point instead of four separate interface methods (`WriteCommitted`, `UpdateCommitted`, `UpdateSummary`, `UpdateCheckpointSummary`).
> 
> A sealed `WriteRequest` union defines four request types—`WriteSession`, `BackfillTranscript`, `BackfillSummary`, and `BackfillAttribution`—mapped 1:1 to the old operations. `CommittedStore` embeds `Writer`; `GitStore.Write` type-switches and forwards to the existing git implementations (unchanged behavior).
> 
> Production call sites (**attach**, condensation, post-commit finalize/backfill, **`entire explain --generate`**, bench seeding) now pass typed requests (e.g. `checkpoint.WriteSession{...}`, `BackfillSummary{...}`). `explain` depends on `checkpoint.Writer` instead of a narrow `UpdateSummary` interface. Tests in `committed_write_test.go` cover dispatch, unknown requests, and error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f0c051d67726e6f127adb2407a29e604e991e6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->