### PR TITLE
agent: move TokenUsage/SkillEvent to leaf types package (detangle)

### DIFF
--- a/cmd/entire/cli/agent/skill_events.go
+++ b/cmd/entire/cli/agent/skill_events.go
@@ -1,69 +1,32 @@
 package agent
 
-// Skill event types recorded in checkpoint metadata.
+import "github.com/entireio/cli/cmd/entire/cli/agent/types"
+
+// The skill-event types and their constants live in the leaf agent/types
+// package so the checkpoint contract can construct and reference skill events
+// without importing the full agent package. These aliases keep existing
+// agent.SkillEvent* references working.
 const (
-	SkillEventTypePromptInvocation = "prompt_invocation"
-	SkillEventTypeToolInvocation   = "tool_invocation"
+	SkillEventTypePromptInvocation = types.SkillEventTypePromptInvocation
+	SkillEventTypeToolInvocation   = types.SkillEventTypeToolInvocation
+
+	SkillSignalPiInputSlashCommand = types.SkillSignalPiInputSlashCommand
+	SkillSignalPromptSlashCommand  = types.SkillSignalPromptSlashCommand
+	SkillSignalClaudeSkillToolUse  = types.SkillSignalClaudeSkillToolUse
+
+	SkillConfidenceExplicit = types.SkillConfidenceExplicit
+
+	SkillCollapseTargetUserMessage = types.SkillCollapseTargetUserMessage
+	SkillCollapseTargetToolPair    = types.SkillCollapseTargetToolPair
 )
 
-// Skill event source signals.
-const (
-	SkillSignalPiInputSlashCommand = "input_slash_command"
-	SkillSignalPromptSlashCommand  = "prompt_slash_command"
-	SkillSignalClaudeSkillToolUse  = "skill_tool_use"
+type (
+	SkillEvent                 = types.SkillEvent
+	SkillEventSkill            = types.SkillEventSkill
+	SkillEventSource           = types.SkillEventSource
+	SkillEventTranscriptAnchor = types.SkillEventTranscriptAnchor
+	SkillEventCollapse         = types.SkillEventCollapse
 )
-
-// Skill event confidence values.
-const (
-	SkillConfidenceExplicit = "explicit"
-)
-
-// Skill event collapse targets.
-const (
-	SkillCollapseTargetUserMessage = "user_message"
-	SkillCollapseTargetToolPair    = "tool_pair"
-)
-
-// SkillEvent records a native agent skill signal without rewriting the raw transcript.
-// Consumers use TranscriptAnchor/Native to locate the underlying raw event and Collapse
-// to decide whether/how to hide verbose skill material by default.
-type SkillEvent struct {
-	ID        string           `json:"id,omitempty"`
-	EventType string           `json:"event_type"`
-	Skill     SkillEventSkill  `json:"skill"`
-	Source    SkillEventSource `json:"source"`
-
-	TurnID    string `json:"turn_id,omitempty"`
-	Timestamp string `json:"timestamp,omitempty"`
-
-	TranscriptAnchor *SkillEventTranscriptAnchor `json:"transcript_anchor,omitempty"`
-	Native           map[string]string           `json:"native,omitempty"`
-	Collapse         SkillEventCollapse          `json:"collapse"`
-}
-
-type SkillEventSkill struct {
-	Name string `json:"name"`
-}
-
-type SkillEventSource struct {
-	Agent      string `json:"agent"`
-	Signal     string `json:"signal"`
-	Confidence string `json:"confidence"`
-}
-
-type SkillEventTranscriptAnchor struct {
-	Unit      string   `json:"unit,omitempty"`
-	Start     int      `json:"start,omitempty"`
-	End       int      `json:"end,omitempty"`
-	EntryIDs  []string `json:"entry_ids,omitempty"`
-	ToolUseID string   `json:"tool_use_id,omitempty"`
-}
-
-type SkillEventCollapse struct {
-	Target           string `json:"target"`
-	Label            string `json:"label,omitempty"`
-	DefaultCollapsed bool   `json:"default_collapsed"`
-}
 
 // SkillEventExtractor is implemented by agents that can derive native skill events
 // from their transcript format.

--- a/cmd/entire/cli/agent/types.go
+++ b/cmd/entire/cli/agent/types.go
@@ -1,6 +1,10 @@
 package agent
 
-import "time"
+import (
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+)
 
 // HookType represents agent lifecycle events
 type HookType string
@@ -43,19 +47,7 @@ type SessionChange struct {
 	Timestamp  time.Time
 }
 
-// TokenUsage represents aggregated token usage for a checkpoint.
-// This is agent-agnostic and can be populated by any agent that tracks token usage.
-type TokenUsage struct {
-	// InputTokens is the number of input tokens (fresh, not from cache)
-	InputTokens int `json:"input_tokens"`
-	// CacheCreationTokens is tokens written to cache (billable at cache write rate)
-	CacheCreationTokens int `json:"cache_creation_tokens"`
-	// CacheReadTokens is tokens read from cache (discounted rate)
-	CacheReadTokens int `json:"cache_read_tokens"`
-	// OutputTokens is the number of output tokens generated
-	OutputTokens int `json:"output_tokens"`
-	// APICallCount is the number of API calls made
-	APICallCount int `json:"api_call_count"`
-	// SubagentTokens contains token usage from spawned subagents (if any)
-	SubagentTokens *TokenUsage `json:"subagent_tokens,omitempty"`
-}
+// TokenUsage is defined in the leaf agent/types package so the checkpoint
+// contract can reference it without importing the full agent package. The
+// alias keeps existing agent.TokenUsage references working.
+type TokenUsage = types.TokenUsage

--- a/cmd/entire/cli/agent/types/skill_events.go
+++ b/cmd/entire/cli/agent/types/skill_events.go
@@ -1,0 +1,66 @@
+package types
+
+// Skill event types recorded in checkpoint metadata.
+const (
+	SkillEventTypePromptInvocation = "prompt_invocation"
+	SkillEventTypeToolInvocation   = "tool_invocation"
+)
+
+// Skill event source signals.
+const (
+	SkillSignalPiInputSlashCommand = "input_slash_command"
+	SkillSignalPromptSlashCommand  = "prompt_slash_command"
+	SkillSignalClaudeSkillToolUse  = "skill_tool_use"
+)
+
+// Skill event confidence values.
+const (
+	SkillConfidenceExplicit = "explicit"
+)
+
+// Skill event collapse targets.
+const (
+	SkillCollapseTargetUserMessage = "user_message"
+	SkillCollapseTargetToolPair    = "tool_pair"
+)
+
+// SkillEvent records a native agent skill signal without rewriting the raw transcript.
+// Consumers use TranscriptAnchor/Native to locate the underlying raw event and Collapse
+// to decide whether/how to hide verbose skill material by default.
+type SkillEvent struct {
+	ID        string           `json:"id,omitempty"`
+	EventType string           `json:"event_type"`
+	Skill     SkillEventSkill  `json:"skill"`
+	Source    SkillEventSource `json:"source"`
+
+	TurnID    string `json:"turn_id,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+
+	TranscriptAnchor *SkillEventTranscriptAnchor `json:"transcript_anchor,omitempty"`
+	Native           map[string]string           `json:"native,omitempty"`
+	Collapse         SkillEventCollapse          `json:"collapse"`
+}
+
+type SkillEventSkill struct {
+	Name string `json:"name"`
+}
+
+type SkillEventSource struct {
+	Agent      string `json:"agent"`
+	Signal     string `json:"signal"`
+	Confidence string `json:"confidence"`
+}
+
+type SkillEventTranscriptAnchor struct {
+	Unit      string   `json:"unit,omitempty"`
+	Start     int      `json:"start,omitempty"`
+	End       int      `json:"end,omitempty"`
+	EntryIDs  []string `json:"entry_ids,omitempty"`
+	ToolUseID string   `json:"tool_use_id,omitempty"`
+}
+
+type SkillEventCollapse struct {
+	Target           string `json:"target"`
+	Label            string `json:"label,omitempty"`
+	DefaultCollapsed bool   `json:"default_collapsed"`
+}

--- a/cmd/entire/cli/agent/types/token_usage.go
+++ b/cmd/entire/cli/agent/types/token_usage.go
@@ -1,0 +1,18 @@
+package types
+
+// TokenUsage represents aggregated token usage for a checkpoint.
+// This is agent-agnostic and can be populated by any agent that tracks token usage.
+type TokenUsage struct {
+	// InputTokens is the number of input tokens (fresh, not from cache)
+	InputTokens int `json:"input_tokens"`
+	// CacheCreationTokens is tokens written to cache (billable at cache write rate)
+	CacheCreationTokens int `json:"cache_creation_tokens"`
+	// CacheReadTokens is tokens read from cache (discounted rate)
+	CacheReadTokens int `json:"cache_read_tokens"`
+	// OutputTokens is the number of output tokens generated
+	OutputTokens int `json:"output_tokens"`
+	// APICallCount is the number of API calls made
+	APICallCount int `json:"api_call_count"`
+	// SubagentTokens contains token usage from spawned subagents (if any)
+	SubagentTokens *TokenUsage `json:"subagent_tokens,omitempty"`
+}

--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/redact"
@@ -250,10 +249,10 @@ type WriteCommittedOptions struct {
 	// and the deprecated CommittedMetadata.TranscriptLinesAtStart for backward compatibility.
 
 	// TokenUsage contains the token usage for this checkpoint
-	TokenUsage *agent.TokenUsage
+	TokenUsage *types.TokenUsage
 
 	// SkillEvents records explicit native skill signals observed in this session.
-	SkillEvents []agent.SkillEvent
+	SkillEvents []types.SkillEvent
 
 	// SessionMetrics contains hook-provided session metrics (duration, turns, context usage)
 	SessionMetrics *SessionMetrics
@@ -338,7 +337,7 @@ type UpdateCommittedOptions struct {
 	Agent types.AgentType
 
 	// SkillEvents replaces the session metadata skill_events when non-empty.
-	SkillEvents []agent.SkillEvent
+	SkillEvents []types.SkillEvent
 
 	// PrecomputedBlobs, if non-nil, provides chunk blob hashes and the
 	// content-hash blob hash computed once for this transcript. When set,
@@ -469,12 +468,12 @@ type CommittedMetadata struct {
 	TranscriptLinesAtStart int `json:"transcript_lines_at_start,omitempty"`
 
 	// Token usage for this checkpoint
-	TokenUsage *agent.TokenUsage `json:"token_usage,omitempty"`
+	TokenUsage *types.TokenUsage `json:"token_usage,omitempty"`
 
 	// SkillEvents records explicit native skill signals observed in this session.
 	// Consumers use these anchors to collapse skill-related raw transcript events.
 	SkillEventsVersion int                `json:"skill_events_version,omitempty"`
-	SkillEvents        []agent.SkillEvent `json:"skill_events,omitempty"`
+	SkillEvents        []types.SkillEvent `json:"skill_events,omitempty"`
 
 	// SessionMetrics contains hook-provided session metrics (duration, turns, context usage).
 	// Populated for agents that provide these metrics via hooks (e.g., Cursor).
@@ -557,7 +556,7 @@ type CheckpointSummary struct {
 	CheckpointsCount    int                 `json:"checkpoints_count"`
 	FilesTouched        []string            `json:"files_touched"`
 	Sessions            []SessionFilePaths  `json:"sessions"`
-	TokenUsage          *agent.TokenUsage   `json:"token_usage,omitempty"`
+	TokenUsage          *types.TokenUsage   `json:"token_usage,omitempty"`
 	CombinedAttribution *InitialAttribution `json:"combined_attribution,omitempty"`
 
 	// HasReview is the umbrella "any review happened" flag: true when at least


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/624
<!-- entire-trail-link-end -->

> **Stacked on #1481.** Review/merge the lower PRs first; this diff is against that branch.

## What

Dependency detangle that unblocks relocating the checkpoint contract to `api/checkpoint` (#1433). `TokenUsage` and the `SkillEvent` cluster move from the heavy `agent` package into the existing **leaf** `agent/types` package; transparent aliases stay behind in `agent`.

```go
// in agent, after the move:
type TokenUsage = types.TokenUsage
type SkillEvent = types.SkillEvent   // + SkillEventSkill/Source/TranscriptAnchor/Collapse
```

## Why

The checkpoint metadata DTOs (`CommittedMetadata`, `CheckpointSummary`, …) embed `TokenUsage`/`SkillEvent`. While those types lived in `agent`, **any** consumer of the checkpoint contract transitively imported `agent` and its TUI/launch/review fan-out — so the contract could never become a clean standalone package. After this move, `checkpoint.go` references `types.*` and drops its `agent` import.

## Blast radius: zero behavioral change

- The ~34 files using `agent.TokenUsage` / `agent.SkillEvent` keep compiling **unchanged** — the aliases are identical types, JSON tags are preserved verbatim, no method sets involved.
- Constants (`SkillEventType*`, `SkillSignal*`, …) and the `SkillEventExtractor` interface stay in `agent`.
- `CalculateTokenUsage` stays in `agent`, still returns `*TokenUsage` (the alias).

## Next in the stack

PR3b (stacked on this): relocate the now-`agent`-free contract (interfaces + DTOs) to `github.com/entireio/cli/api/checkpoint` and rewrite import paths.

## Verification

`go build ./...`, all tests compile, `mise run fmt` (clean), `mise run lint` (0 issues), and suites for `agent/...`, `checkpoint/...`, `cmd/entire/cli`, `strategy`, `session` all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure type relocation with identical JSON tags and aliases; no runtime or serialization behavior change.
> 
> **Overview**
> Moves **`TokenUsage`** and the **`SkillEvent`** struct family out of `agent` into the leaf **`agent/types`** package so checkpoint metadata can depend on those DTOs without pulling in the full `agent` package.
> 
> **`checkpoint`** now types `TokenUsage` / `SkillEvent` fields as `types.*` and drops its `agent` import. **`agent`** keeps transparent type aliases (`type TokenUsage = types.TokenUsage`, same for `SkillEvent` and related types) so existing `agent.TokenUsage` / `agent.SkillEvent` call sites keep compiling unchanged. Skill constants and **`SkillEventExtractor`** stay in `agent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d2fb5c1d9b486729268982ffe7012022eb75cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->