### PR TITLE
Add `entire trail checkout` subcommand

### DIFF
--- a/cmd/entire/cli/trail_checkout_cmd_test.go
+++ b/cmd/entire/cli/trail_checkout_cmd_test.go
@@ -93,9 +93,12 @@ func TestDescribeTrailRef(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := describeTrailRef(&tc.in)
+			// Copy the input into a local so the parallel subtest never takes the
+			// address of the shared range variable.
+			in := tc.in
+			got := describeTrailRef(&in)
 			if got != tc.want {
-				t.Fatalf("describeTrailRef(%#v) = %q, want %q", tc.in, got, tc.want)
+				t.Fatalf("describeTrailRef(%#v) = %q, want %q", in, got, tc.want)
 			}
 		})
 	}

--- a/cmd/entire/cli/trail_checkout_cmd_test.go
+++ b/cmd/entire/cli/trail_checkout_cmd_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+)
+
+func TestResolveTrailBySelector_FindsBySelector(t *testing.T) {
+	// Not t.Parallel(): the subtests share one httptest server closed on
+	// return, so they must run synchronously before the deferred Close.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if err := json.NewEncoder(w).Encode(api.TrailListResponse{
+			Trails: []api.TrailResource{
+				{ID: "trl_a", Number: 1, Branch: "feature/a", Title: "Alpha"},
+				{ID: "trl_b", Number: 575, Branch: "feature/b", Title: "Bravo"},
+			},
+			Total: 2,
+		}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+
+	cases := []struct {
+		name     string
+		selector string
+		wantID   string
+	}{
+		{"by number", "575", "trl_b"},
+		{"by id", "trl_a", "trl_a"},
+		{"by branch", "feature/b", "trl_b"},
+		{"trims whitespace", "  feature/a  ", "trl_a"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			found, err := resolveTrailBySelector(context.Background(), client, "gh", "acme", "repo", tc.selector)
+			if err != nil {
+				t.Fatalf("resolveTrailBySelector: %v", err)
+			}
+			if found == nil || found.ID != tc.wantID {
+				t.Fatalf("found = %#v, want ID %q", found, tc.wantID)
+			}
+		})
+	}
+}
+
+func TestResolveTrailBySelector_NotFoundIsAnError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if err := json.NewEncoder(w).Encode(api.TrailListResponse{Trails: []api.TrailResource{}}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	found, err := resolveTrailBySelector(context.Background(), client, "gh", "acme", "repo", "does-not-exist")
+	if err == nil {
+		t.Fatalf("expected error for missing trail, got found = %#v", found)
+	}
+	if found != nil {
+		t.Fatalf("found = %#v, want nil on error", found)
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") {
+		t.Fatalf("error %q should name the selector", err)
+	}
+}
+
+func TestDescribeTrailRef(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   api.TrailResource
+		want string
+	}{
+		{"number and title", api.TrailResource{Number: 575, Title: "Add foo"}, "trail #575 (Add foo)"},
+		{"number without title", api.TrailResource{Number: 575}, "trail #575"},
+		{"title without number", api.TrailResource{Title: "Add foo"}, `trail "Add foo"`},
+		{"neither", api.TrailResource{}, "trail"},
+		{"title trimmed", api.TrailResource{Number: 1, Title: "  Add foo  "}, "trail #1 (Add foo)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := describeTrailRef(&tc.in)
+			if got != tc.want {
+				t.Fatalf("describeTrailRef(%#v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrailCheckoutRejectsArgWithTrailFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := newTrailCheckoutCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"feature/b", "--trail", "575"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error combining a positional arg with --trail, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot combine") {
+		t.Fatalf("error = %q, want it to mention 'cannot combine'", err)
+	}
+}

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -63,6 +63,7 @@ func newTrailCmd() *cobra.Command {
 	cmd.AddCommand(newTrailListCmd())
 	cmd.AddCommand(newTrailCreateCmd())
 	cmd.AddCommand(newTrailUpdateCmd())
+	cmd.AddCommand(newTrailCheckoutCmd())
 	cmd.AddCommand(newTrailDeleteCmd())
 	cmd.AddCommand(newTrailFindingCmd())
 	cmd.AddCommand(newTrailWatchCmd())
@@ -122,33 +123,44 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, sel
 			return err
 		}
 
-		selector = strings.TrimSpace(selector)
-		var found *api.TrailResource
-		if selector == "" {
-			branch, err := GetCurrentBranch(ctx)
-			if err != nil {
-				return fmt.Errorf("no trail selector given and current branch is unknown: %w\nhint: run 'entire trail list --status any' or pass a trail number, id, or branch", err)
-			}
-			found, err = findTrailByBranch(ctx, client, forge, owner, repo, branch)
-			if err != nil {
-				return err
-			}
-			if found == nil {
-				return fmt.Errorf("no trail found for current branch %q\nhint: run 'entire trail create' or 'entire trail list --status any'", branch)
-			}
-		} else {
-			found, err = findTrailBySelector(ctx, client, forge, owner, repo, selector)
-			if err != nil {
-				return err
-			}
-			if found == nil {
-				return fmt.Errorf("no trail %q found in %s/%s/%s (run 'entire trail list --status any')", selector, forge, owner, repo)
-			}
+		found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, selector)
+		if err != nil {
+			return err
 		}
 
 		printTrailDetails(w, found.ToMetadata())
 		return nil
 	})
+}
+
+// resolveTrailBySelector resolves a trail by an optional selector (trail
+// number, id, or branch). An empty selector falls back to the current branch's
+// trail. It returns an actionable error (never a nil trail with a nil error)
+// when nothing matches, so callers can rely on a non-nil result.
+func resolveTrailBySelector(ctx context.Context, client *api.Client, forge, owner, repo, selector string) (*api.TrailResource, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		branch, err := GetCurrentBranch(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("no trail selector given and current branch is unknown: %w\nhint: run 'entire trail list --status any' or pass a trail number, id, or branch", err)
+		}
+		found, err := findTrailByBranch(ctx, client, forge, owner, repo, branch)
+		if err != nil {
+			return nil, err
+		}
+		if found == nil {
+			return nil, fmt.Errorf("no trail found for current branch %q\nhint: run 'entire trail create' or 'entire trail list --status any'", branch)
+		}
+		return found, nil
+	}
+	found, err := findTrailBySelector(ctx, client, forge, owner, repo, selector)
+	if err != nil {
+		return nil, err
+	}
+	if found == nil {
+		return nil, fmt.Errorf("no trail %q found in %s/%s/%s (run 'entire trail list --status any')", selector, forge, owner, repo)
+	}
+	return found, nil
 }
 
 func printTrailDetails(w io.Writer, m *trail.Metadata) {
@@ -948,6 +960,93 @@ func buildTrailUpdateRequest(current *api.TrailResource, inputs trailUpdateInput
 	}
 
 	return req
+}
+
+func newTrailCheckoutCmd() *cobra.Command {
+	var trailSelector string
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "checkout [<trail>]",
+		Short: "Check out a trail's branch",
+		Long: `Check out the branch of a trail.
+
+The trail may be given as the first argument or via --trail, as a number, id, or
+branch. Without one, the trail for the current branch is used. The trail's branch
+is checked out, fetching it from origin first when it only exists there.
+
+This must be run from within a clone of the repository the trail belongs to; the
+trail is looked up against that repository's origin remote.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			selector := trailSelector
+			if len(args) == 1 {
+				if cmd.Flags().Changed("trail") {
+					return errors.New("cannot combine a trail argument with --trail")
+				}
+				selector = args[0]
+			}
+			return runTrailCheckout(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector, force)
+		},
+	}
+
+	cmd.Flags().StringVar(&trailSelector, "trail", "", "Trail to check out (number, id, or branch; defaults to the current branch's trail)")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Skip the prompt before fetching a remote-only branch")
+
+	return cmd
+}
+
+func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector string, force bool) error {
+	return runAuthenticatedDataAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
+		forge, owner, repo, err := resolveTrailRemote(ctx)
+		if err != nil {
+			return err
+		}
+
+		found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, selector)
+		if err != nil {
+			return err
+		}
+
+		branch := strings.TrimSpace(found.Branch)
+		if branch == "" {
+			return fmt.Errorf("trail %q has no branch to check out", found.Title)
+		}
+
+		currentBranch, _ := GetCurrentBranch(ctx) //nolint:errcheck // best-effort; a detached HEAD just means "not already on the branch"
+		if currentBranch == branch {
+			fmt.Fprintf(w, "Already on branch %s for %s.\n", branch, describeTrailRef(found))
+			return nil
+		}
+
+		fmt.Fprintf(w, "Checking out %s\n", describeTrailRef(found))
+		// switchToBranchForResume handles local vs. remote-only branches, the
+		// uncommitted-changes guard, and the fetch prompt; reuse it rather than
+		// re-deriving that logic here. proceed=false (user declined the fetch) is
+		// a clean stop, not an error.
+		proceed, err := switchToBranchForResume(ctx, w, errW, branch, force)
+		if err != nil || !proceed {
+			return err
+		}
+		return nil
+	})
+}
+
+// describeTrailRef renders a short human reference to a trail for status
+// messages, e.g. "trail #575 (Add foo)" or, when the trail has no number yet,
+// "trail \"Add foo\"".
+func describeTrailRef(t *api.TrailResource) string {
+	title := strings.TrimSpace(t.Title)
+	if t.Number > 0 {
+		if title == "" {
+			return fmt.Sprintf("trail #%d", t.Number)
+		}
+		return fmt.Sprintf("trail #%d (%s)", t.Number, title)
+	}
+	if title == "" {
+		return "trail"
+	}
+	return fmt.Sprintf("trail %q", title)
 }
 
 // parseTrailNumberArg parses an optional positional trail-number argument.

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1010,7 +1010,7 @@ func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool,
 
 		branch := strings.TrimSpace(found.Branch)
 		if branch == "" {
-			return fmt.Errorf("trail %q has no branch to check out", found.Title)
+			return fmt.Errorf("%s has no branch to check out", describeTrailRef(found))
 		}
 
 		currentBranch, _ := GetCurrentBranch(ctx) //nolint:errcheck // best-effort; a detached HEAD just means "not already on the branch"
@@ -1022,11 +1022,16 @@ func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool,
 		fmt.Fprintf(w, "Checking out %s\n", describeTrailRef(found))
 		// switchToBranchForResume handles local vs. remote-only branches, the
 		// uncommitted-changes guard, and the fetch prompt; reuse it rather than
-		// re-deriving that logic here. proceed=false (user declined the fetch) is
-		// a clean stop, not an error.
+		// re-deriving that logic here.
 		proceed, err := switchToBranchForResume(ctx, w, errW, branch, force)
-		if err != nil || !proceed {
+		if err != nil {
 			return err
+		}
+		if !proceed {
+			// The user declined to fetch a remote-only branch — a clean stop, not
+			// an error. Say so explicitly so the preceding "Checking out …" line
+			// doesn't read as a successful switch.
+			fmt.Fprintf(w, "Checkout of branch %s cancelled.\n", branch)
 		}
 		return nil
 	})


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/625
<!-- entire-trail-link-end -->

## Summary

Adds `entire trail checkout`, which checks out a trail's branch. Modeled on the `entire trail merge` subcommand.

- `entire trail checkout <trail>` or `entire trail checkout --trail <trail>` — the specifier accepts a **number, id, or branch** (the positional arg and `--trail` are mutually exclusive).
- With no specifier, falls back to the **current branch's trail** (consistent with `trail show`).
- Resolves the trail's branch and checks it out: switches to it if it exists locally (guarding uncommitted changes), or fetches it from origin first when it only exists there (prompting unless `--force`).
- **Repo scoping is enforced naturally**: the trail is looked up against the current clone's `origin` remote via `resolveTrailRemote`, so a resolved trail inherently belongs to the repo you're in.

## Changes

- Registered `newTrailCheckoutCmd()` and added `runTrailCheckout`, reusing the existing `switchToBranchForResume` helper for the local/remote/uncommitted/fetch-prompt mechanics rather than duplicating that logic.
- Extracted `resolveTrailBySelector` (mirroring the merge PR) and refactored `runTrailShow` to use it.
- Added `describeTrailRef` for concise status messages (`trail #575 (Title)`).

## Tests

- `resolveTrailBySelector` resolves by number/id/branch and trims whitespace; not-found surfaces as an error naming the selector.
- `describeTrailRef` formatting across number/title combinations.
- The command rejects combining a positional arg with `--trail`.

Verified with `mise run fmt`, `mise run lint` (0 issues), `go test ./cmd/entire/cli/`, and `go build ./...`.

> Note: the `resolveTrailBySelector` extraction + `runTrailShow` refactor also appear on the `trail merge` branch. If both merge, git should resolve the identical additions cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 643ba8efea174d0dea29d66c05a1c3f3cae27bd3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->