### PR TITLE
Loosen connect timeouts for slow links

### DIFF
--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -103,10 +103,15 @@ func run(args []string) int {
 	clusterBaseURL := nodeCfg.EntryURL
 	repoSlug := parsedURL.Path
 
+	// This client drives the auth path only: cluster /.well-known discovery
+	// and the token exchange. Both talk to a single control-plane host with no
+	// failover to fall back on, so they get the patient discovery dial budget
+	// (DefaultDiscoveryDialTimeout) rather than the short failover one — a slow
+	// cold connect here would otherwise fail the whole clone/fetch.
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &httpclient.UserAgentTransport{
-			Next: httpclient.NewTransport(skipTLS),
+			Next: httpclient.NewDiscoveryTransport(skipTLS),
 			UA:   httpUserAgent,
 		},
 	}

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -106,8 +106,9 @@ func run(args []string) int {
 	// This client drives the auth path only: cluster /.well-known discovery
 	// and the token exchange. Both talk to a single control-plane host with no
 	// failover to fall back on, so they get the patient discovery dial budget
-	// (DefaultDiscoveryDialTimeout) rather than the short failover one — a slow
-	// cold connect here would otherwise fail the whole clone/fetch.
+	// (DiscoveryDialTimeout, i.e. DefaultDiscoveryDialTimeout unless
+	// ENTIRE_CONNECT_TIMEOUT_SECONDS overrides it) rather than the short failover
+	// one — a slow cold connect here would otherwise fail the whole clone/fetch.
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &httpclient.UserAgentTransport{

--- a/internal/entireclient/httpclient/transport.go
+++ b/internal/entireclient/httpclient/transport.go
@@ -16,27 +16,65 @@ import (
 	"time"
 )
 
+// EnvConnectTimeout is the env var that overrides every connect timeout.
+const EnvConnectTimeout = "ENTIRE_CONNECT_TIMEOUT_SECONDS"
+
 // DefaultDialTimeout is the per-host TCP connect timeout. Short by default
 // so failover paths skip dead nodes quickly, but long enough to absorb a
 // slow initial connect (cold DNS, TLS-fronting LB, distant region) that a
 // tighter budget would trip; override via ENTIRE_CONNECT_TIMEOUT_SECONDS on
-// slow links where even this trips before the node can answer.
-const DefaultDialTimeout = 2 * time.Second
+// slow links (e.g. satellite) where even this trips before the node answers.
+const DefaultDialTimeout = 4 * time.Second
 
-// DialTimeout returns the configured dial timeout, honoring
-// ENTIRE_CONNECT_TIMEOUT_SECONDS. Invalid values fall back to
-// DefaultDialTimeout with a warning to stderr.
-func DialTimeout() time.Duration {
-	v := os.Getenv("ENTIRE_CONNECT_TIMEOUT_SECONDS")
-	if v == "" {
-		return DefaultDialTimeout
+// DefaultDiscoveryDialTimeout is the per-host TCP connect budget for the
+// initial replica-discovery request — the cold info/refs probe to the
+// cluster entry domain that answers "which nodes serve this repo". It is
+// deliberately longer than DefaultDialTimeout: this first contact often pays
+// a cold DNS + TLS handshake to a possibly-distant entry LB, and unlike
+// replica failover there is no second node to roll to, so tripping here fails
+// the whole clone/fetch. Replica failover keeps the short DefaultDialTimeout
+// so dead nodes are still skipped quickly.
+//
+// An explicit ENTIRE_CONNECT_TIMEOUT_SECONDS overrides this too: a user who
+// sets it gets that one value for every connect, discovery included.
+const DefaultDiscoveryDialTimeout = 10 * time.Second
+
+// envConnectTimeout reads ENTIRE_CONNECT_TIMEOUT_SECONDS. It returns the
+// parsed duration and true only when the var is set to a positive integer;
+// an unset/blank var yields false, and an invalid value warns to stderr and
+// yields false so callers fall back to their own default.
+func envConnectTimeout() (time.Duration, bool) {
+	v, ok := os.LookupEnv(EnvConnectTimeout)
+	if !ok || v == "" {
+		return 0, false
 	}
 	secs, err := strconv.Atoi(v)
 	if err != nil || secs <= 0 {
-		fmt.Fprintf(os.Stderr, "httpclient: ignoring invalid ENTIRE_CONNECT_TIMEOUT_SECONDS=%q, using default %s\n", v, DefaultDialTimeout)
-		return DefaultDialTimeout
+		fmt.Fprintf(os.Stderr, "httpclient: ignoring invalid %s=%q, using defaults\n", EnvConnectTimeout, v)
+		return 0, false
 	}
-	return time.Duration(secs) * time.Second
+	return time.Duration(secs) * time.Second, true
+}
+
+// DialTimeout returns the connect timeout for ordinary requests (and replica
+// failover): the ENTIRE_CONNECT_TIMEOUT_SECONDS override if set, else
+// DefaultDialTimeout.
+func DialTimeout() time.Duration {
+	if d, ok := envConnectTimeout(); ok {
+		return d
+	}
+	return DefaultDialTimeout
+}
+
+// DiscoveryDialTimeout returns the connect budget for the discovery probe.
+// When ENTIRE_CONNECT_TIMEOUT_SECONDS is set it wins outright (the user's
+// chosen value applies to every connect); otherwise it falls back to the
+// more patient DefaultDiscoveryDialTimeout rather than DefaultDialTimeout.
+func DiscoveryDialTimeout() time.Duration {
+	if d, ok := envConnectTimeout(); ok {
+		return d
+	}
+	return DefaultDiscoveryDialTimeout
 }
 
 // NewTransport builds an *http.Transport with the configured dial timeout
@@ -44,8 +82,19 @@ func DialTimeout() time.Duration {
 // own RoundTripper as needed (e.g. debug logging) and assemble their own
 // *http.Client around it.
 func NewTransport(skipTLSVerify bool) *http.Transport {
+	return newTransport(skipTLSVerify, DialTimeout())
+}
+
+// NewDiscoveryTransport is NewTransport with the longer discovery connect
+// budget (DiscoveryDialTimeout). Use it for the initial replica-discovery
+// probe; see DefaultDiscoveryDialTimeout for why it is more patient.
+func NewDiscoveryTransport(skipTLSVerify bool) *http.Transport {
+	return newTransport(skipTLSVerify, DiscoveryDialTimeout())
+}
+
+func newTransport(skipTLSVerify bool, dialTimeout time.Duration) *http.Transport {
 	return &http.Transport{
-		DialContext: (&net.Dialer{Timeout: DialTimeout()}).DialContext,
+		DialContext: (&net.Dialer{Timeout: dialTimeout}).DialContext,
 		TLSClientConfig: &tls.Config{
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: skipTLSVerify, //nolint:gosec // intentional for local development

--- a/internal/entireclient/httpclient/transport.go
+++ b/internal/entireclient/httpclient/transport.go
@@ -50,7 +50,7 @@ func envConnectTimeout() (time.Duration, bool) {
 	}
 	secs, err := strconv.Atoi(v)
 	if err != nil || secs <= 0 {
-		fmt.Fprintf(os.Stderr, "httpclient: ignoring invalid %s=%q, using defaults\n", EnvConnectTimeout, v)
+		fmt.Fprintf(os.Stderr, "httpclient: ignoring invalid %s=%q, using defaults (%s failover, %s discovery)\n", EnvConnectTimeout, v, DefaultDialTimeout, DefaultDiscoveryDialTimeout)
 		return 0, false
 	}
 	return time.Duration(secs) * time.Second, true

--- a/internal/entireclient/httpclient/transport_test.go
+++ b/internal/entireclient/httpclient/transport_test.go
@@ -28,3 +28,26 @@ func TestDialTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestDiscoveryDialTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset uses discovery default", "", DefaultDiscoveryDialTimeout},
+		{"override below default still wins", "2", 2 * time.Second},
+		{"override equal to default", "10", 10 * time.Second},
+		{"larger override wins", "20", 20 * time.Second},
+		{"invalid falls back to discovery default", "abc", DefaultDiscoveryDialTimeout},
+		{"zero falls back to discovery default", "0", DefaultDiscoveryDialTimeout},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ENTIRE_CONNECT_TIMEOUT_SECONDS", tc.env)
+			if got := DiscoveryDialTimeout(); got != tc.want {
+				t.Fatalf("DiscoveryDialTimeout()=%s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/entireclient/httpclient/transport_test.go
+++ b/internal/entireclient/httpclient/transport_test.go
@@ -11,7 +11,7 @@ func TestDialTimeout(t *testing.T) {
 		env  string
 		want time.Duration
 	}{
-		{"unset uses default", "", DefaultDialTimeout},
+		{"blank uses default", "", DefaultDialTimeout},
 		{"valid seconds", "10", 10 * time.Second},
 		{"single second", "1", 1 * time.Second},
 		{"non-integer falls back", "abc", DefaultDialTimeout},
@@ -35,7 +35,7 @@ func TestDiscoveryDialTimeout(t *testing.T) {
 		env  string
 		want time.Duration
 	}{
-		{"unset uses discovery default", "", DefaultDiscoveryDialTimeout},
+		{"blank uses discovery default", "", DefaultDiscoveryDialTimeout},
 		{"override below default still wins", "2", 2 * time.Second},
 		{"override equal to default", "10", 10 * time.Second},
 		{"larger override wins", "20", 20 * time.Second},

--- a/internal/remotehelper/transport/proxy.go
+++ b/internal/remotehelper/transport/proxy.go
@@ -73,9 +73,14 @@ type Proxy struct {
 	// path is the URL path on each node.
 	path string
 
-	client       *http.Client
-	setAuth      SetAuthFunc
-	onNodeFailed func(failedNode string)
+	client *http.Client
+	// discoveryTransport is the RoundTripper used for the cold info/refs
+	// probe to the entry domain (see noRedirectClient). It carries a longer
+	// dial budget than client's transport because that first
+	// replica-discovery connect has no failover to fall back on.
+	discoveryTransport http.RoundTripper
+	setAuth            SetAuthFunc
+	onNodeFailed       func(failedNode string)
 
 	// stickyNode is the URL (matching one of nodes) of the replica
 	// that served the most recent successful request, post-redirects.
@@ -112,16 +117,21 @@ func New(cfg Config) *Proxy {
 	// User-Agent must be set before httpdebug logs the request, so the
 	// wrapper sits outside httpdebug. The order is:
 	//   user-agent → httpdebug → http.Transport
-	// so the debug log captures the same headers the wire sees.
-	var rt http.RoundTripper = httpclient.NewTransport(cfg.SkipTLS)
-	rt = &httpdebug.RoundTripper{Next: rt}
-	if cfg.UserAgent != "" {
-		rt = &httpclient.UserAgentTransport{Next: rt, UA: cfg.UserAgent}
+	// so the debug log captures the same headers the wire sees. Both the
+	// failover client and the discovery probe wrap identically; only the
+	// underlying transport's dial budget differs.
+	wrap := func(base http.RoundTripper) http.RoundTripper {
+		var rt http.RoundTripper = &httpdebug.RoundTripper{Next: base}
+		if cfg.UserAgent != "" {
+			rt = &httpclient.UserAgentTransport{Next: rt, UA: cfg.UserAgent}
+		}
+		return rt
 	}
 	p.client = &http.Client{
-		Transport:     rt,
+		Transport:     wrap(httpclient.NewTransport(cfg.SkipTLS)),
 		CheckRedirect: p.checkRedirect,
 	}
+	p.discoveryTransport = wrap(httpclient.NewDiscoveryTransport(cfg.SkipTLS))
 	return p
 }
 
@@ -350,12 +360,15 @@ func (p *Proxy) doWithFailover(ctx context.Context, makeSuffix string, method st
 	return nil, fmt.Errorf("all %d nodes failed, last error: %w", len(nodes), lastErr)
 }
 
-// noRedirectClient returns a one-shot client that shares this proxy's
-// transport (so connection pooling still applies) but never follows
-// redirects, surfacing 3xx responses to the caller.
+// noRedirectClient returns a one-shot client for the cold info/refs probe
+// to the entry domain. It never follows redirects (surfacing 3xx responses
+// to the caller) and uses the discovery transport, whose longer dial budget
+// absorbs the cold first-contact connect that has no replica failover to
+// fall back on. Falls back to the proxy's main transport when no discovery
+// transport was wired (e.g. proxies built directly in tests).
 func (p *Proxy) noRedirectClient() *http.Client {
-	var transport http.RoundTripper
-	if p.client != nil {
+	transport := p.discoveryTransport
+	if transport == nil && p.client != nil {
 		transport = p.client.Transport
 	}
 	return &http.Client{

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -47,8 +47,12 @@ func proxyWithClient(nodes []string, path, entryURL, clusterHost string, client 
 	})
 	if client != nil {
 		// Swap in the test-provided client (e.g. one we want to
-		// inspect or one with a custom CheckRedirect).
+		// inspect or one with a custom CheckRedirect). Point the
+		// discovery probe at the same transport so the cold info/refs
+		// path honors the test's TLS trust / routing instead of the
+		// real-network discovery transport New wired up.
 		p.client = client
+		p.discoveryTransport = client.Transport
 	}
 	return p
 }
@@ -1245,13 +1249,27 @@ func TestNoRedirectClientShareTransport(t *testing.T) {
 	p := &Proxy{client: &http.Client{Transport: transport}}
 	got := p.noRedirectClient()
 	if got.Transport != transport {
-		t.Errorf("NoRedirectClient transport = %v, want %v", got.Transport, transport)
+		t.Errorf("NoRedirectClient transport = %v, want %v (fallback to client transport)", got.Transport, transport)
 	}
 	if got.CheckRedirect == nil {
 		t.Fatal("NoRedirectClient must set CheckRedirect")
 	}
 	if err := got.CheckRedirect(nil, nil); !errors.Is(err, http.ErrUseLastResponse) {
 		t.Errorf("CheckRedirect returned %v, want http.ErrUseLastResponse", err)
+	}
+}
+
+func TestNoRedirectClientPrefersDiscoveryTransport(t *testing.T) {
+	t.Parallel()
+	clientTransport := &fakeTransport{}
+	discovery := &fakeTransport{}
+	p := &Proxy{
+		client:             &http.Client{Transport: clientTransport},
+		discoveryTransport: discovery,
+	}
+	got := p.noRedirectClient()
+	if got.Transport != discovery {
+		t.Errorf("NoRedirectClient transport = %v, want discovery transport %v", got.Transport, discovery)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/629
<!-- entire-trail-link-end -->

**User impact:** Clones/fetches/pushes on slow links (e.g. satellite) no longer time out as easily. Default per-host connect timeout is 4s (was 2s), and the initial node-discovery + `/.well-known` requests get a roomier 10s. `ENTIRE_CONNECT_TIMEOUT_SECONDS` now overrides every connect timeout.

**Why:** Pushing over satellite failed because no node responded under 2s, and the first "which nodes serve this repo" request (cold DNS + TLS to a distant entry LB, no failover to fall back on) intermittently tripped. Replica failover keeps the short timeout so dead nodes are still skipped quickly.  Cloning a new repo also failed for me on my home internet connection when asking "which nodes serve this repo".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Networking timeout defaults only; replica failover stays on the shorter dial and behavior is covered by new unit tests.
> 
> **Overview**
> **Improves clone/fetch/push reliability on high-latency links** by tuning TCP connect budgets instead of changing auth or Git protocol behavior.
> 
> The default **failover** per-host connect timeout rises from **2s to 4s** (`DefaultDialTimeout`), while **replica discovery** and other single-host control-plane calls get a separate **10s** budget (`DefaultDiscoveryDialTimeout`). **`ENTIRE_CONNECT_TIMEOUT_SECONDS`** still overrides both when set to a positive integer.
> 
> **`NewDiscoveryTransport`** and **`DiscoveryDialTimeout`** centralize the longer dial; **`git-remote-entire`** uses it for `/.well-known` and token exchange. The remote **`Proxy`** keeps the short transport for replica failover but routes the cold **`info/refs`** entry probe (`noRedirectClient`) through **`discoveryTransport`** so the first “which nodes serve this repo?” contact is not held to the failover timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cdac4eb7014ac646fab5a40983222541eb2acfb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->