### PR TITLE
Session liveness: finalize ACTIVE sessions whose agent has exited

### DIFF
--- a/cmd/entire/cli/doctor.go
+++ b/cmd/entire/cli/doctor.go
@@ -120,6 +120,14 @@ func runSessionsFix(cmd *cobra.Command, force bool) error {
 	}
 	defer repo.Close()
 
+	// Finalize any ACTIVE session whose agent process has exited (no SessionStop
+	// hook fired). A gone process is unambiguous, so these are condensed on the
+	// spot rather than left for the interactive prompt below; the sweep marks
+	// them ended in place so classifySession won't re-flag them.
+	if n := finalizeExitedSessions(ctx, states); n > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "Finalized %d exited session(s) (agent process gone).\n\n", n)
+	}
+
 	// Identify stuck sessions
 	now := time.Now()
 	var stuck []stuckSession
@@ -210,14 +218,22 @@ func classifySession(state *strategy.SessionState, repo *git.Repository, now tim
 
 	switch {
 	case state.Phase.IsActive():
-		if !state.IsStuckActive() {
-			return nil
-		}
-
 		var reason string
-		if state.LastInteractionTime != nil {
+		switch {
+		case state.OwnerExited():
+			// Detected immediately (no timeout wait): the owning agent process
+			// is gone. Normally finalized up front in runSessionsFix; this
+			// branch covers a session that couldn't be finalized there.
+			pid := 0
+			if state.Owner != nil {
+				pid = state.Owner.PID
+			}
+			reason = fmt.Sprintf("agent process %d exited (no longer running)", pid)
+		case !state.IsStuckActive():
+			return nil
+		case state.LastInteractionTime != nil:
 			reason = fmt.Sprintf("active, last interaction %s ago", now.Sub(*state.LastInteractionTime).Truncate(time.Minute))
-		} else {
+		default:
 			reason = fmt.Sprintf("active, started %s ago with no recorded interaction", now.Sub(state.StartedAt).Truncate(time.Minute))
 		}
 

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -933,26 +933,39 @@ func handleLifecycleSessionEnd(ctx context.Context, ag agent.Agent, event *agent
 	// the transcript to extract file changes. Cleanup is handled by
 	// `entire clean` or when the session state is fully removed.
 
-	if err := markSessionEnded(ctx, event, event.SessionID); err != nil {
+	if _, err := endSessionNow(ctx, event, event.SessionID, nil); err != nil {
 		logging.Warn(logCtx, "failed to mark session ended",
-			slog.String("error", err.Error()))
-		// Don't attempt eager condense if we couldn't even mark the session ended —
-		// the session state may be in an inconsistent state.
-		return nil
-	}
-
-	// Eagerly condense session data so PostCommit doesn't have to process it.
-	// This prevents zombie ENDED sessions from accumulating and causing O(N)
-	// overhead on every future commit (GitHub issue #591).
-	// Fail-open: if this fails, PostCommit will still process it on the next commit.
-	strat := GetStrategy(ctx)
-	if err := strat.CondenseAndMarkFullyCondensed(ctx, event.SessionID); err != nil {
-		logging.Warn(logCtx, "eager condense on session stop failed",
-			slog.String("session_id", event.SessionID),
 			slog.String("error", err.Error()))
 	}
 
 	return nil
+}
+
+// endSessionNow runs the canonical "this session is over" sequence: it marks the
+// session ended (firing the SessionStop transition → PhaseEnded + EndedAt) and
+// eagerly condenses its pending work so PostCommit need not. This prevents
+// zombie ENDED sessions from accumulating and causing O(N) overhead on every
+// future commit (GitHub issue #591). It is shared by the SessionStop hook
+// (handleLifecycleSessionEnd) and the exited-session sweep
+// (finalizeExitedSessions), so the two stay in lockstep.
+//
+// The condense is fail-open (PostCommit retries on the next commit); an error
+// marking the session ended is returned so callers can react, and skips the
+// condense since the state may be inconsistent. event may be nil when no hook
+// event drives the end (the sweep), which skips event-metadata persistence.
+// guard is forwarded to markSessionEnded (see there); when it skips the end,
+// the condense is skipped too and ended is false.
+func endSessionNow(ctx context.Context, event *agent.Event, sessionID string, guard func(*strategy.SessionState) bool) (ended bool, err error) {
+	ended, err = markSessionEnded(ctx, event, sessionID, guard)
+	if err != nil || !ended {
+		return ended, err
+	}
+	if condErr := GetStrategy(ctx).CondenseAndMarkFullyCondensed(ctx, sessionID); condErr != nil {
+		logging.Warn(logging.WithComponent(ctx, "lifecycle"), "eager condense on session end failed",
+			slog.String("session_id", sessionID),
+			slog.String("error", condErr.Error()))
+	}
+	return true, nil
 }
 
 // handleLifecycleSubagentStart handles subagent start: captures pre-task state.
@@ -1170,8 +1183,18 @@ func transitionSessionTurnEnd(ctx context.Context, sessionID string, event *agen
 
 // markSessionEnded transitions the session to ENDED phase via the state machine.
 // If event is non-nil, hook-provided metrics are persisted to state before saving.
-func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string) error {
+// markSessionEnded fires the SessionStop transition (PhaseEnded + EndedAt) under
+// the session-state lock. When guard is non-nil and returns false on the
+// freshly-loaded state, the transition is skipped — callers use it to
+// re-validate a precondition that may have changed since their snapshot (the
+// exited-session sweep re-checks OwnerExited under the lock so it never ends a
+// session a concurrent turn just revived). It reports whether the session was
+// actually ended.
+func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string, guard func(*strategy.SessionState) bool) (ended bool, err error) {
 	mutErr := strategy.MutateSessionState(ctx, sessionID, func(state *strategy.SessionState) error {
+		if guard != nil && !guard(state) {
+			return strategy.ErrMutationSkip
+		}
 		if event != nil {
 			persistEventMetadataToState(event, state)
 		}
@@ -1181,15 +1204,16 @@ func markSessionEnded(ctx context.Context, event *agent.Event, sessionID string)
 		}
 		now := time.Now()
 		state.EndedAt = &now
+		ended = true
 		return nil
 	})
-	if errors.Is(mutErr, strategy.ErrStateNotFound) {
-		return nil
+	if errors.Is(mutErr, strategy.ErrStateNotFound) || errors.Is(mutErr, strategy.ErrMutationSkip) {
+		return false, nil
 	}
 	if mutErr != nil {
-		return fmt.Errorf("failed to save session state: %w", mutErr)
+		return false, fmt.Errorf("failed to save session state: %w", mutErr)
 	}
-	return nil
+	return ended, nil
 }
 
 // logFileChanges logs the files modified, created, and deleted during a session.

--- a/cmd/entire/cli/phase_wiring_test.go
+++ b/cmd/entire/cli/phase_wiring_test.go
@@ -30,7 +30,7 @@ func TestMarkSessionEnded_SetsPhaseEnded(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call markSessionEnded
-	err = markSessionEnded(context.Background(), nil, "test-session-end-1")
+	_, err = markSessionEnded(context.Background(), nil, "test-session-end-1", nil)
 	require.NoError(t, err)
 
 	// Verify phase is ENDED
@@ -60,7 +60,7 @@ func TestMarkSessionEnded_IdleToEnded(t *testing.T) {
 	err := strategy.SaveSessionState(context.Background(), state)
 	require.NoError(t, err)
 
-	err = markSessionEnded(context.Background(), nil, "test-session-end-idle")
+	_, err = markSessionEnded(context.Background(), nil, "test-session-end-idle", nil)
 	require.NoError(t, err)
 
 	loaded, err := strategy.LoadSessionState(context.Background(), "test-session-end-idle")
@@ -85,7 +85,7 @@ func TestMarkSessionEnded_AlreadyEndedIsNoop(t *testing.T) {
 	err := strategy.SaveSessionState(context.Background(), state)
 	require.NoError(t, err)
 
-	err = markSessionEnded(context.Background(), nil, "test-session-end-noop")
+	_, err = markSessionEnded(context.Background(), nil, "test-session-end-noop", nil)
 	require.NoError(t, err)
 
 	loaded, err := strategy.LoadSessionState(context.Background(), "test-session-end-noop")
@@ -110,7 +110,7 @@ func TestMarkSessionEnded_EmptyPhaseBackwardCompat(t *testing.T) {
 	err := strategy.SaveSessionState(context.Background(), state)
 	require.NoError(t, err)
 
-	err = markSessionEnded(context.Background(), nil, "test-session-end-compat")
+	_, err = markSessionEnded(context.Background(), nil, "test-session-end-compat", nil)
 	require.NoError(t, err)
 
 	loaded, err := strategy.LoadSessionState(context.Background(), "test-session-end-compat")
@@ -125,7 +125,7 @@ func TestMarkSessionEnded_NoState(t *testing.T) {
 	dir := setupGitRepoForPhaseTest(t)
 	t.Chdir(dir)
 
-	err := markSessionEnded(context.Background(), nil, "nonexistent-session")
+	_, err := markSessionEnded(context.Background(), nil, "nonexistent-session", nil)
 	assert.NoError(t, err, "should be a no-op when no state exists")
 }
 

--- a/cmd/entire/cli/proclive/proc_darwin.go
+++ b/cmd/entire/cli/proclive/proc_darwin.go
@@ -1,0 +1,42 @@
+//go:build darwin
+
+package proclive
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// procStat looks up a process via sysctl(kern.proc.pid) and returns its parent
+// PID, executable name (comm), and start time as the fingerprint. It uses the
+// typed KinfoProc decoder from golang.org/x/sys/unix rather than hand-decoding
+// raw sysctl bytes. p_starttime is an absolute wall-clock timeval, so it is a
+// stable per-process fingerprint without needing the boot guard.
+func procStat(pid int) (ppid int, name, start string, err error) {
+	k, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		// A missing process surfaces as ESRCH or as EIO (sysctl returns a
+		// zero-length result, which the wrapper rejects). Either way it's gone.
+		if err == unix.ESRCH || err == unix.EIO || err == unix.ENOENT {
+			return 0, "", "", errProcessGone
+		}
+		return 0, "", "", fmt.Errorf("proclive: sysctl kern.proc.pid %d: %w", pid, err)
+	}
+	tv := k.Proc.P_starttime
+	return int(k.Eproc.Ppid),
+		unix.ByteSliceToString(k.Proc.P_comm[:]),
+		fmt.Sprintf("%d.%06d", tv.Sec, tv.Usec),
+		nil
+}
+
+// bootID returns no boot guard on darwin. kern.boottime is NOT stable for a
+// running machine — the kernel recomputes it whenever the wall clock is stepped
+// (e.g. an NTP correction), so using it would let a clock adjustment falsely
+// declare a still-running session dead. It is also unnecessary here: darwin's
+// P_starttime fingerprint is an absolute wall-clock timestamp fixed at process
+// creation, so it already distinguishes a reused PID across reboots without a
+// boot guard. (Linux uses ticks-since-boot, which does need the guard.)
+func bootID() (string, error) {
+	return "", nil
+}

--- a/cmd/entire/cli/proclive/proc_linux.go
+++ b/cmd/entire/cli/proclive/proc_linux.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package proclive
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// procStat reads /proc/<pid>/stat and returns the parent PID, executable name
+// (comm), and the process start time (field 22, in clock ticks since boot) used
+// as the start fingerprint. The fingerprint only needs to be stable for the
+// process lifetime and distinct across PID reuse within a boot; the boot guard
+// in Check invalidates it across reboots, so raw ticks suffice and we avoid
+// needing _SC_CLK_TCK.
+func procStat(pid int) (ppid int, name, start string, err error) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, "", "", errProcessGone
+		}
+		return 0, "", "", fmt.Errorf("proclive: read /proc/%d/stat: %w", pid, err)
+	}
+	return parseProcStat(string(data))
+}
+
+// parseProcStat parses the contents of /proc/<pid>/stat. It is separated from
+// the file read so it can be unit-tested with adversarial comm values.
+//
+// The comm (field 2) is wrapped in parentheses and may itself contain spaces
+// and ')'. Everything before the first '(' is the PID; the comm runs to the
+// LAST ')'; the remaining space-separated fields begin at 'state' (field 3).
+func parseProcStat(content string) (ppid int, name, start string, err error) {
+	openIdx := strings.IndexByte(content, '(')
+	closeIdx := strings.LastIndexByte(content, ')')
+	if openIdx < 0 || closeIdx < 0 || closeIdx < openIdx {
+		return 0, "", "", errors.New("proclive: malformed /proc stat: no comm parens")
+	}
+	name = content[openIdx+1 : closeIdx]
+
+	// Fields after the comm, 0-indexed: 0=state (field 3), 1=ppid (field 4),
+	// ... 19=starttime (field 22).
+	const ppidIdx, starttimeIdx = 1, 19
+	rest := strings.Fields(content[closeIdx+1:])
+	if len(rest) <= starttimeIdx {
+		return 0, "", "", errors.New("proclive: truncated /proc stat")
+	}
+	ppid, err = strconv.Atoi(rest[ppidIdx])
+	if err != nil {
+		return 0, "", "", fmt.Errorf("proclive: parse ppid: %w", err)
+	}
+	return ppid, name, rest[starttimeIdx], nil
+}
+
+// bootID returns the kernel boot id, which changes on every reboot. It falls
+// back to /proc/stat's btime line if boot_id is unavailable.
+func bootID() (string, error) {
+	if data, err := os.ReadFile("/proc/sys/kernel/random/boot_id"); err == nil {
+		return strings.TrimSpace(string(data)), nil
+	}
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return "", fmt.Errorf("proclive: read /proc/stat: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if rest, ok := strings.CutPrefix(line, "btime "); ok {
+			return strings.TrimSpace(rest), nil
+		}
+	}
+	return "", nil
+}

--- a/cmd/entire/cli/proclive/proc_linux_test.go
+++ b/cmd/entire/cli/proclive/proc_linux_test.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package proclive
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestParseProcStat_CommWithSpacesAndParens(t *testing.T) {
+	t.Parallel()
+
+	// comm contains both spaces and ')', which must NOT confuse field parsing.
+	const comm = "weird) proc name"
+	const wantPPID = 1000
+	const wantStart = "987654"
+
+	// Build the post-comm fields: index 0=state, 1=ppid, ..., 19=starttime.
+	rest := make([]string, 20)
+	for i := range rest {
+		rest[i] = strconv.Itoa(i) // distinct filler so a wrong index is obvious
+	}
+	rest[0] = "R"
+	rest[1] = strconv.Itoa(wantPPID)
+	rest[19] = wantStart
+
+	content := "4242 (" + comm + ") " + strings.Join(rest, " ") + "\n"
+
+	ppid, name, start, err := parseProcStat(content)
+	if err != nil {
+		t.Fatalf("parseProcStat: %v", err)
+	}
+	if name != comm {
+		t.Errorf("name = %q, want %q", name, comm)
+	}
+	if ppid != wantPPID {
+		t.Errorf("ppid = %d, want %d", ppid, wantPPID)
+	}
+	if start != wantStart {
+		t.Errorf("start = %q, want %q", start, wantStart)
+	}
+}
+
+func TestParseProcStat_Malformed(t *testing.T) {
+	t.Parallel()
+	for _, content := range []string{
+		"no parens here",
+		"123 (proc) R 1", // truncated: too few post-comm fields
+		"",
+	} {
+		if _, _, _, err := parseProcStat(content); err == nil {
+			t.Errorf("parseProcStat(%q) = nil error, want error", content)
+		}
+	}
+}

--- a/cmd/entire/cli/proclive/proc_other.go
+++ b/cmd/entire/cli/proclive/proc_other.go
@@ -1,0 +1,16 @@
+//go:build !linux && !darwin
+
+package proclive
+
+// On platforms without process introspection (e.g. Windows), the seam reports
+// "unsupported". Check then yields LivenessUnknown and ResolveOwner yields no
+// owner, so session liveness degrades cleanly to the inactivity-timeout
+// fallback instead of producing wrong answers.
+
+func procStat(pid int) (ppid int, name, start string, err error) {
+	return 0, "", "", errUnsupported
+}
+
+func bootID() (string, error) {
+	return "", errUnsupported
+}

--- a/cmd/entire/cli/proclive/proc_other_test.go
+++ b/cmd/entire/cli/proclive/proc_other_test.go
@@ -1,0 +1,21 @@
+//go:build !linux && !darwin
+
+package proclive
+
+import (
+	"os"
+	"testing"
+)
+
+// On unsupported platforms liveness must degrade to Unknown (never a wrong
+// Alive/Dead), so callers fall back to the inactivity timeout.
+func TestCheck_UnsupportedIsUnknown(t *testing.T) {
+	t.Parallel()
+	id := Identity{PID: os.Getpid(), Start: "anything"}
+	if got := Check(id); got != LivenessUnknown {
+		t.Errorf("Check on unsupported platform = %v, want unknown", got)
+	}
+	if _, ok := ResolveOwner(); ok {
+		t.Errorf("ResolveOwner on unsupported platform returned ok=true, want false")
+	}
+}

--- a/cmd/entire/cli/proclive/proclive.go
+++ b/cmd/entire/cli/proclive/proclive.go
@@ -1,0 +1,195 @@
+// Package proclive captures a process's identity (PID plus a start-time
+// fingerprint) and later reports whether that exact process is still alive.
+//
+// It exists to detect agent sessions left in an ACTIVE state when the owning
+// process went away — a clean exit, a crash, a kill, a closed terminal, or a
+// reboot — without firing a SessionStop hook. Recording the owner's identity at
+// turn start lets `entire status` / `entire doctor` notice the process is gone
+// immediately, instead of waiting out a coarse inactivity timeout.
+//
+// This package is a leaf: it imports only the standard library and
+// golang.org/x/sys/unix. It must NOT import session, strategy, agent, or cli,
+// so those packages can depend on it without an import cycle.
+package proclive
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// Liveness is the result of checking a recorded process Identity.
+type Liveness int
+
+const (
+	// LivenessUnknown means liveness could not be determined: the identity is
+	// empty, was recorded on another host, or the platform cannot introspect
+	// processes. Callers should fall back to a time-based heuristic.
+	LivenessUnknown Liveness = iota
+	// LivenessAlive means the recorded process is still running.
+	LivenessAlive
+	// LivenessDead means the recorded process is gone (exited, killed, or the
+	// machine rebooted) or its PID has been reused by a different process.
+	LivenessDead
+)
+
+func (l Liveness) String() string {
+	switch l {
+	case LivenessAlive:
+		return "alive"
+	case LivenessDead:
+		return "dead"
+	case LivenessUnknown:
+		return "unknown"
+	default:
+		return "unknown"
+	}
+}
+
+// Identity fingerprints the process that owns a session turn. It is persisted
+// in session state and later passed to Check. The zero value means "no owner
+// recorded" and always yields LivenessUnknown.
+type Identity struct {
+	// PID is the operating-system process id of the owner.
+	PID int `json:"pid"`
+	// Start is an opaque, per-platform process start-time fingerprint. It need
+	// only be stable for the process lifetime and distinct across PID reuse
+	// within a single boot; the Boot guard invalidates it across reboots.
+	Start string `json:"start"`
+	// Boot identifies the current OS boot. A mismatch at check time means the
+	// machine rebooted, so the recorded PID cannot still be the same process.
+	Boot string `json:"boot,omitempty"`
+	// Host is the hostname where the identity was recorded. PIDs are only
+	// meaningful on their own machine, so a mismatch yields Unknown.
+	Host string `json:"host,omitempty"`
+	// Name is the owning process's executable name (comm). Diagnostic only.
+	Name string `json:"name,omitempty"`
+}
+
+var (
+	// errProcessGone is returned by procStat when no process with the given PID
+	// exists. Check maps it to LivenessDead.
+	errProcessGone = errors.New("proclive: process not found")
+	// errUnsupported is returned by the per-platform seam when the OS cannot be
+	// introspected (e.g. Windows). Check maps it to LivenessUnknown.
+	errUnsupported = errors.New("proclive: unsupported platform")
+)
+
+// maxAncestorDepth bounds the ResolveOwner walk so a pathological or cyclic
+// process tree can never loop or hang.
+const maxAncestorDepth = 12
+
+// transientNames are process names that are never the long-lived session owner:
+// our own hook binary, the shells agents commonly use to exec hooks, and the Go
+// toolchain (local-dev runs hooks via `go run`, whose short-lived `go` parent
+// would otherwise be recorded as the owner and exit immediately). The walk skips
+// past these to reach the real agent process. Note that interpreter runtimes
+// (node, bun, python) are deliberately absent — for several agents the runtime
+// IS the long-lived agent, so treating it as transient would skip the real owner.
+var transientNames = map[string]bool{
+	"entire": true,
+	"sh":     true,
+	"bash":   true,
+	"zsh":    true,
+	"dash":   true,
+	"fish":   true,
+	"ash":    true,
+	"ksh":    true,
+	"env":    true,
+	"go":     true,
+}
+
+func isTransient(name string) bool {
+	return transientNames[strings.ToLower(strings.TrimSpace(name))]
+}
+
+// ResolveOwner walks up the process tree from the current process and returns
+// the Identity of the first ancestor that is not our own hook binary or a
+// shell — i.e. the long-lived agent that owns this session.
+//
+// It returns (zero, false) when no such ancestor can be determined: an
+// unsupported platform, a truncated/looping tree, or only transient ancestors.
+// In that case the caller should record no owner and let liveness degrade to
+// the time-based fallback. Resolving to nothing is always safer than recording
+// a guessed PID, which could later be (mis)read as a live or dead owner.
+func ResolveOwner() (Identity, bool) {
+	// The host guard is essential — a PID is only meaningful on the machine that
+	// recorded it — so if the hostname can't be determined, record no owner
+	// rather than an unguarded one that Check could later (mis)classify as
+	// alive/dead across machines. Boot is a best-effort secondary guard; an
+	// empty value just disables it (darwin records none — see bootID there).
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		return Identity{}, false
+	}
+	boot, err := bootID()
+	if err != nil {
+		boot = ""
+	}
+
+	// Walk up from our own process, reading each ancestor exactly once: procStat
+	// returns its parent (to continue the walk), its name (to skip shells and our
+	// own binary), and its start fingerprint (to record).
+	candidate, _, _, err := procStat(os.Getpid())
+	if err != nil {
+		return Identity{}, false
+	}
+	for range maxAncestorDepth {
+		if candidate <= 1 {
+			return Identity{}, false
+		}
+		parent, name, start, err := procStat(candidate)
+		if err != nil {
+			return Identity{}, false
+		}
+		if !isTransient(name) {
+			return Identity{PID: candidate, Start: start, Boot: boot, Host: host, Name: name}, true
+		}
+		candidate = parent
+	}
+	return Identity{}, false
+}
+
+// Check reports whether the process recorded in id is still alive.
+//
+// Precedence: an empty identity or a host mismatch is Unknown (cannot judge); a
+// boot mismatch means a reboot, so the process is Dead; a missing PID or a
+// start-fingerprint mismatch (PID reuse) is Dead; otherwise Alive. An
+// unsupported platform is always Unknown so callers fall back to a timeout.
+func Check(id Identity) Liveness {
+	if id.PID <= 0 {
+		return LivenessUnknown
+	}
+	if id.Host != "" {
+		// Can't confirm we're on the recording host → can't trust its PIDs.
+		host, err := os.Hostname()
+		if err != nil || host != id.Host {
+			return LivenessUnknown
+		}
+	}
+	if id.Boot != "" {
+		boot, err := bootID()
+		switch {
+		case err != nil || boot == "":
+			return LivenessUnknown // can't confirm the boot → can't trust the PID
+		case boot != id.Boot:
+			return LivenessDead // rebooted: the process cannot have survived
+		}
+	}
+
+	_, _, start, err := procStat(id.PID)
+	switch {
+	case errors.Is(err, errUnsupported):
+		return LivenessUnknown
+	case errors.Is(err, errProcessGone):
+		return LivenessDead
+	case err != nil:
+		// Transient/unexpected error: don't claim the process is dead.
+		return LivenessUnknown
+	}
+	if id.Start != "" && start != "" && id.Start != start {
+		// Same PID, different start time: the PID was reused by another process.
+		return LivenessDead
+	}
+	return LivenessAlive
+}

--- a/cmd/entire/cli/proclive/proclive_live_test.go
+++ b/cmd/entire/cli/proclive/proclive_live_test.go
@@ -1,0 +1,111 @@
+//go:build linux || darwin
+
+package proclive
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// startSleeper spawns a real long-lived child bound to the test context (so it
+// is killed when the test ends) and returns its PID and a captured Identity.
+func startSleeper(t *testing.T) (int, Identity) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		// The context kill (on test end) signals the process; reap it here to
+		// avoid a zombie. A non-nil "signal: killed" error is expected.
+		if err := cmd.Wait(); err != nil {
+			t.Logf("sleeper wait: %v", err)
+		}
+	})
+	pid := cmd.Process.Pid
+	_, name, start, err := procStat(pid)
+	if err != nil {
+		t.Fatalf("procStat(child %d): %v", pid, err)
+	}
+	return pid, Identity{PID: pid, Start: start, Name: name}
+}
+
+func TestCheck_LiveProcessIsAlive(t *testing.T) {
+	t.Parallel()
+	_, id := startSleeper(t)
+	if got := Check(id); got != LivenessAlive {
+		t.Errorf("Check(live) = %v, want alive", got)
+	}
+}
+
+func TestCheck_ExitedProcessIsDead(t *testing.T) {
+	t.Parallel()
+	cmd := exec.CommandContext(t.Context(), "sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	pid := cmd.Process.Pid
+	_, name, start, err := procStat(pid)
+	if err != nil {
+		t.Fatalf("procStat(child %d): %v", pid, err)
+	}
+	id := Identity{PID: pid, Start: start, Name: name}
+
+	// Kill and reap, then the recorded identity must read as dead. (A PID reused
+	// within the test window would mismatch Start and still be Dead.)
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Logf("wait after kill: %v", err) // expected: "signal: killed"
+	}
+
+	if got := Check(id); got != LivenessDead {
+		t.Errorf("Check(exited) = %v, want dead", got)
+	}
+}
+
+func TestCheck_StartMismatchIsDead(t *testing.T) {
+	t.Parallel()
+	// Our own process is alive, but a bogus start fingerprint must read as PID
+	// reuse → Dead.
+	id := Identity{PID: os.Getpid(), Start: "0.000000-not-a-real-fingerprint"}
+	if got := Check(id); got != LivenessDead {
+		t.Errorf("Check(start mismatch) = %v, want dead", got)
+	}
+}
+
+func TestProcStat_Self(t *testing.T) {
+	t.Parallel()
+	ppid, name, start, err := procStat(os.Getpid())
+	if err != nil {
+		t.Fatalf("procStat(self): %v", err)
+	}
+	if ppid <= 0 {
+		t.Errorf("ppid = %d, want > 0", ppid)
+	}
+	if name == "" {
+		t.Errorf("name is empty")
+	}
+	if start == "" {
+		t.Errorf("start is empty")
+	}
+}
+
+func TestResolveOwner_ReturnsSomething(t *testing.T) {
+	t.Parallel()
+	// Under `go test` the ancestor chain (test binary ← go ← shell ← ...) should
+	// resolve to some non-shell owner. We can't assert which, but if it resolves
+	// it must be self-consistent and currently alive.
+	id, ok := ResolveOwner()
+	if !ok {
+		t.Skip("no stable owner resolved in this environment")
+	}
+	if id.PID <= 0 {
+		t.Errorf("resolved PID = %d, want > 0", id.PID)
+	}
+	if got := Check(id); got != LivenessAlive {
+		t.Errorf("resolved owner Check = %v, want alive", got)
+	}
+}

--- a/cmd/entire/cli/proclive/proclive_test.go
+++ b/cmd/entire/cli/proclive/proclive_test.go
@@ -1,0 +1,55 @@
+package proclive
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLiveness_String(t *testing.T) {
+	t.Parallel()
+	cases := map[Liveness]string{
+		LivenessUnknown: "unknown",
+		LivenessAlive:   "alive",
+		LivenessDead:    "dead",
+		Liveness(99):    "unknown",
+	}
+	for l, want := range cases {
+		if got := l.String(); got != want {
+			t.Errorf("Liveness(%d).String() = %q, want %q", int(l), got, want)
+		}
+	}
+}
+
+func TestCheck_EmptyIdentityIsUnknown(t *testing.T) {
+	t.Parallel()
+	if got := Check(Identity{}); got != LivenessUnknown {
+		t.Errorf("Check(empty) = %v, want unknown", got)
+	}
+	if got := Check(Identity{PID: 0, Start: "x"}); got != LivenessUnknown {
+		t.Errorf("Check(pid=0) = %v, want unknown", got)
+	}
+}
+
+func TestCheck_HostMismatchIsUnknown(t *testing.T) {
+	t.Parallel()
+	// A recorded host that cannot match the current machine must yield Unknown
+	// regardless of platform, before any process introspection happens.
+	id := Identity{PID: os.Getpid(), Start: "anything", Host: "not-this-host-\x00-ever"}
+	if got := Check(id); got != LivenessUnknown {
+		t.Errorf("Check(host mismatch) = %v, want unknown", got)
+	}
+}
+
+func TestIsTransient(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"entire", "sh", "bash", "ZSH", " dash ", "Fish", "go"} {
+		if !isTransient(name) {
+			t.Errorf("isTransient(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"node", "bun", "claude", "cursor", "python3", ""} {
+		if isTransient(name) {
+			t.Errorf("isTransient(%q) = true, want false", name)
+		}
+	}
+}

--- a/cmd/entire/cli/session/owner_live_test.go
+++ b/cmd/entire/cli/session/owner_live_test.go
@@ -1,0 +1,37 @@
+//go:build linux || darwin
+
+package session
+
+import (
+	"os"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+)
+
+func TestOwnerExited_DeadOwnerActiveIsTrue(t *testing.T) {
+	t.Parallel()
+	// Our own PID is alive, but a mismatched start fingerprint makes proclive
+	// treat it as a reused (dead) PID — a deterministic "owner gone" signal.
+	exitedOwner := &proclive.Identity{PID: os.Getpid(), Start: "bogus-start-fingerprint"}
+	s := &State{Phase: PhaseActive, Owner: exitedOwner}
+	if s.OwnerLiveness() != proclive.LivenessDead {
+		t.Fatalf("OwnerLiveness = %v, want dead", s.OwnerLiveness())
+	}
+	if !s.OwnerExited() {
+		t.Error("OwnerExited(active, dead owner) = false, want true")
+	}
+}
+
+func TestOwnerExited_LiveOwnerActiveIsFalse(t *testing.T) {
+	t.Parallel()
+	// A faithfully-captured identity of a live process must NOT read as exited.
+	id, ok := proclive.ResolveOwner()
+	if !ok {
+		t.Skip("no stable owner resolved in this environment")
+	}
+	s := &State{Phase: PhaseActive, Owner: &id}
+	if s.OwnerExited() {
+		t.Error("OwnerExited(active, live owner) = true, want false")
+	}
+}

--- a/cmd/entire/cli/session/owner_test.go
+++ b/cmd/entire/cli/session/owner_test.go
@@ -1,0 +1,38 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+)
+
+func TestOwnerLiveness_NilOwnerIsUnknown(t *testing.T) {
+	t.Parallel()
+	s := &State{Phase: PhaseActive}
+	if got := s.OwnerLiveness(); got != proclive.LivenessUnknown {
+		t.Errorf("OwnerLiveness(nil owner) = %v, want unknown", got)
+	}
+}
+
+func TestOwnerExited_NilOwnerIsFalse(t *testing.T) {
+	t.Parallel()
+	// No owner recorded: behavior must degrade to the timeout heuristic, so
+	// OwnerExited reports false regardless of phase.
+	s := &State{Phase: PhaseActive}
+	if s.OwnerExited() {
+		t.Error("OwnerExited(nil owner) = true, want false")
+	}
+}
+
+func TestOwnerExited_NonActivePhaseIsFalse(t *testing.T) {
+	t.Parallel()
+	// Even with a dead owner, a non-ACTIVE session is not "exited" — there's no
+	// live turn to have been orphaned.
+	deadOwner := &proclive.Identity{PID: 999999999, Start: "never"}
+	for _, phase := range []Phase{PhaseIdle, PhaseEnded} {
+		s := &State{Phase: phase, Owner: deadOwner}
+		if s.OwnerExited() {
+			t.Errorf("OwnerExited(phase=%s) = true, want false", phase)
+		}
+	}
+}

--- a/cmd/entire/cli/session/state.go
+++ b/cmd/entire/cli/session/state.go
@@ -18,6 +18,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
 	"github.com/entireio/cli/cmd/entire/cli/validation"
 )
 
@@ -300,6 +301,15 @@ type State struct {
 	// PendingPromptAttribution holds attribution calculated at prompt start (before agent runs).
 	// This is moved to PromptAttributions when SaveStep is called.
 	PendingPromptAttribution *PromptAttribution `json:"pending_prompt_attribution,omitempty"`
+
+	// Owner fingerprints the process that owns this session's agent turn,
+	// captured at each turn start via proclive.ResolveOwner. It lets liveness
+	// checks detect an ACTIVE session whose agent has exited (clean /exit,
+	// crash, kill, terminal close, reboot) without a SessionStop hook firing —
+	// see OwnerExited. nil for legacy sessions or when the owner couldn't be
+	// resolved, in which case liveness falls back to the StuckActiveThreshold
+	// timeout. Only meaningful on Owner.Host.
+	Owner *proclive.Identity `json:"owner,omitempty"`
 }
 
 // PromptAttribution captures line-level attribution data at the start of each prompt.
@@ -408,6 +418,31 @@ func (s *State) IsStuckActive() bool {
 		ref = &s.StartedAt
 	}
 	return time.Since(*ref) > StuckActiveThreshold
+}
+
+// OwnerLiveness reports the liveness of this session's recorded owner process.
+// It returns proclive.LivenessUnknown when no owner was recorded (legacy
+// sessions, or sessions where the owner couldn't be resolved), so callers can
+// fall back to the time-based IsStuckActive heuristic.
+func (s *State) OwnerLiveness() proclive.Liveness {
+	if s.Owner == nil {
+		return proclive.LivenessUnknown
+	}
+	return proclive.Check(*s.Owner)
+}
+
+// OwnerExited reports true when this session is ACTIVE but its owning agent
+// process is gone — exited cleanly, crashed, was killed, or the machine
+// rebooted — without a SessionStop hook firing. Unlike IsStuckActive (a
+// time-based heuristic), this is detected immediately, regardless of how
+// recently the session interacted. It returns false when liveness is Unknown
+// (no owner recorded, cross-host state, or an unsupported platform) so behavior
+// degrades to the StuckActiveThreshold timeout.
+func (s *State) OwnerExited() bool {
+	if !s.Phase.IsActive() {
+		return false
+	}
+	return s.OwnerLiveness() == proclive.LivenessDead
 }
 
 func (s *State) IsStale() bool {

--- a/cmd/entire/cli/session_finalize.go
+++ b/cmd/entire/cli/session_finalize.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+)
+
+// finalizeExitedSessions finalizes every ACTIVE session in states whose owning
+// agent process has exited (clean /exit, crash, kill, terminal close, reboot)
+// without a SessionStop hook firing. Each such session is finalized exactly as a
+// clean session stop would be: the session-stop transition runs (PhaseEnded +
+// EndedAt) and pending work is eagerly condensed.
+//
+// It refreshes the matched in-memory states from disk after finalizing — so
+// callers can re-filter/re-render without their own reload — and returns the
+// number finalized. Each session is best-effort: a failure to mark one ended is
+// logged and skipped; a condense failure is logged but the session is still
+// counted (PostCommit will retry the condense later).
+func finalizeExitedSessions(ctx context.Context, states []*session.State) int {
+	logCtx := logging.WithComponent(ctx, "session")
+
+	var store *session.StateStore // lazily created on first finalize
+	finalized := 0
+	for _, st := range states {
+		if !st.OwnerExited() {
+			continue // cheap pre-filter on the (possibly stale) list snapshot
+		}
+
+		// Finalize via the same path a clean SessionStop hook would take, but
+		// re-validate OwnerExited on the freshly-loaded state under the lock:
+		// a turn may have started since the snapshot and replaced the dead
+		// owner with a live one, in which case ended is false and we leave it be.
+		ended, err := endSessionNow(ctx, nil, st.SessionID, func(s *session.State) bool {
+			return s.OwnerExited()
+		})
+		if err != nil {
+			logging.Warn(logCtx, "failed to finalize exited session",
+				slog.String("session_id", st.SessionID),
+				slog.String("error", err.Error()))
+			continue
+		}
+		if !ended {
+			continue
+		}
+
+		// Refresh the in-memory snapshot from disk so downstream filtering and
+		// doctor classification see the true post-finalize state: ended, and
+		// condensed only if the eager condense actually succeeded (it is
+		// fail-open, so StepCount/FullyCondensed must not be assumed). Fall back
+		// to a minimal ended-marking if the reload fails — enough for the
+		// caller's "active" filter to drop it.
+		if store == nil {
+			if s, serr := session.NewStateStore(ctx); serr == nil {
+				store = s
+			}
+		}
+		refreshed := false
+		if store != nil {
+			if reloaded, lerr := store.Load(ctx, st.SessionID); lerr == nil && reloaded != nil {
+				*st = *reloaded
+				refreshed = true
+			}
+		}
+		if !refreshed {
+			now := time.Now()
+			st.Phase = session.PhaseEnded
+			st.EndedAt = &now
+		}
+		finalized++
+	}
+	return finalized
+}

--- a/cmd/entire/cli/session_finalize_test.go
+++ b/cmd/entire/cli/session_finalize_test.go
@@ -1,0 +1,127 @@
+//go:build linux || darwin
+
+package cli
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+	"github.com/entireio/cli/cmd/entire/cli/session"
+)
+
+// TestFinalizeExitedSessions finalizes an ACTIVE session whose owner process is
+// gone, and leaves an ACTIVE session without a recorded owner untouched.
+//
+// Not parallel: setupAttachTestRepo uses t.Chdir.
+func TestFinalizeExitedSessions(t *testing.T) {
+	setupAttachTestRepo(t)
+	ctx := context.Background()
+
+	store, err := session.NewStateStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Owner with a mismatched start fingerprint reads as a reused (dead) PID, a
+	// deterministic "agent exited" signal on linux/darwin.
+	exited := &session.State{
+		SessionID: "exited-session",
+		Phase:     session.PhaseActive,
+		StartedAt: time.Now(),
+		Owner:     &proclive.Identity{PID: os.Getpid(), Start: "bogus-start-fingerprint"},
+	}
+	// No owner recorded: must be left alone (liveness unknown → timeout fallback).
+	noOwner := &session.State{
+		SessionID: "no-owner-session",
+		Phase:     session.PhaseActive,
+		StartedAt: time.Now(),
+	}
+	for _, s := range []*session.State{exited, noOwner} {
+		if err := store.Save(ctx, s); err != nil {
+			t.Fatalf("save %s: %v", s.SessionID, err)
+		}
+	}
+
+	states, err := store.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if n := finalizeExitedSessions(ctx, states); n != 1 {
+		t.Fatalf("finalizeExitedSessions = %d, want 1", n)
+	}
+
+	// The exited session is now ended on disk.
+	got, err := store.Load(ctx, "exited-session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EndedAt == nil {
+		t.Error("exited session EndedAt = nil, want set")
+	}
+	if got.Phase != session.PhaseEnded {
+		t.Errorf("exited session Phase = %q, want %q", got.Phase, session.PhaseEnded)
+	}
+
+	// The owner-less session is untouched.
+	got, err = store.Load(ctx, "no-owner-session")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EndedAt != nil {
+		t.Error("no-owner session EndedAt set, want nil (left active)")
+	}
+}
+
+// TestFinalizeExitedSessions_RevalidatesUnderLock guards against the
+// time-of-check/time-of-use race: the sweep must re-check OwnerExited on the
+// freshly-loaded state, not act on a stale list snapshot. Here the on-disk
+// state has a LIVE owner while the snapshot passed to the sweep carries a dead
+// one (as if a turn revived the session after the list was taken).
+//
+// Not parallel: setupAttachTestRepo uses t.Chdir.
+func TestFinalizeExitedSessions_RevalidatesUnderLock(t *testing.T) {
+	setupAttachTestRepo(t)
+	ctx := context.Background()
+
+	liveOwner, ok := proclive.ResolveOwner()
+	if !ok {
+		t.Skip("no stable process owner resolvable in this environment")
+	}
+
+	store, err := session.NewStateStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save(ctx, &session.State{
+		SessionID: "revived",
+		Phase:     session.PhaseActive,
+		StartedAt: time.Now(),
+		Owner:     &liveOwner, // on disk: a live owner
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale snapshot the sweep sees: same session, but with a dead owner.
+	stale := &session.State{
+		SessionID: "revived",
+		Phase:     session.PhaseActive,
+		StartedAt: time.Now(),
+		Owner:     &proclive.Identity{PID: os.Getpid(), Start: "bogus-start-fingerprint"},
+	}
+
+	if n := finalizeExitedSessions(ctx, []*session.State{stale}); n != 0 {
+		t.Fatalf("finalizeExitedSessions = %d, want 0 (revalidation should skip the revived session)", n)
+	}
+
+	got, err := store.Load(ctx, "revived")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EndedAt != nil {
+		t.Error("revived session was ended despite a live owner on disk")
+	}
+}

--- a/cmd/entire/cli/sessions.go
+++ b/cmd/entire/cli/sessions.go
@@ -870,7 +870,7 @@ func stopSessionAndPrint(ctx context.Context, cmd *cobra.Command, state *strateg
 	lastCheckpointID := state.LastCheckpointID
 	stepCount := state.StepCount
 
-	if err := markSessionEnded(ctx, nil, sessionID); err != nil {
+	if _, err := markSessionEnded(ctx, nil, sessionID, nil); err != nil {
 		return fmt.Errorf("failed to stop session %s: %w", sessionID, err)
 	}
 

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -271,6 +271,14 @@ func writeActiveSessions(ctx context.Context, w io.Writer, sty statusStyles) {
 		return
 	}
 
+	// Finalize any ACTIVE session whose agent process has exited without a
+	// SessionStop hook firing, so it doesn't linger as "active" until the
+	// inactivity timeout. The sweep marks them ended in place, so the filter
+	// below drops them.
+	if n := finalizeExitedSessions(ctx, states); n > 0 {
+		fmt.Fprintln(w, sty.render(sty.dim, fmt.Sprintf("Finalized %d exited session(s) (agent process gone).", n)))
+	}
+
 	// Filter to active sessions only
 	var active []*session.State
 	for _, s := range states {
@@ -379,11 +387,18 @@ func writeActiveSessions(ctx context.Context, w io.Writer, sty statusStyles) {
 			}
 
 			statsLine := strings.Join(stats, sty.render(sty.dim, " · "))
-			if st.IsStuckActive() {
+			switch {
+			case st.OwnerExited():
+				// Agent process is gone but the session couldn't be finalized
+				// above (e.g. condense/transition error); flag it explicitly.
+				fmt.Fprintf(w, "%s %s %s\n", sty.render(sty.dim, statsLine),
+					sty.render(sty.dim, "·"),
+					sty.render(sty.yellow, "exited")+" (run 'entire doctor')")
+			case st.IsStuckActive():
 				fmt.Fprintf(w, "%s %s %s\n", sty.render(sty.dim, statsLine),
 					sty.render(sty.dim, "·"),
 					sty.render(sty.yellow, "stale")+" (run 'entire doctor')")
-			} else {
+			default:
 				fmt.Fprintln(w, sty.render(sty.dim, statsLine))
 			}
 			if warning := divergenceWarnings[st.SessionID]; warning != "" {
@@ -622,6 +637,10 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 
 		if store, err := session.NewStateStore(ctx); err == nil {
 			if states, err := store.List(ctx); err == nil {
+				// Finalize sessions whose agent has exited (matches the human
+				// status path) so --json doesn't leave them orphaned ACTIVE or
+				// report them under active_sessions.
+				finalizeExitedSessions(ctx, states)
 				// Deduplicate by agent: one entry per agent, "active" wins over "idle".
 				type agentEntry struct {
 					brief    sessionBriefJSON
@@ -671,6 +690,10 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 func sessionStatusLabel(s *session.State) string {
 	if s.EndedAt != nil {
 		return "ended"
+	}
+	if s.OwnerExited() {
+		// ACTIVE on disk, but the owning agent process is gone.
+		return "exited"
 	}
 	if s.Phase != "" {
 		return string(s.Phase)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -25,6 +25,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
 	"github.com/entireio/cli/cmd/entire/cli/session"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/stringutil"
@@ -2296,6 +2297,7 @@ func (s *ManualCommitStrategy) InitializeSession(ctx context.Context, sessionID 
 			state.TranscriptPath = transcriptPath
 		}
 		captureSessionBranch(repo, state)
+		captureSessionOwner(state)
 
 		// ORDERING: attribution runs BEFORE migrate to use the pre-migration
 		// BaseCommit as the base tree (preserving correct agent-line counts
@@ -2340,6 +2342,7 @@ func (s *ManualCommitStrategy) InitializeSession(ctx context.Context, sessionID 
 		promptAttr := s.calculatePromptAttributionAtStart(ctx, repo, state)
 		state.PendingPromptAttribution = &promptAttr
 		captureSessionBranch(repo, state)
+		captureSessionOwner(state)
 		return nil
 	})
 	if mutErr != nil && !errors.Is(mutErr, ErrStateNotFound) {
@@ -2367,6 +2370,26 @@ func captureSessionBranch(repo *git.Repository, state *SessionState) {
 		// falls back to deriving the branch from checkpoint trailers instead of
 		// using a stale, now-incorrect value.
 		state.Branch = ""
+	}
+}
+
+// captureSessionOwner records the owning agent process (PID + start-time
+// fingerprint) into the session state so liveness checks can later detect an
+// ACTIVE session whose agent exited without firing a SessionStop hook. The hook
+// runs as a short-lived child of the agent, so proclive.ResolveOwner walks up
+// past our own binary and any shells to the long-lived agent process.
+//
+// It is best-effort and re-run on every turn start: if the owner can't be
+// resolved (unsupported platform, transient-only ancestry) the field is cleared
+// and liveness degrades to the inactivity timeout; re-resolving each turn keeps
+// the fingerprint current across agent restarts.
+func captureSessionOwner(state *SessionState) {
+	// Clear first: a failed resolve must never leave a stale owner from an
+	// earlier turn. Otherwise a now-live session (agent restarted with a new
+	// PID) could still carry a dead PID and be wrongly finalized as exited.
+	state.Owner = nil
+	if owner, ok := proclive.ResolveOwner(); ok {
+		state.Owner = &owner
 	}
 }
 

--- a/cmd/entire/cli/strategy/owner_wiring_test.go
+++ b/cmd/entire/cli/strategy/owner_wiring_test.go
@@ -1,0 +1,34 @@
+//go:build linux || darwin
+
+package strategy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/proclive"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInitializeSession_CapturesOwner verifies that a turn start records the
+// owning process identity, and that the live owner reads as not-exited.
+func TestInitializeSession_CapturesOwner(t *testing.T) {
+	if _, ok := proclive.ResolveOwner(); !ok {
+		t.Skip("no stable process owner resolvable in this environment")
+	}
+
+	dir := setupGitRepo(t)
+	t.Chdir(dir)
+
+	s := &ManualCommitStrategy{}
+	err := s.InitializeSession(context.Background(), "test-session-owner", "Claude Code", "", "", "")
+	require.NoError(t, err)
+
+	state, err := s.loadSessionState(context.Background(), "test-session-owner")
+	require.NoError(t, err)
+	require.NotNil(t, state.Owner, "InitializeSession should capture the owning process")
+	assert.Positive(t, state.Owner.PID, "captured owner PID should be positive")
+	assert.False(t, state.OwnerExited(), "a freshly-captured live owner must not read as exited")
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/583
<!-- entire-trail-link-end -->

## Problem

A session is marked `PhaseActive` while an agent takes a turn, and the lifecycle relies on a `SessionStop` hook firing to leave ACTIVE. When the agent process goes away mid-turn — a clean `/exit`/Ctrl-D, a crash, a kill, a closed terminal, or a reboot — no hook fires, so the session is stuck ACTIVE forever. The only prior mitigation was `IsStuckActive()`, a coarse **1-hour timeout**, which is both too slow (a session whose agent exited 2 minutes ago still shows active for an hour) and imprecise (a genuinely long, still-running turn gets flagged after an hour).

## Approach

Record the owning agent process's identity at each turn start and detect immediately when that process is gone.

- **`cmd/entire/cli/proclive`** — new stdlib + `x/sys/unix` leaf package. Captures `{PID, start-time fingerprint, host, boot}` by walking up the process tree from the hook to the first non-shell, non-`entire` (and non-`go`) ancestor. `Check()` returns Alive / Dead / Unknown — Dead on a missing PID, start-time mismatch (PID reuse), or reboot; **Unknown** (fail-closed) when it can't confirm the host/boot or the platform can't introspect (Windows), so callers fall back to the timeout.
- **`session.State`** gains `Owner` plus `OwnerLiveness()`/`OwnerExited()`. `OwnerExited()` is true only for an ACTIVE session whose owner is gone.
- **Turn start** (`InitializeSession`) records the owner alongside the branch, cleared-then-set each turn so a failed resolve never leaves a stale owner and the fingerprint tracks agent restarts.
- **`entire status` and `entire doctor`** run a shared `finalizeExitedSessions` sweep up front, finalizing exited sessions on the spot by replaying the missing `SessionStop` (`PhaseEnded` + condense) via the extracted `endSessionNow` — the same path the clean-stop hook runs. The sweep re-checks `OwnerExited()` under the session-state lock to avoid racing a turn that revived the session. Both surfaces also carry an `exited` label (human, `--json`, and doctor's stuck-session reason) as a fallback.

Terminology is **"exited"**, not "crashed" — it covers a clean exit as much as an abnormal one.

## Commits

1. `proclive: add process-liveness package`
2. `session: record owning process and detect exited sessions`
3. `strategy: capture session owner at each turn start`
4. `status, doctor: finalize sessions whose agent has exited`

## Testing

- Unit tests for `proclive` (live-process Alive/Dead, PID-reuse, `/proc` parsing with parens, unsupported-platform Unknown), `OwnerExited`, owner capture at turn start, the finalize sweep, and its under-lock revalidation.
- `mise run lint` → 0 issues; `mise run test:ci` green (unit + integration + Vogon + external-agent canary); cross-compiles on linux/darwin/windows.
- Live smoke: `entire status` finalized a planted exited session (`phase: ended`, `fully_condensed: true`) immediately rather than after an hour.

Reviewed in two passes by Codex; all findings addressed.

## Out of scope

- Windows process liveness (degrades to the timeout).
- `entire session list` "exited" labeling (easy follow-up reusing `OwnerExited`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session lifecycle, condensation, and doctor/status auto-finalization; incorrect liveness could end live sessions, though guards and fail-closed Unknown reduce that risk.
> 
> **Overview**
> Adds **process-based session liveness** so ACTIVE sessions are not stuck until the 1-hour inactivity timeout when the agent exits without a `SessionStop` hook.
> 
> A new **`proclive`** package records the owning agent at each turn start (PID + start fingerprint, host/boot guards) and reports alive/dead/unknown. Session state gains **`Owner`** plus **`OwnerExited()`**; turn start clears then re-captures the owner via **`captureSessionOwner`**.
> 
> **`endSessionNow`** centralizes mark-ended + eager condense (shared by SessionStop and the new sweep). **`markSessionEnded`** takes an optional **guard** and returns whether the session actually ended.
> 
> **`finalizeExitedSessions`** runs at the start of **`entire status`** and **`entire doctor`**, ending and condensing exited sessions under lock (re-checking `OwnerExited` to avoid races). Doctor **`classifySession`** treats exited owners as stuck immediately; status shows an **exited** label when finalize could not complete.
> 
> Linux/darwin get real introspection; other platforms degrade to **Unknown** and keep the timeout fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e2f3ae69fbb0174e3acad1a772518d796b467e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->