### PR TITLE
Send versioned User-Agent (entire-cli/{version})

### DIFF
--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -9,11 +9,12 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 const (
 	maxResponseBytes = 16 << 20
-	userAgent        = "entire-cli"
 )
 
 // Client is an authenticated HTTP client for the Entire API.
@@ -79,7 +80,7 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.token != "" {
 		r.Header.Set("Authorization", "Bearer "+t.token)
 	}
-	r.Header.Set("User-Agent", userAgent)
+	r.Header.Set("User-Agent", versioninfo.UserAgent())
 	if r.Header.Get("Accept") == "" {
 		r.Header.Set("Accept", "application/json")
 	}

--- a/cmd/entire/cli/api/client_test.go
+++ b/cmd/entire/cli/api/client_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 const testBearerHeader = "Bearer tok"
@@ -47,8 +49,8 @@ func TestBearerTransport_InjectsAuthHeader(t *testing.T) {
 	if gotAuth != "Bearer test-token-123" {
 		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer test-token-123")
 	}
-	if gotUA != "entire-cli" {
-		t.Errorf("User-Agent = %q, want %q", gotUA, "entire-cli")
+	if want := versioninfo.UserAgent(); gotUA != want {
+		t.Errorf("User-Agent = %q, want %q", gotUA, want)
 	}
 	if gotAccept != "application/json" {
 		t.Errorf("Accept = %q, want %q", gotAccept, "application/json")
@@ -87,8 +89,8 @@ func TestBearerTransport_EmptyTokenOmitsAuthHeader(t *testing.T) {
 	if gotAuth != "" {
 		t.Errorf("Authorization = %q, want empty", gotAuth)
 	}
-	if gotUA != "entire-cli" {
-		t.Errorf("User-Agent = %q, want entire-cli", gotUA)
+	if want := versioninfo.UserAgent(); gotUA != want {
+		t.Errorf("User-Agent = %q, want %q", gotUA, want)
 	}
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 (server should have decided, not the transport)", resp.StatusCode)

--- a/cmd/entire/cli/search/search.go
+++ b/cmd/entire/cli/search/search.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 const apiTimeout = 30 * time.Second
@@ -590,7 +592,7 @@ func Search(ctx context.Context, cfg Config) (*Response, error) {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+cfg.GitHubToken)
-	req.Header.Set("User-Agent", "entire-cli")
+	req.Header.Set("User-Agent", versioninfo.UserAgent())
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/cmd/entire/cli/search/search_test.go
+++ b/cmd/entire/cli/search/search_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
 const testOwner = "entirehq"
@@ -173,8 +175,8 @@ func TestSearch_URLConstruction(t *testing.T) {
 	if capturedReq.Header.Get("Authorization") != "Bearer ghp_test123" {
 		t.Errorf("auth header = %s, want 'Bearer ghp_test123'", capturedReq.Header.Get("Authorization"))
 	}
-	if capturedReq.Header.Get("User-Agent") != "entire-cli" {
-		t.Errorf("user-agent = %s, want 'entire-cli'", capturedReq.Header.Get("User-Agent"))
+	if want := versioninfo.UserAgent(); capturedReq.Header.Get("User-Agent") != want {
+		t.Errorf("user-agent = %s, want %q", capturedReq.Header.Get("User-Agent"), want)
 	}
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -185,7 +185,7 @@ func fetchLatestVersion(ctx context.Context) (string, error) {
 	}
 
 	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "entire-cli")
+	req.Header.Set("User-Agent", versioninfo.UserAgent())
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -229,7 +229,7 @@ func fetchLatestNightlyVersion(ctx context.Context) (string, error) {
 	}
 
 	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "entire-cli/"+versioninfo.Version)
+	req.Header.Set("User-Agent", versioninfo.UserAgent())
 
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/spf13/cobra"
 )
 
@@ -248,8 +249,8 @@ func TestFetchLatestVersion(t *testing.T) {
 		if r.Header.Get("Accept") != "application/vnd.github+json" {
 			t.Errorf("Accept header = %q, want application/vnd.github+json", r.Header.Get("Accept"))
 		}
-		if r.Header.Get("User-Agent") != "entire-cli" {
-			t.Errorf("User-Agent header = %q, want entire-cli", r.Header.Get("User-Agent"))
+		if want := versioninfo.UserAgent(); r.Header.Get("User-Agent") != want {
+			t.Errorf("User-Agent header = %q, want %q", r.Header.Get("User-Agent"), want)
 		}
 
 		release := GitHubRelease{

--- a/cmd/entire/cli/versioninfo/versioninfo.go
+++ b/cmd/entire/cli/versioninfo/versioninfo.go
@@ -18,6 +18,12 @@ var (
 	Commit  = "unknown"
 )
 
+// UserAgent is the HTTP User-Agent the CLI sends on outbound requests:
+// "entire-cli/<version>". Call after Load() so the version is resolved.
+func UserAgent() string {
+	return "entire-cli/" + Version
+}
+
 // Load fills Version and Commit from the binary's build info when ldflags left
 // them at their defaults. Call once from main() before either is read.
 func Load() {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/630
<!-- entire-trail-link-end -->

Outbound HTTP requests now send `User-Agent: entire-cli/<version>` instead of a bare `entire-cli`, so servers can tell which CLI version is calling.

- New `versioninfo.UserAgent()` helper; reuses the already-resolved build version (no new version plumbing).
- Routes the API client, `search`, and version-check requests through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only observability change with no auth or request-body logic; behavior is unchanged aside from User-Agent formatting.
> 
> **Overview**
> Outbound HTTP from the CLI now sends **`User-Agent: entire-cli/<version>`** instead of a fixed `entire-cli`, so backends can attribute traffic to a specific build.
> 
> A new **`versioninfo.UserAgent()`** helper formats the string from the existing resolved `Version` (documented to call after `Load()`). The Entire API client transport, search service requests, and GitHub version-check fetches all use it; nightly release checks no longer hand-build `entire-cli/` + version and match the same helper as stable checks. Tests were updated to expect `versioninfo.UserAgent()` rather than a hardcoded value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0847cb911876d70967cfbdadcbd4247c2ea1ad8b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->