### PR TITLE
checkpoint: rename InitialAttribution → Attribution

### DIFF
--- a/api/checkpoint/interfaces.go
+++ b/api/checkpoint/interfaces.go
@@ -64,7 +64,7 @@ type BackfillSummary struct {
 // (Former UpdateCheckpointSummary.)
 type BackfillAttribution struct {
 	CheckpointID id.CheckpointID
-	Attribution  *InitialAttribution
+	Attribution  *Attribution
 }
 
 func (WriteSession) isWriteRequest()        {}

--- a/api/checkpoint/metadata.go
+++ b/api/checkpoint/metadata.go
@@ -109,9 +109,9 @@ type WriteCommittedOptions struct {
 	// SessionMetrics contains hook-provided session metrics (duration, turns, context usage)
 	SessionMetrics *SessionMetrics
 
-	// InitialAttribution is line-level attribution calculated at commit time
+	// Attribution is line-level attribution calculated at commit time
 	// comparing checkpoint tree (agent work) to committed tree (may include human edits)
-	InitialAttribution *InitialAttribution
+	Attribution *Attribution
 
 	// PromptAttributionsJSON is the raw PromptAttributions data, JSON-encoded.
 	// Persisted for diagnostic purposes — shows exactly which prompt recorded
@@ -122,7 +122,7 @@ type WriteCommittedOptions struct {
 	// CombinedAttribution is holistic attribution across all sessions.
 	// Used during migration to preserve v1 root summary attribution.
 	// During normal condensation this is nil (computed post-commit via UpdateCheckpointSummary).
-	CombinedAttribution *InitialAttribution
+	CombinedAttribution *Attribution
 
 	// Summary is an optional AI-generated summary for this checkpoint.
 	// This field may be nil when:
@@ -333,10 +333,10 @@ type CommittedMetadata struct {
 	// AI-generated summary of the checkpoint
 	Summary *Summary `json:"summary,omitempty"`
 
-	// InitialAttribution is line-level attribution calculated at commit time
-	InitialAttribution *InitialAttribution `json:"initial_attribution,omitempty"`
+	// Attribution is line-level attribution calculated at commit time
+	Attribution *Attribution `json:"initial_attribution,omitempty"`
 
-	// PromptAttributions is the raw per-prompt attribution data used to compute InitialAttribution.
+	// PromptAttributions is the raw per-prompt attribution data used to compute Attribution.
 	// Diagnostic field — shows which prompt recorded which "user" lines.
 	PromptAttributions json.RawMessage `json:"prompt_attributions,omitempty"`
 
@@ -400,15 +400,15 @@ type SessionFilePaths struct {
 //
 //nolint:revive // Named CheckpointSummary to avoid conflict with existing Summary struct
 type CheckpointSummary struct {
-	CLIVersion          string              `json:"cli_version,omitempty"`
-	CheckpointID        id.CheckpointID     `json:"checkpoint_id"`
-	Strategy            string              `json:"strategy"`
-	Branch              string              `json:"branch,omitempty"`
-	CheckpointsCount    int                 `json:"checkpoints_count"`
-	FilesTouched        []string            `json:"files_touched"`
-	Sessions            []SessionFilePaths  `json:"sessions"`
-	TokenUsage          *types.TokenUsage   `json:"token_usage,omitempty"`
-	CombinedAttribution *InitialAttribution `json:"combined_attribution,omitempty"`
+	CLIVersion          string             `json:"cli_version,omitempty"`
+	CheckpointID        id.CheckpointID    `json:"checkpoint_id"`
+	Strategy            string             `json:"strategy"`
+	Branch              string             `json:"branch,omitempty"`
+	CheckpointsCount    int                `json:"checkpoints_count"`
+	FilesTouched        []string           `json:"files_touched"`
+	Sessions            []SessionFilePaths `json:"sessions"`
+	TokenUsage          *types.TokenUsage  `json:"token_usage,omitempty"`
+	CombinedAttribution *Attribution       `json:"combined_attribution,omitempty"`
 
 	// HasReview is the umbrella "any review happened" flag: true when at least
 	// one session in this checkpoint has a review-kind Kind (currently
@@ -460,7 +460,7 @@ type CodeLearning struct {
 	Finding string `json:"finding"`            // What was learned
 }
 
-// InitialAttribution captures line-level attribution metrics at commit time.
+// Attribution captures line-level attribution metrics at commit time.
 // This is a point-in-time snapshot comparing the checkpoint tree (agent work)
 // against the committed tree (may include human edits).
 //
@@ -469,7 +469,7 @@ type CodeLearning struct {
 //   - TotalLinesChanged measures total committed line changes (adds + modifies + removes)
 //   - AgentPercentage represents "of the lines changed in this commit, what percentage came from the agent"
 //   - AgentRemoved tracks committed deletions performed by the agent
-type InitialAttribution struct {
+type Attribution struct {
 	CalculatedAt      time.Time `json:"calculated_at"`
 	AgentLines        int       `json:"agent_lines"`              // Lines added by agent that remain in the commit
 	AgentRemoved      int       `json:"agent_removed"`            // Lines removed by agent that remain removed in the commit

--- a/cmd/entire/cli/attribution.go
+++ b/cmd/entire/cli/attribution.go
@@ -564,7 +564,7 @@ type checkpointSessionForFile struct {
 	Prompt       string
 	Intent       string
 	FilesTouched []string
-	Attribution  *checkpoint.InitialAttribution
+	Attribution  *checkpoint.Attribution
 }
 
 func (r *attributionResolver) readSessionForCheckpoint(cpID id.CheckpointID, index int) (checkpointSessionForFile, error) {
@@ -591,7 +591,7 @@ func (r *attributionResolver) readSessionForCheckpoint(cpID id.CheckpointID, ind
 		Prompt:       prompt,
 		Intent:       intent,
 		FilesTouched: normalizePathSlice(meta.FilesTouched),
-		Attribution:  meta.InitialAttribution,
+		Attribution:  meta.Attribution,
 	}, nil
 }
 
@@ -1202,7 +1202,7 @@ func normalizeGitPath(path string) string {
 	return filepath.ToSlash(path)
 }
 
-func attributionIsMixed(attr *checkpoint.InitialAttribution) bool {
+func attributionIsMixed(attr *checkpoint.Attribution) bool {
 	if attr == nil {
 		return false
 	}

--- a/cmd/entire/cli/attribution_test.go
+++ b/cmd/entire/cli/attribution_test.go
@@ -98,7 +98,7 @@ func TestAttributionBlameShowsHumanAndAICheckpointLines(t *testing.T) {
 		Agent:            agent.AgentTypeClaudeCode,
 		Model:            "claude-sonnet-test",
 		CheckpointsCount: 1,
-		InitialAttribution: &checkpoint.InitialAttribution{
+		Attribution: &checkpoint.Attribution{
 			AgentLines:        1,
 			TotalCommitted:    1,
 			TotalLinesChanged: 1,
@@ -168,7 +168,7 @@ func TestAttributionBlameLongShowsDetailedColumns(t *testing.T) {
 		Agent:            agent.AgentTypeClaudeCode,
 		Model:            "claude-sonnet-test",
 		CheckpointsCount: 1,
-		InitialAttribution: &checkpoint.InitialAttribution{
+		Attribution: &checkpoint.Attribution{
 			AgentLines:        1,
 			TotalCommitted:    1,
 			TotalLinesChanged: 1,
@@ -200,7 +200,7 @@ func TestAttributionBlameMarksMixedCheckpoint(t *testing.T) {
 		Agent:            agent.AgentTypeClaudeCode,
 		Model:            "claude-sonnet-test",
 		CheckpointsCount: 1,
-		InitialAttribution: &checkpoint.InitialAttribution{
+		Attribution: &checkpoint.Attribution{
 			AgentLines:        1,
 			HumanModified:     1,
 			TotalCommitted:    1,
@@ -315,7 +315,7 @@ func TestAttributionBlameMixedUsesFileMatchingCheckpoint(t *testing.T) {
 		FilesTouched:     []string{"auth.py"},
 		Agent:            agent.AgentTypeClaudeCode,
 		CheckpointsCount: 1,
-		InitialAttribution: &checkpoint.InitialAttribution{
+		Attribution: &checkpoint.Attribution{
 			AgentLines:        1,
 			TotalCommitted:    1,
 			TotalLinesChanged: 1,
@@ -329,7 +329,7 @@ func TestAttributionBlameMixedUsesFileMatchingCheckpoint(t *testing.T) {
 		FilesTouched:     []string{"other.py"},
 		Agent:            agent.AgentTypeClaudeCode,
 		CheckpointsCount: 1,
-		InitialAttribution: &checkpoint.InitialAttribution{
+		Attribution: &checkpoint.Attribution{
 			AgentLines:        1,
 			HumanModified:     1,
 			TotalCommitted:    1,
@@ -407,7 +407,7 @@ func TestAttributionBlameScopesMixedToSessionNotCheckpoint(t *testing.T) {
 		Agent:            agent.AgentTypeClaudeCode,
 		CheckpointsCount: 1,
 		// The session that touched auth.py is purely agent work...
-		InitialAttribution: &checkpoint.InitialAttribution{
+		Attribution: &checkpoint.Attribution{
 			AgentLines:        1,
 			TotalCommitted:    1,
 			TotalLinesChanged: 1,
@@ -416,7 +416,7 @@ func TestAttributionBlameScopesMixedToSessionNotCheckpoint(t *testing.T) {
 		},
 		// ...even though the checkpoint as a whole mixed agent and human work
 		// (e.g. a human-edited file elsewhere in the same checkpoint).
-		CombinedAttribution: &checkpoint.InitialAttribution{
+		CombinedAttribution: &checkpoint.Attribution{
 			AgentLines:        1,
 			HumanModified:     1,
 			TotalCommitted:    2,

--- a/cmd/entire/cli/checkpoint/aliases.go
+++ b/cmd/entire/cli/checkpoint/aliases.go
@@ -17,15 +17,15 @@ type (
 	// Persisted document types.
 	CommittedMetadata = apicheckpoint.CommittedMetadata
 	//nolint:revive // Named CheckpointSummary to avoid conflict with the Summary struct (matches the contract definition).
-	CheckpointSummary  = apicheckpoint.CheckpointSummary
-	CommittedInfo      = apicheckpoint.CommittedInfo
-	SessionContent     = apicheckpoint.SessionContent
-	SessionFilePaths   = apicheckpoint.SessionFilePaths
-	SessionMetrics     = apicheckpoint.SessionMetrics
-	Summary            = apicheckpoint.Summary
-	LearningsSummary   = apicheckpoint.LearningsSummary
-	CodeLearning       = apicheckpoint.CodeLearning
-	InitialAttribution = apicheckpoint.InitialAttribution
+	CheckpointSummary = apicheckpoint.CheckpointSummary
+	CommittedInfo     = apicheckpoint.CommittedInfo
+	SessionContent    = apicheckpoint.SessionContent
+	SessionFilePaths  = apicheckpoint.SessionFilePaths
+	SessionMetrics    = apicheckpoint.SessionMetrics
+	Summary           = apicheckpoint.Summary
+	LearningsSummary  = apicheckpoint.LearningsSummary
+	CodeLearning      = apicheckpoint.CodeLearning
+	Attribution       = apicheckpoint.Attribution
 
 	// Operation option types.
 	WriteCommittedOptions      = apicheckpoint.WriteCommittedOptions

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -450,7 +450,7 @@ func (s *GitStore) writeSessionToSubdirectory(ctx context.Context, opts WriteCom
 		SkillEventsVersion:          skillEventsVersion(opts.SkillEvents),
 		SkillEvents:                 opts.SkillEvents,
 		SessionMetrics:              opts.SessionMetrics,
-		InitialAttribution:          opts.InitialAttribution,
+		Attribution:                 opts.Attribution,
 		PromptAttributions:          opts.PromptAttributionsJSON,
 		Summary:                     redactSummary(opts.Summary),
 		CLIVersion:                  versioninfo.Version,
@@ -538,7 +538,7 @@ func (s *GitStore) writeCheckpointSummary(opts WriteCommittedOptions, basePath s
 
 // UpdateCheckpointSummary updates root-level checkpoint metadata fields that depend
 // on the full set of sessions already written to the checkpoint.
-func (s *GitStore) UpdateCheckpointSummary(ctx context.Context, checkpointID id.CheckpointID, combinedAttribution *InitialAttribution) error {
+func (s *GitStore) UpdateCheckpointSummary(ctx context.Context, checkpointID id.CheckpointID, combinedAttribution *Attribution) error {
 	if err := ctx.Err(); err != nil {
 		return err //nolint:wrapcheck // Propagating context cancellation
 	}

--- a/cmd/entire/cli/checkpoint/committed_write_test.go
+++ b/cmd/entire/cli/checkpoint/committed_write_test.go
@@ -72,7 +72,7 @@ func TestWrite_DispatchesEachRequest(t *testing.T) {
 	// BackfillAttribution rewrites the checkpoint root combined attribution.
 	if err := store.Write(ctx, BackfillAttribution{
 		CheckpointID: cpID,
-		Attribution:  &InitialAttribution{AgentLines: 42},
+		Attribution:  &Attribution{AgentLines: 42},
 	}); err != nil {
 		t.Fatalf("Write(BackfillAttribution) error = %v", err)
 	}

--- a/cmd/entire/cli/integration_test/attribution_test.go
+++ b/cmd/entire/cli/integration_test/attribution_test.go
@@ -152,7 +152,7 @@ func TestManualCommit_Attribution(t *testing.T) {
 		t.Fatalf("Failed to get sessions tree: %v", err)
 	}
 
-	// Read session-level metadata.json from sharded path (InitialAttribution is in 0/metadata.json)
+	// Read session-level metadata.json from sharded path (Attribution is in 0/metadata.json)
 	metadataPath := SessionMetadataPath(checkpointID.String())
 	metadataFile, err := sessionsTree.File(metadataPath)
 	if err != nil {
@@ -169,12 +169,12 @@ func TestManualCommit_Attribution(t *testing.T) {
 		t.Fatalf("Failed to parse metadata.json: %v", err)
 	}
 
-	// Verify InitialAttribution exists
-	if metadata.InitialAttribution == nil {
-		t.Fatal("InitialAttribution is nil")
+	// Verify Attribution exists
+	if metadata.Attribution == nil {
+		t.Fatal("Attribution is nil")
 	}
 
-	attr := metadata.InitialAttribution
+	attr := metadata.Attribution
 	t.Logf("Attribution: agent=%d, human_added=%d, human_modified=%d, human_removed=%d, total=%d, percentage=%.1f%%",
 		attr.AgentLines, attr.HumanAdded, attr.HumanModified, attr.HumanRemoved,
 		attr.TotalCommitted, attr.AgentPercentage)
@@ -295,7 +295,7 @@ func TestManualCommit_AttributionDeletionOnly(t *testing.T) {
 		t.Fatalf("Failed to get sessions tree: %v", err)
 	}
 
-	// Read session-level metadata.json (InitialAttribution is in 0/metadata.json)
+	// Read session-level metadata.json (Attribution is in 0/metadata.json)
 	metadataPath := SessionMetadataPath(checkpointID.String())
 	metadataFile, err := sessionsTree.File(metadataPath)
 	if err != nil {
@@ -312,11 +312,11 @@ func TestManualCommit_AttributionDeletionOnly(t *testing.T) {
 		t.Fatalf("Failed to parse metadata.json: %v", err)
 	}
 
-	if metadata.InitialAttribution == nil {
-		t.Fatal("InitialAttribution is nil")
+	if metadata.Attribution == nil {
+		t.Fatal("Attribution is nil")
 	}
 
-	attr := metadata.InitialAttribution
+	attr := metadata.Attribution
 	t.Logf("Attribution (deletion-only): agent_added=%d, agent_removed=%d, human_added=%d, human_removed=%d, total=%d, changed=%d, percentage=%.1f%%",
 		attr.AgentLines, attr.AgentRemoved, attr.HumanAdded, attr.HumanRemoved,
 		attr.TotalCommitted, attr.TotalLinesChanged, attr.AgentPercentage)
@@ -823,8 +823,8 @@ func TestManualCommit_AttributionStaleBase_BranchSwitch(t *testing.T) {
 }
 
 // getAttributionFromMetadata reads attribution from a checkpoint on entire/checkpoints/v1 branch.
-// InitialAttribution is stored in session-level metadata (0/metadata.json).
-func getAttributionFromMetadata(t *testing.T, repo *git.Repository, checkpointID id.CheckpointID) *checkpoint.InitialAttribution {
+// Attribution is stored in session-level metadata (0/metadata.json).
+func getAttributionFromMetadata(t *testing.T, repo *git.Repository, checkpointID id.CheckpointID) *checkpoint.Attribution {
 	t.Helper()
 
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
@@ -842,7 +842,7 @@ func getAttributionFromMetadata(t *testing.T, repo *git.Repository, checkpointID
 		t.Fatalf("Failed to get sessions tree: %v", err)
 	}
 
-	// Read session-level metadata (InitialAttribution is in 0/metadata.json)
+	// Read session-level metadata (Attribution is in 0/metadata.json)
 	metadataPath := SessionMetadataPath(checkpointID.String())
 	metadataFile, err := sessionsTree.File(metadataPath)
 	if err != nil {
@@ -859,9 +859,9 @@ func getAttributionFromMetadata(t *testing.T, repo *git.Repository, checkpointID
 		t.Fatalf("Failed to parse metadata.json: %v", err)
 	}
 
-	if metadata.InitialAttribution == nil {
-		t.Fatal("InitialAttribution is nil")
+	if metadata.Attribution == nil {
+		t.Fatal("Attribution is nil")
 	}
 
-	return metadata.InitialAttribution
+	return metadata.Attribution
 }

--- a/cmd/entire/cli/strategy/common.go
+++ b/cmd/entire/cli/strategy/common.go
@@ -594,7 +594,7 @@ func isEmptyMetadataBranch(repo *git.Repository, ref *plumbing.Reference) (bool,
 }
 
 // sessionMetadataLite contains only the fields needed from session-level metadata.json.
-// Using a minimal struct avoids allocating large nested objects (Summary, InitialAttribution,
+// Using a minimal struct avoids allocating large nested objects (Summary, Attribution,
 // TokenUsage, etc.) that CommittedMetadata carries but callers never need here.
 type sessionMetadataLite struct {
 	SessionID string          `json:"session_id"`
@@ -660,7 +660,7 @@ func decodeSummaryLiteFromTree(checkpointTree checkpoint.FileReader) (checkpoint
 // also reading session-level metadata for IsTask/ToolUseID fields.
 //
 // Uses streaming json.Decoder and minimal structs to avoid loading large nested
-// objects (Summary, InitialAttribution, TokenUsage) into memory.
+// objects (Summary, Attribution, TokenUsage) into memory.
 func ReadCheckpointMetadata(tree checkpoint.FileReader, checkpointPath string) (*CheckpointInfo, error) {
 	metadataPath := checkpointPath + "/metadata.json"
 	file, err := tree.File(metadataPath)

--- a/cmd/entire/cli/strategy/manual_commit_attribution.go
+++ b/cmd/entire/cli/strategy/manual_commit_attribution.go
@@ -203,7 +203,7 @@ type AttributionParams struct {
 // calculations since line-based diffing only applies to text files.
 //
 // See docs/architecture/attribution.md for details on the per-file tracking approach.
-func CalculateAttributionWithAccumulated(ctx context.Context, p AttributionParams) *checkpoint.InitialAttribution {
+func CalculateAttributionWithAccumulated(ctx context.Context, p AttributionParams) *checkpoint.Attribution {
 	if len(p.FilesTouched) == 0 {
 		return nil
 	}
@@ -267,7 +267,7 @@ func CalculateAttributionWithAccumulated(ctx context.Context, p AttributionParam
 		agentPercentage = float64(agentChangedLines) / float64(totalLinesChanged) * 100
 	}
 
-	return &checkpoint.InitialAttribution{
+	return &checkpoint.Attribution{
 		CalculatedAt:      time.Now().UTC(),
 		AgentLines:        agentLinesInCommit,
 		AgentRemoved:      agentRemovedInCommit,

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -276,7 +276,7 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 		TokenUsage:                  sessionData.TokenUsage,
 		SkillEvents:                 skillEvents,
 		SessionMetrics:              buildSessionMetrics(state),
-		InitialAttribution:          attribution,
+		Attribution:                 attribution,
 		PromptAttributionsJSON:      marshalPromptAttributionsIncludingPending(state),
 		Summary:                     summary,
 		Kind:                        string(state.Kind),
@@ -585,7 +585,7 @@ func buildSummaryGenerator(ctx context.Context) summarize.Generator { //nolint:i
 // marshalPromptAttributionsIncludingPending builds the complete prompt attribution slice
 // (including PendingPromptAttribution for mid-turn commits) and encodes it to JSON.
 // This must stay consistent with the slice used by calculateSessionAttributions so the
-// persisted diagnostics match the computed InitialAttribution.
+// persisted diagnostics match the computed Attribution.
 func marshalPromptAttributionsIncludingPending(state *SessionState) json.RawMessage {
 	pas := make([]PromptAttribution, len(state.PromptAttributions), len(state.PromptAttributions)+1)
 	copy(pas, state.PromptAttributions)
@@ -680,7 +680,7 @@ type attributionOpts struct {
 	allAgentFiles         map[string]struct{} // Union of all sessions' FilesTouched (nil = single-session)
 }
 
-func calculateSessionAttributions(ctx context.Context, repo *git.Repository, shadowRef *plumbing.Reference, sessionData *ExtractedSessionData, state *SessionState, opts ...attributionOpts) *cpkg.InitialAttribution {
+func calculateSessionAttributions(ctx context.Context, repo *git.Repository, shadowRef *plumbing.Reference, sessionData *ExtractedSessionData, state *SessionState, opts ...attributionOpts) *cpkg.Attribution {
 	// Calculate initial attribution using accumulated prompt attribution data.
 	// This uses user edits captured at each prompt start (before agent works),
 	// plus any user edits after the final checkpoint (shadow → head).

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -1137,7 +1137,7 @@ func (s *ManualCommitStrategy) updateCombinedAttributionForCheckpoint(
 		agentPercentage = float64(agentAdded+agentRemoved) / float64(totalLinesChanged) * 100
 	}
 
-	combined := &checkpoint.InitialAttribution{
+	combined := &checkpoint.Attribution{
 		CalculatedAt:      time.Now().UTC(),
 		AgentLines:        agentAdded,
 		AgentRemoved:      agentRemoved,

--- a/cmd/entire/cli/strategy/manual_commit_test.go
+++ b/cmd/entire/cli/strategy/manual_commit_test.go
@@ -2212,10 +2212,10 @@ func TestExtractUserPrompts(t *testing.T) {
 	}
 }
 
-// TestCondenseSession_IncludesInitialAttribution verifies that when manual-commit
-// condenses a session, it calculates InitialAttribution by comparing the shadow branch
+// TestCondenseSession_IncludesAttribution verifies that when manual-commit
+// condenses a session, it calculates Attribution by comparing the shadow branch
 // (agent work) to HEAD (what was committed).
-func TestCondenseSession_IncludesInitialAttribution(t *testing.T) {
+func TestCondenseSession_IncludesAttribution(t *testing.T) {
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)
 	repo, err := git.PlainOpen(dir)
@@ -2310,7 +2310,7 @@ func TestCondenseSession_IncludesInitialAttribution(t *testing.T) {
 		t.Fatalf("loadSessionState() error = %v", err)
 	}
 
-	// Condense the session - this should calculate InitialAttribution
+	// Condense the session - this should calculate Attribution
 	checkpointID := id.MustCheckpointID("a1b2c3d4e5f6")
 	result, err := s.CondenseSession(context.Background(), repo, checkpointID, state, nil)
 	if err != nil {
@@ -2322,7 +2322,7 @@ func TestCondenseSession_IncludesInitialAttribution(t *testing.T) {
 		t.Errorf("CheckpointID = %q, want %q", result.CheckpointID, checkpointID)
 	}
 
-	// Read metadata from entire/checkpoints/v1 branch and verify InitialAttribution
+	// Read metadata from entire/checkpoints/v1 branch and verify Attribution
 	sessionsRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {
 		t.Fatalf("failed to get sessions branch: %v", err)
@@ -2338,7 +2338,7 @@ func TestCondenseSession_IncludesInitialAttribution(t *testing.T) {
 		t.Fatalf("failed to get tree: %v", err)
 	}
 
-	// InitialAttribution is stored in session-level metadata (0/metadata.json), not root (0-based indexing)
+	// Attribution is stored in session-level metadata (0/metadata.json), not root (0-based indexing)
 	sessionMetadataPath := checkpointID.Path() + "/0/" + paths.MetadataFileName
 	metadataFile, err := tree.File(sessionMetadataPath)
 	if err != nil {
@@ -2350,9 +2350,9 @@ func TestCondenseSession_IncludesInitialAttribution(t *testing.T) {
 		t.Fatalf("failed to read metadata.json: %v", err)
 	}
 
-	// Parse and verify InitialAttribution is present
+	// Parse and verify Attribution is present
 	var metadata struct {
-		InitialAttribution *struct {
+		Attribution *struct {
 			AgentLines      int     `json:"agent_lines"`
 			HumanAdded      int     `json:"human_added"`
 			HumanModified   int     `json:"human_modified"`
@@ -2365,40 +2365,40 @@ func TestCondenseSession_IncludesInitialAttribution(t *testing.T) {
 		t.Fatalf("failed to parse metadata.json: %v", err)
 	}
 
-	if metadata.InitialAttribution == nil {
-		t.Fatal("InitialAttribution should be present in session metadata.json for manual-commit")
+	if metadata.Attribution == nil {
+		t.Fatal("Attribution should be present in session metadata.json for manual-commit")
 	}
 
 	// Verify the attribution values are reasonable
 	// Agent added new function, human added a comment line
 	// The exact line counts depend on how the diff algorithm interprets the changes
 	// (insertion vs modification), but we should have non-zero totals and reasonable percentages.
-	if metadata.InitialAttribution.TotalCommitted == 0 {
+	if metadata.Attribution.TotalCommitted == 0 {
 		t.Error("TotalCommitted should be > 0")
 	}
-	if metadata.InitialAttribution.AgentLines == 0 {
+	if metadata.Attribution.AgentLines == 0 {
 		t.Error("AgentLines should be > 0 (agent wrote code)")
 	}
 
 	// Human contribution should be captured in either HumanAdded or HumanModified
 	// When inserting lines in the middle of existing code, the diff algorithm may
 	// interpret it as a modification rather than a pure addition.
-	humanContribution := metadata.InitialAttribution.HumanAdded + metadata.InitialAttribution.HumanModified
+	humanContribution := metadata.Attribution.HumanAdded + metadata.Attribution.HumanModified
 	if humanContribution == 0 {
 		t.Error("Human contribution (HumanAdded + HumanModified) should be > 0")
 	}
 
-	if metadata.InitialAttribution.AgentPercentage <= 0 || metadata.InitialAttribution.AgentPercentage > 100 {
-		t.Errorf("AgentPercentage should be between 0-100, got %f", metadata.InitialAttribution.AgentPercentage)
+	if metadata.Attribution.AgentPercentage <= 0 || metadata.Attribution.AgentPercentage > 100 {
+		t.Errorf("AgentPercentage should be between 0-100, got %f", metadata.Attribution.AgentPercentage)
 	}
 
 	t.Logf("Attribution: agent=%d, human_added=%d, human_modified=%d, human_removed=%d, total=%d, percentage=%.1f%%",
-		metadata.InitialAttribution.AgentLines,
-		metadata.InitialAttribution.HumanAdded,
-		metadata.InitialAttribution.HumanModified,
-		metadata.InitialAttribution.HumanRemoved,
-		metadata.InitialAttribution.TotalCommitted,
-		metadata.InitialAttribution.AgentPercentage)
+		metadata.Attribution.AgentLines,
+		metadata.Attribution.HumanAdded,
+		metadata.Attribution.HumanModified,
+		metadata.Attribution.HumanRemoved,
+		metadata.Attribution.TotalCommitted,
+		metadata.Attribution.AgentPercentage)
 }
 
 // TestCondenseSession_AttributionWithoutShadowBranch verifies that when an agent
@@ -2517,7 +2517,7 @@ func TestCondenseSession_AttributionWithoutShadowBranch(t *testing.T) {
 	}
 
 	var metadata struct {
-		InitialAttribution *struct {
+		Attribution *struct {
 			AgentLines      int     `json:"agent_lines"`
 			HumanAdded      int     `json:"human_added"`
 			TotalCommitted  int     `json:"total_committed"`
@@ -2528,27 +2528,27 @@ func TestCondenseSession_AttributionWithoutShadowBranch(t *testing.T) {
 		t.Fatalf("failed to parse metadata: %v", err)
 	}
 
-	if metadata.InitialAttribution == nil {
-		t.Fatal("InitialAttribution should be present even without shadow branch")
+	if metadata.Attribution == nil {
+		t.Fatal("Attribution should be present even without shadow branch")
 	}
 
 	// Agent created all content (10 lines across 2 files), no human edits
-	if metadata.InitialAttribution.AgentLines == 0 {
+	if metadata.Attribution.AgentLines == 0 {
 		t.Error("AgentLines should be > 0 (agent created the file)")
 	}
-	if metadata.InitialAttribution.TotalCommitted == 0 {
+	if metadata.Attribution.TotalCommitted == 0 {
 		t.Error("TotalCommitted should be > 0")
 	}
-	if metadata.InitialAttribution.AgentPercentage <= 50 {
+	if metadata.Attribution.AgentPercentage <= 50 {
 		t.Errorf("AgentPercentage should be > 50%% (agent wrote all content), got %.1f%%",
-			metadata.InitialAttribution.AgentPercentage)
+			metadata.Attribution.AgentPercentage)
 	}
 
 	t.Logf("Attribution (no shadow branch): agent=%d, human_added=%d, total=%d, percentage=%.1f%%",
-		metadata.InitialAttribution.AgentLines,
-		metadata.InitialAttribution.HumanAdded,
-		metadata.InitialAttribution.TotalCommitted,
-		metadata.InitialAttribution.AgentPercentage)
+		metadata.Attribution.AgentLines,
+		metadata.Attribution.HumanAdded,
+		metadata.Attribution.TotalCommitted,
+		metadata.Attribution.AgentPercentage)
 }
 
 // TestCondenseSession_AttributionWithoutShadowBranch_MixedHumanAgent verifies attribution
@@ -2684,7 +2684,7 @@ func TestCondenseSession_AttributionWithoutShadowBranch_MixedHumanAgent(t *testi
 	}
 
 	var metadata struct {
-		InitialAttribution *struct {
+		Attribution *struct {
 			AgentLines      int     `json:"agent_lines"`
 			HumanAdded      int     `json:"human_added"`
 			TotalCommitted  int     `json:"total_committed"`
@@ -2695,11 +2695,11 @@ func TestCondenseSession_AttributionWithoutShadowBranch_MixedHumanAgent(t *testi
 		t.Fatalf("failed to parse metadata: %v", err)
 	}
 
-	if metadata.InitialAttribution == nil {
-		t.Fatal("InitialAttribution should be present")
+	if metadata.Attribution == nil {
+		t.Fatal("Attribution should be present")
 	}
 
-	attr := metadata.InitialAttribution
+	attr := metadata.Attribution
 	t.Logf("Attribution (mixed, no shadow): agent=%d, human_added=%d, total=%d, percentage=%.1f%%",
 		attr.AgentLines, attr.HumanAdded, attr.TotalCommitted, attr.AgentPercentage)
 
@@ -2989,7 +2989,7 @@ func TestMultiCheckpoint_UserEditsBetweenCheckpoints(t *testing.T) {
 		t.Fatalf("failed to get tree: %v", err)
 	}
 
-	// InitialAttribution is stored in session-level metadata (0/metadata.json), not root (0-based indexing)
+	// Attribution is stored in session-level metadata (0/metadata.json), not root (0-based indexing)
 	sessionMetadataPath := checkpointID.Path() + "/0/" + paths.MetadataFileName
 	metadataFile, err := tree.File(sessionMetadataPath)
 	if err != nil {
@@ -3002,7 +3002,7 @@ func TestMultiCheckpoint_UserEditsBetweenCheckpoints(t *testing.T) {
 	}
 
 	var metadata struct {
-		InitialAttribution *struct {
+		Attribution *struct {
 			AgentLines      int     `json:"agent_lines"`
 			HumanAdded      int     `json:"human_added"`
 			HumanModified   int     `json:"human_modified"`
@@ -3015,38 +3015,38 @@ func TestMultiCheckpoint_UserEditsBetweenCheckpoints(t *testing.T) {
 		t.Fatalf("failed to parse metadata.json: %v", err)
 	}
 
-	if metadata.InitialAttribution == nil {
-		t.Fatal("InitialAttribution should be present in session metadata")
+	if metadata.Attribution == nil {
+		t.Fatal("Attribution should be present in session metadata")
 	}
 
 	t.Logf("Final Attribution: agent=%d, human_added=%d, human_modified=%d, human_removed=%d, total=%d, percentage=%.1f%%",
-		metadata.InitialAttribution.AgentLines,
-		metadata.InitialAttribution.HumanAdded,
-		metadata.InitialAttribution.HumanModified,
-		metadata.InitialAttribution.HumanRemoved,
-		metadata.InitialAttribution.TotalCommitted,
-		metadata.InitialAttribution.AgentPercentage)
+		metadata.Attribution.AgentLines,
+		metadata.Attribution.HumanAdded,
+		metadata.Attribution.HumanModified,
+		metadata.Attribution.HumanRemoved,
+		metadata.Attribution.TotalCommitted,
+		metadata.Attribution.AgentPercentage)
 
 	// Verify the attribution makes sense:
 	// - Agent modified agent.go: added ~8 lines total
 	// - User modified user.go: added ~5 lines
 	// - So agent percentage should be around 50-70%
-	if metadata.InitialAttribution.AgentLines == 0 {
+	if metadata.Attribution.AgentLines == 0 {
 		t.Error("AgentLines should be > 0")
 	}
-	if metadata.InitialAttribution.TotalCommitted == 0 {
+	if metadata.Attribution.TotalCommitted == 0 {
 		t.Error("TotalCommitted should be > 0")
 	}
 
 	// The key test: user's lines should be captured in HumanAdded
-	if metadata.InitialAttribution.HumanAdded == 0 {
+	if metadata.Attribution.HumanAdded == 0 {
 		t.Error("HumanAdded should be > 0 because user added lines to user.go")
 	}
 
 	// Agent percentage should not be 100% since user contributed
-	if metadata.InitialAttribution.AgentPercentage >= 100 {
+	if metadata.Attribution.AgentPercentage >= 100 {
 		t.Errorf("AgentPercentage should be < 100%% since user contributed, got %.1f%%",
-			metadata.InitialAttribution.AgentPercentage)
+			metadata.Attribution.AgentPercentage)
 	}
 }
 

--- a/e2e/tests/attribution_test.go
+++ b/e2e/tests/attribution_test.go
@@ -34,11 +34,11 @@ func TestLineAttributionReasonable(t *testing.T) {
 		cpID := testutil.AssertHasCheckpointTrailer(t, s.Dir, "HEAD")
 		sm := testutil.ReadSessionMetadata(t, s.Dir, cpID, 0)
 
-		assert.Greater(t, sm.InitialAttribution.AgentLines, 0,
+		assert.Greater(t, sm.Attribution.AgentLines, 0,
 			"agent lines should be > 0")
-		assert.Greater(t, sm.InitialAttribution.TotalCommitted, 0,
+		assert.Greater(t, sm.Attribution.TotalCommitted, 0,
 			"total committed should be > 0")
-		assert.Greater(t, sm.InitialAttribution.AgentPercentage, 50.0,
+		assert.Greater(t, sm.Attribution.AgentPercentage, 50.0,
 			"agent created 100%% of content, percentage should be > 50%%")
 		testutil.WaitForNoShadowBranches(t, s.Dir, 10*time.Second)
 	})
@@ -66,9 +66,9 @@ func TestInteractiveAttributionOnAgentCommit(t *testing.T) {
 		cpID := testutil.AssertHasCheckpointTrailer(t, s.Dir, "HEAD")
 		sm := testutil.ReadSessionMetadata(t, s.Dir, cpID, 0)
 
-		assert.Greater(t, sm.InitialAttribution.AgentLines, 0,
+		assert.Greater(t, sm.Attribution.AgentLines, 0,
 			"agent lines should be > 0 on first agent commit")
-		assert.Greater(t, sm.InitialAttribution.TotalCommitted, 0,
+		assert.Greater(t, sm.Attribution.TotalCommitted, 0,
 			"total committed should be > 0 on first agent commit")
 		testutil.WaitForNoShadowBranches(t, s.Dir, 10*time.Second)
 	})
@@ -104,11 +104,11 @@ func TestInteractiveAttributionMultiCommitSameSession(t *testing.T) {
 		testutil.WaitForCheckpointExists(t, s.Dir, cpID2, 30*time.Second)
 		sm := testutil.WaitForSessionMetadata(t, s.Dir, cpID2, 0, 10*time.Second)
 
-		assert.Greater(t, sm.InitialAttribution.AgentLines, 0,
+		assert.Greater(t, sm.Attribution.AgentLines, 0,
 			"agent lines should be > 0 on second commit")
-		assert.Greater(t, sm.InitialAttribution.TotalCommitted, 0,
+		assert.Greater(t, sm.Attribution.TotalCommitted, 0,
 			"total committed should be > 0 on second commit")
-		assert.Greater(t, sm.InitialAttribution.AgentPercentage, 50.0,
+		assert.Greater(t, sm.Attribution.AgentPercentage, 50.0,
 			"agent wrote all content, percentage should be > 50%%")
 		testutil.WaitForNoShadowBranches(t, s.Dir, 10*time.Second)
 	})
@@ -174,15 +174,15 @@ func TestAttributionMixedHumanAndAgent(t *testing.T) {
 		cpID := testutil.AssertHasCheckpointTrailer(t, s.Dir, "HEAD")
 		sm := testutil.ReadSessionMetadata(t, s.Dir, cpID, 0)
 
-		assert.Equal(t, agentLines, sm.InitialAttribution.AgentLines,
+		assert.Equal(t, agentLines, sm.Attribution.AgentLines,
 			"agent_lines should match actual lines in agent.txt")
-		assert.Equal(t, humanLines, sm.InitialAttribution.HumanAdded,
+		assert.Equal(t, humanLines, sm.Attribution.HumanAdded,
 			"human_added should match lines in human.txt")
-		assert.Equal(t, agentLines+humanLines, sm.InitialAttribution.TotalCommitted,
+		assert.Equal(t, agentLines+humanLines, sm.Attribution.TotalCommitted,
 			"total_committed should be sum of agent and human lines")
-		assert.Greater(t, sm.InitialAttribution.AgentPercentage, 0.0,
+		assert.Greater(t, sm.Attribution.AgentPercentage, 0.0,
 			"agent_percentage should be > 0 when agent wrote content")
-		assert.Less(t, sm.InitialAttribution.AgentPercentage, 100.0,
+		assert.Less(t, sm.Attribution.AgentPercentage, 100.0,
 			"agent_percentage should be < 100 when human also wrote content")
 		// Shadow branch may persist if agent created extra files beyond
 		// agent.txt — we only stage the two known files for precise

--- a/e2e/testutil/metadata.go
+++ b/e2e/testutil/metadata.go
@@ -40,19 +40,19 @@ type SessionRef struct {
 }
 
 type SessionMetadata struct {
-	CLIVersion         string      `json:"cli_version"`
-	CheckpointID       string      `json:"checkpoint_id"`
-	SessionID          string      `json:"session_id"`
-	Strategy           string      `json:"strategy"`
-	CreatedAt          time.Time   `json:"created_at"`
-	Branch             string      `json:"branch"`
-	Agent              string      `json:"agent"`
-	Model              string      `json:"model"`
-	CheckpointsCount   int         `json:"checkpoints_count"`
-	FilesTouched       []string    `json:"files_touched"`
-	TokenUsage         TokenUsage  `json:"token_usage"`
-	InitialAttribution Attribution `json:"initial_attribution"`
-	TranscriptPath     string      `json:"transcript_path"`
+	CLIVersion       string      `json:"cli_version"`
+	CheckpointID     string      `json:"checkpoint_id"`
+	SessionID        string      `json:"session_id"`
+	Strategy         string      `json:"strategy"`
+	CreatedAt        time.Time   `json:"created_at"`
+	Branch           string      `json:"branch"`
+	Agent            string      `json:"agent"`
+	Model            string      `json:"model"`
+	CheckpointsCount int         `json:"checkpoints_count"`
+	FilesTouched     []string    `json:"files_touched"`
+	TokenUsage       TokenUsage  `json:"token_usage"`
+	Attribution      Attribution `json:"initial_attribution"`
+	TranscriptPath   string      `json:"transcript_path"`
 
 	// CheckpointTranscriptStart is the transcript.jsonl line offset where this
 	// checkpoint's contributions begin. For the first checkpoint in a session


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/632
<!-- entire-trail-link-end -->

> Stacked on #1484.

Review feedback (#1484, point 3): there's only one attribution struct, and `Initial` is misleading — the same type is also used for the combined post-commit attribution (`CombinedAttribution *Attribution`). Drop the qualifier.

Whole-codebase rename, no behavior change. `go build ./...`, tests, and lint green.

First of the naming-feedback changes; the larger Persistent/Ephemeral rename + GitStore split follows in a separate stacked PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename with JSON wire format preserved; risk is limited to any out-of-tree code that imported the old Go symbol name.
> 
> **Overview**
> This PR renames **`InitialAttribution`** to **`Attribution`** everywhere in Go (API contract, CLI aliases, write options, blame/condensation paths, and tests). The name better matches how the type is used for both per-session commit-time metrics and checkpoint-level **`CombinedAttribution`**.
> 
> **On-disk JSON is unchanged:** session metadata still serializes under `initial_attribution` via struct tags, so existing checkpoints and external readers are not broken.
> 
> No attribution math, storage layout, or runtime behavior changes—only identifiers, comments, and test names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 722d628f6ad82018eacb42100503db9a74c5cfc0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->