### PR TITLE
Record checkpoint storage version metadata

### DIFF
--- a/cmd/entire/cli/checkpoint/checkpoint.go
+++ b/cmd/entire/cli/checkpoint/checkpoint.go
@@ -28,6 +28,9 @@ var (
 	ErrNoTranscript = errors.New("no transcript found for checkpoint")
 )
 
+// CheckpointVersionBranchV1 identifies the branch-backed checkpoint metadata format.
+const CheckpointVersionBranchV1 = "branch-v1"
+
 // Checkpoint represents a save point within a session.
 type Checkpoint struct {
 	// ID is the unique checkpoint identifier
@@ -550,6 +553,7 @@ type SessionFilePaths struct {
 //nolint:revive // Named CheckpointSummary to avoid conflict with existing Summary struct
 type CheckpointSummary struct {
 	CLIVersion          string              `json:"cli_version,omitempty"`
+	CheckpointVersion   string              `json:"checkpoint_version,omitempty"`
 	CheckpointID        id.CheckpointID     `json:"checkpoint_id"`
 	Strategy            string              `json:"strategy"`
 	Branch              string              `json:"branch,omitempty"`
@@ -573,6 +577,16 @@ type CheckpointSummary struct {
 	// be set so callers can keep asking "was this investigated in any way?"
 	// without caring about the variant.
 	HasInvestigation bool `json:"has_investigation,omitempty"`
+}
+
+func normalizeCheckpointSummary(summary *CheckpointSummary) *CheckpointSummary {
+	if summary == nil {
+		return nil
+	}
+	if summary.CheckpointVersion == "" {
+		summary.CheckpointVersion = CheckpointVersionBranchV1
+	}
+	return summary
 }
 
 // SessionMetrics contains hook-provided session metrics from agents that report

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -488,12 +488,14 @@ func (s *GitStore) writeCheckpointSummary(opts WriteCommittedOptions, basePath s
 	}
 
 	combinedAttribution := opts.CombinedAttribution
+	checkpointVersion := CheckpointVersionBranchV1
 	hasReview := opts.HasReview
 	hasInvestigation := opts.HasInvestigation
 	rootMetadataPath := basePath + paths.MetadataFileName
 	if entry, exists := entries[rootMetadataPath]; exists {
 		existingSummary, readErr := s.readSummaryFromBlob(entry.Hash)
 		if readErr == nil {
+			checkpointVersion = existingSummary.CheckpointVersion
 			if combinedAttribution == nil {
 				combinedAttribution = existingSummary.CombinedAttribution
 			}
@@ -509,7 +511,7 @@ func (s *GitStore) writeCheckpointSummary(opts WriteCommittedOptions, basePath s
 	summary := CheckpointSummary{
 		CheckpointID:        opts.CheckpointID,
 		CLIVersion:          versioninfo.Version,
-		CheckpointVersion:   CheckpointVersionBranchV1,
+		CheckpointVersion:   checkpointVersion,
 		Strategy:            opts.Strategy,
 		Branch:              opts.Branch,
 		CheckpointsCount:    checkpointsCount,

--- a/cmd/entire/cli/checkpoint/committed.go
+++ b/cmd/entire/cli/checkpoint/committed.go
@@ -509,6 +509,7 @@ func (s *GitStore) writeCheckpointSummary(opts WriteCommittedOptions, basePath s
 	summary := CheckpointSummary{
 		CheckpointID:        opts.CheckpointID,
 		CLIVersion:          versioninfo.Version,
+		CheckpointVersion:   CheckpointVersionBranchV1,
 		Strategy:            opts.Strategy,
 		Branch:              opts.Branch,
 		CheckpointsCount:    checkpointsCount,
@@ -690,7 +691,11 @@ func readJSONFromBlob[T any](repo *git.Repository, hash plumbing.Hash) (*T, erro
 
 // readSummaryFromBlob reads CheckpointSummary from a blob hash.
 func (s *GitStore) readSummaryFromBlob(hash plumbing.Hash) (*CheckpointSummary, error) {
-	return readJSONFromBlob[CheckpointSummary](s.repo, hash)
+	summary, err := readJSONFromBlob[CheckpointSummary](s.repo, hash)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeCheckpointSummary(summary), nil
 }
 
 // aggregateTokenUsage sums two TokenUsage structs.
@@ -982,7 +987,7 @@ func (s *GitStore) ReadCommitted(ctx context.Context, checkpointID id.Checkpoint
 		return nil, fmt.Errorf("failed to parse metadata.json: %w", err)
 	}
 
-	return &summary, nil
+	return normalizeCheckpointSummary(&summary), nil
 }
 
 // ReadSessionMetadata reads only the metadata.json for a specific session within a checkpoint.

--- a/cmd/entire/cli/checkpoint/committed_reader_resolve.go
+++ b/cmd/entire/cli/checkpoint/committed_reader_resolve.go
@@ -50,7 +50,7 @@ func ReadCommittedCheckpoint(ctx context.Context, reader CommittedReader, checkp
 	if summary == nil {
 		return nil, ErrCheckpointNotFound
 	}
-	return normalizeCheckpointSummary(summary), nil
+	return summary, nil
 }
 
 // ReadLatestSessionContent reads the latest session from an already-resolved

--- a/cmd/entire/cli/checkpoint/committed_reader_resolve.go
+++ b/cmd/entire/cli/checkpoint/committed_reader_resolve.go
@@ -50,7 +50,7 @@ func ReadCommittedCheckpoint(ctx context.Context, reader CommittedReader, checkp
 	if summary == nil {
 		return nil, ErrCheckpointNotFound
 	}
-	return summary, nil
+	return normalizeCheckpointSummary(summary), nil
 }
 
 // ReadLatestSessionContent reads the latest session from an already-resolved

--- a/cmd/entire/cli/checkpoint/committed_update_test.go
+++ b/cmd/entire/cli/checkpoint/committed_update_test.go
@@ -468,6 +468,36 @@ func TestUpdateCheckpointSummaryPreservesExplicitCheckpointVersion(t *testing.T)
 	}
 }
 
+func TestWriteCommittedPreservesExplicitCheckpointVersion(t *testing.T) {
+	t.Parallel()
+	_, store, cpID := setupRepoForUpdate(t)
+	const futureVersion = "refs-v1"
+
+	rewriteRootSummary(t, store, cpID, func(summary *CheckpointSummary) {
+		summary.CheckpointVersion = futureVersion
+	})
+
+	if err := store.WriteCommitted(context.Background(), WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-002",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("second session\n")),
+		Prompts:      []string{"second prompt"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}); err != nil {
+		t.Fatalf("WriteCommitted() error = %v", err)
+	}
+
+	rawSummary := readSummaryFromBranch(t, store.repo, cpID)
+	if rawSummary.CheckpointVersion != futureVersion {
+		t.Fatalf("raw checkpoint_version = %q, want %q", rawSummary.CheckpointVersion, futureVersion)
+	}
+	if len(rawSummary.Sessions) != 2 {
+		t.Fatalf("len(Sessions) = %d, want 2", len(rawSummary.Sessions))
+	}
+}
+
 func isValidContentHash(hash string) bool {
 	return len(hash) > 10 && hash[:7] == "sha256:"
 }

--- a/cmd/entire/cli/checkpoint/committed_update_test.go
+++ b/cmd/entire/cli/checkpoint/committed_update_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
@@ -65,6 +66,52 @@ func setupRepoForUpdate(t *testing.T) (*git.Repository, *GitStore, id.Checkpoint
 	}
 
 	return repo, store, cpID
+}
+
+func rewriteRootSummary(t *testing.T, store *GitStore, cpID id.CheckpointID, mutate func(*CheckpointSummary)) {
+	t.Helper()
+	ctx := context.Background()
+	parentHash, rootTreeHash, err := store.getSessionsBranchRef()
+	if err != nil {
+		t.Fatalf("getSessionsBranchRef(): %v", err)
+	}
+
+	basePath := cpID.Path() + "/"
+	entries, err := store.flattenCheckpointEntries(rootTreeHash, cpID.Path())
+	if err != nil {
+		t.Fatalf("flattenCheckpointEntries(): %v", err)
+	}
+
+	summary := readSummaryFromBranch(t, store.repo, cpID)
+	mutate(&summary)
+
+	metadataJSON, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal summary: %v", err)
+	}
+	metadataHash, err := CreateBlobFromContent(store.repo, metadataJSON)
+	if err != nil {
+		t.Fatalf("CreateBlobFromContent(): %v", err)
+	}
+
+	rootMetadataPath := basePath + paths.MetadataFileName
+	entries[rootMetadataPath] = object.TreeEntry{
+		Name: rootMetadataPath,
+		Mode: filemode.Regular,
+		Hash: metadataHash,
+	}
+
+	newTreeHash, err := store.spliceCheckpointSubtree(ctx, rootTreeHash, cpID, basePath, entries)
+	if err != nil {
+		t.Fatalf("spliceCheckpointSubtree(): %v", err)
+	}
+	commitHash, err := CreateCommit(ctx, store.repo, newTreeHash, parentHash, "rewrite checkpoint summary\n", "Test", "test@test.com")
+	if err != nil {
+		t.Fatalf("CreateCommit(): %v", err)
+	}
+	if err := store.setPrimaryRef(commitHash); err != nil {
+		t.Fatalf("setPrimaryRef(): %v", err)
+	}
 }
 
 func TestUpdateCommitted_ReplacesTranscript(t *testing.T) {
@@ -350,6 +397,74 @@ func TestUpdateCommitted_SummaryPreserved(t *testing.T) {
 	}
 	if len(summaryAfter.Sessions) != len(summaryBefore.Sessions) {
 		t.Errorf("sessions count changed: %d -> %d", len(summaryBefore.Sessions), len(summaryAfter.Sessions))
+	}
+}
+
+func TestReadCommittedDefaultsLegacyCheckpointVersion(t *testing.T) {
+	t.Parallel()
+	_, store, cpID := setupRepoForUpdate(t)
+
+	rewriteRootSummary(t, store, cpID, func(summary *CheckpointSummary) {
+		summary.CheckpointVersion = ""
+	})
+
+	rawSummary := readSummaryFromBranch(t, store.repo, cpID)
+	if rawSummary.CheckpointVersion != "" {
+		t.Fatalf("raw legacy CheckpointVersion = %q, want empty", rawSummary.CheckpointVersion)
+	}
+
+	summary, err := store.ReadCommitted(context.Background(), cpID)
+	if err != nil {
+		t.Fatalf("ReadCommitted() error = %v", err)
+	}
+	if summary == nil {
+		t.Fatal("ReadCommitted() returned nil summary")
+	}
+	if summary.CheckpointVersion != CheckpointVersionBranchV1 {
+		t.Fatalf("CheckpointVersion = %q, want %q", summary.CheckpointVersion, CheckpointVersionBranchV1)
+	}
+}
+
+func TestUpdateCheckpointSummaryBackfillsLegacyCheckpointVersion(t *testing.T) {
+	t.Parallel()
+	_, store, cpID := setupRepoForUpdate(t)
+
+	rewriteRootSummary(t, store, cpID, func(summary *CheckpointSummary) {
+		summary.CheckpointVersion = ""
+	})
+
+	if err := store.UpdateCheckpointSummary(context.Background(), cpID, &InitialAttribution{AgentLines: 7}); err != nil {
+		t.Fatalf("UpdateCheckpointSummary() error = %v", err)
+	}
+
+	rawSummary := readSummaryFromBranch(t, store.repo, cpID)
+	if rawSummary.CheckpointVersion != CheckpointVersionBranchV1 {
+		t.Fatalf("raw checkpoint_version = %q, want %q", rawSummary.CheckpointVersion, CheckpointVersionBranchV1)
+	}
+	if rawSummary.CombinedAttribution == nil || rawSummary.CombinedAttribution.AgentLines != 7 {
+		t.Fatalf("CombinedAttribution = %+v, want AgentLines 7", rawSummary.CombinedAttribution)
+	}
+}
+
+func TestUpdateCheckpointSummaryPreservesExplicitCheckpointVersion(t *testing.T) {
+	t.Parallel()
+	_, store, cpID := setupRepoForUpdate(t)
+	const futureVersion = "refs-v1"
+
+	rewriteRootSummary(t, store, cpID, func(summary *CheckpointSummary) {
+		summary.CheckpointVersion = futureVersion
+	})
+
+	if err := store.UpdateCheckpointSummary(context.Background(), cpID, &InitialAttribution{AgentLines: 11}); err != nil {
+		t.Fatalf("UpdateCheckpointSummary() error = %v", err)
+	}
+
+	rawSummary := readSummaryFromBranch(t, store.repo, cpID)
+	if rawSummary.CheckpointVersion != futureVersion {
+		t.Fatalf("raw checkpoint_version = %q, want %q", rawSummary.CheckpointVersion, futureVersion)
+	}
+	if rawSummary.CombinedAttribution == nil || rawSummary.CombinedAttribution.AgentLines != 11 {
+		t.Fatalf("CombinedAttribution = %+v, want AgentLines 11", rawSummary.CombinedAttribution)
 	}
 }
 

--- a/cmd/entire/cli/checkpoint/committed_write_test.go
+++ b/cmd/entire/cli/checkpoint/committed_write_test.go
@@ -87,6 +87,42 @@ func TestWrite_DispatchesEachRequest(t *testing.T) {
 	}
 }
 
+func TestWriteCommittedWritesBranchCheckpointVersion(t *testing.T) {
+	t.Parallel()
+	repo, _ := setupBranchTestRepo(t)
+	store := NewGitStore(repo, DefaultV1Refs())
+	ctx := context.Background()
+	cpID := id.MustCheckpointID("b1b2c3d4e5f6")
+
+	if err := store.WriteCommitted(ctx, WriteCommittedOptions{
+		CheckpointID: cpID,
+		SessionID:    "session-001",
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte("transcript\n")),
+		Prompts:      []string{"initial"},
+		AuthorName:   "Test",
+		AuthorEmail:  "test@test.com",
+	}); err != nil {
+		t.Fatalf("WriteCommitted() error = %v", err)
+	}
+
+	summary, err := store.ReadCommitted(ctx, cpID)
+	if err != nil {
+		t.Fatalf("ReadCommitted() error = %v", err)
+	}
+	if summary == nil {
+		t.Fatal("ReadCommitted() returned nil summary")
+	}
+	if summary.CheckpointVersion != CheckpointVersionBranchV1 {
+		t.Fatalf("CheckpointVersion = %q, want %q", summary.CheckpointVersion, CheckpointVersionBranchV1)
+	}
+
+	rawSummary := readSummaryFromBranch(t, repo, cpID)
+	if rawSummary.CheckpointVersion != CheckpointVersionBranchV1 {
+		t.Fatalf("raw checkpoint_version = %q, want %q", rawSummary.CheckpointVersion, CheckpointVersionBranchV1)
+	}
+}
+
 // TestWrite_UnknownRequestErrors verifies the dispatcher surfaces an
 // unhandled request type rather than silently ignoring it.
 func TestWrite_UnknownRequestErrors(t *testing.T) {

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -212,6 +212,8 @@ Metadata only, sharded by checkpoint ID. Supports **multiple sessions per checkp
 **Root-level metadata.json (`CheckpointSummary`):**
 ```json
 {
+  "cli_version": "0.0.0-dev",
+  "checkpoint_version": "branch-v1",
   "checkpoint_id": "abc123def456",
   "strategy": "manual-commit",
   "branch": "main",


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/636
<!-- entire-trail-link-end -->

**Why**

Refs #1471.

Checkpoint metadata needs to state which storage format created the root
checkpoint summary. Branch-backed checkpoints are the first format, and
existing metadata without a version should continue to read without migration.

**What changed**

Root checkpoint summaries now carry `checkpoint_version: "branch-v1"`.
Readers default omitted versions to `branch-v1`, and updates preserve any
explicit version already on the summary.

**Implementation decisions**

The field lives at the checkpoint root because all sessions in a checkpoint
share one storage format. Session metadata stays unchanged, and this remains
metadata-only; it does not introduce the later custom-ref configuration path.

**Tradeoffs and alternatives considered**

A generic `v1` would be shorter, but it would make the later custom-ref format
reuse awkward. `branch-v1` names both the current storage family and its first
version while leaving room for a future `refs-v1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only JSON field on checkpoint root summaries; no auth, migration, or session blob layout changes.
> 
> **Overview**
> Root **CheckpointSummary** metadata now records which storage format produced the checkpoint via **`checkpoint_version`**, set to **`branch-v1`** for branch-backed checkpoints on `entire/checkpoints/v1`.
> 
> **Readers** treat a missing field as **`branch-v1`** through **`normalizeCheckpointSummary`**, so older summaries need no migration. **Writers** stamp new summaries with **`branch-v1`** and **reuse any explicit version** already on the root summary when rewriting (e.g. **`WriteCommitted`**, **`UpdateCheckpointSummary`**). Session-level metadata is unchanged.
> 
> Tests cover legacy backfill on read/update, persistence of a future version like **`refs-v1`**, and docs show the new JSON field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b15155fa81f244dbbd6253d35d2757737bbb43. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->