### PR TITLE
Add repo checkpoint policy

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -122,6 +122,7 @@ linters:
         - github.com/entireio/cli/cmd/entire/cli/review/types.AgentReviewer
         - github.com/entireio/cli/cmd/entire/cli/review.SynthesisProvider
         - github.com/entireio/cli/cmd/entire/cli/checkpoint.CommittedReader
+        - github.com/entireio/cli/cmd/entire/cli/checkpoint.TemporaryStore
         - github.com/entireio/cli/cmd/entire/cli/strategy.Strategy
         - github.com/entireio/cli/internal/entireclient/tokenstore.store
         - github.com/go-git/go-git/v6/x/plugin.Signer

--- a/cmd/entire/cli/attach.go
+++ b/cmd/entire/cli/attach.go
@@ -228,6 +228,10 @@ func runAttach(ctx context.Context, w io.Writer, sessionID string, agentName typ
 		return nil
 	}
 
+	if err := ensureCommittedCheckpointWritePolicy(ctx, repo); err != nil {
+		return err
+	}
+
 	// Resolve agent and transcript path.
 	ag, transcriptPath, err := resolveAgentAndTranscript(logCtx, w, sessionID, agentName, existingState)
 	if err != nil {

--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	cliReview "github.com/entireio/cli/cmd/entire/cli/review"
 	"github.com/entireio/cli/cmd/entire/cli/session"
@@ -65,6 +66,39 @@ func TestAttach_TranscriptNotFound(t *testing.T) {
 	err := runAttach(context.Background(), &out, "nonexistent-session-id", agent.AgentNameClaudeCode, attachOptions{Force: true})
 	if err == nil {
 		t.Fatal("expected error for missing transcript")
+	}
+}
+
+func TestAttachRejectsUnsupportedCheckpointWritePolicy(t *testing.T) {
+	setupAttachTestRepo(t)
+
+	repoRoot := mustGetwd(t)
+	repo, err := git.PlainOpen(repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := checkpointpolicy.WriteLocal(context.Background(), repo, plumbing.ZeroHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "branch-v1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "test-attach-policy-unsupported"
+	setupClaudeTranscript(t, sessionID, `{"type":"user","message":{"role":"user","content":"create a file"},"uuid":"uuid-1"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Done"}]},"uuid":"uuid-2"}
+`)
+
+	var out bytes.Buffer
+	err = runAttach(context.Background(), &out, sessionID, agent.AgentNameClaudeCode, attachOptions{Force: true})
+	if err == nil {
+		t.Fatal("expected unsupported checkpoint policy error")
+	}
+	if !strings.Contains(err.Error(), `checkpoint_version "refs-v1"`) {
+		t.Fatalf("error = %v, want checkpoint policy version", err)
+	}
+	if _, refErr := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true); refErr == nil {
+		t.Fatal("metadata branch exists after rejected attach")
 	}
 }
 

--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -55,7 +55,7 @@ func resolveOpenRefs(ctx context.Context, opts OpenOptions) CommittedRefs {
 }
 
 // Temporary returns the git-backed temporary shadow-branch store.
-func (s *Stores) Temporary() TemporaryStore { return s.temporary } //nolint:ireturn // temporary store capability is the abstraction boundary
+func (s *Stores) Temporary() TemporaryStore { return s.temporary }
 
 // Refs returns the resolved committed-ref topology.
 func (s *Stores) Refs() CommittedRefs { return s.refs }

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -219,38 +219,6 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 	return pushURL, true, nil
 }
 
-// ConfiguredURL returns the configured checkpoint_remote URL without the
-// push-owner fallback used by PushURL. The boolean reports whether a
-// checkpoint_remote is configured.
-func ConfiguredURL(ctx context.Context, remoteName, dir string) (string, bool, error) {
-	s, err := settings.Load(ctx)
-	if err != nil {
-		return "", false, fmt.Errorf("load settings: %w", err)
-	}
-	config := s.GetCheckpointRemote()
-	if config == nil {
-		return "", false, nil
-	}
-
-	remoteURL, remoteErr := GetRemoteURLInDir(ctx, dir, remoteName)
-	if remoteErr == nil {
-		info, parseErr := ParseURL(remoteURL)
-		if parseErr == nil {
-			if checkpointURL, deriveErr := deriveCheckpointURLFromInfo(checkpointTokenTransport(info), config); deriveErr == nil {
-				return checkpointURL, true, nil
-			}
-		}
-	}
-
-	if providerURL, ok := resolveProviderCheckpointURL(config, remoteName, dir); ok {
-		return providerURL, true, nil
-	}
-	if remoteErr != nil {
-		return "", true, fmt.Errorf("get %s remote URL: %w", remoteName, remoteErr)
-	}
-	return "", true, fmt.Errorf("resolve checkpoint remote URL from %s", remoteName)
-}
-
 // Configured reports whether a structured checkpoint_remote is configured.
 func Configured(ctx context.Context) bool {
 	s, err := settings.Load(ctx)

--- a/cmd/entire/cli/checkpoint/remote/util.go
+++ b/cmd/entire/cli/checkpoint/remote/util.go
@@ -186,27 +186,7 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 		}
 		return "", true, fmt.Errorf("no push URL found: %w", err)
 	}
-	if strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) != "" && isDerivableProtocol(pushInfo.Protocol) {
-		// Coerce a derivable (ssh/https) remote to HTTPS so the token applies,
-		// keeping the host so enterprise installations stay on their own host.
-		// A non-derivable protocol (e.g. entire://) carries a host that isn't a
-		// usable HTTPS host, so it's left untouched and falls through to the
-		// providerCheckpointURL fallback below.
-		//
-		// Keep the port only when the source was already HTTPS. SSH ports
-		// (e.g., :2222) don't map to HTTPS ports on the same host.
-		port := ""
-		if pushInfo.Protocol == ProtocolHTTPS {
-			port = pushInfo.Port
-		}
-		pushInfo = &Info{
-			Protocol: ProtocolHTTPS,
-			Host:     pushInfo.Host,
-			Port:     port,
-			Owner:    pushInfo.Owner,
-			Repo:     pushInfo.Repo,
-		}
-	}
+	pushInfo = checkpointTokenTransport(pushInfo)
 
 	checkpointOwner := config.Owner()
 	if pushInfo.Owner != "" && checkpointOwner != "" && !strings.EqualFold(pushInfo.Owner, checkpointOwner) {
@@ -237,6 +217,38 @@ func PushURL(ctx context.Context, pushRemoteName string) (string, bool, error) {
 	}
 
 	return pushURL, true, nil
+}
+
+// ConfiguredURL returns the configured checkpoint_remote URL without the
+// push-owner fallback used by PushURL. The boolean reports whether a
+// checkpoint_remote is configured.
+func ConfiguredURL(ctx context.Context, remoteName, dir string) (string, bool, error) {
+	s, err := settings.Load(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("load settings: %w", err)
+	}
+	config := s.GetCheckpointRemote()
+	if config == nil {
+		return "", false, nil
+	}
+
+	remoteURL, remoteErr := GetRemoteURLInDir(ctx, dir, remoteName)
+	if remoteErr == nil {
+		info, parseErr := ParseURL(remoteURL)
+		if parseErr == nil {
+			if checkpointURL, deriveErr := deriveCheckpointURLFromInfo(checkpointTokenTransport(info), config); deriveErr == nil {
+				return checkpointURL, true, nil
+			}
+		}
+	}
+
+	if providerURL, ok := resolveProviderCheckpointURL(config, remoteName, dir); ok {
+		return providerURL, true, nil
+	}
+	if remoteErr != nil {
+		return "", true, fmt.Errorf("get %s remote URL: %w", remoteName, remoteErr)
+	}
+	return "", true, fmt.Errorf("resolve checkpoint remote URL from %s", remoteName)
 }
 
 // Configured reports whether a structured checkpoint_remote is configured.
@@ -291,6 +303,24 @@ func DeriveCheckpointURL(pushRemoteURL string, config *settings.CheckpointRemote
 // helper scheme like entire:// or a local file://).
 func isDerivableProtocol(protocol string) bool {
 	return protocol == ProtocolSSH || protocol == ProtocolHTTPS
+}
+
+func checkpointTokenTransport(info *Info) *Info {
+	if strings.TrimSpace(os.Getenv(CheckpointTokenEnvVar)) == "" || !isDerivableProtocol(info.Protocol) {
+		return info
+	}
+
+	port := ""
+	if info.Protocol == ProtocolHTTPS {
+		port = info.Port
+	}
+	return &Info{
+		Protocol: ProtocolHTTPS,
+		Host:     info.Host,
+		Port:     port,
+		Owner:    info.Owner,
+		Repo:     info.Repo,
+	}
 }
 
 func deriveCheckpointURLFromInfo(info *Info, config *settings.CheckpointRemoteConfig) (string, error) {

--- a/cmd/entire/cli/checkpoint_policy_read_test.go
+++ b/cmd/entire/cli/checkpoint_policy_read_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadCheckpointInfoFromStoreRejectsUnsupportedCheckpointVersion(t *testing.T) {
+	t.Parallel()
+
+	cpID := id.MustCheckpointID("111111111111")
+	_, err := readCheckpointInfoFromStore(context.Background(), checkpointInfoPolicyStub{
+		summary: &checkpoint.CheckpointSummary{
+			CheckpointID:      cpID,
+			CheckpointVersion: "refs-v1",
+		},
+	}, cpID)
+
+	require.ErrorContains(t, err, `checkpoint 111111111111 uses unsupported checkpoint_version "refs-v1"`)
+}
+
+type checkpointInfoPolicyStub struct {
+	summary *checkpoint.CheckpointSummary
+}
+
+func (s checkpointInfoPolicyStub) ReadCommitted(context.Context, id.CheckpointID) (*checkpoint.CheckpointSummary, error) {
+	return s.summary, nil
+}
+
+func (s checkpointInfoPolicyStub) ReadSessionContent(context.Context, id.CheckpointID, int) (*checkpoint.SessionContent, error) {
+	return nil, checkpoint.ErrCheckpointNotFound
+}
+
+func (s checkpointInfoPolicyStub) ReadSessionMetadata(context.Context, id.CheckpointID, int) (*checkpoint.CommittedMetadata, error) {
+	return nil, checkpoint.ErrCheckpointNotFound
+}

--- a/cmd/entire/cli/checkpoint_policy_warning.go
+++ b/cmd/entire/cli/checkpoint_policy_warning.go
@@ -16,11 +16,20 @@ func ShouldCheckCheckpointPolicyWarning(cmd *cobra.Command) bool {
 		return false
 	}
 	for c := cmd; c != nil; c = c.Parent() {
-		if c.Hidden || c.Name() == "hooks" {
+		if isCheckpointPolicyWarningExcludedCommand(c.Name()) {
 			return false
 		}
 	}
 	return true
+}
+
+func isCheckpointPolicyWarningExcludedCommand(name string) bool {
+	switch name {
+	case "hooks", "__send_analytics", "curl-bash-post-install":
+		return true
+	default:
+		return false
+	}
 }
 
 func WarnCheckpointPolicyIfNeeded(ctx context.Context, w io.Writer, currentVersion string) {

--- a/cmd/entire/cli/checkpoint_policy_warning.go
+++ b/cmd/entire/cli/checkpoint_policy_warning.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
+	"github.com/spf13/cobra"
+)
+
+func ShouldCheckCheckpointPolicyWarning(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Hidden || c.Name() == "hooks" {
+			return false
+		}
+	}
+	return true
+}
+
+func WarnCheckpointPolicyIfNeeded(ctx context.Context, w io.Writer, currentVersion string) {
+	repo, err := gitrepo.OpenCurrent(ctx)
+	if err != nil {
+		return
+	}
+	defer repo.Close()
+
+	state, err := checkpointpolicy.ReadLocal(ctx, repo)
+	if err != nil {
+		return
+	}
+	if !checkpointpolicy.RequiresUpgrade(state.Policy) && !checkpointpolicy.UnsupportedWrite(state.Policy) {
+		return
+	}
+
+	fmt.Fprint(w, checkpointpolicy.UpgradeWarning(versioncheck.UpdateCommandForCurrentBinary(currentVersion)))
+}

--- a/cmd/entire/cli/checkpoint_policy_warning_test.go
+++ b/cmd/entire/cli/checkpoint_policy_warning_test.go
@@ -41,6 +41,14 @@ func TestShouldCheckCheckpointPolicyWarning(t *testing.T) {
 	hooks.AddCommand(gitHook)
 	root.AddCommand(hooks)
 
+	hiddenAlias := &cobra.Command{Use: "explain", Hidden: true}
+	root.AddCommand(hiddenAlias)
+
+	sendAnalytics := &cobra.Command{Use: "__send_analytics", Hidden: true}
+	root.AddCommand(sendAnalytics)
+
 	require.True(t, ShouldCheckCheckpointPolicyWarning(visible))
+	require.True(t, ShouldCheckCheckpointPolicyWarning(hiddenAlias))
 	require.False(t, ShouldCheckCheckpointPolicyWarning(gitHook))
+	require.False(t, ShouldCheckCheckpointPolicyWarning(sendAnalytics))
 }

--- a/cmd/entire/cli/checkpoint_policy_warning_test.go
+++ b/cmd/entire/cli/checkpoint_policy_warning_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWarnCheckpointPolicyIfNeeded(t *testing.T) {
+	_, _ = setupPolicyCheckpointRepo(t)
+	repo, err := git.PlainOpen(".")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	_, err = checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "refs-v1",
+	})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	WarnCheckpointPolicyIfNeeded(context.Background(), &buf, "1.0.0")
+
+	require.Contains(t, buf.String(), "requires checkpoint support newer than this Entire CLI")
+}
+
+func TestShouldCheckCheckpointPolicyWarning(t *testing.T) {
+	root := &cobra.Command{Use: "entire"}
+	visible := &cobra.Command{Use: "status"}
+	root.AddCommand(visible)
+
+	hooks := &cobra.Command{Use: "hooks", Hidden: true}
+	gitHook := &cobra.Command{Use: "git"}
+	hooks.AddCommand(gitHook)
+	root.AddCommand(hooks)
+
+	require.True(t, ShouldCheckCheckpointPolicyWarning(visible))
+	require.False(t, ShouldCheckCheckpointPolicyWarning(gitHook))
+}

--- a/cmd/entire/cli/checkpoint_policy_write.go
+++ b/cmd/entire/cli/checkpoint_policy_write.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+	"github.com/go-git/go-git/v6"
+)
+
+func ensureCommittedCheckpointWritePolicy(ctx context.Context, repo *git.Repository) error {
+	state, err := checkpointpolicy.ReadLocal(ctx, repo)
+	if err != nil {
+		return fmt.Errorf("read checkpoint policy: %w", err)
+	}
+	if !checkpointpolicy.UnsupportedWrite(state.Policy) {
+		return nil
+	}
+	return fmt.Errorf(
+		"checkpoint policy requires checkpoint_version %q, which this Entire CLI cannot write; upgrade Entire and rerun the command: %s",
+		state.Policy.CheckpointVersion,
+		versioncheck.UpdateCommandForCurrentBinary(versioninfo.Version),
+	)
+}

--- a/cmd/entire/cli/checkpointpolicy/format.go
+++ b/cmd/entire/cli/checkpointpolicy/format.go
@@ -53,11 +53,6 @@ func Compare(a, b CheckpointFormat) int {
 	return compareInt(a.Major, b.Major)
 }
 
-func KnowsFormat(format CheckpointFormat) bool {
-	_, ok := knownFormats[format]
-	return ok
-}
-
 func CanRead(format CheckpointFormat) bool {
 	return readFormats[format]
 }
@@ -82,15 +77,9 @@ var familyRanks = map[CheckpointFamily]int{
 	CheckpointFamilyRefs:   1,
 }
 
+var branchV1Format = CheckpointFormat{Family: CheckpointFamilyBranch, Major: 1}
+
 var (
-	branchV1Format = CheckpointFormat{Family: CheckpointFamilyBranch, Major: 1}
-	refsV1Format   = CheckpointFormat{Family: CheckpointFamilyRefs, Major: 1}
-
-	knownFormats = map[CheckpointFormat]struct{}{
-		branchV1Format: {},
-		refsV1Format:   {},
-	}
-
 	readFormats = map[CheckpointFormat]bool{
 		branchV1Format: true,
 	}

--- a/cmd/entire/cli/checkpointpolicy/format.go
+++ b/cmd/entire/cli/checkpointpolicy/format.go
@@ -1,6 +1,7 @@
 package checkpointpolicy
 
 import (
+	"cmp"
 	"fmt"
 	"strconv"
 	"strings"
@@ -48,9 +49,9 @@ func Compare(a, b CheckpointFormat) int {
 	aRank := familyRanks[a.Family]
 	bRank := familyRanks[b.Family]
 	if aRank != bRank {
-		return compareInt(aRank, bRank)
+		return cmp.Compare(aRank, bRank)
 	}
-	return compareInt(a.Major, b.Major)
+	return cmp.Compare(a.Major, b.Major)
 }
 
 func CanRead(format CheckpointFormat) bool {
@@ -59,17 +60,6 @@ func CanRead(format CheckpointFormat) bool {
 
 func CanWrite(format CheckpointFormat) bool {
 	return writeFormats[format]
-}
-
-func compareInt(a, b int) int {
-	switch {
-	case a < b:
-		return -1
-	case a > b:
-		return 1
-	default:
-		return 0
-	}
 }
 
 var familyRanks = map[CheckpointFamily]int{

--- a/cmd/entire/cli/checkpointpolicy/format.go
+++ b/cmd/entire/cli/checkpointpolicy/format.go
@@ -1,0 +1,101 @@
+package checkpointpolicy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type CheckpointFamily string
+
+const (
+	CheckpointFamilyBranch CheckpointFamily = "branch"
+	CheckpointFamilyRefs   CheckpointFamily = "refs"
+)
+
+type CheckpointFormat struct {
+	Family CheckpointFamily
+	Major  int
+}
+
+func ParseFormat(raw string) (CheckpointFormat, error) {
+	familyRaw, majorRaw, ok := strings.Cut(raw, "-v")
+	if !ok || familyRaw == "" || majorRaw == "" {
+		return CheckpointFormat{}, fmt.Errorf("invalid checkpoint format %q", raw)
+	}
+
+	family := CheckpointFamily(familyRaw)
+	if _, ok := familyRanks[family]; !ok {
+		return CheckpointFormat{}, fmt.Errorf("unknown checkpoint family %q", familyRaw)
+	}
+
+	major, err := strconv.Atoi(majorRaw)
+	if err != nil || major <= 0 {
+		return CheckpointFormat{}, fmt.Errorf("invalid checkpoint major %q", majorRaw)
+	}
+
+	return CheckpointFormat{Family: family, Major: major}, nil
+}
+
+func (f CheckpointFormat) String() string {
+	if f.Family == "" || f.Major == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s-v%d", f.Family, f.Major)
+}
+
+func Compare(a, b CheckpointFormat) int {
+	aRank := familyRanks[a.Family]
+	bRank := familyRanks[b.Family]
+	if aRank != bRank {
+		return compareInt(aRank, bRank)
+	}
+	return compareInt(a.Major, b.Major)
+}
+
+func KnowsFormat(format CheckpointFormat) bool {
+	_, ok := knownFormats[format]
+	return ok
+}
+
+func CanRead(format CheckpointFormat) bool {
+	return readFormats[format]
+}
+
+func CanWrite(format CheckpointFormat) bool {
+	return writeFormats[format]
+}
+
+func compareInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+var familyRanks = map[CheckpointFamily]int{
+	CheckpointFamilyBranch: 0,
+	CheckpointFamilyRefs:   1,
+}
+
+var (
+	branchV1Format = CheckpointFormat{Family: CheckpointFamilyBranch, Major: 1}
+	refsV1Format   = CheckpointFormat{Family: CheckpointFamilyRefs, Major: 1}
+
+	knownFormats = map[CheckpointFormat]struct{}{
+		branchV1Format: {},
+		refsV1Format:   {},
+	}
+
+	readFormats = map[CheckpointFormat]bool{
+		branchV1Format: true,
+	}
+
+	writeFormats = map[CheckpointFormat]bool{
+		branchV1Format: true,
+	}
+)

--- a/cmd/entire/cli/checkpointpolicy/format_test.go
+++ b/cmd/entire/cli/checkpointpolicy/format_test.go
@@ -24,7 +24,6 @@ func TestParseFormat(t *testing.T) {
 		{name: "non numeric major", input: "branch-vx", wantErr: "invalid checkpoint major"},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := checkpointpolicy.ParseFormat(tt.input)
@@ -54,5 +53,5 @@ func TestSupportedFormats(t *testing.T) {
 	require.True(t, checkpointpolicy.KnowsFormat(refsV1))
 	require.False(t, checkpointpolicy.CanRead(refsV1))
 	require.False(t, checkpointpolicy.CanWrite(refsV1))
-	require.Less(t, checkpointpolicy.Compare(branchV1, refsV1), 0)
+	require.Negative(t, checkpointpolicy.Compare(branchV1, refsV1))
 }

--- a/cmd/entire/cli/checkpointpolicy/format_test.go
+++ b/cmd/entire/cli/checkpointpolicy/format_test.go
@@ -45,12 +45,10 @@ func TestSupportedFormats(t *testing.T) {
 	refsV1, err := checkpointpolicy.ParseFormat("refs-v1")
 	require.NoError(t, err)
 
-	require.True(t, checkpointpolicy.KnowsFormat(branchV1))
 	require.True(t, checkpointpolicy.CanRead(branchV1))
 	require.True(t, checkpointpolicy.CanWrite(branchV1))
 	require.Equal(t, checkpoint.CheckpointVersionBranchV1, branchV1.String())
 
-	require.True(t, checkpointpolicy.KnowsFormat(refsV1))
 	require.False(t, checkpointpolicy.CanRead(refsV1))
 	require.False(t, checkpointpolicy.CanWrite(refsV1))
 	require.Negative(t, checkpointpolicy.Compare(branchV1, refsV1))

--- a/cmd/entire/cli/checkpointpolicy/format_test.go
+++ b/cmd/entire/cli/checkpointpolicy/format_test.go
@@ -1,0 +1,58 @@
+package checkpointpolicy_test
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFormat(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    checkpointpolicy.CheckpointFormat
+		wantErr string
+	}{
+		{name: "branch v1", input: "branch-v1", want: checkpointpolicy.CheckpointFormat{Family: checkpointpolicy.CheckpointFamilyBranch, Major: 1}},
+		{name: "refs v2", input: "refs-v2", want: checkpointpolicy.CheckpointFormat{Family: checkpointpolicy.CheckpointFamilyRefs, Major: 2}},
+		{name: "unknown family", input: "unknown-v1", wantErr: "unknown checkpoint family"},
+		{name: "missing v", input: "branch-1", wantErr: "invalid checkpoint format"},
+		{name: "zero major", input: "branch-v0", wantErr: "invalid checkpoint major"},
+		{name: "non numeric major", input: "branch-vx", wantErr: "invalid checkpoint major"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := checkpointpolicy.ParseFormat(tt.input)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.input, got.String())
+		})
+	}
+}
+
+func TestSupportedFormats(t *testing.T) {
+	t.Parallel()
+	branchV1, err := checkpointpolicy.ParseFormat(checkpoint.CheckpointVersionBranchV1)
+	require.NoError(t, err)
+	refsV1, err := checkpointpolicy.ParseFormat("refs-v1")
+	require.NoError(t, err)
+
+	require.True(t, checkpointpolicy.KnowsFormat(branchV1))
+	require.True(t, checkpointpolicy.CanRead(branchV1))
+	require.True(t, checkpointpolicy.CanWrite(branchV1))
+	require.Equal(t, checkpoint.CheckpointVersionBranchV1, branchV1.String())
+
+	require.True(t, checkpointpolicy.KnowsFormat(refsV1))
+	require.False(t, checkpointpolicy.CanRead(refsV1))
+	require.False(t, checkpointpolicy.CanWrite(refsV1))
+	require.Less(t, checkpointpolicy.Compare(branchV1, refsV1), 0)
+}

--- a/cmd/entire/cli/checkpointpolicy/policy.go
+++ b/cmd/entire/cli/checkpointpolicy/policy.go
@@ -1,6 +1,7 @@
 package checkpointpolicy
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -75,14 +76,42 @@ func UpgradeWarning(updateCommand string) string {
 	return fmt.Sprintf("[entire] This repository requires checkpoint support newer than this Entire CLI.\n[entire] Upgrade Entire, then rerun the command:\n[entire]   %s\n", updateCommand)
 }
 
+// IsUnsupportedVersion reports whether err wraps a checkpoint version incompatibility.
+func IsUnsupportedVersion(err error) bool {
+	var unsupported *unsupportedVersionError
+	return errors.As(err, &unsupported)
+}
+
 func EnsureCanReadVersion(checkpointID, version string) error {
 	policy := Normalize(Policy{CheckpointMinVersion: version})
 	format, err := ParseFormat(policy.CheckpointMinVersion)
 	if err != nil {
-		return fmt.Errorf("checkpoint %s uses unsupported checkpoint_version %q: %w", checkpointID, policy.CheckpointMinVersion, err)
+		return &unsupportedVersionError{
+			CheckpointID: checkpointID,
+			Version:      policy.CheckpointMinVersion,
+			Err:          err,
+		}
 	}
 	if !CanRead(format) {
-		return fmt.Errorf("checkpoint %s uses unsupported checkpoint_version %q: not read-supported by this Entire CLI", checkpointID, policy.CheckpointMinVersion)
+		return &unsupportedVersionError{
+			CheckpointID: checkpointID,
+			Version:      policy.CheckpointMinVersion,
+			Err:          errors.New("not read-supported by this Entire CLI"),
+		}
 	}
 	return nil
+}
+
+type unsupportedVersionError struct {
+	CheckpointID string
+	Version      string
+	Err          error
+}
+
+func (e unsupportedVersionError) Error() string {
+	return fmt.Sprintf("checkpoint %s uses unsupported checkpoint_version %q: %v", e.CheckpointID, e.Version, e.Err)
+}
+
+func (e unsupportedVersionError) Unwrap() error {
+	return e.Err
 }

--- a/cmd/entire/cli/checkpointpolicy/policy.go
+++ b/cmd/entire/cli/checkpointpolicy/policy.go
@@ -70,3 +70,19 @@ func UnsupportedWrite(policy Policy) bool {
 	}
 	return !CanWrite(version)
 }
+
+func UpgradeWarning(updateCommand string) string {
+	return fmt.Sprintf("[entire] This repository requires checkpoint support newer than this Entire CLI.\n[entire] Upgrade Entire, then rerun the command:\n[entire]   %s\n", updateCommand)
+}
+
+func EnsureCanReadVersion(checkpointID, version string) error {
+	policy := Normalize(Policy{CheckpointMinVersion: version})
+	format, err := ParseFormat(policy.CheckpointMinVersion)
+	if err != nil {
+		return fmt.Errorf("checkpoint %s uses unsupported checkpoint_version %q: %w", checkpointID, policy.CheckpointMinVersion, err)
+	}
+	if !CanRead(format) {
+		return fmt.Errorf("checkpoint %s uses unsupported checkpoint_version %q: not read-supported by this Entire CLI", checkpointID, policy.CheckpointMinVersion)
+	}
+	return nil
+}

--- a/cmd/entire/cli/checkpointpolicy/policy.go
+++ b/cmd/entire/cli/checkpointpolicy/policy.go
@@ -86,11 +86,7 @@ func EnsureCanReadVersion(checkpointID, version string) error {
 	policy := Normalize(Policy{CheckpointMinVersion: version})
 	format, err := ParseFormat(policy.CheckpointMinVersion)
 	if err != nil {
-		return &unsupportedVersionError{
-			CheckpointID: checkpointID,
-			Version:      policy.CheckpointMinVersion,
-			Err:          err,
-		}
+		return fmt.Errorf("checkpoint %s has invalid checkpoint_version %q: %w", checkpointID, policy.CheckpointMinVersion, err)
 	}
 	if !CanRead(format) {
 		return &unsupportedVersionError{

--- a/cmd/entire/cli/checkpointpolicy/policy.go
+++ b/cmd/entire/cli/checkpointpolicy/policy.go
@@ -1,0 +1,72 @@
+package checkpointpolicy
+
+import (
+	"fmt"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+)
+
+type Policy struct {
+	CheckpointVersion    string `json:"checkpoint_version"`
+	CheckpointMinVersion string `json:"checkpoint_min_version"`
+}
+
+func DefaultPolicy() Policy {
+	return Policy{
+		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
+		CheckpointMinVersion: checkpoint.CheckpointVersionBranchV1,
+	}
+}
+
+func Normalize(policy Policy) Policy {
+	if policy.CheckpointVersion == "" {
+		policy.CheckpointVersion = checkpoint.CheckpointVersionBranchV1
+	}
+	if policy.CheckpointMinVersion == "" {
+		policy.CheckpointMinVersion = checkpoint.CheckpointVersionBranchV1
+	}
+	return policy
+}
+
+func ValidatePolicy(policy Policy) error {
+	policy = Normalize(policy)
+
+	version, err := ParseFormat(policy.CheckpointVersion)
+	if err != nil {
+		return fmt.Errorf("checkpoint_version: %w", err)
+	}
+	if !CanWrite(version) {
+		return fmt.Errorf("checkpoint_version %q is not write-supported by this Entire CLI", policy.CheckpointVersion)
+	}
+
+	minVersion, err := ParseFormat(policy.CheckpointMinVersion)
+	if err != nil {
+		return fmt.Errorf("checkpoint_min_version: %w", err)
+	}
+	if !CanRead(minVersion) {
+		return fmt.Errorf("checkpoint_min_version %q is not read-supported by this Entire CLI", policy.CheckpointMinVersion)
+	}
+	if Compare(minVersion, version) > 0 {
+		return fmt.Errorf("checkpoint_min_version %q is newer than checkpoint_version %q", policy.CheckpointMinVersion, policy.CheckpointVersion)
+	}
+
+	return nil
+}
+
+func RequiresUpgrade(policy Policy) bool {
+	policy = Normalize(policy)
+	minVersion, err := ParseFormat(policy.CheckpointMinVersion)
+	if err != nil {
+		return true
+	}
+	return !CanRead(minVersion)
+}
+
+func UnsupportedWrite(policy Policy) bool {
+	policy = Normalize(policy)
+	version, err := ParseFormat(policy.CheckpointVersion)
+	if err != nil {
+		return true
+	}
+	return !CanWrite(version)
+}

--- a/cmd/entire/cli/checkpointpolicy/policy_test.go
+++ b/cmd/entire/cli/checkpointpolicy/policy_test.go
@@ -28,7 +28,6 @@ func TestValidatePolicy(t *testing.T) {
 		{name: "unsupported minimum", policy: checkpointpolicy.Policy{CheckpointVersion: "branch-v1", CheckpointMinVersion: "refs-v1"}, wantErr: "not read-supported"},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := checkpointpolicy.ValidatePolicy(tt.policy)

--- a/cmd/entire/cli/checkpointpolicy/policy_test.go
+++ b/cmd/entire/cli/checkpointpolicy/policy_test.go
@@ -1,0 +1,42 @@
+package checkpointpolicy_test
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultPolicy(t *testing.T) {
+	t.Parallel()
+	got := checkpointpolicy.DefaultPolicy()
+	require.Equal(t, checkpoint.CheckpointVersionBranchV1, got.CheckpointVersion)
+	require.Equal(t, checkpoint.CheckpointVersionBranchV1, got.CheckpointMinVersion)
+}
+
+func TestValidatePolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		policy  checkpointpolicy.Policy
+		wantErr string
+	}{
+		{name: "default", policy: checkpointpolicy.DefaultPolicy()},
+		{name: "unknown current", policy: checkpointpolicy.Policy{CheckpointVersion: "future-v1", CheckpointMinVersion: "branch-v1"}, wantErr: "unknown checkpoint family"},
+		{name: "unsupported current", policy: checkpointpolicy.Policy{CheckpointVersion: "refs-v1", CheckpointMinVersion: "branch-v1"}, wantErr: "not write-supported"},
+		{name: "unsupported minimum", policy: checkpointpolicy.Policy{CheckpointVersion: "branch-v1", CheckpointMinVersion: "refs-v1"}, wantErr: "not read-supported"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkpointpolicy.ValidatePolicy(tt.policy)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/cmd/entire/cli/checkpointpolicy/remote.go
+++ b/cmd/entire/cli/checkpointpolicy/remote.go
@@ -38,6 +38,11 @@ func ResolveTarget(ctx context.Context, baseRemote string) (Target, error) {
 	if err != nil {
 		return Target{}, fmt.Errorf("resolve worktree root: %w", err)
 	}
+	if target, dedicated, err := remote.ConfiguredURL(ctx, baseRemote, dir); err != nil {
+		return Target{}, fmt.Errorf("resolve checkpoint remote URL: %w", err)
+	} else if dedicated {
+		return Target{Remote: target, Label: "checkpoint remote", Dir: dir}, nil
+	}
 	target, dedicated, err := remote.PushURL(ctx, baseRemote)
 	if err != nil {
 		return Target{}, fmt.Errorf("resolve checkpoint push URL: %w", err)

--- a/cmd/entire/cli/checkpointpolicy/remote.go
+++ b/cmd/entire/cli/checkpointpolicy/remote.go
@@ -13,8 +13,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
-const defaultBaseRemote = "origin"
-
 const (
 	sha1HexSize   = 40
 	sha256HexSize = 64
@@ -34,22 +32,14 @@ type RemoteState struct {
 	Hash   plumbing.Hash
 }
 
-func ResolveTarget(ctx context.Context, baseRemote string) (Target, error) {
-	if baseRemote == "" {
-		baseRemote = defaultBaseRemote
-	}
+func ResolveTarget(ctx context.Context) (Target, error) {
 	dir, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		return Target{}, fmt.Errorf("resolve worktree root: %w", err)
 	}
-	if target, dedicated, err := remote.ConfiguredURL(ctx, baseRemote, dir); err != nil {
-		return Target{}, fmt.Errorf("resolve checkpoint remote URL: %w", err)
-	} else if dedicated {
-		return Target{Remote: target, Dir: dir}, nil
-	}
-	target, _, err := remote.PushURL(ctx, baseRemote)
+	target, err := remote.FetchURL(ctx, remote.FetchURLOptions{WorktreeRoot: dir})
 	if err != nil {
-		return Target{}, fmt.Errorf("resolve checkpoint push URL: %w", err)
+		return Target{}, fmt.Errorf("resolve checkpoint remote URL: %w", err)
 	}
 	return Target{Remote: target, Dir: dir}, nil
 }

--- a/cmd/entire/cli/checkpointpolicy/remote.go
+++ b/cmd/entire/cli/checkpointpolicy/remote.go
@@ -36,11 +36,11 @@ func ResolveTarget(ctx context.Context, baseRemote string) (Target, error) {
 	}
 	dir, err := paths.WorktreeRoot(ctx)
 	if err != nil {
-		return Target{}, err
+		return Target{}, fmt.Errorf("resolve worktree root: %w", err)
 	}
 	target, dedicated, err := remote.PushURL(ctx, baseRemote)
 	if err != nil {
-		return Target{}, err
+		return Target{}, fmt.Errorf("resolve checkpoint push URL: %w", err)
 	}
 	label := baseRemote
 	if dedicated {
@@ -52,7 +52,7 @@ func ResolveTarget(ctx context.Context, baseRemote string) (Target, error) {
 func CheckRemote(ctx context.Context, target Target) (RemoteState, error) {
 	output, err := remote.LsRemoteInDir(ctx, target.Dir, target.Remote, RefName.String())
 	if err != nil {
-		return RemoteState{}, err
+		return RemoteState{}, fmt.Errorf("check remote checkpoint policy ref: %w", err)
 	}
 	fields := strings.Fields(string(output))
 	if len(fields) == 0 {
@@ -88,9 +88,7 @@ func Sync(ctx context.Context, repo *git.Repository, target Target) (State, erro
 		return State{}, err
 	}
 	fetched.RemoteHash = remoteState.Hash
-	defer func() {
-		_ = repo.Storer.RemoveReference(fetchRefName)
-	}()
+	defer removeFetchRef(repo)
 
 	if local.Hash.IsZero() || isAncestorOf(ctx, repo, local.Hash, fetched.Hash) {
 		if err := SetRef(repo, RefName, fetched.Hash); err != nil {
@@ -132,9 +130,15 @@ func fetchRemotePolicy(ctx context.Context, repo *git.Repository, target Target)
 		NoFilter: true,
 		Dir:      target.Dir,
 	}); err != nil {
-		return State{}, err
+		return State{}, fmt.Errorf("fetch checkpoint policy ref: %w", err)
 	}
 	return ReadFromRef(ctx, repo, fetchRefName, SourceRemote)
+}
+
+func removeFetchRef(repo *git.Repository) {
+	if err := repo.Storer.RemoveReference(fetchRefName); err != nil {
+		return
+	}
 }
 
 func isAncestorOf(ctx context.Context, repo *git.Repository, ancestor, target plumbing.Hash) bool {
@@ -149,9 +153,9 @@ func isAncestorOf(ctx context.Context, repo *git.Repository, ancestor, target pl
 	defer iter.Close()
 
 	found := false
-	_ = iter.ForEach(func(commit *object.Commit) error {
+	err = iter.ForEach(func(commit *object.Commit) error {
 		if err := ctx.Err(); err != nil {
-			return err
+			return fmt.Errorf("traverse checkpoint policy ancestry: %w", err)
 		}
 		if commit.Hash == ancestor {
 			found = true
@@ -159,5 +163,8 @@ func isAncestorOf(ctx context.Context, repo *git.Repository, ancestor, target pl
 		}
 		return nil
 	})
+	if err != nil && !errors.Is(err, errStopTraversal) {
+		return false
+	}
 	return found
 }

--- a/cmd/entire/cli/checkpointpolicy/remote.go
+++ b/cmd/entire/cli/checkpointpolicy/remote.go
@@ -1,0 +1,163 @@
+package checkpointpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+const defaultBaseRemote = "origin"
+
+const fetchRefName = plumbing.ReferenceName("refs/entire/policies/checkpoint-fetch")
+
+var errStopTraversal = errors.New("stop traversal")
+
+type Target struct {
+	Remote string
+	Label  string
+	Dir    string
+}
+
+type RemoteState struct {
+	Exists bool
+	Hash   plumbing.Hash
+}
+
+func ResolveTarget(ctx context.Context, baseRemote string) (Target, error) {
+	if baseRemote == "" {
+		baseRemote = defaultBaseRemote
+	}
+	dir, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return Target{}, err
+	}
+	target, dedicated, err := remote.PushURL(ctx, baseRemote)
+	if err != nil {
+		return Target{}, err
+	}
+	label := baseRemote
+	if dedicated {
+		label = "checkpoint remote"
+	}
+	return Target{Remote: target, Label: label, Dir: dir}, nil
+}
+
+func CheckRemote(ctx context.Context, target Target) (RemoteState, error) {
+	output, err := remote.LsRemoteInDir(ctx, target.Dir, target.Remote, RefName.String())
+	if err != nil {
+		return RemoteState{}, err
+	}
+	fields := strings.Fields(string(output))
+	if len(fields) == 0 {
+		return RemoteState{}, nil
+	}
+	if len(fields[0]) != 40 {
+		return RemoteState{}, fmt.Errorf("invalid remote checkpoint policy hash %q", fields[0])
+	}
+	return RemoteState{Exists: true, Hash: plumbing.NewHash(fields[0])}, nil
+}
+
+func Sync(ctx context.Context, repo *git.Repository, target Target) (State, error) {
+	local, err := ReadLocal(ctx, repo)
+	if err != nil {
+		return State{}, err
+	}
+
+	remoteState, err := CheckRemote(ctx, target)
+	if err != nil {
+		return State{}, err
+	}
+	if !remoteState.Exists {
+		return local, nil
+	}
+	if local.Hash == remoteState.Hash {
+		local.Source = SourceRemote
+		local.RemoteHash = remoteState.Hash
+		return local, nil
+	}
+
+	fetched, err := fetchRemotePolicy(ctx, repo, target)
+	if err != nil {
+		return State{}, err
+	}
+	fetched.RemoteHash = remoteState.Hash
+	defer func() {
+		_ = repo.Storer.RemoveReference(fetchRefName)
+	}()
+
+	if local.Hash.IsZero() || isAncestorOf(ctx, repo, local.Hash, fetched.Hash) {
+		if err := SetRef(repo, RefName, fetched.Hash); err != nil {
+			return State{}, err
+		}
+		fetched.Source = SourceRemote
+		return fetched, nil
+	}
+
+	local.Source = SourceLocalDiverged
+	local.RemoteHash = remoteState.Hash
+	local.Warning = fmt.Sprintf("local checkpoint policy %s diverges from remote %s", local.Hash, remoteState.Hash)
+	return local, nil
+}
+
+func Push(ctx context.Context, target Target) error {
+	refspec := RefName.String() + ":" + RefName.String()
+	result, err := remote.PushWithOptions(ctx, remote.PushOptions{
+		Remote:   target.Remote,
+		RefSpecs: []string{refspec},
+		Dir:      target.Dir,
+	})
+	if err != nil {
+		output := strings.TrimSpace(result.Output)
+		if output == "" {
+			return fmt.Errorf("push checkpoint policy: %w", err)
+		}
+		return fmt.Errorf("push checkpoint policy: %s: %w", output, err)
+	}
+	return nil
+}
+
+func fetchRemotePolicy(ctx context.Context, repo *git.Repository, target Target) (State, error) {
+	refspec := fmt.Sprintf("+%s:%s", RefName, fetchRefName)
+	if _, err := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   target.Remote,
+		RefSpecs: []string{refspec},
+		NoTags:   true,
+		NoFilter: true,
+		Dir:      target.Dir,
+	}); err != nil {
+		return State{}, err
+	}
+	return ReadFromRef(ctx, repo, fetchRefName, SourceRemote)
+}
+
+func isAncestorOf(ctx context.Context, repo *git.Repository, ancestor, target plumbing.Hash) bool {
+	if ancestor == target {
+		return true
+	}
+
+	iter, err := repo.Log(&git.LogOptions{From: target})
+	if err != nil {
+		return false
+	}
+	defer iter.Close()
+
+	found := false
+	_ = iter.ForEach(func(commit *object.Commit) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if commit.Hash == ancestor {
+			found = true
+			return errStopTraversal
+		}
+		return nil
+	})
+	return found
+}

--- a/cmd/entire/cli/checkpointpolicy/remote.go
+++ b/cmd/entire/cli/checkpointpolicy/remote.go
@@ -15,6 +15,11 @@ import (
 
 const defaultBaseRemote = "origin"
 
+const (
+	sha1HexSize   = 40
+	sha256HexSize = 64
+)
+
 const fetchRefName = plumbing.ReferenceName("refs/entire/policies/checkpoint-fetch")
 
 var errStopTraversal = errors.New("stop traversal")
@@ -58,10 +63,11 @@ func CheckRemote(ctx context.Context, target Target) (RemoteState, error) {
 	if len(fields) == 0 {
 		return RemoteState{}, nil
 	}
-	if len(fields[0]) != 40 {
-		return RemoteState{}, fmt.Errorf("invalid remote checkpoint policy hash %q", fields[0])
+	hash, err := parseRemotePolicyHash(fields[0])
+	if err != nil {
+		return RemoteState{}, err
 	}
-	return RemoteState{Exists: true, Hash: plumbing.NewHash(fields[0])}, nil
+	return RemoteState{Exists: true, Hash: hash}, nil
 }
 
 func Sync(ctx context.Context, repo *git.Repository, target Target) (State, error) {
@@ -112,6 +118,21 @@ func remoteBaseline(ctx context.Context, repo *git.Repository, target Target, lo
 	fetched.RemoteHash = remoteState.Hash
 	defer removeFetchRef(repo)
 	return fetched, true, nil
+}
+
+func parseRemotePolicyHash(raw string) (plumbing.Hash, error) {
+	if !isSupportedRemotePolicyHashLength(raw) {
+		return plumbing.ZeroHash, fmt.Errorf("invalid remote checkpoint policy hash %q", raw)
+	}
+	hash, ok := plumbing.FromHex(raw)
+	if !ok {
+		return plumbing.ZeroHash, fmt.Errorf("invalid remote checkpoint policy hash %q", raw)
+	}
+	return hash, nil
+}
+
+func isSupportedRemotePolicyHashLength(raw string) bool {
+	return len(raw) == sha1HexSize || len(raw) == sha256HexSize
 }
 
 func Push(ctx context.Context, target Target) error {

--- a/cmd/entire/cli/checkpointpolicy/remote.go
+++ b/cmd/entire/cli/checkpointpolicy/remote.go
@@ -21,7 +21,6 @@ var errStopTraversal = errors.New("stop traversal")
 
 type Target struct {
 	Remote string
-	Label  string
 	Dir    string
 }
 
@@ -41,17 +40,13 @@ func ResolveTarget(ctx context.Context, baseRemote string) (Target, error) {
 	if target, dedicated, err := remote.ConfiguredURL(ctx, baseRemote, dir); err != nil {
 		return Target{}, fmt.Errorf("resolve checkpoint remote URL: %w", err)
 	} else if dedicated {
-		return Target{Remote: target, Label: "checkpoint remote", Dir: dir}, nil
+		return Target{Remote: target, Dir: dir}, nil
 	}
-	target, dedicated, err := remote.PushURL(ctx, baseRemote)
+	target, _, err := remote.PushURL(ctx, baseRemote)
 	if err != nil {
 		return Target{}, fmt.Errorf("resolve checkpoint push URL: %w", err)
 	}
-	label := baseRemote
-	if dedicated {
-		label = "checkpoint remote"
-	}
-	return Target{Remote: target, Label: label, Dir: dir}, nil
+	return Target{Remote: target, Dir: dir}, nil
 }
 
 func CheckRemote(ctx context.Context, target Target) (RemoteState, error) {
@@ -75,38 +70,48 @@ func Sync(ctx context.Context, repo *git.Repository, target Target) (State, erro
 		return State{}, err
 	}
 
-	remoteState, err := CheckRemote(ctx, target)
+	baseline, remoteFound, err := remoteBaseline(ctx, repo, target, local)
 	if err != nil {
 		return State{}, err
 	}
+	if !remoteFound || local.Hash == baseline.Hash {
+		return baseline, nil
+	}
+
+	if local.Hash.IsZero() || isAncestorOf(ctx, repo, local.Hash, baseline.Hash) {
+		if err := SetRef(repo, RefName, baseline.Hash); err != nil {
+			return State{}, err
+		}
+		baseline.Source = SourceRemote
+		return baseline, nil
+	}
+
+	local.Source = SourceLocalDiverged
+	local.RemoteHash = baseline.RemoteHash
+	return local, nil
+}
+
+func remoteBaseline(ctx context.Context, repo *git.Repository, target Target, local State) (State, bool, error) {
+	remoteState, err := CheckRemote(ctx, target)
+	if err != nil {
+		return State{}, false, err
+	}
 	if !remoteState.Exists {
-		return local, nil
+		return local, false, nil
 	}
 	if local.Hash == remoteState.Hash {
 		local.Source = SourceRemote
 		local.RemoteHash = remoteState.Hash
-		return local, nil
+		return local, true, nil
 	}
 
 	fetched, err := fetchRemotePolicy(ctx, repo, target)
 	if err != nil {
-		return State{}, err
+		return State{}, false, err
 	}
 	fetched.RemoteHash = remoteState.Hash
 	defer removeFetchRef(repo)
-
-	if local.Hash.IsZero() || isAncestorOf(ctx, repo, local.Hash, fetched.Hash) {
-		if err := SetRef(repo, RefName, fetched.Hash); err != nil {
-			return State{}, err
-		}
-		fetched.Source = SourceRemote
-		return fetched, nil
-	}
-
-	local.Source = SourceLocalDiverged
-	local.RemoteHash = remoteState.Hash
-	local.Warning = fmt.Sprintf("local checkpoint policy %s diverges from remote %s", local.Hash, remoteState.Hash)
-	return local, nil
+	return fetched, true, nil
 }
 
 func Push(ctx context.Context, target Target) error {

--- a/cmd/entire/cli/checkpointpolicy/remote_internal_test.go
+++ b/cmd/entire/cli/checkpointpolicy/remote_internal_test.go
@@ -1,0 +1,28 @@
+package checkpointpolicy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRemotePolicyHash(t *testing.T) {
+	t.Parallel()
+	sha1 := strings.Repeat("a", 40)
+	sha256 := strings.Repeat("b", 64)
+
+	got, err := parseRemotePolicyHash(sha1)
+	require.NoError(t, err)
+	require.Equal(t, sha1, got.String())
+
+	got, err = parseRemotePolicyHash(sha256)
+	require.NoError(t, err)
+	require.Equal(t, sha256, got.String())
+
+	_, err = parseRemotePolicyHash(strings.Repeat("c", 41))
+	require.ErrorContains(t, err, "invalid remote checkpoint policy hash")
+
+	_, err = parseRemotePolicyHash(strings.Repeat("g", 40))
+	require.ErrorContains(t, err, "invalid remote checkpoint policy hash")
+}

--- a/cmd/entire/cli/checkpointpolicy/remote_test.go
+++ b/cmd/entire/cli/checkpointpolicy/remote_test.go
@@ -1,0 +1,144 @@
+package checkpointpolicy_test
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncRemotePolicyDefaultsWhenRemoteMissing(t *testing.T) {
+	t.Parallel()
+	localDir, repo, bareDir := initPolicyRemoteFixture(t)
+
+	got, err := checkpointpolicy.Sync(t.Context(), repo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir})
+	require.NoError(t, err)
+	require.Equal(t, checkpointpolicy.SourceDefaults, got.Source)
+	require.Equal(t, checkpointpolicy.DefaultPolicy(), got.Policy)
+	require.True(t, got.Hash.IsZero())
+	require.True(t, got.RemoteHash.IsZero())
+}
+
+func TestSyncRemotePolicyFetchesAndPromotesMissingLocalRef(t *testing.T) {
+	t.Parallel()
+	remoteDir, remoteRepo, bareDir := initPolicyRemoteFixture(t)
+	remoteHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, remoteDir, bareDir)
+
+	localDir, localRepo := initPolicyRepoWithDir(t)
+	got, err := checkpointpolicy.Sync(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir})
+	require.NoError(t, err)
+	require.Equal(t, checkpointpolicy.SourceRemote, got.Source)
+	require.Equal(t, remoteHash, got.Hash)
+	require.Equal(t, remoteHash, got.RemoteHash)
+
+	localState, err := checkpointpolicy.ReadLocal(t.Context(), localRepo)
+	require.NoError(t, err)
+	require.Equal(t, remoteHash, localState.Hash)
+}
+
+func TestSyncRemotePolicyDoesNotLeaveTempRefWhenSHAAlreadyMatches(t *testing.T) {
+	t.Parallel()
+	localDir, repo, bareDir := initPolicyRemoteFixture(t)
+	localHash, err := checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, localDir, bareDir)
+
+	got, err := checkpointpolicy.Sync(t.Context(), repo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir})
+	require.NoError(t, err)
+	require.Equal(t, checkpointpolicy.SourceRemote, got.Source)
+	require.Equal(t, localHash, got.Hash)
+	require.Equal(t, localHash, got.RemoteHash)
+	requireNoRef(t, repo, "refs/entire/policies/checkpoint-fetch")
+}
+
+func TestSyncRemotePolicyKeepsDivergedLocalRef(t *testing.T) {
+	t.Parallel()
+	remoteDir, remoteRepo, bareDir := initPolicyRemoteFixture(t)
+	baseHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, remoteDir, bareDir)
+
+	localDir, localRepo := initPolicyRepoWithDir(t)
+	_, err = checkpointpolicy.Sync(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir})
+	require.NoError(t, err)
+	localHash, err := checkpointpolicy.WriteLocal(t.Context(), localRepo, baseHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+
+	remoteHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, baseHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "refs-v1",
+	})
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, remoteDir, bareDir)
+
+	got, err := checkpointpolicy.Sync(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir})
+	require.NoError(t, err)
+	require.Equal(t, checkpointpolicy.SourceLocalDiverged, got.Source)
+	require.Equal(t, localHash, got.Hash)
+	require.Equal(t, remoteHash, got.RemoteHash)
+
+	localState, err := checkpointpolicy.ReadLocal(t.Context(), localRepo)
+	require.NoError(t, err)
+	require.Equal(t, localHash, localState.Hash)
+	requireNoRef(t, localRepo, "refs/entire/policies/checkpoint-fetch")
+}
+
+func TestPushPolicyRejectsNonFastForward(t *testing.T) {
+	t.Parallel()
+	firstDir, firstRepo, bareDir := initPolicyRemoteFixture(t)
+	_, err := checkpointpolicy.WriteLocal(t.Context(), firstRepo, plumbing.ZeroHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, firstDir, bareDir)
+
+	secondDir, secondRepo := initPolicyRepoWithDir(t)
+	_, err = checkpointpolicy.WriteLocal(t.Context(), secondRepo, plumbing.ZeroHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "refs-v1",
+	})
+	require.NoError(t, err)
+
+	err = checkpointpolicy.Push(t.Context(), checkpointpolicy.Target{Remote: bareDir, Dir: secondDir})
+	require.ErrorContains(t, err, "push checkpoint policy")
+}
+
+func initPolicyRemoteFixture(t *testing.T) (string, *git.Repository, string) {
+	t.Helper()
+	localDir, repo := initPolicyRepoWithDir(t)
+	bareDir := filepath.Join(t.TempDir(), "remote.git")
+	_, err := git.PlainInit(bareDir, true)
+	require.NoError(t, err)
+	return localDir, repo, bareDir
+}
+
+func initPolicyRepoWithDir(t *testing.T) (string, *git.Repository) {
+	t.Helper()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	return dir, repo
+}
+
+func pushPolicyRefWithGit(t *testing.T, dir, remote string) {
+	t.Helper()
+	refspec := checkpointpolicy.RefName.String() + ":" + checkpointpolicy.RefName.String()
+	cmd := exec.CommandContext(context.Background(), "git", "push", remote, refspec)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
+func requireNoRef(t *testing.T, repo *git.Repository, refName plumbing.ReferenceName) {
+	t.Helper()
+	_, err := repo.Reference(refName, true)
+	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+}

--- a/cmd/entire/cli/checkpointpolicy/remote_test.go
+++ b/cmd/entire/cli/checkpointpolicy/remote_test.go
@@ -131,7 +131,6 @@ func TestResolveTargetUsesConfiguredCheckpointRemoteWithOriginOwnerMismatch(t *t
 	target, err := checkpointpolicy.ResolveTarget(t.Context(), "origin")
 	require.NoError(t, err)
 	require.Equal(t, "git@github.com:org/checkpoints.git", target.Remote)
-	require.Equal(t, "checkpoint remote", target.Label)
 	wantDir, err := filepath.EvalSymlinks(localDir)
 	require.NoError(t, err)
 	gotDir, err := filepath.EvalSymlinks(target.Dir)

--- a/cmd/entire/cli/checkpointpolicy/remote_test.go
+++ b/cmd/entire/cli/checkpointpolicy/remote_test.go
@@ -2,11 +2,13 @@ package checkpointpolicy_test
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -109,6 +111,34 @@ func TestPushPolicyRejectsNonFastForward(t *testing.T) {
 	require.ErrorContains(t, err, "push checkpoint policy")
 }
 
+func TestResolveTargetUsesConfiguredCheckpointRemoteWithOriginOwnerMismatch(t *testing.T) {
+	localDir, _ := initPolicyRepoWithDir(t)
+	runPolicyGit(t, localDir, "remote", "add", "origin", "git@github.com:fork/cli.git")
+	require.NoError(t, os.MkdirAll(filepath.Join(localDir, ".entire"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, ".entire", "settings.json"), []byte(`{
+  "enabled": true,
+  "strategy_options": {
+    "checkpoint_remote": {
+      "provider": "github",
+      "repo": "org/checkpoints"
+    }
+  }
+}`), 0o600))
+
+	t.Chdir(localDir)
+	paths.ClearWorktreeRootCache()
+
+	target, err := checkpointpolicy.ResolveTarget(t.Context(), "origin")
+	require.NoError(t, err)
+	require.Equal(t, "git@github.com:org/checkpoints.git", target.Remote)
+	require.Equal(t, "checkpoint remote", target.Label)
+	wantDir, err := filepath.EvalSymlinks(localDir)
+	require.NoError(t, err)
+	gotDir, err := filepath.EvalSymlinks(target.Dir)
+	require.NoError(t, err)
+	require.Equal(t, wantDir, gotDir)
+}
+
 func initPolicyRemoteFixture(t *testing.T) (string, *git.Repository, string) {
 	t.Helper()
 	localDir, repo := initPolicyRepoWithDir(t)
@@ -130,7 +160,12 @@ func initPolicyRepoWithDir(t *testing.T) (string, *git.Repository) {
 func pushPolicyRefWithGit(t *testing.T, dir, remote string) {
 	t.Helper()
 	refspec := checkpointpolicy.RefName.String() + ":" + checkpointpolicy.RefName.String()
-	cmd := exec.CommandContext(context.Background(), "git", "push", remote, refspec)
+	runPolicyGit(t, dir, "push", remote, refspec)
+}
+
+func runPolicyGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
 	cmd.Dir = dir
 	cmd.Env = testutil.GitIsolatedEnv()
 	output, err := cmd.CombinedOutput()

--- a/cmd/entire/cli/checkpointpolicy/remote_test.go
+++ b/cmd/entire/cli/checkpointpolicy/remote_test.go
@@ -128,7 +128,7 @@ func TestResolveTargetUsesConfiguredCheckpointRemoteWithOriginOwnerMismatch(t *t
 	t.Chdir(localDir)
 	paths.ClearWorktreeRootCache()
 
-	target, err := checkpointpolicy.ResolveTarget(t.Context(), "origin")
+	target, err := checkpointpolicy.ResolveTarget(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, "git@github.com:org/checkpoints.git", target.Remote)
 	wantDir, err := filepath.EvalSymlinks(localDir)
@@ -136,6 +136,20 @@ func TestResolveTargetUsesConfiguredCheckpointRemoteWithOriginOwnerMismatch(t *t
 	gotDir, err := filepath.EvalSymlinks(target.Dir)
 	require.NoError(t, err)
 	require.Equal(t, wantDir, gotDir)
+}
+
+func TestResolveTargetUsesFetchURLPolicyTarget(t *testing.T) {
+	localDir, _ := initPolicyRepoWithDir(t)
+	upstreamDir := filepath.Join(t.TempDir(), "upstream.git")
+	_, err := git.PlainInit(upstreamDir, true)
+	require.NoError(t, err)
+	runPolicyGit(t, localDir, "remote", "add", "upstream", upstreamDir)
+
+	t.Chdir(localDir)
+	paths.ClearWorktreeRootCache()
+
+	_, err = checkpointpolicy.ResolveTarget(t.Context())
+	require.ErrorContains(t, err, "no fetch URL found")
 }
 
 func initPolicyRemoteFixture(t *testing.T) (string, *git.Repository, string) {

--- a/cmd/entire/cli/checkpointpolicy/store.go
+++ b/cmd/entire/cli/checkpointpolicy/store.go
@@ -1,0 +1,116 @@
+package checkpointpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+const PolicyFileName = "policy.json"
+
+const RefName = plumbing.ReferenceName("refs/entire/policies/checkpoint")
+
+type Source string
+
+const (
+	SourceDefaults      Source = "defaults"
+	SourceLocal         Source = "local"
+	SourceRemote        Source = "remote"
+	SourceLocalDiverged Source = "local-diverged"
+)
+
+type State struct {
+	Policy     Policy
+	Source     Source
+	Hash       plumbing.Hash
+	RemoteHash plumbing.Hash
+	Warning    string
+}
+
+func ReadLocal(ctx context.Context, repo *git.Repository) (State, error) {
+	ref, err := repo.Reference(RefName, true)
+	if err != nil {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return State{Policy: DefaultPolicy(), Source: SourceDefaults}, nil
+		}
+		return State{}, fmt.Errorf("read checkpoint policy ref: %w", err)
+	}
+	return readFromHash(ctx, repo, ref.Hash(), SourceLocal)
+}
+
+func ReadFromRef(ctx context.Context, repo *git.Repository, refName plumbing.ReferenceName, source Source) (State, error) {
+	ref, err := repo.Reference(refName, true)
+	if err != nil {
+		return State{}, fmt.Errorf("read checkpoint policy ref %s: %w", refName, err)
+	}
+	return readFromHash(ctx, repo, ref.Hash(), source)
+}
+
+func WriteLocal(ctx context.Context, repo *git.Repository, parent plumbing.Hash, policy Policy) (plumbing.Hash, error) {
+	policy = Normalize(policy)
+	data, err := jsonutil.MarshalIndentWithNewline(policy, "", "  ")
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("marshal checkpoint policy: %w", err)
+	}
+	blobHash, err := checkpoint.CreateBlobFromContent(repo, data)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	treeHash, err := checkpoint.BuildTreeFromEntries(ctx, repo, map[string]object.TreeEntry{
+		PolicyFileName: {Name: PolicyFileName, Mode: filemode.Regular, Hash: blobHash},
+	})
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("build checkpoint policy tree: %w", err)
+	}
+	authorName, authorEmail := checkpoint.GetGitAuthorFromRepo(repo)
+	commitHash, err := checkpoint.CreateCommit(ctx, repo, treeHash, parent, "Update checkpoint policy", authorName, authorEmail)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	if err := SetRef(repo, RefName, commitHash); err != nil {
+		return plumbing.ZeroHash, err
+	}
+	return commitHash, nil
+}
+
+func SetRef(repo *git.Repository, ref plumbing.ReferenceName, hash plumbing.Hash) error {
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(ref, hash)); err != nil {
+		return fmt.Errorf("set checkpoint policy ref %s: %w", ref, err)
+	}
+	return nil
+}
+
+func readFromHash(ctx context.Context, repo *git.Repository, hash plumbing.Hash, source Source) (State, error) {
+	if err := ctx.Err(); err != nil {
+		return State{}, err
+	}
+	commit, err := repo.CommitObject(hash)
+	if err != nil {
+		return State{}, fmt.Errorf("read checkpoint policy commit: %w", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return State{}, fmt.Errorf("read checkpoint policy tree: %w", err)
+	}
+	file, err := tree.File(PolicyFileName)
+	if err != nil {
+		return State{}, fmt.Errorf("read %s: %w", PolicyFileName, err)
+	}
+	content, err := file.Contents()
+	if err != nil {
+		return State{}, fmt.Errorf("read %s contents: %w", PolicyFileName, err)
+	}
+	var policy Policy
+	if err := json.Unmarshal([]byte(content), &policy); err != nil {
+		return State{}, fmt.Errorf("parse %s: %w", PolicyFileName, err)
+	}
+	return State{Policy: Normalize(policy), Source: source, Hash: hash}, nil
+}

--- a/cmd/entire/cli/checkpointpolicy/store.go
+++ b/cmd/entire/cli/checkpointpolicy/store.go
@@ -32,7 +32,6 @@ type State struct {
 	Source     Source
 	Hash       plumbing.Hash
 	RemoteHash plumbing.Hash
-	Warning    string
 }
 
 func ReadLocal(ctx context.Context, repo *git.Repository) (State, error) {

--- a/cmd/entire/cli/checkpointpolicy/store.go
+++ b/cmd/entire/cli/checkpointpolicy/store.go
@@ -62,7 +62,7 @@ func WriteLocal(ctx context.Context, repo *git.Repository, parent plumbing.Hash,
 	}
 	blobHash, err := checkpoint.CreateBlobFromContent(repo, data)
 	if err != nil {
-		return plumbing.ZeroHash, err
+		return plumbing.ZeroHash, fmt.Errorf("create checkpoint policy blob: %w", err)
 	}
 	treeHash, err := checkpoint.BuildTreeFromEntries(ctx, repo, map[string]object.TreeEntry{
 		PolicyFileName: {Name: PolicyFileName, Mode: filemode.Regular, Hash: blobHash},
@@ -73,7 +73,7 @@ func WriteLocal(ctx context.Context, repo *git.Repository, parent plumbing.Hash,
 	authorName, authorEmail := checkpoint.GetGitAuthorFromRepo(repo)
 	commitHash, err := checkpoint.CreateCommit(ctx, repo, treeHash, parent, "Update checkpoint policy", authorName, authorEmail)
 	if err != nil {
-		return plumbing.ZeroHash, err
+		return plumbing.ZeroHash, fmt.Errorf("create checkpoint policy commit: %w", err)
 	}
 	if err := SetRef(repo, RefName, commitHash); err != nil {
 		return plumbing.ZeroHash, err
@@ -90,7 +90,7 @@ func SetRef(repo *git.Repository, ref plumbing.ReferenceName, hash plumbing.Hash
 
 func readFromHash(ctx context.Context, repo *git.Repository, hash plumbing.Hash, source Source) (State, error) {
 	if err := ctx.Err(); err != nil {
-		return State{}, err
+		return State{}, fmt.Errorf("read checkpoint policy: %w", err)
 	}
 	commit, err := repo.CommitObject(hash)
 	if err != nil {

--- a/cmd/entire/cli/checkpointpolicy/store_test.go
+++ b/cmd/entire/cli/checkpointpolicy/store_test.go
@@ -1,0 +1,94 @@
+package checkpointpolicy_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadLocalPolicyDefaultsWhenRefMissing(t *testing.T) {
+	t.Parallel()
+	repo := initPolicyRepo(t)
+	got, err := checkpointpolicy.ReadLocal(t.Context(), repo)
+	require.NoError(t, err)
+	require.Equal(t, checkpointpolicy.SourceDefaults, got.Source)
+	require.Equal(t, checkpointpolicy.DefaultPolicy(), got.Policy)
+	require.True(t, got.Hash.IsZero())
+}
+
+func TestWriteAndReadLocalPolicy(t *testing.T) {
+	t.Parallel()
+	repo := initPolicyRepo(t)
+	policy := checkpointpolicy.Policy{
+		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
+		CheckpointMinVersion: checkpoint.CheckpointVersionBranchV1,
+	}
+	hash, err := checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, policy)
+	require.NoError(t, err)
+	require.False(t, hash.IsZero())
+
+	got, err := checkpointpolicy.ReadLocal(t.Context(), repo)
+	require.NoError(t, err)
+	require.Equal(t, checkpointpolicy.SourceLocal, got.Source)
+	require.Equal(t, hash, got.Hash)
+	require.Equal(t, policy, got.Policy)
+}
+
+func TestReadLocalPolicyRejectsMalformedJSON(t *testing.T) {
+	t.Parallel()
+	repo := initPolicyRepo(t)
+	writeRawPolicyCommit(t, repo, []byte(`{"checkpoint_version":`), plumbing.ZeroHash)
+
+	_, err := checkpointpolicy.ReadLocal(t.Context(), repo)
+	require.ErrorContains(t, err, "parse policy.json")
+}
+
+func TestReadLocalPolicyAllowsUnsupportedPolicy(t *testing.T) {
+	t.Parallel()
+	repo := initPolicyRepo(t)
+	policy := checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "refs-v1",
+	}
+	data, err := json.Marshal(policy)
+	require.NoError(t, err)
+	hash := writeRawPolicyCommit(t, repo, data, plumbing.ZeroHash)
+
+	got, err := checkpointpolicy.ReadLocal(t.Context(), repo)
+	require.NoError(t, err)
+	require.Equal(t, checkpointpolicy.SourceLocal, got.Source)
+	require.Equal(t, hash, got.Hash)
+	require.Equal(t, policy, got.Policy)
+}
+
+func initPolicyRepo(t *testing.T) *git.Repository {
+	t.Helper()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	return repo
+}
+
+func writeRawPolicyCommit(t *testing.T, repo *git.Repository, data []byte, parent plumbing.Hash) plumbing.Hash {
+	t.Helper()
+	blobHash, err := checkpoint.CreateBlobFromContent(repo, data)
+	require.NoError(t, err)
+	treeHash, err := checkpoint.BuildTreeFromEntries(context.Background(), repo, map[string]object.TreeEntry{
+		checkpointpolicy.PolicyFileName: {Name: checkpointpolicy.PolicyFileName, Mode: filemode.Regular, Hash: blobHash},
+	})
+	require.NoError(t, err)
+	commitHash, err := checkpoint.CreateCommit(context.Background(), repo, treeHash, parent, "raw policy", "Test", "test@example.com")
+	require.NoError(t, err)
+	require.NoError(t, checkpointpolicy.SetRef(repo, checkpointpolicy.RefName, commitHash))
+	return commitHash
+}

--- a/cmd/entire/cli/checkpointpolicy/update.go
+++ b/cmd/entire/cli/checkpointpolicy/update.go
@@ -52,8 +52,21 @@ func updateBaseline(ctx context.Context, repo *git.Repository, target Target) (S
 		return State{}, err
 	}
 
-	baseline, _, err := remoteBaseline(ctx, repo, target, local)
-	return baseline, err
+	baseline, remoteFound, err := remoteBaseline(ctx, repo, target, local)
+	if err != nil {
+		return State{}, err
+	}
+	if !remoteFound || local.Hash == baseline.Hash {
+		return baseline, nil
+	}
+	if local.Hash.IsZero() || isAncestorOf(ctx, repo, local.Hash, baseline.Hash) {
+		return baseline, nil
+	}
+	if isAncestorOf(ctx, repo, baseline.Hash, local.Hash) {
+		local.RemoteHash = baseline.RemoteHash
+		return local, nil
+	}
+	return State{}, fmt.Errorf("local checkpoint policy %s diverges from remote %s; push or reconcile the policy before updating", local.Hash, baseline.RemoteHash)
 }
 
 func rejectDowngrades(before, after Policy, opts UpdateOptions) error {

--- a/cmd/entire/cli/checkpointpolicy/update.go
+++ b/cmd/entire/cli/checkpointpolicy/update.go
@@ -52,26 +52,8 @@ func updateBaseline(ctx context.Context, repo *git.Repository, target Target) (S
 		return State{}, err
 	}
 
-	remoteState, err := CheckRemote(ctx, target)
-	if err != nil {
-		return State{}, err
-	}
-	if !remoteState.Exists {
-		return local, nil
-	}
-	if local.Hash == remoteState.Hash {
-		local.Source = SourceRemote
-		local.RemoteHash = remoteState.Hash
-		return local, nil
-	}
-
-	fetched, err := fetchRemotePolicy(ctx, repo, target)
-	if err != nil {
-		return State{}, err
-	}
-	fetched.RemoteHash = remoteState.Hash
-	defer removeFetchRef(repo)
-	return fetched, nil
+	baseline, _, err := remoteBaseline(ctx, repo, target, local)
+	return baseline, err
 }
 
 func rejectDowngrades(before, after Policy, opts UpdateOptions) error {

--- a/cmd/entire/cli/checkpointpolicy/update.go
+++ b/cmd/entire/cli/checkpointpolicy/update.go
@@ -1,0 +1,110 @@
+package checkpointpolicy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-git/go-git/v6"
+)
+
+type UpdateOptions struct {
+	CheckpointVersion    string
+	CheckpointMinVersion string
+	Force                bool
+}
+
+func Update(ctx context.Context, repo *git.Repository, target Target, opts UpdateOptions) (State, error) {
+	baseline, err := updateBaseline(ctx, repo, target)
+	if err != nil {
+		return State{}, err
+	}
+
+	policy := baseline.Policy
+	if opts.CheckpointVersion != "" {
+		policy.CheckpointVersion = opts.CheckpointVersion
+	}
+	if opts.CheckpointMinVersion != "" {
+		policy.CheckpointMinVersion = opts.CheckpointMinVersion
+	}
+
+	if err := rejectDowngrades(baseline.Policy, policy, opts); err != nil {
+		return State{}, err
+	}
+	if err := ValidatePolicy(policy); err != nil {
+		return State{}, err
+	}
+
+	hash, err := WriteLocal(ctx, repo, baseline.Hash, policy)
+	if err != nil {
+		return State{}, err
+	}
+	return State{
+		Policy:     Normalize(policy),
+		Source:     SourceLocal,
+		Hash:       hash,
+		RemoteHash: baseline.RemoteHash,
+	}, nil
+}
+
+func updateBaseline(ctx context.Context, repo *git.Repository, target Target) (State, error) {
+	local, err := ReadLocal(ctx, repo)
+	if err != nil {
+		return State{}, err
+	}
+
+	remoteState, err := CheckRemote(ctx, target)
+	if err != nil {
+		return State{}, err
+	}
+	if !remoteState.Exists {
+		return local, nil
+	}
+	if local.Hash == remoteState.Hash {
+		local.Source = SourceRemote
+		local.RemoteHash = remoteState.Hash
+		return local, nil
+	}
+
+	fetched, err := fetchRemotePolicy(ctx, repo, target)
+	if err != nil {
+		return State{}, err
+	}
+	fetched.RemoteHash = remoteState.Hash
+	defer removeFetchRef(repo)
+	return fetched, nil
+}
+
+func rejectDowngrades(before, after Policy, opts UpdateOptions) error {
+	before = Normalize(before)
+	after = Normalize(after)
+
+	if opts.Force {
+		return nil
+	}
+	if opts.CheckpointVersion != "" {
+		if err := rejectFieldDowngrade("checkpoint_version", before.CheckpointVersion, after.CheckpointVersion); err != nil {
+			return err
+		}
+	}
+	if opts.CheckpointMinVersion != "" {
+		if err := rejectFieldDowngrade("checkpoint_min_version", before.CheckpointMinVersion, after.CheckpointMinVersion); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectFieldDowngrade(field, beforeRaw, afterRaw string) error {
+	before, err := ParseFormat(beforeRaw)
+	if err != nil {
+		return fmt.Errorf("%s existing value %q: %w", field, beforeRaw, err)
+	}
+	after, err := ParseFormat(afterRaw)
+	if err != nil {
+		return fmt.Errorf("%s: %w", field, err)
+	}
+	if Compare(after, before) < 0 {
+		return fmt.Errorf("would downgrade %s from %q to %q; pass --force to allow this", field, beforeRaw, afterRaw)
+	}
+	return nil
+}

--- a/cmd/entire/cli/checkpointpolicy/update_test.go
+++ b/cmd/entire/cli/checkpointpolicy/update_test.go
@@ -1,0 +1,64 @@
+package checkpointpolicy_test
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateRejectsDowngradeFromRemoteWithoutForce(t *testing.T) {
+	t.Parallel()
+	remoteDir, remoteRepo, bareDir := initPolicyRemoteFixture(t)
+	remoteHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "refs-v1",
+	})
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, remoteDir, bareDir)
+
+	localDir, localRepo := initPolicyRepoWithDir(t)
+	localHash, err := checkpointpolicy.WriteLocal(t.Context(), localRepo, plumbing.ZeroHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+
+	_, err = checkpointpolicy.Update(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir}, checkpointpolicy.UpdateOptions{
+		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
+		CheckpointMinVersion: checkpoint.CheckpointVersionBranchV1,
+	})
+	require.ErrorContains(t, err, "would downgrade checkpoint_version")
+
+	localState, err := checkpointpolicy.ReadLocal(t.Context(), localRepo)
+	require.NoError(t, err)
+	require.Equal(t, localHash, localState.Hash)
+	require.NotEqual(t, remoteHash, localState.Hash)
+}
+
+func TestUpdateAllowsDowngradeWithForce(t *testing.T) {
+	t.Parallel()
+	remoteDir, remoteRepo, bareDir := initPolicyRemoteFixture(t)
+	remoteHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "refs-v1",
+	})
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, remoteDir, bareDir)
+
+	localDir, localRepo := initPolicyRepoWithDir(t)
+	got, err := checkpointpolicy.Update(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir}, checkpointpolicy.UpdateOptions{
+		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
+		CheckpointMinVersion: checkpoint.CheckpointVersionBranchV1,
+		Force:                true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, checkpointpolicy.SourceLocal, got.Source)
+	require.Equal(t, checkpointpolicy.Policy{
+		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
+		CheckpointMinVersion: checkpoint.CheckpointVersionBranchV1,
+	}, got.Policy)
+
+	commit, err := localRepo.CommitObject(got.Hash)
+	require.NoError(t, err)
+	require.Equal(t, []plumbing.Hash{remoteHash}, commit.ParentHashes)
+}

--- a/cmd/entire/cli/checkpointpolicy/update_test.go
+++ b/cmd/entire/cli/checkpointpolicy/update_test.go
@@ -12,7 +12,7 @@ import (
 func TestUpdateRejectsDowngradeFromRemoteWithoutForce(t *testing.T) {
 	t.Parallel()
 	remoteDir, remoteRepo, bareDir := initPolicyRemoteFixture(t)
-	remoteHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.Policy{
+	_, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.Policy{
 		CheckpointVersion:    "refs-v1",
 		CheckpointMinVersion: "refs-v1",
 	})
@@ -20,8 +20,6 @@ func TestUpdateRejectsDowngradeFromRemoteWithoutForce(t *testing.T) {
 	pushPolicyRefWithGit(t, remoteDir, bareDir)
 
 	localDir, localRepo := initPolicyRepoWithDir(t)
-	localHash, err := checkpointpolicy.WriteLocal(t.Context(), localRepo, plumbing.ZeroHash, checkpointpolicy.DefaultPolicy())
-	require.NoError(t, err)
 
 	_, err = checkpointpolicy.Update(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir}, checkpointpolicy.UpdateOptions{
 		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
@@ -31,8 +29,7 @@ func TestUpdateRejectsDowngradeFromRemoteWithoutForce(t *testing.T) {
 
 	localState, err := checkpointpolicy.ReadLocal(t.Context(), localRepo)
 	require.NoError(t, err)
-	require.Equal(t, localHash, localState.Hash)
-	require.NotEqual(t, remoteHash, localState.Hash)
+	require.True(t, localState.Hash.IsZero())
 }
 
 func TestUpdateAllowsDowngradeWithForce(t *testing.T) {
@@ -61,4 +58,62 @@ func TestUpdateAllowsDowngradeWithForce(t *testing.T) {
 	commit, err := localRepo.CommitObject(got.Hash)
 	require.NoError(t, err)
 	require.Equal(t, []plumbing.Hash{remoteHash}, commit.ParentHashes)
+}
+
+func TestUpdatePreservesLocalPolicyAheadOfRemote(t *testing.T) {
+	t.Parallel()
+	remoteDir, remoteRepo, bareDir := initPolicyRemoteFixture(t)
+	baseHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, remoteDir, bareDir)
+
+	localDir, localRepo := initPolicyRepoWithDir(t)
+	_, err = checkpointpolicy.Sync(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir})
+	require.NoError(t, err)
+	localHash, err := checkpointpolicy.WriteLocal(t.Context(), localRepo, baseHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+
+	got, err := checkpointpolicy.Update(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir}, checkpointpolicy.UpdateOptions{
+		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
+		CheckpointMinVersion: checkpoint.CheckpointVersionBranchV1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, baseHash, got.RemoteHash)
+
+	commit, err := localRepo.CommitObject(got.Hash)
+	require.NoError(t, err)
+	require.Equal(t, []plumbing.Hash{localHash}, commit.ParentHashes)
+}
+
+func TestUpdateRejectsDivergedLocalPolicy(t *testing.T) {
+	t.Parallel()
+	remoteDir, remoteRepo, bareDir := initPolicyRemoteFixture(t)
+	baseHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, remoteDir, bareDir)
+
+	localDir, localRepo := initPolicyRepoWithDir(t)
+	_, err = checkpointpolicy.Sync(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir})
+	require.NoError(t, err)
+	localHash, err := checkpointpolicy.WriteLocal(t.Context(), localRepo, baseHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+
+	remoteHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, baseHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "refs-v1",
+	})
+	require.NoError(t, err)
+	pushPolicyRefWithGit(t, remoteDir, bareDir)
+
+	_, err = checkpointpolicy.Update(t.Context(), localRepo, checkpointpolicy.Target{Remote: bareDir, Dir: localDir}, checkpointpolicy.UpdateOptions{
+		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
+		CheckpointMinVersion: checkpoint.CheckpointVersionBranchV1,
+	})
+	require.ErrorContains(t, err, "local checkpoint policy")
+	require.ErrorContains(t, err, "diverges from remote")
+
+	localState, err := checkpointpolicy.ReadLocal(t.Context(), localRepo)
+	require.NoError(t, err)
+	require.Equal(t, localHash, localState.Hash)
+	require.NotEqual(t, remoteHash, localState.Hash)
 }

--- a/cmd/entire/cli/checkpointpolicy/warning_test.go
+++ b/cmd/entire/cli/checkpointpolicy/warning_test.go
@@ -27,4 +27,14 @@ func TestEnsureCanReadVersion(t *testing.T) {
 	err := checkpointpolicy.EnsureCanReadVersion("abc123", "refs-v1")
 	require.ErrorContains(t, err, `checkpoint abc123 uses unsupported checkpoint_version "refs-v1"`)
 	require.ErrorContains(t, err, "not read-supported")
+	require.True(t, checkpointpolicy.IsUnsupportedVersion(err))
+}
+
+func TestEnsureCanReadVersionParseErrorIsNotUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	err := checkpointpolicy.EnsureCanReadVersion("abc123", "not-a-format")
+
+	require.ErrorContains(t, err, `checkpoint abc123 has invalid checkpoint_version "not-a-format"`)
+	require.False(t, checkpointpolicy.IsUnsupportedVersion(err))
 }

--- a/cmd/entire/cli/checkpointpolicy/warning_test.go
+++ b/cmd/entire/cli/checkpointpolicy/warning_test.go
@@ -1,0 +1,30 @@
+package checkpointpolicy_test
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeWarning(t *testing.T) {
+	t.Parallel()
+
+	got := checkpointpolicy.UpgradeWarning("brew upgrade entire")
+
+	require.Contains(t, got, "[entire] This repository requires checkpoint support newer than this Entire CLI.")
+	require.Contains(t, got, "[entire] Upgrade Entire, then rerun the command:")
+	require.Contains(t, got, "[entire]   brew upgrade entire")
+}
+
+func TestEnsureCanReadVersion(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, checkpointpolicy.EnsureCanReadVersion("abc123", checkpoint.CheckpointVersionBranchV1))
+	require.NoError(t, checkpointpolicy.EnsureCanReadVersion("abc123", ""))
+
+	err := checkpointpolicy.EnsureCanReadVersion("abc123", "refs-v1")
+	require.ErrorContains(t, err, `checkpoint abc123 uses unsupported checkpoint_version "refs-v1"`)
+	require.ErrorContains(t, err, "not read-supported")
+}

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -23,6 +23,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -753,6 +754,9 @@ func loadCheckpointForExplain(ctx context.Context, lookup *explainCheckpointLook
 	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, store, cpID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read checkpoint: %w", err)
+	}
+	if err := checkpointpolicy.EnsureCanReadVersion(cpID.String(), summary.CheckpointVersion); err != nil {
+		return nil, nil, fmt.Errorf("check checkpoint version: %w", err)
 	}
 
 	content, contentErr := checkpoint.ReadLatestSessionContent(ctx, store, cpID, summary)

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -687,7 +687,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		if openErr != nil {
 			return fmt.Errorf("open checkpoint store: %w", openErr)
 		}
-		if err := generateCheckpointSummary(ctx, w, errW, writeStores.Primary, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
+		if err := generateCheckpointSummary(ctx, w, errW, lookup.repo, writeStores.Primary, fullCheckpointID, summary, content, force, summaryTimeoutSeconds); err != nil {
 			return err
 		}
 		// Reload to get the updated summary.
@@ -899,7 +899,7 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 // summaryTimeoutSeconds is the per-invocation --summary-timeout-seconds flag
 // value (0 = unset). Effective precedence for the deadline: flag > settings >
 // package default. See resolveSummaryTimeout for the resolution.
-func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store checkpoint.Writer, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
+func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, repo *git.Repository, store checkpoint.Writer, checkpointID id.CheckpointID, cpSummary *checkpoint.CheckpointSummary, content *checkpoint.SessionContent, force bool, summaryTimeoutSeconds int) error {
 	// Check if summary already exists
 	if content.Metadata.Summary != nil && !force {
 		return renderExplainFailure(errW, "Summary already exists", []explainRow{
@@ -921,6 +921,9 @@ func generateCheckpointSummary(ctx context.Context, w, errW io.Writer, store che
 		return renderExplainFailure(errW, "Checkpoint has no transcript content (scoped)", []explainRow{
 			{Label: "id", Value: checkpointID.String()},
 		}, fmt.Errorf("checkpoint %s has no transcript content for this checkpoint (scoped)", checkpointID))
+	}
+	if err := ensureCommittedCheckpointWritePolicy(ctx, repo); err != nil {
+		return err
 	}
 	provider, err := resolveCheckpointSummaryProvider(ctx, w)
 	if err != nil {

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 )
@@ -265,6 +266,9 @@ func runExplainStreamTranscript(ctx context.Context, w, errW io.Writer, opts exp
 	if err != nil {
 		return fmt.Errorf("failed to read checkpoint: %w", err)
 	}
+	if err := checkpointpolicy.EnsureCanReadVersion(cpID.String(), summary.CheckpointVersion); err != nil {
+		return fmt.Errorf("check checkpoint version: %w", err)
+	}
 
 	idx, err := resolveSessionIndex(summary, opts.sessionIndex)
 	if err != nil {
@@ -358,6 +362,9 @@ func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts expla
 	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, store, cpID)
 	if err != nil {
 		return fmt.Errorf("failed to read checkpoint: %w", err)
+	}
+	if err := checkpointpolicy.EnsureCanReadVersion(cpID.String(), summary.CheckpointVersion); err != nil {
+		return fmt.Errorf("check checkpoint version: %w", err)
 	}
 
 	envelope, failedSessions := buildCheckpointJSONEnvelope(ctx, store, summary, cpID)

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/entireio/cli/redact"
 	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/require"
 )
@@ -78,6 +79,44 @@ func writeCheckpointForExport(t *testing.T, repo *git.Repository, cpID id.Checkp
 	require.NoError(t, store.WriteCommitted(context.Background(), opts))
 }
 
+func rewriteExportCheckpointVersion(t *testing.T, repo *git.Repository, cpID id.CheckpointID, version string) {
+	t.Helper()
+	ctx := context.Background()
+	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
+	ref, err := repo.Reference(refName, true)
+	require.NoError(t, err)
+	commit, err := repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	tree, err := commit.Tree()
+	require.NoError(t, err)
+
+	metadataPath := cpID.Path() + "/" + paths.MetadataFileName
+	metadataFile, err := tree.File(metadataPath)
+	require.NoError(t, err)
+	content, err := metadataFile.Contents()
+	require.NoError(t, err)
+	var summary checkpoint.CheckpointSummary
+	require.NoError(t, json.Unmarshal([]byte(content), &summary))
+	summary.CheckpointVersion = version
+	metadataJSON, err := json.Marshal(summary)
+	require.NoError(t, err)
+	metadataHash, err := checkpoint.CreateBlobFromContent(repo, metadataJSON)
+	require.NoError(t, err)
+
+	entries := make(map[string]object.TreeEntry)
+	require.NoError(t, tree.Files().ForEach(func(file *object.File) error {
+		entries[file.Name] = object.TreeEntry{Name: file.Name, Mode: file.Mode, Hash: file.Hash}
+		return nil
+	}))
+	entries[metadataPath] = object.TreeEntry{Name: metadataPath, Mode: metadataFile.Mode, Hash: metadataHash}
+
+	treeHash, err := checkpoint.BuildTreeFromEntries(ctx, repo, entries)
+	require.NoError(t, err)
+	commitHash, err := checkpoint.CreateCommit(ctx, repo, treeHash, ref.Hash(), "rewrite checkpoint summary\n", exportTestAuthorName, exportTestAuthorEmail)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refName, commitHash)))
+}
+
 func TestRunExplainExport_JSONSingleCheckpoint(t *testing.T) {
 	repo := setupExportRepo(t)
 
@@ -103,6 +142,26 @@ func TestRunExplainExport_JSONSingleCheckpoint(t *testing.T) {
 	require.Len(t, envelope.Sessions, 1)
 	require.Equal(t, "session-json", envelope.Sessions[0].SessionID)
 	require.Equal(t, 0, envelope.Sessions[0].Index)
+}
+
+func TestRunExplainExportJSONRejectsUnsupportedCheckpointVersion(t *testing.T) {
+	repo := setupExportRepo(t)
+
+	cpID := id.MustCheckpointID("aaaabbbbcccc")
+	writeCheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+		SessionID:  "session-json-unsupported",
+		Transcript: redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n")),
+	})
+	rewriteExportCheckpointVersion(t, repo, cpID, "refs-v1")
+
+	var stdout, stderr bytes.Buffer
+	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
+		target:       "aaaabbbb",
+		json:         true,
+		sessionIndex: -1,
+	})
+	require.ErrorContains(t, err, `checkpoint aaaabbbbcccc uses unsupported checkpoint_version "refs-v1"`)
+	require.Empty(t, stdout.String())
 }
 
 func TestRunExplainExport_JSONFetchesRemoteV1Metadata(t *testing.T) {
@@ -230,6 +289,33 @@ func TestRunExplainExport_TranscriptStreamsStoredBytes(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, raw, stdout.Bytes())
+}
+
+func TestRunExplainExportTranscriptRejectsUnsupportedCheckpointVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		opts explainExportOptions
+	}{
+		{name: "transcript", opts: explainExportOptions{target: "abcd1111", transcript: true, sessionIndex: -1}},
+		{name: "raw transcript", opts: explainExportOptions{target: "abcd1111", rawTranscript: true, sessionIndex: -1}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := setupExportRepo(t)
+			cpID := id.MustCheckpointID("abcd11112222")
+			raw := []byte(`{"type":"user","message":{"content":[{"type":"text","text":"stored line"}]}}` + "\n")
+			writeCheckpointForExport(t, repo, cpID, checkpoint.WriteCommittedOptions{
+				SessionID:  "session-unsupported-transcript",
+				Transcript: redact.AlreadyRedacted(raw),
+			})
+			rewriteExportCheckpointVersion(t, repo, cpID, "refs-v1")
+
+			var stdout, stderr bytes.Buffer
+			err := runExplainExport(context.Background(), &stdout, &stderr, tt.opts)
+			require.ErrorContains(t, err, `checkpoint abcd11112222 uses unsupported checkpoint_version "refs-v1"`)
+			require.Empty(t, stdout.String())
+		})
+	}
 }
 
 func TestRunExplainExport_RawTranscriptStreamsRawBytes(t *testing.T) {

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
@@ -995,7 +996,18 @@ func TestGenerateCheckpointAISummary_PreservesClaudeErrorWhenCtxIsDone(t *testin
 }
 
 // Not parallel: uses t.Chdir() and package-level var stubs.
-func TestGenerateCheckpointSummary_AdvancesV1Metadata(t *testing.T) {
+type generateSummaryFixture struct {
+	ctx       context.Context
+	repo      *git.Repository
+	store     checkpoint.CommittedStore
+	cpID      id.CheckpointID
+	cpSummary *checkpoint.CheckpointSummary
+	content   *checkpoint.SessionContent
+	v1Hash    plumbing.Hash
+}
+
+func setupGenerateSummaryFixture(t *testing.T) generateSummaryFixture {
+	t.Helper()
 	ctx := context.Background()
 	tmpDir := t.TempDir()
 	testutil.InitRepo(t, tmpDir)
@@ -1029,6 +1041,20 @@ func TestGenerateCheckpointSummary_AdvancesV1Metadata(t *testing.T) {
 	v1Before, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.NoError(t, err)
 
+	return generateSummaryFixture{
+		ctx:       ctx,
+		repo:      repo,
+		store:     store,
+		cpID:      cpID,
+		cpSummary: cpSummary,
+		content:   content,
+		v1Hash:    v1Before.Hash(),
+	}
+}
+
+func stubSummaryProviderForTest(t *testing.T) {
+	t.Helper()
+
 	origLoad := loadSummarySettings
 	origGet := getSummaryAgent
 	origCLI := isSummaryCLIAvailable
@@ -1054,13 +1080,57 @@ func TestGenerateCheckpointSummary_AdvancesV1Metadata(t *testing.T) {
 	generateTranscriptSummary = func(context.Context, redact.RedactedBytes, []string, types.AgentType, summarize.Generator) (*checkpoint.Summary, error) {
 		return &checkpoint.Summary{Intent: "i", Outcome: "o"}, nil
 	}
+}
+
+func TestGenerateCheckpointSummary_AdvancesV1Metadata(t *testing.T) {
+	fixture := setupGenerateSummaryFixture(t)
+	stubSummaryProviderForTest(t)
 
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, generateCheckpointSummary(ctx, &stdout, &stderr, stores.Primary, cpID, cpSummary, content, false, 0))
+	require.NoError(t, generateCheckpointSummary(
+		fixture.ctx,
+		&stdout,
+		&stderr,
+		fixture.repo,
+		fixture.store,
+		fixture.cpID,
+		fixture.cpSummary,
+		fixture.content,
+		false,
+		0,
+	))
 
-	v1After, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	v1After, err := fixture.repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	require.NoError(t, err)
-	require.NotEqual(t, v1Before.Hash(), v1After.Hash(), "v1 metadata branch must advance after UpdateSummary")
+	require.NotEqual(t, fixture.v1Hash, v1After.Hash(), "v1 metadata branch must advance after UpdateSummary")
+}
+
+func TestGenerateCheckpointSummaryRejectsUnsupportedCheckpointWritePolicy(t *testing.T) {
+	fixture := setupGenerateSummaryFixture(t)
+	_, err := checkpointpolicy.WriteLocal(fixture.ctx, fixture.repo, plumbing.ZeroHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "branch-v1",
+	})
+	require.NoError(t, err)
+
+	var stdout, stderr bytes.Buffer
+	err = generateCheckpointSummary(
+		fixture.ctx,
+		&stdout,
+		&stderr,
+		fixture.repo,
+		fixture.store,
+		fixture.cpID,
+		fixture.cpSummary,
+		fixture.content,
+		false,
+		0,
+	)
+	require.ErrorContains(t, err, `checkpoint_version "refs-v1"`)
+
+	v1After, refErr := fixture.repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
+	require.NoError(t, refErr)
+	require.Equal(t, fixture.v1Hash, v1After.Hash(), "v1 metadata branch must not advance after rejected summary write")
 }
 
 func TestGenerateCheckpointAISummary_ClampsLongParentDeadlineToDefaultTimeout(t *testing.T) {

--- a/cmd/entire/cli/policy_checkpoint.go
+++ b/cmd/entire/cli/policy_checkpoint.go
@@ -39,7 +39,7 @@ func runPolicyCheckpoint(cmd *cobra.Command, opts policyCheckpointOptions) error
 	}
 	defer repo.Close()
 
-	target, err := checkpointpolicy.ResolveTarget(ctx, "origin")
+	target, err := checkpointpolicy.ResolveTarget(ctx)
 	if err != nil {
 		return fmt.Errorf("resolve checkpoint policy remote: %w", err)
 	}

--- a/cmd/entire/cli/policy_checkpoint.go
+++ b/cmd/entire/cli/policy_checkpoint.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
@@ -33,15 +35,18 @@ func newPolicyCheckpointCmd() *cobra.Command {
 
 func runPolicyCheckpoint(cmd *cobra.Command, opts policyCheckpointOptions) error {
 	ctx := cmd.Context()
+	if err := ctx.Err(); err != nil {
+		return NewSilentError(err)
+	}
 	repo, err := gitrepo.OpenCurrent(ctx)
 	if err != nil {
-		return fmt.Errorf("open repository: %w", err)
+		return policyCheckpointError("open repository", err)
 	}
 	defer repo.Close()
 
 	target, err := checkpointpolicy.ResolveTarget(ctx)
 	if err != nil {
-		return fmt.Errorf("resolve checkpoint policy remote: %w", err)
+		return policyCheckpointError("resolve checkpoint policy remote", err)
 	}
 
 	var state checkpointpolicy.State
@@ -52,16 +57,16 @@ func runPolicyCheckpoint(cmd *cobra.Command, opts policyCheckpointOptions) error
 			Force:                opts.force,
 		})
 		if err != nil {
-			return fmt.Errorf("update checkpoint policy: %w", err)
+			return policyCheckpointError("update checkpoint policy", err)
 		}
 		if err := checkpointpolicy.Push(ctx, target); err != nil {
-			return fmt.Errorf("push checkpoint policy: %w", err)
+			return policyCheckpointError("push checkpoint policy", err)
 		}
 		state.Source = checkpointpolicy.SourceRemote
 	} else {
 		state, err = checkpointpolicy.Sync(ctx, repo, target)
 		if err != nil {
-			return fmt.Errorf("sync checkpoint policy: %w", err)
+			return policyCheckpointError("sync checkpoint policy", err)
 		}
 	}
 
@@ -73,4 +78,12 @@ func runPolicyCheckpoint(cmd *cobra.Command, opts policyCheckpointOptions) error
 
 func hasPolicyCheckpointUpdate(opts policyCheckpointOptions) bool {
 	return opts.version != "" || opts.minVersion != ""
+}
+
+func policyCheckpointError(message string, err error) error {
+	wrapped := fmt.Errorf("%s: %w", message, err)
+	if errors.Is(wrapped, context.Canceled) {
+		return NewSilentError(wrapped)
+	}
+	return wrapped
 }

--- a/cmd/entire/cli/policy_checkpoint.go
+++ b/cmd/entire/cli/policy_checkpoint.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/spf13/cobra"
+)
+
+type policyCheckpointOptions struct {
+	version    string
+	minVersion string
+	force      bool
+}
+
+func newPolicyCheckpointCmd() *cobra.Command {
+	var opts policyCheckpointOptions
+	cmd := &cobra.Command{
+		Use:   "checkpoint",
+		Short: "Inspect and update checkpoint policy",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runPolicyCheckpoint(cmd, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.version, "checkpoint-version", "", "Set the checkpoint version written by this repository")
+	cmd.Flags().StringVar(&opts.minVersion, "checkpoint-min-version", "", "Set the minimum checkpoint version required by this repository")
+	cmd.Flags().BoolVar(&opts.force, "force", false, "Allow checkpoint policy version downgrades")
+	return cmd
+}
+
+func runPolicyCheckpoint(cmd *cobra.Command, opts policyCheckpointOptions) error {
+	ctx := cmd.Context()
+	repo, err := gitrepo.OpenCurrent(ctx)
+	if err != nil {
+		return fmt.Errorf("open repository: %w", err)
+	}
+	defer repo.Close()
+
+	target, err := checkpointpolicy.ResolveTarget(ctx, "origin")
+	if err != nil {
+		return fmt.Errorf("resolve checkpoint policy remote: %w", err)
+	}
+
+	var state checkpointpolicy.State
+	if hasPolicyCheckpointUpdate(opts) {
+		state, err = checkpointpolicy.Update(ctx, repo, target, checkpointpolicy.UpdateOptions{
+			CheckpointVersion:    opts.version,
+			CheckpointMinVersion: opts.minVersion,
+			Force:                opts.force,
+		})
+		if err != nil {
+			return fmt.Errorf("update checkpoint policy: %w", err)
+		}
+		if err := checkpointpolicy.Push(ctx, target); err != nil {
+			return fmt.Errorf("push checkpoint policy: %w", err)
+		}
+		state.Source = checkpointpolicy.SourceRemote
+	} else {
+		state, err = checkpointpolicy.Sync(ctx, repo, target)
+		if err != nil {
+			return fmt.Errorf("sync checkpoint policy: %w", err)
+		}
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "checkpoint_version: %s\n", state.Policy.CheckpointVersion)
+	fmt.Fprintf(cmd.OutOrStdout(), "checkpoint_min_version: %s\n", state.Policy.CheckpointMinVersion)
+	fmt.Fprintf(cmd.OutOrStdout(), "source: %s\n", state.Source)
+	return nil
+}
+
+func hasPolicyCheckpointUpdate(opts policyCheckpointOptions) bool {
+	return opts.version != "" || opts.minVersion != ""
+}

--- a/cmd/entire/cli/policy_checkpoint_test.go
+++ b/cmd/entire/cli/policy_checkpoint_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,6 +81,29 @@ func TestPolicyCheckpointCmd_UpdatesAndPushesOnlyPolicyRef(t *testing.T) {
 
 	branches := runPolicyCheckpointGit(t, dir, "ls-remote", bareDir, "refs/heads/*")
 	require.Empty(t, strings.TrimSpace(branches))
+}
+
+func TestPolicyCheckpointCmd_SilencesContextCanceled(t *testing.T) {
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd.SetContext(ctx)
+
+	err := runPolicyCheckpoint(cmd, policyCheckpointOptions{})
+	require.ErrorIs(t, err, context.Canceled)
+	var silent *SilentError
+	require.ErrorAs(t, err, &silent, "error = %T %v, want SilentError", err, err)
+	require.Empty(t, stderr.String())
+}
+
+func TestPolicyCheckpointErrorSilencesWrappedContextCanceled(t *testing.T) {
+	err := policyCheckpointError("sync checkpoint policy", fmt.Errorf("remote: %w", context.Canceled))
+	require.ErrorIs(t, err, context.Canceled)
+	var silent *SilentError
+	require.ErrorAs(t, err, &silent, "error = %T %v, want SilentError", err, err)
 }
 
 func setupPolicyCheckpointRepo(t *testing.T) (string, string) {

--- a/cmd/entire/cli/policy_checkpoint_test.go
+++ b/cmd/entire/cli/policy_checkpoint_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyCheckpointCmd_PrintsDefaults(t *testing.T) {
+	_, _ = setupPolicyCheckpointRepo(t)
+
+	stdout, err := executePolicyCheckpointCmd(t)
+	require.NoError(t, err)
+	require.Contains(t, stdout, "checkpoint_version: branch-v1")
+	require.Contains(t, stdout, "checkpoint_min_version: branch-v1")
+	require.Contains(t, stdout, "source: defaults")
+}
+
+func TestPolicyCheckpointCmd_RejectsUnsupportedVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "checkpoint version", args: []string{"--checkpoint-version", "refs-v1"}, wantErr: "not write-supported"},
+		{name: "minimum version", args: []string{"--checkpoint-min-version", "refs-v1"}, wantErr: "not read-supported"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _ = setupPolicyCheckpointRepo(t)
+
+			_, err := executePolicyCheckpointCmd(t, tt.args...)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestPolicyCheckpointCmd_RejectsDowngradeWithoutForce(t *testing.T) {
+	dir, bareDir := setupPolicyCheckpointRepo(t)
+	seedPolicyForCheckpointCommand(t, dir, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "refs-v1",
+	})
+	pushCheckpointPolicyRefForCommandTest(t, dir, bareDir)
+
+	_, err := executePolicyCheckpointCmd(t, "--checkpoint-version", "branch-v1", "--checkpoint-min-version", "branch-v1")
+	require.ErrorContains(t, err, "would downgrade checkpoint_version")
+}
+
+func TestPolicyCheckpointCmd_UpdatesAndPushesOnlyPolicyRef(t *testing.T) {
+	dir, bareDir := setupPolicyCheckpointRepo(t)
+	testutil.WriteFile(t, dir, "README.md", "hello\n")
+	testutil.GitAdd(t, dir, "README.md")
+	testutil.GitCommit(t, dir, "init")
+
+	stdout, err := executePolicyCheckpointCmd(t, "--checkpoint-version", "branch-v1", "--checkpoint-min-version", "branch-v1")
+	require.NoError(t, err)
+	require.Contains(t, stdout, "checkpoint_version: branch-v1")
+	require.Contains(t, stdout, "checkpoint_min_version: branch-v1")
+	require.Contains(t, stdout, "source: remote")
+
+	remoteHash := checkpointPolicyRemoteHashForCommandTest(t, dir, bareDir)
+	require.False(t, remoteHash.IsZero())
+
+	repo := openPolicyCheckpointRepoForCommandTest(t, dir)
+	localState, err := checkpointpolicy.ReadLocal(t.Context(), repo)
+	require.NoError(t, err)
+	require.Equal(t, remoteHash, localState.Hash)
+
+	branches := runPolicyCheckpointGit(t, dir, "ls-remote", bareDir, "refs/heads/*")
+	require.Empty(t, strings.TrimSpace(branches))
+}
+
+func setupPolicyCheckpointRepo(t *testing.T) (string, string) {
+	t.Helper()
+	testutil.IsolateGitConfigEnv(t)
+	dir := setupTestDir(t)
+	testutil.InitRepo(t, dir)
+
+	bareDir := filepath.Join(t.TempDir(), "remote.git")
+	_, err := git.PlainInit(bareDir, true)
+	require.NoError(t, err)
+	runPolicyCheckpointGit(t, dir, "remote", "add", "origin", bareDir)
+	return dir, bareDir
+}
+
+func executePolicyCheckpointCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := newPolicyCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(append([]string{"checkpoint"}, args...))
+	cmd.SetContext(t.Context())
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	return stdout.String(), err
+}
+
+func seedPolicyForCheckpointCommand(t *testing.T, dir string, policy checkpointpolicy.Policy) plumbing.Hash {
+	t.Helper()
+	repo := openPolicyCheckpointRepoForCommandTest(t, dir)
+	hash, err := checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, policy)
+	require.NoError(t, err)
+	return hash
+}
+
+func openPolicyCheckpointRepoForCommandTest(t *testing.T, dir string) *git.Repository {
+	t.Helper()
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	return repo
+}
+
+func pushCheckpointPolicyRefForCommandTest(t *testing.T, dir, remote string) {
+	t.Helper()
+	refspec := checkpointpolicy.RefName.String() + ":" + checkpointpolicy.RefName.String()
+	runPolicyCheckpointGit(t, dir, "push", remote, refspec)
+}
+
+func checkpointPolicyRemoteHashForCommandTest(t *testing.T, dir, remote string) plumbing.Hash {
+	t.Helper()
+	output := runPolicyCheckpointGit(t, dir, "ls-remote", remote, checkpointpolicy.RefName.String())
+	fields := strings.Fields(output)
+	require.NotEmpty(t, fields, "missing remote checkpoint policy ref")
+	return plumbing.NewHash(fields[0])
+}
+
+func runPolicyCheckpointGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	return string(output)
+}

--- a/cmd/entire/cli/policy_group.go
+++ b/cmd/entire/cli/policy_group.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/spf13/cobra"
+)
+
+func newPolicyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy",
+		Short: "Manage repo-wide Entire policies",
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := paths.WorktreeRoot(cmd.Context()); err != nil {
+				return errors.New("not a git repository")
+			}
+			return nil
+		},
+	}
+	cmd.AddCommand(newPolicyCheckpointCmd())
+	return cmd
+}

--- a/cmd/entire/cli/policy_group.go
+++ b/cmd/entire/cli/policy_group.go
@@ -9,8 +9,9 @@ import (
 
 func newPolicyCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "policy",
-		Short: "Manage repo-wide Entire policies",
+		Use:    "policy",
+		Short:  "Manage repo-wide Entire policies",
+		Hidden: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if _, err := paths.WorktreeRoot(cmd.Context()); err != nil {
 				return errors.New("not a git repository")

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -340,11 +340,15 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 // the checkpoint with the latest CreatedAt.
 func resolveLatestCheckpoint(ctx context.Context, store checkpointInfoReader, checkpointIDs []id.CheckpointID) (*strategy.CheckpointInfo, bool, error) {
 	infoMap := make(map[id.CheckpointID]strategy.CheckpointInfo, len(checkpointIDs))
+	var unsupportedErr error
 	for _, cpID := range checkpointIDs {
 		metadata, readErr := readCheckpointInfoFromStore(ctx, store, cpID)
 		if readErr != nil {
 			if checkpointpolicy.IsUnsupportedVersion(readErr) {
-				return nil, false, readErr
+				if unsupportedErr == nil {
+					unsupportedErr = readErr
+				}
+				continue
 			}
 			logging.Debug(ctx, "resolveLatestCheckpoint: checkpoint metadata read failed",
 				slog.String("checkpoint_id", cpID.String()),
@@ -356,6 +360,9 @@ func resolveLatestCheckpoint(ctx context.Context, store checkpointInfoReader, ch
 	}
 	latest, found := strategy.ResolveLatestCheckpointFromMap(checkpointIDs, infoMap)
 	if !found {
+		if unsupportedErr != nil {
+			return nil, false, unsupportedErr
+		}
 		return nil, false, nil
 	}
 	return &latest, true, nil

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -15,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
@@ -358,6 +359,9 @@ func readCheckpointInfoFromStore(ctx context.Context, store checkpointInfoReader
 	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, store, checkpointID)
 	if err != nil {
 		return nil, fmt.Errorf("read checkpoint: %w", err)
+	}
+	if err := checkpointpolicy.EnsureCanReadVersion(checkpointID.String(), summary.CheckpointVersion); err != nil {
+		return nil, fmt.Errorf("check checkpoint version: %w", err)
 	}
 	info := &strategy.CheckpointInfo{
 		CheckpointID:     checkpointID,
@@ -942,7 +946,14 @@ func resumeSingleSession(ctx context.Context, w, _ io.Writer, ag agent.Agent, se
 	if err != nil {
 		return fmt.Errorf("open checkpoint store: %w", err)
 	}
-	logContent, _, err := checkpoint.ReadRawSessionLogForCheckpoint(ctx, stores.Primary, checkpointID)
+	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, stores.Primary, checkpointID)
+	if err == nil {
+		err = checkpointpolicy.EnsureCanReadVersion(checkpointID.String(), summary.CheckpointVersion)
+	}
+	var content *checkpoint.SessionContent
+	if err == nil {
+		content, err = checkpoint.ReadLatestSessionContent(ctx, stores.Primary, checkpointID, summary)
+	}
 	if err != nil {
 		if errors.Is(err, checkpoint.ErrCheckpointNotFound) || errors.Is(err, checkpoint.ErrNoTranscript) {
 			logging.Debug(ctx, "resume session completed (no metadata)",
@@ -961,6 +972,7 @@ func resumeSingleSession(ctx context.Context, w, _ io.Writer, ag agent.Agent, se
 		)
 		return fmt.Errorf("failed to get session log: %w", err)
 	}
+	logContent := content.Transcript
 
 	// By default, never overwrite a session log that already exists locally: the
 	// on-disk transcript is the live session the user is resuming, so we keep it

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -215,6 +215,9 @@ func resumeByCheckpointID(ctx context.Context, w, errW io.Writer, checkpointID i
 
 	metadata, err := readCheckpointInfoFromStore(ctx, store, checkpointID)
 	if err != nil {
+		if checkpointpolicy.IsUnsupportedVersion(err) {
+			return err
+		}
 		logging.Debug(ctx, "resume by checkpoint: metadata read failed, checking remote",
 			slog.String("checkpoint_id", checkpointID.String()),
 			slog.String("error", err.Error()),
@@ -284,12 +287,14 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 
 	// Multiple checkpoints (squash merge): resolve latest by CreatedAt timestamp.
 	if len(result.checkpointIDs) > 1 {
-		latestMetadata, err := resolveLatestCheckpoint(ctx, store, result.checkpointIDs)
+		latestMetadata, found, err := resolveLatestCheckpoint(ctx, store, result.checkpointIDs)
 		if err != nil {
+			return err
+		}
+		if !found {
 			// No metadata available — nothing to resume from
 			logging.Warn(logCtx, "resolveLatestCheckpoint failed",
 				slog.Int("checkpoint_count", len(result.checkpointIDs)),
-				slog.String("error", err.Error()),
 			)
 			fmt.Fprintf(w, "Found %d checkpoints for commit %s but metadata is not available\n",
 				len(result.checkpointIDs), result.commitHash[:7])
@@ -307,6 +312,9 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 		if storeErr == nil {
 			metadata = storeInfo
 		} else {
+			if checkpointpolicy.IsUnsupportedVersion(storeErr) {
+				return storeErr
+			}
 			logging.Debug(ctx, "checkpoint store metadata read failed",
 				slog.String("checkpoint_id", checkpointID.String()),
 				slog.String("error", storeErr.Error()),
@@ -330,11 +338,14 @@ func resumeFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName 
 
 // resolveLatestCheckpoint reads metadata for each checkpoint ID and returns
 // the checkpoint with the latest CreatedAt.
-func resolveLatestCheckpoint(ctx context.Context, store checkpointInfoReader, checkpointIDs []id.CheckpointID) (*strategy.CheckpointInfo, error) {
+func resolveLatestCheckpoint(ctx context.Context, store checkpointInfoReader, checkpointIDs []id.CheckpointID) (*strategy.CheckpointInfo, bool, error) {
 	infoMap := make(map[id.CheckpointID]strategy.CheckpointInfo, len(checkpointIDs))
 	for _, cpID := range checkpointIDs {
 		metadata, readErr := readCheckpointInfoFromStore(ctx, store, cpID)
 		if readErr != nil {
+			if checkpointpolicy.IsUnsupportedVersion(readErr) {
+				return nil, false, readErr
+			}
 			logging.Debug(ctx, "resolveLatestCheckpoint: checkpoint metadata read failed",
 				slog.String("checkpoint_id", cpID.String()),
 				slog.String("error", readErr.Error()),
@@ -345,9 +356,9 @@ func resolveLatestCheckpoint(ctx context.Context, store checkpointInfoReader, ch
 	}
 	latest, found := strategy.ResolveLatestCheckpointFromMap(checkpointIDs, infoMap)
 	if !found {
-		return nil, errors.New("no checkpoint metadata found")
+		return nil, false, nil
 	}
-	return &latest, nil
+	return &latest, true, nil
 }
 
 type checkpointInfoReader interface {

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
@@ -629,6 +630,58 @@ func TestResolveLatestCheckpointUsesCheckpointInfoReader(t *testing.T) {
 	}
 	if latest.CheckpointID != newID {
 		t.Errorf("resolveLatestCheckpoint() = %s, want %s", latest.CheckpointID, newID)
+	}
+}
+
+func TestResolveLatestCheckpointSkipsUnsupportedCheckpointWhenReadableCheckpointExists(t *testing.T) {
+	t.Parallel()
+
+	unsupportedID := id.MustCheckpointID("aaa111bbb222")
+	newID := id.MustCheckpointID("ccc333ddd444")
+	reader := &resumeCheckpointInfoReaderStub{
+		summaries: map[id.CheckpointID]*checkpoint.CheckpointSummary{
+			unsupportedID: {CheckpointVersion: "refs-v1"},
+			newID:         {Sessions: []checkpoint.SessionFilePaths{{Metadata: "new"}}},
+		},
+		metadata: map[id.CheckpointID][]checkpoint.CommittedMetadata{
+			newID: {{
+				SessionID: "new-session",
+				CreatedAt: time.Date(2025, 1, 1, 11, 0, 0, 0, time.UTC),
+			}},
+		},
+	}
+
+	latest, found, err := resolveLatestCheckpoint(context.Background(), reader, []id.CheckpointID{unsupportedID, newID})
+	if err != nil {
+		t.Fatalf("resolveLatestCheckpoint() error = %v", err)
+	}
+	if !found {
+		t.Fatal("resolveLatestCheckpoint() found = false")
+	}
+	if latest.CheckpointID != newID {
+		t.Errorf("resolveLatestCheckpoint() = %s, want %s", latest.CheckpointID, newID)
+	}
+}
+
+func TestResolveLatestCheckpointReturnsUnsupportedWhenNoReadableCheckpointExists(t *testing.T) {
+	t.Parallel()
+
+	unsupportedID := id.MustCheckpointID("aaa111bbb222")
+	reader := &resumeCheckpointInfoReaderStub{
+		summaries: map[id.CheckpointID]*checkpoint.CheckpointSummary{
+			unsupportedID: {CheckpointVersion: "refs-v1"},
+		},
+	}
+
+	_, found, err := resolveLatestCheckpoint(context.Background(), reader, []id.CheckpointID{unsupportedID})
+	if err == nil {
+		t.Fatal("resolveLatestCheckpoint() error = nil, want unsupported version")
+	}
+	if found {
+		t.Fatal("resolveLatestCheckpoint() found = true")
+	}
+	if !checkpointpolicy.IsUnsupportedVersion(err) {
+		t.Fatalf("resolveLatestCheckpoint() error = %v, want unsupported version", err)
 	}
 }
 

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -571,9 +571,12 @@ func TestResolveLatestCheckpoint(t *testing.T) {
 	// simulating git CLI squash merge trailer order.
 	reverseOrderIDs := []id.CheckpointID{cpID3, cpID2, cpID1}
 	reader := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
-	latest, err := resolveLatestCheckpoint(context.Background(), reader, reverseOrderIDs)
+	latest, found, err := resolveLatestCheckpoint(context.Background(), reader, reverseOrderIDs)
 	if err != nil {
 		t.Fatalf("resolveLatestCheckpoint() error = %v", err)
+	}
+	if !found {
+		t.Fatal("resolveLatestCheckpoint() found = false")
 	}
 
 	// Should return the newest checkpoint regardless of input order
@@ -583,9 +586,12 @@ func TestResolveLatestCheckpoint(t *testing.T) {
 
 	// Also verify with chronological order
 	chronologicalIDs := []id.CheckpointID{cpID1, cpID2, cpID3}
-	latest2, err := resolveLatestCheckpoint(context.Background(), reader, chronologicalIDs)
+	latest2, found, err := resolveLatestCheckpoint(context.Background(), reader, chronologicalIDs)
 	if err != nil {
 		t.Fatalf("resolveLatestCheckpoint() error = %v", err)
+	}
+	if !found {
+		t.Fatal("resolveLatestCheckpoint() found = false")
 	}
 	if latest2.CheckpointID.String() != cpID3.String() {
 		t.Errorf("resolveLatestCheckpoint() = %s, want newest %s", latest2.CheckpointID, cpID3)
@@ -614,9 +620,12 @@ func TestResolveLatestCheckpointUsesCheckpointInfoReader(t *testing.T) {
 		},
 	}
 
-	latest, err := resolveLatestCheckpoint(context.Background(), reader, []id.CheckpointID{oldID, newID})
+	latest, found, err := resolveLatestCheckpoint(context.Background(), reader, []id.CheckpointID{oldID, newID})
 	if err != nil {
 		t.Fatalf("resolveLatestCheckpoint() error = %v", err)
+	}
+	if !found {
+		t.Fatal("resolveLatestCheckpoint() found = false")
 	}
 	if latest.CheckpointID != newID {
 		t.Errorf("resolveLatestCheckpoint() = %s, want %s", latest.CheckpointID, newID)
@@ -716,9 +725,12 @@ func TestResolveLatestCheckpointUsesV1Checkpoint(t *testing.T) {
 
 	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
 
-	latest, err := resolveLatestCheckpoint(context.Background(), store, []id.CheckpointID{targetID})
+	latest, found, err := resolveLatestCheckpoint(context.Background(), store, []id.CheckpointID{targetID})
 	if err != nil {
 		t.Fatalf("resolveLatestCheckpoint() error = %v", err)
+	}
+	if !found {
+		t.Fatal("resolveLatestCheckpoint() found = false")
 	}
 	if latest.CheckpointID != targetID {
 		t.Errorf("resolveLatestCheckpoint() = %s, want %s", latest.CheckpointID, targetID)

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -18,6 +18,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
@@ -330,9 +331,12 @@ func runRewindInteractive(ctx context.Context, w, errW io.Writer) error { //noli
 	var restored bool
 	if !selectedPoint.CheckpointID.IsEmpty() {
 		// Try checkpoint storage first for committed checkpoints
-		if returnedSessionID, err := restoreSessionTranscriptFromStrategy(ctx, selectedPoint.CheckpointID, sessionID, agent); err == nil {
+		returnedSessionID, err := restoreSessionTranscriptFromStrategy(ctx, selectedPoint.CheckpointID, sessionID, agent)
+		if err == nil {
 			sessionID = returnedSessionID
 			restored = true
+		} else if checkpointpolicy.IsUnsupportedVersion(err) {
+			return err
 		}
 	}
 
@@ -533,9 +537,12 @@ func runRewindToInternal(ctx context.Context, w, errW io.Writer, commitID string
 	var restored bool
 	if !selectedPoint.CheckpointID.IsEmpty() {
 		// Try checkpoint storage first for committed checkpoints
-		if returnedSessionID, err := restoreSessionTranscriptFromStrategy(ctx, selectedPoint.CheckpointID, sessionID, agent); err == nil {
+		returnedSessionID, err := restoreSessionTranscriptFromStrategy(ctx, selectedPoint.CheckpointID, sessionID, agent)
+		if err == nil {
 			sessionID = returnedSessionID
 			restored = true
+		} else if checkpointpolicy.IsUnsupportedVersion(err) {
+			return err
 		}
 	}
 
@@ -722,13 +729,22 @@ func restoreSessionTranscriptFromStrategy(ctx context.Context, cpID id.Checkpoin
 	if err != nil {
 		return "", fmt.Errorf("open checkpoint store: %w", err)
 	}
-	content, returnedSessionID, err := checkpoint.ReadRawSessionLogForCheckpoint(ctx, stores.Primary, cpID)
+	summary, err := checkpoint.ReadCommittedCheckpoint(ctx, stores.Primary, cpID)
+	if err != nil {
+		return "", fmt.Errorf("failed to read checkpoint: %w", err)
+	}
+	if err := checkpointpolicy.EnsureCanReadVersion(cpID.String(), summary.CheckpointVersion); err != nil {
+		return "", fmt.Errorf("check checkpoint version: %w", err)
+	}
+
+	content, err := checkpoint.ReadLatestSessionContent(ctx, stores.Primary, cpID, summary)
 	if err != nil {
 		return "", fmt.Errorf("failed to get session log: %w", err)
 	}
 
 	// Use session ID returned from checkpoint if available
 	// Otherwise fall back to the passed-in sessionID
+	returnedSessionID := content.Metadata.SessionID
 	if returnedSessionID != "" {
 		sessionID = returnedSessionID
 	}
@@ -744,7 +760,7 @@ func restoreSessionTranscriptFromStrategy(ctx context.Context, cpID id.Checkpoin
 		SessionID:  sessionID,
 		AgentName:  agent.Name(),
 		SessionRef: sessionFile,
-		NativeData: content,
+		NativeData: content.Transcript,
 	}
 	if err := agent.WriteSession(ctx, agentSession); err != nil {
 		return "", fmt.Errorf("failed to write session: %w", err)

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -84,6 +84,7 @@ func NewRootCmd() *cobra.Command {
 	// Noun groups (canonical homes for subcommands).
 	cmd.AddCommand(newSessionsCmd())        // 'session' (with 'sessions' as Cobra alias)
 	cmd.AddCommand(newCheckpointGroupCmd()) // 'checkpoint' / 'cp' / 'checkpoints'
+	cmd.AddCommand(newPolicyCmd())          // 'policy'
 	cmd.AddCommand(newAgentGroupCmd())      // 'agent'
 	cmd.AddCommand(newAuthCmd())            // 'auth'
 	cmd.AddCommand(newDoctorCmd())          // 'doctor' (group: trace/logs/bundle)

--- a/cmd/entire/cli/root_test.go
+++ b/cmd/entire/cli/root_test.go
@@ -234,6 +234,28 @@ func TestCheckpointSearchIsVisibleButTopLevelSearchIsHidden(t *testing.T) {
 	}
 }
 
+func TestPolicyCommandIsHiddenDuringDevelopment(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd()
+
+	policy, _, err := root.Find([]string{"policy"})
+	if err != nil {
+		t.Fatalf("find policy command: %v", err)
+	}
+	if !policy.Hidden {
+		t.Fatal("policy command should be hidden while it is in active development")
+	}
+
+	checkpointPolicy, _, err := root.Find([]string{"policy", "checkpoint"})
+	if err != nil {
+		t.Fatalf("find policy checkpoint command: %v", err)
+	}
+	if checkpointPolicy.Hidden {
+		t.Fatal("policy checkpoint should remain invokable through the hidden policy group")
+	}
+}
+
 func containsString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {

--- a/cmd/entire/cli/strategy/checkpoint_policy.go
+++ b/cmd/entire/cli/strategy/checkpoint_policy.go
@@ -28,7 +28,7 @@ func committedCheckpointWriteAllowed(ctx context.Context, repo *git.Repository) 
 	return false
 }
 
-func syncCheckpointPolicyForPrePush(ctx context.Context, remoteName string) bool {
+func syncCheckpointPolicyForPrePush(ctx context.Context) bool {
 	repo, err := OpenRepository(ctx)
 	if err != nil {
 		logging.Warn(ctx, "checkpoint policy pre-push: failed to open repository; allowing checkpoint push",
@@ -38,7 +38,7 @@ func syncCheckpointPolicyForPrePush(ctx context.Context, remoteName string) bool
 	}
 	defer repo.Close()
 
-	target, err := checkpointpolicy.ResolveTarget(ctx, remoteName)
+	target, err := checkpointpolicy.ResolveTarget(ctx)
 	if err != nil {
 		logging.Warn(ctx, "checkpoint policy pre-push: failed to resolve policy remote; allowing checkpoint push",
 			slog.String("error", err.Error()),

--- a/cmd/entire/cli/strategy/checkpoint_policy.go
+++ b/cmd/entire/cli/strategy/checkpoint_policy.go
@@ -73,7 +73,12 @@ func warnOrLogCheckpointPolicySyncFailure(ctx context.Context, err error) {
 
 func warnOrLogCheckpointPolicyDiverged(ctx context.Context, state checkpointpolicy.State) {
 	if interactive.CanPromptInteractively() {
-		fmt.Fprintf(stderrWriter, "[entire] Could not reconcile checkpoint policy: %s\n", state.Warning)
+		fmt.Fprintf(
+			stderrWriter,
+			"[entire] Could not reconcile checkpoint policy: local checkpoint policy %s diverges from remote %s\n",
+			state.Hash,
+			state.RemoteHash,
+		)
 		return
 	}
 	logging.Warn(ctx, "checkpoint policy diverged; skipping checkpoint push",

--- a/cmd/entire/cli/strategy/checkpoint_policy.go
+++ b/cmd/entire/cli/strategy/checkpoint_policy.go
@@ -1,0 +1,80 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+	"github.com/go-git/go-git/v6"
+)
+
+func committedCheckpointWriteAllowed(ctx context.Context, repo *git.Repository) bool {
+	state, err := checkpointpolicy.ReadLocal(ctx, repo)
+	if err != nil {
+		logging.Warn(ctx, "checkpoint policy read failed; allowing checkpoint write",
+			slog.String("error", err.Error()),
+		)
+		return true
+	}
+	if !checkpointpolicy.UnsupportedWrite(state.Policy) {
+		return true
+	}
+	warnOrLogUnsupportedCheckpointWrite(ctx, state.Policy)
+	return false
+}
+
+func syncCheckpointPolicyForPrePush(ctx context.Context, remoteName string) bool {
+	repo, err := OpenRepository(ctx)
+	if err != nil {
+		logging.Warn(ctx, "checkpoint policy pre-push: failed to open repository; allowing checkpoint push",
+			slog.String("error", err.Error()),
+		)
+		return true
+	}
+	defer repo.Close()
+
+	target, err := checkpointpolicy.ResolveTarget(ctx, remoteName)
+	if err != nil {
+		logging.Warn(ctx, "checkpoint policy pre-push: failed to resolve policy remote; allowing checkpoint push",
+			slog.String("error", err.Error()),
+		)
+		return true
+	}
+	state, err := checkpointpolicy.Sync(ctx, repo, target)
+	if err != nil {
+		warnOrLogCheckpointPolicySyncFailure(ctx, err)
+		return true
+	}
+	if !checkpointpolicy.UnsupportedWrite(state.Policy) {
+		return true
+	}
+	warnOrLogUnsupportedCheckpointWrite(ctx, state.Policy)
+	return false
+}
+
+func warnOrLogCheckpointPolicySyncFailure(ctx context.Context, err error) {
+	if interactive.CanPromptInteractively() {
+		fmt.Fprintf(stderrWriter, "[entire] Could not refresh checkpoint policy: %v\n", err)
+		return
+	}
+	logging.Warn(ctx, "checkpoint policy sync failed",
+		slog.String("error", err.Error()),
+	)
+}
+
+func warnOrLogUnsupportedCheckpointWrite(ctx context.Context, policy checkpointpolicy.Policy) {
+	warning := checkpointpolicy.UpgradeWarning(versioncheck.UpdateCommandForCurrentBinary(versioninfo.Version))
+	if interactive.CanPromptInteractively() {
+		fmt.Fprint(stderrWriter, warning)
+		return
+	}
+	logging.Warn(ctx, "checkpoint write skipped by policy",
+		slog.String("checkpoint_version", policy.CheckpointVersion),
+		slog.String("checkpoint_min_version", policy.CheckpointMinVersion),
+	)
+}

--- a/cmd/entire/cli/strategy/checkpoint_policy.go
+++ b/cmd/entire/cli/strategy/checkpoint_policy.go
@@ -50,6 +50,10 @@ func syncCheckpointPolicyForPrePush(ctx context.Context, remoteName string) bool
 		warnOrLogCheckpointPolicySyncFailure(ctx, err)
 		return true
 	}
+	if state.Source == checkpointpolicy.SourceLocalDiverged {
+		warnOrLogCheckpointPolicyDiverged(ctx, state)
+		return false
+	}
 	if !checkpointpolicy.UnsupportedWrite(state.Policy) {
 		return true
 	}
@@ -64,6 +68,17 @@ func warnOrLogCheckpointPolicySyncFailure(ctx context.Context, err error) {
 	}
 	logging.Warn(ctx, "checkpoint policy sync failed",
 		slog.String("error", err.Error()),
+	)
+}
+
+func warnOrLogCheckpointPolicyDiverged(ctx context.Context, state checkpointpolicy.State) {
+	if interactive.CanPromptInteractively() {
+		fmt.Fprintf(stderrWriter, "[entire] Could not reconcile checkpoint policy: %s\n", state.Warning)
+		return
+	}
+	logging.Warn(ctx, "checkpoint policy diverged; skipping checkpoint push",
+		slog.String("local_hash", state.Hash.String()),
+		slog.String("remote_hash", state.RemoteHash.String()),
 	)
 }
 

--- a/cmd/entire/cli/strategy/checkpoint_policy_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_policy_test.go
@@ -1,0 +1,62 @@
+package strategy
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrePushSkipsCheckpointPushWhenPolicyWriteUnsupported(t *testing.T) {
+	workDir := setupRepoWithCheckpointBranch(t)
+	bareDir := filepath.Join(t.TempDir(), "remote.git")
+	_, err := git.PlainInit(bareDir, true)
+	require.NoError(t, err)
+	runCheckpointPolicyGit(t, workDir, "remote", "add", "origin", bareDir)
+
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	_, err = checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "branch-v1",
+	})
+	require.NoError(t, err)
+
+	t.Chdir(workDir)
+	paths.ClearWorktreeRootCache()
+	t.Setenv(interactive.EnvTestTTY, "1")
+	oldWriter := stderrWriter
+	var stderr bytes.Buffer
+	stderrWriter = &stderr
+	t.Cleanup(func() { stderrWriter = oldWriter })
+
+	err = NewManualCommitStrategy().PrePush(context.Background(), "origin")
+	require.NoError(t, err)
+	require.Contains(t, stderr.String(), "requires checkpoint support newer than this Entire CLI")
+
+	out := runCheckpointPolicyGit(t, workDir, "ls-remote", bareDir, "refs/heads/"+paths.MetadataBranchName)
+	require.Empty(t, strings.TrimSpace(out))
+}
+
+func runCheckpointPolicyGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = testutil.GitIsolatedEnv()
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	return string(output)
+}

--- a/cmd/entire/cli/strategy/checkpoint_policy_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_policy_test.go
@@ -51,6 +51,48 @@ func TestPrePushSkipsCheckpointPushWhenPolicyWriteUnsupported(t *testing.T) {
 	require.Empty(t, strings.TrimSpace(out))
 }
 
+func TestPrePushSkipsCheckpointPushWhenPolicyDiverged(t *testing.T) {
+	workDir := setupRepoWithCheckpointBranch(t)
+	bareDir := filepath.Join(t.TempDir(), "remote.git")
+	_, err := git.PlainInit(bareDir, true)
+	require.NoError(t, err)
+	runCheckpointPolicyGit(t, workDir, "remote", "add", "origin", bareDir)
+
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = repo.Close()
+	})
+	baseHash, err := checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+	runCheckpointPolicyGit(t, workDir, "push", bareDir, checkpointpolicy.RefName.String()+":"+checkpointpolicy.RefName.String())
+
+	localHash, err := checkpointpolicy.WriteLocal(t.Context(), repo, baseHash, checkpointpolicy.DefaultPolicy())
+	require.NoError(t, err)
+	_, err = checkpointpolicy.WriteLocal(t.Context(), repo, baseHash, checkpointpolicy.Policy{
+		CheckpointVersion:    "refs-v1",
+		CheckpointMinVersion: "branch-v1",
+	})
+	require.NoError(t, err)
+	runCheckpointPolicyGit(t, workDir, "push", bareDir, checkpointpolicy.RefName.String()+":"+checkpointpolicy.RefName.String())
+	require.NoError(t, checkpointpolicy.SetRef(repo, checkpointpolicy.RefName, localHash))
+
+	t.Chdir(workDir)
+	paths.ClearWorktreeRootCache()
+	t.Setenv(interactive.EnvTestTTY, "1")
+	oldWriter := stderrWriter
+	var stderr bytes.Buffer
+	stderrWriter = &stderr
+	t.Cleanup(func() { stderrWriter = oldWriter })
+
+	err = NewManualCommitStrategy().PrePush(context.Background(), "origin")
+	require.NoError(t, err)
+	require.Contains(t, stderr.String(), "Could not reconcile checkpoint policy")
+
+	out := runCheckpointPolicyGit(t, workDir, "ls-remote", bareDir, "refs/heads/"+paths.MetadataBranchName)
+	require.Empty(t, strings.TrimSpace(out))
+}
+
 func runCheckpointPolicyGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.CommandContext(context.Background(), "git", args...)

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -52,7 +52,7 @@ func (s *ManualCommitStrategy) getCheckpointStores(ctx context.Context, repo *gi
 // topology. Writes target refs.Primary; reads target refs.Read. The strategy's
 // blob fetcher is wired in so reads can fetch blobs on demand after a treeless
 // fetch.
-func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git.Repository) (checkpoint.CommittedStore, error) { //nolint:ireturn // committed store capability is the abstraction boundary
+func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git.Repository) (checkpoint.CommittedStore, error) {
 	stores, err := s.getCheckpointStores(ctx, repo)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git
 
 // getTemporaryStore returns the git-backed shadow-branch store with the
 // strategy's blob fetcher wired in.
-func (s *ManualCommitStrategy) getTemporaryStore(ctx context.Context, repo *git.Repository) (checkpoint.TemporaryStore, error) { //nolint:ireturn // temporary store capability is the abstraction boundary
+func (s *ManualCommitStrategy) getTemporaryStore(ctx context.Context, repo *git.Repository) (checkpoint.TemporaryStore, error) {
 	stores, err := s.getCheckpointStores(ctx, repo)
 	if err != nil {
 		return nil, err

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -52,7 +52,7 @@ func (s *ManualCommitStrategy) getCheckpointStores(ctx context.Context, repo *gi
 // topology. Writes target refs.Primary; reads target refs.Read. The strategy's
 // blob fetcher is wired in so reads can fetch blobs on demand after a treeless
 // fetch.
-func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git.Repository) (checkpoint.CommittedStore, error) {
+func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git.Repository) (checkpoint.CommittedStore, error) { //nolint:ireturn // committed store capability is the abstraction boundary
 	stores, err := s.getCheckpointStores(ctx, repo)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git
 
 // getTemporaryStore returns the git-backed shadow-branch store with the
 // strategy's blob fetcher wired in.
-func (s *ManualCommitStrategy) getTemporaryStore(ctx context.Context, repo *git.Repository) (checkpoint.TemporaryStore, error) {
+func (s *ManualCommitStrategy) getTemporaryStore(ctx context.Context, repo *git.Repository) (checkpoint.TemporaryStore, error) { //nolint:ireturn // temporary store capability is the abstraction boundary
 	stores, err := s.getCheckpointStores(ctx, repo)
 	if err != nil {
 		return nil, err

--- a/cmd/entire/cli/strategy/manual_commit.go
+++ b/cmd/entire/cli/strategy/manual_commit.go
@@ -62,7 +62,7 @@ func (s *ManualCommitStrategy) getCheckpointStore(ctx context.Context, repo *git
 
 // getTemporaryStore returns the git-backed shadow-branch store with the
 // strategy's blob fetcher wired in.
-func (s *ManualCommitStrategy) getTemporaryStore(ctx context.Context, repo *git.Repository) (checkpoint.TemporaryStore, error) { //nolint:ireturn // temporary store capability is the abstraction boundary
+func (s *ManualCommitStrategy) getTemporaryStore(ctx context.Context, repo *git.Repository) (checkpoint.TemporaryStore, error) {
 	stores, err := s.getCheckpointStores(ctx, repo)
 	if err != nil {
 		return nil, err

--- a/cmd/entire/cli/strategy/manual_commit_condensation.go
+++ b/cmd/entire/cli/strategy/manual_commit_condensation.go
@@ -147,6 +147,9 @@ func (s *ManualCommitStrategy) CondenseSession(ctx context.Context, repo *git.Re
 	}
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	condenseStart := time.Now()
+	if !committedCheckpointWriteAllowed(ctx, repo) {
+		return newSkippedResult(checkpointID, state.SessionID), nil
+	}
 
 	shadowBranchName := getShadowBranchNameForCommit(state.BaseCommit, state.WorktreeID)
 	ref, hasShadowBranch := resolveShadowRef(repo, shadowBranchName, o.shadowRef)

--- a/cmd/entire/cli/strategy/manual_commit_hooks.go
+++ b/cmd/entire/cli/strategy/manual_commit_hooks.go
@@ -2762,6 +2762,10 @@ func (s *ManualCommitStrategy) finalizeAllTurnCheckpoints(ctx context.Context, s
 		return 1 // Count as error - all checkpoints will be skipped
 	}
 	defer repo.Close()
+	if !committedCheckpointWriteAllowed(ctx, repo) {
+		state.TurnCheckpointIDs = nil
+		return 0
+	}
 
 	prompts := readPromptsFromShadowBranch(ctx, repo, state)
 	if len(prompts) == 0 {

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -44,6 +44,9 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 	}
 
 	refs := checkpoint.ResolveCommittedRefs(ctx)
+	if !syncCheckpointPolicyForPrePush(ctx, remote) {
+		return nil
+	}
 
 	// OPF pre-push rewrite: if OPF is configured, resolve the user's
 	// decision (env > settings > prompt > non-TTY auto-run), then

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -44,7 +44,7 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 	}
 
 	refs := checkpoint.ResolveCommittedRefs(ctx)
-	if !syncCheckpointPolicyForPrePush(ctx, remote) {
+	if !syncCheckpointPolicyForPrePush(ctx) {
 		return nil
 	}
 

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -16,6 +16,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 	cpkg "github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/osroot"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
@@ -650,6 +651,9 @@ func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.W
 	summary, err := cpkg.ReadCommittedCheckpoint(ctx, store, point.CheckpointID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read checkpoint: %w", err)
+	}
+	if err := checkpointpolicy.EnsureCanReadVersion(point.CheckpointID.String(), summary.CheckpointVersion); err != nil {
+		return nil, fmt.Errorf("check checkpoint version: %w", err)
 	}
 
 	// Get worktree root for agent session directory lookup

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -410,6 +410,10 @@ func updateCommand(currentVersion string) string {
 	return "curl -fsSL https://entire.io/install.sh | bash"
 }
 
+func UpdateCommandForCurrentBinary(currentVersion string) string {
+	return updateCommand(currentVersion)
+}
+
 // printNotification prints the version update notification to the user.
 func printNotification(w io.Writer, current, latest string) {
 	fmt.Fprintf(w, "\nUpdate available! %s -> %s\nRelease notes: %s\n",

--- a/cmd/entire/cli/versioncheck/versioncheck.go
+++ b/cmd/entire/cli/versioncheck/versioncheck.go
@@ -411,6 +411,9 @@ func updateCommand(currentVersion string) string {
 }
 
 func UpdateCommandForCurrentBinary(currentVersion string) string {
+	if !canAutoInstall() {
+		return downloadsURL
+	}
 	return updateCommand(currentVersion)
 }
 

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -423,6 +423,15 @@ func TestUpdateCommand(t *testing.T) {
 	}
 }
 
+func TestUpdateCommandForCurrentBinary(t *testing.T) {
+	t.Parallel()
+
+	got := UpdateCommandForCurrentBinary("1.2.3")
+	if got == "" {
+		t.Fatal("UpdateCommandForCurrentBinary returned empty command")
+	}
+}
+
 // setupCheckAndNotifyTest points the global config dir at a per-test temp
 // dir and overrides githubAPIURL. Returns a cobra.Command with captured
 // stdout and a cleanup function.

--- a/cmd/entire/cli/versioncheck/versioncheck_test.go
+++ b/cmd/entire/cli/versioncheck/versioncheck_test.go
@@ -346,6 +346,8 @@ func TestParseGitHubRelease(t *testing.T) {
 // it without tripping goconst on repeated string literals.
 const brewUpgradeCmd = "brew upgrade entire"
 
+const scoopExecutablePath = `C:\Users\test\scoop\apps\cli\current\entire.exe`
+
 func TestUpdateCommand(t *testing.T) {
 	const plainBinPath = "/usr/local/bin/entire"
 	tests := []struct {
@@ -387,7 +389,7 @@ func TestUpdateCommand(t *testing.T) {
 		{
 			name:           "scoop path",
 			currentVersion: "1.0.0",
-			execPath:       func() (string, error) { return `C:\Users\test\scoop\apps\cli\current\entire.exe`, nil },
+			execPath:       func() (string, error) { return scoopExecutablePath, nil },
 			want:           "scoop update entire/cli",
 		},
 		{
@@ -424,11 +426,50 @@ func TestUpdateCommand(t *testing.T) {
 }
 
 func TestUpdateCommandForCurrentBinary(t *testing.T) {
-	t.Parallel()
+	tests := []struct {
+		name           string
+		currentVersion string
+		goos           string
+		execPath       func() (string, error)
+		want           string
+	}{
+		{
+			name:           "known installer returns command",
+			currentVersion: "1.2.3",
+			goos:           goosWindows,
+			execPath:       func() (string, error) { return scoopExecutablePath, nil },
+			want:           "scoop update entire/cli",
+		},
+		{
+			name:           "windows unknown installer returns releases URL",
+			currentVersion: "1.2.3",
+			goos:           goosWindows,
+			execPath:       func() (string, error) { return `C:\Program Files\Entire\entire.exe`, nil },
+			want:           downloadsURL,
+		},
+		{
+			name:           "non-windows unknown installer returns curl command",
+			currentVersion: "1.2.3",
+			goos:           "linux",
+			execPath:       func() (string, error) { return "/usr/local/bin/entire", nil },
+			want:           "curl -fsSL https://entire.io/install.sh | bash",
+		},
+	}
 
-	got := UpdateCommandForCurrentBinary("1.2.3")
-	if got == "" {
-		t.Fatal("UpdateCommandForCurrentBinary returned empty command")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalExecPath := executablePath
+			executablePath = tt.execPath
+			t.Cleanup(func() { executablePath = originalExecPath })
+
+			originalGOOS := goos
+			goos = tt.goos
+			t.Cleanup(func() { goos = originalGOOS })
+
+			if got := UpdateCommandForCurrentBinary(tt.currentVersion); got != tt.want {
+				t.Errorf("UpdateCommandForCurrentBinary() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -87,6 +87,9 @@ func main() {
 		cancel()
 		os.Exit(1)
 	}
+	if cli.ShouldCheckCheckpointPolicyWarning(executed) {
+		cli.WarnCheckpointPolicyIfNeeded(ctx, rootCmd.ErrOrStderr(), versioninfo.Version)
+	}
 	cancel() // Cleanup on successful exit
 }
 

--- a/docs/architecture/sessions-and-checkpoints.md
+++ b/docs/architecture/sessions-and-checkpoints.md
@@ -278,6 +278,41 @@ When condensing multiple concurrent sessions:
 - `sessions` array in `CheckpointSummary` maps each session to its file paths
 - `files_touched` is merged from all sessions
 
+### Checkpoint Policy
+
+Repo-wide checkpoint policy lives at `refs/entire/policies/checkpoint`. The ref
+points at a commit whose tree contains `policy.json`:
+
+```json
+{
+  "checkpoint_version": "branch-v1",
+  "checkpoint_min_version": "branch-v1"
+}
+```
+
+`checkpoint_version` is the checkpoint format new writes should use.
+`checkpoint_min_version` is the oldest checkpoint format clients must be able
+to read for this repo. Missing policy fields default to `branch-v1`.
+
+Policy follows the configured checkpoint remote. `entire policy checkpoint`
+fetches the latest remote policy before validating requested changes, updates
+the local policy ref, and pushes only `refs/entire/policies/checkpoint`.
+Policy commits use the same signing settings as checkpoint commits.
+
+Hooks that run while ordinary git operations must keep working offline:
+post-commit and agent lifecycle hooks read only the local policy ref. If the
+local policy requires checkpoint writes this CLI does not support, they skip
+writing checkpoint data and warn only when running in an interactive terminal.
+The pre-push hook is the regular online sync point: it compares the remote
+policy ref with the local ref, fetches updated policy when needed, and evaluates
+the refreshed policy before pushing `entire/checkpoints/v1`. If policy refresh
+fails, the hook warns or logs the failure and lets the normal push continue.
+
+User-driven commands warn when the local policy indicates the CLI should be
+upgraded. Commands that need to decode checkpoint contents, such as
+`entire checkpoint explain` and `entire session resume`, fail when the target
+checkpoint uses an unsupported `checkpoint_version`.
+
 ### Checkpoint ID Linking
 
 The checkpoint ID is the **stable identifier** that links user commits to metadata across branches.


### PR DESCRIPTION
**Why**

Repositories need a repo-wide checkpoint policy so older CLIs can warn users before writing incompatible checkpoint data, and user-driven commands can fail clearly when they cannot decode a checkpoint format.

**Usage Examples**

The policy command is hidden while the surface is still in active development, but it is callable directly.

Inspect the current effective policy:

```bash
entire policy checkpoint
```

Example output:

```text
checkpoint_version: branch-v1
checkpoint_min_version: branch-v1
source: remote
```

Set the checkpoint version the repo should write:

```bash
entire policy checkpoint --checkpoint-version branch-v1
```

Set the minimum checkpoint version required by the repo:

```bash
entire policy checkpoint --checkpoint-min-version branch-v1
```

Set both values in one update:

```bash
entire policy checkpoint --checkpoint-version branch-v1 --checkpoint-min-version branch-v1
```

Allow an explicit downgrade:

```bash
entire policy checkpoint --checkpoint-version branch-v1 --checkpoint-min-version branch-v1 --force
```

On updates, the command refreshes the latest policy from the configured checkpoint remote, validates the requested change against the current CLI capabilities, updates the local `refs/entire/policies/checkpoint` ref, and pushes only that policy ref.

**What Changed**

This adds a checkpoint policy stored in `refs/entire/policies/checkpoint`, backed by a versionable commit containing `policy.json`. Policy commits follow the existing checkpoint commit-signing settings when signing is configured. If no signing is configured, policy commits are not signed.

The PR adds hidden `entire policy checkpoint` commands for inspection and updates, applies compatibility warnings to user-driven commands, and teaches hooks and pre-push to respect the policy without breaking ordinary git workflows.

**Technical Tradeoffs**

- Store policy in a Git ref instead of `.entire/settings.json`: this makes the policy repo-wide, versionable, and compatible with commit signing, but it adds Git ref sync and divergence handling.
- Reuse the existing checkpoint remote resolver: policy commands and hooks now resolve the same repo-wide checkpoint remote instead of adding a separate remote-selection path. This assumes policy belongs with checkpoint storage, not with the current branch or current push remote.
- Keep offline hooks non-networked: post-commit and agent lifecycle hooks read only the local policy so normal Git usage works offline. The tradeoff is that those hooks can act on a stale local policy until an explicit policy command or pre-push refreshes it.
- Make hooks warn or skip instead of fail: hook-triggered writes may come from agents or editor integrations, so incompatible write policy skips checkpoint persistence and warns only in interactive terminals. User-driven read commands fail when they cannot decode checkpoint data.
- Avoid a SemVer dependency for now: checkpoint formats are parsed as family plus numeric major version. This keeps the implementation small while current support is limited to `branch-v1`.
- Defer policy signature verification: this PR writes policy commits through the existing checkpoint signing path when signing is configured, but readers do not verify signatures before accepting a policy ref.
- Hide the new command group during development: the command is usable for rollout and testing, but it is not advertised in help while the CLI surface is still settling.

**Decisions And Assumptions**

- Use policy terminology instead of config terminology because this state is stored in Git, not local JSON settings.
- Use `entire policy checkpoint` rather than `entire configure` so users do not expect `.entire/settings.json` to change.
- Use the singular ref `refs/entire/policies/checkpoint`, aligned with the singular `policy checkpoint` command.
- Keep version numbers out of the ref name so future policy format changes are represented by committed content rather than ref namespace churn.
- Treat missing checkpoint versions as `branch-v1`; that behavior comes from the predecessor checkpoint-version PR.
- Only allow configuring checkpoint versions supported by the current CLI. Downgrades are rejected unless `--force` is provided.
- Use pre-push as the regular online policy refresh point because Git workflows should remain functional offline and pre-push already requires remote access.
- Fetch the remote policy before applying updates so local changes are validated against the latest remote state.
- Push only the policy ref after policy updates, not the broader checkpoint refs.
- Consider `branch-v1` readable and writable today. Known future families such as `refs-v1` are parsed but treated as unsupported until this CLI learns to read or write them.

**Reviewer Notes**

The policy flow intentionally follows the configured checkpoint remote. For repos with a separate checkpoint storage remote, this may differ from the ordinary Git `origin`, and that should be called out during rollout.

Policy commit signature verification is intentionally out of scope for this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint write/read paths across hooks, pre-push, attach, resume, and explain—incorrect policy sync or enforcement could skip metadata pushes or block legitimate workflows, but behavior is largely fail-closed with tests and offline hook fallbacks.
> 
> **Overview**
> Introduces **repo-wide checkpoint policy** stored at `refs/entire/policies/checkpoint` (`policy.json` with `checkpoint_version` / `checkpoint_min_version`), plus a new **`checkpointpolicy`** package for format parsing (`branch-v1` vs future families like `refs-v1`), validation, local Git storage, and remote sync/push against the configured checkpoint remote.
> 
> Adds hidden **`entire policy checkpoint`** to inspect or update policy (with downgrade protection unless `--force`), pushing only the policy ref on updates. **User-driven writes** (`attach`, explain summary generation) **fail** when local policy requires a checkpoint format this CLI cannot write; **reads** (explain, export, resume, rewind) **fail** on unsupported per-checkpoint `checkpoint_version`. **Hooks** skip checkpoint writes and warn in interactive TTY when write policy is unsupported; **pre-push** syncs remote policy and can skip checkpoint pushes on unsupported write or diverged local/remote policy. Successful CLI runs (except hooks/analytics) can print an upgrade warning when policy needs a newer Entire.
> 
> Also refactors checkpoint-remote HTTPS token handling into `checkpointTokenTransport` and adds `ConfiguredURL` for policy remote resolution; documents checkpoint policy in architecture docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99336ff98546c3d547c1e395e09eed6ce636f322. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->