### PR TITLE
fix(cor-572): CLI client timeout vs draining/black-holed core host

### DIFF
--- a/internal/coreapi/client_timeout_test.go
+++ b/internal/coreapi/client_timeout_test.go
@@ -1,0 +1,70 @@
+package coreapi
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// A draining/black-holed core accepts the connection but never sends
+// response headers. Without an overall client timeout the request hangs on
+// the OS TCP timeout; the client must instead fail fast (COR-572).
+func TestCrossJurisHTTPClient_TimesOutOnSilentHost(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // never respond; unblock only when the client gives up
+	}))
+	defer srv.Close()
+
+	client := newCrossJurisHTTPClientWithTimeout(150 * time.Millisecond)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected a timeout error, got a response")
+	}
+	var nerr net.Error
+	if !errors.As(err, &nerr) || !nerr.Timeout() {
+		t.Fatalf("expected a timeout net.Error, got %v (%T)", err, err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("client blocked %v; should have timed out near 150ms", elapsed)
+	}
+}
+
+// The overall timeout must not break a normal, responsive request.
+func TestCrossJurisHTTPClient_ResponsiveHostSucceeds(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := newCrossJurisHTTPClientWithTimeout(5 * time.Second)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("responsive host should succeed, got %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/internal/coreapi/cross_juris_transport.go
+++ b/internal/coreapi/cross_juris_transport.go
@@ -18,13 +18,28 @@ import (
 	"github.com/entireio/cli/internal/entireclient/httputil"
 )
 
+// controlPlaneRequestTimeout caps a whole control-plane HTTP exchange —
+// connect, TLS, headers, body, and any 421-follow / token-exchange retry —
+// so a draining or black-holed core (one that accepts the connection but
+// never answers) fails fast instead of hanging on the OS TCP timeout. The
+// connect step is separately bounded by httpclient.DefaultDialTimeout.
+const controlPlaneRequestTimeout = 30 * time.Second
+
 // newCrossJurisHTTPClient builds the *http.Client the control-plane
 // (coreapi) client dials with. Its transport follows cross-jurisdiction
 // 421 redirects and runs the RFC 8693 token exchange a foreign core
 // requires, so a home-region login JWT can operate on a resource whose
 // home jurisdiction is another region. Inert for same-jurisdiction calls.
 func newCrossJurisHTTPClient() *http.Client {
+	return newCrossJurisHTTPClientWithTimeout(controlPlaneRequestTimeout)
+}
+
+// newCrossJurisHTTPClientWithTimeout is newCrossJurisHTTPClient with an
+// explicit overall timeout, so tests can exercise the deadline on a short
+// budget.
+func newCrossJurisHTTPClientWithTimeout(timeout time.Duration) *http.Client {
 	return &http.Client{
+		Timeout:   timeout,
 		Transport: newCrossJurisRoundTripper(httpclient.NewTransport(false)),
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/644
<!-- entire-trail-link-end -->

## COR-572 — `entire` CLI hangs against a draining / black-holed core host

**Problem.** Control-plane commands build their HTTP client in `internal/coreapi/cross_juris_transport.go:newCrossJurisHTTPClient()` (reached via both `coreapi.New()` → `clientForTarget` and `coreapi.NewWithBearer`). That client sets **no overall `Timeout`**. The shared transport already bounds the TCP *connect* (`httpclient.DefaultDialTimeout = 4s`, env-overridable via `ENTIRE_CONNECT_TIMEOUT_SECONDS`), so a host that refuses/drops packets fails fast — but a **draining** host that accepts the connection and then never sends response headers (exactly the COR-562 cutover scenario) makes `client.Do` block until the OS TCP timeout. No CLI-level deadline applies.

**Fix.** Give the control-plane `http.Client` an overall request timeout (`30s`) at that single chokepoint. Every caller (`New`, `NewForCluster`, `NewWithBearer`, the `ENTIRE_TOKEN` bypass) inherits it. A per-command `context` deadline in `corecmd.go` was considered but the client-level timeout is the single point that covers *all* callers, including `entire auth status`, which builds its own `/me` client.

**Note on the issue's "2s-dial".** The repo standardized on a 4s dial timeout (`httpclient.DefaultDialTimeout`); I did not introduce a conflicting 2s value. Only the missing overall timeout is added.

### Files touched
- `internal/coreapi/cross_juris_transport.go` — add `controlPlaneRequestTimeout` const + set `Timeout` on the client (via a `newCrossJurisHTTPClientWithTimeout` helper so tests can use a short budget).
- `internal/coreapi/client_timeout_test.go` — test: a silent/draining host returns a timeout error promptly instead of blocking.

Closes COR-572

---
🚧 **Draft — NO MERGE / NO DEPLOY.** Part of the COR-562 cutover tooling batch; scrapbook: entirehq/entiredb#2121.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow networking guardrail at one client factory; may surface timeouts on legitimately slow control-plane responses over 30s.
> 
> **Overview**
> Fixes **CLI hangs** when the control-plane core accepts TCP but never returns HTTP headers (e.g. draining/black-holed host during cutover). Connect already fails fast via the shared **4s dial** budget; the missing piece was an **overall request deadline** on `client.Do`.
> 
> Adds a **30s** `http.Client.Timeout` at the single chokepoint in `newCrossJurisHTTPClient` (via a test-friendly helper so tests can use a shorter budget), so every control-plane path—`coreapi.New`, `NewForCluster`, `NewWithBearer`, and `ENTIRE_TOKEN`—inherits the same cap, including `entire auth status`’s `/me` client.
> 
> New test in `client_timeout_test.go` asserts a silent/draining host returns a timeout error instead of blocking indefinitely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38a6bc514941c221ab002fc7e816d083965b0d8b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->