### PR TITLE
fix(cor-573): CLI 503 → scheduled-maintenance copy

### DIFF
--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -305,17 +306,25 @@ func markRequired(cmd *cobra.Command, names ...string) {
 	}
 }
 
+// maintenanceMessage is the shared 503 scheduled-maintenance copy, kept
+// identical to the Cloudflare edge 503 page (COR-566) and the SPA banner.
+const maintenanceMessage = "Entire is under scheduled maintenance — please try again shortly"
+
 // renderCoreError converts a Core API error into the server's
 // problem-detail message (so users see "organization name already taken"
 // rather than ogen's decode-wrapped string), falling back to the raw error
-// for transport/local failures. It returns a plain error, not a
-// SilentError: main.go prints plain errors, and runCore has already set
-// SilenceUsage, so the message reaches the user without a usage dump. (A
+// for transport/local failures. A 503 is special-cased to the
+// scheduled-maintenance copy regardless of body. It returns a plain error,
+// not a SilentError: main.go prints plain errors, and runCore has already
+// set SilenceUsage, so the message reaches the user without a usage dump. (A
 // SilentError here would be swallowed — main.go skips printing those —
 // leaving e.g. a 409 conflict with no output.)
 func renderCoreError(err error) error {
 	if err == nil {
 		return nil
+	}
+	if status, ok := coreapi.HTTPStatus(err); ok && status == http.StatusServiceUnavailable {
+		return errors.New(maintenanceMessage) //nolint:staticcheck // user-facing copy, shared verbatim across CLI/SPA/edge
 	}
 	if msg := coreapi.APIError(err); msg != "" {
 		return errors.New(msg)

--- a/cmd/entire/cli/corecmd.go
+++ b/cmd/entire/cli/corecmd.go
@@ -306,9 +306,9 @@ func markRequired(cmd *cobra.Command, names ...string) {
 	}
 }
 
-// maintenanceMessage is the shared 503 scheduled-maintenance copy, kept
-// identical to the Cloudflare edge 503 page (COR-566) and the SPA banner.
-const maintenanceMessage = "Entire is under scheduled maintenance — please try again shortly"
+// maintenanceMessage is the canonical 503 headline, byte-identical to the
+// COR-566 edge page <h1> and the SPA maintenance banner heading.
+const maintenanceMessage = "Entire is under scheduled maintenance"
 
 // renderCoreError converts a Core API error into the server's
 // problem-detail message (so users see "organization name already taken"
@@ -323,6 +323,8 @@ func renderCoreError(err error) error {
 	if err == nil {
 		return nil
 	}
+	// Only an explicit 503 maps to maintenance copy. A draining or black-holed
+	// host (COR-572) surfaces as a timeout, not a 503, and stays a generic error.
 	if status, ok := coreapi.HTTPStatus(err); ok && status == http.StatusServiceUnavailable {
 		return errors.New(maintenanceMessage) //nolint:staticcheck // user-facing copy, shared verbatim across CLI/SPA/edge
 	}

--- a/cmd/entire/cli/corecmd_test.go
+++ b/cmd/entire/cli/corecmd_test.go
@@ -2,7 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"errors"
+	"net/http"
 	"testing"
+
+	"github.com/entireio/cli/internal/coreapi"
 )
 
 // printTable/printFields render plain (no color/escape) when the writer
@@ -37,5 +41,39 @@ func TestPrintFields(t *testing.T) {
 		"NAME  widgets\n"
 	if got := buf.String(); got != want {
 		t.Errorf("printFields output:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+func TestRenderCoreError_ScheduledMaintenance(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   error
+	}{
+		{"bare 503", &coreapi.ErrorModelStatusCode{StatusCode: http.StatusServiceUnavailable}},
+		{"503 with problem-detail body", &coreapi.ErrorModelStatusCode{
+			StatusCode: http.StatusServiceUnavailable,
+			Response:   coreapi.ErrorModel{Detail: coreapi.OptString{Set: true, Value: "db unreachable"}},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := renderCoreError(tc.in)
+			if got == nil || got.Error() != maintenanceMessage {
+				t.Errorf("renderCoreError(%s) = %v, want %q", tc.name, got, maintenanceMessage)
+			}
+		})
+	}
+}
+
+func TestRenderCoreError_PassThrough(t *testing.T) {
+	t.Parallel()
+	if got := renderCoreError(nil); got != nil {
+		t.Errorf("renderCoreError(nil) = %v, want nil", got)
+	}
+	transport := errors.New("dial tcp: connection refused")
+	if got := renderCoreError(transport); !errors.Is(got, transport) {
+		t.Errorf("renderCoreError(transport) = %v, want passthrough", got)
 	}
 }

--- a/internal/coreapi/client.go
+++ b/internal/coreapi/client.go
@@ -227,3 +227,14 @@ func APIError(err error) string {
 		return fmt.Sprintf("control-plane request failed with status %d", statusErr.StatusCode)
 	}
 }
+
+// HTTPStatus reports the HTTP status code carried by a control-plane API
+// error and whether err was one. It returns (0, false) for transport or
+// local failures that never reached the server.
+func HTTPStatus(err error) (int, bool) {
+	var statusErr *ErrorModelStatusCode
+	if !errors.As(err, &statusErr) {
+		return 0, false
+	}
+	return statusErr.StatusCode, true
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/645
<!-- entire-trail-link-end -->

## COR-573 (CLI surface) — scheduled-maintenance 503 copy

Part of **[COR-573](https://linear.app/entirehq/issue/COR-573) — User-facing maintenance signal**, split per surface. This is the **CLI** surface (1 of 3); siblings cover the SPA banner and the incident.io statuspage.

### What
When the control plane returns HTTP `503` — a draining/maintenance host, i.e. the COR-562 cutover scenario — the `entire` CLI printed the raw `control-plane request failed with status 503`. `renderCoreError` now special-cases `503` to a friendly, shared message:

> Entire is under scheduled maintenance — please try again shortly

### Changes
- `internal/coreapi/client.go` — new `HTTPStatus(err) (int, bool)` helper, alongside `APIError`.
- `cmd/entire/cli/corecmd.go` — `renderCoreError` 503 branch + shared `maintenanceMessage` const (`//nolint:staticcheck` — user-facing copy kept verbatim across surfaces).
- `cmd/entire/cli/corecmd_test.go` — `TestRenderCoreError_ScheduledMaintenance` (bare 503 + 503-with-body) and `TestRenderCoreError_PassThrough` (nil + transport error).

### Coordination
- Copy is **verbatim-shared** with the Cloudflare edge 503 page (COR-566) and the SPA banner (COR-573 sibling). Convergence tracked in entiredb#2121.
- Touches `entireio/cli` alongside **COR-572** (client timeout). My change is in `renderCoreError`; COR-572 is in `coreapi.New()` — distinct functions, no file-region overlap.

### Verification
- `go test ./cmd/entire/cli/` ✓
- `mise run lint` → 0 issues ✓

**NO MERGE / NO DEPLOY — draft only.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error copy only; no auth, transport, or API behavior changes beyond 503 messaging.
> 
> **Overview**
> Control-plane commands no longer print generic `control-plane request failed with status 503` when the API returns **503**. **`renderCoreError`** now maps that status to shared user-facing copy: *Entire is under scheduled maintenance — please try again shortly* (aligned with COR-566 edge and the SPA banner), including when a problem-detail body is present.
> 
> **`coreapi.HTTPStatus`** was added so the CLI can detect API status codes without parsing **`APIError`** text. Tests cover 503 (bare and with body), nil, and transport passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 058e835dd2f10c179b3a8f4aaf822641c5f37c19. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->