### PR TITLE
Add basic .worktreeinclude file

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.claude/settings.local.json
+mise.local.toml


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/657
<!-- entire-trail-link-end -->

This PR adds a `.worktreeinclude` file, adding two new entries to ensure that `.claude/settings.local.json` and `mise.local.toml` are included in worktrees created by certain tools.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition with no runtime or application code changes.
> 
> **Overview**
> Introduces a new **`.worktreeinclude`** file listing two paths that should be carried into git worktrees when using tools that honor this convention.
> 
> The entries are **`.claude/settings.local.json`** and **`mise.local.toml`**, so per-machine Claude and mise overrides stay available in secondary worktrees without manual copying.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14188fa634b111a98104f104bd3470b4b0d04d5c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->