### PR TITLE
Smooth mirror onboarding: `entire repo mirror create` wizard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,10 @@ their canonical paths are still runnable.
 - `configure`: bare prints help and a hint pointing at `entire agent`; flags
   manage non-agent settings (telemetry, git-hook installation mode, strategy
   options, summary provider). Agent CRUD lives under `entire agent`.
-- `auth`: `login`, `logout`, `status`, `contexts`, `use`. `logout` takes
-  `--everywhere` (revoke every session on the active core, not just the
+- `auth`: `login`, `logout`, `status`, `contexts`, `use`, plus the hidden
+  `token` (prints the active control-plane bearer to stdout for scripting/curl;
+  honors `ENTIRE_TOKEN`, else the refreshed active-context login JWT). `logout`
+  takes `--everywhere` (revoke every session on the active core, not just the
   current one) and `--all-contexts` (log out of every saved login)
 - `doctor`: bare runs the scan-and-fix flow, plus `trace`, `logs`, `bundle`
 

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -199,6 +199,9 @@ type authProfile struct {
 	Email          string
 	Provider       string
 	ProviderUserID string
+	// Jurisdiction is the caller's home jurisdiction slug (e.g. "eu"), used to
+	// pick the default mirror cluster for that jurisdiction. May be empty.
+	Jurisdiction string
 }
 
 // profileFetcher fetches a user's profile via GET /me on coreURL, authenticated
@@ -319,6 +322,7 @@ func defaultFetchProfile(ctx context.Context, coreURL, token string) (*authProfi
 		ProviderUserID: me.Auth.ProviderUserId,
 	}
 	p.Handle, _ = me.Global.Handle.Get()
+	p.Jurisdiction, _ = me.Jurisdiction.Get()
 	if reg, ok := me.Regional.Get(); ok {
 		p.DisplayName, _ = reg.DisplayName.Get()
 		p.Email, _ = reg.Email.Get()

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -148,10 +148,19 @@ func newAuthTokenCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Refresh may exchange/refresh over the network; honor the
 			// plain-HTTP opt-in before resolving so local dev cores work.
-			applyInsecureHTTPAuth(insecureHTTPAuth)
+			insecure := applyInsecureHTTPAuth(insecureHTTPAuth)
 			target, err := resolveAuthStatusTarget(cmd.Context(), auth.Contexts, auth.RefreshedLoginToken)
 			if err != nil {
 				return err
+			}
+			// Don't mint/print a bearer for an insecure core unless explicitly
+			// opted in — the token would otherwise be usable over plain HTTP.
+			// Mirrors `auth status`.
+			if !insecure && target.coreURL != "" {
+				if err := api.RequireSecureURL(target.coreURL); err != nil {
+					cmd.SilenceUsage = true
+					return fmt.Errorf("login server URL check: %w", err)
+				}
 			}
 			if target.token == "" {
 				cmd.SilenceUsage = true

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -118,8 +118,51 @@ func newAuthCmd() *cobra.Command {
 	cmd.AddCommand(newLoginCmd())
 	cmd.AddCommand(newLogoutCmd())
 	cmd.AddCommand(newAuthStatusCmd())
+	cmd.AddCommand(newAuthTokenCmd())
 	cmd.AddCommand(newAuthContextsCmd())
 	cmd.AddCommand(newAuthUseCmd())
+	return cmd
+}
+
+// --- token ------------------------------------------------------------------
+
+// newAuthTokenCmd prints the active control-plane bearer to stdout so scripts
+// (and ad-hoc curl) can authenticate against the core API without re-deriving
+// the keychain slot — e.g.
+//
+//	curl -H "Authorization: Bearer $(entire auth token)" "$CORE/api/v1/clusters"
+//
+// Hidden: it emits a live credential, so it's a deliberate scripting escape
+// hatch, not part of the everyday surface. It resolves the same bearer the API
+// client would — ENTIRE_TOKEN verbatim when set, otherwise the active context's
+// login JWT, refreshed if it's near expiry — and prints nothing but the token
+// (errors and the not-logged-in hint go to stderr) so command substitution
+// stays clean.
+func newAuthTokenCmd() *cobra.Command {
+	var insecureHTTPAuth bool
+	cmd := &cobra.Command{
+		Use:    "token",
+		Short:  "Print the active control-plane bearer token (for scripting)",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Refresh may exchange/refresh over the network; honor the
+			// plain-HTTP opt-in before resolving so local dev cores work.
+			applyInsecureHTTPAuth(insecureHTTPAuth)
+			target, err := resolveAuthStatusTarget(cmd.Context(), auth.Contexts, auth.RefreshedLoginToken)
+			if err != nil {
+				return err
+			}
+			if target.token == "" {
+				cmd.SilenceUsage = true
+				fmt.Fprintln(cmd.ErrOrStderr(), "Not logged in. Run 'entire login' to authenticate.")
+				return NewSilentError(errors.New("not logged in"))
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), target.token)
+			return nil
+		},
+	}
+	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
 	return cmd
 }
 

--- a/cmd/entire/cli/auth_token_test.go
+++ b/cmd/entire/cli/auth_token_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// makeTestJWT builds an unsigned JWT with the given payload JSON. ParseClaims
+// (used by ENTIRE_TOKEN resolution) reads the payload without verifying the
+// signature, so an unsigned token is enough to exercise the resolution path.
+func makeTestJWT(t *testing.T, payloadJSON string) string {
+	t.Helper()
+	enc := base64.RawURLEncoding
+	header := enc.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := enc.EncodeToString([]byte(payloadJSON))
+	return header + "." + payload + "." + enc.EncodeToString([]byte("sig"))
+}
+
+// TestAuthTokenCmd covers the hidden `entire auth token` scripting helper.
+//
+// Not parallel: it manipulates ENTIRE_TOKEN / ENTIRE_CONFIG_DIR.
+func TestAuthTokenCmd(t *testing.T) {
+	// Guard against a real ENTIRE_TOKEN in the dev's environment leaking into
+	// the not-logged-in case; restore it afterward.
+	if v, ok := os.LookupEnv("ENTIRE_TOKEN"); ok {
+		os.Unsetenv("ENTIRE_TOKEN")
+		// t.Setenv can't unset, and there's no t.Unsetenv, so restore manually.
+		t.Cleanup(func() { os.Setenv("ENTIRE_TOKEN", v) }) //nolint:usetesting // restoring a captured value; no t.Unsetenv equivalent
+	}
+
+	t.Run("prints the env token verbatim", func(t *testing.T) {
+		token := makeTestJWT(t, `{"sub":"ci","aud":"https://core.us.entire.io"}`)
+		t.Setenv("ENTIRE_TOKEN", token)
+
+		cmd := newAuthTokenCmd()
+		var out, errOut bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&errOut)
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		require.Equal(t, token+"\n", out.String())
+		require.Empty(t, errOut.String())
+	})
+
+	t.Run("not logged in errors silently with a hint", func(t *testing.T) {
+		// Isolated empty config so there's no active context to resolve.
+		t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+
+		cmd := newAuthTokenCmd()
+		var out, errOut bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&errOut)
+		err := cmd.ExecuteContext(t.Context())
+
+		var silent *SilentError
+		require.ErrorAs(t, err, &silent)
+		require.Empty(t, out.String(), "stdout must stay clean for command substitution")
+		require.Contains(t, errOut.String(), "Not logged in")
+	})
+}

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/internal/coreapi"
 )
 
@@ -78,10 +77,10 @@ var clusterHostLabelRe = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-
 
 // validateClusterHost rejects a cluster host that is anything other than a
 // bare DNS name or IP with an optional :port. The host is concatenated as
-// "https://"+host both into the smart-HTTP probe URL (waitForMirrorClone) and
-// into the STS audience (auth.RepoScopedToken), so a value carrying URL
-// metacharacters can redirect the request — and the repo-scoped basic-auth
-// token it carries — somewhere other than the intended cluster. Classic case:
+// "https://"+host into the clone URL and the STS audience
+// (auth.RepoScopedToken), so a value carrying URL metacharacters can redirect
+// the request — and the repo-scoped basic-auth token it carries — somewhere
+// other than the intended cluster. Classic case:
 // `aws-us-east-2.entire.io@evil.com`, which Go's URL parser reads as
 // host=evil.com with the real cluster demoted to userinfo, leaking the token
 // to evil.com. We parse the host the same way the rest of the code does and
@@ -167,28 +166,14 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 				return fmt.Errorf("invalid [cluster-host]: %w", err)
 			}
 			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
-				created, err := c.CreateMirror(ctx, &coreapi.CreateMirrorInputBody{
-					Provider:    coreapi.CreateMirrorInputBodyProviderGithub,
-					Owner:       owner,
-					Repo:        repo,
-					ClusterHost: clusterHost,
-				})
-				if err != nil {
-					return err
-				}
-				out := cmd.OutOrStdout()
-				repoSlug := "/gh/" + owner + "/" + repo
-				return finishMirrorCreate(out, cmd.ErrOrStderr(), created, noWait,
-					func() error {
-						if _, terr := auth.RepoScopedToken(ctx, clusterHost, repoSlug, "pull"); terr != nil {
-							return fmt.Errorf("probe mirror for suspension: %w", terr)
-						}
-						return nil
-					},
-					func() error {
-						return waitForMirrorClone(ctx, out, clusterHost, owner, repo, waitTimeout)
-					},
-				)
+				errW := cmd.ErrOrStderr()
+				stop := startSpinner(errW, fmt.Sprintf("Cloning %s/%s into %s", owner, repo, clusterHost))
+				outcome, err := createAndAwaitMirror(ctx, c, owner, repo, clusterHost, noWait, waitTimeout)
+				// Only a confirmed-ready clone earns the ✓; everything else
+				// (empty, --no-wait, suspended, failed, timeout) erases the line
+				// and lets reportOneShotMirror print the specific outcome.
+				stop(err == nil && outcome.polled && outcome.status == coreapi.MirrorStatusReady)
+				return reportOneShotMirror(cmd.OutOrStdout(), errW, outcome, err)
 			})
 		},
 	}
@@ -197,23 +182,52 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 	return cmd
 }
 
-// finishMirrorCreate prints the post-create status for `repo mirror create`
-// and, unless noWait, makes sure the mirror is usable before returning.
-//
-// Empty upstream and suspended placement interact. An empty upstream has no
-// clone to wait for, so the HEAD-poll loop is skipped — it could only spin to
-// the timeout, since an empty repo never advertises a HEAD. But an *existing*
-// placement can be suspended even when its upstream is empty, and the
-// repo-scoped token exchange is the only signal that surfaces that; a *fresh*
-// create can't be suspended (suspension follows upstream access loss), so it
-// needs neither the probe nor the wait. Non-empty mirrors take the normal
-// clone-wait path.
-//
-// probeSuspended mints a repo-scoped pull token and returns its error for
-// explainSuspendedMirror to classify; waitClone runs the HEAD-poll loop. Both
-// are injected so the branching is unit-testable without the auth and
-// control-plane stack the production caller wires up.
-func finishMirrorCreate(out, errW io.Writer, created *coreapi.CreatedMirror, noWait bool, probeSuspended, waitClone func() error) error {
+// mirrorCreateOutcome bundles the create response with the clone status
+// observed while waiting. polled is false for --no-wait and for empty upstreams,
+// where there is nothing to await; in those cases status is unset.
+type mirrorCreateOutcome struct {
+	created *coreapi.CreatedMirror
+	status  coreapi.MirrorStatus
+	polled  bool
+}
+
+// createAndAwaitMirror is the single create-then-wait path shared by the
+// `repo mirror create <github-url>` one-shot and the onboarding wizard, so both
+// report identical lifecycle states. It registers the GitHub mirror on
+// clusterHost (idempotent on (upstream, cluster)) and, unless noWait or the
+// upstream is empty, polls the control plane until the clone reaches a terminal
+// status. The returned error is the create error (when outcome.created is nil)
+// or the wait error — a status sentinel (errMirrorCloneFailed /
+// errMirrorSuspended) or a timeout; callers read outcome.status for the state.
+func createAndAwaitMirror(ctx context.Context, c *coreapi.Client, owner, repo, clusterHost string, noWait bool, timeout time.Duration) (mirrorCreateOutcome, error) {
+	created, err := c.CreateMirror(ctx, &coreapi.CreateMirrorInputBody{
+		Provider:    coreapi.CreateMirrorInputBodyProviderGithub,
+		Owner:       owner,
+		Repo:        repo,
+		ClusterHost: clusterHost,
+	})
+	if err != nil {
+		return mirrorCreateOutcome{}, err
+	}
+	outcome := mirrorCreateOutcome{created: created}
+	if noWait || created.Empty {
+		return outcome, nil
+	}
+	status, werr := awaitMirrorReady(ctx, c, created.MirrorId, timeout)
+	outcome.status = status
+	outcome.polled = true
+	return outcome, werr
+}
+
+// reportOneShotMirror renders the human output for `repo mirror create
+// <github-url>` from the shared createAndAwaitMirror result. A nil
+// outcome.created means CreateMirror itself failed — surface that error (nothing
+// was printed yet). Otherwise echo the placement, then the lifecycle outcome.
+func reportOneShotMirror(out, errW io.Writer, outcome mirrorCreateOutcome, err error) error {
+	created := outcome.created
+	if created == nil {
+		return err
+	}
 	if created.Created {
 		fmt.Fprintf(out, "Registered mirror %s\n", created.MirrorId)
 	} else {
@@ -221,36 +235,31 @@ func finishMirrorCreate(out, errW io.Writer, created *coreapi.CreatedMirror, noW
 	}
 	fmt.Fprintf(out, "  %s\n", created.MirrorUrl)
 
-	if created.Empty {
-		// An existing placement can sit behind a suspension even with an empty
-		// upstream, so probe the token exchange to surface it. A fresh create
-		// can't be suspended, so skip the probe there.
-		if !created.Created {
-			if err := probeSuspended(); err != nil {
-				if handled, serr := explainSuspendedMirror(errW, created.MirrorId, created.Created, err); handled {
-					return serr
-				}
-				// A non-suspension probe error isn't fatal: the placement exists
-				// and the upstream is genuinely empty, so report that rather than
-				// failing the create on a transient token hiccup.
-			}
+	if !outcome.polled {
+		if created.Empty {
+			fmt.Fprintln(out, "Upstream has no commits yet — nothing to clone. The mirror will pick up refs once the upstream is pushed to.")
+		} else {
+			fmt.Fprintf(out, "Initial clone may still be in progress; `git clone %s` will work once it completes.\n", created.MirrorUrl)
 		}
-		fmt.Fprintln(out, "Upstream has no commits yet — nothing to clone. The mirror will pick up refs once the upstream is pushed to.")
 		return nil
 	}
 
-	if noWait {
-		fmt.Fprintf(out, "Initial clone may still be in progress; `git clone %s` will work once it completes.\n", created.MirrorUrl)
+	switch outcome.status {
+	case coreapi.MirrorStatusReady:
+		fmt.Fprintf(out, "\nClone it:\n  git clone %s\n", created.MirrorUrl)
 		return nil
-	}
-	if err := waitClone(); err != nil {
-		if handled, serr := explainSuspendedMirror(errW, created.MirrorId, created.Created, err); handled {
-			return serr
-		}
+	case coreapi.MirrorStatusSuspended:
+		explainSuspendedMirror(errW, created.MirrorId)
+		return NewSilentError(errMirrorSuspended)
+	case coreapi.MirrorStatusFailed:
+		return fmt.Errorf("initial clone of mirror %s failed", created.MirrorId)
+	case coreapi.MirrorStatusProcessing:
+		// Still processing when the poll returned: the wait timed out (or a
+		// transport error broke the poll). awaitMirrorReady's err carries which.
+		return err
+	default:
 		return err
 	}
-	fmt.Fprintf(out, "\nClone it:\n  git clone %s\n", created.MirrorUrl)
-	return nil
 }
 
 func newRepoMirrorListCmd() *cobra.Command {

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -212,27 +212,55 @@ func resolveDefaultClusterHost(ctx context.Context, c *coreapi.Client) (string, 
 	if err != nil {
 		return "", err
 	}
-	return pickDefaultRegionHost(regions)
+	jurisdiction, err := callerJurisdiction(ctx, c)
+	if err != nil {
+		return "", err
+	}
+	return pickDefaultRegionHost(regions, jurisdiction)
 }
 
-// pickDefaultRegionHost chooses the default cluster host from the catalog: the
-// is-default cluster, or the sole cluster when there's exactly one. Empty or
-// ambiguous catalogs error so the caller can tell the user to pass
-// [cluster-host]. Pure, so the selection is unit-testable without a live core.
-func pickDefaultRegionHost(regions []regionChoice) (string, error) {
+// callerJurisdiction returns the active principal's home jurisdiction slug from
+// GET /me (e.g. "eu"). May return "" if the server doesn't report one.
+func callerJurisdiction(ctx context.Context, c *coreapi.Client) (string, error) {
+	me, err := c.GetMe(ctx)
+	if err != nil {
+		return "", renderCoreError(err)
+	}
+	j, _ := me.Jurisdiction.Get()
+	return j, nil
+}
+
+// pickDefaultRegionHost chooses the default cluster host for the caller's
+// jurisdiction. is_default is per-jurisdiction (each jurisdiction has one), so a
+// known jurisdiction selects its default directly. With no jurisdiction it falls
+// back to a lone cluster or a lone default; anything ambiguous errors so the
+// caller can tell the user to pass [cluster-host]. Pure, so the selection is
+// unit-testable without a live core.
+func pickDefaultRegionHost(regions []regionChoice, jurisdiction string) (string, error) {
+	if len(regions) == 0 {
+		return "", errors.New("no clusters available to mirror into; pass [cluster-host] explicitly")
+	}
+	if jurisdiction != "" {
+		for _, r := range regions {
+			if r.isDefault && r.jurisdiction == jurisdiction {
+				return r.host, nil
+			}
+		}
+		return "", fmt.Errorf("no default cluster for your jurisdiction (%s); pass [cluster-host] explicitly", jurisdiction)
+	}
+	if len(regions) == 1 {
+		return regions[0].host, nil
+	}
+	var defaults []regionChoice
 	for _, r := range regions {
 		if r.isDefault {
-			return r.host, nil
+			defaults = append(defaults, r)
 		}
 	}
-	switch len(regions) {
-	case 0:
-		return "", errors.New("no clusters available to mirror into; pass [cluster-host] explicitly")
-	case 1:
-		return regions[0].host, nil
-	default:
-		return "", errors.New("no default cluster configured; pass [cluster-host] explicitly")
+	if len(defaults) == 1 {
+		return defaults[0].host, nil
 	}
+	return "", errors.New("could not determine your jurisdiction's default cluster; pass [cluster-host] explicitly")
 }
 
 // mirrorCreateOutcome bundles the create response with the clone status

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -217,7 +217,25 @@ func createAndAwaitMirror(ctx context.Context, c *coreapi.Client, owner, repo, c
 		return mirrorCreateOutcome{}, err
 	}
 	outcome := mirrorCreateOutcome{created: created}
-	if noWait || created.Empty {
+	if created.Empty {
+		// An empty upstream has nothing to clone, so don't poll for "ready" — it
+		// never would. But an *existing* placement can be suspended even when
+		// empty, and one status read surfaces that (a fresh create can't be
+		// suspended — suspension follows upstream access loss). Mirrors the old
+		// finishMirrorCreate behavior; the read is best-effort, so a transient
+		// GetMirror error just falls through to the benign "nothing to clone".
+		if !created.Created {
+			if m, gerr := c.GetMirror(ctx, coreapi.GetMirrorParams{MirrorId: created.MirrorId}); gerr == nil {
+				if s, ok := m.Status.Get(); ok && s == coreapi.MirrorStatusSuspended {
+					outcome.status = s
+					outcome.polled = true
+					return outcome, errMirrorSuspended
+				}
+			}
+		}
+		return outcome, nil
+	}
+	if noWait {
 		return outcome, nil
 	}
 	status, werr := awaitMirrorReady(ctx, c, created.MirrorId, timeout, onStatus)

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -48,10 +48,11 @@ func availableMirrorRow(m coreapi.AvailableMirror) []string {
 	return []string{m.Owner + "/" + m.Repo, string(m.Access), string(m.Status)}
 }
 
-// defaultClusterHost is the cluster the mirror commands target when the
-// caller omits the <cluster-host> argument. A pragmatic single-region
-// default for now — once multi-cluster selection lands this should come
-// from config/context rather than a constant.
+// defaultClusterHost is the cluster the positional-arg mirror commands target
+// when the caller omits the <cluster-host> argument. The no-arg create wizard
+// instead enumerates real clusters from the catalog (GET /api/v1/clusters, see
+// availableRegions in repo_mirror_create_wizard.go); this stays as the
+// single-region fallback for the explicit `create <github-url>` form.
 const defaultClusterHost = "aws-us-east-2.entire.io"
 
 // clusterArg returns the cluster host from the optional second positional
@@ -136,18 +137,25 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 		waitTimeout time.Duration
 	)
 	cmd := &cobra.Command{
-		Use:   "create <github-url> [cluster-host]",
+		Use:   "create [github-url] [cluster-host]",
 		Short: "Register a GitHub mirror on a cluster",
-		Long: "Registers a mirror placement for a GitHub repo on the target " +
-			"cluster, then waits for the initial GitHub→EntireDB clone to " +
-			"finish so `git clone` works on return. Pass --no-wait to return " +
+		Long: "With no arguments, launches an interactive wizard: pick repos to " +
+			"mirror, pick one or more regions, then creates every (repo, region) " +
+			"mirror in parallel and prints the clone URLs.\n\n" +
+			"With a <github-url>, registers a mirror placement for that repo on " +
+			"the target cluster, then waits for the initial GitHub→EntireDB clone " +
+			"to finish so `git clone` works on return. Pass --no-wait to return " +
 			"as soon as the placement is registered. Idempotent on " +
 			"(upstream, cluster). The cluster-host defaults to " +
 			defaultClusterHost + " when omitted.",
-		Example: "  entire repo mirror create github.com/octocat/hello-world\n" +
+		Example: "  entire repo mirror create\n" +
+			"  entire repo mirror create github.com/octocat/hello-world\n" +
 			"  entire repo mirror create github.com/octocat/hello-world eu-west-1.entire.io",
-		Args: cobra.RangeArgs(1, 2),
+		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return runMirrorCreateWizard(cmd, noWait, waitTimeout)
+			}
 			owner, repo, err := parseGitHubURL(args[0])
 			if err != nil {
 				cmd.SilenceUsage = true

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -145,8 +145,9 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 			"the target cluster, then waits for the initial GitHub→EntireDB clone " +
 			"to finish so `git clone` works on return. Pass --no-wait to return " +
 			"as soon as the placement is registered. Idempotent on " +
-			"(upstream, cluster). The cluster-host defaults to your catalog's " +
-			"default cluster when omitted.",
+			"(upstream, cluster). The cluster-host defaults to " +
+			defaultClusterHost + " when omitted (the interactive wizard, with " +
+			"no args, instead lets you pick clusters).",
 		Example: "  entire repo mirror create\n" +
 			"  entire repo mirror create github.com/octocat/hello-world\n" +
 			"  entire repo mirror create github.com/octocat/hello-world aws-us-east-2.entire.io",
@@ -160,29 +161,14 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid <github-url>: %w", err)
 			}
-			var clusterHost string
-			if len(args) > 1 {
-				clusterHost = args[1]
-				if err := validateClusterHost(clusterHost); err != nil {
-					cmd.SilenceUsage = true
-					return fmt.Errorf("invalid [cluster-host]: %w", err)
-				}
-			} else {
-				// No cluster given: pick the catalog's default cluster (the same
-				// GET /api/v1/clusters source the wizard uses), resolved via the
-				// active context. runCore owns the active-client preamble
-				// (silence-usage, --insecure-http-auth, error mapping).
-				if err := runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
-					h, rerr := resolveDefaultClusterHost(ctx, c)
-					if rerr != nil {
-						return rerr
-					}
-					clusterHost = h
-					fmt.Fprintf(cmd.ErrOrStderr(), "Using default cluster %s\n", clusterHost)
-					return nil
-				}); err != nil {
-					return err
-				}
+			// The non-interactive one-shot keeps a fixed default cluster
+			// (defaultClusterHost) when [cluster-host] is omitted — catalog-based
+			// cluster guessing is intentionally limited to the interactive
+			// wizard (the no-args path above), so scripts get stable behavior.
+			clusterHost := clusterArg(args)
+			if err := validateClusterHost(clusterHost); err != nil {
+				cmd.SilenceUsage = true
+				return fmt.Errorf("invalid [cluster-host]: %w", err)
 			}
 			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
 				errW := cmd.ErrOrStderr()
@@ -199,68 +185,6 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noWait, "no-wait", false, "return once the placement is registered, without waiting for the initial clone")
 	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Minute, "how long to wait for the initial clone to finish")
 	return cmd
-}
-
-// resolveDefaultClusterHost picks the cluster a `repo mirror create
-// <github-url>` targets when [cluster-host] is omitted, from the control plane's
-// cluster catalog (the same GET /api/v1/clusters the wizard uses): the cluster
-// flagged is_default, or the sole cluster when there is exactly one. It errors
-// when the catalog is empty or has no clear default so the user knows to pass
-// [cluster-host] explicitly, rather than silently guessing.
-func resolveDefaultClusterHost(ctx context.Context, c *coreapi.Client) (string, error) {
-	regions, err := availableRegions(ctx, c)
-	if err != nil {
-		return "", err
-	}
-	jurisdiction, err := callerJurisdiction(ctx, c)
-	if err != nil {
-		return "", err
-	}
-	return pickDefaultRegionHost(regions, jurisdiction)
-}
-
-// callerJurisdiction returns the active principal's home jurisdiction slug from
-// GET /me (e.g. "eu"). May return "" if the server doesn't report one.
-func callerJurisdiction(ctx context.Context, c *coreapi.Client) (string, error) {
-	me, err := c.GetMe(ctx)
-	if err != nil {
-		return "", renderCoreError(err)
-	}
-	j, _ := me.Jurisdiction.Get()
-	return j, nil
-}
-
-// pickDefaultRegionHost chooses the default cluster host for the caller's
-// jurisdiction. is_default is per-jurisdiction (each jurisdiction has one), so a
-// known jurisdiction selects its default directly. With no jurisdiction it falls
-// back to a lone cluster or a lone default; anything ambiguous errors so the
-// caller can tell the user to pass [cluster-host]. Pure, so the selection is
-// unit-testable without a live core.
-func pickDefaultRegionHost(regions []regionChoice, jurisdiction string) (string, error) {
-	if len(regions) == 0 {
-		return "", errors.New("no clusters available to mirror into; pass [cluster-host] explicitly")
-	}
-	if jurisdiction != "" {
-		for _, r := range regions {
-			if r.isDefault && r.jurisdiction == jurisdiction {
-				return r.host, nil
-			}
-		}
-		return "", fmt.Errorf("no default cluster for your jurisdiction (%s); pass [cluster-host] explicitly", jurisdiction)
-	}
-	if len(regions) == 1 {
-		return regions[0].host, nil
-	}
-	var defaults []regionChoice
-	for _, r := range regions {
-		if r.isDefault {
-			defaults = append(defaults, r)
-		}
-	}
-	if len(defaults) == 1 {
-		return defaults[0].host, nil
-	}
-	return "", errors.New("could not determine your jurisdiction's default cluster; pass [cluster-host] explicitly")
 }
 
 // mirrorCreateOutcome bundles the create response with the clone status

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -145,8 +145,8 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 			"the target cluster, then waits for the initial GitHub→EntireDB clone " +
 			"to finish so `git clone` works on return. Pass --no-wait to return " +
 			"as soon as the placement is registered. Idempotent on " +
-			"(upstream, cluster). The cluster-host defaults to " +
-			defaultClusterHost + " when omitted.",
+			"(upstream, cluster). The cluster-host defaults to your catalog's " +
+			"default cluster when omitted.",
 		Example: "  entire repo mirror create\n" +
 			"  entire repo mirror create github.com/octocat/hello-world\n" +
 			"  entire repo mirror create github.com/octocat/hello-world eu-west-1.entire.io",
@@ -160,10 +160,29 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 				cmd.SilenceUsage = true
 				return fmt.Errorf("invalid <github-url>: %w", err)
 			}
-			clusterHost := clusterArg(args)
-			if err := validateClusterHost(clusterHost); err != nil {
-				cmd.SilenceUsage = true
-				return fmt.Errorf("invalid [cluster-host]: %w", err)
+			var clusterHost string
+			if len(args) > 1 {
+				clusterHost = args[1]
+				if err := validateClusterHost(clusterHost); err != nil {
+					cmd.SilenceUsage = true
+					return fmt.Errorf("invalid [cluster-host]: %w", err)
+				}
+			} else {
+				// No cluster given: pick the catalog's default cluster (the same
+				// GET /api/v1/clusters source the wizard uses), resolved via the
+				// active context. runCore owns the active-client preamble
+				// (silence-usage, --insecure-http-auth, error mapping).
+				if err := runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+					h, rerr := resolveDefaultClusterHost(ctx, c)
+					if rerr != nil {
+						return rerr
+					}
+					clusterHost = h
+					fmt.Fprintf(cmd.ErrOrStderr(), "Using default cluster %s\n", clusterHost)
+					return nil
+				}); err != nil {
+					return err
+				}
 			}
 			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
 				errW := cmd.ErrOrStderr()
@@ -180,6 +199,40 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noWait, "no-wait", false, "return once the placement is registered, without waiting for the initial clone")
 	cmd.Flags().DurationVar(&waitTimeout, "wait-timeout", 30*time.Minute, "how long to wait for the initial clone to finish")
 	return cmd
+}
+
+// resolveDefaultClusterHost picks the cluster a `repo mirror create
+// <github-url>` targets when [cluster-host] is omitted, from the control plane's
+// cluster catalog (the same GET /api/v1/clusters the wizard uses): the cluster
+// flagged is_default, or the sole cluster when there is exactly one. It errors
+// when the catalog is empty or has no clear default so the user knows to pass
+// [cluster-host] explicitly, rather than silently guessing.
+func resolveDefaultClusterHost(ctx context.Context, c *coreapi.Client) (string, error) {
+	regions, err := availableRegions(ctx, c)
+	if err != nil {
+		return "", err
+	}
+	return pickDefaultRegionHost(regions)
+}
+
+// pickDefaultRegionHost chooses the default cluster host from the catalog: the
+// is-default cluster, or the sole cluster when there's exactly one. Empty or
+// ambiguous catalogs error so the caller can tell the user to pass
+// [cluster-host]. Pure, so the selection is unit-testable without a live core.
+func pickDefaultRegionHost(regions []regionChoice) (string, error) {
+	for _, r := range regions {
+		if r.isDefault {
+			return r.host, nil
+		}
+	}
+	switch len(regions) {
+	case 0:
+		return "", errors.New("no clusters available to mirror into; pass [cluster-host] explicitly")
+	case 1:
+		return regions[0].host, nil
+	default:
+		return "", errors.New("no default cluster configured; pass [cluster-host] explicitly")
+	}
 }
 
 // mirrorCreateOutcome bundles the create response with the clone status

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -149,7 +149,7 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 			"default cluster when omitted.",
 		Example: "  entire repo mirror create\n" +
 			"  entire repo mirror create github.com/octocat/hello-world\n" +
-			"  entire repo mirror create github.com/octocat/hello-world eu-west-1.entire.io",
+			"  entire repo mirror create github.com/octocat/hello-world aws-us-east-2.entire.io",
 		Args: cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -173,7 +173,9 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
 				errW := cmd.ErrOrStderr()
 				stop := startSpinner(errW, fmt.Sprintf("Cloning %s/%s into %s", owner, repo, clusterHost))
-				outcome, err := createAndAwaitMirror(ctx, c, owner, repo, clusterHost, noWait, waitTimeout)
+				// nil onStatus: the one-shot's single spinner shows liveness; the
+				// per-mirror progress lines are the wizard's concern.
+				outcome, err := createAndAwaitMirror(ctx, c, owner, repo, clusterHost, noWait, waitTimeout, nil)
 				// Only a confirmed-ready clone earns the ✓; everything else
 				// (empty, --no-wait, suspended, failed, timeout) erases the line
 				// and lets reportOneShotMirror print the specific outcome.
@@ -204,7 +206,7 @@ type mirrorCreateOutcome struct {
 // status. The returned error is the create error (when outcome.created is nil)
 // or the wait error — a status sentinel (errMirrorCloneFailed /
 // errMirrorSuspended) or a timeout; callers read outcome.status for the state.
-func createAndAwaitMirror(ctx context.Context, c *coreapi.Client, owner, repo, clusterHost string, noWait bool, timeout time.Duration) (mirrorCreateOutcome, error) {
+func createAndAwaitMirror(ctx context.Context, c *coreapi.Client, owner, repo, clusterHost string, noWait bool, timeout time.Duration, onStatus func(coreapi.MirrorStatus)) (mirrorCreateOutcome, error) {
 	created, err := c.CreateMirror(ctx, &coreapi.CreateMirrorInputBody{
 		Provider:    coreapi.CreateMirrorInputBodyProviderGithub,
 		Owner:       owner,
@@ -218,7 +220,7 @@ func createAndAwaitMirror(ctx context.Context, c *coreapi.Client, owner, repo, c
 	if noWait || created.Empty {
 		return outcome, nil
 	}
-	status, werr := awaitMirrorReady(ctx, c, created.MirrorId, timeout)
+	status, werr := awaitMirrorReady(ctx, c, created.MirrorId, timeout, onStatus)
 	outcome.status = status
 	outcome.polled = true
 	return outcome, werr

--- a/cmd/entire/cli/repo_mirror_collaborators.go
+++ b/cmd/entire/cli/repo_mirror_collaborators.go
@@ -74,7 +74,7 @@ func newRepoMirrorCollaboratorsAddCmd() *cobra.Command {
 			"(pull works without push-through). The cluster-host defaults to " +
 			defaultClusterHost + " when omitted.",
 		Example: "  entire repo mirror collaborators add github.com/acme/widget github:alice --role writer\n" +
-			"  entire repo mirror collaborators add github.com/acme/widget github:alice eu-west-1.entire.io --role reader",
+			"  entire repo mirror collaborators add github.com/acme/widget github:alice aws-us-east-2.entire.io --role reader",
 		Args: cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			owner, repo, err := parseGitHubURL(args[0])

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -242,6 +242,15 @@ func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Dur
 	outW := cmd.OutOrStdout()
 	errW := cmd.ErrOrStderr()
 
+	// The wizard drives interactive huh pickers, so it needs a real terminal.
+	// Without one (CI, pipes), fail fast with a clear pointer at the
+	// non-interactive form rather than letting huh error obscurely.
+	if !interactive.CanPromptInteractively() {
+		fmt.Fprintln(errW, "The mirror create wizard needs an interactive terminal.")
+		fmt.Fprintln(errW, "Run 'entire repo mirror create <github-url> [cluster-host]' to create one non-interactively.")
+		return NewSilentError(errors.New("not an interactive terminal"))
+	}
+
 	insecure := insecureHTTPRequested(cmd)
 	if insecure {
 		auth.EnableInsecureHTTP()
@@ -271,7 +280,7 @@ func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Dur
 		fmt.Fprintln(errW, "Run 'entire repo mirror list --show-available' to see what's onboardable.")
 		return nil
 	}
-	selectedRepos, err := pickRepos(outW, repos)
+	selectedRepos, err := pickRepos(ctx, outW, repos)
 	if err != nil || len(selectedRepos) == 0 {
 		return err
 	}
@@ -287,7 +296,7 @@ func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Dur
 	if len(regions) == 0 {
 		return errors.New("no regions available to mirror into")
 	}
-	selectedRegions, err := pickRegions(outW, regions, jurisdiction)
+	selectedRegions, err := pickRegions(ctx, outW, regions, jurisdiction)
 	if err != nil || len(selectedRegions) == 0 {
 		return err
 	}
@@ -296,6 +305,11 @@ func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Dur
 	targets := mirrorTargets(selectedRepos, selectedRegions)
 	results := createMirrors(ctx, errW, targets, noWait, waitTimeout)
 
+	// A cancelled run (Ctrl+C) leaves in-flight mirrors looking like errors;
+	// exit quietly instead of reporting them as "N mirror(s) failed".
+	if ctx.Err() != nil {
+		return NewSilentError(ctx.Err())
+	}
 	return reportMirrorResults(outW, errW, results)
 }
 
@@ -336,8 +350,8 @@ func ensureMirrorWizardAuth(ctx context.Context, errW io.Writer, insecure bool) 
 }
 
 // pickRepos runs the repo multi-select and returns the chosen available
-// mirrors. A clean cancel (Ctrl+C) returns (nil, nil).
-func pickRepos(w io.Writer, repos []coreapi.AvailableMirror) ([]coreapi.AvailableMirror, error) {
+// mirrors. A clean cancel (Ctrl+C / cancelled ctx) returns (nil, nil).
+func pickRepos(ctx context.Context, w io.Writer, repos []coreapi.AvailableMirror) ([]coreapi.AvailableMirror, error) {
 	repoByKey := make(map[string]coreapi.AvailableMirror, len(repos))
 	options := make([]huh.Option[string], len(repos))
 	for i, m := range repos {
@@ -363,7 +377,7 @@ func pickRepos(w io.Writer, repos []coreapi.AvailableMirror) ([]coreapi.Availabl
 				Value(&selected),
 		),
 	)
-	if err := form.Run(); err != nil {
+	if err := form.RunWithContext(ctx); err != nil {
 		return nil, handleFormCancellation(w, "Mirror create", err)
 	}
 
@@ -378,7 +392,7 @@ func pickRepos(w io.Writer, repos []coreapi.AvailableMirror) ([]coreapi.Availabl
 
 // pickRegions runs the region multi-select, pre-selecting the default cluster
 // for the caller's jurisdiction. A clean cancel returns (nil, nil).
-func pickRegions(w io.Writer, regions []regionChoice, jurisdiction string) ([]regionChoice, error) {
+func pickRegions(ctx context.Context, w io.Writer, regions []regionChoice, jurisdiction string) ([]regionChoice, error) {
 	opts, defaults := clusterChoices(regions, jurisdiction)
 	regionByHost := make(map[string]regionChoice, len(regions))
 	for _, r := range regions {
@@ -403,7 +417,7 @@ func pickRegions(w io.Writer, regions []regionChoice, jurisdiction string) ([]re
 				Value(&selected),
 		),
 	)
-	if err := form.Run(); err != nil {
+	if err := form.RunWithContext(ctx); err != nil {
 		return nil, handleFormCancellation(w, "Mirror create", err)
 	}
 
@@ -521,9 +535,13 @@ func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, cli
 	case coreapi.MirrorStatusReady:
 		res.status = mirrorStatusReady
 	case coreapi.MirrorStatusSuspended:
-		res.status, res.err = mirrorStatusSuspended, err
+		// Carry the mirror id + resume command so the failure summary is
+		// actionable, matching the one-shot's explainSuspendedMirror guidance.
+		res.status, res.err = mirrorStatusSuspended,
+			fmt.Errorf("suspended — an operator can resume it: entire-core admin mirrors resume %s", outcome.created.MirrorId)
 	case coreapi.MirrorStatusFailed:
-		res.status, res.err = mirrorStatusFailed, err
+		res.status, res.err = mirrorStatusFailed,
+			fmt.Errorf("initial clone failed (mirror %s)", outcome.created.MirrorId)
 	case coreapi.MirrorStatusProcessing:
 		nonTerminal()
 	default:

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -30,9 +30,10 @@ const (
 	mirrorStatusReady      = "ready"      // clone landed, ready to use
 	mirrorStatusRegistered = "registered" // placement created, clone in progress (--no-wait)
 	mirrorStatusEmpty      = "empty"      // upstream has no commits, nothing to clone
-	mirrorStatusSuspended  = "suspended"  // placement exists but the cluster won't issue clone tokens
+	mirrorStatusSuspended  = "suspended"  // placement exists but the cluster won't serve it
+	mirrorStatusFailed     = "failed"     // initial clone reached the terminal failed status
 	mirrorStatusTimedOut   = "timed out"  // clone didn't finish within --wait-timeout
-	mirrorStatusError      = "error"      // create or probe failed
+	mirrorStatusError      = "error"      // create or poll failed
 )
 
 // regionChoice is one mirrorable region offered by the create wizard's region
@@ -431,37 +432,45 @@ func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, cli
 		res.status, res.err = mirrorStatusError, clientErr
 		return res
 	}
-	created, err := c.CreateMirror(ctx, &coreapi.CreateMirrorInputBody{
-		Provider:    coreapi.CreateMirrorInputBodyProviderGithub,
-		Owner:       t.owner,
-		Repo:        t.repo,
-		ClusterHost: t.region.host,
-	})
-	if err != nil {
+	// Same create-then-wait path as the one-shot `repo mirror create <url>`
+	// (createAndAwaitMirror), so both report identical lifecycle states. The
+	// poll is silent; the wizard's aggregate spinner shows liveness.
+	outcome, err := createAndAwaitMirror(ctx, c, t.owner, t.repo, t.region.host, noWait, waitTimeout)
+	if outcome.created == nil {
 		res.status, res.err = mirrorStatusError, renderCoreError(err)
 		return res
 	}
-	res.cloneURL = created.MirrorUrl
+	res.cloneURL = outcome.created.MirrorUrl
 
-	switch {
-	case created.Empty:
-		res.status = mirrorStatusEmpty
-	case noWait:
-		res.status = mirrorStatusRegistered
-	default:
-		// Discard the per-mirror heartbeat: concurrent waits would interleave
-		// their dots on a shared writer. The aggregate spinner shows liveness.
-		werr := waitForMirrorClone(ctx, io.Discard, t.region.host, t.owner, t.repo, waitTimeout)
-		switch {
-		case werr == nil:
-			res.status = mirrorStatusReady
-		case errors.Is(werr, auth.ErrRepoTargetUnknown):
-			res.status, res.err = mirrorStatusSuspended, werr
-		case errors.Is(werr, context.DeadlineExceeded):
-			res.status, res.err = mirrorStatusTimedOut, werr
-		default:
-			res.status, res.err = mirrorStatusError, werr
+	if !outcome.polled {
+		if outcome.created.Empty {
+			res.status = mirrorStatusEmpty
+		} else {
+			res.status = mirrorStatusRegistered
 		}
+		return res
+	}
+
+	// nonTerminal classifies a still-processing/unknown result: the poll ended
+	// without a terminal status, so the wait timed out or a poll call errored.
+	nonTerminal := func() {
+		if errors.Is(err, context.DeadlineExceeded) {
+			res.status, res.err = mirrorStatusTimedOut, err
+		} else {
+			res.status, res.err = mirrorStatusError, err
+		}
+	}
+	switch outcome.status {
+	case coreapi.MirrorStatusReady:
+		res.status = mirrorStatusReady
+	case coreapi.MirrorStatusSuspended:
+		res.status, res.err = mirrorStatusSuspended, err
+	case coreapi.MirrorStatusFailed:
+		res.status, res.err = mirrorStatusFailed, err
+	case coreapi.MirrorStatusProcessing:
+		nonTerminal()
+	default:
+		nonTerminal()
 	}
 	return res
 }

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -103,9 +103,12 @@ func hostFromPublicURL(raw string) (string, error) {
 	// Reject anything beyond scheme://host[:port]. url.Parse demotes the
 	// `host@evil.com` userinfo trick into u.User (leaving u.Host=evil.com) and
 	// stashes a trailing path in u.Path, neither of which validateClusterHost
-	// would otherwise see. Same belt-and-suspenders the positional <cluster-host>
-	// arg gets — the host flows into clone URLs and the STS audience.
-	if u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+	// would otherwise see. A bare "/" path is tolerated: publicUrl is a trusted
+	// catalog field, and a trailing slash (https://host/) is benign — rejecting
+	// it would silently drop the cluster and could leave the wizard with no
+	// regions. Anything richer (a real path, query, fragment, userinfo) is still
+	// refused, since the host flows into clone URLs and the STS audience.
+	if u.User != nil || (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
 		return "", fmt.Errorf("public_url %q must be scheme://host[:port] only", raw)
 	}
 	if err := validateClusterHost(u.Host); err != nil {

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -136,13 +136,17 @@ func selectableAvailableRepos(avail []coreapi.AvailableMirror) []coreapi.Availab
 	return out
 }
 
-// clusterChoices maps regions to multi-select options (value = bare host) and
-// the hosts that should start checked (the is-default regions).
-func clusterChoices(regions []regionChoice) (opts []huh.Option[string], defaults []string) {
+// clusterChoices maps regions to multi-select options (value = bare host),
+// listing every cluster, and returns the host(s) that should start checked:
+// the default cluster for the caller's jurisdiction. is_default is
+// per-jurisdiction, so pre-selecting only the caller's avoids defaulting a repo
+// into every jurisdiction. With no jurisdiction nothing is pre-checked (the user
+// picks). All clusters stay selectable regardless.
+func clusterChoices(regions []regionChoice, jurisdiction string) (opts []huh.Option[string], defaults []string) {
 	opts = make([]huh.Option[string], 0, len(regions))
 	for _, r := range regions {
 		opts = append(opts, huh.NewOption(regionLabel(r), r.host))
-		if r.isDefault {
+		if jurisdiction != "" && r.isDefault && r.jurisdiction == jurisdiction {
 			defaults = append(defaults, r.host)
 		}
 	}
@@ -218,7 +222,8 @@ func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Dur
 		auth.EnableInsecureHTTP()
 	}
 
-	if err := ensureMirrorWizardAuth(ctx, errW, insecure); err != nil {
+	jurisdiction, err := ensureMirrorWizardAuth(ctx, errW, insecure)
+	if err != nil {
 		return err
 	}
 
@@ -257,7 +262,7 @@ func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Dur
 	if len(regions) == 0 {
 		return errors.New("no regions available to mirror into")
 	}
-	selectedRegions, err := pickRegions(outW, regions)
+	selectedRegions, err := pickRegions(outW, regions, jurisdiction)
 	if err != nil || len(selectedRegions) == 0 {
 		return err
 	}
@@ -272,31 +277,37 @@ func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Dur
 // ensureMirrorWizardAuth mirrors `entire auth status`: resolve the active
 // target (honouring ENTIRE_TOKEN), enforce TLS on the core we'll dial, and
 // validate the token with a /me probe so the wizard fails fast with a re-login
-// hint rather than deep inside the first API call.
-func ensureMirrorWizardAuth(ctx context.Context, errW io.Writer, insecure bool) error {
+// hint rather than deep inside the first API call. Returns the caller's home
+// jurisdiction (from /me, may be "") so the region picker can pre-select that
+// jurisdiction's default cluster.
+func ensureMirrorWizardAuth(ctx context.Context, errW io.Writer, insecure bool) (string, error) {
 	target, err := resolveAuthStatusTarget(ctx, auth.Contexts, auth.RefreshedLoginToken)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if target.token == "" {
 		fmt.Fprintln(errW, "Not logged in. Run 'entire login' to authenticate.")
-		return NewSilentError(errors.New("not logged in"))
+		return "", NewSilentError(errors.New("not logged in"))
 	}
 	if !insecure && target.coreURL != "" {
 		if err := api.RequireSecureURL(target.coreURL); err != nil {
-			return fmt.Errorf("login server URL check: %w", err)
+			return "", fmt.Errorf("login server URL check: %w", err)
 		}
 	}
 	profile, err := defaultFetchProfile(ctx, target.coreURL, target.token)
 	if err != nil {
 		if isKeychainTokenRejected(err) {
 			fmt.Fprintf(errW, "Login for %s is no longer valid. Run 'entire login' to re-authenticate.\n", target.coreURL)
-			return NewSilentError(errors.New("login no longer valid"))
+			return "", NewSilentError(errors.New("login no longer valid"))
 		}
-		return fmt.Errorf("validate auth: %w", err)
+		return "", fmt.Errorf("validate auth: %w", err)
 	}
-	fmt.Fprintf(errW, "Signed in as %s via %s\n", profile.Handle, target.coreURL)
-	return nil
+	if profile.Jurisdiction != "" {
+		fmt.Fprintf(errW, "Signed in as %s (%s) via %s\n", profile.Handle, profile.Jurisdiction, target.coreURL)
+	} else {
+		fmt.Fprintf(errW, "Signed in as %s via %s\n", profile.Handle, target.coreURL)
+	}
+	return profile.Jurisdiction, nil
 }
 
 // pickRepos runs the repo multi-select and returns the chosen available
@@ -339,10 +350,10 @@ func pickRepos(w io.Writer, repos []coreapi.AvailableMirror) ([]coreapi.Availabl
 	return chosen, nil
 }
 
-// pickRegions runs the region multi-select, pre-selecting the default
-// region(s). A clean cancel returns (nil, nil).
-func pickRegions(w io.Writer, regions []regionChoice) ([]regionChoice, error) {
-	opts, defaults := clusterChoices(regions)
+// pickRegions runs the region multi-select, pre-selecting the default cluster
+// for the caller's jurisdiction. A clean cancel returns (nil, nil).
+func pickRegions(w io.Writer, regions []regionChoice, jurisdiction string) ([]regionChoice, error) {
+	opts, defaults := clusterChoices(regions, jurisdiction)
 	regionByHost := make(map[string]regionChoice, len(regions))
 	for _, r := range regions {
 		regionByHost[r.host] = r

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -1,0 +1,500 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"charm.land/huh/v2"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// mirrorCreateConcurrency bounds how many (repo, region) mirror creations run
+// at once. The slow phase is the per-mirror clone wait, which is I/O-bound on
+// the cluster, so a modest fan-out keeps the wizard responsive without
+// hammering the control plane or the user's STS.
+const mirrorCreateConcurrency = 8
+
+// Per-mirror outcome labels shown in the results table's STATUS column.
+const (
+	mirrorStatusReady      = "ready"      // clone landed, ready to use
+	mirrorStatusRegistered = "registered" // placement created, clone in progress (--no-wait)
+	mirrorStatusEmpty      = "empty"      // upstream has no commits, nothing to clone
+	mirrorStatusSuspended  = "suspended"  // placement exists but the cluster won't issue clone tokens
+	mirrorStatusTimedOut   = "timed out"  // clone didn't finish within --wait-timeout
+	mirrorStatusError      = "error"      // create or probe failed
+)
+
+// regionChoice is one mirrorable region offered by the create wizard's region
+// picker, sourced from the control plane's cluster catalog
+// (GET /api/v1/clusters via availableRegions).
+type regionChoice struct {
+	slug         string
+	jurisdiction string
+	host         string // bare cluster host passed to CreateMirror / validateClusterHost
+	isDefault    bool
+}
+
+// availableRegions lists the data-plane clusters the user may mirror into,
+// fetched from the control plane's cluster catalog. A cluster whose advertised
+// public URL can't be safely reduced to a bare host (hostFromPublicURL) is
+// skipped rather than failing the whole wizard, so a single malformed entry
+// can't block onboarding into the others.
+func availableRegions(ctx context.Context, c *coreapi.Client) ([]regionChoice, error) {
+	out, err := c.ListClusters(ctx)
+	if err != nil {
+		return nil, renderCoreError(err)
+	}
+	return clustersToRegions(out.Clusters), nil
+}
+
+// clustersToRegions maps the catalog's clusters to picker choices, dropping any
+// whose advertised public URL can't be safely reduced to a bare host.
+func clustersToRegions(clusters []coreapi.Cluster) []regionChoice {
+	regions := make([]regionChoice, 0, len(clusters))
+	for _, cl := range clusters {
+		host, herr := hostFromPublicURL(cl.PublicUrl)
+		if herr != nil {
+			continue
+		}
+		regions = append(regions, regionChoice{
+			slug:         cl.Slug,
+			jurisdiction: cl.Jurisdiction,
+			host:         host,
+			isDefault:    cl.IsDefault,
+		})
+	}
+	return regions
+}
+
+// hostFromPublicURL extracts the bare cluster host from a cluster's public_url
+// (with or without a scheme) and runs it through validateClusterHost, the same
+// anti-token-leak guard the positional <cluster-host> arg uses. Kept separate
+// so the ListClusters → regionChoice mapping is unit-testable without a live
+// catalog.
+func hostFromPublicURL(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", errors.New("empty public_url")
+	}
+	if !strings.Contains(s, "://") {
+		s = "https://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("parse public_url %q: %w", raw, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("public_url %q has no host", raw)
+	}
+	// Reject anything beyond scheme://host[:port]. url.Parse demotes the
+	// `host@evil.com` userinfo trick into u.User (leaving u.Host=evil.com) and
+	// stashes a trailing path in u.Path, neither of which validateClusterHost
+	// would otherwise see. Same belt-and-suspenders the positional <cluster-host>
+	// arg gets — the host flows into clone URLs and the STS audience.
+	if u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("public_url %q must be scheme://host[:port] only", raw)
+	}
+	if err := validateClusterHost(u.Host); err != nil {
+		return "", err
+	}
+	return u.Host, nil
+}
+
+// selectableAvailableRepos narrows the ListAvailableMirrors result to repos the
+// wizard should offer: status "available" (not already mirrored or owner-only)
+// with write or admin access (read-only can't be onboarded). Sorted by
+// owner/repo for a stable picker order.
+func selectableAvailableRepos(avail []coreapi.AvailableMirror) []coreapi.AvailableMirror {
+	out := make([]coreapi.AvailableMirror, 0, len(avail))
+	for _, m := range avail {
+		if m.Status != coreapi.AvailableMirrorStatusAvailable {
+			continue
+		}
+		if m.Access != coreapi.AvailableMirrorAccessWrite && m.Access != coreapi.AvailableMirrorAccessAdmin {
+			continue
+		}
+		out = append(out, m)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Owner != out[j].Owner {
+			return out[i].Owner < out[j].Owner
+		}
+		return out[i].Repo < out[j].Repo
+	})
+	return out
+}
+
+// clusterChoices maps regions to multi-select options (value = bare host) and
+// the hosts that should start checked (the is-default regions).
+func clusterChoices(regions []regionChoice) (opts []huh.Option[string], defaults []string) {
+	opts = make([]huh.Option[string], 0, len(regions))
+	for _, r := range regions {
+		opts = append(opts, huh.NewOption(regionLabel(r), r.host))
+		if r.isDefault {
+			defaults = append(defaults, r.host)
+		}
+	}
+	return opts, defaults
+}
+
+// regionLabel is the human label for a region in the picker and the results
+// table: "slug (jurisdiction)" when both are known, else whatever identifier we
+// have, falling back to the bare host.
+func regionLabel(r regionChoice) string {
+	switch {
+	case r.slug != "" && r.jurisdiction != "":
+		return fmt.Sprintf("%s (%s)", r.slug, r.jurisdiction)
+	case r.slug != "":
+		return r.slug
+	default:
+		return r.host
+	}
+}
+
+// mirrorTarget is one unit of work: a selected repo to be mirrored into a
+// selected region. The wizard creates the cross-product of repos × regions.
+type mirrorTarget struct {
+	owner  string
+	repo   string
+	region regionChoice
+}
+
+// mirrorTargets expands the selected repos and regions into the full
+// cross-product of (repo, region) pairs.
+func mirrorTargets(repos []coreapi.AvailableMirror, regions []regionChoice) []mirrorTarget {
+	targets := make([]mirrorTarget, 0, len(repos)*len(regions))
+	for _, r := range repos {
+		for _, reg := range regions {
+			targets = append(targets, mirrorTarget{owner: r.Owner, repo: r.Repo, region: reg})
+		}
+	}
+	return targets
+}
+
+// mirrorResult is the outcome of creating one (repo, region) mirror.
+type mirrorResult struct {
+	owner       string
+	repo        string
+	regionLabel string
+	cloneURL    string
+	status      string // ready | registered | empty | suspended | timed out | error
+	err         error
+}
+
+var mirrorCreateResultColumns = []string{"REPO", "REGION", "STATUS", "CLONE URL"}
+
+func mirrorCreateResultRow(r mirrorResult) []string {
+	url := r.cloneURL
+	if url == "" {
+		url = placeholderDash
+	}
+	return []string{r.owner + "/" + r.repo, r.regionLabel, r.status, url}
+}
+
+// runMirrorCreateWizard is the zero-argument `entire repo mirror create` flow:
+// verify auth, pick repos, pick regions, then create the cross-product of
+// mirrors in parallel and report the clone URLs. noWait/waitTimeout carry the
+// same meaning as the positional-arg create path.
+func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Duration) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	outW := cmd.OutOrStdout()
+	errW := cmd.ErrOrStderr()
+
+	insecure := insecureHTTPRequested(cmd)
+	if insecure {
+		auth.EnableInsecureHTTP()
+	}
+
+	if err := ensureMirrorWizardAuth(ctx, errW, insecure); err != nil {
+		return err
+	}
+
+	client, err := coreapi.New()
+	if err != nil {
+		return fmt.Errorf("connect to Entire control plane: %w", err)
+	}
+
+	// --- pick repos ---------------------------------------------------------
+	avail, err := client.ListAvailableMirrors(ctx, coreapi.ListAvailableMirrorsParams{})
+	if err != nil {
+		return renderCoreError(err)
+	}
+	repos := selectableAvailableRepos(avail.Available)
+	if len(repos) == 0 {
+		fmt.Fprintln(errW, "No GitHub repos available to mirror (you need write access to a repo that isn't mirrored yet).")
+		fmt.Fprintln(errW, "Run 'entire repo mirror list --show-available' to see what's onboardable.")
+		return nil
+	}
+	selectedRepos, err := pickRepos(outW, repos)
+	if err != nil || len(selectedRepos) == 0 {
+		return err
+	}
+
+	// --- pick regions -------------------------------------------------------
+	regions, err := availableRegions(ctx, client)
+	if err != nil {
+		return fmt.Errorf("list regions: %w", err)
+	}
+	if len(regions) == 0 {
+		return errors.New("no regions available to mirror into")
+	}
+	selectedRegions, err := pickRegions(outW, regions)
+	if err != nil || len(selectedRegions) == 0 {
+		return err
+	}
+
+	// --- create + poll ------------------------------------------------------
+	targets := mirrorTargets(selectedRepos, selectedRegions)
+	results := createMirrors(ctx, errW, targets, noWait, waitTimeout)
+
+	return reportMirrorResults(outW, errW, results)
+}
+
+// ensureMirrorWizardAuth mirrors `entire auth status`: resolve the active
+// target (honouring ENTIRE_TOKEN), enforce TLS on the core we'll dial, and
+// validate the token with a /me probe so the wizard fails fast with a re-login
+// hint rather than deep inside the first API call.
+func ensureMirrorWizardAuth(ctx context.Context, errW io.Writer, insecure bool) error {
+	target, err := resolveAuthStatusTarget(ctx, auth.Contexts, auth.RefreshedLoginToken)
+	if err != nil {
+		return err
+	}
+	if target.token == "" {
+		fmt.Fprintln(errW, "Not logged in. Run 'entire login' to authenticate.")
+		return NewSilentError(errors.New("not logged in"))
+	}
+	if !insecure && target.coreURL != "" {
+		if err := api.RequireSecureURL(target.coreURL); err != nil {
+			return fmt.Errorf("login server URL check: %w", err)
+		}
+	}
+	profile, err := defaultFetchProfile(ctx, target.coreURL, target.token)
+	if err != nil {
+		if isKeychainTokenRejected(err) {
+			fmt.Fprintf(errW, "Login for %s is no longer valid. Run 'entire login' to re-authenticate.\n", target.coreURL)
+			return NewSilentError(errors.New("login no longer valid"))
+		}
+		return fmt.Errorf("validate auth: %w", err)
+	}
+	fmt.Fprintf(errW, "Signed in as %s via %s\n", profile.Handle, target.coreURL)
+	return nil
+}
+
+// pickRepos runs the repo multi-select and returns the chosen available
+// mirrors. A clean cancel (Ctrl+C) returns (nil, nil).
+func pickRepos(w io.Writer, repos []coreapi.AvailableMirror) ([]coreapi.AvailableMirror, error) {
+	repoByKey := make(map[string]coreapi.AvailableMirror, len(repos))
+	options := make([]huh.Option[string], len(repos))
+	for i, m := range repos {
+		key := m.Owner + "/" + m.Repo
+		repoByKey[key] = m
+		options[i] = huh.NewOption(key, key)
+	}
+
+	var selected []string
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Select repos to mirror").
+				Description("Space to select, enter to confirm.").
+				Options(options...).
+				Validate(func(s []string) error {
+					if len(s) == 0 {
+						return errors.New("select at least one repo")
+					}
+					return nil
+				}).
+				Value(&selected),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return nil, handleFormCancellation(w, "Mirror create", err)
+	}
+
+	chosen := make([]coreapi.AvailableMirror, 0, len(selected))
+	for _, key := range selected {
+		if m, ok := repoByKey[key]; ok {
+			chosen = append(chosen, m)
+		}
+	}
+	return chosen, nil
+}
+
+// pickRegions runs the region multi-select, pre-selecting the default
+// region(s). A clean cancel returns (nil, nil).
+func pickRegions(w io.Writer, regions []regionChoice) ([]regionChoice, error) {
+	opts, defaults := clusterChoices(regions)
+	regionByHost := make(map[string]regionChoice, len(regions))
+	for _, r := range regions {
+		regionByHost[r.host] = r
+	}
+
+	// Pre-fill with the default hosts so they start checked.
+	selected := append([]string(nil), defaults...)
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Select regions to mirror into").
+				Description("Each selected repo is mirrored into every selected region. Space to select, enter to confirm.").
+				Options(opts...).
+				Validate(func(s []string) error {
+					if len(s) == 0 {
+						return errors.New("select at least one region")
+					}
+					return nil
+				}).
+				Value(&selected),
+		),
+	)
+	if err := form.Run(); err != nil {
+		return nil, handleFormCancellation(w, "Mirror create", err)
+	}
+
+	chosen := make([]regionChoice, 0, len(selected))
+	for _, host := range selected {
+		if r, ok := regionByHost[host]; ok {
+			chosen = append(chosen, r)
+		}
+	}
+	return chosen, nil
+}
+
+// createMirrors fans out CreateMirror (and the clone-readiness poll) across all
+// targets in parallel, returning one result per target in input order. One
+// cluster client is built per region and shared across that region's repos; a
+// region the active login can't reach fails every pair in that region rather
+// than aborting the whole run.
+func createMirrors(ctx context.Context, errW io.Writer, targets []mirrorTarget, noWait bool, waitTimeout time.Duration) []mirrorResult {
+	// One client per distinct region, built once.
+	clientByHost := make(map[string]*coreapi.Client)
+	clientErrByHost := make(map[string]error)
+	for _, t := range targets {
+		if _, seen := clientByHost[t.region.host]; seen {
+			continue
+		}
+		if _, seen := clientErrByHost[t.region.host]; seen {
+			continue
+		}
+		c, err := coreapi.NewForCluster(ctx, t.region.host)
+		if err != nil {
+			clientErrByHost[t.region.host] = err
+		} else {
+			clientByHost[t.region.host] = c
+		}
+	}
+
+	stop := startSpinner(errW, fmt.Sprintf("Creating %d mirror(s)…", len(targets)))
+	results := make([]mirrorResult, len(targets))
+	g := new(errgroup.Group)
+	g.SetLimit(mirrorCreateConcurrency)
+	for i, t := range targets {
+		g.Go(func() error {
+			results[i] = createOneMirror(ctx, t, clientByHost[t.region.host], clientErrByHost[t.region.host], noWait, waitTimeout)
+			return nil
+		})
+	}
+	// createOneMirror folds every failure into results and never returns an
+	// error, so Wait is structurally always nil; check it anyway to satisfy
+	// errcheck and stay correct if that invariant ever changes.
+	if err := g.Wait(); err != nil {
+		fmt.Fprintf(errW, "mirror creation: %v\n", err)
+	}
+	stop(true)
+	return results
+}
+
+// createOneMirror registers a single (repo, region) mirror and, unless noWait
+// or the upstream is empty, waits for its initial clone. It never returns an
+// error: every outcome is folded into the mirrorResult so a single failure
+// can't sink the batch.
+func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, clientErr error, noWait bool, waitTimeout time.Duration) mirrorResult {
+	res := mirrorResult{owner: t.owner, repo: t.repo, regionLabel: regionLabel(t.region)}
+	if clientErr != nil {
+		res.status, res.err = mirrorStatusError, clientErr
+		return res
+	}
+	created, err := c.CreateMirror(ctx, &coreapi.CreateMirrorInputBody{
+		Provider:    coreapi.CreateMirrorInputBodyProviderGithub,
+		Owner:       t.owner,
+		Repo:        t.repo,
+		ClusterHost: t.region.host,
+	})
+	if err != nil {
+		res.status, res.err = mirrorStatusError, renderCoreError(err)
+		return res
+	}
+	res.cloneURL = created.MirrorUrl
+
+	switch {
+	case created.Empty:
+		res.status = mirrorStatusEmpty
+	case noWait:
+		res.status = mirrorStatusRegistered
+	default:
+		// Discard the per-mirror heartbeat: concurrent waits would interleave
+		// their dots on a shared writer. The aggregate spinner shows liveness.
+		werr := waitForMirrorClone(ctx, io.Discard, t.region.host, t.owner, t.repo, waitTimeout)
+		switch {
+		case werr == nil:
+			res.status = mirrorStatusReady
+		case errors.Is(werr, auth.ErrRepoTargetUnknown):
+			res.status, res.err = mirrorStatusSuspended, werr
+		case errors.Is(werr, context.DeadlineExceeded):
+			res.status, res.err = mirrorStatusTimedOut, werr
+		default:
+			res.status, res.err = mirrorStatusError, werr
+		}
+	}
+	return res
+}
+
+// reportMirrorResults renders the results table, a copy-pasteable git-clone
+// block for the ready mirrors, and per-failure detail. It returns a
+// SilentError (so the table isn't reprinted) when any mirror failed, giving the
+// command a non-zero exit while still showing what succeeded.
+func reportMirrorResults(outW, errW io.Writer, results []mirrorResult) error {
+	if len(results) == 0 {
+		return nil
+	}
+	if err := printTable(outW, mirrorCreateResultColumns, results, mirrorCreateResultRow); err != nil {
+		return err
+	}
+
+	var readyURLs []string
+	var failures int
+	for _, r := range results {
+		if r.status == mirrorStatusReady && r.cloneURL != "" {
+			readyURLs = append(readyURLs, r.cloneURL)
+		}
+		if r.err != nil {
+			failures++
+		}
+	}
+	if len(readyURLs) > 0 {
+		fmt.Fprintln(outW, "\nClone them:")
+		for _, u := range readyURLs {
+			fmt.Fprintf(outW, "  git clone %s\n", u)
+		}
+	}
+	if failures > 0 {
+		for _, r := range results {
+			if r.err != nil {
+				fmt.Fprintf(errW, "%s/%s @ %s: %v\n", r.owner, r.repo, r.regionLabel, r.err)
+			}
+		}
+		return NewSilentError(fmt.Errorf("%d mirror(s) failed", failures))
+	}
+	return nil
+}

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -142,9 +142,20 @@ func selectableAvailableRepos(avail []coreapi.AvailableMirror) []coreapi.Availab
 // per-jurisdiction, so pre-selecting only the caller's avoids defaulting a repo
 // into every jurisdiction. With no jurisdiction nothing is pre-checked (the user
 // picks). All clusters stay selectable regardless.
+//
+// The caller's-jurisdiction clusters are listed first so that on a short
+// terminal — where huh's option viewport shows only the top rows — the visible,
+// pre-checked default is the relevant one, not some other jurisdiction's.
 func clusterChoices(regions []regionChoice, jurisdiction string) (opts []huh.Option[string], defaults []string) {
-	opts = make([]huh.Option[string], 0, len(regions))
-	for _, r := range regions {
+	ordered := make([]regionChoice, len(regions))
+	copy(ordered, regions)
+	if jurisdiction != "" {
+		sort.SliceStable(ordered, func(i, j int) bool {
+			return ordered[i].jurisdiction == jurisdiction && ordered[j].jurisdiction != jurisdiction
+		})
+	}
+	opts = make([]huh.Option[string], 0, len(ordered))
+	for _, r := range ordered {
 		opts = append(opts, huh.NewOption(regionLabel(r), r.host))
 		if jurisdiction != "" && r.isDefault && r.jurisdiction == jurisdiction {
 			defaults = append(defaults, r.host)
@@ -365,7 +376,7 @@ func pickRegions(w io.Writer, regions []regionChoice, jurisdiction string) ([]re
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("Select regions to mirror into").
-				Description("Each selected repo is mirrored into every selected region. Space to select, enter to confirm.").
+				Description("Each repo is mirrored into every selected region.").
 				Options(opts...).
 				Validate(func(s []string) error {
 					if len(s) == 0 {

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -535,13 +535,9 @@ func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, cli
 	case coreapi.MirrorStatusReady:
 		res.status = mirrorStatusReady
 	case coreapi.MirrorStatusSuspended:
-		// Carry the mirror id + resume command so the failure summary is
-		// actionable, matching the one-shot's explainSuspendedMirror guidance.
-		res.status, res.err = mirrorStatusSuspended,
-			fmt.Errorf("suspended — an operator can resume it: entire-core admin mirrors resume %s", outcome.created.MirrorId)
+		res.status, res.err = mirrorStatusSuspended, errors.New("the mirror is suspended; contact support")
 	case coreapi.MirrorStatusFailed:
-		res.status, res.err = mirrorStatusFailed,
-			fmt.Errorf("initial clone failed (mirror %s)", outcome.created.MirrorId)
+		res.status, res.err = mirrorStatusFailed, errors.New("the initial clone failed; contact support")
 	case coreapi.MirrorStatusProcessing:
 		nonTerminal()
 	default:

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -658,6 +658,8 @@ func reportMirrorResults(outW, errW io.Writer, results []mirrorResult) error {
 	if len(results) == 0 {
 		return nil
 	}
+	// Headroom between the live progress block and the summary table.
+	fmt.Fprintln(outW)
 	if err := printTable(outW, mirrorCreateResultColumns, results, mirrorCreateResultRow); err != nil {
 		return err
 	}

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -136,6 +136,18 @@ func selectableAvailableRepos(avail []coreapi.AvailableMirror) []coreapi.Availab
 	return out
 }
 
+// multiSelectHeight returns an explicit huh multi-select Height that keeps every
+// option visible. huh auto-sizes an unset height to (rendered option lines −
+// title/description rows), which collapses to ~1 visible row for short lists
+// (e.g. 3 regions vs. a long repo list) — the cause of the region picker
+// appearing clamped to one option. We set it to the option count plus slack for
+// the title + (possibly wrapped) description so the whole list shows; huh still
+// scrolls if the list outgrows the terminal.
+func multiSelectHeight(n int) int {
+	const headerSlack = 3 // title (1) + description (1–2 when wrapped)
+	return n + headerSlack
+}
+
 // clusterChoices maps regions to multi-select options (value = bare host),
 // listing every cluster, and returns the host(s) that should start checked:
 // the default cluster for the caller's jurisdiction. is_default is
@@ -339,6 +351,7 @@ func pickRepos(w io.Writer, repos []coreapi.AvailableMirror) ([]coreapi.Availabl
 				Title("Select repos to mirror").
 				Description("Space to select, enter to confirm.").
 				Options(options...).
+				Height(multiSelectHeight(len(options))).
 				Validate(func(s []string) error {
 					if len(s) == 0 {
 						return errors.New("select at least one repo")
@@ -378,6 +391,7 @@ func pickRegions(w io.Writer, regions []regionChoice, jurisdiction string) ([]re
 				Title("Select regions to mirror into").
 				Description("Each repo is mirrored into every selected region.").
 				Options(opts...).
+				Height(multiSelectHeight(len(opts))).
 				Validate(func(s []string) error {
 					if len(s) == 0 {
 						return errors.New("select at least one region")

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"charm.land/huh/v2"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/internal/coreapi"
 )
 
@@ -438,13 +440,22 @@ func createMirrors(ctx context.Context, errW io.Writer, targets []mirrorTarget, 
 		}
 	}
 
-	stop := startSpinner(errW, fmt.Sprintf("Creating %d mirror(s)…", len(targets)))
+	// Docker-pull-style live progress: one line per (repo, region), each
+	// updating independently as its CreateMirror + clone poll advance.
+	labels := make([]string, len(targets))
+	for i, t := range targets {
+		labels[i] = t.owner + "/" + t.repo + " @ " + t.region.host
+	}
+	prog := newMirrorProgress(errW, labels)
+	prog.start()
+
 	results := make([]mirrorResult, len(targets))
 	g := new(errgroup.Group)
 	g.SetLimit(mirrorCreateConcurrency)
 	for i, t := range targets {
 		g.Go(func() error {
-			results[i] = createOneMirror(ctx, t, clientByHost[t.region.host], clientErrByHost[t.region.host], noWait, waitTimeout)
+			results[i] = createOneMirror(ctx, t, clientByHost[t.region.host], clientErrByHost[t.region.host], noWait, waitTimeout,
+				func(status string, final, ok bool) { prog.set(i, status, final, ok) })
 			return nil
 		})
 	}
@@ -454,26 +465,35 @@ func createMirrors(ctx context.Context, errW io.Writer, targets []mirrorTarget, 
 	if err := g.Wait(); err != nil {
 		fmt.Fprintf(errW, "mirror creation: %v\n", err)
 	}
-	stop(true)
+	prog.stop()
 	return results
 }
 
 // createOneMirror registers a single (repo, region) mirror and, unless noWait
 // or the upstream is empty, waits for its initial clone. It never returns an
 // error: every outcome is folded into the mirrorResult so a single failure
-// can't sink the batch.
-func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, clientErr error, noWait bool, waitTimeout time.Duration) mirrorResult {
+// can't sink the batch. report (may be nil) is called as the mirror moves
+// through its phases so the caller can render live progress; the final call has
+// final=true and ok set to whether it succeeded.
+func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, clientErr error, noWait bool, waitTimeout time.Duration, report func(status string, final, ok bool)) mirrorResult {
+	if report == nil {
+		report = func(string, bool, bool) {}
+	}
 	res := mirrorResult{owner: t.owner, repo: t.repo, regionLabel: regionLabel(t.region)}
 	if clientErr != nil {
 		res.status, res.err = mirrorStatusError, clientErr
+		report(mirrorStatusError, true, false)
 		return res
 	}
+	report("creating", false, false)
 	// Same create-then-wait path as the one-shot `repo mirror create <url>`
 	// (createAndAwaitMirror), so both report identical lifecycle states. The
-	// poll is silent; the wizard's aggregate spinner shows liveness.
-	outcome, err := createAndAwaitMirror(ctx, c, t.owner, t.repo, t.region.host, noWait, waitTimeout)
+	// per-poll status drives this mirror's progress line.
+	outcome, err := createAndAwaitMirror(ctx, c, t.owner, t.repo, t.region.host, noWait, waitTimeout,
+		func(s coreapi.MirrorStatus) { report(string(s), false, false) })
 	if outcome.created == nil {
 		res.status, res.err = mirrorStatusError, renderCoreError(err)
+		report(mirrorStatusError, true, false)
 		return res
 	}
 	res.cloneURL = outcome.created.MirrorUrl
@@ -484,6 +504,7 @@ func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, cli
 		} else {
 			res.status = mirrorStatusRegistered
 		}
+		report(res.status, true, true)
 		return res
 	}
 
@@ -508,7 +529,125 @@ func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, cli
 	default:
 		nonTerminal()
 	}
+	report(res.status, true, res.err == nil)
 	return res
+}
+
+// mirrorProgress renders a Docker-pull-style live list: one line per mirror,
+// each showing its label and a status that updates independently — a spinner
+// while in flight, ✓/✗ once terminal. On a non-terminal writer (pipes, tests)
+// it degrades to one printed line per mirror as each reaches a terminal state.
+type mirrorProgress struct {
+	w       io.Writer
+	tty     bool
+	labelW  int
+	mu      sync.Mutex
+	lines   []mirrorProgressLine
+	frame   int
+	painted bool
+	done    chan struct{}
+	stopped chan struct{}
+}
+
+type mirrorProgressLine struct {
+	label   string
+	status  string
+	final   bool
+	ok      bool
+	printed bool // non-tty: terminal line already emitted
+}
+
+func newMirrorProgress(w io.Writer, labels []string) *mirrorProgress {
+	lines := make([]mirrorProgressLine, len(labels))
+	labelW := 0
+	for i, l := range labels {
+		lines[i] = mirrorProgressLine{label: l, status: "queued"}
+		if n := len(l); n > labelW {
+			labelW = n
+		}
+	}
+	return &mirrorProgress{w: w, tty: interactive.IsTerminalWriter(w), labelW: labelW, lines: lines}
+}
+
+// start paints the initial block and, on a TTY, begins animating the spinner.
+func (p *mirrorProgress) start() {
+	if !p.tty {
+		return
+	}
+	p.done = make(chan struct{})
+	p.stopped = make(chan struct{})
+	p.mu.Lock()
+	p.renderLocked()
+	p.mu.Unlock()
+	go func() {
+		defer close(p.stopped)
+		ticker := time.NewTicker(spinnerInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-p.done:
+				return
+			case <-ticker.C:
+				p.mu.Lock()
+				p.frame++
+				p.renderLocked()
+				p.mu.Unlock()
+			}
+		}
+	}()
+}
+
+// set updates one mirror's line. On a TTY it repaints immediately; otherwise it
+// prints a single line the first time the mirror reaches a terminal state.
+func (p *mirrorProgress) set(i int, status string, final, ok bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lines[i].status = status
+	p.lines[i].final = final
+	p.lines[i].ok = ok
+	switch {
+	case p.tty:
+		p.renderLocked()
+	case final && !p.lines[i].printed:
+		p.lines[i].printed = true
+		fmt.Fprintf(p.w, "%s %s %s\n", terminalIcon(ok), p.lines[i].label, status)
+	}
+}
+
+// stop ends the animation and leaves the final state painted.
+func (p *mirrorProgress) stop() {
+	if !p.tty {
+		return
+	}
+	close(p.done)
+	<-p.stopped
+	p.mu.Lock()
+	p.renderLocked()
+	p.mu.Unlock()
+}
+
+// renderLocked repaints the whole block in place. Caller holds p.mu.
+func (p *mirrorProgress) renderLocked() {
+	if p.painted {
+		fmt.Fprintf(p.w, "\033[%dA", len(p.lines)) // move up to the block's top
+	}
+	p.painted = true
+	for _, ln := range p.lines {
+		var icon string
+		if ln.final {
+			icon = terminalIcon(ln.ok)
+		} else {
+			icon = spinnerFrames[p.frame%len(spinnerFrames)]
+		}
+		fmt.Fprintf(p.w, "\r\033[K%-*s  %s %s\n", p.labelW, ln.label, icon, ln.status)
+	}
+}
+
+func terminalIcon(ok bool) string {
+	if ok {
+		return "✓"
+	}
+	return "✗"
 }
 
 // reportMirrorResults renders the results table, a copy-pasteable git-clone

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -227,10 +227,13 @@ func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Dur
 	}
 
 	// --- pick repos ---------------------------------------------------------
+	stopRepos := startSpinner(errW, "Fetching available repos")
 	avail, err := client.ListAvailableMirrors(ctx, coreapi.ListAvailableMirrorsParams{})
 	if err != nil {
+		stopRepos(false)
 		return renderCoreError(err)
 	}
+	stopRepos(true)
 	repos := selectableAvailableRepos(avail.Available)
 	if len(repos) == 0 {
 		fmt.Fprintln(errW, "No GitHub repos available to mirror (you need write access to a repo that isn't mirrored yet).")
@@ -243,10 +246,13 @@ func runMirrorCreateWizard(cmd *cobra.Command, noWait bool, waitTimeout time.Dur
 	}
 
 	// --- pick regions -------------------------------------------------------
+	stopRegions := startSpinner(errW, "Fetching regions")
 	regions, err := availableRegions(ctx, client)
 	if err != nil {
+		stopRegions(false)
 		return fmt.Errorf("list regions: %w", err)
 	}
+	stopRegions(true)
 	if len(regions) == 0 {
 		return errors.New("no regions available to mirror into")
 	}

--- a/cmd/entire/cli/repo_mirror_create_wizard_test.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard_test.go
@@ -72,20 +72,26 @@ func TestClusterChoices(t *testing.T) {
 		{host: "bare.entire.io"}, // no slug/jurisdiction
 	}
 
-	// Caller is in "eu": every cluster is listed, but only the eu default
-	// pre-selects (is_default is per-jurisdiction, so the us default must not).
+	// Caller is in "eu": every cluster is listed, the eu cluster is ordered
+	// first (so it's visible+checked on a short terminal), and only the eu
+	// default pre-selects (is_default is per-jurisdiction, so us must not).
 	opts, defaults := clusterChoices(regions, "eu")
 
 	require.Len(t, opts, 3)
-	require.Equal(t, "us-east (us)", opts[0].Key)
-	require.Equal(t, "aws-us-east-2.entire.io", opts[0].Value)
-	require.Equal(t, "eu-west (eu)", opts[1].Key)
-	require.Equal(t, "bare.entire.io", opts[2].Key) // falls back to host
+	require.Equal(t, "eu-west (eu)", opts[0].Key, "caller's jurisdiction listed first")
+	require.Equal(t, "eu-west-1.entire.io", opts[0].Value)
 	require.Equal(t, []string{"eu-west-1.entire.io"}, defaults)
+	// The other jurisdictions are still present, in their original relative order.
+	var keys []string
+	for _, o := range opts {
+		keys = append(keys, o.Key)
+	}
+	require.ElementsMatch(t, []string{"us-east (us)", "eu-west (eu)", "bare.entire.io"}, keys)
 
-	// Unknown jurisdiction: all still listed, nothing pre-selected.
-	_, noneDefault := clusterChoices(regions, "")
+	// Unknown jurisdiction: all still listed, original order, nothing pre-selected.
+	noOpts, noneDefault := clusterChoices(regions, "")
 	require.Empty(t, noneDefault)
+	require.Equal(t, "us-east (us)", noOpts[0].Key)
 }
 
 func TestRegionLabel(t *testing.T) {

--- a/cmd/entire/cli/repo_mirror_create_wizard_test.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard_test.go
@@ -2,12 +2,34 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"testing"
+	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/internal/coreapi"
 )
+
+func TestRunMirrorCreateWizard_RequiresTTY(t *testing.T) {
+	t.Parallel()
+	// In-process tests are non-interactive, so the wizard must refuse before
+	// touching auth or the network, pointing at the non-interactive form.
+	cmd := &cobra.Command{}
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetContext(context.Background())
+
+	err := runMirrorCreateWizard(cmd, false, time.Minute)
+
+	var silent *SilentError
+	require.ErrorAs(t, err, &silent)
+	require.Empty(t, out.String(), "stdout must stay clean")
+	require.Contains(t, errOut.String(), "interactive terminal")
+	require.Contains(t, errOut.String(), "entire repo mirror create <github-url>")
+}
 
 func TestSelectableAvailableRepos(t *testing.T) {
 	t.Parallel()

--- a/cmd/entire/cli/repo_mirror_create_wizard_test.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard_test.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+func TestSelectableAvailableRepos(t *testing.T) {
+	t.Parallel()
+	in := []coreapi.AvailableMirror{
+		{Owner: "octocat", Repo: "zeta", Access: coreapi.AvailableMirrorAccessAdmin, Status: coreapi.AvailableMirrorStatusAvailable},
+		{Owner: "octocat", Repo: "alpha", Access: coreapi.AvailableMirrorAccessWrite, Status: coreapi.AvailableMirrorStatusAvailable},
+		// dropped: read-only access can't onboard
+		{Owner: "octocat", Repo: "readonly", Access: coreapi.AvailableMirrorAccessRead, Status: coreapi.AvailableMirrorStatusAvailable},
+		// dropped: already mirrored
+		{Owner: "octocat", Repo: "done", Access: coreapi.AvailableMirrorAccessWrite, Status: coreapi.AvailableMirrorStatusMirrored},
+		// dropped: owner-only
+		{Owner: "someone", Repo: "private", Access: coreapi.AvailableMirrorAccessAdmin, Status: coreapi.AvailableMirrorStatusOwnerOnly},
+		// kept, sorts before octocat
+		{Owner: "acme", Repo: "thing", Access: coreapi.AvailableMirrorAccessWrite, Status: coreapi.AvailableMirrorStatusAvailable},
+	}
+
+	got := selectableAvailableRepos(in)
+
+	var keys []string
+	for _, m := range got {
+		keys = append(keys, m.Owner+"/"+m.Repo)
+	}
+	require.Equal(t, []string{"acme/thing", "octocat/alpha", "octocat/zeta"}, keys)
+}
+
+func TestHostFromPublicURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{name: "https url", in: "https://aws-us-east-2.entire.io", want: "aws-us-east-2.entire.io"},
+		{name: "bare host", in: "eu-west-1.entire.io", want: "eu-west-1.entire.io"},
+		{name: "host with port", in: "https://localhost:8080", want: "localhost:8080"},
+		{name: "trims space", in: "  https://aws-us-east-2.entire.io  ", want: "aws-us-east-2.entire.io"},
+		{name: "empty", in: "", wantErr: true},
+		// userinfo trick rejected by validateClusterHost
+		{name: "userinfo injection", in: "https://aws-us-east-2.entire.io@evil.com", wantErr: true},
+		{name: "url with path", in: "https://aws-us-east-2.entire.io/sneaky", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := hostFromPublicURL(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestClusterChoices(t *testing.T) {
+	t.Parallel()
+	regions := []regionChoice{
+		{slug: "us-east", jurisdiction: "us", host: "aws-us-east-2.entire.io", isDefault: true},
+		{slug: "eu-west", jurisdiction: "eu", host: "eu-west-1.entire.io"},
+		{host: "bare.entire.io"}, // no slug/jurisdiction
+	}
+
+	opts, defaults := clusterChoices(regions)
+
+	require.Len(t, opts, 3)
+	require.Equal(t, "us-east (us)", opts[0].Key)
+	require.Equal(t, "aws-us-east-2.entire.io", opts[0].Value)
+	require.Equal(t, "eu-west (eu)", opts[1].Key)
+	require.Equal(t, "bare.entire.io", opts[2].Key) // falls back to host
+	require.Equal(t, []string{"aws-us-east-2.entire.io"}, defaults)
+}
+
+func TestRegionLabel(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "us-east (us)", regionLabel(regionChoice{slug: "us-east", jurisdiction: "us", host: "h"}))
+	require.Equal(t, "us-east", regionLabel(regionChoice{slug: "us-east", host: "h"}))
+	require.Equal(t, "h", regionLabel(regionChoice{host: "h"}))
+}
+
+func TestMirrorTargets(t *testing.T) {
+	t.Parallel()
+	repos := []coreapi.AvailableMirror{
+		{Owner: "a", Repo: "x"},
+		{Owner: "b", Repo: "y"},
+	}
+	regions := []regionChoice{
+		{host: "r1.entire.io"},
+		{host: "r2.entire.io"},
+	}
+
+	targets := mirrorTargets(repos, regions)
+
+	// Cross-product: 2 repos × 2 regions = 4 pairs, repo-major order.
+	require.Len(t, targets, 4)
+	require.Equal(t, mirrorTarget{owner: "a", repo: "x", region: regions[0]}, targets[0])
+	require.Equal(t, mirrorTarget{owner: "a", repo: "x", region: regions[1]}, targets[1])
+	require.Equal(t, mirrorTarget{owner: "b", repo: "y", region: regions[0]}, targets[2])
+	require.Equal(t, mirrorTarget{owner: "b", repo: "y", region: regions[1]}, targets[3])
+}
+
+func TestMirrorCreateResultRow(t *testing.T) {
+	t.Parallel()
+	require.Equal(t,
+		[]string{"octocat/hello", "us-east (us)", "ready", "entire://h/gh/octocat/hello"},
+		mirrorCreateResultRow(mirrorResult{owner: "octocat", repo: "hello", regionLabel: "us-east (us)", status: "ready", cloneURL: "entire://h/gh/octocat/hello"}),
+	)
+	// No clone URL (e.g. error/empty) renders a dash.
+	require.Equal(t,
+		[]string{"octocat/hello", "us-east", "error", placeholderDash},
+		mirrorCreateResultRow(mirrorResult{owner: "octocat", repo: "hello", regionLabel: "us-east", status: "error"}),
+	)
+}
+
+func TestClustersToRegions(t *testing.T) {
+	t.Parallel()
+	in := []coreapi.Cluster{
+		{Slug: "us-east", Jurisdiction: "us", PublicUrl: "https://aws-us-east-2.entire.io", IsDefault: true},
+		{Slug: "eu-west", Jurisdiction: "eu", PublicUrl: "eu-west-1.entire.io"},
+		// dropped: public_url can't reduce to a bare host (userinfo trick)
+		{Slug: "bad", Jurisdiction: "us", PublicUrl: "https://aws-us-east-2.entire.io@evil.com"},
+	}
+
+	got := clustersToRegions(in)
+
+	require.Equal(t, []regionChoice{
+		{slug: "us-east", jurisdiction: "us", host: "aws-us-east-2.entire.io", isDefault: true},
+		{slug: "eu-west", jurisdiction: "eu", host: "eu-west-1.entire.io"},
+	}, got)
+}

--- a/cmd/entire/cli/repo_mirror_create_wizard_test.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard_test.go
@@ -66,19 +66,26 @@ func TestHostFromPublicURL(t *testing.T) {
 func TestClusterChoices(t *testing.T) {
 	t.Parallel()
 	regions := []regionChoice{
+		// Both us-east and eu-west are defaults — for their own jurisdictions.
 		{slug: "us-east", jurisdiction: "us", host: "aws-us-east-2.entire.io", isDefault: true},
-		{slug: "eu-west", jurisdiction: "eu", host: "eu-west-1.entire.io"},
+		{slug: "eu-west", jurisdiction: "eu", host: "eu-west-1.entire.io", isDefault: true},
 		{host: "bare.entire.io"}, // no slug/jurisdiction
 	}
 
-	opts, defaults := clusterChoices(regions)
+	// Caller is in "eu": every cluster is listed, but only the eu default
+	// pre-selects (is_default is per-jurisdiction, so the us default must not).
+	opts, defaults := clusterChoices(regions, "eu")
 
 	require.Len(t, opts, 3)
 	require.Equal(t, "us-east (us)", opts[0].Key)
 	require.Equal(t, "aws-us-east-2.entire.io", opts[0].Value)
 	require.Equal(t, "eu-west (eu)", opts[1].Key)
 	require.Equal(t, "bare.entire.io", opts[2].Key) // falls back to host
-	require.Equal(t, []string{"aws-us-east-2.entire.io"}, defaults)
+	require.Equal(t, []string{"eu-west-1.entire.io"}, defaults)
+
+	// Unknown jurisdiction: all still listed, nothing pre-selected.
+	_, noneDefault := clusterChoices(regions, "")
+	require.Empty(t, noneDefault)
 }
 
 func TestRegionLabel(t *testing.T) {

--- a/cmd/entire/cli/repo_mirror_create_wizard_test.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard_test.go
@@ -67,6 +67,8 @@ func TestHostFromPublicURL(t *testing.T) {
 		{name: "bare host", in: "eu-west-1.entire.io", want: "eu-west-1.entire.io"},
 		{name: "host with port", in: "https://localhost:8080", want: "localhost:8080"},
 		{name: "trims space", in: "  https://aws-us-east-2.entire.io  ", want: "aws-us-east-2.entire.io"},
+		// A trailing slash is a benign catalog shape, not a path injection.
+		{name: "trailing slash", in: "https://aws-us-east-2.entire.io/", want: "aws-us-east-2.entire.io"},
 		{name: "empty", in: "", wantErr: true},
 		// userinfo trick rejected by validateClusterHost
 		{name: "userinfo injection", in: "https://aws-us-east-2.entire.io@evil.com", wantErr: true},

--- a/cmd/entire/cli/repo_mirror_create_wizard_test.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -133,6 +134,26 @@ func TestMirrorCreateResultRow(t *testing.T) {
 		[]string{"octocat/hello", "us-east", "error", placeholderDash},
 		mirrorCreateResultRow(mirrorResult{owner: "octocat", repo: "hello", regionLabel: "us-east", status: "error"}),
 	)
+}
+
+func TestMirrorProgress_NonTTY(t *testing.T) {
+	t.Parallel()
+	// A bytes.Buffer is non-interactive, so the progress degrades to one printed
+	// line per mirror as it reaches a terminal state — no cursor escapes, and
+	// non-final updates print nothing.
+	var buf bytes.Buffer
+	p := newMirrorProgress(&buf, []string{"a/x @ aws-eu-central-1.entire.io", "b/y @ aws-us-east-2.entire.io"})
+	p.start()
+	p.set(0, "processing", false, false) // in-flight: prints nothing
+	require.Empty(t, buf.String())
+	p.set(0, "ready", true, true)
+	p.set(1, "failed", true, false)
+	p.stop()
+
+	out := buf.String()
+	require.Contains(t, out, "✓ a/x @ aws-eu-central-1.entire.io ready")
+	require.Contains(t, out, "✗ b/y @ aws-us-east-2.entire.io failed")
+	require.NotContains(t, out, "\033[", "non-tty output must not emit cursor escapes")
 }
 
 func TestClustersToRegions(t *testing.T) {

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -5,15 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"regexp"
 	"strings"
 	"time"
 
-	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
-
-	"github.com/entireio/cli/cmd/entire/cli/auth"
-	"github.com/entireio/cli/internal/entireclient/discovery"
+	"github.com/entireio/cli/internal/coreapi"
 )
 
 // gitHubHTTPSRe / gitHubSSHRe / gitHubBareRe parse the GitHub URL shapes
@@ -28,12 +24,12 @@ import (
 //
 // The owner/repo capture groups are restricted to GitHub's real identifier
 // charset rather than a permissive "anything but slash". owner/repo flow
-// unescaped into the STS audience (auth.RepoScopedToken) and the smart-HTTP
-// probe URL (waitForMirrorClone); a loose pattern would admit ?, #, %, .. and
-// control chars, letting a name like `repo?bypass=1` smuggle a query string
-// or `repo#x` truncate the path. GitHub owners are [A-Za-z0-9-] and repos are
-// [A-Za-z0-9._-], so matching upstream reality closes those vectors at the
-// boundary instead of relying on whatever the server does with weird strings.
+// unescaped into the STS audience (auth.RepoScopedToken) and the clone URL;
+// a loose pattern would admit ?, #, %, .. and control chars, letting a name
+// like `repo?bypass=1` smuggle a query string or `repo#x` truncate the path.
+// GitHub owners are [A-Za-z0-9-] and repos are [A-Za-z0-9._-], so matching
+// upstream reality closes those vectors at the boundary instead of relying on
+// whatever the server does with weird strings.
 const (
 	gitHubOwnerPat = `([A-Za-z0-9-]+)`
 	gitHubRepoPat  = `([A-Za-z0-9._-]+?)`
@@ -67,256 +63,97 @@ func parseGitHubURL(rawURL string) (owner, repo string, err error) {
 	return "", "", fmt.Errorf("not a recognized GitHub URL: %s", rawURL)
 }
 
-// probeInterval is the cadence between info/refs probes during the
-// clone wait. minReauthInterval floors how often we'll re-mint a
-// repo-scoped token after a 401: STS rate-limits or auth flapping
-// during a long wait shouldn't be amplified by the 2s probe cadence.
-const (
-	probeInterval     = 2 * time.Second
-	minReauthInterval = 30 * time.Second
+// mirrorPollInterval is the cadence between mirror-status polls while waiting
+// for the initial clone. A package var (not const) so tests can shorten it.
+var mirrorPollInterval = 2 * time.Second
+
+var (
+	// errMirrorCloneFailed reports the mirror's initial clone reached the
+	// terminal "failed" status — the server gave up cloning the upstream.
+	errMirrorCloneFailed = errors.New("initial clone failed")
+	// errMirrorSuspended reports the placement is suspended: registered, but the
+	// cluster won't serve it. Recovery is operator-side (explainSuspendedMirror).
+	errMirrorSuspended = errors.New("mirror is suspended")
 )
 
-// maxProbeBytes bounds the smart-HTTP info/refs body read so a
-// pathological or misbehaving server can't make us allocate without
-// limit. Real ref advertisements for the largest repos sit well under
-// this; the cap is sized for headroom, not snugness.
-const maxProbeBytes = 8 << 20 // 8 MiB
-
-// probeClient is the HTTP client used for the clone-readiness loop. It is
-// purpose-built (own Transport, explicit timeouts, no redirect surprises)
-// instead of http.DefaultClient: DefaultClient is process-global and can
-// be poisoned by other code, and its zero-Timeout default would let a
-// stuck connection consume one ticker slot indefinitely. Each probe is
-// already context-bound by the loop's deadline, but Timeout is a belt to
-// the context's braces for the connection/TLS phase.
-var probeClient = &http.Client{
-	Timeout: 15 * time.Second,
-	Transport: &http.Transport{
-		// One mirror, repeated probes — a tiny idle pool is enough to
-		// reuse the TLS session between ticks without leaking conns.
-		MaxIdleConns:        2,
-		MaxIdleConnsPerHost: 2,
-		IdleConnTimeout:     90 * time.Second,
-		TLSHandshakeTimeout: 10 * time.Second,
-	},
-	// The cluster front door 307-redirects info/refs to the node holding the
-	// mirror (e.g. bishop.<cluster-host>); git follows these to clone, so the
-	// probe must too. Refusing them (the old http.ErrUseLastResponse) made
-	// mirrorAdvertisesHead read the 307 as "not 200, not ready" and spin the
-	// cloning-dots forever even after the clone had landed.
-	CheckRedirect: checkProbeRedirect,
+// mirrorStatusGetter is the slice of *coreapi.Client that awaitMirrorReady
+// needs, declared as an interface so the poll is unit-testable with a fake.
+type mirrorStatusGetter interface {
+	GetMirror(ctx context.Context, params coreapi.GetMirrorParams) (*coreapi.Mirror, error)
 }
 
-// maxProbeRedirects bounds redirect-following during the clone probe.
-// One front-door→node hop is expected; the cap is headroom against a
-// misconfigured loop, not snugness.
-const maxProbeRedirects = 5
-
-// checkProbeRedirect confines the clone probe's redirect-following to the
-// cluster trust domain, over https. The 307 the front door issues carries the
-// pull token in the Location userinfo; following it out of the cluster would
-// hand that token to whoever the redirect named. discovery.HostInCluster is
-// the same boundary the entire:// transport enforces on its own redirects.
-func checkProbeRedirect(req *http.Request, via []*http.Request) error {
-	if len(via) >= maxProbeRedirects {
-		return fmt.Errorf("stopped after %d redirects", maxProbeRedirects)
-	}
-	if req.URL.Scheme != schemeHTTPS {
-		return fmt.Errorf("refusing non-https redirect to %s", req.URL.Redacted())
-	}
-	if !discovery.HostInCluster(req.URL.Hostname(), via[0].URL.Hostname()) {
-		return fmt.Errorf("refusing cross-host redirect to %s", req.URL.Redacted())
-	}
-	return nil
-}
-
-// explainSuspendedMirror translates a clone-probe failure into a clear,
-// actionable message when the cluster reports no servable mirror
-// (auth.ErrRepoTargetUnknown) for a placement create just confirmed exists.
-// That pairing — "Mirror already exists" from create, then a refused token
-// exchange — is the signature of a suspended placement: create is idempotent
-// on (repo, cluster) and ignores suspended_at, while the auth gate hides
-// suspended mirrors behind invalid_target. Recovery is operator-side, so we
-// name the exact resume command rather than leaking the raw OAuth error.
+// awaitMirrorReady polls the control plane for a mirror's clone lifecycle until
+// it reaches a terminal status or the deadline/cancellation fires. It returns
+// the last observed status plus:
 //
-// freshCreate gates the diagnosis: a mirror created moments ago cannot be
-// suspended (suspension only happens after upstream access is lost), so an
-// invalid_target on a fresh create is propagation lag, not suspension.
-// Diagnosing that as "suspended" would misdirect the user to a resume command
-// that does nothing, so we decline (handled=false) and let the raw error surface.
+//   - nil                     when ready (the repo is clonable)
+//   - errMirrorCloneFailed    when the initial clone failed
+//   - errMirrorSuspended      when the placement is suspended
+//   - a timeout/transport err when the wait deadline passed or a poll errored
 //
-// Returns handled=false for any other error so the caller surfaces it
-// verbatim. When handled, the message is already written to w and the
-// returned error is a SilentError so main.go won't reprint it.
-func explainSuspendedMirror(w io.Writer, mirrorID string, freshCreate bool, err error) (bool, error) {
-	if freshCreate || !errors.Is(err, auth.ErrRepoTargetUnknown) {
-		return false, nil
-	}
-	fmt.Fprintf(w,
-		"\nMirror %s is registered but the cluster won't issue clone tokens for it.\n"+
-			"This usually means the placement is suspended after upstream GitHub access\n"+
-			"was lost (App uninstalled, the repo went private, or a transient API error).\n"+
-			"An operator can re-enable it once access is restored:\n"+
-			"  entire-core admin mirrors resume %s\n",
-		mirrorID, mirrorID)
-	return true, NewSilentError(fmt.Errorf("mirror %s is suspended", mirrorID))
-}
-
-// repoTokenSource is the subset of auth.RepoTokenSource the clone probe
-// uses; an interface so tests can substitute a fake.
-type repoTokenSource interface {
-	Token(ctx context.Context, repoSlug, action string) (string, error)
-	Invalidate(repoSlug, action string)
-}
-
-// newRepoTokenSource builds the clone probe's token source. Package var so
-// tests can substitute a slow or failing auth path.
-var newRepoTokenSource = func(ctx context.Context, clusterHost string) (repoTokenSource, error) {
-	return auth.NewRepoTokenSource(ctx, clusterHost)
-}
-
-// waitForMirrorClone blocks until the mirror at /gh/<owner>/<repo> on
-// clusterHost advertises a resolvable HEAD (the initial GitHub→EntireDB
-// clone has landed) or the deadline expires. It probes the data plane's
-// smart-HTTP info/refs endpoint every 2s, printing a heartbeat so a long
-// clone doesn't look hung.
-//
-// Repo-scoped pull tokens are short-lived (minutes) while the default wait
-// is 30m, so a single token can't cover the whole wait. The loop re-mints
-// from the (long-lived) login token whenever a probe comes back 401, rather
-// than minting once up front. Cluster discovery and context selection run
-// once, when the source is built — a discovery hiccup mid-wait can't abort
-// a wait that already authorized. Re-mints are floored at minReauthInterval
-// so a flapping STS can't be amplified into a re-mint every probeInterval
-// ticks.
-//
-// The deadline is applied before the source is built: authorization spans
-// cluster discovery and a possible login refresh, so it must consume the
-// user's wait budget, not run before it.
-func waitForMirrorClone(ctx context.Context, out io.Writer, clusterHost, owner, repo string, timeout time.Duration) error {
+// "processing" keeps the loop running. This replaces the old smart-HTTP
+// info/refs probe: the control plane now reports clone readiness directly via
+// Mirror.status, so a single authenticated control-plane call per tick suffices
+// — no repo-scoped token exchange or data-plane round trip.
+func awaitMirrorReady(ctx context.Context, c mirrorStatusGetter, mirrorID string, timeout time.Duration) (coreapi.MirrorStatus, error) {
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-
-	repoSlug := "/gh/" + owner + "/" + repo
-	checkURL := fmt.Sprintf("https://%s%s/info/refs?service=git-upload-pack", clusterHost, repoSlug)
-
-	src, err := newRepoTokenSource(ctx, clusterHost)
-	if err != nil {
-		return fmt.Errorf("authorize clone probe: %w", err)
-	}
-	token, err := src.Token(ctx, repoSlug, "pull")
-	if err != nil {
-		return fmt.Errorf("authorize clone probe: %w", err)
-	}
-	lastMint := time.Now()
-
-	ticker := time.NewTicker(probeInterval)
+	ticker := time.NewTicker(mirrorPollInterval)
 	defer ticker.Stop()
 
-	cloning := false
+	var last coreapi.MirrorStatus
 	for {
-		ready, status := mirrorAdvertisesHead(ctx, probeClient, checkURL, token)
-		switch {
-		case ready:
-			if cloning {
-				fmt.Fprintln(out, " ready")
-			} else {
-				fmt.Fprintln(out, "  ready to use")
+		m, err := c.GetMirror(ctx, coreapi.GetMirrorParams{MirrorId: mirrorID})
+		if err != nil {
+			if ctx.Err() != nil {
+				return last, classifyWaitContextErr(ctx.Err())
 			}
-			return nil
-		case status == http.StatusUnauthorized:
-			// The repo-scoped token expired mid-wait; mint a fresh one from
-			// the login token (no dot, since this is a token refresh, not
-			// clone progress). Skip the re-mint if we just refreshed —
-			// otherwise an STS hiccup that 401s every probe would mint on
-			// every probeInterval tick.
-			if since := time.Since(lastMint); since < minReauthInterval {
-				break
+			return last, fmt.Errorf("poll mirror status: %w", err)
+		}
+		if s, ok := m.Status.Get(); ok {
+			last = s
+			switch s {
+			case coreapi.MirrorStatusReady:
+				return s, nil
+			case coreapi.MirrorStatusFailed:
+				return s, errMirrorCloneFailed
+			case coreapi.MirrorStatusSuspended:
+				return s, errMirrorSuspended
+			case coreapi.MirrorStatusProcessing:
+				// keep waiting
 			}
-			// Drop the cached token first: the cluster rejected it ahead of
-			// its recorded expiry, so a plain Token call could replay it.
-			src.Invalidate(repoSlug, "pull")
-			newToken, mintErr := src.Token(ctx, repoSlug, "pull")
-			if mintErr != nil {
-				if cloning {
-					fmt.Fprintln(out)
-				}
-				return fmt.Errorf("re-authorize clone probe: %w", mintErr)
-			}
-			token = newToken
-			lastMint = time.Now()
-		default:
-			if !cloning {
-				fmt.Fprint(out, "  cloning")
-				cloning = true
-			}
-			fmt.Fprint(out, ".")
 		}
 		select {
 		case <-ctx.Done():
-			fmt.Fprintln(out)
-			// User cancellation (Ctrl+C) should exit quietly, not print a
-			// "timed out…: context canceled" line. NewSilentError signals
-			// main.go to skip printing; a real deadline still reports.
-			if errors.Is(ctx.Err(), context.Canceled) {
-				return NewSilentError(ctx.Err())
-			}
-			return fmt.Errorf("timed out waiting for initial clone: %w", ctx.Err())
+			return last, classifyWaitContextErr(ctx.Err())
 		case <-ticker.C:
 		}
 	}
 }
 
-// mirrorAdvertisesHead fetches the smart-HTTP ref advertisement and reports
-// whether HEAD resolves to a real commit, plus the HTTP status so the
-// caller can distinguish an expired token (401, re-mint) from a
-// still-cloning mirror (200 with no resolvable HEAD, or 404/503). status is
-// 0 for transport/build/decode failures, treated as "not ready, keep
-// waiting". Auth is the repo-scoped token as HTTP basic-auth password, the
-// same shape git presents over the entire:// transport.
-func mirrorAdvertisesHead(ctx context.Context, client *http.Client, checkURL, token string) (ready bool, status int) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checkURL, nil)
-	if err != nil {
-		return false, 0
+// classifyWaitContextErr maps the clone wait's context error to a user-facing
+// error: a user Ctrl+C exits quietly (SilentError, so main.go doesn't reprint
+// it), while a real deadline reports the timeout.
+func classifyWaitContextErr(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return NewSilentError(err)
 	}
-	req.SetBasicAuth("entire-cli", token)
-	resp, err := client.Do(req)
-	if err != nil {
-		return false, 0
-	}
-	// Drain before close so the transport can return the connection to the
-	// idle pool and reuse the TLS session on the next tick. Go only recycles
-	// a conn whose body was read to EOF before Close, and the Decode error
-	// returns below leave the body partially read. Drain to EOF, uncapped:
-	// the maxProbeBytes cap on the read below bounds the Decode *allocation*,
-	// but draining to io.Discard is O(1) memory, and a LimitReader cap
-	// shorter than the body would stop before EOF and silently defeat reuse.
-	// The client Timeout still bounds how long the drain can run.
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body) //nolint:errcheck // best-effort drain to enable conn reuse; copy errors are irrelevant
-		_ = resp.Body.Close()
-	}()
-	if resp.StatusCode != http.StatusOK {
-		return false, resp.StatusCode
-	}
-	// Cap the body to prevent unbounded reads; ogen's api/client.go does
-	// the same for JSON. Smart-HTTP wraps the advertisement in a "#
-	// service=..." pkt-line header + flush; AdvRefs.Decode expects to
-	// start at the first ref line, so strip the wrapper first.
-	body := io.LimitReader(resp.Body, maxProbeBytes)
-	var sr packp.SmartReply
-	if err := sr.Decode(body); err != nil {
-		return false, 0
-	}
-	var adv packp.AdvRefs
-	if err := adv.Decode(body); err != nil {
-		return false, 0
-	}
-	if _, err := adv.ResolvedHead(); err != nil {
-		return false, http.StatusOK // reachable, clone still in progress
-	}
-	return true, http.StatusOK
+	return fmt.Errorf("timed out waiting for initial clone: %w", err)
+}
+
+// explainSuspendedMirror prints operator-recovery guidance for a suspended
+// placement: the cluster won't serve clones until upstream GitHub access is
+// restored and an operator resumes it. Suspension usually follows upstream
+// access loss (App uninstalled, repo went private, or a transient API error).
+func explainSuspendedMirror(w io.Writer, mirrorID string) {
+	fmt.Fprintf(w,
+		"\nMirror %s is registered but suspended — the cluster won't serve it.\n"+
+			"This usually means upstream GitHub access was lost (App uninstalled,\n"+
+			"the repo went private, or a transient API error). An operator can\n"+
+			"re-enable it once access is restored:\n"+
+			"  entire-core admin mirrors resume %s\n",
+		mirrorID, mirrorID)
 }

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -150,16 +150,16 @@ func classifyWaitContextErr(err error) error {
 	return fmt.Errorf("timed out waiting for initial clone: %w", err)
 }
 
-// explainSuspendedMirror prints operator-recovery guidance for a suspended
-// placement: the cluster won't serve clones until upstream GitHub access is
-// restored and an operator resumes it. Suspension usually follows upstream
-// access loss (App uninstalled, repo went private, or a transient API error).
+// explainSuspendedMirror tells the user a suspended placement can't be served
+// and to contact support. Suspension usually follows a loss of upstream GitHub
+// access (App uninstalled, repo went private, or a transient API error); the
+// fix is operator-side, so we point at support rather than leaking an internal
+// admin command.
 func explainSuspendedMirror(w io.Writer, mirrorID string) {
 	fmt.Fprintf(w,
-		"\nMirror %s is registered but suspended — the cluster won't serve it.\n"+
+		"\nMirror %s is registered but suspended, so it can't be cloned yet.\n"+
 			"This usually means upstream GitHub access was lost (App uninstalled,\n"+
-			"the repo went private, or a transient API error). An operator can\n"+
-			"re-enable it once access is restored:\n"+
-			"  entire-core admin mirrors resume %s\n",
-		mirrorID, mirrorID)
+			"the repo went private, or a transient API error). Contact support to\n"+
+			"restore it.\n",
+		mirrorID)
 }

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -67,6 +67,13 @@ func parseGitHubURL(rawURL string) (owner, repo string, err error) {
 // for the initial clone. A package var (not const) so tests can shorten it.
 var mirrorPollInterval = 2 * time.Second
 
+// maxConsecutivePollErrors bounds how many back-to-back GetMirror failures the
+// clone wait tolerates before giving up. A brief network/API glitch during a
+// long initial clone shouldn't fail the create, but a persistent error
+// (deleted mirror, revoked auth) should surface rather than spin to the
+// deadline. The counter resets on any successful poll.
+const maxConsecutivePollErrors = 5
+
 var (
 	// errMirrorCloneFailed reports the mirror's initial clone reached the
 	// terminal "failed" status — the server gave up cloning the upstream.
@@ -89,7 +96,8 @@ type mirrorStatusGetter interface {
 //   - nil                     when ready (the repo is clonable)
 //   - errMirrorCloneFailed    when the initial clone failed
 //   - errMirrorSuspended      when the placement is suspended
-//   - a timeout/transport err when the wait deadline passed or a poll errored
+//   - a timeout/transport err when the wait deadline passed, or polls kept
+//     erroring past maxConsecutivePollErrors (transient glitches are retried)
 //
 // "processing" keeps the loop running. This replaces the old smart-HTTP
 // info/refs probe: the control plane now reports clone readiness directly via
@@ -108,28 +116,37 @@ func awaitMirrorReady(ctx context.Context, c mirrorStatusGetter, mirrorID string
 	defer ticker.Stop()
 
 	var last coreapi.MirrorStatus
+	var consecutiveErrs int
 	for {
 		m, err := c.GetMirror(ctx, coreapi.GetMirrorParams{MirrorId: mirrorID})
-		if err != nil {
+		switch {
+		case err != nil:
 			if ctx.Err() != nil {
 				return last, classifyWaitContextErr(ctx.Err())
 			}
-			return last, fmt.Errorf("poll mirror status: %w", err)
-		}
-		if s, ok := m.Status.Get(); ok {
-			last = s
-			if onStatus != nil {
-				onStatus(s)
+			// Tolerate transient glitches: the clone may still be progressing,
+			// so retry on the next tick. Only give up once errors persist.
+			consecutiveErrs++
+			if consecutiveErrs >= maxConsecutivePollErrors {
+				return last, fmt.Errorf("poll mirror status: %w", err)
 			}
-			switch s {
-			case coreapi.MirrorStatusReady:
-				return s, nil
-			case coreapi.MirrorStatusFailed:
-				return s, errMirrorCloneFailed
-			case coreapi.MirrorStatusSuspended:
-				return s, errMirrorSuspended
-			case coreapi.MirrorStatusProcessing:
-				// keep waiting
+		default:
+			consecutiveErrs = 0
+			if s, ok := m.Status.Get(); ok {
+				last = s
+				if onStatus != nil {
+					onStatus(s)
+				}
+				switch s {
+				case coreapi.MirrorStatusReady:
+					return s, nil
+				case coreapi.MirrorStatusFailed:
+					return s, errMirrorCloneFailed
+				case coreapi.MirrorStatusSuspended:
+					return s, errMirrorSuspended
+				case coreapi.MirrorStatusProcessing:
+					// keep waiting
+				}
 			}
 		}
 		select {

--- a/cmd/entire/cli/repo_mirror_probe.go
+++ b/cmd/entire/cli/repo_mirror_probe.go
@@ -95,7 +95,10 @@ type mirrorStatusGetter interface {
 // info/refs probe: the control plane now reports clone readiness directly via
 // Mirror.status, so a single authenticated control-plane call per tick suffices
 // — no repo-scoped token exchange or data-plane round trip.
-func awaitMirrorReady(ctx context.Context, c mirrorStatusGetter, mirrorID string, timeout time.Duration) (coreapi.MirrorStatus, error) {
+//
+// onStatus (may be nil) is invoked with each observed status so callers can show
+// live per-mirror progress (e.g. the wizard's Docker-style line list).
+func awaitMirrorReady(ctx context.Context, c mirrorStatusGetter, mirrorID string, timeout time.Duration, onStatus func(coreapi.MirrorStatus)) (coreapi.MirrorStatus, error) {
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
@@ -115,6 +118,9 @@ func awaitMirrorReady(ctx context.Context, c mirrorStatusGetter, mirrorID string
 		}
 		if s, ok := m.Status.Get(); ok {
 			last = s
+			if onStatus != nil {
+				onStatus(s)
+			}
 			switch s {
 			case coreapi.MirrorStatusReady:
 				return s, nil

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -452,59 +452,6 @@ func TestAvailableMirrorRow(t *testing.T) {
 	}
 }
 
-func TestPickDefaultRegionHost(t *testing.T) {
-	t.Parallel()
-
-	// Three per-jurisdiction defaults, like prod.
-	threeDefaults := []regionChoice{
-		{host: "aws-ap-southeast-2.entire.io", jurisdiction: "au", isDefault: true},
-		{host: "aws-eu-central-1.entire.io", jurisdiction: "eu", isDefault: true},
-		{host: "aws-us-east-2.entire.io", jurisdiction: "us", isDefault: true},
-	}
-
-	t.Run("picks the default for the caller's jurisdiction", func(t *testing.T) {
-		t.Parallel()
-		host, err := pickDefaultRegionHost(threeDefaults, "eu")
-		require.NoError(t, err)
-		require.Equal(t, "aws-eu-central-1.entire.io", host)
-	})
-
-	t.Run("jurisdiction with no default errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := pickDefaultRegionHost(threeDefaults, "antarctica")
-		require.Error(t, err)
-	})
-
-	t.Run("unknown jurisdiction, sole cluster is the default", func(t *testing.T) {
-		t.Parallel()
-		host, err := pickDefaultRegionHost([]regionChoice{{host: "only.entire.io"}}, "")
-		require.NoError(t, err)
-		require.Equal(t, "only.entire.io", host)
-	})
-
-	t.Run("unknown jurisdiction, lone default wins", func(t *testing.T) {
-		t.Parallel()
-		host, err := pickDefaultRegionHost([]regionChoice{
-			{host: "a.entire.io"},
-			{host: "b.entire.io", isDefault: true},
-		}, "")
-		require.NoError(t, err)
-		require.Equal(t, "b.entire.io", host)
-	})
-
-	t.Run("empty catalog errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := pickDefaultRegionHost(nil, "eu")
-		require.Error(t, err)
-	})
-
-	t.Run("unknown jurisdiction with multiple defaults errors", func(t *testing.T) {
-		t.Parallel()
-		_, err := pickDefaultRegionHost(threeDefaults, "")
-		require.Error(t, err)
-	})
-}
-
 func TestClusterArg(t *testing.T) {
 	t.Parallel()
 	if got := clusterArg([]string{"github.com/o/r", "eu-west-1.entire.io"}); got != "eu-west-1.entire.io" {

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -455,34 +455,52 @@ func TestAvailableMirrorRow(t *testing.T) {
 func TestPickDefaultRegionHost(t *testing.T) {
 	t.Parallel()
 
-	t.Run("prefers the is-default cluster", func(t *testing.T) {
+	// Three per-jurisdiction defaults, like prod.
+	threeDefaults := []regionChoice{
+		{host: "aws-ap-southeast-2.entire.io", jurisdiction: "au", isDefault: true},
+		{host: "aws-eu-central-1.entire.io", jurisdiction: "eu", isDefault: true},
+		{host: "aws-us-east-2.entire.io", jurisdiction: "us", isDefault: true},
+	}
+
+	t.Run("picks the default for the caller's jurisdiction", func(t *testing.T) {
 		t.Parallel()
-		host, err := pickDefaultRegionHost([]regionChoice{
-			{host: "eu-west-1.entire.io"},
-			{host: "aws-us-east-2.entire.io", isDefault: true},
-		})
+		host, err := pickDefaultRegionHost(threeDefaults, "eu")
 		require.NoError(t, err)
-		require.Equal(t, "aws-us-east-2.entire.io", host)
+		require.Equal(t, "aws-eu-central-1.entire.io", host)
 	})
 
-	t.Run("sole cluster is the default", func(t *testing.T) {
+	t.Run("jurisdiction with no default errors", func(t *testing.T) {
 		t.Parallel()
-		host, err := pickDefaultRegionHost([]regionChoice{{host: "only.entire.io"}})
+		_, err := pickDefaultRegionHost(threeDefaults, "antarctica")
+		require.Error(t, err)
+	})
+
+	t.Run("unknown jurisdiction, sole cluster is the default", func(t *testing.T) {
+		t.Parallel()
+		host, err := pickDefaultRegionHost([]regionChoice{{host: "only.entire.io"}}, "")
 		require.NoError(t, err)
 		require.Equal(t, "only.entire.io", host)
 	})
 
+	t.Run("unknown jurisdiction, lone default wins", func(t *testing.T) {
+		t.Parallel()
+		host, err := pickDefaultRegionHost([]regionChoice{
+			{host: "a.entire.io"},
+			{host: "b.entire.io", isDefault: true},
+		}, "")
+		require.NoError(t, err)
+		require.Equal(t, "b.entire.io", host)
+	})
+
 	t.Run("empty catalog errors", func(t *testing.T) {
 		t.Parallel()
-		_, err := pickDefaultRegionHost(nil)
+		_, err := pickDefaultRegionHost(nil, "eu")
 		require.Error(t, err)
 	})
 
-	t.Run("ambiguous (multiple, none default) errors", func(t *testing.T) {
+	t.Run("unknown jurisdiction with multiple defaults errors", func(t *testing.T) {
 		t.Parallel()
-		_, err := pickDefaultRegionHost([]regionChoice{
-			{host: "a.entire.io"}, {host: "b.entire.io"},
-		})
+		_, err := pickDefaultRegionHost(threeDefaults, "")
 		require.Error(t, err)
 	})
 }

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -22,7 +22,9 @@ func TestExplainSuspendedMirror(t *testing.T) {
 	explainSuspendedMirror(&buf, id)
 	out := buf.String()
 	require.Contains(t, out, id, "message must name the mirror")
-	require.Contains(t, out, "entire-core admin mirrors resume "+id, "message must give the resume command")
+	require.Contains(t, out, "suspended")
+	require.Contains(t, out, "Contact support", "must point at support, not an internal admin command")
+	require.NotContains(t, out, "entire-core", "must not leak internal terminology")
 }
 
 // fakeMirrorGetter feeds awaitMirrorReady a scripted sequence of statuses (the
@@ -142,14 +144,15 @@ func TestReportOneShotMirror(t *testing.T) {
 		require.Contains(t, out.String(), "git clone "+mirrorURL)
 	})
 
-	t.Run("suspended surfaces resume guidance as SilentError", func(t *testing.T) {
+	t.Run("suspended surfaces support guidance as SilentError", func(t *testing.T) {
 		t.Parallel()
 		var out, errW bytes.Buffer
 		outcome := mirrorCreateOutcome{created: mk(false, false), status: coreapi.MirrorStatusSuspended, polled: true}
 		err := reportOneShotMirror(&out, &errW, outcome, errMirrorSuspended)
 		var silent *SilentError
 		require.ErrorAs(t, err, &silent)
-		require.Contains(t, errW.String(), "entire-core admin mirrors resume "+id)
+		require.Contains(t, errW.String(), "Contact support")
+		require.NotContains(t, errW.String(), "entire-core")
 		require.NotContains(t, out.String(), "git clone")
 	})
 

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -4,218 +4,171 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
-	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/internal/coreapi"
 )
 
 func TestExplainSuspendedMirror(t *testing.T) {
 	t.Parallel()
 	const id = "01KS6KFJR2XS6PZ188MVYE07AN"
+	var buf bytes.Buffer
+	explainSuspendedMirror(&buf, id)
+	out := buf.String()
+	require.Contains(t, out, id, "message must name the mirror")
+	require.Contains(t, out, "entire-core admin mirrors resume "+id, "message must give the resume command")
+}
 
-	t.Run("suspended mirror is explained with resume command", func(t *testing.T) {
-		t.Parallel()
-		// Wrap the sentinel the way RepoScopedToken/waitForMirrorClone do, to
-		// prove detection survives the wrapping chain.
-		err := fmt.Errorf("authorize clone probe: %w", fmt.Errorf("repo-scoped token exchange: %w", auth.ErrRepoTargetUnknown))
-		var buf bytes.Buffer
-		handled, serr := explainSuspendedMirror(&buf, id, false, err)
-		if !handled {
-			t.Fatal("expected handled=true for ErrRepoTargetUnknown")
-		}
-		var silent *SilentError
-		if !errors.As(serr, &silent) {
-			t.Errorf("expected a SilentError, got %T: %v", serr, serr)
-		}
-		out := buf.String()
-		if !strings.Contains(out, id) {
-			t.Errorf("message %q omits the mirror id", out)
-		}
-		if !strings.Contains(out, "entire-core admin mirrors resume "+id) {
-			t.Errorf("message %q omits the resume command", out)
-		}
+// fakeMirrorGetter feeds awaitMirrorReady a scripted sequence of statuses (the
+// last entry repeats) or a fixed error, standing in for *coreapi.Client.GetMirror.
+type fakeMirrorGetter struct {
+	statuses []coreapi.MirrorStatus
+	err      error
+	calls    int
+}
+
+func (f *fakeMirrorGetter) GetMirror(_ context.Context, _ coreapi.GetMirrorParams) (*coreapi.Mirror, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	i := f.calls
+	if i >= len(f.statuses) {
+		i = len(f.statuses) - 1
+	}
+	f.calls++
+	m := &coreapi.Mirror{}
+	m.Status = coreapi.NewOptMirrorStatus(f.statuses[i])
+	return m, nil
+}
+
+// TestAwaitMirrorReady covers the clone-status poll that replaced the info/refs
+// probe: terminal statuses resolve, processing keeps polling, and an exhausted
+// deadline reports a timeout.
+//
+// Not parallel: shortens the package-level mirrorPollInterval.
+func TestAwaitMirrorReady(t *testing.T) {
+	prev := mirrorPollInterval
+	mirrorPollInterval = time.Millisecond
+	t.Cleanup(func() { mirrorPollInterval = prev })
+	ctx := t.Context()
+
+	t.Run("ready resolves with no error", func(t *testing.T) {
+		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusReady}}
+		status, err := awaitMirrorReady(ctx, f, "m", time.Second)
+		require.NoError(t, err)
+		require.Equal(t, coreapi.MirrorStatusReady, status)
 	})
 
-	t.Run("fresh create passes invalid_target through as propagation lag", func(t *testing.T) {
-		t.Parallel()
-		// Same invalid_target signature, but on a just-created placement it's
-		// eventual-consistency lag, not suspension — don't misdirect to resume.
-		err := fmt.Errorf("authorize clone probe: %w", fmt.Errorf("repo-scoped token exchange: %w", auth.ErrRepoTargetUnknown))
-		var buf bytes.Buffer
-		handled, serr := explainSuspendedMirror(&buf, id, true, err)
-		if handled {
-			t.Error("expected handled=false for a fresh create")
-		}
-		if serr != nil {
-			t.Errorf("expected nil error, got %v", serr)
-		}
-		if buf.Len() != 0 {
-			t.Errorf("expected no output, got %q", buf.String())
-		}
+	t.Run("processing then ready keeps polling", func(t *testing.T) {
+		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{
+			coreapi.MirrorStatusProcessing, coreapi.MirrorStatusProcessing, coreapi.MirrorStatusReady,
+		}}
+		status, err := awaitMirrorReady(ctx, f, "m", time.Second)
+		require.NoError(t, err)
+		require.Equal(t, coreapi.MirrorStatusReady, status)
+		require.GreaterOrEqual(t, f.calls, 3)
 	})
 
-	t.Run("unrelated error passes through untouched", func(t *testing.T) {
-		t.Parallel()
-		var buf bytes.Buffer
-		handled, serr := explainSuspendedMirror(&buf, id, false, errors.New("timed out waiting for initial clone"))
-		if handled {
-			t.Error("expected handled=false for an unrelated error")
-		}
-		if serr != nil {
-			t.Errorf("expected nil error, got %v", serr)
-		}
-		if buf.Len() != 0 {
-			t.Errorf("expected no output, got %q", buf.String())
-		}
+	t.Run("failed returns errMirrorCloneFailed", func(t *testing.T) {
+		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusFailed}}
+		status, err := awaitMirrorReady(ctx, f, "m", time.Second)
+		require.ErrorIs(t, err, errMirrorCloneFailed)
+		require.Equal(t, coreapi.MirrorStatusFailed, status)
+	})
+
+	t.Run("suspended returns errMirrorSuspended", func(t *testing.T) {
+		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusSuspended}}
+		status, err := awaitMirrorReady(ctx, f, "m", time.Second)
+		require.ErrorIs(t, err, errMirrorSuspended)
+		require.Equal(t, coreapi.MirrorStatusSuspended, status)
+	})
+
+	t.Run("never-ready times out", func(t *testing.T) {
+		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusProcessing}}
+		_, err := awaitMirrorReady(ctx, f, "m", 20*time.Millisecond)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 }
 
-// TestFinishMirrorCreate exercises the post-create branching: when the
-// upstream is empty we must skip the HEAD-poll loop (an empty repo never
-// advertises a HEAD), yet an *existing* empty placement must still go through
-// the token exchange so a suspended mirror surfaces its resume guidance
-// instead of a success-style "nothing to clone" note.
-func TestFinishMirrorCreate(t *testing.T) {
+// TestReportOneShotMirror exercises the one-shot create's presentation across
+// the shared lifecycle outcomes — the branching finishMirrorCreate used to own,
+// now driven by mirrorCreateOutcome (and shared with the wizard).
+func TestReportOneShotMirror(t *testing.T) {
 	t.Parallel()
-
 	const id = "01KS6KFJR2XS6PZ188MVYE07AN"
 	const mirrorURL = "entire://eu-west-1.entire.io/gh/octocat/hello-world"
-	// The error shape RepoScopedToken/waitForMirrorClone produce for a
-	// suspended (non-servable) placement.
-	suspended := fmt.Errorf("repo-scoped token exchange: %w", auth.ErrRepoTargetUnknown)
+	mk := func(created, empty bool) *coreapi.CreatedMirror {
+		return &coreapi.CreatedMirror{Created: created, Empty: empty, MirrorId: id, MirrorUrl: mirrorURL}
+	}
 
-	// seen records whether each injected operation ran, so we can assert the
-	// empty path never polls and a fresh create never probes.
-	type call struct{ probed, waited bool }
-
-	t.Run("fresh empty create skips both probe and poll", func(t *testing.T) {
+	t.Run("create failure surfaces with nothing printed", func(t *testing.T) {
 		t.Parallel()
-		var seen call
 		var out, errW bytes.Buffer
-		created := &coreapi.CreatedMirror{Created: true, Empty: true, MirrorId: id, MirrorUrl: mirrorURL}
-		err := finishMirrorCreate(&out, &errW, created, false,
-			func() error { seen.probed = true; return nil },
-			func() error { seen.waited = true; return nil },
-		)
-		require.NoError(t, err)
-		require.False(t, seen.probed, "a fresh create can't be suspended; must not probe")
-		require.False(t, seen.waited, "empty upstream has nothing to clone; must not poll")
-		require.Contains(t, out.String(), "nothing to clone")
-		require.Empty(t, errW.String())
+		wantErr := errors.New("boom")
+		err := reportOneShotMirror(&out, &errW, mirrorCreateOutcome{}, wantErr)
+		require.ErrorIs(t, err, wantErr)
+		require.Empty(t, out.String())
 	})
 
-	t.Run("existing empty healthy probes but does not poll", func(t *testing.T) {
+	t.Run("empty upstream prints nothing-to-clone", func(t *testing.T) {
 		t.Parallel()
-		var seen call
 		var out, errW bytes.Buffer
-		created := &coreapi.CreatedMirror{Created: false, Empty: true, MirrorId: id, MirrorUrl: mirrorURL}
-		err := finishMirrorCreate(&out, &errW, created, false,
-			func() error { seen.probed = true; return nil },
-			func() error { seen.waited = true; return nil },
-		)
+		err := reportOneShotMirror(&out, &errW, mirrorCreateOutcome{created: mk(true, true)}, nil)
 		require.NoError(t, err)
-		require.True(t, seen.probed, "existing empty placement must probe for suspension")
-		require.False(t, seen.waited, "empty upstream has nothing to clone; must not poll")
+		require.Contains(t, out.String(), "Registered mirror "+id)
 		require.Contains(t, out.String(), "nothing to clone")
 	})
 
-	t.Run("existing empty suspended surfaces resume guidance", func(t *testing.T) {
-		t.Parallel()
-		var seen call
-		var out, errW bytes.Buffer
-		created := &coreapi.CreatedMirror{Created: false, Empty: true, MirrorId: id, MirrorUrl: mirrorURL}
-		err := finishMirrorCreate(&out, &errW, created, false,
-			func() error { seen.probed = true; return suspended },
-			func() error { seen.waited = true; return nil },
-		)
-		var silent *SilentError
-		require.ErrorAs(t, err, &silent, "suspended mirror must return a SilentError")
-		require.True(t, seen.probed)
-		require.False(t, seen.waited, "must not poll a suspended empty mirror")
-		require.Contains(t, errW.String(), "entire-core admin mirrors resume "+id)
-		require.NotContains(t, out.String(), "nothing to clone",
-			"a suspended mirror must not get the success-style empty note")
-	})
-
-	t.Run("existing empty transient probe error is non-fatal", func(t *testing.T) {
+	t.Run("no-wait prints in-progress hint", func(t *testing.T) {
 		t.Parallel()
 		var out, errW bytes.Buffer
-		created := &coreapi.CreatedMirror{Created: false, Empty: true, MirrorId: id, MirrorUrl: mirrorURL}
-		err := finishMirrorCreate(&out, &errW, created, false,
-			func() error { return errors.New("dial tcp: connection refused") },
-			func() error { t.Fatal("must not poll an empty mirror"); return nil },
-		)
-		require.NoError(t, err, "a non-suspension probe error must not fail a create whose placement exists")
-		require.Contains(t, out.String(), "nothing to clone")
-	})
-
-	t.Run("non-empty no-wait skips both probe and poll", func(t *testing.T) {
-		t.Parallel()
-		var seen call
-		var out, errW bytes.Buffer
-		created := &coreapi.CreatedMirror{Created: true, Empty: false, MirrorId: id, MirrorUrl: mirrorURL}
-		err := finishMirrorCreate(&out, &errW, created, true,
-			func() error { seen.probed = true; return nil },
-			func() error { seen.waited = true; return nil },
-		)
+		err := reportOneShotMirror(&out, &errW, mirrorCreateOutcome{created: mk(true, false)}, nil)
 		require.NoError(t, err)
-		require.False(t, seen.probed)
-		require.False(t, seen.waited, "--no-wait must not poll")
 		require.Contains(t, out.String(), "still be in progress")
 	})
 
-	t.Run("non-empty waits for clone then prints clone hint", func(t *testing.T) {
+	t.Run("ready prints clone hint", func(t *testing.T) {
 		t.Parallel()
-		var seen call
 		var out, errW bytes.Buffer
-		created := &coreapi.CreatedMirror{Created: true, Empty: false, MirrorId: id, MirrorUrl: mirrorURL}
-		err := finishMirrorCreate(&out, &errW, created, false,
-			func() error { seen.probed = true; return nil },
-			func() error { seen.waited = true; return nil },
-		)
+		outcome := mirrorCreateOutcome{created: mk(true, false), status: coreapi.MirrorStatusReady, polled: true}
+		err := reportOneShotMirror(&out, &errW, outcome, nil)
 		require.NoError(t, err)
-		require.False(t, seen.probed, "non-empty path detects suspension through waitClone, not a separate probe")
-		require.True(t, seen.waited)
 		require.Contains(t, out.String(), "git clone "+mirrorURL)
 	})
 
-	t.Run("non-empty existing suspended surfaces resume guidance", func(t *testing.T) {
+	t.Run("suspended surfaces resume guidance as SilentError", func(t *testing.T) {
 		t.Parallel()
 		var out, errW bytes.Buffer
-		created := &coreapi.CreatedMirror{Created: false, Empty: false, MirrorId: id, MirrorUrl: mirrorURL}
-		err := finishMirrorCreate(&out, &errW, created, false,
-			func() error { return nil },
-			func() error { return suspended },
-		)
+		outcome := mirrorCreateOutcome{created: mk(false, false), status: coreapi.MirrorStatusSuspended, polled: true}
+		err := reportOneShotMirror(&out, &errW, outcome, errMirrorSuspended)
 		var silent *SilentError
 		require.ErrorAs(t, err, &silent)
 		require.Contains(t, errW.String(), "entire-core admin mirrors resume "+id)
 		require.NotContains(t, out.String(), "git clone")
 	})
 
-	t.Run("non-empty wait error other than suspension propagates", func(t *testing.T) {
+	t.Run("failed returns an error naming the mirror", func(t *testing.T) {
 		t.Parallel()
 		var out, errW bytes.Buffer
-		created := &coreapi.CreatedMirror{Created: true, Empty: false, MirrorId: id, MirrorUrl: mirrorURL}
+		outcome := mirrorCreateOutcome{created: mk(true, false), status: coreapi.MirrorStatusFailed, polled: true}
+		err := reportOneShotMirror(&out, &errW, outcome, errMirrorCloneFailed)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), id)
+	})
+
+	t.Run("timeout propagates the wait error", func(t *testing.T) {
+		t.Parallel()
+		var out, errW bytes.Buffer
 		wantErr := errors.New("timed out waiting for initial clone")
-		err := finishMirrorCreate(&out, &errW, created, false,
-			func() error { return nil },
-			func() error { return wantErr },
-		)
+		outcome := mirrorCreateOutcome{created: mk(true, false), status: coreapi.MirrorStatusProcessing, polled: true}
+		err := reportOneShotMirror(&out, &errW, outcome, wantErr)
 		require.ErrorIs(t, err, wantErr)
-		require.Empty(t, errW.String())
 	})
 }
 
@@ -628,168 +581,4 @@ func TestValidateClusterHost(t *testing.T) {
 			}
 		})
 	}
-}
-
-// TestMirrorAdvertisesHead_ReusesConnection is the regression test for the
-// body drain in mirrorAdvertisesHead. The probe runs every 2s for up to 30m,
-// and probeClient keeps a small idle pool specifically to reuse the TLS
-// session across ticks — but Go only returns a connection to that pool when
-// the response body is read to EOF before Close. If the drain is removed (or
-// re-capped shorter than the body), the body is left partially read and the
-// transport closes the connection instead, so every probe pays a fresh
-// handshake.
-//
-// We serve a non-200 with a non-empty body: mirrorAdvertisesHead returns at
-// the status check without reading the body itself, so the deferred drain is
-// the *only* thing that consumes it. Counting StateNew transitions then
-// distinguishes "drained → one reused connection" from "not drained → a new
-// connection per call".
-func TestMirrorAdvertisesHead_ReusesConnection(t *testing.T) {
-	t.Parallel()
-
-	// Larger than any plausible "small cap" someone might reintroduce, so a
-	// capped drain would stop before EOF and fail this test too.
-	body := strings.Repeat("x", 64<<10)
-
-	var newConns atomic.Int64
-	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// 503 = mirror reachable but not ready; the function returns at the
-		// status check below http.StatusOK without touching the body.
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_, _ = w.Write([]byte(body)) //nolint:errcheck // test server write; failure surfaces as a client error
-	}))
-	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
-		if state == http.StateNew {
-			newConns.Add(1)
-		}
-	}
-	srv.Start()
-	defer srv.Close()
-
-	// Isolated client (not the package-global probeClient) so the idle pool
-	// is private to this test and the assertion stays deterministic under
-	// t.Parallel(). Keep-alives and idle pooling are on by default.
-	client := &http.Client{
-		Timeout:   15 * time.Second,
-		Transport: &http.Transport{MaxIdleConns: 2, MaxIdleConnsPerHost: 2, IdleConnTimeout: 90 * time.Second},
-	}
-
-	const probes = 5
-	for range probes {
-		ready, status := mirrorAdvertisesHead(context.Background(), client, srv.URL, "tok")
-		require.False(t, ready)
-		require.Equal(t, http.StatusServiceUnavailable, status)
-	}
-
-	require.Equal(t, int64(1), newConns.Load(),
-		"expected the drained body to let all %d probes share one connection; got %d new connections (body not drained to EOF?)",
-		probes, newConns.Load())
-}
-
-// pktLine encodes s as a git pkt-line (4-hex length prefix including the
-// prefix itself), mirroring what a smart-HTTP server writes.
-func pktLine(s string) string { return fmt.Sprintf("%04x%s", len(s)+4, s) }
-
-// uploadPackAdvertisement returns a minimal but valid git-upload-pack
-// info/refs body: the "# service" banner, a flush, a HEAD line carrying the
-// symref capability, a refs/heads/main line, and a trailing flush. It decodes
-// to an AdvRefs whose HEAD resolves to refs/heads/main.
-func uploadPackAdvertisement() string {
-	const sha = "d9a69831082341eab799c062e10ad28b3204c08a"
-	return pktLine("# service=git-upload-pack\n") +
-		"0000" +
-		pktLine(sha+" HEAD\x00symref=HEAD:refs/heads/main\n") +
-		pktLine(sha+" refs/heads/main\n") +
-		"0000"
-}
-
-// TestMirrorAdvertisesHead_FollowsNodeRedirect is the regression test for the
-// infinite cloning-dots bug. The cluster front door 307-redirects info/refs to
-// the node holding the mirror; git follows that to clone. The probe used to
-// refuse all redirects (http.ErrUseLastResponse), so it saw the 307 as "not
-// 200, not ready" and printed cloning-dots forever even after the clone had
-// landed. With checkProbeRedirect the probe follows same-host redirects and
-// reaches the advertisement, so it reports ready.
-func TestMirrorAdvertisesHead_FollowsNodeRedirect(t *testing.T) {
-	t.Parallel()
-
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/node/info/refs" {
-			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
-			_, _ = w.Write([]byte(uploadPackAdvertisement())) //nolint:errcheck // test server write
-			return
-		}
-		// Front door: route to the backing node on the same host, the way the
-		// real cluster front door 307s to bishop.<cluster-host>.
-		http.Redirect(w, r, "/node/info/refs", http.StatusTemporaryRedirect)
-	}))
-	defer srv.Close()
-
-	// srv.Client() trusts the test cert; layer on the production redirect
-	// policy so we exercise the real follow path.
-	client := srv.Client()
-	client.CheckRedirect = checkProbeRedirect
-
-	ready, status := mirrorAdvertisesHead(context.Background(), client, srv.URL+"/info/refs", "tok")
-	require.True(t, ready, "probe should follow the node redirect and see HEAD")
-	require.Equal(t, http.StatusOK, status)
-}
-
-func TestCheckProbeRedirect(t *testing.T) {
-	t.Parallel()
-
-	orig := mustReq(t, "https://aws-us-east-2.entire.io/gh/o/r/info/refs")
-	tests := []struct {
-		name    string
-		target  string
-		via     int
-		wantErr bool
-	}{
-		{name: "same host", target: "https://aws-us-east-2.entire.io/node/info/refs", via: 1},
-		{name: "subdomain node", target: "https://bishop.aws-us-east-2.entire.io/gh/o/r/info/refs", via: 1},
-		{name: "cross host leaks token", target: "https://evil.example.com/info/refs", via: 1, wantErr: true},
-		{name: "sibling suffix trick", target: "https://aws-us-east-2.entire.io.evil.com/x", via: 1, wantErr: true},
-		{name: "non-https", target: "http://bishop.aws-us-east-2.entire.io/x", via: 1, wantErr: true},
-		{name: "too many hops", target: "https://bishop.aws-us-east-2.entire.io/x", via: maxProbeRedirects, wantErr: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			via := make([]*http.Request, tt.via)
-			via[0] = orig
-			err := checkProbeRedirect(mustReq(t, tt.target), via)
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func mustReq(t *testing.T, rawURL string) *http.Request {
-	t.Helper()
-	u, err := url.Parse(rawURL)
-	require.NoError(t, err)
-	return &http.Request{URL: u}
-}
-
-// TestWaitForMirrorClone_TimeoutBoundsAuthorization pins that --wait-timeout
-// covers the authorization phase, not just the probe loop: building the
-// token source spans cluster discovery and a possible login refresh, so a
-// hung auth path must be cut off by the user's wait budget.
-//
-// Not parallel: swaps the package-level newRepoTokenSource seam.
-func TestWaitForMirrorClone_TimeoutBoundsAuthorization(t *testing.T) {
-	prev := newRepoTokenSource
-	newRepoTokenSource = func(ctx context.Context, _ string) (repoTokenSource, error) {
-		<-ctx.Done() // hang until the wait deadline fires
-		return nil, ctx.Err()
-	}
-	t.Cleanup(func() { newRepoTokenSource = prev })
-
-	start := time.Now()
-	err := waitForMirrorClone(context.Background(), io.Discard, "cluster.example", "o", "r", 50*time.Millisecond)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	require.Less(t, time.Since(start), 10*time.Second, "authorization must be bounded by the wait timeout")
 }

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -452,6 +452,41 @@ func TestAvailableMirrorRow(t *testing.T) {
 	}
 }
 
+func TestPickDefaultRegionHost(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefers the is-default cluster", func(t *testing.T) {
+		t.Parallel()
+		host, err := pickDefaultRegionHost([]regionChoice{
+			{host: "eu-west-1.entire.io"},
+			{host: "aws-us-east-2.entire.io", isDefault: true},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "aws-us-east-2.entire.io", host)
+	})
+
+	t.Run("sole cluster is the default", func(t *testing.T) {
+		t.Parallel()
+		host, err := pickDefaultRegionHost([]regionChoice{{host: "only.entire.io"}})
+		require.NoError(t, err)
+		require.Equal(t, "only.entire.io", host)
+	})
+
+	t.Run("empty catalog errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := pickDefaultRegionHost(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("ambiguous (multiple, none default) errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := pickDefaultRegionHost([]regionChoice{
+			{host: "a.entire.io"}, {host: "b.entire.io"},
+		})
+		require.Error(t, err)
+	})
+}
+
 func TestClusterArg(t *testing.T) {
 	t.Parallel()
 	if got := clusterArg([]string{"github.com/o/r", "eu-west-1.entire.io"}); got != "eu-west-1.entire.io" {

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -29,21 +29,28 @@ func TestExplainSuspendedMirror(t *testing.T) {
 
 // fakeMirrorGetter feeds awaitMirrorReady a scripted sequence of statuses (the
 // last entry repeats) or a fixed error, standing in for *coreapi.Client.GetMirror.
+// errsBefore makes the first N calls return a transient error before the status
+// sequence begins, to exercise the poll's retry tolerance.
 type fakeMirrorGetter struct {
-	statuses []coreapi.MirrorStatus
-	err      error
-	calls    int
+	statuses   []coreapi.MirrorStatus
+	err        error
+	errsBefore int
+	calls      int
 }
 
 func (f *fakeMirrorGetter) GetMirror(_ context.Context, _ coreapi.GetMirrorParams) (*coreapi.Mirror, error) {
+	n := f.calls
+	f.calls++
 	if f.err != nil {
 		return nil, f.err
 	}
-	i := f.calls
+	if n < f.errsBefore {
+		return nil, errors.New("transient: connection reset")
+	}
+	i := n - f.errsBefore
 	if i >= len(f.statuses) {
 		i = len(f.statuses) - 1
 	}
-	f.calls++
 	m := &coreapi.Mirror{}
 	m.Status = coreapi.NewOptMirrorStatus(f.statuses[i])
 	return m, nil
@@ -95,6 +102,21 @@ func TestAwaitMirrorReady(t *testing.T) {
 		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusProcessing}}
 		_, err := awaitMirrorReady(ctx, f, "m", 20*time.Millisecond, nil)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("transient errors are tolerated, then ready", func(t *testing.T) {
+		// Fewer consecutive errors than the cap, so the poll rides them out.
+		f := &fakeMirrorGetter{errsBefore: maxConsecutivePollErrors - 1, statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusReady}}
+		status, err := awaitMirrorReady(ctx, f, "m", time.Second, nil)
+		require.NoError(t, err)
+		require.Equal(t, coreapi.MirrorStatusReady, status)
+	})
+
+	t.Run("persistent errors give up after the cap", func(t *testing.T) {
+		f := &fakeMirrorGetter{err: errors.New("boom")}
+		_, err := awaitMirrorReady(ctx, f, "m", time.Second, nil)
+		require.ErrorContains(t, err, "poll mirror status")
+		require.Equal(t, maxConsecutivePollErrors, f.calls, "should stop at the cap, not spin to the deadline")
 	})
 }
 

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -60,7 +60,7 @@ func TestAwaitMirrorReady(t *testing.T) {
 
 	t.Run("ready resolves with no error", func(t *testing.T) {
 		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusReady}}
-		status, err := awaitMirrorReady(ctx, f, "m", time.Second)
+		status, err := awaitMirrorReady(ctx, f, "m", time.Second, nil)
 		require.NoError(t, err)
 		require.Equal(t, coreapi.MirrorStatusReady, status)
 	})
@@ -69,7 +69,7 @@ func TestAwaitMirrorReady(t *testing.T) {
 		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{
 			coreapi.MirrorStatusProcessing, coreapi.MirrorStatusProcessing, coreapi.MirrorStatusReady,
 		}}
-		status, err := awaitMirrorReady(ctx, f, "m", time.Second)
+		status, err := awaitMirrorReady(ctx, f, "m", time.Second, nil)
 		require.NoError(t, err)
 		require.Equal(t, coreapi.MirrorStatusReady, status)
 		require.GreaterOrEqual(t, f.calls, 3)
@@ -77,21 +77,21 @@ func TestAwaitMirrorReady(t *testing.T) {
 
 	t.Run("failed returns errMirrorCloneFailed", func(t *testing.T) {
 		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusFailed}}
-		status, err := awaitMirrorReady(ctx, f, "m", time.Second)
+		status, err := awaitMirrorReady(ctx, f, "m", time.Second, nil)
 		require.ErrorIs(t, err, errMirrorCloneFailed)
 		require.Equal(t, coreapi.MirrorStatusFailed, status)
 	})
 
 	t.Run("suspended returns errMirrorSuspended", func(t *testing.T) {
 		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusSuspended}}
-		status, err := awaitMirrorReady(ctx, f, "m", time.Second)
+		status, err := awaitMirrorReady(ctx, f, "m", time.Second, nil)
 		require.ErrorIs(t, err, errMirrorSuspended)
 		require.Equal(t, coreapi.MirrorStatusSuspended, status)
 	})
 
 	t.Run("never-ready times out", func(t *testing.T) {
 		f := &fakeMirrorGetter{statuses: []coreapi.MirrorStatus{coreapi.MirrorStatusProcessing}}
-		_, err := awaitMirrorReady(ctx, f, "m", 20*time.Millisecond)
+		_, err := awaitMirrorReady(ctx, f, "m", 20*time.Millisecond, nil)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 }

--- a/cmd/entire/cli/utils.go
+++ b/cmd/entire/cli/utils.go
@@ -28,10 +28,13 @@ func NewAccessibleForm(groups ...*huh.Group) *huh.Form {
 }
 
 // handleFormCancellation handles cancellation from huh form prompts.
-// User abort (Ctrl+C) and timeout both print a cancelled message and return nil.
-// Other errors are wrapped with the action name for context.
+// User abort (Ctrl+C), timeout, and a cancelled/expired context (when the form
+// ran via RunWithContext and the command's context was cancelled) all print a
+// cancelled message and return nil. Other errors are wrapped with the action
+// name for context.
 func handleFormCancellation(w io.Writer, action string, err error) error {
-	if errors.Is(err, huh.ErrUserAborted) || errors.Is(err, huh.ErrTimeout) {
+	if errors.Is(err, huh.ErrUserAborted) || errors.Is(err, huh.ErrTimeout) ||
+		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		fmt.Fprintf(w, "%s cancelled.\n", action)
 		return nil
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/660
<!-- entire-trail-link-end -->

Adds an interactive onboarding flow and modernizes mirror creation.

## User impact
- `entire repo mirror create` (no args) → interactive wizard: pick repos, pick regions, watch Docker-style per-mirror progress (`processing → ready`), then a summary table with clone URLs.
- Clone readiness now polls the new `Mirror.status` API instead of probing smart-HTTP `info/refs` — faster, and surfaces `failed`/`suspended` directly.
- Regions come from `GET /api/v1/clusters`; the wizard's default selection is jurisdiction-aware (from `/me`).
- New hidden `entire auth token` prints the active control-plane bearer for scripting/curl.

## Unchanged
- One-shot `entire repo mirror create <github-url> [cluster-host]` keeps its fixed default cluster and behavior; `remove`/`collaborators` untouched.

Stacked on #1518 (OpenAPI refresh) — retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large user-facing change to mirror create (parallel API calls, new polling semantics) plus a hidden command that prints live bearer tokens; behavior is well-guarded (TLS, empty stdout on failure) but affects control-plane onboarding paths.
> 
> **Overview**
> Adds **interactive mirror onboarding** when `entire repo mirror create` runs with no arguments: onboardable repos from the API, regions from `GET /api/v1/clusters`, jurisdiction-aware default region selection from `/me`, then parallel `(repo × region)` creates with per-line progress and a summary table plus clone URLs.
> 
> **Clone readiness** no longer probes smart-HTTP `info/refs` or mints repo-scoped tokens for the wait loop. One-shot and wizard paths share `createAndAwaitMirror`, which polls control-plane `Mirror.status` via `awaitMirrorReady` and surfaces `ready`, `failed`, and `suspended` consistently; suspended placements now point users at support instead of an internal admin command.
> 
> Also adds hidden **`entire auth token`** (same bearer resolution as the API client, stdout-only for scripting), extends auth profile with **jurisdiction**, and treats cancelled wizard contexts as clean exits in `handleFormCancellation`. The explicit `create <github-url> [cluster-host]` form keeps a fixed default cluster; catalog-based region picking is wizard-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5692a01907a37722e2471cfe968b58ab69cc69f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->