### PR TITLE
Collect installed git version in telemetry

### DIFF
--- a/cmd/entire/cli/telemetry/detached.go
+++ b/cmd/entire/cli/telemetry/detached.go
@@ -1,8 +1,10 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -177,6 +179,16 @@ func SendEvent(payloadJSON string) {
 		_ = client.Close()
 	}()
 
+	// Resolve the installed git version best-effort. A missing or failing
+	// git must never block the rest of the telemetry — the property is simply
+	// omitted when it can't be determined.
+	if v := gitVersion(context.Background()); v != "" {
+		if payload.Properties == nil {
+			payload.Properties = map[string]any{}
+		}
+		payload.Properties["git_version"] = v
+	}
+
 	// Build properties
 	props := posthog.NewProperties()
 	for k, v := range payload.Properties {
@@ -190,4 +202,29 @@ func SendEvent(payloadJSON string) {
 		Properties: props,
 		Timestamp:  payload.Timestamp,
 	})
+}
+
+// gitVersion returns the installed git version (e.g. "2.43.0"), best-effort.
+// It returns "" when git is absent, the command fails or times out, or the
+// output cannot be parsed — callers must treat "" as "unknown" and move on.
+func gitVersion(ctx context.Context) string {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "git", "--version").Output()
+	if err != nil {
+		return ""
+	}
+	return parseGitVersion(string(out))
+}
+
+// parseGitVersion extracts the version token from `git --version` output, which
+// looks like "git version 2.43.0" (sometimes with a platform suffix such as
+// "git version 2.39.3 (Apple Git-146)"). Returns "" if the shape is unexpected.
+func parseGitVersion(out string) string {
+	fields := strings.Fields(out)
+	if len(fields) < 3 || fields[0] != "git" || fields[1] != "version" {
+		return ""
+	}
+	return fields[2]
 }

--- a/cmd/entire/cli/telemetry/detached_test.go
+++ b/cmd/entire/cli/telemetry/detached_test.go
@@ -153,3 +153,28 @@ func TestSendEventHandlesInvalidJSON(_ *testing.T) {
 	SendEvent("")
 	SendEvent("{}")
 }
+
+func TestParseGitVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{"standard", "git version 2.43.0\n", "2.43.0"},
+		{"apple suffix", "git version 2.39.3 (Apple Git-146)\n", "2.39.3"},
+		{"windows suffix", "git version 2.45.1.windows.1\n", "2.45.1.windows.1"},
+		{"no trailing newline", "git version 2.40.0", "2.40.0"},
+		{"empty", "", ""},
+		{"unexpected prefix", "not git output", ""},
+		{"missing version token", "git version", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parseGitVersion(tt.out); got != tt.want {
+				t.Errorf("parseGitVersion(%q) = %q, want %q", tt.out, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/security-and-privacy.md
+++ b/docs/security-and-privacy.md
@@ -382,7 +382,7 @@ File an issue when the rule would benefit every Entire user (e.g., a major SaaS 
 
 ## Telemetry
 
-The CLI captures anonymous usage analytics by default. Sent to PostHog with `DisableGeoIP` enabled. Captured per command: command name, selected agent, whether Entire is enabled in the repo, CLI version, OS/arch, and **names** of flags passed (never their values). The distinct ID is a hashed machine identifier (`machineid.ProtectedID`), not a user identity.
+The CLI captures anonymous usage analytics by default. Sent to PostHog with `DisableGeoIP` enabled. Captured per command: command name, selected agent, whether Entire is enabled in the repo, CLI version, OS/arch, installed git version (best-effort; omitted if git is absent or unparseable), and **names** of flags passed (never their values). The distinct ID is a hashed machine identifier (`machineid.ProtectedID`), not a user identity.
 
 Not captured: flag values, prompt text, transcripts, file paths, repository identifiers, GitHub usernames, source code.
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/661
<!-- entire-trail-link-end -->

Resolve `git --version` in the detached analytics subprocess and attach it as a best-effort git_version property. Off the command hot path; any failure (git absent, exec error, timeout, unparseable output) omits the property and never blocks the rest of the telemetry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, best-effort addition to anonymous telemetry in an already-detached subprocess; failures are silent and docs were updated.
> 
> **Overview**
> Adds a best-effort **`git_version`** PostHog property when the hidden detached analytics subprocess runs **`SendEvent`**, so the main CLI path stays unchanged.
> 
> Before enqueueing, it runs **`git --version`** with a 5s timeout, parses the version token (including Apple/Windows-style suffixes), and sets **`git_version`** on the payload; missing git, exec failure, timeout, or bad output omits the property and does not block sending other telemetry.
> 
> **`docs/security-and-privacy.md`** now documents that installed git version may be captured. **`TestParseGitVersion`** covers parsing edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444c985437ea666713d40b30697a0cb94e718a03. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->