### PR TITLE
Update trail watch for trail-wide events

### DIFF
--- a/cmd/entire/cli/trail_watch_cmd.go
+++ b/cmd/entire/cli/trail_watch_cmd.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// SSE control events for the agent-native finding stream. Domain events
+// SSE control events for the trail-wide event stream. Domain events
 // (for example "session.started" or "comment.created") are emitted as their
 // code_review_events.event_type values.
 const (
@@ -47,19 +47,19 @@ func newTrailWatchCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "watch [<number>]",
-		Short: "Tail a trail's finding events live",
-		Long: `Subscribe to the trail-scoped agent-native finding SSE stream and
-print events as they arrive. Reconnects automatically when the server caps the
-connection (~50s) and on transient network errors.
+		Short: "Tail a trail's events live",
+		Long: `Subscribe to the trail-wide SSE stream and print events as they arrive.
+Reconnects automatically when the server caps the connection (~50s) and on
+transient network errors.
 
 If <number> is omitted, the trail for the current branch is used.
 
 This command resolves the trail's id internally and streams
-GET /api/v1/trails/<id>/reviews/events with Accept: text/event-stream.
+GET /api/v1/trails/<id>/events with Accept: text/event-stream.
 
 Events emitted by the server:
   ready              initial frame, includes trail and cursor
-  <event_type>       finding domain event (sessions, findings, suggested changes, ...)
+  <event_type>       trail domain event (reviews, findings, runners, monitors, ...)
   reconnect          server cap reached; re-establishing
   forbidden          access was revoked; stream ends
   error              server-side error; treated as reconnect`,
@@ -220,7 +220,7 @@ func trailWatchDescription(forge, owner, repo string, number int, trailID string
 }
 
 func reviewEventsPath(trailID string) string {
-	return "/api/v1/trails/" + url.PathEscape(trailID) + "/reviews/events"
+	return "/api/v1/trails/" + url.PathEscape(trailID) + "/events"
 }
 
 type streamCloseReason int

--- a/cmd/entire/cli/trail_watch_cmd_test.go
+++ b/cmd/entire/cli/trail_watch_cmd_test.go
@@ -40,7 +40,7 @@ func fakeSSEServer(t *testing.T, frames []string) (*httptest.Server, *string) {
 
 func TestReviewEventsPath(t *testing.T) {
 	got := reviewEventsPath("trail id/with slash")
-	want := "/api/v1/trails/trail%20id%2Fwith%20slash/reviews/events"
+	want := "/api/v1/trails/trail%20id%2Fwith%20slash/events"
 	if got != want {
 		t.Fatalf("reviewEventsPath = %q, want %q", got, want)
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/663
<!-- entire-trail-link-end -->

## Summary
- switch `entire trail watch` from `/reviews/events` to the trail-wide `/events` endpoint
- update watch help text and stream event structs for trail-wide review events
- render runner and monitor events in human-readable watch output

## Tests
- `go test ./cmd/entire/cli`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only streaming URL and display logic; backward-compatible session event names limit breakage for older server payloads.
> 
> **Overview**
> **`entire trail watch`** now subscribes to the **trail-wide** SSE endpoint (`/api/v1/trails/<id>/events`) instead of the review-scoped `/reviews/events` stream. Help text and naming were updated accordingly (`trailEventsPath`, `trailStreamEvent`, etc.).
> 
> Stream JSON now uses **`review_id`** (replacing `review_session_id`). Human-readable output adds **`review.started` / `review.ended`** while still handling legacy **`session.started` / `session.ended`**. New formatters cover **runner** events (`runner.run`, `runner.status`, `runner.done`, `runner.error`) and **`monitor.updated`**.
> 
> Tests were renamed and extended to assert the new path, `review.*` payloads, runner/monitor lines, and `Last-Event-ID` cursor `4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cad45f708503d9147bb7cc3599b030e7e8bbbc4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->