### PR TITLE
Refine checkpoint version policy error handling

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -88,8 +88,14 @@ linters:
       # RFC 7807 problem detail via errors.As. Per-call-site wrapping would
       # only be unwrapped again, so the command closures return coreapi
       # errors verbatim.
+      #
+      # checkpointpolicy.EnsureCanReadVersion already returns a clean,
+      # user-facing message (including the checkpoint ID and version), and
+      # callers classify it via IsUnsupportedVersion. Wrapping would obscure
+      # that purpose-built message, so call sites return it verbatim.
       ignore-package-globs:
         - github.com/entireio/cli/internal/coreapi
+        - github.com/entireio/cli/cmd/entire/cli/checkpointpolicy
     forbidigo:
       analyze-types: true
       forbid:

--- a/cmd/entire/cli/checkpointpolicy/format.go
+++ b/cmd/entire/cli/checkpointpolicy/format.go
@@ -24,17 +24,12 @@ func ParseFormat(raw string) (CheckpointFormat, error) {
 		return CheckpointFormat{}, fmt.Errorf("invalid checkpoint format %q", raw)
 	}
 
-	family := CheckpointFamily(familyRaw)
-	if _, ok := knownFamilies[family]; !ok {
-		return CheckpointFormat{}, fmt.Errorf("unknown checkpoint family %q", familyRaw)
-	}
-
 	major, err := strconv.Atoi(majorRaw)
 	if err != nil || major <= 0 {
 		return CheckpointFormat{}, fmt.Errorf("invalid checkpoint major %q", majorRaw)
 	}
 
-	return CheckpointFormat{Family: family, Major: major}, nil
+	return CheckpointFormat{Family: CheckpointFamily(familyRaw), Major: major}, nil
 }
 
 func (f CheckpointFormat) String() string {
@@ -46,11 +41,6 @@ func (f CheckpointFormat) String() string {
 
 func CanRead(format CheckpointFormat) bool {
 	return readFormats[format]
-}
-
-var knownFamilies = map[CheckpointFamily]bool{
-	CheckpointFamilyBranch: true,
-	CheckpointFamilyRefs:   true,
 }
 
 var branchV1Format = CheckpointFormat{Family: CheckpointFamilyBranch, Major: 1}

--- a/cmd/entire/cli/checkpointpolicy/format_test.go
+++ b/cmd/entire/cli/checkpointpolicy/format_test.go
@@ -18,7 +18,7 @@ func TestParseFormat(t *testing.T) {
 	}{
 		{name: "branch v1", input: "branch-v1", want: checkpointpolicy.CheckpointFormat{Family: checkpointpolicy.CheckpointFamilyBranch, Major: 1}},
 		{name: "refs v2", input: "refs-v2", want: checkpointpolicy.CheckpointFormat{Family: checkpointpolicy.CheckpointFamilyRefs, Major: 2}},
-		{name: "unknown family", input: "unknown-v1", wantErr: "unknown checkpoint family"},
+		{name: "unknown family parses", input: "unknown-v1", want: checkpointpolicy.CheckpointFormat{Family: "unknown", Major: 1}},
 		{name: "missing v", input: "branch-1", wantErr: "invalid checkpoint format"},
 		{name: "zero major", input: "branch-v0", wantErr: "invalid checkpoint major"},
 		{name: "non numeric major", input: "branch-vx", wantErr: "invalid checkpoint major"},
@@ -45,7 +45,10 @@ func TestCanReadFormat(t *testing.T) {
 	require.NoError(t, err)
 	refsV1, err := checkpointpolicy.ParseFormat("refs-v1")
 	require.NoError(t, err)
+	unknownV1, err := checkpointpolicy.ParseFormat("unknown-v1")
+	require.NoError(t, err)
 
 	require.True(t, checkpointpolicy.CanRead(branchV1))
 	require.False(t, checkpointpolicy.CanRead(refsV1))
+	require.False(t, checkpointpolicy.CanRead(unknownV1))
 }

--- a/cmd/entire/cli/checkpointpolicy/version.go
+++ b/cmd/entire/cli/checkpointpolicy/version.go
@@ -26,7 +26,6 @@ func EnsureCanReadVersion(checkpointID, version string) error {
 		return unsupportedVersionError{
 			CheckpointID: checkpointID,
 			Version:      version,
-			Err:          errUnsupportedVersion,
 		}
 	}
 	return nil
@@ -35,13 +34,12 @@ func EnsureCanReadVersion(checkpointID, version string) error {
 type unsupportedVersionError struct {
 	CheckpointID string
 	Version      string
-	Err          error
 }
 
 func (e unsupportedVersionError) Error() string {
-	return fmt.Sprintf("checkpoint %s uses unsupported checkpoint_version %q: %v", e.CheckpointID, e.Version, e.Err)
+	return fmt.Sprintf("checkpoint %s uses unsupported checkpoint_version %q: %v", e.CheckpointID, e.Version, errUnsupportedVersion)
 }
 
 func (e unsupportedVersionError) Unwrap() error {
-	return e.Err
+	return errUnsupportedVersion
 }

--- a/cmd/entire/cli/checkpointpolicy/version.go
+++ b/cmd/entire/cli/checkpointpolicy/version.go
@@ -7,9 +7,10 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 )
 
+var errUnsupportedVersion = errors.New("not read-supported by this Entire CLI")
+
 func IsUnsupportedVersion(err error) bool {
-	var unsupported *unsupportedVersionError
-	return errors.As(err, &unsupported)
+	return errors.Is(err, errUnsupportedVersion)
 }
 
 func EnsureCanReadVersion(checkpointID, version string) error {
@@ -22,10 +23,10 @@ func EnsureCanReadVersion(checkpointID, version string) error {
 		return fmt.Errorf("checkpoint %s has invalid checkpoint_version %q: %w", checkpointID, version, err)
 	}
 	if !CanRead(format) {
-		return &unsupportedVersionError{
+		return unsupportedVersionError{
 			CheckpointID: checkpointID,
 			Version:      version,
-			Err:          errors.New("not read-supported by this Entire CLI"),
+			Err:          errUnsupportedVersion,
 		}
 	}
 	return nil

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -756,7 +756,7 @@ func loadCheckpointForExplain(ctx context.Context, lookup *explainCheckpointLook
 		return nil, nil, fmt.Errorf("failed to read checkpoint: %w", err)
 	}
 	if err := checkpointpolicy.EnsureCanReadVersion(cpID.String(), summary.CheckpointVersion); err != nil {
-		return nil, nil, fmt.Errorf("%w", err)
+		return nil, nil, err
 	}
 
 	content, contentErr := checkpoint.ReadLatestSessionContent(ctx, store, cpID, summary)

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -267,7 +267,7 @@ func runExplainStreamTranscript(ctx context.Context, w, errW io.Writer, opts exp
 		return fmt.Errorf("failed to read checkpoint: %w", err)
 	}
 	if err := checkpointpolicy.EnsureCanReadVersion(cpID.String(), summary.CheckpointVersion); err != nil {
-		return fmt.Errorf("%w", err)
+		return err
 	}
 
 	idx, err := resolveSessionIndex(summary, opts.sessionIndex)
@@ -364,7 +364,7 @@ func runExplainCheckpointJSON(ctx context.Context, w, errW io.Writer, opts expla
 		return fmt.Errorf("failed to read checkpoint: %w", err)
 	}
 	if err := checkpointpolicy.EnsureCanReadVersion(cpID.String(), summary.CheckpointVersion); err != nil {
-		return fmt.Errorf("%w", err)
+		return err
 	}
 
 	envelope, failedSessions := buildCheckpointJSONEnvelope(ctx, store, summary, cpID)

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -369,7 +369,7 @@ func readCheckpointInfoFromStore(ctx context.Context, store checkpointInfoReader
 		return nil, fmt.Errorf("read checkpoint: %w", err)
 	}
 	if err := checkpointpolicy.EnsureCanReadVersion(checkpointID.String(), summary.CheckpointVersion); err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, err
 	}
 	info := &strategy.CheckpointInfo{
 		CheckpointID:     checkpointID,

--- a/cmd/entire/cli/rewind.go
+++ b/cmd/entire/cli/rewind.go
@@ -734,7 +734,7 @@ func restoreSessionTranscriptFromStrategy(ctx context.Context, cpID id.Checkpoin
 		return "", fmt.Errorf("failed to read checkpoint: %w", err)
 	}
 	if err := checkpointpolicy.EnsureCanReadVersion(cpID.String(), summary.CheckpointVersion); err != nil {
-		return "", fmt.Errorf("%w", err)
+		return "", err
 	}
 
 	logContent, returnedSessionID, err := checkpoint.ReadRawSessionLogForCheckpoint(ctx, stores.Persistent, cpID)

--- a/cmd/entire/cli/strategy/manual_commit_rewind.go
+++ b/cmd/entire/cli/strategy/manual_commit_rewind.go
@@ -653,7 +653,7 @@ func (s *ManualCommitStrategy) RestoreLogsOnly(ctx context.Context, w, errW io.W
 		return nil, fmt.Errorf("failed to read checkpoint: %w", err)
 	}
 	if err := checkpointpolicy.EnsureCanReadVersion(point.CheckpointID.String(), summary.CheckpointVersion); err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, err
 	}
 
 	// Get worktree root for agent session directory lookup


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/667
<!-- entire-trail-link-end -->

## Why

Follow-up to #1507 ("Add checkpoint format compatibility checks"), addressing post-merge review feedback. Two issues surfaced:

1. The unsupported-version classification was built around a pointer error matched with `errors.As`, and every `EnsureCanReadVersion` call site wrapped the result in a no-op `fmt.Errorf("%w", err)`. That added a meaningless layer over an already purpose-built, user-facing message without adding context.
2. `ParseFormat` hard-failed on any unrecognized checkpoint family. A checkpoint written by a *newer* client (e.g. a future `refs-vN` or other family) therefore surfaced as a malformed-format error, and `IsUnsupportedVersion` returned false — suppressing the "please upgrade" path that is the entire point of the compatibility check.

## What changed

- `unsupportedVersionError` is now a value-based error carrying only its per-instance context (checkpoint ID + version); classification flows through the package sentinel `errUnsupportedVersion` matched with `errors.Is`. The six no-op error wraps at the `EnsureCanReadVersion` call sites return the error verbatim.
- `ParseFormat` validates only the `family-vN` structure; `CanRead` is the sole read gate. Unknown but well-formed families now parse and resolve to an unsupported-version error, so the upgrade prompt fires as intended.

## Decisions made during development

- Added `checkpointpolicy` to wrapcheck's `ignore-package-globs` rather than re-wrapping at call sites. This mirrors the existing `coreapi` entry: the policy error is already a clean, user-facing message classified by callers via `IsUnsupportedVersion`, so wrapping would only obscure it.
- Kept the squash-merge `resolveLatestCheckpoint` fail-fast-on-unsupported behavior as-is. It was raised by review bots but is an intentional design choice (keep the logic simple, encourage upgrades).
- Dropped the family allow-list (`knownFamilies`) entirely instead of extending it. Concentrating the read gate in `CanRead`/`readFormats` gives a single source of truth and removes a concept. Checkpoint versions are machine-written (commit trailers / metadata), so precise errors for a typo'd family carry little value next to correct forward-compat behavior.

## Reviewer notes

This flips a previously-tested behavior: `ParseFormat("unknown-v1")` now succeeds (and is gated by `CanRead`) instead of erroring. Tests were updated to pin the new parse-then-gate contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling and format parsing in checkpointpolicy and read paths; behavior change is intentional forward-compat for newer checkpoint families.
> 
> **Overview**
> **Checkpoint version policy** is tightened so unsupported formats behave like upgrade prompts instead of parse failures, and callers surface the policy errors without extra wrapping.
> 
> `ParseFormat` no longer rejects unknown families (e.g. `unknown-v1`, future `refs-vN`); it only checks `family-vN` shape. **Read support** is decided solely by `CanRead` / `readFormats`, so well-formed but unreadable versions flow through `EnsureCanReadVersion` as unsupported-version errors. `IsUnsupportedVersion` now uses `errors.Is` against a package sentinel; `unsupportedVersionError` is value-based and unwraps that sentinel.
> 
> Six CLI call sites (`explain`, export, `resume`, `rewind`, manual-commit rewind) return `EnsureCanReadVersion` errors **verbatim** instead of `fmt.Errorf("%w", err)`. `checkpointpolicy` is added to **wrapcheck** `ignore-package-globs` with rationale matching `coreapi`. Tests document parse-then-gate for unknown families.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228397efeed1ecbd51fcda4af6eb5704ddfb4739. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->