### PR TITLE
Add `entire repo clone`

### DIFF
--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -13,9 +13,10 @@ import (
 )
 
 // newRepoCmd is the hidden `entire repo` command group: control-plane
-// repository lifecycle (create, list within a project, get, delete) on the
-// Entire control plane. Git content operations (clone, log, diff, …) are
-// intentionally out of scope here. Surfaced via `entire labs`.
+// repository lifecycle (create, list within a project, get, delete) plus the
+// `clone` convenience that resolves a mirror and shells out to `git clone`.
+// Other git content operations (log, diff, …) remain intentionally out of scope
+// here. Surfaced via `entire labs`.
 func newRepoCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "repo",

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -27,6 +27,7 @@ func newRepoCmd() *cobra.Command {
 	cmd.AddCommand(newRepoListCmd())
 	cmd.AddCommand(newRepoGetCmd())
 	cmd.AddCommand(newRepoDeleteCmd())
+	cmd.AddCommand(newRepoCloneCmd())
 	cmd.AddCommand(newRepoMirrorCmd())
 	return cmd
 }

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -39,6 +39,17 @@ func parseMirrorCloneRef(ref string) (provider, owner, repo string, err error) {
 	return checkpointProviderGitHub, owner, repo, nil
 }
 
+// newCloneAliasCmd is the top-level `entire clone` alias for `entire repo
+// clone`. Cobra forbids attaching one command to two parents, so this builds a
+// fresh clone command and adds the control-plane flags (--json,
+// --insecure-http-auth) the repo group otherwise supplies to its children as
+// persistent flags.
+func newCloneAliasCmd() *cobra.Command {
+	cmd := newRepoCloneCmd()
+	addControlPlaneFlags(cmd)
+	return cmd
+}
+
 func newRepoCloneCmd() *cobra.Command {
 	var cluster string
 	cmd := &cobra.Command{

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -31,13 +31,21 @@ const mirrorCloneProviderGitHub = "github"
 
 // entireCloneURLScheme is the scheme of a full mirror clone URL, which
 // git-remote-entire resolves directly. Such a URL already names the cluster, so
-// `entire clone` passes it through to `git clone` untouched.
+// `repo clone` passes it through to `git clone` untouched.
 const entireCloneURLScheme = "entire://"
 
 // isEntireCloneURL reports whether ref is a full entire:// clone URL (vs. the
 // `/gh/<owner>/<repo>` shorthand that needs a mirror lookup).
 func isEntireCloneURL(ref string) bool {
 	return strings.HasPrefix(strings.TrimSpace(ref), entireCloneURLScheme)
+}
+
+// mirrorCloneURL synthesizes the entire:// clone URL for a GitHub mirror from
+// its cluster host and owner/repo — the form `git clone` accepts, which the
+// mirror list API doesn't return. Shared by the mirror table view (mirrorRow)
+// and `repo clone` so the wire format lives in one place.
+func mirrorCloneURL(host, owner, repo string) string {
+	return fmt.Sprintf("%s%s/gh/%s/%s", entireCloneURLScheme, host, owner, repo)
 }
 
 // parseMirrorCloneRef turns a clone ref like `/gh/entirehq/entire-api` into the
@@ -143,7 +151,7 @@ func newRepoCloneCmd() *cobra.Command {
 			if err := validateClusterHost(chosen.ClusterHost); err != nil {
 				return fmt.Errorf("mirror has an invalid cluster host %q: %w", chosen.ClusterHost, err)
 			}
-			cloneURL := fmt.Sprintf("entire://%s/gh/%s/%s", chosen.ClusterHost, owner, repo)
+			cloneURL := mirrorCloneURL(chosen.ClusterHost, owner, repo)
 			return runGitClone(cmd.Context(), cmd, cloneURL, targetDir)
 		},
 	}

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -88,7 +88,9 @@ func newRepoCloneCmd() *cobra.Command {
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			ref := args[0]
+			// Trim once up front so the entire:// detection and the value forwarded
+			// to git clone agree (the shorthand path trims inside parseMirrorCloneRef).
+			ref := strings.TrimSpace(args[0])
 			var targetDir string
 			if len(args) > 1 {
 				targetDir = args[1]

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -199,20 +199,24 @@ func listMirrorsForRepo(ctx context.Context, c *coreapi.Client, provider, owner,
 // interactively, failing fast with a --cluster pointer when there's no terminal.
 func selectCloneTarget(cmd *cobra.Command, mirrors []coreapi.Mirror, clusterFlag string) (coreapi.Mirror, error) {
 	// Dedupe by cluster host: one placement per cluster is what a clone targets,
-	// and the same host appearing twice would only confuse the picker.
+	// and the same host appearing twice would only confuse the picker. Key on the
+	// case-folded host — DNS is case-insensitive, so a --cluster value differing
+	// only in case from the API's ClusterHost must still match (the alternative is
+	// a misleading "not mirrored on ..." after a successful lookup + dial).
 	byHost := make(map[string]coreapi.Mirror, len(mirrors))
 	hosts := make([]string, 0, len(mirrors))
 	for _, m := range mirrors {
-		if _, seen := byHost[m.ClusterHost]; seen {
+		key := strings.ToLower(m.ClusterHost)
+		if _, seen := byHost[key]; seen {
 			continue
 		}
-		byHost[m.ClusterHost] = m
-		hosts = append(hosts, m.ClusterHost)
+		byHost[key] = m
+		hosts = append(hosts, key)
 	}
 	sort.Strings(hosts)
 
 	if clusterFlag != "" {
-		m, ok := byHost[clusterFlag]
+		m, ok := byHost[strings.ToLower(strings.TrimSpace(clusterFlag))]
 		if !ok {
 			return coreapi.Mirror{}, fmt.Errorf("repo is not mirrored on %q; available: %s", clusterFlag, strings.Join(hosts, ", "))
 		}

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -23,6 +23,12 @@ import (
 // (owner/repo flow unescaped into the synthesised entire:// clone URL).
 var mirrorCloneRefRe = regexp.MustCompile(`^/?gh/` + gitHubOwnerPat + `/` + gitHubRepoPat + `$`)
 
+// mirrorCloneProviderGitHub is the upstream provider the `gh` path token maps to
+// — the value the control plane records and the list API filters on. Kept local
+// to the clone path so the provider mapping is self-contained rather than
+// borrowing a constant named for an unrelated (checkpoint) concern.
+const mirrorCloneProviderGitHub = "github"
+
 // parseMirrorCloneRef turns a clone ref like `/gh/entirehq/entire-api` into the
 // API provider ("github") and the lowercased owner/repo. The `gh` token is the
 // path provider used in entire:// clone URLs; it maps to the "github" upstream
@@ -30,13 +36,13 @@ var mirrorCloneRefRe = regexp.MustCompile(`^/?gh/` + gitHubOwnerPat + `/` + gitH
 func parseMirrorCloneRef(ref string) (provider, owner, repo string, err error) {
 	m := mirrorCloneRefRe.FindStringSubmatch(strings.TrimSpace(ref))
 	if m == nil {
-		return "", "", "", fmt.Errorf("expected /gh/<owner>/<repo>, got %q", ref)
+		return "", "", "", fmt.Errorf("expected gh/<owner>/<repo> (leading slash optional), got %q", ref)
 	}
 	owner, repo = strings.ToLower(m[1]), strings.ToLower(m[2])
 	if gitHubDotOnlyRe.MatchString(repo) {
 		return "", "", "", fmt.Errorf("repo cannot be dot-only: %s", ref)
 	}
-	return checkpointProviderGitHub, owner, repo, nil
+	return mirrorCloneProviderGitHub, owner, repo, nil
 }
 
 // newCloneAliasCmd is the top-level `entire clone` alias for `entire repo
@@ -106,7 +112,7 @@ func newRepoCloneCmd() *cobra.Command {
 			}
 
 			if len(mirrors) == 0 {
-				return fmt.Errorf("no mirror found for gh/%s/%s; run 'entire repo mirror create github.com/%s/%s' to onboard it", owner, repo, owner, repo)
+				return fmt.Errorf("no mirror found for /gh/%s/%s; run 'entire repo mirror create github.com/%s/%s' to onboard it", owner, repo, owner, repo)
 			}
 
 			chosen, err := selectCloneTarget(cmd, mirrors, cluster)
@@ -114,6 +120,13 @@ func newRepoCloneCmd() *cobra.Command {
 				return err
 			}
 
+			// chosen.ClusterHost is server-provided, but it's interpolated into the
+			// entire:// clone URL just like the user-supplied --cluster, so apply the
+			// same anti-token-leak guard (validateClusterHost) before building it —
+			// defense-in-depth against a malformed host reaching git / the STS audience.
+			if err := validateClusterHost(chosen.ClusterHost); err != nil {
+				return fmt.Errorf("mirror has an invalid cluster host %q: %w", chosen.ClusterHost, err)
+			}
 			cloneURL := fmt.Sprintf("entire://%s/gh/%s/%s", chosen.ClusterHost, owner, repo)
 			return runGitClone(cmd.Context(), cmd, cloneURL, targetDir)
 		},

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -29,6 +29,17 @@ var mirrorCloneRefRe = regexp.MustCompile(`^/?gh/` + gitHubOwnerPat + `/` + gitH
 // borrowing a constant named for an unrelated (checkpoint) concern.
 const mirrorCloneProviderGitHub = "github"
 
+// entireCloneURLScheme is the scheme of a full mirror clone URL, which
+// git-remote-entire resolves directly. Such a URL already names the cluster, so
+// `entire clone` passes it through to `git clone` untouched.
+const entireCloneURLScheme = "entire://"
+
+// isEntireCloneURL reports whether ref is a full entire:// clone URL (vs. the
+// `/gh/<owner>/<repo>` shorthand that needs a mirror lookup).
+func isEntireCloneURL(ref string) bool {
+	return strings.HasPrefix(strings.TrimSpace(ref), entireCloneURLScheme)
+}
+
 // parseMirrorCloneRef turns a clone ref like `/gh/entirehq/entire-api` into the
 // API provider ("github") and the lowercased owner/repo. The `gh` token is the
 // path provider used in entire:// clone URLs; it maps to the "github" upstream
@@ -61,24 +72,38 @@ func newRepoCloneCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clone <repo> [target-dir]",
 		Short: "Clone a mirrored repository",
-		Long: "Clone a GitHub mirror by its `/gh/<owner>/<repo>` ref. Looks up where " +
-			"the repo is mirrored: if it's on a single cluster, clones it directly; " +
-			"if it's mirrored on more than one, prompts you to pick which to clone " +
-			"from (or pass --cluster to choose non-interactively). The optional " +
-			"[target-dir] is passed straight through to `git clone`.",
+		Long: "Clone a GitHub mirror by its `/gh/<owner>/<repo>` ref, or by a full " +
+			"`entire://<cluster>/gh/<owner>/<repo>` clone URL.\n\n" +
+			"With a `/gh/<owner>/<repo>` ref, looks up where the repo is mirrored: if " +
+			"it's on a single cluster, clones it directly; if it's mirrored on more " +
+			"than one, prompts you to pick which to clone from (or pass --cluster to " +
+			"choose non-interactively).\n\n" +
+			"A full `entire://` URL already names the cluster, so it's passed straight " +
+			"through to `git clone` with no lookup (and --cluster is ignored). The " +
+			"optional [target-dir] is passed through to `git clone` either way.",
 		Example: "  entire repo clone /gh/entirehq/entire-api\n" +
 			"  entire repo clone /gh/entirehq/entire-api ./entire-api\n" +
-			"  entire repo clone /gh/entirehq/entire-api --cluster aws-us-east-2.entire.io",
+			"  entire repo clone /gh/entirehq/entire-api --cluster aws-us-east-2.entire.io\n" +
+			"  entire repo clone entire://aws-us-east-2.entire.io/gh/entirehq/entire-api",
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
-			provider, owner, repo, err := parseMirrorCloneRef(args[0])
-			if err != nil {
-				return fmt.Errorf("invalid <repo>: %w", err)
-			}
+			ref := args[0]
 			var targetDir string
 			if len(args) > 1 {
 				targetDir = args[1]
+			}
+
+			// A full entire:// clone URL already embeds the cluster host (it's what
+			// --cluster would otherwise resolve to), so pass it verbatim to git clone
+			// — no mirror lookup or cluster resolution. --cluster is irrelevant here.
+			if isEntireCloneURL(ref) {
+				return runGitClone(cmd.Context(), cmd, ref, targetDir)
+			}
+
+			provider, owner, repo, err := parseMirrorCloneRef(ref)
+			if err != nil {
+				return fmt.Errorf("invalid <repo>: %w", err)
 			}
 
 			var mirrors []coreapi.Mirror

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -76,14 +76,32 @@ func newRepoCloneCmd() *cobra.Command {
 			}
 
 			var mirrors []coreapi.Mirror
-			if err := runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+			lister := func(ctx context.Context, c *coreapi.Client) error {
 				ms, err := listMirrorsForRepo(ctx, c, provider, owner, repo)
 				if err != nil {
 					return err
 				}
 				mirrors = ms
 				return nil
-			}); err != nil {
+			}
+			// An explicit --cluster may name a cluster in a different federation
+			// than the active context, whose mirrors the active-context core can't
+			// see (the original bug: cloning a royalcanin.partial.to mirror while a
+			// different context is active failed with "not mirrored on ..."). Dial
+			// the core fronting that cluster — discovered from its well-known and
+			// authenticated with the matching local context, the same path
+			// `mirror create <url> [cluster]` uses — so the lookup resolves against
+			// the right federation. With no --cluster, list from the active context.
+			runWithCore := runCore
+			if cluster != "" {
+				if err := validateClusterHost(cluster); err != nil {
+					return fmt.Errorf("invalid --cluster: %w", err)
+				}
+				runWithCore = func(cmd *cobra.Command, fn func(context.Context, *coreapi.Client) error) error {
+					return runCoreForCluster(cmd, cluster, fn)
+				}
+			}
+			if err := runWithCore(cmd, lister); err != nil {
 				return err
 			}
 
@@ -100,7 +118,7 @@ func newRepoCloneCmd() *cobra.Command {
 			return runGitClone(cmd.Context(), cmd, cloneURL, targetDir)
 		},
 	}
-	cmd.Flags().StringVar(&cluster, "cluster", "", "cluster host to clone from when the repo is mirrored on more than one")
+	cmd.Flags().StringVar(&cluster, "cluster", "", "cluster host to clone from when the repo is mirrored on more than one (may live in another auth context; resolved via that cluster's core)")
 	return cmd
 }
 

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -96,6 +96,13 @@ func newRepoCloneCmd() *cobra.Command {
 			// A full entire:// clone URL already embeds the cluster host (it's what
 			// --cluster would otherwise resolve to), so pass it verbatim to git clone
 			// — no mirror lookup or cluster resolution. --cluster is irrelevant here.
+			//
+			// Deliberately NOT run through validateClusterHost: this is a raw URL the
+			// user typed, forwarded to `git clone` exactly as given (the whole point
+			// of this branch), so it's equivalent to running `git clone entire://…`
+			// directly. The validateClusterHost guard applies on the shorthand path
+			// where we *synthesize* the URL from a --cluster flag or an API-supplied
+			// host — values that flow into the STS audience under our own construction.
 			if isEntireCloneURL(ref) {
 				return runGitClone(cmd.Context(), cmd, ref, targetDir)
 			}

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -201,11 +201,18 @@ func selectCloneTarget(cmd *cobra.Command, mirrors []coreapi.Mirror, clusterFlag
 		),
 	)
 	if err := form.RunWithContext(cmd.Context()); err != nil {
-		return coreapi.Mirror{}, handleFormCancellation(cmd.ErrOrStderr(), "Clone", err)
+		// handleFormCancellation prints "Clone cancelled." and returns nil for a
+		// Ctrl+C / cancelled-context abort. Surface that as a SilentError so the
+		// caller stops instead of falling through to clone a zero-value target
+		// (the `entire:///gh/...` empty-host bug); a real form error propagates.
+		if cerr := handleFormCancellation(cmd.ErrOrStderr(), "Clone", err); cerr != nil {
+			return coreapi.Mirror{}, cerr
+		}
+		return coreapi.Mirror{}, NewSilentError(errors.New("clone cancelled"))
 	}
 	m, ok := byHost[selected]
 	if !ok {
-		return coreapi.Mirror{}, errors.New("no cluster selected")
+		return coreapi.Mirror{}, NewSilentError(errors.New("clone cancelled"))
 	}
 	return m, nil
 }

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -118,7 +118,7 @@ func newRepoCloneCmd() *cobra.Command {
 			return runGitClone(cmd.Context(), cmd, cloneURL, targetDir)
 		},
 	}
-	cmd.Flags().StringVar(&cluster, "cluster", "", "cluster host to clone from when the repo is mirrored on more than one (may live in another auth context; resolved via that cluster's core)")
+	cmd.Flags().StringVar(&cluster, "cluster", "", "cluster host to clone from when the repo is mirrored on more than one (may belong to another auth context)")
 	return cmd
 }
 

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -56,17 +56,6 @@ func parseMirrorCloneRef(ref string) (provider, owner, repo string, err error) {
 	return mirrorCloneProviderGitHub, owner, repo, nil
 }
 
-// newCloneAliasCmd is the top-level `entire clone` alias for `entire repo
-// clone`. Cobra forbids attaching one command to two parents, so this builds a
-// fresh clone command and adds the control-plane flags (--json,
-// --insecure-http-auth) the repo group otherwise supplies to its children as
-// persistent flags.
-func newCloneAliasCmd() *cobra.Command {
-	cmd := newRepoCloneCmd()
-	addControlPlaneFlags(cmd)
-	return cmd
-}
-
 func newRepoCloneCmd() *cobra.Command {
 	var cluster string
 	cmd := &cobra.Command{

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -1,0 +1,218 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+
+	"charm.land/huh/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// mirrorCloneRefRe parses the clone-ref shape `entire repo clone` accepts:
+// the `/gh/<owner>/<repo>` path of a mirror's clone URL, with or without the
+// leading slash. owner/repo reuse the GitHub identifier charsets from
+// parseGitHubURL so the same metacharacter vectors are closed at the boundary
+// (owner/repo flow unescaped into the synthesised entire:// clone URL).
+var mirrorCloneRefRe = regexp.MustCompile(`^/?gh/` + gitHubOwnerPat + `/` + gitHubRepoPat + `$`)
+
+// parseMirrorCloneRef turns a clone ref like `/gh/entirehq/entire-api` into the
+// API provider ("github") and the lowercased owner/repo. The `gh` token is the
+// path provider used in entire:// clone URLs; it maps to the "github" upstream
+// provider the control plane records.
+func parseMirrorCloneRef(ref string) (provider, owner, repo string, err error) {
+	m := mirrorCloneRefRe.FindStringSubmatch(strings.TrimSpace(ref))
+	if m == nil {
+		return "", "", "", fmt.Errorf("expected /gh/<owner>/<repo>, got %q", ref)
+	}
+	owner, repo = strings.ToLower(m[1]), strings.ToLower(m[2])
+	if gitHubDotOnlyRe.MatchString(repo) {
+		return "", "", "", fmt.Errorf("repo cannot be dot-only: %s", ref)
+	}
+	return checkpointProviderGitHub, owner, repo, nil
+}
+
+func newRepoCloneCmd() *cobra.Command {
+	var cluster string
+	cmd := &cobra.Command{
+		Use:   "clone <repo> [target-dir]",
+		Short: "Clone a mirrored repository",
+		Long: "Clone a GitHub mirror by its `/gh/<owner>/<repo>` ref. Looks up where " +
+			"the repo is mirrored: if it's on a single cluster, clones it directly; " +
+			"if it's mirrored on more than one, prompts you to pick which to clone " +
+			"from (or pass --cluster to choose non-interactively). The optional " +
+			"[target-dir] is passed straight through to `git clone`.",
+		Example: "  entire repo clone /gh/entirehq/entire-api\n" +
+			"  entire repo clone /gh/entirehq/entire-api ./entire-api\n" +
+			"  entire repo clone /gh/entirehq/entire-api --cluster aws-us-east-2.entire.io",
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			provider, owner, repo, err := parseMirrorCloneRef(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid <repo>: %w", err)
+			}
+			var targetDir string
+			if len(args) > 1 {
+				targetDir = args[1]
+			}
+
+			var mirrors []coreapi.Mirror
+			if err := runCore(cmd, func(ctx context.Context, c *coreapi.Client) error {
+				ms, err := listMirrorsForRepo(ctx, c, provider, owner, repo)
+				if err != nil {
+					return err
+				}
+				mirrors = ms
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			if len(mirrors) == 0 {
+				return fmt.Errorf("no mirror found for gh/%s/%s; run 'entire repo mirror create github.com/%s/%s' to onboard it", owner, repo, owner, repo)
+			}
+
+			chosen, err := selectCloneTarget(cmd, mirrors, cluster)
+			if err != nil {
+				return err
+			}
+
+			cloneURL := fmt.Sprintf("entire://%s/gh/%s/%s", chosen.ClusterHost, owner, repo)
+			return runGitClone(cmd.Context(), cmd, cloneURL, targetDir)
+		},
+	}
+	cmd.Flags().StringVar(&cluster, "cluster", "", "cluster host to clone from when the repo is mirrored on more than one")
+	return cmd
+}
+
+// listMirrorsForRepo returns every mirror placement of one upstream repo across
+// clusters. The list API filters by provider+owner server-side but has no repo
+// filter, so the repo match is applied client-side (owner is already lowercased
+// to match what the server persists).
+func listMirrorsForRepo(ctx context.Context, c *coreapi.Client, provider, owner, repo string) ([]coreapi.Mirror, error) {
+	all, err := fetchAllPages(ctx, func(ctx context.Context, cursor string) ([]coreapi.Mirror, string, error) {
+		params := coreapi.ListMirrorsParams{
+			Provider: coreapi.NewOptString(provider),
+			Owner:    coreapi.NewOptString(owner),
+		}
+		if cursor != "" {
+			params.PageToken = coreapi.NewOptString(cursor)
+		}
+		out, err := c.ListMirrors(ctx, params)
+		if err != nil {
+			return nil, "", err
+		}
+		return out.Mirrors, out.NextPageToken.Or(""), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	matched := make([]coreapi.Mirror, 0, len(all))
+	for _, m := range all {
+		if strings.EqualFold(m.Repo, repo) {
+			matched = append(matched, m)
+		}
+	}
+	return matched, nil
+}
+
+// selectCloneTarget resolves which mirror placement to clone from. With one
+// placement it returns it directly. With --cluster it picks the matching one (or
+// errors listing the available hosts). With more than one and no flag it prompts
+// interactively, failing fast with a --cluster pointer when there's no terminal.
+func selectCloneTarget(cmd *cobra.Command, mirrors []coreapi.Mirror, clusterFlag string) (coreapi.Mirror, error) {
+	// Dedupe by cluster host: one placement per cluster is what a clone targets,
+	// and the same host appearing twice would only confuse the picker.
+	byHost := make(map[string]coreapi.Mirror, len(mirrors))
+	hosts := make([]string, 0, len(mirrors))
+	for _, m := range mirrors {
+		if _, seen := byHost[m.ClusterHost]; seen {
+			continue
+		}
+		byHost[m.ClusterHost] = m
+		hosts = append(hosts, m.ClusterHost)
+	}
+	sort.Strings(hosts)
+
+	if clusterFlag != "" {
+		m, ok := byHost[clusterFlag]
+		if !ok {
+			return coreapi.Mirror{}, fmt.Errorf("repo is not mirrored on %q; available: %s", clusterFlag, strings.Join(hosts, ", "))
+		}
+		return m, nil
+	}
+
+	if len(hosts) == 1 {
+		return byHost[hosts[0]], nil
+	}
+
+	if !interactive.CanPromptInteractively() {
+		return coreapi.Mirror{}, fmt.Errorf("repo is mirrored on %d clusters; pass --cluster to choose one of: %s", len(hosts), strings.Join(hosts, ", "))
+	}
+
+	options := make([]huh.Option[string], len(hosts))
+	for i, h := range hosts {
+		options[i] = huh.NewOption(mirrorCellLabel(byHost[h]), h)
+	}
+	var selected string
+	form := NewAccessibleForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("This repo is mirrored on more than one cluster — pick one to clone from").
+				Options(options...).
+				Value(&selected),
+		),
+	)
+	if err := form.RunWithContext(cmd.Context()); err != nil {
+		return coreapi.Mirror{}, handleFormCancellation(cmd.ErrOrStderr(), "Clone", err)
+	}
+	m, ok := byHost[selected]
+	if !ok {
+		return coreapi.Mirror{}, errors.New("no cluster selected")
+	}
+	return m, nil
+}
+
+// mirrorCellLabel is the human label for a mirror placement in the clone picker:
+// the physical cell and jurisdiction when known, always anchored by the cluster
+// host that goes into the clone URL.
+func mirrorCellLabel(m coreapi.Mirror) string {
+	cell := strings.TrimSpace(m.Cell.Or(""))
+	jur := strings.TrimSpace(m.Jurisdiction.Or(""))
+	switch {
+	case cell != "" && jur != "":
+		return fmt.Sprintf("%s (%s) — %s", cell, jur, m.ClusterHost)
+	case cell != "":
+		return fmt.Sprintf("%s — %s", cell, m.ClusterHost)
+	default:
+		return m.ClusterHost
+	}
+}
+
+// runGitClone shells out to `git clone <cloneURL> [target-dir]`, wiring the
+// child's stdio through so git-remote-entire's auth prompts and clone progress
+// reach the user. A clone failure is wrapped as a SilentError: git already
+// printed its own diagnostics, so main.go shouldn't reprint the wrapper.
+func runGitClone(ctx context.Context, cmd *cobra.Command, cloneURL, targetDir string) error {
+	args := []string{"clone", cloneURL}
+	if targetDir != "" {
+		args = append(args, targetDir)
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "Cloning %s\n", cloneURL)
+	gitCmd := exec.CommandContext(ctx, "git", args...)
+	gitCmd.Stdin = cmd.InOrStdin()
+	gitCmd.Stdout = cmd.OutOrStdout()
+	gitCmd.Stderr = cmd.ErrOrStderr()
+	if err := gitCmd.Run(); err != nil {
+		return NewSilentError(fmt.Errorf("git clone failed: %w", err))
+	}
+	return nil
+}

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -96,6 +96,20 @@ func TestNewCloneAliasCmd(t *testing.T) {
 	require.NotNil(t, cmd.Flags().Lookup("cluster"))
 }
 
+// TestRepoClone_InvalidClusterFlag locks in that a malformed --cluster is
+// rejected up front (before any core is dialled), so the anti-token-leak guard
+// validateClusterHost applies to the user-supplied cluster the clone routes to.
+func TestRepoClone_InvalidClusterFlag(t *testing.T) {
+	t.Parallel()
+	cmd := newRepoCloneCmd()
+	cmd.SetOut(&nopWriter{})
+	cmd.SetErr(&nopWriter{})
+	cmd.SetArgs([]string{"/gh/entirehq/entire-api", "--cluster", "aws-us-east-2.entire.io@evil.com"})
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --cluster")
+}
+
 func newCloneTestCmd() *cobra.Command {
 	cmd := newRepoCloneCmd()
 	cmd.SetOut(&nopWriter{})

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -168,6 +168,15 @@ func TestSelectCloneTarget(t *testing.T) {
 		require.Equal(t, "aws-eu-west-1.entire.io", got.ClusterHost)
 	})
 
+	t.Run("--cluster matches case-insensitively", func(t *testing.T) {
+		t.Parallel()
+		// DNS hosts are case-insensitive: a mixed-case --cluster must still match
+		// the API's lowercase ClusterHost rather than falsely "not mirrored".
+		got, err := selectCloneTarget(newCloneTestCmd(), []coreapi.Mirror{usEast, euWest}, "AWS-EU-West-1.Entire.IO")
+		require.NoError(t, err)
+		require.Equal(t, "aws-eu-west-1.entire.io", got.ClusterHost)
+	})
+
 	t.Run("--cluster with no match errors and lists hosts", func(t *testing.T) {
 		t.Parallel()
 		_, err := selectCloneTarget(newCloneTestCmd(), []coreapi.Mirror{usEast, euWest}, "aws-ap-south-1.entire.io")

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -46,6 +46,26 @@ func TestParseMirrorCloneRef(t *testing.T) {
 	}
 }
 
+func TestIsEntireCloneURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{ref: "entire://aws-us-east-2.entire.io/gh/entirehq/entire-api", want: true},
+		{ref: "  entire://host/gh/a/b", want: true},
+		{ref: "/gh/entirehq/entire-api", want: false},
+		{ref: "gh/entirehq/entire-api", want: false},
+		{ref: "https://github.com/entirehq/entire-api", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isEntireCloneURL(tt.ref))
+		})
+	}
+}
+
 func TestMirrorCellLabel(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -84,6 +84,18 @@ func TestMirrorCellLabel(t *testing.T) {
 	}
 }
 
+func TestNewCloneAliasCmd(t *testing.T) {
+	t.Parallel()
+	cmd := newCloneAliasCmd()
+	require.Equal(t, "clone", cmd.Name())
+	// Carries the control-plane flags the repo group otherwise supplies to its
+	// children as persistent flags, so `entire clone` honors --json /
+	// --insecure-http-auth too.
+	require.NotNil(t, cmd.PersistentFlags().Lookup("json"))
+	require.NotNil(t, cmd.PersistentFlags().Lookup("insecure-http-auth"))
+	require.NotNil(t, cmd.Flags().Lookup("cluster"))
+}
+
 func newCloneTestCmd() *cobra.Command {
 	cmd := newRepoCloneCmd()
 	cmd.SetOut(&nopWriter{})

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -66,6 +66,13 @@ func TestIsEntireCloneURL(t *testing.T) {
 	}
 }
 
+func TestMirrorCloneURL(t *testing.T) {
+	t.Parallel()
+	require.Equal(t,
+		"entire://aws-us-east-2.entire.io/gh/entirehq/entire-api",
+		mirrorCloneURL("aws-us-east-2.entire.io", "entirehq", "entire-api"))
+}
+
 func TestMirrorCellLabel(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+func TestParseMirrorCloneRef(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		ref       string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{name: "leading slash", ref: "/gh/entirehq/entire-api", wantOwner: "entirehq", wantRepo: "entire-api"},
+		{name: "no leading slash", ref: "gh/entirehq/entire-api", wantOwner: "entirehq", wantRepo: "entire-api"},
+		{name: "lowercased", ref: "/gh/EntireHQ/Entire-API", wantOwner: "entirehq", wantRepo: "entire-api"},
+		{name: "wrong provider", ref: "/gl/entirehq/entire-api", wantErr: true},
+		{name: "missing repo", ref: "/gh/entirehq", wantErr: true},
+		{name: "extra segment", ref: "/gh/entirehq/entire-api/extra", wantErr: true},
+		{name: "dot-only repo", ref: "/gh/entirehq/..", wantErr: true},
+		{name: "metachar in repo", ref: "/gh/entirehq/repo?x=1", wantErr: true},
+		{name: "empty", ref: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			provider, owner, repo, err := parseMirrorCloneRef(tt.ref)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, "github", provider)
+			require.Equal(t, tt.wantOwner, owner)
+			require.Equal(t, tt.wantRepo, repo)
+		})
+	}
+}
+
+func TestMirrorCellLabel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mirror coreapi.Mirror
+		want   string
+	}{
+		{
+			name:   "host only",
+			mirror: coreapi.Mirror{ClusterHost: "aws-us-east-2.entire.io"},
+			want:   "aws-us-east-2.entire.io",
+		},
+		{
+			name: "cell and jurisdiction",
+			mirror: coreapi.Mirror{
+				ClusterHost:  "aws-us-east-2.entire.io",
+				Cell:         coreapi.NewOptString("aws-us-east-2"),
+				Jurisdiction: coreapi.NewOptString("us"),
+			},
+			want: "aws-us-east-2 (us) — aws-us-east-2.entire.io",
+		},
+		{
+			name: "cell without jurisdiction",
+			mirror: coreapi.Mirror{
+				ClusterHost: "aws-us-east-2.entire.io",
+				Cell:        coreapi.NewOptString("aws-us-east-2"),
+			},
+			want: "aws-us-east-2 — aws-us-east-2.entire.io",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, mirrorCellLabel(tt.mirror))
+		})
+	}
+}
+
+func newCloneTestCmd() *cobra.Command {
+	cmd := newRepoCloneCmd()
+	cmd.SetOut(&nopWriter{})
+	cmd.SetErr(&nopWriter{})
+	return cmd
+}
+
+type nopWriter struct{}
+
+func (*nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestSelectCloneTarget(t *testing.T) {
+	t.Parallel()
+
+	usEast := coreapi.Mirror{Repo: "entire-api", ClusterHost: "aws-us-east-2.entire.io"}
+	euWest := coreapi.Mirror{Repo: "entire-api", ClusterHost: "aws-eu-west-1.entire.io"}
+
+	t.Run("single placement returns directly", func(t *testing.T) {
+		t.Parallel()
+		got, err := selectCloneTarget(newCloneTestCmd(), []coreapi.Mirror{usEast}, "")
+		require.NoError(t, err)
+		require.Equal(t, "aws-us-east-2.entire.io", got.ClusterHost)
+	})
+
+	t.Run("dedupes repeated host to a single placement", func(t *testing.T) {
+		t.Parallel()
+		got, err := selectCloneTarget(newCloneTestCmd(), []coreapi.Mirror{usEast, usEast}, "")
+		require.NoError(t, err)
+		require.Equal(t, "aws-us-east-2.entire.io", got.ClusterHost)
+	})
+
+	t.Run("--cluster picks the matching placement", func(t *testing.T) {
+		t.Parallel()
+		got, err := selectCloneTarget(newCloneTestCmd(), []coreapi.Mirror{usEast, euWest}, "aws-eu-west-1.entire.io")
+		require.NoError(t, err)
+		require.Equal(t, "aws-eu-west-1.entire.io", got.ClusterHost)
+	})
+
+	t.Run("--cluster with no match errors and lists hosts", func(t *testing.T) {
+		t.Parallel()
+		_, err := selectCloneTarget(newCloneTestCmd(), []coreapi.Mirror{usEast, euWest}, "aws-ap-south-1.entire.io")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "aws-us-east-2.entire.io")
+		require.Contains(t, err.Error(), "aws-eu-west-1.entire.io")
+	})
+
+	t.Run("multiple placements with no terminal errors with a --cluster pointer", func(t *testing.T) {
+		t.Parallel()
+		// go test is non-interactive, so the picker path is unreachable here.
+		_, err := selectCloneTarget(newCloneTestCmd(), []coreapi.Mirror{usEast, euWest}, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "--cluster")
+	})
+}
+
+// TestListMirrorsForRepo_FiltersByRepo verifies the client-side repo filter:
+// the list API filters provider+owner server-side, but the repo match (which
+// the API has no param for) is applied locally.
+func TestListMirrorsForRepo_FiltersByRepo(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := &coreapi.ListMirrorsOutputBody{Mirrors: []coreapi.Mirror{
+			{Owner: "entirehq", Repo: "entire-api", ClusterHost: "aws-us-east-2.entire.io"},
+			{Owner: "entirehq", Repo: "entire-api", ClusterHost: "aws-eu-west-1.entire.io"},
+			{Owner: "entirehq", Repo: "entire-cli", ClusterHost: "aws-us-east-2.entire.io"},
+		}}
+		if err := writeJSON(w, body); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c, err := coreapi.NewWithBearer(srv.URL, "tok")
+	require.NoError(t, err)
+
+	got, err := listMirrorsForRepo(t.Context(), c, "github", "entirehq", "entire-api")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, m := range got {
+		require.Equal(t, "entire-api", m.Repo)
+	}
+}

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -104,18 +104,6 @@ func TestMirrorCellLabel(t *testing.T) {
 	}
 }
 
-func TestNewCloneAliasCmd(t *testing.T) {
-	t.Parallel()
-	cmd := newCloneAliasCmd()
-	require.Equal(t, "clone", cmd.Name())
-	// Carries the control-plane flags the repo group otherwise supplies to its
-	// children as persistent flags, so `entire clone` honors --json /
-	// --insecure-http-auth too.
-	require.NotNil(t, cmd.PersistentFlags().Lookup("json"))
-	require.NotNil(t, cmd.PersistentFlags().Lookup("insecure-http-auth"))
-	require.NotNil(t, cmd.Flags().Lookup("cluster"))
-}
-
 // TestRepoClone_InvalidClusterFlag locks in that a malformed --cluster is
 // rejected up front (before any core is dialled), so the anti-token-leak guard
 // validateClusterHost applies to the user-supplied cluster the clone routes to.

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -26,7 +26,7 @@ var mirrorColumns = []string{"REPO", "CLONE URL", "PRIVATE"}
 
 func mirrorRow(m coreapi.Mirror) []string {
 	repo := m.Owner + "/" + m.Repo
-	cloneURL := fmt.Sprintf("entire://%s/gh/%s/%s", m.ClusterHost, m.Owner, m.Repo)
+	cloneURL := mirrorCloneURL(m.ClusterHost, m.Owner, m.Repo)
 	private := "no"
 	if m.IsPrivate.Or(false) {
 		private = "yes"

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -98,6 +98,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newOrgCmd())                                    // hidden during maturation; control-plane org management
 	cmd.AddCommand(newProjectCmd())                                // hidden during maturation; control-plane project management
 	cmd.AddCommand(newRepoCmd())                                   // hidden during maturation; control-plane repo lifecycle
+	cmd.AddCommand(newCloneAliasCmd())                             // top-level alias for 'repo clone'
 	cmd.AddCommand(newGrantCmd())                                  // hidden during maturation; control-plane access grants
 	cmd.AddCommand(newCleanCmd())
 	cmd.AddCommand(newSetupCmd()) // 'configure' — non-agent settings; agent CRUD lives under 'agent'

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -98,7 +98,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newOrgCmd())                                    // hidden during maturation; control-plane org management
 	cmd.AddCommand(newProjectCmd())                                // hidden during maturation; control-plane project management
 	cmd.AddCommand(newRepoCmd())                                   // hidden during maturation; control-plane repo lifecycle
-	cmd.AddCommand(newCloneAliasCmd())                             // top-level alias for 'repo clone'
 	cmd.AddCommand(newGrantCmd())                                  // hidden during maturation; control-plane access grants
 	cmd.AddCommand(newCleanCmd())
 	cmd.AddCommand(newSetupCmd()) // 'configure' — non-agent settings; agent CRUD lives under 'agent'

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -53,6 +53,11 @@ func ResolveContextForCluster(ctx context.Context, configDir, cacheDir, clusterH
 	if debugf == nil {
 		debugf = func(string, ...any) {}
 	}
+	// DNS hostnames are case-insensitive, so fold case before the host drives any
+	// lookup: the cache key, the /.well-known fetch, and the cores→context match.
+	// Without this, `aws-US-east-2.entire.io` and `aws-us-east-2.entire.io`
+	// resolve as different hosts and a context determination can fail spuriously.
+	clusterHost = normalizeClusterHost(clusterHost)
 	f, err := contexts.Load(configDir)
 	if err != nil {
 		return nil, fmt.Errorf("load contexts: %w", err)
@@ -77,7 +82,15 @@ func ResolveClusterCores(ctx context.Context, cacheDir, clusterHost string, http
 	if debugf == nil {
 		debugf = func(string, ...any) {}
 	}
-	return resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
+	return resolveClusterCores(ctx, cacheDir, normalizeClusterHost(clusterHost), httpClient, debugf)
+}
+
+// normalizeClusterHost folds a cluster host to its canonical form for use as a
+// lookup key. DNS is case-insensitive, so two hosts differing only in case (or
+// surrounding whitespace) name the same cluster and must resolve identically —
+// for the host→cores cache, /.well-known discovery, and context determination.
+func normalizeClusterHost(clusterHost string) string {
+	return strings.ToLower(strings.TrimSpace(clusterHost))
 }
 
 // resolveCachedCores is the shared cache-then-/.well-known resolution behind

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -163,6 +163,40 @@ func TestResolve_CoresCachedAcrossCalls(t *testing.T) {
 	assert.Equal(t, []string{"https://eu.auth.entire.io"}, urls)
 }
 
+// TestResolve_ClusterHostCaseInsensitive: a mixed-case cluster host resolves
+// the same context as its lowercase form and caches under the canonical
+// (lowercased) key, since DNS hosts are case-insensitive.
+func TestResolve_ClusterHostCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	var calls int32
+	srv := httptest.NewServer(coresHandler(t, &calls, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod-eu",
+		Contexts: []*contexts.Context{
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}))
+
+	c, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "AWS-EU-Central-1.Entire.IO", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c.Name)
+
+	// Cached under the canonical lowercase host, so the lowercase form is a hit.
+	cache, err := discovery.LoadClusterCores(cacheDir)
+	require.NoError(t, err)
+	_, _, ok := cache.Get("aws-eu-central-1.entire.io")
+	assert.True(t, ok, "cores cached under the lowercased host key")
+
+	c2, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, "prod-eu", c2.Name)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "lowercase form hits the cache the mixed-case call populated")
+}
+
 // TestResolve_StaleCacheFallbackOnDiscoveryFailure: an expired cache entry
 // is used when the live re-fetch fails, so a brief cluster outage doesn't
 // break an operation whose cores we already knew.


### PR DESCRIPTION
Clone a mirrored repo by its `/gh/<owner>/<repo>` ref:

```
entire repo clone /gh/entirehq/entire-api              # one cell → clones directly
entire repo clone /gh/entirehq/entire-api ./dest       # optional target dir
entire repo clone /gh/entirehq/entire-api --cluster royalcanin.partial.to
```

- Mirrored on one cluster → clones immediately; on several → interactive picker (or `--cluster`).
- `--cluster` resolves through that cluster's core, so it works even when the cluster lives in a different auth context than the active one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth routing (`runCoreForCluster`), cluster host validation before token-bearing git URLs, and `git` subprocess execution; mitigated by reusing existing mirror patterns and broad unit tests.
> 
> **Overview**
> Adds **`entire clone`** (top-level alias) and **`entire repo clone`** to clone GitHub mirrors by **`/gh/<owner>/<repo>`** or a full **`entire://`** URL, then run **`git clone`** with stdio wired through git-remote-entire.
> 
> For the shorthand ref, the command **lists mirror placements** from the control plane (provider+owner server-side, **repo filtered client-side**), picks a cluster when there is only one, otherwise **`--cluster`** or an interactive picker (with cancellation guarded so an empty host is never cloned). **`--cluster`** dials that cluster’s core via **`runCoreForCluster`** so mirrors in another auth federation still resolve. User- and API-supplied cluster hosts go through **`validateClusterHost`** before building clone URLs.
> 
> **Cluster discovery** now **normalizes cluster host case/whitespace** so mixed-case hosts share cache keys and context resolution. Tests cover ref parsing, target selection, mirror filtering, invalid `--cluster`, and case-insensitive resolve. Minor lint tweaks: allow **`agentimport.Importer`** in ireturn and drop a redundant nolint on **`Get`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc653d47cbe4da9d2a0b31a2f956fd3d065a899. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->