### PR TITLE
Fix misleading checkpoint explain hint in entire why

### DIFF
--- a/cmd/entire/cli/attribution.go
+++ b/cmd/entire/cli/attribution.go
@@ -1004,8 +1004,10 @@ func renderAttributionLineWhy(w io.Writer, file string, line attributionLine) {
 				fmt.Fprintln(w)
 			}
 		}
-		if line.CheckpointID != "" {
+		if line.CheckpointID != "" && !line.MetadataMissing {
 			fmt.Fprintf(w, "\n  %s %s\n\n", sty.render(sty.dim, "Full context:"), sty.render(sty.cyan, "entire checkpoint explain "+line.CheckpointID))
+		} else if line.CheckpointID != "" {
+			fmt.Fprintf(w, "\n  %s\n\n", sty.render(sty.dim, "Full checkpoint context is unavailable for this attribution."))
 		} else {
 			fmt.Fprintln(w)
 		}


### PR DESCRIPTION
This pull request adds improved handling for cases where checkpoint metadata is missing in the attribution output. Now, if a `CheckpointID` is present but its metadata is missing, a clear message is displayed to inform the user that the full checkpoint context is unavailable.

Output improvements for missing checkpoint metadata:

* In `cmd/entire/cli/attribution.go`, the `renderAttributionLineWhy` function now checks if `line.MetadataMissing` is true when a `CheckpointID` is present, and displays a message indicating that the full checkpoint context is unavailable for the attribution.