### PR TITLE
feat(trail): --repo and --branch overrides

### DIFF
--- a/cmd/entire/cli/gitremote/gitremote.go
+++ b/cmd/entire/cli/gitremote/gitremote.go
@@ -56,6 +56,15 @@ var forgeToHost = func() map[string]string {
 	return m
 }()
 
+// IsSupportedForge reports whether forge is a known short forge id (e.g. "gh")
+// understood by the trails API. It rejects forge hostnames ("github.com") and
+// any other unrecognized value, so callers parsing a bare forge/owner/repo
+// triple can fail clearly instead of forwarding a malformed forge to the API.
+func IsSupportedForge(forge string) bool {
+	_, ok := forgeToHost[forge]
+	return ok
+}
+
 // CanonicalHost returns the canonical public host of the upstream forge.
 //
 // For direct git URLs this is just Host. For entire:// remotes — whose Host is

--- a/cmd/entire/cli/review_bridge.go
+++ b/cmd/entire/cli/review_bridge.go
@@ -61,7 +61,7 @@ func postReviewToTrail(ctx context.Context, out io.Writer, profileName, verdict 
 		return nil
 	}
 	return runAuthenticatedDataAPI(ctx, out, false, func(ctx context.Context, client *api.Client) error {
-		target, err := resolveTrailReviewTarget(ctx, client, "")
+		target, err := resolveTrailReviewTarget(ctx, client, "", "", "")
 		if err != nil {
 			return err
 		}

--- a/cmd/entire/cli/trail_checkout_cmd_test.go
+++ b/cmd/entire/cli/trail_checkout_cmd_test.go
@@ -42,7 +42,7 @@ func TestResolveTrailBySelector_FindsBySelector(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			found, err := resolveTrailBySelector(context.Background(), client, "gh", "acme", "repo", tc.selector)
+			found, err := resolveTrailBySelector(context.Background(), client, "gh", "acme", "repo", tc.selector, "")
 			if err != nil {
 				t.Fatalf("resolveTrailBySelector: %v", err)
 			}
@@ -64,7 +64,7 @@ func TestResolveTrailBySelector_NotFoundIsAnError(t *testing.T) {
 	defer srv.Close()
 
 	client := api.NewClientWithBaseURL("tok", srv.URL)
-	found, err := resolveTrailBySelector(context.Background(), client, "gh", "acme", "repo", "does-not-exist")
+	found, err := resolveTrailBySelector(context.Background(), client, "gh", "acme", "repo", "does-not-exist", "")
 	if err == nil {
 		t.Fatalf("expected error for missing trail, got found = %#v", found)
 	}

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -108,6 +108,18 @@ func ensureNoTrailRepoOverride(cmd *cobra.Command, op string) error {
 	return nil
 }
 
+// ensureTrailRepoHasTarget requires an explicit branch or trail selector when
+// --repo targets a repository other than the local clone. Without one, the
+// branch-defaulting commands fall back to the local checkout's current branch,
+// which would silently resolve the wrong trail (a shared branch name) in the
+// overridden repo. hint names the acceptable targets for the command.
+func ensureTrailRepoHasTarget(cmd *cobra.Command, hasTarget bool, hint string) error {
+	if trailRepoFlag(cmd) != "" && !hasTarget {
+		return fmt.Errorf("--repo requires an explicit target: %s", hint)
+	}
+	return nil
+}
+
 // trailListOptions are the inputs to runTrailListAll. Keeping them on a
 // struct avoids a long positional argument list at the two call sites.
 type trailListOptions struct {
@@ -146,6 +158,9 @@ Otherwise, <trail> may be a trail number, id, or branch in the target repo.`,
 			}
 			if selector != "" && trailBranchFlag(cmd) != "" {
 				return errors.New("pass a trail selector or --branch, not both")
+			}
+			if err := ensureTrailRepoHasTarget(cmd, selector != "" || trailBranchFlag(cmd) != "", "pass a trail selector or --branch"); err != nil {
+				return err
 			}
 			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector, trailRepoFlag(cmd), trailBranchFlag(cmd))
 		},
@@ -998,6 +1013,9 @@ func newTrailUpdateCmd() *cobra.Command {
 		Short: "Update trail metadata",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := ensureTrailRepoHasTarget(cmd, strings.TrimSpace(branch) != "", "pass --branch"); err != nil {
+				return err
+			}
 			return runTrailUpdate(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), trailUpdateInputs{
 				Status:        statusStr,
 				StatusChanged: cmd.Flags().Changed("status"),
@@ -1338,6 +1356,9 @@ Deletion is permanent; you are prompted to confirm unless --force is passed.`,
 			}
 			if number > 0 && cmd.Flags().Changed("branch") {
 				return errors.New("cannot combine a trail <number> with --branch")
+			}
+			if err := ensureTrailRepoHasTarget(cmd, number > 0 || strings.TrimSpace(branch) != "", "pass a trail number or --branch"); err != nil {
+				return err
 			}
 			return runTrailDelete(cmd, number, branch, force)
 		},

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -171,7 +171,7 @@ Otherwise, <trail> may be a trail number, id, or branch in the target repo.`,
 
 // runTrailShow shows one trail, defaulting to the current branch's trail.
 func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector, repoOverride, branchOverride string) error {
-	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, repoOverride, func(ctx context.Context, client *api.Client) error {
 		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 		if err != nil {
 			return err
@@ -386,7 +386,7 @@ func runTrailListAll(ctx context.Context, w, errW io.Writer, opts trailListOptio
 	if err != nil {
 		return err
 	}
-	return runAuthenticatedTrailAPI(ctx, errW, opts.InsecureHTTP, func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedTrailAPI(ctx, errW, opts.InsecureHTTP, opts.Repo, func(ctx context.Context, client *api.Client) error {
 		return runTrailListAllWithClient(ctx, w, client, opts, statusFilters)
 	})
 }
@@ -1055,7 +1055,7 @@ type trailUpdateInputs struct {
 }
 
 func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, inputs trailUpdateInputs) error {
-	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, inputs.Repo, func(ctx context.Context, client *api.Client) error {
 		forge, owner, repoName, err := resolveTrailRepoOrRemote(ctx, inputs.Repo)
 		if err != nil {
 			return err
@@ -1266,7 +1266,9 @@ trail is looked up against that repository's origin remote.`,
 }
 
 func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector string, force bool) error {
-	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
+	// checkout rejects --repo (it operates on the local clone), so the enablement
+	// cache always tracks the local origin here.
+	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, "", func(ctx context.Context, client *api.Client) error {
 		forge, owner, repo, err := resolveTrailRemote(ctx)
 		if err != nil {
 			return err
@@ -1374,7 +1376,7 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 	ctx := cmd.Context()
 	w := cmd.OutOrStdout()
 
-	return runAuthenticatedTrailAPI(ctx, cmd.ErrOrStderr(), trailInsecureHTTP(cmd), func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedTrailAPI(ctx, cmd.ErrOrStderr(), trailInsecureHTTP(cmd), trailRepoFlag(cmd), func(ctx context.Context, client *api.Client) error {
 		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, trailRepoFlag(cmd))
 		if err != nil {
 			return err

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -40,6 +40,7 @@ const (
 
 func newTrailCmd() *cobra.Command {
 	var insecureHTTPAuth bool
+	var repoOverride string
 
 	cmd := &cobra.Command{
 		Use:    "trail",
@@ -57,6 +58,13 @@ func newTrailCmd() *cobra.Command {
 	if err := cmd.PersistentFlags().MarkHidden("insecure-http-auth"); err != nil {
 		panic(fmt.Sprintf("hide insecure-http-auth flag: %v", err))
 	}
+
+	// Target an explicit repository instead of the origin remote, so the trail
+	// commands can drive a repo the caller is not checked out in (e.g. a GUI
+	// backend). Commands that mutate the local clone (create, checkout, finding
+	// apply) reject it via ensureNoTrailRepoOverride.
+	cmd.PersistentFlags().StringVar(&repoOverride, "repo", "",
+		"Target repository as forge/owner/repo (e.g. gh/acme/app) or a clone URL; defaults to the origin remote")
 
 	cmd.AddCommand(newTrailShowCmd())
 	cmd.AddCommand(newTrailListCmd())
@@ -76,6 +84,30 @@ func trailInsecureHTTP(cmd *cobra.Command) bool {
 	return v
 }
 
+// trailRepoFlag reads the persistent --repo flag from the trail command tree.
+// It is always registered on the trail root, so a missing flag (empty string)
+// just means "derive from origin".
+func trailRepoFlag(cmd *cobra.Command) string {
+	v, _ := cmd.Flags().GetString("repo") //nolint:errcheck // flag is always registered on the trail root
+	return strings.TrimSpace(v)
+}
+
+// trailBranchFlag reads an optional --branch flag. Only some subcommands
+// register it; on the rest GetString errors and we treat it as unset.
+func trailBranchFlag(cmd *cobra.Command) string {
+	v, _ := cmd.Flags().GetString("branch") //nolint:errcheck // absent on commands that don't register --branch
+	return strings.TrimSpace(v)
+}
+
+// ensureNoTrailRepoOverride rejects --repo for commands that operate on the
+// local clone and so cannot target an arbitrary repository.
+func ensureNoTrailRepoOverride(cmd *cobra.Command, op string) error {
+	if trailRepoFlag(cmd) != "" {
+		return fmt.Errorf("--repo is not supported for %q because it operates on the local clone", op)
+	}
+	return nil
+}
+
 // trailListOptions are the inputs to runTrailListAll. Keeping them on a
 // struct avoids a long positional argument list at the two call sites.
 type trailListOptions struct {
@@ -84,6 +116,9 @@ type trailListOptions struct {
 	JSON         bool
 	Limit        int
 	InsecureHTTP bool
+	// Repo is an optional --repo override (forge/owner/repo or a clone URL);
+	// empty means derive the repo from the origin remote.
+	Repo string
 }
 
 func defaultTrailListOptions(insecureHTTP bool) trailListOptions {
@@ -95,34 +130,39 @@ func defaultTrailListOptions(insecureHTTP bool) trailListOptions {
 }
 
 func newTrailShowCmd() *cobra.Command {
+	var branch string
 	cmd := &cobra.Command{
 		Use:   "show [<trail>]",
 		Short: "Show a trail",
 		Long: `Show a trail.
 
-If <trail> is omitted, shows the trail for the current branch. Otherwise,
-<trail> may be a trail number, id, or branch in the current repo.`,
+If <trail> is omitted, shows the trail for the current branch (or --branch).
+Otherwise, <trail> may be a trail number, id, or branch in the target repo.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			selector := ""
 			if len(args) == 1 {
 				selector = args[0]
 			}
-			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector)
+			if selector != "" && trailBranchFlag(cmd) != "" {
+				return errors.New("pass a trail selector or --branch, not both")
+			}
+			return runTrailShow(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector, trailRepoFlag(cmd), trailBranchFlag(cmd))
 		},
 	}
+	cmd.Flags().StringVar(&branch, "branch", "", "Show the trail for this branch instead of the current branch; cannot be combined with a trail selector")
 	return cmd
 }
 
 // runTrailShow shows one trail, defaulting to the current branch's trail.
-func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector string) error {
+func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, selector, repoOverride, branchOverride string) error {
 	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
-		forge, owner, repo, err := resolveTrailRemote(ctx)
+		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 		if err != nil {
 			return err
 		}
 
-		found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, selector)
+		found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, selector, branchOverride)
 		if err != nil {
 			return err
 		}
@@ -165,10 +205,10 @@ func runTrailShow(ctx context.Context, w, errW io.Writer, insecureHTTP bool, sel
 // number, id, or branch). An empty selector falls back to the current branch's
 // trail. It returns an actionable error (never a nil trail with a nil error)
 // when nothing matches, so callers can rely on a non-nil result.
-func resolveTrailBySelector(ctx context.Context, client *api.Client, forge, owner, repo, selector string) (*api.TrailResource, error) {
+func resolveTrailBySelector(ctx context.Context, client *api.Client, forge, owner, repo, selector, branchOverride string) (*api.TrailResource, error) {
 	selector = strings.TrimSpace(selector)
 	if selector == "" {
-		branch, err := GetCurrentBranch(ctx)
+		branch, err := resolveTrailBranch(ctx, branchOverride)
 		if err != nil {
 			return nil, fmt.Errorf("no trail selector given and current branch is unknown: %w\nhint: run 'entire trail list --status any' or pass a trail number, id, or branch", err)
 		}
@@ -311,6 +351,7 @@ func newTrailListCmd() *cobra.Command {
 		Short: "List recent trails",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts.InsecureHTTP = trailInsecureHTTP(cmd)
+			opts.Repo = trailRepoFlag(cmd)
 			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts)
 		},
 	}
@@ -362,7 +403,7 @@ func runTrailListAllWithClient(ctx context.Context, w io.Writer, client *api.Cli
 		authorFilter = login
 	}
 
-	forge, owner, repo, err := resolveTrailRemote(ctx)
+	forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, opts.Repo)
 	if err != nil {
 		return err
 	}
@@ -694,6 +735,9 @@ func newTrailCreateCmd() *cobra.Command {
 		Short: "Create a trail for the current, a new, or no branch",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := ensureNoTrailRepoOverride(cmd, "trail create"); err != nil {
+				return err
+			}
 			return runTrailCreate(cmd, title, body, base, branch, status, checkout, noBranch)
 		},
 	}
@@ -962,6 +1006,7 @@ func newTrailUpdateCmd() *cobra.Command {
 				Body:          body,
 				BodyChanged:   cmd.Flags().Changed("body"),
 				Branch:        branch,
+				Repo:          trailRepoFlag(cmd),
 				LabelAdd:      labelAdd,
 				LabelRemove:   labelRemove,
 			})
@@ -986,13 +1031,14 @@ type trailUpdateInputs struct {
 	Body          string
 	BodyChanged   bool
 	Branch        string
+	Repo          string
 	LabelAdd      []string
 	LabelRemove   []string
 }
 
 func runTrailUpdate(ctx context.Context, w, errW io.Writer, insecureHTTP bool, inputs trailUpdateInputs) error {
 	return runAuthenticatedTrailAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
-		forge, owner, repoName, err := resolveTrailRemote(ctx)
+		forge, owner, repoName, err := resolveTrailRepoOrRemote(ctx, inputs.Repo)
 		if err != nil {
 			return err
 		}
@@ -1188,6 +1234,9 @@ trail is looked up against that repository's origin remote.`,
 				}
 				selector = args[0]
 			}
+			if err := ensureNoTrailRepoOverride(cmd, "trail checkout"); err != nil {
+				return err
+			}
 			return runTrailCheckout(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), selector, force)
 		},
 	}
@@ -1205,7 +1254,7 @@ func runTrailCheckout(ctx context.Context, w, errW io.Writer, insecureHTTP bool,
 			return err
 		}
 
-		found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, selector)
+		found, err := resolveTrailBySelector(ctx, client, forge, owner, repo, selector, "")
 		if err != nil {
 			return err
 		}
@@ -1305,7 +1354,7 @@ func runTrailDelete(cmd *cobra.Command, number int, branch string, force bool) e
 	w := cmd.OutOrStdout()
 
 	return runAuthenticatedTrailAPI(ctx, cmd.ErrOrStderr(), trailInsecureHTTP(cmd), func(ctx context.Context, client *api.Client) error {
-		forge, owner, repo, err := resolveTrailRemote(ctx)
+		forge, owner, repo, err := resolveTrailRepoOrRemote(ctx, trailRepoFlag(cmd))
 		if err != nil {
 			return err
 		}
@@ -1639,6 +1688,53 @@ func resolveTrailRemote(ctx context.Context) (forge, owner, repo string, err err
 		return "", "", "", errors.New("origin remote is not on a forge supported by Entire trails (supported: github.com)")
 	}
 	return forge, owner, repo, nil
+}
+
+// resolveTrailRepoOrRemote resolves the forge/owner/repo triple used to build
+// trail API paths. An explicit --repo override (repoOverride) wins; otherwise
+// it derives the triple from the origin remote of the current clone.
+func resolveTrailRepoOrRemote(ctx context.Context, repoOverride string) (forge, owner, repo string, err error) {
+	if repoOverride != "" {
+		return parseTrailRepoArg(repoOverride)
+	}
+	return resolveTrailRemote(ctx)
+}
+
+// resolveTrailBranch returns the branch a trail lookup should use: an explicit
+// --branch override (branchOverride) when given, otherwise the current branch.
+func resolveTrailBranch(ctx context.Context, branchOverride string) (string, error) {
+	if branchOverride != "" {
+		return branchOverride, nil
+	}
+	return GetCurrentBranch(ctx)
+}
+
+// parseTrailRepoArg parses an explicit --repo value into the forge/owner/repo
+// triple. It accepts the canonical "forge/owner/repo" form (e.g. gh/acme/app)
+// as well as a full clone URL (https://, git@, or entire://) that gitremote
+// can parse. A trailing ".git" on the repo is stripped.
+func parseTrailRepoArg(raw string) (forge, owner, repo string, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", "", errors.New("empty --repo value")
+	}
+	// Bare path form: forge/owner/repo. URLs (with a scheme or an SCP "@")
+	// fall through to the URL parser, which understands hosts and schemes.
+	if !strings.Contains(raw, "://") && !strings.Contains(raw, "@") {
+		parts := strings.Split(strings.Trim(raw, "/"), "/")
+		if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
+			return parts[0], parts[1], strings.TrimSuffix(parts[2], ".git"), nil
+		}
+		return "", "", "", fmt.Errorf("invalid --repo %q: expected forge/owner/repo (e.g. gh/acme/app) or a clone URL", raw)
+	}
+	info, perr := gitremote.ParseURL(raw)
+	if perr != nil {
+		return "", "", "", fmt.Errorf("invalid --repo %q: %w", raw, perr)
+	}
+	if info.Forge == "" {
+		return "", "", "", fmt.Errorf("invalid --repo %q: unsupported forge host (supported: github.com)", raw)
+	}
+	return info.Forge, info.Owner, info.Repo, nil
 }
 
 // checkTrailResponse checks the API response and returns user-friendly errors.

--- a/cmd/entire/cli/trail_cmd.go
+++ b/cmd/entire/cli/trail_cmd.go
@@ -1722,10 +1722,16 @@ func parseTrailRepoArg(raw string) (forge, owner, repo string, err error) {
 	// fall through to the URL parser, which understands hosts and schemes.
 	if !strings.Contains(raw, "://") && !strings.Contains(raw, "@") {
 		parts := strings.Split(strings.Trim(raw, "/"), "/")
-		if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
-			return parts[0], parts[1], strings.TrimSuffix(parts[2], ".git"), nil
+		if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+			return "", "", "", fmt.Errorf("invalid --repo %q: expected forge/owner/repo (e.g. gh/acme/app) or a clone URL", raw)
 		}
-		return "", "", "", fmt.Errorf("invalid --repo %q: expected forge/owner/repo (e.g. gh/acme/app) or a clone URL", raw)
+		// parts[0] must be a short forge id ("gh"), not a hostname. A host-like
+		// value (github.com/acme/app) would otherwise be forwarded verbatim and
+		// the server would reject the malformed path with an opaque error.
+		if !gitremote.IsSupportedForge(parts[0]) {
+			return "", "", "", fmt.Errorf("invalid --repo %q: %q is not a supported forge id (use a forge id like \"gh\", or pass a clone URL such as https://github.com/%s/%s)", raw, parts[0], parts[1], parts[2])
+		}
+		return parts[0], parts[1], strings.TrimSuffix(parts[2], ".git"), nil
 	}
 	info, perr := gitremote.ParseURL(raw)
 	if perr != nil {

--- a/cmd/entire/cli/trail_context_cache.go
+++ b/cmd/entire/cli/trail_context_cache.go
@@ -276,10 +276,17 @@ func noteTrailCommandEnablement(ctx context.Context, client *api.Client, command
 	refreshTrailsEnabledCacheBestEffort(ctx, client)
 }
 
-func runAuthenticatedTrailAPI(ctx context.Context, errW io.Writer, insecureHTTP bool, fn func(context.Context, *api.Client) error) error {
+// runAuthenticatedTrailAPI runs fn against the data API as the current user.
+// repoOverride is the raw --repo flag: when non-empty the trails-enablement
+// cache is skipped, because that cache is keyed to the local clone's origin and
+// a cross-repo query says nothing about the local clone (recording it would
+// mis-attribute enablement to the wrong repo).
+func runAuthenticatedTrailAPI(ctx context.Context, errW io.Writer, insecureHTTP bool, repoOverride string, fn func(context.Context, *api.Client) error) error {
 	return runAuthenticatedDataAPI(ctx, errW, insecureHTTP, func(ctx context.Context, client *api.Client) error {
 		err := fn(ctx, client)
-		noteTrailCommandEnablement(ctx, client, err)
+		if repoOverride == "" {
+			noteTrailCommandEnablement(ctx, client, err)
+		}
 		return err
 	})
 }

--- a/cmd/entire/cli/trail_repo_flag_test.go
+++ b/cmd/entire/cli/trail_repo_flag_test.go
@@ -136,6 +136,31 @@ func TestTrailSelectorAndBranchAreMutuallyExclusive(t *testing.T) {
 	}
 }
 
+// --repo must not silently fall back to the local checkout's branch: the
+// branch-defaulting commands require an explicit branch or selector alongside it.
+func TestTrailRepoRequiresExplicitTarget(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "show", args: []string{"show", "--repo", "gh/acme/app"}},
+		{name: "watch", args: []string{"watch", "--repo", "gh/acme/app"}},
+		{name: "update", args: []string{"update", "--repo", "gh/acme/app"}},
+		{name: "delete", args: []string{"delete", "--repo", "gh/acme/app"}},
+		{name: "finding list", args: []string{"finding", "list", "--repo", "gh/acme/app"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := execTrailCmdExpectErr(t, tt.args...)
+			if err == nil || !strings.Contains(err.Error(), "--repo requires an explicit target") {
+				t.Fatalf("err = %v, want '--repo requires an explicit target'", err)
+			}
+		})
+	}
+}
+
 // Sanity: the persistent --repo flag is registered on the trail root and shows
 // up in help, so every read subcommand inherits it.
 func TestTrailRepoFlagRegisteredOnRoot(t *testing.T) {

--- a/cmd/entire/cli/trail_repo_flag_test.go
+++ b/cmd/entire/cli/trail_repo_flag_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestParseTrailRepoArg(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		raw                  string
+		wantForge, wantOwner string
+		wantRepo             string
+		wantErr              bool
+	}{
+		{name: "forge/owner/repo", raw: "gh/entireio/cli", wantForge: "gh", wantOwner: "entireio", wantRepo: "cli"},
+		{name: "strips .git", raw: "gh/acme/app.git", wantForge: "gh", wantOwner: "acme", wantRepo: "app"},
+		{name: "trims whitespace", raw: "  gh/acme/app  ", wantForge: "gh", wantOwner: "acme", wantRepo: "app"},
+		{name: "trims surrounding slashes", raw: "/gh/acme/app/", wantForge: "gh", wantOwner: "acme", wantRepo: "app"},
+		{name: "https clone URL", raw: "https://github.com/acme/app.git", wantForge: "gh", wantOwner: "acme", wantRepo: "app"},
+		{name: "ssh scp URL", raw: "git@github.com:acme/app.git", wantForge: "gh", wantOwner: "acme", wantRepo: "app"},
+		{name: "entire URL", raw: "entire://host/gh/acme/app", wantForge: "gh", wantOwner: "acme", wantRepo: "app"},
+		{name: "empty", raw: "", wantErr: true},
+		{name: "two segments", raw: "acme/app", wantErr: true},
+		{name: "forge plus owner only", raw: "gh/acme", wantErr: true},
+		{name: "four segments", raw: "gh/acme/app/extra", wantErr: true},
+		{name: "unsupported forge host", raw: "git@gitlab.com:acme/app.git", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			forge, owner, repo, err := parseTrailRepoArg(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseTrailRepoArg(%q) = (%q,%q,%q), want error", tt.raw, forge, owner, repo)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTrailRepoArg(%q): unexpected error %v", tt.raw, err)
+			}
+			if forge != tt.wantForge || owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Fatalf("parseTrailRepoArg(%q) = (%q,%q,%q), want (%q,%q,%q)",
+					tt.raw, forge, owner, repo, tt.wantForge, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
+// resolveTrailRepoOrRemote with an explicit override must not touch git: it
+// resolves straight from the flag value. (The fallback path needs a repo and is
+// covered elsewhere.)
+func TestResolveTrailRepoOrRemote_OverrideSkipsGit(t *testing.T) {
+	t.Parallel()
+	forge, owner, repo, err := resolveTrailRepoOrRemote(t.Context(), "gh/acme/app")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if forge != "gh" || owner != "acme" || repo != "app" {
+		t.Fatalf("got (%q,%q,%q), want (gh,acme,app)", forge, owner, repo)
+	}
+}
+
+func TestResolveTrailBranch_OverrideWins(t *testing.T) {
+	t.Parallel()
+	got, err := resolveTrailBranch(t.Context(), "my/feature")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "my/feature" {
+		t.Fatalf("got %q, want my/feature", got)
+	}
+}
+
+// execTrailCmdExpectErr runs `entire trail <args...>` against a fresh command
+// tree and returns the error, with output discarded. Used to assert flag
+// validation that fires before any auth/network/git access.
+func execTrailCmdExpectErr(t *testing.T, args ...string) error {
+	t.Helper()
+	cmd := newTrailCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func TestTrailRepoOverride_RejectedByLocalCommands(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "create", args: []string{"create", "--repo", "gh/acme/app"}},
+		{name: "checkout", args: []string{"checkout", "--repo", "gh/acme/app"}},
+		{name: "finding apply", args: []string{"finding", "apply", "--repo", "gh/acme/app", "deadbeef"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := execTrailCmdExpectErr(t, tt.args...)
+			if err == nil || !strings.Contains(err.Error(), "--repo is not supported") {
+				t.Fatalf("err = %v, want '--repo is not supported'", err)
+			}
+		})
+	}
+}
+
+func TestTrailSelectorAndBranchAreMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		args    []string
+		wantSub string
+	}{
+		{name: "show", args: []string{"show", "123", "--branch", "foo"}, wantSub: "not both"},
+		{name: "watch", args: []string{"watch", "5", "--branch", "foo"}, wantSub: "not both"},
+		{name: "finding list positional", args: []string{"finding", "list", "123", "--branch", "foo"}, wantSub: "not both"},
+		{name: "finding list --trail", args: []string{"finding", "list", "--trail", "123", "--branch", "foo"}, wantSub: "not both"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := execTrailCmdExpectErr(t, tt.args...)
+			if err == nil || !strings.Contains(err.Error(), tt.wantSub) {
+				t.Fatalf("err = %v, want substring %q", err, tt.wantSub)
+			}
+		})
+	}
+}
+
+// Sanity: the persistent --repo flag is registered on the trail root and shows
+// up in help, so every read subcommand inherits it.
+func TestTrailRepoFlagRegisteredOnRoot(t *testing.T) {
+	t.Parallel()
+	cmd := newTrailCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	if !strings.Contains(out.String(), "--repo") {
+		t.Fatalf("help output missing --repo flag:\n%s", out.String())
+	}
+}

--- a/cmd/entire/cli/trail_repo_flag_test.go
+++ b/cmd/entire/cli/trail_repo_flag_test.go
@@ -29,6 +29,9 @@ func TestParseTrailRepoArg(t *testing.T) {
 		{name: "forge plus owner only", raw: "gh/acme", wantErr: true},
 		{name: "four segments", raw: "gh/acme/app/extra", wantErr: true},
 		{name: "unsupported forge host", raw: "git@gitlab.com:acme/app.git", wantErr: true},
+		{name: "bare host instead of forge id", raw: "github.com/acme/app", wantErr: true},
+		{name: "bare unsupported forge host", raw: "gitlab.com/acme/app", wantErr: true},
+		{name: "unknown short forge id", raw: "zz/acme/app", wantErr: true},
 	}
 
 	for _, tt := range tests {

--- a/cmd/entire/cli/trail_review_cmd.go
+++ b/cmd/entire/cli/trail_review_cmd.go
@@ -480,7 +480,7 @@ func authenticatedTrailReviewTarget(cmd *cobra.Command, selector string) (*api.C
 	}
 	var target trailReviewTarget
 	var resolvedClient *api.Client
-	err := runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), func(ctx context.Context, client *api.Client) error {
+	err := runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), repoOverride, func(ctx context.Context, client *api.Client) error {
 		var err error
 		resolvedClient = client
 		target, err = resolveTrailReviewTarget(ctx, client, selector, repoOverride, branchOverride)

--- a/cmd/entire/cli/trail_review_cmd.go
+++ b/cmd/entire/cli/trail_review_cmd.go
@@ -475,6 +475,9 @@ func authenticatedTrailReviewTarget(cmd *cobra.Command, selector string) (*api.C
 	if selector != "" && branchOverride != "" {
 		return nil, trailReviewTarget{}, errors.New("pass a trail selector or --branch, not both")
 	}
+	if repoOverride != "" && selector == "" && branchOverride == "" {
+		return nil, trailReviewTarget{}, errors.New("--repo requires an explicit target: pass a trail selector or --branch")
+	}
 	var target trailReviewTarget
 	var resolvedClient *api.Client
 	err := runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), func(ctx context.Context, client *api.Client) error {

--- a/cmd/entire/cli/trail_review_cmd.go
+++ b/cmd/entire/cli/trail_review_cmd.go
@@ -58,6 +58,7 @@ type trailReviewListOptions struct {
 
 type trailReviewTargetOptions struct {
 	Selector string
+	Branch   string
 }
 
 type trailReviewTarget struct {
@@ -91,6 +92,7 @@ discover a trail selector first.`,
 		},
 	}
 	cmd.PersistentFlags().StringVar(&targetOpts.Selector, "trail", "", "Trail selector (number, id, or branch); defaults to the current branch's trail")
+	cmd.PersistentFlags().StringVar(&targetOpts.Branch, "branch", "", "Resolve the trail for this branch instead of the current branch; cannot be combined with a trail selector")
 	addTrailReviewListFlags(cmd, &opts)
 
 	cmd.AddCommand(newTrailFindingListCmd(&targetOpts))
@@ -252,6 +254,9 @@ By default this only changes files. Pass --resolve to update the finding's
 lifecycle status after the patch applies successfully.`,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := ensureNoTrailRepoOverride(cmd, "trail finding apply"); err != nil {
+				return err
+			}
 			selector, commentID, err := parseTrailSelectorAndCommentID(args, targetOpts.Selector)
 			if err != nil {
 				return err
@@ -293,7 +298,7 @@ func runTrailReviewDashboard(cmd *cobra.Command, selector string, opts trailRevi
 		if strings.TrimSpace(selector) == "" && errors.Is(err, errTrailReviewDefaultTargetNotFound) {
 			fmt.Fprintln(cmd.OutOrStdout(), "No trail found for the current branch; showing trails in this repo.")
 			fmt.Fprintln(cmd.OutOrStdout())
-			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailListOptions{Status: trailListStatusAny, Limit: defaultTrailListLimit, InsecureHTTP: trailInsecureHTTP(cmd)})
+			return runTrailListAll(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), trailListOptions{Status: trailListStatusAny, Limit: defaultTrailListLimit, InsecureHTTP: trailInsecureHTTP(cmd), Repo: trailRepoFlag(cmd)})
 		}
 		return err
 	}
@@ -465,12 +470,17 @@ func runTrailReviewSetStatus(cmd *cobra.Command, selector string, commentID, sta
 }
 
 func authenticatedTrailReviewTarget(cmd *cobra.Command, selector string) (*api.Client, trailReviewTarget, error) {
+	repoOverride := trailRepoFlag(cmd)
+	branchOverride := trailBranchFlag(cmd)
+	if selector != "" && branchOverride != "" {
+		return nil, trailReviewTarget{}, errors.New("pass a trail selector or --branch, not both")
+	}
 	var target trailReviewTarget
 	var resolvedClient *api.Client
 	err := runAuthenticatedTrailAPI(cmd.Context(), cmd.ErrOrStderr(), trailInsecureHTTP(cmd), func(ctx context.Context, client *api.Client) error {
 		var err error
 		resolvedClient = client
-		target, err = resolveTrailReviewTarget(ctx, client, selector)
+		target, err = resolveTrailReviewTarget(ctx, client, selector, repoOverride, branchOverride)
 		return err
 	})
 	if err != nil {
@@ -479,8 +489,8 @@ func authenticatedTrailReviewTarget(cmd *cobra.Command, selector string) (*api.C
 	return resolvedClient, target, nil
 }
 
-func resolveTrailReviewTarget(ctx context.Context, client *api.Client, selector string) (trailReviewTarget, error) {
-	host, owner, repo, err := resolveTrailRemote(ctx)
+func resolveTrailReviewTarget(ctx context.Context, client *api.Client, selector, repoOverride, branchOverride string) (trailReviewTarget, error) {
+	host, owner, repo, err := resolveTrailRepoOrRemote(ctx, repoOverride)
 	if err != nil {
 		return trailReviewTarget{}, err
 	}
@@ -496,7 +506,7 @@ func resolveTrailReviewTarget(ctx context.Context, client *api.Client, selector 
 			return trailReviewTarget{}, fmt.Errorf("no trail %q found in %s/%s/%s (run 'entire trail list --status any')", selector, host, owner, repo)
 		}
 	} else {
-		branch, branchErr := GetCurrentBranch(ctx)
+		branch, branchErr := resolveTrailBranch(ctx, branchOverride)
 		if branchErr != nil {
 			return trailReviewTarget{}, fmt.Errorf("%w: no trail selector given and current branch is unknown: %w\nhint: run 'entire trail list --status any' or pass --trail <number|id|branch>", errTrailReviewDefaultTargetNotFound, branchErr)
 		}
@@ -505,7 +515,7 @@ func resolveTrailReviewTarget(ctx context.Context, client *api.Client, selector 
 			return trailReviewTarget{}, err
 		}
 		if found == nil {
-			return trailReviewTarget{}, fmt.Errorf("%w: no trail found for current branch %q\nhint: run 'entire trail create', 'entire trail list --status any', or pass --trail <number|id|branch>", errTrailReviewDefaultTargetNotFound, branch)
+			return trailReviewTarget{}, fmt.Errorf("%w: no trail found for branch %q\nhint: run 'entire trail create', 'entire trail list --status any', or pass --trail <number|id|branch>", errTrailReviewDefaultTargetNotFound, branch)
 		}
 	}
 	if found.ID == "" {

--- a/cmd/entire/cli/trail_review_cmd_test.go
+++ b/cmd/entire/cli/trail_review_cmd_test.go
@@ -83,7 +83,7 @@ func TestResolveTrailReviewTargetRejectsUnsupportedForge(t *testing.T) {
 	}
 	t.Chdir(repoDir)
 
-	_, err := resolveTrailReviewTarget(context.Background(), api.NewClient("tok"), "")
+	_, err := resolveTrailReviewTarget(context.Background(), api.NewClient("tok"), "", "", "")
 	if err == nil {
 		t.Fatal("expected error for gitlab.com origin, got nil")
 	}

--- a/cmd/entire/cli/trail_watch_cmd.go
+++ b/cmd/entire/cli/trail_watch_cmd.go
@@ -41,6 +41,7 @@ func newTrailWatchCmd() *cobra.Command {
 		jsonOutput bool
 		showPings  bool
 		once       bool
+		branch     string
 	)
 
 	cmd := &cobra.Command{
@@ -77,6 +78,7 @@ Events emitted by the server:
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print each event as a single JSON line")
 	cmd.Flags().BoolVar(&showPings, "show-pings", false, "Print SSE keepalive pings (otherwise suppressed)")
 	cmd.Flags().BoolVar(&once, "once", false, "Open one SSE connection then exit instead of reconnecting")
+	cmd.Flags().StringVar(&branch, "branch", "", "Watch the trail for this branch instead of the current branch; cannot be combined with a trail selector")
 
 	return cmd
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/671
<!-- entire-trail-link-end -->

`entire trail` derived the repo from `origin` and the branch from the current checkout, so it only worked from inside a clone of the target repo. This adds flag overrides so trails can be driven as a scripting tool (e.g. as a backend for a Trails GUI) against any repo/branch.

```
entire trail show    --repo gh/entireio/cli --branch my/feature
entire trail finding list --repo gh/entireio/cli --branch my/feature
entire trail finding list --repo gh/entireio/cli --trail 123
```

- `--repo forge/owner/repo` (or a clone URL): persistent on the `trail` root; honored by `show`/`list`/`update`/`delete`/`watch`/`finding`. Rejected on local-clone commands (`create`, `checkout`, `finding apply`).
- `--branch` on `show`/`watch`/`finding` (update/delete already had it); mutually exclusive with an explicit trail selector.

Auth is unchanged — it already resolves via the API base URL's `.well-known/entire-api.json`, independent of any local git repo, so overriding `ENTIRE_API_BASE_URL` picks the right context automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trail API path resolution and default targeting across many subcommands; mistakes could hit the wrong repo/trail, though explicit validation and cache skipping reduce silent mis-routing.
> 
> **Overview**
> **`entire trail` can now target repositories and branches explicitly** instead of always using `origin` and the current checkout—intended for scripting and GUI backends.
> 
> A **persistent `--repo`** on the trail root accepts `forge/owner/repo` (e.g. `gh/acme/app`) or clone URLs; **`--branch`** is added on `show`, `watch`, and `finding` (update/delete already had branch). Repo resolution goes through `resolveTrailRepoOrRemote` / `parseTrailRepoArg`, with **`gitremote.IsSupportedForge`** so bare triples reject hostnames like `github.com/acme/app` with a clear error.
> 
> **Guardrails:** `--repo` is **rejected** on local-only flows (`create`, `checkout`, `finding apply`). With `--repo`, commands that would default to the local branch **require** an explicit trail selector or `--branch` so the wrong trail is not resolved silently. Trail selector and `--branch` are **mutually exclusive** where both apply.
> 
> **`list`**, **`show`**, **`update`**, **`delete`**, **`watch`**, and **`finding`** honor `--repo`; cross-repo calls **skip** the local-origin trails enablement cache in `runAuthenticatedTrailAPI` / `watch` so enablement is not mis-attributed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e30a965590f6b1902aac1f82b155bc81dccea9ad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->