### PR TITLE
Phase 2: pluggable checkpoint stores (registry + topology)

### DIFF
--- a/cmd/entire/cli/benchutil/benchutil.go
+++ b/cmd/entire/cli/benchutil/benchutil.go
@@ -172,8 +172,11 @@ func NewBenchRepo(b *testing.B, opts RepoOpts) *BenchRepo {
 	}
 
 	br := &BenchRepo{
-		Dir:       dir,
-		Repo:      repo,
+		Dir:  dir,
+		Repo: repo,
+		// Benchmark fixture: construct the git store directly rather than via
+		// checkpoint.Open. Benchmarks pin the v1 topology and never exercise
+		// settings-driven backend selection, so they deliberately bypass Open.
 		Store:     checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs()),
 		Ephemeral: checkpoint.NewEphemeralStore(repo, checkpoint.DefaultV1Refs()),
 		HeadHash:  headHash.String(),

--- a/cmd/entire/cli/checkpoint/checkpoint_test.go
+++ b/cmd/entire/cli/checkpoint/checkpoint_test.go
@@ -3787,9 +3787,9 @@ func TestWriteCommitted_ModelFieldAlwaysPresent(t *testing.T) {
 
 func TestRedactSummary_Nil(t *testing.T) {
 	t.Parallel()
-	result := redactSummary(nil)
+	result := RedactSummary(nil)
 	if result != nil {
-		t.Error("redactSummary(nil) should return nil")
+		t.Error("RedactSummary(nil) should return nil")
 	}
 }
 
@@ -3823,7 +3823,7 @@ func TestRedactSummary_WithSecrets(t *testing.T) {
 		},
 	}
 
-	result := redactSummary(summary)
+	result := RedactSummary(summary)
 
 	// Verify secrets are removed from all text fields
 	if strings.Contains(result.Intent, highEntropySecret) {
@@ -3896,7 +3896,7 @@ func TestRedactSummary_NoSecrets(t *testing.T) {
 		},
 	}
 
-	result := redactSummary(summary)
+	result := RedactSummary(summary)
 
 	if result.Intent != "Fix a bug" {
 		t.Errorf("Intent should be unchanged, got %q", result.Intent)

--- a/cmd/entire/cli/checkpoint/fanout.go
+++ b/cmd/entire/cli/checkpoint/fanout.go
@@ -1,0 +1,98 @@
+package checkpoint
+
+import (
+	"context"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+)
+
+// fanoutStore serves all reads from the primary and fans writes out to the
+// primary plus zero or more mirror backends. The primary is the source of
+// truth: a write fails only if the primary write fails. Mirror writes are
+// best-effort — a mirror failure is logged and swallowed so it can never break
+// a checkpoint operation. Mirrors are therefore write-only and may legitimately
+// lag the primary (they never receive ref-level mutations such as cleanup
+// deletes or pre-push OPF re-redaction); they must not be promoted to a read or
+// sync source without separate reconciliation.
+type fanoutStore struct {
+	primary PersistentStore
+	mirrors []Writer
+}
+
+// newFanoutStore wraps a primary with mirror write fan-out. With no mirrors it
+// returns the primary unchanged, so the common (no-mirror) path keeps the
+// concrete store and all of its optional capabilities. When wrapping is needed,
+// it preserves the optional AuthorReader capability iff the primary has it.
+func newFanoutStore(primary PersistentStore, mirrors []Writer) PersistentStore {
+	if len(mirrors) == 0 {
+		return primary
+	}
+	base := &fanoutStore{primary: primary, mirrors: mirrors}
+	if author, ok := primary.(AuthorReader); ok {
+		return &fanoutStoreWithAuthor{fanoutStore: base, author: author}
+	}
+	return base
+}
+
+// The read methods are pure delegation to the primary; nolint:wrapcheck because
+// re-wrapping the primary's errors here would add noise without context (same
+// convention as the contract re-exports in aliases.go).
+
+func (s *fanoutStore) Read(ctx context.Context, checkpointID id.CheckpointID) (*CheckpointSummary, error) {
+	return s.primary.Read(ctx, checkpointID) //nolint:wrapcheck // pure delegation to primary
+}
+
+func (s *fanoutStore) List(ctx context.Context) ([]CheckpointInfo, error) {
+	return s.primary.List(ctx) //nolint:wrapcheck // pure delegation to primary
+}
+
+func (s *fanoutStore) ReadSessionContent(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*SessionContent, error) {
+	return s.primary.ReadSessionContent(ctx, checkpointID, sessionIndex) //nolint:wrapcheck // pure delegation to primary
+}
+
+func (s *fanoutStore) ReadSessionMetadata(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*Metadata, error) {
+	return s.primary.ReadSessionMetadata(ctx, checkpointID, sessionIndex) //nolint:wrapcheck // pure delegation to primary
+}
+
+func (s *fanoutStore) ReadSessionPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (string, error) {
+	return s.primary.ReadSessionPrompts(ctx, checkpointID, sessionIndex) //nolint:wrapcheck // pure delegation to primary
+}
+
+func (s *fanoutStore) ReadSessionMetadataAndPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*Metadata, string, error) {
+	return s.primary.ReadSessionMetadataAndPrompts(ctx, checkpointID, sessionIndex) //nolint:wrapcheck // pure delegation to primary
+}
+
+// Write applies to the primary first; only on primary success does it fan out to
+// each mirror best-effort. A mirror error is logged and dropped.
+func (s *fanoutStore) Write(ctx context.Context, req WriteRequest) error {
+	if err := s.primary.Write(ctx, req); err != nil {
+		return err //nolint:wrapcheck // primary error is the operation's error, surfaced verbatim
+	}
+	for i, mirror := range s.mirrors {
+		if err := mirror.Write(ctx, req); err != nil {
+			logging.Warn(ctx, "checkpoint mirror write failed; primary write succeeded",
+				"mirror_index", i, "error", err.Error())
+		}
+	}
+	return nil
+}
+
+// fanoutStoreWithAuthor adds the optional AuthorReader capability when the
+// wrapped primary supports it, so callers that type-assert the store to
+// AuthorReader (e.g. explain's author fallback) keep working through the wrapper.
+type fanoutStoreWithAuthor struct {
+	*fanoutStore
+
+	author AuthorReader
+}
+
+func (s *fanoutStoreWithAuthor) GetCheckpointAuthor(ctx context.Context, checkpointID id.CheckpointID) (Author, error) {
+	return s.author.GetCheckpointAuthor(ctx, checkpointID) //nolint:wrapcheck // pure delegation to primary
+}
+
+var (
+	_ PersistentStore = (*fanoutStore)(nil)
+	_ PersistentStore = (*fanoutStoreWithAuthor)(nil)
+	_ AuthorReader    = (*fanoutStoreWithAuthor)(nil)
+)

--- a/cmd/entire/cli/checkpoint/fanout_test.go
+++ b/cmd/entire/cli/checkpoint/fanout_test.go
@@ -1,0 +1,168 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+)
+
+// fakePrimary is a minimal PersistentStore that records writes and reports a
+// fixed read result, so tests can assert read delegation and write fan-out.
+type fakePrimary struct {
+	writes   []WriteRequest
+	writeErr error
+	listErr  error
+	listCall int
+}
+
+func (f *fakePrimary) Read(context.Context, id.CheckpointID) (*CheckpointSummary, error) {
+	return &CheckpointSummary{}, nil
+}
+
+func (f *fakePrimary) List(context.Context) ([]CheckpointInfo, error) {
+	f.listCall++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return []CheckpointInfo{{}}, nil
+}
+
+func (f *fakePrimary) ReadSessionContent(context.Context, id.CheckpointID, int) (*SessionContent, error) {
+	return &SessionContent{}, nil
+}
+func (f *fakePrimary) ReadSessionMetadata(context.Context, id.CheckpointID, int) (*Metadata, error) {
+	return &Metadata{}, nil
+}
+func (f *fakePrimary) ReadSessionPrompts(context.Context, id.CheckpointID, int) (string, error) {
+	return "", nil
+}
+func (f *fakePrimary) ReadSessionMetadataAndPrompts(context.Context, id.CheckpointID, int) (*Metadata, string, error) {
+	return &Metadata{}, "", nil
+}
+
+func (f *fakePrimary) Write(_ context.Context, req WriteRequest) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.writes = append(f.writes, req)
+	return nil
+}
+
+// fakePrimaryWithAuthor adds the optional AuthorReader capability.
+type fakePrimaryWithAuthor struct {
+	*fakePrimary
+
+	author    Author
+	authorErr error
+}
+
+func (f *fakePrimaryWithAuthor) GetCheckpointAuthor(context.Context, id.CheckpointID) (Author, error) {
+	return f.author, f.authorErr
+}
+
+// fakeMirror records the writes it receives and can be made to fail.
+type fakeMirror struct {
+	writes   []WriteRequest
+	writeErr error
+}
+
+func (m *fakeMirror) Write(_ context.Context, req WriteRequest) error {
+	if m.writeErr != nil {
+		return m.writeErr
+	}
+	m.writes = append(m.writes, req)
+	return nil
+}
+
+func TestFanout_NoMirrorsReturnsPrimaryUnwrapped(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakePrimaryWithAuthor{fakePrimary: &fakePrimary{}, author: Author{Name: "A"}}
+	store := newFanoutStore(primary, nil)
+
+	// With no mirrors the primary is returned as-is — same value, no wrapper.
+	assert.Same(t, any(primary), any(store))
+}
+
+func TestFanout_WriteFansOutToAllMirrors(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakePrimary{}
+	m1, m2 := &fakeMirror{}, &fakeMirror{}
+	store := newFanoutStore(primary, []Writer{m1, m2})
+
+	req := SessionSummary{CheckpointID: id.CheckpointID("abc123def456")}
+	require.NoError(t, store.Write(context.Background(), req))
+
+	assert.Len(t, primary.writes, 1)
+	assert.Len(t, m1.writes, 1)
+	assert.Len(t, m2.writes, 1)
+}
+
+func TestFanout_MirrorFailureDoesNotFailWrite(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakePrimary{}
+	failing := &fakeMirror{writeErr: errors.New("mirror down")}
+	ok := &fakeMirror{}
+	store := newFanoutStore(primary, []Writer{failing, ok})
+
+	// Primary succeeded, so the operation succeeds even though a mirror failed,
+	// and later mirrors still receive the write.
+	require.NoError(t, store.Write(context.Background(), SessionSummary{}))
+	assert.Len(t, primary.writes, 1)
+	assert.Len(t, ok.writes, 1)
+}
+
+func TestFanout_PrimaryFailureSkipsMirrors(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakePrimary{writeErr: errors.New("primary down")}
+	mirror := &fakeMirror{}
+	store := newFanoutStore(primary, []Writer{mirror})
+
+	err := store.Write(context.Background(), SessionSummary{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "primary down")
+	// The mirror must not be written when the primary write failed.
+	assert.Empty(t, mirror.writes)
+}
+
+func TestFanout_ReadsDelegateToPrimary(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakePrimary{}
+	store := newFanoutStore(primary, []Writer{&fakeMirror{}})
+
+	_, err := store.List(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, primary.listCall)
+}
+
+func TestFanout_PreservesAuthorReaderWhenPrimaryHasIt(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakePrimaryWithAuthor{fakePrimary: &fakePrimary{}, author: Author{Name: "Ada", Email: "ada@example.com"}}
+	store := newFanoutStore(primary, []Writer{&fakeMirror{}})
+
+	author, ok := store.(AuthorReader)
+	require.True(t, ok, "fan-out wrapper should expose AuthorReader when primary does")
+	got, err := author.GetCheckpointAuthor(context.Background(), id.CheckpointID("abc123def456"))
+	require.NoError(t, err)
+	assert.Equal(t, "Ada", got.Name)
+}
+
+func TestFanout_OmitsAuthorReaderWhenPrimaryLacksIt(t *testing.T) {
+	t.Parallel()
+
+	primary := &fakePrimary{} // no GetCheckpointAuthor
+	store := newFanoutStore(primary, []Writer{&fakeMirror{}})
+
+	_, ok := store.(AuthorReader)
+	assert.False(t, ok, "fan-out wrapper must not advertise AuthorReader when primary lacks it")
+}

--- a/cmd/entire/cli/checkpoint/fsstore/fsstore.go
+++ b/cmd/entire/cli/checkpoint/fsstore/fsstore.go
@@ -33,6 +33,7 @@ import (
 	cp "github.com/entireio/cli/api/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 )
 
 // BackendType is the registry type name for the filesystem reference backend.
@@ -96,16 +97,12 @@ func (s *Store) save(sc *storedCheckpoint) error {
 	if err != nil {
 		return fmt.Errorf("fsstore: encode %s: %w", sc.Summary.CheckpointID, err)
 	}
-	// Write atomically (temp + rename) so a reader never observes a partial
-	// document. This guards a single writer's in-progress write; cross-process
-	// concurrency is out of scope for this test-only backend.
-	final := s.path(sc.Summary.CheckpointID)
-	tmp := final + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+	// Write atomically via the shared helper (unique temp file, cleaned up on
+	// failure) so a reader never observes a partial document. This guards a
+	// single writer's in-progress write; cross-process concurrency is out of
+	// scope for this test-only backend.
+	if err := jsonutil.WriteFileAtomic(s.path(sc.Summary.CheckpointID), data, 0o600); err != nil {
 		return fmt.Errorf("fsstore: write %s: %w", sc.Summary.CheckpointID, err)
-	}
-	if err := os.Rename(tmp, final); err != nil {
-		return fmt.Errorf("fsstore: commit %s: %w", sc.Summary.CheckpointID, err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/checkpoint/fsstore/fsstore.go
+++ b/cmd/entire/cli/checkpoint/fsstore/fsstore.go
@@ -4,9 +4,10 @@
 // of the api/checkpoint contract, and to serve as a worked example for new
 // backends.
 //
-// It is deliberately NOT registered by production code: only RegisterForTesting
-// wires it into the checkpoint registry, so a production binary can never select
-// it. As a mirror it receives best-effort write fan-out; it intentionally ignores
+// It is deliberately NOT registered by production code: only a test-only helper
+// (registerForTesting, in register_test.go) wires it into the checkpoint
+// registry, so a production binary can never select it. As a mirror it receives
+// best-effort write fan-out; it intentionally ignores
 // the git-specific blob-hash fields of the contract and stores transcript bytes
 // directly, which keeps the example small and makes the contract's remaining
 // git leakage concrete.
@@ -35,9 +36,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/jsonutil"
 )
-
-// BackendType is the registry type name for the filesystem reference backend.
-const BackendType = "fs"
 
 // Store is a JSON-file-backed persistent checkpoint store. One file per
 // checkpoint (<root>/<checkpoint-id>.json) holds the root summary plus all

--- a/cmd/entire/cli/checkpoint/fsstore/fsstore.go
+++ b/cmd/entire/cli/checkpoint/fsstore/fsstore.go
@@ -32,7 +32,6 @@ import (
 	cp "github.com/entireio/cli/api/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
-	"github.com/entireio/cli/redact"
 )
 
 // BackendType is the registry type name for the filesystem reference backend.
@@ -142,7 +141,7 @@ func (s *Store) writeSession(opts cp.WriteOptions) error {
 		SessionID:  opts.SessionID,
 		Metadata:   metadataFromWriteOptions(opts),
 		Transcript: opts.Transcript.Bytes(),
-		Prompts:    redact.String(strings.Join(opts.Prompts, checkpoint.PromptSeparator)),
+		Prompts:    checkpoint.RedactedJoinedPrompts(opts.Prompts),
 	}
 	sc.Sessions = upsertSession(sc.Sessions, session)
 
@@ -174,7 +173,7 @@ func (s *Store) backfillTranscript(opts cp.UpdateOptions) error {
 	// Replace semantics, but do not clobber sibling fields (matches the git
 	// store's stop-time transcript backfill).
 	sc.Sessions[idx].Transcript = opts.Transcript.Bytes()
-	sc.Sessions[idx].Prompts = redact.String(strings.Join(opts.Prompts, checkpoint.PromptSeparator))
+	sc.Sessions[idx].Prompts = checkpoint.RedactedJoinedPrompts(opts.Prompts)
 	if len(opts.SkillEvents) > 0 {
 		sc.Sessions[idx].Metadata.SkillEvents = opts.SkillEvents
 	}

--- a/cmd/entire/cli/checkpoint/fsstore/fsstore.go
+++ b/cmd/entire/cli/checkpoint/fsstore/fsstore.go
@@ -12,10 +12,11 @@
 // git leakage concrete.
 //
 // It is faithful to the contract's per-session metadata and write-request
-// semantics, but it does not replicate the git store's cross-session
-// aggregation: the root summary's TokenUsage reflects the latest session rather
-// than a sum across sessions. That aggregation is not needed to validate the
-// pluggable seam and is intentionally omitted.
+// semantics — including prompt and summary redaction via the shared
+// checkpoint helpers — but it does not replicate two git-writer behaviors:
+// cross-session aggregation (the root summary's TokenUsage reflects the latest
+// session, not a sum) and derived stamps the git writer adds (CLI version,
+// skill-events version). Neither is needed to validate the pluggable seam.
 package fsstore
 
 import (
@@ -188,7 +189,7 @@ func (s *Store) writeSessionSummary(r cp.SessionSummary) error {
 	if sc == nil || len(sc.Sessions) == 0 {
 		return fmt.Errorf("fsstore: cannot set summary for unknown checkpoint %s", r.CheckpointID)
 	}
-	sc.Sessions[len(sc.Sessions)-1].Metadata.Summary = r.Summary
+	sc.Sessions[len(sc.Sessions)-1].Metadata.Summary = checkpoint.RedactSummary(r.Summary)
 	return s.save(sc)
 }
 
@@ -335,7 +336,7 @@ func metadataFromWriteOptions(opts cp.WriteOptions) cp.Metadata {
 		SkillEvents:                 opts.SkillEvents,
 		PromptAttributions:          opts.PromptAttributionsJSON,
 		SessionMetrics:              opts.SessionMetrics,
-		Summary:                     opts.Summary,
+		Summary:                     checkpoint.RedactSummary(opts.Summary),
 		Attribution:                 opts.Attribution,
 		Kind:                        opts.Kind,
 		ReviewSkills:                opts.ReviewSkills,

--- a/cmd/entire/cli/checkpoint/fsstore/fsstore.go
+++ b/cmd/entire/cli/checkpoint/fsstore/fsstore.go
@@ -1,0 +1,386 @@
+// Package fsstore is a reference, test-only persistent checkpoint backend that
+// stores checkpoints as JSON files on disk. It exists to exercise the pluggable
+// backend seam (registry + mirror fan-out) with a real, non-git implementation
+// of the api/checkpoint contract, and to serve as a worked example for new
+// backends.
+//
+// It is deliberately NOT registered by production code: only RegisterForTesting
+// wires it into the checkpoint registry, so a production binary can never select
+// it. As a mirror it receives best-effort write fan-out; it intentionally ignores
+// the git-specific blob-hash fields of the contract and stores transcript bytes
+// directly, which keeps the example small and makes the contract's remaining
+// git leakage concrete.
+package fsstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	cp "github.com/entireio/cli/api/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/redact"
+)
+
+// BackendType is the registry type name for the filesystem reference backend.
+const BackendType = "fs"
+
+// Store is a JSON-file-backed persistent checkpoint store. One file per
+// checkpoint (<root>/<checkpoint-id>.json) holds the root summary plus all
+// session content.
+type Store struct {
+	root string
+	mu   sync.Mutex
+}
+
+// New constructs a filesystem store rooted at dir.
+func New(dir string) *Store {
+	return &Store{root: dir}
+}
+
+type storedSession struct {
+	SessionID  string      `json:"session_id"`
+	Metadata   cp.Metadata `json:"metadata"`
+	Transcript []byte      `json:"transcript,omitempty"`
+	Prompts    string      `json:"prompts,omitempty"`
+}
+
+type storedCheckpoint struct {
+	Summary  cp.CheckpointSummary `json:"summary"`
+	Sessions []storedSession      `json:"sessions"`
+}
+
+var (
+	_ cp.PersistentStore = (*Store)(nil)
+	_ cp.Writer          = (*Store)(nil)
+)
+
+func (s *Store) path(checkpointID id.CheckpointID) string {
+	return filepath.Join(s.root, string(checkpointID)+".json")
+}
+
+// load reads the stored checkpoint, returning (nil, nil) when it does not exist.
+func (s *Store) load(checkpointID id.CheckpointID) (*storedCheckpoint, error) {
+	data, err := os.ReadFile(s.path(checkpointID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil //nolint:nilnil // absent checkpoint, not an error
+		}
+		return nil, fmt.Errorf("fsstore: read %s: %w", checkpointID, err)
+	}
+	var sc storedCheckpoint
+	if err := json.Unmarshal(data, &sc); err != nil {
+		return nil, fmt.Errorf("fsstore: parse %s: %w", checkpointID, err)
+	}
+	return &sc, nil
+}
+
+func (s *Store) save(sc *storedCheckpoint) error {
+	if err := os.MkdirAll(s.root, 0o750); err != nil {
+		return fmt.Errorf("fsstore: create root %s: %w", s.root, err)
+	}
+	data, err := json.MarshalIndent(sc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("fsstore: encode %s: %w", sc.Summary.CheckpointID, err)
+	}
+	if err := os.WriteFile(s.path(sc.Summary.CheckpointID), data, 0o644); err != nil { //nolint:gosec // reference test backend
+		return fmt.Errorf("fsstore: write %s: %w", sc.Summary.CheckpointID, err)
+	}
+	return nil
+}
+
+// Write dispatches on the request type, mirroring the git store's Write.
+func (s *Store) Write(_ context.Context, req cp.WriteRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch r := req.(type) {
+	case cp.Session:
+		return s.writeSession(cp.WriteOptions(r))
+	case cp.SessionTranscript:
+		return s.backfillTranscript(cp.UpdateOptions(r))
+	case cp.SessionSummary:
+		return s.writeSessionSummary(r)
+	case cp.CheckpointAttribution:
+		return s.writeAttribution(r)
+	default:
+		return fmt.Errorf("fsstore: unsupported write request %T", req)
+	}
+}
+
+func (s *Store) writeSession(opts cp.WriteOptions) error {
+	sc, err := s.load(opts.CheckpointID)
+	if err != nil {
+		return err
+	}
+	if sc == nil {
+		sc = &storedCheckpoint{Summary: cp.CheckpointSummary{CheckpointID: opts.CheckpointID}}
+	}
+
+	session := storedSession{
+		SessionID:  opts.SessionID,
+		Metadata:   metadataFromWriteOptions(opts),
+		Transcript: opts.Transcript.Bytes(),
+		Prompts:    redact.String(strings.Join(opts.Prompts, checkpoint.PromptSeparator)),
+	}
+	sc.Sessions = upsertSession(sc.Sessions, session)
+	recomputeSummary(sc)
+	return s.save(sc)
+}
+
+func (s *Store) backfillTranscript(opts cp.UpdateOptions) error {
+	sc, err := s.load(opts.CheckpointID)
+	if err != nil {
+		return err
+	}
+	if sc == nil {
+		return fmt.Errorf("fsstore: cannot backfill transcript for unknown checkpoint %s", opts.CheckpointID)
+	}
+	idx := sessionIndexByID(sc.Sessions, opts.SessionID)
+	if idx < 0 {
+		return fmt.Errorf("fsstore: cannot backfill transcript for unknown session %q in %s", opts.SessionID, opts.CheckpointID)
+	}
+	// Replace semantics, but do not clobber sibling fields (matches the git
+	// store's stop-time transcript backfill).
+	sc.Sessions[idx].Transcript = opts.Transcript.Bytes()
+	sc.Sessions[idx].Prompts = redact.String(strings.Join(opts.Prompts, checkpoint.PromptSeparator))
+	if len(opts.SkillEvents) > 0 {
+		sc.Sessions[idx].Metadata.SkillEvents = opts.SkillEvents
+	}
+	return s.save(sc)
+}
+
+func (s *Store) writeSessionSummary(r cp.SessionSummary) error {
+	sc, err := s.load(r.CheckpointID)
+	if err != nil {
+		return err
+	}
+	if sc == nil || len(sc.Sessions) == 0 {
+		return fmt.Errorf("fsstore: cannot set summary for unknown checkpoint %s", r.CheckpointID)
+	}
+	sc.Sessions[len(sc.Sessions)-1].Metadata.Summary = r.Summary
+	return s.save(sc)
+}
+
+func (s *Store) writeAttribution(r cp.CheckpointAttribution) error {
+	sc, err := s.load(r.CheckpointID)
+	if err != nil {
+		return err
+	}
+	if sc == nil {
+		return fmt.Errorf("fsstore: cannot set attribution for unknown checkpoint %s", r.CheckpointID)
+	}
+	sc.Summary.CombinedAttribution = r.Attribution
+	return s.save(sc)
+}
+
+// Read returns the checkpoint summary, or (nil, nil) when absent so the
+// contract helper normalizes it to ErrCheckpointNotFound.
+func (s *Store) Read(_ context.Context, checkpointID id.CheckpointID) (*cp.CheckpointSummary, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sc, err := s.load(checkpointID)
+	if err != nil || sc == nil {
+		return nil, err
+	}
+	summary := sc.Summary
+	return &summary, nil
+}
+
+func (s *Store) List(_ context.Context) ([]cp.CheckpointInfo, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("fsstore: list %s: %w", s.root, err)
+	}
+
+	var infos []cp.CheckpointInfo
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		checkpointID := id.CheckpointID(strings.TrimSuffix(e.Name(), ".json"))
+		sc, err := s.load(checkpointID)
+		if err != nil {
+			return nil, err
+		}
+		if sc == nil {
+			continue
+		}
+		infos = append(infos, infoFromStored(sc))
+	}
+	sort.Slice(infos, func(i, j int) bool { return infos[i].CreatedAt.After(infos[j].CreatedAt) })
+	return infos, nil
+}
+
+func (s *Store) ReadSessionContent(_ context.Context, checkpointID id.CheckpointID, sessionIndex int) (*cp.SessionContent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	session, err := s.sessionAt(checkpointID, sessionIndex)
+	if err != nil {
+		return nil, err
+	}
+	return &cp.SessionContent{
+		Metadata:   session.Metadata,
+		Transcript: session.Transcript,
+		Prompts:    session.Prompts,
+	}, nil
+}
+
+func (s *Store) ReadSessionMetadata(_ context.Context, checkpointID id.CheckpointID, sessionIndex int) (*cp.Metadata, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	session, err := s.sessionAt(checkpointID, sessionIndex)
+	if err != nil {
+		return nil, err
+	}
+	meta := session.Metadata
+	return &meta, nil
+}
+
+func (s *Store) ReadSessionPrompts(_ context.Context, checkpointID id.CheckpointID, sessionIndex int) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	session, err := s.sessionAt(checkpointID, sessionIndex)
+	if err != nil {
+		return "", err
+	}
+	return session.Prompts, nil
+}
+
+func (s *Store) ReadSessionMetadataAndPrompts(_ context.Context, checkpointID id.CheckpointID, sessionIndex int) (*cp.Metadata, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	session, err := s.sessionAt(checkpointID, sessionIndex)
+	if err != nil {
+		return nil, "", err
+	}
+	meta := session.Metadata
+	return &meta, session.Prompts, nil
+}
+
+func (s *Store) sessionAt(checkpointID id.CheckpointID, sessionIndex int) (*storedSession, error) {
+	sc, err := s.load(checkpointID)
+	if err != nil {
+		return nil, err
+	}
+	if sc == nil {
+		return nil, cp.ErrCheckpointNotFound
+	}
+	if sessionIndex < 0 || sessionIndex >= len(sc.Sessions) {
+		return nil, fmt.Errorf("fsstore: session index %d out of range for %s (%d sessions)", sessionIndex, checkpointID, len(sc.Sessions))
+	}
+	return &sc.Sessions[sessionIndex], nil
+}
+
+func metadataFromWriteOptions(opts cp.WriteOptions) cp.Metadata {
+	return cp.Metadata{
+		CheckpointID:     opts.CheckpointID,
+		SessionID:        opts.SessionID,
+		Strategy:         opts.Strategy,
+		CreatedAt:        opts.CreatedAt,
+		Branch:           opts.Branch,
+		CheckpointsCount: opts.CheckpointsCount,
+		SaveStepCount:    opts.SaveStepCount,
+		FilesTouched:     opts.FilesTouched,
+		Agent:            opts.Agent,
+		Model:            opts.Model,
+		TurnID:           opts.TurnID,
+		IsTask:           opts.IsTask,
+		ToolUseID:        opts.ToolUseID,
+		TokenUsage:       opts.TokenUsage,
+		SkillEvents:      opts.SkillEvents,
+		SessionMetrics:   opts.SessionMetrics,
+		Summary:          opts.Summary,
+		Attribution:      opts.Attribution,
+		Kind:             opts.Kind,
+		ReviewSkills:     opts.ReviewSkills,
+		ReviewPrompt:     opts.ReviewPrompt,
+	}
+}
+
+func upsertSession(sessions []storedSession, session storedSession) []storedSession {
+	if idx := sessionIndexByID(sessions, session.SessionID); idx >= 0 {
+		sessions[idx] = session
+		return sessions
+	}
+	return append(sessions, session)
+}
+
+func sessionIndexByID(sessions []storedSession, sessionID string) int {
+	for i := range sessions {
+		if sessions[i].SessionID == sessionID {
+			return i
+		}
+	}
+	return -1
+}
+
+// recomputeSummary rebuilds the aggregated root summary from the sessions, so a
+// reader sees one Sessions entry per stored session and aggregate counts.
+func recomputeSummary(sc *storedCheckpoint) {
+	summary := &sc.Summary
+	summary.Sessions = make([]cp.SessionFilePaths, len(sc.Sessions))
+	summary.CheckpointsCount = 0
+	files := map[string]struct{}{}
+	var orderedFiles []string
+
+	for i := range sc.Sessions {
+		session := &sc.Sessions[i]
+		summary.Sessions[i] = cp.SessionFilePaths{
+			Metadata:   fmt.Sprintf("%d/metadata.json", i+1),
+			Transcript: fmt.Sprintf("%d/full.jsonl", i+1),
+			Prompt:     fmt.Sprintf("%d/prompt.txt", i+1),
+		}
+		summary.CheckpointsCount += session.Metadata.CheckpointsCount
+		if session.Metadata.Strategy != "" {
+			summary.Strategy = session.Metadata.Strategy
+		}
+		if session.Metadata.Branch != "" {
+			summary.Branch = session.Metadata.Branch
+		}
+		if session.Metadata.TokenUsage != nil {
+			summary.TokenUsage = session.Metadata.TokenUsage
+		}
+		for _, f := range session.Metadata.FilesTouched {
+			if _, seen := files[f]; !seen {
+				files[f] = struct{}{}
+				orderedFiles = append(orderedFiles, f)
+			}
+		}
+	}
+	summary.FilesTouched = orderedFiles
+}
+
+func infoFromStored(sc *storedCheckpoint) cp.CheckpointInfo {
+	info := cp.CheckpointInfo{
+		CheckpointID:     sc.Summary.CheckpointID,
+		CheckpointsCount: sc.Summary.CheckpointsCount,
+		FilesTouched:     sc.Summary.FilesTouched,
+		SessionCount:     len(sc.Sessions),
+	}
+	if n := len(sc.Sessions); n > 0 {
+		last := sc.Sessions[n-1]
+		info.SessionID = last.SessionID
+		info.CreatedAt = last.Metadata.CreatedAt
+		info.Agent = last.Metadata.Agent
+		info.IsTask = last.Metadata.IsTask
+		info.ToolUseID = last.Metadata.ToolUseID
+	}
+	info.SessionIDs = make([]string, 0, len(sc.Sessions))
+	for i := range sc.Sessions {
+		info.SessionIDs = append(info.SessionIDs, sc.Sessions[i].SessionID)
+	}
+	return info
+}

--- a/cmd/entire/cli/checkpoint/fsstore/fsstore.go
+++ b/cmd/entire/cli/checkpoint/fsstore/fsstore.go
@@ -10,6 +10,12 @@
 // the git-specific blob-hash fields of the contract and stores transcript bytes
 // directly, which keeps the example small and makes the contract's remaining
 // git leakage concrete.
+//
+// It is faithful to the contract's per-session metadata and write-request
+// semantics, but it does not replicate the git store's cross-session
+// aggregation: the root summary's TokenUsage reflects the latest session rather
+// than a sum across sessions. That aggregation is not needed to validate the
+// pluggable seam and is intentionally omitted.
 package fsstore
 
 import (
@@ -21,6 +27,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	cp "github.com/entireio/cli/api/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
@@ -89,8 +96,16 @@ func (s *Store) save(sc *storedCheckpoint) error {
 	if err != nil {
 		return fmt.Errorf("fsstore: encode %s: %w", sc.Summary.CheckpointID, err)
 	}
-	if err := os.WriteFile(s.path(sc.Summary.CheckpointID), data, 0o644); err != nil { //nolint:gosec // reference test backend
+	// Write atomically (temp + rename) so a reader never observes a partial
+	// document. This guards a single writer's in-progress write; cross-process
+	// concurrency is out of scope for this test-only backend.
+	final := s.path(sc.Summary.CheckpointID)
+	tmp := final + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return fmt.Errorf("fsstore: write %s: %w", sc.Summary.CheckpointID, err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		return fmt.Errorf("fsstore: commit %s: %w", sc.Summary.CheckpointID, err)
 	}
 	return nil
 }
@@ -130,6 +145,16 @@ func (s *Store) writeSession(opts cp.WriteOptions) error {
 		Prompts:    redact.String(strings.Join(opts.Prompts, checkpoint.PromptSeparator)),
 	}
 	sc.Sessions = upsertSession(sc.Sessions, session)
+
+	// Summary-level flags accumulate across sessions and survive recompute.
+	sc.Summary.HasReview = sc.Summary.HasReview || opts.HasReview
+	sc.Summary.HasInvestigation = sc.Summary.HasInvestigation || opts.HasInvestigation
+	if opts.CombinedAttribution != nil {
+		// Migration path: an initial write may carry holistic attribution. Normal
+		// condensation sets this later via a CheckpointAttribution write instead.
+		sc.Summary.CombinedAttribution = opts.CombinedAttribution
+	}
+
 	recomputeSummary(sc)
 	return s.save(sc)
 }
@@ -285,28 +310,39 @@ func (s *Store) sessionAt(checkpointID id.CheckpointID, sessionIndex int) (*stor
 }
 
 func metadataFromWriteOptions(opts cp.WriteOptions) cp.Metadata {
+	createdAt := opts.CreatedAt
+	if createdAt.IsZero() {
+		// Contract: a zero CreatedAt means "use the current time".
+		createdAt = time.Now()
+	}
 	return cp.Metadata{
-		CheckpointID:     opts.CheckpointID,
-		SessionID:        opts.SessionID,
-		Strategy:         opts.Strategy,
-		CreatedAt:        opts.CreatedAt,
-		Branch:           opts.Branch,
-		CheckpointsCount: opts.CheckpointsCount,
-		SaveStepCount:    opts.SaveStepCount,
-		FilesTouched:     opts.FilesTouched,
-		Agent:            opts.Agent,
-		Model:            opts.Model,
-		TurnID:           opts.TurnID,
-		IsTask:           opts.IsTask,
-		ToolUseID:        opts.ToolUseID,
-		TokenUsage:       opts.TokenUsage,
-		SkillEvents:      opts.SkillEvents,
-		SessionMetrics:   opts.SessionMetrics,
-		Summary:          opts.Summary,
-		Attribution:      opts.Attribution,
-		Kind:             opts.Kind,
-		ReviewSkills:     opts.ReviewSkills,
-		ReviewPrompt:     opts.ReviewPrompt,
+		CheckpointID:                opts.CheckpointID,
+		SessionID:                   opts.SessionID,
+		Strategy:                    opts.Strategy,
+		CreatedAt:                   createdAt,
+		Branch:                      opts.Branch,
+		CheckpointsCount:            opts.CheckpointsCount,
+		SaveStepCount:               opts.SaveStepCount,
+		FilesTouched:                opts.FilesTouched,
+		Agent:                       opts.Agent,
+		Model:                       opts.Model,
+		TurnID:                      opts.TurnID,
+		IsTask:                      opts.IsTask,
+		ToolUseID:                   opts.ToolUseID,
+		TranscriptIdentifierAtStart: opts.TranscriptIdentifierAtStart,
+		CheckpointTranscriptStart:   opts.CheckpointTranscriptStart,
+		TranscriptLinesAtStart:      opts.CheckpointTranscriptStart, // git writes both for back-compat
+		TokenUsage:                  opts.TokenUsage,
+		SkillEvents:                 opts.SkillEvents,
+		PromptAttributions:          opts.PromptAttributionsJSON,
+		SessionMetrics:              opts.SessionMetrics,
+		Summary:                     opts.Summary,
+		Attribution:                 opts.Attribution,
+		Kind:                        opts.Kind,
+		ReviewSkills:                opts.ReviewSkills,
+		ReviewPrompt:                opts.ReviewPrompt,
+		InvestigateRunID:            opts.InvestigateRunID,
+		InvestigateTopic:            opts.InvestigateTopic,
 	}
 }
 

--- a/cmd/entire/cli/checkpoint/fsstore/fsstore_test.go
+++ b/cmd/entire/cli/checkpoint/fsstore/fsstore_test.go
@@ -130,6 +130,41 @@ func TestStore_ListReturnsCheckpoints(t *testing.T) {
 	assert.Equal(t, id.MustCheckpointID("b1b2c3d4e5f6"), infos[0].CheckpointID)
 }
 
+func TestStore_DefaultsCreatedAtWhenZero(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := New(t.TempDir())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	require.NoError(t, store.Write(ctx, cp.Session{
+		CheckpointID: cid, SessionID: "s1", // CreatedAt left zero
+		Transcript: redact.AlreadyRedacted([]byte("t")),
+	}))
+
+	meta, err := store.ReadSessionMetadata(ctx, cid, 0)
+	require.NoError(t, err)
+	assert.False(t, meta.CreatedAt.IsZero(), "zero CreatedAt should default to the current time")
+}
+
+func TestStore_PersistsReviewFlagAndCombinedAttribution(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := New(t.TempDir())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	require.NoError(t, store.Write(ctx, cp.Session{
+		CheckpointID: cid, SessionID: "s1", Transcript: redact.AlreadyRedacted([]byte("t")),
+		HasReview:           true,
+		CombinedAttribution: &cp.Attribution{AgentLines: 3},
+	}))
+
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	assert.True(t, summary.HasReview)
+	require.NotNil(t, summary.CombinedAttribution)
+	assert.Equal(t, 3, summary.CombinedAttribution.AgentLines)
+}
+
 func TestStore_FactoryRequiresPath(t *testing.T) {
 	t.Parallel()
 	_, err := factory(context.Background(), checkpoint.OpenEnv{}, nil)

--- a/cmd/entire/cli/checkpoint/fsstore/fsstore_test.go
+++ b/cmd/entire/cli/checkpoint/fsstore/fsstore_test.go
@@ -1,0 +1,138 @@
+package fsstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cp "github.com/entireio/cli/api/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/redact"
+)
+
+func TestStore_WriteSessionRoundTrips(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := New(t.TempDir())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	require.NoError(t, store.Write(ctx, cp.Session{
+		CheckpointID:     cid,
+		SessionID:        "sess-1",
+		Strategy:         "manual-commit",
+		Transcript:       redact.AlreadyRedacted([]byte("transcript-1")),
+		Prompts:          []string{"hello"},
+		FilesTouched:     []string{"a.go"},
+		CheckpointsCount: 2,
+	}))
+
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, cid, summary.CheckpointID)
+	require.Len(t, summary.Sessions, 1)
+	assert.Equal(t, 2, summary.CheckpointsCount)
+	assert.Equal(t, []string{"a.go"}, summary.FilesTouched)
+
+	content, err := store.ReadSessionContent(ctx, cid, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("transcript-1"), content.Transcript)
+	assert.Contains(t, content.Prompts, "hello")
+}
+
+func TestStore_ReadUnknownCheckpoint(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := New(t.TempDir())
+
+	summary, err := store.Read(ctx, id.MustCheckpointID("ffffffffffff"))
+	require.NoError(t, err)
+	assert.Nil(t, summary, "absent checkpoint should read as nil summary")
+
+	_, err = store.ReadSessionContent(ctx, id.MustCheckpointID("ffffffffffff"), 0)
+	require.ErrorIs(t, err, cp.ErrCheckpointNotFound)
+}
+
+func TestStore_BackfillTranscriptReplacesWithoutClobbering(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := New(t.TempDir())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	require.NoError(t, store.Write(ctx, cp.Session{
+		CheckpointID: cid, SessionID: "sess-1", Strategy: "manual-commit",
+		Transcript: redact.AlreadyRedacted([]byte("old")), FilesTouched: []string{"a.go"},
+	}))
+	require.NoError(t, store.Write(ctx, cp.SessionTranscript{
+		CheckpointID: cid, SessionID: "sess-1",
+		Transcript: redact.AlreadyRedacted([]byte("new")), Prompts: []string{"p"},
+	}))
+
+	content, err := store.ReadSessionContent(ctx, cid, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new"), content.Transcript)
+	// Sibling field (files touched, surfaced via the summary) must survive.
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a.go"}, summary.FilesTouched)
+}
+
+func TestStore_SessionSummaryAndAttribution(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := New(t.TempDir())
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	require.NoError(t, store.Write(ctx, cp.Session{
+		CheckpointID: cid, SessionID: "sess-1", Strategy: "manual-commit",
+		Transcript: redact.AlreadyRedacted([]byte("t")),
+	}))
+	require.NoError(t, store.Write(ctx, cp.SessionSummary{
+		CheckpointID: cid, Summary: &cp.Summary{Intent: "do a thing", Outcome: "did it"},
+	}))
+	require.NoError(t, store.Write(ctx, cp.CheckpointAttribution{
+		CheckpointID: cid, Attribution: &cp.Attribution{AgentLines: 10, AgentPercentage: 80},
+	}))
+
+	meta, err := store.ReadSessionMetadata(ctx, cid, 0)
+	require.NoError(t, err)
+	require.NotNil(t, meta.Summary)
+	assert.Equal(t, "do a thing", meta.Summary.Intent)
+
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, summary.CombinedAttribution)
+	assert.Equal(t, 10, summary.CombinedAttribution.AgentLines)
+}
+
+func TestStore_ListReturnsCheckpoints(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := New(t.TempDir())
+
+	require.NoError(t, store.Write(ctx, cp.Session{
+		CheckpointID: id.MustCheckpointID("a1b2c3d4e5f6"), SessionID: "s1",
+		CreatedAt: time.Unix(100, 0), Transcript: redact.AlreadyRedacted([]byte("t")),
+	}))
+	require.NoError(t, store.Write(ctx, cp.Session{
+		CheckpointID: id.MustCheckpointID("b1b2c3d4e5f6"), SessionID: "s2",
+		CreatedAt: time.Unix(200, 0), Transcript: redact.AlreadyRedacted([]byte("t")),
+	}))
+
+	infos, err := store.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, infos, 2)
+	// Sorted newest-first by CreatedAt.
+	assert.Equal(t, id.MustCheckpointID("b1b2c3d4e5f6"), infos[0].CheckpointID)
+}
+
+func TestStore_FactoryRequiresPath(t *testing.T) {
+	t.Parallel()
+	_, err := factory(context.Background(), checkpoint.OpenEnv{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "config.path is required")
+}

--- a/cmd/entire/cli/checkpoint/fsstore/register.go
+++ b/cmd/entire/cli/checkpoint/fsstore/register.go
@@ -1,0 +1,44 @@
+package fsstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	cp "github.com/entireio/cli/api/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+)
+
+// Config is the fsstore backend's settings "config" block.
+type Config struct {
+	Path string `json:"path"`
+}
+
+var registerOnce sync.Once
+
+// RegisterForTesting registers the fsstore backend under its type so tests can
+// select it as a checkpoint mirror (or primary in fsstore's own tests). It is
+// the only path that adds fsstore to the registry: production code never calls
+// it, so a production binary cannot resolve the "fs" backend. Registration is
+// process-wide and idempotent (checkpoint.Register panics on duplicates).
+func RegisterForTesting() {
+	registerOnce.Do(func() {
+		checkpoint.Register(BackendType, factory)
+	})
+}
+
+//nolint:ireturn // must return the contract interface to satisfy checkpoint.Factory
+func factory(_ context.Context, _ checkpoint.OpenEnv, cfg json.RawMessage) (cp.PersistentStore, error) {
+	var c Config
+	if len(cfg) > 0 {
+		if err := json.Unmarshal(cfg, &c); err != nil {
+			return nil, fmt.Errorf("fsstore: invalid config: %w", err)
+		}
+	}
+	if c.Path == "" {
+		return nil, errors.New("fsstore: config.path is required")
+	}
+	return New(c.Path), nil
+}

--- a/cmd/entire/cli/checkpoint/fsstore/register_test.go
+++ b/cmd/entire/cli/checkpoint/fsstore/register_test.go
@@ -11,27 +11,30 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 )
 
-// Config is the fsstore backend's settings "config" block.
-type Config struct {
+// backendType is the registry type name for the filesystem reference backend.
+const backendType = "fs"
+
+// config is the fsstore backend's settings "config" block.
+type config struct {
 	Path string `json:"path"`
 }
 
 var registerOnce sync.Once
 
-// RegisterForTesting registers the fsstore backend under its type so tests can
-// select it as a checkpoint mirror (or primary in fsstore's own tests). It is
-// the only path that adds fsstore to the registry: production code never calls
-// it, so a production binary cannot resolve the "fs" backend. Registration is
-// process-wide and idempotent (checkpoint.Register panics on duplicates).
-func RegisterForTesting() {
+// registerForTesting registers the fsstore backend so tests can select it as a
+// checkpoint mirror. It lives in a _test.go file on purpose: the production
+// fsstore package exposes no way to add itself to the registry, so a production
+// binary can never resolve the "fs" backend. Registration is process-wide and
+// idempotent (checkpoint.Register panics on duplicates).
+func registerForTesting() {
 	registerOnce.Do(func() {
-		checkpoint.Register(BackendType, factory)
+		checkpoint.Register(backendType, factory)
 	})
 }
 
 //nolint:ireturn // must return the contract interface to satisfy checkpoint.Factory
 func factory(_ context.Context, _ checkpoint.OpenEnv, cfg json.RawMessage) (cp.PersistentStore, error) {
-	var c Config
+	var c config
 	if len(cfg) > 0 {
 		if err := json.Unmarshal(cfg, &c); err != nil {
 			return nil, fmt.Errorf("fsstore: invalid config: %w", err)

--- a/cmd/entire/cli/checkpoint/fsstore/seam_test.go
+++ b/cmd/entire/cli/checkpoint/fsstore/seam_test.go
@@ -25,7 +25,7 @@ import (
 //
 // Not parallel: uses t.Chdir so settings + ref resolution target the test repo.
 func TestSeam_GitPrimaryWithFsMirror(t *testing.T) {
-	RegisterForTesting()
+	registerForTesting()
 
 	dir := t.TempDir()
 	testutil.InitRepo(t, dir)

--- a/cmd/entire/cli/checkpoint/fsstore/seam_test.go
+++ b/cmd/entire/cli/checkpoint/fsstore/seam_test.go
@@ -111,7 +111,7 @@ func writeMirrorSettings(t *testing.T, repoDir, mirrorDir string) {
 	// json-encode the path so separators / spaces are escaped correctly.
 	encodedPath, err := json.Marshal(mirrorDir)
 	require.NoError(t, err)
-	body := `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"type": "fs", "config": {"path": ` +
+	body := `{"enabled": true, "checkpoints": {"primary": {"type": "git-branch"}, "mirrors": [{"type": "fs", "config": {"path": ` +
 		string(encodedPath) + `}}]}}`
 	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".entire"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".entire", "settings.json"), []byte(body), 0o644))

--- a/cmd/entire/cli/checkpoint/fsstore/seam_test.go
+++ b/cmd/entire/cli/checkpoint/fsstore/seam_test.go
@@ -1,0 +1,118 @@
+package fsstore
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cp "github.com/entireio/cli/api/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/redact"
+)
+
+// TestSeam_GitPrimaryWithFsMirror exercises the full pluggable seam: a git
+// primary with the fsstore as a configured mirror, driven through
+// checkpoint.Open. It writes all four WriteRequest variants and asserts each
+// lands in BOTH backends, while reads resolve from the git primary.
+//
+// Not parallel: uses t.Chdir so settings + ref resolution target the test repo.
+func TestSeam_GitPrimaryWithFsMirror(t *testing.T) {
+	RegisterForTesting()
+
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "README.md", "# test")
+	testutil.GitAdd(t, dir, "README.md")
+	testutil.GitCommit(t, dir, "init")
+
+	mirrorDir := filepath.Join(t.TempDir(), "fs-mirror")
+	writeMirrorSettings(t, dir, mirrorDir)
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	stores, err := checkpoint.Open(context.Background(), repo, checkpoint.OpenOptions{})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	const sessionID = "sess-1"
+
+	// 1. Session: create the checkpoint.
+	require.NoError(t, stores.Persistent.Write(ctx, cp.Session{
+		CheckpointID: cid, SessionID: sessionID, Strategy: "manual-commit",
+		Transcript: redact.AlreadyRedacted([]byte("initial transcript")),
+		Prompts:    []string{"do the thing"}, FilesTouched: []string{"a.go"},
+		AuthorName: "Test", AuthorEmail: "test@example.com",
+	}))
+	// 2. SessionTranscript: replace transcript at stop time.
+	require.NoError(t, stores.Persistent.Write(ctx, cp.SessionTranscript{
+		CheckpointID: cid, SessionID: sessionID,
+		Transcript: redact.AlreadyRedacted([]byte("final transcript")),
+		Prompts:    []string{"do the thing"},
+	}))
+	// 3. SessionSummary: set the latest session's summary.
+	require.NoError(t, stores.Persistent.Write(ctx, cp.SessionSummary{
+		CheckpointID: cid, Summary: &cp.Summary{Intent: "intent-x", Outcome: "outcome-y"},
+	}))
+	// 4. CheckpointAttribution: set combined attribution.
+	require.NoError(t, stores.Persistent.Write(ctx, cp.CheckpointAttribution{
+		CheckpointID: cid, Attribution: &cp.Attribution{AgentLines: 7, AgentPercentage: 70},
+	}))
+
+	// Reads resolve from the git primary.
+	t.Run("git primary", func(t *testing.T) {
+		assertAllVariants(t, stores.Persistent, cid)
+	})
+
+	// The fsstore mirror independently received every write.
+	t.Run("fs mirror", func(t *testing.T) {
+		mirror := New(mirrorDir)
+		assertAllVariants(t, mirror, cid)
+	})
+}
+
+// assertAllVariants verifies that all four writes are visible in a backend.
+func assertAllVariants(t *testing.T, store cp.PersistentStore, cid id.CheckpointID) {
+	t.Helper()
+	ctx := context.Background()
+
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, summary, "checkpoint should exist")
+	require.Len(t, summary.Sessions, 1)
+
+	// SessionTranscript landed.
+	content, err := store.ReadSessionContent(ctx, cid, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("final transcript"), content.Transcript)
+
+	// SessionSummary landed.
+	meta, err := store.ReadSessionMetadata(ctx, cid, 0)
+	require.NoError(t, err)
+	require.NotNil(t, meta.Summary)
+	assert.Equal(t, "intent-x", meta.Summary.Intent)
+
+	// CheckpointAttribution landed.
+	require.NotNil(t, summary.CombinedAttribution)
+	assert.Equal(t, 7, summary.CombinedAttribution.AgentLines)
+}
+
+func writeMirrorSettings(t *testing.T, repoDir, mirrorDir string) {
+	t.Helper()
+	// json-encode the path so separators / spaces are escaped correctly.
+	encodedPath, err := json.Marshal(mirrorDir)
+	require.NoError(t, err)
+	body := `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"type": "fs", "config": {"path": ` +
+		string(encodedPath) + `}}]}}`
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".entire", "settings.json"), []byte(body), 0o644))
+}

--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -37,16 +37,16 @@ type Stores struct {
 // Open resolves the checkpoint storage topology and constructs the backing
 // store(s). It keeps ref resolution, backend selection, and blob-fetcher wiring
 // in one place. The primary is built through the backend registry; with no
-// checkpoints config it resolves to the git backend with no mirrors, so default
-// behavior is unchanged. When mirrors are configured, the persistent store is a
-// fan-out wrapper (reads from primary, best-effort writes to each mirror).
+// checkpoints config it resolves to the git-branch backend with no mirrors, so
+// default behavior is unchanged. When mirrors are configured, the persistent
+// store is a fan-out wrapper (reads from primary, best-effort writes to mirrors).
 //
 // Backend selection is read via settings.LoadCheckpointsConfig, which resolves
 // like settings.Load: from the context's worktree root if set, else relative to
 // the current working directory — not from repo. Callers opening a repository
 // that is not the cwd should wrap ctx with that worktree root (as dispatch does).
 // Resolution is fail-soft: a missing or unreadable settings file yields the
-// default git backend with no mirrors, preserving default behavior.
+// default git-branch backend with no mirrors, preserving default behavior.
 func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores, error) {
 	refs := resolveOpenRefs(ctx, opts)
 	env := OpenEnv{Repo: repo, BlobFetcher: opts.BlobFetcher, Refs: refs}
@@ -56,11 +56,12 @@ func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores,
 		return nil, fmt.Errorf("resolve checkpoints config: %w", err)
 	}
 
-	primary, err := buildPrimary(ctx, env, cfg)
+	primaryType := resolvePrimaryType(cfg)
+	primary, err := buildPrimary(ctx, env, primaryType, primaryConfig(cfg))
 	if err != nil {
 		return nil, err
 	}
-	mirrors, err := buildMirrors(ctx, env, cfg)
+	mirrors, err := buildMirrors(ctx, env, cfg, primaryType)
 	if err != nil {
 		return nil, err
 	}
@@ -72,33 +73,60 @@ func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores,
 	}, nil
 }
 
-// buildPrimary constructs the primary persistent store. The primary must be the
-// git backend: attach, resume, push, doctor, cleanup, and OPF all assume a git
-// refs.Primary, so a non-git primary is rejected rather than silently
-// half-supported.
-func buildPrimary(ctx context.Context, env OpenEnv, cfg *settings.CheckpointsConfig) (PersistentStore, error) {
-	typ, raw := BackendTypeGit, json.RawMessage(nil)
+// resolvePrimaryType returns the configured primary backend type, defaulting to
+// the git-branch backend when none is configured.
+func resolvePrimaryType(cfg *settings.CheckpointsConfig) string {
 	if cfg != nil && cfg.Primary.Type != "" {
-		typ, raw = cfg.Primary.Type, cfg.Primary.Config
+		return cfg.Primary.Type
 	}
-	if typ != BackendTypeGit {
-		return nil, fmt.Errorf("checkpoints.primary.type %q is not supported: only %q may be the primary backend", typ, BackendTypeGit)
+	return BackendTypeGitBranch
+}
+
+// primaryConfig returns the primary backend's config block, if any.
+func primaryConfig(cfg *settings.CheckpointsConfig) json.RawMessage {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.Primary.Config
+}
+
+// buildPrimary constructs the primary persistent store. The primary must be a
+// git-backed backend: attach, resume, push, doctor, cleanup, and OPF all drive
+// the primary's record through the repo and its refs, so a non-git-backed
+// primary is rejected rather than silently half-supported.
+func buildPrimary(ctx context.Context, env OpenEnv, typ string, raw json.RawMessage) (PersistentStore, error) {
+	b, err := lookupBackend(typ)
+	if err != nil {
+		return nil, fmt.Errorf("checkpoints.primary: %w", err)
+	}
+	if !b.gitBacked {
+		return nil, fmt.Errorf("checkpoints.primary.type %q cannot be the primary: only git-backed backends (e.g. %q) may be the primary", typ, BackendTypeGitBranch)
 	}
 	return build(ctx, env, typ, raw)
 }
 
-// buildMirrors constructs the mirror writers. A git-typed mirror is rejected: it
-// would share the primary ref topology and double-write the same ref, so it is
-// never a meaningful independent mirror.
-func buildMirrors(ctx context.Context, env OpenEnv, cfg *settings.CheckpointsConfig) ([]Writer, error) {
+// buildMirrors constructs the mirror writers. Each backend type may appear at
+// most once across the topology (primary + mirrors), so a mirror cannot reuse
+// the primary's type or another mirror's. This is the conservative form of "no
+// two backends may write the same target": today two backends of the same type
+// share the same refs/storage, so a duplicate type is a guaranteed collision
+// (e.g. a git-branch mirror under a git-branch primary would double-write the v1
+// branch). A future per-mirror config (same backend type pointed at a distinct
+// repo/refs) could relax this; for now it is one of each type.
+func buildMirrors(ctx context.Context, env OpenEnv, cfg *settings.CheckpointsConfig, primaryType string) ([]Writer, error) {
 	if cfg == nil || len(cfg.Mirrors) == 0 {
 		return nil, nil
 	}
+	seen := map[string]bool{primaryType: true}
 	mirrors := make([]Writer, 0, len(cfg.Mirrors))
 	for i, m := range cfg.Mirrors {
-		if m.Type == BackendTypeGit {
-			return nil, fmt.Errorf("checkpoints.mirrors[%d]: a %q mirror would duplicate the primary ref and is not supported", i, BackendTypeGit)
+		if _, err := lookupBackend(m.Type); err != nil {
+			return nil, fmt.Errorf("checkpoints.mirrors[%d]: %w", i, err)
 		}
+		if seen[m.Type] {
+			return nil, fmt.Errorf("checkpoints.mirrors[%d]: backend type %q is already used by the primary or another mirror; each backend type may appear at most once", i, m.Type)
+		}
+		seen[m.Type] = true
 		store, err := build(ctx, env, m.Type, m.Config)
 		if err != nil {
 			return nil, fmt.Errorf("checkpoints.mirrors[%d]: %w", i, err)

--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -2,8 +2,12 @@ package checkpoint
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/go-git/go-git/v6"
+
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 )
 
 // OpenOptions configures Open. The zero value uses the default committed-ref
@@ -32,20 +36,69 @@ type Stores struct {
 
 // Open resolves the checkpoint storage topology and constructs the backing
 // store(s). It keeps ref resolution, backend selection, and blob-fetcher wiring
-// in one place. The primary is built through the backend registry; today it
-// always resolves to the git backend, so default behavior is unchanged.
+// in one place. The primary is built through the backend registry; with no
+// checkpoints config it resolves to the git backend with no mirrors, so default
+// behavior is unchanged. When mirrors are configured, the persistent store is a
+// fan-out wrapper (reads from primary, best-effort writes to each mirror).
 func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores, error) {
 	refs := resolveOpenRefs(ctx, opts)
 	env := OpenEnv{Repo: repo, BlobFetcher: opts.BlobFetcher, Refs: refs}
-	primary, err := build(ctx, env, BackendTypeGit, nil)
+
+	cfg, err := settings.LoadCheckpointsConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve checkpoints config: %w", err)
+	}
+
+	primary, err := buildPrimary(ctx, env, cfg)
 	if err != nil {
 		return nil, err
 	}
+	mirrors, err := buildMirrors(ctx, env, cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Stores{
-		Persistent: primary,
+		Persistent: newFanoutStore(primary, mirrors),
 		ephemeral:  newEphemeralStore(repo, refs),
 		refs:       refs,
 	}, nil
+}
+
+// buildPrimary constructs the primary persistent store. The primary must be the
+// git backend: attach, resume, push, doctor, cleanup, and OPF all assume a git
+// refs.Primary, so a non-git primary is rejected rather than silently
+// half-supported.
+func buildPrimary(ctx context.Context, env OpenEnv, cfg *settings.CheckpointsConfig) (PersistentStore, error) {
+	typ, raw := BackendTypeGit, json.RawMessage(nil)
+	if cfg != nil && cfg.Primary.Type != "" {
+		typ, raw = cfg.Primary.Type, cfg.Primary.Config
+	}
+	if typ != BackendTypeGit {
+		return nil, fmt.Errorf("checkpoints.primary.type %q is not supported: only %q may be the primary backend", typ, BackendTypeGit)
+	}
+	return build(ctx, env, typ, raw)
+}
+
+// buildMirrors constructs the mirror writers. A git-typed mirror is rejected: it
+// would share the primary ref topology and double-write the same ref, so it is
+// never a meaningful independent mirror.
+func buildMirrors(ctx context.Context, env OpenEnv, cfg *settings.CheckpointsConfig) ([]Writer, error) {
+	if cfg == nil || len(cfg.Mirrors) == 0 {
+		return nil, nil
+	}
+	mirrors := make([]Writer, 0, len(cfg.Mirrors))
+	for i, m := range cfg.Mirrors {
+		if m.Type == BackendTypeGit {
+			return nil, fmt.Errorf("checkpoints.mirrors[%d]: a %q mirror would duplicate the primary ref and is not supported", i, BackendTypeGit)
+		}
+		store, err := build(ctx, env, m.Type, m.Config)
+		if err != nil {
+			return nil, fmt.Errorf("checkpoints.mirrors[%d]: %w", i, err)
+		}
+		mirrors = append(mirrors, store)
+	}
+	return mirrors, nil
 }
 
 func resolveOpenRefs(ctx context.Context, opts OpenOptions) PersistentRefs {

--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -31,17 +31,18 @@ type Stores struct {
 }
 
 // Open resolves the checkpoint storage topology and constructs the backing
-// store. It keeps ref resolution and blob-fetcher wiring in one place.
-//
-//nolint:unparam // Callers treat store construction as fallible at this boundary; the git backend has no fallible setup today.
+// store(s). It keeps ref resolution, backend selection, and blob-fetcher wiring
+// in one place. The primary is built through the backend registry; today it
+// always resolves to the git backend, so default behavior is unchanged.
 func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores, error) {
 	refs := resolveOpenRefs(ctx, opts)
-	store := NewGitStore(repo, refs)
-	if opts.BlobFetcher != nil {
-		store.SetBlobFetcher(opts.BlobFetcher)
+	env := OpenEnv{Repo: repo, BlobFetcher: opts.BlobFetcher, Refs: refs}
+	primary, err := build(ctx, env, BackendTypeGit, nil)
+	if err != nil {
+		return nil, err
 	}
 	return &Stores{
-		Persistent: store,
+		Persistent: primary,
 		ephemeral:  newEphemeralStore(repo, refs),
 		refs:       refs,
 	}, nil

--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -40,6 +40,13 @@ type Stores struct {
 // checkpoints config it resolves to the git backend with no mirrors, so default
 // behavior is unchanged. When mirrors are configured, the persistent store is a
 // fan-out wrapper (reads from primary, best-effort writes to each mirror).
+//
+// Backend selection is read via settings.LoadCheckpointsConfig, which resolves
+// like settings.Load: from the context's worktree root if set, else relative to
+// the current working directory — not from repo. Callers opening a repository
+// that is not the cwd should wrap ctx with that worktree root (as dispatch does).
+// Resolution is fail-soft: a missing or unreadable settings file yields the
+// default git backend with no mirrors, preserving default behavior.
 func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores, error) {
 	refs := resolveOpenRefs(ctx, opts)
 	env := OpenEnv{Repo: repo, BlobFetcher: opts.BlobFetcher, Refs: refs}

--- a/cmd/entire/cli/checkpoint/open_config_test.go
+++ b/cmd/entire/cli/checkpoint/open_config_test.go
@@ -47,32 +47,56 @@ func TestOpen_DefaultIsGitPrimaryNoMirrors(t *testing.T) {
 	assert.True(t, isGit, "default persistent store should be the raw git store, not a fan-out wrapper")
 }
 
-func TestOpen_RejectsNonGitPrimary(t *testing.T) {
+func TestOpen_RejectsNonGitBackedPrimary(t *testing.T) {
+	registerFakeMirrorBackend(t) // a registered, non-git-backed backend
 	dir, repo, _ := newTestRepo(t)
 	t.Chdir(dir)
-	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "fs"}}}`)
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "`+fakeMirrorBackendType+`"}}}`)
 
 	_, err := Open(context.Background(), repo, OpenOptions{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "is not supported")
-	assert.Contains(t, err.Error(), "primary")
+	assert.Contains(t, err.Error(), "cannot be the primary")
+	assert.Contains(t, err.Error(), "git-backed")
 }
 
-func TestOpen_RejectsGitMirror(t *testing.T) {
+func TestOpen_RejectsUnknownPrimary(t *testing.T) {
 	dir, repo, _ := newTestRepo(t)
 	t.Chdir(dir)
-	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"type": "git"}]}}`)
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "nope"}}}`)
 
 	_, err := Open(context.Background(), repo, OpenOptions{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate the primary ref")
+	assert.Contains(t, err.Error(), "unknown checkpoint backend type")
+}
+
+func TestOpen_RejectsMirrorOfPrimaryType(t *testing.T) {
+	dir, repo, _ := newTestRepo(t)
+	t.Chdir(dir)
+	// A git-branch mirror under a git-branch primary would double-write v1.
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git-branch"}, "mirrors": [{"type": "git-branch"}]}}`)
+
+	_, err := Open(context.Background(), repo, OpenOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at most once")
+}
+
+func TestOpen_RejectsDuplicateMirrorType(t *testing.T) {
+	registerFakeMirrorBackend(t)
+	dir, repo, _ := newTestRepo(t)
+	t.Chdir(dir)
+	// Two mirrors of the same type are rejected (one of each type).
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git-branch"}, "mirrors": [{"type": "`+fakeMirrorBackendType+`"}, {"type": "`+fakeMirrorBackendType+`"}]}}`)
+
+	_, err := Open(context.Background(), repo, OpenOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at most once")
 }
 
 func TestOpen_BuildsConfiguredMirror(t *testing.T) {
 	registerFakeMirrorBackend(t)
 	dir, repo, _ := newTestRepo(t)
 	t.Chdir(dir)
-	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"type": "`+fakeMirrorBackendType+`"}]}}`)
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git-branch"}, "mirrors": [{"type": "`+fakeMirrorBackendType+`"}]}}`)
 
 	stores, err := Open(context.Background(), repo, OpenOptions{})
 	require.NoError(t, err)
@@ -89,7 +113,7 @@ func TestOpen_InvalidCheckpointsBlockErrors(t *testing.T) {
 	dir, repo, _ := newTestRepo(t)
 	t.Chdir(dir)
 	// Present checkpoints block, but a mirror with no type is invalid.
-	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"config": {}}]}}`)
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git-branch"}, "mirrors": [{"config": {}}]}}`)
 
 	_, err := Open(context.Background(), repo, OpenOptions{})
 	require.Error(t, err)

--- a/cmd/entire/cli/checkpoint/open_config_test.go
+++ b/cmd/entire/cli/checkpoint/open_config_test.go
@@ -1,0 +1,121 @@
+package checkpoint
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+const fakeMirrorBackendType = "faketest-mirror"
+
+var fakeMirrorBackendOnce sync.Once
+
+// registerFakeMirrorBackend registers a non-git backend so mirror-selection
+// paths can be exercised without the real fsstore. Registration is process-wide
+// and idempotent (Register panics on duplicates).
+func registerFakeMirrorBackend(t *testing.T) {
+	t.Helper()
+	fakeMirrorBackendOnce.Do(func() {
+		Register(fakeMirrorBackendType, func(_ context.Context, _ OpenEnv, _ json.RawMessage) (PersistentStore, error) {
+			return &fakePrimary{}, nil
+		})
+	})
+}
+
+func writeRawSettings(t *testing.T, dir, body string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".entire", paths.SettingsFileName), []byte(body), 0o644))
+}
+
+// Not parallel: uses t.Chdir so settings resolve to the test repo.
+func TestOpen_DefaultIsGitPrimaryNoMirrors(t *testing.T) {
+	dir, repo, _ := newTestRepo(t)
+	t.Chdir(dir)
+
+	stores, err := Open(context.Background(), repo, OpenOptions{})
+	require.NoError(t, err)
+	_, isGit := stores.Persistent.(*GitStore)
+	assert.True(t, isGit, "default persistent store should be the raw git store, not a fan-out wrapper")
+}
+
+func TestOpen_RejectsNonGitPrimary(t *testing.T) {
+	dir, repo, _ := newTestRepo(t)
+	t.Chdir(dir)
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "fs"}}}`)
+
+	_, err := Open(context.Background(), repo, OpenOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not supported")
+	assert.Contains(t, err.Error(), "primary")
+}
+
+func TestOpen_RejectsGitMirror(t *testing.T) {
+	dir, repo, _ := newTestRepo(t)
+	t.Chdir(dir)
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"type": "git"}]}}`)
+
+	_, err := Open(context.Background(), repo, OpenOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate the primary ref")
+}
+
+func TestOpen_BuildsConfiguredMirror(t *testing.T) {
+	registerFakeMirrorBackend(t)
+	dir, repo, _ := newTestRepo(t)
+	t.Chdir(dir)
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"type": "`+fakeMirrorBackendType+`"}]}}`)
+
+	stores, err := Open(context.Background(), repo, OpenOptions{})
+	require.NoError(t, err)
+
+	// With a mirror configured the persistent store is the fan-out wrapper, not
+	// the raw git store, and it still exposes AuthorReader (git primary has it).
+	_, isGit := stores.Persistent.(*GitStore)
+	assert.False(t, isGit, "configured mirror should wrap the primary in a fan-out store")
+	_, isAuthor := stores.Persistent.(AuthorReader)
+	assert.True(t, isAuthor, "fan-out store should preserve the git primary's AuthorReader")
+}
+
+func TestOpen_InvalidCheckpointsBlockErrors(t *testing.T) {
+	dir, repo, _ := newTestRepo(t)
+	t.Chdir(dir)
+	// Present checkpoints block, but a mirror with no type is invalid.
+	writeRawSettings(t, dir, `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"config": {}}]}}`)
+
+	_, err := Open(context.Background(), repo, OpenOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checkpoints")
+}
+
+func TestOpen_ToleratesUnrelatedMalformedSettings(t *testing.T) {
+	dir, repo, _ := newTestRepo(t)
+	t.Chdir(dir)
+	// summary_generation is the wrong shape and the JSON has no checkpoints
+	// block: checkpoint construction must stay fail-soft and default to git.
+	writeRawSettings(t, dir, `{"enabled": true, "summary_generation": "not-an-object"}`)
+
+	stores, err := Open(context.Background(), repo, OpenOptions{})
+	require.NoError(t, err)
+	_, isGit := stores.Persistent.(*GitStore)
+	assert.True(t, isGit)
+}
+
+func TestOpen_ToleratesWholeFileSyntaxError(t *testing.T) {
+	dir, repo, _ := newTestRepo(t)
+	t.Chdir(dir)
+	writeRawSettings(t, dir, `{"enabled": true,,}`) // invalid JSON
+
+	stores, err := Open(context.Background(), repo, OpenOptions{})
+	require.NoError(t, err)
+	_, isGit := stores.Persistent.(*GitStore)
+	assert.True(t, isGit)
+}

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -461,7 +461,7 @@ func (s *GitStore) writeSessionToSubdirectory(ctx context.Context, opts WriteOpt
 		SessionMetrics:              opts.SessionMetrics,
 		Attribution:                 opts.Attribution,
 		PromptAttributions:          opts.PromptAttributionsJSON,
-		Summary:                     redactSummary(opts.Summary),
+		Summary:                     RedactSummary(opts.Summary),
 		CLIVersion:                  versioninfo.Version,
 		Kind:                        opts.Kind,
 		ReviewSkills:                opts.ReviewSkills,
@@ -924,11 +924,12 @@ func mergeFilesTouched(existing, additional []string) []string {
 	return result
 }
 
-// redactSummary returns a copy of the summary with text fields redacted.
-// Structural fields (Path, Line, EndLine) are preserved.
+// RedactSummary returns a copy of the summary with text fields redacted.
+// Structural fields (Path, Line, EndLine) are preserved. Exported so alternate
+// persistent backends redact summaries the same way the git store does.
 // NOTE: When adding new text fields to Summary, LearningsSummary, or CodeLearning,
 // update this function to include them in redaction.
-func redactSummary(s *Summary) *Summary {
+func RedactSummary(s *Summary) *Summary {
 	if s == nil {
 		return nil
 	}
@@ -1456,7 +1457,7 @@ func (s *GitStore) backfillSummary(ctx context.Context, checkpointID id.Checkpoi
 	}
 
 	// Update the summary
-	existingMetadata.Summary = redactSummary(summary)
+	existingMetadata.Summary = RedactSummary(summary)
 
 	// Write updated session metadata
 	metadataJSON, err := jsonutil.MarshalIndentWithNewline(existingMetadata, "", "  ")

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -424,7 +424,7 @@ func (s *GitStore) writeSessionToSubdirectory(ctx context.Context, opts WriteOpt
 	// Write prompts via the 7-layer pipeline. OPF runs only in the
 	// pre-push rewrite path (manual_commit_opf_rewrite.go).
 	if len(opts.Prompts) > 0 {
-		promptContent := redactedJoinedPrompts(opts.Prompts)
+		promptContent := RedactedJoinedPrompts(opts.Prompts)
 		blobHash, err := CreateBlobFromContent(s.repo, []byte(promptContent))
 		if err != nil {
 			return filePaths, err
@@ -1610,7 +1610,7 @@ func (s *GitStore) backfillTranscript(ctx context.Context, opts UpdateOptions) e
 
 	// Replace prompts with 7-layer-redacted content.
 	if len(opts.Prompts) > 0 {
-		promptContent := redactedJoinedPrompts(opts.Prompts)
+		promptContent := RedactedJoinedPrompts(opts.Prompts)
 		blobHash, err := CreateBlobFromContent(s.repo, []byte(promptContent))
 		if err != nil {
 			return fmt.Errorf("failed to create prompt blob: %w", err)

--- a/cmd/entire/cli/checkpoint/prompts.go
+++ b/cmd/entire/cli/checkpoint/prompts.go
@@ -28,9 +28,10 @@ func SplitPromptContent(content string) []string {
 	return prompts
 }
 
-// redactedJoinedPrompts joins prompts and runs the 7-layer redaction
+// RedactedJoinedPrompts joins prompts and runs the 7-layer redaction
 // pipeline. OPF runs exclusively in the pre-push rewrite (not here),
-// so the writer's hot path stays predictable.
-func redactedJoinedPrompts(prompts []string) string {
+// so the writer's hot path stays predictable. Exported so alternate
+// persistent backends produce identically-redacted prompt blobs.
+func RedactedJoinedPrompts(prompts []string) string {
 	return redact.String(strings.Join(prompts, PromptSeparator))
 }

--- a/cmd/entire/cli/checkpoint/prompts_test.go
+++ b/cmd/entire/cli/checkpoint/prompts_test.go
@@ -31,7 +31,7 @@ func TestSplitPromptContent_EmptyContent(t *testing.T) {
 // pipeline. OPF runs only in the pre-push rewrite path, never here.
 func TestRedactedJoinedPrompts_AppliesSafetyNet(t *testing.T) {
 	t.Parallel()
-	got := redactedJoinedPrompts([]string{"hello", "world"})
+	got := RedactedJoinedPrompts([]string{"hello", "world"})
 	assert.NotEmpty(t, got)
 	assert.Contains(t, got, PromptSeparator)
 }

--- a/cmd/entire/cli/checkpoint/registry.go
+++ b/cmd/entire/cli/checkpoint/registry.go
@@ -12,13 +12,15 @@ import (
 	"github.com/go-git/go-git/v6"
 )
 
-// BackendTypeGit is the built-in git checkpoint backend, registered in
-// production and used as the default primary when no backend is configured.
-const BackendTypeGit = "git"
+// BackendTypeGitBranch is the built-in git-branch checkpoint backend: it stores
+// the committed record on a git branch (entire/checkpoints/v1) in this repo. It
+// is git-backed (see registeredBackend.gitBacked) and is the default primary
+// when no backend is configured.
+const BackendTypeGitBranch = "git-branch"
 
-// OpenEnv carries the construction context a backend factory may need. The git
-// backend requires Repo and uses Refs/BlobFetcher; non-git backends ignore the
-// git-shaped fields and read their own configuration from the cfg block.
+// OpenEnv carries the construction context a backend factory may need.
+// Git-backed backends require Repo and use Refs/BlobFetcher; other backends
+// ignore the git-shaped fields and read their own configuration from cfg.
 type OpenEnv struct {
 	Repo        *git.Repository
 	BlobFetcher BlobFetchFunc
@@ -29,37 +31,65 @@ type OpenEnv struct {
 // backend-specific JSON "config" block from settings (nil when absent).
 type Factory func(ctx context.Context, env OpenEnv, cfg json.RawMessage) (PersistentStore, error)
 
+// registeredBackend is a factory plus the capabilities the topology layer needs.
+type registeredBackend struct {
+	factory Factory
+	// gitBacked reports whether the backend stores the committed record in this
+	// repo's git object store. Only git-backed backends may be the primary,
+	// because the checkpoint lifecycle (resume bootstrap, doctor reconcile,
+	// explain tree-read, push, cleanup, pre-push OPF) drives the primary's record
+	// through the repo and its refs — see buildPrimary. A backend that is not
+	// git-backed has no such ref for those paths to operate on, so it is
+	// mirror-only (write fan-out) until that lifecycle moves behind the store.
+	// Whether a backend may be a *mirror* is governed separately by the
+	// one-of-each-type topology rule in buildMirrors, not by this flag (a
+	// git-backed backend can mirror alongside a different git-backed primary).
+	gitBacked bool
+}
+
 var (
 	registryMu sync.RWMutex
-	// registry maps backend type to factory. The git backend is built in;
-	// test-only backends add themselves through their RegisterForTesting helpers
-	// so a production binary can never select them.
-	registry = map[string]Factory{BackendTypeGit: gitBackendFactory}
+	// registry maps backend type to its factory and capabilities. Git-backed
+	// backends are built in (registered here). Other backends add themselves
+	// through Register — in practice only test-only backends do, via their
+	// RegisterForTesting helpers, so a production binary can never select them.
+	registry = map[string]registeredBackend{
+		BackendTypeGitBranch: {factory: gitBranchBackendFactory, gitBacked: true},
+	}
 )
 
-// Register adds a backend factory under typ. It panics on a duplicate type to
-// surface wiring mistakes at init time. Production code registers only the git
-// backend; test-only backends register through their own RegisterForTesting
-// helpers so they can never be selected by a production binary.
+// Register adds a non-git-backed backend factory under typ. Such backends can
+// serve as mirrors but not as the primary (see registeredBackend.gitBacked).
+// Git-backed backends are built in and not registered through this path. It
+// panics on a duplicate type to surface wiring mistakes.
 func Register(typ string, f Factory) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 	if _, exists := registry[typ]; exists {
 		panic(fmt.Sprintf("checkpoint: backend type %q already registered", typ))
 	}
-	registry[typ] = f
+	registry[typ] = registeredBackend{factory: f, gitBacked: false}
 }
 
-// build constructs the store for the named backend type, returning a clear
-// error (naming the registered types) when the type is unknown.
-func build(ctx context.Context, env OpenEnv, typ string, cfg json.RawMessage) (PersistentStore, error) {
+// lookupBackend returns the registered backend for typ, or a clear error
+// (naming the registered types) when the type is unknown.
+func lookupBackend(typ string) (registeredBackend, error) {
 	registryMu.RLock()
-	f, ok := registry[typ]
+	b, ok := registry[typ]
 	registryMu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("unknown checkpoint backend type %q (registered: %s)", typ, registeredTypes())
+		return registeredBackend{}, fmt.Errorf("unknown checkpoint backend type %q (registered: %s)", typ, registeredTypes())
 	}
-	store, err := f(ctx, env, cfg)
+	return b, nil
+}
+
+// build constructs the store for the named backend type.
+func build(ctx context.Context, env OpenEnv, typ string, cfg json.RawMessage) (PersistentStore, error) {
+	b, err := lookupBackend(typ)
+	if err != nil {
+		return nil, err
+	}
+	store, err := b.factory(ctx, env, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("construct %q checkpoint backend: %w", typ, err)
 	}
@@ -77,11 +107,11 @@ func registeredTypes() string {
 	return strings.Join(types, ", ")
 }
 
-// gitBackendFactory builds the git-backed persistent store from the open
+// gitBranchBackendFactory builds the git-branch persistent store from the open
 // environment. It ignores cfg: git topology comes from env.Refs, not settings.
-func gitBackendFactory(_ context.Context, env OpenEnv, _ json.RawMessage) (PersistentStore, error) {
+func gitBranchBackendFactory(_ context.Context, env OpenEnv, _ json.RawMessage) (PersistentStore, error) {
 	if env.Repo == nil {
-		return nil, errors.New("git checkpoint backend requires a repository")
+		return nil, errors.New("git-branch checkpoint backend requires a repository")
 	}
 	store := NewGitStore(env.Repo, env.Refs)
 	if env.BlobFetcher != nil {

--- a/cmd/entire/cli/checkpoint/registry.go
+++ b/cmd/entire/cli/checkpoint/registry.go
@@ -1,0 +1,91 @@
+package checkpoint
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/go-git/go-git/v6"
+)
+
+// BackendTypeGit is the built-in git checkpoint backend, registered in
+// production and used as the default primary when no backend is configured.
+const BackendTypeGit = "git"
+
+// OpenEnv carries the construction context a backend factory may need. The git
+// backend requires Repo and uses Refs/BlobFetcher; non-git backends ignore the
+// git-shaped fields and read their own configuration from the cfg block.
+type OpenEnv struct {
+	Repo        *git.Repository
+	BlobFetcher BlobFetchFunc
+	Refs        PersistentRefs
+}
+
+// Factory constructs a persistent store for one backend type. cfg is the
+// backend-specific JSON "config" block from settings (nil when absent).
+type Factory func(ctx context.Context, env OpenEnv, cfg json.RawMessage) (PersistentStore, error)
+
+var (
+	registryMu sync.RWMutex
+	// registry maps backend type to factory. The git backend is built in;
+	// test-only backends add themselves through their RegisterForTesting helpers
+	// so a production binary can never select them.
+	registry = map[string]Factory{BackendTypeGit: gitBackendFactory}
+)
+
+// Register adds a backend factory under typ. It panics on a duplicate type to
+// surface wiring mistakes at init time. Production code registers only the git
+// backend; test-only backends register through their own RegisterForTesting
+// helpers so they can never be selected by a production binary.
+func Register(typ string, f Factory) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if _, exists := registry[typ]; exists {
+		panic(fmt.Sprintf("checkpoint: backend type %q already registered", typ))
+	}
+	registry[typ] = f
+}
+
+// build constructs the store for the named backend type, returning a clear
+// error (naming the registered types) when the type is unknown.
+func build(ctx context.Context, env OpenEnv, typ string, cfg json.RawMessage) (PersistentStore, error) {
+	registryMu.RLock()
+	f, ok := registry[typ]
+	registryMu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown checkpoint backend type %q (registered: %s)", typ, registeredTypes())
+	}
+	store, err := f(ctx, env, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("construct %q checkpoint backend: %w", typ, err)
+	}
+	return store, nil
+}
+
+func registeredTypes() string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	types := make([]string, 0, len(registry))
+	for t := range registry {
+		types = append(types, t)
+	}
+	sort.Strings(types)
+	return strings.Join(types, ", ")
+}
+
+// gitBackendFactory builds the git-backed persistent store from the open
+// environment. It ignores cfg: git topology comes from env.Refs, not settings.
+func gitBackendFactory(_ context.Context, env OpenEnv, _ json.RawMessage) (PersistentStore, error) {
+	if env.Repo == nil {
+		return nil, errors.New("git checkpoint backend requires a repository")
+	}
+	store := NewGitStore(env.Repo, env.Refs)
+	if env.BlobFetcher != nil {
+		store.SetBlobFetcher(env.BlobFetcher)
+	}
+	return store, nil
+}

--- a/cmd/entire/cli/checkpoint/registry_test.go
+++ b/cmd/entire/cli/checkpoint/registry_test.go
@@ -9,14 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegistry_GitBackendRegistered(t *testing.T) {
+func TestRegistry_GitBranchBackendRegistered(t *testing.T) {
 	t.Parallel()
 
-	_, err := build(context.Background(), OpenEnv{}, BackendTypeGit, nil)
-	// The git factory rejects a nil repo, which proves it is registered and
-	// reached (an unknown type would fail earlier with a different message).
+	_, err := build(context.Background(), OpenEnv{}, BackendTypeGitBranch, nil)
+	// The git-branch factory rejects a nil repo, which proves it is registered
+	// and reached (an unknown type would fail earlier with a different message).
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "git checkpoint backend requires a repository")
+	assert.Contains(t, err.Error(), "git-branch checkpoint backend requires a repository")
+}
+
+func TestRegistry_GitBranchIsGitBacked(t *testing.T) {
+	t.Parallel()
+
+	b, err := lookupBackend(BackendTypeGitBranch)
+	require.NoError(t, err)
+	assert.True(t, b.gitBacked, "git-branch backend must be git-backed so it can serve as the primary")
 }
 
 func TestRegistry_UnknownType(t *testing.T) {
@@ -26,15 +34,15 @@ func TestRegistry_UnknownType(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `unknown checkpoint backend type "definitely-not-a-backend"`)
 	// The error lists registered types so misconfiguration is debuggable.
-	assert.Contains(t, err.Error(), BackendTypeGit)
+	assert.Contains(t, err.Error(), BackendTypeGitBranch)
 }
 
-func TestRegistry_GitFactoryIgnoresConfig(t *testing.T) {
+func TestRegistry_GitBranchFactoryIgnoresConfig(t *testing.T) {
 	t.Parallel()
 
-	// A non-nil cfg block must not change the nil-repo rejection: the git
+	// A non-nil cfg block must not change the nil-repo rejection: the git-branch
 	// backend takes its topology from env.Refs, not from settings cfg.
-	_, err := build(context.Background(), OpenEnv{}, BackendTypeGit, json.RawMessage(`{"anything":true}`))
+	_, err := build(context.Background(), OpenEnv{}, BackendTypeGitBranch, json.RawMessage(`{"anything":true}`))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "git checkpoint backend requires a repository")
+	assert.Contains(t, err.Error(), "git-branch checkpoint backend requires a repository")
 }

--- a/cmd/entire/cli/checkpoint/registry_test.go
+++ b/cmd/entire/cli/checkpoint/registry_test.go
@@ -1,0 +1,40 @@
+package checkpoint
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_GitBackendRegistered(t *testing.T) {
+	t.Parallel()
+
+	_, err := build(context.Background(), OpenEnv{}, BackendTypeGit, nil)
+	// The git factory rejects a nil repo, which proves it is registered and
+	// reached (an unknown type would fail earlier with a different message).
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "git checkpoint backend requires a repository")
+}
+
+func TestRegistry_UnknownType(t *testing.T) {
+	t.Parallel()
+
+	_, err := build(context.Background(), OpenEnv{}, "definitely-not-a-backend", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown checkpoint backend type "definitely-not-a-backend"`)
+	// The error lists registered types so misconfiguration is debuggable.
+	assert.Contains(t, err.Error(), BackendTypeGit)
+}
+
+func TestRegistry_GitFactoryIgnoresConfig(t *testing.T) {
+	t.Parallel()
+
+	// A non-nil cfg block must not change the nil-repo rejection: the git
+	// backend takes its topology from env.Refs, not from settings cfg.
+	_, err := build(context.Background(), OpenEnv{}, BackendTypeGit, json.RawMessage(`{"anything":true}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "git checkpoint backend requires a repository")
+}

--- a/cmd/entire/cli/settings/checkpoints.go
+++ b/cmd/entire/cli/settings/checkpoints.go
@@ -6,11 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"log/slog"
-	"os"
-	"path/filepath"
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
@@ -114,32 +111,6 @@ func rawCheckpointsBlock(ctx context.Context, filePath string) json.RawMessage {
 		return nil
 	}
 	return env.Checkpoints
-}
-
-// readConfined reads filePath through an os.Root anchored at its parent
-// directory. The root confines the open to that directory, so the read cannot
-// be redirected outside it by a swapped or symlinked path between resolution and
-// open (TOCTOU) — unlike a bare os.ReadFile of an absolute path. A symlink that
-// escapes the directory surfaces as a non-ENOENT error, which the caller treats
-// as fail-soft.
-func readConfined(filePath string) ([]byte, error) {
-	root, err := os.OpenRoot(filepath.Dir(filePath))
-	if err != nil {
-		return nil, fmt.Errorf("open settings dir: %w", err)
-	}
-	defer root.Close()
-
-	f, err := root.Open(filepath.Base(filePath))
-	if err != nil {
-		return nil, fmt.Errorf("open settings file: %w", err)
-	}
-	defer f.Close()
-
-	data, err := io.ReadAll(f)
-	if err != nil {
-		return nil, fmt.Errorf("read settings file: %w", err)
-	}
-	return data, nil
 }
 
 func (c *CheckpointsConfig) validate() error {

--- a/cmd/entire/cli/settings/checkpoints.go
+++ b/cmd/entire/cli/settings/checkpoints.go
@@ -8,10 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
-	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
 // ErrInvalidCheckpointsConfig is returned when a present "checkpoints" settings
@@ -128,15 +126,7 @@ func (c *CheckpointsConfig) validate() error {
 // same way Load does (minus clone preferences, which carry no checkpoint config).
 func checkpointsSettingsPaths(ctx context.Context) (base, local string) {
 	if worktreeRoot, ok := worktreeRootFromContext(ctx); ok {
-		return filepath.Join(worktreeRoot, EntireSettingsFile), filepath.Join(worktreeRoot, EntireSettingsLocalFile)
+		return worktreeSettingsPaths(worktreeRoot)
 	}
-	base, err := paths.AbsPath(ctx, EntireSettingsFile)
-	if err != nil {
-		base = EntireSettingsFile
-	}
-	local, err = paths.AbsPath(ctx, EntireSettingsLocalFile)
-	if err != nil {
-		local = EntireSettingsLocalFile
-	}
-	return base, local
+	return settingsAbsPaths(ctx)
 }

--- a/cmd/entire/cli/settings/checkpoints.go
+++ b/cmd/entire/cli/settings/checkpoints.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
@@ -19,7 +22,7 @@ var ErrInvalidCheckpointsConfig = errors.New("invalid checkpoints config")
 // CheckpointsConfig selects checkpoint storage backends: one primary (source of
 // truth, serves all reads and writes) and zero or more mirrors (independent
 // backends that receive best-effort write fan-out). When absent, the checkpoint
-// layer defaults to the built-in git backend with no mirrors.
+// layer defaults to the built-in git-branch backend with no mirrors.
 type CheckpointsConfig struct {
 	Primary BackendConfig   `json:"primary"`
 	Mirrors []BackendConfig `json:"mirrors,omitempty"`
@@ -68,9 +71,14 @@ func LoadCheckpointsConfig(ctx context.Context) (*CheckpointsConfig, error) {
 
 	var cfg CheckpointsConfig
 	dec := json.NewDecoder(bytes.NewReader(raw))
+	// DisallowUnknownFields surfaces typos (e.g. "primry") instead of silently
+	// ignoring them. The trade-off is that this CLI is not forward-compatible
+	// with checkpoints fields added by a newer CLI: an unknown field errors here.
+	// Adding a field is therefore a coordinated rollout — ship the reader before
+	// any writer emits the field. The error below points users at that cause.
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("%w in %s: %w", ErrInvalidCheckpointsConfig, src, err)
+		return nil, fmt.Errorf("%w in %s: %w; an unrecognized field can also mean this file was written by a newer CLI — confirm you are on the latest version", ErrInvalidCheckpointsConfig, src, err)
 	}
 	if err := cfg.validate(); err != nil {
 		return nil, err
@@ -84,12 +92,13 @@ func LoadCheckpointsConfig(ctx context.Context) (*CheckpointsConfig, error) {
 // must not block checkpoint construction (the strict Load path surfaces it for
 // normal commands).
 func rawCheckpointsBlock(ctx context.Context, filePath string) json.RawMessage {
-	data, err := os.ReadFile(filePath) //nolint:gosec // path is from AbsPath or a worktree-root join
+	data, err := readConfined(filePath)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			// A non-ENOENT read error (bad perms, settings.json is a directory,
-			// etc.) is a broken setup; stay fail-soft so checkpoint construction
-			// defaults to git rather than newly failing resume/explain/hooks.
+		if !errors.Is(err, fs.ErrNotExist) {
+			// A non-ENOENT read error (bad perms, settings.json is a directory or
+			// an escaping symlink, etc.) is a broken/untrusted setup; stay
+			// fail-soft so checkpoint construction defaults to git rather than
+			// newly failing resume/explain/hooks.
 			logging.Debug(ctx, "checkpoints config unreadable; defaulting to git backend",
 				slog.String("path", filePath), slog.String("error", err.Error()))
 		}
@@ -105,6 +114,32 @@ func rawCheckpointsBlock(ctx context.Context, filePath string) json.RawMessage {
 		return nil
 	}
 	return env.Checkpoints
+}
+
+// readConfined reads filePath through an os.Root anchored at its parent
+// directory. The root confines the open to that directory, so the read cannot
+// be redirected outside it by a swapped or symlinked path between resolution and
+// open (TOCTOU) — unlike a bare os.ReadFile of an absolute path. A symlink that
+// escapes the directory surfaces as a non-ENOENT error, which the caller treats
+// as fail-soft.
+func readConfined(filePath string) ([]byte, error) {
+	root, err := os.OpenRoot(filepath.Dir(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("open settings dir: %w", err)
+	}
+	defer root.Close()
+
+	f, err := root.Open(filepath.Base(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("open settings file: %w", err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read settings file: %w", err)
+	}
+	return data, nil
 }
 
 func (c *CheckpointsConfig) validate() error {

--- a/cmd/entire/cli/settings/checkpoints.go
+++ b/cmd/entire/cli/settings/checkpoints.go
@@ -54,60 +54,57 @@ type checkpointsEnvelope struct {
 func LoadCheckpointsConfig(ctx context.Context) (*CheckpointsConfig, error) {
 	base, local := checkpointsSettingsPaths(ctx)
 
-	cfg, err := loadCheckpointsFromFile(ctx, base)
-	if err != nil {
+	// "local replaces base wholesale": prefer a checkpoints block from local
+	// settings; fall back to base only when local has none. We extract the raw
+	// blocks fail-soft, then decode/validate just the one that wins — so a
+	// malformed block in the overridden file never blocks the file that wins.
+	raw, src := rawCheckpointsBlock(ctx, local), local
+	if raw == nil {
+		raw, src = rawCheckpointsBlock(ctx, base), base
+	}
+	if raw == nil {
+		return nil, nil //nolint:nilnil // no checkpoints block present => default git backend
+	}
+
+	var cfg CheckpointsConfig
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("%w in %s: %w", ErrInvalidCheckpointsConfig, src, err)
+	}
+	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
-	if local != "" {
-		localCfg, err := loadCheckpointsFromFile(ctx, local)
-		if err != nil {
-			return nil, err
-		}
-		if localCfg != nil {
-			cfg = localCfg
-		}
-	}
-
-	if cfg != nil {
-		if err := cfg.validate(); err != nil {
-			return nil, err
-		}
-	}
-	return cfg, nil
+	return &cfg, nil
 }
 
-func loadCheckpointsFromFile(ctx context.Context, filePath string) (*CheckpointsConfig, error) {
+// rawCheckpointsBlock returns the raw "checkpoints" JSON block from filePath, or
+// nil when the file is absent/unreadable, has a whole-file syntax error, or has
+// no checkpoints block. It never errors: unrelated breakage in a settings file
+// must not block checkpoint construction (the strict Load path surfaces it for
+// normal commands).
+func rawCheckpointsBlock(ctx context.Context, filePath string) json.RawMessage {
 	data, err := os.ReadFile(filePath) //nolint:gosec // path is from AbsPath or a worktree-root join
 	if err != nil {
 		if !os.IsNotExist(err) {
 			// A non-ENOENT read error (bad perms, settings.json is a directory,
-			// etc.) is a broken setup that the strict Load path surfaces for
-			// normal commands. Stay fail-soft here so checkpoint construction
+			// etc.) is a broken setup; stay fail-soft so checkpoint construction
 			// defaults to git rather than newly failing resume/explain/hooks.
 			logging.Debug(ctx, "checkpoints config unreadable; defaulting to git backend",
 				slog.String("path", filePath), slog.String("error", err.Error()))
 		}
-		return nil, nil //nolint:nilnil // absent or unreadable file => no checkpoints config, fail-soft
+		return nil
 	}
 
 	var env checkpointsEnvelope
 	if err := json.Unmarshal(data, &env); err != nil {
-		// A whole-file parse failure is an unrelated breakage that the strict
-		// Load path surfaces for normal commands. Stay fail-soft here so
-		// checkpoint construction defaults to git rather than failing.
-		return nil, nil //nolint:nilnil,nilerr // intentionally fail-soft on unrelated malformed settings
+		// Whole-file parse failure is unrelated breakage; stay fail-soft.
+		return nil
 	}
 	if len(env.Checkpoints) == 0 {
-		return nil, nil //nolint:nilnil // no checkpoints block present
+		return nil
 	}
-
-	var cfg CheckpointsConfig
-	dec := json.NewDecoder(bytes.NewReader(env.Checkpoints))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("invalid checkpoints config in %s: %w", filePath, err)
-	}
-	return &cfg, nil
+	return env.Checkpoints
 }
 
 func (c *CheckpointsConfig) validate() error {

--- a/cmd/entire/cli/settings/checkpoints.go
+++ b/cmd/entire/cli/settings/checkpoints.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 )
 
@@ -54,12 +56,12 @@ type checkpointsEnvelope struct {
 func LoadCheckpointsConfig(ctx context.Context) (*CheckpointsConfig, error) {
 	base, local := checkpointsSettingsPaths(ctx)
 
-	cfg, err := loadCheckpointsFromFile(base)
+	cfg, err := loadCheckpointsFromFile(ctx, base)
 	if err != nil {
 		return nil, err
 	}
 	if local != "" {
-		localCfg, err := loadCheckpointsFromFile(local)
+		localCfg, err := loadCheckpointsFromFile(ctx, local)
 		if err != nil {
 			return nil, err
 		}
@@ -76,13 +78,18 @@ func LoadCheckpointsConfig(ctx context.Context) (*CheckpointsConfig, error) {
 	return cfg, nil
 }
 
-func loadCheckpointsFromFile(filePath string) (*CheckpointsConfig, error) {
+func loadCheckpointsFromFile(ctx context.Context, filePath string) (*CheckpointsConfig, error) {
 	data, err := os.ReadFile(filePath) //nolint:gosec // path is from AbsPath or a worktree-root join
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil //nolint:nilnil // absent file => no checkpoints config, not an error
+		if !os.IsNotExist(err) {
+			// A non-ENOENT read error (bad perms, settings.json is a directory,
+			// etc.) is a broken setup that the strict Load path surfaces for
+			// normal commands. Stay fail-soft here so checkpoint construction
+			// defaults to git rather than newly failing resume/explain/hooks.
+			logging.Debug(ctx, "checkpoints config unreadable; defaulting to git backend",
+				slog.String("path", filePath), slog.String("error", err.Error()))
 		}
-		return nil, fmt.Errorf("reading settings file %s: %w", filePath, err)
+		return nil, nil //nolint:nilnil // absent or unreadable file => no checkpoints config, fail-soft
 	}
 
 	var env checkpointsEnvelope

--- a/cmd/entire/cli/settings/checkpoints.go
+++ b/cmd/entire/cli/settings/checkpoints.go
@@ -1,0 +1,135 @@
+package settings
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// ErrInvalidCheckpointsConfig is returned when a present "checkpoints" settings
+// block is malformed (e.g. a backend with no type).
+var ErrInvalidCheckpointsConfig = errors.New("invalid checkpoints config")
+
+// CheckpointsConfig selects checkpoint storage backends: one primary (source of
+// truth, serves all reads and writes) and zero or more mirrors (independent
+// backends that receive best-effort write fan-out). When absent, the checkpoint
+// layer defaults to the built-in git backend with no mirrors.
+type CheckpointsConfig struct {
+	Primary BackendConfig   `json:"primary"`
+	Mirrors []BackendConfig `json:"mirrors,omitempty"`
+}
+
+// BackendConfig is a discriminated backend selector: Type names the registered
+// backend and Config carries the backend-specific options block (opaque here,
+// decoded by the backend factory).
+type BackendConfig struct {
+	Type   string          `json:"type"`
+	Config json.RawMessage `json:"config,omitempty"`
+}
+
+// checkpointsEnvelope extracts only the "checkpoints" key, leaving every other
+// settings field untouched so unrelated malformed/unknown settings cannot break
+// checkpoint backend resolution.
+type checkpointsEnvelope struct {
+	Checkpoints json.RawMessage `json:"checkpoints"`
+}
+
+// LoadCheckpointsConfig reads the checkpoint backend selection from settings
+// without the strict whole-settings validation that Load performs. It is
+// deliberately fail-soft: a missing settings file, a whole-file JSON syntax
+// error, or unrelated invalid fields all resolve to "no checkpoints config"
+// (nil), so checkpoint construction falls back to the default git backend. It
+// errors only when a "checkpoints" block is present but itself invalid.
+//
+// Precedence mirrors Load: a "checkpoints" block in settings.local.json
+// replaces the one in settings.json wholesale (this is a selection config, not
+// a deep-merged document). Clone preferences carry no checkpoint config and are
+// not consulted.
+func LoadCheckpointsConfig(ctx context.Context) (*CheckpointsConfig, error) {
+	base, local := checkpointsSettingsPaths(ctx)
+
+	cfg, err := loadCheckpointsFromFile(base)
+	if err != nil {
+		return nil, err
+	}
+	if local != "" {
+		localCfg, err := loadCheckpointsFromFile(local)
+		if err != nil {
+			return nil, err
+		}
+		if localCfg != nil {
+			cfg = localCfg
+		}
+	}
+
+	if cfg != nil {
+		if err := cfg.validate(); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}
+
+func loadCheckpointsFromFile(filePath string) (*CheckpointsConfig, error) {
+	data, err := os.ReadFile(filePath) //nolint:gosec // path is from AbsPath or a worktree-root join
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil //nolint:nilnil // absent file => no checkpoints config, not an error
+		}
+		return nil, fmt.Errorf("reading settings file %s: %w", filePath, err)
+	}
+
+	var env checkpointsEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		// A whole-file parse failure is an unrelated breakage that the strict
+		// Load path surfaces for normal commands. Stay fail-soft here so
+		// checkpoint construction defaults to git rather than failing.
+		return nil, nil //nolint:nilnil,nilerr // intentionally fail-soft on unrelated malformed settings
+	}
+	if len(env.Checkpoints) == 0 {
+		return nil, nil //nolint:nilnil // no checkpoints block present
+	}
+
+	var cfg CheckpointsConfig
+	dec := json.NewDecoder(bytes.NewReader(env.Checkpoints))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("invalid checkpoints config in %s: %w", filePath, err)
+	}
+	return &cfg, nil
+}
+
+func (c *CheckpointsConfig) validate() error {
+	if c.Primary.Type == "" {
+		return fmt.Errorf("%w: checkpoints.primary.type is required", ErrInvalidCheckpointsConfig)
+	}
+	for i, m := range c.Mirrors {
+		if m.Type == "" {
+			return fmt.Errorf("%w: checkpoints.mirrors[%d].type is required", ErrInvalidCheckpointsConfig, i)
+		}
+	}
+	return nil
+}
+
+// checkpointsSettingsPaths resolves the base and local settings file paths the
+// same way Load does (minus clone preferences, which carry no checkpoint config).
+func checkpointsSettingsPaths(ctx context.Context) (base, local string) {
+	if worktreeRoot, ok := worktreeRootFromContext(ctx); ok {
+		return filepath.Join(worktreeRoot, EntireSettingsFile), filepath.Join(worktreeRoot, EntireSettingsLocalFile)
+	}
+	base, err := paths.AbsPath(ctx, EntireSettingsFile)
+	if err != nil {
+		base = EntireSettingsFile
+	}
+	local, err = paths.AbsPath(ctx, EntireSettingsLocalFile)
+	if err != nil {
+		local = EntireSettingsLocalFile
+	}
+	return base, local
+}

--- a/cmd/entire/cli/settings/checkpoints_test.go
+++ b/cmd/entire/cli/settings/checkpoints_test.go
@@ -91,6 +91,19 @@ func TestLoadCheckpointsConfig_ToleratesWholeFileSyntaxError(t *testing.T) {
 	assert.Nil(t, cfg)
 }
 
+func TestLoadCheckpointsConfig_LocalOverridesInvalidBase(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	// Base has an invalid checkpoints block; local has a valid one. Since local
+	// replaces base wholesale, the base's invalidity must not block the load.
+	writeFile(t, dir, "settings.json", `{"enabled": true, "checkpoints": {"primary": {}}}`)
+	writeFile(t, dir, "settings.local.json", `{"checkpoints": {"primary": {"type": "git"}}}`)
+
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "git", cfg.Primary.Type)
+}
+
 func TestLoadCheckpointsConfig_ToleratesUnreadableFile(t *testing.T) {
 	dir := newCheckpointsSettingsRepo(t)
 	// settings.json as a directory makes os.ReadFile fail with a non-ENOENT

--- a/cmd/entire/cli/settings/checkpoints_test.go
+++ b/cmd/entire/cli/settings/checkpoints_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -102,6 +103,25 @@ func TestLoadCheckpointsConfig_LocalOverridesInvalidBase(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	assert.Equal(t, "git", cfg.Primary.Type)
+}
+
+func TestLoadCheckpointsConfig_RejectsEscapingSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privileges on Windows")
+	}
+	dir := newCheckpointsSettingsRepo(t)
+
+	// A valid checkpoints config that lives OUTSIDE the .entire directory.
+	outside := filepath.Join(t.TempDir(), "evil.json")
+	require.NoError(t, os.WriteFile(outside, []byte(`{"checkpoints": {"primary": {"type": "git-branch"}}}`), 0o644))
+	// Point .entire/settings.json at it via an (absolute) symlink that escapes
+	// the directory. The confined read must refuse to follow it, so the config
+	// is not picked up and we fail soft to the default.
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, ".entire", "settings.json")))
+
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, cfg, "an escaping symlink must not be followed; config should fail soft to nil")
 }
 
 func TestLoadCheckpointsConfig_ToleratesUnreadableFile(t *testing.T) {

--- a/cmd/entire/cli/settings/checkpoints_test.go
+++ b/cmd/entire/cli/settings/checkpoints_test.go
@@ -91,6 +91,16 @@ func TestLoadCheckpointsConfig_ToleratesWholeFileSyntaxError(t *testing.T) {
 	assert.Nil(t, cfg)
 }
 
+func TestLoadCheckpointsConfig_ToleratesUnreadableFile(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	// settings.json as a directory makes os.ReadFile fail with a non-ENOENT
+	// error; the loader must stay fail-soft (no new failure for Open).
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire", "settings.json"), 0o755))
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
 func TestLoadCheckpointsConfig_LocalOverridesBase(t *testing.T) {
 	dir := newCheckpointsSettingsRepo(t)
 	writeFile(t, dir, "settings.json", `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"type": "fs"}]}}`)

--- a/cmd/entire/cli/settings/checkpoints_test.go
+++ b/cmd/entire/cli/settings/checkpoints_test.go
@@ -1,0 +1,105 @@
+package settings
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCheckpointsSettingsRepo creates a tmp repo (with a .git dir so
+// paths.AbsPath resolves) and chdirs into it. Not parallel: uses t.Chdir.
+func newCheckpointsSettingsRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	t.Chdir(dir)
+	return dir
+}
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".entire", name), []byte(body), 0o644))
+}
+
+func TestLoadCheckpointsConfig_AbsentIsNil(t *testing.T) {
+	newCheckpointsSettingsRepo(t)
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestLoadCheckpointsConfig_NoBlockIsNil(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	writeFile(t, dir, "settings.json", `{"enabled": true}`)
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestLoadCheckpointsConfig_ParsesPrimaryAndMirrors(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	writeFile(t, dir, "settings.json", `{
+		"enabled": true,
+		"checkpoints": {
+			"primary": {"type": "git"},
+			"mirrors": [{"type": "fs", "config": {"path": "/tmp/x"}}]
+		}
+	}`)
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "git", cfg.Primary.Type)
+	require.Len(t, cfg.Mirrors, 1)
+	assert.Equal(t, "fs", cfg.Mirrors[0].Type)
+	assert.JSONEq(t, `{"path": "/tmp/x"}`, string(cfg.Mirrors[0].Config))
+}
+
+func TestLoadCheckpointsConfig_RejectsUnknownFieldInBlock(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	writeFile(t, dir, "settings.json", `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "bogus": 1}}`)
+	_, err := LoadCheckpointsConfig(context.Background())
+	require.Error(t, err)
+}
+
+func TestLoadCheckpointsConfig_InvalidWhenPrimaryTypeMissing(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	writeFile(t, dir, "settings.json", `{"enabled": true, "checkpoints": {"primary": {}}}`)
+	_, err := LoadCheckpointsConfig(context.Background())
+	require.ErrorIs(t, err, ErrInvalidCheckpointsConfig)
+}
+
+func TestLoadCheckpointsConfig_ToleratesUnrelatedMalformedSettings(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	// Unrelated field is the wrong shape and there is no checkpoints block:
+	// the loader must stay fail-soft and return nil rather than erroring.
+	writeFile(t, dir, "settings.json", `{"enabled": true, "summary_generation": "not-an-object"}`)
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestLoadCheckpointsConfig_ToleratesWholeFileSyntaxError(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	writeFile(t, dir, "settings.json", `{"enabled": true,,}`)
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
+}
+
+func TestLoadCheckpointsConfig_LocalOverridesBase(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	writeFile(t, dir, "settings.json", `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "mirrors": [{"type": "fs"}]}}`)
+	writeFile(t, dir, "settings.local.json", `{"checkpoints": {"primary": {"type": "git"}}}`)
+
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	// Local block replaces the base block wholesale, so the base's mirror is gone.
+	assert.Equal(t, "git", cfg.Primary.Type)
+	assert.Empty(t, cfg.Mirrors)
+}

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -377,11 +377,7 @@ func Load(ctx context.Context) (*EntireSettings, error) {
 		return loadForWorktreeRoot(ctx, worktreeRoot)
 	}
 
-	// Get absolute paths for settings files
-	settingsFileAbs, err := paths.AbsPath(ctx, EntireSettingsFile)
-	if err != nil {
-		settingsFileAbs = EntireSettingsFile // Fallback to relative
-	}
+	settingsFileAbs, localSettingsFileAbs := settingsAbsPaths(ctx)
 	preferencesFileAbs := ""
 	if path, prefErr := ClonePreferencesPath(ctx); prefErr == nil {
 		preferencesFileAbs = path
@@ -394,16 +390,33 @@ func Load(ctx context.Context) (*EntireSettings, error) {
 		logging.Debug(ctx, "clone preferences path unresolved; skipping preferences layer",
 			slog.String("error", prefErr.Error()))
 	}
-	localSettingsFileAbs, err := paths.AbsPath(ctx, EntireSettingsLocalFile)
-	if err != nil {
-		localSettingsFileAbs = EntireSettingsLocalFile // Fallback to relative
-	}
 
 	return loadMergedSettings(settingsFileAbs, preferencesFileAbs, localSettingsFileAbs)
 }
 
+// settingsAbsPaths resolves the base and local settings file paths relative to
+// the current working directory, falling back to the relative path when
+// absolute resolution fails.
+func settingsAbsPaths(ctx context.Context) (base, local string) {
+	base, err := paths.AbsPath(ctx, EntireSettingsFile)
+	if err != nil {
+		base = EntireSettingsFile // Fallback to relative
+	}
+	local, err = paths.AbsPath(ctx, EntireSettingsLocalFile)
+	if err != nil {
+		local = EntireSettingsLocalFile // Fallback to relative
+	}
+	return base, local
+}
+
+// worktreeSettingsPaths resolves the base and local settings file paths under
+// an explicit worktree root.
+func worktreeSettingsPaths(worktreeRoot string) (base, local string) {
+	return filepath.Join(worktreeRoot, EntireSettingsFile), filepath.Join(worktreeRoot, EntireSettingsLocalFile)
+}
+
 func loadForWorktreeRoot(ctx context.Context, worktreeRoot string) (*EntireSettings, error) {
-	settingsFileAbs := filepath.Join(worktreeRoot, EntireSettingsFile)
+	settingsFileAbs, localSettingsFileAbs := worktreeSettingsPaths(worktreeRoot)
 	preferencesFileAbs := ""
 	if path, prefErr := clonePreferencesPathForWorktreeRoot(ctx, worktreeRoot); prefErr == nil {
 		preferencesFileAbs = path
@@ -411,7 +424,6 @@ func loadForWorktreeRoot(ctx context.Context, worktreeRoot string) (*EntireSetti
 		logging.Debug(ctx, "clone preferences path unresolved; skipping preferences layer",
 			slog.String("error", prefErr.Error()))
 	}
-	localSettingsFileAbs := filepath.Join(worktreeRoot, EntireSettingsLocalFile)
 	return loadMergedSettings(settingsFileAbs, preferencesFileAbs, localSettingsFileAbs)
 }
 

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -7,7 +7,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -457,9 +460,9 @@ func loadMergedSettings(settingsFileAbs, preferencesFileAbs, localSettingsFileAb
 	}
 
 	// Apply local overrides if they exist
-	localData, err := os.ReadFile(localSettingsFileAbs) //nolint:gosec // path is from AbsPath or constant
+	localData, err := readConfined(localSettingsFileAbs)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("reading local settings file: %w", err)
 		}
 		// Local file doesn't exist, continue without overrides
@@ -506,9 +509,9 @@ func LoadProjectRaw(ctx context.Context) (path string, raw map[string]json.RawMe
 	if err != nil {
 		path = EntireSettingsFile
 	}
-	data, readErr := os.ReadFile(path) //nolint:gosec // path is from AbsPath or a project-relative constant
+	data, readErr := readConfined(path)
 	if readErr != nil {
-		if os.IsNotExist(readErr) {
+		if errors.Is(readErr, fs.ErrNotExist) {
 			return path, map[string]json.RawMessage{}, false, nil
 		}
 		return path, nil, false, fmt.Errorf("reading project settings: %w", readErr)
@@ -533,9 +536,9 @@ func LoadLocalRaw(ctx context.Context) (path string, raw map[string]json.RawMess
 	if err != nil {
 		path = EntireSettingsLocalFile
 	}
-	data, readErr := os.ReadFile(path) //nolint:gosec // path is from AbsPath or a project-relative constant
+	data, readErr := readConfined(path)
 	if readErr != nil {
-		if os.IsNotExist(readErr) {
+		if errors.Is(readErr, fs.ErrNotExist) {
 			return path, map[string]json.RawMessage{}, false, nil
 		}
 		return path, nil, false, fmt.Errorf("reading local settings: %w", readErr)
@@ -633,6 +636,33 @@ func LoadFromBytes(data []byte) (*EntireSettings, error) {
 	return s, nil
 }
 
+// readConfined reads filePath through an os.Root anchored at its parent
+// directory. The root confines the open to that directory, so the read cannot
+// be redirected outside it by a swapped or symlinked path between resolution and
+// open (TOCTOU) — unlike a bare os.ReadFile of an absolute path. A symlink that
+// escapes the directory surfaces as a non-ENOENT error. Callers must classify
+// "missing" with errors.Is(err, fs.ErrNotExist) rather than os.IsNotExist,
+// since the returned errors are wrapped.
+func readConfined(filePath string) ([]byte, error) {
+	root, err := os.OpenRoot(filepath.Dir(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("open settings dir: %w", err)
+	}
+	defer root.Close()
+
+	f, err := root.Open(filepath.Base(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("open settings file: %w", err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read settings file: %w", err)
+	}
+	return data, nil
+}
+
 // loadFromFile loads settings from a specific file path.
 // Returns default settings if the file doesn't exist.
 func loadFromFile(filePath string) (*EntireSettings, error) {
@@ -640,9 +670,9 @@ func loadFromFile(filePath string) (*EntireSettings, error) {
 		Enabled: true, // Default to enabled
 	}
 
-	data, err := os.ReadFile(filePath) //nolint:gosec // path is from caller
+	data, err := readConfined(filePath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return settings, nil
 		}
 		return nil, fmt.Errorf("%w", err)
@@ -675,9 +705,9 @@ func loadFromFile(filePath string) (*EntireSettings, error) {
 func loadClonePreferencesFromFile(filePath string) (*ClonePreferences, error) {
 	prefs := &ClonePreferences{}
 
-	data, err := os.ReadFile(filePath) //nolint:gosec // path is from caller
+	data, err := readConfined(filePath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return prefs, nil
 		}
 		return nil, fmt.Errorf("%w", err)

--- a/cmd/entire/cli/settings/settings.go
+++ b/cmd/entire/cli/settings/settings.go
@@ -127,6 +127,12 @@ type EntireSettings struct {
 	// nil/true = sign (default), false = skip signing.
 	SignCheckpointCommits *bool `json:"sign_checkpoint_commits,omitempty"`
 
+	// Checkpoints selects checkpoint storage backends (a primary plus optional
+	// write-only mirrors). checkpoint.Open consumes it via the lenient
+	// LoadCheckpointsConfig loader; the field also lives here so the strict
+	// settings loader (DisallowUnknownFields) accepts a "checkpoints" key.
+	Checkpoints *CheckpointsConfig `json:"checkpoints,omitempty"`
+
 	// Deprecated: no longer used. Exists to tolerate old settings files
 	// that still contain "strategy": "auto-commit" or similar.
 	Strategy string `json:"strategy,omitempty"`

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -113,8 +113,11 @@ func runTokensProfile(ctx context.Context, cmd *cobra.Command, jsonOutput bool, 
 	}
 	defer repo.Close()
 
-	store := checkpoint.NewGitStore(repo, checkpoint.ResolveRefs(ctx))
-	store.SetBlobFetcher(FetchBlobsByHash)
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	if err != nil {
+		return fmt.Errorf("failed to open checkpoint stores: %w", err)
+	}
+	store := stores.Persistent
 	infos, err := store.List(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to list checkpoints: %w", err)
@@ -132,7 +135,7 @@ func runTokensProfile(ctx context.Context, cmd *cobra.Command, jsonOutput bool, 
 	return nil
 }
 
-func buildTokensProfileReport(ctx context.Context, store *checkpoint.GitStore, infos []checkpoint.CheckpointInfo, limit int) (tokensProfileReport, error) {
+func buildTokensProfileReport(ctx context.Context, store checkpoint.PersistentStore, infos []checkpoint.CheckpointInfo, limit int) (tokensProfileReport, error) {
 	checkpointsAvailable := len(infos)
 	infos = limitTokensProfileCheckpoints(infos, limit)
 	report := tokensProfileReport{
@@ -192,7 +195,7 @@ func limitTokensProfileCheckpoints(infos []checkpoint.CheckpointInfo, limit int)
 	return infos[:limit]
 }
 
-func tokensProfileCheckpointUsage(ctx context.Context, store *checkpoint.GitStore, checkpointID id.CheckpointID, summary *checkpoint.CheckpointSummary) (*agent.TokenUsage, bool, error) {
+func tokensProfileCheckpointUsage(ctx context.Context, store checkpoint.PersistentStore, checkpointID id.CheckpointID, summary *checkpoint.CheckpointSummary) (*agent.TokenUsage, bool, error) {
 	if summary == nil {
 		return nil, false, nil
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/672
<!-- entire-trail-link-end -->

Implements **Phase 2 — topology + registry** of the pluggable checkpoint stores refactor (#1433). Phases 0–1 (the seam + `api/checkpoint` contract) already merged; this adds the factory, settings-driven backend selection, and independent-backend mirror fan-out.

Default config (no `checkpoints` block → the `git-branch` backend, no mirrors) is byte-identical to today.

## How it works

- **Backend registry** (`cmd/entire/cli/checkpoint/registry.go`): maps a backend type to a factory + capabilities. The built-in **`git-branch`** backend (stores the committed record on the `entire/checkpoints/v1` branch) is registered by default. Other backends register via `Register`; in practice only test-only backends do (through `RegisterForTesting`), so a production binary can't select them.
- **Settings** (`settings.LoadCheckpointsConfig`): a `checkpoints.{primary, mirrors}` block using a discriminated `{type, config}` shape, read through a **fail-soft** loader — a missing, unreadable, whole-file-malformed, or unrelated-broken settings file quietly falls back to the default backend; it errors only on an invalid `checkpoints` block. Local settings override base wholesale.
- **`checkpoint.Open`** builds the primary and mirrors through the registry. When mirrors are configured, the persistent store is a **fan-out wrapper**: all reads come from the primary; writes hit the primary first, then each mirror best-effort (failures logged, never surfaced). With no mirrors it returns the primary unwrapped, preserving its concrete type and optional `AuthorReader`.

## Two topology rules (the constraints, after review)

- **The primary must be a git-backed backend.** `gitBacked` is a declared capability: a backend whose committed record lives in this repo's git object store. The checkpoint lifecycle (resume bootstrap, doctor reconcile, explain tree-read, push, cleanup, pre-push OPF) drives the primary through the repo and its refs, so a non-git-backed primary is rejected rather than silently half-supported. (This relaxes once Phase 3 moves the lifecycle behind the store.)
- **At most one backend of each type** across primary + mirrors. Two backends of the same type share the same refs/storage today, so a `git-branch` mirror under a `git-branch` primary would double-write v1 — rejected. This deliberately *permits* a different git-backed backend (e.g. a future **`git-refs`**) to mirror alongside a `git-branch` primary, i.e. the branch↔refs **parallel-rollout** topology. A future per-mirror config (same type, distinct repo/refs) could relax it further.

## Reference backend (test-only)

`cmd/entire/cli/checkpoint/fsstore` — a filesystem/JSON implementation of the full `api/checkpoint` contract, registered only via `RegisterForTesting`. A seam integration test drives a `git-branch` primary + `fs` mirror through `Open` and asserts all four `WriteRequest` variants land in both backends while reads resolve from the primary. Serves as a worked example for a real backend.

## Supporting changes
- Route `tokens profile` through `checkpoint.Open` (was the one production path still constructing a store directly).
- Export `checkpoint.RedactedJoinedPrompts` / `RedactSummary` so alternate backends redact prompts and summaries identically to the git store.
- Extract shared settings-path helpers (`settingsAbsPaths`/`worktreeSettingsPaths`).
- benchutil keeps its direct constructor (documented bench fixture).

## Review
Reviewed by Codex twice (with a `/simplify` pass between) and by the PR bots; findings addressed — local-override loader bug (Cursor Bugbot), atomic-write reuse of `jsonutil.WriteFileAtomic` (Copilot), fail-soft settings reads, fsstore fidelity (CreatedAt/metadata/summary redaction), and the taxonomy reframe above.

## Out of scope (later phases)
- **Phase 3** — relocate push/fetch sync into the store; cleanup-delete + pre-push OPF fan-out to mirrors (mirrors are currently best-effort write-only and never a read/sync source without reconciliation); doctor mirror repair. This is also what unlocks a non-git-backed primary.
- de-gitting the `api/checkpoint` `plumbing.Hash` DTOs (needed by a real S3/gmeta backend).

## Testing
`mise run check` green: fmt, lint (0 issues), and the full CI suite (unit + integration + e2e canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)