### PR TITLE
README: mention tap trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ With Entire, you can:
 ## Quick Start
 
 ```bash
-# Install stable via Homebrew
+# To use Homebrew, first tap:
 brew tap entireio/tap
+brew trust entireio/tap
+
+# Install stable via Homebrew
 brew install --cask entire
 
 # Or install nightly via Homebrew
-brew tap entireio/tap
 brew install --cask entire@nightly
 
 # Or install stable via install.sh

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Entire currently ships two release channels:
 
 How to use each channel:
 
+- Homebrew (one-time setup): `brew tap entireio/tap && brew trust entireio/tap`
 - Homebrew stable: `brew install --cask entire`
 - Homebrew nightly: `brew install --cask entire@nightly`
 - `install.sh` stable: `curl -fsSL https://entire.io/install.sh | bash`


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/673
<!-- entire-trail-link-end -->

As of homebrew v6.0.0 or 5.2.0, casks and formulae from outside sources require a "trust" step.  Let's make onboarding smooth.

See: https://docs.brew.sh/Tap-Trust

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to install instructions; no code or runtime behavior is affected.
> 
> **Overview**
> Updates **Quick Start** Homebrew instructions for newer Homebrew versions that require trusting third-party taps before installing casks.
> 
> The flow now taps `entireio/tap`, runs **`brew trust entireio/tap`**, then installs stable or nightly—without repeating the tap before the nightly line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6338076ee3a49460615b04282f7a0dd84843e13. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->