### PR TITLE
feat(investigate): interactive `show --html` findings page + review fixes

### DIFF
--- a/cmd/entire/cli/investigate/bootstrap.go
+++ b/cmd/entire/cli/investigate/bootstrap.go
@@ -249,7 +249,17 @@ test output, or direct quotes. -->
 
 ## Conclusion
 
-<!-- Filled in once consensus is reached. Stop here. Recommendations and
-action items belong in a plan, not an investigation. -->
+<!-- Filled in once consensus is reached. Structure it as three bold lead-ins:
+
+**Question:** restate the question in one sentence.
+
+**Answer:** the root cause / conclusion, with the key evidence cited inline
+(file:line). This is the full explanation a reader needs.
+
+**Decisive code evidence:** the single most load-bearing proof — the exact
+file:line (and production signal, if any) that settles it.
+
+Stop here. Recommendations and action items belong in a plan, not an
+investigation. -->
 `, topic, createdISODate, question)
 }

--- a/cmd/entire/cli/investigate/browser.go
+++ b/cmd/entire/cli/investigate/browser.go
@@ -1,0 +1,44 @@
+package investigate
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
+)
+
+// openInBrowser opens a local file path in the user's default browser/viewer.
+//
+// Unlike login.go's openBrowser (which is HTTP-scheme-only), this accepts a
+// filesystem path so `investigate show --html` can launch the generated
+// findings.html. It no-ops under test so the suite never spawns a real
+// browser, and detaches the launched process so the CLI does not block on it.
+func openInBrowser(ctx context.Context, path string) error {
+	if interactive.UnderTest() {
+		return nil
+	}
+
+	var command string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		command, args = "open", []string{path}
+	case "linux":
+		command, args = "xdg-open", []string{path}
+	case "windows":
+		command, args = "cmd", []string{"/c", "start", "", path}
+	default:
+		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	}
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start viewer command %q: %w", command, err)
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return fmt.Errorf("release viewer process: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/investigate/browser_test.go
+++ b/cmd/entire/cli/investigate/browser_test.go
@@ -1,0 +1,16 @@
+package investigate
+
+import (
+	"context"
+	"testing"
+)
+
+func TestOpenInBrowser_NoOpUnderTest(t *testing.T) {
+	t.Parallel()
+
+	// Under test (testing.Testing() is true) the opener must not spawn a real
+	// browser; it returns nil so callers proceed normally.
+	if err := openInBrowser(context.Background(), "/tmp/findings.html"); err != nil {
+		t.Errorf("openInBrowser under test should no-op, got: %v", err)
+	}
+}

--- a/cmd/entire/cli/investigate/cmd.go
+++ b/cmd/entire/cli/investigate/cmd.go
@@ -70,6 +70,7 @@ type runFlags struct {
 	cont               string
 	edit               bool
 	findings           bool
+	all                bool
 	allowUntrustedSeed bool
 }
 
@@ -104,7 +105,9 @@ Flags:
   --quorum N              approvals needed to terminate (0 = all agents)
   --continue <run-id>     resume an existing run
   --edit                  re-open the investigate config picker
-  --findings              browse local investigation manifests
+  --findings              browse local investigation manifests (this worktree;
+                          add --all for every worktree)
+  --all                   with --findings, list runs from every worktree
   --allow-untrusted-seed  required to run a non-interactive --issue-link
                           investigation (otherwise refused: the seed is
                           attacker-influenced GitHub content and agents run
@@ -114,6 +117,7 @@ Subcommands:
   fix [run-id]            launch a coding agent with the run's findings as
                           grounded context
   show [run-id]           print a saved investigation's summary + findings
+                          (no run-id: this worktree's run; --all for any)
   clean [run-id|--all]    delete saved investigation artifacts`,
 		Args: func(_ *cobra.Command, args []string) error {
 			if len(args) > 1 {
@@ -137,6 +141,7 @@ Subcommands:
 	cmd.Flags().StringVar(&flags.cont, "continue", "", "resume an existing run by id")
 	cmd.Flags().BoolVar(&flags.edit, "edit", false, "re-open the investigate config picker")
 	cmd.Flags().BoolVar(&flags.findings, "findings", false, "browse local investigation manifests")
+	cmd.Flags().BoolVar(&flags.all, "all", false, "with --findings, list investigations from every worktree (default: this worktree only)")
 	cmd.Flags().BoolVar(&flags.allowUntrustedSeed, "allow-untrusted-seed", false,
 		"required to seed a non-interactive --issue-link run with attacker-influenced GitHub content")
 
@@ -236,7 +241,10 @@ func newFixSubcommand(deps Deps) *cobra.Command {
 
 // newShowSubcommand wires `entire investigate show [run-id]` to RunShow.
 func newShowSubcommand(deps Deps) *cobra.Command {
-	var asHTML bool
+	var (
+		asHTML  bool
+		showAll bool
+	)
 	cmd := &cobra.Command{
 		Use:   "show [run-id]",
 		Short: "Print a saved investigation's summary and findings",
@@ -248,7 +256,8 @@ func newShowSubcommand(deps Deps) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			if _, err := paths.WorktreeRoot(ctx); err != nil {
+			worktreeRoot, err := paths.WorktreeRoot(ctx)
+			if err != nil {
 				cmd.SilenceUsage = true
 				fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Run `entire enable` first.")
 				return wrapSilent(deps.NewSilentError, errors.New("not a git repository"))
@@ -262,15 +271,19 @@ func newShowSubcommand(deps Deps) *cobra.Command {
 				runID = args[0]
 			}
 			return RunShow(ctx, ShowInput{
-				RunID:  runID,
-				Out:    cmd.OutOrStdout(),
-				ErrOut: cmd.ErrOrStderr(),
-				HTML:   asHTML,
+				RunID:           runID,
+				Out:             cmd.OutOrStdout(),
+				ErrOut:          cmd.ErrOrStderr(),
+				HTML:            asHTML,
+				All:             showAll,
+				CurrentWorktree: worktreeRoot,
 			}, ShowDeps{ManifestStore: store})
 		},
 	}
 	cmd.Flags().BoolVar(&asHTML, "html", false,
 		"render findings to a styled HTML page and open it in the browser")
+	cmd.Flags().BoolVar(&showAll, "all", false,
+		"with no run id, consider investigations from every worktree (default: this worktree only)")
 	return cmd
 }
 
@@ -379,7 +392,7 @@ func runInvestigate(ctx context.Context, cmd *cobra.Command, args []string, f ru
 		return runEdit(ctx, cmd, deps)
 	}
 	if f.findings {
-		return runInvestigateFindings(ctx, cmd, silentErr)
+		return runInvestigateFindings(ctx, cmd, silentErr, f.all)
 	}
 	if strings.TrimSpace(f.cont) != "" {
 		return runContinue(ctx, cmd, f, deps)

--- a/cmd/entire/cli/investigate/cmd.go
+++ b/cmd/entire/cli/investigate/cmd.go
@@ -1087,14 +1087,17 @@ func writeInvestigateFooter(w io.Writer, m LocalManifest) {
 		fmt.Fprintln(w)
 	}
 
-	// For terminal outcomes, suggest `fix` (which feeds findings into a
-	// coding agent). For paused/cancelled, `fix` would launch off stale
-	// partial findings; the resume hint above is the right next step
-	// instead.
+	// For terminal outcomes, point at the HTML view first (read the findings
+	// in a browser), then suggest `fix` (which feeds findings into a coding
+	// agent). For paused/cancelled, `fix` would launch off stale partial
+	// findings; the resume hint above is the right next step instead.
 	switch m.Outcome {
 	case string(OutcomePaused), string(OutcomeCancelled):
 		// Resume hint already emitted above.
 	default:
+		fmt.Fprintln(w, "To view these findings in your browser:")
+		fmt.Fprintf(w, "  entire investigate show %s --html\n", m.RunID)
+		fmt.Fprintln(w)
 		fmt.Fprintln(w, "To apply these findings:")
 		fmt.Fprintf(w, "  entire investigate fix %s\n", m.RunID)
 	}

--- a/cmd/entire/cli/investigate/cmd.go
+++ b/cmd/entire/cli/investigate/cmd.go
@@ -236,7 +236,8 @@ func newFixSubcommand(deps Deps) *cobra.Command {
 
 // newShowSubcommand wires `entire investigate show [run-id]` to RunShow.
 func newShowSubcommand(deps Deps) *cobra.Command {
-	return &cobra.Command{
+	var asHTML bool
+	cmd := &cobra.Command{
 		Use:   "show [run-id]",
 		Short: "Print a saved investigation's summary and findings",
 		Args: func(_ *cobra.Command, args []string) error {
@@ -264,9 +265,13 @@ func newShowSubcommand(deps Deps) *cobra.Command {
 				RunID:  runID,
 				Out:    cmd.OutOrStdout(),
 				ErrOut: cmd.ErrOrStderr(),
+				HTML:   asHTML,
 			}, ShowDeps{ManifestStore: store})
 		},
 	}
+	cmd.Flags().BoolVar(&asHTML, "html", false,
+		"render findings to a styled HTML page and open it in the browser")
+	return cmd
 }
 
 // newCleanSubcommand wires `entire investigate clean [run-id]` to RunClean.

--- a/cmd/entire/cli/investigate/cmd_test.go
+++ b/cmd/entire/cli/investigate/cmd_test.go
@@ -265,6 +265,14 @@ func TestNewCommand_FreshRunWritesManifest(t *testing.T) {
 	if !strings.Contains(out.String(), "entire investigate fix") {
 		t.Errorf("expected fix hint in output, got:\n%s", out.String())
 	}
+	// ...and how to view the findings as HTML, shown before the fix hint.
+	htmlHint := "entire investigate show " + captured.RunID + " --html"
+	if !strings.Contains(out.String(), htmlHint) {
+		t.Errorf("expected HTML view hint %q in output, got:\n%s", htmlHint, out.String())
+	}
+	if strings.Index(out.String(), htmlHint) > strings.Index(out.String(), "entire investigate fix "+captured.RunID) {
+		t.Errorf("HTML view hint should appear before the fix hint, got:\n%s", out.String())
+	}
 	// Footer should embed the findings body (rendered via mdrender;
 	// out is a bytes.Buffer so mdrender falls back to raw markdown,
 	// and the scaffold's `# Investigation:` header is a stable anchor).

--- a/cmd/entire/cli/investigate/findings.go
+++ b/cmd/entire/cli/investigate/findings.go
@@ -15,9 +15,11 @@ import (
 
 // runInvestigateFindings handles `entire investigate --findings`: prints
 // a plain list of saved investigations with `entire investigate fix
-// <run-id>` hints.
-func runInvestigateFindings(ctx context.Context, cmd *cobra.Command, silentErr func(error) error) error {
-	if _, err := paths.WorktreeRoot(ctx); err != nil {
+// <run-id>` hints. By default the list is scoped to the current worktree;
+// all=true (the `--all` flag) lists investigations from every worktree.
+func runInvestigateFindings(ctx context.Context, cmd *cobra.Command, silentErr func(error) error, all bool) error {
+	worktreeRoot, err := paths.WorktreeRoot(ctx)
+	if err != nil {
 		cmd.SilenceUsage = true
 		fmt.Fprintln(cmd.ErrOrStderr(), "Not a git repository. Run `entire enable` first.")
 		return wrapSilent(silentErr, errors.New("not a git repository"))
@@ -34,9 +36,18 @@ func runInvestigateFindings(ctx context.Context, cmd *cobra.Command, silentErr f
 		fmt.Fprintln(cmd.OutOrStdout(), "No local investigations found.")
 		return nil
 	}
-	// Always print the full list — users reach for --findings to see all
-	// runs. The `fix:` hint per row gives them the next step.
-	printInvestigateFindingsList(cmd.OutOrStdout(), manifests)
+	// Default to this worktree's runs; `--all` widens to every worktree.
+	shown := manifests
+	if !all {
+		shown = FilterByWorktree(manifests, worktreeRoot)
+	}
+	if len(shown) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(),
+			"No investigations found for this worktree (%d across the repository). "+
+				"Re-run with `entire investigate --findings --all` to list them.\n", len(manifests))
+		return nil
+	}
+	printInvestigateFindingsList(cmd.OutOrStdout(), shown)
 	return nil
 }
 

--- a/cmd/entire/cli/investigate/flowchart/flowchart.go
+++ b/cmd/entire/cli/investigate/flowchart/flowchart.go
@@ -236,7 +236,11 @@ func parseNodeToken(s string) (id, label string, ok bool) {
 // the inner label text.
 func unwrapShape(shape string) string {
 	for _, pair := range []struct{ open, close string }{
-		{"[[", "]]"}, {"((", "))"}, {"[", "]"}, {"(", ")"}, {"{", "}"}, {">", "]"},
+		// Two-char wrappers first: subroutine [[ ]], circle (( )), cylinder
+		// [( )], and stadium ([ ]) must be matched before the single-char [ ]
+		// and ( ) pairs, or the inner bracket/paren leaks into the label.
+		{"[[", "]]"}, {"((", "))"}, {"[(", ")]"}, {"([", "])"},
+		{"[", "]"}, {"(", ")"}, {"{", "}"}, {">", "]"},
 	} {
 		if strings.HasPrefix(shape, pair.open) && strings.HasSuffix(shape, pair.close) {
 			return strings.TrimSuffix(strings.TrimPrefix(shape, pair.open), pair.close)

--- a/cmd/entire/cli/investigate/flowchart/flowchart.go
+++ b/cmd/entire/cli/investigate/flowchart/flowchart.go
@@ -38,11 +38,22 @@ type outEdge struct {
 	label string
 }
 
-// linkRe matches a Mermaid link operator with an optional `|label|`. The
-// surrounding whitespace is consumed so the text between matches is exactly
-// the node tokens. Inline-label syntax (`A -- text --> B`) is intentionally
-// unsupported and causes a parse failure → raw fallback.
-var linkRe = regexp.MustCompile(`\s*(?:-->|---|==>|===|-\.->|-\.-)\s*(?:\|"?([^|"]*)"?\|)?\s*`)
+// linkRe matches a Mermaid link operator with an optional label. The
+// surrounding whitespace is consumed so the text between matches is exactly the
+// node tokens. Two label forms are captured: the inline form (`-- text -->`) in
+// group 1, and the pipe form (`-->|text|`) in group 2.
+//
+// Supported operators: arrows of any length (`-->`, `---->`), thick (`==>`) and
+// dotted (`-.->`, `-..->`) arrows, alternate arrowheads (`--x`, `--o`), an
+// optional reverse head (`<-->`), and open/invisible links (`---`, `===`,
+// `~~~`). A bare `--` (two dashes, no head) is not a link, so it stays as label
+// text. Multi-edge `&` shorthand is still rejected upstream.
+var linkRe = regexp.MustCompile(`\s*(?:` +
+	`(?:-{2,}|={2,}|-\.+)\s*([^|>\s][^>|]*?)\s*(?:-{2,}|={2,}|\.+-)[>xo]` + // inline label (spaces optional)
+	`|` +
+	`(?:<?(?:-{2,}|={2,}|-\.+-|~{2,})[>xo]|-{3,}|={3,}|-\.+-|~{3,})` + // headed or open link
+	`(?:\s*\|\s*"?([^|"]*?)"?\s*\|)?` + // optional pipe label
+	`)\s*`)
 
 // nodeRe matches a single node token: an id followed by an optional shape
 // wrapper. We extract the id and the inner label regardless of shape.
@@ -158,8 +169,11 @@ func parseLine(line string) ([]nodeDecl, []outEdgeWithFrom, bool) {
 		}
 		tokens = append(tokens, nodeDecl{id, label})
 		el := ""
-		if loc[2] >= 0 {
+		switch {
+		case loc[2] >= 0: // inline label: `-- text -->`
 			el = cleanEdgeLabel(line[loc[2]:loc[3]])
+		case len(loc) >= 6 && loc[4] >= 0: // pipe label: `-->|text|`
+			el = cleanEdgeLabel(line[loc[4]:loc[5]])
 		}
 		edgeLabels = append(edgeLabels, el)
 		prev = loc[1]

--- a/cmd/entire/cli/investigate/flowchart/flowchart.go
+++ b/cmd/entire/cli/investigate/flowchart/flowchart.go
@@ -48,8 +48,18 @@ type outEdge struct {
 // optional reverse head (`<-->`), and open/invisible links (`---`, `===`,
 // `~~~`). A bare `--` (two dashes, no head) is not a link, so it stays as label
 // text. Multi-edge `&` shorthand is still rejected upstream.
+//
+// Inline labels (`-- text -->`) are recognized only when the arrow ends in a
+// `>` head, and the label may not contain node-shape delimiters (`[](){}`).
+// Both constraints prevent over-matching: without the `>`-only rule a chain of
+// `--x`/`--o` arrows (`A --x B --x C`) would treat the second arrowhead as a
+// label closer and swallow the middle node; without the delimiter exclusion a
+// node label that itself contains ` -- ` (`A[fetch -- retry] --> B`) would be
+// mistaken for an inline edge label. Inline labels on `--x`/`--o` arrows are
+// therefore unsupported (they fall back to raw source, losslessly); bare
+// `--x`/`--o` arrows without a label still render via the headed branch.
 var linkRe = regexp.MustCompile(`\s*(?:` +
-	`(?:-{2,}|={2,}|-\.+)\s*([^|>\s][^>|]*?)\s*(?:-{2,}|={2,}|\.+-)[>xo]` + // inline label (spaces optional)
+	`(?:-{2,}|={2,}|-\.+)\s*([^|>\s(){}\[\]][^>|(){}\[\]]*?)\s*(?:-{2,}|={2,}|\.+-)>` + // inline label (spaces optional)
 	`|` +
 	`(?:<?(?:-{2,}|={2,}|-\.+-|~{2,})[>xo]|-{3,}|={3,}|-\.+-|~{3,})` + // headed or open link
 	`(?:\s*\|\s*"?([^|"]*?)"?\s*\|)?` + // optional pipe label

--- a/cmd/entire/cli/investigate/flowchart/flowchart.go
+++ b/cmd/entire/cli/investigate/flowchart/flowchart.go
@@ -69,6 +69,13 @@ var linkRe = regexp.MustCompile(`\s*(?:` +
 // wrapper. We extract the id and the inner label regardless of shape.
 var nodeRe = regexp.MustCompile(`^([A-Za-z0-9_]+)\s*(\[\[.*\]\]|\(\(.*\)\)|\[.*\]|\(.*\)|\{.*\}|>.*\])?$`)
 
+// classSuffixRe matches a trailing Mermaid `:::class` inline class assignment
+// (`A:::dead`, `A["label"]:::dead`). It is styling we render transparently, so
+// the suffix is stripped before a token is parsed. Anchored to the end and
+// limited to a bare class identifier, so a `:::` inside a quoted label
+// (`A["a:::b"]`) is left intact.
+var classSuffixRe = regexp.MustCompile(`:::[A-Za-z0-9_]+$`)
+
 // headerRe matches the `flowchart`/`graph` declaration line.
 var headerRe = regexp.MustCompile(`^(?:flowchart|graph)\b`)
 
@@ -206,6 +213,9 @@ func parseLine(line string) ([]nodeDecl, []outEdgeWithFrom, bool) {
 // isn't a lone node reference.
 func parseNodeToken(s string) (id, label string, ok bool) {
 	s = strings.TrimSpace(s)
+	// Drop a trailing `:::class` inline class assignment — Mermaid styling we
+	// render transparently, like the classDef/class/style directives.
+	s = strings.TrimSpace(classSuffixRe.ReplaceAllString(s, ""))
 	m := nodeRe.FindStringSubmatch(s)
 	if m == nil {
 		return "", "", false

--- a/cmd/entire/cli/investigate/flowchart/flowchart_test.go
+++ b/cmd/entire/cli/investigate/flowchart/flowchart_test.go
@@ -95,6 +95,125 @@ func TestRender_RenderableTrees(t *testing.T) {
 	}
 }
 
+// Edge-syntax variants Mermaid accepts that must still render as boxes rather
+// than falling back to raw source.
+func TestRender_EdgeSyntaxVariants(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		src       string
+		wantOrder []string
+		wantSub   []string
+	}{
+		{
+			name:      "inline dashed label",
+			src:       "flowchart LR\n  A[Start] -- needs --> B[End]",
+			wantOrder: []string{"Start", "End"},
+			wantSub:   []string{"needs"},
+		},
+		{
+			name:      "inline thick label",
+			src:       "flowchart LR\n  A == build ==> B",
+			wantOrder: []string{"A", "B"},
+			wantSub:   []string{"build"},
+		},
+		{
+			name:      "inline dotted label",
+			src:       "flowchart LR\n  A -. maybe .-> B",
+			wantOrder: []string{"A", "B"},
+			wantSub:   []string{"maybe"},
+		},
+		{
+			name:      "long arrow",
+			src:       "flowchart LR\n  A ----> B",
+			wantOrder: []string{"A", "B"},
+		},
+		{
+			name:      "thick arrow",
+			src:       "flowchart LR\n  A ==> B",
+			wantOrder: []string{"A", "B"},
+		},
+		{
+			name:      "circle arrowhead",
+			src:       "flowchart LR\n  A --o B",
+			wantOrder: []string{"A", "B"},
+		},
+		{
+			name:      "cross arrowhead",
+			src:       "flowchart LR\n  A --x B",
+			wantOrder: []string{"A", "B"},
+		},
+		{
+			name:      "no spaces around arrow",
+			src:       "flowchart TD\n  A-->B-->C",
+			wantOrder: []string{"A", "B", "C"},
+		},
+		{
+			name:      "inline dotted label without spaces",
+			src:       "flowchart LR\n  A -.permanent: always 413.-> B",
+			wantOrder: []string{"A", "B"},
+			wantSub:   []string{"permanent: always 413"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, ok := Render(tc.src)
+			if !ok {
+				t.Fatalf("expected renderable, got ok=false for:\n%s", tc.src)
+			}
+			prev := -1
+			for _, label := range tc.wantOrder {
+				idx := strings.Index(out, label)
+				if idx < 0 {
+					t.Fatalf("label %q missing from output:\n%s", label, out)
+				}
+				if idx <= prev {
+					t.Errorf("label %q out of order:\n%s", label, out)
+				}
+				prev = idx
+			}
+			for _, sub := range tc.wantSub {
+				if !strings.Contains(out, sub) {
+					t.Errorf("expected %q in output:\n%s", sub, out)
+				}
+			}
+		})
+	}
+}
+
+// A real-world findings diagram: subgraph grouping, <br/> in labels, pipe
+// labels, a chained line, and a no-space inline dotted back-edge. Must render
+// as boxes, not fall back to raw source.
+func TestRender_RealFindingsDiagram(t *testing.T) {
+	t.Parallel()
+
+	src := "flowchart LR\n" +
+		"  subgraph nats[NATS JetStream]\n" +
+		"    Q[ref event msg]\n" +
+		"  end\n" +
+		"  Q --> W[consumer.worker<br/>consumer.go:102]\n" +
+		"  W --> PC[processCheckpoint<br/>handler.go:758]\n" +
+		"  PC -->|200 stream| OK[chunk + embed + upsert]\n" +
+		"  PC -->|413 oversized| ERR[APIError 413<br/>client.go:392-394]\n" +
+		"  ERR --> NA[IsAccessError=false<br/>access.go:14] --> RF[fetchFailed=true]\n" +
+		"  RF --> NAK[NakWithDelay, retry x7<br/>~17h backoff]\n" +
+		"  NAK -.permanent: always 413.-> W\n"
+
+	out, ok := Render(src)
+	if !ok {
+		t.Fatalf("expected renderable, got ok=false for real diagram")
+	}
+	for _, want := range []string{"ref event msg", "processCheckpoint", "200 stream", "permanent: always 413"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in rendered diagram:\n%s", want, out)
+		}
+	}
+}
+
 // A chain renders as boxes stacked top-down joined by ▼ arrows, one box per
 // node, in path order.
 func TestRender_VerticalFlow(t *testing.T) {

--- a/cmd/entire/cli/investigate/flowchart/flowchart_test.go
+++ b/cmd/entire/cli/investigate/flowchart/flowchart_test.go
@@ -56,6 +56,11 @@ func TestRender_RenderableTrees(t *testing.T) {
 			wantOrder: []string{"Producer", "Decision"},
 		},
 		{
+			name:      "cylinder and stadium shapes",
+			src:       "flowchart LR\n  A[(prompt.txt)] --> B([status])",
+			wantOrder: []string{"prompt.txt", "status"},
+		},
+		{
 			name:      "single node only",
 			src:       "flowchart LR\n  A[Solo]",
 			wantOrder: []string{"Solo"},
@@ -226,6 +231,25 @@ func TestRender_ChainedArrowheadsKeepEveryNode(t *testing.T) {
 		}
 		if got := strings.Count(out, "▼"); got != 2 {
 			t.Errorf("expected 2 arrows for a 3-node chain in %q, got %d:\n%s", src, got, out)
+		}
+	}
+}
+
+// Cylinder (`[(text)]`) and stadium (`([text])`) shape wrappers must be fully
+// unwrapped — their nested delimiters must not leak into the rendered label.
+func TestRender_CylinderAndStadiumUnwrapCleanly(t *testing.T) {
+	t.Parallel()
+
+	out, ok := Render("flowchart LR\n  A[(prompt.txt)] --> B([status check])")
+	if !ok {
+		t.Fatalf("expected renderable, got ok=false")
+	}
+	if !strings.Contains(out, "prompt.txt") || !strings.Contains(out, "status check") {
+		t.Fatalf("expected unwrapped labels, got:\n%s", out)
+	}
+	for _, leak := range []string{"(prompt.txt", "prompt.txt)", "([status", "status check])"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("shape delimiter leaked into label (%q) in:\n%s", leak, out)
 		}
 	}
 }

--- a/cmd/entire/cli/investigate/flowchart/flowchart_test.go
+++ b/cmd/entire/cli/investigate/flowchart/flowchart_test.go
@@ -150,6 +150,19 @@ func TestRender_EdgeSyntaxVariants(t *testing.T) {
 			wantOrder: []string{"A", "B", "C"},
 		},
 		{
+			// `:::class` inline class assignments are styling we render
+			// transparently — they must not force a raw fallback.
+			name:      "inline class assignment on a node",
+			src:       "flowchart LR\n  A[Start]:::dead --> B[End]\n  classDef dead stroke-dasharray: 5 5,color:#999;",
+			wantOrder: []string{"Start", "End"},
+		},
+		{
+			name:      "inline class assignment with a labelled edge and dotted arrow",
+			src:       "flowchart LR\n  A[\"x:::y kept\"]:::dead -.->|\"note\"| B[End]\n  classDef dead color:#999;",
+			wantOrder: []string{"x:::y kept", "End"},
+			wantSub:   []string{"note"},
+		},
+		{
 			// Regression: a node whose bracketed label contains ` -- ` must
 			// still render — the inline-label match must not reach inside the
 			// shape brackets and corrupt the node token.

--- a/cmd/entire/cli/investigate/flowchart/flowchart_test.go
+++ b/cmd/entire/cli/investigate/flowchart/flowchart_test.go
@@ -150,6 +150,14 @@ func TestRender_EdgeSyntaxVariants(t *testing.T) {
 			wantOrder: []string{"A", "B", "C"},
 		},
 		{
+			// Regression: a node whose bracketed label contains ` -- ` must
+			// still render — the inline-label match must not reach inside the
+			// shape brackets and corrupt the node token.
+			name:      "node label containing a double dash",
+			src:       "flowchart TD\n  A[fetch -- retry logic] --> B[done]",
+			wantOrder: []string{"fetch -- retry logic", "done"},
+		},
+		{
 			name:      "inline dotted label without spaces",
 			src:       "flowchart LR\n  A -.permanent: always 413.-> B",
 			wantOrder: []string{"A", "B"},
@@ -182,6 +190,30 @@ func TestRender_EdgeSyntaxVariants(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Regression: a chain of bare cross/circle arrowheads (`A --x B --x C`) must
+// render one box per node. The inline-label branch previously accepted the
+// second `--x` as its closing operator, swallowing the middle node B into a
+// bogus edge label and collapsing the chain to A → C.
+func TestRender_ChainedArrowheadsKeepEveryNode(t *testing.T) {
+	t.Parallel()
+
+	for _, src := range []string{
+		"flowchart LR\n  A --x B --x C",
+		"flowchart LR\n  A --o B --o C",
+	} {
+		out, ok := Render(src)
+		if !ok {
+			t.Fatalf("expected renderable, got ok=false for:\n%s", src)
+		}
+		if got := strings.Count(out, "┌"); got != 3 {
+			t.Errorf("expected 3 boxes (one per node) for %q, got %d:\n%s", src, got, out)
+		}
+		if got := strings.Count(out, "▼"); got != 2 {
+			t.Errorf("expected 2 arrows for a 3-node chain in %q, got %d:\n%s", src, got, out)
+		}
 	}
 }
 

--- a/cmd/entire/cli/investigate/html.go
+++ b/cmd/entire/cli/investigate/html.go
@@ -1,0 +1,1003 @@
+package investigate
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"html"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/yuin/goldmark"
+
+	"github.com/entireio/cli/cmd/entire/cli/investigate/flowchart"
+)
+
+// errNoFindingsContent signals that a manifest has no findings body to render —
+// neither embedded content nor a readable on-disk findings file. Callers map
+// this to the same soft "No findings content available" notice the terminal
+// `show` path emits, rather than treating it as a hard failure.
+var errNoFindingsContent = errors.New("investigate: no findings content")
+
+// wordsPerMinute is the assumed reading speed for the reading-time estimate.
+const wordsPerMinute = 200
+
+// pageDoc is the data assembled into the findings HTML page.
+type pageDoc struct {
+	Title    string
+	Intro    string // pre-rendered hero HTML
+	Content  string // pre-rendered section HTML
+	TOC      []tocEntry
+	Minutes  int
+	Sections int
+}
+
+// RenderFindingsHTML builds a self-contained, interactive HTML document from a
+// saved investigation's findings.
+//
+// Findings follow a fixed template (TLDR, Question, Prior work, Approach,
+// Findings, Conclusion, …). The renderer is template-aware: it splits the body
+// on the canonical section headings, folds the raw issue body and its noise
+// headings into a single section, drops sections that are empty (only authoring
+// comments), lifts the TLDR into the hero as a standfirst, and reorders so the
+// useful findings come first and process/context sections (Approach, Prior
+// work, the original issue) sink to the bottom. Findings with no recognizable
+// sections fall back to a straight markdown render.
+//
+// Markdown is converted with goldmark in default (safe) mode — raw HTML in
+// agent-authored findings is NOT passed through. Renderable Mermaid flowcharts
+// become Unicode box-outlines in <pre>. The page shows findings only (no agent
+// / outcome / stance metadata) and references no external assets. An empty body
+// returns errNoFindingsContent.
+func RenderFindingsHTML(m LocalManifest) (string, error) {
+	body := findingsBody(m)
+	if body == "" {
+		return "", errNoFindingsContent
+	}
+
+	// parseSections also strips the TLDR and Question sections; the TLDR is
+	// intentionally not surfaced (no hero standfirst).
+	secs := parseSections(body)
+
+	content, toc, err := renderSections(secs)
+	if err != nil {
+		return "", err
+	}
+	// Fallback: no recognizable sections → straight render of the whole body.
+	if content == "" {
+		generic, gerr := renderFindingsContent(body)
+		if gerr != nil {
+			return "", gerr
+		}
+		generic, toc = injectHeadingIDs(applyCallouts(generic))
+		content = generic
+	}
+
+	// Referenced files are their own collapsible section at the very bottom.
+	if files := extractFileRefs(body); len(files) > 0 {
+		fhtml, fentry := buildFilesSection(files)
+		content += fhtml
+		toc = append(toc, fentry)
+	}
+
+	doc := pageDoc{
+		Title:    m.Topic,
+		Intro:    buildIntro(m.Topic),
+		Content:  content,
+		TOC:      toc,
+		Minutes:  readingMinutes(body),
+		Sections: len(toc),
+	}
+	return assembleHTMLDoc(doc), nil
+}
+
+// buildFilesSection renders the referenced-files list as a collapsible section
+// for the bottom of the page, plus its table-of-contents entry. References are
+// grouped by file so each file appears once with its line numbers beside it.
+func buildFilesSection(refs []string) (string, tocEntry) {
+	groups := groupFileRefs(refs)
+	var b strings.Builder
+	b.WriteString(`<section class="sec"><h2 class="sec-h" id="referenced-files">Referenced files</h2><div class="sec-body"><ul class="file-list">`)
+	for _, g := range groups {
+		fmt.Fprintf(&b, `<li><span class="file-path">%s</span>`, html.EscapeString(g.path))
+		if len(g.lines) > 0 {
+			fmt.Fprintf(&b, ` <span class="file-lines">%s</span>`, html.EscapeString(strings.Join(g.lines, ", ")))
+		}
+		b.WriteString(`</li>`)
+	}
+	b.WriteString(`</ul></div></section>`)
+	return b.String(), tocEntry{Level: 2, Text: "Referenced files", ID: "referenced-files"}
+}
+
+// fileRef is one file path with the distinct line specs referenced in it.
+type fileRef struct {
+	path  string
+	lines []string
+}
+
+var lineSpecRe = regexp.MustCompile(`^\d+(-\d+)?$`)
+
+// groupFileRefs collapses raw `path:line` reference tokens into one entry per
+// file, with sorted unique line specs. A bare filename (no slash) is merged
+// into a full path when exactly one referenced path shares its basename, so
+// `handler.go` and `internal/handler/handler.go` become a single row.
+func groupFileRefs(refs []string) []fileRef {
+	lines := map[string]map[string]struct{}{}
+	add := func(p, line string) {
+		if lines[p] == nil {
+			lines[p] = map[string]struct{}{}
+		}
+		if line != "" {
+			lines[p][line] = struct{}{}
+		}
+	}
+	for _, r := range refs {
+		p, line := r, ""
+		if i := strings.LastIndex(r, ":"); i >= 0 && lineSpecRe.MatchString(r[i+1:]) {
+			p, line = r[:i], r[i+1:]
+		}
+		add(p, line)
+	}
+
+	for bare := range lines {
+		if strings.Contains(bare, "/") {
+			continue
+		}
+		match, n := "", 0
+		for full := range lines {
+			if full != bare && strings.Contains(full, "/") && path.Base(full) == bare {
+				match, n = full, n+1
+			}
+		}
+		if n == 1 {
+			for l := range lines[bare] {
+				lines[match][l] = struct{}{}
+			}
+			delete(lines, bare)
+		}
+	}
+
+	out := make([]fileRef, 0, len(lines))
+	for p, set := range lines {
+		ls := make([]string, 0, len(set))
+		for l := range set {
+			ls = append(ls, l)
+		}
+		sort.Slice(ls, func(i, j int) bool {
+			if a, b := leadingInt(ls[i]), leadingInt(ls[j]); a != b {
+				return a < b
+			}
+			return ls[i] < ls[j]
+		})
+		out = append(out, fileRef{path: p, lines: ls})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].path < out[j].path })
+	return out
+}
+
+// leadingInt parses the leading run of digits in s (0 if none).
+func leadingInt(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			break
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// orderedFindingsMarkdown rebuilds the findings markdown in the same shape the
+// HTML view uses, so the terminal `show` output matches it: the TLDR and the
+// raw-issue Question section are dropped, empty (comment-only) sections are
+// removed, sections are reordered (Conclusion first … Approach last), and a
+// Referenced files list is appended. Findings with no recognizable sections are
+// returned unchanged.
+func orderedFindingsMarkdown(body string) string {
+	secs := parseSections(body)
+	if len(secs) == 0 {
+		return body
+	}
+	var b strings.Builder
+	for _, s := range secs {
+		fmt.Fprintf(&b, "## %s\n\n%s\n\n", s.title, strings.TrimSpace(s.body.String()))
+	}
+	if files := extractFileRefs(body); len(files) > 0 {
+		b.WriteString("## Referenced files\n\n")
+		for _, g := range groupFileRefs(files) {
+			if len(g.lines) > 0 {
+				fmt.Fprintf(&b, "- `%s` %s\n", g.path, strings.Join(g.lines, ", "))
+			} else {
+				fmt.Fprintf(&b, "- `%s`\n", g.path)
+			}
+		}
+	}
+	return b.String()
+}
+
+// section is one parsed findings section: a canonical/slug key, its display
+// title, and the accumulated markdown body.
+type section struct {
+	key   string
+	title string
+	body  strings.Builder
+}
+
+// canonicalKeys maps a normalized section title to a stable key. Titles not in
+// this map keep their own slug key and sort into the middle by document order.
+var canonicalKeys = map[string]string{
+	"tldr": "tldr", "tl;dr": "tldr", "summary": "tldr",
+	"question":                   "question",
+	"prior work":                 "prior-work",
+	"system under investigation": "system",
+	"approach":                   "approach",
+	"findings":                   "findings",
+	"unknowns / assumptions":     "unknowns",
+	"unknowns":                   "unknowns",
+	"unknowns/assumptions":       "unknowns",
+	"assumptions":                "unknowns",
+	"conclusion":                 "conclusion",
+	"comments":                   "comments",
+}
+
+// sectionRank sets display order (lower = higher on the page). Conclusion
+// leads, then the supporting findings; process sections (prior work, approach)
+// sink to the bottom. Unknown sections take the middle rank and keep document
+// order via a stable sort. The Question (raw issue) section is dropped entirely
+// in parseSections.
+var sectionRank = map[string]int{
+	"conclusion": 5, "system": 10, "findings": 20, "unknowns": 40,
+	"comments": 65, "prior-work": 70, "approach": 80,
+}
+
+const unknownRank = 50
+
+var (
+	sectionHeadingRe = regexp.MustCompile(`^##[ \t]+(.+?)[ \t]*$`)
+	htmlCommentRe    = regexp.MustCompile(`(?s)<!--.*?-->`)
+)
+
+// parseSections splits the findings body into the template sections in display
+// order, dropping the TLDR and raw-issue Question sections and any empty
+// (comment-only) sections.
+//
+// Section boundaries are level-2 headings whose title matches a canonical
+// template section. Everything else — level-1/3 headings, the raw issue body
+// inside <untrusted> blocks, authoring comments — folds into the current
+// section's content, so the issue's own headings never pollute the outline.
+func parseSections(body string) []*section {
+	order := []*section{}
+	byKey := map[string]*section{}
+	// Content before the first canonical heading (scaffold title/metadata) lands
+	// in this preamble, which is never added to order and so is discarded.
+	preamble := &section{key: "__preamble__"}
+	cur := preamble
+
+	start := func(title string) {
+		key := canonicalKeyFor(title)
+		if s, ok := byKey[key]; ok {
+			s.body.WriteString("\n")
+			cur = s
+			return
+		}
+		s := &section{key: key, title: title}
+		byKey[key] = s
+		order = append(order, s)
+		cur = s
+	}
+
+	var inFence, inUntrusted, inComment bool
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		switch {
+		case inComment:
+			cur.body.WriteString(line + "\n")
+			if strings.Contains(line, "-->") {
+				inComment = false
+			}
+		case inUntrusted:
+			if strings.Contains(t, "</untrusted") {
+				inUntrusted = false
+			} else {
+				cur.body.WriteString(line + "\n")
+			}
+		case inFence:
+			cur.body.WriteString(line + "\n")
+			if strings.HasPrefix(t, "```") {
+				inFence = false
+			}
+		case strings.HasPrefix(t, "<untrusted"):
+			inUntrusted = true // drop the tag line itself
+		case strings.HasPrefix(t, "<!--") && !strings.Contains(t, "-->"):
+			inComment = true
+			cur.body.WriteString(line + "\n")
+		case strings.HasPrefix(t, "```"):
+			inFence = true
+			cur.body.WriteString(line + "\n")
+		case sectionHeadingRe.MatchString(line):
+			start(sectionHeadingRe.FindStringSubmatch(line)[1])
+		default:
+			cur.body.WriteString(line + "\n")
+		}
+	}
+
+	var secs []*section
+	for _, s := range order {
+		clean := strings.TrimSpace(htmlCommentRe.ReplaceAllString(s.body.String(), ""))
+		if clean == "" {
+			continue
+		}
+		// The TLDR and the raw-issue Question section are dropped entirely.
+		if s.key == "tldr" || s.key == "question" {
+			continue
+		}
+		s.body.Reset()
+		s.body.WriteString(clean)
+		secs = append(secs, s)
+	}
+
+	sort.SliceStable(secs, func(i, j int) bool {
+		return rankOf(secs[i].key) < rankOf(secs[j].key)
+	})
+	return secs
+}
+
+// canonicalKeyFor maps a section title to its canonical key, or a slug key for
+// unknown sections.
+func canonicalKeyFor(title string) string {
+	n := strings.ToLower(strings.TrimSpace(title))
+	n = strings.TrimRight(n, ":：")
+	n = strings.Join(strings.Fields(n), " ")
+	if k, ok := canonicalKeys[n]; ok {
+		return k
+	}
+	return "x:" + slugify(title)
+}
+
+func rankOf(key string) int {
+	if r, ok := sectionRank[key]; ok {
+		return r
+	}
+	return unknownRank
+}
+
+// renderSections renders each section to HTML and builds the table of contents.
+// Each section is a collapsible block with a slugged heading id.
+func renderSections(secs []*section) (string, []tocEntry, error) {
+	if len(secs) == 0 {
+		return "", nil, nil
+	}
+	seen := map[string]int{}
+	var content strings.Builder
+	var toc []tocEntry
+	for _, s := range secs {
+		inner, err := renderFindingsContent(s.body.String())
+		if err != nil {
+			return "", nil, err
+		}
+		inner = applyCallouts(inner)
+		id := uniqueSlug(s.title, seen)
+		toc = append(toc, tocEntry{Level: 2, Text: s.title, ID: id})
+		fmt.Fprintf(&content, `<section class="sec"><h2 class="sec-h" id=%q>%s</h2><div class="sec-body">%s</div></section>`,
+			id, html.EscapeString(s.title), inner)
+	}
+	return content.String(), toc, nil
+}
+
+// findingsMD is the shared goldmark renderer (default, safe config). Reused
+// across every section so a fresh parser/renderer isn't built per call.
+var findingsMD = goldmark.New()
+
+// renderFindingsContent converts markdown to HTML: prose through goldmark,
+// renderable Mermaid flowcharts as escaped box-outlines in <pre class="diagram">.
+func renderFindingsContent(body string) (string, error) {
+	var content strings.Builder
+	for _, seg := range flowchart.SplitRenderable(body) {
+		if seg.Diagram != "" {
+			content.WriteString(`<pre class="diagram">`)
+			content.WriteString(html.EscapeString(seg.Diagram))
+			content.WriteString("</pre>\n")
+			continue
+		}
+		var buf bytes.Buffer
+		if err := findingsMD.Convert([]byte(seg.Markdown), &buf); err != nil {
+			return "", fmt.Errorf("render findings markdown: %w", err)
+		}
+		content.Write(buf.Bytes())
+	}
+	return content.String(), nil
+}
+
+// buildIntro renders the hero: an eyebrow and the prompt as the question.
+// Returns "" when there is no prompt.
+func buildIntro(topic string) string {
+	if strings.TrimSpace(topic) == "" {
+		return ""
+	}
+	return `<section class="intro"><p class="eyebrow">Investigated</p>` +
+		fmt.Sprintf(`<h1 class="intro-q">%s</h1>`, html.EscapeString(topic)) +
+		`</section>`
+}
+
+// tocEntry is one heading in the generated table of contents.
+type tocEntry struct {
+	Level int
+	Text  string
+	ID    string
+}
+
+var (
+	headingRe = regexp.MustCompile(`(?s)<h([1-6])>(.*?)</h[1-6]>`)
+	tagRe     = regexp.MustCompile(`<[^>]+>`)
+)
+
+// injectHeadingIDs adds a unique slug id to every heading in content and
+// returns the rewritten content plus the table-of-contents entries in document
+// order. Used only by the fallback (no recognizable sections) path.
+func injectHeadingIDs(content string) (string, []tocEntry) {
+	seen := map[string]int{}
+	var toc []tocEntry
+	out := headingRe.ReplaceAllStringFunc(content, func(match string) string {
+		sub := headingRe.FindStringSubmatch(match)
+		level := int(sub[1][0] - '0')
+		inner := sub[2]
+		label := html.UnescapeString(strings.TrimSpace(tagRe.ReplaceAllString(inner, "")))
+		id := uniqueSlug(label, seen)
+		toc = append(toc, tocEntry{Level: level, Text: label, ID: id})
+		return fmt.Sprintf("<h%d id=%q>%s</h%d>", level, id, inner, level)
+	})
+	return out, toc
+}
+
+// uniqueSlug returns a URL-fragment-safe slug for text, disambiguating repeats
+// with a numeric suffix so every id is unique within the document.
+func uniqueSlug(text string, seen map[string]int) string {
+	base := slugify(text)
+	if base == "" {
+		base = "section"
+	}
+	n := seen[base]
+	seen[base]++
+	if n == 0 {
+		return base
+	}
+	return fmt.Sprintf("%s-%d", base, n)
+}
+
+// slugify lowercases text and collapses every run of non-alphanumeric
+// characters into a single hyphen, trimming leading/trailing hyphens. Shares
+// the package's slugRE with SlugifyTopic (which adds a length cap + fallback).
+func slugify(text string) string {
+	return strings.Trim(slugRE.ReplaceAllString(strings.ToLower(text), "-"), "-")
+}
+
+var (
+	codeSpanRe = regexp.MustCompile("`([^`\n]+)`")
+	fileLikeRe = regexp.MustCompile(`^[\w@~][\w./@+-]*\.[A-Za-z][A-Za-z0-9]{0,5}(:\d+(-\d+)?)?$`)
+	bareRefRe  = regexp.MustCompile(`[\w./~@-]+\.[A-Za-z]{1,6}:\d+(-\d+)?`)
+)
+
+// knownFileExt is the set of extensions that mark a dotted token as a file even
+// when it has no directory, so identifiers like `consumer.worker` or
+// `h.poller.Poll` are not mistaken for files.
+var knownFileExt = map[string]bool{
+	"go": true, "mod": true, "sum": true, "ts": true, "tsx": true, "js": true,
+	"jsx": true, "mjs": true, "cjs": true, "py": true, "rb": true, "rs": true,
+	"java": true, "kt": true, "c": true, "h": true, "cc": true, "cpp": true,
+	"hpp": true, "cs": true, "php": true, "swift": true, "scala": true,
+	"sql": true, "proto": true, "graphql": true, "gql": true, "sh": true,
+	"bash": true, "zsh": true, "ps1": true, "yaml": true, "yml": true,
+	"json": true, "toml": true, "ini": true, "cfg": true, "conf": true,
+	"env": true, "md": true, "mdx": true, "txt": true, "html": true,
+	"css": true, "scss": true, "xml": true, "svg": true, "lock": true,
+	"gradle": true, "tf": true, "tfvars": true, "dockerfile": true,
+}
+
+// looksLikeFile reports whether tok is a file reference: a path (contains a
+// slash) or a dotted name with a recognized file extension. A trailing
+// `:line` / `:start-end` is ignored.
+func looksLikeFile(tok string) bool {
+	if !fileLikeRe.MatchString(tok) {
+		return false
+	}
+	if strings.Contains(tok, "/") {
+		return true
+	}
+	base := tok
+	if i := strings.LastIndex(base, ":"); i >= 0 && lineSpecRe.MatchString(base[i+1:]) {
+		base = base[:i]
+	}
+	ext := base[strings.LastIndex(base, ".")+1:]
+	return knownFileExt[strings.ToLower(ext)]
+}
+
+// extractFileRefs scans the findings body for file-path references — code spans
+// that look like paths and bare `path.ext:line` mentions — returning a sorted,
+// deduplicated list for the "Referenced files" section.
+func extractFileRefs(body string) []string {
+	set := map[string]struct{}{}
+	for _, m := range codeSpanRe.FindAllStringSubmatch(body, -1) {
+		tok := strings.TrimSpace(m[1])
+		if looksLikeFile(tok) {
+			set[tok] = struct{}{}
+		}
+	}
+	for _, tok := range bareRefRe.FindAllString(body, -1) {
+		if looksLikeFile(tok) {
+			set[tok] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for tok := range set {
+		out = append(out, tok)
+	}
+	sort.Strings(out)
+	return out
+}
+
+var (
+	alertRe   = regexp.MustCompile(`(?is)<blockquote>\s*<p>\s*\[!(note|tip|important|warning|caution)\]\s*(.*?)</blockquote>`)
+	leadInRe  = regexp.MustCompile(`(?i)<p>(<strong>(root cause|evidence|fix|conclusion|hypothesis|recommendation|impact|note|warning|caution|tip|important)[:：]</strong>)`)
+	calloutSv = map[string]string{
+		"warning": "warning", "caution": "warning", "impact": "warning",
+		"fix": "success", "recommendation": "success", "conclusion": "success",
+	}
+)
+
+func calloutSeverity(kind string) string {
+	if s, ok := calloutSv[strings.ToLower(kind)]; ok {
+		return s
+	}
+	return "info"
+}
+
+// applyCallouts rewrites GitHub-style alert blockquotes (`> [!WARNING]`) and
+// bold lead-in paragraphs (`**Fix:** …`) into styled callout boxes.
+func applyCallouts(content string) string {
+	content = alertRe.ReplaceAllStringFunc(content, func(match string) string {
+		sub := alertRe.FindStringSubmatch(match)
+		kind := strings.ToLower(sub[1])
+		title := strings.ToUpper(kind[:1]) + kind[1:]
+		return fmt.Sprintf(
+			`<div class="callout callout-%s"><p class="callout-title">%s</p><p>%s</div>`,
+			calloutSeverity(kind), title, sub[2])
+	})
+	content = leadInRe.ReplaceAllStringFunc(content, func(match string) string {
+		sub := leadInRe.FindStringSubmatch(match)
+		return fmt.Sprintf(`<p class="callout callout-%s">%s`, calloutSeverity(sub[2]), sub[1])
+	})
+	return content
+}
+
+// readingMinutes estimates reading time from the body word count (min 1).
+func readingMinutes(body string) int {
+	m := (len(strings.Fields(body)) + wordsPerMinute - 1) / wordsPerMinute
+	if m < 1 {
+		return 1
+	}
+	return m
+}
+
+// buildSidebar renders the table-of-contents navigation. Returns "" when there
+// are no entries (single-column layout).
+func buildSidebar(toc []tocEntry) string {
+	if len(toc) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(`<aside class="sidebar"><nav class="toc" aria-label="Findings contents"><div class="panel-title">Contents</div>`)
+	for _, e := range toc {
+		fmt.Fprintf(&b, `<a class="toc-link lvl-%d" href="#%s">%s</a>`,
+			e.Level, e.ID, html.EscapeString(e.Text))
+	}
+	b.WriteString(`</nav></aside>`)
+	return b.String()
+}
+
+// assembleHTMLDoc wraps the rendered findings in the full interactive page.
+func assembleHTMLDoc(d pageDoc) string {
+	title := d.Title
+	if title == "" {
+		title = "Investigation findings"
+	}
+	escTitle := html.EscapeString(title)
+	sidebar := buildSidebar(d.TOC)
+	layoutClass := "layout"
+	if sidebar == "" {
+		layoutClass = "layout no-sidebar"
+	}
+
+	var b strings.Builder
+	b.WriteString("<!doctype html>\n<html lang=\"en\">\n<head>\n")
+	b.WriteString(`<meta charset="utf-8">` + "\n")
+	b.WriteString(`<meta name="viewport" content="width=device-width, initial-scale=1">` + "\n")
+	fmt.Fprintf(&b, "<title>%s</title>\n", escTitle)
+	b.WriteString("<style>\n" + findingsCSS + "</style>\n")
+	b.WriteString("</head>\n<body>\n")
+
+	b.WriteString(`<header class="topbar">`)
+	fmt.Fprintf(&b, `<span class="doc-title" title=%q>%s</span>`, escTitle, escTitle)
+	fmt.Fprintf(&b, `<span class="stats">%d min read · %s</span>`, d.Minutes, sectionLabel(d.Sections))
+	b.WriteString(`<div class="controls">`)
+	b.WriteString(`<input type="search" id="filter" placeholder="Filter findings…" aria-label="Filter findings" autocomplete="off">`)
+	b.WriteString(`<button type="button" data-print aria-label="Print or save as PDF" title="Print / save as PDF">⎙</button>`)
+	b.WriteString(`<button type="button" data-theme-toggle aria-label="Switch colour theme" title="Switch colour theme">●</button>`)
+	b.WriteString(`</div></header>`)
+
+	fmt.Fprintf(&b, `<div class="%s">`, layoutClass)
+	b.WriteString(sidebar)
+	b.WriteString(`<main class="findings" id="findings-root">` + "\n")
+	b.WriteString(d.Intro)
+	b.WriteString(d.Content)
+	b.WriteString("\n</main></div>\n")
+	b.WriteString(`<p class="empty-hint" id="empty-hint" hidden>No findings match your filter.</p>` + "\n")
+	b.WriteString(`<button type="button" id="to-top" aria-label="Back to top" title="Back to top" hidden>↑</button>` + "\n")
+
+	b.WriteString("<script>\n" + findingsJS + "</script>\n")
+	b.WriteString("</body>\n</html>\n")
+	return b.String()
+}
+
+func sectionLabel(n int) string {
+	if n == 1 {
+		return "1 section"
+	}
+	return fmt.Sprintf("%d sections", n)
+}
+
+// findingsCSS is the inline stylesheet for the generated page. Self-contained
+// (no @import, no external fonts) so the document renders offline.
+const findingsCSS = `
+:root {
+  --bg: #fbfcfd; --fg: #1b2330; --muted: #5b6675; --muted-strong: #3a4452;
+  --border: #e4e8ef; --rule: #eef1f5; --surface: #f3f6fa; --surface-2: #eaeef4;
+  --accent: #4f46e5; --accent-soft: #ecebfd;
+  --mark: #ffe89a; --shadow: rgba(27,35,48,0.07);
+  --info: #4f46e5; --info-bg: #f1f0fe; --warn: #9a6700; --warn-bg: #fdf6d8;
+  --ok: #1a7f4b; --ok-bg: #e6f6ed;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+[data-theme="dark"] {
+  --bg: #0f1216; --fg: #dce3ec; --muted: #8b95a4; --muted-strong: #aab4c2;
+  --border: #262d38; --rule: #1c222b; --surface: #171c23; --surface-2: #1f262f;
+  --accent: #8b85f5; --accent-soft: #211f3a;
+  --mark: #5c4a00; --shadow: rgba(0,0,0,0.45);
+  --info: #8b85f5; --info-bg: #1a1830; --warn: #d8b34a; --warn-bg: #2a2206;
+  --ok: #46c07e; --ok-bg: #0e2618;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #0f1216; --fg: #dce3ec; --muted: #8b95a4; --muted-strong: #aab4c2;
+    --border: #262d38; --rule: #1c222b; --surface: #171c23; --surface-2: #1f262f;
+    --accent: #8b85f5; --accent-soft: #211f3a;
+    --mark: #5c4a00; --shadow: rgba(0,0,0,0.45);
+    --info: #8b85f5; --info-bg: #1a1830; --warn: #d8b34a; --warn-bg: #2a2206;
+    --ok: #46c07e; --ok-bg: #0e2618;
+  }
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0; color: var(--fg); background: var(--bg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 17px; line-height: 1.72; -webkit-font-smoothing: antialiased;
+}
+.eyebrow, .panel-title, .stats, .callout-title, .doc-title {
+  font-family: var(--mono); text-transform: uppercase; letter-spacing: 0.11em;
+}
+.topbar {
+  position: sticky; top: 0; z-index: 20;
+  display: flex; align-items: center; gap: 1rem;
+  padding: 0.65rem 1.5rem;
+  background: color-mix(in srgb, var(--bg) 86%, transparent);
+  backdrop-filter: saturate(150%) blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+.doc-title {
+  font-size: 0.78rem; font-weight: 600; color: var(--muted);
+  margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; flex: 1;
+}
+.stats { color: var(--muted); font-size: 0.66rem; white-space: nowrap; }
+.controls { display: flex; align-items: center; gap: 0.5rem; }
+#filter {
+  width: 13rem; max-width: 34vw;
+  padding: 0.4rem 0.8rem; border: 1px solid var(--border); border-radius: 8px;
+  background: var(--bg); color: var(--fg); font-size: 0.85rem;
+}
+#filter:focus { outline: 2px solid var(--accent); outline-offset: 0; border-color: transparent; }
+[data-print], [data-theme-toggle] {
+  width: 2rem; height: 2rem; border-radius: 8px; cursor: pointer;
+  border: 1px solid var(--border); background: var(--bg); color: var(--muted);
+  font-size: 0.85rem; line-height: 1;
+}
+[data-print]:hover, [data-theme-toggle]:hover { color: var(--accent); border-color: var(--accent); }
+.layout {
+  display: grid; grid-template-columns: minmax(180px, 230px) minmax(0, 1fr);
+  gap: 3.5rem; max-width: 1080px; margin: 0 auto; padding: 3rem 2rem 7rem;
+}
+.layout.no-sidebar { grid-template-columns: minmax(0, 46rem); justify-content: center; }
+.sidebar { position: sticky; top: 4.5rem; align-self: start; max-height: calc(100vh - 6rem); overflow-y: auto; }
+.panel-title { font-size: 0.66rem; color: var(--muted); margin-bottom: 0.7rem; font-weight: 600; }
+.toc { display: flex; flex-direction: column; gap: 0.05rem; font-size: 0.86rem; line-height: 1.4; }
+.toc-link {
+  color: var(--muted); text-decoration: none; padding: 0.28rem 0.7rem;
+  border-left: 2px solid var(--rule); transition: color 0.1s, border-color 0.1s;
+}
+.toc-link:hover { color: var(--fg); }
+.toc-link.active { color: var(--accent); border-left-color: var(--accent); font-weight: 600; }
+.file-list { list-style: none; margin: 0; padding: 0; font-family: var(--mono); font-size: 0.84rem; }
+.file-list li { padding: 0.2rem 0; color: var(--fg); word-break: break-all; }
+.file-path { color: var(--fg); }
+.file-lines { color: var(--muted); }
+.findings { min-width: 0; max-width: 46rem; }
+.findings > :first-child { margin-top: 0; }
+/* Hero */
+.intro { margin: 0 0 1rem; padding-bottom: 2rem; border-bottom: 1px solid var(--border); }
+.eyebrow { font-size: 0.72rem; font-weight: 600; color: var(--accent); margin: 0 0 0.9rem; }
+.intro-q { font-size: 2rem; font-weight: 700; line-height: 1.18; letter-spacing: -0.018em; margin: 0; }
+/* Sections */
+.sec { border-top: 1px solid var(--rule); }
+.sec:first-of-type { border-top: 0; }
+.sec-h {
+  font-size: 1.3rem; font-weight: 680; line-height: 1.3; letter-spacing: -0.01em;
+  margin: 2.4rem 0 1rem; scroll-margin-top: 5rem; cursor: pointer; position: relative;
+}
+.sec-h::before {
+  content: ""; position: absolute; left: -1.5rem; top: 0.5em;
+  width: 0.5rem; height: 0.5rem; border-right: 2px solid var(--accent); border-bottom: 2px solid var(--accent);
+  transform: rotate(45deg); transition: transform 0.15s ease; opacity: 0.8;
+}
+.sec.collapsed .sec-h::before { transform: rotate(-45deg); }
+.sec.collapsed .sec-body { display: none; }
+.anchor { opacity: 0; text-decoration: none; color: var(--muted); margin-left: 0.5rem; font-weight: 400; font-size: 0.7em; }
+.sec-h:hover .anchor { opacity: 1; }
+/* Content headings inside a section (e.g. raw issue body) are subdued. */
+.sec-body h1, .sec-body h2, .sec-body h3, .sec-body h4 {
+  font-size: 1rem; font-weight: 650; line-height: 1.35; margin: 1.5rem 0 0.5rem; color: var(--muted-strong);
+}
+.findings p { margin: 0 0 1.15rem; }
+.findings li { margin: 0.3rem 0; }
+.findings ul, .findings ol { padding-left: 1.4rem; }
+.findings a { color: var(--accent); text-underline-offset: 2px; }
+.findings code {
+  font-family: var(--mono); background: var(--surface-2); padding: 0.12em 0.4em;
+  border-radius: 5px; font-size: 0.85em;
+}
+.findings pre {
+  position: relative; background: var(--surface); border: 1px solid var(--border);
+  padding: 1rem 1.1rem; border-radius: 10px; overflow-x: auto; margin: 1.4rem 0;
+}
+.findings pre code { background: none; padding: 0; font-size: 0.84rem; }
+.findings pre.diagram { font-family: var(--mono); line-height: 1.25; white-space: pre; font-size: 0.8rem; color: var(--muted-strong); }
+.copy-btn {
+  position: absolute; top: 0.5rem; right: 0.5rem; padding: 0.2rem 0.55rem;
+  font-family: var(--mono); font-size: 0.66rem; border: 1px solid var(--border); border-radius: 6px;
+  background: var(--bg); color: var(--muted); cursor: pointer; opacity: 0; transition: opacity 0.12s;
+}
+.findings pre:hover .copy-btn { opacity: 1; }
+.copy-btn:hover { color: var(--accent); border-color: var(--accent); }
+.callout {
+  margin: 1.5rem 0; padding: 0.9rem 1.1rem; border-left: 3px solid var(--info);
+  background: var(--info-bg); border-radius: 0 8px 8px 0;
+}
+.callout-title { margin: 0 0 0.35rem; font-weight: 600; font-size: 0.7rem; color: var(--info); }
+.callout > :last-child { margin-bottom: 0; }
+.callout-warning { border-left-color: var(--warn); background: var(--warn-bg); }
+.callout-warning .callout-title { color: var(--warn); }
+.callout-success { border-left-color: var(--ok); background: var(--ok-bg); }
+.callout-success .callout-title { color: var(--ok); }
+.findings blockquote {
+  margin: 1.4rem 0; padding: 0.3rem 1.1rem; color: var(--muted); border-left: 3px solid var(--border);
+}
+.findings table { border-collapse: collapse; width: 100%; margin: 1.4rem 0; font-size: 0.92rem; }
+.findings th, .findings td { border: 1px solid var(--border); padding: 0.5rem 0.8rem; text-align: left; }
+.findings th { background: var(--surface); font-family: var(--mono); font-size: 0.78rem; }
+.findings img { max-width: 100%; }
+mark.hl { background: var(--mark); color: var(--fg); border-radius: 3px; padding: 0 0.1em; }
+.sec.filtered-out { display: none !important; }
+.empty-hint { text-align: center; color: var(--muted); margin: 3rem auto; }
+#to-top {
+  position: fixed; bottom: 1.5rem; right: 1.5rem; width: 2.6rem; height: 2.6rem;
+  border-radius: 10px; border: 1px solid var(--border); background: var(--bg);
+  color: var(--fg); font-size: 1rem; cursor: pointer; box-shadow: 0 4px 14px var(--shadow); z-index: 30;
+}
+#to-top:hover { color: var(--accent); border-color: var(--accent); }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+@media (max-width: 800px) {
+  body { font-size: 16px; }
+  .layout { grid-template-columns: minmax(0, 1fr); gap: 1.5rem; padding: 1.5rem 1.25rem 4rem; }
+  .sidebar { position: static; max-height: none; border-bottom: 1px solid var(--border); padding-bottom: 1.25rem; }
+  .stats { display: none; }
+  #filter { width: 8rem; }
+  .intro-q { font-size: 1.6rem; }
+  .sec-h::before { left: -1.15rem; }
+}
+@media print {
+  .topbar, .sidebar, #to-top, .copy-btn, .anchor { display: none !important; }
+  .layout { display: block; max-width: none; padding: 0; }
+  .findings { max-width: none; font-size: 11pt; }
+  .sec.collapsed .sec-body { display: block !important; }
+  .sec-h::before { display: none; }
+  .findings pre, .callout, .intro, blockquote, table, img, .sec { break-inside: avoid; }
+  a { color: inherit; text-decoration: underline; }
+}
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  * { transition: none !important; }
+}
+`
+
+// findingsJS powers the page interactivity: theme toggle (persisted),
+// collapsible sections, scroll-spy TOC, in-page filter with highlighting,
+// copy-to-clipboard, heading anchors, back-to-top, print/PDF, and keyboard
+// shortcuts. Vanilla JS, no external dependencies.
+const findingsJS = `
+(function () {
+  var root = document.documentElement;
+  var THEME_KEY = "entire-findings-theme";
+
+  function applyTheme(t) {
+    if (t === "light" || t === "dark") root.setAttribute("data-theme", t);
+    else root.removeAttribute("data-theme");
+  }
+  try { applyTheme(localStorage.getItem(THEME_KEY)); } catch (e) {}
+  var toggle = document.querySelector("[data-theme-toggle]");
+  if (toggle) {
+    toggle.addEventListener("click", function () {
+      var cur = root.getAttribute("data-theme") || "auto";
+      var next = cur === "auto" ? "light" : cur === "light" ? "dark" : "auto";
+      applyTheme(next);
+      try {
+        if (next === "auto") localStorage.removeItem(THEME_KEY);
+        else localStorage.setItem(THEME_KEY, next);
+      } catch (e) {}
+    });
+  }
+
+  var findings = document.getElementById("findings-root");
+  if (!findings) return;
+  var sections = Array.prototype.slice.call(findings.querySelectorAll(".sec"));
+
+  // Collapsible sections (click the heading; ignore clicks on the anchor link).
+  sections.forEach(function (sec) {
+    var h = sec.querySelector(".sec-h");
+    if (!h) return;
+    h.addEventListener("click", function (ev) {
+      if (ev.target.closest("a")) return;
+      sec.classList.toggle("collapsed");
+    });
+  });
+
+  // Anchor links on section headings (hover to reveal, click copies a link).
+  findings.querySelectorAll(".sec-h[id]").forEach(function (h) {
+    var a = document.createElement("a");
+    a.className = "anchor"; a.href = "#" + h.id; a.textContent = "#";
+    a.setAttribute("aria-label", "Link to this section");
+    a.addEventListener("click", function () {
+      var url = location.href.split("#")[0] + "#" + h.id;
+      if (navigator.clipboard && navigator.clipboard.writeText) navigator.clipboard.writeText(url).catch(function () {});
+    });
+    h.appendChild(a);
+  });
+
+  // Scroll-spy: highlight the TOC link for the section heading in view.
+  var links = {};
+  document.querySelectorAll(".toc-link").forEach(function (a) { links[a.getAttribute("href").slice(1)] = a; });
+  if (window.IntersectionObserver && Object.keys(links).length) {
+    var active = null;
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (!e.isIntersecting) return;
+        var link = links[e.target.id];
+        if (!link) return;
+        if (active) active.classList.remove("active");
+        link.classList.add("active");
+        active = link;
+      });
+    }, { rootMargin: "-4.5rem 0px -70% 0px", threshold: 0 });
+    findings.querySelectorAll(".sec-h[id]").forEach(function (h) { obs.observe(h); });
+  }
+
+  // Copy buttons on code blocks (skip rendered diagrams).
+  findings.querySelectorAll("pre > code").forEach(function (code) {
+    var pre = code.parentNode;
+    if (pre.classList.contains("diagram")) return;
+    var btn = document.createElement("button");
+    btn.type = "button"; btn.className = "copy-btn"; btn.textContent = "Copy";
+    btn.addEventListener("click", function () {
+      var text = code.textContent;
+      var done = function () { btn.textContent = "Copied"; setTimeout(function () { btn.textContent = "Copy"; }, 1200); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done, function () { fallbackCopy(text); done(); });
+      } else { fallbackCopy(text); done(); }
+    });
+    pre.appendChild(btn);
+  });
+  function fallbackCopy(text) {
+    var ta = document.createElement("textarea");
+    ta.value = text; ta.style.position = "fixed"; ta.style.opacity = "0";
+    document.body.appendChild(ta); ta.select();
+    try { document.execCommand("copy"); } catch (e) {}
+    document.body.removeChild(ta);
+  }
+
+  // In-page filter: show matching sections, highlight matches.
+  function clearMarks(el) {
+    el.querySelectorAll("mark.hl").forEach(function (m) {
+      var parent = m.parentNode;
+      parent.replaceChild(document.createTextNode(m.textContent), m);
+      parent.normalize();
+    });
+  }
+  function highlight(el, term) {
+    var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (n) {
+        if (!n.nodeValue.toLowerCase().includes(term)) return NodeFilter.FILTER_REJECT;
+        if (n.parentNode && n.parentNode.closest("pre")) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    var targets = [];
+    while (walker.nextNode()) targets.push(walker.currentNode);
+    targets.forEach(function (node) {
+      var frag = document.createDocumentFragment();
+      var lower = node.nodeValue.toLowerCase();
+      var i = 0, idx;
+      while ((idx = lower.indexOf(term, i)) !== -1) {
+        if (idx > i) frag.appendChild(document.createTextNode(node.nodeValue.slice(i, idx)));
+        var mk = document.createElement("mark");
+        mk.className = "hl";
+        mk.textContent = node.nodeValue.slice(idx, idx + term.length);
+        frag.appendChild(mk);
+        i = idx + term.length;
+      }
+      if (i < node.nodeValue.length) frag.appendChild(document.createTextNode(node.nodeValue.slice(i)));
+      node.parentNode.replaceChild(frag, node);
+    });
+  }
+  var filter = document.getElementById("filter");
+  var emptyHint = document.getElementById("empty-hint");
+  function runFilter() {
+    var term = filter.value.trim().toLowerCase();
+    sections.forEach(function (sec) { clearMarks(sec); });
+    if (!term) {
+      sections.forEach(function (sec) { sec.classList.remove("filtered-out"); });
+      if (emptyHint) emptyHint.hidden = true;
+      return;
+    }
+    var anyVisible = false;
+    sections.forEach(function (sec) {
+      var match = sec.textContent.toLowerCase().includes(term);
+      sec.classList.toggle("filtered-out", !match);
+      if (match) { anyVisible = true; sec.classList.remove("collapsed"); highlight(sec, term); }
+    });
+    if (emptyHint) emptyHint.hidden = anyVisible;
+  }
+  if (filter) filter.addEventListener("input", runFilter);
+
+  // Print / save as PDF (expand sections first).
+  var printBtn = document.querySelector("[data-print]");
+  if (printBtn) printBtn.addEventListener("click", function () { window.print(); });
+  window.addEventListener("beforeprint", function () {
+    sections.forEach(function (sec) { sec.classList.remove("collapsed"); });
+  });
+
+  // Back to top.
+  var toTop = document.getElementById("to-top");
+  if (toTop) {
+    window.addEventListener("scroll", function () { toTop.hidden = window.scrollY < 600; });
+    toTop.addEventListener("click", function () { window.scrollTo({ top: 0, behavior: "smooth" }); });
+  }
+
+  // Keyboard: "/" focuses filter, Esc clears it.
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "/" && filter && document.activeElement !== filter) {
+      e.preventDefault(); filter.focus();
+    } else if (e.key === "Escape" && document.activeElement === filter) {
+      filter.value = ""; runFilter(); filter.blur();
+    }
+  });
+})();
+`

--- a/cmd/entire/cli/investigate/html.go
+++ b/cmd/entire/cli/investigate/html.go
@@ -41,10 +41,11 @@ type pageDoc struct {
 // Findings, Conclusion, …). The renderer is template-aware: it splits the body
 // on the canonical section headings, folds the raw issue body and its noise
 // headings into a single section, drops sections that are empty (only authoring
-// comments), lifts the TLDR into the hero as a standfirst, and reorders so the
-// useful findings come first and process/context sections (Approach, Prior
-// work, the original issue) sink to the bottom. Findings with no recognizable
-// sections fall back to a straight markdown render.
+// comments), drops the TLDR and Question sections entirely (the hero shows the
+// prompt as the title, not the TLDR), and reorders so the useful findings come
+// first and process/context sections (Approach, Prior work, the original issue)
+// sink to the bottom. Findings with no recognizable sections fall back to a
+// straight markdown render.
 //
 // Markdown is converted with goldmark in default (safe) mode — raw HTML in
 // agent-authored findings is NOT passed through. Renderable Mermaid flowcharts
@@ -288,7 +289,12 @@ func parseSections(body string) []*section {
 		cur = s
 	}
 
-	var inFence, inUntrusted, inComment bool
+	// fenceMarker holds the marker that opened the current code fence ("```"
+	// or "~~~"); empty when not inside a fence. CommonMark accepts both, and a
+	// fence is closed only by its own marker, so a ``` line cannot close a ~~~
+	// block. While fenced, `##`-looking lines are code, not section headings.
+	var fenceMarker string
+	var inUntrusted, inComment bool
 	for _, line := range strings.Split(body, "\n") {
 		t := strings.TrimSpace(line)
 		switch {
@@ -303,18 +309,21 @@ func parseSections(body string) []*section {
 			} else {
 				cur.body.WriteString(line + "\n")
 			}
-		case inFence:
+		case fenceMarker != "":
 			cur.body.WriteString(line + "\n")
-			if strings.HasPrefix(t, "```") {
-				inFence = false
+			if strings.HasPrefix(t, fenceMarker) {
+				fenceMarker = ""
 			}
 		case strings.HasPrefix(t, "<untrusted"):
 			inUntrusted = true // drop the tag line itself
 		case strings.HasPrefix(t, "<!--") && !strings.Contains(t, "-->"):
 			inComment = true
 			cur.body.WriteString(line + "\n")
-		case strings.HasPrefix(t, "```"):
-			inFence = true
+		case strings.HasPrefix(t, "```") || strings.HasPrefix(t, "~~~"):
+			fenceMarker = "```"
+			if strings.HasPrefix(t, "~~~") {
+				fenceMarker = "~~~"
+			}
 			cur.body.WriteString(line + "\n")
 		case sectionHeadingRe.MatchString(line):
 			start(sectionHeadingRe.FindStringSubmatch(line)[1])
@@ -882,22 +891,43 @@ const findingsJS = `
     h.appendChild(a);
   });
 
-  // Scroll-spy: highlight the TOC link for the section heading in view.
+  // Scroll-spy: highlight the TOC link for the heading nearest the top of the
+  // viewport. Computed from scroll position (rather than only reacting to
+  // intersection events) so the active link stays correct even when no heading
+  // sits in a thin observation band — deep inside a long section, or at the
+  // very top/bottom of the page. Hidden (filtered-out) headings are skipped.
   var links = {};
   document.querySelectorAll(".toc-link").forEach(function (a) { links[a.getAttribute("href").slice(1)] = a; });
-  if (window.IntersectionObserver && Object.keys(links).length) {
-    var active = null;
-    var obs = new IntersectionObserver(function (entries) {
-      entries.forEach(function (e) {
-        if (!e.isIntersecting) return;
-        var link = links[e.target.id];
-        if (!link) return;
-        if (active) active.classList.remove("active");
-        link.classList.add("active");
-        active = link;
-      });
-    }, { rootMargin: "-4.5rem 0px -70% 0px", threshold: 0 });
-    findings.querySelectorAll(".sec-h[id]").forEach(function (h) { obs.observe(h); });
+  var spyHeadings = Array.prototype.slice.call(findings.querySelectorAll(".sec-h[id]"));
+  if (spyHeadings.length && Object.keys(links).length) {
+    var activeLink = null;
+    function setActive(link) {
+      if (link === activeLink) return;
+      if (activeLink) activeLink.classList.remove("active");
+      if (link) link.classList.add("active");
+      activeLink = link;
+    }
+    function syncSpy() {
+      var threshold = 80; // just below the sticky top bar
+      var current = null, firstVisible = null;
+      for (var i = 0; i < spyHeadings.length; i++) {
+        var h = spyHeadings[i];
+        if (!h.getClientRects().length) continue; // skip hidden headings
+        if (!firstVisible) firstVisible = h;
+        if (h.getBoundingClientRect().top <= threshold) current = h;
+      }
+      if (!current) current = firstVisible; // above the first heading → highlight it
+      setActive(current ? (links[current.id] || null) : null);
+    }
+    var spyTicking = false;
+    function onSpyScroll() {
+      if (spyTicking) return;
+      spyTicking = true;
+      window.requestAnimationFrame(function () { syncSpy(); spyTicking = false; });
+    }
+    window.addEventListener("scroll", onSpyScroll, { passive: true });
+    window.addEventListener("resize", onSpyScroll);
+    syncSpy();
   }
 
   // Copy buttons on code blocks (skip rendered diagrams).

--- a/cmd/entire/cli/investigate/html_test.go
+++ b/cmd/entire/cli/investigate/html_test.go
@@ -465,6 +465,34 @@ func TestRenderFindingsHTML_RemovesQuestionSection(t *testing.T) {
 	}
 }
 
+func TestRenderFindingsHTML_TildeFenceIsNotASection(t *testing.T) {
+	t.Parallel()
+
+	// A `##`-looking line inside a ~~~ code fence (valid CommonMark) must not
+	// be treated as a section boundary — it is code, not a heading.
+	m := LocalManifest{
+		RunID:     "abcdef012345",
+		Topic:     "tilde fences",
+		StartedAt: time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## Findings\n\nExample config:\n\n~~~\n" +
+			"## not-a-real-heading\nkey = value\n~~~\n\nReal prose after the fence.\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+	if strings.Contains(out, `id="not-a-real-heading"`) {
+		t.Errorf("a ## line inside a ~~~ fence must not become a section, got: %q", out)
+	}
+	if !strings.Contains(out, `id="findings"`) {
+		t.Errorf("expected the real Findings section, got: %q", out)
+	}
+	if !strings.Contains(out, "Real prose after the fence.") {
+		t.Errorf("expected post-fence prose to render inside Findings, got: %q", out)
+	}
+}
+
 func TestRenderFindingsHTML_EmptyBodyReturnsSentinel(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entire/cli/investigate/html_test.go
+++ b/cmd/entire/cli/investigate/html_test.go
@@ -1,0 +1,482 @@
+package investigate
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderFindingsHTML_RendersFindingsBody(t *testing.T) {
+	t.Parallel()
+
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "why is the build slow",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## Findings\n\nThe answer is npm install.\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+
+	if !strings.Contains(out, "<!doctype html>") && !strings.Contains(out, "<!DOCTYPE html>") {
+		t.Errorf("expected a complete HTML document, got: %q", out)
+	}
+	// Self-contained: no external (CDN / network) references.
+	if strings.Contains(out, "http://") || strings.Contains(out, "https://") {
+		t.Errorf("expected no external references, got a URL in: %q", out)
+	}
+	// Prompt is the page title.
+	if !strings.Contains(out, "why is the build slow") {
+		t.Errorf("expected the prompt as the page title, got: %q", out)
+	}
+	if !strings.Contains(out, "<h2") {
+		t.Errorf("expected markdown heading rendered to <h2>, got: %q", out)
+	}
+	if !strings.Contains(out, "The answer is npm install.") {
+		t.Errorf("expected findings prose, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_OmitsAgentMetadata(t *testing.T) {
+	t.Parallel()
+
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "pipeline question",
+		Agents:          []string{"claude-code", "codex"},
+		Outcome:         "quorum",
+		StancesByAgent:  map[string]string{"claude-code": "agree", "codex": "disagree"},
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		EndedAt:         time.Date(2026, 6, 23, 9, 10, 0, 0, time.UTC),
+		FindingsContent: "## Result\n\nA clean explanation with no agent names.\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+
+	for _, banned := range []string{"claude-code", "codex", "quorum", "disagree", "Last stance"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("expected no agent/outcome metadata, but found %q in: %q", banned, out)
+		}
+	}
+}
+
+func TestRenderFindingsHTML_BuildsTOCWithHeadingLinks(t *testing.T) {
+	t.Parallel()
+
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "build hang",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## Background\n\nbody\n\n## Evidence\n\nmore\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+
+	// Headings get anchor ids and the TOC links to them.
+	if !strings.Contains(out, `id="background"`) || !strings.Contains(out, `id="evidence"`) {
+		t.Errorf("expected slugged heading ids, got: %q", out)
+	}
+	if !strings.Contains(out, `href="#background"`) || !strings.Contains(out, `href="#evidence"`) {
+		t.Errorf("expected TOC links to headings, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_IsInteractive(t *testing.T) {
+	t.Parallel()
+
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "interactivity",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## Section\n\nbody\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+
+	// Inline behavior — no external scripts.
+	if !strings.Contains(out, "<script>") {
+		t.Errorf("expected inline interactivity, got no <script>: %q", out)
+	}
+	// In-page search control.
+	if !strings.Contains(out, `type="search"`) {
+		t.Errorf("expected a search input, got: %q", out)
+	}
+	// Theme toggle control.
+	if !strings.Contains(out, "data-theme-toggle") {
+		t.Errorf("expected a theme toggle control, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_RendersRenderableMermaidAsDiagramPre(t *testing.T) {
+	t.Parallel()
+
+	body := "## Flow\n\n```mermaid\nflowchart LR\n  A[Producer] --> B[Consumer]\n```\n"
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "pipeline",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: body,
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+
+	if !strings.Contains(out, `<pre class="diagram">`) {
+		t.Errorf("expected a diagram <pre> block, got: %q", out)
+	}
+	if !strings.Contains(out, "Producer") || !strings.Contains(out, "Consumer") {
+		t.Errorf("expected diagram to contain node labels, got: %q", out)
+	}
+	if strings.Contains(out, "flowchart LR") {
+		t.Errorf("expected mermaid source to be replaced by the diagram, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_EscapesHTML(t *testing.T) {
+	t.Parallel()
+
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "<script>alert('xss')</script>",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "Inline danger: <img src=x onerror=alert(1)>\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+
+	if strings.Contains(out, "<script>alert") {
+		t.Errorf("topic was not escaped, got: %q", out)
+	}
+	if strings.Contains(out, "<img src=x onerror") {
+		t.Errorf("raw HTML in findings was not neutralized, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_HeroShowsTitleNotTLDR(t *testing.T) {
+	t.Parallel()
+
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "Why does the build hang?",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## Summary\n\nThe root cause is an orphaned cache lock.\n\n## Detail\n\nmore\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+	// The hero shows the prompt as the title.
+	if !strings.Contains(out, `class="intro"`) || !strings.Contains(out, "Why does the build hang?") {
+		t.Errorf("expected the prompt in the hero, got: %q", out)
+	}
+	// The TLDR/Summary section is removed entirely — not shown as a standfirst.
+	if strings.Contains(out, "The root cause is an orphaned cache lock.") {
+		t.Errorf("TLDR should be removed, but found it in: %q", out)
+	}
+	// Other sections still render.
+	if !strings.Contains(out, `id="detail"`) {
+		t.Errorf("expected the Detail section, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_ListsReferencedFiles(t *testing.T) {
+	t.Parallel()
+
+	body := "## Cause\n\nThe bug is in `internal/cache/lock.go:42`, `internal/cache/lock.go:90`, and also `pkg/install/run.go`.\n"
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "files",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: body,
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+	if !strings.Contains(out, `id="referenced-files"`) {
+		t.Errorf("expected a referenced-files section, got: %q", out)
+	}
+	// Refs are grouped by file: the path appears once, its lines listed beside it.
+	if !strings.Contains(out, `class="file-path">internal/cache/lock.go</span>`) {
+		t.Errorf("expected grouped file path, got: %q", out)
+	}
+	if !strings.Contains(out, `class="file-lines">42, 90</span>`) {
+		t.Errorf("expected grouped line list, got: %q", out)
+	}
+	if strings.Count(out, `class="file-path">internal/cache/lock.go</span>`) != 1 {
+		t.Errorf("grouped file path should appear once in the files list, got: %q", out)
+	}
+	if !strings.Contains(out, "pkg/install/run.go") {
+		t.Errorf("expected second file ref, got: %q", out)
+	}
+	// The files section sits at the very bottom (after all parsed sections).
+	if idx := strings.Index(out, `id="referenced-files"`); idx != -1 {
+		if cause := strings.Index(out, `id="cause"`); cause == -1 || cause > idx {
+			t.Errorf("referenced-files should come after content sections")
+		}
+	}
+}
+
+func TestRenderFindingsHTML_RendersCallouts(t *testing.T) {
+	t.Parallel()
+
+	body := "## Notes\n\n> [!WARNING]\n> Do not interrupt the install.\n\n**Fix:** wrap the install in a trap.\n"
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "callouts",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: body,
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+	if !strings.Contains(out, "callout-warning") {
+		t.Errorf("expected a warning callout from the GitHub alert, got: %q", out)
+	}
+	if !strings.Contains(out, "callout-success") {
+		t.Errorf("expected a success callout from the **Fix:** lead-in, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_ShowsReadingStats(t *testing.T) {
+	t.Parallel()
+
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "stats",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## A\n\nword word word\n\n## B\n\nmore\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+	if !strings.Contains(out, "min read") {
+		t.Errorf("expected a reading-time stat, got: %q", out)
+	}
+	if !strings.Contains(out, "2 sections") {
+		t.Errorf("expected a section count, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_HasReadingAids(t *testing.T) {
+	t.Parallel()
+
+	m := LocalManifest{
+		RunID:           "abcdef012345",
+		Topic:           "aids",
+		StartedAt:       time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## Section\n\nbody\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+	if !strings.Contains(out, "data-print") {
+		t.Errorf("expected a print/PDF control, got: %q", out)
+	}
+	if !strings.Contains(out, "window.print") {
+		t.Errorf("expected print wiring, got: %q", out)
+	}
+	if !strings.Contains(out, `id="to-top"`) {
+		t.Errorf("expected a back-to-top control, got: %q", out)
+	}
+	if !strings.Contains(out, "@media print") {
+		t.Errorf("expected a print stylesheet, got: %q", out)
+	}
+}
+
+func TestOrderedFindingsMarkdown(t *testing.T) {
+	t.Parallel()
+
+	body := "## TLDR\n\nthe gist\n\n## Question\n\n<untrusted source=\"x\">\nissue text\n</untrusted>\n\n" +
+		"## Prior work\n\nsearched\n\n## Approach\n\nread code\n\n## Findings\n\nbug in `pkg/run.go:10`\n\n## Conclusion\n\nship it\n"
+
+	out := orderedFindingsMarkdown(body)
+
+	// TLDR and Question (raw issue) are dropped.
+	if strings.Contains(out, "the gist") || strings.Contains(out, "issue text") || strings.Contains(out, "## Question") {
+		t.Errorf("TLDR/Question should be dropped, got:\n%s", out)
+	}
+	// Sections appear in HTML order: Conclusion, Findings, Prior work, Approach.
+	order := []string{"## Conclusion", "## Findings", "## Prior work", "## Approach", "## Referenced files"}
+	last := -1
+	for _, want := range order {
+		at := strings.Index(out, want)
+		if at == -1 {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+		if at < last {
+			t.Errorf("%q out of order in:\n%s", want, out)
+		}
+		last = at
+	}
+	// Referenced files list present.
+	if !strings.Contains(out, "`pkg/run.go` 10") {
+		t.Errorf("expected grouped referenced file, got:\n%s", out)
+	}
+}
+
+func TestOrderedFindingsMarkdown_NoSectionsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	body := "just some freeform notes\n\nno headings here\n"
+	if got := orderedFindingsMarkdown(body); got != body {
+		t.Errorf("freeform findings should pass through unchanged, got: %q", got)
+	}
+}
+
+func TestGroupFileRefs(t *testing.T) {
+	t.Parallel()
+
+	got := groupFileRefs([]string{
+		"handler.go:418", "handler.go:418-420",
+		"internal/handler/handler.go:856", "handler.go:120",
+		"client.go:10", "pkg/run.go",
+	})
+
+	// handler.go (bare) merges into internal/handler/handler.go (unique basename);
+	// client.go stays bare (no matching full path). Sorted by path, lines by start.
+	want := []fileRef{
+		{path: "client.go", lines: []string{"10"}},
+		{path: "internal/handler/handler.go", lines: []string{"120", "418", "418-420", "856"}},
+		{path: "pkg/run.go", lines: nil},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d groups, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].path != want[i].path {
+			t.Errorf("group %d path = %q, want %q", i, got[i].path, want[i].path)
+		}
+		if strings.Join(got[i].lines, ",") != strings.Join(want[i].lines, ",") {
+			t.Errorf("group %d (%s) lines = %v, want %v", i, got[i].path, got[i].lines, want[i].lines)
+		}
+	}
+}
+
+func TestRenderFindingsHTML_OrdersProcessSectionsLast(t *testing.T) {
+	t.Parallel()
+
+	// Authored in template order; Approach and Prior work must sink below
+	// Findings and Conclusion in the rendered output.
+	m := LocalManifest{
+		RunID:     "abcdef012345",
+		Topic:     "ordering",
+		StartedAt: time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## Prior work\n\nsearched X\n\n## Approach\n\nread Y\n\n" +
+			"## Findings\n\nthe bug is real\n\n## Conclusion\n\nship the fix\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+	order := []string{`id="conclusion"`, `id="findings"`, `id="prior-work"`, `id="approach"`}
+	last := -1
+	for _, want := range order {
+		at := strings.Index(out, want)
+		if at == -1 {
+			t.Fatalf("missing section %s in: %q", want, out)
+		}
+		if at < last {
+			t.Errorf("section %s out of order (expected conclusion, findings, prior-work, approach)", want)
+		}
+		last = at
+	}
+}
+
+func TestRenderFindingsHTML_DropsEmptyTemplateSections(t *testing.T) {
+	t.Parallel()
+
+	// A section containing only an authoring comment must not render.
+	m := LocalManifest{
+		RunID:     "abcdef012345",
+		Topic:     "empties",
+		StartedAt: time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## Approach\n\n<!-- how the investigation was run -->\n\n" +
+			"## Findings\n\nthe real finding\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+	if strings.Contains(out, `id="approach"`) {
+		t.Errorf("empty Approach section should be dropped, got: %q", out)
+	}
+	if !strings.Contains(out, `id="findings"`) {
+		t.Errorf("non-empty Findings section should render, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_RemovesQuestionSection(t *testing.T) {
+	t.Parallel()
+
+	// The Question section holds the raw issue body (with its own headings
+	// inside <untrusted>). The whole section — including that issue content —
+	// must be dropped.
+	m := LocalManifest{
+		RunID:     "abcdef012345",
+		Topic:     "untrusted",
+		StartedAt: time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsContent: "## Question\n\n<untrusted source=\"issue-body\">\n" +
+			"## What happened?\n\nit broke\n\n## Steps to reproduce\n\nrun it\n</untrusted>\n\n" +
+			"## Findings\n\nthe real finding\n",
+	}
+
+	out, err := RenderFindingsHTML(m)
+	if err != nil {
+		t.Fatalf("RenderFindingsHTML: %v", err)
+	}
+	if strings.Contains(out, `id="question"`) {
+		t.Errorf("Question section should be removed, got: %q", out)
+	}
+	if strings.Contains(out, "it broke") {
+		t.Errorf("issue content should be gone with the Question section, got: %q", out)
+	}
+	// Other sections still render.
+	if !strings.Contains(out, `id="findings"`) || !strings.Contains(out, "the real finding") {
+		t.Errorf("expected the Findings section to survive, got: %q", out)
+	}
+}
+
+func TestRenderFindingsHTML_EmptyBodyReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	m := LocalManifest{
+		RunID:       "abcdef012345",
+		Topic:       "lost run",
+		StartedAt:   time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC),
+		FindingsDoc: "/tmp/this/does/not/exist.md",
+	}
+
+	_, err := RenderFindingsHTML(m)
+	if !errors.Is(err, errNoFindingsContent) {
+		t.Errorf("expected errNoFindingsContent for empty body, got: %v", err)
+	}
+}

--- a/cmd/entire/cli/investigate/manifest.go
+++ b/cmd/entire/cli/investigate/manifest.go
@@ -106,6 +106,18 @@ func NewLocalManifestStoreWithDir(dir string) *LocalManifestStore {
 	return &LocalManifestStore{dir: dir}
 }
 
+// RunDir returns the per-run investigation directory for runID — the sibling
+// of the manifests directory that holds findings.md / state.json:
+//
+//	<commonDir>/entire-investigations/<run-id>
+//
+// It is derived from the store's manifests dir
+// (<commonDir>/entire-investigations/manifests), so it stays correct without a
+// separate git lookup and works with the test constructor.
+func (s *LocalManifestStore) RunDir(runID string) string {
+	return filepath.Join(filepath.Dir(s.dir), runID)
+}
+
 // Write persists m to the manifests directory using a deterministic filename
 // derived from m.StartedAt and m.RunID. Existing files are overwritten — the
 // timestamp+run-id combination is unique by construction (each run has a fresh

--- a/cmd/entire/cli/investigate/manifest.go
+++ b/cmd/entire/cli/investigate/manifest.go
@@ -272,6 +272,26 @@ func ResolveByRunID(manifests []LocalManifest, runID string) ([]LocalManifest, e
 	}
 }
 
+// FilterByWorktree returns the subset of manifests recorded as having run in
+// the worktree at worktreeRoot, comparing the cleaned WorktreePath. Manifests
+// with no recorded WorktreePath are excluded — they cannot be attributed to a
+// worktree, so they surface only in the unscoped (--all) view. A blank
+// worktreeRoot disables scoping and returns manifests unchanged: when the
+// caller cannot determine the current worktree, it must not hide runs.
+func FilterByWorktree(manifests []LocalManifest, worktreeRoot string) []LocalManifest {
+	if strings.TrimSpace(worktreeRoot) == "" {
+		return manifests
+	}
+	want := filepath.Clean(worktreeRoot)
+	out := make([]LocalManifest, 0, len(manifests))
+	for _, m := range manifests {
+		if m.WorktreePath != "" && filepath.Clean(m.WorktreePath) == want {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
 // ambiguousRunIDError formats a list of candidate run ids for the user
 // to choose from. When runID is empty, the header asks the user to pass a
 // run id; otherwise it reports the ambiguous prefix.

--- a/cmd/entire/cli/investigate/manifest_test.go
+++ b/cmd/entire/cli/investigate/manifest_test.go
@@ -266,3 +266,37 @@ func TestResolveByRunID_IgnoresInvalidRunID(t *testing.T) {
 		t.Errorf("ResolveByRunID(valid) = %+v, want single abcdef012345", got)
 	}
 }
+
+func TestFilterByWorktree(t *testing.T) {
+	t.Parallel()
+
+	wtA := filepath.Join(string(filepath.Separator)+"repos", "a")
+	wtB := filepath.Join(string(filepath.Separator)+"repos", "b")
+	manifests := []LocalManifest{
+		{RunID: "aaaaaaaaaaaa", WorktreePath: wtA},
+		{RunID: "bbbbbbbbbbbb", WorktreePath: wtB},
+		{RunID: "cccccccccccc", WorktreePath: wtA + string(filepath.Separator)}, // trailing sep → same after Clean
+		{RunID: "dddddddddddd"},                                                 // no recorded worktree
+	}
+
+	// Scoped to worktree A: only the two A runs (one via Clean-normalized path).
+	got := FilterByWorktree(manifests, wtA)
+	gotIDs := map[string]bool{}
+	for _, m := range got {
+		gotIDs[m.RunID] = true
+	}
+	if len(got) != 2 || !gotIDs["aaaaaaaaaaaa"] || !gotIDs["cccccccccccc"] {
+		t.Errorf("expected the two worktree-A runs, got: %+v", got)
+	}
+	if gotIDs["bbbbbbbbbbbb"] {
+		t.Errorf("worktree-B run must not appear when scoped to A: %+v", got)
+	}
+	if gotIDs["dddddddddddd"] {
+		t.Errorf("run with no recorded worktree must be excluded from a scoped view: %+v", got)
+	}
+
+	// A blank worktree disables scoping — every manifest passes through.
+	if all := FilterByWorktree(manifests, ""); len(all) != len(manifests) {
+		t.Errorf("blank worktree must not scope; got %d, want %d", len(all), len(manifests))
+	}
+}

--- a/cmd/entire/cli/investigate/show.go
+++ b/cmd/entire/cli/investigate/show.go
@@ -27,6 +27,15 @@ type ShowInput struct {
 	// HTML renders the findings to a styled findings.html in the per-run
 	// directory and opens it in the browser, instead of printing to Out.
 	HTML bool
+	// All, when true, considers investigations from every worktree of the
+	// repository. When false (the default), the no-run-id picker is scoped to
+	// CurrentWorktree. An explicit run id (or prefix) is always resolved
+	// across the whole repository regardless of this flag.
+	All bool
+	// CurrentWorktree is the absolute path of the worktree the command is
+	// running in, used to scope the no-run-id picker when All is false. Blank
+	// disables scoping (every manifest is considered).
+	CurrentWorktree string
 }
 
 // ShowDeps collects what RunShow needs that's test-injectable.
@@ -73,10 +82,24 @@ func RunShow(ctx context.Context, in ShowInput, deps ShowDeps) error {
 	}
 
 	if runID == "" {
-		if len(manifests) == 1 {
-			return emitShow(ctx, in, deps, manifests[0])
+		// No run id: default to investigations from the current worktree.
+		// `--all` widens to every worktree. An explicit run id below is never
+		// scoped — targeting a specific run should work from anywhere.
+		scoped := manifests
+		if !in.All {
+			scoped = FilterByWorktree(manifests, in.CurrentWorktree)
 		}
-		return ambiguousRunIDError(manifests, "")
+		switch len(scoped) {
+		case 0:
+			fmt.Fprintf(in.Out,
+				"No investigations found for this worktree (%d across the repository). "+
+					"Re-run with --all to list them, or pass a run id.\n", len(manifests))
+			return nil
+		case 1:
+			return emitShow(ctx, in, deps, scoped[0])
+		default:
+			return ambiguousRunIDError(scoped, "")
+		}
 	}
 
 	resolved, err := ResolveByRunID(manifests, runID)

--- a/cmd/entire/cli/investigate/show.go
+++ b/cmd/entire/cli/investigate/show.go
@@ -24,6 +24,9 @@ type ShowInput struct {
 	Out io.Writer
 	// ErrOut is the destination writer for user-facing error/help messages.
 	ErrOut io.Writer
+	// HTML renders the findings to a styled findings.html in the per-run
+	// directory and opens it in the browser, instead of printing to Out.
+	HTML bool
 }
 
 // ShowDeps collects what RunShow needs that's test-injectable.
@@ -57,9 +60,7 @@ func RunShow(ctx context.Context, in ShowInput, deps ShowDeps) error {
 		if !ok {
 			return fmt.Errorf("no investigation found with run id %q", runID)
 		}
-		printShowSummary(in.Out, m)
-		printShowFindings(in.Out, m)
-		return nil
+		return emitShow(ctx, in, deps, m)
 	}
 
 	manifests, err := deps.ManifestStore.List(ctx)
@@ -73,9 +74,7 @@ func RunShow(ctx context.Context, in ShowInput, deps ShowDeps) error {
 
 	if runID == "" {
 		if len(manifests) == 1 {
-			printShowSummary(in.Out, manifests[0])
-			printShowFindings(in.Out, manifests[0])
-			return nil
+			return emitShow(ctx, in, deps, manifests[0])
 		}
 		return ambiguousRunIDError(manifests, "")
 	}
@@ -84,8 +83,55 @@ func RunShow(ctx context.Context, in ShowInput, deps ShowDeps) error {
 	if err != nil {
 		return err
 	}
-	printShowSummary(in.Out, resolved[0])
-	printShowFindings(in.Out, resolved[0])
+	return emitShow(ctx, in, deps, resolved[0])
+}
+
+// emitShow renders a resolved manifest either to the terminal (default) or as
+// an HTML page (in.HTML).
+func emitShow(ctx context.Context, in ShowInput, deps ShowDeps, m LocalManifest) error {
+	if in.HTML {
+		return emitShowHTML(ctx, in, deps, m)
+	}
+	printShowSummary(in.Out, m)
+	printShowFindings(in.Out, m)
+	return nil
+}
+
+// emitShowHTML renders m to findings.html in the per-run directory, prints the
+// path, and opens it in the browser. A manifest with no findings body prints
+// the same soft notice as the terminal path and writes nothing. Browser-open
+// failures are non-fatal: the path is already printed for manual opening.
+func emitShowHTML(ctx context.Context, in ShowInput, deps ShowDeps, m LocalManifest) error {
+	doc, err := RenderFindingsHTML(m)
+	if errors.Is(err, errNoFindingsContent) {
+		fmt.Fprintf(in.Out, "No findings content available for run %s.\n", m.RunID)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("render findings html: %w", err)
+	}
+
+	dir := deps.ManifestStore.RunDir(m.RunID)
+	if mkErr := os.MkdirAll(dir, 0o750); mkErr != nil {
+		return fmt.Errorf("create investigation dir: %w", mkErr)
+	}
+	htmlPath := filepath.Join(dir, "findings.html")
+	// 0o600: findings embed the user-supplied prompt and findings body, matching
+	// the mode used for findings.md / state.json.
+	if writeErr := os.WriteFile(htmlPath, []byte(doc), 0o600); writeErr != nil {
+		return fmt.Errorf("write findings html: %w", writeErr)
+	}
+	// Print/open an absolute path: the git common dir resolves relative to cwd,
+	// and a relative path is fragile for the user to open and for the OS opener
+	// to resolve. Best-effort — fall back to the joined path on failure.
+	if abs, absErr := filepath.Abs(htmlPath); absErr == nil {
+		htmlPath = abs
+	}
+	fmt.Fprintf(in.Out, "Wrote %s\n", htmlPath)
+
+	// Non-fatal: a headless host (or a missing opener) just means the user opens
+	// the printed path themselves.
+	_ = openInBrowser(ctx, htmlPath) //nolint:errcheck // best-effort; path already printed
 	return nil
 }
 
@@ -130,24 +176,34 @@ func printShowSummary(w io.Writer, m LocalManifest) {
 // cancelled runs). Body is rendered through mdrender for terminal
 // output; raw markdown passes through for piped/NO_COLOR output.
 func printShowFindings(w io.Writer, m LocalManifest) {
-	body := ""
+	body := findingsBody(m)
+	if body == "" {
+		fmt.Fprintf(w, "No findings content available for run %s.\n", m.RunID)
+		return
+	}
+	// Reorder/filter sections to match the HTML view so both outputs agree.
+	writeRenderedFindings(w, orderedFindingsMarkdown(body))
+}
+
+// findingsBody returns the findings markdown for m, preferring the manifest's
+// embedded content (set on terminal outcomes) and falling back to the on-disk
+// findings file (still present for paused / cancelled runs). Returns "" when
+// neither source yields content. Shared by the terminal renderer and the HTML
+// renderer so both resolve findings identically.
+func findingsBody(m LocalManifest) string {
 	switch {
 	case m.FindingsContent != "":
-		body = m.FindingsContent
+		return m.FindingsContent
 	case m.FindingsDoc != "" && filepath.IsAbs(m.FindingsDoc):
 		// FindingsDoc is contractually absolute (see LocalManifest docs).
 		// Refuse to read relative paths: those would resolve against the
 		// current process cwd, which may differ from where the run wrote
 		// findings.md, and could surface unrelated content.
 		if data, err := os.ReadFile(m.FindingsDoc); err == nil {
-			body = string(data)
+			return string(data)
 		}
 	}
-	if body == "" {
-		fmt.Fprintf(w, "No findings content available for run %s.\n", m.RunID)
-		return
-	}
-	writeRenderedFindings(w, body)
+	return ""
 }
 
 // writeRenderedFindings renders findings markdown to w, ensuring a trailing

--- a/cmd/entire/cli/investigate/show_html_test.go
+++ b/cmd/entire/cli/investigate/show_html_test.go
@@ -1,0 +1,114 @@
+package investigate
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunShow_HTMLWritesFileAndPrintsPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	store := NewLocalManifestStoreWithDir(filepath.Join(root, "manifests"))
+	t1 := time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC)
+	writeShowManifest(t, store, "abcdef012345", "build perf", t1, "quorum", "",
+		"## Findings\n\nThe answer is 42.\n",
+		map[string]string{"claude-code": "agree"},
+	)
+
+	var out bytes.Buffer
+	err := RunShow(context.Background(),
+		ShowInput{RunID: "abcdef012345", Out: &out, HTML: true},
+		ShowDeps{ManifestStore: store},
+	)
+	if err != nil {
+		t.Fatalf("RunShow: %v", err)
+	}
+
+	htmlPath := filepath.Join(root, "abcdef012345", "findings.html")
+	if !strings.Contains(out.String(), htmlPath) {
+		t.Errorf("expected output to print the html path %q, got: %q", htmlPath, out.String())
+	}
+
+	data, readErr := os.ReadFile(htmlPath)
+	if readErr != nil {
+		t.Fatalf("expected findings.html written at %q: %v", htmlPath, readErr)
+	}
+	html := string(data)
+	if !strings.Contains(html, "The answer is 42.") {
+		t.Errorf("findings.html missing body, got: %q", html)
+	}
+	if !strings.Contains(html, "build perf") {
+		t.Errorf("findings.html missing banner topic, got: %q", html)
+	}
+}
+
+func TestRunShow_HTMLNoContentPrintsSoftNotice(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	store := NewLocalManifestStoreWithDir(filepath.Join(root, "manifests"))
+	t1 := time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC)
+	writeShowManifest(t, store, "abcdef012345", "lost run", t1, "cancelled",
+		"/tmp/does/not/exist.md", "", nil)
+
+	var out bytes.Buffer
+	err := RunShow(context.Background(),
+		ShowInput{RunID: "abcdef012345", Out: &out, HTML: true},
+		ShowDeps{ManifestStore: store},
+	)
+	if err != nil {
+		t.Fatalf("RunShow: %v", err)
+	}
+	if !strings.Contains(out.String(), "No findings content available for run abcdef012345.") {
+		t.Errorf("expected soft no-content notice, got: %q", out.String())
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "abcdef012345", "findings.html")); !os.IsNotExist(statErr) {
+		t.Errorf("expected no findings.html written when there is no content")
+	}
+}
+
+func TestRunShow_HTMLPrintsAbsolutePath(t *testing.T) {
+	// Not parallel: uses t.Chdir to exercise a relative common-dir path, which
+	// is what session.GetGitCommonDir returns from the repo root.
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	store := NewLocalManifestStoreWithDir(filepath.Join("rel-investigations", "manifests"))
+	t1 := time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC)
+	writeShowManifest(t, store, "abcdef012345", "rel path", t1, "quorum", "",
+		"## Findings\n\nbody\n", nil)
+
+	var out bytes.Buffer
+	err := RunShow(context.Background(),
+		ShowInput{RunID: "abcdef012345", Out: &out, HTML: true},
+		ShowDeps{ManifestStore: store},
+	)
+	if err != nil {
+		t.Fatalf("RunShow: %v", err)
+	}
+
+	printed := strings.TrimSpace(strings.TrimPrefix(out.String(), "Wrote "))
+	if !filepath.IsAbs(printed) {
+		t.Errorf("expected an absolute path to be printed, got: %q", printed)
+	}
+	if _, statErr := os.Stat(printed); statErr != nil {
+		t.Errorf("printed path should exist: %v", statErr)
+	}
+}
+
+func TestLocalManifestStore_RunDir(t *testing.T) {
+	t.Parallel()
+
+	store := NewLocalManifestStoreWithDir(filepath.Join("/repo/.git", InvestigationsDirName, "manifests"))
+	got := store.RunDir("abcdef012345")
+	want := filepath.Join("/repo/.git", InvestigationsDirName, "abcdef012345")
+	if got != want {
+		t.Errorf("RunDir = %q, want %q", got, want)
+	}
+}

--- a/cmd/entire/cli/investigate/show_test.go
+++ b/cmd/entire/cli/investigate/show_test.go
@@ -276,3 +276,116 @@ func TestRunShow_NoContentAvailable(t *testing.T) {
 		t.Errorf("expected soft no-content notice, got: %q", out.String())
 	}
 }
+
+// writeShowManifestInWorktree persists a minimal terminal-outcome manifest
+// tagged with worktreePath, for the worktree-scoping tests.
+func writeShowManifestInWorktree(t *testing.T, store *LocalManifestStore, runID, topic, worktreePath string, started time.Time) {
+	t.Helper()
+	m := LocalManifest{
+		RunID:           runID,
+		Topic:           topic,
+		Slug:            SlugifyTopic(topic),
+		WorktreePath:    worktreePath,
+		Outcome:         "quorum",
+		FindingsContent: "## Findings\n\n" + topic + " body\n",
+		Agents:          []string{"claude-code"},
+		StartedAt:       started,
+		EndedAt:         started.Add(time.Minute),
+	}
+	if err := store.Write(context.Background(), m); err != nil {
+		t.Fatalf("Write %s: %v", runID, err)
+	}
+}
+
+func TestRunShow_NoRunID_ScopesToCurrentWorktree(t *testing.T) {
+	t.Parallel()
+
+	store := NewLocalManifestStoreWithDir(t.TempDir())
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	writeShowManifestInWorktree(t, store, "aaaaaaaaaaaa", "here run", "/repos/here", t1)
+	writeShowManifestInWorktree(t, store, "bbbbbbbbbbbb", "there run", "/repos/there", t2)
+
+	// No run id, scoped to /repos/here → exactly one match → shows it directly.
+	var out bytes.Buffer
+	err := RunShow(context.Background(),
+		ShowInput{Out: &out, CurrentWorktree: "/repos/here"},
+		ShowDeps{ManifestStore: store},
+	)
+	if err != nil {
+		t.Fatalf("RunShow: %v", err)
+	}
+	if !strings.Contains(out.String(), "Investigation aaaaaaaaaaaa") {
+		t.Errorf("expected the current-worktree run to be shown, got: %q", out.String())
+	}
+	if strings.Contains(out.String(), "bbbbbbbbbbbb") {
+		t.Errorf("other worktree's run must not appear when scoped, got: %q", out.String())
+	}
+}
+
+func TestRunShow_NoRunID_NoneInWorktreeHintsAll(t *testing.T) {
+	t.Parallel()
+
+	store := NewLocalManifestStoreWithDir(t.TempDir())
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	writeShowManifestInWorktree(t, store, "aaaaaaaaaaaa", "elsewhere run", "/repos/elsewhere", t1)
+
+	var out bytes.Buffer
+	err := RunShow(context.Background(),
+		ShowInput{Out: &out, CurrentWorktree: "/repos/here"},
+		ShowDeps{ManifestStore: store},
+	)
+	if err != nil {
+		t.Fatalf("RunShow: %v", err)
+	}
+	if !strings.Contains(out.String(), "No investigations found for this worktree") {
+		t.Errorf("expected a worktree-scoped empty notice, got: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "--all") {
+		t.Errorf("expected an --all hint, got: %q", out.String())
+	}
+}
+
+func TestRunShow_NoRunID_AllWidensAcrossWorktrees(t *testing.T) {
+	t.Parallel()
+
+	store := NewLocalManifestStoreWithDir(t.TempDir())
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	writeShowManifestInWorktree(t, store, "aaaaaaaaaaaa", "here run", "/repos/here", t1)
+	writeShowManifestInWorktree(t, store, "bbbbbbbbbbbb", "there run", "/repos/there", t2)
+
+	// --all + multiple total → ambiguous listing across every worktree.
+	var out bytes.Buffer
+	err := RunShow(context.Background(),
+		ShowInput{Out: &out, CurrentWorktree: "/repos/here", All: true},
+		ShowDeps{ManifestStore: store},
+	)
+	if err == nil {
+		t.Fatal("expected ambiguity error with --all and multiple runs, got nil")
+	}
+	if !strings.Contains(err.Error(), "aaaaaaaaaaaa") || !strings.Contains(err.Error(), "bbbbbbbbbbbb") {
+		t.Errorf("expected both runs listed under --all, got: %v", err)
+	}
+}
+
+func TestRunShow_ExplicitRunID_NotScopedByWorktree(t *testing.T) {
+	t.Parallel()
+
+	store := NewLocalManifestStoreWithDir(t.TempDir())
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	writeShowManifestInWorktree(t, store, "bbbbbbbbbbbb", "there run", "/repos/there", t1)
+
+	// Targeting a specific run from a different worktree must still resolve.
+	var out bytes.Buffer
+	err := RunShow(context.Background(),
+		ShowInput{RunID: "bbbbbbbbbbbb", Out: &out, CurrentWorktree: "/repos/here"},
+		ShowDeps{ManifestStore: store},
+	)
+	if err != nil {
+		t.Fatalf("RunShow: %v", err)
+	}
+	if !strings.Contains(out.String(), "Investigation bbbbbbbbbbbb") {
+		t.Errorf("explicit run id should resolve regardless of worktree, got: %q", out.String())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/yuin/goldmark v1.8.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.53.0
 	golang.org/x/mod v0.37.0
@@ -126,7 +127,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect


### PR DESCRIPTION
## Summary

Adds `entire investigate show --html` — a self-contained, interactive HTML findings page — plus correctness fixes from review, a footer hint, and worktree scoping for the browse commands.

### What's here

**`show --html` (base feature)** — renders a saved investigation's findings to a styled, self-contained `findings.html` (no external assets) and opens it in the browser. Template-aware section parsing, TOC, in-page filter/highlight, collapsible sections, theme toggle, copy buttons, print/PDF, and Mermaid flowcharts rendered as Unicode box diagrams.

**Review correctness fixes** (`dc59db9b6`)
- **flowchart:** a chain of bare cross/circle arrowheads (`A --x B --x C`) collapsed to a single edge, silently dropping the middle node — the inline-label regex accepted `--x`/`--o` as a label closer. Restricted inline labels to `>`-headed arrows; bare `--x`/`--o` arrows still render.
- **flowchart:** a node label containing ` -- ` (`A[fetch -- retry] --> B`) regressed to raw fallback because the inline-label match reached inside the shape brackets. Excluded shape delimiters from the inline-label class.
- **html:** `~~~` code fences weren't tracked in `parseSections`, so a `##` line inside a tilde-fenced block became a phantom section. Now tracks both fence markers.
- **html:** scroll-spy left a stale TOC link highlighted when no heading was in the IntersectionObserver band. Recompute the active link from scroll position, skipping hidden headings.
- Fixed a stale `RenderFindingsHTML` doc comment.

**Footer HTML hint** (`ae5c3d3a4`) — after a terminal investigation, the post-run footer points at the HTML view before the `fix` command.

**Worktree scoping** (`14bad9c38`) — `show` (no run id) and `--findings` now default to the **current worktree** (matched on the manifest's `WorktreePath`), with `--all` to widen to every worktree. An explicit run id is always resolved repo-wide. Manifests with no recorded worktree, or when the worktree can't be determined, surface only under `--all` — scoping never silently hides a run.

### Testing

- `mise run lint` clean.
- Full `investigate` + `flowchart` package tests pass, including new regression tests (chained-arrowhead box count, double-dash node label, tilde fence, worktree filter, show scoping).
- Pre-existing `TestExplainCmd_SummaryTimeoutSecondsValidation` failures are unrelated (environmental; fail identically on a clean tree).

### Follow-up (not in this PR)

Investigation findings (the curated `findings.md`) currently live **only** in the local manifest — unlike `review`, whose deliverable is the session transcript on the checkpoint. Persisting the findings doc onto the investigation checkpoint (so it's pushed, survives `clean`/worktree deletion, and `show` works from any clone) is a separate change with its own design surface, deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only presentation and listing behavior; HTML uses safe markdown rendering and tests cover XSS escaping, scoping, and flowchart regressions.
> 
> **Overview**
> Adds **`entire investigate show --html`**, which builds a self-contained offline **`findings.html`** (goldmark-safe markdown, template-aware sections, TOC, filter/theme/print) and opens it via a new cross-platform **`openInBrowser`** helper. Terminal **`show`** now reorders findings through **`orderedFindingsMarkdown`** so CLI output matches the HTML view.
> 
> **`--findings`** and **`show`** without a run id default to the **current worktree** (`FilterByWorktree` on manifest `WorktreePath`); **`--all`** lists repo-wide. Explicit run ids still resolve globally. Post-run footers suggest **`show <id> --html`** before **`fix`**.
> 
> The **flowchart** parser gains broader Mermaid edge syntax (inline/pipe labels, `--x`/`--o` chains) with regressions fixed so chained arrowheads and labels containing ` -- ` do not drop nodes. **`LocalManifestStore.RunDir`** supports writing HTML beside per-run artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14bad9c383c2663f0fa11ada6547fc42cb6486d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->