### PR TITLE
import: support cursor, pi, factory, codex, copilot, gemini

### DIFF
--- a/cmd/entire/cli/agent/copilotcli/compat.go
+++ b/cmd/entire/cli/agent/copilotcli/compat.go
@@ -80,7 +80,7 @@ func parseHookEnvelope(data []byte) (*hookEnvelope, error) {
 		Reason:         firstString(raw, "reason"),
 	}
 
-	ts, err := parseTimestamp(raw["timestamp"])
+	ts, err := ParseTimestamp(raw["timestamp"])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse hook input: %w", err)
 	}
@@ -126,7 +126,11 @@ func firstString(raw map[string]json.RawMessage, keys ...string) string {
 	return ""
 }
 
-func parseTimestamp(raw json.RawMessage) (time.Time, error) {
+// ParseTimestamp decodes a Copilot event timestamp, which may be either numeric
+// epoch-millis or an RFC3339(Nano) string. A null/zero value returns the zero
+// time (callers treat that as "missing"). Exported so transcript importers can
+// decode the same dual-format field without re-implementing the logic.
+func ParseTimestamp(raw json.RawMessage) (time.Time, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return time.Time{}, nil
 	}

--- a/cmd/entire/cli/agentimport/agentimport.go
+++ b/cmd/entire/cli/agentimport/agentimport.go
@@ -75,8 +75,6 @@ var importers = []Importer{
 }
 
 // Get returns the importer registered under name.
-//
-//nolint:ireturn // Importer is the intended polymorphic seam returned to callers.
 func Get(name string) (Importer, bool) {
 	for _, imp := range importers {
 		if imp.Name() == name {

--- a/cmd/entire/cli/agentimport/agentimport.go
+++ b/cmd/entire/cli/agentimport/agentimport.go
@@ -66,6 +66,12 @@ type Importer interface {
 // Importer implementation appended here — no init() / runtime registration.
 var importers = []Importer{
 	claudeImporter{},
+	cursorImporter{},
+	piImporter{},
+	factoryImporter{},
+	codexImporter{},
+	copilotImporter{},
+	geminiImporter{},
 }
 
 // Get returns the importer registered under name.

--- a/cmd/entire/cli/agentimport/agentimport.go
+++ b/cmd/entire/cli/agentimport/agentimport.go
@@ -75,6 +75,8 @@ var importers = []Importer{
 }
 
 // Get returns the importer registered under name.
+//
+//nolint:ireturn // Importer is the intended polymorphic seam returned to callers.
 func Get(name string) (Importer, bool) {
 	for _, imp := range importers {
 		if imp.Name() == name {

--- a/cmd/entire/cli/agentimport/agentimport_test.go
+++ b/cmd/entire/cli/agentimport/agentimport_test.go
@@ -46,6 +46,36 @@ func TestRegistry_HasClaude(t *testing.T) {
 	}
 }
 
+// TestRegistry_AllSupportedAgents asserts every supported importer is
+// registered with a distinct name and a non-empty agent type.
+func TestRegistry_AllSupportedAgents(t *testing.T) {
+	t.Parallel()
+	want := []string{
+		"claude-code", "cursor", "pi", "factoryai-droid", "codex", "copilot-cli", "gemini",
+	}
+	for _, name := range want {
+		imp, ok := Get(name)
+		if !ok {
+			t.Errorf("%s importer not registered", name)
+			continue
+		}
+		if imp.AgentType() == "" {
+			t.Errorf("%s importer has empty AgentType", name)
+		}
+	}
+
+	seen := make(map[string]bool)
+	for _, imp := range All() {
+		if seen[imp.Name()] {
+			t.Errorf("duplicate importer name %q", imp.Name())
+		}
+		seen[imp.Name()] = true
+	}
+	if len(All()) != len(want) {
+		t.Errorf("registered %d importers, want %d (%v)", len(All()), len(want), want)
+	}
+}
+
 func initRepoWithCommit(t *testing.T) (*git.Repository, string) {
 	t.Helper()
 	repoDir := t.TempDir()
@@ -173,6 +203,52 @@ func TestRun_AppliesConfiguredCustomRedaction(t *testing.T) {
 	}
 	if !strings.Contains(string(sc.Transcript), redact.RedactedPlaceholder) {
 		t.Fatalf("expected %q in redacted transcript, got: %s", redact.RedactedPlaceholder, sc.Transcript)
+	}
+}
+
+// TestRun_CursorImporterEndToEnd exercises the generic Run pipeline through a
+// non-Claude importer whose turns carry nil tokens and an empty model, proving
+// the checkpoint write tolerates those (the riskiest divergence from Claude).
+func TestRun_CursorImporterEndToEnd(t *testing.T) {
+	t.Parallel()
+	repo, repoDir := initRepoWithCommit(t)
+	cursorDir := t.TempDir()
+	content := strings.Join([]string{
+		`{"role":"user","uuid":"u1","timestamp":"2026-06-20T00:00:00Z","message":{"role":"user","content":"hello"}}`,
+		`{"role":"assistant","uuid":"a1","message":{"content":[{"type":"text","text":"hi"}]}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(cursorDir, "sessC.jsonl"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := Options{RepoRoot: repoDir, OverridePath: cursorDir, Now: time.Date(2026, 6, 25, 0, 0, 0, 0, time.UTC)}
+	res, err := Run(context.Background(), repo, cursorImporter{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.TurnsImported != 1 {
+		t.Fatalf("want 1 imported, got %+v", res)
+	}
+
+	// Re-run is idempotent.
+	res2, err := Run(context.Background(), repo, cursorImporter{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res2.TurnsImported != 0 || res2.TurnsSkipped != 1 {
+		t.Fatalf("re-run not idempotent: %+v", res2)
+	}
+
+	stores, err := cp.Open(context.Background(), repo, cp.OpenOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	infos, err := stores.Persistent.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 1 || !infos[0].Imported {
+		t.Fatalf("expected 1 imported cursor checkpoint, got %+v", infos)
 	}
 }
 

--- a/cmd/entire/cli/agentimport/claude.go
+++ b/cmd/entire/cli/agentimport/claude.go
@@ -3,9 +3,7 @@ package agentimport
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -36,34 +34,7 @@ func (claudeImporter) Discover(repoRoot, overridePath string, now time.Time, ses
 		}
 		dir = d
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil // no transcripts for this repo
-		}
-		return nil, fmt.Errorf("read claude session dir: %w", err)
-	}
-	cutoff := now.AddDate(0, 0, -LookbackDays)
-	var out []SessionFile
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
-			continue
-		}
-		stem := strings.TrimSuffix(e.Name(), ".jsonl")
-		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, stem) {
-			continue
-		}
-		info, err := e.Info()
-		if err != nil {
-			continue
-		}
-		if info.ModTime().Before(cutoff) {
-			continue
-		}
-		out = append(out, SessionFile{Path: filepath.Join(dir, e.Name()), SessionID: stem})
-	}
-	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
-	return out, nil
+	return discoverSessionFiles(dir, now, sessionFilter, jsonlSessionResolver(".jsonl", identitySessionID))
 }
 
 // SplitTurns produces one Turn per user-prompt line. Token usage for each turn

--- a/cmd/entire/cli/agentimport/claude.go
+++ b/cmd/entire/cli/agentimport/claude.go
@@ -43,58 +43,34 @@ func (claudeImporter) Discover(repoRoot, overridePath string, now time.Time, ses
 // start a turn.
 func (claudeImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
 	subagentsDir := filepath.Join(filepath.Dir(sf.Path), sf.SessionID, "subagents")
-	rawLines := splitRawLines(full)
-
-	// Identify user-prompt turn starts in raw-line space.
-	var starts []int
-	for i, raw := range rawLines {
-		if isUserPromptLine(raw) {
-			starts = append(starts, i)
-		}
-	}
-
 	ag := &claudecode.ClaudeCodeAgent{}
-	turns := make([]Turn, 0, len(starts))
-	for k, start := range starts {
-		end := len(rawLines)
-		if k+1 < len(starts) {
-			end = starts[k+1]
-		}
-
-		// Bound token usage to [start, end): truncate to the first `end` lines,
-		// then let the agent helper slice from `start`.
-		truncated := joinLines(rawLines[:end])
-		tokens, err := ag.CalculateTotalTokenUsage(truncated, start, subagentsDir)
-		if err != nil {
-			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
-		}
-
-		var rec struct {
-			UUID      string          `json:"uuid"`
-			Message   json.RawMessage `json:"message"`
-			Timestamp string          `json:"timestamp"`
-		}
-		if err := json.Unmarshal(rawLines[start], &rec); err != nil {
-			// Already validated as a user-prompt line in isUserPromptLine; skip
-			// defensively if it somehow fails to parse here.
-			continue
-		}
-		ts, parseErr := time.Parse(time.RFC3339, rec.Timestamp)
-		if parseErr != nil {
-			ts = time.Time{}
-		}
-
-		turns = append(turns, Turn{
-			LineStart: start,
-			LineEnd:   end,
-			UUID:      rec.UUID,
-			Prompt:    transcript.ExtractUserContent(rec.Message),
-			Model:     modelInRange(rawLines, start, end),
-			CreatedAt: ts,
-			Tokens:    tokens,
+	return splitLineTurns(splitRawLines(full), isUserPromptLine,
+		func(rawLines [][]byte, start, end int, truncated []byte) (*Turn, error) {
+			tokens, err := ag.CalculateTotalTokenUsage(truncated, start, subagentsDir)
+			if err != nil {
+				return nil, fmt.Errorf("token usage: %w", err)
+			}
+			var rec struct {
+				UUID      string          `json:"uuid"`
+				Message   json.RawMessage `json:"message"`
+				Timestamp string          `json:"timestamp"`
+			}
+			if err := json.Unmarshal(rawLines[start], &rec); err != nil {
+				//nolint:nilerr // skip defensively; the line already parsed in isUserPromptLine
+				return nil, nil
+			}
+			ts, parseErr := time.Parse(time.RFC3339, rec.Timestamp)
+			if parseErr != nil {
+				ts = time.Time{}
+			}
+			return &Turn{
+				UUID:      rec.UUID,
+				Prompt:    transcript.ExtractUserContent(rec.Message),
+				Model:     modelInRange(rawLines, start, end),
+				CreatedAt: ts,
+				Tokens:    tokens,
+			}, nil
 		})
-	}
-	return turns, nil
 }
 
 // claudeExtraFields are line fields not modeled by transcript.Line.

--- a/cmd/entire/cli/agentimport/claude.go
+++ b/cmd/entire/cli/agentimport/claude.go
@@ -25,14 +25,9 @@ func (claudeImporter) AgentType() types.AgentType { return agent.AgentTypeClaude
 // dir; sessionFilter, when non-empty, keeps only matching session IDs (the
 // file stem).
 func (claudeImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
-	dir := overridePath
-	if dir == "" {
-		ag := &claudecode.ClaudeCodeAgent{}
-		d, err := ag.GetSessionDir(repoRoot)
-		if err != nil {
-			return nil, fmt.Errorf("resolve claude session dir: %w", err)
-		}
-		dir = d
+	dir, err := resolveDir(repoRoot, overridePath, "claude", (&claudecode.ClaudeCodeAgent{}).GetSessionDir)
+	if err != nil {
+		return nil, err
 	}
 	return discoverSessionFiles(dir, now, sessionFilter, jsonlSessionResolver(".jsonl", identitySessionID))
 }
@@ -59,15 +54,11 @@ func (claudeImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
 				//nolint:nilerr // skip defensively; the line already parsed in isUserPromptLine
 				return nil, nil
 			}
-			ts, parseErr := time.Parse(time.RFC3339, rec.Timestamp)
-			if parseErr != nil {
-				ts = time.Time{}
-			}
 			return &Turn{
 				UUID:      rec.UUID,
 				Prompt:    transcript.ExtractUserContent(rec.Message),
 				Model:     modelInRange(rawLines, start, end),
-				CreatedAt: ts,
+				CreatedAt: parseTimestamp(rec.Timestamp),
 				Tokens:    tokens,
 			}, nil
 		})

--- a/cmd/entire/cli/agentimport/codex.go
+++ b/cmd/entire/cli/agentimport/codex.go
@@ -112,41 +112,22 @@ func codexReadSessionMeta(path string) (codexSessionMeta, error) {
 // its (append-only) start line index. Token usage is delegated to the Codex
 // agent, which computes the cumulative-usage delta for the line range.
 func (codexImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
-	rawLines := splitRawLines(full)
-	var starts []int
-	for i, raw := range rawLines {
-		if _, ok := codexPromptText(raw); ok {
-			starts = append(starts, i)
-		}
-	}
-
 	ag := &codex.CodexAgent{}
-	turns := make([]Turn, 0, len(starts))
-	for k, start := range starts {
-		end := len(rawLines)
-		if k+1 < len(starts) {
-			end = starts[k+1]
-		}
-
-		truncated := joinLines(rawLines[:end])
-		tokens, err := ag.CalculateTokenUsage(truncated, start)
-		if err != nil {
-			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
-		}
-
-		prompt, _ := codexPromptText(rawLines[start])
-		ts := codexLineTime(rawLines[start])
-
-		turns = append(turns, Turn{
-			LineStart: start,
-			LineEnd:   end,
-			UUID:      strconv.Itoa(start),
-			Prompt:    prompt,
-			CreatedAt: ts,
-			Tokens:    tokens,
+	return splitLineTurns(splitRawLines(full),
+		func(raw []byte) bool { _, ok := codexPromptText(raw); return ok },
+		func(rawLines [][]byte, start, _ int, truncated []byte) (*Turn, error) {
+			tokens, err := ag.CalculateTokenUsage(truncated, start)
+			if err != nil {
+				return nil, fmt.Errorf("token usage: %w", err)
+			}
+			prompt, _ := codexPromptText(rawLines[start])
+			return &Turn{
+				UUID:      strconv.Itoa(start),
+				Prompt:    prompt,
+				CreatedAt: codexLineTime(rawLines[start]),
+				Tokens:    tokens,
+			}, nil
 		})
-	}
-	return turns, nil
 }
 
 // codexPromptText reports whether a raw rollout line is a user-prompt

--- a/cmd/entire/cli/agentimport/codex.go
+++ b/cmd/entire/cli/agentimport/codex.go
@@ -37,14 +37,9 @@ type codexSessionMeta struct {
 // Discover walks the Codex sessions tree and returns transcripts belonging to
 // this repo (by session_meta cwd) modified within the lookback window.
 func (codexImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
-	dir := overridePath
-	if dir == "" {
-		ag := &codex.CodexAgent{}
-		d, err := ag.GetSessionDir(repoRoot)
-		if err != nil {
-			return nil, fmt.Errorf("resolve codex session dir: %w", err)
-		}
-		dir = d
+	dir, err := resolveDir(repoRoot, overridePath, "codex", (&codex.CodexAgent{}).GetSessionDir)
+	if err != nil {
+		return nil, err
 	}
 	cutoff := now.AddDate(0, 0, -LookbackDays)
 	var out []SessionFile
@@ -178,11 +173,7 @@ func codexLineTime(raw []byte) time.Time {
 	if err := json.Unmarshal(raw, &line); err != nil {
 		return time.Time{}
 	}
-	ts, err := time.Parse(time.RFC3339, line.Timestamp)
-	if err != nil {
-		return time.Time{}
-	}
-	return ts
+	return parseTimestamp(line.Timestamp)
 }
 
 // repoMatches reports whether cwd is the repo root or a descendant of it. Both

--- a/cmd/entire/cli/agentimport/codex.go
+++ b/cmd/entire/cli/agentimport/codex.go
@@ -1,0 +1,232 @@
+package agentimport
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/codex"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+)
+
+// codexImporter imports Codex rollout transcripts. Codex stores sessions
+// globally (CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl), not per-repo, so
+// Discover walks the tree and keeps only sessions whose session_meta cwd is the
+// repo root or a descendant of it.
+type codexImporter struct{}
+
+func (codexImporter) Name() string { return string(agent.AgentNameCodex) }
+
+func (codexImporter) AgentType() types.AgentType { return agent.AgentTypeCodex }
+
+// codexSessionMeta is the subset of a Codex session_meta payload import needs.
+type codexSessionMeta struct {
+	ID  string `json:"id"`
+	Cwd string `json:"cwd"`
+}
+
+// Discover walks the Codex sessions tree and returns transcripts belonging to
+// this repo (by session_meta cwd) modified within the lookback window.
+func (codexImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
+	dir := overridePath
+	if dir == "" {
+		ag := &codex.CodexAgent{}
+		d, err := ag.GetSessionDir(repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve codex session dir: %w", err)
+		}
+		dir = d
+	}
+	cutoff := now.AddDate(0, 0, -LookbackDays)
+	var out []SessionFile
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil // missing root or vanished entry: nothing to import
+			}
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") {
+			return nil
+		}
+		info, statErr := d.Info()
+		if statErr != nil || info.ModTime().Before(cutoff) {
+			return nil //nolint:nilerr // skip unreadable/old entries, keep walking
+		}
+		meta, metaErr := codexReadSessionMeta(path)
+		if metaErr != nil || !repoMatches(meta.Cwd, repoRoot) {
+			return nil //nolint:nilerr // skip sessions we can't attribute to this repo
+		}
+		sessionID := meta.ID
+		if sessionID == "" {
+			sessionID = strings.TrimSuffix(d.Name(), ".jsonl")
+		}
+		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, sessionID) {
+			return nil
+		}
+		out = append(out, SessionFile{Path: path, SessionID: sessionID})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("walk codex sessions: %w", walkErr)
+	}
+	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
+	return out, nil
+}
+
+// codexReadSessionMeta reads the first JSONL line of a rollout file and returns
+// its session_meta payload. The first line must be session_meta by Codex's
+// format.
+func codexReadSessionMeta(path string) (codexSessionMeta, error) {
+	f, err := os.Open(path) //nolint:gosec // path discovered by walking the configured session dir
+	if err != nil {
+		return codexSessionMeta{}, fmt.Errorf("open rollout: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	r := bufio.NewReader(f)
+	first, err := r.ReadBytes('\n')
+	if len(first) == 0 && err != nil {
+		return codexSessionMeta{}, fmt.Errorf("read session_meta line: %w", err)
+	}
+	var line struct {
+		Type    string           `json:"type"`
+		Payload codexSessionMeta `json:"payload"`
+	}
+	if jsonErr := json.Unmarshal(first, &line); jsonErr != nil || line.Type != "session_meta" {
+		return codexSessionMeta{}, errors.New("first line is not session_meta")
+	}
+	return line.Payload, nil
+}
+
+// SplitTurns produces one Turn per user response_item, bounded by the next.
+// Codex response_items carry no per-message UUID, so the turn's stable key is
+// its (append-only) start line index. Token usage is delegated to the Codex
+// agent, which computes the cumulative-usage delta for the line range.
+func (codexImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
+	rawLines := splitRawLines(full)
+	var starts []int
+	for i, raw := range rawLines {
+		if _, ok := codexPromptText(raw); ok {
+			starts = append(starts, i)
+		}
+	}
+
+	ag := &codex.CodexAgent{}
+	turns := make([]Turn, 0, len(starts))
+	for k, start := range starts {
+		end := len(rawLines)
+		if k+1 < len(starts) {
+			end = starts[k+1]
+		}
+
+		truncated := joinLines(rawLines[:end])
+		tokens, err := ag.CalculateTokenUsage(truncated, start)
+		if err != nil {
+			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
+		}
+
+		prompt, _ := codexPromptText(rawLines[start])
+		ts := codexLineTime(rawLines[start])
+
+		turns = append(turns, Turn{
+			LineStart: start,
+			LineEnd:   end,
+			UUID:      strconv.Itoa(start),
+			Prompt:    prompt,
+			CreatedAt: ts,
+			Tokens:    tokens,
+		})
+	}
+	return turns, nil
+}
+
+// codexPromptText reports whether a raw rollout line is a user-prompt
+// response_item and returns its concatenated input_text. Assistant messages,
+// tool calls, and event_msg lines return false.
+func codexPromptText(raw []byte) (string, bool) {
+	var line struct {
+		Type    string          `json:"type"`
+		Payload json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(raw, &line); err != nil || line.Type != "response_item" {
+		return "", false
+	}
+	var payload struct {
+		Type    string `json:"type"`
+		Role    string `json:"role"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(line.Payload, &payload); err != nil {
+		return "", false
+	}
+	if payload.Type != "message" || payload.Role != "user" {
+		return "", false
+	}
+	var texts []string
+	for _, item := range payload.Content {
+		if item.Type == "input_text" {
+			if t := strings.TrimSpace(item.Text); t != "" {
+				texts = append(texts, t)
+			}
+		}
+	}
+	if len(texts) == 0 {
+		return "", false
+	}
+	return strings.Join(texts, "\n\n"), true
+}
+
+// codexLineTime returns the RFC3339 timestamp on a rollout line, or the zero
+// time when absent or unparseable.
+func codexLineTime(raw []byte) time.Time {
+	var line struct {
+		Timestamp string `json:"timestamp"`
+	}
+	if err := json.Unmarshal(raw, &line); err != nil {
+		return time.Time{}
+	}
+	ts, err := time.Parse(time.RFC3339, line.Timestamp)
+	if err != nil {
+		return time.Time{}
+	}
+	return ts
+}
+
+// repoMatches reports whether cwd is the repo root or a descendant of it. Both
+// paths are normalized (cleaned, symlinks resolved best-effort) before
+// comparison. Used by the global/flat-store importers (Codex, Copilot) to keep
+// only sessions belonging to this repo.
+func repoMatches(cwd, repoRoot string) bool {
+	if cwd == "" || repoRoot == "" {
+		return false
+	}
+	rel, err := filepath.Rel(normalizePath(repoRoot), normalizePath(cwd))
+	if err != nil {
+		return false
+	}
+	return !strings.HasPrefix(rel, "..")
+}
+
+// normalizePath cleans a path and resolves symlinks when possible, so a cwd
+// recorded through a symlinked path (e.g. macOS /var → /private/var) still
+// matches the repo root. Falls back to the cleaned path when the target does
+// not exist on this machine.
+func normalizePath(p string) string {
+	cleaned := filepath.Clean(p)
+	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
+		return resolved
+	}
+	return cleaned
+}

--- a/cmd/entire/cli/agentimport/codex_test.go
+++ b/cmd/entire/cli/agentimport/codex_test.go
@@ -1,0 +1,112 @@
+package agentimport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// codexSession builds a Codex rollout transcript whose session_meta carries the
+// given id and cwd.
+func codexSession(id, cwd string, body ...string) string {
+	meta := `{"timestamp":"2026-06-20T00:00:00Z","type":"session_meta","payload":{"id":"` + id + `","cwd":"` + cwd + `"}}`
+	return strings.Join(append([]string{meta}, body...), "\n") + "\n"
+}
+
+func TestCodexDiscover_RepoFilterLookbackRecursive(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	repoRoot := "/work/myrepo"
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+	writeRollout := func(rel, id, cwd string, age time.Duration) {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(codexSession(id, cwd)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		mt := now.Add(-age)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// In repo, recent (date-sharded path → exercises recursive walk).
+	writeRollout("2026/06/20/rollout-a-mine.jsonl", "mine", repoRoot, 5*24*time.Hour)
+	// In a subdir of the repo → still matches.
+	writeRollout("2026/06/20/rollout-b-sub.jsonl", "sub", repoRoot+"/pkg", 5*24*time.Hour)
+	// Different repo → excluded.
+	writeRollout("2026/06/20/rollout-c-other.jsonl", "other", "/work/elsewhere", 5*24*time.Hour)
+	// In repo but outside lookback → excluded.
+	writeRollout("2026/05/01/rollout-d-old.jsonl", "old", repoRoot, 60*24*time.Hour)
+
+	got, err := codexImporter{}.Discover(repoRoot, dir, now, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotIDs := map[string]bool{}
+	for _, sf := range got {
+		gotIDs[sf.SessionID] = true
+	}
+	if len(got) != 2 || !gotIDs["mine"] || !gotIDs["sub"] {
+		t.Fatalf("repo/lookback filter wrong, got %v", gotIDs)
+	}
+
+	got, err = codexImporter{}.Discover(repoRoot, dir, now, []string{"mine"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != "mine" {
+		t.Fatalf("session filter wrong: %v", got)
+	}
+}
+
+func TestCodexSplitTurns_PromptsAndTokenDelta(t *testing.T) {
+	t.Parallel()
+	full := []byte(codexSession("s1", "/work/myrepo",
+		`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"first"}]}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"total_tokens":15}}}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":30,"cached_input_tokens":0,"output_tokens":12,"total_tokens":42}}}}`,
+	))
+
+	turns, err := codexImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "r.jsonl"), SessionID: "s1"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("want 2 turns, got %d", len(turns))
+	}
+	if turns[0].LineStart != 1 || turns[0].LineEnd != 3 {
+		t.Errorf("turn0 bounds = [%d,%d), want [1,3)", turns[0].LineStart, turns[0].LineEnd)
+	}
+	if turns[0].Prompt != fxFirst || turns[1].Prompt != fxSecond {
+		t.Errorf("prompts = %q,%q", turns[0].Prompt, turns[1].Prompt)
+	}
+	// Codex reports cumulative usage; the per-turn delta must be scoped.
+	if turns[0].Tokens == nil || turns[0].Tokens.OutputTokens != 5 {
+		t.Errorf("turn0 token delta wrong: %+v", turns[0].Tokens)
+	}
+	if turns[1].Tokens == nil || turns[1].Tokens.OutputTokens != 7 {
+		t.Errorf("turn1 token delta = %+v, want output 7 (12-5)", turns[1].Tokens)
+	}
+}
+
+func TestCodexSplitTurns_NonUserResponseItemIsNotATurn(t *testing.T) {
+	t.Parallel()
+	full := []byte(codexSession("s1", "/work/myrepo",
+		`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"do it"}]}}`,
+		`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"working"}]}}`,
+		`{"type":"response_item","payload":{"type":"function_call","name":"shell","input":"ls"}}`,
+	))
+	turns, err := codexImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "r.jsonl"), SessionID: "s1"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("only the user message starts a turn; want 1, got %d", len(turns))
+	}
+}

--- a/cmd/entire/cli/agentimport/copilot.go
+++ b/cmd/entire/cli/agentimport/copilot.go
@@ -92,53 +92,30 @@ func copilotSessionInRepo(path, repoRoot string) bool {
 // Token usage is delegated to the Copilot agent (per-turn slices sum
 // assistant.message outputTokens); the model is read once from the transcript.
 func (copilotImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
-	rawLines := splitRawLines(full)
-	var starts []int
-	for i, raw := range rawLines {
-		if _, ok := copilotPromptText(raw); ok {
-			starts = append(starts, i)
-		}
-	}
-
 	ag := &copilotcli.CopilotCLIAgent{}
 	model := copilotcli.ExtractModelFromTranscript(context.Background(), sf.Path)
-	turns := make([]Turn, 0, len(starts))
-	for k, start := range starts {
-		end := len(rawLines)
-		if k+1 < len(starts) {
-			end = starts[k+1]
-		}
-
-		truncated := joinLines(rawLines[:end])
-		tokens, err := ag.CalculateTokenUsage(truncated, start)
-		if err != nil {
-			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
-		}
-
-		var evt struct {
-			ID        string `json:"id"`
-			Timestamp string `json:"timestamp"`
-		}
-		if err := json.Unmarshal(rawLines[start], &evt); err != nil {
-			continue
-		}
-		ts, parseErr := time.Parse(time.RFC3339, evt.Timestamp)
-		if parseErr != nil {
-			ts = time.Time{}
-		}
-		prompt, _ := copilotPromptText(rawLines[start])
-
-		turns = append(turns, Turn{
-			LineStart: start,
-			LineEnd:   end,
-			UUID:      evt.ID,
-			Prompt:    prompt,
-			Model:     model,
-			CreatedAt: ts,
-			Tokens:    tokens,
+	return splitLineTurns(splitRawLines(full),
+		func(raw []byte) bool { _, ok := copilotPromptText(raw); return ok },
+		func(rawLines [][]byte, start, _ int, truncated []byte) (*Turn, error) {
+			tokens, err := ag.CalculateTokenUsage(truncated, start)
+			if err != nil {
+				return nil, fmt.Errorf("token usage: %w", err)
+			}
+			var evt struct {
+				ID        string `json:"id"`
+				Timestamp string `json:"timestamp"`
+			}
+			if err := json.Unmarshal(rawLines[start], &evt); err != nil {
+				//nolint:nilerr // skip defensively; the line already parsed in copilotPromptText
+				return nil, nil
+			}
+			ts, parseErr := time.Parse(time.RFC3339, evt.Timestamp)
+			if parseErr != nil {
+				ts = time.Time{}
+			}
+			prompt, _ := copilotPromptText(rawLines[start])
+			return &Turn{UUID: evt.ID, Prompt: prompt, Model: model, CreatedAt: ts, Tokens: tokens}, nil
 		})
-	}
-	return turns, nil
 }
 
 // copilotPromptText reports whether a raw events.jsonl line is a user.message

--- a/cmd/entire/cli/agentimport/copilot.go
+++ b/cmd/entire/cli/agentimport/copilot.go
@@ -1,6 +1,7 @@
 package agentimport
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -73,11 +74,17 @@ func (copilotImporter) Discover(repoRoot, overridePath string, now time.Time, se
 // it in this repo (gitRoot or cwd is the repo root or a descendant). Sessions
 // whose location can't be determined are treated as not belonging to the repo.
 func copilotSessionInRepo(path, repoRoot string) bool {
-	data, err := os.ReadFile(path) //nolint:gosec // path discovered under the configured session dir
+	f, err := os.Open(path) //nolint:gosec // path discovered under the configured session dir
 	if err != nil {
 		return false
 	}
-	for _, raw := range splitRawLines(data) {
+	defer func() { _ = f.Close() }()
+
+	// Scan line-by-line and stop at the first session.start (normally line 0)
+	// rather than slurping the whole transcript, which can be large.
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), 10*1024*1024) // 10 MB max line
+	for scanner.Scan() {
 		var evt struct {
 			Type string `json:"type"`
 			Data struct {
@@ -87,7 +94,7 @@ func copilotSessionInRepo(path, repoRoot string) bool {
 				} `json:"context"`
 			} `json:"data"`
 		}
-		if err := json.Unmarshal(raw, &evt); err != nil || evt.Type != "session.start" {
+		if err := json.Unmarshal(scanner.Bytes(), &evt); err != nil || evt.Type != "session.start" {
 			continue
 		}
 		return repoMatches(evt.Data.Context.GitRoot, repoRoot) || repoMatches(evt.Data.Context.Cwd, repoRoot)

--- a/cmd/entire/cli/agentimport/copilot.go
+++ b/cmd/entire/cli/agentimport/copilot.go
@@ -16,6 +16,11 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/agent/types"
 )
 
+// maxCopilotLineBytes bounds the scanner buffer when reading events.jsonl;
+// individual Copilot events (e.g. large tool payloads) can exceed bufio's
+// default 64 KB line limit.
+const maxCopilotLineBytes = 10 * 1024 * 1024
+
 // copilotImporter imports Copilot CLI transcripts. Copilot stores sessions
 // flat (~/.copilot/session-state/<id>/events.jsonl), not per-repo, so Discover
 // reads each session's session.start event and keeps only those whose
@@ -83,7 +88,7 @@ func copilotSessionInRepo(path, repoRoot string) bool {
 	// Scan line-by-line and stop at the first session.start (normally line 0)
 	// rather than slurping the whole transcript, which can be large.
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), 10*1024*1024) // 10 MB max line
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxCopilotLineBytes)
 	for scanner.Scan() {
 		var evt struct {
 			Type string `json:"type"`

--- a/cmd/entire/cli/agentimport/copilot.go
+++ b/cmd/entire/cli/agentimport/copilot.go
@@ -97,15 +97,24 @@ func (copilotImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
 				return nil, fmt.Errorf("token usage: %w", err)
 			}
 			var evt struct {
-				ID        string `json:"id"`
-				Timestamp string `json:"timestamp"`
+				ID        string          `json:"id"`
+				Timestamp json.RawMessage `json:"timestamp"`
 			}
 			if err := json.Unmarshal(rawLines[start], &evt); err != nil {
 				//nolint:nilerr // skip defensively; the line already parsed in copilotPromptText
 				return nil, nil
 			}
+			// Copilot timestamps may be numeric epoch-millis or an RFC3339
+			// string; decode via the agent's dual-format parser so a numeric
+			// timestamp doesn't fail the turn.
+			createdAt, tsErr := copilotcli.ParseTimestamp(evt.Timestamp)
+			if tsErr != nil {
+				// A malformed timestamp degrades to the zero time rather than
+				// dropping the turn.
+				createdAt = time.Time{}
+			}
 			prompt, _ := copilotPromptText(rawLines[start])
-			return &Turn{UUID: evt.ID, Prompt: prompt, Model: model, CreatedAt: parseTimestamp(evt.Timestamp), Tokens: tokens}, nil
+			return &Turn{UUID: evt.ID, Prompt: prompt, Model: model, CreatedAt: createdAt, Tokens: tokens}, nil
 		})
 }
 

--- a/cmd/entire/cli/agentimport/copilot.go
+++ b/cmd/entire/cli/agentimport/copilot.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -44,35 +42,18 @@ func (copilotImporter) Discover(repoRoot, overridePath string, now time.Time, se
 		}
 		dir = d
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read copilot session dir: %w", err)
-	}
-	cutoff := now.AddDate(0, 0, -LookbackDays)
-	var out []SessionFile
-	for _, e := range entries {
+	// Each session is a subdirectory holding events.jsonl; keep only those whose
+	// session.start places them in this repo.
+	return discoverSessionFiles(dir, now, sessionFilter, func(dir string, e os.DirEntry) (string, string, bool) {
 		if !e.IsDir() {
-			continue
+			return "", "", false
 		}
-		sessionID := e.Name()
-		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, sessionID) {
-			continue
-		}
-		path := filepath.Join(dir, sessionID, "events.jsonl")
-		info, statErr := os.Stat(path)
-		if statErr != nil || info.ModTime().Before(cutoff) {
-			continue
-		}
+		path := filepath.Join(dir, e.Name(), "events.jsonl")
 		if !copilotSessionInRepo(path, repoRoot) {
-			continue
+			return "", "", false
 		}
-		out = append(out, SessionFile{Path: path, SessionID: sessionID})
-	}
-	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
-	return out, nil
+		return e.Name(), path, true
+	})
 }
 
 // copilotSessionInRepo reports whether the session's session.start event places

--- a/cmd/entire/cli/agentimport/copilot.go
+++ b/cmd/entire/cli/agentimport/copilot.go
@@ -33,14 +33,9 @@ func (copilotImporter) AgentType() types.AgentType { return agent.AgentTypeCopil
 // session.start context) modified within the lookback window. The session ID is
 // the session-state subdirectory name.
 func (copilotImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
-	dir := overridePath
-	if dir == "" {
-		ag := &copilotcli.CopilotCLIAgent{}
-		d, err := ag.GetSessionDir(repoRoot)
-		if err != nil {
-			return nil, fmt.Errorf("resolve copilot session dir: %w", err)
-		}
-		dir = d
+	dir, err := resolveDir(repoRoot, overridePath, "copilot", (&copilotcli.CopilotCLIAgent{}).GetSessionDir)
+	if err != nil {
+		return nil, err
 	}
 	// Each session is a subdirectory holding events.jsonl; keep only those whose
 	// session.start places them in this repo.
@@ -109,12 +104,8 @@ func (copilotImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
 				//nolint:nilerr // skip defensively; the line already parsed in copilotPromptText
 				return nil, nil
 			}
-			ts, parseErr := time.Parse(time.RFC3339, evt.Timestamp)
-			if parseErr != nil {
-				ts = time.Time{}
-			}
 			prompt, _ := copilotPromptText(rawLines[start])
-			return &Turn{UUID: evt.ID, Prompt: prompt, Model: model, CreatedAt: ts, Tokens: tokens}, nil
+			return &Turn{UUID: evt.ID, Prompt: prompt, Model: model, CreatedAt: parseTimestamp(evt.Timestamp), Tokens: tokens}, nil
 		})
 }
 

--- a/cmd/entire/cli/agentimport/copilot.go
+++ b/cmd/entire/cli/agentimport/copilot.go
@@ -1,0 +1,167 @@
+package agentimport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/copilotcli"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+)
+
+// copilotImporter imports Copilot CLI transcripts. Copilot stores sessions
+// flat (~/.copilot/session-state/<id>/events.jsonl), not per-repo, so Discover
+// reads each session's session.start event and keeps only those whose
+// cwd/gitRoot is the repo root or a descendant.
+type copilotImporter struct{}
+
+func (copilotImporter) Name() string { return string(agent.AgentNameCopilotCLI) }
+
+func (copilotImporter) AgentType() types.AgentType { return agent.AgentTypeCopilotCLI }
+
+// Discover returns Copilot session transcripts belonging to this repo (by the
+// session.start context) modified within the lookback window. The session ID is
+// the session-state subdirectory name.
+func (copilotImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
+	dir := overridePath
+	if dir == "" {
+		ag := &copilotcli.CopilotCLIAgent{}
+		d, err := ag.GetSessionDir(repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve copilot session dir: %w", err)
+		}
+		dir = d
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read copilot session dir: %w", err)
+	}
+	cutoff := now.AddDate(0, 0, -LookbackDays)
+	var out []SessionFile
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sessionID := e.Name()
+		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, sessionID) {
+			continue
+		}
+		path := filepath.Join(dir, sessionID, "events.jsonl")
+		info, statErr := os.Stat(path)
+		if statErr != nil || info.ModTime().Before(cutoff) {
+			continue
+		}
+		if !copilotSessionInRepo(path, repoRoot) {
+			continue
+		}
+		out = append(out, SessionFile{Path: path, SessionID: sessionID})
+	}
+	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
+	return out, nil
+}
+
+// copilotSessionInRepo reports whether the session's session.start event places
+// it in this repo (gitRoot or cwd is the repo root or a descendant). Sessions
+// whose location can't be determined are treated as not belonging to the repo.
+func copilotSessionInRepo(path, repoRoot string) bool {
+	data, err := os.ReadFile(path) //nolint:gosec // path discovered under the configured session dir
+	if err != nil {
+		return false
+	}
+	for _, raw := range splitRawLines(data) {
+		var evt struct {
+			Type string `json:"type"`
+			Data struct {
+				Context struct {
+					Cwd     string `json:"cwd"`
+					GitRoot string `json:"gitRoot"`
+				} `json:"context"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(raw, &evt); err != nil || evt.Type != "session.start" {
+			continue
+		}
+		return repoMatches(evt.Data.Context.GitRoot, repoRoot) || repoMatches(evt.Data.Context.Cwd, repoRoot)
+	}
+	return false
+}
+
+// SplitTurns produces one Turn per user.message event, bounded by the next.
+// Token usage is delegated to the Copilot agent (per-turn slices sum
+// assistant.message outputTokens); the model is read once from the transcript.
+func (copilotImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
+	rawLines := splitRawLines(full)
+	var starts []int
+	for i, raw := range rawLines {
+		if _, ok := copilotPromptText(raw); ok {
+			starts = append(starts, i)
+		}
+	}
+
+	ag := &copilotcli.CopilotCLIAgent{}
+	model := copilotcli.ExtractModelFromTranscript(context.Background(), sf.Path)
+	turns := make([]Turn, 0, len(starts))
+	for k, start := range starts {
+		end := len(rawLines)
+		if k+1 < len(starts) {
+			end = starts[k+1]
+		}
+
+		truncated := joinLines(rawLines[:end])
+		tokens, err := ag.CalculateTokenUsage(truncated, start)
+		if err != nil {
+			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
+		}
+
+		var evt struct {
+			ID        string `json:"id"`
+			Timestamp string `json:"timestamp"`
+		}
+		if err := json.Unmarshal(rawLines[start], &evt); err != nil {
+			continue
+		}
+		ts, parseErr := time.Parse(time.RFC3339, evt.Timestamp)
+		if parseErr != nil {
+			ts = time.Time{}
+		}
+		prompt, _ := copilotPromptText(rawLines[start])
+
+		turns = append(turns, Turn{
+			LineStart: start,
+			LineEnd:   end,
+			UUID:      evt.ID,
+			Prompt:    prompt,
+			Model:     model,
+			CreatedAt: ts,
+			Tokens:    tokens,
+		})
+	}
+	return turns, nil
+}
+
+// copilotPromptText reports whether a raw events.jsonl line is a user.message
+// and returns its content. Other event types return false.
+func copilotPromptText(raw []byte) (string, bool) {
+	var evt struct {
+		Type string `json:"type"`
+		Data struct {
+			Content string `json:"content"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &evt); err != nil || evt.Type != "user.message" {
+		return "", false
+	}
+	if evt.Data.Content == "" {
+		return "", false
+	}
+	return evt.Data.Content, true
+}

--- a/cmd/entire/cli/agentimport/copilot_test.go
+++ b/cmd/entire/cli/agentimport/copilot_test.go
@@ -98,6 +98,36 @@ func TestCopilotSplitTurns_PromptsTokensModel(t *testing.T) {
 	}
 }
 
+// TestCopilotSplitTurns_NumericTimestamp covers the dual-format timestamp:
+// Copilot may emit a numeric epoch-millis timestamp instead of an RFC3339
+// string. Decoding it as a plain string would fail json.Unmarshal and silently
+// drop the turn, importing zero turns for the session.
+func TestCopilotSplitTurns_NumericTimestamp(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "events.jsonl")
+	const epochMillis = 1750377601000 // 2025-06-20T00:00:01Z
+	full := []byte(strings.Join([]string{
+		`{"type":"session.start","id":"s0","timestamp":1750377600000,"data":{"context":{"gitRoot":"/work/myrepo"}}}`,
+		`{"type":"user.message","id":"u1","timestamp":1750377601000,"data":{"content":"first"}}`,
+		`{"type":"assistant.message","id":"a1","data":{"content":"ok","outputTokens":5}}`,
+	}, "\n") + "\n")
+	if err := os.WriteFile(p, full, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	turns, err := copilotImporter{}.SplitTurns(SessionFile{Path: p, SessionID: "sess"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("numeric timestamp must not drop the turn; want 1, got %d", len(turns))
+	}
+	if want := time.UnixMilli(epochMillis); !turns[0].CreatedAt.Equal(want) {
+		t.Errorf("CreatedAt = %v, want %v (decoded from epoch-millis)", turns[0].CreatedAt, want)
+	}
+}
+
 func TestCopilotSplitTurns_NonUserEventIsNotATurn(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/cmd/entire/cli/agentimport/copilot_test.go
+++ b/cmd/entire/cli/agentimport/copilot_test.go
@@ -1,0 +1,120 @@
+package agentimport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// copilotSession writes <base>/<id>/events.jsonl with a session.start carrying
+// gitRoot, and returns nothing (sets modtime via age).
+func writeCopilotSession(t *testing.T, base, id, gitRoot string, age time.Duration, now time.Time, body ...string) {
+	t.Helper()
+	sdir := filepath.Join(base, id)
+	if err := os.MkdirAll(sdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	start := `{"type":"session.start","id":"s0","timestamp":"2026-06-20T00:00:00Z","data":{"context":{"cwd":"` + gitRoot + `","gitRoot":"` + gitRoot + `"}}}`
+	content := strings.Join(append([]string{start}, body...), "\n") + "\n"
+	p := filepath.Join(sdir, "events.jsonl")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mt := now.Add(-age)
+	if err := os.Chtimes(p, mt, mt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCopilotDiscover_RepoFilterAndLookback(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	repoRoot := "/work/myrepo"
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+	writeCopilotSession(t, base, "mine", repoRoot, 5*24*time.Hour, now)
+	writeCopilotSession(t, base, "other", "/work/elsewhere", 5*24*time.Hour, now)
+	writeCopilotSession(t, base, "old", repoRoot, 60*24*time.Hour, now)
+
+	got, err := copilotImporter{}.Discover(repoRoot, base, now, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != "mine" {
+		t.Fatalf("repo/lookback filter wrong: %v", got)
+	}
+
+	got, err = copilotImporter{}.Discover(repoRoot, base, now, []string{"old"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("old session is outside lookback even when filtered: %v", got)
+	}
+}
+
+func TestCopilotSplitTurns_PromptsTokensModel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "events.jsonl")
+	full := []byte(strings.Join([]string{
+		`{"type":"session.start","id":"s0","timestamp":"2026-06-20T00:00:00Z","data":{"context":{"gitRoot":"/work/myrepo"}}}`,
+		`{"type":"session.model_change","id":"mc","data":{"newModel":"gpt-5"}}`,
+		`{"type":"user.message","id":"u1","timestamp":"2026-06-20T00:00:01Z","data":{"content":"first"}}`,
+		`{"type":"assistant.message","id":"a1","data":{"content":"ok","outputTokens":5}}`,
+		`{"type":"user.message","id":"u2","timestamp":"2026-06-20T00:01:00Z","data":{"content":"second"}}`,
+		`{"type":"assistant.message","id":"a2","data":{"content":"done","outputTokens":7}}`,
+	}, "\n") + "\n")
+	if err := os.WriteFile(p, full, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	turns, err := copilotImporter{}.SplitTurns(SessionFile{Path: p, SessionID: "sess"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("want 2 turns, got %d", len(turns))
+	}
+	if turns[0].LineStart != 2 || turns[0].LineEnd != 4 {
+		t.Errorf("turn0 bounds = [%d,%d), want [2,4)", turns[0].LineStart, turns[0].LineEnd)
+	}
+	if turns[0].Prompt != fxFirst || turns[1].Prompt != fxSecond {
+		t.Errorf("prompts = %q,%q", turns[0].Prompt, turns[1].Prompt)
+	}
+	if turns[0].UUID != "u1" {
+		t.Errorf("turn0 uuid = %q, want u1", turns[0].UUID)
+	}
+	if turns[0].Model != "gpt-5" {
+		t.Errorf("turn0 model = %q, want gpt-5", turns[0].Model)
+	}
+	if turns[0].Tokens == nil || turns[0].Tokens.OutputTokens != 5 {
+		t.Errorf("turn0 tokens not bounded to its own turn: %+v", turns[0].Tokens)
+	}
+	if turns[1].Tokens == nil || turns[1].Tokens.OutputTokens != 7 {
+		t.Errorf("turn1 tokens wrong: %+v", turns[1].Tokens)
+	}
+}
+
+func TestCopilotSplitTurns_NonUserEventIsNotATurn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "events.jsonl")
+	full := []byte(strings.Join([]string{
+		`{"type":"user.message","id":"u1","data":{"content":"do it"}}`,
+		`{"type":"tool.execution_complete","id":"t1","data":{"toolCallId":"x"}}`,
+		`{"type":"assistant.message","id":"a1","data":{"content":"done","outputTokens":3}}`,
+	}, "\n") + "\n")
+	if werr := os.WriteFile(p, full, 0o644); werr != nil {
+		t.Fatal(werr)
+	}
+	turns, err := copilotImporter{}.SplitTurns(SessionFile{Path: p, SessionID: "sess"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("only user.message starts a turn; want 1, got %d", len(turns))
+	}
+}

--- a/cmd/entire/cli/agentimport/cursor.go
+++ b/cmd/entire/cli/agentimport/cursor.go
@@ -64,38 +64,25 @@ func cursorSessionFile(dir string, e os.DirEntry) (sessionID, path string) {
 // reuses the package's shared JSONL helpers; Cursor carries no token usage or
 // model, so those fields are left zero.
 func (cursorImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
-	rawLines := splitRawLines(full)
-	var starts []int
-	for i, raw := range rawLines {
-		if isUserPromptLine(raw) {
-			starts = append(starts, i)
-		}
-	}
-	turns := make([]Turn, 0, len(starts))
-	for k, start := range starts {
-		end := len(rawLines)
-		if k+1 < len(starts) {
-			end = starts[k+1]
-		}
-		var rec struct {
-			UUID      string          `json:"uuid"`
-			Message   json.RawMessage `json:"message"`
-			Timestamp string          `json:"timestamp"`
-		}
-		if err := json.Unmarshal(rawLines[start], &rec); err != nil {
-			continue
-		}
-		ts, parseErr := time.Parse(time.RFC3339, rec.Timestamp)
-		if parseErr != nil {
-			ts = time.Time{}
-		}
-		turns = append(turns, Turn{
-			LineStart: start,
-			LineEnd:   end,
-			UUID:      rec.UUID,
-			Prompt:    transcript.ExtractUserContent(rec.Message),
-			CreatedAt: ts,
+	return splitLineTurns(splitRawLines(full), isUserPromptLine,
+		func(rawLines [][]byte, start, _ int, _ []byte) (*Turn, error) {
+			var rec struct {
+				UUID      string          `json:"uuid"`
+				Message   json.RawMessage `json:"message"`
+				Timestamp string          `json:"timestamp"`
+			}
+			if err := json.Unmarshal(rawLines[start], &rec); err != nil {
+				//nolint:nilerr // skip defensively; the line already parsed in isUserPromptLine
+				return nil, nil
+			}
+			ts, parseErr := time.Parse(time.RFC3339, rec.Timestamp)
+			if parseErr != nil {
+				ts = time.Time{}
+			}
+			return &Turn{
+				UUID:      rec.UUID,
+				Prompt:    transcript.ExtractUserContent(rec.Message),
+				CreatedAt: ts,
+			}, nil
 		})
-	}
-	return turns, nil
 }

--- a/cmd/entire/cli/agentimport/cursor.go
+++ b/cmd/entire/cli/agentimport/cursor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -38,31 +37,10 @@ func (cursorImporter) Discover(repoRoot, overridePath string, now time.Time, ses
 		}
 		dir = d
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read cursor session dir: %w", err)
-	}
-	cutoff := now.AddDate(0, 0, -LookbackDays)
-	var out []SessionFile
-	for _, e := range entries {
-		stem, path := cursorSessionFile(dir, e)
-		if path == "" {
-			continue
-		}
-		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, stem) {
-			continue
-		}
-		info, statErr := os.Stat(path)
-		if statErr != nil || info.ModTime().Before(cutoff) {
-			continue
-		}
-		out = append(out, SessionFile{Path: path, SessionID: stem})
-	}
-	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
-	return out, nil
+	return discoverSessionFiles(dir, now, sessionFilter, func(dir string, e os.DirEntry) (string, string, bool) {
+		id, path := cursorSessionFile(dir, e)
+		return id, path, path != ""
+	})
 }
 
 // cursorSessionFile maps a directory entry to a (sessionID, transcript path),

--- a/cmd/entire/cli/agentimport/cursor.go
+++ b/cmd/entire/cli/agentimport/cursor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -57,22 +58,31 @@ func cursorSessionFile(dir string, e os.DirEntry) (sessionID, path string) {
 // SplitTurns produces one Turn per user-prompt line, bounded by the next. It
 // reuses the package's shared JSONL helpers; Cursor carries no token usage or
 // model, so those fields are left zero.
-func (cursorImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
+//
+// Real Cursor lines carry only role + message — there is no per-turn uuid or
+// timestamp (see cursor/AGENT.md). The append-only line index is the stable
+// turn key (as the Codex importer does), so each prompt yields a distinct
+// checkpoint ID instead of colliding on an empty UUID and dropping every turn
+// after the first. The timestamp falls back to the transcript file's modtime
+// (as the Factory/Gemini importers do).
+func (cursorImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
+	var createdAt time.Time
+	if info, statErr := os.Stat(sf.Path); statErr == nil {
+		createdAt = info.ModTime()
+	}
 	return splitLineTurns(splitRawLines(full), isUserPromptLine,
 		func(rawLines [][]byte, start, _ int, _ []byte) (*Turn, error) {
 			var rec struct {
-				UUID      string          `json:"uuid"`
-				Message   json.RawMessage `json:"message"`
-				Timestamp string          `json:"timestamp"`
+				Message json.RawMessage `json:"message"`
 			}
 			if err := json.Unmarshal(rawLines[start], &rec); err != nil {
 				//nolint:nilerr // skip defensively; the line already parsed in isUserPromptLine
 				return nil, nil
 			}
 			return &Turn{
-				UUID:      rec.UUID,
+				UUID:      strconv.Itoa(start),
 				Prompt:    transcript.ExtractUserContent(rec.Message),
-				CreatedAt: parseTimestamp(rec.Timestamp),
+				CreatedAt: createdAt,
 			}, nil
 		})
 }

--- a/cmd/entire/cli/agentimport/cursor.go
+++ b/cmd/entire/cli/agentimport/cursor.go
@@ -2,7 +2,6 @@ package agentimport
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,14 +27,9 @@ func (cursorImporter) AgentType() types.AgentType { return agent.AgentTypeCursor
 // lookback window. Cursor stores sessions either flat (<dir>/<id>.jsonl) or
 // nested (<dir>/<id>/<id>.jsonl, the IDE layout); both are discovered.
 func (cursorImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
-	dir := overridePath
-	if dir == "" {
-		ag := &cursor.CursorAgent{}
-		d, err := ag.GetSessionDir(repoRoot)
-		if err != nil {
-			return nil, fmt.Errorf("resolve cursor session dir: %w", err)
-		}
-		dir = d
+	dir, err := resolveDir(repoRoot, overridePath, "cursor", (&cursor.CursorAgent{}).GetSessionDir)
+	if err != nil {
+		return nil, err
 	}
 	return discoverSessionFiles(dir, now, sessionFilter, func(dir string, e os.DirEntry) (string, string, bool) {
 		id, path := cursorSessionFile(dir, e)
@@ -75,14 +69,10 @@ func (cursorImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
 				//nolint:nilerr // skip defensively; the line already parsed in isUserPromptLine
 				return nil, nil
 			}
-			ts, parseErr := time.Parse(time.RFC3339, rec.Timestamp)
-			if parseErr != nil {
-				ts = time.Time{}
-			}
 			return &Turn{
 				UUID:      rec.UUID,
 				Prompt:    transcript.ExtractUserContent(rec.Message),
-				CreatedAt: ts,
+				CreatedAt: parseTimestamp(rec.Timestamp),
 			}, nil
 		})
 }

--- a/cmd/entire/cli/agentimport/cursor.go
+++ b/cmd/entire/cli/agentimport/cursor.go
@@ -1,0 +1,123 @@
+package agentimport
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/cursor"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/transcript"
+)
+
+// cursorImporter imports Cursor transcripts. Cursor uses the same JSONL line
+// format as Claude Code (role-tagged), so it reuses the shared user-prompt
+// detection and content extraction. Cursor records neither model nor token
+// usage, so imported turns carry an empty model and nil tokens.
+type cursorImporter struct{}
+
+func (cursorImporter) Name() string { return string(agent.AgentNameCursor) }
+
+func (cursorImporter) AgentType() types.AgentType { return agent.AgentTypeCursor }
+
+// Discover returns Cursor transcript files for the repo modified within the
+// lookback window. Cursor stores sessions either flat (<dir>/<id>.jsonl) or
+// nested (<dir>/<id>/<id>.jsonl, the IDE layout); both are discovered.
+func (cursorImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
+	dir := overridePath
+	if dir == "" {
+		ag := &cursor.CursorAgent{}
+		d, err := ag.GetSessionDir(repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve cursor session dir: %w", err)
+		}
+		dir = d
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read cursor session dir: %w", err)
+	}
+	cutoff := now.AddDate(0, 0, -LookbackDays)
+	var out []SessionFile
+	for _, e := range entries {
+		stem, path := cursorSessionFile(dir, e)
+		if path == "" {
+			continue
+		}
+		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, stem) {
+			continue
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil || info.ModTime().Before(cutoff) {
+			continue
+		}
+		out = append(out, SessionFile{Path: path, SessionID: stem})
+	}
+	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
+	return out, nil
+}
+
+// cursorSessionFile maps a directory entry to a (sessionID, transcript path),
+// resolving both the flat and nested Cursor layouts. Returns an empty path for
+// entries that are not Cursor transcripts.
+func cursorSessionFile(dir string, e os.DirEntry) (sessionID, path string) {
+	if e.IsDir() {
+		nested := filepath.Join(dir, e.Name(), e.Name()+".jsonl")
+		if _, err := os.Stat(nested); err == nil {
+			return e.Name(), nested
+		}
+		return "", ""
+	}
+	if !strings.HasSuffix(e.Name(), ".jsonl") {
+		return "", ""
+	}
+	return strings.TrimSuffix(e.Name(), ".jsonl"), filepath.Join(dir, e.Name())
+}
+
+// SplitTurns produces one Turn per user-prompt line, bounded by the next. It
+// reuses the package's shared JSONL helpers; Cursor carries no token usage or
+// model, so those fields are left zero.
+func (cursorImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
+	rawLines := splitRawLines(full)
+	var starts []int
+	for i, raw := range rawLines {
+		if isUserPromptLine(raw) {
+			starts = append(starts, i)
+		}
+	}
+	turns := make([]Turn, 0, len(starts))
+	for k, start := range starts {
+		end := len(rawLines)
+		if k+1 < len(starts) {
+			end = starts[k+1]
+		}
+		var rec struct {
+			UUID      string          `json:"uuid"`
+			Message   json.RawMessage `json:"message"`
+			Timestamp string          `json:"timestamp"`
+		}
+		if err := json.Unmarshal(rawLines[start], &rec); err != nil {
+			continue
+		}
+		ts, parseErr := time.Parse(time.RFC3339, rec.Timestamp)
+		if parseErr != nil {
+			ts = time.Time{}
+		}
+		turns = append(turns, Turn{
+			LineStart: start,
+			LineEnd:   end,
+			UUID:      rec.UUID,
+			Prompt:    transcript.ExtractUserContent(rec.Message),
+			CreatedAt: ts,
+		})
+	}
+	return turns, nil
+}

--- a/cmd/entire/cli/agentimport/cursor_test.go
+++ b/cmd/entire/cli/agentimport/cursor_test.go
@@ -90,14 +90,21 @@ func TestCursorDiscover_MissingDirIsEmpty(t *testing.T) {
 
 func TestCursorSplitTurns_TwoPromptsNoTokensNoModel(t *testing.T) {
 	t.Parallel()
-	// Cursor uses "role" (not "type") and records neither model nor token usage.
+	// Real Cursor lines use "role" (not "type"), carry no per-turn uuid or
+	// timestamp, and record neither model nor token usage (see cursor/AGENT.md).
 	full := []byte(strings.Join([]string{
-		`{"role":"user","uuid":"u1","timestamp":"2026-06-20T00:00:00Z","message":{"role":"user","content":"first"}}`,
-		`{"role":"assistant","uuid":"a1","message":{"content":[{"type":"text","text":"ok"}]}}`,
-		`{"role":"user","uuid":"u2","timestamp":"2026-06-20T00:01:00Z","message":{"role":"user","content":"second"}}`,
+		`{"role":"user","message":{"role":"user","content":"first"}}`,
+		`{"role":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}`,
+		`{"role":"user","message":{"role":"user","content":"second"}}`,
 	}, "\n") + "\n")
+	// Write the transcript so the importer's modtime CreatedAt fallback has a
+	// real file to stat.
+	p := filepath.Join(t.TempDir(), "s.jsonl")
+	if err := os.WriteFile(p, full, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
-	turns, err := cursorImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "s.jsonl"), SessionID: "s"}, full)
+	turns, err := cursorImporter{}.SplitTurns(SessionFile{Path: p, SessionID: "s"}, full)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,6 +117,14 @@ func TestCursorSplitTurns_TwoPromptsNoTokensNoModel(t *testing.T) {
 	if turns[0].Prompt != fxFirst || turns[1].Prompt != fxSecond {
 		t.Errorf("prompts = %q,%q", turns[0].Prompt, turns[1].Prompt)
 	}
+	// Each turn must get a distinct (line-index) key; an empty/duplicate UUID
+	// would collide on one checkpoint ID and drop every turn after the first.
+	if turns[0].UUID == "" || turns[1].UUID == "" || turns[0].UUID == turns[1].UUID {
+		t.Errorf("turn UUIDs must be non-empty and distinct, got %q and %q", turns[0].UUID, turns[1].UUID)
+	}
+	if turns[0].CreatedAt.IsZero() {
+		t.Errorf("CreatedAt should fall back to the file modtime, got zero")
+	}
 	if turns[0].Tokens != nil {
 		t.Errorf("cursor records no tokens, want nil, got %+v", turns[0].Tokens)
 	}
@@ -121,9 +136,9 @@ func TestCursorSplitTurns_TwoPromptsNoTokensNoModel(t *testing.T) {
 func TestCursorSplitTurns_ToolResultIsNotATurn(t *testing.T) {
 	t.Parallel()
 	full := []byte(strings.Join([]string{
-		`{"role":"user","uuid":"u1","message":{"role":"user","content":"do it"}}`,
-		`{"role":"assistant","uuid":"a1","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]}}`,
-		`{"role":"user","uuid":"r1","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"out"}]}}`,
+		`{"role":"user","message":{"role":"user","content":"do it"}}`,
+		`{"role":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]}}`,
+		`{"role":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"out"}]}}`,
 	}, "\n") + "\n")
 	turns, err := cursorImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "s.jsonl"), SessionID: "s"}, full)
 	if err != nil {

--- a/cmd/entire/cli/agentimport/cursor_test.go
+++ b/cmd/entire/cli/agentimport/cursor_test.go
@@ -1,0 +1,135 @@
+package agentimport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCursorDiscover_FlatLookbackAndFilter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	writeAged := func(name string, age time.Duration) {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		mt := now.Add(-age)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeAged("recent.jsonl", 5*24*time.Hour)
+	writeAged("old.jsonl", 60*24*time.Hour)
+	writeAged("skip.txt", 1*time.Hour)
+
+	imp := cursorImporter{}
+	got, err := imp.Discover("", dir, now, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != fxRecent {
+		t.Fatalf("lookback filter wrong: %v", got)
+	}
+
+	writeAged("abc123.jsonl", 1*24*time.Hour)
+	got, err = imp.Discover("", dir, now, []string{"abc123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != "abc123" {
+		t.Fatalf("session filter wrong: %v", got)
+	}
+}
+
+// TestCursorDiscover_NestedLayout covers Cursor's IDE layout where the transcript
+// lives at <dir>/<id>/<id>.jsonl rather than flat at <dir>/<id>.jsonl.
+func TestCursorDiscover_NestedLayout(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	sessID := "nested-sess"
+	nestedDir := filepath.Join(dir, sessID)
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(nestedDir, sessID+".jsonl")
+	if err := os.WriteFile(p, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mt := now.Add(-2 * 24 * time.Hour)
+	if err := os.Chtimes(p, mt, mt); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := cursorImporter{}.Discover("", dir, now, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != sessID {
+		t.Fatalf("nested discover wrong: %v", got)
+	}
+	if got[0].Path != p {
+		t.Fatalf("nested path = %q, want %q", got[0].Path, p)
+	}
+}
+
+func TestCursorDiscover_MissingDirIsEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := cursorImporter{}.Discover("", filepath.Join(t.TempDir(), "nope"), time.Now(), nil)
+	if err != nil {
+		t.Fatalf("missing dir should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty, got %v", got)
+	}
+}
+
+func TestCursorSplitTurns_TwoPromptsNoTokensNoModel(t *testing.T) {
+	t.Parallel()
+	// Cursor uses "role" (not "type") and records neither model nor token usage.
+	full := []byte(strings.Join([]string{
+		`{"role":"user","uuid":"u1","timestamp":"2026-06-20T00:00:00Z","message":{"role":"user","content":"first"}}`,
+		`{"role":"assistant","uuid":"a1","message":{"content":[{"type":"text","text":"ok"}]}}`,
+		`{"role":"user","uuid":"u2","timestamp":"2026-06-20T00:01:00Z","message":{"role":"user","content":"second"}}`,
+	}, "\n") + "\n")
+
+	turns, err := cursorImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "s.jsonl"), SessionID: "s"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("want 2 turns, got %d", len(turns))
+	}
+	if turns[0].LineStart != 0 || turns[0].LineEnd != 2 {
+		t.Errorf("turn0 bounds = [%d,%d), want [0,2)", turns[0].LineStart, turns[0].LineEnd)
+	}
+	if turns[0].Prompt != fxFirst || turns[1].Prompt != fxSecond {
+		t.Errorf("prompts = %q,%q", turns[0].Prompt, turns[1].Prompt)
+	}
+	if turns[0].Tokens != nil {
+		t.Errorf("cursor records no tokens, want nil, got %+v", turns[0].Tokens)
+	}
+	if turns[0].Model != "" {
+		t.Errorf("cursor records no model, want empty, got %q", turns[0].Model)
+	}
+}
+
+func TestCursorSplitTurns_ToolResultIsNotATurn(t *testing.T) {
+	t.Parallel()
+	full := []byte(strings.Join([]string{
+		`{"role":"user","uuid":"u1","message":{"role":"user","content":"do it"}}`,
+		`{"role":"assistant","uuid":"a1","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]}}`,
+		`{"role":"user","uuid":"r1","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"out"}]}}`,
+	}, "\n") + "\n")
+	turns, err := cursorImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "s.jsonl"), SessionID: "s"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("tool_result must not start a turn; want 1 turn, got %d", len(turns))
+	}
+}

--- a/cmd/entire/cli/agentimport/discover.go
+++ b/cmd/entire/cli/agentimport/discover.go
@@ -1,0 +1,70 @@
+package agentimport
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+// sessionResolver maps a directory entry under dir to a discovered session's
+// (sessionID, transcript path). ok=false skips the entry — it is not a
+// transcript this importer should import (wrong extension/layout, or rejected
+// by an importer-specific predicate such as a repo match).
+type sessionResolver func(dir string, e os.DirEntry) (sessionID, path string, ok bool)
+
+// discoverSessionFiles lists transcripts in dir using the discovery rules every
+// flat-directory importer shares: skip entries the resolver rejects, apply the
+// session-ID filter, drop transcripts older than the lookback window (by the
+// transcript file's modtime), and sort by path. A missing dir yields no
+// sessions (not an error).
+//
+// codex does not use this — its sessions live in a recursively-walked,
+// session_meta-filtered tree rather than a flat directory.
+func discoverSessionFiles(dir string, now time.Time, sessionFilter []string, resolve sessionResolver) ([]SessionFile, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read session dir: %w", err)
+	}
+	cutoff := now.AddDate(0, 0, -LookbackDays)
+	var out []SessionFile
+	for _, e := range entries {
+		sessionID, path, ok := resolve(dir, e)
+		if !ok {
+			continue
+		}
+		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, sessionID) {
+			continue
+		}
+		info, statErr := os.Stat(path)
+		if statErr != nil || info.ModTime().Before(cutoff) {
+			continue
+		}
+		out = append(out, SessionFile{Path: path, SessionID: sessionID})
+	}
+	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
+	return out, nil
+}
+
+// identitySessionID uses the file stem verbatim as the session ID — the common
+// case for agents that name transcripts <sessionID><ext>.
+func identitySessionID(stem string) string { return stem }
+
+// jsonlSessionResolver returns a sessionResolver for the common flat layout:
+// one <stem><ext> file per session. deriveID maps the file stem to the session
+// ID (identity for most agents; pi derives a UUID suffix). Directories and
+// non-matching extensions are skipped.
+func jsonlSessionResolver(ext string, deriveID func(stem string) string) sessionResolver {
+	return func(dir string, e os.DirEntry) (string, string, bool) {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ext) {
+			return "", "", false
+		}
+		stem := strings.TrimSuffix(e.Name(), ext)
+		return deriveID(stem), filepath.Join(dir, e.Name()), true
+	}
+}

--- a/cmd/entire/cli/agentimport/discover.go
+++ b/cmd/entire/cli/agentimport/discover.go
@@ -9,6 +9,19 @@ import (
 	"time"
 )
 
+// resolveDir returns overridePath when set, otherwise the agent's session
+// directory for the repo. getDir is the agent's GetSessionDir method.
+func resolveDir(repoRoot, overridePath, agentName string, getDir func(string) (string, error)) (string, error) {
+	if overridePath != "" {
+		return overridePath, nil
+	}
+	dir, err := getDir(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s session dir: %w", agentName, err)
+	}
+	return dir, nil
+}
+
 // sessionResolver maps a directory entry under dir to a discovered session's
 // (sessionID, transcript path). ok=false skips the entry — it is not a
 // transcript this importer should import (wrong extension/layout, or rejected

--- a/cmd/entire/cli/agentimport/factory.go
+++ b/cmd/entire/cli/agentimport/factory.go
@@ -3,10 +3,7 @@ package agentimport
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -37,31 +34,7 @@ func (factoryImporter) Discover(repoRoot, overridePath string, now time.Time, se
 		}
 		dir = d
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read factory session dir: %w", err)
-	}
-	cutoff := now.AddDate(0, 0, -LookbackDays)
-	var out []SessionFile
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
-			continue
-		}
-		stem := strings.TrimSuffix(e.Name(), ".jsonl")
-		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, stem) {
-			continue
-		}
-		info, statErr := e.Info()
-		if statErr != nil || info.ModTime().Before(cutoff) {
-			continue
-		}
-		out = append(out, SessionFile{Path: filepath.Join(dir, e.Name()), SessionID: stem})
-	}
-	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
-	return out, nil
+	return discoverSessionFiles(dir, now, sessionFilter, jsonlSessionResolver(".jsonl", identitySessionID))
 }
 
 // SplitTurns produces one Turn per user-prompt envelope, bounded by the next.

--- a/cmd/entire/cli/agentimport/factory.go
+++ b/cmd/entire/cli/agentimport/factory.go
@@ -41,48 +41,26 @@ func (factoryImporter) Discover(repoRoot, overridePath string, now time.Time, se
 // Token usage (including spawned subagents) is delegated to the Factory agent;
 // the model is read once from the session's adjacent settings file.
 func (factoryImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
-	rawLines := splitRawLines(full)
-	var starts []int
-	for i, raw := range rawLines {
-		if _, ok := factoryPromptText(raw); ok {
-			starts = append(starts, i)
-		}
-	}
-
 	subagentsDir := filepath.Join(filepath.Dir(sf.Path), sf.SessionID, "subagents")
 	model := factoryaidroid.ExtractModelFromTranscript(sf.Path)
 	ag := &factoryaidroid.FactoryAIDroidAgent{}
-	turns := make([]Turn, 0, len(starts))
-	for k, start := range starts {
-		end := len(rawLines)
-		if k+1 < len(starts) {
-			end = starts[k+1]
-		}
-
-		truncated := joinLines(rawLines[:end])
-		tokens, err := ag.CalculateTotalTokenUsage(truncated, start, subagentsDir)
-		if err != nil {
-			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
-		}
-
-		var env struct {
-			ID string `json:"id"`
-		}
-		if err := json.Unmarshal(rawLines[start], &env); err != nil {
-			continue
-		}
-		prompt, _ := factoryPromptText(rawLines[start])
-
-		turns = append(turns, Turn{
-			LineStart: start,
-			LineEnd:   end,
-			UUID:      env.ID,
-			Prompt:    prompt,
-			Model:     model,
-			Tokens:    tokens,
+	return splitLineTurns(splitRawLines(full),
+		func(raw []byte) bool { _, ok := factoryPromptText(raw); return ok },
+		func(rawLines [][]byte, start, _ int, truncated []byte) (*Turn, error) {
+			tokens, err := ag.CalculateTotalTokenUsage(truncated, start, subagentsDir)
+			if err != nil {
+				return nil, fmt.Errorf("token usage: %w", err)
+			}
+			var env struct {
+				ID string `json:"id"`
+			}
+			if err := json.Unmarshal(rawLines[start], &env); err != nil {
+				//nolint:nilerr // skip defensively; the line already parsed in factoryPromptText
+				return nil, nil
+			}
+			prompt, _ := factoryPromptText(rawLines[start])
+			return &Turn{UUID: env.ID, Prompt: prompt, Model: model, Tokens: tokens}, nil
 		})
-	}
-	return turns, nil
 }
 
 // factoryPromptText reports whether a raw Droid JSONL line is a user-prompt

--- a/cmd/entire/cli/agentimport/factory.go
+++ b/cmd/entire/cli/agentimport/factory.go
@@ -3,6 +3,7 @@ package agentimport
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -39,10 +40,17 @@ func (factoryImporter) Discover(repoRoot, overridePath string, now time.Time, se
 
 // SplitTurns produces one Turn per user-prompt envelope, bounded by the next.
 // Token usage (including spawned subagents) is delegated to the Factory agent;
-// the model is read once from the session's adjacent settings file.
+// the model is read once from the session's adjacent settings file. Droid
+// envelopes carry no per-message timestamp (the agent stamps events with
+// time.Now() at hook time), so every turn falls back to the transcript file's
+// modtime — the same fallback the Gemini importer uses.
 func (factoryImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
 	subagentsDir := filepath.Join(filepath.Dir(sf.Path), sf.SessionID, "subagents")
 	model := factoryaidroid.ExtractModelFromTranscript(sf.Path)
+	var createdAt time.Time
+	if info, statErr := os.Stat(sf.Path); statErr == nil {
+		createdAt = info.ModTime()
+	}
 	ag := &factoryaidroid.FactoryAIDroidAgent{}
 	return splitLineTurns(splitRawLines(full),
 		func(raw []byte) bool { _, ok := factoryPromptText(raw); return ok },
@@ -59,7 +67,7 @@ func (factoryImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
 				return nil, nil
 			}
 			prompt, _ := factoryPromptText(rawLines[start])
-			return &Turn{UUID: env.ID, Prompt: prompt, Model: model, Tokens: tokens}, nil
+			return &Turn{UUID: env.ID, Prompt: prompt, Model: model, CreatedAt: createdAt, Tokens: tokens}, nil
 		})
 }
 

--- a/cmd/entire/cli/agentimport/factory.go
+++ b/cmd/entire/cli/agentimport/factory.go
@@ -26,14 +26,9 @@ func (factoryImporter) AgentType() types.AgentType { return agent.AgentTypeFacto
 // Discover returns Factory transcript files for the repo modified within the
 // lookback window.
 func (factoryImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
-	dir := overridePath
-	if dir == "" {
-		ag := &factoryaidroid.FactoryAIDroidAgent{}
-		d, err := ag.GetSessionDir(repoRoot)
-		if err != nil {
-			return nil, fmt.Errorf("resolve factory session dir: %w", err)
-		}
-		dir = d
+	dir, err := resolveDir(repoRoot, overridePath, "factory", (&factoryaidroid.FactoryAIDroidAgent{}).GetSessionDir)
+	if err != nil {
+		return nil, err
 	}
 	return discoverSessionFiles(dir, now, sessionFilter, jsonlSessionResolver(".jsonl", identitySessionID))
 }

--- a/cmd/entire/cli/agentimport/factory.go
+++ b/cmd/entire/cli/agentimport/factory.go
@@ -1,0 +1,137 @@
+package agentimport
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/factoryaidroid"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/transcript"
+)
+
+// factoryImporter imports Factory AI Droid transcripts
+// (~/.factory/sessions/<repo>/<id>.jsonl). Droid wraps each message in an
+// envelope ({"type":"message","id":..,"message":{...}}); token usage is
+// subagent-aware and the model lives in an adjacent <id>.settings.json.
+type factoryImporter struct{}
+
+func (factoryImporter) Name() string { return string(agent.AgentNameFactoryAIDroid) }
+
+func (factoryImporter) AgentType() types.AgentType { return agent.AgentTypeFactoryAIDroid }
+
+// Discover returns Factory transcript files for the repo modified within the
+// lookback window.
+func (factoryImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
+	dir := overridePath
+	if dir == "" {
+		ag := &factoryaidroid.FactoryAIDroidAgent{}
+		d, err := ag.GetSessionDir(repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve factory session dir: %w", err)
+		}
+		dir = d
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read factory session dir: %w", err)
+	}
+	cutoff := now.AddDate(0, 0, -LookbackDays)
+	var out []SessionFile
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		stem := strings.TrimSuffix(e.Name(), ".jsonl")
+		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, stem) {
+			continue
+		}
+		info, statErr := e.Info()
+		if statErr != nil || info.ModTime().Before(cutoff) {
+			continue
+		}
+		out = append(out, SessionFile{Path: filepath.Join(dir, e.Name()), SessionID: stem})
+	}
+	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
+	return out, nil
+}
+
+// SplitTurns produces one Turn per user-prompt envelope, bounded by the next.
+// Token usage (including spawned subagents) is delegated to the Factory agent;
+// the model is read once from the session's adjacent settings file.
+func (factoryImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
+	rawLines := splitRawLines(full)
+	var starts []int
+	for i, raw := range rawLines {
+		if _, ok := factoryPromptText(raw); ok {
+			starts = append(starts, i)
+		}
+	}
+
+	subagentsDir := filepath.Join(filepath.Dir(sf.Path), sf.SessionID, "subagents")
+	model := factoryaidroid.ExtractModelFromTranscript(sf.Path)
+	ag := &factoryaidroid.FactoryAIDroidAgent{}
+	turns := make([]Turn, 0, len(starts))
+	for k, start := range starts {
+		end := len(rawLines)
+		if k+1 < len(starts) {
+			end = starts[k+1]
+		}
+
+		truncated := joinLines(rawLines[:end])
+		tokens, err := ag.CalculateTotalTokenUsage(truncated, start, subagentsDir)
+		if err != nil {
+			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
+		}
+
+		var env struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(rawLines[start], &env); err != nil {
+			continue
+		}
+		prompt, _ := factoryPromptText(rawLines[start])
+
+		turns = append(turns, Turn{
+			LineStart: start,
+			LineEnd:   end,
+			UUID:      env.ID,
+			Prompt:    prompt,
+			Model:     model,
+			Tokens:    tokens,
+		})
+	}
+	return turns, nil
+}
+
+// factoryPromptText reports whether a raw Droid JSONL line is a user-prompt
+// message and returns its text. Droid tags the role inside the inner message;
+// tool_result user messages carry no extractable text and return false.
+func factoryPromptText(raw []byte) (string, bool) {
+	var env struct {
+		Type    string          `json:"type"`
+		Message json.RawMessage `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || env.Type != "message" {
+		return "", false
+	}
+	var role struct {
+		Role string `json:"role"`
+	}
+	if err := json.Unmarshal(env.Message, &role); err != nil || role.Role != transcript.TypeUser {
+		return "", false
+	}
+	text := transcript.ExtractUserContent(env.Message)
+	if text == "" {
+		return "", false
+	}
+	return text, true
+}

--- a/cmd/entire/cli/agentimport/factory_test.go
+++ b/cmd/entire/cli/agentimport/factory_test.go
@@ -57,6 +57,12 @@ func TestFactorySplitTurns_PromptsTokensSettingsModel(t *testing.T) {
 	if err := os.WriteFile(sessPath, full, 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// Droid carries no per-message timestamp, so turns fall back to the file
+	// modtime; pin it so we can assert CreatedAt is populated from it.
+	modTime := time.Date(2026, 6, 24, 9, 30, 0, 0, time.UTC)
+	if err := os.Chtimes(sessPath, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
 	// Model comes from the adjacent <session>.settings.json, not the transcript.
 	if err := os.WriteFile(filepath.Join(dir, "sess.settings.json"), []byte(`{"model":"custom:Gemini-2.5-Pro-0"}`), 0o644); err != nil {
 		t.Fatal(err)
@@ -80,6 +86,9 @@ func TestFactorySplitTurns_PromptsTokensSettingsModel(t *testing.T) {
 	}
 	if turns[0].Model != "Gemini-2.5-Pro-0" {
 		t.Errorf("turn0 model = %q, want Gemini-2.5-Pro-0 (cleaned from settings)", turns[0].Model)
+	}
+	if !turns[0].CreatedAt.Equal(modTime) {
+		t.Errorf("turn0 CreatedAt = %v, want file modtime %v", turns[0].CreatedAt, modTime)
 	}
 	if turns[0].Tokens == nil || turns[0].Tokens.OutputTokens != 5 {
 		t.Errorf("turn0 tokens not bounded to its own turn: %+v", turns[0].Tokens)

--- a/cmd/entire/cli/agentimport/factory_test.go
+++ b/cmd/entire/cli/agentimport/factory_test.go
@@ -1,0 +1,106 @@
+package agentimport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFactoryDiscover_LookbackAndFilter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	writeAged := func(name string, age time.Duration) {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		mt := now.Add(-age)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeAged("recent.jsonl", 5*24*time.Hour)
+	writeAged("old.jsonl", 60*24*time.Hour)
+
+	got, err := factoryImporter{}.Discover("", dir, now, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != fxRecent {
+		t.Fatalf("lookback filter wrong: %v", got)
+	}
+
+	got, err = factoryImporter{}.Discover("", dir, now, []string{"old"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("old session is outside lookback even when filtered: %v", got)
+	}
+}
+
+func TestFactorySplitTurns_PromptsTokensSettingsModel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sessPath := filepath.Join(dir, "sess.jsonl")
+	// Droid envelope: {"type":"message","id":..,"message":{"role":..,"content":..}}.
+	full := []byte(strings.Join([]string{
+		`{"type":"session_start","id":"s0"}`,
+		`{"type":"message","id":"u1","message":{"role":"user","content":"first"}}`,
+		`{"type":"message","id":"a1","message":{"role":"assistant","id":"m1","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":10,"output_tokens":5}}}`,
+		`{"type":"message","id":"u2","message":{"role":"user","content":"second"}}`,
+		`{"type":"message","id":"a2","message":{"role":"assistant","id":"m2","content":[{"type":"text","text":"done"}],"usage":{"input_tokens":20,"output_tokens":7}}}`,
+	}, "\n") + "\n")
+	if err := os.WriteFile(sessPath, full, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Model comes from the adjacent <session>.settings.json, not the transcript.
+	if err := os.WriteFile(filepath.Join(dir, "sess.settings.json"), []byte(`{"model":"custom:Gemini-2.5-Pro-0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	turns, err := factoryImporter{}.SplitTurns(SessionFile{Path: sessPath, SessionID: "sess"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("want 2 turns, got %d", len(turns))
+	}
+	if turns[0].LineStart != 1 || turns[0].LineEnd != 3 {
+		t.Errorf("turn0 bounds = [%d,%d), want [1,3)", turns[0].LineStart, turns[0].LineEnd)
+	}
+	if turns[0].Prompt != fxFirst || turns[1].Prompt != fxSecond {
+		t.Errorf("prompts = %q,%q", turns[0].Prompt, turns[1].Prompt)
+	}
+	if turns[0].UUID != "u1" {
+		t.Errorf("turn0 uuid = %q, want u1", turns[0].UUID)
+	}
+	if turns[0].Model != "Gemini-2.5-Pro-0" {
+		t.Errorf("turn0 model = %q, want Gemini-2.5-Pro-0 (cleaned from settings)", turns[0].Model)
+	}
+	if turns[0].Tokens == nil || turns[0].Tokens.OutputTokens != 5 {
+		t.Errorf("turn0 tokens not bounded to its own turn: %+v", turns[0].Tokens)
+	}
+	if turns[1].Tokens == nil || turns[1].Tokens.OutputTokens != 7 {
+		t.Errorf("turn1 tokens wrong: %+v", turns[1].Tokens)
+	}
+}
+
+func TestFactorySplitTurns_ToolResultIsNotATurn(t *testing.T) {
+	t.Parallel()
+	full := []byte(strings.Join([]string{
+		`{"type":"message","id":"u1","message":{"role":"user","content":"do it"}}`,
+		`{"type":"message","id":"a1","message":{"role":"assistant","id":"m1","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]}}`,
+		`{"type":"message","id":"r1","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"out"}]}}`,
+	}, "\n") + "\n")
+	turns, err := factoryImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "s.jsonl"), SessionID: "s"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("tool_result must not start a turn; want 1 turn, got %d", len(turns))
+	}
+}

--- a/cmd/entire/cli/agentimport/fixtures_test.go
+++ b/cmd/entire/cli/agentimport/fixtures_test.go
@@ -1,0 +1,9 @@
+package agentimport
+
+// Shared fixture constants used across the per-agent importer tests. They keep
+// the common prompt/session literals in one place (and satisfy goconst).
+const (
+	fxFirst  = "first"
+	fxSecond = "second"
+	fxRecent = "recent"
+)

--- a/cmd/entire/cli/agentimport/gemini.go
+++ b/cmd/entire/cli/agentimport/gemini.go
@@ -3,9 +3,6 @@ package agentimport
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -36,31 +33,7 @@ func (geminiImporter) Discover(repoRoot, overridePath string, now time.Time, ses
 		}
 		dir = d
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read gemini session dir: %w", err)
-	}
-	cutoff := now.AddDate(0, 0, -LookbackDays)
-	var out []SessionFile
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
-			continue
-		}
-		stem := strings.TrimSuffix(e.Name(), ".json")
-		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, stem) {
-			continue
-		}
-		info, statErr := e.Info()
-		if statErr != nil || info.ModTime().Before(cutoff) {
-			continue
-		}
-		out = append(out, SessionFile{Path: filepath.Join(dir, e.Name()), SessionID: stem})
-	}
-	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
-	return out, nil
+	return discoverSessionFiles(dir, now, sessionFilter, jsonlSessionResolver(".json", identitySessionID))
 }
 
 // SplitTurns returns a single Turn covering the whole session. Offsets are

--- a/cmd/entire/cli/agentimport/gemini.go
+++ b/cmd/entire/cli/agentimport/gemini.go
@@ -1,0 +1,104 @@
+package agentimport
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/geminicli"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+)
+
+// geminiImporter imports Gemini CLI transcripts
+// (~/.gemini/tmp/<project-hash>/chats/session-*.json). Unlike the JSONL agents,
+// a Gemini transcript is a single JSON document whose offsets are message
+// indices, not line numbers, so import is per-session: one checkpoint covering
+// the whole transcript rather than per-turn.
+type geminiImporter struct{}
+
+func (geminiImporter) Name() string { return string(agent.AgentNameGemini) }
+
+func (geminiImporter) AgentType() types.AgentType { return agent.AgentTypeGemini }
+
+// Discover returns Gemini transcript files for the repo modified within the
+// lookback window. The session ID is the file stem (session-<date>-<shortid>).
+func (geminiImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
+	dir := overridePath
+	if dir == "" {
+		ag := &geminicli.GeminiCLIAgent{}
+		d, err := ag.GetSessionDir(repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve gemini session dir: %w", err)
+		}
+		dir = d
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read gemini session dir: %w", err)
+	}
+	cutoff := now.AddDate(0, 0, -LookbackDays)
+	var out []SessionFile
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		stem := strings.TrimSuffix(e.Name(), ".json")
+		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, stem) {
+			continue
+		}
+		info, statErr := e.Info()
+		if statErr != nil || info.ModTime().Before(cutoff) {
+			continue
+		}
+		out = append(out, SessionFile{Path: filepath.Join(dir, e.Name()), SessionID: stem})
+	}
+	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
+	return out, nil
+}
+
+// SplitTurns returns a single Turn covering the whole session. Offsets are
+// message indices (the native Gemini space): LineStart 0, LineEnd the message
+// count. Token usage is the whole-session total and the prompt is the first
+// user message. The turn UUID is the session ID so re-imports stay idempotent.
+func (geminiImporter) SplitTurns(sf SessionFile, full []byte) ([]Turn, error) {
+	tr, err := geminicli.ParseTranscript(full)
+	if err != nil {
+		return nil, fmt.Errorf("parse gemini transcript: %w", err)
+	}
+	if len(tr.Messages) == 0 {
+		return nil, nil
+	}
+
+	ag := &geminicli.GeminiCLIAgent{}
+	tokens, err := ag.CalculateTokenUsage(full, 0)
+	if err != nil {
+		return nil, fmt.Errorf("token usage: %w", err)
+	}
+
+	prompt := ""
+	if prompts := geminicli.ExtractAllUserPromptsFromTranscript(tr); len(prompts) > 0 {
+		prompt = prompts[0]
+	}
+	// Gemini messages carry no per-message timestamp; the file modtime is the
+	// best available session time.
+	var createdAt time.Time
+	if info, statErr := os.Stat(sf.Path); statErr == nil {
+		createdAt = info.ModTime()
+	}
+
+	return []Turn{{
+		LineStart: 0,
+		LineEnd:   len(tr.Messages),
+		UUID:      sf.SessionID,
+		Prompt:    prompt,
+		CreatedAt: createdAt,
+		Tokens:    tokens,
+	}}, nil
+}

--- a/cmd/entire/cli/agentimport/gemini.go
+++ b/cmd/entire/cli/agentimport/gemini.go
@@ -24,14 +24,9 @@ func (geminiImporter) AgentType() types.AgentType { return agent.AgentTypeGemini
 // Discover returns Gemini transcript files for the repo modified within the
 // lookback window. The session ID is the file stem (session-<date>-<shortid>).
 func (geminiImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
-	dir := overridePath
-	if dir == "" {
-		ag := &geminicli.GeminiCLIAgent{}
-		d, err := ag.GetSessionDir(repoRoot)
-		if err != nil {
-			return nil, fmt.Errorf("resolve gemini session dir: %w", err)
-		}
-		dir = d
+	dir, err := resolveDir(repoRoot, overridePath, "gemini", (&geminicli.GeminiCLIAgent{}).GetSessionDir)
+	if err != nil {
+		return nil, err
 	}
 	return discoverSessionFiles(dir, now, sessionFilter, jsonlSessionResolver(".json", identitySessionID))
 }

--- a/cmd/entire/cli/agentimport/gemini_test.go
+++ b/cmd/entire/cli/agentimport/gemini_test.go
@@ -1,0 +1,94 @@
+package agentimport
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGeminiDiscover_LookbackAndFilter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	writeAged := func(name string, age time.Duration) {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(`{"messages":[]}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		mt := now.Add(-age)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeAged("session-2026-06-20-recent01.json", 5*24*time.Hour)
+	writeAged("session-2026-04-01-old00001.json", 60*24*time.Hour)
+	writeAged("notes.txt", 1*time.Hour)
+
+	got, err := geminiImporter{}.Discover("", dir, now, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != "session-2026-06-20-recent01" {
+		t.Fatalf("lookback/extension filter wrong: %v", got)
+	}
+
+	got, err = geminiImporter{}.Discover("", dir, now, []string{"session-2026-06-20-recent01"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("session filter wrong: %v", got)
+	}
+}
+
+// TestGeminiSplitTurns_OneCheckpointPerSession verifies Gemini imports at
+// session granularity: a single Turn covering the whole (message-indexed)
+// transcript, with whole-session tokens and the first user prompt.
+func TestGeminiSplitTurns_OneCheckpointPerSession(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "session-x.json")
+	full := []byte(`{"messages":[` +
+		`{"type":"user","id":"u1","content":[{"text":"first"}]},` +
+		`{"type":"gemini","id":"g1","content":"ok","tokens":{"input":10,"output":5}},` +
+		`{"type":"user","id":"u2","content":[{"text":"second"}]},` +
+		`{"type":"gemini","id":"g2","content":"done","tokens":{"input":20,"output":7}}` +
+		`]}`)
+	if err := os.WriteFile(p, full, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	turns, err := geminiImporter{}.SplitTurns(SessionFile{Path: p, SessionID: "session-x"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("gemini imports per-session; want 1 turn, got %d", len(turns))
+	}
+	turn := turns[0]
+	if turn.LineStart != 0 || turn.LineEnd != 4 {
+		t.Errorf("turn bounds = [%d,%d), want [0,4) in message-index space", turn.LineStart, turn.LineEnd)
+	}
+	if turn.UUID != "session-x" {
+		t.Errorf("per-session turn uuid = %q, want session-x (stable/idempotent)", turn.UUID)
+	}
+	if turn.Prompt != "first" {
+		t.Errorf("prompt = %q, want the first user prompt", turn.Prompt)
+	}
+	// Whole-session totals: 5 + 7 output, 10 + 20 input.
+	if turn.Tokens == nil || turn.Tokens.OutputTokens != 12 || turn.Tokens.InputTokens != 30 {
+		t.Errorf("session tokens wrong: %+v", turn.Tokens)
+	}
+}
+
+func TestGeminiSplitTurns_EmptyTranscriptNoTurns(t *testing.T) {
+	t.Parallel()
+	turns, err := geminiImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "s.json"), SessionID: "s"}, []byte(`{"messages":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 0 {
+		t.Fatalf("empty transcript should yield no turns, got %d", len(turns))
+	}
+}

--- a/cmd/entire/cli/agentimport/linesplit.go
+++ b/cmd/entire/cli/agentimport/linesplit.go
@@ -1,0 +1,43 @@
+package agentimport
+
+// splitLineTurns is the shared per-turn scaffolding for line-based (JSONL)
+// importers. It finds the user-prompt turn starts with isPrompt, then for each
+// turn spanning raw lines [start, end) calls build to fill the agent-specific
+// fields (prompt, uuid, model, timestamp, tokens). LineStart/LineEnd are set
+// here, and `truncated` is the [0,end) buffer the agents' token helpers consume
+// (truncating the end bounds the turn while keeping the file's beginning, which
+// branch-aware agents like Pi need). build may return a nil Turn to skip a
+// start defensively (e.g. a line that unexpectedly fails to parse).
+//
+// Gemini imports per-session and does not use this — its transcript is a single
+// JSON document, not newline-delimited records.
+func splitLineTurns(
+	rawLines [][]byte,
+	isPrompt func(raw []byte) bool,
+	build func(rawLines [][]byte, start, end int, truncated []byte) (*Turn, error),
+) ([]Turn, error) {
+	var starts []int
+	for i, raw := range rawLines {
+		if isPrompt(raw) {
+			starts = append(starts, i)
+		}
+	}
+
+	turns := make([]Turn, 0, len(starts))
+	for k, start := range starts {
+		end := len(rawLines)
+		if k+1 < len(starts) {
+			end = starts[k+1]
+		}
+		turn, err := build(rawLines, start, end, joinLines(rawLines[:end]))
+		if err != nil {
+			return nil, err
+		}
+		if turn == nil {
+			continue
+		}
+		turn.LineStart, turn.LineEnd = start, end
+		turns = append(turns, *turn)
+	}
+	return turns, nil
+}

--- a/cmd/entire/cli/agentimport/linesplit.go
+++ b/cmd/entire/cli/agentimport/linesplit.go
@@ -1,5 +1,18 @@
 package agentimport
 
+import "time"
+
+// parseTimestamp parses an RFC3339 timestamp, returning the zero time when the
+// string is empty or unparseable. Shared by the importers that read a per-turn
+// timestamp off the transcript line.
+func parseTimestamp(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
 // splitLineTurns is the shared per-turn scaffolding for line-based (JSONL)
 // importers. It finds the user-prompt turn starts with isPrompt, then for each
 // turn spanning raw lines [start, end) calls build to fill the agent-specific

--- a/cmd/entire/cli/agentimport/pi.go
+++ b/cmd/entire/cli/agentimport/pi.go
@@ -50,60 +50,36 @@ func piSessionID(stem string) string {
 // next. Token usage and model are delegated to the Pi agent so import reuses the
 // same accounting (branch-aware) the live path uses.
 func (piImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
-	rawLines := splitRawLines(full)
-	var starts []int
-	for i, raw := range rawLines {
-		if _, ok := piPromptText(raw); ok {
-			starts = append(starts, i)
-		}
-	}
-
 	ag := &pi.PiAgent{}
-	turns := make([]Turn, 0, len(starts))
-	for k, start := range starts {
-		end := len(rawLines)
-		if k+1 < len(starts) {
-			end = starts[k+1]
-		}
-
-		// Bound this turn to [start, end) by truncating to the first `end` lines
-		// (keeping the file from line 0). Pi's branch-aware helpers resolve the
-		// active branch by walking parentId back to the root, so the prefix MUST
-		// retain the beginning — truncating the end is safe (parents are always
-		// earlier lines) but slicing off the start would break those chains.
-		// CalculateTokenUsage then slices forward from `start`; ExtractModel
-		// reports the active-branch model as of this turn's end.
-		truncated := joinLines(rawLines[:end])
-		tokens, err := ag.CalculateTokenUsage(truncated, start)
-		if err != nil {
-			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
-		}
-		model, mErr := ag.ExtractModel(truncated)
-		if mErr != nil {
-			model = ""
-		}
-
-		var entry pijsonl.Entry
-		if err := json.Unmarshal(rawLines[start], &entry); err != nil {
-			continue
-		}
-		ts, parseErr := time.Parse(time.RFC3339, entry.Timestamp)
-		if parseErr != nil {
-			ts = time.Time{}
-		}
-		prompt, _ := piPromptText(rawLines[start])
-
-		turns = append(turns, Turn{
-			LineStart: start,
-			LineEnd:   end,
-			UUID:      entry.ID,
-			Prompt:    prompt,
-			Model:     model,
-			CreatedAt: ts,
-			Tokens:    tokens,
+	return splitLineTurns(splitRawLines(full),
+		func(raw []byte) bool { _, ok := piPromptText(raw); return ok },
+		func(rawLines [][]byte, start, _ int, truncated []byte) (*Turn, error) {
+			// truncated is the [0,end) prefix (file kept from line 0). Pi's
+			// branch-aware helpers walk parentId back to the root, so the prefix
+			// MUST retain the beginning — truncating the end is safe (parents are
+			// earlier lines) but slicing off the start would break those chains.
+			// CalculateTokenUsage slices forward from `start`; ExtractModel reports
+			// the active-branch model as of this turn's end.
+			tokens, err := ag.CalculateTokenUsage(truncated, start)
+			if err != nil {
+				return nil, fmt.Errorf("token usage: %w", err)
+			}
+			model, mErr := ag.ExtractModel(truncated)
+			if mErr != nil {
+				model = ""
+			}
+			var entry pijsonl.Entry
+			if err := json.Unmarshal(rawLines[start], &entry); err != nil {
+				//nolint:nilerr // skip defensively; the line already parsed in piPromptText
+				return nil, nil
+			}
+			ts, parseErr := time.Parse(time.RFC3339, entry.Timestamp)
+			if parseErr != nil {
+				ts = time.Time{}
+			}
+			prompt, _ := piPromptText(rawLines[start])
+			return &Turn{UUID: entry.ID, Prompt: prompt, Model: model, CreatedAt: ts, Tokens: tokens}, nil
 		})
-	}
-	return turns, nil
 }
 
 // piPromptText reports whether a raw Pi JSONL line is a user-prompt message and

--- a/cmd/entire/cli/agentimport/pi.go
+++ b/cmd/entire/cli/agentimport/pi.go
@@ -94,14 +94,19 @@ func (piImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
 			end = starts[k+1]
 		}
 
-		// Bound token usage to [start, end): truncate to the first `end` lines,
-		// then let the agent helper slice from `start`.
+		// Bound this turn to [start, end) by truncating to the first `end` lines
+		// (keeping the file from line 0). Pi's branch-aware helpers resolve the
+		// active branch by walking parentId back to the root, so the prefix MUST
+		// retain the beginning — truncating the end is safe (parents are always
+		// earlier lines) but slicing off the start would break those chains.
+		// CalculateTokenUsage then slices forward from `start`; ExtractModel
+		// reports the active-branch model as of this turn's end.
 		truncated := joinLines(rawLines[:end])
 		tokens, err := ag.CalculateTokenUsage(truncated, start)
 		if err != nil {
 			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
 		}
-		model, mErr := ag.ExtractModel(joinLines(rawLines[start:end]))
+		model, mErr := ag.ExtractModel(truncated)
 		if mErr != nil {
 			model = ""
 		}

--- a/cmd/entire/cli/agentimport/pi.go
+++ b/cmd/entire/cli/agentimport/pi.go
@@ -3,9 +3,6 @@ package agentimport
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -37,32 +34,7 @@ func (piImporter) Discover(repoRoot, overridePath string, now time.Time, session
 		}
 		dir = d
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read pi session dir: %w", err)
-	}
-	cutoff := now.AddDate(0, 0, -LookbackDays)
-	var out []SessionFile
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
-			continue
-		}
-		stem := strings.TrimSuffix(e.Name(), ".jsonl")
-		sessionID := piSessionID(stem)
-		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, sessionID) {
-			continue
-		}
-		info, statErr := e.Info()
-		if statErr != nil || info.ModTime().Before(cutoff) {
-			continue
-		}
-		out = append(out, SessionFile{Path: filepath.Join(dir, e.Name()), SessionID: sessionID})
-	}
-	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
-	return out, nil
+	return discoverSessionFiles(dir, now, sessionFilter, jsonlSessionResolver(".jsonl", piSessionID))
 }
 
 // piSessionID extracts the <uuid> portion of a "<timestamp>_<uuid>" file stem.

--- a/cmd/entire/cli/agentimport/pi.go
+++ b/cmd/entire/cli/agentimport/pi.go
@@ -1,0 +1,160 @@
+package agentimport
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/pi"
+	"github.com/entireio/cli/cmd/entire/cli/agent/pi/pijsonl"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+)
+
+// piImporter imports Pi transcripts (~/.pi/agent/sessions/<repo>/<ts>_<uuid>.jsonl).
+// Pi records token usage and the model on every assistant message, so imported
+// turns carry both via the agent's own CalculateTokenUsage / ExtractModel.
+type piImporter struct{}
+
+func (piImporter) Name() string { return string(agent.AgentNamePi) }
+
+func (piImporter) AgentType() types.AgentType { return agent.AgentTypePi }
+
+// Discover returns Pi transcript files for the repo modified within the lookback
+// window. The session ID is the <uuid> suffix of the <timestamp>_<uuid> file
+// stem (Pi timestamps use dashes, so the first underscore is the separator).
+func (piImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
+	dir := overridePath
+	if dir == "" {
+		ag := &pi.PiAgent{}
+		d, err := ag.GetSessionDir(repoRoot)
+		if err != nil {
+			return nil, fmt.Errorf("resolve pi session dir: %w", err)
+		}
+		dir = d
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read pi session dir: %w", err)
+	}
+	cutoff := now.AddDate(0, 0, -LookbackDays)
+	var out []SessionFile
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		stem := strings.TrimSuffix(e.Name(), ".jsonl")
+		sessionID := piSessionID(stem)
+		if len(sessionFilter) > 0 && !slices.Contains(sessionFilter, sessionID) {
+			continue
+		}
+		info, statErr := e.Info()
+		if statErr != nil || info.ModTime().Before(cutoff) {
+			continue
+		}
+		out = append(out, SessionFile{Path: filepath.Join(dir, e.Name()), SessionID: sessionID})
+	}
+	slices.SortFunc(out, func(a, b SessionFile) int { return strings.Compare(a.Path, b.Path) })
+	return out, nil
+}
+
+// piSessionID extracts the <uuid> portion of a "<timestamp>_<uuid>" file stem.
+// Falls back to the whole stem when there is no underscore separator.
+func piSessionID(stem string) string {
+	if i := strings.Index(stem, "_"); i >= 0 {
+		return stem[i+1:]
+	}
+	return stem
+}
+
+// SplitTurns produces one Turn per user-prompt message line, bounded by the
+// next. Token usage and model are delegated to the Pi agent so import reuses the
+// same accounting (branch-aware) the live path uses.
+func (piImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
+	rawLines := splitRawLines(full)
+	var starts []int
+	for i, raw := range rawLines {
+		if _, ok := piPromptText(raw); ok {
+			starts = append(starts, i)
+		}
+	}
+
+	ag := &pi.PiAgent{}
+	turns := make([]Turn, 0, len(starts))
+	for k, start := range starts {
+		end := len(rawLines)
+		if k+1 < len(starts) {
+			end = starts[k+1]
+		}
+
+		// Bound token usage to [start, end): truncate to the first `end` lines,
+		// then let the agent helper slice from `start`.
+		truncated := joinLines(rawLines[:end])
+		tokens, err := ag.CalculateTokenUsage(truncated, start)
+		if err != nil {
+			return nil, fmt.Errorf("token usage for turn %d: %w", k, err)
+		}
+		model, mErr := ag.ExtractModel(joinLines(rawLines[start:end]))
+		if mErr != nil {
+			model = ""
+		}
+
+		var entry pijsonl.Entry
+		if err := json.Unmarshal(rawLines[start], &entry); err != nil {
+			continue
+		}
+		ts, parseErr := time.Parse(time.RFC3339, entry.Timestamp)
+		if parseErr != nil {
+			ts = time.Time{}
+		}
+		prompt, _ := piPromptText(rawLines[start])
+
+		turns = append(turns, Turn{
+			LineStart: start,
+			LineEnd:   end,
+			UUID:      entry.ID,
+			Prompt:    prompt,
+			Model:     model,
+			CreatedAt: ts,
+			Tokens:    tokens,
+		})
+	}
+	return turns, nil
+}
+
+// piPromptText reports whether a raw Pi JSONL line is a user-prompt message and
+// returns its text. Pi user content may be a plain string or an array of typed
+// blocks; toolResult/assistant messages and empty content return false.
+func piPromptText(raw []byte) (string, bool) {
+	var entry pijsonl.Entry
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return "", false
+	}
+	if entry.Type != pijsonl.EntryTypeMessage || entry.Message.Role != pijsonl.RoleUser {
+		return "", false
+	}
+	if s := pijsonl.DecodeStringContent(entry.Message.Content); s != "" {
+		return s, true
+	}
+	var items []pijsonl.ContentItem
+	if err := json.Unmarshal(entry.Message.Content, &items); err != nil {
+		return "", false
+	}
+	var texts []string
+	for _, it := range items {
+		if it.Type == pijsonl.ContentTypeText && it.Text != "" {
+			texts = append(texts, it.Text)
+		}
+	}
+	if len(texts) == 0 {
+		return "", false
+	}
+	return strings.Join(texts, "\n\n"), true
+}

--- a/cmd/entire/cli/agentimport/pi.go
+++ b/cmd/entire/cli/agentimport/pi.go
@@ -25,14 +25,9 @@ func (piImporter) AgentType() types.AgentType { return agent.AgentTypePi }
 // window. The session ID is the <uuid> suffix of the <timestamp>_<uuid> file
 // stem (Pi timestamps use dashes, so the first underscore is the separator).
 func (piImporter) Discover(repoRoot, overridePath string, now time.Time, sessionFilter []string) ([]SessionFile, error) {
-	dir := overridePath
-	if dir == "" {
-		ag := &pi.PiAgent{}
-		d, err := ag.GetSessionDir(repoRoot)
-		if err != nil {
-			return nil, fmt.Errorf("resolve pi session dir: %w", err)
-		}
-		dir = d
+	dir, err := resolveDir(repoRoot, overridePath, "pi", (&pi.PiAgent{}).GetSessionDir)
+	if err != nil {
+		return nil, err
 	}
 	return discoverSessionFiles(dir, now, sessionFilter, jsonlSessionResolver(".jsonl", piSessionID))
 }
@@ -73,12 +68,8 @@ func (piImporter) SplitTurns(_ SessionFile, full []byte) ([]Turn, error) {
 				//nolint:nilerr // skip defensively; the line already parsed in piPromptText
 				return nil, nil
 			}
-			ts, parseErr := time.Parse(time.RFC3339, entry.Timestamp)
-			if parseErr != nil {
-				ts = time.Time{}
-			}
 			prompt, _ := piPromptText(rawLines[start])
-			return &Turn{UUID: entry.ID, Prompt: prompt, Model: model, CreatedAt: ts, Tokens: tokens}, nil
+			return &Turn{UUID: entry.ID, Prompt: prompt, Model: model, CreatedAt: parseTimestamp(entry.Timestamp), Tokens: tokens}, nil
 		})
 }
 

--- a/cmd/entire/cli/agentimport/pi_test.go
+++ b/cmd/entire/cli/agentimport/pi_test.go
@@ -80,6 +80,32 @@ func TestPiSplitTurns_PromptsTokensModel(t *testing.T) {
 	}
 }
 
+// TestPiSplitTurns_ModelInheritedOverPrefix guards the branch-resolution fix:
+// a later turn whose own assistant message omits the model must still resolve
+// the model from an earlier active-branch message. This only works when the
+// model is extracted over the [0,end) prefix (chains intact); extracting over
+// the [start,end) slice would strip the earlier model and yield "".
+func TestPiSplitTurns_ModelInheritedOverPrefix(t *testing.T) {
+	t.Parallel()
+	full := []byte(strings.Join([]string{
+		`{"type":"message","id":"pu1","message":{"role":"user","content":"first"}}`,
+		`{"type":"message","id":"pa1","message":{"role":"assistant","content":[{"type":"text","text":"ok"}],"model":"model-A","usage":{"input":10,"output":5}}}`,
+		`{"type":"message","id":"pu2","message":{"role":"user","content":"second"}}`,
+		`{"type":"message","id":"pa2","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"usage":{"input":20,"output":7}}}`,
+	}, "\n") + "\n")
+
+	turns, err := piImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "s.jsonl"), SessionID: "s"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("want 2 turns, got %d", len(turns))
+	}
+	if turns[1].Model != "model-A" {
+		t.Errorf("turn1 model = %q, want model-A inherited from the active branch", turns[1].Model)
+	}
+}
+
 func TestPiSplitTurns_ToolResultIsNotATurn(t *testing.T) {
 	t.Parallel()
 	// A toolResult-role message is not a user prompt and must not start a turn.

--- a/cmd/entire/cli/agentimport/pi_test.go
+++ b/cmd/entire/cli/agentimport/pi_test.go
@@ -1,0 +1,98 @@
+package agentimport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPiDiscover_LookbackFilterAndSessionID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	writeAged := func(name string, age time.Duration) {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		mt := now.Add(-age)
+		if err := os.Chtimes(p, mt, mt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Pi names files <timestamp>_<uuid>.jsonl; the session ID is the uuid suffix.
+	writeAged("2026-06-20T00-00-00-000Z_sessA.jsonl", 5*24*time.Hour)
+	writeAged("2026-04-01T00-00-00-000Z_old.jsonl", 60*24*time.Hour)
+
+	got, err := piImporter{}.Discover("", dir, now, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != "sessA" {
+		t.Fatalf("lookback/session-id wrong: %v", got)
+	}
+
+	got, err = piImporter{}.Discover("", dir, now, []string{"sessA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SessionID != "sessA" {
+		t.Fatalf("session filter wrong: %v", got)
+	}
+}
+
+func TestPiSplitTurns_PromptsTokensModel(t *testing.T) {
+	t.Parallel()
+	full := []byte(strings.Join([]string{
+		`{"type":"session","id":"s0","timestamp":"2026-06-20T00:00:00Z"}`,
+		`{"type":"message","id":"u1","timestamp":"2026-06-20T00:00:01Z","message":{"role":"user","content":"first"}}`,
+		`{"type":"message","id":"a1","timestamp":"2026-06-20T00:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"ok"}],"model":"gpt-5.5","usage":{"input":10,"output":5}}}`,
+		`{"type":"message","id":"u2","timestamp":"2026-06-20T00:01:00Z","message":{"role":"user","content":"second"}}`,
+		`{"type":"message","id":"a2","timestamp":"2026-06-20T00:01:02Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"model":"gpt-5.5","usage":{"input":20,"output":7}}}`,
+	}, "\n") + "\n")
+
+	turns, err := piImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "s.jsonl"), SessionID: "s"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 2 {
+		t.Fatalf("want 2 turns, got %d", len(turns))
+	}
+	if turns[0].LineStart != 1 || turns[0].LineEnd != 3 {
+		t.Errorf("turn0 bounds = [%d,%d), want [1,3)", turns[0].LineStart, turns[0].LineEnd)
+	}
+	if turns[0].Prompt != fxFirst || turns[1].Prompt != fxSecond {
+		t.Errorf("prompts = %q,%q", turns[0].Prompt, turns[1].Prompt)
+	}
+	if turns[0].UUID != "u1" {
+		t.Errorf("turn0 uuid = %q, want u1", turns[0].UUID)
+	}
+	if turns[0].Model != "gpt-5.5" {
+		t.Errorf("turn0 model = %q, want gpt-5.5", turns[0].Model)
+	}
+	if turns[0].Tokens == nil || turns[0].Tokens.OutputTokens != 5 {
+		t.Errorf("turn0 tokens not bounded to its own turn: %+v", turns[0].Tokens)
+	}
+	if turns[1].Tokens == nil || turns[1].Tokens.OutputTokens != 7 {
+		t.Errorf("turn1 tokens wrong: %+v", turns[1].Tokens)
+	}
+}
+
+func TestPiSplitTurns_ToolResultIsNotATurn(t *testing.T) {
+	t.Parallel()
+	// A toolResult-role message is not a user prompt and must not start a turn.
+	full := []byte(strings.Join([]string{
+		`{"type":"message","id":"u1","message":{"role":"user","content":"do it"}}`,
+		`{"type":"message","id":"a1","message":{"role":"assistant","content":[{"type":"toolCall","name":"edit","id":"t1","arguments":{}}]}}`,
+		`{"type":"message","id":"r1","message":{"role":"toolResult","content":"out","toolCallId":"t1"}}`,
+	}, "\n") + "\n")
+	turns, err := piImporter{}.SplitTurns(SessionFile{Path: filepath.Join(t.TempDir(), "s.jsonl"), SessionID: "s"}, full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(turns) != 1 {
+		t.Fatalf("non-user message must not start a turn; want 1, got %d", len(turns))
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/676
<!-- entire-trail-link-end -->

## What

Extends `entire import` (PR #1527, Claude Code only) to the other supported agents: **Cursor, Pi, Factory AI Droid, Codex, Copilot CLI, and Gemini CLI**. Each `entire import <agent>` subcommand now surfaces automatically. Supports https://github.com/entireio/cli/issues/1336.

OpenCode is intentionally **out of scope**: it has no on-disk transcript Entire can read (transcripts only materialize via `opencode export`), and its sessions aren't repo-attributable.

## How

PR #1527 built the agent-agnostic orchestration (discovery loop, idempotent per-turn IDs, redaction, checkpoint write) behind an `Importer` seam. This adds one self-contained `Importer` per agent and registers them in the `importers` slice — no command wiring, since `import_cmd.go` iterates `agentimport.All()`.

Each importer reuses its agent's **existing** transcript methods rather than re-encoding parsing:

| Agent | Granularity | Tokens / Model |
|---|---|---|
| cursor | per-turn | none (nil tokens, empty model — records neither) |
| pi | per-turn | `CalculateTokenUsage` + `ExtractModel` (branch-aware) |
| factoryai-droid | per-turn | subagent-aware `CalculateTotalTokenUsage`; model from adjacent `.settings.json` |
| codex | per-turn | cumulative-usage delta; **global store**, filtered by `session_meta.cwd` |
| copilot-cli | per-turn | `CalculateTokenUsage`; **flat store**, filtered by `session.start` cwd/gitRoot |
| gemini | per-session | single JSON doc, message-index offsets → one checkpoint/session |

Codex and Copilot share a `repoMatches` helper (equal-or-descendant, symlink-normalized) so their global/flat stores only import the current repo's sessions.

Imported checkpoints keep the merged Claude behavior: commit-less, `Kind:"imported"`, `[imported]` label, not rewindable, idempotent per `sha256(sessionID + "/" + turnUUID)`.

No changes to `claude.go`, `Run`, the `Importer` interface, or `Turn`.

## Testing

- Per-agent unit tests: `Discover` (lookback / `--session` filter / repo-match) and `SplitTurns` (turn boundaries, prompt/model/tokens; Gemini single-turn).
- Registry test asserts all seven importers register with distinct names.
- End-to-end `Run` test through the Cursor importer (nil tokens / empty model) confirms the generic pipeline + idempotency.
- `mise run lint` (0 issues) and the import/agentimport test suites pass locally. Verified against sample fixtures: cursor 3 turns / pi 2 / factory 2 / codex 2 / copilot 2 / gemini 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Imports local transcripts into persistent checkpoints with format-specific parsing and repo attribution; mistakes could mis-attribute sessions or miscount tokens, but scope is additive with strong test coverage and no auth/data-path changes.
> 
> **Overview**
> Extends **`entire import`** beyond Claude Code by registering six new **`Importer`** implementations (Cursor, Pi, Factory AI Droid, Codex, Copilot CLI, Gemini CLI) in the static `importers` slice—existing command wiring via `agentimport.All()` picks them up automatically.
> 
> Each agent gets its own **`Discover`** (30-day lookback, optional session filter, agent-specific paths) and **`SplitTurns`** logic, mostly delegating tokens/model to existing agent helpers. **Codex** and **Copilot** filter global/flat session stores with shared **`repoMatches`** (cwd/gitRoot under repo, symlink-normalized). **Gemini** differs: one checkpoint per session with message-index offsets, not per user turn. **Cursor** imports with nil tokens and empty model.
> 
> Adds per-agent unit tests, a registry test for all seven names, shared test fixtures, and a **`Run`** end-to-end test through the Cursor importer for idempotency and checkpoint writes without token/model data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2045376ffaa20acbe3cde17f741851dc37e9680e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->