### PR TITLE
allow different target directory for mise run dev:publish

### DIFF
--- a/mise-tasks/dev/publish
+++ b/mise-tasks/dev/publish
@@ -5,12 +5,11 @@
 set -eu
 
 target=${usage_target:-${1:-}}
-if [ -n "$target" ]; then
-  mkdir -p "$target"
-  # go install requires an absolute GOBIN path
-  GOBIN=$(cd "$target" && pwd)
-fi
-export GOBIN=${GOBIN:-${GOPATH:-$HOME/go}/bin}
+GOBIN=${target:-${GOBIN:-${GOPATH:-$HOME/go}/bin}}
+mkdir -p "$GOBIN"
+# go install requires an absolute GOBIN path
+GOBIN=$(cd "$GOBIN" && pwd)
+export GOBIN
 echo "Installing into: $GOBIN" 1>&2
 
 commands=(

--- a/mise-tasks/dev/publish
+++ b/mise-tasks/dev/publish
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
-#MISE description="Install binaries into ~/go/bin"
+#MISE description="Install binaries into ~/go/bin (or a target folder)"
+#USAGE arg "[target]" help="Target folder to install binaries into; defaults to GOBIN or ~/go/bin"
 
 set -eu
 
-export GOBIN=${GOPATH:-$HOME/go}/bin
-echo "NOTE: we're overriding \$GOBIN: $GOBIN" 1>&2
+target=${usage_target:-${1:-}}
+if [ -n "$target" ]; then
+  mkdir -p "$target"
+  # go install requires an absolute GOBIN path
+  GOBIN=$(cd "$target" && pwd)
+fi
+export GOBIN=${GOBIN:-${GOPATH:-$HOME/go}/bin}
+echo "Installing into: $GOBIN" 1>&2
 
 commands=(
   entire


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/677
<!-- entire-trail-link-end -->

Entire-Checkpoint: 44496786b888

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only mise install script change with no impact on runtime CLI, auth, or data handling.
> 
> **Overview**
> **`mise run dev:publish`** can now install `entire` and `git-remote-entire` into a custom folder instead of always using `GOBIN` or `~/go/bin`.
> 
> An optional **`[target]`** argument (wired through mise `#USAGE`) creates the directory if needed, resolves it to an absolute path for **`GOBIN`** (required by `go install`), then runs the same `go install` loop. With no target, behavior matches the previous default. Task description and stderr output were updated to reflect the configurable install path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c17ac986b755799768473974e46eefae1fa6979. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->