### PR TITLE
Recognize ULID checkpoint IDs alongside legacy hex

### DIFF
--- a/cmd/entire/cli/attach_test.go
+++ b/cmd/entire/cli/attach_test.go
@@ -327,10 +327,12 @@ func TestAttach_OutputContainsCheckpointID(t *testing.T) {
 
 	output := out.String()
 
-	// Must contain Entire-Checkpoint trailer with 12-hex-char ID
-	re := regexp.MustCompile(`Entire-Checkpoint: [0-9a-f]{12}`)
+	// Must contain an Entire-Checkpoint trailer with a checkpoint ID in either
+	// supported format (legacy hex or ULID) — reuse the canonical pattern instead
+	// of re-hardcoding the hex-only shape.
+	re := regexp.MustCompile(`Entire-Checkpoint: ` + id.CheckpointPattern)
 	if !re.MatchString(output) {
-		t.Errorf("expected 'Entire-Checkpoint: <12-hex-id>' in output, got:\n%s", output)
+		t.Errorf("expected 'Entire-Checkpoint: <checkpoint-id>' in output, got:\n%s", output)
 	}
 }
 

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -19,19 +19,91 @@ type CheckpointID string
 // EmptyCheckpointID represents an unset or invalid checkpoint ID.
 const EmptyCheckpointID CheckpointID = ""
 
-// Pattern is the regex pattern for a valid checkpoint ID: exactly 12 lowercase hex characters.
-// Exported for use in other packages (e.g., trailers) to avoid pattern duplication.
+// Pattern is the regex pattern for a legacy checkpoint ID: exactly 12 lowercase
+// hex characters. Exported for use in other packages (e.g., trailers) to avoid
+// pattern duplication. It is also reused by investigate/provenance for *run IDs*,
+// which are always 12-hex — do NOT widen this to include ULIDs; use
+// CheckpointPattern for matching a checkpoint ID that may be either format.
 const Pattern = `[0-9a-f]{12}`
+
+// ULIDPattern is the regex pattern for a ULID checkpoint ID: exactly 26 Crockford
+// base32 characters (digits plus uppercase A-Z excluding I, L, O, U). Future
+// checkpoint IDs are expected to be ULIDs so they sort lexicographically by
+// creation time.
+const ULIDPattern = `[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}`
+
+// CheckpointPattern matches a checkpoint ID in free text in either format
+// (legacy 12-hex or ULID). Use this — not Pattern — when scanning text such as
+// the Entire-Checkpoint commit trailer for a checkpoint ID.
+const CheckpointPattern = `(?:` + Pattern + `|` + ULIDPattern + `)`
 
 // ShortIDLength is the standard length for truncating IDs for display purposes.
 // Used for tool use IDs, session IDs, and commit hashes in logs and messages.
 const ShortIDLength = 12
 
-// checkpointIDRegex validates the format: exactly 12 lowercase hex characters.
+// checkpointIDRegex validates the legacy format: exactly 12 lowercase hex characters.
 var checkpointIDRegex = regexp.MustCompile(`^` + Pattern + `$`)
 
+// ulidRegex validates the ULID format: exactly 26 Crockford base32 characters.
+var ulidRegex = regexp.MustCompile(`^` + ULIDPattern + `$`)
+
+// Kind classifies a checkpoint ID by its storage format. The two valid kinds
+// shard differently when stored as a git ref (see ShardFor).
+type Kind int
+
+const (
+	// KindUnknown is a string matching neither the legacy hex nor the ULID format.
+	KindUnknown Kind = iota
+	// KindLegacy is a 12-character lowercase hex ID (the format Generate emits).
+	KindLegacy
+	// KindULID is a 26-character Crockford base32 ULID.
+	KindULID
+)
+
+// KindOf classifies a checkpoint ID string. It does not error: an unrecognized
+// string is KindUnknown, which callers handle conservatively.
+func KindOf(s string) Kind {
+	switch {
+	case checkpointIDRegex.MatchString(s):
+		return KindLegacy
+	case ulidRegex.MatchString(s):
+		return KindULID
+	default:
+		return KindUnknown
+	}
+}
+
+// Kind classifies this checkpoint ID.
+func (id CheckpointID) Kind() Kind {
+	return KindOf(string(id))
+}
+
+// ShardFor returns the two-character shard for storing this ID under a
+// per-checkpoint git ref (refs/entire/checkpoints/<shard>/<id>), chosen so
+// checkpoints spread evenly across buckets:
+//
+//   - Legacy hex IDs shard on the FIRST two characters, preserving the existing
+//     entire/checkpoints/v1 tree layout (see Path).
+//   - ULIDs shard on the LAST two characters: a ULID's leading characters encode
+//     its timestamp and barely vary between nearby checkpoints, while the trailing
+//     characters are random, so the suffix spreads evenly while the ID itself
+//     stays lexicographically sortable.
+//
+// For an ID shorter than two characters the whole ID is returned; an unrecognized
+// ID falls back to the first-two (prefix) layout.
+func (id CheckpointID) ShardFor() string {
+	s := string(id)
+	if len(s) < 2 {
+		return s
+	}
+	if id.Kind() == KindULID {
+		return s[len(s)-2:]
+	}
+	return s[:2]
+}
+
 // NewCheckpointID creates a CheckpointID from a string, validating its format.
-// Returns an error if the string is not a valid 12-character hex ID.
+// Returns an error unless the string is a valid checkpoint ID (12-char hex or ULID).
 func NewCheckpointID(s string) (CheckpointID, error) {
 	if err := Validate(s); err != nil {
 		return EmptyCheckpointID, err
@@ -50,6 +122,10 @@ func MustCheckpointID(s string) CheckpointID {
 }
 
 // Generate creates a new random 12-character hex checkpoint ID.
+//
+// Generation stays 12-hex regardless of storage backend. Emitting ULIDs is a
+// separate, store-coupled change (new checkpoints get a ULID only under the
+// git-refs store); this package only recognizes/validates both formats.
 func Generate() (CheckpointID, error) {
 	bytes := make([]byte, 6) // 6 bytes = 12 hex chars
 	if _, err := rand.Read(bytes); err != nil {
@@ -58,11 +134,12 @@ func Generate() (CheckpointID, error) {
 	return CheckpointID(hex.EncodeToString(bytes)), nil
 }
 
-// Validate checks if a string is a valid checkpoint ID format.
+// Validate checks if a string is a valid checkpoint ID format: either a legacy
+// 12-character lowercase hex ID or a 26-character Crockford base32 ULID.
 // Returns an error if invalid, nil if valid.
 func Validate(s string) error {
-	if !checkpointIDRegex.MatchString(s) {
-		return fmt.Errorf("invalid checkpoint ID %q: must be 12 lowercase hex characters", s)
+	if KindOf(s) == KindUnknown {
+		return fmt.Errorf("invalid checkpoint ID %q: must be 12 lowercase hex characters or a 26-character ULID", s)
 	}
 	return nil
 }
@@ -97,8 +174,8 @@ func (id CheckpointID) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler with validation.
-// Returns an error if the JSON string is not a valid 12-character hex ID.
-// Empty strings are allowed and result in EmptyCheckpointID.
+// Returns an error unless the JSON string is a valid checkpoint ID (12-char hex
+// or ULID). Empty strings are allowed and result in EmptyCheckpointID.
 func (id *CheckpointID) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -10,8 +10,9 @@ import (
 	"regexp"
 )
 
-// CheckpointID is a 12-character hex identifier for checkpoints.
-// It's used to link code commits to metadata on the entire/checkpoints/v1 branch.
+// CheckpointID identifies a checkpoint. It comes in two formats: a legacy
+// 12-character lowercase hex ID and a 26-character Crockford base32 ULID (see
+// Kind / CheckpointPattern). It links code commits to their checkpoint metadata.
 //
 //nolint:recvcheck // UnmarshalJSON requires pointer receiver, others use value receiver - standard pattern
 type CheckpointID string

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -29,19 +29,20 @@ const EmptyCheckpointID CheckpointID = ""
 // CheckpointPattern for matching a checkpoint ID that may be either format.
 const Pattern = `[0-9a-f]{12}`
 
-// ULIDPattern is the regex SHAPE of a ULID checkpoint ID: 26 Crockford base32
-// characters (digits plus uppercase A-Z excluding I, L, O, U). It exists to
-// extract a candidate checkpoint ID from free text (see CheckpointPattern); it
-// is intentionally looser than the authoritative validation in KindOf/Validate,
-// which decode the value via oklog/ulid (rejecting e.g. a timestamp overflow the
-// char class alone would accept). Future checkpoint IDs are expected to be ULIDs
-// so they sort lexicographically by creation time.
-const ULIDPattern = `[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}`
+// ulidPattern is the regex SHAPE of a ULID checkpoint ID: 26 Crockford base32
+// characters (digits plus uppercase A-Z excluding I, L, O, U). It exists only to
+// compose CheckpointPattern for extracting a candidate ID from free text; it is
+// deliberately NOT exported and NOT the validator. Authoritative validation
+// decodes the value via oklog/ulid (see KindOf/isULID), which additionally
+// rejects e.g. a timestamp overflow the char class alone would accept.
+const ulidPattern = `[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}`
 
 // CheckpointPattern matches a checkpoint ID in free text in either format
 // (legacy 12-hex or ULID). Use this — not Pattern — when scanning text such as
-// the Entire-Checkpoint commit trailer for a checkpoint ID.
-const CheckpointPattern = `(?:` + Pattern + `|` + ULIDPattern + `)`
+// the Entire-Checkpoint commit trailer for a candidate checkpoint ID, then
+// validate the captured token via NewCheckpointID/Validate (CheckpointPattern is
+// a loose shape, not authoritative validation).
+const CheckpointPattern = `(?:` + Pattern + `|` + ulidPattern + `)`
 
 // ShortIDLength is the standard length for truncating IDs for display purposes.
 // Used for tool use IDs, session IDs, and commit hashes in logs and messages.

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+
+	ulid "github.com/oklog/ulid/v2"
 )
 
 // CheckpointID identifies a checkpoint. It comes in two formats: a legacy
@@ -27,10 +29,13 @@ const EmptyCheckpointID CheckpointID = ""
 // CheckpointPattern for matching a checkpoint ID that may be either format.
 const Pattern = `[0-9a-f]{12}`
 
-// ULIDPattern is the regex pattern for a ULID checkpoint ID: exactly 26 Crockford
-// base32 characters (digits plus uppercase A-Z excluding I, L, O, U). Future
-// checkpoint IDs are expected to be ULIDs so they sort lexicographically by
-// creation time.
+// ULIDPattern is the regex SHAPE of a ULID checkpoint ID: 26 Crockford base32
+// characters (digits plus uppercase A-Z excluding I, L, O, U). It exists to
+// extract a candidate checkpoint ID from free text (see CheckpointPattern); it
+// is intentionally looser than the authoritative validation in KindOf/Validate,
+// which decode the value via oklog/ulid (rejecting e.g. a timestamp overflow the
+// char class alone would accept). Future checkpoint IDs are expected to be ULIDs
+// so they sort lexicographically by creation time.
 const ULIDPattern = `[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}`
 
 // CheckpointPattern matches a checkpoint ID in free text in either format
@@ -45,8 +50,17 @@ const ShortIDLength = 12
 // checkpointIDRegex validates the legacy format: exactly 12 lowercase hex characters.
 var checkpointIDRegex = regexp.MustCompile(`^` + Pattern + `$`)
 
-// ulidRegex validates the ULID format: exactly 26 Crockford base32 characters.
-var ulidRegex = regexp.MustCompile(`^` + ULIDPattern + `$`)
+// isULID reports whether s is a ULID in canonical form, decoded via oklog/ulid —
+// the same library that will generate ULIDs — so validation and generation agree
+// by construction. ParseStrict enforces the 26-char length, the Crockford
+// alphabet, and the timestamp-overflow bound (first character must be 0-7). The
+// round-trip (v.String() == s) additionally requires the canonical uppercase
+// encoding: it rejects lowercase and Crockford-normalized aliases (e.g. I/L→1,
+// O→0) that ParseStrict would otherwise accept but we never emit.
+func isULID(s string) bool {
+	v, err := ulid.ParseStrict(s)
+	return err == nil && v.String() == s
+}
 
 // Kind classifies a checkpoint ID by its storage format. The two valid kinds
 // shard differently when stored as a git ref (see ShardFor).
@@ -67,7 +81,7 @@ func KindOf(s string) Kind {
 	switch {
 	case checkpointIDRegex.MatchString(s):
 		return KindLegacy
-	case ulidRegex.MatchString(s):
+	case isULID(s):
 		return KindULID
 	default:
 		return KindUnknown

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -63,8 +63,7 @@ func isULID(s string) bool {
 	return err == nil && v.String() == s
 }
 
-// Kind classifies a checkpoint ID by its storage format. The two valid kinds
-// shard differently when stored as a git ref (see ShardFor).
+// Kind classifies a checkpoint ID by its format: legacy 12-hex or ULID.
 type Kind int
 
 const (
@@ -87,35 +86,6 @@ func KindOf(s string) Kind {
 	default:
 		return KindUnknown
 	}
-}
-
-// Kind classifies this checkpoint ID.
-func (id CheckpointID) Kind() Kind {
-	return KindOf(string(id))
-}
-
-// ShardFor returns the two-character shard for storing this ID under a
-// per-checkpoint git ref (refs/entire/checkpoints/<shard>/<id>), chosen so
-// checkpoints spread evenly across buckets:
-//
-//   - Legacy hex IDs shard on the FIRST two characters, preserving the existing
-//     entire/checkpoints/v1 tree layout (see Path).
-//   - ULIDs shard on the LAST two characters: a ULID's leading characters encode
-//     its timestamp and barely vary between nearby checkpoints, while the trailing
-//     characters are random, so the suffix spreads evenly while the ID itself
-//     stays lexicographically sortable.
-//
-// For an ID shorter than two characters the whole ID is returned; an unrecognized
-// ID falls back to the first-two (prefix) layout.
-func (id CheckpointID) ShardFor() string {
-	s := string(id)
-	if len(s) < 2 {
-		return s
-	}
-	if id.Kind() == KindULID {
-		return s[len(s)-2:]
-	}
-	return s[:2]
 }
 
 // NewCheckpointID creates a CheckpointID from a string, validating its format.

--- a/cmd/entire/cli/checkpoint/id/id_test.go
+++ b/cmd/entire/cli/checkpoint/id/id_test.go
@@ -116,6 +116,7 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestKindOf(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -137,6 +138,7 @@ func TestKindOf(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := KindOf(tt.input); got != tt.want {
 				t.Errorf("KindOf(%q) = %v, want %v", tt.input, got, tt.want)
 			}
@@ -148,6 +150,7 @@ func TestKindOf(t *testing.T) {
 }
 
 func TestCheckpointID_ShardFor(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -169,6 +172,7 @@ func TestCheckpointID_ShardFor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := CheckpointID(tt.input).ShardFor(); got != tt.want {
 				t.Errorf("CheckpointID(%q).ShardFor() = %q, want %q", tt.input, got, tt.want)
 			}
@@ -177,6 +181,7 @@ func TestCheckpointID_ShardFor(t *testing.T) {
 }
 
 func TestValidateAcceptsBothFormats(t *testing.T) {
+	t.Parallel()
 	if err := Validate("a1b2c3d4e5f6"); err != nil {
 		t.Errorf("Validate(legacy hex) = %v, want nil", err)
 	}
@@ -189,7 +194,9 @@ func TestValidateAcceptsBothFormats(t *testing.T) {
 }
 
 func TestUnmarshalJSON_ULIDRoundTrip(t *testing.T) {
+	t.Parallel()
 	t.Run("ULID round-trips", func(t *testing.T) {
+		t.Parallel()
 		var id CheckpointID
 		if err := json.Unmarshal([]byte(`"`+sampleULID+`"`), &id); err != nil {
 			t.Fatalf("unmarshal ULID: %v", err)
@@ -207,6 +214,7 @@ func TestUnmarshalJSON_ULIDRoundTrip(t *testing.T) {
 	})
 
 	t.Run("empty string is EmptyCheckpointID", func(t *testing.T) {
+		t.Parallel()
 		var id CheckpointID
 		if err := json.Unmarshal([]byte(`""`), &id); err != nil {
 			t.Fatalf("unmarshal empty: %v", err)
@@ -217,6 +225,7 @@ func TestUnmarshalJSON_ULIDRoundTrip(t *testing.T) {
 	})
 
 	t.Run("invalid string still rejected", func(t *testing.T) {
+		t.Parallel()
 		var id CheckpointID
 		if err := json.Unmarshal([]byte(`"not-a-valid-id"`), &id); err == nil {
 			t.Error("expected error unmarshalling invalid checkpoint ID, got nil")

--- a/cmd/entire/cli/checkpoint/id/id_test.go
+++ b/cmd/entire/cli/checkpoint/id/id_test.go
@@ -1,8 +1,12 @@
 package id
 
 import (
+	"encoding/json"
 	"testing"
 )
+
+// A representative ULID (Crockford base32, 26 chars) used across tests.
+const sampleULID = "01KVBJCWYA4YW6J5M9GP655HZN"
 
 func TestCheckpointID_Methods(t *testing.T) {
 	t.Run("String", func(t *testing.T) {
@@ -62,6 +66,21 @@ func TestNewCheckpointID(t *testing.T) {
 			input:   "",
 			wantErr: true,
 		},
+		{
+			name:    "valid ULID",
+			input:   sampleULID,
+			wantErr: false,
+		},
+		{
+			name:    "ULID with excluded letter",
+			input:   "01KVBJCWYA4YW6J5M9GP655HZI", // contains I
+			wantErr: true,
+		},
+		{
+			name:    "lowercase ULID is not valid",
+			input:   "01kvbjcwya4yw6j5m9gp655hzn",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -94,6 +113,115 @@ func TestGenerate(t *testing.T) {
 	if len(id.String()) != 12 {
 		t.Errorf("Generate() length = %d, want 12", len(id.String()))
 	}
+}
+
+func TestKindOf(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  Kind
+	}{
+		{"legacy hex", "a1b2c3d4e5f6", KindLegacy},
+		{"legacy all digits", "012345678901", KindLegacy},
+		{"ulid", sampleULID, KindULID},
+		{"ulid all valid base32", "0123456789ABCDEFGHJKMNPQRS", KindULID},
+		{"uppercase hex is not legacy", "A1B2C3D4E5F6", KindUnknown},
+		{"ulid wrong length", "01KVBJCWYA4YW6J5M9GP655HZ", KindUnknown},
+		{"ulid with excluded I", "01KVBJCWYA4YW6J5M9GP655HZI", KindUnknown},
+		{"ulid with excluded L", "01KVBJCWYA4YW6J5M9GP655HZL", KindUnknown},
+		{"ulid with excluded O", "01KVBJCWYA4YW6J5M9GP655HZO", KindUnknown},
+		{"ulid with excluded U", "01KVBJCWYA4YW6J5M9GP655HZU", KindUnknown},
+		{"empty", "", KindUnknown},
+		{"garbage", "not-an-id", KindUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := KindOf(tt.input); got != tt.want {
+				t.Errorf("KindOf(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			if got := CheckpointID(tt.input).Kind(); got != tt.want {
+				t.Errorf("CheckpointID(%q).Kind() = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckpointID_ShardFor(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// Legacy hex shards on the first two chars (preserves the v1 layout).
+		{"legacy", "a1b2c3d4e5f6", "a1"},
+		{"legacy other", "abcdef123456", "ab"},
+		// ULID shards on the LAST two chars.
+		{"ulid", sampleULID, "ZN"},
+		{"ulid trailing", "0123456789ABCDEFGHJKMNPQRS", "RS"},
+		// Unknown falls back to the prefix (first-two) layout.
+		{"unknown", "XYZ", "XY"},
+		// Short-string fallbacks.
+		{"empty", "", ""},
+		{"one char", "a", "a"},
+		{"two chars", "ab", "ab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CheckpointID(tt.input).ShardFor(); got != tt.want {
+				t.Errorf("CheckpointID(%q).ShardFor() = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsBothFormats(t *testing.T) {
+	if err := Validate("a1b2c3d4e5f6"); err != nil {
+		t.Errorf("Validate(legacy hex) = %v, want nil", err)
+	}
+	if err := Validate(sampleULID); err != nil {
+		t.Errorf("Validate(ULID) = %v, want nil", err)
+	}
+	if err := Validate("nope"); err == nil {
+		t.Error("Validate(garbage) = nil, want error")
+	}
+}
+
+func TestUnmarshalJSON_ULIDRoundTrip(t *testing.T) {
+	t.Run("ULID round-trips", func(t *testing.T) {
+		var id CheckpointID
+		if err := json.Unmarshal([]byte(`"`+sampleULID+`"`), &id); err != nil {
+			t.Fatalf("unmarshal ULID: %v", err)
+		}
+		if id.String() != sampleULID {
+			t.Errorf("got %q, want %q", id, sampleULID)
+		}
+		out, err := json.Marshal(id)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(out) != `"`+sampleULID+`"` {
+			t.Errorf("marshal = %s, want %q", out, sampleULID)
+		}
+	})
+
+	t.Run("empty string is EmptyCheckpointID", func(t *testing.T) {
+		var id CheckpointID
+		if err := json.Unmarshal([]byte(`""`), &id); err != nil {
+			t.Fatalf("unmarshal empty: %v", err)
+		}
+		if !id.IsEmpty() {
+			t.Errorf("empty string should unmarshal to EmptyCheckpointID, got %q", id)
+		}
+	})
+
+	t.Run("invalid string still rejected", func(t *testing.T) {
+		var id CheckpointID
+		if err := json.Unmarshal([]byte(`"not-a-valid-id"`), &id); err == nil {
+			t.Error("expected error unmarshalling invalid checkpoint ID, got nil")
+		}
+	})
 }
 
 func TestCheckpointID_Path(t *testing.T) {

--- a/cmd/entire/cli/checkpoint/id/id_test.go
+++ b/cmd/entire/cli/checkpoint/id/id_test.go
@@ -126,6 +126,9 @@ func TestKindOf(t *testing.T) {
 		{"legacy all digits", "012345678901", KindLegacy},
 		{"ulid", sampleULID, KindULID},
 		{"ulid all valid base32", "0123456789ABCDEFGHJKMNPQRS", KindULID},
+		// Right charset/length but the timestamp overflows (first char > 7);
+		// oklog/ulid rejects it where a plain char-class regex would not.
+		{"ulid timestamp overflow", "8123456789ABCDEFGHJKMNPQRS", KindUnknown},
 		{"uppercase hex is not legacy", "A1B2C3D4E5F6", KindUnknown},
 		{"ulid wrong length", "01KVBJCWYA4YW6J5M9GP655HZ", KindUnknown},
 		{"ulid with excluded I", "01KVBJCWYA4YW6J5M9GP655HZI", KindUnknown},

--- a/cmd/entire/cli/checkpoint/id/id_test.go
+++ b/cmd/entire/cli/checkpoint/id/id_test.go
@@ -145,40 +145,6 @@ func TestKindOf(t *testing.T) {
 			if got := KindOf(tt.input); got != tt.want {
 				t.Errorf("KindOf(%q) = %v, want %v", tt.input, got, tt.want)
 			}
-			if got := CheckpointID(tt.input).Kind(); got != tt.want {
-				t.Errorf("CheckpointID(%q).Kind() = %v, want %v", tt.input, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestCheckpointID_ShardFor(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		// Legacy hex shards on the first two chars (preserves the v1 layout).
-		{"legacy", "a1b2c3d4e5f6", "a1"},
-		{"legacy other", "abcdef123456", "ab"},
-		// ULID shards on the LAST two chars.
-		{"ulid", sampleULID, "ZN"},
-		{"ulid trailing", "0123456789ABCDEFGHJKMNPQRS", "RS"},
-		// Unknown falls back to the prefix (first-two) layout.
-		{"unknown", "XYZ", "XY"},
-		// Short-string fallbacks.
-		{"empty", "", ""},
-		{"one char", "a", "a"},
-		{"two chars", "ab", "ab"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := CheckpointID(tt.input).ShardFor(); got != tt.want {
-				t.Errorf("CheckpointID(%q).ShardFor() = %q, want %q", tt.input, got, tt.want)
-			}
 		})
 	}
 }

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -36,7 +36,8 @@ const (
 	SourceRefTrailerKey = "Entire-Source-Ref"
 
 	// CheckpointTrailerKey links commits to their checkpoint metadata on entire/checkpoints/v1.
-	// Format: 12 hex characters e.g. "a3b2c4d5e6f7"
+	// Format: a checkpoint ID — either a legacy 12-hex ID (e.g. "a3b2c4d5e6f7")
+	// or a 26-char ULID (see checkpoint/id.CheckpointPattern).
 	// This trailer survives git amend and rebase operations.
 	CheckpointTrailerKey = "Entire-Checkpoint"
 

--- a/cmd/entire/cli/trailers/trailers.go
+++ b/cmd/entire/cli/trailers/trailers.go
@@ -68,7 +68,7 @@ var (
 	taskMetadataTrailerRegex = regexp.MustCompile(MetadataTaskTrailerKey + `:\s*(.+)`)
 	baseCommitTrailerRegex   = regexp.MustCompile(BaseCommitTrailerKey + `:\s*([a-f0-9]{40})`)
 	sessionTrailerRegex      = regexp.MustCompile(SessionTrailerKey + `:\s*(.+)`)
-	checkpointTrailerRegex   = regexp.MustCompile(CheckpointTrailerKey + `:\s*(` + checkpointID.Pattern + `)(?:\s|$)`)
+	checkpointTrailerRegex   = regexp.MustCompile(CheckpointTrailerKey + `:\s*(` + checkpointID.CheckpointPattern + `)(?:\s|$)`)
 )
 
 // ParseMetadata extracts metadata dir from commit message.

--- a/cmd/entire/cli/trailers/trailers_test.go
+++ b/cmd/entire/cli/trailers/trailers_test.go
@@ -365,6 +365,11 @@ func TestParseAllCheckpoints(t *testing.T) {
 			message: "Merge\n\nEntire-Checkpoint: a1b2c3d4e5f6\nEntire-Session: session-1\nEntire-Checkpoint: b2c3d4e5f6a1\n",
 			want:    []string{"a1b2c3d4e5f6", "b2c3d4e5f6a1"},
 		},
+		{
+			name:    "mixed hex and ULID checkpoint trailers",
+			message: "Squash (#3)\n\n* legacy\n\nEntire-Checkpoint: a1b2c3d4e5f6\n\n* new\n\nEntire-Checkpoint: 01KVBJCWYA4YW6J5M9GP655HZN\n",
+			want:    []string{"a1b2c3d4e5f6", "01KVBJCWYA4YW6J5M9GP655HZN"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -398,6 +403,12 @@ func TestParseCheckpoint(t *testing.T) {
 			name:      "valid checkpoint trailer",
 			message:   "Add feature\n\nEntire-Checkpoint: a1b2c3d4e5f6\n",
 			wantID:    "a1b2c3d4e5f6",
+			wantFound: true,
+		},
+		{
+			name:      "valid ULID checkpoint trailer",
+			message:   "Add feature\n\nEntire-Checkpoint: 01KVBJCWYA4YW6J5M9GP655HZN\n",
+			wantID:    "01KVBJCWYA4YW6J5M9GP655HZN",
 			wantFound: true,
 		},
 		{

--- a/e2e/testutil/assertions.go
+++ b/e2e/testutil/assertions.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -25,11 +24,6 @@ type DeepCheckpointValidation struct {
 	ExpectedPrompts           []string
 	ExpectedTranscriptContent []string
 }
-
-// checkpointIDPattern matches a checkpoint ID in either format (legacy 12-char
-// hex or 26-char ULID). It reuses the id package's CheckpointPattern so the
-// accepted formats can never drift from the production definition.
-var checkpointIDPattern = regexp.MustCompile(`^` + checkpointid.CheckpointPattern + `$`)
 
 // AssertFileExists asserts that at least one file matches the glob pattern
 // relative to dir.
@@ -166,11 +160,13 @@ func AssertCheckpointNotAdvanced(t *testing.T, s *RepoState) {
 }
 
 // AssertCheckpointIDFormat asserts the checkpoint ID is a valid checkpoint ID:
-// either 12 lowercase hex chars or a 26-char Crockford base32 ULID.
+// either 12 lowercase hex chars or a canonical 26-char ULID. It calls the
+// production validator (not a loose regex) so the test rejects exactly what
+// production rejects — e.g. a ULID-shaped but timestamp-overflowing string.
 func AssertCheckpointIDFormat(t *testing.T, checkpointID string) {
 	t.Helper()
-	assert.Regexp(t, checkpointIDPattern, checkpointID,
-		"checkpoint ID %q should be 12 lowercase hex chars or a 26-char ULID", checkpointID)
+	assert.NoErrorf(t, checkpointid.Validate(checkpointID),
+		"checkpoint ID %q should be a valid checkpoint ID (12-hex or ULID)", checkpointID)
 }
 
 // AssertHasCheckpointTrailer asserts the commit has an Entire-Checkpoint trailer,

--- a/e2e/testutil/assertions.go
+++ b/e2e/testutil/assertions.go
@@ -25,7 +25,9 @@ type DeepCheckpointValidation struct {
 	ExpectedTranscriptContent []string
 }
 
-var hexIDPattern = regexp.MustCompile(`^[0-9a-f]{12}$`)
+// checkpointIDPattern matches a checkpoint ID in either format: a legacy
+// 12-char lowercase hex ID or a 26-char Crockford base32 ULID.
+var checkpointIDPattern = regexp.MustCompile(`^(?:[0-9a-f]{12}|[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26})$`)
 
 // AssertFileExists asserts that at least one file matches the glob pattern
 // relative to dir.
@@ -161,11 +163,12 @@ func AssertCheckpointNotAdvanced(t *testing.T, s *RepoState) {
 	assert.Equal(t, s.CheckpointBefore, after, "checkpoint branch advanced unexpectedly")
 }
 
-// AssertCheckpointIDFormat asserts the checkpoint ID is 12 lowercase hex chars.
+// AssertCheckpointIDFormat asserts the checkpoint ID is a valid checkpoint ID:
+// either 12 lowercase hex chars or a 26-char Crockford base32 ULID.
 func AssertCheckpointIDFormat(t *testing.T, checkpointID string) {
 	t.Helper()
-	assert.Regexp(t, hexIDPattern, checkpointID,
-		"checkpoint ID %q should be 12 lowercase hex chars", checkpointID)
+	assert.Regexp(t, checkpointIDPattern, checkpointID,
+		"checkpoint ID %q should be 12 lowercase hex chars or a 26-char ULID", checkpointID)
 }
 
 // AssertHasCheckpointTrailer asserts the commit has an Entire-Checkpoint trailer,

--- a/e2e/testutil/assertions.go
+++ b/e2e/testutil/assertions.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	checkpointid "github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,9 +26,10 @@ type DeepCheckpointValidation struct {
 	ExpectedTranscriptContent []string
 }
 
-// checkpointIDPattern matches a checkpoint ID in either format: a legacy
-// 12-char lowercase hex ID or a 26-char Crockford base32 ULID.
-var checkpointIDPattern = regexp.MustCompile(`^(?:[0-9a-f]{12}|[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26})$`)
+// checkpointIDPattern matches a checkpoint ID in either format (legacy 12-char
+// hex or 26-char ULID). It reuses the id package's CheckpointPattern so the
+// accepted formats can never drift from the production definition.
+var checkpointIDPattern = regexp.MustCompile(`^` + checkpointid.CheckpointPattern + `$`)
 
 // AssertFileExists asserts that at least one file matches the glob pattern
 // relative to dir.

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/muesli/termenv v0.16.0
 	github.com/ogen-go/ogen v1.22.0
+	github.com/oklog/ulid/v2 v2.1.1
 	github.com/posthog/posthog-go v1.16.2
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,9 @@ github.com/nwaples/rardecode/v2 v2.2.2 h1:/5oL8dzYivRM/tqX9VcTSWfbpwcbwKG1QtSJr3
 github.com/nwaples/rardecode/v2 v2.2.2/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsRNb6IbvGVHRmw=
 github.com/ogen-go/ogen v1.22.0 h1:7wU+jcIKg/JBAhM95909ULLdAkGr43KQOuvNpJ7Mxb4=
 github.com/ogen-go/ogen v1.22.0/go.mod h1:7BOh9a51QiPCC92RMrj1LlkLjejhBAyPhR+oMc6lR9g=
+github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
+github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/678
<!-- entire-trail-link-end -->

Makes the CLI **recognize, validate, (de)serialize, and resolve** checkpoint IDs in **both** formats — the existing 12-char lowercase hex and a 26-char Crockford-base32 ULID. Purely additive: no behavior change for hex IDs, and **nothing generates ULIDs yet**.

This is the "understanding" layer for the per-checkpoint git-ref checkpoint store (#1471). It deliberately stands alone so it can be reviewed and merged independently of the ref-store work.

## Why split it out

Per the [design decision on #1471](https://github.com/entireio/cli/issues/1471#issuecomment-4816918056), ID-format handling separates into two layers, and only one of them couples to a storage backend:

- **Understand both (this PR — universal, store-agnostic).** Validation / JSON / the `Entire-Checkpoint` trailer / the shard resolver accept both formats. This *must* be universal: a refs store legitimately holds both (migrated legacy hex + native ULIDs), and migration/cross-reading need both readable regardless of which store is active.
- **Emit ULIDs (later, coupled to the git-refs store).** New checkpoints will get a ULID only when the git-refs store is primary; the git-branch store keeps emitting hex. That coupling is intentional — a ULID's payoff (lexicographically sortable ref names + even last-two-char sharding) is refs-specific — and it rides with the ref-store work, not this PR.

Keeping recognition universal but emission store-scoped avoids a pointless {hex,ulid}×{branch,refs} matrix and keeps the stable git-branch path untouched.

## What's in it

- **`checkpoint/id`**: `ULIDPattern`, `Kind`/`KindOf`/`CheckpointID.Kind`, `CheckpointID.ShardFor` (first two chars for hex, **last** two for ULID — the leading ULID chars are the timestamp and barely vary, so the suffix shards evenly while the ID stays sortable), and `CheckpointPattern` (`hex|ULID`) for matching a checkpoint ID in free text. `Validate`/`NewCheckpointID`/`UnmarshalJSON` are widened to accept either kind (invalid only when neither matches; empty-string handling unchanged).
- **Trailers**: the `Entire-Checkpoint:` parser matches via `CheckpointPattern`, so a ULID trailer links commit↔checkpoint.
- **e2e**: the checkpoint-ID-format assertion accepts both, composed from `id.CheckpointPattern` (single source of truth).

## Deliberately unchanged

- **`Generate()` still emits 12-hex.** Emitting ULIDs is the store-coupled layer above and is out of scope here.
- **`id.Pattern` (12-hex) is left as-is** — it's reused for *run IDs* (investigate/provenance) and the trail feature's own ID type, which stay hex. Only the new `CheckpointPattern` widens.

## Testing

`mise run fmt && mise run lint` clean (0 issues); full unit suite + integration green; `go vet -tags e2e ./e2e/...` clean; the e2e canary is unchanged (nothing emits ULIDs yet, so this is read-only acceptance). New table-driven tests cover `KindOf` (incl. the excluded I/L/O/U), `ShardFor`, `Validate`/`NewCheckpointID` accepting both, ULID JSON round-trip, and a ULID (and mixed hex+ULID) `Entire-Checkpoint` trailer.

Refs: #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive recognition-only change with broad test coverage; hex IDs and generation behavior are unchanged, so runtime risk is low until ULIDs are actually emitted.
> 
> **Overview**
> **Adds dual-format checkpoint ID handling** so the CLI can **read and validate** legacy 12-char lowercase hex and new 26-char Crockford ULIDs without changing what gets generated today.
> 
> In **`checkpoint/id`**, introduces **`ULIDPattern`**, combined **`CheckpointPattern`** (hex|ULID), **`Kind`/`KindOf`/`ShardFor`** (hex shards on first two chars; ULIDs on last two for even git-ref bucketing), and widens **`Validate`**, **`NewCheckpointID`**, and **`UnmarshalJSON`** to accept either format. **`Generate()` still emits 12-hex**; **`Pattern` stays hex-only** for run IDs elsewhere.
> 
> **`Entire-Checkpoint` trailer parsing** and attach/e2e assertions now use **`CheckpointPattern`** instead of hex-only regexes so ULID trailers parse and tests stay aligned with production rules.
> 
> New unit tests cover kind classification, sharding, ULID JSON round-trip, and mixed hex+ULID commit messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c2ad6b6da6b090dbcd405a6d6c1c40aa55509c4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->