### PR TITLE
chore: Ditch 'ireturn' lint.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,6 @@ linters:
     - inamedparam
     - ineffassign
     - intrange
-    - ireturn
     - loggercheck
     - maintidx
     - makezero
@@ -113,36 +112,6 @@ linters:
       disable:
         - fieldalignment
         - shadow
-    ireturn:
-      allow:
-        - anon
-        - error
-        - empty
-        - stdlib
-        - charm.land/bubbletea/v2.Model
-        - charm.land/bubbletea/v2.Msg
-        - charm.land/huh/v2.Theme
-        - grpc.DialOption
-        - github.com/entireio/cli/cmd/entire/cli/summarize.Generator
-        - github.com/entireio/cli/cmd/entire/cli/agent\..+
-        - github.com/entireio/cli/cmd/entire/cli/agent/spawn.Spawner
-        - github.com/entireio/cli/cmd/entire/cli/review/types.Process
-        - github.com/entireio/cli/cmd/entire/cli/review/types.AgentReviewer
-        - github.com/entireio/cli/cmd/entire/cli/review.SynthesisProvider
-        - github.com/entireio/cli/cmd/entire/cli/checkpoint.CheckpointReader
-        - github.com/entireio/cli/cmd/entire/cli/checkpoint.PersistentStore
-        - github.com/entireio/cli/cmd/entire/cli/checkpoint.EphemeralStore
-        - github.com/entireio/cli/cmd/entire/cli/strategy.Strategy
-        - github.com/entireio/cli/internal/entireclient/tokenstore.store
-        - github.com/go-git/go-git/v6/x/plugin.Signer
-        - github.com/go-git/go-git/v6/plumbing/storer.ReferenceIter
-        - github.com/go-git/go-git/v6/plumbing.EncodedObject
-        - github.com/go-git/go-git/v6/storage.Storer
-        - github.com/go-git/go-git/v6/plumbing/storer.EncodedObjectIter
-        - github.com/entireio/cli/e2e/agents.Session
-        - github.com/go-git/go-billy/v6.File
-        - github.com/go-git/go-billy/v6.Filesystem
-        - golang.org/x/crypto/ssh/agent.Agent
     nolintlint:
       require-explanation: true
       require-specific: true
@@ -178,12 +147,6 @@ linters:
       - path: ^internal/sim/
         linters:
           - wrapcheck
-      - path: ^cmd/entire/cli/review/tui_model\.go$
-        linters:
-          - ireturn
-      - path: ^cmd/entire/cli/investigate/cmd\.go$
-        linters:
-          - ireturn
       # configloader.go is a thin os-backed billy.Basic adapter. It must return
       # raw os errors unwrapped so go-git's os.IsNotExist() fall-through (for
       # absent config files) keeps working; wrapping would break it.

--- a/cmd/entire/cli/agentimport/agentimport.go
+++ b/cmd/entire/cli/agentimport/agentimport.go
@@ -69,8 +69,6 @@ var importers = []Importer{
 }
 
 // Get returns the importer registered under name.
-//
-//nolint:ireturn // Importer is the intended polymorphic seam returned to callers.
 func Get(name string) (Importer, bool) {
 	for _, imp := range importers {
 		if imp.Name() == name {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/680
<!-- entire-trail-link-end -->

golangci-lint fights with itself about adding and removing these annotations, and generally wastes our time.

Don't tell me we must "simply align versions", we've tried that, we have wasted collective hours on a stupid non-issue.  We even have the `#lint-ireturn` Slack channel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only configuration change with no runtime behavior; interface-return style is no longer enforced in CI.
> 
> **Overview**
> **Removes the `ireturn` linter** from golangci-lint so CI no longer flags interface return types or forces `//nolint:ireturn` churn.
> 
> The change drops `ireturn` from the enabled linter list, deletes its `allow` list (stdlib, bubbletea, agent/review/checkpoint interfaces, go-git types, etc.), and removes path-specific `ireturn` exclusions for `review/tui_model.go` and `investigate/cmd.go`. In `agentimport`, the `Get` helper no longer needs a targeted `nolint` for returning `Importer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef481758b4eb3d4677df3597de9b942c2343f0d6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->