### PR TITLE
fix(dev:publish): always install to ~/go/bin, ignore stray $GOBIN

### DIFF
--- a/mise-tasks/dev/publish
+++ b/mise-tasks/dev/publish
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 #MISE description="Install binaries into ~/go/bin (or a target folder)"
-#USAGE arg "[target]" help="Target folder to install binaries into; defaults to GOBIN or ~/go/bin"
+#USAGE arg "[target]" help="Target folder to install binaries into; defaults to \$GOPATH/bin or ~/go/bin"
 
 set -eu
 
+# Precedence: explicit target arg, else $GOPATH/bin, else ~/go/bin. We do NOT
+# fall back to a pre-existing $GOBIN: mise sets GOBIN to its own managed Go
+# toolchain dir, which is usually behind ~/go/bin on PATH, so honoring it
+# silently installs a shadowed binary the user never runs. Anyone wanting a
+# custom location passes it as the target arg.
 target=${usage_target:-${1:-}}
-GOBIN=${target:-${GOBIN:-${GOPATH:-$HOME/go}/bin}}
+GOBIN=${target:-${GOPATH:-$HOME/go}/bin}
 mkdir -p "$GOBIN"
 # go install requires an absolute GOBIN path
 GOBIN=$(cd "$GOBIN" && pwd)


### PR DESCRIPTION
`mise run dev:publish` can install the CLI into a directory that's shadowed on your PATH, so you keep running a stale `entire` after a rebuild. One-line fix: the no-arg default stops honoring a pre-existing `$GOBIN`.

### a) What commit 8c17ac986 intended
[`8c17ac986`](https://github.com/entireio/cli/commit/8c17ac986) ("allow different target directory for mise run dev:publish") set out to add **one feature**: let you install binaries into a folder of your choice instead of always `~/go/bin`. That's the `[target]` arg.

Before it, the task force-set the destination:
```bash
export GOBIN=${GOPATH:-$HOME/go}/bin
```
After it, the destination became `${target:-${GOBIN:-${GOPATH:-$HOME/go}/bin}}` — so with no arg it now falls back to a pre-existing `$GOBIN`. That fallback was incidental to writing the default; respecting `$GOBIN` was never the goal.

### b) Evidence it was just the target-folder feature
- The commit message and the only added surface are the `[target]` arg (`#USAGE arg "[target]"`).
- The follow-up [`9c46a6a2c`](https://github.com/entireio/cli/commit/9c46a6a2c) ("address pr comments/feedback") only **refactored** the default from an `if`-block into the one-line `${target:-${GOBIN:-…}}`. It left the `$GOBIN` fallback untouched — no review comment asked to honor `$GOBIN`.
- The sibling script in `entiredb` (`mise-tasks/dev/publish`) never took this change and still force-overrides: `export GOBIN=${GOPATH:-$HOME/go}/bin`. So the robust behavior is the established norm.

### c) Why setting GOBIN explicitly fixes it
mise sets `$GOBIN` to its **own managed Go toolchain dir** (e.g. `~/.local/share/mise/installs/go/<ver>/bin`). That dir typically sits **behind** `~/go/bin` on PATH. So when the task honored that `$GOBIN`, `go install` wrote a perfectly good new binary there — but the shell kept resolving `entire` to the stale `~/go/bin/entire` ahead of it. The rebuild "did nothing" from the user's point of view.

By defaulting to `$GOPATH/bin` (→ `~/go/bin`) and ignoring the ambient `$GOBIN`, the freshly built binary lands where PATH actually looks first. The `[target]` arg is preserved, so anyone who genuinely wants a different location (including their own `$GOBIN` dir) passes it explicitly — cake, and eat it.

```bash
target=${usage_target:-${1:-}}
GOBIN=${target:-${GOPATH:-$HOME/go}/bin}   # arg wins; else ~/go/bin — never stray $GOBIN
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only install script behavior; no production runtime or security impact.
> 
> **Overview**
> **`mise run dev:publish`** no longer uses a pre-existing **`$GOBIN`** when no target is passed. The default install dir is **`${GOPATH:-$HOME/go}/bin`** (typically **`~/go/bin`**), so rebuilt **`entire`** / **`git-remote-entire`** land where PATH usually resolves first.
> 
> The optional **`[target]`** arg is unchanged: pass a folder explicitly when you want a non-default location (including a custom **`GOBIN`**). Usage help and inline comments document why ambient **`GOBIN`** is ignored (mise’s managed Go toolchain dir is often shadowed by **`~/go/bin`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e42f0d1f905a241f7828ebf3f8400bbf750d2e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->