### PR TITLE
Fix escaping in help text.

### DIFF
--- a/mise-tasks/dev/publish
+++ b/mise-tasks/dev/publish
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Install binaries into ~/go/bin (or a target folder)"
-#USAGE arg "[target]" help="Target folder to install binaries into; defaults to \$GOPATH/bin or ~/go/bin"
+#USAGE arg "[target]" help="Target folder to install binaries into; defaults to $GOPATH/bin or ~/go/bin"
 
 set -eu
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/683
<!-- entire-trail-link-end -->

This is a fix for recently merged PR:

- https://github.com/entireio/cli/pull/1550

The review comment was correct https://github.com/entireio/cli/pull/1550#discussion_r3487884521, and i made a fix on my local branch https://github.com/entireio/cli/commit/9dea51cdfb292e80a6daff12cb557586599fee81 (timestamped before the merge, but excluded) but i think i hit 'push' and slammed my laptop shut too fast.  The fix didn't end up on the branch and @Soph merged it.  Sorry about that 😬 Anyway here is the syntax fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to mise task help text with no runtime or install logic impact.
> 
> **Overview**
> Fixes the **`dev/publish`** mise task `#USAGE` help string so it shows **`$GOPATH/bin`** instead of a backslash-escaped **`\$GOPATH/bin`**, which was wrong after PR #1550.
> 
> Only the help text for the optional `[target]` argument changes; install behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a89650bd76175ccffc17787cd896278933846c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->