### PR TITLE
Extract checkpoint write helpers into treeWriter (no behavior change)

### DIFF
--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -82,34 +82,19 @@ func (s *GitStore) writeSession(ctx context.Context, opts WriteOptions) error {
 		return err
 	}
 
-	// Use sharded path: <id[:2]>/<id[2:]>/
-	basePath := opts.CheckpointID.Path() + "/"
-	checkpointPath := opts.CheckpointID.Path()
-
-	// Flatten only the checkpoint subtree (O(files in checkpoint))
-	entries, err := s.flattenCheckpointEntries(rootTreeHash, checkpointPath)
+	// Build the new checkpoint subtree from its current state on the v1 branch,
+	// then splice it back at the shard path. basePath keeps the v1 sharded layout
+	// so stored session-file pointers stay /<shard>/<id>/<n>/... as before.
+	existing, err := s.subtreeObjAt(rootTreeHash, opts.CheckpointID.Path())
+	if err != nil {
+		return err
+	}
+	checkpointSubtree, taskMetadataPath, err := s.applySessionWrite(ctx, opts, existing, opts.CheckpointID.Path()+"/", CheckpointVersionBranchV1)
 	if err != nil {
 		return err
 	}
 
-	// Track task metadata path for commit trailer
-	var taskMetadataPath string
-
-	// Handle task checkpoints
-	if opts.IsTask && opts.ToolUseID != "" {
-		taskMetadataPath, err = s.writeTaskCheckpointEntries(ctx, opts, basePath, entries)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Write standard checkpoint entries (transcript, prompts, context, metadata)
-	if err := s.writeStandardCheckpointEntries(ctx, opts, basePath, entries); err != nil {
-		return err
-	}
-
-	// Build checkpoint subtree and splice into root (O(depth) tree surgery)
-	newTreeHash, err := s.spliceCheckpointSubtree(ctx, rootTreeHash, opts.CheckpointID, basePath, entries)
+	newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, opts.CheckpointID, checkpointSubtree)
 	if err != nil {
 		return err
 	}
@@ -127,67 +112,326 @@ func (s *GitStore) writeSession(ctx context.Context, opts WriteOptions) error {
 	return s.setPrimaryRef(newCommitHash)
 }
 
-// flattenCheckpointEntries reads only the entries under a specific checkpoint path
-// from the sessions branch tree. This is O(files in checkpoint) instead of O(all checkpoints).
-// Returns an empty map if the checkpoint doesn't exist yet.
-func (s *GitStore) flattenCheckpointEntries(rootTreeHash plumbing.Hash, checkpointPath string) (map[string]object.TreeEntry, error) {
-	entries := make(map[string]object.TreeEntry)
+// subtreeObjAt returns the tree object for one checkpoint's subtree within a root
+// tree, or (nil, nil) when the root or the checkpoint path does not exist yet.
+// path is the in-tree checkpoint path (e.g. "a3/b2c4d5e6f7"); pass "" to return
+// the root tree itself (the per-checkpoint-ref layout, where the whole tree is
+// the checkpoint subtree).
+func (s *treeWriter) subtreeObjAt(rootTreeHash plumbing.Hash, path string) (*object.Tree, error) {
 	if rootTreeHash == plumbing.ZeroHash {
-		return entries, nil
+		return nil, nil //nolint:nilnil // absent checkpoint (no tree yet), not an error
 	}
-
 	rootTree, err := s.repo.TreeObject(rootTreeHash)
 	if err != nil {
 		if errors.Is(err, plumbing.ErrObjectNotFound) {
-			return entries, nil // Tree doesn't exist yet
+			return nil, nil //nolint:nilnil // tree doesn't exist yet, not an error
 		}
 		return nil, fmt.Errorf("failed to read root tree %s: %w", rootTreeHash, err)
 	}
-
-	subtree, err := rootTree.Tree(checkpointPath)
-	if err != nil {
-		return entries, nil //nolint:nilerr // Checkpoint doesn't exist yet
+	if path == "" {
+		return rootTree, nil
 	}
+	subtree, err := rootTree.Tree(path)
+	if err != nil {
+		return nil, nil //nolint:nilnil,nilerr // checkpoint doesn't exist yet, not an error
+	}
+	return subtree, nil
+}
 
-	// Flatten just this subtree with the full path prefix
-	if err := FlattenTree(s.repo, subtree, checkpointPath, entries); err != nil {
+// flattenExisting flattens a checkpoint's current subtree into a path->entry map
+// keyed under basePath, so the per-checkpoint write helpers (which build paths as
+// basePath+"<n>/<file>") see the existing files. basePath is "" for the
+// per-checkpoint-ref layout or "<shard>/<id>/" for the v1 branch layout. A nil
+// subtree (new checkpoint) yields an empty map.
+func (s *treeWriter) flattenExisting(existing *object.Tree, basePath string) (map[string]object.TreeEntry, error) {
+	entries := make(map[string]object.TreeEntry)
+	if existing == nil {
+		return entries, nil
+	}
+	if err := FlattenTree(s.repo, existing, strings.TrimSuffix(basePath, "/"), entries); err != nil {
 		return nil, err
 	}
 	return entries, nil
 }
 
-// spliceCheckpointSubtree builds a tree from checkpoint-local entries and installs it
-// at the correct shard location in the root tree using O(depth) tree surgery.
-// basePath is like "a3/b2c4d5e6f7/" (with trailing slash).
-// Returns the new root tree hash.
-func (s *GitStore) spliceCheckpointSubtree(ctx context.Context, rootTreeHash plumbing.Hash, checkpointID id.CheckpointID, basePath string, entries map[string]object.TreeEntry) (plumbing.Hash, error) {
-	// Convert entries to relative paths (strip basePath prefix)
-	relEntries := make(map[string]object.TreeEntry, len(entries))
-	for path, entry := range entries {
-		relPath := strings.TrimPrefix(path, basePath)
-		if relPath == path {
-			continue // Entry doesn't have the expected prefix
+// buildCheckpointSubtree builds the checkpoint subtree object from entries keyed
+// under basePath, stripping the prefix so the subtree is rooted at the checkpoint
+// directory. With basePath "" the entries are already root-relative.
+func (s *treeWriter) buildCheckpointSubtree(ctx context.Context, entries map[string]object.TreeEntry, basePath string) (plumbing.Hash, error) {
+	relEntries := entries
+	if basePath != "" {
+		relEntries = make(map[string]object.TreeEntry, len(entries))
+		for path, entry := range entries {
+			relPath := strings.TrimPrefix(path, basePath)
+			if relPath == path {
+				continue // Entry doesn't have the expected prefix
+			}
+			relEntries[relPath] = entry
 		}
-		relEntries[relPath] = entry
 	}
-
-	// Build the checkpoint subtree from relative entries
-	checkpointTreeHash, err := BuildTreeFromEntries(ctx, s.repo, relEntries)
+	subtree, err := BuildTreeFromEntries(ctx, s.repo, relEntries)
 	if err != nil {
 		return plumbing.ZeroHash, fmt.Errorf("failed to build checkpoint subtree: %w", err)
 	}
+	return subtree, nil
+}
 
-	// Splice into root tree at the shard path using tree surgery
-	// Path: ["a3"] with entry "b2c4d5e6f7" pointing to the checkpoint tree
+// spliceCheckpointSubtree installs a prebuilt checkpoint subtree at the shard
+// location in the v1 root tree using O(depth) tree surgery, returning the new
+// root tree hash. The v1 branch always shards on the first two ID characters.
+func (s *GitStore) spliceCheckpointSubtree(rootTreeHash plumbing.Hash, checkpointID id.CheckpointID, checkpointSubtree plumbing.Hash) (plumbing.Hash, error) {
 	shardPrefix := string(checkpointID[:2])
 	shardSuffix := string(checkpointID[2:])
 	return UpdateSubtree(s.repo, rootTreeHash, []string{shardPrefix}, []object.TreeEntry{
-		{Name: shardSuffix, Mode: filemode.Dir, Hash: checkpointTreeHash},
+		{Name: shardSuffix, Mode: filemode.Dir, Hash: checkpointSubtree},
 	}, UpdateSubtreeOptions{MergeMode: MergeKeepExisting})
 }
 
+// applySessionWrite applies a Session write to a checkpoint's current subtree and
+// returns the new checkpoint subtree hash plus the task metadata path (for the
+// commit trailer). It is backing-independent: the v1-branch store passes the
+// sharded basePath and the per-checkpoint-ref store passes "". checkpointVersion
+// is stamped into a freshly written root summary.
+func (s *treeWriter) applySessionWrite(ctx context.Context, opts WriteOptions, existing *object.Tree, basePath, checkpointVersion string) (plumbing.Hash, string, error) {
+	entries, err := s.flattenExisting(existing, basePath)
+	if err != nil {
+		return plumbing.ZeroHash, "", err
+	}
+
+	var taskMetadataPath string
+	if opts.IsTask && opts.ToolUseID != "" {
+		taskMetadataPath, err = s.writeTaskCheckpointEntries(ctx, opts, basePath, entries)
+		if err != nil {
+			return plumbing.ZeroHash, "", err
+		}
+	}
+
+	if err := s.writeStandardCheckpointEntries(ctx, opts, basePath, entries, checkpointVersion); err != nil {
+		return plumbing.ZeroHash, "", err
+	}
+
+	subtree, err := s.buildCheckpointSubtree(ctx, entries, basePath)
+	if err != nil {
+		return plumbing.ZeroHash, "", err
+	}
+	return subtree, taskMetadataPath, nil
+}
+
+// applyAttributionBackfill rewrites the checkpoint root summary's combined
+// attribution on the checkpoint's current subtree, returning the new subtree
+// hash. Returns ErrCheckpointNotFound when the checkpoint has no root summary.
+func (s *treeWriter) applyAttributionBackfill(ctx context.Context, existing *object.Tree, basePath string, combinedAttribution *Attribution) (plumbing.Hash, error) {
+	entries, err := s.flattenExisting(existing, basePath)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	rootMetadataPath := basePath + paths.MetadataFileName
+	entry, exists := entries[rootMetadataPath]
+	if !exists {
+		return plumbing.ZeroHash, ErrCheckpointNotFound
+	}
+
+	summary, err := s.readSummaryFromBlob(entry.Hash)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to read checkpoint summary: %w", err)
+	}
+	summary.CombinedAttribution = combinedAttribution
+
+	metadataJSON, err := jsonutil.MarshalIndentWithNewline(summary, "", "  ")
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to marshal checkpoint summary: %w", err)
+	}
+	metadataHash, err := CreateBlobFromContent(s.repo, metadataJSON)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to create checkpoint summary blob: %w", err)
+	}
+	entries[rootMetadataPath] = object.TreeEntry{
+		Name: rootMetadataPath,
+		Mode: filemode.Regular,
+		Hash: metadataHash,
+	}
+
+	return s.buildCheckpointSubtree(ctx, entries, basePath)
+}
+
+// applySummaryBackfill rewrites the latest session's summary on the checkpoint's
+// current subtree, returning the new subtree hash and that session's ID (for the
+// commit message). Returns ErrCheckpointNotFound when the checkpoint has no root
+// summary.
+func (s *treeWriter) applySummaryBackfill(ctx context.Context, existing *object.Tree, basePath string, summary *Summary) (plumbing.Hash, string, error) {
+	entries, err := s.flattenExisting(existing, basePath)
+	if err != nil {
+		return plumbing.ZeroHash, "", err
+	}
+
+	rootMetadataPath := basePath + paths.MetadataFileName
+	entry, exists := entries[rootMetadataPath]
+	if !exists {
+		return plumbing.ZeroHash, "", ErrCheckpointNotFound
+	}
+
+	checkpointSummary, err := s.readSummaryFromBlob(entry.Hash)
+	if err != nil {
+		return plumbing.ZeroHash, "", fmt.Errorf("failed to read checkpoint summary: %w", err)
+	}
+
+	// Find the latest session's metadata path (0-based indexing)
+	latestIndex := len(checkpointSummary.Sessions) - 1
+	sessionMetadataPath := fmt.Sprintf("%s%d/%s", basePath, latestIndex, paths.MetadataFileName)
+	sessionEntry, exists := entries[sessionMetadataPath]
+	if !exists {
+		return plumbing.ZeroHash, "", fmt.Errorf("session metadata not found at %s", sessionMetadataPath)
+	}
+
+	existingMetadata, err := s.readMetadataFromBlob(sessionEntry.Hash)
+	if err != nil {
+		return plumbing.ZeroHash, "", fmt.Errorf("failed to read session metadata: %w", err)
+	}
+
+	existingMetadata.Summary = RedactSummary(summary)
+
+	metadataJSON, err := jsonutil.MarshalIndentWithNewline(existingMetadata, "", "  ")
+	if err != nil {
+		return plumbing.ZeroHash, "", fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+	metadataHash, err := CreateBlobFromContent(s.repo, metadataJSON)
+	if err != nil {
+		return plumbing.ZeroHash, "", fmt.Errorf("failed to create metadata blob: %w", err)
+	}
+	entries[sessionMetadataPath] = object.TreeEntry{
+		Name: sessionMetadataPath,
+		Mode: filemode.Regular,
+		Hash: metadataHash,
+	}
+
+	subtree, err := s.buildCheckpointSubtree(ctx, entries, basePath)
+	if err != nil {
+		return plumbing.ZeroHash, "", err
+	}
+	return subtree, existingMetadata.SessionID, nil
+}
+
+// applyTranscriptBackfill replaces a session's transcript, prompts, and skill
+// events on the checkpoint's current subtree, returning the new subtree hash.
+// Returns ErrCheckpointNotFound when the checkpoint has no sessions yet.
+func (s *treeWriter) applyTranscriptBackfill(ctx context.Context, opts UpdateOptions, existing *object.Tree, basePath string) (plumbing.Hash, error) {
+	entries, err := s.flattenExisting(existing, basePath)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	rootMetadataPath := basePath + paths.MetadataFileName
+	entry, exists := entries[rootMetadataPath]
+	if !exists {
+		return plumbing.ZeroHash, ErrCheckpointNotFound
+	}
+
+	checkpointSummary, err := s.readSummaryFromBlob(entry.Hash)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("failed to read checkpoint summary: %w", err)
+	}
+	if len(checkpointSummary.Sessions) == 0 {
+		return plumbing.ZeroHash, ErrCheckpointNotFound
+	}
+
+	// Find session index matching opts.SessionID
+	sessionIndex := -1
+	var sessionMeta *Metadata
+	for i := range len(checkpointSummary.Sessions) {
+		metaPath := fmt.Sprintf("%s%d/%s", basePath, i, paths.MetadataFileName)
+		if metaEntry, metaExists := entries[metaPath]; metaExists {
+			meta, metaErr := s.readMetadataFromBlob(metaEntry.Hash)
+			if metaErr == nil && meta.SessionID == opts.SessionID {
+				sessionIndex = i
+				sessionMeta = meta
+				break
+			}
+		}
+	}
+	if sessionIndex == -1 {
+		// Fall back to latest session; log so mismatches are diagnosable.
+		sessionIndex = len(checkpointSummary.Sessions) - 1
+		logging.Debug(ctx, "backfillTranscript: session ID not found, falling back to latest",
+			slog.String("session_id", opts.SessionID),
+			slog.String("checkpoint_id", string(opts.CheckpointID)),
+			slog.Int("fallback_index", sessionIndex),
+		)
+		metaPath := fmt.Sprintf("%s%d/%s", basePath, sessionIndex, paths.MetadataFileName)
+		if metaEntry, metaExists := entries[metaPath]; metaExists {
+			sessionMeta, _ = s.readMetadataFromBlob(metaEntry.Hash) //nolint:errcheck // best-effort; nil meta means start 0
+		}
+	}
+
+	sessionPath := fmt.Sprintf("%s%d/", basePath, sessionIndex)
+
+	// Replace transcript (full replace, not append).
+	// Transcript is pre-redacted by the caller (enforced by RedactedBytes type).
+	if opts.Transcript.Len() > 0 {
+		agentType := opts.Agent
+		startLine := 0
+		if sessionMeta != nil {
+			startLine = sessionMeta.GetTranscriptStart()
+			if agentType == "" {
+				agentType = sessionMeta.Agent
+			}
+		}
+		if err := s.replaceTranscript(ctx, opts.Transcript, agentType, startLine, opts.PrecomputedBlobs, sessionPath, entries); err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("failed to replace transcript: %w", err)
+		}
+
+		// Keep the root metadata.json compact_transcript pointer consistent with
+		// the finalized tree. replaceTranscript may have written transcript.jsonl
+		// that the initial write lacked (e.g. compaction was skipped then and
+		// succeeds now), so re-derive the pointer from the tree entry and rewrite
+		// the root summary when it changed.
+		compactPath := ""
+		if _, ok := entries[sessionPath+paths.CompactTranscriptFileName]; ok {
+			compactPath = "/" + sessionPath + paths.CompactTranscriptFileName
+		}
+		if checkpointSummary.Sessions[sessionIndex].CompactTranscript != compactPath {
+			checkpointSummary.Sessions[sessionIndex].CompactTranscript = compactPath
+			summaryJSON, err := jsonutil.MarshalIndentWithNewline(checkpointSummary, "", "  ")
+			if err != nil {
+				return plumbing.ZeroHash, fmt.Errorf("failed to marshal checkpoint summary: %w", err)
+			}
+			summaryHash, err := CreateBlobFromContent(s.repo, summaryJSON)
+			if err != nil {
+				return plumbing.ZeroHash, fmt.Errorf("failed to create checkpoint summary blob: %w", err)
+			}
+			entries[rootMetadataPath] = object.TreeEntry{
+				Name: rootMetadataPath,
+				Mode: filemode.Regular,
+				Hash: summaryHash,
+			}
+		}
+	}
+
+	// Replace prompts with 7-layer-redacted content.
+	if len(opts.Prompts) > 0 {
+		promptContent := RedactedJoinedPrompts(opts.Prompts)
+		blobHash, err := CreateBlobFromContent(s.repo, []byte(promptContent))
+		if err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("failed to create prompt blob: %w", err)
+		}
+		entries[sessionPath+paths.PromptFileName] = object.TreeEntry{
+			Name: sessionPath + paths.PromptFileName,
+			Mode: filemode.Regular,
+			Hash: blobHash,
+		}
+	}
+
+	if len(opts.SkillEvents) > 0 {
+		if err := s.replaceSkillEvents(opts.SkillEvents, sessionPath, entries); err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("failed to replace skill events: %w", err)
+		}
+	}
+
+	return s.buildCheckpointSubtree(ctx, entries, basePath)
+}
+
 // writeTaskCheckpointEntries writes task-specific checkpoint entries and returns the task metadata path.
-func (s *GitStore) writeTaskCheckpointEntries(ctx context.Context, opts WriteOptions, basePath string, entries map[string]object.TreeEntry) (string, error) {
+func (s *treeWriter) writeTaskCheckpointEntries(ctx context.Context, opts WriteOptions, basePath string, entries map[string]object.TreeEntry) (string, error) {
 	taskPath := basePath + "tasks/" + opts.ToolUseID + "/"
 
 	if opts.IsIncremental {
@@ -197,7 +441,7 @@ func (s *GitStore) writeTaskCheckpointEntries(ctx context.Context, opts WriteOpt
 }
 
 // writeIncrementalTaskCheckpoint writes an incremental checkpoint file during task execution.
-func (s *GitStore) writeIncrementalTaskCheckpoint(opts WriteOptions, taskPath string, entries map[string]object.TreeEntry) (string, error) {
+func (s *treeWriter) writeIncrementalTaskCheckpoint(opts WriteOptions, taskPath string, entries map[string]object.TreeEntry) (string, error) {
 	incData, err := redact.JSONLBytes(opts.IncrementalData)
 	if err != nil {
 		return "", fmt.Errorf("failed to redact incremental checkpoint: %w", err)
@@ -228,7 +472,7 @@ func (s *GitStore) writeIncrementalTaskCheckpoint(opts WriteOptions, taskPath st
 }
 
 // writeFinalTaskCheckpoint writes the final checkpoint.json and subagent transcript.
-func (s *GitStore) writeFinalTaskCheckpoint(ctx context.Context, opts WriteOptions, taskPath string, entries map[string]object.TreeEntry) (string, error) {
+func (s *treeWriter) writeFinalTaskCheckpoint(ctx context.Context, opts WriteOptions, taskPath string, entries map[string]object.TreeEntry) (string, error) {
 	checkpoint := taskCheckpointData{
 		SessionID:      opts.SessionID,
 		ToolUseID:      opts.ToolUseID,
@@ -299,7 +543,7 @@ func (s *GitStore) writeFinalTaskCheckpoint(ctx context.Context, opts WriteOptio
 //	│   └── content_hash.txt
 //	├── 2/                    # Second session
 //	└── ...
-func (s *GitStore) writeStandardCheckpointEntries(ctx context.Context, opts WriteOptions, basePath string, entries map[string]object.TreeEntry) error {
+func (s *treeWriter) writeStandardCheckpointEntries(ctx context.Context, opts WriteOptions, basePath string, entries map[string]object.TreeEntry, checkpointVersion string) error {
 	// Read existing summary to get current session count
 	var existingSummary *CheckpointSummary
 	metadataPath := basePath + paths.MetadataFileName
@@ -388,12 +632,12 @@ func (s *GitStore) writeStandardCheckpointEntries(ctx context.Context, opts Writ
 	}
 
 	// Update root metadata.json with CheckpointSummary
-	return s.writeCheckpointSummary(opts, basePath, entries, sessions)
+	return s.writeCheckpointSummary(opts, basePath, entries, sessions, checkpointVersion)
 }
 
 // writeSessionToSubdirectory writes a single session's files to a numbered subdirectory.
 // Returns the absolute file paths from the git tree root for the sessions map.
-func (s *GitStore) writeSessionToSubdirectory(ctx context.Context, opts WriteOptions, sessionPath string, entries map[string]object.TreeEntry) (SessionFilePaths, error) {
+func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteOptions, sessionPath string, entries map[string]object.TreeEntry) (SessionFilePaths, error) {
 	filePaths := SessionFilePaths{}
 
 	// Clear any existing entries at this path so stale files from a previous
@@ -490,14 +734,13 @@ func (s *GitStore) writeSessionToSubdirectory(ctx context.Context, opts WriteOpt
 
 // writeCheckpointSummary writes the root-level CheckpointSummary with aggregated statistics.
 // sessions is the complete sessions array (already built by the caller).
-func (s *GitStore) writeCheckpointSummary(opts WriteOptions, basePath string, entries map[string]object.TreeEntry, sessions []SessionFilePaths) error {
+func (s *treeWriter) writeCheckpointSummary(opts WriteOptions, basePath string, entries map[string]object.TreeEntry, sessions []SessionFilePaths, checkpointVersion string) error {
 	checkpointsCount, filesTouched, tokenUsage, err := s.reaggregateFromEntries(basePath, len(sessions), entries)
 	if err != nil {
 		return fmt.Errorf("failed to aggregate session stats: %w", err)
 	}
 
 	combinedAttribution := opts.CombinedAttribution
-	checkpointVersion := CheckpointVersionBranchV1
 	hasReview := opts.HasReview
 	hasInvestigation := opts.HasInvestigation
 	// imported is the umbrella flag: true when any session in this checkpoint
@@ -572,40 +815,16 @@ func (s *GitStore) backfillAttribution(ctx context.Context, checkpointID id.Chec
 		return err
 	}
 
-	basePath := checkpointID.Path() + "/"
-	checkpointPath := checkpointID.Path()
-	entries, err := s.flattenCheckpointEntries(rootTreeHash, checkpointPath)
+	existing, err := s.subtreeObjAt(rootTreeHash, checkpointID.Path())
+	if err != nil {
+		return err
+	}
+	checkpointSubtree, err := s.applyAttributionBackfill(ctx, existing, checkpointID.Path()+"/", combinedAttribution)
 	if err != nil {
 		return err
 	}
 
-	rootMetadataPath := basePath + paths.MetadataFileName
-	entry, exists := entries[rootMetadataPath]
-	if !exists {
-		return ErrCheckpointNotFound
-	}
-
-	summary, err := s.readSummaryFromBlob(entry.Hash)
-	if err != nil {
-		return fmt.Errorf("failed to read checkpoint summary: %w", err)
-	}
-	summary.CombinedAttribution = combinedAttribution
-
-	metadataJSON, err := jsonutil.MarshalIndentWithNewline(summary, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal checkpoint summary: %w", err)
-	}
-	metadataHash, err := CreateBlobFromContent(s.repo, metadataJSON)
-	if err != nil {
-		return fmt.Errorf("failed to create checkpoint summary blob: %w", err)
-	}
-	entries[rootMetadataPath] = object.TreeEntry{
-		Name: rootMetadataPath,
-		Mode: filemode.Regular,
-		Hash: metadataHash,
-	}
-
-	newTreeHash, err := s.spliceCheckpointSubtree(ctx, rootTreeHash, checkpointID, basePath, entries)
+	newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, checkpointID, checkpointSubtree)
 	if err != nil {
 		return err
 	}
@@ -622,7 +841,7 @@ func (s *GitStore) backfillAttribution(ctx context.Context, checkpointID id.Chec
 
 // findSessionIndex returns the index of an existing session with the given ID,
 // or the next available index if not found. This prevents duplicate session entries.
-func (s *GitStore) findSessionIndex(ctx context.Context, basePath string, existingSummary *CheckpointSummary, entries map[string]object.TreeEntry, sessionID string) int {
+func (s *treeWriter) findSessionIndex(ctx context.Context, basePath string, existingSummary *CheckpointSummary, entries map[string]object.TreeEntry, sessionID string) int {
 	if existingSummary == nil {
 		return 0
 	}
@@ -650,7 +869,7 @@ func (s *GitStore) findSessionIndex(ctx context.Context, basePath string, existi
 
 // reaggregateFromEntries reads all session metadata from the entries map and
 // reaggregates CheckpointsCount, FilesTouched, and TokenUsage.
-func (s *GitStore) reaggregateFromEntries(basePath string, sessionCount int, entries map[string]object.TreeEntry) (int, []string, *agent.TokenUsage, error) {
+func (s *treeWriter) reaggregateFromEntries(basePath string, sessionCount int, entries map[string]object.TreeEntry) (int, []string, *agent.TokenUsage, error) {
 	var totalCount int
 	var allFiles []string
 	var totalTokens *agent.TokenUsage
@@ -709,7 +928,7 @@ func readJSONFromBlob[T any](repo *git.Repository, hash plumbing.Hash) (*T, erro
 }
 
 // readSummaryFromBlob reads CheckpointSummary from a blob hash.
-func (s *GitStore) readSummaryFromBlob(hash plumbing.Hash) (*CheckpointSummary, error) {
+func (s *treeWriter) readSummaryFromBlob(hash plumbing.Hash) (*CheckpointSummary, error) {
 	summary, err := readJSONFromBlob[CheckpointSummary](s.repo, hash)
 	if err != nil {
 		return nil, err
@@ -746,7 +965,7 @@ func aggregateTokenUsage(a, b *agent.TokenUsage) *agent.TokenUsage {
 // tree (so it is pushed alongside full.jsonl) but is not yet referenced by
 // metadata. Returns true when a transcript was written, false when it was
 // empty and nothing was written.
-func (s *GitStore) writeTranscript(ctx context.Context, opts WriteOptions, basePath string, entries map[string]object.TreeEntry) (bool, error) {
+func (s *treeWriter) writeTranscript(ctx context.Context, opts WriteOptions, basePath string, entries map[string]object.TreeEntry) (bool, error) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	transcriptBytes := opts.Transcript.Bytes()
 
@@ -860,7 +1079,7 @@ func compactAgentName(agentType types.AgentType) string {
 // checkpoint write. transcriptBytes must already be sanitized for the agent
 // (e.g. Codex portable-transcript sanitization); callers sanitize before
 // calling so the expensive pass runs exactly once.
-func (s *GitStore) writeCompactTranscript(ctx context.Context, agentType types.AgentType, startLine int, transcriptBytes []byte, sessionPath string, entries map[string]object.TreeEntry) {
+func (s *treeWriter) writeCompactTranscript(ctx context.Context, agentType types.AgentType, startLine int, transcriptBytes []byte, sessionPath string, entries map[string]object.TreeEntry) {
 	compactCtx, compactSpan := perf.Start(ctx, "write_compact_transcript")
 	defer compactSpan.End()
 
@@ -984,14 +1203,14 @@ func redactCodeLearnings(cls []CodeLearning) []CodeLearning {
 }
 
 // readMetadataFromBlob reads Metadata from a blob hash.
-func (s *GitStore) readMetadataFromBlob(hash plumbing.Hash) (*Metadata, error) {
+func (s *treeWriter) readMetadataFromBlob(hash plumbing.Hash) (*Metadata, error) {
 	return readJSONFromBlob[Metadata](s.repo, hash)
 }
 
 // buildCommitMessage constructs the commit message with proper trailers.
 // The commit subject is always "Checkpoint: <id>" for consistency.
 // If CommitSubject is provided (e.g., for task checkpoints), it's included in the body.
-func (s *GitStore) buildCommitMessage(opts WriteOptions, taskMetadataPath string) string {
+func (s *treeWriter) buildCommitMessage(opts WriteOptions, taskMetadataPath string) string {
 	var commitMsg strings.Builder
 
 	// Subject line is always the checkpoint ID for consistent formatting
@@ -1431,66 +1650,22 @@ func (s *GitStore) backfillSummary(ctx context.Context, checkpointID id.Checkpoi
 		return err
 	}
 
-	// Flatten only the checkpoint subtree
-	basePath := checkpointID.Path() + "/"
-	checkpointPath := checkpointID.Path()
-	entries, err := s.flattenCheckpointEntries(rootTreeHash, checkpointPath)
+	existing, err := s.subtreeObjAt(rootTreeHash, checkpointID.Path())
+	if err != nil {
+		return err
+	}
+	checkpointSubtree, sessionID, err := s.applySummaryBackfill(ctx, existing, checkpointID.Path()+"/", summary)
 	if err != nil {
 		return err
 	}
 
-	// Read root CheckpointSummary to find the latest session
-	rootMetadataPath := basePath + paths.MetadataFileName
-	entry, exists := entries[rootMetadataPath]
-	if !exists {
-		return ErrCheckpointNotFound
-	}
-
-	checkpointSummary, err := s.readSummaryFromBlob(entry.Hash)
-	if err != nil {
-		return fmt.Errorf("failed to read checkpoint summary: %w", err)
-	}
-
-	// Find the latest session's metadata path (0-based indexing)
-	latestIndex := len(checkpointSummary.Sessions) - 1
-	sessionMetadataPath := fmt.Sprintf("%s%d/%s", basePath, latestIndex, paths.MetadataFileName)
-	sessionEntry, exists := entries[sessionMetadataPath]
-	if !exists {
-		return fmt.Errorf("session metadata not found at %s", sessionMetadataPath)
-	}
-
-	// Read and update session metadata
-	existingMetadata, err := s.readMetadataFromBlob(sessionEntry.Hash)
-	if err != nil {
-		return fmt.Errorf("failed to read session metadata: %w", err)
-	}
-
-	// Update the summary
-	existingMetadata.Summary = RedactSummary(summary)
-
-	// Write updated session metadata
-	metadataJSON, err := jsonutil.MarshalIndentWithNewline(existingMetadata, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal metadata: %w", err)
-	}
-	metadataHash, err := CreateBlobFromContent(s.repo, metadataJSON)
-	if err != nil {
-		return fmt.Errorf("failed to create metadata blob: %w", err)
-	}
-	entries[sessionMetadataPath] = object.TreeEntry{
-		Name: sessionMetadataPath,
-		Mode: filemode.Regular,
-		Hash: metadataHash,
-	}
-
-	// Build checkpoint subtree and splice into root (O(depth) tree surgery)
-	newTreeHash, err := s.spliceCheckpointSubtree(ctx, rootTreeHash, checkpointID, basePath, entries)
+	newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, checkpointID, checkpointSubtree)
 	if err != nil {
 		return err
 	}
 
 	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
-	commitMsg := fmt.Sprintf("Update summary for checkpoint %s (session: %s)", checkpointID, existingMetadata.SessionID)
+	commitMsg := fmt.Sprintf("Update summary for checkpoint %s (session: %s)", checkpointID, sessionID)
 	newCommitHash, err := CreateCommit(ctx, s.repo, newTreeHash, parentHash, commitMsg, authorName, authorEmail)
 	if err != nil {
 		return err
@@ -1523,123 +1698,16 @@ func (s *GitStore) backfillTranscript(ctx context.Context, opts UpdateOptions) e
 		return err
 	}
 
-	// Flatten only the checkpoint subtree
-	basePath := opts.CheckpointID.Path() + "/"
-	checkpointPath := opts.CheckpointID.Path()
-	entries, err := s.flattenCheckpointEntries(rootTreeHash, checkpointPath)
+	existing, err := s.subtreeObjAt(rootTreeHash, opts.CheckpointID.Path())
+	if err != nil {
+		return err
+	}
+	checkpointSubtree, err := s.applyTranscriptBackfill(ctx, opts, existing, opts.CheckpointID.Path()+"/")
 	if err != nil {
 		return err
 	}
 
-	// Read root CheckpointSummary to find the session slot
-	rootMetadataPath := basePath + paths.MetadataFileName
-	entry, exists := entries[rootMetadataPath]
-	if !exists {
-		return ErrCheckpointNotFound
-	}
-
-	checkpointSummary, err := s.readSummaryFromBlob(entry.Hash)
-	if err != nil {
-		return fmt.Errorf("failed to read checkpoint summary: %w", err)
-	}
-	if len(checkpointSummary.Sessions) == 0 {
-		return ErrCheckpointNotFound
-	}
-
-	// Find session index matching opts.SessionID
-	sessionIndex := -1
-	var sessionMeta *Metadata
-	for i := range len(checkpointSummary.Sessions) {
-		metaPath := fmt.Sprintf("%s%d/%s", basePath, i, paths.MetadataFileName)
-		if metaEntry, metaExists := entries[metaPath]; metaExists {
-			meta, metaErr := s.readMetadataFromBlob(metaEntry.Hash)
-			if metaErr == nil && meta.SessionID == opts.SessionID {
-				sessionIndex = i
-				sessionMeta = meta
-				break
-			}
-		}
-	}
-	if sessionIndex == -1 {
-		// Fall back to latest session; log so mismatches are diagnosable.
-		sessionIndex = len(checkpointSummary.Sessions) - 1
-		logging.Debug(ctx, "backfillTranscript: session ID not found, falling back to latest",
-			slog.String("session_id", opts.SessionID),
-			slog.String("checkpoint_id", string(opts.CheckpointID)),
-			slog.Int("fallback_index", sessionIndex),
-		)
-		metaPath := fmt.Sprintf("%s%d/%s", basePath, sessionIndex, paths.MetadataFileName)
-		if metaEntry, metaExists := entries[metaPath]; metaExists {
-			sessionMeta, _ = s.readMetadataFromBlob(metaEntry.Hash) //nolint:errcheck // best-effort; nil meta means start 0
-		}
-	}
-
-	sessionPath := fmt.Sprintf("%s%d/", basePath, sessionIndex)
-
-	// Replace transcript (full replace, not append).
-	// Transcript is pre-redacted by the caller (enforced by RedactedBytes type).
-	if opts.Transcript.Len() > 0 {
-		agentType := opts.Agent
-		startLine := 0
-		if sessionMeta != nil {
-			startLine = sessionMeta.GetTranscriptStart()
-			if agentType == "" {
-				agentType = sessionMeta.Agent
-			}
-		}
-		if err := s.replaceTranscript(ctx, opts.Transcript, agentType, startLine, opts.PrecomputedBlobs, sessionPath, entries); err != nil {
-			return fmt.Errorf("failed to replace transcript: %w", err)
-		}
-
-		// Keep the root metadata.json compact_transcript pointer consistent with
-		// the finalized tree. replaceTranscript may have written transcript.jsonl
-		// that the initial write lacked (e.g. compaction was skipped then and
-		// succeeds now), so re-derive the pointer from the tree entry and rewrite
-		// the root summary when it changed.
-		compactPath := ""
-		if _, ok := entries[sessionPath+paths.CompactTranscriptFileName]; ok {
-			compactPath = "/" + sessionPath + paths.CompactTranscriptFileName
-		}
-		if checkpointSummary.Sessions[sessionIndex].CompactTranscript != compactPath {
-			checkpointSummary.Sessions[sessionIndex].CompactTranscript = compactPath
-			summaryJSON, err := jsonutil.MarshalIndentWithNewline(checkpointSummary, "", "  ")
-			if err != nil {
-				return fmt.Errorf("failed to marshal checkpoint summary: %w", err)
-			}
-			summaryHash, err := CreateBlobFromContent(s.repo, summaryJSON)
-			if err != nil {
-				return fmt.Errorf("failed to create checkpoint summary blob: %w", err)
-			}
-			entries[rootMetadataPath] = object.TreeEntry{
-				Name: rootMetadataPath,
-				Mode: filemode.Regular,
-				Hash: summaryHash,
-			}
-		}
-	}
-
-	// Replace prompts with 7-layer-redacted content.
-	if len(opts.Prompts) > 0 {
-		promptContent := RedactedJoinedPrompts(opts.Prompts)
-		blobHash, err := CreateBlobFromContent(s.repo, []byte(promptContent))
-		if err != nil {
-			return fmt.Errorf("failed to create prompt blob: %w", err)
-		}
-		entries[sessionPath+paths.PromptFileName] = object.TreeEntry{
-			Name: sessionPath + paths.PromptFileName,
-			Mode: filemode.Regular,
-			Hash: blobHash,
-		}
-	}
-
-	if len(opts.SkillEvents) > 0 {
-		if err := s.replaceSkillEvents(opts.SkillEvents, sessionPath, entries); err != nil {
-			return fmt.Errorf("failed to replace skill events: %w", err)
-		}
-	}
-
-	// Build checkpoint subtree and splice into root (O(depth) tree surgery)
-	newTreeHash, err := s.spliceCheckpointSubtree(ctx, rootTreeHash, opts.CheckpointID, basePath, entries)
+	newTreeHash, err := s.spliceCheckpointSubtree(rootTreeHash, opts.CheckpointID, checkpointSubtree)
 	if err != nil {
 		return err
 	}
@@ -1658,7 +1726,7 @@ func (s *GitStore) backfillTranscript(ctx context.Context, opts UpdateOptions) e
 	return s.setPrimaryRef(newCommitHash)
 }
 
-func (s *GitStore) replaceSkillEvents(skillEvents []agent.SkillEvent, sessionPath string, entries map[string]object.TreeEntry) error {
+func (s *treeWriter) replaceSkillEvents(skillEvents []agent.SkillEvent, sessionPath string, entries map[string]object.TreeEntry) error {
 	metadataPath := sessionPath + paths.MetadataFileName
 	entry, exists := entries[metadataPath]
 	if !exists {
@@ -1700,7 +1768,7 @@ func (s *GitStore) replaceSkillEvents(skillEvents []agent.SkillEvent, sessionPat
 // reuse precomputed blobs: each checkpoint in a turn shares the full
 // transcript but has its own start offset, so the compact content differs per
 // checkpoint.
-func (s *GitStore) replaceTranscript(ctx context.Context, transcript redact.RedactedBytes, agentType types.AgentType, startLine int, precomputed *PrecomputedTranscriptBlobs, sessionPath string, entries map[string]object.TreeEntry) error {
+func (s *treeWriter) replaceTranscript(ctx context.Context, transcript redact.RedactedBytes, agentType types.AgentType, startLine int, precomputed *PrecomputedTranscriptBlobs, sessionPath string, entries map[string]object.TreeEntry) error {
 	// Ignore precompute if invariants are violated — fall back to fresh chunking.
 	if precomputed != nil && !precomputed.IsUsable() {
 		precomputed = nil
@@ -1943,7 +2011,7 @@ func CreateBlobFromContent(repo *git.Repository, content []byte) (plumbing.Hash,
 
 // copyMetadataDir copies all files from a directory to the checkpoint path.
 // Used to include additional metadata files like task checkpoints, subagent transcripts, etc.
-func (s *GitStore) copyMetadataDir(ctx context.Context, metadataDir, basePath string, entries map[string]object.TreeEntry) error {
+func (s *treeWriter) copyMetadataDir(ctx context.Context, metadataDir, basePath string, entries map[string]object.TreeEntry) error {
 	err := filepath.Walk(metadataDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/cmd/entire/cli/checkpoint/persistent_tripwire_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_tripwire_test.go
@@ -72,7 +72,7 @@ func TestWriteStandardCheckpointEntries_RefusesUnexpectedSessionZeroOverwrite(t 
 		Prompts:      []string{"hi"},
 	}
 
-	err = store.writeStandardCheckpointEntries(context.Background(), opts, basePath, entries)
+	err = store.writeStandardCheckpointEntries(context.Background(), opts, basePath, entries, CheckpointVersionBranchV1)
 	if err == nil {
 		t.Fatal("expected writeStandardCheckpointEntries to refuse, got nil error")
 	}

--- a/cmd/entire/cli/checkpoint/persistent_update_test.go
+++ b/cmd/entire/cli/checkpoint/persistent_update_test.go
@@ -77,9 +77,13 @@ func rewriteRootSummary(t *testing.T, store *GitStore, cpID id.CheckpointID, mut
 	}
 
 	basePath := cpID.Path() + "/"
-	entries, err := store.flattenCheckpointEntries(rootTreeHash, cpID.Path())
+	existing, err := store.subtreeObjAt(rootTreeHash, cpID.Path())
 	if err != nil {
-		t.Fatalf("flattenCheckpointEntries(): %v", err)
+		t.Fatalf("subtreeObjAt(): %v", err)
+	}
+	entries, err := store.flattenExisting(existing, basePath)
+	if err != nil {
+		t.Fatalf("flattenExisting(): %v", err)
 	}
 
 	summary := readSummaryFromBranch(t, store.repo, cpID)
@@ -101,7 +105,11 @@ func rewriteRootSummary(t *testing.T, store *GitStore, cpID id.CheckpointID, mut
 		Hash: metadataHash,
 	}
 
-	newTreeHash, err := store.spliceCheckpointSubtree(ctx, rootTreeHash, cpID, basePath, entries)
+	checkpointSubtree, err := store.buildCheckpointSubtree(ctx, entries, basePath)
+	if err != nil {
+		t.Fatalf("buildCheckpointSubtree(): %v", err)
+	}
+	newTreeHash, err := store.spliceCheckpointSubtree(rootTreeHash, cpID, checkpointSubtree)
 	if err != nil {
 		t.Fatalf("spliceCheckpointSubtree(): %v", err)
 	}

--- a/cmd/entire/cli/checkpoint/store.go
+++ b/cmd/entire/cli/checkpoint/store.go
@@ -14,11 +14,25 @@ var (
 	_ EphemeralStore  = (*ephemeralStore)(nil)
 )
 
+// treeWriter holds the repo-only machinery for building a single checkpoint's
+// subtree from write requests: entry builders, transcript/session writers, and
+// the per-request appliers (applySessionWrite / applyTranscriptBackfill /
+// applySummaryBackfill / applyAttributionBackfill). It is independent of where
+// the resulting subtree is committed, so both the git-branch store (which nests
+// the subtree under <shard>/<id>/ on the v1 branch) and the git-refs store
+// (which keeps it at the root of a per-checkpoint ref) embed it and share this
+// code.
+type treeWriter struct {
+	repo *git.Repository
+}
+
 // GitStore is the committed (persistent) checkpoint store. Writes target
 // refs.Primary; committed reads resolve against refs.Read. The temporary
-// shadow-branch surface lives in ephemeralStore.
+// shadow-branch surface lives in ephemeralStore. It embeds *treeWriter for the
+// shared subtree-building machinery.
 type GitStore struct {
-	repo        *git.Repository
+	*treeWriter
+
 	refs        PersistentRefs
 	blobFetcher BlobFetchFunc
 }
@@ -49,7 +63,7 @@ func NewEphemeralStore(repo *git.Repository, refs PersistentRefs) EphemeralStore
 // and committed-metadata topology. Pass DefaultV1Refs() for the v1-only default
 // or ResolveRefs(ctx) in code paths that honor settings.
 func NewGitStore(repo *git.Repository, refs PersistentRefs) *GitStore {
-	return &GitStore{repo: repo, refs: refs}
+	return &GitStore{treeWriter: &treeWriter{repo: repo}, refs: refs}
 }
 
 // SetBlobFetcher configures the store to automatically fetch missing blobs


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/685
<!-- entire-trail-link-end -->

Behavior-preserving refactor toward the per-checkpoint git-ref checkpoint store (#1471). It isolates the repo-only "build one checkpoint's subtree" machinery from the git-branch store so a second backend can share it instead of duplicating it. **No functional change** — nothing constructs a second backend yet.

This is intentionally its own PR so the "no v1-tree change" property is verifiable in isolation, ahead of the feature PR that adds the git-refs backend on top.

## What changes
- The repo-only entry/subtree builders move from `*GitStore` to a new `*treeWriter` (`writeStandardCheckpointEntries`, `writeTaskCheckpointEntries`, `writeSessionToSubdirectory`, `writeCheckpointSummary`, `findSessionIndex`, `reaggregateFromEntries`, `replaceTranscript`, `replaceSkillEvents`, `writeTranscript`/`writeCompactTranscript`, `copyMetadataDir`, `readSummaryFromBlob`, `readMetadataFromBlob`, `buildCommitMessage`). `GitStore` embeds `*treeWriter`, so existing call sites resolve unchanged via field promotion.
- `GitStore`'s four write methods route through shared appliers anchored at the checkpoint-dir root. The git-branch store still splices the resulting subtree under `<shard>/<id>/` into the v1 tree, so **the committed `entire/checkpoints/v1` tree is byte-identical**. `writeCheckpointSummary` now takes the checkpoint-version to stamp.

## Why it's safe
The git-branch entry-building logic is unchanged; only its *receiver* moved and the write methods now build the subtree via the shared core before the identical splice. Equivalence rests on: flatten-at-root then `BuildTreeFromEntries` produces the same subtree as the old flatten-with-prefix then strip+build.

## Testing
`mise run fmt && lint` clean (0 issues); checkpoint + strategy unit suites green; **integration suite (378) green** — the real condensation→v1 write path, the strongest "no change" signal.

Refs: #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of committed checkpoint git tree writes and backfills; wrong flatten/basePath handling could corrupt metadata trees, though the PR targets byte-identical v1 output and tests cover the path.
> 
> **Overview**
> Introduces a **`treeWriter`** type that owns repo-only logic for building one checkpoint’s git subtree, and **`GitStore` embeds it** so v1-branch writes keep the same call surface via promotion.
> 
> **`writeSession`**, attribution/summary/transcript backfills, and related paths no longer inline flatten → mutate entries → strip prefix → build → splice. They load the existing checkpoint tree with **`subtreeObjAt`**, run shared **`applySessionWrite`** / **`applyAttributionBackfill`** / **`applySummaryBackfill`** / **`applyTranscriptBackfill`**, then **`spliceCheckpointSubtree`** installs a **prebuilt subtree hash** (signature drops `ctx` and the entries map). Helpers **`flattenExisting`** and **`buildCheckpointSubtree`** separate v1 sharded `basePath` from a future per-ref layout (`basePath ""`).
> 
> Subtree entry builders (`writeStandardCheckpointEntries`, task/session/transcript writers, blob readers, `buildCommitMessage`, etc.) move from **`*GitStore` to `*treeWriter`**. **`writeCheckpointSummary`** now takes an explicit **`checkpointVersion`** argument instead of hard-coding v1 inside the helper.
> 
> Tests (`persistent_tripwire_test`, `persistent_update_test`) are updated to call the new helpers; **intended behavior on `entire/checkpoints/v1` is unchanged** (prep for #1471).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ae00149756edd6e629b0d235b052d67d78e7a06. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->