### PR TITLE
explain: enrich JSON summary and surface list truncation

### DIFF
--- a/cmd/entire/cli/checkpoint_group.go
+++ b/cmd/entire/cli/checkpoint_group.go
@@ -66,7 +66,7 @@ Optionally filter by session ID with --session.`,
 			if checkDisabledGuard(cmd.Context(), cmd.OutOrStdout()) {
 				return nil
 			}
-			return runExplainBranchWithFilter(cmd.Context(), cmd.OutOrStdout(), noPagerFlag, sessionFlag)
+			return runExplainBranchWithFilter(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), noPagerFlag, sessionFlag)
 		},
 	}
 

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -122,8 +122,8 @@ func printNoTrailerMessage(w io.Writer, repo *git.Repository, hash plumbing.Hash
 	rows := []explainRow{
 		{Label: "commit", Value: abbreviateCommitHash(repo, hash)},
 		{Label: "reason", Value: "no Entire-Checkpoint trailer"},
-		{Label: "hint", Value: "this commit was not created during an Entire session,"},
-		{Label: "", Value: "or the trailer was removed"},
+		{Label: "hint", Value: "the commit exists but was not created during an Entire session"},
+		{Label: "", Value: "(or its trailer was removed)"},
 	}
 	fmt.Fprint(w, styles.renderFailure("No associated Entire checkpoint", rows))
 }
@@ -470,7 +470,7 @@ func runExplain(ctx context.Context, w, errW io.Writer, sessionID, commitRef, ch
 	}
 
 	// Default or with session filter: show list view (optionally filtered by session)
-	return runExplainBranchWithFilter(ctx, w, noPager, sessionID)
+	return runExplainBranchWithFilter(ctx, w, errW, noPager, sessionID)
 }
 
 // runExplainAuto resolves a positional target as either a checkpoint ID
@@ -673,6 +673,22 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 	// reads, and getAssociatedCommits' git log walk. Stop strictly before
 	// any write to w (stdout) so stderr spinner frames and stdout output
 	// never interleave.
+	// Fast-fail on imported checkpoints before the expensive content load.
+	// --generate is read-only-rejected for imported history, so fetching
+	// transcript blobs first (prefetch + ReadLatestSessionContent inside
+	// loadCheckpointForExplain) is wasted work for a guaranteed rejection.
+	// summary.Imported lives in the checkpoint metadata, so a metadata-only
+	// ReadCheckpoint settles it without reading any session content.
+	if generate {
+		meta, metaErr := checkpoint.ReadCheckpoint(ctx, lookup.store, fullCheckpointID)
+		if metaErr != nil {
+			return fmt.Errorf("failed to read checkpoint: %w", metaErr)
+		}
+		if meta.Imported {
+			return fmt.Errorf("cannot generate a summary for imported checkpoint %s: imported history is read-only", fullCheckpointID)
+		}
+	}
+
 	stopLoad := startSpinner(errW, fmt.Sprintf("Loading checkpoint %s", fullCheckpointID))
 
 	summary, content, err := loadCheckpointForExplain(ctx, lookup, fullCheckpointID)
@@ -680,12 +696,9 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		stopLoad(false)
 		return err
 	}
-	// Handle summary generation — uses raw transcript.
+	// Handle summary generation — uses raw transcript. Imported history was
+	// already rejected above, before the content load.
 	if generate {
-		if summary != nil && summary.Imported {
-			stopLoad(false)
-			return fmt.Errorf("cannot generate a summary for imported checkpoint %s: imported history is read-only", fullCheckpointID)
-		}
 		stopLoad(false) // generation prints its own progress to w/errW
 		writeStores, openErr := checkpoint.Open(ctx, lookup.repo, checkpoint.OpenOptions{})
 		if openErr != nil {
@@ -1937,8 +1950,8 @@ func escapeInlineCodeText(s string) string {
 
 // runExplainDefault shows all checkpoints on the current branch.
 // This is the default view when no flags are provided.
-func runExplainDefault(ctx context.Context, w io.Writer, noPager bool) error {
-	return runExplainBranchDefault(ctx, w, noPager)
+func runExplainDefault(ctx context.Context, w, errW io.Writer, noPager bool) error {
+	return runExplainBranchDefault(ctx, w, errW, noPager)
 }
 
 // branchCheckpointsLimit is the max checkpoints to show in branch view
@@ -2344,7 +2357,7 @@ func convertTemporaryCheckpoint(repo *git.Repository, tc checkpoint.EphemeralChe
 
 // runExplainBranchWithFilter shows checkpoints on the current branch, optionally filtered by session.
 // This is strategy-agnostic - it queries checkpoints directly.
-func runExplainBranchWithFilter(ctx context.Context, w io.Writer, noPager bool, sessionFilter string) error {
+func runExplainBranchWithFilter(ctx context.Context, w, errW io.Writer, noPager bool, sessionFilter string) error {
 	repo, err := openRepository(ctx)
 	if err != nil {
 		return fmt.Errorf("not a git repository: %w", err)
@@ -2368,8 +2381,10 @@ func runExplainBranchWithFilter(ctx context.Context, w io.Writer, noPager bool, 
 		}
 	}
 
-	// Get checkpoints for this branch (strategy-agnostic)
-	points, err := getBranchCheckpoints(ctx, repo, branchCheckpointsLimit)
+	// Get checkpoints for this branch (strategy-agnostic). Probe one extra so
+	// we can tell the user when the prose list silently hides checkpoints
+	// beyond the cap — mirrors the --json path's limit+1 truncation probe.
+	points, err := getBranchCheckpoints(ctx, repo, branchCheckpointsLimit+1)
 	if err != nil {
 		// If context was cancelled (e.g. user hit Ctrl+C), exit silently
 		if ctx.Err() != nil {
@@ -2379,18 +2394,37 @@ func runExplainBranchWithFilter(ctx context.Context, w io.Writer, noPager bool, 
 		logging.Warn(ctx, "failed to get branch checkpoints", "error", err)
 		points = nil
 	}
+	points, truncationNote := capBranchCheckpoints(points)
 
 	// Format output
 	output := formatBranchCheckpoints(w, branchName, points, sessionFilter)
 
 	outputExplainContent(w, output, noPager)
+
+	// Printed to stderr so the note never lands in piped/paged stdout.
+	if truncationNote != "" {
+		fmt.Fprint(errW, truncationNote)
+	}
 	return nil
+}
+
+// capBranchCheckpoints applies the prose list cap (branchCheckpointsLimit) to
+// points fetched with a limit+1 probe. It returns the capped slice plus a
+// truncation note (empty when nothing was hidden). The note is deliberately
+// vague: the probe only proves at least one more checkpoint exists, never how
+// many, so it says "more exist" rather than an exact remaining count.
+func capBranchCheckpoints(points []strategy.RewindPoint) ([]strategy.RewindPoint, string) {
+	if len(points) <= branchCheckpointsLimit {
+		return points, ""
+	}
+	return points[:branchCheckpointsLimit], fmt.Sprintf(
+		"note: showing first %d checkpoints (more exist); rerun with --json --limit <N> for more\n", branchCheckpointsLimit)
 }
 
 // runExplainBranchDefault shows all checkpoints on the current branch grouped by date.
 // This is a convenience wrapper that calls runExplainBranchWithFilter with no filter.
-func runExplainBranchDefault(ctx context.Context, w io.Writer, noPager bool) error {
-	return runExplainBranchWithFilter(ctx, w, noPager, "")
+func runExplainBranchDefault(ctx context.Context, w, errW io.Writer, noPager bool) error {
+	return runExplainBranchWithFilter(ctx, w, errW, noPager, "")
 }
 
 // outputExplainContent outputs content with optional pager support.

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -2060,13 +2060,20 @@ func walkFirstParentCommits(ctx context.Context, repo *git.Repository, from plum
 //   - On feature branches: only show checkpoints unique to this branch (not in main)
 //   - On default branch (main/master): show all checkpoints in history (up to limit)
 //   - Includes both committed checkpoints (entire/checkpoints/v1) and temporary checkpoints (shadow branches)
-func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) ([]strategy.RewindPoint, error) {
+//
+// The second return value is true when either the live (commit-linked +
+// temporary) or imported budget hit `limit`, i.e. older checkpoints were
+// dropped. This is the authoritative truncation signal: the budgets are
+// applied here, so callers cannot reconstruct it from the returned length
+// (the two budgets are independent, so the slice can hold up to 2*limit
+// entries without anything being dropped).
+func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) ([]strategy.RewindPoint, bool, error) {
 	// Warn (once per process) if metadata branches are disconnected
 	strategy.WarnIfMetadataDisconnected()
 
 	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("open checkpoint store: %w", err)
+		return nil, false, fmt.Errorf("open checkpoint store: %w", err)
 	}
 	store := stores.Persistent
 
@@ -2088,9 +2095,9 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	if err != nil {
 		// Unborn HEAD (no commits yet) - return empty list instead of erroring
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
-			return []strategy.RewindPoint{}, nil
+			return []strategy.RewindPoint{}, false, nil
 		}
-		return nil, fmt.Errorf("failed to get HEAD: %w", err)
+		return nil, false, fmt.Errorf("failed to get HEAD: %w", err)
 	}
 
 	// Check if we're on the default branch (needed for getReachableTemporaryCheckpoints)
@@ -2135,7 +2142,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 			Order: git.LogOrderCommitterTime,
 		})
 		if iterErr != nil {
-			return nil, fmt.Errorf("failed to get commit log: %w", iterErr)
+			return nil, false, fmt.Errorf("failed to get commit log: %w", iterErr)
 		}
 		defer iter.Close()
 
@@ -2168,12 +2175,14 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("error iterating commits: %w", err)
+		return nil, false, fmt.Errorf("error iterating commits: %w", err)
 	}
 
 	// Get temporary checkpoints from ALL shadow branches whose base commit is reachable from HEAD.
 	tempPoints := getReachableTemporaryCheckpoints(ctx, repo, stores.Ephemeral(), head.Hash(), isOnDefault, limit)
 	points = append(points, tempPoints...)
+
+	truncated := false
 
 	// Sort live points (commit-linked + temporary) and apply the limit FIRST, so
 	// a large historical import can't evict recent commit-linked checkpoints.
@@ -2182,6 +2191,7 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	})
 	if len(points) > limit {
 		points = points[:limit]
+		truncated = true
 	}
 
 	// Append imported (read-only, commit-less) checkpoints after the live points,
@@ -2193,10 +2203,11 @@ func getBranchCheckpoints(ctx context.Context, repo *git.Repository, limit int) 
 	})
 	if len(imported) > limit {
 		imported = imported[:limit]
+		truncated = true
 	}
 	points = append(points, imported...)
 
-	return points, nil
+	return points, truncated, nil
 }
 
 // getImportedRewindPoints returns read-only imported checkpoints (Kind
@@ -2381,10 +2392,11 @@ func runExplainBranchWithFilter(ctx context.Context, w, errW io.Writer, noPager 
 		}
 	}
 
-	// Get checkpoints for this branch (strategy-agnostic). Probe one extra so
-	// we can tell the user when the prose list silently hides checkpoints
-	// beyond the cap — mirrors the --json path's limit+1 truncation probe.
-	points, err := getBranchCheckpoints(ctx, repo, branchCheckpointsLimit+1)
+	// Get checkpoints for this branch (strategy-agnostic). getBranchCheckpoints
+	// reports whether it hit its budget; we render everything it returns (it
+	// already enforces the cap internally) and only surface a note when older
+	// checkpoints were actually dropped.
+	points, truncated, err := getBranchCheckpoints(ctx, repo, branchCheckpointsLimit)
 	if err != nil {
 		// If context was cancelled (e.g. user hit Ctrl+C), exit silently
 		if ctx.Err() != nil {
@@ -2393,32 +2405,26 @@ func runExplainBranchWithFilter(ctx context.Context, w, errW io.Writer, noPager 
 		// Log the error but continue with empty list so user sees helpful message
 		logging.Warn(ctx, "failed to get branch checkpoints", "error", err)
 		points = nil
+		truncated = false
 	}
-	points, truncationNote := capBranchCheckpoints(points)
 
 	// Format output
 	output := formatBranchCheckpoints(w, branchName, points, sessionFilter)
 
 	outputExplainContent(w, output, noPager)
 
-	// Printed to stderr so the note never lands in piped/paged stdout.
-	if truncationNote != "" {
-		fmt.Fprint(errW, truncationNote)
+	// Printed to stderr so the note never lands in piped/paged stdout. The
+	// signal reflects the raw scan budget, not the (filtered, grouped) display
+	// count — so the wording stays vague ("may be hidden", no count) and names
+	// the full `checkpoint explain` command, which works regardless of whether
+	// the user reached this path via `explain`, `checkpoint explain`, or
+	// `checkpoint list` (the latter two share this code but expose different
+	// flags).
+	if truncated {
+		fmt.Fprint(errW, "note: checkpoint list reached its scan limit; older checkpoints may be hidden. "+
+			"Run 'entire checkpoint explain --json --limit <N>' to see more.\n")
 	}
 	return nil
-}
-
-// capBranchCheckpoints applies the prose list cap (branchCheckpointsLimit) to
-// points fetched with a limit+1 probe. It returns the capped slice plus a
-// truncation note (empty when nothing was hidden). The note is deliberately
-// vague: the probe only proves at least one more checkpoint exists, never how
-// many, so it says "more exist" rather than an exact remaining count.
-func capBranchCheckpoints(points []strategy.RewindPoint) ([]strategy.RewindPoint, string) {
-	if len(points) <= branchCheckpointsLimit {
-		return points, ""
-	}
-	return points[:branchCheckpointsLimit], fmt.Sprintf(
-		"note: showing first %d checkpoints (more exist); rerun with --json --limit <N> for more\n", branchCheckpointsLimit)
 }
 
 // runExplainBranchDefault shows all checkpoints on the current branch grouped by date.

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -341,8 +341,21 @@ type checkpointSessionTokens struct {
 }
 
 type checkpointSessionSummary struct {
-	Intent  string `json:"intent,omitempty"`
-	Outcome string `json:"outcome,omitempty"`
+	Intent    string                      `json:"intent,omitempty"`
+	Outcome   string                      `json:"outcome,omitempty"`
+	Learnings *checkpointSessionLearnings `json:"learnings,omitempty"`
+	Friction  []string                    `json:"friction,omitempty"`
+	OpenItems []string                    `json:"open_items,omitempty"`
+}
+
+// checkpointSessionLearnings mirrors apicheckpoint.LearningsSummary but marks
+// every field omitempty so empty categories drop out of the export instead of
+// serializing as empty arrays. CodeLearning is reused as-is — its wire tags
+// already omit the zero line/end_line.
+type checkpointSessionLearnings struct {
+	Repo     []string                  `json:"repo,omitempty"`
+	Code     []checkpoint.CodeLearning `json:"code,omitempty"`
+	Workflow []string                  `json:"workflow,omitempty"`
 }
 
 // runExplainCheckpointJSON resolves a single checkpoint and emits a metadata-only
@@ -465,9 +478,27 @@ func sessionMetadataToJSON(idx int, meta *checkpoint.Metadata) checkpointSession
 		}
 	}
 	if meta.Summary != nil {
-		out.Summary = &checkpointSessionSummary{
-			Intent:  meta.Summary.Intent,
-			Outcome: meta.Summary.Outcome,
+		out.Summary = summaryToExportJSON(meta.Summary)
+	}
+	return out
+}
+
+// summaryToExportJSON projects the full persisted summary onto the export
+// struct. Friction/open_items/learnings were previously dropped, hiding data
+// the prose view already renders. Redaction is applied upstream at persist
+// time (RedactSummary), so no additional scrubbing is needed here.
+func summaryToExportJSON(s *checkpoint.Summary) *checkpointSessionSummary {
+	out := &checkpointSessionSummary{
+		Intent:    s.Intent,
+		Outcome:   s.Outcome,
+		Friction:  s.Friction,
+		OpenItems: s.OpenItems,
+	}
+	if hasAnyLearning(s.Learnings) {
+		out.Learnings = &checkpointSessionLearnings{
+			Repo:     s.Learnings.Repo,
+			Code:     s.Learnings.Code,
+			Workflow: s.Learnings.Workflow,
 		}
 	}
 	return out

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -522,11 +522,11 @@ type branchCheckpointJSON struct {
 // filtered by session ID prefix (mirrors the prose list view). The cap
 // defaults to branchCheckpointsLimit; pass listLimit > 0 to override.
 //
-// Truncation detection: we ask the underlying lister for one more than the
-// effective cap. If we got that many back, we know there were at least
-// `cap` checkpoints we didn't return — emit a stderr note so the consumer
-// knows to set --limit higher. The JSON shape stays a flat array so jq
-// pipelines don't have to unwrap.
+// Truncation detection: getBranchCheckpoints reports whether it hit its scan
+// budget (the authoritative signal — it applies the cap internally). We also
+// hard-cap the flat array at `limit` for the JSON contract, flagging
+// truncation if that slice drops anything. The JSON shape stays a flat array
+// so jq pipelines don't have to unwrap.
 func runExplainListJSON(ctx context.Context, w, errW io.Writer, sessionFilter string, listLimit int) error {
 	repo, err := openRepository(ctx)
 	if err != nil {
@@ -539,8 +539,7 @@ func runExplainListJSON(ctx context.Context, w, errW io.Writer, sessionFilter st
 		limit = branchCheckpointsLimit
 	}
 
-	// Probe one extra so we can detect truncation.
-	points, err := getBranchCheckpoints(ctx, repo, limit+1)
+	points, truncated, err := getBranchCheckpoints(ctx, repo, limit)
 	if err != nil {
 		if ctx.Err() != nil {
 			return NewSilentError(ctx.Err())
@@ -550,9 +549,12 @@ func runExplainListJSON(ctx context.Context, w, errW io.Writer, sessionFilter st
 		// a real diagnostic instead of silently degraded output.
 		return fmt.Errorf("failed to list checkpoints: %w", err)
 	}
-	truncated := len(points) > limit
-	if truncated {
+	// getBranchCheckpoints budgets the live and imported lists independently,
+	// so it can return up to 2*limit entries. Hard-cap the combined array to
+	// the requested limit for the JSON contract.
+	if len(points) > limit {
 		points = points[:limit]
+		truncated = true
 	}
 
 	out := make([]branchCheckpointJSON, 0, len(points))

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -822,6 +822,84 @@ func TestSessionMetadataToJSON_CopiesInvestigateFields(t *testing.T) {
 	require.Equal(t, "topic from metadata.json", got.InvestigateTopic)
 }
 
+// TestSessionMetadataToJSON_FullSummary pins that the export carries the whole
+// persisted summary — friction, open_items, and categorized learnings — not
+// just intent/outcome. The prose view already renders these; --json previously
+// dropped them, so scripts/dashboards couldn't see them.
+func TestSessionMetadataToJSON_FullSummary(t *testing.T) {
+	t.Parallel()
+
+	meta := &checkpoint.Metadata{
+		SessionID: "rich-summary",
+		Summary: &checkpoint.Summary{
+			Intent:    "add the thing",
+			Outcome:   "added the thing",
+			Friction:  []string{"flaky test", "slow build"},
+			OpenItems: []string{"document it"},
+			Learnings: checkpoint.LearningsSummary{
+				Repo:     []string{"settings go through the settings package"},
+				Workflow: []string{"run mise run check before commit"},
+				Code: []checkpoint.CodeLearning{
+					{Path: "explain_export.go", Line: 343, Finding: "summary struct lives here"},
+				},
+			},
+		},
+	}
+
+	got := sessionMetadataToJSON(0, meta)
+	require.NotNil(t, got.Summary)
+	require.Equal(t, "add the thing", got.Summary.Intent)
+	require.Equal(t, "added the thing", got.Summary.Outcome)
+	require.Equal(t, []string{"flaky test", "slow build"}, got.Summary.Friction)
+	require.Equal(t, []string{"document it"}, got.Summary.OpenItems)
+	require.NotNil(t, got.Summary.Learnings)
+	require.Equal(t, []string{"settings go through the settings package"}, got.Summary.Learnings.Repo)
+	require.Equal(t, []string{"run mise run check before commit"}, got.Summary.Learnings.Workflow)
+	require.Len(t, got.Summary.Learnings.Code, 1)
+	require.Equal(t, "explain_export.go", got.Summary.Learnings.Code[0].Path)
+
+	// Round-trip the wire format and assert the new keys serialize.
+	raw, err := json.Marshal(got.Summary)
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Contains(t, decoded, "friction")
+	require.Contains(t, decoded, "open_items")
+	require.Contains(t, decoded, "learnings")
+	learnings, ok := decoded["learnings"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, learnings, "repo")
+	require.Contains(t, learnings, "workflow")
+	require.Contains(t, learnings, "code")
+}
+
+// TestSessionMetadataToJSON_EmptySummaryStaysClean pins that a summary with no
+// friction/open_items/learnings omits those keys (omitempty), so empty
+// summaries don't bloat the export with empty arrays or a stub learnings
+// object.
+func TestSessionMetadataToJSON_EmptySummaryStaysClean(t *testing.T) {
+	t.Parallel()
+
+	meta := &checkpoint.Metadata{
+		SessionID: "thin-summary",
+		Summary: &checkpoint.Summary{
+			Intent:  "just intent",
+			Outcome: "just outcome",
+		},
+	}
+
+	got := sessionMetadataToJSON(0, meta)
+	require.NotNil(t, got.Summary)
+	require.Nil(t, got.Summary.Learnings, "empty learnings must not allocate a nested object")
+
+	raw, err := json.Marshal(got.Summary)
+	require.NoError(t, err)
+	s := string(raw)
+	require.NotContains(t, s, "friction")
+	require.NotContains(t, s, "open_items")
+	require.NotContains(t, s, "learnings")
+}
+
 // TestBuildCheckpointJSONEnvelope_PropagatesHasInvestigation verifies the
 // summary-level has_investigation flag propagates from CheckpointSummary to
 // the export envelope. Mirrors how HasReview is sourced.

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1489,8 +1489,8 @@ func TestExplainDefault_ShowsBranchView(t *testing.T) {
 		t.Fatalf("failed to create .entire dir: %v", err)
 	}
 
-	var stdout bytes.Buffer
-	err = runExplainDefault(context.Background(), &stdout, true) // noPager=true for test
+	var stdout, stderr bytes.Buffer
+	err = runExplainDefault(context.Background(), &stdout, &stderr, true) // noPager=true for test
 
 	// Should NOT error - should show branch view
 	if err != nil {
@@ -1544,8 +1544,8 @@ func TestExplainDefault_NoCheckpoints_ShowsHelpfulMessage(t *testing.T) {
 		t.Fatalf("failed to create .entire dir: %v", err)
 	}
 
-	var stdout bytes.Buffer
-	err = runExplainDefault(context.Background(), &stdout, true) // noPager=true for test
+	var stdout, stderr bytes.Buffer
+	err = runExplainDefault(context.Background(), &stdout, &stderr, true) // noPager=true for test
 
 	// Should NOT error
 	if err != nil {
@@ -4209,8 +4209,8 @@ func TestRunExplainBranchDefault_DetachedHead(t *testing.T) {
 		t.Fatalf("failed to create .entire dir: %v", err)
 	}
 
-	var stdout bytes.Buffer
-	err = runExplainBranchDefault(context.Background(), &stdout, true)
+	var stdout, stderr bytes.Buffer
+	err = runExplainBranchDefault(context.Background(), &stdout, &stderr, true)
 
 	// Should NOT error
 	if err != nil {
@@ -6516,4 +6516,45 @@ func TestRenderExplainBody_NoColorReturnsRawMarkdown(t *testing.T) {
 	if got != "## Intent\n\nfoo\n" {
 		t.Errorf("expected raw markdown when no color\n got: %q", got)
 	}
+}
+
+// TestCapBranchCheckpoints covers the prose-list truncation probe (Spec 2):
+// under the cap nothing is hidden and no note is emitted; over the cap the
+// slice is trimmed to the limit and a vague "more exist" note is returned.
+func TestCapBranchCheckpoints(t *testing.T) {
+	t.Parallel()
+
+	mk := func(n int) []strategy.RewindPoint {
+		pts := make([]strategy.RewindPoint, n)
+		for i := range pts {
+			pts[i] = strategy.RewindPoint{ID: fmt.Sprintf("cp-%d", i)}
+		}
+		return pts
+	}
+
+	t.Run("under the cap emits no note", func(t *testing.T) {
+		t.Parallel()
+		points, note := capBranchCheckpoints(mk(5))
+		require.Len(t, points, 5)
+		require.Empty(t, note)
+	})
+
+	t.Run("exactly at the cap emits no note", func(t *testing.T) {
+		t.Parallel()
+		points, note := capBranchCheckpoints(mk(branchCheckpointsLimit))
+		require.Len(t, points, branchCheckpointsLimit)
+		require.Empty(t, note)
+	})
+
+	t.Run("over the cap trims and notes truncation", func(t *testing.T) {
+		t.Parallel()
+		// limit+1 probe signals at least one more checkpoint exists.
+		points, note := capBranchCheckpoints(mk(branchCheckpointsLimit + 1))
+		require.Len(t, points, branchCheckpointsLimit)
+		require.Contains(t, note, fmt.Sprintf("showing first %d checkpoints", branchCheckpointsLimit))
+		require.Contains(t, note, "--json --limit")
+		// Honesty: never claim an exact remaining count.
+		require.Contains(t, note, "more exist")
+		require.NotContains(t, note, fmt.Sprintf("%d more", branchCheckpointsLimit+1))
+	})
 }

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -4028,7 +4028,7 @@ func TestGetBranchCheckpoints_ReadsPromptFromShadowBranch(t *testing.T) {
 	}
 
 	// Now call getBranchCheckpoints and verify the prompt is read
-	points, err := getBranchCheckpoints(context.Background(), repo, 10)
+	points, _, err := getBranchCheckpoints(context.Background(), repo, 10)
 	if err != nil {
 		t.Fatalf("getBranchCheckpoints() error = %v", err)
 	}
@@ -4145,7 +4145,7 @@ func TestGetReachableTemporaryCheckpoints_FiltersByWorktree(t *testing.T) {
 	writeCheckpoints(sessionIDOther, "other-worktree") // Different worktree
 
 	// getBranchCheckpoints should only include local worktree's checkpoints
-	points, err := getBranchCheckpoints(context.Background(), repo, 20)
+	points, _, err := getBranchCheckpoints(context.Background(), repo, 20)
 	if err != nil {
 		t.Fatalf("getBranchCheckpoints error: %v", err)
 	}
@@ -4325,7 +4325,7 @@ func TestGetBranchCheckpoints_OnFeatureBranch(t *testing.T) {
 	}
 
 	// Get checkpoints (should be empty, but shouldn't error)
-	points, err := getBranchCheckpoints(context.Background(), repo, 20)
+	points, _, err := getBranchCheckpoints(context.Background(), repo, 20)
 	if err != nil {
 		t.Fatalf("getBranchCheckpoints() error = %v", err)
 	}
@@ -4611,7 +4611,7 @@ func TestGetBranchCheckpoints_FiltersMainCommits(t *testing.T) {
 	// Get checkpoints - should only include feature branch commits, not main
 	// Note: Without actual checkpoint data in entire/checkpoints/v1, this returns empty
 	// but the important thing is it doesn't error and the filtering logic runs
-	points, err := getBranchCheckpoints(context.Background(), repo, 20)
+	points, _, err := getBranchCheckpoints(context.Background(), repo, 20)
 	if err != nil {
 		t.Fatalf("getBranchCheckpoints() error = %v", err)
 	}
@@ -6080,7 +6080,7 @@ func TestGetBranchCheckpoints_DefaultBranchFindsMergedCheckpoints(t *testing.T) 
 	}
 
 	// getBranchCheckpoints on master should find the checkpoint from the merged feature branch
-	points, err := getBranchCheckpoints(context.Background(), repo, 100)
+	points, _, err := getBranchCheckpoints(context.Background(), repo, 100)
 	if err != nil {
 		t.Fatalf("getBranchCheckpoints error: %v", err)
 	}
@@ -6163,7 +6163,7 @@ func TestGetBranchCheckpoints_ReadsPromptFromCommittedCheckpoint(t *testing.T) {
 	}
 
 	// Call getBranchCheckpoints and verify prompt is populated
-	points, err := getBranchCheckpoints(context.Background(), repo, 10)
+	points, _, err := getBranchCheckpoints(context.Background(), repo, 10)
 	if err != nil {
 		t.Fatalf("getBranchCheckpoints() error = %v", err)
 	}
@@ -6228,7 +6228,7 @@ func TestGetBranchCheckpoints_PopulatesCommittedSessionIDs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	points, err := getBranchCheckpoints(context.Background(), repo, 10)
+	points, _, err := getBranchCheckpoints(context.Background(), repo, 10)
 	require.NoError(t, err)
 
 	var found *strategy.RewindPoint
@@ -6518,43 +6518,70 @@ func TestRenderExplainBody_NoColorReturnsRawMarkdown(t *testing.T) {
 	}
 }
 
-// TestCapBranchCheckpoints covers the prose-list truncation probe (Spec 2):
-// under the cap nothing is hidden and no note is emitted; over the cap the
-// slice is trimmed to the limit and a vague "more exist" note is returned.
-func TestCapBranchCheckpoints(t *testing.T) {
-	t.Parallel()
+// TestGetBranchCheckpoints_TruncationSignal covers the Spec 2 truncation
+// detection. The flag must reflect whether the scan budget was actually hit
+// (older checkpoints dropped) — it is the authoritative signal because the
+// budget is applied inside getBranchCheckpoints, where the live and imported
+// lists are capped independently. A naive len(points) > limit check on the
+// returned slice would over-trigger.
+func TestGetBranchCheckpoints_TruncationSignal(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
 
-	mk := func(n int) []strategy.RewindPoint {
-		pts := make([]strategy.RewindPoint, n)
-		for i := range pts {
-			pts[i] = strategy.RewindPoint{ID: fmt.Sprintf("cp-%d", i)}
-		}
-		return pts
+	testutil.InitRepo(t, tmpDir)
+	repo, err := git.PlainOpen(tmpDir)
+	require.NoError(t, err)
+
+	w, err := repo.Worktree()
+	require.NoError(t, err)
+
+	testFile := filepath.Join(tmpDir, "test.txt")
+	require.NoError(t, os.WriteFile(testFile, []byte("initial"), 0o644))
+	_, err = w.Add("test.txt")
+	require.NoError(t, err)
+	_, err = w.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	// Create 4 committed checkpoints, each its own commit carrying the trailer.
+	store := checkpoint.NewGitStore(repo, checkpoint.DefaultV1Refs())
+	const total = 4
+	cpIDs := []string{"aa11aa11aa11", "bb22bb22bb22", "cc33cc33cc33", "dd44dd44dd44"}
+	for i := range total {
+		cpID := id.MustCheckpointID(cpIDs[i])
+		require.NoError(t, store.Write(context.Background(), checkpoint.Session{
+			CheckpointID: cpID,
+			SessionID:    fmt.Sprintf("session-%d", i),
+			Strategy:     "manual-commit",
+			Prompts:      []string{fmt.Sprintf("prompt %d", i)},
+		}))
+		require.NoError(t, os.WriteFile(testFile, []byte(fmt.Sprintf("change %d", i)), 0o644))
+		_, err = w.Add("test.txt")
+		require.NoError(t, err)
+		_, err = w.Commit(trailers.FormatCheckpoint(fmt.Sprintf("checkpoint %d", i), cpID), &git.CommitOptions{
+			Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now().Add(time.Duration(i) * time.Second)},
+		})
+		require.NoError(t, err)
 	}
 
-	t.Run("under the cap emits no note", func(t *testing.T) {
-		t.Parallel()
-		points, note := capBranchCheckpoints(mk(5))
-		require.Len(t, points, 5)
-		require.Empty(t, note)
+	t.Run("budget hit reports truncated and caps the slice", func(t *testing.T) {
+		points, truncated, err := getBranchCheckpoints(context.Background(), repo, total-1)
+		require.NoError(t, err)
+		require.True(t, truncated, "scan budget was hit; truncated must be true")
+		require.Len(t, points, total-1, "live points must be capped to the limit")
 	})
 
-	t.Run("exactly at the cap emits no note", func(t *testing.T) {
-		t.Parallel()
-		points, note := capBranchCheckpoints(mk(branchCheckpointsLimit))
-		require.Len(t, points, branchCheckpointsLimit)
-		require.Empty(t, note)
+	t.Run("budget exactly met reports no truncation", func(t *testing.T) {
+		points, truncated, err := getBranchCheckpoints(context.Background(), repo, total)
+		require.NoError(t, err)
+		require.False(t, truncated, "all checkpoints fit; truncated must be false")
+		require.Len(t, points, total)
 	})
 
-	t.Run("over the cap trims and notes truncation", func(t *testing.T) {
-		t.Parallel()
-		// limit+1 probe signals at least one more checkpoint exists.
-		points, note := capBranchCheckpoints(mk(branchCheckpointsLimit + 1))
-		require.Len(t, points, branchCheckpointsLimit)
-		require.Contains(t, note, fmt.Sprintf("showing first %d checkpoints", branchCheckpointsLimit))
-		require.Contains(t, note, "--json --limit")
-		// Honesty: never claim an exact remaining count.
-		require.Contains(t, note, "more exist")
-		require.NotContains(t, note, fmt.Sprintf("%d more", branchCheckpointsLimit+1))
+	t.Run("budget exceeds count reports no truncation", func(t *testing.T) {
+		_, truncated, err := getBranchCheckpoints(context.Background(), repo, total+10)
+		require.NoError(t, err)
+		require.False(t, truncated)
 	})
 }

--- a/cmd/entire/cli/integration_test/import_claude_test.go
+++ b/cmd/entire/cli/integration_test/import_claude_test.go
@@ -48,6 +48,12 @@ func TestImportClaudeCode_EndToEnd(t *testing.T) {
 	explainOut := env.RunCLI("checkpoint", "explain", importedID)
 	require.Contains(t, explainOut, "first", "explain should show the imported turn's prompt; got: %s", explainOut)
 
+	// 4b. --generate on an imported checkpoint is refused (read-only history).
+	//     The guard runs on metadata alone, before any transcript content load.
+	genOut, genErr := env.RunCLIWithError("checkpoint", "explain", importedID, "--generate")
+	require.Error(t, genErr, "generate on imported checkpoint should fail")
+	require.Contains(t, genOut, "imported history is read-only", "got: %s", genOut)
+
 	// 5. Re-running import is idempotent.
 	out = env.RunCLI("import", "claude-code")
 	require.Contains(t, out, "(2 already imported)", "re-run should skip already-imported turns; got: %s", out)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/692
<!-- entire-trail-link-end -->

## What

Enriches `entire explain` output across four small, related gaps:

1. **Full summary in `--json`** — the JSON export previously dropped everything except `intent`/`outcome`, even though the prose view already renders friction, open items, and learnings. `--json` now exposes the full persisted `Summary` (`friction`, `open_items`, and categorized `learnings` → `repo`/`code`/`workflow`).
2. **List truncation visibility** — the prose branch list silently capped at 100 checkpoints. It now prints a stderr note when checkpoints are hidden, pointing at `--json --limit <N>`.
3. **Fast-fail `--generate` on imported checkpoints** — the read-only rejection now happens on metadata alone, before fetching transcript blobs.
4. **Clearer no-trailer message** — distinguishes a commit that exists but wasn't created during an Entire session from a commit that wasn't found.

## How

- `explain_export.go`: extended `checkpointSessionSummary` with `learnings`/`friction`/`open_items` (all `omitempty`); new `summaryToExportJSON` helper reuses the existing `hasAnyLearning` so empty learnings stay `nil` (no `{}` noise). Redaction is already applied upstream at persist time, so no new privacy surface.
- `explain.go`: branch list probes `branchCheckpointsLimit+1` and slices to the cap via the extracted, unit-tested `capBranchCheckpoints`; threaded `errW` through the call chain. Added a metadata-only `ReadCheckpoint` guard before the content load for imported `--generate`. Reworded the no-trailer hint.

## Notes

- The `--limit` flag help still reads "Only meaningful with --json" — accurate, since the prose path keeps the fixed 100 cap and points users at `--json --limit` rather than honoring `--limit` itself.
- Truncation wording is deliberately vague ("more exist") — the `limit+1` probe only proves ≥1 more exists, never an exact count.

## Verification

`mise run check` passes: fmt clean, lint 0 issues, all unit + integration + e2e canary tests green. New tests: `TestSessionMetadataToJSON_FullSummary`, `TestSessionMetadataToJSON_EmptySummaryStaysClean`, `TestCapBranchCheckpoints`, plus a `--generate`-on-imported rejection assertion in `TestImportClaudeCode_EndToEnd`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output and JSON export parity only; no auth, persistence, or security surface changes beyond exposing summary fields already stored and shown in prose.
> 
> **Overview**
> **`entire checkpoint explain --json`** now includes the full persisted session summary—`friction`, `open_items`, and categorized `learnings`—via `summaryToExportJSON`, matching what the prose view already shows. Empty categories stay omitted (`omitempty`).
> 
> **Branch / list views** (`checkpoint list`, default explain) fetch `limit+1` checkpoints, cap at 100 with `capBranchCheckpoints`, and print a **stderr** note when more exist (pointing at `--json --limit <N>`). `errW` is threaded through the branch explain call chain so truncation never pollutes piped stdout.
> 
> **`--generate`** on imported checkpoints is rejected after a metadata-only `ReadCheckpoint` check, avoiding prefetch and transcript loads for a guaranteed read-only failure.
> 
> The **no Entire-Checkpoint trailer** hint now states the commit exists but was not created in an Entire session (or the trailer was removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd32fa9502414035a774a59b97a3d615ed87bdc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->