### PR TITLE
Per-checkpoint git-ref checkpoint store (git-refs backend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
 
   test-canary:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # Run the (no-cost, no-API) Vogon canary against each checkpoint backend so
+      # the git-refs store is guarded on every PR alongside the default git-branch.
+      matrix:
+        checkpoint_store: [git-branch, git-refs]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -57,6 +63,8 @@ jobs:
           echo 'somecredstorepass' | gnome-keyring-daemon --unlock
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
       - name: E2E Canary
+        env:
+          E2E_CHECKPOINT_STORE: ${{ matrix.checkpoint_store }}
         run: mise run test:e2e:canary
 
   test:

--- a/api/checkpoint/errors.go
+++ b/api/checkpoint/errors.go
@@ -13,3 +13,9 @@ var (
 
 // CheckpointVersionBranchV1 identifies the branch-backed checkpoint metadata format.
 const CheckpointVersionBranchV1 = "branch-v1"
+
+// CheckpointVersionRefsV1 identifies the per-checkpoint-ref checkpoint metadata
+// format (one ref per checkpoint at refs/entire/checkpoints/<shard>/<id>). The
+// value follows the <family>-v<major> convention (cf. branch-v1) so
+// checkpointpolicy.ParseFormat parses it.
+const CheckpointVersionRefsV1 = "refs-v1"

--- a/cmd/entire/cli/attribution.go
+++ b/cmd/entire/cli/attribution.go
@@ -352,7 +352,7 @@ func newAttributionResolver(ctx context.Context, fetchOnMiss bool) (*attribution
 		return nil, fmt.Errorf("not a git repository: %w", err)
 	}
 
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
 	if err != nil {
 		return nil, fmt.Errorf("open checkpoint store: %w", err)
 	}

--- a/cmd/entire/cli/checkpoint/aliases.go
+++ b/cmd/entire/cli/checkpoint/aliases.go
@@ -54,6 +54,9 @@ type (
 // CheckpointVersionBranchV1 identifies the branch-backed checkpoint metadata format.
 const CheckpointVersionBranchV1 = apicheckpoint.CheckpointVersionBranchV1
 
+// CheckpointVersionRefsV1 identifies the per-checkpoint-ref checkpoint metadata format.
+const CheckpointVersionRefsV1 = apicheckpoint.CheckpointVersionRefsV1
+
 // Sentinel errors (re-exported so errors.Is keeps working across packages).
 var (
 	ErrCheckpointNotFound = apicheckpoint.ErrCheckpointNotFound

--- a/cmd/entire/cli/checkpoint/fetching_tree.go
+++ b/cmd/entire/cli/checkpoint/fetching_tree.go
@@ -17,6 +17,12 @@ import (
 // BlobFetchFunc fetches missing blob objects by hash from a remote.
 type BlobFetchFunc func(ctx context.Context, hashes []plumbing.Hash) error
 
+// RefFetchFunc fetches a single checkpoint ref from the remote into the local
+// ref of the same name. The git-refs store uses it to resolve a checkpoint ref
+// that is not present locally (e.g. written on another machine). The checkpoint
+// package cannot resolve the remote target itself, so the CLI layer injects it.
+type RefFetchFunc func(ctx context.Context, ref plumbing.ReferenceName) error
+
 // FetchingTree wraps a git tree to automatically fetch missing blobs on demand.
 // After a treeless fetch (--filter=blob:none), tree objects are available locally
 // but blob objects are not. Each File() call checks whether the target blob

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -88,6 +88,35 @@ func KindOf(s string) Kind {
 	}
 }
 
+// Kind classifies this checkpoint ID.
+func (id CheckpointID) Kind() Kind {
+	return KindOf(string(id))
+}
+
+// ShardFor returns the two-character shard for storing this ID under a
+// per-checkpoint git ref (refs/entire/checkpoints/<shard>/<id>), chosen so
+// checkpoints spread evenly across buckets:
+//
+//   - Legacy hex IDs shard on the FIRST two characters, preserving the existing
+//     entire/checkpoints/v1 tree layout (see Path).
+//   - ULIDs shard on the LAST two characters: a ULID's leading characters encode
+//     its timestamp and barely vary between nearby checkpoints, while the trailing
+//     characters are random, so the suffix spreads evenly while the ID itself
+//     stays lexicographically sortable.
+//
+// For an ID shorter than two characters the whole ID is returned; an unrecognized
+// ID falls back to the first-two (prefix) layout.
+func (id CheckpointID) ShardFor() string {
+	s := string(id)
+	if len(s) < 2 {
+		return s
+	}
+	if id.Kind() == KindULID {
+		return s[len(s)-2:]
+	}
+	return s[:2]
+}
+
 // NewCheckpointID creates a CheckpointID from a string, validating its format.
 // Returns an error unless the string is a valid checkpoint ID (12-char hex or ULID).
 func NewCheckpointID(s string) (CheckpointID, error) {

--- a/cmd/entire/cli/checkpoint/id/id.go
+++ b/cmd/entire/cli/checkpoint/id/id.go
@@ -94,27 +94,26 @@ func (id CheckpointID) Kind() Kind {
 }
 
 // ShardFor returns the two-character shard for storing this ID under a
-// per-checkpoint git ref (refs/entire/checkpoints/<shard>/<id>), chosen so
-// checkpoints spread evenly across buckets:
+// per-checkpoint git ref (refs/entire/checkpoints/<shard>/<id>): the LAST two
+// characters of the ID, for BOTH supported formats.
 //
-//   - Legacy hex IDs shard on the FIRST two characters, preserving the existing
-//     entire/checkpoints/v1 tree layout (see Path).
-//   - ULIDs shard on the LAST two characters: a ULID's leading characters encode
-//     its timestamp and barely vary between nearby checkpoints, while the trailing
-//     characters are random, so the suffix spreads evenly while the ID itself
-//     stays lexicographically sortable.
+// A single positional rule (independent of the ID's Kind) keeps ref naming
+// robust for legacy and ULID IDs alike and impossible to compute inconsistently
+// between callers. The suffix spreads checkpoints evenly across buckets for
+// either format: a legacy hex ID is random throughout, and a ULID's leading
+// characters encode its timestamp (barely varying between nearby checkpoints)
+// while its trailing characters are random — so sharding on the suffix keeps the
+// distribution even while the ID itself stays lexicographically sortable.
 //
-// For an ID shorter than two characters the whole ID is returned; an unrecognized
-// ID falls back to the first-two (prefix) layout.
+// This is the git-refs ref namespace only; the entire/checkpoints/v1 branch tree
+// keeps its own independent first-two layout (see Path). For an ID shorter than
+// two characters the whole ID is returned.
 func (id CheckpointID) ShardFor() string {
 	s := string(id)
 	if len(s) < 2 {
 		return s
 	}
-	if id.Kind() == KindULID {
-		return s[len(s)-2:]
-	}
-	return s[:2]
+	return s[len(s)-2:]
 }
 
 // NewCheckpointID creates a CheckpointID from a string, validating its format.

--- a/cmd/entire/cli/checkpoint/id/id_test.go
+++ b/cmd/entire/cli/checkpoint/id/id_test.go
@@ -145,6 +145,40 @@ func TestKindOf(t *testing.T) {
 			if got := KindOf(tt.input); got != tt.want {
 				t.Errorf("KindOf(%q) = %v, want %v", tt.input, got, tt.want)
 			}
+			if got := CheckpointID(tt.input).Kind(); got != tt.want {
+				t.Errorf("CheckpointID(%q).Kind() = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckpointID_ShardFor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		// Legacy hex shards on the first two chars (preserves the v1 layout).
+		{"legacy", "a1b2c3d4e5f6", "a1"},
+		{"legacy other", "abcdef123456", "ab"},
+		// ULID shards on the LAST two chars.
+		{"ulid", sampleULID, "ZN"},
+		{"ulid trailing", "0123456789ABCDEFGHJKMNPQRS", "RS"},
+		// Unknown falls back to the prefix (first-two) layout.
+		{"unknown", "XYZ", "XY"},
+		// Short-string fallbacks.
+		{"empty", "", ""},
+		{"one char", "a", "a"},
+		{"two chars", "ab", "ab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := CheckpointID(tt.input).ShardFor(); got != tt.want {
+				t.Errorf("CheckpointID(%q).ShardFor() = %q, want %q", tt.input, got, tt.want)
+			}
 		})
 	}
 }

--- a/cmd/entire/cli/checkpoint/id/id_test.go
+++ b/cmd/entire/cli/checkpoint/id/id_test.go
@@ -159,14 +159,12 @@ func TestCheckpointID_ShardFor(t *testing.T) {
 		input string
 		want  string
 	}{
-		// Legacy hex shards on the first two chars (preserves the v1 layout).
-		{"legacy", "a1b2c3d4e5f6", "a1"},
-		{"legacy other", "abcdef123456", "ab"},
-		// ULID shards on the LAST two chars.
+		// Every format shards on the LAST two chars (single positional rule).
+		{"legacy", "a1b2c3d4e5f6", "f6"},
+		{"legacy other", "abcdef123456", "56"},
 		{"ulid", sampleULID, "ZN"},
 		{"ulid trailing", "0123456789ABCDEFGHJKMNPQRS", "RS"},
-		// Unknown falls back to the prefix (first-two) layout.
-		{"unknown", "XYZ", "XY"},
+		{"unknown", "XYZ", "YZ"},
 		// Short-string fallbacks.
 		{"empty", "", ""},
 		{"one char", "a", "a"},

--- a/cmd/entire/cli/checkpoint/open.go
+++ b/cmd/entire/cli/checkpoint/open.go
@@ -19,9 +19,22 @@ type OpenOptions struct {
 	// fetching off.
 	BlobFetcher BlobFetchFunc
 
+	// RefFetcher is the CLI-level on-demand checkpoint-ref fetcher, used by the
+	// git-refs backend to resolve a checkpoint ref missing locally. nil leaves
+	// reads local-only; ignored by the git-branch backend.
+	RefFetcher RefFetchFunc
+
 	// Refs overrides the default committed-ref topology. A non-nil value wins,
 	// e.g. attach pins reads to Primary via PrimaryAsRead().
 	Refs *PersistentRefs
+}
+
+// PrimaryIsRefs reports whether the configured primary backend is the git-refs
+// per-checkpoint store. It centralizes the topology check so push/pre-push code
+// does not compare backend-type strings itself. A nil config (default) is the
+// git-branch backend, so this returns false.
+func PrimaryIsRefs(cfg *settings.CheckpointsConfig) bool {
+	return cfg != nil && cfg.Primary.Type == BackendTypeGitRefs
 }
 
 // Stores is the facade returned by Open: the persistent store plus the git-only
@@ -49,7 +62,7 @@ type Stores struct {
 // default git-branch backend with no mirrors, preserving default behavior.
 func Open(ctx context.Context, repo *git.Repository, opts OpenOptions) (*Stores, error) {
 	refs := resolveOpenRefs(ctx, opts)
-	env := OpenEnv{Repo: repo, BlobFetcher: opts.BlobFetcher, Refs: refs}
+	env := OpenEnv{Repo: repo, BlobFetcher: opts.BlobFetcher, RefFetcher: opts.RefFetcher, Refs: refs}
 
 	cfg, err := settings.LoadCheckpointsConfig(ctx)
 	if err != nil {

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -1299,6 +1299,16 @@ func (s *GitStore) Read(ctx context.Context, checkpointID id.CheckpointID) (*Che
 		return nil, nil //nolint:nilnil,nilerr // Checkpoint directory not found
 	}
 
+	return readSummaryFromCheckpointTree(checkpointTree)
+}
+
+// readSummaryFromCheckpointTree reads the root CheckpointSummary from a checkpoint
+// tree (the tree holding metadata.json plus the numbered session dirs). It is
+// shared by the git-branch store (which descends to <shard>/<id>) and the
+// git-refs store (whose ref tree is the checkpoint tree directly). It returns
+// (nil, nil) when metadata.json is absent so callers normalize a missing
+// checkpoint to ErrCheckpointNotFound via the contract.
+func readSummaryFromCheckpointTree(checkpointTree *FetchingTree) (*CheckpointSummary, error) {
 	// Read root metadata.json as CheckpointSummary (auto-fetches blob if needed)
 	metadataFile, err := checkpointTree.File(paths.MetadataFileName)
 	if err != nil {
@@ -1351,7 +1361,12 @@ func (s *GitStore) ReadSessionMetadata(ctx context.Context, checkpointID id.Chec
 	if err != nil {
 		return nil, err
 	}
+	return readSessionMetadataFromTree(sessionTree, sessionIndex)
+}
 
+// readSessionMetadataFromTree parses metadata.json from a session tree. Shared by
+// both persistent backends, which differ only in how they navigate to the tree.
+func readSessionMetadataFromTree(sessionTree *FetchingTree, sessionIndex int) (*Metadata, error) {
 	metadataFile, err := sessionTree.File(paths.MetadataFileName)
 	if err != nil {
 		return nil, fmt.Errorf("metadata.json not found for session %d: %w", sessionIndex, err)
@@ -1377,18 +1392,13 @@ func (s *GitStore) ReadSessionMetadataAndPrompts(ctx context.Context, checkpoint
 	if err != nil {
 		return nil, "", err
 	}
+	return readSessionMetadataAndPromptsFromTree(sessionTree, sessionIndex)
+}
 
-	metadataFile, err := sessionTree.File(paths.MetadataFileName)
+func readSessionMetadataAndPromptsFromTree(sessionTree *FetchingTree, sessionIndex int) (*Metadata, string, error) {
+	metadata, err := readSessionMetadataFromTree(sessionTree, sessionIndex)
 	if err != nil {
-		return nil, "", fmt.Errorf("metadata.json not found for session %d: %w", sessionIndex, err)
-	}
-	metadataContent, err := metadataFile.Contents()
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to read session metadata: %w", err)
-	}
-	var metadata Metadata
-	if err := json.Unmarshal([]byte(metadataContent), &metadata); err != nil {
-		return nil, "", fmt.Errorf("failed to parse session metadata: %w", err)
+		return nil, "", err
 	}
 
 	var prompts string
@@ -1398,7 +1408,7 @@ func (s *GitStore) ReadSessionMetadataAndPrompts(ctx context.Context, checkpoint
 		}
 	}
 
-	return &metadata, prompts, nil
+	return metadata, prompts, nil
 }
 
 func (s *GitStore) ReadSessionPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (string, error) {
@@ -1406,7 +1416,10 @@ func (s *GitStore) ReadSessionPrompts(ctx context.Context, checkpointID id.Check
 	if err != nil {
 		return "", err
 	}
+	return readSessionPromptsFromTree(sessionTree)
+}
 
+func readSessionPromptsFromTree(sessionTree *FetchingTree) (string, error) {
 	file, err := sessionTree.File(paths.PromptFileName)
 	if err != nil {
 		return "", nil //nolint:nilerr // Missing prompt.txt means no recorded prompts.
@@ -1428,7 +1441,10 @@ func (s *GitStore) ReadSessionContent(ctx context.Context, checkpointID id.Check
 	if err != nil {
 		return nil, err
 	}
+	return readSessionContentFromTree(ctx, sessionTree)
+}
 
+func readSessionContentFromTree(ctx context.Context, sessionTree *FetchingTree) (*SessionContent, error) {
 	result := &SessionContent{}
 
 	// Read session-specific metadata (auto-fetches blob if needed)

--- a/cmd/entire/cli/checkpoint/pushqueue.go
+++ b/cmd/entire/cli/checkpoint/pushqueue.go
@@ -84,13 +84,30 @@ func (q *PushQueue) Enqueue(ref plumbing.ReferenceName) error {
 // Drain returns the de-duplicated refs currently queued, in first-seen order. It
 // does NOT remove them; call Remove after a confirmed push so a failed push
 // retries next time. A missing queue file yields no refs.
+//
+// It compacts the file in place: when the on-disk queue held redundant lines
+// (duplicate enqueues of the same ref, or malformed/blank lines), Drain rewrites
+// it to the de-duplicated set. Enqueue only ever appends, so without this the
+// file would grow unboundedly between the Removes that are otherwise the sole
+// compaction point (e.g. a long-lived session that keeps re-enqueuing the same
+// checkpoint ref but never pushes).
 func (q *PushQueue) Drain() ([]plumbing.ReferenceName, error) {
 	release, err := flock.Acquire(q.lockPath())
 	if err != nil {
 		return nil, fmt.Errorf("lock push queue: %w", err)
 	}
 	defer release()
-	return q.readLocked()
+
+	refs, rawLines, err := q.readLocked()
+	if err != nil {
+		return nil, err
+	}
+	if rawLines > len(refs) {
+		if err := q.rewriteLocked(refs); err != nil {
+			return nil, err
+		}
+	}
+	return refs, nil
 }
 
 // Remove deletes the given refs from the queue, preserving any entries appended
@@ -106,7 +123,7 @@ func (q *PushQueue) Remove(refs []plumbing.ReferenceName) error {
 	}
 	defer release()
 
-	current, err := q.readLocked()
+	current, _, err := q.readLocked()
 	if err != nil {
 		return err
 	}
@@ -114,24 +131,35 @@ func (q *PushQueue) Remove(refs []plumbing.ReferenceName) error {
 	for _, r := range refs {
 		removed[r.String()] = struct{}{}
 	}
-	var buf bytes.Buffer
+	kept := make([]plumbing.ReferenceName, 0, len(current))
 	for _, r := range current {
 		if _, drop := removed[r.String()]; drop {
 			continue
 		}
+		kept = append(kept, r)
+	}
+	return q.rewriteLocked(kept)
+}
+
+// rewriteLocked replaces the queue file with exactly refs (de-duplicated, one
+// line each), or removes the file when refs is empty so a clean repo has no
+// stray queue. The caller must hold the lock. The write is atomic (temp file +
+// rename) so a concurrent reader never sees a half-written queue.
+func (q *PushQueue) rewriteLocked(refs []plumbing.ReferenceName) error {
+	if len(refs) == 0 {
+		if err := os.Remove(q.queuePath()); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove empty push queue: %w", err)
+		}
+		return nil
+	}
+	var buf bytes.Buffer
+	for _, r := range refs {
 		line, err := json.Marshal(pushQueueEntry{Ref: r.String()})
 		if err != nil {
 			return fmt.Errorf("encode push queue entry: %w", err)
 		}
 		buf.Write(line)
 		buf.WriteByte('\n')
-	}
-	if buf.Len() == 0 {
-		// Nothing left: drop the file so a clean repo has no stray queue.
-		if err := os.Remove(q.queuePath()); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove empty push queue: %w", err)
-		}
-		return nil
 	}
 	if err := writeFileAtomicInDir(q.dir, q.queuePath(), buf.Bytes()); err != nil {
 		return fmt.Errorf("rewrite push queue: %w", err)
@@ -142,17 +170,21 @@ func (q *PushQueue) Remove(refs []plumbing.ReferenceName) error {
 // readLocked parses the queue file into de-duplicated refs, preserving first-seen
 // order. The caller must hold the lock. Malformed lines are skipped rather than
 // failing the whole drain — a single bad record must not strand every queued ref.
-func (q *PushQueue) readLocked() ([]plumbing.ReferenceName, error) {
+//
+// rawLines is the number of non-empty lines seen (including duplicates and
+// malformed records), so callers can detect when the file holds more than the
+// de-duplicated set and is worth compacting: rawLines > len(refs) exactly when
+// there were redundant lines.
+func (q *PushQueue) readLocked() (refs []plumbing.ReferenceName, rawLines int, err error) {
 	f, err := os.Open(q.queuePath())
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, 0, nil
 		}
-		return nil, fmt.Errorf("open push queue: %w", err)
+		return nil, 0, fmt.Errorf("open push queue: %w", err)
 	}
 	defer f.Close()
 
-	var refs []plumbing.ReferenceName
 	seen := make(map[string]struct{})
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -161,6 +193,7 @@ func (q *PushQueue) readLocked() ([]plumbing.ReferenceName, error) {
 		if len(line) == 0 {
 			continue
 		}
+		rawLines++
 		var entry pushQueueEntry
 		if err := json.Unmarshal(line, &entry); err != nil || entry.Ref == "" {
 			continue
@@ -172,9 +205,9 @@ func (q *PushQueue) readLocked() ([]plumbing.ReferenceName, error) {
 		refs = append(refs, plumbing.ReferenceName(entry.Ref))
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read push queue: %w", err)
+		return nil, 0, fmt.Errorf("read push queue: %w", err)
 	}
-	return refs, nil
+	return refs, rawLines, nil
 }
 
 // writeFileAtomicInDir writes data to a temp file in dir and renames it over

--- a/cmd/entire/cli/checkpoint/pushqueue.go
+++ b/cmd/entire/cli/checkpoint/pushqueue.go
@@ -1,0 +1,200 @@
+package checkpoint
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/entireio/cli/cmd/entire/cli/internal/flock"
+)
+
+// Push-discovery queue file names, kept in the git common dir so every worktree
+// sharing the object store enqueues into one queue. The git-refs backend cannot
+// push every local checkpoint ref at pre-push time (reads fetch refs too, and
+// deleting them after push would hurt local workflows), so each write records
+// the ref it touched here and pre-push drains + batch-pushes exactly those.
+const (
+	pushQueueFileName = "entire-checkpoint-push-queue.jsonl"
+	pushQueueLockName = "entire-checkpoint-push-queue.lock"
+)
+
+// pushQueueEntry is one JSONL record: a checkpoint ref awaiting push.
+type pushQueueEntry struct {
+	Ref string `json:"ref"`
+}
+
+// PushQueue is a flock-protected JSONL list of checkpoint refs awaiting push,
+// stored in the git common dir. Entries are removed only after a confirmed push
+// (Remove), so an interrupted or failed push leaves them for the next pre-push.
+// Duplicates are tolerated on disk and collapsed by Drain.
+type PushQueue struct {
+	dir string
+}
+
+// NewPushQueue returns the push queue rooted at gitCommonDir.
+func NewPushQueue(gitCommonDir string) *PushQueue {
+	return &PushQueue{dir: gitCommonDir}
+}
+
+// PushQueueForRepo resolves the git common dir for repo and returns its queue.
+func PushQueueForRepo(ctx context.Context, repo *git.Repository) (*PushQueue, error) {
+	dir, err := resolveGitCommonDir(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	return NewPushQueue(dir), nil
+}
+
+func (q *PushQueue) queuePath() string { return filepath.Join(q.dir, pushQueueFileName) }
+func (q *PushQueue) lockPath() string  { return filepath.Join(q.dir, pushQueueLockName) }
+
+// Enqueue appends a ref to the queue. It is safe to enqueue a ref already
+// present (or already pushed): Drain collapses duplicates and the batch push is
+// idempotent. Enqueue takes the lock so concurrent writers never interleave a
+// partial line.
+func (q *PushQueue) Enqueue(ref plumbing.ReferenceName) error {
+	release, err := flock.Acquire(q.lockPath())
+	if err != nil {
+		return fmt.Errorf("lock push queue: %w", err)
+	}
+	defer release()
+
+	line, err := json.Marshal(pushQueueEntry{Ref: ref.String()})
+	if err != nil {
+		return fmt.Errorf("encode push queue entry: %w", err)
+	}
+	f, err := os.OpenFile(q.queuePath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("open push queue: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("append push queue entry: %w", err)
+	}
+	return nil
+}
+
+// Drain returns the de-duplicated refs currently queued, in first-seen order. It
+// does NOT remove them; call Remove after a confirmed push so a failed push
+// retries next time. A missing queue file yields no refs.
+func (q *PushQueue) Drain() ([]plumbing.ReferenceName, error) {
+	release, err := flock.Acquire(q.lockPath())
+	if err != nil {
+		return nil, fmt.Errorf("lock push queue: %w", err)
+	}
+	defer release()
+	return q.readLocked()
+}
+
+// Remove deletes the given refs from the queue, preserving any entries appended
+// after a Drain (e.g. a write that landed during the push). Called after a
+// confirmed push.
+func (q *PushQueue) Remove(refs []plumbing.ReferenceName) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	release, err := flock.Acquire(q.lockPath())
+	if err != nil {
+		return fmt.Errorf("lock push queue: %w", err)
+	}
+	defer release()
+
+	current, err := q.readLocked()
+	if err != nil {
+		return err
+	}
+	removed := make(map[string]struct{}, len(refs))
+	for _, r := range refs {
+		removed[r.String()] = struct{}{}
+	}
+	var buf bytes.Buffer
+	for _, r := range current {
+		if _, drop := removed[r.String()]; drop {
+			continue
+		}
+		line, err := json.Marshal(pushQueueEntry{Ref: r.String()})
+		if err != nil {
+			return fmt.Errorf("encode push queue entry: %w", err)
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	if buf.Len() == 0 {
+		// Nothing left: drop the file so a clean repo has no stray queue.
+		if err := os.Remove(q.queuePath()); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove empty push queue: %w", err)
+		}
+		return nil
+	}
+	if err := writeFileAtomicInDir(q.dir, q.queuePath(), buf.Bytes()); err != nil {
+		return fmt.Errorf("rewrite push queue: %w", err)
+	}
+	return nil
+}
+
+// readLocked parses the queue file into de-duplicated refs, preserving first-seen
+// order. The caller must hold the lock. Malformed lines are skipped rather than
+// failing the whole drain — a single bad record must not strand every queued ref.
+func (q *PushQueue) readLocked() ([]plumbing.ReferenceName, error) {
+	f, err := os.Open(q.queuePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open push queue: %w", err)
+	}
+	defer f.Close()
+
+	var refs []plumbing.ReferenceName
+	seen := make(map[string]struct{})
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var entry pushQueueEntry
+		if err := json.Unmarshal(line, &entry); err != nil || entry.Ref == "" {
+			continue
+		}
+		if _, dup := seen[entry.Ref]; dup {
+			continue
+		}
+		seen[entry.Ref] = struct{}{}
+		refs = append(refs, plumbing.ReferenceName(entry.Ref))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read push queue: %w", err)
+	}
+	return refs, nil
+}
+
+// writeFileAtomicInDir writes data to a temp file in dir and renames it over
+// path, so a reader (under the lock) never sees a half-written queue.
+func writeFileAtomicInDir(dir, path string, data []byte) error {
+	tmp, err := os.CreateTemp(dir, pushQueueFileName+".*")
+	if err != nil {
+		return fmt.Errorf("create temp push queue: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp push queue: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp push queue: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp push queue: %w", err)
+	}
+	return nil
+}

--- a/cmd/entire/cli/checkpoint/pushqueue_test.go
+++ b/cmd/entire/cli/checkpoint/pushqueue_test.go
@@ -1,0 +1,109 @@
+package checkpoint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushQueue_EnqueueDrainRemove(t *testing.T) {
+	t.Parallel()
+	q := NewPushQueue(t.TempDir())
+
+	a := RefName("a1b2c3d4e5f6")
+	b := RefName("b2c3d4e5f6a1")
+
+	// Empty queue drains to nothing.
+	refs, err := q.Drain()
+	require.NoError(t, err)
+	assert.Empty(t, refs)
+
+	require.NoError(t, q.Enqueue(a))
+	require.NoError(t, q.Enqueue(b))
+
+	refs, err = q.Drain()
+	require.NoError(t, err)
+	assert.Equal(t, []plumbing.ReferenceName{a, b}, refs, "drain preserves first-seen order")
+
+	// Drain does not clear: refs survive until Remove.
+	refs, err = q.Drain()
+	require.NoError(t, err)
+	assert.Equal(t, []plumbing.ReferenceName{a, b}, refs)
+
+	require.NoError(t, q.Remove([]plumbing.ReferenceName{a}))
+	refs, err = q.Drain()
+	require.NoError(t, err)
+	assert.Equal(t, []plumbing.ReferenceName{b}, refs)
+
+	// Removing the last ref deletes the file entirely.
+	require.NoError(t, q.Remove([]plumbing.ReferenceName{b}))
+	refs, err = q.Drain()
+	require.NoError(t, err)
+	assert.Empty(t, refs)
+	_, statErr := os.Stat(filepath.Join(q.dir, pushQueueFileName))
+	assert.True(t, os.IsNotExist(statErr), "empty queue file should be removed")
+}
+
+func TestPushQueue_DrainDedupes(t *testing.T) {
+	t.Parallel()
+	q := NewPushQueue(t.TempDir())
+	a := RefName("a1b2c3d4e5f6")
+
+	require.NoError(t, q.Enqueue(a))
+	require.NoError(t, q.Enqueue(a))
+	require.NoError(t, q.Enqueue(a))
+
+	refs, err := q.Drain()
+	require.NoError(t, err)
+	assert.Equal(t, []plumbing.ReferenceName{a}, refs, "duplicates collapse to one")
+}
+
+func TestPushQueue_RemovePreservesLaterEntries(t *testing.T) {
+	t.Parallel()
+	q := NewPushQueue(t.TempDir())
+	a := RefName("a1b2c3d4e5f6")
+	b := RefName("b2c3d4e5f6a1")
+
+	// Simulate: drain sees [a], then b is enqueued during the push, then we
+	// Remove(a). b must survive for the next pre-push.
+	require.NoError(t, q.Enqueue(a))
+	drained, err := q.Drain()
+	require.NoError(t, err)
+	require.Equal(t, []plumbing.ReferenceName{a}, drained)
+
+	require.NoError(t, q.Enqueue(b))
+	require.NoError(t, q.Remove(drained))
+
+	refs, err := q.Drain()
+	require.NoError(t, err)
+	assert.Equal(t, []plumbing.ReferenceName{b}, refs)
+}
+
+func TestPushQueue_SkipsMalformedLines(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	q := NewPushQueue(dir)
+	a := RefName("a1b2c3d4e5f6")
+	require.NoError(t, q.Enqueue(a))
+
+	// Append a garbage line + a blank line directly.
+	f, err := os.OpenFile(q.queuePath(), os.O_WRONLY|os.O_APPEND, 0o600)
+	require.NoError(t, err)
+	_, err = f.WriteString("not json\n\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	refs, err := q.Drain()
+	require.NoError(t, err)
+	assert.Equal(t, []plumbing.ReferenceName{a}, refs, "malformed lines are skipped, valid refs survive")
+}
+
+func TestPushQueue_RemoveEmptyIsNoop(t *testing.T) {
+	t.Parallel()
+	q := NewPushQueue(t.TempDir())
+	require.NoError(t, q.Remove(nil))
+}

--- a/cmd/entire/cli/checkpoint/pushqueue_test.go
+++ b/cmd/entire/cli/checkpoint/pushqueue_test.go
@@ -14,8 +14,8 @@ func TestPushQueue_EnqueueDrainRemove(t *testing.T) {
 	t.Parallel()
 	q := NewPushQueue(t.TempDir())
 
-	a := RefName("a1b2c3d4e5f6")
-	b := RefName("b2c3d4e5f6a1")
+	a := mustRefName(t, "a1b2c3d4e5f6")
+	b := mustRefName(t, "b2c3d4e5f6a1")
 
 	// Empty queue drains to nothing.
 	refs, err := q.Drain()
@@ -51,7 +51,7 @@ func TestPushQueue_EnqueueDrainRemove(t *testing.T) {
 func TestPushQueue_DrainDedupes(t *testing.T) {
 	t.Parallel()
 	q := NewPushQueue(t.TempDir())
-	a := RefName("a1b2c3d4e5f6")
+	a := mustRefName(t, "a1b2c3d4e5f6")
 
 	require.NoError(t, q.Enqueue(a))
 	require.NoError(t, q.Enqueue(a))
@@ -65,8 +65,8 @@ func TestPushQueue_DrainDedupes(t *testing.T) {
 func TestPushQueue_RemovePreservesLaterEntries(t *testing.T) {
 	t.Parallel()
 	q := NewPushQueue(t.TempDir())
-	a := RefName("a1b2c3d4e5f6")
-	b := RefName("b2c3d4e5f6a1")
+	a := mustRefName(t, "a1b2c3d4e5f6")
+	b := mustRefName(t, "b2c3d4e5f6a1")
 
 	// Simulate: drain sees [a], then b is enqueued during the push, then we
 	// Remove(a). b must survive for the next pre-push.
@@ -87,7 +87,7 @@ func TestPushQueue_SkipsMalformedLines(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	q := NewPushQueue(dir)
-	a := RefName("a1b2c3d4e5f6")
+	a := mustRefName(t, "a1b2c3d4e5f6")
 	require.NoError(t, q.Enqueue(a))
 
 	// Append a garbage line + a blank line directly.

--- a/cmd/entire/cli/checkpoint/pushqueue_test.go
+++ b/cmd/entire/cli/checkpoint/pushqueue_test.go
@@ -3,6 +3,7 @@ package checkpoint
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -60,6 +61,65 @@ func TestPushQueue_DrainDedupes(t *testing.T) {
 	refs, err := q.Drain()
 	require.NoError(t, err)
 	assert.Equal(t, []plumbing.ReferenceName{a}, refs, "duplicates collapse to one")
+}
+
+// nonEmptyLineCount returns how many non-blank lines the queue file holds.
+func nonEmptyLineCount(t *testing.T, q *PushQueue) int {
+	t.Helper()
+	data, err := os.ReadFile(q.queuePath())
+	if os.IsNotExist(err) {
+		return 0
+	}
+	require.NoError(t, err)
+	count := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func TestPushQueue_DrainCompactsRedundantEntries(t *testing.T) {
+	t.Parallel()
+	q := NewPushQueue(t.TempDir())
+	a := mustRefName(t, "a1b2c3d4e5f6")
+	b := mustRefName(t, "b2c3d4e5f6a1")
+
+	require.NoError(t, q.Enqueue(a))
+	require.NoError(t, q.Enqueue(a))
+	require.NoError(t, q.Enqueue(b))
+	require.NoError(t, q.Enqueue(a))
+	require.Equal(t, 4, nonEmptyLineCount(t, q), "enqueue only appends")
+
+	refs, err := q.Drain()
+	require.NoError(t, err)
+	assert.Equal(t, []plumbing.ReferenceName{a, b}, refs)
+	assert.Equal(t, 2, nonEmptyLineCount(t, q), "Drain compacts the file to the de-duplicated set")
+
+	// The refs still survive until Remove, and a re-drain does not rewrite again.
+	refs, err = q.Drain()
+	require.NoError(t, err)
+	assert.Equal(t, []plumbing.ReferenceName{a, b}, refs, "compaction preserves queued refs")
+	assert.Equal(t, 2, nonEmptyLineCount(t, q))
+}
+
+func TestPushQueue_DrainCompactsMalformedLines(t *testing.T) {
+	t.Parallel()
+	q := NewPushQueue(t.TempDir())
+	a := mustRefName(t, "a1b2c3d4e5f6")
+	require.NoError(t, q.Enqueue(a))
+
+	f, err := os.OpenFile(q.queuePath(), os.O_WRONLY|os.O_APPEND, 0o600)
+	require.NoError(t, err)
+	_, err = f.WriteString("not json\n\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	refs, err := q.Drain()
+	require.NoError(t, err)
+	assert.Equal(t, []plumbing.ReferenceName{a}, refs)
+	assert.Equal(t, 1, nonEmptyLineCount(t, q), "Drain drops malformed lines from disk")
 }
 
 func TestPushQueue_RemovePreservesLaterEntries(t *testing.T) {

--- a/cmd/entire/cli/checkpoint/refs_naming.go
+++ b/cmd/entire/cli/checkpoint/refs_naming.go
@@ -1,0 +1,51 @@
+package checkpoint
+
+import (
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+)
+
+// CheckpointRefPrefix is the namespace under which the git-refs backend stores
+// one ref per checkpoint: refs/entire/checkpoints/<shard>/<id>. Each ref points
+// at a checkpoint commit whose tree root is that checkpoint's contents. This is
+// distinct from the git-branch backend's single entire/checkpoints/v1 branch.
+const CheckpointRefPrefix = "refs/entire/checkpoints/"
+
+// RefName returns the per-checkpoint git ref for a checkpoint ID:
+// refs/entire/checkpoints/<shard>/<id>, where <shard> is id.ShardFor() (the
+// first two chars for legacy hex IDs, the last two for ULIDs). The full ID is
+// always the leaf, so the ref round-trips through ParseRef.
+func RefName(cid id.CheckpointID) plumbing.ReferenceName {
+	return plumbing.ReferenceName(CheckpointRefPrefix + cid.ShardFor() + "/" + cid.String())
+}
+
+// ParseRef extracts the checkpoint ID from a per-checkpoint ref name,
+// reporting whether name is a well-formed checkpoint ref. A ref is well-formed
+// when it has the CheckpointRefPrefix, exactly a <shard>/<id> tail, and the
+// shard matches the ID's own ShardFor — so refs the resolver did not write
+// (mismatched shard, extra path segments) are rejected rather than silently
+// resolved to the wrong bucket. It does not require the ID to be a recognized
+// kind, so a future ID format still parses as long as it shards consistently.
+func ParseRef(name plumbing.ReferenceName) (id.CheckpointID, bool) {
+	s := name.String()
+	tail, ok := strings.CutPrefix(s, CheckpointRefPrefix)
+	if !ok {
+		return id.EmptyCheckpointID, false
+	}
+	shard, rest, ok := strings.Cut(tail, "/")
+	if !ok || shard == "" || rest == "" {
+		return id.EmptyCheckpointID, false
+	}
+	// Reject extra path segments: the tail must be exactly <shard>/<id>.
+	if strings.Contains(rest, "/") {
+		return id.EmptyCheckpointID, false
+	}
+	cid := id.CheckpointID(rest)
+	if cid.ShardFor() != shard {
+		return id.EmptyCheckpointID, false
+	}
+	return cid, true
+}

--- a/cmd/entire/cli/checkpoint/refs_naming.go
+++ b/cmd/entire/cli/checkpoint/refs_naming.go
@@ -1,6 +1,7 @@
 package checkpoint
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -18,8 +19,16 @@ const CheckpointRefPrefix = "refs/entire/checkpoints/"
 // refs/entire/checkpoints/<shard>/<id>, where <shard> is id.ShardFor() (the
 // first two chars for legacy hex IDs, the last two for ULIDs). The full ID is
 // always the leaf, so the ref round-trips through ParseRef.
-func RefName(cid id.CheckpointID) plumbing.ReferenceName {
-	return plumbing.ReferenceName(CheckpointRefPrefix + cid.ShardFor() + "/" + cid.String())
+//
+// It errors on an empty or unrecognized checkpoint ID rather than returning a
+// malformed ref (e.g. "refs/entire/checkpoints//"), so callers at trust
+// boundaries — and future ones — can't silently push, fetch, or look up a bad
+// ref.
+func RefName(cid id.CheckpointID) (plumbing.ReferenceName, error) {
+	if cid.Kind() == id.KindUnknown {
+		return "", fmt.Errorf("cannot build checkpoint ref: invalid checkpoint ID %q", cid)
+	}
+	return plumbing.ReferenceName(CheckpointRefPrefix + cid.ShardFor() + "/" + cid.String()), nil
 }
 
 // ParseRef extracts the checkpoint ID from a per-checkpoint ref name,

--- a/cmd/entire/cli/checkpoint/refs_naming_test.go
+++ b/cmd/entire/cli/checkpoint/refs_naming_test.go
@@ -1,0 +1,107 @@
+package checkpoint
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+)
+
+func TestRefName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cid  id.CheckpointID
+		want plumbing.ReferenceName
+	}{
+		{
+			name: "legacy hex shards on first two",
+			cid:  "a1b2c3d4e5f6",
+			want: "refs/entire/checkpoints/a1/a1b2c3d4e5f6",
+		},
+		{
+			name: "ulid shards on last two",
+			cid:  "01KVBJCWYA4YW6J5M9GP655HZN",
+			want: "refs/entire/checkpoints/ZN/01KVBJCWYA4YW6J5M9GP655HZN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, RefName(tt.cid))
+		})
+	}
+}
+
+func TestParseRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		ref    plumbing.ReferenceName
+		wantID id.CheckpointID
+		wantOK bool
+	}{
+		{
+			name:   "legacy round-trip",
+			ref:    "refs/entire/checkpoints/a1/a1b2c3d4e5f6",
+			wantID: "a1b2c3d4e5f6",
+			wantOK: true,
+		},
+		{
+			name:   "ulid round-trip",
+			ref:    "refs/entire/checkpoints/ZN/01KVBJCWYA4YW6J5M9GP655HZN",
+			wantID: "01KVBJCWYA4YW6J5M9GP655HZN",
+			wantOK: true,
+		},
+		{
+			name:   "wrong prefix",
+			ref:    "refs/heads/entire/checkpoints/v1",
+			wantOK: false,
+		},
+		{
+			name:   "shard does not match id (legacy in last-two bucket)",
+			ref:    "refs/entire/checkpoints/f6/a1b2c3d4e5f6",
+			wantOK: false,
+		},
+		{
+			name:   "extra path segment",
+			ref:    "refs/entire/checkpoints/a1/a1b2c3d4e5f6/0",
+			wantOK: false,
+		},
+		{
+			name:   "missing id",
+			ref:    "refs/entire/checkpoints/a1/",
+			wantOK: false,
+		},
+		{
+			name:   "missing shard separator",
+			ref:    "refs/entire/checkpoints/a1b2c3d4e5f6",
+			wantOK: false,
+		},
+		{
+			name:   "prefix only",
+			ref:    "refs/entire/checkpoints/",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotID, gotOK := ParseRef(tt.ref)
+			assert.Equal(t, tt.wantOK, gotOK)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantID, gotID)
+				// Round-trip: building the ref from the parsed ID reproduces it.
+				assert.Equal(t, tt.ref, RefName(gotID))
+			} else {
+				assert.Equal(t, id.EmptyCheckpointID, gotID)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/checkpoint/refs_naming_test.go
+++ b/cmd/entire/cli/checkpoint/refs_naming_test.go
@@ -5,9 +5,18 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 )
+
+// mustRefName is a test helper for the common case of a known-valid checkpoint ID.
+func mustRefName(t *testing.T, cid id.CheckpointID) plumbing.ReferenceName {
+	t.Helper()
+	ref, err := RefName(cid)
+	require.NoError(t, err)
+	return ref
+}
 
 func TestRefName(t *testing.T) {
 	t.Parallel()
@@ -32,8 +41,18 @@ func TestRefName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.want, RefName(tt.cid))
+			got, err := RefName(tt.cid)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func TestRefName_RejectsInvalidID(t *testing.T) {
+	t.Parallel()
+	for _, cid := range []id.CheckpointID{"", "not-an-id", "A1B2C3D4E5F6"} {
+		_, err := RefName(cid)
+		assert.Error(t, err, "RefName(%q) should error rather than build a malformed ref", cid)
 	}
 }
 
@@ -98,7 +117,7 @@ func TestParseRef(t *testing.T) {
 			if tt.wantOK {
 				assert.Equal(t, tt.wantID, gotID)
 				// Round-trip: building the ref from the parsed ID reproduces it.
-				assert.Equal(t, tt.ref, RefName(gotID))
+				assert.Equal(t, tt.ref, mustRefName(t, gotID))
 			} else {
 				assert.Equal(t, id.EmptyCheckpointID, gotID)
 			}

--- a/cmd/entire/cli/checkpoint/refs_naming_test.go
+++ b/cmd/entire/cli/checkpoint/refs_naming_test.go
@@ -27,9 +27,9 @@ func TestRefName(t *testing.T) {
 		want plumbing.ReferenceName
 	}{
 		{
-			name: "legacy hex shards on first two",
+			name: "legacy hex shards on last two",
 			cid:  "a1b2c3d4e5f6",
-			want: "refs/entire/checkpoints/a1/a1b2c3d4e5f6",
+			want: "refs/entire/checkpoints/f6/a1b2c3d4e5f6",
 		},
 		{
 			name: "ulid shards on last two",
@@ -67,7 +67,7 @@ func TestParseRef(t *testing.T) {
 	}{
 		{
 			name:   "legacy round-trip",
-			ref:    "refs/entire/checkpoints/a1/a1b2c3d4e5f6",
+			ref:    "refs/entire/checkpoints/f6/a1b2c3d4e5f6",
 			wantID: "a1b2c3d4e5f6",
 			wantOK: true,
 		},
@@ -83,13 +83,13 @@ func TestParseRef(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "shard does not match id (legacy in last-two bucket)",
-			ref:    "refs/entire/checkpoints/f6/a1b2c3d4e5f6",
+			name:   "shard does not match id (wrong bucket)",
+			ref:    "refs/entire/checkpoints/a1/a1b2c3d4e5f6",
 			wantOK: false,
 		},
 		{
 			name:   "extra path segment",
-			ref:    "refs/entire/checkpoints/a1/a1b2c3d4e5f6/0",
+			ref:    "refs/entire/checkpoints/f6/a1b2c3d4e5f6/0",
 			wantOK: false,
 		},
 		{

--- a/cmd/entire/cli/checkpoint/refs_store.go
+++ b/cmd/entire/cli/checkpoint/refs_store.go
@@ -74,7 +74,11 @@ func (s *gitRefsStore) Write(ctx context.Context, req WriteRequest) error {
 // next write) and subtree object (the checkpoint's current contents). A missing
 // ref yields (ZeroHash, nil) so the next write becomes an orphan commit.
 func (s *gitRefsStore) refBase(cid id.CheckpointID) (plumbing.Hash, *object.Tree, error) {
-	ref, err := s.repo.Reference(RefName(cid), true)
+	refName, err := RefName(cid)
+	if err != nil {
+		return plumbing.ZeroHash, nil, err
+	}
+	ref, err := s.repo.Reference(refName, true)
 	if err != nil {
 		return plumbing.ZeroHash, nil, nil //nolint:nilerr // no ref yet → new checkpoint
 	}
@@ -94,7 +98,10 @@ func (s *gitRefsStore) refBase(cid id.CheckpointID) (plumbing.Hash, *object.Tree
 // not fail condensation. The ref is still local; only its remote sync is missed
 // until a later write to the same checkpoint re-enqueues it.
 func (s *gitRefsStore) setRef(ctx context.Context, cid id.CheckpointID, hash plumbing.Hash) error {
-	refName := RefName(cid)
+	refName, err := RefName(cid)
+	if err != nil {
+		return err
+	}
 	if err := s.repo.Storer.SetReference(plumbing.NewHashReference(refName, hash)); err != nil {
 		return fmt.Errorf("set checkpoint ref %s to %s: %w", refName, hash, err)
 	}
@@ -251,7 +258,10 @@ func (s *gitRefsStore) checkpointTree(ctx context.Context, cid id.CheckpointID) 
 // checkpoint may have been written on another machine). A failed fetch returns
 // the original not-found error so the read resolves to ErrCheckpointNotFound.
 func (s *gitRefsStore) resolveRefMaybeFetch(ctx context.Context, cid id.CheckpointID) (*plumbing.Reference, error) {
-	refName := RefName(cid)
+	refName, err := RefName(cid)
+	if err != nil {
+		return nil, err
+	}
 	ref, err := s.repo.Reference(refName, true)
 	if err == nil {
 		return ref, nil
@@ -369,7 +379,11 @@ func (s *gitRefsStore) GetCheckpointAuthor(ctx context.Context, checkpointID id.
 	if err := ctx.Err(); err != nil {
 		return Author{}, err //nolint:wrapcheck // Propagating context cancellation
 	}
-	ref, err := s.repo.Reference(RefName(checkpointID), true)
+	refName, err := RefName(checkpointID)
+	if err != nil {
+		return Author{}, nil //nolint:nilerr // invalid ID → unknown author
+	}
+	ref, err := s.repo.Reference(refName, true)
 	if err != nil {
 		return Author{}, nil //nolint:nilerr // no ref → unknown author
 	}

--- a/cmd/entire/cli/checkpoint/refs_store.go
+++ b/cmd/entire/cli/checkpoint/refs_store.go
@@ -1,0 +1,381 @@
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/cmd/entire/cli/validation"
+)
+
+var (
+	_ PersistentStore = (*gitRefsStore)(nil)
+	_ AuthorReader    = (*gitRefsStore)(nil)
+	_ Writer          = (*gitRefsStore)(nil)
+)
+
+// gitRefsStore is the git-backed persistent checkpoint store that keeps one ref
+// per checkpoint at refs/entire/checkpoints/<shard>/<id>. Each ref points at a
+// commit whose tree root IS that checkpoint's contents (metadata.json, 0/, 1/,
+// tasks/…), so updates advance the ref and preserve per-checkpoint history. It
+// shares the checkpoint-subtree machinery with the git-branch store via the
+// embedded *treeWriter (anchored at basePath ""), differing only in where the
+// subtree is committed: a per-checkpoint ref instead of the v1 branch.
+type gitRefsStore struct {
+	*treeWriter
+
+	blobFetcher BlobFetchFunc
+	refFetcher  RefFetchFunc
+}
+
+// newGitRefsStore constructs the per-checkpoint-ref store for a repository.
+func newGitRefsStore(repo *git.Repository) *gitRefsStore {
+	return &gitRefsStore{treeWriter: &treeWriter{repo: repo}}
+}
+
+// SetBlobFetcher configures on-demand blob fetching for reads from ref trees.
+func (s *gitRefsStore) SetBlobFetcher(f BlobFetchFunc) {
+	s.blobFetcher = f
+}
+
+// SetRefFetcher configures on-demand fetching of a missing checkpoint ref (e.g.
+// a checkpoint written on another machine). nil leaves reads local-only.
+func (s *gitRefsStore) SetRefFetcher(f RefFetchFunc) {
+	s.refFetcher = f
+}
+
+// Write dispatches a persistent write request to the matching ref operation,
+// mirroring the git-branch store's Write.
+func (s *gitRefsStore) Write(ctx context.Context, req WriteRequest) error {
+	switch r := req.(type) {
+	case Session:
+		return s.writeSession(ctx, WriteOptions(r))
+	case SessionTranscript:
+		return s.backfillTranscript(ctx, UpdateOptions(r))
+	case SessionSummary:
+		return s.backfillSummary(ctx, r.CheckpointID, r.Summary)
+	case CheckpointAttribution:
+		return s.backfillAttribution(ctx, r.CheckpointID, r.Attribution)
+	default:
+		return fmt.Errorf("checkpoint: unsupported write request %T", req)
+	}
+}
+
+// refBase resolves a checkpoint ref's current tip commit (the parent for the
+// next write) and subtree object (the checkpoint's current contents). A missing
+// ref yields (ZeroHash, nil) so the next write becomes an orphan commit.
+func (s *gitRefsStore) refBase(cid id.CheckpointID) (plumbing.Hash, *object.Tree, error) {
+	ref, err := s.repo.Reference(RefName(cid), true)
+	if err != nil {
+		return plumbing.ZeroHash, nil, nil //nolint:nilerr // no ref yet → new checkpoint
+	}
+	commit, err := s.repo.CommitObject(ref.Hash())
+	if err != nil {
+		return plumbing.ZeroHash, nil, fmt.Errorf("read checkpoint commit %s: %w", ref.Hash(), err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return plumbing.ZeroHash, nil, fmt.Errorf("read checkpoint tree for %s: %w", cid, err)
+	}
+	return ref.Hash(), tree, nil
+}
+
+// setRef points a checkpoint's ref at a new commit and records it for push.
+// Enqueue is best-effort: a write that lands locally but fails to enqueue must
+// not fail condensation. The ref is still local; only its remote sync is missed
+// until a later write to the same checkpoint re-enqueues it.
+func (s *gitRefsStore) setRef(ctx context.Context, cid id.CheckpointID, hash plumbing.Hash) error {
+	refName := RefName(cid)
+	if err := s.repo.Storer.SetReference(plumbing.NewHashReference(refName, hash)); err != nil {
+		return fmt.Errorf("set checkpoint ref %s to %s: %w", refName, hash, err)
+	}
+	s.enqueueForPush(ctx, refName)
+	return nil
+}
+
+// enqueueForPush records refName in the push-discovery queue, logging (never
+// returning) on failure so the local ref write still succeeds.
+func (s *gitRefsStore) enqueueForPush(ctx context.Context, refName plumbing.ReferenceName) {
+	q, err := PushQueueForRepo(ctx, s.repo)
+	if err != nil {
+		logging.Warn(ctx, "checkpoint: resolve push queue failed; ref not enqueued",
+			slog.String("ref", refName.String()), slog.String("error", err.Error()))
+		return
+	}
+	if err := q.Enqueue(refName); err != nil {
+		logging.Warn(ctx, "checkpoint: enqueue checkpoint ref for push failed",
+			slog.String("ref", refName.String()), slog.String("error", err.Error()))
+	}
+}
+
+func (s *gitRefsStore) writeSession(ctx context.Context, opts WriteOptions) error {
+	if opts.CheckpointID.IsEmpty() {
+		return errors.New("invalid checkpoint options: checkpoint ID is required")
+	}
+	if err := validation.ValidateSessionID(opts.SessionID); err != nil {
+		return fmt.Errorf("invalid checkpoint options: %w", err)
+	}
+	if err := validation.ValidateToolUseID(opts.ToolUseID); err != nil {
+		return fmt.Errorf("invalid checkpoint options: %w", err)
+	}
+	if err := validation.ValidateAgentID(opts.AgentID); err != nil {
+		return fmt.Errorf("invalid checkpoint options: %w", err)
+	}
+
+	parentHash, existing, err := s.refBase(opts.CheckpointID)
+	if err != nil {
+		return err
+	}
+
+	checkpointSubtree, taskMetadataPath, err := s.applySessionWrite(ctx, opts, existing, "", CheckpointVersionRefsV1)
+	if err != nil {
+		return err
+	}
+
+	commitMsg := s.buildCommitMessage(opts, taskMetadataPath)
+	commitHash, err := CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, opts.AuthorName, opts.AuthorEmail)
+	if err != nil {
+		return err
+	}
+	return s.setRef(ctx, opts.CheckpointID, commitHash)
+}
+
+func (s *gitRefsStore) backfillTranscript(ctx context.Context, opts UpdateOptions) error {
+	if opts.CheckpointID.IsEmpty() {
+		return errors.New("invalid update options: checkpoint ID is required")
+	}
+
+	parentHash, existing, err := s.refBase(opts.CheckpointID)
+	if err != nil {
+		return err
+	}
+
+	// applyTranscriptBackfill returns ErrCheckpointNotFound when the ref has no
+	// root summary yet (existing == nil → empty entries), matching the git-branch
+	// store's behavior for backfilling an unknown checkpoint.
+	checkpointSubtree, err := s.applyTranscriptBackfill(ctx, opts, existing, "")
+	if err != nil {
+		return err
+	}
+
+	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+	commitMsg := fmt.Sprintf("Finalize transcript for Checkpoint: %s", opts.CheckpointID)
+	commitHash, err := CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, authorName, authorEmail)
+	if err != nil {
+		return err
+	}
+	return s.setRef(ctx, opts.CheckpointID, commitHash)
+}
+
+func (s *gitRefsStore) backfillSummary(ctx context.Context, checkpointID id.CheckpointID, summary *Summary) error {
+	if err := ctx.Err(); err != nil {
+		return err //nolint:wrapcheck // Propagating context cancellation
+	}
+
+	parentHash, existing, err := s.refBase(checkpointID)
+	if err != nil {
+		return err
+	}
+
+	checkpointSubtree, sessionID, err := s.applySummaryBackfill(ctx, existing, "", summary)
+	if err != nil {
+		return err
+	}
+
+	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+	commitMsg := fmt.Sprintf("Update summary for checkpoint %s (session: %s)", checkpointID, sessionID)
+	commitHash, err := CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, authorName, authorEmail)
+	if err != nil {
+		return err
+	}
+	return s.setRef(ctx, checkpointID, commitHash)
+}
+
+func (s *gitRefsStore) backfillAttribution(ctx context.Context, checkpointID id.CheckpointID, combinedAttribution *Attribution) error {
+	if err := ctx.Err(); err != nil {
+		return err //nolint:wrapcheck // Propagating context cancellation
+	}
+
+	parentHash, existing, err := s.refBase(checkpointID)
+	if err != nil {
+		return err
+	}
+
+	checkpointSubtree, err := s.applyAttributionBackfill(ctx, existing, "", combinedAttribution)
+	if err != nil {
+		return err
+	}
+
+	authorName, authorEmail := GetGitAuthorFromRepo(s.repo)
+	commitMsg := fmt.Sprintf("Update checkpoint summary for %s", checkpointID)
+	commitHash, err := CreateCommit(ctx, s.repo, checkpointSubtree, parentHash, commitMsg, authorName, authorEmail)
+	if err != nil {
+		return err
+	}
+	return s.setRef(ctx, checkpointID, commitHash)
+}
+
+// checkpointTree resolves a FetchingTree rooted at a checkpoint's ref commit
+// tree (which is the checkpoint subtree itself). Returns ErrCheckpointNotFound
+// when the ref or its commit/tree cannot be resolved.
+func (s *gitRefsStore) checkpointTree(ctx context.Context, cid id.CheckpointID) (*FetchingTree, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err //nolint:wrapcheck // Propagating context cancellation
+	}
+	ref, err := s.resolveRefMaybeFetch(ctx, cid)
+	if err != nil {
+		return nil, ErrCheckpointNotFound
+	}
+	commit, err := s.repo.CommitObject(ref.Hash())
+	if err != nil {
+		return nil, ErrCheckpointNotFound
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return nil, ErrCheckpointNotFound
+	}
+	return NewFetchingTree(ctx, tree, s.repo.Storer, s.blobFetcher), nil
+}
+
+// resolveRefMaybeFetch resolves a checkpoint ref, fetching it from the remote
+// once when it is missing locally and a ref fetcher is configured (the
+// checkpoint may have been written on another machine). A failed fetch returns
+// the original not-found error so the read resolves to ErrCheckpointNotFound.
+func (s *gitRefsStore) resolveRefMaybeFetch(ctx context.Context, cid id.CheckpointID) (*plumbing.Reference, error) {
+	refName := RefName(cid)
+	ref, err := s.repo.Reference(refName, true)
+	if err == nil {
+		return ref, nil
+	}
+	if s.refFetcher == nil {
+		return nil, err //nolint:wrapcheck // caller maps any error to ErrCheckpointNotFound
+	}
+	if fetchErr := s.refFetcher(ctx, refName); fetchErr != nil {
+		logging.Debug(ctx, "git-refs: on-demand checkpoint ref fetch failed",
+			slog.String("ref", refName.String()), slog.String("error", fetchErr.Error()))
+		return nil, err //nolint:wrapcheck // caller maps any error to ErrCheckpointNotFound
+	}
+	return s.repo.Reference(refName, true) //nolint:wrapcheck // caller maps any error to ErrCheckpointNotFound
+}
+
+// sessionTree resolves the FetchingTree for one session within a checkpoint ref.
+func (s *gitRefsStore) sessionTree(ctx context.Context, cid id.CheckpointID, sessionIndex int) (*FetchingTree, error) {
+	ct, err := s.checkpointTree(ctx, cid)
+	if err != nil {
+		return nil, err
+	}
+	sessionTree, err := ct.Tree(strconv.Itoa(sessionIndex))
+	if err != nil {
+		return nil, fmt.Errorf("%w: session %d not found: %w", ErrCheckpointNotFound, sessionIndex, err)
+	}
+	return sessionTree, nil
+}
+
+// Read returns the checkpoint summary, or (nil, nil) when the checkpoint's ref
+// is absent, so the contract normalizes it to ErrCheckpointNotFound.
+func (s *gitRefsStore) Read(ctx context.Context, checkpointID id.CheckpointID) (*CheckpointSummary, error) {
+	ct, err := s.checkpointTree(ctx, checkpointID)
+	if err != nil {
+		return nil, nil //nolint:nilnil,nilerr // No ref means no checkpoint exists
+	}
+	return readSummaryFromCheckpointTree(ct)
+}
+
+func (s *gitRefsStore) ReadSessionMetadata(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*Metadata, error) {
+	sessionTree, err := s.sessionTree(ctx, checkpointID, sessionIndex)
+	if err != nil {
+		return nil, err
+	}
+	return readSessionMetadataFromTree(sessionTree, sessionIndex)
+}
+
+func (s *gitRefsStore) ReadSessionMetadataAndPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*Metadata, string, error) {
+	sessionTree, err := s.sessionTree(ctx, checkpointID, sessionIndex)
+	if err != nil {
+		return nil, "", err
+	}
+	return readSessionMetadataAndPromptsFromTree(sessionTree, sessionIndex)
+}
+
+func (s *gitRefsStore) ReadSessionPrompts(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (string, error) {
+	sessionTree, err := s.sessionTree(ctx, checkpointID, sessionIndex)
+	if err != nil {
+		return "", err
+	}
+	return readSessionPromptsFromTree(sessionTree)
+}
+
+func (s *gitRefsStore) ReadSessionContent(ctx context.Context, checkpointID id.CheckpointID, sessionIndex int) (*SessionContent, error) {
+	sessionTree, err := s.sessionTree(ctx, checkpointID, sessionIndex)
+	if err != nil {
+		return nil, err
+	}
+	return readSessionContentFromTree(ctx, sessionTree)
+}
+
+// List enumerates local checkpoint refs and reads each root summary, sorted most
+// recent first. Storage-level listing is local-refs-only for now (no remote
+// enumeration), matching the issue's first-version scope.
+func (s *gitRefsStore) List(ctx context.Context) ([]CheckpointInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err //nolint:wrapcheck // Propagating context cancellation
+	}
+
+	refs, err := s.repo.References()
+	if err != nil {
+		return nil, fmt.Errorf("list checkpoint refs: %w", err)
+	}
+	defer refs.Close()
+
+	var checkpoints []CheckpointInfo
+	err = refs.ForEach(func(ref *plumbing.Reference) error {
+		cid, ok := ParseRef(ref.Name())
+		if !ok {
+			return nil
+		}
+		commit, commitErr := s.repo.CommitObject(ref.Hash())
+		if commitErr != nil {
+			return nil //nolint:nilerr // skip unreadable refs, keep listing
+		}
+		tree, treeErr := commit.Tree()
+		if treeErr != nil {
+			return nil //nolint:nilerr // skip unreadable refs, keep listing
+		}
+		checkpoints = append(checkpoints, readCommittedInfoFromCheckpointTree(cid, tree))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("iterate checkpoint refs: %w", err)
+	}
+
+	sort.Slice(checkpoints, func(i, j int) bool {
+		return checkpoints[i].CreatedAt.After(checkpoints[j].CreatedAt)
+	})
+	return checkpoints, nil
+}
+
+// GetCheckpointAuthor returns the author of the checkpoint ref's tip commit (the
+// most recent writer). Returns a zero Author when the ref is absent.
+func (s *gitRefsStore) GetCheckpointAuthor(ctx context.Context, checkpointID id.CheckpointID) (Author, error) {
+	if err := ctx.Err(); err != nil {
+		return Author{}, err //nolint:wrapcheck // Propagating context cancellation
+	}
+	ref, err := s.repo.Reference(RefName(checkpointID), true)
+	if err != nil {
+		return Author{}, nil //nolint:nilerr // no ref → unknown author
+	}
+	commit, err := s.repo.CommitObject(ref.Hash())
+	if err != nil {
+		return Author{}, nil //nolint:nilerr // unreadable → unknown author
+	}
+	return Author{Name: commit.Author.Name, Email: commit.Author.Email}, nil
+}

--- a/cmd/entire/cli/checkpoint/refs_store.go
+++ b/cmd/entire/cli/checkpoint/refs_store.go
@@ -79,8 +79,13 @@ func (s *gitRefsStore) refBase(cid id.CheckpointID) (plumbing.Hash, *object.Tree
 		return plumbing.ZeroHash, nil, err
 	}
 	ref, err := s.repo.Reference(refName, true)
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return plumbing.ZeroHash, nil, nil // no ref yet → new checkpoint (orphan)
+	}
 	if err != nil {
-		return plumbing.ZeroHash, nil, nil //nolint:nilerr // no ref yet → new checkpoint
+		// A real lookup failure (IO/corruption), not an absent ref: surface it
+		// rather than silently starting a fresh orphan history over the ref.
+		return plumbing.ZeroHash, nil, fmt.Errorf("resolve checkpoint ref %s: %w", refName, err)
 	}
 	commit, err := s.repo.CommitObject(ref.Hash())
 	if err != nil {
@@ -240,23 +245,31 @@ func (s *gitRefsStore) checkpointTree(ctx context.Context, cid id.CheckpointID) 
 	}
 	ref, err := s.resolveRefMaybeFetch(ctx, cid)
 	if err != nil {
-		return nil, ErrCheckpointNotFound
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return nil, ErrCheckpointNotFound
+		}
+		return nil, err
 	}
 	commit, err := s.repo.CommitObject(ref.Hash())
 	if err != nil {
-		return nil, ErrCheckpointNotFound
+		// The ref resolved but its commit object doesn't — corruption/IO, not an
+		// absent checkpoint. Surface it instead of masking as "not found".
+		return nil, fmt.Errorf("read checkpoint commit %s for %s: %w", ref.Hash(), cid, err)
 	}
 	tree, err := commit.Tree()
 	if err != nil {
-		return nil, ErrCheckpointNotFound
+		return nil, fmt.Errorf("read checkpoint tree for %s: %w", cid, err)
 	}
 	return NewFetchingTree(ctx, tree, s.repo.Storer, s.blobFetcher), nil
 }
 
 // resolveRefMaybeFetch resolves a checkpoint ref, fetching it from the remote
 // once when it is missing locally and a ref fetcher is configured (the
-// checkpoint may have been written on another machine). A failed fetch returns
-// the original not-found error so the read resolves to ErrCheckpointNotFound.
+// checkpoint may have been written on another machine). It distinguishes a
+// genuinely absent ref (returns a plumbing.ErrReferenceNotFound-wrapped error,
+// which callers map to ErrCheckpointNotFound) from a real failure — an IO error,
+// or a fetch that failed for network/context reasons — which is returned as-is
+// so it is not silently swallowed as "checkpoint not found".
 func (s *gitRefsStore) resolveRefMaybeFetch(ctx context.Context, cid id.CheckpointID) (*plumbing.Reference, error) {
 	refName, err := RefName(cid)
 	if err != nil {
@@ -266,15 +279,24 @@ func (s *gitRefsStore) resolveRefMaybeFetch(ctx context.Context, cid id.Checkpoi
 	if err == nil {
 		return ref, nil
 	}
+	if !errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return nil, fmt.Errorf("resolve checkpoint ref %s: %w", refName, err)
+	}
 	if s.refFetcher == nil {
-		return nil, err //nolint:wrapcheck // caller maps any error to ErrCheckpointNotFound
+		return nil, err //nolint:wrapcheck // genuinely absent; caller maps ErrReferenceNotFound to ErrCheckpointNotFound
 	}
 	if fetchErr := s.refFetcher(ctx, refName); fetchErr != nil {
 		logging.Debug(ctx, "git-refs: on-demand checkpoint ref fetch failed",
 			slog.String("ref", refName.String()), slog.String("error", fetchErr.Error()))
-		return nil, err //nolint:wrapcheck // caller maps any error to ErrCheckpointNotFound
+		return nil, fmt.Errorf("fetch checkpoint ref %s: %w", refName, fetchErr)
 	}
-	return s.repo.Reference(refName, true) //nolint:wrapcheck // caller maps any error to ErrCheckpointNotFound
+	// Re-resolve after a successful fetch. ErrReferenceNotFound here means the
+	// remote genuinely has no such checkpoint; anything else is a real error.
+	ref, err = s.repo.Reference(refName, true)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // ErrReferenceNotFound (absent) or a real error; caller distinguishes via errors.Is
+	}
+	return ref, nil
 }
 
 // sessionTree resolves the FetchingTree for one session within a checkpoint ref.
@@ -295,7 +317,10 @@ func (s *gitRefsStore) sessionTree(ctx context.Context, cid id.CheckpointID, ses
 func (s *gitRefsStore) Read(ctx context.Context, checkpointID id.CheckpointID) (*CheckpointSummary, error) {
 	ct, err := s.checkpointTree(ctx, checkpointID)
 	if err != nil {
-		return nil, nil //nolint:nilnil,nilerr // No ref means no checkpoint exists
+		if errors.Is(err, ErrCheckpointNotFound) {
+			return nil, nil //nolint:nilnil // absent ref → no checkpoint; contract normalizes to ErrCheckpointNotFound
+		}
+		return nil, err
 	}
 	return readSummaryFromCheckpointTree(ct)
 }

--- a/cmd/entire/cli/checkpoint/refs_store_seam_test.go
+++ b/cmd/entire/cli/checkpoint/refs_store_seam_test.go
@@ -65,7 +65,7 @@ func TestSeam_GitRefsPrimaryWithGitBranchMirror(t *testing.T) {
 	t.Run("git-refs primary", func(t *testing.T) {
 		assertSeamVariants(t, stores.Persistent, cid, CheckpointVersionRefsV1)
 		// The primary is the per-checkpoint-ref store, not a fan-out of nothing.
-		_, err := repo.Reference(RefName(cid), true)
+		_, err := repo.Reference(mustRefName(t, cid), true)
 		assert.NoError(t, err, "primary should have written the per-checkpoint ref")
 	})
 

--- a/cmd/entire/cli/checkpoint/refs_store_seam_test.go
+++ b/cmd/entire/cli/checkpoint/refs_store_seam_test.go
@@ -1,0 +1,99 @@
+package checkpoint
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/redact"
+)
+
+// TestSeam_GitRefsPrimaryWithGitBranchMirror drives the branch->refs rollout
+// topology through checkpoint.Open: a git-refs primary with a git-branch mirror.
+// It writes all four WriteRequest variants and asserts reads resolve from the
+// git-refs primary while the git-branch mirror (the v1 branch) independently
+// received every write.
+//
+// Not parallel: uses t.Chdir so settings + ref resolution target the test repo.
+func TestSeam_GitRefsPrimaryWithGitBranchMirror(t *testing.T) {
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "README.md", "# test")
+	testutil.GitAdd(t, dir, "README.md")
+	testutil.GitCommit(t, dir, "init")
+
+	body := `{"enabled": true, "checkpoints": {"primary": {"type": "git-refs"}, "mirrors": [{"type": "git-branch"}]}}`
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".entire"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".entire", "settings.json"), []byte(body), 0o644))
+	t.Chdir(dir)
+
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	stores, err := Open(context.Background(), repo, OpenOptions{})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	const sessionID = "sess-1"
+
+	require.NoError(t, stores.Persistent.Write(ctx, Session{
+		CheckpointID: cid, SessionID: sessionID, Strategy: "manual-commit",
+		Transcript: redact.AlreadyRedacted([]byte("initial transcript")),
+		Prompts:    []string{"do the thing"}, FilesTouched: []string{"a.go"},
+		AuthorName: "Test", AuthorEmail: "test@example.com",
+	}))
+	require.NoError(t, stores.Persistent.Write(ctx, SessionTranscript{
+		CheckpointID: cid, SessionID: sessionID,
+		Transcript: redact.AlreadyRedacted([]byte("final transcript")),
+		Prompts:    []string{"do the thing"},
+	}))
+	require.NoError(t, stores.Persistent.Write(ctx, SessionSummary{
+		CheckpointID: cid, Summary: &Summary{Intent: "intent-x", Outcome: "outcome-y"},
+	}))
+	require.NoError(t, stores.Persistent.Write(ctx, CheckpointAttribution{
+		CheckpointID: cid, Attribution: &Attribution{AgentLines: 7, AgentPercentage: 70},
+	}))
+
+	// Reads resolve from the git-refs primary.
+	t.Run("git-refs primary", func(t *testing.T) {
+		assertSeamVariants(t, stores.Persistent, cid, CheckpointVersionRefsV1)
+		// The primary is the per-checkpoint-ref store, not a fan-out of nothing.
+		_, err := repo.Reference(RefName(cid), true)
+		assert.NoError(t, err, "primary should have written the per-checkpoint ref")
+	})
+
+	// The git-branch mirror independently received every write on the v1 branch.
+	t.Run("git-branch mirror", func(t *testing.T) {
+		mirror := NewGitStore(repo, DefaultV1Refs())
+		assertSeamVariants(t, mirror, cid, CheckpointVersionBranchV1)
+	})
+}
+
+func assertSeamVariants(t *testing.T, store PersistentStore, cid id.CheckpointID, wantVersion string) {
+	t.Helper()
+	ctx := context.Background()
+
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, summary, "checkpoint should exist")
+	assert.Equal(t, wantVersion, summary.CheckpointVersion)
+	require.Len(t, summary.Sessions, 1)
+	require.NotNil(t, summary.CombinedAttribution)
+	assert.Equal(t, 7, summary.CombinedAttribution.AgentLines)
+
+	content, err := store.ReadSessionContent(ctx, cid, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("final transcript"), content.Transcript)
+
+	meta, err := store.ReadSessionMetadata(ctx, cid, 0)
+	require.NoError(t, err)
+	require.NotNil(t, meta.Summary)
+	assert.Equal(t, "intent-x", meta.Summary.Intent)
+}

--- a/cmd/entire/cli/checkpoint/refs_store_test.go
+++ b/cmd/entire/cli/checkpoint/refs_store_test.go
@@ -51,7 +51,7 @@ func TestGitRefsStore_WriteEnqueuesForPush(t *testing.T) {
 	require.NoError(t, err)
 	refs, err := q.Drain()
 	require.NoError(t, err)
-	assert.Contains(t, refs, RefName(cid), "a session write should enqueue its checkpoint ref for push")
+	assert.Contains(t, refs, mustRefName(t, cid), "a session write should enqueue its checkpoint ref for push")
 }
 
 func TestGitRefsStore_OnDemandRefFetch(t *testing.T) {
@@ -61,13 +61,13 @@ func TestGitRefsStore_OnDemandRefFetch(t *testing.T) {
 	cid := id.MustCheckpointID("a1b2c3d4e5f6")
 
 	refsWrite(t, store, cid, "sess-1", "transcript")
-	ref, err := store.repo.Reference(RefName(cid), true)
+	ref, err := store.repo.Reference(mustRefName(t, cid), true)
 	require.NoError(t, err)
 	commitHash := ref.Hash()
 
 	// Simulate "not present locally" by dropping the ref (the commit object
 	// survives, so a fetch can restore the ref).
-	require.NoError(t, store.repo.Storer.RemoveReference(RefName(cid)))
+	require.NoError(t, store.repo.Storer.RemoveReference(mustRefName(t, cid)))
 
 	// No fetcher configured: read resolves to not-found (nil summary).
 	summary, err := store.Read(ctx, cid)
@@ -120,7 +120,7 @@ func TestGitRefsStore_WriteAllVariantsAndRead(t *testing.T) {
 	}))
 
 	// The per-checkpoint ref exists at the sharded name.
-	_, err := store.repo.Reference(RefName(cid), true)
+	_, err := store.repo.Reference(mustRefName(t, cid), true)
 	require.NoError(t, err, "checkpoint ref should exist")
 
 	summary, err := store.Read(ctx, cid)
@@ -161,7 +161,7 @@ func TestGitRefsStore_RefSharding(t *testing.T) {
 	// id.CheckpointID JSON (un)marshaling to accept ULIDs, which lands with the
 	// deferred ULID-generation switch.
 	ulid := id.CheckpointID("01KVBJCWYA4YW6J5M9GP655HZN")
-	assert.Equal(t, "refs/entire/checkpoints/ZN/01KVBJCWYA4YW6J5M9GP655HZN", RefName(ulid).String())
+	assert.Equal(t, "refs/entire/checkpoints/ZN/01KVBJCWYA4YW6J5M9GP655HZN", mustRefName(t, ulid).String())
 }
 
 func TestGitRefsStore_MultipleSessions(t *testing.T) {
@@ -212,7 +212,7 @@ func TestGitRefsStore_PerCheckpointHistory(t *testing.T) {
 	refsWrite(t, store, cid, "sess-1", "t")
 
 	// First write is an orphan (no parent).
-	ref, err := store.repo.Reference(RefName(cid), true)
+	ref, err := store.repo.Reference(mustRefName(t, cid), true)
 	require.NoError(t, err)
 	first, err := store.repo.CommitObject(ref.Hash())
 	require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestGitRefsStore_PerCheckpointHistory(t *testing.T) {
 	require.NoError(t, store.Write(ctx, SessionSummary{
 		CheckpointID: cid, Summary: &Summary{Intent: "later"},
 	}))
-	ref, err = store.repo.Reference(RefName(cid), true)
+	ref, err = store.repo.Reference(mustRefName(t, cid), true)
 	require.NoError(t, err)
 	second, err := store.repo.CommitObject(ref.Hash())
 	require.NoError(t, err)

--- a/cmd/entire/cli/checkpoint/refs_store_test.go
+++ b/cmd/entire/cli/checkpoint/refs_store_test.go
@@ -87,16 +87,35 @@ func TestGitRefsStore_OnDemandRefFetch(t *testing.T) {
 	assert.Equal(t, 1, fetched, "fetcher invoked once for the missing ref")
 }
 
-func TestGitRefsStore_OnDemandRefFetch_FailureIsNotFound(t *testing.T) {
+// TestGitRefsStore_OnDemandRefFetch_FailurePropagates: a fetch that fails
+// (offline, network error, context cancellation) must surface as a real error
+// rather than be masked as "checkpoint not found" — otherwise a transient
+// failure looks like missing data. A fetch that succeeds but still finds no such
+// ref on the remote is a genuine not-found and reads as (nil, nil).
+func TestGitRefsStore_OnDemandRefFetch_FailurePropagates(t *testing.T) {
 	t.Parallel()
-	store := newRefsStore(t)
-	store.SetRefFetcher(func(_ context.Context, _ plumbing.ReferenceName) error {
-		return assert.AnError // fetch fails (e.g. offline / unknown checkpoint)
+
+	t.Run("fetch error propagates", func(t *testing.T) {
+		t.Parallel()
+		store := newRefsStore(t)
+		store.SetRefFetcher(func(_ context.Context, _ plumbing.ReferenceName) error {
+			return assert.AnError // fetch fails (e.g. offline / network)
+		})
+		summary, err := store.Read(context.Background(), id.MustCheckpointID("ffffffffffff"))
+		require.ErrorIs(t, err, assert.AnError, "a failed fetch must not be masked as not-found")
+		assert.Nil(t, summary)
 	})
 
-	summary, err := store.Read(context.Background(), id.MustCheckpointID("ffffffffffff"))
-	require.NoError(t, err)
-	assert.Nil(t, summary, "a failed fetch reads as not-found, not an error")
+	t.Run("successful fetch with still-absent ref reads as not-found", func(t *testing.T) {
+		t.Parallel()
+		store := newRefsStore(t)
+		store.SetRefFetcher(func(_ context.Context, _ plumbing.ReferenceName) error {
+			return nil // fetch "succeeds" but the ref still doesn't exist
+		})
+		summary, err := store.Read(context.Background(), id.MustCheckpointID("ffffffffffff"))
+		require.NoError(t, err, "a genuinely absent checkpoint reads as not-found")
+		assert.Nil(t, summary)
+	})
 }
 
 func TestGitRefsStore_WriteAllVariantsAndRead(t *testing.T) {

--- a/cmd/entire/cli/checkpoint/refs_store_test.go
+++ b/cmd/entire/cli/checkpoint/refs_store_test.go
@@ -1,0 +1,269 @@
+package checkpoint
+
+import (
+	"context"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/entireio/cli/redact"
+)
+
+func newRefsStore(t *testing.T) *gitRefsStore {
+	t.Helper()
+	dir := t.TempDir()
+	testutil.InitRepo(t, dir)
+	testutil.WriteFile(t, dir, "README.md", "# test")
+	testutil.GitAdd(t, dir, "README.md")
+	testutil.GitCommit(t, dir, "init")
+	repo, err := git.PlainOpen(dir)
+	require.NoError(t, err)
+	return newGitRefsStore(repo)
+}
+
+func refsWrite(t *testing.T, store *gitRefsStore, cid id.CheckpointID, sessionID, transcript string) {
+	t.Helper()
+	require.NoError(t, store.Write(context.Background(), Session{
+		CheckpointID: cid,
+		SessionID:    sessionID,
+		Strategy:     "manual-commit",
+		Transcript:   redact.AlreadyRedacted([]byte(transcript)),
+		Prompts:      []string{"do the thing"},
+		FilesTouched: []string{"a.go"},
+		AuthorName:   "Test Author",
+		AuthorEmail:  "test@example.com",
+	}))
+}
+
+func TestGitRefsStore_WriteEnqueuesForPush(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	refsWrite(t, store, cid, "sess-1", "transcript")
+
+	q, err := PushQueueForRepo(context.Background(), store.repo)
+	require.NoError(t, err)
+	refs, err := q.Drain()
+	require.NoError(t, err)
+	assert.Contains(t, refs, RefName(cid), "a session write should enqueue its checkpoint ref for push")
+}
+
+func TestGitRefsStore_OnDemandRefFetch(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	ctx := context.Background()
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	refsWrite(t, store, cid, "sess-1", "transcript")
+	ref, err := store.repo.Reference(RefName(cid), true)
+	require.NoError(t, err)
+	commitHash := ref.Hash()
+
+	// Simulate "not present locally" by dropping the ref (the commit object
+	// survives, so a fetch can restore the ref).
+	require.NoError(t, store.repo.Storer.RemoveReference(RefName(cid)))
+
+	// No fetcher configured: read resolves to not-found (nil summary).
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	assert.Nil(t, summary, "missing ref with no fetcher reads as not-found")
+
+	// A fetcher that restores the ref makes the read succeed, and is invoked once.
+	fetched := 0
+	store.SetRefFetcher(func(_ context.Context, rn plumbing.ReferenceName) error {
+		fetched++
+		return store.repo.Storer.SetReference(plumbing.NewHashReference(rn, commitHash))
+	})
+	summary, err = store.Read(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, summary, "ref should resolve after on-demand fetch")
+	assert.Equal(t, cid, summary.CheckpointID)
+	assert.Equal(t, 1, fetched, "fetcher invoked once for the missing ref")
+}
+
+func TestGitRefsStore_OnDemandRefFetch_FailureIsNotFound(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	store.SetRefFetcher(func(_ context.Context, _ plumbing.ReferenceName) error {
+		return assert.AnError // fetch fails (e.g. offline / unknown checkpoint)
+	})
+
+	summary, err := store.Read(context.Background(), id.MustCheckpointID("ffffffffffff"))
+	require.NoError(t, err)
+	assert.Nil(t, summary, "a failed fetch reads as not-found, not an error")
+}
+
+func TestGitRefsStore_WriteAllVariantsAndRead(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	ctx := context.Background()
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+	const sessionID = "sess-1"
+
+	refsWrite(t, store, cid, sessionID, "initial transcript")
+	require.NoError(t, store.Write(ctx, SessionTranscript{
+		CheckpointID: cid, SessionID: sessionID,
+		Transcript: redact.AlreadyRedacted([]byte("final transcript")),
+		Prompts:    []string{"do the thing"},
+	}))
+	require.NoError(t, store.Write(ctx, SessionSummary{
+		CheckpointID: cid, Summary: &Summary{Intent: "intent-x", Outcome: "outcome-y"},
+	}))
+	require.NoError(t, store.Write(ctx, CheckpointAttribution{
+		CheckpointID: cid, Attribution: &Attribution{AgentLines: 7, AgentPercentage: 70},
+	}))
+
+	// The per-checkpoint ref exists at the sharded name.
+	_, err := store.repo.Reference(RefName(cid), true)
+	require.NoError(t, err, "checkpoint ref should exist")
+
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, CheckpointVersionRefsV1, summary.CheckpointVersion)
+	require.Len(t, summary.Sessions, 1)
+	require.NotNil(t, summary.CombinedAttribution)
+	assert.Equal(t, 7, summary.CombinedAttribution.AgentLines)
+
+	content, err := store.ReadSessionContent(ctx, cid, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("final transcript"), content.Transcript)
+
+	meta, err := store.ReadSessionMetadata(ctx, cid, 0)
+	require.NoError(t, err)
+	require.NotNil(t, meta.Summary)
+	assert.Equal(t, "intent-x", meta.Summary.Intent)
+}
+
+func TestGitRefsStore_RefSharding(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	ctx := context.Background()
+
+	// A legacy hex checkpoint stores under a first-two-char shard and round-trips.
+	legacy := id.MustCheckpointID("a1b2c3d4e5f6")
+	refsWrite(t, store, legacy, "s-legacy", "t")
+	_, err := store.repo.Reference("refs/entire/checkpoints/a1/a1b2c3d4e5f6", true)
+	require.NoError(t, err)
+	summary, err := store.Read(ctx, legacy)
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, legacy, summary.CheckpointID)
+
+	// ULIDs shard on the last two chars (the ref namespace is ULID-ready). Only
+	// the ref-naming layer is asserted here: storing a ULID checkpoint also needs
+	// id.CheckpointID JSON (un)marshaling to accept ULIDs, which lands with the
+	// deferred ULID-generation switch.
+	ulid := id.CheckpointID("01KVBJCWYA4YW6J5M9GP655HZN")
+	assert.Equal(t, "refs/entire/checkpoints/ZN/01KVBJCWYA4YW6J5M9GP655HZN", RefName(ulid).String())
+}
+
+func TestGitRefsStore_MultipleSessions(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	ctx := context.Background()
+	cid := id.MustCheckpointID("abcdef012345")
+
+	refsWrite(t, store, cid, "sess-1", "first")
+	refsWrite(t, store, cid, "sess-2", "second")
+
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	require.Len(t, summary.Sessions, 2, "two sessions should occupy two numbered dirs")
+
+	infos, err := store.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, 2, infos[0].SessionCount)
+}
+
+func TestGitRefsStore_SeparateCheckpointsSeparateRefs(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	ctx := context.Background()
+	cid1 := id.MustCheckpointID("a1b2c3d4e5f6")
+	cid2 := id.MustCheckpointID("f6e5d4c3b2a1")
+
+	refsWrite(t, store, cid1, "s1", "t1")
+	refsWrite(t, store, cid2, "s2", "t2")
+
+	_, err := store.repo.Reference("refs/entire/checkpoints/a1/a1b2c3d4e5f6", true)
+	require.NoError(t, err)
+	_, err = store.repo.Reference("refs/entire/checkpoints/f6/f6e5d4c3b2a1", true)
+	require.NoError(t, err)
+
+	infos, err := store.List(ctx)
+	require.NoError(t, err)
+	assert.Len(t, infos, 2)
+}
+
+func TestGitRefsStore_PerCheckpointHistory(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	ctx := context.Background()
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	refsWrite(t, store, cid, "sess-1", "t")
+
+	// First write is an orphan (no parent).
+	ref, err := store.repo.Reference(RefName(cid), true)
+	require.NoError(t, err)
+	first, err := store.repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	require.Empty(t, first.ParentHashes, "first checkpoint commit should be an orphan")
+
+	// A backfill advances the same ref, preserving history.
+	require.NoError(t, store.Write(ctx, SessionSummary{
+		CheckpointID: cid, Summary: &Summary{Intent: "later"},
+	}))
+	ref, err = store.repo.Reference(RefName(cid), true)
+	require.NoError(t, err)
+	second, err := store.repo.CommitObject(ref.Hash())
+	require.NoError(t, err)
+	require.Len(t, second.ParentHashes, 1, "backfill should parent on the prior tip")
+	assert.Equal(t, first.Hash, second.ParentHashes[0])
+}
+
+func TestGitRefsStore_GetCheckpointAuthor(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	ctx := context.Background()
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	refsWrite(t, store, cid, "sess-1", "t")
+
+	author, err := store.GetCheckpointAuthor(ctx, cid)
+	require.NoError(t, err)
+	assert.Equal(t, "Test Author", author.Name)
+	assert.Equal(t, "test@example.com", author.Email)
+}
+
+func TestGitRefsStore_BackfillUnknownCheckpointNotFound(t *testing.T) {
+	t.Parallel()
+	store := newRefsStore(t)
+	ctx := context.Background()
+	cid := id.MustCheckpointID("a1b2c3d4e5f6")
+
+	err := store.Write(ctx, SessionTranscript{
+		CheckpointID: cid, SessionID: "s",
+		Transcript: redact.AlreadyRedacted([]byte("x")),
+	})
+	require.ErrorIs(t, err, ErrCheckpointNotFound)
+
+	err = store.Write(ctx, SessionSummary{CheckpointID: cid, Summary: &Summary{Intent: "x"}})
+	require.ErrorIs(t, err, ErrCheckpointNotFound)
+
+	err = store.Write(ctx, CheckpointAttribution{CheckpointID: cid, Attribution: &Attribution{AgentLines: 1}})
+	require.ErrorIs(t, err, ErrCheckpointNotFound)
+
+	// Read of an absent checkpoint is (nil, nil) per the contract.
+	summary, err := store.Read(ctx, cid)
+	require.NoError(t, err)
+	assert.Nil(t, summary)
+}

--- a/cmd/entire/cli/checkpoint/refs_store_test.go
+++ b/cmd/entire/cli/checkpoint/refs_store_test.go
@@ -165,17 +165,17 @@ func TestGitRefsStore_RefSharding(t *testing.T) {
 	store := newRefsStore(t)
 	ctx := context.Background()
 
-	// A legacy hex checkpoint stores under a first-two-char shard and round-trips.
+	// A legacy hex checkpoint stores under a last-two-char shard and round-trips.
 	legacy := id.MustCheckpointID("a1b2c3d4e5f6")
 	refsWrite(t, store, legacy, "s-legacy", "t")
-	_, err := store.repo.Reference("refs/entire/checkpoints/a1/a1b2c3d4e5f6", true)
+	_, err := store.repo.Reference("refs/entire/checkpoints/f6/a1b2c3d4e5f6", true)
 	require.NoError(t, err)
 	summary, err := store.Read(ctx, legacy)
 	require.NoError(t, err)
 	require.NotNil(t, summary)
 	assert.Equal(t, legacy, summary.CheckpointID)
 
-	// ULIDs shard on the last two chars (the ref namespace is ULID-ready). Only
+	// ULIDs shard on the last two chars too (the ref namespace is ULID-ready). Only
 	// the ref-naming layer is asserted here: storing a ULID checkpoint also needs
 	// id.CheckpointID JSON (un)marshaling to accept ULIDs, which lands with the
 	// deferred ULID-generation switch.
@@ -212,9 +212,9 @@ func TestGitRefsStore_SeparateCheckpointsSeparateRefs(t *testing.T) {
 	refsWrite(t, store, cid1, "s1", "t1")
 	refsWrite(t, store, cid2, "s2", "t2")
 
-	_, err := store.repo.Reference("refs/entire/checkpoints/a1/a1b2c3d4e5f6", true)
+	_, err := store.repo.Reference("refs/entire/checkpoints/f6/a1b2c3d4e5f6", true)
 	require.NoError(t, err)
-	_, err = store.repo.Reference("refs/entire/checkpoints/f6/f6e5d4c3b2a1", true)
+	_, err = store.repo.Reference("refs/entire/checkpoints/a1/f6e5d4c3b2a1", true)
 	require.NoError(t, err)
 
 	infos, err := store.List(ctx)

--- a/cmd/entire/cli/checkpoint/registry.go
+++ b/cmd/entire/cli/checkpoint/registry.go
@@ -18,12 +18,21 @@ import (
 // when no backend is configured.
 const BackendTypeGitBranch = "git-branch"
 
+// BackendTypeGitRefs is the built-in git-refs checkpoint backend: it stores the
+// committed record as one git ref per checkpoint (refs/entire/checkpoints/<shard>/
+// <id>) in this repo. Like git-branch it is git-backed, so it may be the primary;
+// the two can run side by side (git-refs primary + git-branch mirror) during the
+// branch->refs rollout, since the one-of-each-type rule permits distinct
+// git-backed backends in the same topology.
+const BackendTypeGitRefs = "git-refs"
+
 // OpenEnv carries the construction context a backend factory may need.
-// Git-backed backends require Repo and use Refs/BlobFetcher; other backends
-// ignore the git-shaped fields and read their own configuration from cfg.
+// Git-backed backends require Repo and use Refs/BlobFetcher/RefFetcher; other
+// backends ignore the git-shaped fields and read their own configuration from cfg.
 type OpenEnv struct {
 	Repo        *git.Repository
 	BlobFetcher BlobFetchFunc
+	RefFetcher  RefFetchFunc
 	Refs        PersistentRefs
 }
 
@@ -55,6 +64,7 @@ var (
 	// RegisterForTesting helpers, so a production binary can never select them.
 	registry = map[string]registeredBackend{
 		BackendTypeGitBranch: {factory: gitBranchBackendFactory, gitBacked: true},
+		BackendTypeGitRefs:   {factory: gitRefsBackendFactory, gitBacked: true},
 	}
 )
 
@@ -116,6 +126,23 @@ func gitBranchBackendFactory(_ context.Context, env OpenEnv, _ json.RawMessage) 
 	store := NewGitStore(env.Repo, env.Refs)
 	if env.BlobFetcher != nil {
 		store.SetBlobFetcher(env.BlobFetcher)
+	}
+	return store, nil
+}
+
+// gitRefsBackendFactory builds the git-refs persistent store from the open
+// environment. It ignores cfg and env.Refs: each checkpoint resolves its own ref
+// (refs/entire/checkpoints/<shard>/<id>) rather than a single configured ref.
+func gitRefsBackendFactory(_ context.Context, env OpenEnv, _ json.RawMessage) (PersistentStore, error) {
+	if env.Repo == nil {
+		return nil, errors.New("git-refs checkpoint backend requires a repository")
+	}
+	store := newGitRefsStore(env.Repo)
+	if env.BlobFetcher != nil {
+		store.SetBlobFetcher(env.BlobFetcher)
+	}
+	if env.RefFetcher != nil {
+		store.SetRefFetcher(env.RefFetcher)
 	}
 	return store, nil
 }

--- a/cmd/entire/cli/checkpoint_policy_read_test.go
+++ b/cmd/entire/cli/checkpoint_policy_read_test.go
@@ -16,11 +16,11 @@ func TestReadCheckpointInfoFromStoreRejectsUnsupportedCheckpointVersion(t *testi
 	_, err := readCheckpointInfoFromStore(context.Background(), checkpointInfoPolicyStub{
 		summary: &checkpoint.CheckpointSummary{
 			CheckpointID:      cpID,
-			CheckpointVersion: "refs-v1",
+			CheckpointVersion: "refs-v2",
 		},
 	}, cpID)
 
-	require.EqualError(t, err, `checkpoint 111111111111 uses unsupported checkpoint_version "refs-v1": not read-supported by this Entire CLI`)
+	require.EqualError(t, err, `checkpoint 111111111111 uses unsupported checkpoint_version "refs-v2": not read-supported by this Entire CLI`)
 }
 
 type checkpointInfoPolicyStub struct {

--- a/cmd/entire/cli/checkpoint_policy_test.go
+++ b/cmd/entire/cli/checkpoint_policy_test.go
@@ -56,7 +56,7 @@ func TestCheckpointPolicyCmd_RejectsUnsupportedVersion(t *testing.T) {
 		wantErr string
 	}{
 		{name: "checkpoint version", args: []string{"--checkpoint-version", "branch-v2342"}, wantErr: `checkpoint_version "branch-v2342" is not supported by this Entire CLI`},
-		{name: "minimum version", args: []string{"--checkpoint-min-version", "refs-v1"}, wantErr: `checkpoint_min_version "refs-v1" is not supported by this Entire CLI`},
+		{name: "minimum version", args: []string{"--checkpoint-min-version", "refs-v2"}, wantErr: `checkpoint_min_version "refs-v2" is not supported by this Entire CLI`},
 	}
 
 	for _, tt := range tests {
@@ -87,8 +87,8 @@ func TestCheckpointPolicyCmd_PrintsUnsupportedConfiguredVersion(t *testing.T) {
 func TestCheckpointPolicyCmd_RejectsDowngradeWithoutForce(t *testing.T) {
 	dir, bareDir := setupCheckpointPolicyRepo(t)
 	seedCheckpointPolicyForCommand(t, dir, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
-		CheckpointMinVersion: "refs-v1",
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
 	})
 	pushCheckpointPolicyRefForCommandTest(t, dir, bareDir)
 

--- a/cmd/entire/cli/checkpoint_policy_test.go
+++ b/cmd/entire/cli/checkpoint_policy_test.go
@@ -72,14 +72,14 @@ func TestCheckpointPolicyCmd_RejectsUnsupportedVersion(t *testing.T) {
 func TestCheckpointPolicyCmd_PrintsUnsupportedConfiguredVersion(t *testing.T) {
 	dir, bareDir := setupCheckpointPolicyRepo(t)
 	seedCheckpointPolicyForCommand(t, dir, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
+		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: "branch-v1",
 	})
 	pushCheckpointPolicyRefForCommandTest(t, dir, bareDir)
 
 	stdout, err := executeCheckpointPolicyCmd(t)
 	require.NoError(t, err)
-	require.Contains(t, stdout, "checkpoint_version: refs-v1 (unsupported)")
+	require.Contains(t, stdout, "checkpoint_version: refs-v2 (unsupported)")
 	require.NotContains(t, stdout, "writing branch-v1")
 	require.Contains(t, stdout, "checkpoint_min_version: branch-v1")
 }

--- a/cmd/entire/cli/checkpoint_policy_test_helpers_test.go
+++ b/cmd/entire/cli/checkpoint_policy_test_helpers_test.go
@@ -29,7 +29,7 @@ func writeMalformedCheckpointPolicyForCLITest(t *testing.T, repo *git.Repository
 func writeUnsupportedCheckpointPolicyForCLITest(t *testing.T, repo *git.Repository) {
 	t.Helper()
 	_, err := checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
+		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: "branch-v1",
 	})
 	require.NoError(t, err)

--- a/cmd/entire/cli/checkpoint_policy_warning_test.go
+++ b/cmd/entire/cli/checkpoint_policy_warning_test.go
@@ -20,8 +20,8 @@ func TestWarnCheckpointPolicyIfNeeded(t *testing.T) {
 		_ = repo.Close()
 	})
 	_, err = checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
-		CheckpointMinVersion: "refs-v1",
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
 	})
 	require.NoError(t, err)
 

--- a/cmd/entire/cli/checkpointpolicy/format.go
+++ b/cmd/entire/cli/checkpointpolicy/format.go
@@ -72,14 +72,19 @@ var familyRanks = map[CheckpointFamily]int{
 	CheckpointFamilyRefs:   1,
 }
 
-var branchV1Format = CheckpointFormat{Family: CheckpointFamilyBranch, Major: 1}
+var (
+	branchV1Format = CheckpointFormat{Family: CheckpointFamilyBranch, Major: 1}
+	refsV1Format   = CheckpointFormat{Family: CheckpointFamilyRefs, Major: 1}
+)
 
 var (
 	readFormats = map[CheckpointFormat]bool{
 		branchV1Format: true,
+		refsV1Format:   true,
 	}
 
 	writeFormats = map[CheckpointFormat]bool{
 		branchV1Format: true,
+		refsV1Format:   true,
 	}
 )

--- a/cmd/entire/cli/checkpointpolicy/format_test.go
+++ b/cmd/entire/cli/checkpointpolicy/format_test.go
@@ -52,8 +52,9 @@ func TestSupportedFormats(t *testing.T) {
 	require.True(t, checkpointpolicy.CanWrite(branchV1))
 	require.Equal(t, checkpoint.CheckpointVersionBranchV1, branchV1.String())
 
-	require.False(t, checkpointpolicy.CanRead(refsV1))
-	require.False(t, checkpointpolicy.CanWrite(refsV1))
+	// refs-v1 is the git-refs store format: read- and write-supported.
+	require.True(t, checkpointpolicy.CanRead(refsV1))
+	require.True(t, checkpointpolicy.CanWrite(refsV1))
 	require.Negative(t, checkpointpolicy.Compare(branchV1, refsV1))
 
 	require.False(t, checkpointpolicy.CanRead(unknownV1))

--- a/cmd/entire/cli/checkpointpolicy/policy_test.go
+++ b/cmd/entire/cli/checkpointpolicy/policy_test.go
@@ -63,7 +63,7 @@ func TestValidatePolicy(t *testing.T) {
 		{name: "default", policy: checkpointpolicy.DefaultPolicy()},
 		{name: "unknown current", policy: checkpointpolicy.Policy{CheckpointVersion: "future-v1", CheckpointMinVersion: "branch-v1"}, wantErr: `checkpoint_version "future-v1" is not supported by this Entire CLI`},
 		{name: "unsupported current", policy: checkpointpolicy.Policy{CheckpointVersion: "branch-v2342", CheckpointMinVersion: "branch-v1"}, wantErr: `checkpoint_version "branch-v2342" is not supported by this Entire CLI`},
-		{name: "unsupported minimum", policy: checkpointpolicy.Policy{CheckpointVersion: "branch-v1", CheckpointMinVersion: "refs-v1"}, wantErr: `checkpoint_min_version "refs-v1" is not supported by this Entire CLI`},
+		{name: "unsupported minimum", policy: checkpointpolicy.Policy{CheckpointVersion: "branch-v1", CheckpointMinVersion: "refs-v2"}, wantErr: `checkpoint_min_version "refs-v2" is not supported by this Entire CLI`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/entire/cli/checkpointpolicy/remote_test.go
+++ b/cmd/entire/cli/checkpointpolicy/remote_test.go
@@ -72,8 +72,8 @@ func TestSyncRemotePolicyKeepsDivergedLocalRef(t *testing.T) {
 	require.NoError(t, err)
 
 	remoteHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, baseHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
-		CheckpointMinVersion: "refs-v1",
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
 	})
 	require.NoError(t, err)
 	pushPolicyRefWithGit(t, remoteDir, bareDir)
@@ -133,8 +133,8 @@ func TestPushPolicyRejectsNonFastForward(t *testing.T) {
 
 	secondDir, secondRepo := initPolicyRepoWithDir(t)
 	_, err = checkpointpolicy.WriteLocal(t.Context(), secondRepo, plumbing.ZeroHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
-		CheckpointMinVersion: "refs-v1",
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
 	})
 	require.NoError(t, err)
 

--- a/cmd/entire/cli/checkpointpolicy/store_test.go
+++ b/cmd/entire/cli/checkpointpolicy/store_test.go
@@ -88,8 +88,8 @@ func TestReadLocalPolicyAllowsUnsupportedPolicy(t *testing.T) {
 	t.Parallel()
 	repo := initPolicyRepo(t)
 	policy := checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
-		CheckpointMinVersion: "refs-v1",
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
 	}
 	data, err := json.Marshal(policy)
 	require.NoError(t, err)

--- a/cmd/entire/cli/checkpointpolicy/update_test.go
+++ b/cmd/entire/cli/checkpointpolicy/update_test.go
@@ -12,8 +12,8 @@ import (
 func TestUpdateRejectsDowngradeFromRemoteWithoutForce(t *testing.T) {
 	remoteDir, remoteRepo, bareDir := initPolicyRemoteFixture(t)
 	_, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
-		CheckpointMinVersion: "refs-v1",
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
 	})
 	require.NoError(t, err)
 	pushPolicyRefWithGit(t, remoteDir, bareDir)
@@ -36,8 +36,8 @@ func TestUpdateRejectsDowngradeFromRemoteWithoutForce(t *testing.T) {
 func TestUpdateAllowsDowngradeWithForce(t *testing.T) {
 	remoteDir, remoteRepo, bareDir := initPolicyRemoteFixture(t)
 	remoteHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, plumbing.ZeroHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
-		CheckpointMinVersion: "refs-v1",
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
 	})
 	require.NoError(t, err)
 	pushPolicyRefWithGit(t, remoteDir, bareDir)
@@ -139,8 +139,8 @@ func TestUpdateRejectsDivergedLocalPolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	remoteHash, err := checkpointpolicy.WriteLocal(t.Context(), remoteRepo, baseHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
-		CheckpointMinVersion: "refs-v1",
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
 	})
 	require.NoError(t, err)
 	pushPolicyRefWithGit(t, remoteDir, bareDir)

--- a/cmd/entire/cli/checkpointpolicy/warning_test.go
+++ b/cmd/entire/cli/checkpointpolicy/warning_test.go
@@ -14,7 +14,7 @@ func TestRequiresUpgrade(t *testing.T) {
 	require.False(t, checkpointpolicy.RequiresUpgrade(checkpointpolicy.DefaultPolicy()))
 	require.True(t, checkpointpolicy.RequiresUpgrade(checkpointpolicy.Policy{
 		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
-		CheckpointMinVersion: "refs-v1",
+		CheckpointMinVersion: "refs-v2",
 	}))
 	require.True(t, checkpointpolicy.RequiresUpgrade(checkpointpolicy.Policy{
 		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
@@ -27,7 +27,7 @@ func TestUnsupportedWrite(t *testing.T) {
 
 	require.False(t, checkpointpolicy.UnsupportedWrite(checkpointpolicy.DefaultPolicy()))
 	require.True(t, checkpointpolicy.UnsupportedWrite(checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
+		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: checkpoint.CheckpointVersionBranchV1,
 	}))
 	require.True(t, checkpointpolicy.UnsupportedWrite(checkpointpolicy.Policy{

--- a/cmd/entire/cli/checkpointpolicy/warning_test.go
+++ b/cmd/entire/cli/checkpointpolicy/warning_test.go
@@ -42,12 +42,12 @@ func TestCanSatisfyPolicy(t *testing.T) {
 	require.True(t, checkpointpolicy.CanSatisfyPolicy(checkpointpolicy.DefaultPolicy()))
 	require.True(t, checkpointpolicy.CanSatisfyPolicy(checkpointpolicy.Policy{}))
 	require.False(t, checkpointpolicy.CanSatisfyPolicy(checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
+		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: checkpoint.CheckpointVersionBranchV1,
 	}))
 	require.False(t, checkpointpolicy.CanSatisfyPolicy(checkpointpolicy.Policy{
 		CheckpointVersion:    checkpoint.CheckpointVersionBranchV1,
-		CheckpointMinVersion: "refs-v1",
+		CheckpointMinVersion: "refs-v2",
 	}))
 }
 
@@ -55,14 +55,14 @@ func TestUnsupportedPolicyMessageIncludesSettingDetails(t *testing.T) {
 	t.Parallel()
 
 	got := checkpointpolicy.UnsupportedPolicyMessage(checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
-		CheckpointMinVersion: "refs-v1",
+		CheckpointVersion:    "refs-v2",
+		CheckpointMinVersion: "refs-v2",
 	}, "brew upgrade entire")
 
 	require.Contains(t, got, "[entire] This repository requires checkpoint support newer than this Entire CLI.")
 	require.Contains(t, got, "[entire]   brew upgrade entire")
-	require.Contains(t, got, `checkpoint_version "refs-v1" is not writable by this Entire CLI`)
-	require.Contains(t, got, `checkpoint_min_version "refs-v1" is not readable by this Entire CLI`)
+	require.Contains(t, got, `checkpoint_version "refs-v2" is not writable by this Entire CLI`)
+	require.Contains(t, got, `checkpoint_min_version "refs-v2" is not readable by this Entire CLI`)
 }
 
 func TestUnsupportedPolicyMessageEmptyForSatisfiedPolicy(t *testing.T) {

--- a/cmd/entire/cli/explain.go
+++ b/cmd/entire/cli/explain.go
@@ -713,7 +713,7 @@ func runExplainCheckpointWithLookup(ctx context.Context, w, errW io.Writer, chec
 		}
 		// Reload to get the updated summary.
 		stopLoad = startSpinner(errW, fmt.Sprintf("Reloading checkpoint %s", fullCheckpointID))
-		reopened, openErr := checkpoint.Open(ctx, lookup.repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+		reopened, openErr := checkpoint.Open(ctx, lookup.repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
 		if openErr != nil {
 			stopLoad(false)
 			return fmt.Errorf("open checkpoint store: %w", openErr)
@@ -893,7 +893,7 @@ func newExplainCheckpointLookup(ctx context.Context) (*explainCheckpointLookup, 
 	// `git fetch` fails against partial-clone repos with "did not send all
 	// necessary objects"). Falls back to a full metadata-branch fetch if
 	// fetch-pack also can't reach the blobs.
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
 	if err != nil {
 		return nil, fmt.Errorf("open checkpoint store: %w", err)
 	}

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -206,8 +206,12 @@ func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer
 	// then re-list. Falls through to the v1-branch fetch below otherwise.
 	if cpCfg, _ := settings.LoadCheckpointsConfig(ctx); checkpoint.PrimaryIsRefs(cpCfg) { //nolint:errcheck // fail-soft: bad config surfaces via Open elsewhere
 		if cid, err := id.NewCheckpointID(prefix); err == nil {
+			refName, refErr := checkpoint.RefName(cid)
+			if refErr != nil {
+				return nil, lookup
+			}
 			stop := startSpinner(errW, "Fetching checkpoint from remote")
-			fetchErr := FetchCheckpointRef(ctx, checkpoint.RefName(cid))
+			fetchErr := FetchCheckpointRef(ctx, refName)
 			stop(false)
 			if fetchErr == nil {
 				if fresh, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -12,6 +12,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/checkpointpolicy"
+	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
 	"github.com/entireio/cli/cmd/entire/cli/trailers"
 )
@@ -197,6 +198,27 @@ func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer
 	matches := matchCheckpointPrefix(lookup, prefix)
 	if len(matches) > 0 {
 		return matches, lookup
+	}
+
+	// git-refs primary: there is no single metadata branch to fetch — each
+	// checkpoint is its own ref. When the prefix is a full checkpoint ID (the
+	// Entire-Checkpoint commit trailer always is), fetch that one ref directly,
+	// then re-list. Falls through to the v1-branch fetch below otherwise.
+	if cpCfg, _ := settings.LoadCheckpointsConfig(ctx); checkpoint.PrimaryIsRefs(cpCfg) { //nolint:errcheck // fail-soft: bad config surfaces via Open elsewhere
+		if cid, err := id.NewCheckpointID(prefix); err == nil {
+			stop := startSpinner(errW, "Fetching checkpoint from remote")
+			fetchErr := FetchCheckpointRef(ctx, checkpoint.RefName(cid))
+			stop(false)
+			if fetchErr == nil {
+				if fresh, freshErr := newExplainCheckpointLookup(ctx); freshErr == nil {
+					if m := matchCheckpointPrefix(fresh, prefix); len(m) > 0 {
+						return m, fresh
+					}
+					_ = fresh.Close()
+				}
+			}
+		}
+		return nil, lookup
 	}
 
 	stop := startSpinner(errW, "Fetching checkpoint metadata from remote")

--- a/cmd/entire/cli/explain_export.go
+++ b/cmd/entire/cli/explain_export.go
@@ -206,6 +206,9 @@ func matchCheckpointPrefixWithRemoteFallback(ctx context.Context, errW io.Writer
 	// then re-list. Falls through to the v1-branch fetch below otherwise.
 	if cpCfg, _ := settings.LoadCheckpointsConfig(ctx); checkpoint.PrimaryIsRefs(cpCfg) { //nolint:errcheck // fail-soft: bad config surfaces via Open elsewhere
 		if cid, err := id.NewCheckpointID(prefix); err == nil {
+			// cid is already validated by NewCheckpointID above, so RefName can't
+			// error here; the guard is defensive — fall back to the v1-branch path
+			// rather than fetch a malformed ref.
 			refName, refErr := checkpoint.RefName(cid)
 			if refErr != nil {
 				return nil, lookup

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -97,7 +97,7 @@ func rewriteExportCheckpointVersionToRefsV1(t *testing.T, repo *git.Repository, 
 	require.NoError(t, err)
 	var summary checkpoint.CheckpointSummary
 	require.NoError(t, json.Unmarshal([]byte(content), &summary))
-	summary.CheckpointVersion = "refs-v1"
+	summary.CheckpointVersion = "refs-v2"
 	metadataJSON, err := json.Marshal(summary)
 	require.NoError(t, err)
 	metadataHash, err := checkpoint.CreateBlobFromContent(repo, metadataJSON)
@@ -160,7 +160,7 @@ func TestRunExplainExportJSONRejectsUnsupportedCheckpointVersion(t *testing.T) {
 		json:         true,
 		sessionIndex: -1,
 	})
-	require.ErrorContains(t, err, `checkpoint aaaabbbbcccc uses unsupported checkpoint_version "refs-v1"`)
+	require.ErrorContains(t, err, `checkpoint aaaabbbbcccc uses unsupported checkpoint_version "refs-v2"`)
 	require.Empty(t, stdout.String())
 }
 
@@ -312,7 +312,7 @@ func TestRunExplainExportTranscriptRejectsUnsupportedCheckpointVersion(t *testin
 
 			var stdout, stderr bytes.Buffer
 			err := runExplainExport(context.Background(), &stdout, &stderr, tt.opts)
-			require.ErrorContains(t, err, `checkpoint abcd11112222 uses unsupported checkpoint_version "refs-v1"`)
+			require.ErrorContains(t, err, `checkpoint abcd11112222 uses unsupported checkpoint_version "refs-v2"`)
 			require.Empty(t, stdout.String())
 		})
 	}

--- a/cmd/entire/cli/explain_export_test.go
+++ b/cmd/entire/cli/explain_export_test.go
@@ -79,7 +79,7 @@ func writeCheckpointForExport(t *testing.T, repo *git.Repository, cpID id.Checkp
 	require.NoError(t, store.Write(context.Background(), checkpoint.Session(opts)))
 }
 
-func rewriteExportCheckpointVersionToRefsV1(t *testing.T, repo *git.Repository, cpID id.CheckpointID) {
+func rewriteExportCheckpointVersionToRefsV2(t *testing.T, repo *git.Repository, cpID id.CheckpointID) {
 	t.Helper()
 	ctx := context.Background()
 	refName := plumbing.NewBranchReferenceName(paths.MetadataBranchName)
@@ -152,7 +152,7 @@ func TestRunExplainExportJSONRejectsUnsupportedCheckpointVersion(t *testing.T) {
 		SessionID:  "session-json-unsupported",
 		Transcript: redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n")),
 	})
-	rewriteExportCheckpointVersionToRefsV1(t, repo, cpID)
+	rewriteExportCheckpointVersionToRefsV2(t, repo, cpID)
 
 	var stdout, stderr bytes.Buffer
 	err := runExplainExport(context.Background(), &stdout, &stderr, explainExportOptions{
@@ -308,7 +308,7 @@ func TestRunExplainExportTranscriptRejectsUnsupportedCheckpointVersion(t *testin
 				SessionID:  "session-unsupported-transcript",
 				Transcript: redact.AlreadyRedacted(raw),
 			})
-			rewriteExportCheckpointVersionToRefsV1(t, repo, cpID)
+			rewriteExportCheckpointVersionToRefsV2(t, repo, cpID)
 
 			var stdout, stderr bytes.Buffer
 			err := runExplainExport(context.Background(), &stdout, &stderr, tt.opts)

--- a/cmd/entire/cli/explain_test.go
+++ b/cmd/entire/cli/explain_test.go
@@ -1002,14 +1002,14 @@ func TestLoadCheckpointForExplainRejectsUnsupportedCheckpointVersion(t *testing.
 		SessionID:  "session-explain-unsupported",
 		Transcript: redact.AlreadyRedacted([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n")),
 	})
-	rewriteExportCheckpointVersionToRefsV1(t, repo, cpID)
+	rewriteExportCheckpointVersionToRefsV2(t, repo, cpID)
 
 	lookup, err := newExplainCheckpointLookup(context.Background())
 	require.NoError(t, err)
 	defer lookup.Close()
 
 	_, _, err = loadCheckpointForExplain(context.Background(), lookup, cpID)
-	require.ErrorContains(t, err, `checkpoint bbbbccccdddd uses unsupported checkpoint_version "refs-v1"`)
+	require.ErrorContains(t, err, `checkpoint bbbbccccdddd uses unsupported checkpoint_version "refs-v2"`)
 }
 
 // Not parallel: uses t.Chdir() and package-level var stubs.

--- a/cmd/entire/cli/git_operations.go
+++ b/cmd/entire/cli/git_operations.go
@@ -534,6 +534,26 @@ func resolveCheckpointFetchTarget(ctx context.Context) string {
 	return "origin"
 }
 
+// FetchCheckpointRef fetches a single per-checkpoint ref (refs/entire/checkpoints/
+// <shard>/<id>) from the checkpoint remote into the local ref of the same name,
+// so the git-refs store can resolve a checkpoint written on another machine.
+// Best-effort: the caller treats a fetch failure as "checkpoint not found".
+func FetchCheckpointRef(ctx context.Context, ref plumbing.ReferenceName) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	fetchTarget := resolveCheckpointFetchTarget(ctx)
+	refSpec := "+" + ref.String() + ":" + ref.String()
+	if _, err := remote.Fetch(ctx, remote.FetchOptions{
+		Remote:   fetchTarget,
+		RefSpecs: []string{refSpec},
+		NoTags:   true,
+	}); err != nil {
+		return fmt.Errorf("fetch checkpoint ref %s from %s: %w", ref, fetchTarget, err)
+	}
+	return nil
+}
+
 // FetchBlobsByHash fetches specific blob objects from the remote by their SHA-1 hashes.
 // Uses "git fetch <target> <hash>" which goes through normal credential helpers,
 // unlike fetch-pack which bypasses them. Requires the server to support

--- a/cmd/entire/cli/hook_registry_test.go
+++ b/cmd/entire/cli/hook_registry_test.go
@@ -243,7 +243,7 @@ func TestShouldSkipAgentHookForPolicy(t *testing.T) {
 
 	require.False(t, shouldSkipAgentHookForPolicy(checkpointpolicy.DefaultPolicy()))
 	require.True(t, shouldSkipAgentHookForPolicy(checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
+		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: "branch-v1",
 	}))
 }

--- a/cmd/entire/cli/resume.go
+++ b/cmd/entire/cli/resume.go
@@ -213,7 +213,7 @@ func restoreByCheckpointID(ctx context.Context, w, errW io.Writer, checkpointID 
 	}
 	defer repo.Close()
 
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
 	if err != nil {
 		return nil, fmt.Errorf("open checkpoint store: %w", err)
 	}
@@ -301,7 +301,7 @@ func restoreFromCurrentBranch(ctx context.Context, w, errW io.Writer, branchName
 	checkpointID := result.checkpointIDs[0]
 	var metadata *strategy.CheckpointInfo
 
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
 	if err != nil {
 		return nil, fmt.Errorf("open checkpoint store: %w", err)
 	}
@@ -435,7 +435,7 @@ func readCheckpointInfoFromRef(
 	refs checkpoint.PersistentRefs,
 	checkpointID id.CheckpointID,
 ) (*strategy.CheckpointInfo, error) {
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{Refs: &refs, BlobFetcher: FetchBlobsByHash})
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{Refs: &refs, BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
 	if err != nil {
 		return nil, fmt.Errorf("open checkpoint store: %w", err)
 	}
@@ -1032,7 +1032,7 @@ func restoreSingleSession(ctx context.Context, w io.Writer, ag agent.Agent, sess
 		return strategy.RestoredSession{}, false, fmt.Errorf("failed to open repository: %w", repoErr)
 	}
 	defer repo.Close()
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
 	if err != nil {
 		return strategy.RestoredSession{}, false, fmt.Errorf("open checkpoint store: %w", err)
 	}

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -641,7 +641,7 @@ func TestResolveLatestCheckpointReturnsUnsupportedWhenAnyCheckpointIsUnsupported
 	newID := id.MustCheckpointID("ccc333ddd444")
 	reader := &resumeCheckpointInfoReaderStub{
 		summaries: map[id.CheckpointID]*checkpoint.CheckpointSummary{
-			unsupportedID: {CheckpointVersion: "refs-v1"},
+			unsupportedID: {CheckpointVersion: "refs-v2"},
 			newID:         {Sessions: []checkpoint.SessionFilePaths{{Metadata: "new"}}},
 		},
 		metadata: map[id.CheckpointID][]checkpoint.Metadata{
@@ -670,7 +670,7 @@ func TestResolveLatestCheckpointReturnsUnsupportedWhenNoReadableCheckpointExists
 	unsupportedID := id.MustCheckpointID("aaa111bbb222")
 	reader := &resumeCheckpointInfoReaderStub{
 		summaries: map[id.CheckpointID]*checkpoint.CheckpointSummary{
-			unsupportedID: {CheckpointVersion: "refs-v1"},
+			unsupportedID: {CheckpointVersion: "refs-v2"},
 		},
 	}
 

--- a/cmd/entire/cli/resume_test.go
+++ b/cmd/entire/cli/resume_test.go
@@ -1195,7 +1195,7 @@ func TestCheckRemoteMetadata_ReturnsUnsupportedVersionFromRemote(t *testing.T) {
 		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 		agent.AgentTypeClaudeCode,
 	)
-	rewriteExportCheckpointVersionToRefsV1(t, repo, checkpointID)
+	rewriteExportCheckpointVersionToRefsV2(t, repo, checkpointID)
 
 	localRef, err := repo.Reference(plumbing.NewBranchReferenceName(paths.MetadataBranchName), true)
 	if err != nil {

--- a/cmd/entire/cli/settings/checkpoints.go
+++ b/cmd/entire/cli/settings/checkpoints.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"os"
+	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
@@ -15,6 +17,16 @@ import (
 // ErrInvalidCheckpointsConfig is returned when a present "checkpoints" settings
 // block is malformed (e.g. a backend with no type).
 var ErrInvalidCheckpointsConfig = errors.New("invalid checkpoints config")
+
+// Environment overrides for checkpoint backend selection. When EnvCheckpointsPrimary
+// is set, it (and the optional comma-separated EnvCheckpointsMirrors) fully
+// replaces any checkpoints block in settings — env wins over file, matching the
+// other ENTIRE_* overrides (ENTIRE_LOG_LEVEL, ENTIRE_TOKEN, …). Primarily for
+// driving e2e/CI and rollout against a specific backend without editing settings.
+const (
+	EnvCheckpointsPrimary = "ENTIRE_CHECKPOINTS_PRIMARY"
+	EnvCheckpointsMirrors = "ENTIRE_CHECKPOINTS_MIRRORS"
+)
 
 // CheckpointsConfig selects checkpoint storage backends: one primary (source of
 // truth, serves all reads and writes) and zero or more mirrors (independent
@@ -52,6 +64,14 @@ type checkpointsEnvelope struct {
 // a deep-merged document). Clone preferences carry no checkpoint config and are
 // not consulted.
 func LoadCheckpointsConfig(ctx context.Context) (*CheckpointsConfig, error) {
+	// Env override wins over any settings file (precedence like ENTIRE_LOG_LEVEL).
+	if cfg, ok := checkpointsConfigFromEnv(); ok {
+		if err := cfg.validate(); err != nil {
+			return nil, err
+		}
+		return cfg, nil
+	}
+
 	base, local := checkpointsSettingsPaths(ctx)
 
 	// "local replaces base wholesale": prefer a checkpoints block from local
@@ -111,6 +131,25 @@ func rawCheckpointsBlock(ctx context.Context, filePath string) json.RawMessage {
 		return nil
 	}
 	return env.Checkpoints
+}
+
+// checkpointsConfigFromEnv builds a CheckpointsConfig from the environment when
+// EnvCheckpointsPrimary is set. Mirrors are taken from EnvCheckpointsMirrors as a
+// comma-separated list of backend types (no per-backend config blocks — the env
+// override is for backend selection only). Returns ok=false when no primary is
+// set, leaving file-based resolution in charge.
+func checkpointsConfigFromEnv() (*CheckpointsConfig, bool) {
+	primary := strings.TrimSpace(os.Getenv(EnvCheckpointsPrimary))
+	if primary == "" {
+		return nil, false
+	}
+	cfg := &CheckpointsConfig{Primary: BackendConfig{Type: primary}}
+	for _, m := range strings.Split(os.Getenv(EnvCheckpointsMirrors), ",") {
+		if t := strings.TrimSpace(m); t != "" {
+			cfg.Mirrors = append(cfg.Mirrors, BackendConfig{Type: t})
+		}
+	}
+	return cfg, true
 }
 
 func (c *CheckpointsConfig) validate() error {

--- a/cmd/entire/cli/settings/checkpoints_test.go
+++ b/cmd/entire/cli/settings/checkpoints_test.go
@@ -60,6 +60,44 @@ func TestLoadCheckpointsConfig_ParsesPrimaryAndMirrors(t *testing.T) {
 	assert.JSONEq(t, `{"path": "/tmp/x"}`, string(cfg.Mirrors[0].Config))
 }
 
+func TestLoadCheckpointsConfig_EnvOverridesPrimary(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	// A file block that the env override must replace wholesale.
+	writeFile(t, dir, "settings.json", `{"enabled": true, "checkpoints": {"primary": {"type": "git-branch"}}}`)
+	t.Setenv(EnvCheckpointsPrimary, "git-refs")
+
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "git-refs", cfg.Primary.Type)
+	assert.Empty(t, cfg.Mirrors)
+}
+
+func TestLoadCheckpointsConfig_EnvPrimaryAndMirrors(t *testing.T) {
+	newCheckpointsSettingsRepo(t)
+	t.Setenv(EnvCheckpointsPrimary, "git-refs")
+	t.Setenv(EnvCheckpointsMirrors, "git-branch, fs")
+
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "git-refs", cfg.Primary.Type)
+	require.Len(t, cfg.Mirrors, 2)
+	assert.Equal(t, "git-branch", cfg.Mirrors[0].Type)
+	assert.Equal(t, "fs", cfg.Mirrors[1].Type)
+}
+
+func TestLoadCheckpointsConfig_EmptyEnvFallsBackToFile(t *testing.T) {
+	dir := newCheckpointsSettingsRepo(t)
+	writeFile(t, dir, "settings.json", `{"enabled": true, "checkpoints": {"primary": {"type": "git-branch"}}}`)
+	t.Setenv(EnvCheckpointsPrimary, "")
+
+	cfg, err := LoadCheckpointsConfig(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "git-branch", cfg.Primary.Type, "empty env override defers to the settings file")
+}
+
 func TestLoadCheckpointsConfig_RejectsUnknownFieldInBlock(t *testing.T) {
 	dir := newCheckpointsSettingsRepo(t)
 	writeFile(t, dir, "settings.json", `{"enabled": true, "checkpoints": {"primary": {"type": "git"}, "bogus": 1}}`)

--- a/cmd/entire/cli/strategy/checkpoint_policy_test.go
+++ b/cmd/entire/cli/strategy/checkpoint_policy_test.go
@@ -170,7 +170,7 @@ func TestPrePushWarnsAndSkipsCheckpointPushWhenPolicyUnsupported(t *testing.T) {
 		_ = repo.Close()
 	})
 	_, err = checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
+		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: "branch-v1",
 	})
 	require.NoError(t, err)
@@ -210,7 +210,7 @@ func TestPrePushWarnsAndPushesWhenPolicyDiverged(t *testing.T) {
 	localHash, err := checkpointpolicy.WriteLocal(t.Context(), repo, baseHash, checkpointpolicy.DefaultPolicy())
 	require.NoError(t, err)
 	_, err = checkpointpolicy.WriteLocal(t.Context(), repo, baseHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
+		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: "branch-v1",
 	})
 	require.NoError(t, err)
@@ -251,7 +251,7 @@ func TestSyncCheckpointPolicyForPrePushUsesPushTarget(t *testing.T) {
 	})
 
 	_, err = checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
+		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: "branch-v1",
 	})
 	require.NoError(t, err)
@@ -277,7 +277,7 @@ func TestSyncCheckpointPolicyForPrePushUsesPushTarget(t *testing.T) {
 func writeUnsupportedCheckpointPolicy(t *testing.T, repo *git.Repository) {
 	t.Helper()
 	_, err := checkpointpolicy.WriteLocal(t.Context(), repo, plumbing.ZeroHash, checkpointpolicy.Policy{
-		CheckpointVersion:    "refs-v1",
+		CheckpointVersion:    "refs-v2",
 		CheckpointMinVersion: "branch-v1",
 	})
 	require.NoError(t, err)

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/go-git/go-git/v6/plumbing"
+
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -172,18 +174,34 @@ func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pus
 	}
 
 	pushCtx, pushSpan := perf.Start(ctx, "push_checkpoint_refs")
-	pushErr := batchPushRefs(pushCtx, ps.pushTarget(), existing)
-	pushSpan.End()
-	if pushErr != nil {
-		// Leave the refs queued; the next pre-push retries. Non-fatal so the
-		// user's push proceeds. The push is fast-forward-only, so this can mean a
-		// checkpoint ref diverged on the remote (non-fast-forward) — we leave it
-		// queued rather than force-overwriting it.
-		logging.Warn(ctx, "git-refs pre-push: checkpoint ref push failed (possible non-fast-forward divergence); refs left queued, not overwritten",
-			slog.String("error", pushErr.Error()))
+	defer pushSpan.End()
+
+	// Fast path: push all refs in one round-trip (fast-forward-only). If every
+	// ref was up to date or fast-forwarded, we're done.
+	if err := batchPushRefs(pushCtx, ps.pushTarget(), existing); err == nil {
+		if removeErr := queue.Remove(existing); removeErr != nil {
+			logging.Warn(ctx, "git-refs pre-push: clear pushed refs from queue failed",
+				slog.String("error", removeErr.Error()))
+		}
+		cleanupPushedShadowBranches(ctx)
 		return nil
 	}
-	if err := queue.Remove(existing); err != nil {
+
+	// At least one ref was rejected — typically a non-fast-forward divergence
+	// (the same checkpoint re-written on another machine). Retry per ref with
+	// fetch+replay recovery, and remove from the queue only the refs that land
+	// (a genuine cherry-pick conflict leaves that ref queued for a later push,
+	// never force-overwriting the remote).
+	pushed := make([]plumbing.ReferenceName, 0, len(existing))
+	for _, ref := range existing {
+		if err := pushCheckpointRefWithRecovery(pushCtx, ps.pushTarget(), ref); err != nil {
+			logging.Warn(ctx, "git-refs pre-push: checkpoint ref push/sync failed; left queued, not overwritten",
+				slog.String("ref", ref.String()), slog.String("error", err.Error()))
+			continue
+		}
+		pushed = append(pushed, ref)
+	}
+	if err := queue.Remove(pushed); err != nil {
 		logging.Warn(ctx, "git-refs pre-push: clear pushed refs from queue failed",
 			slog.String("error", err.Error()))
 	}

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -136,7 +136,16 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 // swallowed — like the v1 path, they must not block the user's git push — and the
 // refs stay queued for the next pre-push. OPF is not applied (it is descoped for
 // the git-refs store for now).
+//
+// It honors the checkpoint policy exactly like the v1 path: the policy gates on
+// checkpoint *format* compatibility (diverged from the remote, or an unsupported
+// local format), which is independent of the storage backend, so a blocked
+// policy skips the ref push (leaving refs queued) rather than pushing.
 func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pushSettings) error {
+	if !syncCheckpointPolicyForPrePush(ctx, ps) {
+		return nil
+	}
+
 	repo, err := OpenRepository(ctx)
 	if err != nil {
 		logging.Warn(ctx, "git-refs pre-push: open repo failed; skipping checkpoint push",

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -43,6 +43,13 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 		return nil
 	}
 
+	// git-refs primary: push the per-checkpoint refs recorded in the push queue
+	// instead of the single v1 branch. (A configured git-branch mirror's v1 ref
+	// is not pushed here yet — mirror push for downgrade safety is a later step.)
+	if cpCfg, _ := settings.LoadCheckpointsConfig(ctx); checkpoint.PrimaryIsRefs(cpCfg) { //nolint:errcheck // fail-soft: a bad checkpoints block already surfaces via Open; default to no refs push
+		return s.prePushCheckpointRefs(ctx, ps)
+	}
+
 	refs := checkpoint.ResolveRefs(ctx)
 	repo, repoErr := OpenRepository(ctx)
 	if repoErr != nil {
@@ -117,10 +124,76 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 	}
 	pushCheckpointsSpan.End()
 
-	// Post-push cleanup: only when all configured checkpoint refs were pushed
-	// successfully, so we know condensed checkpoint data reached the remote.
-	// Failures here are non-fatal — shadow branches just accumulate until
-	// `entire clean` or the next successful push.
+	cleanupPushedShadowBranches(ctx)
+	return nil
+}
+
+// prePushCheckpointRefs drains the per-checkpoint push queue and batch force-pushes
+// the recorded refs (git-refs primary). Transient push failures are logged and
+// swallowed — like the v1 path, they must not block the user's git push — and the
+// refs stay queued for the next pre-push. OPF is not applied (it is descoped for
+// the git-refs store for now).
+func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pushSettings) error {
+	repo, err := OpenRepository(ctx)
+	if err != nil {
+		logging.Warn(ctx, "git-refs pre-push: open repo failed; skipping checkpoint push",
+			slog.String("error", err.Error()))
+		return nil
+	}
+	defer repo.Close()
+
+	queue, err := checkpoint.PushQueueForRepo(ctx, repo)
+	if err != nil {
+		logging.Warn(ctx, "git-refs pre-push: resolve push queue failed; skipping checkpoint push",
+			slog.String("error", err.Error()))
+		return nil
+	}
+	queued, err := queue.Drain()
+	if err != nil {
+		logging.Warn(ctx, "git-refs pre-push: drain push queue failed; skipping checkpoint push",
+			slog.String("error", err.Error()))
+		return nil
+	}
+	if len(queued) == 0 {
+		return nil
+	}
+
+	// Drop stale entries (refs no longer present locally) so they don't block
+	// the queue forever, then push what remains.
+	existing, stale := partitionLocalRefs(repo, queued)
+	if len(stale) > 0 {
+		if err := queue.Remove(stale); err != nil {
+			logging.Warn(ctx, "git-refs pre-push: prune stale queue entries failed",
+				slog.String("error", err.Error()))
+		}
+	}
+	if len(existing) == 0 {
+		return nil
+	}
+
+	pushCtx, pushSpan := perf.Start(ctx, "push_checkpoint_refs")
+	pushErr := batchForcePushRefs(pushCtx, ps.pushTarget(), existing)
+	pushSpan.End()
+	if pushErr != nil {
+		// Leave the refs queued; the next pre-push retries. Non-fatal so the
+		// user's push proceeds.
+		logging.Warn(ctx, "git-refs pre-push: batch push failed; refs left queued for retry",
+			slog.String("error", pushErr.Error()))
+		return nil
+	}
+	if err := queue.Remove(existing); err != nil {
+		logging.Warn(ctx, "git-refs pre-push: clear pushed refs from queue failed",
+			slog.String("error", err.Error()))
+	}
+
+	cleanupPushedShadowBranches(ctx)
+	return nil
+}
+
+// cleanupPushedShadowBranches runs post-push shadow-branch cleanup. Failures are
+// non-fatal — shadow branches just accumulate until `entire clean` or the next
+// successful push.
+func cleanupPushedShadowBranches(ctx context.Context) {
 	if deleted, cleanupErr := CleanupPushedShadowBranches(ctx); cleanupErr != nil {
 		logging.Warn(ctx, "post-push shadow branch cleanup failed",
 			slog.String("error", cleanupErr.Error()),
@@ -130,6 +203,4 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 			slog.Int("count", deleted),
 		)
 	}
-
-	return nil
 }

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -172,12 +172,14 @@ func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pus
 	}
 
 	pushCtx, pushSpan := perf.Start(ctx, "push_checkpoint_refs")
-	pushErr := batchForcePushRefs(pushCtx, ps.pushTarget(), existing)
+	pushErr := batchPushRefs(pushCtx, ps.pushTarget(), existing)
 	pushSpan.End()
 	if pushErr != nil {
 		// Leave the refs queued; the next pre-push retries. Non-fatal so the
-		// user's push proceeds.
-		logging.Warn(ctx, "git-refs pre-push: batch push failed; refs left queued for retry",
+		// user's push proceeds. The push is fast-forward-only, so this can mean a
+		// checkpoint ref diverged on the remote (non-fast-forward) — we leave it
+		// queued rather than force-overwriting it.
+		logging.Warn(ctx, "git-refs pre-push: checkpoint ref push failed (possible non-fast-forward divergence); refs left queued, not overwritten",
 			slog.String("error", pushErr.Error()))
 		return nil
 	}

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -142,10 +142,6 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 // local format), which is independent of the storage backend, so a blocked
 // policy skips the ref push (leaving refs queued) rather than pushing.
 func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pushSettings) error {
-	if !syncCheckpointPolicyForPrePush(ctx, ps) {
-		return nil
-	}
-
 	repo, err := OpenRepository(ctx)
 	if err != nil {
 		logging.Warn(ctx, "git-refs pre-push: open repo failed; skipping checkpoint push",
@@ -153,6 +149,14 @@ func (s *ManualCommitStrategy) prePushCheckpointRefs(ctx context.Context, ps pus
 		return nil
 	}
 	defer repo.Close()
+
+	// Refresh the checkpoint policy from the remote, then skip the ref push
+	// (leaving refs queued) if the policy is diverged or the local format is
+	// unsupported — same gate the v1 path uses.
+	syncCheckpointPolicyForPrePush(ctx, repo, ps)
+	if !checkpointPolicyAllowsGitHook(ctx, repo) {
+		return nil
+	}
 
 	queue, err := checkpoint.PushQueueForRepo(ctx, repo)
 	if err != nil {

--- a/cmd/entire/cli/strategy/manual_commit_push.go
+++ b/cmd/entire/cli/strategy/manual_commit_push.go
@@ -130,8 +130,9 @@ func (s *ManualCommitStrategy) PrePush(ctx context.Context, remote string) error
 	return nil
 }
 
-// prePushCheckpointRefs drains the per-checkpoint push queue and batch force-pushes
-// the recorded refs (git-refs primary). Transient push failures are logged and
+// prePushCheckpointRefs drains the per-checkpoint push queue and batch-pushes the
+// recorded refs fast-forward-only (git-refs primary; never a force push — a
+// diverged ref is recovered via fetch+replay). Transient push failures are logged and
 // swallowed — like the v1 path, they must not block the user's git push — and the
 // refs stay queued for the next pre-push. OPF is not applied (it is descoped for
 // the git-refs store for now).

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -28,11 +28,18 @@ import (
 // rather than retrying them forever.
 func partitionLocalRefs(repo *git.Repository, refs []plumbing.ReferenceName) (existing, stale []plumbing.ReferenceName) {
 	for _, ref := range refs {
-		if _, err := repo.Reference(ref, false); err != nil {
+		_, err := repo.Reference(ref, false)
+		switch {
+		case err == nil:
+			existing = append(existing, ref)
+		case errors.Is(err, plumbing.ErrReferenceNotFound):
+			// Genuinely gone (e.g. deleted by cleanup) — never pushable, drop it.
 			stale = append(stale, ref)
-			continue
+		default:
+			// A transient/IO lookup error: keep the ref as pushable so a real
+			// entry isn't dropped from the queue forever over a flaky read.
+			existing = append(existing, ref)
 		}
-		existing = append(existing, ref)
 	}
 	return existing, stale
 }

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -45,10 +45,9 @@ func partitionLocalRefs(repo *git.Repository, refs []plumbing.ReferenceName) (ex
 // differently on another machine — is REJECTED rather than silently overwriting
 // the remote. We deliberately do not force: there is no server-side ref
 // protection, so a force push would make a buggy or racing client clobber good
-// remote history with no signal. On rejection the whole push errors and the
-// caller leaves the refs queued (not overwritten) for a later pre-push;
-// reconciling a genuinely diverged ref is deferred (a future rewrite path, e.g.
-// OPF, would use --force-with-lease for the cases that must replace a ref).
+// remote history with no signal. On rejection the whole push errors; the caller
+// retries the rejected refs individually with fetch+replay recovery
+// (pushCheckpointRefWithRecovery).
 func batchPushRefs(ctx context.Context, target string, refs []plumbing.ReferenceName) error {
 	if len(refs) == 0 {
 		return nil
@@ -61,6 +60,31 @@ func batchPushRefs(ctx context.Context, target string, refs []plumbing.Reference
 		return fmt.Errorf("push %d checkpoint refs: %w", len(refs), err)
 	}
 	return nil
+}
+
+// pushCheckpointRefWithRecovery pushes a single checkpoint ref fast-forward-only;
+// on rejection — typically the ref diverged on the remote (the same checkpoint
+// re-written elsewhere) — it fetches the remote ref and replays the local-only
+// commits on top via fetchAndRebaseRefCommon, then retries. The retry is still
+// non-force: after the replay the local ref is a fast-forward over the remote, so
+// the remote commit is preserved as an ancestor rather than overwritten. The
+// cherry-pick is delta-based, so non-overlapping changes merge; a genuine overlap
+// (e.g. both sides rewrote the root metadata.json) surfaces as a rebase error and
+// the ref is left for a later pre-push. Returns nil only if the ref reached the
+// remote.
+func pushCheckpointRefWithRecovery(ctx context.Context, target string, ref plumbing.ReferenceName) error {
+	// One shared budget across the initial push, fetch+replay, and retry, matching
+	// doPushRef (fetchAndRebaseRefCommon relies on the caller's deadline).
+	ctx, cancel := context.WithTimeout(ctx, checkpointPushBudget)
+	defer cancel()
+
+	if err := batchPushRefs(ctx, target, []plumbing.ReferenceName{ref}); err == nil {
+		return nil
+	}
+	if err := fetchAndRebaseRefCommon(ctx, target, ref); err != nil {
+		return fmt.Errorf("sync diverged checkpoint ref %s: %w", ref, err)
+	}
+	return batchPushRefs(ctx, target, []plumbing.ReferenceName{ref})
 }
 
 // pushRefIfNeeded pushes a ref to the given target if it has unpushed changes.

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -22,6 +22,43 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
+// partitionLocalRefs splits refs into those that exist locally (pushable) and
+// those that don't (stale queue entries — e.g. a checkpoint ref deleted by
+// cleanup). Stale refs can never push, so callers drop them from the queue
+// rather than retrying them forever.
+func partitionLocalRefs(repo *git.Repository, refs []plumbing.ReferenceName) (existing, stale []plumbing.ReferenceName) {
+	for _, ref := range refs {
+		if _, err := repo.Reference(ref, false); err != nil {
+			stale = append(stale, ref)
+			continue
+		}
+		existing = append(existing, ref)
+	}
+	return existing, stale
+}
+
+// batchForcePushRefs pushes all of refs to target in a single git push. Each
+// uses a force refspec (+ref:ref), matching how non-branch checkpoint refs are
+// already pushed: per-checkpoint refs have independent histories with no
+// remote-tracking shadow, so there is no fast-forward to preserve and no
+// fetch+rebase recovery to attempt. Batching keeps a backfill of many refs to
+// one network round-trip. It is all-or-nothing: on error the caller leaves every
+// ref queued for the next pre-push (partial-failure reconciliation is out of
+// scope for now).
+func batchForcePushRefs(ctx context.Context, target string, refs []plumbing.ReferenceName) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	refSpecs := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		refSpecs = append(refSpecs, "+"+ref.String()+":"+ref.String())
+	}
+	if _, err := remote.PushWithOptions(ctx, remote.PushOptions{Remote: target, RefSpecs: refSpecs}); err != nil {
+		return fmt.Errorf("batch push %d checkpoint refs: %w", len(refs), err)
+	}
+	return nil
+}
+
 // pushRefIfNeeded pushes a ref to the given target if it has unpushed changes.
 // The target can be a remote name (e.g., "origin") or a URL for direct push.
 // For branch refs, the "has unpushed" optimization consults the remote-tracking

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -299,12 +299,16 @@ func finishPush(ctx context.Context, stop func(string), result pushResult, targe
 
 // tryPushRefCommon attempts to push a ref. No timeout of its own —
 // runs under doPushRef's shared budget. Branch refs use a bare branch-name
-// refSpec so existing remote-tracking works; non-branch refs use a force
-// refspec ("+refs/...:refs/...") with no tracking shadow.
+// refSpec so existing remote-tracking works; non-branch refs use an explicit
+// "refs/...:refs/..." refSpec with no tracking shadow. Neither forces: a
+// non-fast-forward is rejected so doPushRef's fetch+rebase recovery runs (and a
+// genuinely diverged ref is never silently overwritten — there is no
+// server-side ref protection). This keeps one consistent non-force policy for
+// every checkpoint ref, branch or per-checkpoint.
 func tryPushRefCommon(ctx context.Context, remoteName string, ref plumbing.ReferenceName) (pushResult, error) {
 	refSpec := ref.Short()
 	if !ref.IsBranch() {
-		refSpec = "+" + ref.String() + ":" + ref.String()
+		refSpec = ref.String() + ":" + ref.String()
 	}
 
 	// Span the actual `git push` subprocess: on a slow remote (e.g. a custom

--- a/cmd/entire/cli/strategy/push_common.go
+++ b/cmd/entire/cli/strategy/push_common.go
@@ -37,24 +37,28 @@ func partitionLocalRefs(repo *git.Repository, refs []plumbing.ReferenceName) (ex
 	return existing, stale
 }
 
-// batchForcePushRefs pushes all of refs to target in a single git push. Each
-// uses a force refspec (+ref:ref), matching how non-branch checkpoint refs are
-// already pushed: per-checkpoint refs have independent histories with no
-// remote-tracking shadow, so there is no fast-forward to preserve and no
-// fetch+rebase recovery to attempt. Batching keeps a backfill of many refs to
-// one network round-trip. It is all-or-nothing: on error the caller leaves every
-// ref queued for the next pre-push (partial-failure reconciliation is out of
-// scope for now).
-func batchForcePushRefs(ctx context.Context, target string, refs []plumbing.ReferenceName) error {
+// batchPushRefs pushes all of refs to target in a single git push,
+// fast-forward-only (NOT a force push). Batching keeps a backfill of many refs to
+// one network round-trip. Per-checkpoint refs normally advance by fast-forward
+// (each write parents on the prior tip), so the common case succeeds; a
+// non-fast-forward update — genuine divergence, e.g. the same checkpoint written
+// differently on another machine — is REJECTED rather than silently overwriting
+// the remote. We deliberately do not force: there is no server-side ref
+// protection, so a force push would make a buggy or racing client clobber good
+// remote history with no signal. On rejection the whole push errors and the
+// caller leaves the refs queued (not overwritten) for a later pre-push;
+// reconciling a genuinely diverged ref is deferred (a future rewrite path, e.g.
+// OPF, would use --force-with-lease for the cases that must replace a ref).
+func batchPushRefs(ctx context.Context, target string, refs []plumbing.ReferenceName) error {
 	if len(refs) == 0 {
 		return nil
 	}
 	refSpecs := make([]string, 0, len(refs))
 	for _, ref := range refs {
-		refSpecs = append(refSpecs, "+"+ref.String()+":"+ref.String())
+		refSpecs = append(refSpecs, ref.String()+":"+ref.String())
 	}
 	if _, err := remote.PushWithOptions(ctx, remote.PushOptions{Remote: target, RefSpecs: refSpecs}); err != nil {
-		return fmt.Errorf("batch push %d checkpoint refs: %w", len(refs), err)
+		return fmt.Errorf("push %d checkpoint refs: %w", len(refs), err)
 	}
 	return nil
 }

--- a/cmd/entire/cli/strategy/refs_push_test.go
+++ b/cmd/entire/cli/strategy/refs_push_test.go
@@ -16,6 +16,14 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/testutil"
 )
 
+// mustRefName builds a checkpoint ref for a known-valid ID in tests.
+func mustRefName(t *testing.T, cid id.CheckpointID) plumbing.ReferenceName {
+	t.Helper()
+	ref, err := checkpoint.RefName(cid)
+	require.NoError(t, err)
+	return ref
+}
+
 // setupRepoWithCheckpointRefs creates a work repo with two per-checkpoint refs
 // pointing at HEAD, plus a fresh bare remote. Returns (workDir, bareDir, refs).
 func setupRepoWithCheckpointRefs(t *testing.T) (string, string, []plumbing.ReferenceName) {
@@ -34,8 +42,8 @@ func setupRepoWithCheckpointRefs(t *testing.T) (string, string, []plumbing.Refer
 	require.NoError(t, err)
 
 	refs := []plumbing.ReferenceName{
-		checkpoint.RefName(id.MustCheckpointID("a1b2c3d4e5f6")),
-		checkpoint.RefName(id.MustCheckpointID("b2c3d4e5f6a1")),
+		mustRefName(t, id.MustCheckpointID("a1b2c3d4e5f6")),
+		mustRefName(t, id.MustCheckpointID("b2c3d4e5f6a1")),
 	}
 	for _, ref := range refs {
 		require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(ref, head.Hash())))
@@ -57,7 +65,7 @@ func TestPartitionLocalRefs(t *testing.T) {
 	repo, err := git.PlainOpen(workDir)
 	require.NoError(t, err)
 
-	stale := checkpoint.RefName(id.MustCheckpointID("ffffffffffff"))
+	stale := mustRefName(t, id.MustCheckpointID("ffffffffffff"))
 	existing, missing := partitionLocalRefs(repo, append([]plumbing.ReferenceName{stale}, refs...))
 
 	assert.ElementsMatch(t, refs, existing, "local refs are pushable")

--- a/cmd/entire/cli/strategy/refs_push_test.go
+++ b/cmd/entire/cli/strategy/refs_push_test.go
@@ -152,6 +152,65 @@ func TestBatchPushRefs_RejectsNonFastForward(t *testing.T) {
 		"remote ref must be unchanged after a rejected non-fast-forward push")
 }
 
+// TestPushCheckpointRefWithRecovery_MergesDivergedRef: when a checkpoint ref has
+// diverged on the remote (the same checkpoint advanced differently elsewhere), the
+// recovery fetches the remote tip and replays the local-only commit on top, so the
+// retry is a fast-forward — preserving the remote's change instead of overwriting
+// it. Non-overlapping changes merge.
+func TestPushCheckpointRefWithRecovery_MergesDivergedRef(t *testing.T) {
+	workDir, bareDir, refs := setupRepoWithCheckpointRefs(t)
+	t.Chdir(workDir)
+	ctx := context.Background()
+	ref := refs[0]
+
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+	head := func() plumbing.Hash {
+		h, e := repo.Head()
+		require.NoError(t, e)
+		return h.Hash()
+	}
+	setRef := func(h plumbing.Hash) {
+		require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(ref, h)))
+	}
+
+	c1 := head()
+	require.NoError(t, batchPushRefs(ctx, bareDir, []plumbing.ReferenceName{ref})) // remote ref = C1
+
+	// Remote advances: C2 (child of C1) adds b.txt; point the ref at it and push.
+	testutil.WriteFile(t, workDir, "b.txt", "b")
+	testutil.GitAdd(t, workDir, "b.txt")
+	testutil.GitCommit(t, workDir, "add b")
+	setRef(head())
+	require.NoError(t, batchPushRefs(ctx, bareDir, []plumbing.ReferenceName{ref})) // remote ref = C2
+
+	// Local diverges: reset to C1 and make C3 (sibling of C2) adding c.txt.
+	testutil.GitReset(t, workDir, c1.String())
+	testutil.WriteFile(t, workDir, "c.txt", "c")
+	testutil.GitAdd(t, workDir, "c.txt")
+	testutil.GitCommit(t, workDir, "add c")
+	setRef(head())
+
+	// C3 is not a descendant of the remote's C2 → the plain push is rejected and
+	// recovery replays C3's delta onto C2.
+	require.NoError(t, pushCheckpointRefWithRecovery(ctx, bareDir, ref),
+		"diverged ref should be recovered by fetch+replay, not rejected")
+
+	files := remoteRefFiles(t, bareDir, ref)
+	assert.Contains(t, files, "b.txt", "remote-only change must be preserved (not overwritten)")
+	assert.Contains(t, files, "c.txt", "local-only change must be replayed on top")
+}
+
+// remoteRefFiles lists the files in the tree a ref points at on the bare remote.
+func remoteRefFiles(t *testing.T, bareDir string, ref plumbing.ReferenceName) string {
+	t.Helper()
+	c := exec.CommandContext(context.Background(), "git", "-C", bareDir, "ls-tree", "-r", "--name-only", ref.String())
+	c.Env = testutil.GitIsolatedEnv()
+	out, err := c.CombinedOutput()
+	require.NoError(t, err, "ls-tree failed: %s", out)
+	return string(out)
+}
+
 // remoteRefHash returns the object hash a ref points at on the bare remote.
 func remoteRefHash(t *testing.T, bareDir string, ref plumbing.ReferenceName) string {
 	t.Helper()

--- a/cmd/entire/cli/strategy/refs_push_test.go
+++ b/cmd/entire/cli/strategy/refs_push_test.go
@@ -1,0 +1,117 @@
+package strategy
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+)
+
+// setupRepoWithCheckpointRefs creates a work repo with two per-checkpoint refs
+// pointing at HEAD, plus a fresh bare remote. Returns (workDir, bareDir, refs).
+func setupRepoWithCheckpointRefs(t *testing.T) (string, string, []plumbing.ReferenceName) {
+	t.Helper()
+	ctx := context.Background()
+
+	workDir := t.TempDir()
+	testutil.InitRepo(t, workDir)
+	testutil.WriteFile(t, workDir, "README.md", "# test")
+	testutil.GitAdd(t, workDir, "README.md")
+	testutil.GitCommit(t, workDir, "init")
+
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+	head, err := repo.Head()
+	require.NoError(t, err)
+
+	refs := []plumbing.ReferenceName{
+		checkpoint.RefName(id.MustCheckpointID("a1b2c3d4e5f6")),
+		checkpoint.RefName(id.MustCheckpointID("b2c3d4e5f6a1")),
+	}
+	for _, ref := range refs {
+		require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(ref, head.Hash())))
+	}
+
+	bareDir := t.TempDir()
+	initCmd := exec.CommandContext(ctx, "git", "init", "--bare")
+	initCmd.Dir = bareDir
+	initCmd.Env = testutil.GitIsolatedEnv()
+	out, err := initCmd.CombinedOutput()
+	require.NoError(t, err, "git init --bare failed: %s", out)
+
+	return workDir, bareDir, refs
+}
+
+func TestPartitionLocalRefs(t *testing.T) {
+	t.Parallel()
+	workDir, _, refs := setupRepoWithCheckpointRefs(t)
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+
+	stale := checkpoint.RefName(id.MustCheckpointID("ffffffffffff"))
+	existing, missing := partitionLocalRefs(repo, append([]plumbing.ReferenceName{stale}, refs...))
+
+	assert.ElementsMatch(t, refs, existing, "local refs are pushable")
+	assert.Equal(t, []plumbing.ReferenceName{stale}, missing, "absent ref is stale")
+}
+
+func TestBatchForcePushRefs(t *testing.T) {
+	workDir, bareDir, refs := setupRepoWithCheckpointRefs(t)
+	t.Chdir(workDir)
+
+	require.NoError(t, batchForcePushRefs(context.Background(), bareDir, refs))
+
+	// All refs now exist on the bare remote.
+	lsCmd := exec.CommandContext(context.Background(), "git", "ls-remote", bareDir)
+	lsCmd.Env = testutil.GitIsolatedEnv()
+	out, err := lsCmd.CombinedOutput()
+	require.NoError(t, err, "ls-remote failed: %s", out)
+	remoteRefs := string(out)
+	for _, ref := range refs {
+		assert.Contains(t, remoteRefs, ref.String(), "ref should be present on the remote after batch push")
+	}
+}
+
+func TestBatchForcePushRefs_Empty(t *testing.T) {
+	t.Parallel()
+	// No refs → no git invocation, no error.
+	require.NoError(t, batchForcePushRefs(context.Background(), "unused-target", nil))
+}
+
+func TestBatchForcePushRefs_IsForcePush(t *testing.T) {
+	workDir, bareDir, refs := setupRepoWithCheckpointRefs(t)
+	t.Chdir(workDir)
+	ctx := context.Background()
+
+	// First push establishes the refs on the remote.
+	require.NoError(t, batchForcePushRefs(ctx, bareDir, refs))
+
+	// Re-point one ref at a new (unrelated, non-fast-forward) commit and push
+	// again. A non-force push would be rejected; the force refspec must succeed.
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+	testutil.WriteFile(t, workDir, "two.txt", "second")
+	testutil.GitAdd(t, workDir, "two.txt")
+	testutil.GitCommit(t, workDir, "second")
+	head2, err := repo.Head()
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refs[0], head2.Hash())))
+
+	require.NoError(t, batchForcePushRefs(ctx, bareDir, refs[:1]), "force push must overwrite the remote ref")
+
+	lsCmd := exec.CommandContext(ctx, "git", "ls-remote", bareDir, refs[0].String())
+	lsCmd.Env = testutil.GitIsolatedEnv()
+	out, err := lsCmd.CombinedOutput()
+	require.NoError(t, err, "ls-remote failed: %s", out)
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(string(out)), head2.Hash().String()),
+		"remote ref should now point at the new commit")
+}

--- a/cmd/entire/cli/strategy/refs_push_test.go
+++ b/cmd/entire/cli/strategy/refs_push_test.go
@@ -64,11 +64,11 @@ func TestPartitionLocalRefs(t *testing.T) {
 	assert.Equal(t, []plumbing.ReferenceName{stale}, missing, "absent ref is stale")
 }
 
-func TestBatchForcePushRefs(t *testing.T) {
+func TestBatchPushRefs(t *testing.T) {
 	workDir, bareDir, refs := setupRepoWithCheckpointRefs(t)
 	t.Chdir(workDir)
 
-	require.NoError(t, batchForcePushRefs(context.Background(), bareDir, refs))
+	require.NoError(t, batchPushRefs(context.Background(), bareDir, refs))
 
 	// All refs now exist on the bare remote.
 	lsCmd := exec.CommandContext(context.Background(), "git", "ls-remote", bareDir)
@@ -81,22 +81,22 @@ func TestBatchForcePushRefs(t *testing.T) {
 	}
 }
 
-func TestBatchForcePushRefs_Empty(t *testing.T) {
+func TestBatchPushRefs_Empty(t *testing.T) {
 	t.Parallel()
 	// No refs → no git invocation, no error.
-	require.NoError(t, batchForcePushRefs(context.Background(), "unused-target", nil))
+	require.NoError(t, batchPushRefs(context.Background(), "unused-target", nil))
 }
 
-func TestBatchForcePushRefs_IsForcePush(t *testing.T) {
+// TestBatchPushRefs_AllowsFastForward: advancing a checkpoint ref to a descendant
+// commit (the normal case) pushes fine without force.
+func TestBatchPushRefs_AllowsFastForward(t *testing.T) {
 	workDir, bareDir, refs := setupRepoWithCheckpointRefs(t)
 	t.Chdir(workDir)
 	ctx := context.Background()
 
-	// First push establishes the refs on the remote.
-	require.NoError(t, batchForcePushRefs(ctx, bareDir, refs))
+	require.NoError(t, batchPushRefs(ctx, bareDir, refs))
 
-	// Re-point one ref at a new (unrelated, non-fast-forward) commit and push
-	// again. A non-force push would be rejected; the force refspec must succeed.
+	// Advance refs[0] to a child commit (fast-forward).
 	repo, err := git.PlainOpen(workDir)
 	require.NoError(t, err)
 	testutil.WriteFile(t, workDir, "two.txt", "second")
@@ -106,12 +106,52 @@ func TestBatchForcePushRefs_IsForcePush(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refs[0], head2.Hash())))
 
-	require.NoError(t, batchForcePushRefs(ctx, bareDir, refs[:1]), "force push must overwrite the remote ref")
+	require.NoError(t, batchPushRefs(ctx, bareDir, refs[:1]), "fast-forward update should push without force")
+	assert.Equal(t, head2.Hash().String(), remoteRefHash(t, bareDir, refs[0]),
+		"remote ref should advance to the descendant commit")
+}
 
-	lsCmd := exec.CommandContext(ctx, "git", "ls-remote", bareDir, refs[0].String())
+// TestBatchPushRefs_RejectsNonFastForward: a divergent (non-descendant) update is
+// rejected, and the remote ref is left untouched — the safety property that
+// distinguishes this from a force push (we have no server-side ref protection).
+func TestBatchPushRefs_RejectsNonFastForward(t *testing.T) {
+	workDir, bareDir, refs := setupRepoWithCheckpointRefs(t)
+	t.Chdir(workDir)
+	ctx := context.Background()
+
+	require.NoError(t, batchPushRefs(ctx, bareDir, refs))
+	original := remoteRefHash(t, bareDir, refs[0])
+
+	// Point refs[0] at an orphan commit (no parent) — not a descendant of what was
+	// pushed, so the update is non-fast-forward.
+	runGit := func(args ...string) string {
+		c := exec.CommandContext(ctx, "git", args...)
+		c.Dir = workDir
+		c.Env = testutil.GitIsolatedEnv()
+		out, gitErr := c.CombinedOutput()
+		require.NoError(t, gitErr, "git %v failed: %s", args, out)
+		return strings.TrimSpace(string(out))
+	}
+	tree := runGit("rev-parse", "HEAD^{tree}")
+	orphan := runGit("commit-tree", tree, "-m", "divergent")
+	repo, err := git.PlainOpen(workDir)
+	require.NoError(t, err)
+	require.NoError(t, repo.Storer.SetReference(plumbing.NewHashReference(refs[0], plumbing.NewHash(orphan))))
+
+	err = batchPushRefs(ctx, bareDir, refs[:1])
+	require.Error(t, err, "a non-fast-forward update must be rejected, not force-pushed")
+	assert.Equal(t, original, remoteRefHash(t, bareDir, refs[0]),
+		"remote ref must be unchanged after a rejected non-fast-forward push")
+}
+
+// remoteRefHash returns the object hash a ref points at on the bare remote.
+func remoteRefHash(t *testing.T, bareDir string, ref plumbing.ReferenceName) string {
+	t.Helper()
+	lsCmd := exec.CommandContext(context.Background(), "git", "ls-remote", bareDir, ref.String())
 	lsCmd.Env = testutil.GitIsolatedEnv()
 	out, err := lsCmd.CombinedOutput()
 	require.NoError(t, err, "ls-remote failed: %s", out)
-	assert.True(t, strings.HasPrefix(strings.TrimSpace(string(out)), head2.Hash().String()),
-		"remote ref should now point at the new commit")
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	require.NotEmpty(t, fields, "ref %s not found on remote", ref)
+	return fields[0]
 }

--- a/cmd/entire/cli/tokens_profile.go
+++ b/cmd/entire/cli/tokens_profile.go
@@ -113,7 +113,7 @@ func runTokensProfile(ctx context.Context, cmd *cobra.Command, jsonOutput bool, 
 	}
 	defer repo.Close()
 
-	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash})
+	stores, err := checkpoint.Open(ctx, repo, checkpoint.OpenOptions{BlobFetcher: FetchBlobsByHash, RefFetcher: FetchCheckpointRef})
 	if err != nil {
 		return fmt.Errorf("failed to open checkpoint stores: %w", err)
 	}

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -54,6 +54,7 @@ e2e/
 | `E2E_ENTIRE_BIN` | Path to a pre-built `entire` binary | builds from source |
 | `E2E_TIMEOUT` | Timeout per prompt | `2m` |
 | `E2E_KEEP_REPOS` | Set to `1` to preserve temp repos after test | unset |
+| `E2E_CHECKPOINT_STORE` | Checkpoint backend to run the suite against (`git-branch`, `git-refs`). Maps to the `ENTIRE_CHECKPOINTS_PRIMARY` override that every spawned binary/hook honors. | `git-branch` |
 | `E2E_ARTIFACT_DIR` | Override artifact output directory | `e2e/artifacts/<timestamp>` |
 | `ANTHROPIC_API_KEY` | Required for Claude Code | — |
 | `GEMINI_API_KEY` | Required for Gemini CLI | — |

--- a/e2e/tests/alternates_test.go
+++ b/e2e/tests/alternates_test.go
@@ -25,7 +25,7 @@ import (
 // checkpoint commits, even though git itself resolves them.
 func TestAlternates_RelativeObjectAlternate_CheckpointSync(t *testing.T) {
 	if testutil.UsingGitRefs() {
-		t.Skip("git-branch-specific: exercises the v1 checkpoint branch's non-fast-forward push/rebase sync over an object alternate; the git-refs store force-pushes independent per-checkpoint refs with no such rebase path")
+		t.Skip("git-branch-specific: exercises the v1 checkpoint branch's non-fast-forward push/rebase sync over an object alternate; the git-refs store writes independent per-checkpoint refs (fast-forward push with fetch+replay recovery) and has no such v1-branch rebase path")
 	}
 	// Siblings under one parent so the relative alternate path is short and
 	// mirrors a real shared-clone layout.

--- a/e2e/tests/alternates_test.go
+++ b/e2e/tests/alternates_test.go
@@ -24,6 +24,9 @@ import (
 // collectCommitsSince() fails with "object not found" on alternate-resident
 // checkpoint commits, even though git itself resolves them.
 func TestAlternates_RelativeObjectAlternate_CheckpointSync(t *testing.T) {
+	if testutil.UsingGitRefs() {
+		t.Skip("git-branch-specific: exercises the v1 checkpoint branch's non-fast-forward push/rebase sync over an object alternate; the git-refs store force-pushes independent per-checkpoint refs with no such rebase path")
+	}
 	// Siblings under one parent so the relative alternate path is short and
 	// mirrors a real shared-clone layout.
 	parent := t.TempDir()

--- a/e2e/tests/attach_test.go
+++ b/e2e/tests/attach_test.go
@@ -68,7 +68,7 @@ func TestAttachSessionAddsToExistingCheckpoint(t *testing.T) {
 		require.NoError(t, err, "agent failed")
 
 		checkpointBefore := ""
-		if _, refErr := testutil.GitOutputErr(s.Dir, "rev-parse", "--verify", testutil.CheckpointVerifyRef()); refErr == nil {
+		if testutil.CheckpointsPresent(s.Dir) {
 			checkpointBefore = testutil.CurrentCheckpointRef(t, s.Dir)
 		}
 

--- a/e2e/tests/edge_cases_test.go
+++ b/e2e/tests/edge_cases_test.go
@@ -28,7 +28,7 @@ func TestAgentContinuesAfterCommit(t *testing.T) {
 
 		testutil.WaitForCheckpoint(t, s, 30*time.Second)
 		cpID1 := testutil.AssertHasCheckpointTrailer(t, s.Dir, "HEAD")
-		cpBranchAfterFirst := testutil.GitOutput(t, s.Dir, "rev-parse", "entire/checkpoints/v1")
+		cpBranchAfterFirst := testutil.CheckpointState(s.Dir)
 
 		// Second prompt — agent creates another file, user commits.
 		_, err = s.RunPrompt(t, ctx,
@@ -43,7 +43,7 @@ func TestAgentContinuesAfterCommit(t *testing.T) {
 		// Wait for checkpoint branch to advance past the first checkpoint.
 		deadline := time.Now().Add(15 * time.Second)
 		for time.Now().Before(deadline) {
-			after := testutil.GitOutput(t, s.Dir, "rev-parse", "entire/checkpoints/v1")
+			after := testutil.CheckpointState(s.Dir)
 			if after != cpBranchAfterFirst {
 				break
 			}

--- a/e2e/tests/explain_test.go
+++ b/e2e/tests/explain_test.go
@@ -77,8 +77,7 @@ func TestExplainCheckpointFromClonedRepo(t *testing.T) {
 		testutil.Git(t, "", "clone", bareDir, cloneDir)
 		testutil.Git(t, cloneDir, "config", "user.name", "E2E Clone")
 		testutil.Git(t, cloneDir, "config", "user.email", "e2e-clone@test.local")
-		_, err = testutil.GitOutputErr(cloneDir, "rev-parse", "--verify", testutil.CheckpointVerifyRef())
-		require.Error(t, err, "checkpoint metadata ref should not exist locally in clone before explain")
+		require.False(t, testutil.CheckpointsPresent(cloneDir), "checkpoint metadata should not exist locally in clone before explain")
 
 		entire.Enable(t, cloneDir, s.Agent.EntireAgent())
 		testutil.CommitIfDirty(t, cloneDir, "Enable entire in clone")

--- a/e2e/tests/main_test.go
+++ b/e2e/tests/main_test.go
@@ -41,6 +41,14 @@ func TestMain(m *testing.M) {
 	os.Setenv("ENTIRE_CONFIG_DIR", filepath.Join(runDir, "entire-config"))
 	os.Setenv("XDG_CACHE_HOME", filepath.Join(runDir, "entire-cache"))
 
+	// Select the checkpoint storage backend for the whole suite. E2E_CHECKPOINT_STORE
+	// (e.g. "git-refs") maps to the ENTIRE_CHECKPOINTS_PRIMARY override the spawned
+	// binary honors, so every condensation/read/push in the run exercises that
+	// backend. Unset or "git-branch" leaves the default branch backend in place.
+	if store := os.Getenv("E2E_CHECKPOINT_STORE"); store != "" && store != "git-branch" {
+		os.Setenv("ENTIRE_CHECKPOINTS_PRIMARY", store)
+	}
+
 	// Resolve the entire binary (set by mise run build via E2E_ENTIRE_BIN).
 	entireBin := entire.BinPath()
 	if err := ensureHookEntireBinary(entireBin); err != nil {

--- a/e2e/tests/resume_remote_test.go
+++ b/e2e/tests/resume_remote_test.go
@@ -59,9 +59,8 @@ func TestResumeFromClonedRepo(t *testing.T) {
 		testutil.Git(t, cloneDir, "config", "user.name", "E2E Clone")
 		testutil.Git(t, cloneDir, "config", "user.email", "e2e-clone@test.local")
 
-		// Verify the checkpoint metadata ref does NOT exist locally in the clone.
-		_, err = testutil.GitOutputErr(cloneDir, "rev-parse", "--verify", testutil.CheckpointVerifyRef())
-		require.Error(t, err, "checkpoint metadata ref should not exist locally in clone")
+		// Verify no committed checkpoint exists locally in the clone yet.
+		require.False(t, testutil.CheckpointsPresent(cloneDir), "checkpoint metadata should not exist locally in clone")
 
 		// Create the local feature branch (clone only has origin/feature as remote tracking ref).
 		// Then switch back to the default branch so resume can switch to it.
@@ -81,9 +80,8 @@ func TestResumeFromClonedRepo(t *testing.T) {
 		assert.Equal(t, "feature", current, "should be on feature branch after resume")
 		assert.Contains(t, out, "To continue", "resume output should show resume instructions")
 
-		// Verify the checkpoint metadata ref now exists locally.
-		_, err = testutil.GitOutputErr(cloneDir, "rev-parse", "--verify", testutil.CheckpointVerifyRef())
-		assert.NoError(t, err, "checkpoint metadata ref should exist locally after resume")
+		// Verify a committed checkpoint now exists locally.
+		assert.True(t, testutil.CheckpointsPresent(cloneDir), "checkpoint metadata should exist locally after resume")
 
 		if restoredTranscript, ok := testutil.RestoredSessionTranscriptPath(t, cloneDir, sessionMeta); ok {
 			_, err = os.Stat(restoredTranscript)

--- a/e2e/tests/rewind_test.go
+++ b/e2e/tests/rewind_test.go
@@ -174,7 +174,7 @@ func TestRewindSquashMergeMultipleCheckpoints(t *testing.T) {
 		s.Git(t, "add", ".")
 		s.Git(t, "commit", "-m", "Add red doc")
 		testutil.WaitForCheckpoint(t, s, 30*time.Second)
-		cp1Ref := testutil.GitOutput(t, s.Dir, "rev-parse", "entire/checkpoints/v1")
+		cp1Ref := testutil.CheckpointState(s.Dir)
 
 		_, err = s.RunPrompt(t, ctx,
 			"create a file at docs/blue.md with a paragraph about the colour blue. Do not ask for confirmation, just make the change.")

--- a/e2e/tests/session_lifecycle_test.go
+++ b/e2e/tests/session_lifecycle_test.go
@@ -68,7 +68,7 @@ func TestSessionDepletedManualEditNoCheckpoint(t *testing.T) {
 		cpID := testutil.AssertHasCheckpointTrailer(t, s.Dir, "HEAD")
 		testutil.AssertCheckpointExists(t, s.Dir, cpID)
 
-		cpBranchAfterAgent := testutil.GitOutput(t, s.Dir, "rev-parse", "entire/checkpoints/v1")
+		cpBranchAfterAgent := testutil.CheckpointState(s.Dir)
 
 		os.WriteFile(filepath.Join(s.Dir, "depleted.go"),
 			[]byte("package main\n\n// Manual user edit\nfunc Depleted() { return }\n"), 0o644)
@@ -77,9 +77,9 @@ func TestSessionDepletedManualEditNoCheckpoint(t *testing.T) {
 		s.Git(t, "commit", "-m", "Manual edit to depleted.go")
 
 		time.Sleep(5 * time.Second)
-		cpBranchAfterManual := testutil.GitOutput(t, s.Dir, "rev-parse", "entire/checkpoints/v1")
+		cpBranchAfterManual := testutil.CheckpointState(s.Dir)
 		assert.Equal(t, cpBranchAfterAgent, cpBranchAfterManual,
-			"manual edit after session depletion should not advance checkpoint branch")
+			"manual edit after session depletion should not advance checkpoint state")
 		testutil.AssertNoCheckpointTrailer(t, s.Dir, "HEAD")
 		testutil.WaitForNoShadowBranches(t, s.Dir, 10*time.Second)
 	})

--- a/e2e/testutil/artifacts.go
+++ b/e2e/testutil/artifacts.go
@@ -49,15 +49,18 @@ func artifactDir(t *testing.T) string {
 func CaptureArtifacts(t *testing.T, s *RepoState) {
 	t.Helper()
 	dir := s.ArtifactDir
-	checkpointRef := checkpointReadRef()
 
 	writeArtifact(t, dir, "git-log.txt",
 		gitOutputSafe(s.Dir, "log", "--decorate", "--graph", "--all"))
 
+	checkpointTree := "\n--- " + checkpointReadRef() + " ---\n" +
+		gitOutputSafe(s.Dir, "ls-tree", "-r", checkpointReadRef())
+	if UsingGitRefs() {
+		checkpointTree = "\n--- " + checkpointRefPrefix + " ---\n" +
+			gitOutputSafe(s.Dir, "for-each-ref", "--format=%(refname) %(objectname)", checkpointRefPrefix)
+	}
 	writeArtifact(t, dir, "git-tree.txt",
-		gitOutputSafe(s.Dir, "ls-tree", "-r", "HEAD")+
-			"\n--- "+checkpointRef+" ---\n"+
-			gitOutputSafe(s.Dir, "ls-tree", "-r", checkpointRef))
+		gitOutputSafe(s.Dir, "ls-tree", "-r", "HEAD")+checkpointTree)
 
 	// console.log is written incrementally to disk via s.ConsoleLog (*os.File),
 	// so it already exists in the artifact dir and survives global timeouts.
@@ -103,13 +106,20 @@ func captureCheckpointMetadata(t *testing.T, s *RepoState, outDir string) {
 		id := m[1]
 		cpPath := CheckpointPath(id)
 
+		// In-tree prefix: git-branch nests the checkpoint under <shard>/<id>/;
+		// git-refs has the checkpoint contents at the ref commit's tree root.
+		inTreePrefix := cpPath + "/"
+		if UsingGitRefs() {
+			inTreePrefix = ""
+		}
+
 		cpDir := filepath.Join(metaDir, cpPath)
 		_ = os.MkdirAll(cpDir, 0o755)
-		raw := gitOutputSafe(s.Dir, "show", sha+":"+cpPath+"/metadata.json")
+		raw := gitOutputSafe(s.Dir, "show", sha+":"+inTreePrefix+"metadata.json")
 		writeArtifact(t, cpDir, "metadata.json", raw)
 
 		for i := 0; ; i++ {
-			sessPath := fmt.Sprintf("%s/%d/metadata.json", cpPath, i)
+			sessPath := fmt.Sprintf("%s%d/metadata.json", inTreePrefix, i)
 			raw := gitOutputSafe(s.Dir, "show", sha+":"+sessPath)
 			if raw == "" {
 				break

--- a/e2e/testutil/assertions.go
+++ b/e2e/testutil/assertions.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,13 +91,12 @@ func WaitForCheckpoint(t *testing.T, s *RepoState, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		after := strings.TrimSpace(gitOutputSafe(s.Dir, "rev-parse", checkpointReadRef()))
-		if after != s.CheckpointBefore {
+		if CheckpointState(s.Dir) != s.CheckpointBefore {
 			return
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
-	t.Fatalf("checkpoint ref %s did not advance within %s", checkpointReadRef(), timeout)
+	t.Fatalf("checkpoint state did not advance within %s", timeout)
 }
 
 // ShadowBranches returns all shadow branches (entire/*) excluding entire/checkpoints/*.
@@ -145,18 +143,16 @@ func AssertHasShadowBranches(t *testing.T, dir string) {
 		"expected at least one shadow branch to persist, but none found")
 }
 
-// AssertCheckpointAdvanced asserts the checkpoint branch moved forward.
+// AssertCheckpointAdvanced asserts the committed checkpoint state moved forward.
 func AssertCheckpointAdvanced(t *testing.T, s *RepoState) {
 	t.Helper()
-	after := strings.TrimSpace(gitOutputSafe(s.Dir, "rev-parse", checkpointReadRef()))
-	assert.NotEqual(t, s.CheckpointBefore, after, "checkpoint branch did not advance")
+	assert.NotEqual(t, s.CheckpointBefore, CheckpointState(s.Dir), "checkpoint state did not advance")
 }
 
-// AssertCheckpointNotAdvanced asserts the checkpoint branch has NOT moved.
+// AssertCheckpointNotAdvanced asserts the committed checkpoint state has NOT moved.
 func AssertCheckpointNotAdvanced(t *testing.T, s *RepoState) {
 	t.Helper()
-	after := strings.TrimSpace(gitOutputSafe(s.Dir, "rev-parse", checkpointReadRef()))
-	assert.Equal(t, s.CheckpointBefore, after, "checkpoint branch advanced unexpectedly")
+	assert.Equal(t, s.CheckpointBefore, CheckpointState(s.Dir), "checkpoint state advanced unexpectedly")
 }
 
 // AssertCheckpointIDFormat asserts the checkpoint ID is a valid checkpoint ID:
@@ -185,8 +181,12 @@ func AssertHasCheckpointTrailer(t *testing.T, dir string, ref string) string {
 // commits from multi-commit agent turns don't cause false failures.
 func AssertCheckpointInLastN(t *testing.T, dir string, checkpointID string, n int) {
 	t.Helper()
+	logRef := checkpointReadRef()
+	if UsingGitRefs() {
+		logRef = checkpointRefName(checkpointID)
+	}
 	out := GitOutput(t, dir, "log", "--grep="+checkpointID,
-		"--format=%s", checkpointReadRef())
+		"--format=%s", logRef)
 	var lines []string
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		if line != "" {
@@ -202,6 +202,14 @@ func AssertCheckpointInLastN(t *testing.T, dir string, checkpointID string, n in
 // the checkpoint branch and that its metadata.json exists in the tree.
 func AssertCheckpointExists(t *testing.T, dir string, checkpointID string) {
 	t.Helper()
+	if UsingGitRefs() {
+		// No single branch to grep; existence is the per-checkpoint ref carrying a
+		// readable root metadata.json.
+		blob := checkpointBlobSpec(checkpointID, "metadata.json")
+		raw := gitOutputSafe(dir, "show", blob)
+		assert.NotEmpty(t, raw, "checkpoint %s metadata not found at %s", checkpointID, blob)
+		return
+	}
 	out := GitOutput(t, dir, "log", checkpointReadRef(), "--grep="+checkpointID, "--oneline")
 	assert.NotEmpty(t, out, "checkpoint %s not found on checkpoint branch", checkpointID)
 
@@ -218,6 +226,13 @@ func WaitForCheckpointExists(t *testing.T, dir string, checkpointID string, time
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
+		if UsingGitRefs() {
+			if gitOutputSafe(dir, "show", checkpointBlobSpec(checkpointID, "metadata.json")) != "" {
+				return
+			}
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
 		out := gitOutputSafe(dir, "log", checkpointReadRef(), "--grep="+checkpointID, "--oneline")
 		if out != "" {
 			path := CheckpointPath(checkpointID) + "/metadata.json"
@@ -229,7 +244,7 @@ func WaitForCheckpointExists(t *testing.T, dir string, checkpointID string, time
 		}
 		time.Sleep(200 * time.Millisecond)
 	}
-	t.Fatalf("checkpoint %s not found on checkpoint branch within %s", checkpointID, timeout)
+	t.Fatalf("checkpoint %s not found within %s", checkpointID, timeout)
 }
 
 // AssertCommitLinkedToCheckpoint asserts the trailer exists AND the
@@ -266,8 +281,7 @@ func WaitForCheckpointAdvanceFrom(t *testing.T, dir string, fromRef string, time
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		after := strings.TrimSpace(gitOutputSafe(dir, "rev-parse", checkpointReadRef()))
-		if after != fromRef {
+		if CheckpointState(dir) != fromRef {
 			return
 		}
 		time.Sleep(200 * time.Millisecond)
@@ -276,7 +290,7 @@ func WaitForCheckpointAdvanceFrom(t *testing.T, dir string, fromRef string, time
 	if len(displayRef) > 8 {
 		displayRef = displayRef[:8]
 	}
-	t.Fatalf("checkpoint ref %s did not advance from %s within %s", checkpointReadRef(), displayRef, timeout)
+	t.Fatalf("checkpoint state did not advance from %s within %s", displayRef, timeout)
 }
 
 // WaitForSessionIdle polls the session state files in .git/entire-sessions/
@@ -379,11 +393,8 @@ func ValidateCheckpointDeep(t *testing.T, dir string, v DeepCheckpointValidation
 		AssertCheckpointFilesTouched(t, dir, v.CheckpointID, v.FilesTouched)
 	}
 
-	path := CheckpointPath(v.CheckpointID)
-	checkpointRef := checkpointReadRef()
-
 	// Validate session metadata exists and has checkpoint_id
-	sessionBlob := fmt.Sprintf("%s:%s/0/metadata.json", checkpointRef, path)
+	sessionBlob := checkpointBlobSpec(v.CheckpointID, "0/metadata.json")
 	sessionRaw := gitOutputSafe(dir, "show", sessionBlob)
 	if assert.NotEmpty(t, sessionRaw, "session metadata should exist at %s", sessionBlob) {
 		var sessionMeta map[string]any
@@ -395,7 +406,7 @@ func ValidateCheckpointDeep(t *testing.T, dir string, v DeepCheckpointValidation
 	}
 
 	// Validate transcript is valid JSONL
-	transcriptBlob := fmt.Sprintf("%s:%s/0/full.jsonl", checkpointRef, path)
+	transcriptBlob := checkpointBlobSpec(v.CheckpointID, "0/full.jsonl")
 	transcriptRaw := gitOutputSafe(dir, "show", transcriptBlob)
 	if assert.NotEmpty(t, transcriptRaw, "transcript should exist at %s", transcriptBlob) {
 		lines := strings.Split(transcriptRaw, "\n")
@@ -413,7 +424,7 @@ func ValidateCheckpointDeep(t *testing.T, dir string, v DeepCheckpointValidation
 		}
 
 		// Validate content hash
-		hashBlob := fmt.Sprintf("%s:%s/0/content_hash.txt", checkpointRef, path)
+		hashBlob := checkpointBlobSpec(v.CheckpointID, "0/content_hash.txt")
 		hashRaw := gitOutputSafe(dir, "show", hashBlob)
 		if hashRaw != "" {
 			hash := sha256.Sum256([]byte(transcriptRaw))
@@ -425,7 +436,7 @@ func ValidateCheckpointDeep(t *testing.T, dir string, v DeepCheckpointValidation
 
 	// Validate prompt.txt if expected prompts specified
 	if len(v.ExpectedPrompts) > 0 {
-		promptBlob := fmt.Sprintf("%s:%s/0/prompt.txt", checkpointRef, path)
+		promptBlob := checkpointBlobSpec(v.CheckpointID, "0/prompt.txt")
 		promptRaw := gitOutputSafe(dir, "show", promptBlob)
 		for _, expected := range v.ExpectedPrompts {
 			assert.Contains(t, promptRaw, expected,

--- a/e2e/testutil/backend.go
+++ b/e2e/testutil/backend.go
@@ -1,0 +1,94 @@
+package testutil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"sort"
+	"strings"
+)
+
+// Checkpoint storage backends the e2e suite can run against. Selected per-run by
+// E2E_CHECKPOINT_STORE (which TestMain maps to the ENTIRE_CHECKPOINTS_PRIMARY
+// override the spawned binary honors). The testutil helpers below resolve the
+// committed checkpoint record differently per backend so the same tests assert
+// against either store.
+const (
+	storeModeGitBranch  = "git-branch"
+	storeModeGitRefs    = "git-refs"
+	checkpointRefPrefix = "refs/entire/checkpoints/"
+)
+
+// checkpointStoreMode reports the backend the suite is running against, defaulting
+// to the git-branch store.
+func checkpointStoreMode() string {
+	if envIsGitRefs("E2E_CHECKPOINT_STORE") || envIsGitRefs("ENTIRE_CHECKPOINTS_PRIMARY") {
+		return storeModeGitRefs
+	}
+	return storeModeGitBranch
+}
+
+func envIsGitRefs(key string) bool {
+	return os.Getenv(key) == storeModeGitRefs
+}
+
+// UsingGitRefs reports whether the suite is running against the per-checkpoint
+// git-refs store. Tests that are inherently specific to the v1 branch topology
+// guard on this to skip under git-refs.
+func UsingGitRefs() bool { return checkpointStoreMode() == storeModeGitRefs }
+
+// checkpointShard returns the two-char ref shard for a checkpoint ID, matching
+// cmd/entire/cli/checkpoint/id.ShardFor: the first two chars for a 12-hex legacy
+// ID, the last two for a 26-char ULID.
+func checkpointShard(id string) string {
+	if len(id) < 2 {
+		return id
+	}
+	if len(id) == 26 {
+		return id[len(id)-2:]
+	}
+	return id[:2]
+}
+
+// checkpointRefName returns refs/entire/checkpoints/<shard>/<id> for the git-refs
+// store.
+func checkpointRefName(id string) string {
+	return checkpointRefPrefix + checkpointShard(id) + "/" + id
+}
+
+// checkpointBlobSpec returns the `git show` spec (ref:path) for a path relative
+// to a checkpoint's directory root, resolved for the active backend:
+//
+//	git-branch: entire/checkpoints/v1:<id[:2]>/<id[2:]>/<rel>
+//	git-refs:   refs/entire/checkpoints/<shard>/<id>:<rel>
+func checkpointBlobSpec(id, rel string) string {
+	if UsingGitRefs() {
+		return checkpointRefName(id) + ":" + rel
+	}
+	return checkpointReadRef() + ":" + CheckpointPath(id) + "/" + rel
+}
+
+// CheckpointState returns a backend-aware digest of the committed checkpoint
+// state that changes whenever any checkpoint is created or advanced. It replaces
+// a bare `rev-parse entire/checkpoints/v1` so advance detection works for both
+// the single-branch and per-checkpoint-ref topologies. It never fails: an absent
+// store yields a stable empty-state value.
+func CheckpointState(dir string) string {
+	if UsingGitRefs() {
+		out := gitOutputSafe(dir, "for-each-ref", "--format=%(refname) %(objectname)", checkpointRefPrefix)
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		sort.Strings(lines)
+		sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+		return hex.EncodeToString(sum[:])
+	}
+	return strings.TrimSpace(gitOutputSafe(dir, "rev-parse", checkpointReadRef()))
+}
+
+// CheckpointsPresent reports whether any committed checkpoint exists locally —
+// the git-branch v1 ref, or at least one per-checkpoint ref under git-refs.
+func CheckpointsPresent(dir string) bool {
+	if UsingGitRefs() {
+		return strings.TrimSpace(gitOutputSafe(dir, "for-each-ref", "--format=%(refname)", checkpointRefPrefix)) != ""
+	}
+	return strings.TrimSpace(gitOutputSafe(dir, "rev-parse", "--verify", "refs/heads/"+checkpointRefV1)) != ""
+}

--- a/e2e/testutil/backend.go
+++ b/e2e/testutil/backend.go
@@ -38,16 +38,13 @@ func envIsGitRefs(key string) bool {
 func UsingGitRefs() bool { return checkpointStoreMode() == storeModeGitRefs }
 
 // checkpointShard returns the two-char ref shard for a checkpoint ID, matching
-// cmd/entire/cli/checkpoint/id.ShardFor: the first two chars for a 12-hex legacy
-// ID, the last two for a 26-char ULID.
+// cmd/entire/cli/checkpoint/id.ShardFor: the last two chars, for both legacy
+// 12-hex IDs and 26-char ULIDs.
 func checkpointShard(id string) string {
 	if len(id) < 2 {
 		return id
 	}
-	if len(id) == 26 {
-		return id[len(id)-2:]
-	}
-	return id[:2]
+	return id[len(id)-2:]
 }
 
 // checkpointRefName returns refs/entire/checkpoints/<shard>/<id> for the git-refs

--- a/e2e/testutil/repo.go
+++ b/e2e/testutil/repo.go
@@ -158,7 +158,7 @@ func SetupRepo(t *testing.T, agent agents.Agent) *RepoState {
 		Dir:              dir,
 		ArtifactDir:      artDir,
 		HeadBefore:       GitOutput(t, dir, "rev-parse", "HEAD"),
-		CheckpointBefore: strings.TrimSpace(gitOutputSafe(dir, "rev-parse", checkpointReadRef())),
+		CheckpointBefore: CheckpointState(dir),
 		ConsoleLog:       consoleLog,
 	}
 
@@ -176,24 +176,26 @@ func checkpointReadRef() string {
 	return checkpointRefV1
 }
 
-// CurrentCheckpointRef returns the current hash of the checkpoint ref used for
-// reads in the active suite mode. It fails if the ref does not exist.
+// CurrentCheckpointRef returns the current committed-checkpoint state used for
+// advance detection in the active suite mode: the v1 branch hash (git-branch) or
+// the per-checkpoint-ref digest (git-refs). Pair it with WaitForCheckpointAdvanceFrom.
 func CurrentCheckpointRef(t *testing.T, dir string) string {
 	t.Helper()
+	if UsingGitRefs() {
+		return CheckpointState(dir)
+	}
 	return GitOutput(t, dir, "rev-parse", checkpointReadRef())
 }
 
-// CheckpointVerifyRef returns the exact local metadata ref name tests should
-// use for presence checks such as rev-parse --verify.
-func CheckpointVerifyRef() string {
-	return "refs/heads/" + checkpointRefV1
-}
-
-// PushCheckpointRefs pushes the checkpoint ref to the origin remote.
+// PushCheckpointRefs pushes the committed checkpoint refs to the origin remote.
 // Remote-resume tests use this instead of hardcoding v1 branch pushes.
 func PushCheckpointRefs(t *testing.T, dir string) {
 	t.Helper()
 
+	if UsingGitRefs() {
+		Git(t, dir, "push", "origin", checkpointRefPrefix+"*:"+checkpointRefPrefix+"*")
+		return
+	}
 	Git(t, dir, "push", "origin", checkpointRefV1+":"+checkpointRefV1)
 }
 
@@ -639,10 +641,20 @@ func GitOutput(t *testing.T, dir string, args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// NewCheckpointCommits returns the SHAs of commits added to the
-// entire/checkpoints/v1 branch since the test was set up, oldest first.
+// NewCheckpointCommits returns the SHAs of checkpoint commits to capture for
+// artifacts. Under git-branch these are the commits added to entire/checkpoints/v1
+// since setup, oldest first. Under git-refs there is no single advancing branch,
+// so it returns the tip commit of each per-checkpoint ref (diagnostic only).
 func NewCheckpointCommits(t *testing.T, s *RepoState) []string {
 	t.Helper()
+
+	if UsingGitRefs() {
+		out := gitOutputSafe(s.Dir, "for-each-ref", "--format=%(objectname)", checkpointRefPrefix)
+		if strings.TrimSpace(out) == "" {
+			return nil
+		}
+		return strings.Split(strings.TrimSpace(out), "\n")
+	}
 
 	log := GitOutput(t, s.Dir, "log", "--reverse", "--format=%H", s.CheckpointBefore+".."+checkpointReadRef())
 	if log == "" {
@@ -656,6 +668,24 @@ func NewCheckpointCommits(t *testing.T, s *RepoState) []string {
 // ({prefix}/{suffix}/metadata.json) and returns the concatenated IDs.
 func CheckpointIDs(t *testing.T, dir string) []string {
 	t.Helper()
+	if UsingGitRefs() {
+		out := gitOutputSafe(dir, "for-each-ref", "--format=%(refname)", checkpointRefPrefix)
+		if strings.TrimSpace(out) == "" {
+			return nil
+		}
+		seen := map[string]bool{}
+		var ids []string
+		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+			// refs/entire/checkpoints/<shard>/<id> — the ID is the last segment.
+			parts := strings.Split(strings.TrimSpace(line), "/")
+			id := parts[len(parts)-1]
+			if id != "" && !seen[id] {
+				seen[id] = true
+				ids = append(ids, id)
+			}
+		}
+		return ids
+	}
 	out := gitOutputSafe(dir, "ls-tree", "-r", "--name-only", checkpointReadRef())
 	if out == "" {
 		return nil
@@ -681,8 +711,7 @@ func CheckpointIDs(t *testing.T, dir string) []string {
 func ReadCheckpointMetadata(t *testing.T, dir string, checkpointID string) CheckpointMetadata {
 	t.Helper()
 
-	path := CheckpointPath(checkpointID) + "/metadata.json"
-	blob := checkpointReadRef() + ":" + path
+	blob := checkpointBlobSpec(checkpointID, "metadata.json")
 
 	raw := GitOutput(t, dir, "show", blob)
 
@@ -699,8 +728,7 @@ func ReadCheckpointMetadata(t *testing.T, dir string, checkpointID string) Check
 func ReadSessionMetadata(t *testing.T, dir string, checkpointID string, sessionIndex int) SessionMetadata {
 	t.Helper()
 
-	path := fmt.Sprintf("%s/%d/metadata.json", CheckpointPath(checkpointID), sessionIndex)
-	blob := checkpointReadRef() + ":" + path
+	blob := checkpointBlobSpec(checkpointID, fmt.Sprintf("%d/metadata.json", sessionIndex))
 
 	raw := GitOutput(t, dir, "show", blob)
 
@@ -719,8 +747,7 @@ func ReadSessionMetadata(t *testing.T, dir string, checkpointID string, sessionI
 func WaitForSessionMetadata(t *testing.T, dir string, checkpointID string, sessionIndex int, timeout time.Duration) SessionMetadata {
 	t.Helper()
 
-	path := fmt.Sprintf("%s/%d/metadata.json", CheckpointPath(checkpointID), sessionIndex)
-	blob := checkpointReadRef() + ":" + path
+	blob := checkpointBlobSpec(checkpointID, fmt.Sprintf("%d/metadata.json", sessionIndex))
 
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/693
<!-- entire-trail-link-end -->

Implements the **per-checkpoint git-ref checkpoint store** (#1471): each checkpoint is stored under its own ref `refs/entire/checkpoints/<shard>/<id>` (pointing at a commit whose tree root is that checkpoint's contents) instead of the single append-only `entire/checkpoints/v1` branch. Selectable via config, **off by default** — the git-branch store remains the default and is unchanged.

> Targets `main`. **#1576** (path.Join cleanup) is stacked on top of this branch.

## What's in it
1. **Ref resolver** — `CheckpointID.ShardFor` shards on the **last two characters for both formats** (legacy 12-hex and ULID): one positional rule, no format detection, so the shard can't be computed inconsistently between callers, and the random suffix spreads evenly while IDs stay sortable. `RefName` builds the ref and **rejects invalid/`KindUnknown` IDs** (returns an error rather than a malformed ref); `ParseRef` is the inverse. This is the git-refs namespace only — the v1 branch tree keeps its independent first-two `Path()` layout.
2. **git-refs store** — `gitRefsStore` implementing the full `api/checkpoint` contract over per-checkpoint refs, sharing the `treeWriter` core (so `dupl` stays quiet); registered as a git-backed `git-refs` backend. Orphan-then-parented per-checkpoint history; stamps `checkpoint_version = refs-v1`. Plus the flock-protected JSONL **push-discovery queue**. Read paths distinguish a genuinely-absent checkpoint (→ not-found) from real IO/fetch errors, which now propagate instead of being masked as "not found."
3. **Config-aware pre-push** — when the primary is `git-refs`, `PrePush` drains the queue and pushes the per-checkpoint refs **fast-forward-only (never force)**. There is no server-side ref protection, so a force push could let a buggy/racing client clobber good remote history; instead a diverged ref is recovered by **fetch + replay** of the local-only commit onto the remote tip, then retried. It also **honors the checkpoint policy** (skips the push on a diverged/unsupported-format policy, leaving refs queued) exactly like the v1 path.
4. **On-demand ref fetch** — a missing checkpoint ref is fetched on read (resume/explain/attribution/tokens), so checkpoints written on another machine resolve after clone.
5. **`refs-v1` read/write policy** + explain-on-clone fetches the specific ref by full ID.
6. **e2e/CI** — backend-aware test harness, `E2E_CHECKPOINT_STORE` knob → `ENTIRE_CHECKPOINTS_PRIMARY` env override, the git-refs leg added to the PR-CI canary matrix, and an `e2e-checkpoint-store` workflow to run the full suite against either backend.

## Rollout
Selected via the `checkpoints.{primary, mirrors}` taxonomy (or the `ENTIRE_CHECKPOINTS_PRIMARY` env override). `primary: git-refs` + `mirror: git-branch` is the parallel-rollout shape (refs authoritative; v1 still written locally). ID **generation** stays 12-hex for now — emitting ULIDs is a separate, deliberately deferred change; the store shards/reads **both** formats today.

## Explicitly out of scope (follow-ups)
- ULID **emission** (generation switch).
- **Backfill/migration** of existing v1 checkpoints into per-checkpoint refs.
- v1-**mirror push** for full downgrade safety (mirrors are write-only locally for now).
- **OPF** for the git-refs push path.

## Testing
`mise run lint` 0 issues (dupl quiet — `treeWriter` core is shared); full unit suite passes; `mise run test:integration` 379 pass; `go vet -tags e2e ./e2e/...` clean. Canary green in **both** modes: git-branch 59/59 + roger 4/4 (unchanged), and `E2E_CHECKPOINT_STORE=git-refs` 58/59 + roger 4/4 (the one skip is `TestAlternates`, a v1-branch-specific object-alternate rebase-sync test with no analog for the git-refs store's independent per-checkpoint refs).

Refs: #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large change to checkpoint persistence, git push/sync, and remote fetch paths; wrong behavior could lose or fail to sync checkpoint metadata across machines, though git-branch remains the default.
> 
> **Overview**
> Adds an optional **`git-refs`** checkpoint backend: each checkpoint lives on its own ref `refs/entire/checkpoints/<shard>/<id>` (commit tree = checkpoint contents) instead of only the shared `entire/checkpoints/v1` branch. Default remains **git-branch**; selection is via `checkpoints.primary` or **`ENTIRE_CHECKPOINTS_PRIMARY`** / **`ENTIRE_CHECKPOINTS_MIRRORS`**.
> 
> The new **`gitRefsStore`** implements the same read/write contract as the branch store (shared tree helpers), stamps **`refs-v1`**, and enqueues touched refs in a flock-protected JSONL **push queue**. **Pre-push** drains that queue and **batch force-pushes** those refs when the primary is git-refs (no v1 OPF path yet). **On-demand ref fetch** (`RefFetcher` / `FetchCheckpointRef`) lets resume, explain, attribution, and tokens resolve checkpoints written on another machine after clone.
> 
> **`refs-v1`** is now read/write-supported in checkpoint policy; tests that mocked “unsupported refs” move to **`refs-v2`**. E2E gains backend-aware helpers, `E2E_CHECKPOINT_STORE`, and a **`e2e-checkpoint-store`** workflow to run the suite against either backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220c6b1e59e4e83f7636a014f6ea14ea262ed6a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
