### PR TITLE
test(transport): fix flaky cold-path failover test

### DIFF
--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -873,6 +873,7 @@ func closedServerURL() string {
 }
 
 func TestColdPathFailoverWhenRedirectTargetUnreachable(t *testing.T) {
+	t.Parallel()
 	dead := closedServerURL()
 
 	var aliveURL string

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -893,38 +893,35 @@ func TestColdPathFailoverWhenRedirectTargetUnreachable(t *testing.T) {
 	}))
 	defer entry.Close()
 
-	const iterations = 8
-	deadFailoverObserved := false
+	var failed []string
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			EntryURL:    entry.URL,
+			ClusterHost: "127.0.0.1",
+		},
+		Path:         "/et/alice/repo",
+		OnNodeFailed: func(node string) { failed = append(failed, node) },
+	})
+	// Pin the dead (redirect-target) replica as the first node tried so the
+	// failover path is exercised deterministically. doWithFailover otherwise
+	// starts at a random offset and ~half the time reaches the alive replica
+	// first, leaving dead untried; the previous 8-iteration loop still skipped
+	// dead entirely in (1/2)^8 of runs — a real flake.
+	p.stickyNode = dead
 
-	for i := range iterations {
-		var failed []string
-		p := New(Config{
-			Nodes: replicas.NodeConfig{
-				EntryURL:    entry.URL,
-				ClusterHost: "127.0.0.1",
-			},
-			Path:         "/et/alice/repo",
-			OnNodeFailed: func(node string) { failed = append(failed, node) },
-		})
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err, "failover must succeed")
 
-		body, err := p.InfoRefs(context.Background(), "git-upload-pack")
-		require.NoErrorf(t, err, "iteration %d: failover must succeed", i)
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	_ = body.Close()
+	assert.Equal(t, "refs from alive", string(got), "response must come from alive replica")
 
-		got, err := io.ReadAll(body)
-		require.NoError(t, err)
-		_ = body.Close()
-		assert.Equal(t, "refs from alive", string(got), "iteration %d: response must come from alive replica", i)
-
-		if !slices.Equal(p.nodes, []string{aliveURL}) {
-			t.Errorf("iteration %d: nodes after failover = %v, want [%s]", i, p.nodes, aliveURL)
-		}
-		if slices.Contains(failed, dead) {
-			deadFailoverObserved = true
-		}
+	if !slices.Equal(p.nodes, []string{aliveURL}) {
+		t.Errorf("nodes after failover = %v, want [%s]", p.nodes, aliveURL)
 	}
-
-	if !deadFailoverObserved {
-		t.Errorf("dead replica never marked failed across %d iterations — failover path may not be exercised", iterations)
+	if !slices.Contains(failed, dead) {
+		t.Errorf("dead replica was not marked failed — failover path not exercised; failed=%v", failed)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/698
<!-- entire-trail-link-end -->

## What

Fixes the intermittent failure in `TestColdPathFailoverWhenRedirectTargetUnreachable`:

```
proxy_test.go: dead replica never marked failed across 8 iterations — failover path may not be exercised
```

It's a flake in the **test**, not the product — failover always works; the response always comes from the alive replica.

## Root cause

The test drives the cold path: the entry server returns `307` with `X-Entire-Replicas: [dead, alive]`, so the proxy adopts `nodes = [dead, alive]` and runs `doWithFailover`. But `doWithFailover` starts at a **random** node offset (`start := rand.IntN(len(nodes))`, load-spreading). Per iteration:

- start = `dead` → dead's dial fails → `markNodeFailed(dead)` fires → fail over to `alive` ✓
- start = `alive` → alive serves immediately, `dead` is never tried, and alive's `X-Entire-Replicas` header resets `p.nodes` to `[alive]`

So `OnNodeFailed(dead)` only fired when the random start happened to pick `dead`. The 8-iteration loop required at least one dead-first pick across 8 tries; all 8 picking alive-first is **(1/2)⁸ ≈ 0.39%** — the observed flake rate.

## Fix

Pin the dead (redirect-target) replica as the first node tried via `p.stickyNode = dead` — the same in-package idiom the redirect/sticky tests already use — so the redirect-target-unreachable failover path is exercised deterministically. The 8-iteration probabilistic loop is then unnecessary and is removed.

No production code changes.

## Verification

`go test ./internal/remotehelper/transport/ -run TestColdPathFailoverWhenRedirectTargetUnreachable -count=3000` — all pass (the old version would have failed ~12× at this count). Full package green under `-race`; lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in transport proxy tests; no runtime behavior modified.
> 
> **Overview**
> **`TestColdPathFailoverWhenRedirectTargetUnreachable`** was flaky because **`doWithFailover`** picks a random starting replica, so the test often hit the alive node first and never observed **`OnNodeFailed`** for the unreachable redirect target.
> 
> The fix pins **`p.stickyNode = dead`** (same pattern as other sticky tests) so failover always tries the dead replica first, then drops the eight-iteration probabilistic loop in favor of a single deterministic run with a direct assertion that **`dead`** appears in **`failed`**.
> 
> No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a653eb3bd4b333f206e81009d5a08e7bcdd751db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->