### PR TITLE
WIP: Add entire experts CLI

### DIFF
--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -200,6 +200,17 @@ type ErrorResponse struct {
 	Error any `json:"error"`
 }
 
+// Code extracts a stable machine-readable error code from the structured
+// envelope shape. Older string-only errors do not carry a code.
+func (e ErrorResponse) Code() string {
+	if v, ok := e.Error.(map[string]any); ok {
+		if code, ok := v["code"].(string); ok {
+			return strings.TrimSpace(code)
+		}
+	}
+	return ""
+}
+
 // Message extracts the human-readable error message from either envelope shape.
 func (e ErrorResponse) Message() string {
 	switch v := e.Error.(type) {
@@ -220,6 +231,7 @@ func (e ErrorResponse) Message() string {
 // errors.As to inspect the HTTP status, or IsHTTPErrorStatus for a quick check.
 type HTTPError struct {
 	StatusCode int
+	Code       string
 	Message    string
 }
 
@@ -253,6 +265,7 @@ func CheckResponse(resp *http.Response) error {
 
 	var parsed ErrorResponse
 	if err := json.Unmarshal(body, &parsed); err == nil {
+		apiError.Code = parsed.Code()
 		if message := parsed.Message(); message != "" {
 			apiError.Message = message
 			return apiError

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -160,6 +160,9 @@ func buildExpertsRequest(
 	}
 
 	if opts.Staged {
+		if strings.TrimSpace(opts.RepoOverride) != "" {
+			return req, "", errors.New("--staged cannot be combined with --repo; staged files come from the local checkout")
+		}
 		scopes, err := stagedExpertScopes(ctx)
 		if err != nil {
 			return req, "", err
@@ -221,7 +224,7 @@ func resolveExpertsRepo(ctx context.Context, override string) (string, string, e
 	if override == "" {
 		_, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 		if err != nil {
-			return "", "", err
+			return "", "", fmt.Errorf("resolve origin remote: %w", err)
 		}
 		return owner, repo, nil
 	}
@@ -229,7 +232,7 @@ func resolveExpertsRepo(ctx context.Context, override string) (string, string, e
 	if strings.Contains(override, "://") || strings.Contains(override, ":") {
 		info, err := gitremote.ParseURL(override)
 		if err != nil {
-			return "", "", err
+			return "", "", fmt.Errorf("parse repository URL %q: %w", override, err)
 		}
 		return info.Owner, info.Repo, nil
 	}
@@ -249,13 +252,13 @@ func resolveExpertsRepo(ctx context.Context, override string) (string, string, e
 }
 
 func localExpertScope(ctx context.Context, subject string) (string, bool, error) {
-	info, err := os.Stat(subject)
-	if err != nil {
-		return "", false, nil
-	}
+	cwdInfo, cwdExists := localExpertScopeInfo(subject)
 
 	root, err := paths.WorktreeRoot(ctx)
 	if err != nil {
+		if !cwdExists {
+			return "", false, nil
+		}
 		return "", true, fmt.Errorf("resolve git worktree root for %q: %w", subject, err)
 	}
 	rootAbs, err := filepath.Abs(root)
@@ -265,9 +268,22 @@ func localExpertScope(ctx context.Context, subject string) (string, bool, error)
 	if resolved, err := filepath.EvalSymlinks(rootAbs); err == nil {
 		rootAbs = resolved
 	}
-	subjectAbs, err := filepath.Abs(subject)
+
+	info := cwdInfo
+	subjectPath := subject
+	if !cwdExists {
+		rootRelative := filepath.Join(rootAbs, subject)
+		rootInfo, rootExists := localExpertScopeInfo(rootRelative)
+		if !rootExists {
+			return "", false, nil
+		}
+		info = rootInfo
+		subjectPath = rootRelative
+	}
+
+	subjectAbs, err := filepath.Abs(subjectPath)
 	if err != nil {
-		return "", true, fmt.Errorf("resolve path %q: %w", subject, err)
+		return "", true, fmt.Errorf("resolve path %q: %w", subjectPath, err)
 	}
 	if resolved, err := filepath.EvalSymlinks(subjectAbs); err == nil {
 		subjectAbs = resolved
@@ -279,6 +295,9 @@ func localExpertScope(ctx context.Context, subject string) (string, bool, error)
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
 		return "", true, fmt.Errorf("path %q is outside git worktree %q", subject, root)
 	}
+	if rel == "." {
+		return "", true, errors.New("repo root scope is not supported; pass a file or directory below the repo root")
+	}
 
 	scope := filepath.ToSlash(filepath.Clean(rel))
 	scope = strings.TrimPrefix(scope, "./")
@@ -286,6 +305,14 @@ func localExpertScope(ctx context.Context, subject string) (string, bool, error)
 		scope += "/"
 	}
 	return scope, true, nil
+}
+
+func localExpertScopeInfo(subject string) (os.FileInfo, bool) {
+	info, err := os.Stat(subject)
+	if err == nil {
+		return info, true
+	}
+	return nil, false
 }
 
 func stagedExpertScopes(ctx context.Context) ([]string, error) {

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -1,0 +1,375 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultExpertsLimit         = 10
+	defaultExpertsEvidenceLimit = 3
+)
+
+type expertsRequest struct {
+	Owner         string
+	Repo          string
+	Scopes        []string
+	Query         string
+	Branch        string
+	Limit         int
+	EvidenceLimit int
+}
+
+type expertsAPIRequest struct {
+	Scopes        []string `json:"scopes,omitempty"`
+	Query         string   `json:"query,omitempty"`
+	Branch        string   `json:"branch,omitempty"`
+	Limit         int      `json:"limit,omitempty"`
+	EvidenceLimit int      `json:"evidence_limit,omitempty"`
+}
+
+type expertEvidence struct {
+	SessionID             string   `json:"sessionId"`
+	DisplayName           string   `json:"displayName"`
+	Agent                 *string  `json:"agent"`
+	Prompt                *string  `json:"prompt"`
+	LastActivityAt        string   `json:"lastActivityAt"`
+	CheckpointCount       int      `json:"checkpointCount"`
+	StepCount             int      `json:"stepCount"`
+	AttributionAgentLines *int     `json:"attributionAgentLines"`
+	MatchedFiles          []string `json:"matchedFiles"`
+}
+
+type expertEntry struct {
+	Login                 string           `json:"login"`
+	Score                 int              `json:"score"`
+	MembershipStatus      string           `json:"membershipStatus"`
+	LastActivityAt        string           `json:"lastActivityAt"`
+	SessionCount          int              `json:"sessionCount"`
+	CheckpointCount       int              `json:"checkpointCount"`
+	StepCount             int              `json:"stepCount"`
+	AttributionAgentLines *int             `json:"attributionAgentLines"`
+	MatchedFiles          []string         `json:"matchedFiles"`
+	Evidence              []expertEvidence `json:"evidence"`
+}
+
+type expertsResponse struct {
+	Experts      []expertEntry `json:"experts"`
+	Scopes       []string      `json:"scopes"`
+	Query        *string       `json:"query"`
+	RepoFullName string        `json:"repo_full_name"`
+	Source       string        `json:"source"`
+}
+
+func newExpertsCmd() *cobra.Command {
+	var opts expertsCommandOptions
+
+	cmd := &cobra.Command{
+		Use:    "experts [scope-or-query]",
+		Short:  "Find people with prior session evidence for code",
+		Hidden: true,
+		Args:   cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Subject = strings.TrimSpace(strings.Join(args, " "))
+			return runExpertsCommand(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.RepoOverride, "repo", "", "Target repository as owner/repo, gh/owner/repo, or a clone URL; defaults to origin")
+	cmd.Flags().StringVar(&opts.Branch, "branch", "", "Restrict evidence to a branch; defaults to the repository default branch")
+	cmd.Flags().IntVar(&opts.Limit, "limit", defaultExpertsLimit, "Maximum experts to show")
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Emit JSON")
+	cmd.Flags().BoolVar(&opts.Staged, "staged", false, "Use staged file paths as scopes")
+	cmd.Flags().BoolVar(&opts.InsecureHTTPAuth, "insecure-http-auth", false, "Allow API calls over plain HTTP (insecure, for local development only)")
+	if err := cmd.Flags().MarkHidden("insecure-http-auth"); err != nil {
+		panic(fmt.Sprintf("hide insecure-http-auth flag: %v", err))
+	}
+	return cmd
+}
+
+type expertsCommandOptions struct {
+	Subject          string
+	RepoOverride     string
+	Branch           string
+	Limit            int
+	JSON             bool
+	Staged           bool
+	InsecureHTTPAuth bool
+}
+
+func runExpertsCommand(ctx context.Context, w, errW io.Writer, opts expertsCommandOptions) error {
+	owner, repo, err := resolveExpertsRepo(ctx, opts.RepoOverride)
+	if err != nil {
+		return err
+	}
+	req, label, err := buildExpertsRequest(ctx, owner, repo, opts)
+	if err != nil {
+		return err
+	}
+
+	return runAuthenticatedDataAPI(ctx, errW, opts.InsecureHTTPAuth, func(ctx context.Context, client *api.Client) error {
+		resp, err := fetchExperts(ctx, client, req)
+		if err != nil {
+			return err
+		}
+		if opts.JSON {
+			enc := json.NewEncoder(w)
+			enc.SetIndent("", "  ")
+			return enc.Encode(resp)
+		}
+		if len(resp.Experts) == 0 {
+			fmt.Fprintf(w, "No expert evidence found for %s.\n", label)
+			return nil
+		}
+		renderExpertsText(w, *resp)
+		return nil
+	})
+}
+
+func buildExpertsRequest(
+	ctx context.Context,
+	owner, repo string,
+	opts expertsCommandOptions,
+) (expertsRequest, string, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultExpertsLimit
+	}
+
+	req := expertsRequest{
+		Owner:         owner,
+		Repo:          repo,
+		Branch:        strings.TrimSpace(opts.Branch),
+		Limit:         limit,
+		EvidenceLimit: defaultExpertsEvidenceLimit,
+	}
+
+	if opts.Staged {
+		scopes, err := stagedExpertScopes(ctx)
+		if err != nil {
+			return req, "", err
+		}
+		if len(scopes) == 0 {
+			return req, "", errors.New("no staged files found")
+		}
+		req.Scopes = scopes
+		return req, strings.Join(scopes, ", "), nil
+	}
+
+	if opts.Subject == "" {
+		return req, "", errors.New("scope or query required")
+	}
+
+	if scope, ok, err := localExpertScope(ctx, opts.Subject); ok || err != nil {
+		if err != nil {
+			return req, "", err
+		}
+		req.Scopes = []string{scope}
+		return req, scope, nil
+	}
+
+	req.Query = opts.Subject
+	return req, opts.Subject, nil
+}
+
+func fetchExperts(ctx context.Context, client *api.Client, req expertsRequest) (*expertsResponse, error) {
+	body := expertsAPIRequest{
+		Scopes:        req.Scopes,
+		Query:         req.Query,
+		Branch:        req.Branch,
+		Limit:         req.Limit,
+		EvidenceLimit: req.EvidenceLimit,
+	}
+	path := fmt.Sprintf(
+		"/api/v1/cache/%s/%s/experts",
+		url.PathEscape(req.Owner),
+		url.PathEscape(req.Repo),
+	)
+	resp, err := client.Post(ctx, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("POST experts: %w", err)
+	}
+	defer resp.Body.Close()
+	if err := api.CheckResponse(resp); err != nil {
+		return nil, fmt.Errorf("experts response: %w", err)
+	}
+
+	var result expertsResponse
+	if err := api.DecodeJSON(resp, &result); err != nil {
+		return nil, fmt.Errorf("decode experts: %w", err)
+	}
+	return &result, nil
+}
+
+func resolveExpertsRepo(ctx context.Context, override string) (string, string, error) {
+	override = strings.TrimSpace(override)
+	if override == "" {
+		_, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+		if err != nil {
+			return "", "", err
+		}
+		return owner, repo, nil
+	}
+
+	if strings.Contains(override, "://") || strings.Contains(override, ":") {
+		info, err := gitremote.ParseURL(override)
+		if err != nil {
+			return "", "", err
+		}
+		return info.Owner, info.Repo, nil
+	}
+
+	parts := strings.Split(override, "/")
+	switch len(parts) {
+	case 2:
+		return parts[0], parts[1], nil
+	case 3:
+		if !gitremote.IsSupportedForge(parts[0]) {
+			return "", "", fmt.Errorf("unsupported forge %q", parts[0])
+		}
+		return parts[1], parts[2], nil
+	default:
+		return "", "", fmt.Errorf("invalid repository %q", override)
+	}
+}
+
+func localExpertScope(ctx context.Context, subject string) (string, bool, error) {
+	info, err := os.Stat(subject)
+	if err != nil {
+		return "", false, nil
+	}
+
+	root, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return "", true, fmt.Errorf("resolve git worktree root for %q: %w", subject, err)
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", true, fmt.Errorf("resolve git worktree root for %q: %w", subject, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(rootAbs); err == nil {
+		rootAbs = resolved
+	}
+	subjectAbs, err := filepath.Abs(subject)
+	if err != nil {
+		return "", true, fmt.Errorf("resolve path %q: %w", subject, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(subjectAbs); err == nil {
+		subjectAbs = resolved
+	}
+	rel, err := filepath.Rel(rootAbs, subjectAbs)
+	if err != nil {
+		return "", true, fmt.Errorf("resolve path %q relative to git worktree: %w", subject, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return "", true, fmt.Errorf("path %q is outside git worktree %q", subject, root)
+	}
+
+	scope := filepath.ToSlash(filepath.Clean(rel))
+	scope = strings.TrimPrefix(scope, "./")
+	if info.IsDir() && !strings.HasSuffix(scope, "/") {
+		scope += "/"
+	}
+	return scope, true, nil
+}
+
+func stagedExpertScopes(ctx context.Context) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--name-only", "--diff-filter=ACMR")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("read staged files: %w", err)
+	}
+	seen := map[string]struct{}{}
+	var scopes []string
+	for _, line := range strings.Split(string(out), "\n") {
+		scope := strings.TrimSpace(filepath.ToSlash(line))
+		if scope == "" {
+			continue
+		}
+		if _, ok := seen[scope]; ok {
+			continue
+		}
+		seen[scope] = struct{}{}
+		scopes = append(scopes, scope)
+	}
+	sort.Strings(scopes)
+	return scopes, nil
+}
+
+func renderExpertsText(w io.Writer, resp expertsResponse) {
+	fmt.Fprintf(w, "EXPERTS for %s\n\n", resp.RepoFullName)
+	if resp.Query != nil && strings.TrimSpace(*resp.Query) != "" {
+		fmt.Fprintf(w, "Query: %s\n", *resp.Query)
+	}
+	if len(resp.Scopes) > 0 {
+		fmt.Fprintf(w, "Scopes: %s\n", strings.Join(resp.Scopes, ", "))
+	}
+	fmt.Fprintln(w)
+
+	for _, expert := range resp.Experts {
+		fmt.Fprintf(w, "@%s", expert.Login)
+		if expert.MembershipStatus != "" && expert.MembershipStatus != "unknown" {
+			fmt.Fprintf(w, " (%s)", expert.MembershipStatus)
+		}
+		fmt.Fprintf(w, "  %d sessions, %d checkpoints, %d steps", expert.SessionCount, expert.CheckpointCount, expert.StepCount)
+		if expert.AttributionAgentLines != nil {
+			fmt.Fprintf(w, ", %d agent lines", *expert.AttributionAgentLines)
+		}
+		fmt.Fprintln(w)
+		if len(expert.MatchedFiles) > 0 {
+			fmt.Fprintf(w, "  files: %s\n", strings.Join(expert.MatchedFiles, ", "))
+		}
+		for _, ev := range expert.Evidence {
+			when := shortExpertTime(ev.LastActivityAt)
+			agent := ptrStringValue(ev.Agent)
+			if agent == "" {
+				agent = "unknown"
+			}
+			fmt.Fprintf(w, "  - %s", ev.DisplayName)
+			if when != "" {
+				fmt.Fprintf(w, " (%s, %s)", agent, when)
+			} else {
+				fmt.Fprintf(w, " (%s)", agent)
+			}
+			fmt.Fprintf(w, " — %d checkpoints", ev.CheckpointCount)
+			if ev.AttributionAgentLines != nil {
+				fmt.Fprintf(w, ", %d agent lines", *ev.AttributionAgentLines)
+			}
+			fmt.Fprintln(w)
+			if len(ev.MatchedFiles) > 0 {
+				fmt.Fprintf(w, "    %s\n", strings.Join(ev.MatchedFiles, ", "))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+func ptrStringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func shortExpertTime(value string) string {
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -240,15 +240,24 @@ func resolveExpertsRepo(ctx context.Context, override string) (string, string, e
 	parts := strings.Split(override, "/")
 	switch len(parts) {
 	case 2:
-		return parts[0], parts[1], nil
+		return normalizeExpertRepoParts(parts[0], parts[1], override)
 	case 3:
 		if !gitremote.IsSupportedForge(parts[0]) {
 			return "", "", fmt.Errorf("unsupported forge %q", parts[0])
 		}
-		return parts[1], parts[2], nil
+		return normalizeExpertRepoParts(parts[1], parts[2], override)
 	default:
 		return "", "", fmt.Errorf("invalid repository %q", override)
 	}
+}
+
+func normalizeExpertRepoParts(owner, repo, raw string) (string, string, error) {
+	owner = strings.TrimSpace(owner)
+	repo = strings.TrimSuffix(strings.TrimSpace(repo), ".git")
+	if owner == "" || repo == "" {
+		return "", "", fmt.Errorf("invalid repository %q", raw)
+	}
+	return owner, repo, nil
 }
 
 func localExpertScope(ctx context.Context, subject string) (string, bool, error) {
@@ -316,15 +325,30 @@ func localExpertScopeInfo(subject string) (os.FileInfo, bool) {
 }
 
 func stagedExpertScopes(ctx context.Context) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "git", "diff", "--cached", "--name-only", "--diff-filter=ACMR")
+	root, err := paths.WorktreeRoot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve git worktree root: %w", err)
+	}
+	cmd := exec.CommandContext(
+		ctx,
+		"git",
+		"-C",
+		root,
+		"diff",
+		"--no-relative",
+		"--cached",
+		"--name-only",
+		"-z",
+		"--diff-filter=ACMR",
+	)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("read staged files: %w", err)
 	}
 	seen := map[string]struct{}{}
 	var scopes []string
-	for _, line := range strings.Split(string(out), "\n") {
-		scope := strings.TrimSpace(filepath.ToSlash(line))
+	for _, line := range strings.Split(string(out), "\x00") {
+		scope := filepath.ToSlash(line)
 		if scope == "" {
 			continue
 		}

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -17,12 +18,14 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/search"
 	"github.com/spf13/cobra"
 )
 
 const (
 	defaultExpertsLimit         = 10
 	defaultExpertsEvidenceLimit = 3
+	maxExpertsResponseBytes     = 16 << 20
 )
 
 type expertsRequest struct {
@@ -69,11 +72,12 @@ type expertEntry struct {
 }
 
 type expertsResponse struct {
-	Experts      []expertEntry `json:"experts"`
-	Scopes       []string      `json:"scopes"`
-	Query        *string       `json:"query"`
-	RepoFullName string        `json:"repo_full_name"`
-	Source       string        `json:"source"`
+	Experts      []expertEntry   `json:"experts"`
+	Scopes       []string        `json:"scopes"`
+	Query        *string         `json:"query"`
+	RepoFullName string          `json:"repo_full_name"`
+	Source       string          `json:"source"`
+	RawJSON      json.RawMessage `json:"-"`
 }
 
 func newExpertsCmd() *cobra.Command {
@@ -128,9 +132,7 @@ func runExpertsCommand(ctx context.Context, w, errW io.Writer, opts expertsComma
 			return err
 		}
 		if opts.JSON {
-			enc := json.NewEncoder(w)
-			enc.SetIndent("", "  ")
-			return enc.Encode(resp)
+			return writeExpertsJSON(w, resp)
 		}
 		if len(resp.Experts) == 0 {
 			fmt.Fprintf(w, "No expert evidence found for %s.\n", label)
@@ -182,6 +184,11 @@ func buildExpertsRequest(
 		if err != nil {
 			return req, "", err
 		}
+		if strings.TrimSpace(opts.RepoOverride) != "" {
+			if err := validateLocalExpertScopeRepo(ctx, owner, repo); err != nil {
+				return req, "", err
+			}
+		}
 		req.Scopes = []string{scope}
 		return req, scope, nil
 	}
@@ -209,20 +216,78 @@ func fetchExperts(ctx context.Context, client *api.Client, req expertsRequest) (
 	}
 	defer resp.Body.Close()
 	if err := api.CheckResponse(resp); err != nil {
+		if friendly := friendlyExpertsAPIError(err); friendly != nil {
+			return nil, friendly
+		}
 		return nil, fmt.Errorf("experts response: %w", err)
 	}
 
+	raw, err := readExpertsResponseBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read experts response: %w", err)
+	}
 	var result expertsResponse
-	if err := api.DecodeJSON(resp, &result); err != nil {
+	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, fmt.Errorf("decode experts: %w", err)
 	}
+	result.RawJSON = append(result.RawJSON[:0], raw...)
 	return &result, nil
+}
+
+func readExpertsResponseBody(r io.Reader) ([]byte, error) {
+	raw, err := io.ReadAll(io.LimitReader(r, maxExpertsResponseBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read experts response body: %w", err)
+	}
+	if len(raw) > maxExpertsResponseBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxExpertsResponseBytes)
+	}
+	return raw, nil
+}
+
+func writeExpertsJSON(w io.Writer, resp *expertsResponse) error {
+	if len(resp.RawJSON) > 0 {
+		if _, err := w.Write(resp.RawJSON); err != nil {
+			return fmt.Errorf("write experts JSON: %w", err)
+		}
+		return nil
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(resp); err != nil {
+		return fmt.Errorf("encode experts JSON: %w", err)
+	}
+	return nil
+}
+
+func friendlyExpertsAPIError(err error) error {
+	var httpErr *api.HTTPError
+	if !errors.As(err, &httpErr) {
+		return nil
+	}
+
+	code := strings.TrimSpace(httpErr.Code)
+	message := strings.TrimSpace(httpErr.Message)
+	if httpErr.StatusCode == http.StatusServiceUnavailable &&
+		(strings.EqualFold(code, "code-search-unavailable") ||
+			strings.EqualFold(message, "Code search is not configured") ||
+			strings.EqualFold(message, "code-search-unavailable")) {
+		return errors.New("code search is not configured")
+	}
+	if httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden {
+		if message == "" {
+			message = "Authentication failed"
+		}
+		return fmt.Errorf("%s; run 'entire login' to authenticate", strings.TrimRight(message, ". "))
+	}
+	return nil
 }
 
 func resolveExpertsRepo(ctx context.Context, override string) (string, string, error) {
 	override = strings.TrimSpace(override)
 	if override == "" {
-		_, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+		owner, repo, err := resolveExpertsGitHubOrigin(ctx)
 		if err != nil {
 			return "", "", fmt.Errorf("resolve origin remote: %w", err)
 		}
@@ -230,11 +295,11 @@ func resolveExpertsRepo(ctx context.Context, override string) (string, string, e
 	}
 
 	if strings.Contains(override, "://") || strings.Contains(override, ":") {
-		info, err := gitremote.ParseURL(override)
+		owner, repo, err := search.ParseGitHubRemote(override)
 		if err != nil {
-			return "", "", fmt.Errorf("parse repository URL %q: %w", override, err)
+			return "", "", fmt.Errorf("parse repository URL %q: %w", gitremote.RedactURL(override), err)
 		}
-		return info.Owner, info.Repo, nil
+		return owner, repo, nil
 	}
 
 	parts := strings.Split(override, "/")
@@ -258,6 +323,29 @@ func normalizeExpertRepoParts(owner, repo, raw string) (string, string, error) {
 		return "", "", fmt.Errorf("invalid repository %q", raw)
 	}
 	return owner, repo, nil
+}
+
+func resolveExpertsGitHubOrigin(ctx context.Context) (string, string, error) {
+	remoteURL, err := gitremote.GetRemoteURL(ctx, "origin")
+	if err != nil {
+		return "", "", fmt.Errorf("get origin remote URL: %w", err)
+	}
+	owner, repo, err := search.ParseGitHubRemote(remoteURL)
+	if err != nil {
+		return "", "", fmt.Errorf("parse origin remote URL: %w", err)
+	}
+	return owner, repo, nil
+}
+
+func validateLocalExpertScopeRepo(ctx context.Context, owner, repo string) error {
+	localOwner, localRepo, err := resolveExpertsGitHubOrigin(ctx)
+	if err != nil {
+		return fmt.Errorf("--repo cannot be combined with a local path when origin cannot be verified: %w", err)
+	}
+	if strings.EqualFold(localOwner, owner) && strings.EqualFold(localRepo, repo) {
+		return nil
+	}
+	return fmt.Errorf("--repo %s/%s cannot be combined with a local path from %s/%s; run from the target checkout or pass a non-local topic query", owner, repo, localOwner, localRepo)
 }
 
 func localExpertScope(ctx context.Context, subject string) (string, bool, error) {

--- a/cmd/entire/cli/experts_cmd_test.go
+++ b/cmd/entire/cli/experts_cmd_test.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -109,6 +111,147 @@ func TestFetchExpertsPostsRequestShape(t *testing.T) {
 	require.Equal(t, "acme/widget", resp.RepoFullName)
 }
 
+func TestWriteExpertsJSONPreservesServerShape(t *testing.T) {
+	raw := []byte(`{"repo_full_name":"acme/widget","experts":[{"login":"maya","extra_nested":{"source":"server"}}],"source":"db","extra_top":true}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write(raw)
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	resp, err := fetchExperts(context.Background(), client, expertsRequest{
+		Owner: "acme",
+		Repo:  "widget",
+		Limit: 3,
+	})
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	require.NoError(t, writeExpertsJSON(&out, resp))
+	require.Equal(t, raw, out.Bytes())
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Equal(t, true, got["extra_top"])
+	experts, ok := got["experts"].([]any)
+	require.True(t, ok)
+	first, ok := experts[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, map[string]any{"source": "server"}, first["extra_nested"])
+}
+
+func TestFetchExpertsRejectsOversizedSuccessResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"repo_full_name":"acme/widget","source":"db","padding":"` + strings.Repeat("x", maxExpertsResponseBytes) + `"}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	_, err := fetchExperts(context.Background(), client, expertsRequest{
+		Owner: "acme",
+		Repo:  "widget",
+		Limit: 3,
+	})
+
+	require.ErrorContains(t, err, "response body exceeds")
+}
+
+func TestFetchExpertsFormatsCodeSearchUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, err := w.Write([]byte(`{"error":"Code search is not configured"}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	_, err := fetchExperts(context.Background(), client, expertsRequest{
+		Owner: "acme",
+		Repo:  "widget",
+		Query: "stripe webhook retry logic",
+		Limit: 3,
+	})
+
+	require.EqualError(t, err, "code search is not configured")
+}
+
+func TestFetchExpertsFormatsStructuredCodeSearchUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, err := w.Write([]byte(`{"error":{"code":"code-search-unavailable","message":"Search backend unavailable"}}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	_, err := fetchExperts(context.Background(), client, expertsRequest{
+		Owner: "acme",
+		Repo:  "widget",
+		Query: "stripe webhook retry logic",
+		Limit: 3,
+	})
+
+	require.EqualError(t, err, "code search is not configured")
+}
+
+func TestFetchExpertsFormatsUnauthorizedMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, err := w.Write([]byte(`{"error":"Not authenticated"}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	_, err := fetchExperts(context.Background(), client, expertsRequest{
+		Owner:  "acme",
+		Repo:   "widget",
+		Scopes: []string{"src/foo.ts"},
+		Limit:  3,
+	})
+
+	require.EqualError(t, err, "Not authenticated; run 'entire login' to authenticate")
+}
+
+func TestFetchExpertsFormatsForbiddenMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, err := w.Write([]byte(`{"error":"Checkpoint repo access denied"}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	_, err := fetchExperts(context.Background(), client, expertsRequest{
+		Owner:  "acme",
+		Repo:   "widget",
+		Scopes: []string{"src/foo.ts"},
+		Limit:  3,
+	})
+
+	require.EqualError(t, err, "Checkpoint repo access denied; run 'entire login' to authenticate")
+}
+
 func TestBuildExpertsRequestNormalizesLocalPathsToRepoRelative(t *testing.T) {
 	repoDir := t.TempDir()
 	testutil.InitRepo(t, repoDir)
@@ -144,6 +287,65 @@ func TestBuildExpertsRequestNormalizesLocalPathsToRepoRelative(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"cmd/entire/cli/experts_cmd.go"}, req.Scopes)
 	require.Equal(t, "cmd/entire/cli/experts_cmd.go", label)
+}
+
+func TestBuildExpertsRequestAllowsRepoOverrideMatchingLocalOriginPath(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	runExpertsGit(t, repoDir, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	testutil.WriteFile(t, repoDir, "cmd/entire/cli/experts_cmd.go", "package cli\n")
+
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	req, label, err := buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
+		RepoOverride: "gh/acme/widget",
+		Subject:      "cmd/entire/cli/experts_cmd.go",
+		Limit:        5,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"cmd/entire/cli/experts_cmd.go"}, req.Scopes)
+	require.Equal(t, "cmd/entire/cli/experts_cmd.go", label)
+}
+
+func TestBuildExpertsRequestRejectsRepoOverrideWithDifferentLocalPath(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	runExpertsGit(t, repoDir, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	testutil.WriteFile(t, repoDir, "cmd/entire/cli/experts_cmd.go", "package cli\n")
+
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	_, _, err := buildExpertsRequest(context.Background(), "other", "project", expertsCommandOptions{
+		RepoOverride: "gh/other/project",
+		Subject:      "cmd/entire/cli/experts_cmd.go",
+		Limit:        5,
+	})
+
+	require.ErrorContains(t, err, "--repo other/project cannot be combined with a local path from acme/widget")
+}
+
+func TestBuildExpertsRequestRejectsRepoOverrideWithNonGitHubLocalPath(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	runExpertsGit(t, repoDir, "remote", "add", "origin", "https://gitlab.com/acme/widget.git")
+	testutil.WriteFile(t, repoDir, "cmd/entire/cli/experts_cmd.go", "package cli\n")
+
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	_, _, err := buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
+		RepoOverride: "gh/acme/widget",
+		Subject:      "cmd/entire/cli/experts_cmd.go",
+		Limit:        5,
+	})
+
+	require.ErrorContains(t, err, "not a GitHub repository")
 }
 
 func TestBuildExpertsRequestNormalizesLocalDirectoriesToRepoRelativePrefix(t *testing.T) {
@@ -221,6 +423,37 @@ func TestResolveExpertsRepoValidatesBareOverrides(t *testing.T) {
 
 	_, _, err = resolveExpertsRepo(context.Background(), "/widget")
 	require.ErrorContains(t, err, "invalid repository")
+
+	owner, repo, err = resolveExpertsRepo(context.Background(), "git@github.com:acme/widget.git")
+	require.NoError(t, err)
+	require.Equal(t, "acme", owner)
+	require.Equal(t, "widget", repo)
+
+	_, _, err = resolveExpertsRepo(context.Background(), "https://gitlab.com/acme/widget.git")
+	require.ErrorContains(t, err, "not a GitHub repository")
+
+	_, _, err = resolveExpertsRepo(context.Background(), "https://github.com/acme/widget/extra.git")
+	require.ErrorContains(t, err, "extra segments")
+}
+
+func TestResolveExpertsRepoValidatesOriginRemote(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	runExpertsGit(t, repoDir, "remote", "add", "origin", "https://github.com/acme/widget.git")
+
+	t.Chdir(repoDir)
+	owner, repo, err := resolveExpertsRepo(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, "acme", owner)
+	require.Equal(t, "widget", repo)
+
+	runExpertsGit(t, repoDir, "remote", "set-url", "origin", "https://gitlab.com/acme/widget.git")
+	_, _, err = resolveExpertsRepo(context.Background(), "")
+	require.ErrorContains(t, err, "not a GitHub repository")
+
+	runExpertsGit(t, repoDir, "remote", "set-url", "origin", "https://github.com/acme/widget/extra.git")
+	_, _, err = resolveExpertsRepo(context.Background(), "")
+	require.ErrorContains(t, err, "extra segments")
 }
 
 func TestStagedExpertScopesAreRepoRelativeWithDiffRelative(t *testing.T) {

--- a/cmd/entire/cli/experts_cmd_test.go
+++ b/cmd/entire/cli/experts_cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -207,4 +208,43 @@ func TestBuildExpertsRequestAllowsQueryOutsideLocalWorktree(t *testing.T) {
 	require.Equal(t, "stripe webhook retry logic", req.Query)
 	require.Empty(t, req.Scopes)
 	require.Equal(t, "stripe webhook retry logic", label)
+}
+
+func TestResolveExpertsRepoValidatesBareOverrides(t *testing.T) {
+	owner, repo, err := resolveExpertsRepo(context.Background(), "gh/acme/widget.git")
+	require.NoError(t, err)
+	require.Equal(t, "acme", owner)
+	require.Equal(t, "widget", repo)
+
+	_, _, err = resolveExpertsRepo(context.Background(), "gh/acme/")
+	require.ErrorContains(t, err, "invalid repository")
+
+	_, _, err = resolveExpertsRepo(context.Background(), "/widget")
+	require.ErrorContains(t, err, "invalid repository")
+}
+
+func TestStagedExpertScopesAreRepoRelativeWithDiffRelative(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "root.txt", "root\n")
+	testutil.WriteFile(t, repoDir, "nested/inside.txt", "inside\n")
+
+	runExpertsGit(t, repoDir, "config", "diff.relative", "true")
+	runExpertsGit(t, repoDir, "add", "root.txt", "nested/inside.txt")
+
+	t.Chdir(filepath.Join(repoDir, "nested"))
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	scopes, err := stagedExpertScopes(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"nested/inside.txt", "root.txt"}, scopes)
+}
+
+func runExpertsGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v failed: %s", args, out)
 }

--- a/cmd/entire/cli/experts_cmd_test.go
+++ b/cmd/entire/cli/experts_cmd_test.go
@@ -78,10 +78,17 @@ func TestFetchExpertsPostsRequestShape(t *testing.T) {
 	var gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			return
+		}
 		gotBody = string(body)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"repo_full_name":"acme/widget","scopes":["src/foo.ts"],"query":null,"experts":[],"source":"db"}`))
+		_, err = w.Write([]byte(`{"repo_full_name":"acme/widget","scopes":["src/foo.ts"],"query":null,"experts":[],"source":"db"}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
 	}))
 	t.Cleanup(srv.Close)
 
@@ -120,6 +127,15 @@ func TestBuildExpertsRequestNormalizesLocalPathsToRepoRelative(t *testing.T) {
 	require.Equal(t, "cmd/entire/cli/experts_cmd.go", label)
 
 	req, label, err = buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
+		Subject: "cmd/entire/cli/experts_cmd.go",
+		Limit:   5,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"cmd/entire/cli/experts_cmd.go"}, req.Scopes)
+	require.Equal(t, "cmd/entire/cli/experts_cmd.go", label)
+
+	req, label, err = buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
 		Subject: filepath.Join(repoDir, "cmd", "entire", "cli", "experts_cmd.go"),
 		Limit:   5,
 	})
@@ -146,4 +162,49 @@ func TestBuildExpertsRequestNormalizesLocalDirectoriesToRepoRelativePrefix(t *te
 	require.NoError(t, err)
 	require.Equal(t, []string{"billing/webhooks/"}, req.Scopes)
 	require.Equal(t, "billing/webhooks/", label)
+}
+
+func TestBuildExpertsRequestRejectsStagedWithRepoOverride(t *testing.T) {
+	req, label, err := buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
+		RepoOverride: "gh/acme/widget",
+		Staged:       true,
+		Limit:        5,
+	})
+
+	require.ErrorContains(t, err, "--staged cannot be combined with --repo")
+	require.Empty(t, label)
+	require.Empty(t, req.Scopes)
+}
+
+func TestBuildExpertsRequestRejectsRepoRootScope(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+
+	t.Chdir(repoDir)
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	_, _, err := buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
+		Subject: ".",
+		Limit:   5,
+	})
+
+	require.ErrorContains(t, err, "repo root scope is not supported")
+}
+
+func TestBuildExpertsRequestAllowsQueryOutsideLocalWorktree(t *testing.T) {
+	t.Chdir(t.TempDir())
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	req, label, err := buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
+		RepoOverride: "gh/acme/widget",
+		Subject:      "stripe webhook retry logic",
+		Limit:        5,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "stripe webhook retry logic", req.Query)
+	require.Empty(t, req.Scopes)
+	require.Equal(t, "stripe webhook retry logic", label)
 }

--- a/cmd/entire/cli/experts_cmd_test.go
+++ b/cmd/entire/cli/experts_cmd_test.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+	"github.com/entireio/cli/cmd/entire/cli/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func expertStringPtr(v string) *string {
+	return &v
+}
+
+func TestExpertsCommandIsHiddenButListedInLabs(t *testing.T) {
+	root := NewRootCmd()
+	cmd, _, err := root.Find([]string{"experts"})
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.True(t, cmd.Hidden)
+	require.Contains(t, labsOverview(), "entire experts")
+}
+
+func TestRenderExpertsTextShowsEvidence(t *testing.T) {
+	resp := expertsResponse{
+		RepoFullName: "acme/widget",
+		Scopes:       []string{"billing/webhooks/sender.go"},
+		Experts: []expertEntry{
+			{
+				Login:                 "maya",
+				Score:                 93,
+				MembershipStatus:      "active",
+				SessionCount:          2,
+				CheckpointCount:       3,
+				StepCount:             11,
+				AttributionAgentLines: intPtr(120),
+				MatchedFiles:          []string{"billing/webhooks/sender.go"},
+				Evidence: []expertEvidence{
+					{
+						SessionID:             "sess-a",
+						DisplayName:           "add retry to webhook sender",
+						Agent:                 expertStringPtr("codex"),
+						LastActivityAt:        "2026-06-20T10:00:00.000Z",
+						CheckpointCount:       2,
+						StepCount:             9,
+						AttributionAgentLines: intPtr(120),
+						MatchedFiles:          []string{"billing/webhooks/sender.go"},
+					},
+				},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	renderExpertsText(&out, resp)
+
+	text := out.String()
+	require.Contains(t, text, "EXPERTS for acme/widget")
+	require.Contains(t, text, "@maya")
+	require.Contains(t, text, "3 checkpoints")
+	require.Contains(t, text, "billing/webhooks/sender.go")
+	require.Contains(t, text, "add retry to webhook sender")
+}
+
+func TestFetchExpertsPostsRequestShape(t *testing.T) {
+	var gotPath string
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"repo_full_name":"acme/widget","scopes":["src/foo.ts"],"query":null,"experts":[],"source":"db"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := api.NewClientWithBaseURL("tok", srv.URL)
+	resp, err := fetchExperts(context.Background(), client, expertsRequest{
+		Owner:         "acme",
+		Repo:          "widget",
+		Scopes:        []string{"src/foo.ts"},
+		Branch:        "main",
+		Limit:         3,
+		EvidenceLimit: 2,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "/api/v1/cache/acme/widget/experts", gotPath)
+	require.JSONEq(t, `{"scopes":["src/foo.ts"],"branch":"main","limit":3,"evidence_limit":2}`, gotBody)
+	require.Equal(t, "acme/widget", resp.RepoFullName)
+}
+
+func TestBuildExpertsRequestNormalizesLocalPathsToRepoRelative(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "cmd/entire/cli/experts_cmd.go", "package cli\n")
+
+	t.Chdir(filepath.Join(repoDir, "cmd", "entire"))
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	req, label, err := buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
+		Subject: "cli/experts_cmd.go",
+		Limit:   5,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"cmd/entire/cli/experts_cmd.go"}, req.Scopes)
+	require.Equal(t, "cmd/entire/cli/experts_cmd.go", label)
+
+	req, label, err = buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
+		Subject: filepath.Join(repoDir, "cmd", "entire", "cli", "experts_cmd.go"),
+		Limit:   5,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"cmd/entire/cli/experts_cmd.go"}, req.Scopes)
+	require.Equal(t, "cmd/entire/cli/experts_cmd.go", label)
+}
+
+func TestBuildExpertsRequestNormalizesLocalDirectoriesToRepoRelativePrefix(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitRepo(t, repoDir)
+	testutil.WriteFile(t, repoDir, "billing/webhooks/sender.go", "package webhooks\n")
+
+	t.Chdir(filepath.Join(repoDir, "billing"))
+	paths.ClearWorktreeRootCache()
+	t.Cleanup(paths.ClearWorktreeRootCache)
+
+	req, label, err := buildExpertsRequest(context.Background(), "acme", "widget", expertsCommandOptions{
+		Subject: "webhooks",
+		Limit:   5,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"billing/webhooks/"}, req.Scopes)
+	require.Equal(t, "billing/webhooks/", label)
+}

--- a/cmd/entire/cli/labs.go
+++ b/cmd/entire/cli/labs.go
@@ -70,6 +70,11 @@ var experimentalCommands = []experimentalCommandInfo{
 		Invocation:  "entire why",
 		Summary:     "Show why a line exists (commit, checkpoint, prompt, session)",
 	},
+	{
+		CommandPath: []string{"experts"},
+		Invocation:  "entire experts",
+		Summary:     "Find people with prior session evidence for code",
+	},
 }
 
 func newLabsCmd() *cobra.Command {
@@ -120,6 +125,7 @@ Try:
   entire grant --help
   entire blame --help
   entire why --help
+  entire experts --help
 `
 }
 

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -112,6 +112,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newDispatchCmd())
 	cmd.AddCommand(newActivityCmd())
 	cmd.AddCommand(newRecapCmd())
+	cmd.AddCommand(newExpertsCmd())
 
 	// Hidden top-level shortcuts. Functional but print a deprecation hint.
 	cmd.AddCommand(hideAsAlias(newResumeCmd(), "entire session resume"))


### PR DESCRIPTION
## What this is

Adds hidden/labs `entire experts`, a CLI command for finding prior Entire session evidence for a file, directory, staged diff, or natural-language topic.

V1 displays human contributors because the backend currently ranks first-commit authors, but the command is intentionally evidence/provenance-first: names are shown with matched files, sessions, agents used, checkpoint counts, and recency rather than probability percentages.

Backend/API companion PR: https://github.com/entirehq/entire.io/pull/2683

## Why

The command is meant to answer: “what prior work actually knows this area?”

That is different from:

- CODEOWNERS, which names responsible reviewers.
- Git blame, which names line authors.
- Last commit history, which can point at refactor or bot noise.

`entire experts` asks the API for session evidence and renders the evidence trail. This makes it useful to a human trying to find context and to an agent trying to decide which repo history is worth reading next.

## User-facing behavior

Supported forms:

- `entire experts billing/webhooks/`
- `entire experts sender.go`
- `entire experts "stripe webhook retry logic"`
- `entire experts --staged`
- `entire experts --repo owner/repo "topic"`
- `entire experts --json ...`

Default resolution:

- `--staged` collects staged file paths from the local checkout and sends them as path scopes.
- Existing local files/directories are normalized to repo-relative scopes.
- Anything else is sent as a natural-language query.
- Empty results are quiet: `No expert evidence found for <scope>.`

## What changed

- Added hidden top-level `experts` command and listed it in `entire labs`.
- Added API request/response structs for `/api/v1/cache/:org/:repo/experts`.
- Added repo resolution from `origin`, `--repo owner/repo`, `--repo gh/owner/repo`, or clone URL.
- Added path/query/staged request building.
- Added human text rendering and JSON output.
- Added hidden `--insecure-http-auth` for local API development consistency.
- Added CLI tests for command wiring, request shape, text rendering, local path normalization, directories, staged scopes, repo overrides, JSON response handling, and edge cases.

## Audit fixes included

- Local paths normalize to repo-relative paths from subdirectories and absolute paths.
- Repo-relative paths still resolve correctly when invoked from a subdirectory.
- `--staged` is rejected with `--repo` so local staged files are not sent to the wrong remote repo.
- `--staged` runs from the worktree root with `--no-relative` and `-z`, so user `diff.relative=true` and unusual filenames do not corrupt scopes.
- Repo-root `.` is rejected clearly because the backend does not define a whole-repo scope.
- Bare `--repo` overrides validate non-empty owner/repo segments and normalize a trailing `.git`.
- Remote `--repo` natural-language queries still work outside a local checkout.
- GitHub remote parsing is strict for origin and URL overrides, rejecting non-GitHub remotes and clone URLs with extra path segments.
- `--repo` plus a local path verifies the local checkout origin matches the override instead of silently mixing repositories.
- `--json` preserves the exact server response body, including future unknown fields.
- Successful experts responses are capped at 16 MiB.
- Auth failures print a short `entire login` hint.
- `code-search-unavailable` is recognized by structured API error code as well as legacy message text.

## Verification

Local verification run on the final pushed head:

- `go test ./cmd/entire/cli ./cmd/entire/cli/api -run 'Test(FetchExperts|WriteExperts|BuildExperts|StagedExpert|ResolveExperts|RenderExperts|ExpertsCommand|CheckResponse|ErrorResponse)'`
- `go test ./cmd/entire/cli/...`
- `mise run lint`

Final read-only review pass found no remaining critical or important CLI issues.