### PR TITLE
test(transport): de-flake ColdPathFailover redirect-target test

### DIFF
--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -893,38 +893,35 @@ func TestColdPathFailoverWhenRedirectTargetUnreachable(t *testing.T) {
 	}))
 	defer entry.Close()
 
-	const iterations = 8
-	deadFailoverObserved := false
+	var failed []string
+	p := New(Config{
+		Nodes: replicas.NodeConfig{
+			EntryURL:    entry.URL,
+			ClusterHost: "127.0.0.1",
+		},
+		Path:         "/et/alice/repo",
+		OnNodeFailed: func(node string) { failed = append(failed, node) },
+	})
+	// doWithFailover starts at a random offset for load-spreading, so with two
+	// adopted replicas [dead, alive] the dead one is only attempted ~half the
+	// time — the old loop-8-and-hope made that a ~1/256 flake. Pin the sticky
+	// node to dead so it is always tried first: that deterministically exercises
+	// the failure → OnNodeFailed → failover-to-alive path this test is about.
+	p.stickyNode = dead
 
-	for i := range iterations {
-		var failed []string
-		p := New(Config{
-			Nodes: replicas.NodeConfig{
-				EntryURL:    entry.URL,
-				ClusterHost: "127.0.0.1",
-			},
-			Path:         "/et/alice/repo",
-			OnNodeFailed: func(node string) { failed = append(failed, node) },
-		})
+	body, err := p.InfoRefs(context.Background(), "git-upload-pack")
+	require.NoError(t, err, "failover must succeed")
 
-		body, err := p.InfoRefs(context.Background(), "git-upload-pack")
-		require.NoErrorf(t, err, "iteration %d: failover must succeed", i)
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	_ = body.Close()
+	assert.Equal(t, "refs from alive", string(got), "response must come from alive replica")
 
-		got, err := io.ReadAll(body)
-		require.NoError(t, err)
-		_ = body.Close()
-		assert.Equal(t, "refs from alive", string(got), "iteration %d: response must come from alive replica", i)
-
-		if !slices.Equal(p.nodes, []string{aliveURL}) {
-			t.Errorf("iteration %d: nodes after failover = %v, want [%s]", i, p.nodes, aliveURL)
-		}
-		if slices.Contains(failed, dead) {
-			deadFailoverObserved = true
-		}
+	if !slices.Equal(p.nodes, []string{aliveURL}) {
+		t.Errorf("nodes after failover = %v, want [%s]", p.nodes, aliveURL)
 	}
-
-	if !deadFailoverObserved {
-		t.Errorf("dead replica never marked failed across %d iterations — failover path may not be exercised", iterations)
+	if !slices.Contains(failed, dead) {
+		t.Errorf("dead replica %s was not marked failed; failover path not exercised (failed=%v)", dead, failed)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/700
<!-- entire-trail-link-end -->

Fixes a low-rate CI flake in `TestColdPathFailoverWhenRedirectTargetUnreachable` (seen failing on unrelated PRs).

**Cause:** `doWithFailover` starts at a random offset for load-spreading. With the two adopted replicas `[dead, alive]`, the dead node is only attempted ~half the time. The test looped 8× hoping to observe dead failing over — a ~1/256 chance every iteration starts on `alive` and dead is never tried → `dead replica never marked failed across 8 iterations`.

**Fix:** pin `stickyNode = dead` (the existing white-box knob sibling tests use) so dead is always tried first, deterministically exercising the failure → `OnNodeFailed` → failover-to-alive path. Drops the probabilistic loop.

**Production unchanged** — test-only. Verified 30× + `-race` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; production transport/failover behavior is unchanged.
> 
> **Overview**
> **Fixes a CI flake** in `TestColdPathFailoverWhenRedirectTargetUnreachable` by making the cold-path failover scenario deterministic instead of probabilistic.
> 
> `doWithFailover` picks a random starting replica for load spreading, so with `[dead, alive]` the dead node might never be tried in a single run. The test used to loop 8 times hoping to see `OnNodeFailed` for the dead replica (~1/256 flake when every run started on `alive`).
> 
> The change **pins `p.stickyNode = dead`** (same white-box knob as other sticky tests) so the dead redirect target is always attempted first, then asserts one successful `InfoRefs`, response from the alive replica, node list updated to alive, and that `dead` appears in `failed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa07d1f6cefe74e67dd68ee556a6c2bf8376e131. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->