### PR TITLE
Surface wrong-cluster clone errors clearly in git-remote-entire

### DIFF
--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -182,6 +182,9 @@ func fatalMessage(err error, parsedURL *url.URL) string {
 	if errors.As(err, &oe) && oe.Code == "invalid_target" {
 		if m := wrongClusterRe.FindStringSubmatch(oe.Description); m != nil {
 			host := m[1]
+			// Copy the URL the user typed and swap only the host, so any
+			// escaped path (RawPath) or query stays byte-identical to what
+			// they originally ran.
 			correctedURL := *parsedURL
 			correctedURL.Scheme = "entire"
 			correctedURL.Host = host

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -20,12 +20,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"regexp"
 	"runtime"
 	"strings"
 	"syscall"
@@ -35,6 +37,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
 	"github.com/entireio/cli/internal/entireclient/httpclient"
+	"github.com/entireio/cli/internal/entireclient/httputil"
 	"github.com/entireio/cli/internal/entireclient/repocreds"
 	"github.com/entireio/cli/internal/entireclient/userdirs"
 	"github.com/entireio/cli/internal/remotehelper"
@@ -154,10 +157,38 @@ func run(args []string) int {
 	debuglog.Printf("git protocol.version=%d (v2 advertises stateless-connect + push; v0/v1 advertises connect)", protocolVersion)
 
 	if err := githelper.Run(ctx, proxy, protocolVersion, os.Stdin, os.Stdout); err != nil {
-		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
+		fmt.Fprint(os.Stderr, fatalMessage(err, parsedURL))
 		return 128
 	}
 	return 0
+}
+
+// wrongClusterRe extracts the host that actually serves the repo from the
+// data plane's `invalid_target` error_description (RFC 8693). The data plane
+// emits this when the audience host doesn't host the repo but a sibling
+// cluster does, naming the correct host so we can point the user at it. The
+// phrasing is "… it lives on \"<host>\" …"; anchoring on "lives on" keeps the
+// match tied to this specific, actionable case rather than other
+// invalid_target variants (e.g. a suspended mirror).
+var wrongClusterRe = regexp.MustCompile(`lives on "([^"]+)"`)
+
+// fatalMessage renders the stderr "fatal: …" line for a transfer error. When
+// the failure is the data plane reporting that the repo lives on a different
+// cluster, it special-cases the raw OAuth chain into an actionable message
+// naming the correct host (and the corrected entire:// URL). Everything else
+// falls back to the verbatim error.
+func fatalMessage(err error, parsedURL *url.URL) string {
+	var oe *httputil.OAuthError
+	if errors.As(err, &oe) && oe.Code == "invalid_target" {
+		if m := wrongClusterRe.FindStringSubmatch(oe.Description); m != nil {
+			host := m[1]
+			corrected := (&url.URL{Scheme: "entire", Host: host, Path: parsedURL.Path}).String()
+			return fmt.Sprintf("fatal: this repository is not hosted on %s; it lives on %s.\n"+
+				"Re-run against the correct host, e.g.:\n\n    git clone %s\n",
+				parsedURL.Host, host, corrected)
+		}
+	}
+	return fmt.Sprintf("fatal: %v\n", err)
 }
 
 // loadedVersion populates the build info and returns the resolved version.

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -182,7 +182,10 @@ func fatalMessage(err error, parsedURL *url.URL) string {
 	if errors.As(err, &oe) && oe.Code == "invalid_target" {
 		if m := wrongClusterRe.FindStringSubmatch(oe.Description); m != nil {
 			host := m[1]
-			corrected := (&url.URL{Scheme: "entire", Host: host, Path: parsedURL.Path}).String()
+			correctedURL := *parsedURL
+			correctedURL.Scheme = "entire"
+			correctedURL.Host = host
+			corrected := correctedURL.String()
 			return fmt.Sprintf("fatal: this repository is not hosted on %s; it lives on %s.\n"+
 				"Re-run against the correct host, e.g.:\n\n    git clone %s\n",
 				parsedURL.Host, host, corrected)

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -188,6 +188,7 @@ func fatalMessage(err error, parsedURL *url.URL) string {
 			correctedURL := *parsedURL
 			correctedURL.Scheme = "entire"
 			correctedURL.Host = host
+			correctedURL.User = nil
 			corrected := correctedURL.String()
 			return fmt.Sprintf("fatal: this repository is not hosted on %s; it lives on %s.\n"+
 				"Re-run against the correct host, e.g.:\n\n    git clone %s\n",

--- a/cmd/git-remote-entire/main_test.go
+++ b/cmd/git-remote-entire/main_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/entireclient/httputil"
 )
 
 func TestInfoFlagText(t *testing.T) {
@@ -111,6 +113,61 @@ func TestGitActionFromRequest(t *testing.T) {
 			req := httptest.NewRequestWithContext(context.Background(), tc.method, "https://host"+tc.path+"?"+tc.query, nil)
 			if got := gitActionFromRequest(req); got != tc.want {
 				t.Fatalf("gitActionFromRequest(%s %s?%s) = %q, want %q", tc.method, tc.path, tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFatalMessage(t *testing.T) {
+	t.Parallel()
+	parsedURL := &url.URL{Scheme: "entire", Host: "aws-us-east-2.entire.io", Path: "/et/paul/dogbark"}
+	wrongCluster := &httputil.OAuthError{
+		Status:      http.StatusBadRequest,
+		Code:        "invalid_target",
+		Description: `audience host "aws-us-east-2.entire.io" does not host this repo; it lives on "aws-eu-central-1.entire.io" — re-target the request there`,
+		Body:        "{...}",
+	}
+	tests := []struct {
+		name        string
+		err         error
+		contains    []string
+		notContains []string
+	}{
+		{
+			name: "wrong cluster names correct host and URL",
+			// Wrapped to mirror production: the OAuthError surfaces buried under
+			// several fmt.Errorf layers, so errors.As must dig it out.
+			err: fmt.Errorf("stateless-connect v2 info/refs: fetching info/refs from entry domain: repo-scoped token exchange: oauth token exchange: %w", wrongCluster),
+			contains: []string{
+				"aws-eu-central-1.entire.io",
+				"git clone entire://aws-eu-central-1.entire.io/et/paul/dogbark",
+			},
+			notContains: []string{"HTTP 400", "invalid_target"},
+		},
+		{
+			name:     "invalid_target without lives-on hint falls back",
+			err:      &httputil.OAuthError{Status: http.StatusBadRequest, Code: "invalid_target", Description: "no servable mirror", Body: "HTTP 400: no servable mirror"},
+			contains: []string{"fatal:", "no servable mirror"},
+		},
+		{
+			name:     "unrelated error falls back verbatim",
+			err:      errors.New("connection refused"),
+			contains: []string{"fatal: connection refused"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := fatalMessage(tc.err, parsedURL)
+			for _, sub := range tc.contains {
+				if !strings.Contains(got, sub) {
+					t.Errorf("fatalMessage() = %q, missing %q", got, sub)
+				}
+			}
+			for _, sub := range tc.notContains {
+				if strings.Contains(got, sub) {
+					t.Errorf("fatalMessage() = %q, should not contain %q", got, sub)
+				}
 			}
 		})
 	}

--- a/internal/entireclient/httputil/oauth.go
+++ b/internal/entireclient/httputil/oauth.go
@@ -63,9 +63,10 @@ func cloneValuesWithoutClient(v url.Values) url.Values {
 // status-specific UX (e.g. a friendly 403 message) or branch on the
 // RFC 6749 error code.
 type OAuthError struct {
-	Status int
-	Code   string // RFC 6749 `error` code from the response body; "" when not present
-	Body   string
+	Status      int
+	Code        string // RFC 6749 `error` code from the response body; "" when not present
+	Description string // RFC 6749 `error_description` from the response body; "" when not present
+	Body        string
 }
 
 func (e *OAuthError) Error() string {
@@ -118,10 +119,11 @@ func PostOAuthToken(ctx context.Context, httpClient *http.Client, coreURL string
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 1024)) //nolint:errcheck // best-effort body read for error message
 		var oauthBody struct {
-			Code string `json:"error"`
+			Code        string `json:"error"`
+			Description string `json:"error_description"`
 		}
 		_ = json.Unmarshal(msg, &oauthBody) //nolint:errcheck // best-effort code extraction; non-JSON bodies leave Code empty
-		return "", 0, &OAuthError{Status: resp.StatusCode, Code: oauthBody.Code, Body: strings.TrimSpace(string(msg))}
+		return "", 0, &OAuthError{Status: resp.StatusCode, Code: oauthBody.Code, Description: oauthBody.Description, Body: strings.TrimSpace(string(msg))}
 	}
 
 	var out struct {

--- a/internal/entireclient/httputil/oauth_test.go
+++ b/internal/entireclient/httputil/oauth_test.go
@@ -52,15 +52,17 @@ func TestPostOAuthToken_LiftsAndPercentEncodesClientCreds(t *testing.T) {
 }
 
 // TestPostOAuthToken_ErrorCode pins that a non-200 response surfaces as
-// *OAuthError with the RFC 6749 `error` code parsed from the body (empty for
-// non-JSON bodies), so callers can branch on e.g. invalid_target.
+// *OAuthError with the RFC 6749 `error` code and `error_description` parsed
+// from the body (both empty for non-JSON bodies), so callers can branch on
+// e.g. invalid_target and render the description (the git-remote-entire
+// wrong-cluster UX relies on Description being extracted here).
 func TestPostOAuthToken_ErrorCode(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name, body, wantCode string
+		name, body, wantCode, wantDesc string
 	}{
-		{"json error code", `{"error":"invalid_target","error_description":"no mirror"}`, "invalid_target"},
-		{"non-json body", `gateway exploded`, ""},
+		{"json error code", `{"error":"invalid_target","error_description":"no mirror"}`, "invalid_target", "no mirror"},
+		{"non-json body", `gateway exploded`, "", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -75,6 +77,7 @@ func TestPostOAuthToken_ErrorCode(t *testing.T) {
 			require.ErrorAs(t, err, &oe)
 			assert.Equal(t, http.StatusBadRequest, oe.Status)
 			assert.Equal(t, tc.wantCode, oe.Code)
+			assert.Equal(t, tc.wantDesc, oe.Description)
 			assert.Equal(t, tc.body, oe.Body)
 		})
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/701
<!-- entire-trail-link-end -->

## What

Cloning a repo whose audience host doesn't match where the repo actually lives produced an opaque error:

```
fatal: stateless-connect v2 info/refs: fetching info/refs from entry domain: repo-scoped token exchange: oauth token exchange: HTTP 400: {"error":"invalid_target","error_description":"audience host \"aws-us-east-2.entire.io\" does not host this repo; it lives on \"aws-eu-central-1.entire.io\" — re-target the request there"}
```

Now it prints:

```
fatal: this repository is not hosted on aws-us-east-2.entire.io; it lives on aws-eu-central-1.entire.io.
Re-run against the correct host, e.g.:

    git clone entire://aws-eu-central-1.entire.io/et/paul/dogbark
```

## How

- `httputil.OAuthError` now captures the `error_description` field.
- `git-remote-entire` `errors.As`-digs the buried `OAuthError`, and for `invalid_target` whose description names the hosting cluster ("… lives on \"<host>\"") renders an actionable message with the corrected `entire://` URL. Other errors fall back verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 97aa0c91b91fdf74b9037cd1f186c2765f241171. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->