### PR TITLE
Build checkpoint subtree paths via path.Join helper (no tree change)

### DIFF
--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -152,6 +152,15 @@ func (s *treeWriter) subtreeObjAt(rootTreeHash plumbing.Hash, path string) (*obj
 // and checkpointSubtreePath("a3/b2.../", "0", "metadata.json") == "a3/b2.../0/metadata.json".
 // Callers therefore need not maintain the trailing-slash invariant by hand.
 func checkpointSubtreePath(base string, segs ...string) string {
+	if len(segs) == 0 {
+		// path.Join with no segments would clean a "" base to "." — an invalid
+		// git tree key. At the ref root the correct key is ""; for a non-empty
+		// base, clean it to keep the trailing-slash-stripping behavior.
+		if base == "" {
+			return ""
+		}
+		return path.Clean(base)
+	}
 	return path.Join(append([]string{base}, segs...)...)
 }
 

--- a/cmd/entire/cli/checkpoint/persistent.go
+++ b/cmd/entire/cli/checkpoint/persistent.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -142,6 +143,18 @@ func (s *treeWriter) subtreeObjAt(rootTreeHash plumbing.Hash, path string) (*obj
 	return subtree, nil
 }
 
+// checkpointSubtreePath joins a checkpoint-relative git tree path from a base and
+// trailing segments using path.Join. Git tree paths are always "/"-separated, so
+// this uses the stdlib path package (never path/filepath, which would emit "\" on
+// Windows and corrupt tree keys). path.Join cleans separators, so base may be ""
+// (per-checkpoint-ref root), a clean dir ("a3/b2.../0"), or a trailing-slash dir
+// ("a3/b2.../"): checkpointSubtreePath("", "0", "metadata.json") == "0/metadata.json"
+// and checkpointSubtreePath("a3/b2.../", "0", "metadata.json") == "a3/b2.../0/metadata.json".
+// Callers therefore need not maintain the trailing-slash invariant by hand.
+func checkpointSubtreePath(base string, segs ...string) string {
+	return path.Join(append([]string{base}, segs...)...)
+}
+
 // flattenExisting flattens a checkpoint's current subtree into a path->entry map
 // keyed under basePath, so the per-checkpoint write helpers (which build paths as
 // basePath+"<n>/<file>") see the existing files. basePath is "" for the
@@ -230,7 +243,7 @@ func (s *treeWriter) applyAttributionBackfill(ctx context.Context, existing *obj
 		return plumbing.ZeroHash, err
 	}
 
-	rootMetadataPath := basePath + paths.MetadataFileName
+	rootMetadataPath := checkpointSubtreePath(basePath, paths.MetadataFileName)
 	entry, exists := entries[rootMetadataPath]
 	if !exists {
 		return plumbing.ZeroHash, ErrCheckpointNotFound
@@ -269,7 +282,7 @@ func (s *treeWriter) applySummaryBackfill(ctx context.Context, existing *object.
 		return plumbing.ZeroHash, "", err
 	}
 
-	rootMetadataPath := basePath + paths.MetadataFileName
+	rootMetadataPath := checkpointSubtreePath(basePath, paths.MetadataFileName)
 	entry, exists := entries[rootMetadataPath]
 	if !exists {
 		return plumbing.ZeroHash, "", ErrCheckpointNotFound
@@ -282,7 +295,7 @@ func (s *treeWriter) applySummaryBackfill(ctx context.Context, existing *object.
 
 	// Find the latest session's metadata path (0-based indexing)
 	latestIndex := len(checkpointSummary.Sessions) - 1
-	sessionMetadataPath := fmt.Sprintf("%s%d/%s", basePath, latestIndex, paths.MetadataFileName)
+	sessionMetadataPath := checkpointSubtreePath(basePath, strconv.Itoa(latestIndex), paths.MetadataFileName)
 	sessionEntry, exists := entries[sessionMetadataPath]
 	if !exists {
 		return plumbing.ZeroHash, "", fmt.Errorf("session metadata not found at %s", sessionMetadataPath)
@@ -325,7 +338,7 @@ func (s *treeWriter) applyTranscriptBackfill(ctx context.Context, opts UpdateOpt
 		return plumbing.ZeroHash, err
 	}
 
-	rootMetadataPath := basePath + paths.MetadataFileName
+	rootMetadataPath := checkpointSubtreePath(basePath, paths.MetadataFileName)
 	entry, exists := entries[rootMetadataPath]
 	if !exists {
 		return plumbing.ZeroHash, ErrCheckpointNotFound
@@ -343,7 +356,7 @@ func (s *treeWriter) applyTranscriptBackfill(ctx context.Context, opts UpdateOpt
 	sessionIndex := -1
 	var sessionMeta *Metadata
 	for i := range len(checkpointSummary.Sessions) {
-		metaPath := fmt.Sprintf("%s%d/%s", basePath, i, paths.MetadataFileName)
+		metaPath := checkpointSubtreePath(basePath, strconv.Itoa(i), paths.MetadataFileName)
 		if metaEntry, metaExists := entries[metaPath]; metaExists {
 			meta, metaErr := s.readMetadataFromBlob(metaEntry.Hash)
 			if metaErr == nil && meta.SessionID == opts.SessionID {
@@ -361,13 +374,13 @@ func (s *treeWriter) applyTranscriptBackfill(ctx context.Context, opts UpdateOpt
 			slog.String("checkpoint_id", string(opts.CheckpointID)),
 			slog.Int("fallback_index", sessionIndex),
 		)
-		metaPath := fmt.Sprintf("%s%d/%s", basePath, sessionIndex, paths.MetadataFileName)
+		metaPath := checkpointSubtreePath(basePath, strconv.Itoa(sessionIndex), paths.MetadataFileName)
 		if metaEntry, metaExists := entries[metaPath]; metaExists {
 			sessionMeta, _ = s.readMetadataFromBlob(metaEntry.Hash) //nolint:errcheck // best-effort; nil meta means start 0
 		}
 	}
 
-	sessionPath := fmt.Sprintf("%s%d/", basePath, sessionIndex)
+	sessionDir := checkpointSubtreePath(basePath, strconv.Itoa(sessionIndex))
 
 	// Replace transcript (full replace, not append).
 	// Transcript is pre-redacted by the caller (enforced by RedactedBytes type).
@@ -380,7 +393,7 @@ func (s *treeWriter) applyTranscriptBackfill(ctx context.Context, opts UpdateOpt
 				agentType = sessionMeta.Agent
 			}
 		}
-		if err := s.replaceTranscript(ctx, opts.Transcript, agentType, startLine, opts.PrecomputedBlobs, sessionPath, entries); err != nil {
+		if err := s.replaceTranscript(ctx, opts.Transcript, agentType, startLine, opts.PrecomputedBlobs, sessionDir, entries); err != nil {
 			return plumbing.ZeroHash, fmt.Errorf("failed to replace transcript: %w", err)
 		}
 
@@ -390,8 +403,8 @@ func (s *treeWriter) applyTranscriptBackfill(ctx context.Context, opts UpdateOpt
 		// succeeds now), so re-derive the pointer from the tree entry and rewrite
 		// the root summary when it changed.
 		compactPath := ""
-		if _, ok := entries[sessionPath+paths.CompactTranscriptFileName]; ok {
-			compactPath = "/" + sessionPath + paths.CompactTranscriptFileName
+		if _, ok := entries[checkpointSubtreePath(sessionDir, paths.CompactTranscriptFileName)]; ok {
+			compactPath = "/" + checkpointSubtreePath(sessionDir, paths.CompactTranscriptFileName)
 		}
 		if checkpointSummary.Sessions[sessionIndex].CompactTranscript != compactPath {
 			checkpointSummary.Sessions[sessionIndex].CompactTranscript = compactPath
@@ -418,15 +431,16 @@ func (s *treeWriter) applyTranscriptBackfill(ctx context.Context, opts UpdateOpt
 		if err != nil {
 			return plumbing.ZeroHash, fmt.Errorf("failed to create prompt blob: %w", err)
 		}
-		entries[sessionPath+paths.PromptFileName] = object.TreeEntry{
-			Name: sessionPath + paths.PromptFileName,
+		promptPath := checkpointSubtreePath(sessionDir, paths.PromptFileName)
+		entries[promptPath] = object.TreeEntry{
+			Name: promptPath,
 			Mode: filemode.Regular,
 			Hash: blobHash,
 		}
 	}
 
 	if len(opts.SkillEvents) > 0 {
-		if err := s.replaceSkillEvents(opts.SkillEvents, sessionPath, entries); err != nil {
+		if err := s.replaceSkillEvents(opts.SkillEvents, sessionDir, entries); err != nil {
 			return plumbing.ZeroHash, fmt.Errorf("failed to replace skill events: %w", err)
 		}
 	}
@@ -436,16 +450,16 @@ func (s *treeWriter) applyTranscriptBackfill(ctx context.Context, opts UpdateOpt
 
 // writeTaskCheckpointEntries writes task-specific checkpoint entries and returns the task metadata path.
 func (s *treeWriter) writeTaskCheckpointEntries(ctx context.Context, opts WriteOptions, basePath string, entries map[string]object.TreeEntry) (string, error) {
-	taskPath := basePath + "tasks/" + opts.ToolUseID + "/"
+	taskDir := checkpointSubtreePath(basePath, "tasks", opts.ToolUseID)
 
 	if opts.IsIncremental {
-		return s.writeIncrementalTaskCheckpoint(opts, taskPath, entries)
+		return s.writeIncrementalTaskCheckpoint(opts, taskDir, entries)
 	}
-	return s.writeFinalTaskCheckpoint(ctx, opts, taskPath, entries)
+	return s.writeFinalTaskCheckpoint(ctx, opts, taskDir, entries)
 }
 
 // writeIncrementalTaskCheckpoint writes an incremental checkpoint file during task execution.
-func (s *treeWriter) writeIncrementalTaskCheckpoint(opts WriteOptions, taskPath string, entries map[string]object.TreeEntry) (string, error) {
+func (s *treeWriter) writeIncrementalTaskCheckpoint(opts WriteOptions, taskDir string, entries map[string]object.TreeEntry) (string, error) {
 	incData, err := redact.JSONLBytes(opts.IncrementalData)
 	if err != nil {
 		return "", fmt.Errorf("failed to redact incremental checkpoint: %w", err)
@@ -466,7 +480,7 @@ func (s *treeWriter) writeIncrementalTaskCheckpoint(opts WriteOptions, taskPath 
 	}
 
 	cpFilename := fmt.Sprintf("%03d-%s.json", opts.IncrementalSequence, opts.ToolUseID)
-	cpPath := taskPath + "checkpoints/" + cpFilename
+	cpPath := checkpointSubtreePath(taskDir, "checkpoints", cpFilename)
 	entries[cpPath] = object.TreeEntry{
 		Name: cpPath,
 		Mode: filemode.Regular,
@@ -476,7 +490,7 @@ func (s *treeWriter) writeIncrementalTaskCheckpoint(opts WriteOptions, taskPath 
 }
 
 // writeFinalTaskCheckpoint writes the final checkpoint.json and subagent transcript.
-func (s *treeWriter) writeFinalTaskCheckpoint(ctx context.Context, opts WriteOptions, taskPath string, entries map[string]object.TreeEntry) (string, error) {
+func (s *treeWriter) writeFinalTaskCheckpoint(ctx context.Context, opts WriteOptions, taskDir string, entries map[string]object.TreeEntry) (string, error) {
 	checkpoint := taskCheckpointData{
 		SessionID:      opts.SessionID,
 		ToolUseID:      opts.ToolUseID,
@@ -492,7 +506,7 @@ func (s *treeWriter) writeFinalTaskCheckpoint(ctx context.Context, opts WriteOpt
 		return "", fmt.Errorf("failed to create task checkpoint blob: %w", err)
 	}
 
-	checkpointFile := taskPath + "checkpoint.json"
+	checkpointFile := checkpointSubtreePath(taskDir, "checkpoint.json")
 	entries[checkpointFile] = object.TreeEntry{
 		Name: checkpointFile,
 		Mode: filemode.Regular,
@@ -518,7 +532,7 @@ func (s *treeWriter) writeFinalTaskCheckpoint(ctx context.Context, opts WriteOpt
 
 			agentBlobHash, agentBlobErr := CreateBlobFromContent(s.repo, agentContent)
 			if agentBlobErr == nil {
-				agentPath := taskPath + "agent-" + opts.AgentID + ".jsonl"
+				agentPath := checkpointSubtreePath(taskDir, "agent-"+opts.AgentID+".jsonl")
 				entries[agentPath] = object.TreeEntry{
 					Name: agentPath,
 					Mode: filemode.Regular,
@@ -528,8 +542,8 @@ func (s *treeWriter) writeFinalTaskCheckpoint(ctx context.Context, opts WriteOpt
 		}
 	}
 
-	// Return task path without trailing slash
-	return taskPath[:len(taskPath)-1], nil
+	// taskDir is already a clean path (no trailing slash).
+	return taskDir, nil
 }
 
 // writeStandardCheckpointEntries writes session files to numbered subdirectories and
@@ -550,7 +564,7 @@ func (s *treeWriter) writeFinalTaskCheckpoint(ctx context.Context, opts WriteOpt
 func (s *treeWriter) writeStandardCheckpointEntries(ctx context.Context, opts WriteOptions, basePath string, entries map[string]object.TreeEntry, checkpointVersion string) error {
 	// Read existing summary to get current session count
 	var existingSummary *CheckpointSummary
-	metadataPath := basePath + paths.MetadataFileName
+	metadataPath := checkpointSubtreePath(basePath, paths.MetadataFileName)
 	if entry, exists := entries[metadataPath]; exists {
 		existing, err := s.readSummaryFromBlob(entry.Hash)
 		if err == nil {
@@ -575,7 +589,7 @@ func (s *treeWriter) writeStandardCheckpointEntries(ctx context.Context, opts Wr
 	// We read and capture BEFORE writeSessionToSubdirectory clears the subtree,
 	// otherwise we'd only ever see our own write.
 	if sessionIndex == 0 {
-		if entry, exists := entries[fmt.Sprintf("%s0/%s", basePath, paths.MetadataFileName)]; exists {
+		if entry, exists := entries[checkpointSubtreePath(basePath, "0", paths.MetadataFileName)]; exists {
 			if existingMeta, readErr := s.readMetadataFromBlob(entry.Hash); readErr == nil && existingMeta.SessionID != opts.SessionID {
 				logging.Error(ctx, "refusing checkpoint write: session 0 holds a different sessionID",
 					slog.String("checkpoint_id", opts.CheckpointID.String()),
@@ -591,15 +605,15 @@ func (s *treeWriter) writeStandardCheckpointEntries(ctx context.Context, opts Wr
 	}
 
 	// Write session files to numbered subdirectory
-	sessionPath := fmt.Sprintf("%s%d/", basePath, sessionIndex)
-	sessionFilePaths, err := s.writeSessionToSubdirectory(ctx, opts, sessionPath, entries)
+	sessionDir := checkpointSubtreePath(basePath, strconv.Itoa(sessionIndex))
+	sessionFilePaths, err := s.writeSessionToSubdirectory(ctx, opts, sessionDir, entries)
 	if err != nil {
 		return err
 	}
 
 	// Copy additional metadata files from directory if specified (to session subdirectory)
 	if opts.MetadataDir != "" {
-		if err := s.copyMetadataDir(ctx, opts.MetadataDir, sessionPath, entries); err != nil {
+		if err := s.copyMetadataDir(ctx, opts.MetadataDir, sessionDir, entries); err != nil {
 			return fmt.Errorf("failed to copy metadata directory: %w", err)
 		}
 	}
@@ -623,7 +637,7 @@ func (s *treeWriter) writeStandardCheckpointEntries(ctx context.Context, opts Wr
 	// metadata with a DIFFERENT sessionID, that's the exact bug shape.
 	// Loud WARN so we get a log trace instead of only the symptom.
 	if sessionIndex == 0 {
-		path := fmt.Sprintf("%s0/%s", basePath, paths.MetadataFileName)
+		path := checkpointSubtreePath(basePath, "0", paths.MetadataFileName)
 		if entry, exists := entries[path]; exists {
 			if existingMeta, readErr := s.readMetadataFromBlob(entry.Hash); readErr == nil && existingMeta.SessionID != opts.SessionID {
 				logging.Warn(ctx, "checkpoint write overwrites session 0 with a different sessionID — potential overwrite regression",
@@ -641,13 +655,14 @@ func (s *treeWriter) writeStandardCheckpointEntries(ctx context.Context, opts Wr
 
 // writeSessionToSubdirectory writes a single session's files to a numbered subdirectory.
 // Returns the absolute file paths from the git tree root for the sessions map.
-func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteOptions, sessionPath string, entries map[string]object.TreeEntry) (SessionFilePaths, error) {
+func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteOptions, sessionDir string, entries map[string]object.TreeEntry) (SessionFilePaths, error) {
 	filePaths := SessionFilePaths{}
 
-	// Clear any existing entries at this path so stale files from a previous
-	// write (e.g. prompt.txt) don't persist on overwrite.
+	// Clear any existing entries under this session dir so stale files from a
+	// previous write (e.g. prompt.txt) don't persist on overwrite. Match on the
+	// dir plus "/" so a sibling session (e.g. "10") isn't caught by "1".
 	for key := range entries {
-		if strings.HasPrefix(key, sessionPath) {
+		if strings.HasPrefix(key, sessionDir+"/") {
 			delete(entries, key)
 		}
 	}
@@ -655,17 +670,17 @@ func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteO
 	// Write transcript. Transcript points at full.jsonl (CLI
 	// rewind/resume/explain read it by filename); the compact transcript.jsonl,
 	// when written, is also pushed and pointed at by CompactTranscript.
-	wroteTranscript, compactTranscriptStart, err := s.writeTranscript(ctx, opts, sessionPath, entries)
+	wroteTranscript, compactTranscriptStart, err := s.writeTranscript(ctx, opts, sessionDir, entries)
 	if err != nil {
 		return filePaths, err
 	}
 	if wroteTranscript {
-		filePaths.Transcript = "/" + sessionPath + paths.TranscriptFileName
-		filePaths.ContentHash = "/" + sessionPath + paths.ContentHashFileName
+		filePaths.Transcript = "/" + checkpointSubtreePath(sessionDir, paths.TranscriptFileName)
+		filePaths.ContentHash = "/" + checkpointSubtreePath(sessionDir, paths.ContentHashFileName)
 		// Point at the compact transcript only when it was actually written
 		// (best-effort), deriving from the tree entry so the path can't dangle.
-		if _, ok := entries[sessionPath+paths.CompactTranscriptFileName]; ok {
-			filePaths.CompactTranscript = "/" + sessionPath + paths.CompactTranscriptFileName
+		if _, ok := entries[checkpointSubtreePath(sessionDir, paths.CompactTranscriptFileName)]; ok {
+			filePaths.CompactTranscript = "/" + checkpointSubtreePath(sessionDir, paths.CompactTranscriptFileName)
 		}
 	}
 
@@ -677,12 +692,13 @@ func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteO
 		if err != nil {
 			return filePaths, err
 		}
-		entries[sessionPath+paths.PromptFileName] = object.TreeEntry{
-			Name: sessionPath + paths.PromptFileName,
+		promptPath := checkpointSubtreePath(sessionDir, paths.PromptFileName)
+		entries[promptPath] = object.TreeEntry{
+			Name: promptPath,
 			Mode: filemode.Regular,
 			Hash: blobHash,
 		}
-		filePaths.Prompt = "/" + sessionPath + paths.PromptFileName
+		filePaths.Prompt = "/" + promptPath
 	}
 
 	// Write session-level metadata.json (Metadata with all fields including initial_attribution)
@@ -727,12 +743,13 @@ func (s *treeWriter) writeSessionToSubdirectory(ctx context.Context, opts WriteO
 	if err != nil {
 		return filePaths, err
 	}
-	entries[sessionPath+paths.MetadataFileName] = object.TreeEntry{
-		Name: sessionPath + paths.MetadataFileName,
+	sessionMetadataPath := checkpointSubtreePath(sessionDir, paths.MetadataFileName)
+	entries[sessionMetadataPath] = object.TreeEntry{
+		Name: sessionMetadataPath,
 		Mode: filemode.Regular,
 		Hash: metadataHash,
 	}
-	filePaths.Metadata = "/" + sessionPath + paths.MetadataFileName
+	filePaths.Metadata = "/" + sessionMetadataPath
 
 	return filePaths, nil
 }
@@ -752,7 +769,7 @@ func (s *treeWriter) writeCheckpointSummary(opts WriteOptions, basePath string, 
 	// was imported (Kind == "imported"). Compared as a literal because the
 	// session package imports checkpoint, so we can't reference its constant.
 	imported := opts.Kind == "imported"
-	rootMetadataPath := basePath + paths.MetadataFileName
+	rootMetadataPath := checkpointSubtreePath(basePath, paths.MetadataFileName)
 	if entry, exists := entries[rootMetadataPath]; exists {
 		existingSummary, readErr := s.readSummaryFromBlob(entry.Hash)
 		if readErr == nil {
@@ -796,8 +813,8 @@ func (s *treeWriter) writeCheckpointSummary(opts WriteOptions, basePath string, 
 	if err != nil {
 		return err
 	}
-	entries[basePath+paths.MetadataFileName] = object.TreeEntry{
-		Name: basePath + paths.MetadataFileName,
+	entries[rootMetadataPath] = object.TreeEntry{
+		Name: rootMetadataPath,
 		Mode: filemode.Regular,
 		Hash: metadataHash,
 	}
@@ -851,7 +868,7 @@ func (s *treeWriter) findSessionIndex(ctx context.Context, basePath string, exis
 		return 0
 	}
 	for i := range len(existingSummary.Sessions) {
-		path := fmt.Sprintf("%s%d/%s", basePath, i, paths.MetadataFileName)
+		path := checkpointSubtreePath(basePath, strconv.Itoa(i), paths.MetadataFileName)
 		entry, exists := entries[path]
 		if !exists {
 			continue
@@ -880,7 +897,7 @@ func (s *treeWriter) reaggregateFromEntries(basePath string, sessionCount int, e
 	var totalTokens *agent.TokenUsage
 
 	for i := range sessionCount {
-		path := fmt.Sprintf("%s%d/%s", basePath, i, paths.MetadataFileName)
+		path := checkpointSubtreePath(basePath, strconv.Itoa(i), paths.MetadataFileName)
 		entry, exists := entries[path]
 		if !exists {
 			return 0, nil, nil, fmt.Errorf("session %d metadata not found at %s", i, path)
@@ -972,7 +989,7 @@ func aggregateTokenUsage(a, b *agent.TokenUsage) *agent.TokenUsage {
 // empty, nothing written); compactStart is the line offset of this checkpoint's
 // slice within the compact transcript, to record as CompactTranscriptStart, or
 // nil when no compact transcript was produced.
-func (s *treeWriter) writeTranscript(ctx context.Context, opts WriteOptions, basePath string, entries map[string]object.TreeEntry) (bool, *int, error) {
+func (s *treeWriter) writeTranscript(ctx context.Context, opts WriteOptions, sessionDir string, entries map[string]object.TreeEntry) (bool, *int, error) {
 	logCtx := logging.WithComponent(ctx, "checkpoint")
 	transcriptBytes := opts.Transcript.Bytes()
 
@@ -1017,7 +1034,7 @@ func (s *treeWriter) writeTranscript(ctx context.Context, opts WriteOptions, bas
 	blobStart := time.Now()
 	blobCtx, writeTranscriptBlobsSpan := perf.Start(chunkCtx, "write_transcript_blobs")
 	for i, chunk := range chunks {
-		chunkPath := basePath + agent.ChunkFileName(paths.TranscriptFileName, i)
+		chunkPath := checkpointSubtreePath(sessionDir, agent.ChunkFileName(paths.TranscriptFileName, i))
 		blobHash, err := CreateBlobFromContent(s.repo, chunk)
 		if err != nil {
 			writeTranscriptBlobsSpan.RecordError(err)
@@ -1043,8 +1060,9 @@ func (s *treeWriter) writeTranscript(ctx context.Context, opts WriteOptions, bas
 		contentHashSpan.End()
 		return false, nil, err
 	}
-	entries[basePath+paths.ContentHashFileName] = object.TreeEntry{
-		Name: basePath + paths.ContentHashFileName,
+	contentHashPath := checkpointSubtreePath(sessionDir, paths.ContentHashFileName)
+	entries[contentHashPath] = object.TreeEntry{
+		Name: contentHashPath,
 		Mode: filemode.Regular,
 		Hash: hashBlob,
 	}
@@ -1055,7 +1073,7 @@ func (s *treeWriter) writeTranscript(ctx context.Context, opts WriteOptions, bas
 	// full.jsonl, which the CLI read paths resolve by filename. compactStart is
 	// the line offset of this checkpoint's slice within the full compact output,
 	// recorded into session metadata so downstream readers can segment it.
-	compactStart := s.writeCompactTranscript(logCtx, opts.Agent, opts.CheckpointTranscriptStart, transcriptBytes, basePath, entries)
+	compactStart := s.writeCompactTranscript(logCtx, opts.Agent, opts.CheckpointTranscriptStart, transcriptBytes, sessionDir, entries)
 
 	logging.Debug(logCtx, "write transcript timings",
 		slog.String("session_id", opts.SessionID),
@@ -1081,7 +1099,7 @@ func compactAgentName(agentType types.AgentType) string {
 }
 
 // writeCompactTranscript converts the pre-redacted full transcript into the
-// compact transcript.jsonl format and records it at sessionPath in the tree.
+// compact transcript.jsonl format and records it under sessionDir in the tree.
 // The whole session is compacted (so each checkpoint is self-contained); the
 // returned offset is the line in the compact output at which this checkpoint's
 // data begins (derived from startLine), to be stored as
@@ -1093,7 +1111,7 @@ func compactAgentName(agentType types.AgentType) string {
 // already be sanitized for the agent (e.g. Codex portable-transcript
 // sanitization); callers sanitize before calling so the expensive pass runs
 // exactly once.
-func (s *treeWriter) writeCompactTranscript(ctx context.Context, agentType types.AgentType, startLine int, transcriptBytes []byte, sessionPath string, entries map[string]object.TreeEntry) *int {
+func (s *treeWriter) writeCompactTranscript(ctx context.Context, agentType types.AgentType, startLine int, transcriptBytes []byte, sessionDir string, entries map[string]object.TreeEntry) *int {
 	compactCtx, compactSpan := perf.Start(ctx, "write_compact_transcript")
 	defer compactSpan.End()
 
@@ -1132,7 +1150,7 @@ func (s *treeWriter) writeCompactTranscript(ctx context.Context, agentType types
 		)
 		return nil
 	}
-	compactPath := sessionPath + paths.CompactTranscriptFileName
+	compactPath := checkpointSubtreePath(sessionDir, paths.CompactTranscriptFileName)
 	entries[compactPath] = object.TreeEntry{
 		Name: compactPath,
 		Mode: filemode.Regular,
@@ -1761,8 +1779,8 @@ func (s *GitStore) backfillTranscript(ctx context.Context, opts UpdateOptions) e
 // mutate, and rewrites the blob. Reading from the blob (rather than an in-memory
 // copy) keeps it correct when several finalize-path steps mutate the same
 // metadata in sequence — each sees the prior step's changes.
-func (s *treeWriter) updateSessionMetadata(sessionPath string, entries map[string]object.TreeEntry, mutate func(*Metadata)) error {
-	metadataPath := sessionPath + paths.MetadataFileName
+func (s *treeWriter) updateSessionMetadata(sessionDir string, entries map[string]object.TreeEntry, mutate func(*Metadata)) error {
+	metadataPath := checkpointSubtreePath(sessionDir, paths.MetadataFileName)
 	entry, exists := entries[metadataPath]
 	if !exists {
 		return fmt.Errorf("session metadata not found at %s", metadataPath)
@@ -1819,7 +1837,7 @@ func (s *treeWriter) setCompactTranscriptStart(sessionPath string, start *int, e
 // reuse precomputed blobs: each checkpoint in a turn shares the full
 // transcript but has its own start offset, so the compact content differs per
 // checkpoint.
-func (s *treeWriter) replaceTranscript(ctx context.Context, transcript redact.RedactedBytes, agentType types.AgentType, startLine int, precomputed *PrecomputedTranscriptBlobs, sessionPath string, entries map[string]object.TreeEntry) error {
+func (s *treeWriter) replaceTranscript(ctx context.Context, transcript redact.RedactedBytes, agentType types.AgentType, startLine int, precomputed *PrecomputedTranscriptBlobs, sessionDir string, entries map[string]object.TreeEntry) error {
 	// Ignore precompute if invariants are violated — fall back to fresh chunking.
 	if precomputed != nil && !precomputed.IsUsable() {
 		precomputed = nil
@@ -1836,7 +1854,7 @@ func (s *treeWriter) replaceTranscript(ctx context.Context, transcript redact.Re
 	// Short-circuit: if the existing content_hash.txt already matches, the
 	// chunk entries currently in `entries` represent the same content. Leave
 	// everything as-is and skip chunking + zlib.
-	hashPath := sessionPath + paths.ContentHashFileName
+	hashPath := checkpointSubtreePath(sessionDir, paths.ContentHashFileName)
 	if existing, ok := entries[hashPath]; ok {
 		if blob, err := s.repo.BlobObject(existing.Hash); err == nil {
 			if rdr, rerr := blob.Reader(); rerr == nil {
@@ -1850,7 +1868,7 @@ func (s *treeWriter) replaceTranscript(ctx context.Context, transcript redact.Re
 	}
 
 	// Remove existing transcript files (base + any chunks)
-	transcriptBase := sessionPath + paths.TranscriptFileName
+	transcriptBase := checkpointSubtreePath(sessionDir, paths.TranscriptFileName)
 	for key := range entries {
 		if key == transcriptBase || strings.HasPrefix(key, transcriptBase+".") {
 			delete(entries, key)
@@ -1878,7 +1896,7 @@ func (s *treeWriter) replaceTranscript(ctx context.Context, transcript redact.Re
 
 	// Record chunk files in the tree at v1 (full.jsonl) naming.
 	for i, blobHash := range chunkHashes {
-		chunkPath := sessionPath + agent.ChunkFileName(paths.TranscriptFileName, i)
+		chunkPath := checkpointSubtreePath(sessionDir, agent.ChunkFileName(paths.TranscriptFileName, i))
 		entries[chunkPath] = object.TreeEntry{
 			Name: chunkPath,
 			Mode: filemode.Regular,
@@ -1911,7 +1929,7 @@ func (s *treeWriter) replaceTranscript(ctx context.Context, transcript redact.Re
 	if agentType == agent.AgentTypeCodex {
 		compactBytes = codex.SanitizePortableTranscript(compactBytes)
 	}
-	compactStart := s.writeCompactTranscript(ctx, agentType, startLine, compactBytes, sessionPath, entries)
+	compactStart := s.writeCompactTranscript(ctx, agentType, startLine, compactBytes, sessionDir, entries)
 
 	// If regeneration produced no compact transcript (failure, empty, or
 	// oversized), drop any stale transcript.jsonl carried over from the prior
@@ -1921,13 +1939,13 @@ func (s *treeWriter) replaceTranscript(ctx context.Context, transcript redact.Re
 	// re-redacted full transcript. The caller re-derives the root summary's
 	// compact_transcript pointer from the (now absent) tree entry.
 	if compactStart == nil {
-		delete(entries, sessionPath+paths.CompactTranscriptFileName)
+		delete(entries, checkpointSubtreePath(sessionDir, paths.CompactTranscriptFileName))
 	}
 
 	// Keep the session metadata's marker consistent with the regenerated
 	// transcript.jsonl: record the new boundary when one was produced, or clear
 	// it (nil) when the compact transcript was dropped above.
-	if err := s.setCompactTranscriptStart(sessionPath, compactStart, entries); err != nil {
+	if err := s.setCompactTranscriptStart(sessionDir, compactStart, entries); err != nil {
 		return fmt.Errorf("failed to update compact transcript start: %w", err)
 	}
 
@@ -2078,7 +2096,7 @@ func CreateBlobFromContent(repo *git.Repository, content []byte) (plumbing.Hash,
 
 // copyMetadataDir copies all files from a directory to the checkpoint path.
 // Used to include additional metadata files like task checkpoints, subagent transcripts, etc.
-func (s *treeWriter) copyMetadataDir(ctx context.Context, metadataDir, basePath string, entries map[string]object.TreeEntry) error {
+func (s *treeWriter) copyMetadataDir(ctx context.Context, metadataDir, sessionDir string, entries map[string]object.TreeEntry) error {
 	err := filepath.Walk(metadataDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -2129,7 +2147,7 @@ func (s *treeWriter) copyMetadataDir(ctx context.Context, metadataDir, basePath 
 		}
 
 		// Store at checkpoint path (use forward slashes for git tree compatibility on Windows)
-		fullPath := basePath + filepath.ToSlash(relPath)
+		fullPath := checkpointSubtreePath(sessionDir, filepath.ToSlash(relPath))
 		entries[fullPath] = object.TreeEntry{
 			Name: fullPath,
 			Mode: mode,

--- a/cmd/entire/cli/checkpoint/subtree_path_test.go
+++ b/cmd/entire/cli/checkpoint/subtree_path_test.go
@@ -1,0 +1,33 @@
+package checkpoint
+
+import "testing"
+
+func TestCheckpointSubtreePath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		base string
+		segs []string
+		want string
+	}{
+		// Per-checkpoint-ref root (basePath == "").
+		{"ref root metadata", "", []string{"metadata.json"}, "metadata.json"},
+		{"ref root session meta", "", []string{"0", "metadata.json"}, "0/metadata.json"},
+		// v1 branch layout (basePath has a trailing slash — path.Join cleans it).
+		{"v1 root metadata", "a3/b2c4d5e6f7/", []string{"metadata.json"}, "a3/b2c4d5e6f7/metadata.json"},
+		{"v1 session meta", "a3/b2c4d5e6f7/", []string{"0", "metadata.json"}, "a3/b2c4d5e6f7/0/metadata.json"},
+		{"v1 task file", "a3/b2c4d5e6f7/", []string{"tasks", "tool-1", "checkpoint.json"}, "a3/b2c4d5e6f7/tasks/tool-1/checkpoint.json"},
+		// A clean dir base (no trailing slash) joins identically.
+		{"clean session dir", "a3/b2c4d5e6f7/0", []string{"full.jsonl"}, "a3/b2c4d5e6f7/0/full.jsonl"},
+		// No segments returns the cleaned base (trailing slash stripped).
+		{"base only trailing slash", "a3/b2c4d5e6f7/", nil, "a3/b2c4d5e6f7"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := checkpointSubtreePath(tt.base, tt.segs...); got != tt.want {
+				t.Errorf("checkpointSubtreePath(%q, %v) = %q, want %q", tt.base, tt.segs, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/checkpoint/subtree_path_test.go
+++ b/cmd/entire/cli/checkpoint/subtree_path_test.go
@@ -21,6 +21,8 @@ func TestCheckpointSubtreePath(t *testing.T) {
 		{"clean session dir", "a3/b2c4d5e6f7/0", []string{"full.jsonl"}, "a3/b2c4d5e6f7/0/full.jsonl"},
 		// No segments returns the cleaned base (trailing slash stripped).
 		{"base only trailing slash", "a3/b2c4d5e6f7/", nil, "a3/b2c4d5e6f7"},
+		// Ref root with no segments must stay "" (not path.Join's "." cleaning).
+		{"ref root base only", "", nil, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/703
<!-- entire-trail-link-end -->

Follow-up cleanup: replace the trailing-slash string-concat checkpoint-subtree path construction with a `path.Join`-based helper, so paths join correctly without relying on the "`basePath` ends with `/`" invariant. Prompted by review feedback that `fmt.Sprintf("%s%d/%s", basePath, latestIndex, paths.MetadataFileName)` *looks* like it's missing a `/` (it's correct today only because `basePath` carries the trailing slash).

> Stacked on #1566 (git-refs backend). Diff here is only the path-construction cleanup.

## Change
- New helper `checkpointSubtreePath(base string, segs ...string) string` → stdlib `path.Join` (**not** `path/filepath` — git tree paths are always `/`; `filepath` would emit `\` on Windows and corrupt tree keys). Joins correctly for `base == ""` (per-checkpoint-ref root), `"<shard>/<id>/"` (v1), or any clean dir.
- Converted the full-path construction sites (the flagged pattern + siblings) to the helper.
- Made the directory-prefix intermediates (`sessionDir`, `taskDir`) **clean paths** and updated all their consumers to join via the helper, instead of relying on a load-bearing trailing slash for `prefix + filename`.
- Edge case (from review): with no trailing segments, `path.Join("")` cleans to `"."` — an invalid tree key. The helper special-cases this so the ref root (`base == ""`) returns `""` and a non-empty base returns its cleaned form; a `ref root base only` test locks it in.

## No behavior change
These are committed-metadata tree keys, so the bar is byte-identical trees. Two trailing-slash-sensitive spots were handled explicitly: the stale-entry clear now matches `sessionDir + "/"` (so session `"1"` doesn't match `"10"`), and the leading-slash `SessionFilePaths` values are preserved exactly.

## Testing
`mise run lint` 0; full unit (incl. the checkpoint tree-structure + tripwire/update assertions that are the byte-identical gate); integration 379; canary green both modes (git-branch 59/59 + roger 4/4; `E2E_CHECKPOINT_STORE=git-refs` 58/59 +1 skip + roger 4/4) — all unchanged.

Refs: #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only path joining in checkpoint persistence with explicit prefix fix and tests; risk is low if byte-identical tree tests pass, but any join mistake would corrupt metadata keys.
> 
> **Overview**
> Introduces **`checkpointSubtreePath`** (`path.Join`, not `path/filepath`) so checkpoint git tree keys are built with forward slashes on all platforms and callers no longer depend on a trailing slash on `basePath`.
> 
> **`persistent.go`** routes session, task, transcript, backfill, and metadata paths through that helper; directory handles are **`sessionDir` / `taskDir`** (clean paths) instead of load-bearing `…/` prefixes. Stale session entry cleanup now matches **`sessionDir + "/"`** so session `1` does not wipe sibling `10`.
> 
> Adds **`subtree_path_test.go`** for join behavior across ref-root, v1 sharded, and clean-dir bases. Intended as a no-op on committed tree bytes; existing checkpoint tests are the regression gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318e49ef90fbee247519d9b783031683ecb11ac8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
