### PR TITLE
Tackle failing E2E tests, part 1

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,7 +109,15 @@ jobs:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
           E2E_CONCURRENT_TEST_LIMIT: ${{ matrix.agent == 'gemini-cli' && '6' || matrix.agent == 'factoryai-droid' && '1' || matrix.agent == 'cursor-cli' && '2' || '' }}
-        run: mise run test:e2e --agent ${{ matrix.agent }} ${{ matrix.agent == 'roger-roger' && 'TestExternalAgent' || '' }}
+        # roger-roger is deterministic, so it runs through its dedicated task,
+        # which does NOT enable --rerun-fails. Routing it through the default
+        # task (`test:e2e`) would retry a real regression and mask it.
+        run: |
+          if [ "${{ matrix.agent }}" = "roger-roger" ]; then
+            mise run test:e2e:roger-roger TestExternalAgent
+          else
+            mise run test:e2e --agent ${{ matrix.agent }}
+          fi
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,14 +128,64 @@ jobs:
     needs: [e2e-tests, e2e-windows]
     if: ${{ always() && (needs.e2e-tests.result == 'failure' || needs.e2e-windows.result == 'failure') && github.event_name == 'push' }}
     steps:
-      - name: Get failed agents
-        id: failed
+      # Classify the failed jobs into two severities:
+      #   RED    — a "reliable" agent (or Windows) failed. These pass on every
+      #            healthy run, so a failure here is a real regression.
+      #   YELLOW — only a known-flaky agent failed. Worth investigating, but not
+      #            a `main` regression. Reported so we don't lose visibility.
+      - name: Classify failures
+        id: classify
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          failed=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-            --jq '[.jobs[] | select(.conclusion == "failure") | .name | if test("\\(") then capture("\\((?<agent>[^)]+)\\)") | .agent else . end] | join(", ")')
-          echo "agents=$failed" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          # Reliable tier (RED). The e2e-windows reusable job is also RED but
+          # is matched separately below since it has no "(agent)" suffix.
+          reliable="claude-code opencode gemini-cli roger-roger"
+
+          failed_names=$(gh api --paginate \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
+            --jq '.jobs[] | select(.conclusion == "failure") | .name')
+
+          red=""
+          yellow=""
+          while IFS= read -r name; do
+            [ -z "$name" ] && continue
+            case "$name" in
+              *e2e-windows*) red="$red windows"; continue ;;
+            esac
+            # "e2e-tests (cursor-cli)" -> "cursor-cli"
+            agent="${name#*(}"; agent="${agent%)*}"
+            case " $reliable " in
+              *" $agent "*) red="$red $agent" ;;
+              *)            yellow="$yellow $agent" ;;
+            esac
+          done <<EOF
+          $failed_names
+          EOF
+
+          # Normalize to comma-separated lists. paste -d takes a delimiter
+          # *set* used in rotation, so join with a single ',' then space it out.
+          red=$(echo $red | tr ' ' '\n' | sed '/^$/d' | paste -sd, - | sed 's/,/, /g')
+          yellow=$(echo $yellow | tr ' ' '\n' | sed '/^$/d' | paste -sd, - | sed 's/,/, /g')
+
+          if [ -n "$red" ]; then
+            color="#d50200"
+            header=":red_circle: *E2E Tests Failed* on \`main\`"
+          else
+            color="#daa038"
+            header=":large_yellow_circle: *E2E flaky-agent failures* on \`main\`"
+          fi
+
+          body=""
+          [ -n "$red" ]    && body="${body}Reliable agents (regression): *${red}*\\n"
+          [ -n "$yellow" ] && body="${body}Flaky agents (investigate): *${yellow}*\\n"
+
+          {
+            echo "color=$color"
+            echo "header=$header"
+            echo "body=$body"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack of E2E failure
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
@@ -144,20 +194,25 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "blocks": [
+              "attachments": [
                 {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":red_circle: *E2E Tests Failed* on `main`\n\nFailed agents: *${{ steps.failed.outputs.agents }}*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run details>"
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
+                  "color": "${{ steps.classify.outputs.color }}",
+                  "blocks": [
                     {
-                      "type": "mrkdwn",
-                      "text": "Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> by ${{ github.actor }}"
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "${{ steps.classify.outputs.header }}\n\n${{ steps.classify.outputs.body }}<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run details>"
+                      }
+                    },
+                    {
+                      "type": "context",
+                      "elements": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> by ${{ github.actor }}"
+                        }
+                      ]
                     }
                   ]
                 }

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -172,10 +172,10 @@ jobs:
           $failed_names
           EOF
 
-          # Normalize to comma-separated lists. paste -d takes a delimiter
-          # *set* used in rotation, so join with a single ',' then space it out.
-          red=$(echo $red | tr ' ' '\n' | sed '/^$/d' | paste -sd, - | sed 's/,/, /g')
-          yellow=$(echo $yellow | tr ' ' '\n' | sed '/^$/d' | paste -sd, - | sed 's/,/, /g')
+          # Each list was built as " a b c" (leading space, space-separated).
+          # Strip the leading space, then join on ", ". Empty stays empty.
+          red="${red# }";       red="${red// /, }"
+          yellow="${yellow# }"; yellow="${yellow// /, }"
 
           if [ -n "$red" ]; then
             color="#d50200"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,7 +108,7 @@ jobs:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
-          E2E_CONCURRENT_TEST_LIMIT: ${{ matrix.agent == 'gemini-cli' && '6' || matrix.agent == 'factoryai-droid' && '1' || '' }}
+          E2E_CONCURRENT_TEST_LIMIT: ${{ matrix.agent == 'gemini-cli' && '6' || matrix.agent == 'factoryai-droid' && '1' || matrix.agent == 'cursor-cli' && '2' || '' }}
         run: mise run test:e2e --agent ${{ matrix.agent }} ${{ matrix.agent == 'roger-roger' && 'TestExternalAgent' || '' }}
 
       - name: Upload artifacts

--- a/e2e/agents/cursor_cli.go
+++ b/e2e/agents/cursor_cli.go
@@ -16,6 +16,10 @@ func init() {
 		return
 	}
 	Register(&CursorCLI{})
+	// Cursor is rate-limited ("Increase limits for faster responses"), so gate
+	// its parallelism. Without a registered gate, AcquireSlot is a no-op and the
+	// E2E_CONCURRENT_TEST_LIMIT override the workflow sets has no effect.
+	RegisterGate("cursor-cli", 2)
 }
 
 // CursorCLI implements the E2E Agent interface for the Cursor Agent CLI binary.

--- a/e2e/agents/droid.go
+++ b/e2e/agents/droid.go
@@ -20,6 +20,10 @@ func init() {
 		return
 	}
 	Register(&Droid{})
+	// factoryai-droid is run serially in CI (E2E_CONCURRENT_TEST_LIMIT=1).
+	// Without a registered gate, AcquireSlot is a no-op and that limit has no
+	// effect; register the gate so the intended serialization is respected.
+	RegisterGate("factoryai-droid", 1)
 }
 
 // Droid implements the Agent interface for Factory AI Droid.

--- a/e2e/tests/codex_resume_test.go
+++ b/e2e/tests/codex_resume_test.go
@@ -3,11 +3,11 @@
 package tests
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 	"time"
 
@@ -77,10 +77,32 @@ func readCodexSessionID(t *testing.T, rolloutPath string) string {
 	data, err := os.ReadFile(rolloutPath)
 	require.NoError(t, err)
 
-	re := regexp.MustCompile(`(?m)^\{"timestamp":".*","type":"session_meta","payload":\{"id":"([^"]+)"`)
-	m := re.FindSubmatch(data)
-	require.Len(t, m, 2, "session_meta id not found in rollout")
-	return string(m[1])
+	// Codex rollout files are JSONL; the session id lives in the payload of the
+	// first "session_meta" line. Parse line-by-line rather than anchoring a
+	// regex on field order — Codex reorders JSON keys between versions (the old
+	// regex silently stopped matching on Codex 0.142.x). This mirrors the CLI's
+	// own parser in cmd/entire/cli/agent/codex/transcript.go.
+	for _, raw := range bytes.Split(data, []byte("\n")) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		var line struct {
+			Type    string          `json:"type"`
+			Payload json.RawMessage `json:"payload"`
+		}
+		if err := json.Unmarshal(raw, &line); err != nil || line.Type != "session_meta" {
+			continue
+		}
+		var payload struct {
+			ID string `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(line.Payload, &payload))
+		require.NotEmpty(t, payload.ID, "session_meta payload missing id")
+		return payload.ID
+	}
+
+	t.Fatalf("session_meta line not found in rollout %s", rolloutPath)
+	return ""
 }
 
 func appendCompactedEncryptedHistory(t *testing.T, rolloutPath string) {

--- a/mise-tasks/test/e2e/_default
+++ b/mise-tasks/test/e2e/_default
@@ -31,10 +31,18 @@ filter="${usage_filter:-}"
 # triggers a Go toolchain panic on Windows ARM64 in modload/search.go
 # (slice bounds out of range) and a GetFileInformationByHandleEx error
 # with relative paths.
-gotestsum --format dots --jsonfile "$E2E_ARTIFACT_DIR/test-events.json" -- \
+#
+# --rerun-fails retries only the tests that failed (one extra attempt) to
+# absorb transient real-agent non-determinism. It requires --packages (so the
+# package list can no longer be a trailing positional arg) and -count=1. The
+# default --rerun-fails-max-failures=10 means a broadly-broken run (>10
+# failures) is reported as-is rather than retried, so a genuine regression
+# still surfaces. Do NOT add reruns to the deterministic canary/roger-roger
+# tasks — there a failure is always a real bug and must not be masked.
+gotestsum --format dots --rerun-fails=1 --packages=./e2e/tests \
+  --jsonfile "$E2E_ARTIFACT_DIR/test-events.json" -- \
   -tags=e2e -count=1 -timeout=30m \
-  ${filter:+-run "$filter"} \
-  ./e2e/tests || rc=$?
+  ${filter:+-run "$filter"} || rc=$?
 
 go run ./e2e/cmd/testreport -color -o "$E2E_ARTIFACT_DIR/report.txt" "$E2E_ARTIFACT_DIR/test-events.json"
 echo ""


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/704
<!-- entire-trail-link-end -->

Our E2E tests on main are basically always red.

Broadly:

- Always green: claude-code, opencode, gemini-cli, roger-roger, e2e-windows
- Always red: cursor-cli, copilot-cli, codex, factoryai-droid

This PR:

1. downgrade to a red/yellow indicator: only show red if one of the "always green" ones fails.
2. allow one auto-retry on failure
3. throttle cursor-cli concurrency - it seems like we really often see "Error: Increase limits for faster responses", maybe this helps.
4. fix codex `TestCodexResumeRestoredSessionWithSanitizedCompactedHistory`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E workflows, test harness, and a test helper; no production runtime or auth paths are modified.
> 
> **Overview**
> **CI reliability** for `main` E2E: Slack no longer treats every agent failure as a regression. Failures are split into **reliable** agents (`claude-code`, `opencode`, `gemini-cli`, `roger-roger`, Windows) → red alert, versus **known-flaky** agents → yellow “investigate” alert with colored attachments.
> 
> The default `test:e2e` task now runs **`gotestsum --rerun-fails=1`** (one retry per failed test, capped so broad breakage isn’t masked). **roger-roger** is routed to **`test:e2e:roger-roger`** so deterministic failures are not retried.
> 
> **Concurrency gates** are registered for **`cursor-cli`** (2) and **`factoryai-droid`** (1) so workflow `E2E_CONCURRENT_TEST_LIMIT` values actually apply via `AcquireSlot`. **`TestCodexResumeRestoredSessionWithSanitizedCompactedHistory`** reads Codex rollout **`session_meta`** via JSONL parsing instead of a field-order-sensitive regex (broken on Codex 0.142.x).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 810086c27f6c0b09e0d841c15e6af155a2c01111. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->