### PR TITLE
copilot: don't create phantom sessions for subagent turns

### DIFF
--- a/cmd/entire/cli/agent/copilotcli/lifecycle.go
+++ b/cmd/entire/cli/agent/copilotcli/lifecycle.go
@@ -4,10 +4,23 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/agent"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 )
+
+// subagentSessionIDPrefix is the prefix Copilot uses when it reuses a Task
+// tool-use id as the sessionId on lifecycle hooks fired for a subagent turn.
+// Real Copilot session ids are UUIDs, so this prefix unambiguously marks a
+// subagent context (e.g. "toolu_bdrk_01K…" on Bedrock-backed models).
+const subagentSessionIDPrefix = "toolu_"
+
+// isSubagentSessionID reports whether a Copilot sessionId is actually a
+// subagent's tool-use id rather than a real interactive session id.
+func isSubagentSessionID(sessionID string) bool {
+	return strings.HasPrefix(sessionID, subagentSessionIDPrefix)
+}
 
 // Ensure CopilotCLIAgent implements HookSupport at compile time.
 var _ agent.HookSupport = (*CopilotCLIAgent)(nil)
@@ -66,6 +79,20 @@ func (c *CopilotCLIAgent) ParseHookEvent(ctx context.Context, hookName string, s
 				"hookEventName", env.HookEventName, "hookName", hookName)
 			return nil, nil //nolint:nilnil // Mismatched VS Code event — skip silently.
 		}
+	}
+
+	// Copilot fires the per-turn/session lifecycle hooks for subagent turns too,
+	// using the subagent's Task tool-use id (e.g. "toolu_…") as the sessionId.
+	// Those must NOT spin up a top-level Entire session: the subagent never gets
+	// a matching stop for that id, so the phantom session would stay "active"
+	// forever and pin its shadow branch open after the user commits. The
+	// subagent's work is still captured via the main session's subagentStop →
+	// task checkpoint path, so we drop only the session-lifecycle hooks here and
+	// leave subagentStop itself to run.
+	if hookName != HookNameSubagentStop && isSubagentSessionID(env.SessionID) {
+		logging.Debug(ctx, "copilot-cli: skipping lifecycle event for subagent session",
+			"sessionID", env.SessionID, "hook", hookName)
+		return nil, nil //nolint:nilnil // Subagent lifecycle hook — no top-level session action.
 	}
 
 	switch hookName {

--- a/cmd/entire/cli/agent/copilotcli/lifecycle_test.go
+++ b/cmd/entire/cli/agent/copilotcli/lifecycle_test.go
@@ -358,6 +358,53 @@ func TestParseHookEvent_SubagentStop(t *testing.T) {
 	}
 }
 
+// TestParseHookEvent_SubagentSession_LifecycleHooksReturnNil verifies that the
+// per-turn/session lifecycle hooks are dropped when Copilot fires them for a
+// subagent turn (sessionId is a Task tool-use id, e.g. "toolu_…"). Otherwise a
+// phantom top-level session is created that never ends and pins its shadow
+// branch open after the user commits.
+func TestParseHookEvent_SubagentSession_LifecycleHooksReturnNil(t *testing.T) {
+	t.Parallel()
+
+	const subagentSessionID = "toolu_bdrk_01KTyZvJLaUtkjgvdA355rMX"
+	ag := &CopilotCLIAgent{}
+
+	lifecycleHooks := []string{
+		HookNameUserPromptSubmitted,
+		HookNameSessionStart,
+		HookNameAgentStop,
+		HookNameSessionEnd,
+	}
+
+	for _, hookName := range lifecycleHooks {
+		t.Run(hookName, func(t *testing.T) {
+			t.Parallel()
+			input := `{"timestamp":1771480081360,"cwd":"/path/to/repo","sessionId":"` + subagentSessionID + `","prompt":"hi"}`
+
+			event, err := ag.ParseHookEvent(context.Background(), hookName, strings.NewReader(input))
+
+			require.NoError(t, err)
+			require.Nil(t, event, "expected nil event for subagent-session lifecycle hook %s", hookName)
+		})
+	}
+}
+
+// TestParseHookEvent_SubagentSession_SubagentStopStillFires verifies the
+// subagent-stop hook is NOT dropped — it always carries the main session id and
+// drives the task-checkpoint path.
+func TestParseHookEvent_SubagentSession_SubagentStopStillFires(t *testing.T) {
+	t.Parallel()
+
+	ag := &CopilotCLIAgent{}
+	input := `{"timestamp":1771480085412,"cwd":"/path/to/repo","sessionId":"` + testSessionID + `"}`
+
+	event, err := ag.ParseHookEvent(context.Background(), HookNameSubagentStop, strings.NewReader(input))
+
+	require.NoError(t, err)
+	require.NotNil(t, event, "subagent-stop must still produce an event")
+	require.Equal(t, agent.SubagentEnd, event.Type)
+}
+
 func TestParseHookEvent_PassthroughHooks_ReturnNil(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/705
<!-- entire-trail-link-end -->

Fixes the chronically-failing `TestSubagentCommitFlow` (copilot-cli) — leaked shadow branch on `main`.

**Root cause:** Copilot fires the per-turn/session lifecycle hooks for subagent turns using the Task tool-use id (`toolu_…`) as the `sessionId`. That created a second top-level session that never ends (subagent-stop carries the *main* session id), so it stayed `active` and pinned its shadow branch open. After the user commit, post-commit logged `preserving shadow branch (active session exists)` instead of deleting it → `WaitForNoShadowBranches` failed.

**Fix:** drop the session-lifecycle hooks (user-prompt-submitted, session-start, agent-stop, session-end) when the `sessionId` is a subagent tool-use id (`toolu_` prefix; real Copilot ids are UUIDs). `subagent-stop` is untouched, so the subagent's work is still captured via the main session's task checkpoint.

**Validation:** new copilot unit tests cover both branches (lifecycle hooks dropped for `toolu_` ids; subagent-stop still fires). Full `mise run lint` clean. Real copilot-cli E2E (`TestSubagentCommitFlow`) should be run to confirm end-to-end before merge.

**Out of scope:** the same flow also saves the task checkpoint with an empty `tool_use_id` (malformed `tasks//checkpoint.json`, logged as a WARN) — separate copilot bug, not required for this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session lifecycle handling for Copilot hooks; wrong filtering could drop real sessions or still leak branches, but scope is narrow and covered by new tests.
> 
> **Overview**
> Copilot CLI hook parsing now **ignores** `user-prompt-submitted`, `session-start`, `agent-stop`, and `session-end` when `sessionId` starts with **`toolu_`** (Task tool-use id reused for subagent turns). That stops Entire from opening a **phantom top-level session** that never gets a matching end and leaves shadow branches pinned after commit.
> 
> **`subagent-stop` is unchanged** — it still emits `SubagentEnd` with the real UUID session id so task checkpoints work on the main session.
> 
> Adds `isSubagentSessionID` plus unit tests for dropped lifecycle hooks vs. still-firing `subagent-stop`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f193be6fef9711bd17e3dd025649949f159fa4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->