### PR TITLE
e2e-checkpoint-store: blank agent runs all agents

### DIFF
--- a/.github/workflows/e2e-checkpoint-store.yml
+++ b/.github/workflows/e2e-checkpoint-store.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       agent:
-        description: "Agent to run"
-        required: true
-        default: "vogon"
+        description: "Agent to run (leave empty to run all agents)"
+        required: false
         type: choice
         options:
+          - ""
           - vogon
           - claude-code
           - opencode
@@ -28,13 +28,35 @@ on:
           - git-refs
 
 jobs:
+  # Build the agent matrix dynamically: a single selected agent, or all of them
+  # when the input is left empty.
+  matrix-setup:
+    runs-on: ubuntu-latest
+    outputs:
+      agents: ${{ steps.set.outputs.agents }}
+    steps:
+      - id: set
+        run: |
+          input="${{ github.event.inputs.agent }}"
+          if [ -n "$input" ]; then
+            echo "agents=[\"$input\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo 'agents=["claude-code","opencode","gemini-cli","factoryai-droid","cursor-cli","copilot-cli","roger-roger","codex"]' >> "$GITHUB_OUTPUT"
+          fi
+
   e2e-checkpoint-store:
-    if: inputs.agent != 'copilot-cli'
+    needs: matrix-setup
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
       actions: read
       contents: read
+      # Granted for every leg so copilot-cli works in the matrix; harmless for others.
+      copilot-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        agent: ${{ fromJson(needs.matrix-setup.outputs.agents) }}
 
     steps:
       - name: Checkout repository
@@ -55,13 +77,13 @@ jobs:
         run: go build -o /usr/local/bin/entire ./cmd/entire
 
       - name: Build vogon binary
-        if: inputs.agent == 'vogon'
+        if: matrix.agent == 'vogon'
         run: go build -o /usr/local/bin/vogon ./e2e/vogon
 
       - name: Install agent CLI
-        if: inputs.agent != 'vogon'
+        if: matrix.agent != 'vogon'
         run: |
-          case "${{ inputs.agent }}" in
+          case "${{ matrix.agent }}" in
             claude-code) curl -fsSL https://claude.ai/install.sh | bash ;;
             opencode)    curl -fsSL https://opencode.ai/install | bash ;;
             gemini-cli)  npm install -g @google/gemini-cli ;;
@@ -74,7 +96,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Verify roger-roger agent
-        if: inputs.agent == 'roger-roger'
+        if: matrix.agent == 'roger-roger'
         run: |
           set -euo pipefail
           echo "Verifying roger-roger binaries on PATH..."
@@ -82,89 +104,36 @@ jobs:
           command -v entire-agent-roger-roger
 
       - name: Bootstrap agent
-        if: inputs.agent != 'roger-roger' && inputs.agent != 'vogon'
+        if: matrix.agent != 'roger-roger' && matrix.agent != 'vogon'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-        run: go run ./e2e/bootstrap ${{ inputs.agent }}
+          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+        run: go run ./e2e/bootstrap ${{ matrix.agent }}
 
       - name: E2E Checkpoint Store
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          E2E_CODEX_MODEL: ${{ inputs.agent == 'codex' && 'gpt-5.1-codex-mini' || '' }}
+          E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.1-codex-mini' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts
-          E2E_ENTIRE_BIN: /usr/local/bin/entire
-          E2E_CHECKPOINT_STORE: ${{ inputs.checkpoint_store }}
-        run: |
-          mkdir -p "$E2E_ARTIFACT_DIR"
-          mise run test:e2e --agent ${{ inputs.agent }}
-
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: e2e-checkpoint-store-${{ inputs.agent }}-${{ inputs.checkpoint_store }}
-          path: e2e-artifacts/
-          retention-days: 7
-
-  e2e-checkpoint-store-copilot:
-    if: inputs.agent == 'copilot-cli'
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    permissions:
-      actions: read
-      contents: read
-      copilot-requests: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gnome-keyring tmux
-          echo 'somecredstorepass' | gnome-keyring-daemon --unlock
-
-      - name: Setup mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
-
-      - name: Build entire CLI
-        run: go build -o /usr/local/bin/entire ./cmd/entire
-
-      - name: Install agent CLI
-        run: |
-          npm install -g @github/copilot
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Bootstrap agent
-        env:
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
-        run: go run ./e2e/bootstrap ${{ inputs.agent }}
-
-      - name: E2E Checkpoint Store
-        env:
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts
           E2E_ENTIRE_BIN: /usr/local/bin/entire
           E2E_CHECKPOINT_STORE: ${{ inputs.checkpoint_store }}
         run: |
           mkdir -p "$E2E_ARTIFACT_DIR"
-          mise run test:e2e --agent ${{ inputs.agent }}
+          mise run test:e2e --agent ${{ matrix.agent }}
 
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: e2e-checkpoint-store-${{ inputs.agent }}-${{ inputs.checkpoint_store }}
+          name: e2e-checkpoint-store-${{ matrix.agent }}-${{ inputs.checkpoint_store }}
           path: e2e-artifacts/
           retention-days: 7

--- a/.github/workflows/e2e-checkpoint-store.yml
+++ b/.github/workflows/e2e-checkpoint-store.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       agent:
-        description: "Agent to run (leave empty to run all agents)"
+        description: "Agent to run (leave empty to run all real agents; vogon must be selected explicitly)"
         required: false
         type: choice
         options:
@@ -36,8 +36,13 @@ jobs:
       agents: ${{ steps.set.outputs.agents }}
     steps:
       - id: set
+        # Pass the input through env rather than interpolating it into the script:
+        # `type: choice` only constrains the UI, so a REST-API dispatch could inject
+        # shell metacharacters here otherwise.
+        env:
+          AGENT_INPUT: ${{ github.event.inputs.agent }}
         run: |
-          input="${{ github.event.inputs.agent }}"
+          input="$AGENT_INPUT"
           if [ -n "$input" ]; then
             echo "agents=[\"$input\"]" >> "$GITHUB_OUTPUT"
           else
@@ -119,16 +124,27 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.1-codex-mini' || '' }}
+          # Pin per-agent models and concurrency limits to match e2e.yml so this
+          # workflow tests the same versions and avoids per-agent rate limits.
+          E2E_CODEX_MODEL: ${{ matrix.agent == 'codex' && 'gpt-5.4-mini' || '' }}
+          E2E_GEMINI_MODEL: ${{ matrix.agent == 'gemini-cli' && 'gemini-3.1-flash-lite' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          E2E_CONCURRENT_TEST_LIMIT: ${{ matrix.agent == 'gemini-cli' && '6' || matrix.agent == 'factoryai-droid' && '1' || matrix.agent == 'cursor-cli' && '2' || '' }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts
           E2E_ENTIRE_BIN: /usr/local/bin/entire
           E2E_CHECKPOINT_STORE: ${{ inputs.checkpoint_store }}
+        # roger-roger is deterministic, so it runs through its dedicated task,
+        # which does NOT enable --rerun-fails. Routing it through the default
+        # task (`test:e2e`) would retry a real regression and mask it.
         run: |
           mkdir -p "$E2E_ARTIFACT_DIR"
-          mise run test:e2e --agent ${{ matrix.agent }}
+          if [ "${{ matrix.agent }}" = "roger-roger" ]; then
+            mise run test:e2e:roger-roger TestExternalAgent
+          else
+            mise run test:e2e --agent ${{ matrix.agent }}
+          fi
 
       - name: Upload artifacts
         if: always()


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/706
<!-- entire-trail-link-end -->

Lets the **E2E Checkpoint Store** workflow run **all agents** when the `agent` input is left blank, instead of requiring a single pick — mirroring how `e2e.yml` works.

## Changes
- `agent` input is now optional with a blank (`""`) first option ("leave empty to run all agents").
- A `matrix-setup` job builds the agent list: the one selected agent, or all of them when blank.
- The two jobs collapse into **one matrix job** (`fail-fast: false`). copilot-cli runs in the matrix — `copilot-requests: write` is granted to every leg (harmless for others) and `COPILOT_GITHUB_TOKEN` is passed through — so the separate copilot job is no longer needed.
- `checkpoint_store` (git-branch / git-refs) is unchanged and applies to every agent in the run.

"All agents" is the same set `e2e.yml` uses (the eight real agents); `vogon` remains selectable individually for a no-cost smoke test.

Workflow-only change (`workflow_dispatch`), so it can't run automatically and can't affect other CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only `workflow_dispatch` change with no application code or automatic CI triggers.
> 
> **Overview**
> The **E2E Checkpoint Store** `workflow_dispatch` workflow now matches **`e2e.yml`**: leaving **`agent`** empty runs the full eight-agent matrix instead of forcing a single choice.
> 
> A **`matrix-setup`** job emits either one agent or the standard list; the former split between a normal job and a **copilot-only** job is replaced by one **`fail-fast: false`** matrix job. **`copilot-requests: write`** and **`COPILOT_GITHUB_TOKEN`** apply on every matrix leg so **copilot-cli** works without a dedicated job. **`checkpoint_store`** still applies to all legs; **`vogon`** stays a manual single-agent option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41fdb08581bf1a32b25597a94df5c1c32be97963. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->