### PR TITLE
e2e: scope copilot GitHub token to the copilot-cli agent only

### DIFF
--- a/.github/workflows/e2e-checkpoint-store.yml
+++ b/.github/workflows/e2e-checkpoint-store.yml
@@ -56,7 +56,12 @@ jobs:
     permissions:
       actions: read
       contents: read
-      # Granted for every leg so copilot-cli works in the matrix; harmless for others.
+      # Needed by the copilot-cli leg. GitHub does not allow matrix expressions in
+      # `permissions:`, so this scope is granted to every leg's GITHUB_TOKEN. The
+      # token is kept away from non-copilot agents in two ways: it is only placed
+      # in COPILOT_GITHUB_TOKEN for the copilot-cli leg (see env blocks below), and
+      # checkout runs with persist-credentials: false so it is not left in
+      # .git/config for an agent process to read.
       copilot-requests: write
     strategy:
       fail-fast: false
@@ -68,6 +73,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Don't persist the (copilot-scoped) GITHUB_TOKEN in .git/config, where
+          # an agent process running in the checkout could read it.
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |
@@ -116,7 +124,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          # Only the copilot-cli leg gets the token; other agents must not receive it.
+          COPILOT_GITHUB_TOKEN: ${{ matrix.agent == 'copilot-cli' && github.token || '' }}
         run: go run ./e2e/bootstrap ${{ matrix.agent }}
 
       - name: E2E Checkpoint Store
@@ -130,7 +139,8 @@ jobs:
           E2E_GEMINI_MODEL: ${{ matrix.agent == 'gemini-cli' && 'gemini-3.1-flash-lite' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          # Only the copilot-cli leg gets the token; other agents must not receive it.
+          COPILOT_GITHUB_TOKEN: ${{ matrix.agent == 'copilot-cli' && github.token || '' }}
           E2E_CONCURRENT_TEST_LIMIT: ${{ matrix.agent == 'gemini-cli' && '6' || matrix.agent == 'factoryai-droid' && '1' || matrix.agent == 'cursor-cli' && '2' || '' }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts
           E2E_ENTIRE_BIN: /usr/local/bin/entire

--- a/.github/workflows/e2e-isolated.yml
+++ b/.github/workflows/e2e-isolated.yml
@@ -62,7 +62,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          # Only copilot-cli gets the token; other agents must not receive it.
+          COPILOT_GITHUB_TOKEN: ${{ inputs.agent == 'copilot-cli' && secrets.COPILOT_GITHUB_TOKEN || '' }}
         run: go run ./e2e/bootstrap
 
       - name: Run isolated test
@@ -73,7 +74,8 @@ jobs:
           E2E_CODEX_MODEL: ${{ inputs.agent == 'codex' && 'gpt-5.4-mini' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          # Only copilot-cli gets the token; other agents must not receive it.
+          COPILOT_GITHUB_TOKEN: ${{ inputs.agent == 'copilot-cli' && secrets.COPILOT_GITHUB_TOKEN || '' }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts
           E2E_ENTIRE_BIN: /usr/local/bin/entire
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,12 @@ jobs:
     permissions:
       actions: read
       contents: read
+      # Needed by the copilot-cli leg. GitHub does not allow matrix expressions in
+      # `permissions:`, so this scope is granted to every leg's GITHUB_TOKEN. The
+      # token is kept away from non-copilot agents in two ways: it is only placed
+      # in COPILOT_GITHUB_TOKEN for the copilot-cli leg (see env blocks below), and
+      # checkout runs with persist-credentials: false so it is not left in
+      # .git/config for an agent process to read.
       copilot-requests: write
     strategy:
       fail-fast: false
@@ -58,6 +64,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Don't persist the (copilot-scoped) GITHUB_TOKEN in .git/config, where
+          # an agent process running in the checkout could read it.
+          persist-credentials: false
 
       - name: Setup mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
@@ -95,7 +105,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          # Only the copilot-cli leg gets the token; other agents must not receive it.
+          COPILOT_GITHUB_TOKEN: ${{ matrix.agent == 'copilot-cli' && github.token || '' }}
         run: go run ./e2e/bootstrap
 
       - name: Run E2E Tests
@@ -107,7 +118,8 @@ jobs:
           E2E_GEMINI_MODEL: ${{ matrix.agent == 'gemini-cli' && 'gemini-3.1-flash-lite' || '' }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          COPILOT_GITHUB_TOKEN: ${{ github.token }}
+          # Only the copilot-cli leg gets the token; other agents must not receive it.
+          COPILOT_GITHUB_TOKEN: ${{ matrix.agent == 'copilot-cli' && github.token || '' }}
           E2E_CONCURRENT_TEST_LIMIT: ${{ matrix.agent == 'gemini-cli' && '6' || matrix.agent == 'factoryai-droid' && '1' || matrix.agent == 'cursor-cli' && '2' || '' }}
         # roger-roger is deterministic, so it runs through its dedicated task,
         # which does NOT enable --rerun-fails. Routing it through the default


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/710
<!-- entire-trail-link-end -->

Fixes the credential-exposure issue flagged on the trail for #1580: the E2E workflows that run agents in a shared/single job were passing the **copilot GitHub token to every agent**. A third-party agent CLI (opencode, gemini-cli, cursor-cli, factoryai-droid, codex) received a usable GitHub token in its process environment that it has no need for.

## The leak
`COPILOT_GITHUB_TOKEN` was set unconditionally on the bootstrap and test steps, so every matrix leg / selected agent got it:
- **`e2e.yml`** — shared matrix, `${{ github.token }}` to all legs (live on every push to `main` since 2026-04-09).
- **`e2e-checkpoint-store.yml`** — same, after #1580 collapsed copilot into the matrix.
- **`e2e-isolated.yml`** — single-agent, but passed `secrets.COPILOT_GITHUB_TOKEN` (a stored PAT) to whichever agent was selected.

On top of that, `actions/checkout` persists the (copilot-scoped) `GITHUB_TOKEN` into `.git/config` by default, so an agent running in the checkout could read it even without the env var.

## The fix (keeps the single-matrix design — no job re-duplication)
- Scope the token to the copilot leg only:
  - matrix workflows: `COPILOT_GITHUB_TOKEN: ${{ matrix.agent == 'copilot-cli' && github.token || '' }}`
  - `e2e-isolated.yml`: `${{ inputs.agent == 'copilot-cli' && secrets.COPILOT_GITHUB_TOKEN || '' }}`
- `persist-credentials: false` on checkout in the two matrix workflows, so the elevated token isn't left on disk for an agent process.

The job-level `copilot-requests: write` permission has to stay (GitHub doesn't allow matrix expressions in `permissions:`), but after these changes no non-copilot agent can obtain that token — not via env, not via `.git/config`.

`e2e-checkpoints-v2.yml` is unchanged: it already runs copilot in a dedicated `copilot-cli`-only job, so its token never reaches other agents.

## Safety of `persist-credentials: false`
The E2E harness runs agents in isolated temp repos with local bare remotes and never pushes/fetches against `origin`, so dropping the persisted origin credential doesn't affect the tests. (These workflows are `push`/`workflow_dispatch`-triggered, so they won't run on this PR — they take effect on the next push to `main` / next dispatch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only credential scoping with no application runtime changes; matrix copilot leg behavior is preserved.
> 
> **Overview**
> Stops **third-party agent CLIs** in shared E2E jobs from receiving a usable GitHub token they do not need.
> 
> **`e2e.yml`** and **`e2e-checkpoint-store.yml`** now set `COPILOT_GITHUB_TOKEN` only when `matrix.agent == 'copilot-cli'` (empty for all other legs), and checkout uses **`persist-credentials: false`** so the job’s copilot-scoped `GITHUB_TOKEN` is not written to `.git/config` for an agent process to read. Comments document why job-level `copilot-requests: write` still applies to every matrix leg.
> 
> **`e2e-isolated.yml`** applies the same env scoping for the selected agent: the stored PAT is passed only when `inputs.agent == 'copilot-cli'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb32a0457d448e4b853f5ffb27be13837d48edeb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->