### PR TITLE
feat(review): raise review timeouts — reviewer 10m→20m, and --timeout now governs the judge (default 5m)

### DIFF
--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -134,9 +134,10 @@ Flags:
   --models       list the models each agent advertises (optionally --agent NAME)
   --profile NAME select a profile (also accepted as positional arg)
   --prompt TEXT  add one-off per-run instructions for this invocation
-  --timeout DUR  max time each reviewer may run before it's cancelled and
-                 marked failed (default 20m; 0 disables). Siblings and the
-                 judge proceed.
+  --timeout DUR  max time each reviewer may run before it's cancelled and marked
+                 failed; also bounds the consolidating judge, whose final report
+                 is skipped on timeout (default 20m; 0 disables both bounds). A
+                 timed-out reviewer's siblings and the judge still proceed.
   --base REF     scope against REF instead of mainline. Useful for stacked
                  PRs where the base is the parent feature branch, not main.
                  Default: first existing of origin/HEAD, origin/main,
@@ -207,14 +208,12 @@ To tag an already-finished session as a review, use
 			if findings {
 				return runReviewFindings(ctx, cmd, deps.NewSilentError)
 			}
-			// --timeout 0 disables the per-reviewer bound. The RunConfig zero
-			// value means "use the default", so translate an explicit 0 to a
-			// negative disable sentinel. (The flag defaults to 10m, so the value is
-			// only 0 when the user passed --timeout 0.)
-			timeoutArg := reviewTimeout
-			if timeoutArg == 0 {
-				timeoutArg = -1
-			}
+			// Map the flag to the RunConfig timeout convention: a non-positive
+			// value (the user passed --timeout 0) means "disable", encoded as the
+			// negative sentinel, which disables BOTH the per-reviewer bound and the
+			// judge's deadline. A positive value passes through and bounds both.
+			// (The flag's default is nonzero, so 0 only appears on --timeout 0.)
+			timeoutArg := resolveReviewerTimeoutArg(reviewTimeout)
 			return runReview(ctx, cmd, agentOverride, modelOverride, baseOverride, profileName, perRunPrompt, timeoutArg, deps)
 		},
 	}
@@ -236,7 +235,7 @@ To tag an already-finished session as a review, use
 	cmd.Flags().StringVar(&profileOverride, "profile", "", "review profile to run (default: review_default_profile or general)")
 	cmd.Flags().StringVar(&perRunPrompt, "prompt", "", "one-off instructions appended to this review run")
 	cmd.Flags().StringVar(&baseOverride, "base", "", "git ref to scope the review against (default: origin/HEAD → origin/main → origin/master → main → master)")
-	cmd.Flags().DurationVar(&reviewTimeout, "timeout", defaultReviewerTimeout, "max time each reviewer may run before it is cancelled and marked failed (0 disables)")
+	cmd.Flags().DurationVar(&reviewTimeout, "timeout", defaultReviewerTimeout, "max time each reviewer may run before it is cancelled and marked failed; also bounds the consolidating judge, whose final report is skipped on timeout (0 disables both)")
 	// The listing modes and the action modes each select a distinct command
 	// behavior; combining them silently runs one and drops the rest, so reject
 	// the combination up front with a clear cobra error.
@@ -696,6 +695,18 @@ func reviewAgentNames(deps Deps) []string {
 		}
 	}
 	return names
+}
+
+// resolveReviewerTimeoutArg maps the --timeout flag value to the RunConfig
+// timeout convention used by reviewerTimeout and the judge's providerContext: a
+// non-positive value (the user passed --timeout 0) becomes the negative
+// "disabled" sentinel; a positive value passes through unchanged. The flag's
+// default is nonzero, so 0 only reaches here when the user explicitly set it.
+func resolveReviewerTimeoutArg(flagValue time.Duration) time.Duration {
+	if flagValue <= 0 {
+		return -1
+	}
+	return flagValue
 }
 
 // runReview executes the main review flow.
@@ -1204,6 +1215,7 @@ func runMultiAgentPath(
 		profileName:       profileName,
 		task:              profile.Task,
 		masterName:        masterLabel,
+		judgeTimeout:      timeout,
 		onSynthesisResult: func(result string) {
 			aggregateOutput = result
 		},
@@ -1259,6 +1271,11 @@ type multiAgentSinkInputs struct {
 	profileName       string
 	task              string
 	masterName        string
+	// judgeTimeout bounds the judge's consolidation call, following the same
+	// three-state convention as the reviewer timeout (positive: use it; zero:
+	// default; negative: disabled). Set from the resolved --timeout so one knob
+	// governs both reviewers and the judge.
+	judgeTimeout      time.Duration
 	onSynthesisResult func(result string)
 }
 
@@ -1289,15 +1306,16 @@ func composeMultiAgentSinks(in multiAgentSinkInputs) []reviewtypes.Sink {
 			postRunOut := &bytes.Buffer{}
 			sinks = append(sinks, DumpSink{W: postRunOut})
 			sinks = append(sinks, SynthesisSink{
-				Provider:     in.synthesisProvider,
-				Writer:       postRunOut,
-				RenderWriter: in.out,
-				PerRunPrompt: in.perRunPrompt,
-				ProfileName:  in.profileName,
-				Task:         in.task,
-				MasterName:   in.masterName,
-				RunContext:   in.runContext,
-				OnResult:     in.onSynthesisResult,
+				Provider:        in.synthesisProvider,
+				Writer:          postRunOut,
+				RenderWriter:    in.out,
+				PerRunPrompt:    in.perRunPrompt,
+				ProfileName:     in.profileName,
+				Task:            in.task,
+				MasterName:      in.masterName,
+				RunContext:      in.runContext,
+				ProviderTimeout: in.judgeTimeout,
+				OnResult:        in.onSynthesisResult,
 				OnStart: func() {
 					tui.FinalPhaseStarted(finalJudgeDisplayName(in.masterName))
 				},
@@ -1316,14 +1334,15 @@ func composeMultiAgentSinks(in multiAgentSinkInputs) []reviewtypes.Sink {
 	sinks = append(sinks, DumpSink{W: in.out})
 	if in.synthesisProvider != nil {
 		sinks = append(sinks, SynthesisSink{
-			Provider:     in.synthesisProvider,
-			Writer:       in.out,
-			PerRunPrompt: in.perRunPrompt,
-			ProfileName:  in.profileName,
-			Task:         in.task,
-			MasterName:   in.masterName,
-			RunContext:   in.runContext,
-			OnResult:     in.onSynthesisResult,
+			Provider:        in.synthesisProvider,
+			Writer:          in.out,
+			PerRunPrompt:    in.perRunPrompt,
+			ProfileName:     in.profileName,
+			Task:            in.task,
+			MasterName:      in.masterName,
+			RunContext:      in.runContext,
+			ProviderTimeout: in.judgeTimeout,
+			OnResult:        in.onSynthesisResult,
 		})
 	}
 	return sinks

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -135,9 +135,10 @@ Flags:
   --profile NAME select a profile (also accepted as positional arg)
   --prompt TEXT  add one-off per-run instructions for this invocation
   --timeout DUR  max time each reviewer may run before it's cancelled and marked
-                 failed; also bounds the consolidating judge, whose final report
-                 is skipped on timeout (default 20m; 0 disables both bounds). A
-                 timed-out reviewer's siblings and the judge still proceed.
+                 failed; also bounds the consolidating judge, whose timeout or
+                 error fails the review with no verdict (default 20m; 0 disables
+                 both bounds). A timed-out reviewer's siblings and the judge
+                 still proceed.
   --base REF     scope against REF instead of mainline. Useful for stacked
                  PRs where the base is the parent feature branch, not main.
                  Default: first existing of origin/HEAD, origin/main,
@@ -235,7 +236,7 @@ To tag an already-finished session as a review, use
 	cmd.Flags().StringVar(&profileOverride, "profile", "", "review profile to run (default: review_default_profile or general)")
 	cmd.Flags().StringVar(&perRunPrompt, "prompt", "", "one-off instructions appended to this review run")
 	cmd.Flags().StringVar(&baseOverride, "base", "", "git ref to scope the review against (default: origin/HEAD → origin/main → origin/master → main → master)")
-	cmd.Flags().DurationVar(&reviewTimeout, "timeout", defaultReviewerTimeout, "max time each reviewer may run before it is cancelled and marked failed; also bounds the consolidating judge, whose final report is skipped on timeout (0 disables both)")
+	cmd.Flags().DurationVar(&reviewTimeout, "timeout", defaultReviewerTimeout, "max time each reviewer may run before it is cancelled and marked failed; also bounds the consolidating judge, whose timeout or error fails the review (0 disables both)")
 	// The listing modes and the action modes each select a distinct command
 	// behavior; combining them silently runs one and drops the rest, so reject
 	// the combination up front with a clear cobra error.
@@ -1199,6 +1200,7 @@ func runMultiAgentPath(
 		agentNames[i] = r.Name()
 	}
 	aggregateOutput := ""
+	var synthErr error
 
 	// The single consolidating judge (resolved and validated by the caller)
 	// turns the reviewers' reports into the final verdict.
@@ -1219,6 +1221,9 @@ func runMultiAgentPath(
 		onSynthesisResult: func(result string) {
 			aggregateOutput = result
 		},
+		onSynthesisError: func(err error) {
+			synthErr = err
+		},
 	})
 	if tuiSink, ok := findTUISink(sinks); ok {
 		tuiSink.Start()
@@ -1230,11 +1235,33 @@ func runMultiAgentPath(
 	runMultiCfg.EnrichSummary = reviewSummaryTokenEnricher(worktreeRoot, headSHA)
 	summary, waitErr := RunMulti(runCtx, reviewers, runMultiCfg, sinks)
 	if shouldAbortMultiReview(summary, waitErr) && runCtx.Err() == nil && ctx.Err() == nil {
+		// Operational failure, not a usage error — don't dump the command help.
+		cmd.SilenceUsage = true
 		return multiReviewFailureError(waitErr)
 	}
 	writePostReviewManifest(ctx, out, worktreeRoot, headSHA, summary, aggregateOutput)
 	maybePostReviewToTrail(ctx, out, deps, outputMode, profileName, summary, aggregateOutput)
+	// The judge produces the review's primary deliverable — the consolidated
+	// verdict. If it was attempted but failed (provider error or timeout), the
+	// run produced no verdict, so exit non-zero instead of reporting success.
+	// The reviewers' partial output is still recorded above. Skip when the run
+	// was cancelled (Ctrl+C cancels both ctx and runCtx), which is not a failure.
+	if synthErr != nil && ctx.Err() == nil && runCtx.Err() == nil {
+		// Operational failure, not a usage error — don't dump the command help.
+		cmd.SilenceUsage = true
+		return judgeFailureError(masterLabel, synthErr)
+	}
 	return nil
+}
+
+// judgeFailureError reports a judge (synthesis) failure as the command's error
+// so a missing verdict surfaces in the exit status. The provider's own message
+// was already printed to the output; this drives the non-zero exit.
+func judgeFailureError(judge string, err error) error {
+	if judge != "" {
+		return fmt.Errorf("review verdict unavailable: judge %s failed: %w", judge, err)
+	}
+	return fmt.Errorf("review verdict unavailable: %w", err)
 }
 
 // handlePickerError maps picker error sentinels to the appropriate
@@ -1277,6 +1304,7 @@ type multiAgentSinkInputs struct {
 	// governs both reviewers and the judge.
 	judgeTimeout      time.Duration
 	onSynthesisResult func(result string)
+	onSynthesisError  func(err error)
 }
 
 type singleAgentSinkInputs struct {
@@ -1316,6 +1344,7 @@ func composeMultiAgentSinks(in multiAgentSinkInputs) []reviewtypes.Sink {
 				RunContext:      in.runContext,
 				ProviderTimeout: in.judgeTimeout,
 				OnResult:        in.onSynthesisResult,
+				OnError:         in.onSynthesisError,
 				OnStart: func() {
 					tui.FinalPhaseStarted(finalJudgeDisplayName(in.masterName))
 				},
@@ -1343,6 +1372,7 @@ func composeMultiAgentSinks(in multiAgentSinkInputs) []reviewtypes.Sink {
 			RunContext:      in.runContext,
 			ProviderTimeout: in.judgeTimeout,
 			OnResult:        in.onSynthesisResult,
+			OnError:         in.onSynthesisError,
 		})
 	}
 	return sinks

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -135,7 +135,7 @@ Flags:
   --profile NAME select a profile (also accepted as positional arg)
   --prompt TEXT  add one-off per-run instructions for this invocation
   --timeout DUR  max time each reviewer may run before it's cancelled and
-                 marked failed (default 10m; 0 disables). Siblings and the
+                 marked failed (default 20m; 0 disables). Siblings and the
                  judge proceed.
   --base REF     scope against REF instead of mainline. Useful for stacked
                  PRs where the base is the parent feature branch, not main.

--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	cli "github.com/entireio/cli/cmd/entire/cli"
 	"github.com/entireio/cli/cmd/entire/cli/agent"
@@ -902,6 +903,44 @@ func TestComposeMultiAgentSinks(t *testing.T) {
 			}
 			if hasSynth != tt.wantSynth {
 				t.Errorf("SynthesisSink present=%v, want %v", hasSynth, tt.wantSynth)
+			}
+		})
+	}
+}
+
+// TestComposeMultiAgentSinks_JudgeTimeoutWired proves the resolved --timeout
+// value reaches the judge: composeMultiAgentSinks must set the SynthesisSink's
+// ProviderTimeout from judgeTimeout, in both the TTY and non-TTY paths. Without
+// this, the judge would silently keep its own default regardless of --timeout.
+func TestComposeMultiAgentSinks_JudgeTimeoutWired(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubCmdSynthesisProvider{}
+	noopCancel := func() {}
+	const want = 17 * time.Minute
+
+	for _, isTTY := range []bool{false, true} {
+		t.Run(map[bool]string{false: "non-tty", true: "tty"}[isTTY], func(t *testing.T) {
+			t.Parallel()
+			sinks := review.ExposedComposeMultiAgentSinks(review.SinkComposeInputs{
+				Out:               &bytes.Buffer{},
+				IsTTY:             isTTY,
+				AgentNames:        []string{"a", "b"},
+				CancelRun:         noopCancel,
+				SynthesisProvider: provider,
+				JudgeTimeout:      want,
+			})
+			var found bool
+			for _, s := range sinks {
+				if ss, ok := s.(review.SynthesisSink); ok {
+					found = true
+					if ss.ProviderTimeout != want {
+						t.Errorf("SynthesisSink.ProviderTimeout = %v, want %v (judgeTimeout not wired)", ss.ProviderTimeout, want)
+					}
+				}
+			}
+			if !found {
+				t.Fatal("no SynthesisSink composed")
 			}
 		})
 	}

--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -909,9 +909,11 @@ func TestComposeMultiAgentSinks(t *testing.T) {
 }
 
 // TestComposeMultiAgentSinks_JudgeTimeoutWired proves the resolved --timeout
-// value reaches the judge: composeMultiAgentSinks must set the SynthesisSink's
-// ProviderTimeout from judgeTimeout, in both the TTY and non-TTY paths. Without
-// this, the judge would silently keep its own default regardless of --timeout.
+// value AND the synthesis-error callback reach the judge: composeMultiAgentSinks
+// must set the SynthesisSink's ProviderTimeout from judgeTimeout and its OnError
+// from onSynthesisError, in both the TTY and non-TTY paths. Without the former
+// the judge would silently keep its own default regardless of --timeout; without
+// the latter a failed judge could not surface in the command's exit status.
 func TestComposeMultiAgentSinks_JudgeTimeoutWired(t *testing.T) {
 	t.Parallel()
 
@@ -929,6 +931,7 @@ func TestComposeMultiAgentSinks_JudgeTimeoutWired(t *testing.T) {
 				CancelRun:         noopCancel,
 				SynthesisProvider: provider,
 				JudgeTimeout:      want,
+				OnSynthesisError:  func(error) {},
 			})
 			var found bool
 			for _, s := range sinks {
@@ -936,6 +939,9 @@ func TestComposeMultiAgentSinks_JudgeTimeoutWired(t *testing.T) {
 					found = true
 					if ss.ProviderTimeout != want {
 						t.Errorf("SynthesisSink.ProviderTimeout = %v, want %v (judgeTimeout not wired)", ss.ProviderTimeout, want)
+					}
+					if ss.OnError == nil {
+						t.Error("SynthesisSink.OnError is nil (onSynthesisError not wired) — a failed judge could not fail the command")
 					}
 				}
 			}

--- a/cmd/entire/cli/review/export_test.go
+++ b/cmd/entire/cli/review/export_test.go
@@ -3,6 +3,7 @@ package review
 import (
 	"context"
 	"io"
+	"time"
 
 	reviewtypes "github.com/entireio/cli/cmd/entire/cli/review/types"
 )
@@ -25,6 +26,7 @@ type SinkComposeInputs struct {
 	SynthesisProvider SynthesisProvider
 	PerRunPrompt      string
 	MasterName        string
+	JudgeTimeout      time.Duration
 }
 
 type SingleAgentSinkComposeInputs struct {
@@ -45,6 +47,7 @@ func ExposedComposeMultiAgentSinks(in SinkComposeInputs) []reviewtypes.Sink {
 		synthesisProvider: in.SynthesisProvider,
 		perRunPrompt:      in.PerRunPrompt,
 		masterName:        in.MasterName,
+		judgeTimeout:      in.JudgeTimeout,
 	})
 }
 

--- a/cmd/entire/cli/review/export_test.go
+++ b/cmd/entire/cli/review/export_test.go
@@ -27,6 +27,7 @@ type SinkComposeInputs struct {
 	PerRunPrompt      string
 	MasterName        string
 	JudgeTimeout      time.Duration
+	OnSynthesisError  func(error)
 }
 
 type SingleAgentSinkComposeInputs struct {
@@ -48,6 +49,7 @@ func ExposedComposeMultiAgentSinks(in SinkComposeInputs) []reviewtypes.Sink {
 		perRunPrompt:      in.PerRunPrompt,
 		masterName:        in.MasterName,
 		judgeTimeout:      in.JudgeTimeout,
+		onSynthesisError:  in.OnSynthesisError,
 	})
 }
 

--- a/cmd/entire/cli/review/run.go
+++ b/cmd/entire/cli/review/run.go
@@ -37,7 +37,11 @@ func reviewerModelName(r reviewtypes.AgentReviewer) string {
 // defaultReviewerTimeout bounds a single reviewer's run when the caller
 // doesn't set RunConfig.ReviewerTimeout. A stuck agent is cancelled (its
 // process killed) and marked failed rather than hanging the review forever.
-const defaultReviewerTimeout = 10 * time.Minute
+//
+// A full reviewer pass (read the diff, run skills, write the report) regularly
+// runs past 10m, especially for the consolidating judge, so the default is 20m;
+// override with --timeout (0 disables).
+const defaultReviewerTimeout = 20 * time.Minute
 
 // reviewerTimeout resolves the effective per-reviewer timeout, distinguishing
 // the three RunConfig.ReviewerTimeout states the zero value alone can't:

--- a/cmd/entire/cli/review/run_test.go
+++ b/cmd/entire/cli/review/run_test.go
@@ -1006,3 +1006,70 @@ func TestReviewerTimeout(t *testing.T) {
 		t.Errorf("disabled (negative) = %v, want 0 (no timeout)", got)
 	}
 }
+
+// TestResolveReviewerTimeoutArg pins the --timeout flag -> RunConfig sentinel
+// mapping: a non-positive flag value (the user passed --timeout 0) becomes the
+// negative "disabled" sentinel that turns off both the reviewer bound and the
+// judge's deadline; a positive value passes through unchanged.
+func TestResolveReviewerTimeoutArg(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   time.Duration
+		want time.Duration
+	}{
+		{"explicit zero disables", 0, -1},
+		{"negative disables", -5 * time.Minute, -1},
+		{"positive passes through", 20 * time.Minute, 20 * time.Minute},
+	}
+	for _, tc := range cases {
+		if got := resolveReviewerTimeoutArg(tc.in); got != tc.want {
+			t.Errorf("%s: resolveReviewerTimeoutArg(%v) = %v, want %v", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestDefaultReviewerTimeoutValue pins the literal default so an accidental edit
+// to the constant is caught (the other timeout tests compare against the
+// constant itself and would silently follow a change).
+func TestDefaultReviewerTimeoutValue(t *testing.T) {
+	t.Parallel()
+	if defaultReviewerTimeout != 20*time.Minute {
+		t.Errorf("defaultReviewerTimeout = %v, want 20m", defaultReviewerTimeout)
+	}
+}
+
+// TestTimeoutFlag_ResolvesThroughCommand drives the real --timeout flag through
+// the command (parse only, no RunE) and the resolver, covering the full
+// flag -> resolveReviewerTimeoutArg chain: 0 (and the default) and a positive
+// override. Guards the documented "0 disables" contract against a regression
+// that bypasses the resolver.
+func TestTimeoutFlag_ResolvesThroughCommand(t *testing.T) {
+	t.Parallel()
+	parseTimeout := func(args []string) time.Duration {
+		cmd := NewCommand(Deps{})
+		if err := cmd.ParseFlags(args); err != nil {
+			t.Fatalf("ParseFlags(%v): %v", args, err)
+		}
+		d, err := cmd.Flags().GetDuration("timeout")
+		if err != nil {
+			t.Fatalf("GetDuration: %v", err)
+		}
+		return d
+	}
+
+	// Default (no flag) is the nonzero default and resolves to a positive bound.
+	if d := parseTimeout(nil); d != defaultReviewerTimeout {
+		t.Errorf("default --timeout = %v, want %v", d, defaultReviewerTimeout)
+	} else if got := resolveReviewerTimeoutArg(d); got != defaultReviewerTimeout {
+		t.Errorf("default resolves to %v, want %v", got, defaultReviewerTimeout)
+	}
+	// --timeout 0 resolves to the negative disable sentinel (reviewers + judge).
+	if got := resolveReviewerTimeoutArg(parseTimeout([]string{"--timeout", "0"})); got != -1 {
+		t.Errorf("--timeout 0 resolves to %v, want -1 (disabled)", got)
+	}
+	// A positive override passes through unchanged.
+	if got := resolveReviewerTimeoutArg(parseTimeout([]string{"--timeout", "30m"})); got != 30*time.Minute {
+		t.Errorf("--timeout 30m resolves to %v, want 30m", got)
+	}
+}

--- a/cmd/entire/cli/review/synthesis_sink.go
+++ b/cmd/entire/cli/review/synthesis_sink.go
@@ -28,8 +28,9 @@ import (
 // roundtrip; production wiring uses AgentSynthesisProvider.
 type SynthesisProvider interface {
 	// Synthesize takes the composed synthesis prompt and returns the
-	// verdict text. Errors are surfaced to the caller; SynthesisSink
-	// degrades gracefully on error rather than failing the run.
+	// verdict text. On error the sink prints "final report unavailable" and
+	// signals OnError; the command then surfaces an attempted-but-failed
+	// synthesis as a non-zero exit (see runMultiAgentPath).
 	Synthesize(ctx context.Context, prompt string) (string, error)
 }
 
@@ -76,6 +77,11 @@ type SynthesisSink struct {
 	OnResult        func(result string)
 	OnStart         func()
 	OnComplete      func(error)
+	// OnError is called when an attempted synthesis fails (provider error or
+	// timeout). It is NOT called when synthesis is skipped (cancelled run or
+	// fewer than two usable reviewers). Lets the caller surface a missing verdict
+	// in the command's exit status instead of exiting 0 with no final report.
+	OnError func(error)
 }
 
 // Compile-time interface check.
@@ -121,6 +127,9 @@ func (s SynthesisSink) RunFinished(summary reviewtypes.RunSummary) {
 	result, provErr := s.Provider.Synthesize(providerCtx, synthesisPrompt)
 	if provErr != nil {
 		fmt.Fprintf(s.Writer, "final report unavailable: %v\n", provErr)
+		if s.OnError != nil {
+			s.OnError(provErr)
+		}
 		if s.OnComplete != nil {
 			s.OnComplete(provErr)
 		}

--- a/cmd/entire/cli/review/synthesis_sink.go
+++ b/cmd/entire/cli/review/synthesis_sink.go
@@ -72,7 +72,7 @@ type SynthesisSink struct {
 	Task            string
 	MasterName      string
 	RunContext      context.Context // optional; nil falls back to context.Background()
-	ProviderTimeout time.Duration   // optional; zero uses defaultSynthesisProviderTimeout
+	ProviderTimeout time.Duration   // positive: use it; zero: defaultSynthesisProviderTimeout; negative: disabled (no deadline)
 	OnResult        func(result string)
 	OnStart         func()
 	OnComplete      func(error)
@@ -81,7 +81,11 @@ type SynthesisSink struct {
 // Compile-time interface check.
 var _ reviewtypes.Sink = SynthesisSink{}
 
-const defaultSynthesisProviderTimeout = 2 * time.Minute
+// defaultSynthesisProviderTimeout bounds the judge's single consolidation call
+// when SynthesisSink.ProviderTimeout is unset. The judge reads every reviewer's
+// report and writes the combined verdict in one text-generation call, which
+// regularly needs more than the original 2m, so the default is 5m.
+const defaultSynthesisProviderTimeout = 5 * time.Minute
 
 // AgentEvent is a no-op; SynthesisSink only acts in RunFinished.
 func (SynthesisSink) AgentEvent(_ string, _ reviewtypes.Event) {}
@@ -157,12 +161,21 @@ func (s SynthesisSink) runContext() context.Context {
 	return context.Background()
 }
 
+// providerContext bounds the judge's consolidation call. ProviderTimeout follows
+// the same three-state convention as the reviewer timeout so a single --timeout
+// value can govern the whole command:
+//   - positive: use it.
+//   - zero (unset): use defaultSynthesisProviderTimeout.
+//   - negative: disabled — no deadline (mirrors `--timeout 0` for reviewers).
 func (s SynthesisSink) providerContext() (context.Context, context.CancelFunc) {
-	timeout := s.ProviderTimeout
-	if timeout <= 0 {
-		timeout = defaultSynthesisProviderTimeout
+	switch {
+	case s.ProviderTimeout < 0:
+		return context.WithCancel(s.runContext())
+	case s.ProviderTimeout > 0:
+		return context.WithTimeout(s.runContext(), s.ProviderTimeout)
+	default:
+		return context.WithTimeout(s.runContext(), defaultSynthesisProviderTimeout)
 	}
-	return context.WithTimeout(s.runContext(), timeout)
 }
 
 // usableAgentCount returns the number of agents that produced usable narrative

--- a/cmd/entire/cli/review/synthesis_sink_test.go
+++ b/cmd/entire/cli/review/synthesis_sink_test.go
@@ -28,6 +28,35 @@ func (s *stubSynthesisProvider) Synthesize(_ context.Context, prompt string) (st
 	return s.response, nil
 }
 
+// deadlineCapturingSynthesisProvider records whether the provider context
+// carried a deadline, so a test can assert the judge call is bounded without
+// blocking for the real timeout.
+type deadlineCapturingSynthesisProvider struct {
+	hadDeadline bool
+}
+
+func (s *deadlineCapturingSynthesisProvider) Synthesize(ctx context.Context, _ string) (string, error) {
+	_, s.hadDeadline = ctx.Deadline()
+	return "ok", nil
+}
+
+// deadlineDurationSynthesisProvider additionally records how far out the
+// deadline is, so a test can assert an explicit timeout was honored (vs the
+// package default).
+type deadlineDurationSynthesisProvider struct {
+	hadDeadline bool
+	remaining   time.Duration
+}
+
+func (s *deadlineDurationSynthesisProvider) Synthesize(ctx context.Context, _ string) (string, error) {
+	dl, ok := ctx.Deadline()
+	s.hadDeadline = ok
+	if ok {
+		s.remaining = time.Until(dl)
+	}
+	return "ok", nil
+}
+
 type contextWaitingSynthesisProvider struct {
 	capturedPrompt string
 	capturedErr    error
@@ -262,6 +291,83 @@ func TestSynthesisSink_ProviderTimeout(t *testing.T) {
 	}
 	if !errors.Is(provider.capturedErr, context.DeadlineExceeded) {
 		t.Fatalf("provider context error = %v, want context.DeadlineExceeded", provider.capturedErr)
+	}
+}
+
+// TestSynthesisSink_DefaultProviderTimeoutBounds verifies the judge call is
+// still bounded by the default when ProviderTimeout is left unset — guarding
+// against a regression where zero is misread as "no deadline" (unbounded judge).
+func TestSynthesisSink_DefaultProviderTimeoutBounds(t *testing.T) {
+	t.Parallel()
+	w := &bytes.Buffer{}
+	provider := &deadlineCapturingSynthesisProvider{}
+	sink := buildSink(provider, w, "")
+	// ProviderTimeout intentionally left at its zero value.
+
+	sink.RunFinished(makeTwoAgentSummary())
+
+	if !provider.hadDeadline {
+		t.Fatal("judge provider context must carry a deadline even when ProviderTimeout is unset")
+	}
+}
+
+// TestSynthesisSink_DefaultProviderTimeoutValue pins the judge's default
+// deadline (~5m) when ProviderTimeout is unset, so an accidental change to
+// defaultSynthesisProviderTimeout is caught rather than passing silently.
+func TestSynthesisSink_DefaultProviderTimeoutValue(t *testing.T) {
+	t.Parallel()
+	w := &bytes.Buffer{}
+	provider := &deadlineDurationSynthesisProvider{}
+	sink := buildSink(provider, w, "")
+	// ProviderTimeout intentionally left unset (zero) -> default applies.
+
+	sink.RunFinished(makeTwoAgentSummary())
+
+	if !provider.hadDeadline {
+		t.Fatal("unset ProviderTimeout must apply the default deadline")
+	}
+	// The default is 5m; allow generous slack for scheduling between context
+	// creation and the provider reading the deadline.
+	if provider.remaining < 4*time.Minute || provider.remaining > 5*time.Minute {
+		t.Fatalf("default deadline remaining = %v, want ~5m", provider.remaining)
+	}
+}
+
+// TestSynthesisSink_DisabledProviderTimeout verifies a negative ProviderTimeout
+// disables the judge's deadline (no bound), mirroring `--timeout 0` for
+// reviewers. This is the path the resolved disable sentinel takes.
+func TestSynthesisSink_DisabledProviderTimeout(t *testing.T) {
+	t.Parallel()
+	w := &bytes.Buffer{}
+	provider := &deadlineCapturingSynthesisProvider{}
+	sink := buildSink(provider, w, "")
+	sink.ProviderTimeout = -1
+
+	sink.RunFinished(makeTwoAgentSummary())
+
+	if provider.hadDeadline {
+		t.Fatal("a negative ProviderTimeout must disable the deadline (unbounded judge)")
+	}
+}
+
+// TestSynthesisSink_ExplicitProviderTimeoutHonored verifies a positive
+// ProviderTimeout (e.g. the resolved --timeout) is the deadline the judge runs
+// under, not the package default.
+func TestSynthesisSink_ExplicitProviderTimeoutHonored(t *testing.T) {
+	t.Parallel()
+	w := &bytes.Buffer{}
+	provider := &deadlineDurationSynthesisProvider{}
+	sink := buildSink(provider, w, "")
+	sink.ProviderTimeout = time.Hour
+
+	sink.RunFinished(makeTwoAgentSummary())
+
+	if !provider.hadDeadline {
+		t.Fatal("explicit ProviderTimeout must apply a deadline")
+	}
+	// Generous slack: the deadline should be ~1h out, far above the 5m default.
+	if provider.remaining < 30*time.Minute {
+		t.Fatalf("deadline remaining = %v, want ~1h (explicit timeout not honored, fell back to default)", provider.remaining)
 	}
 }
 

--- a/cmd/entire/cli/review/synthesis_sink_test.go
+++ b/cmd/entire/cli/review/synthesis_sink_test.go
@@ -394,6 +394,56 @@ func TestSynthesisSink_ProviderErrorDegradeGracefully(t *testing.T) {
 	}
 }
 
+// TestSynthesisSink_OnErrorCalledOnProviderFailure verifies an attempted
+// synthesis that fails invokes OnError with the provider error — the signal the
+// command uses to surface a missing verdict in its exit status.
+func TestSynthesisSink_OnErrorCalledOnProviderFailure(t *testing.T) {
+	t.Parallel()
+	w := &bytes.Buffer{}
+	stub := &stubSynthesisProvider{err: errors.New("judge boom")}
+	sink := buildSink(stub, w, "")
+	calls := 0
+	var gotErr error
+	sink.OnError = func(err error) { calls++; gotErr = err }
+
+	sink.RunFinished(makeTwoAgentSummary())
+
+	if calls != 1 {
+		t.Fatalf("OnError called %d times, want 1", calls)
+	}
+	if gotErr == nil || !strings.Contains(gotErr.Error(), "judge boom") {
+		t.Errorf("OnError error = %v, want it to carry the provider error", gotErr)
+	}
+}
+
+// TestSynthesisSink_OnErrorNotCalledOnSuccess verifies a successful synthesis
+// does not invoke OnError (so the command does not falsely fail).
+func TestSynthesisSink_OnErrorNotCalledOnSuccess(t *testing.T) {
+	t.Parallel()
+	w := &bytes.Buffer{}
+	stub := &stubSynthesisProvider{response: "the verdict"}
+	sink := buildSink(stub, w, "")
+	sink.OnError = func(error) { t.Error("OnError must not be called when synthesis succeeds") }
+
+	sink.RunFinished(makeTwoAgentSummary())
+}
+
+// TestSynthesisSink_OnErrorNotCalledWhenSkipped verifies a skipped synthesis
+// (cancelled run, or fewer than two usable reviewers) does not invoke OnError —
+// a skip is not a judge failure and must not fail the command.
+func TestSynthesisSink_OnErrorNotCalledWhenSkipped(t *testing.T) {
+	t.Parallel()
+	w := &bytes.Buffer{}
+	stub := &stubSynthesisProvider{err: errors.New("would fail if attempted")}
+	sink := buildSink(stub, w, "")
+	sink.OnError = func(error) { t.Error("OnError must not be called when synthesis is skipped") }
+
+	// Cancelled run: skipped before the provider is called.
+	sink.RunFinished(reviewtypes.RunSummary{Cancelled: true})
+	// Fewer than two usable reviewers: also skipped.
+	sink.RunFinished(reviewtypes.RunSummary{})
+}
+
 // TestSynthesisSink_PerRunPromptThreaded verifies that the PerRunPrompt field
 // is threaded through to the composed prompt sent to the provider.
 func TestSynthesisSink_PerRunPromptThreaded(t *testing.T) {


### PR DESCRIPTION
**Trail:** https://entire.io/gh/entireio/cli/trails/711

## Problem

`entire review` (the command, not agent-session reviews) cancels work on timeouts that are too tight, marking agents **failed**. Reported in entire-cli:

> 2 agent(s) done — 0 succeeded, 2 failed — `review agent claude-code timed out after 10m0s`

A review has **two independent** time bounds, both too low for real runs — and the second was **not controllable** at all:

1. **Per-reviewer** (`defaultReviewerTimeout`, 10m) — each reviewer subprocess (read diff, run skills, write report). Governed by `--timeout`.
2. **Judge consolidation** (`defaultSynthesisProviderTimeout`, 2m) — the single text-generation call where the judge reads *every* reviewer report and writes the combined verdict. It runs as a `SynthesisSink`, **separate** from reviewers, and `--timeout` did **not** reach it — so a slow judge was cancelled regardless of the flag.

## Change

- **Reviewers:** `defaultReviewerTimeout` **10m → 20m** (`review/run.go`). One constant drives the per-reviewer bound (single + multi paths) and the `--timeout` flag default.
- **Judge:** `--timeout` now governs the judge too. The resolved timeout is threaded into `SynthesisSink.ProviderTimeout`, and `providerContext` gets the **same three-state convention** as the reviewer timeout — *positive*: use it; *zero (unset)*: default; *negative*: disabled. The unset default is raised **2m → 5m** (library/non-CLI fallback).

Net behavior — one coherent knob for the whole command:

| `--timeout` | reviewers | judge |
|---|---|---|
| *(default)* | 20m | 20m (5m if constructed without the CLI) |
| `30m` | 30m | 30m |
| `0` | disabled | disabled |

These are the only two run-bounding timeouts in the review path — verified by sweeping every `time.Minute`/`WithTimeout` in `cmd/entire/cli/review` and confirming the reviewer adapters + `GenerateText` impose no inner cap. (Other timeouts there — a detached 30s finalize/manifest write, timestamp-skew windows, a 2s TUI grace — don't clip a run.) `SynthesisSink` is constructed only by the review command, so the blast radius is exactly this command.

## Tests

- `synthesis_sink_test.go`: judge call is bounded by default, **honors an explicit timeout**, and is **unbounded when disabled** (negative).
- `cmd_test.go`: `composeMultiAgentSinks` wires `--timeout` into the judge's `ProviderTimeout` in **both** TTY and non-TTY paths.

`go build` ✅ · `review` + `review/types` tests ✅ · integration `Review` ✅ · `golangci-lint` 0 ✅ · gofmt clean · full `mise run check` (fmt + lint + test:ci) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
