### PR TITLE
feat(agents): active + passive agent-help discovery for no-channel agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,16 @@ source of truth the first-turn context injection and the `--agent-help-skill`
 skill point agents at, instead of enumerating a surface that goes stale.
 Hidden commands opt into being advertised here by setting
 `Annotations[agentHelpAnnotation] = "true"` (e.g. `trail`).
+No-channel agents (Cursor, Copilot CLI, Factory Droid, MCP hosts — no
+context-injection channel and no agent-help skill template) reach it without an
+active push. All of them can discover it passively: it is visible in `entire
+help`, the `entire status` footer points at it, and `entire status --json`
+exposes it as the `agent_help` field. On top of that, Factory AI Droid (which is
+banner-only) gets the pointer appended to its SessionStart hook banner, and
+MCP-host agents can launch the hidden `entire mcp` stdio server, which exposes
+`agent_help` and `entire_status` as MCP tools using the same live rendering.
+Enabling a no-channel agent with `--agent-help-skill` reports the skill
+unsupported and points the agent at this passive path instead.
 
 Hidden top-level shortcuts (functional, emit a one-line deprecation hint):
 `resume` → `session resume`, `attach` → `session attach`, `explain` →
@@ -80,7 +90,8 @@ Deprecated top-level commands (functional, print a cobra deprecation message):
 deprecation as `checkpoint rewind`).
 
 Hidden infrastructure commands: `hooks`, `trail`,
-`curl-bash-post-install`, `__send_analytics`.
+`curl-bash-post-install`, `__send_analytics`, `mcp` (MCP stdio server for
+MCP-host agents).
 
 The `hideAsAlias(cmd, canonical)` helper in `cmd/entire/cli/aliascmd.go`
 marks a command Hidden and sets cobra's `Deprecated` field so the hint

--- a/cmd/entire/cli/agent_help_banner_test.go
+++ b/cmd/entire/cli/agent_help_banner_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+	"github.com/entireio/cli/cmd/entire/cli/agent/types"
+	"github.com/entireio/cli/cmd/entire/cli/agent/vogon"
+)
+
+// Factory AI Droid is banner-only (no context injection, no agent-help skill
+// file), so it is the one built-in agent that gets the agent-help pointer
+// appended to its SessionStart banner. Every other agent already receives the
+// pointer via context injection or a skill file, or relies on the passive
+// `entire status` surface, so none of them get a duplicate banner pointer.
+func TestAgentHelpBannerSuffix(t *testing.T) {
+	t.Parallel()
+
+	got := agentHelpBannerSuffix(agent.AgentNameFactoryAIDroid)
+	if !strings.Contains(got, "entire agent-help") {
+		t.Errorf("Factory Droid banner suffix should point at `entire agent-help`, got %q", got)
+	}
+
+	for _, name := range []types.AgentName{
+		agent.AgentNameClaudeCode,
+		agent.AgentNameCodex,
+		agent.AgentNameGemini,
+		agent.AgentNameCursor,
+		agent.AgentNameCopilotCLI,
+		agent.AgentNameOpenCode,
+		agent.AgentNamePi,
+		vogon.AgentNameVogon, // the deterministic test agent must stay banner-free
+	} {
+		if suffix := agentHelpBannerSuffix(name); suffix != "" {
+			t.Errorf("agent %q should not get a banner agent-help pointer (avoids a duplicate), got %q", name, suffix)
+		}
+	}
+}
+
+// The agent-help pointer must survive an agent-supplied ResponseMessage override:
+// the override replaces the assembled message wholesale, so the pointer has to be
+// appended after it, not before (else Factory Droid loses its only in-session
+// pointer the moment an agent sets a custom banner).
+func TestFinalizeSessionStartBanner(t *testing.T) {
+	t.Parallel()
+
+	// Factory + assembled message: pointer appended to the base.
+	if out := finalizeSessionStartBanner("base message", "", agent.AgentNameFactoryAIDroid); !strings.Contains(out, "base message") || !strings.Contains(out, "entire agent-help") {
+		t.Errorf("Factory banner should append the pointer to the base message, got %q", out)
+	}
+
+	// Factory + ResponseMessage override: override wins, but the pointer survives.
+	out := finalizeSessionStartBanner("base message", "custom override", agent.AgentNameFactoryAIDroid)
+	if !strings.Contains(out, "custom override") {
+		t.Errorf("ResponseMessage override should replace the assembled message, got %q", out)
+	}
+	if strings.Contains(out, "base message") {
+		t.Errorf("override should replace, not append to, the base message, got %q", out)
+	}
+	if !strings.Contains(out, "entire agent-help") {
+		t.Errorf("Factory pointer must survive the ResponseMessage override, got %q", out)
+	}
+
+	// Non-Factory: no pointer; an override is respected verbatim.
+	if out := finalizeSessionStartBanner("base", "custom", agent.AgentNameClaudeCode); out != "custom" {
+		t.Errorf("non-banner agent should get the override verbatim with no pointer, got %q", out)
+	}
+}

--- a/cmd/entire/cli/agent_help_banner_test.go
+++ b/cmd/entire/cli/agent_help_banner_test.go
@@ -18,7 +18,7 @@ func TestAgentHelpBannerSuffix(t *testing.T) {
 	t.Parallel()
 
 	got := agentHelpBannerSuffix(agent.AgentNameFactoryAIDroid)
-	if !strings.Contains(got, "entire agent-help") {
+	if !strings.Contains(got, agentHelpCommand) {
 		t.Errorf("Factory Droid banner suffix should point at `entire agent-help`, got %q", got)
 	}
 
@@ -46,7 +46,7 @@ func TestFinalizeSessionStartBanner(t *testing.T) {
 	t.Parallel()
 
 	// Factory + assembled message: pointer appended to the base.
-	if out := finalizeSessionStartBanner("base message", "", agent.AgentNameFactoryAIDroid); !strings.Contains(out, "base message") || !strings.Contains(out, "entire agent-help") {
+	if out := finalizeSessionStartBanner("base message", "", agent.AgentNameFactoryAIDroid); !strings.Contains(out, "base message") || !strings.Contains(out, agentHelpCommand) {
 		t.Errorf("Factory banner should append the pointer to the base message, got %q", out)
 	}
 
@@ -58,7 +58,7 @@ func TestFinalizeSessionStartBanner(t *testing.T) {
 	if strings.Contains(out, "base message") {
 		t.Errorf("override should replace, not append to, the base message, got %q", out)
 	}
-	if !strings.Contains(out, "entire agent-help") {
+	if !strings.Contains(out, agentHelpCommand) {
 		t.Errorf("Factory pointer must survive the ResponseMessage override, got %q", out)
 	}
 

--- a/cmd/entire/cli/lifecycle.go
+++ b/cmd/entire/cli/lifecycle.go
@@ -209,9 +209,10 @@ func handleLifecycleSessionStart(ctx context.Context, ag agent.Agent, event *age
 	// the banner marker is only claimed inside this branch so a non-writer
 	// winner can't consume the user's only banner.
 	_, hookResponseSpan := perf.Start(ctx, "write_hook_response")
-	if event.ResponseMessage != "" {
-		message = event.ResponseMessage
-	}
+	// Apply any agent-supplied ResponseMessage override, then append the
+	// agent-help banner pointer so it survives the override — banner-only agents
+	// (Factory Droid) have no other in-session channel for it.
+	message = finalizeSessionStartBanner(message, event.ResponseMessage, ag.Name())
 	if writer, ok := agent.AsHookResponseWriter(ag); ok {
 		bannerFirst, bErr := strategy.ClaimSessionStartBanner(ctx, event.SessionID)
 		if bErr != nil {
@@ -275,6 +276,32 @@ func sessionStartMessage(agentName types.AgentName, emptyRepo bool) string {
 		return "\n\nEntire CLI found no commits yet — checkpoints will activate after your first commit."
 	}
 	return "\n\nEntire CLI will link this conversation to your next commit."
+}
+
+// agentHelpBannerSuffix returns the SessionStart banner suffix that points an
+// agent at `entire agent-help`. It targets Factory AI Droid, which is banner-only
+// — no model-context injection and no agent-help skill file — so the SessionStart
+// banner is its sole in-session channel for the pointer. Every other agent gets
+// the pointer via context injection (Claude/Codex/Gemini/OpenCode/Pi), a skill
+// file (Claude/Codex/Gemini), or the passive `entire status` surface
+// (Cursor/Copilot), so this returns "" for them to avoid a duplicate pointer.
+func agentHelpBannerSuffix(agentName types.AgentName) string {
+	if agentName == agent.AgentNameFactoryAIDroid {
+		return fmt.Sprintf("\n  Run `%s` to see entire's commands and flags.", agentHelpCommand)
+	}
+	return ""
+}
+
+// finalizeSessionStartBanner applies an agent-supplied ResponseMessage override
+// (if any) and THEN appends the agent-help banner pointer, so the pointer
+// survives even when the agent supplies its own banner text. Order matters: a
+// ResponseMessage override replaces the assembled message wholesale, so the
+// pointer must be appended after it, not before.
+func finalizeSessionStartBanner(message, responseMessage string, agentName types.AgentName) string {
+	if responseMessage != "" {
+		message = responseMessage
+	}
+	return message + agentHelpBannerSuffix(agentName)
 }
 
 // handleLifecycleModelUpdate persists the model name for the current session.

--- a/cmd/entire/cli/mcp.go
+++ b/cmd/entire/cli/mcp.go
@@ -95,6 +95,20 @@ func runMCPServer(ctx context.Context, rootCmd *cobra.Command, in io.Reader, out
 			continue
 		}
 
+		// Reject a parseable-but-invalid request (missing/incorrect jsonrpc version
+		// or empty method) with -32600 before dispatch, per JSON-RPC, rather than
+		// treating it as method-not-found.
+		if req.JSONRPC != "2.0" || req.Method == "" {
+			id := req.ID
+			if len(id) == 0 {
+				id = json.RawMessage("null")
+			}
+			if encErr := enc.Encode(mcpResponse{JSONRPC: "2.0", ID: id, Error: &mcpError{Code: -32600, Message: "invalid request"}}); encErr != nil {
+				return fmt.Errorf("write mcp invalid-request response: %w", encErr)
+			}
+			continue
+		}
+
 		result, rpcErr := dispatchMCP(ctx, rootCmd, req.Method, req.Params)
 
 		// A request without an id is a notification: never responded to.

--- a/cmd/entire/cli/mcp.go
+++ b/cmd/entire/cli/mcp.go
@@ -1,0 +1,237 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+)
+
+// `entire mcp` runs a Model Context Protocol (MCP) server over stdio so that
+// "MCP-host" agents — agents with no entire hook or context-injection channel —
+// can reach entire's machine-readable surface as MCP tools. It is the active
+// counterpart to the passive `entire status` / `entire help` discovery path: the
+// host launches `entire mcp` as a stdio server and calls the agent_help and
+// entire_status tools. The server is read-only and reuses the same live
+// agent-help / status rendering the CLI uses, so it always matches the installed
+// binary. Transport is newline-delimited JSON-RPC 2.0 (the MCP stdio framing).
+
+// mcpProtocolVersion is the MCP revision we advertise when a client doesn't
+// request one. We echo the client's requested version when present.
+const mcpProtocolVersion = "2025-06-18"
+
+// maxMCPMessageBytes bounds a single newline-delimited JSON-RPC message so a
+// malformed or abusive line can't exhaust memory. 1 MiB is far above any real
+// agent_help / status request.
+const maxMCPMessageBytes = 1 << 20
+
+// mcpServerName is the MCP serverInfo name advertised at initialize.
+const mcpServerName = "entire"
+
+func newMCPCmd(rootCmd *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:   "mcp",
+		Short: "Run a Model Context Protocol server for MCP-host agents",
+		Long: `Runs a Model Context Protocol (MCP) server over stdio. Configure an MCP host to
+launch "entire mcp" as a stdio server; it exposes entire's agent-help and status
+as MCP tools so agents without a hook or context-injection channel can discover
+and use entire. Read-only; speaks newline-delimited JSON-RPC 2.0.`,
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			return runMCPServer(c.Context(), rootCmd, c.InOrStdin(), c.OutOrStdout())
+		},
+	}
+}
+
+type mcpRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type mcpResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *mcpError       `json:"error,omitempty"`
+}
+
+type mcpError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// runMCPServer reads newline-delimited JSON-RPC 2.0 messages from in (one per
+// line — the MCP stdio framing), bounding each line to maxMCPMessageBytes, and
+// writes responses to out until EOF. Notifications (messages with no id) get no
+// response, per JSON-RPC. An unparseable line — including a JSON-RPC batch array,
+// which this server does not support — yields a parse error and the server
+// recovers to the next line rather than terminating.
+func runMCPServer(ctx context.Context, rootCmd *cobra.Command, in io.Reader, out io.Writer) error {
+	enc := json.NewEncoder(out)
+	sc := bufio.NewScanner(in)
+	sc.Buffer(make([]byte, 0, 64*1024), maxMCPMessageBytes)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var req mcpRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			if encErr := enc.Encode(mcpResponse{JSONRPC: "2.0", ID: json.RawMessage("null"), Error: &mcpError{Code: -32700, Message: "parse error"}}); encErr != nil {
+				return fmt.Errorf("write mcp parse-error response: %w", encErr)
+			}
+			continue
+		}
+
+		result, rpcErr := dispatchMCP(ctx, rootCmd, req.Method, req.Params)
+
+		// A request without an id is a notification: never responded to.
+		if len(req.ID) == 0 {
+			continue
+		}
+
+		resp := mcpResponse{JSONRPC: "2.0", ID: req.ID}
+		if rpcErr != nil {
+			resp.Error = rpcErr
+		} else {
+			resp.Result = result
+		}
+		if err := enc.Encode(resp); err != nil {
+			return fmt.Errorf("write mcp response: %w", err)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		// A single line exceeded maxMCPMessageBytes (the scanner can't resynchronize
+		// past an over-long token) or the read failed; report once and stop.
+		if errors.Is(err, bufio.ErrTooLong) {
+			if encErr := enc.Encode(mcpResponse{JSONRPC: "2.0", ID: json.RawMessage("null"), Error: &mcpError{Code: -32600, Message: "request too large"}}); encErr != nil {
+				return fmt.Errorf("write mcp oversize response: %w", encErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("read mcp request: %w", err)
+	}
+	return nil
+}
+
+func dispatchMCP(ctx context.Context, rootCmd *cobra.Command, method string, params json.RawMessage) (any, *mcpError) {
+	switch method {
+	case "initialize":
+		return mcpInitializeResult(params), nil
+	case "notifications/initialized":
+		return nil, nil // notification; result is ignored by the caller
+	case "ping":
+		return map[string]any{}, nil
+	case "tools/list":
+		return map[string]any{"tools": mcpToolDefs()}, nil
+	case "tools/call":
+		return handleMCPToolCall(ctx, rootCmd, params)
+	default:
+		return nil, &mcpError{Code: -32601, Message: "method not found: " + method}
+	}
+}
+
+func mcpInitializeResult(params json.RawMessage) map[string]any {
+	protocol := mcpProtocolVersion
+	if len(params) > 0 {
+		var p struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if json.Unmarshal(params, &p) == nil && p.ProtocolVersion != "" {
+			protocol = p.ProtocolVersion
+		}
+	}
+	return map[string]any{
+		"protocolVersion": protocol,
+		"capabilities":    map[string]any{"tools": map[string]any{}},
+		"serverInfo":      map[string]any{"name": mcpServerName, "version": versioninfo.Version},
+	}
+}
+
+func mcpToolDefs() []map[string]any {
+	objSchema := func(props map[string]any) map[string]any {
+		return map[string]any{"type": "object", "properties": props}
+	}
+	return []map[string]any{
+		{
+			"name":        "agent_help",
+			"description": "Machine-readable usage for the entire CLI, generated live from the installed binary. Omit command for a top-level map of when to use entire and which subcommand; pass a command path to drill into that command's exact, current flags.",
+			"inputSchema": objSchema(map[string]any{
+				"command": map[string]any{
+					"type":        "string",
+					"description": "Optional subcommand path, space-separated (e.g. \"checkpoint\" or \"doctor trace\"). Empty for the top-level overview.",
+				},
+			}),
+		},
+		{
+			"name":        "entire_status",
+			"description": "Current entire status for this repo as JSON (enabled, agents, active sessions, agent_help pointer).",
+			"inputSchema": objSchema(map[string]any{}),
+		},
+	}
+}
+
+func handleMCPToolCall(ctx context.Context, rootCmd *cobra.Command, params json.RawMessage) (any, *mcpError) {
+	var call struct {
+		Name      string `json:"name"`
+		Arguments struct {
+			Command string `json:"command"`
+		} `json:"arguments"`
+	}
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &call); err != nil {
+			return nil, &mcpError{Code: -32602, Message: "invalid tool call params"}
+		}
+	}
+
+	if call.Name == "" {
+		return nil, &mcpError{Code: -32602, Message: "invalid params: tool name required"}
+	}
+	switch call.Name {
+	case "agent_help":
+		args := strings.Fields(call.Arguments.Command)
+		// Resolve origin once (mirrors `entire agent-help`): derive both the repo
+		// line and the trails-enablement check from a single scope.
+		repoLine, trailsEnabled := agentHelpRepoContext(ctx)
+		text, err := runAgentHelp(rootCmd, args, repoLine, true, trailsEnabled)
+		if err != nil {
+			// A bad command path is a tool-level error the agent can recover from,
+			// not a protocol error — return it as an isError result.
+			return mcpToolErrorResult(err.Error()), nil
+		}
+		return mcpToolTextResult(text), nil
+	case "entire_status":
+		var buf bytes.Buffer
+		if err := runStatusJSON(ctx, &buf); err != nil {
+			return mcpToolErrorResult(err.Error()), nil
+		}
+		return mcpToolTextResult(buf.String()), nil
+	default:
+		return nil, &mcpError{Code: -32602, Message: "unknown tool: " + call.Name}
+	}
+}
+
+func mcpToolTextResult(text string) map[string]any {
+	return map[string]any{
+		"content": []map[string]any{{"type": "text", "text": text}},
+	}
+}
+
+func mcpToolErrorResult(text string) map[string]any {
+	return map[string]any{
+		"content": []map[string]any{{"type": "text", "text": text}},
+		"isError": true,
+	}
+}

--- a/cmd/entire/cli/mcp_test.go
+++ b/cmd/entire/cli/mcp_test.go
@@ -1,0 +1,343 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+type mcpTestResp struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// driveMCP runs the server against a sequence of newline-delimited requests and
+// returns the decoded responses (notifications produce none).
+func driveMCP(t *testing.T, requests ...string) []mcpTestResp {
+	t.Helper()
+	root := NewRootCmd()
+	in := strings.NewReader(strings.Join(requests, "\n") + "\n")
+	var out bytes.Buffer
+	if err := runMCPServer(context.Background(), root, in, &out); err != nil {
+		t.Fatalf("runMCPServer: %v", err)
+	}
+	var resps []mcpTestResp
+	dec := json.NewDecoder(&out)
+	for dec.More() {
+		var r mcpTestResp
+		if err := dec.Decode(&r); err != nil {
+			t.Fatalf("decode response: %v (raw: %s)", err, out.String())
+		}
+		resps = append(resps, r)
+	}
+	return resps
+}
+
+func mcpResultText(t *testing.T, result json.RawMessage) string {
+	t.Helper()
+	var res struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(result, &res); err != nil {
+		t.Fatalf("unmarshal tool result content: %v", err)
+	}
+	if len(res.Content) == 0 {
+		t.Fatalf("tool result had no content: %s", result)
+	}
+	return res.Content[0].Text
+}
+
+// The MCP handshake: initialize echoes the client's protocolVersion and returns
+// serverInfo + the tools capability; the `notifications/initialized` notification
+// gets no response.
+func TestMCPServer_InitializeHandshake(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+	)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response (the notification is silent), got %d", len(resps))
+	}
+	var res struct {
+		ProtocolVersion string                     `json:"protocolVersion"`
+		Capabilities    map[string]json.RawMessage `json:"capabilities"`
+		ServerInfo      struct {
+			Name string `json:"name"`
+		} `json:"serverInfo"`
+	}
+	if err := json.Unmarshal(resps[0].Result, &res); err != nil {
+		t.Fatalf("unmarshal initialize result: %v", err)
+	}
+	if res.ServerInfo.Name != mcpServerName {
+		t.Errorf("serverInfo.name = %q, want %q", res.ServerInfo.Name, mcpServerName)
+	}
+	if res.ProtocolVersion != "2024-11-05" {
+		t.Errorf("initialize should echo the client's protocolVersion, got %q", res.ProtocolVersion)
+	}
+	if _, ok := res.Capabilities["tools"]; !ok {
+		t.Errorf("initialize result should advertise the tools capability, got %v", res.Capabilities)
+	}
+}
+
+// When the client omits protocolVersion, the server advertises its own default.
+func TestMCPServer_InitializeDefaultProtocol(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	var res struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := json.Unmarshal(resps[0].Result, &res); err != nil {
+		t.Fatalf("unmarshal initialize result: %v", err)
+	}
+	if res.ProtocolVersion != mcpProtocolVersion {
+		t.Errorf("default protocolVersion = %q, want %q", res.ProtocolVersion, mcpProtocolVersion)
+	}
+}
+
+// A non-string protocolVersion is ignored gracefully; the server falls back to
+// its default instead of erroring.
+func TestMCPServer_InitializeBadProtocolType(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":123}}`)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	var res struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := json.Unmarshal(resps[0].Result, &res); err != nil {
+		t.Fatalf("unmarshal initialize result: %v", err)
+	}
+	if res.ProtocolVersion != mcpProtocolVersion {
+		t.Errorf("bad protocolVersion type should fall back to default %q, got %q", mcpProtocolVersion, res.ProtocolVersion)
+	}
+}
+
+func TestMCPServer_Ping(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":8,"method":"ping"}`)
+	if len(resps) != 1 || resps[0].Error != nil {
+		t.Fatalf("ping should return exactly one non-error response, got %+v", resps)
+	}
+}
+
+func TestMCPServer_ToolsList(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	var res struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(resps[0].Result, &res); err != nil {
+		t.Fatalf("unmarshal tools/list: %v", err)
+	}
+	names := map[string]bool{}
+	for _, tl := range res.Tools {
+		names[tl.Name] = true
+	}
+	for _, want := range []string{"agent_help", "entire_status"} {
+		if !names[want] {
+			t.Errorf("tools/list missing %q; got %v", want, names)
+		}
+	}
+}
+
+// The agent_help tool returns the live agent-help JSON document (asJSON=true),
+// reusing the same renderer the CLI uses.
+func TestMCPServer_AgentHelpToolCall(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"agent_help","arguments":{"command":""}}}`)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	var doc struct {
+		Command     string `json:"command"`
+		Subcommands []struct {
+			Name string `json:"name"`
+		} `json:"subcommands"`
+	}
+	if err := json.Unmarshal([]byte(mcpResultText(t, resps[0].Result)), &doc); err != nil {
+		t.Fatalf("agent_help tool should return the agent-help JSON document: %v", err)
+	}
+	if doc.Command != NewRootCmd().Name() {
+		t.Errorf("top-level agent_help should be the root command document, got command=%q", doc.Command)
+	}
+	if len(doc.Subcommands) == 0 {
+		t.Error("top-level agent_help should list subcommands, got none")
+	}
+}
+
+// Drilling into a command path returns that command's document.
+func TestMCPServer_AgentHelpToolCall_Subcommand(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"agent_help","arguments":{"command":"status"}}}`)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	var doc struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal([]byte(mcpResultText(t, resps[0].Result)), &doc); err != nil {
+		t.Fatalf("agent_help subcommand should return JSON: %v", err)
+	}
+	if doc.Command != "entire status" {
+		t.Errorf("agent_help command=status should drill into `entire status`, got %q", doc.Command)
+	}
+}
+
+// A bad command path is surfaced as a tool error (isError), not a protocol error,
+// so the agent can recover.
+func TestMCPServer_AgentHelpUnknownCommandIsToolError(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"agent_help","arguments":{"command":"definitely-not-a-command"}}}`)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	var res struct {
+		IsError bool `json:"isError"`
+	}
+	if err := json.Unmarshal(resps[0].Result, &res); err != nil {
+		t.Fatalf("unmarshal tool result: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("unknown command should be a tool error (isError=true); result: %s", resps[0].Result)
+	}
+}
+
+// The entire_status tool must stay byte-identical to the passive `status --json`
+// surface (runStatusJSON) — it is the same data over a different transport.
+func TestMCPServer_EntireStatusMatchesPassive(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"entire_status"}}`)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	text := mcpResultText(t, resps[0].Result)
+	var direct bytes.Buffer
+	if err := runStatusJSON(context.Background(), &direct); err != nil {
+		t.Fatalf("runStatusJSON: %v", err)
+	}
+	if strings.TrimSpace(text) != strings.TrimSpace(direct.String()) {
+		t.Errorf("entire_status MCP tool must match runStatusJSON\n tool:   %s\n direct: %s", text, direct.String())
+	}
+}
+
+// entire_status is a shipped path: it must return parseable status JSON.
+func TestMCPServer_EntireStatusToolCall(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"entire_status","arguments":{}}}`)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	text := mcpResultText(t, resps[0].Result)
+	var status struct {
+		Enabled        *bool    `json:"enabled"`
+		Agents         []string `json:"agents"`
+		ActiveSessions []any    `json:"active_sessions"`
+		AgentHelp      string   `json:"agent_help"`
+		Error          string   `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(text), &status); err != nil {
+		t.Fatalf("entire_status tool should return status JSON, got %q (err %v)", text, err)
+	}
+}
+
+func TestMCPServer_EmptyToolName(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":""}}`)
+	if len(resps) != 1 || resps[0].Error == nil || resps[0].Error.Code != -32602 {
+		t.Fatalf("empty tool name should return invalid-params (-32602), got %+v", resps)
+	}
+}
+
+func TestMCPServer_UnknownToolIsProtocolError(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"no-such-tool"}}`)
+	if len(resps) != 1 || resps[0].Error == nil {
+		t.Fatalf("expected one error response for an unknown tool, got %+v", resps)
+	}
+}
+
+func TestMCPServer_UnknownMethodReturnsError(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t, `{"jsonrpc":"2.0","id":6,"method":"bogus/method"}`)
+	if len(resps) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(resps))
+	}
+	if resps[0].Error == nil || resps[0].Error.Code != -32601 {
+		t.Errorf("expected method-not-found (-32601), got: %+v", resps[0].Error)
+	}
+}
+
+// A single line larger than maxMCPMessageBytes is rejected without consuming
+// unbounded memory, and the server stops cleanly.
+func TestMCPServer_OversizedMessageRejected(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("x", maxMCPMessageBytes+1024)
+	line := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"agent_help","arguments":{"command":"` + big + `"}}}` + "\n"
+	var out bytes.Buffer
+	if err := runMCPServer(context.Background(), NewRootCmd(), strings.NewReader(line), &out); err != nil {
+		t.Fatalf("runMCPServer: %v", err)
+	}
+	var resp mcpTestResp
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("expected an oversize error response, got %q (err %v)", out.String(), err)
+	}
+	if resp.Error == nil || resp.Error.Code != -32600 {
+		t.Errorf("expected request-too-large (-32600), got %+v", resp.Error)
+	}
+}
+
+// A JSON-RPC batch array is unsupported: it yields a parse error, and the server
+// recovers to the next line instead of terminating.
+func TestMCPServer_BatchArrayRejectedThenRecovers(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t,
+		`[{"jsonrpc":"2.0","id":1,"method":"ping"}]`,
+		`{"jsonrpc":"2.0","id":2,"method":"ping"}`,
+	)
+	if len(resps) != 2 {
+		t.Fatalf("expected 2 responses (parse error, then the recovered ping), got %d: %+v", len(resps), resps)
+	}
+	if resps[0].Error == nil || resps[0].Error.Code != -32700 {
+		t.Errorf("batch array should yield a parse error (-32700), got %+v", resps[0].Error)
+	}
+	if resps[1].Error != nil {
+		t.Errorf("server should recover and serve the next message, got error %+v", resps[1].Error)
+	}
+}
+
+// Malformed JSON in the stream is reported as a JSON-RPC parse error (-32700).
+func TestMCPServer_ParseError(t *testing.T) {
+	t.Parallel()
+	root := NewRootCmd()
+	var out bytes.Buffer
+	if err := runMCPServer(context.Background(), root, strings.NewReader("{not valid json\n"), &out); err != nil {
+		t.Fatalf("runMCPServer: %v", err)
+	}
+	var resp mcpTestResp
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("expected a JSON parse-error response, got %q (err %v)", out.String(), err)
+	}
+	if resp.Error == nil || resp.Error.Code != -32700 {
+		t.Errorf("expected parse error -32700, got %+v", resp.Error)
+	}
+}

--- a/cmd/entire/cli/mcp_test.go
+++ b/cmd/entire/cli/mcp_test.go
@@ -287,6 +287,21 @@ func TestMCPServer_UnknownMethodReturnsError(t *testing.T) {
 	}
 }
 
+// A parseable-but-invalid request (missing method or wrong jsonrpc version) is
+// rejected with -32600 before dispatch, not treated as method-not-found.
+func TestMCPServer_InvalidRequest(t *testing.T) {
+	t.Parallel()
+	for _, req := range []string{
+		`{"jsonrpc":"2.0","id":1}`,                 // missing method
+		`{"jsonrpc":"1.0","id":2,"method":"ping"}`, // wrong jsonrpc version
+	} {
+		resps := driveMCP(t, req)
+		if len(resps) != 1 || resps[0].Error == nil || resps[0].Error.Code != -32600 {
+			t.Errorf("request %s should be rejected with -32600 (invalid request), got %+v", req, resps)
+		}
+	}
+}
+
 // A single line larger than maxMCPMessageBytes is rejected without consuming
 // unbounded memory, and the server stops cleanly.
 func TestMCPServer_OversizedMessageRejected(t *testing.T) {

--- a/cmd/entire/cli/mcp_test.go
+++ b/cmd/entire/cli/mcp_test.go
@@ -302,6 +302,25 @@ func TestMCPServer_InvalidRequest(t *testing.T) {
 	}
 }
 
+// runMCPServer must echo the request id verbatim (numeric or string); a
+// dropped/swapped id silently breaks multi-call MCP sessions.
+func TestMCPServer_EchoesRequestID(t *testing.T) {
+	t.Parallel()
+	resps := driveMCP(t,
+		`{"jsonrpc":"2.0","id":42,"method":"ping"}`,
+		`{"jsonrpc":"2.0","id":"abc","method":"ping"}`,
+	)
+	if len(resps) != 2 {
+		t.Fatalf("expected 2 responses, got %d", len(resps))
+	}
+	if string(resps[0].ID) != "42" {
+		t.Errorf("numeric id should round-trip verbatim, got %s", resps[0].ID)
+	}
+	if string(resps[1].ID) != `"abc"` {
+		t.Errorf("string id should round-trip verbatim, got %s", resps[1].ID)
+	}
+}
+
 // A single line larger than maxMCPMessageBytes is rejected without consuming
 // unbounded memory, and the server stops cleanly.
 func TestMCPServer_OversizedMessageRejected(t *testing.T) {

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -127,6 +127,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newRewindCmd())
 
 	// Hidden infrastructure.
+	cmd.AddCommand(newMCPCmd(cmd)) // MCP stdio server for MCP-host agents
 	cmd.AddCommand(newHooksCmd())
 	cmd.AddCommand(newTrailCmd())
 	cmd.AddCommand(newSendAnalyticsCmd())

--- a/cmd/entire/cli/setup_agent_help_skill.go
+++ b/cmd/entire/cli/setup_agent_help_skill.go
@@ -74,6 +74,7 @@ func reportAgentHelpSkillScaffold(w io.Writer, ag agent.Agent, result managedSca
 		fmt.Fprintf(w, "    %s\n", result.RelPath)
 	case managedScaffoldUnsupported:
 		fmt.Fprintf(w, "  Agent-help skill is not supported for %s\n", ag.Type())
+		fmt.Fprintf(w, "    %s discovers entire via `%s` (passive — no skill file needed)\n", ag.Type(), agentHelpCommand)
 	case managedScaffoldUnchanged:
 		fmt.Fprintf(w, "  Agent-help skill already installed for %s\n", ag.Type())
 		fmt.Fprintf(w, "    %s\n", result.RelPath)

--- a/cmd/entire/cli/setup_agent_help_skill_test.go
+++ b/cmd/entire/cli/setup_agent_help_skill_test.go
@@ -70,7 +70,7 @@ func TestScaffoldAgentHelpSkill_CreatesManagedFiles(t *testing.T) {
 			if !strings.Contains(content, entireManagedAgentHelpSkillMarker) {
 				t.Error("scaffolded file should contain the Entire-managed marker")
 			}
-			if !strings.Contains(content, "entire agent-help") {
+			if !strings.Contains(content, agentHelpCommand) {
 				t.Errorf("scaffolded file should point at `entire agent-help`:\n%s", content)
 			}
 			if !strings.Contains(strings.ToLower(content), "never ask") {
@@ -142,7 +142,7 @@ func TestScaffoldAgentHelpSkill_UpdatesManagedFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read updated content: %v", err)
 	}
-	if !strings.Contains(string(data), "entire agent-help") {
+	if !strings.Contains(string(data), agentHelpCommand) {
 		t.Error("updated managed file should contain the current template")
 	}
 	if strings.Contains(string(data), "outdated body") {
@@ -247,5 +247,13 @@ func TestSetupOptionalAgentHelpSkillForNames_DedupsAndSkipsUnsupported(t *testin
 	}
 	if !strings.Contains(out.String(), "not supported") {
 		t.Fatalf("cursor (no template) should be reported unsupported, got: %s", out.String())
+	}
+	// A no-channel agent must be pointed at the passive pull path, not left at a
+	// dead-end "not supported" line.
+	if !strings.Contains(out.String(), agentHelpCommand) {
+		t.Fatalf("unsupported agent should be pointed at `entire agent-help`, got: %s", out.String())
+	}
+	if !strings.Contains(strings.ToLower(out.String()), "passive") {
+		t.Fatalf("unsupported agent note should mention passive discovery, got: %s", out.String())
 	}
 }

--- a/cmd/entire/cli/status.go
+++ b/cmd/entire/cli/status.go
@@ -109,11 +109,18 @@ func runStatus(ctx context.Context, w io.Writer, detailed, jsonOutput bool) erro
 	return nil
 }
 
+// agentHelpCommand is the invocation a coding agent runs to get machine-readable
+// usage. It is surfaced both in the human status footer (writeAgentHelpHint) and
+// in `entire status --json` (statusJSON.AgentHelp), so no-channel agents (Cursor,
+// Copilot CLI, Factory Droid, MCP hosts) can discover entire's surface by reading
+// either output.
+const agentHelpCommand = "entire agent-help"
+
 // writeAgentHelpHint prints a one-line pointer at `entire agent-help` for coding
 // agents that have no context-injection channel (Cursor, Copilot CLI, Factory
 // Droid) and so discover entire's surface only by reading command output.
 func writeAgentHelpHint(w io.Writer, sty statusStyles) {
-	fmt.Fprintln(w, sty.render(sty.dim, "Agents: run `entire agent-help` for machine-readable usage."))
+	fmt.Fprintln(w, sty.render(sty.dim, "Agents: run `"+agentHelpCommand+"` for machine-readable usage."))
 }
 
 // runStatusDetailed shows the effective status plus detailed status for each settings file.
@@ -588,7 +595,11 @@ type statusJSON struct {
 	Enabled        bool               `json:"enabled"`
 	Agents         []string           `json:"agents"`
 	ActiveSessions []sessionBriefJSON `json:"active_sessions"`
-	Error          string             `json:"error,omitempty"`
+	// AgentHelp is the machine-readable pointer for no-channel agents that parse
+	// `entire status --json` instead of the human footer. Set only on the
+	// success path (mirrors writeAgentHelpHint, which only renders when set up).
+	AgentHelp string `json:"agent_help,omitempty"`
+	Error     string `json:"error,omitempty"`
 }
 
 type sessionBriefJSON struct {
@@ -637,6 +648,7 @@ func runStatusJSON(ctx context.Context, w io.Writer) error {
 		Enabled:        s.Enabled,
 		Agents:         []string{},
 		ActiveSessions: []sessionBriefJSON{},
+		AgentHelp:      agentHelpCommand,
 	}
 
 	if s.Enabled {

--- a/cmd/entire/cli/status_test.go
+++ b/cmd/entire/cli/status_test.go
@@ -222,7 +222,7 @@ func TestRunStatus_ShowsAgentHelpHintWhenSetUp(t *testing.T) {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
-	if !strings.Contains(stdout.String(), "entire agent-help") {
+	if !strings.Contains(stdout.String(), agentHelpCommand) {
 		t.Errorf("expected agent-help hint in status output, got: %s", stdout.String())
 	}
 }
@@ -235,8 +235,19 @@ func TestRunStatus_NoAgentHelpHintWhenNotSetUp(t *testing.T) {
 		t.Fatalf("runStatus() error = %v", err)
 	}
 
-	if strings.Contains(stdout.String(), "entire agent-help") {
+	if strings.Contains(stdout.String(), agentHelpCommand) {
 		t.Errorf("agent-help hint should not appear when not set up, got: %s", stdout.String())
+	}
+}
+
+// agentHelpCommand is user-facing — docs, the installed skills, and agents key
+// off the exact string — so pin its value here. Every other assertion uses the
+// const; this guards against it silently drifting.
+func TestAgentHelpCommandValue(t *testing.T) {
+	t.Parallel()
+	const want = "entire agent-help"
+	if agentHelpCommand != want {
+		t.Errorf("agentHelpCommand = %q, want %q", agentHelpCommand, want)
 	}
 }
 
@@ -251,6 +262,10 @@ func TestRunStatus_Disabled(t *testing.T) {
 
 	if !strings.Contains(stdout.String(), "Disabled") {
 		t.Errorf("Expected output to show 'Disabled', got: %s", stdout.String())
+	}
+	// The agent-help footer renders whenever entire is set up, including disabled.
+	if !strings.Contains(stdout.String(), agentHelpCommand) {
+		t.Errorf("Expected agent-help hint in disabled (but set-up) status, got: %s", stdout.String())
 	}
 }
 
@@ -1730,6 +1745,11 @@ func TestRunStatusJSON_Enabled(t *testing.T) {
 	if result.Error != "" {
 		t.Errorf("Expected no error, got %q", result.Error)
 	}
+	// No-channel agents (Cursor/Copilot/Droid/MCP) parse --json, not the text
+	// footer, so the agent-help pointer must be present once entire is set up.
+	if result.AgentHelp != agentHelpCommand {
+		t.Errorf("Expected agent_help='entire agent-help', got %q", result.AgentHelp)
+	}
 }
 
 func TestRunStatusJSON_Disabled(t *testing.T) {
@@ -1748,6 +1768,11 @@ func TestRunStatusJSON_Disabled(t *testing.T) {
 
 	if result.Enabled {
 		t.Error("Expected enabled=false")
+	}
+	// Disabled-but-set-up still advertises the passive agent-help pointer (the
+	// hint is gated on "set up", not on "enabled") — matches the text footer.
+	if result.AgentHelp != agentHelpCommand {
+		t.Errorf("Expected agent_help='entire agent-help' when disabled-but-set-up, got %q", result.AgentHelp)
 	}
 }
 
@@ -1770,6 +1795,10 @@ func TestRunStatusJSON_NotSetUp(t *testing.T) {
 	if result.Error != "not set up" {
 		t.Errorf("Expected error='not set up', got %q", result.Error)
 	}
+	// Mirrors the text footer: no agent-help pointer until entire is set up.
+	if result.AgentHelp != "" {
+		t.Errorf("agent_help should be empty when not set up, got %q", result.AgentHelp)
+	}
 }
 
 func TestRunStatusJSON_NotGitRepo(t *testing.T) {
@@ -1790,6 +1819,9 @@ func TestRunStatusJSON_NotGitRepo(t *testing.T) {
 	}
 	if result.Error != "not a git repository" {
 		t.Errorf("Expected error='not a git repository', got %q", result.Error)
+	}
+	if result.AgentHelp != "" {
+		t.Errorf("agent_help should be empty when not a git repo, got %q", result.AgentHelp)
 	}
 }
 
@@ -1837,6 +1869,9 @@ func TestRunStatusJSON_WithActiveSessions(t *testing.T) {
 	}
 	if s.Status != "active" {
 		t.Errorf("Expected status='active', got %q", s.Status)
+	}
+	if result.AgentHelp != agentHelpCommand {
+		t.Errorf("Expected agent_help='entire agent-help' with active sessions, got %q", result.AgentHelp)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/712
<!-- entire-trail-link-end -->

## What
Completes agent-help discovery for "no-channel" agents — agents with no entire context-injection channel and no agent-help skill template (Cursor, Copilot CLI, Factory Droid, MCP hosts) — across a passive and two active paths.

## Why / how it helps
`entire agent-help` is the live, single source of truth for the CLI's surface, but no-channel agents had no reliable way to find it: the `entire status` footer was human-text only, Factory Droid got nothing in-session, and MCP hosts had no tool to call. This gives each of them a discovery path without enumerating a surface that goes stale.

## How
- **Passive** — `entire status --json` now carries an `agent_help` pointer (present whenever Entire is set up); the `--agent-help-skill` path points no-channel agents at it instead of reporting a bare "unsupported".
- **Active (Factory Droid)** — the pointer is appended to Droid's SessionStart banner, after any `ResponseMessage` override so it can't be dropped (`finalizeSessionStartBanner`).
- **Active (MCP hosts)** — a hidden `entire mcp` stdio JSON-RPC 2.0 server exposes `agent_help` and `entire_status` as MCP tools, reusing the live rendering so both always match the installed binary. Each message is bounded to 1 MiB and a malformed line is reported then skipped (the server recovers to the next line). No new dependencies.

Reviewers: focus on `mcp.go` (stdio framing / per-message bound / recover-to-next-line) and `finalizeSessionStartBanner` (override-then-append ordering).

## Testing
- `mise run lint` — 0 issues
- `go test ./cmd/entire/cli/` — full unit suite green, including new coverage:
  - MCP: initialize (echo + default + bad-type protocol), silent notifications, tools/list, agent_help (top-level + drill-down), entire_status parity with `status --json`, ping, unknown-method (-32601), unknown/empty tool (-32602), parse error (-32700), oversized message (-32600), batch-array reject + recover-to-next-line
  - banner: Factory-only pointer, survives `ResponseMessage` override, no pointer for other agents (incl. the Vogon test agent)
  - status: `agent_help` present on success incl. disabled-but-set-up, absent on error paths
- real-binary stdio smoke of `entire mcp` (initialize -> tools/list -> tools/call)
- verified on the committed tree

## Notes
- Builds on the agent-help work merged in #1562; the three commits here are the only diff vs `main`.
- The branch is behind `main` and needs a rebase before merge; opening as a draft.
