### PR TITLE
Add telemetry for policy-blocked checkpoint hooks

### DIFF
--- a/cmd/entire/cli/checkpoint_policy_telemetry.go
+++ b/cmd/entire/cli/checkpoint_policy_telemetry.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
+	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
+)
+
+// emitCheckpointPolicyBlocked reports a checkpoint_policy_blocked telemetry
+// event when telemetry is opted in (settings.Telemetry == true). Best-effort
+// and non-blocking; failures to load settings simply suppress the event.
+func emitCheckpointPolicyBlocked(ctx context.Context, event telemetry.CheckpointPolicyBlockedEvent) {
+	s, err := LoadEntireSettings(ctx)
+	if err != nil || s.Telemetry == nil || !*s.Telemetry {
+		return
+	}
+	telemetry.TrackCheckpointPolicyBlocked(event, versioninfo.Version)
+}

--- a/cmd/entire/cli/hook_registry.go
+++ b/cmd/entire/cli/hook_registry.go
@@ -20,6 +20,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/perf"
@@ -179,7 +180,7 @@ func executeAgentHook(cmd *cobra.Command, agentName types.AgentName, hookName st
 	}
 
 	if eventType == agent.SessionStart {
-		skipSessionStart, err := shouldSkipSessionStartForPolicy(ctx, cmd.ErrOrStderr(), ag, worktreeRoot)
+		skipSessionStart, err := shouldSkipSessionStartForPolicy(ctx, cmd.ErrOrStderr(), agentName, ag, worktreeRoot)
 		if err != nil {
 			span.RecordError(err)
 			return err
@@ -188,7 +189,8 @@ func executeAgentHook(cmd *cobra.Command, agentName types.AgentName, hookName st
 			return nil
 		}
 	} else if hookWritesCheckpointData(eventType, claudePostTodoCheckpointHook) {
-		if err := rejectUnsupportedCheckpointWritePolicy(ctx, cmd.ErrOrStderr(), worktreeRoot); err != nil {
+		writeHook := agentWriteHookLabel(eventType, claudePostTodoCheckpointHook)
+		if err := rejectUnsupportedCheckpointWritePolicy(ctx, cmd.ErrOrStderr(), agentName, writeHook, worktreeRoot); err != nil {
 			span.RecordError(err)
 			return err
 		}
@@ -221,16 +223,32 @@ func shouldSkipAgentHookForPolicy(policy checkpointpolicy.Policy) bool {
 	return !checkpointpolicy.CanSatisfyPolicy(policy)
 }
 
-func shouldSkipSessionStartForPolicy(ctx context.Context, errW io.Writer, ag agent.Agent, worktreeRoot string) (bool, error) {
+func shouldSkipSessionStartForPolicy(ctx context.Context, errW io.Writer, agentName types.AgentName, ag agent.Agent, worktreeRoot string) (bool, error) {
 	policy, err := agentHookPolicy(ctx, worktreeRoot)
 	if err != nil {
 		logging.Warn(ctx, "checkpoint policy read failed for agent hook",
 			slog.String("error", err.Error()))
+		emitCheckpointPolicyBlocked(ctx, telemetry.CheckpointPolicyBlockedEvent{
+			Hook:     "session-start",
+			HookType: telemetry.PolicyBlockedHookTypeAgent,
+			Reason:   telemetry.PolicyBlockedReasonUnreadable,
+			Outcome:  telemetry.PolicyBlockedOutcomeSkipped,
+			Agent:    string(agentName),
+		})
 		// Let the agent start; the warning explains that checkpoint capture is
 		// disabled until the policy can be read.
 		return true, writeUnsupportedPolicySessionStartWarning(errW, ag, sessionStartPolicyReadErrorWarning(err))
 	}
 	if shouldSkipAgentHookForPolicy(policy) {
+		emitCheckpointPolicyBlocked(ctx, telemetry.CheckpointPolicyBlockedEvent{
+			Hook:                 "session-start",
+			HookType:             telemetry.PolicyBlockedHookTypeAgent,
+			Reason:               telemetry.PolicyBlockedReasonUnsupported,
+			Outcome:              telemetry.PolicyBlockedOutcomeSkipped,
+			Agent:                string(agentName),
+			CheckpointVersion:    policy.CheckpointVersion,
+			CheckpointMinVersion: policy.CheckpointMinVersion,
+		})
 		// Let the agent start; the warning explains that checkpoint capture is
 		// disabled until the CLI is upgraded.
 		return true, writeUnsupportedPolicySessionStartWarning(errW, ag, sessionStartPolicyWarning(policy))
@@ -238,15 +256,31 @@ func shouldSkipSessionStartForPolicy(ctx context.Context, errW io.Writer, ag age
 	return false, nil
 }
 
-func rejectUnsupportedCheckpointWritePolicy(ctx context.Context, errW io.Writer, worktreeRoot string) error {
+func rejectUnsupportedCheckpointWritePolicy(ctx context.Context, errW io.Writer, agentName types.AgentName, hook string, worktreeRoot string) error {
 	policy, err := agentHookPolicy(ctx, worktreeRoot)
 	if err != nil {
 		logging.Warn(ctx, "checkpoint policy read failed for agent hook",
 			slog.String("error", err.Error()))
+		emitCheckpointPolicyBlocked(ctx, telemetry.CheckpointPolicyBlockedEvent{
+			Hook:     hook,
+			HookType: telemetry.PolicyBlockedHookTypeAgent,
+			Reason:   telemetry.PolicyBlockedReasonUnreadable,
+			Outcome:  telemetry.PolicyBlockedOutcomeBlocked,
+			Agent:    string(agentName),
+		})
 		fmt.Fprint(errW, agentCheckpointCaptureDisabledReadErrorMessage(err))
 		return NewSilentError(err)
 	}
 	if shouldSkipAgentHookForPolicy(policy) {
+		emitCheckpointPolicyBlocked(ctx, telemetry.CheckpointPolicyBlockedEvent{
+			Hook:                 hook,
+			HookType:             telemetry.PolicyBlockedHookTypeAgent,
+			Reason:               telemetry.PolicyBlockedReasonUnsupported,
+			Outcome:              telemetry.PolicyBlockedOutcomeBlocked,
+			Agent:                string(agentName),
+			CheckpointVersion:    policy.CheckpointVersion,
+			CheckpointMinVersion: policy.CheckpointMinVersion,
+		})
 		fmt.Fprint(errW, agentCheckpointCaptureDisabledMessage(policy))
 		return NewSilentError(errUnsupportedCheckpointPolicy)
 	}
@@ -258,6 +292,17 @@ func hookWritesCheckpointData(eventType agent.EventType, claudePostTodoCheckpoin
 		return true
 	}
 	return eventType == agent.TurnEnd || eventType == agent.SubagentEnd
+}
+
+func agentWriteHookLabel(eventType agent.EventType, claudePostTodoCheckpointHook bool) string {
+	switch {
+	case claudePostTodoCheckpointHook:
+		return "post-todo"
+	case eventType == agent.SubagentEnd:
+		return "subagent-end"
+	default:
+		return "turn-end"
+	}
 }
 
 func sessionStartPolicyWarning(policy checkpointpolicy.Policy) string {

--- a/cmd/entire/cli/hook_registry_test.go
+++ b/cmd/entire/cli/hook_registry_test.go
@@ -278,6 +278,29 @@ func TestHookWritesCheckpointData(t *testing.T) {
 	}
 }
 
+func TestAgentWriteHookLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                         string
+		eventType                    agent.EventType
+		claudePostTodoCheckpointHook bool
+		want                         string
+	}{
+		{name: "post todo takes priority", claudePostTodoCheckpointHook: true, want: "post-todo"},
+		{name: "subagent end", eventType: agent.SubagentEnd, want: "subagent-end"},
+		{name: "turn end is the default", eventType: agent.TurnEnd, want: "turn-end"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, agentWriteHookLabel(tt.eventType, tt.claudePostTodoCheckpointHook))
+		})
+	}
+}
+
 func TestExecuteAgentHookTurnStartDispatchesWhenPolicyUnsupported(t *testing.T) {
 	setupStopTestRepo(t)
 	repoRoot := mustGetwd(t)

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
 	"github.com/entireio/cli/cmd/entire/cli/strategy"
+	"github.com/entireio/cli/cmd/entire/cli/telemetry"
 	"github.com/entireio/cli/cmd/entire/cli/versioncheck"
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 	"github.com/entireio/cli/perf"
@@ -75,6 +76,12 @@ func (g *gitHookContext) skipUnsupportedCheckpointPolicy() bool {
 		if interactive.CanPromptInteractively() {
 			fmt.Fprintf(os.Stderr, "[entire] Could not read checkpoint policy; skipping Entire checkpoint work: %v\n", err)
 		}
+		emitCheckpointPolicyBlocked(g.ctx, telemetry.CheckpointPolicyBlockedEvent{
+			Hook:     g.hookName,
+			HookType: telemetry.PolicyBlockedHookTypeGit,
+			Reason:   telemetry.PolicyBlockedReasonUnreadable,
+			Outcome:  telemetry.PolicyBlockedOutcomeSkipped,
+		})
 		return true
 	}
 	defer repo.Close()
@@ -86,6 +93,12 @@ func (g *gitHookContext) skipUnsupportedCheckpointPolicy() bool {
 		if interactive.CanPromptInteractively() {
 			fmt.Fprintf(os.Stderr, "[entire] Could not read checkpoint policy; skipping Entire checkpoint work: %v\n", err)
 		}
+		emitCheckpointPolicyBlocked(g.ctx, telemetry.CheckpointPolicyBlockedEvent{
+			Hook:     g.hookName,
+			HookType: telemetry.PolicyBlockedHookTypeGit,
+			Reason:   telemetry.PolicyBlockedReasonUnreadable,
+			Outcome:  telemetry.PolicyBlockedOutcomeSkipped,
+		})
 		return true
 	}
 
@@ -103,6 +116,14 @@ func (g *gitHookContext) skipUnsupportedCheckpointPolicy() bool {
 			versioncheck.UpdateCommandForCurrentBinary(versioninfo.Version),
 		))
 	}
+	emitCheckpointPolicyBlocked(g.ctx, telemetry.CheckpointPolicyBlockedEvent{
+		Hook:                 g.hookName,
+		HookType:             telemetry.PolicyBlockedHookTypeGit,
+		Reason:               telemetry.PolicyBlockedReasonUnsupported,
+		Outcome:              telemetry.PolicyBlockedOutcomeSkipped,
+		CheckpointVersion:    policy.CheckpointVersion,
+		CheckpointMinVersion: policy.CheckpointMinVersion,
+	})
 	return true
 }
 

--- a/cmd/entire/cli/hooks_git_cmd.go
+++ b/cmd/entire/cli/hooks_git_cmd.go
@@ -71,35 +71,13 @@ func (g *gitHookContext) skipUnsupportedCheckpointPolicy() bool {
 	// disable Entire checkpoint work, not make Git reject the user's operation.
 	repo, err := gitrepo.OpenCurrent(g.ctx)
 	if err != nil {
-		logging.Warn(g.ctx, "checkpoint policy read failed; skipping git hook",
-			slog.String("error", err.Error()))
-		if interactive.CanPromptInteractively() {
-			fmt.Fprintf(os.Stderr, "[entire] Could not read checkpoint policy; skipping Entire checkpoint work: %v\n", err)
-		}
-		emitCheckpointPolicyBlocked(g.ctx, telemetry.CheckpointPolicyBlockedEvent{
-			Hook:     g.hookName,
-			HookType: telemetry.PolicyBlockedHookTypeGit,
-			Reason:   telemetry.PolicyBlockedReasonUnreadable,
-			Outcome:  telemetry.PolicyBlockedOutcomeSkipped,
-		})
-		return true
+		return g.skipUnreadableCheckpointPolicy(err)
 	}
 	defer repo.Close()
 
 	state, err := checkpointpolicy.ReadLocal(g.ctx, repo)
 	if err != nil {
-		logging.Warn(g.ctx, "checkpoint policy read failed; skipping git hook",
-			slog.String("error", err.Error()))
-		if interactive.CanPromptInteractively() {
-			fmt.Fprintf(os.Stderr, "[entire] Could not read checkpoint policy; skipping Entire checkpoint work: %v\n", err)
-		}
-		emitCheckpointPolicyBlocked(g.ctx, telemetry.CheckpointPolicyBlockedEvent{
-			Hook:     g.hookName,
-			HookType: telemetry.PolicyBlockedHookTypeGit,
-			Reason:   telemetry.PolicyBlockedReasonUnreadable,
-			Outcome:  telemetry.PolicyBlockedOutcomeSkipped,
-		})
-		return true
+		return g.skipUnreadableCheckpointPolicy(err)
 	}
 
 	policy := state.Policy
@@ -123,6 +101,24 @@ func (g *gitHookContext) skipUnsupportedCheckpointPolicy() bool {
 		Outcome:              telemetry.PolicyBlockedOutcomeSkipped,
 		CheckpointVersion:    policy.CheckpointVersion,
 		CheckpointMinVersion: policy.CheckpointMinVersion,
+	})
+	return true
+}
+
+// skipUnreadableCheckpointPolicy warns, notifies the user, and reports the
+// policy-blocked telemetry event for a hook whose checkpoint policy could not be
+// read. It always returns true so callers skip Entire checkpoint work.
+func (g *gitHookContext) skipUnreadableCheckpointPolicy(err error) bool {
+	logging.Warn(g.ctx, "checkpoint policy read failed; skipping git hook",
+		slog.String("error", err.Error()))
+	if interactive.CanPromptInteractively() {
+		fmt.Fprintf(os.Stderr, "[entire] Could not read checkpoint policy; skipping Entire checkpoint work: %v\n", err)
+	}
+	emitCheckpointPolicyBlocked(g.ctx, telemetry.CheckpointPolicyBlockedEvent{
+		Hook:     g.hookName,
+		HookType: telemetry.PolicyBlockedHookTypeGit,
+		Reason:   telemetry.PolicyBlockedReasonUnreadable,
+		Outcome:  telemetry.PolicyBlockedOutcomeSkipped,
 	})
 	return true
 }

--- a/cmd/entire/cli/telemetry/checkpoint_policy.go
+++ b/cmd/entire/cli/telemetry/checkpoint_policy.go
@@ -1,0 +1,89 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+// Property values for the checkpoint_policy_blocked event.
+const (
+	PolicyBlockedHookTypeGit   = "git"
+	PolicyBlockedHookTypeAgent = "agent"
+
+	PolicyBlockedReasonUnsupported = "policy_unsupported"
+	PolicyBlockedReasonUnreadable  = "policy_unreadable"
+
+	PolicyBlockedOutcomeSkipped = "skipped"
+	PolicyBlockedOutcomeBlocked = "blocked"
+)
+
+// CheckpointPolicyBlockedEvent carries the gate-derived fields for a
+// checkpoint_policy_blocked telemetry event. Agent, CheckpointVersion, and
+// CheckpointMinVersion are optional and omitted from the payload when empty.
+type CheckpointPolicyBlockedEvent struct {
+	Hook                 string
+	HookType             string
+	Reason               string
+	Outcome              string
+	Agent                string
+	CheckpointVersion    string
+	CheckpointMinVersion string
+}
+
+// BuildCheckpointPolicyBlockedPayload constructs the event payload. Exported for
+// testing. Returns nil if the machine ID cannot be resolved.
+func BuildCheckpointPolicyBlockedPayload(event CheckpointPolicyBlockedEvent, version string) *EventPayload {
+	machineID, err := machineid.ProtectedID("entire-cli")
+	if err != nil {
+		return nil
+	}
+
+	properties := map[string]any{
+		"hook":        event.Hook,
+		"hook_type":   event.HookType,
+		"reason":      event.Reason,
+		"outcome":     event.Outcome,
+		"cli_version": version,
+		"os":          runtime.GOOS,
+		"arch":        runtime.GOARCH,
+	}
+	if event.Agent != "" {
+		properties["agent"] = event.Agent
+	}
+	if event.CheckpointVersion != "" {
+		properties["checkpoint_version"] = event.CheckpointVersion
+	}
+	if event.CheckpointMinVersion != "" {
+		properties["checkpoint_min_version"] = event.CheckpointMinVersion
+	}
+
+	return &EventPayload{
+		Event:      "checkpoint_policy_blocked",
+		DistinctID: machineID,
+		Properties: properties,
+		Timestamp:  time.Now(),
+	}
+}
+
+// TrackCheckpointPolicyBlocked sends a checkpoint_policy_blocked event by
+// spawning a detached subprocess. Best-effort and non-blocking; callers are
+// responsible for the settings.Telemetry opt-in check. Honors
+// ENTIRE_TELEMETRY_OPTOUT like the other trackers.
+func TrackCheckpointPolicyBlocked(event CheckpointPolicyBlockedEvent, version string) {
+	if os.Getenv("ENTIRE_TELEMETRY_OPTOUT") != "" {
+		return
+	}
+
+	payload := BuildCheckpointPolicyBlockedPayload(event, version)
+	if payload == nil {
+		return
+	}
+
+	if payloadJSON, err := json.Marshal(payload); err == nil {
+		spawnDetachedAnalytics(string(payloadJSON))
+	}
+}

--- a/cmd/entire/cli/telemetry/checkpoint_policy_test.go
+++ b/cmd/entire/cli/telemetry/checkpoint_policy_test.go
@@ -1,0 +1,69 @@
+package telemetry
+
+import "testing"
+
+func TestBuildCheckpointPolicyBlockedPayload_Unsupported(t *testing.T) {
+	t.Parallel()
+	payload := BuildCheckpointPolicyBlockedPayload(CheckpointPolicyBlockedEvent{
+		Hook:                 "post-commit",
+		HookType:             PolicyBlockedHookTypeGit,
+		Reason:               PolicyBlockedReasonUnsupported,
+		Outcome:              PolicyBlockedOutcomeSkipped,
+		CheckpointVersion:    "v2",
+		CheckpointMinVersion: "v2",
+	}, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildCheckpointPolicyBlockedPayload returned nil")
+		return
+	}
+	if payload.Event != "checkpoint_policy_blocked" {
+		t.Errorf("Event = %q, want %q", payload.Event, "checkpoint_policy_blocked")
+	}
+	if payload.DistinctID == "" {
+		t.Error("DistinctID must be set to the machine ID")
+	}
+	checks := map[string]any{
+		"hook":                   "post-commit",
+		"hook_type":              "git",
+		"reason":                 "policy_unsupported",
+		"outcome":                "skipped",
+		"checkpoint_version":     "v2",
+		"checkpoint_min_version": "v2",
+		"cli_version":            "1.2.3",
+	}
+	for k, want := range checks {
+		if got := payload.Properties[k]; got != want {
+			t.Errorf("Properties[%q] = %v, want %v", k, got, want)
+		}
+	}
+	if _, ok := payload.Properties["agent"]; ok {
+		t.Error("git-hook payload must not include 'agent'")
+	}
+}
+
+func TestBuildCheckpointPolicyBlockedPayload_UnreadableOmitsVersions(t *testing.T) {
+	t.Parallel()
+	payload := BuildCheckpointPolicyBlockedPayload(CheckpointPolicyBlockedEvent{
+		Hook:     "session-start",
+		HookType: PolicyBlockedHookTypeAgent,
+		Reason:   PolicyBlockedReasonUnreadable,
+		Outcome:  PolicyBlockedOutcomeSkipped,
+		Agent:    "claude-code",
+	}, "1.2.3")
+	if payload == nil {
+		t.Fatal("BuildCheckpointPolicyBlockedPayload returned nil")
+		return
+	}
+	if got := payload.Properties["agent"]; got != "claude-code" {
+		t.Errorf("Properties[agent] = %v, want %q", got, "claude-code")
+	}
+	if _, ok := payload.Properties["checkpoint_version"]; ok {
+		t.Error("unreadable payload must omit 'checkpoint_version'")
+	}
+	if _, ok := payload.Properties["checkpoint_min_version"]; ok {
+		t.Error("unreadable payload must omit 'checkpoint_min_version'")
+	}
+	if got := payload.Properties["outcome"]; got != "skipped" {
+		t.Errorf("Properties[outcome] = %v, want %q", got, "skipped")
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/713
<!-- entire-trail-link-end -->

## Why

PR #1541 ("Gate checkpoint writes on policy support") made the CLI skip or reject Entire checkpoint work when a repository's checkpoint policy cannot be satisfied or cannot be read. When that happens inside a hook, checkpoint capture is lost — silently for git hooks, visibly for agent write hooks — and today we have no signal for how often policy gating actually blocks checkpoint creation in the field.

## What changed

Adds an opt-in PostHog event, `checkpoint_policy_blocked`, emitted at the git and agent hook policy gates whenever a hook is prevented from creating checkpoint data because the policy is unsupported or unreadable.

## Event schema

Emitted via the existing detached-subprocess telemetry path (`distinct_id` is the machine ID).

| Property | Values |
|---|---|
| `hook` | `prepare-commit-msg`, `commit-msg`, `post-commit`, `post-rewrite`, `session-start`, `turn-end`, `subagent-end`, `post-todo` |
| `hook_type` | `git` \| `agent` |
| `reason` | `policy_unsupported` \| `policy_unreadable` |
| `outcome` | `skipped` (git hooks + agent session-start) \| `blocked` (agent write hooks) |
| `agent` | agent name (omitted for git hooks) |
| `checkpoint_version`, `checkpoint_min_version` | admin-set policy versions (omitted when `policy_unreadable`) |
| `cli_version`, `os`, `arch` | standard, matching existing events |

All values are operational metadata — no prompts, file contents, commit messages, or paths.

## Decisions made during development

- **Per-gate emission.** Each gated hook emits its own event, so one blocked `git commit` produces up to three events (`prepare-commit-msg`, `commit-msg`, `post-commit`), distinguished by `hook`. The three are separate processes with no shared in-memory state, so dedup is left to downstream analysis (`distinct_id` + timestamp + `hook_type`) rather than persisting a cross-process marker.
- **Rides the existing opt-in telemetry gate.** Emits only when `settings.Telemetry == true` and `ENTIRE_TELEMETRY_OPTOUT` is unset — identical to `cli_command_executed`. This undercounts (only opted-in users), but keeps the privacy model consistent.
- **Boundary.** The `telemetry` package stays settings-agnostic; the `settings.Telemetry` opt-in check lives in a thin CLI helper (`emitCheckpointPolicyBlocked`) to avoid an import cycle, mirroring how `TrackCommandDetached` leaves opt-in to its caller. The new builder/tracker mirror the established per-event `Build*`/`Track*` pattern rather than introducing a generic tracker.

## Technical tradeoffs

- **Over-counting vs. complexity:** per-gate emission over-counts a single user action, but cross-process dedup would add a persisted marker and new failure modes for a best-effort signal. Chose simplicity + downstream dedup.
- **Undercounting vs. privacy:** opt-in gating means the signal misses users who never enabled telemetry. Accepted for privacy consistency rather than adding a separate operational channel.

## Reviewer notes

Scope is intentionally limited to the hook gates. Strategy-internal condensation/finalization, the pre-push hook, and the command gates (`session attach`, `checkpoint import`, `explain --generate`) are not instrumented in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior of policy gates is unchanged; this only adds best-effort, opt-in telemetry with operational metadata and honors ENTIRE_TELEMETRY_OPTOUT.
> 
> **Overview**
> Adds **observability** for checkpoint policy gating introduced earlier: when hooks refuse checkpoint work because policy cannot be read or the CLI cannot satisfy it, the CLI can now emit a **`checkpoint_policy_blocked`** analytics event (same detached-subprocess path as other telemetry).
> 
> A new **`telemetry`** builder/tracker defines the event schema (`hook`, `hook_type`, `reason`, `outcome`, optional `agent` and policy versions, plus `cli_version`/`os`/`arch`). **`emitCheckpointPolicyBlocked`** in the CLI layer gates emission on **`settings.Telemetry`** and delegates tracking, keeping the telemetry package free of settings imports.
> 
> **Git hooks** call the emitter from `skipUnsupportedCheckpointPolicy` and a refactored **`skipUnreadableCheckpointPolicy`** helper (outcome **`skipped`**). **Agent hooks** emit on session-start skips and on write-path rejects (`turn-end`, `subagent-end`, `post-todo` via new **`agentWriteHookLabel`**), with outcomes **`skipped`** vs **`blocked`** and the agent name included. Payload tests cover supported vs unreadable cases; a small unit test covers hook label mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d276ec2f162cbdd643bdcdbe5642d5c9d5212e34. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->