### PR TITLE
feat(mirror): split placement and clone progress steps

### DIFF
--- a/cmd/entire/cli/list_pagination_test.go
+++ b/cmd/entire/cli/list_pagination_test.go
@@ -70,7 +70,7 @@ func TestOrgList_FollowsCursor(t *testing.T) {
 func TestMirrorList_FollowsCursor(t *testing.T) {
 	var gotTokens []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/mirrors" {
+		if r.URL.Path != mirrorsAPIPath {
 			t.Errorf("unexpected path %q", r.URL.Path)
 		}
 		token := r.URL.Query().Get("pageToken")

--- a/cmd/entire/cli/repo_mirror.go
+++ b/cmd/entire/cli/repo_mirror.go
@@ -172,14 +172,36 @@ func newRepoMirrorCreateCmd() *cobra.Command {
 			}
 			return runCoreForCluster(cmd, clusterHost, func(ctx context.Context, c *coreapi.Client) error {
 				errW := cmd.ErrOrStderr()
-				stop := startSpinner(errW, fmt.Sprintf("Cloning %s/%s into %s", owner, repo, clusterHost))
-				// nil onStatus: the one-shot's single spinner shows liveness; the
+				// Two-phase progress: a "Placing" spinner covers the fast
+				// CreateMirror call (placement, <15s), then a separate "Cloning"
+				// spinner covers the clone-readiness poll. An already-ready mirror
+				// completes the first poll faster than the spinner's initial delay,
+				// so the Cloning line never paints and we go straight to the clone
+				// instructions.
+				placing := startSpinner(errW, fmt.Sprintf("Placing mirror %s/%s into %s", owner, repo, clusterHost))
+				placed := false
+				var cloning func(success bool)
+				// nil onStatus: the one-shot's spinners show liveness; the
 				// per-mirror progress lines are the wizard's concern.
-				outcome, err := createAndAwaitMirror(ctx, c, owner, repo, clusterHost, noWait, waitTimeout, nil)
-				// Only a confirmed-ready clone earns the ✓; everything else
-				// (empty, --no-wait, suspended, failed, timeout) erases the line
-				// and lets reportOneShotMirror print the specific outcome.
-				stop(err == nil && outcome.polled && outcome.status == coreapi.MirrorStatusReady)
+				outcome, err := createAndAwaitMirror(ctx, c, owner, repo, clusterHost, noWait, waitTimeout,
+					func(created *coreapi.CreatedMirror) {
+						placing(true)
+						placed = true
+						// Only start a Cloning spinner when there's a clone to await.
+						if !noWait && !created.Empty {
+							cloning = startSpinner(errW, fmt.Sprintf("Cloning %s/%s into %s", owner, repo, clusterHost))
+						}
+					}, nil)
+				if !placed {
+					// CreateMirror failed before onCreated fired — erase the line.
+					placing(false)
+				}
+				if cloning != nil {
+					// Only a confirmed-ready clone earns the ✓; everything else
+					// (suspended, failed, timeout) erases the line and lets
+					// reportOneShotMirror print the specific outcome.
+					cloning(err == nil && outcome.polled && outcome.status == coreapi.MirrorStatusReady)
+				}
 				return reportOneShotMirror(cmd.OutOrStdout(), errW, outcome, err)
 			})
 		},
@@ -206,7 +228,11 @@ type mirrorCreateOutcome struct {
 // status. The returned error is the create error (when outcome.created is nil)
 // or the wait error — a status sentinel (errMirrorCloneFailed /
 // errMirrorSuspended) or a timeout; callers read outcome.status for the state.
-func createAndAwaitMirror(ctx context.Context, c *coreapi.Client, owner, repo, clusterHost string, noWait bool, timeout time.Duration, onStatus func(coreapi.MirrorStatus)) (mirrorCreateOutcome, error) {
+//
+// onCreated (may be nil) fires once the placement is registered, before any
+// clone polling — it separates the fast "placing" phase from the slow "cloning"
+// wait so callers can render them as distinct steps.
+func createAndAwaitMirror(ctx context.Context, c *coreapi.Client, owner, repo, clusterHost string, noWait bool, timeout time.Duration, onCreated func(*coreapi.CreatedMirror), onStatus func(coreapi.MirrorStatus)) (mirrorCreateOutcome, error) {
 	created, err := c.CreateMirror(ctx, &coreapi.CreateMirrorInputBody{
 		Provider:    coreapi.CreateMirrorInputBodyProviderGithub,
 		Owner:       owner,
@@ -215,6 +241,9 @@ func createAndAwaitMirror(ctx context.Context, c *coreapi.Client, owner, repo, c
 	})
 	if err != nil {
 		return mirrorCreateOutcome{}, err
+	}
+	if onCreated != nil {
+		onCreated(created)
 	}
 	outcome := mirrorCreateOutcome{created: created}
 	if created.Empty {
@@ -254,9 +283,9 @@ func reportOneShotMirror(out, errW io.Writer, outcome mirrorCreateOutcome, err e
 		return err
 	}
 	if created.Created {
-		fmt.Fprintf(out, "Registered mirror %s\n", created.MirrorId)
+		fmt.Fprintf(out, "\nRegistered mirror %s\n", created.MirrorId)
 	} else {
-		fmt.Fprintf(out, "Mirror already exists (%s)\n", created.MirrorId)
+		fmt.Fprintf(out, "\nMirror exists (%s)\n", created.MirrorId)
 	}
 	fmt.Fprintf(out, "  %s\n", created.MirrorUrl)
 

--- a/cmd/entire/cli/repo_mirror_create_wizard.go
+++ b/cmd/entire/cli/repo_mirror_create_wizard.go
@@ -506,7 +506,7 @@ func createOneMirror(ctx context.Context, t mirrorTarget, c *coreapi.Client, cli
 	// Same create-then-wait path as the one-shot `repo mirror create <url>`
 	// (createAndAwaitMirror), so both report identical lifecycle states. The
 	// per-poll status drives this mirror's progress line.
-	outcome, err := createAndAwaitMirror(ctx, c, t.owner, t.repo, t.region.host, noWait, waitTimeout,
+	outcome, err := createAndAwaitMirror(ctx, c, t.owner, t.repo, t.region.host, noWait, waitTimeout, nil,
 		func(s coreapi.MirrorStatus) { report(string(s), false, false) })
 	if outcome.created == nil {
 		res.status, res.err = mirrorStatusError, renderCoreError(err)

--- a/cmd/entire/cli/repo_mirror_test.go
+++ b/cmd/entire/cli/repo_mirror_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
+// mirrorsAPIPath is the control-plane mirrors collection endpoint, shared by the
+// fake servers in these tests.
+const mirrorsAPIPath = "/api/v1/mirrors"
+
 func TestExplainSuspendedMirror(t *testing.T) {
 	t.Parallel()
 	const id = "01KS6KFJR2XS6PZ188MVYE07AN"
@@ -119,6 +123,107 @@ func TestAwaitMirrorReady(t *testing.T) {
 		require.ErrorContains(t, err, "poll mirror status")
 		require.Equal(t, maxConsecutivePollErrors, f.calls, "should stop at the cap, not spin to the deadline")
 	})
+}
+
+// serveMirrorCreate stands up a control plane that answers POST /mirrors with
+// the given CreatedMirror (or a 500 when createErr) and GET /mirrors/{id} with
+// a Ready status, then points createAndAwaitMirror's client at it. It records
+// the ordered request paths so tests can assert create-before-poll sequencing.
+func serveMirrorCreate(t *testing.T, created *coreapi.CreatedMirror, createErr bool) (*coreapi.Client, *[]string) {
+	t.Helper()
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == mirrorsAPIPath:
+			if createErr {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			if err := writeJSON(w, created); err != nil {
+				t.Errorf("encode created response: %v", err)
+			}
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/mirrors/"):
+			m := &coreapi.Mirror{}
+			m.Status = coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)
+			if err := writeJSON(w, m); err != nil {
+				t.Errorf("encode mirror response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := coreapi.NewWithBearer(srv.URL, "tok")
+	require.NoError(t, err)
+	return c, &paths
+}
+
+// TestCreateAndAwaitMirror_OnCreated pins the onCreated callback contract: it
+// delimits the placing vs cloning phases, so it must fire exactly once on
+// CreateMirror success (before any clone polling / onStatus), and never on a
+// CreateMirror error.
+//
+// Not parallel: shortens the package-level mirrorPollInterval.
+func TestCreateAndAwaitMirror_OnCreated(t *testing.T) {
+	prev := mirrorPollInterval
+	mirrorPollInterval = time.Millisecond
+	t.Cleanup(func() { mirrorPollInterval = prev })
+	ctx := t.Context()
+
+	mk := func() *coreapi.CreatedMirror {
+		return &coreapi.CreatedMirror{Created: true, MirrorId: "m1", MirrorUrl: "entire://c/gh/o/r"}
+	}
+
+	t.Run("fires once before onStatus on success", func(t *testing.T) {
+		c, _ := serveMirrorCreate(t, mk(), false)
+		var events []string
+		outcome, err := createAndAwaitMirror(ctx, c, "o", "r", "c", false, time.Second,
+			func(m *coreapi.CreatedMirror) {
+				require.Equal(t, "m1", m.MirrorId, "onCreated receives the create response")
+				events = append(events, "created")
+			},
+			func(coreapi.MirrorStatus) { events = append(events, "status") },
+		)
+		require.NoError(t, err)
+		require.Equal(t, coreapi.MirrorStatusReady, outcome.status)
+		require.NotEmpty(t, events)
+		require.Equal(t, "created", events[0], "onCreated must fire before any onStatus")
+		require.Equal(t, 1, countEq(events, "created"), "onCreated fires exactly once")
+	})
+
+	t.Run("does not fire on CreateMirror error", func(t *testing.T) {
+		c, _ := serveMirrorCreate(t, nil, true)
+		fired := 0
+		outcome, err := createAndAwaitMirror(ctx, c, "o", "r", "c", false, time.Second,
+			func(*coreapi.CreatedMirror) { fired++ }, nil)
+		require.Error(t, err)
+		require.Nil(t, outcome.created)
+		require.Zero(t, fired, "onCreated must not fire when create fails")
+	})
+
+	t.Run("fires once even with no-wait (no polling)", func(t *testing.T) {
+		c, paths := serveMirrorCreate(t, mk(), false)
+		fired := 0
+		_, err := createAndAwaitMirror(ctx, c, "o", "r", "c", true, time.Second,
+			func(*coreapi.CreatedMirror) { fired++ }, nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, fired)
+		require.Equal(t, []string{mirrorsAPIPath}, *paths, "no-wait must not poll GetMirror")
+	})
+}
+
+func countEq(xs []string, want string) int {
+	n := 0
+	for _, x := range xs {
+		if x == want {
+			n++
+		}
+	}
+	return n
 }
 
 // TestReportOneShotMirror exercises the one-shot create's presentation across
@@ -225,7 +330,7 @@ func serveMirrorList(t *testing.T, mirrors []coreapi.Mirror, available []coreapi
 			if err := writeJSON(w, &coreapi.ListAvailableMirrorsOutputBody{Available: available}); err != nil {
 				t.Errorf("encode available response: %v", err)
 			}
-		case "/api/v1/mirrors":
+		case mirrorsAPIPath:
 			if err := writeJSON(w, &coreapi.ListMirrorsOutputBody{Mirrors: mirrors}); err != nil {
 				t.Errorf("encode mirrors response: %v", err)
 			}
@@ -295,7 +400,7 @@ func TestRepoMirrorList_ShowAvailableRouting(t *testing.T) {
 		stdout, stderr := runMirrorList(t)
 		rec := <-recCh
 
-		require.Equal(t, "/api/v1/mirrors", rec.path)
+		require.Equal(t, mirrorsAPIPath, rec.path)
 		require.Contains(t, stderr, "Listing mirrors on")
 		require.Contains(t, stdout, "CLONE URL")
 		require.Contains(t, stdout, "entire://aws-us-east-2.entire.io/gh/acme/web")
@@ -319,7 +424,7 @@ func TestRepoMirrorList_ShowAvailableRouting(t *testing.T) {
 		runMirrorList(t, "--owner", "acme")
 		rec := <-recCh
 
-		require.Equal(t, "/api/v1/mirrors", rec.path)
+		require.Equal(t, mirrorsAPIPath, rec.path)
 		require.Equal(t, "acme", rec.query.Get("owner"))
 	})
 
@@ -329,7 +434,7 @@ func TestRepoMirrorList_ShowAvailableRouting(t *testing.T) {
 		)
 		runMirrorList(t, "--cluster", "eu-west-1.entire.io", "--provider", "github")
 		rec := <-recCh
-		require.Equal(t, "/api/v1/mirrors", rec.path)
+		require.Equal(t, mirrorsAPIPath, rec.path)
 		require.Equal(t, "eu-west-1.entire.io", rec.query.Get("cluster"))
 		require.Equal(t, "github", rec.query.Get("provider"))
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/714
<!-- entire-trail-link-end -->

`entire repo mirror create <url> <cluster>` now shows two distinct steps: a **Placing mirror** spinner for the fast `CreateMirror` call (<15s), then a **Cloning** spinner for the readiness poll. Already-ready mirrors skip the Cloning line entirely and jump straight to clone instructions.

Also: "Mirror exists" (was "already exists"), plus a leading newline before the summary for breathing room.

```
✓ Placing mirror entireio/cli into aws-ap-southeast-2.entire.io
✓ Cloning entireio/cli into aws-ap-southeast-2.entire.io

Mirror exists (01KWEE1WHJ5CRZFM497WNKJPCK)
  entire://aws-ap-southeast-2.entire.io/gh/entireio/cli

Clone it:
  git clone entire://aws-ap-southeast-2.entire.io/gh/entireio/cli
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI UX and callback signature only; no API or auth changes.
> 
> **Overview**
> The non-interactive **`entire repo mirror create <url> [cluster]`** flow now shows **two progress steps** instead of one combined spinner: **Placing mirror** while `CreateMirror` runs, then **Cloning** only when the command will wait on an initial clone (`--no-wait` off and upstream not empty). The shared **`createAndAwaitMirror`** helper gains an optional **`onCreated`** callback that runs right after placement is registered so callers can end the placing phase and start cloning UI before polling begins; mirrors that are already ready can finish polling before the cloning spinner paints, so users may see only the placing checkmark and then the summary.
> 
> The interactive wizard still uses **`onStatus`** for per-mirror lines and passes **`nil`** for **`onCreated`**. Summary text is slightly adjusted (**Mirror exists**, leading newline before registration lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88aa100c3cd74c85cd953df85af81de4532ed89b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->