### PR TITLE
fix(experts): route to the repo's entire-api cell with an identity token

### DIFF
--- a/cmd/entire/cli/api_client.go
+++ b/cmd/entire/cli/api_client.go
@@ -50,8 +50,19 @@ func NewAuthenticatedAPIClient(ctx context.Context, insecureHTTP bool) (*api.Cli
 
 // NewAuthenticatedEntireAPICellClient creates an API client for repo-scoped
 // entire-api routes (e.g. experts). It exchanges the login JWT for a
-// jurisdictional identity token and dials the home entire-api cell directly
-// when the configured data host is the entire.io BFF (COR-666).
-func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool) (*api.Client, error) {
-	return auth.NewEntireAPICellClient(ctx, insecureHTTP)
+// jurisdictional identity token and dials the entire-api cell directly, because
+// the BFF does not proxy these routes for bearer callers (COR-666).
+//
+// fullName (owner/repo) and/or ulid identify the repo whose cell to reach. When
+// either is supplied, the repo's OWNING cell + jurisdiction are resolved from
+// the control plane (mirroring the BFF's per-repo cell selection) so the call
+// lands in the region that hosts the repo. Resolution is best-effort: any
+// failure yields a nil target and NewEntireAPICellClient falls back to
+// home-jurisdiction routing, so the common same-region case never regresses.
+func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool, fullName, ulid string) (*api.Client, error) {
+	target := resolveExpertsCellTarget(ctx, fullName, ulid)
+	// NewEntireAPICellClient already returns user-facing, context-rich errors
+	// (login hint, discovery-unavailable, region guidance); re-wrapping here
+	// would bury them, so surface them verbatim.
+	return auth.NewEntireAPICellClient(ctx, insecureHTTP, target) //nolint:wrapcheck // pass through contextual auth errors
 }

--- a/cmd/entire/cli/api_client.go
+++ b/cmd/entire/cli/api_client.go
@@ -47,3 +47,11 @@ func NewAuthenticatedAPIClient(ctx context.Context, insecureHTTP bool) (*api.Cli
 
 	return api.NewClient(token), nil
 }
+
+// NewAuthenticatedEntireAPICellClient creates an API client for repo-scoped
+// entire-api routes (e.g. experts). It exchanges the login JWT for a
+// jurisdictional identity token and dials the home entire-api cell directly
+// when the configured data host is the entire.io BFF (COR-666).
+func NewAuthenticatedEntireAPICellClient(ctx context.Context, insecureHTTP bool) (*api.Client, error) {
+	return auth.NewEntireAPICellClient(ctx, insecureHTTP)
+}

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -22,11 +23,31 @@ import (
 const (
 	cellDataAPITimeout = 30 * time.Second
 
-	defaultJurisdictionAudienceTemplate = "https://{jurisdiction}.entire.io"
-	defaultCoreBaseURLTemplate          = "https://{jurisdiction}.auth.entire.io"
-
 	jurisdictionIdentityScope = "openid"
 )
+
+// jurisdictionLabelPattern bounds a home_jurisdiction claim to a single DNS
+// label before it is substituted into a URL template. The claim rides on the
+// login JWT (which we decode without verifying the signature) and, for the
+// home-jurisdiction fallback path, is attacker-influenceable if a token is ever
+// mis-minted; constraining it to [a-z0-9-] means it can only ever name a
+// sibling jurisdiction, never inject host/scheme syntax (e.g.
+// "us.auth.evil.tld") into jurisdictionAudience / jurisdictionCoreURL.
+var jurisdictionLabelPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$`)
+
+// CellTarget pins the entire-api cell a repo-scoped call must reach and the
+// jurisdiction its identity token must be minted for. The cli layer resolves it
+// from the repo's own cluster (via coreapi mirrors/clusters), so a repo-scoped
+// route reaches the cell that HOSTS the repo — not the caller's home cell. A nil
+// target falls back to home-jurisdiction routing (derived from the login JWT),
+// which is correct for the common same-region case and for local dev.
+type CellTarget struct {
+	// BaseURL is the cell's apiUrl to dial (e.g. https://aws-eu-west-1.api.entire.io).
+	BaseURL string
+	// Jurisdiction is the repo's cluster jurisdiction; it drives the identity
+	// token's audience and the core the exchange is performed at.
+	Jurisdiction string
+}
 
 // resolveContextForCellAPI is the discovery seam for cell routing, swapped in
 // tests. Mirrors resolveContextForAPI.
@@ -44,15 +65,31 @@ func SetResolveContextForCellAPIForTest(t interface{ Helper() }, fn resolveConte
 // jurisdiction token exchange and cluster listing. Production leaves it nil.
 var cellExchangeTransportForTest http.RoundTripper
 
-// NewEntireAPICellClient returns an authenticated client aimed at the caller's
-// home-jurisdiction entire-api cell with a jurisdictional identity token
-// (scope=openid, aud=jurisdiction host). This is the COR-666 CLI-side routing
-// path: repo-scoped entire-api reads do not accept the narrowed api-access
-// bearer minted for https://entire.io — they require a cell identity token.
+// SetCellExchangeTransportForTest overrides the transport used for jurisdiction
+// token exchange and cluster listing, returning a restore closure — the same
+// set/restore convention the rest of the package uses for test seams.
+func SetCellExchangeTransportForTest(t interface{ Helper() }, rt http.RoundTripper) func() {
+	t.Helper()
+	prev := cellExchangeTransportForTest
+	cellExchangeTransportForTest = rt
+	return func() { cellExchangeTransportForTest = prev }
+}
+
+// NewEntireAPICellClient returns an authenticated client aimed at an entire-api
+// cell, carrying a jurisdictional identity token (scope=openid, aud=jurisdiction
+// host). Repo-scoped entire-api routes do not accept the narrowed api-access
+// bearer minted for the BFF origin — they require a cell identity token
+// (COR-666).
 //
-// When ENTIRE_API_BASE_URL already targets a cell (not the entire.io BFF), the
-// configured origin is kept and only the token exchange is performed.
-func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool) (*api.Client, error) {
+// Cell selection, in precedence order:
+//   - target != nil: dial target.BaseURL and mint for target.Jurisdiction. This
+//     is the repo-scoped path — the caller (cli) resolved the repo's own cell.
+//   - the configured data host already targets a cell (host contains ".api."):
+//     keep that origin.
+//   - a loopback data host (local dev): keep that origin.
+//   - otherwise the data host is a BFF/apex: resolve the caller's home-cell
+//     apiUrl from the cluster catalog (home-jurisdiction fallback).
+func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *CellTarget) (*api.Client, error) {
 	dataURL := api.BaseURL()
 	if insecureHTTP {
 		EnableInsecureHTTP()
@@ -69,12 +106,13 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool) (*api.Client
 	dctx, cancel := context.WithTimeout(ctx, dataAPIDiscoveryTimeout)
 	defer cancel()
 	var httpClient *http.Client
-	if cellExchangeTransportForTest != nil {
+	switch {
+	case cellExchangeTransportForTest != nil:
 		httpClient = &http.Client{Timeout: cellDataAPITimeout, Transport: cellExchangeTransportForTest}
-	} else if shouldUsePlainHTTPDiscovery(dataOrigin) {
+	case shouldUsePlainHTTPDiscovery(dataOrigin):
 		httpClient = dataAPIDiscoveryClient(dataOrigin)
 		httpClient.Timeout = cellDataAPITimeout
-	} else {
+	default:
 		httpClient = &http.Client{Timeout: cellDataAPITimeout}
 	}
 
@@ -100,24 +138,26 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool) (*api.Client
 		return nil, fmt.Errorf("refresh login token: %w", err)
 	}
 
-	jurisdiction, err := homeJurisdictionFromLoginJWT(loginJWT)
+	jurisdiction, err := targetJurisdiction(target, loginJWT)
 	if err != nil {
 		return nil, err
 	}
-	if jurisdiction == "" {
-		return nil, errors.New("login token has no home_jurisdiction claim; cannot route to entire-api cell")
+
+	coreURL := jurisdictionCoreURL(jurisdiction, dataOrigin, selected.CoreURL)
+	if err := requireSafeExchangeURL("entire-core", coreURL); err != nil {
+		return nil, err
 	}
 
-	cellBaseURL := strings.TrimRight(dataOrigin, "/")
-	if isEntireIOBFF(dataOrigin) {
-		cellBaseURL, err = resolveCellAPIBaseURL(ctx, jurisdictionCoreURL(jurisdiction, selected.CoreURL), loginJWT, jurisdiction, httpClient)
-		if err != nil {
-			return nil, err
-		}
+	cellBaseURL, err := resolveTargetCellBaseURL(ctx, target, dataOrigin, jurisdiction, coreURL, loginJWT, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireSafeExchangeURL("entire-api cell", cellBaseURL); err != nil {
+		return nil, err
 	}
 
-	audience := jurisdictionAudience(jurisdiction)
-	token, err := exchangeJurisdictionToken(ctx, jurisdictionCoreURL(jurisdiction, selected.CoreURL), loginJWT, audience, httpClient)
+	audience := jurisdictionAudience(jurisdiction, dataOrigin, selected.CoreURL)
+	token, err := exchangeJurisdictionToken(ctx, coreURL, loginJWT, audience, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("exchange jurisdictional identity token: %w", err)
 	}
@@ -125,35 +165,162 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool) (*api.Client
 	return api.NewClientWithBaseURL(token, cellBaseURL), nil
 }
 
-func isEntireIOBFF(origin string) bool {
+// targetJurisdiction picks the jurisdiction to mint for: the explicit repo
+// target when present, otherwise the caller's home jurisdiction from the login
+// JWT. The result is validated as a DNS label before it is templated into URLs.
+func targetJurisdiction(target *CellTarget, loginJWT string) (string, error) {
+	jurisdiction := ""
+	if target != nil {
+		jurisdiction = strings.TrimSpace(target.Jurisdiction)
+	}
+	if jurisdiction == "" {
+		var err error
+		jurisdiction, err = homeJurisdictionFromLoginJWT(loginJWT)
+		if err != nil {
+			return "", err
+		}
+	}
+	if jurisdiction == "" {
+		return "", errors.New("login token has no home_jurisdiction claim; cannot route to entire-api cell")
+	}
+	if !jurisdictionLabelPattern.MatchString(jurisdiction) {
+		return "", fmt.Errorf("jurisdiction %q is not a valid label; refusing to route", jurisdiction)
+	}
+	return jurisdiction, nil
+}
+
+// resolveTargetCellBaseURL decides which cell origin to dial. See
+// NewEntireAPICellClient's precedence doc.
+func resolveTargetCellBaseURL(ctx context.Context, target *CellTarget, dataOrigin, jurisdiction, coreURL, loginJWT string, httpClient *http.Client) (string, error) {
+	if target != nil && strings.TrimSpace(target.BaseURL) != "" {
+		return strings.TrimRight(target.BaseURL, "/"), nil
+	}
+	if !isBFFOrigin(dataOrigin) {
+		// Already a cell URL, or a loopback local-dev host: keep it verbatim.
+		return strings.TrimRight(dataOrigin, "/"), nil
+	}
+	return resolveCellAPIBaseURL(ctx, coreURL, loginJWT, jurisdiction, httpClient)
+}
+
+// isBFFOrigin reports whether origin is a BFF / apex host that fronts multiple
+// cells (so the actual cell must be resolved from the cluster catalog), as
+// opposed to a direct entire-api cell (host contains ".api.") or a loopback
+// local-dev host (kept verbatim). This is environment-agnostic: it recognises
+// prod (entire.io), staging (partial.to) and any future apex without a
+// hardcoded domain list.
+func isBFFOrigin(origin string) bool {
 	u, err := url.Parse(origin)
 	if err != nil || u.Host == "" {
 		return false
 	}
 	host := strings.ToLower(u.Hostname())
-	if strings.Contains(host, ".api.") {
+	if host == "" || isLoopbackHost(host) {
 		return false
 	}
-	return host == "entire.io" || strings.HasSuffix(host, ".entire.io")
+	// A direct cell advertises itself under an ".api." label; anything else that
+	// isn't loopback is treated as a BFF/apex needing cell resolution.
+	return !strings.Contains(host, ".api.")
 }
 
-func jurisdictionAudience(jurisdiction string) string {
-	tmpl := strings.TrimSpace(os.Getenv("ENTIRE_API_AUDIENCE_TEMPLATE"))
-	if tmpl == "" {
-		tmpl = defaultJurisdictionAudienceTemplate
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
 	}
+	return false
+}
+
+// entireDomainFamily returns the registrable apex ("entire.io" / "partial.to")
+// derived from the discovered login core's host, or "" for loopback/custom
+// cores. It lets the audience/core templates follow the environment the user is
+// actually logged into (prod vs staging) instead of a hardcoded prod default.
+func entireDomainFamily(coreURL string) string {
+	u, err := url.Parse(coreURL)
+	if err != nil {
+		return ""
+	}
+	host := strings.ToLower(u.Hostname())
+	switch {
+	case host == "partial.to" || strings.HasSuffix(host, ".partial.to"):
+		return "partial.to"
+	case host == "entire.io" || strings.HasSuffix(host, ".entire.io"):
+		return "entire.io"
+	default:
+		return ""
+	}
+}
+
+// environmentFamily picks the registrable apex to template jurisdiction URLs
+// against. The configured data host (what the user pointed the CLI at) is the
+// most reliable signal for prod-vs-staging, so it wins; the discovered login
+// core is the fallback.
+func environmentFamily(dataOrigin, discoveredCore string) string {
+	if fam := entireDomainFamily(dataOrigin); fam != "" {
+		return fam
+	}
+	return entireDomainFamily(discoveredCore)
+}
+
+// jurisdictionAudience returns the aud the entire-api cell for `jurisdiction`
+// pins its identity tokens to (its jurisdiction host). Precedence:
+//   - ENTIRE_API_AUDIENCE_TEMPLATE (with {jurisdiction}) if set;
+//   - else https://{jurisdiction}.<family> for the environment family;
+//   - else (loopback/custom) the data origin, best-effort and overridable.
+//
+// This mirrors the BFF's buildAudience(template, jurisdiction) (repos-stream.ts).
+func jurisdictionAudience(jurisdiction, dataOrigin, discoveredCore string) string {
+	if tmpl := strings.TrimSpace(os.Getenv("ENTIRE_API_AUDIENCE_TEMPLATE")); tmpl != "" {
+		return applyJurisdictionTemplate(tmpl, jurisdiction)
+	}
+	if fam := environmentFamily(dataOrigin, discoveredCore); fam != "" {
+		return "https://" + jurisdiction + "." + fam
+	}
+	return strings.TrimRight(dataOrigin, "/")
+}
+
+// jurisdictionCoreURL returns the entire-core origin the identity-token exchange
+// is performed at for `jurisdiction`. Precedence:
+//   - a loopback discovered core (local dev): honour it verbatim — the local
+//     core signs the local login JWT, and the prod template would send the
+//     exchange to production, which rejects the local token;
+//   - ENTIRE_CORE_BASE_URL_TEMPLATE (with {jurisdiction}) if set;
+//   - else https://{jurisdiction}.auth.<family> for the environment family;
+//   - else the discovered core verbatim.
+//
+// This mirrors the BFF's buildCoreBaseUrl(template, jurisdiction, fallback),
+// which honours a fallback core when the template can't produce one.
+func jurisdictionCoreURL(jurisdiction, dataOrigin, discoveredCore string) string {
+	if isLoopbackHTTP(discoveredCore) {
+		return strings.TrimRight(discoveredCore, "/")
+	}
+	if tmpl := strings.TrimSpace(os.Getenv("ENTIRE_CORE_BASE_URL_TEMPLATE")); tmpl != "" {
+		if strings.Contains(tmpl, "{jurisdiction}") {
+			return applyJurisdictionTemplate(tmpl, jurisdiction)
+		}
+		return strings.TrimRight(discoveredCore, "/")
+	}
+	if fam := environmentFamily(dataOrigin, discoveredCore); fam != "" {
+		return "https://" + jurisdiction + ".auth." + fam
+	}
+	return strings.TrimRight(discoveredCore, "/")
+}
+
+func applyJurisdictionTemplate(tmpl, jurisdiction string) string {
 	return strings.ReplaceAll(strings.TrimRight(tmpl, "/"), "{jurisdiction}", jurisdiction)
 }
 
-func jurisdictionCoreURL(homeJurisdiction, fallbackCore string) string {
-	tmpl := strings.TrimSpace(os.Getenv("ENTIRE_CORE_BASE_URL_TEMPLATE"))
-	if tmpl == "" {
-		tmpl = defaultCoreBaseURLTemplate
+// requireSafeExchangeURL rejects a target the login JWT / identity token would
+// be sent to unless it is https (or an explicitly-allowed loopback/insecure
+// http). Mirrors the tokenmanager guard the sibling data_api.go relies on, so a
+// buggy core catalog can't downgrade the login JWT onto plaintext.
+func requireSafeExchangeURL(label, raw string) error {
+	if insecureHTTPEnabled() || isLoopbackHTTP(raw) {
+		return nil
 	}
-	if strings.Contains(tmpl, "{jurisdiction}") {
-		return strings.ReplaceAll(strings.TrimRight(tmpl, "/"), "{jurisdiction}", homeJurisdiction)
+	if err := api.RequireSecureURL(raw); err != nil {
+		return fmt.Errorf("%s URL check: %w", label, err)
 	}
-	return strings.TrimRight(fallbackCore, "/")
+	return nil
 }
 
 func homeJurisdictionFromLoginJWT(loginJWT string) (string, error) {
@@ -180,6 +347,12 @@ type clusterListingRow struct {
 	APIURL       string `json:"apiUrl"`
 }
 
+// resolveCellAPIBaseURL is the home-jurisdiction fallback cell resolver: it
+// lists the caller's clusters and picks the apiUrl for `jurisdiction` (default
+// cluster first). It hand-parses GET /api/v1/clusters rather than reusing the
+// generated coreapi.ListClusters() because coreapi imports this (auth) package,
+// so auth cannot import coreapi without a cycle — the repo-scoped path avoids
+// this by resolving the cell in the cli layer (see resolveExpertsCellTarget).
 func resolveCellAPIBaseURL(ctx context.Context, coreURL, loginJWT, jurisdiction string, httpClient *http.Client) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(coreURL, "/")+"/api/v1/clusters", nil)
 	if err != nil {
@@ -194,7 +367,7 @@ func resolveCellAPIBaseURL(ctx context.Context, coreURL, loginJWT, jurisdiction 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096)) //nolint:errcheck // best-effort error-detail snippet
 		return "", fmt.Errorf("list clusters: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
@@ -206,13 +379,23 @@ func resolveCellAPIBaseURL(ctx context.Context, coreURL, loginJWT, jurisdiction 
 	}
 
 	var matches []clusterListingRow
+	sawJurisdiction := false
 	for _, row := range listing.Clusters {
-		if row.Jurisdiction == jurisdiction && strings.TrimSpace(row.APIURL) != "" {
+		if row.Jurisdiction != jurisdiction {
+			continue
+		}
+		sawJurisdiction = true
+		if strings.TrimSpace(row.APIURL) != "" {
 			matches = append(matches, row)
 		}
 	}
 	if len(matches) == 0 {
-		return "", fmt.Errorf("no entire-api cell configured for home jurisdiction %q", jurisdiction)
+		if sawJurisdiction {
+			// A cluster row exists for the jurisdiction but carries no apiUrl —
+			// a schema/deploy problem, distinct from "no cell for jurisdiction".
+			return "", fmt.Errorf("cluster for jurisdiction %q advertises no apiUrl (entire-api cell not configured?)", jurisdiction)
+		}
+		return "", fmt.Errorf("no entire-api cell configured for jurisdiction %q", jurisdiction)
 	}
 	chosen := matches[0]
 	for _, row := range matches {
@@ -239,7 +422,10 @@ func exchangeJurisdictionToken(ctx context.Context, coreURL, loginJWT, audience 
 
 	token, _, err := httputil.PostOAuthToken(ctx, httpClient, coreURL, form)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("post token exchange: %w", err)
+	}
+	if strings.TrimSpace(token) == "" {
+		return "", errors.New("token exchange returned an empty access token")
 	}
 	return token, nil
 }

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -127,7 +127,11 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *Cell
 		return nil, err
 	}
 
-	allowInsecure := insecureHTTPEnabled() || isLoopbackHTTP(selected.CoreURL) || isLoopbackHTTP(dataOrigin)
+	// Gate the login provider's HTTPS relaxation on the core it actually dials
+	// (selected.CoreURL) plus the explicit --insecure-http-auth opt-in, matching
+	// the sibling ResolveDataAPIToken. A loopback data API must not relax HTTPS
+	// for a non-loopback core.
+	allowInsecure := insecureHTTPEnabled() || isLoopbackHTTP(selected.CoreURL)
 	loginProvider, err := NewRefreshingLoginProvider(selected, cellExchangeTransportForTest, allowInsecure)
 	if err != nil {
 		return nil, err
@@ -138,7 +142,9 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *Cell
 		if errors.Is(err, ErrNotLoggedIn) {
 			return nil, fmt.Errorf("not logged in (run 'entire login' first): %w", err)
 		}
-		return nil, fmt.Errorf("refresh login token: %w", err)
+		// The provider already prefixes "refresh login token:"; return as-is to
+		// avoid a doubled prefix.
+		return nil, err
 	}
 
 	jurisdiction, err := targetJurisdiction(target, loginJWT)

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -24,6 +24,9 @@ const (
 	cellDataAPITimeout = 30 * time.Second
 
 	jurisdictionIdentityScope = "openid"
+
+	// clustersAPIPath is entire-core's cluster catalog endpoint.
+	clustersAPIPath = "/api/v1/clusters"
 )
 
 // jurisdictionLabelPattern bounds a home_jurisdiction claim to a single DNS
@@ -294,10 +297,11 @@ func jurisdictionCoreURL(jurisdiction, dataOrigin, discoveredCore string) string
 		return strings.TrimRight(discoveredCore, "/")
 	}
 	if tmpl := strings.TrimSpace(os.Getenv("ENTIRE_CORE_BASE_URL_TEMPLATE")); tmpl != "" {
-		if strings.Contains(tmpl, "{jurisdiction}") {
-			return applyJurisdictionTemplate(tmpl, jurisdiction)
-		}
-		return strings.TrimRight(discoveredCore, "/")
+		// Apply unconditionally: applyJurisdictionTemplate is a no-op when the
+		// template has no {jurisdiction}, yielding the fixed core verbatim — the
+		// single-core case, matching the BFF's buildCoreBaseUrl and this file's
+		// own audience handling.
+		return applyJurisdictionTemplate(tmpl, jurisdiction)
 	}
 	if fam := environmentFamily(dataOrigin, discoveredCore); fam != "" {
 		return "https://" + jurisdiction + ".auth." + fam
@@ -311,14 +315,20 @@ func applyJurisdictionTemplate(tmpl, jurisdiction string) string {
 
 // requireSafeExchangeURL rejects a target the login JWT / identity token would
 // be sent to unless it is https (or an explicitly-allowed loopback/insecure
-// http). Mirrors the tokenmanager guard the sibling data_api.go relies on, so a
-// buggy core catalog can't downgrade the login JWT onto plaintext.
+// http). It affirmatively requires the https scheme — not merely "not http" —
+// so ftp/ws/scheme-relative/empty targets from a buggy core catalog can't
+// smuggle the login JWT off https. Mirrors the tokenmanager guard the sibling
+// data_api.go relies on.
 func requireSafeExchangeURL(label, raw string) error {
 	if insecureHTTPEnabled() || isLoopbackHTTP(raw) {
 		return nil
 	}
-	if err := api.RequireSecureURL(raw); err != nil {
-		return fmt.Errorf("%s URL check: %w", label, err)
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s URL check: parse %q: %w", label, raw, err)
+	}
+	if u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("%s URL %q must be https", label, raw)
 	}
 	return nil
 }
@@ -354,7 +364,7 @@ type clusterListingRow struct {
 // so auth cannot import coreapi without a cycle — the repo-scoped path avoids
 // this by resolving the cell in the cli layer (see resolveExpertsCellTarget).
 func resolveCellAPIBaseURL(ctx context.Context, coreURL, loginJWT, jurisdiction string, httpClient *http.Client) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(coreURL, "/")+"/api/v1/clusters", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(coreURL, "/")+clustersAPIPath, nil)
 	if err != nil {
 		return "", fmt.Errorf("build clusters request: %w", err)
 	}

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -1,0 +1,245 @@
+package auth
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
+	"github.com/entireio/cli/internal/entireclient/httputil"
+	"github.com/entireio/cli/internal/entireclient/userdirs"
+)
+
+const (
+	cellDataAPITimeout = 30 * time.Second
+
+	defaultJurisdictionAudienceTemplate = "https://{jurisdiction}.entire.io"
+	defaultCoreBaseURLTemplate          = "https://{jurisdiction}.auth.entire.io"
+
+	jurisdictionIdentityScope = "openid"
+)
+
+// resolveContextForCellAPI is the discovery seam for cell routing, swapped in
+// tests. Mirrors resolveContextForAPI.
+var resolveContextForCellAPI resolveContextFunc = clusterdiscovery.ResolveContextForAPI
+
+// SetResolveContextForCellAPIForTest overrides the cell-API discovery seam.
+func SetResolveContextForCellAPIForTest(t interface{ Helper() }, fn resolveContextFunc) func() {
+	t.Helper()
+	prev := resolveContextForCellAPI
+	resolveContextForCellAPI = fn
+	return func() { resolveContextForCellAPI = prev }
+}
+
+// cellExchangeTransportForTest, when non-nil, is the HTTP transport used for
+// jurisdiction token exchange and cluster listing. Production leaves it nil.
+var cellExchangeTransportForTest http.RoundTripper
+
+// NewEntireAPICellClient returns an authenticated client aimed at the caller's
+// home-jurisdiction entire-api cell with a jurisdictional identity token
+// (scope=openid, aud=jurisdiction host). This is the COR-666 CLI-side routing
+// path: repo-scoped entire-api reads do not accept the narrowed api-access
+// bearer minted for https://entire.io — they require a cell identity token.
+//
+// When ENTIRE_API_BASE_URL already targets a cell (not the entire.io BFF), the
+// configured origin is kept and only the token exchange is performed.
+func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool) (*api.Client, error) {
+	dataURL := api.BaseURL()
+	if insecureHTTP {
+		EnableInsecureHTTP()
+	} else if err := api.RequireSecureURL(dataURL); err != nil {
+		return nil, fmt.Errorf("base URL check: %w", err)
+	}
+
+	dataOrigin := api.OriginOnly(dataURL)
+	host, ok := hostOf(dataOrigin)
+	if !ok {
+		return nil, fmt.Errorf("data API URL %q has no host to discover against", dataURL)
+	}
+
+	dctx, cancel := context.WithTimeout(ctx, dataAPIDiscoveryTimeout)
+	defer cancel()
+	var httpClient *http.Client
+	if cellExchangeTransportForTest != nil {
+		httpClient = &http.Client{Timeout: cellDataAPITimeout, Transport: cellExchangeTransportForTest}
+	} else if shouldUsePlainHTTPDiscovery(dataOrigin) {
+		httpClient = dataAPIDiscoveryClient(dataOrigin)
+		httpClient.Timeout = cellDataAPITimeout
+	} else {
+		httpClient = &http.Client{Timeout: cellDataAPITimeout}
+	}
+
+	selected, err := resolveContextForCellAPI(dctx, userdirs.Config(), userdirs.Cache(), host, httpClient, nil)
+	if errors.Is(err, clusterdiscovery.ErrDiscoveryUnavailable) {
+		return nil, fmt.Errorf("%s does not advertise its trusted login servers (/.well-known/entire-api.json missing or unreachable); cannot authenticate: %w", host, err)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	allowInsecure := insecureHTTPEnabled() || isLoopbackHTTP(selected.CoreURL) || isLoopbackHTTP(dataOrigin)
+	loginProvider, err := NewRefreshingLoginProvider(selected, cellExchangeTransportForTest, allowInsecure)
+	if err != nil {
+		return nil, err
+	}
+
+	loginJWT, err := loginProvider(ctx)
+	if err != nil {
+		if errors.Is(err, ErrNotLoggedIn) {
+			return nil, fmt.Errorf("not logged in (run 'entire login' first): %w", err)
+		}
+		return nil, fmt.Errorf("refresh login token: %w", err)
+	}
+
+	jurisdiction, err := homeJurisdictionFromLoginJWT(loginJWT)
+	if err != nil {
+		return nil, err
+	}
+	if jurisdiction == "" {
+		return nil, errors.New("login token has no home_jurisdiction claim; cannot route to entire-api cell")
+	}
+
+	cellBaseURL := strings.TrimRight(dataOrigin, "/")
+	if isEntireIOBFF(dataOrigin) {
+		cellBaseURL, err = resolveCellAPIBaseURL(ctx, jurisdictionCoreURL(jurisdiction, selected.CoreURL), loginJWT, jurisdiction, httpClient)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	audience := jurisdictionAudience(jurisdiction)
+	token, err := exchangeJurisdictionToken(ctx, jurisdictionCoreURL(jurisdiction, selected.CoreURL), loginJWT, audience, httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("exchange jurisdictional identity token: %w", err)
+	}
+
+	return api.NewClientWithBaseURL(token, cellBaseURL), nil
+}
+
+func isEntireIOBFF(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if strings.Contains(host, ".api.") {
+		return false
+	}
+	return host == "entire.io" || strings.HasSuffix(host, ".entire.io")
+}
+
+func jurisdictionAudience(jurisdiction string) string {
+	tmpl := strings.TrimSpace(os.Getenv("ENTIRE_API_AUDIENCE_TEMPLATE"))
+	if tmpl == "" {
+		tmpl = defaultJurisdictionAudienceTemplate
+	}
+	return strings.ReplaceAll(strings.TrimRight(tmpl, "/"), "{jurisdiction}", jurisdiction)
+}
+
+func jurisdictionCoreURL(homeJurisdiction, fallbackCore string) string {
+	tmpl := strings.TrimSpace(os.Getenv("ENTIRE_CORE_BASE_URL_TEMPLATE"))
+	if tmpl == "" {
+		tmpl = defaultCoreBaseURLTemplate
+	}
+	if strings.Contains(tmpl, "{jurisdiction}") {
+		return strings.ReplaceAll(strings.TrimRight(tmpl, "/"), "{jurisdiction}", homeJurisdiction)
+	}
+	return strings.TrimRight(fallbackCore, "/")
+}
+
+func homeJurisdictionFromLoginJWT(loginJWT string) (string, error) {
+	parts := strings.Split(loginJWT, ".")
+	if len(parts) < 2 {
+		return "", errors.New("login token is not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode login token payload: %w", err)
+	}
+	var claims struct {
+		HomeJurisdiction string `json:"home_jurisdiction"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parse login token payload: %w", err)
+	}
+	return claims.HomeJurisdiction, nil
+}
+
+type clusterListingRow struct {
+	Jurisdiction string `json:"jurisdiction"`
+	IsDefault    bool   `json:"isDefault"`
+	APIURL       string `json:"apiUrl"`
+}
+
+func resolveCellAPIBaseURL(ctx context.Context, coreURL, loginJWT, jurisdiction string, httpClient *http.Client) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(coreURL, "/")+"/api/v1/clusters", nil)
+	if err != nil {
+		return "", fmt.Errorf("build clusters request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+loginJWT)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("list clusters: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return "", fmt.Errorf("list clusters: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var listing struct {
+		Clusters []clusterListingRow `json:"clusters"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
+		return "", fmt.Errorf("decode clusters response: %w", err)
+	}
+
+	var matches []clusterListingRow
+	for _, row := range listing.Clusters {
+		if row.Jurisdiction == jurisdiction && strings.TrimSpace(row.APIURL) != "" {
+			matches = append(matches, row)
+		}
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no entire-api cell configured for home jurisdiction %q", jurisdiction)
+	}
+	chosen := matches[0]
+	for _, row := range matches {
+		if row.IsDefault {
+			chosen = row
+			break
+		}
+	}
+	return strings.TrimRight(chosen.APIURL, "/"), nil
+}
+
+func exchangeJurisdictionToken(ctx context.Context, coreURL, loginJWT, audience string, httpClient *http.Client) (string, error) {
+	if coreURL == "" {
+		return "", errors.New("no entire-core URL configured for jurisdiction token exchange")
+	}
+	form := url.Values{}
+	form.Set("grant_type", httputil.GrantTypeTokenExchange)
+	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	form.Set("subject_token", loginJWT)
+	form.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	form.Set("audience", audience)
+	form.Set("scope", jurisdictionIdentityScope)
+	form.Set("client_id", oauthClientID)
+
+	token, _, err := httputil.PostOAuthToken(ctx, httpClient, coreURL, form)
+	if err != nil {
+		return "", err
+	}
+	return token, nil
+}

--- a/cmd/entire/cli/auth/cell_data_api_test.go
+++ b/cmd/entire/cli/auth/cell_data_api_test.go
@@ -94,6 +94,62 @@ func TestJurisdictionCoreURLHonorsLoopbackAndFamily(t *testing.T) {
 	if got := jurisdictionCoreURL("eu", "https://partial.to", "https://us.auth.partial.to"); got != "https://eu.auth.partial.to" {
 		t.Errorf("staging core = %q, want https://eu.auth.partial.to", got)
 	}
+	// Prod: mirrors the audience test's prod/staging pair.
+	if got := jurisdictionCoreURL("eu", "https://entire.io", "https://us.auth.entire.io"); got != "https://eu.auth.entire.io" {
+		t.Errorf("prod core = %q, want https://eu.auth.entire.io", got)
+	}
+}
+
+func TestJurisdictionCoreURLHonorsFixedTemplate(t *testing.T) {
+	// A placeholder-less template names a single core for every jurisdiction
+	// (single-core deployments), matching the BFF and the audience handler.
+	t.Setenv("ENTIRE_CORE_BASE_URL_TEMPLATE", "https://single-core.example")
+	if got := jurisdictionCoreURL("eu", "https://entire.io", "https://us.auth.entire.io"); got != "https://single-core.example" {
+		t.Errorf("fixed-template core = %q, want https://single-core.example", got)
+	}
+	// A loopback discovered core still wins over any template (local dev).
+	if got := jurisdictionCoreURL("eu", "https://entire.io", "http://127.0.0.1:9000"); got != "http://127.0.0.1:9000" {
+		t.Errorf("loopback core = %q, want http://127.0.0.1:9000", got)
+	}
+}
+
+func TestRequireSafeExchangeURL(t *testing.T) {
+	// Exercises the plaintext-downgrade guard. Reset the process-global insecure
+	// override (no public setter) so the assertion is order-independent.
+	prev := insecureHTTPOverride.Load()
+	insecureHTTPOverride.Store(false)
+	t.Cleanup(func() { insecureHTTPOverride.Store(prev) })
+
+	tests := []struct {
+		raw     string
+		wantErr bool
+	}{
+		{"https://us.entire.io", false},
+		{"https://aws-eu-west-1.api.entire.io", false},
+		{"http://127.0.0.1:9000", false}, // loopback allowed
+		{"http://localhost:8787", false}, // loopback allowed
+		{"http://evil.example.com", true},
+		{"ftp://evil.example.com", true},  // non-https, non-loopback
+		{"ws://evil.example.com", true},   // scheme-relative-ish
+		{"//evil.example.com/path", true}, // no scheme
+		{"", true},                        // empty
+		{"https://", true},                // no host
+	}
+	for _, tc := range tests {
+		err := requireSafeExchangeURL("test", tc.raw)
+		if tc.wantErr && err == nil {
+			t.Errorf("requireSafeExchangeURL(%q) = nil, want error", tc.raw)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("requireSafeExchangeURL(%q) = %v, want nil", tc.raw, err)
+		}
+	}
+
+	// With the insecure override on, a plain-http non-loopback host is allowed.
+	insecureHTTPOverride.Store(true)
+	if err := requireSafeExchangeURL("test", "http://dev.example.com"); err != nil {
+		t.Errorf("with insecure override: got %v, want nil", err)
+	}
 }
 
 func TestTargetJurisdictionRejectsBadLabel(t *testing.T) {
@@ -124,7 +180,7 @@ func TestNewEntireAPICellClient_RoutesThroughHomeCell(t *testing.T) {
 	var gotExchangeAudience, gotReposHost string
 	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/v1/clusters":
+		case clustersAPIPath:
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck // test handler
 				"clusters": []map[string]any{{
@@ -195,13 +251,19 @@ func TestNewEntireAPICellClient_KeepsDirectCellBaseURL(t *testing.T) {
 	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
 	t.Cleanup(restore)
 
+	var exchangeHit, clustersHit bool
 	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != oauthTokenPath {
+		switch r.URL.Path {
+		case oauthTokenPath:
+			exchangeHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"access_token":"cell-identity-token","token_type":"Bearer","expires_in":3600}`)
+		case clustersAPIPath:
+			clustersHit = true
 			http.NotFound(w, r)
-			return
+		default:
+			http.NotFound(w, r)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"access_token":"cell-identity-token","token_type":"Bearer","expires_in":3600}`)
 	}))
 	defer coreSrv.Close()
 
@@ -226,12 +288,33 @@ func TestNewEntireAPICellClient_KeepsDirectCellBaseURL(t *testing.T) {
 	if client == nil {
 		t.Fatal("client is nil")
 	}
+	// A direct cell origin must NOT trigger cluster resolution, but the identity
+	// token must still be minted.
+	if clustersHit {
+		t.Error("direct cell URL should not resolve clusters")
+	}
+	if !exchangeHit {
+		t.Error("identity token exchange did not happen for a direct cell URL")
+	}
+	if !strings.HasSuffix(api.OriginOnly(cellBase), ".api.entire.io") {
+		t.Fatalf("test precondition: %q is not a direct cell URL", cellBase)
+	}
+}
 
-	// api.Client doesn't expose baseURL; verify via a stub round trip by calling
-	// ResolveURLFromBase indirectly through Get — use httptest on cell path instead.
-	gotBase := api.OriginOnly(cellBase)
-	if !strings.HasSuffix(gotBase, ".api.entire.io") {
-		t.Fatalf("unexpected cell base %q", gotBase)
+func TestResolveTargetCellBaseURL(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	// A direct cell origin (host with .api.) is kept verbatim, no resolution.
+	if got, err := resolveTargetCellBaseURL(ctx, nil, "https://aws-us-east-2.api.entire.io", "us", "https://us.auth.entire.io", "login", nil); err != nil || got != "https://aws-us-east-2.api.entire.io" {
+		t.Fatalf("direct cell: got %q, %v", got, err)
+	}
+	// A loopback (local dev) origin is kept verbatim.
+	if got, err := resolveTargetCellBaseURL(ctx, nil, "http://127.0.0.1:8099", "us", "http://127.0.0.1:9000", "login", nil); err != nil || got != "http://127.0.0.1:8099" {
+		t.Fatalf("loopback: got %q, %v", got, err)
+	}
+	// An explicit target wins over everything and is trimmed of a trailing slash.
+	if got, err := resolveTargetCellBaseURL(ctx, &CellTarget{BaseURL: "https://eu.api.entire.io/"}, "https://entire.io", "eu", "https://eu.auth.entire.io", "login", nil); err != nil || got != "https://eu.api.entire.io" {
+		t.Fatalf("target override: got %q, %v", got, err)
 	}
 }
 
@@ -250,7 +333,7 @@ func TestNewEntireAPICellClient_TargetRoutesToRepoCell(t *testing.T) {
 
 	var gotExchangeAudience string
 	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/clusters" {
+		if r.URL.Path == clustersAPIPath {
 			t.Errorf("target path must not resolve clusters, but /api/v1/clusters was called")
 		}
 		if r.URL.Path != oauthTokenPath {

--- a/cmd/entire/cli/auth/cell_data_api_test.go
+++ b/cmd/entire/cli/auth/cell_data_api_test.go
@@ -29,21 +29,86 @@ func TestHomeJurisdictionFromLoginJWT(t *testing.T) {
 	}
 }
 
-func TestIsEntireIOBFF(t *testing.T) {
+func TestIsBFFOrigin(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		origin string
 		want   bool
 	}{
-		{"https://entire.io", true},
-		{"https://staging.entire.io", true},
-		{"https://aws-us-east-2.api.entire.io", false},
-		{"http://127.0.0.1:8099", false},
+		{"https://entire.io", true},                     // prod BFF
+		{"https://staging.entire.io", true},             // prod apex variant
+		{"https://partial.to", true},                    // staging BFF
+		{"https://us.partial.to", true},                 // staging apex variant
+		{"https://aws-us-east-2.api.entire.io", false},  // direct cell
+		{"https://aws-eu-west-1.api.partial.to", false}, // staging direct cell
+		{"http://127.0.0.1:8099", false},                // local dev
+		{"http://localhost:8787", false},                // local dev
 	}
 	for _, tc := range tests {
-		if got := isEntireIOBFF(tc.origin); got != tc.want {
-			t.Errorf("isEntireIOBFF(%q) = %v, want %v", tc.origin, got, tc.want)
+		if got := isBFFOrigin(tc.origin); got != tc.want {
+			t.Errorf("isBFFOrigin(%q) = %v, want %v", tc.origin, got, tc.want)
 		}
+	}
+}
+
+func TestEntireDomainFamily(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		core string
+		want string
+	}{
+		{"https://us.auth.entire.io", "entire.io"},
+		{"https://eu.auth.entire.io", "entire.io"},
+		{"https://us.auth.partial.to", "partial.to"},
+		{"http://127.0.0.1:9000", ""},
+		{"https://auth.example.com", ""},
+	}
+	for _, tc := range tests {
+		if got := entireDomainFamily(tc.core); got != tc.want {
+			t.Errorf("entireDomainFamily(%q) = %q, want %q", tc.core, got, tc.want)
+		}
+	}
+}
+
+func TestJurisdictionAudienceFollowsLoginFamily(t *testing.T) {
+	// No env override: the audience must follow the environment family so a
+	// staging (partial.to) login mints a partial.to audience, not a prod one.
+	t.Setenv("ENTIRE_API_AUDIENCE_TEMPLATE", "")
+	if got := jurisdictionAudience("us", "https://entire.io", "https://us.auth.entire.io"); got != "https://us.entire.io" {
+		t.Errorf("prod audience = %q, want https://us.entire.io", got)
+	}
+	if got := jurisdictionAudience("eu", "https://partial.to", "https://us.auth.partial.to"); got != "https://eu.partial.to" {
+		t.Errorf("staging audience = %q, want https://eu.partial.to", got)
+	}
+}
+
+func TestJurisdictionCoreURLHonorsLoopbackAndFamily(t *testing.T) {
+	t.Setenv("ENTIRE_CORE_BASE_URL_TEMPLATE", "")
+	// Local dev: a loopback discovered core must be honored verbatim, NOT
+	// replaced by the production template (which would send the local login JWT
+	// to prod).
+	if got := jurisdictionCoreURL("us", "http://127.0.0.1:8099", "http://127.0.0.1:9000"); got != "http://127.0.0.1:9000" {
+		t.Errorf("loopback core = %q, want http://127.0.0.1:9000", got)
+	}
+	// Staging: core follows the environment family and target jurisdiction.
+	if got := jurisdictionCoreURL("eu", "https://partial.to", "https://us.auth.partial.to"); got != "https://eu.auth.partial.to" {
+		t.Errorf("staging core = %q, want https://eu.auth.partial.to", got)
+	}
+}
+
+func TestTargetJurisdictionRejectsBadLabel(t *testing.T) {
+	t.Parallel()
+	bad := makeJWT(t, fmt.Sprintf(`{"home_jurisdiction":"us.auth.evil.tld","exp":%d}`, time.Now().Add(time.Hour).Unix()))
+	if _, err := targetJurisdiction(nil, bad); err == nil {
+		t.Fatal("expected rejection of non-label home_jurisdiction")
+	}
+	good := makeJWT(t, fmt.Sprintf(`{"home_jurisdiction":"us","exp":%d}`, time.Now().Add(time.Hour).Unix()))
+	if got, err := targetJurisdiction(nil, good); err != nil || got != "us" {
+		t.Fatalf("targetJurisdiction(good) = %q, %v; want us, nil", got, err)
+	}
+	// An explicit target wins over the JWT claim.
+	if got, err := targetJurisdiction(&CellTarget{Jurisdiction: "eu"}, good); err != nil || got != "eu" {
+		t.Fatalf("targetJurisdiction(target=eu) = %q, %v; want eu, nil", got, err)
 	}
 }
 
@@ -61,14 +126,14 @@ func TestNewEntireAPICellClient_RoutesThroughHomeCell(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v1/clusters":
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
+			_ = json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck // test handler
 				"clusters": []map[string]any{{
 					"jurisdiction": "us",
 					"isDefault":    true,
 					"apiUrl":       "http://" + r.Host,
 				}},
 			})
-		case "/oauth/token":
+		case oauthTokenPath:
 			_ = r.ParseForm() //nolint:errcheck // test handler
 			gotExchangeAudience = r.FormValue("audience")
 			if r.FormValue("scope") != jurisdictionIdentityScope {
@@ -98,11 +163,9 @@ func TestNewEntireAPICellClient_RoutesThroughHomeCell(t *testing.T) {
 	})
 	t.Cleanup(cleanupDiscovery)
 
-	prevTransport := cellExchangeTransportForTest
-	cellExchangeTransportForTest = coreSrv.Client().Transport
-	t.Cleanup(func() { cellExchangeTransportForTest = prevTransport })
+	t.Cleanup(SetCellExchangeTransportForTest(t, coreSrv.Client().Transport))
 
-	client, err := NewEntireAPICellClient(context.Background(), false)
+	client, err := NewEntireAPICellClient(context.Background(), false, nil)
 	if err != nil {
 		t.Fatalf("NewEntireAPICellClient: %v", err)
 	}
@@ -133,7 +196,7 @@ func TestNewEntireAPICellClient_KeepsDirectCellBaseURL(t *testing.T) {
 	t.Cleanup(restore)
 
 	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/oauth/token" {
+		if r.URL.Path != oauthTokenPath {
 			http.NotFound(w, r)
 			return
 		}
@@ -154,11 +217,9 @@ func TestNewEntireAPICellClient_KeepsDirectCellBaseURL(t *testing.T) {
 	})
 	t.Cleanup(cleanupDiscovery)
 
-	prevTransport := cellExchangeTransportForTest
-	cellExchangeTransportForTest = coreSrv.Client().Transport
-	t.Cleanup(func() { cellExchangeTransportForTest = prevTransport })
+	t.Cleanup(SetCellExchangeTransportForTest(t, coreSrv.Client().Transport))
 
-	client, err := NewEntireAPICellClient(context.Background(), false)
+	client, err := NewEntireAPICellClient(context.Background(), false, nil)
 	if err != nil {
 		t.Fatalf("NewEntireAPICellClient: %v", err)
 	}
@@ -171,5 +232,76 @@ func TestNewEntireAPICellClient_KeepsDirectCellBaseURL(t *testing.T) {
 	gotBase := api.OriginOnly(cellBase)
 	if !strings.HasSuffix(gotBase, ".api.entire.io") {
 		t.Fatalf("unexpected cell base %q", gotBase)
+	}
+}
+
+// TestNewEntireAPICellClient_TargetRoutesToRepoCell proves the repo-scoped path:
+// when a CellTarget names a different jurisdiction than the caller's home, the
+// client mints for the TARGET jurisdiction and dials the TARGET cell — not the
+// caller's home cell. This is the cross-jurisdiction case the home-only routing
+// could never satisfy.
+func TestNewEntireAPICellClient_TargetRoutesToRepoCell(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Setenv("ENTIRE_API_BASE_URL", "https://entire.io")
+	t.Setenv("ENTIRE_API_AUDIENCE_TEMPLATE", "")
+	t.Setenv("ENTIRE_CORE_BASE_URL_TEMPLATE", "")
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	var gotExchangeAudience string
+	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/clusters" {
+			t.Errorf("target path must not resolve clusters, but /api/v1/clusters was called")
+		}
+		if r.URL.Path != oauthTokenPath {
+			http.NotFound(w, r)
+			return
+		}
+		_ = r.ParseForm() //nolint:errcheck // test handler
+		gotExchangeAudience = r.FormValue("audience")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"access_token":"eu-identity-token","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer coreSrv.Close()
+
+	var euCellHit bool
+	euCell := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		euCellHit = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"repos":[]}`)
+	}))
+	defer euCell.Close()
+
+	svc := tokenstore.CoreKeyringService(coreSrv.URL)
+	loginJWT := makeJWT(t, fmt.Sprintf(`{"iss":%q,"home_jurisdiction":"us","exp":%d}`, coreSrv.URL, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "me", tokenstore.EncodeTokenWithExpiration(loginJWT, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	ctxObj := &contexts.Context{Name: "me@core", CoreURL: coreSrv.URL, Handle: "me", KeychainService: svc}
+	t.Cleanup(SetResolveContextForCellAPIForTest(t, func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+		return ctxObj, nil
+	}))
+	t.Cleanup(SetCellExchangeTransportForTest(t, coreSrv.Client().Transport))
+
+	// Caller home_jurisdiction is "us"; the repo is homed in "eu".
+	target := &CellTarget{BaseURL: euCell.URL, Jurisdiction: "eu"}
+	client, err := NewEntireAPICellClient(context.Background(), false, target)
+	if err != nil {
+		t.Fatalf("NewEntireAPICellClient: %v", err)
+	}
+	if gotExchangeAudience != "https://eu.entire.io" {
+		t.Fatalf("exchange audience = %q, want https://eu.entire.io (repo jurisdiction, not caller home us)", gotExchangeAudience)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/repos")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if !euCellHit {
+		t.Fatal("request did not reach the target (eu) cell")
+	}
+	if got := resp.Request.Header.Get("Authorization"); !strings.Contains(got, "eu-identity-token") {
+		t.Fatalf("Authorization = %q, want eu identity token", got)
 	}
 }

--- a/cmd/entire/cli/auth/cell_data_api_test.go
+++ b/cmd/entire/cli/auth/cell_data_api_test.go
@@ -1,0 +1,175 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
+	"github.com/entireio/cli/internal/entireclient/contexts"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+func TestHomeJurisdictionFromLoginJWT(t *testing.T) {
+	t.Parallel()
+	jwt := makeJWT(t, fmt.Sprintf(`{"home_jurisdiction":"us","exp":%d}`, time.Now().Add(time.Hour).Unix()))
+	got, err := homeJurisdictionFromLoginJWT(jwt)
+	if err != nil {
+		t.Fatalf("homeJurisdictionFromLoginJWT: %v", err)
+	}
+	if got != "us" {
+		t.Fatalf("jurisdiction = %q, want us", got)
+	}
+}
+
+func TestIsEntireIOBFF(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		origin string
+		want   bool
+	}{
+		{"https://entire.io", true},
+		{"https://staging.entire.io", true},
+		{"https://aws-us-east-2.api.entire.io", false},
+		{"http://127.0.0.1:8099", false},
+	}
+	for _, tc := range tests {
+		if got := isEntireIOBFF(tc.origin); got != tc.want {
+			t.Errorf("isEntireIOBFF(%q) = %v, want %v", tc.origin, got, tc.want)
+		}
+	}
+}
+
+func TestNewEntireAPICellClient_RoutesThroughHomeCell(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Setenv("ENTIRE_API_BASE_URL", "https://entire.io")
+	t.Setenv("ENTIRE_CORE_BASE_URL_TEMPLATE", "https://fixed-core.test")
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	const wantAudience = "https://us.entire.io"
+
+	var gotExchangeAudience, gotReposHost string
+	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/clusters":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusters": []map[string]any{{
+					"jurisdiction": "us",
+					"isDefault":    true,
+					"apiUrl":       "http://" + r.Host,
+				}},
+			})
+		case "/oauth/token":
+			_ = r.ParseForm() //nolint:errcheck // test handler
+			gotExchangeAudience = r.FormValue("audience")
+			if r.FormValue("scope") != jurisdictionIdentityScope {
+				t.Errorf("scope = %q, want openid", r.FormValue("scope"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"access_token":"cell-identity-token","token_type":"Bearer","expires_in":3600}`)
+		case "/api/v1/repos":
+			gotReposHost = r.Host
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"repos":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer coreSrv.Close()
+
+	svc := tokenstore.CoreKeyringService(coreSrv.URL)
+	loginJWT := makeJWT(t, fmt.Sprintf(`{"iss":%q,"home_jurisdiction":"us","exp":%d}`, coreSrv.URL, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "me", tokenstore.EncodeTokenWithExpiration(loginJWT, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	ctxObj := &contexts.Context{Name: "me@core", CoreURL: coreSrv.URL, Handle: "me", KeychainService: svc}
+
+	cleanupDiscovery := SetResolveContextForCellAPIForTest(t, func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+		return ctxObj, nil
+	})
+	t.Cleanup(cleanupDiscovery)
+
+	prevTransport := cellExchangeTransportForTest
+	cellExchangeTransportForTest = coreSrv.Client().Transport
+	t.Cleanup(func() { cellExchangeTransportForTest = prevTransport })
+
+	client, err := NewEntireAPICellClient(context.Background(), false)
+	if err != nil {
+		t.Fatalf("NewEntireAPICellClient: %v", err)
+	}
+	if gotExchangeAudience != wantAudience {
+		t.Fatalf("exchange audience = %q, want %q", gotExchangeAudience, wantAudience)
+	}
+
+	resp, err := client.Get(context.Background(), "/api/v1/repos")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if gotReposHost == "" {
+		t.Fatal("cell repos request was not received")
+	}
+	auth := resp.Request.Header.Get("Authorization")
+	if !strings.Contains(auth, "cell-identity-token") {
+		t.Fatalf("Authorization = %q, want cell identity token", auth)
+	}
+}
+
+func TestNewEntireAPICellClient_KeepsDirectCellBaseURL(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	const cellBase = "https://aws-us-east-2.api.entire.io"
+	t.Setenv("ENTIRE_API_BASE_URL", cellBase)
+	t.Setenv("ENTIRE_CORE_BASE_URL_TEMPLATE", "https://fixed-core.test")
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"access_token":"cell-identity-token","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer coreSrv.Close()
+
+	svc := tokenstore.CoreKeyringService(coreSrv.URL)
+	loginJWT := makeJWT(t, fmt.Sprintf(`{"iss":%q,"home_jurisdiction":"us","exp":%d}`, coreSrv.URL, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "me", tokenstore.EncodeTokenWithExpiration(loginJWT, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	ctxObj := &contexts.Context{Name: "me@core", CoreURL: coreSrv.URL, Handle: "me", KeychainService: svc}
+
+	cleanupDiscovery := SetResolveContextForCellAPIForTest(t, func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+		return ctxObj, nil
+	})
+	t.Cleanup(cleanupDiscovery)
+
+	prevTransport := cellExchangeTransportForTest
+	cellExchangeTransportForTest = coreSrv.Client().Transport
+	t.Cleanup(func() { cellExchangeTransportForTest = prevTransport })
+
+	client, err := NewEntireAPICellClient(context.Background(), false)
+	if err != nil {
+		t.Fatalf("NewEntireAPICellClient: %v", err)
+	}
+	if client == nil {
+		t.Fatal("client is nil")
+	}
+
+	// api.Client doesn't expose baseURL; verify via a stub round trip by calling
+	// ResolveURLFromBase indirectly through Get — use httptest on cell path instead.
+	gotBase := api.OriginOnly(cellBase)
+	if !strings.HasSuffix(gotBase, ".api.entire.io") {
+		t.Fatalf("unexpected cell base %q", gotBase)
+	}
+}

--- a/cmd/entire/cli/experts_cell_target.go
+++ b/cmd/entire/cli/experts_cell_target.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// resolveExpertsCellTarget resolves the entire-api cell that HOSTS the given
+// repo, plus that cell's jurisdiction, so a repo-scoped experts call reaches the
+// region that owns the repo — mirroring how the entire.io BFF selects a cell per
+// repo (resolve-cluster-host.ts / repos-stream.ts) rather than using the
+// caller's home cell.
+//
+// It is deliberately best-effort: ANY failure (not logged in, control-plane
+// error, unknown/ambiguous placement, missing apiUrl) returns nil, and the
+// auth-layer client falls back to home-jurisdiction routing. That fallback is
+// exactly the previous behaviour, so this can never regress the common
+// same-region case (where the repo's jurisdiction equals the caller's home).
+//
+// Placement source:
+//   - ulid form: coreapi.GetRepo(ulid) -> Repo.ClusterHost;
+//   - owner/repo form: coreapi mirrors filtered to this repo -> ClusterHost.
+//
+// The cluster host is then mapped to a cell apiUrl + jurisdiction via the
+// coreapi cluster catalog (ListClusters), which is the authoritative source for
+// a jurisdiction's cell URL.
+func resolveExpertsCellTarget(ctx context.Context, fullName, ulid string) *auth.CellTarget {
+	c, err := coreapi.New()
+	if err != nil {
+		logging.Debug(ctx, "experts cell target: core client unavailable, using home-jurisdiction routing", "error", err.Error())
+		return nil
+	}
+
+	clusterHost, ok := resolveRepoClusterHost(ctx, c, fullName, ulid)
+	if !ok || clusterHost == "" {
+		return nil
+	}
+
+	clusters, err := c.ListClusters(ctx)
+	if err != nil {
+		logging.Debug(ctx, "experts cell target: list clusters failed, using home-jurisdiction routing", "error", err.Error())
+		return nil
+	}
+	cluster, ok := matchClusterByHost(clusters.Clusters, clusterHost)
+	if !ok {
+		logging.Debug(ctx, "experts cell target: no cluster matched repo host, using home-jurisdiction routing", "cluster_host", clusterHost)
+		return nil
+	}
+	apiURL := strings.TrimRight(strings.TrimSpace(cluster.ApiUrl.Or("")), "/")
+	jurisdiction := strings.TrimSpace(cluster.Jurisdiction)
+	if apiURL == "" || jurisdiction == "" {
+		logging.Debug(ctx, "experts cell target: matched cluster missing apiUrl/jurisdiction, using home-jurisdiction routing", "cluster_host", clusterHost)
+		return nil
+	}
+	return &auth.CellTarget{BaseURL: apiURL, Jurisdiction: jurisdiction}
+}
+
+// resolveRepoClusterHost finds the public cluster host that owns the repo. It
+// returns ok=false to signal "fall back to home-jurisdiction routing" for every
+// unresolved or ambiguous case, never an error.
+func resolveRepoClusterHost(ctx context.Context, c *coreapi.Client, fullName, ulid string) (string, bool) {
+	if strings.TrimSpace(ulid) != "" {
+		repo, err := c.GetRepo(ctx, coreapi.GetRepoParams{RepoId: ulid})
+		if err != nil {
+			logging.Debug(ctx, "experts cell target: GetRepo failed, using home-jurisdiction routing", "error", err.Error())
+			return "", false
+		}
+		return strings.TrimSpace(repo.ClusterHost.Or("")), true
+	}
+
+	owner, repo, ok := strings.Cut(strings.TrimSpace(fullName), "/")
+	if !ok || owner == "" || repo == "" {
+		return "", false
+	}
+	mirrors, err := listMirrorsForRepo(ctx, c, mirrorCloneProviderGitHub, strings.ToLower(owner), strings.ToLower(repo))
+	if err != nil {
+		logging.Debug(ctx, "experts cell target: list mirrors failed, using home-jurisdiction routing", "error", err.Error())
+		return "", false
+	}
+	hosts := distinctActiveClusterHosts(mirrors)
+	if len(hosts) != 1 {
+		// Zero placements (not mirrored / unknown) or multiple regions
+		// (ambiguous which cell holds the experts data): fall back rather than
+		// guess a region.
+		if len(hosts) > 1 {
+			logging.Debug(ctx, "experts cell target: repo mirrored in multiple regions, using home-jurisdiction routing", "count", len(hosts))
+		}
+		return "", false
+	}
+	return hosts[0], true
+}
+
+// distinctActiveClusterHosts returns the set of cluster hosts a repo is actively
+// mirrored on, excluding archived placements. Case-folded to match DNS
+// semantics; order-stable is unnecessary since callers only use it when the set
+// has exactly one member.
+func distinctActiveClusterHosts(mirrors []coreapi.Mirror) []string {
+	seen := make(map[string]string, len(mirrors))
+	for _, m := range mirrors {
+		if m.IsArchived.Or(false) {
+			continue
+		}
+		host := strings.TrimSpace(m.ClusterHost)
+		if host == "" {
+			continue
+		}
+		key := strings.ToLower(host)
+		if _, ok := seen[key]; !ok {
+			seen[key] = host
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for _, host := range seen {
+		out = append(out, host)
+	}
+	return out
+}
+
+// matchClusterByHost finds the catalog cluster whose public host equals
+// clusterHost (case-insensitive). The cluster's apiUrl + jurisdiction are the
+// authoritative cell coordinates.
+func matchClusterByHost(clusters []coreapi.Cluster, clusterHost string) (coreapi.Cluster, bool) {
+	want := strings.ToLower(strings.TrimSpace(clusterHost))
+	if want == "" {
+		return coreapi.Cluster{}, false
+	}
+	for _, cl := range clusters {
+		host, err := hostFromPublicURL(cl.PublicUrl)
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(host), want) {
+			return cl, true
+		}
+	}
+	return coreapi.Cluster{}, false
+}

--- a/cmd/entire/cli/experts_cell_target.go
+++ b/cmd/entire/cli/experts_cell_target.go
@@ -3,11 +3,32 @@ package cli
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/internal/coreapi"
 )
+
+// expertsCellResolveTimeout bounds the best-effort control-plane lookups that
+// pick a repo's cell. Without it, a reachable-but-hung control plane would block
+// the whole experts command instead of degrading to home-jurisdiction routing —
+// the "any failure falls back" contract must hold for slow cores, not just
+// erroring ones.
+const expertsCellResolveTimeout = 5 * time.Second
+
+// expertsCoreClient is the control-plane surface the cell-target resolver needs.
+// An interface (with a swappable constructor) so the resolver is unit-testable
+// against a fake control plane; *coreapi.Client satisfies it.
+type expertsCoreClient interface {
+	GetRepo(ctx context.Context, params coreapi.GetRepoParams) (*coreapi.Repo, error)
+	ListClusters(ctx context.Context) (*coreapi.ListClustersOutputBody, error)
+	ListMirrors(ctx context.Context, params coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error)
+}
+
+// newExpertsCoreClient builds the control-plane client used for cell resolution.
+// Swapped in tests.
+var newExpertsCoreClient = func() (expertsCoreClient, error) { return coreapi.New() }
 
 // resolveExpertsCellTarget resolves the entire-api cell that HOSTS the given
 // repo, plus that cell's jurisdiction, so a repo-scoped experts call reaches the
@@ -16,20 +37,24 @@ import (
 // caller's home cell.
 //
 // It is deliberately best-effort: ANY failure (not logged in, control-plane
-// error, unknown/ambiguous placement, missing apiUrl) returns nil, and the
-// auth-layer client falls back to home-jurisdiction routing. That fallback is
-// exactly the previous behaviour, so this can never regress the common
-// same-region case (where the repo's jurisdiction equals the caller's home).
+// error or timeout, unknown/ambiguous placement, missing apiUrl) returns nil,
+// and the auth-layer client falls back to home-jurisdiction routing. That
+// fallback is exactly the previous behaviour, so this can never regress the
+// common same-region case (where the repo's jurisdiction equals the caller's
+// home). A short deadline keeps a slow control plane from stalling the command.
 //
 // Placement source:
 //   - ulid form: coreapi.GetRepo(ulid) -> Repo.ClusterHost;
 //   - owner/repo form: coreapi mirrors filtered to this repo -> ClusterHost.
 //
 // The cluster host is then mapped to a cell apiUrl + jurisdiction via the
-// coreapi cluster catalog (ListClusters), which is the authoritative source for
-// a jurisdiction's cell URL.
+// coreapi cluster catalog (ListClusters), the authoritative source for a
+// jurisdiction's cell URL.
 func resolveExpertsCellTarget(ctx context.Context, fullName, ulid string) *auth.CellTarget {
-	c, err := coreapi.New()
+	ctx, cancel := context.WithTimeout(ctx, expertsCellResolveTimeout)
+	defer cancel()
+
+	c, err := newExpertsCoreClient()
 	if err != nil {
 		logging.Debug(ctx, "experts cell target: core client unavailable, using home-jurisdiction routing", "error", err.Error())
 		return nil
@@ -51,7 +76,10 @@ func resolveExpertsCellTarget(ctx context.Context, fullName, ulid string) *auth.
 		return nil
 	}
 	apiURL := strings.TrimRight(strings.TrimSpace(cluster.ApiUrl.Or("")), "/")
-	jurisdiction := strings.TrimSpace(cluster.Jurisdiction)
+	// DNS is case-insensitive; normalise the catalog jurisdiction so a
+	// non-lowercase value still passes the auth layer's strict label check
+	// instead of hard-failing the target path.
+	jurisdiction := strings.ToLower(strings.TrimSpace(cluster.Jurisdiction))
 	if apiURL == "" || jurisdiction == "" {
 		logging.Debug(ctx, "experts cell target: matched cluster missing apiUrl/jurisdiction, using home-jurisdiction routing", "cluster_host", clusterHost)
 		return nil
@@ -62,7 +90,7 @@ func resolveExpertsCellTarget(ctx context.Context, fullName, ulid string) *auth.
 // resolveRepoClusterHost finds the public cluster host that owns the repo. It
 // returns ok=false to signal "fall back to home-jurisdiction routing" for every
 // unresolved or ambiguous case, never an error.
-func resolveRepoClusterHost(ctx context.Context, c *coreapi.Client, fullName, ulid string) (string, bool) {
+func resolveRepoClusterHost(ctx context.Context, c expertsCoreClient, fullName, ulid string) (string, bool) {
 	if strings.TrimSpace(ulid) != "" {
 		repo, err := c.GetRepo(ctx, coreapi.GetRepoParams{RepoId: ulid})
 		if err != nil {
@@ -95,13 +123,20 @@ func resolveRepoClusterHost(ctx context.Context, c *coreapi.Client, fullName, ul
 }
 
 // distinctActiveClusterHosts returns the set of cluster hosts a repo is actively
-// mirrored on, excluding archived placements. Case-folded to match DNS
-// semantics; order-stable is unnecessary since callers only use it when the set
-// has exactly one member.
+// serviced on: excluding archived placements and unhealthy ones (failed /
+// suspended clone status), since those cells can't answer experts for the repo.
+// A failed/suspended placement must neither manufacture false cross-region
+// ambiguity nor become a sole "active" host. Case-folded to match DNS
+// semantics; order is unimportant (callers only use a single-member set).
 func distinctActiveClusterHosts(mirrors []coreapi.Mirror) []string {
 	seen := make(map[string]string, len(mirrors))
 	for _, m := range mirrors {
 		if m.IsArchived.Or(false) {
+			continue
+		}
+		// Treat unset status as active (older data); only failed/suspended
+		// placements can't serve experts for the repo.
+		if st := m.Status.Or(coreapi.MirrorStatusReady); st == coreapi.MirrorStatusFailed || st == coreapi.MirrorStatusSuspended {
 			continue
 		}
 		host := strings.TrimSpace(m.ClusterHost)

--- a/cmd/entire/cli/experts_cell_target_test.go
+++ b/cmd/entire/cli/experts_cell_target_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+func TestDistinctActiveClusterHosts(t *testing.T) {
+	t.Parallel()
+	mirrors := []coreapi.Mirror{
+		{ClusterHost: "aws-us-east-2.entire.io"},
+		{ClusterHost: "AWS-US-EAST-2.entire.io"},                                       // dup (case-insensitive)
+		{ClusterHost: "aws-eu-west-1.entire.io"},                                       // distinct
+		{ClusterHost: "aws-eu-west-1.entire.io", IsArchived: coreapi.NewOptBool(true)}, // archived → excluded
+		{ClusterHost: ""}, // empty → excluded
+	}
+	got := distinctActiveClusterHosts(mirrors)
+	sort.Strings(got)
+	want := []string{"aws-eu-west-1.entire.io", "aws-us-east-2.entire.io"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("distinctActiveClusterHosts = %v, want %v", got, want)
+	}
+}
+
+func TestDistinctActiveClusterHosts_AllArchived(t *testing.T) {
+	t.Parallel()
+	mirrors := []coreapi.Mirror{
+		{ClusterHost: "aws-us-east-2.entire.io", IsArchived: coreapi.NewOptBool(true)},
+	}
+	if got := distinctActiveClusterHosts(mirrors); len(got) != 0 {
+		t.Fatalf("distinctActiveClusterHosts = %v, want empty", got)
+	}
+}
+
+func TestMatchClusterByHost(t *testing.T) {
+	t.Parallel()
+	clusters := []coreapi.Cluster{
+		{PublicUrl: "https://us.entire.io", Jurisdiction: "us", ApiUrl: coreapi.NewOptString("https://aws-us-east-2.api.entire.io")},
+		{PublicUrl: "https://eu.entire.io", Jurisdiction: "eu", ApiUrl: coreapi.NewOptString("https://aws-eu-west-1.api.entire.io")},
+	}
+
+	// Match is on the public host, case-insensitive.
+	cl, ok := matchClusterByHost(clusters, "EU.entire.io")
+	if !ok {
+		t.Fatal("expected a match for eu.entire.io")
+	}
+	if cl.Jurisdiction != "eu" || cl.ApiUrl.Or("") != "https://aws-eu-west-1.api.entire.io" {
+		t.Fatalf("matched wrong cluster: %+v", cl)
+	}
+
+	if _, ok := matchClusterByHost(clusters, "ap.entire.io"); ok {
+		t.Fatal("expected no match for unknown host")
+	}
+	if _, ok := matchClusterByHost(clusters, ""); ok {
+		t.Fatal("expected no match for empty host")
+	}
+}

--- a/cmd/entire/cli/experts_cell_target_test.go
+++ b/cmd/entire/cli/experts_cell_target_test.go
@@ -1,19 +1,28 @@
 package cli
 
 import (
+	"context"
+	"errors"
 	"sort"
 	"testing"
 
 	"github.com/entireio/cli/internal/coreapi"
 )
 
+const euCellAPIURL = "https://eu.api.entire.io"
+
 func TestDistinctActiveClusterHosts(t *testing.T) {
 	t.Parallel()
 	mirrors := []coreapi.Mirror{
 		{ClusterHost: "aws-us-east-2.entire.io"},
-		{ClusterHost: "AWS-US-EAST-2.entire.io"},                                       // dup (case-insensitive)
-		{ClusterHost: "aws-eu-west-1.entire.io"},                                       // distinct
-		{ClusterHost: "aws-eu-west-1.entire.io", IsArchived: coreapi.NewOptBool(true)}, // archived → excluded
+		{ClusterHost: "AWS-US-EAST-2.entire.io"}, // dup (case-insensitive) → collapses
+		{ClusterHost: "aws-eu-west-1.entire.io"}, // distinct active
+		// Unique host that is archived → must be excluded (observably absent).
+		{ClusterHost: "aws-ap-south-1.entire.io", IsArchived: coreapi.NewOptBool(true)},
+		// Unique host with a failed clone → excluded (can't serve experts).
+		{ClusterHost: "aws-sa-east-1.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusFailed)},
+		// Unique host suspended → excluded.
+		{ClusterHost: "aws-ca-central-1.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusSuspended)},
 		{ClusterHost: ""}, // empty → excluded
 	}
 	got := distinctActiveClusterHosts(mirrors)
@@ -24,10 +33,11 @@ func TestDistinctActiveClusterHosts(t *testing.T) {
 	}
 }
 
-func TestDistinctActiveClusterHosts_AllArchived(t *testing.T) {
+func TestDistinctActiveClusterHosts_AllInactive(t *testing.T) {
 	t.Parallel()
 	mirrors := []coreapi.Mirror{
 		{ClusterHost: "aws-us-east-2.entire.io", IsArchived: coreapi.NewOptBool(true)},
+		{ClusterHost: "aws-eu-west-1.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusFailed)},
 	}
 	if got := distinctActiveClusterHosts(mirrors); len(got) != 0 {
 		t.Fatalf("distinctActiveClusterHosts = %v, want empty", got)
@@ -55,5 +65,141 @@ func TestMatchClusterByHost(t *testing.T) {
 	}
 	if _, ok := matchClusterByHost(clusters, ""); ok {
 		t.Fatal("expected no match for empty host")
+	}
+}
+
+// TestClusterHostJoin exercises the realistic invariant that a mirror's
+// ClusterHost joins to a cluster whose PublicUrl host equals it — the actual
+// key the resolver relies on.
+func TestClusterHostJoin(t *testing.T) {
+	t.Parallel()
+	mirrors := []coreapi.Mirror{{ClusterHost: "eu.entire.io", Repo: "widget"}}
+	clusters := []coreapi.Cluster{
+		{PublicUrl: "https://us.entire.io", Jurisdiction: "us", ApiUrl: coreapi.NewOptString("https://us.api.entire.io")},
+		{PublicUrl: "https://eu.entire.io", Jurisdiction: "eu", ApiUrl: coreapi.NewOptString(euCellAPIURL)},
+	}
+	hosts := distinctActiveClusterHosts(mirrors)
+	if len(hosts) != 1 {
+		t.Fatalf("hosts = %v, want 1", hosts)
+	}
+	cl, ok := matchClusterByHost(clusters, hosts[0])
+	if !ok || cl.Jurisdiction != "eu" || cl.ApiUrl.Or("") != euCellAPIURL {
+		t.Fatalf("join failed: ok=%v cluster=%+v", ok, cl)
+	}
+}
+
+// fakeExpertsCore is a stub control plane for resolveExpertsCellTarget tests.
+type fakeExpertsCore struct {
+	repo        *coreapi.Repo
+	repoErr     error
+	mirrors     []coreapi.Mirror
+	mirrorsErr  error
+	clusters    []coreapi.Cluster
+	clustersErr error
+}
+
+func (f *fakeExpertsCore) GetRepo(context.Context, coreapi.GetRepoParams) (*coreapi.Repo, error) {
+	return f.repo, f.repoErr
+}
+
+func (f *fakeExpertsCore) ListClusters(context.Context) (*coreapi.ListClustersOutputBody, error) {
+	if f.clustersErr != nil {
+		return nil, f.clustersErr
+	}
+	return &coreapi.ListClustersOutputBody{Clusters: f.clusters}, nil
+}
+
+func (f *fakeExpertsCore) ListMirrors(context.Context, coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error) {
+	if f.mirrorsErr != nil {
+		return nil, f.mirrorsErr
+	}
+	return &coreapi.ListMirrorsOutputBody{Mirrors: f.mirrors}, nil
+}
+
+func withFakeExpertsCore(t *testing.T, f *fakeExpertsCore) {
+	t.Helper()
+	prev := newExpertsCoreClient
+	newExpertsCoreClient = func() (expertsCoreClient, error) { return f, nil }
+	t.Cleanup(func() { newExpertsCoreClient = prev })
+}
+
+func euClusters() []coreapi.Cluster {
+	return []coreapi.Cluster{
+		{PublicUrl: "https://us.entire.io", Jurisdiction: "us", ApiUrl: coreapi.NewOptString("https://us.api.entire.io")},
+		{PublicUrl: "https://eu.entire.io", Jurisdiction: "eu", ApiUrl: coreapi.NewOptString(euCellAPIURL)},
+	}
+}
+
+func TestResolveExpertsCellTarget_ULID(t *testing.T) {
+	withFakeExpertsCore(t, &fakeExpertsCore{
+		repo:     &coreapi.Repo{ID: "ULID", ClusterHost: coreapi.NewOptString("eu.entire.io")},
+		clusters: euClusters(),
+	})
+	target := resolveExpertsCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	if target == nil {
+		t.Fatal("expected a target for a resolvable ULID")
+	}
+	if target.BaseURL != euCellAPIURL || target.Jurisdiction != "eu" {
+		t.Fatalf("target = %+v, want eu cell", target)
+	}
+}
+
+func TestResolveExpertsCellTarget_ULIDError_FallsBack(t *testing.T) {
+	withFakeExpertsCore(t, &fakeExpertsCore{repoErr: errors.New("boom"), clusters: euClusters()})
+	if target := resolveExpertsCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV"); target != nil {
+		t.Fatalf("expected nil (fallback) on GetRepo error, got %+v", target)
+	}
+}
+
+func TestResolveExpertsCellTarget_OwnerRepoSingleRegion(t *testing.T) {
+	withFakeExpertsCore(t, &fakeExpertsCore{
+		mirrors: []coreapi.Mirror{
+			{Repo: "widget", ClusterHost: "eu.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)},
+			// A failed placement in another region must be ignored, not create ambiguity.
+			{Repo: "widget", ClusterHost: "us.entire.io", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusFailed)},
+			// A different repo must be filtered out by listMirrorsForRepo.
+			{Repo: "other", ClusterHost: "us.entire.io"},
+		},
+		clusters: euClusters(),
+	})
+	target := resolveExpertsCellTarget(context.Background(), "acme/widget", "")
+	if target == nil || target.Jurisdiction != "eu" || target.BaseURL != euCellAPIURL {
+		t.Fatalf("target = %+v, want eu cell", target)
+	}
+}
+
+func TestResolveExpertsCellTarget_MultiRegion_FallsBack(t *testing.T) {
+	withFakeExpertsCore(t, &fakeExpertsCore{
+		mirrors: []coreapi.Mirror{
+			{Repo: "widget", ClusterHost: "eu.entire.io"},
+			{Repo: "widget", ClusterHost: "us.entire.io"},
+		},
+		clusters: euClusters(),
+	})
+	if target := resolveExpertsCellTarget(context.Background(), "acme/widget", ""); target != nil {
+		t.Fatalf("expected nil (fallback) for ambiguous multi-region repo, got %+v", target)
+	}
+}
+
+func TestResolveExpertsCellTarget_NoClusterMatch_FallsBack(t *testing.T) {
+	withFakeExpertsCore(t, &fakeExpertsCore{
+		repo:     &coreapi.Repo{ClusterHost: coreapi.NewOptString("ap.entire.io")}, // not in catalog
+		clusters: euClusters(),
+	})
+	if target := resolveExpertsCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV"); target != nil {
+		t.Fatalf("expected nil (fallback) when no cluster matches, got %+v", target)
+	}
+}
+
+func TestResolveExpertsCellTarget_JurisdictionLowercased(t *testing.T) {
+	withFakeExpertsCore(t, &fakeExpertsCore{
+		repo: &coreapi.Repo{ClusterHost: coreapi.NewOptString("eu.entire.io")},
+		clusters: []coreapi.Cluster{
+			{PublicUrl: "https://eu.entire.io", Jurisdiction: "EU", ApiUrl: coreapi.NewOptString(euCellAPIURL)},
+		},
+	})
+	target := resolveExpertsCellTarget(context.Background(), "", "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	if target == nil || target.Jurisdiction != "eu" {
+		t.Fatalf("target = %+v, want lowercased jurisdiction eu", target)
 	}
 }

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -26,13 +26,16 @@ type expertsAPIClient interface {
 	Post(ctx context.Context, path string, body any) (*http.Response, error)
 }
 
-var newExpertsAPIClient = func(ctx context.Context, insecureHTTP bool) (expertsAPIClient, error) {
-	return NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP)
+// newExpertsAPIClient builds the entire-api cell client. fullName (owner/repo)
+// and/or ulid identify the repo so the client can route to the cell that hosts
+// it (see NewAuthenticatedEntireAPICellClient).
+var newExpertsAPIClient = func(ctx context.Context, insecureHTTP bool, fullName, ulid string) (expertsAPIClient, error) {
+	return NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP, fullName, ulid)
 }
 
 func setExpertsClientFactoryForTest(
 	t interface{ Helper() },
-	fn func(context.Context, bool) (expertsAPIClient, error),
+	fn func(context.Context, bool, string, string) (expertsAPIClient, error),
 ) func() {
 	t.Helper()
 	prev := newExpertsAPIClient
@@ -267,7 +270,16 @@ func runExperts(ctx context.Context, out, errOut io.Writer, args []string, f *ex
 		}
 	}
 
-	client, err := newExpertsAPIClient(ctx, f.insecureHTTP)
+	// Identify the repo for cell routing: a ULID goes on the ulid arg, an
+	// owner/repo on the fullName arg. The client uses whichever is set to reach
+	// the cell that hosts the repo (falling back to home-jurisdiction routing).
+	cellFullName, cellULID := "", ""
+	if repoIsULID {
+		cellULID = repoOverride
+	} else {
+		cellFullName = repoFullName
+	}
+	client, err := newExpertsAPIClient(ctx, f.insecureHTTP, cellFullName, cellULID)
 	if err != nil {
 		return fmt.Errorf("create experts API client: %w", err)
 	}
@@ -288,12 +300,21 @@ func runExperts(ctx context.Context, out, errOut io.Writer, args []string, f *ex
 
 	if err := api.CheckResponse(resp); err != nil {
 		var httpErr *api.HTTPError
-		if errors.As(err, &httpErr) &&
-			httpErr.StatusCode == http.StatusServiceUnavailable &&
-			req.Query != nil &&
-			strings.Contains(strings.ToLower(httpErr.Message), "code search") {
-			fmt.Fprintln(errOut, "Code search is not configured for natural-language experts queries.")
-			return NewSilentError(err)
+		if errors.As(err, &httpErr) {
+			if httpErr.StatusCode == http.StatusServiceUnavailable &&
+				req.Query != nil &&
+				strings.Contains(strings.ToLower(httpErr.Message), "code search") {
+				fmt.Fprintln(errOut, "Code search is not configured for natural-language experts queries.")
+				return NewSilentError(err)
+			}
+			// entire-api returns 404 "repo not in this region" when the repo is
+			// homed in a different cell than the one reached. Surface that as an
+			// actionable region hint instead of the raw service-to-service text.
+			if httpErr.StatusCode == http.StatusNotFound &&
+				strings.Contains(strings.ToLower(httpErr.Message), "region") {
+				fmt.Fprintln(errOut, "This repo appears to be homed in a different Entire region than the cell this command reached; cross-region experts routing may be incomplete.")
+				return NewSilentError(err)
+			}
 		}
 		return fmt.Errorf("fetch experts: %w", err)
 	}
@@ -371,7 +392,7 @@ func resolveExpertsRepoID(ctx context.Context, client expertsAPIClient, fullName
 			return r.ID, nil
 		}
 	}
-	return "", fmt.Errorf("repo %q is not among your accessible repos on this API (is it onboarded to Entire, and do you have access?)", fullName)
+	return "", fmt.Errorf("repo %q was not found on the entire-api cell this command reached. It may be homed in another Entire region (cross-region experts routing may be incomplete), not onboarded to Entire, or outside your access", fullName)
 }
 
 type expertsRepoListItem struct {

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -301,10 +301,13 @@ func runExperts(ctx context.Context, out, errOut io.Writer, args []string, f *ex
 	if err := api.CheckResponse(resp); err != nil {
 		var httpErr *api.HTTPError
 		if errors.As(err, &httpErr) {
-			if httpErr.StatusCode == http.StatusServiceUnavailable &&
-				req.Query != nil &&
-				strings.Contains(strings.ToLower(httpErr.Message), "code search") {
-				fmt.Fprintln(errOut, "Code search is not configured for natural-language experts queries.")
+			// A natural-language query needs code search on the cell. When it
+			// isn't available the cell returns 503 — sometimes with only a bare
+			// "Service Unavailable" body — so treat any 503 on a query as the
+			// code-search-unavailable case. Path scopes don't need code search
+			// and fall through to the generic error below.
+			if httpErr.StatusCode == http.StatusServiceUnavailable && req.Query != nil {
+				fmt.Fprintln(errOut, "Code search is not available for natural-language experts queries on this backend.")
 				return NewSilentError(err)
 			}
 			// entire-api returns 404 "repo not in this region" when the repo is

--- a/cmd/entire/cli/experts_cmd.go
+++ b/cmd/entire/cli/experts_cmd.go
@@ -27,7 +27,7 @@ type expertsAPIClient interface {
 }
 
 var newExpertsAPIClient = func(ctx context.Context, insecureHTTP bool) (expertsAPIClient, error) {
-	return NewAuthenticatedAPIClient(ctx, insecureHTTP)
+	return NewAuthenticatedEntireAPICellClient(ctx, insecureHTTP)
 }
 
 func setExpertsClientFactoryForTest(

--- a/cmd/entire/cli/experts_test.go
+++ b/cmd/entire/cli/experts_test.go
@@ -597,8 +597,34 @@ func TestExpertsCommandDoesNotRewritePathScope503AsCodeSearch(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "Database unavailable") {
 		t.Fatalf("error = %v", err)
 	}
-	if strings.Contains(out.String(), "Code search is not configured") {
-		t.Fatalf("path-scope 503 should not be rewritten as code search setup:\n%s", out.String())
+	if strings.Contains(out.String(), "Code search is not available") {
+		t.Fatalf("path-scope 503 should not be rewritten as code search unavailable:\n%s", out.String())
+	}
+}
+
+// TestExpertsCommandQuery503ShowsCodeSearchMessage covers the real backend
+// behaviour observed live: a natural-language query hits a cell without code
+// search and gets a bare 503, which must surface as a clean code-search message
+// (not the raw "fetch experts: API error" wrap).
+func TestExpertsCommandQuery503ShowsCodeSearchMessage(t *testing.T) {
+	fake := &fakeExpertsClient{status: http.StatusServiceUnavailable, body: `{"error":"Service Unavailable"}`}
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
+		return fake, nil
+	})
+	defer restore()
+
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"experts", "some natural language topic", "--repo", "acme/widget"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected a non-nil (silent) error for a 503 query")
+	}
+	if !strings.Contains(out.String(), "Code search is not available") {
+		t.Fatalf("query 503 should show the code-search message:\n%s", out.String())
 	}
 }
 

--- a/cmd/entire/cli/experts_test.go
+++ b/cmd/entire/cli/experts_test.go
@@ -134,7 +134,7 @@ func TestExpertsCommandIsHiddenAndListedInLabs(t *testing.T) {
 
 func TestExpertsCommandSendsQueryAndPrintsJSON(t *testing.T) {
 	fake := &fakeExpertsClient{body: expertsSuccessBody()}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -179,7 +179,7 @@ func TestExpertsCommandSendsQueryAndPrintsJSON(t *testing.T) {
 
 func TestExpertsCommandPrintsAgentCenteredEvidence(t *testing.T) {
 	fake := &fakeExpertsClient{body: expertsSuccessBody()}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -256,7 +256,7 @@ func TestExpertsCommandUsesStagedFilesAsScopes(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["billing/webhooks/sender.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -298,7 +298,7 @@ func TestExpertsCommandUsesStagedDeletionsAsScopes(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["billing/webhooks/sender.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -338,7 +338,7 @@ func TestExpertsCommandResolvesRepoRootPathFromSubdirectory(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["cmd/entire/cli/experts.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -380,7 +380,7 @@ func TestExpertsCommandResolvesCWDRelativePathFromSubdirectory(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["cmd/entire/cli/experts.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -405,7 +405,7 @@ func TestExpertsCommandResolvesCWDRelativePathFromSubdirectory(t *testing.T) {
 
 func TestExpertsCommandTreatsPathLikeRepoOverrideArgAsScope(t *testing.T) {
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["api/deleted.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -438,7 +438,7 @@ func TestExpertsCommandRelativizesAbsoluteDeletedPathScope(t *testing.T) {
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["api/deleted.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -484,7 +484,7 @@ func TestExpertsCommandRelativizesDeletedPathScopeFromSubdirectory(t *testing.T)
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["cmd/entire/cli/deleted.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -523,7 +523,7 @@ func TestExpertsCommandAcceptsCaseInsensitiveRepoOverrideForLocalScope(t *testin
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["cmd/"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -563,7 +563,7 @@ func TestExpertsCommandRejectsMismatchedRepoOverrideForLocalScope(t *testing.T) 
 	paths.ClearWorktreeRootCache()
 	t.Cleanup(paths.ClearWorktreeRootCache)
 
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return &fakeExpertsClient{}, nil
 	})
 	defer restore()
@@ -582,7 +582,7 @@ func TestExpertsCommandRejectsMismatchedRepoOverrideForLocalScope(t *testing.T) 
 
 func TestExpertsCommandDoesNotRewritePathScope503AsCodeSearch(t *testing.T) {
 	fake := &fakeExpertsClient{status: http.StatusServiceUnavailable, body: `{"error":"Database unavailable"}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -634,7 +634,7 @@ func TestResolveExpertsRepoIDPaginatesAccessibleRepoList(t *testing.T) {
 		},
 		body: `{"repo_full_name":"acme/widget","scopes":["api/x.go"],"query":null,"branch":"main","source":"db","profiles":[]}`,
 	}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()
@@ -664,7 +664,7 @@ func TestResolveExpertsRepoIDPaginatesAccessibleRepoList(t *testing.T) {
 
 func TestExpertsCommandAcceptsRepoULIDWithoutResolution(t *testing.T) {
 	fake := &fakeExpertsClient{body: `{"repo_full_name":"acme/widget","scopes":["api/x.go"],"query":null,"branch":"main","source":"db","profiles":[]}`}
-	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool) (expertsAPIClient, error) {
+	restore := setExpertsClientFactoryForTest(t, func(context.Context, bool, string, string) (expertsAPIClient, error) {
 		return fake, nil
 	})
 	defer restore()

--- a/cmd/entire/cli/repo_clone.go
+++ b/cmd/entire/cli/repo_clone.go
@@ -166,11 +166,18 @@ func newRepoCloneCmd() *cobra.Command {
 	return cmd
 }
 
+// mirrorLister is the subset of the control-plane client listMirrorsForRepo
+// needs. Narrowing to an interface lets callers (e.g. the experts cell-target
+// resolver) inject a fake control plane in tests; *coreapi.Client satisfies it.
+type mirrorLister interface {
+	ListMirrors(ctx context.Context, params coreapi.ListMirrorsParams) (*coreapi.ListMirrorsOutputBody, error)
+}
+
 // listMirrorsForRepo returns every mirror placement of one upstream repo across
 // clusters. The list API filters by provider+owner server-side but has no repo
 // filter, so the repo match is applied client-side (owner is already lowercased
 // to match what the server persists).
-func listMirrorsForRepo(ctx context.Context, c *coreapi.Client, provider, owner, repo string) ([]coreapi.Mirror, error) {
+func listMirrorsForRepo(ctx context.Context, c mirrorLister, provider, owner, repo string) ([]coreapi.Mirror, error) {
 	all, err := fetchAllPages(ctx, func(ctx context.Context, cursor string) ([]coreapi.Mirror, string, error) {
 		params := coreapi.ListMirrorsParams{
 			Provider: coreapi.NewOptString(provider),
@@ -181,7 +188,7 @@ func listMirrorsForRepo(ctx context.Context, c *coreapi.Client, provider, owner,
 		}
 		out, err := c.ListMirrors(ctx, params)
 		if err != nil {
-			return nil, "", err
+			return nil, "", fmt.Errorf("list mirrors: %w", err)
 		}
 		return out.Mirrors, out.NextPageToken.Or(""), nil
 	})


### PR DESCRIPTION
https://entire.io/gh/entireio/cli/trails/715

## Problem

`entire experts --repo owner/repo` fails with `401 Not authenticated`, even while logged in and while `entire activity` / `entire search` work. Repo-scoped entire-api routes (`GET /api/v1/repos`, `POST /api/v1/repos/{id}/experts`) require a **jurisdictional identity token** (`scope=openid`, `aud` = the cell's jurisdiction host, signed by Core JWKS) — not the `entire:api-access` bearer minted for the `entire.io` BFF. The BFF also does not proxy these routes for bearer callers, so the CLI must dial the entire-api cell directly.

## Fix

Mint the identity token (token-exchange from the login JWT → `audience=<jurisdiction host>`, `scope=openid` — the exact shape the entire.io BFF's `mintJurisdictionToken` uses) and dial the cell directly.

- **Route to the repo's own cell, not the caller's home cell.** The cli layer resolves the repo's placement from the control plane (`coreapi` mirrors for `owner/repo`; `GetRepo` for a ULID) and maps it to a cell `apiUrl` + jurisdiction via `ListClusters` — mirroring how the BFF mints one token per target jurisdiction and fans out to the repo's cell. Resolution is **best-effort with a 5s deadline**: any failure/timeout/ambiguity falls back to home-jurisdiction routing, so the common same-region path can't regress.
- **Staging (partial.to) supported.** Cell-vs-BFF detection is environment-agnostic (a direct cell is any host containing `.api.`); the audience/core follow the `entire.io` / `partial.to` family of the configured host.
- **Local dev fixed.** A loopback discovered core is honored verbatim, so the exchange no longer goes to production.
- **Security.** The login JWT / identity token targets (core + cell `apiUrl`) are affirmatively gated to `https` (loopback / `--insecure-http-auth` excepted); `home_jurisdiction` is validated as a DNS label before URL templating.
- **Clearer errors.** A cross-region `404` and the repo-not-found path tell the user the repo may be homed in another region; a natural-language query against a cell without code search surfaces a clean message.

## Verified live against production

Ran the branch binary with a real login (read-only):

| Command | Result |
|---|---|
| `experts . --repo entireio/cli --json` | **HTTP 200** → `{"repo_full_name":"entireio/cli","source":"db","profiles":[]}` — repo resolved + cell reached, **401 gone** |
| `experts cmd/entire/cli/ --repo entireio/cli` | exit 0, clean "no provenance" (backend has none indexed yet) |
| `experts "…query…" --repo entireio/cli` | clean "code search not available" message (cell 503) |
| `experts . --repo entireio/does-not-exist` | clear region/onboarding/access hint, no 401 |

Empty provenance + query-503 are **backend-side** (entire-api/entiredb work in progress), not this CLI change. The genuine cross-region path routes correctly in code and falls back safely, but wasn't exercised live (no repo homed in another region available).

## Checks

- `go build ./...` clean · `mise run lint` **0 issues** · `mise run test:ci` **green** (unit + integration + e2e canary)
- Three-pass adversarial audit (find → refute → synthesize) seeded with the entire-api cell + entire.io BFF ground truth; the final pass raised 0 medium+ findings.
- Copilot review comments addressed (allowInsecure scoping; duplicate error prefix).

Entire trail: https://entire.io/gh/entireio/cli/trails/715

🤖 Generated with [Claude Code](https://claude.com/claude-code)