### PR TITLE
feat(transcript): externalize images from Codex transcripts

### DIFF
--- a/cmd/entire/cli/integration_test/codex_image_externalize_test.go
+++ b/cmd/entire/cli/integration_test/codex_image_externalize_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
+	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
+	"github.com/entireio/cli/cmd/entire/cli/gitrepo"
+	"github.com/entireio/cli/cmd/entire/cli/paths"
+)
+
+// TestCodexImageExternalization_FullHookFlow is the Codex end-to-end proof: it
+// drives the real Codex hook binary (user-prompt-submit -> apply_patch
+// post-tool-use -> mid-turn commit condensation -> stop finalize) on a Codex
+// rollout transcript that embeds an image as a data-URI, with externalization
+// enabled via settings.local.json. It then asserts the actual
+// entire/checkpoints/v1 ref stores a placeholder (not the raw base64) that
+// survives Codex's SanitizePortableTranscript, writes the asset blob + manifest,
+// and that ReadSessionContent reinjects the image byte-exactly.
+func TestCodexImageExternalization_FullHookFlow(t *testing.T) {
+	env := NewFeatureBranchEnv(t)
+
+	localSettings := filepath.Join(env.RepoDir, ".entire", "settings.local.json")
+	if err := os.WriteFile(localSettings, []byte(`{"redaction":{"externalize_images":true}}`), 0o644); err != nil {
+		t.Fatalf("write settings.local.json: %v", err)
+	}
+
+	// A real, minimal PNG padded past the externalization length threshold.
+	imgBytes := []byte("\x89PNG\r\n\x1a\n" + strings.Repeat("codex-real-e2e-image-payload-", 4))
+	b64 := base64.StdEncoding.EncodeToString(imgBytes)
+
+	sessionID := "codex-image-e2e"
+	transcriptPath := filepath.Join(env.RepoDir, ".entire", "tmp", "codex-rollout.jsonl")
+
+	// A Codex rollout: session meta, then a user message with an inline image
+	// data-URI (the confirmed real format), then an assistant reply.
+	rollout := strings.Join([]string{
+		`{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"id":"` + sessionID + `","cwd":"` + env.RepoDir + `"}}`,
+		`{"timestamp":"2026-01-01T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[` +
+			`{"type":"input_text","text":"add feature.txt and look at this screenshot"},` +
+			`{"type":"input_image","image_url":"data:image/png;base64,` + b64 + `"}` +
+			`]}}`,
+		`{"timestamp":"2026-01-01T00:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}`,
+	}, "\n") + "\n"
+	if err := os.MkdirAll(filepath.Dir(transcriptPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(transcriptPath, []byte(rollout), 0o644); err != nil {
+		t.Fatalf("write rollout: %v", err)
+	}
+
+	runner := NewCodexHookRunner(env.RepoDir, t)
+	hook := func(name string, extra map[string]any) {
+		t.Helper()
+		in := map[string]any{
+			"session_id":      sessionID,
+			"transcript_path": transcriptPath,
+			"cwd":             env.RepoDir,
+			"model":           "gpt-5",
+			"permission_mode": "default",
+		}
+		for k, v := range extra {
+			in[k] = v
+		}
+		b, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("marshal %s input: %v", name, err)
+		}
+		if err := runner.runCodexHook(name, b); err != nil {
+			t.Fatalf("codex hook %s: %v", name, err)
+		}
+	}
+
+	// Turn start (creates the Codex session), then a file-mutating tool use so the
+	// commit has attributable content.
+	hook("user-prompt-submit", map[string]any{"prompt": "add feature.txt and look at this screenshot", "hook_event_name": "UserPromptSubmit"})
+	patch := "*** Begin Patch\n*** Add File: feature.txt\n+hi\n*** End Patch\n"
+	hook("post-tool-use", map[string]any{
+		"hook_event_name": "PostToolUse", "tool_name": "apply_patch",
+		"tool_use_id": "call_1", "tool_input": map[string]string{"command": patch}, "tool_response": "Success.",
+	})
+
+	// Mid-turn commit -> post-commit condensation externalizes; stop -> finalize.
+	env.WriteFile("feature.txt", "hi\n")
+	env.GitCommitWithShadowHooks("add feature.txt", "feature.txt")
+	hook("stop", map[string]any{"hook_event_name": "Stop"})
+
+	if !env.BranchExists(paths.MetadataBranchName) {
+		t.Fatal("entire/checkpoints/v1 should exist after Codex condensation")
+	}
+	cpID := env.GetLatestCheckpointIDFromHistory()
+	if cpID == "" {
+		t.Fatal("no checkpoint id in history")
+	}
+	sessionPath := ShardedCheckpointPath(cpID) + "/0/"
+
+	full, ok := env.ReadFileFromBranch(paths.MetadataBranchName, sessionPath+paths.TranscriptFileName)
+	if !ok {
+		t.Fatalf("full.jsonl missing at %s", sessionPath)
+	}
+	if strings.Contains(full, b64) {
+		t.Error("stored full.jsonl still contains the raw base64 image (externalization did not persist)")
+	}
+	if !strings.Contains(full, "entire-asset:assets/") {
+		t.Error("stored full.jsonl has no image placeholder")
+	}
+	if !strings.Contains(full, "data:image/png;base64,entire-asset:assets/") {
+		t.Error("expected the placeholder inside the data-URI (prefix preserved)")
+	}
+	if _, ok := env.ReadFileFromBranch(paths.MetadataBranchName, sessionPath+paths.AssetsManifestFile); !ok {
+		t.Error("assets/manifest.json missing")
+	}
+
+	// Restore reinjects the image byte-exactly.
+	repo, err := gitrepo.OpenPath(env.RepoDir)
+	if err != nil {
+		t.Fatalf("open repo: %v", err)
+	}
+	defer repo.Close()
+	stores, err := checkpoint.Open(context.Background(), repo, checkpoint.OpenOptions{})
+	if err != nil {
+		t.Fatalf("open stores: %v", err)
+	}
+	checkpointID, err := id.NewCheckpointID(cpID)
+	if err != nil {
+		t.Fatalf("parse checkpoint id: %v", err)
+	}
+	content, err := stores.Persistent.ReadSessionContent(context.Background(), checkpointID, 0)
+	if err != nil {
+		t.Fatalf("ReadSessionContent: %v", err)
+	}
+	if strings.Contains(string(content.Transcript), "entire-asset:assets/") {
+		t.Error("restored transcript still has a placeholder (reinjection failed)")
+	}
+	if !strings.Contains(string(content.Transcript), b64) {
+		t.Error("restored transcript is missing the reinjected base64 image")
+	}
+}

--- a/cmd/entire/cli/transcript/imageextract/codex_test.go
+++ b/cmd/entire/cli/transcript/imageextract/codex_test.go
@@ -1,0 +1,229 @@
+package imageextract
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/entireio/cli/cmd/entire/cli/agent"
+)
+
+// codexImageLine returns a real-format Codex user message embedding one inline
+// image as a data-URI in an input_image content block (compact serialization,
+// matching how the Codex rollout JSONL is written).
+func codexImageLine(b64 string) string {
+	return `{"type":"response_item","payload":{"type":"message","role":"user","content":[` +
+		`{"type":"input_text","text":"<image name=[Image #1]>"},` +
+		`{"type":"input_image","image_url":"data:image/png;base64,` + b64 + `"},` +
+		`{"type":"input_text","text":"</image>"}` +
+		`]}}`
+}
+
+// codexFunctionOutputLine embeds a data-URI inside function_call_output text,
+// the way a screenshot/generated-image tool result appears in the rollout.
+func codexFunctionOutputLine(b64 string) string {
+	return `{"type":"response_item","payload":{"type":"function_call_output","call_id":"call_1",` +
+		`"output":"here is the render: data:image/png;base64,` + b64 + ` done"}}`
+}
+
+func codexPNG(payload string) string {
+	return base64.StdEncoding.EncodeToString([]byte("\x89PNG\r\n\x1a\n" + payload + strings.Repeat("-codex-image-bytes", 3)))
+}
+
+func codexJPEG(payload string) string {
+	return base64.StdEncoding.EncodeToString([]byte("\xFF\xD8\xFF" + payload + strings.Repeat("-codex-image-bytes", 3)))
+}
+
+// The core contract for Codex: extract then reinject reproduces the bytes exactly.
+func TestCodexCodec_RoundTripByteExact(t *testing.T) {
+	t.Parallel()
+	c := CodecFor(agent.AgentTypeCodex)
+	if c == nil {
+		t.Fatal("expected a codec for Codex")
+	}
+	b64 := codexPNG("round-trip")
+	orig := codexImageLine(b64) + "\n" +
+		`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}}` + "\n"
+
+	rewritten, assets, err := c.ExtractImages([]byte(orig))
+	if err != nil {
+		t.Fatalf("ExtractImages: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected 1 asset, got %d", len(assets))
+	}
+	if assets[0].MediaType != mediaTypePNG {
+		t.Errorf("media type = %q, want image/png", assets[0].MediaType)
+	}
+	if strings.Contains(string(rewritten), b64) {
+		t.Error("base64 must be gone from the rewritten transcript")
+	}
+	// The data-URI prefix stays inline; only the base64 value became a placeholder.
+	if !strings.Contains(string(rewritten), "data:image/png;base64,"+placeholderPrefix) {
+		t.Error("expected the placeholder to sit inside the data-URI, prefix preserved")
+	}
+
+	restored, err := c.ReinjectImages(rewritten, lookupFrom(assets))
+	if err != nil {
+		t.Fatalf("ReinjectImages: %v", err)
+	}
+	if string(restored) != orig {
+		t.Fatalf("round trip not byte-exact:\n got: %s\nwant: %s", restored, orig)
+	}
+}
+
+// A data-URI embedded in function_call_output text round-trips too.
+func TestCodexCodec_FunctionOutputDataURIRoundTrips(t *testing.T) {
+	t.Parallel()
+	c := CodecFor(agent.AgentTypeCodex)
+	b64 := codexPNG("tool-output")
+	orig := codexFunctionOutputLine(b64) + "\n"
+
+	rewritten, assets, err := c.ExtractImages([]byte(orig))
+	if err != nil {
+		t.Fatalf("ExtractImages: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected 1 asset, got %d", len(assets))
+	}
+	if strings.Contains(string(rewritten), b64) {
+		t.Error("base64 in tool output should be externalized")
+	}
+	restored, err := c.ReinjectImages(rewritten, lookupFrom(assets))
+	if err != nil {
+		t.Fatalf("ReinjectImages: %v", err)
+	}
+	if string(restored) != orig {
+		t.Fatal("function_call_output round trip not byte-exact")
+	}
+}
+
+// A single message with many images (the real Codex case) round-trips, each a
+// distinct asset.
+func TestCodexCodec_MultipleImagesOneMessage(t *testing.T) {
+	t.Parallel()
+	c := CodecFor(agent.AgentTypeCodex)
+	b1, b2, b3 := codexPNG("one"), codexJPEG("two"), codexPNG("three")
+	orig := `{"type":"response_item","payload":{"type":"message","role":"user","content":[` +
+		`{"type":"input_image","image_url":"data:image/png;base64,` + b1 + `"},` +
+		`{"type":"input_image","image_url":"data:image/jpeg;base64,` + b2 + `"},` +
+		`{"type":"input_image","image_url":"data:image/png;base64,` + b3 + `"}` +
+		`]}}` + "\n"
+
+	rewritten, assets, err := c.ExtractImages([]byte(orig))
+	if err != nil {
+		t.Fatalf("ExtractImages: %v", err)
+	}
+	if len(assets) != 3 {
+		t.Fatalf("expected 3 assets, got %d", len(assets))
+	}
+	// jpeg maps to .jpg extension.
+	var sawJPG bool
+	for _, a := range assets {
+		if strings.HasSuffix(a.Name, ".jpg") {
+			sawJPG = true
+		}
+	}
+	if !sawJPG {
+		t.Error("expected a .jpg asset from the image/jpeg data-URI")
+	}
+	restored, err := c.ReinjectImages(rewritten, lookupFrom(assets))
+	if err != nil {
+		t.Fatalf("ReinjectImages: %v", err)
+	}
+	if string(restored) != orig {
+		t.Fatal("multi-image round trip not byte-exact")
+	}
+}
+
+// Identical images dedupe to one asset but round-trip both occurrences.
+func TestCodexCodec_DedupesIdenticalImages(t *testing.T) {
+	t.Parallel()
+	c := CodecFor(agent.AgentTypeCodex)
+	b64 := codexPNG("same")
+	orig := codexImageLine(b64) + "\n" + codexImageLine(b64) + "\n"
+	rewritten, assets, err := c.ExtractImages([]byte(orig))
+	if err != nil {
+		t.Fatalf("ExtractImages: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("identical images should dedupe to 1 asset, got %d", len(assets))
+	}
+	restored, err := c.ReinjectImages(rewritten, lookupFrom(assets))
+	if err != nil {
+		t.Fatalf("ReinjectImages: %v", err)
+	}
+	if string(restored) != orig {
+		t.Fatal("dedup round trip not byte-exact")
+	}
+}
+
+// A text-only Codex transcript is a no-op.
+func TestCodexCodec_NoImagesIsNoOp(t *testing.T) {
+	t.Parallel()
+	c := CodecFor(agent.AgentTypeCodex)
+	orig := `{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}` + "\n"
+	rewritten, assets, err := c.ExtractImages([]byte(orig))
+	if err != nil {
+		t.Fatalf("ExtractImages: %v", err)
+	}
+	if assets != nil {
+		t.Errorf("expected no assets, got %d", len(assets))
+	}
+	if string(rewritten) != orig {
+		t.Error("text-only transcript should be unchanged")
+	}
+}
+
+// A tiny data-URI (below the externalize threshold) is left inline.
+func TestCodexCodec_LeavesTinyDataURIInline(t *testing.T) {
+	t.Parallel()
+	c := CodecFor(agent.AgentTypeCodex)
+	tiny := base64.StdEncoding.EncodeToString([]byte("tiny"))
+	if len(tiny) >= minExternalizedBase64Len {
+		t.Fatalf("fixture too long: %d", len(tiny))
+	}
+	orig := codexImageLine(tiny) + "\n"
+	rewritten, assets, err := c.ExtractImages([]byte(orig))
+	if err != nil {
+		t.Fatalf("ExtractImages: %v", err)
+	}
+	if len(assets) != 0 || string(rewritten) != orig {
+		t.Errorf("tiny data-URI must be left inline; assets=%d changed=%v", len(assets), string(rewritten) != orig)
+	}
+}
+
+// Ordering: a Codex line carrying both a secret and an image data-URI —
+// extraction lifts the image, leaving the secret for the redaction pass, and the
+// image reinjects cleanly.
+func TestCodexCodec_ExtractLeavesSecretForRedaction(t *testing.T) {
+	t.Parallel()
+	c := CodecFor(agent.AgentTypeCodex)
+	secret := "aB3xK9mQ7pL2wR8tY4vN6cF1gH5jD0sZeW7uI2oP"
+	b64 := codexPNG("secret-plus-image")
+	orig := `{"type":"response_item","payload":{"type":"message","role":"user","content":[` +
+		`{"type":"input_text","text":"token ` + secret + `"},` +
+		`{"type":"input_image","image_url":"data:image/png;base64,` + b64 + `"}` +
+		`]}}` + "\n"
+
+	rewritten, assets, err := c.ExtractImages([]byte(orig))
+	if err != nil {
+		t.Fatalf("ExtractImages: %v", err)
+	}
+	if len(assets) != 1 {
+		t.Fatalf("expected 1 asset, got %d", len(assets))
+	}
+	if strings.Contains(string(rewritten), b64) {
+		t.Error("image should be externalized")
+	}
+	if !strings.Contains(string(rewritten), secret) {
+		t.Error("the secret must remain for the downstream redaction pass")
+	}
+	restored, err := c.ReinjectImages(rewritten, lookupFrom(assets))
+	if err != nil {
+		t.Fatalf("ReinjectImages: %v", err)
+	}
+	if string(restored) != orig {
+		t.Fatal("round trip not byte-exact")
+	}
+}

--- a/cmd/entire/cli/transcript/imageextract/imageextract.go
+++ b/cmd/entire/cli/transcript/imageextract/imageextract.go
@@ -3,8 +3,10 @@
 // path-bearing placeholder, and re-injects them byte-exactly on restore.
 //
 // The transform is per-agent because transcript formats differ: only agents that
-// inline base64 images (Claude Code today) register a codec; every other agent
-// resolves to nil and its transcript flows through untouched (a graceful no-op).
+// inline base64 images (Claude Code and Codex today) register a codec; every
+// other agent resolves to nil and its transcript flows through untouched (a
+// graceful no-op). All codecs share one extraction engine and reinjection routine
+// and differ only in how they *find* images (their collector).
 //
 // Correctness contract: for any transcript x from a supported agent,
 // ReinjectImages(ExtractImages(x)) == x, byte-for-byte. This is achieved by only
@@ -95,6 +97,7 @@ const minExternalizedBase64Len = 64
 
 var codecs = map[types.AgentType]ImageCodec{
 	agent.AgentTypeClaudeCode: claudeCodec{},
+	agent.AgentTypeCodex:      codexCodec{},
 }
 
 // CodecFor returns the image codec for an agent type, or nil if the agent's
@@ -107,13 +110,16 @@ func HasPlaceholders(transcript []byte) bool {
 	return bytes.Contains(transcript, []byte(placeholderPrefix))
 }
 
-// claudeCodec handles Claude Code (and, structurally, Cursor) JSONL transcripts,
-// which embed images as {"type":"image","source":{"type":"base64","media_type":…,"data":…}}.
-type claudeCodec struct{}
-
+// imgHit is one image found by a collector: the bare base64 value to swap out and
+// its declared media type (used only to pick the asset filename extension).
 type imgHit struct{ data, mediaType string }
 
-func (claudeCodec) ExtractImages(transcript []byte) ([]byte, []Asset, error) {
+// extractImagesWith is the shared extraction engine. It parses each JSONL line,
+// gathers image hits via the per-agent collector, dedupes, decodes and re-encodes
+// to confirm the base64 is byte-exactly reversible, then swaps each value out for
+// a placeholder — longest value first (so a value that is a substring of another
+// can't orphan it) and only recording assets whose swap actually replaced bytes.
+func extractImagesWith(transcript []byte, collect func(v any, out *[]imgHit)) ([]byte, []Asset, error) {
 	if len(transcript) == 0 {
 		return transcript, nil, nil
 	}
@@ -126,9 +132,7 @@ func (claudeCodec) ExtractImages(transcript []byte) ([]byte, []Asset, error) {
 
 	for _, line := range bytes.Split(transcript, []byte("\n")) {
 		trimmed := bytes.TrimSpace(line)
-		// Accept object- and array-rooted JSON lines; collectBase64Images walks
-		// both. Claude Code uses object lines today, but the walker's "any nesting"
-		// contract shouldn't be silently undercut by the line filter.
+		// Accept object- and array-rooted JSON lines; the collectors walk both.
 		if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
 			continue
 		}
@@ -137,7 +141,7 @@ func (claudeCodec) ExtractImages(transcript []byte) ([]byte, []Asset, error) {
 			continue // non-JSON line; leave untouched
 		}
 		var hits []imgHit
-		collectBase64Images(v, &hits)
+		collect(v, &hits)
 		for _, h := range hits {
 			if len(h.data) < minExternalizedBase64Len {
 				continue // too small to be a real image; also keeps it out of placeholders
@@ -154,11 +158,20 @@ func (claudeCodec) ExtractImages(transcript []byte) ([]byte, []Asset, error) {
 			if base64.StdEncoding.EncodeToString(raw) != h.data {
 				continue
 			}
-			name, err := uniqueImageName(usedNames, h.mediaType)
+			// Prefer the media type detected from the actual bytes over the declared
+			// one: agents mislabel it (real Codex data-URIs declare image/jpeg for
+			// PNG bytes), and the asset filename/manifest should reflect the content.
+			// This is metadata only — the transcript's declared type is untouched, so
+			// the round trip stays byte-exact.
+			mediaType := detectMediaType(raw)
+			if mediaType == "" {
+				mediaType = h.mediaType
+			}
+			name, err := uniqueImageName(usedNames, mediaType)
 			if err != nil {
 				return transcript, nil, err
 			}
-			seen[h.data] = Asset{Name: name, MediaType: h.mediaType, Data: raw}
+			seen[h.data] = Asset{Name: name, MediaType: mediaType, Data: raw}
 			order = append(order, h.data)
 		}
 	}
@@ -182,12 +195,12 @@ func (claudeCodec) ExtractImages(transcript []byte) ([]byte, []Asset, error) {
 	assets := make([]Asset, 0, len(order))
 	for _, data := range order {
 		a := seen[data]
-		// Swap the base64 value itself, not a "data":"<b64>" wrapper: Claude Code
-		// serializes the image content block both compactly ("data":"<b64>") and
-		// spaced ("data": "<b64>") depending on version, so matching the bare value
-		// is the only format-agnostic anchor. This can also swap a copy of the same
-		// base64 that appears in a text field, but the round trip stays byte-exact
-		// because ReinjectImages restores every occurrence to the identical value.
+		// Swap the base64 value itself, not a field wrapper. Agents serialize the
+		// enclosing JSON differently and across versions (compact vs spaced, string
+		// vs object image_url, data-URI vs bare), so the bare value is the only
+		// format-agnostic anchor. This can also swap a copy of the same base64 in a
+		// text field, but the round trip stays byte-exact because ReinjectImages
+		// restores every occurrence to the identical value.
 		swapped := bytes.ReplaceAll(rewritten, []byte(data), []byte(placeholderPrefix+a.Name))
 		if bytes.Equal(swapped, rewritten) {
 			// Exact bytes weren't present (e.g. JSON-escaped in the raw transcript);
@@ -204,7 +217,10 @@ func (claudeCodec) ExtractImages(transcript []byte) ([]byte, []Asset, error) {
 	return rewritten, assets, nil
 }
 
-func (claudeCodec) ReinjectImages(transcript []byte, lookup func(name string) (Asset, bool)) ([]byte, error) {
+// reinjectImages restores every placeholder to its asset's base64. It is shared
+// by all codecs: the placeholder token is agent-independent, so restore only
+// needs the asset lookup.
+func reinjectImages(transcript []byte, lookup func(name string) (Asset, bool)) ([]byte, error) {
 	if !HasPlaceholders(transcript) {
 		return transcript, nil
 	}
@@ -225,10 +241,35 @@ func (claudeCodec) ReinjectImages(transcript []byte, lookup func(name string) (A
 	return result, nil
 }
 
-// collectBase64Images walks any decoded JSON value and gathers every inline
+// claudeCodec handles Claude Code (and, structurally, Cursor) JSONL transcripts,
+// which embed images as {"type":"image","source":{"type":"base64","media_type":…,"data":…}}.
+type claudeCodec struct{}
+
+func (claudeCodec) ExtractImages(transcript []byte) ([]byte, []Asset, error) {
+	return extractImagesWith(transcript, collectClaudeImages)
+}
+
+func (claudeCodec) ReinjectImages(transcript []byte, lookup func(name string) (Asset, bool)) ([]byte, error) {
+	return reinjectImages(transcript, lookup)
+}
+
+// codexCodec handles OpenAI Codex rollout JSONL transcripts, which embed images
+// as base64 data-URIs (data:image/<type>;base64,<data>) — in input_image
+// image_url values, user messages, and function_call_output content alike.
+type codexCodec struct{}
+
+func (codexCodec) ExtractImages(transcript []byte) ([]byte, []Asset, error) {
+	return extractImagesWith(transcript, collectCodexImages)
+}
+
+func (codexCodec) ReinjectImages(transcript []byte, lookup func(name string) (Asset, bool)) ([]byte, error) {
+	return reinjectImages(transcript, lookup)
+}
+
+// collectClaudeImages walks any decoded JSON value and gathers every inline
 // base64 image block, at any nesting depth (top-level content, tool_result
 // content, etc.).
-func collectBase64Images(v any, out *[]imgHit) {
+func collectClaudeImages(v any, out *[]imgHit) {
 	switch t := v.(type) {
 	case map[string]any:
 		if t["type"] == "image" {
@@ -243,24 +284,75 @@ func collectBase64Images(v any, out *[]imgHit) {
 			}
 		}
 		for _, vv := range t {
-			collectBase64Images(vv, out)
+			collectClaudeImages(vv, out)
 		}
 	case []any:
 		for _, vv := range t {
-			collectBase64Images(vv, out)
+			collectClaudeImages(vv, out)
 		}
+	}
+}
+
+// codexDataURIRe matches an image data-URI and captures (media subtype, base64).
+// Codex serializes every inline image this way — input_image image_url values,
+// user-message content, and function_call_output payloads — so keying on the
+// data-URI (rather than a specific field) covers input and generated/tool images
+// uniformly. The captured group is the bare base64, which is what gets swapped.
+var codexDataURIRe = regexp.MustCompile(`data:image/([a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/]+={0,2})`)
+
+// collectCodexImages walks any decoded JSON value and, for each string leaf,
+// gathers every image data-URI it contains (a leaf may be the URI itself, e.g.
+// input_image.image_url, or embed one inside larger tool output).
+func collectCodexImages(v any, out *[]imgHit) {
+	switch t := v.(type) {
+	case map[string]any:
+		for _, vv := range t {
+			collectCodexImages(vv, out)
+		}
+	case []any:
+		for _, vv := range t {
+			collectCodexImages(vv, out)
+		}
+	case string:
+		for _, m := range codexDataURIRe.FindAllStringSubmatch(t, -1) {
+			*out = append(*out, imgHit{data: m[2], mediaType: "image/" + m[1]})
+		}
+	}
+}
+
+const (
+	mediaTypePNG  = "image/png"
+	mediaTypeJPEG = "image/jpeg"
+	mediaTypeGIF  = "image/gif"
+	mediaTypeWEBP = "image/webp"
+)
+
+// detectMediaType returns the image media type implied by the leading magic
+// bytes, or "" if unrecognized (caller falls back to the declared type).
+func detectMediaType(raw []byte) string {
+	switch {
+	case bytes.HasPrefix(raw, []byte("\x89PNG\r\n\x1a\n")):
+		return mediaTypePNG
+	case bytes.HasPrefix(raw, []byte{0xFF, 0xD8, 0xFF}):
+		return mediaTypeJPEG
+	case bytes.HasPrefix(raw, []byte("GIF87a")), bytes.HasPrefix(raw, []byte("GIF89a")):
+		return mediaTypeGIF
+	case len(raw) >= 12 && bytes.HasPrefix(raw, []byte("RIFF")) && bytes.Equal(raw[8:12], []byte("WEBP")):
+		return mediaTypeWEBP
+	default:
+		return ""
 	}
 }
 
 func extForMedia(mediaType string) string {
 	switch mediaType {
-	case "image/png":
+	case mediaTypePNG:
 		return "png"
-	case "image/jpeg":
+	case mediaTypeJPEG:
 		return "jpg"
-	case "image/gif":
+	case mediaTypeGIF:
 		return "gif"
-	case "image/webp":
+	case mediaTypeWEBP:
 		return "webp"
 	default:
 		return "bin"

--- a/cmd/entire/cli/transcript/imageextract/imageextract_test.go
+++ b/cmd/entire/cli/transcript/imageextract/imageextract_test.go
@@ -55,7 +55,7 @@ func TestClaudeCodec_RoundTripByteExact(t *testing.T) {
 	if !strings.Contains(string(rewritten), placeholderPrefix) {
 		t.Error("rewritten transcript should carry a placeholder")
 	}
-	if assets[0].MediaType != "image/png" {
+	if assets[0].MediaType != mediaTypePNG {
 		t.Errorf("asset media type = %q, want image/png", assets[0].MediaType)
 	}
 
@@ -316,7 +316,7 @@ func TestClaudeCodec_LeavesNonBase64Inline(t *testing.T) {
 // Agents that don't inline images have no codec (graceful no-op upstream).
 func TestCodecFor_NonImageAgentsAreNil(t *testing.T) {
 	t.Parallel()
-	for _, at := range []string{"Codex", "Gemini CLI", "OpenCode", "Pi", "Factory AI Droid", "Copilot CLI"} {
+	for _, at := range []string{"Gemini CLI", "OpenCode", "Pi", "Factory AI Droid", "Copilot CLI"} {
 		if CodecFor(types.AgentType(at)) != nil {
 			t.Errorf("agent %q should not have an image codec yet", at)
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/717
<!-- entire-trail-link-end -->

**Stacked on #1589** (base branch `feat-image-externalize`) — this PR is only the Codex delta.

**What:** Extend image externalization to Codex. Codex rollout JSONL embeds images as base64 data-URIs (`data:image/…;base64,…`) — in `input_image` image_url values, user messages, and `function_call_output` — and inlines multi-MB generated images the same way. This lifts them into per-session checkpoint `assets/` blobs with a placeholder, and reinjects byte-exactly on restore, exactly like the Claude Code codec.

**Why / how it helps:** Codex is a bigger win than Claude here. Real sessions on disk carry 100+ MB of inline image base64; OpenAI's own issue [#22603](https://github.com/openai/codex/issues/22603) reports image-heavy rollouts taking minutes to open. Externalizing shrinks `full.jsonl`, cuts what's pushed to the platform, dedupes identical images, and keeps restore lossless. Also: without externalization, an inline Codex `input_image` base64 (which redaction does *not* skip, since the enclosing type is `input_image`, not `image`) can be mangled by the high-entropy redaction pass — extracting before redaction preserves it.

**How:**
- Refactor the codec into a shared extraction engine + reinject routine that take a per-agent *collector*; codecs now differ only in how they find images.
- New `codexCodec` keyed on the `data:image/…;base64,…` marker (not a specific field), so input, generated, and tool-output images are covered uniformly. The bare base64 value is swapped (the tiny `data:…;base64,` prefix stays inline), so the swap is format-agnostic and byte-exact — the same value-swap contract as Claude.
- Detect the media type from the decoded magic bytes (declared type as fallback): real Codex data-URIs mislabel some PNGs as `image/jpeg`, so the asset filename/manifest should reflect the actual content. Metadata only — the transcript's declared type is untouched, so the round trip stays byte-exact.
- Register `agent.AgentTypeCodex` in the codec map. No changes to condensation/persistence/finalize/settings — that plumbing is agent-agnostic; reuses the same opt-in `redaction.externalize_images` flag.

Codex's `SanitizePortableTranscript` (which runs before `full.jsonl` is chunked) only drops `compaction` lines and strips `reasoning.encrypted_content`; image-bearing message and tool-output lines pass through, so the placeholder survives and the byte-exact contract holds against the stored bytes.

**Testing:**
- `mise run lint` — 0 issues; `mise run test:ci` — unit + integration + Vogon canary green on the committed tree.
- Codec units: data-URI round trip; `function_call_output` embedded data-URI; multiple images in one message (the real Codex case); dedup; text-only no-op; tiny data-URI left inline; media-type detection (jpeg vs png); extract-before-redact ordering (secret redacted, image reinjects). Claude codec unchanged and still passing.
- **Real-data:** ran the codec over real Codex rollouts — 176 images across 12 sessions, every asset valid PNG/JPEG magic, extract→reinject byte-exact, up to ~119 MB saved in one session.
- **Integration (real hook flow):** a Codex session (rollout with a data-URI image) → post-commit condensation → stop finalize → assert the real `entire/checkpoints/v1` `full.jsonl` carries the placeholder (base64 gone), the asset blob + `manifest.json` are written, and `ReadSessionContent` reinjects byte-exact.

**Risk / rollback:** Off by default (opt-in flag), no-op for agents without a codec, reinject is a no-op without placeholders. Revert by reverting the two commits on this branch. Incidental large data-URIs embedded in fetched tool output are also externalized — harmless (still bloat, still lossless).

**Follow-ups:** Cursor/Copilot/others; platform-side web rendering of the stored asset (shared with #1589).
