### PR TITLE
cli: route activity/recap through the entire-api cell client

### DIFF
--- a/cmd/entire/cli/activity_cmd.go
+++ b/cmd/entire/cli/activity_cmd.go
@@ -56,7 +56,7 @@ func newActivityCmd() *cobra.Command {
 }
 
 func runActivity(ctx context.Context, w, errW io.Writer) error {
-	return runAuthenticatedDataAPI(ctx, errW, false, func(ctx context.Context, client *api.Client) error {
+	return runAuthenticatedActivityAPI(ctx, errW, false, func(ctx context.Context, client *api.Client) error {
 		// Non-interactive fallback: piped output or accessibility mode
 		if !interactive.IsTerminalWriter(w) || IsAccessibleMode() {
 			return runActivityStatic(ctx, w, client)

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -116,7 +116,11 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *Cell
 		return nil, err
 	}
 
-	cellBaseURL, err := resolveTargetCellBaseURL(ctx, target, subject.dataOrigin, jurisdiction, coreURL, subject.loginJWT, subject.httpClient)
+	// The home-jurisdiction fallback lists the cluster catalog with loginJWT,
+	// which is signed by the discovered login core — so list there, not at the
+	// templated jurisdiction core (coreURL), which in a multi-core setup could
+	// differ and reject the token. coreURL still governs the token exchange below.
+	cellBaseURL, err := resolveTargetCellBaseURL(ctx, target, subject.dataOrigin, jurisdiction, subject.discoveredCore, subject.loginJWT, subject.httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -306,13 +310,13 @@ func targetJurisdiction(target *CellTarget, loginJWT string) (string, error) {
 }
 
 // resolveJurisdiction picks the jurisdiction to mint for: the explicit override
-// (normalised to a lowercase DNS label) when non-empty, otherwise the subject
-// token's home_jurisdiction claim. The result is validated as a DNS label before
-// it is templated into URLs. Normalising the override means `--jurisdiction US`,
-// `" us "` and `us` all resolve to `us`; the home-fallback claim is already a
-// lowercase label so it is left as-is (an off-spec claim still fails the check).
+// when non-empty, otherwise the subject token's home_jurisdiction claim. Either
+// source is normalised to a lowercase DNS label and validated before it is
+// templated into URLs — `--jurisdiction US`, `" us "` and `us` all resolve to
+// `us`, and an uppercase home_jurisdiction claim routes instead of hard-failing
+// the strict [a-z0-9-] label check.
 func resolveJurisdiction(override, loginJWT string) (string, error) {
-	jurisdiction := strings.ToLower(strings.TrimSpace(override))
+	jurisdiction := strings.TrimSpace(override)
 	if jurisdiction == "" {
 		var err error
 		jurisdiction, err = HomeJurisdictionFromLoginJWT(loginJWT)
@@ -320,6 +324,7 @@ func resolveJurisdiction(override, loginJWT string) (string, error) {
 			return "", err
 		}
 	}
+	jurisdiction = strings.ToLower(strings.TrimSpace(jurisdiction))
 	if jurisdiction == "" {
 		return "", errors.New("login token has no home_jurisdiction claim; cannot route to entire-api cell")
 	}
@@ -330,8 +335,10 @@ func resolveJurisdiction(override, loginJWT string) (string, error) {
 }
 
 // resolveTargetCellBaseURL decides which cell origin to dial. See
-// NewEntireAPICellClient's precedence doc.
-func resolveTargetCellBaseURL(ctx context.Context, target *CellTarget, dataOrigin, jurisdiction, coreURL, loginJWT string, httpClient *http.Client) (string, error) {
+// NewEntireAPICellClient's precedence doc. listCoreURL is the core the
+// home-jurisdiction fallback lists the cluster catalog against; it must be a
+// core that accepts loginJWT (i.e. the discovered login core).
+func resolveTargetCellBaseURL(ctx context.Context, target *CellTarget, dataOrigin, jurisdiction, listCoreURL, loginJWT string, httpClient *http.Client) (string, error) {
 	if target != nil && strings.TrimSpace(target.BaseURL) != "" {
 		return strings.TrimRight(target.BaseURL, "/"), nil
 	}
@@ -339,7 +346,7 @@ func resolveTargetCellBaseURL(ctx context.Context, target *CellTarget, dataOrigi
 		// Already a cell URL, or a loopback local-dev host: keep it verbatim.
 		return strings.TrimRight(dataOrigin, "/"), nil
 	}
-	return resolveCellAPIBaseURL(ctx, coreURL, loginJWT, jurisdiction, httpClient)
+	return resolveCellAPIBaseURL(ctx, listCoreURL, loginJWT, jurisdiction, httpClient)
 }
 
 // isBFFOrigin reports whether origin is a BFF / apex host that fronts multiple
@@ -499,6 +506,13 @@ type clusterListingRow struct {
 	APIURL       string `json:"apiUrl"`
 }
 
+// ErrNoCellForJurisdiction signals that the caller's home jurisdiction has no
+// entire-api cell in the cluster catalog (or its row carries no apiUrl). It is
+// not fatal: callers that also have a data-API path (e.g. activity/recap) treat
+// it as "entire-api isn't serving this region yet" and fall back rather than
+// failing the command. errors.Is unwraps it from the contextual message.
+var ErrNoCellForJurisdiction = errors.New("no entire-api cell configured for jurisdiction")
+
 // resolveCellAPIBaseURL is the home-jurisdiction fallback cell resolver: it
 // lists the caller's clusters and picks the apiUrl for `jurisdiction` (default
 // cluster first). It hand-parses GET /api/v1/clusters rather than reusing the
@@ -545,9 +559,9 @@ func resolveCellAPIBaseURL(ctx context.Context, coreURL, loginJWT, jurisdiction 
 		if sawJurisdiction {
 			// A cluster row exists for the jurisdiction but carries no apiUrl —
 			// a schema/deploy problem, distinct from "no cell for jurisdiction".
-			return "", fmt.Errorf("cluster for jurisdiction %q advertises no apiUrl (entire-api cell not configured?)", jurisdiction)
+			return "", fmt.Errorf("%w %q: cluster advertises no apiUrl (entire-api cell not configured?)", ErrNoCellForJurisdiction, jurisdiction)
 		}
-		return "", fmt.Errorf("no entire-api cell configured for jurisdiction %q", jurisdiction)
+		return "", fmt.Errorf("%w %q", ErrNoCellForJurisdiction, jurisdiction)
 	}
 	chosen := matches[0]
 	for _, row := range matches {

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -547,7 +547,10 @@ func resolveCellAPIBaseURL(ctx context.Context, coreURL, loginJWT, jurisdiction 
 	var matches []clusterListingRow
 	sawJurisdiction := false
 	for _, row := range listing.Clusters {
-		if row.Jurisdiction != jurisdiction {
+		// jurisdiction is already a folded lowercase label (resolveJurisdiction);
+		// fold the catalog row too so a differently-cased row still matches
+		// instead of misreporting "no cell for jurisdiction".
+		if !strings.EqualFold(strings.TrimSpace(row.Jurisdiction), jurisdiction) {
 			continue
 		}
 		sawJurisdiction = true

--- a/cmd/entire/cli/auth/cell_data_api_test.go
+++ b/cmd/entire/cli/auth/cell_data_api_test.go
@@ -173,6 +173,12 @@ func TestTargetJurisdictionRejectsBadLabel(t *testing.T) {
 	if got, err := targetJurisdiction(&CellTarget{Jurisdiction: "eu"}, good); err != nil || got != "eu" {
 		t.Fatalf("targetJurisdiction(target=eu) = %q, %v; want eu, nil", got, err)
 	}
+	// An uppercase JWT claim is case-folded rather than rejected by the strict
+	// lowercase label check.
+	upper := makeJWT(t, fmt.Sprintf(`{"home_jurisdiction":"US","exp":%d}`, time.Now().Add(time.Hour).Unix()))
+	if got, err := targetJurisdiction(nil, upper); err != nil || got != "us" {
+		t.Fatalf("targetJurisdiction(US) = %q, %v; want us, nil", got, err)
+	}
 }
 
 func TestNewEntireAPICellClient_RoutesThroughHomeCell(t *testing.T) {

--- a/cmd/entire/cli/entireapi_client.go
+++ b/cmd/entire/cli/entireapi_client.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+// runAuthenticatedActivityAPI runs fn with an authenticated client for the
+// activity/recap surface. It prefers the caller's home entire-api cell (the same
+// shared client the experts commands use), which serves the /me/* endpoints
+// these commands call.
+//
+// Cell routing is a best-effort upgrade: any failure building the cell client —
+// the region has no cell yet (ErrNoCellForJurisdiction), not logged in, or a
+// discovery/exchange error — falls back to the data API, which also serves
+// /me/* and yields the canonical auth errors (e.g. the "not logged in" hint).
+// This keeps the migration transparent and non-regressive; non-obvious
+// fallbacks are logged for diagnosis. Both backends expose the same /me/* paths,
+// so fn is agnostic to which client it receives.
+func runAuthenticatedActivityAPI(ctx context.Context, errW io.Writer, insecureHTTP bool, fn func(context.Context, *api.Client) error) error {
+	client, err := auth.NewEntireAPICellClient(ctx, insecureHTTP, nil)
+	if err != nil {
+		if !errors.Is(err, auth.ErrNoCellForJurisdiction) {
+			logging.Debug(ctx, "activity/recap: entire-api cell client unavailable, using data API", "error", err.Error())
+		}
+		return runAuthenticatedDataAPI(ctx, errW, insecureHTTP, fn)
+	}
+	return fn(ctx, client)
+}
+
+// forgeToMirrorProvider maps a gitremote forge identifier (e.g. "gh") to the
+// upstream provider the control plane records mirrors under (e.g. "github").
+// entire-api routing only supports GitHub mirrors today.
+func forgeToMirrorProvider(forge string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(forge)) {
+	case "gh", mirrorCloneProviderGitHub:
+		return mirrorCloneProviderGitHub, true
+	default:
+		return "", false
+	}
+}
+
+// currentRepoID best-effort resolves the current repo (its "origin" remote) to
+// the ULID entire-api uses for repo-scoped params — recap's /me/recap?repo=.
+// entire.io/api documents the mirror id as exactly that repo_id (repo_id =
+// mirror_repos.id), and the CLI already lists mirrors via the control plane, so
+// no extra resolution is needed. Any failure returns "" — recap then shows the
+// personal side only rather than erroring.
+func currentRepoID(ctx context.Context) string {
+	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	if err != nil {
+		return ""
+	}
+	provider, ok := forgeToMirrorProvider(forge)
+	if !ok {
+		return ""
+	}
+	c, err := coreapi.New()
+	if err != nil {
+		return ""
+	}
+	mirrors, err := listMirrorsForRepo(ctx, c, provider, strings.ToLower(owner), repo)
+	if err != nil {
+		return ""
+	}
+	return firstActiveRepoID(mirrors)
+}
+
+// firstActiveRepoID returns the id of the repo's first active mirror (the repo
+// id is stable across a repo's placements, so any active one serves). Archived
+// and failed/suspended placements are skipped — they can't answer for the repo.
+func firstActiveRepoID(mirrors []coreapi.Mirror) string {
+	for i := range mirrors {
+		if mirrors[i].IsArchived.Or(false) {
+			continue
+		}
+		if st := mirrors[i].Status.Or(coreapi.MirrorStatusReady); st == coreapi.MirrorStatusFailed || st == coreapi.MirrorStatusSuspended {
+			continue
+		}
+		if id := strings.TrimSpace(mirrors[i].MirrorId); id != "" {
+			return id
+		}
+	}
+	return ""
+}

--- a/cmd/entire/cli/entireapi_client.go
+++ b/cmd/entire/cli/entireapi_client.go
@@ -14,10 +14,11 @@ import (
 	"github.com/entireio/cli/internal/coreapi"
 )
 
-// currentRepoIDTimeout bounds currentRepoID's control-plane lookup. The lookup
-// is best-effort decoration (recap degrades to personal-only without it), so a
-// stalled core must not hang the command — mirror expertsCellResolveTimeout.
-const currentRepoIDTimeout = 5 * time.Second
+// currentRepoRefTimeout bounds currentRepoRef's control-plane lookup. The
+// lookup is best-effort decoration (recap degrades to personal-only without
+// it), so a stalled core must not hang the command — mirror
+// expertsCellResolveTimeout.
+const currentRepoRefTimeout = 5 * time.Second
 
 // runAuthenticatedActivityAPI runs fn with an authenticated client for the
 // activity/recap surface. It prefers the caller's home entire-api cell (the same
@@ -63,33 +64,39 @@ func forgeToMirrorProvider(forge string) (string, bool) {
 	}
 }
 
-// currentRepoID best-effort resolves the current repo (its "origin" remote) to
-// the ULID entire-api uses for repo-scoped params — recap's /me/recap?repo=.
-// entire.io/api documents the mirror id as exactly that repo_id (repo_id =
-// mirror_repos.id), and the CLI already lists mirrors via the control plane, so
-// no extra resolution is needed. Any failure returns "" — recap then shows the
-// personal side only rather than erroring.
-func currentRepoID(ctx context.Context) string {
-	ctx, cancel := context.WithTimeout(ctx, currentRepoIDTimeout)
+// currentRepoRef best-effort resolves the current repo (its "origin" remote)
+// to the ULID entire-api uses for repo-scoped params — recap's /me/recap?repo=
+// — plus the human owner/repo slug for display, from a single remote
+// resolution (the caller needs both; resolving twice would double the git and
+// control-plane work). entire.io/api documents the mirror id as exactly that
+// repo_id (repo_id = mirror_repos.id), and the CLI already lists mirrors via
+// the control plane, so no extra resolution is needed. Any failure returns
+// "", "" — recap then shows the personal side only rather than erroring.
+func currentRepoRef(ctx context.Context) (repoID, repoSlug string) {
+	ctx, cancel := context.WithTimeout(ctx, currentRepoRefTimeout)
 	defer cancel()
 
 	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
-	if err != nil {
-		return ""
+	if err != nil || owner == "" || repo == "" {
+		return "", ""
 	}
 	provider, ok := forgeToMirrorProvider(forge)
 	if !ok {
-		return ""
+		return "", ""
 	}
 	c, err := coreapi.New()
 	if err != nil {
-		return ""
+		return "", ""
 	}
 	mirrors, err := listMirrorsForRepo(ctx, c, provider, strings.ToLower(owner), repo)
 	if err != nil {
-		return ""
+		return "", ""
 	}
-	return firstActiveRepoID(mirrors)
+	repoID = firstActiveRepoID(mirrors)
+	if repoID == "" {
+		return "", ""
+	}
+	return repoID, owner + "/" + repo
 }
 
 // firstActiveRepoID returns the id of the repo's first active mirror (the repo

--- a/cmd/entire/cli/entireapi_client.go
+++ b/cmd/entire/cli/entireapi_client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli/api"
 	"github.com/entireio/cli/cmd/entire/cli/auth"
@@ -12,6 +13,11 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/internal/coreapi"
 )
+
+// currentRepoIDTimeout bounds currentRepoID's control-plane lookup. The lookup
+// is best-effort decoration (recap degrades to personal-only without it), so a
+// stalled core must not hang the command — mirror expertsCellResolveTimeout.
+const currentRepoIDTimeout = 5 * time.Second
 
 // runAuthenticatedActivityAPI runs fn with an authenticated client for the
 // activity/recap surface. It prefers the caller's home entire-api cell (the same
@@ -64,6 +70,9 @@ func forgeToMirrorProvider(forge string) (string, bool) {
 // no extra resolution is needed. Any failure returns "" — recap then shows the
 // personal side only rather than erroring.
 func currentRepoID(ctx context.Context) string {
+	ctx, cancel := context.WithTimeout(ctx, currentRepoIDTimeout)
+	defer cancel()
+
 	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
 	if err != nil {
 		return ""

--- a/cmd/entire/cli/entireapi_client.go
+++ b/cmd/entire/cli/entireapi_client.go
@@ -28,12 +28,21 @@ import (
 func runAuthenticatedActivityAPI(ctx context.Context, errW io.Writer, insecureHTTP bool, fn func(context.Context, *api.Client) error) error {
 	client, err := auth.NewEntireAPICellClient(ctx, insecureHTTP, nil)
 	if err != nil {
-		if !errors.Is(err, auth.ErrNoCellForJurisdiction) {
-			logging.Debug(ctx, "activity/recap: entire-api cell client unavailable, using data API", "error", err.Error())
-		}
+		logCellClientFallback(ctx, err)
 		return runAuthenticatedDataAPI(ctx, errW, insecureHTTP, fn)
 	}
 	return fn(ctx, client)
+}
+
+// logCellClientFallback records, at debug, that an activity/recap command fell
+// back from the entire-api cell to the data API. The expected cases — the
+// region has no cell yet, or the caller isn't logged in — aren't logged: they
+// are normal during rollout and on first use, not diagnosable failures.
+func logCellClientFallback(ctx context.Context, err error) {
+	if errors.Is(err, auth.ErrNoCellForJurisdiction) || errors.Is(err, auth.ErrNotLoggedIn) {
+		return
+	}
+	logging.Debug(ctx, "activity/recap: entire-api cell client unavailable, using data API", "error", err.Error())
 }
 
 // forgeToMirrorProvider maps a gitremote forge identifier (e.g. "gh") to the
@@ -79,10 +88,7 @@ func currentRepoID(ctx context.Context) string {
 // and failed/suspended placements are skipped — they can't answer for the repo.
 func firstActiveRepoID(mirrors []coreapi.Mirror) string {
 	for i := range mirrors {
-		if mirrors[i].IsArchived.Or(false) {
-			continue
-		}
-		if st := mirrors[i].Status.Or(coreapi.MirrorStatusReady); st == coreapi.MirrorStatusFailed || st == coreapi.MirrorStatusSuspended {
+		if !isActiveMirror(mirrors[i]) {
 			continue
 		}
 		if id := strings.TrimSpace(mirrors[i].MirrorId); id != "" {

--- a/cmd/entire/cli/entireapi_client_test.go
+++ b/cmd/entire/cli/entireapi_client_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+func TestForgeToMirrorProvider(t *testing.T) {
+	t.Parallel()
+
+	for _, forge := range []string{"gh", "github", "GitHub", " gh "} {
+		if p, ok := forgeToMirrorProvider(forge); !ok || p != mirrorCloneProviderGitHub {
+			t.Errorf("forgeToMirrorProvider(%q) = (%q, %v), want (%q, true)", forge, p, ok, mirrorCloneProviderGitHub)
+		}
+	}
+	if _, ok := forgeToMirrorProvider("gitlab"); ok {
+		t.Error("forgeToMirrorProvider(gitlab) = ok, want not ok")
+	}
+}
+
+func TestFirstActiveRepoID(t *testing.T) {
+	t.Parallel()
+
+	archived := coreapi.Mirror{MirrorId: "archived", IsArchived: coreapi.NewOptBool(true)}
+	failed := coreapi.Mirror{MirrorId: "failed", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusFailed)}
+	suspended := coreapi.Mirror{MirrorId: "suspended", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusSuspended)}
+	ready := coreapi.Mirror{MirrorId: "ready-ulid", Status: coreapi.NewOptMirrorStatus(coreapi.MirrorStatusReady)}
+	unset := coreapi.Mirror{MirrorId: "unset-status-ulid"} // no status → treated as active
+
+	tests := []struct {
+		name    string
+		mirrors []coreapi.Mirror
+		want    string
+	}{
+		{"none", nil, ""},
+		{"single ready", []coreapi.Mirror{ready}, "ready-ulid"},
+		{"unset status counts as active", []coreapi.Mirror{unset}, "unset-status-ulid"},
+		{"skips archived and unhealthy", []coreapi.Mirror{archived, failed, suspended, ready}, "ready-ulid"},
+		{"all inactive", []coreapi.Mirror{archived, failed, suspended}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := firstActiveRepoID(tt.mirrors); got != tt.want {
+				t.Fatalf("firstActiveRepoID = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
+	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/recap"
 )
@@ -123,7 +124,7 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 	if err != nil {
 		return err
 	}
-	client, err := newRecapClient(ctx, f.insecureHTTP)
+	client, repoSlug, err := newRecapClient(ctx, f.insecureHTTP)
 	if err != nil {
 		if errors.Is(err, api.ErrInsecureHTTP) {
 			fmt.Fprintf(errW, "ENTIRE_API_BASE_URL is set to an insecure http:// URL (%s). Use https:// for production, or pass --insecure-http-auth for local dev.\n", api.BaseURL())
@@ -138,7 +139,6 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 		return err
 	}
 	rangeKey := f.rangeKey()
-	repoSlug := currentRepoSlug(ctx)
 	if f.useTUI(interactive.IsTerminalWriter(w), interactive.CanPromptInteractively(), IsAccessibleMode()) {
 		return runRecapTUI(ctx, client, recapTUIOptions{
 			Range: rangeKey,
@@ -179,7 +179,26 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 // these were all relabelled as keyring read failures via keyringReadError,
 // which sent users on wild goose chases when the keyring was fine and the real
 // problem was downstream.
-func newRecapClient(ctx context.Context, insecureHTTP bool) (*api.Client, error) {
+// newRecapClient returns the recap client and the value to pass as /me/recap's
+// ?repo= (its team/contributors scope): the current repo's ULID when routed to
+// an entire-api cell (which addresses repos by id), or its owner/repo slug on
+// the data API (which addresses them by name). Empty when the current repo
+// can't be resolved — recap then shows the personal side only.
+//
+// It prefers the caller's home entire-api cell (the shared client), falling back
+// to the data API when the region has no cell yet (ErrNoCellForJurisdiction) or
+// the caller isn't logged in — recap tolerates the latter, rendering and letting
+// the server answer 401 rather than hard-failing. Every other failure surfaces.
+func newRecapClient(ctx context.Context, insecureHTTP bool) (*api.Client, string, error) {
+	if client, err := auth.NewEntireAPICellClient(ctx, insecureHTTP, nil); err == nil {
+		return client, currentRepoID(ctx), nil
+	} else if !errors.Is(err, auth.ErrNoCellForJurisdiction) {
+		// Best-effort upgrade: fall back to the data API on any cell failure. Its
+		// path below tolerates a missing login (renders, lets the server 401), so
+		// the not-logged-in case keeps working; log non-obvious failures.
+		logging.Debug(ctx, "recap: entire-api cell client unavailable, using data API", "error", err.Error())
+	}
+
 	if insecureHTTP {
 		auth.EnableInsecureHTTP()
 	}
@@ -189,14 +208,14 @@ func newRecapClient(ctx context.Context, insecureHTTP bool) (*api.Client, error)
 		err = nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if token != "" && !insecureHTTP {
 		if err := api.RequireSecureURL(api.BaseURL()); err != nil {
-			return nil, fmt.Errorf("base URL check: %w", err)
+			return nil, "", fmt.Errorf("base URL check: %w", err)
 		}
 	}
-	return api.NewClient(token), nil
+	return api.NewClient(token), currentRepoSlug(ctx), nil
 }
 
 func handleRecapFetchError(w io.Writer, err error) error {

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -123,7 +123,11 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 	if err != nil {
 		return err
 	}
-	client, repoScope, err := newRecapClient(ctx, f.insecureHTTP)
+	// repoName is the human owner/repo label for the scope line: the ?repo=
+	// scope value is a repo_id ULID when routed to a cell (echoed back verbatim
+	// by the response), which is meaningless to show a user. Both are empty when
+	// no repo query is sent, so an unscoped recap isn't mislabelled.
+	client, repoScope, repoName, err := newRecapClient(ctx, f.insecureHTTP)
 	if err != nil {
 		if errors.Is(err, api.ErrInsecureHTTP) {
 			fmt.Fprintf(errW, "ENTIRE_API_BASE_URL is set to an insecure http:// URL (%s). Use https:// for production, or pass --insecure-http-auth for local dev.\n", api.BaseURL())
@@ -138,14 +142,6 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 		return err
 	}
 	rangeKey := f.rangeKey()
-	// The ?repo= value is a repo_id ULID when routed to a cell, which the recap
-	// response echoes back; show the human owner/repo name instead. Only when
-	// actually scoped (a repo query was sent), so an unscoped recap isn't
-	// mislabelled as scoped to the current repo.
-	repoName := ""
-	if repoScope != "" {
-		repoName = currentRepoSlug(ctx)
-	}
 	if f.useTUI(interactive.IsTerminalWriter(w), interactive.CanPromptInteractively(), IsAccessibleMode()) {
 		return runRecapTUI(ctx, client, recapTUIOptions{
 			Range:    rangeKey,
@@ -188,11 +184,13 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 // these were all relabelled as keyring read failures via keyringReadError,
 // which sent users on wild goose chases when the keyring was fine and the real
 // problem was downstream.
-// newRecapClient returns the recap client and the value to pass as /me/recap's
-// ?repo= (its team/contributors scope): the current repo's ULID when routed to
-// an entire-api cell (which addresses repos by id), or its owner/repo slug on
-// the data API (which addresses them by name). Empty when the current repo
-// can't be resolved — recap then shows the personal side only.
+// newRecapClient returns the recap client, the value to pass as /me/recap's
+// ?repo= (its team/contributors scope), and the repo's owner/repo display name.
+// The scope is the current repo's ULID when routed to an entire-api cell (which
+// addresses repos by id), or its owner/repo slug on the data API (which
+// addresses them by name); both come from one remote/mirror resolution, so the
+// caller never re-resolves for display. Empty when the current repo can't be
+// resolved — recap then shows the personal side only.
 //
 // It prefers the caller's home entire-api cell (the shared client) and falls
 // back to the data API on ANY cell-client failure — the cell path is a
@@ -201,13 +199,14 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 // are silent; unexpected ones are debug-logged (logCellClientFallback). Only
 // failures of the data-API path itself surface — except ErrNotLoggedIn, which
 // recap tolerates, rendering and letting the server answer 401.
-func newRecapClient(ctx context.Context, insecureHTTP bool) (*api.Client, string, error) {
+func newRecapClient(ctx context.Context, insecureHTTP bool) (client *api.Client, repoScope, repoName string, err error) {
 	// Best-effort upgrade: on any cell failure fall back to the data API path
 	// below, which tolerates a missing login (renders, lets the server 401) so
 	// the not-logged-in case keeps working.
 	cellClient, cellErr := auth.NewEntireAPICellClient(ctx, insecureHTTP, nil)
 	if cellErr == nil {
-		return cellClient, currentRepoID(ctx), nil
+		repoID, repoSlug := currentRepoRef(ctx)
+		return cellClient, repoID, repoSlug, nil
 	}
 	logCellClientFallback(ctx, cellErr)
 
@@ -220,14 +219,16 @@ func newRecapClient(ctx context.Context, insecureHTTP bool) (*api.Client, string
 		err = nil
 	}
 	if err != nil {
-		return nil, "", err
+		return nil, "", "", err
 	}
 	if token != "" && !insecureHTTP {
 		if err := api.RequireSecureURL(api.BaseURL()); err != nil {
-			return nil, "", fmt.Errorf("base URL check: %w", err)
+			return nil, "", "", fmt.Errorf("base URL check: %w", err)
 		}
 	}
-	return api.NewClient(token), currentRepoSlug(ctx), nil
+	// The data API scopes by slug, so scope and display name coincide.
+	slug := currentRepoSlug(ctx)
+	return api.NewClient(token), slug, slug, nil
 }
 
 func handleRecapFetchError(w io.Writer, err error) error {

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -138,13 +138,22 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 		return err
 	}
 	rangeKey := f.rangeKey()
+	// The ?repo= value is a repo_id ULID when routed to a cell, which the recap
+	// response echoes back; show the human owner/repo name instead. Only when
+	// actually scoped (a repo query was sent), so an unscoped recap isn't
+	// mislabelled as scoped to the current repo.
+	repoName := ""
+	if repoSlug != "" {
+		repoName = currentRepoSlug(ctx)
+	}
 	if f.useTUI(interactive.IsTerminalWriter(w), interactive.CanPromptInteractively(), IsAccessibleMode()) {
 		return runRecapTUI(ctx, client, recapTUIOptions{
-			Range: rangeKey,
-			View:  mode,
-			Agent: f.agentName(),
-			Repo:  repoSlug,
-			Color: color,
+			Range:    rangeKey,
+			View:     mode,
+			Agent:    f.agentName(),
+			Repo:     repoSlug,
+			RepoName: repoName,
+			Color:    color,
 		})
 	}
 	start, end := rangeKey.Bounds(time.Now())
@@ -153,11 +162,12 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 		return handleRecapFetchError(errW, err)
 	}
 	fmt.Fprint(w, recap.RenderStaticRecap(resp, recap.RenderOptions{
-		Range: rangeKey,
-		View:  mode,
-		Agent: f.agentName(),
-		Width: terminalWidth(w),
-		Color: color,
+		Range:    rangeKey,
+		View:     mode,
+		Agent:    f.agentName(),
+		Width:    terminalWidth(w),
+		Color:    color,
+		RepoName: repoName,
 	}))
 	fmt.Fprintln(w)
 	return nil

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -18,7 +18,6 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/cmd/entire/cli/gitremote"
 	"github.com/entireio/cli/cmd/entire/cli/interactive"
-	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/recap"
 )
@@ -190,14 +189,14 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 // the caller isn't logged in — recap tolerates the latter, rendering and letting
 // the server answer 401 rather than hard-failing. Every other failure surfaces.
 func newRecapClient(ctx context.Context, insecureHTTP bool) (*api.Client, string, error) {
-	if client, err := auth.NewEntireAPICellClient(ctx, insecureHTTP, nil); err == nil {
-		return client, currentRepoID(ctx), nil
-	} else if !errors.Is(err, auth.ErrNoCellForJurisdiction) {
-		// Best-effort upgrade: fall back to the data API on any cell failure. Its
-		// path below tolerates a missing login (renders, lets the server 401), so
-		// the not-logged-in case keeps working; log non-obvious failures.
-		logging.Debug(ctx, "recap: entire-api cell client unavailable, using data API", "error", err.Error())
+	// Best-effort upgrade: on any cell failure fall back to the data API path
+	// below, which tolerates a missing login (renders, lets the server 401) so
+	// the not-logged-in case keeps working.
+	cellClient, cellErr := auth.NewEntireAPICellClient(ctx, insecureHTTP, nil)
+	if cellErr == nil {
+		return cellClient, currentRepoID(ctx), nil
 	}
+	logCellClientFallback(ctx, cellErr)
 
 	if insecureHTTP {
 		auth.EnableInsecureHTTP()

--- a/cmd/entire/cli/recap.go
+++ b/cmd/entire/cli/recap.go
@@ -123,7 +123,7 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 	if err != nil {
 		return err
 	}
-	client, repoSlug, err := newRecapClient(ctx, f.insecureHTTP)
+	client, repoScope, err := newRecapClient(ctx, f.insecureHTTP)
 	if err != nil {
 		if errors.Is(err, api.ErrInsecureHTTP) {
 			fmt.Fprintf(errW, "ENTIRE_API_BASE_URL is set to an insecure http:// URL (%s). Use https:// for production, or pass --insecure-http-auth for local dev.\n", api.BaseURL())
@@ -143,7 +143,7 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 	// actually scoped (a repo query was sent), so an unscoped recap isn't
 	// mislabelled as scoped to the current repo.
 	repoName := ""
-	if repoSlug != "" {
+	if repoScope != "" {
 		repoName = currentRepoSlug(ctx)
 	}
 	if f.useTUI(interactive.IsTerminalWriter(w), interactive.CanPromptInteractively(), IsAccessibleMode()) {
@@ -151,13 +151,13 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 			Range:    rangeKey,
 			View:     mode,
 			Agent:    f.agentName(),
-			Repo:     repoSlug,
+			Repo:     repoScope,
 			RepoName: repoName,
 			Color:    color,
 		})
 	}
 	start, end := rangeKey.Bounds(time.Now())
-	resp, err := recap.FetchMeRecap(ctx, client, start, end, repoSlug, 0)
+	resp, err := recap.FetchMeRecap(ctx, client, start, end, repoScope, 0)
 	if err != nil {
 		return handleRecapFetchError(errW, err)
 	}
@@ -194,10 +194,13 @@ func runRecap(ctx context.Context, w, errW io.Writer, f *recapFlags) error {
 // the data API (which addresses them by name). Empty when the current repo
 // can't be resolved — recap then shows the personal side only.
 //
-// It prefers the caller's home entire-api cell (the shared client), falling back
-// to the data API when the region has no cell yet (ErrNoCellForJurisdiction) or
-// the caller isn't logged in — recap tolerates the latter, rendering and letting
-// the server answer 401 rather than hard-failing. Every other failure surfaces.
+// It prefers the caller's home entire-api cell (the shared client) and falls
+// back to the data API on ANY cell-client failure — the cell path is a
+// best-effort upgrade, so a cell problem must never break a command that worked
+// before it existed. Expected fallbacks (region has no cell yet, not logged in)
+// are silent; unexpected ones are debug-logged (logCellClientFallback). Only
+// failures of the data-API path itself surface — except ErrNotLoggedIn, which
+// recap tolerates, rendering and letting the server answer 401.
 func newRecapClient(ctx context.Context, insecureHTTP bool) (*api.Client, string, error) {
 	// Best-effort upgrade: on any cell failure fall back to the data API path
 	// below, which tolerates a missing login (renders, lets the server 401) so

--- a/cmd/entire/cli/recap/render_static.go
+++ b/cmd/entire/cli/recap/render_static.go
@@ -23,11 +23,16 @@ const (
 )
 
 type RenderOptions struct {
-	Range    RangeKey
-	View     ViewMode
-	Agent    string
-	Width    int
-	Color    bool
+	Range RangeKey
+	View  ViewMode
+	Agent string
+	Width int
+	Color bool
+	// RepoName is the human owner/repo name of the repo the recap is scoped to,
+	// when the caller knows it. It is preferred over the response's repo field
+	// for display: /me/recap identifies the scoped repo by its repo_id ULID
+	// (echoed back verbatim), which is meaningless to show a user.
+	RepoName string
 	Location *time.Location
 }
 
@@ -160,7 +165,7 @@ func renderSummary(resp *MeRecapResponse, opts RenderOptions, width int, styles 
 		lines = append(lines, "", styles.muted.Render("top")+"  "+strings.Join(top, styles.muted.Render(" · ")))
 	}
 	context := []string{plural(len(filteredAgents(resp, opts)), "agent")}
-	if repoScope := repoScopeText(resp); repoScope != "" {
+	if repoScope := repoScopeText(resp, opts.RepoName); repoScope != "" {
 		context = append(context, repoScope)
 	}
 	if !agentFiltered {
@@ -309,7 +314,12 @@ func formatWindowTime(t time.Time) string {
 	return t.Format("Jan 2, 2006 15:04 MST")
 }
 
-func repoScopeText(resp *MeRecapResponse) string {
+func repoScopeText(resp *MeRecapResponse, repoName string) string {
+	// The caller-supplied human name wins when the recap is scoped to one repo:
+	// the response echoes the queried repo_id ULID, not an owner/repo slug.
+	if name := strings.TrimSpace(repoName); name != "" {
+		return "repo " + name
+	}
 	repos := recapRepoNames(resp)
 	switch {
 	case len(repos) == 1:

--- a/cmd/entire/cli/recap/static_server_test.go
+++ b/cmd/entire/cli/recap/static_server_test.go
@@ -7,6 +7,25 @@ import (
 	"time"
 )
 
+func TestRenderStaticRecap_RepoNameOverridesEchoedID(t *testing.T) {
+	t.Parallel()
+	// /me/recap echoes the queried repo_id ULID in Repo; the caller-supplied
+	// human name must be shown instead.
+	resp := &MeRecapResponse{
+		Repo:    ptr("01KSFAN13YPQ0EWBV5KRE7F5HV"),
+		Since:   "2026-05-02T04:00:00Z",
+		Until:   "2026-05-09T04:00:00Z",
+		Summary: Summary{Me: SummaryTotals{Checkpoints: 1}, RepoCount: 1, ActiveDays: 1},
+	}
+	out := RenderStaticRecap(resp, RenderOptions{Range: RangeDay, View: ViewYou, Width: 80, RepoName: "entireio/cli"})
+	if !strings.Contains(out, "repo entireio/cli") {
+		t.Errorf("expected human repo name in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "01KSFAN13YPQ0EWBV5KRE7F5HV") {
+		t.Errorf("expected the repo_id ULID to be hidden, got:\n%s", out)
+	}
+}
+
 func TestRenderStaticRecap_ServerBackedBoth90(t *testing.T) {
 	t.Parallel()
 	resp := &MeRecapResponse{

--- a/cmd/entire/cli/recap_tui.go
+++ b/cmd/entire/cli/recap_tui.go
@@ -21,7 +21,10 @@ type recapTUIOptions struct {
 	View  recap.ViewMode
 	Agent string
 	Repo  string
-	Color bool
+	// RepoName is the human owner/repo display name for the scoped repo; Repo is
+	// the ?repo= query value (a repo_id ULID when routed to a cell).
+	RepoName string
+	Color    bool
 }
 
 type recapDataMsg struct {
@@ -35,9 +38,10 @@ type recapErrMsg struct {
 }
 
 type recapTUIModel struct {
-	ctx    context.Context
-	client *api.Client
-	repo   string
+	ctx      context.Context
+	client   *api.Client
+	repo     string
+	repoName string
 
 	rangeKey recap.RangeKey
 	view     recap.ViewMode
@@ -77,6 +81,7 @@ func newRecapTUIModel(ctx context.Context, client *api.Client, opts recapTUIOpti
 		ctx:       ctx,
 		client:    client,
 		repo:      opts.Repo,
+		repoName:  opts.RepoName,
 		rangeKey:  opts.Range,
 		view:      opts.View,
 		agent:     opts.Agent,
@@ -244,11 +249,12 @@ func (m recapTUIModel) withViewport() recapTUIModel {
 	}
 	if m.resp != nil {
 		m.viewport.SetContent(recap.RenderStaticRecap(m.resp, recap.RenderOptions{
-			Range: m.rangeKey,
-			View:  m.view,
-			Agent: m.agent,
-			Width: m.width,
-			Color: m.color,
+			Range:    m.rangeKey,
+			View:     m.view,
+			Agent:    m.agent,
+			Width:    m.width,
+			Color:    m.color,
+			RepoName: m.repoName,
 		}))
 	}
 	return m


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/719
<!-- entire-trail-link-end -->

Routes `entire activity` and `entire recap` to the per-cell entire-api product API, reusing the shared cell-routing client that landed with the experts work (#1588) rather than a parallel mechanism. Both commands call the `/me/*` endpoints entire-api serves, so this is a routing change, not a response rewrite.

## What changed

- **`activity` and `recap` go through `auth.NewEntireAPICellClient`** (home-jurisdiction routing, `target=nil`) — one routing/token path across the CLI.
- **Best-effort upgrade with data-API fallback.** Any failure building the cell client (region has no cell yet, not logged in, discovery/exchange error) falls back to the data API, which also serves `/me/*` and yields the canonical auth errors. Existing users are unaffected until their region has a cell; `recap` keeps its render-through-401 behaviour via that fallback.
- **recap's team column keeps working.** `/me/recap?repo=` wants a repo ULID; entire.io/api documents the mirror id as exactly that `repo_id`, and the CLI already lists mirrors — so `currentRepoID` resolves it best-effort (empty → personal recap only), no extra resolution service needed.

## Review nits folded in (from the #1588 review)

- Case-fold the `home_jurisdiction` JWT claim before the strict label check, so an uppercase claim routes instead of hard-failing.
- Home-jurisdiction fallback lists the cluster catalog against the discovered login core (which signs the login JWT), not the templated jurisdiction core.
- Added `ErrNoCellForJurisdiction` sentinel so callers can degrade cleanly.

## Cleanups

- Extracted `isActiveMirror` — the archived + failed/suspended placement filter previously duplicated between `firstActiveRepoID` and `distinctActiveClusterHosts`.
- Extracted `logCellClientFallback` for the two cell→data-API call sites.

## Testing

`mise run test:ci` green — unit + integration + both E2E canary suites (Vogon 59/59, roger-roger 4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 21ff7f24054619261e85cfa98187bcddf5689b81. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->