### PR TITLE
fix(lint): resolve goconst findings for checkpoint/trail

### DIFF
--- a/cmd/entire/cli/review_context.go
+++ b/cmd/entire/cli/review_context.go
@@ -379,10 +379,7 @@ func truncateReviewContextText(value string) string {
 }
 
 func reviewContextCheckpointNoun(count int) string {
-	if count == 1 {
-		return "checkpoint"
-	}
-	return "checkpoints"
+	return pluralize("checkpoint", count)
 }
 
 func reviewContextCommitMessages(ctx context.Context, repoRoot string, scopeBaseRef string, maxCommits int) ([]string, bool, error) {

--- a/cmd/entire/cli/runner_gather.go
+++ b/cmd/entire/cli/runner_gather.go
@@ -25,6 +25,13 @@ const (
 	tuneMaxTrailsForFindings = 8  // trails to pull findings from in the trails tier
 )
 
+const (
+	sourceCheckpoint  = "checkpoint"
+	sourceCheckpoints = "checkpoints"
+	sourceTrail       = "trail"
+	sourceTrails      = "trails"
+)
+
 // tuneSources selects which data tiers gatherTuningContext collects.
 type tuneSources struct {
 	repo        bool
@@ -52,9 +59,9 @@ func parseTuneSources(list []string) (tuneSources, error) {
 			s.repo = true
 		case "pr", "prs", "issue", "issues":
 			s.prs = true
-		case "checkpoint", "checkpoints":
+		case sourceCheckpoint, sourceCheckpoints:
 			s.checkpoints = true
-		case "trail", "trails":
+		case sourceTrail, sourceTrails:
 			s.trails = true
 		default:
 			return s, fmt.Errorf("unknown source %q (valid: repo, prs, checkpoints, trails, all)", item)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/720
<!-- entire-trail-link-end -->

## Why

Recent refactors (notably moving `trail tune` into `entire runner setup`) added new occurrences of the repeated string literals `"checkpoint"` and `"trail"`, pushing each past goconst's occurrence threshold. This broke the lint step in CI.

## What changed

- `reviewContextCheckpointNoun` now delegates to the existing `pluralize` helper instead of hand-rolling the singular/plural branch, removing a duplicated helper.
- The tune-source tokens in `parseTuneSources` are named as constants (`sourceCheckpoint`, `sourceCheckpoints`, `sourceTrail`, `sourceTrails`) and referenced in the parse switch.

No behavior change; `mise run lint` is clean and the tune-source tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical lint fixes only; pluralization and tune-source parsing semantics stay the same.
> 
> **Overview**
> Satisfies **goconst** after repeated `"checkpoint"` / `"trail"` literals crossed the lint threshold (e.g. from runner tune work), with no intended behavior change.
> 
> **`review_context.go`:** `reviewContextCheckpointNoun` now calls the shared `pluralize("checkpoint", count)` helper instead of an inline singular/plural branch.
> 
> **`runner_gather.go`:** Tune-source CLI tokens are defined as `sourceCheckpoint`, `sourceCheckpoints`, `sourceTrail`, and `sourceTrails`, and `parseTuneSources` matches those constants in its switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77cada39c0b5ec373136e16d9ffebed28cd8994a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->