### PR TITLE
Add agent-safe review findings fallback

### DIFF
--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -150,7 +150,7 @@ To tag an already-finished session as a review, use
 			if len(args) > 1 {
 				return fmt.Errorf("accepts at most one argument, received %d", len(args))
 			}
-			if len(args) == 1 && profileOverride != "" {
+			if len(args) == 1 && profileOverride != "" && !findings {
 				return errors.New("pass profile either positionally or with --profile, not both")
 			}
 			return nil
@@ -188,9 +188,13 @@ To tag an already-finished session as a review, use
 			if modelOverride != "" && agentOverride == "" {
 				return errors.New("--model requires --agent (the model applies to a single reviewer)")
 			}
-			profileName := profileOverride
+			positionalArg := ""
 			if len(args) == 1 {
-				profileName = args[0]
+				positionalArg = args[0]
+			}
+			profileName := profileOverride
+			if positionalArg != "" && !findings {
+				profileName = positionalArg
 			}
 			if configure {
 				return runReviewConfigure(ctx, cmd, profileName, reviewConfigureOptions{
@@ -217,7 +221,7 @@ To tag an already-finished session as a review, use
 				return RunReviewProfileConfigPicker(ctx, cmd.OutOrStdout(), deps.GetAgentsWithHooksInstalled, profileName)
 			}
 			if findings {
-				return runReviewFindings(ctx, cmd, profileName, deps.NewSilentError)
+				return runReviewFindings(ctx, cmd, positionalArg, deps.NewSilentError)
 			}
 			// Map the flag to the RunConfig timeout convention: a non-positive
 			// value (the user passed --timeout 0) means "disable", encoded as the

--- a/cmd/entire/cli/review/cmd.go
+++ b/cmd/entire/cli/review/cmd.go
@@ -126,7 +126,7 @@ Flags:
   --set-slot     with --configure: a reviewer slot as agent[=model] (repeatable;
                  the same agent/model may repeat to run it multiple times)
   --edit         re-open the advanced profile skill picker
-  --findings     browse local findings
+  --findings     browse local findings; pass a handle to print one saved run
   --agent NAME   run only one reviewer from the selected profile
   --list         list configured review profiles (their reviewers and judge)
   --agents       list the reviewer agents you can pass to --agent for the profile
@@ -204,10 +204,20 @@ To tag an already-finished session as a review, use
 				}, deps)
 			}
 			if edit {
+				if !interactive.IsTerminalWriter(cmd.OutOrStdout()) || !interactive.CanPromptInteractively() {
+					err := errors.New("--edit requires an interactive terminal")
+					cmd.SilenceUsage = true
+					fmt.Fprintln(cmd.ErrOrStderr(), "--edit requires an interactive terminal.")
+					fmt.Fprintln(cmd.ErrOrStderr(), "Inspect current profiles with:")
+					fmt.Fprintln(cmd.ErrOrStderr(), "  entire review --list")
+					fmt.Fprintln(cmd.ErrOrStderr(), "For non-interactive changes, use:")
+					fmt.Fprintln(cmd.ErrOrStderr(), "  entire review --configure --set-agents <agent>[,<agent>] [--set-judge <agent>]")
+					return wrapReviewSilentError(deps.NewSilentError, err)
+				}
 				return RunReviewProfileConfigPicker(ctx, cmd.OutOrStdout(), deps.GetAgentsWithHooksInstalled, profileName)
 			}
 			if findings {
-				return runReviewFindings(ctx, cmd, deps.NewSilentError)
+				return runReviewFindings(ctx, cmd, profileName, deps.NewSilentError)
 			}
 			// Map the flag to the RunConfig timeout convention: a non-positive
 			// value (the user passed --timeout 0) means "disable", encoded as the
@@ -227,7 +237,7 @@ To tag an already-finished session as a review, use
 	cmd.Flags().StringArrayVar(&setModels, "set-model", nil, "with --configure: per-reviewer model as agent=model (repeatable)")
 	cmd.Flags().StringArrayVar(&setSlots, "set-slot", nil, "with --configure: a reviewer slot as agent[=model] (repeatable; same agent/model may repeat)")
 	cmd.Flags().BoolVar(&edit, "edit", false, "re-open the advanced review profile skill picker")
-	cmd.Flags().BoolVar(&findings, "findings", false, "browse local review findings")
+	cmd.Flags().BoolVar(&findings, "findings", false, "browse local review findings; pass a handle to print one saved run")
 	cmd.Flags().BoolVar(&listAgents, "agents", false, "list the reviewer agents you can pass to --agent for the selected profile")
 	cmd.Flags().BoolVar(&listModels, "models", false, "list the models each review agent advertises (optionally filtered by --agent)")
 	cmd.Flags().BoolVar(&listProfiles, "list", false, "list configured review profiles (reviewers and judge)")

--- a/cmd/entire/cli/review/cmd_test.go
+++ b/cmd/entire/cli/review/cmd_test.go
@@ -398,6 +398,26 @@ func TestRunReview_BareNonInteractiveRequiresProfile(t *testing.T) {
 	}
 }
 
+func TestReviewEditNonInteractiveRefusesWithScriptedAlternatives(t *testing.T) {
+	setupCmdTestRepo(t)
+
+	rootCmd := cli.NewRootCmd()
+	errBuf := &bytes.Buffer{}
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs([]string{"review", "--edit"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected non-interactive --edit to fail")
+	}
+	got := errBuf.String()
+	for _, want := range []string{"--edit requires an interactive terminal", "entire review --configure --set-agents", "entire review --list"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("--edit error missing %q:\n%s", want, got)
+		}
+	}
+}
+
 // TestRunReview_FlagOverrideSkipsPicker verifies that --agent flag bypasses
 // the interactive picker even when multiple eligible agents are configured.
 func TestRunReview_FlagOverrideSkipsPicker(t *testing.T) {

--- a/cmd/entire/cli/review/fix.go
+++ b/cmd/entire/cli/review/fix.go
@@ -31,11 +31,18 @@ func runReviewFindings(ctx context.Context, cmd *cobra.Command, handle string, s
 	if err != nil {
 		return err
 	}
+	handle = strings.TrimSpace(handle)
 	if len(manifests) == 0 {
+		if handle != "" {
+			err := fmt.Errorf("no local review findings match %q", handle)
+			cmd.SilenceUsage = true
+			fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+			return wrapReviewSilentError(silentErr, err)
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), "No local review findings found.")
 		return nil
 	}
-	if handle = strings.TrimSpace(handle); handle != "" {
+	if handle != "" {
 		manifest, findErr := findReviewManifestByHandle(manifests, handle)
 		if findErr != nil {
 			cmd.SilenceUsage = true
@@ -117,7 +124,7 @@ func writeReviewCompletionFooter(w io.Writer, manifest LocalReviewManifest) {
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Browse findings:")
-	fmt.Fprintf(w, "  %s --findings %s\n", reviewCommandBinary, handle)
+	fmt.Fprintf(w, "  %s\n", reviewFindingsCommand(handle))
 }
 
 func reviewManifestHandle(manifest LocalReviewManifest) string {
@@ -138,9 +145,17 @@ func printReviewFindingsList(w io.Writer, manifests []LocalReviewManifest) {
 	for _, manifest := range manifests {
 		fmt.Fprintf(w, "%s\n", reviewManifestListLabel(manifest))
 		if handle := reviewManifestHandle(manifest); handle != "" {
-			fmt.Fprintf(w, "  view: %s --findings %s\n", reviewCommandBinary, handle)
+			fmt.Fprintf(w, "  view: %s\n", reviewFindingsCommand(handle))
 		}
 	}
+}
+
+func reviewFindingsCommand(handle string) string {
+	return fmt.Sprintf("%s --findings %s", reviewCommandBinary, quoteReviewFindingsHandle(handle))
+}
+
+func quoteReviewFindingsHandle(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 func printReviewFindingsHandles(w io.Writer, manifests []LocalReviewManifest) {

--- a/cmd/entire/cli/review/fix.go
+++ b/cmd/entire/cli/review/fix.go
@@ -112,7 +112,7 @@ func reviewPickerHeight(optionCount int) int {
 func writeReviewCompletionFooter(w io.Writer, manifest LocalReviewManifest) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Review complete.")
-	handle := reviewManifestHandle(manifest)
+	handle := reviewManifestCompletionHandle(manifest)
 	if handle == "" {
 		return
 	}
@@ -128,12 +128,19 @@ func reviewManifestHandle(manifest LocalReviewManifest) string {
 	return ""
 }
 
+func reviewManifestCompletionHandle(manifest LocalReviewManifest) string {
+	if !manifest.CreatedAt.IsZero() {
+		return reviewManifestTimeHandle(manifest.CreatedAt)
+	}
+	return reviewManifestHandle(manifest)
+}
+
 func printReviewFindingsList(w io.Writer, manifests []LocalReviewManifest) {
 	fmt.Fprintln(w, "Review Findings")
 	fmt.Fprintln(w)
 	for _, manifest := range manifests {
 		fmt.Fprintf(w, "%s\n", reviewManifestListLabel(manifest))
-		if handle := reviewManifestHandle(manifest); handle != "" {
+		if handle := reviewManifestViewHandle(manifest, manifests); handle != "" {
 			fmt.Fprintf(w, "  view: %s\n", reviewFindingsCommand(handle))
 		}
 	}
@@ -145,11 +152,7 @@ func reviewFindingsCommand(handle string) string {
 }
 
 func printReviewFindingsHandles(w io.Writer, manifests []LocalReviewManifest) {
-	var handles []string
-	for _, manifest := range manifests {
-		handles = append(handles, reviewManifestHandles(manifest)...)
-	}
-	handles = dedupeStrings(handles)
+	handles := reviewAvailableManifestHandles(manifests)
 	if len(handles) == 0 {
 		return
 	}
@@ -157,6 +160,39 @@ func printReviewFindingsHandles(w io.Writer, manifests []LocalReviewManifest) {
 	for _, handle := range handles {
 		fmt.Fprintf(w, "  view: %s\n", reviewFindingsCommand(handle))
 	}
+}
+
+func reviewManifestViewHandle(manifest LocalReviewManifest, manifests []LocalReviewManifest) string {
+	counts := reviewManifestHandleCounts(manifests)
+	for _, handle := range reviewManifestHandles(manifest) {
+		if counts[handle] == 1 {
+			return handle
+		}
+	}
+	return ""
+}
+
+func reviewAvailableManifestHandles(manifests []LocalReviewManifest) []string {
+	counts := reviewManifestHandleCounts(manifests)
+	var handles []string
+	for _, manifest := range manifests {
+		for _, handle := range reviewManifestHandles(manifest) {
+			if counts[handle] == 1 {
+				handles = append(handles, handle)
+			}
+		}
+	}
+	return dedupeStrings(handles)
+}
+
+func reviewManifestHandleCounts(manifests []LocalReviewManifest) map[string]int {
+	counts := make(map[string]int)
+	for _, manifest := range manifests {
+		for _, handle := range reviewManifestHandles(manifest) {
+			counts[handle]++
+		}
+	}
+	return counts
 }
 
 func printReviewManifestDetail(w io.Writer, manifest LocalReviewManifest) {

--- a/cmd/entire/cli/review/fix.go
+++ b/cmd/entire/cli/review/fix.go
@@ -32,16 +32,6 @@ func runReviewFindings(ctx context.Context, cmd *cobra.Command, handle string, s
 		return err
 	}
 	handle = strings.TrimSpace(handle)
-	if len(manifests) == 0 {
-		if handle != "" {
-			err := fmt.Errorf("no local review findings match %q", handle)
-			cmd.SilenceUsage = true
-			fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
-			return wrapReviewSilentError(silentErr, err)
-		}
-		fmt.Fprintln(cmd.OutOrStdout(), "No local review findings found.")
-		return nil
-	}
 	if handle != "" {
 		manifest, findErr := findReviewManifestByHandle(manifests, handle)
 		if findErr != nil {
@@ -51,6 +41,10 @@ func runReviewFindings(ctx context.Context, cmd *cobra.Command, handle string, s
 			return wrapReviewSilentError(silentErr, findErr)
 		}
 		printReviewManifestDetail(cmd.OutOrStdout(), manifest)
+		return nil
+	}
+	if len(manifests) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No local review findings found.")
 		return nil
 	}
 	if interactive.IsTerminalWriter(cmd.OutOrStdout()) && interactive.CanPromptInteractively() {
@@ -128,13 +122,8 @@ func writeReviewCompletionFooter(w io.Writer, manifest LocalReviewManifest) {
 }
 
 func reviewManifestHandle(manifest LocalReviewManifest) string {
-	for _, source := range manifest.Sources {
-		if source.SessionID != "" {
-			return source.SessionID
-		}
-	}
-	if !manifest.CreatedAt.IsZero() {
-		return reviewManifestTimeHandle(manifest.CreatedAt)
+	if handles := reviewManifestHandles(manifest); len(handles) > 0 {
+		return handles[0]
 	}
 	return ""
 }
@@ -151,21 +140,22 @@ func printReviewFindingsList(w io.Writer, manifests []LocalReviewManifest) {
 }
 
 func reviewFindingsCommand(handle string) string {
-	return fmt.Sprintf("%s --findings %s", reviewCommandBinary, quoteReviewFindingsHandle(handle))
-}
-
-func quoteReviewFindingsHandle(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+	quoted := "'" + strings.ReplaceAll(handle, "'", "'\\''") + "'"
+	return fmt.Sprintf("%s --findings %s", reviewCommandBinary, quoted)
 }
 
 func printReviewFindingsHandles(w io.Writer, manifests []LocalReviewManifest) {
-	handles := reviewManifestHandleList(manifests)
+	var handles []string
+	for _, manifest := range manifests {
+		handles = append(handles, reviewManifestHandles(manifest)...)
+	}
+	handles = dedupeStrings(handles)
 	if len(handles) == 0 {
 		return
 	}
 	fmt.Fprintln(w, "Available findings:")
 	for _, handle := range handles {
-		fmt.Fprintf(w, "  %s\n", handle)
+		fmt.Fprintf(w, "  view: %s\n", reviewFindingsCommand(handle))
 	}
 }
 
@@ -228,38 +218,17 @@ func reviewManifestHasHandle(manifest LocalReviewManifest, handle string) bool {
 	return slices.Contains(reviewManifestHandles(manifest), handle)
 }
 
-func reviewManifestHandleList(manifests []LocalReviewManifest) []string {
-	handles := []string{}
-	for _, manifest := range manifests {
-		for _, handle := range reviewManifestHandles(manifest) {
-			if slices.Contains(handles, handle) {
-				continue
-			}
-			handles = append(handles, handle)
-		}
-	}
-	return handles
-}
-
 func reviewManifestHandles(manifest LocalReviewManifest) []string {
-	handles := []string{}
-	add := func(handle string) {
-		handle = strings.TrimSpace(handle)
-		if handle == "" {
-			return
-		}
-		if slices.Contains(handles, handle) {
-			return
-		}
-		handles = append(handles, handle)
-	}
+	var handles []string
 	for _, source := range manifest.Sources {
-		add(source.SessionID)
+		if id := strings.TrimSpace(source.SessionID); id != "" {
+			handles = append(handles, id)
+		}
 	}
 	if !manifest.CreatedAt.IsZero() {
-		add(reviewManifestTimeHandle(manifest.CreatedAt))
+		handles = append(handles, reviewManifestTimeHandle(manifest.CreatedAt))
 	}
-	return handles
+	return dedupeStrings(handles)
 }
 
 func reviewManifestTimeHandle(t time.Time) string {

--- a/cmd/entire/cli/review/fix.go
+++ b/cmd/entire/cli/review/fix.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
+	"time"
 
 	"charm.land/huh/v2"
 	"github.com/spf13/cobra"
@@ -18,7 +20,7 @@ import (
 
 const reviewCommandBinary = "entire review"
 
-func runReviewFindings(ctx context.Context, cmd *cobra.Command, silentErr func(error) error) error {
+func runReviewFindings(ctx context.Context, cmd *cobra.Command, handle string, silentErr func(error) error) error {
 	worktreeRoot, err := paths.WorktreeRoot(ctx)
 	if err != nil {
 		cmd.SilenceUsage = true
@@ -33,6 +35,17 @@ func runReviewFindings(ctx context.Context, cmd *cobra.Command, silentErr func(e
 		fmt.Fprintln(cmd.OutOrStdout(), "No local review findings found.")
 		return nil
 	}
+	if handle = strings.TrimSpace(handle); handle != "" {
+		manifest, findErr := findReviewManifestByHandle(manifests, handle)
+		if findErr != nil {
+			cmd.SilenceUsage = true
+			fmt.Fprintln(cmd.ErrOrStderr(), findErr.Error())
+			printReviewFindingsHandles(cmd.ErrOrStderr(), manifests)
+			return wrapReviewSilentError(silentErr, findErr)
+		}
+		printReviewManifestDetail(cmd.OutOrStdout(), manifest)
+		return nil
+	}
 	if interactive.IsTerminalWriter(cmd.OutOrStdout()) && interactive.CanPromptInteractively() {
 		manifest, pickErr := promptForReviewManifest(ctx, manifests)
 		if pickErr != nil {
@@ -43,6 +56,23 @@ func runReviewFindings(ctx context.Context, cmd *cobra.Command, silentErr func(e
 	}
 	printReviewFindingsList(cmd.OutOrStdout(), manifests)
 	return nil
+}
+
+func findReviewManifestByHandle(manifests []LocalReviewManifest, handle string) (LocalReviewManifest, error) {
+	var matched []LocalReviewManifest
+	for _, manifest := range manifests {
+		if reviewManifestHasHandle(manifest, handle) {
+			matched = append(matched, manifest)
+		}
+	}
+	switch len(matched) {
+	case 0:
+		return LocalReviewManifest{}, fmt.Errorf("no local review findings match %q", handle)
+	case 1:
+		return matched[0], nil
+	default:
+		return LocalReviewManifest{}, fmt.Errorf("local review findings handle %q is ambiguous", handle)
+	}
 }
 
 func wrapReviewSilentError(silentErr func(error) error, err error) error {
@@ -81,12 +111,13 @@ func reviewPickerHeight(optionCount int) int {
 func writeReviewCompletionFooter(w io.Writer, manifest LocalReviewManifest) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Review complete.")
-	if reviewManifestHandle(manifest) == "" {
+	handle := reviewManifestHandle(manifest)
+	if handle == "" {
 		return
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Browse findings:")
-	fmt.Fprintf(w, "  %s --findings\n", reviewCommandBinary)
+	fmt.Fprintf(w, "  %s --findings %s\n", reviewCommandBinary, handle)
 }
 
 func reviewManifestHandle(manifest LocalReviewManifest) string {
@@ -94,6 +125,9 @@ func reviewManifestHandle(manifest LocalReviewManifest) string {
 		if source.SessionID != "" {
 			return source.SessionID
 		}
+	}
+	if !manifest.CreatedAt.IsZero() {
+		return reviewManifestTimeHandle(manifest.CreatedAt)
 	}
 	return ""
 }
@@ -103,6 +137,20 @@ func printReviewFindingsList(w io.Writer, manifests []LocalReviewManifest) {
 	fmt.Fprintln(w)
 	for _, manifest := range manifests {
 		fmt.Fprintf(w, "%s\n", reviewManifestListLabel(manifest))
+		if handle := reviewManifestHandle(manifest); handle != "" {
+			fmt.Fprintf(w, "  view: %s --findings %s\n", reviewCommandBinary, handle)
+		}
+	}
+}
+
+func printReviewFindingsHandles(w io.Writer, manifests []LocalReviewManifest) {
+	handles := reviewManifestHandleList(manifests)
+	if len(handles) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "Available findings:")
+	for _, handle := range handles {
+		fmt.Fprintf(w, "  %s\n", handle)
 	}
 }
 
@@ -159,4 +207,46 @@ func reviewManifestPreview(manifest LocalReviewManifest) string {
 		return stringutil.TruncateRunes(strings.Join(strings.Fields(text), " "), 70, "...")
 	}
 	return ""
+}
+
+func reviewManifestHasHandle(manifest LocalReviewManifest, handle string) bool {
+	return slices.Contains(reviewManifestHandles(manifest), handle)
+}
+
+func reviewManifestHandleList(manifests []LocalReviewManifest) []string {
+	handles := []string{}
+	for _, manifest := range manifests {
+		for _, handle := range reviewManifestHandles(manifest) {
+			if slices.Contains(handles, handle) {
+				continue
+			}
+			handles = append(handles, handle)
+		}
+	}
+	return handles
+}
+
+func reviewManifestHandles(manifest LocalReviewManifest) []string {
+	handles := []string{}
+	add := func(handle string) {
+		handle = strings.TrimSpace(handle)
+		if handle == "" {
+			return
+		}
+		if slices.Contains(handles, handle) {
+			return
+		}
+		handles = append(handles, handle)
+	}
+	for _, source := range manifest.Sources {
+		add(source.SessionID)
+	}
+	if !manifest.CreatedAt.IsZero() {
+		add(reviewManifestTimeHandle(manifest.CreatedAt))
+	}
+	return handles
+}
+
+func reviewManifestTimeHandle(t time.Time) string {
+	return t.UTC().Format("20060102T150405")
 }

--- a/cmd/entire/cli/review/manifest.go
+++ b/cmd/entire/cli/review/manifest.go
@@ -785,7 +785,7 @@ func localReviewManifestDir(ctx context.Context) (string, error) {
 }
 
 func localReviewManifestFilename(manifest LocalReviewManifest) string {
-	name := manifest.CreatedAt.UTC().Format("20060102T150405")
+	name := reviewManifestTimeHandle(manifest.CreatedAt)
 	if len(manifest.Sources) > 0 && manifest.Sources[0].SessionID != "" {
 		name += "-" + safeManifestFilenamePart(manifest.Sources[0].SessionID)
 	}

--- a/cmd/entire/cli/review/manifest_test.go
+++ b/cmd/entire/cli/review/manifest_test.go
@@ -172,6 +172,24 @@ func TestWriteReviewCompletionFooter_PointsToFindings(t *testing.T) {
 	}
 }
 
+func TestWriteReviewCompletionFooter_UsesTimestampWhenAvailable(t *testing.T) {
+	manifest := LocalReviewManifest{
+		CreatedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+		Sources:   []ManifestSource{{SessionID: "claude-session", Label: "Claude Code"}},
+	}
+	var b strings.Builder
+
+	writeReviewCompletionFooter(&b, manifest)
+
+	got := b.String()
+	if !strings.Contains(got, "entire review --findings '20260507T100000'") {
+		t.Fatalf("footer missing timestamp view command:\n%s", got)
+	}
+	if strings.Contains(got, "entire review --findings 'claude-session'") {
+		t.Fatalf("footer should not advertise session handle when timestamp is available:\n%s", got)
+	}
+}
+
 func TestReviewFindingCommandsQuoteShellHandles(t *testing.T) {
 	manifest := LocalReviewManifest{
 		Sources: []ManifestSource{{
@@ -192,6 +210,43 @@ func TestReviewFindingCommandsQuoteShellHandles(t *testing.T) {
 	}
 	if !strings.Contains(footer.String(), want) {
 		t.Fatalf("footer output missing quoted view command:\n%s", footer.String())
+	}
+}
+
+func TestPrintReviewFindingsList_UsesTimestampForDuplicateSessionHandles(t *testing.T) {
+	manifests := []LocalReviewManifest{
+		{
+			CreatedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+			Sources: []ManifestSource{{
+				SessionID: "claude-session",
+				Label:     "Claude Code",
+				Output:    "first finding",
+			}},
+		},
+		{
+			CreatedAt: time.Date(2026, 5, 7, 10, 5, 0, 0, time.UTC),
+			Sources: []ManifestSource{{
+				SessionID: "claude-session",
+				Label:     "Claude Code",
+				Output:    "second finding",
+			}},
+		},
+	}
+	var b strings.Builder
+
+	printReviewFindingsList(&b, manifests)
+
+	got := b.String()
+	for _, want := range []string{
+		"view: entire review --findings '20260507T100000'",
+		"view: entire review --findings '20260507T100500'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("findings list missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "view: entire review --findings 'claude-session'") {
+		t.Fatalf("findings list should not advertise ambiguous session handle:\n%s", got)
 	}
 }
 

--- a/cmd/entire/cli/review/manifest_test.go
+++ b/cmd/entire/cli/review/manifest_test.go
@@ -21,6 +21,8 @@ import (
 const manifestTestCodexAgent = "codex"
 const manifestTokenTestAgentName agenttypes.AgentName = "review-token-test"
 const manifestTokenTestAgentType agenttypes.AgentType = "Review Token Test"
+const manifestFindingsFlag = "--findings"
+const manifestTestFinding = "finding"
 
 func TestHydrateReviewSummaryTokensFromStates_PopulatesTokensFromSessionState(t *testing.T) {
 	t.Parallel()
@@ -160,13 +162,36 @@ func TestWriteReviewCompletionFooter_PointsToFindings(t *testing.T) {
 	writeReviewCompletionFooter(&b, manifest)
 
 	got := b.String()
-	for _, want := range []string{"Review complete.", "entire review --findings claude-session"} {
+	for _, want := range []string{"Review complete.", "entire review --findings 'claude-session'"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("footer missing %q:\n%s", want, got)
 		}
 	}
 	if strings.Contains(got, "--fix") {
 		t.Fatalf("footer should not reference removed --fix:\n%s", got)
+	}
+}
+
+func TestReviewFindingCommandsQuoteShellHandles(t *testing.T) {
+	manifest := LocalReviewManifest{
+		Sources: []ManifestSource{{
+			SessionID: "sid; echo pwned",
+			Label:     "Claude Code",
+			Output:    manifestTestFinding,
+		}},
+	}
+	var list strings.Builder
+	var footer strings.Builder
+
+	printReviewFindingsList(&list, []LocalReviewManifest{manifest})
+	writeReviewCompletionFooter(&footer, manifest)
+
+	want := "entire review --findings 'sid; echo pwned'"
+	if !strings.Contains(list.String(), "view: "+want) {
+		t.Fatalf("list output missing quoted view command:\n%s", list.String())
+	}
+	if !strings.Contains(footer.String(), want) {
+		t.Fatalf("footer output missing quoted view command:\n%s", footer.String())
 	}
 }
 
@@ -200,11 +225,46 @@ func TestPrintReviewFindingsList_ListsSessionsWithoutLocalPath(t *testing.T) {
 	if !strings.Contains(got, "claude-session") {
 		t.Fatalf("findings list missing session handle:\n%s", got)
 	}
-	if !strings.Contains(got, "view: entire review --findings claude-session") {
+	if !strings.Contains(got, "view: entire review --findings 'claude-session'") {
 		t.Fatalf("findings list missing view command:\n%s", got)
 	}
-	if !strings.Contains(got, "view: entire review --findings 20260508T110000") {
+	if !strings.Contains(got, "view: entire review --findings '20260508T110000'") {
 		t.Fatalf("findings list missing timestamp fallback handle:\n%s", got)
+	}
+}
+
+func TestReviewFindingsCommand_ProfileFlagListsFindings(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "init")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "init")
+	t.Chdir(tmp)
+
+	if err := writeLocalReviewManifest(context.Background(), LocalReviewManifest{
+		CreatedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+		Sources: []ManifestSource{{
+			SessionID: "claude-session",
+			Label:     "Claude Code",
+			Output:    manifestTestFinding,
+		}},
+	}); err != nil {
+		t.Fatalf("writeLocalReviewManifest: %v", err)
+	}
+
+	cmd := NewCommand(Deps{})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{manifestFindingsFlag, "--profile", "general"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute review --findings --profile: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"Review Findings", "view: entire review --findings 'claude-session'"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("findings list missing %q:\n%s", want, got)
+		}
 	}
 }
 
@@ -231,7 +291,7 @@ func TestReviewFindingsCommand_WithHandlePrintsFullDetail(t *testing.T) {
 	cmd := NewCommand(Deps{})
 	var out strings.Builder
 	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"--findings", "claude-session"})
+	cmd.SetArgs([]string{manifestFindingsFlag, "claude-session"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute review --findings handle: %v", err)
@@ -248,6 +308,28 @@ func TestReviewFindingsCommand_WithHandlePrintsFullDetail(t *testing.T) {
 	}
 }
 
+func TestReviewFindingsCommand_HandleWithNoManifestsFails(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "init")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "init")
+	t.Chdir(tmp)
+
+	cmd := NewCommand(Deps{})
+	var errOut strings.Builder
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{manifestFindingsFlag, "missing-session"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected unknown findings handle to fail")
+	}
+	got := errOut.String()
+	if !strings.Contains(got, `no local review findings match "missing-session"`) {
+		t.Fatalf("no-manifest handle error mismatch:\n%s", got)
+	}
+}
+
 func TestReviewFindingsCommand_UnknownHandleListsValidHandles(t *testing.T) {
 	tmp := t.TempDir()
 	testutil.InitRepo(t, tmp)
@@ -261,7 +343,7 @@ func TestReviewFindingsCommand_UnknownHandleListsValidHandles(t *testing.T) {
 		Sources: []ManifestSource{{
 			SessionID: "claude-session",
 			Label:     "Claude Code",
-			Output:    "finding",
+			Output:    manifestTestFinding,
 		}},
 	}); err != nil {
 		t.Fatalf("writeLocalReviewManifest: %v", err)
@@ -270,7 +352,7 @@ func TestReviewFindingsCommand_UnknownHandleListsValidHandles(t *testing.T) {
 	cmd := NewCommand(Deps{})
 	var errOut strings.Builder
 	cmd.SetErr(&errOut)
-	cmd.SetArgs([]string{"--findings", "missing-session"})
+	cmd.SetArgs([]string{manifestFindingsFlag, "missing-session"})
 
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("expected unknown findings handle to fail")

--- a/cmd/entire/cli/review/manifest_test.go
+++ b/cmd/entire/cli/review/manifest_test.go
@@ -341,7 +341,7 @@ func TestReviewFindingsCommand_UnknownHandleListsValidHandles(t *testing.T) {
 	if err := writeLocalReviewManifest(context.Background(), LocalReviewManifest{
 		CreatedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
 		Sources: []ManifestSource{{
-			SessionID: "claude-session",
+			SessionID: "claude-session; echo pwned",
 			Label:     "Claude Code",
 			Output:    manifestTestFinding,
 		}},
@@ -358,7 +358,7 @@ func TestReviewFindingsCommand_UnknownHandleListsValidHandles(t *testing.T) {
 		t.Fatal("expected unknown findings handle to fail")
 	}
 	got := errOut.String()
-	for _, want := range []string{"no local review findings match", "claude-session"} {
+	for _, want := range []string{"no local review findings match", "view: entire review --findings 'claude-session; echo pwned'"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("unknown-handle error missing %q:\n%s", want, got)
 		}

--- a/cmd/entire/cli/review/manifest_test.go
+++ b/cmd/entire/cli/review/manifest_test.go
@@ -160,7 +160,7 @@ func TestWriteReviewCompletionFooter_PointsToFindings(t *testing.T) {
 	writeReviewCompletionFooter(&b, manifest)
 
 	got := b.String()
-	for _, want := range []string{"Review complete.", "entire review --findings"} {
+	for _, want := range []string{"Review complete.", "entire review --findings claude-session"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("footer missing %q:\n%s", want, got)
 		}
@@ -185,7 +185,13 @@ func TestPrintReviewFindingsList_ListsSessionsWithoutLocalPath(t *testing.T) {
 	}
 	var b strings.Builder
 
-	printReviewFindingsList(&b, []LocalReviewManifest{manifest})
+	printReviewFindingsList(&b, []LocalReviewManifest{
+		manifest,
+		{
+			CreatedAt:       time.Date(2026, 5, 8, 11, 0, 0, 0, time.UTC),
+			AggregateOutput: "aggregate-only finding",
+		},
+	})
 
 	got := b.String()
 	if strings.Contains(got, "/tmp/local-build/entire") {
@@ -193,6 +199,87 @@ func TestPrintReviewFindingsList_ListsSessionsWithoutLocalPath(t *testing.T) {
 	}
 	if !strings.Contains(got, "claude-session") {
 		t.Fatalf("findings list missing session handle:\n%s", got)
+	}
+	if !strings.Contains(got, "view: entire review --findings claude-session") {
+		t.Fatalf("findings list missing view command:\n%s", got)
+	}
+	if !strings.Contains(got, "view: entire review --findings 20260508T110000") {
+		t.Fatalf("findings list missing timestamp fallback handle:\n%s", got)
+	}
+}
+
+func TestReviewFindingsCommand_WithHandlePrintsFullDetail(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "init")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "init")
+	t.Chdir(tmp)
+
+	if err := writeLocalReviewManifest(context.Background(), LocalReviewManifest{
+		CreatedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+		Sources: []ManifestSource{{
+			SessionID: "claude-session",
+			Label:     "Claude Code",
+			Output:    "Full finding body that must not be hidden behind a picker.",
+		}},
+		AggregateOutput: "Aggregate detail for agents.",
+	}); err != nil {
+		t.Fatalf("writeLocalReviewManifest: %v", err)
+	}
+
+	cmd := NewCommand(Deps{})
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--findings", "claude-session"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute review --findings handle: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"Review findings from",
+		"Full finding body that must not be hidden behind a picker.",
+		"Aggregate detail for agents.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("detail output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestReviewFindingsCommand_UnknownHandleListsValidHandles(t *testing.T) {
+	tmp := t.TempDir()
+	testutil.InitRepo(t, tmp)
+	testutil.WriteFile(t, tmp, "f.txt", "init")
+	testutil.GitAdd(t, tmp, "f.txt")
+	testutil.GitCommit(t, tmp, "init")
+	t.Chdir(tmp)
+
+	if err := writeLocalReviewManifest(context.Background(), LocalReviewManifest{
+		CreatedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+		Sources: []ManifestSource{{
+			SessionID: "claude-session",
+			Label:     "Claude Code",
+			Output:    "finding",
+		}},
+	}); err != nil {
+		t.Fatalf("writeLocalReviewManifest: %v", err)
+	}
+
+	cmd := NewCommand(Deps{})
+	var errOut strings.Builder
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{"--findings", "missing-session"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected unknown findings handle to fail")
+	}
+	got := errOut.String()
+	for _, want := range []string{"no local review findings match", "claude-session"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("unknown-handle error missing %q:\n%s", want, got)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/724
<!-- entire-trail-link-end -->

**Why**

`entire review --findings` needed an agent-safe way to reach full saved review
findings. The previous non-interactive fallback could show that findings
existed, but agents still needed the terminal picker to reveal the full detail.

**What changed**

The findings list now prints stable handles with direct `view:` commands, and
`entire review --findings <handle>` renders the full saved findings without a
TUI. Non-interactive profile editing now refuses with scripted alternatives
instead of requiring a picker.

**Usage examples**

```sh
entire review --findings
```

prints saved findings with commands such as:

```text
view: entire review --findings 'claude-session'
```

Then:

```sh
entire review --findings claude-session
```

prints the full saved review detail.

**Decisions made during development**

The fallback stays plain text instead of forcing JSON everywhere, matching the
agent-safe CLI guidance that complete human-readable output is acceptable.
Handles prefer saved source session IDs and fall back to a timestamp handle when
no session ID is available.

**Technical tradeoffs**

Timestamp fallback handles can theoretically collide, so the command reports an
ambiguous handle instead of guessing. Generated `view:` commands quote handles
for copy-paste safety while lookup still accepts the raw argument value.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only review findings browsing and argument routing; no auth, persistence format changes beyond shared timestamp helper for manifest filenames.
> 
> **Overview**
> **`entire review --findings`** now supports an optional handle so agents and scripts can open a saved run without the TUI. **`entire review --findings <handle>`** prints full reviewer output and aggregate summary; handles are source **session IDs**, with a **UTC timestamp** fallback when there is no session ID. Ambiguous handles fail explicitly instead of picking a manifest.
> 
> The non-interactive findings list and post-review footer include copy-paste **`view:`** commands with **shell-quoted** handles. Unknown handles error with a list of available **`view:`** commands. With **`--findings`**, a positional argument is treated as the handle (so **`--profile`** can be combined without conflicting with “profile as positional”).
> 
> **`entire review --edit`** in a non-interactive environment now exits with pointers to **`--list`** and **`--configure --set-*`** instead of requiring the picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71171b04f7e0e1d55abe7d0927a2807655a0c251. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->