### PR TITLE
fix(e2e): droid prompt submission and claude-code subagent flakes

### DIFF
--- a/e2e/agents/tmux.go
+++ b/e2e/agents/tmux.go
@@ -81,8 +81,9 @@ func (s *TmuxSession) Send(input string) error {
 	s.stableAtSend = stableContent(s.Capture())
 
 	// Verify the pane reacted to Enter; a swallowed Enter leaves the prompt
-	// sitting unsubmitted in the input box. Retry a couple of times — Enter
-	// on an already-submitted (empty) input box is a no-op.
+	// sitting unsubmitted in the input box. Retry a couple of times — TUIs
+	// treat Enter on an already-submitted (empty) input box as a no-op, and
+	// the vogon REPL ignores empty lines.
 	for range 3 {
 		preEnter := s.Capture()
 		if err := s.SendKeys("Enter"); err != nil {

--- a/e2e/agents/tmux.go
+++ b/e2e/agents/tmux.go
@@ -98,19 +98,29 @@ func (s *TmuxSession) Send(input string) error {
 }
 
 // waitForInputIngested waits until the pane content has changed from preSend
-// (the echoed input is visible) and stopped changing between consecutive
-// polls (the TUI's input handler has caught up), then returns the settled
-// content. Gives up after 15s and returns the last capture.
+// (the echoed input is visible) and held still for two consecutive polls
+// (the TUI's input handler has caught up — droid renders long pastes in
+// bursts, so a single quiet interval can fake stability), then returns the
+// settled content. Gives up after 15s and returns the last capture.
+//
+// Compares raw captures: the input box lives in the bottom lines that
+// stableContent strips, so stable comparison would be blind to the echo.
 func (s *TmuxSession) waitForInputIngested(preSend string) string {
 	deadline := time.Now().Add(15 * time.Second)
 	last := s.Capture()
+	stablePolls := 0
 	for time.Now().Before(deadline) {
 		time.Sleep(300 * time.Millisecond)
 		current := s.Capture()
-		if current == last && current != preSend {
+		if current != last || current == preSend {
+			stablePolls = 0
+			last = current
+			continue
+		}
+		stablePolls++
+		if stablePolls >= 2 {
 			return current
 		}
-		last = current
 	}
 	return last
 }

--- a/e2e/agents/tmux.go
+++ b/e2e/agents/tmux.go
@@ -72,48 +72,49 @@ func (s *TmuxSession) Send(input string) error {
 	if err := s.SendKeys(input); err != nil {
 		return err
 	}
-	s.waitForInputIngested(preSendRaw)
+	settled := s.waitForInputIngested(preSendRaw)
 
 	// Snapshot the post-echo, pre-submit content. WaitFor requires content to
 	// change from this snapshot before it can settle, preventing false matches
 	// on prompt characters (e.g. ❯) in the echoed input. Taken before Enter so
 	// it can never include response output from a fast agent.
-	s.stableAtSend = stableContent(s.Capture())
+	s.stableAtSend = stableContent(settled)
 
 	// Verify the pane reacted to Enter; a swallowed Enter leaves the prompt
 	// sitting unsubmitted in the input box. Retry a couple of times — TUIs
 	// treat Enter on an already-submitted (empty) input box as a no-op, and
 	// the vogon REPL ignores empty lines.
+	preEnter := settled
 	for range 3 {
-		preEnter := s.Capture()
 		if err := s.SendKeys("Enter"); err != nil {
 			return err
 		}
 		if s.paneChangedFrom(preEnter, 2*time.Second) {
 			break
 		}
+		preEnter = s.Capture()
 	}
 	return nil
 }
 
 // waitForInputIngested waits until the pane content has changed from preSend
 // (the echoed input is visible) and stopped changing between consecutive
-// polls (the TUI's input handler has caught up).
-func (s *TmuxSession) waitForInputIngested(preSend string) {
+// polls (the TUI's input handler has caught up), then returns the settled
+// content. Gives up after 15s and returns the last capture.
+func (s *TmuxSession) waitForInputIngested(preSend string) string {
 	deadline := time.Now().Add(15 * time.Second)
 	last := s.Capture()
 	for time.Now().Before(deadline) {
 		time.Sleep(300 * time.Millisecond)
 		current := s.Capture()
 		if current == last && current != preSend {
-			return
+			return current
 		}
 		last = current
 	}
+	return last
 }
 
-// paneChangedFrom reports whether the pane content diverges from prev within
-// the timeout.
 func (s *TmuxSession) paneChangedFrom(prev string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/e2e/agents/tmux.go
+++ b/e2e/agents/tmux.go
@@ -64,31 +64,64 @@ func NewTmuxSession(name string, dir string, unsetEnv []string, command string, 
 }
 
 func (s *TmuxSession) Send(input string) error {
-	preSend := stableContent(s.Capture())
-	// Send text and Enter separately — Claude's TUI can swallow Enter
+	preSendRaw := s.Capture()
+	// Send text and Enter separately — TUIs (Claude, droid) can swallow Enter
 	// if it arrives before the input handler finishes processing the text.
+	// Droid ingests long pasted prompts over several seconds, so wait until
+	// the echoed input has fully rendered before submitting.
 	if err := s.SendKeys(input); err != nil {
 		return err
 	}
-	time.Sleep(200 * time.Millisecond)
-	if err := s.SendKeys("Enter"); err != nil {
-		return err
-	}
+	s.waitForInputIngested(preSendRaw)
 
-	// Wait for the terminal to reflect the echoed input, then snapshot.
-	// This ensures WaitFor compares against post-echo content, preventing
-	// false matches on prompt characters (e.g. ❯) in the echoed input.
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		time.Sleep(200 * time.Millisecond)
-		current := stableContent(s.Capture())
-		if current != preSend {
-			s.stableAtSend = current
-			return nil
+	// Snapshot the post-echo, pre-submit content. WaitFor requires content to
+	// change from this snapshot before it can settle, preventing false matches
+	// on prompt characters (e.g. ❯) in the echoed input. Taken before Enter so
+	// it can never include response output from a fast agent.
+	s.stableAtSend = stableContent(s.Capture())
+
+	// Verify the pane reacted to Enter; a swallowed Enter leaves the prompt
+	// sitting unsubmitted in the input box. Retry a couple of times — Enter
+	// on an already-submitted (empty) input box is a no-op.
+	for range 3 {
+		preEnter := s.Capture()
+		if err := s.SendKeys("Enter"); err != nil {
+			return err
+		}
+		if s.paneChangedFrom(preEnter, 2*time.Second) {
+			break
 		}
 	}
-	s.stableAtSend = stableContent(s.Capture())
 	return nil
+}
+
+// waitForInputIngested waits until the pane content has changed from preSend
+// (the echoed input is visible) and stopped changing between consecutive
+// polls (the TUI's input handler has caught up).
+func (s *TmuxSession) waitForInputIngested(preSend string) {
+	deadline := time.Now().Add(15 * time.Second)
+	last := s.Capture()
+	for time.Now().Before(deadline) {
+		time.Sleep(300 * time.Millisecond)
+		current := s.Capture()
+		if current == last && current != preSend {
+			return
+		}
+		last = current
+	}
+}
+
+// paneChangedFrom reports whether the pane content diverges from prev within
+// the timeout.
+func (s *TmuxSession) paneChangedFrom(prev string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(200 * time.Millisecond)
+		if s.Capture() != prev {
+			return true
+		}
+	}
+	return false
 }
 
 // SendKeys sends raw tmux key names without appending Enter.

--- a/e2e/tests/factory_hooks_test.go
+++ b/e2e/tests/factory_hooks_test.go
@@ -34,7 +34,7 @@ func TestFactoryTaskCheckpointExistsBeforeCommit(t *testing.T) {
 		// WaitFor can return while droid is still working: the input box's
 		// "> Enter to steer" matches the prompt pattern even mid-turn, so the
 		// file wait must absorb the Worker's runtime (60-120s turns on CI).
-		testutil.WaitForFileExists(t, s.Dir, "docs/factory-hook-check.md", 90*time.Second)
+		testutil.WaitForFileExists(t, s.Dir, "docs/factory-hook-check.md", 120*time.Second)
 
 		waitForTaskRewindPoint(t, s.Dir, 30*time.Second)
 	})
@@ -62,7 +62,7 @@ func TestFactoryCommittedCheckpointExcludesPreExistingUntrackedFiles(t *testing.
 
 		// See TestFactoryTaskCheckpointExistsBeforeCommit: the file wait must
 		// absorb the Worker's runtime because WaitFor can return mid-turn.
-		testutil.WaitForFileExists(t, s.Dir, "docs/factory-prehook-worker.md", 90*time.Second)
+		testutil.WaitForFileExists(t, s.Dir, "docs/factory-prehook-worker.md", 120*time.Second)
 		waitForTaskRewindPoint(t, s.Dir, 30*time.Second)
 
 		s.Git(t, "add", "docs/factory-prehook-worker.md")

--- a/e2e/tests/factory_hooks_test.go
+++ b/e2e/tests/factory_hooks_test.go
@@ -31,9 +31,12 @@ func TestFactoryTaskCheckpointExistsBeforeCommit(t *testing.T) {
 			"Can you run a Worker that inspects this code and comes up with a short summary about what it is about? Have the Worker write that summary to docs/factory-hook-check.md as one short paragraph followed by exactly 3 bullet points. Do not create or edit the file in the main agent process. Only the Worker should write the file. Do not commit. Do not ask for confirmation.")
 		s.WaitFor(t, session, s.Agent.PromptPattern(), 90*time.Second)
 
-		testutil.WaitForFileExists(t, s.Dir, "docs/factory-hook-check.md", 10*time.Second)
+		// WaitFor can return while droid is still working: the input box's
+		// "> Enter to steer" matches the prompt pattern even mid-turn, so the
+		// file wait must absorb the Worker's runtime (60-120s turns on CI).
+		testutil.WaitForFileExists(t, s.Dir, "docs/factory-hook-check.md", 90*time.Second)
 
-		waitForTaskRewindPoint(t, s.Dir, 15*time.Second)
+		waitForTaskRewindPoint(t, s.Dir, 30*time.Second)
 	})
 }
 
@@ -57,8 +60,10 @@ func TestFactoryCommittedCheckpointExcludesPreExistingUntrackedFiles(t *testing.
 			"Can you run a Worker that inspects this code and writes its findings to docs/factory-prehook-worker.md as one short paragraph followed by exactly 3 bullet points? Do not read, modify, or mention docs/factory-preexisting-human-note.md. Do not create or edit the file in the main agent process. Only the Worker should write docs/factory-prehook-worker.md. Do not commit. Do not ask for confirmation.")
 		s.WaitFor(t, session, s.Agent.PromptPattern(), 90*time.Second)
 
-		testutil.WaitForFileExists(t, s.Dir, "docs/factory-prehook-worker.md", 10*time.Second)
-		waitForTaskRewindPoint(t, s.Dir, 15*time.Second)
+		// See TestFactoryTaskCheckpointExistsBeforeCommit: the file wait must
+		// absorb the Worker's runtime because WaitFor can return mid-turn.
+		testutil.WaitForFileExists(t, s.Dir, "docs/factory-prehook-worker.md", 90*time.Second)
+		waitForTaskRewindPoint(t, s.Dir, 30*time.Second)
 
 		s.Git(t, "add", "docs/factory-prehook-worker.md")
 		s.Git(t, "commit", "-m", "Add factory worker checkpoint regression fixtures")

--- a/e2e/tests/single_session_test.go
+++ b/e2e/tests/single_session_test.go
@@ -96,7 +96,7 @@ func TestSingleSessionSubagentCommitInTurn(t *testing.T) {
 		}
 
 		_, err := s.RunPrompt(t, ctx,
-			"use a subagent: create a markdown file at docs/red.md with a paragraph about the colour red, then commit it. Do not ask for confirmation, just make the change.")
+			"use a subagent: create a markdown file at docs/red.md with a paragraph about the colour red, then commit it. Run the subagent in the foreground and wait for it to finish; never run it in the background. Do not ask for confirmation, just make the change.")
 		if err != nil {
 			t.Fatalf("agent failed: %v", err)
 		}

--- a/e2e/tests/subagent_commit_flow_test.go
+++ b/e2e/tests/subagent_commit_flow_test.go
@@ -17,7 +17,7 @@ import (
 func TestSubagentCommitFlow(t *testing.T) {
 	testutil.ForEachAgent(t, 3*time.Minute, func(t *testing.T, s *testutil.RepoState, ctx context.Context) {
 		_, err := s.RunPrompt(t, ctx,
-			"use a subagent: create a markdown file at docs/red.md with a paragraph about the colour red. Do not commit the file. Do not ask for confirmation, just make the change.")
+			"use a subagent: create a markdown file at docs/red.md with a paragraph about the colour red. Run the subagent in the foreground and wait for it to finish; never run it in the background. Do not commit the file. Do not ask for confirmation, just make the change.")
 		if err != nil {
 			t.Fatalf("agent failed: %v", err)
 		}

--- a/e2e/vogon/main.go
+++ b/e2e/vogon/main.go
@@ -71,6 +71,7 @@ func main() {
 			// doesn't visibly react in time, and treating that as termination
 			// would end the session mid-test.
 			if line == "" {
+				fmt.Fprint(os.Stdout, "> ")
 				continue
 			}
 			// Give tmux's Send() time to observe a distinct pre-output pane

--- a/e2e/vogon/main.go
+++ b/e2e/vogon/main.go
@@ -64,14 +64,18 @@ func main() {
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
-			if line == "" || line == "exit" || line == "quit" {
+			if line == "exit" || line == "quit" {
 				break
 			}
-			// Give tmux's Send() time to capture the echoed-input state
-			// before we produce any output. Send polls every 200ms; without
-			// this pause, vogon output appears in the same capture window
-			// as the echo, causing stableAtSend to include final output and
-			// preventing WaitFor's contentChanged detection.
+			// Ignore empty lines: tmux's Send() may retry Enter when the pane
+			// doesn't visibly react in time, and treating that as termination
+			// would end the session mid-test.
+			if line == "" {
+				continue
+			}
+			// Give tmux's Send() time to observe a distinct pre-output pane
+			// state, so its Enter verification and WaitFor's contentChanged
+			// detection see a clean echo -> output transition.
 			time.Sleep(700 * time.Millisecond)
 			fmt.Fprintln(os.Stdout, "Working...")
 			runTurn(dir, cfg.sessionID, transcriptPath, line)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/725
<!-- entire-trail-link-end -->

## Why

E2E runs on main have been failing repeatedly (latest: run 28549683381):

- **factoryai-droid** — `TestFactoryTaskCheckpointExistsBeforeCommit` and `TestFactoryCommittedCheckpointExcludesPreExistingUntrackedFiles` fail because the harness sends Enter a fixed 200ms after pasting the prompt. Droid v0.162.x ingests long pasted prompts over several seconds, the Enter gets swallowed, and the prompt sits unsubmitted in the input box until the test times out. Recurring across at least three recent main runs.
- **claude-code** (Linux and Windows) — `TestSingleSessionSubagentCommitInTurn` and `TestSubagentCommitFlow` fail because newer Claude Code releases can run Task subagents in the background: the tool call returns in ~40ms, the foreground turn ends (`stop` hook sees no changes), and the subagent's file changes and commit land after turn-end with no active session — no checkpoint trailer, no condensation, so the checkpoint-advance assertions time out.

## What changed

- `TmuxSession.Send` waits until the echoed input has fully rendered before submitting, then verifies the pane reacted to Enter and retries up to 3× if it was swallowed.
- The `stableAtSend` snapshot is now taken before Enter, so it can never include response output from a fast agent (a post-Enter snapshot deadlocks `WaitFor`'s change-detection guard — caught by the Vogon canary during development).
- The Vogon REPL ignores empty lines (exits only on `exit`/`quit`), so a retried Enter cannot terminate the session mid-test.
- The two subagent test prompts instruct claude-code to run the subagent in the foreground.

## Decisions made during development

- The Send hardening lives in the shared `TmuxSession`, not a droid-specific override: the race is universal (the old code already worked around the same issue for Claude's TUI with a fixed sleep); droid merely widened the timing window past it.
- The prompt pinning keeps the subagent tests on the synchronous path they were written to cover. Making the CLI track background-subagent work (e.g. wiring Claude Code's `SubagentStop` hook) is a separate product gap and deliberately not part of this PR — with a foreground subagent, hook logs confirm `pre-task`/`post-task` now span the actual subagent work (~22s) and the mid-turn commit gets its trailer.

## Reviewer notes

- Droid cannot run locally (no `FACTORY_API_KEY`); the droid-side fix is exercised by the full Vogon canary (which drives the same `TmuxSession.Send` path, 59/59 green) but needs the CI E2E workflow for final confirmation.
- `copilot-cli`'s `Send` override still carries the old fixed-delay + unverified-Enter pattern; unifying it requires parameterizing around Copilot's Ctrl+S/autocomplete submission semantics — follow-up candidate, no regression here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to E2E harness, Vogon canary, and test timeouts/prompts; no production CLI or hook logic is modified.
> 
> **Overview**
> Hardens **shared `TmuxSession.Send`** for slow TUIs (especially factoryai-droid): wait until pasted text is fully echoed (raw pane polling with consecutive stability), snapshot **`stableAtSend` before Enter** so fast agents cannot deadlock `WaitFor`, then submit Enter with pane-change verification and up to three retries when Enter is swallowed.
> 
> Updates the **Vogon** interactive REPL to **ignore empty lines** (only `exit`/`quit` end the session) so Enter retries from `Send` do not terminate mid-test.
> 
> **Factory droid** hook tests extend file and task-rewind waits (90s / 30s) because prompt-pattern `WaitFor` can return mid-turn while a Worker is still running.
> 
> **Claude Code subagent** tests add explicit instructions to run the subagent in the foreground and wait for completion, avoiding background Task runs that finish after hooks and break checkpoint assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3db5ced4ef44887d694bbffdfc5ba4bb9cc2171. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->