### PR TITLE
fix(cli): Ctrl-C escapes shell loops and aborts cleanly

### DIFF
--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -89,14 +89,20 @@ func main() {
 		var silent *cli.SilentError
 
 		switch {
-		case errors.Is(err, context.Canceled):
-			// Aborted (a signal cancelled the root context). Don't dump the
-			// raw transport/keyring cancellation string ("...: context
-			// canceled", "read access token: signal: interrupt") as if it
-			// were a failure — die quietly by re-raising the signal that
-			// triggered it (see dieFromSignal) so an enclosing
+		case errors.Is(err, context.Canceled) && caughtSignal.Load() != nil:
+			// A signal cancelled the root context (our handler fired). Don't
+			// dump the raw transport/keyring cancellation string ("...:
+			// context canceled", "read access token: signal: interrupt") as
+			// if it were a failure — die quietly by re-raising the signal
+			// that triggered it (see dieFromSignal) so an enclosing
 			// `while ...; do entire; done` loop actually breaks on a single
 			// Ctrl-C, and a SIGTERM shutdown still exits 143.
+			//
+			// We gate on the handler having fired rather than on the error
+			// type alone: a context.Canceled that arose without a signal
+			// (e.g. an internally-cancelled sub-context) is a genuine error
+			// and must fall through to normal reporting, not masquerade as a
+			// user abort (which would also wrongly break an enclosing loop).
 			cancel()
 			dieFromSignal(terminatingSignal())
 		case errors.As(err, &silent):

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -33,18 +34,26 @@ func main() {
 	signal.Notify(sigChan, signals...)
 	go func() {
 		// First signal: cancel the context so in-flight work unwinds
-		// cleanly. signal.Notify has disabled Go's default "SIGINT
+		// cleanly. signal.Notify has disabled Go's default "signal
 		// terminates" behavior, so without the second read below a user
 		// who Ctrl-C's again during a slow/stuck shutdown (e.g. a keyring
 		// read blocked in a subprocess we can't cancel) would find every
 		// further Ctrl-C swallowed. The second read restores an escape
-		// hatch: press Ctrl-C again to force-exit with the conventional
-		// 130 (128 + SIGINT).
-		<-sigChan
-		fmt.Fprintln(os.Stderr, "\nInterrupting… press Ctrl-C again to force quit.")
+		// hatch: signal again to force-exit.
+		//
+		// We remember which signal fired so the eventual termination
+		// re-raises that same signal — a SIGTERM (from a supervisor /
+		// container stop) must exit 143, not masquerade as a SIGINT 130.
+		sig := <-sigChan
+		caughtSignal.Store(sig)
+		if sig == os.Interrupt {
+			fmt.Fprintln(os.Stderr, "\nInterrupting… press Ctrl-C again to force quit.")
+		} else {
+			fmt.Fprintln(os.Stderr, "\nReceived termination signal, shutting down… signal again to force quit.")
+		}
 		cancel()
 		<-sigChan
-		dieFromInterrupt()
+		dieFromSignal(sig)
 	}()
 
 	// Create and execute root command
@@ -81,14 +90,15 @@ func main() {
 
 		switch {
 		case errors.Is(err, context.Canceled):
-			// User aborted (Ctrl-C cancelled the root context). Don't dump
-			// the raw transport/keyring cancellation string ("...: context
+			// Aborted (a signal cancelled the root context). Don't dump the
+			// raw transport/keyring cancellation string ("...: context
 			// canceled", "read access token: signal: interrupt") as if it
-			// were a failure — die quietly by re-raising SIGINT (see
-			// dieFromInterrupt) so an enclosing `while ...; do entire; done`
-			// loop actually breaks on a single Ctrl-C.
+			// were a failure — die quietly by re-raising the signal that
+			// triggered it (see dieFromSignal) so an enclosing
+			// `while ...; do entire; done` loop actually breaks on a single
+			// Ctrl-C, and a SIGTERM shutdown still exits 143.
 			cancel()
-			dieFromInterrupt()
+			dieFromSignal(terminatingSignal())
 		case errors.As(err, &silent):
 			// Command already printed the error
 		case strings.Contains(err.Error(), "unknown command") || strings.Contains(err.Error(), "unknown flag"):
@@ -114,23 +124,51 @@ func main() {
 	cancel() // Cleanup on successful exit
 }
 
-// dieFromInterrupt terminates the process as if it had been killed by SIGINT,
-// rather than exiting normally with code 130. The distinction matters to an
-// interactive shell: it only aborts a `while true; do entire ...; done` loop
-// when the child is *killed by* SIGINT (WIFSIGNALED). A plain os.Exit(130) is
-// an ordinary exit, so the loop keeps respawning entire and Ctrl-C never
-// escapes it. We reset SIGINT to its default disposition, re-raise it to
+// caughtSignal records the terminating signal (SIGINT or SIGTERM) the handler
+// observed, so a later cancellation-driven exit can re-raise the *same* signal
+// rather than always SIGINT. Read via terminatingSignal.
+var caughtSignal atomic.Value // stores os.Signal
+
+// terminatingSignal returns the signal that cancelled the root context,
+// defaulting to SIGINT when the cancellation came from something other than
+// our signal handler (so a stray context.Canceled still exits 130).
+func terminatingSignal() os.Signal {
+	if v := caughtSignal.Load(); v != nil {
+		if s, ok := v.(os.Signal); ok {
+			return s
+		}
+	}
+	return os.Interrupt
+}
+
+// dieFromSignal terminates the process as if it had been killed by sig, rather
+// than exiting normally. The distinction matters to an interactive shell: it
+// only aborts a `while true; do entire ...; done` loop when the child is
+// *killed by* SIGINT (WIFSIGNALED). A plain os.Exit(130) is an ordinary exit,
+// so the loop keeps respawning entire and Ctrl-C never escapes it. Re-raising
+// the actual signal also keeps a SIGTERM shutdown reporting the conventional
+// 143 (not 130). We reset sig to its default disposition, re-raise it to
 // ourselves, and briefly wait for delivery; if the re-raise can't be delivered
-// (e.g. Windows, where os.Interrupt-to-self is unsupported) we fall back to a
-// conventional exit so we never hang.
-func dieFromInterrupt() {
-	signal.Reset(os.Interrupt)
+// (e.g. Windows, where signal-to-self is unsupported) we fall back to a
+// conventional 128+signal exit so we never hang.
+func dieFromSignal(sig os.Signal) {
+	signal.Reset(sig)
 	if p, err := os.FindProcess(os.Getpid()); err == nil {
-		if err := p.Signal(os.Interrupt); err == nil {
+		if err := p.Signal(sig); err == nil {
 			time.Sleep(500 * time.Millisecond) // signal delivery ends the process well before this elapses
 		}
 	}
-	os.Exit(130)
+	os.Exit(exitCodeForSignal(sig))
+}
+
+// exitCodeForSignal maps a signal to the conventional 128+signum exit code
+// (130 for SIGINT, 143 for SIGTERM), falling back to 130 for a signal that
+// doesn't carry a numeric value on this platform.
+func exitCodeForSignal(sig os.Signal) int {
+	if s, ok := sig.(syscall.Signal); ok {
+		return 128 + int(s)
+	}
+	return 130
 }
 
 // isPositionalArgError reports whether err looks like a cobra positional-

--- a/cmd/entire/main.go
+++ b/cmd/entire/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/entireio/cli/cmd/entire/cli"
 	"github.com/entireio/cli/cmd/entire/cli/api"
@@ -31,8 +32,19 @@ func main() {
 	}
 	signal.Notify(sigChan, signals...)
 	go func() {
+		// First signal: cancel the context so in-flight work unwinds
+		// cleanly. signal.Notify has disabled Go's default "SIGINT
+		// terminates" behavior, so without the second read below a user
+		// who Ctrl-C's again during a slow/stuck shutdown (e.g. a keyring
+		// read blocked in a subprocess we can't cancel) would find every
+		// further Ctrl-C swallowed. The second read restores an escape
+		// hatch: press Ctrl-C again to force-exit with the conventional
+		// 130 (128 + SIGINT).
 		<-sigChan
+		fmt.Fprintln(os.Stderr, "\nInterrupting… press Ctrl-C again to force quit.")
 		cancel()
+		<-sigChan
+		dieFromInterrupt()
 	}()
 
 	// Create and execute root command
@@ -68,6 +80,15 @@ func main() {
 		var silent *cli.SilentError
 
 		switch {
+		case errors.Is(err, context.Canceled):
+			// User aborted (Ctrl-C cancelled the root context). Don't dump
+			// the raw transport/keyring cancellation string ("...: context
+			// canceled", "read access token: signal: interrupt") as if it
+			// were a failure — die quietly by re-raising SIGINT (see
+			// dieFromInterrupt) so an enclosing `while ...; do entire; done`
+			// loop actually breaks on a single Ctrl-C.
+			cancel()
+			dieFromInterrupt()
 		case errors.As(err, &silent):
 			// Command already printed the error
 		case strings.Contains(err.Error(), "unknown command") || strings.Contains(err.Error(), "unknown flag"):
@@ -91,6 +112,25 @@ func main() {
 		cli.WarnCheckpointPolicyIfNeeded(ctx, rootCmd.ErrOrStderr(), versioninfo.Version)
 	}
 	cancel() // Cleanup on successful exit
+}
+
+// dieFromInterrupt terminates the process as if it had been killed by SIGINT,
+// rather than exiting normally with code 130. The distinction matters to an
+// interactive shell: it only aborts a `while true; do entire ...; done` loop
+// when the child is *killed by* SIGINT (WIFSIGNALED). A plain os.Exit(130) is
+// an ordinary exit, so the loop keeps respawning entire and Ctrl-C never
+// escapes it. We reset SIGINT to its default disposition, re-raise it to
+// ourselves, and briefly wait for delivery; if the re-raise can't be delivered
+// (e.g. Windows, where os.Interrupt-to-self is unsupported) we fall back to a
+// conventional exit so we never hang.
+func dieFromInterrupt() {
+	signal.Reset(os.Interrupt)
+	if p, err := os.FindProcess(os.Getpid()); err == nil {
+		if err := p.Signal(os.Interrupt); err == nil {
+			time.Sleep(500 * time.Millisecond) // signal delivery ends the process well before this elapses
+		}
+	}
+	os.Exit(130)
 }
 
 // isPositionalArgError reports whether err looks like a cobra positional-

--- a/cmd/entire/main_test.go
+++ b/cmd/entire/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// nonNumericSignal is an os.Signal that isn't a syscall.Signal, exercising
+// exitCodeForSignal's fallback branch.
+type nonNumericSignal struct{}
+
+func (nonNumericSignal) String() string { return "non-numeric" }
+func (nonNumericSignal) Signal()        {}
+
+// TestExitCodeForSignal locks the conventional 128+signum mapping the
+// Ctrl-C/SIGTERM fix relies on, so a future "simplification" back to a
+// hardcoded 130 can't silently regress SIGTERM's 143.
+func TestExitCodeForSignal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sig  os.Signal
+		want int
+	}{
+		{"SIGINT", os.Interrupt, 130},
+		{"SIGTERM", syscall.SIGTERM, 143},
+		{"non-numeric signal falls back to 130", nonNumericSignal{}, 130},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := exitCodeForSignal(tc.sig); got != tc.want {
+				t.Errorf("exitCodeForSignal(%v) = %d, want %d", tc.sig, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/entireclient/tokenstore/keyring_timeout.go
+++ b/internal/entireclient/tokenstore/keyring_timeout.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"runtime"
 	"time"
 )
@@ -36,15 +37,34 @@ func keyringTimeout() time.Duration {
 }
 
 // callKeyringWithTimeout runs fn in a goroutine and returns its result,
-// or a descriptive error if the configured keyring timeout elapses
-// first. The goroutine continues running — a blocked D-Bus syscall
-// can't be cancelled from Go — and its eventual result is discarded.
-// The buffered result channel keeps the goroutine from leaking forever
-// waiting to publish into a receiver that's already gone. fn's own
-// error (including ErrNotFound) propagates unchanged on the fast path;
-// only the timeout branch wraps.
+// or a descriptive error if the configured keyring timeout elapses or the
+// user interrupts (Ctrl-C) first. The goroutine continues running — a
+// blocked D-Bus syscall / Keychain subprocess can't be cancelled from Go —
+// and its eventual result is discarded. The buffered result channel keeps
+// the goroutine from leaking forever waiting to publish into a receiver
+// that's already gone. fn's own error (including ErrNotFound) propagates
+// unchanged on the fast path; only the timeout and interrupt branches wrap.
+//
+// It listens for SIGINT for the duration of the call so a Ctrl-C unblocks a
+// stuck keyring read *now* rather than after the full timeout. This is the
+// only cancellation lever available here: the credential store is reached
+// through auth-go's Store interface (LoadTokens/SaveTokens), which carries
+// no context.Context, so a per-request context can't be threaded down to
+// this point. signal.Notify fans a signal out to every registered channel,
+// so the process's own handler (which cancels the root context) still runs
+// — this is an additional listener scoped to the keyring call.
 func callKeyringWithTimeout(op string, fn func() (string, error)) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), keyringTimeout())
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	return callKeyringWithInterrupt(op, keyringTimeout(), fn, sigCh)
+}
+
+// callKeyringWithInterrupt is the testable core of callKeyringWithTimeout:
+// the interrupt source is injected so tests can exercise the Ctrl-C branch
+// without sending real signals to the test process.
+func callKeyringWithInterrupt(op string, timeout time.Duration, fn func() (string, error), interrupt <-chan os.Signal) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	type result struct {
@@ -59,6 +79,10 @@ func callKeyringWithTimeout(op string, fn func() (string, error)) (string, error
 	select {
 	case r := <-ch:
 		return r.val, r.err
+	case <-interrupt:
+		// Wrap context.Canceled so the abort flows into the CLI's silent
+		// "user aborted" exit path rather than printing as a keyring failure.
+		return "", fmt.Errorf("%s interrupted: %w", op, context.Canceled)
 	case <-ctx.Done():
 		return "", fmt.Errorf(
 			"%s timed out: OS keyring (%s) appears unavailable; set %s to a longer duration to wait further: %w",

--- a/internal/entireclient/tokenstore/keyring_timeout_test.go
+++ b/internal/entireclient/tokenstore/keyring_timeout_test.go
@@ -3,6 +3,7 @@ package tokenstore
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -73,6 +74,38 @@ func TestCallKeyringWithTimeout_DeadlineExceeded(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("timeout error %q missing %q", msg, want)
 		}
+	}
+}
+
+// A Ctrl-C must unblock a stuck keyring call immediately — well before the
+// timeout — and surface as a context.Canceled so the CLI treats it as a user
+// abort rather than a keyring failure.
+func TestCallKeyringWithInterrupt_AbortsOnSignal(t *testing.T) {
+	t.Parallel()
+
+	interrupt := make(chan os.Signal, 1)
+	started := make(chan struct{})
+	start := time.Now()
+	go func() {
+		<-started
+		interrupt <- os.Interrupt
+	}()
+
+	_, err := callKeyringWithInterrupt("get", 10*time.Second, func() (string, error) {
+		close(started)
+		time.Sleep(10 * time.Second) // never completes within the test
+		return "should not be returned", nil
+	}, interrupt)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled wrapped, got %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("interrupt did not return promptly: elapsed=%s", elapsed)
+	}
+	if !strings.Contains(err.Error(), "interrupted") {
+		t.Errorf("error %q should mention it was interrupted", err.Error())
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/730
<!-- entire-trail-link-end -->

`while true; do entire mirror create …; done` couldn't be stopped with Ctrl-C, and interrupts spewed raw transport/keyring errors.

**Cause:** `entire` trapped SIGINT and exited *normally*. A shell only breaks a loop when the child is killed *by* SIGINT, so each Ctrl-C just ended one iteration and the loop respawned entire instantly.

**Fixes:**
- On abort, re-raise SIGINT to self → the process dies by the signal → enclosing loops break on a single Ctrl-C.
- Second Ctrl-C force-quits (escape hatch for a stuck shutdown).
- `context.Canceled` exits silently (130) instead of printing `do request: Post ".../mirrors": … context canceled`.
- Keyring reads now abort on Ctrl-C instead of waiting out the 5s timeout (or hanging on a daemon-less box).

**Try it:** `while true; do entire repo mirror create …; done`, then Ctrl-C once — the loop now exits.

Verified with a PTY harness driving interactive `zsh`: one Ctrl-C breaks the loop (0 further iterations) vs. the old behavior (loop kept running). `mise run test:ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global signal handling and exit semantics for all CLI invocations; incorrect behavior could affect shutdown, loop scripts, or interrupt during credential access.
> 
> **Overview**
> Fixes **Ctrl-C** so it reliably stops the CLI and breaks enclosing shell loops (e.g. `while true; do entire …; done`), instead of respawning each iteration or printing noisy cancellation/keyring errors.
> 
> **Process shutdown (`main`):** The first SIGINT cancels the root context and prints a short “Interrupting…” hint; a **second** Ctrl-C force-quits. User aborts that surface as `context.Canceled` no longer print as failures—they go through **`dieFromInterrupt`**, which resets SIGINT and re-raises it to the process so the shell sees a signal-killed child (not a plain `exit 130`), which is what breaks `while` loops.
> 
> **Keyring reads:** Wrapped OS keyring calls now also listen for SIGINT for the duration of the call, returning immediately with an error wrapping **`context.Canceled`** (same silent abort path) instead of waiting for the full timeout when the backend is stuck.
> 
> Adds a unit test for the injectable interrupt path on keyring calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d0b686b0e0853d99811e4156f7108625751441. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->