### PR TITLE
cli: add `entire api` authenticated passthrough (core + cell)

### DIFF
--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -149,6 +149,15 @@ func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error
 	return c.do(ctx, http.MethodDelete, path, nil, nil)
 }
 
+// Request sends an authenticated request with an explicit method, optional
+// extra headers, and an optional raw body. It's the general-purpose escape
+// hatch behind `entire api`; prefer the typed verbs (Get/Post/…) for normal
+// use. The bearer, User-Agent, and default Accept are still attached by the
+// transport; a body still gets Content-Type: application/json.
+func (c *Client) Request(ctx context.Context, method, path string, headers http.Header, body io.Reader) (*http.Response, error) {
+	return c.do(ctx, method, path, body, headers)
+}
+
 func (c *Client) do(ctx context.Context, method, path string, body io.Reader, headers http.Header) (*http.Response, error) {
 	endpoint, err := ResolveURLFromBase(c.baseURL, path)
 	if err != nil {

--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -193,7 +193,8 @@ func (c *Client) Delete(ctx context.Context, path string) (*http.Response, error
 // extra headers, and an optional raw body. It's the general-purpose escape
 // hatch behind `entire api`; prefer the typed verbs (Get/Post/…) for normal
 // use. The bearer, User-Agent, and default Accept are still attached by the
-// transport; a body still gets Content-Type: application/json.
+// transport; a body defaults to Content-Type: application/json unless the
+// caller supplies its own via headers.
 func (c *Client) Request(ctx context.Context, method, path string, headers http.Header, body io.Reader) (*http.Response, error) {
 	return c.do(ctx, method, path, body, headers)
 }
@@ -221,7 +222,10 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, he
 		}
 	}
 
-	if body != nil {
+	// Default a body's Content-Type to JSON, but don't clobber a caller-supplied
+	// one — the `entire api -H 'Content-Type: …'` escape hatch must be able to
+	// send non-JSON bodies.
+	if body != nil && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
 

--- a/cmd/entire/cli/api/client.go
+++ b/cmd/entire/cli/api/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
@@ -56,12 +57,51 @@ func NewClientWithBaseURL(token, baseURL string) *Client {
 				token: token,
 				base:  http.DefaultTransport,
 			},
+			// A cross-host redirect must never carry the Entire bearer to
+			// another origin; refuse it rather than follow it. Same-origin
+			// requests are guaranteed by the base-host check in do().
+			CheckRedirect: rejectCrossHostRedirect,
 		},
 		baseURL: baseURL,
 	}
 }
 
+// rejectCrossHostRedirect stops a redirect chain from leaving the origin the
+// client was built for. Same-host redirects (e.g. a trailing-slash normalize)
+// still follow, up to Go's usual 10-hop cap.
+func rejectCrossHostRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	if len(via) > 0 && !strings.EqualFold(req.URL.Host, via[0].URL.Host) {
+		return fmt.Errorf("refusing redirect to a different host (%s → %s): the Entire bearer must not leave its origin", via[0].URL.Host, req.URL.Host)
+	}
+	return nil
+}
+
+// requireSameHost rejects an endpoint whose host differs from the base URL's.
+// It guards the direct case (a path that resolved to another host); redirects
+// are handled by rejectCrossHostRedirect.
+func requireSameHost(baseURL, endpoint string) error {
+	b, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("parse base URL: %w", err)
+	}
+	e, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("parse endpoint URL: %w", err)
+	}
+	if !strings.EqualFold(b.Host, e.Host) {
+		return fmt.Errorf("refusing to send an authenticated request to %q, which is not the API host %q", e.Host, b.Host)
+	}
+	return nil
+}
+
 // bearerTransport is an http.RoundTripper that injects the Authorization header.
+//
+// The token is only ever sent to the client's base host: do() rejects a request
+// URL whose host differs from the base, and CheckRedirect refuses a cross-host
+// redirect, so every request this transport sees is same-origin as the base.
 //
 // When token is empty, the Authorization header is omitted (rather than sent
 // as a malformed "Authorization: Bearer "). This supports endpoints like
@@ -162,6 +202,12 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, he
 	endpoint, err := ResolveURLFromBase(c.baseURL, path)
 	if err != nil {
 		return nil, fmt.Errorf("resolve URL %s: %w", path, err)
+	}
+	// The bearer is only ever sent to the API's own host. A path that resolves
+	// to another host (absolute or scheme-relative URL) would otherwise redirect
+	// the Authorization header off-origin.
+	if err := requireSameHost(c.baseURL, endpoint); err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)

--- a/cmd/entire/cli/api/client_test.go
+++ b/cmd/entire/cli/api/client_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/versioninfo"
 )
 
-const testBearerHeader = "Bearer tok"
+const (
+	testBearerHeader = "Bearer tok"
+	jsonContentType  = "application/json"
+)
 
 func TestBearerTransport_InjectsAuthHeader(t *testing.T) {
 	t.Parallel()
@@ -52,8 +55,8 @@ func TestBearerTransport_InjectsAuthHeader(t *testing.T) {
 	if want := versioninfo.UserAgent(); gotUA != want {
 		t.Errorf("User-Agent = %q, want %q", gotUA, want)
 	}
-	if gotAccept != "application/json" {
-		t.Errorf("Accept = %q, want %q", gotAccept, "application/json")
+	if gotAccept != jsonContentType {
+		t.Errorf("Accept = %q, want %q", gotAccept, jsonContentType)
 	}
 }
 
@@ -171,7 +174,7 @@ func TestClient_Get(t *testing.T) {
 		if r.Header.Get("Authorization") != "Bearer my-token" {
 			t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
 		}
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", jsonContentType)
 		w.Write([]byte(`{"ok": true}`)) //nolint:errcheck // test handler
 	}))
 	defer server.Close()
@@ -219,7 +222,7 @@ func TestClient_Post_JSON(t *testing.T) {
 	if resp.StatusCode != http.StatusCreated {
 		t.Errorf("status = %d, want 201", resp.StatusCode)
 	}
-	if gotContentType != "application/json" {
+	if gotContentType != jsonContentType {
 		t.Errorf("Content-Type = %q, want application/json", gotContentType)
 	}
 	if gotBody["name"] != "test" {
@@ -268,7 +271,7 @@ func TestCheckResponse_ErrorWithJSON(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", jsonContentType)
 		w.WriteHeader(http.StatusForbidden)
 		w.Write([]byte(`{"error": "insufficient permissions"}`)) //nolint:errcheck // test handler
 	}))
@@ -293,7 +296,7 @@ func TestCheckResponse_ErrorWithObjectEnvelope(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", jsonContentType)
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte(`{"error":{"code":"not_found","message":"session not found","field":null,"retryable":false}}`)) //nolint:errcheck // test handler
 	}))
@@ -342,7 +345,7 @@ func TestDecodeJSONResponse(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", jsonContentType)
 		w.Write([]byte(`{"id": "abc", "status": "ok"}`)) //nolint:errcheck // test handler
 	}))
 	defer server.Close()
@@ -400,7 +403,7 @@ func TestDecodeJSONResponse_LargeBodyOverOldCap(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", jsonContentType)
 		w.Write(encoded) //nolint:errcheck // test handler
 	}))
 	defer server.Close()
@@ -480,5 +483,40 @@ func TestClient_RefusesCrossHostRedirect(t *testing.T) {
 	}
 	if reached {
 		t.Fatalf("request reached the other host (Authorization=%q); bearer must not follow a cross-host redirect", leakedAuth)
+	}
+}
+
+// TestClient_Request_RespectsCallerContentType verifies a caller-supplied
+// Content-Type survives (the -H escape hatch), while a body with no
+// Content-Type still defaults to JSON.
+func TestClient_Request_RespectsCallerContentType(t *testing.T) {
+	t.Parallel()
+
+	var gotCT string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := NewClientWithBaseURL("tok", server.URL)
+
+	resp, err := c.Request(context.Background(), http.MethodPost, "/x",
+		http.Header{"Content-Type": {"text/plain"}}, strings.NewReader("hi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if gotCT != "text/plain" {
+		t.Errorf("caller Content-Type = %q, want text/plain (must not be clobbered)", gotCT)
+	}
+
+	resp, err = c.Request(context.Background(), http.MethodPost, "/y", nil, strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if gotCT != jsonContentType {
+		t.Errorf("default Content-Type = %q, want application/json", gotCT)
 	}
 }

--- a/cmd/entire/cli/api/client_test.go
+++ b/cmd/entire/cli/api/client_test.go
@@ -421,3 +421,64 @@ func TestDecodeJSONResponse_LargeBodyOverOldCap(t *testing.T) {
 		t.Errorf("decoded %d items, want %d", len(got.Items), itemCount)
 	}
 }
+
+// TestClient_RefusesCrossHostPath verifies a path that resolves to a host other
+// than the client's base is rejected before any request (and its bearer) is
+// sent — covering absolute and scheme-relative URLs.
+func TestClient_RefusesCrossHostPath(t *testing.T) {
+	t.Parallel()
+
+	var reached bool
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer other.Close()
+
+	c := NewClientWithBaseURL("secret-token", "https://api.example")
+
+	for _, path := range []string{other.URL + "/leak", "//evil.example/x", "https://evil.example/x"} {
+		resp, err := c.Get(context.Background(), path)
+		if err == nil {
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+			t.Errorf("Get(%q) = nil error, want cross-host rejection", path)
+		}
+	}
+	if reached {
+		t.Fatal("request reached another host; the bearer must not be sent off-origin")
+	}
+}
+
+// TestClient_RefusesCrossHostRedirect verifies a backend redirect to another
+// host is refused rather than followed with the bearer.
+func TestClient_RefusesCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	var reached bool
+	var leakedAuth string
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		leakedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer other.Close()
+
+	base := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, other.URL+"/leak", http.StatusFound)
+	}))
+	defer base.Close()
+
+	client := NewClientWithBaseURL("secret-token", base.URL)
+	resp, err := client.Get(context.Background(), "/start")
+	if err == nil {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		t.Fatal("expected cross-host redirect to be refused")
+	}
+	if reached {
+		t.Fatalf("request reached the other host (Authorization=%q); bearer must not follow a cross-host redirect", leakedAuth)
+	}
+}

--- a/cmd/entire/cli/api_cmd.go
+++ b/cmd/entire/cli/api_cmd.go
@@ -338,9 +338,23 @@ func appendQuery(path string, q url.Values) string {
 	return path + sep + q.Encode()
 }
 
+// readWithinLimit reads r up to limit bytes and errors if the source is larger,
+// rather than silently truncating — a truncated JSON body would be malformed
+// and misleading for an escape-hatch command.
+func readWithinLimit(r io.Reader, limit int64) ([]byte, error) {
+	raw, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read: %w", err)
+	}
+	if int64(len(raw)) > limit {
+		return nil, fmt.Errorf("exceeds the %d-byte limit", limit)
+	}
+	return raw, nil
+}
+
 func readAPIInput(path string) ([]byte, error) {
 	if path == "-" {
-		raw, err := io.ReadAll(io.LimitReader(os.Stdin, apiMaxResponseBytes))
+		raw, err := readWithinLimit(os.Stdin, apiMaxResponseBytes)
 		if err != nil {
 			return nil, fmt.Errorf("read body from stdin: %w", err)
 		}
@@ -381,7 +395,7 @@ func writeAPIResponse(w, errW io.Writer, resp *http.Response, include bool) erro
 		fmt.Fprintln(errW)
 	}
 
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, apiMaxResponseBytes))
+	raw, err := readWithinLimit(resp.Body, apiMaxResponseBytes)
 	if err != nil {
 		return fmt.Errorf("read response body: %w", err)
 	}

--- a/cmd/entire/cli/api_cmd.go
+++ b/cmd/entire/cli/api_cmd.go
@@ -121,7 +121,9 @@ func resolveAPIClient(ctx context.Context, to string, insecure bool) (*api.Clien
 			return nil, err
 		}
 		if target.token == "" {
-			return nil, NewSilentError(errors.New("not logged in (run 'entire login' first)"))
+			// Return a normal (non-silent) error so main.go prints the hint;
+			// a SilentError would exit non-zero with no explanation.
+			return nil, errors.New("not logged in: run 'entire login' to authenticate")
 		}
 		if !insecure && target.coreURL != "" {
 			if err := api.RequireSecureURL(target.coreURL); err != nil {

--- a/cmd/entire/cli/api_cmd.go
+++ b/cmd/entire/cli/api_cmd.go
@@ -88,7 +88,7 @@ func runAPI(ctx context.Context, w, errW io.Writer, rawPath string, f *apiFlags)
 		return err
 	}
 
-	req, err := buildAPIRequestBody(ctx, path, f, fields)
+	req, err := buildAPIRequestBody(path, f, fields)
 	if err != nil {
 		return err
 	}
@@ -141,19 +141,24 @@ func resolveAPIClient(ctx context.Context, to string, insecure bool) (*api.Clien
 // Resolution is lazy: {owner}/{repo} need only the git remote; {repo_id} costs
 // a control-plane mirror lookup, so it's only done when actually referenced.
 func expandAPIPlaceholders(ctx context.Context, s string) (string, error) {
-	if !strings.Contains(s, "{") {
+	needOwnerRepo := strings.Contains(s, "{owner}") || strings.Contains(s, "{repo}")
+	needRepoID := strings.Contains(s, "{repo_id}")
+	if !needOwnerRepo && !needRepoID {
 		return s, nil
 	}
-	if strings.Contains(s, "{owner}") || strings.Contains(s, "{repo}") {
-		_, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
-		if err != nil {
-			return "", fmt.Errorf("resolve {owner}/{repo} from origin remote: %w", err)
-		}
+
+	// Resolve the origin remote once, even when both {owner}/{repo} and
+	// {repo_id} are present, and thread it into the mirror lookup.
+	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	if err != nil {
+		return "", fmt.Errorf("resolve current repo from origin remote: %w", err)
+	}
+	if needOwnerRepo {
 		s = strings.ReplaceAll(s, "{owner}", owner)
 		s = strings.ReplaceAll(s, "{repo}", repo)
 	}
-	if strings.Contains(s, "{repo_id}") {
-		id, err := resolveCurrentRepoID(ctx)
+	if needRepoID {
+		id, err := resolveCurrentRepoID(ctx, forge, owner, repo)
 		if err != nil {
 			return "", err
 		}
@@ -162,14 +167,10 @@ func expandAPIPlaceholders(ctx context.Context, s string) (string, error) {
 	return s, nil
 }
 
-// resolveCurrentRepoID resolves the current repo's Entire ULID from its mirror
-// (the mirror id, which entire-api uses as the repo_id). Picks the first active
-// (non-archived, non-failed/suspended) placement.
-func resolveCurrentRepoID(ctx context.Context) (string, error) {
-	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
-	if err != nil {
-		return "", fmt.Errorf("resolve current repo: %w", err)
-	}
+// resolveCurrentRepoID resolves a repo's Entire ULID from its mirror (the mirror
+// id, which entire-api uses as the repo_id), given its already-resolved origin
+// coordinates. Picks the first active placement.
+func resolveCurrentRepoID(ctx context.Context, forge, owner, repo string) (string, error) {
 	if f := strings.ToLower(strings.TrimSpace(forge)); f != "gh" && f != mirrorCloneProviderGitHub {
 		return "", fmt.Errorf("{repo_id} needs a GitHub repo; origin forge is %q", forge)
 	}
@@ -182,10 +183,7 @@ func resolveCurrentRepoID(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("list mirrors for %s/%s: %w", owner, repo, err)
 	}
 	for i := range mirrors {
-		if mirrors[i].IsArchived.Or(false) {
-			continue
-		}
-		if st := mirrors[i].Status.Or(coreapi.MirrorStatusReady); st == coreapi.MirrorStatusFailed || st == coreapi.MirrorStatusSuspended {
+		if !isActiveMirror(mirrors[i]) {
 			continue
 		}
 		if id := strings.TrimSpace(mirrors[i].MirrorId); id != "" {
@@ -246,29 +244,25 @@ type apiRequest struct {
 // body), else fields become a JSON body. The method defaults to GET, or POST
 // when there's a body; an explicit -X wins. For a GET with fields, the fields
 // go on the query string instead of a body.
-func buildAPIRequestBody(ctx context.Context, path string, f *apiFlags, fields map[string]any) (apiRequest, error) {
+func buildAPIRequestBody(path string, f *apiFlags, fields map[string]any) (apiRequest, error) {
 	method := strings.ToUpper(strings.TrimSpace(f.method))
+	if method == "" {
+		if f.input != "" || len(fields) > 0 {
+			method = http.MethodPost
+		} else {
+			method = http.MethodGet
+		}
+	}
 
 	if f.input != "" {
 		if len(fields) > 0 {
 			return apiRequest{}, errors.New("use either --input or -f/-F, not both")
 		}
-		raw, err := readAPIInput(ctx, f.input)
+		raw, err := readAPIInput(f.input)
 		if err != nil {
 			return apiRequest{}, err
 		}
-		if method == "" {
-			method = http.MethodPost
-		}
 		return apiRequest{method: method, path: path, body: bytes.NewReader(raw)}, nil
-	}
-
-	if method == "" {
-		if len(fields) > 0 {
-			method = http.MethodPost
-		} else {
-			method = http.MethodGet
-		}
 	}
 
 	if len(fields) == 0 {
@@ -323,9 +317,9 @@ func appendQuery(path string, q url.Values) string {
 	return path + sep + q.Encode()
 }
 
-func readAPIInput(ctx context.Context, path string) ([]byte, error) {
+func readAPIInput(path string) ([]byte, error) {
 	if path == "-" {
-		raw, err := io.ReadAll(io.LimitReader(stdinReader(ctx), apiMaxResponseBytes))
+		raw, err := io.ReadAll(io.LimitReader(os.Stdin, apiMaxResponseBytes))
 		if err != nil {
 			return nil, fmt.Errorf("read body from stdin: %w", err)
 		}
@@ -337,9 +331,6 @@ func readAPIInput(ctx context.Context, path string) ([]byte, error) {
 	}
 	return raw, nil
 }
-
-// stdinReader is a seam so tests can supply a body without touching os.Stdin.
-var stdinReader = func(context.Context) io.Reader { return os.Stdin }
 
 func parseAPIHeaders(headers []string) (http.Header, error) {
 	h := make(http.Header, len(headers))

--- a/cmd/entire/cli/api_cmd.go
+++ b/cmd/entire/cli/api_cmd.go
@@ -1,0 +1,395 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/entireio/cli/cmd/entire/cli/api"
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/cmd/entire/cli/gitremote"
+	"github.com/entireio/cli/internal/coreapi"
+)
+
+const apiMaxResponseBytes = 32 << 20 // 32 MiB cap on a printed response body.
+
+type apiFlags struct {
+	to           string
+	method       string
+	rawFields    []string
+	typedFields  []string
+	headers      []string
+	input        string
+	include      bool
+	insecureHTTP bool
+}
+
+func newAPICmd() *cobra.Command {
+	f := &apiFlags{}
+	cmd := &cobra.Command{
+		Use:   "api <path>",
+		Short: "Make an authenticated request to an Entire API and print the response",
+		Long: "Make an authenticated HTTP request to an Entire API and print the JSON response.\n\n" +
+			"The CLI attaches the right bearer token and dials the right host for the\n" +
+			"chosen backend, so you don't have to plumb auth yourself:\n\n" +
+			"  --to core   the control plane (default): orgs, repos, mirrors, clusters, /me\n" +
+			"  --to cell   your home entire-api cell: /me/* activity, repo aggregates\n\n" +
+			"<path> is the full path on that host, e.g. /api/v1/clusters. These\n" +
+			"placeholders are filled from the current repo's origin remote:\n" +
+			"  {owner} {repo}   the GitHub owner / repo\n" +
+			"  {repo_id}        the repo's Entire ULID (from its mirror) — cells key on this\n\n" +
+			"The method is GET unless a field/body is given (then POST); override with -X.",
+		Example: "  entire api /api/v1/clusters\n" +
+			"  entire api --to cell /api/v1/me/activity\n" +
+			"  entire api --to cell \"/api/v1/me/recap?repo={repo_id}\"\n" +
+			"  entire api -X POST /api/v1/projects -f name=demo",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAPI(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args[0], f)
+		},
+	}
+	cmd.Flags().StringVar(&f.to, "to", "core", "which backend to call: core or cell")
+	cmd.Flags().StringVarP(&f.method, "method", "X", "", "HTTP method (default GET, or POST when a field/body is given)")
+	cmd.Flags().StringArrayVarP(&f.rawFields, "raw-field", "f", nil, "add a string parameter in key=value format (repeatable)")
+	cmd.Flags().StringArrayVarP(&f.typedFields, "field", "F", nil, "add a typed parameter in key=value format; true/false/null/numbers are converted (repeatable)")
+	cmd.Flags().StringArrayVarP(&f.headers, "header", "H", nil, "add a request header in key:value format (repeatable)")
+	cmd.Flags().StringVar(&f.input, "input", "", "file with the request body (\"-\" for stdin)")
+	cmd.Flags().BoolVarP(&f.include, "include", "i", false, "print the response status line and headers too")
+	addInsecureHTTPAuthFlag(cmd, &f.insecureHTTP)
+	return cmd
+}
+
+func runAPI(ctx context.Context, w, errW io.Writer, rawPath string, f *apiFlags) error {
+	insecure := applyInsecureHTTPAuth(f.insecureHTTP)
+
+	client, err := resolveAPIClient(ctx, f.to, insecure)
+	if err != nil {
+		return err
+	}
+
+	path, err := expandAPIPlaceholders(ctx, rawPath)
+	if err != nil {
+		return err
+	}
+
+	fields, err := buildAPIFields(f.rawFields, f.typedFields)
+	if err != nil {
+		return err
+	}
+
+	req, err := buildAPIRequestBody(ctx, path, f, fields)
+	if err != nil {
+		return err
+	}
+
+	headers, err := parseAPIHeaders(f.headers)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Request(ctx, req.method, req.path, headers, req.body)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", req.method, req.path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return writeAPIResponse(w, errW, resp, f.include)
+}
+
+// resolveAPIClient builds an authenticated client for the chosen backend. Both
+// return an *api.Client whose base URL is the backend origin, so <path> is the
+// full path (e.g. /api/v1/…) against that host.
+func resolveAPIClient(ctx context.Context, to string, insecure bool) (*api.Client, error) {
+	switch strings.ToLower(strings.TrimSpace(to)) {
+	case "", "core":
+		target, err := resolveAuthStatusTarget(ctx, auth.Contexts, auth.RefreshedLoginToken)
+		if err != nil {
+			return nil, err
+		}
+		if target.token == "" {
+			return nil, NewSilentError(errors.New("not logged in (run 'entire login' first)"))
+		}
+		if !insecure && target.coreURL != "" {
+			if err := api.RequireSecureURL(target.coreURL); err != nil {
+				return nil, fmt.Errorf("control-plane URL check: %w", err)
+			}
+		}
+		return api.NewClientWithBaseURL(target.token, target.coreURL), nil
+	case "cell":
+		client, err := auth.NewEntireAPICellClient(ctx, insecure, nil)
+		if err != nil {
+			return nil, err //nolint:wrapcheck // NewEntireAPICellClient already returns contextual auth errors
+		}
+		return client, nil
+	default:
+		return nil, fmt.Errorf("unknown --to %q (use core or cell)", to)
+	}
+}
+
+// expandAPIPlaceholders fills {owner}/{repo}/{repo_id} from the current repo.
+// Resolution is lazy: {owner}/{repo} need only the git remote; {repo_id} costs
+// a control-plane mirror lookup, so it's only done when actually referenced.
+func expandAPIPlaceholders(ctx context.Context, s string) (string, error) {
+	if !strings.Contains(s, "{") {
+		return s, nil
+	}
+	if strings.Contains(s, "{owner}") || strings.Contains(s, "{repo}") {
+		_, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+		if err != nil {
+			return "", fmt.Errorf("resolve {owner}/{repo} from origin remote: %w", err)
+		}
+		s = strings.ReplaceAll(s, "{owner}", owner)
+		s = strings.ReplaceAll(s, "{repo}", repo)
+	}
+	if strings.Contains(s, "{repo_id}") {
+		id, err := resolveCurrentRepoID(ctx)
+		if err != nil {
+			return "", err
+		}
+		s = strings.ReplaceAll(s, "{repo_id}", id)
+	}
+	return s, nil
+}
+
+// resolveCurrentRepoID resolves the current repo's Entire ULID from its mirror
+// (the mirror id, which entire-api uses as the repo_id). Picks the first active
+// (non-archived, non-failed/suspended) placement.
+func resolveCurrentRepoID(ctx context.Context) (string, error) {
+	forge, owner, repo, err := gitremote.ResolveRemoteRepo(ctx, "origin")
+	if err != nil {
+		return "", fmt.Errorf("resolve current repo: %w", err)
+	}
+	if f := strings.ToLower(strings.TrimSpace(forge)); f != "gh" && f != mirrorCloneProviderGitHub {
+		return "", fmt.Errorf("{repo_id} needs a GitHub repo; origin forge is %q", forge)
+	}
+	c, err := coreapi.New()
+	if err != nil {
+		return "", fmt.Errorf("resolve {repo_id} needs the control plane: %w", err)
+	}
+	mirrors, err := listMirrorsForRepo(ctx, c, mirrorCloneProviderGitHub, strings.ToLower(owner), strings.ToLower(repo))
+	if err != nil {
+		return "", fmt.Errorf("list mirrors for %s/%s: %w", owner, repo, err)
+	}
+	for i := range mirrors {
+		if mirrors[i].IsArchived.Or(false) {
+			continue
+		}
+		if st := mirrors[i].Status.Or(coreapi.MirrorStatusReady); st == coreapi.MirrorStatusFailed || st == coreapi.MirrorStatusSuspended {
+			continue
+		}
+		if id := strings.TrimSpace(mirrors[i].MirrorId); id != "" {
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("no active mirror for %s/%s to resolve {repo_id}", owner, repo)
+}
+
+// buildAPIFields merges -f (always string) and -F (type-inferred) into one map.
+// Returns an empty (non-nil) map when no fields are given.
+func buildAPIFields(rawFields, typedFields []string) (map[string]any, error) {
+	out := make(map[string]any, len(rawFields)+len(typedFields))
+	for _, kv := range rawFields {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid -f %q (want key=value)", kv)
+		}
+		out[k] = v
+	}
+	for _, kv := range typedFields {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid -F %q (want key=value)", kv)
+		}
+		out[k] = inferFieldValue(v)
+	}
+	return out, nil
+}
+
+// inferFieldValue mirrors gh's -F conversion: true/false/null and numbers get
+// their JSON type; everything else stays a string.
+func inferFieldValue(v string) any {
+	switch v {
+	case "true":
+		return true
+	case "false":
+		return false
+	case "null":
+		return nil
+	}
+	if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return n
+	}
+	if fl, err := strconv.ParseFloat(v, 64); err == nil {
+		return fl
+	}
+	return v
+}
+
+type apiRequest struct {
+	method string
+	path   string
+	body   io.Reader
+}
+
+// buildAPIRequestBody resolves method + body from the flags: --input wins (raw
+// body), else fields become a JSON body. The method defaults to GET, or POST
+// when there's a body; an explicit -X wins. For a GET with fields, the fields
+// go on the query string instead of a body.
+func buildAPIRequestBody(ctx context.Context, path string, f *apiFlags, fields map[string]any) (apiRequest, error) {
+	method := strings.ToUpper(strings.TrimSpace(f.method))
+
+	if f.input != "" {
+		if len(fields) > 0 {
+			return apiRequest{}, errors.New("use either --input or -f/-F, not both")
+		}
+		raw, err := readAPIInput(ctx, f.input)
+		if err != nil {
+			return apiRequest{}, err
+		}
+		if method == "" {
+			method = http.MethodPost
+		}
+		return apiRequest{method: method, path: path, body: bytes.NewReader(raw)}, nil
+	}
+
+	if method == "" {
+		if len(fields) > 0 {
+			method = http.MethodPost
+		} else {
+			method = http.MethodGet
+		}
+	}
+
+	if len(fields) == 0 {
+		return apiRequest{method: method, path: path, body: nil}, nil
+	}
+
+	if method == http.MethodGet {
+		q, err := fieldsToQuery(fields)
+		if err != nil {
+			return apiRequest{}, err
+		}
+		return apiRequest{method: method, path: appendQuery(path, q), body: nil}, nil
+	}
+
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return apiRequest{}, fmt.Errorf("encode fields: %w", err)
+	}
+	return apiRequest{method: method, path: path, body: bytes.NewReader(data)}, nil
+}
+
+// fieldsToQuery stringifies fields for a GET query string. Non-string scalars
+// are rendered with their JSON form (e.g. true, 42) so -F round-trips sensibly.
+func fieldsToQuery(fields map[string]any) (url.Values, error) {
+	q := make(url.Values, len(fields))
+	for k, v := range fields {
+		switch val := v.(type) {
+		case string:
+			q.Set(k, val)
+		case nil:
+			q.Set(k, "null")
+		default:
+			b, err := json.Marshal(val)
+			if err != nil {
+				return nil, fmt.Errorf("encode field %q: %w", k, err)
+			}
+			q.Set(k, string(b))
+		}
+	}
+	return q, nil
+}
+
+// appendQuery adds encoded query params to a path that may already have some.
+func appendQuery(path string, q url.Values) string {
+	if len(q) == 0 {
+		return path
+	}
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return path + sep + q.Encode()
+}
+
+func readAPIInput(ctx context.Context, path string) ([]byte, error) {
+	if path == "-" {
+		raw, err := io.ReadAll(io.LimitReader(stdinReader(ctx), apiMaxResponseBytes))
+		if err != nil {
+			return nil, fmt.Errorf("read body from stdin: %w", err)
+		}
+		return raw, nil
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // a user-specified request-body file is the whole point
+	if err != nil {
+		return nil, fmt.Errorf("read body file: %w", err)
+	}
+	return raw, nil
+}
+
+// stdinReader is a seam so tests can supply a body without touching os.Stdin.
+var stdinReader = func(context.Context) io.Reader { return os.Stdin }
+
+func parseAPIHeaders(headers []string) (http.Header, error) {
+	h := make(http.Header, len(headers))
+	for _, kv := range headers {
+		k, v, ok := strings.Cut(kv, ":")
+		if !ok || strings.TrimSpace(k) == "" {
+			return nil, fmt.Errorf("invalid -H %q (want key:value)", kv)
+		}
+		h.Add(strings.TrimSpace(k), strings.TrimSpace(v))
+	}
+	return h, nil
+}
+
+func writeAPIResponse(w, errW io.Writer, resp *http.Response, include bool) error {
+	if include {
+		fmt.Fprintf(errW, "%s %s\n", resp.Proto, resp.Status)
+		names := make([]string, 0, len(resp.Header))
+		for name := range resp.Header {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			for _, v := range resp.Header[name] {
+				fmt.Fprintf(errW, "%s: %s\n", name, v)
+			}
+		}
+		fmt.Fprintln(errW)
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, apiMaxResponseBytes))
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+
+	toWrite := raw
+	if body := bytes.TrimSpace(raw); len(body) > 0 && json.Valid(body) {
+		var pretty bytes.Buffer
+		if json.Indent(&pretty, body, "", "  ") == nil {
+			pretty.WriteByte('\n')
+			toWrite = pretty.Bytes()
+		}
+	}
+	if _, err := w.Write(toWrite); err != nil {
+		return fmt.Errorf("write response: %w", err)
+	}
+
+	// Non-2xx: the body is already printed; return a silent error so the exit
+	// code is non-zero for scripts without reprinting anything.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return NewSilentError(fmt.Errorf("HTTP %d", resp.StatusCode))
+	}
+	return nil
+}

--- a/cmd/entire/cli/api_cmd.go
+++ b/cmd/entire/cli/api_cmd.go
@@ -82,6 +82,9 @@ func runAPI(ctx context.Context, w, errW io.Writer, rawPath string, f *apiFlags)
 	if err != nil {
 		return err
 	}
+	if err := validateAPIPath(path); err != nil {
+		return err
+	}
 
 	fields, err := buildAPIFields(f.rawFields, f.typedFields)
 	if err != nil {
@@ -135,6 +138,22 @@ func resolveAPIClient(ctx context.Context, to string, insecure bool) (*api.Clien
 	default:
 		return nil, fmt.Errorf("unknown --to %q (use core or cell)", to)
 	}
+}
+
+// validateAPIPath rejects anything that isn't origin-relative. The path is
+// resolved against the backend origin via url.ResolveReference, which lets an
+// absolute ("https://evil/…") or scheme-relative ("//evil/…") value replace the
+// host — and the bearer transport would then send the Entire token there. So a
+// path carrying its own scheme or host is refused before any request is made.
+func validateAPIPath(path string) error {
+	u, err := url.Parse(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q: %w", path, err)
+	}
+	if u.Scheme != "" || u.Host != "" {
+		return fmt.Errorf("path must be origin-relative (e.g. /api/v1/…), not a cross-host or absolute URL: %q", path)
+	}
+	return nil
 }
 
 // expandAPIPlaceholders fills {owner}/{repo}/{repo_id} from the current repo.

--- a/cmd/entire/cli/api_cmd_test.go
+++ b/cmd/entire/cli/api_cmd_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestInferFieldValue(t *testing.T) {
+	t.Parallel()
+	cases := map[string]any{
+		"true":  true,
+		"false": false,
+		"null":  nil,
+		"42":    int64(42),
+		"-7":    int64(-7),
+		"3.14":  3.14,
+		"demo":  "demo",
+		"":      "",
+		"v1.2":  "v1.2",
+	}
+	for in, want := range cases {
+		if got := inferFieldValue(in); got != want {
+			t.Errorf("inferFieldValue(%q) = %#v, want %#v", in, got, want)
+		}
+	}
+}
+
+func TestBuildAPIFields(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildAPIFields([]string{"name=demo"}, []string{"count=3", "enabled=true"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["name"] != "demo" || got["count"] != int64(3) || got["enabled"] != true {
+		t.Fatalf("fields = %#v", got)
+	}
+
+	if f, err := buildAPIFields(nil, nil); len(f) != 0 || err != nil {
+		t.Fatalf("no fields = (%v, %v), want (empty, nil)", f, err)
+	}
+	if _, err := buildAPIFields([]string{"bogus"}, nil); err == nil {
+		t.Error("expected error for -f without '='")
+	}
+	if _, err := buildAPIFields(nil, []string{"=novalue"}); err == nil {
+		t.Error("expected error for -F with empty key")
+	}
+}
+
+func TestParseAPIHeaders(t *testing.T) {
+	t.Parallel()
+
+	h, err := parseAPIHeaders([]string{"Accept: application/json", "X-Foo:bar"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.Get("Accept") != "application/json" || h.Get("X-Foo") != "bar" {
+		t.Fatalf("headers = %v", h)
+	}
+	if _, err := parseAPIHeaders([]string{"nocolon"}); err == nil {
+		t.Error("expected error for header without ':'")
+	}
+}
+
+func TestBuildAPIRequestBody_MethodInference(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// No fields, no method → GET, no body.
+	r, err := buildAPIRequestBody(ctx, "/p", &apiFlags{}, nil)
+	if err != nil || r.method != http.MethodGet || r.body != nil {
+		t.Fatalf("bare = %+v, err %v", r, err)
+	}
+
+	// Fields, no method → POST with JSON body.
+	r, err = buildAPIRequestBody(ctx, "/p", &apiFlags{}, map[string]any{"a": "b"})
+	if err != nil || r.method != http.MethodPost || r.body == nil {
+		t.Fatalf("fields = %+v, err %v", r, err)
+	}
+
+	// Explicit -X wins over inference.
+	r, err = buildAPIRequestBody(ctx, "/p", &apiFlags{method: "delete"}, nil)
+	if err != nil || r.method != http.MethodDelete {
+		t.Fatalf("explicit method = %+v, err %v", r, err)
+	}
+
+	// GET + fields → fields go on the query string, no body.
+	r, err = buildAPIRequestBody(ctx, "/p", &apiFlags{method: "GET"}, map[string]any{"limit": int64(5)})
+	if err != nil || r.body != nil || !strings.Contains(r.path, "limit=5") {
+		t.Fatalf("GET+fields = %+v, err %v", r, err)
+	}
+
+	// --input together with fields is rejected.
+	if _, err := buildAPIRequestBody(ctx, "/p", &apiFlags{input: "x"}, map[string]any{"a": "b"}); err == nil {
+		t.Error("expected error combining --input and fields")
+	}
+}
+
+func TestAppendQuery(t *testing.T) {
+	t.Parallel()
+
+	if got := appendQuery("/p", nil); got != "/p" {
+		t.Errorf("empty query = %q", got)
+	}
+	q, err := fieldsToQuery(map[string]any{"a": "b"})
+	if err != nil {
+		t.Fatalf("fieldsToQuery: %v", err)
+	}
+	if got := appendQuery("/p", q); got != "/p?a=b" {
+		t.Errorf("fresh query = %q, want /p?a=b", got)
+	}
+	if got := appendQuery("/p?x=1", q); got != "/p?x=1&a=b" {
+		t.Errorf("existing query = %q, want /p?x=1&a=b", got)
+	}
+}
+
+func TestResolveAPIClient_UnknownTarget(t *testing.T) {
+	t.Parallel()
+	if _, err := resolveAPIClient(context.Background(), "banana", false); err == nil {
+		t.Error("expected error for unknown --to")
+	}
+}
+
+func TestWriteAPIResponse(t *testing.T) {
+	t.Parallel()
+
+	newResp := func(status int, body string) *http.Response {
+		return &http.Response{
+			StatusCode: status,
+			Proto:      "HTTP/2.0",
+			Status:     http.StatusText(status),
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}
+	}
+
+	write := func(status int, body string, include bool) (out, errOut bytes.Buffer, err error) {
+		resp := newResp(status, body)
+		defer func() { _ = resp.Body.Close() }()
+		err = writeAPIResponse(&out, &errOut, resp, include)
+		return out, errOut, err
+	}
+
+	// 2xx JSON is pretty-printed (indentation added) and returns no error.
+	out, _, err := write(200, `{"a":1}`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out.String(), "\n  \"a\": 1") {
+		t.Fatalf("expected indented JSON, got:\n%s", out.String())
+	}
+
+	// Non-2xx still prints the body but returns a (silent) error for a non-zero exit.
+	out, _, err = write(404, `{"error":"nope"}`, false)
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(out.String(), "nope") {
+		t.Fatalf("expected body printed on 404, got:\n%s", out.String())
+	}
+
+	// --include writes the status line + headers to errOut.
+	_, errOut, err := write(200, `{}`, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "HTTP/2.0") || !strings.Contains(errOut.String(), "Content-Type: application/json") {
+		t.Fatalf("expected status+headers on errOut, got:\n%s", errOut.String())
+	}
+}

--- a/cmd/entire/cli/api_cmd_test.go
+++ b/cmd/entire/cli/api_cmd_test.go
@@ -194,3 +194,22 @@ func TestWriteAPIResponse(t *testing.T) {
 		t.Fatalf("expected status+headers on errOut, got:\n%s", errOut.String())
 	}
 }
+
+func TestReadWithinLimit(t *testing.T) {
+	t.Parallel()
+
+	// Under and exactly at the limit: full content, no error.
+	for _, tc := range []struct {
+		in    string
+		limit int64
+	}{{"hello", 10}, {"hello", 5}, {"", 3}} {
+		got, err := readWithinLimit(strings.NewReader(tc.in), tc.limit)
+		if err != nil || string(got) != tc.in {
+			t.Errorf("readWithinLimit(%q, %d) = (%q, %v), want (%q, nil)", tc.in, tc.limit, got, err, tc.in)
+		}
+	}
+	// Over the limit: error rather than silent truncation.
+	if _, err := readWithinLimit(strings.NewReader("hello world"), 5); err == nil {
+		t.Error("readWithinLimit over limit = nil error, want limit error (must not truncate)")
+	}
+}

--- a/cmd/entire/cli/api_cmd_test.go
+++ b/cmd/entire/cli/api_cmd_test.go
@@ -68,34 +68,33 @@ func TestParseAPIHeaders(t *testing.T) {
 
 func TestBuildAPIRequestBody_MethodInference(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// No fields, no method → GET, no body.
-	r, err := buildAPIRequestBody(ctx, "/p", &apiFlags{}, nil)
+	r, err := buildAPIRequestBody("/p", &apiFlags{}, nil)
 	if err != nil || r.method != http.MethodGet || r.body != nil {
 		t.Fatalf("bare = %+v, err %v", r, err)
 	}
 
 	// Fields, no method → POST with JSON body.
-	r, err = buildAPIRequestBody(ctx, "/p", &apiFlags{}, map[string]any{"a": "b"})
+	r, err = buildAPIRequestBody("/p", &apiFlags{}, map[string]any{"a": "b"})
 	if err != nil || r.method != http.MethodPost || r.body == nil {
 		t.Fatalf("fields = %+v, err %v", r, err)
 	}
 
 	// Explicit -X wins over inference.
-	r, err = buildAPIRequestBody(ctx, "/p", &apiFlags{method: "delete"}, nil)
+	r, err = buildAPIRequestBody("/p", &apiFlags{method: "delete"}, nil)
 	if err != nil || r.method != http.MethodDelete {
 		t.Fatalf("explicit method = %+v, err %v", r, err)
 	}
 
 	// GET + fields → fields go on the query string, no body.
-	r, err = buildAPIRequestBody(ctx, "/p", &apiFlags{method: "GET"}, map[string]any{"limit": int64(5)})
+	r, err = buildAPIRequestBody("/p", &apiFlags{method: "GET"}, map[string]any{"limit": int64(5)})
 	if err != nil || r.body != nil || !strings.Contains(r.path, "limit=5") {
 		t.Fatalf("GET+fields = %+v, err %v", r, err)
 	}
 
 	// --input together with fields is rejected.
-	if _, err := buildAPIRequestBody(ctx, "/p", &apiFlags{input: "x"}, map[string]any{"a": "b"}); err == nil {
+	if _, err := buildAPIRequestBody("/p", &apiFlags{input: "x"}, map[string]any{"a": "b"}); err == nil {
 		t.Error("expected error combining --input and fields")
 	}
 }

--- a/cmd/entire/cli/api_cmd_test.go
+++ b/cmd/entire/cli/api_cmd_test.go
@@ -117,6 +117,29 @@ func TestAppendQuery(t *testing.T) {
 	}
 }
 
+func TestValidateAPIPath(t *testing.T) {
+	t.Parallel()
+
+	// Origin-relative paths are allowed.
+	for _, ok := range []string{"/api/v1/clusters", "/api/v1/me/recap?repo=01K", "api/v1/x", "/"} {
+		if err := validateAPIPath(ok); err != nil {
+			t.Errorf("validateAPIPath(%q) = %v, want nil", ok, err)
+		}
+	}
+	// Absolute and scheme-relative URLs must be refused — they'd redirect the
+	// bearer token to another host via url.ResolveReference.
+	for _, bad := range []string{
+		"https://evil.example/api/v1/x",
+		"http://evil.example/x",
+		"//evil.example/x",
+		"https:/evil",
+	} {
+		if err := validateAPIPath(bad); err == nil {
+			t.Errorf("validateAPIPath(%q) = nil, want rejection (token-leak vector)", bad)
+		}
+	}
+}
+
 func TestResolveAPIClient_UnknownTarget(t *testing.T) {
 	t.Parallel()
 	if _, err := resolveAPIClient(context.Background(), "banana", false); err == nil {

--- a/cmd/entire/cli/experts_cell_target.go
+++ b/cmd/entire/cli/experts_cell_target.go
@@ -122,6 +122,18 @@ func resolveRepoClusterHost(ctx context.Context, c expertsCoreClient, fullName, 
 	return hosts[0], true
 }
 
+// isActiveMirror reports whether a mirror placement can currently serve the
+// repo: not archived, and not in a failed/suspended clone state. An unset status
+// is treated as active (older data). Shared by every caller that must ignore
+// placements a cell can't answer for.
+func isActiveMirror(m coreapi.Mirror) bool {
+	if m.IsArchived.Or(false) {
+		return false
+	}
+	st := m.Status.Or(coreapi.MirrorStatusReady)
+	return st != coreapi.MirrorStatusFailed && st != coreapi.MirrorStatusSuspended
+}
+
 // distinctActiveClusterHosts returns the set of cluster hosts a repo is actively
 // serviced on: excluding archived placements and unhealthy ones (failed /
 // suspended clone status), since those cells can't answer experts for the repo.
@@ -131,12 +143,7 @@ func resolveRepoClusterHost(ctx context.Context, c expertsCoreClient, fullName, 
 func distinctActiveClusterHosts(mirrors []coreapi.Mirror) []string {
 	seen := make(map[string]string, len(mirrors))
 	for _, m := range mirrors {
-		if m.IsArchived.Or(false) {
-			continue
-		}
-		// Treat unset status as active (older data); only failed/suspended
-		// placements can't serve experts for the repo.
-		if st := m.Status.Or(coreapi.MirrorStatusReady); st == coreapi.MirrorStatusFailed || st == coreapi.MirrorStatusSuspended {
+		if !isActiveMirror(m) {
 			continue
 		}
 		host := strings.TrimSpace(m.ClusterHost)

--- a/cmd/entire/cli/root.go
+++ b/cmd/entire/cli/root.go
@@ -112,6 +112,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newDispatchCmd())
 	cmd.AddCommand(newActivityCmd())
 	cmd.AddCommand(newRecapCmd())
+	cmd.AddCommand(newAPICmd())          // authenticated passthrough to core/cell APIs
 	cmd.AddCommand(newAgentHelpCmd(cmd)) // visible: agents on transports without context injection discover it via `entire help`
 
 	// Hidden top-level shortcuts. Functional but print a deprecation hint.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/731
<!-- entire-trail-link-end -->

A `gh api`-style escape hatch: make an authenticated HTTP request to an Entire API and print the JSON response, with the CLI attaching the right bearer token and dialing the right host — so you don't have to plumb auth yourself.

```
entire api /api/v1/clusters                            # control plane (core)
entire api --to cell /api/v1/me/activity               # your home entire-api cell
entire api --to cell "/api/v1/me/recap?repo={repo_id}" # placeholder → repo ULID
entire api -X POST /api/v1/projects -f name=demo
```

## Behavior

- **`--to core`** (default) reuses the same bearer resolution as the hidden `auth token` helper (honors `ENTIRE_TOKEN`, else the active login context). **`--to cell`** mints the jurisdictional identity token via `NewEntireAPICellClient` and dials your home cell. The data API is deliberately **not** a target — it's being retired.
- `<path>` is the full path on the chosen host (e.g. `/api/v1/clusters`), so you can hit anything, not just a fixed surface.
- **Placeholders** filled from the current repo's `origin` remote: `{owner}`, `{repo}`, and `{repo_id}` — the repo's Entire ULID resolved from its mirror, which is what cell endpoints key on. Resolution is lazy (only `{repo_id}` costs a control-plane lookup).
- **Method** defaults to `GET`, or `POST` when `-f/-F` fields or `--input` is given; `-X` overrides. `GET` + fields go on the query string; otherwise fields become a JSON body.
- `-f` (string) / `-F` (typed: `true`/`false`/`null`/numbers), `-H` headers, `--input file` (`-` = stdin), `-i` prints the status line + headers. JSON responses are pretty-printed; non-2xx still prints the body and exits non-zero.
- Adds `api.Client.Request` as the general method/header escape hatch behind the command.

## Why

Removes the `curl -H "Authorization: Bearer $(entire auth token)" …` dance, and makes it trivial to inspect either backend directly — including comparing what a cell returns vs. what the CLI renders (which is how it surfaced the repo-name/enrichment parity gap between the cell and the old data API).

## Testing

Unit tests cover field/header parsing, type inference, method inference, query building, and response formatting. Manually verified against prod core (`/api/v1/version`, `/api/v1/mirrors`) and the home cell (`/api/v1/me/activity`, `/api/v1/me/recap?repo={repo_id}`), plus `-i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes arbitrary authenticated API access (including mutating methods) using existing login/cell tokens; mistakes or scripts could hit production endpoints, though behavior mirrors existing auth paths and includes TLS checks for core.
> 
> **Overview**
> Adds **`entire api <path>`**, a `gh api`-style command that sends authenticated HTTP requests to Entire backends and prints the response (JSON pretty-printed; optional `-i` for status/headers; non-2xx exits non-zero after printing the body).
> 
> **`--to core`** (default) uses the same control-plane bearer and URL as other login-aware commands; **`--to cell`** uses `NewEntireAPICellClient` for the home entire-api cell. Paths can include **`{owner}`**, **`{repo}`**, and **`{repo_id}`** (mirror ULID via a lazy control-plane lookup). Request shaping follows familiar flags: `-X`, `-f`/`-F`, `-H`, `--input`, with GET + fields encoded as query params and bodies defaulting to POST when fields or input are present.
> 
> Extends **`api.Client`** with **`Request`** (method, extra headers, raw body) as the transport behind the command, and registers the command on the root CLI. Unit tests cover field/header parsing, method inference, query building, client target validation, and response formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e979527738b5a68b86e65345569ab3a154932e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->