### PR TITLE
feat(attribution): interactive why viewer + tag legend

### DIFF
--- a/cmd/entire/cli/attribution.go
+++ b/cmd/entire/cli/attribution.go
@@ -21,6 +21,7 @@ import (
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/id"
 	"github.com/entireio/cli/cmd/entire/cli/checkpoint/remote"
+	"github.com/entireio/cli/cmd/entire/cli/interactive"
 	"github.com/entireio/cli/cmd/entire/cli/logging"
 	"github.com/entireio/cli/cmd/entire/cli/paths"
 	"github.com/entireio/cli/cmd/entire/cli/settings"
@@ -202,6 +203,7 @@ func newBlameCmd() *cobra.Command {
 func newWhyCmd() *cobra.Command {
 	var jsonFlag bool
 	var lineFlag string
+	var tuiFlag bool
 
 	cmd := &cobra.Command{
 		Use: "why <file>[:line]",
@@ -210,18 +212,20 @@ func newWhyCmd() *cobra.Command {
 		// --help` keep working normally.
 		Hidden: true,
 		Short:  "Show why a line exists",
-		Long:   "Explain the commit, checkpoint, prompt, and session behind a file or line.\n\nTarget a specific line with <file>:12 or the --line flag.",
+		Long:   "Explain the commit, checkpoint, prompt, and session behind a file or line.\n\nTarget a specific line with <file>:12 or the --line flag.\n\nUse --tui to browse the file interactively (TTY only; non-interactive runs fall back to the plain output).",
 		Args:   cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAttributionWhy(cmd.Context(), cmd.OutOrStdout(), args[0], attributionWhyOptions{
 				LineFlag: lineFlag,
 				JSON:     jsonFlag,
+				TUI:      tuiFlag,
 			})
 		},
 	}
 
 	cmd.Flags().StringVar(&lineFlag, "line", "", "Explain a specific line, for example 12 (same as <file>:12)")
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "Output explanation as JSON")
+	cmd.Flags().BoolVar(&tuiFlag, "tui", false, "Browse line attribution in an interactive viewer (TTY only)")
 	return cmd
 }
 
@@ -234,6 +238,7 @@ type attributionBlameOptions struct {
 type attributionWhyOptions struct {
 	LineFlag string
 	JSON     bool
+	TUI      bool
 }
 
 func runAttributionBlame(ctx context.Context, w io.Writer, file string, opts attributionBlameOptions) error {
@@ -292,6 +297,18 @@ func runAttributionWhy(ctx context.Context, w io.Writer, target string, opts att
 	result, err := resolveFileAttribution(ctx, file, true)
 	if err != nil {
 		return err
+	}
+
+	// Interactive browsing is strictly opt-in AND TTY-gated (agent-safe CLI
+	// fallbacks): a non-interactive run with --tui falls through to the same
+	// deterministic plain/JSON output below, which carries the full
+	// information. --json wins over --tui so scripted callers never block.
+	if opts.TUI && !opts.JSON && interactive.IsTerminalWriter(w) && !IsAccessibleMode() {
+		startLine := 0
+		if hasLine {
+			startLine = line
+		}
+		return runWhyTUI(result, attributionRepoFullName(ctx), shouldUseColor(w), startLine)
 	}
 
 	if !hasLine {
@@ -1265,6 +1282,12 @@ func attributionLineMarker(line attributionLine) string {
 // renderAttributionMarkerLegend prints a one-line legend explaining the blame
 // markers, but only for the markers actually present in the table.
 func renderAttributionMarkerLegend(w io.Writer, sty statusStyles, lines []attributionLine) {
+	// Always explain the authorship tags — insiders found [MX] and [HU]
+	// confusing without it. Wording is deliberate (see whyMarkerLegend):
+	// [AI] means fully agent-authored checkpoint work, [MX] means agent work
+	// with human edits mixed in at commit, [HU] means no agent checkpoint.
+	fmt.Fprintf(w, "  %s\n", sty.render(sty.dim, whyMarkerLegend))
+
 	approximate, ambiguous := false, false
 	for _, line := range lines {
 		switch attributionLineMarker(line) {
@@ -1721,6 +1744,21 @@ func shortCheckpointSession(line attributionLine) string {
 		return line.CheckpointID
 	}
 	return line.CheckpointID + "/" + shortSessionID(line.SessionID)
+}
+
+// attributionRepoFullName derives "owner/repo" from the origin remote for
+// entire.io hyperlinks in the why TUI. Best-effort decoration: any failure
+// (no origin, unparseable URL) returns "" and links are simply omitted.
+func attributionRepoFullName(ctx context.Context) string {
+	originURL, err := remote.GetRemoteURL(ctx, "origin")
+	if err != nil || originURL == "" {
+		return ""
+	}
+	info, err := remote.ParseURL(originURL)
+	if err != nil || info.Owner == "" || info.Repo == "" {
+		return ""
+	}
+	return info.Owner + "/" + info.Repo
 }
 
 func shortSessionID(sessionID string) string {

--- a/cmd/entire/cli/attribution.go
+++ b/cmd/entire/cli/attribution.go
@@ -1288,7 +1288,7 @@ func renderAttributionMarkerLegend(w io.Writer, sty statusStyles, lines []attrib
 	// with human edits mixed in at commit, [HU] means no agent checkpoint.
 	fmt.Fprintf(w, "  %s\n", sty.render(sty.dim, whyMarkerLegend))
 
-	approximate, ambiguous := false, false
+	approximate, ambiguous, uncommitted := false, false, false
 	for _, line := range lines {
 		switch attributionLineMarker(line) {
 		case "~":
@@ -1296,11 +1296,17 @@ func renderAttributionMarkerLegend(w io.Writer, sty statusStyles, lines []attrib
 		case "?":
 			ambiguous = true
 		}
+		if line.Authorship == attributionUncommitted {
+			uncommitted = true
+		}
 	}
-	if !approximate && !ambiguous {
+	if !approximate && !ambiguous && !uncommitted {
 		return
 	}
 	var parts []string
+	if uncommitted {
+		parts = append(parts, "[??] uncommitted (no commit yet)")
+	}
 	if approximate {
 		parts = append(parts, "~ best-effort attribution (file not in the checkpoint's recorded paths)")
 	}

--- a/cmd/entire/cli/attribution_tui.go
+++ b/cmd/entire/cli/attribution_tui.go
@@ -1,0 +1,545 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/entireio/cli/cmd/entire/cli/stringutil"
+)
+
+// Layout budget for the why viewer. The header is a title line plus a blank
+// line; the footer is a marker legend line plus a help line. The remaining rows
+// are split between the file-line list (left) and the selected line's
+// explanation (right), separated by a thin vertical rule.
+const (
+	whyHeaderHeight   = 2
+	whyFooterHeight   = 2
+	whyListMinWidth   = 34
+	whyListWidthRatio = 0.55 // list gets slightly more room than the detail
+	whyPaneGap        = 3    // " │ "
+)
+
+// whyMarkerLegend is the one-line explanation of the attribution tags shown in
+// the footer and in the plain-text views. Wording is deliberate: [AI] means the
+// commit's checkpointed work was fully agent-authored; [MX] means agent work
+// with human edits mixed in at commit; [HU] means no agent checkpoint recorded.
+// Kept within the blame table's 80-column budget (with its 2-space indent); the
+// full sentences live in the why detail views.
+const whyMarkerLegend = "[AI] all agent · [MX] agent+human mixed · [HU] no agent · [??] uncommitted"
+
+// whyTUIStyles holds the interactive viewer's palette. Empty styles render as
+// plain text when color is off, which also keeps tests assertable.
+type whyTUIStyles struct {
+	colorEnabled bool
+
+	title    lipgloss.Style
+	file     lipgloss.Style
+	dim      lipgloss.Style
+	selected lipgloss.Style
+	section  lipgloss.Style
+	tagAI    lipgloss.Style
+	tagMX    lipgloss.Style
+	tagHU    lipgloss.Style
+	warn     lipgloss.Style
+	helpKey  lipgloss.Style
+	helpDesc lipgloss.Style
+	sepBar   lipgloss.Style
+}
+
+func newWhyTUIStyles(useColor bool) whyTUIStyles {
+	s := whyTUIStyles{colorEnabled: useColor}
+	if !useColor {
+		return s
+	}
+	s.title = lipgloss.NewStyle().Bold(true)
+	s.file = lipgloss.NewStyle().Foreground(lipgloss.Color("#fb923c")).Bold(true)
+	s.dim = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	s.selected = lipgloss.NewStyle().Foreground(lipgloss.Color("#fb923c")).Bold(true)
+	s.section = lipgloss.NewStyle().Foreground(lipgloss.Color("#fb923c")).Bold(true)
+	s.tagAI = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	s.tagMX = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	s.tagHU = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	s.warn = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	s.helpKey = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Bold(true)
+	s.helpDesc = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	s.sepBar = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	return s
+}
+
+func (s whyTUIStyles) render(style lipgloss.Style, text string) string {
+	if !s.colorEnabled {
+		return text
+	}
+	return style.Render(text)
+}
+
+// link renders text with an OSC 8 hyperlink when styling is enabled; plain
+// styled text otherwise, so dumb terminals and piped output are unaffected.
+func (s whyTUIStyles) link(style lipgloss.Style, linkURL, text string) string {
+	if !s.colorEnabled || strings.TrimSpace(linkURL) == "" {
+		return s.render(style, text)
+	}
+	return style.Hyperlink(linkURL).Render(text)
+}
+
+func (s whyTUIStyles) tagStyle(tag string) lipgloss.Style {
+	switch tag {
+	case "[AI]":
+		return s.tagAI
+	case "[MX]":
+		return s.tagMX
+	default:
+		return s.tagHU
+	}
+}
+
+// whyTUIModel renders a master-detail view over a pre-resolved file
+// attribution: the file's lines on the left (with attribution markers) and the
+// selected line's full explanation on the right. All data is resolved before
+// the program starts — no git or network I/O happens inside the TUI.
+type whyTUIModel struct {
+	result *fileAttributionResult
+	styles whyTUIStyles
+
+	// repoFullName ("owner/repo") enables entire.io session hyperlinks; empty
+	// disables them (links are best-effort decoration, never required).
+	repoFullName string
+
+	cursor    int
+	listTop   int // first visible list row (manual scroll window)
+	expanded  bool
+	width     int
+	height    int
+	ready     bool
+	vp        viewport.Model
+	statusMsg string
+}
+
+func newWhyTUIModel(result *fileAttributionResult, repoFullName string, useColor bool, startLine int) whyTUIModel {
+	m := whyTUIModel{
+		result:       result,
+		styles:       newWhyTUIStyles(useColor),
+		repoFullName: repoFullName,
+	}
+	if startLine > 0 {
+		for i := range result.Lines {
+			if result.Lines[i].LineNumber == startLine {
+				m.cursor = i
+				break
+			}
+		}
+	}
+	return m
+}
+
+func runWhyTUI(result *fileAttributionResult, repoFullName string, useColor bool, startLine int) error {
+	p := tea.NewProgram(newWhyTUIModel(result, repoFullName, useColor, startLine))
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("why TUI: %w", err)
+	}
+	return nil
+}
+
+func (m whyTUIModel) Init() tea.Cmd { return nil }
+
+func (m whyTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m = m.layout()
+		return m, nil
+	case tea.KeyPressMsg:
+		return m.handleKey(msg)
+	}
+	if m.ready {
+		var cmd tea.Cmd
+		m.vp, cmd = m.vp.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m whyTUIModel) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, keys.Quit), key.Matches(msg, keys.Back):
+		return m, tea.Quit
+	case key.Matches(msg, keys.Up):
+		return m.moveCursor(m.cursor - 1), nil
+	case key.Matches(msg, keys.Down):
+		return m.moveCursor(m.cursor + 1), nil
+	// Paging is bound to pgup/pgdown explicitly: the shared keymap's
+	// NextPage/PrevPage claim n/p, which this viewer uses for the more useful
+	// next/previous agent-attributed line jumps.
+	case msg.String() == "pgup":
+		return m.moveCursor(m.cursor - m.bodyHeight()), nil
+	case msg.String() == "pgdown":
+		return m.moveCursor(m.cursor + m.bodyHeight()), nil
+	case key.Matches(msg, keys.Home):
+		return m.moveCursor(0), nil
+	case key.Matches(msg, keys.End):
+		return m.moveCursor(len(m.result.Lines) - 1), nil
+	case key.Matches(msg, keys.Confirm):
+		m.expanded = !m.expanded
+		return m.refreshDetail(), nil
+	case msg.String() == "n":
+		return m.jumpAgentLine(1), nil
+	case msg.String() == "p", msg.String() == "N":
+		return m.jumpAgentLine(-1), nil
+	}
+	if m.ready {
+		var cmd tea.Cmd
+		m.vp, cmd = m.vp.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m whyTUIModel) moveCursor(to int) whyTUIModel {
+	if len(m.result.Lines) == 0 {
+		return m
+	}
+	if to < 0 {
+		to = 0
+	}
+	if to > len(m.result.Lines)-1 {
+		to = len(m.result.Lines) - 1
+	}
+	if to == m.cursor {
+		return m
+	}
+	m.cursor = to
+	m.expanded = false
+	m = m.scrollListToCursor()
+	return m.refreshDetail()
+}
+
+// scrollListToCursor adjusts the persisted list window so the cursor stays
+// visible. Kept separate from rendering so the scroll state survives value-
+// receiver renders.
+func (m whyTUIModel) scrollListToCursor() whyTUIModel {
+	height := m.bodyHeight()
+	if m.cursor < m.listTop {
+		m.listTop = m.cursor
+	}
+	if m.cursor >= m.listTop+height {
+		m.listTop = m.cursor - height + 1
+	}
+	if m.listTop < 0 {
+		m.listTop = 0
+	}
+	return m
+}
+
+// jumpAgentLine moves the cursor to the next/previous line with agent
+// involvement ([AI] or [MX]) — browsing straight to the interesting lines.
+func (m whyTUIModel) jumpAgentLine(dir int) whyTUIModel {
+	lines := m.result.Lines
+	for i := m.cursor + dir; i >= 0 && i < len(lines); i += dir {
+		if lines[i].Authorship == attributionAI || lines[i].Authorship == attributionMixed {
+			return m.moveCursor(i)
+		}
+	}
+	m.statusMsg = "no more agent-attributed lines"
+	return m
+}
+
+func (m whyTUIModel) layout() whyTUIModel {
+	if m.width <= 0 || m.height <= 0 {
+		return m
+	}
+	bodyH := m.bodyHeight()
+	rightW := m.rightPaneWidth()
+	if !m.ready {
+		m.vp = viewport.New(viewport.WithWidth(rightW), viewport.WithHeight(bodyH))
+		m.ready = true
+	} else {
+		m.vp.SetWidth(rightW)
+		m.vp.SetHeight(bodyH)
+	}
+	return m.refreshDetail()
+}
+
+func (m whyTUIModel) bodyHeight() int {
+	h := m.height - whyHeaderHeight - whyFooterHeight
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func (m whyTUIModel) listWidth() int {
+	w := int(float64(m.width) * whyListWidthRatio)
+	if w < whyListMinWidth {
+		w = whyListMinWidth
+	}
+	if limit := m.width - whyPaneGap - 20; w > limit {
+		w = limit
+	}
+	if w < 1 {
+		w = 1
+	}
+	return w
+}
+
+func (m whyTUIModel) rightPaneWidth() int {
+	w := m.width - m.listWidth() - whyPaneGap
+	if w < 1 {
+		w = 1
+	}
+	return w
+}
+
+func (m whyTUIModel) refreshDetail() whyTUIModel {
+	m.statusMsg = ""
+	if !m.ready {
+		return m
+	}
+	m.vp.SetContent(m.renderDetail(m.rightPaneWidth()))
+	m.vp.GotoTop()
+	return m
+}
+
+// selectedLine returns the line under the cursor, or nil for an empty file.
+func (m whyTUIModel) selectedLine() *attributionLine {
+	if m.cursor < 0 || m.cursor >= len(m.result.Lines) {
+		return nil
+	}
+	return &m.result.Lines[m.cursor]
+}
+
+// sessionWebURL builds the entire.io session URL for the selected line, or ""
+// when there is nothing to link.
+func (m whyTUIModel) sessionWebURL(line *attributionLine) string {
+	if line == nil || m.repoFullName == "" || line.SessionID == "" {
+		return ""
+	}
+	owner, repo, ok := strings.Cut(m.repoFullName, "/")
+	if !ok || owner == "" || repo == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://entire.io/gh/%s/%s/session/%s",
+		url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(line.SessionID))
+}
+
+func (m whyTUIModel) View() tea.View {
+	if !m.ready {
+		return tea.NewView("")
+	}
+	var b strings.Builder
+	summary := m.result.Summary
+	fmt.Fprintf(&b, "%s %s  %s\n\n",
+		m.styles.render(m.styles.title, "why"),
+		m.styles.render(m.styles.file, m.result.File),
+		m.styles.render(m.styles.dim, fmt.Sprintf("%d lines · %d%% AI · %d%% human · %d%% mixed",
+			summary.TotalLines, summary.AIPercentage, summary.HumanPercentage, summary.MixedPercentage)))
+
+	list := m.renderList(m.listWidth(), m.bodyHeight())
+	detail := strings.Split(m.vp.View(), "\n")
+	sep := m.styles.render(m.styles.sepBar, "│")
+	for i := range m.bodyHeight() {
+		left, right := "", ""
+		if i < len(list) {
+			left = list[i]
+		}
+		if i < len(detail) {
+			right = detail[i]
+		}
+		fmt.Fprintf(&b, "%-*s %s %s\n", m.listWidth(), left, sep, right)
+	}
+
+	legend := whyMarkerLegend
+	if m.statusMsg != "" {
+		legend = m.statusMsg
+	}
+	b.WriteString(m.styles.render(m.styles.dim, legend) + "\n")
+	b.WriteString(m.renderHelp())
+	return tea.NewView(b.String())
+}
+
+// renderList renders the visible window of file lines, keeping the cursor in
+// view. Lines are windowed manually (a file can be thousands of lines).
+func (m whyTUIModel) renderList(width, height int) []string {
+	lines := m.result.Lines
+	if len(lines) == 0 {
+		return []string{m.styles.render(m.styles.dim, "(empty file)")}
+	}
+
+	// Read-only clamp: the persisted window is maintained by
+	// scrollListToCursor; this only guards against a resize shrinking the
+	// window after the last cursor move.
+	top := m.listTop
+	if m.cursor < top {
+		top = m.cursor
+	}
+	if m.cursor >= top+height {
+		top = m.cursor - height + 1
+	}
+	if top < 0 {
+		top = 0
+	}
+
+	numW := len(strconv.Itoa(lines[len(lines)-1].LineNumber))
+	out := make([]string, 0, height)
+	for i := top; i < len(lines) && len(out) < height; i++ {
+		line := lines[i]
+		tag := attributionTag(line.Authorship)
+		marker := attributionLineMarker(line)
+		if marker == "" {
+			marker = " "
+		}
+		content := stringutil.TruncateRunes(strings.ReplaceAll(line.Content, "\t", "    "), width-numW-9, "…")
+		row := fmt.Sprintf("%*d %s%s %s", numW, line.LineNumber,
+			m.styles.render(m.styles.tagStyle(tag), tag), marker, content)
+		if i == m.cursor {
+			row = m.styles.render(m.styles.selected, fmt.Sprintf("%*d %s%s %s", numW, line.LineNumber, tag, marker, content))
+		}
+		out = append(out, stringutil.TruncateRunes(row, width+64, "")) // guard against style overshoot
+	}
+	return out
+}
+
+// renderDetail builds the explanation pane for the selected line — the same
+// facts as the plain-text `why <file>:<line>` output, formatted for a pane.
+func (m whyTUIModel) renderDetail(width int) string {
+	line := m.selectedLine()
+	if line == nil {
+		return m.styles.render(m.styles.dim, "No lines.")
+	}
+	wrap := func(s string) string {
+		return lipgloss.NewStyle().Width(width).Render(s)
+	}
+	var b strings.Builder
+	sec := func(title string) { b.WriteString(m.styles.render(m.styles.section, title) + "\n") }
+
+	sec(fmt.Sprintf("LINE %d  %s", line.LineNumber, attributionTag(line.Authorship)))
+	b.WriteString(wrap(m.authorshipSentence(line)) + "\n\n")
+
+	if line.ShortCommitSHA != "" {
+		commit := "Commit: " + line.ShortCommitSHA
+		if line.Author != "" {
+			commit += "  by " + line.Author
+		}
+		if line.AuthorTime != nil {
+			commit += "  " + line.AuthorTime.Format("2006-01-02 15:04")
+		}
+		b.WriteString(wrap(commit) + "\n")
+	}
+	if line.Agent != "" {
+		agentLine := "Agent: " + line.Agent
+		if line.Model != "" {
+			agentLine += " · " + line.Model
+		}
+		b.WriteString(wrap(agentLine) + "\n")
+	}
+	if line.SessionID != "" {
+		sessionText := "Session: " + shortSessionID(line.SessionID)
+		if u := m.sessionWebURL(line); u != "" {
+			sessionText = m.link(m.styles.dim, u, sessionText) // dim styled + clickable
+		}
+		b.WriteString(wrap(sessionText) + "\n")
+	}
+	if line.CheckpointID != "" {
+		b.WriteString(wrap("Checkpoint: "+line.CheckpointID) + "\n")
+	}
+	b.WriteString("\n")
+
+	if line.Prompt != "" {
+		label := "PROMPT"
+		if line.PromptSessionLevel {
+			label = "SESSION PROMPT"
+		}
+		sec(label)
+		prompt := line.Prompt
+		if !m.expanded {
+			prompt = stringutil.TruncateRunes(stringutil.CollapseWhitespace(prompt), 240, "… (enter to expand)")
+		}
+		b.WriteString(wrap(prompt) + "\n")
+		if line.PromptSessionLevel {
+			b.WriteString(wrap(m.styles.render(m.styles.dim, "session-level prompt — may not appear in this checkpoint's transcript")) + "\n")
+		}
+		b.WriteString("\n")
+	}
+	if line.Intent != "" && line.Intent != line.Prompt {
+		sec("INTENT")
+		b.WriteString(wrap(line.Intent) + "\n\n")
+	}
+
+	if line.MetadataMissing {
+		msg := "Checkpoint metadata was not found locally; showing trailer-level attribution only."
+		if line.MetadataMissingReason != "" {
+			msg = line.MetadataMissingReason
+		}
+		b.WriteString(wrap(m.styles.render(m.styles.warn, msg)) + "\n\n")
+	}
+	if line.SessionFallback {
+		b.WriteString(wrap(m.styles.render(m.styles.warn,
+			"~ best-effort: this file is not in the checkpoint session's recorded paths; the agent and prompt shown are a guess")) + "\n\n")
+	}
+
+	if len(line.Candidates) > 1 {
+		sec(fmt.Sprintf("CANDIDATE CHECKPOINTS (%d)", len(line.Candidates)))
+		for _, c := range line.Candidates {
+			row := "- " + c.CheckpointID
+			if c.Agent != "" {
+				row += " · " + c.Agent
+			}
+			if m.expanded && c.Prompt != "" {
+				row += " · " + stringutil.TruncateRunes(stringutil.CollapseWhitespace(c.Prompt), 120, "…")
+			}
+			b.WriteString(wrap(row) + "\n")
+		}
+		b.WriteString("\n")
+	}
+
+	if line.CheckpointID != "" && !line.MetadataMissing {
+		b.WriteString(wrap(m.styles.render(m.styles.dim, "Full context: entire checkpoint explain "+line.CheckpointID)) + "\n")
+	}
+	return b.String()
+}
+
+// authorshipSentence spells out what the tag means for THIS line, with the
+// wording the attribution actually supports: [AI] = the commit's checkpointed
+// work was fully agent-authored; [MX] = agent work with human edits mixed in;
+// [HU] = no agent checkpoint recorded for the commit.
+func (m whyTUIModel) authorshipSentence(line *attributionLine) string {
+	switch line.Authorship {
+	case attributionAI:
+		return "Agent-authored: the checkpoint work behind this commit was fully agent-authored."
+	case attributionMixed:
+		return "Mixed: this commit combined agent work with human edits, so this line may be either."
+	case attributionUncommitted:
+		return "Uncommitted: this line has no commit yet."
+	case attributionHuman:
+		return "Human: no agent checkpoint is recorded for this commit."
+	default:
+		return string(line.Authorship)
+	}
+}
+
+// link is a tiny alias so renderDetail reads naturally.
+func (m whyTUIModel) link(style lipgloss.Style, url, text string) string {
+	return m.styles.link(style, url, text)
+}
+
+func (m whyTUIModel) renderHelp() string {
+	parts := []struct{ k, d string }{
+		{"↑/↓", "line"}, {"n/p", "next/prev agent line"}, {"enter", "expand"},
+		{"pgup/pgdn", "page"}, {"g/G", "top/bottom"}, {"q", "quit"},
+	}
+	var b strings.Builder
+	for i, p := range parts {
+		if i > 0 {
+			b.WriteString(m.styles.render(m.styles.helpDesc, " · "))
+		}
+		b.WriteString(m.styles.render(m.styles.helpKey, p.k) + " " + m.styles.render(m.styles.helpDesc, p.d))
+	}
+	return b.String()
+}

--- a/cmd/entire/cli/attribution_tui.go
+++ b/cmd/entire/cli/attribution_tui.go
@@ -27,12 +27,14 @@ const (
 )
 
 // whyMarkerLegend is the one-line explanation of the attribution tags shown in
-// the footer and in the plain-text views. Wording is deliberate: [AI] means the
-// commit's checkpointed work was fully agent-authored; [MX] means agent work
-// with human edits mixed in at commit; [HU] means no agent checkpoint recorded.
-// Kept within the blame table's 80-column budget (with its 2-space indent); the
-// full sentences live in the why detail views.
-const whyMarkerLegend = "[AI] all agent · [MX] agent+human mixed · [HU] no agent · [??] uncommitted"
+// the footer and in the plain-text views. Wording is deliberate — the tags are
+// a PER-COMMIT inference, not a per-line truth: [AI] means the commit's
+// checkpointed work was fully agent-authored; [MX] means the commit mixed
+// agent work with human edits (so any given line may be either); [HU] means no
+// agent checkpoint is recorded for the commit. Kept within the blame table's
+// 80-column budget (with its 2-space indent); full sentences live in the why
+// detail views, and [??]/~/? markers are explained by their own legend line.
+const whyMarkerLegend = "per commit: [AI] all agent · [MX] mixed — line may be either · [HU] no agent"
 
 // whyTUIStyles holds the interactive viewer's palette. Empty styles render as
 // plain text when color is off, which also keeps tests assertable.

--- a/cmd/entire/cli/attribution_tui_test.go
+++ b/cmd/entire/cli/attribution_tui_test.go
@@ -1,0 +1,280 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func whyTUIFixture() *fileAttributionResult {
+	when := time.Date(2026, 1, 2, 15, 4, 0, 0, time.UTC)
+	lines := []attributionLine{
+		{
+			LineNumber: 1, Authorship: attributionHuman, Tag: "[HU]",
+			CommitSHA: "1111111111111111111111111111111111111111", ShortCommitSHA: "1111111",
+			Author: "Ada", AuthorTime: &when, Content: "package main",
+		},
+		{
+			LineNumber: 2, Authorship: attributionAI, Tag: "[AI]",
+			CommitSHA: "2222222222222222222222222222222222222222", ShortCommitSHA: "2222222",
+			Author: "Ada", AuthorTime: &when,
+			CheckpointID: "a1b2c3d4e5f6", SessionID: "session-agent-12345678",
+			Agent: "Claude Code", Model: "claude-test",
+			Prompt:  "Fix the authentication bug in login flow please",
+			Intent:  "Fix auth bug",
+			Content: "func login() {}",
+		},
+		{
+			LineNumber: 3, Authorship: attributionMixed, Tag: "[MX]",
+			CommitSHA: "3333333333333333333333333333333333333333", ShortCommitSHA: "3333333",
+			CheckpointID: "b1b2c3d4e5f6", SessionID: "session-mixed-12345678",
+			Agent: "Claude Code", Prompt: "Refactor helpers", PromptSessionLevel: true,
+			Candidates: []attributionCandidate{
+				{CheckpointID: "b1b2c3d4e5f6", Agent: "Claude Code", Prompt: "Refactor helpers"},
+				{CheckpointID: "c1b2c3d4e5f6", Agent: "Codex", Prompt: "Tidy up"},
+			},
+			Content: "func helper() {}",
+		},
+		{
+			LineNumber: 4, Authorship: attributionAI, Tag: "[AI]",
+			CheckpointID: "d1b2c3d4e5f6", MetadataMissing: true,
+			MetadataMissingReason: "checkpoint metadata was not found locally. Run: git fetch origin entire/checkpoints/v1:entire/checkpoints/v1.",
+			Content:               "func missing() {}",
+		},
+	}
+	return &fileAttributionResult{
+		File:  "auth.py",
+		Lines: lines,
+		Summary: attributionSummary{
+			TotalLines: 4, AILines: 2, HumanLines: 1, MixedLines: 1,
+			AIPercentage: 50, HumanPercentage: 25, MixedPercentage: 25,
+		},
+	}
+}
+
+func updateWhyTUI(t *testing.T, m whyTUIModel, msg tea.Msg) whyTUIModel {
+	t.Helper()
+	next, _ := m.Update(msg)
+	tm, ok := next.(whyTUIModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want whyTUIModel", next)
+	}
+	return tm
+}
+
+// Color off keeps assertions on raw text; a tall window keeps the detail pane
+// fully visible so assertions aren't tripped by viewport scrolling.
+func newSizedWhyTUI(t *testing.T, result *fileAttributionResult, startLine int) whyTUIModel {
+	t.Helper()
+	m := newWhyTUIModel(result, "acme/app", false, startLine)
+	return updateWhyTUI(t, m, tea.WindowSizeMsg{Width: 140, Height: 44})
+}
+
+func whyTUIViewText(t *testing.T, m whyTUIModel) string {
+	t.Helper()
+	return m.View().Content
+}
+
+func keyPress(k string) tea.KeyPressMsg {
+	switch k {
+	case "up":
+		return tea.KeyPressMsg{Code: tea.KeyUp}
+	case "down":
+		return tea.KeyPressMsg{Code: tea.KeyDown}
+	case "enter":
+		return tea.KeyPressMsg{Code: tea.KeyEnter}
+	default:
+		r := []rune(k)[0]
+		return tea.KeyPressMsg{Code: r, Text: k}
+	}
+}
+
+func TestWhyTUIRendersFileAndSelectedLineDetail(t *testing.T) {
+	t.Parallel()
+	m := newSizedWhyTUI(t, whyTUIFixture(), 0)
+	text := whyTUIViewText(t, m)
+
+	for _, want := range []string{
+		"why", "auth.py", "4 lines", "50% AI",
+		"package main", "func login() {}", // list content
+		"LINE 1", "[HU]", "Human: no agent checkpoint", // detail for initial cursor (line 1)
+		whyMarkerLegend, // footer legend
+		"quit",          // help line
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("TUI view missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestWhyTUINavigationShowsPromptDetail(t *testing.T) {
+	t.Parallel()
+	m := newSizedWhyTUI(t, whyTUIFixture(), 0)
+	m = updateWhyTUI(t, m, keyPress("down")) // to line 2 ([AI])
+	text := whyTUIViewText(t, m)
+
+	for _, want := range []string{
+		"LINE 2", "[AI]", "fully agent-authored",
+		"Agent: Claude Code · claude-test",
+		"Session: session-", "Checkpoint: a1b2c3d4e5f6",
+		"PROMPT", "Fix the authentication bug",
+		"INTENT", "Fix auth bug",
+		"Full context: entire checkpoint explain a1b2c3d4e5f6",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("after down, view missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestWhyTUIStartLinePositionsCursor(t *testing.T) {
+	t.Parallel()
+	m := newSizedWhyTUI(t, whyTUIFixture(), 3)
+	text := whyTUIViewText(t, m)
+
+	for _, want := range []string{
+		"LINE 3", "[MX]", "combined agent work with human edits",
+		"SESSION PROMPT", "session-level prompt",
+		"CANDIDATE CHECKPOINTS (2)", "c1b2c3d4e5f6", "Codex",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("start-line view missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestWhyTUIJumpToNextAgentLine(t *testing.T) {
+	t.Parallel()
+	m := newSizedWhyTUI(t, whyTUIFixture(), 0) // cursor at line 1 [HU]
+	m = updateWhyTUI(t, m, keyPress("n"))      // -> line 2 [AI]
+	if got := m.selectedLine().LineNumber; got != 2 {
+		t.Fatalf("n jumped to line %d, want 2", got)
+	}
+	m = updateWhyTUI(t, m, keyPress("n")) // -> line 3 [MX]
+	m = updateWhyTUI(t, m, keyPress("n")) // -> line 4 [AI]
+	if got := m.selectedLine().LineNumber; got != 4 {
+		t.Fatalf("n n jumped to line %d, want 4", got)
+	}
+	// No further agent lines: cursor stays, status message appears.
+	m = updateWhyTUI(t, m, keyPress("n"))
+	if got := m.selectedLine().LineNumber; got != 4 {
+		t.Fatalf("n at end moved to line %d, want 4", got)
+	}
+	if !strings.Contains(whyTUIViewText(t, m), "no more agent-attributed lines") {
+		t.Fatal("expected status message about no more agent lines")
+	}
+	// p goes back.
+	m = updateWhyTUI(t, m, keyPress("p"))
+	if got := m.selectedLine().LineNumber; got != 3 {
+		t.Fatalf("p jumped to line %d, want 3", got)
+	}
+}
+
+func TestWhyTUIExpandTogglesFullPrompt(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("very long prompt text ", 30)
+	result := whyTUIFixture()
+	result.Lines[1].Prompt = long
+	m := newSizedWhyTUI(t, result, 2)
+
+	if !strings.Contains(whyTUIViewText(t, m), "enter to expand") {
+		t.Fatal("collapsed view should hint at expansion")
+	}
+	m = updateWhyTUI(t, m, keyPress("enter"))
+	if strings.Contains(whyTUIViewText(t, m), "enter to expand") {
+		t.Fatal("expanded view should not truncate the prompt")
+	}
+}
+
+func TestWhyTUIMissingMetadataShowsReason(t *testing.T) {
+	t.Parallel()
+	m := newSizedWhyTUI(t, whyTUIFixture(), 4)
+	text := whyTUIViewText(t, m)
+	if !strings.Contains(text, "checkpoint metadata was not found locally") {
+		t.Fatalf("missing-metadata reason absent:\n%s", text)
+	}
+	if strings.Contains(text, "Full context: entire checkpoint explain d1b2c3d4e5f6") {
+		t.Fatal("explain hint must be suppressed when metadata is missing")
+	}
+}
+
+// g/G map to the shared keymap's Home/End bindings.
+func TestWhyTUIHomeEndKeys(t *testing.T) {
+	t.Parallel()
+	m := newSizedWhyTUI(t, whyTUIFixture(), 3) // start mid-file
+	m = updateWhyTUI(t, m, keyPress("g"))
+	if got := m.selectedLine().LineNumber; got != 1 {
+		t.Fatalf("g moved to line %d, want 1", got)
+	}
+	m = updateWhyTUI(t, m, keyPress("G"))
+	if got := m.selectedLine().LineNumber; got != 4 {
+		t.Fatalf("G moved to line %d, want 4", got)
+	}
+}
+
+func TestWhyTUIQuitKeys(t *testing.T) {
+	t.Parallel()
+	m := newSizedWhyTUI(t, whyTUIFixture(), 0)
+	for _, k := range []string{"q"} {
+		_, cmd := m.Update(keyPress(k))
+		if cmd == nil {
+			t.Fatalf("key %q should quit", k)
+		}
+	}
+}
+
+func TestWhyTUIEmptyFileDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	empty := &fileAttributionResult{File: "empty.py", Lines: nil}
+	m := newWhyTUIModel(empty, "", false, 0)
+	m = updateWhyTUI(t, m, tea.WindowSizeMsg{Width: 80, Height: 20})
+	m = updateWhyTUI(t, m, keyPress("down"))
+	m = updateWhyTUI(t, m, keyPress("n"))
+	text := whyTUIViewText(t, m)
+	if !strings.Contains(text, "empty.py") {
+		t.Fatalf("empty-file view missing filename:\n%s", text)
+	}
+}
+
+func TestWhyTUITinyWindowDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	m := newWhyTUIModel(whyTUIFixture(), "", false, 0)
+	m = updateWhyTUI(t, m, tea.WindowSizeMsg{Width: 8, Height: 3})
+	_ = whyTUIViewText(t, m)
+	m = updateWhyTUI(t, m, keyPress("down"))
+	_ = whyTUIViewText(t, m)
+}
+
+// The agent-safe fallback contract: --tui against a non-TTY writer must fall
+// through to the deterministic plain-text output (never start the TUI, never
+// block). A bytes.Buffer is the non-TTY case IsTerminalWriter reports false for.
+func TestWhyTUIFlagFallsBackToPlainTextWhenNotTTY(t *testing.T) {
+	newAttributionRepo(t)
+
+	var buf bytes.Buffer
+	err := runAttributionWhy(t.Context(), &buf, "auth.py", attributionWhyOptions{TUI: true})
+	if err != nil {
+		t.Fatalf("runAttributionWhy --tui non-TTY: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "auth.py") || !strings.Contains(out, "lines") {
+		t.Fatalf("expected the plain file summary as fallback, got:\n%s", out)
+	}
+}
+
+// --json must win over --tui so scripted callers always get JSON.
+func TestWhyTUIFlagJSONWins(t *testing.T) {
+	newAttributionRepo(t)
+
+	var buf bytes.Buffer
+	err := runAttributionWhy(t.Context(), &buf, "auth.py", attributionWhyOptions{TUI: true, JSON: true})
+	if err != nil {
+		t.Fatalf("runAttributionWhy --tui --json: %v", err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(buf.String()), "{") {
+		t.Fatalf("expected JSON output, got:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/738
<!-- entire-trail-link-end -->

**Base: `fix-why-metadata-consistency` (stacked on the #1551 fix — review that first).**

## What

An interactive viewer for `entire why <file>` plus the readability fixes insiders asked for — built strictly under the new Agent-Safe CLI Fallbacks rules (#1596).

### `entire why <file> --tui`

Master-detail Bubble Tea viewer over the already-resolved attribution (no git/network I/O inside the TUI):

- **Left pane:** the file's lines with `[AI]/[MX]/[HU]/[??]` tags and `~`/`?` markers, windowed scrolling for large files.
- **Right pane:** the selected line's full explanation — authorship sentence, commit/author/time, agent · model, session (OSC 8 hyperlink to the entire.io session when origin resolves — the CLI↔UI linking idea from the summit), checkpoint, prompt (with the `Session prompt` caveat), intent, metadata-missing reason, candidate checkpoints, and the `checkpoint explain` hint (suppressed when metadata is missing, matching the text view).
- **Keys:** ↑/↓ line, `n`/`p` **next/previous agent-attributed line** (jump straight to the interesting lines), enter expands the full prompt/candidates, pgup/pgdn, g/G, q. `why <file>:12 --tui` opens positioned at line 12.

### Agent-safe by construction

- TUI is **opt-in** (`--tui`) and **TTY-gated** (`interactive.IsTerminalWriter`) and skipped in accessible mode — the exact `experts --tui` pattern the guidelines cite as good.
- Non-TTY with `--tui` falls through to the **same deterministic plain output**; `--json` always wins over `--tui` so scripted callers never block. Both pinned by tests against a non-TTY writer.
- No information is TUI-only: everything the TUI shows exists in the plain/JSON paths.

### Insider-feedback fixes (text output)

- **Tag legend everywhere** (`blame`, why file view, TUI footer): `[AI] all agent · [MX] agent+human mixed · [HU] no agent · [??] uncommitted` — wording per soph's correction (AI = 100% agent-authored checkpoint work; MX = agent + human edits; careful not to overclaim). Full sentences in the TUI detail pane.
- Fits the blame table's 80-column budget (test-enforced).

## Testing

- Model-level TUI tests (the repo's established pattern — pure `Update`/`View`, color off): render + summary, navigation → prompt detail, start-line positioning, `n`/`p` agent-line jumps (including exhaustion + status message), expand toggle, missing-metadata reason + suppressed explain hint, quit keys, empty file, tiny window.
- Agent-safe fallback pins: `--tui` on a non-TTY writer produces the plain file summary; `--tui --json` produces JSON.
- Found during development: the shared keymap claims `n`/`p` for paging — the viewer rebinds paging to pgup/pgdn so `n`/`p` can do agent-line jumps (commented).
- `mise run lint` 0 issues; full `cmd/entire/cli` suite green; `mise run test:ci` green.

## Notes

`entire why` stays hidden/labs. The TUI addresses the insiders' "why is hard to read" feedback and pfleidi's browse-the-file/summit-linking ideas without touching the default output contract.
