### PR TITLE
cli/auth: unhide `entire auth token` and add `--jurisdiction`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ their canonical paths are still runnable.
 - `configure`: bare prints help and a hint pointing at `entire agent`; flags
   manage non-agent settings (telemetry, git-hook installation mode, strategy
   options, summary provider). Agent CRUD lives under `entire agent`.
-- `auth`: `login`, `logout`, `status`, `contexts`, `use`, plus the hidden
+- `auth`: `login`, `logout`, `status`, `contexts`, `use`, plus
   `token` (prints the active control-plane bearer to stdout for scripting/curl;
   honors `ENTIRE_TOKEN`, else the refreshed active-context login JWT). `logout`
   takes `--everywhere` (revoke every session on the active core, not just the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,14 @@ their canonical paths are still runnable.
   options, summary provider). Agent CRUD lives under `entire agent`.
 - `auth`: `login`, `logout`, `status`, `contexts`, `use`, plus
   `token` (prints the active control-plane bearer to stdout for scripting/curl;
-  honors `ENTIRE_TOKEN`, else the refreshed active-context login JWT). `logout`
+  honors `ENTIRE_TOKEN`, else the refreshed active-context login JWT). `token`
+  also takes `--jurisdiction <slug>` (e.g. `us`, `eu`), which instead mints a
+  jurisdictional identity token (RFC 8693 exchange, `scope=openid`,
+  `aud=<jurisdiction host>`) for that jurisdiction's entire-api cells (e.g.
+  `https://aws-us-east-2.api.entire.io/api/v1`), which reject the control-plane
+  bearer; it exchanges `ENTIRE_TOKEN` when set (deriving the environment from the
+  env token's `aud`), else the active login. `auth status` shows the caller's
+  home jurisdiction so the slug is discoverable. `logout`
   takes `--everywhere` (revoke every session on the active core, not just the
   current one) and `--all-contexts` (log out of every saved login)
 - `doctor`: bare runs the scan-and-fix flow, plus `trace`, `logs`, `bundle`

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -132,19 +132,17 @@ func newAuthCmd() *cobra.Command {
 //
 //	curl -H "Authorization: Bearer $(entire auth token)" "$CORE/api/v1/clusters"
 //
-// Hidden: it emits a live credential, so it's a deliberate scripting escape
-// hatch, not part of the everyday surface. It resolves the same bearer the API
-// client would — ENTIRE_TOKEN verbatim when set, otherwise the active context's
-// login JWT, refreshed if it's near expiry — and prints nothing but the token
-// (errors and the not-logged-in hint go to stderr) so command substitution
-// stays clean.
+// It emits a live credential, so treat the output as a secret. It resolves the
+// same bearer the API client would — ENTIRE_TOKEN verbatim when set, otherwise
+// the active context's login JWT, refreshed if it's near expiry — and prints
+// nothing but the token (errors and the not-logged-in hint go to stderr) so
+// command substitution stays clean.
 func newAuthTokenCmd() *cobra.Command {
 	var insecureHTTPAuth bool
 	cmd := &cobra.Command{
-		Use:    "token",
-		Short:  "Print the active control-plane bearer token (for scripting)",
-		Hidden: true,
-		Args:   cobra.NoArgs,
+		Use:   "token",
+		Short: "Print the active control-plane bearer token (for scripting)",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Refresh may exchange/refresh over the network; honor the
 			// plain-HTTP opt-in before resolving so local dev cores work.

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -139,14 +139,13 @@ func newAuthTokenCmd() *cobra.Command {
 		Use:   "token",
 		Short: "Print the active control-plane bearer token — a live credential, treat as a secret",
 		Long: "Print the active control-plane bearer token to stdout so scripts and\n" +
-			"ad-hoc curl can authenticate against the core API without re-deriving the\n" +
-			"keychain slot.\n\n" +
+			"ad-hoc curl can authenticate against the control-plane API.\n\n" +
 			"The output is a live credential — treat it as a secret. It is the same\n" +
 			"bearer the API client uses: ENTIRE_TOKEN verbatim when set, otherwise the\n" +
 			"active context's login JWT (refreshed if it's near expiry). Only the token\n" +
 			"is printed to stdout; errors and the not-logged-in hint go to stderr so\n" +
 			"command substitution stays clean.",
-		Example: "  curl -H \"Authorization: Bearer $(entire auth token)\" \"$CORE/api/v1/clusters\"",
+		Example: "  curl -H \"Authorization: Bearer $(entire auth token)\" \"https://us.console.entire.io/api/v1/clusters\"",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Refresh may exchange/refresh over the network; honor the

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -126,23 +126,28 @@ func newAuthCmd() *cobra.Command {
 
 // --- token ------------------------------------------------------------------
 
-// newAuthTokenCmd prints the active control-plane bearer to stdout so scripts
-// (and ad-hoc curl) can authenticate against the core API without re-deriving
-// the keychain slot — e.g.
-//
-//	curl -H "Authorization: Bearer $(entire auth token)" "$CORE/api/v1/clusters"
-//
-// It emits a live credential, so treat the output as a secret. It resolves the
-// same bearer the API client would — ENTIRE_TOKEN verbatim when set, otherwise
-// the active context's login JWT, refreshed if it's near expiry — and prints
-// nothing but the token (errors and the not-logged-in hint go to stderr) so
-// command substitution stays clean.
+// newAuthTokenCmd prints the active control-plane bearer to stdout for
+// scripting. The user-facing Long and Example carry the detail and the
+// "treat the output as a secret" caveat; the token resolves the same way the
+// API client's does (ENTIRE_TOKEN verbatim when set, otherwise the active
+// context's login JWT, refreshed if it's near expiry), and only the token is
+// printed — errors and the not-logged-in hint go to stderr so command
+// substitution stays clean.
 func newAuthTokenCmd() *cobra.Command {
 	var insecureHTTPAuth bool
 	cmd := &cobra.Command{
 		Use:   "token",
-		Short: "Print the active control-plane bearer token (for scripting)",
-		Args:  cobra.NoArgs,
+		Short: "Print the active control-plane bearer token — a live credential, treat as a secret",
+		Long: "Print the active control-plane bearer token to stdout so scripts and\n" +
+			"ad-hoc curl can authenticate against the core API without re-deriving the\n" +
+			"keychain slot.\n\n" +
+			"The output is a live credential — treat it as a secret. It is the same\n" +
+			"bearer the API client uses: ENTIRE_TOKEN verbatim when set, otherwise the\n" +
+			"active context's login JWT (refreshed if it's near expiry). Only the token\n" +
+			"is printed to stdout; errors and the not-logged-in hint go to stderr so\n" +
+			"command substitution stays clean.",
+		Example: "  curl -H \"Authorization: Bearer $(entire auth token)\" \"$CORE/api/v1/clusters\"",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Refresh may exchange/refresh over the network; honor the
 			// plain-HTTP opt-in before resolving so local dev cores work.

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -126,31 +126,61 @@ func newAuthCmd() *cobra.Command {
 
 // --- token ------------------------------------------------------------------
 
-// newAuthTokenCmd prints the active control-plane bearer to stdout for
-// scripting. The user-facing Long and Example carry the detail and the
-// "treat the output as a secret" caveat; the token resolves the same way the
-// API client's does (ENTIRE_TOKEN verbatim when set, otherwise the active
-// context's login JWT, refreshed if it's near expiry), and only the token is
-// printed — errors and the not-logged-in hint go to stderr so command
+// newAuthTokenCmd prints an Entire bearer to stdout for scripting. By default
+// that's the active control-plane bearer (resolved the same way the API client's
+// is: ENTIRE_TOKEN verbatim when set, otherwise the active context's login JWT,
+// refreshed if near expiry); with --jurisdiction it mints a data-plane cell
+// identity token for that jurisdiction instead. The user-facing Long and Example
+// carry the detail and the "treat the output as a secret" caveat; only the token
+// is printed — errors and the not-logged-in hint go to stderr so command
 // substitution stays clean.
 func newAuthTokenCmd() *cobra.Command {
 	var insecureHTTPAuth bool
+	var jurisdiction string
 	cmd := &cobra.Command{
 		Use:   "token",
-		Short: "Print the active control-plane bearer token — a live credential, treat as a secret",
-		Long: "Print the active control-plane bearer token to stdout so scripts and\n" +
-			"ad-hoc curl can authenticate against the control-plane API.\n\n" +
-			"The output is a live credential — treat it as a secret. It is the same\n" +
-			"bearer the API client uses: ENTIRE_TOKEN verbatim when set, otherwise the\n" +
-			"active context's login JWT (refreshed if it's near expiry). Only the token\n" +
-			"is printed to stdout; errors and the not-logged-in hint go to stderr so\n" +
-			"command substitution stays clean.",
-		Example: "  curl -H \"Authorization: Bearer $(entire auth token)\" \"https://us.console.entire.io/api/v1/clusters\"",
-		Args:    cobra.NoArgs,
+		Short: "Print an Entire bearer token — a live credential, treat as a secret",
+		Long: "Print an Entire bearer token to stdout so scripts and ad-hoc curl can\n" +
+			"authenticate without plumbing auth themselves.\n\n" +
+			"By default it prints the control-plane bearer: the same one the API client\n" +
+			"uses (ENTIRE_TOKEN verbatim when set, otherwise the active context's login\n" +
+			"JWT, refreshed if near expiry), for the control-plane API (orgs, repos,\n" +
+			"clusters, /me).\n\n" +
+			"With --jurisdiction <slug> it instead mints a jurisdictional identity token\n" +
+			"for that jurisdiction's entire-api cells (e.g.\n" +
+			"https://aws-us-east-2.api.entire.io/api/v1), which reject the control-plane\n" +
+			"bearer. The slug is a jurisdiction like 'us' or 'eu' (find yours with\n" +
+			"'entire auth status'); the token works against any cell in that\n" +
+			"jurisdiction. It is minted by exchanging your login (or ENTIRE_TOKEN, when\n" +
+			"set) for the jurisdiction's audience.\n\n" +
+			"The output is a live credential — treat it as a secret. Only the token is\n" +
+			"printed to stdout; errors and the not-logged-in hint go to stderr so command\n" +
+			"substitution stays clean.",
+		Example: "  curl -H \"Authorization: Bearer $(entire auth token)\" \"https://us.console.entire.io/api/v1/clusters\"\n" +
+			"  curl -H \"Authorization: Bearer $(entire auth token --jurisdiction us)\" \"https://aws-us-east-2.api.entire.io/api/v1/me/activity\"",
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Refresh may exchange/refresh over the network; honor the
 			// plain-HTTP opt-in before resolving so local dev cores work.
 			insecure := applyInsecureHTTPAuth(insecureHTTPAuth)
+
+			// --jurisdiction mints a data-plane cell identity token instead of the
+			// control-plane bearer. JurisdictionToken performs its own TLS/exchange
+			// guards and returns context-rich errors.
+			if strings.TrimSpace(jurisdiction) != "" {
+				token, err := auth.JurisdictionToken(cmd.Context(), insecure, jurisdiction)
+				if err != nil {
+					cmd.SilenceUsage = true
+					if errors.Is(err, auth.ErrNotLoggedIn) {
+						fmt.Fprintln(cmd.ErrOrStderr(), "Not logged in. Run 'entire login' to authenticate.")
+						return NewSilentError(err)
+					}
+					return err //nolint:wrapcheck // JurisdictionToken already returns contextual auth errors
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), token)
+				return nil
+			}
+
 			target, err := resolveAuthStatusTarget(cmd.Context(), auth.Contexts, auth.RefreshedLoginToken)
 			if err != nil {
 				return err
@@ -174,6 +204,7 @@ func newAuthTokenCmd() *cobra.Command {
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
+	cmd.Flags().StringVar(&jurisdiction, "jurisdiction", "", "mint a jurisdictional identity token for this jurisdiction slug (e.g. us, eu) for use against that jurisdiction's entire-api cells")
 	return cmd
 }
 
@@ -378,14 +409,14 @@ func runAuthStatus(ctx context.Context, w io.Writer, fetchProfile profileFetcher
 	// session — the bearer is the env var itself. Name that and stop, rather
 	// than printing context/keychain/session lines that don't apply.
 	if t.envToken {
-		fmt.Fprintf(w, "  %-9s %s\n", "Token:", auth.EnvTokenVar+" environment variable")
+		writeAuthStatusLine(w, "Token:", auth.EnvTokenVar+" environment variable")
 		return nil
 	}
 
 	if t.activeContext != "" {
-		fmt.Fprintf(w, "  %-9s %s\n", "Context:", t.activeContext)
+		writeAuthStatusLine(w, "Context:", t.activeContext)
 	}
-	fmt.Fprintf(w, "  %-9s %s\n", "Token:", "stored in OS keychain")
+	writeAuthStatusLine(w, "Token:", "stored in OS keychain")
 
 	// Active sessions on this core. The token is already known good, so a
 	// listing failure is non-fatal — note it and carry on.
@@ -407,6 +438,14 @@ func runAuthStatus(ctx context.Context, w io.Writer, fetchProfile profileFetcher
 	return nil
 }
 
+// writeAuthStatusLine writes one aligned "  Label   value" row of the
+// `entire auth status` block. writeProfileLines and runAuthStatus both render
+// into this same column, so the label width lives here in one place (it must be
+// ≥ the longest label, currently "Jurisdiction:").
+func writeAuthStatusLine(w io.Writer, label, value string) {
+	fmt.Fprintf(w, "  %-13s %s\n", label, value)
+}
+
 // writeProfileLines renders the user identity from GET /me as aligned
 // label/value lines, omitting any field the server didn't populate.
 func writeProfileLines(w io.Writer, p *authProfile) {
@@ -421,14 +460,19 @@ func writeProfileLines(w io.Writer, p *authProfile) {
 		parts = append(parts, "<"+p.Email+">")
 	}
 	if len(parts) > 0 {
-		fmt.Fprintf(w, "  %-9s %s\n", "User:", strings.Join(parts, " "))
+		writeAuthStatusLine(w, "User:", strings.Join(parts, " "))
 	}
 	if p.Provider != "" {
 		identity := p.Provider
 		if p.ProviderUserID != "" {
 			identity += "/" + p.ProviderUserID
 		}
-		fmt.Fprintf(w, "  %-9s %s\n", "Identity:", identity)
+		writeAuthStatusLine(w, "Identity:", identity)
+	}
+	// The home jurisdiction slug is what 'entire auth token --jurisdiction'
+	// takes; surface it so it's discoverable non-interactively.
+	if p.Jurisdiction != "" {
+		writeAuthStatusLine(w, "Jurisdiction:", p.Jurisdiction)
 	}
 }
 

--- a/cmd/entire/cli/auth.go
+++ b/cmd/entire/cli/auth.go
@@ -204,7 +204,7 @@ func newAuthTokenCmd() *cobra.Command {
 		},
 	}
 	addInsecureHTTPAuthFlag(cmd, &insecureHTTPAuth)
-	cmd.Flags().StringVar(&jurisdiction, "jurisdiction", "", "mint a jurisdictional identity token for this jurisdiction slug (e.g. us, eu) for use against that jurisdiction's entire-api cells")
+	cmd.Flags().StringVarP(&jurisdiction, "jurisdiction", "j", "", "mint a jurisdictional identity token for this jurisdiction slug (e.g. us, eu) for use against that jurisdiction's entire-api cells")
 	return cmd
 }
 

--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -97,38 +97,135 @@ func SetCellExchangeTransportForTest(t interface{ Helper() }, rt http.RoundTripp
 //   - otherwise the data host is a BFF/apex: resolve the caller's home-cell
 //     apiUrl from the cluster catalog (home-jurisdiction fallback).
 func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *CellTarget) (*api.Client, error) {
+	// NewEntireAPICellClient deliberately does NOT consult ENTIRE_TOKEN: it
+	// resolves the active stored login context (like every other cell/data-API
+	// command). Only `entire auth token --jurisdiction` (JurisdictionToken) adds
+	// the env-token path.
+	subject, err := resolveStoredCellSubject(ctx, insecureHTTP)
+	if err != nil {
+		return nil, err
+	}
+
+	jurisdiction, err := targetJurisdiction(target, subject.loginJWT)
+	if err != nil {
+		return nil, err
+	}
+
+	coreURL := jurisdictionCoreURL(jurisdiction, subject.dataOrigin, subject.discoveredCore)
+	if err := requireSafeExchangeURL("entire-core", coreURL); err != nil {
+		return nil, err
+	}
+
+	cellBaseURL, err := resolveTargetCellBaseURL(ctx, target, subject.dataOrigin, jurisdiction, coreURL, subject.loginJWT, subject.httpClient)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireSafeExchangeURL("entire-api cell", cellBaseURL); err != nil {
+		return nil, err
+	}
+
+	audience := jurisdictionAudience(jurisdiction, subject.dataOrigin, subject.discoveredCore)
+	token, err := exchangeJurisdictionToken(ctx, coreURL, subject.loginJWT, audience, subject.httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("exchange jurisdictional identity token: %w", err)
+	}
+
+	return api.NewClientWithBaseURL(token, cellBaseURL), nil
+}
+
+// JurisdictionToken mints and returns a jurisdictional identity token
+// (scope=openid, aud=jurisdiction host) for `jurisdiction`, for authenticating
+// against that jurisdiction's entire-api cells (e.g.
+// https://aws-us-east-2.api.entire.io/api/v1). Unlike NewEntireAPICellClient it
+// returns the raw token string (it skips the cell-base-URL resolution, which is
+// only needed to build a client) and it honours ENTIRE_TOKEN.
+//
+// Subject credential precedence:
+//   - ENTIRE_TOKEN set: the env token is the exchange subject_token, and its own
+//     aud core drives the environment family (so this works with only
+//     ENTIRE_TOKEN set, no ENTIRE_API_BASE_URL, in prod/staging/loopback).
+//     Presence is exclusive and fail-closed — a malformed/blank value errors
+//     rather than falling back to a stored login. The env token must be a login
+//     JWT (subject-capable); a rejected exchange surfaces the server error.
+//   - otherwise: the active stored context's refreshed login JWT.
+//
+// An empty `jurisdiction` falls back to the subject token's home_jurisdiction
+// claim.
+func JurisdictionToken(ctx context.Context, insecureHTTP bool, jurisdiction string) (string, error) {
+	subject, err := resolveCellSubject(ctx, insecureHTTP)
+	if err != nil {
+		return "", err
+	}
+
+	j, err := resolveJurisdiction(jurisdiction, subject.loginJWT)
+	if err != nil {
+		return "", err
+	}
+
+	coreURL := jurisdictionCoreURL(j, subject.dataOrigin, subject.discoveredCore)
+	if err := requireSafeExchangeURL("entire-core", coreURL); err != nil {
+		return "", err
+	}
+
+	audience := jurisdictionAudience(j, subject.dataOrigin, subject.discoveredCore)
+	token, err := exchangeJurisdictionToken(ctx, coreURL, subject.loginJWT, audience, subject.httpClient)
+	if err != nil {
+		return "", fmt.Errorf("exchange jurisdictional identity token: %w", err)
+	}
+	return token, nil
+}
+
+// cellSubject carries the credential and routing signals a jurisdiction token
+// exchange needs: the subject login JWT, the core that issued it (drives the
+// environment family and loopback detection), the data origin the CLI is pointed
+// at (audience/cell fallback), and the HTTP client to use for the exchange (and
+// any cluster listing).
+type cellSubject struct {
+	loginJWT       string
+	discoveredCore string
+	dataOrigin     string
+	httpClient     *http.Client
+}
+
+// resolveCellSubject picks the jurisdiction-exchange subject: ENTIRE_TOKEN when
+// set (exclusive, fail-closed), otherwise the active stored login context. This
+// is the ENTIRE_TOKEN-aware dispatcher used by JurisdictionToken;
+// NewEntireAPICellClient calls resolveStoredCellSubject directly so its behavior
+// is unchanged.
+func resolveCellSubject(ctx context.Context, insecureHTTP bool) (cellSubject, error) {
+	if raw, ok := os.LookupEnv(EnvTokenVar); ok {
+		return resolveEnvTokenCellSubject(raw, insecureHTTP)
+	}
+	return resolveStoredCellSubject(ctx, insecureHTTP)
+}
+
+// resolveStoredCellSubject resolves the exchange subject from the active stored
+// login context: it discovers the data host's trusted login servers and
+// mints/refreshes the context's login JWT.
+func resolveStoredCellSubject(ctx context.Context, insecureHTTP bool) (cellSubject, error) {
 	dataURL := api.BaseURL()
 	if insecureHTTP {
 		EnableInsecureHTTP()
 	} else if err := api.RequireSecureURL(dataURL); err != nil {
-		return nil, fmt.Errorf("base URL check: %w", err)
+		return cellSubject{}, fmt.Errorf("base URL check: %w", err)
 	}
 
 	dataOrigin := api.OriginOnly(dataURL)
 	host, ok := hostOf(dataOrigin)
 	if !ok {
-		return nil, fmt.Errorf("data API URL %q has no host to discover against", dataURL)
+		return cellSubject{}, fmt.Errorf("data API URL %q has no host to discover against", dataURL)
 	}
 
 	dctx, cancel := context.WithTimeout(ctx, dataAPIDiscoveryTimeout)
 	defer cancel()
-	var httpClient *http.Client
-	switch {
-	case cellExchangeTransportForTest != nil:
-		httpClient = &http.Client{Timeout: cellDataAPITimeout, Transport: cellExchangeTransportForTest}
-	case shouldUsePlainHTTPDiscovery(dataOrigin):
-		httpClient = dataAPIDiscoveryClient(dataOrigin)
-		httpClient.Timeout = cellDataAPITimeout
-	default:
-		httpClient = &http.Client{Timeout: cellDataAPITimeout}
-	}
+	httpClient := cellExchangeHTTPClient(dataOrigin)
 
 	selected, err := resolveContextForCellAPI(dctx, userdirs.Config(), userdirs.Cache(), host, httpClient, nil)
 	if errors.Is(err, clusterdiscovery.ErrDiscoveryUnavailable) {
-		return nil, fmt.Errorf("%s does not advertise its trusted login servers (/.well-known/entire-api.json missing or unreachable); cannot authenticate: %w", host, err)
+		return cellSubject{}, fmt.Errorf("%s does not advertise its trusted login servers (/.well-known/entire-api.json missing or unreachable); cannot authenticate: %w", host, err)
 	}
 	if err != nil {
-		return nil, err
+		return cellSubject{}, err
 	}
 
 	// Gate the login provider's HTTPS relaxation on the core it actually dials
@@ -138,54 +235,84 @@ func NewEntireAPICellClient(ctx context.Context, insecureHTTP bool, target *Cell
 	allowInsecure := insecureHTTPEnabled() || isLoopbackHTTP(selected.CoreURL)
 	loginProvider, err := NewRefreshingLoginProvider(selected, cellExchangeTransportForTest, allowInsecure)
 	if err != nil {
-		return nil, err
+		return cellSubject{}, err
 	}
 
 	loginJWT, err := loginProvider(ctx)
 	if err != nil {
 		if errors.Is(err, ErrNotLoggedIn) {
-			return nil, fmt.Errorf("not logged in (run 'entire login' first): %w", err)
+			return cellSubject{}, fmt.Errorf("not logged in (run 'entire login' first): %w", err)
 		}
 		// The provider already prefixes "refresh login token:"; return as-is to
 		// avoid a doubled prefix.
-		return nil, err
+		return cellSubject{}, err
 	}
 
-	jurisdiction, err := targetJurisdiction(target, loginJWT)
-	if err != nil {
-		return nil, err
-	}
-
-	coreURL := jurisdictionCoreURL(jurisdiction, dataOrigin, selected.CoreURL)
-	if err := requireSafeExchangeURL("entire-core", coreURL); err != nil {
-		return nil, err
-	}
-
-	cellBaseURL, err := resolveTargetCellBaseURL(ctx, target, dataOrigin, jurisdiction, coreURL, loginJWT, httpClient)
-	if err != nil {
-		return nil, err
-	}
-	if err := requireSafeExchangeURL("entire-api cell", cellBaseURL); err != nil {
-		return nil, err
-	}
-
-	audience := jurisdictionAudience(jurisdiction, dataOrigin, selected.CoreURL)
-	token, err := exchangeJurisdictionToken(ctx, coreURL, loginJWT, audience, httpClient)
-	if err != nil {
-		return nil, fmt.Errorf("exchange jurisdictional identity token: %w", err)
-	}
-
-	return api.NewClientWithBaseURL(token, cellBaseURL), nil
+	return cellSubject{
+		loginJWT:       loginJWT,
+		discoveredCore: selected.CoreURL,
+		dataOrigin:     dataOrigin,
+		httpClient:     httpClient,
+	}, nil
 }
 
-// targetJurisdiction picks the jurisdiction to mint for: the explicit repo
-// target when present, otherwise the caller's home jurisdiction from the login
-// JWT. The result is validated as a DNS label before it is templated into URLs.
-func targetJurisdiction(target *CellTarget, loginJWT string) (string, error) {
-	jurisdiction := ""
-	if target != nil {
-		jurisdiction = strings.TrimSpace(target.Jurisdiction)
+// resolveEnvTokenCellSubject builds the exchange subject from ENTIRE_TOKEN: the
+// env token is the subject login JWT and its aud core is the environment signal
+// (passed as dataOrigin) so the audience/core templates follow prod/staging/
+// loopback without ENTIRE_API_BASE_URL. Discovery is skipped — the token is used
+// verbatim. Presence is fail-closed via ParseEnvToken.
+func resolveEnvTokenCellSubject(raw string, insecureHTTP bool) (cellSubject, error) {
+	if insecureHTTP {
+		EnableInsecureHTTP()
 	}
+	core, token, err := ParseEnvToken(raw)
+	if err != nil {
+		return cellSubject{}, err
+	}
+	return cellSubject{
+		loginJWT:       token,
+		discoveredCore: core,
+		dataOrigin:     core,
+		httpClient:     cellExchangeHTTPClient(core),
+	}, nil
+}
+
+// cellExchangeHTTPClient builds the HTTP client used for jurisdiction token
+// exchange (and the home-jurisdiction cluster listing). It honours the test
+// transport seam, then the plain-HTTP-discovery relaxation for a loopback
+// origin, else a plain timeout client.
+func cellExchangeHTTPClient(origin string) *http.Client {
+	switch {
+	case cellExchangeTransportForTest != nil:
+		return &http.Client{Timeout: cellDataAPITimeout, Transport: cellExchangeTransportForTest}
+	case shouldUsePlainHTTPDiscovery(origin):
+		c := dataAPIDiscoveryClient(origin)
+		c.Timeout = cellDataAPITimeout
+		return c
+	default:
+		return &http.Client{Timeout: cellDataAPITimeout}
+	}
+}
+
+// targetJurisdiction picks the jurisdiction to mint for from a repo CellTarget:
+// the target's explicit jurisdiction when present, otherwise the caller's home
+// jurisdiction from the login JWT.
+func targetJurisdiction(target *CellTarget, loginJWT string) (string, error) {
+	override := ""
+	if target != nil {
+		override = target.Jurisdiction
+	}
+	return resolveJurisdiction(override, loginJWT)
+}
+
+// resolveJurisdiction picks the jurisdiction to mint for: the explicit override
+// (normalised to a lowercase DNS label) when non-empty, otherwise the subject
+// token's home_jurisdiction claim. The result is validated as a DNS label before
+// it is templated into URLs. Normalising the override means `--jurisdiction US`,
+// `" us "` and `us` all resolve to `us`; the home-fallback claim is already a
+// lowercase label so it is left as-is (an off-spec claim still fails the check).
+func resolveJurisdiction(override, loginJWT string) (string, error) {
+	jurisdiction := strings.ToLower(strings.TrimSpace(override))
 	if jurisdiction == "" {
 		var err error
 		jurisdiction, err = HomeJurisdictionFromLoginJWT(loginJWT)

--- a/cmd/entire/cli/auth/cell_data_api_test.go
+++ b/cmd/entire/cli/auth/cell_data_api_test.go
@@ -1,11 +1,14 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,6 +19,10 @@ import (
 	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 )
+
+// usEntireAudience is the prod "us" jurisdiction audience, reused across the
+// cell/jurisdiction tests.
+const usEntireAudience = "https://us.entire.io"
 
 func TestHomeJurisdictionFromLoginJWT(t *testing.T) {
 	t.Parallel()
@@ -74,7 +81,7 @@ func TestJurisdictionAudienceFollowsLoginFamily(t *testing.T) {
 	// No env override: the audience must follow the environment family so a
 	// staging (partial.to) login mints a partial.to audience, not a prod one.
 	t.Setenv("ENTIRE_API_AUDIENCE_TEMPLATE", "")
-	if got := jurisdictionAudience("us", "https://entire.io", "https://us.auth.entire.io"); got != "https://us.entire.io" {
+	if got := jurisdictionAudience("us", "https://entire.io", "https://us.auth.entire.io"); got != usEntireAudience {
 		t.Errorf("prod audience = %q, want https://us.entire.io", got)
 	}
 	if got := jurisdictionAudience("eu", "https://partial.to", "https://us.auth.partial.to"); got != "https://eu.partial.to" {
@@ -124,7 +131,7 @@ func TestRequireSafeExchangeURL(t *testing.T) {
 		raw     string
 		wantErr bool
 	}{
-		{"https://us.entire.io", false},
+		{usEntireAudience, false},
 		{"https://aws-eu-west-1.api.entire.io", false},
 		{"http://127.0.0.1:9000", false}, // loopback allowed
 		{"http://localhost:8787", false}, // loopback allowed
@@ -175,7 +182,7 @@ func TestNewEntireAPICellClient_RoutesThroughHomeCell(t *testing.T) {
 	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
 	t.Cleanup(restore)
 
-	const wantAudience = "https://us.entire.io"
+	const wantAudience = usEntireAudience
 
 	var gotExchangeAudience, gotReposHost string
 	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -386,5 +393,146 @@ func TestNewEntireAPICellClient_TargetRoutesToRepoCell(t *testing.T) {
 	}
 	if got := resp.Request.Header.Get("Authorization"); !strings.Contains(got, "eu-identity-token") {
 		t.Fatalf("Authorization = %q, want eu identity token", got)
+	}
+}
+
+// TestJurisdictionToken_StoredContext exercises the exported token-only path off
+// a stored login context: it must return the exchanged identity token and mint
+// it with scope=openid, the jurisdiction audience, and the login JWT as
+// subject_token. Not parallel: manipulates env + token store.
+func TestJurisdictionToken_StoredContext(t *testing.T) {
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	t.Setenv("ENTIRE_API_BASE_URL", "https://entire.io")
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	t.Cleanup(restore)
+
+	var gotAudience, gotScope, gotSubject, gotGrant string
+	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != oauthTokenPath {
+			http.NotFound(w, r)
+			return
+		}
+		_ = r.ParseForm() //nolint:errcheck // test handler
+		gotAudience = r.FormValue("audience")
+		gotScope = r.FormValue("scope")
+		gotSubject = r.FormValue("subject_token")
+		gotGrant = r.FormValue("grant_type")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"access_token":"cell-identity-token","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer coreSrv.Close()
+
+	svc := tokenstore.CoreKeyringService(coreSrv.URL)
+	loginJWT := makeJWT(t, fmt.Sprintf(`{"iss":%q,"home_jurisdiction":"us","exp":%d}`, coreSrv.URL, time.Now().Add(2*time.Hour).Unix()))
+	if err := tokenstore.Set(svc, "me", tokenstore.EncodeTokenWithExpiration(loginJWT, 7200)); err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+	ctxObj := &contexts.Context{Name: "me@core", CoreURL: coreSrv.URL, Handle: "me", KeychainService: svc}
+
+	t.Cleanup(SetResolveContextForCellAPIForTest(t, func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+		return ctxObj, nil
+	}))
+	t.Cleanup(SetCellExchangeTransportForTest(t, coreSrv.Client().Transport))
+
+	token, err := JurisdictionToken(context.Background(), false, "us")
+	if err != nil {
+		t.Fatalf("JurisdictionToken: %v", err)
+	}
+	if token != "cell-identity-token" {
+		t.Fatalf("token = %q, want cell-identity-token", token)
+	}
+	if gotAudience != usEntireAudience {
+		t.Errorf("audience = %q, want https://us.entire.io", gotAudience)
+	}
+	if gotScope != JurisdictionIdentityScope {
+		t.Errorf("scope = %q, want %q", gotScope, JurisdictionIdentityScope)
+	}
+	if gotSubject != loginJWT {
+		t.Errorf("subject_token = %q, want the login JWT", gotSubject)
+	}
+	if gotGrant != "urn:ietf:params:oauth:grant-type:token-exchange" {
+		t.Errorf("grant_type = %q, want token-exchange", gotGrant)
+	}
+}
+
+// captureTransport counts exchanges and records the last request's parsed
+// form body, URL, and Authorization header, returning a canned RFC 8693
+// token-exchange success response. The minted access_token is `token`, or
+// "repo-scoped.jwt" when unset.
+type captureTransport struct {
+	calls int
+	form  url.Values
+	url   string
+	auth  string
+	token string
+}
+
+func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	form, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, err
+	}
+	c.calls++
+	c.form = form
+	c.url = req.URL.String()
+	c.auth = req.Header.Get("Authorization")
+	accessToken := c.token
+	if accessToken == "" {
+		accessToken = "repo-scoped.jwt"
+	}
+	resp := fmt.Sprintf(`{"access_token":%q,"token_type":"Bearer",`+
+		`"issued_token_type":"urn:ietf:params:oauth:token-type:access_token","expires_in":300}`, accessToken)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString(resp)),
+		Request:    req,
+	}, nil
+}
+
+// TestJurisdictionToken_EnvToken proves ENTIRE_TOKEN is used as the exchange
+// subject with no stored context or discovery, and that its own aud drives the
+// environment family (no ENTIRE_API_BASE_URL set). Not parallel: sets env.
+func TestJurisdictionToken_EnvToken(t *testing.T) {
+	// Empty config dir: if the env-token path fell through to stored-login
+	// resolution this would fail "not logged in", so success proves the env path.
+	t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+	envToken := makeJWT(t, fmt.Sprintf(`{"aud":"https://us.auth.entire.io","home_jurisdiction":"us","exp":%d}`, time.Now().Add(2*time.Hour).Unix()))
+	t.Setenv("ENTIRE_TOKEN", envToken)
+
+	// captureTransport intercepts the /oauth/token POST and records the form, so
+	// the ENTIRE_TOKEN path is tested without a real (https) core server.
+	rt := &captureTransport{token: "env-cell-token"}
+	t.Cleanup(SetCellExchangeTransportForTest(t, rt))
+
+	// Explicit jurisdiction: audience follows the requested region, subject is the
+	// env token verbatim.
+	token, err := JurisdictionToken(context.Background(), false, "eu")
+	if err != nil {
+		t.Fatalf("JurisdictionToken(eu): %v", err)
+	}
+	if token != "env-cell-token" {
+		t.Fatalf("token = %q, want env-cell-token", token)
+	}
+	if got := rt.form.Get("subject_token"); got != envToken {
+		t.Errorf("subject_token = %q, want the ENTIRE_TOKEN value", got)
+	}
+	if got := rt.form.Get("audience"); got != "https://eu.entire.io" {
+		t.Errorf("audience = %q, want https://eu.entire.io", got)
+	}
+	if got := rt.form.Get("scope"); got != JurisdictionIdentityScope {
+		t.Errorf("scope = %q, want %q", got, JurisdictionIdentityScope)
+	}
+
+	// Empty jurisdiction falls back to the env token's home_jurisdiction claim.
+	if _, err := JurisdictionToken(context.Background(), false, ""); err != nil {
+		t.Fatalf("JurisdictionToken(home): %v", err)
+	}
+	if got := rt.form.Get("audience"); got != usEntireAudience {
+		t.Errorf("home-fallback audience = %q, want https://us.entire.io", got)
 	}
 }

--- a/cmd/entire/cli/auth_test.go
+++ b/cmd/entire/cli/auth_test.go
@@ -90,6 +90,25 @@ func TestRunAuthStatus_LoggedIn(t *testing.T) {
 	}
 }
 
+// TestWriteProfileLines_Jurisdiction verifies the home jurisdiction slug is
+// rendered (so `auth token --jurisdiction` is discoverable) and omitted when the
+// server didn't populate it.
+func TestWriteProfileLines_Jurisdiction(t *testing.T) {
+	t.Parallel()
+
+	var withJ bytes.Buffer
+	writeProfileLines(&withJ, &authProfile{Handle: "alice", Provider: "github", Jurisdiction: "us"})
+	if !strings.Contains(withJ.String(), "Jurisdiction: us") {
+		t.Fatalf("output = %q, want a 'Jurisdiction: us' line", withJ.String())
+	}
+
+	var withoutJ bytes.Buffer
+	writeProfileLines(&withoutJ, &authProfile{Handle: "alice", Provider: "github"})
+	if strings.Contains(withoutJ.String(), "Jurisdiction") {
+		t.Fatalf("output = %q, want no Jurisdiction line when the slug is empty", withoutJ.String())
+	}
+}
+
 // In ENTIRE_TOKEN mode there is no stored context, keychain slot, or revocable
 // session: status names the env-token core and bearer source, and renders none
 // of the context/keychain/session lines. listSessions must not be called — you

--- a/cmd/entire/cli/auth_token_test.go
+++ b/cmd/entire/cli/auth_token_test.go
@@ -20,7 +20,7 @@ func makeTestJWT(t *testing.T, payloadJSON string) string {
 	return header + "." + payload + "." + enc.EncodeToString([]byte("sig"))
 }
 
-// TestAuthTokenCmd covers the hidden `entire auth token` scripting helper.
+// TestAuthTokenCmd covers the `entire auth token` scripting helper.
 //
 // Not parallel: it manipulates ENTIRE_TOKEN / ENTIRE_CONFIG_DIR.
 func TestAuthTokenCmd(t *testing.T) {

--- a/cmd/entire/cli/auth_token_test.go
+++ b/cmd/entire/cli/auth_token_test.go
@@ -112,6 +112,23 @@ func TestAuthTokenCmd_Jurisdiction(t *testing.T) {
 		require.Empty(t, errOut.String(), "stdout-only: no diagnostics on success")
 	})
 
+	t.Run("-j shorthand behaves like --jurisdiction", func(t *testing.T) {
+		t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+		envToken := makeTestJWT(t, fmt.Sprintf(`{"aud":"https://us.auth.entire.io","home_jurisdiction":"us","exp":%d}`, time.Now().Add(2*time.Hour).Unix()))
+		t.Setenv("ENTIRE_TOKEN", envToken)
+		t.Cleanup(auth.SetCellExchangeTransportForTest(t, stubExchangeRT{token: "jurisdiction-token"}))
+
+		cmd := newAuthTokenCmd()
+		cmd.SetArgs([]string{"-j", "us"})
+		var out, errOut bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&errOut)
+
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		require.Equal(t, "jurisdiction-token\n", out.String())
+		require.Empty(t, errOut.String(), "stdout-only: no diagnostics on success")
+	})
+
 	t.Run("not logged in errors silently with a hint", func(t *testing.T) {
 		t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
 		// No ENTIRE_TOKEN → stored path. Stub discovery to surface ErrNotLoggedIn

--- a/cmd/entire/cli/auth_token_test.go
+++ b/cmd/entire/cli/auth_token_test.go
@@ -2,12 +2,35 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/auth"
+	"github.com/entireio/cli/internal/entireclient/clusterdiscovery"
+	"github.com/entireio/cli/internal/entireclient/contexts"
 	"github.com/stretchr/testify/require"
 )
+
+// stubExchangeRT intercepts any /oauth/token POST and returns a canned identity
+// token, so the --jurisdiction command path can be tested without a real core.
+type stubExchangeRT struct{ token string }
+
+func (s stubExchangeRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	_, _ = io.Copy(io.Discard, r.Body) //nolint:errcheck // test transport
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"access_token":%q,"token_type":"Bearer","expires_in":3600}`, s.token))),
+		Request:    r,
+	}, nil
+}
 
 // makeTestJWT builds an unsigned JWT with the given payload JSON. ParseClaims
 // (used by ENTIRE_TOKEN resolution) reads the payload without verifying the
@@ -50,6 +73,55 @@ func TestAuthTokenCmd(t *testing.T) {
 		t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
 
 		cmd := newAuthTokenCmd()
+		var out, errOut bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&errOut)
+		err := cmd.ExecuteContext(t.Context())
+
+		var silent *SilentError
+		require.ErrorAs(t, err, &silent)
+		require.Empty(t, out.String(), "stdout must stay clean for command substitution")
+		require.Contains(t, errOut.String(), "Not logged in")
+	})
+}
+
+// TestAuthTokenCmd_Jurisdiction covers `entire auth token --jurisdiction`.
+//
+// Not parallel: it manipulates ENTIRE_TOKEN / ENTIRE_CONFIG_DIR and the
+// package-global cell-exchange seams.
+func TestAuthTokenCmd_Jurisdiction(t *testing.T) {
+	if v, ok := os.LookupEnv("ENTIRE_TOKEN"); ok {
+		os.Unsetenv("ENTIRE_TOKEN")
+		t.Cleanup(func() { os.Setenv("ENTIRE_TOKEN", v) }) //nolint:usetesting // restoring a captured value; no t.Unsetenv equivalent
+	}
+
+	t.Run("mints and prints a jurisdictional token from ENTIRE_TOKEN", func(t *testing.T) {
+		t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+		envToken := makeTestJWT(t, fmt.Sprintf(`{"aud":"https://us.auth.entire.io","home_jurisdiction":"us","exp":%d}`, time.Now().Add(2*time.Hour).Unix()))
+		t.Setenv("ENTIRE_TOKEN", envToken)
+		t.Cleanup(auth.SetCellExchangeTransportForTest(t, stubExchangeRT{token: "jurisdiction-token"}))
+
+		cmd := newAuthTokenCmd()
+		cmd.SetArgs([]string{"--jurisdiction", "us"})
+		var out, errOut bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&errOut)
+
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		require.Equal(t, "jurisdiction-token\n", out.String())
+		require.Empty(t, errOut.String(), "stdout-only: no diagnostics on success")
+	})
+
+	t.Run("not logged in errors silently with a hint", func(t *testing.T) {
+		t.Setenv("ENTIRE_CONFIG_DIR", t.TempDir())
+		// No ENTIRE_TOKEN → stored path. Stub discovery to surface ErrNotLoggedIn
+		// without a network call, so the command maps it to the clean hint.
+		t.Cleanup(auth.SetResolveContextForCellAPIForTest(t, func(context.Context, string, string, string, *http.Client, clusterdiscovery.DebugFunc) (*contexts.Context, error) {
+			return nil, fmt.Errorf("no eligible context: %w", auth.ErrNotLoggedIn)
+		}))
+
+		cmd := newAuthTokenCmd()
+		cmd.SetArgs([]string{"--jurisdiction", "us"})
 		var out, errOut bytes.Buffer
 		cmd.SetOut(&out)
 		cmd.SetErr(&errOut)


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/743
<!-- entire-trail-link-end -->

## What

Two related changes to `entire auth token`:

1. **Unhide the command** so it appears in `entire auth --help` and `entire agent-help`, surfacing the supported way to authenticate ad-hoc requests.
2. **Add `--jurisdiction <slug>`** (e.g. `us`, `eu`) to mint a *jurisdictional identity token* for that jurisdiction's entire-api cells, plus a `Jurisdiction:` line in `entire auth status` so the slug is discoverable.

```
# control-plane bearer (default)
curl -H "Authorization: Bearer $(entire auth token)" "https://us.console.entire.io/api/v1/clusters"

# jurisdictional cell token
curl -H "Authorization: Bearer $(entire auth token --jurisdiction us)" "https://aws-us-east-2.api.entire.io/api/v1/me/activity"
```

## Why

`entire auth token` was a hidden, scripting-only escape hatch that printed the **control-plane** bearer. Two gaps:

- It wasn't discoverable — users and agents had no surfaced way to authenticate ad-hoc `curl` against the core API.
- The per-jurisdiction data-plane **cells** (e.g. `https://aws-us-east-2.api.entire.io/api/v1`) *reject* the control-plane bearer; they require a jurisdictional identity token (RFC 8693 exchange, `scope=openid`, `aud=<jurisdiction host>`, per COR-666). There was no way to obtain that token.

## Details

**Unhide** (`05f3feb`, `58f798b`, `ccc62a4`)
- Remove `Hidden: true` from `newAuthTokenCmd`; reword the doc comment to drop the "not part of the everyday surface" framing while keeping the "treat the output as a secret" caveat. `--insecure-http-auth` on the command stays hidden. `RunE` is otherwise unchanged; `agent-help` renders live from the Cobra tree so it picks up the visibility change automatically.

**`--jurisdiction`** (`2b08ff1`)
- New exported `auth.JurisdictionToken`, built by extracting a shared subject-resolution helper out of `NewEntireAPICellClient` (whose behavior is unchanged). **No new exchange/URL/security logic** — it reuses the audited `exchangeJurisdictionToken` / `jurisdictionAudience` / `jurisdictionCoreURL` helpers and returns the raw token instead of a client (skipping the cell-URL round-trip a client would need).
- **`ENTIRE_TOKEN` is honored** as the exchange subject (exclusive, fail-closed), with the environment (prod/staging/loopback) derived from the token's own `aud` — so CI works with only `ENTIRE_TOKEN` set, no `ENTIRE_API_BASE_URL`. Only the `--jurisdiction` path gains this; `NewEntireAPICellClient` / `entire api --to cell` are unchanged.
- The slug is a bare lowercase jurisdiction (normalized: `US`/`" us "` -> `us`); the one token works against any cell in that jurisdiction.
- `entire auth status` now shows the caller's home jurisdiction so the slug is discoverable non-interactively.

## Testing

- Unit tests for `JurisdictionToken` (stored-context + `ENTIRE_TOKEN` subject paths, asserting `subject_token`, `scope=openid`, and the jurisdiction audience).
- Command-level tests for `--jurisdiction` (env-token success + not-logged-in hint) and the new `auth status` slug line.
- `mise run lint` clean; the `cmd/entire/cli` and `cmd/entire/cli/auth` packages pass.

> Note: `mise run test:ci` fails locally only in unrelated `cmd/entire/cli/strategy` git-hook tests, caused by a global `~/.git_template` leaking hooks into test repos — those tests are untouched by this change and fail the same way on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ByabUEH7Egwn2rMt8o6bB
