### PR TITLE
git-remote-entire: persisted jurisdiction access tokens for git auth

### DIFF
--- a/cmd/entire/cli/auth/cell_data_api.go
+++ b/cmd/entire/cli/auth/cell_data_api.go
@@ -23,7 +23,11 @@ import (
 const (
 	cellDataAPITimeout = 30 * time.Second
 
-	jurisdictionIdentityScope = "openid"
+	// JurisdictionIdentityScope is the scope jurisdiction identity tokens
+	// are minted with (also used by git-remote-entire's jurisdiction git
+	// auth). The receiving surface authorizes live per request, so the
+	// scope carries identity semantics only, not a permission grant.
+	JurisdictionIdentityScope = "openid"
 
 	// clustersAPIPath is entire-core's cluster catalog endpoint.
 	clustersAPIPath = "/api/v1/clusters"
@@ -184,7 +188,7 @@ func targetJurisdiction(target *CellTarget, loginJWT string) (string, error) {
 	}
 	if jurisdiction == "" {
 		var err error
-		jurisdiction, err = homeJurisdictionFromLoginJWT(loginJWT)
+		jurisdiction, err = HomeJurisdictionFromLoginJWT(loginJWT)
 		if err != nil {
 			return "", err
 		}
@@ -339,7 +343,12 @@ func requireSafeExchangeURL(label, raw string) error {
 	return nil
 }
 
-func homeJurisdictionFromLoginJWT(loginJWT string) (string, error) {
+// HomeJurisdictionFromLoginJWT reads the home_jurisdiction claim without
+// verifying the signature — callers only route with it; the server
+// re-verifies. Returns "" (no error) when the claim is absent so each
+// caller can phrase its own missing-claim error. Shared with
+// git-remote-entire's jurisdiction git auth.
+func HomeJurisdictionFromLoginJWT(loginJWT string) (string, error) {
 	parts := strings.Split(loginJWT, ".")
 	if len(parts) < 2 {
 		return "", errors.New("login token is not a JWT")
@@ -427,14 +436,7 @@ func exchangeJurisdictionToken(ctx context.Context, coreURL, loginJWT, audience 
 	if coreURL == "" {
 		return "", errors.New("no entire-core URL configured for jurisdiction token exchange")
 	}
-	form := url.Values{}
-	form.Set("grant_type", httputil.GrantTypeTokenExchange)
-	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
-	form.Set("subject_token", loginJWT)
-	form.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
-	form.Set("audience", audience)
-	form.Set("scope", jurisdictionIdentityScope)
-	form.Set("client_id", oauthClientID)
+	form := httputil.TokenExchangeForm(loginJWT, audience, JurisdictionIdentityScope)
 
 	token, _, err := httputil.PostOAuthToken(ctx, httpClient, coreURL, form)
 	if err != nil {

--- a/cmd/entire/cli/auth/cell_data_api_test.go
+++ b/cmd/entire/cli/auth/cell_data_api_test.go
@@ -20,9 +20,9 @@ import (
 func TestHomeJurisdictionFromLoginJWT(t *testing.T) {
 	t.Parallel()
 	jwt := makeJWT(t, fmt.Sprintf(`{"home_jurisdiction":"us","exp":%d}`, time.Now().Add(time.Hour).Unix()))
-	got, err := homeJurisdictionFromLoginJWT(jwt)
+	got, err := HomeJurisdictionFromLoginJWT(jwt)
 	if err != nil {
-		t.Fatalf("homeJurisdictionFromLoginJWT: %v", err)
+		t.Fatalf("HomeJurisdictionFromLoginJWT: %v", err)
 	}
 	if got != "us" {
 		t.Fatalf("jurisdiction = %q, want us", got)
@@ -192,7 +192,7 @@ func TestNewEntireAPICellClient_RoutesThroughHomeCell(t *testing.T) {
 		case oauthTokenPath:
 			_ = r.ParseForm() //nolint:errcheck // test handler
 			gotExchangeAudience = r.FormValue("audience")
-			if r.FormValue("scope") != jurisdictionIdentityScope {
+			if r.FormValue("scope") != JurisdictionIdentityScope {
 				t.Errorf("scope = %q, want openid", r.FormValue("scope"))
 			}
 			w.Header().Set("Content-Type", "application/json")

--- a/cmd/entire/cli/auth/provider.go
+++ b/cmd/entire/cli/auth/provider.go
@@ -1,5 +1,7 @@
 package auth
 
+import "github.com/entireio/cli/internal/entireclient/httputil"
+
 // OAuth wiring for the entire-cli public client against an entire-core
 // login server. Matches an OIDC-standard auth server's discovery doc —
 // confirmed against us.auth.entire.io's /.well-known/openid-configuration.
@@ -8,7 +10,7 @@ package auth
 // grant_type differentiates token vs exchange at the shared /oauth/token
 // endpoint.
 const (
-	oauthClientID       = "entire-cli"
+	oauthClientID       = httputil.OAuthClientID
 	oauthDeviceCodePath = "/device_authorization"
 	oauthAuthorizePath  = "/authorize"
 	oauthTokenPath      = "/oauth/token" //nolint:gosec // G101: an endpoint path, not a credential

--- a/cmd/entire/cli/integration_test/trail_resume_test.go
+++ b/cmd/entire/cli/integration_test/trail_resume_test.go
@@ -183,7 +183,7 @@ func configureTrailResumeIntegrationAuth(t *testing.T, env *TestEnv, coreURL str
 	host := mustTrailResumeIntegrationHost(t, coreURL)
 	cacheDir := filepath.Join(xdgCacheHome, "entire")
 	if err := discovery.ModifyAPICores(cacheDir, func(c discovery.ClusterCoresCache) error {
-		c.Set(host, []string{coreURL})
+		c.SetEntry(host, discovery.CoresEntry{CoreURLs: []string{coreURL}})
 		return nil
 	}); err != nil {
 		t.Fatalf("seed API discovery cache: %v", err)

--- a/cmd/git-remote-entire/identityauth.go
+++ b/cmd/git-remote-entire/identityauth.go
@@ -47,10 +47,10 @@ type identityTokenSource struct {
 	homeCoreURL string
 	// audience is the cluster's advertised jurisdiction audience.
 	audience string
-	// trustedCores is the cluster's advertised core set; a derived
-	// cross-juris exchange core must be in it before the login JWT is
-	// POSTed there.
-	trustedCores []string
+	// jurisdictionCoreURL is the cluster's advertised core that mints for
+	// audience — the cross-jurisdiction exchange endpoint. It rides the
+	// same TLS-authenticated /.well-known trust root as the audience.
+	jurisdictionCoreURL string
 	// handle is the context's account handle — the keychain account key.
 	handle string
 	login  func(context.Context) (string, error)
@@ -61,17 +61,17 @@ type identityTokenSource struct {
 	expiresAt time.Time
 }
 
-func newIdentityTokenSource(homeCoreURL, audience string, trustedCores []string, handle string, login func(context.Context) (string, error), client *http.Client) *identityTokenSource {
+func newIdentityTokenSource(homeCoreURL, audience, jurisdictionCoreURL, handle string, login func(context.Context) (string, error), client *http.Client) *identityTokenSource {
 	if override := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_AUDIENCE")); override != "" {
 		audience = override
 	}
 	return &identityTokenSource{
-		homeCoreURL:  homeCoreURL,
-		audience:     audience,
-		trustedCores: trustedCores,
-		handle:       handle,
-		login:        login,
-		client:       client,
+		homeCoreURL:         homeCoreURL,
+		audience:            audience,
+		jurisdictionCoreURL: strings.TrimRight(jurisdictionCoreURL, "/"),
+		handle:              handle,
+		login:               login,
+		client:              client,
 	}
 }
 
@@ -149,16 +149,16 @@ func (s *identityTokenSource) mint(ctx context.Context) (string, time.Duration, 
 }
 
 // exchangeCore picks the core to exchange at: the login's own core when the
-// audience is in the login's home jurisdiction, else the audience
-// jurisdiction's sibling core (https://<label>.auth.<family>), which must be
-// in the cluster's advertised core set before the login JWT is sent to it.
-// ENTIRE_IDENTITY_CORE overrides.
+// audience is in the login's home jurisdiction, else the cluster's
+// advertised jurisdiction core. Both arrive over TLS-authenticated trust
+// roots (the login context / the cluster's /.well-known), but the login JWT
+// is only ever POSTed to an https origin. ENTIRE_IDENTITY_CORE overrides.
 func (s *identityTokenSource) exchangeCore(loginJWT string) (string, error) {
 	if override := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_CORE")); override != "" {
 		return strings.TrimRight(override, "/"), nil
 	}
 
-	label, family, err := splitJurisdictionHost(s.audience)
+	label, err := jurisdictionLabel(s.audience)
 	if err != nil {
 		return "", err
 	}
@@ -170,29 +170,29 @@ func (s *identityTokenSource) exchangeCore(loginJWT string) (string, error) {
 		return s.homeCoreURL, nil
 	}
 
-	sibling := "https://" + label + ".auth." + family
-	for _, trusted := range s.trustedCores {
-		if strings.TrimRight(trusted, "/") == sibling {
-			return sibling, nil
-		}
+	if s.jurisdictionCoreURL == "" {
+		return "", fmt.Errorf("cross-jurisdiction identity exchange for %s: cluster advertises no jurisdiction_core_url; upgrade the cluster (or set ENTIRE_IDENTITY_CORE)", s.audience)
 	}
-	return "", fmt.Errorf("cross-jurisdiction identity exchange: derived core %s is not in the cluster's advertised core set %v; set ENTIRE_IDENTITY_CORE", sibling, s.trustedCores)
+	if !strings.HasPrefix(s.jurisdictionCoreURL, "https://") {
+		return "", fmt.Errorf("advertised jurisdiction core %q must be https", s.jurisdictionCoreURL)
+	}
+	return s.jurisdictionCoreURL, nil
 }
 
-// splitJurisdictionHost splits a jurisdiction audience like
-// https://au.entire.io into its jurisdiction label ("au") and domain family
-// ("entire.io").
-func splitJurisdictionHost(audience string) (label, family string, err error) {
+// jurisdictionLabel extracts the jurisdiction label from an audience like
+// https://au.entire.io ("au"), for comparison against the login JWT's
+// home_jurisdiction claim.
+func jurisdictionLabel(audience string) (string, error) {
 	u, err := url.Parse(audience)
 	if err != nil {
-		return "", "", fmt.Errorf("parse jurisdiction audience %q: %w", audience, err)
+		return "", fmt.Errorf("parse jurisdiction audience %q: %w", audience, err)
 	}
 	host := strings.ToLower(u.Hostname())
-	label, family, ok := strings.Cut(host, ".")
-	if !ok || label == "" || family == "" {
-		return "", "", fmt.Errorf("jurisdiction audience %q has no <jurisdiction>.<domain> host", audience)
+	label, rest, ok := strings.Cut(host, ".")
+	if !ok || label == "" || rest == "" {
+		return "", fmt.Errorf("jurisdiction audience %q has no <jurisdiction>.<domain> host", audience)
 	}
-	return label, family, nil
+	return label, nil
 }
 
 // homeJurisdictionFromLoginJWT reads the home_jurisdiction claim without

--- a/cmd/git-remote-entire/identityauth.go
+++ b/cmd/git-remote-entire/identityauth.go
@@ -67,6 +67,18 @@ func (s *identityTokenSource) Token(ctx context.Context, _, _ string) (string, e
 		return "", err
 	}
 
+	// The identity token must be minted by the core owning the target
+	// jurisdiction (isJurisdictionAudience is an exact match on that core's
+	// own audience). For a repo homed outside the login's jurisdiction the
+	// exchange goes to the sibling core, which accepts our login JWT via the
+	// foreign-session path (validateForeignSessionExchange) and mints the
+	// identity token in the same single POST. ENTIRE_IDENTITY_CORE overrides
+	// the exchange target for that cross-juris case.
+	coreURL := s.coreURL
+	if override := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_CORE")); override != "" {
+		coreURL = strings.TrimRight(override, "/")
+	}
+
 	form := url.Values{}
 	form.Set("grant_type", httputil.GrantTypeTokenExchange)
 	form.Set("subject_token", loginJWT)
@@ -76,9 +88,9 @@ func (s *identityTokenSource) Token(ctx context.Context, _, _ string) (string, e
 	form.Set("scope", "openid")
 	form.Set("client_id", "entire-cli") // same client as repocreds' oauthClientID
 
-	token, expiresIn, err := httputil.PostOAuthToken(ctx, s.client, s.coreURL, form)
+	token, expiresIn, err := httputil.PostOAuthToken(ctx, s.client, coreURL, form)
 	if err != nil {
-		return "", fmt.Errorf("identity token exchange (aud=%s at %s): %w", audience, s.coreURL, err)
+		return "", fmt.Errorf("identity token exchange (aud=%s at %s): %w", audience, coreURL, err)
 	}
 	if strings.TrimSpace(token) == "" {
 		return "", errors.New("identity token exchange returned an empty access token")

--- a/cmd/git-remote-entire/identityauth.go
+++ b/cmd/git-remote-entire/identityauth.go
@@ -1,0 +1,157 @@
+package main
+
+// EXPERIMENT (jwt-latency-experiment branch): mint a jurisdiction identity
+// token (ADR 20260612, scope=openid, aud=https://<jurisdiction>.<family>)
+// instead of a per-(repo,action) repo-scoped token, and send that on git
+// smart-HTTP requests. The data plane authorizes it live against regional
+// SpiceDB. Enabled with ENTIRE_GIT_AUTH=identity.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/entireio/cli/internal/entireclient/httputil"
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+)
+
+const identityAuthMode = "identity"
+
+func identityAuthEnabled() bool {
+	return os.Getenv("ENTIRE_GIT_AUTH") == identityAuthMode
+}
+
+// identityTokenSource satisfies the same Token(ctx, audienceSuffix, action)
+// seam as repocreds.Cache but ignores the repo/action: one identity token
+// covers every repo the account can reach, so a single mint serves the whole
+// process. audienceSuffix/action params are kept so setAuth doesn't care
+// which mode is active.
+type identityTokenSource struct {
+	coreURL string
+	login   func(context.Context) (string, error)
+	client  *http.Client
+
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+}
+
+func newIdentityTokenSource(coreURL string, login func(context.Context) (string, error), client *http.Client) *identityTokenSource {
+	return &identityTokenSource{coreURL: coreURL, login: login, client: client}
+}
+
+// Token returns the memoized identity token, minting on first use or after
+// expiry (1m safety margin, mirroring repocreds.SafetyMargin).
+func (s *identityTokenSource) Token(ctx context.Context, _, _ string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.token != "" && time.Now().Before(s.expiresAt) {
+		return s.token, nil
+	}
+
+	loginJWT, err := s.login(ctx)
+	if err != nil {
+		return "", fmt.Errorf("refresh login token: %w", err)
+	}
+
+	audience, err := identityAudience(s.coreURL, loginJWT)
+	if err != nil {
+		return "", err
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", httputil.GrantTypeTokenExchange)
+	form.Set("subject_token", loginJWT)
+	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	form.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
+	form.Set("audience", audience)
+	form.Set("scope", "openid")
+	form.Set("client_id", "entire-cli") // same client as repocreds' oauthClientID
+
+	token, expiresIn, err := httputil.PostOAuthToken(ctx, s.client, s.coreURL, form)
+	if err != nil {
+		return "", fmt.Errorf("identity token exchange (aud=%s at %s): %w", audience, s.coreURL, err)
+	}
+	if strings.TrimSpace(token) == "" {
+		return "", errors.New("identity token exchange returned an empty access token")
+	}
+
+	ttl := time.Duration(expiresIn) * time.Second
+	margin := min(time.Minute, ttl/2)
+	s.token = token
+	s.expiresAt = time.Now().Add(ttl - margin)
+	debuglog.Printf("identity token minted: aud=%s ttl=%s", audience, ttl)
+	return token, nil
+}
+
+// identityAudience derives the jurisdiction audience the data plane pins
+// identity tokens to (its ENTIRE_JURISDICTION_AUDIENCE). Precedence:
+// ENTIRE_IDENTITY_AUDIENCE verbatim; else https://<home_jurisdiction from
+// the login JWT>.<domain family of coreURL>. Cross-jurisdiction targets
+// (repo homed outside the login's jurisdiction) are out of scope for this
+// experiment — the /.well-known doc would need to advertise the cluster's
+// jurisdiction for that.
+func identityAudience(coreURL, loginJWT string) (string, error) {
+	if aud := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_AUDIENCE")); aud != "" {
+		return aud, nil
+	}
+	jurisdiction, err := homeJurisdictionFromLoginJWT(loginJWT)
+	if err != nil {
+		return "", err
+	}
+	family, err := domainFamily(coreURL)
+	if err != nil {
+		return "", err
+	}
+	return "https://" + jurisdiction + "." + family, nil
+}
+
+// domainFamily maps the login core's host to the environment apex the
+// jurisdiction audience is templated on (prod entire.io / staging partial.to),
+// mirroring auth.entireDomainFamily.
+func domainFamily(coreURL string) (string, error) {
+	u, err := url.Parse(coreURL)
+	if err != nil {
+		return "", fmt.Errorf("parse core URL %q: %w", coreURL, err)
+	}
+	host := strings.ToLower(u.Hostname())
+	switch {
+	case host == "entire.io" || strings.HasSuffix(host, ".entire.io"):
+		return "entire.io", nil
+	case host == "partial.to" || strings.HasSuffix(host, ".partial.to"):
+		return "partial.to", nil
+	}
+	return "", fmt.Errorf("core %q is not in a known domain family; set ENTIRE_IDENTITY_AUDIENCE explicitly", coreURL)
+}
+
+// homeJurisdictionFromLoginJWT reads the home_jurisdiction claim without
+// verifying the signature (we only route with it; the server re-verifies).
+// Copied from auth.homeJurisdictionFromLoginJWT, which is unexported.
+func homeJurisdictionFromLoginJWT(loginJWT string) (string, error) {
+	parts := strings.Split(loginJWT, ".")
+	if len(parts) < 2 {
+		return "", errors.New("login token is not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode login token payload: %w", err)
+	}
+	var claims struct {
+		HomeJurisdiction string `json:"home_jurisdiction"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parse login token payload: %w", err)
+	}
+	if claims.HomeJurisdiction == "" {
+		return "", errors.New("login token has no home_jurisdiction claim; set ENTIRE_IDENTITY_AUDIENCE explicitly")
+	}
+	return claims.HomeJurisdiction, nil
+}

--- a/cmd/git-remote-entire/identityauth.go
+++ b/cmd/git-remote-entire/identityauth.go
@@ -1,10 +1,16 @@
 package main
 
 // EXPERIMENT (jwt-latency-experiment branch): mint a jurisdiction identity
-// token (ADR 20260612, scope=openid, aud=https://<jurisdiction>.<family>)
-// instead of a per-(repo,action) repo-scoped token, and send that on git
-// smart-HTTP requests. The data plane authorizes it live against regional
-// SpiceDB. Enabled with ENTIRE_GIT_AUTH=identity.
+// token (ADR 20260612, scope=openid, aud = the cluster's advertised
+// jurisdiction_audience) instead of a per-(repo,action) repo-scoped token,
+// and send that on git smart-HTTP requests. The data plane authorizes it
+// live against regional SpiceDB, so one token covers every repo the account
+// can reach. Enabled with ENTIRE_GIT_AUTH=identity.
+//
+// The token is persisted in the OS keychain (like the login JWT) so fresh
+// git-remote-entire processes reuse it instead of paying the exchange per
+// git command — with the server-side 2h IdentityTokenTTL that removes the
+// exchange from the hot path entirely.
 
 import (
 	"context"
@@ -20,6 +26,7 @@ import (
 	"time"
 
 	"github.com/entireio/cli/internal/entireclient/httputil"
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 )
 
@@ -29,27 +36,54 @@ func identityAuthEnabled() bool {
 	return os.Getenv("ENTIRE_GIT_AUTH") == identityAuthMode
 }
 
+// identityKeyringService is the keychain service name for a jurisdiction's
+// identity tokens, keyed by audience so tokens for different jurisdictions
+// (and prod vs staging) can't be confused. The account is the context handle.
+func identityKeyringService(audience string) string {
+	return "entire-identity:" + strings.TrimRight(audience, "/")
+}
+
 // identityTokenSource satisfies the same Token(ctx, audienceSuffix, action)
 // seam as repocreds.Cache but ignores the repo/action: one identity token
-// covers every repo the account can reach, so a single mint serves the whole
-// process. audienceSuffix/action params are kept so setAuth doesn't care
-// which mode is active.
+// covers every repo the account can reach. Tokens come from, in order: the
+// in-process memo, the OS keychain (persisted by an earlier invocation),
+// or a fresh /oauth/token exchange (then persisted).
 type identityTokenSource struct {
-	coreURL string
-	login   func(context.Context) (string, error)
-	client  *http.Client
+	// homeCoreURL is the login context's core — the exchange target for the
+	// common case where the cluster's jurisdiction is the login's home.
+	homeCoreURL string
+	// audience is the cluster's advertised jurisdiction audience.
+	audience string
+	// trustedCores is the cluster's advertised core set; a derived
+	// cross-juris exchange core must be in it before the login JWT is
+	// POSTed there.
+	trustedCores []string
+	// handle is the context's account handle — the keychain account key.
+	handle string
+	login  func(context.Context) (string, error)
+	client *http.Client
 
 	mu        sync.Mutex
 	token     string
 	expiresAt time.Time
 }
 
-func newIdentityTokenSource(coreURL string, login func(context.Context) (string, error), client *http.Client) *identityTokenSource {
-	return &identityTokenSource{coreURL: coreURL, login: login, client: client}
+func newIdentityTokenSource(homeCoreURL, audience string, trustedCores []string, handle string, login func(context.Context) (string, error), client *http.Client) *identityTokenSource {
+	if override := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_AUDIENCE")); override != "" {
+		audience = override
+	}
+	return &identityTokenSource{
+		homeCoreURL:  homeCoreURL,
+		audience:     audience,
+		trustedCores: trustedCores,
+		handle:       handle,
+		login:        login,
+		client:       client,
+	}
 }
 
-// Token returns the memoized identity token, minting on first use or after
-// expiry (1m safety margin, mirroring repocreds.SafetyMargin).
+// Token returns the identity token, minting only when neither the memo nor
+// the keychain has a fresh one.
 func (s *identityTokenSource) Token(ctx context.Context, _, _ string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -57,26 +91,47 @@ func (s *identityTokenSource) Token(ctx context.Context, _, _ string) (string, e
 		return s.token, nil
 	}
 
-	loginJWT, err := s.login(ctx)
-	if err != nil {
-		return "", fmt.Errorf("refresh login token: %w", err)
+	service := identityKeyringService(s.audience)
+	if encoded, err := tokenstore.Get(service, s.handle); err == nil {
+		token, expiresAt := tokenstore.DecodeTokenWithExpiration(encoded)
+		if !tokenstore.IsTokenExpiredOrExpiring(expiresAt) {
+			debuglog.Printf("identity token from keychain (aud=%s, expires %s)", s.audience, expiresAt.Format(time.RFC3339))
+			s.token = token
+			s.expiresAt = expiresAt.Add(-time.Minute)
+			return token, nil
+		}
 	}
 
-	audience, err := identityAudience(s.coreURL, loginJWT)
+	token, ttl, err := s.mint(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	// The identity token must be minted by the core owning the target
-	// jurisdiction (isJurisdictionAudience is an exact match on that core's
-	// own audience). For a repo homed outside the login's jurisdiction the
-	// exchange goes to the sibling core, which accepts our login JWT via the
-	// foreign-session path (validateForeignSessionExchange) and mints the
-	// identity token in the same single POST. ENTIRE_IDENTITY_CORE overrides
-	// the exchange target for that cross-juris case.
-	coreURL := s.coreURL
-	if override := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_CORE")); override != "" {
-		coreURL = strings.TrimRight(override, "/")
+	s.token = token
+	margin := min(time.Minute, ttl/2)
+	s.expiresAt = time.Now().Add(ttl - margin)
+	if err := tokenstore.Set(service, s.handle, tokenstore.EncodeTokenWithExpiration(token, int64(ttl/time.Second))); err != nil {
+		// Non-fatal: the token still serves this process; the next
+		// invocation just re-mints.
+		debuglog.Printf("identity token keychain write failed: %v", err)
+	}
+	return token, nil
+}
+
+// mint exchanges the login JWT for an identity token at the core owning the
+// target jurisdiction. For a same-jurisdiction login that is the login's own
+// core; for a cross-jurisdiction repo the sibling core accepts our login JWT
+// via the foreign-session path and mints the identity token in the same
+// single POST.
+func (s *identityTokenSource) mint(ctx context.Context) (string, time.Duration, error) {
+	loginJWT, err := s.login(ctx)
+	if err != nil {
+		return "", 0, fmt.Errorf("refresh login token: %w", err)
+	}
+
+	coreURL, err := s.exchangeCore(loginJWT)
+	if err != nil {
+		return "", 0, err
 	}
 
 	form := url.Values{}
@@ -84,64 +139,67 @@ func (s *identityTokenSource) Token(ctx context.Context, _, _ string) (string, e
 	form.Set("subject_token", loginJWT)
 	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
 	form.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
-	form.Set("audience", audience)
+	form.Set("audience", s.audience)
 	form.Set("scope", "openid")
 	form.Set("client_id", "entire-cli") // same client as repocreds' oauthClientID
 
 	token, expiresIn, err := httputil.PostOAuthToken(ctx, s.client, coreURL, form)
 	if err != nil {
-		return "", fmt.Errorf("identity token exchange (aud=%s at %s): %w", audience, coreURL, err)
+		return "", 0, fmt.Errorf("identity token exchange (aud=%s at %s): %w", s.audience, coreURL, err)
 	}
 	if strings.TrimSpace(token) == "" {
-		return "", errors.New("identity token exchange returned an empty access token")
+		return "", 0, errors.New("identity token exchange returned an empty access token")
 	}
-
 	ttl := time.Duration(expiresIn) * time.Second
-	margin := min(time.Minute, ttl/2)
-	s.token = token
-	s.expiresAt = time.Now().Add(ttl - margin)
-	debuglog.Printf("identity token minted: aud=%s ttl=%s", audience, ttl)
-	return token, nil
+	debuglog.Printf("identity token minted: aud=%s at %s ttl=%s", s.audience, coreURL, ttl)
+	return token, ttl, nil
 }
 
-// identityAudience derives the jurisdiction audience the data plane pins
-// identity tokens to (its ENTIRE_JURISDICTION_AUDIENCE). Precedence:
-// ENTIRE_IDENTITY_AUDIENCE verbatim; else https://<home_jurisdiction from
-// the login JWT>.<domain family of coreURL>. Cross-jurisdiction targets
-// (repo homed outside the login's jurisdiction) are out of scope for this
-// experiment — the /.well-known doc would need to advertise the cluster's
-// jurisdiction for that.
-func identityAudience(coreURL, loginJWT string) (string, error) {
-	if aud := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_AUDIENCE")); aud != "" {
-		return aud, nil
+// exchangeCore picks the core to exchange at: the login's own core when the
+// audience is in the login's home jurisdiction, else the audience
+// jurisdiction's sibling core (https://<label>.auth.<family>), which must be
+// in the cluster's advertised core set before the login JWT is sent to it.
+// ENTIRE_IDENTITY_CORE overrides.
+func (s *identityTokenSource) exchangeCore(loginJWT string) (string, error) {
+	if override := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_CORE")); override != "" {
+		return strings.TrimRight(override, "/"), nil
 	}
-	jurisdiction, err := homeJurisdictionFromLoginJWT(loginJWT)
+
+	label, family, err := splitJurisdictionHost(s.audience)
 	if err != nil {
 		return "", err
 	}
-	family, err := domainFamily(coreURL)
+	home, err := homeJurisdictionFromLoginJWT(loginJWT)
 	if err != nil {
 		return "", err
 	}
-	return "https://" + jurisdiction + "." + family, nil
+	if home == label {
+		return s.homeCoreURL, nil
+	}
+
+	sibling := "https://" + label + ".auth." + family
+	for _, trusted := range s.trustedCores {
+		if strings.TrimRight(trusted, "/") == sibling {
+			return sibling, nil
+		}
+	}
+	return "", fmt.Errorf("cross-jurisdiction identity exchange: derived core %s is not in the cluster's advertised core set %v; set ENTIRE_IDENTITY_CORE", sibling, s.trustedCores)
 }
 
-// domainFamily maps the login core's host to the environment apex the
-// jurisdiction audience is templated on (prod entire.io / staging partial.to),
-// mirroring auth.entireDomainFamily.
-func domainFamily(coreURL string) (string, error) {
-	u, err := url.Parse(coreURL)
+// splitJurisdictionHost splits a jurisdiction audience like
+// https://au.entire.io into its jurisdiction label ("au") and domain family
+// ("entire.io").
+func splitJurisdictionHost(audience string) (label, family string, err error) {
+	u, err := url.Parse(audience)
 	if err != nil {
-		return "", fmt.Errorf("parse core URL %q: %w", coreURL, err)
+		return "", "", fmt.Errorf("parse jurisdiction audience %q: %w", audience, err)
 	}
 	host := strings.ToLower(u.Hostname())
-	switch {
-	case host == "entire.io" || strings.HasSuffix(host, ".entire.io"):
-		return "entire.io", nil
-	case host == "partial.to" || strings.HasSuffix(host, ".partial.to"):
-		return "partial.to", nil
+	label, family, ok := strings.Cut(host, ".")
+	if !ok || label == "" || family == "" {
+		return "", "", fmt.Errorf("jurisdiction audience %q has no <jurisdiction>.<domain> host", audience)
 	}
-	return "", fmt.Errorf("core %q is not in a known domain family; set ENTIRE_IDENTITY_AUDIENCE explicitly", coreURL)
+	return label, family, nil
 }
 
 // homeJurisdictionFromLoginJWT reads the home_jurisdiction claim without
@@ -163,7 +221,7 @@ func homeJurisdictionFromLoginJWT(loginJWT string) (string, error) {
 		return "", fmt.Errorf("parse login token payload: %w", err)
 	}
 	if claims.HomeJurisdiction == "" {
-		return "", errors.New("login token has no home_jurisdiction claim; set ENTIRE_IDENTITY_AUDIENCE explicitly")
+		return "", errors.New("login token has no home_jurisdiction claim")
 	}
 	return claims.HomeJurisdiction, nil
 }

--- a/cmd/git-remote-entire/identityauth.go
+++ b/cmd/git-remote-entire/identityauth.go
@@ -30,10 +30,13 @@ import (
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 )
 
-const identityAuthMode = "identity"
-
+// identityAuthEnabled reports whether git auth should use jurisdiction
+// identity tokens. Default on — clusters that don't advertise a
+// jurisdiction_audience fall back to repo-scoped tokens anyway, so the
+// default is safe against not-yet-upgraded clusters. ENTIRE_GIT_AUTH=scoped
+// is the escape hatch back to per-(repo,action) scoped tokens.
 func identityAuthEnabled() bool {
-	return os.Getenv("ENTIRE_GIT_AUTH") == identityAuthMode
+	return os.Getenv("ENTIRE_GIT_AUTH") != "scoped"
 }
 
 // identityKeyringService is the keychain service name for a jurisdiction's

--- a/cmd/git-remote-entire/identityauth.go
+++ b/cmd/git-remote-entire/identityauth.go
@@ -1,11 +1,10 @@
 package main
 
-// EXPERIMENT (jwt-latency-experiment branch): mint a jurisdiction identity
-// token (ADR 20260612, scope=openid, aud = the cluster's advertised
-// jurisdiction_audience) instead of a per-(repo,action) repo-scoped token,
-// and send that on git smart-HTTP requests. The data plane authorizes it
-// live against regional SpiceDB, so one token covers every repo the account
-// can reach. Enabled with ENTIRE_GIT_AUTH=identity.
+// Jurisdiction identity tokens (ADR 20260612) are how git-remote-entire
+// authenticates git smart-HTTP: a token minted with scope=openid and
+// aud = the cluster's advertised jurisdiction_audience. The data plane
+// authorizes it live against regional SpiceDB, so one token covers every
+// repo the account can reach.
 //
 // The token is persisted in the OS keychain (like the login JWT) so fresh
 // git-remote-entire processes reuse it instead of paying the exchange per
@@ -29,15 +28,6 @@ import (
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 )
-
-// identityAuthEnabled reports whether git auth should use jurisdiction
-// identity tokens. Default on — clusters that don't advertise a
-// jurisdiction_audience fall back to repo-scoped tokens anyway, so the
-// default is safe against not-yet-upgraded clusters. ENTIRE_GIT_AUTH=scoped
-// is the escape hatch back to per-(repo,action) scoped tokens.
-func identityAuthEnabled() bool {
-	return os.Getenv("ENTIRE_GIT_AUTH") != "scoped"
-}
 
 // identityKeyringService is the keychain service name for a jurisdiction's
 // identity tokens, keyed by audience so tokens for different jurisdictions

--- a/cmd/git-remote-entire/identityauth_test.go
+++ b/cmd/git-remote-entire/identityauth_test.go
@@ -35,12 +35,12 @@ func TestExchangeCore(t *testing.T) {
 	trusted := []string{"https://eu.auth.example.io", "https://au.auth.example.io"}
 
 	t.Run("same jurisdiction uses home core", func(t *testing.T) {
-		s := newIdentityTokenSource("https://eu.auth.example.io", "https://eu.example.io", trusted, "h", nil, nil)
-		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
+		s := newIdentityTokenSource("https://au.auth.example.io", "https://au.example.io", trusted, "h", nil, nil)
+		core, err := s.exchangeCore(fakeLoginJWT(t, "au"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if core != "https://eu.auth.example.io" {
+		if core != "https://au.auth.example.io" {
 			t.Fatalf("core = %q, want home core", core)
 		}
 	})
@@ -90,7 +90,7 @@ func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
 			t.Errorf("audience = %q", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"identity-jwt","token_type":"Bearer","expires_in":7200}`))
+		_, _ = w.Write([]byte(`{"access_token":"identity-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
 	}))
 	defer core.Close()
 
@@ -158,7 +158,7 @@ func TestIdentityToken_ExpiredPersistedTokenRemints(t *testing.T) {
 	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		mints++
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"fresh-jwt","token_type":"Bearer","expires_in":7200}`))
+		_, _ = w.Write([]byte(`{"access_token":"fresh-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
 	}))
 	defer core.Close()
 	t.Setenv("ENTIRE_IDENTITY_CORE", core.URL)

--- a/cmd/git-remote-entire/identityauth_test.go
+++ b/cmd/git-remote-entire/identityauth_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/entireio/cli/internal/entireclient/tokenstore"
+)
+
+// fakeLoginJWT builds an unsigned JWT whose payload carries the given
+// home_jurisdiction claim — enough for the client-side routing decisions,
+// which never verify the signature.
+func fakeLoginJWT(t *testing.T, homeJurisdiction string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]string{"home_jurisdiction": homeJurisdiction})
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+func staticLogin(jwt string) func(context.Context) (string, error) {
+	return func(context.Context) (string, error) { return jwt, nil }
+}
+
+func TestExchangeCore(t *testing.T) {
+	trusted := []string{"https://eu.auth.example.io", "https://au.auth.example.io"}
+
+	t.Run("same jurisdiction uses home core", func(t *testing.T) {
+		s := newIdentityTokenSource("https://eu.auth.example.io", "https://eu.example.io", trusted, "h", nil, nil)
+		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if core != "https://eu.auth.example.io" {
+			t.Fatalf("core = %q, want home core", core)
+		}
+	})
+
+	t.Run("cross jurisdiction derives sibling from trusted set", func(t *testing.T) {
+		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", trusted, "h", nil, nil)
+		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if core != "https://au.auth.example.io" {
+			t.Fatalf("core = %q, want au sibling", core)
+		}
+	})
+
+	t.Run("derived sibling not advertised is refused", func(t *testing.T) {
+		s := newIdentityTokenSource("https://eu.auth.example.io", "https://us.example.io", trusted, "h", nil, nil)
+		if _, err := s.exchangeCore(fakeLoginJWT(t, "eu")); err == nil {
+			t.Fatal("expected error for unadvertised sibling core")
+		}
+	})
+
+	t.Run("ENTIRE_IDENTITY_CORE overrides", func(t *testing.T) {
+		t.Setenv("ENTIRE_IDENTITY_CORE", "https://override.example.io/")
+		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", nil, "h", nil, nil)
+		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if core != "https://override.example.io" {
+			t.Fatalf("core = %q, want trimmed override", core)
+		}
+	})
+}
+
+func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	defer restore()
+
+	mints := 0
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mints++
+		if got := r.FormValue("scope"); got != "openid" {
+			t.Errorf("scope = %q, want openid", got)
+		}
+		if got := r.FormValue("audience"); got != "https://eu.example.io" {
+			t.Errorf("audience = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"identity-jwt","token_type":"Bearer","expires_in":7200}`))
+	}))
+	defer core.Close()
+
+	login := staticLogin(fakeLoginJWT(t, "eu"))
+	s := newIdentityTokenSource(core.URL, "https://eu.example.io", nil, "toothbrush", login, core.Client())
+	// The home-core short-circuit compares jurisdiction labels; the httptest
+	// URL is not jurisdiction-shaped, so route via the override.
+	t.Setenv("ENTIRE_IDENTITY_CORE", core.URL)
+
+	token, err := s.Token(context.Background(), "/et/x/y", "pull")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "identity-jwt" {
+		t.Fatalf("token = %q", token)
+	}
+	if mints != 1 {
+		t.Fatalf("mints = %d, want 1", mints)
+	}
+
+	// Same source: memoized, no second exchange.
+	if _, err := s.Token(context.Background(), "/et/x/y", "push"); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 1 {
+		t.Fatalf("mints after memo hit = %d, want 1", mints)
+	}
+
+	// Fresh source (new process): served from the persisted keychain entry.
+	s2 := newIdentityTokenSource(core.URL, "https://eu.example.io", nil, "toothbrush", login, core.Client())
+	token2, err := s2.Token(context.Background(), "/et/x/y", "pull")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token2 != "identity-jwt" {
+		t.Fatalf("token2 = %q", token2)
+	}
+	if mints != 1 {
+		t.Fatalf("mints after keychain hit = %d, want 1", mints)
+	}
+
+	// A different handle must not share the token.
+	s3 := newIdentityTokenSource(core.URL, "https://eu.example.io", nil, "other-account", login, core.Client())
+	if _, err := s3.Token(context.Background(), "/et/x/y", "pull"); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 2 {
+		t.Fatalf("mints for different handle = %d, want 2", mints)
+	}
+}
+
+func TestIdentityToken_ExpiredPersistedTokenRemints(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	defer restore()
+
+	// Seed a token 1 minute from expiry — inside the 5m refresh buffer.
+	service := identityKeyringService("https://eu.example.io")
+	expiring := "stale-jwt" + tokenstore.TokenExpirationSeparator +
+		strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10)
+	if err := tokenstore.Set(service, "toothbrush", expiring); err != nil {
+		t.Fatal(err)
+	}
+
+	mints := 0
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mints++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"fresh-jwt","token_type":"Bearer","expires_in":7200}`))
+	}))
+	defer core.Close()
+	t.Setenv("ENTIRE_IDENTITY_CORE", core.URL)
+
+	s := newIdentityTokenSource(core.URL, "https://eu.example.io", nil, "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
+	token, err := s.Token(context.Background(), "/et/x/y", "pull")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "fresh-jwt" || mints != 1 {
+		t.Fatalf("token = %q mints = %d, want fresh mint", token, mints)
+	}
+}

--- a/cmd/git-remote-entire/identityauth_test.go
+++ b/cmd/git-remote-entire/identityauth_test.go
@@ -32,10 +32,8 @@ func staticLogin(jwt string) func(context.Context) (string, error) {
 }
 
 func TestExchangeCore(t *testing.T) {
-	trusted := []string{"https://eu.auth.example.io", "https://au.auth.example.io"}
-
 	t.Run("same jurisdiction uses home core", func(t *testing.T) {
-		s := newIdentityTokenSource("https://au.auth.example.io", "https://au.example.io", trusted, "h", nil, nil)
+		s := newIdentityTokenSource("https://au.auth.example.io", "https://au.example.io", "https://au.auth.example.io", "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "au"))
 		if err != nil {
 			t.Fatal(err)
@@ -45,27 +43,34 @@ func TestExchangeCore(t *testing.T) {
 		}
 	})
 
-	t.Run("cross jurisdiction derives sibling from trusted set", func(t *testing.T) {
-		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", trusted, "h", nil, nil)
+	t.Run("cross jurisdiction uses advertised jurisdiction core", func(t *testing.T) {
+		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", "https://au.auth.example.io/", "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
 		if err != nil {
 			t.Fatal(err)
 		}
 		if core != "https://au.auth.example.io" {
-			t.Fatalf("core = %q, want au sibling", core)
+			t.Fatalf("core = %q, want advertised au core (trimmed)", core)
 		}
 	})
 
-	t.Run("derived sibling not advertised is refused", func(t *testing.T) {
-		s := newIdentityTokenSource("https://eu.auth.example.io", "https://us.example.io", trusted, "h", nil, nil)
+	t.Run("cross jurisdiction without advertised core is refused", func(t *testing.T) {
+		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil)
 		if _, err := s.exchangeCore(fakeLoginJWT(t, "eu")); err == nil {
-			t.Fatal("expected error for unadvertised sibling core")
+			t.Fatal("expected error when no jurisdiction core is advertised")
+		}
+	})
+
+	t.Run("non-https advertised core is refused", func(t *testing.T) {
+		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", "http://au.auth.example.io", "h", nil, nil)
+		if _, err := s.exchangeCore(fakeLoginJWT(t, "eu")); err == nil {
+			t.Fatal("expected error for plaintext advertised core")
 		}
 	})
 
 	t.Run("ENTIRE_IDENTITY_CORE overrides", func(t *testing.T) {
 		t.Setenv("ENTIRE_IDENTITY_CORE", "https://override.example.io/")
-		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", nil, "h", nil, nil)
+		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
 		if err != nil {
 			t.Fatal(err)
@@ -95,7 +100,7 @@ func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
 	defer core.Close()
 
 	login := staticLogin(fakeLoginJWT(t, "eu"))
-	s := newIdentityTokenSource(core.URL, "https://eu.example.io", nil, "toothbrush", login, core.Client())
+	s := newIdentityTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
 	// The home-core short-circuit compares jurisdiction labels; the httptest
 	// URL is not jurisdiction-shaped, so route via the override.
 	t.Setenv("ENTIRE_IDENTITY_CORE", core.URL)
@@ -120,7 +125,7 @@ func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 
 	// Fresh source (new process): served from the persisted keychain entry.
-	s2 := newIdentityTokenSource(core.URL, "https://eu.example.io", nil, "toothbrush", login, core.Client())
+	s2 := newIdentityTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
 	token2, err := s2.Token(context.Background(), "/et/x/y", "pull")
 	if err != nil {
 		t.Fatal(err)
@@ -133,7 +138,7 @@ func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 
 	// A different handle must not share the token.
-	s3 := newIdentityTokenSource(core.URL, "https://eu.example.io", nil, "other-account", login, core.Client())
+	s3 := newIdentityTokenSource(core.URL, "https://eu.example.io", "", "other-account", login, core.Client())
 	if _, err := s3.Token(context.Background(), "/et/x/y", "pull"); err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +168,7 @@ func TestIdentityToken_ExpiredPersistedTokenRemints(t *testing.T) {
 	defer core.Close()
 	t.Setenv("ENTIRE_IDENTITY_CORE", core.URL)
 
-	s := newIdentityTokenSource(core.URL, "https://eu.example.io", nil, "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
+	s := newIdentityTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
 	token, err := s.Token(context.Background(), "/et/x/y", "pull")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/git-remote-entire/jurisdictionauth.go
+++ b/cmd/git-remote-entire/jurisdictionauth.go
@@ -8,7 +8,7 @@ package main
 //
 // The token is persisted in the OS keychain (like the login JWT) so fresh
 // git-remote-entire processes reuse it instead of paying the exchange per
-// git command — with the server-side 2h IdentityTokenTTL that removes the
+// git command — with the server-side 8h JurisdictionAccessTokenTTL that removes the
 // exchange from the hot path entirely.
 
 import (
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -29,8 +28,8 @@ import (
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 )
 
-// jurisdictionKeyringService is the keychain service name for a jurisdiction's
-// jurisdiction tokens, keyed by audience so tokens for different jurisdictions
+// jurisdictionKeyringService is the keychain service name for jurisdiction
+// tokens, keyed by audience so tokens for different jurisdictions
 // (and prod vs staging) can't be confused. The account is the context handle.
 func jurisdictionKeyringService(audience string) string {
 	return "entire-jurisdiction:" + strings.TrimRight(audience, "/")
@@ -62,9 +61,6 @@ type jurisdictionTokenSource struct {
 }
 
 func newJurisdictionTokenSource(homeCoreURL, audience, jurisdictionCoreURL, handle string, login func(context.Context) (string, error), client *http.Client) *jurisdictionTokenSource {
-	if override := strings.TrimSpace(os.Getenv("ENTIRE_JURISDICTION_AUDIENCE")); override != "" {
-		audience = override
-	}
 	return &jurisdictionTokenSource{
 		homeCoreURL:         homeCoreURL,
 		audience:            audience,
@@ -111,7 +107,7 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (strin
 	return token, nil
 }
 
-// mint exchanges the login JWT for an jurisdiction token at the core owning the
+// mint exchanges the login JWT for a jurisdiction token at the core owning the
 // target jurisdiction. For a same-jurisdiction login that is the login's own
 // core; for a cross-jurisdiction repo the sibling core accepts our login JWT
 // via the foreign-session path and mints the jurisdiction token in the same
@@ -152,12 +148,8 @@ func (s *jurisdictionTokenSource) mint(ctx context.Context) (string, time.Durati
 // audience is in the login's home jurisdiction, else the cluster's
 // advertised jurisdiction core. Both arrive over TLS-authenticated trust
 // roots (the login context / the cluster's /.well-known), but the login JWT
-// is only ever POSTed to an https origin. ENTIRE_JURISDICTION_CORE overrides.
+// is only ever POSTed to an https origin.
 func (s *jurisdictionTokenSource) exchangeCore(loginJWT string) (string, error) {
-	if override := strings.TrimSpace(os.Getenv("ENTIRE_JURISDICTION_CORE")); override != "" {
-		return strings.TrimRight(override, "/"), nil
-	}
-
 	label, err := jurisdictionLabel(s.audience)
 	if err != nil {
 		return "", err
@@ -171,7 +163,7 @@ func (s *jurisdictionTokenSource) exchangeCore(loginJWT string) (string, error) 
 	}
 
 	if s.jurisdictionCoreURL == "" {
-		return "", fmt.Errorf("cross-jurisdiction jurisdiction-token exchange for %s: cluster advertises no jurisdiction_core_url; upgrade the cluster (or set ENTIRE_JURISDICTION_CORE)", s.audience)
+		return "", fmt.Errorf("cross-jurisdiction token exchange for %s: cluster advertises no jurisdiction_core_url", s.audience)
 	}
 	if !strings.HasPrefix(s.jurisdictionCoreURL, "https://") {
 		return "", fmt.Errorf("advertised jurisdiction core %q must be https", s.jurisdictionCoreURL)

--- a/cmd/git-remote-entire/jurisdictionauth.go
+++ b/cmd/git-remote-entire/jurisdictionauth.go
@@ -13,8 +13,6 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -23,7 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/entireio/cli/cmd/entire/cli/auth"
 	"github.com/entireio/cli/internal/entireclient/httputil"
+	"github.com/entireio/cli/internal/entireclient/repocreds"
 	"github.com/entireio/cli/internal/entireclient/tokenstore"
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 )
@@ -92,12 +92,13 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (strin
 		//
 		// Freshness margins differ by design: cross-process reuse stops at
 		// the 5m TokenExpirationBuffer (a fresh process should not start on
-		// a nearly-dead token), while this process keeps its token until 1m
-		// before actual expiry — individual git requests are short.
+		// a nearly-dead token), while this process keeps its token until
+		// SafetyMargin before actual expiry — individual git requests are
+		// short.
 		if token, expiresAt := tokenstore.DecodeTokenWithExpiration(encoded); token != "" && !tokenstore.IsTokenExpiredOrExpiring(expiresAt) {
 			debuglog.Printf("jurisdiction token from keychain (aud=%s, expires %s)", s.audience, expiresAt.Format(time.RFC3339))
 			s.token = token
-			s.expiresAt = expiresAt.Add(-time.Minute)
+			s.expiresAt = expiresAt.Add(-repocreds.SafetyMargin)
 			return token, nil
 		}
 	}
@@ -113,7 +114,7 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (strin
 	}
 
 	s.token = token
-	margin := min(time.Minute, ttl/2)
+	margin := min(repocreds.SafetyMargin, ttl/2)
 	s.expiresAt = time.Now().Add(ttl - margin)
 	if err := tokenstore.Set(service, s.handle, tokenstore.EncodeTokenWithExpiration(token, int64(ttl/time.Second))); err != nil {
 		// Non-fatal: the token still serves this process; the next
@@ -156,14 +157,7 @@ func (s *jurisdictionTokenSource) mint(ctx context.Context) (string, time.Durati
 		return "", 0, err
 	}
 
-	form := url.Values{}
-	form.Set("grant_type", httputil.GrantTypeTokenExchange)
-	form.Set("subject_token", loginJWT)
-	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
-	form.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
-	form.Set("audience", s.audience)
-	form.Set("scope", "openid")
-	form.Set("client_id", "entire-cli") // same client as repocreds' oauthClientID
+	form := httputil.TokenExchangeForm(loginJWT, s.audience, auth.JurisdictionIdentityScope)
 
 	token, expiresIn, err := httputil.PostOAuthToken(ctx, s.client, coreURL, form)
 	if err != nil {
@@ -179,17 +173,21 @@ func (s *jurisdictionTokenSource) mint(ctx context.Context) (string, time.Durati
 
 // exchangeCore picks the core to exchange at: the login's own core when the
 // audience is in the login's home jurisdiction, else the cluster's
-// advertised jurisdiction core. Both arrive over TLS-authenticated trust
-// roots (the login context / the cluster's /.well-known), but the login JWT
-// is only ever POSTed to an https origin.
+// advertised jurisdiction core. The home core is the issuer the user logged
+// in at, used verbatim (it may legitimately be loopback http in local dev);
+// the advertised core comes from a foreign cluster's /.well-known, so it
+// must be https before the login JWT is POSTed to it.
 func (s *jurisdictionTokenSource) exchangeCore(loginJWT string) (string, error) {
 	label, err := jurisdictionLabel(s.audience)
 	if err != nil {
 		return "", err
 	}
-	home, err := homeJurisdictionFromLoginJWT(loginJWT)
+	home, err := auth.HomeJurisdictionFromLoginJWT(loginJWT)
 	if err != nil {
 		return "", err
+	}
+	if home == "" {
+		return "", errors.New("login token has no home_jurisdiction claim")
 	}
 	if home == label {
 		return s.homeCoreURL, nil
@@ -218,28 +216,4 @@ func jurisdictionLabel(audience string) (string, error) {
 		return "", fmt.Errorf("jurisdiction audience %q has no <jurisdiction>.<domain> host", audience)
 	}
 	return label, nil
-}
-
-// homeJurisdictionFromLoginJWT reads the home_jurisdiction claim without
-// verifying the signature (we only route with it; the server re-verifies).
-// Copied from auth.homeJurisdictionFromLoginJWT, which is unexported.
-func homeJurisdictionFromLoginJWT(loginJWT string) (string, error) {
-	parts := strings.Split(loginJWT, ".")
-	if len(parts) < 2 {
-		return "", errors.New("login token is not a JWT")
-	}
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return "", fmt.Errorf("decode login token payload: %w", err)
-	}
-	var claims struct {
-		HomeJurisdiction string `json:"home_jurisdiction"`
-	}
-	if err := json.Unmarshal(payload, &claims); err != nil {
-		return "", fmt.Errorf("parse login token payload: %w", err)
-	}
-	if claims.HomeJurisdiction == "" {
-		return "", errors.New("login token has no home_jurisdiction claim")
-	}
-	return claims.HomeJurisdiction, nil
 }

--- a/cmd/git-remote-entire/jurisdictionauth.go
+++ b/cmd/git-remote-entire/jurisdictionauth.go
@@ -189,7 +189,9 @@ func (s *jurisdictionTokenSource) exchangeCore(loginJWT string) (string, error) 
 	if home == "" {
 		return "", errors.New("login token has no home_jurisdiction claim")
 	}
-	if home == label {
+	// jurisdictionLabel lowercases the audience host; fold the claim too so
+	// the comparison doesn't hinge on core config region keys being lowercase.
+	if strings.ToLower(home) == label {
 		return s.homeCoreURL, nil
 	}
 

--- a/cmd/git-remote-entire/jurisdictionauth.go
+++ b/cmd/git-remote-entire/jurisdictionauth.go
@@ -1,6 +1,6 @@
 package main
 
-// Jurisdiction identity tokens (ADR 20260612) are how git-remote-entire
+// Jurisdiction access tokens (docs/auth.md, ADR 20260612) are how git-remote-entire
 // authenticates git smart-HTTP: a token minted with scope=openid and
 // aud = the cluster's advertised jurisdiction_audience. The data plane
 // authorizes it live against regional SpiceDB, so one token covers every
@@ -29,19 +29,19 @@ import (
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 )
 
-// identityKeyringService is the keychain service name for a jurisdiction's
-// identity tokens, keyed by audience so tokens for different jurisdictions
+// jurisdictionKeyringService is the keychain service name for a jurisdiction's
+// jurisdiction tokens, keyed by audience so tokens for different jurisdictions
 // (and prod vs staging) can't be confused. The account is the context handle.
-func identityKeyringService(audience string) string {
-	return "entire-identity:" + strings.TrimRight(audience, "/")
+func jurisdictionKeyringService(audience string) string {
+	return "entire-jurisdiction:" + strings.TrimRight(audience, "/")
 }
 
-// identityTokenSource satisfies the same Token(ctx, audienceSuffix, action)
-// seam as repocreds.Cache but ignores the repo/action: one identity token
+// jurisdictionTokenSource satisfies the same Token(ctx, audienceSuffix, action)
+// seam as repocreds.Cache but ignores the repo/action: one jurisdiction token
 // covers every repo the account can reach. Tokens come from, in order: the
 // in-process memo, the OS keychain (persisted by an earlier invocation),
 // or a fresh /oauth/token exchange (then persisted).
-type identityTokenSource struct {
+type jurisdictionTokenSource struct {
 	// homeCoreURL is the login context's core — the exchange target for the
 	// common case where the cluster's jurisdiction is the login's home.
 	homeCoreURL string
@@ -61,11 +61,11 @@ type identityTokenSource struct {
 	expiresAt time.Time
 }
 
-func newIdentityTokenSource(homeCoreURL, audience, jurisdictionCoreURL, handle string, login func(context.Context) (string, error), client *http.Client) *identityTokenSource {
-	if override := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_AUDIENCE")); override != "" {
+func newJurisdictionTokenSource(homeCoreURL, audience, jurisdictionCoreURL, handle string, login func(context.Context) (string, error), client *http.Client) *jurisdictionTokenSource {
+	if override := strings.TrimSpace(os.Getenv("ENTIRE_JURISDICTION_AUDIENCE")); override != "" {
 		audience = override
 	}
-	return &identityTokenSource{
+	return &jurisdictionTokenSource{
 		homeCoreURL:         homeCoreURL,
 		audience:            audience,
 		jurisdictionCoreURL: strings.TrimRight(jurisdictionCoreURL, "/"),
@@ -75,20 +75,20 @@ func newIdentityTokenSource(homeCoreURL, audience, jurisdictionCoreURL, handle s
 	}
 }
 
-// Token returns the identity token, minting only when neither the memo nor
+// Token returns the jurisdiction token, minting only when neither the memo nor
 // the keychain has a fresh one.
-func (s *identityTokenSource) Token(ctx context.Context, _, _ string) (string, error) {
+func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.token != "" && time.Now().Before(s.expiresAt) {
 		return s.token, nil
 	}
 
-	service := identityKeyringService(s.audience)
+	service := jurisdictionKeyringService(s.audience)
 	if encoded, err := tokenstore.Get(service, s.handle); err == nil {
 		token, expiresAt := tokenstore.DecodeTokenWithExpiration(encoded)
 		if !tokenstore.IsTokenExpiredOrExpiring(expiresAt) {
-			debuglog.Printf("identity token from keychain (aud=%s, expires %s)", s.audience, expiresAt.Format(time.RFC3339))
+			debuglog.Printf("jurisdiction token from keychain (aud=%s, expires %s)", s.audience, expiresAt.Format(time.RFC3339))
 			s.token = token
 			s.expiresAt = expiresAt.Add(-time.Minute)
 			return token, nil
@@ -106,17 +106,17 @@ func (s *identityTokenSource) Token(ctx context.Context, _, _ string) (string, e
 	if err := tokenstore.Set(service, s.handle, tokenstore.EncodeTokenWithExpiration(token, int64(ttl/time.Second))); err != nil {
 		// Non-fatal: the token still serves this process; the next
 		// invocation just re-mints.
-		debuglog.Printf("identity token keychain write failed: %v", err)
+		debuglog.Printf("jurisdiction token keychain write failed: %v", err)
 	}
 	return token, nil
 }
 
-// mint exchanges the login JWT for an identity token at the core owning the
+// mint exchanges the login JWT for an jurisdiction token at the core owning the
 // target jurisdiction. For a same-jurisdiction login that is the login's own
 // core; for a cross-jurisdiction repo the sibling core accepts our login JWT
-// via the foreign-session path and mints the identity token in the same
+// via the foreign-session path and mints the jurisdiction token in the same
 // single POST.
-func (s *identityTokenSource) mint(ctx context.Context) (string, time.Duration, error) {
+func (s *jurisdictionTokenSource) mint(ctx context.Context) (string, time.Duration, error) {
 	loginJWT, err := s.login(ctx)
 	if err != nil {
 		return "", 0, fmt.Errorf("refresh login token: %w", err)
@@ -138,13 +138,13 @@ func (s *identityTokenSource) mint(ctx context.Context) (string, time.Duration, 
 
 	token, expiresIn, err := httputil.PostOAuthToken(ctx, s.client, coreURL, form)
 	if err != nil {
-		return "", 0, fmt.Errorf("identity token exchange (aud=%s at %s): %w", s.audience, coreURL, err)
+		return "", 0, fmt.Errorf("jurisdiction token exchange (aud=%s at %s): %w", s.audience, coreURL, err)
 	}
 	if strings.TrimSpace(token) == "" {
-		return "", 0, errors.New("identity token exchange returned an empty access token")
+		return "", 0, errors.New("jurisdiction token exchange returned an empty access token")
 	}
 	ttl := time.Duration(expiresIn) * time.Second
-	debuglog.Printf("identity token minted: aud=%s at %s ttl=%s", s.audience, coreURL, ttl)
+	debuglog.Printf("jurisdiction token minted: aud=%s at %s ttl=%s", s.audience, coreURL, ttl)
 	return token, ttl, nil
 }
 
@@ -152,9 +152,9 @@ func (s *identityTokenSource) mint(ctx context.Context) (string, time.Duration, 
 // audience is in the login's home jurisdiction, else the cluster's
 // advertised jurisdiction core. Both arrive over TLS-authenticated trust
 // roots (the login context / the cluster's /.well-known), but the login JWT
-// is only ever POSTed to an https origin. ENTIRE_IDENTITY_CORE overrides.
-func (s *identityTokenSource) exchangeCore(loginJWT string) (string, error) {
-	if override := strings.TrimSpace(os.Getenv("ENTIRE_IDENTITY_CORE")); override != "" {
+// is only ever POSTed to an https origin. ENTIRE_JURISDICTION_CORE overrides.
+func (s *jurisdictionTokenSource) exchangeCore(loginJWT string) (string, error) {
+	if override := strings.TrimSpace(os.Getenv("ENTIRE_JURISDICTION_CORE")); override != "" {
 		return strings.TrimRight(override, "/"), nil
 	}
 
@@ -171,7 +171,7 @@ func (s *identityTokenSource) exchangeCore(loginJWT string) (string, error) {
 	}
 
 	if s.jurisdictionCoreURL == "" {
-		return "", fmt.Errorf("cross-jurisdiction identity exchange for %s: cluster advertises no jurisdiction_core_url; upgrade the cluster (or set ENTIRE_IDENTITY_CORE)", s.audience)
+		return "", fmt.Errorf("cross-jurisdiction jurisdiction-token exchange for %s: cluster advertises no jurisdiction_core_url; upgrade the cluster (or set ENTIRE_JURISDICTION_CORE)", s.audience)
 	}
 	if !strings.HasPrefix(s.jurisdictionCoreURL, "https://") {
 		return "", fmt.Errorf("advertised jurisdiction core %q must be https", s.jurisdictionCoreURL)

--- a/cmd/git-remote-entire/jurisdictionauth.go
+++ b/cmd/git-remote-entire/jurisdictionauth.go
@@ -123,6 +123,23 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (strin
 	return token, nil
 }
 
+// Invalidate drops the memoized token and the persisted keychain entry, so
+// the next acquisition (this process or the next) mints fresh. Wired to the
+// transport's 401 observer: when the data plane rejects the credential
+// itself (signing-key rotation, expiry skew), replaying it until its
+// recorded expiry — up to the full 8h TTL — would keep every git command
+// failing. The in-flight command still fails; the next one self-heals.
+func (s *jurisdictionTokenSource) Invalidate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token = ""
+	s.expiresAt = time.Time{}
+	if err := tokenstore.Delete(jurisdictionKeyringService(s.audience), s.handle); err != nil && !errors.Is(err, tokenstore.ErrNotFound) {
+		debuglog.Printf("jurisdiction token keychain delete failed: %v", err)
+	}
+	debuglog.Printf("jurisdiction token invalidated after 401 (aud=%s); next invocation re-mints", s.audience)
+}
+
 // mint exchanges the login JWT for a jurisdiction token at the core owning the
 // target jurisdiction. For a same-jurisdiction login that is the login's own
 // core; for a cross-jurisdiction repo the sibling core accepts our login JWT

--- a/cmd/git-remote-entire/jurisdictionauth.go
+++ b/cmd/git-remote-entire/jurisdictionauth.go
@@ -184,7 +184,7 @@ func (s *jurisdictionTokenSource) exchangeCore(loginJWT string) (string, error) 
 	}
 	home, err := auth.HomeJurisdictionFromLoginJWT(loginJWT)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("read home jurisdiction: %w", err)
 	}
 	if home == "" {
 		return "", errors.New("login token has no home_jurisdiction claim")

--- a/cmd/git-remote-entire/jurisdictionauth.go
+++ b/cmd/git-remote-entire/jurisdictionauth.go
@@ -62,7 +62,11 @@ type jurisdictionTokenSource struct {
 
 func newJurisdictionTokenSource(homeCoreURL, audience, jurisdictionCoreURL, handle string, login func(context.Context) (string, error), client *http.Client) *jurisdictionTokenSource {
 	return &jurisdictionTokenSource{
-		homeCoreURL:         homeCoreURL,
+		// Both core URLs feed httputil.PostOAuthToken, which appends
+		// "/oauth/token" to the base verbatim — trim so a trailing slash
+		// (context core_url comes from the login JWT's iss claim) can't
+		// produce a double-slash endpoint.
+		homeCoreURL:         strings.TrimRight(homeCoreURL, "/"),
 		audience:            audience,
 		jurisdictionCoreURL: strings.TrimRight(jurisdictionCoreURL, "/"),
 		handle:              handle,
@@ -82,8 +86,15 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (strin
 
 	service := jurisdictionKeyringService(s.audience)
 	if encoded, err := tokenstore.Get(service, s.handle); err == nil {
-		token, expiresAt := tokenstore.DecodeTokenWithExpiration(encoded)
-		if !tokenstore.IsTokenExpiredOrExpiring(expiresAt) {
+		// The empty-token guard rejects a corrupted keychain entry that
+		// decodes to a valid timestamp but no token — otherwise it would
+		// produce bare "Bearer " headers until the entry expired.
+		//
+		// Freshness margins differ by design: cross-process reuse stops at
+		// the 5m TokenExpirationBuffer (a fresh process should not start on
+		// a nearly-dead token), while this process keeps its token until 1m
+		// before actual expiry — individual git requests are short.
+		if token, expiresAt := tokenstore.DecodeTokenWithExpiration(encoded); token != "" && !tokenstore.IsTokenExpiredOrExpiring(expiresAt) {
 			debuglog.Printf("jurisdiction token from keychain (aud=%s, expires %s)", s.audience, expiresAt.Format(time.RFC3339))
 			s.token = token
 			s.expiresAt = expiresAt.Add(-time.Minute)
@@ -94,6 +105,11 @@ func (s *jurisdictionTokenSource) Token(ctx context.Context, _, _ string) (strin
 	token, ttl, err := s.mint(ctx)
 	if err != nil {
 		return "", err
+	}
+	if ttl <= 0 {
+		// A non-positive expires_in would memoize/persist an already-dead
+		// token; serve this one request and re-mint next time.
+		return token, nil
 	}
 
 	s.token = token

--- a/cmd/git-remote-entire/jurisdictionauth_test.go
+++ b/cmd/git-remote-entire/jurisdictionauth_test.go
@@ -67,18 +67,6 @@ func TestExchangeCore(t *testing.T) {
 			t.Fatal("expected error for plaintext advertised core")
 		}
 	})
-
-	t.Run("ENTIRE_JURISDICTION_CORE overrides", func(t *testing.T) {
-		t.Setenv("ENTIRE_JURISDICTION_CORE", "https://override.example.io/")
-		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil)
-		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if core != "https://override.example.io" {
-			t.Fatalf("core = %q, want trimmed override", core)
-		}
-	})
 }
 
 func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
@@ -99,11 +87,10 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 	}))
 	defer core.Close()
 
+	// Same-jurisdiction routing: home_jurisdiction "eu" matches the audience
+	// label, so the exchange goes to homeCoreURL — the fake core.
 	login := staticLogin(fakeLoginJWT(t, "eu"))
 	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
-	// The home-core short-circuit compares jurisdiction labels; the httptest
-	// URL is not jurisdiction-shaped, so route via the override.
-	t.Setenv("ENTIRE_JURISDICTION_CORE", core.URL)
 
 	token, err := s.Token(context.Background(), "/et/x/y", "pull")
 	if err != nil {
@@ -166,7 +153,6 @@ func TestJurisdictionToken_ExpiredPersistedTokenRemints(t *testing.T) {
 		_, _ = w.Write([]byte(`{"access_token":"fresh-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
 	}))
 	defer core.Close()
-	t.Setenv("ENTIRE_JURISDICTION_CORE", core.URL)
 
 	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
 	token, err := s.Token(context.Background(), "/et/x/y", "pull")

--- a/cmd/git-remote-entire/jurisdictionauth_test.go
+++ b/cmd/git-remote-entire/jurisdictionauth_test.go
@@ -33,7 +33,7 @@ func staticLogin(jwt string) func(context.Context) (string, error) {
 
 func TestExchangeCore(t *testing.T) {
 	t.Run("same jurisdiction uses home core", func(t *testing.T) {
-		s := newIdentityTokenSource("https://au.auth.example.io", "https://au.example.io", "https://au.auth.example.io", "h", nil, nil)
+		s := newJurisdictionTokenSource("https://au.auth.example.io", "https://au.example.io", "https://au.auth.example.io", "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "au"))
 		if err != nil {
 			t.Fatal(err)
@@ -44,7 +44,7 @@ func TestExchangeCore(t *testing.T) {
 	})
 
 	t.Run("cross jurisdiction uses advertised jurisdiction core", func(t *testing.T) {
-		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", "https://au.auth.example.io/", "h", nil, nil)
+		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "https://au.auth.example.io/", "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
 		if err != nil {
 			t.Fatal(err)
@@ -55,22 +55,22 @@ func TestExchangeCore(t *testing.T) {
 	})
 
 	t.Run("cross jurisdiction without advertised core is refused", func(t *testing.T) {
-		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil)
+		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil)
 		if _, err := s.exchangeCore(fakeLoginJWT(t, "eu")); err == nil {
 			t.Fatal("expected error when no jurisdiction core is advertised")
 		}
 	})
 
 	t.Run("non-https advertised core is refused", func(t *testing.T) {
-		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", "http://au.auth.example.io", "h", nil, nil)
+		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "http://au.auth.example.io", "h", nil, nil)
 		if _, err := s.exchangeCore(fakeLoginJWT(t, "eu")); err == nil {
 			t.Fatal("expected error for plaintext advertised core")
 		}
 	})
 
-	t.Run("ENTIRE_IDENTITY_CORE overrides", func(t *testing.T) {
-		t.Setenv("ENTIRE_IDENTITY_CORE", "https://override.example.io/")
-		s := newIdentityTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil)
+	t.Run("ENTIRE_JURISDICTION_CORE overrides", func(t *testing.T) {
+		t.Setenv("ENTIRE_JURISDICTION_CORE", "https://override.example.io/")
+		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
 		if err != nil {
 			t.Fatal(err)
@@ -81,7 +81,7 @@ func TestExchangeCore(t *testing.T) {
 	})
 }
 
-func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
+func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
 	defer restore()
 
@@ -95,21 +95,21 @@ func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
 			t.Errorf("audience = %q", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"access_token":"identity-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
+		_, _ = w.Write([]byte(`{"access_token":"juri-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
 	}))
 	defer core.Close()
 
 	login := staticLogin(fakeLoginJWT(t, "eu"))
-	s := newIdentityTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
+	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
 	// The home-core short-circuit compares jurisdiction labels; the httptest
 	// URL is not jurisdiction-shaped, so route via the override.
-	t.Setenv("ENTIRE_IDENTITY_CORE", core.URL)
+	t.Setenv("ENTIRE_JURISDICTION_CORE", core.URL)
 
 	token, err := s.Token(context.Background(), "/et/x/y", "pull")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if token != "identity-jwt" {
+	if token != "juri-jwt" {
 		t.Fatalf("token = %q", token)
 	}
 	if mints != 1 {
@@ -125,12 +125,12 @@ func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 
 	// Fresh source (new process): served from the persisted keychain entry.
-	s2 := newIdentityTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
+	s2 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
 	token2, err := s2.Token(context.Background(), "/et/x/y", "pull")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if token2 != "identity-jwt" {
+	if token2 != "juri-jwt" {
 		t.Fatalf("token2 = %q", token2)
 	}
 	if mints != 1 {
@@ -138,7 +138,7 @@ func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 
 	// A different handle must not share the token.
-	s3 := newIdentityTokenSource(core.URL, "https://eu.example.io", "", "other-account", login, core.Client())
+	s3 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "other-account", login, core.Client())
 	if _, err := s3.Token(context.Background(), "/et/x/y", "pull"); err != nil {
 		t.Fatal(err)
 	}
@@ -147,12 +147,12 @@ func TestIdentityToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 }
 
-func TestIdentityToken_ExpiredPersistedTokenRemints(t *testing.T) {
+func TestJurisdictionToken_ExpiredPersistedTokenRemints(t *testing.T) {
 	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
 	defer restore()
 
 	// Seed a token 1 minute from expiry — inside the 5m refresh buffer.
-	service := identityKeyringService("https://eu.example.io")
+	service := jurisdictionKeyringService("https://eu.example.io")
 	expiring := "stale-jwt" + tokenstore.TokenExpirationSeparator +
 		strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10)
 	if err := tokenstore.Set(service, "toothbrush", expiring); err != nil {
@@ -166,9 +166,9 @@ func TestIdentityToken_ExpiredPersistedTokenRemints(t *testing.T) {
 		_, _ = w.Write([]byte(`{"access_token":"fresh-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
 	}))
 	defer core.Close()
-	t.Setenv("ENTIRE_IDENTITY_CORE", core.URL)
+	t.Setenv("ENTIRE_JURISDICTION_CORE", core.URL)
 
-	s := newIdentityTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
+	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
 	token, err := s.Token(context.Background(), "/et/x/y", "pull")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/git-remote-entire/jurisdictionauth_test.go
+++ b/cmd/git-remote-entire/jurisdictionauth_test.go
@@ -59,6 +59,18 @@ func TestExchangeCore(t *testing.T) {
 		}
 	})
 
+	t.Run("home jurisdiction claim casing is folded", func(t *testing.T) {
+		t.Parallel()
+		s := newJurisdictionTokenSource(auCore, "https://au.example.io", "", "h", nil, nil)
+		core, err := s.exchangeCore(fakeLoginJWT(t, "AU"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if core != auCore {
+			t.Fatalf("core = %q, want home core despite mixed-case claim", core)
+		}
+	})
+
 	t.Run("cross jurisdiction uses advertised jurisdiction core", func(t *testing.T) {
 		t.Parallel()
 		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", auCore+"/", "h", nil, nil)

--- a/cmd/git-remote-entire/jurisdictionauth_test.go
+++ b/cmd/git-remote-entire/jurisdictionauth_test.go
@@ -32,24 +32,37 @@ func staticLogin(jwt string) func(context.Context) (string, error) {
 }
 
 func TestExchangeCore(t *testing.T) {
+	const auCore = "https://au.auth.example.io"
+
 	t.Run("same jurisdiction uses home core", func(t *testing.T) {
-		s := newJurisdictionTokenSource("https://au.auth.example.io", "https://au.example.io", "https://au.auth.example.io", "h", nil, nil)
+		s := newJurisdictionTokenSource(auCore, "https://au.example.io", auCore, "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "au"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if core != "https://au.auth.example.io" {
+		if core != auCore {
 			t.Fatalf("core = %q, want home core", core)
 		}
 	})
 
+	t.Run("home core trailing slash is trimmed", func(t *testing.T) {
+		s := newJurisdictionTokenSource(auCore+"/", "https://au.example.io", "", "h", nil, nil)
+		core, err := s.exchangeCore(fakeLoginJWT(t, "au"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if core != auCore {
+			t.Fatalf("core = %q, want trimmed home core", core)
+		}
+	})
+
 	t.Run("cross jurisdiction uses advertised jurisdiction core", func(t *testing.T) {
-		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "https://au.auth.example.io/", "h", nil, nil)
+		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", auCore+"/", "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if core != "https://au.auth.example.io" {
+		if core != auCore {
 			t.Fatalf("core = %q, want advertised au core (trimmed)", core)
 		}
 	})
@@ -131,6 +144,37 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 	if mints != 2 {
 		t.Fatalf("mints for different handle = %d, want 2", mints)
+	}
+}
+
+func TestJurisdictionToken_EmptyPersistedTokenRemints(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	defer restore()
+
+	// A corrupted entry: valid future timestamp, empty token. Must not be
+	// served as a bare "Bearer " header.
+	service := jurisdictionKeyringService("https://eu.example.io")
+	corrupted := tokenstore.TokenExpirationSeparator +
+		strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)
+	if err := tokenstore.Set(service, "toothbrush", corrupted); err != nil {
+		t.Fatal(err)
+	}
+
+	mints := 0
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mints++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"fresh-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
+	}))
+	defer core.Close()
+
+	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", staticLogin(fakeLoginJWT(t, "eu")), core.Client())
+	token, err := s.Token(context.Background(), "/et/x/y", "pull")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "fresh-jwt" || mints != 1 {
+		t.Fatalf("token = %q mints = %d, want fresh mint over corrupted entry", token, mints)
 	}
 }
 

--- a/cmd/git-remote-entire/jurisdictionauth_test.go
+++ b/cmd/git-remote-entire/jurisdictionauth_test.go
@@ -32,9 +32,11 @@ func staticLogin(jwt string) func(context.Context) (string, error) {
 }
 
 func TestExchangeCore(t *testing.T) {
+	t.Parallel()
 	const auCore = "https://au.auth.example.io"
 
 	t.Run("same jurisdiction uses home core", func(t *testing.T) {
+		t.Parallel()
 		s := newJurisdictionTokenSource(auCore, "https://au.example.io", auCore, "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "au"))
 		if err != nil {
@@ -46,6 +48,7 @@ func TestExchangeCore(t *testing.T) {
 	})
 
 	t.Run("home core trailing slash is trimmed", func(t *testing.T) {
+		t.Parallel()
 		s := newJurisdictionTokenSource(auCore+"/", "https://au.example.io", "", "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "au"))
 		if err != nil {
@@ -57,6 +60,7 @@ func TestExchangeCore(t *testing.T) {
 	})
 
 	t.Run("cross jurisdiction uses advertised jurisdiction core", func(t *testing.T) {
+		t.Parallel()
 		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", auCore+"/", "h", nil, nil)
 		core, err := s.exchangeCore(fakeLoginJWT(t, "eu"))
 		if err != nil {
@@ -68,6 +72,7 @@ func TestExchangeCore(t *testing.T) {
 	})
 
 	t.Run("cross jurisdiction without advertised core is refused", func(t *testing.T) {
+		t.Parallel()
 		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "", "h", nil, nil)
 		if _, err := s.exchangeCore(fakeLoginJWT(t, "eu")); err == nil {
 			t.Fatal("expected error when no jurisdiction core is advertised")
@@ -75,6 +80,7 @@ func TestExchangeCore(t *testing.T) {
 	})
 
 	t.Run("non-https advertised core is refused", func(t *testing.T) {
+		t.Parallel()
 		s := newJurisdictionTokenSource("https://eu.auth.example.io", "https://au.example.io", "http://au.auth.example.io", "h", nil, nil)
 		if _, err := s.exchangeCore(fakeLoginJWT(t, "eu")); err == nil {
 			t.Fatal("expected error for plaintext advertised core")

--- a/cmd/git-remote-entire/jurisdictionauth_test.go
+++ b/cmd/git-remote-entire/jurisdictionauth_test.go
@@ -147,6 +147,50 @@ func TestJurisdictionToken_MintsPersistsAndReuses(t *testing.T) {
 	}
 }
 
+func TestJurisdictionToken_InvalidateDropsMemoAndKeychain(t *testing.T) {
+	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
+	defer restore()
+
+	mints := 0
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mints++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"juri-jwt","token_type":"Bearer","expires_in":7200}`)) //nolint:errcheck // test
+	}))
+	defer core.Close()
+
+	login := staticLogin(fakeLoginJWT(t, "eu"))
+	s := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
+	if _, err := s.Token(context.Background(), "/et/x/y", "pull"); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 1 {
+		t.Fatalf("mints = %d, want 1", mints)
+	}
+
+	s.Invalidate()
+
+	// Memo gone: this source re-mints.
+	if _, err := s.Token(context.Background(), "/et/x/y", "pull"); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 2 {
+		t.Fatalf("mints after invalidate = %d, want 2", mints)
+	}
+
+	// Keychain entry gone too: a fresh source (next process) also re-mints
+	// rather than reading a stale persisted copy. (The re-mint above stored
+	// a new entry, so invalidate again to observe the delete.)
+	s.Invalidate()
+	s2 := newJurisdictionTokenSource(core.URL, "https://eu.example.io", "", "toothbrush", login, core.Client())
+	if _, err := s2.Token(context.Background(), "/et/x/y", "pull"); err != nil {
+		t.Fatal(err)
+	}
+	if mints != 3 {
+		t.Fatalf("mints for fresh source after invalidate = %d, want 3", mints)
+	}
+}
+
 func TestJurisdictionToken_EmptyPersistedTokenRemints(t *testing.T) {
 	restore := tokenstore.UseFileBackendForTesting(filepath.Join(t.TempDir(), "tokens.json"))
 	defer restore()

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -278,10 +278,10 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 	// One keychain-persisted jurisdiction access token authenticates every
 	// repo (authorized live at the data plane) — there is no repo-scoped
 	// fallback on this path. The cluster must advertise its jurisdiction
-	// audience; ENTIRE_JURISDICTION_AUDIENCE overrides for local dev.
+	// audience.
 	audience := clusterAuth.JurisdictionAudience
-	if audience == "" && os.Getenv("ENTIRE_JURISDICTION_AUDIENCE") == "" {
-		return nil, fmt.Errorf("cluster %s advertises no jurisdiction_audience at %s; its entire-server predates jurisdiction-token git auth — upgrade the cluster (or set ENTIRE_JURISDICTION_AUDIENCE)", parsedURL.Host, clusterdiscovery.Path)
+	if audience == "" {
+		return nil, fmt.Errorf("cluster %s advertises no jurisdiction_audience at %s; its entire-server predates jurisdiction-token git auth", parsedURL.Host, clusterdiscovery.Path)
 	}
 	debuglog.Printf("auth: jurisdiction access token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
 	return newJurisdictionTokenSource(clusterCtx.CoreURL, audience, clusterAuth.JurisdictionCoreURL, clusterCtx.Handle, loginProvider, httpClient), nil

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -259,10 +259,11 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 	// local contexts — active context if eligible, else the sole eligible
 	// one, else an explicit-choice error.
 	cfgDir := userdirs.Config()
-	clusterCtx, err := clusterdiscovery.ResolveContextForCluster(ctx, cfgDir, userdirs.Cache(), parsedURL.Host, httpClient, debuglog.Printf)
+	clusterAuth, err := clusterdiscovery.ResolveClusterAuth(ctx, cfgDir, userdirs.Cache(), parsedURL.Host, httpClient, debuglog.Printf)
 	if err != nil {
-		return nil, err //nolint:wrapcheck // ResolveContextForCluster already returns a user-facing error; preserved verbatim for the "fatal: <msg>" surface
+		return nil, err //nolint:wrapcheck // ResolveClusterAuth already returns a user-facing error; preserved verbatim for the "fatal: <msg>" surface
 	}
+	clusterCtx := clusterAuth.Context
 
 	// The login-JWT provider transparently refreshes an expired login JWT
 	// from the stored refresh token (serialised across processes, rotated
@@ -272,11 +273,18 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 		return nil, err //nolint:wrapcheck // NewRefreshingLoginProvider already returns a user-facing error
 	}
 
-	// EXPERIMENT: ENTIRE_GIT_AUTH=identity mints one jurisdiction identity
-	// token for the whole process instead of per-(repo,action) scoped tokens.
+	// EXPERIMENT: ENTIRE_GIT_AUTH=identity uses one keychain-persisted
+	// jurisdiction identity token for all repos instead of per-(repo,action)
+	// scoped tokens. Requires the cluster to advertise its jurisdiction
+	// audience (or an ENTIRE_IDENTITY_AUDIENCE override); otherwise falls
+	// back to repo-scoped tokens.
 	if identityAuthEnabled() {
-		debuglog.Printf("auth mode: jurisdiction identity token (ENTIRE_GIT_AUTH=identity), core=%s", clusterCtx.CoreURL)
-		return newIdentityTokenSource(clusterCtx.CoreURL, loginProvider, httpClient), nil
+		audience := clusterAuth.JurisdictionAudience
+		if audience != "" || os.Getenv("ENTIRE_IDENTITY_AUDIENCE") != "" {
+			debuglog.Printf("auth mode: jurisdiction identity token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
+			return newIdentityTokenSource(clusterCtx.CoreURL, audience, clusterAuth.CoreURLs, clusterCtx.Handle, loginProvider, httpClient), nil
+		}
+		debuglog.Printf("ENTIRE_GIT_AUTH=identity set but cluster %s advertises no jurisdiction_audience; using repo-scoped tokens", parsedURL.Host)
 	}
 
 	// Mint repo-scoped tokens by exchanging the context's login JWT at its

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -284,7 +284,7 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 		return nil, fmt.Errorf("cluster %s advertises no jurisdiction_audience at %s; its entire-server predates identity-token git auth — upgrade the cluster (or set ENTIRE_IDENTITY_AUDIENCE)", parsedURL.Host, clusterdiscovery.Path)
 	}
 	debuglog.Printf("auth: jurisdiction identity token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
-	return newIdentityTokenSource(clusterCtx.CoreURL, audience, clusterAuth.CoreURLs, clusterCtx.Handle, loginProvider, httpClient), nil
+	return newIdentityTokenSource(clusterCtx.CoreURL, audience, clusterAuth.JurisdictionCoreURL, clusterCtx.Handle, loginProvider, httpClient), nil
 }
 
 // resolveEnvTokenCreds builds the repo-cred cache for the ENTIRE_TOKEN path.

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -222,8 +222,8 @@ func parseProtocolVersion(raw string, warn io.Writer) int {
 }
 
 // tokenSource is the one-method seam setAuth needs: repocreds.Cache
-// (repo-scoped tokens) and identityTokenSource (jurisdiction identity
-// tokens, ENTIRE_GIT_AUTH=identity) both satisfy it.
+// (repo-scoped tokens) and jurisdictionTokenSource (jurisdiction
+// access tokens) both satisfy it.
 type tokenSource interface {
 	Token(ctx context.Context, audienceSuffix, action string) (string, error)
 }
@@ -236,7 +236,7 @@ type tokenSource interface {
 //     scoped tokens. A non-URL aud is a hard error, never a silent fallback
 //     to context resolution.
 //   - otherwise: resolve the login context for this cluster from contexts.json
-//     and mint a keychain-persisted jurisdiction identity token from its
+//     and mint a keychain-persisted jurisdiction access token from its
 //     stored login JWT.
 func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string, skipTLS bool, httpClient *http.Client) (tokenSource, error) {
 	// Presence of ENTIRE_TOKEN is the signal: if it's set at all (LookupEnv,
@@ -275,16 +275,16 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 		return nil, err //nolint:wrapcheck // NewRefreshingLoginProvider already returns a user-facing error
 	}
 
-	// One keychain-persisted jurisdiction identity token authenticates every
+	// One keychain-persisted jurisdiction access token authenticates every
 	// repo (authorized live at the data plane) — there is no repo-scoped
 	// fallback on this path. The cluster must advertise its jurisdiction
-	// audience; ENTIRE_IDENTITY_AUDIENCE overrides for local dev.
+	// audience; ENTIRE_JURISDICTION_AUDIENCE overrides for local dev.
 	audience := clusterAuth.JurisdictionAudience
-	if audience == "" && os.Getenv("ENTIRE_IDENTITY_AUDIENCE") == "" {
-		return nil, fmt.Errorf("cluster %s advertises no jurisdiction_audience at %s; its entire-server predates identity-token git auth — upgrade the cluster (or set ENTIRE_IDENTITY_AUDIENCE)", parsedURL.Host, clusterdiscovery.Path)
+	if audience == "" && os.Getenv("ENTIRE_JURISDICTION_AUDIENCE") == "" {
+		return nil, fmt.Errorf("cluster %s advertises no jurisdiction_audience at %s; its entire-server predates jurisdiction-token git auth — upgrade the cluster (or set ENTIRE_JURISDICTION_AUDIENCE)", parsedURL.Host, clusterdiscovery.Path)
 	}
-	debuglog.Printf("auth: jurisdiction identity token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
-	return newIdentityTokenSource(clusterCtx.CoreURL, audience, clusterAuth.JurisdictionCoreURL, clusterCtx.Handle, loginProvider, httpClient), nil
+	debuglog.Printf("auth: jurisdiction access token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
+	return newJurisdictionTokenSource(clusterCtx.CoreURL, audience, clusterAuth.JurisdictionCoreURL, clusterCtx.Handle, loginProvider, httpClient), nil
 }
 
 // resolveEnvTokenCreds builds the repo-cred cache for the ENTIRE_TOKEN path.

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/entireio/cli/internal/remotehelper"
 	"github.com/entireio/cli/internal/remotehelper/debuglog"
 	"github.com/entireio/cli/internal/remotehelper/githelper"
+	"github.com/entireio/cli/internal/remotehelper/httpdebug"
 	"github.com/entireio/cli/internal/remotehelper/replicas"
 	"github.com/entireio/cli/internal/remotehelper/transport"
 )
@@ -112,8 +113,11 @@ func run(args []string) int {
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &httpclient.UserAgentTransport{
-			Next: httpclient.NewDiscoveryTransport(skipTLS),
-			UA:   httpUserAgent,
+			Next: &httpdebug.TimingRoundTripper{
+				Next:  httpclient.NewDiscoveryTransport(skipTLS),
+				Label: "auth",
+			},
+			UA: httpUserAgent,
 		},
 	}
 
@@ -128,10 +132,12 @@ func run(args []string) int {
 		if action == "" {
 			return fmt.Errorf("cannot classify git op for %s %s; scoped-token exchange requires a recognised smart-HTTP endpoint", req.Method, req.URL.Path)
 		}
+		start := time.Now()
 		token, err := creds.Token(req.Context(), repoSlug, action)
 		if err != nil {
 			return fmt.Errorf("repo-scoped token exchange: %w", err)
 		}
+		debuglog.Printf("timing: token-acquire action=%s dur_ms=%d (keychain + login refresh + exchange; ~0 when memoized)", action, time.Since(start).Milliseconds())
 		req.Header.Set("Authorization", "Bearer "+token)
 		return nil
 	}
@@ -153,10 +159,12 @@ func run(args []string) int {
 	protocolVersion := resolveProtocolVersion()
 	debuglog.Printf("git protocol.version=%d (v2 advertises stateless-connect + push; v0/v1 advertises connect)", protocolVersion)
 
+	helperStart := time.Now()
 	if err := githelper.Run(ctx, proxy, protocolVersion, os.Stdin, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		return 128
 	}
+	debuglog.Printf("timing: helper-session dur_ms=%d", time.Since(helperStart).Milliseconds())
 	return 0
 }
 
@@ -213,6 +221,13 @@ func parseProtocolVersion(raw string, warn io.Writer) int {
 	return defaultVersion
 }
 
+// tokenSource is the one-method seam setAuth needs: repocreds.Cache
+// (repo-scoped tokens) and identityTokenSource (jurisdiction identity
+// tokens, ENTIRE_GIT_AUTH=identity) both satisfy it.
+type tokenSource interface {
+	Token(ctx context.Context, audienceSuffix, action string) (string, error)
+}
+
 // resolveCreds builds the repo-scoped token cache, choosing the auth source:
 //
 //   - ENTIRE_TOKEN set: use the env JWT verbatim as the login token, deriving
@@ -221,7 +236,7 @@ func parseProtocolVersion(raw string, warn io.Writer) int {
 //     error, never a silent fallback to context resolution.
 //   - otherwise: resolve the login context for this cluster from contexts.json
 //     and exchange its stored login JWT.
-func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string, skipTLS bool, httpClient *http.Client) (*repocreds.Cache, error) {
+func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string, skipTLS bool, httpClient *http.Client) (tokenSource, error) {
 	// Presence of ENTIRE_TOKEN is the signal: if it's set at all (LookupEnv,
 	// not Getenv, so we can tell set-empty from unset), we commit to the
 	// env-token path and any failure to use it is fatal — never a silent
@@ -255,6 +270,13 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 	loginProvider, err := auth.NewRefreshingLoginProvider(clusterCtx, httpClient.Transport, skipTLS)
 	if err != nil {
 		return nil, err //nolint:wrapcheck // NewRefreshingLoginProvider already returns a user-facing error
+	}
+
+	// EXPERIMENT: ENTIRE_GIT_AUTH=identity mints one jurisdiction identity
+	// token for the whole process instead of per-(repo,action) scoped tokens.
+	if identityAuthEnabled() {
+		debuglog.Printf("auth mode: jurisdiction identity token (ENTIRE_GIT_AUTH=identity), core=%s", clusterCtx.CoreURL)
+		return newIdentityTokenSource(clusterCtx.CoreURL, loginProvider, httpClient), nil
 	}
 
 	// Mint repo-scoped tokens by exchanging the context's login JWT at its

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -135,7 +135,7 @@ func run(args []string) int {
 		start := time.Now()
 		token, err := creds.Token(req.Context(), repoSlug, action)
 		if err != nil {
-			return fmt.Errorf("repo-scoped token exchange: %w", err)
+			return fmt.Errorf("git credential exchange: %w", err)
 		}
 		debuglog.Printf("timing: token-acquire action=%s dur_ms=%d (keychain + login refresh + exchange; ~0 when memoized)", action, time.Since(start).Milliseconds())
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -228,14 +228,16 @@ type tokenSource interface {
 	Token(ctx context.Context, audienceSuffix, action string) (string, error)
 }
 
-// resolveCreds builds the repo-scoped token cache, choosing the auth source:
+// resolveCreds builds the git-credential source, choosing by auth model:
 //
 //   - ENTIRE_TOKEN set: use the env JWT verbatim as the login token, deriving
 //     the login server URL from its aud claim. Skips contexts.json and the keyring
-//     entirely — the CI / workload-identity path. A non-URL aud is a hard
-//     error, never a silent fallback to context resolution.
+//     entirely — the CI / workload-identity path, still minting per-(repo,action)
+//     scoped tokens. A non-URL aud is a hard error, never a silent fallback
+//     to context resolution.
 //   - otherwise: resolve the login context for this cluster from contexts.json
-//     and exchange its stored login JWT.
+//     and mint a keychain-persisted jurisdiction identity token from its
+//     stored login JWT.
 func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string, skipTLS bool, httpClient *http.Client) (tokenSource, error) {
 	// Presence of ENTIRE_TOKEN is the signal: if it's set at all (LookupEnv,
 	// not Getenv, so we can tell set-empty from unset), we commit to the
@@ -273,23 +275,16 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 		return nil, err //nolint:wrapcheck // NewRefreshingLoginProvider already returns a user-facing error
 	}
 
-	// Default: one keychain-persisted jurisdiction identity token for all
-	// repos instead of per-(repo,action) scoped tokens. Requires the
-	// cluster to advertise its jurisdiction audience (or an
-	// ENTIRE_IDENTITY_AUDIENCE override); otherwise — and under
-	// ENTIRE_GIT_AUTH=scoped — falls back to repo-scoped tokens.
-	if identityAuthEnabled() {
-		audience := clusterAuth.JurisdictionAudience
-		if audience != "" || os.Getenv("ENTIRE_IDENTITY_AUDIENCE") != "" {
-			debuglog.Printf("auth mode: jurisdiction identity token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
-			return newIdentityTokenSource(clusterCtx.CoreURL, audience, clusterAuth.CoreURLs, clusterCtx.Handle, loginProvider, httpClient), nil
-		}
-		debuglog.Printf("cluster %s advertises no jurisdiction_audience; using repo-scoped tokens", parsedURL.Host)
+	// One keychain-persisted jurisdiction identity token authenticates every
+	// repo (authorized live at the data plane) — there is no repo-scoped
+	// fallback on this path. The cluster must advertise its jurisdiction
+	// audience; ENTIRE_IDENTITY_AUDIENCE overrides for local dev.
+	audience := clusterAuth.JurisdictionAudience
+	if audience == "" && os.Getenv("ENTIRE_IDENTITY_AUDIENCE") == "" {
+		return nil, fmt.Errorf("cluster %s advertises no jurisdiction_audience at %s; its entire-server predates identity-token git auth — upgrade the cluster (or set ENTIRE_IDENTITY_AUDIENCE)", parsedURL.Host, clusterdiscovery.Path)
 	}
-
-	// Mint repo-scoped tokens by exchanging the context's login JWT at its
-	// login server's /oauth/token, cached per (repo, action) for this invocation.
-	return repocreds.New(clusterCtx.CoreURL, clusterBaseURL, loginProvider, httpClient), nil
+	debuglog.Printf("auth: jurisdiction identity token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
+	return newIdentityTokenSource(clusterCtx.CoreURL, audience, clusterAuth.CoreURLs, clusterCtx.Handle, loginProvider, httpClient), nil
 }
 
 // resolveEnvTokenCreds builds the repo-cred cache for the ENTIRE_TOKEN path.

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -128,9 +128,14 @@ func run(args []string) int {
 	}
 
 	setAuth := func(req *http.Request) error {
+		// Refuse to attach credentials to a request we can't classify as a
+		// known git smart-HTTP endpoint. The jurisdiction token doesn't
+		// need the action, but sending a bearer to an unexpected endpoint
+		// is never right; the ENTIRE_TOKEN scoped path additionally needs
+		// pull/push to mint.
 		action := gitActionFromRequest(req)
 		if action == "" {
-			return fmt.Errorf("cannot classify git op for %s %s; scoped-token exchange requires a recognised smart-HTTP endpoint", req.Method, req.URL.Path)
+			return fmt.Errorf("refusing to attach credentials: %s %s is not a recognised git smart-HTTP endpoint", req.Method, req.URL.Path)
 		}
 		start := time.Now()
 		token, err := creds.Token(req.Context(), repoSlug, action)

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -273,18 +273,18 @@ func resolveCreds(ctx context.Context, parsedURL *url.URL, clusterBaseURL string
 		return nil, err //nolint:wrapcheck // NewRefreshingLoginProvider already returns a user-facing error
 	}
 
-	// EXPERIMENT: ENTIRE_GIT_AUTH=identity uses one keychain-persisted
-	// jurisdiction identity token for all repos instead of per-(repo,action)
-	// scoped tokens. Requires the cluster to advertise its jurisdiction
-	// audience (or an ENTIRE_IDENTITY_AUDIENCE override); otherwise falls
-	// back to repo-scoped tokens.
+	// Default: one keychain-persisted jurisdiction identity token for all
+	// repos instead of per-(repo,action) scoped tokens. Requires the
+	// cluster to advertise its jurisdiction audience (or an
+	// ENTIRE_IDENTITY_AUDIENCE override); otherwise — and under
+	// ENTIRE_GIT_AUTH=scoped — falls back to repo-scoped tokens.
 	if identityAuthEnabled() {
 		audience := clusterAuth.JurisdictionAudience
 		if audience != "" || os.Getenv("ENTIRE_IDENTITY_AUDIENCE") != "" {
 			debuglog.Printf("auth mode: jurisdiction identity token (aud=%s, core=%s)", audience, clusterCtx.CoreURL)
 			return newIdentityTokenSource(clusterCtx.CoreURL, audience, clusterAuth.CoreURLs, clusterCtx.Handle, loginProvider, httpClient), nil
 		}
-		debuglog.Printf("ENTIRE_GIT_AUTH=identity set but cluster %s advertises no jurisdiction_audience; using repo-scoped tokens", parsedURL.Host)
+		debuglog.Printf("cluster %s advertises no jurisdiction_audience; using repo-scoped tokens", parsedURL.Host)
 	}
 
 	// Mint repo-scoped tokens by exchanging the context's login JWT at its

--- a/cmd/git-remote-entire/main.go
+++ b/cmd/git-remote-entire/main.go
@@ -152,13 +152,24 @@ func run(args []string) int {
 		onNodeFailed = func(string) { replicas.Invalidate(nodeCfg.ClusterHost, nodeCfg.RepoPath) }
 	}
 
+	// A 401 means the data plane rejected the credential itself (e.g.
+	// signing-key rotation invalidated a persisted jurisdiction token) —
+	// drop it so the next invocation re-mints instead of failing until the
+	// token's recorded expiry. The env-token source has nothing persisted
+	// to drop and doesn't implement the seam.
+	var onUnauthorized func()
+	if invalidator, ok := creds.(interface{ Invalidate() }); ok {
+		onUnauthorized = invalidator.Invalidate
+	}
+
 	proxy := transport.New(transport.Config{
-		Nodes:        nodeCfg,
-		Path:         parsedURL.Path,
-		SkipTLS:      skipTLS,
-		SetAuth:      setAuth,
-		OnNodeFailed: onNodeFailed,
-		UserAgent:    httpUserAgent,
+		Nodes:          nodeCfg,
+		Path:           parsedURL.Path,
+		SkipTLS:        skipTLS,
+		SetAuth:        setAuth,
+		OnNodeFailed:   onNodeFailed,
+		OnUnauthorized: onUnauthorized,
+		UserAgent:      httpUserAgent,
 	})
 
 	protocolVersion := resolveProtocolVersion()

--- a/internal/entireclient/clusterdiscovery/api_discovery.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery.go
@@ -68,16 +68,19 @@ func DiscoverAPI(ctx context.Context, apiHost string, c *http.Client, debugf Deb
 // reuse the cores cache (different file). Cold failures stay folded under
 // ErrDiscoveryUnavailable (from DiscoverAPI) for the caller to surface.
 func resolveAPICores(ctx context.Context, cacheDir, apiHost string, httpClient *http.Client, debugf DebugFunc) ([]string, error) {
-	cores, _, err := resolveCachedCores(cacheDir, apiHost, "api host",
+	entry, err := resolveCachedCores(cacheDir, apiHost, "api host",
 		discovery.LoadAPICores, discovery.ModifyAPICores,
-		func() ([]string, string, error) {
+		func() (discovery.CoresEntry, error) {
 			body, err := DiscoverAPI(ctx, apiHost, httpClient, debugf)
 			if err != nil {
-				return nil, "", err
+				return discovery.CoresEntry{}, err
 			}
-			return body.TrustedIssuers, "", nil
+			return discovery.CoresEntry{CoreURLs: body.TrustedIssuers}, nil
 		}, debugf)
-	return cores, err
+	if err != nil {
+		return nil, err
+	}
+	return entry.CoreURLs, nil
 }
 
 // ResolveContextForAPI picks the local login context to authenticate data-API

--- a/internal/entireclient/clusterdiscovery/api_discovery.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery.go
@@ -68,15 +68,16 @@ func DiscoverAPI(ctx context.Context, apiHost string, c *http.Client, debugf Deb
 // reuse the cores cache (different file). Cold failures stay folded under
 // ErrDiscoveryUnavailable (from DiscoverAPI) for the caller to surface.
 func resolveAPICores(ctx context.Context, cacheDir, apiHost string, httpClient *http.Client, debugf DebugFunc) ([]string, error) {
-	return resolveCachedCores(cacheDir, apiHost, "api host",
+	cores, _, err := resolveCachedCores(cacheDir, apiHost, "api host",
 		discovery.LoadAPICores, discovery.ModifyAPICores,
-		func() ([]string, error) {
+		func() ([]string, string, error) {
 			body, err := DiscoverAPI(ctx, apiHost, httpClient, debugf)
 			if err != nil {
-				return nil, err
+				return nil, "", err
 			}
-			return body.TrustedIssuers, nil
+			return body.TrustedIssuers, "", nil
 		}, debugf)
+	return cores, err
 }
 
 // ResolveContextForAPI picks the local login context to authenticate data-API

--- a/internal/entireclient/clusterdiscovery/api_discovery.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery.go
@@ -68,7 +68,7 @@ func DiscoverAPI(ctx context.Context, apiHost string, c *http.Client, debugf Deb
 // reuse the cores cache (different file). Cold failures stay folded under
 // ErrDiscoveryUnavailable (from DiscoverAPI) for the caller to surface.
 func resolveAPICores(ctx context.Context, cacheDir, apiHost string, httpClient *http.Client, debugf DebugFunc) ([]string, error) {
-	entry, err := resolveCachedCores(cacheDir, apiHost, "api host",
+	entry, err := resolveCachedCores(cacheDir, apiHost, "api host", false,
 		discovery.LoadAPICores, discovery.ModifyAPICores,
 		func() (discovery.CoresEntry, error) {
 			body, err := DiscoverAPI(ctx, apiHost, httpClient, debugf)

--- a/internal/entireclient/clusterdiscovery/api_discovery_test.go
+++ b/internal/entireclient/clusterdiscovery/api_discovery_test.go
@@ -294,10 +294,10 @@ func TestResolveContextForAPI_CachedAcrossCalls(t *testing.T) {
 	// The trusted issuers are persisted (in the cores cache, separate file).
 	cache, err := discovery.LoadAPICores(cacheDir)
 	require.NoError(t, err)
-	urls, fresh, ok := cache.Get("partial.to")
+	entry, fresh, ok := cache.GetEntry("partial.to")
 	require.True(t, ok)
 	assert.True(t, fresh)
-	assert.Equal(t, []string{"https://us.auth.partial.to"}, urls)
+	assert.Equal(t, []string{"https://us.auth.partial.to"}, entry.CoreURLs)
 }
 
 // TestResolveContextForAPI_StaleFallbackOnFetchFailure: a present-but-stale

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -30,14 +30,14 @@ type DebugFunc func(format string, args ...any)
 // fields may be added by the server; unknown ones are ignored.
 type Response struct {
 	CoreURLs []string `json:"core_urls"`
-	// JurisdictionAudience is the cluster's identity-token audience (the
-	// exact aud its data plane accepts on jurisdiction identity tokens,
+	// JurisdictionAudience is the cluster's jurisdiction-token audience (the
+	// exact aud its data plane accepts on jurisdiction access tokens,
 	// e.g. https://au.entire.io). Empty when the cluster does not accept
 	// jurisdiction tokens or predates the field.
 	JurisdictionAudience string `json:"jurisdiction_audience"`
 	// JurisdictionCoreURL is the core (OAuth AS) that mints tokens for
-	// JurisdictionAudience — the endpoint a cross-jurisdiction identity
-	// exchange dials. The audience itself is not dialable.
+	// JurisdictionAudience — the endpoint a cross-jurisdiction
+	// token exchange dials. The audience itself is not dialable.
 	JurisdictionCoreURL string `json:"jurisdiction_core_url"`
 }
 

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -30,6 +30,11 @@ type DebugFunc func(format string, args ...any)
 // fields may be added by the server; unknown ones are ignored.
 type Response struct {
 	CoreURLs []string `json:"core_urls"`
+	// JurisdictionAudience is the cluster's identity-token audience (the
+	// exact aud its data plane accepts on jurisdiction identity tokens,
+	// e.g. https://au.entire.io). Empty when the cluster does not accept
+	// jurisdiction tokens or predates the field.
+	JurisdictionAudience string `json:"jurisdiction_audience"`
 }
 
 // Sentinel errors returned by Discover so callers can branch on the

--- a/internal/entireclient/clusterdiscovery/discovery.go
+++ b/internal/entireclient/clusterdiscovery/discovery.go
@@ -35,6 +35,10 @@ type Response struct {
 	// e.g. https://au.entire.io). Empty when the cluster does not accept
 	// jurisdiction tokens or predates the field.
 	JurisdictionAudience string `json:"jurisdiction_audience"`
+	// JurisdictionCoreURL is the core (OAuth AS) that mints tokens for
+	// JurisdictionAudience — the endpoint a cross-jurisdiction identity
+	// exchange dials. The audience itself is not dialable.
+	JurisdictionCoreURL string `json:"jurisdiction_core_url"`
 }
 
 // Sentinel errors returned by Discover so callers can branch on the

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -63,12 +63,49 @@ func ResolveContextForCluster(ctx context.Context, configDir, cacheDir, clusterH
 		return nil, fmt.Errorf("load contexts: %w", err)
 	}
 
-	coreURLs, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
+	coreURLs, _, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
 	if err != nil {
 		return nil, err
 	}
 
 	return selectContext(f, "cluster "+clusterHost, coreURLs, debugf)
+}
+
+// ClusterAuth is ResolveClusterAuth's result: the selected login context
+// plus the cluster facts a caller needs to mint credentials for it.
+type ClusterAuth struct {
+	Context *contexts.Context
+	// CoreURLs is the cluster's advertised trusted-core set.
+	CoreURLs []string
+	// JurisdictionAudience is the cluster's identity-token audience; empty
+	// when the cluster doesn't advertise one (fall back to repo-scoped
+	// tokens).
+	JurisdictionAudience string
+}
+
+// ResolveClusterAuth is ResolveContextForCluster plus the cluster's
+// advertised metadata (trusted cores, jurisdiction audience), sharing the
+// same cache and single /.well-known fetch.
+func ResolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*ClusterAuth, error) {
+	if debugf == nil {
+		debugf = func(string, ...any) {}
+	}
+	clusterHost = normalizeClusterHost(clusterHost)
+	f, err := contexts.Load(configDir)
+	if err != nil {
+		return nil, fmt.Errorf("load contexts: %w", err)
+	}
+
+	coreURLs, jurisdictionAudience, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
+	if err != nil {
+		return nil, err
+	}
+
+	selected, err := selectContext(f, "cluster "+clusterHost, coreURLs, debugf)
+	if err != nil {
+		return nil, err
+	}
+	return &ClusterAuth{Context: selected, CoreURLs: coreURLs, JurisdictionAudience: jurisdictionAudience}, nil
 }
 
 // ResolveClusterCores returns the trusted control-plane core URLs that
@@ -82,7 +119,8 @@ func ResolveClusterCores(ctx context.Context, cacheDir, clusterHost string, http
 	if debugf == nil {
 		debugf = func(string, ...any) {}
 	}
-	return resolveClusterCores(ctx, cacheDir, normalizeClusterHost(clusterHost), httpClient, debugf)
+	cores, _, err := resolveClusterCores(ctx, cacheDir, normalizeClusterHost(clusterHost), httpClient, debugf)
+	return cores, err
 }
 
 // normalizeClusterHost folds a cluster host to its canonical form for use as a
@@ -105,9 +143,9 @@ func resolveCachedCores(
 	cacheDir, host, label string,
 	load func(string) (discovery.ClusterCoresCache, error),
 	modify func(string, func(discovery.ClusterCoresCache) error) error,
-	discover func() ([]string, error),
+	discover func() ([]string, string, error),
 	debugf DebugFunc,
-) ([]string, error) {
+) ([]string, string, error) {
 	cache, err := load(cacheDir)
 	if err != nil {
 		// A cache read problem must not block resolution — discover live.
@@ -115,49 +153,50 @@ func resolveCachedCores(
 		cache = nil
 	}
 
-	var stale []string
+	var stale *discovery.CoresEntry
 	if cache != nil {
-		if urls, fresh, ok := cache.Get(host); ok {
+		if entry, fresh, ok := cache.GetEntry(host); ok {
 			if fresh {
-				debugf("%s %s cores from cache: %v", label, host, urls)
-				return urls, nil
+				debugf("%s %s cores from cache: %v", label, host, entry.CoreURLs)
+				return entry.CoreURLs, entry.JurisdictionAudience, nil
 			}
-			stale = urls
+			stale = entry
 			debugf("%s %s cores cache expired; re-fetching /.well-known", label, host)
 		}
 	}
 
-	cores, err := discover()
+	cores, jurisdictionAudience, err := discover()
 	if err != nil {
 		if stale != nil {
-			debugf("%s discovery for %s failed (%v); falling back to stale cached cores %v", label, host, err, stale)
-			return stale, nil
+			debugf("%s discovery for %s failed (%v); falling back to stale cached cores %v", label, host, err, stale.CoreURLs)
+			return stale.CoreURLs, stale.JurisdictionAudience, nil
 		}
-		return nil, err
+		return nil, "", err
 	}
 
 	if mErr := modify(cacheDir, func(c discovery.ClusterCoresCache) error {
-		c.Set(host, cores)
+		c.SetEntry(host, cores, jurisdictionAudience)
 		return nil
 	}); mErr != nil {
 		// Non-fatal: we resolved the cores, the next call just re-fetches.
 		debugf("%s cache write for %s failed: %v", label, host, mErr)
 	}
-	return cores, nil
+	return cores, jurisdictionAudience, nil
 }
 
 // resolveClusterCores returns the control-plane core URLs that front
-// clusterHost, from cluster_cores.json when fresh, otherwise via a live
-// /.well-known fetch (cached, with stale fallback on failure).
-func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) ([]string, error) {
+// clusterHost plus its advertised jurisdiction audience, from
+// cluster_cores.json when fresh, otherwise via a live /.well-known fetch
+// (cached, with stale fallback on failure).
+func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) ([]string, string, error) {
 	return resolveCachedCores(cacheDir, clusterHost, "cluster",
 		discovery.LoadClusterCores, discovery.ModifyClusterCores,
-		func() ([]string, error) {
+		func() ([]string, string, error) {
 			body, err := Discover(ctx, clusterHost, httpClient, debugf)
 			if err != nil {
-				return nil, formatDiscoveryError(clusterHost, err)
+				return nil, "", formatDiscoveryError(clusterHost, err)
 			}
-			return body.CoreURLs, nil
+			return body.CoreURLs, body.JurisdictionAudience, nil
 		}, debugf)
 }
 

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -50,25 +50,11 @@ import (
 //
 // debugf is optional; nil suppresses debug output.
 func ResolveContextForCluster(ctx context.Context, configDir, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*contexts.Context, error) {
-	if debugf == nil {
-		debugf = func(string, ...any) {}
-	}
-	// DNS hostnames are case-insensitive, so fold case before the host drives any
-	// lookup: the cache key, the /.well-known fetch, and the cores→context match.
-	// Without this, `aws-US-east-2.entire.io` and `aws-us-east-2.entire.io`
-	// resolve as different hosts and a context determination can fail spuriously.
-	clusterHost = normalizeClusterHost(clusterHost)
-	f, err := contexts.Load(configDir)
-	if err != nil {
-		return nil, fmt.Errorf("load contexts: %w", err)
-	}
-
-	entry, err := resolveClusterCores(ctx, cacheDir, clusterHost, false, httpClient, debugf)
+	a, err := resolveClusterAuth(ctx, configDir, cacheDir, clusterHost, false, httpClient, debugf)
 	if err != nil {
 		return nil, err
 	}
-
-	return selectContext(f, "cluster "+clusterHost, entry.CoreURLs, debugf)
+	return a.Context, nil
 }
 
 // ClusterAuth is ResolveClusterAuth's result: the selected login context
@@ -85,18 +71,30 @@ type ClusterAuth struct {
 
 // ResolveClusterAuth is ResolveContextForCluster plus the cluster's
 // advertised jurisdiction metadata, sharing the same cache and single
-// /.well-known fetch.
+// /.well-known fetch. Because its callers cannot proceed without the
+// jurisdiction audience, resolution requires one (see resolveCachedCores).
 func ResolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*ClusterAuth, error) {
+	return resolveClusterAuth(ctx, configDir, cacheDir, clusterHost, true, httpClient, debugf)
+}
+
+// resolveClusterAuth is the shared body of ResolveContextForCluster and
+// ResolveClusterAuth: load contexts, resolve the cluster's cores entry,
+// select the login context.
+func resolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost string, requireAudience bool, httpClient *http.Client, debugf DebugFunc) (*ClusterAuth, error) {
 	if debugf == nil {
 		debugf = func(string, ...any) {}
 	}
+	// DNS hostnames are case-insensitive, so fold case before the host drives any
+	// lookup: the cache key, the /.well-known fetch, and the cores→context match.
+	// Without this, `aws-US-east-2.entire.io` and `aws-us-east-2.entire.io`
+	// resolve as different hosts and a context determination can fail spuriously.
 	clusterHost = normalizeClusterHost(clusterHost)
 	f, err := contexts.Load(configDir)
 	if err != nil {
 		return nil, fmt.Errorf("load contexts: %w", err)
 	}
 
-	entry, err := resolveClusterCores(ctx, cacheDir, clusterHost, true, httpClient, debugf)
+	entry, err := resolveClusterCores(ctx, cacheDir, clusterHost, requireAudience, httpClient, debugf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -63,29 +63,29 @@ func ResolveContextForCluster(ctx context.Context, configDir, cacheDir, clusterH
 		return nil, fmt.Errorf("load contexts: %w", err)
 	}
 
-	coreURLs, _, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
+	entry, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
 	if err != nil {
 		return nil, err
 	}
 
-	return selectContext(f, "cluster "+clusterHost, coreURLs, debugf)
+	return selectContext(f, "cluster "+clusterHost, entry.CoreURLs, debugf)
 }
 
 // ClusterAuth is ResolveClusterAuth's result: the selected login context
 // plus the cluster facts a caller needs to mint credentials for it.
 type ClusterAuth struct {
 	Context *contexts.Context
-	// CoreURLs is the cluster's advertised trusted-core set.
-	CoreURLs []string
 	// JurisdictionAudience is the cluster's identity-token audience; empty
-	// when the cluster doesn't advertise one (fall back to repo-scoped
-	// tokens).
+	// when the cluster doesn't advertise one.
 	JurisdictionAudience string
+	// JurisdictionCoreURL is the advertised core minting for that audience —
+	// the cross-jurisdiction exchange endpoint.
+	JurisdictionCoreURL string
 }
 
 // ResolveClusterAuth is ResolveContextForCluster plus the cluster's
-// advertised metadata (trusted cores, jurisdiction audience), sharing the
-// same cache and single /.well-known fetch.
+// advertised jurisdiction metadata, sharing the same cache and single
+// /.well-known fetch.
 func ResolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*ClusterAuth, error) {
 	if debugf == nil {
 		debugf = func(string, ...any) {}
@@ -96,16 +96,20 @@ func ResolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost st
 		return nil, fmt.Errorf("load contexts: %w", err)
 	}
 
-	coreURLs, jurisdictionAudience, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
+	entry, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
 	if err != nil {
 		return nil, err
 	}
 
-	selected, err := selectContext(f, "cluster "+clusterHost, coreURLs, debugf)
+	selected, err := selectContext(f, "cluster "+clusterHost, entry.CoreURLs, debugf)
 	if err != nil {
 		return nil, err
 	}
-	return &ClusterAuth{Context: selected, CoreURLs: coreURLs, JurisdictionAudience: jurisdictionAudience}, nil
+	return &ClusterAuth{
+		Context:              selected,
+		JurisdictionAudience: entry.JurisdictionAudience,
+		JurisdictionCoreURL:  entry.JurisdictionCoreURL,
+	}, nil
 }
 
 // ResolveClusterCores returns the trusted control-plane core URLs that
@@ -119,8 +123,11 @@ func ResolveClusterCores(ctx context.Context, cacheDir, clusterHost string, http
 	if debugf == nil {
 		debugf = func(string, ...any) {}
 	}
-	cores, _, err := resolveClusterCores(ctx, cacheDir, normalizeClusterHost(clusterHost), httpClient, debugf)
-	return cores, err
+	entry, err := resolveClusterCores(ctx, cacheDir, normalizeClusterHost(clusterHost), httpClient, debugf)
+	if err != nil {
+		return nil, err
+	}
+	return entry.CoreURLs, nil
 }
 
 // normalizeClusterHost folds a cluster host to its canonical form for use as a
@@ -143,9 +150,9 @@ func resolveCachedCores(
 	cacheDir, host, label string,
 	load func(string) (discovery.ClusterCoresCache, error),
 	modify func(string, func(discovery.ClusterCoresCache) error) error,
-	discover func() ([]string, string, error),
+	discover func() (discovery.CoresEntry, error),
 	debugf DebugFunc,
-) ([]string, string, error) {
+) (*discovery.CoresEntry, error) {
 	cache, err := load(cacheDir)
 	if err != nil {
 		// A cache read problem must not block resolution — discover live.
@@ -164,45 +171,49 @@ func resolveCachedCores(
 			preAudience := label == "cluster" && entry.JurisdictionAudience == ""
 			if fresh && !preAudience {
 				debugf("%s %s cores from cache: %v", label, host, entry.CoreURLs)
-				return entry.CoreURLs, entry.JurisdictionAudience, nil
+				return entry, nil
 			}
 			stale = entry
 			debugf("%s %s cores cache expired or pre-audience; re-fetching /.well-known", label, host)
 		}
 	}
 
-	cores, jurisdictionAudience, err := discover()
+	fetched, err := discover()
 	if err != nil {
 		if stale != nil {
 			debugf("%s discovery for %s failed (%v); falling back to stale cached cores %v", label, host, err, stale.CoreURLs)
-			return stale.CoreURLs, stale.JurisdictionAudience, nil
+			return stale, nil
 		}
-		return nil, "", err
+		return nil, err
 	}
 
 	if mErr := modify(cacheDir, func(c discovery.ClusterCoresCache) error {
-		c.SetEntry(host, cores, jurisdictionAudience)
+		c.SetEntry(host, fetched)
 		return nil
 	}); mErr != nil {
 		// Non-fatal: we resolved the cores, the next call just re-fetches.
 		debugf("%s cache write for %s failed: %v", label, host, mErr)
 	}
-	return cores, jurisdictionAudience, nil
+	return &fetched, nil
 }
 
 // resolveClusterCores returns the control-plane core URLs that front
-// clusterHost plus its advertised jurisdiction audience, from
+// clusterHost plus its advertised jurisdiction audience/core, from
 // cluster_cores.json when fresh, otherwise via a live /.well-known fetch
 // (cached, with stale fallback on failure).
-func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) ([]string, string, error) {
+func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*discovery.CoresEntry, error) {
 	return resolveCachedCores(cacheDir, clusterHost, "cluster",
 		discovery.LoadClusterCores, discovery.ModifyClusterCores,
-		func() ([]string, string, error) {
+		func() (discovery.CoresEntry, error) {
 			body, err := Discover(ctx, clusterHost, httpClient, debugf)
 			if err != nil {
-				return nil, "", formatDiscoveryError(clusterHost, err)
+				return discovery.CoresEntry{}, formatDiscoveryError(clusterHost, err)
 			}
-			return body.CoreURLs, body.JurisdictionAudience, nil
+			return discovery.CoresEntry{
+				CoreURLs:             body.CoreURLs,
+				JurisdictionAudience: body.JurisdictionAudience,
+				JurisdictionCoreURL:  body.JurisdictionCoreURL,
+			}, nil
 		}, debugf)
 }
 

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -75,7 +75,7 @@ func ResolveContextForCluster(ctx context.Context, configDir, cacheDir, clusterH
 // plus the cluster facts a caller needs to mint credentials for it.
 type ClusterAuth struct {
 	Context *contexts.Context
-	// JurisdictionAudience is the cluster's identity-token audience; empty
+	// JurisdictionAudience is the cluster's jurisdiction-token audience; empty
 	// when the cluster doesn't advertise one.
 	JurisdictionAudience string
 	// JurisdictionCoreURL is the advertised core minting for that audience —

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -156,12 +156,18 @@ func resolveCachedCores(
 	var stale *discovery.CoresEntry
 	if cache != nil {
 		if entry, fresh, ok := cache.GetEntry(host); ok {
-			if fresh {
+			// A cluster entry without a jurisdiction audience was cached
+			// before the cluster advertised one (git auth requires it) —
+			// treat it as stale so the upgrade is picked up immediately
+			// instead of after the 24h TTL. API entries never carry an
+			// audience; label distinguishes the two cache families.
+			preAudience := label == "cluster" && entry.JurisdictionAudience == ""
+			if fresh && !preAudience {
 				debugf("%s %s cores from cache: %v", label, host, entry.CoreURLs)
 				return entry.CoreURLs, entry.JurisdictionAudience, nil
 			}
 			stale = entry
-			debugf("%s %s cores cache expired; re-fetching /.well-known", label, host)
+			debugf("%s %s cores cache expired or pre-audience; re-fetching /.well-known", label, host)
 		}
 	}
 

--- a/internal/entireclient/clusterdiscovery/resolve.go
+++ b/internal/entireclient/clusterdiscovery/resolve.go
@@ -63,7 +63,7 @@ func ResolveContextForCluster(ctx context.Context, configDir, cacheDir, clusterH
 		return nil, fmt.Errorf("load contexts: %w", err)
 	}
 
-	entry, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
+	entry, err := resolveClusterCores(ctx, cacheDir, clusterHost, false, httpClient, debugf)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func ResolveClusterAuth(ctx context.Context, configDir, cacheDir, clusterHost st
 		return nil, fmt.Errorf("load contexts: %w", err)
 	}
 
-	entry, err := resolveClusterCores(ctx, cacheDir, clusterHost, httpClient, debugf)
+	entry, err := resolveClusterCores(ctx, cacheDir, clusterHost, true, httpClient, debugf)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func ResolveClusterCores(ctx context.Context, cacheDir, clusterHost string, http
 	if debugf == nil {
 		debugf = func(string, ...any) {}
 	}
-	entry, err := resolveClusterCores(ctx, cacheDir, normalizeClusterHost(clusterHost), httpClient, debugf)
+	entry, err := resolveClusterCores(ctx, cacheDir, normalizeClusterHost(clusterHost), false, httpClient, debugf)
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +146,17 @@ func normalizeClusterHost(clusterHost string) string {
 // already knew. load/modify select the cache file; discover wraps the
 // host-specific /.well-known fetch (and any host-specific error formatting);
 // label names the resource in debug output ("cluster" / "api host").
+//
+// requireAudience marks callers that cannot proceed without the entry's
+// jurisdiction audience (the interactive git path). For them, an entry
+// cached before the cluster advertised an audience is treated as stale so
+// the upgrade is picked up immediately instead of after the 24h TTL — and
+// an audience-less entry is NOT used as the discovery-failure fallback:
+// returning it would make the caller misdiagnose a transient discovery
+// failure as "this cluster doesn't do jurisdiction tokens".
 func resolveCachedCores(
 	cacheDir, host, label string,
+	requireAudience bool,
 	load func(string) (discovery.ClusterCoresCache, error),
 	modify func(string, func(discovery.ClusterCoresCache) error) error,
 	discover func() (discovery.CoresEntry, error),
@@ -163,12 +172,7 @@ func resolveCachedCores(
 	var stale *discovery.CoresEntry
 	if cache != nil {
 		if entry, fresh, ok := cache.GetEntry(host); ok {
-			// A cluster entry without a jurisdiction audience was cached
-			// before the cluster advertised one (git auth requires it) —
-			// treat it as stale so the upgrade is picked up immediately
-			// instead of after the 24h TTL. API entries never carry an
-			// audience; label distinguishes the two cache families.
-			preAudience := label == "cluster" && entry.JurisdictionAudience == ""
+			preAudience := requireAudience && entry.JurisdictionAudience == ""
 			if fresh && !preAudience {
 				debugf("%s %s cores from cache: %v", label, host, entry.CoreURLs)
 				return entry, nil
@@ -180,7 +184,7 @@ func resolveCachedCores(
 
 	fetched, err := discover()
 	if err != nil {
-		if stale != nil {
+		if stale != nil && (!requireAudience || stale.JurisdictionAudience != "") {
 			debugf("%s discovery for %s failed (%v); falling back to stale cached cores %v", label, host, err, stale.CoreURLs)
 			return stale, nil
 		}
@@ -200,9 +204,10 @@ func resolveCachedCores(
 // resolveClusterCores returns the control-plane core URLs that front
 // clusterHost plus its advertised jurisdiction audience/core, from
 // cluster_cores.json when fresh, otherwise via a live /.well-known fetch
-// (cached, with stale fallback on failure).
-func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, httpClient *http.Client, debugf DebugFunc) (*discovery.CoresEntry, error) {
-	return resolveCachedCores(cacheDir, clusterHost, "cluster",
+// (cached, with stale fallback on failure). requireAudience: see
+// resolveCachedCores.
+func resolveClusterCores(ctx context.Context, cacheDir, clusterHost string, requireAudience bool, httpClient *http.Client, debugf DebugFunc) (*discovery.CoresEntry, error) {
+	return resolveCachedCores(cacheDir, clusterHost, "cluster", requireAudience,
 		discovery.LoadClusterCores, discovery.ModifyClusterCores,
 		func() (discovery.CoresEntry, error) {
 			body, err := Discover(ctx, clusterHost, httpClient, debugf)

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -159,10 +159,10 @@ func TestResolve_CoresCachedAcrossCalls(t *testing.T) {
 	// The cores fact is persisted; the account choice is not.
 	cache, err := discovery.LoadClusterCores(cacheDir)
 	require.NoError(t, err)
-	urls, fresh, ok := cache.Get("aws-eu-central-1.entire.io")
+	entry, fresh, ok := cache.GetEntry("aws-eu-central-1.entire.io")
 	require.True(t, ok)
 	assert.True(t, fresh)
-	assert.Equal(t, []string{"https://eu.auth.entire.io"}, urls)
+	assert.Equal(t, []string{"https://eu.auth.entire.io"}, entry.CoreURLs)
 }
 
 // TestResolve_ClusterHostCaseInsensitive: a mixed-case cluster host resolves
@@ -190,7 +190,7 @@ func TestResolve_ClusterHostCaseInsensitive(t *testing.T) {
 	// Cached under the canonical lowercase host, so the lowercase form is a hit.
 	cache, err := discovery.LoadClusterCores(cacheDir)
 	require.NoError(t, err)
-	_, _, ok := cache.Get("aws-eu-central-1.entire.io")
+	_, _, ok := cache.GetEntry("aws-eu-central-1.entire.io")
 	assert.True(t, ok, "cores cached under the lowercased host key")
 
 	c2, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -268,6 +268,73 @@ func TestResolve_PreAudienceCacheRefetched(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "audience-bearing entry must be served from cache")
 }
 
+// TestResolve_PreAudienceEntryNotUsedAsDiscoveryFallback: when the forced
+// pre-audience re-fetch fails, the audience-less stale entry must NOT be
+// served to an audience-requiring caller — that would misdiagnose a
+// transient discovery failure as "cluster doesn't do jurisdiction tokens".
+func TestResolve_PreAudienceEntryNotUsedAsDiscoveryFallback(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	client := hostPinningClient(t, srv)
+	srv.Close() // discovery fails
+
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod-eu",
+		Contexts: []*contexts.Context{
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}))
+	// FRESH entry, but pre-audience.
+	require.NoError(t, discovery.ModifyClusterCores(cacheDir, func(c discovery.ClusterCoresCache) error {
+		c["aws-eu-central-1.entire.io"] = &discovery.CoresEntry{
+			CoreURLs:  []string{"https://eu.auth.entire.io"},
+			FetchedAt: time.Now(),
+		}
+		return nil
+	}))
+
+	_, err := ResolveClusterAuth(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", client, t.Logf)
+	require.Error(t, err, "discovery failure must surface, not an empty audience")
+	assert.Contains(t, err.Error(), "unreachable")
+
+	// The audience-agnostic resolver still gets the stale-cores fallback.
+	c, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", client, t.Logf)
+	require.NoError(t, err, "cores-only callers keep the stale fallback")
+	assert.Equal(t, "prod-eu", c.Name)
+}
+
+// TestResolve_AudienceAgnosticCallersSkipPreAudienceRefetch: a fresh entry
+// without an audience is served from cache for callers that don't need the
+// audience — no forced re-fetch.
+func TestResolve_AudienceAgnosticCallersSkipPreAudienceRefetch(t *testing.T) {
+	t.Parallel()
+	var calls int32
+	srv := httptest.NewServer(coresHandler(t, &calls, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod-eu",
+		Contexts: []*contexts.Context{
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}))
+	require.NoError(t, discovery.ModifyClusterCores(cacheDir, func(c discovery.ClusterCoresCache) error {
+		c["aws-eu-central-1.entire.io"] = &discovery.CoresEntry{
+			CoreURLs:  []string{"https://eu.auth.entire.io"},
+			FetchedAt: time.Now(),
+		}
+		return nil
+	}))
+
+	_, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&calls), "cores-only caller must be served from the fresh cache")
+}
+
 // TestResolve_Unreachable: transport failure with no cached cores surfaces
 // the "doesn't look like a cluster" message.
 func TestResolve_Unreachable(t *testing.T) {

--- a/internal/entireclient/clusterdiscovery/resolve_test.go
+++ b/internal/entireclient/clusterdiscovery/resolve_test.go
@@ -15,11 +15,13 @@ import (
 	"github.com/entireio/cli/internal/entireclient/discovery"
 )
 
-// coresHandler serves a fixed core_urls list and counts how many times
-// /.well-known was hit, so tests can assert cache hits vs live fetches.
+// coresHandler serves a fixed core_urls list (plus a jurisdiction audience,
+// as every current cluster advertises one — a cached entry without it is
+// deliberately treated as stale) and counts how many times /.well-known was
+// hit, so tests can assert cache hits vs live fetches.
 func coresHandler(t *testing.T, calls *int32, coreURLs ...string) http.HandlerFunc {
 	t.Helper()
-	body, err := json.Marshal(Response{CoreURLs: coreURLs})
+	body, err := json.Marshal(Response{CoreURLs: coreURLs, JurisdictionAudience: "https://eu.entire.io"})
 	require.NoError(t, err)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if calls != nil {
@@ -227,6 +229,43 @@ func TestResolve_StaleCacheFallbackOnDiscoveryFailure(t *testing.T) {
 	c, err := ResolveContextForCluster(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", client, t.Logf)
 	require.NoError(t, err, "should fall back to stale cores when re-fetch fails")
 	assert.Equal(t, "prod-eu", c.Name)
+}
+
+// TestResolve_PreAudienceCacheRefetched: a fresh cache entry that predates
+// the jurisdiction_audience field is re-fetched immediately (not after the
+// 24h TTL), so clients pick up a cluster upgrade right away.
+func TestResolve_PreAudienceCacheRefetched(t *testing.T) {
+	t.Parallel()
+	var calls int32
+	srv := httptest.NewServer(coresHandler(t, &calls, "https://eu.auth.entire.io"))
+	defer srv.Close()
+
+	configDir := t.TempDir()
+	cacheDir := t.TempDir()
+	require.NoError(t, contexts.Save(configDir, &contexts.File{
+		CurrentContext: "prod-eu",
+		Contexts: []*contexts.Context{
+			{Name: "prod-eu", CoreURL: "https://eu.auth.entire.io", Handle: "paul", KeychainService: "kc:prod"},
+		},
+	}))
+	// Seed a FRESH entry without a jurisdiction audience (pre-upgrade shape).
+	require.NoError(t, discovery.ModifyClusterCores(cacheDir, func(c discovery.ClusterCoresCache) error {
+		c["aws-eu-central-1.entire.io"] = &discovery.CoresEntry{
+			CoreURLs:  []string{"https://eu.auth.entire.io"},
+			FetchedAt: time.Now(),
+		}
+		return nil
+	}))
+
+	got, err := ResolveClusterAuth(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "pre-audience entry must trigger a live re-fetch")
+	assert.Equal(t, "https://eu.entire.io", got.JurisdictionAudience)
+
+	// The refreshed entry now carries the audience: served from cache.
+	_, err = ResolveClusterAuth(t.Context(), configDir, cacheDir, "aws-eu-central-1.entire.io", hostPinningClient(t, srv), t.Logf)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "audience-bearing entry must be served from cache")
 }
 
 // TestResolve_Unreachable: transport failure with no cached cores surfaces

--- a/internal/entireclient/discovery/api_discovery_test.go
+++ b/internal/entireclient/discovery/api_discovery_test.go
@@ -10,13 +10,13 @@ func TestAPICores_SeparateFileFromClusterCores(t *testing.T) {
 	dir := t.TempDir()
 
 	if err := ModifyClusterCores(dir, func(c ClusterCoresCache) error {
-		c.Set("shared.example", []string{"https://cluster-core.example"})
+		c.SetEntry("shared.example", CoresEntry{CoreURLs: []string{"https://cluster-core.example"}})
 		return nil
 	}); err != nil {
 		t.Fatalf("ModifyClusterCores: %v", err)
 	}
 	if err := ModifyAPICores(dir, func(c ClusterCoresCache) error {
-		c.Set("shared.example", []string{"https://api-core.example"})
+		c.SetEntry("shared.example", CoresEntry{CoreURLs: []string{"https://api-core.example"}})
 		return nil
 	}); err != nil {
 		t.Fatalf("ModifyAPICores: %v", err)
@@ -31,12 +31,12 @@ func TestAPICores_SeparateFileFromClusterCores(t *testing.T) {
 		t.Fatalf("LoadAPICores: %v", err)
 	}
 
-	clusterURLs, _, ok := clusterCache.Get("shared.example")
-	if !ok || clusterURLs[0] != "https://cluster-core.example" {
-		t.Fatalf("cluster cache = %v (ok=%v), want the cluster core", clusterURLs, ok)
+	clusterEntry, _, ok := clusterCache.GetEntry("shared.example")
+	if !ok || clusterEntry.CoreURLs[0] != "https://cluster-core.example" {
+		t.Fatalf("cluster cache = %v (ok=%v), want the cluster core", clusterEntry, ok)
 	}
-	apiURLs, fresh, ok := apiCache.Get("shared.example")
-	if !ok || !fresh || apiURLs[0] != "https://api-core.example" {
-		t.Fatalf("api cache = %v (fresh=%v ok=%v), want the api core", apiURLs, fresh, ok)
+	apiEntry, fresh, ok := apiCache.GetEntry("shared.example")
+	if !ok || !fresh || apiEntry.CoreURLs[0] != "https://api-core.example" {
+		t.Fatalf("api cache = %v (fresh=%v ok=%v), want the api core", apiEntry, fresh, ok)
 	}
 }

--- a/internal/entireclient/discovery/cluster_cores.go
+++ b/internal/entireclient/discovery/cluster_cores.go
@@ -38,9 +38,9 @@ type ClusterCoresCache map[string]*CoresEntry
 // change re-interprets existing entries without a migration.
 type CoresEntry struct {
 	CoreURLs []string `json:"core_urls"`
-	// JurisdictionAudience is the cluster's identity-token audience as
+	// JurisdictionAudience is the cluster's jurisdiction-token audience as
 	// advertised by its /.well-known/entire-cluster.json. Empty when the
-	// cluster does not accept jurisdiction identity tokens (or predates
+	// cluster does not accept jurisdiction access tokens (or predates
 	// the field) — callers must then fall back to repo-scoped tokens.
 	JurisdictionAudience string `json:"jurisdiction_audience,omitempty"`
 	// JurisdictionCoreURL is the advertised core that mints for

--- a/internal/entireclient/discovery/cluster_cores.go
+++ b/internal/entireclient/discovery/cluster_cores.go
@@ -42,8 +42,11 @@ type CoresEntry struct {
 	// advertised by its /.well-known/entire-cluster.json. Empty when the
 	// cluster does not accept jurisdiction identity tokens (or predates
 	// the field) — callers must then fall back to repo-scoped tokens.
-	JurisdictionAudience string    `json:"jurisdiction_audience,omitempty"`
-	FetchedAt            time.Time `json:"fetched_at"`
+	JurisdictionAudience string `json:"jurisdiction_audience,omitempty"`
+	// JurisdictionCoreURL is the advertised core that mints for
+	// JurisdictionAudience — the cross-jurisdiction exchange endpoint.
+	JurisdictionCoreURL string    `json:"jurisdiction_core_url,omitempty"`
+	FetchedAt           time.Time `json:"fetched_at"`
 }
 
 // LoadClusterCores reads the cluster→cores cache. A missing or corrupt file
@@ -113,15 +116,14 @@ func (c ClusterCoresCache) GetEntry(cluster string) (entry *CoresEntry, fresh, o
 // Set records a cluster's core URLs, stamping the fetch time to now. The
 // slice is copied so later mutation by the caller can't corrupt the cache.
 func (c ClusterCoresCache) Set(cluster string, urls []string) {
-	c.SetEntry(cluster, urls, "")
+	c.SetEntry(cluster, CoresEntry{CoreURLs: urls})
 }
 
-// SetEntry is Set plus the cluster's advertised jurisdiction audience
-// (empty when the cluster does not advertise one).
-func (c ClusterCoresCache) SetEntry(cluster string, urls []string, jurisdictionAudience string) {
-	c[cluster] = &CoresEntry{
-		CoreURLs:             append([]string(nil), urls...),
-		JurisdictionAudience: jurisdictionAudience,
-		FetchedAt:            time.Now(),
-	}
+// SetEntry records a full discovery result (cores plus the jurisdiction
+// audience/core when advertised), stamping the fetch time to now. The
+// slice is copied so later mutation by the caller can't corrupt the cache.
+func (c ClusterCoresCache) SetEntry(cluster string, entry CoresEntry) {
+	entry.CoreURLs = append([]string(nil), entry.CoreURLs...)
+	entry.FetchedAt = time.Now()
+	c[cluster] = &entry
 }

--- a/internal/entireclient/discovery/cluster_cores.go
+++ b/internal/entireclient/discovery/cluster_cores.go
@@ -92,32 +92,16 @@ func ModifyAPICores(cacheDir string, fn func(ClusterCoresCache) error) error {
 	return modifyCacheFile(cacheDir, apiDiscoveryFileName, readClusterCoresNoLock, writeClusterCoresNoLock, fn)
 }
 
-// Get returns a cluster's cached core URLs, whether the entry is still fresh,
+// GetEntry returns a cluster's cached cores entry, whether it is still fresh,
 // and whether it exists at all. A present-but-stale entry returns
-// (urls, false, true) so callers can attempt a re-fetch yet fall back to the
-// stale URLs if that fetch fails.
-func (c ClusterCoresCache) Get(cluster string) (urls []string, fresh, ok bool) {
-	entry, fresh, ok := c.GetEntry(cluster)
-	if !ok {
-		return nil, false, false
-	}
-	return entry.CoreURLs, fresh, true
-}
-
-// GetEntry is Get for callers that also need the entry's extra fields
-// (JurisdictionAudience). Same freshness/fallback semantics.
+// (entry, false, true) so callers can attempt a re-fetch yet fall back to
+// the stale entry if that fetch fails.
 func (c ClusterCoresCache) GetEntry(cluster string) (entry *CoresEntry, fresh, ok bool) {
 	entry = c[cluster]
 	if entry == nil || len(entry.CoreURLs) == 0 {
 		return nil, false, false
 	}
 	return entry, time.Now().Before(entry.FetchedAt.Add(ClusterCoresTTL)), true
-}
-
-// Set records a cluster's core URLs, stamping the fetch time to now. The
-// slice is copied so later mutation by the caller can't corrupt the cache.
-func (c ClusterCoresCache) Set(cluster string, urls []string) {
-	c.SetEntry(cluster, CoresEntry{CoreURLs: urls})
 }
 
 // SetEntry records a full discovery result (cores plus the jurisdiction

--- a/internal/entireclient/discovery/cluster_cores.go
+++ b/internal/entireclient/discovery/cluster_cores.go
@@ -37,8 +37,13 @@ type ClusterCoresCache map[string]*CoresEntry
 // Freshness is fetched_at + ClusterCoresTTL, computed at read time so a TTL
 // change re-interprets existing entries without a migration.
 type CoresEntry struct {
-	CoreURLs  []string  `json:"core_urls"`
-	FetchedAt time.Time `json:"fetched_at"`
+	CoreURLs []string `json:"core_urls"`
+	// JurisdictionAudience is the cluster's identity-token audience as
+	// advertised by its /.well-known/entire-cluster.json. Empty when the
+	// cluster does not accept jurisdiction identity tokens (or predates
+	// the field) — callers must then fall back to repo-scoped tokens.
+	JurisdictionAudience string    `json:"jurisdiction_audience,omitempty"`
+	FetchedAt            time.Time `json:"fetched_at"`
 }
 
 // LoadClusterCores reads the cluster→cores cache. A missing or corrupt file
@@ -88,18 +93,35 @@ func ModifyAPICores(cacheDir string, fn func(ClusterCoresCache) error) error {
 // (urls, false, true) so callers can attempt a re-fetch yet fall back to the
 // stale URLs if that fetch fails.
 func (c ClusterCoresCache) Get(cluster string) (urls []string, fresh, ok bool) {
-	entry := c[cluster]
+	entry, fresh, ok := c.GetEntry(cluster)
+	if !ok {
+		return nil, false, false
+	}
+	return entry.CoreURLs, fresh, true
+}
+
+// GetEntry is Get for callers that also need the entry's extra fields
+// (JurisdictionAudience). Same freshness/fallback semantics.
+func (c ClusterCoresCache) GetEntry(cluster string) (entry *CoresEntry, fresh, ok bool) {
+	entry = c[cluster]
 	if entry == nil || len(entry.CoreURLs) == 0 {
 		return nil, false, false
 	}
-	return entry.CoreURLs, time.Now().Before(entry.FetchedAt.Add(ClusterCoresTTL)), true
+	return entry, time.Now().Before(entry.FetchedAt.Add(ClusterCoresTTL)), true
 }
 
 // Set records a cluster's core URLs, stamping the fetch time to now. The
 // slice is copied so later mutation by the caller can't corrupt the cache.
 func (c ClusterCoresCache) Set(cluster string, urls []string) {
+	c.SetEntry(cluster, urls, "")
+}
+
+// SetEntry is Set plus the cluster's advertised jurisdiction audience
+// (empty when the cluster does not advertise one).
+func (c ClusterCoresCache) SetEntry(cluster string, urls []string, jurisdictionAudience string) {
 	c[cluster] = &CoresEntry{
-		CoreURLs:  append([]string(nil), urls...),
-		FetchedAt: time.Now(),
+		CoreURLs:             append([]string(nil), urls...),
+		JurisdictionAudience: jurisdictionAudience,
+		FetchedAt:            time.Now(),
 	}
 }

--- a/internal/entireclient/discovery/cluster_cores.go
+++ b/internal/entireclient/discovery/cluster_cores.go
@@ -41,7 +41,8 @@ type CoresEntry struct {
 	// JurisdictionAudience is the cluster's jurisdiction-token audience as
 	// advertised by its /.well-known/entire-cluster.json. Empty when the
 	// cluster does not accept jurisdiction access tokens (or predates
-	// the field) — callers must then fall back to repo-scoped tokens.
+	// the field) — git-remote-entire treats that as an error; other
+	// callers decide their own fallback.
 	JurisdictionAudience string `json:"jurisdiction_audience,omitempty"`
 	// JurisdictionCoreURL is the advertised core that mints for
 	// JurisdictionAudience — the cross-jurisdiction exchange endpoint.

--- a/internal/entireclient/discovery/cluster_cores_test.go
+++ b/internal/entireclient/discovery/cluster_cores_test.go
@@ -10,7 +10,7 @@ func TestClusterCores_RoundTripFresh(t *testing.T) {
 	dir := t.TempDir()
 
 	if err := ModifyClusterCores(dir, func(c ClusterCoresCache) error {
-		c.Set("aws-us-east-2.entire.io", []string{"https://us.auth.entire.io", "https://eu.auth.entire.io"})
+		c.SetEntry("aws-us-east-2.entire.io", CoresEntry{CoreURLs: []string{"https://us.auth.entire.io", "https://eu.auth.entire.io"}})
 		return nil
 	}); err != nil {
 		t.Fatalf("ModifyClusterCores: %v", err)
@@ -20,14 +20,14 @@ func TestClusterCores_RoundTripFresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadClusterCores: %v", err)
 	}
-	urls, fresh, ok := cache.Get("aws-us-east-2.entire.io")
+	entry, fresh, ok := cache.GetEntry("aws-us-east-2.entire.io")
 	if !ok {
 		t.Fatal("expected entry to exist")
 	}
 	if !fresh {
 		t.Fatal("expected freshly-set entry to be fresh")
 	}
-	if len(urls) != 2 || urls[0] != "https://us.auth.entire.io" || urls[1] != "https://eu.auth.entire.io" {
+	if urls := entry.CoreURLs; len(urls) != 2 || urls[0] != "https://us.auth.entire.io" || urls[1] != "https://eu.auth.entire.io" {
 		t.Fatalf("unexpected core URLs: %v", urls)
 	}
 }
@@ -38,7 +38,7 @@ func TestClusterCores_Miss(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadClusterCores: %v", err)
 	}
-	if _, _, ok := cache.Get("unknown.example"); ok {
+	if _, _, ok := cache.GetEntry("unknown.example"); ok {
 		t.Fatal("expected miss for unknown cluster")
 	}
 }
@@ -62,14 +62,14 @@ func TestClusterCores_StaleEntryStillReturned(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadClusterCores: %v", err)
 	}
-	urls, fresh, ok := cache.Get("old.example")
+	entry, fresh, ok := cache.GetEntry("old.example")
 	if !ok {
 		t.Fatal("stale entry should still report ok=true so callers can fall back to it")
 	}
 	if fresh {
 		t.Fatal("entry older than the TTL should report fresh=false")
 	}
-	if len(urls) != 1 || urls[0] != "https://core.example" {
+	if urls := entry.CoreURLs; len(urls) != 1 || urls[0] != "https://core.example" {
 		t.Fatalf("unexpected stale core URLs: %v", urls)
 	}
 }
@@ -79,7 +79,7 @@ func TestClusterCores_ModifyAccumulates(t *testing.T) {
 	dir := t.TempDir()
 
 	if err := ModifyClusterCores(dir, func(c ClusterCoresCache) error {
-		c.Set("a.example", []string{"https://core-a.example"})
+		c.SetEntry("a.example", CoresEntry{CoreURLs: []string{"https://core-a.example"}})
 		return nil
 	}); err != nil {
 		t.Fatalf("ModifyClusterCores a: %v", err)
@@ -87,7 +87,7 @@ func TestClusterCores_ModifyAccumulates(t *testing.T) {
 	// Second modify must see the first's write (single locked RMW) rather
 	// than clobbering it.
 	if err := ModifyClusterCores(dir, func(c ClusterCoresCache) error {
-		c.Set("b.example", []string{"https://core-b.example"})
+		c.SetEntry("b.example", CoresEntry{CoreURLs: []string{"https://core-b.example"}})
 		return nil
 	}); err != nil {
 		t.Fatalf("ModifyClusterCores b: %v", err)
@@ -97,26 +97,26 @@ func TestClusterCores_ModifyAccumulates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadClusterCores: %v", err)
 	}
-	if _, _, ok := cache.Get("a.example"); !ok {
+	if _, _, ok := cache.GetEntry("a.example"); !ok {
 		t.Fatal("first entry lost after second modify")
 	}
-	if _, _, ok := cache.Get("b.example"); !ok {
+	if _, _, ok := cache.GetEntry("b.example"); !ok {
 		t.Fatal("second entry missing")
 	}
 }
 
-func TestClusterCores_SetCopiesSlice(t *testing.T) {
+func TestClusterCores_SetEntryCopiesSlice(t *testing.T) {
 	t.Parallel()
 	cache := make(ClusterCoresCache)
 	urls := []string{"https://core.example"}
-	cache.Set("c.example", urls)
-	urls[0] = "https://evil.example" // mutate caller's slice after Set
+	cache.SetEntry("c.example", CoresEntry{CoreURLs: urls})
+	urls[0] = "https://evil.example" // mutate caller's slice after SetEntry
 
-	got, _, ok := cache.Get("c.example")
+	got, _, ok := cache.GetEntry("c.example")
 	if !ok {
 		t.Fatal("expected entry")
 	}
-	if got[0] != "https://core.example" {
-		t.Fatalf("Set did not copy the slice; cache corrupted to %v", got)
+	if got.CoreURLs[0] != "https://core.example" {
+		t.Fatalf("SetEntry did not copy the slice; cache corrupted to %v", got.CoreURLs)
 	}
 }

--- a/internal/entireclient/httputil/oauth.go
+++ b/internal/entireclient/httputil/oauth.go
@@ -20,6 +20,28 @@ const (
 	TokenTypeAccessToken   = "urn:ietf:params:oauth:token-type:access_token"   //nolint:gosec // G101: an RFC 8693 token-type URN, not a credential
 )
 
+// OAuthClientID is the public OAuth client_id the CLI identifies as on
+// /oauth/token. Lifted into Basic auth by PostOAuthToken.
+const OAuthClientID = "entire-cli"
+
+// TokenExchangeForm builds the RFC 8693 token-exchange form every CLI
+// exchange POSTs to /oauth/token: subjectToken (the login JWT) is traded
+// for an access token pinned to audience with the given scope. The one
+// form shape serves repo-scoped and jurisdiction tokens alike — only
+// audience and scope differ — so keep call sites on this builder rather
+// than open-coding the fields.
+func TokenExchangeForm(subjectToken, audience, scope string) url.Values {
+	form := url.Values{}
+	form.Set("grant_type", GrantTypeTokenExchange)
+	form.Set("subject_token_type", TokenTypeAccessToken)
+	form.Set("subject_token", subjectToken)
+	form.Set("requested_token_type", TokenTypeAccessToken)
+	form.Set("audience", audience)
+	form.Set("scope", scope)
+	form.Set("client_id", OAuthClientID)
+	return form
+}
+
 // BufferRequestBody reads the request body once so a fallback retry
 // can replay it. http.NoBody (and nil) short-circuits — both signal
 // "no body" but only the latter is a runtime nil, so the explicit

--- a/internal/entireclient/repocreds/repocreds.go
+++ b/internal/entireclient/repocreds/repocreds.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -29,10 +28,6 @@ import (
 // RPCs a fresh token. Matches admincreds.safetyMargin so the two cred caches
 // don't diverge on freshness semantics.
 const SafetyMargin = time.Minute
-
-// oauthClientID is the public OAuth client_id the CLI identifies as on
-// /oauth/token. Lifted into Basic auth by httputil.PostOAuthToken.
-const oauthClientID = "entire-cli"
 
 // LoginJWTProvider returns the current login JWT. Callers wire this to their
 // own refresh logic (e.g. proactive refresh, 401 retry) so the Cache always
@@ -169,14 +164,7 @@ func (c *Cache) exchange(ctx context.Context, audienceSuffix, action string) (st
 	if err != nil {
 		return "", 0, err
 	}
-	form := url.Values{}
-	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
-	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
-	form.Set("subject_token", loginJWT)
-	form.Set("requested_token_type", "urn:ietf:params:oauth:token-type:access_token")
-	form.Set("audience", c.clusterURL+audienceSuffix)
-	form.Set("scope", "repo:"+action)
-	form.Set("client_id", oauthClientID)
+	form := httputil.TokenExchangeForm(loginJWT, c.clusterURL+audienceSuffix, "repo:"+action)
 
 	token, expiresIn, err := httputil.PostOAuthToken(ctx, c.httpClient, c.coreURL, form)
 	if err != nil {

--- a/internal/remotehelper/httpdebug/timing.go
+++ b/internal/remotehelper/httpdebug/timing.go
@@ -1,0 +1,35 @@
+package httpdebug
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/entireio/cli/internal/remotehelper/debuglog"
+)
+
+// TimingRoundTripper logs one ENTIRE_DEBUG-gated line per request with the
+// wall-clock time to response headers (bodies stream afterwards, so transfer
+// time for large packfiles is NOT included — that's deliberate: the auth and
+// discovery calls this instruments are small-bodied, and time-to-headers is
+// the latency signal we want).
+type TimingRoundTripper struct {
+	Next http.RoundTripper
+	// Label distinguishes the client the request rode on (e.g. "auth", "git").
+	Label string
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *TimingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !debuglog.Enabled() {
+		return t.Next.RoundTrip(req)
+	}
+	start := time.Now()
+	resp, err := t.Next.RoundTrip(req)
+	dur := time.Since(start)
+	if err != nil {
+		debuglog.Printf("timing: %s %s %s error=%v dur_ms=%d", t.Label, req.Method, req.URL.Redacted(), err, dur.Milliseconds())
+		return resp, err
+	}
+	debuglog.Printf("timing: %s %s %s status=%d dur_ms=%d", t.Label, req.Method, req.URL.Redacted(), resp.StatusCode, dur.Milliseconds())
+	return resp, nil
+}

--- a/internal/remotehelper/httpdebug/timing.go
+++ b/internal/remotehelper/httpdebug/timing.go
@@ -21,6 +21,7 @@ type TimingRoundTripper struct {
 // RoundTrip implements http.RoundTripper.
 func (t *TimingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if !debuglog.Enabled() {
+		//nolint:wrapcheck // passthrough - wrapping would change error semantics
 		return t.Next.RoundTrip(req)
 	}
 	start := time.Now()
@@ -28,6 +29,7 @@ func (t *TimingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	dur := time.Since(start)
 	if err != nil {
 		debuglog.Printf("timing: %s %s %s error=%v dur_ms=%d", t.Label, req.Method, req.URL.Redacted(), err, dur.Milliseconds())
+		//nolint:wrapcheck // passthrough - wrapping would change error semantics
 		return resp, err
 	}
 	debuglog.Printf("timing: %s %s %s status=%d dur_ms=%d", t.Label, req.Method, req.URL.Redacted(), resp.StatusCode, dur.Milliseconds())

--- a/internal/remotehelper/httpdebug/timing.go
+++ b/internal/remotehelper/httpdebug/timing.go
@@ -8,10 +8,10 @@ import (
 )
 
 // TimingRoundTripper logs one ENTIRE_DEBUG-gated line per request with the
-// wall-clock time to response headers (bodies stream afterwards, so transfer
-// time for large packfiles is NOT included — that's deliberate: the auth and
-// discovery calls this instruments are small-bodied, and time-to-headers is
-// the latency signal we want).
+// wall-clock time to response headers. Bodies stream afterwards, so transfer
+// time for large packfiles is NOT included — deliberately: the instrumented
+// auth and discovery calls are small-bodied, and time-to-headers is the
+// latency signal we want.
 type TimingRoundTripper struct {
 	Next http.RoundTripper
 	// Label distinguishes the client the request rode on (e.g. "auth", "git").

--- a/internal/remotehelper/transport/proxy.go
+++ b/internal/remotehelper/transport/proxy.go
@@ -122,6 +122,7 @@ func New(cfg Config) *Proxy {
 	// underlying transport's dial budget differs.
 	wrap := func(base http.RoundTripper) http.RoundTripper {
 		var rt http.RoundTripper = &httpdebug.RoundTripper{Next: base}
+		rt = &httpdebug.TimingRoundTripper{Next: rt, Label: "git"}
 		if cfg.UserAgent != "" {
 			rt = &httpclient.UserAgentTransport{Next: rt, UA: cfg.UserAgent}
 		}

--- a/internal/remotehelper/transport/proxy.go
+++ b/internal/remotehelper/transport/proxy.go
@@ -41,6 +41,15 @@ type Config struct {
 	SkipTLS      bool
 	SetAuth      SetAuthFunc
 	OnNodeFailed func(failedNode string)
+	// OnUnauthorized fires once per response with HTTP 401 — the data
+	// plane rejected the credential itself (bad signature, e.g. after a
+	// signing-key rotation; expired). Callers use it to invalidate a
+	// persisted token so the next invocation re-mints instead of replaying
+	// the dead credential until its recorded expiry. Deliberately NOT
+	// fired on 403: a 403 means the credential verified fine and
+	// authorization was denied — invalidating would churn valid tokens.
+	// Nil disables the hook.
+	OnUnauthorized func()
 	// UserAgent is stamped on every outbound HTTP request so the
 	// server can attribute git smart-HTTP traffic to the remote
 	// helper. Empty disables the wrapper, in which case the request
@@ -123,6 +132,9 @@ func New(cfg Config) *Proxy {
 	wrap := func(base http.RoundTripper) http.RoundTripper {
 		var rt http.RoundTripper = &httpdebug.RoundTripper{Next: base}
 		rt = &httpdebug.TimingRoundTripper{Next: rt, Label: "git"}
+		if cfg.OnUnauthorized != nil {
+			rt = &unauthorizedObserver{next: rt, fn: cfg.OnUnauthorized}
+		}
 		if cfg.UserAgent != "" {
 			rt = &httpclient.UserAgentTransport{Next: rt, UA: cfg.UserAgent}
 		}
@@ -134,6 +146,23 @@ func New(cfg Config) *Proxy {
 	}
 	p.discoveryTransport = wrap(httpclient.NewDiscoveryTransport(cfg.SkipTLS))
 	return p
+}
+
+// unauthorizedObserver invokes fn on every HTTP 401 response, passing the
+// response through untouched. See Config.OnUnauthorized for the contract.
+type unauthorizedObserver struct {
+	next http.RoundTripper
+	fn   func()
+}
+
+// RoundTrip implements http.RoundTripper.
+func (o *unauthorizedObserver) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := o.next.RoundTrip(req)
+	if err == nil && resp.StatusCode == http.StatusUnauthorized {
+		o.fn()
+	}
+	//nolint:wrapcheck // passthrough - wrapping would change error semantics
+	return resp, err
 }
 
 // ErrorBaseURL returns a URL string suitable for embedding in error

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -1424,3 +1424,36 @@ func TestColdPathRefusesOutOfClusterLocationSalvage(t *testing.T) {
 	_, err := p.InfoRefs(context.Background(), "git-upload-pack")
 	require.Error(t, err, "must not salvage to an off-cluster Location")
 }
+
+// TestUnauthorizedObserver: the 401 hook fires on 401 responses only —
+// 403 (valid credential, authorization denied) must not invalidate.
+func TestUnauthorizedObserver(t *testing.T) {
+	fired := 0
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		status := http.StatusForbidden
+		if req.URL.Path == "/unauth" {
+			status = http.StatusUnauthorized
+		}
+		return &http.Response{StatusCode: status, Body: http.NoBody}, nil
+	})
+	rt := &unauthorizedObserver{next: inner, fn: func() { fired++ }}
+
+	for _, path := range []string{"/forbidden", "/unauth", "/unauth"} {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://node.example"+path, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+	}
+	if fired != 2 {
+		t.Fatalf("hook fired %d times, want 2 (401s only)", fired)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/internal/remotehelper/transport/proxy_test.go
+++ b/internal/remotehelper/transport/proxy_test.go
@@ -1428,6 +1428,7 @@ func TestColdPathRefusesOutOfClusterLocationSalvage(t *testing.T) {
 // TestUnauthorizedObserver: the 401 hook fires on 401 responses only —
 // 403 (valid credential, authorization denied) must not invalidate.
 func TestUnauthorizedObserver(t *testing.T) {
+	t.Parallel()
 	fired := 0
 	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		status := http.StatusForbidden


### PR DESCRIPTION
## Why

Every git command spawns a fresh git-remote-entire that exchanged the login JWT for a 5m repo-scoped token — measured at 60–65% of a `git ls-remote` wall time (~640ms of ~1050ms; server-side p50 968ms at the AU core, tracking improvement in [COR-846](https://linear.app/entirehq/issue/COR-846/core-oauthtoken-exchange-p50-1s-on-au-core-sequential-global)), https://github.com/entirehq/entiredb/pull/2377. Jurisdiction access tokens (entiredb docs/auth.md, ADR 20260612) cover every repo the account can reach and are authorized live at the data plane, so one persisted token removes the exchange from the hot path entirely: git ops drop to ~350ms.

## What

- git auth now mints a **jurisdiction access token** (scope=openid, aud = the cluster's advertised `jurisdiction_audience` from `/.well-known/entire-cluster.json`, cached alongside the cores) and persists it in the OS keychain (`entire-jurisdiction:<audience>`, account = context handle). Fresh helper processes reuse it until the 5m expiry buffer.
- Cross-jurisdiction logins (e.g. EU-homed account, AU-hosted repo) exchange at the cluster's advertised `jurisdiction_core_url` via the foreign-session path — single POST. The audience string itself is not a dialable endpoint, so the server advertises the paired exchange endpoint; the client requires it to be https before the login JWT is sent.
- **No repo-scoped fallback** on the interactive path: a cluster that doesn't advertise `jurisdiction_audience` is a hard error (we own both ends and deploy servers first). A cached pre-upgrade cluster entry is treated as stale so the server upgrade is picked up immediately, not after the 24h discovery TTL. The `ENTIRE_TOKEN` CI path still mints repo-scoped tokens — its migration is a follow-up.
- ENTIRE_DEBUG now emits per-request timings (auth + git transports) plus token-acquisition and session durations.

## Verification

- Unit tests: mint/persist/reuse across processes, per-handle isolation, expiry re-mint, cross-juris core derivation (incl. refusal of unadvertised cores), pre-audience cache refetch.
- Live against `aws-ap-southeast-2.entire.io` (EU-homed login → AU repo): jurisdiction token minted at the AU core via foreign-session, `info/refs` + `upload-pack` served. 20-iteration harness runs on the earlier commits produced the numbers above.
- `mise run check` lint clean.

## Requires / follow-ups

- **Requires entirehq/entiredb#2374 deployed first** (advertised audience/core + 8h `JurisdictionAccessTokenTTL`; with today's 5m tokens the persisted copy is always inside the expiry buffer, so every invocation still mints). No env escape hatches: the advertised values are the only source.
- Token endpoint perf improvements: https://github.com/entirehq/entiredb/pull/2377
- Data-plane 401 → keychain invalidation is included: the transport fires an `OnUnauthorized` hook and the token source drops memo + keychain entry, so a rotation-invalidated token self-heals on the next command (403 deliberately excluded — that's a valid token denied authorization).
- Follow-ups: migrate the `ENTIRE_TOKEN` CI path (COR-847); then sunset repo-scoped tokens server-side.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the default interactive git authentication model and discovery cache semantics; mis-deployed clusters or stale cache edge cases can block git until servers advertise jurisdiction metadata.
> 
> **Overview**
> **Interactive git** (`git-remote-entire` without `ENTIRE_TOKEN`) now authenticates with a single **jurisdiction access token** (`scope=openid`, `aud` = cluster `jurisdiction_audience` from `/.well-known/entire-cluster.json`) instead of exchanging a fresh **repo-scoped** token on every command. Tokens are memoized in-process and **persisted in the OS keychain** (`entire-jurisdiction:<audience>`) so new helper processes reuse them until expiry; cross-jurisdiction repos exchange at the advertised **`jurisdiction_core_url`** (https-only). Clusters without `jurisdiction_audience` **fail hard**—no repo-scoped fallback. **`ENTIRE_TOKEN`** still uses per-(repo, action) scoped tokens.
> 
> **Discovery/cache** now stores full **`CoresEntry`** (cores + jurisdiction audience/core). **`ResolveClusterAuth`** returns context plus that metadata. Callers that need an audience treat **pre-upgrade cache entries** (no audience) as stale for immediate re-fetch and **won’t** fall back to audience-less stale data on discovery failure.
> 
> Shared **`httputil.TokenExchangeForm`**, exported **`HomeJurisdictionFromLoginJWT`** / **`JurisdictionIdentityScope`**. Transport **`OnUnauthorized`** (401 only) invalidates persisted jurisdiction tokens; **`ENTIRE_DEBUG`** adds HTTP and token-acquisition timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 338d79887a78f6408942e4db5a36cc64bf41f867. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->